### PR TITLE
docs(tutorial): launch hello-world via osprey claude chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Changed
 
+- Hello-world tutorial now launches via `osprey claude chat` instead of bare `claude`, so the provider configured under `claude_code` is actually used (bare `claude` silently falls back to the shell's provider); links the CLI-chat how-to (#261).
 - The control_assistant scenario e2e tests (`test_vacuum_burst_scenario` and `test_rf_cavity_correlation_scenario`) drive their archiver ground truth from the simulation engine via `activate_scenarios`, which also seeds the matching ARIEL logbook deterministically at setup (replacing the manual `purge && ingest` pre-seed and its stale-DB footgun). They build at tier 3 so every simulated channel is discoverable through the channel finder.
 
 ### Fixed

--- a/docs/source/getting-started/hello-world-tutorial.rst
+++ b/docs/source/getting-started/hello-world-tutorial.rst
@@ -108,7 +108,15 @@ From your project directory:
 
 .. code-block:: bash
 
-   claude
+   osprey claude chat
+
+.. note::
+
+   ``osprey claude chat`` is the recommended way to launch: it reads
+   ``config.yml`` and points the agent at your configured LLM provider.
+   Launching the bare agent CLI skips this, so it silently uses whatever
+   provider your shell environment points at --- see
+   :doc:`../how-to/use-cli-chat`.
 
 .. note::
 
@@ -184,7 +192,7 @@ agent's behavior. Regenerate the artifacts and relaunch:
 .. code-block:: bash
 
    osprey claude regen
-   claude
+   osprey claude chat
 
 .. note::
 
@@ -297,3 +305,6 @@ Here's where to go from here:
 - **Architecture deep dive**: The :doc:`conceptual-tutorial` explains the
   MCP server architecture, connector system, and safety mechanisms
 - **CLI reference**: See :doc:`../cli-reference/index` for all ``osprey`` commands
+- **Launch options & providers**: :doc:`../how-to/use-cli-chat` explains what
+  ``osprey claude chat`` sets up and how to point the agent at a non-default LLM
+  provider via ``config.yml``


### PR DESCRIPTION
Closes #261.

## Problem

The hello-world tutorial tells users to launch with bare `claude`. But bare `claude` does not consult `claude_code.provider` — it falls back to whatever provider the shell environment points at. A user who configures a non-anthropic provider (e.g. `cborg`) is silently ignored, with no warning. Only `osprey claude chat` resolves the configured provider (injects endpoint/credentials, starts the translation proxy, regenerates artifacts). The `use-cli-chat.rst` how-to documents this but was never linked from the tutorial.

## Change (docs only)

- Step 3 and the Step 5 relaunch: `claude` → `osprey claude chat`.
- A short note (2 sentences) on why the wrapper matters, deferring the mechanism detail to the linked how-to.
- A Next Steps bullet linking `use-cli-chat`.

Wording avoids "Claude Code" branding per project doc convention ("the Osprey agent").

## Out of scope

Suggestion 4 from the issue (a warning when `claude_code.provider` is non-anthropic) is a separate, more involved change with a genuine placement decision (`osprey build` vs `osprey claude status` vs `CLAUDE.md` template) and a trigger that can't be detected at build time. Recommend tracking it as its own issue.