### PR TITLE
feat(dispatch): EPICS Channel Access trigger source + events-panel URL derivation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,6 +208,7 @@ osprey = "osprey.cli.main:cli"
 [project.entry-points."osprey.trigger_sources"]
 webhook = "osprey.dispatch.sources.webhook:WebhookSource"
 cron = "osprey.dispatch.sources.cron:CronSource"
+epics_ca = "osprey.dispatch.sources.epics_ca:EpicsCaSource"
 
 # Hatchling build configuration
 [tool.hatch.version]

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -1315,10 +1315,10 @@ def _inject_dispatch(dispatch: DispatchConfig, profile_dir: Path, project_path: 
             deployed.append(name)
     config["deployed_services"] = deployed
 
-    # 3b. Derive web.panels.events.url from dispatcher_port so it is a single
-    # source of truth.  Write only if the profile has not already set an
-    # explicit URL via a ``web.panels.events.url`` config override (applied in
-    # step 8, before this step 10b); explicit overrides take precedence.
+    # Derive web.panels.events.url from dispatcher_port so the port is a single
+    # source of truth.  Write only if the profile has not already set an explicit
+    # ``web.panels.events.url`` via a config override (merged earlier in the
+    # build); explicit overrides take precedence.
     existing_events_url = (
         config.get("web", {}).get("panels", {}).get("events", {}).get("url", "")
     )

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -1319,9 +1319,7 @@ def _inject_dispatch(dispatch: DispatchConfig, profile_dir: Path, project_path: 
     # source of truth.  Write only if the profile has not already set an explicit
     # ``web.panels.events.url`` via a config override (merged earlier in the
     # build); explicit overrides take precedence.
-    existing_events_url = (
-        config.get("web", {}).get("panels", {}).get("events", {}).get("url", "")
-    )
+    existing_events_url = config.get("web", {}).get("panels", {}).get("events", {}).get("url", "")
     if not existing_events_url:
         derived_url = f"http://localhost:{dispatch.dispatcher_port}/dashboard"
         config.setdefault("web", {}).setdefault("panels", {}).setdefault("events", {})

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -1315,6 +1315,18 @@ def _inject_dispatch(dispatch: DispatchConfig, profile_dir: Path, project_path: 
             deployed.append(name)
     config["deployed_services"] = deployed
 
+    # 3b. Derive web.panels.events.url from dispatcher_port so it is a single
+    # source of truth.  Write only if the profile has not already set an
+    # explicit URL via a ``web.panels.events.url`` config override (applied in
+    # step 8, before this step 10b); explicit overrides take precedence.
+    existing_events_url = (
+        config.get("web", {}).get("panels", {}).get("events", {}).get("url", "")
+    )
+    if not existing_events_url:
+        derived_url = f"http://localhost:{dispatch.dispatcher_port}/dashboard"
+        config.setdefault("web", {}).setdefault("panels", {}).setdefault("events", {})
+        config["web"]["panels"]["events"]["url"] = derived_url
+
     with open(config_path, "w") as fh:
         yaml.dump(config, fh)
 

--- a/src/osprey/dispatch/sources/epics_ca.py
+++ b/src/osprey/dispatch/sources/epics_ca.py
@@ -78,12 +78,25 @@ class _PvWatcher:
         """pyepics CA-thread callback. Schedules the fire coroutine on the loop."""
         if value is None:
             return
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            # Non-numeric PV (enum string, waveform, …): nothing to threshold on.
+            # Log and return rather than raise on the CA thread, where pyepics
+            # swallows the exception and the watcher would silently die.
+            logger.warning(
+                "EPICS CA trigger '%s' PV '%s' produced non-numeric value %r; ignoring",
+                self._trigger.name,
+                self._pv_name,
+                value,
+            )
+            return
         if self._last_value is None:
             # Suppress fire on first (connect-time) read — just record the value.
-            self._last_value = value
+            self._last_value = numeric
             return
-        prev, self._last_value = self._last_value, value
-        if not self._detect_edge(prev, value):
+        prev, self._last_value = self._last_value, numeric
+        if not self._detect_edge(prev, numeric):
             return
         now = time.monotonic()
         if now - self._last_fire_ts < self._cool_down:
@@ -92,7 +105,7 @@ class _PvWatcher:
         payload = {
             "source": "epics_ca",
             "pv": self._pv_name,
-            "value": value,
+            "value": numeric,
             "previous_value": prev,
             "threshold": self._threshold,
             "edge": self._edge,

--- a/src/osprey/dispatch/sources/epics_ca.py
+++ b/src/osprey/dispatch/sources/epics_ca.py
@@ -44,14 +44,14 @@ class _PvWatcher:
         cfg = trigger.source_config
         self._pv_name: str = cfg["pv"]
         self._threshold: float = float(cfg.get("threshold", 0.0))
-        self._edge: str = cfg.get("edge", "rising")          # rising | falling | both
+        self._edge: str = cfg.get("edge", "rising")  # rising | falling | both
         self._cool_down: float = float(cfg.get("cool_down_sec", 60.0))
         self._trigger = trigger
         self._fire = fire_callback
         self._loop = loop
         self._pv: epics.PV | None = None
         self._last_fire_ts: float = 0.0
-        self._last_value: float | None = None                 # None = first read not yet seen
+        self._last_value: float | None = None  # None = first read not yet seen
 
     def start(self) -> None:
         self._pv = epics.PV(self._pv_name, callback=self._on_change)
@@ -111,9 +111,7 @@ class _PvWatcher:
             "edge": self._edge,
             "timestamp": datetime.now(tz=UTC).isoformat(),
         }
-        asyncio.run_coroutine_threadsafe(
-            self._dispatch(payload), self._loop
-        )
+        asyncio.run_coroutine_threadsafe(self._dispatch(payload), self._loop)
 
     async def _dispatch(self, payload: dict[str, Any]) -> None:
         """Coroutine executed on the asyncio loop after an edge is detected."""

--- a/src/osprey/dispatch/sources/epics_ca.py
+++ b/src/osprey/dispatch/sources/epics_ca.py
@@ -50,7 +50,7 @@ class _PvWatcher:
         self._fire = fire_callback
         self._loop = loop
         self._pv: epics.PV | None = None
-        self._last_fire_ts: float = 0.0
+        self._last_fire_ts: float | None = None  # None = has not fired yet
         self._last_value: float | None = None  # None = first read not yet seen
 
     def start(self) -> None:
@@ -99,7 +99,10 @@ class _PvWatcher:
         if not self._detect_edge(prev, numeric):
             return
         now = time.monotonic()
-        if now - self._last_fire_ts < self._cool_down:
+        # Cool-down only applies between actual fires — never relative to the
+        # monotonic epoch, or a large cool_down_sec would suppress the first
+        # event whenever monotonic() < cool_down_sec (e.g. a freshly booted host).
+        if self._last_fire_ts is not None and now - self._last_fire_ts < self._cool_down:
             return
         self._last_fire_ts = now
         payload = {

--- a/src/osprey/dispatch/sources/epics_ca.py
+++ b/src/osprey/dispatch/sources/epics_ca.py
@@ -1,0 +1,160 @@
+"""EPICS Channel Access trigger source for the event dispatcher.
+
+Manages one pyepics CA monitor per trigger, applies threshold/edge/cool-down/
+first-read-suppression logic, and forwards threshold-crossing events to the
+asyncio serving loop via ``run_coroutine_threadsafe``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, ClassVar
+
+import epics
+
+from osprey.dispatch.pool import QueueFullError
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+    from osprey.dispatch.sources.base import FireCallback
+    from osprey.dispatch.trigger_config import TriggerConfig
+
+logger = logging.getLogger("osprey.dispatch.sources.epics_ca")
+
+
+class _PvWatcher:
+    """Monitor one PV and fire a callback when its value crosses a threshold.
+
+    Runs on pyepics' CA thread; hands off to the asyncio serving loop via
+    ``run_coroutine_threadsafe``.  Each instance is self-contained so that
+    multiple PVs are independent: a cool-down or first-read on one does not
+    affect the others.
+    """
+
+    def __init__(
+        self,
+        trigger: TriggerConfig,
+        fire_callback: FireCallback,
+        loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        cfg = trigger.source_config
+        self._pv_name: str = cfg["pv"]
+        self._threshold: float = float(cfg.get("threshold", 0.0))
+        self._edge: str = cfg.get("edge", "rising")          # rising | falling | both
+        self._cool_down: float = float(cfg.get("cool_down_sec", 60.0))
+        self._trigger = trigger
+        self._fire = fire_callback
+        self._loop = loop
+        self._pv: epics.PV | None = None
+        self._last_fire_ts: float = 0.0
+        self._last_value: float | None = None                 # None = first read not yet seen
+
+    def start(self) -> None:
+        self._pv = epics.PV(self._pv_name, callback=self._on_change)
+
+    def stop(self) -> None:
+        if self._pv is not None:
+            self._pv.clear_callbacks()
+            self._pv.disconnect()
+            self._pv = None
+
+    # ------------------------------------------------------------------
+    # Internals (run on pyepics CA thread)
+    # ------------------------------------------------------------------
+
+    def _detect_edge(self, prev: float, curr: float) -> bool:
+        if self._edge == "rising":
+            return prev < self._threshold <= curr
+        if self._edge == "falling":
+            return prev > self._threshold >= curr
+        # "both"
+        return (prev < self._threshold <= curr) or (prev > self._threshold >= curr)
+
+    def _on_change(self, pvname: str | None = None, value: Any = None, **kw: Any) -> None:
+        """pyepics CA-thread callback. Schedules the fire coroutine on the loop."""
+        if value is None:
+            return
+        if self._last_value is None:
+            # Suppress fire on first (connect-time) read — just record the value.
+            self._last_value = value
+            return
+        prev, self._last_value = self._last_value, value
+        if not self._detect_edge(prev, value):
+            return
+        now = time.monotonic()
+        if now - self._last_fire_ts < self._cool_down:
+            return
+        self._last_fire_ts = now
+        payload = {
+            "source": "epics_ca",
+            "pv": self._pv_name,
+            "value": value,
+            "previous_value": prev,
+            "threshold": self._threshold,
+            "edge": self._edge,
+            "timestamp": datetime.now(tz=UTC).isoformat(),
+        }
+        asyncio.run_coroutine_threadsafe(
+            self._dispatch(payload), self._loop
+        )
+
+    async def _dispatch(self, payload: dict[str, Any]) -> None:
+        """Coroutine executed on the asyncio loop after an edge is detected."""
+        try:
+            await self._fire(self._trigger, payload)
+        except QueueFullError as exc:
+            logger.warning(
+                "EPICS CA trigger '%s' dropped: queue full (%s)", self._trigger.name, exc
+            )
+        except Exception:
+            logger.exception("EPICS CA trigger '%s' fire failed", self._trigger.name)
+
+
+class EpicsCaSource:
+    """Event source that fires triggers on EPICS CA PV threshold crossings.
+
+    One CA monitor is armed per trigger in :meth:`start`; all are released in
+    :meth:`stop`. Threshold, edge direction, cool-down, and first-read
+    suppression are per-trigger and implemented in :class:`_PvWatcher`.
+
+    Expected ``source_config`` keys per trigger:
+
+    * ``pv`` (required): EPICS PV name to monitor.
+    * ``threshold`` (default ``0.0``): crossing value.
+    * ``edge`` (default ``"rising"``): ``"rising"``, ``"falling"``, or ``"both"``.
+    * ``cool_down_sec`` (default ``60.0``): minimum seconds between fires for the same trigger.
+    """
+
+    source_type: ClassVar[str] = "epics_ca"
+
+    def __init__(self) -> None:
+        self._watchers: list[_PvWatcher] = []
+
+    def register_routes(self, mcp_app: FastMCP) -> None:
+        """EPICS CA source has no HTTP routes."""
+        return None
+
+    async def start(self, triggers: list[TriggerConfig], fire_callback: FireCallback) -> None:
+        """Arm one CA monitor per trigger (lifespan startup, running loop)."""
+        loop = asyncio.get_running_loop()
+        for trigger in triggers:
+            if not trigger.source_config.get("pv"):
+                logger.warning(
+                    "EPICS CA trigger '%s' has no 'pv' in source_config; skipping",
+                    trigger.name,
+                )
+                continue
+            watcher = _PvWatcher(trigger, fire_callback, loop)
+            watcher.start()
+            self._watchers.append(watcher)
+        logger.info("EPICS CA source started with %d monitor(s)", len(self._watchers))
+
+    async def stop(self) -> None:
+        """Disconnect all CA monitors and release resources."""
+        for watcher in self._watchers:
+            watcher.stop()
+        self._watchers = []

--- a/tests/cli/test_build_cmd.py
+++ b/tests/cli/test_build_cmd.py
@@ -1839,6 +1839,104 @@ def test_build_profile_only_tier(tmp_path: Path, paradigm: str) -> None:
     )
 
 
+# ---------------------------------------------------------------------------
+# Events-panel URL derivation (Task 1.4)
+# ---------------------------------------------------------------------------
+
+
+class TestEventsPanelUrlDerivation:
+    """_inject_dispatch derives web.panels.events.url from dispatcher_port."""
+
+    def _write_minimal_config(self, project_path: Path) -> None:
+        """Write the smallest config.yml that _inject_dispatch needs."""
+        from ruamel.yaml import YAML
+
+        yaml = YAML()
+        with open(project_path / "config.yml", "w") as fh:
+            yaml.dump({"deployed_services": [], "services": {}}, fh)
+
+    def _dispatch(self, dispatcher_port: int = 8020, **overrides: object):
+        from osprey.cli.build_profile import DispatchConfig
+
+        base: dict = {
+            "triggers": "tutorial_triggers.yml",
+            "worker_count": 1,
+            "workspace_mode": "isolated",
+            "max_concurrent_runs": 2,
+            "max_queue_depth": 50,
+            "dispatcher_port": dispatcher_port,
+            "worker_port_base": 9190,
+            "timeout_sec": 300,
+            "facility_name": "generic-facility",
+            "pv_strip_prefix": "",
+        }
+        base.update(overrides)
+        return DispatchConfig(**base)  # type: ignore[arg-type]
+
+    def _inject(self, dispatch, project_path: Path, profile_dir: Path) -> None:
+        from osprey.cli.build_cmd import _inject_dispatch
+
+        _inject_dispatch(dispatch, profile_dir=profile_dir, project_path=project_path)
+
+    def _read_config(self, project_path: Path) -> dict:
+        import yaml
+
+        return yaml.safe_load((project_path / "config.yml").read_text()) or {}
+
+    def test_events_panel_url_derived_from_dispatcher_port(self, tmp_path: Path) -> None:
+        """web.panels.events.url is written as http://localhost:{port}/dashboard."""
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        profile_dir = tmp_path / "profile"
+        profile_dir.mkdir()
+        self._write_minimal_config(project_path)
+
+        self._inject(self._dispatch(dispatcher_port=8888), project_path, profile_dir)
+
+        config = self._read_config(project_path)
+        url = config["web"]["panels"]["events"]["url"]
+        assert url == "http://localhost:8888/dashboard"
+
+    def test_events_panel_url_reflects_custom_port(self, tmp_path: Path) -> None:
+        """Different dispatcher_port values produce different derived URLs."""
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        profile_dir = tmp_path / "profile"
+        profile_dir.mkdir()
+        self._write_minimal_config(project_path)
+
+        self._inject(self._dispatch(dispatcher_port=9999), project_path, profile_dir)
+
+        config = self._read_config(project_path)
+        assert config["web"]["panels"]["events"]["url"] == "http://localhost:9999/dashboard"
+
+    def test_explicit_events_url_not_overwritten(self, tmp_path: Path) -> None:
+        """An explicit web.panels.events.url already in config.yml is not replaced."""
+        from ruamel.yaml import YAML
+
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        profile_dir = tmp_path / "profile"
+        profile_dir.mkdir()
+
+        # Pre-set an explicit URL via a profile config override (simulated here by
+        # writing it directly into config.yml before _inject_dispatch runs).
+        yaml = YAML()
+        config_pre = {
+            "deployed_services": [],
+            "services": {},
+            "web": {"panels": {"events": {"url": "http://custom-host:7777/dashboard"}}},
+        }
+        with open(project_path / "config.yml", "w") as fh:
+            yaml.dump(config_pre, fh)
+
+        self._inject(self._dispatch(dispatcher_port=8020), project_path, profile_dir)
+
+        config = self._read_config(project_path)
+        # Explicit URL must survive — derivation must not overwrite it.
+        assert config["web"]["panels"]["events"]["url"] == "http://custom-host:7777/dashboard"
+
+
 def test_build_channel_finder_agent_requires_mode(tmp_path: Path) -> None:
     """A profile that selects the channel-finder agent but omits
     channel_finder_mode must fail with a clear BuildProfileError."""

--- a/tests/dispatch/test_epics_ca_source.py
+++ b/tests/dispatch/test_epics_ca_source.py
@@ -271,6 +271,20 @@ class TestCoolDown:
             assert rec.wait_until(2)
         assert rec.call_count == 2
 
+    def test_first_fire_not_suppressed_when_monotonic_below_cooldown(self) -> None:
+        """A large cool_down must not suppress the FIRST fire when the monotonic
+        clock reads below cool_down_sec (e.g. a freshly booted host, where
+        ``time.monotonic()`` can be smaller than the configured cool-down)."""
+        rec = _FireRecorder()
+        trigger = _trigger(pv="SIM:BEAM", threshold=1.0, edge="rising", cool_down_sec=9999.0)
+        with patch("osprey.dispatch.sources.epics_ca.time.monotonic", return_value=5.0):
+            with _running_loop() as loop:
+                _watcher, fake_pv = _arm_watcher(trigger, rec, loop)
+                fake_pv.fire(0.0)  # first read (suppressed)
+                fake_pv.fire(2.0)  # crossing — must fire despite monotonic(5) < cool_down
+                assert rec.wait_until(1)
+        assert rec.call_count == 1
+
 
 class TestNonNumericValue:
     """Non-numeric PV values are logged and ignored, not raised on the CA thread."""

--- a/tests/dispatch/test_epics_ca_source.py
+++ b/tests/dispatch/test_epics_ca_source.py
@@ -1,0 +1,359 @@
+"""Unit tests for osprey.dispatch.sources.epics_ca.EpicsCaSource.
+
+Exercises edge detection, cool-down suppression, first-read suppression, and
+multi-PV independence without a live IOC.  pyepics is replaced by a minimal
+fake that injects callbacks synchronously.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from osprey.dispatch.sources.epics_ca import EpicsCaSource, _PvWatcher
+from osprey.dispatch.trigger_config import TriggerConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _trigger(
+    name: str = "test-trigger",
+    pv: str = "SIM:PV",
+    threshold: float = 1.0,
+    edge: str = "rising",
+    cool_down_sec: float = 0.0,
+) -> TriggerConfig:
+    """Build a TriggerConfig with EPICS CA source_config."""
+    return TriggerConfig(
+        name=name,
+        source="epics_ca",
+        action={"prompt": "test prompt"},
+        source_config={
+            "pv": pv,
+            "threshold": threshold,
+            "edge": edge,
+            "cool_down_sec": cool_down_sec,
+        },
+    )
+
+
+class _FakePV:
+    """Minimal pyepics.PV stand-in; stores callback and exposes fire()."""
+
+    def __init__(self, pvname: str, callback=None, **kw: Any) -> None:
+        self.pvname = pvname
+        self._callback = callback
+
+    def fire(self, value: Any) -> None:
+        """Synchronously invoke the callback as if a CA monitor event arrived."""
+        if self._callback is not None:
+            self._callback(pvname=self.pvname, value=value)
+
+    def clear_callbacks(self) -> None:
+        self._callback = None
+
+    def disconnect(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# _PvWatcher unit tests (synchronous, no real asyncio loop)
+# ---------------------------------------------------------------------------
+
+
+class TestPvWatcherEdgeDetection:
+    """_detect_edge covers rising, falling, and both directions."""
+
+    def _make_watcher(self, edge: str, threshold: float = 1.0) -> _PvWatcher:
+        loop = MagicMock()
+        return _PvWatcher(
+            trigger=_trigger(threshold=threshold, edge=edge),
+            fire_callback=AsyncMock(),
+            loop=loop,
+        )
+
+    def test_rising_edge_detected(self) -> None:
+        w = self._make_watcher("rising", threshold=1.0)
+        assert w._detect_edge(0.5, 1.0) is True   # exactly at threshold
+        assert w._detect_edge(0.0, 2.0) is True   # crosses above
+
+    def test_rising_edge_not_detected_when_falling(self) -> None:
+        w = self._make_watcher("rising", threshold=1.0)
+        assert w._detect_edge(1.5, 0.5) is False  # falling through threshold
+        assert w._detect_edge(0.5, 0.8) is False  # below threshold both sides
+
+    def test_falling_edge_detected(self) -> None:
+        w = self._make_watcher("falling", threshold=1.0)
+        assert w._detect_edge(1.5, 0.5) is True   # crosses below
+        assert w._detect_edge(2.0, 1.0) is True   # exactly at threshold
+
+    def test_falling_edge_not_detected_when_rising(self) -> None:
+        w = self._make_watcher("falling", threshold=1.0)
+        assert w._detect_edge(0.5, 1.5) is False
+        assert w._detect_edge(1.5, 2.0) is False  # above threshold both sides
+
+    def test_both_edge_detects_rising_and_falling(self) -> None:
+        w = self._make_watcher("both", threshold=1.0)
+        assert w._detect_edge(0.5, 1.0) is True   # rising
+        assert w._detect_edge(1.5, 0.5) is True   # falling
+
+    def test_both_edge_no_fire_when_same_side(self) -> None:
+        w = self._make_watcher("both", threshold=1.0)
+        assert w._detect_edge(0.5, 0.8) is False
+        assert w._detect_edge(1.5, 2.0) is False
+
+
+# ---------------------------------------------------------------------------
+# Integration-style tests: _PvWatcher with fake CA + real asyncio loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def event_loop():
+    """Fresh asyncio event loop for each test."""
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+def _run(coro, loop: asyncio.AbstractEventLoop):
+    return loop.run_until_complete(coro)
+
+
+def _arm_watcher(
+    trigger: TriggerConfig,
+    fire_cb: AsyncMock,
+    loop: asyncio.AbstractEventLoop,
+) -> tuple[_PvWatcher, _FakePV]:
+    """Arm a _PvWatcher with a _FakePV and return both."""
+    fake_pv = None
+
+    def _fake_epics_pv(pvname, callback=None, **kw):
+        nonlocal fake_pv
+        fake_pv = _FakePV(pvname, callback=callback)
+        return fake_pv
+
+    with patch("osprey.dispatch.sources.epics_ca.epics.PV", side_effect=_fake_epics_pv):
+        watcher = _PvWatcher(trigger=trigger, fire_callback=fire_cb, loop=loop)
+        watcher.start()
+
+    return watcher, fake_pv
+
+
+class TestFirstReadSuppression:
+    """No fire on the initial connect-time PV value."""
+
+    def test_no_fire_on_first_value(self, event_loop) -> None:
+        fire_cb = AsyncMock(return_value="dispatch-id-1")
+        trigger = _trigger(pv="SIM:SETPOINT", threshold=1.0, edge="rising")
+        watcher, fake_pv = _arm_watcher(trigger, fire_cb, event_loop)
+
+        # First value: should suppress regardless of whether it crosses threshold.
+        fake_pv.fire(2.0)
+        _run(asyncio.sleep(0), event_loop)  # drain any queued coroutines
+
+        fire_cb.assert_not_called()
+
+    def test_fire_on_second_crossing(self, event_loop) -> None:
+        fire_cb = AsyncMock(return_value="dispatch-id-2")
+        trigger = _trigger(pv="SIM:SETPOINT", threshold=1.0, edge="rising", cool_down_sec=0.0)
+        watcher, fake_pv = _arm_watcher(trigger, fire_cb, event_loop)
+
+        fake_pv.fire(0.0)   # first read (suppressed)
+        fake_pv.fire(2.0)   # rising crossing — should fire
+
+        # run_coroutine_threadsafe schedules on the loop; run a step to execute it.
+        _run(asyncio.sleep(0), event_loop)
+
+        fire_cb.assert_called_once()
+        payload = fire_cb.call_args[0][1]
+        assert payload["source"] == "epics_ca"
+        assert payload["pv"] == "SIM:SETPOINT"
+        assert payload["value"] == 2.0
+        assert payload["previous_value"] == 0.0
+
+
+class TestCoolDown:
+    """Repeat fires within cool_down_sec are suppressed."""
+
+    def test_second_fire_suppressed_within_cool_down(self, event_loop) -> None:
+        fire_cb = AsyncMock(return_value="dispatch-id")
+        trigger = _trigger(
+            pv="SIM:BEAM", threshold=1.0, edge="rising", cool_down_sec=9999.0
+        )
+        watcher, fake_pv = _arm_watcher(trigger, fire_cb, event_loop)
+
+        fake_pv.fire(0.0)   # first read (suppressed)
+        fake_pv.fire(2.0)   # crossing — fires
+        _run(asyncio.sleep(0), event_loop)
+        assert fire_cb.call_count == 1
+
+        # Simulate falling back below then rising again within the cool-down window.
+        fake_pv.fire(0.0)   # falling
+        fake_pv.fire(2.0)   # rising again — suppressed by cool_down
+        _run(asyncio.sleep(0), event_loop)
+        assert fire_cb.call_count == 1  # still 1, second fire suppressed
+
+    def test_fire_allowed_after_cool_down_expires(self, event_loop) -> None:
+        fire_cb = AsyncMock(return_value="dispatch-id")
+        trigger = _trigger(
+            pv="SIM:BEAM", threshold=1.0, edge="rising", cool_down_sec=0.001
+        )
+        watcher, fake_pv = _arm_watcher(trigger, fire_cb, event_loop)
+
+        fake_pv.fire(0.0)   # first read (suppressed)
+        fake_pv.fire(2.0)   # crossing — fires
+        _run(asyncio.sleep(0), event_loop)
+        assert fire_cb.call_count == 1
+
+        time.sleep(0.01)  # wait longer than cool_down_sec
+
+        fake_pv.fire(0.0)   # fall below
+        fake_pv.fire(2.0)   # rising again — cool-down expired, should fire
+        _run(asyncio.sleep(0), event_loop)
+        assert fire_cb.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Multi-PV independence
+# ---------------------------------------------------------------------------
+
+
+class TestMultiPvIndependence:
+    """Each PV watcher has its own state; one PV does not affect another."""
+
+    def test_cool_down_is_per_pv(self, event_loop) -> None:
+        """Triggering PV-A within its cool-down must not affect PV-B."""
+        fire_a = AsyncMock(return_value="id-a")
+        fire_b = AsyncMock(return_value="id-b")
+
+        trigger_a = _trigger(
+            name="trigger-a", pv="SIM:PV:A", threshold=1.0, edge="rising", cool_down_sec=9999.0
+        )
+        trigger_b = _trigger(
+            name="trigger-b", pv="SIM:PV:B", threshold=1.0, edge="rising", cool_down_sec=0.0
+        )
+
+        watcher_a, pv_a = _arm_watcher(trigger_a, fire_a, event_loop)
+        watcher_b, pv_b = _arm_watcher(trigger_b, fire_b, event_loop)
+
+        pv_a.fire(0.0)   # first read A
+        pv_b.fire(0.0)   # first read B
+
+        pv_a.fire(2.0)   # A fires (1st)
+        pv_b.fire(2.0)   # B fires (1st)
+        _run(asyncio.sleep(0), event_loop)
+        assert fire_a.call_count == 1
+        assert fire_b.call_count == 1
+
+        # A is now in cool-down; B is not (cool_down=0).
+        pv_a.fire(0.0)
+        pv_a.fire(2.0)   # A: suppressed
+        pv_b.fire(0.0)
+        pv_b.fire(2.0)   # B: fires (2nd)
+        _run(asyncio.sleep(0), event_loop)
+        assert fire_a.call_count == 1  # A still suppressed
+        assert fire_b.call_count == 2  # B fired again
+
+    def test_first_read_suppression_is_per_pv(self, event_loop) -> None:
+        """Each PV suppresses only its own first read."""
+        fire_a = AsyncMock(return_value="id-a")
+        fire_b = AsyncMock(return_value="id-b")
+
+        trigger_a = _trigger(name="trigger-a", pv="SIM:PV:A")
+        trigger_b = _trigger(name="trigger-b", pv="SIM:PV:B")
+
+        watcher_a, pv_a = _arm_watcher(trigger_a, fire_a, event_loop)
+        watcher_b, pv_b = _arm_watcher(trigger_b, fire_b, event_loop)
+
+        # B fires its first read (suppressed); A has not yet had one.
+        pv_b.fire(0.0)
+
+        # B crosses the threshold on its 2nd value → fires.
+        pv_b.fire(2.0)
+        _run(asyncio.sleep(0), event_loop)
+        assert fire_b.call_count == 1
+
+        # A still on its first read (suppressed).
+        pv_a.fire(2.0)
+        _run(asyncio.sleep(0), event_loop)
+        assert fire_a.call_count == 0  # A's first read suppressed
+
+        # A's 2nd value fires.
+        pv_a.fire(0.0)   # fall below
+        pv_a.fire(2.0)   # rise → fires
+        _run(asyncio.sleep(0), event_loop)
+        assert fire_a.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# EpicsCaSource integration: start() + stop()
+# ---------------------------------------------------------------------------
+
+
+class TestEpicsCaSourceLifecycle:
+    """EpicsCaSource.start arms watchers; stop() releases them."""
+
+    @pytest.mark.asyncio
+    async def test_start_arms_monitors_per_trigger(self) -> None:
+        source = EpicsCaSource()
+        triggers = [
+            _trigger(name="t1", pv="SIM:PV:1"),
+            _trigger(name="t2", pv="SIM:PV:2"),
+        ]
+        fire_cb = AsyncMock(return_value=None)
+
+        created = []
+
+        def _fake_pv(pvname, callback=None, **kw):
+            pv = _FakePV(pvname, callback)
+            created.append(pv)
+            return pv
+
+        with patch("osprey.dispatch.sources.epics_ca.epics.PV", side_effect=_fake_pv):
+            await source.start(triggers, fire_cb)
+
+        assert len(source._watchers) == 2
+        assert len(created) == 2
+        pv_names = {pv.pvname for pv in created}
+        assert pv_names == {"SIM:PV:1", "SIM:PV:2"}
+
+    @pytest.mark.asyncio
+    async def test_start_skips_trigger_without_pv(self) -> None:
+        source = EpicsCaSource()
+        bad_trigger = TriggerConfig(
+            name="no-pv",
+            source="epics_ca",
+            action={"prompt": "test"},
+            source_config={},  # no 'pv' key
+        )
+        fire_cb = AsyncMock(return_value=None)
+
+        with patch("osprey.dispatch.sources.epics_ca.epics.PV") as mock_pv:
+            await source.start([bad_trigger], fire_cb)
+
+        mock_pv.assert_not_called()
+        assert len(source._watchers) == 0
+
+    @pytest.mark.asyncio
+    async def test_stop_clears_watchers(self) -> None:
+        source = EpicsCaSource()
+        triggers = [_trigger(name="t1", pv="SIM:PV:1")]
+        fire_cb = AsyncMock(return_value=None)
+
+        with patch("osprey.dispatch.sources.epics_ca.epics.PV", side_effect=_FakePV):
+            await source.start(triggers, fire_cb)
+
+        assert len(source._watchers) == 1
+        await source.stop()
+        assert len(source._watchers) == 0
+
+    def test_source_type_classvar(self) -> None:
+        assert EpicsCaSource.source_type == "epics_ca"

--- a/tests/dispatch/test_epics_ca_source.py
+++ b/tests/dispatch/test_epics_ca_source.py
@@ -123,7 +123,34 @@ def event_loop():
 
 
 def _run(coro, loop: asyncio.AbstractEventLoop):
-    return loop.run_until_complete(coro)
+    """Run ``coro`` on ``loop``, then drain any coroutines scheduled via
+    ``run_coroutine_threadsafe``.
+
+    ``run_coroutine_threadsafe`` hands work to the loop in two hops: a
+    threadsafe callback first creates the task, and only a later loop iteration
+    runs that task to completion.  A single ``run_until_complete(sleep(0))`` is
+    therefore not guaranteed to execute the dispatch coroutine — on some
+    platforms/Python builds the self-pipe wakeup and the task's first step land
+    in different iterations, leaving ``call_count`` at 0.  Pump the loop until
+    it has no pending tasks or ready callbacks so the assertions are
+    deterministic regardless of scheduling timing.
+    """
+    result = loop.run_until_complete(coro)
+    # ``run_coroutine_threadsafe`` needs at least two iterations to land: one to
+    # run the threadsafe callback that creates the task, and one (or more) to run
+    # the task itself.  The threadsafe callback may also still be queued and not
+    # yet have created its task, so requiring two *consecutive* idle checks
+    # ensures a just-created task is observed before we stop pumping.
+    idle_checks = 0
+    for _ in range(100):
+        if any(not t.done() for t in asyncio.all_tasks(loop)):
+            idle_checks = 0
+        else:
+            idle_checks += 1
+            if idle_checks >= 2:
+                break
+        loop.run_until_complete(asyncio.sleep(0))
+    return result
 
 
 def _arm_watcher(

--- a/tests/dispatch/test_epics_ca_source.py
+++ b/tests/dispatch/test_epics_ca_source.py
@@ -17,7 +17,6 @@ import pytest
 from osprey.dispatch.sources.epics_ca import EpicsCaSource, _PvWatcher
 from osprey.dispatch.trigger_config import TriggerConfig
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -81,8 +80,8 @@ class TestPvWatcherEdgeDetection:
 
     def test_rising_edge_detected(self) -> None:
         w = self._make_watcher("rising", threshold=1.0)
-        assert w._detect_edge(0.5, 1.0) is True   # exactly at threshold
-        assert w._detect_edge(0.0, 2.0) is True   # crosses above
+        assert w._detect_edge(0.5, 1.0) is True  # exactly at threshold
+        assert w._detect_edge(0.0, 2.0) is True  # crosses above
 
     def test_rising_edge_not_detected_when_falling(self) -> None:
         w = self._make_watcher("rising", threshold=1.0)
@@ -91,8 +90,8 @@ class TestPvWatcherEdgeDetection:
 
     def test_falling_edge_detected(self) -> None:
         w = self._make_watcher("falling", threshold=1.0)
-        assert w._detect_edge(1.5, 0.5) is True   # crosses below
-        assert w._detect_edge(2.0, 1.0) is True   # exactly at threshold
+        assert w._detect_edge(1.5, 0.5) is True  # crosses below
+        assert w._detect_edge(2.0, 1.0) is True  # exactly at threshold
 
     def test_falling_edge_not_detected_when_rising(self) -> None:
         w = self._make_watcher("falling", threshold=1.0)
@@ -101,8 +100,8 @@ class TestPvWatcherEdgeDetection:
 
     def test_both_edge_detects_rising_and_falling(self) -> None:
         w = self._make_watcher("both", threshold=1.0)
-        assert w._detect_edge(0.5, 1.0) is True   # rising
-        assert w._detect_edge(1.5, 0.5) is True   # falling
+        assert w._detect_edge(0.5, 1.0) is True  # rising
+        assert w._detect_edge(1.5, 0.5) is True  # falling
 
     def test_both_edge_no_fire_when_same_side(self) -> None:
         w = self._make_watcher("both", threshold=1.0)
@@ -166,8 +165,8 @@ class TestFirstReadSuppression:
         trigger = _trigger(pv="SIM:SETPOINT", threshold=1.0, edge="rising", cool_down_sec=0.0)
         watcher, fake_pv = _arm_watcher(trigger, fire_cb, event_loop)
 
-        fake_pv.fire(0.0)   # first read (suppressed)
-        fake_pv.fire(2.0)   # rising crossing — should fire
+        fake_pv.fire(0.0)  # first read (suppressed)
+        fake_pv.fire(2.0)  # rising crossing — should fire
 
         # run_coroutine_threadsafe schedules on the loop; run a step to execute it.
         _run(asyncio.sleep(0), event_loop)
@@ -185,38 +184,34 @@ class TestCoolDown:
 
     def test_second_fire_suppressed_within_cool_down(self, event_loop) -> None:
         fire_cb = AsyncMock(return_value="dispatch-id")
-        trigger = _trigger(
-            pv="SIM:BEAM", threshold=1.0, edge="rising", cool_down_sec=9999.0
-        )
+        trigger = _trigger(pv="SIM:BEAM", threshold=1.0, edge="rising", cool_down_sec=9999.0)
         watcher, fake_pv = _arm_watcher(trigger, fire_cb, event_loop)
 
-        fake_pv.fire(0.0)   # first read (suppressed)
-        fake_pv.fire(2.0)   # crossing — fires
+        fake_pv.fire(0.0)  # first read (suppressed)
+        fake_pv.fire(2.0)  # crossing — fires
         _run(asyncio.sleep(0), event_loop)
         assert fire_cb.call_count == 1
 
         # Simulate falling back below then rising again within the cool-down window.
-        fake_pv.fire(0.0)   # falling
-        fake_pv.fire(2.0)   # rising again — suppressed by cool_down
+        fake_pv.fire(0.0)  # falling
+        fake_pv.fire(2.0)  # rising again — suppressed by cool_down
         _run(asyncio.sleep(0), event_loop)
         assert fire_cb.call_count == 1  # still 1, second fire suppressed
 
     def test_fire_allowed_after_cool_down_expires(self, event_loop) -> None:
         fire_cb = AsyncMock(return_value="dispatch-id")
-        trigger = _trigger(
-            pv="SIM:BEAM", threshold=1.0, edge="rising", cool_down_sec=0.001
-        )
+        trigger = _trigger(pv="SIM:BEAM", threshold=1.0, edge="rising", cool_down_sec=0.001)
         watcher, fake_pv = _arm_watcher(trigger, fire_cb, event_loop)
 
-        fake_pv.fire(0.0)   # first read (suppressed)
-        fake_pv.fire(2.0)   # crossing — fires
+        fake_pv.fire(0.0)  # first read (suppressed)
+        fake_pv.fire(2.0)  # crossing — fires
         _run(asyncio.sleep(0), event_loop)
         assert fire_cb.call_count == 1
 
         time.sleep(0.01)  # wait longer than cool_down_sec
 
-        fake_pv.fire(0.0)   # fall below
-        fake_pv.fire(2.0)   # rising again — cool-down expired, should fire
+        fake_pv.fire(0.0)  # fall below
+        fake_pv.fire(2.0)  # rising again — cool-down expired, should fire
         _run(asyncio.sleep(0), event_loop)
         assert fire_cb.call_count == 2
 
@@ -229,7 +224,7 @@ class TestNonNumericValue:
         trigger = _trigger(pv="SIM:ENUM", threshold=1.0, edge="rising", cool_down_sec=0.0)
         watcher, fake_pv = _arm_watcher(trigger, fire_cb, event_loop)
 
-        fake_pv.fire(0.0)        # numeric first read (suppressed)
+        fake_pv.fire(0.0)  # numeric first read (suppressed)
         fake_pv.fire("Enabled")  # non-numeric — must be ignored, not raise
         _run(asyncio.sleep(0), event_loop)
         fire_cb.assert_not_called()
@@ -276,20 +271,20 @@ class TestMultiPvIndependence:
         watcher_a, pv_a = _arm_watcher(trigger_a, fire_a, event_loop)
         watcher_b, pv_b = _arm_watcher(trigger_b, fire_b, event_loop)
 
-        pv_a.fire(0.0)   # first read A
-        pv_b.fire(0.0)   # first read B
+        pv_a.fire(0.0)  # first read A
+        pv_b.fire(0.0)  # first read B
 
-        pv_a.fire(2.0)   # A fires (1st)
-        pv_b.fire(2.0)   # B fires (1st)
+        pv_a.fire(2.0)  # A fires (1st)
+        pv_b.fire(2.0)  # B fires (1st)
         _run(asyncio.sleep(0), event_loop)
         assert fire_a.call_count == 1
         assert fire_b.call_count == 1
 
         # A is now in cool-down; B is not (cool_down=0).
         pv_a.fire(0.0)
-        pv_a.fire(2.0)   # A: suppressed
+        pv_a.fire(2.0)  # A: suppressed
         pv_b.fire(0.0)
-        pv_b.fire(2.0)   # B: fires (2nd)
+        pv_b.fire(2.0)  # B: fires (2nd)
         _run(asyncio.sleep(0), event_loop)
         assert fire_a.call_count == 1  # A still suppressed
         assert fire_b.call_count == 2  # B fired again
@@ -319,8 +314,8 @@ class TestMultiPvIndependence:
         assert fire_a.call_count == 0  # A's first read suppressed
 
         # A's 2nd value fires.
-        pv_a.fire(0.0)   # fall below
-        pv_a.fire(2.0)   # rise → fires
+        pv_a.fire(0.0)  # fall below
+        pv_a.fire(2.0)  # rise → fires
         _run(asyncio.sleep(0), event_loop)
         assert fire_a.call_count == 1
 

--- a/tests/dispatch/test_epics_ca_source.py
+++ b/tests/dispatch/test_epics_ca_source.py
@@ -221,6 +221,38 @@ class TestCoolDown:
         assert fire_cb.call_count == 2
 
 
+class TestNonNumericValue:
+    """Non-numeric PV values are logged and ignored, not raised on the CA thread."""
+
+    def test_non_numeric_value_does_not_fire_or_raise(self, event_loop) -> None:
+        fire_cb = AsyncMock(return_value="dispatch-id")
+        trigger = _trigger(pv="SIM:ENUM", threshold=1.0, edge="rising", cool_down_sec=0.0)
+        watcher, fake_pv = _arm_watcher(trigger, fire_cb, event_loop)
+
+        fake_pv.fire(0.0)        # numeric first read (suppressed)
+        fake_pv.fire("Enabled")  # non-numeric — must be ignored, not raise
+        _run(asyncio.sleep(0), event_loop)
+        fire_cb.assert_not_called()
+
+        # A subsequent numeric crossing still fires (watcher survived the bad value).
+        fake_pv.fire(2.0)
+        _run(asyncio.sleep(0), event_loop)
+        fire_cb.assert_called_once()
+
+    def test_numeric_string_is_coerced(self, event_loop) -> None:
+        fire_cb = AsyncMock(return_value="dispatch-id")
+        trigger = _trigger(pv="SIM:STR", threshold=1.0, edge="rising", cool_down_sec=0.0)
+        watcher, fake_pv = _arm_watcher(trigger, fire_cb, event_loop)
+
+        fake_pv.fire("0.0")  # numeric string first read (suppressed)
+        fake_pv.fire("2.0")  # numeric string crossing — coerced and fires
+        _run(asyncio.sleep(0), event_loop)
+        fire_cb.assert_called_once()
+        payload = fire_cb.call_args[0][1]
+        assert payload["value"] == 2.0
+        assert payload["previous_value"] == 0.0
+
+
 # ---------------------------------------------------------------------------
 # Multi-PV independence
 # ---------------------------------------------------------------------------

--- a/tests/dispatch/test_epics_ca_source.py
+++ b/tests/dispatch/test_epics_ca_source.py
@@ -8,7 +8,9 @@ fake that injects callbacks synchronously.
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
+from contextlib import contextmanager
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -110,52 +112,85 @@ class TestPvWatcherEdgeDetection:
 
 
 # ---------------------------------------------------------------------------
-# Integration-style tests: _PvWatcher with fake CA + real asyncio loop
+# Integration-style tests: _PvWatcher with a fake CA monitor and a real asyncio
+# loop running in a background thread.
+#
+# This mirrors production: pyepics delivers CA callbacks on its own thread while
+# the dispatcher's asyncio loop runs elsewhere, and ``_PvWatcher`` bridges the
+# two via ``run_coroutine_threadsafe``.  Running a genuine loop (rather than
+# hand-stepping one) keeps the threadsafe hand-off deterministic regardless of
+# platform, Python version, or scheduling timing.
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture()
-def event_loop():
-    """Fresh asyncio event loop for each test."""
+@contextmanager
+def _running_loop():
+    """Yield an asyncio loop that is running in a dedicated background thread."""
     loop = asyncio.new_event_loop()
-    yield loop
-    loop.close()
+    ready = threading.Event()
+
+    def _serve() -> None:
+        asyncio.set_event_loop(loop)
+        loop.call_soon(ready.set)
+        loop.run_forever()
+
+    thread = threading.Thread(target=_serve, name="epics-ca-test-loop", daemon=True)
+    thread.start()
+    if not ready.wait(5.0):  # pragma: no cover - safety net
+        raise RuntimeError("test event loop failed to start")
+    try:
+        yield loop
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(5.0)
+        loop.close()
 
 
-def _run(coro, loop: asyncio.AbstractEventLoop):
-    """Run ``coro`` on ``loop``, then drain any coroutines scheduled via
-    ``run_coroutine_threadsafe``.
+class _FireRecorder:
+    """Async fire-callback stand-in that records each dispatch thread-safely.
 
-    ``run_coroutine_threadsafe`` hands work to the loop in two hops: a
-    threadsafe callback first creates the task, and only a later loop iteration
-    runs that task to completion.  A single ``run_until_complete(sleep(0))`` is
-    therefore not guaranteed to execute the dispatch coroutine — on some
-    platforms/Python builds the self-pipe wakeup and the task's first step land
-    in different iterations, leaving ``call_count`` at 0.  Pump the loop until
-    it has no pending tasks or ready callbacks so the assertions are
-    deterministic regardless of scheduling timing.
+    The dispatch runs on the loop thread; the test asserts from the main thread.
+    ``wait_until`` polls the thread-safe counter so positive assertions block
+    only as long as needed, and ``settle`` gives any spurious dispatch a chance
+    to land before a negative assertion.
     """
-    result = loop.run_until_complete(coro)
-    # ``run_coroutine_threadsafe`` needs at least two iterations to land: one to
-    # run the threadsafe callback that creates the task, and one (or more) to run
-    # the task itself.  The threadsafe callback may also still be queued and not
-    # yet have created its task, so requiring two *consecutive* idle checks
-    # ensures a just-created task is observed before we stop pumping.
-    idle_checks = 0
-    for _ in range(100):
-        if any(not t.done() for t in asyncio.all_tasks(loop)):
-            idle_checks = 0
-        else:
-            idle_checks += 1
-            if idle_checks >= 2:
-                break
-        loop.run_until_complete(asyncio.sleep(0))
-    return result
+
+    def __init__(self, return_value: str | None = "dispatch-id") -> None:
+        self._return_value = return_value
+        self._lock = threading.Lock()
+        self._calls: list[tuple[Any, dict[str, Any]]] = []
+
+    async def __call__(self, trigger: Any, payload: dict[str, Any]) -> str | None:
+        with self._lock:
+            self._calls.append((trigger, payload))
+        return self._return_value
+
+    @property
+    def call_count(self) -> int:
+        with self._lock:
+            return len(self._calls)
+
+    @property
+    def payloads(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return [payload for _, payload in self._calls]
+
+    def wait_until(self, count: int, timeout: float = 2.0) -> bool:
+        """Block until at least ``count`` dispatches have run (or timeout)."""
+        deadline = time.monotonic() + timeout
+        while self.call_count < count and time.monotonic() < deadline:
+            time.sleep(0.005)
+        return self.call_count >= count
+
+    @staticmethod
+    def settle(grace: float = 0.15) -> None:
+        """Let any in-flight dispatch land before a 'did not fire' assertion."""
+        time.sleep(grace)
 
 
 def _arm_watcher(
     trigger: TriggerConfig,
-    fire_cb: AsyncMock,
+    fire_cb: Any,
     loop: asyncio.AbstractEventLoop,
 ) -> tuple[_PvWatcher, _FakePV]:
     """Arm a _PvWatcher with a _FakePV and return both."""
@@ -176,30 +211,26 @@ def _arm_watcher(
 class TestFirstReadSuppression:
     """No fire on the initial connect-time PV value."""
 
-    def test_no_fire_on_first_value(self, event_loop) -> None:
-        fire_cb = AsyncMock(return_value="dispatch-id-1")
+    def test_no_fire_on_first_value(self) -> None:
+        rec = _FireRecorder()
         trigger = _trigger(pv="SIM:SETPOINT", threshold=1.0, edge="rising")
-        watcher, fake_pv = _arm_watcher(trigger, fire_cb, event_loop)
+        with _running_loop() as loop:
+            _watcher, fake_pv = _arm_watcher(trigger, rec, loop)
+            # First value: suppressed even though it crosses the threshold.
+            fake_pv.fire(2.0)
+            rec.settle()
+        assert rec.call_count == 0
 
-        # First value: should suppress regardless of whether it crosses threshold.
-        fake_pv.fire(2.0)
-        _run(asyncio.sleep(0), event_loop)  # drain any queued coroutines
-
-        fire_cb.assert_not_called()
-
-    def test_fire_on_second_crossing(self, event_loop) -> None:
-        fire_cb = AsyncMock(return_value="dispatch-id-2")
+    def test_fire_on_second_crossing(self) -> None:
+        rec = _FireRecorder()
         trigger = _trigger(pv="SIM:SETPOINT", threshold=1.0, edge="rising", cool_down_sec=0.0)
-        watcher, fake_pv = _arm_watcher(trigger, fire_cb, event_loop)
-
-        fake_pv.fire(0.0)  # first read (suppressed)
-        fake_pv.fire(2.0)  # rising crossing — should fire
-
-        # run_coroutine_threadsafe schedules on the loop; run a step to execute it.
-        _run(asyncio.sleep(0), event_loop)
-
-        fire_cb.assert_called_once()
-        payload = fire_cb.call_args[0][1]
+        with _running_loop() as loop:
+            _watcher, fake_pv = _arm_watcher(trigger, rec, loop)
+            fake_pv.fire(0.0)  # first read (suppressed)
+            fake_pv.fire(2.0)  # rising crossing — should fire
+            assert rec.wait_until(1)
+        assert rec.call_count == 1
+        payload = rec.payloads[0]
         assert payload["source"] == "epics_ca"
         assert payload["pv"] == "SIM:SETPOINT"
         assert payload["value"] == 2.0
@@ -209,68 +240,66 @@ class TestFirstReadSuppression:
 class TestCoolDown:
     """Repeat fires within cool_down_sec are suppressed."""
 
-    def test_second_fire_suppressed_within_cool_down(self, event_loop) -> None:
-        fire_cb = AsyncMock(return_value="dispatch-id")
+    def test_second_fire_suppressed_within_cool_down(self) -> None:
+        rec = _FireRecorder()
         trigger = _trigger(pv="SIM:BEAM", threshold=1.0, edge="rising", cool_down_sec=9999.0)
-        watcher, fake_pv = _arm_watcher(trigger, fire_cb, event_loop)
+        with _running_loop() as loop:
+            _watcher, fake_pv = _arm_watcher(trigger, rec, loop)
+            fake_pv.fire(0.0)  # first read (suppressed)
+            fake_pv.fire(2.0)  # crossing — fires
+            assert rec.wait_until(1)
 
-        fake_pv.fire(0.0)  # first read (suppressed)
-        fake_pv.fire(2.0)  # crossing — fires
-        _run(asyncio.sleep(0), event_loop)
-        assert fire_cb.call_count == 1
+            # Fall back below then rise again within the cool-down window.
+            fake_pv.fire(0.0)  # falling
+            fake_pv.fire(2.0)  # rising again — suppressed by cool_down
+            rec.settle()
+        assert rec.call_count == 1  # second fire suppressed
 
-        # Simulate falling back below then rising again within the cool-down window.
-        fake_pv.fire(0.0)  # falling
-        fake_pv.fire(2.0)  # rising again — suppressed by cool_down
-        _run(asyncio.sleep(0), event_loop)
-        assert fire_cb.call_count == 1  # still 1, second fire suppressed
-
-    def test_fire_allowed_after_cool_down_expires(self, event_loop) -> None:
-        fire_cb = AsyncMock(return_value="dispatch-id")
+    def test_fire_allowed_after_cool_down_expires(self) -> None:
+        rec = _FireRecorder()
         trigger = _trigger(pv="SIM:BEAM", threshold=1.0, edge="rising", cool_down_sec=0.001)
-        watcher, fake_pv = _arm_watcher(trigger, fire_cb, event_loop)
+        with _running_loop() as loop:
+            _watcher, fake_pv = _arm_watcher(trigger, rec, loop)
+            fake_pv.fire(0.0)  # first read (suppressed)
+            fake_pv.fire(2.0)  # crossing — fires
+            assert rec.wait_until(1)
 
-        fake_pv.fire(0.0)  # first read (suppressed)
-        fake_pv.fire(2.0)  # crossing — fires
-        _run(asyncio.sleep(0), event_loop)
-        assert fire_cb.call_count == 1
+            time.sleep(0.01)  # wait longer than cool_down_sec
 
-        time.sleep(0.01)  # wait longer than cool_down_sec
-
-        fake_pv.fire(0.0)  # fall below
-        fake_pv.fire(2.0)  # rising again — cool-down expired, should fire
-        _run(asyncio.sleep(0), event_loop)
-        assert fire_cb.call_count == 2
+            fake_pv.fire(0.0)  # fall below
+            fake_pv.fire(2.0)  # rising again — cool-down expired, should fire
+            assert rec.wait_until(2)
+        assert rec.call_count == 2
 
 
 class TestNonNumericValue:
     """Non-numeric PV values are logged and ignored, not raised on the CA thread."""
 
-    def test_non_numeric_value_does_not_fire_or_raise(self, event_loop) -> None:
-        fire_cb = AsyncMock(return_value="dispatch-id")
+    def test_non_numeric_value_does_not_fire_or_raise(self) -> None:
+        rec = _FireRecorder()
         trigger = _trigger(pv="SIM:ENUM", threshold=1.0, edge="rising", cool_down_sec=0.0)
-        watcher, fake_pv = _arm_watcher(trigger, fire_cb, event_loop)
+        with _running_loop() as loop:
+            _watcher, fake_pv = _arm_watcher(trigger, rec, loop)
+            fake_pv.fire(0.0)  # numeric first read (suppressed)
+            fake_pv.fire("Enabled")  # non-numeric — must be ignored, not raise
+            rec.settle()
+            assert rec.call_count == 0
 
-        fake_pv.fire(0.0)  # numeric first read (suppressed)
-        fake_pv.fire("Enabled")  # non-numeric — must be ignored, not raise
-        _run(asyncio.sleep(0), event_loop)
-        fire_cb.assert_not_called()
+            # A subsequent numeric crossing still fires (watcher survived the bad value).
+            fake_pv.fire(2.0)
+            assert rec.wait_until(1)
+        assert rec.call_count == 1
 
-        # A subsequent numeric crossing still fires (watcher survived the bad value).
-        fake_pv.fire(2.0)
-        _run(asyncio.sleep(0), event_loop)
-        fire_cb.assert_called_once()
-
-    def test_numeric_string_is_coerced(self, event_loop) -> None:
-        fire_cb = AsyncMock(return_value="dispatch-id")
+    def test_numeric_string_is_coerced(self) -> None:
+        rec = _FireRecorder()
         trigger = _trigger(pv="SIM:STR", threshold=1.0, edge="rising", cool_down_sec=0.0)
-        watcher, fake_pv = _arm_watcher(trigger, fire_cb, event_loop)
-
-        fake_pv.fire("0.0")  # numeric string first read (suppressed)
-        fake_pv.fire("2.0")  # numeric string crossing — coerced and fires
-        _run(asyncio.sleep(0), event_loop)
-        fire_cb.assert_called_once()
-        payload = fire_cb.call_args[0][1]
+        with _running_loop() as loop:
+            _watcher, fake_pv = _arm_watcher(trigger, rec, loop)
+            fake_pv.fire("0.0")  # numeric string first read (suppressed)
+            fake_pv.fire("2.0")  # numeric string crossing — coerced and fires
+            assert rec.wait_until(1)
+        assert rec.call_count == 1
+        payload = rec.payloads[0]
         assert payload["value"] == 2.0
         assert payload["previous_value"] == 0.0
 
@@ -283,10 +312,10 @@ class TestNonNumericValue:
 class TestMultiPvIndependence:
     """Each PV watcher has its own state; one PV does not affect another."""
 
-    def test_cool_down_is_per_pv(self, event_loop) -> None:
+    def test_cool_down_is_per_pv(self) -> None:
         """Triggering PV-A within its cool-down must not affect PV-B."""
-        fire_a = AsyncMock(return_value="id-a")
-        fire_b = AsyncMock(return_value="id-b")
+        rec_a = _FireRecorder("id-a")
+        rec_b = _FireRecorder("id-b")
 
         trigger_a = _trigger(
             name="trigger-a", pv="SIM:PV:A", threshold=1.0, edge="rising", cool_down_sec=9999.0
@@ -295,56 +324,55 @@ class TestMultiPvIndependence:
             name="trigger-b", pv="SIM:PV:B", threshold=1.0, edge="rising", cool_down_sec=0.0
         )
 
-        watcher_a, pv_a = _arm_watcher(trigger_a, fire_a, event_loop)
-        watcher_b, pv_b = _arm_watcher(trigger_b, fire_b, event_loop)
+        with _running_loop() as loop:
+            _watcher_a, pv_a = _arm_watcher(trigger_a, rec_a, loop)
+            _watcher_b, pv_b = _arm_watcher(trigger_b, rec_b, loop)
 
-        pv_a.fire(0.0)  # first read A
-        pv_b.fire(0.0)  # first read B
+            pv_a.fire(0.0)  # first read A
+            pv_b.fire(0.0)  # first read B
 
-        pv_a.fire(2.0)  # A fires (1st)
-        pv_b.fire(2.0)  # B fires (1st)
-        _run(asyncio.sleep(0), event_loop)
-        assert fire_a.call_count == 1
-        assert fire_b.call_count == 1
+            pv_a.fire(2.0)  # A fires (1st)
+            pv_b.fire(2.0)  # B fires (1st)
+            assert rec_a.wait_until(1)
+            assert rec_b.wait_until(1)
 
-        # A is now in cool-down; B is not (cool_down=0).
-        pv_a.fire(0.0)
-        pv_a.fire(2.0)  # A: suppressed
-        pv_b.fire(0.0)
-        pv_b.fire(2.0)  # B: fires (2nd)
-        _run(asyncio.sleep(0), event_loop)
-        assert fire_a.call_count == 1  # A still suppressed
-        assert fire_b.call_count == 2  # B fired again
+            # A is now in cool-down; B is not (cool_down=0).
+            pv_a.fire(0.0)
+            pv_a.fire(2.0)  # A: suppressed
+            pv_b.fire(0.0)
+            pv_b.fire(2.0)  # B: fires (2nd)
+            assert rec_b.wait_until(2)
+            rec_a.settle()
+        assert rec_a.call_count == 1  # A still suppressed
+        assert rec_b.call_count == 2  # B fired again
 
-    def test_first_read_suppression_is_per_pv(self, event_loop) -> None:
+    def test_first_read_suppression_is_per_pv(self) -> None:
         """Each PV suppresses only its own first read."""
-        fire_a = AsyncMock(return_value="id-a")
-        fire_b = AsyncMock(return_value="id-b")
+        rec_a = _FireRecorder("id-a")
+        rec_b = _FireRecorder("id-b")
 
         trigger_a = _trigger(name="trigger-a", pv="SIM:PV:A")
         trigger_b = _trigger(name="trigger-b", pv="SIM:PV:B")
 
-        watcher_a, pv_a = _arm_watcher(trigger_a, fire_a, event_loop)
-        watcher_b, pv_b = _arm_watcher(trigger_b, fire_b, event_loop)
+        with _running_loop() as loop:
+            _watcher_a, pv_a = _arm_watcher(trigger_a, rec_a, loop)
+            _watcher_b, pv_b = _arm_watcher(trigger_b, rec_b, loop)
 
-        # B fires its first read (suppressed); A has not yet had one.
-        pv_b.fire(0.0)
+            # B fires its first read (suppressed); A has not yet had one.
+            pv_b.fire(0.0)
+            pv_b.fire(2.0)  # B crosses the threshold on its 2nd value → fires.
+            assert rec_b.wait_until(1)
 
-        # B crosses the threshold on its 2nd value → fires.
-        pv_b.fire(2.0)
-        _run(asyncio.sleep(0), event_loop)
-        assert fire_b.call_count == 1
+            # A still on its first read (suppressed).
+            pv_a.fire(2.0)
+            rec_a.settle()
+            assert rec_a.call_count == 0
 
-        # A still on its first read (suppressed).
-        pv_a.fire(2.0)
-        _run(asyncio.sleep(0), event_loop)
-        assert fire_a.call_count == 0  # A's first read suppressed
-
-        # A's 2nd value fires.
-        pv_a.fire(0.0)  # fall below
-        pv_a.fire(2.0)  # rise → fires
-        _run(asyncio.sleep(0), event_loop)
-        assert fire_a.call_count == 1
+            # A's 2nd value fires.
+            pv_a.fire(0.0)  # fall below
+            pv_a.fire(2.0)  # rise → fires
+            assert rec_a.wait_until(1)
+        assert rec_a.call_count == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds an EPICS Channel Access trigger source to `osprey.dispatch` and makes the events-panel URL derive from the configured dispatcher port.

### 1. `epics_ca` trigger source
`osprey/dispatch/sources/epics_ca.py` — `EpicsCaSource` implements the `TriggerSource` protocol, arming one pyepics CA monitor per trigger. Each watcher applies threshold / edge (rising | falling | both) / cool-down / first-read suppression and hands CA-thread events to the serving loop via `run_coroutine_threadsafe`. Registered as the `epics_ca` entry point under `osprey.trigger_sources`, so `SourceRegistry` discovers it at dispatcher startup.

### 2. Events-panel URL derivation
`cli/build_cmd.py` — `web.panels.events.url` now derives from `dispatch.dispatcher_port` at build time (an explicit override still takes precedence), making the dispatcher port a single source of truth.

## Tests
- `tests/dispatch/test_epics_ca_source.py` — edge directions, at-threshold, first-read suppression, cool-down expiry, per-PV independence, non-numeric value handling, lifecycle.
- `tests/cli/test_build_cmd.py::TestEventsPanelUrlDerivation` — derived URL, custom port, explicit-override survival.

Non-numeric PV values are coerced to float and logged + skipped rather than raising on the pyepics CA thread, where the exception would otherwise be swallowed and silently kill the watcher.