### PR TITLE
docs: how-to validation pass — reconcile guides with code

### DIFF
--- a/docs/source/architecture/mcp-servers.rst
+++ b/docs/source/architecture/mcp-servers.rst
@@ -4,7 +4,7 @@ MCP Servers
 OSPREY exposes control system operations, data retrieval, and workspace
 management as tools through `FastMCP <https://github.com/jlowin/fastmcp>`_
 servers. The Osprey agent discovers servers from ``.mcp.json`` at startup and calls
-tools via stdio JSON-RPC. There are **7 in-tree MCP servers**; build profiles
+tools via stdio JSON-RPC. There are **8 in-tree MCP servers**; build profiles
 can inject additional servers beyond the core set below.
 
 
@@ -198,3 +198,23 @@ and entry creation with attachments.
 - ``entry_publish`` -- Publish an existing ARIEL entry to the facility logbook.
 - ``capabilities`` -- Report available ARIEL search capabilities.
 - ``status`` -- Get ARIEL service health, database connectivity, and statistics.
+
+
+Facility Knowledge
+------------------
+
+``osprey_facility_knowledge``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Package: ``osprey.mcp_server.facility_knowledge``
+
+Serves a facility's curated knowledge bundle (OKF §2 concept documents) so the
+agent can look up operational know-how and draft new concepts for human review.
+
+**Tools:**
+
+- ``capabilities`` -- Report facility knowledge bundle capabilities.
+- ``list_concepts`` -- List all concepts in the facility knowledge bundle.
+- ``read_concept`` -- Read a concept document by its OKF §2 concept ID.
+- ``search`` -- Search the facility knowledge bundle for a query string.
+- ``draft_concept`` -- Draft a new concept document for human review and approval.

--- a/docs/source/getting-started/control-assistant.rst
+++ b/docs/source/getting-started/control-assistant.rst
@@ -49,8 +49,9 @@ Create a project from the ``control-assistant`` preset:
    osprey build my-control-assistant --preset control-assistant
    cd my-control-assistant
 
-Like ``hello-world``, this project starts in **mock** mode with writes disabled,
-so every example below is safe to run with no hardware attached. Unlike
+Like ``hello-world``, this project starts in **mock** mode, so every example
+below is safe to run with no hardware attached; hardware writes are still gated
+behind the human-approval prompt. Unlike
 ``hello-world``, the preset ships a **channel database**, a **seeded electronic
 logbook**, and a **mock archiver**, plus a set of sub-agents and operator skills.
 

--- a/docs/source/how-to/add-connector.rst
+++ b/docs/source/how-to/add-connector.rst
@@ -66,8 +66,13 @@ Switch to real hardware by changing ``type`` in ``config.yml``:
      connector:
        epics:
          gateways:
-           read_only: { address: cagw.facility.edu, port: 5064 }
-           write_access: { address: cagw-rw.facility.edu, port: 5065 }
+           # EPICS uses one process-wide CA context, so the connector points at a
+           # single gateway. When control_system.writes_enabled is true and a
+           # write_access gateway is set, writes route through it; otherwise the
+           # connector uses read_only (so a read-only deployment rejects writes at
+           # the network layer as well).
+           read_only:   { address: cagw.facility.edu, port: 5064 }
+           write_access: { address: cagw.facility.edu, port: 5084 }
          timeout: 5.0
 
 The Python API is identical -- only the config changes.
@@ -198,8 +203,11 @@ All ``write_channel()`` calls return :class:`~osprey.connectors.control_system.b
    }
 
 ``tolerance_absolute`` takes priority over ``tolerance_percent`` (percentage of value).
-Channels inherit from ``defaults`` unless overridden. Set ``"writable": false`` to block
-writes to a channel entirely.
+Each channel inherits any field it does not set from the ``defaults`` block, and a
+channel's own value always overrides it. ``writable`` defaults to ``true``; a channel's
+verification falls back to the ``defaults`` block's verification and then to the global
+``control_system.write_verification.default_level``. Set ``"writable": false`` -- on a
+channel, or in ``defaults`` to lock everything down by default -- to block writes.
 
 .. _write-safety-config:
 
@@ -231,7 +239,6 @@ Automatic safety-limit validation for write operations:
        enabled: true                     # Enable limits validation
        database_path: ./limits_db.json   # Path to the channel limits JSON
        allow_unlisted_channels: false    # Block writes to channels not in the database
-       on_violation: "error"             # "error" (raise) or "skip" (warn and skip)
 
 When enabled, every ``write_channel()`` call is validated against the limits database
 before the write is sent to hardware. See per-channel configuration above for the

--- a/docs/source/how-to/ariel/data-ingestion.rst
+++ b/docs/source/how-to/ariel/data-ingestion.rst
@@ -11,7 +11,7 @@ Ingestion Architecture
 
    Source System (HTTP API / JSONL file)
            ↓
-   Facility Adapter (BaseAdapter)
+   Facility Adapter (FacilityAdapter)
            ↓
    EnhancedLogbookEntry (TypedDict)
            ↓
@@ -38,11 +38,11 @@ The ingestion pipeline follows a linear flow. A `facility adapter <Facility Adap
 Facility Adapters
 =================
 
