### PR TITLE
fix(cli): osprey build works after uv tool install (#216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ Compatibility is documented in release notes, not encoded in the version string.
   check tiers (`quick_check.sh`, `ci_check.sh`, `premerge_check.sh main`).
 
 ### Fixed
+- **`osprey build` now works after `uv tool install osprey-framework`** (#216).
+  The `osprey_install: local` resolver walked `Path(__file__).parents[3]` to
+  find the source tree, which lands inside `<tool>/lib/python3.11` for
+  non-editable installs and tripped a "no pyproject.toml" error on the
+  recommended quickstart. Resolution now consults `importlib.metadata`:
+  editable installs use the source path; wheel/uv-tool installs pin to
+  `osprey-framework==<running version>`. Existing profiles need no changes.
 - **Channel-finder template renderer honors `suffix_map`.** Templates in
   `in_context.json` (and any project DB using the same schema) declare
   `suffix_map` to translate display-name sub-channels (e.g.

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -14,14 +14,17 @@ Usage:
 
 from __future__ import annotations
 
+import json
 import os
 import shlex
 import shutil
 import subprocess
 import threading
 import time
+from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
 from typing import Any
+from urllib.parse import unquote, urlparse
 
 import click
 
@@ -718,6 +721,56 @@ def _generate_env_template(project_path: Path, env_config: Any) -> None:
         logger.info("  Hint: Copy .env.template to .env and fill in required values")
 
 
+def _resolve_osprey_spec(osprey_install: str) -> tuple[str, str]:
+    """Resolve the osprey install spec for the project venv.
+
+    Returns ``(spec, label)`` where ``spec`` is the pip/uv install argument
+    and ``label`` is a human-readable identifier used in logs and the
+    generated requirements.txt comment.
+
+    The ``osprey_install`` value drives the resolution:
+      - ``"local"`` (default): consult ``importlib.metadata``. Editable
+        installs (``pip install -e .``, ``uv sync``) install from the source
+        tree; non-editable installs (``uv tool install``, wheels from PyPI)
+        pin to the running version (``osprey-framework==<version>``).
+      - ``"pip"``: install ``osprey-framework`` from PyPI, unpinned.
+      - anything else: treated as a PEP 508 spec, passed through verbatim.
+    """
+    if osprey_install == "local":
+        try:
+            dist = distribution("osprey-framework")
+        except PackageNotFoundError:
+            dist = None
+
+        direct_url_text = dist.read_text("direct_url.json") if dist else None
+        info = json.loads(direct_url_text) if direct_url_text else {}
+        if info.get("dir_info", {}).get("editable"):
+            src_path = unquote(urlparse(info["url"]).path)
+            return src_path, f"editable: {src_path}"
+
+        if dist is not None:
+            spec = f"osprey-framework=={dist.version}"
+            return spec, spec
+
+        # Metadata unavailable (rare: e.g. running osprey directly from a
+        # source tree without installing it). Fall back to the source root
+        # one final time so dev workflows that bypass install still work.
+        osprey_root = Path(__file__).resolve().parents[3]
+        if (osprey_root / "pyproject.toml").exists():
+            return str(osprey_root), f"local: {osprey_root}"
+        raise BuildProfileError(
+            "Cannot resolve osprey install location: package metadata is "
+            f"missing and no source tree is present at {osprey_root}. "
+            "Install osprey-framework with `uv tool install osprey-framework` "
+            "or set `osprey_install` explicitly in your profile."
+        )
+
+    if osprey_install == "pip":
+        return "osprey-framework", "osprey-framework"
+
+    return osprey_install, osprey_install
+
+
 def _create_project_venv(project_path: Path, profile: Any) -> None:
     """Create the project venv and install osprey + profile deps.
 
@@ -725,10 +778,8 @@ def _create_project_venv(project_path: Path, profile: Any) -> None:
     One venv, one install command, one resolver pass. The resolver sees all
     dependencies together (osprey + profile deps) and either succeeds or fails.
 
-    The ``osprey_install`` profile field controls where osprey comes from:
-      - ``"local"`` (default): install from the source tree running this build
-      - ``"pip"``: install ``osprey-framework`` from PyPI
-      - anything else: treated as a PEP 508 spec (e.g. ``"osprey-framework==2026.5.0"``)
+    See :func:`_resolve_osprey_spec` for how ``profile.osprey_install`` is
+    interpreted.
     """
     import sys
 
@@ -757,18 +808,7 @@ def _create_project_venv(project_path: Path, profile: Any) -> None:
 
     # --- Resolve osprey install spec ---
     osprey_install = profile.osprey_install or "local"
-    if osprey_install == "local":
-        # build_cmd.py is at src/osprey/cli/build_cmd.py → repo root is parents[3]
-        osprey_root = Path(__file__).resolve().parents[3]
-        if not (osprey_root / "pyproject.toml").exists():
-            raise BuildProfileError(
-                f"osprey_install: local — but no pyproject.toml at {osprey_root}"
-            )
-        osprey_spec = str(osprey_root)
-    elif osprey_install == "pip":
-        osprey_spec = "osprey-framework"
-    else:
-        osprey_spec = osprey_install
+    osprey_spec, osprey_label = _resolve_osprey_spec(osprey_install)
 
     # --- Install osprey + profile deps ---
     all_deps = [osprey_spec] + list(profile.dependencies or [])
@@ -791,7 +831,7 @@ def _create_project_venv(project_path: Path, profile: Any) -> None:
     from rich.live import Live
     from rich.spinner import Spinner
 
-    spinner = Spinner("dots", text=f"  Installing osprey ({osprey_install}) + {dep_count} deps...")
+    spinner = Spinner("dots", text=f"  Installing osprey ({osprey_label}) + {dep_count} deps...")
     with Live(spinner, transient=True):
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
 
@@ -906,7 +946,7 @@ def _create_project_venv(project_path: Path, profile: Any) -> None:
 
     # --- Record deps in requirements.txt for documentation ---
     req_path = project_path / "requirements.txt"
-    lines = ["\n", f"# osprey ({osprey_install})\n", f"{osprey_spec}\n"]
+    lines = ["\n", f"# osprey ({osprey_label})\n", f"{osprey_spec}\n"]
     if profile.dependencies:
         lines.append("\n# Profile dependencies\n")
         for dep in profile.dependencies:

--- a/src/osprey/cli/build_profile.py
+++ b/src/osprey/cli/build_profile.py
@@ -179,7 +179,10 @@ class BuildProfile:
     dependencies: list[str] = field(default_factory=list)
     requires_osprey_version: str | None = None  # PEP 440 specifier, e.g. ">=0.12.0"
     osprey_install: str = (
-        "local"  # "local" | "pip" | PEP 508 spec (e.g. "osprey-framework==2026.5.0")
+        # "local" (auto-detect from importlib.metadata: editable → source tree,
+        # otherwise pin to running version) | "pip" | PEP 508 spec
+        # (e.g. "osprey-framework==2026.5.0")
+        "local"
     )
     python_env: str = "project"  # "project" | "build" | absolute path to Python executable
     hooks: list[str] = field(default_factory=list)

--- a/tests/cli/test_build_cmd.py
+++ b/tests/cli/test_build_cmd.py
@@ -823,6 +823,104 @@ class TestCreateProjectVenv:
 
 
 # ---------------------------------------------------------------------------
+# Osprey install spec resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveOspreySpec:
+    """Tests for _resolve_osprey_spec() — auto-detect install mode from metadata.
+
+    Regression coverage for issue #216: building from a non-editable install
+    (e.g., ``uv tool install osprey-framework``) used to error with
+    "no pyproject.toml at <python lib>" because the resolver walked
+    ``Path(__file__).parents[3]`` instead of consulting package metadata.
+    """
+
+    def _fake_dist(
+        self,
+        version: str = "2026.5.0",
+        direct_url: dict | None = None,
+    ):
+        class _Dist:
+            def __init__(self, ver, du):
+                self.version = ver
+                self._du = du
+
+            def read_text(self, name):
+                if name == "direct_url.json" and self._du is not None:
+                    return json.dumps(self._du)
+                return None
+
+        return _Dist(version, direct_url)
+
+    def test_editable_install_uses_source_path(self, monkeypatch):
+        """Editable install (``pip install -e .``) → spec is the source dir."""
+        from osprey.cli.build_cmd import _resolve_osprey_spec
+
+        fake = self._fake_dist(
+            direct_url={"url": "file:///abs/path/to/osprey", "dir_info": {"editable": True}},
+        )
+        monkeypatch.setattr("osprey.cli.build_cmd.distribution", lambda _name: fake)
+
+        spec, label = _resolve_osprey_spec("local")
+        assert spec == "/abs/path/to/osprey"
+        assert "editable" in label
+
+    def test_wheel_install_pins_to_version(self, monkeypatch):
+        """uv tool / pip wheel install → pinned to ``osprey-framework==<version>``."""
+        from osprey.cli.build_cmd import _resolve_osprey_spec
+
+        fake = self._fake_dist(
+            version="2026.5.0",
+            direct_url={"url": "https://pypi/...", "archive_info": {"hash": "sha256=abc"}},
+        )
+        monkeypatch.setattr("osprey.cli.build_cmd.distribution", lambda _name: fake)
+
+        spec, label = _resolve_osprey_spec("local")
+        assert spec == "osprey-framework==2026.5.0"
+        assert label == "osprey-framework==2026.5.0"
+
+    def test_wheel_install_without_direct_url_pins_to_version(self, monkeypatch):
+        """Older pip wheel install (no direct_url.json) → still pinned to version."""
+        from osprey.cli.build_cmd import _resolve_osprey_spec
+
+        fake = self._fake_dist(version="2026.5.0", direct_url=None)
+        monkeypatch.setattr("osprey.cli.build_cmd.distribution", lambda _name: fake)
+
+        spec, _label = _resolve_osprey_spec("local")
+        assert spec == "osprey-framework==2026.5.0"
+
+    def test_pip_keyword_uses_unpinned_pypi(self, monkeypatch):
+        """Explicit ``osprey_install: pip`` → unpinned ``osprey-framework``."""
+        from osprey.cli.build_cmd import _resolve_osprey_spec
+
+        spec, _label = _resolve_osprey_spec("pip")
+        assert spec == "osprey-framework"
+
+    def test_pep508_spec_passthrough(self):
+        """Explicit PEP 508 spec → passed through verbatim."""
+        from osprey.cli.build_cmd import _resolve_osprey_spec
+
+        spec, label = _resolve_osprey_spec("osprey-framework==2026.4.0")
+        assert spec == "osprey-framework==2026.4.0"
+        assert label == "osprey-framework==2026.4.0"
+
+    def test_metadata_missing_falls_back_to_source_tree(self, monkeypatch, tmp_path):
+        """If metadata is unavailable but a source tree exists at parents[3], use it."""
+        from importlib.metadata import PackageNotFoundError
+
+        from osprey.cli import build_cmd
+
+        def _missing(_name):
+            raise PackageNotFoundError
+
+        monkeypatch.setattr(build_cmd, "distribution", _missing)
+        # Real build_cmd.py is in a source checkout (pyproject.toml at parents[3]).
+        spec, _label = build_cmd._resolve_osprey_spec("local")
+        assert (Path(spec) / "pyproject.toml").exists()
+
+
+# ---------------------------------------------------------------------------
 # CLI Integration
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Fixes #216 — `osprey build` errored with `osprey_install: local — but no pyproject.toml at <python lib>` after `uv tool install osprey-framework`, breaking the recommended quickstart.
- Resolution now consults `importlib.metadata` + PEP 610 `direct_url.json` instead of walking `Path(__file__).parents[3]`. Editable installs (`pip install -e`, `uv sync`) use the source tree; wheel/uv-tool installs pin the project venv to `osprey-framework==<running version>`.
- Field semantics: `osprey_install: local` is now "auto-detect from package metadata." Existing profiles need no changes.

## Why the old code failed
`Path(__file__).resolve().parents[3]` lands on the repo root `<repo>/` only in source-checkout layouts. For `uv tool install osprey-framework`, `__file__` is at `~/.local/share/uv/tools/osprey-framework/lib/python3.11/site-packages/osprey/cli/build_cmd.py`, so `parents[3]` is `…/lib/python3.11` — a real directory with no `pyproject.toml`, hence the error. Every user following the README/docs hit this on their first build.

## Test plan
- [x] New `TestResolveOspreySpec` class — 6 cases covering editable, wheel-with-archive_info, wheel-without-direct_url, `pip` keyword, PEP 508 passthrough, metadata-missing fallback. All pass.
- [x] Existing 74 tests in `tests/cli/test_build_cmd.py` — still pass.
- [x] Full unit suite (`pytest tests/ --ignore=tests/e2e`) — 3754 passed, 108 skipped (skips are docker-only, pre-existing).
- [x] `ruff check` / `ruff format --check` — clean.
- [ ] Manual repro on a fresh `uv tool install osprey-framework` install (requested from reporter).