### PR TITLE
Feat/streaming config

### DIFF
--- a/src/osprey/interfaces/cli/direct_conversation.py
+++ b/src/osprey/interfaces/cli/direct_conversation.py
@@ -680,6 +680,12 @@ class CLI:
                 # Create typed event handler for resume execution
                 handler = CLIEventHandler(console=self.console, verbose=self.show_streaming_updates)
 
+                # Streaming display mode configuration
+                from osprey.utils.config import get_streaming_mode
+
+                respond_streaming = get_streaming_mode("cli", "respond")
+                codegen_streaming = get_streaming_mode("cli", "python_code_generator")
+
                 # Track if we've streamed LLM response tokens
                 streamed_response = False
                 # Track code generation streaming
@@ -734,29 +740,37 @@ class CLI:
 
                             # Route tokens by source node
                             if node_name == "python_code_generator":
-                                # Handle code generation streaming
-                                if not code_gen_active:
-                                    # Add role prefix (like respond does)
+                                if codegen_streaming == "disabled":
+                                    pass  # Skip code gen tokens entirely
+                                else:
+                                    # Handle code generation streaming (show mode)
+                                    if not code_gen_active:
+                                        # Add role prefix (like respond does)
+                                        self.console.print(
+                                            "\n[bold yellow]🤖 Assistant (Code Generator):[/bold yellow] ",
+                                            end="",
+                                        )
+                                        code_gen_active = True
+
+                                    # Stream token with dim color (shows it's thinking/intermediate)
                                     self.console.print(
-                                        "\n[bold yellow]🤖 Assistant (Code Generator):[/bold yellow] ",
-                                        end="",
+                                        f"[dim]{message_chunk.content}[/dim]", end=""
                                     )
-                                    code_gen_active = True
 
-                                # Stream token with dim color (shows it's thinking/intermediate)
-                                self.console.print(f"[dim]{message_chunk.content}[/dim]", end="")
-
-                                # Buffer for final panel (keep for potential future use)
-                                code_gen_buffer += message_chunk.content
+                                    # Buffer for final panel (keep for potential future use)
+                                    code_gen_buffer += message_chunk.content
                             else:
-                                # Handle response streaming (respond node)
-                                if not streamed_response:
-                                    self.console.print(
-                                        "\n[bold cyan]🤖 Assistant:[/bold cyan] ", end=""
-                                    )
-                                    handler.start_response_streaming()
-                                    streamed_response = True
-                                print(message_chunk.content, end="", flush=True)
+                                if respond_streaming == "disabled":
+                                    pass  # Skip — full response shown from state after completion
+                                else:
+                                    # Handle response streaming (respond node)
+                                    if not streamed_response:
+                                        self.console.print(
+                                            "\n[bold cyan]🤖 Assistant:[/bold cyan] ", end=""
+                                        )
+                                        handler.start_response_streaming()
+                                        streamed_response = True
+                                    print(message_chunk.content, end="", flush=True)
 
                             # Track current node for next iteration
                             previous_node = node_name
@@ -882,6 +896,12 @@ class CLI:
             original_level = root_logger.level
             root_logger.setLevel(logging.WARNING)
 
+            # Streaming display mode configuration
+            from osprey.utils.config import get_streaming_mode
+
+            respond_streaming = get_streaming_mode("cli", "respond")
+            codegen_streaming = get_streaming_mode("cli", "python_code_generator")
+
             # Track if we've streamed LLM response tokens
             streamed_response = False
             # Track code generation streaming
@@ -942,31 +962,39 @@ class CLI:
 
                             # Route tokens by source node
                             if node_name == "python_code_generator":
