### PR TITLE
Fix ARIEL enhancement pipeline & semantic search (#193)

### DIFF
--- a/src/osprey/cli/ariel.py
+++ b/src/osprey/cli/ariel.py
@@ -463,7 +463,19 @@ def enhance_command(module: str | None, force: bool, limit: int) -> None:
             enhancers = [e for e in enhancers if e.name == module]
 
         if not enhancers:
-            click.echo("No enhancement modules enabled or selected")
+            if module:
+                click.echo(
+                    f"Enhancement module '{module}' is not enabled. "
+                    f"Enable it in config.yml under ariel.enhancement_modules.{module}.enabled",
+                    err=True,
+                )
+            else:
+                click.echo(
+                    "No enhancement modules enabled. "
+                    "Enable modules in config.yml under ariel.enhancement_modules "
+                    "(e.g., text_embedding.enabled: true)",
+                    err=True,
+                )
             return
 
         click.echo(f"Enhancement modules: {[e.name for e in enhancers]}")

--- a/src/osprey/services/ariel_search/enhancement/factory.py
+++ b/src/osprey/services/ariel_search/enhancement/factory.py
@@ -3,11 +3,31 @@
 This module provides factory functions for creating enhancement modules.
 """
 
+import importlib
+import logging
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from osprey.services.ariel_search.config import ARIELConfig
     from osprey.services.ariel_search.enhancement.base import BaseEnhancementModule
+
+logger = logging.getLogger(__name__)
+
+
+def _get_ordered_registrations() -> list:
+    """Get enhancement module registrations sorted by execution_order.
+
+    Reads directly from ``registry.config.ariel_enhancement_modules``,
+    which is populated at ``RegistryManager`` construction time and does
+    NOT require ``initialize()`` to have been called.
+    """
+    from osprey.registry import get_registry
+
+    registry = get_registry()
+    registrations = list(registry.config.ariel_enhancement_modules)
+    registrations.sort(key=lambda r: r.execution_order)
+    return registrations
 
 
 def create_enhancers_from_config(
@@ -15,8 +35,8 @@ def create_enhancers_from_config(
 ) -> list["BaseEnhancementModule"]:
     """Create enhancement module instances for enabled modules in execution order.
 
-    Uses the central Osprey registry for module discovery with explicit
-    execution ordering.
+    Uses ``registry.config.ariel_enhancement_modules`` for module discovery,
+    which is available without calling ``registry.initialize()``.
 
     Args:
         config: ARIEL configuration with enhancement_modules settings
@@ -24,21 +44,21 @@ def create_enhancers_from_config(
     Returns:
         List of configured enhancement module instances, in execution order
     """
-    from osprey.registry import get_registry
-
-    registry = get_registry()
-    ordered_names = registry.list_ariel_enhancement_modules()
     enhancers: list[BaseEnhancementModule] = []
-    for name in ordered_names:
-        if not config.is_enhancement_module_enabled(name):
+    for reg in _get_ordered_registrations():
+        if not config.is_enhancement_module_enabled(reg.name):
             continue
-        result = registry.get_ariel_enhancement_module(name)
-        if result is None:
+        try:
+            module = importlib.import_module(reg.module_path)
+            cls = getattr(module, reg.class_name)
+        except (ImportError, AttributeError) as e:
+            logger.warning(
+                f"Skipping enhancement module '{reg.name}' (import failed): {e}"
+            )
             continue
-        cls, _reg = result
         enhancer = cls()
         if hasattr(enhancer, "configure"):
-            module_config = config.get_enhancement_module_config(name)
+            module_config = config.get_enhancement_module_config(reg.name)
             if module_config:
                 enhancer.configure(module_config)
         enhancers.append(enhancer)
@@ -51,7 +71,4 @@ def get_enhancer_names() -> list[str]:
     Returns:
         List of enhancer names in execution order
     """
-    from osprey.registry import get_registry
-
-    registry = get_registry()
-    return registry.list_ariel_enhancement_modules()
+    return [reg.name for reg in _get_ordered_registrations()]

--- a/tests/e2e/test_ariel_e2e_pipeline.py
+++ b/tests/e2e/test_ariel_e2e_pipeline.py
@@ -21,9 +21,12 @@ Requirements:
 
 from __future__ import annotations
 
+import asyncio
 import atexit
+import functools
 import logging
 import os
+import warnings
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -37,6 +40,81 @@ if TYPE_CHECKING:
 pytestmark = [pytest.mark.e2e, pytest.mark.slow, pytest.mark.asyncio]
 
 logger = logging.getLogger(__name__)
+
+# Rate limit indicators shared across quota-error handling
+_QUOTA_INDICATORS = [
+    "quota",
+    "rate limit",
+    "rate_limit",
+    "ratelimit",
+    "too many requests",
+    "429",
+    "resource_exhausted",
+    "resourceexhausted",
+]
+
+
+def _is_quota_error(text: str) -> bool:
+    """Check if text contains API quota/rate limit indicators."""
+    text_lower = text.lower()
+    return any(indicator in text_lower for indicator in _QUOTA_INDICATORS)
+
+
+def handle_quota_errors(func):
+    """Decorator to convert API quota/rate limit errors to pytest skips.
+
+    Handles both sync and async functions. Prevents transient rate limiting
+    from failing the test suite while still reporting for visibility.
+    """
+    if asyncio.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        async def async_wrapper(*args, **kwargs):
+            try:
+                return await func(*args, **kwargs)
+            except Exception as e:
+                if _is_quota_error(str(e)):
+                    warnings.warn(
+                        f"API quota/rate limit hit (test skipped): {e}",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                    pytest.skip(f"API quota/rate limit: {type(e).__name__}")
+                raise
+
+        return async_wrapper
+    else:
+
+        @functools.wraps(func)
+        def sync_wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except Exception as e:
+                if _is_quota_error(str(e)):
+                    warnings.warn(
+                        f"API quota/rate limit hit (test skipped): {e}",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                    pytest.skip(f"API quota/rate limit: {type(e).__name__}")
+                raise
+
+        return sync_wrapper
+
+
+def skip_if_rate_limited_response(response_text: str) -> None:
+    """Skip the test if an agent response contains a rate limit error.
+
+    The ReAct agent and full pipeline catch LLM errors internally and
+    surface them in the response text rather than raising exceptions.
+    """
+    if _is_quota_error(response_text):
+        warnings.warn(
+            f"API quota/rate limit in agent response (test skipped): {response_text[:200]}",
+            UserWarning,
+            stacklevel=2,
+        )
+        pytest.skip("API quota/rate limit detected in agent response")
 
 # Dev database URLs - try port 5432 (ariel-postgres), then 5433 (ariel-dev-db)
 DEV_DATABASE_URL_5432 = "postgresql://ariel:ariel@localhost:5432/ariel_pipeline_test"
@@ -446,6 +524,7 @@ class TestAgentExecutorE2E:
     Requires CBORG_API_KEY for LLM calls.
     """
 
+    @handle_quota_errors
     async def test_agent_finds_safety_procedures(
         self, e2e_ariel_seeded_db, e2e_agent_config_env, llm_judge
     ):
@@ -467,6 +546,7 @@ class TestAgentExecutorE2E:
 
         query = "What safety procedures were followed for the power supply work in Sector 8?"
         result = await service.search(query, mode=SearchMode.AGENT)
+        skip_if_rate_limited_response(result.answer or "")
 
         # --- Deterministic assertions ---
 
@@ -496,6 +576,7 @@ class TestAgentExecutorE2E:
             f"LLM judge failed (confidence={evaluation.confidence}):\n{evaluation.reasoning}"
         )
 
+    @handle_quota_errors
     async def test_agent_handles_irrelevant_query(self, e2e_ariel_seeded_db, e2e_agent_config_env):
         """Agent handles queries with no relevant logbook entries gracefully."""
         from osprey.services.ariel_search.models import SearchMode
@@ -512,6 +593,7 @@ class TestAgentExecutorE2E:
             "What is the recipe for chocolate cake?",
             mode=SearchMode.AGENT,
         )
+        skip_if_rate_limited_response(result.answer or "")
 
         # Agent should still produce an answer (not crash)
         assert result.answer is not None, (
@@ -567,6 +649,7 @@ class TestAgentLogbookPipeline:
     5. Verifies the response with deterministic assertions + LLM judge
     """
 
+    @handle_quota_errors
     async def test_agent_routes_logbook_query(
         self, e2e_ariel_seeded_db, e2e_project_factory, llm_judge
     ):
@@ -607,6 +690,13 @@ class TestAgentLogbookPipeline:
         result = await project.query(
             "Search the logbook for any RF cavity trips or issues that were reported"
         )
+
+        # --- Rate limit check (before assertions) ---
+        # The full pipeline catches LLM errors and surfaces them in the
+        # response or error field rather than raising exceptions.
+        if result.error and _is_quota_error(result.error):
+            pytest.skip(f"API quota/rate limit in pipeline: {result.error[:200]}")
+        skip_if_rate_limited_response(result.response)
 
         # --- Deterministic assertions ---
 
@@ -732,6 +822,7 @@ class TestCustomModuleIntegration:
     correct results against real data.
     """
 
+    @handle_quota_errors
     async def test_agent_uses_custom_search_module(
         self, e2e_ariel_watermarked_db, e2e_agent_config_env
     ):
@@ -810,6 +901,7 @@ class TestCustomModuleIntegration:
         )
 
         # --- 5. Assertions ---
+        skip_if_rate_limited_response(result.answer or "")
         assert result.answer is not None, "Agent did not produce an answer"
         assert len(result.answer) > 50, f"Answer too short: {result.answer}"
 

--- a/tests/e2e/test_ariel_search.py
+++ b/tests/e2e/test_ariel_search.py
@@ -12,9 +12,12 @@ With verbose LLM judge output:
 
 from __future__ import annotations
 
+import asyncio
 import atexit
+import functools
 import logging
 import os
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -26,6 +29,66 @@ if TYPE_CHECKING:
 pytestmark = [pytest.mark.e2e, pytest.mark.slow, pytest.mark.asyncio]
 
 logger = logging.getLogger(__name__)
+
+# Rate limit indicators shared across quota-error handling
+_QUOTA_INDICATORS = [
+    "quota",
+    "rate limit",
+    "rate_limit",
+    "ratelimit",
+    "too many requests",
+    "429",
+    "resource_exhausted",
+    "resourceexhausted",
+]
+
+
+def _is_quota_error(text: str) -> bool:
+    """Check if text contains API quota/rate limit indicators."""
+    text_lower = text.lower()
+    return any(indicator in text_lower for indicator in _QUOTA_INDICATORS)
+
+
+def handle_quota_errors(func):
+    """Decorator to convert API quota/rate limit errors to pytest skips.
+
+    Handles both sync and async functions. Prevents transient rate limiting
+    from failing the test suite while still reporting for visibility.
+    """
+    if asyncio.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        async def async_wrapper(*args, **kwargs):
+            try:
+                return await func(*args, **kwargs)
+            except Exception as e:
+                if _is_quota_error(str(e)):
+                    warnings.warn(
+                        f"API quota/rate limit hit (test skipped): {e}",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                    pytest.skip(f"API quota/rate limit: {type(e).__name__}")
+                raise
+
+        return async_wrapper
+    else:
+
+        @functools.wraps(func)
+        def sync_wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except Exception as e:
+                if _is_quota_error(str(e)):
+                    warnings.warn(
+                        f"API quota/rate limit hit (test skipped): {e}",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                    pytest.skip(f"API quota/rate limit: {type(e).__name__}")
+                raise
+
+        return sync_wrapper
 
 # Path to synthetic test data
 TEST_DATA_PATH = Path(__file__).parent.parent / "fixtures" / "ariel" / "test_logbook_entries.jsonl"
@@ -496,6 +559,7 @@ class TestRAGSearchE2E:
     Requires CBORG_API_KEY environment variable for LLM calls.
     """
 
+    @handle_quota_errors
     async def test_factual_qa(self, seeded_ariel_db, rag_config_env):
         """RAG answers 'What caused the RF trip in sector 3?' using E001."""
         from osprey.models.embeddings.ollama import OllamaEmbeddingProvider
@@ -525,6 +589,7 @@ class TestRAGSearchE2E:
             f"Answer should mention RF trip details. Answer: {result.answer[:300]}"
         )
 
+    @handle_quota_errors
     async def test_multi_entry_synthesis(self, seeded_ariel_db, rag_config_env):
         """RAG synthesizes answer from multiple incident entries."""
         from osprey.models.embeddings.ollama import OllamaEmbeddingProvider
@@ -559,6 +624,7 @@ class TestRAGSearchE2E:
             f"Answer should mention multiple issues. Answer: {result.answer[:300]}"
         )
 
+    @handle_quota_errors
     async def test_no_answer_for_unrelated_query(self, seeded_ariel_db, rag_config_env):
         """RAG gracefully handles queries with no relevant entries."""
         from osprey.models.embeddings.ollama import OllamaEmbeddingProvider

--- a/tests/services/ariel_search/conftest.py
+++ b/tests/services/ariel_search/conftest.py
@@ -82,6 +82,9 @@ def _build_ariel_mock_registry():
     ]
     registry.get_ariel_enhancement_module.side_effect = _enhancement_modules.get
 
+    # Provide config.ariel_enhancement_modules for the factory (sorted by execution_order)
+    registry.config.ariel_enhancement_modules = [sp_reg, te_reg]
+
     # --- Pipelines ---
     from osprey.services.ariel_search.pipelines import get_pipeline_descriptor
 

--- a/tests/services/ariel_search/test_enhancement_factory_real_registry.py
+++ b/tests/services/ariel_search/test_enhancement_factory_real_registry.py
@@ -1,0 +1,126 @@
+"""Regression tests for enhancement factory with real (non-mock) registry.
+
+These tests verify that the enhancement factory works with a real
+RegistryManager that has NOT been initialized — reproducing the bug
+where `osprey ariel enhance` fails because `initialize_registry()` was
+never called by the CLI commands.
+
+Unlike test_enhancement.py, these tests do NOT use the autouse
+`_mock_ariel_registry` fixture from conftest.py.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from osprey.registry.manager import RegistryManager
+from osprey.services.ariel_search.config import ARIELConfig
+from osprey.services.ariel_search.enhancement.factory import (
+    create_enhancers_from_config,
+    get_enhancer_names,
+)
+
+
+@pytest.fixture
+def real_registry():
+    """Create a real RegistryManager (framework-only, NOT initialized).
+
+    This reproduces the state the registry is in when CLI commands like
+    `osprey ariel enhance` run — constructed but never initialized.
+    """
+    registry = RegistryManager(registry_path=None)
+    # Patch get_registry globally so the factory uses our real instance
+    with patch("osprey.registry.get_registry", return_value=registry):
+        yield registry
+
+
+@pytest.fixture
+def ariel_config_with_text_embedding():
+    """ARIELConfig with text_embedding enabled."""
+    return ARIELConfig.from_dict(
+        {
+            "database": {"uri": "postgresql://localhost:5432/test"},
+            "enhancement_modules": {
+                "text_embedding": {
+                    "enabled": True,
+                    "models": [{"name": "nomic-embed-text", "dimension": 768}],
+                },
+            },
+        }
+    )
+
+
+@pytest.fixture
+def ariel_config_with_both():
+    """ARIELConfig with both enhancement modules enabled."""
+    return ARIELConfig.from_dict(
+        {
+            "database": {"uri": "postgresql://localhost:5432/test"},
+            "enhancement_modules": {
+                "semantic_processor": {"enabled": True},
+                "text_embedding": {
+                    "enabled": True,
+                    "models": [{"name": "nomic-embed-text", "dimension": 768}],
+                },
+            },
+        }
+    )
+
+
+class TestFactoryWithRealRegistry:
+    """Tests that the factory works without registry.initialize()."""
+
+    def test_create_enhancers_uses_real_registry(
+        self, real_registry, ariel_config_with_text_embedding
+    ):
+        """Factory creates enhancers from un-initialized registry.
+
+        This was the bug: create_enhancers_from_config used
+        registry.list_ariel_enhancement_modules() which needs initialize(),
+        but the CLI never calls initialize().
+        """
+        enhancers = create_enhancers_from_config(ariel_config_with_text_embedding)
+        assert len(enhancers) == 1
+        assert enhancers[0].name == "text_embedding"
+
+    def test_create_enhancers_respects_execution_order(
+        self, real_registry, ariel_config_with_both
+    ):
+        """Factory returns enhancers in execution_order (semantic_processor=10 before text_embedding=20)."""
+        enhancers = create_enhancers_from_config(ariel_config_with_both)
+        assert len(enhancers) == 2
+        assert enhancers[0].name == "semantic_processor"
+        assert enhancers[1].name == "text_embedding"
+
+    def test_get_enhancer_names_uses_real_registry(self, real_registry):
+        """get_enhancer_names works without registry.initialize()."""
+        names = get_enhancer_names()
+        assert "semantic_processor" in names
+        assert "text_embedding" in names
+
+    def test_create_enhancers_configures_module(
+        self, real_registry, ariel_config_with_text_embedding
+    ):
+        """Factory configures the enhancer with module config."""
+        enhancers = create_enhancers_from_config(ariel_config_with_text_embedding)
+        assert len(enhancers) == 1
+        # text_embedding should have been configured with the models list
+        assert len(enhancers[0]._models) == 1
+        assert enhancers[0]._models[0]["name"] == "nomic-embed-text"
+        assert enhancers[0]._models[0]["dimension"] == 768
+
+    def test_create_enhancers_skips_disabled(self, real_registry):
+        """Factory skips modules that are not enabled in config."""
+        config = ARIELConfig.from_dict(
+            {
+                "database": {"uri": "postgresql://localhost:5432/test"},
+                "enhancement_modules": {
+                    "text_embedding": {
+                        "enabled": False,
+                        "models": [{"name": "nomic-embed-text", "dimension": 768}],
+                    },
+                },
+            }
+        )
+        enhancers = create_enhancers_from_config(config)
+        assert enhancers == []


### PR DESCRIPTION
## Summary

Fixes #193 — `osprey ariel enhance --module text_embedding` returns "No enhancement modules enabled or selected" and semantic search returns no results.

**Root cause:** The enhancement factory called `registry.list_ariel_enhancement_modules()`, which requires `registry.initialize()` to populate the internal `_registries` dict. But CLI commands (`enhance`, `quickstart`) never call `initialize()`, so the factory always returned an empty list — no embeddings were ever generated.

**Fix:** The factory now reads module registrations directly from `registry.config.ariel_enhancement_modules` (populated at construction time, no `initialize()` needed) and imports classes inline via `importlib`. This affects all three CLI code paths: `enhance`, `quickstart`, and `status`.

## Changes

- **`factory.py`** — Use `registry.config` registrations + inline imports instead of `_registries` dict
- **`ariel.py`** — Improved error message with actionable config.yml guidance
- **`test_enhancement_factory_real_registry.py`** — New regression tests using a real (non-mock) registry to prevent this class of bug
- **E2E tests** — Hardened ARIEL E2E tests against transient API rate limits (convert 429s to `pytest.skip`)

## Test plan

- [x] New regression tests pass (5/5) — previously 4/5 failed
- [x] Existing enhancement tests pass (47/47) — no regressions
- [x] Full ARIEL test suite passes (777/777)
- [x] Full project test suite passes (4074 passed, 0 failed)
- [x] E2E tests pass (26 passed, 1 skipped due to rate limit)