### PR TITLE
[WIP] Make JSON schemas Bedrock-compatible, fix respond node context retrieval

### DIFF
--- a/src/osprey/infrastructure/respond_node.py
+++ b/src/osprey/infrastructure/respond_node.py
@@ -244,6 +244,10 @@ def _gather_information(state: AgentState, logger=None) -> ResponseContext:
     current_step = StateManager.get_current_step(state)
     relevant_context = context_manager.get_summaries(current_step)
 
+    # If the step had no inputs and returned nothing, fall back to all available context
+    if not relevant_context:
+        relevant_context = context_manager.get_summaries(None)
+
     # Determine response mode and prepare appropriate data
     response_mode = _determine_response_mode(state, current_step)
 

--- a/src/osprey/infrastructure/respond_node.py
+++ b/src/osprey/infrastructure/respond_node.py
@@ -246,6 +246,9 @@ def _gather_information(state: AgentState, logger=None) -> ResponseContext:
 
     # If the step had no inputs and returned nothing, fall back to all available context
     if not relevant_context:
+        logger and logger.warning(
+            "No context found for step %s; falling back to full context", current_step
+        )
         relevant_context = context_manager.get_summaries(None)
 
     # Determine response mode and prepare appropriate data

--- a/src/osprey/models/providers/litellm_adapter.py
+++ b/src/osprey/models/providers/litellm_adapter.py
@@ -29,6 +29,54 @@ from pydantic import BaseModel
 
 from osprey.utils.logger import get_logger
 
+
+def _fix_schema_additional_properties(schema: dict) -> dict:
+    """Make ``additionalProperties`` Bedrock-compatible throughout a JSON schema.
+
+    Bedrock rejects ``additionalProperties`` set to a schema object (e.g.
+    ``{"type": "string"}`` that Pydantic emits for ``dict[str, str]``).  It only
+    accepts the value ``false``.
+
+    Strategy:
+    - **Structured objects** (have ``properties``): set ``additionalProperties: false``.
+    - **Dict / map types** (``type: object`` *without* ``properties``, where
+      ``additionalProperties`` carries a value-type schema): *remove*
+      ``additionalProperties`` entirely so Bedrock sees a plain ``{"type": "object"}``
+      and the LLM is still free to populate keys.
+    """
+    if not isinstance(schema, dict):
+        return schema
+
+    # Process $defs (Pydantic v2 style)
+    if "$defs" in schema:
+        for key in schema["$defs"]:
+            schema["$defs"][key] = _fix_schema_additional_properties(schema["$defs"][key])
+
+    # Structured objects with named properties → lock down
+    if "properties" in schema:
+        schema["additionalProperties"] = False
+    elif schema.get("type") == "object" and isinstance(schema.get("additionalProperties"), dict):
+        # Pure dict/map type (no named properties, value schema in additionalProperties)
+        # Remove the unsupported schema object; {"type": "object"} is sufficient
+        del schema["additionalProperties"]
+
+    # Recurse into property definitions
+    if "properties" in schema:
+        for key in schema["properties"]:
+            schema["properties"][key] = _fix_schema_additional_properties(schema["properties"][key])
+
+    # Recurse into array items
+    if "items" in schema:
+        schema["items"] = _fix_schema_additional_properties(schema["items"])
+
+    # Recurse into combinators
+    for combinator in ("allOf", "anyOf", "oneOf"):
+        if combinator in schema:
+            schema[combinator] = [_fix_schema_additional_properties(s) for s in schema[combinator]]
+
+    return schema
+
+
 if TYPE_CHECKING:
     from .base import BaseProvider
 
@@ -297,6 +345,7 @@ def _handle_structured_output(
         )
 
     schema = output_format.model_json_schema()
+    schema = _fix_schema_additional_properties(schema)
 
     # Check if model supports native structured outputs using LiteLLM's detection
     supports_native = _supports_native_structured_output(litellm_model, provider)

--- a/src/osprey/models/providers/litellm_adapter.py
+++ b/src/osprey/models/providers/litellm_adapter.py
@@ -22,6 +22,7 @@ Provider Integration:
 import json
 import os
 import warnings
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
 import litellm
@@ -410,14 +411,17 @@ def _handle_structured_output(
         original_schema
     )
 
-    schema = original_schema
-    if uses_bedrock_schema_rules and not schema_has_bedrock_incompatible_maps:
-        schema = _fix_schema_additional_properties(schema)
-
     # Check if model supports native structured outputs using LiteLLM's detection
     supports_native = _supports_native_structured_output(litellm_model, provider)