-                                # Handle code generation streaming
-                                if not code_gen_active:
-                                    # Add role prefix (like respond does)
+                                if codegen_streaming == "disabled":
+                                    pass  # Skip code gen tokens entirely
+                                else:
+                                    # Handle code generation streaming (show mode)
+                                    if not code_gen_active:
+                                        # Add role prefix (like respond does)
+                                        self.console.print(
+                                            "\n[bold yellow]🤖 Assistant (Code Generator):[/bold yellow] ",
+                                            end="",
+                                        )
+                                        code_gen_active = True
+
+                                    # Stream token with dim color (shows it's thinking/intermediate)
                                     self.console.print(
-                                        "\n[bold yellow]🤖 Assistant (Code Generator):[/bold yellow] ",
-                                        end="",
+                                        f"[dim]{message_chunk.content}[/dim]", end=""
                                     )
-                                    code_gen_active = True
 
-                                # Stream token with dim color (shows it's thinking/intermediate)
-                                self.console.print(f"[dim]{message_chunk.content}[/dim]", end="")
-
-                                # Buffer for final panel (keep for potential future use)
-                                code_gen_buffer += message_chunk.content
+                                    # Buffer for final panel (keep for potential future use)
+                                    code_gen_buffer += message_chunk.content
                             else:
-                                # Handle response streaming (respond node)
-                                if not streamed_response:
-                                    # Print header before first token
-                                    self.console.print(
-                                        "\n[bold cyan]🤖 Assistant:[/bold cyan] ", end=""
-                                    )
-                                    handler.start_response_streaming()
-                                    streamed_response = True
-                                # Print token directly to console (no newline, immediate flush)
-                                print(message_chunk.content, end="", flush=True)
+                                if respond_streaming == "disabled":
+                                    pass  # Skip — full response shown from state after completion
+                                else:
+                                    # Handle response streaming (respond node)
+                                    if not streamed_response:
+                                        # Print header before first token
+                                        self.console.print(
+                                            "\n[bold cyan]🤖 Assistant:[/bold cyan] ", end=""
+                                        )
+                                        handler.start_response_streaming()
+                                        streamed_response = True
+                                    # Print token directly to console (no newline, immediate flush)
+                                    print(message_chunk.content, end="", flush=True)
 
                             # Track current node for next iteration
                             previous_node = node_name

--- a/src/osprey/interfaces/tui/app.py
+++ b/src/osprey/interfaces/tui/app.py
@@ -806,6 +806,12 @@ class OspreyTUI(App):
             # Start event consumer before streaming
             consumer_task = asyncio.create_task(self._consume_events(user_input, chat_display))
 
+            # Streaming display mode configuration
+            from osprey.utils.config import get_streaming_mode
+
+            respond_streaming = get_streaming_mode("tui", "respond")
+            codegen_streaming = get_streaming_mode("tui", "python_code_generator")
+
             # Track if we've streamed LLM response tokens (to avoid duplicate display)
             streamed_response = False
             streamed_code = False  # Track code generation streaming
@@ -872,6 +878,9 @@ class OspreyTUI(App):
 
                             # Route based on source node
                             if node_name == "python_code_generator":
+                                if codegen_streaming == "disabled":
+                                    continue  # Skip code gen tokens entirely
+
                                 # CODE GENERATION STREAMING - Route to chat flow
                                 # Widget creation is now handled by CodeGenerationStartEvent
                                 # This section only appends tokens to the current widget
@@ -885,7 +894,10 @@ class OspreyTUI(App):
                                     python_block = chat_display.get_python_execution_block()
                                     if python_block:
                                         python_block.set_partial_output("Generating code...")
-                                    await chat_display.start_code_generation_message(attempt=1)
+                                    start_collapsed = codegen_streaming == "hide"
+                                    await chat_display.start_code_generation_message(
+                                        attempt=1, start_collapsed=start_collapsed
+                                    )
                                     streamed_code = True
                                     _previous_code_attempt = 1
 
@@ -894,6 +906,9 @@ class OspreyTUI(App):
                                     message_chunk.content
                                 )
                             else:
+                                if respond_streaming == "disabled":
+                                    continue  # Skip — full response shown from state
+
                                 # Response streaming (respond node or unknown source)
                                 # Start streaming message widget if not already started
                                 if not streamed_response:

