### PR TITLE
Add bidirectional write support to ARIEL facility adapters

### DIFF
--- a/src/osprey/interfaces/ariel/api/schemas.py
+++ b/src/osprey/interfaces/ariel/api/schemas.py
@@ -150,6 +150,8 @@ class EntryCreateResponse(BaseModel):
 
     entry_id: str
     message: str = "Entry created successfully"
+    sync_status: str | None = None
+    source_system: str | None = None
 
 
 class EmbeddingTableStatus(BaseModel):

--- a/src/osprey/services/ariel_search/config.py
+++ b/src/osprey/services/ariel_search/config.py
@@ -156,6 +156,33 @@ class WatchConfig:
 
 
 @dataclass
+class WriteConfig:
+    """Configuration for facility logbook write operations.
+
+    Attributes:
+        enabled: Whether writing to the facility logbook is enabled
+        write_url: URL for the facility write API (if different from source_url)
+        auth_user: Username for write authentication
+        auth_password: Password for write authentication
+    """
+
+    enabled: bool = False
+    write_url: str | None = None
+    auth_user: str | None = None
+    auth_password: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "WriteConfig":
+        """Create WriteConfig from dictionary."""
+        return cls(
+            enabled=data.get("enabled", False),
+            write_url=data.get("write_url"),
+            auth_user=data.get("auth_user") or os.environ.get("ARIEL_WRITE_USER"),
+            auth_password=data.get("auth_password") or os.environ.get("ARIEL_WRITE_PASSWORD"),
+        )
+
+
+@dataclass
 class IngestionConfig:
     """Configuration for logbook ingestion.
 
@@ -170,6 +197,7 @@ class IngestionConfig:
         max_retries: Maximum retry attempts for failed requests (default: 3)
         retry_delay_seconds: Base delay between retries (default: 5)
         watch: Watch mode configuration
+        write: Write operation configuration
     """
 
     adapter: str
@@ -182,6 +210,7 @@ class IngestionConfig:
     max_retries: int = 3
     retry_delay_seconds: int = 5
     watch: WatchConfig = field(default_factory=WatchConfig)
+    write: WriteConfig = field(default_factory=WriteConfig)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "IngestionConfig":
@@ -191,6 +220,10 @@ class IngestionConfig:
         watch = WatchConfig()
         if "watch" in data:
             watch = WatchConfig.from_dict(data["watch"])
+
+        write = WriteConfig()
+        if "write" in data:
+            write = WriteConfig.from_dict(data["write"])
 
         return cls(
             adapter=data.get("adapter", "generic"),
@@ -203,6 +236,7 @@ class IngestionConfig:
             max_retries=data.get("max_retries", 3),
             retry_delay_seconds=data.get("retry_delay_seconds", 5),
             watch=watch,
+            write=write,
         )
 
 

--- a/src/osprey/services/ariel_search/ingestion/__init__.py
+++ b/src/osprey/services/ariel_search/ingestion/__init__.py
@@ -4,9 +4,10 @@ This module provides facility-specific adapters for logbook ingestion.
 """
 
 from osprey.services.ariel_search.ingestion.adapters import get_adapter
-from osprey.services.ariel_search.ingestion.base import BaseAdapter
+from osprey.services.ariel_search.ingestion.base import BaseAdapter, FacilityAdapter
 
 __all__ = [
     "BaseAdapter",
+    "FacilityAdapter",
     "get_adapter",
 ]

--- a/src/osprey/services/ariel_search/ingestion/adapters/__init__.py
+++ b/src/osprey/services/ariel_search/ingestion/adapters/__init__.py
@@ -8,13 +8,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, cast
 
 from osprey.services.ariel_search.exceptions import AdapterNotFoundError
-from osprey.services.ariel_search.ingestion.base import BaseAdapter
+from osprey.services.ariel_search.ingestion.base import BaseAdapter, FacilityAdapter
 
 if TYPE_CHECKING:
     from osprey.services.ariel_search.config import ARIELConfig
 
 
-def get_adapter(config: ARIELConfig) -> BaseAdapter:
+def get_adapter(config: ARIELConfig) -> FacilityAdapter:
     """Load adapter based on configuration using the Osprey registry.
 
     Looks up the adapter class from the central Osprey registry, which supports
@@ -54,4 +54,4 @@ def get_adapter(config: ARIELConfig) -> BaseAdapter:
         )
 
     adapter_class, _registration = result
-    return cast(BaseAdapter, adapter_class(config))
+    return cast(FacilityAdapter, adapter_class(config))

--- a/src/osprey/services/ariel_search/ingestion/adapters/jlab.py
+++ b/src/osprey/services/ariel_search/ingestion/adapters/jlab.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from osprey.services.ariel_search.exceptions import IngestionError
-from osprey.services.ariel_search.ingestion.base import BaseAdapter
+from osprey.services.ariel_search.ingestion.base import FacilityAdapter
 from osprey.services.ariel_search.models import AttachmentInfo, EnhancedLogbookEntry
 from osprey.utils.logger import get_logger
 
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 logger = get_logger("ariel")
 
 
-class JLabLogbookAdapter(BaseAdapter):
+class JLabLogbookAdapter(FacilityAdapter):
     """Adapter for Jefferson Lab electronic logbook system."""
 
     def __init__(self, config: "ARIELConfig") -> None:

