### PR TITLE
[WIP] Add literal channel limit name search

### DIFF
--- a/src/osprey/mcp_server/control_system/tools/channel_limits.py
+++ b/src/osprey/mcp_server/control_system/tools/channel_limits.py
@@ -72,13 +72,22 @@ def _build_channel_entry(validator, channel_address: str) -> dict:
     return entry
 
 
-def _match_channels(validator, pattern: str | None, filter_by: str | None) -> dict:
+def _match_channels(
+    validator,
+    pattern: str | None,
+    name_contains: str | None,
+    filter_by: str | None,
+) -> dict:
     """Match channels by regex pattern and/or property filter. Returns compact entries."""
     addresses = list(validator.limits.keys())
 
     # Apply regex filter
     if pattern:
         addresses = [a for a in addresses if re.search(pattern, a)]
+
+    # Apply literal substring filter
+    if name_contains:
+        addresses = [a for a in addresses if name_contains in a]
 
     # Apply property filter
     if filter_by:
@@ -123,6 +132,7 @@ def _match_channels(validator, pattern: str | None, filter_by: str | None) -> di
 async def channel_limits(
     channels: list[str] | None = None,
     pattern: str | None = None,
+    name_contains: str | None = None,
     filter_by: str | None = None,
 ) -> str:
     """Query the channel safety limits database.
@@ -135,12 +145,15 @@ async def channel_limits(
       - No params: summary statistics and policy overview
       - channels: detailed config for specific channel addresses
       - pattern: regex search across all channel addresses
-      - pattern + filter_by: regex search filtered by property
+      - name_contains: literal substring search across all channel addresses
+      - pattern/name_contains + filter_by: search filtered by property
       - filter_by alone: all channels matching a property
 
     Args:
         channels: Exact channel addresses to look up.
         pattern: Regex to match against channel addresses.
+        name_contains: Literal substring to match against channel addresses. Use this for
+                       names containing regex metacharacters such as [], (), ., or ^.
         filter_by: Property filter — one of: writable, read_only,
                    has_step_limit, has_range, readback_verified.
 
@@ -148,11 +161,21 @@ async def channel_limits(
         JSON with channel limits configuration or database summary.
     """
     # Validate parameter combinations
-    if channels is not None and pattern is not None:
+    if channels is not None and (pattern is not None or name_contains is not None):
         return make_error(
             "validation_error",
-            "Cannot combine 'channels' (exact lookup) with 'pattern' (regex search).",
-            ["Use 'channels' for exact addresses or 'pattern' for regex matching, not both."],
+            "Cannot combine 'channels' (exact lookup) with search parameters.",
+            [
+                "Use 'channels' for exact addresses, 'pattern' for regex matching, "
+                "or 'name_contains' for literal substring matching."
+            ],
+        )
+
+    if pattern is not None and name_contains is not None:
+        return make_error(
+            "validation_error",
+            "Cannot combine 'pattern' (regex search) with 'name_contains' (literal search).",
+            ["Use either 'pattern' or 'name_contains', not both."],
         )
 
     if filter_by is not None and filter_by not in VALID_FILTERS:
@@ -196,7 +219,7 @@ async def channel_limits(
         )
 
     # Dispatch to the appropriate mode
-    if channels is None and pattern is None and filter_by is None:
+    if channels is None and pattern is None and name_contains is None and filter_by is None:
         # Summary mode
         return json.dumps(_build_summary(validator), default=str)
 
@@ -230,11 +253,13 @@ async def channel_limits(
             default=str,
         )
 
-    # Search / Filter mode (pattern and/or filter_by)
-    matched = _match_channels(validator, pattern, filter_by)
+    # Search / Filter mode (pattern/name_contains and/or filter_by)
+    matched = _match_channels(validator, pattern, name_contains, filter_by)
     desc_parts = []
     if pattern:
         desc_parts.append(f"pattern={pattern!r}")
+    if name_contains:
+        desc_parts.append(f"name_contains={name_contains!r}")
     if filter_by:
         desc_parts.append(f"filter={filter_by}")
 

--- a/tests/mcp_server/test_channel_limits_tool.py
+++ b/tests/mcp_server/test_channel_limits_tool.py
@@ -35,6 +35,17 @@ TEST_LIMITS_DB = {
         "max_value": 100.0,
         "writable": True,
     },
+    "Amplifier 2 [J]": {
+        "min_value": 0.0,
+        "max_value": 50.0,
+        "writable": True,
+    },
+    "DDG-AA-ShotCntrl Delay.Ch H": {
+        "writable": True,
+    },
+    "Background density [1e18/cm^3]": {
+        "writable": False,
+    },
 }
 
 
@@ -94,9 +105,9 @@ async def test_summary_mode():
 
     data = extract_response_dict(result)
     assert data["status"] == "success"
