### PR TITLE
feat(context): Store task_objective metadata for intelligent context reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Context**: Store task_objective metadata alongside capability context data (#108)
+  - ContextManager now accepts optional `task_objective` parameter in `set_context()`
+  - Metadata stored in `_meta` field, stripped before Pydantic validation
+  - New helper methods: `get_context_metadata()`, `get_all_context_metadata()`
+  - Orchestrator prompt displays task_objective for each available context
+  - Enables intelligent context reuse by showing what each context was created for
+
 ### Fixed
 - **Graph**: Propagate chat history to orchestrator and respond nodes (#111)
   - Orchestrator now receives full conversation context when `task_depends_on_chat_history=True`

--- a/src/osprey/base/capability.py
+++ b/src/osprey/base/capability.py
@@ -664,6 +664,9 @@ class BaseCapability(ABC):
                 f"Step contents: {self._step}"
             )
 
+        # Extract task_objective for context metadata (enables orchestrator context reuse)
+        task_objective = self._step.get("task_objective")
+
         # Store each and merge updates
         merged: dict[str, Any] = {}
         for obj in context_objects:
@@ -683,7 +686,9 @@ class BaseCapability(ABC):
                     f"Available types: {', '.join(available)}"
                 ) from None
 
-            updates = StateManager.store_context(self._state, ctx_type, context_key, obj)
+            updates = StateManager.store_context(
+                self._state, ctx_type, context_key, obj, task_objective=task_objective
+            )
             merged = {**merged, **updates}
 
         return merged

--- a/src/osprey/prompts/defaults/orchestrator.py
+++ b/src/osprey/prompts/defaults/orchestrator.py
@@ -105,18 +105,19 @@ class DefaultOrchestratorPromptBuilder(FrameworkPromptBuilder):
         base_prompt = "\n\n".join(base_prompt_parts)
         prompt_sections.append(base_prompt)
 
-        # 2. Add context reuse guidance if task builds on previous context
+        # 2. Add chat history first (with visual separators) if task depends on conversation context
+        if task_depends_on_chat_history and messages:
+            chat_history_section = self._build_chat_history_section(messages)
+            if chat_history_section:
+                prompt_sections.append(chat_history_section)
+
+        # 3. Add context reuse guidance if task builds on previous context
+        # (kept together with available context section below for clarity)
         context_guidance = self._build_context_reuse_guidance(
             task_depends_on_chat_history, task_depends_on_user_memory
         )
         if context_guidance:
             prompt_sections.append(context_guidance)
-
-        # 3. Add chat history if task depends on conversation context
-        if task_depends_on_chat_history and messages:
-            chat_history_section = self._build_chat_history_section(messages)
-            if chat_history_section:
-                prompt_sections.append(chat_history_section)
 
         # 4. Add error context for replanning if available
         if error_context:
@@ -210,54 +211,74 @@ class DefaultOrchestratorPromptBuilder(FrameworkPromptBuilder):
         # Format messages using the standard formatter for consistency
         chat_formatted = ChatHistoryFormatter.format_for_llm(messages)
 
+        # Use visual separators to clearly delineate chat history from other prompt sections
         return textwrap.dedent(
             f"""
-            **CONVERSATION HISTORY:**
+            ════════════════════════════════════════════════════════════════════════════════
+            **CONVERSATION HISTORY**
             The following is the conversation history that this task builds upon.
             Use this context to understand references to previous queries, results, or time ranges.
+            ────────────────────────────────────────────────────────────────────────────────
 
-            {chat_formatted}
+{chat_formatted}
+
+            ════════════════════════════════════════════════════════════════════════════════
             """
         ).strip()
 
     def _build_context_section(self, context_manager: ContextManager) -> str | None:
-        """Build the context section of the prompt."""
+        """Build the context section of the prompt.
+
+        Includes task_objective metadata when available to help the orchestrator
+        understand what each context was created for, enabling intelligent reuse.
+        """
         context_data = context_manager.get_raw_data()
         if not context_data:
             return None
 
