### PR TITLE
test: absorb CI infra flakes (store-watcher inotify, SDK smoke)

### DIFF
--- a/tests/e2e/claude_code/test_sdk_workflows.py
+++ b/tests/e2e/claude_code/test_sdk_workflows.py
@@ -38,7 +38,9 @@ class TestClaudeCodeSDKIntegration:
     # Test 1 — Smoke test: single tool call observability
     # -------------------------------------------------------------------
 
-    @pytest.mark.flaky(reruns=2, reruns_delay=5)  # live SDK/provider smoke; absorb rare transient query errors
+    @pytest.mark.flaky(
+        reruns=2, reruns_delay=5
+    )  # live SDK/provider smoke; absorb rare transient query errors
     @pytest.mark.requires_api
     @pytest.mark.requires_als_apg
     @pytest.mark.asyncio

--- a/tests/e2e/claude_code/test_sdk_workflows.py
+++ b/tests/e2e/claude_code/test_sdk_workflows.py
@@ -38,6 +38,7 @@ class TestClaudeCodeSDKIntegration:
     # Test 1 — Smoke test: single tool call observability
     # -------------------------------------------------------------------
 
+    @pytest.mark.flaky(reruns=2, reruns_delay=5)  # live SDK/provider smoke; absorb rare transient query errors
     @pytest.mark.requires_api
     @pytest.mark.requires_als_apg
     @pytest.mark.asyncio

--- a/tests/interfaces/artifacts/test_store_watcher.py
+++ b/tests/interfaces/artifacts/test_store_watcher.py
@@ -83,7 +83,9 @@ class TestStoreWatcher:
         finally:
             watcher.stop()
 
-    @pytest.mark.flaky(reruns=2, reruns_delay=1)  # same inotify-miss risk as test_detects_new_artifact_entry
+    @pytest.mark.flaky(
+        reruns=2, reruns_delay=1
+    )  # same inotify-miss risk as test_detects_new_artifact_entry
     def test_detects_deleted_entry(self, tmp_path):
         """Removing an entry from the index externally triggers delete broadcast."""
         # Pre-populate with an artifact

--- a/tests/interfaces/artifacts/test_store_watcher.py
+++ b/tests/interfaces/artifacts/test_store_watcher.py
@@ -51,6 +51,12 @@ def _wait_for_broadcast(broadcaster, expected_calls=1, timeout=10.0):
 class TestStoreWatcher:
     """Tests for StoreIndexWatcher."""
 
+    # Filesystem-watcher tests depend on the OS delivering an inotify/FSEvents
+    # change event after observer startup. On loaded CI runners that event is
+    # occasionally missed entirely (not merely late — the poll wait below is
+    # already condition-based with a 10s ceiling), so re-run to re-initialize
+    # the observer rather than flake the whole suite.
+    @pytest.mark.flaky(reruns=2, reruns_delay=1)
     def test_detects_new_artifact_entry(self, tmp_path):
         """External write to artifacts.json triggers SSE broadcast."""
         watcher, broadcaster, artifact_store = _make_watcher(tmp_path)
@@ -77,6 +83,7 @@ class TestStoreWatcher:
         finally:
             watcher.stop()
 
+    @pytest.mark.flaky(reruns=2, reruns_delay=1)  # same inotify-miss risk as test_detects_new_artifact_entry
     def test_detects_deleted_entry(self, tmp_path):
         """Removing an entry from the index externally triggers delete broadcast."""
         # Pre-populate with an artifact


### PR DESCRIPTION
## Why
Three open PRs — #290 (benchmark), #293 (**docs-only**), #294 (dispatch) — were all red on the **same** pre-existing flaky tests. A docs-only PR cannot break a filesystem-watcher test, so these are environmental flakes on `main` hitting every branch, not any PR's fault.

| Flaky test | Nature |
|---|---|
| `test_store_watcher::test_detects_new_artifact_entry` / `_deleted_entry` | OS drops the inotify/FSEvents event after observer startup on loaded CI. The poll wait is already condition-based (10s), so the event is *missed*, not slow — a rerun re-inits the observer. |
| `test_sdk_workflows::test_tool_call_observability_smoke` | Live SDK/provider smoke; intermittent `SDK query ended in error: None`. Matches the `reruns=2` guard already on its sibling in the same class. |

## What
`@pytest.mark.flaky(reruns=2)` on exactly those infra/timing tests.

## Deliberately not touched
The channel-finder benchmark aggregates (`test_*_aggregate`). Their threshold is **load-bearing** — a miss means investigate dataset/DB drift, not paper over with reruns — and their module-scoped fixture would make a test-level rerun a no-op anyway.

## After merge
The three blocked PRs need a rebase onto `main` to pick up these markers, then their CI should clear.