### PR TITLE
feat(generators): Add configurable system prompts for code generators

### DIFF
--- a/src/osprey/cli/templates.py
+++ b/src/osprey/cli/templates.py
@@ -361,14 +361,20 @@ class TemplateManager:
         if gitignore_source.exists():
             shutil.copy(gitignore_source, project_dir / ".gitignore")
 
-        # Render Claude generator config if code_generator is set to 'claude_code'
-        if ctx.get("code_generator") == "claude_code":
-            claude_config_template = app_template_dir / "claude_generator_config.yml.j2"
-            if claude_config_template.exists():
+        # Render code generator config based on selected generator
+        generator_configs = {
+            "claude_code": "claude_generator_config.yml",
+            "basic": "basic_generator_config.yml",
+        }
+        selected_generator = ctx.get("code_generator")
+        if selected_generator in generator_configs:
+            config_filename = generator_configs[selected_generator]
+            config_template = app_template_dir / f"{config_filename}.j2"
+            if config_template.exists():
                 self.render_template(
-                    f"apps/{template_name}/claude_generator_config.yml.j2",
+                    f"apps/{template_name}/{config_filename}.j2",
                     ctx,
-                    project_dir / "claude_generator_config.yml",
+                    project_dir / config_filename,
                 )
 
     def copy_services(self, project_dir: Path):
@@ -452,6 +458,8 @@ class TemplateManager:
             "pyproject.toml",
             "claude_generator_config.yml.j2",
             "claude_generator_config.yml",
+            "basic_generator_config.yml.j2",
+            "basic_generator_config.yml",
         }
 
         # Process all files in the template

--- a/src/osprey/context/context_manager.py
+++ b/src/osprey/context/context_manager.py
@@ -31,6 +31,67 @@ logger = get_logger("osprey")
 # ===================================================================
 
 
+class DictNamespace:
+    """A namespace that supports both dot access and subscript access.
+
+    Used as a fallback when context classes can't be loaded from the registry
+    (e.g., in subprocess execution environments). Provides dict-like access
+    patterns while also supporting attribute access.
+
+    Example:
+        >>> ns = DictNamespace({"foo": {"bar": 1}})
+        >>> ns.foo.bar  # Dot access
+        1
+        >>> ns["foo"]["bar"]  # Subscript access
+        1
+        >>> "foo" in ns  # Containment check
+        True
+    """
+
+    def __init__(self, data: dict):
+        self._data = data
+        for k, v in data.items():
+            setattr(self, k, self._convert(v))
+
+    def _convert(self, v):
+        if isinstance(v, dict):
+            return DictNamespace(v)
+        elif isinstance(v, list):
+            return [self._convert(item) for item in v]
+        return v
+
+    def __getitem__(self, key):
+        """Support subscript access: obj['key']"""
+        return getattr(self, key)
+
+    def __contains__(self, key):
+        """Support 'in' operator: 'key' in obj"""
+        return key in self._data
+
+    def __iter__(self):
+        """Support iteration over keys."""
+        return iter(self._data.keys())
+
+    def keys(self):
+        """Support .keys() method."""
+        return self._data.keys()
+
+    def values(self):
+        """Support .values() method."""
+        return [getattr(self, k) for k in self._data.keys()]
+
+    def items(self):
+        """Support .items() method."""
+        return [(k, getattr(self, k)) for k in self._data.keys()]
+
+    def get(self, key, default=None):
+        """Support .get() method."""
+        return getattr(self, key, default)
+
+    def __repr__(self):
+        return f"DictNamespace({self._data!r})"
+
+
 def recursively_summarize_data(data, max_depth: int = 3, current_depth: int = 0):
     """
     Recursively summarize data structures to prevent massive context overflow.
@@ -226,8 +287,11 @@ class ContextManager:
         # Get context class from registry
         context_class = self._get_context_class(context_type)
         if context_class is None:
-            logger.warning(f"Unknown context type: {context_type}")
-            return None
+            # Fallback: return raw dict data wrapped in a DictNamespace for both
+            # dot-access (obj.key) AND subscript access (obj["key"])
+            # This allows code to work without registry (e.g., subprocess execution)
+            logger.info(f"Using raw dict data for {context_type}.{key} (registry not available)")
+            return DictNamespace(raw_data)
 
         # Use Pydantic's model_validate for reconstruction
         try:
@@ -465,7 +529,7 @@ class ContextManager:
             context_type: The context type string
 
         Returns:
-            Context class or None if not found
+            Context class or None if not found (graceful fallback)
         """
         try:
             # Import registry here to avoid circular imports
@@ -474,10 +538,13 @@ class ContextManager:
             registry = get_registry()
             return registry.get_context_class(context_type)
         except Exception as e:
