### PR TITLE
fix: Include deployment infrastructure config for all templates

### DIFF
--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -117,7 +117,6 @@ deployed_services:
   - open_webui
   - pipelines
 
-{% if template_name != 'hello_world_weather' %}
 # ============================================================
 # SAFETY CONTROLS
 # ============================================================
@@ -148,7 +147,6 @@ execution_control:
     graph_recursion_limit: 100        # LangGraph recursion limit
     max_concurrent_classifications: 5 # Maximum concurrent LLM classification requests
 
-{% endif %}
 
 # ============================================================
 # SYSTEM CONFIGURATION
@@ -195,7 +193,11 @@ execution:
       profile: "fast"    # Options: fast | robust (or custom profiles you define)
       # Advanced settings are in claude_generator_config.yml
 
-{% if template_name != 'hello_world_weather' %}
+  # --------------------------------------------------------------------------
+  # DEPLOYMENT INFRASTRUCTURE (required for deployed Jupyter/container services)
+  # These settings configure the container execution environment.
+  # --------------------------------------------------------------------------
+
   # EPICS infrastructure (for hardware control applications)
   epics:
     timeout: 5.0
@@ -207,7 +209,7 @@ execution:
         address: your-gateway.example.com  # Replace with your EPICS gateway address
         port: 5084
 
-  # Python/Jupyter execution modes
+  # Python/Jupyter execution modes (configures Jupyter kernel environments)
   modes:
     read_only:
       kernel_name: "python3-epics-readonly"
@@ -229,6 +231,7 @@ execution:
 # CONTROL SYSTEM CONFIGURATION
 # ============================================================
 # Control system type, write access, limits checking, and verification
+# Default: mock connector (no hardware required, safe for development)
 
 control_system:
   # Control system type - determines which runtime connector to use
@@ -288,7 +291,6 @@ python_executor:
   max_execution_retries: 3
   execution_timeout_seconds: 600
 
-{% endif %}
 
 # ============================================================
 # APPLICATION METADATA


### PR DESCRIPTION
## Summary

Fixes the deployment error `'dict object' has no attribute 'modes'` that occurs during `osprey deploy up` for the `hello_world_weather` template (used when creating a "weather-agent" project).

**Root cause**: Configuration mismatch in `src/osprey/templates/project/config.yml.j2`:

1. `render_kernel_templates: true` is set unconditionally for the Jupyter service
2. The `execution.modes` section (containing EPICS settings) was conditionally excluded when `template_name == 'hello_world_weather'`
3. The kernel templates (`python3-epics-readonly/kernel.json.j2` and `python3-epics-write/kernel.json.j2`) reference `{{execution.modes.read_only.environment.*}}` and `{{execution.modes.write_access.environment.*}}`

When deploying, the system tried to render the EPICS kernel templates for a weather app that had no EPICS configuration, causing the template rendering to fail.

**Fix**: Remove conditional exclusions and include all infrastructure sections for all templates. Added a clear comment header explaining these sections are required for deployed services:

```yaml
# --------------------------------------------------------------------------
# DEPLOYMENT INFRASTRUCTURE (required for deployed Jupyter/container services)
# These settings configure the container execution environment.
# --------------------------------------------------------------------------
```

The defaults are safe (mock connector, writes disabled), so simple apps work out of the box while production deployments can customize as needed.

Closes #85

## Test plan

- [x] All existing tests pass (1765 passed)
- [ ] Create a new weather-agent project and run `osprey deploy up`