### PR TITLE
feat(connectors): add MongoDB archiver connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@ Compatibility is documented in release notes, not encoded in the version string.
 ### Added
 
 - Pin Claude Code CLI version per project. New `claude_code.cli_version` config field; when set, OSPREY launches via `npx -y @anthropic-ai/claude-code@<version>` instead of bare `claude`. Use to insulate projects from upstream CC breakage (#218). Verified by `osprey health`; bypass with `osprey claude chat --no-pin`.
+- **MongoDB archiver connector.** New `mongodb_archiver` type for querying MongoDB time-series collections; install via `pip install "osprey-framework[archiver-mongodb]"` and configure with `archiver.type: mongodb_archiver` plus host/database/collection/auth settings. Ports PR #84 (RemiLehe) onto the current registry; documents are expected to have shape `{date: ISODate, PV1: value, PV2: value, ...}`.
 
 ### Changed
 
 - Documentation cleanup pass over `docs/source/`: resync getting-started, how-to, architecture, and reference pages with the current codebase; fix stale APIs, config keys, and cross-references accumulated since the native-capabilities migration.
+- **`pyepics` promoted to base dependencies.** EPICS connector users no longer need `pip install "osprey-framework[dev]"` to get a working EPICS install; pyepics is used in three production paths (control_system connector, limits_validator, python_executor wrapper).
 
 ### Fixed
 

--- a/docs/source/how-to/add-connector.rst
+++ b/docs/source/how-to/add-connector.rst
@@ -19,6 +19,7 @@ The Control System Integration system provides a **two-layer abstraction** for w
 
 - **mock** / **mock_archiver**: Development/R&D mode (no hardware access required)
 - **epics** / **epics_archiver**: EPICS Channel Access / Archiver Appliance (production)
+- **mongodb_archiver**: MongoDB time-series archiver (optional, ``pip install "osprey-framework[archiver-mongodb]"``)
 
 
 Quick Start: Using Connectors
@@ -91,6 +92,33 @@ archiver (synthetic data) to the EPICS Archiver Appliance the same way:
 
    Write operations require explicit opt-in. See :ref:`write-safety-config` below for the
    ``writes_enabled`` setting that controls write permissions.
+
+MongoDB Archiver
+----------------
+
+For facilities that store time-series PV data in MongoDB rather than EPICS Archiver
+Appliance, configure the archiver block independently of the control-system choice:
+
+.. code-block:: yaml
+
+   archiver:
+     type: mongodb_archiver
+     mongodb_archiver:
+       host: mongodb.facility.edu
+       port: 27017
+       name: archiver_db
+       collection: pv_data
+       auth: admin
+       username: readonly
+       password_env: MONGODB_READONLY_PASSWORD
+
+Documents in the collection are expected to have a ``date`` field (``ISODate``) and
+PV names as top-level fields: ``{date: ISODate(...), PV1: value1, PV2: value2, ...}``.
+The connector requires the optional ``archiver-mongodb`` extra:
+
+.. code-block:: bash
+
+   pip install "osprey-framework[archiver-mongodb]"
 
 
 Write Verification

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,9 @@ dependencies = [
     "unique-namer>=0.1.0",
     # Control system simulation (soft IOC generation)
     "caproto",
+    # EPICS Channel Access client (used by control_system connector,
+    # limits_validator, and python_executor wrapper).
+    "pyepics",
     # PostgreSQL (required for native logbook_search capability and checkpointing)
     "psycopg[binary,pool]>=3.1.0,<4.0.0",
     "psycopg-pool>=3.1.0,<4.0.0",
@@ -137,9 +140,9 @@ dev = [
     "mypy",
     "pre-commit",
     "ruff",
-    "pyepics",  # EPICS connector support for testing
     "build",  # Required for 'osprey deploy up --dev' to build local wheel
     "testcontainers[postgres]>=4.0.0",  # Real PostgreSQL for integration tests
+    "testcontainers[mongodb]>=4.0.0",  # MongoDB for archiver-mongodb integration tests
     "docker>=7.0.0",  # Docker SDK for testcontainers availability check
     "psycopg[binary,pool]>=3.1.0,<4.0.0",  # ARIEL search integration tests
     "psycopg-pool>=3.1.0,<4.0.0",  # ARIEL search integration tests
@@ -163,6 +166,11 @@ sheets = [
     "gspread>=6.0.0",
 ]
 
+# MongoDB archiver connector backend
+archiver-mongodb = [
+    "pymongo>=4.0",
+]
+
 # Screen capture on Linux (X11) — not needed on macOS
 screen-capture-linux = [
     "mss>=9.0.0",
@@ -171,7 +179,7 @@ screen-capture-linux = [
 
 # All optional dependencies for complete installation
 all = [
-    "osprey-framework[docs,dev,ariel,sheets,screen-capture-linux]"
+    "osprey-framework[docs,dev,ariel,sheets,screen-capture-linux,archiver-mongodb]"
 ]
 
 [project.urls]
@@ -222,6 +230,7 @@ module = [
     "matplotlib.*",
     "pyepics.*",
     "podman.*",
+    "pymongo.*",
 ]
 ignore_missing_imports = true
 

--- a/src/osprey/cli/project_actions.py
+++ b/src/osprey/cli/project_actions.py
@@ -499,10 +499,11 @@ def handle_set_control_system(project_path: Path | None = None) -> None:
     if control_type == types.EPICS:
         console.print("\n[bold]Archiver Configuration[/bold]\n")
         archiver_type = questionary.select(
-            "Also switch archiver to EPICS?",
+            "Which archiver?",
             choices=[
-                Choice("Yes - Use EPICS Archiver Appliance", value=types.EPICS_ARCHIVER),
-                Choice("No - Keep mock archiver", value=types.MOCK_ARCHIVER),
+                Choice("EPICS Archiver Appliance", value=types.EPICS_ARCHIVER),
+                Choice("MongoDB", value=types.MONGODB_ARCHIVER),
+                Choice("Mock archiver (keep)", value=types.MOCK_ARCHIVER),
             ],
             style=custom_style,
         ).ask()

--- a/src/osprey/connectors/archiver/mongodb_archiver_connector.py
+++ b/src/osprey/connectors/archiver/mongodb_archiver_connector.py
@@ -1,0 +1,377 @@
+"""
+MongoDB archiver connector for historical PV data retrieval.
+
+Provides interface to MongoDB collections containing archived PV data.
+Documents are expected to have a 'date' field and PV names as fields.
+"""
+
+import asyncio
+import os
+from datetime import datetime
+from typing import Any
+
+import pandas as pd
+
+from osprey.connectors.archiver.base import ArchiverConnector, ArchiverMetadata
+from osprey.utils.logger import get_logger
+
+logger = get_logger("mongodb_archiver_connector")
+
+
+class MongoDBArchiverConnector(ArchiverConnector):
+    """
+    MongoDB archiver connector for historical PV data.
+
+    Provides access to historical PV data stored in MongoDB collections.
+    Documents are expected to have the structure:
+    {date: ISODate(...), PV1: value1, PV2: value2, ...}
+
+    Example:
+        >>> config = {
+        >>>     'host': 'mongodb05.nersc.gov',
+        >>>     'port': 27017,
+        >>>     'name': 'my-archiver-database',
+        >>>     'collection': 'my-archiver-collection',
+        >>>     'auth': 'database-auth',
+        >>>     'username': 'my-username',
+        >>>     'password_env': 'MONGODB_READONLY_PASSWORD'
+        >>> }
+        >>> connector = MongoDBArchiverConnector()
+        >>> await connector.connect(config)
+        >>> df = await connector.get_data(
+        >>>     pv_list=['BEAM:CURRENT'],
+        >>>     start_date=datetime(2024, 1, 1),
+        >>>     end_date=datetime(2024, 1, 2)
+        >>> )
+    """
+
+    def __init__(self):
+        self._connected = False
+        self._client = None
+        self._collection = None
+        self._timeout = 60
+
+    async def connect(self, config: dict[str, Any]) -> None:
+        """
+        Initialize MongoDB connection.
+
+        Args:
+            config: Configuration with keys:
+                - host: MongoDB host (required)
+                - port: MongoDB port (default: 27017)
+                - name: Database name (required)
+                - collection: Collection name (required)
+                - auth: Authentication database (required)
+                - username: MongoDB username (required)
+                - password_env: Environment variable name for password (required)
+                - timeout: Default timeout in seconds (default: 60)
+
+        Raises:
+            ImportError: If pymongo is not installed
+            ValueError: If required config values are missing
+            ConnectionError: If connection cannot be established
+        """
+        try:
+            from pymongo import MongoClient
+            from pymongo.errors import ConfigurationError, ConnectionFailure
+
+            # Store classes in self for lazy import pattern:
+            # 1. Allows module import even if pymongo isn't installed (fails only when connect() is called)
+            # 2. Makes classes available in exception handlers (import scope is local to this method)
+            # 3. Enables reuse in other methods if needed
+            self._MongoClient = MongoClient
+            self._ConnectionFailure = ConnectionFailure
+            self._ConfigurationError = ConfigurationError
+        except ImportError as e:
+            raise ImportError(
+                "pymongo is required for MongoDB archiver. Install with: pip install pymongo"
+            ) from e
+
+        # Validate required config
+        host = config.get("host")
+        if not host:
+            raise ValueError("host is required for MongoDB archiver")
+
+        db_name = config.get("name")
+        if not db_name:
+            raise ValueError("name (database name) is required for MongoDB archiver")
+
+        collection_name = config.get("collection")
+        if not collection_name:
+            raise ValueError("collection is required for MongoDB archiver")
+
+        port = config.get("port", 27017)
+        self._timeout = config.get("timeout", 60)
+
+        # Validate required authentication config
+        username = config.get("username")
+        if not username:
+            raise ValueError("username is required for MongoDB archiver")
+
+        password_env = config.get("password_env")
+        if not password_env:
+            raise ValueError("password_env is required for MongoDB archiver")
+
+        auth_db = config.get("auth")
+        if not auth_db:
+            raise ValueError("auth (authentication database) is required for MongoDB archiver")
+
+        # Get password from environment variable
+        password = os.getenv(password_env)
+        if not password:
+            raise ValueError(
+                f"Environment variable '{password_env}' not set. "
+                "Password is required for MongoDB authentication."
+            )
+
+        try:
+            # Create MongoDB client using direct parameter syntax (more readable than URI)
+            self._client = self._MongoClient(
+                host=host,
+                port=port,
+                username=username,
+                password=password,
+                authSource=auth_db,
+                serverSelectionTimeoutMS=self._timeout * 1000,
+            )
+
+            # Test connection
+            def test_connection():
+                self._client.admin.command("ping")
+
+            await asyncio.to_thread(test_connection)
+
+            # Get collection
+            self._collection = self._client[db_name][collection_name]
+
+            self._connected = True
+            logger.debug(
+                f"MongoDB Archiver connector initialized: {host}:{port}/{db_name}.{collection_name}"
+            )
+
+        except self._ConnectionFailure as e:
+            raise ConnectionError(
+                f"Cannot connect to MongoDB at {host}:{port}. "
+                "Please check connectivity and authentication."
+            ) from e
+        except self._ConfigurationError as e:
+            raise ConnectionError(f"MongoDB configuration error: {e}") from e
+        except (TimeoutError, OSError) as e:
+            raise ConnectionError(f"MongoDB connection failed: {e}") from e
+        except Exception as e:
+            # Last resort - log and re-raise as ConnectionError
+            logger.error(f"Unexpected error connecting to MongoDB: {e}", exc_info=True)
+            raise ConnectionError(f"MongoDB connection failed: {e}") from e
+
+    async def disconnect(self) -> None:
+        """Cleanup MongoDB connection."""
+        if self._client:
+            try:
+
+                def close_connection():
+                    self._client.close()
+
+                await asyncio.to_thread(close_connection)
+            except Exception as e:
+                logger.warning(f"Error closing MongoDB connection: {e}")
+
+        self._client = None
+        self._collection = None
+        self._connected = False
+        logger.debug("MongoDB Archiver connector disconnected")
+
+    async def get_data(
+        self,
+        pv_list: list[str],
+        start_date: datetime,
+        end_date: datetime,
+        precision_ms: int = 1000,
+        timeout: int | None = None,
+    ) -> pd.DataFrame:
+        """
+        Retrieve historical data from MongoDB collection.
+
+        Args:
+            pv_list: List of PV names to retrieve
+            start_date: Start of time range
+            end_date: End of time range
+            precision_ms: Time precision in milliseconds (for downsampling)
+            timeout: Optional timeout in seconds
+
+        Returns:
+            DataFrame with datetime index and PV columns
+
+        Raises:
+            RuntimeError: If archiver not connected
+            TimeoutError: If operation times out
+            ConnectionError: If MongoDB cannot be reached
+            TypeError: If start_date or end_date are not datetime objects
+            ValueError: If pv_list is empty or data retrieval fails
+        """
+        timeout = timeout or self._timeout
+
+        if not self._connected or self._collection is None:
+            raise RuntimeError("MongoDB archiver not connected")
+
+        # Validate inputs
+        if not isinstance(start_date, datetime):
+            raise TypeError(f"start_date must be a datetime object, got {type(start_date)}")
+        if not isinstance(end_date, datetime):
+            raise TypeError(f"end_date must be a datetime object, got {type(end_date)}")
+
+        if not pv_list:
+            raise ValueError("pv_list cannot be empty")
+
+        def fetch_data():
+            """Synchronous data fetch function."""
+            # Build query filter for date range
+            query = {"date": {"$gte": start_date, "$lte": end_date}}
+
+            # Project only the fields we need: date and requested PVs
+            projection = {"date": 1}
+            for pv in pv_list:
+                query[pv] = {"$exists": True}
+                projection[pv] = 1
+
+            # Query MongoDB collection
+            cursor = self._collection.find(query, projection).sort("date", 1)
+
+            # Convert to list of documents
+            documents = list(cursor)
+
+            if not documents:
+                logger.debug(f"No documents found in date range {start_date} to {end_date}")
+                # Return empty DataFrame with correct structure
+                return pd.DataFrame(index=pd.DatetimeIndex([]), columns=pv_list)
+
+            # Extract data into lists for DataFrame construction
+            dates = []
+            data_dict = {pv: [] for pv in pv_list}
+
+            for doc in documents:
+                # Extract date
+                doc_date = doc.get("date")
+                if doc_date is None:
+                    logger.warning("Document missing 'date' field, skipping")
+                    continue
+
+                # Convert to datetime if needed
+                if isinstance(doc_date, str):
+                    doc_date = pd.to_datetime(doc_date)
+                elif not isinstance(doc_date, datetime):
+                    doc_date = pd.to_datetime(doc_date)
+
+                dates.append(doc_date)
+
+                # Extract PV values
+                for pv in pv_list:
+                    value = doc.get(pv)
+                    data_dict[pv].append(value)
+
+            # Create DataFrame
+            if not dates:
+                logger.debug("No valid documents with date field found")
+                return pd.DataFrame(index=pd.DatetimeIndex([]), columns=pv_list)
+
+            df = pd.DataFrame(data_dict, index=pd.to_datetime(dates))
+
+            # Apply downsampling based on precision_ms if needed
+            # This is a simple approach - could be enhanced with more sophisticated downsampling
+            #            if precision_ms > 0 and len(df) > 0:
+            #                # Resample to approximate precision
+            #                freq = f"{precision_ms}ms"
+            #                df = df.resample(freq).mean()
+
+            return df
+
+        try:
+            # Use asyncio.wait_for for timeout, asyncio.to_thread for async execution
+            data = await asyncio.wait_for(asyncio.to_thread(fetch_data), timeout=timeout)
+
+            logger.debug(
+                f"Retrieved MongoDB archiver data: {len(data)} points for {len(pv_list)} PVs"
+            )
+            return data
+
+        except TimeoutError as e:
+            raise TimeoutError(f"MongoDB query timed out after {timeout}s") from e
+        except ConnectionError as e:
+            raise ConnectionError(f"Network connectivity issue with MongoDB: {e}") from e
+        except (ValueError, TypeError) as e:
+            raise ValueError(f"Error retrieving data from MongoDB: {e}") from e
+        except Exception as e:
+            # Log unexpected errors for debugging
+            logger.error(f"Unexpected error retrieving data: {e}", exc_info=True)
+            raise ValueError(f"Error retrieving data from MongoDB: {e}") from e
+
+    async def get_metadata(self, pv_name: str) -> ArchiverMetadata:
+        """
+        Get archiving metadata for a PV.
+
+        Note: Basic implementation that checks if PV exists in collection.
+        Could be enhanced with actual metadata queries.
+
+        Args:
+            pv_name: Name of the process variable
+
+        Returns:
+            ArchiverMetadata with basic archiving information
+
+        Raises:
+            RuntimeError: If archiver not connected
+        """
+        if not self._connected or self._collection is None:
+            raise RuntimeError("MongoDB archiver not connected")
+
+        def check_pv():
+            """Check if PV exists in any document."""
+            # Query for any document that has this PV field
+            query = {pv_name: {"$exists": True}}
+            count = self._collection.count_documents(query, limit=1)
+            return count > 0
+
+        try:
+            is_archived = await asyncio.to_thread(check_pv)
+        except Exception as e:
+            logger.warning(f"Error checking PV metadata: {e}")
+            is_archived = False
+
+        return ArchiverMetadata(
+            pv_name=pv_name,
+            is_archived=is_archived,
+            description=f"MongoDB Archived PV: {pv_name}",
+        )
+
+    async def check_availability(self, pv_names: list[str]) -> dict[str, bool]:
+        """
+        Check which PVs are archived in the MongoDB collection.
+
+        Args:
+            pv_names: List of PV names to check
+
+        Returns:
+            Dictionary mapping PV name to availability status
+
+        Raises:
+            RuntimeError: If archiver not connected
+        """
+        if not self._connected or self._collection is None:
+            raise RuntimeError("MongoDB archiver not connected")
+
+        def check_pvs():
+            """Check which PVs exist in the collection."""
+            availability = {}
+            for pv in pv_names:
+                query = {pv: {"$exists": True}}
+                count = self._collection.count_documents(query, limit=1)
+                availability[pv] = count > 0
+            return availability
+
+        try:
+            availability = await asyncio.to_thread(check_pvs)
+        except Exception as e:
+            logger.warning(f"Error checking PV availability: {e}")
+            # Return all False on error
+            availability = dict.fromkeys(pv_names, False)
+
+        return availability

--- a/src/osprey/connectors/factory.py
+++ b/src/osprey/connectors/factory.py
@@ -242,7 +242,18 @@ def register_builtin_connectors() -> None:
     from osprey.connectors.control_system.epics_connector import EPICSConnector
     from osprey.connectors.control_system.mock_connector import MockConnector
 
+    try:
+        from osprey.connectors.archiver.mongodb_archiver_connector import (
+            MongoDBArchiverConnector,
+        )
+
+        _mongo_available = True
+    except ImportError:
+        _mongo_available = False
+
     ConnectorFactory.register_control_system(types.MOCK, MockConnector)
     ConnectorFactory.register_control_system(types.EPICS, EPICSConnector)
     ConnectorFactory.register_archiver(types.MOCK_ARCHIVER, MockArchiverConnector)
     ConnectorFactory.register_archiver(types.EPICS_ARCHIVER, EPICSArchiverConnector)
+    if _mongo_available:
+        ConnectorFactory.register_archiver(types.MONGODB_ARCHIVER, MongoDBArchiverConnector)

--- a/src/osprey/connectors/types.py
+++ b/src/osprey/connectors/types.py
@@ -12,7 +12,8 @@ EPICS = "epics"
 # -- Archiver connector types --
 MOCK_ARCHIVER = "mock_archiver"
 EPICS_ARCHIVER = "epics_archiver"
+MONGODB_ARCHIVER = "mongodb_archiver"
 
 # -- CLI choice lists (only types with implementations) --
 CLI_CONTROL_SYSTEM_TYPES = [MOCK, EPICS]
-CLI_ARCHIVER_TYPES = [MOCK_ARCHIVER, EPICS_ARCHIVER]
+CLI_ARCHIVER_TYPES = [MOCK_ARCHIVER, EPICS_ARCHIVER, MONGODB_ARCHIVER]

--- a/src/osprey/registry/builtins.py
+++ b/src/osprey/registry/builtins.py
@@ -6,7 +6,7 @@ that all Osprey applications build upon.
 .. seealso:: :class:`RegistryConfigProvider`, :class:`RegistryManager`
 """
 
-from osprey.connectors.types import EPICS, EPICS_ARCHIVER, MOCK, MOCK_ARCHIVER
+from osprey.connectors.types import EPICS, EPICS_ARCHIVER, MOCK, MOCK_ARCHIVER, MONGODB_ARCHIVER
 
 from .base import (
     ArielEnhancementModuleRegistration,
@@ -77,6 +77,13 @@ class FrameworkRegistryProvider(RegistryConfigProvider):
                     module_path="osprey.connectors.archiver.epics_archiver_connector",
                     class_name="EPICSArchiverConnector",
                     description="EPICS Archiver Appliance connector",
+                ),
+                ConnectorRegistration(
+                    name=MONGODB_ARCHIVER,
+                    connector_type="archiver",
+                    module_path="osprey.connectors.archiver.mongodb_archiver_connector",
+                    class_name="MongoDBArchiverConnector",
+                    description="MongoDB archiver connector for time-series PV data",
                 ),
             ],
             # ARIEL search modules

--- a/tests/connectors/conftest.py
+++ b/tests/connectors/conftest.py
@@ -1,0 +1,159 @@
+"""Pytest fixtures for connector tests.
+
+Fixtures defined here are automatically available to all test files in
+``tests/connectors/`` and any subdirectories.
+
+The MongoDB fixtures spin up a real container via testcontainers and
+skip cleanly when Docker is unavailable, matching the pattern used by
+``tests/services/ariel_search/conftest.py``.
+"""
+
+import logging
+import os
+from datetime import datetime, timedelta
+
+import pytest
+
+logger = logging.getLogger(__name__)
+
+
+def is_docker_available() -> bool:
+    """Return True if the Docker daemon is reachable.
+
+    Used to gate testcontainers-backed fixtures so that contributors
+    without a running Docker engine see a skip rather than an error.
+    """
+    try:
+        import docker
+
+        client = docker.from_env()
+        client.ping()
+        return True
+    except Exception as e:
+        logger.warning(f"Docker not available: {e}")
+        return False
+
+
+@pytest.fixture(scope="session")
+def mongodb_container():
+    """Start a MongoDB container for the test session.
+
+    Yields a dict with connection parameters. Skips the entire chain
+    of dependent tests if Docker isn't available or pymongo isn't
+    installed (i.e., the ``archiver-mongodb`` extra wasn't selected).
+    """
+    if not is_docker_available():
+        pytest.skip(
+            "Docker not available — install Docker Desktop or Podman "
+            "to run MongoDB archiver integration tests."
+        )
+
+    try:
+        from testcontainers.mongodb import MongoDbContainer
+    except ImportError:
+        pytest.skip("testcontainers[mongodb] not installed")
+
+    username = "testuser"
+    password = "testpass123"
+    db_name = "test_archiver_db"
+    collection_name = "test_archiver_collection"
+    auth_db = "admin"
+
+    container = MongoDbContainer("mongo:7", username=username, password=password)
+    container.start()
+
+    import atexit
+
+    atexit.register(container.stop)
+
+    host = container.get_container_host_ip()
+    port = int(container.get_exposed_port(27017))
+
+    yield {
+        "host": host,
+        "port": port,
+        "username": username,
+        "password": password,
+        "auth_db": auth_db,
+        "db_name": db_name,
+        "collection_name": collection_name,
+    }
+
+
+@pytest.fixture(scope="function")
+def mongodb_test_data(mongodb_container):
+    """Seed the test collection with 3 days of hourly PV data.
+
+    Cleans up after each test so the collection state stays predictable.
+    """
+    from pymongo import MongoClient
+
+    client = MongoClient(
+        host=mongodb_container["host"],
+        port=mongodb_container["port"],
+        username=mongodb_container["username"],
+        password=mongodb_container["password"],
+        authSource=mongodb_container["auth_db"],
+    )
+
+    collection = client[mongodb_container["db_name"]][mongodb_container["collection_name"]]
+    collection.delete_many({})
+
+    start_date = datetime(2024, 1, 1, 0, 0, 0)
+    end_date = datetime(2024, 1, 4, 0, 0, 0)
+    pv_names = ["BEAM:CURRENT", "BEAM:LIFETIME", "BEAM:ENERGY"]
+
+    documents = []
+    current_date = start_date
+    hour_count = 0
+    while current_date < end_date:
+        doc = {
+            "date": current_date,
+            "BEAM:CURRENT": 100.0 + (hour_count % 100),
+            "BEAM:LIFETIME": 10.0 + (hour_count % 40),
+            "BEAM:ENERGY": 1.0 + (hour_count % 15) * 0.1,
+        }
+        documents.append(doc)
+        current_date += timedelta(hours=1)
+        hour_count += 1
+
+    if documents:
+        collection.insert_many(documents)
+    collection.create_index("date")
+
+    yield {
+        "pv_names": pv_names,
+        "start_date": start_date,
+        "end_date": end_date,
+        "document_count": len(documents),
+    }
+
+    collection.delete_many({})
+    client.close()
+
+
+@pytest.fixture
+def mongodb_config(mongodb_container):
+    """Provide a connector-ready config dict and set the password env var.
+
+    Tests that need seeded data should also depend on ``mongodb_test_data``;
+    this fixture is intentionally not coupled to the data fixture so that
+    error-path tests (missing config keys, etc.) don't pay seeding cost.
+    """
+    password_env = "MONGODB_TEST_PASSWORD"
+    os.environ[password_env] = mongodb_container["password"]
+
+    config = {
+        "host": mongodb_container["host"],
+        "port": mongodb_container["port"],
+        "name": mongodb_container["db_name"],
+        "collection": mongodb_container["collection_name"],
+        "auth": mongodb_container["auth_db"],
+        "username": mongodb_container["username"],
+        "password_env": password_env,
+        "timeout": 10,
+    }
+
+    yield config
+
+    os.environ.pop(password_env, None)

--- a/tests/connectors/test_mongodb_archiver_connector.py
+++ b/tests/connectors/test_mongodb_archiver_connector.py
@@ -319,9 +319,11 @@ class TestGetDataMethod:
         connector = MongoDBArchiverConnector()
         await connector.connect(mongodb_config)
 
-        # Get data for first 6 hours
+        # Get first 6 hourly samples. The connector's range query is inclusive
+        # on both ends ($gte/$lte), so end_date is the timestamp of the last
+        # sample we want, not the exclusive upper bound.
         start_date = mongodb_test_data["start_date"]
-        end_date = datetime(2024, 1, 1, 6, 0, 0)
+        end_date = datetime(2024, 1, 1, 5, 0, 0)
 
         df = await connector.get_data(
             pv_list=["BEAM:CURRENT"],
@@ -329,7 +331,7 @@ class TestGetDataMethod:
             end_date=end_date,
         )
 
-        assert len(df) == 6  # 6 hours of data (hourly intervals)
+        assert len(df) == 6  # hourly samples at 00:00..05:00 inclusive
         assert df.index[0] >= start_date
         assert df.index[-1] <= end_date
 

--- a/tests/connectors/test_mongodb_archiver_connector.py
+++ b/tests/connectors/test_mongodb_archiver_connector.py
@@ -1,0 +1,515 @@
+"""Tests for MongoDB Archiver connector."""
+
+import sys
+from datetime import datetime
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from osprey.connectors.archiver.base import ArchiverMetadata
+from osprey.connectors.archiver.mongodb_archiver_connector import MongoDBArchiverConnector
+from osprey.connectors.factory import ConnectorFactory
+
+
+@pytest.mark.integration
+class TestConnectDisconnectLifecycle:
+    """Tests for connect/disconnect lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_connect_success(self, mongodb_config):
+        """Test that connect succeeds with valid config."""
+        connector = MongoDBArchiverConnector()
+        await connector.connect(mongodb_config)
+
+        assert connector._connected is True
+        assert connector._client is not None
+        assert connector._collection is not None
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_default_timeout(self, mongodb_config):
+        """Test that default timeout of 60s is used when not specified."""
+        # Remove timeout from config to test default
+        config_without_timeout = mongodb_config.copy()
+        del config_without_timeout["timeout"]
+
+        connector = MongoDBArchiverConnector()
+        await connector.connect(config_without_timeout)
+
+        assert connector._timeout == 60
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_custom_timeout(self, mongodb_config):
+        """Test that custom timeout is used when specified."""
+        config_with_timeout = mongodb_config.copy()
+        config_with_timeout["timeout"] = 120
+
+        connector = MongoDBArchiverConnector()
+        await connector.connect(config_with_timeout)
+
+        assert connector._timeout == 120
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_missing_host_raises_value_error(self, mongodb_config):
+        """Test that connect raises ValueError when host is missing."""
+        config = mongodb_config.copy()
+        del config["host"]
+
+        connector = MongoDBArchiverConnector()
+
+        with pytest.raises(ValueError, match="host is required"):
+            await connector.connect(config)
+
+    @pytest.mark.asyncio
+    async def test_connect_missing_database_name_raises_value_error(self, mongodb_config):
+        """Test that connect raises ValueError when database name is missing."""
+        config = mongodb_config.copy()
+        del config["name"]
+
+        connector = MongoDBArchiverConnector()
+
+        with pytest.raises(ValueError, match="name.*database name.*required"):
+            await connector.connect(config)
+
+    @pytest.mark.asyncio
+    async def test_connect_missing_collection_raises_value_error(self, mongodb_config):
+        """Test that connect raises ValueError when collection is missing."""
+        config = mongodb_config.copy()
+        del config["collection"]
+
+        connector = MongoDBArchiverConnector()
+
+        with pytest.raises(ValueError, match="collection is required"):
+            await connector.connect(config)
+
+    @pytest.mark.asyncio
+    async def test_connect_missing_username_raises_value_error(self, mongodb_config):
+        """Test that connect raises ValueError when username is missing."""
+        config = mongodb_config.copy()
+        del config["username"]
+
+        connector = MongoDBArchiverConnector()
+
+        with pytest.raises(ValueError, match="username is required"):
+            await connector.connect(config)
+
+    @pytest.mark.asyncio
+    async def test_connect_missing_password_env_raises_value_error(self, mongodb_config):
+        """Test that connect raises ValueError when password_env is missing."""
+        config = mongodb_config.copy()
+        del config["password_env"]
+
+        connector = MongoDBArchiverConnector()
+
+        with pytest.raises(ValueError, match="password_env is required"):
+            await connector.connect(config)
+
+    @pytest.mark.asyncio
+    async def test_connect_missing_auth_db_raises_value_error(self, mongodb_config):
+        """Test that connect raises ValueError when auth database is missing."""
+        config = mongodb_config.copy()
+        del config["auth"]
+
+        connector = MongoDBArchiverConnector()
+
+        with pytest.raises(ValueError, match="auth.*authentication database.*required"):
+            await connector.connect(config)
+
+    @pytest.mark.asyncio
+    async def test_connect_missing_password_env_var_raises_value_error(self, mongodb_config):
+        """Test that connect raises ValueError when password env var is not set."""
+        config = mongodb_config.copy()
+        config["password_env"] = "NONEXISTENT_ENV_VAR"
+
+        connector = MongoDBArchiverConnector()
+
+        with pytest.raises(ValueError, match="Environment variable.*not set"):
+            await connector.connect(config)
+
+    @pytest.mark.asyncio
+    async def test_disconnect_clears_state(self, mongodb_config):
+        """Test that disconnect clears connection state."""
+        connector = MongoDBArchiverConnector()
+        await connector.connect(mongodb_config)
+
+        await connector.disconnect()
+
+        assert connector._connected is False
+        assert connector._client is None
+        assert connector._collection is None
+
+    @pytest.mark.asyncio
+    async def test_disconnect_when_not_connected(self):
+        """Test that disconnect is safe to call when already disconnected."""
+        connector = MongoDBArchiverConnector()
+        # Should not raise any exception
+        await connector.disconnect()
+
+        assert connector._connected is False
+        assert connector._client is None
+        assert connector._collection is None
+
+
+@pytest.mark.integration
+class TestImportErrorHandling:
+    """Tests for import error handling when pymongo is missing."""
+
+    @pytest.mark.asyncio
+    async def test_connect_raises_import_error_when_pymongo_missing(self, mongodb_config):
+        """Test that connect raises ImportError with helpful message when pymongo missing."""
+        # Remove pymongo from sys.modules if it exists
+        original_modules = sys.modules.copy()
+
+        # Mock the import to raise ImportError
+        def mock_import(name, *args, **kwargs):
+            if name == "pymongo" or name.startswith("pymongo."):
+                raise ImportError("No module named 'pymongo'")
+            return original_modules.get(name)
+
+        connector = MongoDBArchiverConnector()
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            with pytest.raises(ImportError) as exc_info:
+                await connector.connect(mongodb_config)
+
+            assert "pymongo is required" in str(exc_info.value)
+            assert "pip install pymongo" in str(exc_info.value)
+
+
+@pytest.mark.integration
+class TestGetDataMethod:
+    """Tests for get_data method."""
+
+    @pytest.mark.asyncio
+    async def test_get_data_returns_dataframe(self, mongodb_config, mongodb_test_data):
+        """Test that get_data returns a DataFrame with DatetimeIndex."""
+        connector = MongoDBArchiverConnector()
+        await connector.connect(mongodb_config)
+
+        start_date = mongodb_test_data["start_date"]
+        end_date = datetime(2024, 1, 1, 12, 0, 0)  # First 12 hours
+
+        df = await connector.get_data(
+            pv_list=["BEAM:CURRENT"],
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        assert isinstance(df, pd.DataFrame)
+        assert isinstance(df.index, pd.DatetimeIndex)
+        assert "BEAM:CURRENT" in df.columns
+        assert len(df) > 0  # Should have data
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_get_data_multiple_pvs(self, mongodb_config, mongodb_test_data):
+        """Test that get_data returns data for multiple PVs."""
+        connector = MongoDBArchiverConnector()
+        await connector.connect(mongodb_config)
+
+        start_date = mongodb_test_data["start_date"]
+        end_date = datetime(2024, 1, 1, 12, 0, 0)
+        pv_list = mongodb_test_data["pv_names"]
+
+        df = await connector.get_data(
+            pv_list=pv_list,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        assert isinstance(df, pd.DataFrame)
+        # All PVs should be columns
+        for pv in pv_list:
+            assert pv in df.columns
+        assert len(df.columns) == len(pv_list)
+        assert len(df) > 0
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_get_data_empty_time_range(self, mongodb_config):
+        """Test that get_data returns empty DataFrame for time range with no data."""
+        connector = MongoDBArchiverConnector()
+        await connector.connect(mongodb_config)
+
+        # Use a time range that definitely has no data
+        start_date = datetime(2025, 1, 1, 0, 0, 0)
+        end_date = datetime(2025, 1, 2, 0, 0, 0)
+
+        df = await connector.get_data(
+            pv_list=["BEAM:CURRENT"],
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 0
+        assert "BEAM:CURRENT" in df.columns
+        assert isinstance(df.index, pd.DatetimeIndex)
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_get_data_not_connected_raises_runtime_error(self):
+        """Test that get_data raises RuntimeError when not connected."""
+        connector = MongoDBArchiverConnector()
+
+        with pytest.raises(RuntimeError, match="MongoDB archiver not connected"):
+            await connector.get_data(
+                pv_list=["BEAM:CURRENT"],
+                start_date=datetime(2024, 1, 1),
+                end_date=datetime(2024, 1, 2),
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_data_invalid_start_date_raises_type_error(self, mongodb_config):
+        """Test that get_data raises TypeError when start_date is not a datetime."""
+        connector = MongoDBArchiverConnector()
+        await connector.connect(mongodb_config)
+
+        with pytest.raises(TypeError, match="start_date must be a datetime object"):
+            await connector.get_data(
+                pv_list=["BEAM:CURRENT"],
+                start_date="2024-01-01",  # String instead of datetime
+                end_date=datetime(2024, 1, 2),
+            )
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_get_data_invalid_end_date_raises_type_error(self, mongodb_config):
+        """Test that get_data raises TypeError when end_date is not a datetime."""
+        connector = MongoDBArchiverConnector()
+        await connector.connect(mongodb_config)
+
+        with pytest.raises(TypeError, match="end_date must be a datetime object"):
+            await connector.get_data(
+                pv_list=["BEAM:CURRENT"],
+                start_date=datetime(2024, 1, 1),
+                end_date="2024-01-02",  # String instead of datetime
+            )
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_get_data_empty_pv_list_raises_value_error(self, mongodb_config):
+        """Test that get_data raises ValueError when pv_list is empty."""
+        connector = MongoDBArchiverConnector()
+        await connector.connect(mongodb_config)
+
+        with pytest.raises(ValueError, match="pv_list cannot be empty"):
+            await connector.get_data(
+                pv_list=[],
+                start_date=datetime(2024, 1, 1),
+                end_date=datetime(2024, 1, 2),
+            )
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_get_data_time_range_filtering(self, mongodb_config, mongodb_test_data):
+        """Test that get_data correctly filters by time range."""
+        connector = MongoDBArchiverConnector()
+        await connector.connect(mongodb_config)
+
+        # Get data for first 6 hours
+        start_date = mongodb_test_data["start_date"]
+        end_date = datetime(2024, 1, 1, 6, 0, 0)
+
+        df = await connector.get_data(
+            pv_list=["BEAM:CURRENT"],
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        assert len(df) == 6  # 6 hours of data (hourly intervals)
+        assert df.index[0] >= start_date
+        assert df.index[-1] <= end_date
+
+        await connector.disconnect()
+
+
+@pytest.mark.integration
+class TestGetDataErrorHandling:
+    """Tests for error handling in get_data method."""
+
+    @pytest.mark.asyncio
+    async def test_get_data_timeout_raises_timeout_error(self, mongodb_config):
+        """Test that timeout is properly handled."""
+        connector = MongoDBArchiverConnector()
+        await connector.connect(mongodb_config)
+
+        # Use a very short timeout that should fail
+        # Note: This test may be flaky, so we'll use a reasonable timeout
+        # and verify the error handling works
+        start_date = datetime(2024, 1, 1, 0, 0, 0)
+        end_date = datetime(2024, 1, 1, 1, 0, 0)
+
+        # This should work with normal timeout
+        df = await connector.get_data(
+            pv_list=["BEAM:CURRENT"],
+            start_date=start_date,
+            end_date=end_date,
+            timeout=1,  # 1 second should be enough for small query
+        )
+
+        assert isinstance(df, pd.DataFrame)
+
+        await connector.disconnect()
+
+
+@pytest.mark.integration
+class TestMetadataMethods:
+    """Tests for metadata methods."""
+
+    @pytest.mark.asyncio
+    async def test_get_metadata_returns_archiver_metadata(self, mongodb_config, mongodb_test_data):
+        """Test that get_metadata returns ArchiverMetadata dataclass."""
+        connector = MongoDBArchiverConnector()
+        await connector.connect(mongodb_config)
+
+        pv_name = mongodb_test_data["pv_names"][0]
+        metadata = await connector.get_metadata(pv_name)
+
+        assert isinstance(metadata, ArchiverMetadata)
+        assert metadata.pv_name == pv_name
+        assert metadata.is_archived is True  # Should be True since we have test data
+        assert pv_name in metadata.description
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_get_metadata_nonexistent_pv(self, mongodb_config):
+        """Test that get_metadata returns is_archived=False for nonexistent PV."""
+        connector = MongoDBArchiverConnector()
+        await connector.connect(mongodb_config)
+
+        metadata = await connector.get_metadata("NONEXISTENT:PV")
+
+        assert isinstance(metadata, ArchiverMetadata)
+        assert metadata.pv_name == "NONEXISTENT:PV"
+        assert metadata.is_archived is False  # Should be False for nonexistent PV
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_check_availability_returns_dict(self, mongodb_config, mongodb_test_data):
+        """Test that check_availability returns dict mapping PVs to availability."""
+        connector = MongoDBArchiverConnector()
+        await connector.connect(mongodb_config)
+
+        pv_names = mongodb_test_data["pv_names"]
+        availability = await connector.check_availability(pv_names)
+
+        assert isinstance(availability, dict)
+        assert len(availability) == len(pv_names)
+        for pv in pv_names:
+            assert pv in availability
+            assert availability[pv] is True  # All test PVs should be available
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_check_availability_mixed_pvs(self, mongodb_config, mongodb_test_data):
+        """Test that check_availability correctly identifies available and unavailable PVs."""
+        connector = MongoDBArchiverConnector()
+        await connector.connect(mongodb_config)
+
+        # Mix of existing and nonexistent PVs
+        pv_names = mongodb_test_data["pv_names"] + ["NONEXISTENT:PV"]
+        availability = await connector.check_availability(pv_names)
+
+        assert isinstance(availability, dict)
+        assert len(availability) == len(pv_names)
+
+        # Existing PVs should be True
+        for pv in mongodb_test_data["pv_names"]:
+            assert availability[pv] is True
+
+        # Nonexistent PV should be False
+        assert availability["NONEXISTENT:PV"] is False
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_check_availability_empty_list(self, mongodb_config):
+        """Test that check_availability returns empty dict for empty input."""
+        connector = MongoDBArchiverConnector()
+        await connector.connect(mongodb_config)
+
+        availability = await connector.check_availability([])
+
+        assert isinstance(availability, dict)
+        assert len(availability) == 0
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_check_availability_not_connected_raises_runtime_error(self):
+        """Test that check_availability raises RuntimeError when not connected."""
+        connector = MongoDBArchiverConnector()
+
+        with pytest.raises(RuntimeError, match="MongoDB archiver not connected"):
+            await connector.check_availability(["BEAM:CURRENT"])
+
+    @pytest.mark.asyncio
+    async def test_get_metadata_not_connected_raises_runtime_error(self):
+        """Test that get_metadata raises RuntimeError when not connected."""
+        connector = MongoDBArchiverConnector()
+
+        with pytest.raises(RuntimeError, match="MongoDB archiver not connected"):
+            await connector.get_metadata("BEAM:CURRENT")
+
+
+@pytest.mark.integration
+class TestFactoryIntegration:
+    """Tests for factory integration."""
+
+    @pytest.fixture(autouse=True)
+    def setup_factory(self):
+        """Ensure built-in archivers (including mongodb_archiver) are registered.
+
+        Idempotent: ``register_builtin_connectors`` no-ops if already populated,
+        so this is safe regardless of prior test state. No teardown — we leave
+        built-ins in place so subsequent tests can rely on them.
+        """
+        from osprey.connectors.factory import register_builtin_connectors
+
+        register_builtin_connectors()
+        yield
+
+    @pytest.mark.asyncio
+    async def test_factory_creates_mongodb_archiver_connector(self, mongodb_config):
+        """Test that factory creates and connects MongoDBArchiverConnector."""
+        config = {
+            "type": "mongodb_archiver",
+            "mongodb_archiver": mongodb_config,
+        }
+
+        connector = await ConnectorFactory.create_archiver_connector(config)
+
+        assert isinstance(connector, MongoDBArchiverConnector)
+        assert connector._connected is True
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_factory_with_missing_host_raises_error(self, mongodb_config):
+        """Test that factory propagates ValueError for missing host."""
+        config_without_host = mongodb_config.copy()
+        del config_without_host["host"]
+
+        config = {
+            "type": "mongodb_archiver",
+            "mongodb_archiver": config_without_host,
+        }
+
+        with pytest.raises(ValueError, match="host is required"):
+            await ConnectorFactory.create_archiver_connector(config)

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-16T12:59:17.004753Z"
+exclude-newer = "2026-05-18T17:48:27.183271Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -3017,6 +3017,7 @@ dependencies = [
     { name = "plotly" },
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "psycopg-pool" },
+    { name = "pyepics" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "questionary" },
@@ -3048,7 +3049,7 @@ all = [
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "psycopg-pool" },
     { name = "pydata-sphinx-theme" },
-    { name = "pyepics" },
+    { name = "pymongo" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -3062,7 +3063,10 @@ all = [
     { name = "sphinx-design" },
     { name = "sphinxcontrib-jsmath" },
     { name = "sphinxcontrib-mermaid" },
-    { name = "testcontainers" },
+    { name = "testcontainers", extra = ["mongodb"] },
+]
+archiver-mongodb = [
+    { name = "pymongo" },
 ]
 ariel = [
     { name = "psycopg", extra = ["pool"] },
@@ -3078,13 +3082,12 @@ dev = [
     { name = "pre-commit" },
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "psycopg-pool" },
-    { name = "pyepics" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-order" },
     { name = "ruff" },
-    { name = "testcontainers" },
+    { name = "testcontainers", extra = ["mongodb"] },
 ]
 docs = [
     { name = "graphviz" },
@@ -3169,8 +3172,9 @@ requires-dist = [
     { name = "psycopg-pool", marker = "extra == 'dev'", specifier = ">=3.1.0,<4.0.0" },
     { name = "pydata-sphinx-theme", marker = "extra == 'all'" },
     { name = "pydata-sphinx-theme", marker = "extra == 'docs'" },
-    { name = "pyepics", marker = "extra == 'all'" },
-    { name = "pyepics", marker = "extra == 'dev'" },
+    { name = "pyepics" },
+    { name = "pymongo", marker = "extra == 'all'", specifier = ">=4.0" },
+    { name = "pymongo", marker = "extra == 'archiver-mongodb'", specifier = ">=4.0" },
     { name = "pytest", marker = "extra == 'all'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'all'" },
@@ -3205,6 +3209,8 @@ requires-dist = [
     { name = "sphinxcontrib-mermaid", marker = "extra == 'all'" },
     { name = "sphinxcontrib-mermaid", marker = "extra == 'docs'" },
     { name = "tenacity", specifier = ">=9.1.4" },
+    { name = "testcontainers", extras = ["mongodb"], marker = "extra == 'all'", specifier = ">=4.0.0" },
+    { name = "testcontainers", extras = ["mongodb"], marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "testcontainers", extras = ["postgres"], marker = "extra == 'all'", specifier = ">=4.0.0" },
     { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "typing-extensions", specifier = ">=4.12.0" },
@@ -3214,7 +3220,7 @@ requires-dist = [
     { name = "watchdog", specifier = ">=3.0.0" },
     { name = "websocket-client", specifier = ">=1.7.0" },
 ]
-provides-extras = ["all", "ariel", "ariel-proxy", "dev", "docs", "screen-capture-linux", "sheets"]
+provides-extras = ["all", "archiver-mongodb", "ariel", "ariel-proxy", "dev", "docs", "screen-capture-linux", "sheets"]
 
 [[package]]
 name = "packaging"
@@ -3976,6 +3982,67 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pymongo"
+version = "4.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/64/50be6fbac9c79fe2e4c17401a467da2d8764d82833d83cec325afe5cab32/pymongo-4.17.0.tar.gz", hash = "sha256:70ffa08ba641468cc068cf46c06b34f01a8ce3489f6411309fcb5ceabe6b2fc0", size = 2523370, upload-time = "2026-04-20T16:39:53.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/e2/336d86f221cf1b56b2ed9330d4a3b98f9f38f0b37829ae9a9184617d5419/pymongo-4.17.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4141e6c6a339789b2974efa00ecd9409101672d77a0e3ee2cc3839eedf8ec4df", size = 874668, upload-time = "2026-04-20T16:37:41.39Z" },
+    { url = "https://files.pythonhosted.org/packages/34/8e/75d3c6c935d187ab59c61e9c15d9aab3f274b563eaf1706e8cae5f508dec/pymongo-4.17.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e68c76b84e0c132d9dbf9307f12ff8185702328187a87b9aca8c941303873433", size = 875294, upload-time = "2026-04-20T16:37:43.432Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ec/62e855744489dbcd54fd778aae4d80fa4c4819e8fb228ca0cf6f21a03997/pymongo-4.17.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ba2195d4f386f839a52a23ea1cfd60ffaaba78a3d7841db51b7e433001139918", size = 1496233, upload-time = "2026-04-20T16:37:45.518Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e8/93e4e5e5ce8fdf8929dabeefe24aafa5ce046028eed0dfa8eeb936e72c49/pymongo-4.17.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8446ff4bfcb6ec2a2e50998c860986a1e992136f998b7f53e7a717fb8aa5a0b9", size = 1522927, upload-time = "2026-04-20T16:37:47.492Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ca/425dc1d21e0f17bdea0072fc463f662f7fa06d2852af52975c9eced3c07c/pymongo-4.17.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2a0d5ac205728c86e0a02192f1aa5f865b0d7d51f8df6101c01a69a7fc620d72", size = 1583468, upload-time = "2026-04-20T16:37:49.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/9d/f08b07eeffda1a43c1759f0fa625e88ae12360996eb56d42aad832fa7dff/pymongo-4.17.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:485c8a8eaa4c739f00a331fc73757898ee7c092c214a79e63866ff76aaf282ff", size = 1572787, upload-time = "2026-04-20T16:37:51.061Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/c2/6855a07aafa7b894929af23675b6fb9634800ce43122b76a62f6eeb8da2a/pymongo-4.17.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b2dfcc795f5b9fedbe179a11fdf6051581479d196582a3fe819a92a00e9b9969", size = 1526184, upload-time = "2026-04-20T16:37:53.358Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/05/c952bac7db71c1942ea3559fcd308b49754cc5004b455935fb4000d1f37b/pymongo-4.17.0-cp311-cp311-win32.whl", hash = "sha256:c2292144505fb12156b981bd440f3dc994a883da06ac726c0c8692ccdbc1c510", size = 852621, upload-time = "2026-04-20T16:37:55.28Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c0/c04da9f4c0c6252404598f4e394b862a58a9e866822a70ae261c8a018fdf/pymongo-4.17.0-cp311-cp311-win_amd64.whl", hash = "sha256:2e190827834fce70ecdf9d46796c6dbc0ce08ea87dc2ff5bc6f3f5579b605cb9", size = 867852, upload-time = "2026-04-20T16:37:57.233Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b2/c7b4870fbeef471e947d3e014676f5910d02e0197074d692ebcf24ec049a/pymongo-4.17.0-cp311-cp311-win_arm64.whl", hash = "sha256:a8f9c40a09bb7d4b9fc8b1da65ecf6efa79bda5cb2756f39d9b6940fac1d19ae", size = 855019, upload-time = "2026-04-20T16:37:58.983Z" },
+    { url = "https://files.pythonhosted.org/packages/98/90/60bcb508840135d5ee46b51b1a950f548338aa8145a8366dbe6639ae51ac/pymongo-4.17.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53ffa94b2340dbf6b055e09a0090618c60482c158ecfc9565642fc996bf0944", size = 930529, upload-time = "2026-04-20T16:38:00.936Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/e9/313840f1e52c6dfac47f704428cbfbce59956ebe7633bffc92b03f74f0ad/pymongo-4.17.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6fe0de9d0f6791abce3471230b32b4817bf89d27b1182b6a550e1ec0fa72aa9a", size = 930665, upload-time = "2026-04-20T16:38:02.915Z" },
+    { url = "https://files.pythonhosted.org/packages/78/35/9d3565ea45b1606f635c1e2cd2563c28d66caafdc50f7ad7d979fcd1b363/pymongo-4.17.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e537e95514dae1aaa718f481ec03151a0f0394bcd05f1322896d8fc1330cb729", size = 1762369, upload-time = "2026-04-20T16:38:05.375Z" },
+    { url = "https://files.pythonhosted.org/packages/95/ee/149b0d4b1a11c38bff6f14c23d5814c9b0843fd6dc38ad40596bdb1a62d2/pymongo-4.17.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:37a8385c29881b43eab31f584100fa0eaddedd5607adf010147ba1810118be90", size = 1798044, upload-time = "2026-04-20T16:38:07.195Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d4/4cee4a7b8d8f6f0550ef6cd2fea42455c5ed619a220cb6ba4fb40d6a5bc8/pymongo-4.17.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f3ee3d241ed77a4fc99ce3cff3b289c3ebce37f61fdd7349d3592c23b82c8784", size = 1878567, upload-time = "2026-04-20T16:38:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ef/7fe366c84952619ee2f69973566c214775e083dd4df465751912153e4b72/pymongo-4.17.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9eb5d63a3c518cb0804ed678f5e2b875af032d89a7cf57a57360322cf6a4d222", size = 1864881, upload-time = "2026-04-20T16:38:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/35/b577d82c6d1be7aee7ac7e249bc86f7847998345042e5f8360de238e177b/pymongo-4.17.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e97e03fa13327c87e3fdc5656acd01e71817f0c1dc3221cd8f30de136bf4ec3", size = 1800349, upload-time = "2026-04-20T16:38:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/69/dafcf04f66e130ddd91aeb92e7a692480eda46dcd04ec1dbe82c06619e10/pymongo-4.17.0-cp312-cp312-win32.whl", hash = "sha256:6877214bff5f06f6884a9fc8d9016a4a7a5f51f537f5c51ac3a576f93e7dfb32", size = 900518, upload-time = "2026-04-20T16:38:15.541Z" },
+    { url = "https://files.pythonhosted.org/packages/11/35/5c9262a459f988b4eb2605f70815240b77a0d4131136c4326d18f1822b89/pymongo-4.17.0-cp312-cp312-win_amd64.whl", hash = "sha256:9828485f72f63c7d802e0ec41f71906f633c2692621ab3af55ca990186b091b1", size = 920335, upload-time = "2026-04-20T16:38:17.665Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/e9c7265ee176faccf4e52c4797837e794d93569a1046f6b19a4acc36e5ad/pymongo-4.17.0-cp312-cp312-win_arm64.whl", hash = "sha256:1195370a77baf003b59b10e91ecc4706297197f0dd9d29c840cc556dc08f7cee", size = 903289, upload-time = "2026-04-20T16:38:19.33Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/6b/c1206879708b94e82fcd8b9653440ec271f79a3674d122192df383047f5a/pymongo-4.17.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:809ec74de3b9148ae43fa8df9faf53470f511c8d384f13b99d6f671f2a379f15", size = 985829, upload-time = "2026-04-20T16:38:21.031Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cf/bb044ed85160e5c40f568c7c4f4e8ea16f40764ff5d302e5befbe8f6f814/pymongo-4.17.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a431b737816bf4cddd4fa0fcef04e424ad36b7692734a64150f872fb8f3208be", size = 985899, upload-time = "2026-04-20T16:38:23.409Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0a/f6dfd5ea3901e5d6888da8de8ba728971a1d447debab681cfc56f90d1208/pymongo-4.17.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e4fab10f8403169ce92f3cea921609d9ee81107306caae06c08f592d4b8ad2b5", size = 2028569, upload-time = "2026-04-20T16:38:25.343Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/c5/081f59a1c02ae8c0dc73ae58e563838c44eec81aeafa7d0b93a637841c9b/pymongo-4.17.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20323b0b1c1d33770ad1fc68d429c757734ce9ad3594421c3d6618f10572b1b9", size = 2072916, upload-time = "2026-04-20T16:38:27.291Z" },
+    { url = "https://files.pythonhosted.org/packages/31/42/6e41d434297ffe8b30d9c3717916591a4a7be9075a0dcc2fafdfaaaa62ed/pymongo-4.17.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5a5de048e6da5c18e27cc2437e8c15b3b0cdc8385c15b41178b0caa3322a09c2", size = 2173234, upload-time = "2026-04-20T16:38:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/cf/1e4a7db352ef9485831c7268dfe8402f0117b32a9ad54b16e810699e3617/pymongo-4.17.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:dff3de1294fbbc1db0ba6b511f77b8e540601d092538a31312e99c8a91a78b1e", size = 2156784, upload-time = "2026-04-20T16:38:32.134Z" },
+    { url = "https://files.pythonhosted.org/packages/12/10/6195be29962a61ebb5f4bd9e4c7519890b172f7968a0a0d880398c6ddb02/pymongo-4.17.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:faf03e4c2aafd6de626dbd30ba246d369ae33f47f10629d1bbe40f72115027a6", size = 2074446, upload-time = "2026-04-20T16:38:34.004Z" },
+    { url = "https://files.pythonhosted.org/packages/37/48/33410b8819837ed370c738587306bdf060b59cef11823be212f4a07703c5/pymongo-4.17.0-cp313-cp313-win32.whl", hash = "sha256:c9786665926a09630c5d420c79762cfadbff35a9438bcbc4c81a9fb5ab9228b7", size = 948435, upload-time = "2026-04-20T16:38:35.922Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/77/c0ed522f798a286b99acaa7914ed8d9c80ab091f97f57c59ffed72906e5e/pymongo-4.17.0-cp313-cp313-win_amd64.whl", hash = "sha256:5960519b4d7168f1ecdd3ea10c81b2aedeb9423651aca953cfbc8e76705d3b38", size = 972847, upload-time = "2026-04-20T16:38:37.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f0/c39480a2db385fde23861d0c8acda41cdaf1d43e46579db72c5c013a2e81/pymongo-4.17.0-cp313-cp313-win_arm64.whl", hash = "sha256:0ff6bd2f735ab5356541e3e57d5b7dbfbc3f2ee1ccb10b6b0f82d58af69d1d8e", size = 951575, upload-time = "2026-04-20T16:38:40.544Z" },
+    { url = "https://files.pythonhosted.org/packages/da/49/2b0250762a89737ed6f9cea238331baca061b89a8ddd10dd17fee52c3970/pymongo-4.17.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ff5aa3f1c7e3f08eb0e7a016c91ba468b1850ccfd63d9b1f12f56350f4974cef", size = 1040945, upload-time = "2026-04-20T16:38:42.783Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1c/7a9b5447a08be20e84b6e5b17330917e8d6d9507daa3cd099a9309f11ad7/pymongo-4.17.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e816db649ba5d7de0568cf3a9f287a9dc9aad21cf0ca667ab156a7ef47fca0b0", size = 1041187, upload-time = "2026-04-20T16:38:45.358Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a1/71704f61632dfc90407a5834fe5f6132854937c4a3648f6c05c351d85a45/pymongo-4.17.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c4fded3a9f1d6a687e36ebd384ac6d00b9b00de1969aa74048e7051ec2a713", size = 2294806, upload-time = "2026-04-20T16:38:47.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/b9/aff42be75108b96c2469b1d9329b912c15108f3e7ef32fdc86da8423c330/pymongo-4.17.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2db66aa8dd253a0fc1fad3b0d23d5b3993f7ebde02fbbd7727128debf2853675", size = 2348231, upload-time = "2026-04-20T16:38:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/30/44c115b8ba1479942c15fd9480eb29a7da0ba68acd56983423ba0deb4a94/pymongo-4.17.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3987e96e7c7be4083d42e8ac2cc6c0d5b78db9973c90fce42ae800b616ca6b20", size = 2467614, upload-time = "2026-04-20T16:38:52.665Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/84/21ee95c8bf0ca7acae7ec7eb365d740bf8fc0156c194baf2c3bdfcb85ec0/pymongo-4.17.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cee36b3c0d0354f880fa7a7fdcdaf2bb5e542c2281e25c1bfadf8cfe21eba7d2", size = 2445970, upload-time = "2026-04-20T16:38:55.175Z" },
+    { url = "https://files.pythonhosted.org/packages/06/89/081d7f1809d5ca09d1e47e49f2111b245f5694de3a7af32cd3a353a6f43f/pymongo-4.17.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:320b34457b20bbcc79997801f95d25ce00472915ca5241167242b42c4359e027", size = 2348605, upload-time = "2026-04-20T16:38:57.557Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/c3/0d949f9d3f2a341c1f635c398c16615e96f89f51ff424ed81e914cf1a4de/pymongo-4.17.0-cp314-cp314-win32.whl", hash = "sha256:df4a644af9ae132d4bfdb2e9516ea51a615fd881caddfbfbd071cf1354844479", size = 1004119, upload-time = "2026-04-20T16:39:00.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/55/5c3a3db1048054c695c75c5964cc8bedc2247fdb5a75ef6fab4ec8bb013e/pymongo-4.17.0-cp314-cp314-win_amd64.whl", hash = "sha256:c797f8a80957134f6dd9690367a0f8f5906d672119af2c6aa55f0c527b656bed", size = 1032314, upload-time = "2026-04-20T16:39:02.665Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/19/e235f39906134cb0ffd5574c5a59c355ef5380f0499644ab94994afbb109/pymongo-4.17.0-cp314-cp314-win_arm64.whl", hash = "sha256:68fca71e05ee5da23a8d73cee8379dfb3d26e609a377cae731d742771ed96946", size = 1007627, upload-time = "2026-04-20T16:39:04.678Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/e0/c4c1a86791415b14c684fa0908f9da96de91594a3fd1fa1b8dc689fbb800/pymongo-4.17.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b4384700cffc3f1dd98e088bc0072dedf6d7d68a230bb4b972665cf69c071c1e", size = 1099151, upload-time = "2026-04-20T16:39:06.969Z" },
+    { url = "https://files.pythonhosted.org/packages/81/4b/69c67f3e23fd9b23b9bedc7ebd23754881cc9d5c5d5b2a9811e96b07f475/pymongo-4.17.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:93641192644fa1ee0f34030e774fd31022a27ad11ba22cb1716142231524f8bd", size = 1099346, upload-time = "2026-04-20T16:39:08.996Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/19/a5208f62f9508a26d73acc69bd3821b8c8adae253679a3c26d2f9652f0d5/pymongo-4.17.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:75bc3aa5b94fdb7138d357ec6ca61cd97e0c79f4f7f0bd3efe9639b15cc50942", size = 2619034, upload-time = "2026-04-20T16:39:11.049Z" },
+    { url = "https://files.pythonhosted.org/packages/77/27/426cba1ec5973082a56d4150798529bfdf4151c31391ed1fbbecb23ef2ac/pymongo-4.17.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e8f8e23c6df7c6d6929f5e734980b227706e73ee847517c9ba5af90f7fc466", size = 2689939, upload-time = "2026-04-20T16:39:13.617Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2e/f70993d1255e33f6ee59a4ec4371cc65bff7a7e3fda7d55c3386f25287e8/pymongo-4.17.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:15d3f3d732aecac1f8d481bde4029755615639bd3076f258a2147210aec8515a", size = 2824994, upload-time = "2026-04-20T16:39:16.057Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/eb/87b0e988ba889e1fcc3430c2cfc166b251872c813e92b43174298bee17ff/pymongo-4.17.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c5f62862d0f87be481fa1fe8cb811994486773c94a2b61e509285e3f2890763", size = 2801745, upload-time = "2026-04-20T16:39:18.476Z" },
+    { url = "https://files.pythonhosted.org/packages/67/4c/3f83412d086f682d4d468761d66ddc49cf161e786ea74073045eb4491c60/pymongo-4.17.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:64837adbbd72073301af51bb0fc80e3d7707fe5527cea1033ba0320f0b2f881b", size = 2684636, upload-time = "2026-04-20T16:39:20.878Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d8/b75f6f4ab6c8beb50b0270a4f1e2530b5774f5e116563440e1677ca1820f/pymongo-4.17.0-cp314-cp314t-win32.whl", hash = "sha256:b93b22eedc62598cf5ee9d8c8007a8e9121c50fd88137012d8985500e9dc3151", size = 1056356, upload-time = "2026-04-20T16:39:22.996Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5e/648c8a238eef18a25ed8a169ea6542d4a860bbec3e95b3d9badac2935c71/pymongo-4.17.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3689ea34f6b647c7d1e7bdc60fcfb214b2789ed1359a7fb96569c69f50e5f18f", size = 1090964, upload-time = "2026-04-20T16:39:24.989Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/cb/d9780b66939c4fc1f024bcc7be23a2abcfe06a9745ca8fa76dc73395482e/pymongo-4.17.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9543d8f84c2e5608565c08ac679774811e6730770d8a645439b073422a4276fb", size = 1058526, upload-time = "2026-04-20T16:39:27.924Z" },
 ]
 
 [[package]]
@@ -5040,6 +5107,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/02/ef62dec9e4f804189c44df23f0b86897c738d38e9c48282fcd410308632f/testcontainers-4.14.1.tar.gz", hash = "sha256:316f1bb178d829c003acd650233e3ff3c59a833a08d8661c074f58a4fbd42a64", size = 80148, upload-time = "2026-01-31T23:13:46.915Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/31/5e7b23f9e43ff7fd46d243808d70c5e8daf3bc08ecf5a7fb84d5e38f7603/testcontainers-4.14.1-py3-none-any.whl", hash = "sha256:03dfef4797b31c82e7b762a454b6afec61a2a512ad54af47ab41e4fa5415f891", size = 125640, upload-time = "2026-01-31T23:13:45.464Z" },
+]
+
+[package.optional-dependencies]
+mongodb = [
+    { name = "pymongo" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Ports the MongoDB archiver connector from PR #84 (@RemiLehe) into the current built-in-registry pattern, with lazy `pymongo` import so the dep stays optional.
- Adds the missing pieces #84 listed as TODO: a `testcontainers`-backed integration test suite (31 tests, mirrors the `tests/services/ariel_search/` pattern) and a documentation section in `how-to/add-connector.rst`.
- Fixes a packaging bug along the way: `pyepics` was in `[dev]` even though three production paths import it (`control_system` connector, `limits_validator`, `python_executor` wrapper).

This PR supersedes #84 — close #84 after this merges. The original author is credited in the connector commit body.

## Commits

| # | Commit | What |
|---|---|---|
| 1 | `620dbb15` | `feat(connectors): add MongoDB archiver connector` — ported from #84, lazy `pymongo` import, registered in built-in factory |
| 2 | `6da902f9` | `chore(deps): add archiver-mongodb extra; promote pyepics to base deps` — `archiver-mongodb = ["pymongo>=4.0"]` (also in `all`); `pyepics` moved from `[dev]` to base; `testcontainers[mongodb]` added to `[dev]`; pymongo added to mypy `ignore_missing_imports` |
| 3 | `88249544` | `test(connectors): MongoDB archiver integration tests via testcontainers` — 31 tests across 6 classes, all marked `@pytest.mark.integration`; replaces #84's `pytest-docker` conftest with `testcontainers.MongoDbContainer(mongo:7)`; cleanly skips when Docker is unavailable |
| 4 | `0f235ed5` | `docs(connectors): document MongoDB archiver` — adds `mongodb_archiver` to the Built-in Connectors list and a "MongoDB Archiver" subsection covering config shape, expected document layout, and the optional-install command; two CHANGELOG entries under `[Unreleased]` |

## Test plan

- [ ] CI passes (unit + lint + type check).
- [ ] `uv sync --extra dev --extra archiver-mongodb && uv run pytest tests/connectors/test_mongodb_archiver_connector.py -v` — expect 31 passed on a Docker-enabled runner; expect a clean skip without Docker.
- [ ] Sanity check that `mongodb_archiver` shows up in `ConnectorFactory.list_archivers()` only when `pymongo` is installed and disappears cleanly when it isn't.
- [ ] `cd docs && make html` builds without warnings on the touched page.