### PR TITLE
Consolidate formatting/linting to Ruff, remove Black/Isort

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,6 @@ updates:
         patterns:
           - "pytest*"
           - "ruff"
-          - "black"
           - "mypy"
           - "pre-commit"
       sphinx-dependencies:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -73,7 +73,7 @@
 
 <!-- Ensure all items are complete before requesting review -->
 
-- [ ] Code follows project style guidelines (Black, isort, ruff)
+- [ ] Code follows project style guidelines (ruff)
 - [ ] Self-review completed
 - [ ] Comments added for complex/non-obvious code
 - [ ] Documentation updated (or N/A)

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -148,7 +148,7 @@ After creating and activating the virtual environment, install the framework pac
 
    * **[scientific]**: SciPy, Seaborn, Scikit-learn, ipywidgets *(for advanced data analysis)*
    * **[docs]**: Sphinx and documentation tools
-   * **[dev]**: pytest, black, mypy, and development tools
+   * **[dev]**: pytest, ruff, mypy, and development tools
 
    .. note::
       The following packages are now included in the core installation:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,8 +141,6 @@ dev = [
     "pytest-cov",  # Code coverage reporting
     "pytest-vcr",  # Optional: For recording/replaying API interactions
     "vcrpy",
-    "black",
-    "isort",
     "mypy",
     "pre-commit",
     "ruff",
@@ -214,35 +212,6 @@ include = ["osprey*"]
 ]
 
 # Development tool configurations
-[tool.black]
-line-length = 100
-target-version = ['py311']
-include = '\.pyi?$'
-extend-exclude = '''
-/(
-  # Exclude auto-generated files
-  build/
-  | dist/
-  | venv/
-  | \.venv/
-  | _agent_data/
-  | \.git/
-  | __pycache__/
-  | \.pytest_cache/
-  | \.mypy_cache/
-)/
-'''
-
-[tool.isort]
-profile = "black"
-line_length = 100
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-ensure_newline_before_comments = true
-src_paths = ["src", "interfaces", "deployment"]
-
 [tool.mypy]
 python_version = "3.11"
 warn_return_any = true
@@ -312,7 +281,7 @@ select = [
     "UP", # pyupgrade
 ]
 ignore = [
-    "E501",  # line too long, handled by black
+    "E501",  # line too long, handled by formatter
     "B008",  # do not perform function calls in argument defaults
     "C901",  # too complex
 ]

--- a/scripts/premerge_check.sh
+++ b/scripts/premerge_check.sh
@@ -87,10 +87,10 @@ fi
 
 # MEDIUM checks
 echo -e "\n=== MEDIUM ==="
-if black --check src/ tests/ >/dev/null 2>&1; then
-  echo "✓ Black formatted"
+if ruff format --check src/ tests/ >/dev/null 2>&1; then
+  echo "✓ Ruff formatted"
 else
-  echo "⚠ Black formatting needed"
+  echo "⚠ Ruff formatting needed"
   WARNINGS=$((WARNINGS + 1))
 fi
 

--- a/src/osprey/assist/tasks/ai-code-review/instructions.md
+++ b/src/osprey/assist/tasks/ai-code-review/instructions.md
@@ -618,7 +618,7 @@ pytest tests/ --ignore=tests/e2e -v
 
 # Check lints and formatting
 ruff check src/ tests/
-black --check src/ tests/
+ruff format --check src/ tests/
 
 # Verify no unused code
 ruff check --select F401,ARG,F841 src/

--- a/src/osprey/assist/tasks/pre-merge-cleanup/instructions.md
+++ b/src/osprey/assist/tasks/pre-merge-cleanup/instructions.md
@@ -78,7 +78,7 @@ MEDIUM   → Clean but not blocking (formatting, docs warnings, orphans)
 | Type hints | CRITICAL | `ruff check --select ANN src/` | No errors |
 | TODOs linked | HIGH | `git diff main...HEAD \| grep "TODO"` | All have issue # |
 | Coverage | HIGH | `pytest --cov=src/osprey` | ≥80% |
-| Formatting | MEDIUM | `black --check src/` | Already formatted |
+| Formatting | MEDIUM | `ruff format --check src/` | Already formatted |
 | Imports | MEDIUM | `ruff check --select F401,I src/` | No unused |
 
 ---