--- a/src/osprey/interfaces/tui/event_handler.py
+++ b/src/osprey/interfaces/tui/event_handler.py
@@ -430,7 +430,14 @@ class TUIEventHandler:
             python_block.set_partial_output(status_text)
 
         # Create new collapsible code message
-        await self.display.start_code_generation_message(attempt=attempt)
+        # Read streaming config to determine if code should start collapsed
+        from osprey.utils.config import get_streaming_mode
+
+        codegen_mode = get_streaming_mode("tui", "python_code_generator")
+        start_collapsed = codegen_mode == "hide"
+        await self.display.start_code_generation_message(
+            attempt=attempt, start_collapsed=start_collapsed
+        )
 
     async def _handle_code_generated(self, code: str, attempt: int, success: bool) -> None:
         """Handle code generation completion - finalize widget.

--- a/src/osprey/interfaces/tui/event_handler.py
+++ b/src/osprey/interfaces/tui/event_handler.py
@@ -413,6 +413,13 @@ class TUIEventHandler:
             attempt: The attempt number (1-based)
             is_retry: Whether this is a retry attempt
         """
+        # Check streaming config — skip widget creation if disabled
+        from osprey.utils.config import get_streaming_mode
+
+        codegen_mode = get_streaming_mode("tui", "python_code_generator")
+        if codegen_mode == "disabled":
+            return
+
         # Finalize previous code generation widget if it exists
         if self.display._code_gen_message:
             full_code = await self.display.finalize_code_generation_message()
@@ -430,10 +437,6 @@ class TUIEventHandler:
             python_block.set_partial_output(status_text)
 
         # Create new collapsible code message
