### PR TITLE
fix(web): decide companion-server ownership by port binding, not /health (#327)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- Web companion servers (Artifacts, ARIEL, Tuning, Channel Finder, Lattice, KNOWLEDGE) no longer skip their launch when a stale or foreign process briefly answers `/health` on their port during a restart, which previously left the panel unbacked and permanently 502ing. The launcher now decides ownership by whether a live TCP listener holds the port, waits out a shutting-down predecessor, and logs distinctly when it defers to a legitimate external server versus when the port is held by an unresponsive one (#327).
 - The session activity page ("Activity" / session log viewer) no longer applies its `?theme=` query parameter directly to the page; an invalid or unexpected value now falls back to the resolved default instead of being written straight into the page's theme attribute.
 - Web Terminal's and Artifacts' syntax-highlighting theme stylesheet no longer 404s in the default CDN vendor mode (it was previously served from a hardcoded local vendor path regardless of the configured vendor mode).
 - ARIEL now themes itself from the shared OSPREY design system instead of a hardcoded dark palette, and follows the web-terminal hub's theme when embedded; also fixes a phantom `--amber` CSS variable that was never defined (draft banner and image-lightbox link color).

--- a/src/osprey/infrastructure/server_launcher.py
+++ b/src/osprey/infrastructure/server_launcher.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import importlib
 import logging
+import socket
 import threading
+import time
 import urllib.request
 from collections.abc import Callable
 from pathlib import Path
@@ -19,6 +21,33 @@ from osprey.registry.web import FRAMEWORK_WEB_SERVERS, WebServerDefinition
 from osprey.utils.workspace import load_osprey_config
 
 logger = logging.getLogger("osprey.infrastructure.server_launcher")
+
+# When a port is already held on first check, it may be a predecessor that is
+# still shutting down after a restart. Wait a bounded grace period for it to
+# release the port so we can bind (own) it ourselves rather than trusting a
+# possibly-dying external responder. See issue #327.
+_PORT_RELEASE_GRACE_ATTEMPTS = 5
+_PORT_RELEASE_GRACE_INTERVAL = 0.5
+
+# When a port stays held by a process that does not answer /health, we cannot
+# bind it now, but it may free up later (a lazy caller like artifact_store
+# re-invokes ensure_running on every save). Re-probe at most this often so a
+# panel can self-heal without paying the grace cost on every call.
+_HELD_PORT_RETRY_COOLDOWN = 30.0
+
+
+def _loopback_for(host: str) -> str:
+    """Map a wildcard bind host to a loopback address reachable as a *client*.
+
+    A server bound to a wildcard (``0.0.0.0`` / ``::`` / ``""``) also accepts
+    connections on the corresponding loopback, but the wildcard itself is not a
+    valid client destination on macOS/BSD. Non-wildcard hosts pass through.
+    """
+    if host in ("0.0.0.0", ""):
+        return "127.0.0.1"
+    if host == "::":
+        return "::1"
+    return host
 
 
 class ServerLauncher:
@@ -31,6 +60,11 @@ class ServerLauncher:
         app_factory: Callable returning a ASGI app instance. Receives
             ``workspace_root`` kwarg if ``pass_workspace`` is True.
         pass_workspace: If True, resolve and pass ``workspace_root`` to the app factory.
+        release_grace_attempts: Times to re-probe a held port, waiting for a
+            shutting-down predecessor to release it before deferring/warning.
+        release_grace_interval: Seconds between those re-probes.
+        held_port_retry_cooldown: After a port is found held by a non-responder,
+            seconds to wait before ``ensure_running`` re-probes again.
     """
 
     def __init__(
@@ -40,19 +74,45 @@ class ServerLauncher:
         auto_launch_checker: Callable[[], bool],
         app_factory: Callable[..., object],
         pass_workspace: bool = False,
+        release_grace_attempts: int = _PORT_RELEASE_GRACE_ATTEMPTS,
+        release_grace_interval: float = _PORT_RELEASE_GRACE_INTERVAL,
+        held_port_retry_cooldown: float = _HELD_PORT_RETRY_COOLDOWN,
     ) -> None:
         self._name = name
         self._config_reader = config_reader
         self._auto_launch_checker = auto_launch_checker
         self._app_factory = app_factory
         self._pass_workspace = pass_workspace
+        self._release_grace_attempts = release_grace_attempts
+        self._release_grace_interval = release_grace_interval
+        self._held_port_retry_cooldown = held_port_retry_cooldown
         self._launched = False
+        # Monotonic deadline before which ensure_running() short-circuits after
+        # a "port held by a non-responder" outcome (see ensure_running).
+        self._retry_not_before = 0.0
         self._lock = threading.Lock()
+
+    def _port_has_listener(self, host: str, port: int) -> bool:
+        """Return True if a live TCP listener is bound to *host:port*.
+
+        This is a truer "is the port taken?" signal than a ``/health`` 200:
+        it answers the ownership question directly instead of conflating
+        "the port is bound" with "the bound thing is a healthy HTTP server".
+        A wildcard bind host is probed via loopback, which the same listener
+        also accepts.
+        """
+        try:
+            with socket.create_connection((_loopback_for(host), port), timeout=1):
+                return True
+        except OSError:
+            return False
 
     def _is_running(self, host: str, port: int) -> bool:
         """Check the /health endpoint (quick, no dependencies)."""
+        probe_host = _loopback_for(host)
+        netloc = f"[{probe_host}]" if ":" in probe_host else probe_host
         try:
-            url = f"http://{host}:{port}/health"
+            url = f"http://{netloc}:{port}/health"
             req = urllib.request.Request(url, method="GET")
             with urllib.request.urlopen(req, timeout=1) as resp:
                 return resp.status == 200
@@ -81,35 +141,49 @@ class ServerLauncher:
         t.start()
         logger.info("%s launched at http://%s:%s", self._name, host, port)
 
-        # Brief health-check to verify server came up
-        import time
-
+        # Brief health-check to verify *our* server came up. Liveness is checked
+        # first: if the thread has exited (e.g. the bind failed in a TOCTOU race
+        # with another process), a /health 200 would be a foreign responder, not
+        # ours — trusting it would recreate the #327 false positive.
         for _attempt in range(3):
             time.sleep(0.5)
+            if not t.is_alive():
+                logger.warning("%s thread exited before health check passed", self._name)
+                self._launched = False
+                return
             if self._is_running(host, port):
                 logger.info("%s health check passed", self._name)
                 self._launched = True
                 return
 
-        if not t.is_alive():
-            # Thread already exited (crashed) — don't mark as launched
-            logger.warning("%s thread exited before health check passed", self._name)
-            self._launched = False
-        else:
-            logger.warning(
-                "%s health check failed after launch — server may not be reachable at %s:%s",
-                self._name,
-                host,
-                port,
-            )
-            # Still mark as launched to avoid busy-retry loops; the crash handler
-            # in _run() will reset _launched if the thread actually crashes.
-            self._launched = True
+        # Thread still alive but /health never answered — mark launched to avoid
+        # busy-retry loops; the crash handler in _run() resets _launched if the
+        # thread later dies.
+        logger.warning(
+            "%s health check failed after launch — server may not be reachable at %s:%s",
+            self._name,
+            host,
+            port,
+        )
+        self._launched = True
 
     def ensure_running(self) -> None:
         """Ensure the server is running; launch if needed.
 
         Safe to call multiple times — no-op after first launch.
+
+        Ownership is decided by whether a live TCP listener holds the port,
+        not by a bare ``/health`` 200. A ``/health`` 200 from a stale or
+        foreign responder is a false positive: it previously made the manager
+        skip the launch and leave the panel unbacked (proxy 502) after a
+        restart (issue #327). Instead:
+
+        * port free            -> launch and own it;
+        * port held then freed -> a shutting-down predecessor; waited out,
+          then launched;
+        * port held throughout  -> defer to a legitimate external server if it
+          serves ``/health`` (latched); else warn and retry on a later call so a
+          lazily-relaunched panel can self-heal once the port frees.
         """
         if not self._auto_launch_checker():
             return
@@ -121,13 +195,50 @@ class ServerLauncher:
             if self._launched:
                 return
 
-            host, port = self._config_reader()
-
-            if self._is_running(host, port):
-                self._launched = True
+            # A recent "held by a non-responder" outcome throttles re-probing so
+            # a per-call caller (e.g. artifact_store on every save) does not pay
+            # the grace cost repeatedly while still recovering when the port frees.
+            if time.monotonic() < self._retry_not_before:
                 return
 
-            self._launch_in_thread(host, port)
+            host, port = self._config_reader()
+
+            # Nothing listening -> the port is ours to take.
+            if not self._port_has_listener(host, port):
+                self._launch_in_thread(host, port)
+                return
+
+            # Held on first check. Give a shutting-down predecessor a bounded
+            # grace period to release the port so we can bind it ourselves.
+            for _attempt in range(self._release_grace_attempts):
+                time.sleep(self._release_grace_interval)
+                if not self._port_has_listener(host, port):
+                    self._launch_in_thread(host, port)
+                    return
+
+            # Still held after the grace window. A live /health responder is a
+            # legitimate server owned by another process — defer to it (latched).
+            if self._is_running(host, port):
+                logger.info(
+                    "%s already served by another process at %s:%s — deferring launch",
+                    self._name,
+                    host,
+                    port,
+                )
+                self._launched = True
+            else:
+                # Held by something that does not answer /health; we cannot bind
+                # now. Do not latch — throttle and retry so the panel recovers if
+                # the port frees later.
+                logger.warning(
+                    "%s port %s:%s is held by a process that does not answer /health; "
+                    "the panel will be unbacked (502) until the port is free. "
+                    "Will retry on a later call.",
+                    self._name,
+                    host,
+                    port,
+                )
+                self._retry_not_before = time.monotonic() + self._held_port_retry_cooldown
 
 
 # ---------------------------------------------------------------------------

--- a/tests/interfaces/channel_finder/test_server_launcher.py
+++ b/tests/interfaces/channel_finder/test_server_launcher.py
@@ -2,9 +2,30 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+import socket
+import time
+from unittest.mock import MagicMock, patch
 
 from osprey.registry.web import FRAMEWORK_WEB_SERVERS
+
+
+def _free_port() -> int:
+    """Reserve then release an OS-assigned port so nothing is listening on it."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _make_launcher(host: str, port: int):
+    """Build a ServerLauncher wired to a fixed (host, port), auto-launch on."""
+    from osprey.infrastructure.server_launcher import ServerLauncher
+
+    return ServerLauncher(
+        name="Test Server",
+        config_reader=lambda: (host, port),
+        auto_launch_checker=lambda: True,
+        app_factory=lambda: object(),
+    )
 
 
 class TestMakeConfigReader:
@@ -106,3 +127,190 @@ class TestBackwardCompatAliases:
         from osprey.infrastructure.server_launcher import ensure_ariel_server
 
         assert callable(ensure_ariel_server)
+
+
+class TestEnsureRunningOwnership:
+    """ensure_running must own the port, not trust a bare /health 200.
+
+    Regression coverage for the false-positive described in issue #327: a
+    stale/foreign responder answering /health made the launcher skip binding,
+    leaving the panel unbacked (proxy 502) after a restart.
+    """
+
+    def test_launches_when_port_free_despite_health_200(self):
+        """A /health 200 with no real listener must NOT suppress the launch.
+
+        This is the core bug: `_is_running()` returning True (stale/foreign
+        responder) previously short-circuited the launch even though nothing
+        was actually bound to the port.
+        """
+        launcher = _make_launcher("127.0.0.1", _free_port())
+
+        with (
+            patch.object(launcher, "_is_running", return_value=True),
+            patch.object(launcher, "_launch_in_thread") as mock_launch,
+        ):
+            launcher.ensure_running()
+
+        mock_launch.assert_called_once()
+
+    def test_launches_when_port_genuinely_free(self):
+        """No listener + no responder → launch and own the port."""
+        launcher = _make_launcher("127.0.0.1", _free_port())
+
+        with (
+            patch.object(launcher, "_is_running", return_value=False),
+            patch.object(launcher, "_launch_in_thread") as mock_launch,
+        ):
+            launcher.ensure_running()
+
+        mock_launch.assert_called_once()
+
+    def test_waits_out_dying_predecessor_then_launches(self):
+        """A predecessor that releases the port during the grace window is waited out."""
+        launcher = _make_launcher("127.0.0.1", _free_port())
+        # Held on the first probe, released on the second (predecessor shut down).
+        listener_states = iter([True, False])
+
+        with (
+            patch.object(
+                launcher,
+                "_port_has_listener",
+                side_effect=lambda *_: next(listener_states, False),
+            ),
+            patch.object(launcher, "_launch_in_thread") as mock_launch,
+            patch("osprey.infrastructure.server_launcher.time.sleep"),
+        ):
+            launcher.ensure_running()
+
+        mock_launch.assert_called_once()
+
+    def test_defers_to_persistent_external_server(self):
+        """A port held for the full grace window that serves /health → defer, don't launch."""
+        launcher = _make_launcher("127.0.0.1", _free_port())
+
+        with (
+            patch.object(launcher, "_port_has_listener", return_value=True),
+            patch.object(launcher, "_is_running", return_value=True),
+            patch.object(launcher, "_launch_in_thread") as mock_launch,
+            patch("osprey.infrastructure.server_launcher.time.sleep"),
+        ):
+            launcher.ensure_running()
+
+        mock_launch.assert_not_called()
+        assert launcher._launched is True
+
+    def test_warns_when_port_held_by_non_responder(self):
+        """Port held for the full grace window with no /health → loud warning, no silent skip."""
+        launcher = _make_launcher("127.0.0.1", _free_port())
+
+        with (
+            patch.object(launcher, "_port_has_listener", return_value=True),
+            patch.object(launcher, "_is_running", return_value=False),
+            patch.object(launcher, "_launch_in_thread") as mock_launch,
+            patch("osprey.infrastructure.server_launcher.time.sleep"),
+            patch("osprey.infrastructure.server_launcher.logger.warning") as mock_warn,
+        ):
+            launcher.ensure_running()
+
+        mock_launch.assert_not_called()
+        mock_warn.assert_called_once()
+
+    def test_non_responder_does_not_latch_and_self_heals(self):
+        """A non-responder outcome must not latch, so a later call can self-heal.
+
+        Regression guard for the artifact_store per-save relaunch pattern: if the
+        first call hit a foreign holder, a later call (after the port frees) must
+        still launch instead of being permanently short-circuited.
+        """
+        launcher = _make_launcher("127.0.0.1", _free_port())
+
+        # First call: held by a non-responder → warn, throttle, no launch, no latch.
+        with (
+            patch.object(launcher, "_port_has_listener", return_value=True),
+            patch.object(launcher, "_is_running", return_value=False),
+            patch.object(launcher, "_launch_in_thread") as mock_launch,
+            patch("osprey.infrastructure.server_launcher.time.sleep"),
+        ):
+            launcher.ensure_running()
+        mock_launch.assert_not_called()
+        assert launcher._launched is False
+
+        # Cooldown elapsed and the port is now free → launch (self-heal).
+        launcher._retry_not_before = 0.0
+        with (
+            patch.object(launcher, "_port_has_listener", return_value=False),
+            patch.object(launcher, "_launch_in_thread") as mock_launch2,
+        ):
+            launcher.ensure_running()
+        mock_launch2.assert_called_once()
+
+    def test_cooldown_short_circuits_reprobe(self):
+        """Within the retry cooldown, ensure_running must not re-probe (avoids grace cost)."""
+        launcher = _make_launcher("127.0.0.1", _free_port())
+        launcher._retry_not_before = time.monotonic() + 1000  # far future
+
+        with (
+            patch.object(launcher, "_port_has_listener") as mock_probe,
+            patch.object(launcher, "_launch_in_thread") as mock_launch,
+        ):
+            launcher.ensure_running()
+
+        mock_probe.assert_not_called()
+        mock_launch.assert_not_called()
+
+    def test_dead_thread_health_200_not_marked_launched(self):
+        """Post-launch: a /health 200 from a dead thread (foreign responder) is not trusted."""
+        launcher = _make_launcher("127.0.0.1", _free_port())
+        dead_thread = MagicMock()
+        dead_thread.is_alive.return_value = False
+
+        with (
+            patch(
+                "osprey.infrastructure.server_launcher.threading.Thread",
+                return_value=dead_thread,
+            ),
+            patch.object(launcher, "_is_running", return_value=True),
+            patch("osprey.infrastructure.server_launcher.time.sleep"),
+        ):
+            launcher._launch_in_thread("127.0.0.1", 12345)
+
+        assert launcher._launched is False
+
+
+class TestLoopbackFor:
+    """Wildcard bind hosts are normalized to a client-reachable loopback."""
+
+    def test_wildcard_ipv4(self):
+        from osprey.infrastructure.server_launcher import _loopback_for
+
+        assert _loopback_for("0.0.0.0") == "127.0.0.1"
+        assert _loopback_for("") == "127.0.0.1"
+
+    def test_wildcard_ipv6(self):
+        from osprey.infrastructure.server_launcher import _loopback_for
+
+        assert _loopback_for("::") == "::1"
+
+    def test_concrete_host_passthrough(self):
+        from osprey.infrastructure.server_launcher import _loopback_for
+
+        assert _loopback_for("10.0.0.5") == "10.0.0.5"
+        assert _loopback_for("127.0.0.1") == "127.0.0.1"
+
+
+class TestPortHasListener:
+    """The connect-probe distinguishes a bound port from a free one."""
+
+    def test_returns_false_for_free_port(self):
+        launcher = _make_launcher("127.0.0.1", _free_port())
+        host, port = launcher._config_reader()
+        assert launcher._port_has_listener(host, port) is False
+
+    def test_returns_true_for_bound_port(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as srv:
+            srv.bind(("127.0.0.1", 0))
+            srv.listen(1)
+            port = srv.getsockname()[1]
+            launcher = _make_launcher("127.0.0.1", port)
+            assert launcher._port_has_listener("127.0.0.1", port) is True


### PR DESCRIPTION
## Summary

Fixes #327. `ServerLauncher.ensure_running()` treated any `GET /health == 200` on the target port as "the server is already running" and returned without launching. A `/health` 200 from a **stale or foreign** responder — e.g. a predecessor still shutting down during a web-terminal restart — was a false positive: the panel was logged as available but never bound, so the web-terminal proxy returned `502 Upstream connection failed` for that panel until a manual relaunch.

## Root cause

A bare `/health` 200 conflates two different questions: "is the port bound?" and "did *I* bind it?". The launch-skip decision only needs the first, and no instantaneous check can tell a *dying* responder from a *stable* one — only elapsed time can.

## Fix

`ensure_running()` now decides ownership from a **TCP connect-probe**, not a `/health` ping:

- **port free** → launch and own it;
- **port held, then freed** → a shutting-down predecessor; wait it out over a bounded grace window, then launch;
- **port held throughout** → if it serves `/health`, defer to that legitimate external server (latched); otherwise warn loudly and retry on a later call, so a lazily-relaunched panel (e.g. `artifact_store`, which calls `ensure_*` on every save) self-heals once the port frees.

Two hardenings from review came along:

- **Post-launch verification** now requires the launch thread to still be alive before trusting a `/health` 200 — a 200 from a dead launch thread (bind lost a TOCTOU race) is a foreign responder, and trusting it would recreate the same #327 false positive in the verification path.
- **Wildcard bind hosts** (`0.0.0.0` / `::` / `""`) are normalized to loopback for *both* probes via a shared helper, so `0.0.0.0` deploys (documented for `--network host` multi-container) don't misclassify a healthy server as unreachable.

## Why not "defer immediately when /health answers"

A reviewer suggested skipping the grace wait when the held port already answers `/health`. That would reintroduce the bug: a *dying predecessor* is a live OSPREY server that answers `/health` while shutting down. Deferring to it means never binding. The grace-*first* ordering is intentional.

## Tests

Reproduced the bug at the public-contract level first (a `/health` 200 with a genuinely free port must not suppress the launch), then added coverage for the grace/defer/warn branches, the self-heal-after-throttle path, the dead-thread verification guard, and the wildcard-host helper. Full non-e2e suite green; `ruff` clean; no new `mypy` errors (the module's 3 pre-existing type errors are unchanged).
