### PR TITLE
Add explanatory comments to all remaining bare except-pass blocks

### DIFF
--- a/src/osprey/cli/generate_cmd.py
+++ b/src/osprey/cli/generate_cmd.py
@@ -1097,7 +1097,7 @@ def claude_config(output_file: str, force: bool):
                             f"  [{Styles.LABEL}]Detected provider:[/{Styles.LABEL}] [{Styles.VALUE}]{default_provider}[/{Styles.VALUE}]"
                         )
             except Exception:
-                pass
+                pass  # Best-effort provider detection; not critical for generation
         else:
             console.print(f"  [{Styles.DIM}]No config.yml found - using defaults[/{Styles.DIM}]")
 

--- a/src/osprey/cli/remove_cmd.py
+++ b/src/osprey/cli/remove_cmd.py
@@ -40,7 +40,7 @@ def find_capability_file(capability_name: str) -> Path | None:
             if capability_file.exists():
                 return capability_file
     except Exception:
-        pass
+        pass  # Fall through to fallback path lookup below
 
     # Fallback: check simple relative path
     fallback_path = Path(f"capabilities/{capability_name}.py")

--- a/src/osprey/cli/tasks_cmd.py
+++ b/src/osprey/cli/tasks_cmd.py
@@ -248,7 +248,7 @@ def copy_to_clipboard(text: str) -> bool:
             subprocess.run(["clip"], input=text.encode(), check=True, shell=True)
             return True
     except Exception:
-        pass
+        pass  # Clipboard operation failed; return False below
 
     return False
 

--- a/src/osprey/cli/templates.py
+++ b/src/osprey/cli/templates.py
@@ -70,7 +70,7 @@ class TemplateManager:
             if template_path.exists():
                 return template_path
         except (ImportError, AttributeError):
-            pass
+            pass  # Fall through to development fallback path below
 
         # Fallback for development: relative to this file
         fallback_path = Path(__file__).parent.parent / "templates"

--- a/src/osprey/deployment/runtime_helper.py
+++ b/src/osprey/deployment/runtime_helper.py
@@ -140,7 +140,7 @@ def verify_runtime_is_running(config: dict | None = None) -> tuple[bool, str]:
             cmd = get_runtime_command(config)
             runtime = cmd[0]
         except Exception:
-            pass
+            pass  # Best-effort runtime name detection for error message
         return False, f"{runtime.capitalize()} command timed out. The service may not be running."
     except RuntimeError as e:
         # No runtime found at all

--- a/src/osprey/generators/config_updater.py
+++ b/src/osprey/generators/config_updater.py
@@ -181,7 +181,7 @@ def has_capability_react_model(config_path: Path, capability_name: str) -> bool:
         if "models" in config and model_key in config["models"]:
             return True
     except Exception:
-        pass
+        pass  # Config read/parse failed; return default below
 
     return False
 
@@ -207,7 +207,7 @@ def get_orchestrator_model_config(config_path: Path) -> dict | None:
                 "max_tokens": orch_config.get("max_tokens", 4096),
             }
     except Exception:
-        pass
+        pass  # Config read/parse failed; return default below
 
     return None
 
@@ -404,7 +404,7 @@ def get_capability_react_config(config_path: Path, capability_name: str) -> dict
         if "models" in config and model_key in config["models"]:
             return config["models"][model_key]
     except Exception:
-        pass
+        pass  # Config read/parse failed; return default below
 
     return None
 
@@ -438,7 +438,7 @@ def get_control_system_type(config_path: Path, key: str = "control_system.type")
 
         return value
     except Exception:
-        pass
+        pass  # Config read/parse failed; return default below
 
     return None
 
@@ -599,7 +599,7 @@ def get_epics_gateway_config(config_path: Path) -> dict | None:
         )
         return gateways
     except Exception:
-        pass
+        pass  # Config read/parse failed; return default below
 
     return None
 
@@ -665,7 +665,7 @@ def get_all_model_configs(config_path: Path) -> dict | None:
 
         return config.get("models", {})
     except Exception:
