### PR TITLE
fix(artifacts): render notebooks as self-contained HTML for offline gallery

### DIFF
--- a/src/osprey/stores/notebook_renderer.py
+++ b/src/osprey/stores/notebook_renderer.py
@@ -62,8 +62,31 @@ def create_notebook_from_code(
     return notebook
 
 
+# nbconvert's default HTML template links these assets from public CDNs.
+# The gallery serves rendered notebooks inside a sandboxed iframe, and deployed
+# environments have no outbound internet access (a restrictive proxy blocks
+# external hosts), so those loads fail and the notebook renders broken. Every
+# one is an nbconvert HTMLExporter traitlet; blanking them yields self-contained
+# HTML that depends only on the template's inlined CSS. The cost is that inline
+# LaTeX (MathJax), interactive widgets, and Mermaid diagrams are not rendered —
+# but those already fail in the target environment, so this is a strict
+# improvement there, not a regression.
+_EXTERNAL_ASSET_TRAITS = (
+    "mathjax_url",
+    "require_js_url",
+    "jquery_url",
+    "jupyter_widgets_base_url",
+    "widget_renderer_url",
+    "mermaid_js_url",
+    "mermaid_layout_elk_js_url",
+)
+
+
 def render_notebook_to_html(ipynb_path: Path) -> str:
-    """Render a .ipynb file to HTML using nbconvert.
+    """Render a .ipynb file to self-contained HTML using nbconvert.
+
+    The output references no external resources so it renders correctly inside
+    the gallery's sandboxed iframe in offline / proxied deployments.
 
     Args:
         ipynb_path: Path to the .ipynb file.
@@ -76,7 +99,11 @@ def render_notebook_to_html(ipynb_path: Path) -> str:
     with open(ipynb_path) as f:
         nb = nbformat.read(f, as_version=4)
 
-    exporter = HTMLExporter()
+    exporter = HTMLExporter(embed_images=True)
+    for trait in _EXTERNAL_ASSET_TRAITS:
+        if exporter.has_trait(trait):
+            setattr(exporter, trait, "")
+
     html, _ = exporter.from_notebook_node(nb)
     return html
 

--- a/tests/interfaces/artifacts/test_notebook_rendered.py
+++ b/tests/interfaces/artifacts/test_notebook_rendered.py
@@ -1,0 +1,106 @@
+"""Tests for GET /api/notebooks/{id}/rendered endpoint.
+
+The gallery serves rendered notebooks inside a sandboxed iframe. In deployed
+environments there is no outbound internet access (a restrictive proxy blocks
+external hosts), so the rendered HTML must be fully self-contained: nbconvert's
+default template links MathJax / RequireJS / jQuery / widget / Mermaid assets
+from public CDNs, and those loads fail in production, leaving the notebook
+broken in the gallery. These tests pin the contract that the endpoint renders
+the notebook's cells AND emits no external resource references.
+"""
+
+import re
+
+import nbformat
+import pytest
+
+# Hosts nbconvert's default HTMLExporter template pulls assets from.
+_CDN_HOSTS = ("cdnjs.cloudflare.com", "unpkg.com")
+
+
+def _make_notebook_bytes() -> bytes:
+    nb = nbformat.v4.new_notebook()
+    nb.cells = [
+        nbformat.v4.new_markdown_cell("# Demo Notebook\n\nInline math $x^2$."),
+        nbformat.v4.new_code_cell("print('UNIQUE_CELL_TOKEN')"),
+    ]
+    return nbformat.writes(nb).encode()
+
+
+class TestNotebookRenderedAPI:
+    @pytest.fixture
+    def app_client(self, tmp_path):
+        from fastapi.testclient import TestClient
+
+        from osprey.interfaces.artifacts.app import create_app
+
+        app = create_app(workspace_root=tmp_path)
+        return TestClient(app), tmp_path
+
+    def _save_notebook(self, client):
+        store = client.app.state.artifact_store
+        return store.save_file(
+            file_content=_make_notebook_bytes(),
+            filename="demo.ipynb",
+            artifact_type="notebook",
+            title="Demo Notebook",
+            description="demo",
+            mime_type="application/x-ipynb+json",
+            tool_source="test",
+        )
+
+    @pytest.mark.unit
+    def test_renders_notebook_cells_to_html(self, app_client):
+        """A notebook artifact renders its cell content to an HTML page."""
+        client, _ = app_client
+        entry = self._save_notebook(client)
+
+        resp = client.get(f"/api/notebooks/{entry.id}/rendered")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+        # Code cell content is present (the render actually happened, and the
+        # token survives syntax-highlight span-splitting because it is a single
+        # identifier).
+        assert "UNIQUE_CELL_TOKEN" in resp.text
+
+    @pytest.mark.unit
+    def test_rendered_notebook_is_self_contained(self, app_client):
+        """Rendered HTML must not reference external CDN assets.
+
+        In deployed (proxied, offline) environments those loads fail and the
+        notebook renders broken inside the gallery's sandboxed iframe.
+        """
+        client, _ = app_client
+        entry = self._save_notebook(client)
+
+        html = client.get(f"/api/notebooks/{entry.id}/rendered").text
+
+        # No src=/href= pointing at an external http(s) resource.
+        external = re.findall(r'(?:src|href)\s*=\s*["\'](https?://[^"\']+)["\']', html)
+        assert external == [], f"external resource refs leaked: {sorted(set(external))}"
+
+        # Belt-and-suspenders: the known CDN hosts must not appear anywhere.
+        for host in _CDN_HOSTS:
+            assert host not in html, f"rendered notebook references CDN host {host}"
+
+    @pytest.mark.unit
+    def test_non_notebook_returns_400(self, app_client):
+        client, _ = app_client
+        store = client.app.state.artifact_store
+        entry = store.save_file(
+            file_content=b"# not a notebook",
+            filename="x.md",
+            artifact_type="markdown",
+            title="md",
+            description="",
+            mime_type="text/markdown",
+            tool_source="test",
+        )
+        resp = client.get(f"/api/notebooks/{entry.id}/rendered")
+        assert resp.status_code == 400
+
+    @pytest.mark.unit
+    def test_missing_artifact_returns_404(self, app_client):
+        client, _ = app_client
+        resp = client.get("/api/notebooks/nonexistent-id/rendered")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Problem

Notebook artifacts render broken in the gallery on deployments without outbound
internet access (e.g. behind a restrictive proxy). nbconvert's default `lab`
HTML template links MathJax and RequireJS (plus jQuery/widgets/Mermaid) from
public CDNs (`cdnjs.cloudflare.com`). The gallery serves the render inside a
`sandbox="allow-scripts allow-same-origin"` iframe, so those CDN loads fail and
the notebook renders broken. Cell HTML/CSS is inlined, which is exactly why the
bug is invisible on a dev machine with open internet.

## Fix

`render_notebook_to_html` now blanks nbconvert's external-asset URL traitlets
and sets `embed_images=True`, producing self-contained HTML that depends only on
the template's inlined CSS. Native nbconvert knobs only — no HTML
post-processing. A `has_trait()` guard tolerates nbconvert version drift.

## Deliberate tradeoff

Blanking the MathJax/widget/Mermaid URLs means inline LaTeX equations,
interactive ipywidgets, and Mermaid diagrams no longer render — for **every**
deployment, including sites with open internet where they currently work. This
is a conscious tradeoff: in offline/proxied target environments those already
fail, so it is a strict improvement there; for open-internet sites it is a minor
regression. If preserving equations everywhere matters, the durable follow-up is
vendoring MathJax offline (a larger change, intentionally deferred).

## Known cosmetic cost (low)

Blanking the URL traitlets to `""` leaves two `<script src="">` tags in the
output. An empty `src` resolves to the document's own URL, so the sandboxed
iframe issues two redundant same-origin GETs to the `/rendered` endpoint plus a
benign console error per view. Harmless (same-origin, not proxy-blocked; renders
fine); left as-is to avoid post-processing the exporter's HTML.

## Tests

`tests/interfaces/artifacts/test_notebook_rendered.py` saves a real notebook,
hits `/rendered`, and asserts the HTML contains no external `http(s)` resource
references (plus an explicit CDN-host blocklist). Result: 87 passed (83 baseline
+ 4 new), zero regressions.