-        # Create a simple dictionary showing context_type -> [list of available keys]
-        context_dict = {}
+        # Build context info with task_objective metadata when available
+        # This helps the orchestrator understand what each context was created for
+        formatted_lines = []
+
         for context_type, contexts in context_data.items():
-            context_dict[context_type] = list(contexts.keys())
+            if context_type.startswith("_"):
+                continue  # Skip internal keys like _execution_config
 
-        # Format as a clean dictionary representation
-        formatted_lines = ["["]
-        for context_type, keys in context_dict.items():
-            if len(keys) == 1:
-                formatted_lines.append(f'    "{context_type}": "{keys[0]}",')
-            else:
-                keys_str = ", ".join(f'"{key}"' for key in keys)
-                formatted_lines.append(f'    "{context_type}": [{keys_str}],')
+            for context_key, context_value in contexts.items():
+                # Extract task_objective from metadata if available
+                meta = context_value.get("_meta", {}) if isinstance(context_value, dict) else {}
+                task_objective = meta.get("task_objective")
 
-        # Remove trailing comma from last line and close brace
-        if len(formatted_lines) > 1:
-            formatted_lines[-1] = formatted_lines[-1].rstrip(",")
-        formatted_lines.append("]")
+                # Format as {"TYPE": "key"} to match execution plan input format
+                context_ref = f'{{"{context_type}": "{context_key}"}}'
+
+                if task_objective:
+                    # Include the task description for context reuse decisions
+                    formatted_lines.append(f'  - {context_ref}: "{task_objective}"')
+                else:
+                    # Fallback to just showing the key
+                    formatted_lines.append(f"  - {context_ref}")
+
+        if not formatted_lines:
+            return None
 
         formatted_context = "\n".join(formatted_lines)
 
-        return textwrap.dedent(
-            f"""
-            **AVAILABLE CONTEXT (from previous queries):**
-            {formatted_context}
-
-            **CONTEXT REUSE PRINCIPLE:**
-            - REUSE existing context only when user explicitly references previous results
-              ("same time range", "that data", "the plot above", etc.)
-            - CREATE NEW step if user specifies new values - compare against context keys above
-            """
-        ).strip()
+        # Build the section without textwrap.dedent to avoid indentation issues
+        return (
+            "**AVAILABLE CONTEXT (from previous queries):**\n"
+            "The following context data is already available from previous execution steps.\n"
+            "Each entry shows the context type, key, and what it was created for:\n\n"
+            f"{formatted_context}\n\n"
+            "**CONTEXT REUSE PRINCIPLE:**\n"
+            "- PREFER reusing existing context when the user's request involves the same data,\n"
+            "  channels, or time ranges - even if not explicitly stated\n"
+            "- The task descriptions above indicate what each context was created for;\n"
+            "  use semantic similarity to decide on reuse\n"
+            "- CREATE NEW retrieval step only when the user explicitly requests different\n"
+            "  parameters (different channels, different time range, etc.)\n"
+            '- Reference existing context in step inputs using: {"CONTEXT_TYPE": "context_key"}'
+        )
 
     def _build_capability_sections(self, active_capabilities: list[BaseCapability]) -> list[str]:
         """Build capability-specific sections with examples."""

