### PR TITLE
Correct minor typo in the documentation

### DIFF
--- a/docs/source/architecture/mcp-servers.rst
+++ b/docs/source/architecture/mcp-servers.rst
@@ -31,7 +31,7 @@ safety-limits enforcement on all write operations.
 Channel Finding
 ---------------
 
-OSPREY provides four channel finder variants, each suited to different
+OSPREY provides three channel finder variants, each suited to different
 facility data models and search strategies. Deployments typically enable
 one or two variants depending on available metadata.
 


### PR DESCRIPTION
My understanding is that there are only 3 (not 4) variants of the channel finder:
- channel_finder_hierarchical
- channel_finder_in_context
- channel_finder_middle_layer