### PR TITLE
feat(phoebus): native Phoebus perceive/drive/open MCP capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ my-control-assistant/
 my-lattice-assistant/
 my-ariel-standalone/
 my-agent/_audit/
+phoebus-demo/
 
 # Generated benchmark databases (regenerate: uv run python scripts/generate_benchmark_suite.py)
 data/benchmarks/cross_paradigm/tier*/

--- a/demos/phoebus/GETTING_STARTED.md
+++ b/demos/phoebus/GETTING_STARTED.md
@@ -1,0 +1,142 @@
+# Getting Started — OSPREY ↔ Phoebus Standalone Walkthrough
+
+This is a self-contained onboarding guide for running the **OSPREY ↔ Phoebus native
+interaction demo** end-to-end on a single machine (your laptop or a lab workstation
+with a desktop session). It drives a *live* Phoebus control panel from an OSPREY agent:
+the agent perceives the widget tree, snapshots widgets, and drives controls — via
+synthetic GUI events **or** the semantic PV path — while also reading/writing the
+**same PVs** directly through its EPICS connector.
+
+For the architecture and a per-tool tour, see [`README.md`](./README.md) in this folder.
+This file is the "from nothing, get it running" recipe.
+
+> **Status:** internal ALS work-in-progress. Both repos are private ALS GitLab forks.
+> Do **not** push the Phoebus side to the upstream ControlSystemStudio/phoebus repo.
+
+---
+
+## What you need
+
+A **logged-in desktop session** (Phoebus is a JavaFX GUI app — on a headless Linux box
+you'll need `Xvfb`/VNC; on macOS or a normal Linux desktop it just works), plus:
+
+| Tool | Notes |
+|------|-------|
+| **JDK 21** | macOS: `brew install openjdk@21`. The launcher defaults `JAVA_HOME=/opt/homebrew/opt/openjdk@21`. |
+| **Maven** | to build the Phoebus product jar. |
+| **`uv`** | https://docs.astral.sh/uv/ — runs OSPREY and the soft IOC. |
+| **`git`, `curl`, `jq`** | `jq` only for the manual sanity check. |
+| **An LLM API key** | e.g. `CBORG_API_KEY` (LBNL institutional) or `ANTHROPIC_API_KEY`. |
+
+The two repos are assumed to be **siblings** in the same parent directory
+(e.g. both under `~/LBL/ML/`).
+
+---
+
+## Step 0 — Clone both ALS GitLab repos (as siblings)
+
+```bash
+mkdir -p ~/LBL/ML && cd ~/LBL/ML
+
+# OSPREY agent framework + this demo (IOC, panel, launcher, MCP server, preset, skill)
+git clone https://git.als.lbl.gov/physics/tools/osprey.git
+cd osprey && git checkout feature/phoebus-demo-profile && cd ..
+
+# CS-Studio Phoebus fork carrying the in-JVM agent bridge
+git clone https://git.als.lbl.gov/physics/tools/phoebus.git
+cd phoebus && git checkout feature/phoebus-agent-bridge && cd ..
+```
+
+## Step 1 — Install the OSPREY CLI from the demo branch
+
+The demo needs the **demo-branch** OSPREY (it carries the `phoebus` MCP server, the
+`phoebus-standalone` preset, and the `phoebus-walkthrough` skill) — *not* the PyPI
+release. Install it editable from your clone:
+
+```bash
+cd ~/LBL/ML/osprey
+uv tool install --editable .      # puts `osprey` on your PATH
+osprey --version                  # sanity check
+```
+
+## Step 2 — Build the Phoebus product jar (once)
+
+```bash
+cd ~/LBL/ML/phoebus
+mvn -pl phoebus-product -am install -DskipTests
+```
+
+This produces `phoebus-product/target/product-*.jar` — the GUI app `run_demo.sh`
+launches, with the agent bridge baked in. (If Maven complains about missing platform
+artifacts, run the dependency bootstrap in `phoebus/dependencies/` first, then retry.)
+
+## Step 3 — Build the OSPREY demo project from the preset
+
+```bash
+cd ~/LBL/ML/osprey
+osprey build phoebus-demo --preset phoebus-standalone
+```
+
+Then add your API key to `phoebus-demo/.env`, e.g.:
+
+```bash
+echo 'CBORG_API_KEY=sk-...' >> phoebus-demo/.env   # or ANTHROPIC_API_KEY=...
+```
+
+## Step 4 — Launch the demo stack (leave it running)
+
+```bash
+cd ~/LBL/ML/osprey
+bash demos/phoebus/run_demo.sh
+```
+
+Wait for **`✓ Stack is UP`**. A Phoebus window opens showing live `DEMO:*` values.
+Sanity check from another shell:
+
+```bash
+curl -s "http://127.0.0.1:7979/perceive?display=active" \
+  | jq '.widgets[] | select(.pv) | {name, value: .pv.value}'
+```
+
+> Headless Linux box (e.g. appsdev2)? Run the launcher under `xvfb-run -a bash
+> demos/phoebus/run_demo.sh` (and use a VNC session if you want to *see* the panel).
+
+## Step 5 — Start OSPREY and run the walkthrough
+
+In a **separate terminal**:
+
+```bash
+cd ~/LBL/ML/osprey/phoebus-demo
+osprey web            # add --port 8088 if 8087 is taken
+```
+
+Open the printed URL (default `http://127.0.0.1:8087`), pick the **Terminal** tab, and type:
+
+```
+run the phoebus walkthrough
+```
+
+The agent perceives the panel, snapshots a widget, clicks **"Set 42"** (synthetic GUI
+event) and verifies `DEMO:Readback` both via the GUI *and* via OSPREY's EPICS read,
+contrasts a semantic write, and shows a direct PV write surfacing on the panel's
+`Status` widget.
+
+> Prefer a terminal to the browser? Step 5 also works as
+> `cd phoebus-demo && claude`, then `run the phoebus walkthrough`.
+
+---
+
+## If something's off
+
+- **`phoebus_*` tools return `phoebus_unreachable`** — Phoebus/bridge isn't up. Start
+  `run_demo.sh`; confirm `curl -s http://127.0.0.1:7979/displays`.
+- **Panel shows disconnected (white/magenta) PVs but `caget DEMO:Setpoint` works** —
+  Phoebus's pure-Java CA ignores `EPICS_CA_*` by default. `run_demo.sh` already launches
+  it with `-Djca.use_env=true`; if you launch Phoebus yourself, add that flag.
+- **`channel_read DEMO:*` times out** — soft IOC isn't up or CA isn't on loopback;
+  check `/tmp/osprey_demo_ioc.log`.
+- **Phoebus jar not found** — finish Step 2, or set `PHOEBUS_REPO`/`PHOEBUS_JAR`.
+
+See [`README.md`](./README.md) → *Troubleshooting* for the full list, and the headless
+test suite (`tests/e2e/test_phoebus_demo_e2e.py`) which exercises the OSPREY half with
+no desktop required.

--- a/demos/phoebus/README.md
+++ b/demos/phoebus/README.md
@@ -1,0 +1,131 @@
+# OSPREY ↔ Phoebus Native Interaction Demo
+
+This demo shows OSPREY interacting with a **live Phoebus control panel** as a
+first-class capability: the agent perceives the widget tree, snapshots widgets,
+and drives controls — via synthetic GUI events *or* the semantic PV path — while
+also reading/writing the **same PVs** directly through its EPICS connector.
+
+```
+caproto soft IOC ──CA──► Phoebus (agent bridge :7979 + osprey_demo.bob)
+   (DEMO:* PVs)               ▲
+        ▲                     │ HTTP  /perceive /snapshot /drive
+        │ pyepics caget/caput │
+        └────────── OSPREY agent ──── phoebus MCP tools ──┘
+              (epics mode + native Phoebus tools + walkthrough skill)
+```
+
+## Quickstart — run the full demo (`osprey web`)
+
+**Prerequisites:** a logged-in macOS/Linux **desktop** session (Phoebus is a GUI app;
+Linux headless needs Xvfb), **JDK 21**, **`uv`**, and the **`osprey`** CLI on PATH. The
+`osprey` and `phoebus` checkouts are assumed to be siblings (e.g. both under
+`~/LBL/ML/`). All commands below start from the OSPREY repo root unless noted.
+
+1. **Build the Phoebus product once** (produces the jar `run_demo.sh` launches):
+   ```bash
+   cd ../phoebus        # your phoebus checkout; or set PHOEBUS_REPO later
+   mvn -pl phoebus-product -am install -DskipTests
+   cd ../osprey
+   ```
+
+2. **Build the OSPREY demo project** from the preset:
+   ```bash
+   osprey build phoebus-demo --preset phoebus-standalone
+   ```
+   Then put your API key in `phoebus-demo/.env` (e.g. `ANTHROPIC_API_KEY=…`, or whichever
+   provider you configured).
+
+3. **Launch the demo stack** (soft IOC + Phoebus + bridge) and leave it running:
+   ```bash
+   bash demos/phoebus/run_demo.sh
+   ```
+   Wait for `✓ Stack is UP`. A Phoebus window opens showing live `DEMO:*` values.
+   Sanity check from another shell:
+   ```bash
+   curl -s http://127.0.0.1:7979/perceive?display=active | jq '.widgets[] | select(.pv) | {name, value: .pv.value}'
+   ```
+
+4. **Start OSPREY web** in a separate terminal:
+   ```bash
+   cd phoebus-demo
+   osprey web                 # add --port 8088 if 8087 is in use
+   ```
+   Open the printed URL and select the **Terminal** tab.
+
+5. **Run the guided walkthrough** — type into the OSPREY terminal:
+   ```
+   run the phoebus walkthrough
+   ```
+   It perceives the panel, snapshots a widget, clicks "Set 42" (synthetic) and verifies
+   `DEMO:Readback` both via the GUI and via OSPREY's EPICS read, contrasts a semantic
+   write, and shows a direct PV write surfacing on the panel's `Status` widget.
+
+> Prefer the CLI to the browser? Step 4–5 also work as `cd phoebus-demo && claude`, then
+> `run the phoebus walkthrough`.
+
+## What's in here
+
+| File | Purpose |
+|------|---------|
+| `demo_ioc.py` | caproto soft IOC serving `DEMO:*` Channel Access PVs (the shared control-system backend). |
+| `panels/osprey_demo.bob` | Phoebus display bound to `ca://DEMO:*`, exercising every drive kind (text entry, action button, toggle/momentary bool buttons, live readouts). |
+| `run_demo.sh` | Desktop launcher: starts the IOC + Phoebus (with the bridge) and waits. |
+
+The framework pieces live in the OSPREY source tree:
+
+| Component | Location |
+|-----------|----------|
+| `phoebus` MCP server (5 tools) | `src/osprey/mcp_server/phoebus/` |
+| `phoebus-walkthrough` skill | `src/osprey/templates/.../skills/phoebus-walkthrough/` |
+| `phoebus-standalone` preset | `src/osprey/profiles/presets/phoebus-standalone.yml` |
+
+## The PVs (served by `demo_ioc.py`)
+
+| PV | Access | Role |
+|----|--------|------|
+| `DEMO:Setpoint` | r/w | text entry (`type`) + "Set 42" action button (`click`) |
+| `DEMO:Readback` | r | mirrors the committed setpoint |
+| `DEMO:Current` | r | live (noisy) value for trend/meter widgets |
+| `DEMO:Enable` | r/w | toggle bool button (OFF/ON) |
+| `DEMO:Valve` | r/w | momentary bool button (CLOSED/OPEN) |
+| `DEMO:Status` | r | derived OK/WARN/FAULT (≥80 → WARN, ≥95 → FAULT) |
+
+Writing `DEMO:Setpoint` mirrors to `DEMO:Readback` and re-derives `DEMO:Status`.
+
+## Automated tests (no desktop required)
+
+Beyond the live demo above, the OSPREY half of the loop is covered headlessly —
+MCP tools → HTTP → real PV writes, verified via re-perceive *and* pyepics:
+
+```bash
+uv run pytest tests/e2e/test_phoebus_demo_e2e.py -v     # 4 e2e tests (real soft IOC)
+uv run pytest tests/mcp_server/test_phoebus_tools.py -v # 16 unit tests
+```
+
+The live *Phoebus GUI* mile (real synthetic JavaFX events) is what the Quickstart
+exercises; its in-JVM equivalent is covered by the phoebus repo's Monocle
+`EndToEndHttpIT`.
+
+## Configuration knobs
+
+- **Bridge location:** `PHOEBUS_BRIDGE_URL` (full URL) or `phoebus.host`/`phoebus.port`
+  in the project `config.yml` (default `127.0.0.1:7979`).
+- **CA on loopback:** the preset sets `EPICS_CA_ADDR_LIST=127.0.0.1` /
+  `EPICS_CA_AUTO_ADDR_LIST=NO` so the demo never depends on a facility gateway.
+- **EPICS mode:** the preset runs OSPREY's control system in `epics` mode against
+  the soft IOC at `127.0.0.1:5064` (the bundled `simulation` gateway location).
+
+## Troubleshooting
+
+- *`phoebus_*` tools return `phoebus_unreachable`* — Phoebus (with the bridge) isn't
+  running. Start `run_demo.sh`; confirm `curl -s http://127.0.0.1:7979/displays`.
+- *`channel_read DEMO:*` times out* — the soft IOC isn't up, or CA isn't on loopback.
+  Check `/tmp/osprey_demo_ioc.log` and the `EPICS_CA_ADDR_LIST` env.
+- *Phoebus panel shows disconnected PVs (white/magenta), but `caget DEMO:Setpoint`
+  works* — Phoebus's pure-Java CA ignores the `EPICS_CA_*` environment variables by
+  default (it uses `auto_addr_list=true`, a LAN broadcast that never probes the
+  loopback-bound IOC). `run_demo.sh` launches Phoebus with `-Djca.use_env=true` so it
+  honors `EPICS_CA_ADDR_LIST=127.0.0.1`. If you launch Phoebus yourself, add that flag,
+  or set the Phoebus preferences `org.phoebus.pv.ca/addr_list=127.0.0.1` and
+  `org.phoebus.pv.ca/auto_addr_list=false` via a `-settings` file.
+- *Phoebus jar not found* — build it (step 1) or set `PHOEBUS_REPO`/`PHOEBUS_JAR`.

--- a/demos/phoebus/REMOTE_BRIDGE_RUNBOOK.md
+++ b/demos/phoebus/REMOTE_BRIDGE_RUNBOOK.md
@@ -1,0 +1,239 @@
+# Remote Bridge Runbook — isolated Phoebus + OSPREY on appsdev2
+
+Operate the **osprey-phoebus-remote-bridge** demo: an isolated, headless
+Phoebus product on appsdev2 that the OSPREY agent opens, perceives, and drives
+over the loopback bridge, with the live panel streamed into the OSPREY web
+terminal via Xvnc → websockify → noVNC.
+
+Everything below was validated live on appsdev2 on 2026-07-01: pre-flight
+guard, launch, real-bridge e2e (5/5), the noVNC stream (visual framebuffer
+check), the web-terminal `/panel/phoebus` embed path (HTTP + binary
+WebSocket), and clean teardown with the production instances untouched.
+
+---
+
+## 0. Fixed values (recon-chosen, non-colliding)
+
+| Resource | Value |
+|---|---|
+| Bridge HTTP | `127.0.0.1:7979` |
+| X display / RFB | `:99` / `127.0.0.1:5977` (`:99`'s default 5999 is squatted by a host VNC) |
+| Phoebus `-server` | `4079` (prod instances use 4001/4004/4005) |
+| Demo CA server / repeater | `5074` / `5075` (UDP+TCP; host prod CA uses 5064/5065 — never touched) |
+| websockify (noVNC HTTP+WS) | `127.0.0.1:6080` |
+| Xvnc framebuffer | `1600x900` (`DEMO_GEOMETRY`); the launcher seeds a memento pinning the Phoebus window to fill it exactly, so the stream shows ONLY Phoebus |
+| CA scrub | `EPICS_CA_ADDR_LIST=127.0.0.1`, `EPICS_CA_AUTO_ADDR_LIST=NO` (host default points at production 131.243.x subnets — the launcher overrides) |
+
+Per-instance values shift by `INSTANCE-1` (§2b): instance 2 = bridge **7980**,
+display `:100`, RFB **5978**, `-server` **4080**, websockify **6081**. The CA
+ports (5074/5075) are shared — instance 2 is a plain CA client of instance 1's
+soft IOC.
+
+**Production baseline that must stay untouched** (verify with `ps -p`, NOT
+`kill -0` — cross-user `kill -0` returns EPERM and looks like "gone"):
+
+```bash
+ps -p 49901,344076,1805779 -o pid,user,etime,args   # nusaqib/mjchin/hunt Phoebus
+```
+
+## 1. One-time staging layout (already in place)
+
+```
+~/phoebus-remote-bridge-demo/
+├── phoebus/…/target/product-6.0.0-SNAPSHOT.jar + lib/   # bridge-enabled product (built on laptop)
+│   └── lib-mac-aarch64-quarantine/                      # mac JavaFX jars moved OUT of lib/
+├── osprey/            # git worktree of ~/projects/osprey @ feature/phoebus-demo-profile
+├── novnc/             # vendored noVNC 1.6.0 client (vnc.html, app/, core/, vendor/)
+└── pytools/           # pure-python wheels unzipped (pytest, pytest-asyncio, websockify)
+```
+
+* **JavaFX platform jars:** the product was built on macOS, so its `lib/`
+  needed the seven `javafx-*-21.0.7-linux.jar` (from Maven Central) and the
+  `*-mac-aarch64.jar` quarantined. `run_demo.sh` launches with
+  `-cp "jar:lib/*"` (not `-jar`) precisely so *what is in `lib/` defines the
+  runtime set* — the jar's manifest pins the build platform's jars and cannot
+  be overridden with `-Djavafx.platform` at build time.
+  Rebuild + reship after phoebus changes:
+  `JAVA_HOME=/opt/homebrew/opt/openjdk@21 mvn -pl phoebus-product -am install -DskipTests`
+  (laptop), then scp the product jar; `lib/` linux jars only need reshipping
+  when `openjfx.version` changes.
+* **Sync osprey code** (no shared remote involved): from the laptop
+  `git push ssh://appsdev2/~/projects/osprey feature/phoebus-demo-profile:refs/heads/demo-incoming -f`,
+  then on appsdev2 `cd ~/phoebus-remote-bridge-demo/osprey && git merge --ff-only demo-incoming`.
+  (Direct push to the branch is refused once the worktree has it checked out.)
+
+## 2. Launch
+
+```bash
+ssh appsdev2
+cd ~/phoebus-remote-bridge-demo/osprey
+env PHOEBUS_REPO=$HOME/phoebus-remote-bridge-demo/phoebus \
+    JAVA_HOME=/home/als/alsbase/Phoebus/phoebus/jdk \
+    ISOLATED=1 \
+    OSPREY_PYTHON=$HOME/projects/osprey/.venv/bin/python \
+    WEBSOCKIFY_CMD="env PYTHONPATH=$HOME/phoebus-remote-bridge-demo/pytools $HOME/projects/osprey/.venv/bin/python -m websockify" \
+    bash demos/phoebus/run_demo.sh
+```
+
+* `ISOLATED=1` is the auto-default on Linux, but pin it anyway
+  (belt-and-suspenders on a shared box).
+* The **pre-flight collision guard** aborts if display `:99` or any of
+  7979/4079/5977/5074/5075/6080 is occupied — that abort is the safety
+  feature, not a bug. See "Troubleshooting" for the usual culprit.
+* Success banner lists IOC, Phoebus, bridge, VNC, and noVNC endpoints.
+  Logs: `/tmp/osprey_demo_{run,ioc→osprey_demo_ioc,phoebus,websockify}.log`.
+
+## 2b. Optional second Phoebus instance
+
+Same command as §2, prefixed with `INSTANCE=2` — in a second terminal, with
+instance 1 already up (instance 2 skips the IOC and shares instance 1's demo
+soft IOC; its pre-flight expects the CA ports to be busy and checks only its
+own offset ports):
+
+```bash
+env INSTANCE=2 PHOEBUS_REPO=… JAVA_HOME=… ISOLATED=1 WEBSOCKIFY_CMD="…" \
+    bash demos/phoebus/run_demo.sh     # no OSPREY_PYTHON needed — no IOC leg
+```
+
+Logs get a `.i2` suffix (`/tmp/osprey_demo_phoebus.i2.log`, …). To surface it
+in the web terminal and give the agent a second toolset, uncomment the
+`phoebus2` block in the project's `config.yml` (see the `phoebus-standalone`
+preset; the server is declared as an `extends` clone of the framework server —
+`claude_code.servers.phoebus2: {extends: phoebus, env: {PHOEBUS_BRIDGE_URL:
+"${PHOEBUS2_BRIDGE_URL:-http://127.0.0.1:7980}"}}` — NOT the old
+`servers.phoebus2.enabled: true` form, which no longer exists) and restart the
+standalone terminal: PHOEBUS2 tab via `/panel/phoebus2`, tools via the
+`phoebus2` MCP server (bridge 7980, `mcp__phoebus2__*`, drive approval-gated
+like instance 1).
+
+## 2c. Live machine data, read-only (`LIVE_READONLY=1`)
+
+By default the sandbox sees ONLY the demo IOC — a real panel (e.g. GTLView)
+renders with every PV stuck `CONNECTING`. To get live values, add
+`LIVE_READONLY=1` to the §2/§2b launch env. This appends the ALS **read-only
+CA gateway** (`cagw-alsdmz.als.lbl.gov`, the same host ALS's own
+`readOnlyPhoebus.sh` uses) to the *client* search path:
+
+```
+EPICS_CA_ADDR_LIST="127.0.0.1:5074 cagw-alsdmz.als.lbl.gov:5064"
+EPICS_PVA_ADDR_LIST="cagw-alsdmz.als.lbl.gov"
+```
+
+* The gateway grants `read, no write` (CA access security) on every channel —
+  verified with `cainfo`. Writes are impossible **at the network layer**, so
+  even a human clicking an ON/OFF button in the noVNC panel (which bypasses
+  the MCP `phoebus_drive` gate) cannot actuate hardware. Phoebus renders such
+  channels as non-writable.
+* The demo IOC keeps working via the explicit `127.0.0.1:5074` entry.
+* Server-side (`EPICS_CAS_*`) interfaces stay loopback in every mode.
+* Override the gateway host with `READONLY_GATEWAY=<host>` if it ever moves.
+* Quick sanity check of the resolved env without launching anything:
+  `PRINT_EPICS_ENV=1 bash demos/phoebus/run_demo.sh`.
+
+## 3. Verify (30 seconds)
+
+```bash
+curl -s http://127.0.0.1:7979/displays | jq .          # d-1 ready:true
+curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:6080/vnc.html   # 200
+```
+
+Full regression gate — the **real-bridge e2e** (open→perceive→drive→CA readback):
+
+```bash
+cd ~/phoebus-remote-bridge-demo/osprey
+env PYTHONPATH=$PWD/src:$HOME/phoebus-remote-bridge-demo/pytools \
+    OSPREY_REAL_BRIDGE_URL=http://127.0.0.1:7979 \
+    EPICS_CA_ADDR_LIST=127.0.0.1 EPICS_CA_AUTO_ADDR_LIST=NO \
+    EPICS_CA_SERVER_PORT=5074 EPICS_CA_REPEATER_PORT=5075 \
+    ~/projects/osprey/.venv/bin/python -m pytest tests/e2e/test_phoebus_real_bridge_e2e.py -q
+```
+
+`PYTHONPATH=$PWD/src` is required: the shared `.venv` has osprey installed
+editable from `~/projects/osprey` (branch `next`), and the worktree's demo
+code must shadow it.
+
+## 4. Watch the panel (operator view)
+
+**Direct (quickest):** from the laptop
+`ssh -f -N -L 16080:127.0.0.1:6080 appsdev2`, then open
+`http://localhost:16080/vnc.html?autoconnect=1&resize=scale`.
+(A SOCKS `DynamicForward` proxy works too — browse `http://127.0.0.1:6080/…`
+through it.)
+
+**Inside the OSPREY web terminal (PHOEBUS tab):** run a standalone terminal on
+a free port (NOT the containerized 9090–9096) from a project built with the
+`phoebus-standalone` preset — the preset ships the PHOEBUS panel wired to
+`/panel/phoebus/vnc.html` with the RFB WebSocket riding the same proxy, so the
+browser only needs to reach the web terminal port. Forward that one port and
+open the PHOEBUS tab.
+
+Launch it with `PYTHONPATH=~/phoebus-remote-bridge-demo/osprey/src` so the
+demo-branch code shadows the shared `.venv`'s editable install (branch `next`)
+— same trap as the e2e in §3. Without it the `/panel/...` proxy routes are
+missing (404) and the WS relay is not binary-safe.
+
+**Security note (accepted for the demo):** the VNC stream has **no
+authentication** (`-SecurityTypes None`). It is bound to loopback only and
+shows/controls only the demo panel + demo soft IOC (`DEMO:*`), but anyone with
+a shell on appsdev2 can connect to it. Do not reuse this pattern for panels
+bound to real PVs.
+
+## 5. Drive it
+
+Via the agent (in a built phoebus-demo project: `claude` →
+"run the phoebus walkthrough"), or by hand:
+
+```bash
+curl -s -X POST http://127.0.0.1:7979/drive -H "Content-Type: application/json" \
+  -d '{"display":"handle:d-1","widget":"Setpoint","verb":"type","value":"42.5","mode":"synthetic"}'
+caget DEMO:Readback   # ..with EPICS_CA_SERVER_PORT=5074 EPICS_CA_ADDR_LIST=127.0.0.1
+```
+
+The typed value lands in the panel (visible in the stream), mirrors to
+`DEMO:Readback`, and derives `DEMO:Status` (≥80 WARN, ≥95 FAULT).
+`phoebus_drive` from the agent stays behind the approval hook.
+
+## 6. Teardown + "untouched" verification
+
+Ctrl-C the launcher (or `kill <runner pid>` — its trap kills only its own
+children). Then verify:
+
+```bash
+# 1. nothing of ours is left listening
+ss -tln | grep -E ':(7979|4079|5977|5074|6080)\b' || echo CLEAN
+ls /tmp/.X11-unix/X99 2>/dev/null || echo "X99 gone"
+# 2. the known stragglers (see Troubleshooting)
+ss -ulnp | grep ':5075\b' || echo "no repeater leftover"
+pgrep -u $USER -f phoebus-remote-bridge-demo || echo "no demo JVM leftover"
+# 3. production untouched (ps -p, not kill -0)
+ps -p 49901,344076,1805779 -o pid,user,etime
+ss -tln | grep -E ':(4001|4004|4005)\b'      # three prod -server ports still bound
+```
+
+## 7. Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| Pre-flight abort: "CA repeater port 5075 already in use" | A demo **Phoebus JVM** or caproto repeater from a previous run lingers holding UDP 5075 (Phoebus's CA client becomes the repeater when none exists; it can survive teardown holding only that socket). `pid=$(ss -ulnp \| grep ':5075\b' \| grep -oP 'pid=\K[0-9]+')` → confirm it's yours (`ps -p $pid`) → `kill $pid`. |
+| `Error initializing QuantumRenderer: no suitable pipeline` | `lib/` holds the wrong-platform JavaFX jars — see §1. |
+| `NoClassDefFoundError: javafx/application/Application` | Launched with `-jar` (manifest classpath) instead of the script's `-cp` path, with mac jars quarantined. Use `run_demo.sh`. |
+| "RVNC CONNECT" chrome in the stream, or a huge desktop (e.g. 5120×2880) with Phoebus in a corner | `Xvnc` on PATH is **RealVNC's** (its package symlinks `/usr/bin/Xvnc` → `Xvnc-realvnc` and renames TigerVNC's binary to `Xvnc.conflict`). RealVNC ignores `-geometry` in virtual mode and paints `vncserverui` overlays. The launcher auto-detects this and uses `Xvnc.conflict`; override with `XVNC_CMD=<path-to-TigerVNC-Xvnc>`. |
+| noVNC tab shows connect error | The stream leg was skipped (websockify/noVNC assets missing — see the launch log line) or `WEB_VNC_PORT` collided. Bridge + agent still fully work. |
+| e2e skipped | It's opt-in: set `OSPREY_REAL_BRIDGE_URL` (or `PHOEBUS_E2E_LAUNCH=1` to have the test launch the stack itself). |
+| `pkill -f run_demo.sh` kills your own ssh session | The pattern matches your remote shell's own command line. Use `pkill -f 'run_demo[.]sh'` or kill the runner PID. |
+
+## 8. Safety invariants (why this can't disturb production)
+
+1. **Pre-flight guard** refuses to start on ANY resource collision.
+2. All listeners are **loopback-only** (bridge, Xvnc RFB, websockify, CA).
+3. **Dedicated CA ports** (5074/5075) + `EPICS_CA_ADDR_LIST=127.0.0.1` +
+   `EPICS_PVA_ADDR_LIST=127.0.0.1` + `-Djca.use_env=true`: neither Phoebus nor
+   the IOC can reach host CA (5064/5065), host PVA, or the production
+   131.243.x broadcast lists. With `LIVE_READONLY=1` (§2c) the client search
+   path additionally sees the read-only gateway — reads only; the gateway
+   denies writes at the CA access-security layer.
+4. Private `phoebus.user`/`user.home` under a mktemp dir — **no writes**
+   outside it (nothing under `/home/als/alsbase/Phoebus`).
+5. Dedicated `-server 4079`: `-resource` forwarding cannot target another
+   Phoebus (prod uses 4001/4004/4005; default `-server` is disabled).
+6. Teardown kills only the launcher's own children; §6 verifies.