-        # Read streaming config to determine if code should start collapsed
-        from osprey.utils.config import get_streaming_mode
-
-        codegen_mode = get_streaming_mode("tui", "python_code_generator")
         start_collapsed = codegen_mode == "hide"
         await self.display.start_code_generation_message(
             attempt=attempt, start_collapsed=start_collapsed

--- a/src/osprey/interfaces/tui/widgets/chat_display.py
+++ b/src/osprey/interfaces/tui/widgets/chat_display.py
@@ -211,7 +211,9 @@ class ChatDisplay(ScrollableContainer):
 
     # --- Code Generation Streaming Methods ---
 
-    async def start_code_generation_message(self, attempt: int = 1) -> CollapsibleCodeMessage:
+    async def start_code_generation_message(
+        self, attempt: int = 1, start_collapsed: bool = False
+    ) -> CollapsibleCodeMessage:
         """Create and mount a new collapsible code message for streaming.
 
         Similar to start_streaming_message, but creates a CollapsibleCodeMessage
@@ -221,11 +223,14 @@ class ChatDisplay(ScrollableContainer):
 
         Args:
             attempt: The retry attempt number (1 for first, 2+ for retries).
+            start_collapsed: If True, start with content hidden (hide mode).
 
         Returns:
             The newly created CollapsibleCodeMessage widget.
         """
-        self._code_gen_message = CollapsibleCodeMessage(attempt=attempt)
+        self._code_gen_message = CollapsibleCodeMessage(
+            attempt=attempt, start_collapsed=start_collapsed
+        )
         await self.mount(self._code_gen_message)
         self.scroll_end(animate=False)
         return self._code_gen_message

--- a/src/osprey/interfaces/tui/widgets/messages.py
+++ b/src/osprey/interfaces/tui/widgets/messages.py
@@ -98,17 +98,21 @@ class CollapsibleCodeMessage(Static):
     the generated code anytime.
     """
 
-    def __init__(self, attempt: int = 1, **kwargs):
+    def __init__(self, attempt: int = 1, start_collapsed: bool = False, **kwargs):
         """Initialize a collapsible code message.
 
         Args:
             attempt: The retry attempt number (1 for first attempt, 2+ for retries).
+            start_collapsed: If True, start with content hidden (hide mode).
+                When False (default/show mode), content is visible during streaming
+                and auto-collapses after finalization.
 
         The message starts with content visible during streaming and
         transitions to collapsed state after finalization.
         """
         super().__init__(**kwargs)
         self._attempt = attempt
+        self._start_collapsed = start_collapsed
         self._content_buffer: list[str] = []
         self._markdown_stream: Any = None
         self._is_collapsed = False
@@ -135,6 +139,14 @@ class CollapsibleCodeMessage(Static):
         # Make toggle clickable
         toggle = self.query_one("#code-toggle", Static)
         toggle.can_focus = True
+
+        # Hide mode: start collapsed immediately
+        if self._start_collapsed:
+            content = self.query_one("#code-content", Markdown)
+            content.display = False
+            self._is_collapsed = True
+            label = f"code #{self._attempt}" if self._attempt > 1 else "code"
+            toggle.update(f"{label} (click to show)")
 
     def get_markdown_widget(self) -> Markdown:
         """Get the Markdown widget for streaming.

--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -337,6 +337,44 @@ cli:
   # banner: |
   #   Your custom ASCII art here
 
+  # Streaming display configuration
+  # Controls how LLM streaming output is displayed per node
+  # Options: show | disabled  (CLI has no collapse, so "hide" maps to "disabled")
+  # streaming:
+  #   respond: show                   # Final response (show | disabled)
+  #   python_code_generator: disabled # Code generation (show | disabled)
+
+# ============================================================
+# TUI CONFIGURATION
+# ============================================================
+# Customize the terminal UI (Textual) appearance and behavior
+
+tui:
+  # Streaming display configuration
+  # Controls how LLM streaming output is displayed per node
+  # Options: show | hide | disabled
+  #   show     - expanded during streaming, auto-collapses after completion
+  #   hide     - collapsed from the start, user can expand to watch live
+  #   disabled - not displayed at all
+  streaming:
+    respond: show                   # Final response (show | disabled; hide not allowed)
+    python_code_generator: hide     # Code generation collapsed by default
+
+# ============================================================
+# OPEN WEBUI CONFIGURATION
+# ============================================================
+# Customize the Open WebUI pipeline behavior
+
+openwebui:
+  # Streaming display configuration
+  # Controls how LLM streaming output is displayed per node
+  # Options: show | hide | disabled
+  #   show     - tokens stream live, code block visible
+  #   hide     - collapsed <details> block, user can expand to watch live
+  #   disabled - not displayed at all
+  streaming:
+    respond: show                   # Final response (show | disabled; hide not allowed)
+    python_code_generator: hide     # Code generation collapsed by default
 
 # Note: Theme system logging uses the existing 'base' logger color
 # No additional logging configuration needed

--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -370,7 +370,7 @@ openwebui:
   # Controls how LLM streaming output is displayed per node
   # Options: show | hide | disabled
   #   show     - tokens stream live, code block visible
-  #   hide     - collapsed <details> block, user can expand to watch live
+  #   hide     - buffered during streaming, collapsed <details> block after completion
   #   disabled - not displayed at all
   streaming:
     respond: show                   # Final response (show | disabled; hide not allowed)

--- a/src/osprey/templates/services/pipelines/main.py
+++ b/src/osprey/templates/services/pipelines/main.py
@@ -1048,6 +1048,7 @@ class Pipeline:
         accumulated_response = [""]  # Use list for closure access
         code_streaming_active = [False]  # Track if code fence is open
         code_start_buffer = [""]  # Buffer initial tokens for fence detection
+        code_hide_buffer = [[]]  # Buffer code tokens for hide mode (emitted as complete block)
         previous_code_attempt = [0]  # Track which attempt is being streamed
         current_generation_attempt = [1]  # Track retry attempts
         response_was_streamed = [False]  # Track if any response tokens arrived
@@ -1109,7 +1110,19 @@ class Pipeline:
                                         code_streaming_active[0] = False
                                         code_start_buffer[0] = ""
                                         if codegen_streaming == "hide":
-                                            stream_queue.put(("response_token", "\n```\n</details>\n\n"))
+                                            # Emit buffered code as complete <details> block
+                                            buffered_code = "".join(code_hide_buffer[0])
+                                            if buffered_code:
+                                                line_count = len(buffered_code.strip().split("\n"))
+                                                details_block = (
+                                                    "<details>\n"
+                                                    f"<summary>Generated Code ({line_count} lines)</summary>\n\n"
+                                                    f"```python\n{buffered_code}\n```\n"
+                                                    "</details>\n\n"
+                                                )
+                                                stream_queue.put(("response_token", details_block))
+                                                response_was_streamed[0] = True
+                                            code_hide_buffer[0] = []
                                         elif codegen_streaming == "show":
                                             stream_queue.put(("response_token", "\n```\n\n"))
                                         # disabled: nothing to close
@@ -1161,7 +1174,19 @@ class Pipeline:
                                     ):
                                         code_streaming_active[0] = False
                                         if codegen_streaming == "hide":