-        pass
+        pass  # Config read/parse failed; return default below
 
     return None
 

--- a/src/osprey/generators/registry_updater.py
+++ b/src/osprey/generators/registry_updater.py
@@ -32,7 +32,7 @@ def find_registry_file() -> Path | None:
             return registry_file
 
     except Exception:
-        pass
+        pass  # Registry file lookup failed; return None below
 
     return None
 

--- a/src/osprey/generators/soft_ioc_template.py
+++ b/src/osprey/generators/soft_ioc_template.py
@@ -141,7 +141,7 @@ class {ioc_class_name}(PVGroup):
                     if hasattr(attr, 'pvname'):
                         self._pv_map[attr.pvname] = attr
                 except Exception:
-                    pass
+                    pass  # Skip unmappable PV attribute
 
         # Initialize backend with PV definitions
         if self.backend and not self._initialized:
@@ -157,7 +157,7 @@ class {ioc_class_name}(PVGroup):
                     try:
                         await self._pv_map[pv_name].write(value)
                     except Exception:
-                        pass
+                        pass  # Skip PV initial value write failure
 
             self._initialized = True
 
@@ -174,7 +174,7 @@ class {ioc_class_name}(PVGroup):
                         try:
                             await self._pv_map[pv_name].write(value)
                         except Exception:
-                            pass
+                            pass  # Skip PV update failure to keep scan loop running
 
             # Update heartbeat
             heartbeat = (heartbeat + 1) % 1000000
@@ -203,7 +203,7 @@ class {ioc_class_name}(PVGroup):
                             try:
                                 await self._pv_map[update_pv].write(update_val)
                             except Exception:
-                                pass
+                                pass  # Skip PV callback write failure
                 finally:
                     self._in_backend_write = False
 

--- a/src/osprey/interfaces/tui/widgets/input.py
+++ b/src/osprey/interfaces/tui/widgets/input.py
@@ -93,7 +93,7 @@ class ChatInput(TextArea):
                 # Write query with + prefix
                 f.write(f"+{query}\n")
         except Exception:
-            pass
+            pass  # Non-critical: history file write failed
 
     def _history_up(self) -> None:
         """Navigate to previous history entry."""

--- a/src/osprey/models/providers/asksage.py
+++ b/src/osprey/models/providers/asksage.py
@@ -122,7 +122,7 @@ class AskSageProviderAdapter(BaseProvider):
         try:
             self.get_available_models(api_key=api_key, base_url=base_url)
         except Exception:
-            pass
+            pass  # Best-effort model list refresh; not required for completion
 
         # Check for thinking parameters (not supported by AskSage)
         enable_thinking = kwargs.get("enable_thinking", False)

--- a/src/osprey/services/ariel_search/ingestion/adapters/generic.py
+++ b/src/osprey/services/ariel_search/ingestion/adapters/generic.py
@@ -201,12 +201,12 @@ class GenericJSONAdapter(BaseAdapter):
                     value = value[:-1] + "+00:00"
                 return datetime.fromisoformat(value)
             except ValueError:
-                pass
+                pass  # Not ISO 8601; try next format
 
             # Try Unix epoch as string
             try:
                 return datetime.fromtimestamp(float(value), tz=UTC)
             except ValueError:
-                pass
+                pass  # Not a Unix epoch string; fall through to raise below
 
         raise ValueError(f"Cannot parse timestamp: {value}")

--- a/src/osprey/services/ariel_search/ingestion/adapters/ornl.py
+++ b/src/osprey/services/ariel_search/ingestion/adapters/ornl.py
@@ -207,13 +207,13 @@ class ORNLLogbookAdapter(BaseAdapter):
                     value = value[:-1] + "+00:00"
                 return datetime.fromisoformat(value)
             except ValueError:
-                pass
+                pass  # Not ISO 8601; try next format
 
             # Try Unix epoch as string
             try:
                 return datetime.fromtimestamp(float(value), tz=UTC)
             except ValueError:
-                pass
+                pass  # Not a Unix epoch string; fall through to default below
 
         return datetime.now(UTC)
 