--- a/demos/phoebus/demo_ioc.py
+++ b/demos/phoebus/demo_ioc.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Caproto soft IOC for the OSPREY ↔ Phoebus bridge demo.
+
+Serves a small set of EPICS Channel Access PVs (prefix ``DEMO:``) that both
+Phoebus (the ``.bob`` demo panels bind their widgets to these PVs) and the
+OSPREY agent (via its ``epics`` control-system connector, ``pyepics``) read and
+write. This is the shared control-system backend that makes the demo's
+"drive the GUI, observe the PV; or write the PV directly" loop possible — the
+in-process OSPREY ``mock`` connector cannot serve Channel Access, so a real
+soft IOC is required.
+
+PV map (all under the ``DEMO:`` prefix):
+
+==================  ======  ==========  ======================================
+PV                  type    access      demo role / widget kind it drives
+==================  ======  ==========  ======================================
+DEMO:Setpoint       ao      read/write  Text Entry widget (verb ``type``) AND
+                                        the "Set 42" action button (verb
+                                        ``click`` → WritePV 42)
+DEMO:Readback       ai      read-only   Text Update / meter — mirrors Setpoint
+DEMO:Current        ai      read-only   live noisy value — trend plot / meter
+DEMO:Enable         bo      read/write  Bool Button (toggle) — OFF/ON
+DEMO:Valve          bo      read/write  Bool Button (momentary) — CLOSED/OPEN
+DEMO:Status         mbbi    read-only   LED / status — OK/WARN/FAULT (derived)
+==================  ======  ==========  ======================================
+
+Writing DEMO:Setpoint mirrors the value to DEMO:Readback and re-derives
+DEMO:Status (>=80 → WARN, >=95 → FAULT). DEMO:Current wobbles once per second
+around the readback so live widgets visibly update.
+
+Run (binds Channel Access on the loopback interface)::
+
+    EPICS_CAS_INTF_ADDR_LIST=127.0.0.1 \\
+    EPICS_CAS_BEACON_ADDR_LIST=127.0.0.1 \\
+    python demo_ioc.py --list-pvs
+
+Then point both Phoebus and OSPREY at it with
+``EPICS_CA_ADDR_LIST=127.0.0.1`` / ``EPICS_CA_AUTO_ADDR_LIST=NO``.
+"""
+
+from __future__ import annotations
+
+import random
+
+from caproto import ChannelType
+from caproto.server import PVGroup, ioc_arg_parser, pvproperty, run
+
+
+class DemoIOC(PVGroup):
+    """A handful of PVs that mirror a simple setpoint→readback control loop."""
+
+    # Explicit CamelCase ``name=`` so the PVs are DEMO:Setpoint (not the
+    # lowercased attribute name caproto would derive) — EPICS names are
+    # case-sensitive and the panels/config bind to the CamelCase form.
+    setpoint = pvproperty(
+        name="Setpoint",
+        value=0.0,
+        units="mA",
+        precision=2,
+        doc="Operator setpoint (writable). Drives Readback + Status.",
+    )
+    readback = pvproperty(
+        name="Readback",
+        value=0.0,
+        units="mA",
+        precision=2,
+        read_only=True,
+        doc="Mirrors the last committed setpoint.",
+    )
+    current = pvproperty(
+        name="Current",
+        value=100.0,
+        units="mA",
+        precision=2,
+        read_only=True,
+        doc="Live (noisy) current — updates once per second for trend widgets.",
+    )
+    enable = pvproperty(
+        name="Enable",
+        value="OFF",
+        enum_strings=["OFF", "ON"],
+        dtype=ChannelType.ENUM,
+        doc="Enable toggle (bool button).",
+    )
+    valve = pvproperty(
+        name="Valve",
+        value="CLOSED",
+        enum_strings=["CLOSED", "OPEN"],
+        dtype=ChannelType.ENUM,
+        doc="Valve open/closed (momentary bool button).",
+    )
+    status = pvproperty(
+        name="Status",
+        value="OK",
+        enum_strings=["OK", "WARN", "FAULT"],
+        dtype=ChannelType.ENUM,
+        read_only=True,
+        doc="Derived health status from the setpoint magnitude.",
+    )
+
+    @staticmethod
+    def _derive_status(value: float) -> str:
+        if value >= 95:
+            return "FAULT"
+        if value >= 80:
+            return "WARN"
+        return "OK"
+
+    @setpoint.putter
+    async def setpoint(self, instance, value):
+        """Commit a setpoint: mirror to readback and re-derive status."""
+        await self.readback.write(value)
+        await self.status.write(self._derive_status(value))
+        return value
+
+    @current.scan(period=1.0)
+    async def current(self, instance, async_lib):
+        """Wobble around the current readback so live widgets visibly update."""
+        base = self.readback.value if self.readback.value else 100.0
+        await instance.write(base + random.uniform(-1.5, 1.5))
+
+
+def main() -> None:
+    ioc_options, run_options = ioc_arg_parser(
+        default_prefix="DEMO:",
+        desc="OSPREY ↔ Phoebus bridge demo soft IOC",
+    )
+    ioc = DemoIOC(**ioc_options)
+    run(ioc.pvdb, **run_options)
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/phoebus/panels/osprey_demo.bob
+++ b/demos/phoebus/panels/osprey_demo.bob
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- OSPREY <-> Phoebus bridge demo panel.
+
+     Binds to the caproto soft IOC's DEMO:* Channel Access PVs (see
+     demos/phoebus/demo_ioc.py). Both Phoebus (this panel) and the OSPREY agent
+     (its EPICS connector) read/write the SAME PVs, so a synthetic GUI drive and
+     a direct PV write are mutually observable.
+
+     Widget -> bridge drive kind demonstrated:
+       Setpoint  (textentry)     -> verb "type"  (TEXT control)
+       SetButton (action_button) -> verb "click" (ACTION control, WritePV 42)
+       Enable    (bool_button)   -> verb "click" (toggle, ACTION control)
+       Valve     (bool_button)   -> verb "click" (momentary, MOMENTARY control)
+       Readback/Current/Status   -> read-only displays (perceive shows live PVs)
+-->
+<display version="2.0.0">
+  <name>OSPREY Phoebus Demo</name>
+  <width>460</width>
+  <height>360</height>
+
+  <widget type="label" version="2.0.0">
+    <name>Title</name>
+    <text>OSPREY ↔ Phoebus Bridge Demo</text>
+    <x>20</x>
+    <y>10</y>
+    <width>420</width>
+    <height>28</height>
+    <font>
+      <font family="Liberation Sans" style="BOLD" size="16.0"/>
+    </font>
+  </widget>
+
+  <!-- Setpoint: writable text entry (verb "type") -->
+  <widget type="label" version="2.0.0">
+    <name>SetpointLabel</name>
+    <text>Setpoint (mA)</text>
+    <x>20</x>
+    <y>55</y>
+    <width>150</width>
+    <height>25</height>
+  </widget>
+  <widget type="textentry" version="3.0.0">
+    <name>Setpoint</name>
+    <pv_name>ca://DEMO:Setpoint</pv_name>
+    <x>180</x>
+    <y>55</y>
+    <width>120</width>
+    <height>30</height>
+  </widget>
+
+  <!-- Readback: mirrors the setpoint -->
+  <widget type="label" version="2.0.0">
+    <name>ReadbackLabel</name>
+    <text>Readback (mA)</text>
+    <x>20</x>
+    <y>95</y>
+    <width>150</width>
+    <height>25</height>
+  </widget>
+  <widget type="textupdate" version="2.0.0">
+    <name>Readback</name>
+    <pv_name>ca://DEMO:Readback</pv_name>
+    <x>180</x>
+    <y>95</y>
+    <width>120</width>
+    <height>30</height>
+  </widget>
+
+  <!-- Current: live (noisy) value -->
+  <widget type="label" version="2.0.0">
+    <name>CurrentLabel</name>
+    <text>Current (mA)</text>
+    <x>20</x>
+    <y>135</y>
+    <width>150</width>
+    <height>25</height>
+  </widget>
+  <widget type="textupdate" version="2.0.0">
+    <name>Current</name>
+    <pv_name>ca://DEMO:Current</pv_name>
+    <x>180</x>
+    <y>135</y>
+    <width>120</width>
+    <height>30</height>
+  </widget>
+
+  <!-- Status: derived OK/WARN/FAULT -->
+  <widget type="label" version="2.0.0">
+    <name>StatusLabel</name>
+    <text>Status</text>
+    <x>20</x>
+    <y>175</y>
+    <width>150</width>
+    <height>25</height>
+  </widget>
+  <widget type="textupdate" version="2.0.0">
+    <name>Status</name>
+    <pv_name>ca://DEMO:Status</pv_name>
+    <x>180</x>
+    <y>175</y>
+    <width>120</width>
+    <height>30</height>
+  </widget>
+
+  <!-- Set 42 action button: verb "click" -> WritePV 42 to the setpoint -->
+  <widget type="action_button" version="3.0.0">
+    <name>SetButton</name>
+    <text>Set 42</text>
+    <x>20</x>
+    <y>225</y>
+    <width>120</width>
+    <height>40</height>
+    <actions>
+      <action type="write_pv">
+        <pv_name>ca://DEMO:Setpoint</pv_name>
+        <value>42</value>
+        <description>Write 42 to the setpoint</description>
+      </action>
+    </actions>
+  </widget>
+
+  <!-- Enable: toggle bool button (ACTION kind) -->
+  <widget type="bool_button" version="2.0.0">
+    <name>Enable</name>
+    <pv_name>ca://DEMO:Enable</pv_name>
+    <x>160</x>
+    <y>225</y>
+    <width>120</width>
+    <height>40</height>
+    <off_label>Enable OFF</off_label>
+    <on_label>Enable ON</on_label>
+  </widget>
+
+  <!-- Valve: momentary (push) bool button (MOMENTARY kind) -->
+  <widget type="bool_button" version="2.0.0">
+    <name>Valve</name>
+    <pv_name>ca://DEMO:Valve</pv_name>
+    <x>300</x>
+    <y>225</y>
+    <width>120</width>
+    <height>40</height>
+    <off_label>Valve CLOSED</off_label>
+    <on_label>Valve OPEN</on_label>
+    <mode>1</mode>
+  </widget>
+
+  <widget type="label" version="2.0.0">
+    <name>Hint</name>
+    <text>PVs served by demos/phoebus/demo_ioc.py (caproto soft IOC)</text>
+    <x>20</x>
+    <y>290</y>
+    <width>420</width>
+    <height>40</height>
+    <font>
+      <font family="Liberation Sans" style="ITALIC" size="11.0"/>
+    </font>
+  </widget>
+</display>

--- a/demos/phoebus/run_demo.sh
+++ b/demos/phoebus/run_demo.sh
@@ -1,0 +1,476 @@
+#!/usr/bin/env bash
+#
+# Launch the full OSPREY <-> Phoebus demo stack.
+#
+# Two modes, auto-selected:
+#   * DESKTOP  (default when a display is present): Phoebus opens on your
+#     desktop, exactly as before.
+#   * ISOLATED (auto on headless Linux, e.g. appsdev2; force with ISOLATED=1):
+#     Phoebus runs inside a private TigerVNC X server (Xvnc) on a dedicated
+#     display, with a private user dir, a dedicated single-instance-server port,
+#     dedicated demo Channel Access ports, and a PRE-FLIGHT COLLISION CHECK that
+#     refuses to start if the bridge port, X display, the instance-server port,
+#     the Xvnc RFB port, or the demo CA ports are already in use — so it can
+#     never disturb another Phoebus / CA server already running on the host.
+#     (Xvnc renders a real X11 window; a websockify+noVNC bridge on the RFB port
+#     surfaces it in the OSPREY web terminal — see Task 3.2.)
+#
+# Starts:
+#   1. the caproto soft IOC (demo_ioc.py) serving DEMO:* on loopback CA, and
+#   2. a Phoebus product showing the demo panel (osprey_demo.bob), with the
+#      in-JVM agent bridge listening on http://127.0.0.1:${BRIDGE_PORT}.
+#
+# Then it waits — leave it running and, in a SEPARATE terminal, start the OSPREY
+# agent in your built project and ask it to run the Phoebus walkthrough:
+#
+#     cd <your phoebus-demo project> && claude
+#     > run the phoebus walkthrough
+#
+# Press Ctrl-C to tear the stack down (kills only the demo's own processes).
+#
+# Environment overrides:
+#   PHOEBUS_REPO   phoebus checkout (default: sibling ../phoebus)
+#   PHOEBUS_JAR    product jar (default: autodetected under phoebus-product/target)
+#   INSTANCE       demo instance number (default: 1). INSTANCE=2 launches a
+#                  SECOND isolated Phoebus alongside the first: every
+#                  per-instance default below shifts by (INSTANCE-1), the soft
+#                  IOC is NOT started again (instance 1's is shared via the
+#                  same loopback CA ports), and log files get a .i<N> suffix.
+#   START_IOC      1/0 — start the demo soft IOC (default: 1 for INSTANCE=1,
+#                  0 otherwise)
+#   BRIDGE_PORT    bridge HTTP port (default: 7979 + INSTANCE-1)
+#   JAVA_HOME      JDK 21 (default: Homebrew openjdk@21, then `java` on PATH;
+#                  a shared Linux host, e.g. appsdev2, supplies its own JDK by
+#                  setting this env var — no facility-specific path is baked in)
+#   ISOLATED       1 = force isolated/headless mode, 0 = force desktop mode
+#                  (default: auto — isolated on headless Linux)
+#   OSPREY_PYTHON  python used for the demo IOC (needs caproto); overrides the
+#                  default uv / ${OSPREY_ROOT}/.venv resolution
+#   Isolated-mode knobs (defaults are the appsdev2 recon-chosen values; the
+#   per-instance ones shift by INSTANCE-1):
+#     DEMO_DISPLAY     X display for Xvnc            (default: :99 + INSTANCE-1)
+#     DEMO_GEOMETRY    Xvnc framebuffer size WxH     (default: 1600x900) — the
+#                      Phoebus window is pinned to fill it exactly, so the
+#                      stream shows ONLY Phoebus (no bare X root around it)
+#     RFB_PORT         Xvnc RFB port                 (default: 5977 + INSTANCE-1)
+#     INSTANCE_PORT    Phoebus single-instance port  (default: 4079 + INSTANCE-1)
+#     CA_SERVER_PORT   demo Channel Access server    (default: 5074, shared)
+#     CA_REPEATER_PORT demo CA repeater              (default: 5075, shared)
+#     PHOEBUS_USER_DIR private phoebus.user dir       (default: a fresh mktemp dir)
+#   Web-stream knobs (isolated mode; the leg is skipped when websockify or the
+#   vendored noVNC assets are absent — the bridge demo still works without it):
+#     WEB_VNC_PORT     websockify HTTP+WS port        (default: 6080 + INSTANCE-1)
+#     NOVNC_DIR        vendored noVNC client dir      (default: probe
+#                      ${SCRIPT_DIR}/novnc, then ~/phoebus-remote-bridge-demo/novnc)
+#     WEBSOCKIFY_CMD   command to run websockify      (default: `websockify` on
+#                      PATH; e.g. "env PYTHONPATH=… python -m websockify")
+#     XVNC_CMD         Xvnc binary — must be TigerVNC (default: `Xvnc` on PATH,
+#                      except when that is a RealVNC symlink and the TigerVNC
+#                      binary survives as Xvnc.conflict — RealVNC's package
+#                      renames it — in which case the .conflict one is used.
+#                      RealVNC's Xvnc ignores -geometry in virtual mode and
+#                      overlays its own UI windows on the stream.)
+#
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OSPREY_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+IOC="${SCRIPT_DIR}/demo_ioc.py"
+PANEL="${SCRIPT_DIR}/panels/osprey_demo.bob"
+
+: "${PHOEBUS_REPO:=$(cd "${OSPREY_ROOT}/.." && pwd)/phoebus}"
+
+# Multi-instance support: INSTANCE=2 (3, …) runs an additional isolated Phoebus
+# next to instance 1. All per-instance defaults shift by this offset; the demo
+# soft IOC is shared (only instance 1 starts it — the rest are plain CA clients
+# on the same loopback ports).
+: "${INSTANCE:=1}"
+case "${INSTANCE}" in (*[!0-9]*|'') echo "ERROR: INSTANCE must be a positive integer, got '${INSTANCE}'"; exit 2;; esac
+[[ "${INSTANCE}" -ge 1 ]] || { echo "ERROR: INSTANCE must be >= 1, got '${INSTANCE}'"; exit 2; }
+_IOFF=$(( INSTANCE - 1 ))
+: "${START_IOC:=$(( INSTANCE == 1 ? 1 : 0 ))}"
+LOG_SUFFIX=""; [[ "${INSTANCE}" != 1 ]] && LOG_SUFFIX=".i${INSTANCE}"
+
+: "${BRIDGE_PORT:=$(( 7979 + _IOFF ))}"
+BASE_URL="http://127.0.0.1:${BRIDGE_PORT}"
+
+# --- JDK 21 autodetection (Homebrew, then JAVA_HOME env, then PATH) ------------
+# Facility-neutral: no facility-specific JDK path is baked in here. A shared
+# Linux host (e.g. appsdev2) supplies its JDK via the JAVA_HOME env var.
+if [[ -z "${JAVA_HOME:-}" && -x /opt/homebrew/opt/openjdk@21/bin/java ]]; then
+  JAVA_HOME=/opt/homebrew/opt/openjdk@21
+fi
+if [[ -n "${JAVA_HOME:-}" ]]; then
+  export JAVA_HOME
+  export PATH="${JAVA_HOME}/bin:${PATH}"
+fi
+command -v java >/dev/null 2>&1 || { echo "ERROR: no java found; set JAVA_HOME to a JDK 21"; exit 2; }
+
+# --- mode selection: isolated/headless vs desktop ------------------------------
+if [[ -z "${ISOLATED:-}" ]]; then
+  # Safety-first on shared Linux hosts (e.g. appsdev2): default to ISOLATED so the
+  # pre-flight guard + dedicated ports ALWAYS engage. A Linux desktop run must opt
+  # out explicitly with ISOLATED=0. We key on the OS, NOT on DISPLAY — an `ssh -X`
+  # session sets DISPLAY, so keying on it would silently disable the isolation.
+  if [[ "$(uname -s)" == "Linux" ]]; then ISOLATED=1; else ISOLATED=0; fi
+fi
+# Isolated-mode knobs (appsdev2 recon-chosen, non-colliding values; per-instance
+# ones shift by the INSTANCE offset — CA ports are shared across instances)
+: "${DEMO_DISPLAY:=:$(( 99 + _IOFF ))}"
+: "${DEMO_GEOMETRY:=1600x900}"
+: "${RFB_PORT:=$(( 5977 + _IOFF ))}"
+: "${INSTANCE_PORT:=$(( 4079 + _IOFF ))}"
+: "${CA_SERVER_PORT:=5074}"
+: "${CA_REPEATER_PORT:=5075}"
+: "${WEB_VNC_PORT:=$(( 6080 + _IOFF ))}"
+
+# --- Channel Access / PV Access: loopback only, or loopback + read-only gateway -
+# Default: both the IOC (server) and Phoebus/OSPREY (clients) stay on the loopback.
+# LIVE_READONLY=1 additionally points the CA/PVA *client* search path at the ALS
+# read-only gateway (the same host ALS's own readOnlyPhoebus.sh uses). The gateway
+# grants "read, no write" via CA access security on every channel, so real panels
+# show live machine data while writes stay impossible — even for a human clicking
+# buttons in the streamed noVNC panel, which bypasses all MCP-level write gates.
+# Server-side interfaces (EPICS_CAS_*) stay loopback in EVERY mode: the demo IOC
+# never announces itself off-box.
+#
+# READONLY_GATEWAY names a facility-specific gateway host, so it has no
+# framework default here — it is supplied via the env var, or via an untracked
+# demos/phoebus/local.env (sourced if present; not part of the repo, so each
+# facility keeps its own gateway host out of version control). Only required
+# when LIVE_READONLY=1 actually asks for it.
+if [[ -z "${READONLY_GATEWAY:-}" && -f "${SCRIPT_DIR}/local.env" ]]; then
+  # shellcheck disable=SC1091
+  source "${SCRIPT_DIR}/local.env"
+fi
+if [[ "${LIVE_READONLY:-0}" == 1 && -z "${READONLY_GATEWAY:-}" ]]; then
+  echo "ERROR: LIVE_READONLY=1 requires READONLY_GATEWAY (facility read-only CA/PVA gateway host)."
+  echo "       Set the env var, or create demos/phoebus/local.env with READONLY_GATEWAY=<host>."
+  exit 2
+fi
+if [[ "${ISOLATED}" == 1 ]]; then
+  _LOOP_CA_ENTRY="127.0.0.1:${CA_SERVER_PORT}"   # explicit port: stays valid in a mixed list
+else
+  _LOOP_CA_ENTRY="127.0.0.1"
+fi
+if [[ "${LIVE_READONLY:-0}" == 1 ]]; then
+  export EPICS_CA_ADDR_LIST="${_LOOP_CA_ENTRY} ${READONLY_GATEWAY}:5064"
+  export EPICS_PVA_ADDR_LIST="${READONLY_GATEWAY}"
+else
+  export EPICS_CA_ADDR_LIST=127.0.0.1
+  # Scrub PVA too — the host login env points EPICS_PVA_ADDR_LIST at the
+  # production subnets, which would leak any pva:// PV out of the sandbox.
+  export EPICS_PVA_ADDR_LIST=127.0.0.1
+fi
+export EPICS_CA_AUTO_ADDR_LIST=NO
+export EPICS_PVA_AUTO_ADDR_LIST=NO
+export EPICS_CAS_INTF_ADDR_LIST=127.0.0.1
+export EPICS_CAS_BEACON_ADDR_LIST=127.0.0.1
+if [[ "${ISOLATED}" == 1 ]]; then
+  # Dedicated CA ports so the demo IOC never touches the host's default CA
+  # server (5064) or repeater (5065) — a hard isolation guarantee on a shared box.
+  export EPICS_CA_SERVER_PORT="${CA_SERVER_PORT}"
+  export EPICS_CA_REPEATER_PORT="${CA_REPEATER_PORT}"
+fi
+
+# Debug/test seam: print the resolved EPICS client/server env and exit before
+# any pre-flight checks or process launches.
+if [[ "${PRINT_EPICS_ENV:-0}" == 1 ]]; then
+  env | grep -E '^EPICS_(CA|CAS|PVA)_' | sort
+  exit 0
+fi
+
+IOC_PID=""
+PHOEBUS_PID=""
+XVNC_PID=""
+WEBSOCKIFY_PID=""
+RUNDIR=""
+RUNDIR_CREATED=0
+log() { printf '[demo] %s\n' "$*"; }
+
+cleanup() {
+  log "shutting down…"
+  [[ -n "${PHOEBUS_PID}" ]] && kill "${PHOEBUS_PID}" 2>/dev/null
+  [[ -n "${IOC_PID}" ]] && kill "${IOC_PID}" 2>/dev/null
+  [[ -n "${WEBSOCKIFY_PID}" ]] && kill "${WEBSOCKIFY_PID}" 2>/dev/null
+  [[ -n "${XVNC_PID}" ]] && kill "${XVNC_PID}" 2>/dev/null
+  wait 2>/dev/null
+  # Only remove a run dir WE created (mktemp); never a user-supplied PHOEBUS_USER_DIR.
+  [[ "${RUNDIR_CREATED}" == 1 && -n "${RUNDIR}" && -d "${RUNDIR}" ]] && rm -rf "${RUNDIR}"
+}
+trap cleanup EXIT INT TERM
+
+# --- helpers -------------------------------------------------------------------
+# Read-only listener probes. Return 0 (true) if the port is already bound.
+# NB: no `-H` on ss — some builds reject it and would silently emit nothing,
+# turning this safety guard into a false "port free". The header line can't
+# match a ":PORT<end-of-field>" pattern, so plain `ss` is safe to grep.
+tcp_port_in_use() {  # $1 = port
+  if command -v ss >/dev/null 2>&1; then
+    ss -tln 2>/dev/null | grep -qE "[:.]${1}([[:space:]]|\$)"
+  elif command -v lsof >/dev/null 2>&1; then
+    lsof -nP -iTCP:"${1}" -sTCP:LISTEN >/dev/null 2>&1
+  else
+    return 1  # can't probe -> don't block
+  fi
+}
+udp_port_in_use() {  # $1 = port
+  if command -v ss >/dev/null 2>&1; then
+    ss -uln 2>/dev/null | grep -qE "[:.]${1}([[:space:]]|\$)"
+  else
+    return 1
+  fi
+}
+
+# Pre-flight collision check (isolated mode only). Refuses to start — the hard
+# guarantee that we never disturb another Phoebus / CA server / X display.
+preflight_check() {
+  local fail=0 dn="${DEMO_DISPLAY#:}"
+  log "pre-flight collision check (isolated mode)…"
+  if [[ -e "/tmp/.X11-unix/X${dn}" || -e "/tmp/.X${dn}-lock" ]]; then
+    echo "ERROR: X display ${DEMO_DISPLAY} already in use"; fail=1
+  fi
+  tcp_port_in_use "${BRIDGE_PORT}"   && { echo "ERROR: bridge port ${BRIDGE_PORT} already in use"; fail=1; }
+  tcp_port_in_use "${INSTANCE_PORT}" && { echo "ERROR: Phoebus instance-server port ${INSTANCE_PORT} already in use"; fail=1; }
+  tcp_port_in_use "${RFB_PORT}"      && { echo "ERROR: Xvnc RFB port ${RFB_PORT} already in use"; fail=1; }
+  # CA server binds both UDP (search) and TCP (virtual circuits) on its port.
+  # Only checked when THIS instance starts the IOC — a secondary instance
+  # (START_IOC=0) *expects* instance 1's IOC to hold these ports.
+  if [[ "${START_IOC}" == 1 ]]; then
+    { tcp_port_in_use "${CA_SERVER_PORT}" || udp_port_in_use "${CA_SERVER_PORT}"; } && { echo "ERROR: demo CA server port ${CA_SERVER_PORT} already in use"; fail=1; }
+    udp_port_in_use "${CA_REPEATER_PORT}" && { echo "ERROR: demo CA repeater port ${CA_REPEATER_PORT} already in use"; fail=1; }
+  fi
+  [[ "${STREAM_ENABLED}" == 1 ]] && tcp_port_in_use "${WEB_VNC_PORT}" && { echo "ERROR: web-stream (websockify) port ${WEB_VNC_PORT} already in use"; fail=1; }
+  if [[ "${fail}" == 1 ]]; then
+    echo "ABORT: refusing to start — an isolated-runtime resource is occupied."
+    echo "       (This guard exists so the demo can never disturb another running Phoebus/CA/X server.)"
+    exit 3
+  fi
+  log "pre-flight OK — display ${DEMO_DISPLAY}, bridge ${BRIDGE_PORT}, -server ${INSTANCE_PORT}, RFB ${RFB_PORT}, CA ${CA_SERVER_PORT}/${CA_REPEATER_PORT} all free"
+}
+
+# --- preconditions -------------------------------------------------------------
+command -v curl >/dev/null 2>&1 || { echo "ERROR: curl is required"; exit 2; }
+
+# --- IOC interpreter: OSPREY_PYTHON > uv > ${OSPREY_ROOT}/.venv ------------------
+# The demo IOC only needs caproto, so any python that can `import caproto` works.
+# uv is absent on appsdev2 — point OSPREY_PYTHON at an existing venv there, e.g.
+#   OSPREY_PYTHON=~/projects/osprey/.venv/bin/python
+IOC_CMD=()
+if [[ "${START_IOC}" != 1 ]]; then
+  : # secondary instance — no IOC, no python needed
+elif [[ -n "${OSPREY_PYTHON:-}" ]]; then
+  "${OSPREY_PYTHON}" -c 'import caproto' 2>/dev/null \
+    || { echo "ERROR: OSPREY_PYTHON=${OSPREY_PYTHON} cannot import caproto"; exit 2; }
+  IOC_CMD=( "${OSPREY_PYTHON}" )
+elif command -v uv >/dev/null 2>&1; then
+  IOC_CMD=( uv run --project "${OSPREY_ROOT}" python )
+elif [[ -x "${OSPREY_ROOT}/.venv/bin/python" ]] \
+     && "${OSPREY_ROOT}/.venv/bin/python" -c 'import caproto' 2>/dev/null; then
+  IOC_CMD=( "${OSPREY_ROOT}/.venv/bin/python" )
+else
+  echo "ERROR: cannot run the IOC — install uv, or set OSPREY_PYTHON to a python with caproto"
+  exit 2
+fi
+
+# --- web-stream leg (optional): websockify + vendored noVNC ---------------------
+# Serves the noVNC client over HTTP and bridges its WebSocket to the Xvnc RFB
+# port, all on loopback. The OSPREY web terminal embeds it as the PHOEBUS panel
+# (iframe /panel/phoebus/vnc.html; WS relayed by the terminal's /panel proxy).
+WS_CMD=()
+if [[ -n "${WEBSOCKIFY_CMD:-}" ]]; then
+  # Intentionally word-split: the override may carry env vars + args.
+  read -r -a WS_CMD <<< "${WEBSOCKIFY_CMD}"
+elif command -v websockify >/dev/null 2>&1; then
+  WS_CMD=( websockify )
+fi
+if [[ -z "${NOVNC_DIR:-}" ]]; then
+  for _cand in "${SCRIPT_DIR}/novnc" "${HOME}/phoebus-remote-bridge-demo/novnc"; do
+    [[ -f "${_cand}/vnc.html" ]] && { NOVNC_DIR="${_cand}"; break; }
+  done
+fi
+STREAM_ENABLED=0
+if [[ ${#WS_CMD[@]} -gt 0 && -n "${NOVNC_DIR:-}" && -f "${NOVNC_DIR}/vnc.html" ]]; then
+  STREAM_ENABLED=1
+fi
+[[ -f "${PANEL}" ]] || { echo "ERROR: demo panel not found: ${PANEL}"; exit 2; }
+
+PHOEBUS_JAR="${PHOEBUS_JAR:-$(ls "${PHOEBUS_REPO}"/phoebus-product/target/product-*.jar 2>/dev/null | head -1)}"
+if [[ -z "${PHOEBUS_JAR}" || ! -f "${PHOEBUS_JAR}" ]]; then
+  echo "ERROR: Phoebus product jar not found under ${PHOEBUS_REPO}/phoebus-product/target."
+  echo "       Build it:  (cd ${PHOEBUS_REPO} && mvn -pl phoebus-product -am install -DskipTests)"
+  echo "       Or set PHOEBUS_REPO / PHOEBUS_JAR."
+  exit 2
+fi
+
+# --- isolated mode: pre-flight guard + private Xvnc X server -------------------
+# Extra JVM args (before -jar) and Phoebus product args (after -jar). Empty in
+# desktop mode; the ${arr[@]+...} expansion below is set -u / bash-3.2 safe.
+JVM_EXTRA_ARGS=()
+PHX_EXTRA_ARGS=()
+PANEL_RES="file:${PANEL}"   # -resource wants a file: URL (canonical; matches prod usage)
+if [[ "${ISOLATED}" == 1 ]]; then
+  # Resolve the X server. It must be TigerVNC: RealVNC's Xvnc ignores -geometry
+  # in virtual mode (it sizes the desktop itself, e.g. to a past viewer) and
+  # paints vncserverui overlay windows into the framebuffer. RealVNC's package
+  # also usurps /usr/bin/Xvnc and renames TigerVNC's binary to Xvnc.conflict —
+  # prefer that survivor when the default resolves to RealVNC.
+  if [[ -z "${XVNC_CMD:-}" ]]; then
+    XVNC_CMD="Xvnc"
+    _xvnc_path="$(command -v Xvnc 2>/dev/null || true)"
+    if [[ -n "${_xvnc_path}" ]] && readlink -f "${_xvnc_path}" 2>/dev/null | grep -qi realvnc; then
+      if [[ -x /usr/bin/Xvnc.conflict ]]; then
+        XVNC_CMD="/usr/bin/Xvnc.conflict"
+        log "Xvnc on PATH is RealVNC — using TigerVNC at ${XVNC_CMD} instead"
+      else
+        echo "ERROR: Xvnc on PATH is RealVNC (ignores -geometry, overlays its UI on the stream)."
+        echo "       Point XVNC_CMD at a TigerVNC Xvnc binary."
+        exit 2
+      fi
+    fi
+  fi
+  command -v "${XVNC_CMD}" >/dev/null 2>&1 || {
+    echo "ERROR: Xvnc (TigerVNC) is required for isolated/headless mode."
+    echo "       Install tigervnc-server, or run on a desktop with ISOLATED=0."
+    exit 2; }
+
+  preflight_check
+
+  if [[ -n "${PHOEBUS_USER_DIR:-}" ]]; then
+    RUNDIR="${PHOEBUS_USER_DIR}"; RUNDIR_CREATED=0
+  else
+    RUNDIR="$(mktemp -d "${TMPDIR:-/tmp}/osprey-phoebus-demo.XXXXXX")"; RUNDIR_CREATED=1
+  fi
+  mkdir -p "${RUNDIR}/user"
+
+  # Pin the main Phoebus window to fill the Xvnc framebuffer exactly: with no
+  # window manager on the display there are no decorations, so 0,0 x geometry
+  # means the VNC stream shows ONLY Phoebus — no bare X root around it.
+  # Phoebus restores stage bounds from ${phoebus.user}/.phoebus/memento on
+  # startup (Locations.user() appends the ".phoebus" folder;
+  # MementoHelper.restoreStage applies the bounds); geometry applies even though
+  # the empty <pane/> restores no tabs. Re-seeded every launch, clobbering any
+  # layout a previous run saved into a reused PHOEBUS_USER_DIR — for the demo
+  # that reset is wanted.
+  GEOM_W="${DEMO_GEOMETRY%x*}"; GEOM_H="${DEMO_GEOMETRY#*x}"
+  case "${GEOM_W}${GEOM_H}" in (*[!0-9]*|'')
+    echo "ERROR: DEMO_GEOMETRY must be WxH (e.g. 1600x900), got '${DEMO_GEOMETRY}'"; exit 2;;
+  esac
+  mkdir -p "${RUNDIR}/user/.phoebus"
+  cat > "${RUNDIR}/user/.phoebus/memento" <<MEMENTO
+<memento>
+  <DockStage_MAIN x="0" y="0" width="${GEOM_W}" height="${GEOM_H}">
+    <pane/>
+  </DockStage_MAIN>
+</memento>
+MEMENTO
+
+  export XAUTHORITY="${RUNDIR}/Xauthority"; : > "${XAUTHORITY}"
+  _cookie="$(mcookie 2>/dev/null || head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+  xauth -f "${XAUTHORITY}" add "${DEMO_DISPLAY}" . "${_cookie}" >/dev/null 2>&1
+
+  log "starting Xvnc (${XVNC_CMD}) on ${DEMO_DISPLAY} (${DEMO_GEOMETRY}, RFB 127.0.0.1:${RFB_PORT}, loopback, no window manager)…"
+  "${XVNC_CMD}" "${DEMO_DISPLAY}" -geometry "${DEMO_GEOMETRY}" -depth 24 -rfbport "${RFB_PORT}" \
+       -SecurityTypes None -localhost -auth "${XAUTHORITY}" \
+       >"${RUNDIR}/xvnc.log" 2>&1 &
+  XVNC_PID=$!
+  sleep 2
+  kill -0 "${XVNC_PID}" 2>/dev/null || { echo "ERROR: Xvnc failed to start; see ${RUNDIR}/xvnc.log"; exit 1; }
+  export DISPLAY="${DEMO_DISPLAY}"
+
+  if [[ "${STREAM_ENABLED}" == 1 ]]; then
+    log "starting websockify on 127.0.0.1:${WEB_VNC_PORT} (noVNC: ${NOVNC_DIR}, RFB target 127.0.0.1:${RFB_PORT})…"
+    "${WS_CMD[@]}" --web "${NOVNC_DIR}" 127.0.0.1:"${WEB_VNC_PORT}" 127.0.0.1:"${RFB_PORT}" \
+      >"/tmp/osprey_demo_websockify${LOG_SUFFIX}.log" 2>&1 &
+    WEBSOCKIFY_PID=$!
+    sleep 1
+    kill -0 "${WEBSOCKIFY_PID}" 2>/dev/null || {
+      echo "ERROR: websockify failed to start; see /tmp/osprey_demo_websockify${LOG_SUFFIX}.log"; exit 1; }
+  else
+    log "web-stream leg skipped (websockify or noVNC assets not found) — bridge demo still fully functional"
+  fi
+
+  # The bridge's listen port is a Phoebus preference (default 7979) — pass the
+  # instance's BRIDGE_PORT through a per-run settings file, or every instance
+  # would listen on 7979 regardless of the port we probe.
+  printf 'org.phoebus.applications.bridge.web/port=%s\n' "${BRIDGE_PORT}" \
+    > "${RUNDIR}/settings.ini"
+
+  # -Dprism.order=sw : GTK-glass software pipeline (a real X11 window Xvnc can
+  #                    stream — NOT Monocle, which draws no window).
+  # -Dphoebus.user / -Duser.home : keep ALL writes inside the private RUNDIR.
+  # -server ${INSTANCE_PORT} : dedicated single-instance server, so -resource
+  #                    forwarding can never target another Phoebus on the host.
+  JVM_EXTRA_ARGS=( -Dprism.order=sw
+                   -Dphoebus.user="${RUNDIR}/user"
+                   -Duser.home="${RUNDIR}" )
+  PHX_EXTRA_ARGS=( -server "${INSTANCE_PORT}" -settings "${RUNDIR}/settings.ini" )
+  log "isolated runtime: DISPLAY=${DEMO_DISPLAY}, user dir=${RUNDIR}/user, -server ${INSTANCE_PORT}"
+fi
+
+# --- 1. soft IOC ---------------------------------------------------------------
+if [[ "${START_IOC}" == 1 ]]; then
+  log "starting soft IOC (DEMO:*) …"
+  "${IOC_CMD[@]}" "${IOC}" >/tmp/osprey_demo_ioc.log 2>&1 &
+  IOC_PID=$!
+  sleep 4
+  kill -0 "${IOC_PID}" 2>/dev/null || { echo "ERROR: IOC exited; see /tmp/osprey_demo_ioc.log"; exit 1; }
+  log "IOC up (pid ${IOC_PID})"
+else
+  log "soft IOC leg skipped (INSTANCE=${INSTANCE}, START_IOC=${START_IOC}) — sharing instance 1's IOC on CA ${CA_SERVER_PORT}"
+fi
+
+# --- 2. Phoebus + bridge -------------------------------------------------------
+# -Djca.use_env=true makes Phoebus's pure-Java CA honor the EPICS_CA_* env vars
+# above (by default it ignores them and uses auto_addr_list=true / LAN broadcast,
+# so it never probes the loopback-bound soft IOC). With it, Phoebus searches
+# 127.0.0.1 and connects to DEMO:*.
+#
+# Launch with an explicit classpath (jar + sibling lib/*) instead of -jar: the
+# manifest Class-Path pins the JavaFX jars of the BUILD platform, so a product
+# built on macOS never finds the Linux natives on appsdev2. With -cp, whatever
+# platform jars actually sit in lib/ define the runtime set (missing manifest
+# entries are ignored per the JAR spec), so swapping lib/ jars is sufficient.
+PHOEBUS_LIB="$(dirname "${PHOEBUS_JAR}")/lib"
+if [[ -d "${PHOEBUS_LIB}" ]]; then
+  PHOEBUS_LAUNCH=( -cp "${PHOEBUS_JAR}:${PHOEBUS_LIB}/*" org.phoebus.product.Launcher )
+else
+  PHOEBUS_LAUNCH=( -jar "${PHOEBUS_JAR}" )
+fi
+log "launching Phoebus with the demo panel …"
+java -Djca.use_env=true ${JVM_EXTRA_ARGS[@]+"${JVM_EXTRA_ARGS[@]}"} \
+     "${PHOEBUS_LAUNCH[@]}" ${PHX_EXTRA_ARGS[@]+"${PHX_EXTRA_ARGS[@]}"} \
+     -resource "${PANEL_RES}" \
+     >"/tmp/osprey_demo_phoebus${LOG_SUFFIX}.log" 2>&1 &
+PHOEBUS_PID=$!
+
+log "waiting for the bridge at ${BASE_URL}/displays …"
+ready=0
+for _ in $(seq 1 60); do
+  if curl -fsS "${BASE_URL}/displays" >/dev/null 2>&1; then ready=1; break; fi
+  kill -0 "${PHOEBUS_PID}" 2>/dev/null || { echo "ERROR: Phoebus exited; see /tmp/osprey_demo_phoebus${LOG_SUFFIX}.log"; exit 1; }
+  sleep 2
+done
+[[ "${ready}" == 1 ]] || { echo "ERROR: bridge never became ready"; exit 1; }
+
+cat <<EOF
+
+[demo]  ✓ Stack is UP$( [[ "${INSTANCE}" != 1 ]] && echo " (instance ${INSTANCE})" ).
+[demo]    • Soft IOC   : DEMO:* on Channel Access (127.0.0.1$( [[ "${ISOLATED}" == 1 ]] && echo ":${CA_SERVER_PORT}" ))$( [[ "${START_IOC}" != 1 ]] && echo "  [shared — started by instance 1]" )
+[demo]    • Phoebus    : showing osprey_demo.bob$( [[ "${ISOLATED}" == 1 ]] && echo " (isolated: DISPLAY ${DEMO_DISPLAY} @ ${DEMO_GEOMETRY}, -server ${INSTANCE_PORT})" )
+[demo]    • Bridge     : ${BASE_URL}$( [[ "${ISOLATED}" == 1 ]] && echo "
+[demo]    • VNC stream : 127.0.0.1:${RFB_PORT}  (display ${DEMO_DISPLAY})" )$( [[ "${STREAM_ENABLED}" == 1 ]] && echo "
+[demo]    • noVNC      : http://127.0.0.1:${WEB_VNC_PORT}/vnc.html?autoconnect=1&resize=scale
+[demo]                   (the OSPREY web terminal's PHOEBUS$( [[ "${INSTANCE}" != 1 ]] && echo "${INSTANCE}" ) panel embeds this via /panel/phoebus$( [[ "${INSTANCE}" != 1 ]] && echo "${INSTANCE}" ))" )
+[demo]
+[demo]  Next: in a SEPARATE terminal, open your built phoebus-demo project and run:
+[demo]      claude
+[demo]      > run the phoebus walkthrough
+[demo]
+[demo]  Quick manual check (this terminal works too):
+[demo]      curl -s ${BASE_URL}/perceive?display=active | jq '.widgets[].name'
+[demo]
+[demo]  Press Ctrl-C to tear down the stack.
+EOF
+
+wait "${PHOEBUS_PID}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ dependencies = [
     "tenacity>=9.1.4",
     # Cross-version TypedDict/NotRequired — pydantic v2.12 rejects typing.TypedDict on py<3.12.
     "typing_extensions>=4.12.0",
+    "caproto>=1.3.0",
 ]
 
 [project.optional-dependencies]

--- a/src/osprey/agent_runner/write_tools.py
+++ b/src/osprey/agent_runner/write_tools.py
@@ -148,10 +148,12 @@ def _is_destructive(tool: str) -> bool:
     return any(marker in lowered for marker in _DESTRUCTIVE_MARKERS)
 
 
-def _registry_side_effect_tools() -> list[str]:
-    """Side-effecting MCP tool names declared in the framework registry.
+def _server_side_effect_tools(server) -> list[str]:
+    """Side-effecting MCP tool names declared by ONE ServerDefinition.
 
-    For every framework server this unions:
+    Shared classifier for the framework-registry walk and the config-declared
+    ``extends`` clone path — one implementation, so the two can never drift.
+    Unions:
 
     * ``permissions_ask`` + ``fixed_ask`` — the curated "needs approval because
       it acts" sets (e.g. ``entry_create``, ``draft_concept``, ``setup_patch``,
@@ -167,25 +169,54 @@ def _registry_side_effect_tools() -> list[str]:
     *reads* (``channel_read``, ``archiver_read``), which a read-only query must
     still be able to call.
 
-    Returns names as ``mcp__<server>__<tool>``.
+    Does NOT include ``_EXTRA_SIDE_EFFECT_TOOLS`` (tools in no permission list
+    at all) — callers union those separately: the framework walk via
+    :func:`read_only_disallowed_tools`, extends clones via
+    :func:`_extra_side_effect_tools_for`.
+
+    Returns names as ``mcp__<server>__<tool>`` (writes-check matchers verbatim).
     """