-                                            stream_queue.put(("response_token", "\n```\n</details>\n\n"))
+                                            # Emit buffered code as complete <details> block
+                                            buffered_code = "".join(code_hide_buffer[0])
+                                            if buffered_code:
+                                                line_count = len(buffered_code.strip().split("\n"))
+                                                details_block = (
+                                                    "<details>\n"
+                                                    f"<summary>Generated Code ({line_count} lines)</summary>\n\n"
+                                                    f"```python\n{buffered_code}\n```\n"
+                                                    "</details>\n\n"
+                                                )
+                                                stream_queue.put(("response_token", details_block))
+                                                response_was_streamed[0] = True
+                                            code_hide_buffer[0] = []
                                         else:  # show (disabled never opens a fence)
                                             stream_queue.put(("response_token", "\n```\n\n"))
 
@@ -1203,17 +1228,13 @@ class Pipeline:
 
                                             # Prefix depends on streaming mode
                                             if codegen_streaming == "hide":
-                                                # Wrap in <details> — collapsed by default
-                                                content = (
-                                                    "<details>\n"
-                                                    "<summary>Generated Code</summary>\n\n"
-                                                    f"```python\n{stripped}"
-                                                )
+                                                # Buffer tokens — emit as complete block later
+                                                if stripped:
+                                                    code_hide_buffer[0].append(stripped)
                                             else:  # show
                                                 content = f"```python\n{stripped}"
-
-                                            response_was_streamed[0] = True
-                                            stream_queue.put(("response_token", content))
+                                                response_was_streamed[0] = True
+                                                stream_queue.put(("response_token", content))
                                             continue
 
                                         # After buffer phase: strip mid-stream fence artifacts
@@ -1227,8 +1248,12 @@ class Pipeline:
                                         )
 
                                         if content:
-                                            response_was_streamed[0] = True
-                                            stream_queue.put(("response_token", content))
+                                            if codegen_streaming == "hide":
+                                                # Buffer tokens — emit as complete block later
+                                                code_hide_buffer[0].append(content)
+                                            else:  # show
+                                                response_was_streamed[0] = True
+                                                stream_queue.put(("response_token", content))
 
                                     # Response tokens from respond node
                                     elif node_name == "respond":
@@ -1252,7 +1277,19 @@ class Pipeline:
                     if code_streaming_active[0]:
                         code_streaming_active[0] = False
                         if codegen_streaming == "hide":
-                            stream_queue.put(("response_token", "\n```\n</details>\n"))
+                            # Emit buffered code as complete <details> block
+                            buffered_code = "".join(code_hide_buffer[0])
+                            if buffered_code:
+                                line_count = len(buffered_code.strip().split("\n"))
+                                details_block = (
+                                    "<details>\n"
+                                    f"<summary>Generated Code ({line_count} lines)</summary>\n\n"
+                                    f"```python\n{buffered_code}\n```\n"
+                                    "</details>\n\n"
+                                )
+                                stream_queue.put(("response_token", details_block))
+                                response_was_streamed[0] = True
+                            code_hide_buffer[0] = []
                         else:  # show
                             stream_queue.put(("response_token", "\n```\n"))
 

