### PR TITLE
fix(registry): drop unused ANTHROPIC_API_KEY from python executor MCP env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- Drop the unused `ANTHROPIC_API_KEY` forwarding from the `python` executor MCP server env; nothing in the executor stack reads it (#264).
 - `osprey deploy up --dev` now passes `--build` so the freshly-rendered local wheel is actually baked into the image; previously compose reused the cached image and ran stale code after the first build.
 - `osprey deploy up --dev` now builds the local wheel with the active interpreter (`sys.executable`) instead of bare `python3`. In a non-activated virtualenv, PATH `python3` is the system/pyenv interpreter, which lacks the `build` package — so the wheel build silently failed and containers fell back to the released PyPI version (missing any unreleased local code).
 

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -138,7 +138,6 @@ FRAMEWORK_SERVERS: dict[str, ServerDefinition] = {
         env={
             "OSPREY_CONFIG": "{project_root}/config.yml",
             "CONFIG_FILE": "{project_root}/config.yml",
-            "ANTHROPIC_API_KEY": "${ANTHROPIC_API_KEY:-}",
         },
         permissions_allow=[],
         permissions_ask=["execute"],


### PR DESCRIPTION
Closes #264.

## What

Removes the `ANTHROPIC_API_KEY` forwarding from the `python` (python_executor) MCP server env in `src/osprey/registry/mcp.py`.

## Why it's unused (traced, not assumed)

- No code in `mcp_server/python_executor/`, `services/python_executor/`, or `runtime/` reads `ANTHROPIC_API_KEY` — `grep` for `anthropic`/`litellm`/`api_key` in those paths returns nothing. The only env var the executor reads is `CONFIG_FILE` (`wrapper.py`).
- Executed code runs in a **separate Jupyter container** over WebSocket (`container_engine.py`), which does not inherit the MCP server process env — so the key could not reach executed scripts even by accident.
- `git blame` traces the line to the data-driven server-registry refactor (`ec11f013`), where the identical line was added to **both** the `python` and `ariel` server defs. It's a copy-paste carryover; the `python` server never grew a consumer.
- Consistent with existing maintainer practice of minimizing this key's exposure (the web terminal `env.pop("ANTHROPIC_API_KEY", None)` under token auth).

## Risk

None functional: the key was never consumed on this path. Regenerated `.mcp.json` for existing projects simply drops the key from the `python` block.

## Tests

`tests/registry/test_mcp.py` (32) pass; no test asserted the key's presence.

> Note: an out-of-scope observation surfaced during the trace — the `ariel` server's `ANTHROPIC_API_KEY` forwarding may *also* be partly vestigial (it reads the key from `config.yml` provider config, not `os.environ`). Left untouched here; worth a separate look.