-Every logbook system has its own API, data format, and naming conventions. Facility adapters encapsulate these differences behind a uniform interface so that the rest of ARIEL --- storage, enhancement, search --- never needs to know where the data came from. Each adapter connects to one source system, fetches entries within an optional time range, and yields them as ``EnhancedLogbookEntry`` TypedDicts that the repository can store directly. All adapters inherit from ``BaseAdapter`` and implement two required members:
+Every logbook system has its own API, data format, and naming conventions. Facility adapters encapsulate these differences behind a uniform interface so that the rest of ARIEL --- storage, enhancement, search --- never needs to know where the data came from. Each adapter connects to one source system, fetches entries within an optional time range, and yields them as ``EnhancedLogbookEntry`` TypedDicts that the repository can store directly. All adapters inherit from ``FacilityAdapter`` and implement two required members:
 
 .. code-block:: python
 
-   class BaseAdapter(ABC):
+   class FacilityAdapter(ABC):
        @property
        @abstractmethod
        def source_system_name(self) -> str:
@@ -77,11 +77,11 @@ Adapters are discovered through Osprey's central registry. The framework ships w
      - Schema-ready prototype for Oak Ridge National Laboratory. Parses ORNL JSON format into the common schema but does not yet implement the facility's native API protocol.
    * - **Generic JSON**
      - ``generic_json``
-     - Reads from a JSON or JSONL file with flexible field mapping. Useful for demos, testing, and facilities without a custom API.
+     - Reads from a JSON file with flexible field mapping. Useful for demos, testing, and facilities without a custom API.
 
 **Registering a custom adapter:**
 
-To add your own facility adapter, subclass ``BaseAdapter``, implement ``source_system_name`` and ``fetch_entries()``, and register it through your application's registry configuration:
+To add your own facility adapter, subclass ``FacilityAdapter``, implement ``source_system_name`` and ``fetch_entries()``, and register it through your application's registry configuration:
 
 .. code-block:: python
 
@@ -99,7 +99,7 @@ To add your own facility adapter, subclass ``BaseAdapter``, implement ``source_s
        ],
    )
 
-Once registered, you can use your adapter by setting ``ariel.ingestion.adapter: my_facility`` in ``config.yml``. See :class:`~osprey.services.ariel_search.ingestion.base.BaseAdapter` for the full interface (including the optional ``count_entries()`` method) and :class:`~osprey.services.ariel_search.models.EnhancedLogbookEntry` for the field reference.
+Once registered, you can use your adapter by setting ``ariel.ingestion.adapter: my_facility`` in ``config.yml``. See :class:`~osprey.services.ariel_search.ingestion.base.FacilityAdapter` for the full interface (including the optional ``count_entries()`` method) and :class:`~osprey.services.ariel_search.models.EnhancedLogbookEntry` for the field reference.
 
 .. admonition:: Collaboration Welcome
    :class: outreach
@@ -282,7 +282,7 @@ The computed interval is capped at ``max_interval_seconds``. After a successful 
 Database Schema
 ===============
 
-All ingested and enhanced data lives in PostgreSQL. The core ``enhanced_entries`` table stores one row per logbook entry with the normalized fields that every adapter produces --- entry ID, timestamp, author, raw text, and a JSONB metadata column for facility-specific extras. Enhancement modules write their results either into columns on this same table (keywords, summaries) or into dedicated per-model tables (vector embeddings). The pgvector extension provides the ``vector`` column type and cosine-distance operators that power semantic search. All tables are created and updated automatically by ``osprey ariel migrate``, which reads the current configuration to determine which embedding tables need to exist.
+All ingested and enhanced data lives in PostgreSQL. The core ``enhanced_entries`` table stores one row per logbook entry with the normalized fields that every adapter produces --- entry ID, timestamp, author, raw text, and a JSONB metadata column for facility-specific extras. Enhancement modules write their results either into columns on this same table (keywords, summaries) or into dedicated per-model tables (vector embeddings). The pgvector extension provides the ``vector`` column type and cosine-distance operators that power semantic search. Core tables and an embedding table for each configured model are created automatically by ``osprey ariel migrate``, which reads ``enhancement_modules.text_embedding.models`` to determine which embedding tables to create. ``osprey ariel reembed`` (re)creates and backfills a single model's table on demand.
 
 .. admonition:: pgvector requirement
    :class: important
@@ -335,8 +335,11 @@ Core Tables
    * - Column
      - Type
      - Description
+   * - ``id``
+     - ``SERIAL PRIMARY KEY``
+     - Auto-incrementing primary key
    * - ``entry_id``
-     - ``TEXT PRIMARY KEY``
+     - ``TEXT UNIQUE``
      - Foreign key to enhanced_entries
    * - ``embedding``
      - ``vector(<dim>)``
@@ -360,9 +363,15 @@ Core Tables
    * - ``completed_at``
      - ``TIMESTAMPTZ``
      - Ingestion completion time
-   * - ``entries_processed``
+   * - ``entries_added``
      - ``INTEGER``
-     - Number of entries ingested
+     - Number of new entries added
+   * - ``entries_updated``
+     - ``INTEGER``
+     - Number of existing entries updated
+   * - ``entries_failed``
+     - ``INTEGER``
+     - Number of entries that failed
    * - ``source_system``
      - ``TEXT``
      - Source adapter name
