### PR TITLE
web terminal: fix custom-panel proxying for SPA backends like Tiled

### DIFF
--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -176,6 +176,11 @@ def _load_panel_config() -> tuple[set[str], list[dict], str | None]:
                     "url": spec.get("url", ""),
                     "healthEndpoint": spec.get("health_endpoint"),
                     "path": spec.get("path", "/"),
+                    # Path suffixes whose JSON responses get the proxy's
+                    # root-absolute-literal rewrite (see routes/proxy.py) —
+                    # for backends whose SPA bootstraps its API base from a
+                    # JSON config endpoint.
+                    "rewriteJsonPaths": spec.get("rewrite_json_paths") or [],
                 }
             )
 

--- a/src/osprey/interfaces/web_terminal/routes/proxy.py
+++ b/src/osprey/interfaces/web_terminal/routes/proxy.py
@@ -33,6 +33,9 @@ _REWRITE_PREFIXES = (
     "/ws/",
     "/assets/",
     "/dashboard/",
+    # Tiled's built-in web UI (served under /ui/) references root-absolute
+    # /ui/assets/... bundle paths.
+    "/ui/",
     # Event dispatcher endpoints. Without these, the dashboard served through
     # /panel/events/* would call `/webhook/...` at the browser origin (the web
     # terminal) instead of going through this proxy — the dispatcher never
@@ -91,6 +94,17 @@ def _resolve_panel_url(request: Request, panel_id: str) -> str | None:
     return None
 
 
+def _panel_json_rewrite_paths(request: Request, panel_id: str) -> tuple[str, ...]:
+    """The panel's configured ``rewrite_json_paths`` suffixes (usually empty)."""
+    for cp in getattr(request.app.state, "custom_panels", []):
+        if cp.get("id") == panel_id:
+            paths = cp.get("rewriteJsonPaths") or ()
+            if isinstance(paths, (list, tuple)):
+                return tuple(str(p).rstrip("/") for p in paths if p)
+            return (str(paths).rstrip("/"),)
+    return ()
+
+
 def _rewrite_content(body: str, panel_id: str) -> str:
     """Rewrite root-absolute paths inside string delimiters for proxied content.
 
@@ -140,11 +154,17 @@ async def proxy_panel(panel_id: str, path: str, request: Request):
 
     client: httpx.AsyncClient = request.app.state.proxy_client
 
-    # Forward headers, dropping host (httpx sets it) and hop-by-hop.
+    # Forward headers, dropping host (httpx sets it), hop-by-hop, and
+    # accept-encoding. httpx must negotiate content-codings it can itself
+    # decode (it transparently decompresses gzip/br); forwarding the
+    # browser's Accept-Encoding list (which includes zstd) lets upstreams
+    # pick zstd, which httpx cannot decode — it passes the compressed bytes
+    # through unchanged while the proxy strips the content-encoding header
+    # below, so the browser renders raw compressed garbage.
     fwd_headers = {
         k: v
         for k, v in request.headers.items()
-        if k.lower() not in _HOP_BY_HOP and k.lower() != "host"
+        if k.lower() not in _HOP_BY_HOP and k.lower() not in ("host", "accept-encoding")
     }
     fwd_headers["x-forwarded-prefix"] = f"/panel/{panel_id}"
 
@@ -223,6 +243,24 @@ async def proxy_panel(panel_id: str, path: str, request: Request):
             headers=resp_headers,
             media_type=content_type,
         )
+
+    # JSON is normally passed through untouched (rewriting arbitrary API
+    # payloads would corrupt data). But some backends bootstrap their web UI
+    # from a JSON config endpoint that carries root-absolute paths (e.g. an
+    # ``api_url`` the SPA uses as its API base) — served through this proxy,
+    # the UI would then call the *browser* origin and silently break. Panels
+    # opt specific endpoints in via ``web.panels.<id>.rewrite_json_paths``
+    # (a list of path suffixes); only those responses get the same
+    # known-prefix literal rewrite HTML/JS/CSS receive.
+    if base_type == "application/json":
+        stripped = path.rstrip("/")
+        if any(stripped.endswith(sfx) for sfx in _panel_json_rewrite_paths(request, panel_id)):
+            return Response(
+                content=_rewrite_content(resp.text, panel_id),
+                status_code=resp.status_code,
+                headers=resp_headers,
+                media_type=content_type,
+            )
 
     # JSON, images, binary — pass through unchanged.
     return Response(

--- a/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
@@ -394,7 +394,9 @@ async function pollHealth(panel) {
   state.polling = true;
 
   try {
-    const resp = await fetch(`${state.url}/health`, {
+    // Use the panel's configured health endpoint — hardcoding /health only
+    // worked while every panel happened to use it (tiled's is /api/v1/).
+    const resp = await fetch(`${state.url}${panel.healthEndpoint || '/health'}`, {
       signal: AbortSignal.timeout(2000),
     });
     const wasHealthy = state.healthy;


### PR DESCRIPTION
## Summary

Embedding Tiled's built-in React UI as a custom web-terminal panel (the bella-profiles DATA tab) surfaced four latent bugs/gaps in the panel proxy path. All are generic — no Tiled-specific behavior lands in osprey; the one new mechanism is config-driven.

- **proxy: don't forward the browser's `Accept-Encoding` upstream.** Browsers offer zstd, which httpx can't decode, so compressed upstream bodies passed through garbled. httpx now negotiates codings it can decode itself.
- **proxy: add `/ui/` to `_REWRITE_PREFIXES`** — Tiled serves its SPA bundle under root-absolute `/ui/assets/...` paths.
- **proxy + app: new per-panel `web.panels.<id>.rewrite_json_paths` config** (list of path suffixes) opting specific JSON endpoints into the same root-absolute-literal rewrite HTML/JS/CSS already get. JSON stays untouched by default (rewriting arbitrary API payloads would corrupt data), but SPAs that bootstrap their API base from a JSON config endpoint — Tiled's `tiled-ui-settings` returns `{"api_url": "/api/v1"}` — otherwise call the *browser* origin through the proxy and silently render an empty catalog. Profiles opt in, e.g. `web.panels.tiled.rewrite_json_paths: ["tiled-ui-settings"]`.
- **panel-manager.js: poll the panel's configured `healthEndpoint`** instead of a hardcoded `/health`. Tiled's is `/api/v1/`; every prior panel happened to use `/health`, so the tab LED sat red for the first panel that didn't.

## Testing

- `tests/interfaces/web_terminal/test_app.py`: 21 passed on this branch.
- Verified end-to-end against a live bella-profiles demo stack: Tiled catalog browses correctly through the proxy (previously: garbled body → login-shell dead end → silently empty catalog), tab LED green via `/api/v1/` health polling, settings JSON rewritten only for the opted-in endpoint.