### PR TITLE
fix: Use descriptive context keys to prevent incorrect time range reuse

### DIFF
--- a/src/osprey/prompts/defaults/orchestrator.py
+++ b/src/osprey/prompts/defaults/orchestrator.py
@@ -209,10 +209,13 @@ class DefaultOrchestratorPromptBuilder(FrameworkPromptBuilder):
 
         return textwrap.dedent(
             f"""
-            **AVAILABLE CONTEXT:**
-            The following context data is already available for use in your execution plan:
-
+            **AVAILABLE CONTEXT (from previous queries):**
             {formatted_context}
+
+            **CONTEXT REUSE PRINCIPLE:**
+            - REUSE existing context only when user explicitly references previous results
+              ("same time range", "that data", "the plot above", etc.)
+            - CREATE NEW step if user specifies new values - compare against context keys above
             """
         ).strip()
 

--- a/src/osprey/prompts/defaults/time_range_parsing.py
+++ b/src/osprey/prompts/defaults/time_range_parsing.py
@@ -53,36 +53,36 @@ class DefaultTimeRangeParsingPromptBuilder(FrameworkPromptBuilder):
         """Create orchestrator guide for time range parsing."""
         registry = get_registry()
 
-        # Define structured examples using simplified dict format
+        # Define structured examples using descriptive context keys
         relative_time_example = OrchestratorExample(
             step=PlannedStep(
-                context_key="last_week_timerange",
+                context_key="tr_0103_0110",  # Descriptive: Jan 3 to Jan 10
                 capability="time_range_parsing",
                 task_objective="Parse 'last week' time reference into absolute datetime objects",
                 expected_output=registry.context_types.TIME_RANGE,
                 success_criteria="Time range successfully parsed to absolute datetime objects",
                 inputs=[],
             ),
-            scenario_description="Parsing relative time references like 'last hour', 'yesterday'",
-            notes=f"Output stored under {registry.context_types.TIME_RANGE} context type as datetime objects with full datetime functionality.",
+            scenario_description="Parsing relative time references like 'last week' (resolved to actual dates)",
+            notes="Context key encodes the resolved dates (tr_MMDD_MMDD format) for easy comparison with new requests.",
         )
 
         absolute_time_example = OrchestratorExample(
             step=PlannedStep(
-                context_key="explicit_timerange",
+                context_key="tr_0115_9h_21h",  # Descriptive: Jan 15, 9am to 9pm
                 capability="time_range_parsing",
                 task_objective="Parse explicit datetime range '2024-01-15 09:00:00 to 2024-01-15 21:00:00' and validate format",
                 expected_output=registry.context_types.TIME_RANGE,
                 success_criteria="Explicit time range validated and converted to datetime objects",
                 inputs=[],
             ),
-            scenario_description="Parsing explicit time ranges in YYYY-MM-DD HH:MM:SS format",
-            notes=f"Output stored under {registry.context_types.TIME_RANGE} context type. Validates and converts user-provided time ranges to datetime objects",
+            scenario_description="Parsing explicit time ranges (same-day with hours)",
+            notes="For same-day ranges, include hours: tr_MMDD_Hh_Hh format.",
         )
 
         implicit_time_example = OrchestratorExample(
             step=PlannedStep(
-                context_key="current_data_timerange",
+                context_key="tr_recent",  # Descriptive: recent/current data
                 capability="time_range_parsing",
                 task_objective="Infer appropriate time range for current beam energy data request (last 5 minutes)",
                 expected_output=registry.context_types.TIME_RANGE,
@@ -90,7 +90,7 @@ class DefaultTimeRangeParsingPromptBuilder(FrameworkPromptBuilder):
                 inputs=[],
             ),
             scenario_description="Inferring time ranges for 'current' or 'recent' data requests",
-            notes=f"Output stored under {registry.context_types.TIME_RANGE} context type. Provides sensible defaults (e.g., last few minutes) as datetime objects",
+            notes="Use 'tr_recent' or 'tr_now' for current/real-time requests.",
         )
 
         return OrchestratorGuide(
@@ -101,28 +101,31 @@ class DefaultTimeRangeParsingPromptBuilder(FrameworkPromptBuilder):
                 - When user queries contain time references that need to be converted to absolute datetime objects
                 - As a prerequisite step before archiver data retrieval or time-based analysis
 
-                **Step Structure:**
-                - context_key: Unique identifier for output (e.g., "last_week_timerange", "explicit_timerange")
-                - task_objective: The specific and self-contained time range parsing task to perform
+                **Context Key Format (CRITICAL for context reuse):**
+                Use descriptive keys encoding the actual dates for easy comparison:
+                - Date ranges: tr_MMDD_MMDD (e.g., "12/5 to 12/10" → "tr_1205_1210")
+                - Same-day with hours: tr_MMDD_Hh_Hh (e.g., "Dec 5 9am-5pm" → "tr_1205_9h_17h")
+                - Current/recent: tr_recent or tr_now
+                - Cross-month: tr_1128_0103 (Nov 28 to Jan 3)
+
+                This enables the orchestrator to compare new requests against existing context keys
+                and determine if a new time_range_parsing step is needed.
 
                 **Output: {registry.context_types.TIME_RANGE}**
-                - Contains: start_date and end_date as datetime objects with full datetime functionality
+                - Contains: start_date and end_date as datetime objects
                 - Available to downstream steps via context system
-                - Supports datetime arithmetic, comparison, and formatting operations
 
                 **Time Pattern Support:**
-                - Relative: "last X hours/minutes/days", "yesterday", "this week", "last week"
-                - Absolute: "from YYYY-MM-DD HH:MM:SS to YYYY-MM-DD HH:MM:SS"
-                - Implicit: "current", "recent" (defaults to last few minutes)
+                - Relative: "last X hours/days", "yesterday", "this week" → resolve to actual dates in key
+                - Absolute: "from YYYY-MM-DD to YYYY-MM-DD" → encode dates in key
+                - Implicit: "current", "recent" → use tr_recent or tr_now
 
                 **Dependencies and sequencing:**
                 1. This step typically comes early when time-based data operations are needed
                 2. Results feed into subsequent data retrieval capabilities that require time ranges
-                3. Uses LLM to handle complex relative time references and natural language time expressions
-                4. Downstream steps can use datetime objects directly without string parsing
+                3. Downstream steps can use datetime objects directly without string parsing
 
-                ALWAYS plan this step when any time-based data operations are needed,
-                regardless of whether the user provides explicit time ranges or relative time descriptions.
+                ALWAYS plan this step when time-based data operations are needed.
                 """
             ),
             examples=[relative_time_example, absolute_time_example, implicit_time_example],


### PR DESCRIPTION
## Summary

Fixes #75
Fixes #78 

When users made successive queries with different time ranges (e.g., "plot from 12/5 to 12/10" then "plot from 12/5 to 12/8"), the system was incorrectly reusing the previous time range context instead of parsing the new time range.

### Root cause
Generic context keys like `last_week_timerange` or `explicit_timerange` made it difficult for the orchestrator to determine whether a new time range parsing step was needed.

### Solution
- **Descriptive context keys**: Time range context keys now encode the actual dates for easy comparison:
  - Date ranges: `tr_MMDD_MMDD` (e.g., "12/5 to 12/10" → `tr_1205_1210`)
  - Same-day with hours: `tr_MMDD_Hh_Hh` (e.g., "Dec 5 9am-5pm" → `tr_1205_9h_17h`)
  - Current/recent: `tr_recent` or `tr_now`

- **Context reuse guidance**: Added explicit principle in orchestrator prompts to only reuse context when user explicitly references previous results ("same time range", "that data", etc.) and create new steps when user specifies new values.

## Test plan
- [ ] Manual test: Query with one time range, then query with a different time range - verify new parsing occurs
- [ ] Existing tests pass: `pytest tests/ --ignore=tests/e2e -v`