### PR TITLE
fix: store watcher race + stale __pycache__ phantom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- `BaseStore`: in-process lock fixes a lost-update race between the gallery index-watcher thread and same-process saves.
+- `quick_check.sh` / `ci_check.sh` prune stale `__pycache__` + empty dirs so a deleted package can't resurface as a namespace package locally.
+
 ### Removed
 
 ## [2026.5.1] - 2026-05-21

--- a/scripts/ci_check.sh
+++ b/scripts/ci_check.sh
@@ -53,6 +53,15 @@ echo "🧪 Step 2/4: Unit Tests"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 
+# Prune stale bytecode that can resurrect a deleted package as a PEP 420
+# namespace package locally (a dir left holding only __pycache__ still imports).
+# Drop the caches, then the now-empty dirs they kept alive. CI is unaffected —
+# a fresh checkout has no __pycache__ — but this keeps local runs matching CI.
+echo "→ Pruning stale bytecode caches..."
+find src/osprey -type d -name __pycache__ -prune -exec rm -rf {} + 2>/dev/null || true
+find src/osprey -type d -empty -delete 2>/dev/null || true
+echo ""
+
 echo "→ Running pytest with coverage..."
 if ! uv run pytest tests/ --ignore=tests/e2e -v --tb=short --cov=src/osprey --cov-report=xml --cov-report=term; then
     FAILED_CHECKS+=("pytest")

--- a/scripts/quick_check.sh
+++ b/scripts/quick_check.sh
@@ -12,6 +12,14 @@ echo "→ Auto-fixing code style..."
 uv run ruff check src/ tests/ --fix --quiet || true
 uv run ruff format src/ tests/ --quiet
 
+# Prune stale bytecode. After deleting a package's .py files, git leaves the
+# now-empty dir behind if untracked __pycache__/*.pyc remain — and Python imports
+# any non-empty dir as a PEP 420 namespace package, so "package removed" tests
+# fail locally only. Drop the caches, then the dirs they kept alive.
+echo "→ Pruning stale bytecode caches..."
+find src/osprey -type d -name __pycache__ -prune -exec rm -rf {} + 2>/dev/null || true
+find src/osprey -type d -empty -delete 2>/dev/null || true
+
 # Run fast tests only (stop on first failure for speed)
 echo "→ Running fast unit tests..."
 uv run pytest tests/ --ignore=tests/e2e -x --tb=line -q

--- a/src/osprey/stores/base_store.py
+++ b/src/osprey/stores/base_store.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import fcntl
 import json
 import logging
+import threading
 from collections.abc import Callable
 from contextlib import contextmanager
 from datetime import UTC, datetime
@@ -74,6 +75,11 @@ class BaseStore(Generic[T]):
         self._index_file = self._store_dir / self._index_filename
         self._entries: list[T] = []
         self._index_mtime: float = 0.0
+        # In-process reentrant lock guarding ``_entries`` reads/rebinds and
+        # saves. The file ``flock`` only serializes across processes; this lock
+        # prevents a background reload (e.g. StoreIndexWatcher) from swapping
+        # ``_entries`` out from under a same-process mutation.
+        self._thread_lock = threading.RLock()
         self._load_index()
 
     def _entry_from_dict(self, d: dict) -> T:
@@ -101,26 +107,31 @@ class BaseStore(Generic[T]):
         """
         self._ensure_dirs()
         fd = open(self._lock_file, "w")
-        try:
-            fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
-            self._load_index()  # Always reload under lock
-            yield
-        finally:
-            fd.close()  # Releases lock
+        # Hold the in-process lock across the whole critical section so a
+        # concurrent reload can't rebind ``_entries`` between the caller's
+        # mutation and its ``_save_index()``.
+        with self._thread_lock:
+            try:
+                fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
+                self._load_index()  # Always reload under lock
+                yield
+            finally:
+                fd.close()  # Releases lock
 
     def _load_index(self) -> None:
         """Load the index from disk, if present."""
-        if self._index_file.exists():
-            try:
-                self._index_mtime = self._index_file.stat().st_mtime
-                with open(self._index_file) as f:
-                    data = json.load(f)
-                self._entries = self._parse_index_data(data)
-                self._post_load_index()
-            except Exception:
-                logger.warning("Could not load %s index; starting fresh", self._store_name)
-                self._entries = []
-                self._post_load_index()
+        with self._thread_lock:
+            if self._index_file.exists():
+                try:
+                    self._index_mtime = self._index_file.stat().st_mtime
+                    with open(self._index_file) as f:
+                        data = json.load(f)
+                    self._entries = self._parse_index_data(data)
+                    self._post_load_index()
+                except Exception:
+                    logger.warning("Could not load %s index; starting fresh", self._store_name)
+                    self._entries = []
+                    self._post_load_index()
 
     def _parse_index_data(self, data: Any) -> list[T]:
         """Parse loaded JSON into entries.
