### PR TITLE
release: v2026.6.0 — Containerization & local inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ## [Unreleased]
 
+## [2026.6.0] - 2026-06-12
+
 ### Added
 
 - **`ds4` provider** — local DwarfStar/DeepSeek-V4 inference server (OpenAI-compatible, keyless, default `http://127.0.0.1:8000/v1`). Introduces a per-provider `supports_native_structured_output` capability flag (`True`/`False`/`None`=auto-detect via LiteLLM) replacing the hardcoded structured-output whitelist; ds4 declares `False` because the server accepts but ignores `response_format: json_schema`, so OSPREY's prompt-based JSON fallback is used. Also fixes URL mangling in the vLLM/ds4 health checks (`rstrip('/v1')` stripped characters, breaking ports ending in `1`).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
-**🎉 Latest Release: v2026.5.2** - Reliability & integrations: SDK sub-agent trace collection restored, e2e suite stabilized, MongoDB archiver connector, and per-project Claude Code CLI pinning
+**🎉 Latest Release: v2026.6.0** - Containerization & local inference: per-project reference Dockerfile, the ds4 local-inference provider, and a data-driven simulation engine
 
 > **🚧 Early Access Release**
 > This is an early access version of the Osprey Framework. While the core functionality is stable and ready for experimentation, documentation and APIs may still evolve. We welcome feedback and contributions!

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,18 +1,20 @@
-# Osprey Framework - Latest Release (v2026.5.2)
+# Osprey Framework - Latest Release (v2026.6.0)
 
-**Reliability & integrations: SDK sub-agent trace collection restored, e2e suite stabilized, plus a MongoDB archiver and per-project Claude Code CLI pinning**
+**Containerization & local inference: a per-project reference Dockerfile, the `ds4` local-inference provider, and a data-driven simulation engine**
 
 ## Highlights
 
