### PR TITLE
release: v2026.6.1 — event dispatch & facility knowledge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ## [Unreleased]
 
+## [2026.6.1] - 2026-06-17
+
 ### Added
 
 - **Event dispatch (opt-in).** New `osprey.dispatch` FastMCP server + `osprey.mcp_server.dispatch_worker` service turn external events into headless agent runs, with a live dashboard, an in-memory FIFO pool with backpressure, per-trigger tool allowlists, and a server-side tool denylist (shell + web/browser tools blocked regardless of a trigger's allowlist). All dispatcher and worker HTTP endpoints that carry agent output or accept writes are bearer-token gated (the in-terminal EVENTS tab injects the token server-side, so the browser never holds it); `osprey deploy up` auto-generates the tokens into the project `.env` so a fresh deploy is secure with zero editing. Enable per profile via a `dispatch:` block; the `control-assistant` preset ships four control-system-free tutorial triggers (fire `hello-dispatch` with a single `curl`). Trigger sources are pluggable via the `osprey.trigger_sources` entry-point group (built-in: `webhook`, `cron`). Worker containers mount the project `.env` read-only so dispatched agent runs can authenticate to the LLM provider. The pipeline is exercised end-to-end by real-token e2e tests — a subprocess sweep over the shipped triggers and a full Docker-stack deploy. `osprey deploy up` builds a shared local image for the dispatcher + worker from a bundled Dockerfile (no published image required); use `--dev` to bake in a local osprey checkout, or set `OSPREY_DISPATCH_IMAGE`/`OSPREY_WORKER_IMAGE` to use a prebuilt image.
@@ -35,6 +37,7 @@ Compatibility is documented in release notes, not encoded in the version string.
 - Drop the unused `ANTHROPIC_API_KEY` forwarding from the `python` executor MCP server env; nothing in the executor stack reads it (#264).
 - `osprey deploy up --dev` now passes `--build` so the freshly-rendered local wheel is actually baked into the image; previously compose reused the cached image and ran stale code after the first build.
 - `osprey deploy up --dev` now builds the local wheel with the active interpreter (`sys.executable`) instead of bare `python3`. In a non-activated virtualenv, PATH `python3` is the system/pyenv interpreter, which lacks the `build` package — so the wheel build silently failed and containers fell back to the released PyPI version (missing any unreleased local code).
+- `osprey build` no longer aborts when a profile removes a framework agent (e.g. dropping the logbook agents) while also disabling the MCP server those agents depended on. OSPREY's two-pass `.claude/` render left the dropped agents' `.md` files orphaned on disk with their original `mcp__*` tool frontmatter, which the agent tool/permission drift check then flagged as a false positive and aborted the build. Files outside the active manifest selection are now deleted on re-render instead of left behind. (#266)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
-**🎉 Latest Release: v2026.6.0** - Containerization & local inference: per-project reference Dockerfile, the ds4 local-inference provider, and a data-driven simulation engine
+**🎉 Latest Release: v2026.6.1** - Event dispatch & facility knowledge: turn external events into headless agent runs, serve subsystem knowledge on demand, plus composable data-driven simulation scenarios
 
 > **🚧 Early Access Release**
 > This is an early access version of the Osprey Framework. While the core functionality is stable and ready for experimentation, documentation and APIs may still evolve. We welcome feedback and contributions!

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,20 +1,18 @@
-# Osprey Framework - Latest Release (v2026.6.0)
+# Osprey Framework - Latest Release (v2026.6.1)
 
-**Containerization & local inference: a per-project reference Dockerfile, the `ds4` local-inference provider, and a data-driven simulation engine**
+**Event dispatch & facility knowledge: turn external events into headless agent runs, serve subsystem knowledge to the agent on demand, and ship composable, data-driven simulation scenarios**
 
 ## Highlights
 
-- **Per-project reference Dockerfile.** `osprey build` now renders a self-documenting `Dockerfile` + `.dockerignore` into every project — install Claude Code + OSPREY, copy the project, serve the web terminal on 8087 as a non-root user. User-owned (never touched by `regen`); site extension via three build ARGs. New how-to: `docs/source/how-to/containerize-project.rst`.
-- **`ds4` local-inference provider.** Keyless, OpenAI-compatible local DwarfStar/DeepSeek-V4 server (default `http://127.0.0.1:8000/v1`). Introduces a per-provider `supports_native_structured_output` flag replacing the hardcoded structured-output whitelist.
-- **Data-driven simulation engine** (`osprey.simulation`). A `machine.json` defines channels, fault scenarios, and archiver event scripts so corrective writes propagate through physics couplings and archived history correlates with live values. Ships with a generic `sim-scenarios` skill.
-- **`osprey claude regen --runtime-root PATH`.** Re-anchors `project_root` and re-renders Claude Code artifacts for a relocated checkout (e.g. inside a container); a stale `python_env_path` falls back to the current interpreter.
+- **Event dispatch (opt-in).** A new `osprey.dispatch` server + dispatch worker turn external events (webhooks, cron) into headless agent runs, with a live dashboard, bearer-token-gated endpoints, per-trigger tool allowlists, and a server-side shell/web denylist. The `control-assistant` preset ships four control-system-free tutorial triggers; surfaced as an in-terminal **EVENTS** tab in `osprey web`.
+- **Facility Knowledge (OKF).** A structured markdown bundle (`osprey_facility_knowledge` MCP server) for on-demand retrieval of subsystem descriptions, device details, and operational procedures; `facility.md` thins to identity-only and deep content is fetched by the agent on demand. New `facility-knowledge` subagent and `osprey knowledge` CLI.
+- **Composable simulation scenarios.** Self-contained scenario bundles (telemetry + logbook narrative) under `data/simulation/scenarios/`, composed and applied via the new `osprey sim` CLI so the narrative the agent searches matches the telemetry it reads.
+- **Build & config fixes.** `osprey build` no longer crashes when a profile removes agents and disables the MCP server they depended on (#266); the hello-world tutorial now launches via `osprey claude chat` so the configured provider is actually used (#261).
 
 ## Notable changes
 
-- `claude-agent-sdk` upgraded to 0.2.93 (bundles CLI 2.1.167); als-apg routing re-verified.
-- `data-visualizer` subagent defaults to `create_interactive_plot` for unspecified plot requests.
-- Config edits now auto-regenerate Claude Code artifacts so changes (e.g. `writes_enabled`) take effect without a stale-settings gap (#244).
-- Archiver `None`-gap values no longer crash `lttb_downsample()`; gaps render as true gaps in charts (#247).
+- `claude-agent-sdk` upgraded to 0.2.101.
+- **BREAKING:** the mock archiver no longer emits the built-in Sector-7 vacuum-burst and RF cavity-C1 thermal demo events from hard-coded source — that physics is now data-driven. Ship it as a scenario bundle (e.g. the `control-assistant` preset's `vacuum-burst` / `rf-thermal`). Without a `simulation_file`, the mock archiver synthesizes only generic per-PV waveforms.
 
 ## Installation
 

--- a/src/osprey/__init__.py
+++ b/src/osprey/__init__.py
@@ -10,7 +10,7 @@ This package contains:
 """
 
 # Version information
-__version__ = "2026.6.0"
+__version__ = "2026.6.1"
 
 __all__ = ["__version__"]
 

--- a/src/osprey/cli/main.py
+++ b/src/osprey/cli/main.py
@@ -32,7 +32,7 @@ if sys.platform == "win32":
 try:
     from osprey import __version__
 except ImportError:
-    __version__ = "2026.6.0"
+    __version__ = "2026.6.1"
 
 
 class LazyGroup(click.Group):

--- a/tests/e2e/test_claude_code_build_integration.py
+++ b/tests/e2e/test_claude_code_build_integration.py
@@ -417,9 +417,8 @@ class TestClaudeExecutesArchiverAndPlots:
             "Use the archiver_read tool to retrieve data for channels "
             "'DIAG:BPM01:POSITION:X', 'DIAG:BPM02:POSITION:X', "
             "'DIAG:BPM03:POSITION:X' over the last 24 hours. "
-            "Then create a timeseries plot of the data and save it as a PNG "
-            "file. All permissions are pre-approved; do not ask for "
-            "confirmation."
+            "Then create a timeseries plot of the data. All permissions are "
+            "pre-approved; do not ask for confirmation."
         )
 
         result = run_claude(project_dir, prompt, timeout=300)
@@ -452,16 +451,20 @@ class TestClaudeExecutesArchiverAndPlots:
             f"Workspace contents: {list(workspace_dir.rglob('*')) if workspace_dir.exists() else 'N/A'}"
         )
 
-        # A plot PNG was created somewhere in the project tree. The agent
-        # may produce it via either the execute tool (raw python) or the
-        # data-visualizer subagent's create_static_plot — both are valid
-        # routes; we only assert the artifact landed.
+        # A plot artifact was created. The agent may produce a static PNG
+        # (execute tool / create_static_plot) or — the default for an
+        # unspecified plot request — an interactive HTML plot via the
+        # data-visualizer's create_interactive_plot. Both are valid; we only
+        # assert that a plot artifact landed in the artifact store.
         png_files = find_png_files(project_dir)
+        artifacts_dir = project_dir / "_agent_data" / "artifacts"
+        interactive_plots = sorted(artifacts_dir.glob("*.html")) if artifacts_dir.exists() else []
+        plot_files = png_files + interactive_plots
         exec_diag = diagnose_python_execute(project_dir)
         workspace_tree = diagnose_workspace(project_dir)
-        assert len(png_files) > 0, (
-            "No PNG files found anywhere in the project — the agent did "
-            "not produce a plot.\n"
+        assert len(plot_files) > 0, (
+            "No plot artifact (PNG or interactive HTML) found — the agent "
+            "did not produce a plot.\n"
             f"--- Execution diagnostics ---\n{exec_diag}\n"
             f"--- Workspace tree ---\n{workspace_tree}\n"
             f"--- stderr (first 1000) ---\n{result.stderr[:1000]}\n"
@@ -480,11 +483,12 @@ class TestClaudeExecutesArchiverAndPlots:
         # vocabulary. That message is free-form and model-dependent (Haiku
         # sometimes ends with "what would you like me to do next?" even after
         # completing the task), so the scan flaked while the workflow had
-        # actually succeeded. The data-file and PNG assertions above are the
-        # authoritative proof that archiver_read ran and a plot was persisted.
+        # actually succeeded. The data-file and plot-artifact assertions above
+        # are the authoritative proof that archiver_read ran and a plot was
+        # persisted.
 
         print(f"  data files: {len(data_files)}")
-        print(f"  PNG files: {[p.name for p in png_files]}")
+        print(f"  plot files: {[p.name for p in plot_files]}")
 
 
 # ===========================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -17,8 +17,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-06T22:41:07.227999Z"
-exclude-newer-span = "P7D"
+exclude-newer = "2026-06-13T12:00:00Z"
 
 [[package]]
 name = "accelerator-toolbox"
@@ -599,20 +598,20 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.2.93"
+version = "0.2.101"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/9b/66f0f671095a80f78f80aace954f4475705de17933120ff61bc8acc31d68/claude_agent_sdk-0.2.93.tar.gz", hash = "sha256:4fa2f534028c9054eb34960497147df345cb0042331694dfacd54560dd6378bd", size = 253644, upload-time = "2026-06-06T01:44:57.726Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/df/c60107c0b5f246017ab81d628b50d0b4d7a8f43230a3a978085829754cef/claude_agent_sdk-0.2.101.tar.gz", hash = "sha256:f9663e3b8b3a79c20bffd3196525fa5734a1908c1a69ea01aea4de877901a097", size = 255630, upload-time = "2026-06-13T01:37:22.255Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/b6/62fbdf6862b8f06b71e35cb76753cd4fcf3cbbfc74cf369d129e43045d96/claude_agent_sdk-0.2.93-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4fbf4f2c6e6b1085adaac304fa00ac29169a239fc3a15d114d964d2e77ce3e85", size = 64824363, upload-time = "2026-06-06T01:45:01.311Z" },
-    { url = "https://files.pythonhosted.org/packages/61/1d/eb11c804242bf39ba305fdff6dd18bbcb0732dce6baeb8c9df637d700b6d/claude_agent_sdk-0.2.93-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:04779660231c399ffb37a467f3ce070349e34232163a5d92d94dbae7ae168ec3", size = 66888963, upload-time = "2026-06-06T01:45:04.795Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/e2/196e32d83bf95dc9227958d0f70f5c7bd53495dc7af7c8448c7027311fce/claude_agent_sdk-0.2.93-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:6263db6cc6778bb041931190e0316db9ceec1f570ea116554e23683339520ae0", size = 74450006, upload-time = "2026-06-06T01:45:09.438Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/84/479d0f52c0459780ed469ac874377838fcb19089d7ec5ac0630507dd35e6/claude_agent_sdk-0.2.93-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:10064d8e2c36e31248a517d74913c5c26bc0677ddbd63ffe614891ab638df0ac", size = 74621071, upload-time = "2026-06-06T01:45:13.938Z" },
-    { url = "https://files.pythonhosted.org/packages/db/80/5286c4a5ad126d8ee24329de9693c5700c8f6e2b0113799b2787573bebd1/claude_agent_sdk-0.2.93-py3-none-win_amd64.whl", hash = "sha256:51fb629151aff62b6db370bc595104fb609142e08385391f49162fc9ceb6696a", size = 75251517, upload-time = "2026-06-06T01:45:18.03Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3e/f4dacad00720da9362675faaf08f0c3d5e9abab09ed1b21590279f1cb16c/claude_agent_sdk-0.2.101-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c07981e7fbf0cdbf2944a19f852f784c72de9764ea510cf602480eaf8749c969", size = 66210240, upload-time = "2026-06-13T01:37:25.7Z" },
+    { url = "https://files.pythonhosted.org/packages/24/00/61213b804921325d378b27a1fbd1864775a136713d87873a321fce2b50c4/claude_agent_sdk-0.2.101-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:3c03f59de5d7a78509be4f804fd73a2ff67935f13b159b1d89becb3a21ff2d78", size = 68255953, upload-time = "2026-06-13T01:37:29.082Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ea/88e793dcadd7f3b429156f6a648bc191d1f1800aa059e309848b2b7c6bc0/claude_agent_sdk-0.2.101-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:97019d8db2d0aad5632d2f121ea88fb0310e27fc9181cf9f6bc758de640a4c35", size = 75795256, upload-time = "2026-06-13T01:37:32.628Z" },
+    { url = "https://files.pythonhosted.org/packages/40/04/768545299593e963605e99b4a97cb43565e742e994992e69b74999e126ab/claude_agent_sdk-0.2.101-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:ac43f1e0cb7980b447bcbaef7614f6cd068cfd4653c555e3dead2d72d9117133", size = 75968983, upload-time = "2026-06-13T01:37:36.072Z" },
+    { url = "https://files.pythonhosted.org/packages/00/8b/b4c906d8b18aa39afdf6f4a32f94040b9eaf2ef0481b9cd54591bab24d0d/claude_agent_sdk-0.2.101-py3-none-win_amd64.whl", hash = "sha256:9d994518a4939e17c389ae063f06c236528b4ddc23557d22f1a2685a6dc8d7a6", size = 76570206, upload-time = "2026-06-13T01:37:39.593Z" },
 ]
 
 [[package]]
@@ -3120,7 +3119,7 @@ requires-dist = [
     { name = "build", marker = "extra == 'dev'" },
     { name = "certifi", specifier = ">=2025.4.26" },
     { name = "charset-normalizer", specifier = ">=3.4.2" },
-    { name = "claude-agent-sdk", specifier = "==0.2.93" },
+    { name = "claude-agent-sdk", specifier = "==0.2.101" },
     { name = "click", specifier = ">=8.1.0" },
     { name = "docker", marker = "extra == 'all'", specifier = ">=7.0.0" },
     { name = "docker", marker = "extra == 'dev'", specifier = ">=7.0.0" },


### PR DESCRIPTION
## Release v2026.6.1 — Event dispatch & facility knowledge

Patch release bundling the event-dispatch and facility-knowledge features, composable simulation scenarios, and three fixes (#266, #264, #261). Also pins `uv.lock` to the already-merged `claude-agent-sdk==0.2.101` (dependabot #258 bumped `pyproject` but left the lock at 0.2.93).

⚠️ **BREAKING:** the mock archiver no longer emits the hard-coded Sector-7 vacuum-burst / RF cavity-C1 thermal demo events — that physics is now data-driven (ship as a `machine.json` scenario bundle). See the CHANGELOG entry below.

### Validation
- **Clean-venv unit suite:** 4797 passed; the only non-passes were infrastructure-gated (Postgres/Ollama/Docker) or a Starlette-version test-introspection quirk — zero regressions.
- **Full e2e (clean venv, als-apg, SDK 0.2.101):** 69 passed. All failures were environmental (providers without creds in the run env, the advisory Docker-stack dispatch deploy, the optional `semantic_search` module) — the agent loop, safety, approval, delegation, and tooling are all green on the new SDK.

This PR also includes a test-only commit fixing the archiver-plot e2e test to accept the agent's (correct) interactive-HTML plot output.

---

## CHANGELOG
## [2026.6.1] - 2026-06-17

### Added

- **Event dispatch (opt-in).** New `osprey.dispatch` FastMCP server + `osprey.mcp_server.dispatch_worker` service turn external events into headless agent runs, with a live dashboard, an in-memory FIFO pool with backpressure, per-trigger tool allowlists, and a server-side tool denylist (shell + web/browser tools blocked regardless of a trigger's allowlist). All dispatcher and worker HTTP endpoints that carry agent output or accept writes are bearer-token gated (the in-terminal EVENTS tab injects the token server-side, so the browser never holds it); `osprey deploy up` auto-generates the tokens into the project `.env` so a fresh deploy is secure with zero editing. Enable per profile via a `dispatch:` block; the `control-assistant` preset ships four control-system-free tutorial triggers (fire `hello-dispatch` with a single `curl`). Trigger sources are pluggable via the `osprey.trigger_sources` entry-point group (built-in: `webhook`, `cron`). Worker containers mount the project `.env` read-only so dispatched agent runs can authenticate to the LLM provider. The pipeline is exercised end-to-end by real-token e2e tests — a subprocess sweep over the shipped triggers and a full Docker-stack deploy. `osprey deploy up` builds a shared local image for the dispatcher + worker from a bundled Dockerfile (no published image required); use `--dev` to bake in a local osprey checkout, or set `OSPREY_DISPATCH_IMAGE`/`OSPREY_WORKER_IMAGE` to use a prebuilt image.
- The `control-assistant` preset now surfaces the event-dispatcher dashboard as an in-terminal **EVENTS** tab in `osprey web` (health-gated; repoint via `EVENT_DISPATCHER_URL`).
- **Facility Knowledge (OKF).** Structured markdown bundle (`osprey_facility_knowledge` MCP server, `list_concepts` / `read_concept` / `search` tools) for on-demand retrieval of subsystem descriptions, device details, operational procedures, and facility-specific references. `facility.md` is thinned to facility identity only; deep content is fetched via the agent on demand. The `control_assistant` preset ships an Example Research Facility bundle. Includes `draft_concept` write tool (approval-gated) for authoring new concept docs directly from an agent session. See :doc:`/how-to/use-facility-knowledge`.
- `osprey knowledge` CLI: `regen-index` (regenerate bundle indexes, idempotent), `validate` (collect-all frontmatter + index validation, exits 1 on any failure), `seed-from-ttl` (seed device stubs from a NARAD/als-ontology TTL; requires `knowledge` extra; `--force` to overwrite hand-edited stubs).
- `facility-knowledge` subagent: specialist agent scoped to `list_concepts` / `read_concept` / `search`; enabled by default in `control_assistant`; delegates facility knowledge lookups out of the main agent's context.
- Simulation engine: `at_time: "HH:MM:SS"` event anchor — daily local-time recurrence for archiver events (step/spike; width in seconds), complementing window-fraction `at` and activation-relative `at_offset`.
- Simulation engine: optional per-channel `min`/`max` physical bounds clamp live reads and synthesized history on the way out (e.g. forward RF power floored at 0 saturates instead of going negative during a trip); overrides and writes are stored verbatim.
- **Composable, self-contained simulation scenarios.** Scenarios are bundles under `data/simulation/scenarios/<name>/` — each owns its telemetry overlay (`scenario.json`) and, optionally, its logbook narrative (`logbook.json`). Several can be active at once as long as they touch disjoint channel sets (overlapping channels are a hard error). The `control_assistant` preset ships `vacuum-burst` (telemetry-only) and `rf-thermal` (with its DEMO-026/027/028 incident arc).
- **`osprey sim` CLI** — `osprey sim list | status | apply NAME...` composes and applies one or more scenarios: it writes the simulator state (with a shared apply-time anchor) and purges + reseeds the ARIEL logbook from the active bundles, so the narrative the agent searches matches the telemetry it reads, against one clock. `apply` confirms before purging (`--yes` to skip, `--no-seed` for telemetry only).
- **Relative timestamps for demo/seed logbooks** (`osprey.utils.relative_time`) — demo and seed entries express timestamps as `{days_ago, time}` and resolve to concrete datetimes when data enters the system (`osprey sim apply` for scenario bundles; `osprey ariel ingest`/`quickstart` for the generic JSON adapter, which now accepts a relative `when` alongside absolute `timestamp`). The data lands at a recent, deterministic position with no build-time file mutation.
- Deterministic statistical-contract tests (`tests/simulation/test_control_assistant_scenarios.py`, `test_scenario_composition.py`) pin the scenarios' signatures (anti-correlation, excursion positions, derived-channel consistency) and the disjoint-composition contract, so the LLM-judge e2e tests run against a known-good data substrate.

### Changed

- Hello-world tutorial now launches via `osprey claude chat` instead of bare `claude`, so the provider configured under `claude_code` is actually used (bare `claude` silently falls back to the shell's provider); links the CLI-chat how-to (#261).
- The control_assistant scenario e2e tests (`test_vacuum_burst_scenario` and `test_rf_cavity_correlation_scenario`) drive their archiver ground truth from the simulation engine via `activate_scenarios`, which also seeds the matching ARIEL logbook deterministically at setup (replacing the manual `purge && ingest` pre-seed and its stale-DB footgun). They build at tier 3 so every simulated channel is discoverable through the channel finder.

### Fixed

- Drop the unused `ANTHROPIC_API_KEY` forwarding from the `python` executor MCP server env; nothing in the executor stack reads it (#264).
- `osprey deploy up --dev` now passes `--build` so the freshly-rendered local wheel is actually baked into the image; previously compose reused the cached image and ran stale code after the first build.
- `osprey deploy up --dev` now builds the local wheel with the active interpreter (`sys.executable`) instead of bare `python3`. In a non-activated virtualenv, PATH `python3` is the system/pyenv interpreter, which lacks the `build` package — so the wheel build silently failed and containers fell back to the released PyPI version (missing any unreleased local code).
- `osprey build` no longer aborts when a profile removes a framework agent (e.g. dropping the logbook agents) while also disabling the MCP server those agents depended on. OSPREY's two-pass `.claude/` render left the dropped agents' `.md` files orphaned on disk with their original `mcp__*` tool frontmatter, which the agent tool/permission drift check then flagged as a false positive and aborted the build. Files outside the active manifest selection are now deleted on re-render instead of left behind. (#266)

### Removed

- The build-time logbook timestamp rebase (`rebase_logbook_timestamps`) is gone: demo/seed logbooks now carry declarative relative timestamps resolved at ingest/apply time instead of being mutated in place during `osprey build` (which no longer requires a running Postgres for logbook setup).
- **BREAKING:** the mock archiver no longer emits the built-in Sector-7 vacuum-burst and RF cavity-C1 thermal-excursion demo events from hard-coded source. That physics is now data-driven (ship it as a `machine.json` scenario, e.g. the `control_assistant` preset's `vacuum-burst`/`rf-thermal`). Without a `simulation_file`, the mock archiver synthesizes only generic per-PV-type waveforms.

