### PR TITLE
fix(templates): derive enable-able builtin panels from BUILTIN_PANELS

### DIFF
--- a/src/osprey/cli/templates/manager.py
+++ b/src/osprey/cli/templates/manager.py
@@ -13,6 +13,7 @@ from osprey.cli.styles import console
 from osprey.cli.templates import claude_code, manifest, scaffolding
 from osprey.cli.templates._rendering import render_template as _render_template
 from osprey.errors import BuildProfileError
+from osprey.profiles.web_panels import BUILTIN_PANELS
 from osprey.utils.config import resolve_env_vars
 
 
@@ -213,6 +214,11 @@ class TemplateManager:
             "data_bundle": data_bundle,
             "selected_hooks": selected_hooks,
             "selected_web_panels": selected_web_panels,
+            # Enable-able builtin panel registry (single source of truth in
+            # osprey.profiles.web_panels). Templates derive their enable list
+            # from this so it can't drift from the real registry. sorted() for
+            # deterministic rendered output.
+            "builtin_panels": sorted(BUILTIN_PANELS),
             # Add detected environment variables
             "env": detected_env_vars,
             **(context or {}),

--- a/src/osprey/templates/apps/ariel_standalone/config.yml.j2
+++ b/src/osprey/templates/apps/ariel_standalone/config.yml.j2
@@ -234,7 +234,7 @@ claude_code:
 # Universal panels (Workspace, Activity, Session Analytics) are always shown.
 
 web:
-{%- set _BUILTIN_PANELS = ["ariel", "channel-finder", "tuning"] %}
+{%- set _BUILTIN_PANELS = builtin_panels | default(["ariel", "channel-finder", "tuning"]) %}
 {%- set _enabled_builtin_panels = selected_web_panels | select("in", _BUILTIN_PANELS) | list %}
 {%- if default_panel is defined and default_panel %}
   # Tab focused on cold load. Falls back to "artifacts" (Workspace) when unset.

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -602,7 +602,7 @@ claude_code:
 # Domain-specific panels are listed here — remove or disable as needed.
 
 web:
-{%- set _BUILTIN_PANELS = ["ariel", "channel-finder", "tuning"] %}
+{%- set _BUILTIN_PANELS = builtin_panels | default(["ariel", "channel-finder", "tuning"]) %}
 {%- set _enabled_builtin_panels = selected_web_panels | select("in", _BUILTIN_PANELS) | list %}
 {%- if default_panel is defined and default_panel %}
   # Tab focused on cold load. Falls back to "artifacts" (Workspace) when unset.

--- a/tests/cli/test_templates.py
+++ b/tests/cli/test_templates.py
@@ -598,5 +598,86 @@ def test_registry_style_parameter_is_gone():
     )
 
 