-    from osprey.registry.mcp import _WRITES_CHECK, FRAMEWORK_SERVERS
+    from osprey.registry.mcp import _WRITES_CHECK
 
     out: list[str] = []
+    for tool in (*server.permissions_ask, *server.fixed_ask):
+        out.append(f"mcp__{server.name}__{tool}")
+    for tool in (*server.permissions_allow, *server.fixed_allow):
+        if _is_destructive(tool):
+            out.append(f"mcp__{server.name}__{tool}")
+    for rule in server.hooks_pre:
+        if _WRITES_CHECK in rule.hooks:
+            out.append(rule.matcher)
+    return out
 
-    def _add(name: str) -> None:
-        if name not in out:
-            out.append(name)
 
+def _extra_side_effect_tools_for(instance_name: str, template_name: str) -> list[str]:
+    """``_EXTRA_SIDE_EFFECT_TOOLS`` entries owned by one framework template,
+    rewritten to an instance's prefix.
+
+    The extras list is keyed by framework-server name (``mcp__python__…``), but
+    SDK disallow matching is by EXACT tool name — an ``extends`` clone launches
+    the SAME tool module under a new prefix, so the template's extras must
+    follow the clone as ``mcp__<instance>__<tool>`` or the clone would keep an
+    unlisted exec tool (e.g. ``execute_file``) callable in read-only mode.
+    """
+    old = f"mcp__{template_name}__"
+    new = f"mcp__{instance_name}__"
+    return [new + tool[len(old) :] for tool in _EXTRA_SIDE_EFFECT_TOOLS if tool.startswith(old)]
+
+
+def _registry_side_effect_tools() -> list[str]:
+    """Side-effecting MCP tool names declared in the framework registry.
+
+    Applies :func:`_server_side_effect_tools` to every framework server.
+    """
+    from osprey.registry.mcp import FRAMEWORK_SERVERS
+
+    out: list[str] = []
     for server in FRAMEWORK_SERVERS.values():
-        for tool in (*server.permissions_ask, *server.fixed_ask):
-            _add(f"mcp__{server.name}__{tool}")
-        for tool in (*server.permissions_allow, *server.fixed_allow):
-            if _is_destructive(tool):
-                _add(f"mcp__{server.name}__{tool}")
-        for rule in server.hooks_pre:
-            if _WRITES_CHECK in rule.hooks:
-                _add(rule.matcher)
+        for name in _server_side_effect_tools(server):
+            if name not in out:
+                out.append(name)
     return out
 
 
@@ -212,6 +243,20 @@ def _custom_server_side_effect_tools(project_dir: Path) -> list[str]:
     the registry would emit (``mcp__<server>__.*``) is a no-op in the SDK's
     exact-name/server-level disallow engine.
 