--- a/src/osprey/state/state_manager.py
+++ b/src/osprey/state/state_manager.py
@@ -366,7 +366,11 @@ class StateManager:
 
     @staticmethod
     def store_context(
-        state: AgentState, context_type: str, context_key: str, context_object: CapabilityContext
+        state: AgentState,
+        context_type: str,
+        context_key: str,
+        context_object: CapabilityContext,
+        task_objective: str | None = None,
     ) -> StateUpdate:
         """Store capability context data and return LangGraph-compatible state updates.
 
@@ -393,6 +397,10 @@ class StateManager:
         :type context_key: str
         :param context_object: CapabilityContext object containing data to store
         :type context_object: CapabilityContext
+        :param task_objective: Optional task description from execution plan step.
+                              Stored as metadata to help orchestrator understand what
+                              this context was created for (enables context reuse optimization).
+        :type task_objective: Optional[str]
         :return: State update dictionary for LangGraph automatic merging
         :rtype: StateUpdate
 
@@ -440,8 +448,10 @@ class StateManager:
         # Create context manager from state
         context_manager = ContextManager(state)
 
-        # Store the context object
-        context_manager.set_context(context_type, context_key, context_object)
+        # Store the context object with optional task_objective metadata
+        context_manager.set_context(
+            context_type, context_key, context_object, task_objective=task_objective
+        )
 
         # Return state updates with the updated dictionary data
         return {"capability_context_data": context_manager.get_raw_data()}

--- a/tests/context/test_context_manager.py
+++ b/tests/context/test_context_manager.py
@@ -896,3 +896,184 @@ class TestDictNamespace:
         assert ns.bool_false is False
         assert ns.int_val == 0
         assert ns.float_val == 3.14
+
+
+# ===================================================================
+# Test Section 5: Context Metadata (task_objective storage)
+# ===================================================================
+
+
+class TestContextMetadata:
+    """Test context metadata storage for orchestrator context reuse optimization.
+
+    This tests the feature where task_objective from execution plan steps
+    is stored alongside context data to help the orchestrator make intelligent
+    reuse decisions.
+    """
+
+    def test_set_context_stores_task_objective_as_meta(self, context_manager):
+        """Task objective is stored in _meta when provided."""
+        context = PVAddressesContext(pvs=["PV1", "PV2"])
+        context_manager.set_context(
+            "PV_ADDRESSES",
+            "test_key",
+            context,
+            skip_validation=True,
+            task_objective="Find PV addresses for beam current monitoring",
+        )
+
+        # Check raw data includes _meta
+        raw_data = context_manager.get_raw_data()
+        assert "_meta" in raw_data["PV_ADDRESSES"]["test_key"]
+        assert raw_data["PV_ADDRESSES"]["test_key"]["_meta"]["task_objective"] == (
+            "Find PV addresses for beam current monitoring"
+        )
+
+    def test_set_context_without_task_objective_has_no_meta(self, context_manager):
+        """No _meta is stored when task_objective is not provided."""
+        context = PVAddressesContext(pvs=["PV1", "PV2"])
+        context_manager.set_context(
+            "PV_ADDRESSES",
+            "test_key",
+            context,
+            skip_validation=True,
+        )
+
+        # Check raw data does not include _meta
+        raw_data = context_manager.get_raw_data()
+        assert "_meta" not in raw_data["PV_ADDRESSES"]["test_key"]
+
+    def test_get_context_strips_meta_before_pydantic_validation(self, context_manager):
+        """get_context() properly reconstructs object without _meta interference."""
+        context = TimeRangeContext(start="2025-01-01", end="2025-01-02")
+        context_manager.set_context(
+            "TIME_RANGE",
+            "range1",
+            context,
+            skip_validation=True,
+            task_objective="Parse time range: last 24 hours",
+        )
+
+        # Clear cache to force reconstruction from raw data
+        context_manager._object_cache.clear()
+
+        # Get context should work without Pydantic validation errors
+        retrieved = context_manager.get_context("TIME_RANGE", "range1")
+        assert retrieved is not None
+        assert retrieved.start == "2025-01-01"
+        assert retrieved.end == "2025-01-02"
+
+    def test_get_context_metadata_returns_meta(self, context_manager):
+        """get_context_metadata() returns the stored metadata."""
+        context = ArchiverDataContext(data=[1, 2, 3])
+        context_manager.set_context(
+            "ARCHIVER_DATA",
+            "archiver_key",
+            context,
+            skip_validation=True,
+            task_objective="Retrieve historical beam current data from archiver",
+        )
+
+        meta = context_manager.get_context_metadata("ARCHIVER_DATA", "archiver_key")
+        assert meta is not None
+        assert meta["task_objective"] == "Retrieve historical beam current data from archiver"
+
+    def test_get_context_metadata_returns_none_for_missing_meta(self, context_manager):
+        """get_context_metadata() returns None when no metadata exists."""
+        context = PVAddressesContext(pvs=["PV1"])
+        context_manager.set_context(
+            "PV_ADDRESSES",
+            "no_meta_key",
+            context,
+            skip_validation=True,
+        )
+
+        meta = context_manager.get_context_metadata("PV_ADDRESSES", "no_meta_key")
+        assert meta is None
+
+    def test_get_context_metadata_returns_none_for_nonexistent_context(self, context_manager):
+        """get_context_metadata() returns None for non-existent context."""
+        meta = context_manager.get_context_metadata("NONEXISTENT", "key")
+        assert meta is None
+
+    def test_get_all_context_metadata_returns_all_meta(self, context_manager):
+        """get_all_context_metadata() returns metadata for all contexts."""
+        # Store multiple contexts with different metadata
+        context_manager.set_context(
+            "PV_ADDRESSES",
+            "pv_key",
+            PVAddressesContext(pvs=["PV1"]),
+            skip_validation=True,
+            task_objective="Find PV addresses",
+        )
+        context_manager.set_context(
+            "TIME_RANGE",
+            "time_key",
+            TimeRangeContext(start="2025-01-01"),
+            skip_validation=True,
+            task_objective="Parse time range",
+        )
+        # One without metadata
+        context_manager.set_context(
+            "ARCHIVER_DATA",
+            "no_meta",
+            ArchiverDataContext(data=[]),
+            skip_validation=True,
+        )
+
+        all_meta = context_manager.get_all_context_metadata()
+
+        # Should include contexts with metadata
+        assert "PV_ADDRESSES" in all_meta
+        assert "pv_key" in all_meta["PV_ADDRESSES"]
+        assert all_meta["PV_ADDRESSES"]["pv_key"]["task_objective"] == "Find PV addresses"
+
+        assert "TIME_RANGE" in all_meta
+        assert "time_key" in all_meta["TIME_RANGE"]
+        assert all_meta["TIME_RANGE"]["time_key"]["task_objective"] == "Parse time range"
+
+        # Should NOT include context without metadata
+        assert "ARCHIVER_DATA" not in all_meta
+
+    def test_get_all_context_metadata_skips_internal_keys(self, context_manager):
+        """get_all_context_metadata() skips internal keys like _execution_config."""
+        context_manager.set_context(
+            "PV_ADDRESSES",
+            "key",
+            PVAddressesContext(pvs=["PV1"]),
+            skip_validation=True,
+            task_objective="Test task",
+        )
+
+        # Manually add internal key
+        context_manager._data["_execution_config"] = {"some": "config"}
+
+        all_meta = context_manager.get_all_context_metadata()
+
+        # Should have PV_ADDRESSES but not _execution_config
+        assert "PV_ADDRESSES" in all_meta
+        assert "_execution_config" not in all_meta
+
+    def test_metadata_preserved_across_multiple_contexts_same_type(self, context_manager):
+        """Metadata is preserved when storing multiple contexts of same type."""
+        context_manager.set_context(
+            "CURRENT_WEATHER",
+            "sf_weather",
+            CurrentWeatherContext(location="San Francisco", temp=18.0),
+            skip_validation=True,
+            task_objective="Get current weather for San Francisco",
+        )
+        context_manager.set_context(
+            "CURRENT_WEATHER",
+            "ny_weather",
+            CurrentWeatherContext(location="New York", temp=22.0),
+            skip_validation=True,
+            task_objective="Get current weather for New York",
+        )
+
+        # Both should have their respective metadata
+        sf_meta = context_manager.get_context_metadata("CURRENT_WEATHER", "sf_weather")
+        ny_meta = context_manager.get_context_metadata("CURRENT_WEATHER", "ny_weather")
+
+        assert sf_meta["task_objective"] == "Get current weather for San Francisco"
+        assert ny_meta["task_objective"] == "Get current weather for New York"

--- a/tests/prompts/test_orchestrator_prompt.py
+++ b/tests/prompts/test_orchestrator_prompt.py
@@ -5,14 +5,51 @@ This test suite validates that the orchestrator prompt builder correctly:
 1. Includes chat history when task_depends_on_chat_history=True
 2. Excludes chat history when task_depends_on_chat_history=False
 3. Formats chat history appropriately for the orchestrator
-4. Includes capability context data
+4. Includes capability context data with task_objective metadata
 5. Maintains the correct prompt structure
 """
 
