### PR TITLE
Front-end: close render-sink XSS, add tests, tidy artifact gallery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Compatibility is documented in release notes, not encoded in the version string.
 - The event dispatcher dashboard now themes itself from the shared OSPREY design system instead of a hardcoded dark palette, and follows the web-terminal hub's theme when embedded as the EVENTS panel. **Requires a dispatcher container redeploy** to pick up the new `/design-system/*` asset route.
 - Every interface's light/dark toggle is now the shared `<osprey-theme-switcher>` custom element (previously per-interface markup); it's consistently hidden when a panel is embedded in the Web Terminal hub (the hub owns theme chrome there) and visible when opened standalone.
 - JSON artifacts in the Artifacts gallery now render through a syntax-highlighted, collapsible inline viewer instead of a plain read-only iframe of the raw file.
+- Artifacts gallery: timeseries table values now use magnitude-adaptive precision (≤5 significant figures, scientific notation for extremes) and a compact month/day + HH:MM:SS index format.
 
 ### Removed
 
@@ -50,6 +51,7 @@ Compatibility is documented in release notes, not encoded in the version string.
 - Channel Finder's embedded mode no longer hides its whole header: only the logo is hidden now, so the pipeline switcher and navigation stay visible and usable when embedded in the Web Terminal hub (previously the entire header — including those controls — was hidden, with no compensating layout change).
 - Toggling the theme (in the Web Terminal hub or any standalone interface) no longer leaves a stale `?theme=` in the URL; reloading after a toggle now falls back to your saved preference (or the OS setting in `auto` mode) instead of being pinned to whatever value was in the URL at toggle time.
 - Creating a new artifact from the Web Terminal's Scaffold gallery no longer fails with an HTTP 405 — the create-artifact request now uses `POST` directly instead of being routed through a GET-only fetch helper.
+- Artifacts gallery: filter chips no longer accumulate click listeners across live-refresh cycles, and a failed Plotly script load is retried on the next chart render instead of failing for the rest of the page's lifetime.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ Compatibility is documented in release notes, not encoded in the version string.
 - Toggling the theme (in the Web Terminal hub or any standalone interface) no longer leaves a stale `?theme=` in the URL; reloading after a toggle now falls back to your saved preference (or the OS setting in `auto` mode) instead of being pinned to whatever value was in the URL at toggle time.
 - Creating a new artifact from the Web Terminal's Scaffold gallery no longer fails with an HTTP 405 — the create-artifact request now uses `POST` directly instead of being routed through a GET-only fetch helper.
 
+### Security
+
+- Artifacts gallery: agent-supplied artifact metadata (`category`, `artifact_type`, type-registry labels) is now HTML-escaped at every render sink, the shared `escapeHtml` escapes quotes for attribute contexts, and artifact ids are percent-encoded in URL paths — closing a stored-XSS in the gallery sidebar.
+
 ## [2026.6.3] - 2026-06-29
 
 ### Fixed

--- a/src/osprey/interfaces/artifacts/static/css/gallery.css
+++ b/src/osprey/interfaces/artifacts/static/css/gallery.css
@@ -1741,15 +1741,6 @@ body.resizing iframe {
     padding: 2px 6px;
   }
 