--- a/src/osprey/templates/services/pipelines/main.py
+++ b/src/osprey/templates/services/pipelines/main.py
@@ -1052,6 +1052,12 @@ class Pipeline:
         current_generation_attempt = [1]  # Track retry attempts
         response_was_streamed = [False]  # Track if any response tokens arrived
 
+        # Streaming display mode configuration
+        from osprey.utils.config import get_streaming_mode
+
+        respond_streaming = get_streaming_mode("openwebui", "respond")
+        codegen_streaming = get_streaming_mode("openwebui", "python_code_generator")
+
         # Initialize instance variables for metadata
         self._last_response_was_streamed = False
         self._last_accumulated_response = ""
@@ -1102,7 +1108,11 @@ class Pipeline:
                                     if code_streaming_active[0]:
                                         code_streaming_active[0] = False
                                         code_start_buffer[0] = ""
-                                        stream_queue.put(("response_token", "\n```\n\n"))
+                                        if codegen_streaming == "hide":
+                                            stream_queue.put(("response_token", "\n```\n</details>\n\n"))
+                                        elif codegen_streaming == "show":
+                                            stream_queue.put(("response_token", "\n```\n\n"))
+                                        # disabled: nothing to close
                                     current_generation_attempt[0] = event.attempt
 
                                 # Filter for displayable events
@@ -1150,10 +1160,17 @@ class Pipeline:
                                         and node_name != "python_code_generator"
                                     ):
                                         code_streaming_active[0] = False
-                                        stream_queue.put(("response_token", "\n```\n\n"))
+                                        if codegen_streaming == "hide":
+                                            stream_queue.put(("response_token", "\n```\n</details>\n\n"))
+                                        else:  # show (disabled never opens a fence)
+                                            stream_queue.put(("response_token", "\n```\n\n"))
 
                                     # Code generation tokens
                                     if node_name == "python_code_generator":
+                                        # Skip entirely if code streaming is disabled
+                                        if codegen_streaming == "disabled":
+                                            continue
+
                                         content = message_chunk.content
 
                                         # Buffer initial tokens to detect and strip LLM-added fence prefix
@@ -1183,7 +1200,17 @@ class Pipeline:
                                             code_streaming_active[0] = True
                                             previous_code_attempt[0] = current_generation_attempt[0]
                                             code_start_buffer[0] = ""
-                                            content = f"```python\n{stripped}"
+
+                                            # Prefix depends on streaming mode
+                                            if codegen_streaming == "hide":
+                                                # Wrap in <details> — collapsed by default
+                                                content = (
+                                                    "<details>\n"
+                                                    "<summary>Generated Code</summary>\n\n"
+                                                    f"```python\n{stripped}"
+                                                )
+                                            else:  # show
+                                                content = f"```python\n{stripped}"
 
                                             response_was_streamed[0] = True
                                             stream_queue.put(("response_token", content))
@@ -1205,6 +1232,11 @@ class Pipeline:
 
                                     # Response tokens from respond node
                                     elif node_name == "respond":
+                                        if respond_streaming == "disabled":
+                                            # Don't stream — fallback path will yield
+                                            # the full response from state after completion
+                                            continue
+
                                         # Stream response token directly (no manual fence markers)
                                         # Open WebUI handles markdown rendering automatically
                                         response_was_streamed[0] = True
@@ -1219,7 +1251,10 @@ class Pipeline:
                     # Close any trailing code fence
                     if code_streaming_active[0]:
                         code_streaming_active[0] = False
-                        stream_queue.put(("response_token", "\n```\n"))
+                        if codegen_streaming == "hide":
+                            stream_queue.put(("response_token", "\n```\n</details>\n"))
+                        else:  # show
+                            stream_queue.put(("response_token", "\n```\n"))
 
                     # Signal completion (both natural and cancelled paths)
                     stream_queue.put(("done", (response_was_streamed[0], accumulated_response[0])))

--- a/src/osprey/utils/config.py
+++ b/src/osprey/utils/config.py
@@ -856,6 +856,43 @@ def get_interface_context() -> str:
     return configurable.get("interface_context", "unknown")
 
 
