### PR TITLE
feat(interfaces): Phase 1 — micro-frontend shell↔panel contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,7 @@ jobs:
             - 'src/osprey/interfaces/**'
             - 'src/osprey/dispatch/**'
             - 'tests/interfaces/design_system/**'
+            - 'tests/interfaces/web_terminal/**'
             - 'tests/interfaces/conftest.py'
             - 'tests/interfaces/_browser.py'
             - 'tests/interfaces/test_load_smokes.py'
@@ -246,6 +247,7 @@ jobs:
       run: |
         uv run pytest tests/interfaces/design_system/test_behavioral.py \
           tests/interfaces/web_terminal/test_panels_browser.py \
+          tests/interfaces/web_terminal/test_contract_params.py \
           tests/interfaces/test_load_smokes.py -v --tb=short
 
     - name: Run visual regression suite

--- a/src/osprey/interfaces/ariel/static/js/app.js
+++ b/src/osprey/interfaces/ariel/static/js/app.js
@@ -5,6 +5,7 @@
  */
 
 import { initTheme } from '/design-system/js/theme-manager.js';
+import { applyEmbedded } from '/design-system/js/frame-params.js';
 import { capabilitiesApi } from './api.js';
 import { initSearch, performSearch, clearSearch } from './search.js';
 import { initEntries, loadEntries, showEntry, closeEntryModal, loadDraft, showImageLightbox } from './entries.js';
