### PR TITLE
docs(profiles): document claude_code.permissions deny overrides (#292)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Compatibility is documented in release notes, not encoded in the version string.
 - `osprey skills install osprey-design-philosophy` — bundle OSPREY's design and architecture principles as an installable skill for framework contributors.
 - `scripts/benchmark/` — model-capability benchmark toolchain: runs the full e2e suite across a model × provider matrix and renders a per-test pass-rate dashboard. The provider is never hard-wired — the portable layer is the e2e harness's environment-variable contract; the shell/ssh orchestration scripts are documented copy-and-adapt examples for one operator's setup (#259).
 - How-to guide for running the Osprey agent on open-weight / self-hosted models and reproducing the model-capability benchmark (`docs/how-to/run-open-models`).
+- Documented the `claude_code.permissions` profile block (`remove_deny`/`deny`/`allow`/`ask`/`remove_ask`) for overriding the default tool deny list — e.g. unblocking `Bash`/`WebSearch` per facility (#292).
 
 ### Changed
 

--- a/docs/source/how-to/build-profiles.rst
+++ b/docs/source/how-to/build-profiles.rst
@@ -359,6 +359,55 @@ The recommended pattern for facility MCP servers:
          allow: ["phoebus_launch"]
 
 
+.. _profile-tool-permissions:
+
+Tool Permissions
+================
+
+By default OSPREY writes a deny list into ``.claude/settings.json`` that blocks a
+handful of general-purpose tools — ``Bash``, ``Edit``, ``WebFetch``, ``WebSearch``,
+and the Playwright/Context7 plugins — so a stock control-operator agent cannot shell
+out or browse the web. These defaults are **overridable per facility** through the
+``claude_code.permissions`` block in your profile (merged on top of the framework
+defaults at build time):
+
+.. code-block:: yaml
+
+   claude_code:
+     permissions:
+       remove_deny: ["Bash", "WebSearch"]   # drop these from the default deny list
+       allow: ["WebSearch"]                  # then allow them outright
+       ask: ["Bash"]                          # or route to human approval instead
+
+Supported keys:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Key
+     - Effect
+   * - ``remove_deny``
+     - Remove entries from the built-in deny defaults (e.g. unblock ``Bash``)
+   * - ``deny``
+     - Add facility-specific deny entries
+   * - ``allow``
+     - Add allow entries (no approval prompt)
+   * - ``ask``
+     - Add entries that route through human approval
+   * - ``remove_ask``
+     - Remove entries from the ask list
+
+.. admonition:: Deny wins, and it wins at runtime too
+   :class: important
+
+   Claude Code resolves permissions as **deny > ask > allow**, and a static ``deny``
+   entry cannot be overridden during a session. While a tool sits in the deny list,
+   an in-session ``/permissions`` "allow once" will **not** unblock it — you must
+   ``remove_deny`` it and rebuild. Use ``ask`` instead of ``deny`` for tools you want
+   gated but still reachable on a per-call basis.
+
+
 .. _profile-services:
 
 Services


### PR DESCRIPTION
Closes #292.

The tool deny list (`Bash`, `WebSearch`, etc.) written into `.claude/settings.json` is already overridable per facility via the `claude_code.permissions` profile block — it just wasn't documented. The docs only covered per-MCP-server permissions.

- Documents all five keys (`remove_deny`/`deny`/`allow`/`ask`/`remove_ask`) in `build-profiles.rst` with a `remove_deny: [Bash, WebSearch]` example.
- Adds an admonition on the deny > ask > allow precedence: a denied tool can't be re-enabled in-session via `/permissions`; you must `remove_deny` and rebuild. Use `ask` for tools you want gated but reachable.

Docs-only change.