### PR TITLE
fix(config): fail fast when config.yml path is a directory or missing

### DIFF
--- a/src/osprey/utils/config.py
+++ b/src/osprey/utils/config.py
@@ -157,6 +157,30 @@ class ConfigBuilder:
                 )
 
         self.config_path = Path(config_path)
+
+        # Fail fast with an actionable message when the config path is not a
+        # regular file. A common cause: a container bind-mount whose host source
+        # did not exist at container-create time, which the runtime silently
+        # materializes as an empty directory on both ends — so config_path
+        # resolves to a directory and the YAML loader would otherwise surface a
+        # bare "[Errno 21] Is a directory". Treat a missing explicit path the
+        # same way rather than failing later in open().
+        if self.config_path.is_dir():
+            raise IsADirectoryError(
+                f"Config path is a directory, not a file: {self.config_path}\n\n"
+                f"config.yml is expected to be a file here. This usually means it "
+                f"was meant to be provided at runtime (e.g. a bind-mount whose "
+                f"source was missing, so the container runtime created an empty "
+                f"directory) or was not baked into the image. Ensure config.yml "
+                f"exists as a file at this path."
+            )
+        if not self.config_path.exists():
+            raise FileNotFoundError(
+                f"Config file not found: {self.config_path}\n\n"
+                f"Set the CONFIG_FILE environment variable to a valid config.yml, "
+                f"or run from a project directory that contains one."
+            )
+
         self.raw_config, self._unexpanded_config = self._load_config()
 
         # Pre-compute nested structures for efficient runtime access

--- a/tests/config/test_config_builder.py
+++ b/tests/config/test_config_builder.py
@@ -34,6 +34,24 @@ models:
         assert builder.raw_config["registry_path"] == "./my_app/registry.py"
         assert builder.raw_config["models"]["orchestrator"]["provider"] == "openai"
 
+    def test_config_path_is_a_directory_raises_clear_error(self, tmp_path):
+        """A directory at the config path (e.g. a missing bind-mount source the
+        container runtime materialized as an empty dir) fails fast with an
+        actionable IsADirectoryError, not a raw loader error."""
+        config_dir = tmp_path / "config.yml"
+        config_dir.mkdir()
+
+        with pytest.raises(IsADirectoryError, match="is a directory, not a file"):
+            ConfigBuilder(str(config_dir))
+
+    def test_missing_explicit_config_path_raises_file_not_found(self, tmp_path):
+        """An explicitly provided path that does not exist fails fast with a
+        clear FileNotFoundError rather than a later open() error."""
+        missing = tmp_path / "does_not_exist" / "config.yml"
+
+        with pytest.raises(FileNotFoundError, match="Config file not found"):
+            ConfigBuilder(str(missing))
+
     def test_environment_variable_resolution(self, tmp_path, monkeypatch):
         """Test that environment variables are resolved in config."""
         # Set environment variables


### PR DESCRIPTION
## What
ConfigBuilder now validates the config path before loading:
- a directory at the config path raises `IsADirectoryError` with an actionable message
- an explicitly provided path that does not exist raises `FileNotFoundError`

## Why
When a containerized service expects `config.yml` via a bind-mount and the host
source is missing at container-create time, the container runtime silently
creates the mount source as an empty **directory**. The config path then
resolves to a directory and loading failed with an opaque
`[Errno 21] Is a directory: .../config.yml`. This turns that class of
misconfiguration into a clear, self-explaining error for any deployment.

## Tests
Adds `test_config_path_is_a_directory_raises_clear_error` and
`test_missing_explicit_config_path_raises_file_not_found` to
`tests/config/test_config_builder.py`.
