### PR TITLE
fix(ariel): use origin-relative panel URL for logbook drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Compatibility is documented in release notes, not encoded in the version string.
 - Simulation `at_time` events now fire at the facility wall-clock time-of-day regardless of the deploy host's `$TZ` (previously placed in the box's local zone, so daily archiver events landed at the wrong time on non-UTC machines).
 - Seeded and ingested logbook entries now resolve their relative time-of-day in the facility timezone, so on a non-UTC facility the narrative lands at the same wall-clock time as the telemetry it describes (previously anchored in UTC, drifting hours from the archiver event).
 - The ARIEL web **API** now returns entry timestamps as facility-local ISO with an explicit offset, matching the MCP path (previously the web API emitted raw UTC while the agent saw facility-local). The web and MCP paths now share one rendering helper, and the MCP single-entry `get` is localized to match search/browse. (The web UI still renders in the viewer's browser timezone; the wire format now carries the facility offset.)
+- Translation proxy (open-model path): a `role: "system"` message inside the `messages` array is now hoisted into the OpenAI system message instead of being silently dropped, so system instructions Claude Code injects mid-conversation survive translation to OpenAI-compatible providers.
 
 ## [2026.6.1] - 2026-06-17
 

--- a/src/osprey/infrastructure/proxy/translator.py
+++ b/src/osprey/infrastructure/proxy/translator.py
@@ -58,6 +58,16 @@ def anthropic_to_openai_request(body: dict) -> dict:
     return openai_body
 
 
+def _system_text(content: str | list | None) -> str:
+    """Flatten an Anthropic system value (str or content-block list) to text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        text_parts = [b["text"] for b in content if isinstance(b, dict) and b.get("type") == "text"]
+        return "\n".join(text_parts)
+    return ""
+
+
 def _convert_messages(
     anthropic_messages: list[dict],
     system: str | list | None,
@@ -65,17 +75,11 @@ def _convert_messages(
     """Convert Anthropic message array to OpenAI message array."""
     openai_messages: list[dict] = []
 
-    # System prompt
+    # Top-level system prompt
     if system:
-        if isinstance(system, str):
-            openai_messages.append({"role": "system", "content": system})
-        elif isinstance(system, list):
-            # Anthropic system can be list of content blocks
-            text_parts = [
-                b["text"] for b in system if isinstance(b, dict) and b.get("type") == "text"
-            ]
-            if text_parts:
-                openai_messages.append({"role": "system", "content": "\n".join(text_parts)})
+        text = _system_text(system)
+        if text:
+            openai_messages.append({"role": "system", "content": text})
 
     for msg in anthropic_messages:
         role = msg.get("role", "user")
@@ -85,6 +89,14 @@ def _convert_messages(
             openai_messages.extend(_convert_user_message(content))
         elif role == "assistant":
             openai_messages.extend(_convert_assistant_message(content))
+        elif role == "system":
+            # The Anthropic API carries the system prompt in the top-level
+            # ``system`` field, but some clients put a ``role: system`` entry in
+            # the array. Hoist it into an OpenAI system message rather than
+            # dropping it on the floor and silently losing the instruction (#285).
+            text = _system_text(content)
+            if text:
+                openai_messages.append({"role": "system", "content": text})
 
     return openai_messages
 

--- a/src/osprey/interfaces/artifacts/logbook.py
+++ b/src/osprey/interfaces/artifacts/logbook.py
@@ -546,7 +546,13 @@ async def submit(req: SubmitRequest):
         filepath = drafts_dir / f"{draft_id}.json"
         filepath.write_text(json.dumps(draft_data, indent=2))
 
-        base_url = os.environ.get("ARIEL_WEB_URL", "http://127.0.0.1:8085")
+        # Default to the web terminal's origin-relative proxy path (see the
+        # matching note in mcp_server/ariel/tools/entry.py): the panel embeds at
+        # /panel/ariel and resolves this with `new URL(url, origin)`, so a
+        # relative path loads through the proxy. An absolute container-internal
+        # address (127.0.0.1:8085) is unreachable from the user's browser. Set
+        # ARIEL_WEB_URL for standalone (non-proxied) ARIEL deployments.
+        base_url = os.environ.get("ARIEL_WEB_URL", "/panel/ariel")
         url = f"{base_url}/#create?draft={draft_id}"
 
         # Notify web terminal to switch to ARIEL panel (non-fatal)

--- a/src/osprey/mcp_server/ariel/tools/entry.py
+++ b/src/osprey/mcp_server/ariel/tools/entry.py
@@ -312,7 +312,15 @@ async def entry_create(
             filepath = drafts_dir / f"{draft_id}.json"
             filepath.write_text(json.dumps(draft_data, indent=2))
 
-            base_url = os.environ.get("ARIEL_WEB_URL", "http://127.0.0.1:8085")
+            # Default to the web terminal's origin-relative proxy path for the
+            # ARIEL panel. The web terminal embeds the panel at /panel/ariel and
+            # resolves this URL with `new URL(url, origin)`, so a relative path
+            # loads through the proxy in both the clickable link and the
+            # auto-focus iframe. An absolute container-internal address (e.g.
+            # 127.0.0.1:8085) is unreachable from the user's browser. Set
+            # ARIEL_WEB_URL to an absolute base only for standalone (non-proxied)
+            # ARIEL deployments.
+            base_url = os.environ.get("ARIEL_WEB_URL", "/panel/ariel")
             url = f"{base_url}/#create?draft={draft_id}"
 
             logger.info("Draft %s created at %s", draft_id, filepath)

--- a/tests/infrastructure/proxy/test_proxy_translation.py
+++ b/tests/infrastructure/proxy/test_proxy_translation.py
@@ -50,6 +50,70 @@ def test_system_as_block_list_is_flattened():
     assert out["messages"][0] == {"role": "system", "content": "Line one.\nLine two."}
 
 
+def test_embedded_system_message_is_hoisted_not_dropped():
+    """A ``role: system`` entry *inside* ``messages`` must be preserved as an
+    OpenAI system message, not silently dropped (issue #285).
+
+    The Anthropic Messages API places the system prompt in the top-level
+    ``system`` field, so a strict gateway rejects a ``role: system`` entry in
+    the array. The proxy used to drop it on the floor, silently losing the
+    instruction; it must hoist it into an OpenAI system message instead.
+    """
+    body = {
+        "model": "cborg-coder",
+        "messages": [
+            {"role": "system", "content": "You are the channel-finder subagent."},
+            {"role": "user", "content": "find PV X"},
+        ],
+    }
+    out = anthropic_to_openai_request(body)
+    roles = [m["role"] for m in out["messages"]]
+    assert roles == ["system", "user"]
+    assert out["messages"][0] == {
+        "role": "system",
+        "content": "You are the channel-finder subagent.",
+    }
+    assert out["messages"][1] == {"role": "user", "content": "find PV X"}
+
+
+def test_embedded_system_block_list_is_flattened():
+    """A ``role: system`` message whose content is a block list is flattened
+    to text, mirroring how the top-level ``system`` field is handled."""
+    body = {
+        "model": "cborg-coder",
+        "messages": [
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "Line one."},
+                    {"type": "text", "text": "Line two."},
+                ],
+            },
+            {"role": "user", "content": "hi"},
+        ],
+    }
+    out = anthropic_to_openai_request(body)
+    assert out["messages"][0] == {"role": "system", "content": "Line one.\nLine two."}
+    assert out["messages"][1] == {"role": "user", "content": "hi"}
+
+
+def test_top_level_and_embedded_system_both_preserved():
+    """When both a top-level ``system`` and an embedded ``role: system`` message
+    are present, both survive, with the top-level prompt first."""
+    body = {
+        "model": "cborg-coder",
+        "system": "Top-level system.",
+        "messages": [
+            {"role": "system", "content": "Embedded system."},
+            {"role": "user", "content": "go"},
+        ],
+    }
+    out = anthropic_to_openai_request(body)
+    assert [m["role"] for m in out["messages"]] == ["system", "system", "user"]
+    assert out["messages"][0]["content"] == "Top-level system."
+    assert out["messages"][1]["content"] == "Embedded system."
+
+
 def test_tool_definitions_become_openai_functions():
     body = {
         "model": "cborg-coder",

--- a/tests/interfaces/artifacts/test_logbook.py
+++ b/tests/interfaces/artifacts/test_logbook.py
@@ -258,6 +258,31 @@ class TestLogbookSubmit:
         assert "/#create?draft=" in data["url"]
 
     @pytest.mark.unit
+    def test_submit_url_is_browser_resolvable(self, app_client, tmp_path, monkeypatch):
+        """Without ARIEL_WEB_URL, the submit URL must be a web-terminal-relative
+        proxy path — not an absolute container-internal address.
+
+        Regression: the default used to be ``http://127.0.0.1:8085`` which is
+        unreachable from the user's browser. The panel embeds via /panel/ariel
+        and resolves the URL with ``new URL(url, origin)``, so it must be
+        origin-relative to load through the proxy.
+        """
+        monkeypatch.delenv("ARIEL_WEB_URL", raising=False)
+        with (
+            patch(f"{_MODULE}.resolve_shared_data_root", return_value=tmp_path),
+            patch(f"{_MODULE}.notify_panel_focus"),
+        ):
+            resp = app_client.post(
+                "/api/logbook/submit",
+                json={"subject": "Test", "details": "Details."},
+            )
+
+        url = resp.json()["url"]
+        assert not url.startswith("http://127.0.0.1")
+        assert "8085" not in url
+        assert url.startswith("/panel/ariel")
+
+    @pytest.mark.unit
     def test_submit_calls_panel_focus(self, app_client, tmp_path):
         """Mock notify_panel_focus, verify called."""
         with (

--- a/tests/mcp_server/ariel/test_entry.py
+++ b/tests/mcp_server/ariel/test_entry.py
@@ -297,7 +297,7 @@ async def test_entry_create_draft_default(tmp_path, monkeypatch):
     assert data["draft_id"].startswith("draft-")
     assert "url" in data
     assert f"draft={data['draft_id']}" in data["url"]
-    assert "http://127.0.0.1:8085" in data["url"]
+    assert data["url"].startswith("/panel/ariel")
 
     # Verify file was written
     filepath = drafts_dir / f"{data['draft_id']}.json"
@@ -331,6 +331,38 @@ async def test_entry_create_draft_all_fields(tmp_path, monkeypatch):
     assert contents["logbook"] == "Operations"
     assert contents["shift"] == "Swing"
     assert contents["tags"] == ["injection", "kicker"]
+
+
+@pytest.mark.unit
+async def test_entry_create_draft_url_is_browser_resolvable(tmp_path, monkeypatch):
+    """Without ARIEL_WEB_URL, the draft URL must be a web-terminal-relative
+    proxy path — not an absolute container-internal address.
+
+    Regression: the default used to be ``http://127.0.0.1:8085`` which is
+    unreachable from the user's browser (nothing listens on 8085 in the
+    deployed container, and 127.0.0.1 points at the user's own machine). The
+    web terminal embeds the ARIEL panel via the relative proxy path
+    ``/panel/ariel`` and resolves draft URLs with ``new URL(url, origin)``, so
+    the URL must be origin-relative to load through the proxy in both the
+    clickable link and the auto-focus iframe.
+    """
+    import osprey.mcp_server.ariel.tools.entry as entry_mod
+
+    drafts_dir = tmp_path / "drafts"
+    monkeypatch.setattr(entry_mod, "_get_drafts_dir", lambda: drafts_dir)
+    monkeypatch.delenv("ARIEL_WEB_URL", raising=False)
+
+    fn = _get_entry_create()
+    result = await fn(subject="Beam lost", details="Beam lost at SR BM 4.3.2")
+
+    data = json.loads(result)
+    url = data["url"]
+    # Must NOT be an absolute container-internal URL the browser can't reach.
+    assert not url.startswith("http://127.0.0.1")
+    assert "8085" not in url
+    # Must be the origin-relative proxy path the iframe + link resolve against.
+    assert url.startswith("/panel/ariel")
+    assert f"draft={data['draft_id']}" in url
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem

When the ARIEL logbook agent creates a draft entry (`entry_create`, and the artifact-gallery logbook compose endpoint), the draft is written correctly to `_agent_data/drafts/` but two things fail for the user:

1. **The returned review URL doesn't work** — the agent hands back `http://127.0.0.1:8085/#create?draft=…`.
2. **The draft never appears in the ARIEL panel** — the panel's auto-focus iframe navigates to that same dead address.

## Root cause

Both `entry_create` and the logbook compose endpoint built the URL from a hardcoded default:

```python
base_url = os.environ.get("ARIEL_WEB_URL", "http://127.0.0.1:8085")
url = f"{base_url}/#create?draft={draft_id}"
```

Behind the web terminal's panel proxy, `http://127.0.0.1:8085` is unreachable from the user's browser:
- Nothing listens on `8085` in the deployed container (the ARIEL panel is served on a per-terminal `OSPREY_ARIEL_PORT`).
- `127.0.0.1` from the user's browser points at the user's own machine, not the container.
- It's absolute, so it bypasses the proxy entirely.

The web terminal embeds the ARIEL panel via the **relative proxy path** `/panel/ariel` and resolves draft URLs with `new URL(url, window.location.origin)` (in `panel-manager.js navigatePanel`). An absolute container-internal URL defeats both the clickable link and the auto-focus iframe.

## Fix

Default to the origin-relative proxy path `/panel/ariel`, so the URL resolves against the browser origin and loads through the proxy in both consumers. `ARIEL_WEB_URL` still overrides for standalone (non-proxied) ARIEL deployments.

## Why tests didn't catch it

The existing tests asserted the wrong property:
- `test_entry_create_draft_default` required the literal `http://127.0.0.1:8085` string — it codified the broken value as expected output.
- The logbook submit test only checked the `#create?draft=` hash fragment, ignoring the base host entirely.

Neither verified that the URL is actually reachable from the browser. This PR replaces those with behavior assertions: the draft URL must be origin-relative (`/panel/ariel`), not container-internal.

## Tests

- `test_entry_create_draft_url_is_browser_resolvable` (new)
- `test_submit_url_is_browser_resolvable` (new)
- Updated `test_entry_create_draft_default` to assert the relative path.

All affected suites green (123 tests).