-            logger.error(f"Failed to get context class for {context_type}: {e}")
-            raise ValueError(
-                f"Registry not available, cannot get context class for {context_type}"
-            ) from e
+            # Graceful fallback: return None instead of raising
+            # This allows get_context() to return raw dict data when registry isn't available
+            # (e.g., in subprocess execution environments)
+            logger.warning(
+                f"Registry not available for {context_type}, will use raw dict data: {e}"
+            )
+            return None
 
     def extract_from_step(
         self,

--- a/src/osprey/services/python_executor/generation/basic_generator.py
+++ b/src/osprey/services/python_executor/generation/basic_generator.py
@@ -40,9 +40,10 @@ Examples:
 """
 
 import re
-import textwrap
 from pathlib import Path
 from typing import Any
+
+import yaml
 
 from osprey.models import get_chat_completion
 from osprey.utils.config import get_model_config
@@ -66,6 +67,14 @@ class BasicLLMCodeGenerator:
     with configurable model settings. It handles all aspects of prompt construction,
     code generation, and post-processing to produce clean, executable Python code.
 
+    Configuration:
+        The generator can be configured via an external YAML file (basic_generator_config.yml)
+        or uses sensible defaults. The config file allows customization of:
+        - system_role: The generator's identity ("You are...")
+        - core_requirements: Output format requirements
+        - system_prompt_extensions: Domain-specific guidance
+        - fallback_guidance: Used when no capability_prompts provided
+
     :param model_config: Optional model configuration dict. If None, uses the
                         default "python_code_generator" configuration from the
                         framework config.
@@ -80,6 +89,29 @@ class BasicLLMCodeGenerator:
        :func:`osprey.models.get_chat_completion` : LLM interface used for generation
     """
 
+    # Default prompts (used when no config file exists)
+    DEFAULT_SYSTEM_ROLE = "You are an expert Python code generator."
+
+    DEFAULT_CORE_REQUIREMENTS = """\
+CRITICAL REQUIREMENTS:
+1. Generate ONLY executable Python code (no markdown, no explanations)
+2. Store computed results in a dictionary variable named 'results'
+3. Include all necessary imports at the top
+4. Use actual values from the provided 'context' object - NEVER simulate, hardcode, or fabricate data
+5. Prefer direct, simple solutions - if data is available in context, use it directly rather than building complex systems to fetch or generate it"""
+
+    DEFAULT_FALLBACK_GUIDANCE = """\
+GUIDANCE:
+- Write clean, working Python code for the task
+- Use clear variable names and add comments
+- Handle common edge cases appropriately"""
+
+    DEFAULT_ERROR_HEADER = """\
+=== PREVIOUS ATTEMPT(S) FAILED - LEARN FROM THESE ERRORS ===
+Analyze what went wrong and fix the root cause, not just symptoms."""
+
+    DEFAULT_ERROR_FOOTER = "Generate IMPROVED code that fixes these issues."
+
     def __init__(self, model_config=None):
         """Initialize basic generator with optional model configuration.
 
@@ -90,10 +122,71 @@ class BasicLLMCodeGenerator:
         self._provided_model_config = model_config
         self._model_config = None
 
+        # Load prompt configuration from file or defaults
+        self.prompt_config = self._load_prompt_config()
+
         # Save prompts: save all prompts and responses for transparency
-        self._save_prompts = (model_config or {}).get("save_prompts", False)
+        self._save_prompts = self.prompt_config.get(
+            "save_prompts", (model_config or {}).get("save_prompts", False)
+        )
         self._prompt_data: dict[str, Any] = {}  # Stores prompts/responses for inspection
         self._execution_folder: Path | None = None  # Set during generation
+
+        # Log configuration status
+        if self.prompt_config.get("_from_file"):
+            logger.info(
+                f"Basic generator: loaded prompts from {self.prompt_config.get('_config_path')}"
+            )
+        else:
+            logger.debug("Basic generator: using default prompts (no config file)")
+
+    def _load_prompt_config(self) -> dict[str, Any]:
+        """Load prompt configuration from YAML file or use defaults.
+
+        Checks for basic_generator_config.yml in the current directory.
+        If found, loads prompts from file. Otherwise, uses built-in defaults.
+
+        Returns:
+            Configuration dictionary with prompt settings
+        """
+        config_path = (self._provided_model_config or {}).get(
+            "basic_config_path", "basic_generator_config.yml"
+        )
+
+        if Path(config_path).exists():
+            try:
+                with open(config_path) as f:
+                    file_config = yaml.safe_load(f) or {}
+
+                return {
+                    "system_role": file_config.get("system_role", self.DEFAULT_SYSTEM_ROLE).strip(),
+                    "core_requirements": file_config.get(
+                        "core_requirements", self.DEFAULT_CORE_REQUIREMENTS
+                    ).strip(),
+                    "system_prompt_extensions": file_config.get(
+                        "system_prompt_extensions", ""
+                    ).strip(),
+                    "fallback_guidance": file_config.get(
+                        "fallback_guidance", self.DEFAULT_FALLBACK_GUIDANCE
+                    ).strip(),
+                    "error_feedback": file_config.get("error_feedback", {}),
+                    "save_prompts": file_config.get("save_prompts", False),
+                    "_from_file": True,
+                    "_config_path": config_path,
+                }
+            except Exception as e:
+                logger.warning(f"Failed to load {config_path}: {e}, using defaults")
+
+        # Default configuration
+        return {
+            "system_role": self.DEFAULT_SYSTEM_ROLE,
+            "core_requirements": self.DEFAULT_CORE_REQUIREMENTS,
+            "system_prompt_extensions": "",
+            "fallback_guidance": self.DEFAULT_FALLBACK_GUIDANCE,
+            "error_feedback": {},
+            "save_prompts": False,
+            "_from_file": False,
+        }
 
     @property
     def model_config(self):
@@ -115,7 +208,23 @@ class BasicLLMCodeGenerator:
             else:
                 # No config provided - use default
                 logger.info("No model config provided, using default 'python_code_generator'")
-                self._model_config = get_model_config("python_code_generator")
+                cfg = get_model_config("python_code_generator")
+                if not cfg or not cfg.get("provider"):
+                    logger.warning(
+                        "models.python_code_generator missing or incomplete; falling back to response/orchestrator config"
+                    )
+                    for fallback_name in ("response", "orchestrator"):
+                        fallback_cfg = get_model_config(fallback_name)
+                        if fallback_cfg and fallback_cfg.get("provider"):
+                            cfg = fallback_cfg
+                            logger.info(f"Using fallback model config: {fallback_name}")
+                            break
+                if not cfg or not cfg.get("provider"):
+                    raise ValueError(
+                        "No valid model configuration found for python code generation. "
+                        "Please set models.python_code_generator in config.yml."
+                    )
+                self._model_config = cfg
         return self._model_config
 
     async def generate_code(
@@ -239,23 +348,16 @@ class BasicLLMCodeGenerator:
         """
         prompt_parts = []
 
-        # === MINIMAL SYSTEM ROLE ===
-        prompt_parts.append("You are an expert Python code generator.")
+        # === SYSTEM ROLE (configurable) ===
+        prompt_parts.append(self.prompt_config["system_role"])
 
-        # === CRITICAL OUTPUT CONSTRAINTS (safety net) ===
-        # These are essential constraints that MUST always be enforced
-        prompt_parts.append(
-            textwrap.dedent(
-                """
-            CRITICAL REQUIREMENTS:
-            1. Generate ONLY executable Python code (no markdown, no explanations)
-            2. Store computed results in a dictionary variable named 'results'
-            3. Include all necessary imports at the top
-            4. Use actual values from the provided 'context' object - NEVER simulate, hardcode, or fabricate data
-            5. Prefer direct, simple solutions - if data is available in context, use it directly rather than building complex systems to fetch or generate it
-            """
-            ).strip()
-        )
+        # === CORE REQUIREMENTS (configurable) ===
+        prompt_parts.append(self.prompt_config["core_requirements"])
+
+        # === SYSTEM PROMPT EXTENSIONS (configurable, for domain-specific guidance) ===
+        extensions = self.prompt_config.get("system_prompt_extensions", "")
+        if extensions:
+            prompt_parts.append(f"\n{extensions}")
 
         # Task details
         # Note: task_objective is the STEP-SPECIFIC objective from the orchestrator's execution plan
@@ -273,32 +375,25 @@ class BasicLLMCodeGenerator:
                 if prompt:
                     prompt_parts.append(prompt)
         else:
-            # Fallback if no capability prompts provided
-            prompt_parts.append(
-                textwrap.dedent(
-                    """
-                GUIDANCE:
-                - Write clean, working Python code for the task
-                - Use clear variable names and add comments
-                - Handle common edge cases appropriately
-                """
-                ).strip()
-            )
+            # Fallback if no capability prompts provided (configurable)
+            prompt_parts.append(self.prompt_config["fallback_guidance"])
 
-        # Structured error feedback
+        # Structured error feedback (configurable)
         if error_chain:
-            prompt_parts.append("\n=== PREVIOUS ATTEMPT(S) FAILED - LEARN FROM THESE ERRORS ===")
-            prompt_parts.append(
-                "Analyze what went wrong and fix the root cause, not just symptoms."
-            )
+            error_config = self.prompt_config.get("error_feedback", {})
+            max_errors = error_config.get("max_errors", 2)
+            error_header = error_config.get("header", self.DEFAULT_ERROR_HEADER)
+            error_footer = error_config.get("footer", self.DEFAULT_ERROR_FOOTER)
 
-            # Show last 2 attempts with full structured context
-            for error in error_chain[-2:]:
+            prompt_parts.append(f"\n{error_header}")
+
+            # Show last N attempts with full structured context
+            for error in error_chain[-max_errors:]:
                 prompt_parts.append(f"\n{'=' * 60}")
                 prompt_parts.append(error.to_prompt_text())
 
             prompt_parts.append(f"\n{'=' * 60}")
-            prompt_parts.append("Generate IMPROVED code that fixes these issues.")
+            prompt_parts.append(error_footer)
 
         prompt_parts.append("\nGenerate ONLY the Python code.")
 

--- a/src/osprey/templates/apps/control_assistant/basic_generator_config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/basic_generator_config.yml.j2
@@ -1,0 +1,115 @@
+# Basic LLM Code Generator Configuration
+# =======================================
+#
+# This file configures the Basic LLM code generator for Osprey's Python
+# executor service. It provides simple prompt customization for code generation.
+#
+# Quick Start:
+#   1. The default prompts work well for most use cases
+#   2. Customize system_prompt or system_prompt_extensions for domain-specific guidance
+#   3. Use extensions to ADD guidance without losing core requirements
+#
+# Configuration Structure:
+#   - system_role: The "You are..." statement defining the generator's identity
+#   - core_requirements: Critical output format requirements (modify carefully!)
+#   - system_prompt_extensions: Additional domain-specific guidance (recommended)
+#   - fallback_guidance: Used only if no capability_prompts provided
+#
+# Customization Approaches:
+#   1. RECOMMENDED: Add system_prompt_extensions for domain-specific guidance
+#   2. ADVANCED: Modify core_requirements (may break expected output format)
+#   3. FULL CONTROL: Replace entire system_role and core_requirements
+#
+# Save Prompts:
+#   - Set save_prompts: true to save all prompts and responses
+#   - Creates execution_folder/prompts/ with complete prompt history
+#   - Helps debug and understand what the LLM sees
+
+# =============================================================================
+# Model Configuration
+# =============================================================================
+# The model is configured in your main config.yml under models.python_code_generator
+# This file only controls prompts and behavior, not model selection.
+
+save_prompts: true  # Save prompts/responses for transparency (recommended)
+
+# =============================================================================
+# System Role
+# =============================================================================
+# Defines the generator's identity and expertise.
+# This is the "You are..." statement at the start of every prompt.
+
+system_role: |
+  You are an expert Python code generator.
+
+# =============================================================================
+# Core Requirements
+# =============================================================================
+# Critical constraints that ensure correct output format.
+# MODIFY WITH CAUTION - these ensure the generated code works with the executor.
+#
+# Key requirements:
+#   1. Output must be executable Python (no markdown in final output)
+#   2. Results must be stored in a 'results' dictionary
+#   3. Imports must be at the top
+#   4. Must use actual context data, not simulated values
+
+core_requirements: |
+  CRITICAL REQUIREMENTS:
+  1. Generate ONLY executable Python code (no markdown, no explanations)
+  2. Store computed results in a dictionary variable named 'results'
+  3. Include all necessary imports at the top
+  4. Use actual values from the provided 'context' object - NEVER simulate, hardcode, or fabricate data
+  5. Prefer direct, simple solutions - if data is available in context, use it directly rather than building complex systems to fetch or generate it
+
+# =============================================================================
+# System Prompt Extensions (RECOMMENDED FOR CUSTOMIZATION)
+# =============================================================================
+# Add domain-specific guidance here. This is appended AFTER core_requirements.
+# Use this for facility-specific conventions, data handling rules, etc.
+#
+# Examples of what to add:
+#   - Timestamp handling conventions
+#   - Control system operation guidance
+#   - Facility-specific coding standards
+#   - Available libraries and how to use them
+#
+# Leave empty or remove to use defaults without extensions.
+
+system_prompt_extensions: |
+  CONTROL SYSTEM OPERATIONS:
+  - Use osprey.runtime for all channel read/write operations
+  - from osprey.runtime import write_channel, read_channel, write_channels
+  - NEVER use epics.caput() or epics.caget() directly - use osprey.runtime utilities
+  - All safety checks (limits validation, approval workflows) happen automatically
+
+# =============================================================================
+# Fallback Guidance
+# =============================================================================
+# Used ONLY if no capability_prompts are provided in the request.
+# Normally, capability_prompts from the Python capability provide detailed guidance.
+# This is a safety net for edge cases.
+
+fallback_guidance: |
+  GUIDANCE:
+  - Write clean, working Python code for the task
+  - Use clear variable names and add comments
+  - Handle common edge cases appropriately
+
+# =============================================================================
+# Error Feedback Settings
+# =============================================================================
+# Controls how previous errors are presented for iterative improvement.
+
+error_feedback:
+  # How many previous errors to include in the prompt
+  max_errors: 2
+
+  # Header text for the error section
+  header: |
+    === PREVIOUS ATTEMPT(S) FAILED - LEARN FROM THESE ERRORS ===
+    Analyze what went wrong and fix the root cause, not just symptoms.
+
+  # Footer text after error details
+  footer: |
+    Generate IMPROVED code that fixes these issues.

--- a/src/osprey/templates/apps/control_assistant/claude_generator_config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/claude_generator_config.yml.j2
@@ -95,6 +95,45 @@ api_config:
 {% endif %}
 
 # =============================================================================
+# System Prompt Customization
+# =============================================================================
+# Customize the base system prompt sent to Claude Code.
+#
+# Options:
+#   system_prompt: Replace the entire base system prompt (advanced)
+#   system_prompt_extensions: Add domain-specific guidance AFTER the default prompt (recommended)
+#
+# The default system prompt defines Claude's role and basic rules (output format,
+# results dictionary, etc.). Extensions let you add domain-specific guidance
+# without losing the core behavior.
+#
+# Example - Add domain-specific guidance (RECOMMENDED):
+#
+# system_prompt_extensions: |
+#   CONTROL SYSTEM OPERATIONS:
+#   - Use osprey.runtime for all channel read/write operations
+#   - from osprey.runtime import write_channel, read_channel
+#   - NEVER use epics.caput() or epics.caget() directly
+#
+#   TIMESTAMP HANDLING:
+#   - Timestamps in context are ISO format strings
+#   - Convert with: datetime.fromisoformat(ts)
+#
+# Example - Replace entire system prompt (ADVANCED, use carefully):
+#
+# system_prompt: |
+#   You are a custom code generator for the ITS control system.
+#   ... your complete custom prompt ...
+
+# Default: Use built-in system prompt with control system extensions
+system_prompt_extensions: |
+  CONTROL SYSTEM OPERATIONS:
+  - Use osprey.runtime for all channel read/write operations
+  - from osprey.runtime import write_channel, read_channel, write_channels
+  - NEVER use epics.caput() or epics.caget() directly - use osprey.runtime utilities
+  - All safety checks (limits validation, approval workflows) happen automatically
+
+# =============================================================================
 # Phase Definitions (Reusable Building Blocks)
 # =============================================================================
 # These are the individual phases that can be composed into different workflows.

--- a/tests/cli/test_templates.py
+++ b/tests/cli/test_templates.py
@@ -200,5 +200,103 @@ class TestCLIIntegration:
         assert "osprey chat" in result.output
 
 
+class TestGeneratorConfigRendering:
+    """Test code generator config file rendering."""
+
+    def test_claude_code_generator_config_rendered(self, tmp_path):
+        """Test that claude_code generator creates config file."""
+        manager = TemplateManager()
+
+        project_dir = manager.create_project(
+            project_name="claude-app",
+            output_dir=tmp_path,
+            template_name="control_assistant",
+            context={"code_generator": "claude_code"},
+        )
+
+        config_file = project_dir / "claude_generator_config.yml"
+
+        # Should exist
+        assert config_file.exists(), "claude_generator_config.yml should be created"
+
+        # Should have expected content
+        content = config_file.read_text()
+        assert "profile:" in content or "phases:" in content
+        # Should have system prompt extensions section
+        assert "system_prompt_extensions" in content
+
+    def test_basic_generator_config_rendered(self, tmp_path):
+        """Test that basic generator creates config file."""
+        manager = TemplateManager()
+
+        project_dir = manager.create_project(
+            project_name="basic-app",
+            output_dir=tmp_path,
+            template_name="control_assistant",
+            context={"code_generator": "basic"},
+        )
+
+        config_file = project_dir / "basic_generator_config.yml"
+
+        # Should exist
+        assert config_file.exists(), "basic_generator_config.yml should be created"
+
+        # Should have expected content
+        content = config_file.read_text()
+        assert "system_role:" in content
+        assert "core_requirements:" in content
+        assert "system_prompt_extensions:" in content
+
+    def test_no_generator_config_for_default(self, tmp_path):
+        """Test that no generator config is created when generator not specified."""
+        manager = TemplateManager()
+
+        project_dir = manager.create_project(
+            project_name="default-app",
+            output_dir=tmp_path,
+            template_name="minimal",
+            # No code_generator in context
+        )
+
+        # Neither config should exist
+        assert not (project_dir / "claude_generator_config.yml").exists()
+        assert not (project_dir / "basic_generator_config.yml").exists()
+
+    def test_generator_configs_mutually_exclusive(self, tmp_path):
+        """Test that only one generator config is created at a time."""
+        manager = TemplateManager()
+
+        # Create with claude_code
+        project_dir = manager.create_project(
+            project_name="exclusive-app",
+            output_dir=tmp_path,
+            template_name="control_assistant",
+            context={"code_generator": "claude_code"},
+        )
+
+        # Only claude config should exist
+        assert (project_dir / "claude_generator_config.yml").exists()
+        assert not (project_dir / "basic_generator_config.yml").exists()
+
+    def test_generator_config_excluded_from_app_package(self, tmp_path):
+        """Test that generator config is at project root, not in src/."""
+        manager = TemplateManager()
+
+        project_dir = manager.create_project(
+            project_name="placement-test",
+            output_dir=tmp_path,
+            template_name="control_assistant",
+            context={"code_generator": "basic"},
+        )
+
+        # Should be at project root
+        assert (project_dir / "basic_generator_config.yml").exists()
+
+        # Should NOT be in src/ directory
+        src_dir = project_dir / "src" / "placement_test"
+        assert not (src_dir / "basic_generator_config.yml").exists()
+        assert not (src_dir / "basic_generator_config.yml.j2").exists()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/context/test_context_manager.py
+++ b/tests/context/test_context_manager.py
@@ -741,3 +741,158 @@ def test_cardinality_with_soft_constraint_mode(context_manager, mock_state):
     # Should pass - ARCHIVER_DATA present and single
     assert "ARCHIVER_DATA" in contexts
     assert not isinstance(contexts["ARCHIVER_DATA"], list)
+
+
+# ===================================================================
+# Test Section 4.9: DictNamespace Utility Class
+# ===================================================================
+
+
+class TestDictNamespace:
+    """Test DictNamespace utility class for registry-free context access."""
+
+    def test_dot_access(self):
+        """Test attribute-style (dot) access."""
+        from osprey.context.context_manager import DictNamespace
+
+        ns = DictNamespace({"foo": "bar", "count": 42})
+
+        assert ns.foo == "bar"
+        assert ns.count == 42
+
+    def test_subscript_access(self):
+        """Test dictionary-style (subscript) access."""
+        from osprey.context.context_manager import DictNamespace
+
+        ns = DictNamespace({"foo": "bar", "count": 42})
+
+        assert ns["foo"] == "bar"
+        assert ns["count"] == 42
+
+    def test_nested_dict_access(self):
+        """Test nested dictionary conversion to DictNamespace."""
+        from osprey.context.context_manager import DictNamespace
+
+        ns = DictNamespace({"outer": {"inner": {"value": 123}}})
+
+        # Dot access through nesting
+        assert ns.outer.inner.value == 123
+
+        # Subscript access through nesting
+        assert ns["outer"]["inner"]["value"] == 123
+
+        # Mixed access
+        assert ns.outer["inner"].value == 123
+
+    def test_nested_list_conversion(self):
+        """Test lists with nested dicts are converted properly."""
+        from osprey.context.context_manager import DictNamespace
+
+        ns = DictNamespace(
+            {
+                "items": [
+                    {"name": "first", "value": 1},
+                    {"name": "second", "value": 2},
+                ]
+            }
+        )
+
+        assert len(ns.items) == 2
+        assert ns.items[0].name == "first"
+        assert ns.items[1].value == 2
+
+    def test_containment_check(self):
+        """Test 'in' operator for key existence."""
+        from osprey.context.context_manager import DictNamespace
+
+        ns = DictNamespace({"exists": True, "nested": {"inner": 1}})
+
+        assert "exists" in ns
+        assert "nested" in ns
+        assert "nonexistent" not in ns
+
+    def test_iteration_over_keys(self):
+        """Test iteration yields keys."""
+        from osprey.context.context_manager import DictNamespace
+
+        ns = DictNamespace({"a": 1, "b": 2, "c": 3})
+
+        keys = list(ns)
+        assert set(keys) == {"a", "b", "c"}
+
+    def test_keys_method(self):
+        """Test .keys() method."""
+        from osprey.context.context_manager import DictNamespace
+
+        ns = DictNamespace({"x": 10, "y": 20})
+
+        assert set(ns.keys()) == {"x", "y"}
+
+    def test_values_method(self):
+        """Test .values() method returns converted values."""
+        from osprey.context.context_manager import DictNamespace
+
+        ns = DictNamespace({"a": 1, "b": 2})
+
+        assert set(ns.values()) == {1, 2}
+
+    def test_items_method(self):
+        """Test .items() method."""
+        from osprey.context.context_manager import DictNamespace
+
+        ns = DictNamespace({"key1": "val1", "key2": "val2"})
+
+        items = dict(ns.items())
+        assert items == {"key1": "val1", "key2": "val2"}
+
+    def test_get_method_with_default(self):
+        """Test .get() method with default value."""
+        from osprey.context.context_manager import DictNamespace
+
+        ns = DictNamespace({"present": "value"})
+
+        assert ns.get("present") == "value"
+        assert ns.get("absent") is None
+        assert ns.get("absent", "default") == "default"
+
+    def test_repr(self):
+        """Test __repr__ for debugging."""
+        from osprey.context.context_manager import DictNamespace
+
+        ns = DictNamespace({"foo": "bar"})
+
+        repr_str = repr(ns)
+        assert "DictNamespace" in repr_str
+        assert "foo" in repr_str
+
+    def test_empty_dict(self):
+        """Test behavior with empty dictionary."""
+        from osprey.context.context_manager import DictNamespace
+
+        ns = DictNamespace({})
+
+        assert list(ns) == []
+        assert list(ns.keys()) == []
+        assert list(ns.values()) == []
+        assert list(ns.items()) == []
+        assert "anything" not in ns
+
+    def test_special_value_types(self):
+        """Test handling of None, bool, and numeric types."""
+        from osprey.context.context_manager import DictNamespace
+
+        ns = DictNamespace(
+            {
+                "none_val": None,
+                "bool_true": True,
+                "bool_false": False,
+                "int_val": 0,
+                "float_val": 3.14,
+            }
+        )
+
+        assert ns.none_val is None
+        assert ns.bool_true is True
+        assert ns.bool_false is False
+        assert ns.int_val == 0
+        assert ns.float_val == 3.14

--- a/tests/services/python_executor/test_generator_interface.py
+++ b/tests/services/python_executor/test_generator_interface.py
@@ -509,3 +509,161 @@ def test_empty_error_chain_works():
     # Should not contain error sections
     assert "PREVIOUS" not in prompt
     assert "FAILED" not in prompt
+
+
+# =============================================================================
+# BASIC GENERATOR CONFIG LOADING TESTS
+# =============================================================================
+
+
+class TestBasicGeneratorConfigLoading:
+    """Test BasicLLMCodeGenerator YAML config file loading."""
+
+    def test_uses_defaults_when_no_config_file(self):
+        """Generator uses default prompts when no config file exists."""
+        generator = BasicLLMCodeGenerator(model_config={})
+
+        # Should use defaults
+        assert generator.prompt_config["system_role"] == generator.DEFAULT_SYSTEM_ROLE
+        assert generator.prompt_config["core_requirements"] == generator.DEFAULT_CORE_REQUIREMENTS
+        assert generator.prompt_config["fallback_guidance"] == generator.DEFAULT_FALLBACK_GUIDANCE
+        assert generator.prompt_config["_from_file"] is False
+
+    def test_loads_config_from_yaml_file(self, tmp_path, monkeypatch):
+        """Generator loads prompts from YAML config file."""
+
+        # Create a config file
+        config_content = """
+system_role: "You are a custom code generator."
+core_requirements: |
+  CUSTOM REQUIREMENTS:
+  1. Always add comments
+  2. Use type hints
+system_prompt_extensions: |
+  DOMAIN SPECIFIC:
+  - Use pandas for data
+fallback_guidance: |
+  CUSTOM GUIDANCE:
+  - Be thorough
+error_feedback:
+  max_errors: 3
+  header: "=== CUSTOM ERROR HEADER ==="
+  footer: "Fix the issues above."
+save_prompts: true
+"""
+        config_file = tmp_path / "basic_generator_config.yml"
+        config_file.write_text(config_content)
+
+        # Change to tmp directory so generator finds the config
+        monkeypatch.chdir(tmp_path)
+
+        generator = BasicLLMCodeGenerator(model_config={})
+
+        assert generator.prompt_config["_from_file"] is True
+        assert generator.prompt_config["system_role"] == "You are a custom code generator."
+        assert "Always add comments" in generator.prompt_config["core_requirements"]
+        assert "pandas for data" in generator.prompt_config["system_prompt_extensions"]
+        assert "Be thorough" in generator.prompt_config["fallback_guidance"]
+        assert generator.prompt_config["error_feedback"]["max_errors"] == 3
+        assert generator._save_prompts is True
+
+    def test_custom_config_path_via_model_config(self, tmp_path):
+        """Generator can load config from custom path via model_config."""
+        config_content = """
+system_role: "Custom via path"
+"""
+        config_file = tmp_path / "custom_config.yml"
+        config_file.write_text(config_content)
+
+        generator = BasicLLMCodeGenerator(model_config={"basic_config_path": str(config_file)})
+
+        assert generator.prompt_config["system_role"] == "Custom via path"
+        assert generator.prompt_config["_from_file"] is True
+
+    def test_falls_back_to_defaults_on_invalid_yaml(self, tmp_path, monkeypatch):
+        """Generator falls back to defaults if YAML is invalid."""
+        config_file = tmp_path / "basic_generator_config.yml"
+        config_file.write_text("invalid: yaml: content: [")
+
+        monkeypatch.chdir(tmp_path)
+
+        generator = BasicLLMCodeGenerator(model_config={})
+
+        # Should fall back to defaults
+        assert generator.prompt_config["_from_file"] is False
+        assert generator.prompt_config["system_role"] == generator.DEFAULT_SYSTEM_ROLE
+
+    def test_prompt_config_used_in_prompt_building(self, tmp_path, monkeypatch):
+        """Verify loaded config is actually used in prompt building."""
+        config_content = """
+system_role: "CUSTOM_ROLE_MARKER"
+core_requirements: "CUSTOM_REQUIREMENTS_MARKER"
+system_prompt_extensions: "CUSTOM_EXTENSIONS_MARKER"
+"""
+        config_file = tmp_path / "basic_generator_config.yml"
+        config_file.write_text(config_content)
+        monkeypatch.chdir(tmp_path)
+
+        generator = BasicLLMCodeGenerator(model_config={})
+
+        request = PythonExecutionRequest(
+            user_query="Test", task_objective="Test", execution_folder_name="test"
+        )
+
+        prompt = generator._build_code_generation_prompt(request, [])
+
+        assert "CUSTOM_ROLE_MARKER" in prompt
+        assert "CUSTOM_REQUIREMENTS_MARKER" in prompt
+        assert "CUSTOM_EXTENSIONS_MARKER" in prompt
+
+    def test_error_feedback_config_used(self, tmp_path, monkeypatch):
+        """Verify error feedback config is used when building prompts with errors."""
+        config_content = """
+error_feedback:
+  max_errors: 1
+  header: "CUSTOM_ERROR_HEADER"
+  footer: "CUSTOM_ERROR_FOOTER"
+"""
+        config_file = tmp_path / "basic_generator_config.yml"
+        config_file.write_text(config_content)
+        monkeypatch.chdir(tmp_path)
+
+        generator = BasicLLMCodeGenerator(model_config={})
+
+        request = PythonExecutionRequest(
+            user_query="Test", task_objective="Test", execution_folder_name="test"
+        )
+
+        error_chain = [
+            ExecutionError(
+                error_type="execution",
+                error_message="Error 1",
+                attempt_number=1,
+                stage="execution",
+            ),
+            ExecutionError(
+                error_type="execution",
+                error_message="Error 2",
+                attempt_number=2,
+                stage="execution",
+            ),
+        ]
+
+        prompt = generator._build_code_generation_prompt(request, error_chain)
+
+        assert "CUSTOM_ERROR_HEADER" in prompt
+        assert "CUSTOM_ERROR_FOOTER" in prompt
+        # With max_errors=1, only the last error should be included
+        assert "Error 2" in prompt
+
+    def test_default_constants_are_valid_strings(self):
+        """Verify default constants are properly formatted strings."""
+        assert isinstance(BasicLLMCodeGenerator.DEFAULT_SYSTEM_ROLE, str)
+        assert isinstance(BasicLLMCodeGenerator.DEFAULT_CORE_REQUIREMENTS, str)
+        assert isinstance(BasicLLMCodeGenerator.DEFAULT_FALLBACK_GUIDANCE, str)
+        assert isinstance(BasicLLMCodeGenerator.DEFAULT_ERROR_HEADER, str)
+        assert isinstance(BasicLLMCodeGenerator.DEFAULT_ERROR_FOOTER, str)
+
+        # Should not have leading/trailing whitespace issues
+        assert not BasicLLMCodeGenerator.DEFAULT_CORE_REQUIREMENTS.startswith("\n")
+        assert not BasicLLMCodeGenerator.DEFAULT_FALLBACK_GUIDANCE.startswith("\n")


### PR DESCRIPTION
## Summary

Closes #82

This PR implements a **configurable prompt system** that lets each facility customize code generator prompts via config files.

### Changes

- **BasicLLMCodeGenerator**: Load prompts from `basic_generator_config.yml`
  - `system_role`, `core_requirements`, `system_prompt_extensions` configurable
  - `error_feedback` settings (max_errors, header, footer) configurable
  - Falls back to sensible defaults when no config file exists

- **ClaudeCodeGenerator**: Add `system_prompt` and `system_prompt_extensions` options
  - `system_prompt`: Replace entire base prompt (advanced use)
  - `system_prompt_extensions`: Append domain-specific guidance (recommended)
  - `DEFAULT_SYSTEM_PROMPT` extracted as class constant for clarity

- **ContextManager**: Add `DictNamespace` fallback for subprocess execution
  - Moved class to module level (was defined inside method)
  - Enables context access when registry not available in subprocesses
  - Graceful fallback instead of raising errors

- **wrapper.py**: Add application src directory to Python path
  - Fixes import issues for application-specific modules in subprocesses

- **templates.py**: DRY refactor for generator config rendering
  - Generator configs now use a mapping for easier extension
  - Added `basic_generator_config.yml.j2` template

### Usage Example

Facilities can customize prompts by adding to their config files:

```yaml
# basic_generator_config.yml or claude_generator_config.yml
system_prompt_extensions: |
  CONTROL SYSTEM OPERATIONS:
  - Use osprey.runtime for all channel read/write operations
  - NEVER use epics.caput() or epics.caget() directly
```

## Test plan

- [x] Added 32 new unit tests covering all new functionality
- [x] All 1871 existing tests pass
- [x] `./scripts/quick_check.sh` passes