### PR TITLE
build(deps): bump codecov/codecov-action from 6 to 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         uv run pytest tests/ --ignore=tests/e2e -v --tb=short --cov=src/osprey --cov-report=xml --cov-report=term
 
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@v7
       if: matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
       with:
         files: ./coverage.xml


### PR DESCRIPTION
## Summary
- Same one-line bump as dependabot #240 (`codecov/codecov-action@v6` → `@v7` in ci.yml), re-pushed from a maintainer branch so CI runs with repo secrets.
- #240's required `E2E Tests` check fails structurally on dependabot PRs (no secrets → empty `ALS_APG_API_KEY` → instant preflight failure), not because of the action bump.

## Changes
- `.github/workflows/ci.yml`: `codecov/codecov-action@v7` in the coverage-upload step.
- v7.0.0 release notes: GPG signing-key/account rotation only — no changes to the inputs we use (`files`, `flags`, `name`, `fail_ci_if_error`) or to `CODECOV_TOKEN` handling.

## Test plan
- [x] `quick_check.sh` + pre-commit (incl. YAML check) pass locally
- [ ] Full CI on this PR — confirm the Codecov upload step in `Test Python 3.11 on ubuntu-latest` succeeds with v7

## Related issues
- Closes #240 (dependabot original)