-    assert data["summary"]["total_channels"] == 3
-    assert data["summary"]["writable"] == 2
-    assert data["summary"]["read_only"] == 1
+    assert data["summary"]["total_channels"] == 6
+    assert data["summary"]["writable"] == 4
+    assert data["summary"]["read_only"] == 2
     assert data["summary"]["has_step_limit"] == 1
     assert data["summary"]["version"] == "1.0"
     assert data["access_details"]["policy"]["allow_unlisted_channels"] is True
@@ -242,6 +253,43 @@ async def test_pattern_invalid_regex():
 
 
 # ---------------------------------------------------------------------------
+# Literal name search mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_name_contains_matches_regex_metacharacters_literally():
+    """name_contains uses literal matching for names with [], (), ., ^, etc."""
+    with patch(
+        "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
+        return_value=_make_validator(),
+    ):
+        fn = _get_channel_limits()
+        result = await fn(name_contains="Amplifier 2 [J]")
+
+    data = extract_response_dict(result)
+    channels = data["access_details"]["channels"]
+    assert len(channels) == 1
+    assert "Amplifier 2 [J]" in channels
+
+
+@pytest.mark.unit
+async def test_name_contains_treats_dot_as_literal():
+    """Literal matching should not treat '.' as a regex wildcard."""
+    with patch(
+        "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
+        return_value=_make_validator(),
+    ):
+        fn = _get_channel_limits()
+        result = await fn(name_contains="Delay.Ch")
+
+    data = extract_response_dict(result)
+    channels = data["access_details"]["channels"]
+    assert len(channels) == 1
+    assert "DDG-AA-ShotCntrl Delay.Ch H" in channels
+
+
+# ---------------------------------------------------------------------------
 # Filter mode
 # ---------------------------------------------------------------------------
 
@@ -258,7 +306,7 @@ async def test_filter_writable():
 
     data = extract_response_dict(result)
     channels = data["access_details"]["channels"]
-    assert len(channels) == 2
+    assert len(channels) == 4
     assert all(ch["writable"] is True for ch in channels.values())
 
 
@@ -274,7 +322,7 @@ async def test_filter_read_only():
 
     data = extract_response_dict(result)
     channels = data["access_details"]["channels"]
-    assert len(channels) == 1
+    assert len(channels) == 2
     assert "MAG:QF01:CURRENT:SP" in channels
 
 
@@ -332,6 +380,22 @@ async def test_combined_pattern_and_filter():
     assert "MAG:HCM01:CURRENT:SP" in channels
 
 
+@pytest.mark.unit
+async def test_combined_name_contains_and_filter():
+    """name_contains + filter_by → literal search filtered by property."""
+    with patch(
+        "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
+        return_value=_make_validator(),
+    ):
+        fn = _get_channel_limits()
+        result = await fn(name_contains="[", filter_by="read_only")
+
+    data = extract_response_dict(result)
+    channels = data["access_details"]["channels"]
+    assert len(channels) == 1
+    assert "Background density [1e18/cm^3]" in channels
+
+
 # ---------------------------------------------------------------------------
 # Validation errors
 # ---------------------------------------------------------------------------
@@ -343,6 +407,26 @@ async def test_channels_and_pattern_error():
     fn = _get_channel_limits()
     with assert_raises_error(error_type="validation_error") as _exc_ctx:
         await fn(channels=["TEST:PV"], pattern="TEST:.*")
+
+    _exc_ctx["envelope"]
+
+
+@pytest.mark.unit
+async def test_channels_and_name_contains_error():
+    """Both channels and name_contains → validation_error."""
+    fn = _get_channel_limits()
+    with assert_raises_error(error_type="validation_error") as _exc_ctx:
+        await fn(channels=["TEST:PV"], name_contains="TEST")
+
+    _exc_ctx["envelope"]
+
+
+@pytest.mark.unit
+async def test_pattern_and_name_contains_error():
+    """Both pattern and name_contains → validation_error."""
+    fn = _get_channel_limits()
+    with assert_raises_error(error_type="validation_error") as _exc_ctx:
+        await fn(pattern="TEST:.*", name_contains="TEST")
 
     _exc_ctx["envelope"]
 


### PR DESCRIPTION
## Motivation
Some control-system PV/channel names contain characters that are meaningful in Python regular expressions, such as ``.``, `[]`, `()`, and `^`. Today, users have to know to escape those characters when using `channel_limits(pattern=...)`, which is easy to get wrong for human-readable names like `Amplifier 2 [J]` or `DDG-AA-ShotCntrl Delay.Ch H`.

This adds a literal substring search path so callers can search for these names without regex escaping, while preserving the existing regex behavior for callers that want it.

## Summary
- add literal substring search via `name_contains` to `channel_limits`
- preserve existing regex-based `pattern` behavior
- reject ambiguous combinations of `pattern` and `name_contains`
- cover names with regex metacharacters in unit tests

## Tests
- `uv run --extra dev pytest tests/mcp_server/test_channel_limits_tool.py`