--- a/src/osprey/services/python_executor/execution/node.py
+++ b/src/osprey/services/python_executor/execution/node.py
@@ -244,8 +244,8 @@ class LocalCodeExecutor:
             # Clean up temporary file
             try:
                 os.unlink(temp_script)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"Failed to clean up temp script {temp_script}: {e}")
 
     def _detect_python_environment(self) -> str:
         """Detect appropriate Python environment with container-aware logic"""


### PR DESCRIPTION
Annotate 18 bare except...pass blocks across 13 files with inline comments explaining why the exception is silently suppressed. Files with existing get_logger use logger.debug() instead. This satisfies the code quality check for undocumented exception suppression.

https://claude.ai/code/session_01FHuRxhFCHPEna2whQ4ffPj

## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issue

<!-- Link to the related issue using GitHub keywords -->
<!-- Examples: -->
<!-- - Closes #123 (auto-closes issue when PR merges) -->
<!-- - Fixes #123 (auto-closes issue when PR merges) -->
<!-- - Resolves #123 (auto-closes issue when PR merges) -->
<!-- - Addresses #123 (links but doesn't auto-close) -->
<!-- - Part of #123 (links but doesn't auto-close) -->

## Type of Change

<!-- Mark relevant items with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [ ] Documentation update
- [ ] Infrastructure/tooling change
- [ ] Refactoring (no functional changes)
- [ ] Style/formatting changes
- [ ] Performance improvement
- [ ] Test updates

## Changes Made

<!-- List the key changes in this PR -->

-
-
-

## Breaking Changes

<!-- If this introduces breaking changes, describe them here -->
<!-- Include migration instructions for users -->

**None** / **See details below:**

## Testing

<!-- Describe how this has been tested -->

### Test Environment
- [ ] Local development
- [ ] CI/CD pipeline
- [ ] Manual testing
- [ ] Automated tests added/updated

### Test Cases
<!-- List specific test cases or scenarios covered -->

-
-

## Documentation

<!-- Check all that apply -->

- [ ] Code changes are self-documenting
- [ ] Docstrings updated (if applicable)
- [ ] RST documentation updated (if applicable)
- [ ] README updated (if applicable)
- [ ] Migration guide updated (for breaking changes)
- [ ] CHANGELOG.md updated
- [ ] No documentation needed

## Checklist

<!-- Ensure all items are complete before requesting review -->

- [ ] Code follows project style guidelines (ruff)
- [ ] Self-review completed
- [ ] Comments added for complex/non-obvious code
- [ ] Documentation updated (or N/A)
- [ ] Tests added/updated (or N/A)
- [ ] All tests passing locally
- [ ] No new warnings introduced
- [ ] Commits are clean and well-described
- [ ] Branch is up-to-date with target branch

## Framework-Specific Checks

<!-- For changes affecting core framework -->

- [ ] Registry system changes validated
- [ ] Configuration system compatibility verified
- [ ] CLI commands tested
- [ ] Templates validated (if modified)
- [ ] Backward compatibility maintained (or breaking change documented)
- [ ] No circular imports introduced

## Screenshots / Output Examples

<!-- Add screenshots for UI changes or command output examples -->
<!-- Remove this section if not applicable -->

**Before:**
```
<!-- Paste relevant before state -->
```

**After:**
```
<!-- Paste relevant after state -->
```

## Deployment Notes

<!-- Special considerations for deployment -->
<!-- Remove this section if not applicable -->

- [ ] Database migrations required
- [ ] Configuration changes required
- [ ] Environment variables added/changed
- [ ] Dependencies added/updated
- [ ] Service restart required

## Reviewer Notes

<!-- Any specific areas you want reviewers to focus on? -->
<!-- Any concerns or questions for reviewers? -->

## Additional Context

<!-- Add any other context about the PR here -->
<!-- Links to related PRs, external references, design docs, etc. -->

---

<!--
PR Guidelines:
- Keep PRs focused on a single concern
- Link to related issues
- Provide context for reviewers
- Update documentation
- Add tests for new functionality
- Follow semantic commit message format
-->

