### PR TITLE
Changelog for 126/127

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Mock fixtures matching real `archivertools` library format (secs/nanos columns)
 
 ### Fixed
-- **Security**: Bind MCP server template to localhost by default (#126)
-  - Prevents unintended network exposure when generating MCP server configurations
+- **Security**: Bind docker/podman services to localhost by default (#126)
+  - Prevents unintended network exposure when generating server configurations with `osprey deploy up`
+  - Use `--expose` option to bind to public interfaces, if firewalling/authentification is set up properly
 - **CLI**: Auto-prompt to switch control system mode when configuring EPICS gateway
   - After setting a production gateway (ALS, APS, custom), prompts user to switch from 'mock' to 'epics' mode
   - Handles edge cases: missing config key, other control system types (tango, labview)


### PR DESCRIPTION
The changelog from #127 / 277e7da6da9fa66f003393d2609051229a73940e was incomplete and only focused on the MCP server (2nd commit).
This documents the whole aspect of #126