### PR TITLE
test(benchmark): exclude dispatch tutorial from per-model benchmark scoring

### DIFF
--- a/scripts/benchmark/matrix_dashboard.py
+++ b/scripts/benchmark/matrix_dashboard.py
@@ -194,6 +194,32 @@ def canon_name(name: str) -> tuple[str, str]:
     return file, short
 
 
+def apply_exclusions(runs: dict, excluded_files: set[str]) -> None:
+    """Drop tests belonging to excluded files from each run, recomputing counts.
+
+    The matrix runner ignores excluded files at collection time, so a freshly run
+    cell never contains them. But results collected BEFORE a file was added to the
+    exclusion list still carry its tests — e.g. test_dispatch_tutorial, which is
+    pinned to als-apg/haiku and hangs to the worker timeout under CBORG cells, was
+    excluded only after the matrix had already run it. Honor the CURRENT exclusion
+    list retroactively so the per-cell counts and the per-test grid match the
+    footer's advertised exclusion set, without re-running the matrix. Mutates runs
+    in place; cells with no excluded tests are left untouched.
+    """
+    for d in runs.values():
+        tests = d.get("tests", [])
+        kept = [t for t in tests if canon_name(t["name"])[0] not in excluded_files]
+        if len(kept) == len(tests):
+            continue
+        cnt = {"passed": 0, "failed": 0, "timeout": 0, "skipped": 0, "errors": 0}
+        for t in kept:
+            cnt[_LIVE_KEY.get(t.get("outcome"), "errors")] += 1
+        d["tests"] = kept
+        d.update(cnt)
+        d["total"] = len(kept)
+        d["total_duration_s"] = int(sum(t.get("duration_s", 0) for t in kept))
+
+
 def seeds_for(model: str, runs: dict | None = None) -> list[int]:
     """Study subjects run all SEEDS (missing ones render 'pending'). Reference
     models are run on demand (one or more seeds) — show exactly the seeds that
@@ -279,6 +305,10 @@ def main() -> int:
     args = ap.parse_args()
 
     runs = load(args.results_dir)
+    # Honor the exclusion list retroactively: results collected before a file was
+    # excluded still carry its tests, so strip them here to match the footer.
+    exclusions = load_exclusions(args.config)
+    apply_exclusions(runs, {p.replace("tests/e2e/", "", 1) for p, _ in exclusions})
     started, ended, matrix_done = parse_progress(args.results_dir)
     running = started - ended  # combos in flight
     models = list(MODEL_ORDER)
@@ -312,7 +342,6 @@ def main() -> int:
     ]
     union_n = sum(len(v) for v in all_tests.values())
     model_driving_n = max(completed_totals) if completed_totals else (union_n or None)
-    exclusions = load_exclusions(args.config)
 
     css = """
     body{font:14px/1.45 -apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;

--- a/scripts/benchmark/matrix_e2e_config.json
+++ b/scripts/benchmark/matrix_e2e_config.json
@@ -49,6 +49,10 @@
     {
       "path": "tests/e2e/claude_code/test_proxy_open_model_harness_e2e.py",
       "reason": "Opt-in proxy harness tests requiring OSPREY_E2E_OLLAMA/OSPREY_E2E_CBORG flags; skip on bench box."
+    },
+    {
+      "path": "tests/e2e/test_dispatch_tutorial.py",
+      "reason": "Exercises the dispatch pipeline (webhook -> dispatcher -> worker -> SDK round-trip -> persistence), not model capability — the agent task is hello-world level (one-sentence reply, summarize a payload, save a stub report), so any responding model passes and it measures nothing about the model-under-test. Compounding this, its build fixture is pinned to als-apg/haiku and ignores OSPREY_E2E_FORCE_MODEL; under CBORG cells the als-apg key is shimmed to CBORG, so the worker agent hits the real als-apg endpoint with a wrong credential and hangs to the 300s worker timeout — a fixed ~3-test infra penalty per cell."
     }
   ],
   "baseline_expected_run_min": 15

--- a/tests/unit/dispatch/test_cron_source.py
+++ b/tests/unit/dispatch/test_cron_source.py
@@ -33,27 +33,46 @@ class _RecordingCallback:
 
 @pytest.mark.asyncio
 async def test_loop_fires_at_interval_then_stops(monkeypatch):
