### PR TITLE
feat(skills): ship osprey-design-philosophy as an installable skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ## [Unreleased]
 
+### Added
+
+- `osprey skills install osprey-design-philosophy` — bundle OSPREY's design and architecture principles as an installable skill for framework contributors.
+
 ## [2026.6.1] - 2026-06-17
 
 ### Added

--- a/docs/source/cli-reference/index.rst
+++ b/docs/source/cli-reference/index.rst
@@ -437,6 +437,17 @@ can be installed either globally or into a specific project's
      project-locally (into the profile repo's ``.claude/skills/``) by the
      last phase of the ``osprey-build-interview`` skill, so ``/osprey-build-deploy``
      is available wherever the profile repo is cloned.
+   * ``osprey-contribute`` — walks a contributor through the GitHub Flow
+     journey from a working-tree change to a merged PR on ``main`` (branching,
+     atomic commits, push, PR, rebase, merge).
+   * ``osprey-pre-commit`` — runs the quick / ci / premerge check scripts at
+     the right gate before committing, pushing, or opening a PR.
+   * ``osprey-release`` — cuts a CalVer release: opens the version-bump PR,
+     tags the merge commit, and verifies the automated PyPI publish.
+   * ``osprey-design-philosophy`` — OSPREY's design and architecture principles
+     for designing, adding, or reviewing a feature. Useful for framework
+     contributors; install globally to have it available when working on
+     ``src/osprey`` in any session.
 
 .. code-block:: bash
 

--- a/docs/source/contributing/index.rst
+++ b/docs/source/contributing/index.rst
@@ -156,6 +156,8 @@ contributing from a fork. It composes with the other bundled skills:
 - ``osprey-pre-commit`` -- standalone validation runs
 - ``commit-organize`` -- splits a messy working tree into atomic commits
 - ``osprey-release`` -- the release-cutting flow for maintainers
+- ``osprey-design-philosophy`` -- OSPREY's design and architecture principles,
+  for designing or reviewing a feature before you open the PR
 
 List all installable skills with ``uv run osprey skills install --help``.
 
@@ -163,6 +165,24 @@ List all installable skills with ``uv run osprey skills install --help``.
 
 Code Standards
 --------------
+
+Design Principles
+^^^^^^^^^^^^^^^^^
+
+Before designing a new connector, MCP server, provider, capability, or any
+non-trivial feature, consult OSPREY's design and architecture principles -- the
+safe-state default, facility-neutral core, measured symmetry with peer
+subsystems, swappable components, and discoverable user-facing features.
+Install the bundled skill so the Osprey agent applies them as you design and
+review:
+
+.. code-block:: bash
+
+   uv run osprey skills install osprey-design-philosophy
+
+The principles guide decisions; they are not mechanical rules. When a change
+feels wrong but the reason is hard to name, they help you name the drift and
+correct it before you open the PR.
 
 Python Style
 ^^^^^^^^^^^^

--- a/src/osprey/cli/skills_cmd.py
+++ b/src/osprey/cli/skills_cmd.py
@@ -26,6 +26,7 @@ _SKILL_SOURCES: dict[str, str] = {
     "osprey-contribute": "templates/skills/osprey-contribute",
     "osprey-pre-commit": "templates/skills/osprey-pre-commit",
     "osprey-release": "templates/skills/osprey-release",
+    "osprey-design-philosophy": "templates/skills/osprey-design-philosophy",
 }
 
 
@@ -56,6 +57,7 @@ def install(name: str, target: Path | None) -> None:
       osprey-contribute       Walk a contributor through the GitHub Flow journey
       osprey-pre-commit       Run quick / ci / premerge check scripts at the right gate
       osprey-release          Cut a CalVer release: bump PR, tag, verify publish
+      osprey-design-philosophy  OSPREY's design and architecture principles for review/design
 
     On an existing non-empty target, the prior content is renamed to
     <name>.bak.<YYYYMMDD-HHMMSS>/ before the new copy is written, so a

--- a/src/osprey/templates/skills/osprey-design-philosophy/SKILL.md
+++ b/src/osprey/templates/skills/osprey-design-philosophy/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: osprey-design-philosophy
+description: >-
+  OSPREY's design and architecture principles — the rules that define how OSPREY code should be
+  structured, and the anti-pattern each one prevents. Consult before designing, adding, or reviewing
+  any feature (connectors, MCP servers, providers, capabilities, CLI, registry, runtime, config),
+  and when redirecting work that is drifting from these principles. Trigger when the user says "is
+  this the right direction", "does this fit OSPREY", "this feels wrong", "check the design
+  philosophy", or points an agent at how OSPREY code should look. Apply before adding a config knob,
+  a new abstraction, a new subsystem, or anything touching hardware-write safety.
+---
+
+# OSPREY Design Philosophy
+
+> **Working draft.** Principles are still being collected and refined with the maintainer. The five
+> below are confirmed. Each states a rule, its rationale, and the guidance an agent should apply.
+> Principles are written generically: do not hard-code lists of current features or subsystems into
+> this document — they go stale. Refer to "existing peer subsystems" and let the reader inspect the
+> code.
+
+OSPREY runs agentic AI in safety-critical control systems (accelerators, fusion experiments,
+beamlines), where an incorrect hardware write can damage equipment or endanger people. These
+principles exist to keep the framework trustworthy on real machines and adaptable as the field
+changes. Apply judgment: principles guide decisions, they are not mechanical rules to satisfy.
+
+---
+
+## 1. The safe state is the default
+
+The cautious behavior is what happens unless configuration explicitly enables the riskier one.
+
+- Hardware writes are disabled until config opts in; validation fails closed (e.g. an empty limits
+  database blocks every write rather than allowing them); when configuration cannot be read, assume
+  the safe path, not the convenient one.
+- Wire safety in structurally, not per-call, so it cannot be forgotten. New connectors inherit the
+  writes-enabled guard automatically via `ControlSystemConnector.__init_subclass__`
+  (`src/osprey/connectors/control_system/base.py`).
+- A guard that currently never triggers is not dead code. It documents an invariant and protects
+  against the day the assumption changes. Do not remove it.
+
+## 2. Nothing facility-specific belongs in the core
+
+Code in `src/osprey` must run unchanged at a different facility. Anything tied to one accelerator,
+detector, or beamline lives behind a connector, in config, or in a preset/template — never in the
+framework.
+
+- Test each change against: "Would this be wrong at a different facility?" If yes, it is in the
+  wrong layer.
+- Facility values go in config; protocol differences go in connectors; facility narrative and agent
+  wiring go in presets and templates.
+- Do not create domain-prefixed sibling artifacts to hold facility variations. Fold the variation
+  into the relevant preset or configuration and reuse the generic components.
+
+## 3. Reach for symmetry, measured
+
+When building a new subsystem, follow the structure that existing peer subsystems already use before
+inventing a new one. Consistency lowers design cost, shortens the learning curve, and makes later
+refactoring tractable because subsystems resemble each other.
+
+- Look across the codebase first. If peers integrate through a subagent, an MCP server, and a
+  service layer, a new subsystem of the same kind should do likewise unless it genuinely differs.
+- This is a default, not a mandate. Divergence is allowed when a feature does not fit the existing
+  shape, but it must be justified, not assumed. Forcing an ill-fitting feature into the common mold
+  is as wrong as inventing a new pattern needlessly.
+- This principle and Principle 4 both serve future changeability and can pull against each other —
+  symmetry favors resembling neighbors, swappability favors not entangling with them. Balance them.
+
+## 4. Keep components swappable
+
+Separate a feature from the dependencies it relies on so either can be replaced independently. In a
+fast-moving field, tight coupling to a volatile dependency is technical risk, not convenience.
+
+- Isolate the parts most likely to change — the model, the agent harness, external MCP/protocol
+  standards — behind a boundary (interface, adapter, or config). Do not reference them inline
+  throughout the codebase.
+- **Target state:** the agent harness is a replaceable dependency. The current code does not yet meet
+  this. New work moves toward it, not away from it.
+
+## 5. A user-facing feature isn't done until it's discoverable
+
+If a change alters what an operator or deployer sees or does, the user-facing surface ships with it: a
+docs how-to, CLI `--help` text, and a changelog entry. Code that works but cannot be found is
+incomplete, not done.
+
+- Test each change against: "Could a user discover and use this without reading the source?" If no,
+  the feature is unfinished.
+- Match the documentation shape peers already use — if comparable features have a how-to page, this
+  one does too.
+- Internal-only or framework-internal changes are exempt; the bar is reader-facing impact, not line
+  count.
+
+---
+
+## How to apply
+
+When a feature feels wrong but the reason is hard to name, identify which principle it violates and
+state it plainly: name the principle, point at the specific drift, and propose the change that brings
+the work back in line. The questions behind the principles: Is the unsafe path harder to reach than
+the safe one? Would this be wrong at another facility? Does this follow the shape of its peers? Can
+this dependency be swapped later without a rewrite? Could a user discover and use this without
+reading the source?

--- a/tests/cli/test_skills_cmd.py
+++ b/tests/cli/test_skills_cmd.py
@@ -92,6 +92,24 @@ def test_resource_path_for_deploy_skill_resolves() -> None:
     assert skill_md.is_file()
 
 
+def test_resource_path_for_design_philosophy_skill_resolves() -> None:
+    """The design-philosophy skill is discoverable under templates/skills/."""
+    from importlib.resources import files
+
+    skill_md = files("osprey").joinpath("templates/skills/osprey-design-philosophy/SKILL.md")
+    assert skill_md.is_file()
+
+
+def test_install_design_philosophy_skill(fake_home: Path) -> None:
+    """The design-philosophy skill installs into the default global target."""
+    runner = CliRunner()
+    result = runner.invoke(skills, ["install", "osprey-design-philosophy"])
+
+    assert result.exit_code == 0, result.output
+    target = fake_home / ".claude" / "skills" / "osprey-design-philosophy"
+    assert (target / "SKILL.md").is_file()
+
+
 def test_install_deploy_skill_to_custom_target(tmp_path: Path) -> None:
     """``--target`` installs the deploy skill into a project-local .claude/skills/.
 


### PR DESCRIPTION
## What

Ships the `osprey-design-philosophy` skill — OSPREY's design and architecture principles — as a bundled, installable skill via `osprey skills install`.

It was previously local-only (a gitignored `.claude/skills/` directory). This puts it under `src/osprey/templates/skills/` so it's distributed with the wheel and installable like the other bundled skills.

## Changes

- **New skill** `src/osprey/templates/skills/osprey-design-philosophy/SKILL.md` (5 confirmed principles: safe-state default, facility-neutral core, measured symmetry, swappable components, discoverable user-facing features).
- **Install surface** — registered in the `_SKILL_SOURCES` allowlist and the `osprey skills install --help` listing in `skills_cmd.py`.
- **Tests** — resource-resolution + default-target install, mirroring the existing per-skill tests.
- **Docs** — recommended in the contributing guide via a new *Design Principles* subsection (consult before designing a non-trivial feature) plus the bundled-skills list; added to the CLI-reference "Currently supported skills" list. That list had also drifted to omit `osprey-contribute`, `osprey-pre-commit`, and `osprey-release` — backfilled.
- **CHANGELOG** — one-line `[Unreleased]` entry.

## Verification

`pytest tests/cli/test_skills_cmd.py` → 10 passed; ruff lint + format clean.