@@ -371,7 +380,7 @@ Core Tables
 Migration System
 ----------------
 
-Migrations are run via ``osprey ariel migrate`` and managed by the ``run_migrations()`` function in ``database/migrations.py``. The migration system automatically creates embedding tables based on the ``enhancement_modules.text_embedding.models`` configuration.
+Migrations are run via ``osprey ariel migrate`` and managed by the ``run_migrations()`` function in ``database/migrations.py``. When ``text_embedding`` is enabled, ``migrate`` creates an embedding table for each model listed in ``enhancement_modules.text_embedding.models`` (falling back to ``nomic-embed-text``, 768, if none is configured); ``osprey ariel reembed`` (re)creates and backfills a single model's table on demand.
 
 .. admonition:: Schema Evolution
    :class: outreach

--- a/docs/source/how-to/ariel/index.rst
+++ b/docs/source/how-to/ariel/index.rst
@@ -73,11 +73,11 @@ delegated to the Osprey agent layer.
       .. tab-item:: 1. Configure
 
          The easiest way to get started is to create a new project from the
-         ``control_assistant`` template, which includes ARIEL pre-configured:
+         ``ariel-standalone`` template, which includes ARIEL pre-configured:
 
          .. code-block:: bash
 
-            osprey build my-project --preset control-assistant
+            osprey build my-project --preset ariel-standalone
             cd my-project
 
          This generates a ready-to-use ``config.yml`` with PostgreSQL, the ARIEL
@@ -93,7 +93,7 @@ delegated to the Osprey agent layer.
 
          .. code-block:: bash
 
-            osprey deploy up
+            osprey deploy up -d
 
          Once the containers are running, connect to PostgreSQL, run database
          migrations, then ingest the demo logbook data and generate embeddings:

--- a/docs/source/how-to/ariel/osprey-integration.rst
+++ b/docs/source/how-to/ariel/osprey-integration.rst
@@ -56,11 +56,11 @@ Osprey agent selects the appropriate tool based on the user's query.
    * - ``browse``
      - Browse entries with pagination and filters
    * - ``filter_options``
-     - Get available filter values (tags, authors, date ranges)
+     - Get distinct values for a filterable field (authors or source systems)
    * - ``status``
      - Check ARIEL service health and configuration
    * - ``entry_publish``
-     - Publish a new logbook entry
+     - Publish an existing ARIEL entry to the facility logbook
    * - ``capabilities``
      - List available search capabilities and their status
    * - ``entry_get``
@@ -102,7 +102,7 @@ The MCP tool returns a structured result containing:
      - Explanation of results
    * - ``diagnostics``
      - ``tuple[SearchDiagnostic, ...]``
-     - Per-mode timing and result counts
+     - Structured diagnostics (level, source, message) from search execution
 
 
 Service Factory

--- a/docs/source/how-to/ariel/search-modes.rst
+++ b/docs/source/how-to/ariel/search-modes.rst
@@ -4,7 +4,7 @@ Search Modes
 
 ARIEL's search system is built around **search modules** --- leaf-level functions that each implement a single retrieval strategy against the logbook database. The framework ships two modules out of the box: keyword full-text search and embedding-based semantic similarity. At query time, the ``ARIELSearchService`` routes each request to the requested module. All modes share the same underlying :ref:`database <database>` and produce a common ``ARIELSearchResult``. Higher-level reasoning over results --- multi-step retrieval, answer synthesis, custom prompting --- lives in the Osprey agent layer, which calls these search modules through ARIEL's MCP tools. A raw ``sql_query`` MCP tool is also available for direct database access by power users and the agent.
 
-Search modules are discovered through Osprey's central registry, so you can add your own without modifying any framework code. A custom search module only needs to export a ``get_tool_descriptor()`` function. Once registered, it is automatically available to the Osprey agent through the ARIEL MCP server and in the web interface.
+Search modules are discovered through Osprey's central registry, so you can register your own and have it surface in the web interface's capabilities API without modifying any framework code. A custom search module only needs to export a ``get_tool_descriptor()`` function. Once registered and enabled, it is discovered through the registry and surfaced in the web interface's capabilities API. Exposing it as an MCP tool the Osprey agent can call additionally requires adding a matching ARIEL MCP tool and ``SearchMode`` routing (contributions welcome).
 
 Search Architecture
 -------------------
@@ -35,7 +35,7 @@ The ``--mode`` option accepts ``keyword`` (default) or ``semantic``.
 Search Modules
 ==============
 
-Search modules are leaf-level functions that execute a single search strategy against the database. Each module exports a ``get_tool_descriptor()`` function that describes its capabilities, input schema, and execution function so the rest of the system --- the ARIEL MCP server and the web interface --- can discover and use it automatically. The framework ships with the following built-in search modules:
+Search modules are leaf-level functions that execute a single search strategy against the database. Each module exports a ``get_tool_descriptor()`` function that describes its capabilities, input schema, and execution function. The web interface discovers modules through this descriptor via ARIEL's capabilities API; the built-in keyword and semantic modules are exposed to the Osprey agent through dedicated ARIEL MCP tools. The framework ships with the following built-in search modules:
 
 .. tab-set::
 
