### PR TITLE
feat(channel-finder): Google Sheets channel database backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,9 +194,14 @@ ariel-proxy = [
     "aiohttp-socks>=0.8.0",
 ]
 
+# Google Sheets database backend for channel finder
+sheets = [
+    "gspread>=6.0.0",
+]
+
 # All optional dependencies for complete installation
 all = [
-    "osprey-framework[docs,dev,storage,ariel]"
+    "osprey-framework[docs,dev,storage,ariel,sheets]"
 ]
 
 [project.urls]

--- a/src/osprey/services/channel_finder/databases/__init__.py
+++ b/src/osprey/services/channel_finder/databases/__init__.py
@@ -13,6 +13,14 @@ from .hierarchical import HierarchicalChannelDatabase
 from .middle_layer import MiddleLayerDatabase
 from .template import ChannelDatabase as TemplateChannelDatabase
 
+_has_google_sheets = False
+try:
+    from .google_sheets import GoogleSheetsChannelDatabase
+
+    _has_google_sheets = True
+except ImportError:
+    pass
+
 # Backward compatibility alias
 LegacyChannelDatabase = FlatChannelDatabase
 
@@ -23,3 +31,6 @@ __all__ = [
     "HierarchicalChannelDatabase",
     "MiddleLayerDatabase",
 ]
+
+if _has_google_sheets:
+    __all__.append("GoogleSheetsChannelDatabase")