+    An ``extends`` spec (second instance of a framework server) is classified
+    from the RESOLVED clone via :func:`_server_side_effect_tools`, so it
+    inherits the template's ask/destructive-allow/writes-check surface with the
+    ``mcp__<template>__`` → ``mcp__<name>__`` matcher rewrite, plus the
+    template's ``_EXTRA_SIDE_EFFECT_TOOLS`` entries rewritten the same way
+    (:func:`_extra_side_effect_tools_for`). If the extends
+    target cannot be resolved (typo, version skew, config edited after build)
+    this fails CLOSED with a server-level ``mcp__<name>`` disallow — a stale
+    ``.mcp.json`` from a previous build can still launch the server
+    (``enableAllProjectMcpServers: true``), so an unresolvable spec must block
+    the whole server rather than contribute nothing. A spec with NONE of
+    extends/command/url (legacy form ``phoebus2: {enabled: true}``) fails
+    closed the same way.
+
     Returns an empty list when ``config.yml`` is absent or unreadable.
     """
     try:
@@ -219,7 +264,7 @@ def _custom_server_side_effect_tools(project_dir: Path) -> list[str]:
     except (OSError, ValueError):
         return []
 
-    from osprey.registry.mcp import FRAMEWORK_SERVERS
+    from osprey.registry.mcp import FRAMEWORK_SERVERS, build_extended_server
 
     servers = (cfg.get("claude_code") or {}).get("servers") or {}
     if not isinstance(servers, dict):
@@ -231,6 +276,26 @@ def _custom_server_side_effect_tools(project_dir: Path) -> list[str]:
             continue
         if name in FRAMEWORK_SERVERS:
             continue  # framework server (or override) — covered by the registry walk
+        if "extends" in spec:
+            clone = build_extended_server(name, spec)
+            if clone is None:
+                out.append(f"mcp__{name}")  # fail closed (see docstring)
+            else:
+                out.extend(_server_side_effect_tools(clone))
+                # The template's hard-coded extras (side-effect tools in NO
+                # registry list, e.g. python's execute_file) must follow the
+                # clone with the rewritten prefix — the registry classifier
+                # cannot see them, and exact-name disallow matching means the
+                # template's own entry does not cover the clone.
+                out.extend(_extra_side_effect_tools_for(name, spec["extends"]))
+            continue
+        if not spec.get("command") and not spec.get("url"):
+            # NONE of extends/command/url (legacy form 'phoebus2: {enabled:
+            # true}'): resolve_servers skips such a spec, so it never renders
+            # into .mcp.json — but a stale .mcp.json from a previous build can
+            # still launch a server by this name. Fail closed exactly like the
+            # unresolvable-extends path above: block the whole server.
+            out.append(f"mcp__{name}")
         perms = spec.get("permissions") or {}
         for tool in perms.get("ask") or []:
             out.append(f"mcp__{name}__{tool}")
@@ -269,7 +334,9 @@ def read_only_disallowed_tools(project_dir: Path) -> list[str]:
       side-effect surface tracks the registry as the single source of truth, not
       a hand-maintained copy).
     * ``_EXTRA_SIDE_EFFECT_TOOLS`` — side-effecting tools in NO registry
-      permission list (currently ``mcp__python__execute_file``).
+      permission list (currently ``mcp__python__execute_file``); ``extends``
+      clones of the owning template get these rewritten to their own prefix
+      via the custom-server path below.
     * :func:`_custom_server_side_effect_tools` — write tools of facility-defined
       custom MCP servers declared in the project's ``config.yml``.
 

--- a/src/osprey/cli/templates/claude_code.py
+++ b/src/osprey/cli/templates/claude_code.py
@@ -144,6 +144,34 @@ def build_claude_code_context(
 
     ctx["enabled_servers"] = {s["name"] for s in ctx["servers"] if s["enabled"]}
     ctx["enabled_agents"] = {a["name"] for a in ctx["agents"] if a["enabled"]}
+
+    # Approval-overlap guard: a facility permissions.remove_ask or
+    # permissions.allow entry naming an approval-gated (ask) tool of an enabled
+    # server auto-approves it at the permission layer — and the osprey_approval
+    # hook keys its policy on the bare tool name, so a skip/allow there applies
+    # to EVERY instance of a template (extends clones included; per-instance
+    # gating is not possible). Warn loudly at build time.
+    _facility_perms = ctx["facility_permissions"] or {}
+    _overridden = set(_facility_perms.get("remove_ask") or []) | set(
+        _facility_perms.get("allow") or []
+    )
+    if _overridden:
+        for _srv in ctx["servers"]:
+            if not _srv["enabled"]:
+                continue
+            _ask_full = [f"mcp__{_srv['name']}__{t}" for t in _srv["permissions_ask"]] + list(
+                _srv["fixed_ask"]
+            )
+            for _tool in _ask_full:
+                if _tool in _overridden:
+                    logger.warning(
+                        "facility permissions remove_ask/allow overrides the "
+                        "approval-gated tool %s of server %r — it will be "
+                        "auto-approved at the permission layer",
+                        _tool,
+                        _srv["name"],
+                    )
+
     # User-owned files: regen skips these, users edit in-place
     ctx["user_owned"] = config.get("scaffold", {}).get("user_owned", [])
 
@@ -189,12 +217,25 @@ def build_claude_code_context(
     if not config.get("control_system", {}).get("writes_enabled", False):
         facility_perms = dict(ctx["facility_permissions"])
         deny = list(facility_perms.get("deny", []))
-        if "mcp__controls__channel_write" not in deny:
-            deny.append("mcp__controls__channel_write")
-        facility_perms["deny"] = deny
         remove_ask = list(facility_perms.get("remove_ask", []))
-        if "mcp__python__execute" not in remove_ask:
-            remove_ask.append("mcp__python__execute")
+        # Cover extends clones too, not just the literal template names: the
+        # runtime hook templates (osprey_writes_check.py, osprey_approval.py)
+        # exact-match template tool names and are clone-unaware — they are the
+        # belt layer only; this settings.json deny/remove_ask rendering is the
+        # enforced layer for clones.
+        for srv in ctx["servers"]:
+            if not srv["enabled"]:
+                continue
+            template = srv.get("extends_of") or srv["name"]
+            if template == "controls":
+                entry = f"mcp__{srv['name']}__channel_write"
+                if entry not in deny:
+                    deny.append(entry)
+            elif template == "python":
+                entry = f"mcp__{srv['name']}__execute"
+                if entry not in remove_ask:
+                    remove_ask.append(entry)
+        facility_perms["deny"] = deny
         facility_perms["remove_ask"] = remove_ask
         ctx["facility_permissions"] = facility_perms
 

--- a/src/osprey/cli/web_cmd.py
+++ b/src/osprey/cli/web_cmd.py
@@ -192,8 +192,12 @@ def web(
         click.echo("WARNING: Binding to 0.0.0.0 exposes the terminal to the network.")
         click.echo("This is a single-user tool — add authentication before external exposure.\n")
 
-    # Pre-flight: check if port is already in use
+    # Pre-flight: check if port is already in use. SO_REUSEADDR matches
+    # uvicorn's own bind semantics — without it, TIME_WAIT sockets from a
+    # just-killed server fail this check for ~60s even though uvicorn
+    # itself would bind fine.
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
             s.bind((host, port))
         except OSError as exc:
@@ -201,6 +205,13 @@ def web(
             click.echo(f"  Find the process:  lsof -i :{port}", err=True)
             click.echo(f"  Or use another:    osprey web --port {port + 1}", err=True)
             raise SystemExit(1) from exc
+
+    # Publish the ACTUAL port to every child process (PTY shells, their MCP
+    # servers): web_terminal_url() resolves OSPREY_WEB_PORT first, and
+    # without this, panel tools (switch_panel etc.) fire-and-forget their
+    # focus POSTs at the config default (8087) whenever --port differs —
+    # reporting success while the real terminal never hears the event.
+    os.environ["OSPREY_WEB_PORT"] = str(port)
 
     click.echo(f"Starting OSPREY Web Terminal on http://{host}:{port}")
     click.echo(f"Shell: {' '.join(shell_command)}")

--- a/src/osprey/interfaces/web_terminal/routes/proxy.py
+++ b/src/osprey/interfaces/web_terminal/routes/proxy.py
@@ -305,10 +305,19 @@ async def proxy_panel_ws(panel_id: str, path: str, websocket: WebSocket):
         async with websockets.connect(target) as upstream:
 
             async def client_to_upstream():
+                # receive() (not receive_text()) — binary-protocol panels
+                # (e.g. the noVNC/RFB phoebus stream) send bytes frames,
+                # which receive_text() rejects, killing the relay.
                 try:
                     while True:
-                        data = await websocket.receive_text()
-                        await upstream.send(data)
+                        msg = await websocket.receive()
+                        if msg.get("type") == "websocket.disconnect":
+                            break
+                        data = msg.get("bytes")
+                        if data is None:
+                            data = msg.get("text")
+                        if data is not None:
+                            await upstream.send(data)
                 except WebSocketDisconnect:
                     pass
 

--- a/src/osprey/mcp_server/http.py
+++ b/src/osprey/mcp_server/http.py
@@ -34,6 +34,33 @@ def web_terminal_url() -> str:
     return f"http://{host}:{port}"
 
 
+def phoebus_bridge_url() -> str:
+    """Build the Phoebus agent-bridge base URL from env or config.
+
+    The bridge is the in-JVM HTTP server embedded in a running Phoebus product
+    (default ``http://127.0.0.1:7979``). Resolution order:
+
+    1. ``PHOEBUS_BRIDGE_URL`` env var (full URL) — set by the framework server
+       definition; wins outright.
+    2. ``PHOEBUS_BRIDGE_PORT`` env var overrides only the port.
+    3. ``phoebus.host`` / ``phoebus.port`` in config.yml.
+    4. ``127.0.0.1:7979`` default (matches ``bridge_preferences.properties``).
+    """
+    import os
+
+    from osprey.utils.workspace import load_osprey_config
+
+    full = os.environ.get("PHOEBUS_BRIDGE_URL")
+    if full:
+        return full.rstrip("/")
+
+    config = load_osprey_config()
+    ph = config.get("phoebus", {})
+    host = ph.get("host", "127.0.0.1")
+    port = int(os.environ.get("PHOEBUS_BRIDGE_PORT", ph.get("port", 7979)))
+    return f"http://{host}:{port}"
+
+
 def post_json(url: str, payload: dict, *, timeout: int = 3) -> None:
     """Fire-and-forget JSON POST to a local HTTP endpoint.
 

--- a/src/osprey/mcp_server/phoebus/__init__.py
+++ b/src/osprey/mcp_server/phoebus/__init__.py
@@ -1,0 +1,6 @@
+"""OSPREY Phoebus MCP Server — native interaction with live Phoebus panels.
+
+Translates agent tool calls into HTTP requests against the Phoebus *agent
+bridge* (the in-JVM JSON/HTTP server embedded in a running Phoebus product),
+giving the agent first-class perceive + drive access to live control panels.
+"""

--- a/src/osprey/mcp_server/phoebus/__main__.py
+++ b/src/osprey/mcp_server/phoebus/__main__.py
@@ -1,0 +1,11 @@
+"""Entry point for ``python -m osprey.mcp_server.phoebus``."""
+
+from osprey.mcp_server.startup import run_mcp_server
+
+
+def main() -> None:
+    run_mcp_server("osprey.mcp_server.phoebus.server")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/osprey/mcp_server/phoebus/server.py
+++ b/src/osprey/mcp_server/phoebus/server.py
@@ -1,0 +1,48 @@
+"""OSPREY Phoebus MCP Server.
+
+FastMCP server exposing perceive + drive tools that talk to a running
+Phoebus product's agent bridge over JSON/HTTP.
+
+Usage:
+    python -m osprey.mcp_server.phoebus
+"""
+
+import logging
+
+from fastmcp import FastMCP
+
+logger = logging.getLogger("osprey.mcp_server.phoebus")
+
+mcp = FastMCP(
+    "phoebus",
+    instructions=(
+        "Perceive and drive live Phoebus control panels: list open displays, "
+        "read the widget tree with PV values, snapshot a widget as PNG, and "
+        "click/type into widgets via synthetic GUI events or the semantic PV path."
+    ),
+)
+
+
+def create_server() -> FastMCP:
+    """Initialize workspace singletons (for snapshot artifacts) and register tools."""
+    from osprey.mcp_server.startup import (
+        initialize_workspace_singletons,
+        prime_config_builder,
+        startup_timer,
+    )
+    from osprey.utils.workspace import resolve_workspace_root
+
+    # Snapshot results are persisted through the ArtifactStore, which lives in
+    # the workspace singletons — prime them so phoebus_snapshot can save PNGs.
+    prime_config_builder()
+
+    workspace_root = resolve_workspace_root()
+    logger.info("Workspace root: %s", workspace_root)
+    initialize_workspace_singletons(workspace_root)
+
+    # Import tool modules (each registers itself via @mcp.tool())
+    with startup_timer("tool_imports"):
+        from osprey.mcp_server.phoebus.tools import bridge_tools  # noqa: F401
+
+    logger.info("Phoebus MCP server initialised with all tools registered")
+    return mcp

--- a/src/osprey/mcp_server/phoebus/tools/__init__.py
+++ b/src/osprey/mcp_server/phoebus/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Phoebus MCP tool modules."""

--- a/src/osprey/mcp_server/phoebus/tools/bridge_tools.py
+++ b/src/osprey/mcp_server/phoebus/tools/bridge_tools.py
@@ -342,9 +342,7 @@ async def phoebus_open_panel(name: str, focus: bool = True) -> str:
         while _monotonic() < deadline:
             await asyncio.sleep(0.5)
             try:
-                lst_status, displays = await anyio.to_thread.run_sync(
-                    _http_get_json, "/displays"
-                )
+                lst_status, displays = await anyio.to_thread.run_sync(_http_get_json, "/displays")
             except Exception:
                 break  # bridge vanished; return what we have
             if lst_status == 200 and isinstance(displays, list):

--- a/src/osprey/mcp_server/phoebus/tools/bridge_tools.py
+++ b/src/osprey/mcp_server/phoebus/tools/bridge_tools.py
@@ -1,0 +1,661 @@
+"""MCP tools: native Phoebus interaction via the agent bridge.
+
+Each tool is a thin validation + HTTP-delegation layer over one endpoint of the
+Phoebus agent bridge (the in-JVM JSON/HTTP server embedded in a running Phoebus
+product):
+
+==========================  =================================================
+Tool                        Bridge endpoint
+==========================  =================================================
+phoebus_open_panel          POST /open
+phoebus_list_displays       GET  /displays
+phoebus_perceive            GET  /perceive
+phoebus_perceive_region     GET  /perceive/region
+phoebus_snapshot            GET  /snapshot            (image/png)
+phoebus_drive               POST /drive
+==========================  =================================================
+
+The HTTP primitives (``_http_get_json`` / ``_http_get_bytes`` /
+``_http_post_drive`` / ``_http_post_open``) are module-level so tests can patch
+the network boundary.
+
+Display addressing
+------------------
+Every tool that accepts a ``display`` argument supports three forms:
+
+* ``"active"`` — the currently focused display (default).
+* A display name as returned by ``phoebus_list_displays``.
+* ``"handle:<id>"`` — the deterministic handle returned by
+  ``phoebus_open_panel`` (e.g. ``"handle:d-3"``).  Use this form when
+  multiple displays are open and you need to target the one you just opened.
+
+On a backend shared by multiple web terminals, ``"active"`` resolves the
+process-global focused display — a race when two terminals perceive/drive
+concurrently. Set ``PHOEBUS_REQUIRE_HANDLE=1`` (or ``phoebus.require_handle:
+true`` in config.yml) to reject the implicit ``"active"`` fallback and force
+callers to address a specific display (a handle or an explicit name). Off by
+default — the standalone single-user demo is unaffected.
+
+Panel name registry
+-------------------
+``phoebus_open_panel`` resolves logical panel names to ``.bob`` resources via:
+
+1. ``phoebus.panels.<name>`` in config.yml — value may be an absolute path,
+   a ``file:`` URL, or a path relative to the config file's directory.
+2. Built-in registry (demo panels shipped with OSPREY, resolved relative to
+   the osprey repository root when running from a development checkout).
+"""
+
+import asyncio
+import json
+import logging
+import os
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path
+
+import anyio
+from fastmcp.exceptions import ToolError
+
+from osprey.mcp_server.errors import make_error
+from osprey.mcp_server.http import _post_json_with_response, notify_panel_focus, phoebus_bridge_url
+from osprey.mcp_server.phoebus.server import mcp
+from osprey.utils.workspace import load_osprey_config, resolve_config_path
+
+logger = logging.getLogger("osprey.mcp_server.tools.phoebus")
+
+# Module-level alias so tests can patch bridge deadline timing without touching
+# the global time.monotonic that anyio uses internally for its thread-pool logic.
+_monotonic = time.monotonic
+
+_TIMEOUT = 15  # seconds — snapshot/perceive marshal onto the Phoebus FX thread
+
+_UNREACHABLE_HINTS = [
+    "Start a Phoebus product with the agent bridge enabled (default port 7979).",
+    "Check the PHOEBUS_BRIDGE_URL env var or phoebus.host/phoebus.port in config.yml.",
+    "Launch the bundled demo with demos/phoebus/run_demo.sh, then retry.",
+]
+
+
+# ---------------------------------------------------------------------------
+# HTTP boundary (patched in tests)
+# ---------------------------------------------------------------------------
+def _http_get_json(path: str) -> tuple[int, dict | list]:
+    """GET ``path`` on the bridge and return ``(status, parsed_json)``."""
+    url = f"{phoebus_bridge_url()}{path}"
+    try:
+        with urllib.request.urlopen(url, timeout=_TIMEOUT) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        body: dict = {}
+        try:
+            body = json.loads(exc.read())
+        except Exception:
+            pass
+        return exc.code, body
+
+
+def _http_get_bytes(path: str) -> tuple[int, dict, bytes]:
+    """GET ``path`` and return ``(status, headers, raw_body)`` (for image/png)."""
+    url = f"{phoebus_bridge_url()}{path}"
+    try:
+        with urllib.request.urlopen(url, timeout=_TIMEOUT) as resp:
+            return resp.status, dict(resp.headers), resp.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, dict(exc.headers), exc.read()
+
+
+def _http_post_drive(payload: dict) -> tuple[int, dict]:
+    """POST a drive request and return ``(status, parsed_json)``."""
+    return _post_json_with_response(f"{phoebus_bridge_url()}/drive", payload, timeout=_TIMEOUT)
+
+
+def _http_post_open(payload: dict) -> tuple[int, dict]:
+    """POST an open request and return ``(status, parsed_json)``."""
+    return _post_json_with_response(f"{phoebus_bridge_url()}/open", payload, timeout=_TIMEOUT)
+
+
+def _bridge_error_message(body: object, status: int) -> str:
+    """Extract the bridge's JSON ``error`` message, falling back to the status."""
+    if isinstance(body, dict) and body.get("error"):
+        return str(body["error"])
+    return f"Phoebus bridge returned HTTP {status}."
+
+
+def _snapshot_dir() -> Path:
+    """Resolve the directory PNG snapshots are written to (config or default)."""
+    config = load_osprey_config()
+    out = Path(config.get("phoebus", {}).get("snapshot_dir", "./_agent_data/screenshots"))
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Require-handle addressing (off by default; see module docstring)
+# ---------------------------------------------------------------------------
+_TRUTHY = {"1", "true", "yes", "on"}
+_FALSY = {"0", "false", "no", "off"}
+
+
+def _require_handle() -> bool:
+    """Whether implicit ``"active"`` display addressing must be rejected.
+
+    Resolution order (mirrors ``osprey.interfaces.vendor.is_offline``):
+
+    1. ``PHOEBUS_REQUIRE_HANDLE`` env var (truthy: 1/true/yes/on; falsy:
+       0/false/no/off) — set by the framework server definition; wins outright.
+    2. ``phoebus.require_handle`` in config.yml.
+    3. ``False`` default — existing ``"active"`` fallback behavior is unchanged.
+    """
+    env = os.environ.get("PHOEBUS_REQUIRE_HANDLE", "").strip().lower()
+    if env in _TRUTHY:
+        return True
+    if env in _FALSY:
+        return False
+    config = load_osprey_config()
+    return bool(config.get("phoebus", {}).get("require_handle", False))
+
+
+def _check_explicit_display(display: str) -> None:
+    """Reject the implicit ``"active"`` display when require-handle mode is on.
+
+    ``"active"`` is the only value that resolves process-global focus — a
+    handle or an explicit display name always addresses one specific display,
+    so both are allowed regardless of this setting.
+    """
+    if display == "active" and _require_handle():
+        make_error(
+            "phoebus_handle_required",
+            "Implicit 'active' display addressing is disabled on this backend; "
+            "call phoebus_open_panel to obtain a handle and pass it as "
+            "display='handle:<id>'.",
+            [
+                "Call phoebus_open_panel to obtain a handle, then pass "
+                "display='handle:<id>' to target that display explicitly.",
+                "Alternatively pass an explicit display name from phoebus_list_displays.",
+            ],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Panel name → .bob resource resolution
+# ---------------------------------------------------------------------------
+
+# Built-in registry: NOT a framework requirement. The framework works fine with
+# this empty — phoebus.panels.<name> in config.yml is the real deployment path
+# (see the module docstring). The only entry ever added here is the demo panel
+# shipped under demos/, and only when that soft/optional condition is met (see
+# below) — a demos/-relative path must never be a *required* framework default.
+_BUILTIN_PANELS: dict[str, str] = {}
+
+# bridge_tools.py is at src/osprey/mcp_server/phoebus/tools/bridge_tools.py
+# → parents[5] is the repo root (src/osprey/mcp_server/phoebus/tools → 5 up → repo root)
+_OSPREY_REPO_ROOT: Path = Path(__file__).resolve().parents[5]
+
+# Soft default for the standalone demo (run_demo.sh + the walkthrough): register
+# "osprey_demo" only when the demos/ tree is actually present next to this
+# checkout (true for a git clone, false for an installed package) — so the demo
+# keeps working out of the box without the framework carrying a hardcoded
+# demos/-relative path as a required default.
+_DEMO_PANEL_RELATIVE = "demos/phoebus/panels/osprey_demo.bob"
+if (_OSPREY_REPO_ROOT / _DEMO_PANEL_RELATIVE).exists():
+    _BUILTIN_PANELS["osprey_demo"] = _DEMO_PANEL_RELATIVE
+
+_OPEN_READY_TIMEOUT = 30  # seconds to wait for ready=True after /open
+
+
+def _resolve_panel_resource(name: str) -> str:
+    """Map a logical panel name to a bridge-ready resource string.
+
+    Resolution order:
+
+    1. ``phoebus.panels.<name>`` in config.yml — value may be an absolute
+       path, a ``file:`` URL, or a path relative to the config file's
+       directory (resolved to absolute before forwarding).
+    2. Built-in registry (demo panels shipped with OSPREY), resolved relative
+       to the osprey repository root when running from a development checkout,
+       or relative to the config file's directory otherwise.
+
+    Args:
+        name: Logical panel name (e.g. ``"osprey_demo"``).
+
+    Raises:
+        ToolError(unknown_panel): When *name* is not found in either source.
+    """
+    config = load_osprey_config()
+    panels: dict = config.get("phoebus", {}).get("panels", {})
+    resource: str | None = panels.get(name)
+
+    if resource is None:
+        builtin_relative = _BUILTIN_PANELS.get(name)
+        if builtin_relative is not None:
+            # Prefer the development-checkout repo root; fall back to config dir.
+            candidate = (_OSPREY_REPO_ROOT / builtin_relative).resolve()
+            if candidate.exists():
+                resource = str(candidate)
+            else:
+                config_path = resolve_config_path()
+                if config_path.exists():
+                    resource = str((config_path.parent / builtin_relative).resolve())
+                else:
+                    resource = builtin_relative  # pass through; bridge will report missing
+
+    if resource is None:
+        known = sorted(set(panels) | set(_BUILTIN_PANELS))
+        make_error(
+            "unknown_panel",
+            f"Unknown panel name '{name}'.",
+            [
+                f"Known panels: {known}.",
+                f"Add 'phoebus.panels.{name}: /path/to/file.bob' to config.yml to register a custom panel.",
+                "Paths may be absolute or relative to the config.yml directory.",
+            ],
+        )
+
+    # Resolve relative non-URL config paths against the config file's directory.
+    assert resource is not None  # make_error above raises; assertion satisfies type checker
+    if not resource.startswith("file:") and not Path(resource).is_absolute():
+        config_path = resolve_config_path()
+        if config_path.exists():
+            resource = str((config_path.parent / resource).resolve())
+
+    return resource
+
+
+# ---------------------------------------------------------------------------
+# Tool 1: open panel
+# ---------------------------------------------------------------------------
+@mcp.tool()
+async def phoebus_open_panel(name: str, focus: bool = True) -> str:
+    """Open a Phoebus display by logical panel name and return its handle.
+
+    Sends a ``POST /open`` request to the bridge, which loads the named
+    ``.bob`` file and returns a deterministic display handle (e.g.
+    ``"handle:d-3"``).  The tool polls ``GET /displays`` until the display
+    reports ``ready=true`` or a 30-second timeout elapses, so that
+    subsequent ``phoebus_perceive`` / ``phoebus_drive`` calls on the same
+    handle do not race against model loading.
+
+    Pass the returned ``handle`` string as the ``display`` argument of
+    ``phoebus_perceive``, ``phoebus_perceive_region``, ``phoebus_snapshot``,
+    and ``phoebus_drive`` to target this display unambiguously even when
+    multiple displays are open.
+
+    Panel name resolution (in order):
+
+    1. ``phoebus.panels.<name>`` in config.yml — accepts an absolute path, a
+       ``file:`` URL, or a path relative to the config file's directory.
+    2. Built-in registry (demo panels shipped with OSPREY).
+
+    After a successful open the tool asks the Web Terminal (best-effort,
+    never fatal) to focus this instance's panel tab, so the user sees the
+    display they just asked for without hunting through tabs.
+
+    Args:
+        name: Logical panel name (e.g. ``"osprey_demo"``).
+        focus: Switch the Web Terminal to this instance's panel tab after
+            opening (default ``True``). Pass ``False`` for batch or
+            background opens that should not steal the user's view.
+
+    Returns:
+        JSON ``{"status": "success", "handle": "handle:d-N", "id": "d-N",
+        "resource": "<resolved-path>", "ready": <bool>, "focused": <bool>}``.
+    """
+    resource = _resolve_panel_resource(name)  # raises ToolError on unknown name
+
+    try:
+        status, body = await anyio.to_thread.run_sync(_http_post_open, {"resource": resource})
+    except Exception as exc:
+        make_error(
+            "phoebus_unreachable",
+            f"Could not reach the Phoebus bridge: {exc}",
+            _UNREACHABLE_HINTS,
+        )
+
+    if status != 200:
+        make_error(
+            "phoebus_open_failed",
+            _bridge_error_message(body, status),
+            ["Check that the resource path exists and is readable by the Phoebus process."],
+        )
+
+    display_id: str = body.get("id", "")
+    if not display_id:
+        make_error(
+            "phoebus_open_failed",
+            "Phoebus bridge returned a success response with no display id.",
+            ["This may indicate a bridge version mismatch; check the bridge logs."],
+        )
+
+    handle = f"handle:{display_id}"
+    ready: bool = bool(body.get("ready", False))
+
+    # Poll until ready=True so downstream perceive/drive calls don't race the
+    # JavaFX model-loading phase.  Both the sleep and the GET /displays call are
+    # non-blocking so other tool calls and keepalives proceed normally.
+    if not ready:
+        deadline = _monotonic() + _OPEN_READY_TIMEOUT
+        while _monotonic() < deadline:
+            await asyncio.sleep(0.5)
+            try:
+                lst_status, displays = await anyio.to_thread.run_sync(
+                    _http_get_json, "/displays"
+                )
+            except Exception:
+                break  # bridge vanished; return what we have
+            if lst_status == 200 and isinstance(displays, list):
+                for d in displays:
+                    if d.get("id") == display_id:
+                        ready = bool(d.get("ready", False))
+                        break
+            if ready:
+                break
+
+    # Best-effort UX signal: switch the Web Terminal to this instance's panel
+    # tab (panel id == server name; OSPREY_SERVER_NAME is set per-instance by
+    # the registry, so a phoebus2 clone focuses the PHOEBUS2 tab). The display
+    # is already open at this point — a missing/unreachable web terminal
+    # (CLI-only mode) must never turn the open into a failure.
+    focused = False
+    if focus:
+        panel_id = os.environ.get("OSPREY_SERVER_NAME", "phoebus")
+        try:
+            await anyio.to_thread.run_sync(notify_panel_focus, panel_id)
+            focused = True
+        except Exception as exc:
+            logger.debug("panel focus notification failed (non-fatal): %s", exc)
+
+    return json.dumps(
+        {
+            "status": "success",
+            "handle": handle,
+            "id": display_id,
+            "resource": body.get("resource", resource),
+            "ready": ready,
+            "focused": focused,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool 2: list displays
+# ---------------------------------------------------------------------------
+@mcp.tool()
+async def phoebus_list_displays() -> str:
+    """List every currently-open Phoebus display.
+
+    Returns:
+        JSON ``{"status": "success", "displays": [{"name", "ready", "active"}, ...]}``.
+        An empty list means Phoebus is running but has no display open (or the
+        bridge could reach no display).
+    """
+    try:
+        status, body = _http_get_json("/displays")
+    except Exception as exc:
+        return make_error(
+            "phoebus_unreachable", f"Could not reach the Phoebus bridge: {exc}", _UNREACHABLE_HINTS
+        )
+    if status != 200:
+        return make_error("phoebus_error", _bridge_error_message(body, status))
+    return json.dumps({"status": "success", "displays": body})
+
+
+# ---------------------------------------------------------------------------
+# Tool 3: perceive
+# ---------------------------------------------------------------------------
+@mcp.tool()
+async def phoebus_perceive(display: str = "active") -> str:
+    """Perceive a Phoebus display — walk its widget tree and report each widget.
+
+    For every widget the result carries its type, name, nesting depth, on-screen
+    bounds, visibility, and live PV state (name, value, severity, writability).
+    Use this to understand what is on screen before snapshotting or driving.
+
+    Args:
+        display: Display reference — ``"active"`` (default, the focused display),
+                 a display name as returned by ``phoebus_list_displays``, or a
+                 handle string returned by ``phoebus_open_panel`` (e.g.
+                 ``"handle:d-3"``).
+
+    Returns:
+        JSON ``{"status": "success", "display": <ref>, "perception": {...}}`` where
+        ``perception`` is the bridge's stable schema (``display`` + ``widgets``).
+    """
+    _check_explicit_display(display)  # raises phoebus_handle_required if enforced
+    path = f"/perceive?display={urllib.parse.quote(display)}"
+    try:
+        status, body = _http_get_json(path)
+    except Exception as exc:
+        return make_error(
+            "phoebus_unreachable", f"Could not reach the Phoebus bridge: {exc}", _UNREACHABLE_HINTS
+        )
+    if status != 200:
+        return make_error(
+            "phoebus_error",
+            _bridge_error_message(body, status),
+            ["Check the display reference; list displays with phoebus_list_displays."],
+        )
+    return json.dumps({"status": "success", "display": display, "perception": body})
+
+
+# ---------------------------------------------------------------------------
+# Tool 4: perceive region
+# ---------------------------------------------------------------------------
+@mcp.tool()
+async def phoebus_perceive_region(
+    x: float, y: float, w: float, h: float, display: str = "active"
+) -> str:
+    """Perceive only the widgets whose on-screen bounds intersect a rectangle.
+
+    Args:
+        x: Left edge of the query rectangle, in screen pixels.
+        y: Top edge of the query rectangle, in screen pixels.
+        w: Rectangle width in screen pixels (must be > 0).
+        h: Rectangle height in screen pixels (must be > 0).
+        display: Display reference (``"active"``, a display name, or a handle
+                 string from ``phoebus_open_panel`` e.g. ``"handle:d-3"``).
+
+    Returns:
+        JSON ``{"status": "success", "display": <ref>, "perception": {...}}`` whose
+        widget list is filtered to the rectangle and sorted top-left first.
+    """
+    if w <= 0 or h <= 0:
+        return make_error("validation_error", f"w and h must be > 0 (got w={w}, h={h}).")
+    _check_explicit_display(display)  # raises phoebus_handle_required if enforced
+    path = f"/perceive/region?display={urllib.parse.quote(display)}&x={x}&y={y}&w={w}&h={h}"
+    try:
+        status, body = _http_get_json(path)
+    except Exception as exc:
+        return make_error(
+            "phoebus_unreachable", f"Could not reach the Phoebus bridge: {exc}", _UNREACHABLE_HINTS
+        )
+    if status != 200:
+        return make_error("phoebus_error", _bridge_error_message(body, status))
+    return json.dumps({"status": "success", "display": display, "perception": body})
+
+
+# ---------------------------------------------------------------------------
+# Tool 5: snapshot
+# ---------------------------------------------------------------------------
+@mcp.tool()
+async def phoebus_snapshot(
+    widget: str, display: str = "active", highlight: bool = False, dpi: float = 1.0
+) -> str:
+    """Capture a PNG snapshot of one widget and save it for viewing.
+
+    The widget must have a live on-screen representation. The PNG is written to
+    the screenshots directory and registered as an artifact; the response carries
+    its file path plus the screen-space registration headers (origin + scale) so
+    pixels can be mapped back to screen coordinates.
+
+    Args:
+        widget: Widget reference — a walk-order index (e.g. ``"0"``) or a widget
+                name (e.g. ``"Setpoint"``).
+        display: Display reference (``"active"``, a display name, or a handle
+                 string from ``phoebus_open_panel`` e.g. ``"handle:d-3"``).
+        highlight: When true, overlay an orange-red border on the target widget.
+        dpi: Scale factor — 1.0 native, 2.0 HiDPI. Must be in (0, 8].
+
+    Returns:
+        JSON artifact response including the saved file path. Use the Read tool on
+        that path to view the snapshot.
+    """
+    if not (0 < dpi <= 8):
+        return make_error("validation_error", f"dpi must be in (0, 8] (got {dpi}).")
+    _check_explicit_display(display)  # raises phoebus_handle_required if enforced
+
+    path = (
+        f"/snapshot?display={urllib.parse.quote(display)}"
+        f"&widget={urllib.parse.quote(widget)}"
+        f"&highlight={'true' if highlight else 'false'}&dpi={dpi}"
+    )
+    try:
+        status, headers, content = _http_get_bytes(path)
+    except Exception as exc:
+        return make_error(
+            "phoebus_unreachable", f"Could not reach the Phoebus bridge: {exc}", _UNREACHABLE_HINTS
+        )
+    if status != 200:
+        msg = f"Phoebus bridge returned HTTP {status}."
+        try:
+            msg = json.loads(content).get("error", msg)
+        except Exception:
+            pass
+        return make_error(
+            "phoebus_error",
+            msg,
+            [
+                "Confirm the widget is on screen and rendered (headless widgets "
+                "cannot be snapshotted)."
+            ],
+        )
+
+    safe = re.sub(r"[^A-Za-z0-9_.-]", "_", widget)
+    ts = datetime.now(UTC).strftime("%Y%m%d_%H%M%S_%f")
+    fpath = _snapshot_dir() / f"phoebus_{safe}_{ts}.png"
+    fpath.write_bytes(content)
+
+    try:
+        from osprey.stores.artifact_store import get_artifact_store
+
+        store = get_artifact_store()
+        entry = store.save_data(
+            tool="phoebus_snapshot",
+            data={
+                "display": display,
+                "widget": widget,
+                "filepath": str(fpath),
+                "bytes": len(content),
+                "origin_x": headers.get("X-Bridge-Origin-X"),
+                "origin_y": headers.get("X-Bridge-Origin-Y"),
+                "scale": headers.get("X-Bridge-Scale"),
+            },
+            title=f"Phoebus snapshot: {widget}",
+            description=f"PNG snapshot of widget '{widget}' on display '{display}'",
+            summary={
+                "widget": widget,
+                "file_size_kb": round(len(content) / 1024, 1),
+                "filepath": str(fpath),
+            },
+            access_details={
+                "file_format": "PNG",
+                "view_hint": f"Use Read tool on {fpath} to view the snapshot.",
+            },
+            category="screenshot",
+        )
+        return json.dumps(entry.to_tool_response(), default=str)
+    except ToolError:
+        raise
+    except Exception:
+        # ArtifactStore unavailable (e.g. minimal context) — still return the path.
+        logger.exception("phoebus_snapshot: artifact save failed; returning raw path")
+        return json.dumps(
+            {
+                "status": "success",
+                "filepath": str(fpath),
+                "bytes": len(content),
+                "view_hint": f"Use Read tool on {fpath} to view the snapshot.",
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tool 6: drive
+# ---------------------------------------------------------------------------
+@mcp.tool()
+async def phoebus_drive(
+    widget: str,
+    verb: str,
+    display: str = "active",
+    value: str | None = None,
+    mode: str = "synthetic",
+) -> str:
+    """Drive a Phoebus widget — click an action control or type a value.
+
+    Two drive modes:
+      * ``synthetic`` (default) — inject the real GUI event the widget listens
+        for, so confirm dialogs, enable/disable rules, and bound scripts all run,
+        exactly as if an operator clicked.
+      * ``semantic`` — write the widget's primary PV / trigger its action directly
+        through the runtime, bypassing the GUI chain. ``semantic`` supports only
+        the ``type`` verb (``click`` returns a bypass result).
+
+    Args:
+        widget: Widget reference — a walk-order index or a widget name.
+        verb: ``"click"`` (fire an action control) or ``"type"`` (commit a value
+              into a text control).
+        display: Display reference (``"active"``, a display name, or a handle
+                 string from ``phoebus_open_panel`` e.g. ``"handle:d-3"``).
+        value: Value to commit for the ``"type"`` verb; ignored for ``"click"``.
+        mode: ``"synthetic"`` or ``"semantic"``.
+
+    Returns:
+        JSON ``{"status": "success", "fired": <bool>, "detail": <str>}``. ``fired``
+        is false when no interactive control was resolved or the mode bypassed it.
+    """
+    verb_l = verb.lower()
+    mode_l = mode.lower()
+    if verb_l not in ("click", "type"):
+        return make_error(
+            "validation_error", f"Invalid verb '{verb}'.", ["verb must be 'click' or 'type'."]
+        )
+    if mode_l not in ("synthetic", "semantic"):
+        return make_error(
+            "validation_error",
+            f"Invalid mode '{mode}'.",
+            ["mode must be 'synthetic' or 'semantic'."],
+        )
+    if verb_l == "type" and value is None:
+        return make_error("validation_error", "verb 'type' requires a 'value'.")
+    _check_explicit_display(display)  # raises phoebus_handle_required if enforced
+
+    payload = {
+        "display": display,
+        "widget": widget,
+        "verb": verb_l,
+        "value": value,
+        "mode": mode_l,
+    }
+    try:
+        status, body = _http_post_drive(payload)
+    except Exception as exc:
+        return make_error(
+            "phoebus_unreachable", f"Could not reach the Phoebus bridge: {exc}", _UNREACHABLE_HINTS
+        )
+    if status != 200:
+        return make_error(
+            "phoebus_rejected",
+            _bridge_error_message(body, status),
+            ["Check the widget reference and that verb/mode are valid."],
+        )
+    return json.dumps(
+        {
+            "status": "success",
+            "fired": body.get("fired"),
+            "detail": body.get("detail"),
+        }
+    )

--- a/src/osprey/profiles/presets/phoebus-standalone.yml
+++ b/src/osprey/profiles/presets/phoebus-standalone.yml
@@ -1,0 +1,124 @@
+# phoebus-standalone.yml
+# Native-Phoebus interaction demo deployment.
+#
+# A lean, self-contained control-system profile (no logbook, no channel finder,
+# no dispatch) whose headline capability is first-class interaction with a LIVE
+# Phoebus product through the agent bridge: perceive the widget tree, snapshot
+# widgets, and drive controls via synthetic GUI events or the semantic PV path —
+# while ALSO reading/writing the same PVs directly through OSPREY's EPICS
+# connector. Pairs with the bundled demo soft IOC + panels (demos/phoebus/).
+#
+# Build:   osprey build phoebus-demo --preset phoebus-standalone
+# Demo:    bash demos/phoebus/run_demo.sh   (starts the soft IOC + Phoebus)
+# Then in the project: `claude`, and ask it to run the phoebus walkthrough.
+
+name: Phoebus Standalone
+
+# Reuse the control-system project skeleton (config.yml with the full
+# control_system/epics block we override below). The bundled channel database is
+# present but unused — the demo drives PVs by address, not by semantic lookup.
+data_bundle: control_assistant
+
+provider: anthropic
+model: claude-sonnet-4-5
+
+# Keep channel-finder out of the picture for this focused demo.
+channel_finder_mode: in_context
+
+# ── Artifact selection ───────────────────────────────────────────────────────
+hooks:
+  - hook-log          # Append every tool call to a structured JSONL audit log
+  - hook-config       # Inject project config.yml path into every tool call env
+  - approval          # Gate hardware-write + phoebus_drive on human approval
+  - writes-check      # Pre-write safety check: confirm channel is writable
+  - limits            # Enforce per-channel min/max limits before writes
+  - error-guidance    # Post-error hook that surfaces remediation hints
+  - memory-guard      # Warn when context window approaches threshold
+  - notebook-update   # Sync CLAUDE.md notebook after each session
+  - config-drift      # Warn at session start when config.yml drifted from artifacts
+
+rules:
+  - safety                 # Core safety: never write without approval
+  - error-handling         # Standard error handling and retry guidance
+  - facility               # Facility-level conventions (naming, units)
+  - workflows              # Approved workflow patterns
+  - timezone               # Localise timestamps to facility timezone
+  - control-system-safety  # EPICS PV safety: alarm limits, soft-IOC guards
+
+skills:
+  - phoebus-walkthrough  # Guided native-Phoebus perceive + drive demonstration
+  - diagnose             # Structured fault-diagnosis workflow
+  - session-report       # Summarise session actions and outcomes
+
+# Lean like ariel-standalone: no subagents.
+agents: []
+
+output_styles:
+  - control-operator  # Terse, actionable output style
+
+# PHOEBUS panel: a LIVE view of the (headless, isolated) Phoebus instance.
+# run_demo.sh streams the private Xvnc display through websockify+noVNC on
+# loopback; the web terminal embeds the noVNC client through its /panel proxy
+# (iframe /panel/phoebus/vnc.html; the RFB WebSocket rides the same proxy, so
+# the browser only ever talks to the web terminal). Without the stream leg
+# (e.g. desktop runs) the tab shows a connect error and everything else still
+# works — snapshots land in the Workspace tab as before.
+web_panels:
+  - phoebus
+
+# ── Config overrides ─────────────────────────────────────────────────────────
+config:
+  # Real Channel Access against the demo soft IOC (the in-process mock connector
+  # cannot serve CA, so Phoebus and OSPREY share a real soft IOC).
+  control_system.type: epics
+  control_system.writes_enabled: true
+  control_system.write_verification.enabled: true
+  control_system.write_verification.default_level: readback
+  control_system.connector.epics.gateways.read_only.address: "127.0.0.1"
+  control_system.connector.epics.gateways.read_only.port: 5064
+  control_system.connector.epics.gateways.write_access.address: "127.0.0.1"
+  control_system.connector.epics.gateways.write_access.port: 5064
+
+  # Enable the native-Phoebus MCP server (off by default for other profiles).
+  claude_code.servers.phoebus.enabled: true
+
+  # Keep the demo lean: no logbook / channel-finder servers.
+  claude_code.servers.ariel.enabled: false
+  claude_code.servers.channel-finder.enabled: false
+
+  # Phoebus agent-bridge location (also overridable at runtime via
+  # PHOEBUS_BRIDGE_URL / PHOEBUS_BRIDGE_PORT).
+  phoebus.host: "127.0.0.1"
+  phoebus.port: 7979
+
+  # PHOEBUS live-stream panel (websockify+noVNC, started by run_demo.sh in
+  # isolated mode). `path` points the noVNC client's RFB WebSocket back
+  # through the web terminal's /panel proxy — single origin for the browser.
+  # The stream shows ONLY the Phoebus window: run_demo.sh pins the main stage
+  # to fill the Xvnc framebuffer exactly (size = DEMO_GEOMETRY, default
+  # 1600x900; noVNC `resize=scale` fits it to the panel).
+  web.panels.phoebus.label: PHOEBUS
+  web.panels.phoebus.url: "${PHOEBUS_STREAM_URL:-http://127.0.0.1:6080}"
+  web.panels.phoebus.path: "/vnc.html?path=panel/phoebus/websockify&autoconnect=1&resize=scale&reconnect=1"
+
+  # OPTIONAL second Phoebus instance (`INSTANCE=2 bash demos/phoebus/run_demo.sh`
+  # next to the first): uncomment to surface it as a PHOEBUS2 panel and give the
+  # agent a second, independent perceive/drive toolset (mcp__phoebus2__*, bridge
+  # on 7980). `extends: phoebus` clones the framework server — same permissions
+  # and drive-only approval gating, matchers rewritten to mcp__phoebus2__*. Left
+  # off by default so single-instance builds carry no dead tab or erroring tools.
+  # claude_code.servers.phoebus2.extends: phoebus
+  # claude_code.servers.phoebus2.env.PHOEBUS_BRIDGE_URL: "${PHOEBUS2_BRIDGE_URL:-http://127.0.0.1:7980}"
+  # web.panels.phoebus2.label: PHOEBUS2
+  # web.panels.phoebus2.url: "${PHOEBUS2_STREAM_URL:-http://127.0.0.1:6081}"
+  # web.panels.phoebus2.path: "/vnc.html?path=panel/phoebus2/websockify&autoconnect=1&resize=scale&reconnect=1"
+
+  system.timezone: America/Los_Angeles
+
+# ── Environment variables ────────────────────────────────────────────────────
+env:
+  defaults:
+    # Point both OSPREY's CA client and the soft IOC at the loopback interface
+    # so the demo never depends on a facility gateway.
+    EPICS_CA_ADDR_LIST: "127.0.0.1"
+    EPICS_CA_AUTO_ADDR_LIST: "NO"

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import copy
 import logging
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -61,6 +62,9 @@ class ServerDefinition:
     port: int | None = (
         None  # Host/container port for HTTP servers; informational for non-Claude consumers
     )
+    # Framework template name this definition was cloned from via ``extends``
+    # (set by build_extended_server); None for framework/custom definitions.
+    extends_of: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -131,6 +135,42 @@ FRAMEWORK_SERVERS: dict[str, ServerDefinition] = {
             ),
         ],
         hooks_post=[_post_error("mcp__controls__.*")],
+    ),
+    "phoebus": ServerDefinition(
+        name="phoebus",
+        module="osprey.mcp_server.phoebus",
+        # Off by default: only profiles that opt in (claude_code.servers.phoebus.enabled
+        # = true, e.g. the phoebus-standalone preset) get the native-Phoebus tools.
+        # A second live instance (INSTANCE=2 run_demo.sh) is declared in config as
+        # claude_code.servers.<name>.extends: phoebus — see build_extended_server().
+        default_enabled=False,
+        env={
+            "OSPREY_CONFIG": "{project_root}/config.yml",
+            "CONFIG_FILE": "{project_root}/config.yml",
+            # Full-URL override of the in-JVM bridge (default 127.0.0.1:7979).
+            "PHOEBUS_BRIDGE_URL": "${PHOEBUS_BRIDGE_URL:-http://127.0.0.1:7979}",
+            # Instance identity — tools tag UI signals with it (open_panel →
+            # panel_focus targets the matching web-terminal tab). extends
+            # clones get this auto-rewritten to their own name.
+            "OSPREY_SERVER_NAME": "phoebus",
+        },
+        permissions_allow=[
+            "phoebus_list_displays",
+            "phoebus_perceive",
+            "phoebus_perceive_region",
+            "phoebus_snapshot",
+            # Opening a display touches no PVs and actuates nothing — allow.
+            "phoebus_open_panel",
+        ],
+        # Driving a live panel actuates hardware-facing controls — gate on approval.
+        permissions_ask=["phoebus_drive"],
+        hooks_pre=[
+            HookRule(
+                matcher="mcp__phoebus__phoebus_drive",
+                hooks=[_APPROVAL],
+            ),
+        ],
+        hooks_post=[_post_error("mcp__phoebus__.*")],
     ),
     "python": ServerDefinition(
         name="python",
@@ -376,22 +416,200 @@ def resolve_servers(claude_code_config: dict, ctx: dict) -> list[dict]:
     # ── New-format overrides: claude_code.servers ──────────────
     server_overrides = claude_code_config.get("servers", {})
     for name, spec in server_overrides.items():
+        if not isinstance(spec, dict):
+            continue
         if name in servers:
-            # Override existing framework server
-            if isinstance(spec, dict) and spec.get("enabled") is False:
+            # Override existing framework server. Note: only 'enabled' applies
+            # here — an 'extends' key on a framework name would silently shadow
+            # a safety-configured definition, so it is rejected loudly instead.
+            if "extends" in spec:
+                logger.warning(
+                    "Server %r is a framework server — its 'extends' key is ignored "
+                    "(framework definitions cannot be shadowed); only 'enabled' applies",
+                    name,
+                )
+            if spec.get("enabled") is False:
                 servers[name].default_enabled = False
-            elif isinstance(spec, dict) and spec.get("enabled") is True:
+            elif spec.get("enabled") is True:
                 servers[name].default_enabled = True
-        else:
+        elif "extends" in spec:
+            # Second instance of a framework server (e.g. phoebus2 → phoebus).
+            # Declared ⇒ enabled unless the spec says enabled: false (matches
+            # the declared-custom-server convention below).
+            if spec.get("enabled") is False:
+                continue
+            clone = build_extended_server(name, spec)
+            if clone is not None:
+                servers[name] = clone
+        elif spec.get("enabled") is not False:
             # Custom server
-            if isinstance(spec, dict) and spec.get("enabled") is not False:
-                servers[name] = _custom_server_from_spec(name, spec)
+            if not spec.get("command") and not spec.get("url"):
+                # Never emit a broken {"command": ""} entry into .mcp.json —
+                # e.g. a legacy 'phoebus2: {enabled: true}' spec left over from
+                # when phoebus2 was a framework server.
+                logger.warning(
+                    "Server %r has none of 'extends'/'command'/'url' — skipping "
+                    "(a second framework-server instance is declared via "
+                    "'extends: <framework-server>')",
+                    name,
+                )
+                continue
+            servers[name] = _custom_server_from_spec(name, spec)
 
     # ── Build output dicts ────────────────────────────────────
     result = []
     for sdef in servers.values():
         result.append(_server_to_dict(sdef, ctx))
     return result
+
+
+# Extends-clone names are spliced into regex hook matchers, exact permission
+# strings, and the startswith-matched prefixes of hook_config.json — restrict
+# them to characters that are inert in all three contexts. '__' is additionally
+# forbidden: it would corrupt osprey_approval's short-name extraction. A
+# trailing '_' is also forbidden: 'controls_' yields the prefix
+# 'mcp__controls___', which startswith-collides with 'mcp__controls__' and
+# corrupts approval short-name extraction the same way.
+_SERVER_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*(?<!_)$")
+
+
+def build_extended_server(name: str, spec: dict) -> ServerDefinition | None:
+    """Clone a framework ServerDefinition per an ``extends`` config spec.
+
+    Supports second instances of framework servers without copy-pasting the
+    registry entry::
+
+        claude_code:
+          servers:
+            phoebus2:
+              extends: phoebus
+              env:
+                PHOEBUS_BRIDGE_URL: "${PHOEBUS2_BRIDGE_URL:-http://127.0.0.1:7980}"
+
+    Semantics:
+
+    * Deep-copies the pristine ``FRAMEWORK_SERVERS[template]`` (never a mutated
+      per-call copy — clones are independent of declaration order and of the
+      template's own ``enabled`` override).
+    * Enablement comes ONLY from the spec: declared ⇒ enabled unless
+      ``enabled: false`` (the template's ``default_enabled`` must not leak
+      through the copy — phoebus ships ``default_enabled=False``).
+    * Rewrites every hook matcher that starts with the anchored prefix
+      ``mcp__<template>__`` to ``mcp__<name>__`` (prefix splice only — a bare
+      name replace would corrupt tool names like ``phoebus_drive``). Bare tool
+      names in permission lists are left untouched.
+    * Merges spec ``env`` over the template env (spec keys win; ``${...}``
+      values pass through for runtime expansion, as everywhere else).
+    * ``permissions.allow`` / ``permissions.ask`` replace the inherited lists
+      when given, EXCEPT that the template's ``permissions_ask`` members can
+      only be added to, never removed: the ask set doubles as the headless
+      side-effect classifier (agent_runner.write_tools), so an override that
+      promoted e.g. ``phoebus_drive`` into ``allow`` would silently ungate it
+      under ``bypassPermissions``.
+
+    Since ``is_external`` stays False, the clone renders exactly like the
+    template (``python -m <module>``) and ``is_custom`` is False — it is listed
+    as a regular (not "extra") server in the regen summary; accepted cosmetic
+    gap.
+
+    Returns:
+        The cloned ServerDefinition, or ``None`` (after a logged warning) for
+        invalid specs: bad clone name, unknown/non-framework extends target
+        (chaining is not supported), a name shadowing a framework server, or a
+        conditioned/dynamic template (e.g. channel-finder, whose module and
+        permissions are resolved per-pipeline and cannot be cloned).
+    """
+    target = spec.get("extends")
+    if not isinstance(name, str) or not _SERVER_NAME_RE.match(name) or "__" in name:
+        logger.warning(
+            "Invalid extends server name %r — must match [A-Za-z0-9][A-Za-z0-9_-]* "
+            "without '__' and not ending in '_'; skipping",
+            name,
+        )
+        return None
+    if name in FRAMEWORK_SERVERS:
+        logger.warning(
+            "Extends server %r shadows a framework server of the same name — skipping",
+            name,
+        )
+        return None
+    # isinstance BEFORE the membership test: a non-string target (e.g.
+    # ``extends: [phoebus]``) would TypeError on the unhashable dict lookup.
+    if not isinstance(target, str) or target not in FRAMEWORK_SERVERS:
+        logger.warning(
+            "Unknown extends target %r for server %r — must name a framework server "
+            "(chaining extends/custom servers is not supported); skipping",
+            target,
+            name,
+        )
+        return None
+    template = FRAMEWORK_SERVERS[target]
+    if template.condition:
+        logger.warning(
+            "Extends target %r is a conditioned/dynamic server — cloning is not "
+            "supported; skipping server %r",
+            target,
+            name,
+        )
+        return None
+
+    # Deep copy so the clone never shares HookRule/env objects with the template.
+    clone = copy.deepcopy(template)
+    clone.name = name
+    clone.extends_of = target
+    clone.default_enabled = spec.get("enabled") is not False
+
+    # Anchored matcher rewrite: mcp__<template>__… → mcp__<name>__…
+    old_prefix = f"mcp__{target}__"
+    new_prefix = f"mcp__{name}__"
+    for rule in (*clone.hooks_pre, *clone.hooks_post):
+        if rule.matcher.startswith(old_prefix):
+            rule.matcher = new_prefix + rule.matcher[len(old_prefix) :]
+
+    # fixed_allow/fixed_ask hold fully-qualified mcp__<server>__ strings —
+    # apply the same anchored prefix rewrite so they follow the clone.
+    clone.fixed_allow = [
+        new_prefix + entry[len(old_prefix) :] if entry.startswith(old_prefix) else entry
+        for entry in clone.fixed_allow
+    ]
+    clone.fixed_ask = [
+        new_prefix + entry[len(old_prefix) :] if entry.startswith(old_prefix) else entry
+        for entry in clone.fixed_ask
+    ]
+
+    # Spec env merges over template env (spec keys win).
+    merged_env = dict(clone.env)
+    merged_env.update(spec.get("env") or {})
+    # Instance identity follows the clone, like the matcher rewrite: unless the
+    # spec pins OSPREY_SERVER_NAME explicitly, the clone advertises its OWN
+    # name (inheriting the template's would make every instance signal the
+    # template's web-terminal panel, e.g. phoebus2 focusing the phoebus tab).
+    if "OSPREY_SERVER_NAME" not in (spec.get("env") or {}):
+        merged_env["OSPREY_SERVER_NAME"] = name
+    clone.env = merged_env
+
+    # Optional permission overrides (add-only for the template's ask set).
+    # Dedupe (order-preserving) so a duplicated entry cannot defeat the
+    # single .remove() in the ask-union guard below.
+    perms = spec.get("permissions") or {}
+    if "allow" in perms:
+        clone.permissions_allow = list(dict.fromkeys(perms.get("allow") or []))
+    if "ask" in perms:
+        clone.permissions_ask = list(dict.fromkeys(perms.get("ask") or []))
+    for tool in template.permissions_ask:
+        if tool not in clone.permissions_ask:
+            logger.warning(
+                "Server %r: override may not remove approval-gated tool %r inherited "
+                "from %r — re-adding it to permissions.ask",
+                name,
+                tool,
+                target,
+            )
+            clone.permissions_ask.append(tool)
+        if tool in clone.permissions_allow:
+            clone.permissions_allow.remove(tool)
+
+    return clone
 
 
 def _custom_server_from_spec(name: str, spec: dict) -> ServerDefinition:
@@ -471,6 +689,7 @@ def _server_to_dict(sdef: ServerDefinition, ctx: dict) -> dict:
         "hooks_pre": hooks_pre,
         "hooks_post": hooks_post,
         "is_custom": sdef.is_external and sdef.name not in FRAMEWORK_SERVERS,
+        "extends_of": sdef.extends_of,
     }
 
 

--- a/src/osprey/services/build_artifacts/catalog.py
+++ b/src/osprey/services/build_artifacts/catalog.py
@@ -258,6 +258,12 @@ def _get_default_artifacts() -> list[BuildArtifact]:
             description="Artifact Gallery demo showcase skill",
         ),
         BuildArtifact(
+            canonical_name="skills/phoebus-walkthrough",
+            template_path="claude/skills/phoebus-walkthrough/SKILL.md",
+            output_path=".claude/skills/phoebus-walkthrough/SKILL.md",
+            description="Guided native-Phoebus perceive + drive demo skill",
+        ),
+        BuildArtifact(
             canonical_name="skills/sim-scenarios",
             template_path="claude/skills/sim-scenarios/SKILL.md",
             output_path=".claude/skills/sim-scenarios/SKILL.md",

--- a/src/osprey/templates/claude_code/claude/skills/phoebus-walkthrough/SKILL.md
+++ b/src/osprey/templates/claude_code/claude/skills/phoebus-walkthrough/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: phoebus-walkthrough
+description: >
+  Run a guided, end-to-end demonstration of OSPREY's native Phoebus interaction:
+  list and perceive live Phoebus displays, snapshot a widget, drive a control via
+  synthetic GUI events and the semantic PV path, and cross-check the effect through
+  OSPREY's own EPICS connector. Use when the user asks to "demo Phoebus", "show the
+  Phoebus capabilities", "walk through the bridge", or wants to see the
+  perceive→snapshot→drive→readback loop. Requires the demo stack (soft IOC + a
+  Phoebus product with the agent bridge) to be running.
+summary: Guided demo of native Phoebus perceive + drive capabilities
+---
+
+# Phoebus Walkthrough — Native Interaction Demo
+
+Demonstrate the full set of capabilities OSPREY has over a **live** Phoebus control
+panel through the agent bridge. The headline: OSPREY can both **drive the GUI** the
+way an operator would (synthetic events that run confirm dialogs and scripts) **and**
+read/write the **same PVs directly** through its EPICS connector — and prove the two
+agree.
+
+The demo control system is a small soft IOC serving `DEMO:*` PVs (Setpoint, Readback,
+Current, Enable, Valve, Status). The demo panel binds its widgets to those PVs.
+
+Tools you will use:
+- `phoebus_list_displays`, `phoebus_open_panel`, `phoebus_perceive`,
+  `phoebus_perceive_region`, `phoebus_snapshot`, `phoebus_drive` (the `phoebus`
+  MCP server)
+- `channel_read`, `channel_write` (the `controls` MCP server, in `epics` mode against
+  the same soft IOC)
+
+**Targeting a Phoebus instance:** each running Phoebus process has its own MCP
+server, and the server you call IS the target — every tool acts on the instance
+its server is bound to. When a `phoebus2` server exists, the mapping is:
+
+| User says | MCP server | Web-terminal tab | Bridge |
+|---|---|---|---|
+| "first window", "the panel", default | `phoebus` | PHOEBUS | 7979 |
+| "second window", "2nd instance", "other Phoebus" | `phoebus2` | PHOEBUS2 | 7980 |
+
+Displays, handles, and the "active" display are **per instance** — a handle from
+`phoebus` means nothing to `phoebus2`. Both instances watch the same demo soft
+IOC, so a direct PV write surfaces on BOTH panels; only GUI state (tabs, focus,
+open displays) is independent. Run the walkthrough phases against instance 1
+unless the user targets the second.
+
+Follow the phases in order. Narrate each step to the user in plain language — this is a
+*demonstration*, so explain what each capability is as you exercise it.
+
+---
+
+## Phase 1 — Preflight
+
+Confirm the demo stack is up before driving anything.
+
+1. Call `phoebus_list_displays`.
+2. If it returns a `phoebus_unreachable` error, the Phoebus product (with the bridge)
+   is not running. Tell the user to start the stack and stop:
+   > "The demo stack isn't running. From the OSPREY repo, run
+   > `bash demos/phoebus/run_demo.sh` (starts the soft IOC and Phoebus with the demo
+   > panel), then ask me to run the walkthrough again."
+   Do NOT try to launch Phoebus yourself — it is a desktop application.
+3. If it returns a display list, confirm the demo display is present and note its name.
+   Read `DEMO:Readback` and `DEMO:Status` with `channel_read` to confirm the IOC is
+   reachable too. Report both checks succeeded.
+
+---
+
+## Phase 2 — Perceive
+
+Show what OSPREY can *see*.
+
+1. Call `phoebus_perceive` on the active display.
+2. Summarise the widget tree for the user: the widget names/types, and for each
+   widget with a PV, the PV name, value, and severity. Call out `Setpoint` (text
+   entry), `SetButton` (action button), `Readback`, `Enable`, and `Status`.
+3. Optionally call `phoebus_perceive_region` with a rectangle around the control
+   cluster to show region-filtered perception.
+
+Explain: perception walks the *live* JavaFX scene graph, so values, alarm severities,
+and on-screen geometry are real-time — this is how the agent grounds itself before
+acting.
+
+---
+
+## Phase 3 — Snapshot
+
+Show what OSPREY can *capture*.
+
+1. Call `phoebus_snapshot` for the `Setpoint` widget with `highlight=true`.
+2. Use the **Read** tool on the returned file path to view the PNG, and describe what
+   the highlighted widget looks like.
+
+Explain: the snapshot is registered to screen coordinates (origin + scale headers), so
+the agent can map image pixels back to the display.
+
+---
+
+## Phase 4 — Drive (synthetic) and verify two ways
+
+This is the core capability. Drive the GUI, then verify via **both** paths.
+
+1. Record the current `DEMO:Readback` value (`channel_read`).
+2. Call `phoebus_drive` on `SetButton` with `verb="click"`, `mode="synthetic"`. This
+   fires the button's real `ActionEvent` — exactly as an operator click — so the
+   button's WritePV action runs.
+3. Wait ~1s, then verify **two independent ways**:
+   - `phoebus_perceive` again and read the new `Readback` widget value (the GUI's view).
+   - `channel_read DEMO:Readback` (OSPREY's own EPICS view of the same PV).
+4. Confirm both report the new value (the button writes 42) and that they agree.
+
+Explain: synthetic drive proves the agent actuated the *real control*, not a back-door
+PV poke — confirm dialogs, enable-gates, and bound scripts all ran. The two-way check
+proves the GUI and the control system are consistent.
+
+---
+
+## Phase 5 — Drive (semantic) and contrast
+
+Show the labelled fallback path and how it differs.
+
+1. Call `phoebus_drive` on `Setpoint` with `verb="type"`, `value="7"`,
+   `mode="semantic"`. Note the result `detail` is prefixed `[BYPASSED GUI]`.
+2. Verify with `channel_read DEMO:Setpoint` / `DEMO:Readback`.
+
+Explain the contrast: semantic mode writes the PV directly through the widget runtime,
+**bypassing** the GUI chain (no confirm dialog / scripts). It is the labelled fallback
+for widgets with no resolvable interactive control — always tagged so a semantic write
+is never mistaken for a real operator action.
+
+---
+
+## Phase 6 — Direct control, no GUI
+
+Close the loop by showing OSPREY operating the control system *without* the panel.
+
+1. Use `channel_write` to set `DEMO:Setpoint` to a value ≥ 95.
+2. `channel_read DEMO:Status` — show it derived `FAULT`.
+3. `phoebus_perceive` once more — show the panel's `Status` widget now reflects `FAULT`
+   too, i.e. a direct PV write is visible on the live GUI.
+
+Explain: OSPREY is a first-class control-system client (EPICS) *and* a first-class GUI
+driver (bridge) over the very same PVs.
+
+---
+
+## Phase 7 — Open a site panel on demand
+
+Show that the agent can bring up a *new* display by logical name, not just use what
+is already open. Run this phase **last among the interactive phases** — the newly
+opened panel becomes the active tab, so earlier phases that address the demo display
+would otherwise need explicit handles.
+
+1. Check the project config for registered panels (`phoebus.panels.*` in config.yml).
+   At ALS the canonical example is `gtl_overview` — the gun-to-linac overview
+   (`GTLView.bob`). If no site panel is registered, say so and skip this phase.
+2. Call `phoebus_open_panel` with the registered name (e.g. `"gtl_overview"`). It
+   returns a deterministic handle like `"handle:d-2"` once the display reports ready.
+3. Call `phoebus_perceive` with `display=<that handle>` — summarise the scale (widget
+   count, sections) rather than listing everything.
+4. Point out the expected **disconnected** state of the panel's PVs: this is a real
+   production display, but the demo Phoebus is deliberately isolated (Channel Access
+   scrubbed to the loopback soft IOC), so real-machine PVs cannot resolve. The agent
+   can *see* the panel; it physically cannot touch the machine. Frame this as the
+   safety invariant working, not as an error.
+5. Tell the user the new panel is now visible live in the PHOEBUS tab of the web
+   terminal (it opened as a new tab in the streamed Phoebus window).
+6. Do **not** drive anything on this panel.
+
+Explain: open → handle → perceive is the full agent loop for displays it has never
+seen; handles make targeting unambiguous even with several displays open.
+
+---
+
+## Phase 8 — Wrap up
+
+Summarise for the user what was demonstrated, as a short bulleted recap:
+- perceived a live display and its PVs,
+- snapshotted a widget,
+- drove a control via a synthetic GUI event and verified via both the GUI and the PV,
+- contrasted the semantic (GUI-bypassing) path,
+- showed a direct PV write surfacing on the panel,
+- and opened a site display on demand by logical name, perceiving it by handle.
+
+If the `session-report` skill is available, offer to log a session report.

--- a/src/osprey/templates/claude_code/claude/skills/phoebus-walkthrough/SKILL.md
+++ b/src/osprey/templates/claude_code/claude/skills/phoebus-walkthrough/SKILL.md
@@ -152,9 +152,10 @@ opened panel becomes the active tab, so earlier phases that address the demo dis
 would otherwise need explicit handles.
 
 1. Check the project config for registered panels (`phoebus.panels.*` in config.yml).
-   At ALS the canonical example is `gtl_overview` — the gun-to-linac overview
-   (`GTLView.bob`). If no site panel is registered, say so and skip this phase.
-2. Call `phoebus_open_panel` with the registered name (e.g. `"gtl_overview"`). It
+   A site build profile registers these logical names, each mapping to a facility
+   `.bob` display (e.g. a `site_overview` panel). If no site panel is registered,
+   say so and skip this phase.
+2. Call `phoebus_open_panel` with a registered name (e.g. `"site_overview"`). It
    returns a deterministic handle like `"handle:d-2"` once the display reports ready.
 3. Call `phoebus_perceive` with `display=<that handle>` — summarise the scale (widget
    count, sections) rather than listing everything.

--- a/src/osprey/templates/skills/osprey-build-deploy/references/facility-config-schema.md
+++ b/src/osprey/templates/skills/osprey-build-deploy/references/facility-config-schema.md
@@ -336,6 +336,19 @@ modules:
 
 The skill renders compose entries and CI build jobs from this list. Each server gets its own Dockerfile path that the user owns.
 
+> **Agent-facing MCP declaration (`claude_code.servers`)** — the block above builds/serves the containers; what the *agent* sees is declared in the built project's `config.yml` under `claude_code.servers.<name>` (rendered into `.mcp.json` / `settings.json` at build/regen). A custom server needs `command`+`args` or `url`, plus optional `permissions.allow/ask` and `hooks.pre_tool_use` presets. A **second instance of a framework server** is declared with `extends` instead:
+>
+> ```yaml
+> claude_code:
+>   servers:
+>     phoebus2:
+>       extends: phoebus     # clone the framework server under a new name
+>       env:
+>         PHOEBUS_BRIDGE_URL: "${PHOEBUS2_BRIDGE_URL:-http://127.0.0.1:7980}"
+> ```
+>
+> The clone inherits the template's permissions and per-tool hooks with `mcp__<template>__` matchers rewritten to `mcp__<name>__`; spec `env` keys override the template's; `permissions.allow/ask` overrides may add but never remove the template's approval-gated (`ask`) tools. `extends` is only expressible via `config:` dotted overrides in a build profile (e.g. `claude_code.servers.phoebus2.extends: phoebus`) or directly in `config.yml` — the build-profile `mcp_servers:` block requires `command` or `url` and cannot express it. Note: approval policies key on the bare tool name, so they apply to every instance of a template (no per-instance gating).
+
 ### `modules.benchmarks` — e2e agent benchmark suite
 
 ```yaml

--- a/src/osprey/templates/skills/osprey-build-deploy/templates/facility-config.example.yml
+++ b/src/osprey/templates/skills/osprey-build-deploy/templates/facility-config.example.yml
@@ -244,6 +244,14 @@ modules:
   # ---------------------------------------------------------------------------
   # Custom facility-specific MCP servers. Each entry becomes one compose
   # service + one CI build job. The user owns the source code + Dockerfile.
+  # NOTE: this block only builds/serves the containers. What the agent sees is
+  # declared in the project's config.yml under claude_code.servers.<name>
+  # (command/url + permissions/hooks); a SECOND INSTANCE of a framework server
+  # uses `extends` there instead, e.g.
+  #   claude_code.servers.phoebus2.extends: phoebus
+  #   claude_code.servers.phoebus2.env.PHOEBUS_BRIDGE_URL: "${PHOEBUS2_BRIDGE_URL:-http://127.0.0.1:7980}"
+  # (`extends` is not available in the build-profile mcp_servers: block, which
+  # requires command or url.)
   # ---------------------------------------------------------------------------
   custom_mcp_servers:
     enabled: true

--- a/tests/agent_runner/test_write_tools.py
+++ b/tests/agent_runner/test_write_tools.py
@@ -323,6 +323,231 @@ def test_read_only_blocks_writes_check_custom_server_at_server_level(tmp_path: P
     assert "mcp__danger-server" in result
 
 
+def test_read_only_blocks_extends_clone_drive(tmp_path: Path) -> None:
+    """An extends clone (no permissions key of its own) inherits the template's
+    side-effect classification with the rewritten prefix: phoebus_drive
+    (ask-gated on the template) is blocked in the headless read-only path,
+    the perceive/snapshot/list/open_panel reads stay callable.
+    This is the sole guard under bypassPermissions."""
+    (tmp_path / "config.yml").write_text(
+        "claude_code:\n"
+        "  servers:\n"
+        "    phoebus2:\n"
+        "      extends: phoebus\n"
+        "      env:\n"
+        '        PHOEBUS_BRIDGE_URL: "${PHOEBUS2_BRIDGE_URL:-http://127.0.0.1:7980}"\n'
+    )
+
+    result = read_only_disallowed_tools(tmp_path)
+
+    assert "mcp__phoebus2__phoebus_drive" in result
+    assert "mcp__phoebus2__phoebus_open_panel" not in result
+    for read_tool in (
+        "phoebus_perceive",
+        "phoebus_perceive_region",
+        "phoebus_snapshot",
+        "phoebus_list_displays",
+    ):
+        assert f"mcp__phoebus2__{read_tool}" not in result, (
+            f"read tool {read_tool} must stay callable on the clone"
+        )
+
+
+def test_read_only_blocks_extends_clone_extra_tools(tmp_path: Path) -> None:
+    """The hard-coded ``_EXTRA_SIDE_EFFECT_TOOLS`` (unlisted side-effect tools
+    like the python server's execute_file) must follow an extends clone with
+    the rewritten prefix: the clone launches the SAME tool module, and SDK
+    disallow matching is by exact name, so blocking mcp__python__execute_file
+    does NOT cover mcp__python2__execute_file."""
+    (tmp_path / "config.yml").write_text(
+        "claude_code:\n  servers:\n    python2:\n      extends: python\n"
+    )
+
+    result = read_only_disallowed_tools(tmp_path)
+
+    assert "mcp__python2__execute" in result  # via the shared classifier (ask)
+    assert "mcp__python2__execute_file" in result  # via the rewritten extras
+    assert "mcp__python__execute_file" in result  # template extras unchanged
+
+
+def test_read_only_extends_override_cannot_narrow(tmp_path: Path) -> None:
+    """An extends spec that promotes phoebus_drive out of ask into allow must
+    STILL yield the drive tool in the disallow set (template-ask union
+    invariant — overrides can add gated tools, never remove them)."""
+    (tmp_path / "config.yml").write_text(
+        "claude_code:\n"
+        "  servers:\n"
+        "    phoebus2:\n"
+        "      extends: phoebus\n"
+        "      permissions:\n"
+        "        allow: [phoebus_drive, phoebus_perceive]\n"
+        "        ask: []\n"
+    )
+
+    result = read_only_disallowed_tools(tmp_path)
+
+    assert "mcp__phoebus2__phoebus_drive" in result
+    assert "mcp__phoebus2__phoebus_perceive" not in result
+
+
+def test_read_only_extends_unknown_target_fails_closed(tmp_path: Path) -> None:
+    """An unresolvable extends target (typo/version skew) must contribute a
+    server-level disallow, not nothing — a stale .mcp.json from a previous
+    build can still launch the server."""
+    (tmp_path / "config.yml").write_text(
+        "claude_code:\n  servers:\n    phoebus2:\n      extends: no_such_template\n"
+    )
+
+    result = read_only_disallowed_tools(tmp_path)
+
+    assert "mcp__phoebus2" in result
+
+
+def test_read_only_extends_non_string_target_fails_closed(tmp_path: Path) -> None:
+    """A non-string extends value (e.g. ``extends: [phoebus]``) must not crash
+    the classifier with a TypeError — it fails closed with the same
+    server-level disallow as any other unresolvable extends spec."""
+    (tmp_path / "config.yml").write_text(
+        "claude_code:\n  servers:\n    phoebus2:\n      extends: [phoebus]\n"
+    )
+
+    result = read_only_disallowed_tools(tmp_path)
+
+    assert "mcp__phoebus2" in result
+
+
+def test_read_only_legacy_enabled_only_spec_fails_closed(tmp_path: Path) -> None:
+    """A spec with NONE of extends/command/url (legacy form
+    ``phoebus2: {enabled: true}``) must fail closed with the server-level
+    disallow, exactly like an unresolvable extends — resolve_servers skips it,
+    but a stale .mcp.json from a previous build can still launch the server."""
+    (tmp_path / "config.yml").write_text(
+        "claude_code:\n  servers:\n    phoebus2:\n      enabled: true\n"
+    )
+
+    result = read_only_disallowed_tools(tmp_path)
+
+    assert "mcp__phoebus2" in result
+
+
+def test_read_only_extends_disabled_not_enumerated(tmp_path: Path) -> None:
+    """An extends clone with enabled: false contributes nothing (matches the
+    custom-server enabled gate)."""
+    (tmp_path / "config.yml").write_text(
+        "claude_code:\n  servers:\n    phoebus2:\n      extends: phoebus\n      enabled: false\n"
+    )
+
+    result = read_only_disallowed_tools(tmp_path)
+
+    assert "mcp__phoebus2__phoebus_drive" not in result
+    assert "mcp__phoebus2" not in result
+
+
+def test_read_only_extends_rewrites_writes_check_matcher(tmp_path: Path, monkeypatch) -> None:
+    """Extends of a writes-check-gated template yields the REWRITTEN matcher in
+    the disallow set — isolating the hooks_pre/_WRITES_CHECK leg of the shared
+    classifier. Uses a synthetic template whose writes-check-gated tool is NOT
+    in permissions_ask (on the real controls template channel_write is also
+    ask-gated, so the ask leg alone would produce the asserted string and the
+    writes-check leg could silently break)."""
+    from osprey.registry.mcp import _WRITES_CHECK, FRAMEWORK_SERVERS, HookRule, ServerDefinition
+
+    synthetic = ServerDefinition(
+        name="synth",
+        module="osprey.mcp_server.synth",
+        permissions_allow=["hw_read"],
+        hooks_pre=[HookRule(matcher="mcp__synth__hw_write", hooks=[_WRITES_CHECK])],
+    )
+    monkeypatch.setitem(FRAMEWORK_SERVERS, "synth", synthetic)
+    (tmp_path / "config.yml").write_text(
+        "claude_code:\n  servers:\n    synth2:\n      extends: synth\n"
+    )
+
+    result = read_only_disallowed_tools(tmp_path)
+
+    # Only the writes-check leg can produce this entry (hw_write is in no
+    # permissions list of the synthetic template).
+    assert "mcp__synth2__hw_write" in result
+    # Non-gated reads on the clone stay callable.
+    assert "mcp__synth2__hw_read" not in result
+    # No server-level fail-closed entry — the clone resolved fine.
+    assert "mcp__synth2" not in result
+
+
+def test_read_only_extends_third_instance(tmp_path: Path) -> None:
+    """Two extends clones both land their drive tool in the disallow set —
+    N-instance scaling of the headless floor."""
+    (tmp_path / "config.yml").write_text(
+        "claude_code:\n"
+        "  servers:\n"
+        "    phoebus2:\n"
+        "      extends: phoebus\n"
+        "    phoebus3:\n"
+        "      extends: phoebus\n"
+    )
+
+    result = read_only_disallowed_tools(tmp_path)
+
+    assert "mcp__phoebus2__phoebus_drive" in result
+    assert "mcp__phoebus3__phoebus_drive" in result
+
+
+def test_registry_walk_matches_shared_classifier() -> None:
+    """Drift guard: for every framework server the registry walk emits exactly
+    the shared per-server classifier's output — pins that the framework path
+    and the extends path share one implementation."""
+    from osprey.agent_runner.write_tools import (
+        _registry_side_effect_tools,
+        _server_side_effect_tools,
+    )
+    from osprey.registry.mcp import FRAMEWORK_SERVERS
+
+    expected: list[str] = []
+    for server in FRAMEWORK_SERVERS.values():
+        for name in _server_side_effect_tools(server):
+            if name not in expected:
+                expected.append(name)
+
+    assert _registry_side_effect_tools() == expected
+
+
+def test_extends_clone_classifies_like_template(tmp_path: Path) -> None:
+    """Drift guard (extends-aware variant of the registry guard): a clone of
+    each framework server must land in the read-only disallow set exactly like
+    its template with the mcp__<template>__ prefix rewritten — INCLUDING the
+    template's ``_EXTRA_SIDE_EFFECT_TOOLS`` entries (tools in no permission
+    list, e.g. python's execute_file), which the per-server classifier cannot
+    see. Compares the full production output (read_only_disallowed_tools), not
+    the classifier internals, so a blind spot in either path fails here."""
+    from osprey.agent_runner.write_tools import (
+        _EXTRA_SIDE_EFFECT_TOOLS,
+        _server_side_effect_tools,
+    )
+    from osprey.registry.mcp import FRAMEWORK_SERVERS, build_extended_server
+
+    for template_name, template in FRAMEWORK_SERVERS.items():
+        if template.condition:
+            continue  # conditioned templates cannot be extended
+        clone_name = f"{template_name}-clone"
+        clone = build_extended_server(clone_name, {"extends": template_name})
+        assert clone is not None, f"extends of {template_name!r} unexpectedly rejected"
+
+        old, new = f"mcp__{template_name}__", f"mcp__{clone_name}__"
+        template_surface = _server_side_effect_tools(template) + [
+            t for t in _EXTRA_SIDE_EFFECT_TOOLS if t.startswith(old)
+        ]
+        expected = {new + t[len(old) :] if t.startswith(old) else t for t in template_surface}
+
+        (tmp_path / "config.yml").write_text(
+            f"claude_code:\n  servers:\n    {clone_name}:\n      extends: {template_name}\n"
+        )
+        result = set(read_only_disallowed_tools(tmp_path))
+        clone_actual = {t for t in result if t.startswith(new)}
+        assert clone_actual == expected, (
+            f"clone of {template_name!r} classifies differently from its template"
+        )
+
+
 def test_read_only_disabled_custom_server_not_enumerated(tmp_path: Path) -> None:
     """A custom server explicitly disabled contributes no tools."""
     (tmp_path / "config.yml").write_text(

--- a/tests/cli/test_build_cmd.py
+++ b/tests/cli/test_build_cmd.py
@@ -2011,3 +2011,79 @@ def test_build_channel_finder_agent_requires_mode(tmp_path: Path) -> None:
     combined = result.output + (str(result.exception) if result.exception else "")
     assert "channel_finder_mode" in combined
     assert "required" in combined.lower()
+
+
+# ---------------------------------------------------------------------------
+# Approval-overlap guard (extends clones share bare-name approval policies)
+# ---------------------------------------------------------------------------
+
+
+def test_build_context_warns_when_remove_ask_overrides_gated_tool(tmp_path: Path, caplog) -> None:
+    """A facility permissions.remove_ask (or allow) entry naming an enabled
+    server's approval-gated tool — e.g. an extends clone's phoebus_drive —
+    must emit a build-time warning: it auto-approves the tool at the
+    permission layer, and approval policies apply to every instance of a
+    template (no per-instance gating)."""
+    import logging
+
+    from osprey.cli.templates import claude_code
+    from osprey.cli.templates.manager import TemplateManager
+
+    manager = TemplateManager()
+    project = manager.create_project(
+        project_name="remove-ask-warn",
+        output_dir=tmp_path,
+        data_bundle="hello_world",
+    )
+
+    config = yaml.safe_load((project / "config.yml").read_text())
+    cc = config.setdefault("claude_code", {})
+    cc.setdefault("servers", {})["phoebus2"] = {"extends": "phoebus"}
+    cc["permissions"] = {"remove_ask": ["mcp__phoebus2__phoebus_drive"]}
+
+    with caplog.at_level(logging.WARNING):
+        claude_code.build_claude_code_context(
+            manager.template_root, manager.jinja_env, project, config
+        )
+
+    assert any(
+        "mcp__phoebus2__phoebus_drive" in r.message and "approval-gated" in r.message
+        for r in caplog.records
+    ), f"expected approval-overlap warning; got: {[r.message for r in caplog.records]}"
+
+
+def test_writes_disabled_hard_block_covers_extends_clones(tmp_path: Path) -> None:
+    """With control_system.writes_enabled false, the kill-switch hard-block must
+    cover extends clones of the controls/python templates, not just the literal
+    template names: the clone's rewritten channel_write lands in the rendered
+    settings.json permissions.deny, and the clone's execute is pulled out of
+    permissions.ask exactly like mcp__python__execute."""
+    from osprey.cli.templates.manager import TemplateManager
+    from osprey.utils.config_writer import config_update_fields
+
+    manager = TemplateManager()
+    project = manager.create_project(
+        project_name="writes-block-clone",
+        output_dir=tmp_path,
+        data_bundle="hello_world",
+    )
+
+    config_update_fields(
+        project / "config.yml",
+        {
+            "control_system.writes_enabled": False,
+            "claude_code.servers.controls2.extends": "controls",
+            "claude_code.servers.python2.extends": "python",
+        },
+    )
+    manager.regenerate_claude_code(project)
+
+    settings = json.loads((project / ".claude" / "settings.json").read_text())
+    deny = settings["permissions"]["deny"]
+    ask = settings["permissions"]["ask"]
+    # Template and clone both hard-blocked.
+    assert "mcp__controls__channel_write" in deny
+    assert "mcp__controls2__channel_write" in deny
+    # Template and clone execute both pulled out of ask (remove_ask leg).
+    assert "mcp__python__execute" not in ask
+    assert "mcp__python2__execute" not in ask

--- a/tests/cli/test_profile_to_claude_contract.py
+++ b/tests/cli/test_profile_to_claude_contract.py
@@ -383,6 +383,85 @@ def test_overlay_agent_frontmatter_preserved(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Extends (second framework-server instance) rendered artifacts
+# ---------------------------------------------------------------------------
+
+
+def test_extends_phoebus2_rendered_artifacts(tmp_path, monkeypatch):
+    """A config-declared extends clone (claude_code.servers.phoebus2.extends:
+    phoebus, applied via the dotted-override path the phoebus-standalone preset
+    documents) renders exactly like the deleted framework phoebus2 entry:
+
+    * .mcp.json: python -m osprey.mcp_server.phoebus with the ${...} bridge URL
+      preserved literally — even with PHOEBUS2_BRIDGE_URL set in the build env.
+    * settings.json: the four reads in allow, drive + open_panel in ask (and
+      NOT in allow), PreToolUse approval hook under exactly
+      mcp__phoebus2__phoebus_drive (drive-only — no wildcard rule).
+    * hook_config.json: both phoebus prefixes in server/approval prefixes.
+    """
+    manager = TemplateManager()
+    project = manager.create_project(
+        project_name="extends-contract",
+        output_dir=tmp_path,
+        data_bundle="control_assistant",
+        context={"channel_finder_mode": "hierarchical"},
+    )
+
+    from osprey.utils.config_writer import config_update_fields
+
+    config_update_fields(
+        project / "config.yml",
+        {
+            "claude_code.servers.phoebus.enabled": True,
+            "claude_code.servers.phoebus2.extends": "phoebus",
+            "claude_code.servers.phoebus2.env.PHOEBUS_BRIDGE_URL": (
+                "${PHOEBUS2_BRIDGE_URL:-http://127.0.0.1:7980}"
+            ),
+        },
+    )
+
+    # Set during the regen: claude_code.servers.*.env must stay literal anyway
+    # (expanded by Claude Code at MCP launch, not at build time).
+    monkeypatch.setenv("PHOEBUS2_BRIDGE_URL", "http://10.0.0.5:7980")
+    manager.regenerate_claude_code(project)
+
+    mcp = json.loads((project / ".mcp.json").read_text())
+    p2 = mcp["mcpServers"]["phoebus2"]
+    assert p2["args"] == ["-m", "osprey.mcp_server.phoebus"]
+    assert p2["command"], "clone must render the framework interpreter command"
+    assert p2["env"]["PHOEBUS_BRIDGE_URL"] == "${PHOEBUS2_BRIDGE_URL:-http://127.0.0.1:7980}"
+    assert p2["env"]["OSPREY_CONFIG"].endswith("/config.yml")
+
+    settings = json.loads((project / ".claude" / "settings.json").read_text())
+    allow = set(settings["permissions"]["allow"])
+    ask = set(settings["permissions"]["ask"])
+    for tool in (
+        "phoebus_list_displays",
+        "phoebus_perceive",
+        "phoebus_perceive_region",
+        "phoebus_snapshot",
+        "phoebus_open_panel",
+    ):
+        assert f"mcp__phoebus2__{tool}" in allow, f"mcp__phoebus2__{tool} missing from allow"
+    for tool in ("phoebus_drive",):
+        assert f"mcp__phoebus2__{tool}" in ask, f"mcp__phoebus2__{tool} missing from ask"
+        assert f"mcp__phoebus2__{tool}" not in allow
+
+    pre = settings["hooks"]["PreToolUse"]
+    drive_rules = [r for r in pre if r["matcher"] == "mcp__phoebus2__phoebus_drive"]
+    assert len(drive_rules) == 1, "expected exactly one drive-only approval rule for the clone"
+    assert any("osprey_approval.py" in h["command"] for h in drive_rules[0]["hooks"])
+    assert not any(r["matcher"] == "mcp__phoebus2__.*" for r in pre), (
+        "clone must be drive-only gated, not wildcard-gated"
+    )
+
+    hook_cfg = json.loads((project / ".claude" / "hooks" / "hook_config.json").read_text())
+    for prefix in ("mcp__phoebus__", "mcp__phoebus2__"):
+        assert prefix in hook_cfg["server_prefixes"]
+        assert prefix in hook_cfg["approval_prefixes"]
+
+
+# ---------------------------------------------------------------------------
 # Crown-jewel invariant
 # ---------------------------------------------------------------------------
 

--- a/tests/e2e/test_phoebus_demo_e2e.py
+++ b/tests/e2e/test_phoebus_demo_e2e.py
@@ -1,0 +1,227 @@
+"""End-to-end test of the OSPREY-side Phoebus demo stack (no desktop required).
+
+Proves the closed loop that the demo depends on, headlessly:
+
+    phoebus MCP tool  --HTTP-->  bridge-faithful server  --caput-->  soft IOC
+                                                                        |
+    OSPREY EPICS view (pyepics caget)  <--------- same DEMO:* PV -------+
+
+The real ``demo_ioc.py`` runs as a subprocess (a genuine Channel Access server).
+A small in-process HTTP server speaks the *exact* bridge JSON contract the
+``phoebus`` MCP tools expect, but backs ``/perceive`` and ``/drive`` with real
+``pyepics`` reads/writes against the IOC — so a tool-driven "click" actually
+moves the PV, and we verify it two independent ways (re-perceive + caget).
+
+The live *Phoebus GUI* mile (real synthetic JavaFX events) is covered separately
+by the phoebus repo's Monocle ``EndToEndHttpIT`` and by ``run_demo.sh`` on a
+desktop; this test owns the OSPREY half.
+
+Run explicitly (it is outside the default ``--ignore=tests/e2e`` fast run)::
+
+    uv run pytest tests/e2e/test_phoebus_demo_e2e.py -v
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+
+import pytest
+
+pytestmark = [pytest.mark.e2e, pytest.mark.slow]
+
+epics = pytest.importorskip("epics")  # pyepics
+pytest.importorskip("caproto")
+
+_IOC = Path(__file__).resolve().parents[2] / "demos" / "phoebus" / "demo_ioc.py"
+_CA_ENV = {
+    "EPICS_CA_ADDR_LIST": "127.0.0.1",
+    "EPICS_CA_AUTO_ADDR_LIST": "NO",
+    "EPICS_CAS_INTF_ADDR_LIST": "127.0.0.1",
+    "EPICS_CAS_BEACON_ADDR_LIST": "127.0.0.1",
+}
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _ca_env():
+    for k, v in _CA_ENV.items():
+        os.environ[k] = v
+    yield
+
+
+@pytest.fixture(scope="module")
+def demo_ioc():
+    """Start demos/phoebus/demo_ioc.py as a real CA server subprocess."""
+    proc = subprocess.Popen(
+        [sys.executable, str(_IOC)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env={**os.environ, **_CA_ENV},
+    )
+    # Wait until the IOC answers.
+    deadline = time.time() + 20
+    while time.time() < deadline:
+        if epics.caget("DEMO:Setpoint", timeout=1) is not None:
+            break
+        time.sleep(0.5)
+    else:
+        proc.terminate()
+        pytest.fail("demo_ioc did not come up on Channel Access")
+    yield
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except Exception:
+        proc.kill()
+
+
+class _BridgeHandler(BaseHTTPRequestHandler):
+    """Speaks the bridge JSON contract, backed by real pyepics IO on DEMO:*."""
+
+    def log_message(self, *a):  # silence
+        pass
+
+    def _send(self, code, body, content_type="application/json"):
+        payload = body if isinstance(body, bytes) else json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(payload)))
+        if isinstance(body, bytes):  # snapshot registration headers
+            self.send_header("X-Bridge-Origin-X", "100.0")
+            self.send_header("X-Bridge-Origin-Y", "200.0")
+            self.send_header("X-Bridge-Scale", "1.0")
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _perceive(self):
+        def pv(name, addr):
+            return {
+                "name": name,
+                "type": "widget",
+                "pv": {"name": addr, "value": str(epics.caget(addr, as_string=True))},
+            }
+
+        return {
+            "display": {"name": "OSPREY Phoebus Demo"},
+            "widgets": [
+                pv("Setpoint", "DEMO:Setpoint"),
+                pv("Readback", "DEMO:Readback"),
+                pv("Current", "DEMO:Current"),
+                pv("Status", "DEMO:Status"),
+                {"name": "SetButton", "type": "action_button"},
+            ],
+        }
+
+    def do_GET(self):
+        if self.path.startswith("/displays"):
+            self._send(200, [{"name": "OSPREY Phoebus Demo", "ready": True, "active": True}])
+        elif self.path.startswith("/perceive"):
+            self._send(200, self._perceive())
+        elif self.path.startswith("/snapshot"):
+            self._send(200, b"\x89PNG\r\n\x1a\nDEMO", content_type="image/png")
+        else:
+            self._send(404, {"error": f"Unknown route: {self.path}", "status": 404})
+
+    def do_POST(self):
+        if not self.path.startswith("/drive"):
+            self._send(404, {"error": f"Unknown route: {self.path}", "status": 404})
+            return
+        length = int(self.headers.get("Content-Length", 0))
+        req = json.loads(self.rfile.read(length))
+        widget, verb, value = req.get("widget"), req.get("verb"), req.get("value")
+        # SetButton click writes 42; Setpoint type writes the typed value.
+        if widget == "SetButton" and verb == "click":
+            epics.caput("DEMO:Setpoint", 42, wait=True)
+            self._send(200, {"fired": True, "detail": "ActionEvent fired via ButtonBase.fire()"})
+        elif widget == "Setpoint" and verb == "type":
+            epics.caput("DEMO:Setpoint", float(value), wait=True)
+            self._send(200, {"fired": True, "detail": "text set + ENTER fired"})
+        else:
+            self._send(200, {"fired": False, "detail": "no interactive control resolved"})
+
+
+@pytest.fixture(scope="module")
+def bridge(demo_ioc):
+    """Start the bridge-faithful HTTP server; point the tools at it."""
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _BridgeHandler)
+    port = server.server_address[1]
+    Thread(target=server.serve_forever, daemon=True).start()
+    os.environ["PHOEBUS_BRIDGE_URL"] = f"http://127.0.0.1:{port}"
+    yield
+    server.shutdown()
+    os.environ.pop("PHOEBUS_BRIDGE_URL", None)
+
+
+def _tool(name):
+    from osprey.mcp_server.phoebus.tools import bridge_tools
+    from tests.mcp_server.conftest import get_tool_fn
+
+    return get_tool_fn(getattr(bridge_tools, name))
+
+
+def _readback() -> float:
+    return float(epics.caget("DEMO:Readback", timeout=3))
+
+
+async def test_list_and_perceive(bridge):
+    from tests.mcp_server.conftest import extract_response_dict
+
+    displays = extract_response_dict(await _tool("phoebus_list_displays")())
+    assert displays["displays"][0]["name"] == "OSPREY Phoebus Demo"
+
+    perception = extract_response_dict(await _tool("phoebus_perceive")(display="active"))
+    names = [w["name"] for w in perception["perception"]["widgets"]]
+    assert {"Setpoint", "Readback", "Status", "SetButton"}.issubset(set(names))
+
+
+async def test_synthetic_drive_moves_pv_verified_two_ways(bridge):
+    from tests.mcp_server.conftest import extract_response_dict
+
+    # baseline: drive to a known-not-42 value first
+    epics.caput("DEMO:Setpoint", 5, wait=True)
+    assert _readback() != pytest.approx(42)
+
+    # phoebus_drive click the action button -> bridge -> caput 42
+    out = extract_response_dict(await _tool("phoebus_drive")(widget="SetButton", verb="click"))
+    assert out["status"] == "success" and out["fired"] is True
+
+    time.sleep(0.5)
+    # Verify way 1: OSPREY's own EPICS view (pyepics).
+    assert _readback() == pytest.approx(42.0)
+    # Verify way 2: the GUI's view, via a fresh perceive.
+    perception = extract_response_dict(await _tool("phoebus_perceive")())
+    rb = next(w for w in perception["perception"]["widgets"] if w["name"] == "Readback")
+    assert rb["pv"]["value"].startswith("42")
+
+
+async def test_semantic_type_and_status_derivation(bridge):
+    from tests.mcp_server.conftest import extract_response_dict
+
+    out = extract_response_dict(
+        await _tool("phoebus_drive")(widget="Setpoint", verb="type", value="7", mode="semantic")
+    )
+    assert out["fired"] is True
+    time.sleep(0.5)
+    assert _readback() == pytest.approx(7.0)
+    assert epics.caget("DEMO:Status", as_string=True) == "OK"
+
+    # a high setpoint should derive FAULT, visible to OSPREY's EPICS view
+    await _tool("phoebus_drive")(widget="Setpoint", verb="type", value="99", mode="semantic")
+    time.sleep(0.5)
+    assert epics.caget("DEMO:Status", as_string=True) == "FAULT"
+
+
+async def test_snapshot_returns_png(bridge, tmp_path, monkeypatch):
+    from osprey.mcp_server.phoebus.tools import bridge_tools
+    from tests.mcp_server.conftest import extract_response_dict
+
+    monkeypatch.setattr(bridge_tools, "_snapshot_dir", lambda: tmp_path)
+    result = await _tool("phoebus_snapshot")(widget="Setpoint", display="active")
+    data = extract_response_dict(result)
+    assert data["status"] == "success"
+    pngs = list(tmp_path.glob("phoebus_Setpoint_*.png"))
+    assert len(pngs) == 1 and pngs[0].read_bytes().startswith(b"\x89PNG")

--- a/tests/e2e/test_phoebus_real_bridge_e2e.py
+++ b/tests/e2e/test_phoebus_real_bridge_e2e.py
@@ -31,7 +31,6 @@ Run explicitly (outside the default ``--ignore=tests/e2e`` fast run)::
         pytest tests/e2e/test_phoebus_real_bridge_e2e.py -v
 """
 
-import json
 import os
 import platform
 import subprocess
@@ -99,9 +98,7 @@ def real_bridge():
                 "is the demo stack (run_demo.sh) running?"
             )
     elif os.environ.get("PHOEBUS_E2E_LAUNCH") == "1":
-        isolated = os.environ.get(
-            "ISOLATED", "1" if platform.system() == "Linux" else "0"
-        ) == "1"
+        isolated = os.environ.get("ISOLATED", "1" if platform.system() == "Linux" else "0") == "1"
         os.environ.update(_default_ca_env(isolated))
         url = f"http://127.0.0.1:{os.environ.get('BRIDGE_PORT', '7979')}"
         proc = subprocess.Popen(

--- a/tests/e2e/test_phoebus_real_bridge_e2e.py
+++ b/tests/e2e/test_phoebus_real_bridge_e2e.py
@@ -1,0 +1,242 @@
+"""End-to-end test against the REAL in-JVM Phoebus agent bridge (Task 4.1).
+
+Unlike ``test_phoebus_demo_e2e.py`` (which backs the bridge contract with a
+Python fake), this module drives a *running Phoebus product* through the same
+MCP tools the agent uses, and confirms every drive with an independent
+Channel Access read:
+
+    phoebus MCP tool --HTTP--> in-JVM bridge --JavaFX/PV--> demo soft IOC
+                                                                |
+    independent CA readback (caproto sync client) <------------+
+
+The full acceptance loop: ``open(name) → handle``, ``perceive(handle)`` returns
+the widget tree, ``drive(handle)`` commits a setpoint, CA confirms the value.
+
+Activation (skipped otherwise, so the default test run stays hermetic):
+
+* ``OSPREY_REAL_BRIDGE_URL=http://127.0.0.1:7979`` — target a stack that is
+  already running (e.g. started by ``demos/phoebus/run_demo.sh`` on appsdev2).
+  Export the matching CA client env too when the stack uses dedicated ports
+  (isolated mode): ``EPICS_CA_SERVER_PORT=5074 EPICS_CA_ADDR_LIST=127.0.0.1``.
+* ``PHOEBUS_E2E_LAUNCH=1`` — this module launches ``run_demo.sh`` itself
+  (honouring ``PHOEBUS_REPO`` / ``JAVA_HOME`` / ``ISOLATED`` / ``OSPREY_PYTHON``)
+  and tears it down afterwards; CA env is derived from the script's defaults.
+
+Only ``caproto`` is required for the readback (pyepics is not available on
+appsdev2), and it honours the ``EPICS_CA_*`` environment variables.
+
+Run explicitly (outside the default ``--ignore=tests/e2e`` fast run)::
+
+    OSPREY_REAL_BRIDGE_URL=http://127.0.0.1:7979 EPICS_CA_SERVER_PORT=5074 \
+        pytest tests/e2e/test_phoebus_real_bridge_e2e.py -v
+"""
+
+import json
+import os
+import platform
+import subprocess
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.e2e, pytest.mark.slow]
+
+caproto_client = pytest.importorskip("caproto.sync.client")
+
+from fastmcp.exceptions import ToolError  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_RUN_DEMO = _REPO_ROOT / "demos" / "phoebus" / "run_demo.sh"
+
+_BRIDGE_READY_TIMEOUT = 240  # cold JVM + panel load on a shared box
+_PV_SETTLE_TIMEOUT = 20
+
+
+def _ca_get(pv: str, timeout: float = 5.0):
+    """Independent CA read (bypasses Phoebus and the bridge entirely)."""
+    res = caproto_client.read(pv, timeout=timeout)
+    val = res.data[0]
+    return val.decode() if isinstance(val, bytes) else val
+
+
+def _bridge_up(url: str) -> bool:
+    try:
+        with urllib.request.urlopen(f"{url}/displays", timeout=3) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
+
+
+def _default_ca_env(isolated: bool) -> dict[str, str]:
+    env = {
+        "EPICS_CA_ADDR_LIST": "127.0.0.1",
+        "EPICS_CA_AUTO_ADDR_LIST": "NO",
+    }
+    if isolated:
+        # run_demo.sh isolated-mode defaults (appsdev2 recon-chosen ports).
+        env["EPICS_CA_SERVER_PORT"] = os.environ.get("CA_SERVER_PORT", "5074")
+        env["EPICS_CA_REPEATER_PORT"] = os.environ.get("CA_REPEATER_PORT", "5075")
+    return env
+
+
+@pytest.fixture(scope="module")
+def real_bridge():
+    """Yield the URL of a real bridge, launching the demo stack if asked to."""
+    url = os.environ.get("OSPREY_REAL_BRIDGE_URL")
+    saved = dict(os.environ)
+    proc: subprocess.Popen | None = None
+
+    if url:
+        url = url.rstrip("/")
+        # Fill in loopback CA defaults without clobbering caller-provided values.
+        for k, v in _default_ca_env(isolated=False).items():
+            os.environ.setdefault(k, v)
+        if not _bridge_up(url):
+            pytest.fail(
+                f"OSPREY_REAL_BRIDGE_URL={url} does not answer GET /displays — "
+                "is the demo stack (run_demo.sh) running?"
+            )
+    elif os.environ.get("PHOEBUS_E2E_LAUNCH") == "1":
+        isolated = os.environ.get(
+            "ISOLATED", "1" if platform.system() == "Linux" else "0"
+        ) == "1"
+        os.environ.update(_default_ca_env(isolated))
+        url = f"http://127.0.0.1:{os.environ.get('BRIDGE_PORT', '7979')}"
+        proc = subprocess.Popen(
+            ["bash", str(_RUN_DEMO)],
+            cwd=_REPO_ROOT,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.STDOUT,
+        )
+        deadline = time.time() + _BRIDGE_READY_TIMEOUT
+        while time.time() < deadline:
+            if _bridge_up(url):
+                break
+            if proc.poll() is not None:
+                pytest.fail(
+                    "run_demo.sh exited before the bridge came up — see "
+                    "/tmp/osprey_demo_run.log and /tmp/osprey_demo_phoebus.log"
+                )
+            time.sleep(2)
+        else:
+            proc.terminate()
+            pytest.fail(f"bridge at {url} not ready within {_BRIDGE_READY_TIMEOUT}s")
+    else:
+        pytest.skip(
+            "real-bridge e2e needs OSPREY_REAL_BRIDGE_URL (running stack) "
+            "or PHOEBUS_E2E_LAUNCH=1 (launch run_demo.sh here)"
+        )
+
+    os.environ["PHOEBUS_BRIDGE_URL"] = url
+    yield url
+
+    if proc is not None:
+        proc.terminate()  # run_demo.sh traps TERM and tears down its children
+        try:
+            proc.wait(timeout=30)
+        except Exception:
+            proc.kill()
+    os.environ.clear()
+    os.environ.update(saved)
+
+
+def _tool(name):
+    from osprey.mcp_server.phoebus.tools import bridge_tools
+    from tests.mcp_server.conftest import get_tool_fn
+
+    return get_tool_fn(getattr(bridge_tools, name))
+
+
+def _parse(result) -> dict:
+    from tests.mcp_server.conftest import extract_response_dict
+
+    return extract_response_dict(result)
+
+
+async def _perceive_widgets(handle: str) -> list[dict]:
+    out = _parse(await _tool("phoebus_perceive")(display=handle))
+    assert out["status"] == "success"
+    return out["perception"]["widgets"]
+
+
+@pytest.fixture(scope="module")
+async def demo_handle(real_bridge):
+    """Open the demo panel on the REAL bridge and return its handle."""
+    out = _parse(await _tool("phoebus_open_panel")(name="osprey_demo"))
+    assert out["status"] == "success"
+    assert out["handle"].startswith("handle:")
+    assert out["ready"] is True, "display never reported ready=true after /open"
+    return out["handle"]
+
+
+async def test_reopen_is_stable_and_handle_resolves(real_bridge, demo_handle):
+    # Phoebus reuses the existing DockItem when the same .bob is opened again,
+    # so a re-open must return the SAME deterministic handle (distinct handles
+    # for distinct displays are covered by the bridge's own unit/IT tests).
+    out2 = _parse(await _tool("phoebus_open_panel")(name="osprey_demo"))
+    assert out2["status"] == "success" and out2["ready"] is True
+    assert out2["handle"] == demo_handle, (
+        "re-opening an already-open .bob must resolve to the same handle"
+    )
+    ids = {d["id"] for d in _parse(await _tool("phoebus_list_displays")())["displays"]}
+    assert demo_handle.split(":", 1)[1] in ids
+
+
+async def test_perceive_by_handle_returns_live_widget_tree(demo_handle):
+    # PVs may still be connecting right after ready=true — poll briefly.
+    deadline = time.time() + _PV_SETTLE_TIMEOUT
+    names: set = set()
+    while time.time() < deadline:
+        widgets = await _perceive_widgets(demo_handle)
+        names = {w.get("name") for w in widgets}
+        setpoint = next((w for w in widgets if w.get("name") == "Setpoint"), None)
+        if setpoint and (setpoint.get("pv") or {}).get("value") not in (None, ""):
+            break
+        time.sleep(1)
+    assert {"Setpoint", "Readback", "Status", "SetButton"}.issubset(names)
+    setpoint = next(w for w in widgets if w["name"] == "Setpoint")
+    # The bridge reports PV names scheme-qualified (e.g. "ca://DEMO:Setpoint").
+    assert "DEMO:" in setpoint["pv"]["name"], "Setpoint must bind a DEMO:* PV"
+
+
+async def test_drive_by_handle_moves_pv_ca_confirmed(demo_handle):
+    current = float(_ca_get("DEMO:Setpoint"))
+    target = 7.0 if abs(current - 7.0) > 0.01 else 8.0
+
+    out = _parse(
+        await _tool("phoebus_drive")(
+            widget="Setpoint", verb="type", value=str(target), display=demo_handle
+        )
+    )
+    assert out["status"] == "success" and out["fired"] is True, out
+
+    # Verify way 1: independent CA readback (never touches Phoebus).
+    deadline = time.time() + _PV_SETTLE_TIMEOUT
+    rb = None
+    while time.time() < deadline:
+        rb = float(_ca_get("DEMO:Readback"))
+        if rb == pytest.approx(target):
+            break
+        time.sleep(0.5)
+    assert rb == pytest.approx(target), f"CA readback {rb} never reached {target}"
+    # Enum reads may decode as index or string depending on the CA data type.
+    assert _ca_get("DEMO:Status") in (0, "OK")  # "OK" (target < 80)
+
+    # Verify way 2: the GUI's own view via a fresh perceive on the same handle.
+    widgets = await _perceive_widgets(demo_handle)
+    rb_widget = next(w for w in widgets if w["name"] == "Readback")
+    assert str(rb_widget["pv"]["value"]).startswith(str(int(target)))
+
+
+async def test_unknown_handle_is_clean_error_not_crash(real_bridge):
+    with pytest.raises(ToolError):
+        await _tool("phoebus_perceive")(display="handle:no-such-display")
+    # The bridge must survive the bad request.
+    assert _bridge_up(real_bridge), "bridge died after an unknown-handle request"
+
+
+async def test_unknown_panel_name_is_clean_tool_error(real_bridge):
+    with pytest.raises(ToolError, match="[Uu]nknown panel"):
+        await _tool("phoebus_open_panel")(name="definitely-not-a-registered-panel")

--- a/tests/integration/test_preset_static.py
+++ b/tests/integration/test_preset_static.py
@@ -202,6 +202,58 @@ def test_skill_referenced_mcp_tools_exist() -> None:
     )
 
 
+def test_phoebus_standalone_phoebus2_extends_block(tmp_path: Path) -> None:
+    """The commented phoebus2 opt-in in the phoebus-standalone preset must be
+    the ``extends`` form (the framework phoebus2 registry entry was deleted —
+    the legacy ``enabled: true`` form would now be a broken no-op), and
+    uncommenting it must round-trip through the same dotted-override path the
+    build uses (config_update_fields + resolve_env_vars) into a working clone.
+    """
+    import yaml
+
+    from osprey.registry.mcp import resolve_servers
+    from osprey.utils.config import resolve_env_vars
+    from osprey.utils.config_writer import config_update_fields
+
+    preset = PRESETS_DIR / "phoebus-standalone.yml"
+    text = preset.read_text(encoding="utf-8")
+
+    # The legacy opt-in form must be gone from the preset.
+    assert "claude_code.servers.phoebus2.enabled" not in text
+
+    # Shipped commented-out: the parsed profile carries no phoebus2 override.
+    profile = load_profile(preset)
+    config = getattr(profile, "config", {}) or {}
+    assert not any(k.startswith("claude_code.servers.phoebus2") for k in config)
+
+    # Uncomment the dotted overrides and apply them the way a build would.
+    overrides: dict = {}
+    for m in re.finditer(r"^  # (claude_code\.servers\.phoebus2\.\S+): (.+)$", text, re.M):
+        overrides[m.group(1)] = yaml.safe_load(m.group(2))
+    assert overrides.get("claude_code.servers.phoebus2.extends") == "phoebus", (
+        f"preset phoebus2 block is not the extends form: {overrides}"
+    )
+
+    config_path = tmp_path / "config.yml"
+    config_path.write_text("claude_code:\n  servers:\n    phoebus: {enabled: true}\n")
+    config_update_fields(config_path, overrides)
+
+    loaded = resolve_env_vars(
+        yaml.safe_load(config_path.read_text(encoding="utf-8")),
+        environ={"PHOEBUS2_BRIDGE_URL": "http://10.0.0.5:7980"},
+    )
+    servers = resolve_servers(
+        loaded["claude_code"],
+        {"project_root": str(tmp_path), "current_python_env": "/usr/bin/python3"},
+    )
+    p2 = [s for s in servers if s["name"] == "phoebus2"]
+    assert len(p2) == 1 and p2[0]["enabled"] is True
+    assert p2[0]["args"] == ["-m", "osprey.mcp_server.phoebus"]
+    # Server env survives verbatim (${...} expanded at MCP launch, not here).
+    assert p2[0]["env"]["PHOEBUS_BRIDGE_URL"] == "${PHOEBUS2_BRIDGE_URL:-http://127.0.0.1:7980}"
+    assert p2[0]["hooks_pre"][0]["matcher"] == "mcp__phoebus2__phoebus_drive"
+
+
 def test_slash_commands_resolve_targets() -> None:
     """Every ``.claude/commands/*.md`` slash command must reference a real artifact.
 

--- a/tests/mcp_server/test_phoebus_tools.py
+++ b/tests/mcp_server/test_phoebus_tools.py
@@ -346,9 +346,7 @@ async def test_open_panel_config_registered(tmp_path, monkeypatch):
     panel_file = tmp_path / "custom.bob"
     panel_file.write_text("fake bob content")
     config_file = tmp_path / "config.yml"
-    config_file.write_text(yaml.dump({
-        "phoebus": {"panels": {"custom": str(panel_file)}}
-    }))
+    config_file.write_text(yaml.dump({"phoebus": {"panels": {"custom": str(panel_file)}}}))
     monkeypatch.setenv("OSPREY_CONFIG", str(config_file))
 
     body = {"id": "d-4", "resource": str(panel_file), "ready": True}
@@ -396,6 +394,7 @@ async def test_perceive_with_handle():
         result = await _fn("phoebus_perceive")(display="handle:d-1")
     url = m.call_args.args[0]
     import urllib.parse
+
     assert "handle:d-1" in urllib.parse.unquote(url)
     data = extract_response_dict(result)
     assert data["status"] == "success"
@@ -408,9 +407,7 @@ async def test_drive_with_handle_passes_through():
         f"{_MOD}._http_post_drive",
         return_value=(200, {"fired": True, "detail": "fired via ButtonBase.fire()"}),
     ) as m:
-        result = await _fn("phoebus_drive")(
-            widget="SetButton", verb="click", display="handle:d-1"
-        )
+        result = await _fn("phoebus_drive")(widget="SetButton", verb="click", display="handle:d-1")
     payload = m.call_args.args[0]
     assert payload["display"] == "handle:d-1"
     data = extract_response_dict(result)

--- a/tests/mcp_server/test_phoebus_tools.py
+++ b/tests/mcp_server/test_phoebus_tools.py
@@ -1,0 +1,506 @@
+"""Unit tests for the Phoebus MCP bridge tools.
+
+The HTTP boundary (``_http_get_json`` / ``_http_get_bytes`` /
+``_http_post_drive`` / ``_http_post_open``) is patched so these run with no
+Phoebus product and no network.
+"""
+
+import json
+import urllib.error
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import yaml
+
+from osprey.mcp_server.phoebus.tools import bridge_tools
+from osprey.mcp_server.phoebus.tools.bridge_tools import _OPEN_READY_TIMEOUT
+from tests.mcp_server.conftest import assert_raises_error, extract_response_dict, get_tool_fn
+
+_MOD = "osprey.mcp_server.phoebus.tools.bridge_tools"
+
+
+def _fn(name):
+    return get_tool_fn(getattr(bridge_tools, name))
+
+
+# ── list_displays ──────────────────────────────────────────────────────────
+async def test_list_displays_success():
+    displays = [{"name": "demo", "ready": True, "active": True}]
+    with patch(f"{_MOD}._http_get_json", return_value=(200, displays)):
+        result = await _fn("phoebus_list_displays")()
+    data = extract_response_dict(result)
+    assert data["status"] == "success"
+    assert data["displays"][0]["name"] == "demo"
+
+
+async def test_list_displays_unreachable():
+    with patch(f"{_MOD}._http_get_json", side_effect=urllib.error.URLError("refused")):
+        with assert_raises_error(error_type="phoebus_unreachable"):
+            await _fn("phoebus_list_displays")()
+
+
+# ── perceive ───────────────────────────────────────────────────────────────
+async def test_perceive_success():
+    body = {"display": {"name": "demo"}, "widgets": [{"name": "Setpoint", "type": "textentry"}]}
+    with patch(f"{_MOD}._http_get_json", return_value=(200, body)) as m:
+        result = await _fn("phoebus_perceive")(display="active")
+    # display ref is URL-encoded into the path
+    assert "/perceive?display=active" in m.call_args.args[0]
+    data = extract_response_dict(result)
+    assert data["status"] == "success"
+    assert data["perception"]["widgets"][0]["name"] == "Setpoint"
+
+
+async def test_perceive_bridge_error():
+    with patch(
+        f"{_MOD}._http_get_json", return_value=(400, {"error": "No active display", "status": 400})
+    ):
+        with assert_raises_error(error_type="phoebus_error") as ctx:
+            await _fn("phoebus_perceive")()
+    assert "No active display" in ctx["envelope"]["error_message"]
+
+
+# ── perceive_region ────────────────────────────────────────────────────────
+async def test_perceive_region_validation():
+    with assert_raises_error(error_type="validation_error"):
+        await _fn("phoebus_perceive_region")(x=0, y=0, w=0, h=10)
+
+
+async def test_perceive_region_success():
+    body = {"display": {"name": "demo"}, "widgets": []}
+    with patch(f"{_MOD}._http_get_json", return_value=(200, body)) as m:
+        result = await _fn("phoebus_perceive_region")(x=5, y=6, w=100, h=80, display="active")
+    url = m.call_args.args[0]
+    assert "/perceive/region?" in url and "w=100" in url and "h=80" in url
+    assert extract_response_dict(result)["status"] == "success"
+
+
+# ── snapshot ───────────────────────────────────────────────────────────────
+async def test_snapshot_dpi_validation():
+    with assert_raises_error(error_type="validation_error"):
+        await _fn("phoebus_snapshot")(widget="Setpoint", dpi=0)
+    with assert_raises_error(error_type="validation_error"):
+        await _fn("phoebus_snapshot")(widget="Setpoint", dpi=99)
+
+
+async def test_snapshot_success_writes_png(tmp_path):
+    headers = {"X-Bridge-Origin-X": "10.0", "X-Bridge-Origin-Y": "20.0", "X-Bridge-Scale": "1.0"}
+    png = b"\x89PNG\r\n\x1a\nfake"
+    fake_entry = MagicMock()
+    fake_entry.to_tool_response.return_value = {"status": "success", "artifact_id": "abc"}
+    fake_store = MagicMock()
+    fake_store.save_data.return_value = fake_entry
+
+    with (
+        patch(f"{_MOD}._snapshot_dir", return_value=tmp_path),
+        patch(f"{_MOD}._http_get_bytes", return_value=(200, headers, png)),
+        patch("osprey.stores.artifact_store.get_artifact_store", return_value=fake_store),
+    ):
+        result = await _fn("phoebus_snapshot")(widget="Setpoint", display="active", dpi=2.0)
+
+    data = extract_response_dict(result)
+    assert data["status"] == "success"
+    written = list(tmp_path.glob("phoebus_Setpoint_*.png"))
+    assert len(written) == 1 and written[0].read_bytes() == png
+    # registration headers were threaded into the saved artifact data
+    saved = fake_store.save_data.call_args.kwargs["data"]
+    assert saved["scale"] == "1.0" and saved["origin_x"] == "10.0"
+
+
+async def test_snapshot_bridge_error():
+    err = json.dumps({"error": "widget not rendered", "status": 500}).encode()
+    with patch(f"{_MOD}._http_get_bytes", return_value=(500, {}, err)):
+        with assert_raises_error(error_type="phoebus_error") as ctx:
+            await _fn("phoebus_snapshot")(widget="Setpoint")
+    assert "not rendered" in ctx["envelope"]["error_message"]
+
+
+# ── drive ──────────────────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"widget": "0", "verb": "frobnicate"},  # bad verb
+        {"widget": "0", "verb": "click", "mode": "x"},  # bad mode
+        {"widget": "0", "verb": "type"},  # type without value
+    ],
+)
+async def test_drive_validation(kwargs):
+    with assert_raises_error(error_type="validation_error"):
+        await _fn("phoebus_drive")(**kwargs)
+
+
+async def test_drive_success():
+    with patch(
+        f"{_MOD}._http_post_drive",
+        return_value=(200, {"fired": True, "detail": "fired via ButtonBase.fire()"}),
+    ) as m:
+        result = await _fn("phoebus_drive")(widget="SetButton", verb="click")
+    payload = m.call_args.args[0]
+    assert payload == {
+        "display": "active",
+        "widget": "SetButton",
+        "verb": "click",
+        "value": None,
+        "mode": "synthetic",
+    }
+    data = extract_response_dict(result)
+    assert data["status"] == "success" and data["fired"] is True
+
+
+async def test_drive_type_lowercases_and_forwards_value():
+    with patch(
+        f"{_MOD}._http_post_drive", return_value=(200, {"fired": True, "detail": "ok"})
+    ) as m:
+        await _fn("phoebus_drive")(widget="Setpoint", verb="TYPE", value="42", mode="SEMANTIC")
+    payload = m.call_args.args[0]
+    assert payload["verb"] == "type" and payload["mode"] == "semantic" and payload["value"] == "42"
+
+
+async def test_drive_rejected():
+    with patch(
+        f"{_MOD}._http_post_drive", return_value=(400, {"error": "Unknown verb 'x'", "status": 400})
+    ):
+        with assert_raises_error(error_type="phoebus_rejected") as ctx:
+            await _fn("phoebus_drive")(widget="0", verb="click")
+    assert "Unknown verb" in ctx["envelope"]["error_message"]
+
+
+async def test_drive_unreachable():
+    with patch(f"{_MOD}._http_post_drive", side_effect=urllib.error.URLError("refused")):
+        with assert_raises_error(error_type="phoebus_unreachable"):
+            await _fn("phoebus_drive")(widget="0", verb="click")
+
+
+# ── open_panel ─────────────────────────────────────────────────────────────
+async def test_open_panel_success_ready_immediately(tmp_path, monkeypatch):
+    """Bridge returns ready=True on the POST /open response — no polling needed."""
+    config_file = tmp_path / "config.yml"
+    config_file.write_text("{}")
+    monkeypatch.setenv("OSPREY_CONFIG", str(config_file))
+
+    body = {"id": "d-1", "resource": "/path/osprey_demo.bob", "ready": True}
+    with patch(f"{_MOD}._http_post_open", return_value=(200, body)) as mock_open:
+        result = await _fn("phoebus_open_panel")(name="osprey_demo")
+
+    data = extract_response_dict(result)
+    assert data["status"] == "success"
+    assert data["handle"] == "handle:d-1"
+    assert data["id"] == "d-1"
+    assert data["ready"] is True
+    posted = mock_open.call_args.args[0]
+    assert "resource" in posted and posted["resource"].endswith("osprey_demo.bob")
+
+
+async def test_open_panel_polls_until_ready(tmp_path, monkeypatch):
+    """Bridge returns ready=False initially; open_panel polls displays until ready=True."""
+    config_file = tmp_path / "config.yml"
+    config_file.write_text("{}")
+    monkeypatch.setenv("OSPREY_CONFIG", str(config_file))
+
+    open_body = {"id": "d-2", "resource": "/path/demo.bob", "ready": False}
+    displays_body = [{"id": "d-2", "ready": True, "active": True, "name": "demo"}]
+
+    with (
+        patch(f"{_MOD}._http_post_open", return_value=(200, open_body)),
+        patch(f"{_MOD}._http_get_json", return_value=(200, displays_body)),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        result = await _fn("phoebus_open_panel")(name="osprey_demo")
+
+    data = extract_response_dict(result)
+    assert data["status"] == "success"
+    assert data["ready"] is True
+    assert data["handle"] == "handle:d-2"
+
+
+async def test_open_panel_timeout_returns_not_ready(tmp_path, monkeypatch):
+    """When bridge never becomes ready within timeout, ready=False is returned.
+
+    ``time.monotonic`` is patched so the deadline expires before the first loop
+    iteration — no real sleep or polling occurs.
+    """
+    config_file = tmp_path / "config.yml"
+    config_file.write_text("{}")
+    monkeypatch.setenv("OSPREY_CONFIG", str(config_file))
+
+    open_body = {"id": "d-3", "resource": "/path/demo.bob", "ready": False}
+    still_loading = [{"id": "d-3", "ready": False, "active": True, "name": "demo"}]
+
+    # Patch the module-level _monotonic alias (not the global time.monotonic that
+    # anyio uses internally).  First call sets the deadline; second call in the
+    # while-condition already exceeds it → loop never executes → no real sleep.
+    monotonic_seq = iter([0.0, _OPEN_READY_TIMEOUT + 1.0])
+
+    with (
+        patch(f"{_MOD}._http_post_open", return_value=(200, open_body)),
+        patch(f"{_MOD}._http_get_json", return_value=(200, still_loading)),
+        patch(f"{_MOD}._monotonic", side_effect=monotonic_seq),
+    ):
+        result = await _fn("phoebus_open_panel")(name="osprey_demo")
+
+    data = extract_response_dict(result)
+    assert data["status"] == "success"
+    assert data["ready"] is False
+
+
+# ── open_panel auto-focus ──────────────────────────────────────────────────
+async def test_open_panel_focuses_own_web_panel_by_default(tmp_path, monkeypatch):
+    """A successful open notifies the web terminal to focus THIS instance's
+    panel tab, identified by OSPREY_SERVER_NAME (set per-clone by the registry)."""
+    config_file = tmp_path / "config.yml"
+    config_file.write_text("{}")
+    monkeypatch.setenv("OSPREY_CONFIG", str(config_file))
+    monkeypatch.setenv("OSPREY_SERVER_NAME", "phoebus2")
+
+    body = {"id": "d-1", "resource": "/path/osprey_demo.bob", "ready": True}
+    with (
+        patch(f"{_MOD}._http_post_open", return_value=(200, body)),
+        patch(f"{_MOD}.notify_panel_focus") as mock_focus,
+    ):
+        result = await _fn("phoebus_open_panel")(name="osprey_demo")
+
+    data = extract_response_dict(result)
+    assert data["status"] == "success"
+    assert data["focused"] is True
+    mock_focus.assert_called_once_with("phoebus2")
+
+
+async def test_open_panel_focus_defaults_to_phoebus_panel(tmp_path, monkeypatch):
+    """Without OSPREY_SERVER_NAME (template instance / older .mcp.json), the
+    focus target falls back to the canonical 'phoebus' panel id."""
+    config_file = tmp_path / "config.yml"
+    config_file.write_text("{}")
+    monkeypatch.setenv("OSPREY_CONFIG", str(config_file))
+    monkeypatch.delenv("OSPREY_SERVER_NAME", raising=False)
+
+    body = {"id": "d-1", "resource": "/path/osprey_demo.bob", "ready": True}
+    with (
+        patch(f"{_MOD}._http_post_open", return_value=(200, body)),
+        patch(f"{_MOD}.notify_panel_focus") as mock_focus,
+    ):
+        await _fn("phoebus_open_panel")(name="osprey_demo")
+
+    mock_focus.assert_called_once_with("phoebus")
+
+
+async def test_open_panel_focus_opt_out(tmp_path, monkeypatch):
+    """focus=False (batch/background opens) suppresses the panel switch."""
+    config_file = tmp_path / "config.yml"
+    config_file.write_text("{}")
+    monkeypatch.setenv("OSPREY_CONFIG", str(config_file))
+
+    body = {"id": "d-1", "resource": "/path/osprey_demo.bob", "ready": True}
+    with (
+        patch(f"{_MOD}._http_post_open", return_value=(200, body)),
+        patch(f"{_MOD}.notify_panel_focus") as mock_focus,
+    ):
+        result = await _fn("phoebus_open_panel")(name="osprey_demo", focus=False)
+
+    data = extract_response_dict(result)
+    assert data["status"] == "success"
+    assert data["focused"] is False
+    mock_focus.assert_not_called()
+
+
+async def test_open_panel_focus_failure_is_nonfatal(tmp_path, monkeypatch):
+    """A failing focus notification (web terminal gone, config unreadable)
+    must never fail the open itself — the display IS open at that point."""
+    config_file = tmp_path / "config.yml"
+    config_file.write_text("{}")
+    monkeypatch.setenv("OSPREY_CONFIG", str(config_file))
+
+    body = {"id": "d-1", "resource": "/path/osprey_demo.bob", "ready": True}
+    with (
+        patch(f"{_MOD}._http_post_open", return_value=(200, body)),
+        patch(f"{_MOD}.notify_panel_focus", side_effect=OSError("terminal gone")),
+    ):
+        result = await _fn("phoebus_open_panel")(name="osprey_demo")
+
+    data = extract_response_dict(result)
+    assert data["status"] == "success"
+    assert data["focused"] is False
+
+
+async def test_open_panel_empty_id_raises(tmp_path, monkeypatch):
+    """A 200 response with a missing/blank id raises phoebus_open_failed immediately."""
+    config_file = tmp_path / "config.yml"
+    config_file.write_text("{}")
+    monkeypatch.setenv("OSPREY_CONFIG", str(config_file))
+
+    body_no_id = {"resource": "/path/demo.bob", "ready": False}  # no "id" key
+    with patch(f"{_MOD}._http_post_open", return_value=(200, body_no_id)):
+        with assert_raises_error(error_type="phoebus_open_failed") as ctx:
+            await _fn("phoebus_open_panel")(name="osprey_demo")
+    assert "no display id" in ctx["envelope"]["error_message"]
+
+
+async def test_open_panel_unknown_name():
+    """Requesting an unregistered panel name raises ToolError(unknown_panel)."""
+    with assert_raises_error(error_type="unknown_panel") as ctx:
+        await _fn("phoebus_open_panel")(name="nonexistent_panel")
+    assert "nonexistent_panel" in ctx["envelope"]["error_message"]
+
+
+async def test_open_panel_config_registered(tmp_path, monkeypatch):
+    """A panel registered under phoebus.panels in config.yml is opened correctly."""
+    panel_file = tmp_path / "custom.bob"
+    panel_file.write_text("fake bob content")
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(yaml.dump({
+        "phoebus": {"panels": {"custom": str(panel_file)}}
+    }))
+    monkeypatch.setenv("OSPREY_CONFIG", str(config_file))
+
+    body = {"id": "d-4", "resource": str(panel_file), "ready": True}
+    with patch(f"{_MOD}._http_post_open", return_value=(200, body)) as mock_open:
+        result = await _fn("phoebus_open_panel")(name="custom")
+
+    data = extract_response_dict(result)
+    assert data["status"] == "success"
+    assert data["handle"] == "handle:d-4"
+    posted = mock_open.call_args.args[0]
+    assert posted["resource"] == str(panel_file)
+
+
+async def test_open_panel_bridge_400(tmp_path, monkeypatch):
+    """A 400 from the bridge surfaces as phoebus_open_failed with the bridge error text."""
+    config_file = tmp_path / "config.yml"
+    config_file.write_text("{}")
+    monkeypatch.setenv("OSPREY_CONFIG", str(config_file))
+
+    with patch(
+        f"{_MOD}._http_post_open",
+        return_value=(400, {"error": "file not found", "status": 400}),
+    ):
+        with assert_raises_error(error_type="phoebus_open_failed") as ctx:
+            await _fn("phoebus_open_panel")(name="osprey_demo")
+    assert "file not found" in ctx["envelope"]["error_message"]
+
+
+async def test_open_panel_unreachable(tmp_path, monkeypatch):
+    """Bridge unreachable during open raises phoebus_unreachable."""
+    config_file = tmp_path / "config.yml"
+    config_file.write_text("{}")
+    monkeypatch.setenv("OSPREY_CONFIG", str(config_file))
+
+    with patch(f"{_MOD}._http_post_open", side_effect=urllib.error.URLError("refused")):
+        with assert_raises_error(error_type="phoebus_unreachable"):
+            await _fn("phoebus_open_panel")(name="osprey_demo")
+
+
+# ── handle:<id> threading ───────────────────────────────────────────────────
+async def test_perceive_with_handle():
+    """handle:<id> is URL-encoded and forwarded to the bridge as the display query param."""
+    body = {"display": {"name": "d-1"}, "widgets": []}
+    with patch(f"{_MOD}._http_get_json", return_value=(200, body)) as m:
+        result = await _fn("phoebus_perceive")(display="handle:d-1")
+    url = m.call_args.args[0]
+    import urllib.parse
+    assert "handle:d-1" in urllib.parse.unquote(url)
+    data = extract_response_dict(result)
+    assert data["status"] == "success"
+    assert data["display"] == "handle:d-1"
+
+
+async def test_drive_with_handle_passes_through():
+    """handle:<id> is forwarded unchanged in the drive payload."""
+    with patch(
+        f"{_MOD}._http_post_drive",
+        return_value=(200, {"fired": True, "detail": "fired via ButtonBase.fire()"}),
+    ) as m:
+        result = await _fn("phoebus_drive")(
+            widget="SetButton", verb="click", display="handle:d-1"
+        )
+    payload = m.call_args.args[0]
+    assert payload["display"] == "handle:d-1"
+    data = extract_response_dict(result)
+    assert data["status"] == "success" and data["fired"] is True
+
+
+async def test_drive_validation_still_enforced_with_handle():
+    """drive verb/mode validation is enforced even when display is a handle string."""
+    with assert_raises_error(error_type="validation_error"):
+        await _fn("phoebus_drive")(widget="0", verb="frobnicate", display="handle:d-1")
+
+
+# ── require-handle addressing (PHOEBUS_REQUIRE_HANDLE) ─────────────────────
+_REQUIRE_HANDLE_CASES = [
+    ("phoebus_perceive", {}),
+    ("phoebus_perceive_region", {"x": 0, "y": 0, "w": 10, "h": 10}),
+    ("phoebus_snapshot", {"widget": "Setpoint"}),
+    ("phoebus_drive", {"widget": "0", "verb": "click"}),
+]
+
+
+@pytest.mark.parametrize("tool_name,kwargs", _REQUIRE_HANDLE_CASES)
+async def test_require_handle_env_rejects_implicit_active(tool_name, kwargs, monkeypatch):
+    """PHOEBUS_REQUIRE_HANDLE=1 rejects the implicit 'active' fallback on all four tools.
+
+    No bridge patch needed: the rejection happens before any network call.
+    """
+    monkeypatch.setenv("PHOEBUS_REQUIRE_HANDLE", "1")
+    with assert_raises_error(error_type="phoebus_handle_required") as ctx:
+        await _fn(tool_name)(**kwargs)
+    assert "phoebus_open_panel" in ctx["envelope"]["error_message"]
+
+
+async def test_require_handle_config_key_rejects_implicit_active(tmp_path, monkeypatch):
+    """phoebus.require_handle: true in config.yml has the same effect as the env var."""
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(yaml.dump({"phoebus": {"require_handle": True}}))
+    monkeypatch.setenv("OSPREY_CONFIG", str(config_file))
+    with assert_raises_error(error_type="phoebus_handle_required"):
+        await _fn("phoebus_perceive")()
+
+
+async def test_require_handle_perceive_with_handle_succeeds(monkeypatch):
+    """Flag on + explicit handle:<id> resolves normally (no rejection)."""
+    monkeypatch.setenv("PHOEBUS_REQUIRE_HANDLE", "1")
+    body = {"display": {"name": "d-1"}, "widgets": []}
+    with patch(f"{_MOD}._http_get_json", return_value=(200, body)):
+        result = await _fn("phoebus_perceive")(display="handle:d-1")
+    assert extract_response_dict(result)["status"] == "success"
+
+
+async def test_require_handle_perceive_region_with_handle_succeeds(monkeypatch):
+    monkeypatch.setenv("PHOEBUS_REQUIRE_HANDLE", "1")
+    body = {"display": {"name": "d-1"}, "widgets": []}
+    with patch(f"{_MOD}._http_get_json", return_value=(200, body)):
+        result = await _fn("phoebus_perceive_region")(x=0, y=0, w=10, h=10, display="handle:d-1")
+    assert extract_response_dict(result)["status"] == "success"
+
+
+async def test_require_handle_snapshot_with_handle_succeeds(tmp_path, monkeypatch):
+    monkeypatch.setenv("PHOEBUS_REQUIRE_HANDLE", "1")
+    headers = {"X-Bridge-Origin-X": "10.0", "X-Bridge-Origin-Y": "20.0", "X-Bridge-Scale": "1.0"}
+    png = b"\x89PNG\r\n\x1a\nfake"
+    fake_entry = MagicMock()
+    fake_entry.to_tool_response.return_value = {"status": "success", "artifact_id": "abc"}
+    fake_store = MagicMock()
+    fake_store.save_data.return_value = fake_entry
+
+    with (
+        patch(f"{_MOD}._snapshot_dir", return_value=tmp_path),
+        patch(f"{_MOD}._http_get_bytes", return_value=(200, headers, png)),
+        patch("osprey.stores.artifact_store.get_artifact_store", return_value=fake_store),
+    ):
+        result = await _fn("phoebus_snapshot")(widget="Setpoint", display="handle:d-1", dpi=1.0)
+    assert extract_response_dict(result)["status"] == "success"
+
+
+async def test_require_handle_drive_with_handle_succeeds(monkeypatch):
+    monkeypatch.setenv("PHOEBUS_REQUIRE_HANDLE", "1")
+    with patch(
+        f"{_MOD}._http_post_drive",
+        return_value=(200, {"fired": True, "detail": "fired via ButtonBase.fire()"}),
+    ):
+        result = await _fn("phoebus_drive")(widget="SetButton", verb="click", display="handle:d-1")
+    assert extract_response_dict(result)["status"] == "success"
+
+
+async def test_require_handle_off_by_default_active_still_works():
+    """With the flag untouched (default off), the implicit 'active' fallback is unchanged."""
+    body = {"display": {"name": "demo"}, "widgets": []}
+    with patch(f"{_MOD}._http_get_json", return_value=(200, body)):
+        result = await _fn("phoebus_perceive")()  # display omitted -> defaults to "active"
+    assert extract_response_dict(result)["status"] == "success"

--- a/tests/registry/test_mcp.py
+++ b/tests/registry/test_mcp.py
@@ -248,6 +248,343 @@ class TestResolveServers:
 
 
 # ---------------------------------------------------------------------------
+# Extends (second framework-server instance) tests
+# ---------------------------------------------------------------------------
+
+_PHOEBUS2_SPEC = {
+    "extends": "phoebus",
+    "env": {"PHOEBUS_BRIDGE_URL": "${PHOEBUS2_BRIDGE_URL:-http://127.0.0.1:7980}"},
+}
+
+_PHOEBUS_ALLOW = [
+    "phoebus_list_displays",
+    "phoebus_perceive",
+    "phoebus_perceive_region",
+    "phoebus_snapshot",
+    "phoebus_open_panel",
+]
+
+# Only drive actuates hardware-facing controls; open_panel touches no PVs
+# and is plain-allowed — see the registry entry.
+_PHOEBUS_ASK = ["phoebus_drive"]
+
+
+def _resolve_one(cfg, name, ctx=None):
+    servers = resolve_servers(cfg, ctx or _base_ctx())
+    matches = [s for s in servers if s["name"] == name]
+    assert len(matches) == 1, f"expected exactly one {name!r} server, got {len(matches)}"
+    return matches[0]
+
+
+class TestExtendsServers:
+    """Tests for extends clones (claude_code.servers.<name>.extends)."""
+
+    def test_golden_parity_with_deleted_framework_entry(self):
+        """The extends clone reproduces the old hand-written framework phoebus2
+        entry field-for-field (golden capture taken BEFORE the deletion)."""
+        p2 = _resolve_one({"servers": {"phoebus2": dict(_PHOEBUS2_SPEC)}}, "phoebus2")
+
+        assert p2["enabled"] is True  # despite template default_enabled=False
+        assert p2["command"] == "/usr/bin/python3"
+        assert p2["args"] == ["-m", "osprey.mcp_server.phoebus"]
+        # Spec env wins, ${...} NOT expanded; template keys survive with
+        # {project_root} resolved.
+        # OSPREY_SERVER_NAME is a deliberate post-golden addition (instance
+        # identity for UI signals, e.g. open_panel → panel_focus) — auto-set
+        # to the clone's own name, not inherited from the template.
+        assert p2["env"] == {
+            "OSPREY_CONFIG": "/tmp/test-project/config.yml",
+            "CONFIG_FILE": "/tmp/test-project/config.yml",
+            "PHOEBUS_BRIDGE_URL": "${PHOEBUS2_BRIDGE_URL:-http://127.0.0.1:7980}",
+            "OSPREY_SERVER_NAME": "phoebus2",
+        }
+        # Permissions inherited as bare names (unrewritten).
+        assert p2["permissions_allow"] == _PHOEBUS_ALLOW
+        assert p2["permissions_ask"] == _PHOEBUS_ASK
+        # Hook matchers rewritten with the anchored prefix.
+        assert len(p2["hooks_pre"]) == 1
+        assert p2["hooks_pre"][0]["matcher"] == "mcp__phoebus2__phoebus_drive"
+        assert len(p2["hooks_pre"][0]["hooks"]) == 1
+        assert "osprey_approval.py" in p2["hooks_pre"][0]["hooks"][0]["command"]
+        assert [r["matcher"] for r in p2["hooks_post"]] == ["mcp__phoebus2__.*"]
+        assert p2["is_custom"] is False
+        assert p2["url"] is None
+
+    def test_server_name_env_identity(self):
+        """Each instance's env advertises its own name via OSPREY_SERVER_NAME:
+        the template keeps 'phoebus', a clone is auto-rewritten to the clone
+        name, and an explicit spec env pin wins over the auto-rewrite."""
+        pristine = _resolve_one({"servers": {"phoebus": {"enabled": True}}}, "phoebus")
+        assert pristine["env"]["OSPREY_SERVER_NAME"] == "phoebus"
+
+        p2 = _resolve_one({"servers": {"phoebus2": dict(_PHOEBUS2_SPEC)}}, "phoebus2")
+        assert p2["env"]["OSPREY_SERVER_NAME"] == "phoebus2"
+
+        pinned_spec = {
+            "extends": "phoebus",
+            "env": {"OSPREY_SERVER_NAME": "custom-panel-id"},
+        }
+        pinned = _resolve_one({"servers": {"phoebus2": pinned_spec}}, "phoebus2")
+        assert pinned["env"]["OSPREY_SERVER_NAME"] == "custom-panel-id"
+
+    def test_no_bare_name_rewrite(self):
+        """The matcher rewrite is an anchored prefix splice — 'phoebus2_drive'
+        (the bare-name-replace bug class) must appear NOWHERE in any matcher or
+        permission string."""
+        p2 = _resolve_one({"servers": {"phoebus2": dict(_PHOEBUS2_SPEC)}}, "phoebus2")
+
+        strings = [r["matcher"] for r in (*p2["hooks_pre"], *p2["hooks_post"])]
+        strings += p2["permissions_allow"] + p2["permissions_ask"]
+        strings += p2["fixed_allow"] + p2["fixed_ask"]
+        for s in strings:
+            assert "phoebus2_drive" not in s, f"bare-name rewrite corruption in {s!r}"
+
+    def test_template_isolation(self):
+        """Resolving an extends spec must not mutate the phoebus template —
+        neither in the same pass nor in a subsequent resolve_servers() call."""
+        cfg = {"servers": {"phoebus": {"enabled": True}, "phoebus2": dict(_PHOEBUS2_SPEC)}}
+        servers = resolve_servers(cfg, _base_ctx())
+        phoebus = [s for s in servers if s["name"] == "phoebus"][0]
+        assert phoebus["hooks_pre"][0]["matcher"] == "mcp__phoebus__phoebus_drive"
+        assert (
+            phoebus["env"]["PHOEBUS_BRIDGE_URL"] == "${PHOEBUS_BRIDGE_URL:-http://127.0.0.1:7979}"
+        )
+
+        # A fresh resolve with no overrides yields the pristine template.
+        pristine = _resolve_one({}, "phoebus")
+        assert pristine["hooks_pre"][0]["matcher"] == "mcp__phoebus__phoebus_drive"
+        assert pristine["hooks_post"][0]["matcher"] == "mcp__phoebus__.*"
+
+    def test_enabled_semantics(self):
+        """Declared ⇒ enabled (template default_enabled=False must not leak);
+        enabled: false ⇒ absent; independent of the template's own enablement."""
+        # No 'enabled' key → enabled, even with the template explicitly disabled.
+        cfg = {"servers": {"phoebus": {"enabled": False}, "phoebus2": dict(_PHOEBUS2_SPEC)}}
+        servers = resolve_servers(cfg, _base_ctx())
+        by_name = {s["name"]: s for s in servers}
+        assert by_name["phoebus2"]["enabled"] is True
+        assert by_name["phoebus"]["enabled"] is False
+
+        # enabled: false → clone absent entirely.
+        cfg = {"servers": {"phoebus2": {**_PHOEBUS2_SPEC, "enabled": False}}}
+        servers = resolve_servers(cfg, _base_ctx())
+        assert "phoebus2" not in {s["name"] for s in servers}
+
+    def test_order_independence(self):
+        """Clone output is identical regardless of YAML declaration order
+        relative to a template override (copy-from-pristine-FRAMEWORK_SERVERS)."""
+        cfg_a = {"servers": {"phoebus": {"enabled": True}, "phoebus2": dict(_PHOEBUS2_SPEC)}}
+        cfg_b = {"servers": {"phoebus2": dict(_PHOEBUS2_SPEC), "phoebus": {"enabled": True}}}
+        p2_a = _resolve_one(cfg_a, "phoebus2")
+        p2_b = _resolve_one(cfg_b, "phoebus2")
+        assert p2_a == p2_b
+        # Both servers enabled; template env/permissions unchanged either way.
+        phoebus = _resolve_one(cfg_b, "phoebus")
+        assert phoebus["enabled"] is True
+        assert (
+            phoebus["env"]["PHOEBUS_BRIDGE_URL"] == "${PHOEBUS_BRIDGE_URL:-http://127.0.0.1:7979}"
+        )
+
+    def test_unknown_target_warns_and_skips(self, caplog):
+        """Unknown extends target → warning, no server emitted."""
+        with caplog.at_level(logging.WARNING):
+            servers = resolve_servers(
+                {"servers": {"phoebus2": {"extends": "phobeus"}}}, _base_ctx()
+            )
+        assert "phoebus2" not in {s["name"] for s in servers}
+        assert any("phobeus" in r.message for r in caplog.records)
+
+    @pytest.mark.parametrize("order", ["a_first", "b_first"])
+    def test_chaining_warns_and_skips(self, caplog, order):
+        """Extends of an extends/custom server (chaining) → warn + skip the
+        chained server, regardless of declaration order; the base clone survives."""
+        specs = [("a", {"extends": "phoebus"}), ("b", {"extends": "a"})]
+        if order == "b_first":
+            specs.reverse()
+        cfg = {"servers": dict(specs)}
+        with caplog.at_level(logging.WARNING):
+            servers = resolve_servers(cfg, _base_ctx())
+        names = {s["name"] for s in servers}
+        assert "a" in names
+        assert "b" not in names
+        assert any("'a'" in r.message or '"a"' in r.message for r in caplog.records)
+
+    def test_framework_name_shadowing_warns_keeps_framework_definition(self, caplog):
+        """servers.phoebus: {extends: controls} must not rebase phoebus — the
+        extends key is rejected loudly, only 'enabled' applies."""
+        cfg = {"servers": {"phoebus": {"extends": "controls", "enabled": True}}}
+        with caplog.at_level(logging.WARNING):
+            phoebus = _resolve_one(cfg, "phoebus")
+        # Framework definition intact: module, matchers, permissions.
+        assert phoebus["args"] == ["-m", "osprey.mcp_server.phoebus"]
+        assert phoebus["hooks_pre"][0]["matcher"] == "mcp__phoebus__phoebus_drive"
+        assert "channel_write" not in phoebus["permissions_ask"]
+        # The enabled toggle still applies; the extends key warned.
+        assert phoebus["enabled"] is True
+        assert any("extends" in r.message and "phoebus" in r.message for r in caplog.records)
+
+    @pytest.mark.parametrize(
+        "bad_name", ["phoebus(2", "phoebus.2", "phoe__bus2", "-phoebus2", "controls_"]
+    )
+    def test_invalid_clone_name_rejected(self, caplog, bad_name):
+        """Clone names are spliced into regexes and prefix matches — reject
+        anything outside [A-Za-z0-9][A-Za-z0-9_-]*, containing '__', or ending
+        in '_' ('controls_' → prefix 'mcp__controls___' startswith-collides
+        with 'mcp__controls__' and corrupts approval short-name extraction)."""
+        with caplog.at_level(logging.WARNING):
+            servers = resolve_servers({"servers": {bad_name: {"extends": "phoebus"}}}, _base_ctx())
+        assert bad_name not in {s["name"] for s in servers}
+        assert any("Invalid extends server name" in r.message for r in caplog.records)
+
+    @pytest.mark.parametrize("good_name", ["phoebus2", "phoebus-2"])
+    def test_valid_clone_name_accepted(self, good_name):
+        """The tightened name validation still accepts ordinary clone names
+        (trailing digit, trailing hyphen-digit)."""
+        clone = _resolve_one({"servers": {good_name: {"extends": "phoebus"}}}, good_name)
+        assert clone["enabled"] is True
+        assert clone["hooks_pre"][0]["matcher"] == f"mcp__{good_name}__phoebus_drive"
+
+    def test_non_string_extends_target_warns_and_skips(self, caplog):
+        """A non-string extends value (e.g. ``extends: [phoebus]``) must
+        warn+skip like an unknown target, not TypeError on the dict lookup."""
+        with caplog.at_level(logging.WARNING):
+            servers = resolve_servers(
+                {"servers": {"phoebus2": {"extends": ["phoebus"]}}}, _base_ctx()
+            )
+        assert "phoebus2" not in {s["name"] for s in servers}
+        assert any("Unknown extends target" in r.message for r in caplog.records)
+
+    def test_duplicate_allow_override_cannot_defeat_ask_union(self, caplog):
+        """Duplicated entries in an override's permissions.allow must not defeat
+        the single-.remove() ask-union guard: drive ends ONLY in ask."""
+        cfg = {
+            "servers": {
+                "phoebus2": {
+                    "extends": "phoebus",
+                    "permissions": {"allow": ["phoebus_drive", "phoebus_drive"], "ask": []},
+                }
+            }
+        }
+        with caplog.at_level(logging.WARNING):
+            p2 = _resolve_one(cfg, "phoebus2")
+        assert "phoebus_drive" in p2["permissions_ask"]
+        assert "phoebus_drive" not in p2["permissions_allow"]
+
+    def test_fixed_lists_rewritten(self, monkeypatch):
+        """fixed_allow/fixed_ask hold fully-qualified mcp__<server>__ strings —
+        the clone must get them rewritten with the anchored prefix (latent
+        today: no framework server sets them, so use a synthetic template)."""
+        from osprey.registry.mcp import (
+            FRAMEWORK_SERVERS,
+            ServerDefinition,
+            build_extended_server,
+        )
+
+        synthetic = ServerDefinition(
+            name="synth",
+            module="osprey.mcp_server.synth",
+            fixed_allow=["mcp__synth__widget_read", "Read(_agent_data/**)"],
+            fixed_ask=["mcp__synth__widget_write"],
+        )
+        monkeypatch.setitem(FRAMEWORK_SERVERS, "synth", synthetic)
+
+        clone = build_extended_server("synth2", {"extends": "synth"})
+        assert clone is not None
+        assert clone.fixed_allow == ["mcp__synth2__widget_read", "Read(_agent_data/**)"]
+        assert clone.fixed_ask == ["mcp__synth2__widget_write"]
+        # Template untouched.
+        assert synthetic.fixed_ask == ["mcp__synth__widget_write"]
+
+    @pytest.mark.parametrize("with_pipeline", [False, True])
+    def test_conditioned_template_skipped(self, caplog, with_pipeline):
+        """Extends of a conditioned/dynamic template (channel-finder) is not
+        supported: warn + skip, and no rendered dict may carry an unresolved
+        '{channel_finder_pipeline}' placeholder."""
+        ctx = _base_ctx(channel_finder_pipeline="hierarchical") if with_pipeline else _base_ctx()
+        with caplog.at_level(logging.WARNING):
+            servers = resolve_servers({"servers": {"cf2": {"extends": "channel-finder"}}}, ctx)
+        assert "cf2" not in {s["name"] for s in servers}
+        assert any("conditioned" in r.message for r in caplog.records)
+        # No ENABLED server (i.e. rendered into .mcp.json) may carry the broken
+        # 'osprey.mcp_server.channel_finder_' module or an unresolved placeholder.
+        for s in servers:
+            if not s["enabled"]:
+                continue
+            for a in s["args"]:
+                assert "{channel_finder_pipeline}" not in a
+                assert not a.endswith("channel_finder_")
+
+    def test_legacy_phoebus2_enabled_spec_warns_and_skips(self, caplog):
+        """The old form {'phoebus2': {'enabled': True}} (framework entry now
+        deleted; no extends/command/url) → warn + skip; no command=='' server
+        may ever be emitted (the broken-.mcp.json regression)."""
+        with caplog.at_level(logging.WARNING):
+            servers = resolve_servers({"servers": {"phoebus2": {"enabled": True}}}, _base_ctx())
+        assert "phoebus2" not in {s["name"] for s in servers}
+        assert any("phoebus2" in r.message and "extends" in r.message for r in caplog.records)
+        for s in servers:
+            assert not (s["url"] is None and s["command"] == ""), (
+                f"server {s['name']!r} rendered with an empty command"
+            )
+
+    def test_ask_override_cannot_narrow(self, caplog):
+        """An override that promotes phoebus_drive out of ask into allow is
+        corrected: drive stays in ask (union invariant) and leaves allow."""
+        cfg = {
+            "servers": {
+                "phoebus2": {
+                    "extends": "phoebus",
+                    "permissions": {"allow": ["phoebus_drive", "phoebus_perceive"], "ask": []},
+                }
+            }
+        }
+        with caplog.at_level(logging.WARNING):
+            p2 = _resolve_one(cfg, "phoebus2")
+        assert "phoebus_drive" in p2["permissions_ask"]
+        assert "phoebus_drive" not in p2["permissions_allow"]
+        assert "phoebus_perceive" in p2["permissions_allow"]
+        assert any("phoebus_drive" in r.message for r in caplog.records)
+
+    def test_ask_override_can_add(self):
+        """Overrides may ADD approval-gated tools beyond the template's; the
+        template's own ask set is re-added by the union invariant."""
+        cfg = {
+            "servers": {
+                "phoebus2": {
+                    "extends": "phoebus",
+                    "permissions": {"ask": ["phoebus_extra_tool"]},
+                }
+            }
+        }
+        p2 = _resolve_one(cfg, "phoebus2")
+        assert "phoebus_extra_tool" in p2["permissions_ask"]
+        for tool in _PHOEBUS_ASK:
+            assert tool in p2["permissions_ask"]
+
+    def test_third_instance_scales(self):
+        """Two extends clones (phoebus2 + phoebus3) render side by side with
+        distinct prefixes — N-instance scaling without framework changes."""
+        cfg = {
+            "servers": {
+                "phoebus2": dict(_PHOEBUS2_SPEC),
+                "phoebus3": {
+                    "extends": "phoebus",
+                    "env": {"PHOEBUS_BRIDGE_URL": "${PHOEBUS3_BRIDGE_URL:-http://127.0.0.1:7981}"},
+                },
+            }
+        }
+        servers = resolve_servers(cfg, _base_ctx())
+        by_name = {s["name"]: s for s in servers}
+        for name in ("phoebus2", "phoebus3"):
+            assert by_name[name]["enabled"] is True
+            assert by_name[name]["hooks_pre"][0]["matcher"] == f"mcp__{name}__phoebus_drive"
+            assert by_name[name]["permissions_ask"] == _PHOEBUS_ASK
+        assert by_name["phoebus3"]["env"]["PHOEBUS_BRIDGE_URL"] == (
+            "${PHOEBUS3_BRIDGE_URL:-http://127.0.0.1:7981}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Agent resolution tests
 # ---------------------------------------------------------------------------
 
@@ -550,3 +887,74 @@ class TestTemplateRendering:
         data = json.loads(rendered)
         assert "mcp__my-plc__" in data["server_prefixes"]
         assert "mcp__my-plc__" in data["approval_prefixes"]
+
+    _EXTENDS_CFG = {
+        "servers": {
+            "phoebus": {"enabled": True},
+            "phoebus2": {
+                "extends": "phoebus",
+                "env": {"PHOEBUS_BRIDGE_URL": "${PHOEBUS2_BRIDGE_URL:-http://127.0.0.1:7980}"},
+            },
+        }
+    }
+
+    def test_render_settings_json_with_extends(self, template_manager):
+        """settings.json: extends clone yields mcp__phoebus2__ permissions and a
+        drive-only PreToolUse approval hook (no wildcard, no stale template rule)."""
+        ctx = self._full_ctx(_claude_code_config=self._EXTENDS_CFG)
+        rendered = self._render(template_manager, "claude_code/claude/settings.json.j2", ctx)
+        data = json.loads(rendered)
+
+        allow = set(data["permissions"]["allow"])
+        for tool in _PHOEBUS_ALLOW:
+            assert f"mcp__phoebus2__{tool}" in allow
+        assert "mcp__phoebus2__phoebus_drive" not in allow
+        assert set(data["permissions"]["ask"]) >= {
+            "mcp__phoebus__phoebus_drive",
+            "mcp__phoebus2__phoebus_drive",
+        }
+
+        pre = data["hooks"]["PreToolUse"]
+        drive_rules = [r for r in pre if r["matcher"] == "mcp__phoebus2__phoebus_drive"]
+        assert len(drive_rules) == 1
+        assert any("osprey_approval.py" in h["command"] for h in drive_rules[0]["hooks"])
+        # Drive-only gating: no wildcard pre rule for the clone.
+        assert not any(r["matcher"] == "mcp__phoebus2__.*" for r in pre)
+        # The clone contributes no duplicate template-prefixed rule.
+        assert sum(1 for r in pre if r["matcher"] == "mcp__phoebus__phoebus_drive") == 1
+
+    def test_render_mcp_json_with_extends(self, template_manager):
+        """.mcp.json: clone block equals the old framework rendering — python
+        -m osprey.mcp_server.phoebus with ${...} env preserved literally."""
+        ctx = self._full_ctx(_claude_code_config=self._EXTENDS_CFG)
+        rendered = self._render(template_manager, "claude_code/mcp.json.j2", ctx)
+        data = json.loads(rendered)
+        p2 = data["mcpServers"]["phoebus2"]
+        assert p2["command"] == "/usr/bin/python3"
+        assert p2["args"] == ["-m", "osprey.mcp_server.phoebus"]
+        assert p2["env"]["PHOEBUS_BRIDGE_URL"] == "${PHOEBUS2_BRIDGE_URL:-http://127.0.0.1:7980}"
+        assert p2["env"]["OSPREY_CONFIG"] == "/tmp/test-project/config.yml"
+
+    def test_render_hook_config_json_with_extends(self, template_manager):
+        """hook_config.json: both phoebus prefixes land in server_prefixes and
+        approval_prefixes (landmine D — templates are generic over s.name)."""
+        ctx = self._full_ctx(_claude_code_config=self._EXTENDS_CFG)
+        rendered = self._render(
+            template_manager, "claude_code/claude/hooks/hook_config.json.j2", ctx
+        )
+        data = json.loads(rendered)
+        for prefix in ("mcp__phoebus__", "mcp__phoebus2__"):
+            assert prefix in data["server_prefixes"]
+            assert prefix in data["approval_prefixes"]
+
+    def test_render_settings_json_extends_remove_ask_interplay(self, template_manager):
+        """facility remove_ask drops the clone's ask entry but the PreToolUse
+        approval matcher survives (the hook is independent of the ask list)."""
+        ctx = self._full_ctx(_claude_code_config=self._EXTENDS_CFG)
+        ctx["facility_permissions"] = {"remove_ask": ["mcp__phoebus2__phoebus_drive"]}
+        rendered = self._render(template_manager, "claude_code/claude/settings.json.j2", ctx)
+        data = json.loads(rendered)
+        assert "mcp__phoebus2__phoebus_drive" not in data["permissions"]["ask"]
+        assert "mcp__phoebus__phoebus_drive" in data["permissions"]["ask"]
+        pre_matchers = [r["matcher"] for r in data["hooks"]["PreToolUse"]]
+        assert "mcp__phoebus2__phoebus_drive" in pre_matchers

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,8 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-28T00:00:00Z"
+exclude-newer = "2026-06-22T03:11:24.832859Z"
+exclude-newer-span = "P7D"
 
 [[package]]
 name = "accelerator-toolbox"
@@ -433,6 +434,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
     { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
     { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
+]
+
+[[package]]
+name = "caproto"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/0a/6d6cb9d632b283e6215da216d5987763c043fe2a8d9c48a3ea7ab91b77b4/caproto-1.3.0.tar.gz", hash = "sha256:ea74f433297e895695c80a706a2389f745a94d756b5835c80af73af3df585cba", size = 452074, upload-time = "2025-09-03T21:02:00.662Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/bd/4d1f59c9287ec5f93f9d879db3ac06785ba7c4d04a7120678d894e0c53d0/caproto-1.3.0-py3-none-any.whl", hash = "sha256:fa623c4a7d7c3537fc41ce023b7c72922b8819ab88bf9abc527e3ac594634180", size = 407021, upload-time = "2025-09-03T21:01:59.169Z" },
 ]
 
 [[package]]
@@ -2980,6 +2990,7 @@ dependencies = [
     { name = "aiohttp-socks" },
     { name = "anthropic" },
     { name = "bokeh" },
+    { name = "caproto" },
     { name = "certifi" },
     { name = "charset-normalizer" },
     { name = "claude-agent-sdk" },
@@ -3119,6 +3130,7 @@ requires-dist = [
     { name = "bokeh", specifier = ">=3.0" },
     { name = "build", marker = "extra == 'all'" },
     { name = "build", marker = "extra == 'dev'" },
+    { name = "caproto", specifier = ">=1.3.0" },
     { name = "certifi", specifier = ">=2025.4.26" },
     { name = "charset-normalizer", specifier = ">=3.4.2" },
     { name = "claude-agent-sdk", specifier = "==0.2.106" },


### PR DESCRIPTION
## Summary

Lands the **site-agnostic** Phoebus agent-bridge capability on `main` as a curated PR: a native `phoebus` MCP server whose tools perceive / drive / open live Phoebus control panels through an in-JVM HTTP bridge. Framework code carries **no facility specifics** — any site wires its own gateway/panels via a build profile.

## What's included

- `src/osprey/mcp_server/phoebus/` — the phoebus MCP server + `bridge_tools.py` (perceive, perceive_region, snapshot, drive, open_panel, list_displays).
- **Require-handle addressing** (`PHOEBUS_REQUIRE_HANDLE` env / `phoebus.require_handle` config, **OFF by default**): on a backend shared by multiple terminals, rejects the implicit process-global `"active"` display so reads/drives can't race across terminals. Off by default keeps the standalone single-user demo unchanged.
- The `extends` registry mechanism (`registry/mcp.py`, `write_tools.py`, `cli/templates/claude_code.py`) for declaring a second instance of a framework server.
- `phoebus-standalone` preset, the `phoebus-walkthrough` skill, facility-config docs, and the de-ALS'd `demos/phoebus/` (soft-IOC demo + headless launcher; gateway/JDK sourced from env, no baked-in facility values).
- Unit / registry / cli / e2e tests.

## Curation notes (why this isn't a whole-branch merge)

The source demo branch commingled unrelated **ariel/dispatch** changes inside otherwise-phoebus commits. This PR was assembled by **file surface**, not by commit: every phoebus file is included, and the commingled ariel/dispatch files are excluded. `web_terminal/app.py` was deliberately excluded — main's `app_name` feature post-dates the demo branch and a whole-file take would have reverted it.

## Verification (local, on this branch)

- `pytest` collects **5,446 tests tree-wide with zero import errors** (landing phoebus on main breaks nothing).
- Broad sweep (`tests/mcp_server tests/registry tests/cli`): **1,969 passed**.
- Phoebus surface (`test_phoebus_tools.py`, `test_mcp.py`, cli, preset, write_tools): **274 passed**.
- `grep` for `cagw-alsdmz` / `GTLView` / `appsdev2` / `/home/als` under `src/osprey`: **clean** (no facility values in framework code).

## Tasks

Includes Task 0.1 (de-ALS framework hygiene) and Task 0.2 (require-handle enforcement, tested both flag states).