@@ -145,7 +145,7 @@ To add your own search module, create a Python module that exports ``get_tool_de
        ],
    )
 
-Once registered and enabled in ``config.yml`` (``search_modules.my_search.enabled: true``), the module is automatically available as an ARIEL MCP tool that the Osprey agent can call, and as a search option in the web interface. The ``get_tool_descriptor()`` function must return a ``SearchToolDescriptor``:
+Once registered and enabled in ``config.yml`` (``search_modules.my_search.enabled: true``), the module is automatically surfaced as a search option in the web interface's capabilities API. Making it callable by the Osprey agent additionally requires a matching ARIEL MCP tool and ``SearchMode`` routing in ``ARIELSearchService`` (contributions welcome). The ``get_tool_descriptor()`` function must return a ``SearchToolDescriptor``:
 
 :class:`~osprey.services.ariel_search.search.base.SearchToolDescriptor` — a frozen dataclass whose key fields are ``execute`` (the async search function), ``format_result`` (formats results for agent consumption), and ``args_schema`` (a Pydantic model for input validation). See the class definition in the source for the full field list.
 

--- a/docs/source/how-to/ariel/standalone-deployment.rst
+++ b/docs/source/how-to/ariel/standalone-deployment.rst
@@ -87,7 +87,7 @@ on their corpus before committing to the full deployment.
 
          .. code-block:: bash
 
-            osprey deploy up
+            osprey deploy up -d
 
          Once the container is running, run database migrations and
          ingest the bundled demo logbook with embeddings:
@@ -144,12 +144,13 @@ Quick edits (one-off tweaks)
 For small in-place adjustments to a project you just built, edit files
 directly:
 
-1. **Edit** ``.claude/rules/facility.md``. The default ships with a
-   placeholder for the "Example Research Facility" (Primary Source /
-   Transport & Delivery / Experimental Stations, with an EPICS channel
-   pattern table). Replace this content with your facility's real
-   terminology, system names, and naming conventions so the agent uses
-   the right vocabulary when interpreting user questions.
+1. **Edit** ``.claude/rules/facility.md``. The default ships with a thin
+   placeholder for the "Example Research Facility (ERF)" --- a facility-identity
+   stub (name, type, mission) plus a pointer to the ``facility_knowledge`` tools
+   (``list_concepts``/``read_concept``/``search``) for deeper content. Replace
+   this with your facility's real terminology, system names, and naming
+   conventions so the agent uses the right vocabulary when interpreting user
+   questions.
 
    .. note::
 

--- a/docs/source/how-to/ariel/web-interface.rst
+++ b/docs/source/how-to/ariel/web-interface.rst
@@ -31,7 +31,7 @@ The interface has four views, accessible via the navigation bar. All views are r
 
    .. tab-item:: Search
 
-      The primary view. A search bar with mode tabs (Keyword, Semantic --- only enabled modes are shown) and an expandable advanced options panel. Results display as entry cards with relevance scores and highlights. Press ``Enter`` to submit a query; ``Ctrl+Enter`` submits with the current advanced options.
+      The primary view. A search bar with mode tabs (Keyword, Semantic --- only enabled modes are shown) and an expandable advanced options panel. Results display as entry cards with relevance scores and highlights. Press ``Enter`` to submit a query; searches always include the current advanced options and filters.
 
       .. figure:: /_static/screenshots/ariel_search.png
          :alt: ARIEL Search View
@@ -42,7 +42,7 @@ The interface has four views, accessible via the navigation bar. All views are r
 
    .. tab-item:: Browse
 
-      Paginated chronological listing of all logbook entries. Each entry shows its timestamp, author, and a text preview. Click an entry to view its full content. Filter by date range, author, or source system.
+      Chronological, paginated listing of logbook entries (newest first) -- use Previous/Next to page back through older entries. Each entry shows its timestamp, author, and a text preview. Click an entry to view its full content.
 
       .. figure:: /_static/screenshots/ariel_browse.png
          :alt: ARIEL Browse View
@@ -53,7 +53,7 @@ The interface has four views, accessible via the navigation bar. All views are r
 
    .. tab-item:: New Entry
 
-      Form for creating new logbook entries directly from the interface. Fields include subject, details, author, logbook, shift, and tags. New entries are stored with ``source_system: "ARIEL Web"`` and receive a generated ``entry_id`` in the format ``ariel-web-<uuid>``. Created entries are searchable immediately.
+      Form for creating new logbook entries directly from the interface. Fields include subject, details, author, logbook, shift, and tags. When the configured logbook adapter is read-only (the common case for the standalone interface), entries are saved locally with ``source_system: "ARIEL Web"`` and a generated ``entry_id`` of the form ``ariel-<12-hex>``. When a write-capable facility adapter is configured, the entry is published to that logbook and takes the facility's ``source_system`` and ``entry_id``. Created entries are searchable immediately.
 
       .. figure:: /_static/screenshots/ariel_create.png
          :alt: ARIEL New Entry View
@@ -184,38 +184,43 @@ The web interface discovers its search modes and tunable parameters dynamically 
 
       .. tab-item:: Capabilities
 
