### PR TITLE
fix(channel-finder): honor suffix_map in template renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ## [Unreleased]
 
+### Fixed
+- **Channel-finder template renderer honors `suffix_map`.** Templates in
+  `in_context.json` (and any project DB using the same schema) declare
+  `suffix_map` to translate display-name sub-channels (e.g.
+  `CurrentSetPoint`) into EPICS address suffixes (e.g. `SP`). The renderer
+  was ignoring this field and using the raw sub-channel name as the
+  address suffix, producing addresses like
+  `SR:MAG:DIPOLE:B05:CURRENT:CurrentSetPoint` instead of
+  `SR:MAG:DIPOLE:B05:CURRENT:SP`. Affects every project scaffolded with
+  `osprey init --channel-finder-mode=in_context` whose templates declare
+  `suffix_map` (the four magnet templates in the shipped
+  `control_assistant` app: dipoles, focusing quads, horizontal/vertical
+  correctors). Channel aliases (the human-readable names) are unchanged.
+
 ### Changed
 - **Branch strategy: adopt GitHub Flow.** The short-lived `next` integration
   branch is retired in favour of trunk-based development on `main`. CI now

--- a/src/osprey/services/channel_finder/databases/template.py
+++ b/src/osprey/services/channel_finder/databases/template.py
@@ -82,6 +82,10 @@ class ChannelDatabase(FlatChannelDatabase):
             "channel_descriptions": {  # optional, per-sub-channel descriptions
                 "SetPoint": "Specific description for {instance:02d} SetPoint",
                 "ReadBack": "Specific description for {instance:02d} ReadBack"
+            },
+            "suffix_map": {  # optional, sub_channel name -> address suffix
+                "CurrentSetPoint": "SP",
+                "CurrentReadBack": "RB"
             }
         }
         """
@@ -92,6 +96,9 @@ class ChannelDatabase(FlatChannelDatabase):
         generic_description = tmpl.get("description", "")
         address_pattern = tmpl.get("address_pattern", "{base}{instance:02d}{suffix}")
         channel_descriptions = tmpl.get("channel_descriptions", {})
+        # Optional: translate sub_channel names to address suffixes
+        # (e.g. "CurrentSetPoint" -> "SP"). Missing entries fall through unchanged.
+        suffix_map = tmpl.get("suffix_map", {})
 
         # If no sub_channels, use empty string so loop executes once
         if not sub_channels:
@@ -112,11 +119,18 @@ class ChannelDatabase(FlatChannelDatabase):
                         channel_name = f"{base_name}{instance_num:02d}{suffix}"
                         actual_suffix = suffix
 
-                    # Build address (use pattern if provided, else same as channel name)
-                    # When address_pattern has {axis}, use plain suffix; otherwise use actual_suffix
-                    pattern_suffix = (
-                        suffix if (axis and "{axis}" in address_pattern) else actual_suffix
-                    )
+                    # Build address (use pattern if provided, else same as channel name).
+                    # The address suffix may be remapped via suffix_map; the channel
+                    # alias above keeps the raw sub_channel name.
+                    address_suffix = suffix_map.get(suffix, suffix)
+                    if axis and "{axis}" in address_pattern:
+                        # Multi-axis pattern handles {axis} separately
+                        pattern_suffix = address_suffix
+                    elif axis:
+                        # Multi-axis without {axis} placeholder: prepend axis
+                        pattern_suffix = f"{axis}{address_suffix}"
+                    else:
+                        pattern_suffix = address_suffix
                     address = address_pattern.format(
                         base=base_name,
                         instance=instance_num,

--- a/tests/services/channel_finder/databases/test_template_suffix_map.py
+++ b/tests/services/channel_finder/databases/test_template_suffix_map.py
@@ -1,0 +1,154 @@
+"""Regression tests for `suffix_map` handling in template expansion.
+
+When a template declares ``sub_channels`` whose names differ from their EPICS
+address suffixes (e.g. ``"CurrentSetPoint"`` displayed to humans, ``"SP"`` on
+the wire), the template must declare a ``suffix_map`` so the renderer can
+translate one to the other.
+
+These tests pin the contract:
+  * ``channel`` (the human-readable alias) keeps the raw ``sub_channel`` name.
+  * ``address`` is built from the *mapped* suffix.
+  * Templates without ``suffix_map`` continue to use ``sub_channel`` names
+    as the address suffix (backward-compat path).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from osprey.services.channel_finder.databases.template import ChannelDatabase
+
+
+def _write_db(path: Path, channels: list[dict]) -> ChannelDatabase:
+    path.write_text(json.dumps({"channels": channels}, indent=2))
+    return ChannelDatabase(str(path))
+
+
+class TestSuffixMapExpansion:
+    def test_address_uses_mapped_suffix(self, tmp_path: Path):
+        db = _write_db(
+            tmp_path / "db.json",
+            [
+                {
+                    "template": True,
+                    "base_name": "DipoleMagnet",
+                    "instances": [1, 3],
+                    "sub_channels": ["CurrentSetPoint", "CurrentReadBack"],
+                    "address_pattern": "SR:MAG:DIPOLE:B{instance:02d}:CURRENT:{suffix}",
+                    "suffix_map": {"CurrentSetPoint": "SP", "CurrentReadBack": "RB"},
+                }
+            ],
+        )
+
+        sp = db.channel_map["DipoleMagnet01CurrentSetPoint"]
+        rb = db.channel_map["DipoleMagnet01CurrentReadBack"]
+
+        assert sp["address"] == "SR:MAG:DIPOLE:B01:CURRENT:SP"
+        assert rb["address"] == "SR:MAG:DIPOLE:B01:CURRENT:RB"
+
+    def test_alias_keeps_raw_sub_channel_name(self, tmp_path: Path):
+        db = _write_db(
+            tmp_path / "db.json",
+            [
+                {
+                    "template": True,
+                    "base_name": "DipoleMagnet",
+                    "instances": [5, 5],
+                    "sub_channels": ["CurrentSetPoint"],
+                    "address_pattern": "SR:MAG:DIPOLE:B{instance:02d}:CURRENT:{suffix}",
+                    "suffix_map": {"CurrentSetPoint": "SP"},
+                }
+            ],
+        )
+
+        ch = db.channel_map["DipoleMagnet05CurrentSetPoint"]
+        assert ch["channel"] == "DipoleMagnet05CurrentSetPoint"
+        assert ch["address"] == "SR:MAG:DIPOLE:B05:CURRENT:SP"
+
+    def test_partial_map_falls_back_to_raw_for_unmapped(self, tmp_path: Path):
+        db = _write_db(
+            tmp_path / "db.json",
+            [
+                {
+                    "template": True,
+                    "base_name": "Thing",
+                    "instances": [1, 1],
+                    "sub_channels": ["Aliased", "Plain"],
+                    "address_pattern": "DEV:{instance:02d}:{suffix}",
+                    "suffix_map": {"Aliased": "AL"},
+                }
+            ],
+        )
+
+        assert db.channel_map["Thing01Aliased"]["address"] == "DEV:01:AL"
+        assert db.channel_map["Thing01Plain"]["address"] == "DEV:01:Plain"
+
+    def test_no_suffix_map_preserves_legacy_behavior(self, tmp_path: Path):
+        db = _write_db(
+            tmp_path / "db.json",
+            [
+                {
+                    "template": True,
+                    "base_name": "Quad",
+                    "instances": [1, 1],
+                    "sub_channels": ["SP", "RB"],
+                    "address_pattern": "SR:MAG:QF:{instance:02d}:{suffix}",
+                }
+            ],
+        )
+
+        assert db.channel_map["Quad01SP"]["address"] == "SR:MAG:QF:01:SP"
+        assert db.channel_map["Quad01RB"]["address"] == "SR:MAG:QF:01:RB"
+
+    def test_multi_axis_with_suffix_map(self, tmp_path: Path):
+        db = _write_db(
+            tmp_path / "db.json",
+            [
+                {
+                    "template": True,
+                    "base_name": "Steerer",
+                    "instances": [1, 1],
+                    "axes": ["H", "V"],
+                    "sub_channels": ["CurrentSetPoint"],
+                    "address_pattern": "SR:STR:{axis}{instance:02d}:CURRENT:{suffix}",
+                    "suffix_map": {"CurrentSetPoint": "SP"},
+                }
+            ],
+        )
+
+        h = db.channel_map["Steerer01HCurrentSetPoint"]
+        v = db.channel_map["Steerer01VCurrentSetPoint"]
+        assert h["address"] == "SR:STR:H01:CURRENT:SP"
+        assert v["address"] == "SR:STR:V01:CURRENT:SP"
+
+
+class TestShippedTemplateDatabaseRenders:
+    """Pin the addresses produced by the in_context.json template DB shipped
+    with the control_assistant app. This DB drives `osprey init
+    --channel-finder-mode=in_context` and the InContext e2e benchmark."""
+
+    @pytest.fixture()
+    def shipped_db(self) -> ChannelDatabase:
+        path = (
+            Path(__file__).parents[4]
+            / "src/osprey/templates/apps/control_assistant/data/channel_databases/in_context.json"
+        )
+        return ChannelDatabase(str(path))
+
+    @pytest.mark.parametrize(
+        "channel, expected_address",
+        [
+            ("DipoleMagnet05CurrentSetPoint", "SR:MAG:DIPOLE:B05:CURRENT:SP"),
+            ("DipoleMagnet05CurrentReadBack", "SR:MAG:DIPOLE:B05:CURRENT:RB"),
+            ("FocusingQuad03CurrentSetPoint", "SR:MAG:QF:QF03:CURRENT:SP"),
+            ("HorizontalCorrectorMagnet07CurrentSetPoint", "SR:MAG:HCM:H07:CURRENT:SP"),
+            ("VerticalCorrectorMagnet02CurrentReadBack", "SR:MAG:VCM:V02:CURRENT:RB"),
+        ],
+    )
+    def test_canonical_addresses(
+        self, shipped_db: ChannelDatabase, channel: str, expected_address: str
+    ):
+        assert shipped_db.channel_map[channel]["address"] == expected_address