-  .focus-container {
-    padding: var(--space-4);
-  }
-
-  .focus-footer {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
   .timeline-thumb {
     height: 60px;
   }

--- a/src/osprey/interfaces/artifacts/static/js/gallery.js
+++ b/src/osprey/interfaces/artifacts/static/js/gallery.js
@@ -205,6 +205,22 @@ function debounce(fn, ms) {
 /** @type {any} */
 let sseSource = null;
 
+/**
+ * Select an artifact as both the on-screen selection and the agent-focus
+ * target, re-render, and optionally enter fullscreen. Shared by the SSE
+ * "focus" handler's two branches (artifact already local vs. fetched on
+ * retry) so the select→focus→render→fullscreen sequence has one definition.
+ * @param {any} artifact
+ * @param {boolean} wantFullscreen
+ */
+function applyFocus(artifact, wantFullscreen) {
+  setSelectedArtifact(artifact);
+  setFocusedArtifact(artifact);
+  sidebarRenderer.renderSidebar();
+  previewRenderer.renderPreview();
+  if (wantFullscreen) previewRenderer.enterFullscreen(artifact);
+}
+
 function connectSSE() {
   if (sseSource) { sseSource.close(); sseSource = null; }
   const source = new EventSource("/api/events");
@@ -223,11 +239,7 @@ function connectSSE() {
       if (focusId) {
         const a = getArtifacts().find((x) => x.id === focusId);
         if (a) {
-          setSelectedArtifact(a);
-          setFocusedArtifact(a);
-          sidebarRenderer.renderSidebar();
-          previewRenderer.renderPreview();
-          if (wantFullscreen) previewRenderer.enterFullscreen(a);
+          applyFocus(a, wantFullscreen);
           // Scroll the selected item into view
           requestAnimationFrame(() => {
             const sel = sidebarBody.querySelector(`[data-id="${focusId}"]`);
@@ -237,13 +249,7 @@ function connectSSE() {
           // Artifact not yet in local list — refresh and retry
           fetchArtifacts().then(() => {
             const retry = getArtifacts().find((x) => x.id === focusId);
-            if (retry) {
-              setSelectedArtifact(retry);
-              setFocusedArtifact(retry);
-              sidebarRenderer.renderSidebar();
-              previewRenderer.renderPreview();
-              if (wantFullscreen) previewRenderer.enterFullscreen(retry);
-            }
+            if (retry) applyFocus(retry, wantFullscreen);
           });
         }
       }

--- a/src/osprey/interfaces/artifacts/static/js/logbook.js
+++ b/src/osprey/interfaces/artifacts/static/js/logbook.js
@@ -15,6 +15,7 @@
  */
 
 import { getFocusedArtifact, getSelectedArtifact } from "./state.js";
+import { escapeHtml } from "/design-system/js/dom.js";
 
 // Pencil icon SVG for the logbook button
 const PENCIL_ICON = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>';
@@ -227,18 +228,17 @@ function renderArtifactPicker(list) {
     var label = document.createElement("label");
     label.className = "logbook-checkbox-label logbook-artifact-pick-item";
     label.innerHTML =
-      '<input type="checkbox" value="' + art.id + '"' + (isCurrentArtifact ? " checked" : "") + '>' +
+      '<input type="checkbox"' + (isCurrentArtifact ? " checked" : "") + '>' +
       '<span class="logbook-artifact-pick-title">' + escapeHtml(art.title || art.id) + '</span>' +
       '<span class="logbook-artifact-pick-type">' + escapeHtml(art.artifact_type || "") + '</span>';
+    // Assigned as a DOM property (not interpolated into the innerHTML
+    // string above) so the id can never break out of the attribute —
+    // property assignment bypasses HTML parsing entirely. getContextValues()
+    // reads it back via `cb.value`, which is unaffected by this change.
+    var checkbox = /** @type {HTMLInputElement} */ (label.querySelector('input[type=checkbox]'));
+    checkbox.value = art.id;
     list.appendChild(label);
   });
-}
-
-/** @param {unknown} str */
-function escapeHtml(str) {
-  var div = document.createElement("div");
-  div.textContent = /** @type {any} */ (str);
-  return div.innerHTML;
 }
 
 // ---- Phase management ----

--- a/src/osprey/interfaces/artifacts/static/js/logbook.js
+++ b/src/osprey/interfaces/artifacts/static/js/logbook.js
@@ -11,10 +11,10 @@
  *   P2d — Composing (spinner)
  *   P3  — Review Form (subject, details, tags → submit)
  *
- * Depends on: state.js (for getFocusedArtifact/getSelectedArtifact)
+ * Depends on: state.js (for getSelectedArtifact)
  */
 
-import { getFocusedArtifact, getSelectedArtifact } from "./state.js";
+import { getSelectedArtifact } from "./state.js";
 import { escapeHtml } from "/design-system/js/dom.js";
 
 // Pencil icon SVG for the logbook button
@@ -611,19 +611,11 @@ function createLogbookBtn(opts) {
 }
 
 /**
- * Inject logbook buttons into focus and preview action bars.
+ * Inject logbook buttons into the preview action bar.
  * Called after each render pass by preview.js.
  */
 function injectLogbookButtons() {
   document.querySelectorAll(".logbook-action-btn").forEach(function (b) { b.remove(); });
-
-  var focusedArtifact = getFocusedArtifact();
-  if (focusedArtifact) {
-    var bar = document.querySelector("#focus-container .focus-nav");
-    if (bar) {
-      bar.appendChild(createLogbookBtn({ artifact_id: focusedArtifact.id }));
-    }
-  }
 
   var selectedArtifact = getSelectedArtifact();
   if (selectedArtifact) {

--- a/src/osprey/interfaces/artifacts/static/js/logbook.js
+++ b/src/osprey/interfaces/artifacts/static/js/logbook.js
@@ -631,4 +631,4 @@ function injectLogbookButtons() {
   }
 }
 
-export { injectLogbookButtons };
+export { injectLogbookButtons, makeBtn, updateHeaderTitle, getSteeringValues, getContextValues };

--- a/src/osprey/interfaces/artifacts/static/js/preview.js
+++ b/src/osprey/interfaces/artifacts/static/js/preview.js
@@ -45,11 +45,33 @@ import {
   formatSize,
   formatFullTime,
   openUrl,
+  hasTimeseriesData,
   requestColorPass,
 } from "./types.js";
 import { renderMarkdownView, renderJsonView } from "./preview-content.js";
 import { injectLogbookButtons } from "./logbook.js";
 import { injectPrintButton } from "./print.js";
+
+/**
+ * Nudge the preview's embedded media to re-measure after a fullscreen
+ * layout change: fire a `resize` event at any preview iframe (Plotly-HTML
+ * artifacts listen for it) and ask Plotly to re-fit a visible timeseries
+ * chart. Both are best-effort and cross-origin/undefined-safe. Shared by
+ * `enterFullscreen` and `exitFullscreen`, which each run it on the next
+ * animation frame once the fullscreen class toggle has taken effect.
+ * @returns {void}
+ */
+function resizePreviewMedia() {
+  const previewContent = document.getElementById("preview-content");
+  const iframe = previewContent?.querySelector("iframe");
+  if (iframe?.contentWindow) {
+    try { iframe.contentWindow.dispatchEvent(new Event("resize")); } catch {}
+  }
+  const tsChart = document.getElementById("ts-viewport");
+  if (tsChart && typeof Plotly !== "undefined") {
+    try { Plotly.Plots.resize(tsChart); } catch {}
+  }
+}
 
 // ---- Preview Renderer (factory: fullscreen state + effects this module doesn't own) ---- //
 
@@ -95,7 +117,7 @@ export function createPreviewRenderer(callbacks) {
     let viewportHtml = "";
 
     // Check for timeseries data
-    if ((a.metadata && a.metadata.data_type === "timeseries" || a.category === "archiver_data") && (a.data_file || (a.metadata && a.metadata.data_file))) {
+    if (hasTimeseriesData(a)) {
       viewportHtml = `<div id="ts-viewport" class="ts-viewport-container"></div>`;
     } else {
       switch (a.artifact_type) {
@@ -240,7 +262,7 @@ export function createPreviewRenderer(callbacks) {
     if (isFullscreen) updateNewArtifactBadge();
 
     // Render timeseries if applicable
-    if ((a.metadata && a.metadata.data_type === "timeseries" || a.category === "archiver_data") && (a.data_file || (a.metadata && a.metadata.data_file))) {
+    if (hasTimeseriesData(a)) {
       const tsEl = document.getElementById("ts-viewport");
       if (tsEl) callbacks.onTimeseriesNeeded(tsEl, a);
     }
@@ -302,18 +324,8 @@ export function createPreviewRenderer(callbacks) {
     updateNewArtifactBadge();
     renderPreview();
 
-    // Resize iframes / Plotly charts
-    requestAnimationFrame(() => {
-      const previewContent = document.getElementById("preview-content");
-      const iframe = previewContent?.querySelector('iframe');
-      if (iframe?.contentWindow) {
-        try { iframe.contentWindow.dispatchEvent(new Event('resize')); } catch {}
-      }
-      const tsChart = document.getElementById('ts-viewport');
-      if (tsChart && typeof Plotly !== 'undefined') {
-        try { Plotly.Plots.resize(tsChart); } catch {}
-      }
-    });
+    // Re-fit embedded media once the fullscreen layout has applied.
+    requestAnimationFrame(resizePreviewMedia);
   }
 
   /** @returns {void} */
@@ -327,18 +339,9 @@ export function createPreviewRenderer(callbacks) {
     renderPreview();
     callbacks.onFullscreenExit();
 
-    // Resize iframes / Plotly charts
+    // Re-fit embedded media, then scroll the selected item back into view.
     requestAnimationFrame(() => {
-      const previewContent = document.getElementById("preview-content");
-      const iframe = previewContent?.querySelector('iframe');
-      if (iframe?.contentWindow) {
-        try { iframe.contentWindow.dispatchEvent(new Event('resize')); } catch {}
-      }
-      const tsChart = document.getElementById('ts-viewport');
-      if (tsChart && typeof Plotly !== 'undefined') {
-        try { Plotly.Plots.resize(tsChart); } catch {}
-      }
-      // Scroll selected item into view in sidebar
+      resizePreviewMedia();
       if (getSelectedArtifact()) {
         const sidebarBody = document.getElementById("sidebar-body");
         const sel = sidebarBody?.querySelector(`[data-id="${getSelectedArtifact().id}"]`);

--- a/src/osprey/interfaces/artifacts/static/js/preview.js
+++ b/src/osprey/interfaces/artifacts/static/js/preview.js
@@ -106,7 +106,7 @@ export function createPreviewRenderer(callbacks) {
           viewportHtml = `<iframe src="${url}" class="preview-iframe-light" sandbox="allow-scripts allow-same-origin"></iframe>`;
           break;
         case "notebook":
-          viewportHtml = `<iframe src="/api/notebooks/${a.id}/rendered" class="preview-iframe-light" sandbox="allow-scripts allow-same-origin"></iframe>`;
+          viewportHtml = `<iframe src="/api/notebooks/${encodeURIComponent(a.id)}/rendered" class="preview-iframe-light" sandbox="allow-scripts allow-same-origin"></iframe>`;
           break;
         case "plot_png":
         case "image":
@@ -144,7 +144,7 @@ export function createPreviewRenderer(callbacks) {
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
             Back
           </button>
-          <span class="badge badge-${a.category || a.artifact_type}">${typeBadge(a.category || a.artifact_type)}</span>
+          <span class="badge badge-${escapeHtml(a.category || a.artifact_type)}">${typeBadge(a.category || a.artifact_type)}</span>
           <span class="preview-header-title">${escapeHtml(a.title)}</span>
         </div>
         <div class="preview-header-actions">

--- a/src/osprey/interfaces/artifacts/static/js/print.js
+++ b/src/osprey/interfaces/artifacts/static/js/print.js
@@ -23,7 +23,7 @@
 
 import { escapeHtml as esc } from "/design-system/js/dom.js";
 import { getSelectedArtifact, fileUrl } from "./state.js";
-import { openUrl } from "./types.js";
+import { openUrl, isTimeseries, isoToDate } from "./types.js";
 
 export { esc };
 
@@ -60,10 +60,17 @@ const MSG_POPUP_BLOCKED = "Print blocked \u2014 please allow pop-ups for this si
 
 // ---- Helpers ----
 
-/** @param {any} ts */
+/**
+ * Full locale timestamp for the print header. Deliberately keeps the
+ * with-seconds `toLocaleString()` form (a print/PDF header wants precision,
+ * unlike the gallery's compact `formatFullTime`), but shares types.js's
+ * `isoToDate` guard so a malformed/non-ISO timestamp renders "" rather than
+ * a fabricated year-2000/epoch date.
+ * @param {any} ts
+ */
 export function fmtTime(ts) {
-  if (!ts) return "";
-  return new Date(ts).toLocaleString();
+  const d = isoToDate(ts);
+  return d ? d.toLocaleString() : "";
 }
 
 /** @param {any} a */
@@ -76,6 +83,39 @@ export function headerHtml(a) {
     "<h1>" + esc(a.title || a.filename || "Artifact") + "</h1>" +
     (meta ? '<div class="print-meta">' + meta + "</div>" : "") +
     "</div>";
+}
+
+/**
+ * Replace a target window's document with parsed HTML via DOM adoption.
+ *
+ * Resets the window to a minimal shell, parses `html` in the opener's
+ * document, then moves the parsed head/body nodes across with adoptNode.
+ * Adoption (rather than `document.write(html)`) keeps the about:blank
+ * window on the opener's origin, so relative image URLs in `html` resolve
+ * and iframed openers aren't blocked. `html` is always assembled from
+ * `esc()`-escaped fields by the callers.
+ *
+ * Shared by `openBlobAndPrint` (image path) and `printTimeseries` (chart
+ * capture) so this security-sensitive adoption path has a single copy.
+ * @param {Window} w
+ * @param {string} html
+ */
+function populateWindow(w, html) {
+  const parsed = new DOMParser().parseFromString(html, "text/html");
+
+  // Initialize the target document with a minimal shell.
+  // Safe: writing a hardcoded empty document to our own window.
+  w.document.open();  // eslint-disable-line no-restricted-syntax
+  w.document.write("<!DOCTYPE html><html><head></head><body></body></html>");  // static content only
+  w.document.close();
+
+  // Transfer parsed content into the live document via DOM adoption
+  while (parsed.head.childNodes.length) {
+    w.document.head.appendChild(w.document.adoptNode(parsed.head.childNodes[0]));
+  }
+  while (parsed.body.childNodes.length) {
+    w.document.body.appendChild(w.document.adoptNode(parsed.body.childNodes[0]));
+  }
 }
 
 /**
@@ -94,21 +134,7 @@ function openBlobAndPrint(html) {
     return;
   }
 
-  const parsed = new DOMParser().parseFromString(html, "text/html");
-
-  // Initialize the about:blank document with a minimal shell.
-  // Safe: writing a hardcoded empty document to our own about:blank window.
-  w.document.open();  // eslint-disable-line no-restricted-syntax
-  w.document.write("<!DOCTYPE html><html><head></head><body></body></html>");  // static content only
-  w.document.close();
-
-  // Transfer parsed content into the live document via DOM adoption
-  while (parsed.head.childNodes.length) {
-    w.document.head.appendChild(w.document.adoptNode(parsed.head.childNodes[0]));
-  }
-  while (parsed.body.childNodes.length) {
-    w.document.body.appendChild(w.document.adoptNode(parsed.body.childNodes[0]));
-  }
+  populateWindow(w, html);
 
   // Wait for images/stylesheets to load before printing
   w.addEventListener("load", function () { w.focus(); w.print(); });
@@ -204,19 +230,8 @@ function printTimeseries(a) {
         '<div class="print-body"><img src="' + dataUrl +
         '" alt="' + esc(a.title) + ' chart"></div></body></html>';
 
-      var parsed = new DOMParser().parseFromString(html, "text/html");
-
-      // Replace the loading content with the chart
-      // Safe: writing a hardcoded empty document to our own window.
-      w.document.open();  // eslint-disable-line no-restricted-syntax
-      w.document.write("<!DOCTYPE html><html><head></head><body></body></html>");  // static content only
-      w.document.close();
-      while (parsed.head.childNodes.length) {
-        w.document.head.appendChild(w.document.adoptNode(parsed.head.childNodes[0]));
-      }
-      while (parsed.body.childNodes.length) {
-        w.document.body.appendChild(w.document.adoptNode(parsed.body.childNodes[0]));
-      }
+      // Replace the loading content with the captured chart.
+      populateWindow(w, html);
       w.focus();
       w.print();
     })
@@ -233,11 +248,7 @@ function printTimeseries(a) {
 export function printArtifact(a) {
   if (!a) return;
 
-  const isTimeseries =
-    (a.metadata && a.metadata.data_type === "timeseries") ||
-    a.category === "archiver_data";
-
-  if (isTimeseries) { printTimeseries(a); return; }
+  if (isTimeseries(a)) { printTimeseries(a); return; }
 
   switch (a.artifact_type) {
     case "plot_html":

--- a/src/osprey/interfaces/artifacts/static/js/print.js
+++ b/src/osprey/interfaces/artifacts/static/js/print.js
@@ -21,8 +21,11 @@
  *     Plotly.toImage() as PNG, then populates the window and prints.
  */
 
+import { escapeHtml as esc } from "/design-system/js/dom.js";
 import { getSelectedArtifact, fileUrl } from "./state.js";
 import { openUrl } from "./types.js";
+
+export { esc };
 
 // ---- SVG icon (printer) ----
 
@@ -57,21 +60,14 @@ const MSG_POPUP_BLOCKED = "Print blocked \u2014 please allow pop-ups for this si
 
 // ---- Helpers ----
 
-/** @param {unknown} str */
-function esc(str) {
-  if (!str) return "";
-  return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;").replace(/"/g, "&quot;");
-}
-
 /** @param {any} ts */
-function fmtTime(ts) {
+export function fmtTime(ts) {
   if (!ts) return "";
   return new Date(ts).toLocaleString();
 }
 
 /** @param {any} a */
-function headerHtml(a) {
+export function headerHtml(a) {
   let meta = "";
   if (a.timestamp) meta += "<span>" + esc(fmtTime(a.timestamp)) + "</span>";
   if (a.tool_source) meta += " &middot; <span>Source: " + esc(a.tool_source) + "</span>";
@@ -234,7 +230,7 @@ function printTimeseries(a) {
 // ---- Dispatch ----
 
 /** @param {any} a */
-function printArtifact(a) {
+export function printArtifact(a) {
   if (!a) return;
 
   const isTimeseries =

--- a/src/osprey/interfaces/artifacts/static/js/render.js
+++ b/src/osprey/interfaces/artifacts/static/js/render.js
@@ -85,7 +85,7 @@ function galleryCardHtml(a, i) {
   return `
     <div class="gallery-card${sel}${pinnedCls}"
          data-id="${a.id}"
-         data-type="${a.category || a.artifact_type}"
+         data-type="${escapeHtml(a.category || a.artifact_type)}"
          style="animation-delay: ${i * 30}ms">
       <div class="gallery-card-thumb">${thumbnailHtml(a)}</div>
       <div class="gallery-card-info">
@@ -191,7 +191,13 @@ export function createSidebarRenderer(callbacks) {
         const chip = document.createElement("button");
         chip.className = "filter-chip type-chip";
         chip.dataset.filter = type;
-        chip.innerHTML = `<span class="chip-icon">${typeIcon(type)}</span>${(/** @type {any} */ (info)).label || type} <span class="chip-count">${count}</span>`;
+        // typeIcon(type) is intentionally NOT escaped here: it returns
+        // hardcoded SVG markup from an internal map keyed by `icons[type] ||
+        // icons.text` — the `type` argument never reaches the output, so
+        // there is nothing agent-controlled in its return value (audited
+        // 2026-07-07). The label text below IS agent-controlled (registry
+        // label or the raw category/artifact_type) and must be escaped.
+        chip.innerHTML = `<span class="chip-icon">${typeIcon(type)}</span>${escapeHtml((/** @type {any} */ (info)).label || type)} <span class="chip-count">${count}</span>`;
         typesContainer.appendChild(chip);
       });
     }
@@ -281,8 +287,8 @@ export function createSidebarRenderer(callbacks) {
 
       if (isGallery) {
         html += `
-          <div class="tree-section" data-type="${type}">
-            <div class="gallery-section-header" data-type="${type}">
+          <div class="tree-section" data-type="${escapeHtml(type)}">
+            <div class="gallery-section-header" data-type="${escapeHtml(type)}">
               ${chevronSvg}
               <span class="tree-section-icon">${typeIcon(type)}</span>
               <span>${typeBadge(type)}</span>
@@ -294,8 +300,8 @@ export function createSidebarRenderer(callbacks) {
           </div>`;
       } else {
         html += `
-          <div class="tree-section" data-type="${type}">
-            <div class="tree-section-header" data-type="${type}">
+          <div class="tree-section" data-type="${escapeHtml(type)}">
+            <div class="tree-section-header" data-type="${escapeHtml(type)}">
               ${chevronSvg}
               <span class="tree-section-icon">${typeIcon(type)}</span>
               <span>${typeBadge(type)}</span>
@@ -357,7 +363,7 @@ export function createSidebarRenderer(callbacks) {
           html += `
             <div class="timeline-item${getSelectedArtifact() && getSelectedArtifact().id === a.id ? " selected" : ""}${a.pinned ? " pinned" : ""}"
                  data-id="${a.id}"
-                 data-type="${a.category || a.artifact_type}"
+                 data-type="${escapeHtml(a.category || a.artifact_type)}"
                  style="animation-delay: ${itemIndex * 25}ms">
               <span class="timeline-dot"></span>
               <div class="timeline-item-body">

--- a/src/osprey/interfaces/artifacts/static/js/render.js
+++ b/src/osprey/interfaces/artifacts/static/js/render.js
@@ -132,6 +132,10 @@ export function createSidebarRenderer(callbacks) {
   let browseMode = "tree";
   /** @type {"list"|"gallery"} */
   let sidebarLayout = "list";
+  // Guards wireFilterChips so the delegated #filter-bar click listener is
+  // registered exactly once per renderer instance, no matter how many times
+  // initFilterBar/rebuildTypeChips run over the page lifetime (refetch, SSE).
+  let filterBarWired = false;
 
   /** @returns {"tree"|"activity"} */
   function getBrowseMode() { return browseMode; }
@@ -202,20 +206,22 @@ export function createSidebarRenderer(callbacks) {
       });
     }
 
-    wireFilterChips();
     updateFilterBarActive();
   }
 
+  /** Wire a single delegated click listener on #filter-bar (registered once). */
   function wireFilterChips() {
+    if (filterBarWired) return;
     const filterBar = document.getElementById("filter-bar");
     if (!filterBar) return;
-    filterBar.querySelectorAll(".filter-chip").forEach((chip) => {
-      chip.addEventListener("click", () => {
-        setActiveFilter(/** @type {HTMLElement} */ (chip).dataset.filter || "all");
-        updateFilterBarActive();
-        renderSidebar();
-      });
+    filterBar.addEventListener("click", (e) => {
+      const chip = /** @type {HTMLElement|null} */ (/** @type {HTMLElement} */ (e.target).closest(".filter-chip"));
+      if (!chip) return;
+      setActiveFilter(chip.dataset.filter || "all");
+      updateFilterBarActive();
+      renderSidebar();
     });
+    filterBarWired = true;
   }
 
   function updateFilterBarActive() {

--- a/src/osprey/interfaces/artifacts/static/js/state.js
+++ b/src/osprey/interfaces/artifacts/static/js/state.js
@@ -75,7 +75,7 @@ export function setShowAllSessions(v) { showAllSessions = v; }
 
 /** @param {{id: string, filename: string}} a */
 export function fileUrl(a) {
-  return `/files/${a.id}/${encodeURIComponent(a.filename)}`;
+  return `/files/${encodeURIComponent(a.id)}/${encodeURIComponent(a.filename)}`;
 }
 
 // ---- Error Banner ---- //

--- a/src/osprey/interfaces/artifacts/static/js/state.js
+++ b/src/osprey/interfaces/artifacts/static/js/state.js
@@ -19,8 +19,9 @@
  * mirroring scaffold/data.js's createScaffoldDataActions callback-injection
  * pattern.
  *
- * logbook.js/print.js import `getFocusedArtifact`/`getSelectedArtifact`/
- * `fileUrl` directly from here — there is no global-object bridge.
+ * logbook.js/print.js import `getSelectedArtifact`/`fileUrl` and
+ * preview.js/gallery.js import `getFocusedArtifact` directly from here —
+ * there is no global-object bridge.
  *
  * @module state
  */

--- a/src/osprey/interfaces/artifacts/static/js/timeseries.js
+++ b/src/osprey/interfaces/artifacts/static/js/timeseries.js
@@ -21,13 +21,15 @@
  * nullish-collapsing) — see dom.js. This module used to carry its own
  * `_esc` copy; that divergence has been consolidated away.
  *
- * Table cells render values/timestamps raw, with no precision or
- * short-time formatting applied. Changing the rendered precision/format of
- * archiver-data cells deserves its own deliberate decision. (Logged as a
- * follow-up: index cells could use a short-time formatter, value cells a
- * precision formatter, since the backend's split-orient `index` is ISO
- * timestamp strings — see src/osprey/utils/timeseries.py's
- * `extract_timeseries_frame`.)
+ * Table cells apply magnitude-adaptive formatting: index cells go through
+ * `_tsShortTime` (short month/day + hour:minute:second, no year, since the
+ * backend's split-orient `index` is ISO timestamp strings — see
+ * src/osprey/utils/timeseries.py's `extract_timeseries_frame`), value cells
+ * through `_tsFormatValue` (<=5 significant figures, scientific notation for
+ * very large/small magnitudes). Both helpers fall back to raw `String(...)`
+ * for inputs that aren't a number/valid date, so their output is still run
+ * through `escapeHtml` at the interpolation site — never trust it as safe
+ * HTML on its own.
  *
  * @module timeseries
  */
@@ -49,7 +51,10 @@ function ensurePlotlyLoaded() {
     const script = document.createElement("script");
     script.src = "/static/js/vendor/plotly-3.3.1.min.js";
     script.onload = () => { _plotlyLoaded = true; resolve(); };
-    script.onerror = () => reject(new Error("Failed to load Plotly"));
+    script.onerror = () => {
+      _plotlyLoading = null;
+      reject(new Error("Failed to load Plotly"));
+    };
     document.head.appendChild(script);
   });
   return _plotlyLoading;
@@ -67,6 +72,53 @@ function _tsShortChannelName(name) {
   const parts = name.split(":");
   if (parts.length >= 3) return parts[0] + ":...:" + parts[parts.length - 1];
   return name.slice(0, 10) + "..." + name.slice(-10);
+}
+
+/**
+ * Magnitude-adaptive value-cell formatter: <=5 significant figures for
+ * ordinary magnitudes, scientific notation once a value is very large or
+ * very small (but nonzero). Falls back to `String(...)` for non-number
+ * (including NaN) input — callers MUST still escapeHtml the result, since
+ * that fallback echoes the raw input verbatim.
+ * @param {any} num
+ * @returns {string}
+ */
+function _tsFormatValue(num) {
+  if (num === null || num === undefined) return "--";
+  if (typeof num !== "number" || Number.isNaN(num)) return String(num);
+  if (num === 0) return "0";
+  const abs = Math.abs(num);
+  if (abs >= 1e6 || abs < 0.001) return num.toExponential(3);
+  return num.toPrecision(5);
+}
+
+/**
+ * Short index/time-cell formatter for ISO timestamp strings: month/day +
+ * hour:minute:second, no year. Only ISO-date-shaped strings are parsed at
+ * all: `Date` coercion would otherwise turn null/numbers/numeric strings
+ * into fabricated epoch/year-2000 timestamps, so nullish input renders
+ * "--" and any non-ISO-shaped value falls back to `String(iso)` verbatim.
+ * Callers MUST still escapeHtml the result, since that fallback echoes the
+ * raw input.
+ * @param {any} iso
+ * @returns {string}
+ */
+function _tsShortTime(iso) {
+  if (iso === null || iso === undefined) return "--";
+  if (typeof iso !== "string" || !/^\d{4}-\d{2}-\d{2}/.test(iso)) return String(iso);
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return String(iso);
+    return d.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  } catch {
+    return String(iso);
+  }
 }
 
 /** @param {any} chartData */
@@ -285,9 +337,9 @@ export async function renderTimeseriesTable(el, artifactId, columns, offset) {
 
     tableData.index.forEach((/** @type {any} */ idx, /** @type {number} */ i) => {
       html += '<tr>';
-      html += `<td class="ts-index-cell">${escapeHtml(String(idx))}</td>`;
+      html += `<td class="ts-index-cell">${escapeHtml(_tsShortTime(idx))}</td>`;
       const row = tableData.data[i] || [];
-      row.forEach((/** @type {any} */ val) => { html += `<td>${escapeHtml(val == null ? "" : String(val))}</td>`; });
+      row.forEach((/** @type {any} */ val) => { html += `<td>${escapeHtml(_tsFormatValue(val))}</td>`; });
       html += '</tr>';
     });
 

--- a/src/osprey/interfaces/artifacts/static/js/timeseries.js
+++ b/src/osprey/interfaces/artifacts/static/js/timeseries.js
@@ -36,6 +36,7 @@
 
 import { chartTheme, chartSeries } from "/design-system/js/theme-manager.js";
 import { escapeHtml } from "/design-system/js/dom.js";
+import { isoToDate } from "./types.js";
 
 // ---- Lazy Plotly Loader ---- //
 
@@ -94,31 +95,26 @@ function _tsFormatValue(num) {
 
 /**
  * Short index/time-cell formatter for ISO timestamp strings: month/day +
- * hour:minute:second, no year. Only ISO-date-shaped strings are parsed at
- * all: `Date` coercion would otherwise turn null/numbers/numeric strings
- * into fabricated epoch/year-2000 timestamps, so nullish input renders
- * "--" and any non-ISO-shaped value falls back to `String(iso)` verbatim.
- * Callers MUST still escapeHtml the result, since that fallback echoes the
- * raw input.
+ * hour:minute:second, no year. Shares types.js's `isoToDate` guard, which
+ * rejects the null/number/numeric-string inputs that bare `Date` coercion
+ * would otherwise turn into fabricated epoch/year-2000 timestamps: nullish
+ * input renders "--", and any other non-ISO/invalid value falls back to
+ * `String(iso)` verbatim. Callers MUST still escapeHtml the result, since
+ * that fallback echoes the raw input.
  * @param {any} iso
  * @returns {string}
  */
 function _tsShortTime(iso) {
   if (iso === null || iso === undefined) return "--";
-  if (typeof iso !== "string" || !/^\d{4}-\d{2}-\d{2}/.test(iso)) return String(iso);
-  try {
-    const d = new Date(iso);
-    if (Number.isNaN(d.getTime())) return String(iso);
-    return d.toLocaleString(undefined, {
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-    });
-  } catch {
-    return String(iso);
-  }
+  const d = isoToDate(iso);
+  if (!d) return String(iso);
+  return d.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
 }
 
 /** @param {any} chartData */

--- a/src/osprey/interfaces/artifacts/static/js/timeseries.js
+++ b/src/osprey/interfaces/artifacts/static/js/timeseries.js
@@ -17,10 +17,9 @@
  * The lazy `<script src="/static/js/vendor/plotly-3.3.1.min.js">` injection
  * must keep that exact offline-vendored path — do not change it.
  *
- * `_esc` duplicates types.js's `escapeHtml` (same textContent→innerHTML
- * trick, different name) rather than importing it. That divergence is
- * pinned by a labeled KNOWN-DIVERGENCE test elsewhere; consolidation is
- * deliberately deferred, so the local copy stands.
+ * HTML-escaping uses the design-system's canonical `escapeHtml` (quote-safe,
+ * nullish-collapsing) — see dom.js. This module used to carry its own
+ * `_esc` copy; that divergence has been consolidated away.
  *
  * Table cells render values/timestamps raw, with no precision or
  * short-time formatting applied. Changing the rendered precision/format of
@@ -34,6 +33,7 @@
  */
 
 import { chartTheme, chartSeries } from "/design-system/js/theme-manager.js";
+import { escapeHtml } from "/design-system/js/dom.js";
 
 // ---- Lazy Plotly Loader ---- //
 
@@ -56,16 +56,6 @@ function ensurePlotlyLoaded() {
 }
 
 // ---- Helpers ---- //
-
-/**
- * @param {unknown} s
- * @returns {string}
- */
-function _esc(s) {
-  const d = document.createElement("div");
-  d.textContent = /** @type {any} */ (s);
-  return d.innerHTML;
-}
 
 /**
  * @param {string} name
@@ -131,7 +121,7 @@ export async function renderTimeseriesView(container, artifact) {
     // Info bar
     html += '<div class="ts-info-bar">';
     columns.forEach((/** @type {any} */ c) => {
-      html += `<span class="ts-badge ts-badge-channel"><span class="badge-label">CH</span> ${_esc(_tsShortChannelName(c))}</span>`;
+      html += `<span class="ts-badge ts-badge-channel"><span class="badge-label">CH</span> ${escapeHtml(_tsShortChannelName(c))}</span>`;
     });
     html += `<span class="ts-badge ts-badge-rows"><span class="badge-label">Rows</span> ${chartData.total_rows.toLocaleString()}</span>`;
     if (chartData.downsampled) {
@@ -145,9 +135,9 @@ export async function renderTimeseriesView(container, artifact) {
     const _tsPalette = chartSeries();
     columns.forEach((/** @type {any} */ col, /** @type {number} */ ci) => {
       const color = _tsPalette[ci % _tsPalette.length];
-      html += `<button class="ts-ch-toggle" data-ch-index="${ci}" data-ch-name="${_esc(col)}" title="${_esc(col)}">`;
+      html += `<button class="ts-ch-toggle" data-ch-index="${ci}" data-ch-name="${escapeHtml(col)}" title="${escapeHtml(col)}">`;
       html += `<span class="ts-ch-dot" style="background:${color}"></span>`;
-      html += _esc(_tsShortChannelName(col));
+      html += escapeHtml(_tsShortChannelName(col));
       html += '</button>';
     });
     html += '</div>';
@@ -290,14 +280,14 @@ export async function renderTimeseriesTable(el, artifactId, columns, offset) {
 
     let html = '<div class="ts-data-table-wrapper"><table class="ts-data-table">';
     html += '<thead><tr><th>Index</th>';
-    columns.forEach((c) => { html += `<th>${_esc(c)}</th>`; });
+    columns.forEach((c) => { html += `<th>${escapeHtml(c)}</th>`; });
     html += '</tr></thead><tbody>';
 
     tableData.index.forEach((/** @type {any} */ idx, /** @type {number} */ i) => {
       html += '<tr>';
-      html += `<td class="ts-index-cell">${_esc(String(idx))}</td>`;
+      html += `<td class="ts-index-cell">${escapeHtml(String(idx))}</td>`;
       const row = tableData.data[i] || [];
-      row.forEach((/** @type {any} */ val) => { html += `<td>${_esc(val == null ? "" : String(val))}</td>`; });
+      row.forEach((/** @type {any} */ val) => { html += `<td>${escapeHtml(val == null ? "" : String(val))}</td>`; });
       html += '</tr>';
     });
 

--- a/src/osprey/interfaces/artifacts/static/js/types.js
+++ b/src/osprey/interfaces/artifacts/static/js/types.js
@@ -56,45 +56,51 @@ export function typeBadge(type) {
   return escapeHtml(info.label || type.replace(/_/g, " "));
 }
 
+// SVG icon markup keyed by artifact/category type. Module-level constant
+// (not rebuilt per `typeIcon` call — it's read once per artifact card on
+// every sidebar render). The `type` key never reaches output; the markup is
+// a fixed internal map, so callers interpolate `typeIcon()`'s result raw.
+/** @type {Record<string, string>} */
+const TYPE_ICONS = {
+  // Artifact types
+  plot_html: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>',
+  plot_png: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>',
+  table_html: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="3" y1="15" x2="21" y2="15"/><line x1="9" y1="3" x2="9" y2="21"/></svg>',
+  html: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>',
+  markdown: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6"/></svg>',
+  text: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>',
+  json: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6"/></svg>',
+  image: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>',
+  notebook: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z"/><path d="M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z"/></svg>',
+  dashboard_html: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>',
+  // Category types
+  archiver_data: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 5v14c0 1.66-4.03 3-9 3s-9-1.34-9-3V5"/><path d="M3 12c0 1.66 4.03 3 9 3s9-1.34 9-3"/></svg>',
+  channel_values: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>',
+  write_results: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>',
+  code_output: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>',
+  visualization: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="2"/><polyline points="7 14 11 10 15 14 19 8"/></svg>',
+  dashboard: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>',
+  document: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>',
+  screenshot: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>',
+  channel_finder: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>',
+  search_results: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>',
+  logbook_research: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z"/><path d="M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z"/></svg>',
+  literature_research: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z"/><path d="M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z"/></svg>',
+  wiki_research: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z"/><path d="M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z"/></svg>',
+  mml_research: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>',
+  agent_response: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>',
+  user_artifact: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>',
+  diagnostic_report: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M16 4h2a2 2 0 012 2v14a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2h2"/><rect x="8" y="2" width="8" height="4" rx="1"/><path d="M9 14l2 2 4-4"/></svg>',
+};
+
 /**
- * SVG icon markup for an artifact/category type.
+ * SVG icon markup for an artifact/category type, falling back to the generic
+ * text-document icon for unknown types.
  * @param {string} type
  * @returns {string}
  */
 export function typeIcon(type) {
-  /** @type {Record<string, string>} */
-  const icons = {
-    // Artifact types
-    plot_html: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>',
-    plot_png: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>',
-    table_html: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="3" y1="15" x2="21" y2="15"/><line x1="9" y1="3" x2="9" y2="21"/></svg>',
-    html: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>',
-    markdown: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6"/></svg>',
-    text: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>',
-    json: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6"/></svg>',
-    image: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>',
-    notebook: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z"/><path d="M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z"/></svg>',
-    dashboard_html: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>',
-    // Category types
-    archiver_data: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 5v14c0 1.66-4.03 3-9 3s-9-1.34-9-3V5"/><path d="M3 12c0 1.66 4.03 3 9 3s9-1.34 9-3"/></svg>',
-    channel_values: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>',
-    write_results: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>',
-    code_output: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>',
-    visualization: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="2"/><polyline points="7 14 11 10 15 14 19 8"/></svg>',
-    dashboard: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>',
-    document: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>',
-    screenshot: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>',
-    channel_finder: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>',
-    search_results: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>',
-    logbook_research: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z"/><path d="M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z"/></svg>',
-    literature_research: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z"/><path d="M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z"/></svg>',
-    wiki_research: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z"/><path d="M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z"/></svg>',
-    mml_research: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>',
-    agent_response: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>',
-    user_artifact: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>',
-    diagnostic_report: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M16 4h2a2 2 0 012 2v14a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2h2"/><rect x="8" y="2" width="8" height="4" rx="1"/><path d="M9 14l2 2 4-4"/></svg>',
-  };
-  return icons[type] || icons.text;
+  return TYPE_ICONS[type] || TYPE_ICONS.text;
 }
 
 /**
@@ -151,6 +157,26 @@ export function thumbnailHtml(a) {
 export { escapeHtml } from "/design-system/js/dom.js";
 
 /**
+ * Parse an artifact timestamp string to a Date, or null if it isn't a
+ * usable ISO-shaped date. This is the single source of truth for the
+ * timestamp guard: bare `new Date(x)` coercion turns null/numbers/numeric
+ * strings like "0" into fabricated epoch/year-2000 dates, so every display
+ * formatter that renders an artifact timestamp — the three below, plus
+ * print.js's `fmtTime` — routes through this rather than coercing directly.
+ * Nullish, non-string, non-ISO-shaped, or NaN input yields null and the
+ * caller supplies its own empty/"Unknown"/raw fallback instead of an
+ * invented timestamp.
+ * @param {any} iso
+ * @returns {Date|null}
+ */
+export function isoToDate(iso) {
+  if (iso === null || iso === undefined) return null;
+  if (typeof iso !== "string" || !/^\d{4}-\d{2}-\d{2}/.test(iso)) return null;
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/**
  * Human-readable byte size (B/KB/MB/GB).
  * @param {number} bytes
  * @returns {string}
@@ -165,25 +191,26 @@ export function formatSize(bytes) {
 }
 
 /**
- * Locale time-of-day (e.g. "3:45 PM"). Empty string for falsy input.
+ * Locale time-of-day (e.g. "3:45 PM"). Empty string for falsy or non-ISO
+ * input (see `isoToDate`).
  * @param {string} [iso]
  * @returns {string}
  */
 export function formatTime(iso) {
-  if (!iso) return "";
-  const d = new Date(iso);
+  const d = isoToDate(iso);
+  if (!d) return "";
   return d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
 }
 
 /**
  * Full locale date + time (e.g. "Jul 3, 2026, 3:45 PM"). Empty string for
- * falsy input.
+ * falsy or non-ISO input (see `isoToDate`).
  * @param {string} [iso]
  * @returns {string}
  */
 export function formatFullTime(iso) {
-  if (!iso) return "";
-  const d = new Date(iso);
+  const d = isoToDate(iso);
+  if (!d) return "";
   return d.toLocaleString(undefined, {
     year: "numeric", month: "short", day: "numeric",
     hour: "2-digit", minute: "2-digit",
@@ -192,19 +219,50 @@ export function formatFullTime(iso) {
 
 /**
  * "Today" / "Yesterday" / a short locale date, for grouping the activity
- * timeline. "Unknown" for falsy input.
+ * timeline. "Unknown" for falsy or non-ISO input (see `isoToDate`).
  * @param {string} [iso]
  * @returns {string}
  */
 export function formatDate(iso) {
-  if (!iso) return "Unknown";
-  const d = new Date(iso);
+  const d = isoToDate(iso);
+  if (!d) return "Unknown";
   const now = new Date();
   if (d.toDateString() === now.toDateString()) return "Today";
   const yesterday = new Date(now);
   yesterday.setDate(yesterday.getDate() - 1);
   if (d.toDateString() === yesterday.toDateString()) return "Yesterday";
   return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+/**
+ * Whether an artifact is a timeseries (its metadata declares the
+ * `timeseries` data_type, or it carries the `archiver_data` category). This
+ * is the artifact *type* question only — see `hasTimeseriesData` for the
+ * "and it actually has a data file to render" variant. Single source of
+ * truth so print.js's strategy dispatch and preview.js's viewport choice
+ * can never drift on the definition.
+ * @param {any} a
+ * @returns {boolean}
+ */
+export function isTimeseries(a) {
+  return (
+    (!!a.metadata && a.metadata.data_type === "timeseries") ||
+    a.category === "archiver_data"
+  );
+}
+
+/**
+ * Whether an artifact is a timeseries (see `isTimeseries`) *and* has a data
+ * file to fetch and render — the condition preview.js uses to pick the
+ * timeseries viewport over the generic type dispatch. print.js's print
+ * strategy deliberately uses the looser `isTimeseries` instead: it captures
+ * the already-rendered on-screen chart rather than refetching, so it doesn't
+ * need the data file.
+ * @param {any} a
+ * @returns {boolean}
+ */
+export function hasTimeseriesData(a) {
+  return isTimeseries(a) && !!(a.data_file || (a.metadata && a.metadata.data_file));
 }
 
 /**

--- a/src/osprey/interfaces/artifacts/static/js/types.js
+++ b/src/osprey/interfaces/artifacts/static/js/types.js
@@ -11,6 +11,7 @@
  */
 
 import { fileUrl } from "./state.js";
+import { escapeHtml } from "/design-system/js/dom.js";
 
 // ---- Type Registry ---- //
 
@@ -36,6 +37,15 @@ export async function initTypeRegistry() {
 
 /**
  * Human-readable label for an artifact/category type.
+ *
+ * Escaped at the source: `info.label` comes from the agent-fed
+ * `/api/type-registry`, and `type` itself is the agent-supplied
+ * `category`/`artifact_type` value (never validated server-side beyond a
+ * log-warning — see artifact_store.py). Every call site interpolates the
+ * result directly into innerHTML, so this must return HTML-safe text.
+ * Audited: no call site (render.js, preview.js, this module's own
+ * `thumbnailHtml`) wraps the result in `escapeHtml` itself, so escaping here
+ * cannot double-escape.
  * @param {string} type
  * @returns {string}
  */
@@ -43,7 +53,7 @@ export function typeBadge(type) {
   const info =
     (typeRegistry.categories && typeRegistry.categories[type]) ||
     (typeRegistry.artifact_types && typeRegistry.artifact_types[type]) || {};
-  return info.label || type.replace(/_/g, " ");
+  return escapeHtml(info.label || type.replace(/_/g, " "));
 }
 
 /**
@@ -119,7 +129,7 @@ export function thumbnailHtml(a) {
       return `<iframe src="${url}" sandbox="allow-scripts allow-same-origin"
                loading="lazy" tabindex="-1"></iframe>`;
     case "notebook":
-      return `<iframe src="/api/notebooks/${a.id}/rendered"
+      return `<iframe src="/api/notebooks/${encodeURIComponent(a.id)}/rendered"
                sandbox="allow-scripts allow-same-origin"
                loading="lazy" tabindex="-1"></iframe>`;
     default:
@@ -135,17 +145,10 @@ export function thumbnailHtml(a) {
 
 // ---- Utilities ---- //
 
-/**
- * HTML-escape a value using the textContent -> innerHTML trick. Nullish
- * input yields "" (not "undefined"/"null").
- * @param {unknown} str
- * @returns {string}
- */
-export function escapeHtml(str) {
-  const d = document.createElement("div");
-  d.textContent = /** @type {any} */ (str) || "";
-  return d.innerHTML;
-}
+// HTML-escaping now lives in the design-system's canonical helper — this
+// module re-exports it so existing importers (render.js, preview.js,
+// preview-content.js) keep working unchanged.
+export { escapeHtml } from "/design-system/js/dom.js";
 
 /**
  * Human-readable byte size (B/KB/MB/GB).
@@ -212,8 +215,8 @@ export function formatDate(iso) {
  */
 export function openUrl(a) {
   switch (a.artifact_type) {
-    case "markdown": return `/api/markdown/${a.id}/rendered`;
-    case "notebook": return `/api/notebooks/${a.id}/rendered`;
+    case "markdown": return `/api/markdown/${encodeURIComponent(a.id)}/rendered`;
+    case "notebook": return `/api/notebooks/${encodeURIComponent(a.id)}/rendered`;
     default:         return fileUrl(a);
   }
 }

--- a/src/osprey/interfaces/design_system/static/js/dom.js
+++ b/src/osprey/interfaces/design_system/static/js/dom.js
@@ -24,10 +24,13 @@ export function el(tag, className) {
 }
 
 /**
- * HTML-escape a value using the textContent -> innerHTML trick.
+ * HTML-escape a value using the textContent -> innerHTML trick, then also
+ * escape double- and single-quotes.
  *
- * Nullish input yields "" (not "undefined"/"null"). Double-quotes are left
- * as-is, matching the call sites this replaces.
+ * Nullish input yields "" (not "undefined"/"null"). The result is safe to
+ * interpolate both into element text/HTML content AND into a quoted
+ * attribute value (single- or double-quoted), since `"` and `'` are escaped
+ * in addition to `&`, `<`, and `>`.
  *
  * @param {unknown} value
  * @returns {string}
@@ -35,7 +38,7 @@ export function el(tag, className) {
 export function escapeHtml(value) {
   const div = document.createElement("div");
   div.textContent = String(value ?? "");
-  return div.innerHTML;
+  return div.innerHTML.replaceAll('"', "&quot;").replaceAll("'", "&#39;");
 }
 
 /**

--- a/src/osprey/interfaces/tuning/static/js/optimization-form.js
+++ b/src/osprey/interfaces/tuning/static/js/optimization-form.js
@@ -7,6 +7,7 @@
 
 import { api } from './api.js';
 import { state } from './state.js';
+import { escapeHtml } from '/design-system/js/dom.js';
 
 // ---- DOM refs ----
 
@@ -116,7 +117,7 @@ function renderTables() {
   renderTable(els.boTableBody, true);
 }
 
-function renderTable(tbody, showBoRange) {
+export function renderTable(tbody, showBoRange) {
   const data = state.variableTableData;
 
   if (data.length === 0) {
@@ -130,14 +131,15 @@ function renderTable(tbody, showBoRange) {
     const tr = document.createElement('tr');
     tr.className = v.selected ? 'selected' : '';
 
+    const pv = escapeHtml(v.pv_name);
     tr.innerHTML = `
-      <td class="col-check"><input type="checkbox" data-pv="${v.pv_name}" ${v.selected ? 'checked' : ''}></td>
-      <td class="pv-name">${v.pv_name}</td>
+      <td class="col-check"><input type="checkbox" data-pv="${pv}" ${v.selected ? 'checked' : ''}></td>
+      <td class="pv-name">${pv}</td>
       <td class="muted">${formatNum(v.current_value)}</td>
-      <td><input class="input" type="number" data-pv="${v.pv_name}" data-field="min" value="${v.min ?? ''}" step="any"></td>
-      <td><input class="input" type="number" data-pv="${v.pv_name}" data-field="max" value="${v.max ?? ''}" step="any"></td>
-      <td><input class="input" type="number" data-pv="${v.pv_name}" data-field="step_size" value="${v.step_size ?? ''}" step="any"></td>
-      ${showBoRange ? `<td><input class="input" type="number" data-pv="${v.pv_name}" data-field="bo_range_factor" value="${v.bo_range_factor ?? 1}" step="0.1"></td>` : ''}
+      <td><input class="input" type="number" data-pv="${pv}" data-field="min" value="${v.min ?? ''}" step="any"></td>
+      <td><input class="input" type="number" data-pv="${pv}" data-field="max" value="${v.max ?? ''}" step="any"></td>
+      <td><input class="input" type="number" data-pv="${pv}" data-field="step_size" value="${v.step_size ?? ''}" step="any"></td>
+      ${showBoRange ? `<td><input class="input" type="number" data-pv="${pv}" data-field="bo_range_factor" value="${v.bo_range_factor ?? 1}" step="0.1"></td>` : ''}
     `;
 
     // Checkbox toggle

--- a/src/osprey/interfaces/tuning/static/js/progress-display.js
+++ b/src/osprey/interfaces/tuning/static/js/progress-display.js
@@ -7,6 +7,7 @@
 import { api } from './api.js';
 import { state } from './state.js';
 import { createOptimizationPlot } from './plots.js';
+import { escapeHtml } from '/design-system/js/dom.js';
 
 let pollTimer = null;
 let plotContainer;
@@ -173,8 +174,8 @@ function updateResultsTable(optState) {
     const tr = document.createElement('tr');
     tr.innerHTML = `
       <td>${d.iter}</td>
-      <td class="muted">${typeof d.objective_value === 'number' ? d.objective_value.toFixed(6) : (d.objective ?? '--')}</td>
-      <td>${d.phase}</td>
+      <td class="muted">${typeof d.objective_value === 'number' ? d.objective_value.toFixed(6) : escapeHtml(d.objective ?? '--')}</td>
+      <td>${escapeHtml(d.phase)}</td>
     `;
     resultsTableBody.appendChild(tr);
   }

--- a/src/osprey/interfaces/tuning/static/js/results-viewer.js
+++ b/src/osprey/interfaces/tuning/static/js/results-viewer.js
@@ -6,6 +6,7 @@
 
 import { api } from './api.js';
 import { state } from './state.js';
+import { escapeHtml } from '/design-system/js/dom.js';
 import {
   createEfficiencyPlot,
   createConvergencePlot,
@@ -48,16 +49,16 @@ async function loadRun(timestamp) {
       <div class="analysis-empty">
         <div class="analysis-empty-icon">&#9888;</div>
         <div class="analysis-empty-title">Error Loading Run</div>
-        <div class="analysis-empty-text">${err.message}</div>
+        <div class="analysis-empty-text">${escapeHtml(err.message)}</div>
       </div>
     `;
   }
 }
 
-function renderAnalysis(data, timestamp) {
+export function renderAnalysis(data, timestamp) {
   contentEl.innerHTML = `
     <div class="analysis-header" style="margin-bottom: 1rem;">
-      <span style="font-weight: 600; color: var(--text-primary);">Run: ${timestamp}</span>
+      <span style="font-weight: 600; color: var(--text-primary);">Run: ${escapeHtml(timestamp)}</span>
       <span style="color: var(--text-muted); margin-left: 0.5rem;">${data.length} points</span>
     </div>
     <div class="analysis-grid">

--- a/tests/interfaces/artifacts/logbook.test.mjs
+++ b/tests/interfaces/artifacts/logbook.test.mjs
@@ -1,0 +1,234 @@
+/**
+ * Unit tests for the Artifact Gallery logbook entry composer (logbook.js):
+ * the client-side DOM gap left by the backend `test_logbook.py` suite
+ * (which remains the API authority for `/api/logbook/*`).
+ *
+ * Pure-logic/DOM guard, happy-dom environment (configured globally):
+ *   npx vitest run tests/interfaces/artifacts/logbook.test.mjs
+ *
+ * Covers the module's behavior-neutral named exports added for Task 2.4:
+ *   - makeBtn: footer button factory (class, text, click wiring).
+ *   - updateHeaderTitle: phase -> header-title text lookup, including the
+ *     unknown-phase fallback.
+ *   - getSteeringValues / getContextValues: branch logic over the steering
+ *     panel and context controls, including the artifact-picker checkbox
+ *     `.value` readback path (the Task 1.4 attribute-sink fix — ids are
+ *     assigned as a DOM property, never interpolated into innerHTML).
+ *
+ * `escapeHtml` is the canonical design-system helper (tested in
+ * tests/interfaces/design_system/dom.test.mjs and exercised end-to-end
+ * against hostile artifact metadata in security_render.test.mjs) — it is
+ * deliberately NOT re-tested here.
+ */
+
+import { test, expect, describe, afterEach } from 'vitest';
+
+import {
+  makeBtn,
+  updateHeaderTitle,
+  getSteeringValues,
+  getContextValues,
+} from '../../../src/osprey/interfaces/artifacts/static/js/logbook.js';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+// =========================================================================
+// makeBtn
+// =========================================================================
+
+describe('makeBtn', () => {
+  test('builds a button with the expected class and label text', () => {
+    const btn = makeBtn('Cancel', 'cancel', () => {});
+    expect(btn.tagName).toBe('BUTTON');
+    expect(btn.className).toBe('logbook-btn logbook-btn-cancel');
+    expect(btn.textContent).toBe('Cancel');
+  });
+
+  test('wires the click handler so a click invokes it exactly once', () => {
+    let calls = 0;
+    const btn = makeBtn('Submit', 'primary', () => { calls += 1; });
+    document.body.appendChild(btn);
+
+    btn.click();
+    btn.click();
+
+    expect(calls).toBe(2);
+  });
+
+  test('a different style produces a different modifier class', () => {
+    const btn = makeBtn('Show Prompt', 'secondary', () => {});
+    expect(btn.className).toBe('logbook-btn logbook-btn-secondary');
+  });
+});
+
+// =========================================================================
+// updateHeaderTitle
+// =========================================================================
+
+describe('updateHeaderTitle', () => {
+  function mountTitleFixture() {
+    document.body.innerHTML = '<h3 id="logbook-header-title">placeholder</h3>';
+  }
+
+  test.each([
+    ['steering', 'Compose Logbook Entry'],
+    ['preview', 'Prompt Preview'],
+    ['editor', 'Edit Prompt'],
+    ['composing', 'Compose Logbook Entry'],
+    ['review', 'Review Draft'],
+  ])('phase "%s" sets the header title to "%s"', (phase, expected) => {
+    mountTitleFixture();
+    updateHeaderTitle(phase);
+    expect(document.getElementById('logbook-header-title').textContent).toBe(expected);
+  });
+
+  test('an unknown phase falls back to the default composer title', () => {
+    mountTitleFixture();
+    updateHeaderTitle('not-a-real-phase');
+    expect(document.getElementById('logbook-header-title').textContent).toBe('Compose Logbook Entry');
+  });
+
+  test('is a no-op (does not throw) when the header title element is absent', () => {
+    document.body.innerHTML = '';
+    expect(() => updateHeaderTitle('review')).not.toThrow();
+  });
+});
+
+// =========================================================================
+// getSteeringValues
+// =========================================================================
+
+describe('getSteeringValues', () => {
+  function mountSteeringFixture() {
+    document.body.innerHTML = `
+      <select id="logbook-purpose">
+        <option value="observation">Observation</option>
+        <option value="anomaly" selected>Anomaly</option>
+      </select>
+      <div class="logbook-detail-toggle">
+        <button type="button" class="logbook-detail-btn" data-level="brief">Brief</button>
+        <button type="button" class="logbook-detail-btn active" data-level="detailed">Detailed</button>
+      </div>
+      <input type="text" id="logbook-nudge" value="  focus on SR current  ">
+      <select id="logbook-model">
+        <option value="haiku">Haiku</option>
+        <option value="opus" selected>Opus</option>
+      </select>
+    `;
+  }
+
+  test('reads the live control values, trimming the nudge text', () => {
+    mountSteeringFixture();
+    expect(getSteeringValues()).toEqual({
+      purpose: 'anomaly',
+      detail_level: 'detailed',
+      nudge: 'focus on SR current',
+      model: 'opus',
+    });
+  });
+
+  test('falls back to defaults for every field when no controls are present', () => {
+    document.body.innerHTML = '';
+    expect(getSteeringValues()).toEqual({
+      purpose: 'general',
+      detail_level: 'standard',
+      nudge: '',
+      model: 'haiku',
+    });
+  });
+
+  test('detail_level falls back to "standard" when no detail button carries .active', () => {
+    mountSteeringFixture();
+    document.querySelector('.logbook-detail-btn.active').classList.remove('active');
+    expect(getSteeringValues().detail_level).toBe('standard');
+  });
+
+  test('nudge is an empty string (not whitespace) when the input is blank', () => {
+    mountSteeringFixture();
+    /** @type {HTMLInputElement} */ (document.getElementById('logbook-nudge')).value = '   ';
+    expect(getSteeringValues().nudge).toBe('');
+  });
+});
+
+// =========================================================================
+// getContextValues
+// =========================================================================
+
+describe('getContextValues', () => {
+  /**
+   * Mirrors the real steering-panel markup for the context controls plus
+   * the artifact picker list. `checkedIds`, when given, are appended as
+   * checkboxes with ids assigned via the `.value` DOM PROPERTY — exactly
+   * how the real `renderArtifactPicker` (logbook.js) does it for the
+   * Task 1.4 attribute-sink fix — never interpolated into a `value="..."`
+   * HTML string.
+   *
+   * @param {{sessionChecked?: boolean, scope?: 'this'|'all'|'choose'|null, pickerIds?: string[], checkedPickerIds?: string[]}} opts
+   */
+  function mountContextFixture({
+    sessionChecked = true,
+    scope = 'this',
+    pickerIds = [],
+    checkedPickerIds = [],
+  } = {}) {
+    document.body.innerHTML = `
+      <input type="checkbox" id="logbook-ctx-session" ${sessionChecked ? 'checked' : ''}>
+      <div class="logbook-artifact-scope">
+        <label><input type="radio" name="logbook-artifact-scope" value="this" ${scope === 'this' ? 'checked' : ''}></label>
+        <label><input type="radio" name="logbook-artifact-scope" value="all" ${scope === 'all' ? 'checked' : ''}></label>
+        <label><input type="radio" name="logbook-artifact-scope" value="choose" ${scope === 'choose' ? 'checked' : ''}></label>
+      </div>
+      <div id="logbook-artifact-picker-list"></div>
+    `;
+
+    const list = document.getElementById('logbook-artifact-picker-list');
+    pickerIds.forEach((id) => {
+      const label = document.createElement('label');
+      label.innerHTML = '<input type="checkbox">';
+      const cb = /** @type {HTMLInputElement} */ (label.querySelector('input[type=checkbox]'));
+      cb.value = id; // property assignment, matching renderArtifactPicker
+      cb.checked = checkedPickerIds.includes(id);
+      list.appendChild(label);
+    });
+  }
+
+  test('scope "this": session checked, artifact_ids stays null (uses currentOpts.artifact_id)', () => {
+    mountContextFixture({ sessionChecked: true, scope: 'this' });
+    expect(getContextValues()).toEqual({ include_session_log: true, artifact_ids: null });
+  });
+
+  test('session log unchecked is reflected in include_session_log', () => {
+    mountContextFixture({ sessionChecked: false, scope: 'this' });
+    expect(getContextValues().include_session_log).toBe(false);
+  });
+
+  test('scope "all" sets artifact_ids to ["all"]', () => {
+    mountContextFixture({ scope: 'all' });
+    expect(getContextValues().artifact_ids).toEqual(['all']);
+  });
+
+  test('scope "choose" collects the ids of checked picker checkboxes via .value', () => {
+    mountContextFixture({
+      scope: 'choose',
+      pickerIds: ['art-1', 'art-2', 'art-3'],
+      checkedPickerIds: ['art-1', 'art-3'],
+    });
+    expect(getContextValues().artifact_ids).toEqual(['art-1', 'art-3']);
+  });
+
+  test('scope "choose" with nothing checked falls back to null (single artifact_id path)', () => {
+    mountContextFixture({
+      scope: 'choose',
+      pickerIds: ['art-1', 'art-2'],
+      checkedPickerIds: [],
+    });
+    expect(getContextValues().artifact_ids).toBeNull();
+  });
+
+  test('no scope radio checked defaults to "this" (artifact_ids null) and session defaults true when the checkbox is absent', () => {
+    document.body.innerHTML = '<div id="logbook-artifact-picker-list"></div>';
+    expect(getContextValues()).toEqual({ include_session_log: true, artifact_ids: null });
+  });
+});

--- a/tests/interfaces/artifacts/preview.test.mjs
+++ b/tests/interfaces/artifacts/preview.test.mjs
@@ -143,6 +143,18 @@ describe('renderPreview: per-type viewport dispatch', () => {
     expect(iframe.getAttribute('src')).toBe('/api/notebooks/nb1/rendered');
   });
 
+  test('artifact_type "notebook" percent-encodes a hostile id in the iframe src', () => {
+    setSelectedArtifact(makeArtifact({ id: 'a/../b?x="y"', artifact_type: 'notebook' }));
+    const renderer = createPreviewRenderer(makeCallbacks());
+    renderer.renderPreview();
+
+    const iframe = document.querySelector('.preview-viewport iframe.preview-iframe-light');
+    const src = iframe.getAttribute('src');
+    const idSegment = src.split('/')[3];
+    expect(idSegment).not.toMatch(/[/?"]/);
+    expect(src).toBe('/api/notebooks/a%2F..%2Fb%3Fx%3D%22y%22/rendered');
+  });
+
   test('an unrecognized type with mime_type application/pdf renders a light iframe of the file', () => {
     setSelectedArtifact(makeArtifact({ artifact_type: 'weird_type', mime_type: 'application/pdf' }));
     const renderer = createPreviewRenderer(makeCallbacks());
@@ -383,6 +395,29 @@ describe('fullscreen mode', () => {
     const badge = document.getElementById('fullscreen-new-badge');
     expect(badge.textContent).toBe('2 new');
     expect(badge.dataset.count).toBe('2');
+  });
+});
+
+describe('XSS hardening (Task 1.3 — escape-metadata-sinks)', () => {
+  test('a hostile category is escaped in the badge class attribute — no element injection, no attribute breakout', () => {
+    const hostile = '"><img src=x onerror=alert(1)>';
+    setSelectedArtifact(makeArtifact({ category: hostile, artifact_type: hostile }));
+    createPreviewRenderer(makeCallbacks()).renderPreview();
+
+    expect(document.querySelector('.preview-header img')).toBeNull();
+    expect(document.querySelector('.preview-header [onerror]')).toBeNull();
+    expect(document.getElementById('preview-content').innerHTML).not.toMatch(/"><img/);
+
+    const badge = document.querySelector('.badge');
+    expect(badge).not.toBeNull();
+  });
+
+  test('benign category renders the badge class byte-identical (regression guard)', () => {
+    setSelectedArtifact(makeArtifact({ category: 'visualization' }));
+    createPreviewRenderer(makeCallbacks()).renderPreview();
+
+    const badge = document.querySelector('.badge');
+    expect(badge.className).toBe('badge badge-visualization');
   });
 });
 

--- a/tests/interfaces/artifacts/print.test.mjs
+++ b/tests/interfaces/artifacts/print.test.mjs
@@ -113,6 +113,14 @@ describe('fmtTime', () => {
     const ts = '2026-07-03T15:45:00Z';
     expect(fmtTime(ts)).toBe(new Date(ts).toLocaleString());
   });
+
+  test('non-ISO / fabricating input yields "" rather than an invented date', () => {
+    // Shares types.js's isoToDate guard: bare `new Date("0")` would fabricate
+    // a year-2000 date; the guard rejects these numeric/non-ISO strings.
+    for (const junk of ['0', '1751000000000', 'not-a-date', 42, {}]) {
+      expect(fmtTime(junk)).toBe('');
+    }
+  });
 });
 
 describe('headerHtml', () => {

--- a/tests/interfaces/artifacts/print.test.mjs
+++ b/tests/interfaces/artifacts/print.test.mjs
@@ -1,0 +1,386 @@
+/**
+ * Unit tests for the Artifact Gallery print module (print.js): the pure
+ * `esc`/`fmtTime`/`headerHtml` formatting helpers and `printArtifact`'s
+ * artifact_type -> printer-strategy dispatch (iframe / image / timeseries).
+ *
+ * Pure DOM/logic guard, happy-dom environment (configured globally):
+ *   npx vitest run tests/interfaces/artifacts/print.test.mjs
+ *
+ * `window.open` is stubbed via `vi.stubGlobal('open', ...)` — the fake
+ * window it returns wraps a REAL `document.implementation.createHTMLDocument()`
+ * document (so `adoptNode`/`createElement`/`head`/`body` all behave exactly
+ * like the browser DOM print.js relies on) plus `vi.fn()` spies for
+ * `focus`/`print`/`close` and an `addEventListener` spy that just records the
+ * `"load"` callback so tests can fire it deterministically (happy-dom's
+ * `createHTMLDocument()` document never reaches `readyState === "complete"`
+ * on its own, so print.js always takes its `addEventListener("load", ...)`
+ * branch here — the same branch a real slow-loading print window takes).
+ * `alert`/`Plotly` are stubbed the same way scaffold-detail.test.mjs and
+ * timeseries.test.mjs do. No real print window, popup, or Plotly chart is
+ * ever exercised — this is deliberately out of scope (see the module's own
+ * header comment on strategy).
+ */
+
+import { test, expect, describe, afterEach, vi } from 'vitest';
+
+import {
+  esc,
+  fmtTime,
+  headerHtml,
+  printArtifact,
+} from '../../../src/osprey/interfaces/artifacts/static/js/print.js';
+
+const MSG_POPUP_BLOCKED = 'Print blocked — please allow pop-ups for this site and try again.';
+const MSG_CHART_NOT_READY = 'Chart not yet rendered. Please wait for it to load, then try again.';
+const MSG_CAPTURE_FAILED = 'Could not capture chart for printing.';
+
+/** @returns {any} */
+function makeArtifact(overrides = {}) {
+  return {
+    id: 'a1',
+    title: 'Beam Profile',
+    filename: 'beam_profile.png',
+    artifact_type: 'plot_png',
+    category: 'visualization',
+    timestamp: '2026-07-01T10:00:00Z',
+    tool_source: 'plot_tool',
+    ...overrides,
+  };
+}
+
+/**
+ * A fake `window.open()` return value. `document` is a REAL document (via
+ * `document.implementation.createHTMLDocument`) so `adoptNode`/`write`/
+ * `open`/`close` behave exactly as print.js expects; `focus`/`print`/`close`
+ * are spies, and `addEventListener` just records the `"load"` callback for
+ * the test to fire manually.
+ * @returns {any}
+ */
+function makeFakeWindow({ readyState } = {}) {
+  const doc = document.implementation.createHTMLDocument('');
+  // createHTMLDocument docs report "interactive" in happy-dom; tests for the
+  // synchronous already-loaded print path override this to "complete".
+  if (readyState) Object.defineProperty(doc, 'readyState', { value: readyState });
+  /** @type {(() => void) | null} */
+  let loadCb = null;
+  return {
+    document: doc,
+    addEventListener: vi.fn((evt, cb) => { if (evt === 'load') loadCb = cb; }),
+    focus: vi.fn(),
+    print: vi.fn(),
+    close: vi.fn(),
+    fireLoad() { loadCb?.(); },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  document.body.innerHTML = '';
+});
+
+describe('esc (alias of the canonical design-system escapeHtml)', () => {
+  test('escapes &, <, >, and "', () => {
+    expect(esc('<b>"AT&T"</b>')).toBe('&lt;b&gt;&quot;AT&amp;T&quot;&lt;/b&gt;');
+  });
+
+  test('collapses only null/undefined to ""; other falsy values stringify', () => {
+    expect(esc(null)).toBe('');
+    expect(esc(undefined)).toBe('');
+    expect(esc('')).toBe('');
+    expect(esc(0)).toBe('0');
+    expect(esc(false)).toBe('false');
+  });
+
+  test('coerces non-string input to a string before escaping', () => {
+    expect(esc(42)).toBe('42');
+  });
+
+  test('escapes single quotes (canonical attribute-context-safe contract)', () => {
+    expect(esc("it's a 'test'")).toBe('it&#39;s a &#39;test&#39;');
+  });
+});
+
+describe('fmtTime', () => {
+  test('returns "" for falsy input', () => {
+    expect(fmtTime(null)).toBe('');
+    expect(fmtTime(undefined)).toBe('');
+    expect(fmtTime(0)).toBe('');
+    expect(fmtTime('')).toBe('');
+  });
+
+  test('formats a valid timestamp via Date#toLocaleString', () => {
+    const ts = '2026-07-03T15:45:00Z';
+    expect(fmtTime(ts)).toBe(new Date(ts).toLocaleString());
+  });
+});
+
+describe('headerHtml', () => {
+  test('falls back title -> filename -> "Artifact" when fields are missing', () => {
+    expect(headerHtml({})).toContain('<h1>Artifact</h1>');
+    expect(headerHtml({ filename: 'x.png' })).toContain('<h1>x.png</h1>');
+    expect(headerHtml({ title: 'My Plot', filename: 'x.png' })).toContain('<h1>My Plot</h1>');
+  });
+
+  test('omits the .print-meta block entirely when there is no timestamp/tool_source/filename', () => {
+    const html = headerHtml({ title: 'Bare' });
+    expect(html).not.toContain('print-meta');
+  });
+
+  test('joins timestamp, tool_source, and filename with middot separators', () => {
+    const html = headerHtml({
+      title: 'T',
+      timestamp: '2026-07-03T15:45:00Z',
+      tool_source: 'plot_tool',
+      filename: 'x.png',
+    });
+    expect(html).toContain('<div class="print-meta">');
+    expect(html).toContain(esc(fmtTime('2026-07-03T15:45:00Z')));
+    expect(html).toContain('Source: plot_tool');
+    expect(html).toContain('&middot;');
+    expect(html).toContain('x.png');
+  });
+
+  test('escapes hostile title/tool_source/filename values', () => {
+    const html = headerHtml({
+      title: '<img src=x onerror=alert(1)>',
+      tool_source: '"><script>1</script>',
+      filename: '<b>f</b>',
+    });
+    expect(html).not.toContain('<img src=x');
+    expect(html).not.toContain('<script>');
+    expect(html).not.toContain('<b>f</b>');
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+  });
+});
+
+describe('printArtifact: guards and dispatch', () => {
+  test('does nothing for a null/undefined artifact', () => {
+    const openSpy = vi.fn();
+    vi.stubGlobal('open', openSpy);
+    printArtifact(null);
+    printArtifact(undefined);
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  test('alerts and does not throw when window.open is blocked (iframe path)', () => {
+    const alertSpy = vi.fn();
+    vi.stubGlobal('alert', alertSpy);
+    vi.stubGlobal('open', vi.fn(() => null));
+
+    expect(() => printArtifact(makeArtifact({ artifact_type: 'html' }))).not.toThrow();
+    expect(alertSpy).toHaveBeenCalledWith(MSG_POPUP_BLOCKED);
+  });
+
+  describe('iframe strategy (plot_html, table_html, dashboard_html, html, text, json, unknown)', () => {
+    test.each([
+      ['plot_html', '/files/a1/beam_profile.png'],
+      ['table_html', '/files/a1/beam_profile.png'],
+      ['dashboard_html', '/files/a1/beam_profile.png'],
+      ['html', '/files/a1/beam_profile.png'],
+      ['text', '/files/a1/beam_profile.png'],
+      ['json', '/files/a1/beam_profile.png'],
+      ['some_unrecognized_type', '/files/a1/beam_profile.png'],
+    ])('%s opens the raw file URL in a sized popup and injects print-cleanup styles', (artifact_type, expectedUrl) => {
+      const win = makeFakeWindow();
+      const openSpy = vi.fn(() => win);
+      vi.stubGlobal('open', openSpy);
+
+      printArtifact(makeArtifact({ artifact_type }));
+
+      expect(openSpy).toHaveBeenCalledWith(expectedUrl, '_blank', 'width=900,height=700');
+      expect(win.addEventListener).toHaveBeenCalledWith('load', expect.any(Function));
+
+      win.fireLoad();
+      expect(win.focus).toHaveBeenCalled();
+      expect(win.print).toHaveBeenCalledTimes(1);
+      const style = win.document.head.querySelector('style');
+      expect(style?.textContent).toContain('@media print');
+      expect(style?.textContent).toContain('.modebar');
+    });
+
+    test.each([
+      ['markdown', '/api/markdown/a1/rendered'],
+      ['notebook', '/api/notebooks/a1/rendered'],
+    ])('%s opens its server-rendered endpoint', (artifact_type, expectedUrl) => {
+      const win = makeFakeWindow();
+      const openSpy = vi.fn(() => win);
+      vi.stubGlobal('open', openSpy);
+
+      printArtifact(makeArtifact({ artifact_type }));
+
+      expect(openSpy).toHaveBeenCalledWith(expectedUrl, '_blank', 'width=900,height=700');
+    });
+
+    test('a cross-origin document access failure during style injection is swallowed and printing still proceeds', () => {
+      const win = makeFakeWindow();
+      // Force the try{} in onReady to throw, mirroring a cross-origin window.
+      Object.defineProperty(win.document, 'head', {
+        get() { throw new DOMException('cross-origin', 'SecurityError'); },
+      });
+      vi.stubGlobal('open', vi.fn(() => win));
+
+      printArtifact(makeArtifact({ artifact_type: 'html' }));
+      expect(() => win.fireLoad()).not.toThrow();
+      expect(win.focus).toHaveBeenCalled();
+      expect(win.print).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('image strategy (plot_png, image)', () => {
+    test.each(['plot_png', 'image'])('%s builds a self-contained print document with an escaped <img>', (artifact_type) => {
+      const win = makeFakeWindow();
+      vi.stubGlobal('open', vi.fn(() => win));
+
+      printArtifact(makeArtifact({
+        artifact_type,
+        title: '<b>Hostile</b> Title',
+        id: 'img-1',
+        filename: 'p.png',
+      }));
+
+      win.fireLoad();
+
+      // The document was built from an esc()-escaped HTML string, so the
+      // parsed <title> element's own markup (innerHTML) carries the escaped
+      // entities — textContent decodes them back, same as any other
+      // browser-parsed element, so it round-trips to the raw title rather
+      // than proving the escaping (that's what innerHTML is for here).
+      const titleEl = win.document.querySelector('title');
+      expect(titleEl?.textContent).toBe('<b>Hostile</b> Title');
+      expect(titleEl?.innerHTML).toBe(esc('<b>Hostile</b> Title'));
+      const img = win.document.querySelector('.print-body img');
+      expect(img).not.toBeNull();
+      expect(img?.getAttribute('src')).toBe('/files/img-1/p.png');
+      // Attribute values decode entities on parse too, so this round-trips
+      // to the raw title; innerHTML on the <h1> is the escaping proof.
+      expect(img?.getAttribute('alt')).toBe('<b>Hostile</b> Title');
+      const h1 = win.document.querySelector('.print-header h1');
+      expect(h1?.textContent).toBe('<b>Hostile</b> Title');
+      expect(h1?.innerHTML).toBe(esc('<b>Hostile</b> Title'));
+      expect(win.focus).toHaveBeenCalled();
+      expect(win.print).toHaveBeenCalledTimes(1);
+    });
+
+    test('alerts and does not throw when window.open is blocked', () => {
+      const alertSpy = vi.fn();
+      vi.stubGlobal('alert', alertSpy);
+      vi.stubGlobal('open', vi.fn(() => null));
+
+      expect(() => printArtifact(makeArtifact({ artifact_type: 'image' }))).not.toThrow();
+      expect(alertSpy).toHaveBeenCalledWith(MSG_POPUP_BLOCKED);
+    });
+
+    test('an already-loaded document (readyState "complete") prints exactly once, synchronously', () => {
+      const win = makeFakeWindow({ readyState: 'complete' });
+      vi.stubGlobal('open', vi.fn(() => win));
+
+      printArtifact(makeArtifact({ artifact_type: 'plot_png', id: 'img-2', filename: 'q.png' }));
+
+      // The sync branch fired without any load event; the load listener is
+      // still registered but must not produce a second print dialog here.
+      expect(win.print).toHaveBeenCalledTimes(1);
+      expect(win.focus).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('timeseries strategy (dispatch precedes artifact_type switch)', () => {
+    function mountChart() {
+      document.body.innerHTML =
+        '<div id="ts-viewport"><div data-ts-chart><div class="js-plotly-plot"></div></div></div>';
+    }
+
+    test.each([
+      ['metadata.data_type === "timeseries"', { metadata: { data_type: 'timeseries' }, artifact_type: 'json' }],
+      ['category === "archiver_data"', { category: 'archiver_data', artifact_type: 'json' }],
+    ])('routes to the timeseries capture path when %s, overriding artifact_type', (_label, overrides) => {
+      mountChart();
+      const alertSpy = vi.fn();
+      vi.stubGlobal('alert', alertSpy);
+      vi.stubGlobal('Plotly', { toImage: vi.fn(() => Promise.resolve('data:image/png;base64,xyz')) });
+      const win = makeFakeWindow();
+      const openSpy = vi.fn(() => win);
+      vi.stubGlobal('open', openSpy);
+
+      printArtifact(makeArtifact(overrides));
+
+      // Opens synchronously (before the async Plotly.toImage capture) to
+      // dodge popup blockers.
+      expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank', 'width=900,height=700');
+      expect(alertSpy).not.toHaveBeenCalled();
+    });
+
+    test('captures the chart via Plotly.toImage and prints once resolved', async () => {
+      mountChart();
+      vi.stubGlobal('Plotly', { toImage: vi.fn(() => Promise.resolve('data:image/png;base64,xyz')) });
+      const win = makeFakeWindow();
+      vi.stubGlobal('open', vi.fn(() => win));
+
+      printArtifact(makeArtifact({ category: 'archiver_data', title: 'CH1' }));
+
+      await vi.waitFor(() => { expect(win.print).toHaveBeenCalledTimes(1); });
+      expect(win.focus).toHaveBeenCalled();
+      const img = win.document.querySelector('.print-body img');
+      expect(img?.getAttribute('src')).toBe('data:image/png;base64,xyz');
+      expect(img?.getAttribute('alt')).toBe(esc('CH1') + ' chart');
+    });
+
+    test('alerts and does not open a window when the chart element is not yet rendered', () => {
+      const alertSpy = vi.fn();
+      vi.stubGlobal('alert', alertSpy);
+      const openSpy = vi.fn();
+      vi.stubGlobal('open', openSpy);
+      // No mountChart(): #ts-viewport [data-ts-chart] .js-plotly-plot is absent.
+
+      printArtifact(makeArtifact({ category: 'archiver_data' }));
+
+      expect(alertSpy).toHaveBeenCalledWith(MSG_CHART_NOT_READY);
+      expect(openSpy).not.toHaveBeenCalled();
+    });
+
+    test('alerts when the chart element exists but Plotly has not loaded', () => {
+      mountChart();
+      const alertSpy = vi.fn();
+      vi.stubGlobal('alert', alertSpy);
+      const openSpy = vi.fn();
+      vi.stubGlobal('open', openSpy);
+      // No Plotly stub: `typeof Plotly === "undefined"` is true.
+
+      printArtifact(makeArtifact({ category: 'archiver_data' }));
+
+      expect(alertSpy).toHaveBeenCalledWith(MSG_CHART_NOT_READY);
+      expect(openSpy).not.toHaveBeenCalled();
+    });
+
+    test('alerts, logs, and closes the capture window when Plotly.toImage rejects', async () => {
+      mountChart();
+      const captureErr = new Error('capture failed');
+      vi.stubGlobal('Plotly', { toImage: vi.fn(() => Promise.reject(captureErr)) });
+      const alertSpy = vi.fn();
+      vi.stubGlobal('alert', alertSpy);
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const win = makeFakeWindow();
+      vi.stubGlobal('open', vi.fn(() => win));
+
+      printArtifact(makeArtifact({ category: 'archiver_data' }));
+
+      await vi.waitFor(() => { expect(alertSpy).toHaveBeenCalledWith(MSG_CAPTURE_FAILED); });
+      expect(win.close).toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[print.js] Plotly.toImage failed:', captureErr);
+    });
+
+    test('a popup blocker on the capture window alerts without touching Plotly', () => {
+      mountChart();
+      const toImage = vi.fn();
+      vi.stubGlobal('Plotly', { toImage });
+      const alertSpy = vi.fn();
+      vi.stubGlobal('alert', alertSpy);
+      vi.stubGlobal('open', vi.fn(() => null));
+
+      printArtifact(makeArtifact({ category: 'archiver_data' }));
+
+      expect(alertSpy).toHaveBeenCalledWith(MSG_POPUP_BLOCKED);
+      expect(toImage).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/interfaces/artifacts/render.test.mjs
+++ b/tests/interfaces/artifacts/render.test.mjs
@@ -20,7 +20,7 @@
  * gallery.js effects it defers to).
  */
 
-import { test, expect, describe, beforeEach, vi } from 'vitest';
+import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
 
 import {
   setArtifacts,
@@ -31,6 +31,7 @@ import {
   initSplitPaneResize,
   createSidebarRenderer,
 } from '../../../src/osprey/interfaces/artifacts/static/js/render.js';
+import { initTypeRegistry } from '../../../src/osprey/interfaces/artifacts/static/js/types.js';
 
 /** Minimal DOM fixture matching artifacts/static/index.html's structure. */
 function mountFixture() {
@@ -266,6 +267,111 @@ describe('shared item handlers (click/dblclick/drag-to-terminal)', () => {
 
     expect(section.classList.contains('collapsed')).toBe(true);
     expect(callbacks.onSelect).not.toHaveBeenCalled();
+  });
+});
+
+describe('XSS hardening (Task 1.3 — escape-metadata-sinks)', () => {
+  const HOSTILE = '"><img src=x onerror=alert(1)>';
+
+  /**
+   * Seed state with one artifact whose category/artifact_type carry the
+   * hostile payload (title/filename are inert and unasserted).
+   * @param {string} id
+   */
+  function setHostileArtifact(id) {
+    setArtifacts([
+      { id, title: `Hostile ${id}`, filename: `${id}.png`, artifact_type: HOSTILE, category: HOSTILE, pinned: false, timestamp: '2026-07-04T10:00:00Z', size_bytes: 10 },
+    ]);
+  }
+
+  afterEach(async () => {
+    // Reset the module-level type registry so a test that re-inits it with a
+    // hostile label can't leak into later tests — even when its assertions fail.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) }));
+    await initTypeRegistry();
+    vi.unstubAllGlobals();
+  });
+
+  test('a hostile category/artifact_type is escaped in tree-mode data-type attributes — no live <img>, no unescaped attribute breakout', () => {
+    setHostileArtifact('x1');
+    const sidebarRenderer = createSidebarRenderer(makeCallbacks());
+    sidebarRenderer.renderSidebar(); // default: tree mode, list layout
+
+    // No live <img> element was injected anywhere in the sidebar.
+    expect(document.querySelector('#sidebar-body img')).toBeNull();
+    // No unescaped '"><' breakout sequence made it into the serialized markup.
+    expect(document.getElementById('sidebar-body').innerHTML).not.toMatch(/"><img/);
+
+    const section = document.querySelector('.tree-section');
+    expect(section).not.toBeNull();
+    // dataset/getAttribute auto-decode entities, so reading the attribute back
+    // round-trips to the raw hostile string (entity-decoded) — that's expected
+    // and safe; what matters is the SERIALIZED markup never contained a live
+    // '"><' breakout, asserted above.
+    expect(section.dataset.type).toBe(HOSTILE);
+    expect(section.querySelector('.tree-section-header').dataset.type).toBe(HOSTILE);
+  });
+
+  test('a hostile category is escaped in the activity-mode timeline-item data-type attribute', () => {
+    setHostileArtifact('x2');
+    const sidebarRenderer = createSidebarRenderer(makeCallbacks());
+    sidebarRenderer.setBrowseMode('activity');
+    sidebarRenderer.renderSidebar();
+
+    expect(document.querySelector('#sidebar-body img')).toBeNull();
+    expect(document.getElementById('sidebar-body').innerHTML).not.toMatch(/"><img/);
+
+    const item = document.querySelector('.timeline-item');
+    expect(item).not.toBeNull();
+    expect(item.dataset.type).toBe(HOSTILE);
+  });
+
+  test('a hostile gallery-layout category is escaped in the gallery-card data-type attribute', () => {
+    setHostileArtifact('x3');
+    const sidebarRenderer = createSidebarRenderer(makeCallbacks());
+    sidebarRenderer.setSidebarLayout('gallery');
+    sidebarRenderer.renderSidebar();
+
+    expect(document.querySelector('#sidebar-body img')).toBeNull();
+    const card = document.querySelector('.gallery-card');
+    expect(card).not.toBeNull();
+    expect(card.dataset.type).toBe(HOSTILE);
+  });
+
+  test('the filter-chip innerHTML escapes a hostile registry label as text and keeps the typeIcon SVG markup intact', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ categories: { evilchip: { label: '<img src=x onerror=alert(1)>' } } }),
+    }));
+    await initTypeRegistry();
+
+    setArtifacts([
+      { id: 'c1', title: 'Chip Test', filename: 'c.png', artifact_type: 'evilchip', category: 'evilchip', pinned: false, timestamp: '2026-07-04T10:00:00Z', size_bytes: 10 },
+    ]);
+    const sidebarRenderer = createSidebarRenderer(makeCallbacks());
+    sidebarRenderer.initFilterBar();
+
+    const chip = document.querySelector('.filter-chip[data-filter="evilchip"]');
+    expect(chip).not.toBeNull();
+    expect(chip.querySelector('img')).toBeNull();
+    // typeIcon's own SVG markup (audited: `type` never reaches its output) is
+    // untouched by this escaping and must still render.
+    expect(chip.querySelector('.chip-icon svg')).not.toBeNull();
+    expect(chip.innerHTML).toContain('&lt;img');
+    expect(chip.innerHTML).not.toContain('<img');
+  });
+
+  test('benign categories render byte-identical output (regression guard)', () => {
+    setArtifacts(makeFixtureArtifacts());
+    const sidebarRenderer = createSidebarRenderer(makeCallbacks());
+    sidebarRenderer.renderSidebar();
+
+    const visSection = document.querySelector('.tree-section[data-type="visualization"]');
+    expect(visSection).not.toBeNull();
+    expect(visSection.dataset.type).toBe('visualization');
+    expect(visSection.querySelector('.tree-section-header').dataset.type).toBe('visualization');
+    // The serialized markup is also byte-identical for benign values —
+    // escaping must introduce no stray entities.
+    expect(visSection.outerHTML).toContain('data-type="visualization"');
   });
 });
 

--- a/tests/interfaces/artifacts/render.test.mjs
+++ b/tests/interfaces/artifacts/render.test.mjs
@@ -27,6 +27,7 @@ import {
   setSelectedArtifact,
   setActiveFilter,
 } from '../../../src/osprey/interfaces/artifacts/static/js/state.js';
+import * as stateModule from '../../../src/osprey/interfaces/artifacts/static/js/state.js';
 import {
   initSplitPaneResize,
   createSidebarRenderer,
@@ -157,6 +158,21 @@ describe('activity-mode chronological ordering', () => {
 });
 
 describe('filter-chip active-state logic', () => {
+  /**
+   * 2x initFilterBar (a stray extra bootstrap invocation) + 5x
+   * rebuildTypeChips (simulating refetch/SSE cycles): 7 opportunities to
+   * re-wire the delegated #filter-bar listener, all but the first of which
+   * must be no-ops.
+   * @param {ReturnType<typeof createSidebarRenderer>} sidebarRenderer
+   */
+  function churnFilterBarWiring(sidebarRenderer) {
+    sidebarRenderer.initFilterBar();
+    sidebarRenderer.initFilterBar();
+    for (let i = 0; i < 5; i++) {
+      sidebarRenderer.rebuildTypeChips();
+    }
+  }
+
   test('initFilterBar wires clicks so the clicked chip becomes active and others deactivate', () => {
     setArtifacts(makeFixtureArtifacts()); // gives the "pinned" chip a count > 0, unhiding it
     const sidebarRenderer = createSidebarRenderer(makeCallbacks());
@@ -198,6 +214,100 @@ describe('filter-chip active-state logic', () => {
     // Only pinned artifacts (ids 2, 4) should now be rendered.
     const ids = Array.from(document.querySelectorAll('#sidebar-body [data-id]')).map((el) => el.dataset.id).sort();
     expect(ids).toEqual(['2', '4']);
+  });
+
+  test('a delegated #filter-bar click listener is registered exactly once across repeated rebuild/refetch cycles (no handler pileup)', () => {
+    setArtifacts(makeFixtureArtifacts());
+    const sidebarRenderer = createSidebarRenderer(makeCallbacks());
+    const filterBar = document.getElementById('filter-bar');
+    const addEventListenerSpy = vi.spyOn(filterBar, 'addEventListener');
+
+    churnFilterBarWiring(sidebarRenderer);
+
+    // Exactly one 'click' registration across all seven re-wire opportunities.
+    const clickRegistrations = addEventListenerSpy.mock.calls.filter((call) => call[0] === 'click');
+    expect(clickRegistrations.length).toBe(1);
+    addEventListenerSpy.mockRestore();
+
+    const allChip = document.querySelector('.filter-chip[data-filter="all"]');
+    const pinnedChip = document.querySelector('.filter-chip[data-filter="pinned"]');
+
+    // Click the static "pinned" chip once: exactly one filter/active-state
+    // change must fire, not once per (would-be) registered listener.
+    pinnedChip.click();
+
+    expect(pinnedChip.classList.contains('active')).toBe(true);
+    expect(allChip.classList.contains('active')).toBe(false);
+    const ids = Array.from(document.querySelectorAll('#sidebar-body [data-id]')).map((el) => el.dataset.id).sort();
+    expect(ids).toEqual(['2', '4']);
+
+    allChip.click();
+    expect(allChip.classList.contains('active')).toBe(true);
+    expect(pinnedChip.classList.contains('active')).toBe(false);
+  });
+
+  test('bounded handler-invocation count: a single click fires the filter change exactly once even after many rebuilds', () => {
+    setArtifacts(makeFixtureArtifacts());
+    const sidebarRenderer = createSidebarRenderer(makeCallbacks());
+
+    churnFilterBarWiring(sidebarRenderer);
+
+    const pinnedChip = document.querySelector('.filter-chip[data-filter="pinned"]');
+    const allChip = document.querySelector('.filter-chip[data-filter="all"]');
+
+    // The delegated handler's only externally-visible side effect on state
+    // is calling setActiveFilter(). Spy on it directly: if the listener had
+    // piled up (registered N times), a single click would call it N times
+    // instead of once.
+    const setActiveFilterSpy = vi.spyOn(stateModule, 'setActiveFilter');
+    pinnedChip.click();
+    expect(setActiveFilterSpy).toHaveBeenCalledTimes(1);
+    expect(setActiveFilterSpy).toHaveBeenCalledWith('pinned');
+    setActiveFilterSpy.mockRestore();
+
+    expect(pinnedChip.classList.contains('active')).toBe(true);
+    expect(allChip.classList.contains('active')).toBe(false);
+  });
+
+  test('type chips still filter correctly after several rebuild cycles', async () => {
+    // Type chips only render once the registry has category info (mirrors
+    // the "XSS hardening" block's own setup below).
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({
+        categories: {
+          visualization: { label: 'Visualization' },
+          channel_values: { label: 'Channel Values' },
+          document: { label: 'Document' },
+        },
+      }),
+    }));
+    await initTypeRegistry();
+
+    setArtifacts(makeFixtureArtifacts());
+    const sidebarRenderer = createSidebarRenderer(makeCallbacks());
+    sidebarRenderer.initFilterBar();
+    sidebarRenderer.renderSidebar();
+
+    // Simulate several refetch/SSE-driven rebuilds before the user acts.
+    for (let i = 0; i < 5; i++) {
+      sidebarRenderer.rebuildTypeChips();
+    }
+
+    const visualizationChip = document.querySelector('.filter-chip[data-filter="visualization"]');
+    expect(visualizationChip).not.toBeNull();
+
+    visualizationChip.click();
+    sidebarRenderer.renderSidebar();
+
+    expect(visualizationChip.classList.contains('active')).toBe(true);
+    const ids = Array.from(document.querySelectorAll('#sidebar-body [data-id]')).map((el) => el.dataset.id).sort();
+    // visualization category: ids 1 (Beam Profile) and 3 (Lattice Table).
+    expect(ids).toEqual(['1', '3']);
+
+    // Reset the module-level type registry so later tests aren't polluted.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) }));
+    await initTypeRegistry();
+    vi.unstubAllGlobals();
   });
 });
 

--- a/tests/interfaces/artifacts/security_render.test.mjs
+++ b/tests/interfaces/artifacts/security_render.test.mjs
@@ -1,0 +1,639 @@
+/**
+ * Consolidated hostile-metadata security regression suite (Phase 4, Task
+ * 1.5) — the machine-checkable gate proving Phase 1's security fixes
+ * (1.1 quote-safe-canonical-escaper, 1.2 consolidate-artifacts-escapers,
+ * 1.3 escape-metadata-sinks, 1.4 percent-encode-url-id-sinks) hold across
+ * every render path that touches agent-supplied artifact metadata, and
+ * cannot silently regress.
+ *
+ * Unlike the per-module suites (render.test.mjs, preview.test.mjs,
+ * types.test.mjs, timeseries.test.mjs), each of which owns one module's
+ * "XSS hardening" describe for its own sinks, this file drives the RENDER,
+ * PREVIEW, TYPES, TIMESERIES, and LOGBOOK-PICKER paths together with one
+ * broader hostile-fixture set, and pins the already-escaped fields
+ * (description/tool_source/filename) against a future unescaping
+ * regression. A few core assertions unavoidably overlap the per-module
+ * suites; that overlap is intentional (this is the cross-path contract).
+ *
+ * Pure DOM/logic guard, happy-dom environment (configured globally):
+ *   npx vitest run tests/interfaces/artifacts/security_render.test.mjs
+ *
+ * Conventions mirror the sibling suites (no vi.resetModules; state.js
+ * setters reseed the module-singleton artifact list per test). This file
+ * deliberately does NOT vi.mock logbook.js/print.js (unlike
+ * preview.test.mjs) — the real, unmocked implementations are safe no-op/
+ * button-appenders against these fixtures, and Task 1.5 item 5 requires
+ * driving the real artifact-picker id sink (logbook.js's `.value` DOM
+ * property assignment, the Task 1.4 attribute-sink fix) through the actual
+ * render pipeline in this same file, which would be impossible if the
+ * module were mocked here.
+ */
+
+import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  setArtifacts,
+  setSelectedArtifact,
+  setActiveFilter,
+  setFocusedArtifact,
+} from '../../../src/osprey/interfaces/artifacts/static/js/state.js';
+import {
+  createSidebarRenderer,
+} from '../../../src/osprey/interfaces/artifacts/static/js/render.js';
+import {
+  initTypeRegistry,
+  typeBadge,
+  thumbnailHtml,
+  openUrl,
+} from '../../../src/osprey/interfaces/artifacts/static/js/types.js';
+import { createPreviewRenderer } from '../../../src/osprey/interfaces/artifacts/static/js/preview.js';
+import {
+  renderTimeseriesTable,
+  renderTimeseriesView,
+} from '../../../src/osprey/interfaces/artifacts/static/js/timeseries.js';
+import { injectLogbookButtons } from '../../../src/osprey/interfaces/artifacts/static/js/logbook.js';
+
+// ---- Shared hostile payload set ---- //
+
+/**
+ * Double/single-quote attribute-breakout + live-element-injection payloads.
+ * Every one of these MUST be broken (never appear verbatim) in any
+ * serialized HTML this suite inspects, because escaping at least one of
+ * their `"`/`'`/`<`/`>` characters is required to render them inert.
+ */
+const HOSTILE = {
+  DQ_IMG: '"><img src=x onerror=alert(1)>',
+  DQ_ATTR: '" onmouseover=alert(1) x="',
+  SQ_IMG: "'><img src=x onerror=alert(1)>",
+};
+
+/**
+ * javascript: URL-scheme payload. Contains no `"`/`<`/`>`/`'`/`&`, so
+ * escapeHtml leaves it byte-identical — the invariant it must satisfy is
+ * different: it must only ever land in a text/attribute-value sink, never
+ * become a live `href`/`src`.
+ */
+const JS_SCHEME = 'javascript:alert(1)';
+
+/** Hostile artifact id for URL path-segment sinks (percent-encoding contract, Task 1.4). */
+const HOSTILE_ID = 'a/../b?x="y"';
+
+/** Hostile artifact id for the logbook picker's attribute-context id sink (Task 1.4). */
+const HOSTILE_PICKER_ID = '"><input x="';
+
+/** No element anywhere under `root` has live injected markup or a bare event-handler attribute. */
+function expectNoLiveInjection(root) {
+  expect(root.querySelector('img[onerror]')).toBeNull();
+  expect(root.querySelector('[onmouseover]')).toBeNull();
+}
+
+// ---- Shared DOM fixtures / lifecycle helpers ---- //
+
+/** Preview-pane DOM skeleton used by both the PREVIEW and LOGBOOK-picker paths. */
+function mountPreviewFixture() {
+  document.body.className = '';
+  document.body.innerHTML = `
+    <aside class="browse-sidebar" id="browse-sidebar">
+      <div class="sidebar-body" id="sidebar-body"></div>
+    </aside>
+    <div class="browse-preview-pane" id="browse-preview-pane">
+      <div class="preview-empty" id="preview-empty"></div>
+      <div class="preview-content hidden" id="preview-content"></div>
+    </div>
+  `;
+}
+
+function makePreviewCallbacks() {
+  return {
+    onArtifactDeleted: vi.fn(),
+    onPinToggled: vi.fn(),
+    onFullscreenExit: vi.fn(),
+    onTimeseriesNeeded: vi.fn(),
+  };
+}
+
+/**
+ * Reset the module-level type registry so a test that re-inits it with a
+ * hostile label can't leak into a later test, even on assertion failure.
+ * For use in afterEach of any describe that touches initTypeRegistry.
+ */
+async function resetTypeRegistry() {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) }));
+  await initTypeRegistry();
+  vi.unstubAllGlobals();
+}
+
+// =========================================================================
+// RENDER path — render.js's sidebar (tree / activity / gallery layouts) +
+// filter-bar chip labels.
+// =========================================================================
+
+describe('RENDER path (render.js) — hostile metadata in sidebar renders', () => {
+  function mountSidebarFixture() {
+    document.body.innerHTML = `
+      <nav class="filter-bar" id="filter-bar">
+        <div class="filter-bar-inner">
+          <button class="filter-chip active" data-filter="all">ALL</button>
+          <button class="filter-chip" data-filter="pinned" title="Pinned items" hidden>
+            Pinned <span class="chip-count"></span>
+          </button>
+          <span class="filter-chip-separator" id="filter-type-chips"></span>
+        </div>
+      </nav>
+      <input id="search" />
+      <aside class="browse-sidebar" id="browse-sidebar">
+        <div class="sidebar-body" id="sidebar-body"></div>
+      </aside>
+    `;
+  }
+
+  function makeSidebarCallbacks() {
+    return { onSelect: vi.fn(), onPreviewNeeded: vi.fn(), onEnterFullscreen: vi.fn() };
+  }
+
+  /** @param {string} payload */
+  function makeHostileArtifact(payload) {
+    return [{
+      id: 'r1',
+      title: payload,
+      filename: 'x.png',
+      artifact_type: payload,
+      category: payload,
+      pinned: false,
+      timestamp: '2026-07-04T10:00:00Z',
+      size_bytes: 10,
+    }];
+  }
+
+  beforeEach(() => {
+    mountSidebarFixture();
+    setActiveFilter('all');
+    setSelectedArtifact(null);
+  });
+
+  afterEach(resetTypeRegistry);
+
+  test.each(Object.entries(HOSTILE))(
+    'tree mode: a hostile %s payload in title/category/artifact_type renders inert',
+    (_name, payload) => {
+      setArtifacts(makeHostileArtifact(payload));
+      const renderer = createSidebarRenderer(makeSidebarCallbacks());
+      renderer.renderSidebar(); // default: tree mode
+
+      const sidebarBody = document.getElementById('sidebar-body');
+      // The real security property: no live element/attribute got injected.
+      // (A raw-substring check on the serialized HTML is NOT a reliable
+      // proxy for this — HTML text-node serialization is not required to
+      // re-escape `"`/`'`, only `&`/`<`/`>`, since quotes carry no special
+      // meaning outside an attribute-value context; a quote-only payload
+      // can legitimately reappear verbatim in TEXT content while still
+      // being fully inert.)
+      expectNoLiveInjection(sidebarBody);
+      // Exactly one section/item exists — an attribute breakout that split
+      // the hostile string into new attributes/elements would change this.
+      expect(sidebarBody.querySelectorAll('.tree-section').length).toBe(1);
+      expect(sidebarBody.querySelectorAll('.tree-item').length).toBe(1);
+
+      const section = sidebarBody.querySelector('.tree-section');
+      // Round-trip proof that the WHOLE payload landed intact as ONE
+      // attribute value (an early-closed `"` would truncate this).
+      expect(section.dataset.type).toBe(payload);
+      expect(sidebarBody.querySelector('.tree-item-name').textContent).toBe(payload);
+    }
+  );
+
+  test.each(Object.entries(HOSTILE))(
+    'activity mode: a hostile %s payload in category/artifact_type renders inert in the timeline-item',
+    (_name, payload) => {
+      setArtifacts(makeHostileArtifact(payload));
+      const renderer = createSidebarRenderer(makeSidebarCallbacks());
+      renderer.setBrowseMode('activity');
+      renderer.renderSidebar();
+
+      const sidebarBody = document.getElementById('sidebar-body');
+      expectNoLiveInjection(sidebarBody);
+      expect(sidebarBody.querySelectorAll('.timeline-item').length).toBe(1);
+
+      const item = sidebarBody.querySelector('.timeline-item');
+      expect(item.dataset.type).toBe(payload);
+      // The title markup interleaves a conditional pin-indicator span
+      // around the escaped title, so the node carries surrounding
+      // whitespace — trim before the round-trip comparison.
+      expect(item.querySelector('.timeline-item-title').textContent.trim()).toBe(payload);
+    }
+  );
+
+  test.each(Object.entries(HOSTILE))(
+    'gallery layout: a hostile %s payload in category/artifact_type renders inert in the gallery-card',
+    (_name, payload) => {
+      setArtifacts(makeHostileArtifact(payload));
+      const renderer = createSidebarRenderer(makeSidebarCallbacks());
+      renderer.setSidebarLayout('gallery');
+      renderer.renderSidebar();
+
+      const sidebarBody = document.getElementById('sidebar-body');
+      expectNoLiveInjection(sidebarBody);
+      expect(sidebarBody.querySelectorAll('.gallery-card').length).toBe(1);
+
+      const card = sidebarBody.querySelector('.gallery-card');
+      expect(card.dataset.type).toBe(payload);
+      // Same interleaved pin-indicator layout as the timeline-item title.
+      expect(card.querySelector('.gallery-card-title').textContent.trim()).toBe(payload);
+    }
+  );
+
+  test('initFilterBar: a hostile registry label is escaped as text in the chip innerHTML sink, typeIcon SVG survives', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ categories: { evilchip: { label: HOSTILE.DQ_ATTR } } }),
+    }));
+    await initTypeRegistry();
+
+    setArtifacts([
+      { id: 'c1', title: 'Chip Test', filename: 'c.png', artifact_type: 'evilchip', category: 'evilchip', pinned: false, timestamp: '2026-07-04T10:00:00Z', size_bytes: 10 },
+    ]);
+    const renderer = createSidebarRenderer(makeSidebarCallbacks());
+    renderer.initFilterBar();
+
+    const chip = document.querySelector('.filter-chip[data-filter="evilchip"]');
+    expect(chip).not.toBeNull();
+    expectNoLiveInjection(document.body);
+    expect(chip.querySelector('.chip-icon svg')).not.toBeNull();
+  });
+});
+
+// =========================================================================
+// PREVIEW path — preview.js's renderPreview: badge class, title,
+// description, tool_source, filename, and id URL sinks.
+// =========================================================================
+
+describe('PREVIEW path (preview.js) — hostile metadata in the preview pane', () => {
+  /** @returns {any} */
+  function makeArtifact(overrides = {}) {
+    return {
+      id: 'a1',
+      title: 'Beam Profile',
+      filename: 'beam_profile.png',
+      artifact_type: 'plot_png',
+      category: 'visualization',
+      pinned: false,
+      timestamp: '2026-07-01T10:00:00Z',
+      size_bytes: 2048,
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    mountPreviewFixture();
+    setArtifacts([]);
+    setSelectedArtifact(null);
+    setFocusedArtifact(null);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  test.each(Object.entries(HOSTILE))(
+    'a hostile %s payload in title/category/artifact_type is inert in the header badge + title',
+    (_name, payload) => {
+      setSelectedArtifact(makeArtifact({ title: payload, category: payload, artifact_type: payload }));
+      createPreviewRenderer(makePreviewCallbacks()).renderPreview();
+
+      const previewContent = document.getElementById('preview-content');
+      expectNoLiveInjection(previewContent);
+      expect(previewContent.querySelectorAll('.badge').length).toBe(1);
+
+      const badge = previewContent.querySelector('.badge');
+      // Round-trip proof the whole payload landed intact as ONE class
+      // attribute value (an early-closed `"` would truncate/split this).
+      expect(badge.className).toBe(`badge badge-${payload}`);
+      expect(previewContent.querySelector('.preview-header-title').textContent).toBe(payload);
+    }
+  );
+
+  test('description (currently-escaped field) renders as inert text — regression pin against future unescaping', () => {
+    // artifact_type falls through to the plain download-link branch (no
+    // mime_type, no recognized type) so renderPreview never fires a real
+    // network fetch (unlike "json"/"markdown", which load their own content).
+    setSelectedArtifact(makeArtifact({ artifact_type: 'totally_unrecognized_type', category: 'json', description: HOSTILE.DQ_IMG }));
+    createPreviewRenderer(makePreviewCallbacks()).renderPreview();
+
+    const previewContent = document.getElementById('preview-content');
+    expectNoLiveInjection(previewContent);
+    expect(previewContent.innerHTML).not.toContain(HOSTILE.DQ_IMG);
+
+    const desc = previewContent.querySelector('.preview-desc');
+    expect(desc).not.toBeNull();
+    expect(desc.textContent).toBe(HOSTILE.DQ_IMG);
+  });
+
+  test('tool_source (currently-escaped field) renders as inert text — regression pin against future unescaping', () => {
+    setSelectedArtifact(makeArtifact({ artifact_type: 'totally_unrecognized_type', category: 'json', tool_source: HOSTILE.DQ_IMG }));
+    createPreviewRenderer(makePreviewCallbacks()).renderPreview();
+
+    const previewContent = document.getElementById('preview-content');
+    expectNoLiveInjection(previewContent);
+    expect(previewContent.innerHTML).not.toContain(HOSTILE.DQ_IMG);
+
+    const metaValues = Array.from(previewContent.querySelectorAll('.preview-meta-value')).map((el) => el.textContent);
+    expect(metaValues).toContain(HOSTILE.DQ_IMG);
+  });
+
+  test('filename (currently-escaped field) renders as inert text at both the download link and copy-path sinks — regression pin', () => {
+    setSelectedArtifact(makeArtifact({ artifact_type: 'totally_unrecognized_type', category: 'json', filename: HOSTILE.DQ_IMG }));
+    createPreviewRenderer(makePreviewCallbacks()).renderPreview();
+
+    const previewContent = document.getElementById('preview-content');
+    expectNoLiveInjection(previewContent);
+    expect(previewContent.innerHTML).not.toContain(HOSTILE.DQ_IMG);
+
+    const downloadLink = previewContent.querySelector('.preview-download a');
+    expect(downloadLink).not.toBeNull();
+    expect(downloadLink.textContent).toContain(HOSTILE.DQ_IMG);
+
+    const pathText = previewContent.querySelector('.preview-path-text');
+    expect(pathText.textContent).toBe(`_agent_data/artifacts/${HOSTILE.DQ_IMG}`);
+  });
+
+  test('a hostile id is percent-encoded at both the "open in new tab" href and the download-link href', () => {
+    setSelectedArtifact(makeArtifact({ id: HOSTILE_ID, artifact_type: 'totally_unrecognized_type', category: 'json', filename: 'x.bin' }));
+    createPreviewRenderer(makePreviewCallbacks()).renderPreview();
+
+    const previewContent = document.getElementById('preview-content');
+    const expectedUrl = `/files/${encodeURIComponent(HOSTILE_ID)}/${encodeURIComponent('x.bin')}`;
+
+    const openInNewTab = previewContent.querySelector('.preview-header-actions a[target="_blank"]');
+    expect(openInNewTab.getAttribute('href')).toBe(expectedUrl);
+    expect(openInNewTab.getAttribute('href')).not.toMatch(/["?]/);
+
+    const downloadLink = previewContent.querySelector('.preview-download a');
+    expect(downloadLink.getAttribute('href')).toBe(expectedUrl);
+  });
+
+  test('a javascript: scheme payload in the title renders as inert text, never as a live href', () => {
+    setSelectedArtifact(makeArtifact({ title: JS_SCHEME }));
+    createPreviewRenderer(makePreviewCallbacks()).renderPreview();
+
+    const previewContent = document.getElementById('preview-content');
+    expect(previewContent.querySelector('.preview-header-title').textContent).toBe(JS_SCHEME);
+    expect(previewContent.querySelector('a[href^="javascript:"]')).toBeNull();
+  });
+});
+
+// =========================================================================
+// TYPES path — types.js's typeBadge / thumbnailHtml / openUrl-fileUrl id
+// encoding (spot checks; detailed id-encoding assertions live in
+// types.test.mjs/state.test.mjs).
+// =========================================================================
+
+describe('TYPES path (types.js) — typeBadge / thumbnailHtml / id-encoding', () => {
+  afterEach(resetTypeRegistry);
+
+  test('typeBadge escapes a hostile registry label to entity-safe text', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ categories: { evil: { label: HOSTILE.DQ_IMG } } }),
+    }));
+    await initTypeRegistry();
+
+    const result = typeBadge('evil');
+    expect(result).not.toContain(HOSTILE.DQ_IMG);
+    expect(result).toContain('&lt;img');
+    expect(result).not.toContain('<img');
+  });
+
+  test('typeBadge escapes a hostile type string when it falls back to the raw type (registry miss)', () => {
+    const result = typeBadge(HOSTILE.SQ_IMG);
+    expect(result).not.toContain(HOSTILE.SQ_IMG);
+    expect(result).not.toContain('<img');
+  });
+
+  test('thumbnailHtml escapes a hostile summary value at the summary-dump sink, no live element', () => {
+    const html = thumbnailHtml({
+      id: 'th1',
+      artifact_type: 'unknown_xyz',
+      filename: 'f.bin',
+      summary: { note: HOSTILE.DQ_IMG },
+    });
+
+    expect(html).not.toContain(HOSTILE.DQ_IMG);
+
+    const container = document.createElement('div');
+    container.innerHTML = html;
+    expectNoLiveInjection(container);
+    expect(container.querySelector('.thumb-summary').textContent).toContain(HOSTILE.DQ_IMG);
+  });
+
+  test('openUrl percent-encodes a hostile id at the markdown/notebook rendered-endpoint sinks', () => {
+    const mdUrl = openUrl({ id: HOSTILE_ID, artifact_type: 'markdown', filename: 'x.md' });
+    expect(mdUrl).toBe(`/api/markdown/${encodeURIComponent(HOSTILE_ID)}/rendered`);
+    expect(mdUrl).not.toMatch(/["?]/);
+
+    const nbUrl = openUrl({ id: HOSTILE_ID, artifact_type: 'notebook', filename: 'x.ipynb' });
+    expect(nbUrl).toBe(`/api/notebooks/${encodeURIComponent(HOSTILE_ID)}/rendered`);
+    expect(nbUrl).not.toMatch(/["?]/);
+  });
+
+  test('openUrl percent-encodes a hostile id at the default (fileUrl) sink', () => {
+    const url = openUrl({ id: HOSTILE_ID, artifact_type: 'mystery', filename: 'x.bin' });
+    expect(url).toBe(`/files/${encodeURIComponent(HOSTILE_ID)}/${encodeURIComponent('x.bin')}`);
+    expect(url).not.toMatch(/["?]/);
+  });
+});
+
+// =========================================================================
+// TIMESERIES paths — timeseries.js's renderTimeseriesTable (column-header
+// text sink) AND renderTimeseriesView (data-ch-name=/title= attribute
+// sinks at the channel-toggle buttons).
+// =========================================================================
+
+describe('TIMESERIES paths (timeseries.js) — hostile column name', () => {
+  /** Fixture chart-format response (`/api/artifacts/{id}/data?format=chart`). */
+  function makeChartData(overrides = {}) {
+    return {
+      columns: [HOSTILE.DQ_IMG],
+      index: ['2026-07-01T00:00:00Z'],
+      data: [[1.0]],
+      total_rows: 1,
+      downsampled: false,
+      returned_points: 1,
+      ...overrides,
+    };
+  }
+
+  /** Fixture table-format response (`/api/artifacts/{id}/data?format=table`). */
+  function makeTableData(overrides = {}) {
+    return {
+      columns: [HOSTILE.DQ_IMG],
+      index: ['2026-07-01T00:00:00Z'],
+      data: [[1.0]],
+      total_rows: 1,
+      offset: 0,
+      limit: 50,
+      returned_rows: 1,
+      ...overrides,
+    };
+  }
+
+  /** Mirrors timeseries.test.mjs's stubScriptLoad(): fake-loads an injected `<script>`. */
+  function stubScriptLoad() {
+    const originalAppendChild = document.head.appendChild.bind(document.head);
+    vi.spyOn(document.head, 'appendChild').mockImplementation((node) => {
+      if (node && node.tagName === 'SCRIPT') {
+        queueMicrotask(() => node.onload && node.onload());
+        return node;
+      }
+      return originalAppendChild(node);
+    });
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal('Plotly', {
+      newPlot: vi.fn((el) => { el.data = []; }),
+      restyle: vi.fn(),
+      relayout: vi.fn(),
+    });
+    stubScriptLoad();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe('renderTimeseriesTable', () => {
+    test('a hostile column name renders as inert text in the <th> header cell', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(makeTableData()) }));
+      const el = document.createElement('div');
+
+      await renderTimeseriesTable(el, 'ts1', [HOSTILE.DQ_IMG], 0);
+
+      expectNoLiveInjection(el);
+      expect(el.innerHTML).not.toContain(HOSTILE.DQ_IMG);
+      const th = el.querySelector('thead th:not(:first-child)');
+      expect(th.textContent).toBe(HOSTILE.DQ_IMG);
+    });
+  });
+
+  describe('renderTimeseriesView', () => {
+    test('a hostile column name round-trips through the data-ch-name/title attribute sinks with no breakout', async () => {
+      vi.stubGlobal('fetch', vi.fn((url) => {
+        if (url.includes('format=chart')) return Promise.resolve({ ok: true, json: () => Promise.resolve(makeChartData()) });
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(makeTableData()) });
+      }));
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      await renderTimeseriesView(container, { id: 'ts1' });
+
+      expectNoLiveInjection(container);
+      expect(container.innerHTML).not.toContain(HOSTILE.DQ_IMG);
+
+      const toggle = container.querySelector('.ts-ch-toggle');
+      expect(toggle).not.toBeNull();
+      // dataset/getAttribute auto-decode entities: reading back round-trips
+      // to the raw hostile column name — what matters is the SERIALIZED
+      // markup above never contained the raw breakout.
+      expect(toggle.dataset.chName).toBe(HOSTILE.DQ_IMG);
+      expect(toggle.getAttribute('title')).toBe(HOSTILE.DQ_IMG);
+    });
+
+    test('the info-bar channel badge escapes a hostile column name, no live element', async () => {
+      vi.stubGlobal('fetch', vi.fn((url) => {
+        if (url.includes('format=chart')) return Promise.resolve({ ok: true, json: () => Promise.resolve(makeChartData({ columns: [HOSTILE.SQ_IMG] })) });
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(makeTableData({ columns: [HOSTILE.SQ_IMG] })) });
+      }));
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      await renderTimeseriesView(container, { id: 'ts1' });
+
+      // SQ_IMG contains `<`/`>`/`'` but no `"`; the toggle button's
+      // data-ch-name/title attributes are double-quoted, so `'`/`<`/`>`
+      // need no re-escaping there to stay inert (matches the dedicated
+      // attribute-sink test above) — the property this test locks down is
+      // the info-bar's TEXT-content sink, which must still escape `<`/`>`.
+      expectNoLiveInjection(container);
+      const badge = container.querySelector('.ts-badge-channel');
+      expect(badge).not.toBeNull();
+      expect(badge.innerHTML).not.toMatch(/<img/);
+    });
+  });
+});
+
+// =========================================================================
+// LOGBOOK picker path — the deferred Task 1.4 regression: the artifact-
+// picker checkbox id is assigned via the `.value` DOM property, not
+// interpolated into innerHTML. Driven through the real (unmocked)
+// injectLogbookButtons() export via preview.js's actual render pipeline
+// (preview.js calls injectLogbookButtons() directly at the end of
+// renderPreview — see preview.js's module doc-comment), then a real
+// button click + radio change, mirroring the true user flow.
+// =========================================================================
+
+describe('LOGBOOK picker path (logbook.js) — hostile artifact id at the checkbox value sink', () => {
+  beforeEach(() => {
+    mountPreviewFixture();
+    setArtifacts([]);
+    setSelectedArtifact(null);
+    setFocusedArtifact(null);
+  });
+
+  afterEach(() => {
+    // Close the modal (if the test opened one) so logbook.js's module-level
+    // `modal`/`allArtifacts` singleton state doesn't leak into a later test.
+    const closeBtn = document.querySelector('.logbook-modal-close');
+    if (closeBtn) closeBtn.click();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  test('a hostile artifact id round-trips via the checkbox .value property, no injected <input>, no unescaped breakout', async () => {
+    setSelectedArtifact({
+      id: 'current-artifact',
+      title: 'Current',
+      filename: 'current.png',
+      artifact_type: 'plot_png',
+      category: 'visualization',
+      pinned: false,
+      timestamp: '2026-07-01T10:00:00Z',
+      size_bytes: 10,
+    });
+    createPreviewRenderer(makePreviewCallbacks()).renderPreview();
+
+    // renderPreview() calls the real injectLogbookButtons() internally,
+    // which appends the compose-modal trigger to the preview header.
+    const logbookBtn = document.querySelector('.logbook-action-btn');
+    expect(logbookBtn).not.toBeNull();
+    logbookBtn.click(); // opens the compose modal, phase = steering
+
+    const chooseRadio = document.querySelector('input[name="logbook-artifact-scope"][value="choose"]');
+    expect(chooseRadio).not.toBeNull();
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({
+        artifacts: [{ id: HOSTILE_PICKER_ID, title: 'Hostile Artifact', artifact_type: 'json' }],
+      }),
+    }));
+
+    chooseRadio.checked = true;
+    chooseRadio.dispatchEvent(new Event('change', { bubbles: true }));
+
+    // loadArtifactPicker() -> fetch().then(json).then(renderArtifactPicker):
+    // two microtask turns to flush the promise chain.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const list = document.getElementById('logbook-artifact-picker-list');
+    expect(list).not.toBeNull();
+
+    const checkboxes = list.querySelectorAll('input[type=checkbox]');
+    expect(checkboxes.length).toBe(1); // no extra <input> injected by the hostile id
+    expect(checkboxes[0].value).toBe(HOSTILE_PICKER_ID); // raw round-trip via the .value property
+
+    // The id was assigned as a DOM property, never interpolated into the
+    // innerHTML string, so it can never appear as a serialized attribute
+    // breakout in the picker's markup.
+    expect(list.innerHTML).not.toContain(HOSTILE_PICKER_ID);
+  });
+});

--- a/tests/interfaces/artifacts/state.test.mjs
+++ b/tests/interfaces/artifacts/state.test.mjs
@@ -95,6 +95,17 @@ describe('fileUrl', () => {
   test('builds a /files/{id}/{filename} URL, encoding the filename', () => {
     expect(fileUrl({ id: 'abc123', filename: 'plot one.png' })).toBe('/files/abc123/plot%20one.png');
   });
+
+  test('percent-encodes a hostile id, so no raw path-breakout/query/quote characters survive', () => {
+    const url = fileUrl({ id: 'a/../b?x="y"', filename: 'plot.png' });
+    const idSegment = url.split('/')[2];
+    expect(idSegment).not.toMatch(/[/?"]/);
+    expect(url).toBe('/files/a%2F..%2Fb%3Fx%3D%22y%22/plot.png');
+  });
+
+  test('is byte-identical for a real 12-hex artifact id (encodeURIComponent is a no-op)', () => {
+    expect(fileUrl({ id: '0123456789ab', filename: 'plot.png' })).toBe('/files/0123456789ab/plot.png');
+  });
 });
 
 describe('error banner', () => {

--- a/tests/interfaces/artifacts/timeseries.test.mjs
+++ b/tests/interfaces/artifacts/timeseries.test.mjs
@@ -76,6 +76,17 @@ function stubFetchRouting({ chartResp, tableResp } = {}) {
 }
 
 /**
+ * Stub the global `fetch` to resolve ok with `makeTableData(overrides)` for
+ * every call — the common `renderTimeseriesTable` setup. Returns the mock
+ * for tests that assert on fetched URLs.
+ */
+function stubTableFetch(overrides = {}) {
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(makeTableData(overrides)) });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+/**
  * Make an injected `<script>` "load" on the next microtask instead of
  * happy-dom actually processing it — happy-dom's default browser settings
  * disable script file loading outright (`disableJavaScriptFileLoading`),
@@ -337,7 +348,7 @@ describe('renderTimeseriesTable', () => {
   });
 
   test('renders a header row and one data row per index entry, from fixture series', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(makeTableData()) }));
+    stubTableFetch();
 
     await renderTimeseriesTable(el, 'ts1', ['SR:MAG:QF1:I', 'SR:MAG:QF2:I'], 0);
 
@@ -346,25 +357,151 @@ describe('renderTimeseriesTable', () => {
 
     const rows = el.querySelectorAll('tbody tr');
     expect(rows.length).toBe(2);
-    expect(rows[0].querySelector('.ts-index-cell').textContent).toBe('2026-07-01T00:00:00Z');
-    expect(Array.from(rows[0].querySelectorAll('td')).map((td) => td.textContent)).toEqual(['2026-07-01T00:00:00Z', '1', '2']);
+    // Index cell goes through _tsShortTime: exact rendering is locale-dependent,
+    // so assert shape (no year, seconds retained) rather than an exact string.
+    const indexCellText = rows[0].querySelector('.ts-index-cell').textContent;
+    expect(indexCellText).not.toMatch(/\b(19|20)\d{2}\b/);
+    expect(indexCellText).toMatch(/\d{1,2}:\d{2}:\d{2}/);
+    // Value cells go through _tsFormatValue: <=5 significant figures.
+    const valueCells = Array.from(rows[0].querySelectorAll('td')).slice(1).map((td) => td.textContent);
+    expect(valueCells).toEqual(['1.0000', '2.0000']);
   });
 
-  test('renders null values as an empty cell rather than the string "null"', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve(makeTableData({ data: [[null, 2.0]] , index: ['2026-07-01T00:00:00Z']})),
-    }));
+  test('renders null values as "--" rather than the string "null"', async () => {
+    stubTableFetch({ data: [[null, 2.0]], index: ['2026-07-01T00:00:00Z'] });
 
     await renderTimeseriesTable(el, 'ts1', ['a', 'b'], 0);
 
     const cells = Array.from(el.querySelectorAll('tbody tr td')).map((td) => td.textContent);
-    expect(cells).toEqual(['2026-07-01T00:00:00Z', '', '2']);
+    expect(cells[1]).toBe('--');
+    expect(cells[2]).toBe('2.0000');
+  });
+
+  describe('value-cell formatting (_tsFormatValue, exercised via rendered cells)', () => {
+    test('null/undefined -> "--", 0 -> "0", ordinary magnitude -> <=5 significant figures', async () => {
+      stubTableFetch({
+        columns: ['a', 'b', 'c'],
+        index: ['2026-07-01T00:00:00Z'],
+        data: [[null, 0, 1.23456789]],
+      });
+
+      await renderTimeseriesTable(el, 'ts1', ['a', 'b', 'c'], 0);
+
+      const cells = Array.from(el.querySelectorAll('tbody tr td')).map((td) => td.textContent).slice(1);
+      expect(cells).toEqual(['--', '0', '1.2346']);
+    });
+
+    test('very large and very small nonzero magnitudes render in scientific notation (toExponential(3))', async () => {
+      stubTableFetch({
+        columns: ['big', 'tiny'],
+        index: ['2026-07-01T00:00:00Z'],
+        data: [[1e7, 0.000123]],
+      });
+
+      await renderTimeseriesTable(el, 'ts1', ['big', 'tiny'], 0);
+
+      const cells = Array.from(el.querySelectorAll('tbody tr td')).map((td) => td.textContent).slice(1);
+      expect(cells).toEqual([(1e7).toExponential(3), (0.000123).toExponential(3)]);
+    });
+
+    test('a non-number string cell and a NaN cell fall back to String(...)', async () => {
+      stubTableFetch({
+        columns: ['s', 'n'],
+        index: ['2026-07-01T00:00:00Z'],
+        data: [['not-a-number', NaN]],
+      });
+
+      await renderTimeseriesTable(el, 'ts1', ['s', 'n'], 0);
+
+      const cells = Array.from(el.querySelectorAll('tbody tr td')).map((td) => td.textContent).slice(1);
+      expect(cells).toEqual(['not-a-number', 'NaN']);
+    });
+  });
+
+  describe('index-cell short-time formatting (_tsShortTime, exercised via rendered cells)', () => {
+    test('a valid ISO timestamp renders without a 4-digit year and with seconds retained', async () => {
+      stubTableFetch({
+        columns: ['a'],
+        index: ['2026-07-06T12:34:56Z'],
+        data: [[1.0]],
+      });
+
+      await renderTimeseriesTable(el, 'ts1', ['a'], 0);
+
+      const indexCellText = el.querySelector('.ts-index-cell').textContent;
+      // Locale-dependent exact rendering -- assert shape, not an exact string.
+      // (No month-glyph assertion: month:"short" has no ASCII letters under
+      // CJK/numeric-month locales, so that check would flake by CI locale.)
+      expect(indexCellText).not.toMatch(/\b(19|20)\d{2}\b/); // no year
+      expect(indexCellText).toMatch(/\d{1,2}:\d{2}:\d{2}/); // hour:minute:second
+    });
+
+    test('null and numeric index values render honestly instead of as fabricated dates', async () => {
+      stubTableFetch({
+        columns: ['a'],
+        index: [null, 0, '0'],
+        data: [[1.0], [2.0], [3.0]],
+      });
+
+      await renderTimeseriesTable(el, 'ts1', ['a'], 0);
+
+      const cells = Array.from(el.querySelectorAll('.ts-index-cell')).map((c) => c.textContent);
+      // new Date(null) is epoch 0 and new Date('0') parses as year 2000 --
+      // neither may leak into the table as an invented timestamp.
+      expect(cells).toEqual(['--', '0', '0']);
+    });
+
+    test('an unparseable index value falls back to String(iso)', async () => {
+      stubTableFetch({
+        columns: ['a'],
+        index: ['not-a-date'],
+        data: [[1.0]],
+      });
+
+      await renderTimeseriesTable(el, 'ts1', ['a'], 0);
+
+      expect(el.querySelector('.ts-index-cell').textContent).toBe('not-a-date');
+    });
+  });
+
+  describe('hostile cell values (MI-1 regression: agent-supplied strings must render inert)', () => {
+    const XSS_PAYLOAD = '"><img src=x onerror=alert(1)>';
+
+    test('a hostile string value cell renders escaped, with no live <img>', async () => {
+      stubTableFetch({
+        columns: ['a'],
+        index: ['2026-07-01T00:00:00Z'],
+        data: [[XSS_PAYLOAD]],
+      });
+
+      await renderTimeseriesTable(el, 'ts1', ['a'], 0);
+
+      expect(el.querySelectorAll('img').length).toBe(0);
+      expect(el.innerHTML).toContain('&lt;img');
+      expect(el.innerHTML).not.toContain('<img');
+      const valueCell = el.querySelectorAll('tbody tr td')[1];
+      expect(valueCell.textContent).toBe(XSS_PAYLOAD);
+    });
+
+    test('a hostile string index value renders escaped, with no live <img>', async () => {
+      stubTableFetch({
+        columns: ['a'],
+        index: [XSS_PAYLOAD],
+        data: [[1.0]],
+      });
+
+      await renderTimeseriesTable(el, 'ts1', ['a'], 0);
+
+      expect(el.querySelectorAll('img').length).toBe(0);
+      expect(el.innerHTML).toContain('&lt;img');
+      expect(el.innerHTML).not.toContain('<img');
+      expect(el.querySelector('.ts-index-cell').textContent).toBe(XSS_PAYLOAD);
+    });
   });
 
   describe('pagination', () => {
     test('Prev is disabled at offset 0; Next is disabled once all rows are on the page', async () => {
-      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(makeTableData({ total_rows: 2 })) }));
+      stubTableFetch({ total_rows: 2 });
 
       await renderTimeseriesTable(el, 'ts1', ['a', 'b'], 0);
 
@@ -374,8 +511,7 @@ describe('renderTimeseriesTable', () => {
     });
 
     test('Next is enabled when more rows remain, and clicking it re-fetches at the next offset', async () => {
-      const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(makeTableData({ total_rows: 120 })) });
-      vi.stubGlobal('fetch', fetchMock);
+      const fetchMock = stubTableFetch({ total_rows: 120 });
 
       await renderTimeseriesTable(el, 'ts1', ['a', 'b'], 0);
 
@@ -388,8 +524,7 @@ describe('renderTimeseriesTable', () => {
     });
 
     test('Prev clamps to offset 0 rather than going negative', async () => {
-      const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(makeTableData({ total_rows: 120, offset: 20 })) });
-      vi.stubGlobal('fetch', fetchMock);
+      const fetchMock = stubTableFetch({ total_rows: 120, offset: 20 });
 
       await renderTimeseriesTable(el, 'ts1', ['a', 'b'], 20);
       fetchMock.mockClear();
@@ -435,10 +570,7 @@ describe('Plotly loader edge cases (isolated: fresh module instance per test)', 
       }
       throw new Error('unexpected non-script appendChild in this isolated test');
     });
-    vi.stubGlobal('fetch', vi.fn((url) => {
-      if (url.includes('format=chart')) return Promise.resolve({ ok: true, json: () => Promise.resolve(makeChartData()) });
-      return Promise.resolve({ ok: true, json: () => Promise.resolve(makeTableData()) });
-    }));
+    stubFetchRouting();
 
     const fresh = await import('../../../src/osprey/interfaces/artifacts/static/js/timeseries.js');
     const container = document.createElement('div');
@@ -447,6 +579,49 @@ describe('Plotly loader edge cases (isolated: fresh module instance per test)', 
 
     expect(container.textContent).toContain('Failed to load timeseries data');
     expect(Plotly.newPlot).not.toHaveBeenCalled();
+  });
+
+  test('a script load failure does not permanently poison the loader: the next render re-injects a fresh <script> and can succeed', async () => {
+    vi.stubGlobal('Plotly', { newPlot: vi.fn((el) => { el.data = []; }) });
+    stubFetchRouting();
+
+    /** @type {any[]} */
+    const scriptAppends = [];
+    vi.spyOn(document.head, 'appendChild').mockImplementation((node) => {
+      if (node && node.tagName === 'SCRIPT') {
+        scriptAppends.push(node);
+        if (scriptAppends.length === 1) {
+          // First injection: simulate a load failure, as the earlier test does.
+          queueMicrotask(() => node.onerror && node.onerror());
+        }
+        // The second (retry) injection is left pending here -- the test
+        // fires its onload manually below, once it's confirmed injected.
+        return node;
+      }
+      throw new Error('unexpected non-script appendChild in this isolated test');
+    });
+
+    const fresh = await import('../../../src/osprey/interfaces/artifacts/static/js/timeseries.js');
+
+    const container1 = document.createElement('div');
+    await fresh.renderTimeseriesView(container1, { id: 'ts1' });
+
+    expect(container1.textContent).toContain('Failed to load timeseries data');
+    expect(scriptAppends.length).toBe(1);
+
+    const container2 = document.createElement('div');
+    const renderPromise = fresh.renderTimeseriesView(container2, { id: 'ts2' });
+
+    // A second render must re-inject its own fresh <script> rather than
+    // reusing the (permanently rejected) first loading promise.
+    await vi.waitFor(() => expect(scriptAppends.length).toBe(2));
+    expect(scriptAppends[1]).not.toBe(scriptAppends[0]);
+
+    scriptAppends[1].onload();
+    await renderPromise;
+
+    expect(container2.textContent).not.toContain('Failed to load timeseries data');
+    expect(Plotly.newPlot).toHaveBeenCalledTimes(1);
   });
 
   test('concurrent renderTimeseriesChart calls coalesce onto one _plotlyLoading promise (exactly one <script> injected)', async () => {

--- a/tests/interfaces/artifacts/types.test.mjs
+++ b/tests/interfaces/artifacts/types.test.mjs
@@ -31,6 +31,9 @@ import {
   formatFullTime,
   formatDate,
   openUrl,
+  isoToDate,
+  isTimeseries,
+  hasTimeseriesData,
   isNewThisSession,
   sendToTerminal,
   requestColorPass,
@@ -183,6 +186,33 @@ describe('formatSize', () => {
   });
 });
 
+describe('isoToDate (shared timestamp guard)', () => {
+  test('parses a valid ISO string to a Date', () => {
+    const d = isoToDate('2026-07-03T15:45:00Z');
+    expect(d).toBeInstanceOf(Date);
+    expect(d.getUTCFullYear()).toBe(2026);
+  });
+
+  test('accepts the backend microsecond + numeric-offset shape', () => {
+    expect(isoToDate('2026-07-07T15:45:00.123456+00:00')).toBeInstanceOf(Date);
+  });
+
+  test('returns null for nullish input', () => {
+    expect(isoToDate(null)).toBeNull();
+    expect(isoToDate(undefined)).toBeNull();
+  });
+
+  test('returns null for non-string / numeric / non-ISO-shaped input (no fabricated date)', () => {
+    for (const junk of ['0', '1751000000000', 'not-a-date', 0, 42, {}, []]) {
+      expect(isoToDate(junk)).toBeNull();
+    }
+  });
+
+  test('returns null for an ISO-shaped-but-impossible date (NaN branch)', () => {
+    expect(isoToDate('2026-99-99T00:00:00Z')).toBeNull();
+  });
+});
+
 describe('formatTime / formatFullTime / formatDate', () => {
   test('formatTime and formatFullTime return "" for falsy input', () => {
     expect(formatTime(null)).toBe('');
@@ -210,6 +240,31 @@ describe('formatTime / formatFullTime / formatDate', () => {
     const iso = '2026-07-03T15:45:00Z';
     expect(formatTime(iso).length).toBeGreaterThan(0);
     expect(formatFullTime(iso)).toContain('2026');
+  });
+
+  test('accepts the exact backend timestamp shape (microseconds + numeric offset)', () => {
+    // artifact_store.py emits datetime.now(UTC).isoformat(), e.g. this form —
+    // the guard's ISO-shape regex must pass it through, not reject it.
+    const iso = '2026-07-07T15:45:00.123456+00:00';
+    expect(formatTime(iso).length).toBeGreaterThan(0);
+    expect(formatFullTime(iso)).toContain('2026');
+    expect(formatDate(iso)).not.toBe('Unknown');
+  });
+
+  test('non-ISO / fabricating input yields the empty/"Unknown" fallback, never an invented date', () => {
+    // Bare `new Date("0")`/`new Date(0)` would fabricate a year-2000/epoch
+    // date; the guard must reject these rather than render a made-up time.
+    for (const junk of ['0', '1751000000000', 'not-a-date', 42, {}, []]) {
+      expect(formatTime(junk)).toBe('');
+      expect(formatFullTime(junk)).toBe('');
+      expect(formatDate(junk)).toBe('Unknown');
+    }
+  });
+
+  test('an ISO string that parses to an invalid date falls back rather than throwing', () => {
+    // ISO-shaped but impossible (month 99): Date coercion yields NaN.
+    expect(formatFullTime('2026-99-99T00:00:00Z')).toBe('');
+    expect(formatDate('2026-99-99T00:00:00Z')).toBe('Unknown');
   });
 });
 
@@ -246,6 +301,46 @@ describe('openUrl', () => {
 
   test('notebook branch is byte-identical for a real 12-hex artifact id', () => {
     expect(openUrl({ id: '0123456789ab', artifact_type: 'notebook', filename: 'x.ipynb' })).toBe('/api/notebooks/0123456789ab/rendered');
+  });
+});
+
+describe('isTimeseries', () => {
+  test('true when metadata.data_type is "timeseries"', () => {
+    expect(isTimeseries({ metadata: { data_type: 'timeseries' }, artifact_type: 'json' })).toBe(true);
+  });
+
+  test('true when category is "archiver_data"', () => {
+    expect(isTimeseries({ category: 'archiver_data', artifact_type: 'json' })).toBe(true);
+  });
+
+  test('false for an ordinary artifact with no timeseries markers', () => {
+    expect(isTimeseries({ artifact_type: 'json', metadata: { data_type: 'table' } })).toBe(false);
+  });
+
+  test('does not require a data file (print strategy captures the on-screen chart)', () => {
+    expect(isTimeseries({ category: 'archiver_data' })).toBe(true);
+  });
+
+  test('tolerates a missing metadata object without throwing', () => {
+    expect(isTimeseries({ artifact_type: 'json' })).toBe(false);
+  });
+});
+
+describe('hasTimeseriesData', () => {
+  test('true when a timeseries artifact carries a top-level data_file', () => {
+    expect(hasTimeseriesData({ category: 'archiver_data', data_file: 'y.parquet' })).toBe(true);
+  });
+
+  test('true when the data_file lives under metadata', () => {
+    expect(hasTimeseriesData({ metadata: { data_type: 'timeseries', data_file: 'x.parquet' } })).toBe(true);
+  });
+
+  test('false for a timeseries artifact with no data file (nothing to fetch/render)', () => {
+    expect(hasTimeseriesData({ category: 'archiver_data' })).toBe(false);
+  });
+
+  test('false for a non-timeseries artifact even when it happens to have a data_file', () => {
+    expect(hasTimeseriesData({ artifact_type: 'json', data_file: 'z.parquet' })).toBe(false);
   });
 });
 

--- a/tests/interfaces/artifacts/types.test.mjs
+++ b/tests/interfaces/artifacts/types.test.mjs
@@ -78,6 +78,22 @@ describe('typeBadge', () => {
     await initTypeRegistry();
     expect(typeBadge('json')).toBe('JSON Data');
   });
+
+  test('Task 1.3 — a hostile registry label (agent-fed /api/type-registry) is escaped to inert text', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ artifact_types: { evil: { label: '<img src=x onerror=alert(1)>' } } }),
+    }));
+    await initTypeRegistry();
+    const result = typeBadge('evil');
+    expect(result).not.toContain('<img');
+    expect(result).toContain('&lt;img');
+  });
+
+  test('Task 1.3 — a hostile unregistered type falls back to escaped humanized text (agent-supplied category/artifact_type)', () => {
+    const result = typeBadge('<script>alert(1)</script>');
+    expect(result).not.toContain('<script>');
+    expect(result).toContain('&lt;script&gt;');
+  });
 });
 
 describe('typeIcon', () => {
@@ -127,16 +143,18 @@ describe('escapeHtml', () => {
     expect(escapeHtml('')).toBe('');
   });
 
-  test('KNOWN DIVERGENCE from design-system/js/dom.js\'s escapeHtml: falsy-but-defined values (0, false) also collapse to "" here', () => {
-    // dom.js's escapeHtml uses `String(value ?? "")` — only null/undefined
-    // become "", so escapeHtml(0) there is "0" and escapeHtml(false) is
-    // "false". This local implementation uses `str || ""` (moved verbatim
-    // from the original gallery.js, unchanged behavior), which treats ANY
-    // falsy value the same as nullish. Pinning the current behavior here so
-    // a future consolidation onto the shared dom.js helper is a deliberate,
-    // reviewed decision rather than a silent behavior change.
-    expect(escapeHtml(0)).toBe('');
-    expect(escapeHtml(false)).toBe('');
+  test('post-consolidation contract: only null/undefined collapse to "" — 0 and false stringify', () => {
+    // types.js now re-exports design-system/js/dom.js's escapeHtml, which
+    // uses `String(value ?? "")`: only null/undefined become "", so
+    // falsy-but-defined values like 0/false stringify instead of collapsing.
+    // This was a deliberate, reviewed consolidation (previously this module
+    // had its own `str || ""` copy that collapsed ALL falsy values).
+    expect(escapeHtml(0)).toBe('0');
+    expect(escapeHtml(false)).toBe('false');
+  });
+
+  test('escapes double- and single-quotes (quote-safe, attribute-context contract)', () => {
+    expect(escapeHtml(`"quoted" & 'single'`)).toBe('&quot;quoted&quot; &amp; &#39;single&#39;');
   });
 });
 
@@ -207,6 +225,28 @@ describe('openUrl', () => {
   test('any other type falls back to the raw file URL', () => {
     expect(openUrl({ id: 'a3', artifact_type: 'plot_png', filename: 'plot.png' })).toBe('/files/a3/plot.png');
   });
+
+  test('markdown branch percent-encodes a hostile id, so no raw path-breakout/query/quote characters survive', () => {
+    const url = openUrl({ id: 'a/../b?x="y"', artifact_type: 'markdown', filename: 'x.md' });
+    const idSegment = url.split('/')[3];
+    expect(idSegment).not.toMatch(/[/?"]/);
+    expect(url).toBe('/api/markdown/a%2F..%2Fb%3Fx%3D%22y%22/rendered');
+  });
+
+  test('markdown branch is byte-identical for a real 12-hex artifact id', () => {
+    expect(openUrl({ id: '0123456789ab', artifact_type: 'markdown', filename: 'x.md' })).toBe('/api/markdown/0123456789ab/rendered');
+  });
+
+  test('notebook branch percent-encodes a hostile id, so no raw path-breakout/query/quote characters survive', () => {
+    const url = openUrl({ id: 'a/../b?x="y"', artifact_type: 'notebook', filename: 'x.ipynb' });
+    const idSegment = url.split('/')[3];
+    expect(idSegment).not.toMatch(/[/?"]/);
+    expect(url).toBe('/api/notebooks/a%2F..%2Fb%3Fx%3D%22y%22/rendered');
+  });
+
+  test('notebook branch is byte-identical for a real 12-hex artifact id', () => {
+    expect(openUrl({ id: '0123456789ab', artifact_type: 'notebook', filename: 'x.ipynb' })).toBe('/api/notebooks/0123456789ab/rendered');
+  });
 });
 
 describe('thumbnailHtml', () => {
@@ -219,6 +259,17 @@ describe('thumbnailHtml', () => {
   test('an html-family type renders an <iframe>', () => {
     const html = thumbnailHtml({ id: 'i2', artifact_type: 'plot_html', filename: 'p.html' });
     expect(html).toContain('<iframe');
+  });
+
+  test('the notebook iframe src percent-encodes a hostile id, so no raw path-breakout/query/quote characters survive', () => {
+    const html = thumbnailHtml({ id: 'a/../b?x="y"', artifact_type: 'notebook', filename: 'n.ipynb' });
+    expect(html).toContain('/api/notebooks/a%2F..%2Fb%3Fx%3D%22y%22/rendered');
+    expect(html).not.toContain('/api/notebooks/a/../b');
+  });
+
+  test('the notebook iframe src is byte-identical for a real 12-hex artifact id', () => {
+    const html = thumbnailHtml({ id: '0123456789ab', artifact_type: 'notebook', filename: 'n.ipynb' });
+    expect(html).toContain('/api/notebooks/0123456789ab/rendered');
   });
 
   test('a type with a non-empty summary renders the summary fields, escaped', () => {

--- a/tests/interfaces/design_system/js/alias-smoke.test.mjs
+++ b/tests/interfaces/design_system/js/alias-smoke.test.mjs
@@ -20,8 +20,8 @@ test('escapeHtml resolves through the /design-system/js alias and escapes HTML-s
   expect(escapeHtml('<img src=x onerror=alert(1)>')).toBe('&lt;img src=x onerror=alert(1)&gt;');
 });
 
-test('escapeHtml leaves double quotes as-is (matches the call sites it replaces)', () => {
-  expect(escapeHtml('"quoted"')).toBe('"quoted"');
+test('escapeHtml escapes double quotes (attribute-context safe)', () => {
+  expect(escapeHtml('"quoted"')).toBe('&quot;quoted&quot;');
 });
 
 test('escapeHtml treats nullish input as an empty string', () => {

--- a/tests/interfaces/design_system/js/dom.test.js
+++ b/tests/interfaces/design_system/js/dom.test.js
@@ -6,10 +6,10 @@
  *
  * Covers el(), escapeHtml(), and the trailing-edge debounce().
  *
- * NOTE: dom.js is imported by RELATIVE path, not the absolute
- * `/design-system/js/dom.js` runtime specifier — Vitest/Vite resolves against
- * the repo root with no alias configured, so the absolute path would not load.
- * This mirrors tests/interfaces/channel_finder/chunk-filter.test.mjs.
+ * NOTE: dom.js is imported by RELATIVE path here rather than the absolute
+ * `/design-system/js/dom.js` runtime specifier. vitest.config.js does
+ * configure that alias (see alias-smoke.test.mjs), but this file predates it
+ * and mirrors tests/interfaces/channel_finder/chunk-filter.test.mjs.
  */
 
 import { test, expect, vi, describe, afterEach } from 'vitest';
@@ -47,10 +47,20 @@ describe('escapeHtml', () => {
     expect(escapeHtml(42)).toBe("42");
   });
 
-  test('does NOT escape a double-quote', () => {
-    const out = escapeHtml('a"b');
-    expect(out).toContain('"');
-    expect(out).toBe('a"b');
+  test('coerces 0 to "0" (not the empty string)', () => {
+    expect(escapeHtml(0)).toBe("0");
+  });
+
+  test('coerces false to "false"', () => {
+    expect(escapeHtml(false)).toBe("false");
+  });
+
+  test('escapes a double-quote to &quot;', () => {
+    expect(escapeHtml('a"b')).toBe('a&quot;b');
+  });
+
+  test('escapes a single-quote to &#39;', () => {
+    expect(escapeHtml("a'b")).toBe('a&#39;b');
   });
 });
 

--- a/tests/interfaces/tuning/security_render.test.mjs
+++ b/tests/interfaces/tuning/security_render.test.mjs
@@ -1,0 +1,126 @@
+/**
+ * Tuning — hostile-field security regression suite.
+ *
+ * Guards the three render sinks that interpolate caller/backend-supplied
+ * strings into `innerHTML`:
+ *
+ *   1. optimization-form.js `renderTable`   — user-typed PV name (self-XSS),
+ *      interpolated into BOTH a quoted `data-pv="…"` attribute and `<td>`
+ *      element text.
+ *   2. progress-display.js  results table    — backend `objective` field
+ *      (fallback when `objective_value` is non-numeric) and `phase`.
+ *   3. results-viewer.js    `renderAnalysis`  — backend historical-run
+ *      `timestamp`.
+ *
+ * Every payload MUST be neutralised (escaped, never a live element) on every
+ * path. This mirrors the artifacts hostile-metadata suite: the fix is the
+ * shared, quote-safe `escapeHtml` from /design-system/js/dom.js.
+ *
+ * Pure DOM guard, happy-dom environment (configured globally):
+ *   npx vitest run tests/interfaces/tuning/security_render.test.mjs
+ */
+
+import { test, expect, describe, beforeEach } from 'vitest';
+
+import { state } from '../../../src/osprey/interfaces/tuning/static/js/state.js';
+import { renderTable } from '../../../src/osprey/interfaces/tuning/static/js/optimization-form.js';
+import { initProgressDisplay } from '../../../src/osprey/interfaces/tuning/static/js/progress-display.js';
+import {
+  initResultsViewer,
+  renderAnalysis,
+} from '../../../src/osprey/interfaces/tuning/static/js/results-viewer.js';
+
+// plots.js calls the vendored global `Plotly` at runtime; it is absent under
+// Vitest. These render sinks set `innerHTML` synchronously (the assertion runs
+// before any chart draw), so a no-op stub just prevents an unrelated crash.
+globalThis.Plotly = {
+  react() {},
+  newPlot() {},
+  purge() {},
+  relayout() {},
+};
+
+// Double- and single-quote attribute breakout + live-element injection.
+const PAYLOADS = [
+  '"><img src=x onerror=alert(1)>',
+  "'><svg/onload=alert(1)>",
+  '<script>alert(1)</script>',
+];
+
+/**
+ * Assert a rendered container is structurally inert, inspecting the parsed
+ * DOM rather than serialized `innerHTML`. (A payload that survives only as an
+ * attribute *value* — e.g. `data-pv="…<img…>"` — is safe: no element is built
+ * and the value re-serializes with a literal `<img` that is not markup.
+ * Matching that string would be a false positive, so we check structure.)
+ *
+ *   1. No injected element got built from any payload.
+ *   2. No element carries an inline `on*` event-handler attribute (which is
+ *      what a successful attribute breakout would create).
+ */
+function assertInert(container) {
+  expect(container.querySelector('img, svg, script')).toBeNull();
+  for (const el of container.querySelectorAll('*')) {
+    for (const attr of el.attributes) {
+      expect(attr.name.toLowerCase().startsWith('on')).toBe(false);
+    }
+  }
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  state.setVariableTableData([]);
+});
+
+describe('optimization-form renderTable — PV-name sink (attribute + text)', () => {
+  for (const payload of PAYLOADS) {
+    test(`neutralises ${JSON.stringify(payload)}`, () => {
+      state.setVariableTableData([
+        { pv_name: payload, current_value: 1, min: 0, max: 2, step_size: null, bo_range_factor: 1, selected: false },
+      ]);
+      const tbody = document.createElement('tbody');
+      renderTable(tbody, true); // showBoRange: exercises all data-pv attribute copies
+
+      assertInert(tbody);
+      // The PV name survived only as inert text: textContent decodes the
+      // escaped entities back to the literal payload string.
+      expect(tbody.textContent).toContain(payload);
+    });
+  }
+});
+
+describe('progress-display results table — backend objective/phase sink', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="run-status-badge"><span class="status-dot"></span><span class="status-text"></span></div>
+      <table><tbody id="results-table-body"></tbody></table>
+    `;
+    initProgressDisplay();
+  });
+
+  for (const payload of PAYLOADS) {
+    test(`neutralises objective ${JSON.stringify(payload)}`, () => {
+      // Non-numeric objective_value forces the `objective` string fallback sink.
+      state.setOptimizationState({
+        status: 'RUNNING',
+        lhs_data: [{ objective: payload, objective_value: null }],
+        bo_data: [],
+      });
+      assertInert(document.getElementById('results-table-body'));
+    });
+  }
+});
+
+describe('results-viewer renderAnalysis — backend timestamp sink', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="analysis-content"></div>';
+    initResultsViewer();
+  });
+
+  for (const payload of PAYLOADS) {
+    test(`neutralises timestamp ${JSON.stringify(payload)}`, () => {
+      renderAnalysis([{ objective_value: 1 }], payload);
+      assertInert(document.getElementById('analysis-content'));
+    });
+  }
+});


### PR DESCRIPTION
## Security
- Escape agent-supplied artifact metadata (category/type/title) at every render sink; agent input can no longer inject markup. Harden the shared escaper to also escape quotes so it is safe in attribute contexts.
- Escape user-typed PV names and backend optimizer fields in the tuning panel's table/progress/analysis views.
- Add hostile-input regression suites for both interfaces.

## Hygiene
- Delegate artifact filter-bar clicks to a single listener.
- Retry failed Plotly loads; format timeseries table cells.
- Remove dead Focus-view code and CSS.
- Consolidate duplicated gallery helpers; unify timestamp and timeseries formatting (closes a fabricated-timestamp bug on null/numeric indices).
- Add logbook and print unit tests.

## Verification
- Vitest 537/537, `tsc --noEmit` clean.
- Browser smoke rail green.
