### PR TITLE
fix(web): WebSockets on TLS

### DIFF
--- a/src/osprey/interfaces/web_terminal/routes/panels.py
+++ b/src/osprey/interfaces/web_terminal/routes/panels.py
@@ -30,7 +30,8 @@ async def health(request: Request):
 async def artifact_server_config(request: Request):
     """Return the artifact gallery server URL for iframe embedding."""
     url = getattr(request.app.state, "artifact_server_url", None)
-    return {"url": "/panel/artifacts" if url else "http://127.0.0.1:8086"}
+    proxy_url = "/panel/artifacts" if url else None
+    return {"url": proxy_url, "available": proxy_url is not None}
 
 
 @router.get("/api/type-registry")

--- a/src/osprey/interfaces/web_terminal/static/js/api.js
+++ b/src/osprey/interfaces/web_terminal/static/js/api.js
@@ -20,6 +20,16 @@ export function getConnectionState() {
 }
 
 /**
+ * Build a same-origin WebSocket URL with the scheme that matches the current
+ * page: wss:// when served over HTTPS, ws:// otherwise. Pass a root-absolute
+ * path such as '/ws/terminal'. Avoids mixed-content failures under TLS.
+ */
+export function wsUrl(path) {
+  const scheme = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${scheme}//${location.host}${path}`;
+}
+
+/**
  * Create a WebSocket with exponential backoff reconnection.
  */
 export function createWebSocket(url, { onOpen, onMessage, onClose, onError } = {}) {

--- a/src/osprey/interfaces/web_terminal/static/js/terminal.js
+++ b/src/osprey/interfaces/web_terminal/static/js/terminal.js
@@ -1,6 +1,6 @@
 /* OSPREY Web Terminal — Terminal Module */
 
-import { createWebSocket } from './api.js';
+import { createWebSocket, wsUrl } from './api.js';
 import { getXtermPalette, setTerminalRef } from './theme.js';
 
 let term = null;
@@ -91,13 +91,13 @@ export function startTerminal(sessionId = null, mode = 'new') {
   if (wsConnection) return;
   if (!term) return;
 
-  let wsUrl = `ws://${location.host}/ws/terminal`;
+  let url = wsUrl('/ws/terminal');
   if (mode === 'resume' && sessionId) {
-    wsUrl += `?session_id=${encodeURIComponent(sessionId)}&mode=resume`;
+    url += `?session_id=${encodeURIComponent(sessionId)}&mode=resume`;
     currentSessionId = sessionId;
   }
 
-  wsConnection = createWebSocket(wsUrl, {
+  wsConnection = createWebSocket(url, {
     onOpen() {
       // On reconnection (server restart), reset terminal to avoid
       // garbled output from old session mixed with new.
@@ -146,7 +146,7 @@ export function startTerminal(sessionId = null, mode = 'new') {
             // Update reconnect URL so auto-reconnect targets the correct session
             if (wsConnection) {
               wsConnection.setUrl(
-                `ws://${location.host}/ws/terminal?session_id=${encodeURIComponent(msg.session_id)}&mode=resume`
+                wsUrl(`/ws/terminal?session_id=${encodeURIComponent(msg.session_id)}&mode=resume`)
               );
             }
           } else if (msg.type === 'error') {


### PR DESCRIPTION
If TLS is used for transport then keep dynamic connections in JavaScript, especially WebSockets, on TLS, too.

* http -> https
* ws -> wss

Otherwise modern browsers (rightfully) block us for trying to submit unencrypted information from a homepage that we initiated as encrypted. This is technically a security issue, but modern browsers block it before it exposes sensitive information (like session cookies after auth on an rproxy).

Fix #271

- [x] tested locally w/ a HTTPS proxy