### PR TITLE
fix(cli): Display full absolute paths for plot files (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Osprey Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **CLI**: Display full absolute paths for plot files in artifact output (#96)
+  - Figure and notebook paths now resolved to absolute before artifact registration
+  - Ensures users can directly access generated files from CLI output
+
 ## [0.10.4] - 2026-01-15
 
 ### Fixed

--- a/src/osprey/capabilities/python.py
+++ b/src/osprey/capabilities/python.py
@@ -37,6 +37,7 @@ including streaming, configuration management, error handling, and checkpoint su
    :class:`osprey.approval.ApprovalManager` : Code execution approval workflows
 """
 
+from pathlib import Path
 from typing import Any, ClassVar
 
 from langgraph.types import Command
@@ -554,11 +555,13 @@ class PythonCapability(BaseCapability):
 
         # Register figures as IMAGE artifacts
         for figure_path in results_context.figure_paths:
+            # Ensure absolute path for CLI display (fix for issue #96)
+            abs_path = Path(figure_path).resolve()
             artifact_update = StateManager.register_artifact(
                 self._state,
                 artifact_type=ArtifactType.IMAGE,
                 capability="python_executor",
-                data={"path": str(figure_path), "format": figure_path.suffix[1:].lower()},
+                data={"path": str(abs_path), "format": abs_path.suffix[1:].lower()},
                 display_name="Python Execution Figure",
                 metadata={
                     "execution_folder": results_context.folder_path,
@@ -572,12 +575,14 @@ class PythonCapability(BaseCapability):
 
         # Register notebook as NOTEBOOK artifact
         if results_context.notebook_link:
+            # Ensure absolute path for consistency (fix for issue #96)
+            abs_notebook_path = Path(results_context.notebook_path).resolve()
             artifact_update = StateManager.register_artifact(
                 self._state,
                 artifact_type=ArtifactType.NOTEBOOK,
                 capability="python_executor",
                 data={
-                    "path": str(results_context.notebook_path),
+                    "path": str(abs_notebook_path),
                     "url": results_context.notebook_link,
                 },
                 display_name="Python Execution Notebook",


### PR DESCRIPTION
## Summary
- Fix issue where CLI displayed only filenames for plot files instead of full paths
- Figure and notebook paths are now resolved to absolute paths before artifact registration
- Ensures users can directly copy/paste paths from CLI output to access generated files

## Changes
- `src/osprey/capabilities/python.py`: Add `Path.resolve()` for figure and notebook paths
- `tests/capabilities/test_python_capability.py`: Add `TestFigurePathResolution` class with 7 tests
- `CHANGELOG.md`: Add entry under [Unreleased]

## Test plan
- [x] All existing tests pass (1871 passed)
- [x] New tests verify:
  - Path.resolve() converts relative to absolute
  - Artifact registration stores absolute paths
  - CLI _format_artifact_line() displays full paths

Closes #96