### PR TITLE
Add model names for AmSC-i2

### DIFF
--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -31,6 +31,10 @@ api:
     amsc-i2:
       api_key: ${AMSC_I2_API_KEY}
       base_url: https://api.i2-core.american-science-cloud.org/v1
+      models:                        # Model IDs as named by this provider
+        haiku: claude-haiku
+        sonnet: claude-sonnet
+        opus: claude-opus
     stanford:
       api_key: ${STANFORD_API_KEY}
       base_url: https://aiapi-prod.stanford.edu/v1

--- a/src/osprey/templates/apps/hello_world/config.yml.j2
+++ b/src/osprey/templates/apps/hello_world/config.yml.j2
@@ -30,6 +30,10 @@ api:
     amsc-i2:
       api_key: ${AMSC_I2_API_KEY}
       base_url: https://api.i2-core.american-science-cloud.org/v1
+      models:                        # Model IDs as named by this provider
+        haiku: claude-haiku
+        sonnet: claude-sonnet
+        opus: claude-opus
     stanford:
       api_key: ${STANFORD_API_KEY}
       base_url: https://aiapi-prod.stanford.edu/v1

--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -230,6 +230,10 @@ api:
     amsc-i2:
       api_key: ${AMSC_I2_API_KEY}
       base_url: https://api.i2-core.american-science-cloud.org/v1
+      models:                        # Model IDs as named by this provider
+        haiku: claude-haiku
+        sonnet: claude-sonnet
+        opus: claude-opus
     stanford:
       api_key: ${STANFORD_API_KEY}
       base_url: https://aiapi-prod.stanford.edu/v1


### PR DESCRIPTION
Add the model IDs for AmSC-i2, as given here: https://docs.i2-core.american-science-cloud.org/docs/api-available-models
