### PR TITLE
feat(cli): pin Claude Code CLI version per project (#218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Added
 
+- Pin Claude Code CLI version per project. New `claude_code.cli_version` config field; when set, OSPREY launches via `npx -y @anthropic-ai/claude-code@<version>` instead of bare `claude`. Use to insulate projects from upstream CC breakage (#218). Verified by `osprey health`; bypass with `osprey claude chat --no-pin`.
+
 ### Changed
 
 ### Fixed

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -73,6 +73,26 @@ Verify:
    claude --version
 
 
+Pinning the Claude Code CLI version
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Anthropic ships breaking changes to the Claude Code CLI from time to time. To
+insulate a project from upstream releases, pin a specific version in the
+project's ``config.yml``:
+
+.. code-block:: yaml
+
+   claude_code:
+     cli_version: "2.1.146"   # exact version, no semver ranges
+
+When set, ``osprey claude chat`` and the web terminal launch the pinned
+version via ``npx -y @anthropic-ai/claude-code@<version>`` instead of the
+globally-installed ``claude`` binary. The first run downloads the package;
+subsequent runs hit the npx cache. Use ``osprey health`` to confirm the pin
+is being honored. To temporarily bypass the pin for debugging, run
+``osprey claude chat --no-pin``.
+
+
 Step 3: Install Python tools
 ------------------------------
 

--- a/src/osprey/cli/claude_cmd.py
+++ b/src/osprey/cli/claude_cmd.py
@@ -16,6 +16,7 @@ import click
 import yaml
 
 from osprey.cli.styles import console
+from osprey.utils.claude_launcher import build_claude_launch_argv
 
 
 def get_claude_skills_dir() -> Path:
@@ -358,7 +359,12 @@ def status(project):
     default=None,
     help="Claude Code effort level",
 )
-def chat_claude(project, resume, print_mode, effort):
+@click.option(
+    "--no-pin",
+    is_flag=True,
+    help="Ignore claude_code.cli_version and launch the globally-installed `claude` binary",
+)
+def chat_claude(project, resume, print_mode, effort, no_pin):
     """Launch Claude Code with regenerated artifacts.
 
     Regenerates Claude Code integration files from config.yml,
@@ -400,6 +406,7 @@ def chat_claude(project, resume, print_mode, effort):
     )
 
     config_path = project_dir / "config.yml"
+    cc_config: dict = {}
     if config_path.exists():
         config = yaml.safe_load(config_path.read_text()) or {}
         cc_config = config.get("claude_code", {})
@@ -432,8 +439,11 @@ def chat_claude(project, resume, print_mode, effort):
                     f"[dim]Translation proxy started on :{proxy_port} → {spec.upstream_base_url}[/dim]"
                 )
 
-    # Build claude CLI args (claude uses cwd as project root — no --project-dir flag)
-    args = ["claude"]
+    # Build claude CLI args (claude uses cwd as project root — no --project-dir flag).
+    # When claude_code.cli_version is set, build_claude_launch_argv() returns an
+    # ``npx -y @anthropic-ai/claude-code@<v>`` prefix instead of bare ``claude``
+    # so each project can pin the CLI version (issue #218). ``--no-pin`` opts out.
+    args = ["claude"] if no_pin else build_claude_launch_argv(cc_config)
     if resume:
         args.extend(["--resume", resume])
     if print_mode:

--- a/src/osprey/cli/health_cmd.py
+++ b/src/osprey/cli/health_cmd.py
@@ -93,6 +93,7 @@ class HealthChecker:
 
         self.check_containers()
         self.check_api_providers()
+        self.check_claude_cli_version()
 
         if self.full:
             self.check_model_chat_completions()
@@ -103,6 +104,103 @@ class HealthChecker:
         # Return overall status
         errors = sum(1 for r in self.results if r.status == "error")
         return errors == 0
+
+    def check_claude_cli_version(self):
+        """Verify the Claude Code CLI is available, honoring claude_code.cli_version pin.
+
+        When ``claude_code.cli_version`` is set, runs
+        ``npx -y @anthropic-ai/claude-code@<version> --version`` with a 60s
+        timeout (first-run download budget) and warns if the reported version
+        does not match the pin. Otherwise reports the globally-installed
+        ``claude`` version as informational. See issue #218.
+        """
+        from osprey.utils.claude_launcher import parse_claude_version
+
+        console.print("\n[bold]Claude Code CLI[/bold]")
+
+        cc_config = self.config.get("claude_code", {}) or {}
+        pinned = cc_config.get("cli_version")
+
+        if pinned:
+            argv = ["npx", "-y", f"@anthropic-ai/claude-code@{pinned}", "--version"]
+            try:
+                result = subprocess.run(argv, capture_output=True, text=True, timeout=60)
+            except FileNotFoundError:
+                self.add_result(
+                    "claude_cli_version",
+                    "error",
+                    "npx not found in PATH",
+                    "Install Node.js (which ships npx) to use claude_code.cli_version pinning.",
+                )
+                console.print(f"  {Messages.error('✗ npx not found — install Node.js')}")
+                return
+            except subprocess.TimeoutExpired:
+                self.add_result(
+                    "claude_cli_version",
+                    "error",
+                    f"npx timed out fetching @anthropic-ai/claude-code@{pinned} (60s)",
+                    "Check network connectivity to the npm registry.",
+                )
+                console.print(f"  {Messages.error('✗ npx download timed out')}")
+                return
+
+            if result.returncode != 0:
+                self.add_result(
+                    "claude_cli_version",
+                    "error",
+                    f"npx failed for @anthropic-ai/claude-code@{pinned}",
+                    result.stderr.strip() or "no stderr output",
+                )
+                console.print(f"  {Messages.error('✗ npx invocation failed')}")
+                return
+
+            detected = parse_claude_version(result.stdout)
+            if detected == pinned:
+                self.add_result("claude_cli_version", "ok", f"Pinned Claude Code CLI {pinned}")
+                console.print(f"  {Messages.success(f'Pinned: {pinned}')}")
+            else:
+                shown = detected or "unknown"
+                self.add_result(
+                    "claude_cli_version",
+                    "warning",
+                    f"Pinned {pinned} but npx reported {shown}",
+                    f"raw --version output: {result.stdout.strip()!r}",
+                )
+                console.print(f"  {Messages.warning(f' Pin {pinned} != detected {shown}')}")
+            return
+
+        # Unpinned: report globally-installed claude version as informational.
+        try:
+            result = subprocess.run(
+                ["claude", "--version"], capture_output=True, text=True, timeout=5
+            )
+        except FileNotFoundError:
+            self.add_result(
+                "claude_cli_version",
+                "warning",
+                "`claude` not found in PATH",
+                "Install with `npm install -g @anthropic-ai/claude-code` or "
+                "pin via claude_code.cli_version in config.yml.",
+            )
+            console.print(f"  {Messages.warning(' `claude` not installed')}")
+            return
+        except subprocess.TimeoutExpired:
+            self.add_result("claude_cli_version", "warning", "`claude --version` timed out (5s)")
+            console.print(f"  {Messages.warning(' `claude --version` timed out')}")
+            return
+
+        detected = parse_claude_version(result.stdout) if result.returncode == 0 else None
+        if detected:
+            self.add_result("claude_cli_version", "ok", f"Claude Code CLI {detected}")
+            console.print(f"  {Messages.success(f'Detected: {detected}')}")
+        else:
+            self.add_result(
+                "claude_cli_version",
+                "warning",
+                "Could not parse `claude --version` output",
+                f"stdout={result.stdout.strip()!r} stderr={result.stderr.strip()!r}",
+            )
+            console.print(f"  {Messages.warning(' Could not detect Claude Code version')}")
 
     def _check_timezone(self):
         """Check if timezone is configured (not left as UTC default)."""

--- a/src/osprey/cli/web_cmd.py
+++ b/src/osprey/cli/web_cmd.py
@@ -153,19 +153,37 @@ def web(
     _preflight_vendor_check()
 
     wt_config = get_config_value("web_terminal", {})
+    cc_config = get_config_value("claude_code", {})
     host = host or wt_config.get("host", "127.0.0.1")
     port = port or wt_config.get("port", 8087)
+
+    from osprey.utils.claude_launcher import build_claude_launch_argv
     from osprey.utils.shell_resolver import resolve_shell_command
 
-    shell_raw = shell or wt_config.get("shell") or "claude"
+    # Shell-command precedence (highest first):
+    #   1. --shell CLI flag (user-explicit; defeats the pin)
+    #   2. web_terminal.shell config field (also defeats the pin)
+    #   3. claude_code.cli_version pin via build_claude_launch_argv()
+    #   4. bare ["claude"] (current default)
+    # Always normalized to list[str] so downstream consumers can unpack safely.
+    user_shell_override = shell  # keep raw click value for the detached re-spawn
     try:
-        shell = resolve_shell_command(shell_raw)
+        if user_shell_override:
+            shell_command: list[str] = [resolve_shell_command(user_shell_override)]
+        elif wt_config.get("shell"):
+            shell_command = [resolve_shell_command(wt_config["shell"])]
+        else:
+            argv = build_claude_launch_argv(cc_config)
+            if len(argv) == 1:  # no-pin: preserve absolute-path parity with today
+                shell_command = [resolve_shell_command(argv[0])]
+            else:
+                shell_command = argv  # pinned ["npx", "-y", ...] — leave to PATH lookup
     except FileNotFoundError as e:
         click.echo(f"ERROR: {e}", err=True)
         raise SystemExit(1) from e
 
     if detach:
-        _start_detached(host, port, shell, project)
+        _start_detached(host, port, user_shell_override, project)
         return
 
     # -- foreground (original behavior) ------------------------------------
@@ -185,7 +203,7 @@ def web(
             raise SystemExit(1) from exc
 
     click.echo(f"Starting OSPREY Web Terminal on http://{host}:{port}")
-    click.echo(f"Shell: {shell}")
+    click.echo(f"Shell: {' '.join(shell_command)}")
     click.echo("Press Ctrl+C to stop\n")
 
     # Load .env so secrets (e.g. CONFLUENCE_ACCESS_TOKEN) are available
@@ -212,13 +230,20 @@ def web(
         else:
             from osprey.interfaces.web_terminal import run_web
 
-            run_web(host=host, port=port, shell_command=shell, project_dir=project)
+            run_web(host=host, port=port, shell_command=shell_command, project_dir=project)
     except KeyboardInterrupt:
         click.echo("\nShutting down...")
 
 
 def _start_detached(host: str, port: int, shell: str | None, project: str | None) -> None:
-    """Spawn the web server as a background process."""
+    """Spawn the web server as a background process.
+
+    ``shell`` is the raw user ``--shell`` flag (or None), NOT the resolved argv.
+    The child re-derives the shell-command precedence so any ``claude_code.cli_version``
+    pin remains honored from config; if we forwarded a resolved/pinned argv here,
+    it would re-enter ``resolve_shell_command()`` in the child and fail for
+    multi-word forms like ``npx -y @anthropic-ai/claude-code@<v>``.
+    """
     project_dir = Path(project).resolve() if project else Path.cwd()
 
     # Idempotent: if already running, just report

--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -199,21 +199,58 @@ def _load_web_config(config_path: str | Path | None = None) -> dict:
     return {}
 
 
+def _load_claude_code_config(config_path: str | Path | None = None) -> dict:
+    """Load claude_code config section from config.yml.
+
+    Mirrors :func:`_load_web_config` so the lifespan can derive the Claude
+    Code launch argv (honoring ``claude_code.cli_version`` pins) even when
+    no explicit ``shell_command`` was passed — e.g. under ``uvicorn --reload``
+    where ``create_app`` is called with no arguments.
+    """
+    config_paths = [
+        Path(config_path) if config_path else None,
+        Path(os.environ.get("CONFIG_FILE", "")) if os.environ.get("CONFIG_FILE") else None,
+        Path("config.yml"),
+    ]
+
+    for path in config_paths:
+        if path and path.exists() and path.is_file():
+            with open(path) as f:
+                config = yaml.safe_load(f) or {}
+            return config.get("claude_code", {})
+
+    return {}
+
+
 def _create_lifespan(
     config_path: str | Path | None = None,
-    shell_command: str = "claude",
+    shell_command: list[str] | None = None,
     project_dir: str | Path | None = None,
 ):
     """Create a lifespan context manager for the app."""
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        from osprey.utils.claude_launcher import build_claude_launch_argv
+
         config = _load_web_config(config_path)
 
         import uuid
 
         app.state.server_session_id = uuid.uuid4().hex[:12]
-        app.state.shell_command = shell_command or config.get("shell") or "claude"
+        # Shell-command precedence — always normalized to list[str] so every
+        # downstream consumer (websocket initial spawn + switch_session) can
+        # safely unpack with [*base, ...]. The pin lookup lets --reload mode
+        # honor claude_code.cli_version even though uvicorn's factory bypass
+        # never lets web_cmd.py inject the argv.
+        if shell_command:
+            app.state.shell_command = list(shell_command)
+        elif config.get("shell"):
+            app.state.shell_command = [str(config["shell"])]
+        else:
+            app.state.shell_command = build_claude_launch_argv(
+                _load_claude_code_config(config_path)
+            )
         max_bg = int(config.get("max_background_sessions", 5))
         app.state.pty_registry = PtyRegistry(max_background=max_bg)
         app.state.operator_registry = OperatorRegistry()
@@ -331,7 +368,7 @@ def _create_lifespan(
 
 def create_app(
     config_path: str | Path | None = None,
-    shell_command: str = "claude",
+    shell_command: list[str] | None = None,
     project_dir: str | Path | None = None,
 ) -> FastAPI:
     """Create the Web Terminal FastAPI application.
@@ -409,7 +446,7 @@ def _open_browser_when_ready(url: str, timeout: float = 15.0) -> None:
 def run_web(
     host: str = "127.0.0.1",
     port: int = 8087,
-    shell_command: str = "claude",
+    shell_command: list[str] | None = None,
     config_path: str | None = None,
     project_dir: str | None = None,
 ) -> None:

--- a/src/osprey/interfaces/web_terminal/routes/websocket.py
+++ b/src/osprey/interfaces/web_terminal/routes/websocket.py
@@ -117,12 +117,14 @@ async def terminal_ws(websocket: WebSocket):
 
     effort = _read_effort_level(websocket.app.state.config_path)
 
-    # Build the command and determine the initial session key
+    # Build the command and determine the initial session key.
+    # base_shell_command is list[str] (set by app.lifespan), so unpack with
+    # [*base, ...] — nesting would break PtySession's exec (issue #218).
     if mode == "resume" and req_session_id:
-        command: str | list[str] = [base_shell_command, "--resume", req_session_id]
+        command: list[str] = [*base_shell_command, "--resume", req_session_id]
         claude_session_id: str | None = req_session_id
     else:
-        command = [base_shell_command]
+        command = [*base_shell_command]
         claude_session_id = None
 
     if effort:
@@ -235,9 +237,11 @@ async def terminal_ws(websocket: WebSocket):
                             # 2. Detach current session (stays alive in pool)
                             registry.detach_session(current_key)
 
-                            # 3. Build command for target
-                            target_cmd: str | list[str] = [
-                                base_shell_command,
+                            # 3. Build command for target — unpack base_shell_command
+                            #    (list[str]) so a pinned ["npx", "-y", "..."] prefix
+                            #    flattens into target_cmd rather than nesting.
+                            target_cmd: list[str] = [
+                                *base_shell_command,
                                 "--resume",
                                 target_id,
                             ]

--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -136,6 +136,14 @@ control_system:
 # Agents are auto-managed based on config and are not listed here.
 
 claude_code:
+  # ── CLI Version Pin (issue #218) ──────────────────────────
+  # Pin the Claude Code CLI version to insulate this project from upstream
+  # breaking releases. When set, `osprey claude chat` and `osprey web` launch
+  # via `npx -y @anthropic-ai/claude-code@<version>` instead of bare `claude`.
+  # First run downloads the package; subsequent runs hit the npx cache.
+  # Verify with `osprey health` after setting.
+  # cli_version: "2.1.146"
+  #
   # ── Server / Agent Overrides ──────────────────────────────
   # Disable framework servers or add custom MCP servers:
   # servers:

--- a/src/osprey/utils/claude_launcher.py
+++ b/src/osprey/utils/claude_launcher.py
@@ -1,0 +1,48 @@
+"""Build argv prefixes for invoking the Claude Code CLI.
+
+OSPREY projects can pin a specific Claude Code CLI version via the
+``claude_code.cli_version`` config field. When set, OSPREY launches Claude
+through ``npx`` rather than the user's global install, insulating projects
+from upstream CC releases that break compatibility (see issue #218).
+"""
+
+from __future__ import annotations
+
+import re
+
+_VERSION_RE = re.compile(r"\b(\d+\.\d+\.\d+(?:[-+.][0-9A-Za-z.-]+)?)\b")
+
+
+def build_claude_launch_argv(cc_config: dict) -> list[str]:
+    """Return the argv prefix used to launch Claude Code.
+
+    Args:
+        cc_config: The ``claude_code`` block from ``config.yml`` (may be empty).
+
+    Returns:
+        ``["claude"]`` when no version is pinned, otherwise
+        ``["npx", "-y", "@anthropic-ai/claude-code@<version>"]``.
+
+    Raises:
+        ValueError: If ``cli_version`` is present but empty/whitespace.
+    """
+    cli_version = cc_config.get("cli_version")
+    if cli_version is None:
+        return ["claude"]
+    if not isinstance(cli_version, str) or not cli_version.strip():
+        raise ValueError(
+            "claude_code.cli_version must be a non-empty string "
+            '(e.g. "2.1.146"); got an empty value.'
+        )
+    return ["npx", "-y", f"@anthropic-ai/claude-code@{cli_version.strip()}"]
+
+
+def parse_claude_version(version_output: str) -> str | None:
+    """Extract a semver string from ``claude --version`` output.
+
+    Returns ``None`` if no recognisable version token is present.
+    """
+    if not version_output:
+        return None
+    match = _VERSION_RE.search(version_output)
+    return match.group(1) if match else None

--- a/tests/cli/test_claude_cmd.py
+++ b/tests/cli/test_claude_cmd.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
+import yaml
 from click.testing import CliRunner
 
 from osprey.cli.claude_cmd import (
@@ -242,6 +243,55 @@ class TestClaudeChatCommand:
         mock_servers.assert_called_once()
         assert "Artifact gallery" in result.output
         assert "http://127.0.0.1:8086" in result.output
+
+    @patch("osprey.cli.claude_cmd._launch_companion_servers", return_value=[])
+    @patch("subprocess.run", return_value=Mock(returncode=0))
+    def test_chat_uses_cli_version_pin_when_set(self, mock_run, mock_servers, cli_runner, tmp_path):
+        """Pinned claude_code.cli_version launches via npx instead of bare claude."""
+        from osprey.cli.templates.manager import TemplateManager
+
+        manager = TemplateManager()
+        project_dir = manager.create_project(
+            project_name="chat-pin-test",
+            output_dir=tmp_path,
+            data_bundle="control_assistant",
+            context={"channel_finder_mode": "hierarchical"},
+        )
+        config_path = project_dir / "config.yml"
+        config = yaml.safe_load(config_path.read_text()) or {}
+        config.setdefault("claude_code", {})["cli_version"] = "2.1.146"
+        config_path.write_text(yaml.safe_dump(config))
+
+        result = cli_runner.invoke(chat_claude, ["--project", str(project_dir)])
+
+        assert result.exit_code == 0
+        call_args = mock_run.call_args[0][0]
+        assert call_args[:3] == ["npx", "-y", "@anthropic-ai/claude-code@2.1.146"]
+
+    @patch("osprey.cli.claude_cmd._launch_companion_servers", return_value=[])
+    @patch("subprocess.run", return_value=Mock(returncode=0))
+    def test_chat_no_pin_flag_overrides_config(self, mock_run, mock_servers, cli_runner, tmp_path):
+        """--no-pin forces bare `claude` even when config sets cli_version."""
+        from osprey.cli.templates.manager import TemplateManager
+
+        manager = TemplateManager()
+        project_dir = manager.create_project(
+            project_name="chat-no-pin-test",
+            output_dir=tmp_path,
+            data_bundle="control_assistant",
+            context={"channel_finder_mode": "hierarchical"},
+        )
+        config_path = project_dir / "config.yml"
+        config = yaml.safe_load(config_path.read_text()) or {}
+        config.setdefault("claude_code", {})["cli_version"] = "2.1.146"
+        config_path.write_text(yaml.safe_dump(config))
+
+        result = cli_runner.invoke(chat_claude, ["--project", str(project_dir), "--no-pin"])
+
+        assert result.exit_code == 0
+        call_args = mock_run.call_args[0][0]
+        assert call_args[0] == "claude"
+        assert "npx" not in call_args
 
     @patch("osprey.cli.claude_cmd._launch_companion_servers", return_value=[])
     @patch("subprocess.run", return_value=Mock(returncode=0))

--- a/tests/cli/test_health_cmd.py
+++ b/tests/cli/test_health_cmd.py
@@ -489,6 +489,82 @@ class TestHealthCheckerTimezone:
         assert "Europe/Berlin" in tz_results[0].message
 
 
+class TestCheckClaudeCliVersion:
+    """Test the Claude Code CLI pin verification (issue #218)."""
+
+    def _run(self, checker):
+        with patch("osprey.cli.health_cmd.console"):
+            checker.check_claude_cli_version()
+        return [r for r in checker.results if r.name == "claude_cli_version"]
+
+    def test_unpinned_reports_detected_version(self):
+        """Without a pin, runs `claude --version` and reports detected version."""
+        checker = HealthChecker()
+        checker.config = {}
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(returncode=0, stdout="2.1.146 (Claude Code)\n", stderr="")
+            results = self._run(checker)
+
+        assert mock_run.call_args[0][0] == ["claude", "--version"]
+        assert len(results) == 1
+        assert results[0].status == "ok"
+        assert "2.1.146" in results[0].message
+
+    def test_pinned_match_reports_ok(self):
+        """Pinned version that matches what npx reports is ok."""
+        checker = HealthChecker()
+        checker.config = {"claude_code": {"cli_version": "2.1.146"}}
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(returncode=0, stdout="2.1.146\n", stderr="")
+            results = self._run(checker)
+
+        argv = mock_run.call_args[0][0]
+        assert argv[:3] == ["npx", "-y", "@anthropic-ai/claude-code@2.1.146"]
+        assert argv[-1] == "--version"
+        assert len(results) == 1
+        assert results[0].status == "ok"
+        assert "2.1.146" in results[0].message
+
+    def test_pinned_mismatch_reports_warning(self):
+        """Pin set to X but npx returns Y produces warning."""
+        checker = HealthChecker()
+        checker.config = {"claude_code": {"cli_version": "2.1.146"}}
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(returncode=0, stdout="2.1.999\n", stderr="")
+            results = self._run(checker)
+
+        assert len(results) == 1
+        assert results[0].status == "warning"
+        assert "2.1.146" in results[0].message
+        assert "2.1.999" in results[0].message
+
+    def test_pinned_npx_missing_reports_error(self):
+        """npx not installed produces an error result."""
+        checker = HealthChecker()
+        checker.config = {"claude_code": {"cli_version": "2.1.146"}}
+
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            results = self._run(checker)
+
+        assert len(results) == 1
+        assert results[0].status == "error"
+        assert "npx" in results[0].message.lower()
+
+    def test_unpinned_claude_missing_reports_warning(self):
+        """`claude` not installed and no pin → warning (not error)."""
+        checker = HealthChecker()
+        checker.config = {}
+
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            results = self._run(checker)
+
+        assert len(results) == 1
+        assert results[0].status == "warning"
+
+
 class TestHealthDisplayResults:
     """Test result display functionality."""
 

--- a/tests/utils/test_claude_launcher.py
+++ b/tests/utils/test_claude_launcher.py
@@ -1,0 +1,67 @@
+"""Tests for the Claude Code launcher argv builder.
+
+These tests verify that ``build_claude_launch_argv()`` produces the correct
+argv prefix for both the unpinned and pinned cases, and that
+``parse_claude_version()`` extracts semver from realistic CLI output.
+"""
+
+import pytest
+
+from osprey.utils.claude_launcher import build_claude_launch_argv, parse_claude_version
+
+
+class TestBuildClaudeLaunchArgv:
+    """Test argv construction from a ``claude_code`` config dict."""
+
+    def test_no_pin_returns_bare_claude(self):
+        assert build_claude_launch_argv({}) == ["claude"]
+
+    def test_unrelated_keys_do_not_trigger_pin(self):
+        cc_config = {"provider": "anthropic", "default_model": "haiku"}
+        assert build_claude_launch_argv(cc_config) == ["claude"]
+
+    def test_pinned_returns_npx_invocation(self):
+        assert build_claude_launch_argv({"cli_version": "2.1.146"}) == [
+            "npx",
+            "-y",
+            "@anthropic-ai/claude-code@2.1.146",
+        ]
+
+    def test_pinned_strips_whitespace(self):
+        assert build_claude_launch_argv({"cli_version": "  2.1.146  "}) == [
+            "npx",
+            "-y",
+            "@anthropic-ai/claude-code@2.1.146",
+        ]
+
+    def test_empty_string_pin_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            build_claude_launch_argv({"cli_version": ""})
+
+    def test_whitespace_only_pin_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            build_claude_launch_argv({"cli_version": "   "})
+
+    def test_non_string_pin_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            build_claude_launch_argv({"cli_version": 2.1})
+
+
+class TestParseClaudeVersion:
+    """Test extraction of semver from ``claude --version`` output."""
+
+    def test_extracts_simple_semver(self):
+        assert parse_claude_version("2.1.146") == "2.1.146"
+
+    def test_extracts_from_typical_cli_output(self):
+        # Typical output looks like "2.1.146 (Claude Code)"
+        assert parse_claude_version("2.1.146 (Claude Code)") == "2.1.146"
+
+    def test_extracts_from_verbose_prefix(self):
+        assert parse_claude_version("Claude Code version 2.1.146 on darwin") == "2.1.146"
+
+    def test_returns_none_for_garbage(self):
+        assert parse_claude_version("nope, no version here") is None
+
+    def test_returns_none_for_empty(self):
+        assert parse_claude_version("") is None

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-13T17:39:45.372821Z"
+exclude-newer = "2026-05-16T12:59:17.004753Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -3052,6 +3052,7 @@ all = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-order" },
     { name = "python-xlib" },
     { name = "ruff" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -3081,6 +3082,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-order" },
     { name = "ruff" },
     { name = "testcontainers" },
 ]
@@ -3175,6 +3177,8 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'all'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
+    { name = "pytest-order", marker = "extra == 'all'" },
+    { name = "pytest-order", marker = "extra == 'dev'" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "python-xlib", marker = "extra == 'all'", specifier = ">=0.33" },
     { name = "python-xlib", marker = "extra == 'screen-capture-linux'", specifier = ">=0.33" },
@@ -4042,6 +4046,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-order"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/76/c7b4a2ad3758a3c2757f532c6e931aa5e387781512a71b67b6ddc19d9ef8/pytest_order-1.4.0.tar.gz", hash = "sha256:327fb6eee1ae771051da13d2a0d9306d947e87f9ab8f4d6302e5d122c7472691", size = 49891, upload-time = "2026-04-26T12:37:43.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d0/c62c07141151f259faddff6bd591f28235c37dd0c486160d0d2a0d4e6e5a/pytest_order-1.4.0-py3-none-any.whl", hash = "sha256:05b1710cf16bb2123294eec5bdfaee513322ff1926c0dfa86eb8be632eb264a1", size = 14918, upload-time = "2026-04-26T12:37:41.123Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #218. Lets projects pin the Claude Code CLI version via a new `claude_code.cli_version` field in `config.yml` to insulate themselves from upstream CC releases that break compatibility.

When set, OSPREY launches via `npx -y @anthropic-ai/claude-code@<version>` instead of the globally-installed `claude` binary. First run downloads the package; subsequent runs hit the npx cache.

```yaml
claude_code:
  cli_version: "2.1.146"
```

Verified via `osprey health`; bypass for debugging with `osprey claude chat --no-pin`.

## Implementation

- `utils/claude_launcher.py` (new): `build_claude_launch_argv()` and `parse_claude_version()`
- `cli/claude_cmd.py`: `osprey claude chat` uses the launcher; new `--no-pin` flag
- `cli/web_cmd.py`: precedence chain `--shell > web_terminal.shell > pin > bare claude`; `shell_command` normalized to `list[str]`
- `interfaces/web_terminal/app.py`: lifespan re-derives the pin (so `uvicorn --reload`'s factory bypass still honors it)
- `interfaces/web_terminal/routes/websocket.py`: `[*base, ...]` unpack at both spawn sites
- `cli/health_cmd.py`: new `check_claude_cli_version()` with 60s npx / 5s claude timeouts
- `templates/project/config.yml.j2`, docs, CHANGELOG: documented

## Plan deviations worth flagging

1. **`cc_config` scope guard** in `chat_claude` — only defined inside `if config_path.exists()`; initialized to `{}` outside the block so the unpinned path works without a config.yml.
2. **`--reload` mode honors the pin** — `_load_claude_code_config` added to `app.py` and pin resolution moved into the lifespan, since uvicorn `factory=True` bypasses the CLI boundary entirely.
3. **`_start_detached` re-architecture** — forwards the raw user `--shell` flag, not the resolved argv. Re-entry through `resolve_shell_command()` in the child would fail for multi-token forms like `npx -y @anthropic-ai/claude-code@<v>`.

## Test plan

- [x] +19 unit tests added: 12 launcher, 2 `chat`, 5 health-check (all pass)
- [x] Full directly-affected suite: 437/437 pass (`tests/utils/test_claude_launcher.py` + `tests/cli/test_claude_cmd.py` + `tests/cli/test_health_cmd.py` + `tests/cli/test_web_cmd.py` + `tests/interfaces/web_terminal/`)
- [x] Full unit suite: 3947 pass, 107 skipped (locally; one unrelated cross-file flake in `test_artifact_store.py` — passes in isolation, will file separately)
- [x] `ruff check` and `ruff format --check` clean on all modified/new files
- [x] `mypy` clean on `claude_launcher.py` (other warnings pre-existing)
- [ ] E2E suite via CI on this PR
- [ ] Manual: `osprey claude chat` with a pinned version → confirm npx invocation
- [ ] Manual: `osprey web` with a pinned version + `--reload` → confirm pin honored in factory mode
- [ ] Manual: `osprey health` against pinned + unpinned configs

## Side note

`uv.lock` regeneration is in a separate prep commit (`chore(deps): regenerate uv.lock`) — locks `pytest-order` (declared in `pyproject.toml` since 7bb5f6f4 but never locked) and rolls `exclude-newer` forward. Unrelated to #218 but bundled into the same branch for convenience.