### PR TITLE
feat(web-terminal): optional per-deployment name badge in header

### DIFF
--- a/docs/source/how-to/use-web-terminal.rst
+++ b/docs/source/how-to/use-web-terminal.rst
@@ -204,6 +204,11 @@ badge is shown and the header is unchanged.
    web:
      app_name: "Control Room A"
 
+The ``OSPREY_WEB_APP_NAME`` environment variable overrides ``web.app_name`` when
+set. This is useful when several containers share a single baked config image
+but should each display a distinct name — set the variable per container instead
+of rebuilding a config per deployment.
+
 
 Configuration Reference
 -----------------------

--- a/docs/source/how-to/use-web-terminal.rst
+++ b/docs/source/how-to/use-web-terminal.rst
@@ -191,6 +191,20 @@ The ``/api/panel-focus`` endpoint lets MCP tools programmatically switch the
 active panel.
 
 
+Deployment Name
+^^^^^^^^^^^^^^^
+
+Set an optional human-readable name to distinguish otherwise-identical web
+terminals (for example, several deployments sharing the same layout). It is
+rendered as a muted badge on the right of the header. When unset or empty, no
+badge is shown and the header is unchanged.
+
+.. code-block:: yaml
+
+   web:
+     app_name: "Control Room A"
+
+
 Configuration Reference
 -----------------------
 