@@ -596,15 +596,13 @@ done
 
 **Check:**
 ```bash
-black --check src/ tests/ || echo "⚠ Black formatting needed"
-isort --check src/ tests/ || echo "⚠ isort needed"
+ruff format --check src/ tests/ || echo "⚠ Ruff formatting needed"
 ruff check src/ tests/ || echo "⚠ Ruff errors found"
 ```
 
 **Auto-fix all:**
 ```bash
-black src/ tests/
-isort src/ tests/
+ruff format src/ tests/
 ruff check --fix src/ tests/
 ```
 
@@ -633,16 +631,12 @@ repos:
       - id: check-merge-conflict
       - id: debug-statements  # Catches pdb, breakpoint, etc.
 
-  - repo: https://github.com/psf/black
-    rev: 23.12.1
-    hooks:
-      - id: black
-
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.1.9
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.4
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.7.1
@@ -665,7 +659,7 @@ pre-commit run --files path/to/file.py  # Check specific file
 **Skip hooks (when necessary):**
 ```bash
 git commit --no-verify  # Skip all hooks (use sparingly!)
-SKIP=black,ruff git commit  # Skip specific hooks
+SKIP=ruff,ruff-format git commit  # Skip specific hooks
 ```
 
 **Benefits:**
@@ -759,10 +753,10 @@ fi
 
 # MEDIUM checks
 echo -e "\n=== MEDIUM ==="
-if black --check src/ tests/ >/dev/null 2>&1; then
-  echo "✓ Black formatted"
+if ruff format --check src/ tests/ >/dev/null 2>&1; then
+  echo "✓ Ruff formatted"
 else
-  echo "⚠ Black formatting needed"
+  echo "⚠ Ruff formatting needed"
 fi
 
 if ruff check src/ tests/ --quiet >/dev/null 2>&1; then
@@ -846,8 +840,8 @@ Before requesting merge, verify all items:
 - [ ] **Documentation builds**: Run `cd docs && make clean && make html`
   - No errors (warnings OK except critical ones)
   - New modules documented if public API
-- [ ] **Code formatted**: Run `black --check src/ tests/`
-  - Already formatted (or run `black src/ tests/`)
+- [ ] **Code formatted**: Run `ruff format --check src/ tests/`
+  - Already formatted (or run `ruff format src/ tests/`)
 - [ ] **Ruff clean**: Run `ruff check src/ tests/`
   - No linting errors (or run `ruff check --fix`)
 - [ ] **No temp files**: Run `git status --short`
@@ -905,7 +899,7 @@ Before requesting merge, verify all items:
 - Use `# pragma: no cover` for impossible states
 
 **"Formatting conflicts"**
-- Run formatters in order: `black` first, then `ruff check --fix`
+- Run formatters in order: `ruff format` first, then `ruff check --fix`
 - Check `pyproject.toml` for custom config
 
 ---

--- a/src/osprey/templates/project/pyproject.toml.j2
+++ b/src/osprey/templates/project/pyproject.toml.j2
@@ -13,7 +13,6 @@ dependencies = [
 dev = [
     "pytest",
     "pytest-asyncio",
-    "black",
     "ruff",
 ]
 
@@ -24,10 +23,6 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["{{ package_name }}*"]
-
-[tool.black]
-line-length = 100
-target-version = ['py311']
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## Summary
- Remove redundant Black and Isort tooling since Ruff now handles both linting and formatting
- Simplify dev dependencies and configuration
- Update all documentation and scripts to reference only Ruff

## Changes Made
- Remove `black` and `isort` from dev dependencies in `pyproject.toml`
- Remove `[tool.black]` and `[tool.isort]` sections from `pyproject.toml`
- Update `scripts/premerge_check.sh` to use `ruff format` instead of `black`
- Update `.github/dependabot.yml` to remove `black` from development-dependencies group
- Update `.github/pull_request_template.md` to reference only `ruff` for style guidelines
- Update project template (`pyproject.toml.j2`) to remove `black` dependency and config
- Update `docs/source/getting-started/installation.rst` to reference `ruff` instead of `black`
- Update assist task instructions (`pre-merge-cleanup`, `ai-code-review`) to use `ruff format`

## Test plan
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] Unit tests pass (`pytest tests/ --ignore=tests/e2e`)
- [x] Pre-commit hooks already use only Ruff (no changes needed to `.pre-commit-config.yaml`)

Closes #80