### PR TITLE
test: relocate real-LLM InContextBackend test to tests/e2e/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- The `InContextBackend` benchmark test (the sole real-LLM test outside `tests/e2e/`) moved into `tests/e2e/`, so the fast lane (`pytest tests/ --ignore=tests/e2e`) stays hermetic even when a provider key is exported — previously it made a live LLM call and failed with an unrelated gateway auth error on a blocked/expired key. A placement guard prevents recurrence for the whole credentialed `requires_*` marker family.
 - Web companion servers (Artifacts, ARIEL, Tuning, Channel Finder, Lattice, KNOWLEDGE) no longer skip their launch when a stale or foreign process briefly answers `/health` on their port during a restart, which previously left the panel unbacked and permanently 502ing. The launcher now decides ownership by whether a live TCP listener holds the port, waits out a shutting-down predecessor, and logs distinctly when it defers to a legitimate external server versus when the port is held by an unresponsive one (#327).
 - The session activity page ("Activity" / session log viewer) no longer applies its `?theme=` query parameter directly to the page; an invalid or unexpected value now falls back to the resolved default instead of being written straight into the page's theme attribute.
 - Web Terminal's and Artifacts' syntax-highlighting theme stylesheet no longer 404s in the default CDN vendor mode (it was previously served from a hardcoded local vendor path regardless of the configured vendor mode).

--- a/tests/e2e/test_in_context_backend.py
+++ b/tests/e2e/test_in_context_backend.py
@@ -1,4 +1,11 @@
-"""Integration tests for InContextBackend — real subprocess + real LLM call."""
+"""Integration tests for InContextBackend — real subprocess + real LLM call.
+
+Lives under ``tests/e2e/`` because it makes a real credentialed LLM call (the
+inner ``query_channels`` model call happens inside the spawned MCP subprocess).
+Keeping it here means the fast lane — ``pytest tests/ --ignore=tests/e2e`` — is
+hermetic regardless of which provider keys a developer happens to have exported;
+the placement guard in ``tests/test_api_marker_placement.py`` enforces this.
+"""
 
 from __future__ import annotations
 

--- a/tests/test_api_marker_placement.py
+++ b/tests/test_api_marker_placement.py
@@ -1,0 +1,84 @@
+"""Placement guard: credentialed-resource tests must live under ``tests/e2e/``.
+
+The fast lane is invoked as ``pytest tests/ --ignore=tests/e2e`` (see
+``CLAUDE.md`` and ``.github/workflows/ci.yml``). That command must not make
+credentialed provider calls *regardless of which keys a developer has
+exported*.
+
+The ``requires_<resource>`` skip-gates in ``tests/conftest.py`` are
+one-directional: each skips when its resource is *absent*, but silently
+exercises the real resource when it is *present*. For a credentialed marker
+(``requires_api`` / ``requires_als_apg`` / ``requires_anthropic``) that means a
+live LLM call — which passes on a clean machine yet fails on a blocked or
+expired key for anyone who has a key in their shell. That non-determinism is
+what this guard prevents.
+
+We **default-deny** the entire ``requires_*`` marker family outside
+``tests/e2e/`` rather than enumerate the credentialed ones, so a newly-added
+credentialed marker is guarded automatically. Only keyless/local resources are
+allowlisted below — they have no credential and no gateway-auth failure mode,
+so they are fine in the fast lane (e.g. the ARIEL integration tests that gate
+on a local Ollama server). If you add a new keyless resource marker, add it to
+``_KEYLESS_ALLOWLIST``; if it needs a credential, put the test under
+``tests/e2e/`` instead.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# Any `pytest.mark.requires_<resource>` usage. Captures the marker name so we
+# can allowlist keyless resources. The `mark.` prefix excludes the unrelated
+# provider attribute `requires_api_key` (which appears as `.requires_api_key`,
+# never `mark.requires_...`).
+_MARKER_RE = re.compile(r"mark\.(requires_\w+)")
+
+# Keyless / local resources — no credential, no gateway-auth failure mode, so
+# leaving them in the fast lane is safe. Everything else in the requires_*
+# family is treated as credentialed and must live under tests/e2e/.
+_KEYLESS_ALLOWLIST = frozenset({"requires_ollama"})
+
+_TESTS_ROOT = Path(__file__).resolve().parent
+_E2E_ROOT = _TESTS_ROOT / "e2e"
+
+
+def _fast_lane_test_files() -> list[Path]:
+    """Every ``.py`` source the fast lane could collect (all of tests/ except
+    the path-excluded ``tests/e2e/`` subtree, and this guard file itself)."""
+    self_path = Path(__file__).resolve()
+    files: list[Path] = []
+    for path in _TESTS_ROOT.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        resolved = path.resolve()
+        if _E2E_ROOT in resolved.parents:
+            continue
+        if resolved == self_path:  # this guard names the markers in prose above
+            continue
+        files.append(path)
+    return files
+
+
+def test_no_credentialed_markers_outside_e2e() -> None:
+    offenders: list[str] = []
+    for path in _fast_lane_test_files():
+        try:
+            content = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        hits: list[str] = []
+        for i, ln in enumerate(content.splitlines(), start=1):
+            for marker in _MARKER_RE.findall(ln):
+                if marker not in _KEYLESS_ALLOWLIST:
+                    hits.append(f"{i}: {ln.strip()}")
+                    break
+        if hits:
+            rel = path.relative_to(_TESTS_ROOT)
+            offenders.append(f"tests/{rel}:\n  " + "\n  ".join(hits))
+    assert not offenders, (
+        "Credentialed `requires_*` tests must live under tests/e2e/ so the fast "
+        "lane (`pytest tests/ --ignore=tests/e2e`) makes no credentialed call "
+        "when a key is present. Move these to tests/e2e/ (or, if the resource is "
+        "keyless/local, add its marker to _KEYLESS_ALLOWLIST):\n" + "\n".join(offenders)
+    )


### PR DESCRIPTION
## Problem

`tests/services/channel_finder/benchmarks/test_in_context_backend.py` was the only test outside `tests/e2e/` that both carried `pytest.mark.requires_api` and made a real credentialed LLM call (the inner `query_channels` model call happens inside a spawned MCP subprocess).

The fast lane — `pytest tests/ --ignore=tests/e2e`, documented in `CLAUDE.md`/`CONTRIBUTING.md` as needing no API keys — is only hermetic by luck. The `requires_api` skip-gate in `tests/conftest.py` is one-directional: it skips when no provider key is present, but silently fires a live call when a key *is* exported. Result:

- The same command is green for a contributor with a clean shell and red for one whose gateway key happens to be blocked/expired (a contributor hit `AuthenticationError: Key is blocked` — unrelated to their change and unfixable from their side).
- The test ran in **no CI lane at all**: the unit lane skips it for lack of a key, and the e2e lane collects by path and never saw it. The backend's plumbing had zero CI coverage.

## Change

1. Move the test into `tests/e2e/test_in_context_backend.py` (all imports are absolute `osprey.*`, so it relocates cleanly). It now runs in the key-gated e2e lane alongside every other real-LLM test, restoring the "fast lane needs no keys" invariant and *gaining* the CI coverage it never had.
2. Add `tests/test_api_marker_placement.py` — a fast-lane guard that **default-denies** the credentialed `requires_*` marker family outside `tests/e2e/` (keyless/local resources like `requires_ollama` are allowlisted). This covers the repo's dominant `requires_als_apg` convention, not just `requires_api`, so the defect can't recur under any credentialed marker.
3. Terse CHANGELOG entry.

## Verification

- Fast lane no longer collects the moved test; full `--collect-only` = 5706 tests, no import errors.
- Moved test **runs green in the e2e lane** with a live key (2 passed).
- Guard passes on the current tree (ARIEL's out-of-e2e `requires_ollama` tests are correctly allowed), fails on a `requires_als_apg` file dropped outside e2e, and allows a keyless `requires_ollama` file.