### PR TITLE
fix(deploy): Fix claude_config_path resolution in pipelines container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **Deployment**: Copy `claude_generator_config.yml` to pipelines container
-  - Config file with phase definitions wasn't being copied during `osprey deploy`
-  - Code generation worked in CLI but failed in container with "No phase definitions found"
-  - Build process now copies the config file alongside `requirements.txt` and `pyproject.toml`
+- **Deployment**: Fix Claude Code config path resolution in pipelines container
+  - Pipelines container has working directory `/app/` but files are mounted at `/pipelines/`
+  - Config file was copied but relative path `claude_generator_config.yml` couldn't be found
+  - Now reads `claude_config_path` from config, copies the file, and updates path to absolute `/pipelines/` for pipelines service
 
 ## [0.10.5] - 2026-01-16
 


### PR DESCRIPTION
## Summary
- Fix Claude Code config file path resolution in pipelines container
- The pipelines container has working directory `/app/` but files are mounted at `/pipelines/`, so relative path `claude_generator_config.yml` couldn't be found
- Now reads `claude_config_path` from config, copies the file, and updates path to absolute `/pipelines/` for pipelines service

## Problem
The Claude Code generator uses `claude_generator_config.yml` to load phase definitions. During `osprey deploy`:

- **Initial issue**: Config file wasn't being copied to the container
- **Root cause**: Even after copying, the pipelines container has working directory `/app/` but files are mounted at `/pipelines/`, so the relative path didn't resolve

## Solution
- Read `claude_config_path` from the config instead of hardcoded filename
- Copy the file to the build directory during setup
- Update path to absolute `/pipelines/{filename}` for pipelines service (other services use relative path)

## Test plan
- [x] Ran `./scripts/quick_check.sh` - all tests pass (1877 passed, 85 skipped)
- [x] Ran `ruff check` on changed file - passes
- [ ] Manual test: `osprey deploy` with claude_config_path configured should work correctly in pipelines container