### PR TITLE
feat(timezone): unify facility-timezone handling across telemetry, logbook, connectors, and ARIEL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ Compatibility is documented in release notes, not encoded in the version string.
 ### Changed
 
 - ARIEL `capabilities` MCP tool now documents that it is *not* a health check (it reads config only and never touches the database); use the `status` tool or `osprey ariel status` for live database connectivity.
+- All agent-facing timestamps now share one configurable facility timezone (`system.timezone`): archiver queries, live channel reads, simulated events, ARIEL logbook timestamps, and executed-script run times are interpreted and rendered in that zone, and outputs carry an explicit UTC offset. Operator-provided times ("today", "14:32") are read as facility-local. The shipped presets now pin `system.timezone: UTC` explicitly (previously inherited the host `$TZ`, or — for `ariel_standalone` — had no setting at all) for reproducible runs — set your real facility zone in production.
+- OSPREY now logs a one-time warning at startup when the container `$TZ` disagrees with the configured `system.timezone`, surfacing a misconfigured deploy where OS-level log timestamps would differ from agent-reported times (`system.timezone` stays authoritative).
+
+### Fixed
+
+- Simulation `at_time` events now fire at the facility wall-clock time-of-day regardless of the deploy host's `$TZ` (previously placed in the box's local zone, so daily archiver events landed at the wrong time on non-UTC machines).
+- Seeded and ingested logbook entries now resolve their relative time-of-day in the facility timezone, so on a non-UTC facility the narrative lands at the same wall-clock time as the telemetry it describes (previously anchored in UTC, drifting hours from the archiver event).
+- The ARIEL web **API** now returns entry timestamps as facility-local ISO with an explicit offset, matching the MCP path (previously the web API emitted raw UTC while the agent saw facility-local). The web and MCP paths now share one rendering helper, and the MCP single-entry `get` is localized to match search/browse. (The web UI still renders in the viewer's browser timezone; the wire format now carries the facility offset.)
 
 ## [2026.6.1] - 2026-06-17
 

--- a/docs/source/how-to/build-profiles.rst
+++ b/docs/source/how-to/build-profiles.rst
@@ -241,6 +241,9 @@ The ``config:`` section uses **dot notation** to override any key in the generat
      archiver.epics_archiver.url: https://archiver.facility.org
 
      # System
+     # Set your real facility zone: it governs how the agent reads operator
+     # times (parsed as facility-local) and renders every timestamp (with an
+     # explicit offset) — not just a display label.
      system.timezone: America/Los_Angeles
 
      # Channel finder

--- a/src/osprey/connectors/archiver/mock_archiver_connector.py
+++ b/src/osprey/connectors/archiver/mock_archiver_connector.py
@@ -15,6 +15,7 @@ import pandas as pd
 from osprey.connectors.archiver.base import ArchiverConnector, ArchiverMetadata
 from osprey.connectors.pv_taxonomy import classify_pv
 from osprey.simulation import engine_serves
+from osprey.utils.config import get_facility_timezone
 from osprey.utils.logger import get_logger
 
 if TYPE_CHECKING:
@@ -142,8 +143,10 @@ class MockArchiverConnector(ArchiverConnector):
         return ArchiverMetadata(
             pv_name=pv_name,
             is_archived=True,
-            archival_start=datetime(2000, 1, 1),  # Arbitrary old date
-            archival_end=datetime.now(),
+            # Both bounds tz-aware (facility zone) so a consumer can subtract or
+            # compare them without a naive/aware TypeError.
+            archival_start=datetime(2000, 1, 1, tzinfo=get_facility_timezone()),
+            archival_end=datetime.now(get_facility_timezone()),
             sampling_period=1.0 / self._sample_rate_hz,
             description=f"Mock archived PV: {pv_name}",
         )

--- a/src/osprey/connectors/control_system/epics_connector.py
+++ b/src/osprey/connectors/control_system/epics_connector.py
@@ -20,6 +20,7 @@ from osprey.connectors.control_system.base import (
     ControlSystemConnector,
     WriteVerification,
 )
+from osprey.utils.config import get_facility_timezone
 from osprey.utils.logger import get_logger
 
 logger = get_logger("epics_connector")
@@ -217,11 +218,11 @@ class EPICSConnector(ControlSystemConnector):
         # context needs extra time to receive the first value.
         value = pv.get(timeout=timeout)
 
-        # Get timestamp from EPICS (seconds since epoch)
+        # Get timestamp from EPICS (seconds since epoch), rendered in facility tz
         if pv.timestamp:
-            timestamp = datetime.fromtimestamp(pv.timestamp)
+            timestamp = datetime.fromtimestamp(pv.timestamp, get_facility_timezone())
         else:
-            timestamp = datetime.now()
+            timestamp = datetime.now(get_facility_timezone())
 
         # Extract metadata
         metadata = ChannelMetadata(
@@ -450,7 +451,11 @@ class EPICSConnector(ControlSystemConnector):
             """Wrapper to convert EPICS callback to our format."""
             pv_value = ChannelValue(
                 value=value,
-                timestamp=datetime.fromtimestamp(timestamp) if timestamp else datetime.now(),
+                timestamp=(
+                    datetime.fromtimestamp(timestamp, get_facility_timezone())
+                    if timestamp
+                    else datetime.now(get_facility_timezone())
+                ),
                 metadata=ChannelMetadata(
                     units=kwargs.get("units", ""), alarm_status=kwargs.get("status")
                 ),

--- a/src/osprey/connectors/control_system/mock_connector.py
+++ b/src/osprey/connectors/control_system/mock_connector.py
@@ -25,6 +25,7 @@ from osprey.connectors.control_system.base import (
 )
 from osprey.connectors.pv_taxonomy import classify_pv
 from osprey.simulation import engine_serves
+from osprey.utils.config import get_facility_timezone
 from osprey.utils.logger import get_logger
 
 logger = get_logger("mock_connector")
@@ -119,7 +120,7 @@ class MockConnector(ControlSystemConnector):
         # Simulation engine serves its channels; unknown PVs fall back to legacy
         if engine_serves(self._sim_engine, channel_address):
             reading = self._sim_engine.read(channel_address)
-            now = datetime.now()
+            now = datetime.now(get_facility_timezone())
             return ChannelValue(
                 value=reading.value,
                 timestamp=now,
@@ -141,10 +142,10 @@ class MockConnector(ControlSystemConnector):
 
         return ChannelValue(
             value=value,
-            timestamp=datetime.now(),
+            timestamp=datetime.now(get_facility_timezone()),
             metadata=ChannelMetadata(
                 units=self._infer_units(channel_address),
-                timestamp=datetime.now(),
+                timestamp=datetime.now(get_facility_timezone()),
                 description=f"Mock channel: {channel_address}",
             ),
         )
@@ -336,12 +337,12 @@ class MockConnector(ControlSystemConnector):
             return ChannelMetadata(
                 units=reading.units,
                 description=reading.description,
-                timestamp=datetime.now(),
+                timestamp=datetime.now(get_facility_timezone()),
             )
         return ChannelMetadata(
             units=self._infer_units(channel_address),
             description=f"Mock channel: {channel_address}",
-            timestamp=datetime.now(),
+            timestamp=datetime.now(get_facility_timezone()),
         )
 
     async def validate_channel(self, channel_address: str) -> bool:

--- a/src/osprey/interfaces/ariel/api/routes.py
+++ b/src/osprey/interfaces/ariel/api/routes.py
@@ -29,6 +29,7 @@ from osprey.interfaces.ariel.api.schemas import (
     SearchResponse,
     StatusResponse,
 )
+from osprey.utils.config import to_facility_iso
 
 if TYPE_CHECKING:
     from osprey.services.ariel_search import ARIELSearchService
@@ -45,6 +46,20 @@ def _parse_metadata_form(raw: str | None) -> dict[str, Any]:
         return parsed if isinstance(parsed, dict) else {}
     except (ValueError, TypeError):
         return {}
+
+
+def _localize_facility(dt: datetime | None) -> datetime | None:
+    """Attach the facility timezone to a naive operator-provided datetime.
+
+    Mirrors the MCP ``parse_date_filters`` contract so the web UI interprets
+    operator-supplied dates as facility-local (not box-local / UTC) before they
+    drive a ``TIMESTAMPTZ`` query. Aware datetimes pass through unchanged.
+    """
+    if dt is not None and dt.tzinfo is None:
+        from osprey.utils.config import get_facility_timezone
+
+        return dt.replace(tzinfo=get_facility_timezone())
+    return dt
 
 
 def _require_service(request: Request) -> ARIELSearchService:
@@ -73,16 +88,20 @@ def _entry_to_response(
         if not att.get("type") and att.get("filename"):
             att["type"] = guess_mime_type(att["filename"])
 
+    # Render the three timestamp fields facility-local (ISO with offset) via the
+    # shared egress helper, so the web wire format matches the MCP path
+    # (serialize_entry) instead of leaking the DB's raw UTC. The schema fields are
+    # ``str`` so Pydantic passes these pre-formatted strings through unchanged.
     return EntryResponse(
         entry_id=entry["entry_id"],
         source_system=entry["source_system"],
-        timestamp=entry["timestamp"],
+        timestamp=to_facility_iso(entry["timestamp"]),
         author=entry.get("author", ""),
         raw_text=entry["raw_text"],
         attachments=attachments,
         metadata=entry.get("metadata", {}),
-        created_at=entry["created_at"],
-        updated_at=entry["updated_at"],
+        created_at=to_facility_iso(entry["created_at"]),
+        updated_at=to_facility_iso(entry["updated_at"]),
         summary=entry.get("summary"),
         keywords=entry.get("keywords", []),
         score=score,
@@ -161,9 +180,9 @@ async def search(request: Request, search_req: SearchRequest) -> SearchResponse:
         source_system = adv.pop("source_system", None) or search_req.source_system
 
         if isinstance(start_date, str) and start_date:
-            start_date = datetime.fromisoformat(start_date)
+            start_date = _localize_facility(datetime.fromisoformat(start_date))
         if isinstance(end_date, str) and end_date:
-            end_date = datetime.fromisoformat(end_date)
+            end_date = _localize_facility(datetime.fromisoformat(end_date))
 
         time_range = None
         if start_date or end_date:
@@ -230,10 +249,12 @@ async def list_entries(
     try:
         total = await service.repository.count_entries()
 
+        # Operator-supplied query params are parsed naive by FastAPI; interpret
+        # them as facility-local before they hit the TIMESTAMPTZ column.
         # TODO: add offset pagination when repository supports it
         entries = await service.repository.search_by_time_range(
-            start=start_date,
-            end=end_date,
+            start=_localize_facility(start_date),
+            end=_localize_facility(end_date),
             limit=page_size,
         )
 

--- a/src/osprey/interfaces/ariel/api/schemas.py
+++ b/src/osprey/interfaces/ariel/api/schemas.py
@@ -32,13 +32,19 @@ class EntryResponse(BaseModel):
 
     entry_id: str
     source_system: str
-    timestamp: datetime
+    # Pre-rendered facility-local ISO-8601 strings (with explicit offset) via
+    # to_facility_iso in _entry_to_response — kept as ``str`` (not ``datetime``) so
+    # Pydantic does not re-parse and re-emit them in the DB's stored UTC offset,
+    # which would silently undo the localization and reintroduce the web/MCP drift
+    # this fixes. Nullable because the shared helper is None-safe (a missing value
+    # renders as null rather than 500-ing); in practice the DB columns are present.
+    timestamp: str | None
     author: str
     raw_text: str
     attachments: list[AttachmentResponse] = []
     metadata: dict = {}
-    created_at: datetime
-    updated_at: datetime
+    created_at: str | None
+    updated_at: str | None
     summary: str | None = None
     keywords: list[str] = []
     score: float | None = None

--- a/src/osprey/mcp_server/ariel/server.py
+++ b/src/osprey/mcp_server/ariel/server.py
@@ -73,12 +73,9 @@ def serialize_entry(entry: dict, text_limit: int = 300) -> dict:
     Returns:
         Serialized dict suitable for JSON response.
     """
-    from osprey.utils.config import get_facility_timezone
+    from osprey.utils.config import to_facility_iso
 
-    ts = entry["timestamp"]
-    if hasattr(ts, "astimezone"):
-        tz = get_facility_timezone()
-        ts = ts.astimezone(tz).isoformat()
+    ts = to_facility_iso(entry["timestamp"])
 
     result = {
         "entry_id": entry["entry_id"],

--- a/src/osprey/mcp_server/ariel/tools/entry.py
+++ b/src/osprey/mcp_server/ariel/tools/entry.py
@@ -100,20 +100,24 @@ async def entry_get(
                 ],
             )
 
-        # TypedDict -- dict access, not attribute access
+        # TypedDict -- dict access, not attribute access. Localize the three
+        # timestamp fields through the shared egress helper so single-entry get
+        # matches search/browse (serialize_entry) instead of emitting raw UTC.
+        from osprey.utils.config import to_facility_iso
+
         return json.dumps(
             {
                 "entry_id": entry["entry_id"],
                 "source_system": entry["source_system"],
-                "timestamp": entry["timestamp"],
+                "timestamp": to_facility_iso(entry["timestamp"]),
                 "author": entry.get("author", ""),
                 "raw_text": entry["raw_text"],
                 "attachments": entry.get("attachments", []),
                 "metadata": entry.get("metadata", {}),
                 "summary": entry.get("summary"),
                 "keywords": entry.get("keywords", []),
-                "created_at": entry["created_at"],
-                "updated_at": entry["updated_at"],
+                "created_at": to_facility_iso(entry["created_at"]),
+                "updated_at": to_facility_iso(entry["updated_at"]),
             },
             default=str,
         )

--- a/src/osprey/mcp_server/ariel/tools/sql_query.py
+++ b/src/osprey/mcp_server/ariel/tools/sql_query.py
@@ -48,6 +48,11 @@ async def sql_query(
         query: Read-only SQL query (SELECT or WITH only).
         max_rows: Maximum rows to return (1-200, default 100).
 
+    Note: timestamp columns (timestamp, created_at, updated_at) are returned as
+    stored — UTC with a +00:00 offset. Unlike the other ARIEL tools, this raw
+    query path does not convert them to the facility timezone (the columns a query
+    selects are arbitrary), so convert client-side if you need facility-local.
+
     Returns:
         JSON with query results as a list of row objects.
     """

--- a/src/osprey/mcp_server/control_system/tools/archiver_read.py
+++ b/src/osprey/mcp_server/control_system/tools/archiver_read.py
@@ -3,11 +3,12 @@
 import json
 import logging
 import math
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 
 from osprey.mcp_server.control_system.error_handling import connector_error_handler
 from osprey.mcp_server.control_system.server import mcp
 from osprey.mcp_server.errors import make_error
+from osprey.utils.config import get_facility_timezone
 
 logger = logging.getLogger("osprey.mcp_server.tools.archiver_read")
 
@@ -16,9 +17,13 @@ def _parse_time(time_str: str) -> datetime:
     """Parse a time string into a timezone-aware datetime.
 
     Supports ISO-8601 and simple relative expressions like "1h ago", "30m ago", "2d ago".
+    Naive inputs (operator-provided wall-clock with no offset) are interpreted as
+    facility-local — the agent rule promises operator times are facility-local, so the
+    query window and the echoed range must honor the facility zone, not the box/UTC.
     """
+    tz = get_facility_timezone()
     if not time_str or time_str.strip().lower() == "now":
-        return datetime.now(UTC)
+        return datetime.now(tz)
 
     stripped = time_str.strip().lower()
 
@@ -30,7 +35,7 @@ def _parse_time(time_str: str) -> datetime:
             if amount_unit.endswith(suffix):
                 try:
                     amount = float(amount_unit[:-1])
-                    return datetime.now(UTC) - timedelta(**{kwarg: amount})
+                    return datetime.now(tz) - timedelta(**{kwarg: amount})
                 except ValueError:
                     break
 
@@ -39,7 +44,7 @@ def _parse_time(time_str: str) -> datetime:
 
     dt = dateutil_parser.parse(time_str)
     if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=UTC)
+        dt = dt.replace(tzinfo=tz)
     return dt
 
 

--- a/src/osprey/services/ariel_search/ingestion/adapters/generic.py
+++ b/src/osprey/services/ariel_search/ingestion/adapters/generic.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, cast
 from osprey.services.ariel_search.exceptions import IngestionError
 from osprey.services.ariel_search.ingestion.base import FacilityAdapter
 from osprey.services.ariel_search.models import AttachmentInfo, EnhancedLogbookEntry
+from osprey.utils.config import get_facility_timezone
 from osprey.utils.logger import get_logger
 from osprey.utils.relative_time import RelativeTimestamp, resolve_relative_timestamp
 
@@ -212,7 +213,11 @@ class GenericJSONAdapter(FacilityAdapter):
 
     def _convert_entry(self, data: dict[str, Any]) -> EnhancedLogbookEntry:
         """Convert generic JSON entry to EnhancedLogbookEntry."""
-        now = datetime.now(UTC)
+        # Facility zone, not UTC: a relative ``{days_ago, time}`` spec resolves its
+        # time-of-day in this anchor's zone, so seeded demo narrative lands at the
+        # documented facility-local clock time (matching the telemetry it
+        # accompanies). Absolute timestamps ignore ``now`` (see _resolve_timestamp).
+        now = datetime.now(get_facility_timezone())
 
         timestamp = self._resolve_timestamp(data, now)
 

--- a/src/osprey/services/python_executor/services.py
+++ b/src/osprey/services/python_executor/services.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import nbformat
 
+from osprey.utils.config import get_facility_timezone
 from osprey.utils.logger import get_logger
 
 from .models import NotebookAttempt, NotebookType, PythonExecutionContext
@@ -581,7 +582,9 @@ class NotebookManager:
             notebook_path=notebook_path,
             notebook_link=self._file_manager._create_jupyter_url(notebook_path),
             error_context=error_context,
-            created_at=datetime.now().isoformat(),
+            # Operator-facing run time → facility-local ISO with offset (host-side
+            # stamp). The strftime filename above stays naive on purpose.
+            created_at=datetime.now(get_facility_timezone()).isoformat(),
         )
         context.add_notebook_attempt(attempt)
 
@@ -643,7 +646,8 @@ class NotebookManager:
         # Header
         header = f"# Python Executor - Attempt #{attempt_number}\n\n"
         header += f"**Stage:** {stage}\n"
-        header += f"**Created:** {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+        # Operator-facing header → facility-local wall clock with zone label.
+        header += f"**Created:** {datetime.now(get_facility_timezone()).strftime('%Y-%m-%d %H:%M:%S %Z')}\n\n"
 
         if approval_context:
             header += f"{approval_context}\n\n"

--- a/src/osprey/simulation/apply.py
+++ b/src/osprey/simulation/apply.py
@@ -17,12 +17,12 @@ from __future__ import annotations
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from osprey.simulation.engine import SimulationEngine
-from osprey.utils.config import load_config
+from osprey.utils.config import get_facility_timezone, load_config
 from osprey.utils.logger import get_logger
 from osprey.utils.relative_time import resolve_relative_timestamp
 
@@ -79,7 +79,8 @@ def apply_scenarios(
             purge and reseed the ARIEL logbook from the active scenarios'
             entries so the narrative matches the telemetry.
         now: Apply-time anchor T0 (injectable for tests). Defaults to the
-            current UTC time.
+            current time in the facility timezone, so seeded logbook entries
+            resolve their time-of-day on the same clock as the telemetry.
 
     Returns:
         :class:`ApplyResult` with the resolved active set and seed/purge status.
@@ -105,7 +106,12 @@ def apply_scenarios(
         machine_path = project_dir / machine_path
     engine = SimulationEngine.from_file(machine_path)
 
-    t0 = now or datetime.now(UTC)
+    # Default anchor in the FACILITY zone (not UTC): the anchor's tzinfo is the
+    # zone each seeded logbook entry's relative time-of-day resolves into, and it
+    # must match where the simulation engine places the telemetry it narrates
+    # (daily ``at_time`` events are facility-local). A UTC default silently shifts
+    # the narrative hours away from its archiver evidence on a non-UTC facility.
+    t0 = now or datetime.now(get_facility_timezone())
     # set_active_scenarios validates composition and raises on collisions/unknowns.
     active = engine.set_active_scenarios(names, anchor=t0)
     logger.info(f"Activated scenarios {list(active)!r} with anchor {t0.isoformat()}")

--- a/src/osprey/simulation/engine.py
+++ b/src/osprey/simulation/engine.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, ClassVar
+from zoneinfo import ZoneInfo
 
 import numpy as np
 
@@ -46,6 +47,7 @@ from osprey.simulation.series import (
     ref_value,
     string_series,
 )
+from osprey.utils.config import get_facility_timezone
 from osprey.utils.logger import get_logger
 
 logger = get_logger("simulation_engine")
@@ -333,8 +335,8 @@ class SimulationEngine:
         ``until_offset`` for ramps) anchors it in wall-clock time, in seconds
         relative to the apply-time anchor T0 (the ``anchor=`` line in the state
         file, falling back to its mtime; negative = past). ``at_time``
-        (``"HH:MM:SS"``, local
-        time; step/spike only) recurs daily: the event fires at that time of
+        (``"HH:MM:SS"`` in the facility timezone; step/spike only) recurs daily:
+        the event fires at that time of
         day on every calendar date inside the requested window. Anchored and
         time-of-day events honor the actual timestamp values, so an event
         outside the requested window does not appear in it. For anchored and
@@ -359,8 +361,14 @@ class SimulationEngine:
             return []
         t_abs = epoch_seconds_array(timestamps)
         anchor = self._scenario_anchor()
+        # Resolve the facility timezone once per synthesis pass (cheap: config and
+        # ZoneInfo are both cached singletons) and thread it down, so daily
+        # ``at_time`` events are placed in facility-local time regardless of the
+        # deploy host's ``$TZ``. Resolved here, not at engine construction, so it
+        # reflects config loaded after connector init.
+        tz = get_facility_timezone()
         cache: dict[str, np.ndarray | list[str]] = {}
-        series = self._synthesize(pv, n, cache, t_abs, anchor)
+        series = self._synthesize(pv, n, cache, t_abs, anchor, tz)
         if isinstance(series, np.ndarray):
             return [float(v) for v in series]
         return list(series)
@@ -456,7 +464,13 @@ class SimulationEngine:
                 key, _, value = stripped.partition("=")
                 if key.strip() == "anchor":
                     try:
-                        anchor_epoch = datetime.fromisoformat(value.strip()).timestamp()
+                        parsed = datetime.fromisoformat(value.strip())
+                        # Anchors written by apply.py are UTC-aware; attach the
+                        # facility zone to a naive (hand-edited/legacy) anchor so
+                        # ``.timestamp()`` does not silently fall back to box-local.
+                        if parsed.tzinfo is None:
+                            parsed = parsed.replace(tzinfo=get_facility_timezone())
+                        anchor_epoch = parsed.timestamp()
                     except ValueError:
                         logger.warning(f"Ignoring malformed anchor in state file: {stripped!r}")
                 continue
@@ -519,6 +533,7 @@ class SimulationEngine:
         cache: dict[str, "np.ndarray | list[str]"],
         t_abs: "np.ndarray | None",
         anchor: float,
+        tz: ZoneInfo,
     ) -> "np.ndarray | list[str]":
         """Build one channel's series, memoized per synthesis pass."""
         cached = cache.get(pv)
@@ -528,13 +543,13 @@ class SimulationEngine:
         events = self._composed_archiver.get(pv, [])
 
         if channel.expr is None and isinstance(channel.value, str):
-            series_str = string_series(channel.value, events, n, t_abs, anchor)
+            series_str = string_series(channel.value, events, n, t_abs, anchor, tz)
             cache[pv] = series_str
             return series_str
 
         if channel.expr is not None:
             ref_series = {
-                ref: self._synthesize(ref, n, cache, t_abs, anchor) for ref in channel.refs
+                ref: self._synthesize(ref, n, cache, t_abs, anchor, tz) for ref in channel.refs
             }
             values: list[float] = []
             for i in range(n):
@@ -548,7 +563,7 @@ class SimulationEngine:
             assert channel.value is not None  # guaranteed by parse_machine
             series = np.full(n, float(channel.value))
 
-        series = apply_events(series, events, n, t_abs, anchor)
+        series = apply_events(series, events, n, t_abs, anchor, tz)
         if channel.noise > 0.0:
             series = series * (1.0 + self._rng.normal(0.0, channel.noise, n))
         if channel.min_value is not None or channel.max_value is not None:

--- a/src/osprey/simulation/series.py
+++ b/src/osprey/simulation/series.py
@@ -14,6 +14,7 @@ from collections.abc import Sequence
 from datetime import datetime, timedelta
 from datetime import time as dtime
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import numpy as np
 
@@ -56,7 +57,11 @@ def epoch_seconds_array(timestamps: "Sequence[Any]") -> "np.ndarray | None":
 
 
 def event_positions(
-    event: dict[str, Any], t_frac: "np.ndarray", t_abs: "np.ndarray | None", anchor: float
+    event: dict[str, Any],
+    t_frac: "np.ndarray",
+    t_abs: "np.ndarray | None",
+    anchor: float,
+    tz: ZoneInfo | None = None,
 ) -> "list[tuple[np.ndarray, float]]":
     """Coordinate axis and event position(s) for one event.
 
@@ -64,9 +69,9 @@ def event_positions(
     yield one position, on the normalized window axis and the epoch-seconds
     axis respectively. Daily ``at_time`` events yield one epoch-seconds
     position per calendar date whose time-of-day occurrence falls inside the
-    window. Returns an empty list when an anchored or time-of-day event
-    cannot be placed because the timestamps were not convertible to epoch
-    seconds.
+    window, placed in the facility timezone (``tz``). Returns an empty list
+    when an anchored or time-of-day event cannot be placed because the
+    timestamps were not convertible to epoch seconds.
     """
     if "at_offset" in event:
         if t_abs is None:
@@ -79,21 +84,26 @@ def event_positions(
         if t_abs is None:
             logger.debug("Skipping time-of-day event: timestamps not convertible to epoch seconds")
             return []
-        return [(t_abs, at) for at in daily_occurrences(str(event["at_time"]), t_abs)]
+        return [(t_abs, at) for at in daily_occurrences(str(event["at_time"]), t_abs, tz)]
     return [(t_frac, float(event["at"]))]
 
 
-def daily_occurrences(at_time: str, t_abs: "np.ndarray") -> list[float]:
+def daily_occurrences(at_time: str, t_abs: "np.ndarray", tz: ZoneInfo | None = None) -> list[float]:
     """Epoch-second positions of a daily time-of-day within ``[t_abs[0], t_abs[-1]]``.
 
-    Walks calendar dates (local time) from the window start to its end and
-    keeps every occurrence of ``at_time`` that falls inside the window.
+    Walks calendar dates from the window start to its end (in timezone ``tz``)
+    and keeps every occurrence of ``at_time`` that falls inside the window.
+    Placing the time-of-day in an explicit zone — rather than the deploy host's
+    local zone — makes the result independent of the box ``$TZ``. ``tz`` defaults
+    to UTC; the engine resolves and threads the facility zone (so this module
+    stays free of config), so production callers always supply it explicitly.
     Assumes ascending timestamps (the same contract ``apply_events`` relies
     on via ``np.searchsorted``).
     """
+    zone = tz if tz is not None else ZoneInfo("UTC")
     tod = dtime.fromisoformat(at_time)
-    start = datetime.fromtimestamp(float(t_abs[0]))
-    end = datetime.fromtimestamp(float(t_abs[-1]))
+    start = datetime.fromtimestamp(float(t_abs[0]), zone)
+    end = datetime.fromtimestamp(float(t_abs[-1]), zone)
     cursor = start.replace(hour=0, minute=0, second=0, microsecond=0)
     positions: list[float] = []
     while cursor <= end:
@@ -112,6 +122,7 @@ def string_series(
     n: int,
     t_abs: "np.ndarray | None",
     anchor: float,
+    tz: ZoneInfo | None = None,
 ) -> list[str]:
     """Constant string series; only 'step' events are meaningful for strings."""
     t_frac = np.linspace(0.0, 1.0, n)
@@ -119,7 +130,7 @@ def string_series(
     for event in events:
         if event["shape"] != "step":
             continue
-        for x, at in event_positions(event, t_frac, t_abs, anchor):
+        for x, at in event_positions(event, t_frac, t_abs, anchor, tz):
             for i in range(n):
                 if x[i] >= at:
                     series[i] = str(event["to"])
@@ -132,6 +143,7 @@ def apply_events(
     n: int,
     t_abs: "np.ndarray | None",
     anchor: float,
+    tz: ZoneInfo | None = None,
 ) -> "np.ndarray":
     """Apply step/ramp/spike events in order (window-fraction or wall-clock)."""
     if not events:
@@ -141,7 +153,7 @@ def apply_events(
     for event in events:
         shape = event["shape"]
         offset_anchored = "at_offset" in event
-        for x, at in event_positions(event, t_frac, t_abs, anchor):
+        for x, at in event_positions(event, t_frac, t_abs, anchor, tz):
             if shape == "step":
                 series[x >= at] = float(event["to"])
             elif shape == "ramp":

--- a/src/osprey/templates/apps/ariel_standalone/config.yml.j2
+++ b/src/osprey/templates/apps/ariel_standalone/config.yml.j2
@@ -78,6 +78,17 @@ api:
 container_runtime: auto
 
 # ============================================================
+# SYSTEM CONFIGURATION
+# ============================================================
+system:
+  # Facility timezone: ARIEL parses operator-provided times as facility-local
+  # and renders all logbook timestamps in this zone (with an explicit offset).
+  # Pinned to UTC for reproducibility — set your real facility zone
+  # (e.g. America/Los_Angeles) in production. Avoid ${TZ:-...}: inheriting the
+  # host $TZ makes logbook queries and rendered timestamps non-deterministic.
+  timezone: UTC
+
+# ============================================================
 # SERVICE CONFIGURATION
 # ============================================================
 # Only PostgreSQL is needed for ARIEL logbook search

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -419,7 +419,12 @@ cli:
 # ============================================================
 
 system:
-  timezone: ${TZ:-UTC}
+  # Facility timezone: how the agent interprets operator-provided times
+  # (parsed as facility-local) and renders all timestamps (with an explicit
+  # offset). Pinned to UTC for reproducibility — set your real facility zone
+  # (e.g. America/Los_Angeles) in production. Avoid ${TZ:-...}: inheriting the
+  # host $TZ makes archiver queries and simulated events non-deterministic.
+  timezone: UTC
 
 # File paths - Data storage organization
 file_paths:

--- a/src/osprey/templates/apps/hello_world/config.yml.j2
+++ b/src/osprey/templates/apps/hello_world/config.yml.j2
@@ -137,7 +137,11 @@ execution:
 # ============================================================
 
 system:
-  timezone: ${TZ:-UTC}
+  # Pinned to UTC for reproducibility — set your real facility zone in
+  # production. Avoid ${TZ:-...}: inheriting the host $TZ makes archiver
+  # queries and simulated events non-deterministic. Governs how the agent
+  # interprets operator times and renders all timestamps.
+  timezone: UTC
 
 file_paths:
   agent_data_dir: _agent_data

--- a/src/osprey/templates/claude_code/claude/rules/timezone.md.j2
+++ b/src/osprey/templates/claude_code/claude/rules/timezone.md.j2
@@ -1,13 +1,17 @@
 {% if system_timezone is defined and system_timezone %}---
 summary: Facility timezone context for timestamp interpretation
-description: Tells agents what timezone ARIEL timestamps are in
+description: Tells agents what timezone OSPREY timestamps are in
 ---
 
 # Timezone
 
-All timestamps returned by ARIEL tools (logbook search, browse, entry details)
-are in **{{ system_timezone }}**.
+The facility timezone is **{{ system_timezone }}**.
 
-When interpreting user references to time ("today", "this morning", "last Tuesday"),
-use this timezone.
+Every data timestamp an OSPREY tool reports — archiver and live channel reads,
+logbook entries, simulated events, executed-script run times — is in this
+timezone, with an explicit UTC offset. (Internal artifacts like log filenames are
+not operator-facing and may use another format.)
+
+When the operator refers to a time ("today", "this morning", "14:32",
+"last Tuesday"), interpret it as **facility-local** in this timezone.
 {% endif %}

--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -47,8 +47,12 @@ approval:
 # ============================================================
 
 system:
-  # Timezone configuration for all containers and services
-  timezone: ${TZ:-UTC}
+  # Facility timezone: how the agent interprets operator-provided times
+  # (parsed as facility-local) and renders all timestamps (with an explicit
+  # offset). Pinned to UTC for reproducibility — set your real facility zone
+  # (e.g. America/Los_Angeles) in production. Avoid ${TZ:-...}: inheriting the
+  # host $TZ makes archiver queries and simulated events non-deterministic.
+  timezone: UTC
 
 # File paths - Data storage organization
 file_paths:

--- a/src/osprey/templates/project/env.example.j2
+++ b/src/osprey/templates/project/env.example.j2
@@ -14,9 +14,6 @@ GOOGLE_API_KEY=your-google-api-key-here
 #PROJECT_ROOT={{ project_root }}
 #LOCAL_PYTHON_VENV=/path/to/your/venv/bin/python
 
-# Timezone
-TZ=UTC
-
 # Optional: Proxy settings (uncomment if behind corporate firewall)
 # NO_PROXY=localhost,127.0.0.1
 # HTTP_PROXY=http://proxy.example.com:8080

--- a/src/osprey/templates/project/env.j2
+++ b/src/osprey/templates/project/env.j2
@@ -36,6 +36,3 @@ LOCAL_PYTHON_VENV={{ env.LOCAL_PYTHON_VENV }}
 {% else -%}
 #LOCAL_PYTHON_VENV={{ current_python_env }}
 {% endif -%}
-
-# Timezone
-TZ={{ env.get('TZ', 'UTC') }}

--- a/src/osprey/templates/skills/osprey-build-deploy/references/facility-config-schema.md
+++ b/src/osprey/templates/skills/osprey-build-deploy/references/facility-config-schema.md
@@ -34,14 +34,14 @@ facility:
   name: "Advanced Light Source"          # full human-readable name
   prefix: "als"                           # short slug; used in profile filenames (als-prod.yml, als-client.yml)
                                           # and container names (als-mcp-matlab, als-web-thellert)
-  timezone: "America/Los_Angeles"         # IANA timezone for log timestamps and schedules
+  timezone: "America/Los_Angeles"         # facility timezone — drives container TZ and the agent's system.timezone
 ```
 
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
 | `name` | string | yes | Free text, shown in dashboards and Claude context |
 | `prefix` | string (lowercase, alnum + hyphens, 2–6 chars) | yes | Drives generated filenames and container names; choose carefully — changing later requires renaming many files |
-| `timezone` | IANA TZ | no | Default: `UTC` if omitted |
+| `timezone` | IANA TZ | no | The facility timezone. Drives container `TZ`; mirror it into the profile's `system.timezone`. Default: `UTC` if omitted |
 
 ---
 

--- a/src/osprey/templates/skills/osprey-build-deploy/references/setup-interview.md
+++ b/src/osprey/templates/skills/osprey-build-deploy/references/setup-interview.md
@@ -64,7 +64,7 @@ Validate: lowercase, alphanumeric + hyphens only, 2–6 chars. If invalid, expla
 > "Which control system do you connect to? OSPREY ships built-in support for **EPICS** and **Mock** today. DOOCS and TANGO are roadmap values — picking one writes the config but there is no working connector yet, so live control-system access won't work. If your site runs DOOCS/TANGO/Custom, pick `mock` for now so you can exercise the rest of the deploy pipeline; switch to the real value once a connector lands."
 
 **Q1.4 Timezone** (in a follow-up question or the same group if room):
-> "What IANA timezone should logs and schedules use? Default: `UTC`. ALS uses `America/Los_Angeles`."
+> "What timezone is your facility in? Drives container clocks and the assistant's time handling (how it reads operator times and stamps output). Default: `UTC`. ALS uses `America/Los_Angeles`."
 
 **EPICS-only follow-up.** If `control_system.type == "epics"`:
 > "Do you have an EPICS Channel Access broadcast address list (`EPICS_CA_ADDR_LIST`)? This is space-separated IPs/hostnames for CA discovery on your control network."
@@ -398,7 +398,7 @@ Tell the user what to do next:
 > Next steps:
 >
 > 1. **Fill in `.env`** with your actual secrets (it's gitignored, so it never leaves your machine).
-> 2. **Author your build profile**: run `/osprey-build-interview` to walk through creating a `profile.yml`. That's a separate skill — different concerns.
+> 2. **Author your build profile**: run `/osprey-build-interview` to walk through creating a `profile.yml`. That's a separate skill — different concerns. Use the same timezone you gave here so the agent and containers agree (it sets `system.timezone`).
 > 3. **Scaffold deploy infrastructure**: tell me 'scaffold the deploy infra' and I'll generate `docker-compose.yml`, `.gitlab-ci.yml`, `scripts/deploy.sh`, and `scripts/verify.sh` from the templates, parameterized by your config.
 > 4. **Review the generated files** — they're plain text, fully editable. The skill regenerates them from `facility-config.yml` whenever you change values.
 > 5. **First push and deploy**: `git push`, watch CI, trigger the release job, run `deploy.sh` on the server."

--- a/src/osprey/templates/skills/osprey-build-deploy/templates/core/.env.template
+++ b/src/osprey/templates/skills/osprey-build-deploy/templates/core/.env.template
@@ -43,7 +43,8 @@ REGISTRY=${config.registry.url}
 
 
 # -----------------------------------------------------------------------------
-# Timezone — applied to every container that honors $TZ.
+# Timezone — the facility timezone, applied to every container that honors $TZ.
+# Matches the profile's system.timezone (set via /osprey-build-interview).
 # -----------------------------------------------------------------------------
 TZ=${config.facility.timezone}
 

--- a/src/osprey/templates/skills/osprey-build-deploy/templates/facility-config.example.yml
+++ b/src/osprey/templates/skills/osprey-build-deploy/templates/facility-config.example.yml
@@ -30,7 +30,7 @@ schema_version: 1
 facility:
   name: "Demo Light Source"
   prefix: "dls"                          # 2-6 chars, lowercase, alphanumeric + hyphens
-  timezone: "America/Los_Angeles"        # IANA tz; affects log timestamps + scheduled jobs
+  timezone: "America/Los_Angeles"        # facility timezone — drives container TZ and the agent's system.timezone
 
 # -----------------------------------------------------------------------------
 # Control system — determines which connectors and modules are available.

--- a/src/osprey/templates/skills/osprey-build-interview/SKILL.md
+++ b/src/osprey/templates/skills/osprey-build-interview/SKILL.md
@@ -458,6 +458,9 @@ web_panels: []        # e.g. ariel, channel-finder, tuning — only if web dashb
 config:
   project_name: "<project-name>"
   control_system.type: mock   # or "epics"
+  # Default <facility_timezone> from facility-config.yml's facility.timezone if
+  # that file exists at the repo root (one facility, one timezone); only ask
+  # cold when it's absent. system.timezone is what the agent reads at runtime.
   system.timezone: "<facility_timezone>"
 
 overlay:

--- a/src/osprey/templates/skills/osprey-build-interview/references/osprey-config-reference.md
+++ b/src/osprey/templates/skills/osprey-build-interview/references/osprey-config-reference.md
@@ -218,7 +218,12 @@ cli:
 # SYSTEM
 # ============================================================
 system:
-  timezone: ${TZ:-UTC}
+  # Facility timezone: governs how the agent interprets operator-provided times
+  # (parsed as facility-local) and renders all timestamps (with an explicit
+  # offset). Set your real facility zone (e.g. America/Los_Angeles); use UTC for
+  # reproducible demos. Avoid ${TZ:-...}: inheriting the host $TZ makes archiver
+  # queries and simulated events non-deterministic.
+  timezone: UTC
 
 file_paths:
   agent_data_dir: _agent_data

--- a/src/osprey/utils/config.py
+++ b/src/osprey/utils/config.py
@@ -10,9 +10,12 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
+
+if TYPE_CHECKING:
+    from zoneinfo import ZoneInfo
 
 # Use standard logging (not get_logger) to avoid circular imports with logger.py
 # The short name 'CONFIG' enables easy filtering: quiet_logger(['registry', 'CONFIG'])
@@ -675,16 +678,85 @@ def get_config_value(path: str, default: Any = None, config_path: str | None = N
     return value
 
 
-def get_facility_timezone():
+_tz_drift_warned = False
+
+
+def get_facility_timezone() -> "ZoneInfo":
     """Get the facility timezone from config as a ZoneInfo object.
+
+    This is the safe default resolver for every simulation synthesis primitive
+    and timestamp render site, so it must never raise: an unloaded config (no
+    ``config.yml`` and no ``CONFIG_FILE``) or a misconfigured/typo'd zone name
+    degrades to UTC with a logged warning rather than propagating to callers.
 
     Returns:
         ZoneInfo for the configured facility timezone, defaulting to UTC.
     """
     from zoneinfo import ZoneInfo
 
-    tz_name = get_config_value("facility_timezone", "UTC")
-    return ZoneInfo(tz_name)
+    try:
+        tz_name = get_config_value("facility_timezone", "UTC")
+        zone = ZoneInfo(tz_name)
+    except Exception as exc:  # noqa: BLE001 - any failure must degrade to UTC, not raise
+        logger.warning(f"Falling back to UTC facility timezone ({type(exc).__name__}: {exc})")
+        return ZoneInfo("UTC")
+
+    _warn_on_tz_drift(tz_name)
+    return zone
+
+
+def _warn_on_tz_drift(tz_name: str) -> None:
+    """Warn once if the container ``$TZ`` disagrees with an explicit system.timezone.
+
+    Agent-facing timestamps key off ``system.timezone``, not ``$TZ``, so a
+    divergence only mis-stamps OS-level container logs — but it signals a
+    misconfigured deploy (container clock != agent zone). We surface it as a
+    one-time warning rather than enforcing equality: ``system.timezone`` stays the
+    single source of truth, and this check never changes the returned value or
+    raises. Skips the implicit-UTC default (config absent) so CI/tests with
+    ``$TZ`` set but no configured ``system.timezone`` stay quiet.
+    """
+    global _tz_drift_warned
+    if _tz_drift_warned:
+        return
+    host_tz = os.environ.get("TZ")
+    if not host_tz or host_tz == tz_name:
+        return
+    # Only meaningful when system.timezone was explicitly configured (the alias
+    # default would otherwise make every $TZ-set environment look divergent).
+    if get_config_value("system.timezone", None) is None:
+        return
+    _tz_drift_warned = True
+    logger.warning(
+        f"Container $TZ={host_tz!r} differs from the facility system.timezone={tz_name!r}; "
+        f"OS-level log timestamps will differ from agent-reported times. Set both to "
+        f"the same zone (system.timezone is authoritative for what the agent reports)."
+    )
+
+
+def to_facility_iso(value: Any) -> "str | None":
+    """Render a value as a facility-local ISO-8601 string with explicit offset.
+
+    The single shared timestamp-egress transform for agent- and operator-facing
+    output (the ARIEL MCP ``serialize_entry``/``entry_get`` and the ARIEL web
+    responses). Centralizing it here is deliberate: the input side was already
+    mirrored (``parse_date_filters`` / ``_localize_facility``), and the original
+    web/MCP output drift came from a copy-pasted localizer, so both paths now call
+    one function. An aware datetime is converted to the facility zone; a naive
+    datetime is assumed to already be facility-local wall-clock and is stamped with
+    the facility zone (mirroring the parse-side ``_localize_facility`` contract —
+    never the box ``$TZ``, which ``astimezone`` would otherwise impose); ``None``
+    passes through; anything else degrades to ``str(value)`` so callers never crash
+    on an unexpected shape (e.g. a value already serialized upstream).
+    """
+    if value is None:
+        return None
+    if hasattr(value, "astimezone"):  # a datetime
+        tz = get_facility_timezone()
+        if value.tzinfo is None:
+            return str(value.replace(tzinfo=tz).isoformat())
+        return str(value.astimezone(tz).isoformat())
+    return str(value)
 
 
 def get_full_configuration(config_path: str | None = None) -> dict[str, Any]:

--- a/tests/cli/test_build_preset.py
+++ b/tests/cli/test_build_preset.py
@@ -917,6 +917,16 @@ def test_each_bundled_preset_builds_clean(preset: str, runner: CliRunner, tmp_pa
     manifest = json.loads((project_dir / ".osprey-manifest.json").read_text())
     assert manifest["schema_version"] == "1.2.0"
     assert manifest["creation"]["template"] == preset
+    # 3. Every preset must explicitly pin the facility timezone — agent timestamp
+    #    interpretation/rendering keys off system.timezone, and a preset that omits
+    #    it falls back to a silent default (the ariel_standalone blind spot). Binding
+    #    to list_presets() auto-forces any new preset to declare it too.
+    config = _config_yaml(project_dir)
+    tz = config.get("system", {}).get("timezone")
+    assert isinstance(tz, str) and tz.strip(), (
+        f"preset {preset!r} does not pin system.timezone — agent timestamps would "
+        f"fall back to a silent default; add an explicit `system.timezone`"
+    )
 
 
 def test_control_assistant_preset_ships_simulation_model(runner: CliRunner, tmp_path: Path) -> None:

--- a/tests/config/test_config_builder.py
+++ b/tests/config/test_config_builder.py
@@ -294,5 +294,190 @@ control_system:
         assert value == 100  # Should retrieve the value from config
 
 
+class TestGetFacilityTimezone:
+    """``get_facility_timezone`` must never raise — it is the safe default for
+    every synthesis primitive and timestamp render site, so an unloaded config
+    or a misconfigured zone name must degrade to UTC, not blow up the caller."""
+
+    @staticmethod
+    def _reset_config_singleton():
+        import osprey.utils.config as config_module
+
+        config_module._default_config = None
+        config_module._default_configurable = None
+
+    def test_returns_utc_when_no_config_loaded(self, tmp_path, monkeypatch):
+        """No config.yml in cwd and no CONFIG_FILE → UTC, not FileNotFoundError."""
+        from zoneinfo import ZoneInfo
+
+        from osprey.utils.config import get_facility_timezone
+
+        monkeypatch.delenv("CONFIG_FILE", raising=False)
+        monkeypatch.chdir(tmp_path)  # empty dir, no config.yml
+        self._reset_config_singleton()
+
+        assert get_facility_timezone() == ZoneInfo("UTC")
+
+    def test_returns_utc_when_configured_zone_is_invalid(self, tmp_path, monkeypatch):
+        """A typo'd system.timezone → UTC fallback, not ZoneInfoNotFoundError."""
+        from zoneinfo import ZoneInfo
+
+        from osprey.utils.config import get_facility_timezone
+
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("system:\n  timezone: Not/ARealZone\n")
+        monkeypatch.setenv("CONFIG_FILE", str(config_file))
+        self._reset_config_singleton()
+
+        assert get_facility_timezone() == ZoneInfo("UTC")
+
+    def test_returns_configured_zone_when_valid(self, tmp_path, monkeypatch):
+        """A valid system.timezone is honored — the fallback must not swallow it."""
+        from zoneinfo import ZoneInfo
+
+        from osprey.utils.config import get_facility_timezone
+
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("system:\n  timezone: America/Los_Angeles\n")
+        monkeypatch.setenv("CONFIG_FILE", str(config_file))
+        self._reset_config_singleton()
+
+        assert get_facility_timezone() == ZoneInfo("America/Los_Angeles")
+
+
+class TestToFacilityIso:
+    """``to_facility_iso`` is the single shared timestamp-egress transform for the
+    ARIEL MCP and web output paths — both must render the same facility-local ISO
+    string so the two paths can't drift again."""
+
+    @staticmethod
+    def _reset_config_singleton():
+        import osprey.utils.config as config_module
+
+        config_module._default_config = None
+        config_module._default_configurable = None
+
+    def test_none_passes_through(self):
+        from osprey.utils.config import to_facility_iso
+
+        assert to_facility_iso(None) is None
+
+    def test_non_datetime_degrades_to_str(self):
+        """A value already serialized upstream (or any non-datetime) must not crash."""
+        from osprey.utils.config import to_facility_iso
+
+        assert to_facility_iso("2026-06-01T00:00:00+00:00") == "2026-06-01T00:00:00+00:00"
+
+    def test_naive_datetime_is_stamped_facility_local_not_box_local(self, tmp_path, monkeypatch):
+        """A naive datetime is assumed facility-local wall-clock (stamped, not
+        re-interpreted as box-local). Guards against ``astimezone`` reintroducing
+        $TZ dependence on the egress side — mirrors the parse-side contract."""
+        from datetime import datetime
+
+        from osprey.utils.config import to_facility_iso
+
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("system:\n  timezone: Asia/Tokyo\n")  # +09:00
+        monkeypatch.setenv("CONFIG_FILE", str(config_file))
+        # A divergent box $TZ must NOT influence the result.
+        monkeypatch.setenv("TZ", "America/Los_Angeles")
+        self._reset_config_singleton()
+
+        out = to_facility_iso(datetime(2026, 6, 1, 9, 0, 0))  # naive 09:00
+        assert out == "2026-06-01T09:00:00+09:00"  # 09:00 stamped Tokyo, not shifted
+
+    def test_aware_datetime_rendered_in_facility_zone(self, tmp_path, monkeypatch):
+        """A UTC instant is rendered in the configured facility zone, with offset."""
+        from datetime import UTC, datetime
+
+        from osprey.utils.config import to_facility_iso
+
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("system:\n  timezone: Asia/Tokyo\n")  # +09:00, no DST
+        monkeypatch.setenv("CONFIG_FILE", str(config_file))
+        self._reset_config_singleton()
+
+        out = to_facility_iso(datetime(2026, 6, 1, 0, 0, 0, tzinfo=UTC))  # midnight UTC
+        assert out == "2026-06-01T09:00:00+09:00"  # 09:00 Tokyo, explicit offset
+
+
+class TestTimezoneDriftWarning:
+    """``get_facility_timezone`` warns once if the effective container ``$TZ``
+    disagrees with an explicitly-configured ``system.timezone`` — a guardrail for
+    a misconfigured deploy where the OS clock and the agent zone diverge. The
+    resolver reads ``$TZ`` at call time, so tests set it after loading config."""
+
+    @staticmethod
+    def _reset(monkeypatch):
+        import osprey.utils.config as config_module
+
+        config_module._default_config = None
+        config_module._default_configurable = None
+        monkeypatch.setattr(config_module, "_tz_drift_warned", False, raising=False)
+
+    def _load_explicit_zone(self, tmp_path, monkeypatch, zone: str):
+        config_file = tmp_path / "config.yml"
+        config_file.write_text(f"system:\n  timezone: {zone}\n")
+        monkeypatch.setenv("CONFIG_FILE", str(config_file))
+        self._reset(monkeypatch)
+        # Trigger the one-time config load (runs load_dotenv) before we pin $TZ,
+        # so the value we set below is what the resolver reads at call time.
+        from osprey.utils.config import get_config_value
+
+        get_config_value("system.timezone", None)
+
+    def test_warns_once_on_drift(self, tmp_path, monkeypatch, caplog):
+        import logging
+        from zoneinfo import ZoneInfo
+
+        from osprey.utils.config import get_facility_timezone
+
+        self._load_explicit_zone(tmp_path, monkeypatch, "America/Los_Angeles")
+        monkeypatch.setenv("TZ", "UTC")  # diverges from system.timezone
+
+        with caplog.at_level(logging.WARNING, logger="CONFIG"):
+            get_facility_timezone()
+            get_facility_timezone()  # second call must not re-warn
+
+        drift = [r for r in caplog.records if "differs from the facility" in r.message]
+        assert len(drift) == 1
+        # The value returned is still authoritative system.timezone, not $TZ.
+        assert get_facility_timezone() == ZoneInfo("America/Los_Angeles")
+
+    def test_no_warning_when_tz_matches(self, tmp_path, monkeypatch, caplog):
+        import logging
+
+        from osprey.utils.config import get_facility_timezone
+
+        self._load_explicit_zone(tmp_path, monkeypatch, "America/Los_Angeles")
+        monkeypatch.setenv("TZ", "America/Los_Angeles")
+
+        with caplog.at_level(logging.WARNING, logger="CONFIG"):
+            get_facility_timezone()
+
+        assert not [r for r in caplog.records if "differs from the facility" in r.message]
+
+    def test_no_warning_when_timezone_not_explicitly_configured(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Config absent → implicit-UTC default; a set $TZ must stay quiet (else
+        every CI run with $TZ set but no system.timezone would warn spuriously)."""
+        import logging
+
+        from osprey.utils.config import get_config_value, get_facility_timezone
+
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("control_system:\n  type: mock\n")  # no system.timezone
+        monkeypatch.setenv("CONFIG_FILE", str(config_file))
+        self._reset(monkeypatch)
+        get_config_value("system.timezone", None)
+        monkeypatch.setenv("TZ", "America/New_York")
+
+        with caplog.at_level(logging.WARNING, logger="CONFIG"):
+            get_facility_timezone()
+
+        assert not [r for r in caplog.records if "differs from the facility" in r.message]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/config/test_config_builder.py
+++ b/tests/config/test_config_builder.py
@@ -284,7 +284,7 @@ control_system:
         monkeypatch.setenv("CONFIG_FILE", str(config_file))
 
         # Reset global config
-        import osprey.utils.config as config_module
+        from osprey.utils import config as config_module
 
         config_module._default_config = None
         config_module._default_configurable = None
@@ -301,7 +301,7 @@ class TestGetFacilityTimezone:
 
     @staticmethod
     def _reset_config_singleton():
-        import osprey.utils.config as config_module
+        from osprey.utils import config as config_module
 
         config_module._default_config = None
         config_module._default_configurable = None
@@ -352,7 +352,7 @@ class TestToFacilityIso:
 
     @staticmethod
     def _reset_config_singleton():
-        import osprey.utils.config as config_module
+        from osprey.utils import config as config_module
 
         config_module._default_config = None
         config_module._default_configurable = None
@@ -409,7 +409,7 @@ class TestTimezoneDriftWarning:
 
     @staticmethod
     def _reset(monkeypatch):
-        import osprey.utils.config as config_module
+        from osprey.utils import config as config_module
 
         config_module._default_config = None
         config_module._default_configurable = None

--- a/tests/connectors/test_archiver_timezone.py
+++ b/tests/connectors/test_archiver_timezone.py
@@ -1,0 +1,97 @@
+"""Integration guardrail: the archiver data path places daily ``at_time`` events
+at the facility wall-clock, independent of the deploy host's ``$TZ``.
+
+Drives the full ``MockArchiverConnector.get_data -> SimulationEngine`` path over
+the shipped control_assistant ``vacuum-burst`` scenario (SR07 pressure spike at
+14:32:08) and asserts the spike materializes at 14:32 — and lands at the *same*
+wall-clock whether the box runs UTC or a wildly different zone. No LLM involved;
+this locks the regression that broke the benchmark on non-UTC boxes.
+"""
+
+import os
+import shutil
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from osprey.connectors.archiver.mock_archiver_connector import MockArchiverConnector
+
+TEMPLATE_SIM = (
+    Path(__file__).parents[1].parent / "src/osprey/templates/apps/control_assistant/data/simulation"
+)
+SR07 = "SR:VAC:GAUGE:SR07:PRESSURE:RB"
+
+
+def _vacuum_burst_machine(tmp_path: Path) -> Path:
+    """Copy the shipped machine + scenario bundle, pinned to ``vacuum-burst``."""
+    machine = tmp_path / "machine.json"
+    shutil.copy(TEMPLATE_SIM / "machine.json", machine)
+    shutil.copytree(TEMPLATE_SIM / "scenarios", tmp_path / "scenarios")
+    (tmp_path / "active_scenarios").write_text("nominal\nvacuum-burst\n")
+    return machine
+
+
+async def _sr07_window(machine: Path):
+    """SR07 pressure over a 10-min window straddling 14:32:08 UTC (per-second)."""
+    connector = MockArchiverConnector()
+    await connector.connect(
+        {"simulation_file": str(machine), "sample_rate_hz": 1.0, "noise_level": 0.0}
+    )
+    try:
+        center = (datetime.now(UTC) - timedelta(days=1)).replace(
+            hour=14, minute=32, second=8, microsecond=0
+        )
+        start = center - timedelta(minutes=5)
+        end = center + timedelta(minutes=5)
+        df = await connector.get_data([SR07], start, end, precision_ms=1000)
+    finally:
+        await connector.disconnect()
+    return df, center
+
+
+@pytest.mark.asyncio
+async def test_archiver_spike_materializes_at_facility_wall_clock(tmp_path):
+    machine = _vacuum_burst_machine(tmp_path)
+    df, center = await _sr07_window(machine)
+
+    series = df[SR07]
+    baseline = float(series.median())
+    peak = float(series.max())
+    # SR07 baseline pressure ~5e-8; the burst spikes it ~4x. The engine applies
+    # unseeded per-channel multiplicative noise to synthesized series (independent
+    # of the connector's noise_level, which only gates the generic non-engine
+    # path), so assert a margin comfortably below the ~4x ceiling rather than on it.
+    assert peak > 2.5 * baseline, f"no SR07 burst: peak {peak:.2e} vs baseline {baseline:.2e}"
+
+    # The peak sits at 14:32:08, not some box-local-shifted hour.
+    peak_ts = series.idxmax().to_pydatetime()
+    assert abs((peak_ts - center).total_seconds()) < 30
+
+
+@pytest.mark.asyncio
+async def test_archiver_spike_is_box_tz_independent(tmp_path):
+    """Same window, same facility zone (UTC) → identical peak position regardless
+    of the host ``$TZ``. Before the fix the spike shifted with the box zone."""
+    machine = _vacuum_burst_machine(tmp_path)
+
+    df_utc, center = await _sr07_window(machine)
+    peak_utc = df_utc[SR07].idxmax().to_pydatetime()
+
+    old_tz = os.environ.get("TZ")
+    try:
+        os.environ["TZ"] = "Pacific/Kiritimati"  # UTC+14
+        time.tzset()
+        df_far, _ = await _sr07_window(machine)
+    finally:
+        if old_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = old_tz
+        time.tzset()
+
+    peak_far = df_far[SR07].idxmax().to_pydatetime()
+    # Both peaks land at 14:32:08 facility-wall-clock, within sampling resolution.
+    assert abs((peak_utc - center).total_seconds()) < 30
+    assert abs((peak_far - center).total_seconds()) < 30

--- a/tests/connectors/test_epics_connector_timezone.py
+++ b/tests/connectors/test_epics_connector_timezone.py
@@ -1,0 +1,47 @@
+"""Facility-timezone guard for the EPICS connector's read render path.
+
+No general EPICS connector test exists, so a naive-revert of the read timestamp
+(``datetime.fromtimestamp(ts)`` without a zone) would fail nothing. This pins
+that ``read_channel`` emits a facility-tz-aware timestamp, using an injected
+fake ``_epics`` so pyepics is not required.
+"""
+
+from unittest.mock import MagicMock
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from osprey.connectors.control_system.epics_connector import EPICSConnector
+
+TOKYO = ZoneInfo("Asia/Tokyo")  # UTC+9, no DST
+
+
+def _fake_pv(epoch: float):
+    pv = MagicMock()
+    pv.connected = True
+    pv.wait_for_connection.return_value = True
+    pv.get.return_value = 1.23
+    pv.timestamp = epoch
+    pv.units = "A"
+    pv.precision = 3
+    pv.status = 0
+    return pv
+
+
+@pytest.mark.asyncio
+async def test_read_channel_timestamp_is_facility_tz_aware(monkeypatch):
+    monkeypatch.setattr(
+        "osprey.connectors.control_system.epics_connector.get_facility_timezone",
+        lambda: TOKYO,
+    )
+    connector = EPICSConnector()
+    # Inject a fake epics module so no real CA / pyepics is needed.
+    connector._epics = MagicMock()
+    connector._epics.PV.return_value = _fake_pv(1_750_000_000.0)
+    connector._epics_configured = True
+
+    result = await connector.read_channel("SR:TEST:CHANNEL", timeout=1.0)
+
+    assert result.timestamp.tzinfo is not None
+    assert result.timestamp.utcoffset().total_seconds() == 9 * 3600  # facility, not UTC/box
+    assert result.metadata.timestamp.utcoffset().total_seconds() == 9 * 3600

--- a/tests/connectors/test_mock_connector.py
+++ b/tests/connectors/test_mock_connector.py
@@ -49,6 +49,22 @@ class TestMockConnector:
             await connector.disconnect()
 
     @pytest.mark.asyncio
+    async def test_read_returns_tz_aware_timestamps(self):
+        """Live-read timestamps carry an explicit offset (facility zone), not a
+        naive datetime — guards the connector render sites against silent
+        reversion to ``datetime.now()``."""
+        with patch("osprey.utils.config.get_config_value", return_value=True):
+            connector = MockConnector()
+            await connector.connect({"response_delay_ms": 0})
+
+            result = await connector.read_channel("ANY:CHANNEL")
+            assert result.timestamp.tzinfo is not None
+            assert result.timestamp.utcoffset() is not None
+            assert result.metadata.timestamp.tzinfo is not None
+
+            await connector.disconnect()
+
+    @pytest.mark.asyncio
     async def test_read_pv_infers_units(self):
         """Test that connector infers units from PV names."""
         with patch("osprey.utils.config.get_config_value", return_value=True):

--- a/tests/interfaces/ariel/test_timezone.py
+++ b/tests/interfaces/ariel/test_timezone.py
@@ -1,0 +1,68 @@
+"""Facility-timezone parity between the ARIEL web and MCP output paths.
+
+The original bug was parallel-path drift: the web ``_entry_to_response`` emitted
+the DB's raw UTC datetime while the MCP ``serialize_entry`` localized to the
+facility zone, so the same entry showed different times in the UI vs. the agent.
+Both now route through the shared ``to_facility_iso`` helper. This pins that they
+render the SAME facility-local ISO string (with offset) for the same entry under
+a non-UTC facility — the regression guard against the two paths diverging again.
+"""
+
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from osprey.interfaces.ariel.api.routes import _entry_to_response
+from osprey.mcp_server.ariel.server import serialize_entry
+
+TOKYO = ZoneInfo("Asia/Tokyo")  # UTC+9, no DST → stable offset
+
+
+@pytest.fixture()
+def facility_tokyo(monkeypatch):
+    # to_facility_iso resolves the zone via the config module's get_facility_timezone;
+    # patch it there so both the web and MCP call sites see the same facility zone.
+    monkeypatch.setattr("osprey.utils.config.get_facility_timezone", lambda: TOKYO)
+
+
+def _entry() -> dict:
+    midnight_utc = datetime(2026, 6, 1, 0, 0, 0, tzinfo=UTC)
+    return {
+        "entry_id": "e1",
+        "source_system": "elog",
+        "timestamp": midnight_utc,
+        "created_at": midnight_utc,
+        "updated_at": midnight_utc,
+        "author": "op",
+        "raw_text": "hello",
+        "summary": None,
+        "keywords": [],
+        "attachments": [],
+        "metadata": {},
+    }
+
+
+def test_web_and_mcp_render_same_facility_local_timestamp(facility_tokyo):
+    web = _entry_to_response(_entry())
+    mcp = serialize_entry(_entry())
+
+    # Midnight UTC → 09:00 Tokyo with an explicit +09:00 offset, identical on both.
+    assert web.timestamp == "2026-06-01T09:00:00+09:00"
+    assert web.timestamp == mcp["timestamp"]
+
+
+def test_web_localizes_all_three_timestamp_fields(facility_tokyo):
+    """timestamp AND created_at/updated_at must localize — leaving two of three in
+    UTC would reintroduce an intra-object asymmetry on the same entry."""
+    web = _entry_to_response(_entry())
+    assert web.created_at.endswith("+09:00")
+    assert web.updated_at.endswith("+09:00")
+
+
+def test_web_handles_naive_or_missing_gracefully(facility_tokyo):
+    """Naive datetimes degrade to str (no crash); the response stays a string."""
+    entry = _entry()
+    entry["timestamp"] = datetime(2026, 6, 1, 0, 0, 0)  # naive
+    web = _entry_to_response(entry)
+    assert isinstance(web.timestamp, str)

--- a/tests/mcp_server/ariel/test_timezone.py
+++ b/tests/mcp_server/ariel/test_timezone.py
@@ -1,0 +1,47 @@
+"""Facility-timezone guards for the ARIEL server's date parse + serialize contract.
+
+The existing ARIEL tests run with the default (UTC) facility zone, so a regression
+to a hardcoded UTC would stay green. These pin the contract under a non-UTC zone:
+operator-supplied dates are interpreted facility-local, and emitted timestamps are
+rendered in the facility zone with an explicit offset.
+"""
+
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from osprey.mcp_server.ariel.server import parse_date_filters, serialize_entry
+
+TOKYO = ZoneInfo("Asia/Tokyo")  # UTC+9, no DST → stable offset
+
+
+@pytest.fixture()
+def facility_tokyo(monkeypatch):
+    monkeypatch.setattr("osprey.utils.config.get_facility_timezone", lambda: TOKYO)
+
+
+def test_parse_date_filters_interprets_naive_input_as_facility_local(facility_tokyo):
+    start, end = parse_date_filters("2026-06-01 09:00:00", "2026-06-01T17:00:00")
+    assert start.utcoffset().total_seconds() == 9 * 3600
+    assert end.utcoffset().total_seconds() == 9 * 3600
+
+
+def test_parse_date_filters_respects_explicit_offset(facility_tokyo):
+    # An input that already carries an offset must NOT be overridden.
+    start, _ = parse_date_filters("2026-06-01T09:00:00+00:00", None)
+    assert start.utcoffset().total_seconds() == 0
+
+
+def test_serialize_entry_renders_timestamp_in_facility_zone(facility_tokyo):
+    entry = {
+        "entry_id": "e1",
+        "timestamp": datetime(2026, 6, 1, 0, 0, 0, tzinfo=UTC),  # midnight UTC
+        "author": "op",
+        "source_system": "elog",
+        "raw_text": "hello",
+    }
+    out = serialize_entry(entry)
+    # UTC midnight rendered in Tokyo (+09:00) → 09:00+09:00 on the same date.
+    assert out["timestamp"].endswith("+09:00")
+    assert "T09:00:00" in out["timestamp"]

--- a/tests/mcp_server/test_archiver_read_tool.py
+++ b/tests/mcp_server/test_archiver_read_tool.py
@@ -108,6 +108,29 @@ async def test_archiver_read_relative_time(tmp_path, monkeypatch):
 
 
 @pytest.mark.unit
+def test_parse_time_interprets_naive_input_as_facility_local(monkeypatch):
+    """A naive operator time string is localized to the facility zone, not UTC.
+
+    Guards the contract the agent timezone rule promises (archiver_read times are
+    facility-local). A regression to ``tzinfo=UTC`` would query a shifted window.
+    """
+    from zoneinfo import ZoneInfo
+
+    from osprey.mcp_server.control_system.tools import archiver_read as mod
+
+    tokyo = ZoneInfo("Asia/Tokyo")  # UTC+9, fixed offset (no DST)
+    monkeypatch.setattr(mod, "get_facility_timezone", lambda: tokyo)
+
+    parsed = mod._parse_time("2026-06-01 12:00:00")  # naive, no offset
+    assert parsed.tzinfo is not None
+    assert parsed.utcoffset().total_seconds() == 9 * 3600  # facility-local, not UTC
+
+    # An explicit offset in the input is respected, not overridden.
+    aware = mod._parse_time("2026-06-01T12:00:00+00:00")
+    assert aware.utcoffset().total_seconds() == 0
+
+
+@pytest.mark.unit
 async def test_archiver_read_file_persistence(tmp_path, monkeypatch):
     """Archiver read saves data to _agent_data/artifacts/ via ArtifactStore."""
     monkeypatch.chdir(tmp_path)

--- a/tests/services/python_executor/test_notebook_timezone.py
+++ b/tests/services/python_executor/test_notebook_timezone.py
@@ -1,0 +1,31 @@
+"""The operator-facing notebook header carries the facility-local wall clock.
+
+The attempt-notebook "Created:" header is read by humans, so per the timezone
+rule it must render in the facility zone (with a zone label), not the deploy
+host's local clock. The strftime *filename* timestamps in the same module stay
+naive on purpose (aware ISO's ':'/'+' would corrupt paths); this pins only the
+display header. ``_create_attempt_notebook_content`` does not touch instance
+state, so it is exercised on a bare instance without the FileManager harness.
+"""
+
+from zoneinfo import ZoneInfo
+
+from osprey.services.python_executor.services import NotebookManager
+
+TOKYO = ZoneInfo("Asia/Tokyo")  # %Z -> 'JST', distinct from any test host zone
+
+
+def test_attempt_header_renders_facility_zone(monkeypatch):
+    monkeypatch.setattr(
+        "osprey.services.python_executor.services.get_facility_timezone",
+        lambda: TOKYO,
+    )
+    manager = NotebookManager.__new__(NotebookManager)  # bypass FileManager init
+    notebook = manager._create_attempt_notebook_content(
+        attempt_number=1, stage="generate", code="print(1)"
+    )
+
+    header = notebook.cells[0].source
+    assert "**Created:**" in header
+    # Zone label proves the header is facility-local, not box-local/naive.
+    assert "JST" in header

--- a/tests/simulation/test_apply_timezone.py
+++ b/tests/simulation/test_apply_timezone.py
@@ -1,0 +1,87 @@
+"""Regression (review Finding 1): seeded logbook timestamps land in the FACILITY
+zone, coherent with where telemetry ``at_time`` events are placed.
+
+``apply_scenarios`` resolves each bundle entry's ``{days_ago, time}`` relative
+timestamp against the apply-time anchor; the anchor's tzinfo decides the zone the
+narrative time-of-day lands in. Before the fix the *default* anchor was
+``datetime.now(UTC)``, so on a non-UTC facility a logbook entry documented at
+03:20 landed at 03:20 UTC while the archiver spike it describes (a daily
+``at_time`` event, placed facility-local by the simulation engine) landed at
+03:20 facility-local — hours apart, breaking the correlation the scenario exists
+to exercise.
+
+DB-free: ``_seed_logbook`` is stubbed to capture the resolved entries, so the
+contract is pinned without a Postgres dependency and runs in the fast suite.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import yaml
+
+from osprey.simulation.apply import apply_scenarios
+
+TEMPLATE_SIM = (
+    Path(__file__).resolve().parents[2]
+    / "src/osprey/templates/apps/control_assistant/data/simulation"
+)
+LA = ZoneInfo("America/Los_Angeles")  # non-UTC facility; -7h (PDT) / -8h (PST)
+
+
+def _make_project(tmp_path: Path) -> Path:
+    """Stage a minimal sim-backed project with a non-UTC facility timezone."""
+    sim_dst = tmp_path / "data" / "simulation"
+    sim_dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(TEMPLATE_SIM, sim_dst)
+    config = {
+        "control_system": {
+            "connector": {"mock": {"simulation_file": "data/simulation/machine.json"}}
+        },
+        # URI is never dialed: _seed_logbook is stubbed below.
+        "ariel": {"database": {"uri": "postgresql://unused-mocked/none"}},
+        "system": {"timezone": "America/Los_Angeles"},
+    }
+    (tmp_path / "config.yml").write_text(yaml.safe_dump(config))
+    return tmp_path
+
+
+def test_default_anchor_seeds_logbook_in_facility_zone(tmp_path, monkeypatch):
+    project = _make_project(tmp_path)
+
+    captured: dict = {}
+
+    async def _fake_seed(ariel_config, entries):
+        captured["entries"] = entries
+        return len(entries), True
+
+    monkeypatch.setattr("osprey.simulation.apply._seed_logbook", _fake_seed)
+    # Pin the facility zone regardless of host config-loading quirks.
+    monkeypatch.setattr("osprey.simulation.apply.get_facility_timezone", lambda: LA, raising=False)
+
+    # now=None -> exercise the DEFAULT anchor (the path the bug lives on).
+    apply_scenarios(project, ["rf-thermal"], now=None)
+
+    entries = captured.get("entries")
+    assert entries, "no logbook entries were seeded"
+
+    # Every seeded timestamp is expressed in the facility zone (LA), not UTC.
+    # A UTC anchor makes utcoffset() == 0 while LA is -7/-8h, so this is unequal
+    # before the fix and equal after (DST-robust: compares the entry's own zone).
+    for e in entries:
+        ts = e["timestamp"]
+        assert ts.tzinfo is not None, f"entry {e['entry_id']} has a naive timestamp"
+        assert ts.utcoffset() == ts.astimezone(LA).utcoffset(), (
+            f"entry {e['entry_id']} not anchored in the facility zone: {ts.isoformat()}"
+        )
+
+    # DEMO-026 is documented at days_ago=4, 03:20 — that time-of-day is the
+    # FACILITY-LOCAL clock time, matching the archiver narrative it accompanies.
+    demo026 = next(e["timestamp"] for e in entries if e["entry_id"] == "DEMO-026")
+    local = demo026.astimezone(LA)
+    assert (local.hour, local.minute) == (3, 20)
+    # ...and NOT 03:20 UTC (the pre-fix placement).
+    utc = demo026.astimezone(ZoneInfo("UTC"))
+    assert (utc.hour, utc.minute) != (3, 20)

--- a/tests/simulation/test_control_assistant_scenarios.py
+++ b/tests/simulation/test_control_assistant_scenarios.py
@@ -23,7 +23,7 @@ Signatures pinned (target value -> asserted threshold, with margin):
   downward during the excursions.
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import numpy as np
 import pytest
@@ -42,8 +42,10 @@ def _window(center: datetime, minutes: int = 10, step_s: int = 1) -> list[dateti
 
 
 def _yesterday_event() -> datetime:
-    """Yesterday at 14:32:08 — the daily ``at_time`` anchor fires on any past date."""
-    day = datetime.now() - timedelta(days=1)
+    """Yesterday 14:32:08 in the facility zone (UTC in tests) — the daily ``at_time``
+    anchor fires on any past date. Building the window tz-aware in the facility zone
+    keeps the contract independent of the deploy host's ``$TZ``."""
+    day = datetime.now(UTC) - timedelta(days=1)
     return day.replace(hour=14, minute=32, second=8, microsecond=0)
 
 

--- a/tests/simulation/test_scenario_composition.py
+++ b/tests/simulation/test_scenario_composition.py
@@ -8,7 +8,7 @@ silently wrong. These tests pin both halves: (1) the disjoint target combo
 (2) ``validate_composition`` hard-errors on a hand-built same-channel collision.
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import numpy as np
 import pytest
@@ -22,7 +22,7 @@ RF_SERIES_N = 2016  # 7-day window at 5-minute resolution
 
 def _yesterday_1432_window(minutes: int = 10) -> list[datetime]:
     """Per-second window straddling yesterday 14:32:08 (the vacuum at_time anchor)."""
-    center = (datetime.now() - timedelta(days=1)).replace(
+    center = (datetime.now(UTC) - timedelta(days=1)).replace(
         hour=14, minute=32, second=8, microsecond=0
     )
     start = center - timedelta(minutes=minutes / 2)

--- a/tests/simulation/test_series.py
+++ b/tests/simulation/test_series.py
@@ -1,6 +1,6 @@
 """Tests for synthesize_series(): archiver event shapes and pointwise exprs."""
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import numpy as np
 import pytest
@@ -330,7 +330,7 @@ class TestDailyTimeAnchor:
             make_machine_file,
             [{"shape": "spike", "at_time": "14:32:08", "amplitude": 1.5e-7, "width": 15}],
         )
-        day = datetime.now().replace(hour=14, minute=30, second=0, microsecond=0)
+        day = datetime.now(UTC).replace(hour=14, minute=30, second=0, microsecond=0)
         ts = [day + timedelta(seconds=i) for i in range(600)]  # 14:30-14:40
         series = engine.synthesize_series("T:VAC", ts)
         peak_idx = max(range(len(series)), key=lambda i: series[i])
@@ -343,7 +343,7 @@ class TestDailyTimeAnchor:
             make_machine_file,
             [{"shape": "spike", "at_time": "14:32:08", "amplitude": 1.5e-7, "width": 15}],
         )
-        day = datetime.now().replace(hour=9, minute=0, second=0, microsecond=0)
+        day = datetime.now(UTC).replace(hour=9, minute=0, second=0, microsecond=0)
         ts = [day + timedelta(seconds=i) for i in range(600)]
         series = engine.synthesize_series("T:VAC", ts)
         assert max(series) < 1.0e-7  # flat baseline
@@ -356,7 +356,7 @@ class TestDailyTimeAnchor:
             make_machine_file,
             [{"shape": "spike", "at_time": "14:32:08", "amplitude": 1.5e-7, "width": 600}],
         )
-        start = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        start = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
         ts = [start + timedelta(minutes=10 * i) for i in range(288)]  # 2 days @ 10 min
         series = engine.synthesize_series("T:VAC", ts)
         peaks = [i for i in range(1, 287) if series[i] > 1.0e-7]
@@ -369,7 +369,7 @@ class TestDailyTimeAnchor:
             make_machine_file,
             [{"shape": "spike", "at_time": "14:32:08", "amplitude": 1.5e-7, "width": 15}],
         )
-        day = datetime.now().replace(hour=14, minute=30, second=0, microsecond=0)
+        day = datetime.now(UTC).replace(hour=14, minute=30, second=0, microsecond=0)
         ts = [(day + timedelta(seconds=i)).timestamp() for i in range(600)]
         series = engine.synthesize_series("T:VAC", ts)
         assert max(series) > 1.0e-7
@@ -381,7 +381,7 @@ class TestDailyTimeAnchor:
             [{"shape": "step", "at_time": "14:32:08", "to": "FAULT"}],
             channel="T:MODE",
         )
-        day = datetime.now().replace(hour=14, minute=30, second=0, microsecond=0)
+        day = datetime.now(UTC).replace(hour=14, minute=30, second=0, microsecond=0)
         ts = [day + timedelta(seconds=i) for i in range(600)]
         series = engine.synthesize_series("T:MODE", ts)
         for value, t in zip(series, ts, strict=True):

--- a/tests/simulation/test_series_primitives.py
+++ b/tests/simulation/test_series_primitives.py
@@ -6,7 +6,10 @@ module's standalone contract so the extracted primitives can be refactored
 without going through the full engine each time.
 """
 
+import os
+import time
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import numpy as np
 import pytest
@@ -95,21 +98,72 @@ class TestEventPositions:
 
 
 class TestDailyOccurrences:
+    """``at_time`` occurrences are placed in the facility timezone, not the box's
+    local zone. The tests pass an explicit ``tz`` and build expected positions in
+    that same zone, then assert the result is independent of the host ``$TZ``."""
+
     def test_one_per_calendar_date_in_window(self):
-        start = datetime(2026, 1, 1, 0, 0, 0)
-        end = datetime(2026, 1, 2, 23, 0, 0)
+        tz = ZoneInfo("UTC")
+        start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=tz)
+        end = datetime(2026, 1, 2, 23, 0, 0, tzinfo=tz)
         t_abs = np.array([start.timestamp(), end.timestamp()])
-        occ = daily_occurrences("12:00:00", t_abs)
+        occ = daily_occurrences("12:00:00", t_abs, tz=tz)
         assert len(occ) == 2
-        assert occ[0] == datetime(2026, 1, 1, 12, 0, 0).timestamp()
-        assert occ[1] == datetime(2026, 1, 2, 12, 0, 0).timestamp()
+        assert occ[0] == datetime(2026, 1, 1, 12, 0, 0, tzinfo=tz).timestamp()
+        assert occ[1] == datetime(2026, 1, 2, 12, 0, 0, tzinfo=tz).timestamp()
 
     def test_occurrence_outside_window_excluded(self):
         # Window ends before noon on the only date → no occurrence.
-        start = datetime(2026, 1, 1, 0, 0, 0)
-        end = datetime(2026, 1, 1, 6, 0, 0)
+        tz = ZoneInfo("UTC")
+        start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=tz)
+        end = datetime(2026, 1, 1, 6, 0, 0, tzinfo=tz)
         t_abs = np.array([start.timestamp(), end.timestamp()])
-        assert daily_occurrences("12:00:00", t_abs) == []
+        assert daily_occurrences("12:00:00", t_abs, tz=tz) == []
+
+    def test_positions_are_box_tz_independent(self):
+        """A UTC ``tz`` yields UTC-noon epochs even when the host ``$TZ`` is a
+        wildly different zone — this is the regression that broke the archiver
+        ``at_time`` benchmark on non-UTC deploy boxes."""
+        tz = ZoneInfo("UTC")
+        start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=tz)
+        end = datetime(2026, 1, 1, 23, 0, 0, tzinfo=tz)
+        t_abs = np.array([start.timestamp(), end.timestamp()])
+        expected = datetime(2026, 1, 1, 12, 0, 0, tzinfo=tz).timestamp()
+
+        old_tz = os.environ.get("TZ")
+        try:
+            os.environ["TZ"] = "Pacific/Kiritimati"  # UTC+14, maximally far from UTC
+            time.tzset()
+            occ = daily_occurrences("12:00:00", t_abs, tz=tz)
+        finally:
+            if old_tz is None:
+                os.environ.pop("TZ", None)
+            else:
+                os.environ["TZ"] = old_tz
+            time.tzset()
+
+        assert occ == [expected]
+
+    def test_dst_boundary_one_occurrence_per_date(self):
+        """Characterization: across a spring-forward DST boundary the daily walk
+        still yields exactly one (local-noon) occurrence per calendar date — no
+        skipped or duplicated date. Noon is unambiguous (well clear of the 02:00
+        gap), so this pins the current contract and would catch a future cursor
+        refactor that miscounts dates across the transition."""
+        ny = ZoneInfo("America/New_York")
+        # 2026-03-08 is the US spring-forward date (02:00 -> 03:00 EST->EDT).
+        start = datetime(2026, 3, 7, 0, 0, tzinfo=ny)
+        end = datetime(2026, 3, 10, 23, 0, tzinfo=ny)
+        t_abs = np.array([start.timestamp(), end.timestamp()])
+
+        occ = daily_occurrences("12:00:00", t_abs, tz=ny)
+
+        assert len(occ) == 4  # Mar 7, 8, 9, 10
+        dates = {datetime.fromtimestamp(e, ny).date() for e in occ}
+        assert len(dates) == 4  # one per distinct calendar date
+        for epoch in occ:
+            local = datetime.fromtimestamp(epoch, ny)
+            assert (local.hour, local.minute) == (12, 0)
 
 
 class TestStringSeries:


### PR DESCRIPTION
## Summary

Unifies facility-timezone handling so **every agent-facing timestamp shares one configurable zone** (`system.timezone`). Archiver queries, live channel reads, simulated events, ARIEL logbook entries, and executed-script run times are now interpreted and rendered in the facility zone with an explicit UTC offset; operator times ("today", "14:32") are read as facility-local. Shipped presets pin `system.timezone: UTC` explicitly for reproducible runs.

## Bugs fixed

- **Simulation `at_time` events** landed in the deploy box's local zone on non-UTC hosts, placing daily archiver events at the wrong wall-clock time (broke the archiver benchmark on non-UTC machines).
- **Seeded/ingested logbook narrative** resolved its time-of-day in UTC while the telemetry it describes was placed facility-local — so on a non-UTC facility the logbook entry and the archiver spike it references were hours apart, defeating the correlation scenarios.
- **ARIEL web API** emitted raw UTC timestamps while the agent (MCP) saw facility-local — the same entry showed different times. Web and MCP now share one `to_facility_iso` egress helper; MCP single-entry `get` localized to match search/browse.

## Also

- One-time startup **warning** when container `$TZ` disagrees with `system.timezone` (`system.timezone` stays authoritative — no behavior change).
- Operator-facing notebook timestamps render facility-local; agent timezone rule broadened from ARIEL-only to every facility data timestamp.
- `sql_query` documents its raw-UTC exception (arbitrary columns make per-column localization fragile).

## Testing

- Full unit suite: **4928 passed, 23 skipped** (env-gated); ruff + format clean; no new mypy errors on edited lines.
- New coverage: box-`$TZ` independence, DST characterization, web↔MCP rendering parity, drift warning (fires once / suppressed / silent-when-unconfigured), naive-as-facility-local egress, resolver UTC fallback.

## Notes

- The web **UI** still renders in the viewer's browser timezone; this PR makes the **wire/API** format facility-local (matching MCP). The browser display-zone is tracked as a separate decision.
- Reviewed via a multi-agent pass; verdict ready-with-minor-fixes, all recommendations addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
