### PR TITLE
fix: show plots/commands/notebooks in streamed OpenWebUI responses

### DIFF
--- a/src/osprey/templates/services/pipelines/main.py
+++ b/src/osprey/templates/services/pipelines/main.py
@@ -991,7 +991,22 @@ class Pipeline:
                                 yield response
                         else:
                             yield "✅ Execution completed"
-                    # else: response was already streamed, nothing more to do
+
+                    # When response was streamed, streaming only covers LLM
+                    # tokens — post-execution artifacts (figures, commands,
+                    # notebooks) must be extracted and appended separately.
+                    if self._last_response_was_streamed:
+                        figures_html = self._extract_figures_from_state(state.values)
+                        if figures_html:
+                            yield f"\n\n{figures_html}"
+
+                        commands_html = self._extract_commands_from_state(state.values)
+                        if commands_html:
+                            yield f"\n\n{commands_html}"
+
+                        notebooks_html = self._extract_notebooks_from_state(state.values)
+                        if notebooks_html:
+                            yield f"\n\n{notebooks_html}"
 
             finally:
                 try:


### PR DESCRIPTION
## Summary

- Fixes a regression where figures, commands, and notebooks generated by the Python executor were never displayed in OpenWebUI chat responses
- Adds explicit artifact extraction (`_extract_figures_from_state`, `_extract_commands_from_state`, `_extract_notebooks_from_state`) in the streaming code path of `_execute_pipeline`
- The non-streaming fallback path already handled this correctly via `_extract_response_from_state`; the streaming path simply never called the artifact extractors

Fixes #177

## What changed

**`src/osprey/templates/services/pipelines/main.py`** — After the streaming text is fully yielded, the new code checks the final graph state for artifacts and yields them as additional output. This mirrors what `_extract_response_from_state()` already does in the non-streaming fallback, but only runs when `_last_response_was_streamed` is `True` to avoid duplication.

## Test plan

- [x] `uv run pre-commit run --all-files` — all 12 hooks pass
- [ ] **Manual verification needed**: Deploy to OpenWebUI and ask an assistant with Python execution to generate a plot. Verify the plot image appears in the chat response after the streamed text.

@RemiLehe — since you reported this, could you verify the fix in your OpenWebUI setup? The key check is that plots now render inline in the chat after the LLM's streamed text response.