+from typing import ClassVar
+
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
+from pydantic import Field
 
+from osprey.context.base import CapabilityContext
+from osprey.context.context_manager import ContextManager
 from osprey.prompts.defaults.orchestrator import DefaultOrchestratorPromptBuilder
+
+# ===================================================================
+# Test Context Classes
+# ===================================================================
+
+
+class TestPVAddressesContext(CapabilityContext):
+    """Test context for PV addresses."""
+
+    CONTEXT_TYPE: ClassVar[str] = "PV_ADDRESSES"
+    pvs: list[str] = Field(description="List of PV addresses")
+
+    def get_summary(self) -> dict:
+        return {"type": "PV Addresses", "count": len(self.pvs)}
+
+    def get_access_details(self, key: str) -> dict:
+        return {"pvs": self.pvs}
+
+
+class TestArchiverDataContext(CapabilityContext):
+    """Test context for archiver data."""
+
+    CONTEXT_TYPE: ClassVar[str] = "ARCHIVER_DATA"
+    channels: list[str] = Field(description="Channel names")
+    data_points: int = Field(description="Number of data points")
+
+    def get_summary(self) -> dict:
+        return {"type": "Archiver Data", "channels": self.channels, "points": self.data_points}
+
+    def get_access_details(self, key: str) -> dict:
+        return {"channels": self.channels, "data_points": self.data_points}
+
 
 # ===================================================================
 # Test Fixtures
