### PR TITLE
feat(cli): osprey query — headless read-only agent runs for CI (#298)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Added
 
+- `osprey query "<prompt>"` — headless, read-only agent run for CI pipelines; boots the full MCP + tools stack, exits 0 on pass / 1 on verdict fail / 2 on infra error, and supports `--json` for machine-readable output.
 - `osprey skills install osprey-design-philosophy` — bundle OSPREY's design and architecture principles as an installable skill for framework contributors.
 - `scripts/benchmark/` — model-capability benchmark toolchain: runs the model-driving subset of `tests/e2e/` (the tests that route through the model under test) across a model × provider matrix and renders a per-test pass-rate dashboard. The whole run is declared in one config (`scripts/benchmark/matrix.yaml`) — each row names a `provider` and a model `id`, and the launcher (`matrix.py`) resolves credentials, derives the route (proxy for OpenAI-protocol models, direct for Anthropic), wires the LLM judge, and runs one isolated worker per (model, seed) cell. Adding a model — or a new provider such as a local DeepSeek (`ds4`) / Ollama / vLLM server — is a config edit, not a script edit. The provider is never hard-wired (#259).
 - How-to guide for running the Osprey agent on open-weight / self-hosted models and reproducing the model-capability benchmark (`docs/how-to/run-open-models`).

--- a/docs/source/how-to/index.rst
+++ b/docs/source/how-to/index.rst
@@ -66,6 +66,13 @@ Framework & Infrastructure
       Run the Osprey agent in your native terminal with companion services accessible
       in a browser.
 
+   .. grid-item-card:: Non-Interactive Agent Queries
+      :link: non_interactive_query
+      :link-type: doc
+
+      Run the OSPREY agent headlessly from CI pipelines and automated workflows
+      with ``osprey query`` — read-only, structured JSON output, and clear exit codes.
+
    .. grid-item-card:: Use the Python Executor
       :link: use-python-executor
       :link-type: doc
@@ -133,6 +140,7 @@ Services & Connectors
    add-mcp-server
    use-web-terminal
    use-cli-chat
+   non_interactive_query
    use-python-executor
    event-dispatch
    add-connector

--- a/docs/source/how-to/non_interactive_query.rst
+++ b/docs/source/how-to/non_interactive_query.rst
@@ -1,0 +1,222 @@
+Non-Interactive Agent Queries
+==============================
+
+How to use ``osprey query`` to run the OSPREY agent headlessly — in CI
+pipelines, health checks, and automated workflows.
+
+.. dropdown:: What You'll Learn
+   :color: primary
+   :icon: book
+
+   - What ``osprey query`` does and when to reach for it
+   - How project resolution works (``--project`` → ``OSPREY_PROJECT`` → cwd)
+   - The ``--json`` flag for machine-readable output
+   - Exit codes and what each means
+   - The read-only guarantee and how it is enforced
+   - How ``osprey query`` differs from ``osprey health``
+
+   **Prerequisites:** A project built with ``osprey build``.
+
+Overview
+========
+
+``osprey query "<prompt>"`` boots the full OSPREY agent — MCP servers,
+tools, provider authentication — passes your prompt, waits for a response,
+and exits with a code that summarises the outcome. Write, execute, and
+destructive tools are blocked at the SDK level (see `Read-Only Guarantee`_
+below): the command will not write to hardware, run shell commands or code,
+or delete stored data, making it safe for CI pipelines and automated
+workflows. (To deliver an answer it may still create workspace artifacts such
+as plots — see the guarantee's exact scope below.)
+
+Use ``osprey query`` when you need to verify that the *entire agent stack*
+works end-to-end against your real control system, not just that the model
+is reachable.
+
+Project Resolution
+==================
+
+``osprey query`` resolves the project directory in this order:
+
+1. ``--project DIR`` flag (explicit)
+2. ``OSPREY_PROJECT`` environment variable
+3. Current working directory (cwd)
+
+.. code-block:: bash
+
+   # Explicit project
+   osprey query --project ~/projects/als-assistant "List vacuum sections"
+
+   # Via environment variable
+   export OSPREY_PROJECT=~/projects/als-assistant
+   osprey query "List vacuum sections"
+
+   # Current directory (cwd)
+   cd ~/projects/als-assistant
+   osprey query "List vacuum sections"
+
+The command exits with code ``2`` if no valid project is found at the
+resolved path.
+
+Exit Codes
+==========
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 25 65
+
+   * - Code
+     - Meaning
+     - When it occurs
+   * - ``0``
+     - Pass
+     - The agent completed without error and all expected MCP servers
+       connected.
+   * - ``1``
+     - Verdict fail
+     - The agent ran but the outcome was unsatisfactory: a required MCP
+       server was missing from the session, the agent returned an error
+       result, or the run hit its cost budget (USD) or turn limit.
+   * - ``2``
+     - Infra / usage error
+     - The run never started: no project found at the resolved path, the
+       agent SDK is not installed, or the provider is not configured.
+
+Machine-Readable Output (``--json``)
+=====================================
+
+Pass ``--json`` to receive a structured JSON object instead of plain text:
+
+.. code-block:: bash
+
+   osprey query --json "Summarise recent alarms"
+
+Output format:
+
+.. code-block:: json
+
+   {
+     "final_text": "...",
+     "tool_traces": [
+       {"name": "tool_name", "input": {}, "result": "...", "is_error": false}
+     ],
+     "mcp_servers": {"controls": "connected", "ariel": "connected"},
+     "exit_code": 0
+   }
+
+``mcp_servers`` maps each expected server name to its connection-status
+string (e.g. ``"connected"``) from the MCP readiness snapshot taken before
+the prompt is sent. ``exit_code`` repeats the shell exit code so the whole
+verdict is self-contained in the JSON object.
+
+Read-Only Guarantee
+===================
+
+``osprey query`` enforces read-only execution at the SDK level by passing a
+comprehensive ``disallowed_tools`` list directly to the runner. The agent
+cannot call any of these tools even if it tries. The list is the union of:
+
+- **Built-in write/exec/network tools** — ``Bash`` (arbitrary shell, which
+  could itself write hardware via ``caput``), ``Write``, ``Edit``,
+  ``MultiEdit``, ``NotebookEdit``, ``WebFetch``, ``WebSearch``.
+- **Control-system write tools** — ``mcp__controls__channel_write`` and
+  ``mcp__python__execute`` (plus any facility-specific tools in the project's
+  ``hook_config.json`` ``write_tools`` block). These are always included even
+  if a project's ``hook_config.json`` omits them.
+- **Approval-required MCP actions** — every tool a framework MCP server marks
+  as side-effecting (e.g. ``mcp__ariel__entry_create`` logbook writes,
+  ``mcp__python__execute_file``, ``mcp__osprey_workspace__setup_patch``),
+  derived from the server registry so the blocked set tracks the framework
+  rather than a hand-maintained copy.
+- **Destructive workspace tools** — ``data_delete``, ``artifact_delete``, and
+  ``artifact_delete_all``, which permanently remove stored data/artifacts.
+- **Facility-custom write tools** — any tool a custom MCP server in
+  ``claude_code.servers`` marks under ``permissions.ask`` (or a custom server
+  that writes-check-gates all its tools) is blocked too. Declare custom write
+  tools under ``permissions.ask`` so the read-only path recognises them.
+
+Audited *read* tools (e.g. ``mcp__controls__channel_read``) remain available.
+The agent may still **create** workspace artifacts (plots, documents) and write
+session logs to deliver its answer — these are additive and regenerable. The
+guarantee is specifically that the run performs no hardware write, no code or
+shell execution, and no deletion of stored data.
+
+There is no ``--allow-writes`` flag. If you need an agent run that can write,
+use ``osprey claude chat`` or the event-dispatch pipeline instead.
+
+.. note::
+
+   This guarantee is independent of the ``claude_code.permissions`` settings
+   in ``config.yml``: the headless runner uses ``bypassPermissions`` (under
+   which the interactive allow/deny/approval guards are inert), so the
+   read-only guarantee rests *entirely* on the SDK-level ``disallowed_tools``
+   block. That is precisely why the block must cover the built-in and
+   approval-required tools above, not just the ``hook_config.json`` write list.
+
+CI Loop Pattern
+===============
+
+.. important::
+
+   OSPREY ships no canned queries. A query that references a channel address,
+   PV name, or subsystem label only makes sense for your facility. Write
+   queries that reflect your real control system — a generic query cannot
+   validate a facility-specific agent.
+
+The recommended CI pattern is a direct ``|| exit 1`` guard:
+
+.. code-block:: bash
+
+   osprey query "What PVs are used for beam current?" || exit 1
+
+For pipelines that parse results, use ``--json`` and ``jq``:
+
+.. code-block:: bash
+
+   result=$(osprey query --json "Summarise recent alarms")
+   echo "$result" | jq '.final_text'
+   echo "$result" | jq '.exit_code'
+
+For a project not in the current directory:
+
+.. code-block:: bash
+
+   osprey query \
+     --project /opt/osprey/als-assistant \
+     "List all vacuum sections" \
+     || exit 1
+
+``osprey query`` vs. ``osprey health``
+=======================================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50 50
+
+   * - ``osprey health``
+     - ``osprey query``
+   * - Raw model ping — "can I reach the model?"
+     - Full agent run — "does the agent boot its MCP servers and answer
+       against my control system?"
+   * - Checks configuration, connectivity, and optionally sends a minimal
+       test prompt
+     - Sends your real prompt through the full MCP + tools stack
+   * - Fast; optional API cost
+     - Slower; costs one normal agent run
+   * - Good for diagnosing a broken install
+     - Good for verifying end-to-end agent capability in CI
+
+Run ``osprey health`` first when something is wrong with the install.
+Run ``osprey query`` to confirm the agent answers control-system questions
+correctly once the install is healthy.
+
+.. seealso::
+
+   :doc:`use-cli-chat`
+       Interactive agent sessions in your native terminal.
+
+   :doc:`event-dispatch`
+       Turn external events into headless agent runs via webhooks and cron.
+
+   :doc:`/cli-reference/index`
+       Full ``osprey query`` and ``osprey health`` command reference.

--- a/src/osprey/agent_runner/__init__.py
+++ b/src/osprey/agent_runner/__init__.py
@@ -1,0 +1,56 @@
+"""OSPREY headless agent-run primitives.
+
+Provides the shared dataclasses, env helpers, and MCP readiness barrier used
+by both the ``osprey query`` CLI command and the SDK-based E2E test suite.
+
+Public surface::
+
+    from osprey.agent_runner import (
+        SDKWorkflowResult,
+        ToolTrace,
+        combined_text,
+        resolve_default_model,
+        sdk_env,
+        _expected_mcp_servers,
+        _await_mcp_ready,
+    )
+"""
+
+from osprey.agent_runner.primitives import (
+    SDKWorkflowResult,
+    ToolTrace,
+    _await_mcp_ready,
+    _expected_mcp_servers,
+    combined_text,
+    resolve_default_model,
+    sdk_env,
+)
+from osprey.agent_runner.runner import run_query
+from osprey.agent_runner.verdict import (
+    EXIT_PASS,
+    EXIT_USAGE,
+    EXIT_VERDICT_FAIL,
+    evaluate_verdict,
+)
+from osprey.agent_runner.write_tools import load_write_tools, read_only_disallowed_tools
+
+__all__ = [
+    # primitives
+    "SDKWorkflowResult",
+    "ToolTrace",
+    "combined_text",
+    "resolve_default_model",
+    "sdk_env",
+    "_expected_mcp_servers",
+    "_await_mcp_ready",
+    # runner
+    "run_query",
+    # write-tool guard
+    "load_write_tools",
+    "read_only_disallowed_tools",
+    # verdict + exit codes
+    "evaluate_verdict",
+    "EXIT_PASS",
+    "EXIT_VERDICT_FAIL",
+    "EXIT_USAGE",
+]

--- a/src/osprey/agent_runner/primitives.py
+++ b/src/osprey/agent_runner/primitives.py
@@ -1,0 +1,499 @@
+"""Headless agent-run primitives shared across the OSPREY package.
+
+These symbols are extracted from ``tests/e2e/sdk_helpers.py`` so they can be
+imported by production code (e.g. ``osprey query``) without depending on the
+test tree.  The test module re-imports from here and deletes its own copies so
+there is a single source of truth.
+
+The SDK import block mirrors the pattern in ``sdk_helpers.py``: the whole
+module remains importable even when ``claude_agent_sdk`` is not installed; only
+the runtime paths that actually USE the SDK will fail in that case.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from claude_agent_sdk import (
+        ClaudeSDKClient,
+        ResultMessage,
+        SystemMessage,
+        ToolResultBlock,
+    )
+
+# SDK imports — keep module importable even when SDK is absent.
+try:
+    from claude_agent_sdk import ResultMessage, SystemMessage  # type: ignore[assignment]
+
+    HAS_SDK = True
+except ImportError:
+    HAS_SDK = False
+
+
+# ---------------------------------------------------------------------------
+# Internal support: provider / spec resolution
+# ---------------------------------------------------------------------------
+# These helpers back sdk_env() and resolve_default_model().  They are NOT part
+# of the public __all__ but live here because they have no other production
+# home yet (they were in the test tree alongside the consumers).
+
+
+def _apply_e2e_overrides(spec: Any) -> Any:
+    """Apply suite-wide CBORG model-matrix overrides to a resolved spec (#259).
+
+    This is the single chokepoint every routing consumer goes through
+    (``provider_env_for_project``, ``resolve_default_model``,
+    and ``run_sdk_query``'s default model), so forcing the spec here keeps
+    the build env, the SDK ``model=`` argument, and the proxy base URL
+    mutually consistent.
+
+    * ``OSPREY_E2E_FORCE_MODEL`` — collapse every tier onto one model id and
+      rewrite the tier-model env vars to match.
+    * ``OSPREY_E2E_PROXY_BASE_URL`` — point ``ANTHROPIC_BASE_URL`` at the
+      in-process translation proxy (set by the session fixture in
+      tests/e2e/conftest.py for OpenAI-protocol / open models). Anthropic-
+      protocol CBORG models (``claude-*``) leave this unset and route direct.
+
+    Inert (returns the spec unchanged) when neither var is set, so normal
+    e2e runs are unaffected.
+    """
+    if spec is None:
+        return None
+    force_model = os.environ.get("OSPREY_E2E_FORCE_MODEL")
+    proxy_base = os.environ.get("OSPREY_E2E_PROXY_BASE_URL")
+    if not force_model and not proxy_base:
+        return spec
+
+    import dataclasses
+
+    tier_to_model = dict(spec.tier_to_model)
+    env_block = dict(spec.env_block)
+    if force_model:
+        for tier in tier_to_model:
+            tier_to_model[tier] = force_model
+        for key in (
+            "ANTHROPIC_MODEL",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+            "ANTHROPIC_DEFAULT_SONNET_MODEL",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL",
+        ):
+            if key in env_block:
+                env_block[key] = force_model
+    if proxy_base:
+        env_block["ANTHROPIC_BASE_URL"] = proxy_base
+    return dataclasses.replace(spec, tier_to_model=tier_to_model, env_block=env_block)
+
+
+def _resolve_project_spec(project_dir: Path, *, provider: str | None = None) -> Any:
+    """Return the project's ``ClaudeCodeModelSpec`` or ``None``.
+
+    Reads ``config.yml`` and runs the same resolver ``osprey claude chat``
+    uses, so test routing matches production exactly.  Surfaces any unexpected
+    error (missing config, YAML parse failure, resolver import failure) rather
+    than masking it as ``None``.
+
+    Args:
+        project_dir: Path to an initialized OSPREY project.
+        provider: When given, overrides ``claude_code.provider`` in the loaded
+            config before resolving — used by cross-provider model sweeps in
+            the benchmark runner.
+    """
+    import yaml  # type: ignore[import-untyped]
+
+    from osprey.cli.claude_code_resolver import ClaudeCodeModelResolver
+
+    cfg = yaml.safe_load((project_dir / "config.yml").read_text()) or {}
+    cc_config = cfg.get("claude_code", {})
+    if provider is not None:
+        cc_config = {**cc_config, "provider": provider}
+    spec = ClaudeCodeModelResolver.resolve(
+        cc_config,
+        cfg.get("api", {}).get("providers", {}),
+    )
+    return _apply_e2e_overrides(spec)
+
+
+def provider_env_for_project(project_dir: Path, *, provider: str | None = None) -> dict[str, str]:
+    """Resolve provider env vars so the SDK routes to the project's provider.
+
+    Without this, the bundled Claude CLI defaults to ``api.anthropic.com``
+    using whatever ambient ``ANTHROPIC_API_KEY`` happens to be set — which
+    is the wrong endpoint for cborg/als-apg projects and 404s on model
+    aliases like ``anthropic/claude-haiku``.
+
+    Args:
+        project_dir: Path to an initialized OSPREY project.
+        provider: When given, overrides ``claude_code.provider`` in the loaded
+            config before resolving — used by cross-provider model sweeps in
+            the benchmark runner.
+
+    Returns:
+        Env dict with ``ANTHROPIC_BASE_URL``, the auth-token var, the tier-model
+        vars, and the *raw* upstream secret var (see below), populated from the
+        configured provider.
+
+    Raises:
+        RuntimeError: When the project has no resolvable provider.
+
+    Notes:
+        Two distinct auth vars are propagated because the project has two LLM
+        call paths:
+
+        * The bundled Claude CLI / SDK authenticates via ``spec.auth_env_var``
+          (e.g. ``ANTHROPIC_AUTH_TOKEN`` for proxy providers).
+        * The in-context channel-finder benchmark spawns an MCP **stdio**
+          subprocess that inherits only a tiny safe-list (HOME, PATH, …) and
+          then expands ``config.yml``'s ``api_key: ${SECRET}`` against its own
+          environment. So the *raw* ``spec.auth_secret_env`` var must be carried
+          through explicitly, or the literal ``${SECRET}`` reaches litellm and
+          401s. For proxy providers (cborg/als-apg) the two var names differ;
+          for anthropic-direct they coincide.
+
+        A project-level ``.env`` is honoured first, so a freshly-configured key
+        overrides a stale shell export (mirrors ``inject_provider_env``).
+    """
+    spec = _resolve_project_spec(project_dir, provider=provider)
+    if spec is None:
+        raise RuntimeError(
+            f"Project at {project_dir} has no resolvable provider in "
+            "config.yml — pass provider=<als-apg|cborg|anthropic|amsc-i2|argo> "
+            "to init_project()."
+        )
+    env: dict[str, str] = dict(spec.env_block)
+
+    # Overlay a project-level .env so freshly-configured keys win over stale
+    # shell exports; strictly a superset of reading os.environ alone.
+    lookup: dict[str, str] = dict(os.environ)
+    env_file = project_dir / ".env"
+    if env_file.is_file():
+        try:
+            from dotenv import dotenv_values
+
+            for key, value in dotenv_values(env_file).items():
+                if value is not None:
+                    lookup[key] = value
+        except ImportError:
+            pass
+
+    if spec.auth_secret_env:
+        secret = lookup.get(spec.auth_secret_env)
+        if secret:
+            if spec.auth_env_var:
+                env[spec.auth_env_var] = secret
+            # Raw secret for the MCP-subprocess ${SECRET} expansion (see Notes).
+            env[spec.auth_secret_env] = secret
+    return env
+
+
+# ---------------------------------------------------------------------------
+# Tool trace dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ToolTrace:
+    """Lightweight record of a single tool call for observability."""
+
+    name: str
+    input: dict[str, Any]
+    result: str | None = None
+    is_error: bool = False
+    tool_use_id: str | None = None
+    parent_tool_use_id: str | None = None
+
+
+@dataclass
+class SDKWorkflowResult:
+    """Aggregated result from an SDK query run."""
+
+    tool_traces: list[ToolTrace] = field(default_factory=list)
+    text_blocks: list[str] = field(default_factory=list)
+    system_messages: list[SystemMessage] = field(default_factory=list)
+    result: ResultMessage | None = None
+    # Authoritative MCP server snapshot from ``ClaudeSDKClient.get_mcp_status()``
+    # captured just before the prompt is sent (see ``_await_mcp_ready``). Each entry
+    # is an ``McpServerStatus`` object (SDK) or raw dict: {name, status, tools, ...}.
+    # Empty when the runner used the one-shot ``query()`` path with no client to poll.
+    # This is the ground-truth infra-vs-model discriminator: a failure where the
+    # expected tool is absent here is INFRA (server never registered); present-but-
+    # unused is MODEL.
+    mcp_servers: list[Any] = field(default_factory=list)
+
+    @property
+    def tool_names(self) -> list[str]:
+        """Ordered list of tool names that were called."""
+        return [t.name for t in self.tool_traces]
+
+    @property
+    def mcp_server_status(self) -> dict[str, str]:
+        """``{'controls': 'connected', 'python': 'connected', ...}`` from the
+        captured ``get_mcp_status()`` snapshot. Empty if no snapshot was taken."""
+        return {s.get("name", "?"): s.get("status", "unknown") for s in self.mcp_servers}
+
+    @property
+    def registered_tools(self) -> list[str]:
+        """Flattened ``mcp__<server>__<tool>`` names that the MCP handshake exposed.
+
+        Built from the captured snapshot, so it reflects what the model could
+        actually call — not what it chose to call (that is ``tool_names``)."""
+        out: list[str] = []
+        for s in self.mcp_servers:
+            server = s.get("name", "")
+            for t in s.get("tools", []) or []:
+                tname = t.get("name") if isinstance(t, dict) else t
+                if tname:
+                    out.append(f"mcp__{server}__{tname}")
+        return out
+
+    def tool_was_registered(self, tool: str) -> bool | None:
+        """Was *tool* (e.g. ``mcp__controls__channel_write``) exposed by the MCP
+        handshake? ``None`` if no snapshot is available (cannot tell)."""
+        if not self.mcp_servers:
+            return None
+        return tool in self.registered_tools
+
+    @property
+    def repeated_tool_calls(self) -> dict[str, int]:
+        """``{'<tool>::<input-digest>': count}`` for any call issued more than
+        once. A high count on a delegation tool is the fingerprint of a
+        non-convergence loop."""
+        from collections import Counter
+
+        keys = [
+            f"{t.name}::{json.dumps(t.input, sort_keys=True, default=str)}"
+            for t in self.tool_traces
+        ]
+        return {k: n for k, n in Counter(keys).items() if n > 1}
+
+    @property
+    def has_redelegation_loop(self) -> bool:
+        """True if a subagent-spawning tool (``Agent``/``Task*``) was re-issued
+        with identical input 3+ times — model non-convergence (a MODEL timeout),
+        distinct from slow-but-progressing proxy latency (INFRA). Lets a
+        ``resource_timeout`` failure be bucketed from the recorded artifact
+        instead of guessed."""
+        for key, n in self.repeated_tool_calls.items():
+            name = key.split("::", 1)[0]
+            if n >= 3 and (name == "Agent" or name.startswith("Task")):
+                return True
+        return False
+
+    @property
+    def cost_usd(self) -> float | None:
+        """Total cost from the ResultMessage."""
+        return self.result.total_cost_usd if self.result else None
+
+    @property
+    def num_turns(self) -> int | None:
+        """Number of agentic turns from the ResultMessage."""
+        return self.result.num_turns if self.result else None
+
+    @property
+    def input_tokens(self) -> int:
+        """Total input tokens (raw + cache creation + cache read)."""
+        usage: dict[str, Any] | None = getattr(self.result, "usage", None)
+        if not usage:
+            return 0
+        return (
+            int(usage.get("input_tokens", 0))
+            + int(usage.get("cache_creation_input_tokens", 0))
+            + int(usage.get("cache_read_input_tokens", 0))
+        )
+
+    @property
+    def output_tokens(self) -> int:
+        """Total output tokens."""
+        usage: dict[str, Any] | None = getattr(self.result, "usage", None)
+        if not usage:
+            return 0
+        return int(usage.get("output_tokens", 0))
+
+    @property
+    def cache_read_tokens(self) -> int:
+        """Cache-read input tokens (charged at reduced rate)."""
+        usage: dict[str, Any] | None = getattr(self.result, "usage", None)
+        if not usage:
+            return 0
+        return int(usage.get("cache_read_input_tokens", 0))
+
+    @property
+    def cache_creation_tokens(self) -> int:
+        """Cache-creation input tokens."""
+        usage: dict[str, Any] | None = getattr(self.result, "usage", None)
+        if not usage:
+            return 0
+        return int(usage.get("cache_creation_input_tokens", 0))
+
+    def tools_matching(self, substring: str) -> list[ToolTrace]:
+        """Return all tool traces whose name contains *substring*."""
+        return [t for t in self.tool_traces if substring in t.name]
+
+
+# ---------------------------------------------------------------------------
+# Public primitives
+# ---------------------------------------------------------------------------
+
+
+def resolve_default_model(project_dir: Path) -> str:
+    """Resolve the haiku-tier model name for the given project.
+
+    Reads ``config.yml`` and returns the provider's haiku-tier model id,
+    falling back to the upstream Anthropic default when no spec is
+    configured.
+
+    Args:
+        project_dir: Path to an initialized OSPREY project.
+
+    Returns:
+        Model identifier string suitable for passing to the Claude Agent SDK
+        ``model=`` argument.
+    """
+    spec = _resolve_project_spec(project_dir)
+    if spec is not None:
+        return str(spec.tier_to_model.get("haiku", "claude-haiku-4-5-20251001"))
+    return "claude-haiku-4-5-20251001"
+
+
+def sdk_env(project_dir: Path | None = None, *, provider: str | None = None) -> dict[str, str]:
+    """Return env overrides for the SDK subprocess.
+
+    Always sets ``CLAUDECODE=""`` to bypass the nested-session guard
+    (JavaScript treats "" as falsy). When ``project_dir`` is provided,
+    also injects the project's resolved provider env block so the bundled
+    CLI talks to the configured provider (cborg, als-apg, anthropic-direct)
+    instead of falling through to ``api.anthropic.com``.
+
+    Args:
+        project_dir: Optional path to an initialized OSPREY project.  When
+            omitted only the ``CLAUDECODE`` bypass is returned.
+        provider: When given, overrides ``claude_code.provider`` in the loaded
+            config before resolving — used by cross-provider model sweeps in
+            the benchmark runner.  Has no effect when ``project_dir`` is
+            ``None``.
+
+    Returns:
+        Env dict to merge into the SDK options ``env`` field.
+    """
+    env: dict[str, str] = {"CLAUDECODE": ""}
+    if project_dir is not None:
+        env.update(provider_env_for_project(project_dir, provider=provider))
+    return env
+
+
+def combined_text(result: SDKWorkflowResult) -> str:
+    """Combine all text blocks and tool results into a single searchable string.
+
+    Args:
+        result: A completed SDK workflow result.
+
+    Returns:
+        Lower-cased concatenation of all assistant text blocks and every
+        non-empty tool-result string, joined by spaces.
+    """
+    parts = list(result.text_blocks)
+    for trace in result.tool_traces:
+        if trace.result:
+            parts.append(trace.result)
+    return " ".join(parts).lower()
+
+
+def _ingest_tool_result(block: ToolResultBlock, pending_tools: dict[str, ToolTrace]) -> None:
+    """Match a ToolResultBlock to its pending ToolTrace and populate result/is_error.
+
+    ToolResultBlocks arrive in ``UserMessage.content`` (per Anthropic API
+    contract: tool_use is assistant output, tool_result is user input back to
+    the model). They may also appear in ``AssistantMessage`` when the SDK
+    forwards them.
+
+    Args:
+        block: The tool result block to ingest.
+        pending_tools: Map of tool_use_id to the ToolTrace awaiting its result.
+    """
+    matched = pending_tools.get(block.tool_use_id)
+    if matched is None:
+        return
+    if isinstance(block.content, str):
+        matched.result = block.content
+    elif isinstance(block.content, list):
+        texts = []
+        for item in block.content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                texts.append(item.get("text", ""))
+        matched.result = "\n".join(texts) if texts else str(block.content)
+    matched.is_error = bool(block.is_error)
+
+
+# ---------------------------------------------------------------------------
+# MCP readiness barrier + instrumentation
+# ---------------------------------------------------------------------------
+#
+# OSPREY MCP servers register ASYNCHRONOUSLY: the controls stdio subprocess does
+# heavyweight cold-start work (config prime, connector registration, tool-module
+# imports) and only finishes its MCP handshake ~1–1.5s after the CLI launches —
+# noticeably slower than the python/osprey_workspace servers. If the agent's first
+# turn fires before that handshake completes, the controls tools are simply not in
+# its toolset, and a less-persistent agent reports "no controls server connected"
+# and gives up. That is a cold-start race, NOT a model capability gap — yet it is
+# scored as a failure, and it cannot be distinguished from a genuine model give-up
+# from the persisted transcript (which does not record MCP status).
+#
+# Both problems are solved with the SDK's own ``ClaudeSDKClient.get_mcp_status()``:
+#   * READINESS — poll it until the expected servers are ``connected`` before sending
+#     the prompt, so every agent gets a ready toolset (the harness-enforced equivalent
+#     of the CLI's ``WaitForMcpServers`` tool, independent of whether the model thinks
+#     to call it).
+#   * INSTRUMENTATION — persist the final snapshot so a missing tool is provably INFRA
+#     (server never registered) vs MODEL (tool was there, agent ignored it).
+
+# The default ceiling generously covers the measured ~1.5s controls cold start with
+# headroom for a loaded box. Overridable via env for slow CI hosts.
+_MCP_READY_TIMEOUT_S = float(os.environ.get("OSPREY_E2E_MCP_READY_TIMEOUT", "20"))
+_MCP_READY_POLL_S = 0.3
+
+
+def _expected_mcp_servers(project_dir: Path) -> set[str]:
+    """The MCP server names a project declares in ``.mcp.json`` — the set the
+    readiness barrier waits for. Returns an empty set if the file is unreadable."""
+    try:
+        cfg = json.loads((project_dir / ".mcp.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return set()
+    return set(cfg.get("mcpServers", {}).keys())
+
+
+async def _await_mcp_ready(
+    client: ClaudeSDKClient,
+    expected: set[str],
+    *,
+    timeout_s: float = _MCP_READY_TIMEOUT_S,
+    poll_s: float = _MCP_READY_POLL_S,
+) -> list[Any]:
+    """Poll ``get_mcp_status()`` until every server in *expected* reports
+    ``connected`` (or *timeout_s* elapses), then return the final snapshot.
+
+    Resilient to ``get_mcp_status()`` raising early in startup (before the stream
+    is live). Never raises: on timeout it returns the last snapshot seen so the
+    caller can record a genuine registration failure rather than masking it.
+    """
+    deadline = time.monotonic() + timeout_s
+    servers: list[Any] = []
+    while True:
+        try:
+            status = await client.get_mcp_status()
+            servers = status.get("mcpServers", []) if isinstance(status, dict) else (status or [])
+        except Exception:  # noqa: BLE001 — status not queryable yet; keep polling
+            servers = servers or []
+        if expected:
+            connected = {s.get("name") for s in servers if s.get("status") == "connected"}
+            if expected <= connected:
+                return servers
+        if time.monotonic() >= deadline:
+            return servers
+        await asyncio.sleep(poll_s)

--- a/src/osprey/agent_runner/runner.py
+++ b/src/osprey/agent_runner/runner.py
@@ -1,0 +1,161 @@
+"""Headless agent-run entry point for the ``osprey query`` CLI command.
+
+Provides a production-ready ``run_query`` coroutine built on the shared
+primitives in ``osprey.agent_runner.primitives``.  The implementation mirrors
+``tests/e2e/sdk_helpers.run_sdk_query`` without the test-only concerns
+(e2e budget scaling, subagent transcript harvesting, MCP sidecar persistence).
+
+The module remains importable when ``claude_agent_sdk`` is absent; the runtime
+path will raise ``ImportError`` in that case, but module-level imports (e.g.
+for type checking or CLI argument parsing) still succeed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from claude_agent_sdk import ClaudeSDKClient
+
+# SDK imports — keep module importable even when SDK is absent.
+try:
+    from claude_agent_sdk import (
+        AssistantMessage,
+        ClaudeAgentOptions,
+        ClaudeSDKClient,
+        ResultMessage,
+        SystemMessage,
+        TextBlock,
+        ToolResultBlock,
+        ToolUseBlock,
+        UserMessage,
+    )
+
+    HAS_SDK = True
+except ImportError:
+    HAS_SDK = False
+
+from osprey.agent_runner.primitives import (
+    SDKWorkflowResult,
+    ToolTrace,
+    _await_mcp_ready,
+    _expected_mcp_servers,
+    _ingest_tool_result,
+    resolve_default_model,
+    sdk_env,
+)
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+async def run_query(
+    project_dir: Path,
+    prompt: str,
+    *,
+    disallowed_tools: list[str],
+    max_turns: int = 25,
+    max_budget_usd: float = 2.0,
+    model: str | None = None,
+) -> SDKWorkflowResult:
+    """Run a read-only agent query via the Claude Agent SDK.
+
+    This is the production runner used by ``osprey query``.  It is
+    architecturally read-only: the caller supplies ``disallowed_tools`` which
+    the SDK forwards to the Claude Code CLI as ``--disallowedTools``, blocking
+    writes even under ``permission_mode=bypassPermissions``.
+
+    The function polls ``_await_mcp_ready`` before sending the prompt so the
+    agent always starts with a fully registered toolset — eliminating the
+    controls cold-start race described in ``primitives._await_mcp_ready``.
+
+    Args:
+        project_dir: Path to an initialized OSPREY project.
+        prompt: The user prompt to send to the agent.
+        disallowed_tools: Tool names forbidden at the SDK level.  This is the
+            architectural read-only guard; the caller is responsible for
+            supplying the appropriate list (see
+            ``.claude/hooks/hook_config.json`` ``write_tools``).
+        max_turns: Maximum agentic turns before stopping.
+        max_budget_usd: Budget cap in USD (not scaled — this is the literal
+            ceiling passed to the SDK).
+        model: Model identifier.  When ``None``, resolved from the project's
+            ``config.yml`` haiku-tier entry via ``resolve_default_model``.
+
+    Returns:
+        SDKWorkflowResult with all collected tool traces, text blocks,
+        system messages, MCP server snapshot, and the final ResultMessage.
+
+    Raises:
+        ImportError: When ``claude_agent_sdk`` is not installed.
+        RuntimeError: When the underlying SDK query fails.
+    """
+    if not HAS_SDK:
+        raise ImportError(
+            "claude_agent_sdk is required for run_query. "
+            "Install it with: pip install claude-agent-sdk"
+        )
+
+    resolved_model = model if model is not None else resolve_default_model(project_dir)
+
+    options = ClaudeAgentOptions(
+        model=resolved_model,
+        cwd=str(project_dir),
+        permission_mode="bypassPermissions",
+        max_turns=max_turns,
+        max_budget_usd=max_budget_usd,
+        env=sdk_env(project_dir),
+        setting_sources=["project"],
+        disallowed_tools=disallowed_tools,
+    )
+
+    workflow = SDKWorkflowResult()
+
+    # Map tool_use_id → ToolTrace for matching results to calls.
+    pending_tools: dict[str, ToolTrace] = {}
+
+    try:
+        # ClaudeSDKClient (streaming) rather than the one-shot ``query()`` so
+        # we can poll ``get_mcp_status()`` and wait out async MCP registration
+        # before the first turn — eliminating the controls cold-start race.
+        # Message handling is identical to the query() iterator.
+        async with ClaudeSDKClient(options=options) as client:
+            workflow.mcp_servers = await _await_mcp_ready(
+                client, _expected_mcp_servers(project_dir)
+            )
+            await client.query(prompt)
+            async for message in client.receive_response():
+                if isinstance(message, AssistantMessage):
+                    for block in message.content:
+                        if isinstance(block, TextBlock):
+                            workflow.text_blocks.append(block.text)
+                        elif isinstance(block, ToolUseBlock):
+                            trace = ToolTrace(
+                                name=block.name,
+                                input=block.input,
+                                tool_use_id=block.id,
+                                parent_tool_use_id=message.parent_tool_use_id,
+                            )
+                            workflow.tool_traces.append(trace)
+                            pending_tools[block.id] = trace
+                        elif isinstance(block, ToolResultBlock):
+                            _ingest_tool_result(block, pending_tools)
+
+                elif isinstance(message, UserMessage):
+                    # Tool results land here per the Anthropic API contract.
+                    if isinstance(message.content, list):
+                        for block in message.content:
+                            if isinstance(block, ToolResultBlock):
+                                _ingest_tool_result(block, pending_tools)
+
+                elif isinstance(message, SystemMessage):
+                    workflow.system_messages.append(message)
+
+                elif isinstance(message, ResultMessage):
+                    workflow.result = message
+    except Exception as exc:
+        raise RuntimeError(f"SDK query failed: {exc}") from exc
+
+    return workflow

--- a/src/osprey/agent_runner/verdict.py
+++ b/src/osprey/agent_runner/verdict.py
@@ -1,0 +1,73 @@
+"""Exit-code verdict for a completed SDK query run.
+
+Translates the structured ``SDKWorkflowResult`` into one of two exit codes:
+
+* ``EXIT_PASS`` (0) — all expected MCP servers are connected, the run
+  completed without error, and no budget or turn-limit was exceeded.
+* ``EXIT_VERDICT_FAIL`` (1) — any of those conditions is not met.
+
+The third constant, ``EXIT_USAGE`` (2), is reserved for the CLI layer
+(Task 2.1) to report infrastructure or usage errors that prevented the run
+from starting at all.  It lives here so callers can import all three
+constants from a single module.
+"""
+
+from __future__ import annotations
+
+from osprey.agent_runner.primitives import SDKWorkflowResult
+
+# ---------------------------------------------------------------------------
+# Exit-code constants
+# ---------------------------------------------------------------------------
+
+EXIT_PASS: int = 0
+"""Verdict: the query completed successfully."""
+
+EXIT_VERDICT_FAIL: int = 1
+"""Verdict: the query failed (server missing, result error, or budget hit)."""
+
+EXIT_USAGE: int = 2
+"""Reserved for the CLI layer: infrastructure / usage error before run start."""
+
+# ResultMessage subtypes that signal a resource cap was hit.  Both carry
+# ``is_error=True`` in practice, but the explicit subtype check makes the
+# budget/turn branch self-documenting and robust to future SDK changes.
+_BUDGET_SUBTYPES: frozenset[str] = frozenset({"error_max_budget_usd", "error_max_turns"})
+
+
+def evaluate_verdict(result: SDKWorkflowResult, expected_servers: set[str]) -> int:
+    """Evaluate whether an SDK query run should be considered passing.
+
+    Args:
+        result: Aggregated result from a completed SDK query run.
+        expected_servers: MCP server names (e.g. ``{"controls", "python"}``)
+            that must report ``"connected"`` in the pre-prompt snapshot for
+            the run to be considered valid.  An empty set skips the server
+            check.
+
+    Returns:
+        ``EXIT_PASS`` (0) when every server in *expected_servers* reports
+        ``"connected"``, the ``ResultMessage`` is present, ``is_error`` is
+        ``False``, and the subtype is not a budget or turn-limit sentinel.
+        ``EXIT_VERDICT_FAIL`` (1) otherwise.
+    """
+    # --- MCP server connectivity -----------------------------------------
+    if expected_servers:
+        status = result.mcp_server_status  # dict[str, str]
+        for server in expected_servers:
+            if status.get(server) != "connected":
+                return EXIT_VERDICT_FAIL
+
+    # --- Result presence and error flag ------------------------------------
+    msg = result.result
+    if msg is None:
+        return EXIT_VERDICT_FAIL
+
+    if msg.is_error:
+        return EXIT_VERDICT_FAIL
+
+    # --- Budget / turn-limit (defence-in-depth) ----------------------------
+    if msg.subtype in _BUDGET_SUBTYPES:
+        return EXIT_VERDICT_FAIL
+
+    return EXIT_PASS

--- a/src/osprey/agent_runner/write_tools.py
+++ b/src/osprey/agent_runner/write_tools.py
@@ -1,0 +1,292 @@
+"""Write-tool list loader for the OSPREY headless agent runner.
+
+Provides a single entry point, ``load_write_tools``, that returns the list of
+MCP tool names subject to the writes kill switch.  The list is read from the
+project's generated ``hook_config.json``; on any failure the module falls back
+to a replica of the canonical list in
+``templates/claude_code/claude/hooks/osprey_writes_check.py`` so the runner
+always fail-closes (i.e. never accidentally omits a gated tool).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import yaml  # type: ignore[import-untyped]
+
+logger = logging.getLogger(__name__)
+
+# Replica of _FALLBACK_WRITE_TOOLS from osprey_writes_check.py.
+# DRIFT GUARD: the test suite (test_write_tools.py) asserts that this list
+# equals the canonical one in the hook file — update both together.
+_FALLBACK_WRITE_TOOLS = [
+    "mcp__controls__channel_write",
+    "mcp__python__execute",
+]
+
+# Built-in (non-MCP) Claude Code tools that can write to disk, execute shell
+# commands, or reach the network. Under ``permission_mode=bypassPermissions``
+# the settings.json allow/deny/ask layer is INERT, so for the headless,
+# read-only ``osprey query`` path these MUST be blocked via ``disallowed_tools``
+# or the read-only guarantee is hollow — e.g. ``Bash`` could ``caput`` a PV
+# (a hardware write) or ``rm`` files, entirely bypassing the MCP write guard.
+# This is a superset of the built-in (non-``mcp__``) entries in
+# settings.json.j2's ``deny_defaults``; test_write_tools.py guards that the
+# headless floor never drifts below the interactive deny policy.
+_BUILTIN_UNSAFE_TOOLS = [
+    "Bash",
+    "Edit",
+    "Write",
+    "MultiEdit",
+    "NotebookEdit",
+    "WebFetch",
+    "WebSearch",
+]
+
+
+def load_write_tools(project_dir: Path) -> list[str]:
+    """Return the MCP tool names that are subject to the writes kill switch.
+
+    Reads ``<project_dir>/.claude/hooks/hook_config.json`` and returns the
+    ``write_tools`` list.  Falls back to ``_FALLBACK_WRITE_TOOLS`` when the
+    file is absent, unreadable, contains malformed JSON, or the ``write_tools``
+    key is missing or empty.
+
+    The returned list always contains the full canonical write-tool floor
+    (``_FALLBACK_WRITE_TOOLS`` — ``mcp__controls__channel_write`` *and*
+    ``mcp__python__execute``): the fallback includes them by construction, and
+    any member a loaded config omits is appended (with a warning) rather than
+    trusted to be absent. This matters because ``disallowed_tools`` is the sole
+    write guard under ``permission_mode=bypassPermissions`` (the approval hook
+    is inert there), so a gated tool dropped from the project's ``write_tools``
+    must not silently become callable. Disallowing a tool a project does not
+    register is a harmless no-op, so the floor has no downside.
+
+    Args:
+        project_dir: Root of the OSPREY project (the directory that contains
+            ``.claude/``).
+
+    Returns:
+        List of MCP tool-name strings that gate the writes kill switch, always
+        a superset of ``_FALLBACK_WRITE_TOOLS``.
+    """
+    hook_config_path = project_dir / ".claude" / "hooks" / "hook_config.json"
+    try:
+        raw = hook_config_path.read_text(encoding="utf-8")
+        config = json.loads(raw)
+        tools = config.get("write_tools") or []
+        if tools and not isinstance(tools, list):
+            # A scalar (e.g. a bare string) would be character-split by list(),
+            # silently dropping every gated tool. Fail closed to the fallback.
+            logger.warning(
+                "write_tools in %s is %s, not a list — using fallback",
+                hook_config_path,
+                type(tools).__name__,
+            )
+            tools = []
+        if tools:
+            result = list(tools)
+            # Hard-floor every canonical write tool: a loaded config that omits
+            # one would otherwise leave it callable under bypassPermissions.
+            for required in _FALLBACK_WRITE_TOOLS:
+                if required not in result:
+                    logger.warning(
+                        "%s is absent from write_tools in %s — injecting it "
+                        "(write-safety floor; config drift)",
+                        required,
+                        hook_config_path,
+                    )
+                    result.append(required)
+            return result
+        logger.warning(
+            "write_tools key missing or empty in %s — using fallback",
+            hook_config_path,
+        )
+    except FileNotFoundError:
+        logger.debug("hook_config.json not found at %s — using fallback", hook_config_path)
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "malformed JSON in %s (%s) — using fallback",
+            hook_config_path,
+            exc,
+        )
+    except OSError as exc:
+        logger.warning(
+            "could not read %s (%s) — using fallback",
+            hook_config_path,
+            exc,
+        )
+
+    return list(_FALLBACK_WRITE_TOOLS)
+
+
+# Substrings in a tool name that mark it as destroying stored state. Used to
+# auto-detect destructive tools that sit in an auto-approve (``allow``) list —
+# e.g. the workspace server's data_delete/artifact_delete/artifact_delete_all,
+# which are safe-to-auto-approve *interactively* (a human drives) but must not
+# run in a headless read-only query.
+_DESTRUCTIVE_MARKERS = ("delete", "remove", "clear", "wipe", "purge", "destroy")
+
+# Side-effecting MCP tools the registry walk below cannot see because they are
+# in NO registry permission list at all: the python server registers both
+# ``execute`` (gated) and ``execute_file`` (unlisted), and SDK disallow matching
+# is by exact tool name — so disallowing ``mcp__python__execute`` does NOT cover
+# ``execute_file``, which runs arbitrary Python. (Destructive auto-allowed tools
+# such as the workspace deletes are handled generically by the destructive-name
+# scan in ``_registry_side_effect_tools``, not hard-coded here.) Keep this in
+# sync with server tool modules; test_write_tools.py pins it.
+_EXTRA_SIDE_EFFECT_TOOLS = [
+    "mcp__python__execute_file",
+]
+
+
+def _is_destructive(tool: str) -> bool:
+    """True if a tool's name implies it removes/destroys stored state."""
+    lowered = tool.lower()
+    return any(marker in lowered for marker in _DESTRUCTIVE_MARKERS)
+
+
+def _registry_side_effect_tools() -> list[str]:
+    """Side-effecting MCP tool names declared in the framework registry.
+
+    For every framework server this unions:
+
+    * ``permissions_ask`` + ``fixed_ask`` — the curated "needs approval because
+      it acts" sets (e.g. ``entry_create``, ``draft_concept``, ``setup_patch``,
+      ``channel_write``, ``execute``). Both render into the interactive ``ask``
+      list, so both are side-effecting.
+    * destructive-named tools in ``permissions_allow`` + ``fixed_allow`` — tools
+      auto-approved interactively but whose name implies destruction (e.g.
+      ``data_delete``). See ``_is_destructive``.
+    * every ``hooks_pre`` matcher gated by the writes-check hook (hardware
+      writes).
+
+    Deliberately NOT keyed on ``_APPROVAL``: that hook also wraps audited
+    *reads* (``channel_read``, ``archiver_read``), which a read-only query must
+    still be able to call.
+
+    Returns names as ``mcp__<server>__<tool>``.
+    """
+    from osprey.registry.mcp import _WRITES_CHECK, FRAMEWORK_SERVERS
+
+    out: list[str] = []
+
+    def _add(name: str) -> None:
+        if name not in out:
+            out.append(name)
+
+    for server in FRAMEWORK_SERVERS.values():
+        for tool in (*server.permissions_ask, *server.fixed_ask):
+            _add(f"mcp__{server.name}__{tool}")
+        for tool in (*server.permissions_allow, *server.fixed_allow):
+            if _is_destructive(tool):
+                _add(f"mcp__{server.name}__{tool}")
+        for rule in server.hooks_pre:
+            if _WRITES_CHECK in rule.hooks:
+                _add(rule.matcher)
+    return out
+
+
+def _custom_server_side_effect_tools(project_dir: Path) -> list[str]:
+    """Side-effecting tools from facility-defined custom MCP servers.
+
+    Framework servers are covered by :func:`_registry_side_effect_tools`, but a
+    project's ``config.yml`` ``claude_code.servers`` block can declare custom
+    servers whose write tools never reach ``hook_config.json`` ``write_tools``
+    (only writes-check-gated matchers do) and are invisible to the static
+    registry walk. The documented pattern marks them with ``permissions.ask``::
+
+        claude_code:
+          servers:
+            my-server:
+              hooks: {pre_tool_use: [approval]}
+              permissions: {allow: [read_data], ask: [write_data]}
+
+    So for each enabled custom server this emits ``mcp__<server>__<tool>`` for
+    every ``permissions.ask`` tool (exact, preserving the server's reads). If a
+    custom server writes-check-gates *all* its tools (``pre_tool_use:
+    [writes_check]``), it is blocked server-level (``mcp__<server>``) — the
+    facility marked the whole server write-gated, and the per-tool regex matcher
+    the registry would emit (``mcp__<server>__.*``) is a no-op in the SDK's
+    exact-name/server-level disallow engine.
+
+    Returns an empty list when ``config.yml`` is absent or unreadable.
+    """
+    try:
+        cfg = yaml.safe_load((project_dir / "config.yml").read_text(encoding="utf-8")) or {}
+    except (OSError, ValueError):
+        return []
+
+    from osprey.registry.mcp import FRAMEWORK_SERVERS
+
+    servers = (cfg.get("claude_code") or {}).get("servers") or {}
+    if not isinstance(servers, dict):
+        return []
+
+    out: list[str] = []
+    for name, spec in servers.items():
+        if not isinstance(spec, dict) or spec.get("enabled") is False:
+            continue
+        if name in FRAMEWORK_SERVERS:
+            continue  # framework server (or override) — covered by the registry walk
+        perms = spec.get("permissions") or {}
+        for tool in perms.get("ask") or []:
+            out.append(f"mcp__{name}__{tool}")
+        # Destructive-named tools a custom server auto-allows (mirrors the
+        # framework destructive-allow handling) — block them even though the
+        # facility put them in ``allow``.
+        for tool in perms.get("allow") or []:
+            if _is_destructive(tool):
+                out.append(f"mcp__{name}__{tool}")
+        pre = (spec.get("hooks") or {}).get("pre_tool_use") or []
+        if "writes_check" in pre:
+            # Whole server is write-gated; block it server-level (the only form
+            # the SDK disallow engine honors for "all tools of a server").
+            out.append(f"mcp__{name}")
+    return out
+
+
+def read_only_disallowed_tools(project_dir: Path) -> list[str]:
+    """Return the full ``disallowed_tools`` set for a headless read-only agent run.
+
+    This is the set ``osprey query`` passes to the SDK as ``disallowed_tools``.
+    Under ``permission_mode=bypassPermissions`` that list is the *sole* effective
+    write guard (the allow/deny/ask permission layer is inert), so it must cover
+    every write/exec/egress tool — built-in *and* MCP — or the read-only
+    guarantee is hollow.
+
+    It is the union of:
+
+    * ``_BUILTIN_UNSAFE_TOOLS`` — built-in ``Bash`` (arbitrary shell, incl.
+      hardware writes via ``caput``), ``Write``, ``Edit``, etc.
+    * :func:`load_write_tools` — the project's hardware-write kill-switch tools
+      (facility-custom writes included, fail-closed fallback).
+    * :func:`_registry_side_effect_tools` — every framework server's
+      approval-required actions (``permissions_ask`` + ``fixed_ask``),
+      destructive auto-allowed tools, and writes-check-gated tools (so the
+      side-effect surface tracks the registry as the single source of truth, not
+      a hand-maintained copy).
+    * ``_EXTRA_SIDE_EFFECT_TOOLS`` — side-effecting tools in NO registry
+      permission list (currently ``mcp__python__execute_file``).
+    * :func:`_custom_server_side_effect_tools` — write tools of facility-defined
+      custom MCP servers declared in the project's ``config.yml``.
+
+    Args:
+        project_dir: Root of the OSPREY project (the directory containing
+            ``.claude/``).
+
+    Returns:
+        Deduplicated list of every tool blocked in the read-only path.
+    """
+    result = load_write_tools(project_dir)
+    for tool in (
+        *_BUILTIN_UNSAFE_TOOLS,
+        *_registry_side_effect_tools(),
+        *_EXTRA_SIDE_EFFECT_TOOLS,
+        *_custom_server_side_effect_tools(project_dir),
+    ):
+        if tool not in result:
+            result.append(tool)
+    return result

--- a/src/osprey/cli/main.py
+++ b/src/osprey/cli/main.py
@@ -58,6 +58,7 @@ class LazyGroup(click.Group):
             "skills": "osprey.cli.skills_cmd",  # Bundled skill management
             "vendor": "osprey.cli.vendor_cmd",  # Vendor asset management
             "knowledge": "osprey.cli.knowledge_cmd",  # OKF facility knowledge
+            "query": "osprey.cli.query_cmd",  # Headless agent query
         }
 
         if cmd_name not in commands:
@@ -105,6 +106,7 @@ class LazyGroup(click.Group):
             "skills",
             "vendor",
             "knowledge",
+            "query",
         ]
 
 

--- a/src/osprey/cli/query_cmd.py
+++ b/src/osprey/cli/query_cmd.py
@@ -1,0 +1,158 @@
+"""Headless agent query command for the OSPREY CLI.
+
+Provides ``osprey query <prompt>`` — a read-only, non-interactive way to send
+a prompt to the project's configured agent and report the result.  Writes are
+blocked at the SDK level via ``disallowed_tools`` (see
+``agent_runner.read_only_disallowed_tools``): the project's MCP write tools
+(from ``hook_config.json``), the built-in write/exec/network tools (``Bash``,
+``Write``, ``Edit``, ...), and every approval-required MCP action declared in
+the server registry (e.g. ``mcp__ariel__entry_create``,
+``mcp__python__execute_file``).  This matters because the runner uses
+``permission_mode=bypassPermissions``, under which the interactive allow/deny
+permission layer is inert, so ``disallowed_tools`` is the sole write guard.
+
+Exit codes
+----------
+0   Agent run completed; all expected MCP servers connected and no error flag.
+1   Agent run completed but verdict failed (server missing, error result, or
+    budget cap hit).
+2   Infrastructure / usage error that prevented the run from starting at all
+    (missing project, SDK not installed, provider not configured).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import click
+import yaml  # type: ignore[import-untyped]
+
+from osprey.agent_runner import (
+    EXIT_USAGE,
+    SDKWorkflowResult,
+    _expected_mcp_servers,
+    evaluate_verdict,
+    read_only_disallowed_tools,
+    run_query,
+)
+from osprey.cli.project_utils import resolve_project_path
+
+
+def _is_valid_project(project_dir: Path) -> bool:
+    """Return True when *project_dir* looks like a built OSPREY project.
+
+    Requires ``config.yml`` — the file carrying the provider/model config the
+    runner unconditionally reads (``resolve_default_model`` and
+    ``provider_env_for_project`` both parse it). ``.mcp.json`` is *not* required:
+    its absence only means the verdict skips the MCP-server connectivity check.
+    Accepting a ``.mcp.json``-only directory would let the run start and then
+    crash deep in config resolution — better to fail fast with a usage error.
+    """
+    return (project_dir / "config.yml").exists()
+
+
+def _build_json_output(result: SDKWorkflowResult, exit_code: int) -> str:
+    """Serialise *result* to the ``--json`` output format."""
+    return json.dumps(
+        {
+            "final_text": "\n".join(result.text_blocks),
+            "tool_traces": [
+                {
+                    "name": t.name,
+                    "input": t.input,
+                    "result": t.result,
+                    "is_error": t.is_error,
+                }
+                for t in result.tool_traces
+            ],
+            "mcp_servers": result.mcp_server_status,
+            "exit_code": exit_code,
+        },
+        indent=2,
+    )
+
+
+@click.command()
+@click.argument("prompt")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit a JSON object with final_text, tool_traces, mcp_servers, and exit_code.",
+)
+@click.option(
+    "--project",
+    "-p",
+    default=None,
+    metavar="DIR",
+    help="Project directory (default: OSPREY_PROJECT env var, then cwd).",
+)
+@click.pass_context
+def query(ctx: click.Context, prompt: str, as_json: bool, project: str | None) -> None:
+    """Send PROMPT to the project agent and print the response.
+
+    Runs in read-only mode: write tools are blocked at the SDK level so this
+    command is safe to use in CI pipelines and automated workflows.
+
+    Exit codes:
+
+    \b
+      0  Agent completed successfully (all expected MCP servers connected).
+      1  Agent verdict failed (server missing, error result, or budget cap hit).
+      2  Usage error (missing project, SDK not installed, provider not configured).
+
+    Examples:
+
+    \b
+      # Query in the current project directory
+      $ osprey query "What PVs are used for beam current?"
+
+      # Query a specific project
+      $ osprey query --project ~/projects/als-assistant "List vacuum sections"
+
+      # Machine-readable JSON output
+      $ osprey query --json "Summarise recent alarms"
+    """
+    project_dir = resolve_project_path(project)
+
+    if not _is_valid_project(project_dir):
+        click.echo(
+            "Error: no OSPREY project found. "
+            "Run inside an `osprey build` project directory or pass --project.",
+            err=True,
+        )
+        ctx.exit(EXIT_USAGE)
+        return
+
+    disallowed_tools = read_only_disallowed_tools(project_dir)
+    expected = _expected_mcp_servers(project_dir)
+
+    try:
+        result = asyncio.run(run_query(project_dir, prompt, disallowed_tools=disallowed_tools))
+    except (ImportError, RuntimeError) as exc:
+        # SDK not installed, or run_query wrapped an SDK/connection failure.
+        click.echo(f"Error: {exc}", err=True)
+        ctx.exit(EXIT_USAGE)
+        return
+    except (OSError, yaml.YAMLError, ValueError) as exc:
+        # Config resolution (read before the SDK run) hit a missing/malformed
+        # config.yml, or an unknown/misconfigured provider (the resolver raises
+        # ValueError naming the valid providers) — a usage error, not a verdict
+        # failure. The exception message is echoed so the actionable hint
+        # (e.g. "Built-in providers: …") reaches the user.
+        click.echo(f"Error: could not load project configuration: {exc}", err=True)
+        ctx.exit(EXIT_USAGE)
+        return
+
+    code = evaluate_verdict(result, expected)
+
+    if as_json:
+        click.echo(_build_json_output(result, code))
+    else:
+        click.echo("\n".join(result.text_blocks))
+
+    sys.exit(code)

--- a/src/osprey/services/channel_finder/benchmarks/sdk.py
+++ b/src/osprey/services/channel_finder/benchmarks/sdk.py
@@ -2,13 +2,15 @@
 
 Extracted from ``tests/e2e/sdk_helpers.py`` so that production code
 (``BenchmarkRunner``) can use them without importing from the test tree.
+
+``ToolTrace``, ``SDKWorkflowResult``, ``sdk_env``, and ``combined_text`` are
+re-exported from :mod:`osprey.agent_runner` — that module is the single source
+of truth for these primitives.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
 
 # SDK imports — skip if not installed
 try:
@@ -27,161 +29,9 @@ try:
 except ImportError:
     HAS_SDK = False
 
-
-# ---------------------------------------------------------------------------
-# Tool trace dataclass
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class ToolTrace:
-    """Lightweight record of a single tool call for observability."""
-
-    name: str
-    input: dict
-    result: str | None = None
-    is_error: bool = False
-    tool_use_id: str | None = None
-    parent_tool_use_id: str | None = None
-
-
-@dataclass
-class SDKWorkflowResult:
-    """Aggregated result from an SDK query run."""
-
-    tool_traces: list[ToolTrace] = field(default_factory=list)
-    text_blocks: list[str] = field(default_factory=list)
-    system_messages: list[Any] = field(default_factory=list)
-    result: Any = None
-
-    @property
-    def tool_names(self) -> list[str]:
-        """Ordered list of tool names that were called."""
-        return [t.name for t in self.tool_traces]
-
-    @property
-    def cost_usd(self) -> float | None:
-        """Total cost from the ResultMessage."""
-        return self.result.total_cost_usd if self.result else None
-
-    @property
-    def num_turns(self) -> int | None:
-        """Number of agentic turns from the ResultMessage."""
-        return self.result.num_turns if self.result else None
-
-    @property
-    def input_tokens(self) -> int:
-        """Total input tokens (raw + cache creation + cache read)."""
-        if not self.result or not getattr(self.result, "usage", None):
-            return 0
-        u = self.result.usage
-        return (
-            u.get("input_tokens", 0)
-            + u.get("cache_creation_input_tokens", 0)
-            + u.get("cache_read_input_tokens", 0)
-        )
-
-    @property
-    def output_tokens(self) -> int:
-        """Total output tokens."""
-        if not self.result or not getattr(self.result, "usage", None):
-            return 0
-        return self.result.usage.get("output_tokens", 0)
-
-    @property
-    def cache_read_tokens(self) -> int:
-        """Cache-read input tokens (charged at reduced rate)."""
-        if not self.result or not getattr(self.result, "usage", None):
-            return 0
-        return self.result.usage.get("cache_read_input_tokens", 0)
-
-    @property
-    def cache_creation_tokens(self) -> int:
-        """Cache-creation input tokens."""
-        if not self.result or not getattr(self.result, "usage", None):
-            return 0
-        return self.result.usage.get("cache_creation_input_tokens", 0)
-
-    def tools_matching(self, substring: str) -> list[ToolTrace]:
-        """Return all tool traces whose name contains *substring*."""
-        return [t for t in self.tool_traces if substring in t.name]
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def sdk_env(
-    project_dir: Path | None = None,
-    *,
-    provider: str | None = None,
-) -> dict[str, str]:
-    """Return env overrides for SDK subprocess.
-
-    Bypasses nested-session guard (CLAUDECODE="") and injects provider
-    auth from the project's config.yml so the CLI authenticates correctly
-    against Anthropic, CBORG, or other configured providers.
-
-    When ``provider`` is given it overrides the project's ``claude_code.provider``
-    so callers sweeping models across providers (e.g. anthropic for one cell,
-    ollama for another) inject env for the model they're actually running, not
-    whatever the project's claude_code section happens to be configured for.
-
-    Two grammars are propagated, because the project has two LLM call paths:
-
-    * The outer Claude Code CLI authenticates via the gateway bearer
-      (``ANTHROPIC_AUTH_TOKEN`` etc.) — that's what ``inject_provider_env``
-      sets up.
-    * The inner ``aget_chat_completion`` path (used by the in-context MCP
-      server's ``query_channels`` tool) reads
-      ``api.providers[name].api_key: ${SECRET}`` from config.yml and expands
-      it against the subprocess environment. MCP's ``stdio_client`` inherits
-      only a tiny safe-list (HOME, LOGNAME, PATH, SHELL, TERM, USER), so the
-      raw secret env var must be carried through explicitly or the literal
-      ``${SECRET}`` reaches litellm and fails authentication.
-    """
-    import os
-
-    env: dict[str, str] = {"CLAUDECODE": ""}
-
-    if project_dir is not None:
-        try:
-            import yaml
-
-            from osprey.cli.claude_code_resolver import (
-                ClaudeCodeModelResolver,
-                inject_provider_env,
-            )
-
-            config_path = project_dir / "config.yml"
-            if config_path.exists():
-                config = yaml.safe_load(config_path.read_text()) or {}
-                cc_config = config.get("claude_code", {})
-                if provider is not None:
-                    cc_config = {**cc_config, "provider": provider}
-                api_providers = config.get("api", {}).get("providers", {})
-                spec = ClaudeCodeModelResolver.resolve(cc_config, api_providers)
-                if spec:
-                    # Build a copy of environ, inject provider auth, then
-                    # extract only the vars that changed.
-                    scratch = dict(os.environ)
-                    inject_provider_env(scratch, spec, project_dir=project_dir)
-                    for key in list(scratch):
-                        if scratch[key] != os.environ.get(key):
-                            env[key] = scratch[key]
-
-                    # Also propagate the raw upstream secret so config.yml's
-                    # ${SECRET} placeholders in api.providers[name].api_key
-                    # expand correctly inside the MCP subprocess (see docstring).
-                    if spec.auth_secret_env:
-                        secret_value = os.environ.get(spec.auth_secret_env)
-                        if secret_value:
-                            env[spec.auth_secret_env] = secret_value
-        except Exception:
-            pass  # Fall back to bare env if resolver unavailable
-
-    return env
+from osprey.agent_runner import SDKWorkflowResult, ToolTrace, sdk_env
+from osprey.agent_runner import combined_text as combined_text  # re-exported for backends
+from osprey.agent_runner.primitives import _ingest_tool_result
 
 
 def _resolve_default_sdk_model(project_dir: Path) -> str:
@@ -192,7 +42,7 @@ def _resolve_default_sdk_model(project_dir: Path) -> str:
     provider is configured so callers fail loudly instead of silently sending
     a bogus default to the upstream API.
     """
-    import yaml
+    import yaml  # type: ignore[import-untyped]
 
     from osprey.cli.claude_code_resolver import ClaudeCodeModelResolver
 
@@ -211,15 +61,6 @@ def _resolve_default_sdk_model(project_dir: Path) -> str:
             "pass model= explicitly to run_sdk_query"
         )
     return spec.tier_to_model[spec.default_model_tier]
-
-
-def combined_text(result: SDKWorkflowResult) -> str:
-    """Combine all text blocks and tool results into a single searchable string."""
-    parts = list(result.text_blocks)
-    for trace in result.tool_traces:
-        if trace.result:
-            parts.append(trace.result)
-    return " ".join(parts).lower()
 
 
 def init_project(
@@ -402,19 +243,7 @@ async def run_sdk_query(
                         workflow.tool_traces.append(trace)
                         pending_tools[block.id] = trace
                     elif isinstance(block, ToolResultBlock):
-                        # Match result to its tool call
-                        matched = pending_tools.get(block.tool_use_id)
-                        if matched:
-                            if isinstance(block.content, str):
-                                matched.result = block.content
-                            elif isinstance(block.content, list):
-                                # Extract text from content list
-                                texts = []
-                                for item in block.content:
-                                    if isinstance(item, dict) and item.get("type") == "text":
-                                        texts.append(item.get("text", ""))
-                                matched.result = "\n".join(texts) if texts else str(block.content)
-                            matched.is_error = bool(block.is_error)
+                        _ingest_tool_result(block, pending_tools)
 
             elif isinstance(message, SystemMessage):
                 workflow.system_messages.append(message)

--- a/src/osprey/utils/logger.py
+++ b/src/osprey/utils/logger.py
@@ -193,8 +193,12 @@ def _setup_rich_logging(level: int = logging.INFO) -> None:
 
     root_logger.addHandler(handler)
 
-    # Quiet noisy third-party loggers
-    for lib in ["httpx", "httpcore", "requests", "urllib3", "LiteLLM"]:
+    # Quiet noisy third-party loggers. claude_agent_sdk emits an INFO
+    # "Using bundled Claude Code CLI: …" line on stdout (the RichHandler
+    # Console defaults to stdout), which would corrupt `osprey query --json`
+    # machine-readable output; raising it to WARNING keeps that contract clean
+    # while preserving genuine warnings/errors.
+    for lib in ["httpx", "httpcore", "requests", "urllib3", "LiteLLM", "claude_agent_sdk"]:
         logging.getLogger(lib).setLevel(logging.WARNING)
 
 

--- a/tests/agent_runner/test_primitives.py
+++ b/tests/agent_runner/test_primitives.py
@@ -1,0 +1,139 @@
+"""Tests for osprey.agent_runner.primitives provider-env resolution.
+
+Focus: the auth-var propagation contract that the in-context channel-finder
+benchmark depends on. The in_context backend spawns an MCP stdio subprocess
+that inherits only a tiny safe-list and then expands config.yml's
+``api_key: ${SECRET}`` against its own env — so ``provider_env_for_project``
+MUST carry the *raw* secret var (e.g. ``CBORG_API_KEY``), not just the
+auth-token var (``ANTHROPIC_AUTH_TOKEN``).
+
+Regression guard for the single-source refactor: the deleted benchmark
+``sdk_env`` propagated the raw secret; the unified one initially did not, which
+silently broke proxy-provider auth for the in_context backend.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from osprey.agent_runner import sdk_env
+from osprey.agent_runner.primitives import provider_env_for_project
+
+
+def _write_config(project_dir: Path, provider: str) -> None:
+    """Write a minimal config.yml selecting *provider* for the claude_code path."""
+    (project_dir / "config.yml").write_text(
+        f"claude_code:\n  provider: {provider}\n  model: haiku\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Raw-secret propagation (proxy providers: auth_env_var != auth_secret_env)
+# ---------------------------------------------------------------------------
+
+
+def test_proxy_provider_propagates_both_auth_vars(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """cborg: both ANTHROPIC_AUTH_TOKEN (CLI auth) and the raw CBORG_API_KEY
+    (MCP-subprocess ${SECRET} expansion) must carry the secret."""
+    _write_config(tmp_path, "cborg")
+    monkeypatch.setenv("CBORG_API_KEY", "sk-cborg-secret")
+
+    env = provider_env_for_project(tmp_path)
+
+    assert env["ANTHROPIC_AUTH_TOKEN"] == "sk-cborg-secret"
+    assert env["CBORG_API_KEY"] == "sk-cborg-secret", (
+        "raw secret var must be propagated so config.yml ${CBORG_API_KEY} "
+        "expands inside the MCP stdio subprocess"
+    )
+
+
+def test_provider_override_propagates_raw_secret(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The provider= override (used by the benchmark sweep) also propagates the
+    raw secret for the overridden provider, not the config's."""
+    _write_config(tmp_path, "anthropic")
+    monkeypatch.setenv("ALS_APG_API_KEY", "sk-als-secret")
+
+    env = provider_env_for_project(tmp_path, provider="als-apg")
+
+    assert env["ANTHROPIC_AUTH_TOKEN"] == "sk-als-secret"
+    assert env["ALS_APG_API_KEY"] == "sk-als-secret"
+
+
+# ---------------------------------------------------------------------------
+# Direct provider: auth_env_var == auth_secret_env (anthropic)
+# ---------------------------------------------------------------------------
+
+
+def test_direct_provider_sets_single_auth_var(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """anthropic: the two var names coincide (ANTHROPIC_API_KEY) — still set."""
+    _write_config(tmp_path, "anthropic")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-secret")
+
+    env = provider_env_for_project(tmp_path)
+
+    assert env["ANTHROPIC_API_KEY"] == "sk-ant-secret"
+
+
+# ---------------------------------------------------------------------------
+# .env override: a project-level .env wins over a stale shell export
+# ---------------------------------------------------------------------------
+
+
+def test_project_dotenv_overrides_shell_export(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A freshly-configured key in the project .env overrides a stale shell
+    export (mirrors inject_provider_env's dotenv precedence)."""
+    pytest.importorskip("dotenv")
+    _write_config(tmp_path, "cborg")
+    monkeypatch.setenv("CBORG_API_KEY", "sk-stale-shell")
+    (tmp_path / ".env").write_text("CBORG_API_KEY=sk-fresh-from-dotenv\n")
+
+    env = provider_env_for_project(tmp_path)
+
+    assert env["CBORG_API_KEY"] == "sk-fresh-from-dotenv"
+    assert env["ANTHROPIC_AUTH_TOKEN"] == "sk-fresh-from-dotenv"
+
+
+# ---------------------------------------------------------------------------
+# Failure mode: unresolvable provider raises (fail loud, not silent {})
+# ---------------------------------------------------------------------------
+
+
+def test_unresolvable_provider_raises(tmp_path: Path) -> None:
+    """No claude_code block → no resolvable provider → RuntimeError, not {}."""
+    (tmp_path / "config.yml").write_text("api:\n  providers: {}\n")
+
+    with pytest.raises(RuntimeError, match="no resolvable provider"):
+        provider_env_for_project(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# sdk_env composition
+# ---------------------------------------------------------------------------
+
+
+def test_sdk_env_bypasses_nested_guard_without_project() -> None:
+    """sdk_env() with no project returns only the CLAUDECODE bypass."""
+    assert sdk_env() == {"CLAUDECODE": ""}
+
+
+def test_sdk_env_merges_provider_block(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """sdk_env(project) includes CLAUDECODE plus the resolved provider env,
+    including the raw secret var."""
+    _write_config(tmp_path, "cborg")
+    monkeypatch.setenv("CBORG_API_KEY", "sk-cborg-secret")
+
+    env = sdk_env(tmp_path)
+
+    assert env["CLAUDECODE"] == ""
+    assert env["CBORG_API_KEY"] == "sk-cborg-secret"
+    assert env["ANTHROPIC_BASE_URL"]  # provider env block merged in

--- a/tests/agent_runner/test_runner.py
+++ b/tests/agent_runner/test_runner.py
@@ -1,0 +1,386 @@
+"""Unit tests for osprey.agent_runner.runner.run_query.
+
+All tests mock ClaudeSDKClient and _await_mcp_ready so no live model or API
+keys are required.  The fake message stream exercises the full collection
+logic: tool call → tool result (via UserMessage) → text block → ResultMessage.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from claude_agent_sdk import (
+    AssistantMessage,
+    ClaudeAgentOptions,
+    ResultMessage,
+    TextBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+    UserMessage,
+)
+
+from osprey.agent_runner.primitives import SDKWorkflowResult
+from osprey.agent_runner.runner import run_query
+
+# ---------------------------------------------------------------------------
+# Scripted message stream
+# ---------------------------------------------------------------------------
+
+FAKE_TOOL_USE_ID = "tool-abc-123"
+FAKE_TOOL_NAME = "mcp__controls__channel_read"
+FAKE_TOOL_INPUT: dict = {"channel": "BL1:PHOTON_ENERGY"}
+FAKE_TOOL_RESULT = "12345.6 eV"
+FAKE_TEXT = "The photon energy is 12345.6 eV."
+FAKE_MCP_SERVERS = [
+    {"name": "controls", "status": "connected", "tools": [{"name": "channel_read"}]}
+]
+
+
+async def _scripted_stream() -> AsyncIterator:
+    """Yield a scripted sequence: tool call → tool result → text → ResultMessage."""
+    # Turn 1: assistant issues a tool call
+    yield AssistantMessage(
+        content=[ToolUseBlock(id=FAKE_TOOL_USE_ID, name=FAKE_TOOL_NAME, input=FAKE_TOOL_INPUT)],
+        model="claude-haiku-4-5-20251001",
+    )
+    # Turn 1: user returns the tool result
+    yield UserMessage(
+        content=[ToolResultBlock(tool_use_id=FAKE_TOOL_USE_ID, content=FAKE_TOOL_RESULT)]
+    )
+    # Turn 2: assistant produces a text reply
+    yield AssistantMessage(
+        content=[TextBlock(text=FAKE_TEXT)],
+        model="claude-haiku-4-5-20251001",
+    )
+    # Final: result message
+    yield ResultMessage(
+        subtype="success",
+        duration_ms=500,
+        duration_api_ms=400,
+        is_error=False,
+        num_turns=2,
+        session_id="sess-fake-001",
+        total_cost_usd=0.001,
+        stop_reason="end_turn",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def project_dir(tmp_path: Path) -> Path:
+    """Minimal OSPREY project skeleton sufficient for run_query."""
+    # .mcp.json declares the "controls" server so _expected_mcp_servers parses it.
+    (tmp_path / ".mcp.json").write_text(
+        '{"mcpServers": {"controls": {"command": "osprey-controls-mcp"}}}'
+    )
+    # config.yml must exist (read by sdk_env → provider_env_for_project).
+    # We stub sdk_env so this file is never actually parsed in these tests.
+    (tmp_path / "config.yml").write_text("api:\n  providers: {}\n")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a mock ClaudeSDKClient async context manager
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_client() -> MagicMock:
+    """Return a mock that behaves as ``async with ClaudeSDKClient(...) as client``."""
+    client = MagicMock()
+    client.query = AsyncMock(return_value=None)
+    client.receive_response = MagicMock(return_value=_scripted_stream())
+
+    # Async context manager protocol
+    async_cm = MagicMock()
+    async_cm.__aenter__ = AsyncMock(return_value=client)
+    async_cm.__aexit__ = AsyncMock(return_value=False)
+    return async_cm, client
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_query_collects_tool_traces_and_text(project_dir: Path) -> None:
+    """run_query returns an SDKWorkflowResult with the expected tool traces and text."""
+    async_cm, mock_client = _make_mock_client()
+
+    with (
+        patch("osprey.agent_runner.runner.ClaudeSDKClient", return_value=async_cm),
+        patch(
+            "osprey.agent_runner.runner._await_mcp_ready",
+            new=AsyncMock(return_value=FAKE_MCP_SERVERS),
+        ),
+        patch("osprey.agent_runner.runner.sdk_env", return_value={"CLAUDECODE": ""}),
+        patch(
+            "osprey.agent_runner.runner.resolve_default_model",
+            return_value="claude-haiku-4-5-20251001",
+        ),
+        patch(
+            "osprey.agent_runner.runner._expected_mcp_servers",
+            return_value={"controls"},
+        ),
+    ):
+        result = await run_query(
+            project_dir,
+            "What is the photon energy?",
+            disallowed_tools=["mcp__controls__channel_write"],
+        )
+
+    assert isinstance(result, SDKWorkflowResult)
+    # Tool traces
+    assert len(result.tool_traces) == 1
+    trace = result.tool_traces[0]
+    assert trace.name == FAKE_TOOL_NAME
+    assert trace.input == FAKE_TOOL_INPUT
+    assert trace.tool_use_id == FAKE_TOOL_USE_ID
+    assert trace.result == FAKE_TOOL_RESULT
+    assert trace.is_error is False
+    # Text blocks
+    assert result.text_blocks == [FAKE_TEXT]
+    # MCP servers
+    assert result.mcp_servers == FAKE_MCP_SERVERS
+    # ResultMessage
+    assert result.result is not None
+    assert result.result.num_turns == 2
+    assert result.result.total_cost_usd == pytest.approx(0.001)
+
+
+@pytest.mark.asyncio
+async def test_run_query_passes_disallowed_tools_to_options(project_dir: Path) -> None:
+    """disallowed_tools is forwarded to ClaudeAgentOptions as-is."""
+    async_cm, _ = _make_mock_client()
+    captured_options: list[ClaudeAgentOptions] = []
+
+    def _capture_client(options: ClaudeAgentOptions) -> MagicMock:
+        captured_options.append(options)
+        return async_cm
+
+    write_tools = ["mcp__controls__channel_write", "mcp__controls__channel_put"]
+
+    with (
+        patch("osprey.agent_runner.runner.ClaudeSDKClient", side_effect=_capture_client),
+        patch(
+            "osprey.agent_runner.runner._await_mcp_ready",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch("osprey.agent_runner.runner.sdk_env", return_value={"CLAUDECODE": ""}),
+        patch(
+            "osprey.agent_runner.runner.resolve_default_model",
+            return_value="claude-haiku-4-5-20251001",
+        ),
+        patch(
+            "osprey.agent_runner.runner._expected_mcp_servers",
+            return_value=set(),
+        ),
+    ):
+        await run_query(project_dir, "query", disallowed_tools=write_tools)
+
+    assert len(captured_options) == 1
+    opts = captured_options[0]
+    assert opts.disallowed_tools == write_tools
+    assert opts.permission_mode == "bypassPermissions"
+    assert opts.setting_sources == ["project"]
+    assert opts.max_turns == 25
+    assert opts.max_budget_usd == 2.0
+
+
+@pytest.mark.asyncio
+async def test_run_query_uses_resolved_model_when_none(project_dir: Path) -> None:
+    """When model=None, the haiku-tier model is resolved from the project config."""
+    async_cm, _ = _make_mock_client()
+    captured_options: list[ClaudeAgentOptions] = []
+
+    def _capture_client(options: ClaudeAgentOptions) -> MagicMock:
+        captured_options.append(options)
+        return async_cm
+
+    with (
+        patch("osprey.agent_runner.runner.ClaudeSDKClient", side_effect=_capture_client),
+        patch(
+            "osprey.agent_runner.runner._await_mcp_ready",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch("osprey.agent_runner.runner.sdk_env", return_value={"CLAUDECODE": ""}),
+        patch(
+            "osprey.agent_runner.runner.resolve_default_model",
+            return_value="claude-haiku-4-5-20251001",
+        ),
+        patch(
+            "osprey.agent_runner.runner._expected_mcp_servers",
+            return_value=set(),
+        ),
+    ):
+        await run_query(project_dir, "query", disallowed_tools=[], model=None)
+
+    assert captured_options[0].model == "claude-haiku-4-5-20251001"
+
+
+@pytest.mark.asyncio
+async def test_run_query_uses_explicit_model_when_supplied(project_dir: Path) -> None:
+    """When model is explicitly provided it is passed through unchanged."""
+    async_cm, _ = _make_mock_client()
+    captured_options: list[ClaudeAgentOptions] = []
+
+    def _capture_client(options: ClaudeAgentOptions) -> MagicMock:
+        captured_options.append(options)
+        return async_cm
+
+    with (
+        patch("osprey.agent_runner.runner.ClaudeSDKClient", side_effect=_capture_client),
+        patch(
+            "osprey.agent_runner.runner._await_mcp_ready",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch("osprey.agent_runner.runner.sdk_env", return_value={"CLAUDECODE": ""}),
+        patch(
+            "osprey.agent_runner.runner.resolve_default_model",
+            return_value="claude-haiku-4-5-20251001",
+        ),
+        patch(
+            "osprey.agent_runner.runner._expected_mcp_servers",
+            return_value=set(),
+        ),
+    ):
+        await run_query(project_dir, "query", disallowed_tools=[], model="claude-sonnet-4-6")
+
+    assert captured_options[0].model == "claude-sonnet-4-6"
+
+
+@pytest.mark.asyncio
+async def test_run_query_mcp_servers_populated(project_dir: Path) -> None:
+    """MCP server snapshot from _await_mcp_ready is stored in the result."""
+    async_cm, _ = _make_mock_client()
+    fake_servers = [
+        {"name": "controls", "status": "connected", "tools": []},
+        {"name": "python", "status": "connected", "tools": []},
+    ]
+
+    with (
+        patch("osprey.agent_runner.runner.ClaudeSDKClient", return_value=async_cm),
+        patch(
+            "osprey.agent_runner.runner._await_mcp_ready",
+            new=AsyncMock(return_value=fake_servers),
+        ),
+        patch("osprey.agent_runner.runner.sdk_env", return_value={"CLAUDECODE": ""}),
+        patch(
+            "osprey.agent_runner.runner.resolve_default_model",
+            return_value="claude-haiku-4-5-20251001",
+        ),
+        patch(
+            "osprey.agent_runner.runner._expected_mcp_servers",
+            return_value={"controls", "python"},
+        ),
+    ):
+        result = await run_query(project_dir, "query", disallowed_tools=[])
+
+    assert result.mcp_servers == fake_servers
+    assert result.mcp_server_status == {"controls": "connected", "python": "connected"}
+
+
+@pytest.mark.asyncio
+async def test_run_query_wraps_sdk_exception(project_dir: Path) -> None:
+    """SDK errors are re-raised as RuntimeError with a descriptive message."""
+    broken_cm = MagicMock()
+    broken_cm.__aenter__ = AsyncMock(side_effect=RuntimeError("connection refused"))
+    broken_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("osprey.agent_runner.runner.ClaudeSDKClient", return_value=broken_cm),
+        patch("osprey.agent_runner.runner.sdk_env", return_value={"CLAUDECODE": ""}),
+        patch(
+            "osprey.agent_runner.runner.resolve_default_model",
+            return_value="claude-haiku-4-5-20251001",
+        ),
+        patch(
+            "osprey.agent_runner.runner._expected_mcp_servers",
+            return_value=set(),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="SDK query failed"):
+            await run_query(project_dir, "query", disallowed_tools=[])
+
+
+# ---------------------------------------------------------------------------
+# Tool-result parsing branches: list content, is_error, AssistantMessage-embedded
+# ---------------------------------------------------------------------------
+
+
+async def _list_content_stream() -> AsyncIterator:
+    """A run where the tool result arrives as a list of content blocks and is an error.
+
+    Also exercises the path where a ToolResultBlock is embedded directly in an
+    AssistantMessage (rather than a UserMessage) — the SDK forwards it that way.
+    """
+    yield AssistantMessage(
+        content=[ToolUseBlock(id=FAKE_TOOL_USE_ID, name=FAKE_TOOL_NAME, input=FAKE_TOOL_INPUT)],
+        model="claude-haiku-4-5-20251001",
+    )
+    # Tool result embedded in an AssistantMessage, with list-shaped content and is_error.
+    yield AssistantMessage(
+        content=[
+            ToolResultBlock(
+                tool_use_id=FAKE_TOOL_USE_ID,
+                content=[{"type": "text", "text": "channel offline"}],
+                is_error=True,
+            )
+        ],
+        model="claude-haiku-4-5-20251001",
+    )
+    yield ResultMessage(
+        subtype="success",
+        duration_ms=10,
+        duration_api_ms=10,
+        is_error=False,
+        num_turns=1,
+        session_id="sess-list-001",
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_query_parses_list_content_and_is_error(project_dir: Path) -> None:
+    """List-shaped tool-result content is joined to text; is_error is captured;
+    a ToolResultBlock embedded in an AssistantMessage is ingested."""
+    client = MagicMock()
+    client.query = AsyncMock(return_value=None)
+    client.receive_response = MagicMock(return_value=_list_content_stream())
+    async_cm = MagicMock()
+    async_cm.__aenter__ = AsyncMock(return_value=client)
+    async_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("osprey.agent_runner.runner.ClaudeSDKClient", return_value=async_cm),
+        patch(
+            "osprey.agent_runner.runner._await_mcp_ready",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch("osprey.agent_runner.runner.sdk_env", return_value={"CLAUDECODE": ""}),
+        patch(
+            "osprey.agent_runner.runner.resolve_default_model",
+            return_value="claude-haiku-4-5-20251001",
+        ),
+        patch("osprey.agent_runner.runner._expected_mcp_servers", return_value=set()),
+    ):
+        result = await run_query(project_dir, "q", disallowed_tools=[])
+
+    assert len(result.tool_traces) == 1
+    trace = result.tool_traces[0]
+    assert trace.result == "channel offline"
+    assert trace.is_error is True
+
+
+@pytest.mark.asyncio
+async def test_run_query_raises_when_sdk_absent(project_dir: Path) -> None:
+    """When claude_agent_sdk is not installed, run_query raises ImportError."""
+    with patch("osprey.agent_runner.runner.HAS_SDK", False):
+        with pytest.raises(ImportError, match="claude_agent_sdk is required"):
+            await run_query(project_dir, "q", disallowed_tools=[])

--- a/tests/agent_runner/test_single_source.py
+++ b/tests/agent_runner/test_single_source.py
@@ -1,0 +1,96 @@
+"""Single-source guard for agent_runner primitives.
+
+Prevents the "third diverging copy" regression: SDKWorkflowResult, ToolTrace,
+sdk_env, and combined_text must live ONLY in osprey.agent_runner.primitives.
+Both tests/e2e/sdk_helpers.py and src/osprey/services/channel_finder/benchmarks/sdk.py
+re-export (import) these symbols rather than re-defining them. This test fails fast
+if anyone reintroduces a local copy in either consumer module.
+"""
+
+import inspect
+
+import osprey.services.channel_finder.benchmarks.sdk as bench
+import tests.e2e.sdk_helpers as helpers
+from osprey.agent_runner import (
+    SDKWorkflowResult as canonical_workflow_result,
+)
+from osprey.agent_runner import (
+    ToolTrace as canonical_tool_trace,
+)
+from osprey.agent_runner import (
+    sdk_env as canonical_sdk_env,
+)
+
+# ---------------------------------------------------------------------------
+# 1. Identity checks — the object must be the *same* object, not a copy
+# ---------------------------------------------------------------------------
+
+
+def test_sdk_workflow_result_identity_helpers():
+    assert helpers.SDKWorkflowResult is canonical_workflow_result, (
+        "tests/e2e/sdk_helpers.SDKWorkflowResult is not the canonical class; "
+        "it was re-defined instead of imported from osprey.agent_runner"
+    )
+
+
+def test_sdk_workflow_result_identity_bench():
+    assert bench.SDKWorkflowResult is canonical_workflow_result, (
+        "osprey.services.channel_finder.benchmarks.sdk.SDKWorkflowResult is not "
+        "the canonical class; it was re-defined instead of imported from osprey.agent_runner"
+    )
+
+
+def test_tool_trace_identity_helpers():
+    assert helpers.ToolTrace is canonical_tool_trace, (
+        "tests/e2e/sdk_helpers.ToolTrace is not the canonical class"
+    )
+
+
+def test_tool_trace_identity_bench():
+    assert bench.ToolTrace is canonical_tool_trace, (
+        "osprey.services.channel_finder.benchmarks.sdk.ToolTrace is not the canonical class"
+    )
+
+
+def test_sdk_env_identity_helpers():
+    assert helpers.sdk_env is canonical_sdk_env, (
+        "tests/e2e/sdk_helpers.sdk_env is not the canonical function"
+    )
+
+
+def test_sdk_env_identity_bench():
+    assert bench.sdk_env is canonical_sdk_env, (
+        "osprey.services.channel_finder.benchmarks.sdk.sdk_env is not the canonical function"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Source-grep guard — the consumer files must not re-define the primitives
+#    File paths are resolved via __file__ so the test is portable.
+# ---------------------------------------------------------------------------
+
+_FORBIDDEN_PATTERNS = [
+    "class SDKWorkflowResult",
+    "class ToolTrace",
+    "def sdk_env",
+    "def combined_text",
+    "def _ingest_tool_result",
+]
+
+
+def _assert_no_local_definition(module, label: str) -> None:
+    path = inspect.getfile(module)
+    source = open(path).read()
+    for pattern in _FORBIDDEN_PATTERNS:
+        assert pattern not in source, (
+            f"{label} ({path}) re-defines '{pattern}'. "
+            "Move the definition back to osprey.agent_runner.primitives and import from there."
+        )
+
+
+def test_sdk_helpers_no_local_definitions():
+    _assert_no_local_definition(helpers, "tests/e2e/sdk_helpers")
+
+
+def test_bench_sdk_no_local_definitions():
+    _assert_no_local_definition(bench, "osprey.services.channel_finder.benchmarks.sdk")

--- a/tests/agent_runner/test_verdict.py
+++ b/tests/agent_runner/test_verdict.py
@@ -1,0 +1,160 @@
+"""Tests for osprey.agent_runner.verdict.evaluate_verdict.
+
+Covers:
+  - All expected servers connected + no error + within budget → EXIT_PASS (0).
+  - An expected server not connected → EXIT_VERDICT_FAIL (1).
+  - Result indicates error → EXIT_VERDICT_FAIL (1).
+  - Budget exceeded → EXIT_VERDICT_FAIL (1).
+  - Turn-limit exceeded → EXIT_VERDICT_FAIL (1).
+  - Empty expected_servers set + ok result → EXIT_PASS (0).
+"""
+
+from __future__ import annotations
+
+from claude_agent_sdk import ResultMessage
+
+from osprey.agent_runner import SDKWorkflowResult
+from osprey.agent_runner.verdict import EXIT_PASS, EXIT_VERDICT_FAIL, evaluate_verdict
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ok_result(subtype: str = "success") -> ResultMessage:
+    """Return a ResultMessage with is_error=False and the given subtype."""
+    return ResultMessage(
+        subtype=subtype,
+        duration_ms=100,
+        duration_api_ms=100,
+        is_error=False,
+        num_turns=3,
+        session_id="test-session",
+    )
+
+
+def _error_result(subtype: str = "error_during_execution") -> ResultMessage:
+    """Return a ResultMessage with is_error=True and the given subtype."""
+    return ResultMessage(
+        subtype=subtype,
+        duration_ms=100,
+        duration_api_ms=100,
+        is_error=True,
+        num_turns=1,
+        session_id="test-session",
+    )
+
+
+def _workflow(
+    result: ResultMessage | None,
+    server_names: list[str],
+    status: str = "connected",
+) -> SDKWorkflowResult:
+    """Construct an SDKWorkflowResult with a synthetic MCP server snapshot."""
+    mcp_servers = [{"name": name, "status": status} for name in server_names]
+    return SDKWorkflowResult(
+        result=result,
+        mcp_servers=mcp_servers,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_all_connected_no_error_returns_pass() -> None:
+    """All expected servers connected and a clean result → EXIT_PASS."""
+    wf = _workflow(_ok_result(), ["controls", "python"])
+    assert evaluate_verdict(wf, {"controls", "python"}) == EXIT_PASS
+
+
+def test_empty_expected_servers_ok_result_returns_pass() -> None:
+    """Empty expected_servers set with a clean result → EXIT_PASS."""
+    wf = _workflow(_ok_result(), [])
+    assert evaluate_verdict(wf, set()) == EXIT_PASS
+
+
+# ---------------------------------------------------------------------------
+# MCP server not connected
+# ---------------------------------------------------------------------------
+
+
+def test_missing_expected_server_returns_fail() -> None:
+    """A required server absent from the snapshot → EXIT_VERDICT_FAIL."""
+    # Only 'python' is in the snapshot; 'controls' is missing entirely.
+    wf = _workflow(_ok_result(), ["python"])
+    assert evaluate_verdict(wf, {"controls", "python"}) == EXIT_VERDICT_FAIL
+
+
+def test_expected_server_not_connected_returns_fail() -> None:
+    """Required server present but status != 'connected' → EXIT_VERDICT_FAIL."""
+    mcp_servers = [
+        {"name": "controls", "status": "disconnected"},
+        {"name": "python", "status": "connected"},
+    ]
+    wf = SDKWorkflowResult(result=_ok_result(), mcp_servers=mcp_servers)
+    assert evaluate_verdict(wf, {"controls", "python"}) == EXIT_VERDICT_FAIL
+
+
+# ---------------------------------------------------------------------------
+# Result error conditions
+# ---------------------------------------------------------------------------
+
+
+def test_result_is_error_returns_fail() -> None:
+    """ResultMessage with is_error=True → EXIT_VERDICT_FAIL."""
+    wf = _workflow(_error_result("error_during_execution"), ["controls"])
+    assert evaluate_verdict(wf, {"controls"}) == EXIT_VERDICT_FAIL
+
+
+def test_result_none_returns_fail() -> None:
+    """Missing ResultMessage (result=None) → EXIT_VERDICT_FAIL."""
+    wf = _workflow(None, ["controls"])
+    assert evaluate_verdict(wf, {"controls"}) == EXIT_VERDICT_FAIL
+
+
+# ---------------------------------------------------------------------------
+# Budget / turn-limit exceeded
+# ---------------------------------------------------------------------------
+
+
+def test_budget_exceeded_returns_fail() -> None:
+    """ResultMessage with subtype='error_max_budget_usd' → EXIT_VERDICT_FAIL."""
+    wf = _workflow(_error_result("error_max_budget_usd"), ["controls"])
+    assert evaluate_verdict(wf, {"controls"}) == EXIT_VERDICT_FAIL
+
+
+def test_turn_limit_exceeded_returns_fail() -> None:
+    """ResultMessage with subtype='error_max_turns' → EXIT_VERDICT_FAIL."""
+    wf = _workflow(_error_result("error_max_turns"), ["controls"])
+    assert evaluate_verdict(wf, {"controls"}) == EXIT_VERDICT_FAIL
+
+
+def test_budget_subtype_without_error_flag_returns_fail() -> None:
+    """The _BUDGET_SUBTYPES branch (defense-in-depth) must fail even when
+    is_error is NOT set — the only input shape that actually reaches it, since
+    the is_error gate short-circuits first. Pins the documented contract that
+    is robust to future SDK changes."""
+    wf = _workflow(_ok_result("error_max_budget_usd"), ["controls"])
+    assert evaluate_verdict(wf, {"controls"}) == EXIT_VERDICT_FAIL
+
+
+def test_turn_subtype_without_error_flag_returns_fail() -> None:
+    """error_max_turns with is_error=False also fails via the subtype branch."""
+    wf = _workflow(_ok_result("error_max_turns"), ["controls"])
+    assert evaluate_verdict(wf, {"controls"}) == EXIT_VERDICT_FAIL
+
+
+# ---------------------------------------------------------------------------
+# Constants sanity
+# ---------------------------------------------------------------------------
+
+
+def test_constants_values() -> None:
+    """EXIT_PASS=0, EXIT_VERDICT_FAIL=1 (EXIT_USAGE=2 reserved for CLI layer)."""
+    from osprey.agent_runner.verdict import EXIT_USAGE
+
+    assert EXIT_PASS == 0
+    assert EXIT_VERDICT_FAIL == 1
+    assert EXIT_USAGE == 2

--- a/tests/agent_runner/test_write_tools.py
+++ b/tests/agent_runner/test_write_tools.py
@@ -1,0 +1,450 @@
+"""Tests for osprey.agent_runner.write_tools.load_write_tools.
+
+Covers:
+  - Happy path: hook_config.json present with a write_tools list.
+  - Missing file: falls back to _FALLBACK_WRITE_TOOLS.
+  - Malformed JSON: falls back without raising.
+  - Safety invariant: channel_write is always present even on the loaded path.
+  - Drift guard: canonical _FALLBACK_WRITE_TOOLS in osprey_writes_check.py
+    must equal the module-level replica in write_tools.py.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+from pathlib import Path
+
+import osprey
+from osprey.agent_runner.write_tools import (
+    _BUILTIN_UNSAFE_TOOLS,
+    _FALLBACK_WRITE_TOOLS,
+    load_write_tools,
+    read_only_disallowed_tools,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _hook_config_dir(tmp_path: Path) -> Path:
+    """Return the .claude/hooks dir inside a fake project root, created."""
+    hooks = tmp_path / ".claude" / "hooks"
+    hooks.mkdir(parents=True)
+    return hooks
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_load_write_tools_from_config(tmp_path: Path) -> None:
+    """Returns the list verbatim when the config already contains the full floor."""
+    hooks = _hook_config_dir(tmp_path)
+    # Includes both canonical floor tools, so nothing is injected and the
+    # configured list (custom tool included) is returned unchanged.
+    expected = [
+        "mcp__controls__channel_write",
+        "mcp__python__execute",
+        "mcp__custom__tool",
+    ]
+    (hooks / "hook_config.json").write_text(json.dumps({"write_tools": expected}))
+
+    result = load_write_tools(tmp_path)
+
+    assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# Missing file → fallback
+# ---------------------------------------------------------------------------
+
+
+def test_load_write_tools_missing_file_returns_fallback(tmp_path: Path) -> None:
+    """Missing hook_config.json → returns fallback; includes channel_write."""
+    result = load_write_tools(tmp_path)
+
+    assert result == _FALLBACK_WRITE_TOOLS
+    assert "mcp__controls__channel_write" in result
+
+
+# ---------------------------------------------------------------------------
+# Malformed JSON → fallback, no exception
+# ---------------------------------------------------------------------------
+
+
+def test_load_write_tools_malformed_json_returns_fallback(tmp_path: Path) -> None:
+    """Malformed JSON in hook_config.json → returns fallback without raising."""
+    hooks = _hook_config_dir(tmp_path)
+    (hooks / "hook_config.json").write_text("{not valid json")
+
+    result = load_write_tools(tmp_path)
+
+    assert result == _FALLBACK_WRITE_TOOLS
+    assert "mcp__controls__channel_write" in result
+
+
+# ---------------------------------------------------------------------------
+# Missing / empty write_tools key → fallback
+# ---------------------------------------------------------------------------
+
+
+def test_load_write_tools_missing_key_returns_fallback(tmp_path: Path) -> None:
+    """hook_config.json present but lacks write_tools key → returns fallback."""
+    hooks = _hook_config_dir(tmp_path)
+    (hooks / "hook_config.json").write_text(json.dumps({"other_key": []}))
+
+    result = load_write_tools(tmp_path)
+
+    assert result == _FALLBACK_WRITE_TOOLS
+
+
+def test_load_write_tools_empty_list_returns_fallback(tmp_path: Path) -> None:
+    """hook_config.json with empty write_tools list → returns fallback."""
+    hooks = _hook_config_dir(tmp_path)
+    (hooks / "hook_config.json").write_text(json.dumps({"write_tools": []}))
+
+    result = load_write_tools(tmp_path)
+
+    assert result == _FALLBACK_WRITE_TOOLS
+
+
+def test_load_write_tools_scalar_write_tools_returns_fallback(tmp_path: Path) -> None:
+    """A scalar (non-list) write_tools value must fall closed to the fallback.
+
+    Regression guard: ``list("mcp__...")`` would character-split the string,
+    silently dropping every gated tool (including mcp__python__execute) and
+    leaving only an injected channel_write. The type check prevents that.
+    """
+    hooks = _hook_config_dir(tmp_path)
+    (hooks / "hook_config.json").write_text(
+        json.dumps({"write_tools": "mcp__controls__channel_write"})
+    )
+
+    result = load_write_tools(tmp_path)
+
+    assert result == _FALLBACK_WRITE_TOOLS
+    assert "mcp__python__execute" in result  # the other gated tool survives
+
+
+# ---------------------------------------------------------------------------
+# Safety invariant: channel_write always present even on the loaded-config path
+# ---------------------------------------------------------------------------
+
+
+def test_load_write_tools_injects_channel_write_if_absent(tmp_path: Path) -> None:
+    """Config that omits channel_write → it is injected; other tools preserved."""
+    hooks = _hook_config_dir(tmp_path)
+    configured = ["mcp__python__execute", "mcp__custom__tool"]
+    (hooks / "hook_config.json").write_text(json.dumps({"write_tools": configured}))
+
+    result = load_write_tools(tmp_path)
+
+    assert "mcp__controls__channel_write" in result
+    # other configured tools must still be present
+    for tool in configured:
+        assert tool in result
+
+
+def test_load_write_tools_floors_entire_canonical_set(tmp_path: Path) -> None:
+    """A loaded config missing BOTH canonical write tools gets both injected.
+
+    Write-safety floor: under bypassPermissions disallowed_tools is the sole
+    write guard, so neither channel_write nor python execute may silently drop
+    out of a project's write_tools through config drift.
+    """
+    hooks = _hook_config_dir(tmp_path)
+    (hooks / "hook_config.json").write_text(json.dumps({"write_tools": ["mcp__custom__tool"]}))
+
+    result = load_write_tools(tmp_path)
+
+    assert "mcp__controls__channel_write" in result
+    assert "mcp__python__execute" in result
+    assert "mcp__custom__tool" in result  # configured tool preserved
+
+
+# ---------------------------------------------------------------------------
+# Drift guard: canonical file must match module replica
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_write_tools_matches_canonical_hook() -> None:
+    """_FALLBACK_WRITE_TOOLS must equal the list in osprey_writes_check.py.
+
+    Locates the canonical file relative to the installed osprey package so
+    the check works in editable installs and worktrees alike.
+    """
+    package_root = Path(osprey.__file__).parent
+    canonical_path = (
+        package_root / "templates" / "claude_code" / "claude" / "hooks" / "osprey_writes_check.py"
+    )
+    assert canonical_path.exists(), f"canonical hook file not found: {canonical_path}"
+
+    source = canonical_path.read_text()
+    tree = ast.parse(source)
+
+    # Walk top-level assignments looking for _FALLBACK_WRITE_TOOLS = [...]
+    canonical_list: list[str] | None = None
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "_FALLBACK_WRITE_TOOLS"
+            and isinstance(node.value, ast.List)
+        ):
+            canonical_list = [elt.value for elt in node.value.elts if isinstance(elt, ast.Constant)]
+            break
+
+    assert canonical_list is not None, "_FALLBACK_WRITE_TOOLS not found in osprey_writes_check.py"
+    assert _FALLBACK_WRITE_TOOLS == canonical_list, (
+        f"write_tools.py fallback {_FALLBACK_WRITE_TOOLS!r} "
+        f"differs from canonical hook {canonical_list!r} — update one to match"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Headless read-only disallowed set: MCP writes + built-in unsafe tools
+# ---------------------------------------------------------------------------
+
+
+def test_read_only_disallowed_tools_unions_mcp_and_builtins(tmp_path: Path) -> None:
+    """read_only_disallowed_tools blocks the MCP write set AND the built-in
+    write/exec/network tools (the escape hatch under bypassPermissions)."""
+    result = read_only_disallowed_tools(tmp_path)  # no hook_config → fallback
+
+    # MCP write tools
+    assert "mcp__controls__channel_write" in result
+    assert "mcp__python__execute" in result
+    # Built-in unsafe tools
+    for builtin in _BUILTIN_UNSAFE_TOOLS:
+        assert builtin in result, f"{builtin} must be disallowed in the read-only path"
+
+
+def test_read_only_disallowed_tools_no_duplicates(tmp_path: Path) -> None:
+    """A built-in already present in write_tools is not duplicated."""
+    hooks = _hook_config_dir(tmp_path)
+    (hooks / "hook_config.json").write_text(
+        json.dumps({"write_tools": ["mcp__controls__channel_write", "Bash"]})
+    )
+
+    result = read_only_disallowed_tools(tmp_path)
+
+    assert result.count("Bash") == 1
+
+
+def test_read_only_disallowed_tools_blocks_approval_required_actions(tmp_path: Path) -> None:
+    """Approval-required side-effect tools that are NOT in the hardware-write
+    kill-switch list must still be blocked (the round-5 escape hatch):
+    execute_file, entry_create, draft_concept, setup_patch."""
+    result = read_only_disallowed_tools(tmp_path)
+
+    for tool in (
+        "mcp__python__execute_file",
+        "mcp__ariel__entry_create",
+        "mcp__osprey_facility_knowledge__draft_concept",
+        "mcp__osprey_workspace__setup_patch",
+    ):
+        assert tool in result, f"{tool} (side-effecting) must be disallowed"
+
+
+def test_read_only_disallowed_tools_blocks_destructive_workspace_tools(tmp_path: Path) -> None:
+    """Destructive deletes live in permissions_ALLOW (auto-approved interactively)
+    so the registry walk misses them — they must still be blocked (round-6 gap).
+    A read-only query must never permanently delete persistent gallery/data."""
+    result = read_only_disallowed_tools(tmp_path)
+
+    for tool in (
+        "mcp__osprey_workspace__data_delete",
+        "mcp__osprey_workspace__artifact_delete",
+        "mcp__osprey_workspace__artifact_delete_all",
+    ):
+        assert tool in result, f"{tool} (destructive) must be disallowed"
+
+
+def test_read_only_blocks_custom_server_ask_tools(tmp_path: Path) -> None:
+    """A facility-custom MCP server's write tools (declared via permissions.ask
+    in config.yml) must be blocked, while its read tools stay callable. These
+    never reach hook_config write_tools and aren't in the framework registry,
+    so they would otherwise leak under bypassPermissions (round-7 gap)."""
+    (tmp_path / "config.yml").write_text(
+        "claude_code:\n"
+        "  servers:\n"
+        "    my-server:\n"
+        "      hooks: {pre_tool_use: [approval]}\n"
+        "      permissions:\n"
+        "        allow: [read_data]\n"
+        "        ask: [write_data, push_setpoint]\n"
+    )
+
+    result = read_only_disallowed_tools(tmp_path)
+
+    assert "mcp__my-server__write_data" in result
+    assert "mcp__my-server__push_setpoint" in result
+    assert "mcp__my-server__read_data" not in result  # reads preserved
+
+
+def test_read_only_blocks_custom_server_destructive_allow_tool(tmp_path: Path) -> None:
+    """A destructive-named tool a custom server puts in permissions.allow is
+    still blocked (mirrors the framework workspace-delete handling), while its
+    non-destructive reads stay callable."""
+    (tmp_path / "config.yml").write_text(
+        "claude_code:\n"
+        "  servers:\n"
+        "    my-archive:\n"
+        "      permissions:\n"
+        "        allow: [list_runs, delete_run, purge_all]\n"
+    )
+
+    result = read_only_disallowed_tools(tmp_path)
+
+    assert "mcp__my-archive__delete_run" in result
+    assert "mcp__my-archive__purge_all" in result
+    assert "mcp__my-archive__list_runs" not in result  # non-destructive read preserved
+
+
+def test_read_only_blocks_writes_check_custom_server_at_server_level(tmp_path: Path) -> None:
+    """A custom server that writes-check-gates ALL its tools is blocked
+    server-level (the per-tool ``mcp__name__.*`` matcher is a no-op in the SDK
+    disallow engine, so server-level is the only form that actually blocks)."""
+    (tmp_path / "config.yml").write_text(
+        "claude_code:\n"
+        "  servers:\n"
+        "    danger-server:\n"
+        "      hooks: {pre_tool_use: [writes_check]}\n"
+        "      permissions: {allow: [do_thing]}\n"
+    )
+
+    result = read_only_disallowed_tools(tmp_path)
+
+    assert "mcp__danger-server" in result
+
+
+def test_read_only_disabled_custom_server_not_enumerated(tmp_path: Path) -> None:
+    """A custom server explicitly disabled contributes no tools."""
+    (tmp_path / "config.yml").write_text(
+        "claude_code:\n"
+        "  servers:\n"
+        "    off-server:\n"
+        "      enabled: false\n"
+        "      permissions: {ask: [write_data]}\n"
+    )
+
+    result = read_only_disallowed_tools(tmp_path)
+
+    assert "mcp__off-server__write_data" not in result
+
+
+def test_no_destructive_permissions_allow_tool_is_reachable(tmp_path: Path) -> None:
+    """Drift guard: any tool a framework server auto-allows whose name implies
+    destruction (delete/remove/clear) must be in the read-only disallow set.
+    Catches a future destructive permissions_allow tool that the permissions_ask
+    + writes-check registry walk would silently miss."""
+    from osprey.registry.mcp import FRAMEWORK_SERVERS
+
+    result = set(read_only_disallowed_tools(tmp_path))
+    # Independent marker list (do not import the production constant, so this
+    # test fails loudly if that constant is narrowed).
+    destructive_markers = ("delete", "remove", "clear", "wipe", "purge", "destroy")
+    for server in FRAMEWORK_SERVERS.values():
+        for tool in (*server.permissions_allow, *server.fixed_allow):
+            if any(m in tool.lower() for m in destructive_markers):
+                name = f"mcp__{server.name}__{tool}"
+                assert name in result, (
+                    f"{name} is auto-allowed but its name implies destruction and "
+                    f"it is NOT blocked in the read-only path"
+                )
+
+
+def test_read_only_disallowed_tools_allows_audited_reads(tmp_path: Path) -> None:
+    """Approval-gated *reads* must stay callable — the read-only run still needs
+    to read PVs/archiver. Only writes/side-effects are blocked, not all
+    approval-gated tools."""
+    result = read_only_disallowed_tools(tmp_path)
+
+    assert "mcp__controls__channel_read" not in result
+    assert "mcp__controls__archiver_read" not in result
+
+
+def test_read_only_disallowed_covers_registry_side_effect_tools(tmp_path: Path) -> None:
+    """Drift guard: every framework-server permissions_ask tool and every
+    writes-check-gated matcher in the registry must appear in the read-only
+    disallow set. Adding a new approval-required tool to a server thus
+    auto-extends the read-only floor (or fails this test)."""
+    from osprey.registry.mcp import _WRITES_CHECK, FRAMEWORK_SERVERS
+
+    result = set(read_only_disallowed_tools(tmp_path))
+
+    for server in FRAMEWORK_SERVERS.values():
+        # Both ask lists render into the interactive approval list → side-effecting.
+        for tool in (*server.permissions_ask, *server.fixed_ask):
+            name = f"mcp__{server.name}__{tool}"
+            assert name in result, (
+                f"{name} is in {server.name}.permissions_ask/fixed_ask (side-effecting) "
+                f"but missing from read_only_disallowed_tools — read-only floor drifted"
+            )
+        for rule in server.hooks_pre:
+            if _WRITES_CHECK in rule.hooks:
+                assert rule.matcher in result, (
+                    f"{rule.matcher} is writes-check-gated but missing from "
+                    f"read_only_disallowed_tools"
+                )
+
+
+def test_python_server_registers_only_execute_tools_we_block(tmp_path: Path) -> None:
+    """Guard against a future unlisted python tool (the execute_file class of
+    bug): every tool the python executor server registers must be blocked,
+    since the whole server is exec-capable and has no read-only tools.
+
+    Introspects the FastMCP singleton directly (importing the tool modules
+    registers them) rather than running create_server(), which would do heavy
+    config/workspace startup.
+    """
+    import asyncio
+
+    from osprey.mcp_server.python_executor import server as py_server
+    from osprey.mcp_server.python_executor.tools import (  # noqa: F401 — registers tools
+        python_execute,
+        python_execute_file,
+    )
+
+    tools = asyncio.run(py_server.mcp._list_tools())
+    registered = {getattr(t, "name", t) for t in tools}
+    assert registered, "expected the python server to register at least one tool"
+
+    result = set(read_only_disallowed_tools(tmp_path))
+    for short in registered:
+        assert f"mcp__python__{short}" in result, (
+            f"python server registers {short!r} but mcp__python__{short} is not "
+            f"in the read-only disallow set — arbitrary-exec escape hatch"
+        )
+
+
+def test_builtin_unsafe_tools_cover_interactive_deny_defaults() -> None:
+    """Drift guard: every built-in (non-mcp) tool OSPREY denies interactively
+    (settings.json.j2 deny_defaults) must also be in the headless read-only
+    floor — the headless path must never be more permissive than interactive,
+    since its permission/deny layer is inert under bypassPermissions.
+    """
+    package_root = Path(osprey.__file__).parent
+    settings_j2 = package_root / "templates" / "claude_code" / "claude" / "settings.json.j2"
+    assert settings_j2.exists(), f"settings template not found: {settings_j2}"
+
+    source = settings_j2.read_text()
+    match = re.search(r"set\s+deny_defaults\s*=\s*(\[[^\]]*\])", source)
+    assert match, "deny_defaults list not found in settings.json.j2"
+    deny_defaults = ast.literal_eval(match.group(1))
+
+    # Built-in tools are the non-mcp__ entries (mcp__ entries are plugin/facility
+    # servers, absent from a built project's query path).
+    builtin_denies = [d for d in deny_defaults if not d.startswith("mcp__")]
+    assert builtin_denies, "expected at least one built-in tool in deny_defaults"
+    for tool in builtin_denies:
+        assert tool in _BUILTIN_UNSAFE_TOOLS, (
+            f"{tool!r} is denied interactively (settings.json.j2 deny_defaults) but "
+            f"missing from _BUILTIN_UNSAFE_TOOLS — the headless read-only floor would "
+            f"be more permissive than the interactive policy"
+        )

--- a/tests/cli/test_query_cmd.py
+++ b/tests/cli/test_query_cmd.py
@@ -1,0 +1,410 @@
+"""Unit tests for the ``osprey query`` CLI command.
+
+All tests use ``click.testing.CliRunner`` and mock out ``run_query`` (and its
+helpers) so no live model is invoked.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from osprey.agent_runner import (
+    EXIT_PASS,
+    EXIT_USAGE,
+    EXIT_VERDICT_FAIL,
+    SDKWorkflowResult,
+    ToolTrace,
+)
+from osprey.cli.query_cmd import query
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_result(
+    text_blocks: list[str] | None = None,
+    tool_traces: list[ToolTrace] | None = None,
+    mcp_servers: list[dict] | None = None,
+    is_error: bool = False,
+    subtype: str = "end_turn",
+) -> SDKWorkflowResult:
+    """Build a minimal SDKWorkflowResult for mocking."""
+    result_msg = MagicMock()
+    result_msg.is_error = is_error
+    result_msg.subtype = subtype
+
+    r = SDKWorkflowResult(
+        text_blocks=text_blocks or ["Agent response here."],
+        tool_traces=tool_traces or [],
+        mcp_servers=mcp_servers or [],
+    )
+    r.result = result_msg
+    return r
+
+
+def _connected_servers(*names: str) -> list[dict]:
+    """Return a mock MCP server snapshot with all *names* connected."""
+    return [{"name": n, "status": "connected", "tools": []} for n in names]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def project_with_mcp(tmp_path: Path) -> Path:
+    """Minimal valid project: .mcp.json declaring 'controls' + a config.yml.
+
+    ``config.yml`` is what ``_is_valid_project`` keys on; ``run_query`` is
+    mocked in these tests, so the file's contents are never parsed.
+    """
+    mcp_json = {"mcpServers": {"controls": {"command": "osprey-controls"}}}
+    (tmp_path / ".mcp.json").write_text(json.dumps(mcp_json))
+    (tmp_path / "config.yml").write_text("api:\n  providers: {}\n")
+    return tmp_path
+
+
+@pytest.fixture
+def project_no_mcp(tmp_path: Path) -> Path:
+    """Empty directory — not a valid OSPREY project (no config.yml)."""
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Missing-project detection
+# ---------------------------------------------------------------------------
+
+
+class TestMissingProject:
+    def test_empty_dir_exits_usage(self, runner: CliRunner, project_no_mcp: Path) -> None:
+        result = runner.invoke(query, ["--project", str(project_no_mcp), "hello"])
+        assert result.exit_code == EXIT_USAGE
+        assert "osprey build" in result.output.lower() or "--project" in result.output
+
+    def test_error_message_is_actionable(self, runner: CliRunner, project_no_mcp: Path) -> None:
+        result = runner.invoke(query, ["--project", str(project_no_mcp), "hello"])
+        # User must be told how to fix it
+        assert "osprey build" in result.output or "--project" in result.output
+
+    def test_mcp_json_only_without_config_exits_usage(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """A .mcp.json-only directory is NOT valid: the runner needs config.yml,
+        so it must fail fast with exit 2 rather than crash mid-resolution."""
+        (tmp_path / ".mcp.json").write_text('{"mcpServers": {}}')
+        result = runner.invoke(query, ["--project", str(tmp_path), "hello"])
+        assert result.exit_code == EXIT_USAGE
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_exit_zero_on_success(self, runner: CliRunner, project_with_mcp: Path) -> None:
+        mock_result = _make_result(
+            text_blocks=["The answer is 42."],
+            mcp_servers=_connected_servers("controls"),
+        )
+        with (
+            patch("osprey.cli.query_cmd.run_query", new=AsyncMock(return_value=mock_result)),
+            patch(
+                "osprey.cli.query_cmd.read_only_disallowed_tools",
+                return_value=["mcp__controls__channel_write"],
+            ),
+            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value={"controls"}),
+        ):
+            result = runner.invoke(query, ["--project", str(project_with_mcp), "What is 6*7?"])
+        assert result.exit_code == EXIT_PASS
+
+    def test_prints_final_text(self, runner: CliRunner, project_with_mcp: Path) -> None:
+        mock_result = _make_result(
+            text_blocks=["The answer is 42."],
+            mcp_servers=_connected_servers("controls"),
+        )
+        with (
+            patch("osprey.cli.query_cmd.run_query", new=AsyncMock(return_value=mock_result)),
+            patch(
+                "osprey.cli.query_cmd.read_only_disallowed_tools",
+                return_value=["mcp__controls__channel_write"],
+            ),
+            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value={"controls"}),
+        ):
+            result = runner.invoke(query, ["--project", str(project_with_mcp), "What is 6*7?"])
+        assert "The answer is 42." in result.output
+
+
+# ---------------------------------------------------------------------------
+# Verdict failure (exit 1)
+# ---------------------------------------------------------------------------
+
+
+class TestVerdictFailure:
+    def test_missing_server_exits_one(self, runner: CliRunner, project_with_mcp: Path) -> None:
+        # controls server is expected but not in the snapshot
+        mock_result = _make_result(
+            text_blocks=["No controls server found."],
+            mcp_servers=[],  # empty — controls not connected
+        )
+        with (
+            patch("osprey.cli.query_cmd.run_query", new=AsyncMock(return_value=mock_result)),
+            patch(
+                "osprey.cli.query_cmd.read_only_disallowed_tools",
+                return_value=["mcp__controls__channel_write"],
+            ),
+            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value={"controls"}),
+        ):
+            result = runner.invoke(query, ["--project", str(project_with_mcp), "ping"])
+        assert result.exit_code == EXIT_VERDICT_FAIL
+
+
+# ---------------------------------------------------------------------------
+# Safety: disallowed_tools must always include channel_write
+# ---------------------------------------------------------------------------
+
+
+class TestWriteToolSafety:
+    def test_disallowed_tools_cover_mcp_and_builtin_writes(
+        self, runner: CliRunner, project_with_mcp: Path
+    ) -> None:
+        """The disallowed_tools passed to run_query must block BOTH the MCP write
+        tools and the built-in write/exec tools (Bash/Write/Edit).
+
+        Under bypassPermissions disallowed_tools is the sole write guard, so a
+        gap here means the agent could write hardware via Bash. read_only_
+        disallowed_tools is NOT mocked — this verifies the real union reaches
+        run_query.
+        """
+        mock_result = _make_result(mcp_servers=_connected_servers("controls"))
+        captured: list[list[str]] = []
+
+        async def capturing_run_query(project_dir, prompt, *, disallowed_tools, **kwargs):
+            captured.append(list(disallowed_tools))
+            return mock_result
+
+        with (
+            patch("osprey.cli.query_cmd.run_query", side_effect=capturing_run_query),
+            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value={"controls"}),
+        ):
+            runner.invoke(query, ["--project", str(project_with_mcp), "safe query"])
+
+        assert captured, "run_query was never called"
+        disallowed = captured[0]
+        # MCP write tools (fail-closed fallback, no hook_config.json in fixture)
+        assert "mcp__controls__channel_write" in disallowed
+        assert "mcp__python__execute" in disallowed
+        # Built-in write/exec/network tools — the escape hatch this guards
+        for builtin in ("Bash", "Write", "Edit", "WebFetch", "WebSearch"):
+            assert builtin in disallowed, f"{builtin} must be in disallowed_tools"
+
+
+# ---------------------------------------------------------------------------
+# JSON output
+# ---------------------------------------------------------------------------
+
+
+class TestJsonOutput:
+    def test_json_flag_parses(self, runner: CliRunner, project_with_mcp: Path) -> None:
+        trace = ToolTrace(
+            name="mcp__controls__read_pv",
+            input={"pv": "BEAM:CURRENT"},
+            result="42 mA",
+            is_error=False,
+        )
+        mock_result = _make_result(
+            text_blocks=["Beam current is 42 mA."],
+            tool_traces=[trace],
+            mcp_servers=_connected_servers("controls"),
+        )
+        with (
+            patch("osprey.cli.query_cmd.run_query", new=AsyncMock(return_value=mock_result)),
+            patch(
+                "osprey.cli.query_cmd.read_only_disallowed_tools",
+                return_value=["mcp__controls__channel_write"],
+            ),
+            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value={"controls"}),
+        ):
+            result = runner.invoke(
+                query, ["--project", str(project_with_mcp), "--json", "beam current"]
+            )
+
+        assert result.exit_code == EXIT_PASS
+        data = json.loads(result.output)
+        assert "final_text" in data
+        assert "tool_traces" in data
+        assert "mcp_servers" in data
+        assert "exit_code" in data
+
+    def test_json_final_text_content(self, runner: CliRunner, project_with_mcp: Path) -> None:
+        mock_result = _make_result(
+            text_blocks=["Beam current is 42 mA."],
+            mcp_servers=_connected_servers("controls"),
+        )
+        with (
+            patch("osprey.cli.query_cmd.run_query", new=AsyncMock(return_value=mock_result)),
+            patch(
+                "osprey.cli.query_cmd.read_only_disallowed_tools",
+                return_value=["mcp__controls__channel_write"],
+            ),
+            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value={"controls"}),
+        ):
+            result = runner.invoke(
+                query, ["--project", str(project_with_mcp), "--json", "beam current"]
+            )
+
+        data = json.loads(result.output)
+        assert "Beam current is 42 mA." in data["final_text"]
+
+    def test_json_tool_traces_schema(self, runner: CliRunner, project_with_mcp: Path) -> None:
+        trace = ToolTrace(
+            name="mcp__controls__read_pv", input={"pv": "X"}, result="1", is_error=False
+        )
+        mock_result = _make_result(
+            tool_traces=[trace],
+            mcp_servers=_connected_servers("controls"),
+        )
+        with (
+            patch("osprey.cli.query_cmd.run_query", new=AsyncMock(return_value=mock_result)),
+            patch(
+                "osprey.cli.query_cmd.read_only_disallowed_tools",
+                return_value=["mcp__controls__channel_write"],
+            ),
+            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value={"controls"}),
+        ):
+            result = runner.invoke(query, ["--project", str(project_with_mcp), "--json", "q"])
+
+        data = json.loads(result.output)
+        assert len(data["tool_traces"]) == 1
+        t = data["tool_traces"][0]
+        assert set(t.keys()) >= {"name", "input", "result", "is_error"}
+
+    def test_json_emits_valid_payload_on_verdict_failure(
+        self, runner: CliRunner, project_with_mcp: Path
+    ) -> None:
+        """--json must still emit a parseable object on verdict failure, with
+        both the process exit code and the embedded exit_code == 1."""
+        mock_result = _make_result(
+            text_blocks=["No controls server found."],
+            mcp_servers=[],  # controls expected but absent → verdict fail
+        )
+        with (
+            patch("osprey.cli.query_cmd.run_query", new=AsyncMock(return_value=mock_result)),
+            patch(
+                "osprey.cli.query_cmd.read_only_disallowed_tools",
+                return_value=["mcp__controls__channel_write"],
+            ),
+            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value={"controls"}),
+        ):
+            result = runner.invoke(query, ["--project", str(project_with_mcp), "--json", "ping"])
+
+        assert result.exit_code == EXIT_VERDICT_FAIL
+        data = json.loads(result.output)
+        assert data["exit_code"] == EXIT_VERDICT_FAIL
+
+
+# ---------------------------------------------------------------------------
+# Infrastructure / usage errors map to exit code 2
+# ---------------------------------------------------------------------------
+
+
+class TestInfraErrors:
+    def test_import_error_exits_usage(self, runner: CliRunner, project_with_mcp: Path) -> None:
+        with (
+            patch(
+                "osprey.cli.query_cmd.run_query",
+                side_effect=ImportError("claude_agent_sdk not installed"),
+            ),
+            patch(
+                "osprey.cli.query_cmd.read_only_disallowed_tools",
+                return_value=["mcp__controls__channel_write"],
+            ),
+            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value=set()),
+        ):
+            result = runner.invoke(query, ["--project", str(project_with_mcp), "hello"])
+        assert result.exit_code == EXIT_USAGE
+
+    def test_runtime_error_exits_usage(self, runner: CliRunner, project_with_mcp: Path) -> None:
+        with (
+            patch(
+                "osprey.cli.query_cmd.run_query",
+                side_effect=RuntimeError("provider not configured"),
+            ),
+            patch(
+                "osprey.cli.query_cmd.read_only_disallowed_tools",
+                return_value=["mcp__controls__channel_write"],
+            ),
+            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value=set()),
+        ):
+            result = runner.invoke(query, ["--project", str(project_with_mcp), "hello"])
+        assert result.exit_code == EXIT_USAGE
+
+    def test_os_error_exits_usage(self, runner: CliRunner, project_with_mcp: Path) -> None:
+        """A config-read failure (e.g. missing config.yml deep in resolution)
+        surfaces as a usage error (exit 2), not an uncaught traceback."""
+        with (
+            patch(
+                "osprey.cli.query_cmd.run_query",
+                side_effect=FileNotFoundError("config.yml"),
+            ),
+            patch(
+                "osprey.cli.query_cmd.read_only_disallowed_tools",
+                return_value=["mcp__controls__channel_write"],
+            ),
+            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value=set()),
+        ):
+            result = runner.invoke(query, ["--project", str(project_with_mcp), "hello"])
+        assert result.exit_code == EXIT_USAGE
+        assert "configuration" in result.output.lower()
+
+    def test_malformed_yaml_exits_usage(self, runner: CliRunner, project_with_mcp: Path) -> None:
+        """A malformed config.yml (yaml.YAMLError) maps to exit 2."""
+        import yaml
+
+        with (
+            patch(
+                "osprey.cli.query_cmd.run_query",
+                side_effect=yaml.YAMLError("could not parse config.yml"),
+            ),
+            patch(
+                "osprey.cli.query_cmd.read_only_disallowed_tools",
+                return_value=["mcp__controls__channel_write"],
+            ),
+            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value=set()),
+        ):
+            result = runner.invoke(query, ["--project", str(project_with_mcp), "hello"])
+        assert result.exit_code == EXIT_USAGE
+
+    def test_unknown_provider_value_error_exits_usage(
+        self, runner: CliRunner, project_with_mcp: Path
+    ) -> None:
+        """An unknown/misspelled provider (resolver raises ValueError) maps to
+        exit 2, and the resolver's actionable message reaches the user."""
+        with (
+            patch(
+                "osprey.cli.query_cmd.run_query",
+                side_effect=ValueError(
+                    "Unknown Claude Code provider 'typo'. Built-in providers: als-apg, anthropic"
+                ),
+            ),
+            patch(
+                "osprey.cli.query_cmd.read_only_disallowed_tools",
+                return_value=["mcp__controls__channel_write"],
+            ),
+            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value=set()),
+        ):
+            result = runner.invoke(query, ["--project", str(project_with_mcp), "hello"])
+        assert result.exit_code == EXIT_USAGE
+        assert "Built-in providers" in result.output

--- a/tests/e2e/sdk_helpers.py
+++ b/tests/e2e/sdk_helpers.py
@@ -8,12 +8,10 @@ Extracted from test_claude_code_sdk_e2e.py to avoid circular imports.
 
 from __future__ import annotations
 
-import asyncio
 import json
 import os
 import subprocess
 import sys
-import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -52,6 +50,30 @@ try:
 except ImportError:
     HAS_SUBAGENT_READERS = False
 
+
+# ---------------------------------------------------------------------------
+# Shared primitives — imported from the production package so there is a
+# single source of truth; sdk_helpers re-exports them so test modules that
+# import from here continue to work unchanged.
+# ---------------------------------------------------------------------------
+from osprey.agent_runner import (
+    SDKWorkflowResult,
+    ToolTrace,
+    _await_mcp_ready,
+    _expected_mcp_servers,
+    resolve_default_model,
+    sdk_env,
+)
+from osprey.agent_runner import (
+    combined_text as combined_text,  # re-exported for other e2e test modules
+)
+from osprey.agent_runner.primitives import (
+    _ingest_tool_result,
+    _resolve_project_spec,
+)
+from osprey.agent_runner.primitives import (
+    provider_env_for_project as provider_env_for_project,  # re-exported for e2e tests
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -301,112 +323,6 @@ def activate_scenarios(project_dir: Path, *names: str, now=None):
     return apply_scenarios(project_dir, list(names), seed_logbook=True, now=now)
 
 
-def _resolve_project_spec(project_dir: Path):
-    """Return the project's ``ClaudeCodeModelSpec`` or ``None`` when the
-    project's ``config.yml`` has no ``claude_code`` block.
-
-    Reads ``config.yml`` and runs the same resolver ``osprey claude chat``
-    uses, so test routing matches production exactly. Unlike the earlier
-    bare-``except`` version, this surfaces any unexpected error (missing
-    ``config.yml``, YAML parse failure, resolver import failure) rather
-    than masking it as ``None``.
-    """
-    import yaml
-
-    from osprey.cli.claude_code_resolver import ClaudeCodeModelResolver
-
-    cfg = yaml.safe_load((project_dir / "config.yml").read_text()) or {}
-    spec = ClaudeCodeModelResolver.resolve(
-        cfg.get("claude_code", {}),
-        cfg.get("api", {}).get("providers", {}),
-    )
-    return _apply_e2e_overrides(spec)
-
-
-def _apply_e2e_overrides(spec):
-    """Apply suite-wide CBORG model-matrix overrides to a resolved spec (#259).
-
-    This is the single chokepoint every routing consumer goes through
-    (``provider_env_for_project``, ``_default_haiku_model``,
-    ``_default_opus_model``, and ``run_sdk_query``'s default model), so
-    forcing the spec here keeps the build env, the SDK ``model=`` argument,
-    and the proxy base URL mutually consistent.
-
-    * ``OSPREY_E2E_FORCE_MODEL`` — collapse every tier onto one model id and
-      rewrite the tier-model env vars to match.
-    * ``OSPREY_E2E_PROXY_BASE_URL`` — point ``ANTHROPIC_BASE_URL`` at the
-      in-process translation proxy (set by the session fixture in
-      tests/e2e/conftest.py for OpenAI-protocol / open models). Anthropic-
-      protocol CBORG models (``claude-*``) leave this unset and route direct.
-
-    Inert (returns the spec unchanged) when neither var is set, so normal
-    e2e runs are unaffected.
-    """
-    if spec is None:
-        return None
-    force_model = os.environ.get("OSPREY_E2E_FORCE_MODEL")
-    proxy_base = os.environ.get("OSPREY_E2E_PROXY_BASE_URL")
-    if not force_model and not proxy_base:
-        return spec
-
-    import dataclasses
-
-    tier_to_model = dict(spec.tier_to_model)
-    env_block = dict(spec.env_block)
-    if force_model:
-        for tier in tier_to_model:
-            tier_to_model[tier] = force_model
-        for key in (
-            "ANTHROPIC_MODEL",
-            "ANTHROPIC_DEFAULT_HAIKU_MODEL",
-            "ANTHROPIC_DEFAULT_SONNET_MODEL",
-            "ANTHROPIC_DEFAULT_OPUS_MODEL",
-        ):
-            if key in env_block:
-                env_block[key] = force_model
-    if proxy_base:
-        env_block["ANTHROPIC_BASE_URL"] = proxy_base
-    return dataclasses.replace(spec, tier_to_model=tier_to_model, env_block=env_block)
-
-
-def provider_env_for_project(project_dir: Path) -> dict[str, str]:
-    """Resolve provider env vars so the SDK routes to the project's provider.
-
-    Without this, the bundled Claude CLI defaults to ``api.anthropic.com``
-    using whatever ambient ``ANTHROPIC_API_KEY`` happens to be set — which
-    is the wrong endpoint for cborg/als-apg projects and 404s on model
-    aliases like ``anthropic/claude-haiku``.
-
-    Returns the spec's ``env_block`` (``ANTHROPIC_BASE_URL``,
-    ``ANTHROPIC_DEFAULT_*_MODEL``, ...) plus the auth var populated from
-    the configured shell secret. Raises ``RuntimeError`` if the project
-    has no resolvable provider — silently falling back to ``{}`` would
-    let the test subprocess inherit ambient env, which is the exact
-    local-vs-CI divergence we are trying to eliminate.
-    """
-    spec = _resolve_project_spec(project_dir)
-    if spec is None:
-        raise RuntimeError(
-            f"Project at {project_dir} has no resolvable provider in "
-            "config.yml — pass provider=<als-apg|cborg|anthropic|amsc-i2|argo> "
-            "to init_project()."
-        )
-    env: dict[str, str] = dict(spec.env_block)
-    if spec.auth_secret_env and spec.auth_env_var:
-        secret = os.environ.get(spec.auth_secret_env)
-        if secret:
-            env[spec.auth_env_var] = secret
-    return env
-
-
-def _default_haiku_model(project_dir: Path) -> str:
-    """Resolve the project's haiku-tier model name."""
-    spec = _resolve_project_spec(project_dir)
-    if spec is not None:
-        return spec.tier_to_model.get("haiku", "claude-haiku-4-5-20251001")
-    return "claude-haiku-4-5-20251001"
-
-
 def _default_opus_model(project_dir: Path) -> str:
     """Resolve the project's opus-tier model name.
 
@@ -418,30 +334,6 @@ def _default_opus_model(project_dir: Path) -> str:
     if spec is not None:
         return spec.tier_to_model.get("opus", "claude-opus-4-7")
     return "claude-opus-4-7"
-
-
-def sdk_env(project_dir: Path | None = None) -> dict[str, str]:
-    """Return env overrides for the SDK subprocess.
-
-    Always sets ``CLAUDECODE=""`` to bypass the nested-session guard
-    (JavaScript treats "" as falsy). When ``project_dir`` is provided,
-    also injects the project's resolved provider env block so the bundled
-    CLI talks to the configured provider (cborg, als-apg, anthropic-direct)
-    instead of falling through to ``api.anthropic.com``.
-    """
-    env = {"CLAUDECODE": ""}
-    if project_dir is not None:
-        env.update(provider_env_for_project(project_dir))
-    return env
-
-
-def combined_text(result: SDKWorkflowResult) -> str:
-    """Combine all text blocks and tool results into a single searchable string."""
-    parts = list(result.text_blocks)
-    for trace in result.tool_traces:
-        if trace.result:
-            parts.append(trace.result)
-    return " ".join(parts).lower()
 
 
 def find_png_files(root: Path) -> list[Path]:
@@ -470,179 +362,8 @@ def read_audit_events(project_dir: Path) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
-# Tool trace dataclass
+# MCP sidecar + core runner support helpers
 # ---------------------------------------------------------------------------
-
-
-@dataclass
-class ToolTrace:
-    """Lightweight record of a single tool call for observability."""
-
-    name: str
-    input: dict
-    result: str | None = None
-    is_error: bool = False
-    tool_use_id: str | None = None
-    parent_tool_use_id: str | None = None
-
-
-@dataclass
-class SDKWorkflowResult:
-    """Aggregated result from an SDK query run."""
-
-    tool_traces: list[ToolTrace] = field(default_factory=list)
-    text_blocks: list[str] = field(default_factory=list)
-    system_messages: list[SystemMessage] = field(default_factory=list)
-    result: ResultMessage | None = None
-    # Authoritative MCP server snapshot from ``ClaudeSDKClient.get_mcp_status()``
-    # captured just before the prompt is sent (see ``_await_mcp_ready``). Each entry
-    # is the raw ``McpServerStatus`` dict: {name, status, tools, ...}. Empty when the
-    # runner used the one-shot ``query()`` path with no client to poll. This is the
-    # ground-truth infra-vs-model discriminator: a failure where the expected tool is
-    # absent here is INFRA (server never registered); present-but-unused is MODEL.
-    mcp_servers: list[dict[str, Any]] = field(default_factory=list)
-
-    @property
-    def tool_names(self) -> list[str]:
-        """Ordered list of tool names that were called."""
-        return [t.name for t in self.tool_traces]
-
-    @property
-    def mcp_server_status(self) -> dict[str, str]:
-        """``{'controls': 'connected', 'python': 'connected', ...}`` from the
-        captured ``get_mcp_status()`` snapshot. Empty if no snapshot was taken."""
-        return {s.get("name", "?"): s.get("status", "unknown") for s in self.mcp_servers}
-
-    @property
-    def registered_tools(self) -> list[str]:
-        """Flattened ``mcp__<server>__<tool>`` names that the MCP handshake exposed.
-
-        Built from the captured snapshot, so it reflects what the model could
-        actually call — not what it chose to call (that is ``tool_names``)."""
-        out: list[str] = []
-        for s in self.mcp_servers:
-            server = s.get("name", "")
-            for t in s.get("tools", []) or []:
-                tname = t.get("name") if isinstance(t, dict) else t
-                if tname:
-                    out.append(f"mcp__{server}__{tname}")
-        return out
-
-    def tool_was_registered(self, tool: str) -> bool | None:
-        """Was *tool* (e.g. ``mcp__controls__channel_write``) exposed by the MCP
-        handshake? ``None`` if no snapshot is available (cannot tell)."""
-        if not self.mcp_servers:
-            return None
-        return tool in self.registered_tools
-
-    @property
-    def repeated_tool_calls(self) -> dict[str, int]:
-        """``{'<tool>::<input-digest>': count}`` for any call issued more than
-        once. A high count on a delegation tool is the fingerprint of a
-        non-convergence loop."""
-        from collections import Counter
-
-        keys = [
-            f"{t.name}::{json.dumps(t.input, sort_keys=True, default=str)}"
-            for t in self.tool_traces
-        ]
-        return {k: n for k, n in Counter(keys).items() if n > 1}
-
-    @property
-    def has_redelegation_loop(self) -> bool:
-        """True if a subagent-spawning tool (``Agent``/``Task*``) was re-issued
-        with identical input 3+ times — model non-convergence (a MODEL timeout),
-        distinct from slow-but-progressing proxy latency (INFRA). Lets a
-        ``resource_timeout`` failure be bucketed from the recorded artifact
-        instead of guessed."""
-        for key, n in self.repeated_tool_calls.items():
-            name = key.split("::", 1)[0]
-            if n >= 3 and (name == "Agent" or name.startswith("Task")):
-                return True
-        return False
-
-    @property
-    def cost_usd(self) -> float | None:
-        """Total cost from the ResultMessage."""
-        return self.result.total_cost_usd if self.result else None
-
-    @property
-    def num_turns(self) -> int | None:
-        """Number of agentic turns from the ResultMessage."""
-        return self.result.num_turns if self.result else None
-
-    def tools_matching(self, substring: str) -> list[ToolTrace]:
-        """Return all tool traces whose name contains *substring*."""
-        return [t for t in self.tool_traces if substring in t.name]
-
-
-# ---------------------------------------------------------------------------
-# MCP readiness barrier + instrumentation
-# ---------------------------------------------------------------------------
-#
-# OSPREY MCP servers register ASYNCHRONOUSLY: the controls stdio subprocess does
-# heavyweight cold-start work (config prime, connector registration, tool-module
-# imports) and only finishes its MCP handshake ~1–1.5s after the CLI launches —
-# noticeably slower than the python/osprey_workspace servers. If the agent's first
-# turn fires before that handshake completes, the controls tools are simply not in
-# its toolset, and a less-persistent agent reports "no controls server connected"
-# and gives up. That is a cold-start race, NOT a model capability gap — yet it is
-# scored as a failure, and it cannot be distinguished from a genuine model give-up
-# from the persisted transcript (which does not record MCP status).
-#
-# Both problems are solved with the SDK's own ``ClaudeSDKClient.get_mcp_status()``:
-#   * READINESS — poll it until the expected servers are ``connected`` before sending
-#     the prompt, so every agent gets a ready toolset (the harness-enforced equivalent
-#     of the CLI's ``WaitForMcpServers`` tool, independent of whether the model thinks
-#     to call it).
-#   * INSTRUMENTATION — persist the final snapshot so a missing tool is provably INFRA
-#     (server never registered) vs MODEL (tool was there, agent ignored it).
-
-# The default ceiling generously covers the measured ~1.5s controls cold start with
-# headroom for a loaded box. Overridable via env for slow CI hosts.
-_MCP_READY_TIMEOUT_S = float(os.environ.get("OSPREY_E2E_MCP_READY_TIMEOUT", "20"))
-_MCP_READY_POLL_S = 0.3
-
-
-def _expected_mcp_servers(project_dir: Path) -> set[str]:
-    """The MCP server names a project declares in ``.mcp.json`` — the set the
-    readiness barrier waits for. Returns an empty set if the file is unreadable."""
-    try:
-        cfg = json.loads((project_dir / ".mcp.json").read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return set()
-    return set(cfg.get("mcpServers", {}).keys())
-
-
-async def _await_mcp_ready(
-    client: ClaudeSDKClient,
-    expected: set[str],
-    *,
-    timeout_s: float = _MCP_READY_TIMEOUT_S,
-    poll_s: float = _MCP_READY_POLL_S,
-) -> list[dict[str, Any]]:
-    """Poll ``get_mcp_status()`` until every server in *expected* reports
-    ``connected`` (or *timeout_s* elapses), then return the final snapshot.
-
-    Resilient to ``get_mcp_status()`` raising early in startup (before the stream
-    is live). Never raises: on timeout it returns the last snapshot seen so the
-    caller can record a genuine registration failure rather than masking it.
-    """
-    deadline = time.monotonic() + timeout_s
-    servers: list[dict[str, Any]] = []
-    while True:
-        try:
-            status = await client.get_mcp_status()
-            servers = status.get("mcpServers", []) if isinstance(status, dict) else (status or [])
-        except Exception:  # noqa: BLE001 — status not queryable yet; keep polling
-            servers = servers or []
-        if expected:
-            connected = {s.get("name") for s in servers if s.get("status") == "connected"}
-            if expected <= connected:
-                return servers
-        if time.monotonic() >= deadline:
-            return servers
-        await asyncio.sleep(poll_s)
 
 
 def _persist_mcp_sidecar(workflow: SDKWorkflowResult, project_dir: Path) -> None:
@@ -667,32 +388,6 @@ def _persist_mcp_sidecar(workflow: SDKWorkflowResult, project_dir: Path) -> None
         (out_dir / "mcp_status.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
     except OSError:
         pass  # instrumentation must never fail a test
-
-
-# ---------------------------------------------------------------------------
-# Core SDK runner
-# ---------------------------------------------------------------------------
-
-
-def _ingest_tool_result(block: ToolResultBlock, pending_tools: dict[str, ToolTrace]) -> None:
-    """Match a ToolResultBlock to its pending ToolTrace and populate result/is_error.
-
-    ToolResultBlocks arrive in ``UserMessage.content`` (per Anthropic API contract:
-    tool_use is assistant output, tool_result is user input back to the model).
-    They may also appear in ``AssistantMessage`` when the SDK forwards them.
-    """
-    matched = pending_tools.get(block.tool_use_id)
-    if matched is None:
-        return
-    if isinstance(block.content, str):
-        matched.result = block.content
-    elif isinstance(block.content, list):
-        texts = []
-        for item in block.content:
-            if isinstance(item, dict) and item.get("type") == "text":
-                texts.append(item.get("text", ""))
-        matched.result = "\n".join(texts) if texts else str(block.content)
-    matched.is_error = bool(block.is_error)
 
 
 def _result_text(content: Any) -> str:
@@ -796,6 +491,11 @@ def e2e_budget_scale() -> float:
     return scale if scale > 0 else 1.0
 
 
+# ---------------------------------------------------------------------------
+# Core SDK runner
+# ---------------------------------------------------------------------------
+
+
 async def run_sdk_query(
     project_dir: Path,
     prompt: str,
@@ -829,7 +529,7 @@ async def run_sdk_query(
     stderr_lines: list[str] = []
 
     options = ClaudeAgentOptions(
-        model=model if model is not None else _default_haiku_model(project_dir),
+        model=model if model is not None else resolve_default_model(project_dir),
         cwd=str(project_dir),
         permission_mode="bypassPermissions",
         max_turns=max_turns,
@@ -988,7 +688,7 @@ async def run_sdk_query_with_hooks(
             return PermissionResultDeny(message="Denied by test approval policy")
 
     options = ClaudeAgentOptions(
-        model=model if model is not None else _default_haiku_model(project_dir),
+        model=model if model is not None else resolve_default_model(project_dir),
         cwd=str(project_dir),
         permission_mode="default",
         max_turns=max_turns,

--- a/tests/e2e/test_query_cmd_e2e.py
+++ b/tests/e2e/test_query_cmd_e2e.py
@@ -1,0 +1,124 @@
+"""E2E tests for the ``osprey query`` CLI command.
+
+Exercises the *shipped* command path end-to-end.
+
+Template: ``hello_world`` — the minimal preset with one mock ``controls``
+server and an ``example`` channel.  It is self-contained (no ARIEL Postgres,
+no real EPICS hardware) and resolves exit 0 in this environment.  The
+``control_assistant`` preset was considered but skipped: it declares additional
+MCP servers (channel-finder, ARIEL) that require running infrastructure absent
+here.
+
+Two tests, two harnesses
+------------------------
+``test_query_cmd_default_output`` uses ``click.testing.CliRunner`` for the
+plain-text code path.  This exercises the Click entry point directly.
+
+``test_query_cmd_json_mcp_connected`` uses ``subprocess.run`` for the
+``--json`` path.  Rationale: CliRunner's BytesIO stdout capture and
+``sys.exit()`` interact unexpectedly when ``asyncio.run()`` is called inside
+the command — the output buffer is empty even though exit_code=0.  The plain
+subprocess path (same mechanism ``init_project`` uses) avoids this issue and
+is more accurately "end-to-end" for the JSON assertion.
+
+Note on stdout mixing: the SDK logs "Using bundled Claude Code CLI: ..." to
+stdout (via Rich) before the JSON payload.  We extract the JSON by finding the
+first ``{`` in stdout rather than parsing the full output string.
+
+Mechanism-based verdict
+-----------------------
+Exit 0 requires ALL declared MCP servers to connect and the agent to finish
+without error.  Prompts are operator-style (no inlined channel addresses or
+"if any" hedges) — the tests assert mechanism, not specific tool calls.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from osprey.cli.query_cmd import query
+from tests.e2e.sdk_helpers import HAS_SDK, init_project, is_claude_code_available
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.requires_als_apg,
+    pytest.mark.skipif(not HAS_SDK, reason="claude_agent_sdk not installed"),
+    pytest.mark.skipif(not is_claude_code_available(), reason="claude CLI not available"),
+]
+
+
+@pytest.mark.flaky(reruns=2)
+def test_query_cmd_default_output(tmp_path: Path) -> None:
+    """``osprey query`` prints a non-empty answer and exits 0.
+
+    Uses the hello_world preset (mock controls, no external infra).
+    Exercises the CliRunner path for the plain-text output code branch.
+    """
+    project = init_project(tmp_path, "hw_query", template="hello_world", provider="als-apg")
+    runner = CliRunner()
+    result = runner.invoke(
+        query,
+        ["--project", str(project), "What channels are available on the controls MCP server?"],
+    )
+    assert result.exit_code == 0, (
+        f"osprey query exited {result.exit_code}.\n"
+        f"Output: {result.output!r}\n"
+        f"Exception: {result.exception!r}"
+    )
+    assert result.output.strip(), "Expected non-empty printed answer from osprey query"
+
+
+@pytest.mark.flaky(reruns=2)
+def test_query_cmd_json_mcp_connected(tmp_path: Path) -> None:
+    """``osprey query --json`` reports the controls MCP server as connected.
+
+    Uses subprocess (same pattern as ``init_project``) rather than CliRunner:
+    CliRunner + asyncio.run() + sys.exit() does not flush output into the
+    BytesIO buffer reliably for the ``--json`` code path.
+
+    The SDK logs "Using bundled Claude Code CLI: ..." to stdout (via Rich)
+    before emitting the JSON payload.  JSON is extracted by finding the first
+    ``{`` in stdout rather than parsing the full output string.
+
+    Asserts ``mcp_servers.controls == "connected"`` — the mechanism contract
+    proving all declared servers were online before the agent ran.
+    """
+    project = init_project(tmp_path, "hw_query_json", template="hello_world", provider="als-apg")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "osprey.cli.main",
+            "query",
+            "--project",
+            str(project),
+            "--json",
+            "Read the current value of the example channel and report it.",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert result.returncode == 0, (
+        f"osprey query --json exited {result.returncode}.\n"
+        f"stdout: {result.stdout!r}\n"
+        f"stderr: {result.stderr!r}"
+    )
+    # Strip the SDK's Rich-formatted logging preamble that goes to stdout
+    # before the JSON payload (the `{` always opens on its own line).
+    json_start = result.stdout.find("{")
+    assert json_start != -1, f"No JSON object found in stdout.\nstdout: {result.stdout!r}"
+    payload = json.loads(result.stdout[json_start:])
+    assert payload["mcp_servers"].get("controls") == "connected", (
+        f"Expected controls server to be connected. mcp_servers: {payload['mcp_servers']}"
+    )
+    assert payload["exit_code"] == 0, (
+        f"JSON payload exit_code should be 0, got {payload['exit_code']}"
+    )
+    assert payload["final_text"].strip(), "Expected non-empty final_text in JSON payload"

--- a/tests/e2e/test_query_write_refused_e2e.py
+++ b/tests/e2e/test_query_write_refused_e2e.py
@@ -1,0 +1,147 @@
+"""E2E safety test: ``osprey query`` refuses hardware writes.
+
+Proves the read-only guarantee at the SDK layer: ``mcp__controls__channel_write``
+never appears in a query run's tool trace, regardless of the
+``control_system.writes_enabled`` kill-switch setting.
+
+The load-bearing case is ``writes_enabled=True``: the application-level
+kill-switch hook would *permit* the write, yet the SDK-level
+``disallowed_tools`` list (sourced from ``hook_config.json`` via
+``load_write_tools``) removes the tool from the model's toolset entirely, so
+it can never execute. The ``writes_enabled=False`` case is a non-regression
+guard — with the same ``disallowed_tools`` block in force, the outcome must be
+identically clean. Parametrizing both pins read-only as independent of the
+kill switch. (Note: because ``disallowed_tools`` strips the tool regardless of
+``writes_enabled``, neither branch exercises the ``PreToolUse`` hook path —
+that hook is covered by the dedicated kill-switch tests, not here.)
+
+Do NOT mark this test flaky.  Safety contracts must stay strict.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from osprey.agent_runner.write_tools import read_only_disallowed_tools
+from osprey.cli.query_cmd import query
+from tests.e2e.sdk_helpers import (
+    HAS_SDK,
+    enable_writes_in_project,
+    init_project,
+    is_claude_code_available,
+)
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.requires_als_apg,
+    pytest.mark.skipif(not HAS_SDK, reason="claude_agent_sdk not installed"),
+    pytest.mark.skipif(not is_claude_code_available(), reason="claude CLI not available"),
+]
+
+# Directive prompt: explicit tool name so the agent commits to the write path
+# on its first turn rather than dithering with reads or refusals.
+_WRITE_PROMPT = (
+    "Use the mcp__controls__channel_write tool to write the value 1.5 to the channel 'example'."
+)
+
+
+@pytest.mark.parametrize("writes_enabled", [False, True])
+def test_query_refuses_write(tmp_path: Path, writes_enabled: bool) -> None:
+    """``osprey query`` never executes ``channel_write``, regardless of the kill switch.
+
+    Preset used: ``hello_world`` (has the ``controls`` mock server with both
+    ``channel_read`` and ``channel_write``; defaults to ``writes_enabled=False``).
+
+    Guard 1 — disallowed_tools set contains the write tool at the SDK layer
+    (structural: passes even before a live run).
+
+    Guard 2 — a directive prompt explicitly naming ``mcp__controls__channel_write``
+    produces no tool-trace entry for that tool (behavioural: the SDK-level block
+    holds against a model that has been told exactly what to call).
+    """
+    project = init_project(
+        tmp_path,
+        f"w_{writes_enabled}",
+        template="hello_world",
+        provider="als-apg",
+    )
+    if writes_enabled:
+        enable_writes_in_project(project)
+
+    # Guard 1: channel_write must be in the SDK-level disallowed set.
+    assert "mcp__controls__channel_write" in read_only_disallowed_tools(project)
+
+    # Guard 2: a directive write prompt must not produce a channel_write tool trace.
+    runner = CliRunner()
+    res = runner.invoke(
+        query,
+        ["--project", str(project), "--json", _WRITE_PROMPT],
+        catch_exceptions=False,
+    )
+    output = res.output.strip()
+    assert output, (
+        f"No output from osprey query (exit {res.exit_code}). "
+        "The command may have error-exited before printing JSON."
+    )
+    # Locate the JSON object in the output.  In Click 8.3 CliRunner captures
+    # stdout and stderr together, so log lines may precede the JSON payload.
+    # Use raw_decode to find and parse from the first '{' without requiring
+    # the entire string to be valid JSON.
+    json_start = output.find("{")
+    assert json_start >= 0, f"No JSON found in command output:\n{output}"
+    payload, _ = json.JSONDecoder().raw_decode(output[json_start:].strip())
+    names = [t["name"] for t in payload["tool_traces"]]
+    assert "mcp__controls__channel_write" not in names, (
+        f"WRITE LEAKED (writes_enabled={writes_enabled}): {names}"
+    )
+
+
+# Directive prompt naming the built-in Bash tool — the non-MCP escape hatch.
+# Under bypassPermissions the deny list is inert, so only disallowed_tools
+# stops Bash; a leak here would let the agent `caput` a PV (hardware write).
+_BASH_PROMPT = (
+    "Use the Bash tool to run the shell command: echo 'caput EXAMPLE 1.5'. "
+    "Run it with the Bash tool now."
+)
+
+
+def test_query_refuses_builtin_bash(tmp_path: Path) -> None:
+    """``osprey query`` never executes the built-in ``Bash`` tool.
+
+    The read-only guarantee must hold against the built-in tools too, not just
+    MCP write tools: under bypassPermissions disallowed_tools is the sole guard,
+    and Bash is arbitrary shell (a hardware-write / file-mutation vector).
+
+    Guard 1 — Bash is in the SDK-level disallowed set (structural).
+    Guard 2 — a directive prompt naming Bash produces no Bash tool trace
+    (behavioural: the SDK-level block holds against a model told to use it).
+    """
+    project = init_project(
+        tmp_path,
+        "bash_refuse",
+        template="hello_world",
+        provider="als-apg",
+    )
+
+    # Guard 1: Bash (and the other built-in unsafe tools) are disallowed.
+    disallowed = read_only_disallowed_tools(project)
+    assert "Bash" in disallowed
+
+    # Guard 2: a directive Bash prompt must not produce a Bash tool trace.
+    runner = CliRunner()
+    res = runner.invoke(
+        query,
+        ["--project", str(project), "--json", _BASH_PROMPT],
+        catch_exceptions=False,
+    )
+    output = res.output.strip()
+    assert output, f"No output from osprey query (exit {res.exit_code})."
+    json_start = output.find("{")
+    assert json_start >= 0, f"No JSON found in command output:\n{output}"
+    payload, _ = json.JSONDecoder().raw_decode(output[json_start:].strip())
+    names = [t["name"] for t in payload["tool_traces"]]
+    assert "Bash" not in names, f"BASH LEAKED: {names}"


### PR DESCRIPTION
## Summary

- Adds `osprey query "<prompt>"` — a non-interactive way to drive the project agent end-to-end and report the outcome via exit code, **purpose-built for the scheduled CI/CD compatibility checks requested in #298**, where the verbose e2e test harness was the only existing option (`claude -p`-style, but inside the `osprey` CLI itself).
- Read-only by construction, so it is safe to wire into pipelines and cron without any chance of a hardware write, code execution, or data deletion.

## Changes

- **`osprey query`** boots the full MCP + tools stack, sends the prompt, and exits:
  - `0` — pass (agent completed, all expected MCP servers connected)
  - `1` — verdict fail (server missing, error result, or budget/turn cap hit)
  - `2` — infra/usage error (no project, SDK not installed, provider not configured)
- **`--json`** emits `final_text`, `tool_traces`, and `mcp_servers` status for pipelines that parse results.
- **Read-only enforced architecturally.** The runner uses `permission_mode=bypassPermissions` — under which OSPREY's interactive allow/deny and approval-hook guards are inert — so the SDK-level `disallowed_tools` list is the *sole* write barrier. `read_only_disallowed_tools()` builds it fail-closed from the union of built-in unsafe tools (`Bash`/`Write`/`Edit`/…), the project's `hook_config.json` write list (hard-floored so a dropped entry can't become callable), the server registry's side-effecting/destructive tools, and facility-custom servers. There is deliberately **no `--allow-writes` flag**.
- **Shared runner extracted** into a new `osprey.agent_runner` package so the CLI and the e2e/benchmark harnesses draw from one source — guarded by `test_single_source.py`; `tests/e2e/sdk_helpers.py` and `benchmarks/sdk.py` shrink to consume it.
- **`logger.py`** quiets `claude_agent_sdk`'s stdout INFO line so it cannot corrupt `--json` output.
- New how-to guide: *Non-Interactive Agent Queries* (project resolution, exit codes, read-only guarantee scope, CI loop patterns, `osprey query` vs `osprey health`).

## Test plan

- [x] `tests/agent_runner/` + `tests/cli/test_query_cmd.py` — 72 unit tests pass (runner, verdict, write-tool guard, single-source DRY guard).
- [x] `./scripts/quick_check.sh` — full suite green (**5050 passed, 24 skipped**) + lint/format.
- [x] `osprey query --help` renders; command wired into the lazy CLI group.
- [x] E2E coverage added: `test_query_cmd_e2e.py` (happy path) and `test_query_write_refused_e2e.py` (write attempt is refused).
- [x] Doc claims verified against the CLI (`osprey claude chat`, `osprey health`).

## Related issues

Closes #298