-    if uses_bedrock_schema_rules and schema_has_bedrock_incompatible_maps:
-        supports_native = False
+
+    # Bedrock rejects certain additionalProperties shapes; either patch the schema or
+    # fall back to prompt-based output if the schema can't be safely fixed
+    schema = original_schema
+    if uses_bedrock_schema_rules:
+        if schema_has_bedrock_incompatible_maps:
+            supports_native = False  # can't fix these, fall back
+        else:
+            schema = _fix_schema_additional_properties(deepcopy(original_schema))
 
     if supports_native:
         # Use LiteLLM's native structured output support

--- a/src/osprey/models/providers/litellm_adapter.py
+++ b/src/osprey/models/providers/litellm_adapter.py
@@ -30,7 +30,7 @@ from pydantic import BaseModel
 from osprey.utils.logger import get_logger
 
 
-def _fix_schema_additional_properties(schema: dict) -> dict:
+def _fix_schema_additional_properties(schema: Any) -> Any:
     """Make ``additionalProperties`` Bedrock-compatible throughout a JSON schema.
 
     Bedrock rejects ``additionalProperties`` set to a schema object (e.g.

--- a/src/osprey/models/providers/litellm_adapter.py
+++ b/src/osprey/models/providers/litellm_adapter.py
@@ -77,6 +77,66 @@ def _fix_schema_additional_properties(schema: Any) -> Any:
     return schema
 
 
+def _uses_bedrock_schema_rules(provider: str, model_id: str, litellm_model: str) -> bool:
+    """Return whether structured outputs must satisfy Bedrock JSON schema rules.
+
+    Some providers proxy to upstream Bedrock-hosted Claude models and surface
+    Bedrock's stricter JSON schema validation, even when the local provider is
+    not literally named ``bedrock``.
+    """
+    if provider == "bedrock" or litellm_model.startswith("bedrock/"):
+        return True
+
+    # AmSC Claude model groups surface Bedrock schema validation errors.
+    if provider == "amsc" and "claude" in model_id.lower():
+        return True
+
+    return False
+
+
+def _schema_has_map_like_additional_properties(schema: Any) -> bool:
+    """Return whether a schema contains ``additionalProperties`` with a schema object.
+
+    Bedrock rejects these map-like shapes (for example ``dict[str, str]``).
+    We use this to fall back to prompt-based structured output instead of
+    weakening the schema into an unconstrained ``object``.
+    """
+    if not isinstance(schema, dict):
+        return False
+
+    if (
+        schema.get("type") == "object"
+        and "properties" not in schema
+        and isinstance(schema.get("additionalProperties"), dict)
+    ):
+        return True
+
+    if any(
+        _schema_has_map_like_additional_properties(schema[key])
+        for key in ("items", "additionalProperties")
+        if key in schema
+    ):
+        return True
+
+    if "properties" in schema and any(
+        _schema_has_map_like_additional_properties(value) for value in schema["properties"].values()
+    ):
+        return True
+
+    if "$defs" in schema and any(
+        _schema_has_map_like_additional_properties(value) for value in schema["$defs"].values()
+    ):
+        return True
+
+    for combinator in ("allOf", "anyOf", "oneOf"):
+        if combinator in schema and any(
+            _schema_has_map_like_additional_properties(value) for value in schema[combinator]
+        ):
+            return True
+
+    return False
+
+
 if TYPE_CHECKING:
     from .base import BaseProvider
 
@@ -344,11 +404,20 @@ def _handle_structured_output(
             is_typed_dict_output=is_typed_dict_output,
         )
 
-    schema = output_format.model_json_schema()
-    schema = _fix_schema_additional_properties(schema)
+    original_schema = output_format.model_json_schema()
+    uses_bedrock_schema_rules = _uses_bedrock_schema_rules(provider, model_id, litellm_model)
+    schema_has_bedrock_incompatible_maps = _schema_has_map_like_additional_properties(
+        original_schema
+    )
+
+    schema = original_schema
+    if uses_bedrock_schema_rules and not schema_has_bedrock_incompatible_maps:
+        schema = _fix_schema_additional_properties(schema)
 
     # Check if model supports native structured outputs using LiteLLM's detection
     supports_native = _supports_native_structured_output(litellm_model, provider)
+    if uses_bedrock_schema_rules and schema_has_bedrock_incompatible_maps:
+        supports_native = False
 
     if supports_native:
         # Use LiteLLM's native structured output support


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

Coming soon.

## Related Issue

<!-- Link to the related issue using GitHub keywords -->
<!-- Examples: -->
<!-- - Closes #123 (auto-closes issue when PR merges) -->
<!-- - Fixes #123 (auto-closes issue when PR merges) -->
<!-- - Resolves #123 (auto-closes issue when PR merges) -->
<!-- - Addresses #123 (links but doesn't auto-close) -->
<!-- - Part of #123 (links but doesn't auto-close) -->

The `hello_world_weather` template with the AmSC API raises the following error:
```console
👤 You: What's the weather like in San Francisco?
🔄 Processing: What's the weather like in San Francisco?
Gateway           Processing message: 'What's the weather like in San Francisco?...'
Gateway           Processing as new conversation turn
Gateway           Created fresh state for new conversation turn
Starting new conversation turn (execution_step_results: 0 records)...
Router            No current task extracted, routing to task extraction
Task_Extraction   Starting Task Extraction and Processing
Task_Extraction   Extracting actionable task from conversation
Data_Manager      Registered data source: core_user_memory
Data_Manager      Loaded 1 data sources from registry
Data_Manager      Retrieving context from 1 data sources
Data_Manager      Data sources checked: 1 (1 empty) in 0.00s
Task_Extraction   Retrieved data from 1 sources
Task_Extraction   LLM prompt built (4523 chars)
Task_Extraction   LLM response received (135 chars, 0.00s)
Task_Extraction    * Extracted: 'Get current weather conditions for San Francisco...'
Task_Extraction    * Depends on chat history: False
Task_Extraction    * Depends on user memory: False
Task_Extraction   ✓ Task extraction completed
Task_Extraction   ✓ Completed Task Extraction and Processing in 1.88s
Router            No active capabilities, routing to classifier
Classifier        Starting Task Classification and Capability Selection
Classifier        Analyzing task requirements...
Classifier        Classifying task: Get current weather conditions for San Francisco
Classifier        Classifying 5 capabilities with max 5 concurrent requests
Classifier        LLM prompt built for memory (1476 chars)
Classifier        LLM prompt built for time_range_parsing (1799 chars)
Classifier        LLM prompt built for python (2172 chars)
Classifier        LLM prompt built for current_weather (1801 chars)
Classifier        LLM response for memory (18 chars, 0.00s)
Classifier         >>> Capability 'memory' >>> False
Classifier        LLM response for time_range_parsing (18 chars, 0.00s)
Classifier         >>> Capability 'time_range_parsing' >>> False
Classifier        LLM response for python (18 chars, 0.00s)
Classifier         >>> Capability 'python' >>> False
Classifier        LLM response for current_weather (17 chars, 0.00s)
Classifier         >>> Capability 'current_weather' >>> True
Classifier        3 capabilities required: ['respond', 'clarify', 'current_weather']
Classifier        ✓ Classification completed with 3 active capabilities
Classifier        ✓ Completed Task Classification and Capability Selection in 1.32s
Router            No execution plan, routing to orchestrator
Orchestrator      Starting Execution Planning and Orchestration
Orchestrator      Planning for task: Get current weather conditions for San Francisco
Orchestrator      Available capabilities: ['respond', 'clarify', 'current_weather']
Orchestrator      Creating orchestrator prompt for task: "Get current weather conditions for San Francisco..."
Orchestrator      Active capabilities: ['respond', 'clarify', 'current_weather']
Orchestrator      Constructed orchestrator instructions using:
Orchestrator       - 3 capabilities
Orchestrator       - 5 structured examples
Orchestrator       - 0 context types from state
Orchestrator       - Chat history included: False (0 messages)
Orchestrator      Generating execution plan...
Orchestrator      Creating execution plan with orchestrator LLM
Orchestrator      LLM prompt built (5642 chars)
Orchestrator      ✗ InfrastructureError
                  Error in orchestrator after 1.49s: Unknown execution planning error: litellm.BadRequestError:           
                  OpenAIException - litellm.BadRequestError: BedrockException - {"message":"The model returned the        
                  following errors: For 'object' type, 'additionalProperties: object' is not supported. Please set        
                  'additionalProperties' to false"}. Received Model Group=claude-haiku                                    
                  Available Model Group Fallbacks=None                                                                    
Router            ✗ ExecutionError
                  Critical error in orchestrator, routing to error node
Error             Starting Error Response Generation
Error             ✓ Completed Error Response Generation in 1.80s
[04/17/26 13:55:05] WARNING  Deserializing unregistered type osprey.base.errors.ErrorSeverity from checkpoint. This will
                             be blocked in a future version. Set LANGGRAPH_STRICT_MSGPACK=true to block now, or add to  
                             allowed_msgpack_modules to allow explicitly: [('osprey.base.errors', 'ErrorSeverity')]     
                    WARNING  Deserializing unregistered type osprey.base.errors.ErrorClassification from checkpoint.    
                             This will be blocked in a future version. Set LANGGRAPH_STRICT_MSGPACK=true to block now,  
                             or add to allowed_msgpack_modules to allow explicitly: [('osprey.base.errors',             
                             'ErrorClassification')]                                                                    
📊 Execution completed (execution_step_results: 1 records)
🤖 ⚠️  **ERROR REPORT** - 2026-04-17 13:55:03
**Error Severity:** CRITICAL
**Task:** Get current weather conditions for San Francisco
**Failed Operation:** orchestrator
**Capability:** orchestrator
**Previous Execution Error:**
- **User Message:** Unknown execution planning error: litellm.BadRequestError: OpenAIException - litellm.BadRequestError: 
BedrockException - {"message":"The model returned the following errors: For 'object' type, 'additionalProperties: object' 
is not supported. Please set 'additionalProperties' to false"}. Received Model Group=claude-haiku
Available Model Group Fallbacks=None
- **Technical Details:** Error type: BadRequestError, Details: litellm.BadRequestError: OpenAIException - 
litellm.BadRequestError: BedrockException - {"message":"The model returned the following errors: For 'object' type, 
'additionalProperties: object' is not supported. Please set 'additionalProperties' to false"}. Received Model 
Group=claude-haiku
Available Model Group Fallbacks=None
**Execution Stats:** Total operations: 1, Execution time: 1.5s
**Execution Summary:**
❌ **Failed steps:**
   • Step 1: Infrastructure: orchestrator - Failed

**Analysis:** The orchestrator encountered a schema validation error when attempting to route the weather query through 
Claude Haiku. The model's response structure included an object-type field with `additionalProperties: object`, which 
violates Bedrock's schema constraints that require `additionalProperties: false`. Since no fallback model groups are 
configured, the system cannot retry with an alternative model, causing the operation to fail at the planning stage rather 
than execution.
                    WARNING  Deserializing unregistered type osprey.base.errors.ErrorSeverity from checkpoint. This will
                             be blocked in a future version. Set LANGGRAPH_STRICT_MSGPACK=true to block now, or add to  
                             allowed_msgpack_modules to allow explicitly: [('osprey.base.errors', 'ErrorSeverity')]     
                    WARNING  Deserializing unregistered type osprey.base.errors.ErrorClassification from checkpoint.    
                             This will be blocked in a future version. Set LANGGRAPH_STRICT_MSGPACK=true to block now,  
                             or add to allowed_msgpack_modules to allow explicitly: [('osprey.base.errors',             
                             'ErrorClassification')]                                                                    
```

## Type of Change

<!-- Mark relevant items with [x] -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [ ] Documentation update
- [ ] Infrastructure/tooling change
- [ ] Refactoring (no functional changes)
- [ ] Style/formatting changes
- [ ] Performance improvement
- [ ] Test updates

## Breaking Changes

<!-- If this introduces breaking changes, describe them here -->
<!-- Include migration instructions for users -->

**None**

## Testing

<!-- Describe how this has been tested -->

### Test Environment
- [ ] Local development
- [ ] CI/CD pipeline
- [x] Manual testing
- [ ] Automated tests added/updated

### Test Cases
<!-- List specific test cases or scenarios covered -->

- `hello_world_weather` template.

## Documentation

<!-- Check all that apply -->

- [ ] Code changes are self-documenting
- [ ] Docstrings updated (if applicable)
- [ ] RST documentation updated (if applicable)
- [ ] README updated (if applicable)
- [ ] Migration guide updated (for breaking changes)
- [ ] CHANGELOG.md updated
- [x] No documentation needed

## Checklist

<!-- Ensure all items are complete before requesting review -->

- [x] Code follows project style guidelines (ruff)
- [x] Self-review completed
- [x] Comments added for complex/non-obvious code
- [ ] Documentation updated (or N/A)
- [ ] Tests added/updated (or N/A)
- [ ] All tests passing locally
- [ ] No new warnings introduced
- [x] Commits are clean and well-described
- [x] Branch is up-to-date with target branch

## Framework-Specific Checks

<!-- For changes affecting core framework -->

- [ ] Registry system changes validated
- [ ] Configuration system compatibility verified
- [ ] CLI commands tested
- [ ] Templates validated (if modified)
- [ ] Backward compatibility maintained (or breaking change documented)
- [ ] No circular imports introduced

## Screenshots / Output Examples

<!-- Add screenshots for UI changes or command output examples -->
<!-- Remove this section if not applicable -->

**Before:**
```console
👤 You: What's the weather like in San Francisco?
🔄 Processing: What's the weather like in San Francisco?
Gateway           Processing message: 'What's the weather like in San Francisco?...'
Gateway           Processing as new conversation turn
Gateway           Created fresh state for new conversation turn
Starting new conversation turn (execution_step_results: 0 records)...
Router            No current task extracted, routing to task extraction
Task_Extraction   Starting Task Extraction and Processing
Task_Extraction   Extracting actionable task from conversation
Data_Manager      Registered data source: core_user_memory
Data_Manager      Loaded 1 data sources from registry
Data_Manager      Retrieving context from 1 data sources
Data_Manager      Data sources checked: 1 (1 empty) in 0.00s
Task_Extraction   Retrieved data from 1 sources
Task_Extraction   LLM prompt built (4523 chars)
Task_Extraction   LLM response received (135 chars, 0.00s)
Task_Extraction    * Extracted: 'Get current weather conditions for San Francisco...'
Task_Extraction    * Depends on chat history: False
Task_Extraction    * Depends on user memory: False
Task_Extraction   ✓ Task extraction completed
Task_Extraction   ✓ Completed Task Extraction and Processing in 1.88s
Router            No active capabilities, routing to classifier
Classifier        Starting Task Classification and Capability Selection
Classifier        Analyzing task requirements...
Classifier        Classifying task: Get current weather conditions for San Francisco
Classifier        Classifying 5 capabilities with max 5 concurrent requests
Classifier        LLM prompt built for memory (1476 chars)
Classifier        LLM prompt built for time_range_parsing (1799 chars)
Classifier        LLM prompt built for python (2172 chars)
Classifier        LLM prompt built for current_weather (1801 chars)
Classifier        LLM response for memory (18 chars, 0.00s)
Classifier         >>> Capability 'memory' >>> False
Classifier        LLM response for time_range_parsing (18 chars, 0.00s)
Classifier         >>> Capability 'time_range_parsing' >>> False
Classifier        LLM response for python (18 chars, 0.00s)
Classifier         >>> Capability 'python' >>> False
Classifier        LLM response for current_weather (17 chars, 0.00s)
Classifier         >>> Capability 'current_weather' >>> True
Classifier        3 capabilities required: ['respond', 'clarify', 'current_weather']
Classifier        ✓ Classification completed with 3 active capabilities
Classifier        ✓ Completed Task Classification and Capability Selection in 1.32s
Router            No execution plan, routing to orchestrator
Orchestrator      Starting Execution Planning and Orchestration
Orchestrator      Planning for task: Get current weather conditions for San Francisco
Orchestrator      Available capabilities: ['respond', 'clarify', 'current_weather']
Orchestrator      Creating orchestrator prompt for task: "Get current weather conditions for San Francisco..."
Orchestrator      Active capabilities: ['respond', 'clarify', 'current_weather']
Orchestrator      Constructed orchestrator instructions using:
Orchestrator       - 3 capabilities
Orchestrator       - 5 structured examples
Orchestrator       - 0 context types from state
Orchestrator       - Chat history included: False (0 messages)
Orchestrator      Generating execution plan...
Orchestrator      Creating execution plan with orchestrator LLM
Orchestrator      LLM prompt built (5642 chars)
Orchestrator      ✗ InfrastructureError
                  Error in orchestrator after 1.49s: Unknown execution planning error: litellm.BadRequestError:           
                  OpenAIException - litellm.BadRequestError: BedrockException - {"message":"The model returned the        
                  following errors: For 'object' type, 'additionalProperties: object' is not supported. Please set        
                  'additionalProperties' to false"}. Received Model Group=claude-haiku                                    
                  Available Model Group Fallbacks=None                                                                    
Router            ✗ ExecutionError
                  Critical error in orchestrator, routing to error node
Error             Starting Error Response Generation
Error             ✓ Completed Error Response Generation in 1.80s
[04/17/26 13:55:05] WARNING  Deserializing unregistered type osprey.base.errors.ErrorSeverity from checkpoint. This will
                             be blocked in a future version. Set LANGGRAPH_STRICT_MSGPACK=true to block now, or add to  
                             allowed_msgpack_modules to allow explicitly: [('osprey.base.errors', 'ErrorSeverity')]     
                    WARNING  Deserializing unregistered type osprey.base.errors.ErrorClassification from checkpoint.    
                             This will be blocked in a future version. Set LANGGRAPH_STRICT_MSGPACK=true to block now,  
                             or add to allowed_msgpack_modules to allow explicitly: [('osprey.base.errors',             
                             'ErrorClassification')]                                                                    
📊 Execution completed (execution_step_results: 1 records)
🤖 ⚠️  **ERROR REPORT** - 2026-04-17 13:55:03
**Error Severity:** CRITICAL
**Task:** Get current weather conditions for San Francisco
**Failed Operation:** orchestrator
**Capability:** orchestrator
**Previous Execution Error:**
- **User Message:** Unknown execution planning error: litellm.BadRequestError: OpenAIException - litellm.BadRequestError: 
BedrockException - {"message":"The model returned the following errors: For 'object' type, 'additionalProperties: object' 
is not supported. Please set 'additionalProperties' to false"}. Received Model Group=claude-haiku
Available Model Group Fallbacks=None
- **Technical Details:** Error type: BadRequestError, Details: litellm.BadRequestError: OpenAIException - 
litellm.BadRequestError: BedrockException - {"message":"The model returned the following errors: For 'object' type, 
'additionalProperties: object' is not supported. Please set 'additionalProperties' to false"}. Received Model 
Group=claude-haiku
Available Model Group Fallbacks=None
**Execution Stats:** Total operations: 1, Execution time: 1.5s
**Execution Summary:**
❌ **Failed steps:**
   • Step 1: Infrastructure: orchestrator - Failed

**Analysis:** The orchestrator encountered a schema validation error when attempting to route the weather query through 
Claude Haiku. The model's response structure included an object-type field with `additionalProperties: object`, which 
violates Bedrock's schema constraints that require `additionalProperties: false`. Since no fallback model groups are 
configured, the system cannot retry with an alternative model, causing the operation to fail at the planning stage rather 
than execution.
                    WARNING  Deserializing unregistered type osprey.base.errors.ErrorSeverity from checkpoint. This will
                             be blocked in a future version. Set LANGGRAPH_STRICT_MSGPACK=true to block now, or add to  
                             allowed_msgpack_modules to allow explicitly: [('osprey.base.errors', 'ErrorSeverity')]     
                    WARNING  Deserializing unregistered type osprey.base.errors.ErrorClassification from checkpoint.    
                             This will be blocked in a future version. Set LANGGRAPH_STRICT_MSGPACK=true to block now,  
                             or add to allowed_msgpack_modules to allow explicitly: [('osprey.base.errors',             
                             'ErrorClassification')]                                                                    
```

**After:**
```console
👤 You: What's the weather like in San Francisco?
🔄 Processing: What's the weather like in San Francisco?
Gateway           Processing message: 'What's the weather like in San Francisco?...'
Gateway           Processing as new conversation turn
Gateway           Created fresh state for new conversation turn
Starting new conversation turn (execution_step_results: 0 records)...
Router            No current task extracted, routing to task extraction
Task_Extraction   Starting Task Extraction and Processing
Task_Extraction   Extracting actionable task from conversation
Data_Manager      Registered data source: core_user_memory
Data_Manager      Loaded 1 data sources from registry
Data_Manager      Retrieving context from 1 data sources
Data_Manager      Data sources checked: 1 (1 empty) in 0.00s
Task_Extraction   Retrieved data from 1 sources
Task_Extraction   LLM prompt built (4523 chars)
Task_Extraction   LLM response received (135 chars, 0.00s)
Task_Extraction    * Extracted: 'Get current weather conditions for San Francisco...'
Task_Extraction    * Depends on chat history: False
Task_Extraction    * Depends on user memory: False
Task_Extraction   ✓ Task extraction completed
Task_Extraction   ✓ Completed Task Extraction and Processing in 1.67s
Router            No active capabilities, routing to classifier
Classifier        Starting Task Classification and Capability Selection
Classifier        Analyzing task requirements...
Classifier        Classifying task: Get current weather conditions for San Francisco
Classifier        Classifying 5 capabilities with max 5 concurrent requests
Classifier        LLM prompt built for memory (1476 chars)
Classifier        LLM prompt built for time_range_parsing (1799 chars)
Classifier        LLM prompt built for python (2172 chars)
Classifier        LLM prompt built for current_weather (1801 chars)
Classifier        LLM response for memory (18 chars, 0.00s)
Classifier         >>> Capability 'memory' >>> False
Classifier        LLM response for time_range_parsing (18 chars, 0.00s)
Classifier         >>> Capability 'time_range_parsing' >>> False
Classifier        LLM response for python (18 chars, 0.00s)
Classifier         >>> Capability 'python' >>> False
Classifier        LLM response for current_weather (17 chars, 0.00s)
Classifier         >>> Capability 'current_weather' >>> True
Classifier        3 capabilities required: ['respond', 'clarify', 'current_weather']
Classifier        ✓ Classification completed with 3 active capabilities
Classifier        ✓ Completed Task Classification and Capability Selection in 1.76s
Router            No execution plan, routing to orchestrator
Orchestrator      Starting Execution Planning and Orchestration
Orchestrator      Planning for task: Get current weather conditions for San Francisco
Orchestrator      Available capabilities: ['respond', 'clarify', 'current_weather']
Orchestrator      Creating orchestrator prompt for task: "Get current weather conditions for San Francisco..."
Orchestrator      Active capabilities: ['respond', 'clarify', 'current_weather']
Orchestrator      Constructed orchestrator instructions using:
Orchestrator       - 3 capabilities
Orchestrator       - 5 structured examples
Orchestrator       - 0 context types from state
Orchestrator       - Chat history included: False (0 messages)
Orchestrator      Generating execution plan...
Orchestrator      Creating execution plan with orchestrator LLM
Orchestrator      LLM prompt built (5642 chars)
Orchestrator      Orchestrator LLM execution time: 2.33 seconds
Orchestrator      LLM response received (911 chars, 0.00s)
Orchestrator      ✅ All capabilities in execution plan exist in registry
Orchestrator      Execution plan correctly ends with respond step
Orchestrator      ==================================================
Orchestrator       << Step 1
Orchestrator       << ├───── id: 'sf_weather'
Orchestrator       << ├─── node: 'current_weather'
Orchestrator       << ├─── task: 'Retrieve current weather conditions for San Francisco including temperature, conditions,
                  and timestamp'                                                                                          
Orchestrator       << └─ inputs: 'None'
Orchestrator       << Step 2
Orchestrator       << ├───── id: 'final_response'
Orchestrator       << ├─── node: 'respond'
Orchestrator       << ├─── task: 'Provide the user with current weather conditions for San Francisco using the retrieved  
                  weather data'                                                                                           
Orchestrator       << └─ inputs: '[]'
Orchestrator      ==================================================
Orchestrator      ✓ Final execution plan ready with 2 steps
Orchestrator      Planning mode not enabled - proceeding with normal execution
Orchestrator      Execution plan created
Orchestrator      Orchestration processing completed
Orchestrator      ✓ Completed Execution Planning and Orchestration in 2.33s
Router            Executing step 1/2 - capability: current_weather
Current_Weather   Getting weather for San Francisco...
Current_Weather   Weather retrieved: San Francisco - 11.0°C
Router            Executing step 2/2 - capability: respond
Respond           Gathering information for response...
Respond           Using technical response mode (context type: general_context)
Respond           Generating response...
Respond           LLM prompt built (1501 chars)

🤖 Assistant: # Current Weather Conditions - San Francisco

**Date:** April 17, 2026 (PDT)

**Temperature:** 11.0°C (approximately 52°F)

**Conditions:** Drizzle

---

### Summary
San Francisco is currently experiencing drizzly conditions with cool temperatures at just above 11°C. You may want to bring an umbrella or light rain jacket if heading outdoors.
📊 Execution completed (execution_step_results: 2 records)
```

## Deployment Notes

<!-- Special considerations for deployment -->
<!-- Remove this section if not applicable -->

- [ ] Database migrations required
- [ ] Configuration changes required
- [ ] Environment variables added/changed
- [ ] Dependencies added/updated
- [ ] Service restart required

## Reviewer Notes

<!-- Any specific areas you want reviewers to focus on? -->
<!-- Any concerns or questions for reviewers? -->

I will remove the "[WIP]" tag from the PR title once:
- All CI checks have passed.
- We have tested the bug fix with the BELLA accelerator assistant.

## Additional Context

<!-- Add any other context about the PR here -->
<!-- Links to related PRs, external references, design docs, etc. -->

The bug fix expands a fix suggested by @awschmeder to @RemiLehe.

The original fix consisted in adding
```diff

    schema = Result.model_json_schema()
    
+    # Fix Bedrock constraint: set additionalProperties to false on object types
+    if "properties" in schema and "params" in schema["properties"]:
+        schema["properties"]["params"]["additionalProperties"] = False

    completion(
        model="openai/" + model_name,
```
to the minimal reproducer
```py
#!/usr/bin/env python3
"""Minimal reproducer: structured output via CBorg → BedrockException.
"""

import os
import sys

from litellm import completion
from pydantic import BaseModel


class Result(BaseModel):
    """Minimal model whose schema has additionalProperties (object) → Bedrock error."""

    params: dict[str, str]


def main() -> None:

    # Fails with AmSC I2 (used to work in the past)
    api_key = os.environ.get("AMSC_I2_API_KEY")
    base_url = "[https://api.i2-core.american-science-cloud.org/v1](https://urldefense.us/v3/__https://api.i2-core.american-science-cloud.org/v1__;!!G_uCfscf7eWS!Z-2N2pwLqkue8lah9BmycJ5wMJmx1b-05GhHUMHVlySwep1EuFS348MdOsHOyxYGb6fyOBjCy0qjXg$)"
    model_name = "claude-haiku"

    # Works with CBorg
    # api_key = os.environ.get("CBORG_API_KEY")
    # base_url = "[https://api.cborg.lbl.gov/v1](https://urldefense.us/v3/__https://api.cborg.lbl.gov/v1__;!!G_uCfscf7eWS!Z-2N2pwLqkue8lah9BmycJ5wMJmx1b-05GhHUMHVlySwep1EuFS348MdOsHOyxYGb6fyOBj0jXJSJw$)"
    # model_name = "anthropic/claude-haiku"

    schema = Result.model_json_schema()

    completion(
        model="openai/" + model_name,
        messages=[{"role": "user", "content": "Return JSON with params: {\"a\": \"b\"}."}],
        api_key=api_key,
        api_base=base_url,
        response_format={
            "type": "json_schema",
            "json_schema": {"name": "Result", "schema": schema},
        },
    )

if __name__ == "__main__":
    main()#!/usr/bin/env python3
"""Minimal reproducer: structured output via CBorg → BedrockException.
"""

import os
import sys

from litellm import completion
from pydantic import BaseModel


class Result(BaseModel):
    """Minimal model whose schema has additionalProperties (object) → Bedrock error."""

    params: dict[str, str]


def main() -> None:

    # Fails with AmSC I2 (used to work in the past)
    api_key = os.environ.get("AMSC_I2_API_KEY")
    base_url = "[https://api.i2-core.american-science-cloud.org/v1](https://urldefense.us/v3/__https://api.i2-core.american-science-cloud.org/v1__;!!G_uCfscf7eWS!Z-2N2pwLqkue8lah9BmycJ5wMJmx1b-05GhHUMHVlySwep1EuFS348MdOsHOyxYGb6fyOBjCy0qjXg$)"
    model_name = "claude-haiku"


    # Works with CBorg
    # api_key = os.environ.get("CBORG_API_KEY")
    # base_url = "[https://api.cborg.lbl.gov/v1](https://urldefense.us/v3/__https://api.cborg.lbl.gov/v1__;!!G_uCfscf7eWS!Z-2N2pwLqkue8lah9BmycJ5wMJmx1b-05GhHUMHVlySwep1EuFS348MdOsHOyxYGb6fyOBj0jXJSJw$)"
    # model_name = "anthropic/claude-haiku"

    schema = Result.model_json_schema()

    completion(
        model="openai/" + model_name,
        messages=[{"role": "user", "content": "Return JSON with params: {\"a\": \"b\"}."}],
        api_key=api_key,
        api_base=base_url,
        response_format={
            "type": "json_schema",
            "json_schema": {"name": "Result", "schema": schema},
        },
    )

if __name__ == "__main__":
    main()
```

---

<!--
PR Guidelines:
- Keep PRs focused on a single concern
- Link to related issues
- Provide context for reviewers
- Update documentation
- Add tests for new functionality
- Follow semantic commit message format
-->
