### PR TITLE
release: v2026.5.2 — Reliability & integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+## [2026.5.2] - 2026-05-27
+
+### Added
+
 - Pin Claude Code CLI version per project. New `claude_code.cli_version` config field; when set, OSPREY launches via `npx -y @anthropic-ai/claude-code@<version>` instead of bare `claude`. Use to insulate projects from upstream CC breakage (#218). Verified by `osprey health`; bypass with `osprey claude chat --no-pin`.
 - **MongoDB archiver connector.** New `mongodb_archiver` type for querying MongoDB time-series collections; install via `pip install "osprey-framework[archiver-mongodb]"` and configure with `archiver.type: mongodb_archiver` plus host/database/collection/auth settings. Ports PR #84 (RemiLehe) onto the current registry; documents are expected to have shape `{date: ISODate, PV1: value, PV2: value, ...}`.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
-**🎉 Latest Release: v2026.5.1** - Unified channel-finder paradigms, standalone ARIEL preset, GitHub Flow + contributor skills, and the post-2026.5.0 cleanup batch
+**🎉 Latest Release: v2026.5.2** - Reliability & integrations: SDK sub-agent trace collection restored, e2e suite stabilized, MongoDB archiver connector, and per-project Claude Code CLI pinning
 
 > **🚧 Early Access Release**
 > This is an early access version of the Osprey Framework. While the core functionality is stable and ready for experimentation, documentation and APIs may still evolve. We welcome feedback and contributions!

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,21 +1,18 @@
-# Osprey Framework - Latest Release (v2026.5.1)
+# Osprey Framework - Latest Release (v2026.5.2)
 
-**Paradigm-agnostic channel finder, ARIEL standalone, and the v2026.5.0 cleanup batch**
+**Reliability & integrations: SDK sub-agent trace collection restored, e2e suite stabilized, plus a MongoDB archiver and per-project Claude Code CLI pinning**
 
 ## Highlights
 
-- **Paradigm-agnostic channel finder.** `in_context` / `hierarchical` / `middle_layer` share one tier-resolved query set; `control_assistant` ships all 9 tier DBs.
-- **ARIEL standalone preset.** Logbook deployment without the control-system stack — see the [standalone deployment guide](https://als-apg.github.io/osprey/how-to/ariel/standalone-deployment.html).
-- **Virtual-accelerator scenarios.** Mock archiver emits seeded correlated events for operator-style investigation tests.
-- **Cleanup batch.** `osprey build` after `uv tool install` (#216), `osprey deploy up` on service-less presets, `suffix_map` in channel addresses, ARGO base URL (#214), E2E green again on CI.
+- **SDK sub-agent traces restored.** Claude Code CLI ≥2.1.x stopped streaming sub-agent messages through `query()`, blinding delegation/viz/search e2e tests. The trace collector now reads sub-agent transcripts via `list_subagents`/`get_subagent_messages`.
+- **MongoDB archiver connector.** New `mongodb_archiver` type for MongoDB time-series collections — `pip install "osprey-framework[archiver-mongodb]"` (ports PR #84).
+- **Per-project Claude Code CLI pinning.** New `claude_code.cli_version` field launches via `npx -y @anthropic-ai/claude-code@<version>` to insulate projects from upstream CLI breakage (#218).
+- **e2e stabilization.** Multi-step agentic-pipeline tests get `@pytest.mark.flaky(reruns=2)` to absorb rare Haiku stochastic misses; deterministic safety/approval/delegation tests stay strict.
 
-## Breaking
+## Notable changes
 
-- `prompts` → `scaffold` (CLI, web, Python, config) — no shim.
-- ARIEL internal RAG / Agent pipelines removed; drop `pipelines.rag` / `pipelines.agent` from configs.
-- Channel-finder hierarchical schema: bare-numeric device IDs.
-- `build-interview` skill renamed to `osprey-build-interview`.
-- `channel_finder_mode="all"` removed.
+- `pyepics` promoted to base dependencies — EPICS users no longer need the `[dev]` extra.
+- `claude-agent-sdk` upgraded to 0.2.87 (lockfile + venv now match); CBORG/als-apg/anthropic routing re-verified.
 
 ## Installation
 

--- a/src/osprey/__init__.py
+++ b/src/osprey/__init__.py
@@ -10,7 +10,7 @@ This package contains:
 """
 
 # Version information
-__version__ = "2026.5.1"
+__version__ = "2026.5.2"
 
 __all__ = ["__version__"]
 

--- a/src/osprey/cli/main.py
+++ b/src/osprey/cli/main.py
@@ -32,7 +32,7 @@ if sys.platform == "win32":
 try:
     from osprey import __version__
 except ImportError:
-    __version__ = "2026.5.1"
+    __version__ = "2026.5.2"
 
 
 class LazyGroup(click.Group):


### PR DESCRIPTION
## Summary

Version-bump PR for **v2026.5.2** — "Reliability & integrations". Patch release within May 2026 (follows v2026.5.1). No breaking changes this cycle.

Bumps `__version__` in `src/osprey/__init__.py` + `cli/main.py`, rotates `## [Unreleased]` → `## [2026.5.2]` in the CHANGELOG, and refreshes RELEASE_NOTES.md + the README "Latest Release" line.

## CHANGELOG — [2026.5.2] - 2026-05-27

### Added
- Pin Claude Code CLI version per project. New `claude_code.cli_version` config field; when set, OSPREY launches via `npx -y @anthropic-ai/claude-code@<version>` instead of bare `claude`. Use to insulate projects from upstream CC breakage (#218). Verified by `osprey health`; bypass with `osprey claude chat --no-pin`.
- **MongoDB archiver connector.** New `mongodb_archiver` type for querying MongoDB time-series collections; install via `pip install "osprey-framework[archiver-mongodb]"` and configure with `archiver.type: mongodb_archiver` plus host/database/collection/auth settings. Ports PR #84 (RemiLehe) onto the current registry.

### Changed
- Documentation cleanup pass over `docs/source/`: resync getting-started, how-to, architecture, and reference pages with the current codebase.
- **`pyepics` promoted to base dependencies.** EPICS connector users no longer need the `[dev]` extra; pyepics is used in three production paths.
- **`claude-agent-sdk` upgraded to 0.2.87** (lockfile + venv now match `pyproject.toml`). Bundles CLI 2.1.150; CBORG/als-apg/anthropic-direct routing re-verified.

### Fixed
- `BaseStore`: in-process lock fixes a lost-update race between the gallery index-watcher thread and same-process saves.
- `quick_check.sh` / `ci_check.sh` prune stale `__pycache__` + empty dirs so a deleted package can't resurface as a namespace package locally.
- e2e SDK trace collector now reads sub-agent transcripts via `list_subagents`/`get_subagent_messages` (CLI ≥2.1.x stopped streaming sub-agent messages through `query()`).
- `test_channel_read_archiver_plot_with_audit`: dropped chronological tool-ordering assertions (harvested sub-agent traces are appended after the main stream).
- `test_claude_code_build_integration` archiver+plot tests: dropped the model-dependent closing-message vocabulary scan; PNG/data-file artifact assertions remain authoritative.
- `hello_world` preset triggered "OSPREY APPROVAL REQUIRED" on `channel_read` (missing `approval:` block after the May 5 `global_mode` removal). Added standard per-tool policies.
- channel-finder `in_context`/`middle_layer` MCP servers crashed on startup (missing required `workspace_root` arg after RF-001); both now resolve it.
- Multi-step agentic-pipeline e2e tests now `@pytest.mark.flaky(reruns=2)` to absorb ~5%/run Haiku stochastic misses; deterministic safety/approval/delegation tests stay strict. Adds `pytest-rerunfailures` dev dep.

### Removed
- ARIEL's duplicate Claude Setup tab (`/api/claude-setup` endpoints, `claude-setup.js`, related HTML/CSS). Canonical agent-file editor remains in the web terminal.

## Test plan
- CI just passed on the merged feature PR; this PR is pure version metadata.
- Local: `ruff check` + `ruff format --check` clean on edited Python files; pre-commit hooks pass.
- Version consistency verified across all 5 files (`__init__.py`, `cli/main.py`, RELEASE_NOTES, README, CHANGELOG) — all `2026.5.2`.
- The 8 required GitHub checks gate this PR before merge.