+class TestBuiltinPanelRegistryDrift:
+    """Enable-able builtin panels must derive from the BUILTIN_PANELS registry,
+    not a hardcoded template literal that drifts from it.
+
+    Discovered wiring the native ``okf`` KNOWLEDGE panel into BELLA + ALS: both
+    config templates hardcoded ``["ariel", "channel-finder", "tuning"]``, so a
+    profile listing a builtin the literal omitted (``okf`` or ``lattice``) in its
+    ``web_panels`` got filtered out at build time → no ``web.panels.okf`` stanza
+    → the runtime never enabled the tab and it silently never rendered. BELLA/ALS
+    worked around it with an explicit ``web.panels.okf.enabled: true`` override.
+    """
+
+    PANEL_TEMPLATES = [
+        "apps/control_assistant/config.yml.j2",
+        "apps/ariel_standalone/config.yml.j2",
+    ]
+
+    @pytest.mark.parametrize("template_path", PANEL_TEMPLATES)
+    def test_registry_injected_enables_builtin_absent_from_old_literal(self, template_path):
+        """With the registry injected as ``builtin_panels``: a builtin the OLD
+        literal omitted (``okf``) gets a stanza, a builtin the literal contained
+        AND the profile lists (``tuning``) gets one, and a builtin the profile
+        does NOT list (``ariel``) does not."""
+        import yaml
+
+        from osprey.profiles.web_panels import BUILTIN_PANELS
+
+        manager = TemplateManager()
+        template = manager.jinja_env.get_template(template_path)
+        rendered = template.render(
+            builtin_panels=sorted(BUILTIN_PANELS),
+            selected_web_panels=["okf", "tuning"],
+        )
+        panels = yaml.safe_load(rendered)["web"]["panels"]
+
+        # okf: builtin NOT in the old hardcoded literal — the drift bug.
+        assert panels.get("okf", {}).get("enabled") is True, (
+            "okf builtin filtered out — enable list drifted from BUILTIN_PANELS"
+        )
+        # tuning: builtin that WAS in the old literal and IS listed — stanza present.
+        assert panels.get("tuning", {}).get("enabled") is True
+        # ariel: builtin but NOT listed in this profile's web_panels — no stanza.
+        assert "ariel" not in panels
+
+    @pytest.mark.parametrize("template_path", PANEL_TEMPLATES)
+    def test_fallback_literal_excludes_okf_when_registry_absent(self, template_path):
+        """Safety-net fallback: without ``builtin_panels`` in context the template
+        reverts to the old literal, which excludes ``okf``. Proves the fix is the
+        registry injection — okf is enabled only because the registry supplies it,
+        not by accident of an expanded literal."""
+        import yaml
+
+        manager = TemplateManager()
+        template = manager.jinja_env.get_template(template_path)
+        rendered = template.render(selected_web_panels=["okf", "tuning"])
+        panels = yaml.safe_load(rendered)["web"]["panels"]
+
+        assert "okf" not in panels  # old literal omits okf
+        assert panels.get("tuning", {}).get("enabled") is True
+
+    def test_create_project_enables_okf_builtin_panel(self, tmp_path):
+        """End-to-end: ``manager.py`` injects ``sorted(BUILTIN_PANELS)`` → template
+        enables ``okf``. Fails against the old hardcoded literal (which omitted
+        okf) and passes with the registry-derived context. This removes the need
+        for the ``web.panels.okf.enabled: true`` override BELLA/ALS carried."""
+        import yaml
+
+        manager = TemplateManager()
+        project_dir = manager.create_project(
+            project_name="okf-panel-e2e",
+            output_dir=tmp_path,
+            data_bundle="control_assistant",
+            artifacts={"web_panels": ["okf", "tuning"]},
+        )
+        panels = yaml.safe_load((project_dir / "config.yml").read_text())["web"]["panels"]
+
+        assert panels.get("okf", {}).get("enabled") is True
+        assert panels.get("tuning", {}).get("enabled") is True
+        assert "ariel" not in panels
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## The drift

Two config templates hardcoded the enable-able builtin-panel list, which had drifted from the real registry:

- `src/osprey/templates/apps/control_assistant/config.yml.j2`
- `src/osprey/templates/apps/ariel_standalone/config.yml.j2`

Both set `{%- set _BUILTIN_PANELS = ["ariel", "channel-finder", "tuning"] %}`, while the single source of truth `osprey.profiles.web_panels.BUILTIN_PANELS` is `{artifacts, ariel, tuning, channel-finder, lattice, okf}`.

Because **`okf` and `lattice`** were missing from the literal, a profile that listed either in its `web_panels:` got filtered out at build time -> no `web.panels.<id>` stanza in the rendered `config.yml` -> the runtime (`web_terminal/app.py::_load_panel_config`, which enables a builtin only if its id is a key under `web.panels`) never enabled the tab, so it **silently never rendered**.

This was discovered wiring the native `okf` KNOWLEDGE panel into the BELLA and ALS profiles. Both currently work around it with an explicit `web.panels.okf.enabled: true` override — **this PR removes the need for that workaround.**

## The fix

1. **`src/osprey/cli/templates/manager.py`** — inject the registry into the render context: `"builtin_panels": sorted(BUILTIN_PANELS)` (`sorted(...)` for deterministic output), importing `BUILTIN_PANELS` from `osprey.profiles.web_panels`.
2. **Both templates** — derive the enable list from context, keeping the old literal only as a safe fallback:
   ```jinja
   {%- set _BUILTIN_PANELS = builtin_panels | default(["ariel", "channel-finder", "tuning"]) %}
   ```
   The per-profile `select("in", _BUILTIN_PANELS)` filter is unchanged, so a stanza is still emitted only for panels a profile actually lists.

## The test

New `TestBuiltinPanelRegistryDrift` in `tests/cli/test_templates.py`:

- Renders **both** templates with the registry injected and asserts `web.panels.okf.enabled` is `true` (okf is a builtin absent from the old literal), that a listed builtin which *was* in the literal (`tuning`) still emits a stanza, and that a builtin the profile does *not* list (`ariel`) does not.
- Builds a project end-to-end (`create_project`) whose `web_panels` includes `okf` and asserts the same via the written `config.yml`.
- Pins the fallback behavior (old literal excludes `okf` when `builtin_panels` is absent), so the test proves okf is enabled *because* of the registry injection.

Verified these fail against the old hardcoded literal and pass with the fix.

## Verification

Focused suites, all green (59 passed):

```
pytest tests/cli/test_templates.py tests/cli/test_templates_allowlist.py \
       tests/registry/test_okf_panel_registration.py tests/cli/test_dockerfile_template.py
```