### PR TITLE
fix: keep /v1 on translation-proxy upstream across all launch paths (#312)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- Anthropic-native providers configured with a `/v1` base URL (e.g. Argo via `api_protocol: anthropic`) no longer resolve to a doubled `…/v1/v1/messages`: the Claude-Code-facing `ANTHROPIC_BASE_URL` is stripped of a trailing `/v1` (Claude Code appends `/v1/messages` itself), while the translation-proxy upstream keeps its `/v1`. All four launch paths (CLI, web terminal, SDK runner, dispatch worker) now start the proxy from the resolved `upstream_base_url` field rather than the stripped env var, so OpenAI-compatible providers still forward to `…/v1/chat/completions` (#312).
 - Headless dispatch runs now enforce the trigger's `allowed_tools` as the single authority via a PreToolUse hook: project `settings.json` allow-rules and the approval hook's explicit allows can no longer widen a run's tool surface, and declared subagents (`.claude/agents/*.md`) work with exactly their declared tools — no trigger changes needed.
 - `osprey web --project X` launched from another directory now spawns the interactive terminal's Claude Code with `cwd = X`, so it reads `X/.mcp.json` and starts the project's MCP servers (the PTY path previously ignored `--project` and inherited the launch directory) (#313).
 

--- a/src/osprey/agent_runner/runner.py
+++ b/src/osprey/agent_runner/runner.py
@@ -109,14 +109,17 @@ async def run_query(
 
     # Non-native (OpenAI-protocol) providers need the in-process translation
     # proxy: repoint ANTHROPIC_BASE_URL at a loopback proxy that speaks
-    # Anthropic to the SDK and the provider's protocol upstream. The proxy auth
-    # token lives in the env dict here (provider_env_for_project injected it),
-    # not os.environ — see the os.environ-delivery variant in claude_cmd. The
-    # ANTHROPIC_BASE_URL guard mirrors claude_cmd so a base_url-less provider
-    # can't KeyError. In production this never fights the e2e proxy override:
+    # Anthropic to the SDK and the provider's protocol upstream. The proxy is
+    # started from spec.upstream_base_url — the OpenAI root *with* its /v1 —
+    # NOT from env["ANTHROPIC_BASE_URL"], which the resolver strips of /v1 for
+    # Claude Code (see claude_code_resolver); sourcing the upstream from the env
+    # var would forward to a /v1-less "…/chat/completions" (issue #312). The
+    # proxy auth token lives in the env dict here (provider_env_for_project
+    # injected it), not os.environ — see the os.environ-delivery variant in
+    # claude_cmd. In production this never fights the e2e proxy override:
     # run_query is production-only; the e2e harness uses run_sdk_query.
     spec = _resolve_project_spec(project_dir)
-    if spec and spec.needs_proxy and env.get("ANTHROPIC_BASE_URL"):
+    if spec and spec.needs_proxy and spec.upstream_base_url:
         auth_token = env.get(spec.auth_env_var)
         if not auth_token:
             # Mirror claude_cmd's pre-flight auth warning: a missing token here
@@ -127,7 +130,7 @@ async def run_query(
                 spec.auth_env_var,
                 spec.provider,
             )
-        port = start_proxy(env["ANTHROPIC_BASE_URL"], auth_token)
+        port = start_proxy(spec.upstream_base_url, auth_token)
         env["ANTHROPIC_BASE_URL"] = f"http://127.0.0.1:{port}"
 
     options = ClaudeAgentOptions(

--- a/src/osprey/cli/claude_code_resolver.py
+++ b/src/osprey/cli/claude_code_resolver.py
@@ -350,7 +350,8 @@ class ClaudeCodeModelResolver:
 
         # Base URL: use provider literal (no /v1); skip for direct Anthropic
         if provider_def.get("base_url"):
-            env_block["ANTHROPIC_BASE_URL"] = provider_def["base_url"]
+            base = provider_def["base_url"].rstrip("/").removesuffix("/v1")
+            env_block["ANTHROPIC_BASE_URL"] = base # This ensures Anthropic provider doesn't get double /v1 so the url is not broken
 
         # Tier model env vars (all providers)
         env_block["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = tier_to_model["haiku"]
@@ -383,7 +384,7 @@ class ClaudeCodeModelResolver:
         from osprey.infrastructure.proxy.lifecycle import is_proxy_needed
 
         _needs_proxy = is_proxy_needed(provider_name, api_providers)
-        _upstream_url = env_block.get("ANTHROPIC_BASE_URL") if _needs_proxy else None
+        _upstream_url = provider_def.get("base_url") if _needs_proxy else None # If the proxy is needed, use the raw provider_def (with /v1) not the stripped one 
 
         return ClaudeCodeModelSpec(
             provider=provider_name,

--- a/src/osprey/cli/claude_code_resolver.py
+++ b/src/osprey/cli/claude_code_resolver.py
@@ -348,11 +348,17 @@ class ClaudeCodeModelResolver:
         # shell variable references; values are treated as literals.
         env_block: dict[str, str] = {}
 
-        # Base URL: use provider literal (no /v1); skip for direct Anthropic
+        # Base URL for Claude Code. Claude Code always appends "/v1/messages",
+        # so ANTHROPIC_BASE_URL must be the bare origin — never ending in /v1.
+        # OpenAI-compatible endpoints carry a trailing /v1 by convention (it is
+        # the OpenAI API root); strip it here so an anthropic-native provider
+        # configured with such a URL doesn't resolve to "…/v1/v1/messages"
+        # (issue #312). The proxy upstream keeps the original /v1 (see
+        # upstream_base_url below); for proxy providers this value is overwritten
+        # with the loopback URL at launch. Skipped for direct Anthropic (no base_url).
         if provider_def.get("base_url"):
-            base = provider_def["base_url"].rstrip("/").removesuffix("/v1")
             env_block["ANTHROPIC_BASE_URL"] = (
-                base  # This ensures Anthropic provider doesn't get double /v1 so the url is not broken
+                provider_def["base_url"].rstrip("/").removesuffix("/v1")
             )
 
         # Tier model env vars (all providers)
@@ -386,9 +392,11 @@ class ClaudeCodeModelResolver:
         from osprey.infrastructure.proxy.lifecycle import is_proxy_needed
 
         _needs_proxy = is_proxy_needed(provider_name, api_providers)
-        _upstream_url = (
-            provider_def.get("base_url") if _needs_proxy else None
-        )  # If the proxy is needed, use the raw provider_def (with /v1) not the stripped one
+        # The proxy forwards to upstream + "/chat/completions", so the upstream
+        # must keep its /v1. Use the raw configured base_url, NOT the /v1-stripped
+        # ANTHROPIC_BASE_URL above. Every launch path starts the proxy from this
+        # field (never from the env var) — see runner.py / dispatch_api.py.
+        _upstream_url = provider_def.get("base_url") if _needs_proxy else None
 
         return ClaudeCodeModelSpec(
             provider=provider_name,

--- a/src/osprey/cli/claude_code_resolver.py
+++ b/src/osprey/cli/claude_code_resolver.py
@@ -351,7 +351,9 @@ class ClaudeCodeModelResolver:
         # Base URL: use provider literal (no /v1); skip for direct Anthropic
         if provider_def.get("base_url"):
             base = provider_def["base_url"].rstrip("/").removesuffix("/v1")
-            env_block["ANTHROPIC_BASE_URL"] = base # This ensures Anthropic provider doesn't get double /v1 so the url is not broken
+            env_block["ANTHROPIC_BASE_URL"] = (
+                base  # This ensures Anthropic provider doesn't get double /v1 so the url is not broken
+            )
 
         # Tier model env vars (all providers)
         env_block["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = tier_to_model["haiku"]
@@ -384,7 +386,9 @@ class ClaudeCodeModelResolver:
         from osprey.infrastructure.proxy.lifecycle import is_proxy_needed
 
         _needs_proxy = is_proxy_needed(provider_name, api_providers)
-        _upstream_url = provider_def.get("base_url") if _needs_proxy else None # If the proxy is needed, use the raw provider_def (with /v1) not the stripped one 
+        _upstream_url = (
+            provider_def.get("base_url") if _needs_proxy else None
+        )  # If the proxy is needed, use the raw provider_def (with /v1) not the stripped one
 
         return ClaudeCodeModelSpec(
             provider=provider_name,

--- a/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
+++ b/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
@@ -121,16 +121,18 @@ def _inject_provider_env_once() -> None:
             logger.info("Provider env injected: %s (provider=%s)", injected, spec.provider)
 
             # Non-native (OpenAI-protocol) providers need the in-process
-            # translation proxy. Deliver via os.environ (matching claude_cmd)
-            # because sdk_runner.build_clean_env copies os.environ into the SDK
-            # env; the in-container proxy thread is reachable by the SDK CLI.
-            # The ANTHROPIC_BASE_URL guard mirrors claude_cmd so a base_url-less
-            # provider can't KeyError.
-            if spec.needs_proxy and os.environ.get("ANTHROPIC_BASE_URL"):
+            # translation proxy. Deliver the loopback via os.environ (matching
+            # claude_cmd) because sdk_runner.build_clean_env copies os.environ
+            # into the SDK env; the in-container proxy thread is reachable by the
+            # SDK CLI. Start the proxy from spec.upstream_base_url — the OpenAI
+            # root *with* /v1 — NOT os.environ["ANTHROPIC_BASE_URL"], which the
+            # resolver strips of /v1 for Claude Code; sourcing the upstream from
+            # the env var would forward to a /v1-less endpoint (issue #312).
+            if spec.needs_proxy and spec.upstream_base_url:
                 from osprey.infrastructure.proxy.lifecycle import start_proxy
 
                 port = start_proxy(
-                    os.environ["ANTHROPIC_BASE_URL"],
+                    spec.upstream_base_url,
                     os.environ.get(spec.auth_env_var),
                 )
                 os.environ["ANTHROPIC_BASE_URL"] = f"http://127.0.0.1:{port}"

--- a/tests/agent_runner/test_primitives.py
+++ b/tests/agent_runner/test_primitives.py
@@ -161,7 +161,8 @@ def test_custom_provider_base_url_expanded(tmp_path: Path, monkeypatch: pytest.M
 
     env = provider_env_for_project(tmp_path)
 
-    assert env["ANTHROPIC_BASE_URL"] == "https://argo.example/v1"
+    # ${VAR} expanded, and /v1 stripped for the Claude-Code-facing var (issue #312).
+    assert env["ANTHROPIC_BASE_URL"] == "https://argo.example"
     assert "${ARGO_PROD_URL}" not in env["ANTHROPIC_BASE_URL"]
 
 

--- a/tests/agent_runner/test_runner.py
+++ b/tests/agent_runner/test_runner.py
@@ -416,13 +416,19 @@ def _capture(captured: list, async_cm):
 
 @pytest.mark.asyncio
 async def test_run_query_starts_proxy_for_non_native_provider(project_dir: Path) -> None:
-    """needs_proxy spec → start_proxy(upstream, key-from-env-dict); env repointed to loopback."""
+    """needs_proxy spec → start_proxy(spec.upstream_base_url, key-from-env-dict).
+
+    The proxy upstream MUST come from spec.upstream_base_url (the OpenAI root
+    with /v1), NOT from env["ANTHROPIC_BASE_URL"] — which the resolver strips of
+    /v1 for Claude Code (issue #312). The env var here is deliberately the
+    stripped form to prove the two are not conflated.
+    """
     async_cm, _ = _make_mock_client()
     captured: list[ClaudeAgentOptions] = []
     proxy = MagicMock(return_value=8123)
     proxy_env = {
         "CLAUDECODE": "",
-        "ANTHROPIC_BASE_URL": "https://argo.example/v1",
+        "ANTHROPIC_BASE_URL": "https://argo.example",  # stripped (Claude-Code-facing)
         "ANTHROPIC_AUTH_TOKEN": "sk-argo",
     }
 
@@ -435,14 +441,15 @@ async def test_run_query_starts_proxy_for_non_native_provider(project_dir: Path)
         patch("osprey.agent_runner.runner.resolve_default_model", return_value="m"),
         patch(
             "osprey.agent_runner.runner._resolve_project_spec",
-            return_value=_FakeSpec(needs_proxy=True),
+            return_value=_FakeSpec(needs_proxy=True, upstream_base_url="https://argo.example/v1"),
         ),
         patch("osprey.agent_runner.runner.start_proxy", proxy),
         patch("osprey.agent_runner.runner._expected_mcp_servers", return_value=set()),
     ):
         await run_query(project_dir, "q", disallowed_tools=[])
 
-    # api_key sourced from the env dict (not os.environ) on this path
+    # Proxy upstream = spec.upstream_base_url (WITH /v1), NOT the stripped env var.
+    # api_key sourced from the env dict (not os.environ) on this path.
     proxy.assert_called_once_with("https://argo.example/v1", "sk-argo")
     assert captured[0].env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8123"
 
@@ -510,8 +517,8 @@ async def test_run_query_no_proxy_for_native_provider(project_dir: Path) -> None
 
 
 @pytest.mark.asyncio
-async def test_run_query_no_proxy_when_base_url_absent(project_dir: Path) -> None:
-    """needs_proxy spec but no ANTHROPIC_BASE_URL in env → no KeyError, no proxy."""
+async def test_run_query_no_proxy_when_upstream_absent(project_dir: Path) -> None:
+    """needs_proxy spec but no upstream_base_url (base_url-less provider) → no proxy."""
     async_cm, _ = _make_mock_client()
     captured: list[ClaudeAgentOptions] = []
     proxy = MagicMock(return_value=1)
@@ -525,7 +532,7 @@ async def test_run_query_no_proxy_when_base_url_absent(project_dir: Path) -> Non
         patch("osprey.agent_runner.runner.resolve_default_model", return_value="m"),
         patch(
             "osprey.agent_runner.runner._resolve_project_spec",
-            return_value=_FakeSpec(needs_proxy=True),
+            return_value=_FakeSpec(needs_proxy=True, upstream_base_url=None),
         ),
         patch("osprey.agent_runner.runner.start_proxy", proxy),
         patch("osprey.agent_runner.runner._expected_mcp_servers", return_value=set()),

--- a/tests/cli/test_claude_code_resolver.py
+++ b/tests/cli/test_claude_code_resolver.py
@@ -625,7 +625,9 @@ class TestLoadProviderSpec:
 
         assert spec is not None
         assert spec.needs_proxy is True
-        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://argo.example/v1"
+        # Claude-Code-facing var is stripped of the OpenAI /v1 (issue #312)…
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://argo.example"
+        # …while the proxy upstream keeps it (proxy appends /chat/completions).
         assert spec.upstream_base_url == "https://argo.example/v1"
 
     def test_expands_from_os_environ_when_no_dotenv(self, tmp_path, monkeypatch):
@@ -637,7 +639,9 @@ class TestLoadProviderSpec:
 
         spec = load_provider_spec(proj)
 
-        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://argo.from-env/v1"
+        # /v1 stripped for the Claude-Code-facing var; upstream retains it.
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://argo.from-env"
+        assert spec.upstream_base_url == "https://argo.from-env/v1"
 
     def test_dotenv_overrides_os_environ(self, tmp_path, monkeypatch):
         """A project .env value wins over a stale shell export."""
@@ -648,7 +652,9 @@ class TestLoadProviderSpec:
 
         spec = load_provider_spec(proj)
 
-        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://fresh-dotenv/v1"
+        # /v1 stripped for the Claude-Code-facing var; upstream retains it.
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://fresh-dotenv"
+        assert spec.upstream_base_url == "https://fresh-dotenv/v1"
 
     def test_native_config_byte_identical(self, tmp_path):
         """A literal-URL native config resolves identically to the raw resolver."""
@@ -683,3 +689,51 @@ class TestLoadProviderSpec:
         load_provider_spec(proj)
 
         assert "ARGO_PROD_URL" not in os.environ
+
+
+class TestBaseUrlV1Normalization:
+    """ANTHROPIC_BASE_URL vs upstream_base_url /v1 handling (issue #312).
+
+    Claude Code appends ``/v1/messages`` to ``ANTHROPIC_BASE_URL``, so that var
+    must never end in ``/v1``. The proxy appends ``/chat/completions`` to
+    ``upstream_base_url``, so that one must KEEP its ``/v1``. A single
+    configured ``base_url`` feeds both; these tests pin the split.
+    """
+
+    def _resolve(self, base_url, *, native):
+        entry = {"base_url": base_url}
+        if native:
+            entry["api_protocol"] = "anthropic"
+        return ClaudeCodeModelResolver.resolve({"provider": "argo"}, {"argo": entry})
+
+    def test_anthropic_native_strips_v1_and_skips_proxy(self):
+        """The #312 case: native provider + /v1 URL → single /v1, no proxy."""
+        spec = self._resolve("https://apps.inside.anl.gov/argoapi/v1", native=True)
+        assert spec.needs_proxy is False
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://apps.inside.anl.gov/argoapi"
+        # Claude Code appends /v1/messages → exactly one /v1.
+        assert (
+            spec.env_block["ANTHROPIC_BASE_URL"] + "/v1/messages"
+            == "https://apps.inside.anl.gov/argoapi/v1/messages"
+        )
+        assert spec.upstream_base_url is None
+
+    def test_openai_proxy_keeps_v1_on_upstream(self):
+        """Proxy provider: env var stripped, upstream keeps /v1 for the proxy."""
+        spec = self._resolve("https://apps.inside.anl.gov/argoapi/v1", native=False)
+        assert spec.needs_proxy is True
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://apps.inside.anl.gov/argoapi"
+        assert spec.upstream_base_url == "https://apps.inside.anl.gov/argoapi/v1"
+        # Proxy appends /chat/completions → the /v1 must survive.
+        assert (
+            spec.upstream_base_url.rstrip("/") + "/chat/completions"
+            == "https://apps.inside.anl.gov/argoapi/v1/chat/completions"
+        )
+
+    def test_trailing_slash_before_v1_is_stripped(self):
+        spec = self._resolve("https://host/argoapi/v1/", native=True)
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://host/argoapi"
+
+    def test_url_without_v1_is_left_alone(self):
+        spec = self._resolve("https://api.example.com", native=True)
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://api.example.com"

--- a/tests/cli/test_preset_provider_parity.py
+++ b/tests/cli/test_preset_provider_parity.py
@@ -111,4 +111,7 @@ def test_ds4_stanza_resolves_to_deepseek_tiers():
     assert spec.tier_to_model["haiku"] == "deepseek-v4-flash"
     assert spec.tier_to_model["sonnet"] == "deepseek-v4-pro"
     assert spec.tier_to_model["opus"] == "deepseek-v4-pro"
-    assert spec.env_block["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8000/v1"
+    # Claude-Code-facing var is stripped of /v1 (issue #312); the proxy upstream
+    # keeps it for /chat/completions forwarding.
+    assert spec.env_block["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8000"
+    assert spec.upstream_base_url == "http://127.0.0.1:8000/v1"

--- a/tests/cli/test_resolver_cborg_oss.py
+++ b/tests/cli/test_resolver_cborg_oss.py
@@ -43,8 +43,10 @@ def test_custom_provider_resolves_with_proxy():
     assert spec.env_block["ANTHROPIC_MODEL"] == "cborg-coder"
     # Crucially: a custom (non-native) provider needs the translation proxy:
     assert spec.needs_proxy is True
+    # Upstream keeps /v1 (proxy appends /chat/completions); the Claude-Code-facing
+    # var is stripped of /v1 since Claude Code appends /v1/messages (issue #312).
     assert spec.upstream_base_url == "https://api.cborg.lbl.gov/v1"
-    assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://api.cborg.lbl.gov/v1"
+    assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://api.cborg.lbl.gov"
 
 
 def test_builtin_cborg_is_anthropic_native_no_proxy():
@@ -85,7 +87,8 @@ def test_inject_provider_env_wires_auth_and_scrubs_managed_vars():
     assert "ANTHROPIC_API_KEY" not in environ
     # Project's chosen model is authoritative over the stale shell value:
     assert environ["ANTHROPIC_MODEL"] == "cborg-coder"
-    assert environ["ANTHROPIC_BASE_URL"] == "https://api.cborg.lbl.gov/v1"
+    # Claude-Code-facing var is stripped of the OpenAI /v1 (issue #312).
+    assert environ["ANTHROPIC_BASE_URL"] == "https://api.cborg.lbl.gov"
     assert "ANTHROPIC_BASE_URL" in injected
 
 


### PR DESCRIPTION
Closes #312. Supersedes #328 (builds directly on @Anas321's commit — his resolver fix is preserved in this branch's history).

## Background

@Anas321 correctly diagnosed #312: an Anthropic-native provider configured with a `/v1` base URL (e.g. Argo via `api_protocol: anthropic`) resolved to a doubled `…/v1/v1/messages`, because Claude Code appends `/v1/messages` to `ANTHROPIC_BASE_URL` itself. Their fix strips the trailing `/v1` from the Claude-Code-facing `ANTHROPIC_BASE_URL` and keeps the raw URL for the proxy `upstream_base_url`. That part is kept as-is.

## Why this PR extends it

The resolver produces two values: `ANTHROPIC_BASE_URL` (Claude-Code-facing, must **not** end in `/v1`) and `upstream_base_url` (proxy-facing, must **keep** `/v1`, since the proxy appends `/chat/completions`). Four launch paths start the translation proxy:

| Launch path | Proxy upstream source | After the `/v1` strip alone |
|---|---|---|
| `claude_cmd.py` (CLI) | `spec.upstream_base_url` | ✅ `…/v1/chat/completions` |
| `web_terminal/app.py` | `spec.upstream_base_url` | ✅ `…/v1/chat/completions` |
| `agent_runner/runner.py` (SDK, benchmarks) | `env["ANTHROPIC_BASE_URL"]` | ❌ `…/chat/completions` (no `/v1`) |
| `dispatch_worker/dispatch_api.py` (event dispatch) | `os.environ["ANTHROPIC_BASE_URL"]` | ❌ `…/chat/completions` (no `/v1`) |

`inject_provider_env` / `provider_env_for_project` copy the **stripped** `env_block` into the environment, so the two paths that read the upstream back out of `ANTHROPIC_BASE_URL` would forward OpenAI-compatible providers (Argo, Stanford, vLLM, …) to a `/v1`-less endpoint. This PR points those two paths at `spec.upstream_base_url` — the field designed for it — so all four launch paths behave identically.

## Changes

- `runner.py`, `dispatch_api.py`: start the proxy from `spec.upstream_base_url` (guard on it too, so a `base_url`-less provider still skips the proxy).
- `claude_code_resolver.py`: comment clarified (the strip applies to any anthropic-native provider with a `/v1` URL).
- Tests: fix the 8 existing assertions that pinned the pre-strip `ANTHROPIC_BASE_URL`; strengthen the runner/dispatch proxy guards to use **distinct** env-vs-upstream values (the prior tests mocked both with the same string, which is why the divergence was untestable); add `TestBaseUrlV1Normalization` covering the native single-`/v1` case and the proxy `/v1`-retained invariant.

## Verification

- Native `#312` case resolves to a single `/v1`; all four launch paths forward to `…/v1/chat/completions`.
- The two launch-path guards fail on the resolver-strip-only base and pass with this change.
- Full affected suites: `tests/cli tests/agent_runner tests/unit/dispatch_worker` — 1184 passed, 4 skipped; ruff + mypy clean on changed lines.