### PR TITLE
fix(web): run terminal PTY in --project dir so MCP servers start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ## [Unreleased]
 
+### Fixed
+
+- `osprey web --project X` launched from another directory now spawns the interactive terminal's Claude Code with `cwd = X`, so it reads `X/.mcp.json` and starts the project's MCP servers (the PTY path previously ignored `--project` and inherited the launch directory) (#313).
+
 ## [2026.6.2] - 2026-06-28
 
 ### Added

--- a/src/osprey/interfaces/web_terminal/pty_manager.py
+++ b/src/osprey/interfaces/web_terminal/pty_manager.py
@@ -40,6 +40,7 @@ class PtySession:
         initial_rows: int = 24,
         initial_cols: int = 80,
         extra_env: dict[str, str] | None = None,
+        cwd: str | None = None,
     ) -> None:
         """Spawn the shell process attached to a new PTY.
 
@@ -47,6 +48,11 @@ class PtySession:
             initial_rows: Initial terminal row count (default 24).
             initial_cols: Initial terminal column count (default 80).
             extra_env: Additional environment variables to set in the child process.
+            cwd: Working directory for the child process. When set, the spawned
+                process runs in this directory so Claude Code resolves
+                ``.mcp.json`` (and config/.env) relative to the project rather
+                than the launch directory (issue #313). When ``None`` the child
+                inherits the parent's cwd.
         """
         master_fd, slave_fd = pty.openpty()
 
@@ -107,6 +113,7 @@ class PtySession:
             stderr=slave_fd,
             preexec_fn=_child_preexec,
             env=env,
+            cwd=cwd,
         )
 
         # Close slave in parent — only the child uses it
@@ -245,8 +252,14 @@ class PtyRegistry:
         rows: int = 24,
         cols: int = 80,
         extra_env: dict[str, str] | None = None,
