### PR TITLE
feat(phoebus): add phoebus_open_databrowser archiver-plot tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Added
 
-- **Native Phoebus control panels** — an optional `phoebus` MCP server lets the agent perceive a running [Phoebus](https://control-system-studio.readthedocs.io/) panel's widget tree, snapshot widgets, and drive controls (driving is approval-gated, like any hardware write). Off by default; enable with `claude_code.servers.phoebus.enabled: true` and configure the bridge and named panels via the `phoebus.*` config keys (see the build-deploy config schema). The Phoebus agent bridge itself is a facility build, not part of OSPREY.
+- **Native Phoebus control panels** — an optional `phoebus` MCP server lets the agent perceive a running [Phoebus](https://control-system-studio.readthedocs.io/) panel's widget tree, snapshot widgets, drive controls (driving is approval-gated, like any hardware write), and open live Data Browser archiver plots for a PV list and time range (`phoebus_open_databrowser`). Off by default; enable with `claude_code.servers.phoebus.enabled: true` and configure the bridge, named panels, and archiver via the `phoebus.*` config keys (see the build-deploy config schema). The Phoebus agent bridge itself is a facility build, not part of OSPREY.
 
 ### Fixed
 

--- a/src/osprey/mcp_server/phoebus/models.py
+++ b/src/osprey/mcp_server/phoebus/models.py
@@ -1,0 +1,140 @@
+"""Phoebus Data Browser data models.
+
+Pydantic models for configuring Data Browser plots, traces, and annotations.
+
+Migrated from the retired ``phoebus_launch`` server
+(``als-profiles/mcp_servers/phoebus/models.py``) as part of reincarnating its
+``.plt``-generation capability inside the native ``phoebus_open_databrowser``
+tool (see ``.claude/plans/phoebus-als-integration/ADDENDUM-databrowser-reincarnation.md``,
+Task 0.5). Facility-neutral: nothing here names a specific facility, archiver,
+or host — that binding is supplied by the caller (see ``plt_generator``).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class TraceType(Enum):
+    """Available trace types for Data Browser plots."""
+
+    LINE = "LINE"
+    AREA = "AREA"
+    STEP = "STEP"
+    BARS = "BARS"
+
+
+class LineStyle(Enum):
+    """Available line styles for traces."""
+
+    SOLID = "SOLID"
+    DASH = "DASH"
+    DOT = "DOT"
+    DASHDOT = "DASHDOT"
+
+
+class PointType(Enum):
+    """Available point types for traces."""
+
+    NONE = "NONE"
+    CIRCLE = "CIRCLE"
+    SQUARE = "SQUARE"
+    DIAMOND = "DIAMOND"
+    TRIANGLE = "TRIANGLE"
+
+
+class PVConfig(BaseModel):
+    """Configuration for a single PV trace in the Data Browser."""
+
+    name: str = Field(description="PV name (e.g., SR:DCCT)")
+    display_name: str | None = Field(
+        default=None, description="Human-readable display name for the PV"
+    )
+    color_red: int = Field(default=0, description="Red component of RGB color (0-255)")
+    color_green: int = Field(default=100, description="Green component of RGB color (0-255)")
+    color_blue: int = Field(default=200, description="Blue component of RGB color (0-255)")
+    trace_type: TraceType = Field(
+        default=TraceType.LINE, description="Type of trace (LINE, AREA, STEP, BARS)"
+    )
+    line_style: LineStyle = Field(
+        default=LineStyle.SOLID, description="Line style (SOLID, DASH, DOT, DASHDOT)"
+    )
+    line_width: int = Field(default=2, description="Line width in pixels")
+    point_type: PointType = Field(default=PointType.NONE, description="Point marker type")
+    point_size: int = Field(default=2, description="Point marker size")
+    axis: int = Field(default=0, description="Which axis to use (0=left, 1=right, etc.)")
+
+    @property
+    def color(self) -> tuple[int, int, int]:
+        """Get color as RGB tuple."""
+        return (self.color_red, self.color_green, self.color_blue)
+
+
+class TimeRange(BaseModel):
+    """Time range specification for the Data Browser."""
+
+    start: str | datetime = Field(
+        description="Start time - can be datetime, 'now', '-2 hours', etc."
+    )
+    end: str | datetime = Field(description="End time - can be datetime, 'now', etc.")
+
+
+class AnnotationConfig(BaseModel):
+    """Configuration for a plot annotation."""
+
+    text: str = Field(description="Annotation text content")
+    time_position: str | datetime = Field(description="Time position for annotation")
+    value_position: float = Field(description="Value position for annotation")
+    offset_x: float = Field(default=20.0, description="X offset from position")
+    offset_y: float = Field(default=20.0, description="Y offset from position")
+    pv_index: int = Field(default=0, description="Index of PV this annotation refers to")
+
+
+class PlotConfig(BaseModel):
+    """High-level configuration for a Data Browser plot."""
+
+    title: str = Field(description="Title for the plot")
+    pvs: list[PVConfig] = Field(description="List of PV configurations to plot")
+    time_range: TimeRange | None = Field(default=None, description="Time range for the plot")
+    annotations: list[AnnotationConfig] = Field(
+        default_factory=list, description="Plot annotations"
+    )
+
+    # Plot appearance
+    background_red: int = Field(default=255, description="Background red component (0-255)")
+    background_green: int = Field(default=255, description="Background green component (0-255)")
+    background_blue: int = Field(default=255, description="Background blue component (0-255)")
+    foreground_red: int = Field(default=0, description="Foreground red component (0-255)")
+    foreground_green: int = Field(default=0, description="Foreground green component (0-255)")
+    foreground_blue: int = Field(default=0, description="Foreground blue component (0-255)")
+    show_grid: bool = Field(default=True, description="Whether to show grid lines")
+    show_legend: bool = Field(default=True, description="Whether to show legend")
+    show_toolbar: bool = Field(default=True, description="Whether to show toolbar")
+
+    # Time axis
+    scroll: bool = Field(default=True, description="Whether to enable scrolling")
+    update_period: float = Field(default=3.0, description="Update period in seconds")
+
+    # Axis configuration
+    axis_name: str = Field(default="Values", description="Name for the axis")
+    auto_scale: bool = Field(default=True, description="Whether to auto-scale the axis")
+    axis_min: float | None = Field(
+        default=None, description="Minimum axis value (if not auto-scale)"
+    )
+    axis_max: float | None = Field(
+        default=None, description="Maximum axis value (if not auto-scale)"
+    )
+    log_scale: bool = Field(default=False, description="Whether to use logarithmic scale")
+
+    @property
+    def background_color(self) -> tuple[int, int, int]:
+        """Get background color as RGB tuple."""
+        return (self.background_red, self.background_green, self.background_blue)
+
+    @property
+    def foreground_color(self) -> tuple[int, int, int]:
+        """Get foreground color as RGB tuple."""
+        return (self.foreground_red, self.foreground_green, self.foreground_blue)

--- a/src/osprey/mcp_server/phoebus/plt_generator.py
+++ b/src/osprey/mcp_server/phoebus/plt_generator.py
@@ -1,0 +1,239 @@
+"""PLT file generator for Phoebus Data Browser.
+
+Generates Data Browser XML (``.plt``) files from ``PlotConfig`` objects.
+
+Migrated from the retired ``phoebus_launch`` server
+(``als-profiles/mcp_servers/phoebus/plt_generator.py``) as the reincarnated
+capability inside ``phoebus_open_databrowser`` — see
+``.claude/plans/phoebus-als-integration/ADDENDUM-databrowser-reincarnation.md``,
+Task 0.5. The ``.plt`` XML serializer and archiver ``<archive>`` binding are
+kept verbatim; two things were dropped on migration:
+
+* ``create_launch_uri`` (the ``myapp://`` custom-scheme launcher) — nothing in
+  the live-open flow consumes it; the bridge ``POST /open`` opens the
+  generated ``.plt`` directly.
+* The hardcoded ALS archiver default. ``archiver_url`` now defaults to
+  ``None`` (no facility baked into framework code); the caller resolves it
+  from config/env (``phoebus.archiver_url`` — each facility profile supplies
+  its own archiver appliance URL). When no archiver URL is supplied, PVs are
+  emitted without an ``<archive>`` binding (live-only data, no historical
+  backfill) rather than silently pointing at a facility that may not exist.
+"""
+
+from __future__ import annotations
+
+import html
+import logging
+import os
+import re
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from .models import PlotConfig
+
+logger = logging.getLogger(__name__)
+
+
+def sanitize_xml_text(text: str) -> str:
+    """Sanitize text for safe inclusion in XML content.
+
+    Removes control characters, replaces problematic Unicode, and applies
+    HTML escaping for XML special characters.
+    """
+    if not text:
+        return ""
+
+    # Replace common problematic characters
+    text = text.replace("°", "deg")
+    text = text.replace("μ", "u")
+    text = text.replace("²", "2")
+    text = text.replace("³", "3")
+
+    # Remove control characters (ASCII 0-31 except tab, newline, carriage return)
+    text = re.sub(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]", "", text)
+
+    # Normalize temperature patterns
+    text = re.sub(r"\b0C\b", "degC", text)
+    text = re.sub(r"\bdeg\s*C\b", "degC", text)
+
+    # Apply HTML escaping for XML special characters
+    text = html.escape(text)
+
+    return text
+
+
+def create_plt_from_config(
+    plot_config: PlotConfig,
+    workspace_dir: Path,
+    archiver_url: str | None = None,
+) -> str:
+    """Generate a PLT file from a PlotConfig and return the file path.
+
+    Args:
+        plot_config: Plot configuration to render.
+        workspace_dir: Directory to write the .plt file into.
+        archiver_url: Archiver appliance URL for PV data retrieval. Facility-
+            neutral: no default is baked in here — pass ``None`` (the
+            default) to omit the ``<archive>`` binding entirely, or supply a
+            facility's archiver URL (e.g. resolved from
+            ``phoebus.archiver_url`` in config.yml).
+
+    Returns:
+        Absolute path to the created .plt file.
+    """
+    os.makedirs(workspace_dir, exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    temp_fd, temp_path = tempfile.mkstemp(
+        suffix=".plt",
+        prefix=f"{timestamp}_phoebus_databrowser_",
+        dir=workspace_dir,
+    )
+
+    # Format time range
+    if plot_config.time_range:
+        if isinstance(plot_config.time_range.start, datetime):
+            start_str = plot_config.time_range.start.strftime("%Y-%m-%d %H:%M:%S.000")
+        else:
+            start_str = str(plot_config.time_range.start)
+
+        if isinstance(plot_config.time_range.end, datetime):
+            end_str = plot_config.time_range.end.strftime("%Y-%m-%d %H:%M:%S.999")
+        else:
+            end_str = str(plot_config.time_range.end)
+    else:
+        end_time = datetime.now()
+        start_time = end_time - timedelta(hours=24)
+        start_str = start_time.strftime("%Y-%m-%d %H:%M:%S.000")
+        end_str = end_time.strftime("%Y-%m-%d %H:%M:%S.999")
+
+    bg = plot_config.background_color
+    fg = plot_config.foreground_color
+
+    xml_content = f"""<?xml version="1.0" encoding="UTF-8"?>
+<databrowser>
+  <title>{sanitize_xml_text(plot_config.title)}</title>
+  <show_toolbar>{str(plot_config.show_toolbar).lower()}</show_toolbar>
+  <show_legend>{str(plot_config.show_legend).lower()}</show_legend>
+  <update_period>{plot_config.update_period}</update_period>
+  <scroll_step>5</scroll_step>
+  <scroll>{str(plot_config.scroll).lower()}</scroll>
+  <start>{sanitize_xml_text(start_str)}</start>
+  <end>{sanitize_xml_text(end_str)}</end>
+  <archive_rescale>STAGGER</archive_rescale>
+  <foreground>
+    <red>{fg[0]}</red>
+    <green>{fg[1]}</green>
+    <blue>{fg[2]}</blue>
+  </foreground>
+  <background>
+    <red>{bg[0]}</red>
+    <green>{bg[1]}</green>
+    <blue>{bg[2]}</blue>
+  </background>
+  <title_font>Liberation Sans|16|1</title_font>
+  <label_font>Liberation Sans|12|0</label_font>
+  <scale_font>Liberation Sans|10|0</scale_font>
+  <legend_font>Liberation Sans|12|0</legend_font>
+  <axes>
+    <axis>
+      <visible>true</visible>
+      <name>{sanitize_xml_text(plot_config.axis_name)}</name>
+      <use_axis_name>true</use_axis_name>
+      <use_trace_names>true</use_trace_names>
+      <right>false</right>
+      <color>
+        <red>{fg[0]}</red>
+        <green>{fg[1]}</green>
+        <blue>{fg[2]}</blue>
+      </color>"""
+
+    if plot_config.axis_min is not None and plot_config.axis_max is not None:
+        xml_content += f"""
+      <min>{plot_config.axis_min}</min>
+      <max>{plot_config.axis_max}</max>"""
+    else:
+        xml_content += """
+      <min>0.0</min>
+      <max>100.0</max>"""
+
+    xml_content += f"""
+      <grid>{str(plot_config.show_grid).lower()}</grid>
+      <autoscale>{str(plot_config.auto_scale).lower()}</autoscale>
+      <log_scale>{str(plot_config.log_scale).lower()}</log_scale>
+    </axis>
+  </axes>
+  <pvlist>"""
+
+    for pv in plot_config.pvs:
+        display_name = pv.display_name or pv.name
+        color = pv.color
+
+        archive_block = ""
+        if archiver_url:
+            archive_block = f"""
+      <archive>
+        <name>archappl</name>
+        <url>{archiver_url}</url>
+        <key>1</key>
+      </archive>"""
+
+        xml_content += f"""
+    <pv>
+      <display_name>{sanitize_xml_text(display_name)}</display_name>
+      <visible>true</visible>
+      <name>{sanitize_xml_text(pv.name)}</name>
+      <axis>{pv.axis}</axis>
+      <color>
+        <red>{color[0]}</red>
+        <green>{color[1]}</green>
+        <blue>{color[2]}</blue>
+      </color>
+      <trace_type>{pv.trace_type.value}</trace_type>
+      <linewidth>{pv.line_width}</linewidth>
+      <line_style>{pv.line_style.value}</line_style>
+      <point_type>{pv.point_type.value}</point_type>
+      <point_size>{pv.point_size}</point_size>
+      <waveform_index>0</waveform_index>
+      <period>0.0</period>
+      <ring_size>5000</ring_size>
+      <request>OPTIMIZED</request>{archive_block}
+    </pv>"""
+
+    xml_content += """
+  </pvlist>"""
+
+    if plot_config.annotations:
+        xml_content += """
+  <annotations>"""
+
+        for annotation in plot_config.annotations:
+            if isinstance(annotation.time_position, datetime):
+                time_str = annotation.time_position.strftime("%Y-%m-%d %H:%M:%S.000")
+            else:
+                time_str = str(annotation.time_position)
+
+            xml_content += f"""
+    <annotation>
+      <pv>{annotation.pv_index}</pv>
+      <time>{sanitize_xml_text(time_str)}</time>
+      <value>{annotation.value_position}</value>
+      <offset>
+        <x>{annotation.offset_x}</x>
+        <y>{annotation.offset_y}</y>
+      </offset>
+      <text>{sanitize_xml_text(annotation.text)}</text>
+    </annotation>"""
+
+        xml_content += """
+  </annotations>"""
+
+    xml_content += """
+</databrowser>"""
+
+    with os.fdopen(temp_fd, "w") as f:
+        f.write(xml_content)
+
+    logger.info("Created PLT file: %s", temp_path)
+    return temp_path

--- a/src/osprey/mcp_server/phoebus/server.py
+++ b/src/osprey/mcp_server/phoebus/server.py
@@ -18,7 +18,9 @@ mcp = FastMCP(
     instructions=(
         "Perceive and drive live Phoebus control panels: list open displays, "
         "read the widget tree with PV values, snapshot a widget as PNG, and "
-        "click/type into widgets via synthetic GUI events or the semantic PV path."
+        "click/type into widgets via synthetic GUI events or the semantic PV path. "
+        "Also brings up live Data Browser archiver plots for a PV list + time "
+        "range via phoebus_open_databrowser."
     ),
 )
 
@@ -42,7 +44,10 @@ def create_server() -> FastMCP:
 
     # Import tool modules (each registers itself via @mcp.tool())
     with startup_timer("tool_imports"):
-        from osprey.mcp_server.phoebus.tools import bridge_tools  # noqa: F401
+        from osprey.mcp_server.phoebus.tools import (
+            bridge_tools,  # noqa: F401
+            databrowser_tools,  # noqa: F401
+        )
 
     logger.info("Phoebus MCP server initialised with all tools registered")
     return mcp

--- a/src/osprey/mcp_server/phoebus/tools/databrowser_tools.py
+++ b/src/osprey/mcp_server/phoebus/tools/databrowser_tools.py
@@ -1,0 +1,376 @@
+"""MCP tool: bring up a live Phoebus Data Browser for a PV list + time range.
+
+Reincarnates the ``.plt``-generation capability of the retired
+``phoebus_launch`` server (``als-profiles/mcp_servers/phoebus/``) as a
+first-class action of the native Phoebus agent — see
+``.claude/plans/phoebus-als-integration/ADDENDUM-databrowser-reincarnation.md``,
+Task 0.5. Two things changed on migration:
+
+* The embedded LLM styling call is gone. The calling agent is already an LLM
+  — it supplies styling as structured tool arguments (``styling=``) instead
+  of a natural-language ``query`` that used to be sent to a second model.
+* Live-open instead of a ``myapp://`` hand-off. This tool writes a styled
+  ``.plt`` into the workspace (reusing ``plt_generator``) and POSTs its
+  *content* to the agent bridge's ``POST /open`` — the same bridge-client
+  path ``phoebus_open_panel`` uses (``bridge_tools._http_post_open``) — so
+  the Data Browser opens directly in the shared control-room Phoebus.
+
+Content over path (Gap-1): this tool runs in a web-terminal container that
+does not share a writable filesystem with the bridge's container, so the
+``.plt`` *path* written here is meaningless to the bridge. Instead, the
+generated XML is read back and POSTed as ``{"content": <xml>, "extension":
+"plt"}`` — the bridge writes its own temp file and opens that. The local
+``.plt`` written by ``plt_generator`` is kept only as a shareable artifact
+(``plt_file`` in the result, a path in *this* tool's own container) for the
+operator to inspect or download; the open no longer depends on it.
+
+Facility-neutral archiver binding: the archiver-appliance URL bound into the
+generated ``.plt`` is never hardcoded here — it is resolved from
+``PHOEBUS_ARCHIVER_URL`` (env) or ``phoebus.archiver_url`` (config.yml), and
+omitted entirely (live-only PVs, no historical backfill) when neither is set.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from enum import Enum
+from pathlib import Path
+from typing import Any, TypeVar, cast
+
+import anyio
+from pydantic import ValidationError
+
+from osprey.mcp_server.errors import make_error
+from osprey.mcp_server.http import notify_panel_focus
+from osprey.mcp_server.phoebus import plt_generator
+from osprey.mcp_server.phoebus.models import (
+    AnnotationConfig,
+    LineStyle,
+    PlotConfig,
+    PointType,
+    PVConfig,
+    TimeRange,
+    TraceType,
+)
+from osprey.mcp_server.phoebus.server import mcp
+from osprey.mcp_server.phoebus.tools.bridge_tools import (
+    _UNREACHABLE_HINTS,
+    _bridge_error_message,
+    _http_post_open,
+)
+from osprey.utils.workspace import load_osprey_config
+
+logger = logging.getLogger("osprey.mcp_server.tools.phoebus_databrowser")
+
+_EnumT = TypeVar("_EnumT", bound=Enum)
+
+# Default color palette for multiple PVs — parity with the retired server's
+# DEFAULT_COLORS rotation (phoebus_launch.py).
+_DEFAULT_COLORS: list[tuple[int, int, int]] = [
+    (0, 100, 200),  # Blue
+    (200, 0, 0),  # Red
+    (0, 150, 0),  # Green
+    (200, 100, 0),  # Orange
+    (150, 0, 150),  # Purple
+    (0, 150, 150),  # Teal
+    (150, 150, 0),  # Olive
+    (100, 100, 100),  # Gray
+]
+
+_MAX_TITLE_CHANNELS = 5  # channels named in the auto-generated title before "+N more"
+
+
+def _archiver_url() -> str | None:
+    """Resolve the archiver-appliance URL bound into generated ``.plt`` files.
+
+    Facility-neutral: no default archiver is baked in here (see module
+    docstring). Resolution order:
+
+    1. ``PHOEBUS_ARCHIVER_URL`` env var — wins outright when set.
+    2. ``phoebus.archiver_url`` in config.yml.
+    3. ``None`` — PVs are emitted without an ``<archive>`` binding.
+    """
+    env = os.environ.get("PHOEBUS_ARCHIVER_URL", "").strip()
+    if env:
+        return env
+    config = load_osprey_config()
+    value = config.get("phoebus", {}).get("archiver_url")
+    return str(value) if value else None
+
+
+def _plot_dir() -> Path:
+    """Resolve the directory generated ``.plt`` files are written to."""
+    config = load_osprey_config()
+    out = Path(config.get("phoebus", {}).get("plot_dir", "./_agent_data/plots"))
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def _default_title(channels: list[str]) -> str:
+    if len(channels) <= _MAX_TITLE_CHANNELS:
+        names = ", ".join(channels)
+    else:
+        shown = ", ".join(channels[:_MAX_TITLE_CHANNELS])
+        names = f"{shown} +{len(channels) - _MAX_TITLE_CHANNELS} more"
+    return f"Data Browser: {names}"
+
+
+def _coerce_color(value: object, field: str) -> tuple[int, int, int]:
+    """Validate a styling color value: a 3-element ``[r, g, b]`` sequence of
+    ints in 0-255. Raises ``ValueError`` naming *field* on any mismatch."""
+    try:
+        r, g, b = cast("tuple[Any, Any, Any]", value)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"'{field}' must be a 3-element [r, g, b] sequence, got {value!r}."
+        ) from None
+    for component, axis_name in ((r, "r"), (g, "g"), (b, "b")):
+        if (
+            isinstance(component, bool)
+            or not isinstance(component, int)
+            or not (0 <= component <= 255)
+        ):
+            raise ValueError(f"'{field}.{axis_name}' must be an int in 0-255, got {component!r}.")
+    return (r, g, b)
+
+
+def _coerce_enum(enum_cls: type[_EnumT], value: object, field: str) -> _EnumT:
+    """Coerce *value* to *enum_cls*, raising ``ValueError`` naming *field*
+    (with the valid choices) instead of the enum's bare ``ValueError``."""
+    try:
+        return enum_cls(value)
+    except ValueError:
+        valid = ", ".join(m.value for m in enum_cls)
+        raise ValueError(f"'{field}' must be one of {valid}, got {value!r}.") from None
+
+
+def _build_plot_config(
+    channels: list[str],
+    title: str | None,
+    start_time: str,
+    end_time: str,
+    styling: dict | None,
+) -> PlotConfig:
+    """Translate tool arguments into a ``PlotConfig``, applying the retired
+    server's defaults (color rotation, appearance) wherever ``styling``
+    leaves a value unspecified.
+
+    Raises ``ValueError`` (naming the offending ``styling`` field) on any
+    malformed sub-field — enum coercion, color tuples, or
+    ``AnnotationConfig`` construction — so the caller can turn it into a
+    clean ``validation_error`` envelope instead of a raw pydantic/enum
+    exception.
+    """
+    styling = styling or {}
+    per_pv: dict = styling.get("pvs", {})
+
+    pvs: list[PVConfig] = []
+    for i, name in enumerate(channels):
+        pv_style: dict = per_pv.get(name, {})
+        field_prefix = f"pvs.{name}"
+        color = pv_style.get("color")
+        color = (
+            _DEFAULT_COLORS[i % len(_DEFAULT_COLORS)]
+            if color is None
+            else _coerce_color(color, f"{field_prefix}.color")
+        )
+        try:
+            pvs.append(
+                PVConfig(
+                    name=name,
+                    display_name=pv_style.get("display_name", name),
+                    color_red=color[0],
+                    color_green=color[1],
+                    color_blue=color[2],
+                    trace_type=_coerce_enum(
+                        TraceType,
+                        pv_style.get("trace_type", TraceType.LINE.value),
+                        f"{field_prefix}.trace_type",
+                    ),
+                    line_style=_coerce_enum(
+                        LineStyle,
+                        pv_style.get("line_style", LineStyle.SOLID.value),
+                        f"{field_prefix}.line_style",
+                    ),
+                    line_width=pv_style.get("line_width", 2),
+                    point_type=_coerce_enum(
+                        PointType,
+                        pv_style.get("point_type", PointType.NONE.value),
+                        f"{field_prefix}.point_type",
+                    ),
+                    point_size=pv_style.get("point_size", 2),
+                    axis=pv_style.get("axis", 0),
+                )
+            )
+        except ValidationError as exc:
+            raise ValueError(f"Invalid styling for '{field_prefix}': {exc}") from exc
+
+    bg = _coerce_color(styling.get("background", (255, 255, 255)), "background")
+    fg = _coerce_color(styling.get("foreground", (0, 0, 0)), "foreground")
+
+    annotations: list[AnnotationConfig] = []
+    for idx, annotation in enumerate(styling.get("annotations", [])):
+        field = f"annotations[{idx}]"
+        try:
+            annotations.append(AnnotationConfig(**annotation))
+        except (ValidationError, TypeError) as exc:
+            raise ValueError(f"Invalid styling for '{field}': {exc}") from exc
+
+    try:
+        return PlotConfig(
+            title=title or _default_title(channels),
+            pvs=pvs,
+            time_range=TimeRange(start=start_time, end=end_time),
+            annotations=annotations,
+            background_red=bg[0],
+            background_green=bg[1],
+            background_blue=bg[2],
+            foreground_red=fg[0],
+            foreground_green=fg[1],
+            foreground_blue=fg[2],
+            show_grid=styling.get("show_grid", True),
+            show_legend=styling.get("show_legend", True),
+            show_toolbar=styling.get("show_toolbar", True),
+            scroll=styling.get("scroll", True),
+            update_period=styling.get("update_period", 3.0),
+            axis_name=styling.get("axis_name", "Values"),
+            auto_scale=styling.get("auto_scale", True),
+            axis_min=styling.get("axis_min"),
+            axis_max=styling.get("axis_max"),
+            log_scale=styling.get("log_scale", False),
+        )
+    except ValidationError as exc:
+        raise ValueError(f"Invalid styling: {exc}") from exc
+
+
+@mcp.tool()
+async def phoebus_open_databrowser(
+    channels: list[str],
+    start_time: str = "-24 hours",
+    end_time: str = "now",
+    title: str | None = None,
+    styling: dict | None = None,
+) -> str:
+    """Bring up a live Phoebus Data Browser for a PV list and time range.
+
+    Generates a styled Data Browser ``.plt`` (archiver-bound when an archiver
+    URL is configured) and opens it in the shared Phoebus via the agent
+    bridge's ``POST /open``, returning a handle so the result can be
+    perceived visually with ``phoebus_snapshot`` (a Data Browser is a JavaFX
+    chart, not a widget tree — ``phoebus_perceive``/``phoebus_drive`` do not
+    apply to it).
+
+    Args:
+        channels: List of PV/channel names to plot. Required, non-empty.
+        start_time: Start of the time range (e.g. ``"-24 hours"``,
+            ``"2024-01-01 00:00:00"``).
+        end_time: End of the time range (e.g. ``"now"``).
+        title: Plot title. Defaults to a title listing the channels.
+        styling: Optional structured styling, supplied by the calling agent
+            (no embedded LLM styling call is made here):
+            ``{"pvs": {"<channel>": {"color": [r,g,b], "display_name": str,
+            "trace_type": "LINE"|"AREA"|"STEP"|"BARS",
+            "line_style": "SOLID"|"DASH"|"DOT"|"DASHDOT", "line_width": int,
+            "point_type": "NONE"|"CIRCLE"|"SQUARE"|"DIAMOND"|"TRIANGLE",
+            "point_size": int, "axis": int}, ...},
+            "background": [r,g,b], "foreground": [r,g,b],
+            "show_grid": bool, "show_legend": bool, "show_toolbar": bool,
+            "scroll": bool, "update_period": float, "axis_name": str,
+            "auto_scale": bool, "axis_min": float, "axis_max": float,
+            "log_scale": bool, "annotations": [...]}``. Any key omitted uses
+            the retired server's original default.
+
+    Returns:
+        JSON ``{"status": "success", "handle": "handle:d-N", "plt_file":
+        "<path>", "id": "d-N", "ready": <bool>, "channel_count": <int>,
+        "focused": <bool>}``.
+        ``plt_file`` is a local copy in *this tool's own container* — a
+        shareable artifact for the operator, not the path the bridge opened
+        (the bridge is sent the ``.plt`` content directly; see module
+        docstring). ``focused`` reports whether the Web Terminal tab-focus
+        notification (best-effort, mirrors ``phoebus_open_panel``) succeeded.
+    """
+    if not channels:
+        make_error(
+            "validation_error",
+            "No channels provided.",
+            ["Pass at least one PV/channel name in 'channels'."],
+        )
+
+    try:
+        plot_config = _build_plot_config(channels, title, start_time, end_time, styling)
+    except ValueError as exc:
+        make_error(
+            "validation_error",
+            f"Invalid 'styling': {exc}",
+            [
+                "Check styling field types/values against the documented schema "
+                "(see the phoebus_open_databrowser docstring)."
+            ],
+        )
+
+    plt_path = plt_generator.create_plt_from_config(
+        plot_config,
+        workspace_dir=_plot_dir(),
+        archiver_url=_archiver_url(),
+    )
+    plt_content = Path(plt_path).read_text()
+
+    try:
+        status, body = await anyio.to_thread.run_sync(
+            _http_post_open, {"content": plt_content, "extension": "plt"}
+        )
+    except Exception as exc:
+        make_error(
+            "phoebus_unreachable",
+            f"Could not reach the Phoebus bridge: {exc}",
+            _UNREACHABLE_HINTS,
+        )
+
+    if status != 200:
+        make_error(
+            "phoebus_open_failed",
+            _bridge_error_message(body, status),
+            [
+                "Confirm the Phoebus bridge routes .plt resources to the Data "
+                "Browser application (app-aware POST /open)."
+            ],
+        )
+
+    display_id: str = body.get("id", "")
+    if not display_id:
+        make_error(
+            "phoebus_open_failed",
+            "Phoebus bridge returned a success response with no display id.",
+            ["This may indicate a bridge version mismatch; check the bridge logs."],
+        )
+
+    # Best-effort UX signal, mirroring phoebus_open_panel: switch the Web
+    # Terminal to this instance's panel tab so the operator sees the Data
+    # Browser they just opened. A missing/unreachable web terminal (CLI-only
+    # mode) must never turn a successful open into a failure.
+    focused = False
+    panel_id = os.environ.get("OSPREY_SERVER_NAME", "phoebus")
+    try:
+        await anyio.to_thread.run_sync(notify_panel_focus, panel_id)
+        focused = True
+    except Exception as exc:
+        logger.debug("panel focus notification failed (non-fatal): %s", exc)
+
+    return json.dumps(
+        {
+            "status": "success",
+            "handle": f"handle:{display_id}",
+            "plt_file": plt_path,
+            "id": display_id,
+            # No readiness poll here (unlike phoebus_open_panel): a Data
+            # Browser is a streaming chart, not a widget tree that
+            # perceive/drive would race against JavaFX model loading — the
+            # bridge's own "ready" is passed through as-is.
+            "ready": bool(body.get("ready", False)),
+            "channel_count": len(channels),
+            "focused": focused,
+        }
+    )

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -158,8 +158,10 @@ FRAMEWORK_SERVERS: dict[str, ServerDefinition] = {
             "phoebus_perceive",
             "phoebus_perceive_region",
             "phoebus_snapshot",
-            # Opening a display touches no PVs and actuates nothing — allow.
+            # Opening a display or a Data Browser plot touches no PVs and
+            # actuates nothing — allow.
             "phoebus_open_panel",
+            "phoebus_open_databrowser",
         ],
         # Driving a live panel actuates hardware-facing controls — gate on approval.
         permissions_ask=["phoebus_drive"],

--- a/tests/mcp_server/test_phoebus_databrowser.py
+++ b/tests/mcp_server/test_phoebus_databrowser.py
@@ -1,0 +1,202 @@
+"""Unit tests for the ``phoebus_open_databrowser`` MCP tool.
+
+The bridge HTTP boundary (``_http_post_open``, reused from ``bridge_tools``)
+is patched so these run with no Phoebus product, no bridge, and no network —
+per Task 0.5, live behavior depends on the app-aware ``/open`` routing
+(Task 0.6, built in parallel) and must not be required here.
+
+Gap-1 (content over path): the tool POSTs the generated ``.plt`` *content*
+to the bridge (not the local path), since the tool and the bridge may run in
+separate containers with no shared filesystem. ``plt_file`` in the result is
+still a locally-written copy — a shareable artifact — but is no longer what
+the bridge opens.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+from osprey.mcp_server.phoebus.tools import databrowser_tools
+from tests.mcp_server.conftest import assert_raises_error, extract_response_dict, get_tool_fn
+
+_MOD = "osprey.mcp_server.phoebus.tools.databrowser_tools"
+
+
+def _fn(name):
+    return get_tool_fn(getattr(databrowser_tools, name))
+
+
+def _open_databrowser():
+    return _fn("phoebus_open_databrowser")
+
+
+# ── input validation ────────────────────────────────────────────────────────
+async def test_empty_channels_raises_validation_error():
+    with assert_raises_error(error_type="validation_error") as ctx:
+        await _open_databrowser()(channels=[])
+    assert "No channels" in ctx["envelope"]["error_message"]
+
+
+async def test_malformed_styling_returns_validation_error(tmp_path, monkeypatch):
+    """A malformed styling sub-field (bad enum value, bad color tuple) must
+    surface as a clean validation_error envelope naming the bad field, not a
+    raw ValueError/pydantic ValidationError bubbling out of the tool."""
+    monkeypatch.chdir(tmp_path)
+    styling = {"pvs": {"SR:BPM:X": {"trace_type": "NOPE", "color": [0, 0]}}}
+    with assert_raises_error(error_type="validation_error") as ctx:
+        await _open_databrowser()(channels=["SR:BPM:X"], styling=styling)
+    msg = ctx["envelope"]["error_message"]
+    assert "SR:BPM:X" in msg
+    assert "color" in msg
+
+
+# ── success path / output shape ─────────────────────────────────────────────
+async def test_success_returns_handle_and_plt_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    body = {"id": "d-7", "resource": "ignored", "ready": True}
+    with patch(f"{_MOD}._http_post_open", return_value=(200, body)) as mock_open:
+        result = await _open_databrowser()(channels=["SR:DCCT"])
+
+    data = extract_response_dict(result)
+    assert data["status"] == "success"
+    assert data["handle"] == "handle:d-7"
+    assert data["id"] == "d-7"
+    assert data["ready"] is True
+    assert data["channel_count"] == 1
+    plt_file = Path(data["plt_file"])
+    assert plt_file.exists()
+    assert plt_file.suffix == ".plt"
+
+    posted = mock_open.call_args.args[0]
+    assert posted["extension"] == "plt"
+    assert posted["content"] == plt_file.read_text()
+    assert "resource" not in posted
+
+
+async def test_default_title_lists_channels(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    body = {"id": "d-1", "ready": True}
+    with patch(f"{_MOD}._http_post_open", return_value=(200, body)):
+        result = await _open_databrowser()(channels=["SR:A", "SR:B"])
+    data = extract_response_dict(result)
+    content = Path(data["plt_file"]).read_text()
+    assert "SR:A, SR:B" in content
+
+
+async def test_explicit_title_used_verbatim(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    body = {"id": "d-1", "ready": True}
+    with patch(f"{_MOD}._http_post_open", return_value=(200, body)):
+        result = await _open_databrowser()(channels=["SR:A"], title="Injector Health")
+    data = extract_response_dict(result)
+    content = Path(data["plt_file"]).read_text()
+    assert "<title>Injector Health</title>" in content
+
+
+# ── facility-neutral archiver default ───────────────────────────────────────
+async def test_no_archiver_configured_omits_archive_block(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PHOEBUS_ARCHIVER_URL", raising=False)
+    body = {"id": "d-1", "ready": True}
+    with patch(f"{_MOD}._http_post_open", return_value=(200, body)):
+        result = await _open_databrowser()(channels=["SR:DCCT"])
+    data = extract_response_dict(result)
+    content = Path(data["plt_file"]).read_text()
+    assert "<archive>" not in content
+
+
+async def test_configured_archiver_url_binds_into_plt(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(
+        yaml.dump({"phoebus": {"archiver_url": "pbraw://example-archiver.test/archappl_retrieve"}})
+    )
+    monkeypatch.setenv("OSPREY_CONFIG", str(config_file))
+    monkeypatch.delenv("PHOEBUS_ARCHIVER_URL", raising=False)
+
+    body = {"id": "d-1", "ready": True}
+    with patch(f"{_MOD}._http_post_open", return_value=(200, body)):
+        result = await _open_databrowser()(channels=["SR:DCCT"])
+    data = extract_response_dict(result)
+    content = Path(data["plt_file"]).read_text()
+    assert "pbraw://example-archiver.test/archappl_retrieve" in content
+
+
+async def test_env_archiver_url_wins_over_config(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(yaml.dump({"phoebus": {"archiver_url": "pbraw://from-config.test/x"}}))
+    monkeypatch.setenv("OSPREY_CONFIG", str(config_file))
+    monkeypatch.setenv("PHOEBUS_ARCHIVER_URL", "pbraw://from-env.test/x")
+
+    body = {"id": "d-1", "ready": True}
+    with patch(f"{_MOD}._http_post_open", return_value=(200, body)):
+        result = await _open_databrowser()(channels=["SR:DCCT"])
+    data = extract_response_dict(result)
+    content = Path(data["plt_file"]).read_text()
+    assert "pbraw://from-env.test/x" in content
+    assert "from-config.test" not in content
+
+
+# ── structured styling ──────────────────────────────────────────────────────
+async def test_per_pv_styling_applied(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    body = {"id": "d-1", "ready": True}
+    styling = {
+        "pvs": {
+            "SR:BPM:X": {
+                "color": [200, 0, 0],
+                "trace_type": "AREA",
+                "display_name": "Horizontal Position",
+                "axis": 1,
+            }
+        },
+        "show_grid": False,
+    }
+    with patch(f"{_MOD}._http_post_open", return_value=(200, body)):
+        result = await _open_databrowser()(channels=["SR:BPM:X"], styling=styling)
+    data = extract_response_dict(result)
+    content = Path(data["plt_file"]).read_text()
+    assert "Horizontal Position" in content
+    assert "<trace_type>AREA</trace_type>" in content
+    assert "<grid>false</grid>" in content
+
+
+async def test_default_color_rotation_when_no_styling(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    body = {"id": "d-1", "ready": True}
+    with patch(f"{_MOD}._http_post_open", return_value=(200, body)):
+        result = await _open_databrowser()(channels=["SR:A", "SR:B"])
+    data = extract_response_dict(result)
+    content = Path(data["plt_file"]).read_text()
+    # DEFAULT_COLORS[0] = (0, 100, 200), DEFAULT_COLORS[1] = (200, 0, 0)
+    assert "<red>0</red>\n        <green>100</green>\n        <blue>200</blue>" in content
+    assert "<red>200</red>\n        <green>0</green>\n        <blue>0</blue>" in content
+
+
+# ── bridge error paths ───────────────────────────────────────────────────────
+async def test_bridge_unreachable(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with patch(f"{_MOD}._http_post_open", side_effect=OSError("refused")):
+        with assert_raises_error(error_type="phoebus_unreachable"):
+            await _open_databrowser()(channels=["SR:DCCT"])
+
+
+async def test_bridge_error_status(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with patch(
+        f"{_MOD}._http_post_open",
+        return_value=(400, {"error": "unsupported resource type", "status": 400}),
+    ):
+        with assert_raises_error(error_type="phoebus_open_failed") as ctx:
+            await _open_databrowser()(channels=["SR:DCCT"])
+    assert "unsupported resource type" in ctx["envelope"]["error_message"]
+
+
+async def test_bridge_success_with_no_id_raises(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with patch(f"{_MOD}._http_post_open", return_value=(200, {"ready": True})):
+        with assert_raises_error(error_type="phoebus_open_failed") as ctx:
+            await _open_databrowser()(channels=["SR:DCCT"])
+    assert "no display id" in ctx["envelope"]["error_message"]

--- a/tests/mcp_server/test_phoebus_plt_generator.py
+++ b/tests/mcp_server/test_phoebus_plt_generator.py
@@ -1,0 +1,166 @@
+"""Unit tests for the migrated Phoebus Data Browser ``.plt`` generator.
+
+Structural-parity coverage for ``create_plt_from_config`` — the XML shape must
+match the retired ``phoebus_launch`` server's serializer (axis, per-PV
+color/trace/ring_size/request/<archive>, time span), and the archiver binding
+must be facility-neutral: no default archiver URL, and no ALS-specific string
+anywhere in the migrated source.
+"""
+
+from pathlib import Path
+
+import defusedxml.ElementTree as ET
+
+from osprey.mcp_server.phoebus import plt_generator
+from osprey.mcp_server.phoebus.models import (
+    LineStyle,
+    PlotConfig,
+    PointType,
+    PVConfig,
+    TimeRange,
+    TraceType,
+)
+
+
+def _minimal_config(**overrides) -> PlotConfig:
+    defaults = {
+        "title": "Test Plot",
+        "pvs": [PVConfig(name="SR:DCCT")],
+        "time_range": TimeRange(start="-24 hours", end="now"),
+    }
+    defaults.update(overrides)
+    return PlotConfig(**defaults)
+
+
+# ── facility-neutral hygiene ────────────────────────────────────────────────
+def test_no_facility_specific_strings_in_migrated_source():
+    """grep-clean: the migrated files must not bake in an ALS-specific host."""
+    for path in (
+        Path(plt_generator.__file__),
+        Path(plt_generator.__file__).with_name("models.py"),
+    ):
+        text = path.read_text()
+        assert "controls-web.als" not in text
+        assert "cagw-alsdmz" not in text
+        assert "/home/als" not in text
+
+
+def test_default_archiver_url_is_none_no_archive_block(tmp_path):
+    """With no archiver_url supplied, PVs are emitted without <archive> — no
+    facility default is baked into the generator."""
+    plt_path = plt_generator.create_plt_from_config(_minimal_config(), workspace_dir=tmp_path)
+    content = Path(plt_path).read_text()
+    assert "<archive>" not in content
+    assert "archappl" not in content
+
+
+def test_explicit_archiver_url_binds_into_archive_block(tmp_path):
+    plt_path = plt_generator.create_plt_from_config(
+        _minimal_config(),
+        workspace_dir=tmp_path,
+        archiver_url="pbraw://example-archiver.test/archappl_retrieve",
+    )
+    root = ET.fromstring(Path(plt_path).read_text())
+    archive = root.find("./pvlist/pv/archive")
+    assert archive is not None
+    assert archive.find("name").text == "archappl"
+    assert archive.find("url").text == "pbraw://example-archiver.test/archappl_retrieve"
+    assert archive.find("key").text == "1"
+
+
+# ── structural parity with the old serializer ──────────────────────────────
+def test_root_and_title(tmp_path):
+    plt_path = plt_generator.create_plt_from_config(
+        _minimal_config(title="My Plot"), workspace_dir=tmp_path
+    )
+    root = ET.fromstring(Path(plt_path).read_text())
+    assert root.tag == "databrowser"
+    assert root.find("title").text == "My Plot"
+
+
+def test_time_span_from_time_range(tmp_path):
+    plt_path = plt_generator.create_plt_from_config(
+        _minimal_config(time_range=TimeRange(start="-2 hours", end="now")),
+        workspace_dir=tmp_path,
+    )
+    root = ET.fromstring(Path(plt_path).read_text())
+    assert root.find("start").text == "-2 hours"
+    assert root.find("end").text == "now"
+
+
+def test_default_time_span_is_last_24_hours_when_no_time_range(tmp_path):
+    config = PlotConfig(title="No range", pvs=[PVConfig(name="SR:DCCT")], time_range=None)
+    plt_path = plt_generator.create_plt_from_config(config, workspace_dir=tmp_path)
+    root = ET.fromstring(Path(plt_path).read_text())
+    # Both start/end are formatted datetimes (not relative strings) when no
+    # time_range is given — parity with the old default-24h fallback.
+    assert root.find("start").text.count("-") >= 2
+    assert root.find("end").text.endswith(".999")
+
+
+def test_single_axis_block_with_name_and_grid(tmp_path):
+    plt_path = plt_generator.create_plt_from_config(
+        _minimal_config(axis_name="Beam Current", show_grid=False, log_scale=True),
+        workspace_dir=tmp_path,
+    )
+    root = ET.fromstring(Path(plt_path).read_text())
+    axes = root.findall("./axes/axis")
+    assert len(axes) == 1
+    axis = axes[0]
+    assert axis.find("name").text == "Beam Current"
+    assert axis.find("grid").text == "false"
+    assert axis.find("log_scale").text == "true"
+
+
+def test_per_pv_styling_and_ring_size_request(tmp_path):
+    pv = PVConfig(
+        name="SR:BPM:X",
+        display_name="Horizontal Position",
+        color_red=200,
+        color_green=0,
+        color_blue=0,
+        trace_type=TraceType.AREA,
+        line_style=LineStyle.DASH,
+        line_width=3,
+        point_type=PointType.CIRCLE,
+        point_size=4,
+        axis=1,
+    )
+    config = _minimal_config(pvs=[pv])
+    plt_path = plt_generator.create_plt_from_config(config, workspace_dir=tmp_path)
+    root = ET.fromstring(Path(plt_path).read_text())
+    pv_el = root.find("./pvlist/pv")
+    assert pv_el.find("display_name").text == "Horizontal Position"
+    assert pv_el.find("name").text == "SR:BPM:X"
+    assert pv_el.find("axis").text == "1"
+    assert pv_el.find("color/red").text == "200"
+    assert pv_el.find("trace_type").text == "AREA"
+    assert pv_el.find("line_style").text == "DASH"
+    assert pv_el.find("linewidth").text == "3"
+    assert pv_el.find("point_type").text == "CIRCLE"
+    assert pv_el.find("point_size").text == "4"
+    assert pv_el.find("ring_size").text == "5000"
+    assert pv_el.find("request").text == "OPTIMIZED"
+
+
+def test_multiple_pvs_each_get_a_pv_element(tmp_path):
+    config = _minimal_config(
+        pvs=[PVConfig(name="SR:A"), PVConfig(name="SR:B"), PVConfig(name="SR:C")]
+    )
+    plt_path = plt_generator.create_plt_from_config(config, workspace_dir=tmp_path)
+    root = ET.fromstring(Path(plt_path).read_text())
+    pv_els = root.findall("./pvlist/pv")
+    assert [p.find("name").text for p in pv_els] == ["SR:A", "SR:B", "SR:C"]
+
+
+def test_sanitize_xml_text_escapes_and_normalizes():
+    assert plt_generator.sanitize_xml_text("30°C & rising") == "30degC &amp; rising"
+    assert plt_generator.sanitize_xml_text("") == ""
+
+
+def test_file_written_under_workspace_dir_with_plt_suffix(tmp_path):
+    plt_path = plt_generator.create_plt_from_config(_minimal_config(), workspace_dir=tmp_path)
+    p = Path(plt_path)
+    assert p.exists()
+    assert p.suffix == ".plt"
+    assert p.parent == tmp_path

--- a/tests/registry/test_mcp.py
+++ b/tests/registry/test_mcp.py
@@ -262,10 +262,11 @@ _PHOEBUS_ALLOW = [
     "phoebus_perceive_region",
     "phoebus_snapshot",
     "phoebus_open_panel",
+    "phoebus_open_databrowser",
 ]
 
-# Only drive actuates hardware-facing controls; open_panel touches no PVs
-# and is plain-allowed — see the registry entry.
+# Only drive actuates hardware-facing controls; open_panel and open_databrowser
+# touch no PVs and are plain-allowed — see the registry entry.
 _PHOEBUS_ASK = ["phoebus_drive"]
 
 


### PR DESCRIPTION
## What & why

Adds a seventh native-Phoebus tool — **`phoebus_open_databrowser`** — that brings up a live Data Browser in the running Phoebus for a PV list and time range. This is the one genuinely valuable, facility-neutral capability that `main` lacked; it was forward-ported cleanly from the stale `feature/phoebus-capability-to-main` branch (which was 17 commits behind main and carried demo/ALS cruft — not merged).

The calling agent supplies plot styling as structured tool arguments; the tool generates a styled `.plt` and POSTs its **content** to the agent bridge's `/open` (the same path `phoebus_open_panel` uses), so it works even when the bridge and agent don't share a filesystem.

**Facility-neutral by construction:** the archiver-appliance URL bound into the `.plt` is resolved from `PHOEBUS_ARCHIVER_URL` (env) or `phoebus.archiver_url` (config.yml), and omitted entirely (live-only PVs, no historical backfill) when neither is set — nothing facility-specific is baked in. A guard test asserts ALS specifics never leak into generated output.

Opening a plot touches no PVs and actuates nothing, so the tool is **plain-allowed** in the `phoebus` server definition alongside `phoebus_open_panel` (this also closes the gap that forced als-profiles to add an anticipatory `permissions.allow` for the tool).

## Files
- `src/osprey/mcp_server/phoebus/models.py` — PlotConfig / styling pydantic models
- `src/osprey/mcp_server/phoebus/plt_generator.py` — Data Browser `.plt` XML generator
- `src/osprey/mcp_server/phoebus/tools/databrowser_tools.py` — the tool
- `server.py` + `registry/mcp.py` — register + allow the tool
- 2 new test files (tool + generator)

## Notes for review
- **Stacked on #324** (`fix/phoebus-remove-demo`) so this diff shows only the databrowser additions. Base will be retargeted to `main` once #324 merges.
- Cleaned up type/format debt the un-CI'd source branch carried (ruff-format + made the file mypy-clean via a `TypeVar`-generic `_coerce_enum`). No behavior change — tests pass.

## Verification
- Blast-radius suite (`tests/mcp_server tests/registry tests/cli tests/integration tests/agent_runner`): **2206 passed, 5 skipped, 0 failed**
- Server registers `phoebus_open_databrowser`; extends-clone golden-parity updated to include it
- ruff check/format clean; mypy clean on the phoebus module