+def get_streaming_mode(interface: str, node: str) -> str:
+    """Resolve streaming display mode for a given interface and node.
+
+    Determines how streaming output (LLM tokens) should be displayed in a
+    given UI for a specific graph node. The resolution order is:
+
+    1. ``{interface}.streaming.{node}`` — node-specific override
+    2. ``{interface}.streaming.default`` — interface-level default
+    3. Hardcoded defaults: ``respond`` → ``"show"``, everything else → ``"hide"``
+
+    Args:
+        interface: Interface identifier (``"cli"``, ``"tui"``, ``"openwebui"``)
+        node: Node name (``"respond"``, ``"python_code_generator"``, etc.)
+
+    Returns:
+        One of ``"show"``, ``"hide"``, or ``"disabled"``
+    """
+    # 1. Node-specific config
+    mode = get_config_value(f"{interface}.streaming.{node}")
+    if mode is None:
+        # 2. Interface default
+        mode = get_config_value(f"{interface}.streaming.default")
+    if mode is None:
+        # 3. Hardcoded defaults
+        mode = "show" if node == "respond" else "hide"
+
+    # Validate: respond node can't be "hide" (user must see the response)
+    if node == "respond" and mode == "hide":
+        mode = "show"
+
+    # CLI has no collapse mechanism — treat hide as disabled
+    if interface == "cli" and mode == "hide":
+        mode = "disabled"
+
+    return mode
+
+
 def get_current_application() -> str | None:
     """Get current application with automatic context detection."""
     configurable = _get_configurable()

--- a/tests/test_streaming_config.py
+++ b/tests/test_streaming_config.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import patch
 
-import pytest
-
 
 class TestGetStreamingMode:
     """Tests for get_streaming_mode() resolution logic."""