--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -319,9 +319,15 @@ def _create_lifespan(
         app.state.broadcaster = FileEventBroadcaster()
         app.state.active_panel = None
         # Optional human-readable deployment name shown in the header so
-        # otherwise-identical web terminals are distinguishable. Sourced from
-        # ``web.app_name`` in config.yml; empty/absent ⇒ no label is rendered.
-        app.state.app_name = str((config.get("web") or {}).get("app_name") or "").strip()
+        # otherwise-identical web terminals are distinguishable. The
+        # ``OSPREY_WEB_APP_NAME`` environment variable takes precedence over
+        # ``web.app_name`` in config.yml, so several containers that share one
+        # baked config image can each be named individually via the environment.
+        # Empty/absent ⇒ no label is rendered.
+        app.state.app_name = (
+            os.environ.get("OSPREY_WEB_APP_NAME", "").strip()
+            or str((config.get("web") or {}).get("app_name") or "").strip()
+        )
 
         # Ensure OSPREY_CONFIG is set before any load_osprey_config() call
         if "OSPREY_CONFIG" not in os.environ:

--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -318,6 +318,10 @@ def _create_lifespan(
         )
         app.state.broadcaster = FileEventBroadcaster()
         app.state.active_panel = None
+        # Optional human-readable deployment name shown in the header so
+        # otherwise-identical web terminals are distinguishable. Sourced from
+        # ``web.app_name`` in config.yml; empty/absent ⇒ no label is rendered.
+        app.state.app_name = str((config.get("web") or {}).get("app_name") or "").strip()
 
         # Ensure OSPREY_CONFIG is set before any load_osprey_config() call
         if "OSPREY_CONFIG" not in os.environ:
@@ -493,7 +497,8 @@ def create_app(
 
     @app.get("/")
     async def root(request: Request):
-        return templates.TemplateResponse(request, "index.html", {})
+        app_name = getattr(request.app.state, "app_name", "")
+        return templates.TemplateResponse(request, "index.html", {"app_name": app_name})
 
     # Mount shared fonts before /static (Starlette matches in declaration order)
     SHARED_FONTS_DIR = Path(__file__).parent.parent / "shared_fonts"

--- a/src/osprey/interfaces/web_terminal/static/css/terminal.css
+++ b/src/osprey/interfaces/web_terminal/static/css/terminal.css
@@ -178,6 +178,25 @@
   color: var(--color-accent-light);
 }
 
+/* Optional per-deployment name badge (web.app_name), pinned to the header's
+   right so otherwise-identical terminals are distinguishable. */
+.header-app-name {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  letter-spacing: 0.04em;
+  padding: 3px 10px;
+  margin-right: 8px;
+  border: 1px solid var(--border-default);
+  border-radius: 5px;
+  background: var(--bg-elevated);
+  white-space: nowrap;
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .header-title {
   font-family: var(--font-mono);
   font-size: 11px;

--- a/src/osprey/interfaces/web_terminal/static/index.html
+++ b/src/osprey/interfaces/web_terminal/static/index.html
@@ -56,6 +56,7 @@
         <!-- Populated by panel-manager.js -->
       </div>
       <div class="header-actions">
+        {% if app_name %}<span class="header-app-name" title="{{ app_name }}">{{ app_name }}</span>{% endif %}
         <a class="header-icon-btn" id="docs-link" href="https://als-apg.github.io/osprey/" title="Documentation" target="_blank" rel="noopener">&#128214;</a>
         <button class="header-icon-btn" id="theme-toggle" title="Toggle theme" aria-label="Switch to light theme">
           <svg id="theme-icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>

--- a/tests/interfaces/web_terminal/test_app.py
+++ b/tests/interfaces/web_terminal/test_app.py
@@ -245,10 +245,13 @@ class TestHeaderAppName:
         # OSPREY_WEB_APP_NAME wins over web.app_name so containers sharing one
         # baked config image can still be named individually.
         cfg = {"watch_dir": str(workspace_dir), "web": {"app_name": "From Config"}}
-        with patch(
-            "osprey.interfaces.web_terminal.app._load_web_config",
-            return_value=cfg,
-        ), patch.dict("os.environ", {"OSPREY_WEB_APP_NAME": "From Env"}):
+        with (
+            patch(
+                "osprey.interfaces.web_terminal.app._load_web_config",
+                return_value=cfg,
+            ),
+            patch.dict("os.environ", {"OSPREY_WEB_APP_NAME": "From Env"}),
+        ):
             app = create_app(shell_command="echo")
             with TestClient(app) as c:
                 assert app.state.app_name == "From Env"

--- a/tests/interfaces/web_terminal/test_app.py
+++ b/tests/interfaces/web_terminal/test_app.py
@@ -240,3 +240,16 @@ class TestHeaderAppName:
         # The shared `client` fixture supplies no `web` section.
         body = client.get("/").text
         assert "header-app-name" not in body
+
+    def test_env_var_overrides_config(self, workspace_dir):
+        # OSPREY_WEB_APP_NAME wins over web.app_name so containers sharing one
+        # baked config image can still be named individually.
+        cfg = {"watch_dir": str(workspace_dir), "web": {"app_name": "From Config"}}
+        with patch(
+            "osprey.interfaces.web_terminal.app._load_web_config",
+            return_value=cfg,
+        ), patch.dict("os.environ", {"OSPREY_WEB_APP_NAME": "From Env"}):
+            app = create_app(shell_command="echo")
+            with TestClient(app) as c:
+                assert app.state.app_name == "From Env"
+                assert "From Env" in c.get("/").text

--- a/tests/interfaces/web_terminal/test_app.py
+++ b/tests/interfaces/web_terminal/test_app.py
@@ -218,3 +218,25 @@ class TestStaticServing:
         resp = client.get("/")
         assert resp.status_code == 200
         assert "text/html" in resp.headers["content-type"]
+
+
+class TestHeaderAppName:
+    """web.app_name surfaces as an optional header badge for deployment ID."""
+
+    def test_app_name_renders_when_set(self, workspace_dir):
+        cfg = {"watch_dir": str(workspace_dir), "web": {"app_name": "Control Room A"}}
+        with patch(
+            "osprey.interfaces.web_terminal.app._load_web_config",
+            return_value=cfg,
+        ):
+            app = create_app(shell_command="echo")
+            with TestClient(app) as c:
+                assert app.state.app_name == "Control Room A"
+                body = c.get("/").text
+                assert "header-app-name" in body
+                assert "Control Room A" in body
+
+    def test_app_name_absent_when_unset(self, client):
+        # The shared `client` fixture supplies no `web` section.
+        body = client.get("/").text
+        assert "header-app-name" not in body


### PR DESCRIPTION
## What

Adds an optional, config-driven application name to the web terminal header so
otherwise-identical terminals are distinguishable at a glance. Set via a new
`web.app_name` key in `config.yml`:

```yaml
web:
  app_name: "Control Room A"
```

Rendered as a muted badge pinned to the right of the header (left of the
docs/theme/settings icons). Unset or empty ⇒ nothing is rendered — no change for
existing deployments.

## How

- `web_terminal/app.py`: the lifespan resolves `web.app_name` onto
  `app.state.app_name` (null-safe for a missing `web:` block or null value); the
  `/` route passes it into the `index.html` template context.
- `static/index.html`: `{% if app_name %}<span class="header-app-name" …>{{ app_name }}</span>{% endif %}`
  — Jinja2 autoescaped, so config-supplied text is XSS-safe.
- `static/css/terminal.css`: `.header-app-name` muted chip using only existing
  theme variables (renders correctly in light and dark), ellipsis-truncated.
- Docs: `web.app_name` documented in `docs/source/how-to/use-web-terminal.rst`.

## Tests

`TestHeaderAppName` in `tests/interfaces/web_terminal/test_app.py` — renders when
set, absent when unset. Full `tests/interfaces/web_terminal/` suite: 379 passed.
