### PR TITLE
test(e2e): deflake dispatch-parity Repro C — fully specify the archiver prompt

### DIFF
--- a/tests/e2e/test_dispatch_allowlist_parity.py
+++ b/tests/e2e/test_dispatch_allowlist_parity.py
@@ -291,7 +291,13 @@ def test_approval_hook_allow_does_not_override_worker_deny(worker):
     trigger-excluded controls tool."""
     run = dispatch_and_wait(
         worker,
-        "Read the archived history for channel SR:BEAM:CURRENT using the archiver.",
+        # Fully specified so the agent has no reason to ask a clarifying
+        # question instead of attempting the tool call (observed flake: with no
+        # time range the agent asked "what period?" and never touched the tool,
+        # so the deny this test exists to observe never happened).
+        "Call the archiver_read tool NOW for channel SR:BEAM:CURRENT with "
+        "start='2h ago' and end='now'. Do not ask any clarifying questions; "
+        "attempt the tool call immediately and report its result.",
         allowed_tools=["mcp__controls__channel_read"],
     )
 


### PR DESCRIPTION
## Problem

\`test_approval_hook_allow_does_not_override_worker_deny\` failed in the PR #316 CI run and passed on rerun — a flake, not a code issue. The test's prompt ("Read the archived history for channel SR:BEAM:CURRENT using the archiver.") omits a time range, so the agent sometimes asks a clarifying question instead of attempting \`archiver_read\`. The deny this test exists to observe then never happens, and the \`assert attempts\` fails on an empty list.

## Fix

Fully specify the prompt (pin the time range, instruct an immediate tool attempt, forbid clarifying questions) so the only variable left is the behavior under test: whether the worker's deny stands against an approval-hook allow.

Observed failure text from the flaky run, for the record:
> "I can read the archived history for that channel using the archiver tool. However, I need to know what time range you'd like to retrieve. …"