--- a/src/osprey/services/ariel_search/ingestion/adapters/ornl.py
+++ b/src/osprey/services/ariel_search/ingestion/adapters/ornl.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from osprey.services.ariel_search.exceptions import IngestionError
-from osprey.services.ariel_search.ingestion.base import BaseAdapter
+from osprey.services.ariel_search.ingestion.base import FacilityAdapter
 from osprey.services.ariel_search.models import AttachmentInfo, EnhancedLogbookEntry
 from osprey.utils.logger import get_logger
 
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 logger = get_logger("ariel")
 
 
-class ORNLLogbookAdapter(BaseAdapter):
+class ORNLLogbookAdapter(FacilityAdapter):
     """Adapter for Oak Ridge National Laboratory electronic logbook system."""
 
     def __init__(self, config: "ARIELConfig") -> None:

--- a/src/osprey/services/ariel_search/models.py
+++ b/src/osprey/services/ariel_search/models.py
@@ -15,6 +15,39 @@ from enum import Enum
 from typing import Any, NotRequired, TypedDict
 
 
+class SyncStatus(Enum):
+    """Synchronization status for facility-written entries."""
+
+    SYNCED = "synced"
+    PENDING_SYNC = "pending_sync"
+    LOCAL_ONLY = "local_only"
+
+
+@dataclass
+class FacilityEntryCreateRequest:
+    """Request to create a logbook entry through a facility adapter."""
+
+    subject: str
+    details: str
+    author: str | None = None
+    logbook: str | None = None
+    shift: str | None = None
+    tags: list[str] = field(default_factory=list)
+    attachment_paths: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class FacilityEntryCreateResult:
+    """Result from creating a logbook entry through a facility adapter."""
+
+    entry_id: str
+    source_system: str
+    sync_status: SyncStatus
+    message: str
+    attachment_count: int = 0
+
+
 class AttachmentInfo(TypedDict):
     """Normalized attachment metadata.
 

--- a/tests/services/ariel_search/test_service_create.py
+++ b/tests/services/ariel_search/test_service_create.py
@@ -1,0 +1,182 @@
+"""Tests for ARIELSearchService.create_entry() orchestration."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from osprey.services.ariel_search.models import (
+    FacilityEntryCreateRequest,
+    FacilityEntryCreateResult,
+    SyncStatus,
+)
+
+
+def _make_mock_service(adapter_supports_write: bool = True, source_system: str = "Generic JSON"):
+    """Build a mock ARIELSearchService with mocked adapter and repository."""
+    from osprey.services.ariel_search.config import ARIELConfig
+
+    config = ARIELConfig.from_dict(
+        {
+            "database": {"uri": "postgresql://test"},
+            "ingestion": {"adapter": "generic_json", "source_url": "/tmp/test.json"},
+        }
+    )
+
+    mock_pool = MagicMock()
+    mock_repository = AsyncMock()
+    mock_repository.upsert_entry = AsyncMock()
+
+    from osprey.services.ariel_search.service import ARIELSearchService
+
+    service = ARIELSearchService(config=config, pool=mock_pool, repository=mock_repository)
+
+    # Build mock adapter
+    mock_adapter = AsyncMock()
+    mock_adapter.supports_write = adapter_supports_write
+    mock_adapter.source_system_name = source_system
+    mock_adapter.create_entry = AsyncMock(return_value="test-entry-001")
+
+    # For non-local adapters, mock fetch_entries to return empty
+    async def empty_fetch(**kwargs):
+        return
+        yield  # Make it an async generator
+
+    mock_adapter.fetch_entries = empty_fetch
+
+    return service, mock_adapter, mock_repository
+
+
+@pytest.mark.asyncio
+async def test_create_entry_via_generic_adapter():
+    """Full orchestration: adapter write + local upsert for Generic JSON."""
+    service, mock_adapter, mock_repository = _make_mock_service(
+        adapter_supports_write=True,
+        source_system="Generic JSON",
+    )
+
+    request = FacilityEntryCreateRequest(
+        subject="Test entry",
+        details="Test details",
+        author="tester",
+        tags=["test"],
+    )
+
+    with patch(
+        "osprey.services.ariel_search.ingestion.get_adapter",
+        return_value=mock_adapter,
+    ):
+        result = await service.create_entry(request)
+
+    assert isinstance(result, FacilityEntryCreateResult)
+    assert result.entry_id == "test-entry-001"
+    assert result.source_system == "Generic JSON"
+    assert result.sync_status == SyncStatus.LOCAL_ONLY
+
+    # Adapter was called
+    mock_adapter.create_entry.assert_called_once_with(request)
+
+    # Repository upsert was called for optimistic local insert
+    mock_repository.upsert_entry.assert_called_once()
+    upserted = mock_repository.upsert_entry.call_args[0][0]
+    assert upserted["entry_id"] == "test-entry-001"
+    assert upserted["source_system"] == "Generic JSON"
+
+
+@pytest.mark.asyncio
+async def test_create_entry_unsupported_adapter():
+    """NotImplementedError when adapter doesn't support writes."""
+    service, mock_adapter, _mock_repository = _make_mock_service(
+        adapter_supports_write=False,
+        source_system="JLab Logbook",
+    )
+
+    request = FacilityEntryCreateRequest(
+        subject="Test",
+        details="Details",
+    )
+
+    with patch(
+        "osprey.services.ariel_search.ingestion.get_adapter",
+        return_value=mock_adapter,
+    ):
+        with pytest.raises(NotImplementedError, match="does not support"):
+            await service.create_entry(request)
+
+
+@pytest.mark.asyncio
+async def test_create_entry_sync_status_local_only():
+    """Generic JSON adapter gets LOCAL_ONLY sync status."""
+    service, mock_adapter, _mock_repository = _make_mock_service(
+        adapter_supports_write=True,
+        source_system="Generic JSON",
+    )
+
+    request = FacilityEntryCreateRequest(subject="Test", details="Details")
+
+    with patch(
+        "osprey.services.ariel_search.ingestion.get_adapter",
+        return_value=mock_adapter,
+    ):
+        result = await service.create_entry(request)
+
+    assert result.sync_status == SyncStatus.LOCAL_ONLY
+
+
+@pytest.mark.asyncio
+async def test_create_entry_sync_status_pending():
+    """Non-local adapter (ALS) gets PENDING_SYNC when re-ingestion doesn't find entry."""
+    service, mock_adapter, _mock_repository = _make_mock_service(
+        adapter_supports_write=True,
+        source_system="ALS eLog",
+    )
+
+    request = FacilityEntryCreateRequest(subject="Test", details="Details")
+
+    with patch(
+        "osprey.services.ariel_search.ingestion.get_adapter",
+        return_value=mock_adapter,
+    ):
+        result = await service.create_entry(request)
+
+    assert result.sync_status == SyncStatus.PENDING_SYNC
+    assert result.source_system == "ALS eLog"
+
+
+@pytest.mark.asyncio
+async def test_create_entry_sync_status_synced():
+    """Non-local adapter gets SYNCED when re-ingestion finds the entry."""
+    service, mock_adapter, mock_repository = _make_mock_service(
+        adapter_supports_write=True,
+        source_system="ALS eLog",
+    )
+
+    # Mock fetch_entries to return the newly created entry
+    fetched_entry = {
+        "entry_id": "test-entry-001",
+        "source_system": "ALS eLog",
+        "timestamp": None,
+        "author": "tester",
+        "raw_text": "Test entry\n\nTest details",
+        "attachments": [],
+        "metadata": {},
+        "created_at": None,
+        "updated_at": None,
+    }
+
+    async def fetch_with_entry(**kwargs):
+        yield fetched_entry
+
+    mock_adapter.fetch_entries = fetch_with_entry
+
+    request = FacilityEntryCreateRequest(subject="Test entry", details="Test details")
+
+    with patch(
+        "osprey.services.ariel_search.ingestion.get_adapter",
+        return_value=mock_adapter,
+    ):
+        result = await service.create_entry(request)
+
+    assert result.sync_status == SyncStatus.SYNCED
+
+    # Repository was called twice: once for optimistic, once for synced
+    assert mock_repository.upsert_entry.call_count == 2