### PR DESCRIPTION
## Summary
- The `_expand_template` renderer in `services/channel_finder/databases/template.py` was using the raw `sub_channel` name (e.g. `CurrentSetPoint`) as the address suffix and silently ignoring the template's `suffix_map`. Projects scaffolded with `osprey init --channel-finder-mode=in_context` therefore produced wrong PV addresses like `SR:MAG:DIPOLE:B05:CURRENT:CurrentSetPoint` instead of the canonical `SR:MAG:DIPOLE:B05:CURRENT:SP`.
- The fix consults `suffix_map.get(sub_channel, sub_channel)` when building addresses. Channel **aliases** (the human-readable identifiers) are unchanged. Templates **without** `suffix_map` continue to behave as before — covered by an explicit regression test.
- Affects the four magnet templates in the shipped `control_assistant` app DB (dipoles, focusing quads, horizontal/vertical correctors).

## Why this surfaced
Found while debugging the InContext channel-finder e2e benchmark (`test_channel_finder_mcp_benchmarks.py`). Two queries (`ic_03_dipole_sp`, `ic_04_corrector_axis`) flipped between PERFECT and MISS run-to-run because the agent was confidently returning the bogus `:CURRENT:CurrentSetPoint` suffix that the renderer fed it. `suffix_map` was documented in `osprey-config-reference.md` but had **zero** Python references — dead schema.

## Test plan
- [x] New: `tests/services/channel_finder/databases/test_template_suffix_map.py` — 5 unit tests for the renderer (mapped suffix, alias preservation, partial map fallback, multi-axis with map, no-map legacy path) plus 5 parametrized canonical-address checks against the shipped `control_assistant` `in_context.json`. All 10 pass.
- [x] No regressions in `tests/services/channel_finder/databases/` (91/91 pass).
- [x] No regressions in wider `tests/services/channel_finder/` (179/179 pass).
- [x] `ruff check` clean, `ruff format` clean.

## Out of scope
- Hier_10 scorer fix and hier_09 prompt fan-out — those tests are about to be replaced by the cross-paradigm benchmark merge.
- `validate_database.py` warning when `sub_channels` look non-EPICS without a `suffix_map` — useful follow-up but not required for the fix.
- Stale `src/osprey/templates/project/data/channel_databases/middle_layer.json` (dead since `e9d3e5f0`) — defer to cross-paradigm cleanup.