### PR TITLE
fix(web): build + render the events panel when its URL is derived from dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 - `osprey web --project X` launched from another directory now spawns the interactive terminal's Claude Code with `cwd = X`, so it reads `X/.mcp.json` and starts the project's MCP servers (the PTY path previously ignored `--project` and inherited the launch directory) (#313).
 
+## [2026.6.3] - 2026-06-29
+
+### Fixed
+
+- The `events` web panel now builds and renders when its URL is derived from a `dispatch` block. Two regressions from the v2026.6.2 move of `events` out of `BUILTIN_PANELS` are addressed: (1) the build-profile validator now accepts a dispatch-backed `events` panel that has no manual `web.panels.events.url` (the URL is derived post-build, after validation, from `dispatch.dispatcher_port`); (2) the derivation emits a bare-host `url` plus a `/dashboard` `path` instead of baking `/dashboard` into `url`, matching the custom-panel proxy convention (`url.rstrip('/') + '/' + path`) so sub-routes are not double-prefixed. A facility-pinned `web.panels.events.path` is preserved, and an explicit `web.panels.events.url` override still wins.
+
 ## [2026.6.2] - 2026-06-28
 
 ### Added

--- a/docs/source/how-to/event-dispatch.rst
+++ b/docs/source/how-to/event-dispatch.rst
@@ -179,6 +179,25 @@ a container, repoint it at the dispatcher service:
 
    EVENT_DISPATCHER_URL=http://event-dispatcher:8020
 
+Auto-derived URL
+----------------
+
+You do not have to set ``web.panels.events.url`` by hand. Whenever a profile
+lists the ``events`` panel **and** declares a ``dispatch:`` block, the build
+derives the panel's route from ``dispatch.dispatcher_port``:
+
+.. code-block:: yaml
+
+   web.panels.events.url: http://localhost:<dispatcher_port>   # bare host
+   web.panels.events.path: /dashboard                          # route
+
+The ``url`` is the bare dispatcher host and ``path`` carries the ``/dashboard``
+route — the web terminal composes the backend target as ``url`` + ``path``, so
+baking ``/dashboard`` into ``url`` would double-prefix sub-routes. Keep them
+split. If a profile already pins ``web.panels.events.path`` the build leaves it
+untouched, and an explicit ``web.panels.events.url`` override always wins (use it
+for remote/containerized terminals that cannot reach ``localhost``).
+
 Authoring Triggers
 ==================
 

--- a/src/osprey/__init__.py
+++ b/src/osprey/__init__.py
@@ -10,7 +10,7 @@ This package contains:
 """
 
 # Version information
-__version__ = "2026.6.2"
+__version__ = "2026.6.3"
 
 __all__ = ["__version__"]
 

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -1319,11 +1319,18 @@ def _inject_dispatch(dispatch: DispatchConfig, profile_dir: Path, project_path: 
     # source of truth.  Write only if the profile has not already set an explicit
     # ``web.panels.events.url`` via a config override (merged earlier in the
     # build); explicit overrides take precedence.
+    #
+    # Emit a bare-host ``url`` plus a ``/dashboard`` ``path`` (rather than baking
+    # ``/dashboard`` into ``url``) to match the custom-panel proxy convention:
+    # the web terminal composes ``url.rstrip('/') + '/' + path``, so a path baked
+    # into ``url`` double-prefixes sub-routes. ``setdefault`` on ``path`` honors a
+    # facility that pinned its own ``web.panels.events.path``.
     existing_events_url = config.get("web", {}).get("panels", {}).get("events", {}).get("url", "")
     if not existing_events_url:
-        derived_url = f"http://localhost:{dispatch.dispatcher_port}/dashboard"
         config.setdefault("web", {}).setdefault("panels", {}).setdefault("events", {})
-        config["web"]["panels"]["events"]["url"] = derived_url
+        events_panel = config["web"]["panels"]["events"]
+        events_panel["url"] = f"http://localhost:{dispatch.dispatcher_port}"
+        events_panel.setdefault("path", "/dashboard")
 
     with open(config_path, "w") as fh:
         yaml.dump(config, fh)

--- a/src/osprey/cli/build_profile.py
+++ b/src/osprey/cli/build_profile.py
@@ -377,11 +377,18 @@ class BuildProfile:
             if panel in BUILTIN_PANELS:
                 continue
             url_key = f"web.panels.{panel}.url"
-            if url_key not in self.config:
-                errors.append(
-                    f"Unknown web_panel {panel!r}: not in BUILTIN_PANELS "
-                    f"({sorted(BUILTIN_PANELS)}) and no '{url_key}' config override"
-                )
+            if url_key in self.config:
+                continue
+            # The ``events`` panel URL is derived post-build from the dispatch
+            # block (``_inject_dispatch`` in build_cmd.py), which runs after this
+            # validator. So a dispatch-backed events panel is legitimately
+            # url-less here — accept it rather than aborting the build.
+            if panel == "events" and self.dispatch is not None:
+                continue
+            errors.append(
+                f"Unknown web_panel {panel!r}: not in BUILTIN_PANELS "
+                f"({sorted(BUILTIN_PANELS)}) and no '{url_key}' config override"
+            )
 
         # Validate default_panel: must be a built-in, a declared web_panels
         # entry, or a custom panel backed by a `web.panels.<id>.url` override.

--- a/tests/cli/test_build_cmd.py
+++ b/tests/cli/test_build_cmd.py
@@ -1884,7 +1884,7 @@ class TestEventsPanelUrlDerivation:
         return yaml.safe_load((project_path / "config.yml").read_text()) or {}
 
     def test_events_panel_url_derived_from_dispatcher_port(self, tmp_path: Path) -> None:
-        """web.panels.events.url is written as http://localhost:{port}/dashboard."""
+        """events.url is a bare host and events.path carries the /dashboard route."""
         project_path = tmp_path / "project"
         project_path.mkdir()
         profile_dir = tmp_path / "profile"
@@ -1894,11 +1894,15 @@ class TestEventsPanelUrlDerivation:
         self._inject(self._dispatch(dispatcher_port=8888), project_path, profile_dir)
 
         config = self._read_config(project_path)
-        url = config["web"]["panels"]["events"]["url"]
-        assert url == "http://localhost:8888/dashboard"
+        events = config["web"]["panels"]["events"]
+        # Bare host in url + /dashboard in path matches the custom-panel proxy
+        # convention (url.rstrip('/') + '/' + path); /dashboard must NOT be baked
+        # into url or sub-routes would double-prefix.
+        assert events["url"] == "http://localhost:8888"
+        assert events["path"] == "/dashboard"
 
     def test_events_panel_url_reflects_custom_port(self, tmp_path: Path) -> None:
-        """Different dispatcher_port values produce different derived URLs."""
+        """Different dispatcher_port values produce different derived bare-host URLs."""
         project_path = tmp_path / "project"
         project_path.mkdir()
         profile_dir = tmp_path / "profile"
@@ -1908,10 +1912,39 @@ class TestEventsPanelUrlDerivation:
         self._inject(self._dispatch(dispatcher_port=9999), project_path, profile_dir)
 
         config = self._read_config(project_path)
-        assert config["web"]["panels"]["events"]["url"] == "http://localhost:9999/dashboard"
+        events = config["web"]["panels"]["events"]
+        assert events["url"] == "http://localhost:9999"
+        assert events["path"] == "/dashboard"
+
+    def test_events_panel_path_pinned_by_profile_preserved(self, tmp_path: Path) -> None:
+        """A facility-pinned web.panels.events.path is left untouched (setdefault)."""
+        from ruamel.yaml import YAML
+
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        profile_dir = tmp_path / "profile"
+        profile_dir.mkdir()
+
+        yaml = YAML()
+        config_pre = {
+            "deployed_services": [],
+            "services": {},
+            "web": {"panels": {"events": {"path": "/custom-route"}}},
+        }
+        with open(project_path / "config.yml", "w") as fh:
+            yaml.dump(config_pre, fh)
+
+        self._inject(self._dispatch(dispatcher_port=8020), project_path, profile_dir)
+
+        config = self._read_config(project_path)
+        events = config["web"]["panels"]["events"]
+        # url is still derived (no explicit url was set), but the pinned path wins.
+        assert events["url"] == "http://localhost:8020"
+        assert events["path"] == "/custom-route"
 
     def test_explicit_events_url_not_overwritten(self, tmp_path: Path) -> None:
-        """An explicit web.panels.events.url already in config.yml is not replaced."""
+        """An explicit web.panels.events.url already in config.yml is not replaced,
+        and the derivation does not force-inject a path alongside it."""
         from ruamel.yaml import YAML
 
         project_path = tmp_path / "project"
@@ -1933,8 +1966,12 @@ class TestEventsPanelUrlDerivation:
         self._inject(self._dispatch(dispatcher_port=8020), project_path, profile_dir)
 
         config = self._read_config(project_path)
+        events = config["web"]["panels"]["events"]
         # Explicit URL must survive — derivation must not overwrite it.
-        assert config["web"]["panels"]["events"]["url"] == "http://custom-host:7777/dashboard"
+        assert events["url"] == "http://custom-host:7777/dashboard"
+        # Derivation is fully skipped when an explicit url exists; it must not
+        # inject a path that would compose a double route against the explicit url.
+        assert "path" not in events
 
 
 def test_build_channel_finder_agent_requires_mode(tmp_path: Path) -> None:

--- a/tests/cli/test_profile_schema.py
+++ b/tests/cli/test_profile_schema.py
@@ -42,6 +42,43 @@ def test_valid_dispatch_validates(tmp_path: Path) -> None:
     profile.validate(tmp_path)
 
 
+def test_events_panel_with_dispatch_validates_without_url(tmp_path: Path) -> None:
+    """A dispatch-backed ``events`` panel needs no manual ``web.panels.events.url``.
+
+    The URL is derived post-build from ``dispatch.dispatcher_port`` (after this
+    validator runs), so the validator must accept the url-less events panel when
+    a dispatch block is present rather than aborting the build.
+    """
+    triggers = _write_triggers(tmp_path)
+    profile = BuildProfile(
+        name="x",
+        web_panels=["events"],
+        dispatch=DispatchConfig(triggers=triggers),
+    )
+    profile.validate(tmp_path)  # must not raise
+
+
+def test_events_panel_without_dispatch_still_requires_url(tmp_path: Path) -> None:
+    """The escape hatch is narrow: an ``events`` panel with no dispatch block and
+    no url override is still rejected (nothing would derive its URL)."""
+    profile = BuildProfile(name="x", web_panels=["events"])
+    with pytest.raises(BuildProfileError, match="events"):
+        profile.validate(tmp_path)
+
+
+def test_non_events_custom_panel_with_dispatch_still_requires_url(tmp_path: Path) -> None:
+    """The dispatch escape hatch applies only to ``events`` — any other url-less
+    custom panel is still rejected even when a dispatch block is present."""
+    triggers = _write_triggers(tmp_path)
+    profile = BuildProfile(
+        name="x",
+        web_panels=["grafana"],
+        dispatch=DispatchConfig(triggers=triggers),
+    )
+    with pytest.raises(BuildProfileError, match="grafana"):
+        profile.validate(tmp_path)
+
+
 def test_worker_count_below_one_raises(tmp_path: Path) -> None:
     triggers = _write_triggers(tmp_path)
     profile = BuildProfile(name="x", dispatch=DispatchConfig(triggers=triggers, worker_count=0))


### PR DESCRIPTION
## Summary

Moving `events` out of `BUILTIN_PANELS` (v2026.6.2, #304) correctly made it a URL-backed custom panel, but left two regressions for any profile that **derives** the panel URL from a `dispatch:` block instead of pinning `web.panels.events.url`:

1. **Validator blind to dispatch** — `BuildProfile.validate()` (`src/osprey/cli/build_profile.py`) rejected the `events` panel unless `web.panels.events.url` was already present in the profile config. But that URL is derived post-build by `_inject_dispatch`, which runs *after* validation, so a dispatch-backed events panel could never pass → hard build abort (`Unknown web_panel 'events': … no 'web.panels.events.url' config override`).

2. **Derivation broke the custom-panel proxy convention** — `_inject_dispatch` (`src/osprey/cli/build_cmd.py`) baked `/dashboard` into `url` (`http://localhost:{port}/dashboard`) and set no `path`. The web terminal's proxy composes the backend target as `url.rstrip('/') + '/' + path`, so a route baked into `url` double-prefixes sub-routes (`/dashboard/dashboard/...`).

## Fix

- Validator accepts an url-less `events` panel when a `dispatch` block is present (the only panel with a known post-build derivation; other url-less custom panels still error).
- Derivation emits a **bare-host `url`** plus a **`/dashboard` `path`**, matching the custom-panel convention and the `control-assistant` preset. A facility-pinned `web.panels.events.path` is preserved (`setdefault`), and an explicit `web.panels.events.url` override still wins.

## Tests

- Updated `TestEventsPanelUrlDerivation` to assert the url/path split, path-preservation, and that no `path` is injected when an explicit `url` is set.
- Added validator regression tests: dispatch-backed events panel validates without a url; the escape hatch stays narrow (events-only, dispatch-required).
- Docs: documents auto-derivation in `docs/source/how-to/event-dispatch.rst`.

Verified end-to-end in a real deployment (build → CI → web terminal): the EVENTS tab renders the dispatcher dashboard with a single `/dashboard`.