### PR TITLE
fix(cli): prevent crash in `osprey build` when removing agents/MCPs from presets

### DIFF
--- a/src/osprey/cli/templates/claude_code.py
+++ b/src/osprey/cli/templates/claude_code.py
@@ -419,16 +419,24 @@ def create_claude_code_integration(
                 if str(output_rel) == "rules/facility.md":
                     continue
 
-                # Skip files not in manifest (when manifest is active)
-                if allowed_outputs is not None and dst_rel not in allowed_outputs:
-                    continue
-
                 # Skip user-owned files
                 if is_user_owned(dst_rel, ctx):
                     continue
 
-                # Render Jinja2 template, strip .j2 extension
                 dst_file = project_dir / ".claude" / output_rel
+
+                # Not in manifest (when manifest is active): remove any stale
+                # file left by an earlier render pass with a wider manifest
+                # (e.g. an agent dropped from the profile's artifact
+                # selection) instead of orphaning it on disk.
+                if allowed_outputs is not None and dst_rel not in allowed_outputs:
+                    if dst_file.exists():
+                        dst_file.unlink()
+                        if dst_file.parent != project_dir and not any(dst_file.parent.iterdir()):
+                            dst_file.parent.rmdir()
+                    continue
+
+                # Render Jinja2 template, strip .j2 extension
                 dst_file.parent.mkdir(parents=True, exist_ok=True)
                 template_path = f"claude_code/claude/{rel_path}"
                 render_template(jinja_env, template_path, ctx, dst_file)
@@ -443,15 +451,19 @@ def create_claude_code_integration(
             else:
                 dst_rel = f".claude/{rel_path}"
 
-                # Skip files not in manifest (when manifest is active)
-                if allowed_outputs is not None and dst_rel not in allowed_outputs:
-                    continue
-
                 # Skip user-owned files
                 if is_user_owned(dst_rel, ctx):
                     continue
 
                 dst_file = project_dir / ".claude" / rel_path
+
+                # Not in manifest: remove any stale file from an earlier,
+                # wider render pass instead of orphaning it on disk.
+                if allowed_outputs is not None and dst_rel not in allowed_outputs:
+                    if dst_file.exists():
+                        dst_file.unlink()
+                    continue
+
                 dst_file.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(src_file, dst_file)
             files_created += 1
@@ -720,6 +732,8 @@ def regenerate_claude_code(
                 changed.append(rel_path)
             else:
                 unchanged.append(rel_path)
+        elif rel_path in old_checksums:
+            changed.append(rel_path)  # Removed (e.g. dropped from manifest)
 
     # Check for newly created files (e.g., new agents)
     new_agents_dir = project_dir / ".claude" / "agents"


### PR DESCRIPTION
## The bug

`osprey build` fails when a profile removes an agent from the `agents:`
list *and* disables the MCP server that agent depends on — exactly what
you'd do to turn off the logbook feature entirely.

### Minimal repro

Starting from the `control-assistant` preset, change only the `agents:`
list (drop `logbook-search` / `logbook-deep-research`) and disable the
`ariel` server they depend on:

```yaml
data_bundle: control_assistant
provider: anthropic
model: claude-haiku-4-5
channel_finder_mode: hierarchical

agents:
  - channel-finder
  - data-visualizer
  # logbook-search and logbook-deep-research removed

config:
  control_system.type: mock
  claude_code.servers.ariel.enabled: false
```

`osprey build myproject profile.yml` aborts with:

```
✗ Build error: Agent tool/permission drift detected:
  agent logbook-search: tool 'mcp__ariel__keyword_search' not present in .claude/settings.json permissions.allow
  agent logbook-search: tool 'mcp__ariel__semantic_search' not present in .claude/settings.json permissions.allow
  ...
Aborted!
```

This is confusing: the profile never asked for `logbook-search` to exist
at all, so why is the build complaining about its tools?

(Dropping the agent *without* also disabling `ariel` doesn't crash, but
silently leaves `logbook-search.md` on disk fully functional — agents are
deceptively hard to remove.)

## Why: Osprey's two-pass render

`osprey build` renders `.claude/` twice:

1. **`create_project`** does the first, "from scratch" render. It computes
   the allowed file list (`allowed_outputs`) from the *bundled template's*
   default `manifest.yml` — which lists **all** framework agents
   (`channel-finder`, `data-visualizer`, `logbook-search`,
   `logbook-deep-research`), not the profile's narrower selection. At this
   point `config.yml` doesn't have the profile's `config:` overrides
   applied yet either. So `logbook-search.md` / `logbook-deep-research.md`
   get written with full, live content (including their `tools:`
   frontmatter referencing `mcp__ariel__*`).
2. **`regenerate_claude_code`** ("re-render with complete config") runs
   later, after the profile's overrides are applied and `.osprey-manifest.json`
   has been written with the *actual* selection (`channel-finder`,
   `data-visualizer` only). This pass correctly computes a narrower
   `allowed_outputs`, but `create_claude_code_integration()` only **skips**
   re-writing files outside that set — it never deletes the stale ones left
   by pass 1.

So `logbook-search.md` / `logbook-deep-research.md` are orphaned on disk
with their original `mcp__ariel__*` tool list, even though `ariel` is
disabled and those tools were correctly never added to
`.claude/settings.json`'s `permissions.allow`.

The newly-added `validate_agent_tools_against_permissions` check (which
exists to catch real drift — e.g. a facility author adding a tool to an
agent without updating permissions) scans every `*.md` under
`.claude/agents/` regardless of manifest scope, finds the orphaned files,
and aborts the build on what is actually a false positive.

## The fix

In `create_claude_code_integration()` (`src/osprey/cli/templates/claude_code.py`),
when a file falls outside the active `allowed_outputs` on a render pass,
delete it (unless it's user-owned) instead of leaving it in place. Also
fixed `regenerate_claude_code()`'s checksum comparison to report such a
removal as `changed` instead of silently dropping it from both the
`changed`/`unchanged` lists.