### PR DESCRIPTION
## Summary

ARIEL facility adapters were read-only — they could ingest logbook entries but not create them. This PR makes adapters bidirectional so the agent can write entries back to the facility's logbook system.

- **Rename `BaseAdapter` → `FacilityAdapter`** with backwards-compatible alias; add `supports_write` property and `create_entry()` to the adapter interface
- **Implement write path for `GenericJSONAdapter`** — atomic local JSON file append (safe for single-writer scenarios)
- **Implement write path for `ALSLogbookAdapter`** — olog RPC XML POST with retry and error handling
- **Orchestrate write flow in `ARIELSearchService.create_entry()`** — writes to the facility logbook first (source of truth), then performs an optimistic local upsert with re-ingestion sync for non-local adapters
- **Add new models**: `FacilityEntryCreateRequest`, `FacilityEntryCreateResult`, `SyncStatus`, `WriteConfig`
- **Refactor API route** to delegate to service with fallback; add `sync_status` and `source_system` to `EntryCreateResponse`
- **Fix ruff formatting** on 3 files to pass CI lint checks

## Why this matters

Without write support, the control assistant agent can search and read logbook entries but cannot record new ones. This is a prerequisite for the agent to log operational notes, experiment summaries, and shift handoff entries back into the facility's electronic logbook — closing the read/write loop.

## Test plan
- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `uv run ruff format --check src/ tests/` — all files formatted
- [x] `uv run pytest tests/ --ignore=tests/e2e -m "not langgraph" -v` — 4009 passed, 0 failures
- [ ] CI pipeline passes on GitHub