-         The ``/api/capabilities`` endpoint returns a JSON structure describing every enabled search module, along with its parameters:
+         The ``/api/capabilities`` endpoint returns a JSON structure that groups enabled search modes under category objects (currently a single ``direct`` category), along with shared parameters:
 
          .. code-block:: json
 
             {
-              "modes": [
-                {
-                  "name": "keyword",
-                  "label": "Keyword",
-                  "description": "Full-text PostgreSQL search...",
-                  "parameters": [
+              "categories": {
+                "direct": {
+                  "label": "Direct",
+                  "modes": [
                     {
-                      "name": "fuzzy_fallback",
-                      "label": "Fuzzy Fallback",
-                      "param_type": "bool",
-                      "default": true,
-                      "section": "Search"
+                      "name": "keyword",
+                      "label": "Keyword",
+                      "description": "Full-text PostgreSQL search...",
+                      "parameters": [
+                        {
+                          "name": "fuzzy_fallback",
+                          "label": "Fuzzy Fallback",
+                          "type": "bool",
+                          "default": true,
+                          "section": "Search"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "semantic",
+                      "label": "Semantic",
+                      "description": "Embedding-based similarity search...",
+                      "parameters": []
                     }
                   ]
-                },
-                {
-                  "name": "semantic",
-                  "label": "Semantic",
-                  "description": "Embedding-based similarity search...",
-                  "parameters": []
                 }
-              ],
+              },
               "shared_parameters": [
-                {"name": "max_results", "param_type": "int", "default": 10},
-                {"name": "start_date", "param_type": "date"},
-                {"name": "author", "param_type": "text"},
-                {"name": "source_system", "param_type": "dynamic_select",
+                {"name": "max_results", "type": "int", "default": 10},
+                {"name": "start_date", "type": "date"},
+                {"name": "author", "type": "text"},
+                {"name": "source_system", "type": "dynamic_select",
                  "options_endpoint": "/api/filter-options/source_systems"}
               ]
             }
@@ -266,7 +271,7 @@ The web interface discovers its search modes and tunable parameters dynamically 
             * - ``api.js``
               - REST client wrapping ``fetch()`` for all API endpoints
             * - ``search.js``
-              - Search form, mode tabs, results rendering
+              - Search form, query submission, results rendering
             * - ``advanced-options.js``
               - Capabilities-driven advanced options panel (dynamic parameter controls)
             * - ``entries.js``

--- a/docs/source/how-to/ariel/web-interface.rst
+++ b/docs/source/how-to/ariel/web-interface.rst
@@ -203,7 +203,7 @@ The web interface discovers its search modes and tunable parameters dynamically 
                           "label": "Fuzzy Fallback",
                           "type": "bool",
                           "default": true,
-                          "section": "Search"
+                          "section": "Options"
                         }
                       ]
                     },

--- a/docs/source/how-to/build-profiles.rst
+++ b/docs/source/how-to/build-profiles.rst
@@ -132,6 +132,7 @@ Create a minimal profile and build:
    data_bundle: control_assistant
    provider: anthropic
    model: sonnet
+   channel_finder_mode: in_context
    requires_osprey_version: ">=2026.5.0"
 
    config:
@@ -224,8 +225,10 @@ Configuration Overrides
 =======================
 
 The ``config:`` section uses **dot notation** to override any key in the generated
-``config.yml``. Available keys are defined in the config template
-(``src/osprey/templates/project/config.yml.j2``).
+``config.yml``. The base set of keys is in
+``src/osprey/templates/project/config.yml.j2``; presets add further
+sections (e.g. ``archiver``, ``channel_finder``) in their own
+``config.yml.j2``.
 
 .. code-block:: yaml
 
@@ -233,7 +236,7 @@ The ``config:`` section uses **dot notation** to override any key in the generat
      # Control system
      control_system.type: epics
      control_system.writes_enabled: true
-     control_system.limits_checking: true
+     control_system.limits_checking.enabled: true
      control_system.connector.epics.timeout: 10.0
 
      # Archiver
@@ -692,11 +695,13 @@ After building, the project contains:
    ├── _mcp_servers/         # Custom server code (from overlays)
    └── ...
 
-Which agents, rules, hooks, and skills are included is controlled by the
-bundled preset profile (``src/osprey/profiles/presets/<bundle>.yml``) — not
-by your user profile. Your profile can override **data and config** but not
-the set of Osprey agent artifacts. To change the artifact set, edit the
-preset profile for that data bundle directly.
+Which agents, rules, hooks, and skills are included starts from the
+bundled preset profile (``src/osprey/profiles/presets/<preset>.yml``),
+but your user profile can customize it: ``agents:``, ``rules:``,
+``hooks:``, and ``skills:`` are first-class profile fields, and
+``extends:`` union-merges your additions with the preset's set. To
+drop a preset artifact entirely, build from a standalone profile or
+edit the preset directly.
 
 
 Troubleshooting
@@ -710,11 +715,8 @@ profile YAML's directory, not the current working directory.
 **"Overlay destination must be relative without '..'"** — Destination paths cannot
 be absolute or contain ``..``.
 
-**"MCP server 'X' missing 'command'"** — Every MCP server definition needs a
-``command`` field.
-
-**"MCP server 'X' already exists in .mcp.json"** — The server name conflicts with
-a built-in. Choose a different name.
+**"MCP server 'X' missing 'command' or 'url'"** — Every MCP server definition
+needs a ``command`` (stdio) or a ``url`` (HTTP) field.
 
 **"Directory 'X' already exists"** — Use ``--force`` to overwrite, or pick a
 different project name.

--- a/docs/source/how-to/configure-providers.rst
+++ b/docs/source/how-to/configure-providers.rst
@@ -43,7 +43,7 @@ Available Providers
      - OpenAI (proxied)
    * - ``asksage``
      - AskSage proxy
-     - ``ASKSAGE_API_KEY``
+     - *(custom auth)*
      - OpenAI (proxied)
    * - ``openai``
      - OpenAI (GPT models)
@@ -59,6 +59,10 @@ Available Providers
      - OpenAI (proxied)
    * - ``vllm``
      - vLLM inference server
+     - *(none)*
+     - OpenAI (proxied)
+   * - ``ds4``
+     - DwarfStar local server
      - *(none)*
      - OpenAI (proxied)
 
@@ -150,8 +154,9 @@ that assigns provider-specific model IDs to tiers (``haiku``, ``sonnet``,
      default_model: sonnet
 
 ``provider`` picks one of the entries in ``api.providers``.
-``default_model`` selects the tier for the main conversation (defaults to
-``sonnet`` for most providers).
+``default_model`` selects the tier for the main conversation. If omitted, it
+falls back to the provider's own default tier — ``sonnet`` for ``anthropic``,
+``haiku`` for ``cborg`` and ``als-apg``, and ``opus`` for custom providers.
 
 Model Tier Mapping
 ------------------
@@ -164,7 +169,7 @@ The resolver applies model IDs in this priority order:
 
 1. ``claude_code.models`` — explicit per-tier overrides (highest priority).
 2. ``api.providers.<name>.models`` — the provider's own model naming.
-3. Built-in defaults — Anthropic direct model IDs (fallback).
+3. Built-in defaults — the provider's bundled fallback model IDs (Anthropic direct IDs only as a last resort).
 
 For example, to override the opus tier for a specific project:
 

--- a/docs/source/how-to/deploy-project.rst
+++ b/docs/source/how-to/deploy-project.rst
@@ -57,9 +57,10 @@ deployment via ``deployed_services:``. A minimal example (this is what the
 Each service entry must point ``path:`` at a directory containing a
 ``docker-compose.yml.j2`` template. Everything else under the service key is
 project-specific configuration exposed to the template as
-``{{services.<name>.<key>}}``. For the canonical schema (including
-``copy_src``, ``additional_dirs``, ``render_kernel_templates``, and
-``containers`` for multi-container services), see :ref:`profile-services`.
+``{{services.<name>.<key>}}``. Beyond ``path``, a service entry may also
+declare ``copy_src``, ``additional_dirs``, ``render_kernel_templates``, and
+``containers`` (for multi-container services). For how facility services are
+declared inside a build profile, see :ref:`profile-services`.
 
 Service lookup namespaces
 -------------------------

--- a/docs/source/how-to/deploy-project.rst
+++ b/docs/source/how-to/deploy-project.rst
@@ -58,9 +58,10 @@ Each service entry must point ``path:`` at a directory containing a
 ``docker-compose.yml.j2`` template. Everything else under the service key is
 project-specific configuration exposed to the template as
 ``{{services.<name>.<key>}}``. Beyond ``path``, a service entry may also
-declare ``copy_src``, ``additional_dirs``, ``render_kernel_templates``, and
-``containers`` (for multi-container services). For how facility services are
-declared inside a build profile, see :ref:`profile-services`.
+declare ``copy_src``, ``additional_dirs``, and ``render_kernel_templates``
+(a multi-container service is expressed by the ``docker-compose.yml.j2``
+template defining more than one compose service). For how facility services
+are declared inside a build profile, see :ref:`profile-services`.
 
 Service lookup namespaces
 -------------------------

--- a/docs/source/how-to/event-dispatch.rst
+++ b/docs/source/how-to/event-dispatch.rst
@@ -168,8 +168,8 @@ The EVENTS Panel
 Projects built from the ``control-assistant`` preset surface this dashboard as
 an **EVENTS** tab inside the web terminal, so ``osprey web`` exposes it without a
 separate browser window. The tab health-gates itself: while the dispatcher is
-down it shows *unavailable* rather than a broken frame, and turns live once the
-dispatcher answers ``/health``.
+down the tab is disabled with an offline indicator rather than showing a broken
+frame, and it turns live once the dispatcher answers ``/health``.
 
 The panel points at ``${EVENT_DISPATCHER_URL:-http://localhost:8020}``, which
 works out of the box for the host-run flow above. When the web terminal runs in
@@ -216,8 +216,9 @@ Authoring Triggers
    ``KillShell``). This sits on top of the per-trigger allowlist, so a trigger
    can never widen its way to a shell or the open network.
 
-   **Retry policy.** ``on_error: retry`` fires only when the dispatcher *cannot
-   reach the worker* (connection error or timeout) — it re-dispatches up to
+   **Retry policy.** ``on_error: retry`` fires only when the *dispatch itself*
+   fails — the worker being unreachable (connection error or timeout), returning
+   an HTTP error, or rejecting the dispatcher's token — and it re-dispatches up to
    ``max_retries`` with ``backoff_sec`` between attempts. It does *not* retry a
    run that the agent itself ends in error, so firing a trigger against a healthy
    stack never exercises it; the behaviour is covered by

--- a/docs/source/how-to/index.rst
+++ b/docs/source/how-to/index.rst
@@ -118,8 +118,9 @@ Services & Connectors
       :link: ariel/index
       :link-type: doc
 
-      Intelligent search over facility electronic logbooks with keyword, semantic,
-      RAG, and agentic retrieval modes.
+      Intelligent search over facility electronic logbooks with keyword and
+      semantic retrieval modes, plus multi-step reasoning delegated to the
+      Osprey agent.
 
    .. grid-item-card:: Facility Knowledge
       :link: use-facility-knowledge

--- a/docs/source/how-to/run-open-models.rst
+++ b/docs/source/how-to/run-open-models.rst
@@ -25,7 +25,9 @@ Messages** calls. When the endpoint speaks the OpenAI protocol, OSPREY bridges t
 two with a local ``Anthropic ↔ OpenAI`` translation proxy that starts automatically
 once you select an OpenAI-protocol provider — you never invoke it yourself. This is
 identical whether the model is self-hosted (``ollama``, ``vllm``, no API key) or
-served by a remote aggregator. The provider list and ``config.yml`` keys are in
+served by an OpenAI-only remote aggregator. (CBORG is the exception: it exposes an
+Anthropic-compatible endpoint, so the agent reaches it directly without the local
+proxy.) The provider list and ``config.yml`` keys are in
 :doc:`configure-providers`.
 
 Which models are known to work

--- a/docs/source/how-to/use-channel-finder.rst
+++ b/docs/source/how-to/use-channel-finder.rst
@@ -42,8 +42,9 @@ In-Context Pipeline
 Loads the entire channel database into the LLM context for direct semantic
 matching.
 
-**Pipeline stages:** query splitting, semantic matching against full database,
-iterative validation/correction.
+**How it works:** a single inner-LLM call — the complete channel database is
+embedded in the system prompt and the model returns the most relevant channels
+in one shot (no query-splitting or iterative-correction stage).
 
 The database uses a flat JSON structure loaded by ``TemplateChannelDatabase``,
 with standalone entries and template entries for device families:
@@ -112,7 +113,7 @@ Middle Layer Pipeline
 
 A React agent explores the database using query tools
 (``list_systems``, ``list_families``, ``inspect_fields``,
-``list_channel_names``, ``get_common_names``).
+``list_channels``, ``get_common_names``).
 
 The database follows MATLAB Middle Layer (MML) functional organization
 (System -> Family -> Field -> ChannelNames). Convert from MML exports:
@@ -120,7 +121,7 @@ The database follows MATLAB Middle Layer (MML) functional organization
 .. code-block:: bash
 
    python -m osprey.services.channel_finder.utils.mml_converter \
-      --input path/to/mml_exports.py \
+      --input path/to/mml_exports.py:MML_ao_SR \
       --output data/channel_databases/middle_layer.json
 
 
@@ -147,16 +148,15 @@ Key ``config.yml`` settings:
      pipelines:
        in_context:
          database: {type: template, path: data/channel_databases/in_context.json}
-         processing: {chunk_dictionary: false, chunk_size: 50}
        hierarchical:
          database: {type: hierarchical, path: data/channel_databases/hierarchical.json}
        middle_layer:
          database: {type: middle_layer, path: data/channel_databases/middle_layer.json}
      benchmark:
        dataset_path: data/benchmarks/queries.json
-   benchmark:
-     execution: {max_concurrent_queries: 5}
-     output: {results_dir: data/benchmarks/results}
+       # Concurrency and output dir are set per run via CLI flags
+       # (osprey channel-finder benchmark --concurrency / --output-dir);
+       # they are not read from config.yml.
 
 
 .. _channel-finder-framework-integration:
@@ -168,7 +168,8 @@ Each pipeline is exposed to the agent through a dedicated MCP server
 (``channel_finder_in_context``, ``channel_finder_hierarchical``,
 ``channel_finder_middle_layer``). The active server is selected from
 ``channel_finder.pipeline_mode`` in ``config.yml`` and wired into the
-agent automatically by ``osprey deploy``. There is no public Python
+agent's artifacts when you run ``osprey build`` (or ``osprey claude regen``
+after editing the config). There is no public Python
 ``find_channels(...)`` entry point — drive the resolver from natural
 language via the agent, or invoke the CLI directly:
 

--- a/docs/source/how-to/use-facility-knowledge.rst
+++ b/docs/source/how-to/use-facility-knowledge.rst
@@ -69,9 +69,12 @@ example content with your own facility's documents.
 
 .. note::
 
-   The bundle path is required.  If it is missing or the directory does not
-   exist, the ``osprey_facility_knowledge`` server will refuse to start with
-   a clear error message.
+   If ``facility_knowledge.bundle_path`` is missing, or points to a directory
+   that does not exist, the ``osprey_facility_knowledge`` server still starts
+   but logs a warning (missing key) or error (missing directory) and leaves the
+   bundle uninitialised.  Its ``list_concepts``, ``read_concept``, ``search``,
+   and ``draft_concept`` tools then return a ``server_not_initialised`` error on
+   every call until the path is fixed.
 
 
 Authoring Concept Documents
@@ -82,7 +85,7 @@ Each concept document is a markdown file with YAML frontmatter at the top:
 .. code-block:: markdown
 
    ---
-   type: subsystem
+   type: Subsystem
    title: Power Supply System
    description: DC power supplies for all storage-ring magnets.
    tags: [magnets, power-supplies, PSS]
@@ -253,7 +256,9 @@ Example agent prompt:
 
 The agent will call ``draft_concept`` with a proposed path, frontmatter, and
 body.  You review and approve in the standard approval dialog; the document
-is written into the bundle and the index is regenerated.
+is written into the bundle.  ``draft_concept`` does not rebuild the index, so
+run ``osprey knowledge regen-index`` afterwards for the new document to appear
+in ``list_concepts`` and ``search``.
 
 
 The ``facility-knowledge`` Subagent
@@ -267,13 +272,15 @@ and follows a fixed retrieval strategy: list first to orient, search to narrow,
 read to synthesize, then submit the result.
 
 The subagent is enabled by default in the ``control_assistant`` preset.  To
-enable or disable it in another preset, set the ``agents.facility-knowledge``
-flag in ``config.yml``:
+enable or disable it in a generated project, set the agent's ``enabled`` flag
+under ``claude_code.agents`` in ``config.yml``:
 
 .. code-block:: yaml
 
-   agents:
-     facility-knowledge: true   # set to false to disable
+   claude_code:
+     agents:
+       facility-knowledge:
+         enabled: false   # disable the subagent (omit to keep it enabled)
 
 .. note::
 

--- a/docs/source/how-to/use-python-executor.rst
+++ b/docs/source/how-to/use-python-executor.rst
@@ -103,8 +103,9 @@ process is never exposed to user code.
 Local Subprocess Execution
 --------------------------
 
-When containers are unavailable, the service falls back to local subprocess
-execution. The ``ExecutionWrapper`` wraps user code with safety
+Local mode is selected explicitly by setting ``execution_method: local``
+(there is no automatic fallback from container mode). The ``ExecutionWrapper``
+wraps user code with safety
 monkeypatches (e.g., ``epics.caput()`` validation against the limits
 database), writes the wrapped script to an execution folder, and runs it
 as a subprocess:

--- a/docs/source/how-to/use-web-terminal.rst
+++ b/docs/source/how-to/use-web-terminal.rst
@@ -45,7 +45,7 @@ side panels:
 
 - **Artifact gallery** (port 8086) — workspace artifact browser
 
-Domain-specific servers are launched when their config section is present:
+Domain-specific servers are launched when their panel is enabled in ``web.panels`` (see Side Panels below):
 
 - **ARIEL** (port 8085) — logbook search
 - **Tuning panel** (port 8090) — parameter tuning UI


### PR DESCRIPTION
Empirical validation pass over the how-to guides (and a few coupled architecture/getting-started pages), reconciling the prose with the live codebase. Every changed claim was re-proven against source — class/function names, config keys, CLI flags, MCP tool names, capabilities-API shape, the web `entry_id` format, provider tier fallbacks, proxy startup logic — with an adversarial second pass and a repo-wide sweep for stale terms.

## Highlights

- **Renames / corrections caught in prose:** `BaseAdapter` → `FacilityAdapter`; channel-finder middle-layer tool `list_channel_names` → `list_channels`; ARIEL capabilities parameter key `param_type` → `type`; flat `limits_checking: true` → nested `.enabled`; flat top-level `agents:` → `claude_code.agents.<name>.enabled`; web `entry_id` format `ariel-web-<uuid>` → `ariel-<12hex>`.
- **Behavior reconciled with the companion code fixes** (see the code PR): `on_violation` knob removed; channel `defaults`-block inheritance + verification fallback; EPICS single-gateway / `write_access` routing; EVENTS tab now renders and health-gates; `osprey ariel migrate` per-model embedding tables; capabilities API now groups modes under `categories.direct`.
- **Conceptual cleanups:** ARIEL search advertised as keyword + semantic + agent-delegated reasoning (dropped the fictional "RAG/agentic modes"); custom search modules surface in the web capabilities API but are not auto-exposed as agent MCP tools; python-executor local mode is selected explicitly (`execution_method: local`), not an automatic container fallback; CBORG reached natively (Anthropic-compatible) without the local OpenAI↔Anthropic proxy; `osprey deploy up -d`; facility-knowledge server starts-but-warns when `bundle_path` is missing.
- **MCP server count** corrected to 8 in-tree; added the `osprey_facility_knowledge` server reference.

## Verification

A per-page verification workflow re-checked all 18 changed files claim-by-claim against the working tree, then three sweeps (CHANGELOG↔code, missed-pages grep, code soundness). Two carried-forward inaccuracies it surfaced were fixed in the final commit: `deploy-project.rst` invented a `containers` service-entry key (no such key — multi-container is expressed by the compose template), and the `web-interface.rst` capabilities example used `section: "Search"` where the descriptor uses `"Options"`.

Docs-only; rebased on current `main`. Pairs with the code-fix PR — that branch makes the behavior these pages now describe true. Either merge order is fine.