-    """Deterministic: fake sleep fires once, then cancels the loop."""
-    callback = _RecordingCallback()
+    """The loop fires the trigger each interval and stops cleanly when cancelled.
+
+    Deterministic and pollution-proof: the interval wait is replaced with an
+    immediate yield (loop body runs without real time), the test waits on an
+    ``Event`` for the first fire — never racing the spawned task — then
+    ``stop()`` cancels the loop. Earlier this test stopped the loop by counting
+    ``asyncio.sleep`` calls and raising ``CancelledError`` on the second; because
+    the patch lands on the *global* ``asyncio.sleep`` and the counter is shared,
+    any other coroutine's ``sleep`` in the same loop could push the count so the
+    loop's *first* sleep raised before the callback ever fired — an intermittent
+    ``0 == 1`` under full-suite load. Termination now keys off the callback, not
+    the sleep count, so a stray ``sleep`` can no longer skew it.
+    """
     source = CronSource()
     trigger = _make_trigger("nightly", interval_sec=300)
 
-    sleep_calls = {"n": 0}
+    calls: list[tuple[TriggerConfig, dict]] = []
+    fired = asyncio.Event()
 
-    async def fake_sleep(_secs):
-        sleep_calls["n"] += 1
-        if sleep_calls["n"] >= 2:
-            raise asyncio.CancelledError
-        return None
+    async def callback(trig: TriggerConfig, payload: dict) -> str | None:
+        calls.append((trig, payload))
+        fired.set()
+        return "d-1"
 
-    monkeypatch.setattr("osprey.dispatch.sources.cron.asyncio.sleep", fake_sleep)
+    # Capture the genuine sleep before patching so the no-op interval still
+    # yields control to the event loop (without any real delay).
+    real_sleep = asyncio.sleep
+
+    async def instant_interval(_seconds):
+        await real_sleep(0)
+
+    monkeypatch.setattr("osprey.dispatch.sources.cron.asyncio.sleep", instant_interval)
 
     await source.start([trigger], callback)
-    # Let the spawned task run until it cancels itself on the 2nd sleep.
-    await asyncio.gather(*source._tasks, return_exceptions=True)
+    await asyncio.wait_for(fired.wait(), timeout=5)
+    await source.stop()
 
-    assert len(callback.calls) == 1
-    fired_trigger, payload = callback.calls[0]
+    assert source._tasks == []  # stop() cancelled the loop
+    assert len(calls) >= 1  # fired at least once at the interval
+    fired_trigger, payload = calls[0]
     assert fired_trigger is trigger
     assert payload["source"] == "cron"
     assert payload["trigger"] == "nightly"


### PR DESCRIPTION
## What

`test_dispatch_tutorial` exercises the **dispatch pipeline** (webhook → dispatcher → worker → SDK round-trip → persistence), not model capability — its agent tasks are hello-world level (one-sentence reply, summarize a payload, save a stub report), so any responding model passes. It measures nothing about the model-under-test, the same rationale that already excludes `test_ariel_search` and `test_mcp_readiness`.

It still runs in normal CI — this only removes it from the **#259 per-model benchmark scope**.

## Why it was distorting scores

The build fixture is pinned to `als-apg/haiku` and ignores `OSPREY_E2E_FORCE_MODEL`. In CBORG matrix cells the runner shims `ALS_APG_API_KEY=$CBORG_API_KEY`, so the worker agent hits the real als-apg endpoint with a wrong credential and **hangs to the 300s worker timeout** — a fixed 3-test infra penalty (~22 min/cell with flaky reruns) that depressed every subject's pass rate identically across models and seeds.

## Changes

- **`matrix_e2e_config.json`** — add the exclusion (the runner ignores it going forward).
- **`matrix_dashboard.py`** — `apply_exclusions()` strips excluded-file tests from already-collected results and recomputes per-cell counts, so the dashboard honors its own footer **without re-running the matrix**. (Also fixes a latent correctness gap: the footer already advertised the exclusion set, but counts included tests run before a file was excluded.)

## Verification

- Subject cells shed exactly 3 failures each (e.g. `gpt-oss-20b` s1 62→67%, `cborg-coder` s1 87→94%).
- als-apg reference cells (haiku/opus/sonnet) stay 100% — the tutorial *passed* there, confirming the failures were credential-routing, not capability.
- `check_e2e_coverage.py` reports full-kit coverage with the new explicit exclusion; `ruff` clean.