--- a/src/osprey/services/channel_finder/databases/flat.py
+++ b/src/osprey/services/channel_finder/databases/flat.py
@@ -24,6 +24,8 @@ class ChannelDatabase(BaseDatabase):
             FileNotFoundError: If database file doesn't exist
             json.JSONDecodeError: If database file is malformed
         """
+        # Note: GoogleSheetsChannelDatabase mirrors these attributes manually
+        # in its __init__ (it cannot call super().__init__). Keep in sync.
         self.channels: list[dict] = []
         self.channel_map: dict[str, dict] = {}
         super().__init__(db_path)

--- a/src/osprey/services/channel_finder/databases/google_sheets.py
+++ b/src/osprey/services/channel_finder/databases/google_sheets.py
@@ -1,0 +1,185 @@
+"""
+Google Sheets Channel Database
+
+Manages a channel database stored in a Google Sheets spreadsheet,
+enabling collaborative editing via Google Sheets instead of a local JSON file.
+Subclasses FlatChannelDatabase to inherit chunking, formatting, and validation.
+"""
+
+try:
+    import gspread
+except ImportError:
+    gspread = None
+
+from ..core.exceptions import DatabaseLoadError
+from .flat import ChannelDatabase as FlatChannelDatabase
+
+
+class GoogleSheetsChannelDatabase(FlatChannelDatabase):
+    """Channel database backed by a Google Sheets spreadsheet.
+
+    Expects the spreadsheet to have columns: channel, address, description
+    (as the first row / header).
+
+    This class is not thread-safe. External synchronization is required
+    for concurrent access.
+    """
+
+    def __init__(
+        self, spreadsheet_id: str, worksheet: str | None = None, credentials_path: str | None = None
+    ):
+        """Initialize Google Sheets channel database.
+
+        Args:
+            spreadsheet_id: The Google Sheets spreadsheet ID
+            worksheet: Worksheet/tab name (defaults to "Sheet1")
+            credentials_path: Path to service account JSON credentials.
+                If None, uses default ~/.config/gspread/service_account.json
+
+        Raises:
+            ImportError: If gspread is not installed
+        """
+        self.spreadsheet_id = spreadsheet_id
+        self.worksheet_name = worksheet or "Sheet1"
+        self.credentials_path = credentials_path
+
+        # Initialize attributes that FlatChannelDatabase.__init__ would set
+        self.channels: list[dict] = []
+        self.channel_map: dict[str, dict] = {}
+        # Synthetic db_path for logging and get_statistics
+        self.db_path = f"google_sheets://{spreadsheet_id}"
+
+        # Do NOT call super().__init__() — BaseDatabase.__init__ reads
+        # self.db_path as a file path. We set attributes manually instead.
+        self._init_client()
+        self.load_database()
+
+    def _init_client(self):
+        """Initialize the gspread client and open the worksheet.
+
+        Raises:
+            ImportError: If gspread is not installed
+            DatabaseLoadError: If credentials, spreadsheet, or worksheet not found
+        """
+        if gspread is None:
+            raise ImportError(
+                "gspread is required for Google Sheets database support. "
+                "Install it with: pip install osprey-framework[sheets]"
+            )
+
+        try:
+            if self.credentials_path:
+                client = gspread.service_account(filename=self.credentials_path)
+            else:
+                client = gspread.service_account()
+        except FileNotFoundError as e:
+            path = self.credentials_path or "~/.config/gspread/service_account.json"
+            raise DatabaseLoadError(f"Google Sheets credentials file not found: {path}") from e
+
+        try:
+            spreadsheet = client.open_by_key(self.spreadsheet_id)
+        except gspread.exceptions.SpreadsheetNotFound as e:
+            raise DatabaseLoadError(f"Spreadsheet not found: {self.spreadsheet_id}") from e
+
+        try:
+            self._sheet = spreadsheet.worksheet(self.worksheet_name)
+        except gspread.exceptions.WorksheetNotFound as e:
+            raise DatabaseLoadError(
+                f"Worksheet '{self.worksheet_name}' not found in spreadsheet {self.spreadsheet_id}"
+            ) from e
+
+    def load_database(self):
+        """Load channel data from the Google Sheet."""
+        records = self._sheet.get_all_records()
+
+        # Validate columns from first record
+        required = {"channel", "address", "description"}
+        if records:
+            found = set(records[0].keys())
+            missing = required - found
+            if missing:
+                raise DatabaseLoadError(
+                    f"Sheet is missing required columns: {sorted(missing)}. "
+                    f"Found columns: {sorted(found)}"
+                )
+
+        self.channels = [
+            {
+                "channel": row["channel"],
+                "address": row["address"],
+                "description": row["description"],
+            }
+            for row in records
+        ]
+        self.channel_map = {ch["channel"]: ch for ch in self.channels}
+
+    def refresh(self):
+        """Refresh channel data from the Google Sheet."""
+        self.load_database()
+
+    def add_channel(self, channel: str, address: str, description: str):
+        """Add a new channel to the spreadsheet.
+
+        Args:
+            channel: Channel name
+            address: Channel address
+            description: Channel description
+
+        Raises:
+            ValueError: If channel already exists
+        """
+        if channel in self.channel_map:
+            raise ValueError(f"Channel '{channel}' already exists")
+        self._sheet.append_row([channel, address, description])
+        self.load_database()
+
+    def update_channel(
+        self, channel: str, new_description: str | None = None, new_address: str | None = None
+    ):
+        """Update an existing channel in the spreadsheet.
+
+        Args:
+            channel: Channel name to update
+            new_description: New description (if provided)
+            new_address: New address (if provided)
+
+        Raises:
+            ValueError: If channel does not exist
+        """
+        if new_description is None and new_address is None:
+            return
+        cell = self._sheet.find(channel, in_column=1)
+        if cell is None:
+            raise ValueError(f"Channel '{channel}' not found")
+        if new_address is not None:
+            self._sheet.update_cell(cell.row, 2, new_address)
+        if new_description is not None:
+            self._sheet.update_cell(cell.row, 3, new_description)
+        self.load_database()
+
+    def delete_channel(self, channel: str):
+        """Delete a channel from the spreadsheet.
+
+        Args:
+            channel: Channel name to delete
+
+        Raises:
+            ValueError: If channel does not exist
+        """
+        cell = self._sheet.find(channel, in_column=1)
+        if cell is None:
+            raise ValueError(f"Channel '{channel}' not found")
+        self._sheet.delete_rows(cell.row)
+        self.load_database()
+
+    def get_statistics(self) -> dict:
+        """Get database statistics including Google Sheets source info."""
+        stats = super().get_statistics()
+        stats.update(
+            {
+                "source": "google_sheets",
+                "spreadsheet_id": self.spreadsheet_id,
+                "worksheet": self.worksheet_name,
+            }
+        )
+        return stats

--- a/tests/services/channel_finder/test_google_sheets_database.py
+++ b/tests/services/channel_finder/test_google_sheets_database.py
@@ -1,0 +1,327 @@
+"""
+Tests for Google Sheets Channel Database.
+
+All tests mock gspread — no network calls or credentials needed.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from osprey.services.channel_finder.core.exceptions import DatabaseLoadError
+from osprey.services.channel_finder.databases.google_sheets import (
+    GoogleSheetsChannelDatabase,
+)
+
+SAMPLE_RECORDS = [
+    {"channel": "CH1", "address": "ADDR1", "description": "Desc1"},
+    {"channel": "CH2", "address": "ADDR2", "description": "Desc2"},
+    {"channel": "CH3", "address": "ADDR3", "description": "Desc3"},
+]
+
+
+def _make_mock_gspread(records=None):
+    """Create a mock gspread module with pre-configured worksheet."""
+    if records is None:
+        records = SAMPLE_RECORDS
+
+    mock_worksheet = MagicMock()
+    mock_worksheet.get_all_records.return_value = records
+
+    mock_spreadsheet = MagicMock()
+    mock_spreadsheet.worksheet.return_value = mock_worksheet
+
+    mock_gspread = MagicMock()
+    mock_gspread.service_account.return_value.open_by_key.return_value = mock_spreadsheet
+
+    return mock_gspread, mock_spreadsheet, mock_worksheet
+
+
+class TestGoogleSheetsChannelDatabase:
+    """Tests for GoogleSheetsChannelDatabase."""
+
+    @patch("osprey.services.channel_finder.databases.google_sheets.gspread")
+    def test_load_database(self, mock_gspread_module):
+        """Channels are loaded from mocked sheet data."""
+        mock_gspread, _, mock_worksheet = _make_mock_gspread()
+        mock_gspread_module.service_account = mock_gspread.service_account
+
+        db = GoogleSheetsChannelDatabase(spreadsheet_id="test_id")
+
+        assert len(db.channels) == 3
+        assert db.channels[0]["channel"] == "CH1"
+        assert db.channels[2]["address"] == "ADDR3"
+        assert "CH2" in db.channel_map
+
+    @patch("osprey.services.channel_finder.databases.google_sheets.gspread")
+    def test_get_statistics_includes_source(self, mock_gspread_module):
+        """Statistics include google_sheets source info."""
+        mock_gspread, _, _ = _make_mock_gspread()
+        mock_gspread_module.service_account = mock_gspread.service_account
+
+        db = GoogleSheetsChannelDatabase(spreadsheet_id="abc123", worksheet="MyTab")
+        stats = db.get_statistics()
+
+        assert stats["source"] == "google_sheets"
+        assert stats["spreadsheet_id"] == "abc123"
+        assert stats["worksheet"] == "MyTab"
+        assert stats["total_channels"] == 3
+
+    @patch("osprey.services.channel_finder.databases.google_sheets.gspread")
+    def test_inherited_methods_work(self, mock_gspread_module):
+        """Inherited methods (get_channel, validate_channel, format_for_prompt, chunk_database) work."""
+        mock_gspread, _, _ = _make_mock_gspread()
+        mock_gspread_module.service_account = mock_gspread.service_account
+
+        db = GoogleSheetsChannelDatabase(spreadsheet_id="test_id")
+
+        # get_channel
+        ch = db.get_channel("CH1")
+        assert ch is not None
+        assert ch["address"] == "ADDR1"
+        assert db.get_channel("NONEXISTENT") is None
+
+        # validate_channel
+        assert db.validate_channel("CH2") is True
+        assert db.validate_channel("NOPE") is False
+
+        # format_for_prompt
+        prompt = db.format_for_prompt()
+        assert "CH1" in prompt
+        assert "CH3" in prompt
+
+        # chunk_database
+        chunks = db.chunk_database(chunk_size=2)
+        assert len(chunks) == 2
+        assert len(chunks[0]) == 2
+        assert len(chunks[1]) == 1
+
+    @patch("osprey.services.channel_finder.databases.google_sheets.gspread")
+    def test_add_channel(self, mock_gspread_module):
+        """add_channel appends row and reloads cache."""
+        mock_gspread, _, mock_worksheet = _make_mock_gspread()
+        mock_gspread_module.service_account = mock_gspread.service_account
+
+        db = GoogleSheetsChannelDatabase(spreadsheet_id="test_id")
+
+        # After add, the sheet returns updated records
+        new_records = SAMPLE_RECORDS + [
+            {"channel": "CH4", "address": "ADDR4", "description": "Desc4"}
+        ]
+        mock_worksheet.get_all_records.return_value = new_records
+
+        db.add_channel("CH4", "ADDR4", "Desc4")
+
+        mock_worksheet.append_row.assert_called_once_with(["CH4", "ADDR4", "Desc4"])
+        assert len(db.channels) == 4
+        assert "CH4" in db.channel_map
+
+    @patch("osprey.services.channel_finder.databases.google_sheets.gspread")
+    def test_add_duplicate_raises(self, mock_gspread_module):
+        """Adding a duplicate channel raises ValueError."""
+        mock_gspread, _, _ = _make_mock_gspread()
+        mock_gspread_module.service_account = mock_gspread.service_account
+
+        db = GoogleSheetsChannelDatabase(spreadsheet_id="test_id")
+
+        with pytest.raises(ValueError, match="already exists"):
+            db.add_channel("CH1", "ADDR_NEW", "New desc")
+
+    @patch("osprey.services.channel_finder.databases.google_sheets.gspread")
+    def test_delete_channel(self, mock_gspread_module):
+        """delete_channel finds the row, deletes it, and reloads."""
+        mock_gspread, _, mock_worksheet = _make_mock_gspread()
+        mock_gspread_module.service_account = mock_gspread.service_account
+
+        db = GoogleSheetsChannelDatabase(spreadsheet_id="test_id")
+
+        mock_cell = MagicMock()
+        mock_cell.row = 2
+        mock_worksheet.find.return_value = mock_cell
+
+        # After delete, sheet returns fewer records
+        mock_worksheet.get_all_records.return_value = SAMPLE_RECORDS[1:]
+
+        db.delete_channel("CH1")
+
+        mock_worksheet.find.assert_called_once_with("CH1", in_column=1)
+        mock_worksheet.delete_rows.assert_called_once_with(2)
+        assert len(db.channels) == 2
+
+    @patch("osprey.services.channel_finder.databases.google_sheets.gspread")
+    def test_delete_nonexistent_raises(self, mock_gspread_module):
+        """Deleting a nonexistent channel raises ValueError."""
+        mock_gspread, _, mock_worksheet = _make_mock_gspread()
+        mock_gspread_module.service_account = mock_gspread.service_account
+
+        db = GoogleSheetsChannelDatabase(spreadsheet_id="test_id")
+        mock_worksheet.find.return_value = None
+
+        with pytest.raises(ValueError, match="not found"):
+            db.delete_channel("NONEXISTENT")
+
+    @patch("osprey.services.channel_finder.databases.google_sheets.gspread")
+    def test_update_channel(self, mock_gspread_module):
+        """update_channel finds the row, updates cells, and reloads."""
+        mock_gspread, _, mock_worksheet = _make_mock_gspread()
+        mock_gspread_module.service_account = mock_gspread.service_account
+
+        db = GoogleSheetsChannelDatabase(spreadsheet_id="test_id")
+
+        mock_cell = MagicMock()
+        mock_cell.row = 3
+        mock_worksheet.find.return_value = mock_cell
+
+        db.update_channel("CH2", new_description="Updated desc", new_address="NEW_ADDR")
+
+        mock_worksheet.find.assert_called_once_with("CH2", in_column=1)
+        mock_worksheet.update_cell.assert_any_call(3, 2, "NEW_ADDR")
+        mock_worksheet.update_cell.assert_any_call(3, 3, "Updated desc")
+
+    @patch("osprey.services.channel_finder.databases.google_sheets.gspread")
+    def test_update_nonexistent_raises(self, mock_gspread_module):
+        """Updating a nonexistent channel raises ValueError."""
+        mock_gspread, _, mock_worksheet = _make_mock_gspread()
+        mock_gspread_module.service_account = mock_gspread.service_account
+
+        db = GoogleSheetsChannelDatabase(spreadsheet_id="test_id")
+        mock_worksheet.find.return_value = None
+
+        with pytest.raises(ValueError, match="not found"):
+            db.update_channel("NONEXISTENT", new_description="foo")
+
+    @patch("osprey.services.channel_finder.databases.google_sheets.gspread")
+    def test_refresh(self, mock_gspread_module):
+        """refresh() reloads data from the sheet."""
+        mock_gspread, _, mock_worksheet = _make_mock_gspread()
+        mock_gspread_module.service_account = mock_gspread.service_account
+
+        db = GoogleSheetsChannelDatabase(spreadsheet_id="test_id")
+        assert len(db.channels) == 3
+
+        # Simulate sheet data changing
+        mock_worksheet.get_all_records.return_value = SAMPLE_RECORDS[:1]
+        db.refresh()
+        assert len(db.channels) == 1
+
+    @patch("osprey.services.channel_finder.databases.google_sheets.gspread")
+    def test_worksheet_name_selection(self, mock_gspread_module):
+        """worksheet parameter selects the correct tab."""
+        mock_gspread, mock_spreadsheet, _ = _make_mock_gspread()
+        mock_gspread_module.service_account = mock_gspread.service_account
+
+        db = GoogleSheetsChannelDatabase(spreadsheet_id="test_id", worksheet="CustomTab")
+
+        mock_spreadsheet.worksheet.assert_called_with("CustomTab")
+        assert db.worksheet_name == "CustomTab"
+
+    def test_missing_gspread_gives_clear_error(self):
+        """ImportError with helpful message when gspread is not installed."""
+        from osprey.services.channel_finder.databases import google_sheets as gs_module
+
+        # Temporarily set gspread to None to simulate missing package
+        original = gs_module.gspread
+        gs_module.gspread = None
+        try:
+            with pytest.raises(ImportError, match="pip install osprey-framework\\[sheets\\]"):
+                gs_module.GoogleSheetsChannelDatabase(spreadsheet_id="test_id")
+        finally:
+            gs_module.gspread = original
+
+    @patch("osprey.services.channel_finder.databases.google_sheets.gspread")
+    def test_credentials_path_passed_to_service_account(self, mock_gspread_module):
+        """credentials_path is forwarded to gspread.service_account(filename=...)."""
+        mock_gspread, _, _ = _make_mock_gspread()
+        mock_gspread_module.service_account = mock_gspread.service_account
+
+        GoogleSheetsChannelDatabase(
+            spreadsheet_id="test_id",
+            credentials_path="/path/to/creds.json",
+        )
+
+        mock_gspread.service_account.assert_called_once_with(filename="/path/to/creds.json")
+
+    @patch("osprey.services.channel_finder.databases.google_sheets.gspread")
+    def test_default_credentials(self, mock_gspread_module):
+        """Without credentials_path, gspread.service_account() is called with no args."""
+        mock_gspread, _, _ = _make_mock_gspread()
+        mock_gspread_module.service_account = mock_gspread.service_account
+
+        GoogleSheetsChannelDatabase(spreadsheet_id="test_id")
+
+        mock_gspread.service_account.assert_called_once_with()
+
+    # --- New tests for error paths ---
+
+    @patch("osprey.services.channel_finder.databases.google_sheets.gspread")
+    def test_missing_columns_raises_database_load_error(self, mock_gspread_module):
+        """Sheet with wrong columns raises DatabaseLoadError."""
+        bad_records = [{"name": "x", "value": "y"}]
+        mock_gspread, _, _ = _make_mock_gspread(records=bad_records)
+        mock_gspread_module.service_account = mock_gspread.service_account
+
+        with pytest.raises(DatabaseLoadError, match="missing required columns"):
+            GoogleSheetsChannelDatabase(spreadsheet_id="test_id")
+
+    @patch("osprey.services.channel_finder.databases.google_sheets.gspread")
+    def test_spreadsheet_not_found_raises_database_load_error(self, mock_gspread_module):
+        """Nonexistent spreadsheet raises DatabaseLoadError."""
+        mock_gspread, _, _ = _make_mock_gspread()
+        mock_gspread_module.service_account = mock_gspread.service_account
+        mock_gspread_module.exceptions = MagicMock()
+
+        # Make open_by_key raise SpreadsheetNotFound
+        exc_class = type("SpreadsheetNotFound", (Exception,), {})
+        mock_gspread_module.exceptions.SpreadsheetNotFound = exc_class
+        mock_gspread.service_account.return_value.open_by_key.side_effect = exc_class("nope")
+
+        with pytest.raises(DatabaseLoadError, match="Spreadsheet not found"):
+            GoogleSheetsChannelDatabase(spreadsheet_id="bad_id")
+
+    @patch("osprey.services.channel_finder.databases.google_sheets.gspread")
+    def test_worksheet_not_found_raises_database_load_error(self, mock_gspread_module):
+        """Nonexistent worksheet raises DatabaseLoadError."""
+        mock_gspread, mock_spreadsheet, _ = _make_mock_gspread()
+        mock_gspread_module.service_account = mock_gspread.service_account
+        mock_gspread_module.exceptions = MagicMock()
+
+        # Make worksheet() raise WorksheetNotFound
+        exc_class = type("WorksheetNotFound", (Exception,), {})
+        mock_gspread_module.exceptions.WorksheetNotFound = exc_class
+        mock_spreadsheet.worksheet.side_effect = exc_class("nope")
+
+        with pytest.raises(DatabaseLoadError, match="Worksheet.*not found"):
+            GoogleSheetsChannelDatabase(spreadsheet_id="test_id", worksheet="BadTab")
+
+    @patch("osprey.services.channel_finder.databases.google_sheets.gspread")
+    def test_missing_credentials_raises_database_load_error(self, mock_gspread_module):
+        """Missing credentials file raises DatabaseLoadError."""
+        mock_gspread, _, _ = _make_mock_gspread()
+        mock_gspread_module.service_account = mock_gspread.service_account
+
+        mock_gspread.service_account.side_effect = FileNotFoundError("no such file")
+
+        with pytest.raises(DatabaseLoadError, match="credentials file not found"):
+            GoogleSheetsChannelDatabase(
+                spreadsheet_id="test_id",
+                credentials_path="/nonexistent/creds.json",
+            )
+
+    @patch("osprey.services.channel_finder.databases.google_sheets.gspread")
+    def test_update_channel_no_changes_is_noop(self, mock_gspread_module):
+        """update_channel with no new_description or new_address makes no network calls."""
+        mock_gspread, _, mock_worksheet = _make_mock_gspread()
+        mock_gspread_module.service_account = mock_gspread.service_account
+
+        db = GoogleSheetsChannelDatabase(spreadsheet_id="test_id")
+
+        # Reset call counts after init
+        mock_worksheet.find.reset_mock()
+        mock_worksheet.update_cell.reset_mock()
+        mock_worksheet.get_all_records.reset_mock()
+
+        db.update_channel("CH1")
+
+        mock_worksheet.find.assert_not_called()
+        mock_worksheet.update_cell.assert_not_called()
+        mock_worksheet.get_all_records.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds `GoogleSheetsChannelDatabase`, a new channel database backend that reads/writes channel data from a Google Sheets spreadsheet instead of a local JSON file
- Enables collaborative editing of the channel database via the familiar Google Sheets UI
- Integrates with the existing `in_context` pipeline via a `source: google_sheets` config option
- 19 unit tests (all mocked, no credentials needed to run)