@@ -135,21 +146,23 @@ class BaseStore(Generic[T]):
 
     def _refresh_if_stale(self) -> None:
         """Reload the index from disk if another process has updated it."""
-        try:
-            if self._index_file.exists():
-                mtime = self._index_file.stat().st_mtime
-                if mtime > self._index_mtime:
-                    self._load_index()
-        except OSError:
-            pass
+        with self._thread_lock:
+            try:
+                if self._index_file.exists():
+                    mtime = self._index_file.stat().st_mtime
+                    if mtime > self._index_mtime:
+                        self._load_index()
+            except OSError:
+                pass
 
     def _save_index(self) -> None:
         """Persist the index to disk."""
-        self._ensure_dirs()
-        index_data = self._build_index_data()
-        with open(self._index_file, "w") as f:
-            json.dump(_sanitize_for_json(index_data), f, indent=2, default=str)
-        self._index_mtime = self._index_file.stat().st_mtime
+        with self._thread_lock:
+            self._ensure_dirs()
+            index_data = self._build_index_data()
+            with open(self._index_file, "w") as f:
+                json.dump(_sanitize_for_json(index_data), f, indent=2, default=str)
+            self._index_mtime = self._index_file.stat().st_mtime
 
     def _build_index_data(self) -> dict:
         """Build the index dict for serialization.

--- a/tests/mcp_server/test_artifact_store.py
+++ b/tests/mcp_server/test_artifact_store.py
@@ -989,3 +989,68 @@ class TestServerLauncherRetry:
             launcher.ensure_running()
 
         assert any("health check failed" in r.message.lower() for r in caplog.records)
+
+
+class TestArtifactStoreConcurrency:
+    """Regression tests for cross-thread races on the shared in-memory index.
+
+    The Artifact Gallery runs a ``StoreIndexWatcher`` background thread that
+    calls ``store._load_index()`` whenever the on-disk index file changes. That
+    reload rebinds ``self._entries`` to a freshly parsed list. If it lands in the
+    middle of a same-process mutation (between mutating an entry and persisting
+    it), the mutation's ``_save_index()`` serializes the reloaded list and the
+    change is silently lost. The file ``flock`` only guards *cross-process*
+    access, so it does nothing here.
+    """
+
+    def test_concurrent_reload_does_not_clobber_pin(self, tmp_path):
+        """A reload firing mid-``set_pinned`` must not drop the pin.
+
+        Deterministically reproduces the watcher race: a worker thread is
+        released to call ``_load_index()`` exactly while the main thread is
+        between flipping ``pinned`` and writing the index. With proper in-process
+        locking the worker's reload blocks until the mutation commits.
+        """
+        import threading
+        import time
+
+        from osprey.stores.artifact_store import ArtifactStore
+
+        store = ArtifactStore(workspace_root=tmp_path)
+        target = store.save_object("# Target", title="Target")  # persisted unpinned
+
+        reload_started = threading.Event()
+        reload_finished = threading.Event()
+
+        def watcher_reload() -> None:
+            # Simulates StoreIndexWatcher firing on the index write.
+            reload_started.wait(timeout=2)
+            store._load_index()
+            reload_finished.set()
+
+        worker = threading.Thread(target=watcher_reload)
+        worker.start()
+
+        # Open the vulnerable window: when set_pinned()'s _save_index() builds
+        # the index payload, release the worker and give it time to reload.
+        original_build = store._build_index_data
+        calls = {"n": 0}
+
+        def build_with_window() -> dict:
+            calls["n"] += 1
+            if calls["n"] == 1:  # the set_pinned() save
+                reload_started.set()
+                time.sleep(0.1)
+            return original_build()
+
+        store._build_index_data = build_with_window  # type: ignore[method-assign]
+        try:
+            store.set_pinned(target.id, True)
+        finally:
+            worker.join(timeout=2)
+
+        assert not worker.is_alive(), "watcher reload deadlocked"
+        # The pin must survive both in memory and on disk.
+        assert store.get_entry(target.id).pinned is True
+        reloaded = ArtifactStore(workspace_root=tmp_path)
+        assert reloaded.get_entry(target.id).pinned is True


### PR DESCRIPTION
Two test-reliability fixes.

**Store race** — `StoreIndexWatcher` thread reloaded `_entries` mid-mutation, dropping in-flight saves (e.g. `set_pinned`). flock guarded only cross-process. Adds an in-process RLock + deterministic regression test. (Was the "cross-file flake"; actually fails in isolation.)

**__pycache__ phantom** — empty dirs holding only `__pycache__` import as PEP 420 namespace packages, failing package-removed tests locally. Check scripts now prune them. CI unaffected.

Full suite: 3949 passed.