-- **SDK sub-agent traces restored.** Claude Code CLI ≥2.1.x stopped streaming sub-agent messages through `query()`, blinding delegation/viz/search e2e tests. The trace collector now reads sub-agent transcripts via `list_subagents`/`get_subagent_messages`.
-- **MongoDB archiver connector.** New `mongodb_archiver` type for MongoDB time-series collections — `pip install "osprey-framework[archiver-mongodb]"` (ports PR #84).
-- **Per-project Claude Code CLI pinning.** New `claude_code.cli_version` field launches via `npx -y @anthropic-ai/claude-code@<version>` to insulate projects from upstream CLI breakage (#218).
-- **e2e stabilization.** Multi-step agentic-pipeline tests get `@pytest.mark.flaky(reruns=2)` to absorb rare Haiku stochastic misses; deterministic safety/approval/delegation tests stay strict.
+- **Per-project reference Dockerfile.** `osprey build` now renders a self-documenting `Dockerfile` + `.dockerignore` into every project — install Claude Code + OSPREY, copy the project, serve the web terminal on 8087 as a non-root user. User-owned (never touched by `regen`); site extension via three build ARGs. New how-to: `docs/source/how-to/containerize-project.rst`.
+- **`ds4` local-inference provider.** Keyless, OpenAI-compatible local DwarfStar/DeepSeek-V4 server (default `http://127.0.0.1:8000/v1`). Introduces a per-provider `supports_native_structured_output` flag replacing the hardcoded structured-output whitelist.
+- **Data-driven simulation engine** (`osprey.simulation`). A `machine.json` defines channels, fault scenarios, and archiver event scripts so corrective writes propagate through physics couplings and archived history correlates with live values. Ships with a generic `sim-scenarios` skill.
+- **`osprey claude regen --runtime-root PATH`.** Re-anchors `project_root` and re-renders Claude Code artifacts for a relocated checkout (e.g. inside a container); a stale `python_env_path` falls back to the current interpreter.
 
 ## Notable changes
 
-- `pyepics` promoted to base dependencies — EPICS users no longer need the `[dev]` extra.
-- `claude-agent-sdk` upgraded to 0.2.87 (lockfile + venv now match); CBORG/als-apg/anthropic routing re-verified.
+- `claude-agent-sdk` upgraded to 0.2.93 (bundles CLI 2.1.167); als-apg routing re-verified.
+- `data-visualizer` subagent defaults to `create_interactive_plot` for unspecified plot requests.
+- Config edits now auto-regenerate Claude Code artifacts so changes (e.g. `writes_enabled`) take effect without a stale-settings gap (#244).
+- Archiver `None`-gap values no longer crash `lttb_downsample()`; gaps render as true gaps in charts (#247).
 
 ## Installation
 

--- a/src/osprey/__init__.py
+++ b/src/osprey/__init__.py
@@ -10,7 +10,7 @@ This package contains:
 """
 
 # Version information
-__version__ = "2026.5.2"
+__version__ = "2026.6.0"
 
 __all__ = ["__version__"]
 

--- a/src/osprey/cli/main.py
+++ b/src/osprey/cli/main.py
@@ -32,7 +32,7 @@ if sys.platform == "win32":
 try:
     from osprey import __version__
 except ImportError:
-    __version__ = "2026.5.2"
+    __version__ = "2026.6.0"
 
 
 class LazyGroup(click.Group):


### PR DESCRIPTION
## Summary

- Cuts release **v2026.6.0** — theme: *Containerization & local inference*.
- Bumps `__version__` (`__init__.py` + `cli/main.py` fallback), date-stamps the CHANGELOG, and refreshes `RELEASE_NOTES.md` / README "Latest Release".
- No code changes beyond version strings + release docs. No breaking changes.

## Release contents (CHANGELOG [2026.6.0])

### Added

- **`ds4` provider** — local DwarfStar/DeepSeek-V4 inference server (OpenAI-compatible, keyless). Per-provider `supports_native_structured_output` flag replaces the hardcoded structured-output whitelist; fixes vLLM/ds4 health-check URL mangling.
- **Data-driven simulation engine** (`osprey.simulation`) backing the mock control-system + archiver connectors; ships a generic `sim-scenarios` skill.
- **Generated reference Dockerfile** per project (`osprey build`), user-owned, site-extensible via three build ARGs. New how-to `docs/source/how-to/containerize-project.rst`.
- **`osprey claude regen --runtime-root PATH`** — re-anchors `project_root` + re-renders Claude artifacts for a relocated checkout; stale `python_env_path` falls back to the current interpreter.
- New e2e `test_corrector_limit_honest_refusal_scenario.py` — asserts agent behavior under refusal (two-layer deterministic + LLM-judge grading).

### Changed

- `claude-agent-sdk` upgraded to **0.2.93** (bundles CLI 2.1.167); als-apg routing re-verified.
- `data-visualizer` subagent defaults to `create_interactive_plot` for unspecified plot requests.

### Fixed

- `ariel search` CLI renders keyword-search entries when no composed answer is available.
- `osprey build` re-anchors profile-overlaid logbook seeds to the current date.
- Config edits auto-regenerate Claude artifacts so changes (e.g. `writes_enabled`) take effect; SessionStart drift guard added (#244).
- Regen drift detection no longer reports phantom drift for user-owned artifacts.
- `lttb_downsample()` no longer crashes on archiver `None` gap values; true gaps preserved in charts (#247).
- `rules/data-visualization.md` gated on the data-visualizer subagent being disabled (renders empty when enabled).

### Removed

- Unused `caproto` dependency + stale `osprey generate soft-ioc` hints.

## Test plan

- [x] Clean-venv (`pip install -e ".[dev]"`) unit suite: **4252 passed, 31 skipped** (Docker/EPICS env skips).
- [x] `quick_check.sh` + `ci_check.sh` green (ruff, tests, docs build, package build, twine check).
- [x] `premerge_check.sh main` clean.
- [x] Version consistency verified across `__init__.py`, `cli/main.py`, `RELEASE_NOTES.md`, `README.md`, `CHANGELOG.md` heading.

> Note: the local clean-venv build initially tripped on `claude-agent-sdk==0.2.93` being <7 days old vs a personal `uv` `exclude-newer` window; verified resolvable with the documented `UV_EXCLUDE_NEWER` override. CI/PyPI resolve it fine (SDK 0.2.93 published 2026-06-06; #253/#254 already merged green).

## Notes

- The `virtual-linac` preset (PR #243) is **not** in this release — only its simulation-engine backend (#250). It ships in a follow-up once #243 lands.