@@ -66,8 +103,8 @@ class TestOrchestratorChatHistoryInclusion:
             messages=sample_messages,
         )
 
-        # Verify chat history section is present
-        assert "**CONVERSATION HISTORY:**" in prompt
+        # Verify chat history section is present (with visual separators)
+        assert "**CONVERSATION HISTORY**" in prompt
         assert "What's the weather in San Francisco?" in prompt
         assert "6.0°C with clear skies" in prompt
         assert "What did I just ask you?" in prompt
@@ -85,7 +122,7 @@ class TestOrchestratorChatHistoryInclusion:
         )
 
         # Verify chat history section is NOT present
-        assert "**CONVERSATION HISTORY:**" not in prompt
+        assert "**CONVERSATION HISTORY**" not in prompt
         # The actual message content should also not be present
         assert "What's the weather in San Francisco?" not in prompt
 
@@ -102,7 +139,7 @@ class TestOrchestratorChatHistoryInclusion:
         )
 
         # Verify chat history section is NOT present even with flag=True
-        assert "**CONVERSATION HISTORY:**" not in prompt
+        assert "**CONVERSATION HISTORY**" not in prompt
 
     def test_chat_history_excluded_when_messages_empty(self):
         """Test that chat history section is not added when messages list is empty."""
@@ -117,7 +154,7 @@ class TestOrchestratorChatHistoryInclusion:
         )
 
         # Verify chat history section is NOT present