--- a/tests/test_streaming_config.py
+++ b/tests/test_streaming_config.py
@@ -1,0 +1,107 @@
+"""Tests for streaming display mode configuration."""
+
+from unittest.mock import patch
+
+import pytest
+
+
+class TestGetStreamingMode:
+    """Tests for get_streaming_mode() resolution logic."""
+
+    def _call(self, interface: str, node: str, config_overrides: dict | None = None):
+        """Helper to call get_streaming_mode with optional config overrides."""
+        config_overrides = config_overrides or {}
+
+        def mock_get_config_value(path, default=None, config_path=None):
+            return config_overrides.get(path)
+
+        with patch("osprey.utils.config.get_config_value", side_effect=mock_get_config_value):
+            from osprey.utils.config import get_streaming_mode
+
+            return get_streaming_mode(interface, node)
+
+    # --- Default resolution (no config set) ---
+
+    def test_respond_defaults_to_show(self):
+        assert self._call("openwebui", "respond") == "show"
+
+    def test_respond_defaults_to_show_for_cli(self):
+        assert self._call("cli", "respond") == "show"
+
+    def test_respond_defaults_to_show_for_tui(self):
+        assert self._call("tui", "respond") == "show"
+
+    def test_non_respond_defaults_to_hide(self):
+        assert self._call("openwebui", "python_code_generator") == "hide"
+
+    def test_non_respond_defaults_to_hide_for_tui(self):
+        assert self._call("tui", "python_code_generator") == "hide"
+
+    def test_cli_non_respond_defaults_to_disabled(self):
+        """CLI has no collapse mechanism, so hide maps to disabled."""
+        assert self._call("cli", "python_code_generator") == "disabled"
+
+    def test_unknown_node_defaults_to_hide(self):
+        assert self._call("openwebui", "some_future_node") == "hide"
+
+    # --- Node-specific config overrides ---
+
+    def test_node_specific_override(self):
+        config = {"openwebui.streaming.python_code_generator": "show"}
+        assert self._call("openwebui", "python_code_generator", config) == "show"
+
+    def test_node_specific_disabled(self):
+        config = {"openwebui.streaming.python_code_generator": "disabled"}
+        assert self._call("openwebui", "python_code_generator", config) == "disabled"
+
+    def test_respond_disabled(self):
+        config = {"tui.streaming.respond": "disabled"}
+        assert self._call("tui", "respond", config) == "disabled"
+
+    # --- Interface default override ---
+
+    def test_interface_default_overrides_hardcoded(self):
+        config = {"openwebui.streaming.default": "disabled"}
+        assert self._call("openwebui", "python_code_generator", config) == "disabled"
+
+    def test_node_specific_overrides_interface_default(self):
+        config = {
+            "openwebui.streaming.default": "disabled",
+            "openwebui.streaming.python_code_generator": "show",
+        }
+        assert self._call("openwebui", "python_code_generator", config) == "show"
+
+    def test_interface_default_does_not_affect_respond_hardcoded(self):
+        """Interface default shouldn't apply to respond — respond has its own hardcoded default."""
+        # When interface default is "disabled" but no node-specific config for respond,
+        # the interface default takes effect (it IS a valid respond mode)
+        config = {"openwebui.streaming.default": "disabled"}
+        assert self._call("openwebui", "respond", config) == "disabled"
+
+    # --- Validation: respond can't be "hide" ---
+
+    def test_respond_hide_corrected_to_show(self):
+        config = {"openwebui.streaming.respond": "hide"}
+        assert self._call("openwebui", "respond", config) == "show"
+
+    def test_respond_hide_corrected_for_tui(self):
+        config = {"tui.streaming.respond": "hide"}
+        assert self._call("tui", "respond", config) == "show"
+
+    def test_respond_hide_corrected_for_cli(self):
+        config = {"cli.streaming.respond": "hide"}
+        assert self._call("cli", "respond", config) == "show"
+
+    # --- CLI hide → disabled coercion ---
+
+    def test_cli_hide_becomes_disabled(self):
+        config = {"cli.streaming.python_code_generator": "hide"}
+        assert self._call("cli", "python_code_generator", config) == "disabled"
+
+    def test_cli_show_stays_show(self):
+        config = {"cli.streaming.python_code_generator": "show"}
+        assert self._call("cli", "python_code_generator", config) == "show"
+
+    def test_cli_disabled_stays_disabled(self):
+        config = {"cli.streaming.python_code_generator": "disabled"}
+        assert self._call("cli", "python_code_generator", config) == "disabled"


### PR DESCRIPTION
This PR adds support to configure streaming behavior on Osprey UIs through `config.yml`:

```yml
cli:
  # Streaming display configuration
  # Controls how LLM streaming output is displayed per node
  # Options: show | disabled  (CLI has no collapse, so "hide" maps to "disabled")
  streaming:
    respond: show                   # Final response (show | disabled)
    python_code_generator: disabled # Code generation (show | disabled)

tui:
  # Streaming display configuration
  # Controls how LLM streaming output is displayed per node
  # Options: show | hide | disabled
  #   show     - expanded during streaming, auto-collapses after completion
  #   hide     - collapsed from the start, user can expand to watch live
  #   disabled - not displayed at all
  streaming:
    respond: show                   # Final response (show | disabled; hide not allowed)
    python_code_generator: hide     # Code generation collapsed by default

openwebui:
  # Streaming display configuration
  # Controls how LLM streaming output is displayed per node
  # Options: show | hide | disabled
  #   show     - tokens stream live, code block visible
  #   hide     - buffered during streaming, collapsed <details> block after completion
  #   disabled - not displayed at all
  streaming:
    respond: show                   # Final response (show | disabled; hide not allowed)
    python_code_generator: hide     # Code generation collapsed by default
```

The above config shows the default behavior for CLI, TUI, and Open WebUI -- for respond the streaming is enabled, and for python code generator the streaming is hidden or disabled to not disturb users.

You don't have to change anything in the current `config.yml` of your agent to get the default behavior, but if you'd like to, say, completely disable the python code generator streaming (no code would show at all) in Open WebUI, you can put this snippet in your `config.yml`:

```yml
openwebui:
  streaming:
    python_code_generator: disabled
```