+        cwd: str | None = None,
     ) -> tuple[PtySession, bool]:
         """Get existing session or create a new one.
+
+        Args:
+            cwd: Working directory for the spawned process (issue #313). Only
+                used when a new session is created; reused live sessions keep
+                the directory they were spawned in.
 
         Returns:
             (session, was_reused) — True if an existing live session was reattached.
@@ -266,7 +279,7 @@ class PtyRegistry:
         # Evict if at capacity
         self._evict_lru()
 
-        session = self._spawn_session(command, rows, cols, extra_env)
+        session = self._spawn_session(command, rows, cols, extra_env, cwd)
         self._sessions[session_key] = session
         return session, False
 
@@ -319,10 +332,11 @@ class PtyRegistry:
         rows: int,
         cols: int,
         extra_env: dict[str, str] | None,
+        cwd: str | None = None,
     ) -> PtySession:
         """Create and start a new PtySession."""
         session = PtySession(command)
-        session.start(initial_rows=rows, initial_cols=cols, extra_env=extra_env)
+        session.start(initial_rows=rows, initial_cols=cols, extra_env=extra_env, cwd=cwd)
         return session
 
     # ---- Session methods (kept for operator sessions and tests) ---- #
@@ -334,13 +348,19 @@ class PtyRegistry:
         initial_rows: int = 24,
         initial_cols: int = 80,
         extra_env: dict[str, str] | None = None,
+        cwd: str | None = None,
     ) -> PtySession:
         """Create and start a new PTY session."""
         if session_id in self._sessions:
             self._sessions[session_id].terminate()
 
         session = PtySession(shell_command)
-        session.start(initial_rows=initial_rows, initial_cols=initial_cols, extra_env=extra_env)
+        session.start(
+            initial_rows=initial_rows,
+            initial_cols=initial_cols,
+            extra_env=extra_env,
+            cwd=cwd,
+        )
         self._sessions[session_id] = session
         return session
 

--- a/src/osprey/interfaces/web_terminal/routes/websocket.py
+++ b/src/osprey/interfaces/web_terminal/routes/websocket.py
@@ -161,6 +161,7 @@ async def terminal_ws(websocket: WebSocket):
         rows=initial_rows,
         cols=initial_cols,
         extra_env=extra_env if extra_env else None,
+        cwd=websocket.app.state.project_cwd,
     )
     registry.attach_session(current_key)
 
@@ -256,6 +257,7 @@ async def terminal_ws(websocket: WebSocket):
                                 rows=initial_rows,
                                 cols=initial_cols,
                                 extra_env=target_env if target_env else None,
+                                cwd=websocket.app.state.project_cwd,
                             )
                             registry.attach_session(target_id)
 

--- a/tests/interfaces/web_terminal/test_pty_manager.py
+++ b/tests/interfaces/web_terminal/test_pty_manager.py
@@ -84,6 +84,41 @@ class TestPtySession:
         finally:
             session.terminate()
 
+    def test_start_with_cwd(self, tmp_path):
+        """Child process must run in the supplied working directory.
+
+        Regression for #313: `osprey web --project X` launched from another
+        directory must spawn the terminal's Claude with cwd=X so it finds
+        X/.mcp.json. Without threading cwd into the PTY spawn, the child
+        inherits the launch dir and starts zero MCP servers.
+        """
+        import select
+
+        target = tmp_path / "project"
+        target.mkdir()
+
+        session = PtySession("/bin/sh")
+        session.start(cwd=str(target))
+        try:
+            session.write_input(b"pwd -P\n")
+
+            output = b""
+            deadline = time.monotonic() + 3
+            while time.monotonic() < deadline:
+                r, _, _ = select.select([session._master_fd], [], [], 0.1)
+                if r:
+                    try:
+                        chunk = os.read(session._master_fd, 4096)
+                        output += chunk
+                        if os.path.realpath(target).encode() in output:
+                            break
+                    except OSError:
+                        break
+
+            assert os.path.realpath(target).encode() in output
+        finally:
+            session.terminate()
+
     def test_exit_code_none_while_running(self):
         session = PtySession("/bin/sh")
         session.start()
@@ -348,5 +383,65 @@ class TestPtyRegistry:
                         break
 
             assert b"test_value_12345" in output
+        finally:
+            registry.cleanup_all()
+
+    def test_create_session_passes_cwd(self, tmp_path):
+        """create_session forwards cwd to the child (operator/test path)."""
+        import select
+
+        target = tmp_path / "proj"
+        target.mkdir()
+
+        registry = PtyRegistry()
+        try:
+            session = registry.create_session("test-cwd", "/bin/sh", cwd=str(target))
+            session.write_input(b"pwd -P\n")
+
+            output = b""
+            deadline = time.monotonic() + 3
+            while time.monotonic() < deadline:
+                r, _, _ = select.select([session._master_fd], [], [], 0.1)
+                if r:
+                    try:
+                        chunk = os.read(session._master_fd, 4096)
+                        output += chunk
+                        if os.path.realpath(target).encode() in output:
+                            break
+                    except OSError:
+                        break
+
+            assert os.path.realpath(target).encode() in output
+        finally:
+            registry.cleanup_all()
+
+    def test_get_or_create_session_passes_cwd(self, tmp_path):
+        """get_or_create_session (interactive terminal path, #313) forwards cwd."""
+        import select
+
+        target = tmp_path / "proj"
+        target.mkdir()
+
+        registry = PtyRegistry()
+        try:
+            session, _reused = registry.get_or_create_session(
+                "term-cwd", "/bin/sh", cwd=str(target)
+            )
+            session.write_input(b"pwd -P\n")
+
+            output = b""
+            deadline = time.monotonic() + 3
+            while time.monotonic() < deadline:
+                r, _, _ = select.select([session._master_fd], [], [], 0.1)
+                if r:
+                    try:
+                        chunk = os.read(session._master_fd, 4096)
+                        output += chunk
+                        if os.path.realpath(target).encode() in output:
+                            break
+                    except OSError:
+                        break
+
+            assert os.path.realpath(target).encode() in output
         finally:
             registry.cleanup_all()


### PR DESCRIPTION
## Summary

`osprey web --project X` launched from a directory other than `X` started **zero** project MCP servers in the interactive web terminal. The terminal's Claude Code was spawned with `cwd` = the launch directory, so it resolved `.mcp.json` (and `config.yml`/`.env`) against the wrong place and found no project servers.

`--project` was captured and the **API chat path honored it** — only the **PTY/terminal path** ignored it.

## Root cause

`PtySession.start()` built `subprocess.Popen(...)` with no `cwd`, and `app.state.project_cwd` was never threaded into the PTY spawn. The child inherited the `osprey web` process cwd.

## Fix

- Thread an optional `cwd` through `PtySession.start()` → `PtyRegistry.get_or_create_session()` / `create_session()` / `_spawn_session()` to `subprocess.Popen(cwd=...)`.
- Pass `app.state.project_cwd` at both terminal-websocket spawn sites (initial spawn + session switch), mirroring what the chat route already does.

Because the child now runs in the project directory, `config.yml`/`.env` also resolve correctly (the issue's optional follow-up).

## Tests

Added 3 unit tests (`test_pty_manager.py`) that spawn a real child, run `pwd -P`, and assert it runs in the supplied directory — covering `start`, `create_session`, and `get_or_create_session`. Written test-first: verified they fail on the assertion (reproducing the bug — child runs in the launch dir) when the `cwd` pass-through is removed, and pass with the fix. Full `tests/interfaces/web_terminal/` suite: 380 passed; ruff + mypy clean.

Closes #313