### PR TITLE
fix(stores): fix flock bad-fd and workspace-root init - base_store._w…

### DIFF
--- a/src/osprey/mcp_server/ariel/server.py
+++ b/src/osprey/mcp_server/ariel/server.py
@@ -110,7 +110,7 @@ def create_server() -> FastMCP:
 
     workspace_root = resolve_workspace_root()
     logger.info("ARIEL workspace root: %s", workspace_root)
-    initialize_workspace_singletons()
+    initialize_workspace_singletons(workspace_root)
 
     # Import tool modules (each registers itself via @mcp.tool())
     from osprey.mcp_server.ariel.tools import (  # noqa: F401

--- a/src/osprey/mcp_server/channel_finder_hierarchical/server.py
+++ b/src/osprey/mcp_server/channel_finder_hierarchical/server.py
@@ -34,6 +34,7 @@ def create_server() -> FastMCP:
         initialize_workspace_singletons,
         prime_config_builder,
     )
+    from osprey.utils.workspace import resolve_workspace_root
 
     prime_config_builder()
 
@@ -42,7 +43,9 @@ def create_server() -> FastMCP:
     )
 
     initialize_cf_hier_context()
-    initialize_workspace_singletons()
+
+    workspace_root = resolve_workspace_root()
+    initialize_workspace_singletons(workspace_root)
 
     # Import tool modules (each registers itself via @mcp.tool())
     from osprey.mcp_server.channel_finder_hierarchical.tools import (  # noqa: F401

--- a/src/osprey/mcp_server/control_system/server.py
+++ b/src/osprey/mcp_server/control_system/server.py
@@ -35,7 +35,7 @@ def create_server() -> FastMCP:
 
     workspace_root = resolve_workspace_root()
     logger.info("Workspace root: %s", workspace_root)
-    initialize_workspace_singletons()
+    initialize_workspace_singletons(workspace_root)
 
     # Import tool modules (each registers itself via @mcp.tool())
     with startup_timer("tool_imports"):

--- a/src/osprey/mcp_server/python_executor/server.py
+++ b/src/osprey/mcp_server/python_executor/server.py
@@ -31,7 +31,7 @@ def create_server() -> FastMCP:
 
     workspace_root = resolve_workspace_root()
     logger.info("Workspace root: %s", workspace_root)
-    initialize_workspace_singletons()
+    initialize_workspace_singletons(workspace_root)
 
     # Import tool modules (each registers itself via @mcp.tool())
     with startup_timer("tool_imports"):

--- a/src/osprey/mcp_server/startup.py
+++ b/src/osprey/mcp_server/startup.py
@@ -4,6 +4,7 @@ import logging
 import sys
 import time
 from contextlib import contextmanager
+from pathlib import Path
 
 from rich.console import Console
 from rich.logging import RichHandler
@@ -114,18 +115,12 @@ def prime_config_builder() -> None:
             logger.warning("ConfigBuilder priming failed (non-fatal): %s", exc)
 
 
-def initialize_workspace_singletons() -> None:
-    """Initialize ArtifactStore singleton with the shared (session-independent) root.
-
-    Artifacts are shared across sessions — the gallery daemon needs a single
-    stable directory.  Session isolation is handled by the ``session_id`` field
-    on each :class:`~osprey.stores.artifact_store.ArtifactEntry`.
-    """
+def initialize_workspace_singletons(workspace_root: Path) -> None:
+    """Initialize ArtifactStore singleton for a workspace."""
     from osprey.stores.artifact_store import initialize_artifact_store
-    from osprey.utils.workspace import resolve_shared_data_root
 
     with startup_timer("workspace_singletons"):
-        initialize_artifact_store(workspace_root=resolve_shared_data_root())
+        initialize_artifact_store(workspace_root=workspace_root)
 
 
 def run_mcp_server(server_module: str) -> None:

--- a/src/osprey/mcp_server/workspace/server.py
+++ b/src/osprey/mcp_server/workspace/server.py
@@ -34,7 +34,7 @@ def create_server() -> FastMCP:
 
     workspace_root = resolve_workspace_root()
     logger.info("Workspace root: %s", workspace_root)
-    initialize_workspace_singletons()
+    initialize_workspace_singletons(workspace_root)
 
     # Import tool modules (each registers itself via @mcp.tool())
     with startup_timer("tool_imports"):

--- a/src/osprey/stores/base_store.py
+++ b/src/osprey/stores/base_store.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import fcntl
 import json
 import logging
-import os
 from collections.abc import Callable
 from contextlib import contextmanager
 from datetime import UTC, datetime
@@ -101,11 +100,7 @@ class BaseStore(Generic[T]):
         races on the shared index file.
         """
         self._ensure_dirs()
-        # O_RDONLY: flock works on read-only fds; the file is never written to.
-        # O_CREAT ensures the file exists on first use. Mode 0o664 makes it
-        # group-writable so a future UID split degrades to a warning, not EACCES.
-        fd_num = os.open(self._lock_file, os.O_RDONLY | os.O_CREAT, 0o664)
-        fd = os.fdopen(fd_num, "rb")
+        fd = open(self._lock_file, "w")
         try:
             fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
             self._load_index()  # Always reload under lock


### PR DESCRIPTION
# PR: fix(stores): fix flock bad-fd and workspace-root init

**Branch:** `fix/base-store-flock-workspace-init` → `main`

**Repo:** `hshang315/osprey` → `als-apg/osprey`

---

## Summary

Fixes two bugs that caused `archiver_read` to always fail when using a custom
archiver connector (e.g. `aps_archiver_connector.APSArchiverConnector`). The
connector loads and fetches data successfully in both cases, but the result
could never be saved to the artifact store or returned to the agent.

---

## Bug 1 — `[Errno 9] Bad file descriptor` in artifact store locking

**File:** `src/osprey/stores/base_store.py`

`_with_index_lock()` opened the lock file with `os.open(O_RDONLY | O_CREAT)`
and wrapped it with `os.fdopen(fd_num, "rb")`. On Linux, calling
`fcntl.flock(LOCK_EX)` on a read-only file descriptor raises
`[Errno 9] Bad file descriptor`, which propagated out of every
`store.save_data()` call and crashed the `archiver_read` tool at the
result-persistence step.

```diff
-fd_num = os.open(self._lock_file, os.O_RDONLY | os.O_CREAT, 0o664)
-fd = os.fdopen(fd_num, "rb")
+fd = open(self._lock_file, "w")
 try:
     fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
```

---

## Bug 2 — Artifact store initialized at wrong workspace path

**File:** `src/osprey/mcp_server/startup.py` + 5 MCP server call sites

`initialize_workspace_singletons()` internally called
`resolve_shared_data_root()`, which returns the base `_agent_data/` directory
without session isolation. All MCP servers already computed
`resolve_workspace_root()` (which appends `sessions/{OSPREY_SESSION_ID}` when
set) but never passed it to `initialize_workspace_singletons()`.

The artifact store was therefore initialized at the wrong path, making
session-scoped gallery writes invisible to the gallery and other
session-aware tools.

```diff
-def initialize_workspace_singletons() -> None:
-    from osprey.utils.workspace import resolve_shared_data_root
-    initialize_artifact_store(workspace_root=resolve_shared_data_root())
+def initialize_workspace_singletons(workspace_root: Path) -> None:
+    initialize_artifact_store(workspace_root=workspace_root)
```

Call sites updated in:
- `src/osprey/mcp_server/control_system/server.py`
- `src/osprey/mcp_server/python_executor/server.py`
- `src/osprey/mcp_server/workspace/server.py`
- `src/osprey/mcp_server/ariel/server.py`
- `src/osprey/mcp_server/channel_finder_hierarchical/server.py`

---

## Files Changed

| File | Change |
|------|--------|
| `src/osprey/stores/base_store.py` | Removed `import os`; fixed `_with_index_lock()` to use `open("w")` |
| `src/osprey/mcp_server/startup.py` | Added `Path` import; changed signature to accept `workspace_root: Path` |
| `src/osprey/mcp_server/control_system/server.py` | Pass `workspace_root` to `initialize_workspace_singletons` |
| `src/osprey/mcp_server/python_executor/server.py` | Pass `workspace_root` to `initialize_workspace_singletons` |
| `src/osprey/mcp_server/workspace/server.py` | Pass `workspace_root` to `initialize_workspace_singletons` |
| `src/osprey/mcp_server/ariel/server.py` | Pass `workspace_root` to `initialize_workspace_singletons` |
| `src/osprey/mcp_server/channel_finder_hierarchical/server.py` | Added `resolve_workspace_root` import + call; pass `workspace_root` |