-        assert "**CONVERSATION HISTORY:**" not in prompt
+        assert "**CONVERSATION HISTORY**" not in prompt
 
     def test_multi_turn_conversation_preserved(self, multi_turn_messages):
         """Test that multi-turn conversation context is fully preserved.
@@ -218,8 +255,12 @@ class TestOrchestratorPromptStructure:
         assert "TASK:" in prompt
         assert "PlannedStep" in prompt
 
-    def test_chat_history_before_capability_sections(self, sample_messages):
-        """Test that chat history appears before capability sections."""
+    def test_chat_history_before_context_reuse_guidance(self, sample_messages):
+        """Test that chat history appears before context reuse guidance.
+
+        This ensures all context-related sections (guidance + available context + principle)
+        are kept together, with chat history preceding them for better readability.
+        """
         builder = DefaultOrchestratorPromptBuilder()
 
         prompt = builder.get_system_instructions(
@@ -230,8 +271,198 @@ class TestOrchestratorPromptStructure:
         )
 
         # Find positions of sections
-        history_pos = prompt.find("**CONVERSATION HISTORY:**")
+        history_pos = prompt.find("**CONVERSATION HISTORY**")
         guidance_pos = prompt.find("**CONTEXT REUSE GUIDANCE:**")
 
-        # Chat history should come after context reuse guidance
-        assert history_pos > guidance_pos, "Chat history should appear after context reuse guidance"
+        # Chat history should come BEFORE context reuse guidance
+        assert history_pos < guidance_pos, (
+            "Chat history should appear before context reuse guidance"
+        )
+
+
+# ===================================================================
+# Tests for Context Section with Task Objective Metadata
+# ===================================================================
+
+
+class TestOrchestratorContextSection:
+    """Test suite for context section including task_objective metadata.
+
+    This tests the feature where task_objective from execution plan steps
+    is displayed in the orchestrator prompt to enable intelligent context reuse.
+    """
+
+    @pytest.fixture
+    def context_manager_with_metadata(self):
+        """Create a ContextManager with contexts that have task_objective metadata."""
+        state = {"capability_context_data": {}}
+        cm = ContextManager(state)
+
+        # Add context with task_objective metadata
+        cm.set_context(
+            "PV_ADDRESSES",
+            "beam_current_pvs",
+            TestPVAddressesContext(pvs=["SR:CURRENT:RB", "SR:LIFETIME:RB"]),
+            skip_validation=True,
+            task_objective="Find PV addresses for beam current monitoring",
+        )
+        cm.set_context(
+            "ARCHIVER_DATA",
+            "historical_beam_data",
+            TestArchiverDataContext(channels=["SR:CURRENT:RB"], data_points=8640),
+            skip_validation=True,
+            task_objective="Retrieve historical beam current data from archiver for the last 24 hours",
+        )
+
+        return cm
+
+    @pytest.fixture
+    def context_manager_without_metadata(self):
+        """Create a ContextManager with contexts that have no metadata."""
+        state = {"capability_context_data": {}}
+        cm = ContextManager(state)
+
+        # Add context without task_objective metadata
+        cm.set_context(
+            "PV_ADDRESSES",
+            "some_pvs",
+            TestPVAddressesContext(pvs=["TEST:PV"]),
+            skip_validation=True,
+        )
+
+        return cm
+
+    def test_context_section_includes_task_objective(self, context_manager_with_metadata):
+        """Test that context section includes task_objective when available."""
+        builder = DefaultOrchestratorPromptBuilder()
+
+        prompt = builder.get_system_instructions(
+            active_capabilities=[],
+            context_manager=context_manager_with_metadata,
+            task_depends_on_chat_history=False,
+            messages=None,
+        )
+
+        # Verify the context section header
+        assert "**AVAILABLE CONTEXT (from previous queries):**" in prompt
+
+        # Verify task objectives are included
+        assert "Find PV addresses for beam current monitoring" in prompt
+        assert "Retrieve historical beam current data from archiver for the last 24 hours" in prompt
+
+        # Verify context keys are present in execution plan input format
+        assert '{"PV_ADDRESSES": "beam_current_pvs"}' in prompt
+        assert '{"ARCHIVER_DATA": "historical_beam_data"}' in prompt
+
+    def test_context_section_shows_key_without_metadata(self, context_manager_without_metadata):
+        """Test that context keys are shown even without metadata."""
+        builder = DefaultOrchestratorPromptBuilder()
+
+        prompt = builder.get_system_instructions(
+            active_capabilities=[],
+            context_manager=context_manager_without_metadata,
+            task_depends_on_chat_history=False,
+            messages=None,
+        )
+
+        # Verify context key is present even without task_objective
+        assert '{"PV_ADDRESSES": "some_pvs"}' in prompt
+        assert "**AVAILABLE CONTEXT (from previous queries):**" in prompt
+
+    def test_context_section_includes_reuse_principle(self, context_manager_with_metadata):
+        """Test that context section includes the reuse principle guidance."""
+        builder = DefaultOrchestratorPromptBuilder()
+
+        prompt = builder.get_system_instructions(
+            active_capabilities=[],
+            context_manager=context_manager_with_metadata,
+            task_depends_on_chat_history=False,
+            messages=None,
+        )
+
+        # Verify reuse principle is present with softened tone
+        assert "**CONTEXT REUSE PRINCIPLE:**" in prompt
+        assert "PREFER reusing existing context" in prompt
+
+    def test_no_context_section_when_empty(self):
+        """Test that no context section appears when there's no context data."""
+        state = {"capability_context_data": {}}
+        empty_cm = ContextManager(state)
+
+        builder = DefaultOrchestratorPromptBuilder()
+
+        prompt = builder.get_system_instructions(
+            active_capabilities=[],
+            context_manager=empty_cm,
+            task_depends_on_chat_history=False,
+            messages=None,
+        )
+
+        # Verify no context section when empty
+        assert "**AVAILABLE CONTEXT (from previous queries):**" not in prompt
+
+    def test_context_section_skips_internal_keys(self):
+        """Test that internal keys like _execution_config are not shown."""
+        state = {"capability_context_data": {}}
+        cm = ContextManager(state)
+
+        # Add a normal context
+        cm.set_context(
+            "PV_ADDRESSES",
+            "pvs",
+            TestPVAddressesContext(pvs=["PV1"]),
+            skip_validation=True,
+            task_objective="Find PVs",
+        )
+
+        # Manually add internal key (simulating framework behavior)
+        cm._data["_execution_config"] = {"some": "config"}
+
+        builder = DefaultOrchestratorPromptBuilder()
+
+        prompt = builder.get_system_instructions(
+            active_capabilities=[],
+            context_manager=cm,
+            task_depends_on_chat_history=False,
+            messages=None,
+        )
+
+        # Verify PV_ADDRESSES is shown but _execution_config is not
+        assert "PV_ADDRESSES" in prompt
+        assert "_execution_config" not in prompt
+
+    def test_context_section_multiple_contexts_same_type(self):
+        """Test that multiple contexts of same type are all shown with their tasks."""
+        state = {"capability_context_data": {}}
+        cm = ContextManager(state)
+
+        # Add two contexts of same type with different tasks
+        cm.set_context(
+            "ARCHIVER_DATA",
+            "beam_current_data",
+            TestArchiverDataContext(channels=["SR:CURRENT:RB"], data_points=1000),
+            skip_validation=True,
+            task_objective="Retrieve beam current data",
+        )
+        cm.set_context(
+            "ARCHIVER_DATA",
+            "rf_data",
+            TestArchiverDataContext(channels=["SR:RF:POWER"], data_points=2000),
+            skip_validation=True,
+            task_objective="Retrieve RF power data",
+        )
+
+        builder = DefaultOrchestratorPromptBuilder()
+
+        prompt = builder.get_system_instructions(
+            active_capabilities=[],
+            context_manager=cm,
+            task_depends_on_chat_history=False,
+            messages=None,
+        )
+
+        # Both contexts should be shown with their respective task objectives
+        assert '{"ARCHIVER_DATA": "beam_current_data"}' in prompt
+        assert "Retrieve beam current data" in prompt
+        assert '{"ARCHIVER_DATA": "rf_data"}' in prompt
+        assert "Retrieve RF power data" in prompt


### PR DESCRIPTION
## Summary

- Store execution plan `task_objective` alongside context data so the orchestrator can see what each context was created for
- Enables intelligent context reuse decisions by showing semantic meaning, not just context keys
- Improves orchestrator prompt formatting with visual separators and better section ordering

Closes #108

## Changes

### Context Manager
- Add `task_objective` parameter to `set_context()`, stored in `_meta` field
- Strip `_meta` before Pydantic validation to avoid schema conflicts
- New helper methods: `get_context_metadata()`, `get_all_context_metadata()`

### State Manager
- Pass `task_objective` through `store_context()` to ContextManager

### BaseCapability
- Extract `task_objective` from execution step and pass to `store_output_contexts()`

### Orchestrator Prompt
- Display `task_objective` for each available context with clear reuse guidance
- Chat history section now has visual separators for clarity
- Chat history appears before context reuse guidance (related sections grouped)
- Fixed indentation and softened reuse guidance tone

## Test plan

- [x] Unit tests for metadata storage and retrieval in ContextManager
- [x] Unit tests for orchestrator prompt formatting and content
- [x] All 64 related tests pass