### PR TITLE
fix(dispatch): enforce trigger allowlist as single authority; enable declared subagents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- Headless dispatch runs now enforce the trigger's `allowed_tools` as the single authority via a PreToolUse hook: project `settings.json` allow-rules and the approval hook's explicit allows can no longer widen a run's tool surface, and declared subagents (`.claude/agents/*.md`) work with exactly their declared tools — no trigger changes needed.
 - `osprey web --project X` launched from another directory now spawns the interactive terminal's Claude Code with `cwd = X`, so it reads `X/.mcp.json` and starts the project's MCP servers (the PTY path previously ignored `--project` and inherited the launch directory) (#313).
 
 ## [2026.6.3] - 2026-06-29

--- a/src/osprey/interfaces/web_terminal/sdk_context.py
+++ b/src/osprey/interfaces/web_terminal/sdk_context.py
@@ -20,6 +20,8 @@ from datetime import datetime
 from typing import Any
 from zoneinfo import ZoneInfo
 
+from osprey.utils.tool_rules import matches_denylist
+
 try:
     from claude_agent_sdk import (
         PermissionResultAllow,
@@ -79,17 +81,8 @@ def make_tool_allowlist(
     allowed_set = frozenset(allowed)
     denied_tuple = tuple(denied)
 
-    def _denied(tool_name: str) -> bool:
-        for entry in denied_tuple:
-            if entry.endswith("*"):
-                if tool_name.startswith(entry[:-1]):
-                    return True
-            elif tool_name == entry:
-                return True
-        return False
-
     async def can_use_tool(tool_name, tool_input, context):  # type: ignore[no-untyped-def]
-        if _denied(tool_name):
+        if matches_denylist(tool_name, denied_tuple):
             return PermissionResultDeny(
                 message=f"Tool {tool_name!r} is blocked by the dispatch server denylist",
             )

--- a/src/osprey/mcp_server/dispatch_worker/agent_surfaces.py
+++ b/src/osprey/mcp_server/dispatch_worker/agent_surfaces.py
@@ -1,0 +1,107 @@
+"""Declared-subagent tool surfaces for dispatch permission policy.
+
+Parses the provisioned ``<project>/.claude/agents/*.md`` files (rendered from
+``src/osprey/templates/claude_code/claude/agents/*.md.j2``) into a mapping of
+agent name to declared tool surface. The dispatch worker uses this to grant
+each subagent exactly its declared tools — parity with the web terminal —
+without the trigger having to enumerate them.
+
+Frontmatter contract (matching what the Claude Code CLI loads):
+
+* Only files directly in ``.claude/agents/`` (non-recursive; the templates
+  ship a ``_terminology`` sibling directory that must not be scanned).
+* A file must start with ``---``; the block up to the closing ``---`` is
+  parsed with ``yaml.safe_load``.
+* Agents are keyed by the frontmatter ``name:`` (what the CLI dispatches on),
+  not the filename. Duplicate names: last file in sorted order wins, with a
+  warning.
+* ``tools:`` may be a comma-separated scalar (the template form) or a YAML
+  list. An absent or malformed ``tools:`` yields ``None`` — the agent exists
+  but has inherits-all semantics, which dispatch treats as non-delegable
+  rather than granting an unbounded surface.
+
+Parsing is best-effort and never raises: a malformed or unreadable file is
+skipped with a warning so one bad agent file cannot take down dispatch runs.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger("osprey.mcp_server.dispatch_worker.agent_surfaces")
+
+
+def _parse_tools(value: object) -> frozenset[str] | None:
+    """Normalize a frontmatter ``tools`` value to a tool-name set.
+
+    Accepts the template's comma-separated scalar or a YAML list; anything
+    else (including absent → ``None``) yields ``None`` (non-delegable).
+    """
+    if isinstance(value, str):
+        return frozenset(t.strip() for t in value.split(",") if t.strip())
+    if isinstance(value, list):
+        return frozenset(str(t).strip() for t in value if str(t).strip())
+    return None
+
+
+def parse_project_agents(project_dir: str | Path) -> dict[str, frozenset[str] | None]:
+    """Parse declared subagents and their tool surfaces from a project.
+
+    Args:
+        project_dir: Project root containing ``.claude/agents/``.
+
+    Returns:
+        Mapping of frontmatter agent name to its declared tool set, or
+        ``None`` for agents without an explicit ``tools:`` list. Missing
+        directory or no parseable files ⇒ empty mapping.
+    """
+    agents_dir = Path(project_dir) / ".claude" / "agents"
+    surfaces: dict[str, frozenset[str] | None] = {}
+    if not agents_dir.is_dir():
+        return surfaces
+
+    for path in sorted(agents_dir.glob("*.md")):
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            logger.warning("Skipping unreadable agent file %s", path, exc_info=True)
+            continue
+
+        if not text.startswith("---"):
+            continue
+        parts = text.split("---", 2)
+        if len(parts) < 3:
+            continue
+
+        try:
+            frontmatter = yaml.safe_load(parts[1])
+        except yaml.YAMLError:
+            logger.warning("Skipping agent file with malformed frontmatter: %s", path.name)
+            continue
+        if not isinstance(frontmatter, dict):
+            continue
+
+        name = frontmatter.get("name")
+        if not isinstance(name, str) or not name.strip():
+            logger.warning("Skipping agent file without a name: %s", path.name)
+            continue
+        name = name.strip()
+
+        tools = _parse_tools(frontmatter.get("tools"))
+        if tools is None:
+            logger.warning(
+                "Agent %r (%s) declares no explicit tools list — "
+                "it will not be delegable in dispatch runs",
+                name,
+                path.name,
+            )
+        if name in surfaces:
+            logger.warning("Duplicate agent name %r — %s overrides earlier file", name, path.name)
+        surfaces[name] = tools
+
+    return surfaces

--- a/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
+++ b/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
@@ -26,6 +26,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 
 from osprey.mcp_server.dispatch_worker import sdk_runner
+from osprey.utils.tool_rules import matches_denylist
 
 logger = logging.getLogger("osprey.mcp_server.dispatch_worker")
 
@@ -230,13 +231,7 @@ def _is_denied(tool: str) -> bool:
     every ``mcp__plugin_playwright_playwright__<name>`` tool); all other entries
     match exactly.
     """
-    for entry in DENIED_TOOLS:
-        if entry.endswith("*"):
-            if tool.startswith(entry[:-1]):
-                return True
-        elif tool == entry:
-            return True
-    return False
+    return matches_denylist(tool, DENIED_TOOLS)
 
 
 # ---------------------------------------------------------------------------

--- a/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
+++ b/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
@@ -21,11 +21,13 @@ try:
     from claude_agent_sdk import (
         AssistantMessage,
         ClaudeAgentOptions,
+        HookMatcher,
         ResultMessage,
         SystemMessage,
         TextBlock,
         ToolResultBlock,
         ToolUseBlock,
+        UserMessage,
         query,
     )
 
@@ -139,9 +141,11 @@ async def run_dispatch(
     # conflicts.  Provider env (auth token, base URL, model tier IDs) is already
     # injected into os.environ by _inject_provider_env_once() at worker startup.
     from osprey.interfaces.web_terminal.operator_session import build_clean_env
-    from osprey.interfaces.web_terminal.sdk_context import (
-        build_system_prompt,
-        make_tool_allowlist,
+    from osprey.interfaces.web_terminal.sdk_context import build_system_prompt
+    from osprey.mcp_server.dispatch_worker.agent_surfaces import parse_project_agents
+    from osprey.mcp_server.dispatch_worker.tool_policy import (
+        make_backstop,
+        make_pretooluse_hook,
     )
     from osprey.utils.config import get_facility_timezone
 
@@ -161,15 +165,47 @@ async def run_dispatch(
     dispatch_home = os.environ.get("HOME", "/home/dispatch")
     sdk_env["CLAUDE_CONFIG_DIR"] = os.path.join(dispatch_home, ".claude")
 
+    # Marks this CLI session as a headless dispatch run for the project's own
+    # hooks: osprey_approval must not emit explicit allow decisions here (CLI
+    # hook aggregation is not deny-dominates, so an allow would override the
+    # trigger-allowlist hook below).
+    sdk_env["OSPREY_DISPATCH_RUN"] = "1"
+
+    # Declared subagent tool surfaces from the provisioned .claude/agents/ —
+    # each subagent is held to exactly its declared tools (web-terminal parity)
+    # without the trigger having to enumerate them.
+    agent_surfaces = parse_project_agents(project_dir)
+    logger.info(
+        "Dispatch tool policy: %d trigger tools, subagent surfaces %s",
+        len(allowed_tools),
+        {name: (len(s) if s is not None else None) for name, s in agent_surfaces.items()},
+    )
+
     # NOTE: do NOT use permission_mode="bypassPermissions" — the CLI short-circuits
     # can_use_tool under bypass, so the allowlist would not be enforced. With the
     # default mode and can_use_tool set, the SDK auto-configures
-    # permission_prompt_tool_name="stdio" (see client.py:122) which routes every
-    # tool permission check to our allowlist callback.
+    # permission_prompt_tool_name="stdio" (see client.py:122) which routes
+    # unresolved permission checks to our backstop callback.
+    #
+    # The PreToolUse hook is the single authority: unlike can_use_tool — which
+    # the CLI never consults for calls already permitted by settings.json
+    # permissions.allow rules — the hook fires for EVERY tool call, including
+    # inside subagents, so project settings cannot widen the trigger's surface.
+    # Exact-name denied tools additionally go to disallowed_tools, which strips
+    # them from the model's context entirely; prefix entries (``server__*``)
+    # become server-level rules (``server``).
+    disallowed = [t for t in denied_tools if not t.endswith("*")] + [
+        t[: -len("__*")] for t in denied_tools if t.endswith("__*")
+    ]
+    # Any-typed so the SDK's HookCallback union (typed against its own
+    # TypedDict inputs) accepts our dict-based callback.
+    policy_hook: Any = make_pretooluse_hook(allowed_tools, agent_surfaces, denied_tools)
     options = ClaudeAgentOptions(
         allowed_tools=allowed_tools,
         system_prompt=build_system_prompt(get_facility_timezone()),
-        can_use_tool=make_tool_allowlist(allowed_tools, denied_tools),
+        can_use_tool=make_backstop(allowed_tools, agent_surfaces, denied_tools),
+        hooks={"PreToolUse": [HookMatcher(matcher=None, hooks=[policy_hook])]},
+        disallowed_tools=sorted(disallowed),
         cwd=project_dir,
         env=sdk_env,
         max_turns=max_turns,
@@ -248,9 +284,15 @@ async def run_dispatch(
                     }
                 )
 
-            if isinstance(message, AssistantMessage):
-                for block in message.content:
-                    if isinstance(block, TextBlock):
+            # Tool RESULTS arrive as ToolResultBlock inside UserMessage (the
+            # SDK's message_parser wraps tool_result content that way), while
+            # text and ToolUseBlock arrive in AssistantMessage — handle both so
+            # per-call results (including permission denials) are captured.
+            if isinstance(message, AssistantMessage | UserMessage):
+                msg_content = message.content
+                blocks = msg_content if isinstance(msg_content, list) else []
+                for block in blocks:
+                    if isinstance(block, TextBlock) and isinstance(message, AssistantMessage):
                         text_parts.append(block.text)
                         await _push({"type": "text", "content": block.text})
                     elif isinstance(block, ToolUseBlock):

--- a/src/osprey/mcp_server/dispatch_worker/tool_policy.py
+++ b/src/osprey/mcp_server/dispatch_worker/tool_policy.py
@@ -1,0 +1,183 @@
+"""Dispatch permission policy — the trigger allowlist as single authority.
+
+Two per-run enforcement layers for headless dispatch:
+
+* ``make_pretooluse_hook`` builds the **single authority**: a programmatic
+  PreToolUse hook (``ClaudeAgentOptions.hooks``). Unlike ``can_use_tool`` —
+  which the CLI never consults for calls already permitted by
+  ``settings.json`` ``permissions.allow`` rules — a PreToolUse hook fires for
+  every tool call, including inside subagents, so neither project settings
+  nor other hooks' allow decisions can widen a dispatch run's tool surface.
+
+* ``make_backstop`` builds a context-aware ``can_use_tool`` callback as
+  defense-in-depth beneath the hook (e.g. for asks downgraded by concurrent
+  settings-hook decisions).
+
+Both are **context-aware** rather than a flat union: the main thread is held
+to the trigger's ``allowed_tools``; a subagent is held to its own declared
+``tools:`` surface (see ``agent_surfaces.parse_project_agents``). Subagent
+context is detected by ``agent_id`` presence — ``agent_type`` alone also
+appears on the main thread of ``--agent`` sessions.
+
+The hook is deny-only: an allowed call returns ``{}`` (no decision) so the
+facility's own PreToolUse safety hooks and the normal permission flow still
+apply. It never emits ``permissionDecision: "allow"``, which would bypass
+the permission system (and with it the facility write-approval ask-gate).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable, Iterable, Mapping
+from typing import Any
+
+from osprey.utils.tool_rules import matches_denylist
+
+try:
+    from claude_agent_sdk import PermissionResultAllow, PermissionResultDeny
+
+    CLAUDE_SDK_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised only without the SDK
+    CLAUDE_SDK_AVAILABLE = False
+    PermissionResultAllow = object  # type: ignore[assignment,misc]
+    PermissionResultDeny = object  # type: ignore[assignment,misc]
+
+logger = logging.getLogger("osprey.mcp_server.dispatch_worker.tool_policy")
+
+# Permission-free harness tools the CLI lets an agent use without any allow
+# rule today; a strict deny-only hook would otherwise starve them (TodoWrite
+# progress tracking, WaitForMcpServers for MCP cold-start races). Deliberately
+# NOT included: Read/Glob/Grep — main-thread file access would expose e.g.
+# config.yml provider settings. Denylist entries still beat this set.
+PASSTHROUGH_TOOLS = frozenset({"TodoWrite", "WaitForMcpServers"})
+
+# Both names the CLI has used for the subagent-delegation tool.
+DELEGATION_TOOLS = ("Task", "Agent")
+
+AgentSurfaces = Mapping[str, "frozenset[str] | None"]
+
+
+def _deny(reason: str) -> dict[str, Any]:
+    """Build a PreToolUse deny decision in the CLI's hook-output shape."""
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
+
+
+def make_pretooluse_hook(
+    trigger_tools: Iterable[str],
+    agent_surfaces: AgentSurfaces,
+    denied_tools: Iterable[str] = (),
+) -> Callable[[dict[str, Any], str | None, Any], Awaitable[dict[str, Any]]]:
+    """Build the deny-only PreToolUse hook enforcing the dispatch allowlist.
+
+    Args:
+        trigger_tools: The trigger's ``allowed_tools`` — the main thread's
+            entire surface.
+        agent_surfaces: Declared subagent surfaces from
+            ``parse_project_agents`` (``None`` = declared but non-delegable).
+        denied_tools: Server denylist (``*`` suffix = prefix match), always
+            checked first.
+
+    Returns:
+        An async hook callback returning ``{}`` for allowed calls and an
+        explicit deny decision otherwise. Internal errors deny (fail-closed).
+    """
+    trigger_set = frozenset(trigger_tools)
+    denied_tuple = tuple(denied_tools)
+
+    async def pretooluse_hook(
+        input_data: dict[str, Any], tool_use_id: str | None, context: Any
+    ) -> dict[str, Any]:
+        try:
+            tool_name = str(input_data.get("tool_name") or "")
+
+            if matches_denylist(tool_name, denied_tuple):
+                return _deny(f"Tool {tool_name!r} is blocked by the dispatch server denylist")
+
+            if tool_name in PASSTHROUGH_TOOLS:
+                return {}
+
+            if tool_name in DELEGATION_TOOLS:
+                tool_input = input_data.get("tool_input") or {}
+                target = tool_input.get("subagent_type")
+                if not target:
+                    return _deny(
+                        "delegation requires an explicit subagent_type; "
+                        "general-purpose is not permitted in dispatch"
+                    )
+                if target not in agent_surfaces:
+                    return _deny(
+                        f"agent {target!r} is not declared in this project's .claude/agents/"
+                    )
+                if agent_surfaces[target] is None:
+                    return _deny(
+                        f"agent {target!r} has no explicit tools: list in its "
+                        ".claude/agents/ file; declare one to enable it for dispatch"
+                    )
+                return {}
+
+            # Subagent context iff agent_id is present (agent_type alone also
+            # appears on --agent main threads).
+            if "agent_id" in input_data:
+                agent_type = str(input_data.get("agent_type") or "")
+                surface = agent_surfaces.get(agent_type)
+                if surface is None:
+                    return _deny(
+                        f"Tool {tool_name!r} denied: unknown or tools-less subagent "
+                        f"context {agent_type!r}"
+                    )
+                if tool_name in surface:
+                    return {}
+                return _deny(
+                    f"Tool {tool_name!r} is not in subagent {agent_type!r}'s declared tools list"
+                )
+
+            if tool_name in trigger_set:
+                return {}
+            return _deny(f"Tool {tool_name!r} is not in this trigger's allowed_tools list")
+        except Exception:
+            logger.exception("dispatch permission hook internal error — denying tool")
+            return _deny("dispatch permission hook internal error (fail-closed)")
+
+    return pretooluse_hook
+
+
+def make_backstop(
+    trigger_tools: Iterable[str],
+    agent_surfaces: AgentSurfaces,
+    denied_tools: Iterable[str] = (),
+) -> Any:
+    """Build the context-aware ``can_use_tool`` backstop under the hook.
+
+    Main thread (``context.agent_id`` is None) is held to the trigger set;
+    subagent context to the union of all declared surfaces —
+    ``ToolPermissionContext`` carries no ``agent_type``, so per-agent
+    precision is the hook's job; the union merely never widens the main
+    thread (which today's flat allowlist would).
+    """
+    trigger_set = frozenset(trigger_tools)
+    denied_tuple = tuple(denied_tools)
+    subagent_union = frozenset().union(
+        *(surface for surface in agent_surfaces.values() if surface is not None)
+    )
+
+    async def can_use_tool(tool_name, tool_input, context):  # type: ignore[no-untyped-def]
+        if matches_denylist(tool_name, denied_tuple):
+            return PermissionResultDeny(
+                message=f"Tool {tool_name!r} is blocked by the dispatch server denylist",
+            )
+        if tool_name in PASSTHROUGH_TOOLS:
+            return PermissionResultAllow()
+        allowed = trigger_set if getattr(context, "agent_id", None) is None else subagent_union
+        if tool_name in allowed:
+            return PermissionResultAllow()
+        return PermissionResultDeny(
+            message=f"Tool {tool_name!r} is not permitted in this dispatch context",
+        )
+
+    return can_use_tool

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
@@ -141,7 +141,18 @@ def build_approval_output(reason_detail: str) -> dict:
 
 
 def build_allow_output() -> dict:
-    """Explicit allow decision — overrides static permission lists."""
+    """Explicit allow decision — overrides static permission lists.
+
+    In headless dispatch runs (``OSPREY_DISPATCH_RUN=1``, set by the dispatch
+    worker) this returns ``{}`` — no decision — instead. An explicit allow
+    would override the dispatch worker's per-trigger allowlist hook (CLI
+    hook aggregation is not deny-dominates), silently widening a sandboxed
+    run's tool surface. With no decision emitted, the call falls through to
+    the permission flow, where the worker's own callback rules. Ask and deny
+    outputs are unaffected.
+    """
+    if os.environ.get("OSPREY_DISPATCH_RUN") == "1":
+        return {}
     return {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",

--- a/src/osprey/utils/tool_rules.py
+++ b/src/osprey/utils/tool_rules.py
@@ -1,0 +1,37 @@
+"""Shared tool-name denylist matching.
+
+Single implementation of the denylist semantics used by the dispatch worker
+(``dispatch_api.DENIED_TOOLS``) and the web-terminal permission callback
+(``sdk_context.make_tool_allowlist``): entries ending in ``*`` match by prefix
+(e.g. ``mcp__plugin_playwright_playwright__*`` blocks every playwright tool);
+all other entries match exactly.
+
+Lives in ``osprey.utils`` (leaf package) so both the dispatch worker and the
+web terminal can import it without pulling in each other's package trees.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def matches_denylist(tool_name: str, entries: Iterable[str]) -> bool:
+    """Return True if ``tool_name`` matches any denylist entry.
+
+    Args:
+        tool_name: Tool name as reported by the SDK (e.g. ``Bash``,
+            ``mcp__controls__channel_read``).
+        entries: Denylist entries. An entry ending in ``*`` matches any tool
+            whose name starts with the part before the ``*``; every other
+            entry matches exactly.
+
+    Returns:
+        True on the first matching entry, False if none match.
+    """
+    for entry in entries:
+        if entry.endswith("*"):
+            if tool_name.startswith(entry[:-1]):
+                return True
+        elif tool_name == entry:
+            return True
+    return False

--- a/tests/e2e/test_dispatch_allowlist_parity.py
+++ b/tests/e2e/test_dispatch_allowlist_parity.py
@@ -1,0 +1,303 @@
+"""E2E: dispatch trigger allowlist is the single authority (real CLI).
+
+Pins the three defects behind the dispatch-allowlist-parity fix and proves
+the fix end-to-end against a real built project, a real dispatch worker
+subprocess, and the bundled Claude CLI:
+
+* **Repro A (settings-allow bypass):** ``mcp__osprey_workspace__data_list``
+  is in the provisioned ``settings.json`` ``permissions.allow``; per SDK
+  semantics such calls never reach ``can_use_tool``, so pre-fix they executed
+  even when the trigger's ``allowed_tools`` excluded them (observed on a
+  deployed worker as ``Agent`` / ``mcp__controls__archiver_read`` running
+  un-triggered). Post-fix the PreToolUse hook — which fires for every call —
+  denies them.
+
+* **Repro B (subagent starvation):** with the settings allow-rules stripped
+  (so success cannot come from settings), a channel-finder delegation must
+  work with a trigger list that names NONE of the subagent's tools — the
+  hook grants each subagent exactly its declared ``tools:`` surface.
+  Pre-fix, the flat allowlist callback denied every subagent call.
+
+* **Repro C (approval-hook-allow bypass):** with approval disabled, the
+  facility ``osprey_approval.py`` hook emits explicit ``allow`` for
+  ``mcp__controls__*`` — and CLI hook aggregation is NOT deny-dominates
+  (see osprey_approval.py's own aggregation note), so pre-fix that allow
+  could override the worker's deny. Under ``OSPREY_DISPATCH_RUN=1`` the
+  approval hook emits no decision, so the worker hook's deny stands.
+
+Runs are direct ``POST /dispatch`` calls to the worker (bearer-token), no
+dispatcher needed. Requires ALS-APG credentials; skips cleanly without.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import urllib.request
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.test_dispatch_tutorial import (
+    HEALTH_TIMEOUT_SEC,
+    _find_osprey_console_script,
+    _free_port,
+    _terminate,
+    _wait_for_health,
+)
+
+TOKEN = "parity-e2e-token"
+RUN_TIMEOUT_SEC = 320.0  # worker's own DISPATCH_TIMEOUT (300s) + polling slack
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.requires_als_apg,
+    pytest.mark.flaky(reruns=2, reruns_delay=5),  # agentic-e2e convention
+]
+
+# Deny messages emitted by the worker's tool policy (tool_policy.py).
+HOOK_DENY_MARKERS = (
+    "is not in this trigger's allowed_tools list",
+    "is not in subagent",
+    "dispatch server denylist",
+)
+
+
+def _denied_by_policy(result_text: str | None) -> bool:
+    return any(marker in (result_text or "") for marker in HOOK_DENY_MARKERS)
+
+
+# ---------------------------------------------------------------------------
+# Project fixtures — one real build, mutated copies per scenario
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def built_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Build a real als-apg control-assistant project once per module."""
+    base = tmp_path_factory.mktemp("parity_build")
+    project_dir = base / "proj"
+    proc = subprocess.run(
+        [
+            str(_find_osprey_console_script()),
+            "build",
+            "proj",
+            "--preset",
+            "control-assistant",
+            "--set",
+            "provider=als-apg",
+            "--set",
+            "model=haiku",
+            "--skip-deps",
+            "--skip-lifecycle",
+            "--output-dir",
+            str(base),
+            "--force",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        env={**os.environ, "CLAUDECODE": ""},
+    )
+    if proc.returncode != 0:
+        pytest.fail(f"osprey build failed (rc={proc.returncode}):\n{proc.stdout}\n{proc.stderr}")
+    return project_dir
+
+
+def _copy_project(src: Path, dst: Path) -> Path:
+    shutil.copytree(src, dst, symlinks=True)
+    return dst
+
+
+@pytest.fixture(scope="module")
+def stripped_project(built_project: Path, tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Copy of the built project with the Repro-B tools stripped from
+    ``settings.json`` ``permissions.allow`` — success can then only come from
+    the worker's hook, never from settings (discriminating fixture)."""
+    project = _copy_project(built_project, tmp_path_factory.mktemp("parity_stripped") / "proj")
+    settings_path = project / ".claude" / "settings.json"
+    settings = json.loads(settings_path.read_text())
+    before = settings.get("permissions", {}).get("allow", [])
+    after = [
+        entry
+        for entry in before
+        if "channel-finder" not in entry
+        and "submit_response" not in entry
+        and "data_list" not in entry
+        and not entry.startswith(("Task(", "Agent("))
+    ]
+    assert len(after) < len(before), "fixture did not strip anything — check settings.json"
+    settings["permissions"]["allow"] = after
+    settings_path.write_text(json.dumps(settings, indent=2))
+    return project
+
+
+@pytest.fixture(scope="module")
+def approval_off_project(built_project: Path, tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Copy of the built project with ``approval.enabled: false`` so the
+    facility approval hook's explicit-allow path fires deterministically."""
+    import yaml
+
+    project = _copy_project(built_project, tmp_path_factory.mktemp("parity_approval_off") / "proj")
+    config_path = project / "config.yml"
+    config = yaml.safe_load(config_path.read_text())
+    config.setdefault("approval", {})["enabled"] = False
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False))
+    return project
+
+
+# ---------------------------------------------------------------------------
+# Worker harness
+# ---------------------------------------------------------------------------
+
+
+def _start_worker(project_dir: Path) -> tuple[subprocess.Popen, str]:
+    port = _free_port()
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "osprey.mcp_server.dispatch_worker"],
+        cwd=str(project_dir),
+        env={
+            **os.environ,
+            "DISPATCH_WORKER_PORT": str(port),
+            "DISPATCH_WORKER_TOKEN": TOKEN,
+            "OSPREY_PROJECT_DIR": str(project_dir),
+            "CONFIG_FILE": str(project_dir / "config.yml"),
+            "CLAUDECODE": "",
+        },
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    url = f"http://127.0.0.1:{port}"
+    _wait_for_health(f"{url}/health", HEALTH_TIMEOUT_SEC, proc)
+    return proc, url
+
+
+@pytest.fixture
+def worker(request) -> Iterator[str]:
+    """Start a real worker on the project fixture named by the test param."""
+    project_dir = request.getfixturevalue(request.param)
+    proc, url = _start_worker(project_dir)
+    try:
+        yield url
+    finally:
+        _terminate(proc)
+
+
+def _http_json(url: str, payload: dict | None = None) -> dict:
+    body = json.dumps(payload).encode("utf-8") if payload is not None else None
+    req = urllib.request.Request(  # noqa: S310 - localhost only
+        url,
+        data=body,
+        method="POST" if body else "GET",
+        headers={"Authorization": f"Bearer {TOKEN}", "Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=30.0) as resp:  # noqa: S310
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def dispatch_and_wait(worker_url: str, prompt: str, allowed_tools: list[str]) -> dict:
+    """POST /dispatch and poll until the run leaves 'running'."""
+    accepted = _http_json(
+        f"{worker_url}/dispatch",
+        {"prompt": prompt, "allowed_tools": allowed_tools, "max_turns": 15},
+    )
+    run_id = accepted["run_id"]
+    deadline = time.monotonic() + RUN_TIMEOUT_SEC
+    while time.monotonic() < deadline:
+        run = _http_json(f"{worker_url}/dispatch/{run_id}")
+        if run.get("status") not in ("running", "pending"):
+            return run
+        time.sleep(3.0)
+    pytest.fail(f"dispatch run {run_id} did not finish within {RUN_TIMEOUT_SEC}s")
+
+
+def _calls(run: dict, prefix: str) -> list[dict]:
+    return [tc for tc in run.get("tool_calls", []) if tc["name"].startswith(prefix)]
+
+
+# ---------------------------------------------------------------------------
+# Repro A — settings-allow bypass is closed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("worker", ["built_project"], indirect=True)
+def test_settings_allowed_tool_is_denied_when_trigger_excludes_it(worker):
+    """Pre-fix (red): data_list executed because settings.json allow-rules are
+    evaluated before can_use_tool (SDK never consults the callback for them).
+    Post-fix: the PreToolUse hook denies it — trigger list is the authority."""
+    run = dispatch_and_wait(
+        worker,
+        "Use the data_list tool to list the available data files, then summarize.",
+        allowed_tools=["mcp__controls__channel_read"],
+    )
+
+    attempts = _calls(run, "mcp__osprey_workspace__data_list")
+    assert attempts, f"agent never attempted data_list; text={run.get('text_output')!r}"
+    for tc in attempts:
+        assert _denied_by_policy(tc["result"]), (
+            f"settings-allowed tool executed despite trigger exclusion: {tc}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Repro B — declared subagents work without trigger changes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("worker", ["stripped_project"], indirect=True)
+def test_subagent_tools_work_in_settings_stripped_project(worker):
+    """Pre-fix (red): every channel-finder subagent call was denied by the flat
+    trigger allowlist. Post-fix: the context-aware hook grants the subagent its
+    declared tools:, in a fixture where settings.json cannot be the reason."""
+    run = dispatch_and_wait(
+        worker,
+        "Find the channel address for the storage ring beam current.",
+        allowed_tools=["mcp__controls__channel_read", "mcp__osprey_workspace__data_list"],
+    )
+
+    sub_calls = _calls(run, "mcp__channel-finder__") + _calls(
+        run, "mcp__osprey_workspace__submit_response"
+    )
+    assert sub_calls, (
+        "agent never delegated to channel-finder; "
+        f"tools={[tc['name'] for tc in run.get('tool_calls', [])]}, "
+        f"text={run.get('text_output')!r}"
+    )
+    denied = [tc for tc in sub_calls if _denied_by_policy(tc["result"])]
+    assert not denied, f"subagent tool calls denied (starvation persists): {denied}"
+
+    # CF-2 leg: harness pass-through — if the agent waited for MCP cold-start,
+    # that call must not have been denied by the policy.
+    for tc in _calls(run, "WaitForMcpServers"):
+        assert not _denied_by_policy(tc["result"])
+
+
+# ---------------------------------------------------------------------------
+# Repro C — approval-hook explicit allow cannot override the worker's deny
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("worker", ["approval_off_project"], indirect=True)
+def test_approval_hook_allow_does_not_override_worker_deny(worker):
+    """With approval disabled the facility hook would emit an explicit allow
+    for mcp__controls__* (documented to override static permission lists, and
+    CLI aggregation is not deny-dominates). Under OSPREY_DISPATCH_RUN=1 it
+    emits no decision, so the worker hook's deny must stand for a
+    trigger-excluded controls tool."""
+    run = dispatch_and_wait(
+        worker,
+        "Read the archived history for channel SR:BEAM:CURRENT using the archiver.",
+        allowed_tools=["mcp__controls__channel_read"],
+    )
+
+    attempts = _calls(run, "mcp__controls__archiver_read")
+    assert attempts, f"agent never attempted archiver_read; text={run.get('text_output')!r}"
+    for tc in attempts:
+        assert _denied_by_policy(tc["result"]), (
+            f"approval-hook allow overrode the worker deny: {tc}"
+        )

--- a/tests/hooks/test_osprey_approval_dispatch_guard.py
+++ b/tests/hooks/test_osprey_approval_dispatch_guard.py
@@ -1,0 +1,125 @@
+"""Tests for the approval hook's dispatch-context guard.
+
+In headless dispatch runs the worker sets ``OSPREY_DISPATCH_RUN=1``. The
+approval hook must then never emit an explicit ``permissionDecision: allow``
+— CLI hook aggregation is not deny-dominates, so an explicit allow would
+override the dispatch worker's per-trigger allowlist hook. Ask output is
+unaffected: it falls through to the worker's context-aware ``can_use_tool``
+backstop, which decides.
+"""
+
+import pytest
+
+DISPATCH_HOOK_CONFIG = {
+    "server_prefixes": ["mcp__controls__"],
+    "approval_prefixes": ["mcp__controls__"],
+}
+
+WRITE_INPUT = {"operations": [{"channel": "TEST:PV", "value": 1.0}]}
+
+
+def _decision(result) -> str | None:
+    if result is None:
+        return None
+    return result.get("hookSpecificOutput", {}).get("permissionDecision")
+
+
+@pytest.mark.unit
+def test_allow_path_emits_no_decision_in_dispatch_context(
+    tmp_path, hook_runner, make_config, monkeypatch
+):
+    """approval.enabled=false normally emits explicit allow — not under dispatch."""
+    monkeypatch.setenv("OSPREY_DISPATCH_RUN", "1")
+    config = make_config(
+        {"approval": {"enabled": False}, "control_system": {"writes_enabled": True}}
+    )
+
+    result = hook_runner(
+        "osprey_approval.py",
+        "mcp__controls__archiver_read",
+        {"channels": ["TEST:PV"]},
+        config_path=config,
+        cwd=tmp_path,
+        hook_config=DISPATCH_HOOK_CONFIG,
+    )
+
+    # No decision (empty/none output) — never an explicit allow
+    assert _decision(result) is None
+
+
+@pytest.mark.unit
+def test_allow_path_unchanged_outside_dispatch_context(
+    tmp_path, hook_runner, make_config, monkeypatch
+):
+    """Without the env var the explicit allow is preserved (web-terminal behavior)."""
+    monkeypatch.delenv("OSPREY_DISPATCH_RUN", raising=False)
+    config = make_config(
+        {"approval": {"enabled": False}, "control_system": {"writes_enabled": True}}
+    )
+
+    result = hook_runner(
+        "osprey_approval.py",
+        "mcp__controls__archiver_read",
+        {"channels": ["TEST:PV"]},
+        config_path=config,
+        cwd=tmp_path,
+        hook_config=DISPATCH_HOOK_CONFIG,
+    )
+
+    assert _decision(result) == "allow"
+
+
+@pytest.mark.unit
+def test_skip_policy_emits_no_decision_in_dispatch_context(
+    tmp_path, hook_runner, make_config, monkeypatch
+):
+    """Per-tool policy 'skip' is the other explicit-allow path — also guarded."""
+    monkeypatch.setenv("OSPREY_DISPATCH_RUN", "1")
+    config = make_config(
+        {
+            "approval": {
+                "enabled": True,
+                "default_policy": "always",
+                "tools": {"archiver_read": "skip"},
+            },
+            "control_system": {"writes_enabled": True},
+        }
+    )
+
+    result = hook_runner(
+        "osprey_approval.py",
+        "mcp__controls__archiver_read",
+        {"channels": ["TEST:PV"]},
+        config_path=config,
+        cwd=tmp_path,
+        hook_config=DISPATCH_HOOK_CONFIG,
+    )
+
+    assert _decision(result) is None
+
+
+@pytest.mark.unit
+def test_ask_path_still_asks_in_dispatch_context(tmp_path, hook_runner, make_config, monkeypatch):
+    """The approval ask-gate for writes is untouched by the dispatch guard."""
+    monkeypatch.setenv("OSPREY_DISPATCH_RUN", "1")
+    config = make_config(
+        {
+            "approval": {
+                "enabled": True,
+                "default_policy": "selective",
+                "requires_approval": ["channel_write", "execute"],
+            },
+            "control_system": {"writes_enabled": True},
+        }
+    )
+
+    result = hook_runner(
+        "osprey_approval.py",
+        "mcp__controls__channel_write",
+        WRITE_INPUT,
+        config_path=config,
+        cwd=tmp_path,
+        hook_config=DISPATCH_HOOK_CONFIG,
+    )
+
+    assert _decision(result) == "ask"

--- a/tests/unit/dispatch_worker/test_agent_surfaces.py
+++ b/tests/unit/dispatch_worker/test_agent_surfaces.py
@@ -1,0 +1,191 @@
+"""Unit tests for parse_project_agents (dispatch_worker.agent_surfaces).
+
+The parser reads the provisioned ``<project>/.claude/agents/*.md`` files and
+returns ``{agent_name: frozenset(tools) | None}`` — ``None`` marks a declared
+agent without an explicit ``tools:`` list (inherits-all semantics), which the
+dispatch policy treats as non-delegable.
+"""
+
+import logging
+from pathlib import Path
+
+from osprey.mcp_server.dispatch_worker.agent_surfaces import parse_project_agents
+
+
+def _write_agent(agents_dir: Path, filename: str, content: str) -> Path:
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    path = agents_dir / filename
+    path.write_text(content)
+    return path
+
+
+def _project(tmp_path: Path) -> Path:
+    return tmp_path / "project"
+
+
+def _agents_dir(tmp_path: Path) -> Path:
+    return _project(tmp_path) / ".claude" / "agents"
+
+
+class TestParseProjectAgents:
+    def test_comma_string_tools_parsed(self, tmp_path):
+        # Arrange — templates render tools: as a comma-separated scalar
+        _write_agent(
+            _agents_dir(tmp_path),
+            "channel-finder.md",
+            "---\n"
+            "name: channel-finder\n"
+            "tools: mcp__channel-finder__search, mcp__osprey_workspace__submit_response\n"
+            "---\n\n# Channel Finder Agent\n",
+        )
+
+        # Act
+        surfaces = parse_project_agents(_project(tmp_path))
+
+        # Assert
+        assert surfaces == {
+            "channel-finder": frozenset(
+                {"mcp__channel-finder__search", "mcp__osprey_workspace__submit_response"}
+            )
+        }
+
+    def test_yaml_list_tools_parsed(self, tmp_path):
+        # Arrange — customized files may legally use YAML list form
+        _write_agent(
+            _agents_dir(tmp_path),
+            "custom.md",
+            "---\nname: custom\ntools:\n  - mcp__ariel__keyword_search\n  - Read\n---\nbody\n",
+        )
+
+        # Act
+        surfaces = parse_project_agents(_project(tmp_path))
+
+        # Assert
+        assert surfaces == {"custom": frozenset({"mcp__ariel__keyword_search", "Read"})}
+
+    def test_missing_tools_key_yields_none(self, tmp_path, caplog):
+        # Arrange — inherits-all agent: declared but non-delegable
+        _write_agent(
+            _agents_dir(tmp_path),
+            "wild.md",
+            "---\nname: wild\ndescription: no tools declared\n---\nbody\n",
+        )
+
+        # Act
+        with caplog.at_level(logging.WARNING):
+            surfaces = parse_project_agents(_project(tmp_path))
+
+        # Assert
+        assert surfaces == {"wild": None}
+        assert any("wild" in r.message for r in caplog.records)
+
+    def test_malformed_yaml_skips_file(self, tmp_path, caplog):
+        # Arrange
+        _write_agent(
+            _agents_dir(tmp_path),
+            "broken.md",
+            "---\nname: [unclosed\ntools: {{{{\n---\nbody\n",
+        )
+
+        # Act
+        with caplog.at_level(logging.WARNING):
+            surfaces = parse_project_agents(_project(tmp_path))
+
+        # Assert
+        assert surfaces == {}
+        assert any("broken.md" in r.message for r in caplog.records)
+
+    def test_file_without_frontmatter_skipped(self, tmp_path):
+        # Arrange
+        _write_agent(_agents_dir(tmp_path), "readme.md", "# Not an agent file\n")
+
+        # Act / Assert
+        assert parse_project_agents(_project(tmp_path)) == {}
+
+    def test_empty_file_skipped(self, tmp_path):
+        # Arrange
+        _write_agent(_agents_dir(tmp_path), "empty.md", "")
+
+        # Act / Assert
+        assert parse_project_agents(_project(tmp_path)) == {}
+
+    def test_duplicate_name_last_wins_with_warning(self, tmp_path, caplog):
+        # Arrange — two files declaring the same frontmatter name
+        _write_agent(_agents_dir(tmp_path), "a-first.md", "---\nname: dup\ntools: ToolA\n---\n")
+        _write_agent(_agents_dir(tmp_path), "b-second.md", "---\nname: dup\ntools: ToolB\n---\n")
+
+        # Act
+        with caplog.at_level(logging.WARNING):
+            surfaces = parse_project_agents(_project(tmp_path))
+
+        # Assert — sorted glob order: b-second.md parsed last
+        assert surfaces == {"dup": frozenset({"ToolB"})}
+        assert any("dup" in r.message for r in caplog.records)
+
+    def test_frontmatter_name_differs_from_filename(self, tmp_path):
+        # Arrange — the CLI dispatches on frontmatter name, not filename
+        _write_agent(_agents_dir(tmp_path), "some-file.md", "---\nname: real-name\ntools: T\n---\n")
+
+        # Act
+        surfaces = parse_project_agents(_project(tmp_path))
+
+        # Assert
+        assert "real-name" in surfaces
+        assert "some-file" not in surfaces
+
+    def test_missing_name_skips_file(self, tmp_path, caplog):
+        # Arrange
+        _write_agent(_agents_dir(tmp_path), "anon.md", "---\ntools: T\n---\n")
+
+        # Act
+        with caplog.at_level(logging.WARNING):
+            surfaces = parse_project_agents(_project(tmp_path))
+
+        # Assert
+        assert surfaces == {}
+
+    def test_missing_agents_dir_returns_empty(self, tmp_path):
+        # Arrange — project exists, .claude/agents does not
+        _project(tmp_path).mkdir(parents=True)
+
+        # Act / Assert
+        assert parse_project_agents(_project(tmp_path)) == {}
+
+    def test_subdirectories_not_descended(self, tmp_path):
+        # Arrange — templates ship a _terminology sibling dir
+        sub = _agents_dir(tmp_path) / "_terminology"
+        _write_agent(sub, "nested.md", "---\nname: nested\ntools: T\n---\n")
+
+        # Act / Assert
+        assert parse_project_agents(_project(tmp_path)) == {}
+
+    def test_non_dict_frontmatter_skipped(self, tmp_path):
+        # Arrange — YAML that parses to a scalar, not a mapping
+        _write_agent(_agents_dir(tmp_path), "scalar.md", "---\njust a string\n---\n")
+
+        # Act / Assert
+        assert parse_project_agents(_project(tmp_path)) == {}
+
+    def test_tools_odd_type_yields_none(self, tmp_path):
+        # Arrange — tools: as a mapping is not a valid surface declaration
+        _write_agent(_agents_dir(tmp_path), "odd.md", "---\nname: odd\ntools:\n  key: val\n---\n")
+
+        # Act
+        surfaces = parse_project_agents(_project(tmp_path))
+
+        # Assert
+        assert surfaces == {"odd": None}
+
+    def test_comma_string_strips_and_drops_empties(self, tmp_path):
+        # Arrange — trailing comma as rendered by the Jinja loop
+        _write_agent(
+            _agents_dir(tmp_path),
+            "trail.md",
+            "---\nname: trail\ntools: ToolA, ToolB, \n---\n",
+        )
+
+        # Act
+        surfaces = parse_project_agents(_project(tmp_path))
+
+        # Assert
+        assert surfaces == {"trail": frozenset({"ToolA", "ToolB"})}

--- a/tests/unit/dispatch_worker/test_sdk_runner.py
+++ b/tests/unit/dispatch_worker/test_sdk_runner.py
@@ -19,7 +19,14 @@ import asyncio
 from unittest.mock import MagicMock
 
 import pytest
-from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+from claude_agent_sdk import (
+    AssistantMessage,
+    ResultMessage,
+    TextBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+    UserMessage,
+)
 
 from osprey.mcp_server.dispatch_worker import sdk_runner
 
@@ -83,6 +90,117 @@ async def test_happy_path(monkeypatch):
     assert "done" in types
     text_event = next(e for e in events if e["type"] == "text")
     assert text_event["content"] == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_tool_result_in_user_message_is_captured(monkeypatch):
+    """Tool results arrive as ToolResultBlock inside UserMessage — the runner
+    must pair them with the originating ToolUseBlock (permission-denial
+    messages surface this way; the parity e2e depends on seeing them)."""
+
+    async def fake_query(prompt, options):
+        yield AssistantMessage(
+            content=[ToolUseBlock(id="tu1", name="mcp__x__y", input={})], model="m"
+        )
+        yield UserMessage(
+            content=[
+                ToolResultBlock(
+                    tool_use_id="tu1",
+                    content="Tool 'mcp__x__y' is not in this trigger's allowed_tools list",
+                )
+            ]
+        )
+        yield _result_message(cost_usd=0.1, num_turns=1)
+
+    monkeypatch.setattr(sdk_runner, "query", fake_query)
+
+    result = await sdk_runner.run_dispatch("go", ["Read"], event_queue=asyncio.Queue())
+
+    assert result["tool_calls"] == [
+        {
+            "name": "mcp__x__y",
+            "input": {},
+            "result": "Tool 'mcp__x__y' is not in this trigger's allowed_tools list",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tool_policy_wiring(monkeypatch, tmp_path):
+    """run_dispatch wires the dispatch tool policy into ClaudeAgentOptions.
+
+    The PreToolUse hook is the single authority (fires even for
+    settings-allowed calls); allowed_tools stays trigger-only (no subagent
+    union — that would widen the main thread); exact denied tools plus
+    server-level rules for prefix entries land in disallowed_tools; the
+    context-aware backstop replaces the flat allowlist callback; and
+    OSPREY_DISPATCH_RUN=1 marks the session for the approval hook's guard.
+    """
+    from types import SimpleNamespace
+
+    # Arrange — a project with one declared subagent
+    agents_dir = tmp_path / ".claude" / "agents"
+    agents_dir.mkdir(parents=True)
+    (agents_dir / "channel-finder.md").write_text(
+        "---\nname: channel-finder\ntools: mcp__channel-finder__search\n---\n"
+    )
+    monkeypatch.setenv("OSPREY_PROJECT_DIR", str(tmp_path))
+    captured: dict = {}
+
+    async def fake_query(prompt, options):
+        captured["options"] = options
+        yield AssistantMessage(content=[TextBlock(text="ok")], model="m")
+        yield _result_message(cost_usd=0.1, num_turns=1)
+
+    monkeypatch.setattr(sdk_runner, "query", fake_query)
+
+    # Act
+    await sdk_runner.run_dispatch(
+        "do it",
+        ["mcp__controls__channel_read"],
+        event_queue=asyncio.Queue(),
+        denied_tools=["Bash", "WebFetch", "mcp__plugin_playwright_playwright__*"],
+    )
+    options = captured["options"]
+
+    # Assert — trigger-only allowed_tools, unchanged setting sources
+    assert options.allowed_tools == ["mcp__controls__channel_read"]
+    assert options.setting_sources == ["project"]
+    assert options.env["OSPREY_DISPATCH_RUN"] == "1"
+
+    # Assert — exact denies + server rule for the prefix entry, model-context strip
+    assert options.disallowed_tools == [
+        "Bash",
+        "WebFetch",
+        "mcp__plugin_playwright_playwright",
+    ]
+
+    # Assert — hook registered as catch-all PreToolUse matcher and enforcing
+    matchers = options.hooks["PreToolUse"]
+    assert len(matchers) == 1
+    assert matchers[0].matcher is None
+    (hook,) = matchers[0].hooks
+    denied = await hook({"tool_name": "mcp__osprey_workspace__data_list"}, "t", None)
+    assert denied["hookSpecificOutput"]["permissionDecision"] == "deny"
+    allowed = await hook({"tool_name": "mcp__controls__channel_read"}, "t", None)
+    assert allowed == {}
+    sub_ok = await hook(
+        {
+            "tool_name": "mcp__channel-finder__search",
+            "agent_id": "a1",
+            "agent_type": "channel-finder",
+        },
+        "t",
+        None,
+    )
+    assert sub_ok == {}
+
+    # Assert — backstop is context-aware, not the flat allowlist
+    backstop = options.can_use_tool
+    main_deny = await backstop("mcp__channel-finder__search", {}, SimpleNamespace(agent_id=None))
+    assert type(main_deny).__name__ == "PermissionResultDeny"
+    sub_allow = await backstop("mcp__channel-finder__search", {}, SimpleNamespace(agent_id="a1"))
+    assert type(sub_allow).__name__ == "PermissionResultAllow"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/dispatch_worker/test_tool_policy.py
+++ b/tests/unit/dispatch_worker/test_tool_policy.py
@@ -1,0 +1,370 @@
+"""Unit tests for the dispatch permission policy (dispatch_worker.tool_policy).
+
+Covers the two enforcement layers built per run:
+
+* ``make_pretooluse_hook`` — the single authority. Deny-only: allowed calls
+  return ``{}`` (no decision) so facility hooks and the permission flow still
+  apply; everything else returns an explicit deny decision.
+* ``make_backstop`` — context-aware ``can_use_tool`` for calls the CLI routes
+  to the permission prompt (defense-in-depth under the hook).
+
+Hook input dicts use the SDK wire format (snake_case): ``tool_name``,
+``tool_input``, ``agent_id``/``agent_type`` (present only inside subagents).
+"""
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from osprey.mcp_server.dispatch_worker.tool_policy import (
+    DELEGATION_TOOLS,
+    PASSTHROUGH_TOOLS,
+    make_backstop,
+    make_pretooluse_hook,
+)
+
+TRIGGER_TOOLS = ["mcp__controls__channel_read", "mcp__ariel__keyword_search"]
+SURFACES = {
+    "channel-finder": frozenset(
+        {"mcp__channel-finder__search", "mcp__osprey_workspace__submit_response"}
+    ),
+    "wild": None,  # declared, but no explicit tools: list -> non-delegable
+}
+DENIED = ["Bash", "WebFetch", "mcp__plugin_playwright_playwright__*"]
+
+
+def _hook(trigger=TRIGGER_TOOLS, surfaces=SURFACES, denied=DENIED):
+    return make_pretooluse_hook(trigger, surfaces, denied)
+
+
+def _main_input(tool, tool_input=None):
+    return {"hook_event_name": "PreToolUse", "tool_name": tool, "tool_input": tool_input or {}}
+
+
+def _subagent_input(tool, agent_type="channel-finder", tool_input=None):
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": tool,
+        "tool_input": tool_input or {},
+        "agent_id": "agent-123",
+        "agent_type": agent_type,
+    }
+
+
+def _decision(result):
+    return (result or {}).get("hookSpecificOutput", {}).get("permissionDecision")
+
+
+def _reason(result):
+    return (result or {}).get("hookSpecificOutput", {}).get("permissionDecisionReason", "")
+
+
+# ---------------------------------------------------------------------------
+# make_pretooluse_hook
+# ---------------------------------------------------------------------------
+
+
+class TestPretooluseHookContexts:
+    async def test_hook_allows_trigger_tool_on_main_thread_with_no_decision(self):
+        # Arrange
+        hook = _hook()
+
+        # Act
+        result = await hook(_main_input("mcp__controls__channel_read"), "t1", None)
+
+        # Assert — {} means "no decision": permission flow / facility hooks still apply
+        assert result == {}
+
+    async def test_hook_denies_non_trigger_tool_on_main_thread(self):
+        # Arrange
+        hook = _hook()
+
+        # Act — settings-allowed tool that the trigger did not name
+        result = await hook(_main_input("mcp__osprey_workspace__data_list"), "t1", None)
+
+        # Assert
+        assert _decision(result) == "deny"
+        assert "mcp__osprey_workspace__data_list" in _reason(result)
+
+    async def test_hook_denies_subagent_only_tool_on_main_thread(self):
+        # Arrange — subagent surfaces must not leak into the main thread
+        hook = _hook()
+
+        # Act
+        result = await hook(_main_input("mcp__channel-finder__search"), "t1", None)
+
+        # Assert
+        assert _decision(result) == "deny"
+
+    async def test_hook_allows_declared_tool_inside_subagent(self):
+        # Arrange
+        hook = _hook()
+
+        # Act
+        result = await hook(_subagent_input("mcp__channel-finder__search"), "t1", None)
+
+        # Assert
+        assert result == {}
+
+    async def test_hook_denies_tool_outside_subagent_surface(self):
+        # Arrange — trigger tools do not leak into the subagent context
+        hook = _hook()
+
+        # Act
+        result = await hook(_subagent_input("mcp__ariel__keyword_search"), "t1", None)
+
+        # Assert
+        assert _decision(result) == "deny"
+
+    async def test_hook_denies_when_agent_id_present_but_agent_type_unknown(self):
+        # Arrange
+        hook = _hook()
+        input_data = _subagent_input("mcp__channel-finder__search", agent_type="mystery")
+
+        # Act
+        result = await hook(input_data, "t1", None)
+
+        # Assert — fail-closed on unknown context
+        assert _decision(result) == "deny"
+
+    async def test_hook_denies_when_agent_id_present_but_agent_type_missing(self):
+        # Arrange
+        hook = _hook()
+        input_data = _subagent_input("mcp__channel-finder__search")
+        del input_data["agent_type"]
+
+        # Act
+        result = await hook(input_data, "t1", None)
+
+        # Assert
+        assert _decision(result) == "deny"
+
+
+class TestPretooluseHookDenylist:
+    async def test_hook_denies_bash_even_when_in_trigger_and_surface(self):
+        # Arrange — deny beats allow everywhere
+        hook = make_pretooluse_hook(["Bash"], {"channel-finder": frozenset({"Bash"})}, DENIED)
+
+        # Act
+        main = await hook(_main_input("Bash"), "t1", None)
+        sub = await hook(_subagent_input("Bash"), "t2", None)
+
+        # Assert
+        assert _decision(main) == "deny"
+        assert _decision(sub) == "deny"
+
+    async def test_hook_denies_prefix_denylist_entry(self):
+        # Arrange
+        hook = _hook()
+
+        # Act
+        result = await hook(_main_input("mcp__plugin_playwright_playwright__click"), "t1", None)
+
+        # Assert
+        assert _decision(result) == "deny"
+
+    async def test_hook_denylist_beats_passthrough(self):
+        # Arrange — a passthrough name placed on the denylist stays denied
+        hook = make_pretooluse_hook(TRIGGER_TOOLS, SURFACES, ["TodoWrite"])
+
+        # Act
+        result = await hook(_main_input("TodoWrite"), "t1", None)
+
+        # Assert
+        assert _decision(result) == "deny"
+
+
+class TestPretooluseHookPassthrough:
+    async def test_hook_passthrough_set_is_exactly_pinned(self):
+        # Assert — CF-2: permission-free harness tools only; Read/Glob/Grep excluded
+        assert PASSTHROUGH_TOOLS == frozenset({"TodoWrite", "WaitForMcpServers"})
+
+    @pytest.mark.parametrize("tool", sorted(PASSTHROUGH_TOOLS))
+    async def test_hook_allows_passthrough_in_both_contexts(self, tool):
+        # Arrange
+        hook = _hook()
+
+        # Act
+        main = await hook(_main_input(tool), "t1", None)
+        sub = await hook(_subagent_input(tool), "t2", None)
+
+        # Assert
+        assert main == {}
+        assert sub == {}
+
+    @pytest.mark.parametrize("tool", ["Read", "Glob", "Grep"])
+    async def test_hook_does_not_passthrough_file_tools(self, tool):
+        # Arrange — main-thread Read would expose config.yml provider config
+        hook = _hook()
+
+        # Act
+        result = await hook(_main_input(tool), "t1", None)
+
+        # Assert
+        assert _decision(result) == "deny"
+
+
+class TestPretooluseHookDelegation:
+    @pytest.mark.parametrize("tool_name", DELEGATION_TOOLS)
+    async def test_hook_allows_delegation_to_declared_tools_bearing_agent(self, tool_name):
+        # Arrange
+        hook = _hook()
+        input_data = _main_input(tool_name, {"subagent_type": "channel-finder"})
+
+        # Act
+        result = await hook(input_data, "t1", None)
+
+        # Assert — delegation granted by declaration, no trigger change needed
+        assert result == {}
+
+    @pytest.mark.parametrize("tool_name", DELEGATION_TOOLS)
+    async def test_hook_denies_delegation_with_missing_subagent_type(self, tool_name):
+        # Arrange — missing type would fall back to the general-purpose agent
+        hook = _hook()
+
+        # Act
+        result = await hook(_main_input(tool_name, {}), "t1", None)
+
+        # Assert
+        assert _decision(result) == "deny"
+        assert "subagent_type" in _reason(result)
+
+    @pytest.mark.parametrize("tool_name", DELEGATION_TOOLS)
+    async def test_hook_denies_delegation_to_undeclared_agent(self, tool_name):
+        # Arrange
+        hook = _hook()
+        input_data = _main_input(tool_name, {"subagent_type": "nonexistent"})
+
+        # Act
+        result = await hook(input_data, "t1", None)
+
+        # Assert
+        assert _decision(result) == "deny"
+        assert "nonexistent" in _reason(result)
+
+    @pytest.mark.parametrize("tool_name", DELEGATION_TOOLS)
+    async def test_hook_denies_delegation_to_tools_less_agent(self, tool_name):
+        # Arrange — 'wild' is declared but has no explicit tools: list
+        hook = _hook()
+        input_data = _main_input(tool_name, {"subagent_type": "wild"})
+
+        # Act
+        result = await hook(input_data, "t1", None)
+
+        # Assert
+        assert _decision(result) == "deny"
+        assert "wild" in _reason(result)
+        assert "tools" in _reason(result)
+
+
+class TestPretooluseHookFailClosed:
+    async def test_hook_internal_error_denies_and_logs(self, caplog):
+        # Arrange — a surfaces mapping that raises on lookup
+        class Poisoned(dict):
+            def get(self, *a, **kw):  # noqa: D401
+                raise RuntimeError("boom")
+
+        hook = make_pretooluse_hook(TRIGGER_TOOLS, Poisoned(), DENIED)
+
+        # Act
+        with caplog.at_level(logging.ERROR):
+            result = await hook(_subagent_input("mcp__channel-finder__search"), "t1", None)
+
+        # Assert — fail-closed, never fail-open
+        assert _decision(result) == "deny"
+        assert any("boom" in (r.message + str(r.exc_info)) for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# make_backstop
+# ---------------------------------------------------------------------------
+
+
+def _ctx(agent_id=None):
+    return SimpleNamespace(agent_id=agent_id, suggestions=[])
+
+
+def _is_allow(result) -> bool:
+    return type(result).__name__ == "PermissionResultAllow"
+
+
+def _is_deny(result) -> bool:
+    return type(result).__name__ == "PermissionResultDeny"
+
+
+class TestBackstop:
+    async def test_backstop_allows_trigger_tool_on_main_thread(self):
+        # Arrange
+        backstop = make_backstop(TRIGGER_TOOLS, SURFACES, DENIED)
+
+        # Act
+        result = await backstop("mcp__controls__channel_read", {}, _ctx())
+
+        # Assert
+        assert _is_allow(result)
+
+    async def test_backstop_denies_subagent_only_tool_on_main_thread(self):
+        # Arrange — CC-2: no flat union on the main thread
+        backstop = make_backstop(TRIGGER_TOOLS, SURFACES, DENIED)
+
+        # Act
+        result = await backstop("mcp__channel-finder__search", {}, _ctx())
+
+        # Assert
+        assert _is_deny(result)
+        assert "mcp__channel-finder__search" in result.message
+
+    async def test_backstop_allows_union_member_in_subagent_context(self):
+        # Arrange — ToolPermissionContext has no agent_type, only agent_id
+        backstop = make_backstop(TRIGGER_TOOLS, SURFACES, DENIED)
+
+        # Act
+        result = await backstop(
+            "mcp__osprey_workspace__submit_response", {}, _ctx(agent_id="agent-1")
+        )
+
+        # Assert
+        assert _is_allow(result)
+
+    async def test_backstop_denies_non_member_in_subagent_context(self):
+        # Arrange
+        backstop = make_backstop(TRIGGER_TOOLS, SURFACES, DENIED)
+
+        # Act
+        result = await backstop("mcp__osprey_workspace__data_list", {}, _ctx(agent_id="a"))
+
+        # Assert
+        assert _is_deny(result)
+
+    async def test_backstop_denylist_beats_union(self):
+        # Arrange — Bash inside a declared surface is still denied
+        backstop = make_backstop(TRIGGER_TOOLS, {"x": frozenset({"Bash"})}, DENIED)
+
+        # Act
+        result = await backstop("Bash", {}, _ctx(agent_id="a"))
+
+        # Assert
+        assert _is_deny(result)
+
+    async def test_backstop_allows_passthrough_tools(self):
+        # Arrange
+        backstop = make_backstop(TRIGGER_TOOLS, SURFACES, DENIED)
+
+        # Act
+        main = await backstop("WaitForMcpServers", {}, _ctx())
+        sub = await backstop("TodoWrite", {}, _ctx(agent_id="a"))
+
+        # Assert
+        assert _is_allow(main)
+        assert _is_allow(sub)
+
+    async def test_backstop_none_surfaces_contribute_nothing_to_union(self):
+        # Arrange — only 'wild': None declared: union is empty
+        backstop = make_backstop(TRIGGER_TOOLS, {"wild": None}, DENIED)
+
+        # Act
+        result = await backstop("AnyTool", {}, _ctx(agent_id="a"))
+
+        # Assert
+        assert _is_deny(result)

--- a/tests/utils/test_tool_rules.py
+++ b/tests/utils/test_tool_rules.py
@@ -1,0 +1,77 @@
+"""Unit tests for the shared tool denylist matcher (osprey.utils.tool_rules)."""
+
+from osprey.utils.tool_rules import matches_denylist
+
+
+class TestMatchesDenylist:
+    """AAA tests for matches_denylist semantics shared by dispatch + web terminal."""
+
+    def test_exact_entry_matches_exact_tool(self):
+        # Arrange
+        entries = ["Bash", "WebFetch"]
+
+        # Act
+        result = matches_denylist("Bash", entries)
+
+        # Assert
+        assert result is True
+
+    def test_exact_entry_does_not_match_other_tool(self):
+        # Arrange
+        entries = ["Bash"]
+
+        # Act
+        result = matches_denylist("BashOutput", entries)
+
+        # Assert
+        assert result is False
+
+    def test_prefix_entry_matches_by_prefix(self):
+        # Arrange
+        entries = ["mcp__plugin_playwright_playwright__*"]
+
+        # Act
+        result = matches_denylist("mcp__plugin_playwright_playwright__click", entries)
+
+        # Assert
+        assert result is True
+
+    def test_prefix_entry_does_not_match_unrelated_tool(self):
+        # Arrange
+        entries = ["mcp__plugin_playwright_playwright__*"]
+
+        # Act
+        result = matches_denylist("mcp__osprey_workspace__data_list", entries)
+
+        # Assert
+        assert result is False
+
+    def test_bare_star_matches_everything(self):
+        # Arrange
+        entries = ["*"]
+
+        # Act / Assert
+        assert matches_denylist("anything", entries) is True
+        assert matches_denylist("", entries) is True
+
+    def test_empty_entries_matches_nothing(self):
+        # Arrange
+        entries: list[str] = []
+
+        # Act
+        result = matches_denylist("Bash", entries)
+
+        # Assert
+        assert result is False
+
+    def test_empty_tool_name_only_matches_bare_star_or_empty_entry(self):
+        # Arrange / Act / Assert
+        assert matches_denylist("", ["Bash"]) is False
+        assert matches_denylist("", [""]) is True
+
+    def test_prefix_entry_matches_its_own_prefix_exactly(self):
+        # Arrange: "foo*" prefix-matches "foo" itself (empty remainder)
+        entries = ["foo*"]
+
+        # Act / Assert
+        assert matches_denylist("foo", entries) is True


### PR DESCRIPTION
## Problem

Headless dispatch runs enforce their per-trigger tool allowlist via a `can_use_tool` callback — but the CLI never consults that callback for calls already permitted by the project's `settings.json` `permissions.allow` rules (SDK-documented behavior). Three concrete defects, each pinned by a test:

1. **Settings-allow bypass** — settings-allowed tools (`mcp__osprey_workspace__data_list`, `Task(<agent>)` entries, …) executed even when the trigger's `allowed_tools` excluded them. Observed on a deployed worker as `Agent` and `mcp__controls__archiver_read` running un-triggered.
2. **Approval-hook-allow bypass** — with approval off/skip, `osprey_approval.py` emits an explicit `permissionDecision: allow` that overrides static permission lists, and CLI hook aggregation is not deny-dominates (documented in that hook's own aggregation note).
3. **Subagent starvation** — a trigger never names subagent tool surfaces, so closing the bypasses would leave delegation (e.g. channel-finder) denied on every call.

## Fix

A **context-aware, deny-only PreToolUse hook** (`ClaudeAgentOptions.hooks`) is now the single authority — hooks fire for every tool call, including settings-allowed ones and inside subagents:

- Main thread → held to the trigger's `allowed_tools`, exactly.
- Subagent (detected by `agent_id` presence) → held to that agent's declared `tools:` list, parsed from the provisioned `.claude/agents/*.md` (`yaml.safe_load`, comma-string or list form; agents without an explicit `tools:` list are non-delegable).
- Delegation (`Task`/`Agent`) → only to declared, tools-bearing agents via explicit `subagent_type`; missing type is denied (blocks the general-purpose default).
- Allowed calls return **no decision** (never an explicit allow), so facility safety/approval hooks and the permission flow still apply.
- `TodoWrite` and `WaitForMcpServers` pass through (permission-free harness tools; `Read`/`Glob`/`Grep` deliberately excluded). `DENIED_TOOLS` wins everywhere via one shared matcher (`osprey/utils/tool_rules.py`, replacing two duplicates) and exact entries are additionally stripped from model context via `disallowed_tools`.
- `can_use_tool` stays as a context-aware backstop; `osprey_approval.py` emits no allow decision under `OSPREY_DISPATCH_RUN=1` (ask/deny unchanged).

Also fixes a latent observability bug: tool **results** arrive as `ToolResultBlock` inside `UserMessage`, which the runner ignored — every run record and dashboard entry had `result: None` for every call.

## Evidence

- Unit AAA: matcher (8), agent parser (14), hook + backstop (32), approval guard (4), runner wiring + result capture (integration, mocked `query()`).
- E2E (real CLI + worker subprocess, ALS-APG, `requires_als_apg`-gated): settings-allowed tool denied when trigger excludes it (**proven red on unfixed code**, green after); channel-finder delegation succeeds in a settings-**stripped** project (success only reachable via the hook); approval-hook allow cannot override the worker deny.
- `./scripts/ci_check.sh` green; web-terminal permission behavior unchanged (419 existing tests pass unmodified).

Zero changes needed to trigger schemas, `triggers.yml`, or facility prompts — declared subagents now work in dispatch exactly as in the web terminal.