### PR TITLE
Add Gitleaks hook to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,12 @@ repos:
       # Check for debugger imports
       - id: debug-statements
 
+  # Detect hardcoded secrets (passwords, API keys, tokens, etc.)
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+
 # pre-commit.ci configuration
 ci:
   autofix_commit_msg: |


### PR DESCRIPTION
Gitleaks ([github.com/gitleaks/gitleaks](https://github.com/gitleaks/gitleaks)) is a tool for detecting secrets like passwords, API keys, and tokens in git repositories, files, and directories. 

The hook is supported by pre-commit and listed at [pre-commit.com/hooks.html](https://pre-commit.com/hooks.html) in the "secret scanning / security" section.

We started adopting it in the BLAST codes (see, e.g., https://github.com/BLAST-WarpX/warpx/pull/6929) and I thought it could be a good idea to adopt it in Osprey as well.