### PR TITLE
Add option to select CSV delimiter in `osprey channel-finder build-database`

### DIFF
--- a/src/osprey/cli/channel_finder_cmd.py
+++ b/src/osprey/cli/channel_finder_cmd.py
@@ -232,7 +232,12 @@ def benchmark(
     default=None,
     help="Path to facility config file (optional, auto-detected if not provided)",
 )
-def build_database(csv: str, output: str, use_llm: bool, config_path: str | None):
+@click.option(
+    "--delimiter",
+    default=",",
+    help="CSV field delimiter (default: ',')",
+)
+def build_database(csv: str, output: str, use_llm: bool, config_path: str | None, delimiter: str):
     """Build a channel database from a CSV file.
 
     Reads a CSV with columns: address, description, family_name, instances, sub_channel.
@@ -243,6 +248,7 @@ def build_database(csv: str, output: str, use_llm: bool, config_path: str | None
     \b
       osprey channel-finder build-database
       osprey channel-finder build-database --csv data/raw/channels.csv
+      osprey channel-finder build-database --delimiter "|"
       osprey channel-finder build-database --use-llm --config config.yml
       osprey channel-finder build-database --output data/processed/my_db.json
     """
@@ -261,6 +267,7 @@ def build_database(csv: str, output: str, use_llm: bool, config_path: str | None
             output_path=output_path,
             use_llm=use_llm,
             config_path=Path(config_path) if config_path else None,
+            delimiter=delimiter,
         )
     except Exception as e:
         console.print(f"\n{Messages.error(str(e))}")

--- a/src/osprey/services/channel_finder/tools/build_database.py
+++ b/src/osprey/services/channel_finder/tools/build_database.py
@@ -17,11 +17,11 @@ from datetime import datetime
 from pathlib import Path
 
 
-def load_csv(csv_path: Path) -> list[dict]:
+def load_csv(csv_path: Path, delimiter: str = ",") -> list[dict]:
     """Load CSV, skipping comment lines."""
     channels = []
     with open(csv_path, encoding="utf-8") as f:
-        reader = csv.DictReader(f)
+        reader = csv.DictReader(f, delimiter=delimiter)
         for row in reader:
             address = row.get("address", "").strip()
             # Skip comments and empty rows
@@ -159,6 +159,7 @@ def build_database(
     output_path: Path,
     use_llm: bool = False,
     config_path: Path | None = None,
+    delimiter: str = ",",
 ) -> dict:
     """Build channel database from CSV.
 
@@ -167,6 +168,7 @@ def build_database(
         output_path: Path for output JSON database.
         use_llm: Whether to use LLM for name generation.
         config_path: Optional path to config file for LLM settings.
+        delimiter: CSV field delimiter (default: ',').
 
     Returns:
         The built database dict.
@@ -177,7 +179,7 @@ def build_database(
     print(f"\nInput CSV: {csv_path}")
 
     # Load CSV
-    channels = load_csv(csv_path)
+    channels = load_csv(csv_path, delimiter=delimiter)
     print(f"Loaded {len(channels)} channels (excluding comments)")
 
     # Group by family

--- a/tests/cli/test_channel_finder_cmd.py
+++ b/tests/cli/test_channel_finder_cmd.py
@@ -258,6 +258,7 @@ class TestBuildDatabaseSubcommand:
         assert "--csv" in result.output
         assert "--output" in result.output
         assert "--use-llm" in result.output
+        assert "--delimiter" in result.output
 
     def test_build_database_with_csv(self, runner, tmp_path):
         """build-database builds a database from CSV."""
@@ -273,6 +274,38 @@ class TestBuildDatabaseSubcommand:
         result = runner.invoke(
             channel_finder,
             ["build-database", "--csv", str(csv_file), "--output", str(output_file)],
+        )
+        assert result.exit_code == 0
+        assert output_file.exists()
+
+        import json
+
+        db = json.loads(output_file.read_text())
+        assert "channels" in db
+        assert len(db["channels"]) > 0
+
+    def test_build_database_with_delimiter(self, runner, tmp_path):
+        """build-database accepts --delimiter for pipe-separated CSV."""
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text(
+            "address|description|family_name|instances|sub_channel\n"
+            "BEAM:CURRENT|Total beam current|||\n"
+            "BPM01X|BPM horizontal|BPM|3|X\n"
+            "BPM01Y|BPM vertical|BPM|3|Y\n"
+        )
+        output_file = tmp_path / "output.json"
+
+        result = runner.invoke(
+            channel_finder,
+            [
+                "build-database",
+                "--csv",
+                str(csv_file),
+                "--output",
+                str(output_file),
+                "--delimiter",
+                "|",
+            ],
         )
         assert result.exit_code == 0
         assert output_file.exists()


### PR DESCRIPTION
# Motivation

When creating a CSV file with the channel names and natural-language descriptions, it might be good to be able to pick a different delimiter than the comma (`,`).

The reason is that, in some control systems, the name of some channels (or PVs) may themselves contains commas (','). Less crucially, it is also sometimes desirable to use commas in the natural-language descriptions.

For this reason, this PR adds the option to pass the chosen delimiter in `osprey channel-finder build-database`:
```
      osprey channel-finder build-database --delimiter "|"
```