@@ -26,10 +27,7 @@ let currentView = 'search';
  */
 async function init() {
   // Embedded mode — hide logo when loaded inside web terminal iframe
-  const params = new URLSearchParams(window.location.search);
-  if (params.get('embedded') === 'true') {
-    document.body.classList.add('embedded');
-  }
+  applyEmbedded();
 
   // Initialize modules — wrapped in try/catch so navigation always works
   // even if the backend is unavailable (degraded mode).

--- a/src/osprey/interfaces/artifacts/static/js/gallery.js
+++ b/src/osprey/interfaces/artifacts/static/js/gallery.js
@@ -189,6 +189,7 @@ import { initTheme, subscribe, chartTheme, chartSeries } from "/design-system/js
   function sendToTerminal(text) {
     try {
       if (window.parent && window.parent !== window) {
+        // Intentional '*' (same-origin contract exception): parent embedder may be cross-origin.
         window.parent.postMessage({ type: "osprey-paste-to-terminal", text }, "*");
       }
     } catch { /* cross-origin */ }
@@ -1531,6 +1532,7 @@ import { initTheme, subscribe, chartTheme, chartSeries } from "/design-system/js
 
   function _forwardThemeToPreviewFrames(theme) {
     document.querySelectorAll(".preview-viewport iframe, .browse-preview-pane iframe").forEach((iframe) => {
+      // Intentional '*' (same-origin contract exception): nested preview iframe may be null/cross-origin.
       try { iframe.contentWindow.postMessage({ type: "osprey-theme-change", theme }, "*"); } catch {}
     });
   }
@@ -1560,6 +1562,7 @@ import { initTheme, subscribe, chartTheme, chartSeries } from "/design-system/js
   // Session changes are unrelated to theming and stay a plain message
   // listener (theme-manager owns the 'osprey-theme-change' type now).
   window.addEventListener("message", (e) => {
+    if (e.origin !== window.location.origin) return;
     if (e.data && e.data.type === "osprey-session-change" && e.data.session_id) {
       currentSessionId = e.data.session_id;
       const btn = document.getElementById("all-sessions-btn");

--- a/src/osprey/interfaces/channel_finder/static/js/app.js
+++ b/src/osprey/interfaces/channel_finder/static/js/app.js
@@ -5,6 +5,7 @@
  */
 
 import { initTheme } from '/design-system/js/theme-manager.js';
+import { applyEmbedded } from '/design-system/js/frame-params.js';
 import { fetchJSON, putJSON } from './api.js';
 import { state } from './state.js';
 import { mountExplore, unmountExplore } from './explore.js';
@@ -16,9 +17,7 @@ import { refreshStatsBadges } from './stats-badges.js';
 // pre-paint; this call attaches the follower's postMessage listener.
 initTheme({ role: 'follower' });
 
-if (new URLSearchParams(window.location.search).get('embedded') === 'true') {
-  document.body.classList.add('embedded');
-}
+applyEmbedded();
 
 const VIEWS = {
   explore:  { mount: mountExplore,  unmount: unmountExplore },

--- a/src/osprey/interfaces/design_system/static/js/frame-params.js
+++ b/src/osprey/interfaces/design_system/static/js/frame-params.js
@@ -1,0 +1,48 @@
+// @ts-check
+/**
+ * Micro-frontend query-param contract for the design-system front-end.
+ *
+ * Documents and applies the WELL-KNOWN query params a host page may pass to
+ * an embedded design-system frame:
+ *
+ * - `embedded` — `"true"` marks the page as running inside a host frame; see
+ *   {@link applyEmbedded}, which adds the `embedded` class to `document.body`
+ *   when set.
+ * - `theme` — owned and read pre-paint by theme-boot.js / theme-manager.js.
+ *   It is deliberately NOT read here: theme-boot.js is a non-module inline
+ *   script that resolves and applies `data-theme` before first paint, so
+ *   re-reading `theme` in this (deferred) ES module would just duplicate that
+ *   read after the fact and risks a visible theme flash. Consult
+ *   theme-boot.js / theme-manager.js for the theme contract.
+ *
+ * `CONTRACT_VERSION` identifies the version of this query-param contract so
+ * host pages and embedded frames can detect a mismatch.
+ *
+ * Note (decision OC-1): a generic `frameParam()` / `frameParams()` getter is
+ * intentionally NOT provided here — that surface is deferred until a second
+ * consumer actually needs it.
+ *
+ * @module frame-params
+ */
+
+/**
+ * Version of the micro-frontend query-param contract described in this
+ * module's JSDoc.
+ *
+ * @type {string}
+ */
+export const CONTRACT_VERSION = '1';
+
+/**
+ * Read the `embedded` query param and, when it is exactly `"true"`, add the
+ * `embedded` class to `document.body`. No-op otherwise (including when the
+ * param is absent, or set to any other value such as `"false"` or `"1"`).
+ *
+ * @returns {void}
+ */
+export function applyEmbedded() {
+  const embedded = new URLSearchParams(window.location.search).get('embedded') === 'true';
+  if (embedded) {
+    document.body.classList.add('embedded');
+  }
+}

--- a/src/osprey/interfaces/design_system/static/js/theme-manager.js
+++ b/src/osprey/interfaces/design_system/static/js/theme-manager.js
@@ -205,7 +205,7 @@ function _broadcast(id) {
   const iframes = document.querySelectorAll('iframe');
   for (const iframe of iframes) {
     try {
-      iframe.contentWindow?.postMessage({ type: MESSAGE_TYPE, theme: id }, '*');
+      iframe.contentWindow?.postMessage({ type: MESSAGE_TYPE, theme: id }, window.location.origin);
     } catch (error) {
       // Cross-origin -- expected for some iframes; nothing to do.
     }
@@ -242,6 +242,7 @@ function _applyTheme(id, { broadcast = false, transition = false } = {}) {
 
 /** @param {MessageEvent} event */
 function _handleMessage(event) {
+  if (event.origin !== window.location.origin) return;
   const data = event.data;
   if (!data || data.type !== MESSAGE_TYPE) return;
   // Never applies an arbitrary string to data-theme: _resolve() falls

--- a/src/osprey/interfaces/lattice_dashboard/static/dashboard.js
+++ b/src/osprey/interfaces/lattice_dashboard/static/dashboard.js
@@ -5,6 +5,7 @@
  */
 
 import { initTheme, subscribe, chartTheme } from '/design-system/js/theme-manager.js';
+import { applyEmbedded } from '/design-system/js/frame-params.js';
 
 // Panel embedded in the Web Terminal hub: apply the hub's broadcast theme
 // and follow live changes. theme-boot.js already applied data-theme
@@ -86,10 +87,7 @@ let sliderDebounceTimers = {};
 
 document.addEventListener('DOMContentLoaded', () => {
   // Check embedded query param
-  const params = new URLSearchParams(window.location.search);
-  if (params.get('embedded') === 'true') {
-    document.body.classList.add('embedded');
-  }
+  applyEmbedded();
 
   // Bind buttons
   document.getElementById('btn-refresh').addEventListener('click', refreshFast);

--- a/src/osprey/interfaces/okf_panel/static/app.js
+++ b/src/osprey/interfaces/okf_panel/static/app.js
@@ -29,6 +29,7 @@
  */
 
 import { initTheme } from "/design-system/js/theme-manager.js";
+import { applyEmbedded } from "/design-system/js/frame-params.js";
 import { debounce } from "/design-system/js/dom.js";
 
 // Panel embedded in the Web Terminal hub: apply the hub's broadcast theme and
@@ -37,9 +38,7 @@ import { debounce } from "/design-system/js/dom.js";
 // (replacing the legacy `theme:set` the panel's earlier TODO expected).
 initTheme({ role: "follower" });
 
-if (new URLSearchParams(window.location.search).get("embedded") === "true") {
-  document.body.classList.add("embedded");
-}
+applyEmbedded();
 
 (function () {
   // -- DOM handles -----------------------------------------------------------

--- a/src/osprey/interfaces/tuning/static/js/app.js
+++ b/src/osprey/interfaces/tuning/static/js/app.js
@@ -10,6 +10,7 @@ import { initOptimizationForm } from './optimization-form.js';
 import { initProgressDisplay } from './progress-display.js';
 import { initResultsViewer } from './results-viewer.js';
 import { initTheme } from '/design-system/js/theme-manager.js';
+import { applyEmbedded } from '/design-system/js/frame-params.js';
 
 // theme-boot.js (first script in <head>) already applied data-theme
 // before first paint. initTheme({role: 'follower'}) here wires the
@@ -19,10 +20,7 @@ import { initTheme } from '/design-system/js/theme-manager.js';
 // ---- Embedded Detection ----
 
 function checkEmbedded() {
-  const params = new URLSearchParams(window.location.search);
-  if (params.get('embedded') === 'true') {
-    document.body.classList.add('embedded');
-  }
+  applyEmbedded();
 }
 
 // ---- Tab Switching ----

--- a/src/osprey/interfaces/web_terminal/static/js/app.js
+++ b/src/osprey/interfaces/web_terminal/static/js/app.js
@@ -172,6 +172,7 @@ function initResizeHandle() {
 
 function initIframePasteBridge() {
   window.addEventListener('message', (e) => {
+    if (e.origin !== window.location.origin) return;
     // Accept paste-to-terminal messages from embedded iframes
     if (e.data && e.data.type === 'osprey-paste-to-terminal' && e.data.text) {
       pasteToTerminal(e.data.text);

--- a/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
@@ -342,10 +342,6 @@ async function initPanel(panel) {
     if (config.url && (config.available === undefined || config.available)) {
       state.url = config.url;
     }
-    // Some panels return a project name for session filtering
-    if (config.project) {
-      state.project = config.project;
-    }
   } catch {
     // Config endpoint not available — panel stays disabled
   } finally {
@@ -572,9 +568,6 @@ function navigatePanel(panelId, url) {
   const embedUrl = new URL(url, window.location.origin);
   embedUrl.searchParams.set('embedded', 'true');
   embedUrl.searchParams.set('theme', getTheme());
-  if (state.project) {
-    embedUrl.hash = `#/sessions?project=${encodeURIComponent(state.project)}`;
-  }
   state.iframe.src = embedUrl.toString();
   state.pendingUrl = null;
 }
@@ -599,9 +592,6 @@ function createIframe(panelId) {
   const embedUrl = new URL(targetUrl, window.location.origin);
   embedUrl.searchParams.set('embedded', 'true');
   embedUrl.searchParams.set('theme', getTheme());
-  if (state.project) {
-    embedUrl.hash = `#/sessions?project=${encodeURIComponent(state.project)}`;
-  }
   iframe.src = embedUrl.toString();
   iframe.sandbox = 'allow-scripts allow-same-origin allow-popups allow-forms allow-modals';
 

--- a/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
@@ -484,7 +484,7 @@ function updateStatusBar(panel) {
 function sendThemeToIframe(iframe) {
   if (!iframe?.contentWindow) return;
   try {
-    iframe.contentWindow.postMessage({ type: 'osprey-theme-change', theme: getTheme() }, '*');
+    iframe.contentWindow.postMessage({ type: 'osprey-theme-change', theme: getTheme() }, window.location.origin);
   } catch { /* cross-origin */ }
 }
 
@@ -504,7 +504,7 @@ function sendSessionToIframe(iframe) {
   const sid = getCurrentSessionId();
   if (!sid) return;
   try {
-    iframe.contentWindow.postMessage({ type: 'osprey-session-change', session_id: sid }, '*');
+    iframe.contentWindow.postMessage({ type: 'osprey-session-change', session_id: sid }, window.location.origin);
   } catch { /* cross-origin */ }
 }
 

--- a/src/osprey/interfaces/web_terminal/static/js/terminal.js
+++ b/src/osprey/interfaces/web_terminal/static/js/terminal.js
@@ -265,7 +265,7 @@ export function notifySessionChange(sessionId) {
     try {
       iframe.contentWindow.postMessage(
         { type: 'osprey-session-change', session_id: sessionId },
-        '*'
+        window.location.origin
       );
     } catch { /* cross-origin — ignore */ }
   });

--- a/src/osprey/interfaces/web_terminal/static/session.html
+++ b/src/osprey/interfaces/web_terminal/static/session.html
@@ -654,6 +654,7 @@
   // THEMES manifest before ever touching data-theme).
 
   window.addEventListener('message', (e) => {
+    if (e.origin !== window.location.origin) return;
     if (!e.data) return;
     if (e.data.type === 'osprey-session-change') {
       currentSessionId = e.data.session_id || null;

--- a/tests/interfaces/design_system/js/frame-params.test.js
+++ b/tests/interfaces/design_system/js/frame-params.test.js
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for the design-system micro-frontend query-param contract.
+ *
+ * Pure DOM/logic guard, happy-dom environment (configured globally):
+ *   npx vitest run tests/interfaces/design_system/js/frame-params.test.js
+ *
+ * Covers CONTRACT_VERSION and applyEmbedded().
+ *
+ * NOTE: frame-params.js is imported by RELATIVE path, not the absolute
+ * `/design-system/js/frame-params.js` runtime specifier — Vitest/Vite
+ * resolves against the repo root with no alias configured, so the absolute
+ * path would not load. This mirrors tests/interfaces/design_system/js/dom.test.js.
+ */
+
+import { test, expect, describe, afterEach } from 'vitest';
+
+import {
+  applyEmbedded,
+  CONTRACT_VERSION,
+} from '../../../../src/osprey/interfaces/design_system/static/js/frame-params.js';
+
+describe('applyEmbedded', () => {
+  afterEach(() => {
+    document.body.className = '';
+  });
+
+  test('?embedded=true adds the embedded class to document.body', () => {
+    window.history.replaceState({}, '', '?embedded=true');
+
+    applyEmbedded();
+
+    expect(document.body.classList.contains('embedded')).toBe(true);
+  });
+
+  test('no embedded param leaves the embedded class absent', () => {
+    window.history.replaceState({}, '', '?');
+
+    applyEmbedded();
+
+    expect(document.body.classList.contains('embedded')).toBe(false);
+  });
+
+  test('?embedded=false leaves the embedded class absent', () => {
+    window.history.replaceState({}, '', '?embedded=false');
+
+    applyEmbedded();
+
+    expect(document.body.classList.contains('embedded')).toBe(false);
+  });
+
+  test('?embedded=1 leaves the embedded class absent', () => {
+    window.history.replaceState({}, '', '?embedded=1');
+
+    applyEmbedded();
+
+    expect(document.body.classList.contains('embedded')).toBe(false);
+  });
+});
+
+describe('CONTRACT_VERSION', () => {
+  test('is a non-empty string', () => {
+    expect(typeof CONTRACT_VERSION).toBe('string');
+    expect(CONTRACT_VERSION.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/interfaces/web_terminal/test_contract_params.py
+++ b/tests/interfaces/web_terminal/test_contract_params.py
@@ -1,0 +1,390 @@
+"""Browser tests for the shell<->panel micro-frontend contract (Phase 1).
+
+Proves the three transports a host page (the web-terminal hub, or a
+standalone panel opened directly) and an embedded panel use to talk to each
+other, each of which is invisible to a FastAPI ``TestClient`` because it
+requires a real browser evaluating real page script:
+
+- **query = creation-time config.** ``?embedded=true`` -> ``applyEmbedded()``
+  (design-system ``frame-params.js``) adds the ``embedded`` class to
+  ``document.body``; ``?theme=<id>`` -> ``theme-boot.js`` applies
+  ``data-theme`` before first paint and ``theme-manager.js`` follows it.
+  See :func:`test_query_params_configure_embedded_and_theme`.
+- **hash = panel-owned deep-link.** okf_panel reads its own
+  ``location.hash`` and routes to that concept on load
+  (``readPanelParams``/``bootFromParams`` in okf_panel's ``app.js``); the hub
+  sets no hash at all. See :func:`test_hash_deep_links_to_concept`.
+- **postMessage = live push.** Senders post with target origin
+  ``window.location.origin``; receivers guard with
+  ``if (e.origin !== window.location.origin) return;``. A real same-page
+  ``postMessage`` always stamps ``event.origin`` as the page's own origin, so
+  it can only exercise the *accept* path; the *reject* path is exercised with
+  an in-page synthetic ``window.dispatchEvent(new MessageEvent('message',
+  {origin: 'https://evil.example', ...}))``, which is the only way to give
+  ``event.origin`` a value a real cross-document postMessage could never
+  produce here.
+
+All four postMessage receivers are driven directly in a live browser (no
+review-based fallback was needed):
+
+- ``theme-manager.js`` ``_handleMessage`` -- :func:`test_postmessage_theme_change_same_origin_only`
+- ``artifacts`` gallery.js session-change receiver -- :func:`test_postmessage_session_change_gallery_rejects_foreign_origin`
+- ``web_terminal`` ``session.html`` session-change receiver --
+  :func:`test_postmessage_session_change_session_html_rejects_foreign_origin`.
+  ``/static/session.html`` turned out to be independently drivable: web_terminal's
+  ``configure_interface_app(app, static_dir=STATIC_DIR)`` mounts the interface's
+  whole ``static/`` directory at ``/static``, and ``session.html`` lives directly
+  under it, so ``GET /static/session.html`` serves it like any other static asset.
+- ``web_terminal`` app.js paste-to-terminal receiver -- :func:`test_postmessage_paste_to_terminal_rejects_foreign_origin`
+
+Each postMessage test also includes a same-origin "positive control" after
+the foreign-origin rejection check: a genuine same-origin message that IS
+expected to take effect. This guards against a vacuous pass -- proving the
+detection technique used for the rejection assertion (a request URL, or a
+WebSocket frame) is actually capable of observing the effect it claims is
+absent.
+
+Run:
+    .venv/bin/python -m pytest tests/interfaces/web_terminal/test_contract_params.py -v
+
+Skips cleanly when the chromium headless binary is not installed.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from tests.interfaces.test_load_smokes import (
+    _launch_ariel,
+    _launch_artifacts,
+    _launch_channel_finder,
+    _launch_lattice_dashboard,
+    _launch_okf_panel,
+    _launch_tuning,
+    _launch_web_terminal,
+)
+
+try:
+    from playwright.sync_api import expect
+
+    _PLAYWRIGHT_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _PLAYWRIGHT_AVAILABLE = False
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+
+# ---------------------------------------------------------------------------
+# (1) query = creation-time config: ?embedded=true, ?theme=<id>
+# ---------------------------------------------------------------------------
+
+
+# Every panel that the hub embeds shares one reader (frame-params.applyEmbedded())
+# and one theme follower (theme-manager + pre-paint theme-boot.js), but each calls
+# applyEmbedded() at a different site/timing (inline top-level, inside init(),
+# inside checkEmbedded(), inside a DOMContentLoaded handler) -- so the query=config
+# arm is asserted for ALL five, not just one, to prove no per-panel migration
+# regressed the observable outcome.
+_EMBEDDED_PANELS = [
+    ("channel_finder", _launch_channel_finder),
+    ("okf_panel", _launch_okf_panel),
+    ("ariel", _launch_ariel),
+    ("tuning", _launch_tuning),
+    ("lattice_dashboard", _launch_lattice_dashboard),
+]
+
+
+@pytest.mark.parametrize(
+    ("panel_name", "launch"),
+    _EMBEDDED_PANELS,
+    ids=[name for name, _ in _EMBEDDED_PANELS],
+)
+def test_query_params_configure_embedded_and_theme(
+    panel_name, launch, tmp_path, monkeypatch, chromium_browser
+):
+    """``?embedded=true`` adds ``body.embedded``; ``?theme=dark`` applies data-theme -- every panel.
+
+    Drives each of the five embedded panels with the same creation-time query
+    config and asserts the observable outcome -- the ``embedded`` body class
+    (from ``frame-params.applyEmbedded()``) and the requested ``data-theme``
+    (from pre-paint ``theme-boot.js`` + the ``theme-manager`` follower).
+    Requesting theme id 'dark' -- rather than relying on the auto-resolved
+    default, which is 'light' under headless Chromium's default no-preference
+    color scheme -- proves the query param, not the auto default, drove the
+    result.
+    """
+    # Arrange
+    with launch(tmp_path, monkeypatch) as base_url:
+        page = chromium_browser.new_page()
+
+        # Act
+        page.goto(f"{base_url}?embedded=true&theme=dark", wait_until="load")
+
+        # Assert -- applyEmbedded() (frame-params.js) added the embedded class.
+        expect(page.locator("body.embedded")).to_have_count(1)
+        # Assert -- theme-boot.js (pre-paint) + theme-manager.js applied 'dark'.
+        expect(page.locator("html[data-theme='dark']")).to_have_count(1)
+
+        page.close()
+
+
+# ---------------------------------------------------------------------------
+# (2) hash = panel-owned deep-link
+# ---------------------------------------------------------------------------
+
+
+def test_hash_deep_links_to_concept(tmp_path, monkeypatch, chromium_browser):
+    """okf_panel's own ``#<conceptId>`` hash routes to that concept on load.
+
+    The hub sets no hash at all (the dead ``#/sessions?project=`` grammar was
+    removed) -- this transport is entirely panel-owned. Drives okf_panel
+    standalone with a hash matching a real concept in the shared fixture
+    bundle (``tests/interfaces/okf_panel/fixtures/bundle/control-system/
+    channel-finding.md``, frontmatter title "Channel Finding") and asserts
+    the reading pane actually rendered that concept -- not the default
+    structure overview ``bootFromParams()`` falls back to when there is no
+    hash.
+    """
+    # Arrange
+    with _launch_okf_panel(tmp_path, monkeypatch) as base_url:
+        page = chromium_browser.new_page()
+
+        # Act
+        page.goto(f"{base_url}#control-system/channel-finding", wait_until="load")
+
+        # Assert -- renderConcept() (app.js) set the reading-pane heading to
+        # the concept's frontmatter title.
+        expect(page.locator("h1.concept-title")).to_have_text("Channel Finding", timeout=10_000)
+        # Assert -- highlightActive() marked the matching sidebar entry active.
+        expect(
+            page.locator('.concept-link.active[data-concept-id="control-system/channel-finding"]')
+        ).to_be_attached(timeout=10_000)
+
+        page.close()
+
+
+# ---------------------------------------------------------------------------
+# (3) postMessage = live push
+# ---------------------------------------------------------------------------
+
+
+def test_postmessage_theme_change_same_origin_only(tmp_path, monkeypatch, chromium_browser):
+    """theme-manager's ``_handleMessage`` applies same-origin broadcasts, drops foreign ones.
+
+    A genuine same-page ``postMessage`` always stamps ``event.origin`` as the
+    page's own origin -- there is no way to make a real postMessage arrive
+    with a spoofed origin -- so the acceptance step below is a real exercise
+    of the accept path. The rejection step fakes a foreign origin via an
+    in-page synthetic ``dispatchEvent(new MessageEvent(...))``.
+    """
+    # Arrange
+    with _launch_channel_finder(tmp_path, monkeypatch) as base_url:
+        page = chromium_browser.new_page()
+        page.goto(f"{base_url}?theme=dark", wait_until="load")
+        expect(page.locator("html[data-theme='dark']")).to_have_count(1)
+
+        # Act -- genuine same-origin postMessage.
+        page.evaluate(
+            "window.postMessage({type: 'osprey-theme-change', theme: 'light'},"
+            " window.location.origin)"
+        )
+        # Assert -- accepted: theme changed.
+        expect(page.locator("html[data-theme='light']")).to_have_count(1)
+
+        # Act -- synthetic foreign-origin MessageEvent.
+        page.evaluate(
+            """
+            () => window.dispatchEvent(new MessageEvent('message', {
+                origin: 'https://evil.example',
+                data: {type: 'osprey-theme-change', theme: 'dark'},
+            }))
+            """
+        )
+        # Assert -- rejected: theme-manager.js's origin guard
+        # (`if (event.origin !== window.location.origin) return;`) dropped it
+        # before touching data-theme, so it is still 'light' from the
+        # accepted message above, not 'dark' from the rejected one.
+        expect(page.locator("html[data-theme='light']")).to_have_count(1)
+
+        page.close()
+
+
+def test_postmessage_session_change_gallery_rejects_foreign_origin(
+    tmp_path, monkeypatch, chromium_browser
+):
+    """artifacts gallery.js's session-change receiver drops foreign-origin messages.
+
+    ``fetchArtifacts()`` appends ``?session_id=<currentSessionId>`` to its own
+    request whenever ``currentSessionId`` is set (and ``showAllSessions`` is
+    false), so the request URL is the observable signal for whether the
+    receiver actually updated ``currentSessionId``. The genuine handler also
+    calls ``fetchArtifacts()`` itself on acceptance, so the positive-control
+    request below needs no extra UI action to trigger it.
+    """
+    # Arrange
+    with _launch_artifacts(tmp_path, monkeypatch) as base_url:
+        page = chromium_browser.new_page()
+
+        with page.expect_request(lambda r: "/api/artifacts" in r.url) as initial_info:
+            page.goto(base_url, wait_until="load")
+        assert "session_id" not in initial_info.value.url
+
+        # Act -- synthetic foreign-origin session-change.
+        page.evaluate(
+            """
+            () => window.dispatchEvent(new MessageEvent('message', {
+                origin: 'https://evil.example',
+                data: {type: 'osprey-session-change', session_id: 'evil-session-999'},
+            }))
+            """
+        )
+        # Assert -- rejected: currentSessionId did not change, so an
+        # independent refresh click still fetches with no session_id.
+        with page.expect_request(lambda r: "/api/artifacts" in r.url) as rejected_info:
+            page.locator("#refresh-btn").click()
+        assert "evil-session-999" not in rejected_info.value.url
+        assert "session_id" not in rejected_info.value.url
+
+        # Act -- genuine same-origin session-change (positive control).
+        with page.expect_request(lambda r: "/api/artifacts" in r.url) as accepted_info:
+            page.evaluate(
+                "window.postMessage({type: 'osprey-session-change',"
+                " session_id: 'contract-test-session'}, window.location.origin)"
+            )
+        # Assert -- accepted: the handler's own fetchArtifacts() call carries
+        # the new session id, proving the rejection assertion above would
+        # have caught a real leak.
+        assert "session_id=contract-test-session" in accepted_info.value.url
+
+        page.close()
+
+
+def test_postmessage_session_change_session_html_rejects_foreign_origin(
+    tmp_path, monkeypatch, chromium_browser
+):
+    """web_terminal's /static/session.html session-change receiver rejects foreign origin.
+
+    ``session.html`` is served directly by web_terminal's own ``/static``
+    mount (``configure_interface_app(app, static_dir=STATIC_DIR)`` in
+    ``osprey/interfaces/web_terminal/app.py`` mounts the whole static
+    directory, and ``session.html`` lives at its top level), so it is
+    independently drivable rather than needing a review-based fallback.
+    ``apiFetch()`` appends ``&session_id=<currentSessionId>`` to every
+    request once ``currentSessionId`` is set, so the request URL for a view
+    fetch is the observable signal for whether the receiver updated it.
+    """
+    # Arrange
+    with _launch_web_terminal(tmp_path, monkeypatch) as base_url:
+        page = chromium_browser.new_page()
+
+        with page.expect_request(lambda r: "/api/session-agents" in r.url) as initial_info:
+            page.goto(f"{base_url}/static/session.html", wait_until="load")
+        assert "session_id" not in initial_info.value.url
+
+        # Act -- synthetic foreign-origin session-change.
+        page.evaluate(
+            """
+            () => window.dispatchEvent(new MessageEvent('message', {
+                origin: 'https://evil.example',
+                data: {type: 'osprey-session-change', session_id: 'evil-session-999'},
+            }))
+            """
+        )
+        # Assert -- rejected: currentSessionId did not change; switching to
+        # the Tool Log view still fetches with no (foreign) session_id.
+        with page.expect_request(lambda r: "/api/session-log" in r.url) as rejected_info:
+            page.locator('.pill[data-view="toollog"]').click()
+        assert "evil-session-999" not in rejected_info.value.url
+        assert "session_id" not in rejected_info.value.url
+
+        # Act -- genuine same-origin session-change (positive control). The
+        # handler calls refreshActive() itself, re-fetching the currently
+        # active view (Tool Log, from the click above) with the new session id.
+        with page.expect_request(lambda r: "/api/session-log" in r.url) as accepted_info:
+            page.evaluate(
+                "window.postMessage({type: 'osprey-session-change',"
+                " session_id: 'contract-test-session'}, window.location.origin)"
+            )
+        # Assert -- accepted, proving the rejection assertion above would
+        # have caught a real leak.
+        assert "session_id=contract-test-session" in accepted_info.value.url
+
+        page.close()
+
+
+def test_postmessage_paste_to_terminal_rejects_foreign_origin(
+    tmp_path, monkeypatch, chromium_browser
+):
+    """web_terminal app.js's paste bridge drops foreign-origin messages.
+
+    ``pasteToTerminal()`` (terminal.js) sends the pasted text straight over
+    the PTY WebSocket, so a real network-level ``framesent`` event -- not a
+    JS-level spy -- is the observable signal. The test waits for the
+    ``{"type": "resize"}`` handshake frame terminal.js's ``onOpen`` sends
+    immediately once connected before dispatching either message:
+    ``pasteToTerminal()`` silently no-ops while the socket isn't OPEN yet
+    (api.js's ``send()`` guards on ``ws.readyState === WebSocket.OPEN``), so
+    dispatching before the socket opens would make the rejection assertion
+    pass vacuously. (``#session-led.active`` was tried first but is not a
+    reliable readiness signal here: this test's fixture shell command is
+    ``echo hello``, which exits almost instantly, and the LED is removed as
+    soon as the resulting ``{"type": "exit"}`` message arrives -- even though
+    the socket itself stays open and paste still works.)
+    """
+    # Arrange
+    with _launch_web_terminal(tmp_path, monkeypatch) as base_url:
+        page = chromium_browser.new_page()
+        sent_frames: list[str] = []
+
+        def _on_websocket(ws) -> None:
+            ws.on("framesent", lambda payload: sent_frames.append(payload))
+
+        page.on("websocket", _on_websocket)
+
+        page.goto(base_url, wait_until="load")
+        expect(page.locator('button[data-panel-id="artifacts"]')).to_be_visible(timeout=10_000)
+        # Confirm the socket is actually OPEN (not just created) by polling
+        # the already-attached framesent listener for the resize handshake
+        # frame terminal.js's onOpen sends first. A one-shot
+        # ws.wait_for_event() would race: on this fixture's near-instant
+        # 'echo hello' shell command, the resize frame is typically sent (and
+        # the listener above already recorded it) well before this line runs,
+        # so waiting for a *future* framesent event would time out on a frame
+        # that already happened.
+        deadline = time.monotonic() + 10.0
+        while not any("resize" in frame for frame in sent_frames):
+            if time.monotonic() > deadline:
+                raise AssertionError(
+                    f"Never observed a 'resize' handshake frame on the terminal "
+                    f"WebSocket within 10s; frames seen so far: {sent_frames}"
+                )
+            page.wait_for_timeout(50)
+
+        # Act -- synthetic foreign-origin paste.
+        page.evaluate(
+            """
+            () => window.dispatchEvent(new MessageEvent('message', {
+                origin: 'https://evil.example',
+                data: {type: 'osprey-paste-to-terminal', text: 'contract-test-foreign-paste'},
+            }))
+            """
+        )
+        # Best-effort settle: proving an ABSENCE of a network-level side
+        # effect has no DOM/state to auto-wait on, unlike the other arms.
+        page.wait_for_timeout(300)
+        # Assert -- rejected: nothing sent over the PTY socket.
+        assert not any("contract-test-foreign-paste" in frame for frame in sent_frames), sent_frames
+
+        # Act -- genuine same-origin paste (positive control).
+        page.evaluate(
+            "window.postMessage({type: 'osprey-paste-to-terminal',"
+            " text: 'contract-test-accepted-paste'}, window.location.origin)"
+        )
+        page.wait_for_timeout(300)
+        # Assert -- accepted, proving the rejection assertion above would
+        # have caught a real leak.
+        assert any("contract-test-accepted-paste" in frame for frame in sent_frames), sent_frames
+
+        page.close()


### PR DESCRIPTION
## Phase 1 — Micro-frontend shell↔panel contract

Formalizes OSPREY's implicit web-terminal shell↔panel boundary into a **documented, versioned micro-frontend contract** with three explicit transports:

- **query = creation-time config** — `?embedded=true`, `?theme=` set when the hub builds the iframe URL, read at panel boot.
- **hash = panel-owned deep-link** — each panel owns its own `#…` grammar (okf routes from `#<conceptId>`); the hub sets no hash.
- **postMessage = live push** — runtime hub→panel updates, now same-origin.

This is the first phase of the Front-End Foundation program (follows #330's Phase 0 + 0.5). It **ratchets** the existing-but-implicit contract — de-duplicates, prunes dead code, hardens — without redesigning transports.

## What's in it (5 atomic commits)

1. **`feat(design-system):` frame-params reader** — a shared `applyEmbedded()` + `CONTRACT_VERSION` module (`/design-system/js/frame-params.js`), with a Vitest unit spec.
2. **`refactor(interfaces):` migrate 5 panels** — replace the copy-pasted `?embedded=true` reader in channel_finder, okf_panel, ariel, tuning, and lattice_dashboard with `applyEmbedded()` (tailored per-site edits; all five load as ES modules).
3. **`refactor(web-terminal):` remove dead hash grammar** — delete the orphaned `#/sessions?project=` basePath-style grammar (verified no producer/consumer; added for the since-removed `agentsview` panel).
4. **`feat(interfaces):` same-origin postMessage hardening** — four hub→panel senders → `window.location.origin`; four receivers gain an `event.origin` guard; two intentional cross-origin `gallery.js` posts stay `'*'` with documenting comments.
5. **`test(web-terminal):` contract browser test + CI wiring** — a `browser`-marked Playwright suite proving all three transports end-to-end (incl. same-origin acceptance + synthetic foreign-origin rejection on all four receivers), wired into the `visual-theming` CI job.

## Testing

- **17/17** browser suite — 10 contract-param assertions (query=config on all 5 panels, hash deep-link via okf standalone, postMessage live-push + foreign-origin rejection ×4 receivers) + 7 load smokes.
- **22/22** Vitest, `tsc --noEmit` clean, `ruff` clean.
- The new test file (and the pre-existing `test_panels_browser.py`) were outside the `visual-theming` CI `paths-filter` and run command — both fixed here, so the suite actually executes in CI.

## Deliberately deferred

- The **"Embedding OSPREY Panels" how-to + CHANGELOG entry** are held until the front-end surface stabilizes (Phase 2's planned import map will change the absolute-import convention a how-to would document; the contract is currently developer-facing, not operator-facing). The decision log lives in the program tracker.

## Follow-ups (not in this PR)

- A **full-spine integration-test strategy** (browser-first, real MCP/DB/sim, cross-seam assertions) is scoped as a separate future workstream — the long-term answer to functional (not just smoke) front-end coverage.