## How to set up and test with your own spreadsheet

### 1. Create a Google Cloud service account

1. Go to [Google Cloud Console](https://console.cloud.google.com/)
2. Create a project (or use an existing one)
3. Enable the **Google Sheets API** and **Google Drive API**
4. Go to **IAM & Admin → Service Accounts** → Create a service account
5. Create a JSON key for the service account and download it
6. Place it at `~/.config/gspread/service_account.json` (default path), or note the path for the `credentials_path` config option

### 2. Create and share a Google Sheet

1. Create a new Google Sheet
2. Add a header row with exactly these columns: **channel**, **address**, **description**
3. Add a few rows of test data, e.g.:

   | channel | address | description |
   |---------|---------|-------------|
   | MY:CHAN:01 | 192.168.1.10 | My first channel |
   | MY:CHAN:02 | 192.168.1.11 | My second channel |

4. **Share the spreadsheet** with the service account email (it looks like `name@project.iam.gserviceaccount.com`) — give it **Editor** access
5. Copy the spreadsheet ID from the URL: `https://docs.google.com/spreadsheets/d/<SPREADSHEET_ID>/edit`

### 3. Install the extra

```bash
uv pip install -e ".[sheets]"
```

### 4. Configure in `config.yml`

```yaml
channel_finder:
  pipeline_mode: in_context
  pipelines:
    in_context:
      database:
        source: google_sheets
        spreadsheet_id: "<YOUR_SPREADSHEET_ID>"
        # worksheet: "Sheet1"           # optional, defaults to Sheet1
        # credentials_path: "/path/to/creds.json"  # optional, defaults to ~/.config/gspread/service_account.json
```

### 5. Run the tests

```bash
# Google Sheets tests only (all mocked, no credentials needed)
pytest tests/services/channel_finder/test_google_sheets_database.py -v

# Full channel finder suite (verify no regressions)
pytest tests/services/channel_finder/ -v
```

## Test plan

- [x] 19/19 Google Sheets database tests pass
- [x] 459/459 full channel finder test suite passes, no regressions
- [ ] Reviewer: set up a Google Sheet with your facility's channel data following the recipe above and confirm the `in_context` pipeline works end-to-end

## Files changed

| File | What |
|------|------|
| `databases/google_sheets.py` | New `GoogleSheetsChannelDatabase` class |
| `service.py` | Wire up `source: google_sheets` in the in_context pipeline |
| `databases/__init__.py` | Conditional export (graceful when gspread not installed) |
| `databases/flat.py` | Maintenance note about mirrored attributes |
| `pyproject.toml` | New `[sheets]` optional extra (`gspread>=6.0.0`) |
| `test_google_sheets_database.py` | 19 tests covering CRUD, error paths, edge cases |