### PR TITLE
feat: add Bluesky scan plans as write-safe agent actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,13 +478,14 @@ jobs:
           uv run pytest $E2E_FILTER -v --tb=short
         else
           # Tier 3 per-preset agentic flows live in their own matrix job
-          # (agentic-per-preset). The full Docker-stack dispatch test
-          # (dispatch-deploy-e2e) and the Dockerfile e2e (dockerfile-e2e) each
+          # (agentic-per-preset). The full Docker-stack tests (dispatch-deploy-e2e,
+          # scan-deploy-e2e) and the Dockerfile e2e (dockerfile-e2e) each
           # have their own job because they build container images. Exclude all
-          # three here to avoid double-execution.
+          # four here to avoid double-execution.
           uv run pytest tests/e2e/ -v --tb=short \
             --ignore=tests/e2e/test_preset_agentic.py \
             --ignore=tests/e2e/test_dispatch_deploy.py \
+            --ignore=tests/e2e/test_scan_deploy.py \
             --ignore=tests/e2e/test_dockerfile_e2e.py
         fi
 
@@ -600,6 +601,39 @@ jobs:
       run: |
         uv run pytest tests/e2e/test_dispatch_deploy.py -v --tb=short
 
+  scan-deploy-e2e:
+    name: Scan Deploy E2E (bluesky bridge, full Docker stack)
+    runs-on: ubuntu-latest
+    # Only run on PRs from same repo (mirrors dispatch-deploy-e2e/deploy-e2e
+    # gating). This job needs no secrets — the bluesky bridge never shells out
+    # to an LLM — but the same-repo restriction is the house policy for any
+    # extra Docker-build-and-deploy job, not just secret-gated ones.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+
+    - name: Set up Python
+      run: uv python install 3.11
+
+    - name: Set up Docker Compose
+      uses: docker/setup-compose-action@v2
+
+    - name: Install osprey
+      run: uv sync --extra dev
+
+    - name: Run scan deploy E2E
+      run: |
+        uv run pytest tests/e2e/test_scan_deploy.py -v --tb=short
+
   dockerfile-e2e:
     name: Dockerfile E2E (generated container image)
     runs-on: ubuntu-latest
@@ -637,7 +671,7 @@ jobs:
 
   all-checks-passed:
     name: All CI Checks Passed
-    needs: [test, lint, docs, package, static-checks, visual-theming, frontend-js, build-boot-smoke, e2e-tests, deploy-e2e, dispatch-deploy-e2e, dockerfile-e2e, agentic-per-preset]
+    needs: [test, lint, docs, package, static-checks, visual-theming, frontend-js, build-boot-smoke, e2e-tests, deploy-e2e, dispatch-deploy-e2e, scan-deploy-e2e, dockerfile-e2e, agentic-per-preset]
     runs-on: ubuntu-latest
     if: always()
 
@@ -707,6 +741,14 @@ jobs:
           echo "⏭️  Dispatch deploy E2E skipped (only run on PRs)"
         else
           echo "✅ Dispatch deploy E2E passed"
+        fi
+        # Scan Deploy E2E: advisory (Docker-dependent, no LLM involved)
+        if [[ "${{ needs.scan-deploy-e2e.result }}" == "failure" ]]; then
+          echo "⚠️  Scan deploy E2E failed (non-blocking, Docker-dependent)"
+        elif [[ "${{ needs.scan-deploy-e2e.result }}" == "skipped" ]]; then
+          echo "⏭️  Scan deploy E2E skipped (only run on PRs)"
+        else
+          echo "✅ Scan deploy E2E passed"
         fi
         # Dockerfile E2E: advisory (network-dependent: PyPI, claude.ai installer)
         if [[ "${{ needs.dockerfile-e2e.result }}" == "failure" ]]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,6 +252,19 @@ module = [
 ]
 ignore_missing_imports = true
 
+# Bluesky bridge (osprey.services.bluesky_bridge): the lifecycle core (runs.py,
+# app.py, security.py, scanner.py) stays import-clean of these, but Phase 2's
+# submodules (scanner_bluesky.py, devices/epics.py, plans.py, ...) will import
+# them behind the optional `osprey-framework[bluesky-bridge]` extra.
+[[tool.mypy.overrides]]
+module = [
+    "bluesky.*",
+    "ophyd.*",
+    "ophyd_async.*",
+    "tiled.*",
+]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-ra -v --tb=short --strict-markers --color=yes"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,19 @@ screen-capture-linux = [
     "python-xlib>=0.33",
 ]
 
+# Bluesky bridge (osprey.services.bluesky_bridge): the RunEngine, ophyd-async
+# devices, and Tiled writer/reader the bridge's Phase 2 submodules (plans.py,
+# scanner_bluesky.py, devices/*.py) import behind this extra. The bridge's
+# lifecycle core (app.py, runs.py, security.py, scanner.py) stays import-clean
+# of all of these — installed only in the bridge process's own container venv,
+# never required in OSPREY's main venv. fastapi/uvicorn/httpx are already core
+# dependencies, so they're not repeated here.
+bluesky-bridge = [
+    "bluesky>=1.12",
+    "ophyd-async>=0.16,<1.0",
+    "tiled[client]>=0.1",
+]
+
 # All optional dependencies for complete installation
 all = [
     "osprey-framework[docs,dev,ariel,sheets,screen-capture-linux,archiver-mongodb,knowledge]"

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -35,7 +35,7 @@ from osprey.utils.logger import get_logger
 from .templates.manager import TemplateManager
 
 if TYPE_CHECKING:
-    from osprey.cli.build_profile import DispatchConfig
+    from osprey.cli.build_profile import BlueskyConfig, DispatchConfig
 
 logger = get_logger("build")
 
@@ -422,6 +422,10 @@ def build(
         # 10b. Inject event-dispatch services + triggers
         if build_profile.dispatch is not None:
             _inject_dispatch(build_profile.dispatch, profile_dir, project_path)
+
+        # 10c. Inject the Bluesky scan-bridge service
+        if build_profile.bluesky is not None:
+            _inject_bluesky(build_profile.bluesky, project_path)
 
         # 11. Copy overlay files
         if build_profile.overlay:
@@ -1063,6 +1067,22 @@ def _apply_config_overrides(project_path: Path, config_dict: dict[str, Any]) -> 
     config_update_fields(config_path, config_dict)
 
 
+def _locate_pkg_services() -> Path:
+    """Locate the OSPREY package's bundled ``templates/services`` directory.
+
+    Prefers the installed ``osprey.templates`` package's location; falls back to
+    a path relative to this module for source/editable checkouts where the
+    package metadata is unavailable. Callers check ``.is_dir()`` on the result,
+    since the directory may be absent in a stripped-down install.
+    """
+    try:
+        import osprey.templates
+
+        return Path(osprey.templates.__file__).parent / "services"
+    except (ImportError, AttributeError):
+        return Path(__file__).parent.parent / "templates" / "services"
+
+
 def _copy_service_templates(project_path: Path) -> int:
     """Copy service compose templates from the OSPREY package into the project.
 
@@ -1085,12 +1105,7 @@ def _copy_service_templates(project_path: Path) -> int:
         config = yaml.load(fh)
 
     # Locate the package's service templates directory
-    try:
-        import osprey.templates
-
-        pkg_services = Path(osprey.templates.__file__).parent / "services"
-    except (ImportError, AttributeError):
-        pkg_services = Path(__file__).parent.parent / "templates" / "services"
+    pkg_services = _locate_pkg_services()
 
     if not pkg_services.is_dir():
         logger.warning("Service templates directory not found — skipping")
@@ -1256,12 +1271,7 @@ def _inject_dispatch(dispatch: DispatchConfig, profile_dir: Path, project_path: 
             _trigger_yaml.dump(triggers_doc, fh)
 
     # 2. Copy bundled compose templates (located the same way as service templates).
-    try:
-        import osprey.templates
-
-        pkg_services = Path(osprey.templates.__file__).parent / "services"
-    except (ImportError, AttributeError):
-        pkg_services = Path(__file__).parent.parent / "templates" / "services"
+    pkg_services = _locate_pkg_services()
 
     dest_services_root = project_path / "services"
     dest_services_root.mkdir(exist_ok=True)
@@ -1357,6 +1367,93 @@ def _inject_dispatch(dispatch: DispatchConfig, profile_dir: Path, project_path: 
         "(first run is slow). Use `--dev` to bake in your local osprey checkout; "
         "set OSPREY_DISPATCH_IMAGE/OSPREY_WORKER_IMAGE to use a published image."
     )
+
+
+def _inject_bluesky(bluesky: BlueskyConfig, project_path: Path) -> None:
+    """Wire the Bluesky scan-bridge feature into a built project.
+
+    1. Copy the bundled ``templates/services/bluesky/`` compose template into
+       ``<project>/services/bluesky/``.
+    2. Write ``services.bluesky`` config + register it in ``deployed_services``
+       (so ``find_service_config`` resolves it, mirroring ``_inject_dispatch``).
+    3. Print a post-build hint (promote-token env var + image prerequisite).
+
+    Simpler than ``_inject_dispatch``: no triggers file to resolve and no
+    multi-instance worker loop — a project deploys exactly one bluesky-bridge
+    process. The ``scan`` MCP server itself is a separate, always-available
+    framework server (see ``osprey.mcp_server.scan``); this step only wires
+    the *deploy-time* container that server talks to over HTTP.
+
+    Args:
+        bluesky: Validated bluesky configuration from the build profile.
+        project_path: Root of the built project.
+    """
+    from ruamel.yaml import YAML
+
+    # 1. Copy the bundled compose template (located the same way as service templates).
+    pkg_services = _locate_pkg_services()
+
+    src_dir = pkg_services / "bluesky"
+    if not src_dir.is_dir():
+        logger.warning("No package template for bluesky service at %s", src_dir)
+        return
+
+    dest_services_root = project_path / "services"
+    dest_services_root.mkdir(exist_ok=True)
+    dest_dir = dest_services_root / "bluesky"
+    if dest_dir.exists():
+        shutil.rmtree(dest_dir)
+    shutil.copytree(src_dir, dest_dir)
+
+    # 2. Write config.yml entries + register in deployed_services.
+    config_path = project_path / "config.yml"
+    if not config_path.exists():
+        logger.warning("config.yml not found — skipping bluesky config registration")
+        return
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    with open(config_path) as fh:
+        config = yaml.load(fh)
+
+    # No ``image`` key: the service builds the local bluesky-bridge image on
+    # first ``osprey deploy up``. Override with OSPREY_BLUESKY_BRIDGE_IMAGE, or
+    # set ``services.bluesky.image`` here, to use a prebuilt/published image.
+    config.setdefault("services", {})
+    config["services"]["bluesky"] = {
+        "path": "./services/bluesky",
+        "port": bluesky.port,
+        "tiled_enabled": bluesky.tiled_enabled,
+        "tiled_port": bluesky.tiled_port,
+        "demo_scanner": bluesky.demo_scanner,
+    }
+    deployed = config.get("deployed_services", []) or []
+    if "bluesky" not in [str(s) for s in deployed]:
+        deployed.append("bluesky")
+    config["deployed_services"] = deployed
+
+    with open(config_path, "w") as fh:
+        yaml.dump(config, fh)
+
+    # 3. Post-build hint.
+    logger.info("  ✓ Injected Bluesky scan bridge (port %d)", bluesky.port)
+    logger.info(
+        "    Token:      `osprey deploy up` writes BLUESKY_PROMOTE_TOKEN to .env; "
+        "the `scan` MCP server's launch_scan tool reads it automatically."
+    )
+    logger.info(
+        "    Images:     `osprey deploy up` builds the bluesky-bridge image locally "
+        "(first run is slow). Use `--dev` to bake in your local osprey checkout; "
+        "set OSPREY_BLUESKY_BRIDGE_IMAGE to use a published image."
+    )
+    if bluesky.tiled_enabled:
+        logger.info("    Tiled:      enabled on port %d", bluesky.tiled_port)
+    if bluesky.demo_scanner:
+        logger.warning(
+            "    Demo mode:  BLUESKY_DEMO_SCANNER is set — the bridge runs a real "
+            "bluesky RunEngine against MOCK devices only. Never enable this for a "
+            "facility wiring real EPICS hardware."
+        )
 
 
 def _copy_overlay_files(

--- a/src/osprey/cli/build_profile.py
+++ b/src/osprey/cli/build_profile.py
@@ -101,6 +101,30 @@ class DispatchConfig:
     pv_strip_prefix: str = ""
 
 
+@dataclass
+class BlueskyConfig:
+    """Bluesky scan-bridge configuration for a build profile (opt-in via the ``bluesky:`` key).
+
+    Consumed by the build pipeline's bluesky-injection step to deploy the
+    single ``bluesky_bridge`` service (see NAMING-ADDENDUM.md: deploy key
+    ``bluesky``, env var ``BLUESKY_PROMOTE_TOKEN``, MCP server name ``scan``).
+    Ports are validated by :meth:`BuildProfile.validate`.
+    """
+
+    port: int = 8090
+    tiled_enabled: bool = False
+    tiled_port: int = 8091
+    demo_scanner: bool = False
+    """Opt-in only for the deploy-smoke-demo / tutorial case: wires the
+    container's bridge process to a real bluesky RunEngine against mock
+    ophyd-async devices (``devices/mock.py``) via app.py's guarded startup
+    hook (task 2.14a), instead of the Phase 1 no-op ``FakeScanner`` default.
+    MUST stay False for any facility wiring real EPICS hardware — turning
+    this on would silently override real device/plan wiring with an
+    in-memory mock scanner.
+    """
+
+
 _ENV_VAR_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
 
 
@@ -255,6 +279,7 @@ class BuildProfile:
     """
     categories: dict[str, dict[str, str]] = field(default_factory=dict)
     dispatch: DispatchConfig | None = None
+    bluesky: BlueskyConfig | None = None
 
     def resolved_tier(self) -> int:
         """Resolve the build-time tier, applying a paradigm-aware default.
@@ -478,6 +503,19 @@ class BuildProfile:
                     stacklevel=2,
                 )
 
+        # Validate bluesky configuration
+        if self.bluesky is not None:
+            b = self.bluesky
+            if not (1 <= b.port <= 65535):
+                errors.append(f"bluesky.port must be in 1..65535 (got {b.port})")
+            if b.tiled_enabled:
+                if not (1 <= b.tiled_port <= 65535):
+                    errors.append(f"bluesky.tiled_port must be in 1..65535 (got {b.tiled_port})")
+                elif b.tiled_port == b.port:
+                    errors.append(
+                        f"bluesky.tiled_port must differ from bluesky.port (both {b.port})"
+                    )
+
         if errors:
             raise BuildProfileError(
                 "Build profile validation failed:\n  - " + "\n  - ".join(errors)
@@ -547,6 +585,7 @@ _KNOWN_PROFILE_KEYS = frozenset(
         "claude_md_template",
         "categories",
         "dispatch",
+        "bluesky",
     }
 )
 
@@ -655,6 +694,18 @@ def _parse_profile(raw: dict[str, Any]) -> BuildProfile:
             pv_strip_prefix=dispatch_raw.get("pv_strip_prefix", ""),
         )
 
+    bluesky_raw = raw.get("bluesky")
+    bluesky = None
+    if bluesky_raw is not None:
+        if not isinstance(bluesky_raw, dict):
+            raise BuildProfileError("Profile 'bluesky' must be a mapping")
+        bluesky = BlueskyConfig(
+            port=bluesky_raw.get("port", 8090),
+            tiled_enabled=bluesky_raw.get("tiled_enabled", False),
+            tiled_port=bluesky_raw.get("tiled_port", 8091),
+            demo_scanner=bluesky_raw.get("demo_scanner", False),
+        )
+
     return BuildProfile(
         name=raw.get("name", ""),
         data_bundle=raw.get("data_bundle", "control_assistant"),
@@ -682,6 +733,7 @@ def _parse_profile(raw: dict[str, Any]) -> BuildProfile:
         claude_md_template=raw.get("claude_md_template"),
         categories=raw.get("categories", {}),
         dispatch=dispatch,
+        bluesky=bluesky,
     )
 
 

--- a/src/osprey/cli/templates/claude_code.py
+++ b/src/osprey/cli/templates/claude_code.py
@@ -17,6 +17,15 @@ from osprey.utils.config import resolve_env_vars
 
 logger = logging.getLogger("osprey.cli.templates")
 
+# python's execute is the one documented read/write-mixed exception to the
+# kill-switch's hard-deny default (see the docstring in
+# build_claude_code_context below): it accepts both read-only and write-access
+# kernels, so the kill switch pulls it OUT of `ask` instead of hard-denying it
+# outright. Every other _WRITES_CHECK-gated tool is presumed pure-write and
+# must be denied. Module-level so tests can assert against the same set the
+# renderer actually uses instead of re-declaring it.
+_MIXED_READ_WRITE_TEMPLATES = {"python"}
+
 
 def build_claude_code_context(
     template_root: Path,
@@ -214,7 +223,18 @@ def build_claude_code_context(
     # (it has a legitimate readonly path), so instead it is pulled OUT of
     # permissions.ask — with no static ask entry, the writes_check hook's deny
     # on a readwrite execute stands alone and blocks the call before the prompt.
+    #
+    # Generalized over FRAMEWORK_SERVERS rather than hardcoded per server name:
+    # any hooks_pre rule gated by _WRITES_CHECK is a hardware/state write and
+    # defaults to a hard deny (covers controls' channel_write and scan's
+    # launch_scan automatically, plus any future write server with no code
+    # change here). python's execute is the one documented exception — it
+    # accepts both read_only and write_access kernels, so it is pulled into
+    # remove_ask instead (see docstring above); every other writes-check-gated
+    # tool is presumed pure-write and denied outright.
     if not config.get("control_system", {}).get("writes_enabled", False):
+        from osprey.registry.mcp import _WRITES_CHECK, FRAMEWORK_SERVERS
+
         facility_perms = dict(ctx["facility_permissions"])
         deny = list(facility_perms.get("deny", []))
         remove_ask = list(facility_perms.get("remove_ask", []))
@@ -227,14 +247,21 @@ def build_claude_code_context(
             if not srv["enabled"]:
                 continue
             template = srv.get("extends_of") or srv["name"]
-            if template == "controls":
-                entry = f"mcp__{srv['name']}__channel_write"
-                if entry not in deny:
-                    deny.append(entry)
-            elif template == "python":
-                entry = f"mcp__{srv['name']}__execute"
-                if entry not in remove_ask:
-                    remove_ask.append(entry)
+            template_def = FRAMEWORK_SERVERS.get(template)
+            if template_def is None:
+                continue  # custom (non-framework) server — out of scope here
+            old_prefix, new_prefix = f"mcp__{template}__", f"mcp__{srv['name']}__"
+            for rule in template_def.hooks_pre:
+                if _WRITES_CHECK not in rule.hooks:
+                    continue
+                matcher = rule.matcher
+                if matcher.startswith(old_prefix):
+                    matcher = new_prefix + matcher[len(old_prefix) :]
+                if template in _MIXED_READ_WRITE_TEMPLATES:
+                    if matcher not in remove_ask:
+                        remove_ask.append(matcher)
+                elif matcher not in deny:
+                    deny.append(matcher)
         facility_perms["deny"] = deny
         facility_perms["remove_ask"] = remove_ask
         ctx["facility_permissions"] = facility_perms

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -24,32 +24,107 @@ from osprey.utils.logger import get_logger
 
 logger = get_logger("deployment.lifecycle")
 
-# The event-dispatch services fail closed on an unset bearer token (no insecure
-# default in their compose templates), so a deploy must supply real secrets.
-_DISPATCH_SERVICES = {"event_dispatcher", "dispatch_worker"}
-_DISPATCH_TOKEN_VARS = ("EVENT_DISPATCHER_TOKEN", "DISPATCH_WORKER_TOKEN")
+# Services that fail closed on an unset bearer token (no insecure default in
+# their compose templates), so a deploy must supply real secrets. Maps each
+# deployed-service name to the token env var(s) it requires. event_dispatcher
+# and dispatch_worker both list the same pair because they share one .env:
+# the dispatcher forwards routed requests to workers using DISPATCH_WORKER_TOKEN,
+# so either service alone still needs both vars minted. bluesky is a single
+# fail-closed bridge instance needing only its own promote token — see
+# ``security.require_armed`` in ``osprey.services.bluesky_bridge``.
+_SERVICE_TOKEN_VARS: dict[str, tuple[str, ...]] = {
+    "event_dispatcher": ("EVENT_DISPATCHER_TOKEN", "DISPATCH_WORKER_TOKEN"),
+    "dispatch_worker": ("EVENT_DISPATCHER_TOKEN", "DISPATCH_WORKER_TOKEN"),
+    "bluesky": ("BLUESKY_PROMOTE_TOKEN",),
+}
+
+# Services whose fail-closed token must NOT be auto-armed when the agent's code
+# execution is unsandboxed on the host (see _local_exec_arming_unsafe below).
+# Their bearer token gates a write-capable HTTP route (bluesky-bridge's
+# POST /runs/{id}/promote); under local exec, agent-authored code can read that
+# token straight out of .env/config.yml and call the route directly, bypassing
+# the in-tool writes_enabled re-check that's supposed to gate it. The
+# event-dispatch services aren't in this set: their tokens gate an inbound
+# webhook/worker-routing boundary, not a write path the agent itself walks.
+_LOCAL_EXEC_GATED_SERVICES = {"bluesky"}
 
 
-def _ensure_dispatch_tokens(
-    deployed_services, expose_network: bool, env_path: Path | None = None
+def _local_exec_arming_unsafe(config: dict) -> bool:
+    """True when writes are enabled AND python-executor code runs unsandboxed on the host.
+
+    ``control_system.writes_enabled`` (default False) and
+    ``execution.execution_method`` (default "container") are read directly from
+    the raw config dict, mirroring how every other consumer of these two flags
+    resolves them (e.g. ``osprey.connectors.control_system.base``,
+    ``osprey.cli.templates.claude_code``, the ``osprey_writes_check`` hook, and
+    ``osprey.mcp_server.python_executor.executor._read_config``).
+
+    The container execution_method runs agent code fs/network-isolated from the
+    project's ``.env`` and has no equivalent exposure.
+    """
+    writes_enabled = bool(config.get("control_system", {}).get("writes_enabled", False))
+    execution_method = config.get("execution", {}).get("execution_method", "container")
+    return writes_enabled and execution_method == "local"
+
+
+def _ensure_service_tokens(
+    config: dict, expose_network: bool, env_path: Path | None = None
 ) -> None:
-    """Self-provision the dispatch bearer tokens into the project ``.env``.
+    """Self-provision required fail-closed service tokens into the project ``.env``.
 
-    For any dispatch token unset in BOTH the process env and the project
-    ``.env``, generate a strong random value (``secrets.token_urlsafe(32)``,
-    the same recipe the ``.env.template`` documents) and append it to ``.env``
+    For any token var (per ``_SERVICE_TOKEN_VARS``, keyed by the deployed
+    services present) unset in BOTH the process env and the project ``.env``,
+    generate a strong random value (``secrets.token_urlsafe(32)``, the same
+    recipe the ``.env.template`` documents) and append it to ``.env``
     (``chmod 0o600``, matching the build-time convention). Existing values are
-    never overwritten, so re-running ``deploy up`` is idempotent. No-op unless a
-    dispatch service is actually deployed.
+    never overwritten, so re-running ``deploy up`` is idempotent. No-op unless
+    a token-requiring service is actually deployed.
 
     A token that is *present but explicitly empty* (e.g. ``TOKEN=`` exported in
     the shell) is left untouched — generating would silently override a
     deliberate value. For a loopback deploy the server simply fails closed; for
     an exposed deploy (``--expose`` / bind 0.0.0.0) we refuse rather than bind a
     fail-open-at-bind server to all interfaces.
+
+    A service in ``_LOCAL_EXEC_GATED_SERVICES`` is skipped entirely (no token
+    minted, existing values in .env/env left untouched but not read either) when
+    ``_local_exec_arming_unsafe(config)`` — see that function's docstring. The
+    bridge's own ``require_armed()`` then keeps returning 503, i.e. it never
+    arms, rather than being armed with a token any local agent-code execution
+    can trivially read back out of ``.env``.
     """
+    deployed_services = config.get("deployed_services")
     services = {str(s) for s in (deployed_services or [])}
-    if not (_DISPATCH_SERVICES & services):
+    unsafe_local_exec = _local_exec_arming_unsafe(config)
+
+    # Iterate the map (not the deployed `services` set) so var order is
+    # deterministic regardless of set iteration order or config.yml ordering.
+    required_vars: list[str] = []
+    seen: set[str] = set()
+    for svc_name, token_vars in _SERVICE_TOKEN_VARS.items():
+        if svc_name not in services:
+            continue
+        if svc_name in _LOCAL_EXEC_GATED_SERVICES and unsafe_local_exec:
+            logger.warning(
+                "Refusing to arm %r: control_system.writes_enabled is true but "
+                "execution.execution_method is 'local' (agent code runs unsandboxed "
+                "on the host, cwd=project_root). Local execution can read %s "
+                "straight out of .env/config.yml and call the write-capable route "
+                "it gates directly, bypassing the in-tool writes_enabled re-check. "
+                "NOT minting %s — the service stays unarmed. Set "
+                "execution.execution_method: container to use this feature with "
+                "writes_enabled: true.",
+                svc_name,
+                ", ".join(token_vars),
+                ", ".join(token_vars),
+            )
+            continue
+        for var in token_vars:
+            if var not in seen:
+                seen.add(var)
+                required_vars.append(var)
+
+    if not required_vars:
         return
 
     if env_path is None:
@@ -58,7 +133,7 @@ def _ensure_dispatch_tokens(
     existing = parse_dotenv_file(env_path) if env_path.is_file() else {}
 
     generated: dict[str, str] = {}
-    for name in _DISPATCH_TOKEN_VARS:
+    for name in required_vars:
         # Process env wins over .env (matches docker compose --env-file).
         present = name in os.environ or name in existing
         if present:
@@ -73,23 +148,23 @@ def _ensure_dispatch_tokens(
                 prefix = "\n"
         block = "".join(f"{k}={v}\n" for k, v in generated.items())
         with env_path.open("a", encoding="utf-8") as fh:
-            fh.write(f"{prefix}# Auto-generated dispatch auth tokens (osprey deploy up)\n{block}")
+            fh.write(f"{prefix}# Auto-generated service auth tokens (osprey deploy up)\n{block}")
         os.chmod(env_path, 0o600)
         # Log the path and which keys — NEVER the values.
         logger.key_info(
-            "Generated dispatch auth token(s) %s in %s (gitignored) — keep them secret",
+            "Generated auth token(s) %s in %s (gitignored) — keep them secret",
             ", ".join(generated),
             env_path.resolve(),
         )
 
     if expose_network:
         post = parse_dotenv_file(env_path) if env_path.is_file() else {}
-        for name in _DISPATCH_TOKEN_VARS:
+        for name in required_vars:
             effective = os.environ.get(name, post.get(name, ""))
             if not effective.strip():
                 raise RuntimeError(
                     f"{name} is empty; refusing to --expose (bind 0.0.0.0) with an "
-                    f"empty dispatch token. Set {name} in .env to a strong secret."
+                    f"empty token. Set {name} in .env to a strong secret."
                 )
 
 
@@ -119,12 +194,13 @@ def deploy_up(config_path, detached=False, dev_mode=False, expose_network=False)
     if not is_running:
         raise RuntimeError(error_msg)
 
-    # Self-provision dispatch auth tokens into .env (before the --env-file check
-    # below) so a fresh deploy is secure by default. The worker mounts the same
-    # .env for provider auth; a deploy where .env already carries provider keys
-    # renders with osprey_env_present=True and picks up the appended tokens, and
-    # a tokens-only .env carries no provider secret to mount in the first place.
-    _ensure_dispatch_tokens(config.get("deployed_services"), expose_network)
+    # Self-provision fail-closed service tokens into .env (before the --env-file
+    # check below) so a fresh deploy is secure by default. The dispatch worker
+    # mounts the same .env for provider auth; a deploy where .env already
+    # carries provider keys renders with osprey_env_present=True and picks up
+    # the appended tokens, and a tokens-only .env carries no provider secret to
+    # mount in the first place.
+    _ensure_service_tokens(config, expose_network)
 
     # Set up environment for containers
     env = os.environ.copy()
@@ -229,7 +305,7 @@ def deploy_restart(config_path, detached=False, expose_network=False):
 
     # Honor the same fail-closed/expose guard as deploy_up when re-rendering with
     # a (possibly newly exposed) bind address.
-    _ensure_dispatch_tokens(config.get("deployed_services"), expose_network)
+    _ensure_service_tokens(config, expose_network)
 
     cmd = get_runtime_command(config)
     for compose_file in compose_files:
@@ -263,8 +339,8 @@ def rebuild_deployment(config_path, detached=False, dev_mode=False, expose_netwo
     if not is_running:
         raise RuntimeError(error_msg)
 
-    # Self-provision dispatch auth tokens (see deploy_up) before rebuilding.
-    _ensure_dispatch_tokens(config.get("deployed_services"), expose_network)
+    # Self-provision fail-closed service tokens (see deploy_up) before rebuilding.
+    _ensure_service_tokens(config, expose_network)
 
     # Clean first
     clean_deployment(compose_files, config)

--- a/src/osprey/mcp_server/python_executor/executor.py
+++ b/src/osprey/mcp_server/python_executor/executor.py
@@ -9,6 +9,7 @@ wrapper, limits_validator) as-is.
 
 import asyncio
 import logging
+import os
 import time
 import traceback
 import uuid
@@ -16,7 +17,15 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
+from osprey.mcp_server.sandbox_env import _scrub_sensitive_env
+
 logger = logging.getLogger("osprey.mcp_server.python_executor.executor")
+
+# _scrub_sensitive_env (and its deny-list constants) used to be defined here.
+# The implementation now lives in osprey.mcp_server.sandbox_env (imported
+# above) so this module and the workspace sandbox
+# (osprey.mcp_server.workspace.execution.sandbox_executor) share one deny-list
+# instead of two that could drift.
 
 
 @dataclass
@@ -200,6 +209,8 @@ async def _execute_via_local(
     # paths (e.g. "_agent_data/data/002_archiver_read.json")
     project_root = _resolve_project_root()
 
+    sandbox_env = _scrub_sensitive_env(os.environ.copy())
+
     try:
         proc = await asyncio.create_subprocess_exec(
             python_bin,
@@ -207,6 +218,7 @@ async def _execute_via_local(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=str(project_root),
+            env=sandbox_env,
         )
         stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=timeout)
         stdout_text = stdout_bytes.decode("utf-8", errors="replace")

--- a/src/osprey/mcp_server/python_executor/executor.py
+++ b/src/osprey/mcp_server/python_executor/executor.py
@@ -17,11 +17,11 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
-from osprey.mcp_server.sandbox_env import _scrub_sensitive_env
+from osprey.mcp_server.sandbox_env import scrub_sensitive_env
 
 logger = logging.getLogger("osprey.mcp_server.python_executor.executor")
 
-# _scrub_sensitive_env (and its deny-list constants) used to be defined here.
+# scrub_sensitive_env (and its deny-list constants) used to be defined here.
 # The implementation now lives in osprey.mcp_server.sandbox_env (imported
 # above) so this module and the workspace sandbox
 # (osprey.mcp_server.workspace.execution.sandbox_executor) share one deny-list
@@ -209,7 +209,7 @@ async def _execute_via_local(
     # paths (e.g. "_agent_data/data/002_archiver_read.json")
     project_root = _resolve_project_root()
 
-    sandbox_env = _scrub_sensitive_env(os.environ.copy())
+    sandbox_env = scrub_sensitive_env(os.environ.copy())
 
     try:
         proc = await asyncio.create_subprocess_exec(

--- a/src/osprey/mcp_server/sandbox_env.py
+++ b/src/osprey/mcp_server/sandbox_env.py
@@ -22,7 +22,7 @@ _SENSITIVE_ENV_EXACT: tuple[str, ...] = ("EVENT_DISPATCHER_TOKEN",)
 _SENSITIVE_ENV_SUFFIXES: tuple[str, ...] = ("_PROMOTE_TOKEN",)
 
 
-def _scrub_sensitive_env(env: dict[str, str]) -> dict[str, str]:
+def scrub_sensitive_env(env: dict[str, str]) -> dict[str, str]:
     """Return a copy of *env* with write-arming secrets removed.
 
     Drops any key in :data:`_SENSITIVE_ENV_EXACT` and any key ending in one of

--- a/src/osprey/mcp_server/sandbox_env.py
+++ b/src/osprey/mcp_server/sandbox_env.py
@@ -1,0 +1,38 @@
+"""Sensitive-environment scrub shared by every agent-code execution sandbox.
+
+Both ``python_executor.executor`` (the general-purpose Python execution
+sandbox) and ``workspace.execution.sandbox_executor`` (the lighter
+visualization-only sandbox) spawn a local subprocess to run agent-generated
+Python code. Both must exclude write-arming secrets from that subprocess's
+environment: agent-run code must never be able to read a token that gates a
+write-capable action from outside the sandbox (e.g. the Bluesky bridge's
+``/runs/{id}/promote`` endpoint, event-dispatch webhooks) and call the gated
+endpoint directly. The in-tool ``writes_enabled`` re-check inside
+``launch_scan`` is the actual write-safety authority — not possession of a
+token — so this scrub closes the read side of that attack surface.
+
+Centralized here (rather than duplicated per sandbox) so the two deny-lists
+cannot drift.
+"""
+
+# Exact names for known secrets that don't fit the suffix pattern below.
+_SENSITIVE_ENV_EXACT: tuple[str, ...] = ("EVENT_DISPATCHER_TOKEN",)
+# Suffix patterns so future write-arming tokens (e.g. a second bridge's
+# *_PROMOTE_TOKEN) are excluded without needing a code change here.
+_SENSITIVE_ENV_SUFFIXES: tuple[str, ...] = ("_PROMOTE_TOKEN",)
+
+
+def _scrub_sensitive_env(env: dict[str, str]) -> dict[str, str]:
+    """Return a copy of *env* with write-arming secrets removed.
+
+    Drops any key in :data:`_SENSITIVE_ENV_EXACT` and any key ending in one of
+    :data:`_SENSITIVE_ENV_SUFFIXES`. Used to build the environment passed to
+    an agent-code execution subprocess so the sandboxed code cannot read
+    these secrets, even though the parent process needs them for its own
+    MCP/server plumbing.
+    """
+    return {
+        key: value
+        for key, value in env.items()
+        if key not in _SENSITIVE_ENV_EXACT and not key.endswith(_SENSITIVE_ENV_SUFFIXES)
+    }

--- a/src/osprey/mcp_server/scan/__init__.py
+++ b/src/osprey/mcp_server/scan/__init__.py
@@ -1,0 +1,7 @@
+"""OSPREY Scan MCP Server — thin HTTP client for the facility Bluesky bridge.
+
+Translates agent tool calls into HTTP requests against the facility-side
+Bluesky bridge (a FastAPI service wrapping Bluesky's RunEngine, ophyd devices,
+and a Tiled data store). This package makes no bluesky/ophyd/tiled imports;
+see ``osprey.services.bluesky_bridge`` for the facility-side implementation.
+"""

--- a/src/osprey/mcp_server/scan/__main__.py
+++ b/src/osprey/mcp_server/scan/__main__.py
@@ -1,0 +1,11 @@
+"""Entry point for ``python -m osprey.mcp_server.scan``."""
+
+from osprey.mcp_server.startup import run_mcp_server
+
+
+def main() -> None:
+    run_mcp_server("osprey.mcp_server.scan.server")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/osprey/mcp_server/scan/server.py
+++ b/src/osprey/mcp_server/scan/server.py
@@ -1,0 +1,58 @@
+"""OSPREY Scan MCP Server.
+
+FastMCP server exposing Bluesky scan control as a thin HTTP client of the
+facility-side Bluesky bridge: list scan plans, create a scan intent, check run
+status, launch (promote) an intent to a running scan, and stop a run. This
+module and its tools make no bluesky/ophyd/tiled imports — every operation is
+an HTTP request to the bridge (see ``osprey.services.bluesky_bridge``).
+
+Usage:
+    python -m osprey.mcp_server.scan
+"""
+
+import logging
+
+from fastmcp import FastMCP
+
+logger = logging.getLogger("osprey.mcp_server.scan")
+
+mcp = FastMCP(
+    "scan",
+    instructions=(
+        "Drive Bluesky scans through the facility Bluesky bridge: list available "
+        "scan plans, create a scan intent (validated but not yet running), "
+        "check run status, launch (promote) an intent into a running scan, "
+        "and stop a running scan."
+    ),
+)
+
+
+def create_server() -> FastMCP:
+    """Initialize the Bluesky bridge context and register tools."""
+    from osprey.mcp_server.scan.server_context import initialize_server_context
+    from osprey.mcp_server.startup import (
+        initialize_workspace_singletons,
+        prime_config_builder,
+        startup_timer,
+    )
+    from osprey.utils.workspace import resolve_workspace_root
+
+    prime_config_builder()
+
+    with startup_timer("server_context"):
+        initialize_server_context()
+
+    workspace_root = resolve_workspace_root()
+    logger.info("Workspace root: %s", workspace_root)
+    initialize_workspace_singletons(workspace_root)
+
+    # Import tool modules (each registers itself via @mcp.tool())
+    with startup_timer("tool_imports"):
+        from osprey.mcp_server.scan.tools import (  # noqa: F401
+            launch,
+            read_tools,
+            stop,
+        )
+
+    logger.info("Scan MCP server initialised with all tools registered")
+    return mcp

--- a/src/osprey/mcp_server/scan/server_context.py
+++ b/src/osprey/mcp_server/scan/server_context.py
@@ -1,0 +1,212 @@
+"""Scan MCP Server Context — bridge connection resolution and HTTP boundary.
+
+Resolves the facility-side Bluesky bridge's base URL and promote token (env with
+config.yml fallback, mirroring
+``osprey.mcp_server.control_system.server_context``), and exposes the
+module-level HTTP primitives every scan tool module uses to talk to the
+bridge. Centralizing the primitives here means every tool gets identical
+``bluesky_bridge_unreachable`` handling without repeating a try/except around
+each HTTP call.
+
+Also home to the ``bridge_error_message`` / ``UNKNOWN_RUN_HINTS`` helpers
+shared by every tool module (``read_tools``, ``launch``, ``stop``) for
+translating a non-2xx bridge response into a ``make_error`` call, so all three
+render the same error envelope for the same bridge failure.
+
+Usage in tools:
+    from osprey.mcp_server.scan.server_context import _http_get_json, _http_post_json
+
+    status, body = _http_get_json("/runs")
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+
+from osprey.mcp_server.errors import make_error
+
+logger = logging.getLogger("osprey.mcp_server.scan.server_context")
+
+_DEFAULT_BRIDGE_URL = "http://127.0.0.1:8090"
+_TIMEOUT = 15.0  # seconds
+
+_UNREACHABLE_HINTS = [
+    "Confirm the facility Bluesky bridge process is running.",
+    "Check the BLUESKY_BRIDGE_URL env var or scan.bridge_url in config.yml.",
+]
+
+# Shared by every scan tool module (read_tools, launch, stop): the hint
+# attached to a 404 from the bridge's in-memory run registry.
+UNKNOWN_RUN_HINTS = [
+    "The bridge's run registry is in-memory only; a restart forgets prior runs.",
+    "List currently-tracked runs with list_runs.",
+]
+
+
+def bridge_error_message(body: object, status: int) -> str:
+    """Extract the bridge's FastAPI ``detail`` message, falling back to the status."""
+    if isinstance(body, dict) and body.get("detail"):
+        return str(body["detail"])
+    return f"Bluesky bridge returned HTTP {status}."
+
+
+# ---------------------------------------------------------------------------
+# ScanContext
+# ---------------------------------------------------------------------------
+class ScanContext:
+    """Resolved Bluesky bridge connection details for the current process."""
+
+    def __init__(self) -> None:
+        self.bridge_url: str = _DEFAULT_BRIDGE_URL
+        self.promote_token: str | None = None
+        self._initialized = False
+
+    def initialize(self) -> None:
+        """Resolve bridge_url and promote_token from env with config.yml fallback.
+
+        Called once during create_server(). Subsequent calls are no-ops.
+        """
+        if self._initialized:
+            return
+
+        self.bridge_url = self._resolve_bridge_url()
+        self.promote_token = self._resolve_promote_token()
+        self._initialized = True
+        logger.info(
+            "ScanContext: initialized (bridge_url=%s, promote_token_set=%s)",
+            self.bridge_url,
+            self.promote_token is not None,
+        )
+
+    @staticmethod
+    def _resolve_bridge_url() -> str:
+        """Resolve the Bluesky bridge base URL.
+
+        Resolution order:
+
+        1. ``BLUESKY_BRIDGE_URL`` env var (full URL) — set by the framework server
+           definition per bridge instance; wins outright.
+        2. ``scan.bridge_url`` in config.yml.
+        3. ``http://127.0.0.1:8090`` default.
+        """
+        full = os.environ.get("BLUESKY_BRIDGE_URL")
+        if full:
+            return full.rstrip("/")
+
+        from osprey.utils.workspace import load_osprey_config
+
+        config = load_osprey_config()
+        url = config.get("scan", {}).get("bridge_url", _DEFAULT_BRIDGE_URL)
+        return str(url).rstrip("/")
+
+    @staticmethod
+    def _resolve_promote_token() -> str | None:
+        """Resolve the Bluesky bridge promote token.
+
+        Resolution order:
+
+        1. ``BLUESKY_PROMOTE_TOKEN`` env var — minted fail-closed per bridge
+           instance by the framework server definition; wins outright.
+        2. ``scan.promote_token`` in config.yml (local/dev convenience only).
+        3. ``None`` — ``launch_scan`` refuses client-side when unset.
+        """
+        token = os.environ.get("BLUESKY_PROMOTE_TOKEN")
+        if token:
+            return token
+
+        from osprey.utils.workspace import load_osprey_config
+
+        config = load_osprey_config()
+        token = config.get("scan", {}).get("promote_token")
+        return str(token) if token else None
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton (mirrors osprey.mcp_server.control_system.server_context)
+# ---------------------------------------------------------------------------
+
+_context: ScanContext | None = None
+
+
+def get_server_context() -> ScanContext:
+    """Get the ScanContext singleton.
+
+    Raises RuntimeError if initialize_server_context() hasn't been called.
+    """
+    if _context is None:
+        raise RuntimeError(
+            "Scan server context not initialized. Call initialize_server_context() first."
+        )
+    return _context
+
+
+def initialize_server_context() -> ScanContext:
+    """Create and initialize the ScanContext singleton."""
+    global _context
+    _context = ScanContext()
+    _context.initialize()
+    return _context
+
+
+def reset_server_context() -> None:
+    """Reset the ScanContext singleton (for testing)."""
+    global _context
+    _context = None
+
+
+# ---------------------------------------------------------------------------
+# HTTP boundary (patched in tests)
+# ---------------------------------------------------------------------------
+def _http_get_json(path: str) -> tuple[int, dict | list]:
+    """GET ``path`` on the Bluesky bridge and return ``(status, parsed_json)``.
+
+    Raises ``ToolError`` via ``make_error("bluesky_bridge_unreachable", ...)`` when
+    the bridge cannot be reached at all, so every tool gets identical
+    unreachable-bridge handling. HTTP error responses (4xx/5xx) are returned
+    to the caller as ``(status, parsed_body)`` so tools can render the
+    bridge's own error semantics (404/409/403/503).
+    """
+    url = f"{get_server_context().bridge_url}{path}"
+    try:
+        resp = httpx.get(url, timeout=_TIMEOUT)
+    except httpx.HTTPError as exc:
+        make_error(
+            "bluesky_bridge_unreachable",
+            f"Could not reach the Bluesky bridge: {exc}",
+            _UNREACHABLE_HINTS,
+        )
+
+    body: dict | list = {}
+    try:
+        body = resp.json()
+    except Exception:
+        pass
+    return resp.status_code, body
+
+
+def _http_post_json(
+    path: str, payload: dict, *, headers: dict[str, str] | None = None
+) -> tuple[int, dict]:
+    """POST ``payload`` as JSON to ``path`` on the Bluesky bridge.
+
+    Same unreachable-bridge/error-body contract as :func:`_http_get_json`.
+    """
+    url = f"{get_server_context().bridge_url}{path}"
+    try:
+        resp = httpx.post(url, json=payload, headers=headers, timeout=_TIMEOUT)
+    except httpx.HTTPError as exc:
+        make_error(
+            "bluesky_bridge_unreachable",
+            f"Could not reach the Bluesky bridge: {exc}",
+            _UNREACHABLE_HINTS,
+        )
+
+    body: dict = {}
+    try:
+        body = resp.json()
+    except Exception:
+        pass
+    return resp.status_code, body

--- a/src/osprey/mcp_server/scan/tools/__init__.py
+++ b/src/osprey/mcp_server/scan/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Scan MCP tool modules."""

--- a/src/osprey/mcp_server/scan/tools/launch.py
+++ b/src/osprey/mcp_server/scan/tools/launch.py
@@ -1,0 +1,122 @@
+"""MCP tool: launch_scan — the sole promote path from a scan intent to a running scan.
+
+Two safety layers gate this tool, both enforced BEFORE any HTTP call is made:
+
+1. In-tool ``control_system.writes_enabled`` re-check (this module) — the
+   authoritative layer. It mirrors ``ControlSystemConnector._writes_enabled``
+   (``osprey/connectors/control_system/base.py:100-143``) exactly: same
+   config key, same fail-closed except clause. Re-read fresh on every call
+   (never cached), so a hook-bypassed invocation — even one carrying a valid
+   ``BLUESKY_PROMOTE_TOKEN`` — is still refused whenever writes are disabled.
+2. Client-side promote-token presence check — refuses locally, with no
+   network call, if this MCP server process was never armed with a token.
+
+Only once both pass does this POST ``/runs/{id}/promote`` with the
+``X-Promote-Token`` header. The bridge's own ``security.verify_promote_token``
+(server-side, see ``bluesky_bridge/security.py``) is defense-in-depth against a
+caller that skips this tool entirely — it is not the primary guard.
+"""
+
+from __future__ import annotations
+
+import json
+
+import anyio
+
+from osprey.mcp_server.errors import make_error
+from osprey.mcp_server.scan.server import mcp
+from osprey.mcp_server.scan.server_context import (
+    UNKNOWN_RUN_HINTS,
+    _http_post_json,
+    bridge_error_message,
+    get_server_context,
+)
+
+
+def _writes_enabled() -> bool:
+    """Fail-closed re-read of ``control_system.writes_enabled`` straight from config.
+
+    Mirrors ``ControlSystemConnector._writes_enabled`` (same config key, same
+    fail-closed except clause) so the scan write gate agrees with every other
+    OSPREY write path on one on/off switch. Deliberately NOT cached on the
+    ScanContext singleton — the whole point is a fresh read on every call.
+    """
+    try:
+        from osprey.utils.config import get_config_value
+
+        return bool(get_config_value("control_system.writes_enabled", False))
+    except (FileNotFoundError, RuntimeError):
+        return False
+
+
+@mcp.tool()
+async def launch_scan(run_id: str) -> str:
+    """Promote a scan intent into a running scan. The sole write path in this server.
+
+    Two safety layers must pass before any network call is made: this
+    deployment's control_system.writes_enabled must re-read true (checked
+    fresh on every call, never cached, so a hook-bypassed invocation is still
+    refused when writes are disabled), and this MCP server must have been
+    armed with a promote token (BLUESKY_PROMOTE_TOKEN). Only then is
+    POST /runs/{run_id}/promote sent to the bridge with the X-Promote-Token
+    header.
+
+    Args:
+        run_id: Run id returned by create_scan_intent or list_runs. Must
+            currently be in "intent" status.
+
+    Returns:
+        JSON run record with status "running" on success.
+    """
+    if not _writes_enabled():
+        return make_error(
+            "writes_disabled",
+            "Control-system writes are disabled in this deployment "
+            "(control_system.writes_enabled=false in config.yml). launch_scan refused.",
+            ["Set control_system.writes_enabled: true in config.yml to enable launch_scan."],
+        )
+
+    token = get_server_context().promote_token
+    if not token:
+        return make_error(
+            "scan_promote_unarmed",
+            "This scan MCP server has no BLUESKY_PROMOTE_TOKEN configured — "
+            "launch_scan is refused client-side before contacting the bridge.",
+            [
+                "Set BLUESKY_PROMOTE_TOKEN (or scan.promote_token in config.yml) "
+                "for this bridge instance."
+            ],
+        )
+
+    # anyio's run_sync only forwards positional args, and `headers` is
+    # keyword-only on `_http_post_json`, hence the lambda.
+    status, body = await anyio.to_thread.run_sync(
+        lambda: _http_post_json(f"/runs/{run_id}/promote", {}, headers={"X-Promote-Token": token})
+    )
+    if status == 404:
+        return make_error("unknown_run", bridge_error_message(body, status), UNKNOWN_RUN_HINTS)
+    if status == 403:
+        return make_error(
+            "scan_promote_forbidden",
+            "The Bluesky bridge rejected the promote token.",
+            [
+                "Confirm BLUESKY_PROMOTE_TOKEN matches the bridge's configured token for this instance."
+            ],
+        )
+    if status == 409:
+        return make_error(
+            "scan_promote_conflict",
+            bridge_error_message(body, status),
+            ["Check scan_status — the run may already be promoted, stopped, or mid-promotion."],
+        )
+    if status == 503:
+        return make_error(
+            "scan_promote_unarmed",
+            bridge_error_message(body, status),
+            [
+                "The bridge itself has no BLUESKY_PROMOTE_TOKEN configured; contact the deployment operator."
+            ],
+        )
+    if status != 200:
+        return make_error("bluesky_bridge_error", bridge_error_message(body, status))
+    return json.dumps(body)

--- a/src/osprey/mcp_server/scan/tools/read_tools.py
+++ b/src/osprey/mcp_server/scan/tools/read_tools.py
@@ -1,0 +1,180 @@
+"""MCP tools: read/allow-listed Bluesky bridge operations.
+
+Each tool is a thin HTTP client of one endpoint of the facility-side scan
+bridge. All five are safe to call without operator approval
+(``permissions_allow``) — none of them can start motion; ``launch_scan``
+(Task 1.8) is the sole promote path.
+
+==========================  =================================================
+Tool                        Bridge endpoint
+==========================  =================================================
+create_scan_intent          POST /runs
+scan_status                 GET  /runs/{id}
+list_scan_plans             GET  /plans
+list_runs                   GET  /runs
+read_scan_data              GET  /runs/{id}/data
+==========================  =================================================
+
+The HTTP primitives (``_http_get_json`` / ``_http_post_json``) and the
+``bridge_error_message`` / ``UNKNOWN_RUN_HINTS`` error-envelope helpers live in
+``osprey.mcp_server.scan.server_context`` so tests can patch the network
+boundary and every scan tool renders identical error shapes. A
+connection-level failure there already raises the standard
+``bluesky_bridge_unreachable`` error envelope, so the tools below only need to
+translate non-2xx bridge responses (404/409/etc.) into ``make_error`` calls.
+"""
+
+import json
+
+import anyio
+
+from osprey.mcp_server.errors import make_error
+from osprey.mcp_server.scan.server import mcp
+from osprey.mcp_server.scan.server_context import (
+    UNKNOWN_RUN_HINTS,
+    _http_get_json,
+    _http_post_json,
+    bridge_error_message,
+)
+
+
+# ---------------------------------------------------------------------------
+# Tool 1: create scan intent
+# ---------------------------------------------------------------------------
+@mcp.tool()
+async def create_scan_intent(plan_name: str, plan_args: dict | None = None) -> str:
+    """Record a scan intent on the bridge — validated but NOT started.
+
+    Motion-safe: creating an intent never touches a device or starts the
+    RunEngine. It records a request the operator or agent can inspect via
+    scan_status before deciding whether to call launch_scan — the sole
+    promote path, which requires both an armed bridge token and
+    ``control_system.writes_enabled``.
+
+    Args:
+        plan_name: Name of a plan registered on the bridge (e.g. "scan",
+            "count", "grid_scan" for the v1 bluesky built-ins — see
+            list_scan_plans for what this bridge actually supports).
+        plan_args: Plan parameters as a JSON-serializable dict (device
+            names, points, exposure time, etc.); shape is plan-specific and
+            validated by the bridge. Defaults to an empty dict.
+
+    Returns:
+        JSON run record, e.g. ``{"id": <run_id>, "status": "intent"}``.
+    """
+    payload = {"plan_name": plan_name, "plan_args": plan_args or {}}
+    status, body = await anyio.to_thread.run_sync(_http_post_json, "/runs", payload)
+    if status not in (200, 201):
+        return make_error(
+            "scan_intent_rejected",
+            bridge_error_message(body, status),
+            [
+                "Check plan_name is registered on the bridge (see list_scan_plans).",
+                "Check plan_args matches that plan's parameter schema.",
+            ],
+        )
+    return json.dumps(body)
+
+
+# ---------------------------------------------------------------------------
+# Tool 2: scan status
+# ---------------------------------------------------------------------------
+@mcp.tool()
+async def scan_status(run_id: str) -> str:
+    """Get one run's current lifecycle status.
+
+    Args:
+        run_id: Run id returned by create_scan_intent or list_runs.
+
+    Returns:
+        JSON run record: ``{"id", "status", ["completion"], ["launched_by"],
+        ["run_uid"], ["error"]}``. ``status`` is one of "intent", "running",
+        "completed", "stopped", "error".
+    """
+    status, body = await anyio.to_thread.run_sync(_http_get_json, f"/runs/{run_id}")
+    if status == 404:
+        return make_error("unknown_run", bridge_error_message(body, status), UNKNOWN_RUN_HINTS)
+    if status != 200:
+        return make_error("bluesky_bridge_error", bridge_error_message(body, status))
+    return json.dumps(body)
+
+
+# ---------------------------------------------------------------------------
+# Tool 3: list scan plans
+# ---------------------------------------------------------------------------
+@mcp.tool()
+async def list_scan_plans() -> str:
+    """List the plans registered on the bridge.
+
+    Returns:
+        JSON ``{"status": "success", "plans": [...]}``. An empty list means
+        the facility has not injected a plan module (or this bridge version
+        does not yet support plan discovery).
+    """
+    status, body = await anyio.to_thread.run_sync(_http_get_json, "/plans")
+    if status != 200:
+        return make_error("bluesky_bridge_error", bridge_error_message(body, status))
+    return json.dumps({"status": "success", "plans": body})
+
+
+# ---------------------------------------------------------------------------
+# Tool 4: list runs
+# ---------------------------------------------------------------------------
+@mcp.tool()
+async def list_runs(limit: int = 20) -> str:
+    """List this bridge process's tracked runs, newest first.
+
+    Args:
+        limit: Maximum number of runs to return (the bridge clamps this to
+            the range [1, 100]).
+
+    Returns:
+        JSON ``{"status": "success", "runs": [...]}`` — each entry has the
+        same shape as scan_status's response.
+    """
+    status, body = await anyio.to_thread.run_sync(_http_get_json, f"/runs?limit={limit}")
+    if status != 200:
+        return make_error("bluesky_bridge_error", bridge_error_message(body, status))
+    return json.dumps({"status": "success", "runs": body})
+
+
+# ---------------------------------------------------------------------------
+# Tool 5: read scan data (bounded; stub until full Tiled-backed bounding lands)
+# ---------------------------------------------------------------------------
+@mcp.tool()
+async def read_scan_data(
+    run_id: str, max_rows: int = 100, offset: int | None = None, tail: bool = False
+) -> str:
+    """Read a bounded window of a run's data.
+
+    Row-bounded by design: this never returns an unbounded table. This tool
+    targets the bridge's ``GET /runs/{id}/data`` endpoint, which is not yet
+    implemented — the live-row buffer and the route itself land in a later
+    phase. Until then, calls return a ``bluesky_bridge_error`` from the bridge
+    rather than any data.
+
+    Args:
+        run_id: Run id returned by create_scan_intent or list_runs.
+        max_rows: Maximum number of rows to return (bridge-enforced cap).
+        offset: Row offset to start from (``None`` = start from the
+            beginning, or from the end if ``tail`` is true).
+        tail: When true, return the most recent ``max_rows`` rows instead of
+            the earliest ``max_rows`` rows.
+
+    Returns:
+        JSON ``{"run_uid", "columns", "rows", "row_count", "truncated"[,
+        "partial"]}``. ``partial: true`` means the run is still in progress
+        and more rows will arrive; an empty run returns
+        ``{"columns": [], "rows": []}``.
+    """
+    params = f"max_rows={max_rows}"
+    if offset is not None:
+        params += f"&offset={offset}"
+    if tail:
+        params += "&tail=true"
+    status, body = await anyio.to_thread.run_sync(_http_get_json, f"/runs/{run_id}/data?{params}")
+    if status == 404:
+        return make_error("unknown_run", bridge_error_message(body, status), UNKNOWN_RUN_HINTS)
+    if status != 200:
+        return make_error("bluesky_bridge_error", bridge_error_message(body, status))
+    return json.dumps(body)

--- a/src/osprey/mcp_server/scan/tools/read_tools.py
+++ b/src/osprey/mcp_server/scan/tools/read_tools.py
@@ -139,7 +139,7 @@ async def list_runs(limit: int = 20) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Tool 5: read scan data (bounded; stub until full Tiled-backed bounding lands)
+# Tool 5: read scan data (bounded)
 # ---------------------------------------------------------------------------
 @mcp.tool()
 async def read_scan_data(
@@ -147,11 +147,10 @@ async def read_scan_data(
 ) -> str:
     """Read a bounded window of a run's data.
 
-    Row-bounded by design: this never returns an unbounded table. This tool
-    targets the bridge's ``GET /runs/{id}/data`` endpoint, which is not yet
-    implemented — the live-row buffer and the route itself land in a later
-    phase. Until then, calls return a ``bluesky_bridge_error`` from the bridge
-    rather than any data.
+    Row-bounded by design: this never returns an unbounded table. Backed by
+    the bridge's in-process live-row buffer (``GET /runs/{id}/data``), so
+    reads work with no Tiled server — ``row_count``/``truncated`` describe
+    the run's *true* total vs. what this window actually returned.
 
     Args:
         run_id: Run id returned by create_scan_intent or list_runs.
@@ -164,7 +163,7 @@ async def read_scan_data(
     Returns:
         JSON ``{"run_uid", "columns", "rows", "row_count", "truncated"[,
         "partial"]}``. ``partial: true`` means the run is still in progress
-        and more rows will arrive; an empty run returns
+        and more rows will arrive; an empty/never-started buffer returns
         ``{"columns": [], "rows": []}``.
     """
     params = f"max_rows={max_rows}"
@@ -175,6 +174,15 @@ async def read_scan_data(
     status, body = await anyio.to_thread.run_sync(_http_get_json, f"/runs/{run_id}/data?{params}")
     if status == 404:
         return make_error("unknown_run", bridge_error_message(body, status), UNKNOWN_RUN_HINTS)
+    if status == 409:
+        return make_error(
+            "scan_data_not_ready",
+            bridge_error_message(body, status),
+            [
+                "The run has not started yet, so there is no run_uid to read data for.",
+                "Check scan_status; data becomes readable once the run is promoted and running.",
+            ],
+        )
     if status != 200:
         return make_error("bluesky_bridge_error", bridge_error_message(body, status))
     return json.dumps(body)

--- a/src/osprey/mcp_server/scan/tools/stop.py
+++ b/src/osprey/mcp_server/scan/tools/stop.py
@@ -1,0 +1,52 @@
+"""MCP tool: stop_scan — abort a running scan.
+
+Stopping is the safe direction: unlike launch_scan, this tool carries no
+writes_enabled gate and no promote token. The bridge's ``POST /runs/{id}/stop``
+route is not token-gated either (see ``bluesky_bridge/app.py``) — halting is
+always allowed, including on an intent that was never promoted. This tool is
+still approval-gated (``permissions_ask``, see the ``scan`` ServerDefinition
+in task 1.10) so a human sees every stop, but the kill switch (writes-disabled
+deny loop) must never block it.
+"""
+
+from __future__ import annotations
+
+import json
+
+import anyio
+
+from osprey.mcp_server.errors import make_error
+from osprey.mcp_server.scan.server import mcp
+from osprey.mcp_server.scan.server_context import (
+    UNKNOWN_RUN_HINTS,
+    _http_post_json,
+    bridge_error_message,
+)
+
+
+@mcp.tool()
+async def stop_scan(run_id: str) -> str:
+    """Abort a running scan (or mark an unpromoted intent stopped).
+
+    Not gated by control_system.writes_enabled — halting a scan is the safe
+    direction and must always be reachable, kill switch or not. Still
+    approval-gated so a human sees every stop request.
+
+    Args:
+        run_id: Run id returned by create_scan_intent or list_runs.
+
+    Returns:
+        JSON run record with status "stopped" on success.
+    """
+    status, body = await anyio.to_thread.run_sync(_http_post_json, f"/runs/{run_id}/stop", {})
+    if status == 404:
+        return make_error("unknown_run", bridge_error_message(body, status), UNKNOWN_RUN_HINTS)
+    if status == 409:
+        return make_error(
+            "scan_stop_conflict",
+            bridge_error_message(body, status),
+            ["Check scan_status for the run's current state."],
+        )
+    if status != 200:
+        return make_error("bluesky_bridge_error", bridge_error_message(body, status))
+    return json.dumps(body)

--- a/src/osprey/mcp_server/workspace/execution/sandbox_executor.py
+++ b/src/osprey/mcp_server/workspace/execution/sandbox_executor.py
@@ -30,11 +30,11 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
-from osprey.mcp_server.sandbox_env import _scrub_sensitive_env
+from osprey.mcp_server.sandbox_env import scrub_sensitive_env
 
 logger = logging.getLogger("osprey.mcp_server.workspace.execution.sandbox_executor")
 
-# _scrub_sensitive_env's deny-list lives in osprey.mcp_server.sandbox_env
+# scrub_sensitive_env's deny-list lives in osprey.mcp_server.sandbox_env
 # (imported above), shared with python_executor/executor.py's identical
 # local-subprocess seam so the two sandboxes cannot drift.
 
@@ -643,7 +643,7 @@ async def execute_sandbox_code(
     script_path.write_text(wrapped_code, encoding="utf-8")
 
     start_time = time.time()
-    sandbox_env = _scrub_sensitive_env(os.environ.copy())
+    sandbox_env = scrub_sensitive_env(os.environ.copy())
 
     try:
         proc = await asyncio.create_subprocess_exec(

--- a/src/osprey/mcp_server/workspace/execution/sandbox_executor.py
+++ b/src/osprey/mcp_server/workspace/execution/sandbox_executor.py
@@ -22,6 +22,7 @@ import ast
 import asyncio
 import json
 import logging
+import os
 import sys
 import time
 import uuid
@@ -29,7 +30,13 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
+from osprey.mcp_server.sandbox_env import _scrub_sensitive_env
+
 logger = logging.getLogger("osprey.mcp_server.workspace.execution.sandbox_executor")
+
+# _scrub_sensitive_env's deny-list lives in osprey.mcp_server.sandbox_env
+# (imported above), shared with python_executor/executor.py's identical
+# local-subprocess seam so the two sandboxes cannot drift.
 
 
 # ---------------------------------------------------------------------------
@@ -636,6 +643,7 @@ async def execute_sandbox_code(
     script_path.write_text(wrapped_code, encoding="utf-8")
 
     start_time = time.time()
+    sandbox_env = _scrub_sensitive_env(os.environ.copy())
 
     try:
         proc = await asyncio.create_subprocess_exec(
@@ -644,6 +652,7 @@ async def execute_sandbox_code(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=str(project_root),
+            env=sandbox_env,
         )
         stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=timeout)
         stdout_text = stdout_bytes.decode("utf-8", errors="replace")

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -285,6 +285,41 @@ FRAMEWORK_SERVERS: dict[str, ServerDefinition] = {
         ],
         hooks_post=[_post_error("mcp__osprey_facility_knowledge__.*")],
     ),
+    "scan": ServerDefinition(
+        name="scan",
+        module="osprey.mcp_server.scan",
+        # Off by default: only profiles that opt in (claude_code.servers.scan.enabled
+        # = true) get the Bluesky bridge client tools — running them requires a live
+        # facility-side Bluesky bridge process (mirrors phoebus's opt-in reasoning).
+        default_enabled=False,
+        env={
+            "OSPREY_CONFIG": "{project_root}/config.yml",
+            "CONFIG_FILE": "{project_root}/config.yml",
+            "BLUESKY_BRIDGE_URL": "${BLUESKY_BRIDGE_URL:-http://127.0.0.1:8090}",
+            "BLUESKY_PROMOTE_TOKEN": "${BLUESKY_PROMOTE_TOKEN:-}",
+        },
+        permissions_allow=[
+            "create_scan_intent",
+            "scan_status",
+            "list_scan_plans",
+            "list_runs",
+            "read_scan_data",
+        ],
+        # launch_scan starts a real scan (promote); stop_scan is the safe direction
+        # and must never be kill-switch-blocked, so it carries approval only.
+        permissions_ask=["launch_scan", "stop_scan"],
+        hooks_pre=[
+            HookRule(
+                matcher="mcp__scan__launch_scan",
+                hooks=[_WRITES_CHECK, _APPROVAL],
+            ),
+            HookRule(
+                matcher="mcp__scan__stop_scan",
+                hooks=[_APPROVAL],
+            ),
+        ],
+        hooks_post=[_post_error("mcp__scan__.*")],
+    ),
     "channel-finder": ServerDefinition(
         name="channel-finder",
         module="osprey.mcp_server.channel_finder_{channel_finder_pipeline}",

--- a/src/osprey/services/bluesky_bridge/__init__.py
+++ b/src/osprey/services/bluesky_bridge/__init__.py
@@ -1,0 +1,6 @@
+"""Bluesky bridge: a FastAPI service owning the Bluesky RunEngine + ophyd-async devices.
+
+Runs in a separate container from OSPREY's own venv; the ``scan`` MCP server
+talks to it over HTTP. See ``docs/source/how-to/scan-plans.rst`` (Phase 3) for
+the full architecture.
+"""

--- a/src/osprey/services/bluesky_bridge/app.py
+++ b/src/osprey/services/bluesky_bridge/app.py
@@ -7,23 +7,52 @@ HTTP plus the ``X-Promote-Token`` header. It stays import-clean of bluesky/
 ophyd/tiled in Phase 1 — ``_scanner_factory`` defaults to the no-op
 ``FakeScanner`` so this app is runnable and manually smoke-testable
 (``GET /health``, even a real ``promote``) before the bluesky-backed
-``Scanner`` (Phase 2) exists. Phase 2's wiring swaps the factory via
-``set_scanner_factory`` once that implementation lands.
+``Scanner`` exists. Real wiring swaps the factory via ``set_scanner_factory``:
+either a facility deploy (real EPICS devices, Phase 3) or, for the built-in
+deploy smoke demo, this module's own opt-in ``_lifespan`` hook — see below.
 """
 
 from __future__ import annotations
 
+import logging
+import os
 from collections.abc import Callable
-from typing import Any
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
 
-from fastapi import FastAPI, Header
+from fastapi import FastAPI, Header, HTTPException
 from pydantic import BaseModel, Field
 
+from . import live_rows
 from .runs import do_promote, registry
 from .scanner import FakeScanner, Scanner
 from .security import verify_promote_token
 
-app = FastAPI(title="OSPREY Bluesky Bridge")
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+logger = logging.getLogger("osprey.services.bluesky_bridge.app")
+
+# Root package names `plans.py`'s `from .plans import BUILTIN_PLANS` (and the
+# demo-scanner lifespan hook below) are allowed to fail on — i.e. the bridge
+# running without the `bluesky-bridge` extra installed. An ImportError naming
+# anything else (e.g. a module missing an expected attribute, or an unrelated
+# third-party import broke) is a genuine bug and must not be swallowed as
+# "bluesky is just absent".
+_BRIDGE_ONLY_MODULES = {"bluesky", "ophyd", "ophyd_async", "tiled"}
+
+# Opt-in flag (task 2.14a): when truthy (see `_is_demo_scanner_enabled`) AND
+# bluesky/ophyd-async are importable, `_lifespan` wires a real bluesky-backed
+# `BlueskyScanner` against mock devices — the deploy smoke demo's Scanner
+# (PLAN.md), never a facility's real-hardware wiring. The deploy template
+# only renders this var at all when the demo scanner is wanted (house
+# convention, matching `container_lifecycle.py`'s `DEV_MODE="true"`), so
+# "absent" is the off state — but the check itself accepts a few equivalent
+# truthy spellings rather than one exact string, so neither half of this
+# seam (this hook vs. whatever template/generator sets the var) can drift
+# out of sync with the other again.
+_DEMO_SCANNER_ENV = "BLUESKY_DEMO_SCANNER"
+_TRUTHY_VALUES = {"1", "true", "yes", "on"}
 
 # The `Scanner` implementation `do_promote` builds for every promotion.
 _scanner_factory: Callable[[], Scanner] = FakeScanner
@@ -32,20 +61,77 @@ _scanner_factory: Callable[[], Scanner] = FakeScanner
 def set_scanner_factory(factory: Callable[[], Scanner]) -> None:
     """Override the `Scanner` implementation `do_promote` builds.
 
-    The Phase 2 real bluesky-backed factory (and tests) call this instead of
-    reaching into the private module global directly.
+    A real bluesky-backed factory (`_lifespan` below, or a facility's own
+    deploy wiring) calls this instead of reaching into the private module
+    global directly.
     """
     global _scanner_factory
     _scanner_factory = factory
 
 
+def _is_demo_scanner_enabled() -> bool:
+    """True if `BLUESKY_DEMO_SCANNER` is set to any of `_TRUTHY_VALUES` (case/whitespace-insensitive).
+
+    Absent, empty, or any other value (e.g. "false") is off — deliberately
+    liberal on the "on" spellings, but never guesses at "on" from an
+    unrecognized value.
+    """
+    return os.environ.get(_DEMO_SCANNER_ENV, "").strip().lower() in _TRUTHY_VALUES
+
+
+@asynccontextmanager
+async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    """Opt-in guarded startup: wire the mock-devices demo `BlueskyScanner`.
+
+    Only when `_is_demo_scanner_enabled()` AND bluesky/ophyd-async are
+    importable — mirrors ``list_plans``'s guarded/lazy-import pattern so the
+    Phase-1 "app.py import-clean of bluesky" invariant holds whether the
+    extra is absent or the flag is unset (both leave ``_scanner_factory`` at
+    its ``FakeScanner`` default, unchanged). This powers the deploy smoke
+    demo only (mock ophyd-async devices, no real hardware, write-safety
+    guards untouched) — a facility wiring real EPICS devices (Phase 3) sets
+    its own scanner factory and does not go through this flag at all.
+    """
+    if _is_demo_scanner_enabled():
+        try:
+            from .devices.mock import build_devices
+            from .scanner_bluesky import BlueskyScanner
+        except ImportError as exc:
+            root_name = (getattr(exc, "name", None) or "").split(".")[0]
+            if root_name not in _BRIDGE_ONLY_MODULES:
+                raise
+            logger.warning(
+                "%s is enabled but the bluesky-bridge extra is not installed "
+                "(%s not found); falling back to FakeScanner",
+                _DEMO_SCANNER_ENV,
+                exc.name,
+            )
+        else:
+
+            def _demo_scanner_factory() -> BlueskyScanner:
+                # `build_devices` is `async def` (it connects ophyd-async
+                # devices) — `BlueskyScanner._resolve_devices` bridges that
+                # for us; passing the bare callable here, not its result.
+                return BlueskyScanner(devices=lambda: build_devices())
+
+            set_scanner_factory(_demo_scanner_factory)
+            logger.info(
+                "%s is enabled: wired the mock-devices demo BlueskyScanner (deploy smoke demo)",
+                _DEMO_SCANNER_ENV,
+            )
+    yield
+
+
+app = FastAPI(title="OSPREY Bluesky Bridge", lifespan=_lifespan)
+
+
 class RunRequest(BaseModel):
     """A scan launch intent (`POST /runs`).
 
-    Phase 1 has no plan registry yet (`plans.py` arrives in task 2.3), so this
-    is intentionally generic: `plan_name` names a plan the eventual registry
-    will resolve, and `plan_args` is forwarded to the scanner unmodified via
-    `do_promote` -> `Scanner.reinitialize(run.request)`.
+    Intentionally generic: `plan_name` names a plan the registry (`plans.py`,
+    plus any facility-injected plans from `plan_loader.py`) resolves, and
+    `plan_args` is forwarded to the scanner unmodified via `do_promote` ->
+    `Scanner.reinitialize(run.request)`.
     """
 
     plan_name: str
@@ -114,5 +200,85 @@ def stop_run(run_id: str) -> dict:
 
 @app.get("/plans")
 def list_plans() -> list:
-    """Registered scan plans. Stub returning `[]` until task 2.3's plan registry lands."""
-    return []
+    """Registered scan plans: built-ins merged with any facility-injected plans.
+
+    A facility plan overrides a built-in of the same name. `plans.py` (the
+    built-in set) imports bluesky, so it's a guarded/lazy import — this route
+    degrades to facility-only (or `[]`) rather than 500ing when bluesky isn't
+    installed. `plan_loader.py` (facility injection, task 2.4) is import-clean
+    of bluesky, so facility-injected plans are always served regardless — see
+    that module for how the plan module path is resolved.
+    """
+    from .plan_loader import get_facility_plans
+
+    merged: dict[str, Any] = {}
+    try:
+        from .plans import BUILTIN_PLANS
+
+        merged.update(BUILTIN_PLANS)
+    except ImportError as exc:
+        root_name = (getattr(exc, "name", None) or "").split(".")[0]
+        if root_name not in _BRIDGE_ONLY_MODULES:
+            raise
+        logger.info(
+            "GET /plans: built-in plan set unavailable (%s not installed); "
+            "serving facility-injected plans only",
+            exc.name,
+        )
+    merged.update(get_facility_plans().plans)
+
+    return [spec.to_dict() for spec in merged.values()]
+
+
+@app.get("/runs/{run_id}/data")
+def read_run_data(
+    run_id: str, max_rows: int = 100, offset: int | None = None, tail: bool = False
+) -> dict:
+    """Read a bounded window of a run's recorded data (see `live_rows.py`).
+
+    Row-bounded by design — this never returns an unbounded table. Serves
+    from the in-process live-row buffer, so reads work with no Tiled server:
+    ``partial: true`` while the run is still filling in (before its stop doc
+    lands), permanently readable once it's marked completed (see
+    `live_rows.py`'s retention bound). ``row_count`` is the *true* total rows
+    the run has produced so far, even if that's more than what's physically
+    stored — ``truncated`` reflects whether this response's window omits any
+    of them.
+
+    Raises 409 if the run has no `run_uid` yet (never promoted, or promoted
+    but the scan hasn't emitted a start doc) — there is nothing to read.
+    """
+    run = registry.get(run_id)
+    run_uid = run.run_uid
+    if run_uid is None:
+        raise HTTPException(status_code=409, detail=f"run {run_id!r} has not started; no data yet")
+
+    buf = live_rows.get(run_uid)
+    if buf is None:
+        return {"columns": [], "rows": []}
+
+    rows = buf["rows"]
+    stored_count = len(rows)
+    max_rows = max(0, max_rows)
+    skip = max(0, offset) if offset is not None else 0
+
+    if tail:
+        end = max(0, stored_count - skip)
+        start = max(0, end - max_rows)
+    else:
+        start = skip
+        end = start + max_rows
+    window = rows[start:end]
+
+    truncated = start > 0 or end < stored_count or buf["total_seen"] > stored_count
+
+    result: dict[str, Any] = {
+        "run_uid": run_uid,
+        "columns": list(buf["columns"]),
+        "rows": window,
+        "row_count": buf["total_seen"],
+        "truncated": truncated,
+    }
+    if buf["partial"]:
+        result["partial"] = True
+    return result

--- a/src/osprey/services/bluesky_bridge/app.py
+++ b/src/osprey/services/bluesky_bridge/app.py
@@ -1,0 +1,118 @@
+"""The Bluesky bridge's FastAPI app: wires the run registry, promote gate, and
+scanner seam (``runs.py``, ``security.py``, ``scanner.py``) into HTTP routes.
+
+Two processes, one machine (see PLAN.md's Technical Architecture): this app
+runs in a separate container from OSPREY's own venv, reachable only over
+HTTP plus the ``X-Promote-Token`` header. It stays import-clean of bluesky/
+ophyd/tiled in Phase 1 — ``_scanner_factory`` defaults to the no-op
+``FakeScanner`` so this app is runnable and manually smoke-testable
+(``GET /health``, even a real ``promote``) before the bluesky-backed
+``Scanner`` (Phase 2) exists. Phase 2's wiring swaps the factory via
+``set_scanner_factory`` once that implementation lands.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from fastapi import FastAPI, Header
+from pydantic import BaseModel, Field
+
+from .runs import do_promote, registry
+from .scanner import FakeScanner, Scanner
+from .security import verify_promote_token
+
+app = FastAPI(title="OSPREY Bluesky Bridge")
+
+# The `Scanner` implementation `do_promote` builds for every promotion.
+_scanner_factory: Callable[[], Scanner] = FakeScanner
+
+
+def set_scanner_factory(factory: Callable[[], Scanner]) -> None:
+    """Override the `Scanner` implementation `do_promote` builds.
+
+    The Phase 2 real bluesky-backed factory (and tests) call this instead of
+    reaching into the private module global directly.
+    """
+    global _scanner_factory
+    _scanner_factory = factory
+
+
+class RunRequest(BaseModel):
+    """A scan launch intent (`POST /runs`).
+
+    Phase 1 has no plan registry yet (`plans.py` arrives in task 2.3), so this
+    is intentionally generic: `plan_name` names a plan the eventual registry
+    will resolve, and `plan_args` is forwarded to the scanner unmodified via
+    `do_promote` -> `Scanner.reinitialize(run.request)`.
+    """
+
+    plan_name: str
+    plan_args: dict[str, Any] = Field(default_factory=dict)
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok"}
+
+
+@app.post("/runs")
+def create_run(request: RunRequest) -> dict:
+    """Record a launch *intent*. Never touches the scanner seam."""
+    return registry.add(request).to_dict()
+
+
+@app.get("/runs")
+def list_runs(limit: int = 20) -> list[dict]:
+    """This bridge process's tracked runs, newest first (in-memory only)."""
+    return [run.to_dict() for run in registry.list(limit=limit)]
+
+
+@app.get("/runs/{run_id}")
+def get_run_status(run_id: str) -> dict:
+    return registry.get(run_id).to_dict()
+
+
+@app.post("/runs/{run_id}/promote")
+def promote_run(run_id: str, x_promote_token: str = Header(default="")) -> dict:
+    """Promote an intent to a real scan launch. Token-gated (see `security.py`).
+
+    Callable only by holders of `BLUESKY_PROMOTE_TOKEN` — in practice, the
+    `launch_scan` MCP tool, whose own invocation already required a human
+    approval prompt (PreToolUse) plus an in-tool `writes_enabled` re-check.
+    """
+    verify_promote_token(x_promote_token)
+    run = registry.get(run_id)
+    promoted_run = do_promote(run, _scanner_factory)
+    # Only recorded once do_promote actually succeeds (it raises 409/500
+    # otherwise) — a rejected promote attempt must not mark the run as
+    # launched by anything.
+    if promoted_run.launched_by is None:
+        promoted_run.launched_by = "agent"
+    return promoted_run.to_dict()
+
+
+@app.post("/runs/{run_id}/stop")
+def stop_run(run_id: str) -> dict:
+    """Abort a running scan. Not token-gated — halting is always allowed.
+
+    Coordinates with `do_promote`'s unlocked scanner-build window under
+    `registry.lock`: if a promote is concurrently mid-build (``promoting``
+    set, ``scanner``/``promoted`` not yet published), this just records
+    ``stopped`` and `do_promote` itself stops the just-started scanner once
+    it re-checks `stopped` at publish time — see `runs.py`.
+    """
+    run = registry.get(run_id)
+    with registry.lock:
+        scanner_to_stop = run.scanner if run.promoted else None
+        run.stopped = True
+    if scanner_to_stop is not None:
+        scanner_to_stop.stop_scanning_thread()
+    return run.to_dict()
+
+
+@app.get("/plans")
+def list_plans() -> list:
+    """Registered scan plans. Stub returning `[]` until task 2.3's plan registry lands."""
+    return []

--- a/src/osprey/services/bluesky_bridge/devices/__init__.py
+++ b/src/osprey/services/bluesky_bridge/devices/__init__.py
@@ -1,0 +1,13 @@
+"""ophyd-async device factories for the Bluesky bridge.
+
+Both submodules (``mock.py``, ``epics.py``) import ophyd-async and live behind
+the optional ``osprey-framework[bluesky-bridge]`` extra — this package (and
+its submodules) must never be imported from the bridge lifecycle core
+(``app.py``, ``runs.py``, ``scanner.py``, ``security.py``), which stays
+import-clean of bluesky/ophyd so it can be built and unit-tested without the
+extra installed. This ``__init__.py`` itself imports nothing from either
+submodule, so ``from osprey.services.bluesky_bridge import devices`` alone
+stays cheap; callers import ``devices.mock`` or ``devices.epics`` explicitly.
+"""
+
+from __future__ import annotations

--- a/src/osprey/services/bluesky_bridge/devices/_connect.py
+++ b/src/osprey/services/bluesky_bridge/devices/_connect.py
@@ -1,0 +1,37 @@
+"""Shared device-connection helper for the ophyd-async device factories.
+
+Both factories (``mock.py``, ``epics.py``) build a ``{name: device}`` mapping
+whose entries exist only as dict values, then connect them. That connect step
+is centralized here so its non-obvious rationale lives in exactly one place.
+
+Imports ophyd-async, so (like the rest of ``devices/``) this module lives
+behind the optional ``osprey-framework[bluesky-bridge]`` extra — keep it out of
+the bridge lifecycle core's import path (``app.py``, ``runs.py``,
+``scanner.py``, ``security.py``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ophyd_async.core import wait_for_connection
+
+
+async def connect_all(devices: dict[str, Any]) -> dict[str, Any]:
+    """Connect every device in ``devices`` concurrently, returning the same mapping.
+
+    Connects each device explicitly via ``Device.connect()`` rather than
+    wrapping construction in ``ophyd_async.core.init_devices()``: that context
+    manager finds "new" devices by diffing the *caller's local variables* on
+    enter/exit, so a device that only ever exists as a `dict` entry (as every
+    device built from a variable-length ``names``/specs sequence necessarily
+    does) is invisible to it and would silently never get connected — every
+    signal would stay unconnected, failing on first read/write rather than at
+    connect time.
+
+    Raises:
+        ophyd_async.core.NotConnectedError: If any device fails to connect
+            (e.g. an EPICS IOC is unreachable).
+    """
+    await wait_for_connection(**{name: device.connect() for name, device in devices.items()})
+    return devices

--- a/src/osprey/services/bluesky_bridge/devices/epics.py
+++ b/src/osprey/services/bluesky_bridge/devices/epics.py
@@ -1,0 +1,128 @@
+"""ophyd-async EPICS device factory: Channel Access clients of a real IOC.
+
+Builds bluesky-shaped ``EpicsMotor``/``EpicsDetector`` devices that speak
+Channel Access directly to explicit, caller-supplied PV names — no OSPREY
+connector is involved (DA ruling: no new ``osprey`` connector; ophyd-async
+already speaks CA). This is the factory used for the Phase 3 scenario
+benchmark, which reads the same soft-IOC PVs through both this module and
+OSPREY's own ``channel_read`` MCP tool as a consistency cross-check — see
+``channel_read.py`` (:mod:`osprey.mcp_server.control_system.tools.channel_read`),
+which also takes bare PV addresses with no assumed naming convention. Matching
+that, ``EpicsMotorSpec``/``EpicsDetectorSpec`` take full PV names verbatim
+(never a prefix + guessed suffix), so both sides of the cross-check name the
+exact same PV.
+
+Deliberately does NOT use ``ophyd_async.epics.motor.Motor``: that class
+assumes a full EPICS motor record (``.VAL``, ``.RBV``, ``.VELO``, ``.ACCL``,
+...), which the scenario benchmark's soft IOC does not provide (it seeds
+plain scalar PVs, matching what ``channel_read`` reads). ``EpicsMotor`` here
+is a minimal setpoint/readback pair over two such scalar PVs instead.
+
+Imports ophyd-async, so this module (like the rest of ``devices/``) lives
+behind the optional ``osprey-framework[bluesky-bridge]`` extra — keep it out
+of the bridge lifecycle core's import path (``app.py``, ``runs.py``,
+``scanner.py``, ``security.py``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from ophyd_async.core import (
+    AsyncStatus,
+    StandardReadable,
+)
+from ophyd_async.core import (
+    StandardReadableFormat as Format,
+)
+from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
+
+from ._connect import connect_all
+
+
+@dataclass(frozen=True)
+class EpicsMotorSpec:
+    """One ``EpicsMotor`` to build: its device-mapping name and backing PV(s).
+
+    ``readback_pv`` defaults to ``setpoint_pv`` when omitted, for a PV that is
+    both read and written (no separate readback record).
+    """
+
+    name: str
+    setpoint_pv: str
+    readback_pv: str | None = None
+
+
+@dataclass(frozen=True)
+class EpicsDetectorSpec:
+    """One ``EpicsDetector`` to build: its device-mapping name and read-only PV."""
+
+    name: str
+    read_pv: str
+
+
+class EpicsMotor(StandardReadable):
+    """A settable/readable pair of Channel Access PVs, shaped as a bluesky motor.
+
+    Not backed by an EPICS motor record — ``readback`` and ``setpoint`` are
+    each a single scalar PV, named explicitly by the caller (see
+    ``EpicsMotorSpec``), matching the soft-IOC PVs the scenario benchmark seeds.
+    """
+
+    def __init__(self, setpoint_pv: str, readback_pv: str | None = None, name: str = "") -> None:
+        with self.add_children_as_readables(Format.HINTED_SIGNAL):
+            self.readback = epics_signal_r(float, readback_pv or setpoint_pv)
+        self.setpoint = epics_signal_rw(float, setpoint_pv)
+        super().__init__(name=name)
+
+    @AsyncStatus.wrap
+    async def set(self, value: float) -> None:
+        """Write ``value`` to the setpoint PV over Channel Access."""
+        await self.setpoint.set(value)
+
+
+class EpicsDetector(StandardReadable):
+    """A single read-only Channel Access PV, shaped as a bluesky detector."""
+
+    def __init__(self, read_pv: str, name: str = "") -> None:
+        with self.add_children_as_readables(Format.HINTED_SIGNAL):
+            self.value = epics_signal_r(float, read_pv)
+        super().__init__(name=name)
+
+
+async def build_devices(
+    motors: Sequence[EpicsMotorSpec] = (),
+    detectors: Sequence[EpicsDetectorSpec] = (),
+) -> dict[str, Any]:
+    """Build and connect a set of EPICS-backed motors/detectors, keyed by name.
+
+    Matches the ``get_devices() -> dict[str, Any]`` shape ``plans.py``'s
+    built-in plans (and any facility-injected plan, per ``plan_loader.py``)
+    resolve device names against. PV names come entirely from ``motors``/
+    ``detectors`` — this function has no hardcoded PV prefix or naming
+    convention, so the caller (facility config, benchmark harness) decides
+    which real IOC address each device connects to. Connection (and why it's
+    an explicit ``connect()`` rather than ``init_devices()``) is handled by
+    :func:`._connect.connect_all`.
+
+    Args:
+        motors: Specs for the ``EpicsMotor`` instances to build.
+        detectors: Specs for the ``EpicsDetector`` instances to build.
+
+    Returns:
+        Mapping of device name to connected device instance.
+
+    Raises:
+        ophyd_async.core.NotConnectedError: If any PV fails to connect (e.g.
+            the IOC is unreachable).
+    """
+    devices: dict[str, Any] = {}
+    for motor_spec in motors:
+        devices[motor_spec.name] = EpicsMotor(
+            motor_spec.setpoint_pv, motor_spec.readback_pv, name=motor_spec.name
+        )
+    for detector_spec in detectors:
+        devices[detector_spec.name] = EpicsDetector(detector_spec.read_pv, name=detector_spec.name)
+    return await connect_all(devices)

--- a/src/osprey/services/bluesky_bridge/devices/mock.py
+++ b/src/osprey/services/bluesky_bridge/devices/mock.py
@@ -1,0 +1,121 @@
+"""Pure-mock ophyd-async device factory: no CA/EPICS, no scenario/machine state.
+
+``MockMotor``/``MockDetector`` are in-process soft-signal devices — there is no
+external process backing their values, so nothing here is a "scenario": every
+instance starts from the same fixed initial state on every process start, and
+there is no shared substrate two callers could observe each other mutating.
+That makes this module suitable ONLY for:
+
+- lifecycle/contract unit tests (e.g. task 2.7's RunEngine integration test),
+  where the point is to exercise the bridge's own plumbing (``do_promote``,
+  the live-row buffer, plan resolution) against *some* bluesky-shaped device,
+  not to validate real device behavior; and
+- the ``osprey deploy`` smoke demo, where the goal is "does a scan run at
+  all" rather than "does it read a real instrument".
+
+It must NEVER be the substrate for the Phase 3 scenario benchmark — that
+benchmark's whole point is cross-checking ophyd-async's view of a PV against
+OSPREY's own ``channel_read`` on a real (soft-IOC) Channel Access server, and
+this module never touches CA. Use :mod:`osprey.services.bluesky_bridge.devices.epics`
+for anything that needs to read/write a real PV.
+
+Reimplements the shape of ``ophyd_async.sim.SimMotor``/``SimPointDetector``
+(soft position signal with instant "move"; a triggerable soft readout) rather
+than importing ``ophyd_async.sim`` directly: that package's ``__init__``
+eagerly imports ``SimBlobDetector``, which pulls in ``h5py`` — a dependency
+this bridge's ``bluesky-bridge`` extra does not declare and does not need for
+a plain motor + detector.
+
+Imports ophyd-async, so this module (like the rest of ``devices/``) lives
+behind the optional ``osprey-framework[bluesky-bridge]`` extra — keep it out
+of the bridge lifecycle core's import path (``app.py``, ``runs.py``,
+``scanner.py``, ``security.py``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from ophyd_async.core import (
+    AsyncStatus,
+    StandardReadable,
+    soft_signal_r_and_setter,
+    soft_signal_rw,
+)
+from ophyd_async.core import (
+    StandardReadableFormat as Format,
+)
+
+from ._connect import connect_all
+
+
+class MockMotor(StandardReadable):
+    """An in-process simulated motor: a soft position signal that "moves" instantly.
+
+    ``readback`` is the hinted (primary) signal read into every document;
+    ``setpoint`` records the last commanded position. There is no velocity or
+    settle time to simulate — contract tests care that ``set()`` completes and
+    the readback reflects the new value, not motion realism.
+    """
+
+    def __init__(self, name: str = "", initial_value: float = 0.0) -> None:
+        with self.add_children_as_readables(Format.HINTED_SIGNAL):
+            self.readback, self._set_readback = soft_signal_r_and_setter(float, initial_value)
+        self.setpoint = soft_signal_rw(float, initial_value)
+        super().__init__(name=name)
+
+    @AsyncStatus.wrap
+    async def set(self, value: float) -> None:
+        """Move to ``value`` instantly: write the setpoint, then the readback."""
+        await self.setpoint.set(value)
+        self._set_readback(value)
+
+
+class MockDetector(StandardReadable):
+    """An in-process simulated detector: a monotonically incrementing counter.
+
+    Deterministic on purpose — a fixed count sequence (1, 2, 3, ...) per
+    instance, rather than a random value, so lifecycle/contract tests get
+    reproducible documents without needing to seed an RNG.
+    """
+
+    def __init__(self, name: str = "") -> None:
+        with self.add_children_as_readables(Format.HINTED_SIGNAL):
+            self.value, self._set_value = soft_signal_r_and_setter(int, 0)
+        self._count = 0
+        super().__init__(name=name)
+
+    @AsyncStatus.wrap
+    async def trigger(self) -> None:
+        self._count += 1
+        self._set_value(self._count)
+
+
+async def build_devices(
+    motor_names: Sequence[str] = ("motor1",),
+    detector_names: Sequence[str] = ("det1",),
+) -> dict[str, Any]:
+    """Build and connect a set of mock motors/detectors, keyed by name.
+
+    Matches the ``get_devices() -> dict[str, Any]`` shape ``plans.py``'s
+    built-in plans (and any facility-injected plan, per ``plan_loader.py``)
+    resolve device names against. Connection (and why it's an explicit
+    ``connect()`` rather than ``init_devices()``) is handled by
+    :func:`._connect.connect_all`.
+
+    Args:
+        motor_names: Device-mapping keys for the ``MockMotor`` instances to
+            build. Defaults to a single ``"motor1"`` for the deploy smoke demo.
+        detector_names: Device-mapping keys for the ``MockDetector`` instances
+            to build. Defaults to a single ``"det1"``.
+
+    Returns:
+        Mapping of device name to connected device instance.
+    """
+    devices: dict[str, Any] = {}
+    for name in motor_names:
+        devices[name] = MockMotor(name=name)
+    for name in detector_names:
+        devices[name] = MockDetector(name=name)
+    return await connect_all(devices)

--- a/src/osprey/services/bluesky_bridge/live_rows.py
+++ b/src/osprey/services/bluesky_bridge/live_rows.py
@@ -1,0 +1,149 @@
+"""Bounded live-row buffer for scan data still in flight or just completed.
+
+Task 2.2's ``GET /runs/{id}/data`` route needs a source of truth for scan data
+before (or in place of) a Tiled server: the scan itself runs inside this
+bridge process (``runs.do_promote`` owns the scanner/RunEngine), so this
+module subscribes a plain-dict document callback to that same RunEngine and
+keeps translated rows in a bounded, run_uid-keyed buffer. Real RunEngine
+wiring lands in task 2.7 (``real-runengine-integration``) — this module is
+deliberately import-clean of bluesky so it can be built and unit-tested with
+synthetic documents beforehand. Generalizes the concept in BELLA's
+``services/experiment_config/live_rows.py``: this version has no
+GEECS-specific legacy column mapping, and explicitly RETAINS completed runs
+rather than evicting at a small run count, so a read arriving after the scan
+finishes still succeeds without a Tiled server.
+
+Document handling (bluesky's plain-dict document protocol):
+
+- ``start``: begins a new buffer for ``doc["uid"]``, marked partial.
+- ``event``: each event's ``doc["data"]`` becomes one row; columns are
+  discovered incrementally in first-seen order across events. A key seen for
+  the first time extends the column list and backfills every already-stored
+  row with ``None`` in that column, so all stored rows stay aligned to the
+  current column list; a later event missing an already-known column simply
+  records ``None`` for it.
+- ``stop``: flips ``partial`` to ``False``. This is the ONLY thing that ends
+  the "still filling in" state — a buffer that never gets a stop doc (e.g.
+  the process crashed mid-scan) stays partial forever, which is the honest
+  answer.
+
+Bounding uses two independent knobs:
+
+- ``_MAX_ROWS_PER_RUN``: a hard cap on stored rows per run, so a runaway scan
+  cannot grow the buffer without limit. ``total_seen`` keeps counting every
+  event past this cap — Task 2.2's ``row_count`` reports this *true* total
+  even when the tail beyond the cap was never stored (a documented trade-off
+  for a pathological never-ending run, not the common case).
+- ``_MAX_RUNS``: number of run buffers retained at all, oldest-evicted
+  (insertion-ordered ``OrderedDict``, ``move_to_end`` on every write) once
+  exceeded. This is what lets a completed run's data survive to be read
+  later — unlike BELLA's demo-day ``_MAX_RUNS = 4``, Phase 2 sets this much
+  higher since there is no Tiled fallback yet.
+
+The recorder itself never raises: every document is handled inside a
+try/except so a recorder bug can never abort a scan (mirrors the scanner
+seam's own safety contract) — a bug here loses live-read fidelity for that
+run, not the run itself.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+from threading import Lock
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Retained run buffers (oldest evicted first). Considerably higher than
+# BELLA's demo-day `_MAX_RUNS = 4` since Phase 2 has no Tiled fallback yet — a
+# completed run must stay readable well past its own completion.
+_MAX_RUNS = 50
+# Hard per-run row storage cap — a safety valve against a runaway/never-ending
+# scan, not a normal-case limit (see `total_seen` above).
+_MAX_ROWS_PER_RUN = 10_000
+
+_lock = Lock()
+# run_uid -> {"columns": [...], "rows": [[...], ...], "partial": bool, "total_seen": int}
+_buffers: OrderedDict[str, dict[str, Any]] = OrderedDict()
+
+
+def get(run_uid: str) -> dict[str, Any] | None:
+    """A snapshot of the live buffer for *run_uid* (or None if unknown)."""
+    with _lock:
+        buf = _buffers.get(run_uid)
+        if buf is None:
+            return None
+        return {
+            "columns": list(buf["columns"]),
+            "rows": [list(row) for row in buf["rows"]],
+            "partial": buf["partial"],
+            "total_seen": buf["total_seen"],
+        }
+
+
+def _clear() -> None:
+    """Drop all buffers (test isolation only)."""
+    with _lock:
+        _buffers.clear()
+
+
+class LiveRowRecorder:
+    """Bluesky document callback recording rows into the bounded live buffer.
+
+    One instance per promoted run (mirrors BELLA's contract): subscribe it to
+    the RunEngine between ``reinitialize()`` and ``start_scan_thread()``
+    (task 2.7) so the start doc is never missed.
+    """
+
+    def __init__(self) -> None:
+        self._uid: str | None = None
+
+    def __call__(self, name: str, doc: dict[str, Any]) -> None:
+        try:
+            if name == "start":
+                self._on_start(doc)
+            elif name == "event":
+                self._on_event(doc)
+            elif name == "stop":
+                self._on_stop(doc)
+        except Exception:
+            # RunEngine thread — a recorder bug must never touch the scan.
+            logger.warning("live-row recorder failed on %r doc", name, exc_info=True)
+
+    def _on_start(self, doc: dict[str, Any]) -> None:
+        uid = doc.get("uid")
+        if not uid:
+            return
+        self._uid = uid
+        with _lock:
+            _buffers[uid] = {"columns": [], "rows": [], "partial": True, "total_seen": 0}
+            _buffers.move_to_end(uid)
+            while len(_buffers) > _MAX_RUNS:
+                _buffers.popitem(last=False)
+
+    def _on_event(self, doc: dict[str, Any]) -> None:
+        if not self._uid:
+            return
+        data = doc.get("data") or {}
+        with _lock:
+            buf = _buffers.get(self._uid)
+            if buf is None:
+                return
+            new_columns = [key for key in data if key not in buf["columns"]]
+            if new_columns:
+                buf["columns"].extend(new_columns)
+                for row in buf["rows"]:
+                    row.extend([None] * len(new_columns))
+            buf["total_seen"] += 1
+            if len(buf["rows"]) < _MAX_ROWS_PER_RUN:
+                buf["rows"].append([data.get(col) for col in buf["columns"]])
+            _buffers.move_to_end(self._uid)
+
+    def _on_stop(self, doc: dict[str, Any]) -> None:
+        if not self._uid:
+            return
+        with _lock:
+            buf = _buffers.get(self._uid)
+            if buf is not None:
+                buf["partial"] = False

--- a/src/osprey/services/bluesky_bridge/plan_loader.py
+++ b/src/osprey/services/bluesky_bridge/plan_loader.py
@@ -1,0 +1,169 @@
+"""The facility plan-injection contract: loads a facility's plans and devices
+from a config-pointed module path, external to this package.
+
+A facility plan module is any ``.py`` file exposing:
+
+- ``PLANS: dict[str, PlanSpec]`` — additional (or overriding) scan plans.
+- ``get_devices() -> dict[str, Any]`` — builds and returns the device mapping
+  those plans' ``PlanSpec.plan`` callables resolve device names against.
+
+This module is deliberately free of bluesky/ophyd/tiled imports — it loads
+arbitrary facility modules *by path* (``importlib.util``, not a dotted import,
+since a facility module typically lives outside this installed package), and
+only the loaded module itself needs bluesky. That keeps `plan_loader.py`
+importable in any bridge process regardless of whether the `bluesky-bridge`
+extra is installed, so facility-injected plans and devices work even in a
+bluesky-less test/contract environment (see ``plans.py``'s built-in registry,
+which does need bluesky and degrades separately in ``app.py``'s `/plans`
+route).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .plan_types import PlanSpec
+
+logger = logging.getLogger("osprey.services.bluesky_bridge.plan_loader")
+
+# Set per bridge instance by the framework server definition (mirrors
+# BLUESKY_BRIDGE_URL/BLUESKY_PROMOTE_TOKEN); wins outright over config.yml.
+_MODULE_PATH_ENV = "BLUESKY_PLAN_MODULE"
+
+
+@dataclass
+class FacilityPlans:
+    """A facility's injected plans and devices, as loaded from its plan module."""
+
+    plans: dict[str, PlanSpec[Any]] = field(default_factory=dict)
+    devices: dict[str, Any] = field(default_factory=dict)
+
+
+def _resolve_plan_module_path() -> str | None:
+    """Resolve the facility plan module's filesystem path.
+
+    Resolution order:
+
+    1. ``BLUESKY_PLAN_MODULE`` env var (a filesystem path) — set by the
+       framework server definition per bridge instance; wins outright.
+    2. ``scan.plan_module`` in config.yml (local/dev convenience).
+    3. ``None`` — no facility plans are injected; the bridge serves built-ins
+       only.
+    """
+    path = os.environ.get(_MODULE_PATH_ENV)
+    if path:
+        return path
+
+    from osprey.utils.workspace import load_osprey_config
+
+    config = load_osprey_config()
+    value = config.get("scan", {}).get("plan_module")
+    return str(value) if value else None
+
+
+def _load_module_from_path(path: Path) -> Any:
+    """Import a `.py` file at ``path`` as a standalone module, by path (not name)."""
+    if not path.is_file():
+        raise FileNotFoundError(f"facility plan module not found: {path}")
+    spec = importlib.util.spec_from_file_location(
+        f"_bluesky_bridge_facility_plans_{path.stem}", path
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"could not load facility plan module: {path}")
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so the module can reference itself during import
+    # (dataclasses, pickling, submodule imports all resolve the module by name
+    # via sys.modules). Remove it again if exec fails, so a half-initialized
+    # module never lingers to shadow a later, fixed load of the same path.
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        sys.modules.pop(spec.name, None)
+        raise
+    return module
+
+
+def load_facility_plans(module_path: str | None = None) -> FacilityPlans:
+    """Load a facility's ``PLANS``/``get_devices()`` from a config-pointed module path.
+
+    ``module_path`` overrides resolution (mainly for tests); production
+    callers leave it unset so it's resolved via env/config.yml (see
+    ``_resolve_plan_module_path``). Returns an empty `FacilityPlans` when no
+    path is configured — the bridge then serves only the built-in plan set.
+
+    A path that *is* configured but names a missing, unloadable module, or one
+    missing the ``PLANS``/``get_devices`` contract, raises rather than
+    silently falling back — a misconfigured facility injection should fail
+    loudly, not masquerade as "no facility plans".
+    """
+    path_str = module_path if module_path is not None else _resolve_plan_module_path()
+    if not path_str:
+        return FacilityPlans()
+
+    module = _load_module_from_path(Path(path_str))
+
+    plans = getattr(module, "PLANS", None)
+    if plans is None:
+        raise AttributeError(f"facility plan module {path_str!r} does not define PLANS")
+    get_devices = getattr(module, "get_devices", None)
+    if get_devices is None:
+        raise AttributeError(f"facility plan module {path_str!r} does not define get_devices()")
+
+    devices = get_devices()
+    logger.info(
+        "plan_loader: loaded %d facility plan(s) and %d device(s) from %s",
+        len(plans),
+        len(devices),
+        path_str,
+    )
+    _warn_if_shadowing_builtins(plans)
+    return FacilityPlans(plans=dict(plans), devices=dict(devices))
+
+
+def _warn_if_shadowing_builtins(facility_plans: dict[str, PlanSpec[Any]]) -> None:
+    """Log once, at load time, if a facility plan overrides a built-in of the same name.
+
+    Silent shadowing here would be a surprising way for an operator to lose a
+    built-in plan (e.g. `count`) to a same-named facility plan without any
+    trace in the logs. Guarded/lazy import of `plans.py` (which needs
+    bluesky) so this check itself never forces `plan_loader.py` to depend on
+    bluesky — absent bluesky, there's no built-in set to shadow anyway.
+    """
+    try:
+        from .plans import BUILTIN_PLANS
+    except ImportError:
+        return
+    shadowed = sorted(set(BUILTIN_PLANS) & set(facility_plans))
+    if shadowed:
+        logger.warning(
+            "plan_loader: facility plan(s) %s override built-in plan(s) of the same name",
+            shadowed,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton: loaded (and cached) once per bridge process, since
+# device construction may be expensive (e.g. real EPICS connections).
+# ---------------------------------------------------------------------------
+_facility_plans: FacilityPlans | None = None
+
+
+def get_facility_plans() -> FacilityPlans:
+    """The bridge process's facility-injected plans/devices, loading them on first use."""
+    global _facility_plans
+    if _facility_plans is None:
+        _facility_plans = load_facility_plans()
+    return _facility_plans
+
+
+def reset_facility_plans() -> None:
+    """Clear the cached `FacilityPlans` singleton (for testing)."""
+    global _facility_plans
+    _facility_plans = None

--- a/src/osprey/services/bluesky_bridge/plan_types.py
+++ b/src/osprey/services/bluesky_bridge/plan_types.py
@@ -1,0 +1,53 @@
+"""The facility plan-injection contract's shared type: ``PlanSpec``.
+
+Kept free of bluesky/ophyd/tiled imports (pydantic is a core bridge dependency,
+pulled in transitively via FastAPI, so it's fine here) so both sides of the
+injection seam stay on the right side of the import-clean boundary:
+
+- ``plan_loader.py`` (task 2.4) loads a facility module exposing
+  ``PLANS: dict[str, PlanSpec]`` from a config-pointed path *without* itself
+  importing bluesky — only the loaded module needs it.
+- ``plans.py`` (this task, 2.3) builds the v1 built-in ``PlanSpec`` set by
+  wrapping ``bluesky.plans`` callables; it imports bluesky, but doing so here
+  in the shared type would force that import onto the loader too.
+
+A plan's ``plan`` callable is intentionally opaque: ``(devices, params) ->
+Any``, where ``devices`` is whatever ``get_devices()`` returned and ``params``
+is a validated instance of ``schema``. Neither this module nor callers need to
+know if the callable returns a real bluesky plan generator or, in a test
+double, something else entirely.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Generic, TypeVar
+
+from pydantic import BaseModel
+
+SchemaT = TypeVar("SchemaT", bound=BaseModel)
+
+
+@dataclass
+class PlanSpec(Generic[SchemaT]):
+    """One registered scan plan: its name, parameter schema, and implementation.
+
+    Generic over its own ``schema`` type so each concrete plan's ``plan``
+    callable can be typed against its own pydantic model (e.g. ``CountParams``)
+    rather than the common ``BaseModel`` supertype — callers that don't care
+    about a specific plan's schema can still hold these as ``PlanSpec[Any]``.
+    """
+
+    name: str
+    plan: Callable[[dict[str, Any], SchemaT], Any]
+    schema: type[SchemaT]
+    description: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for `GET /plans`: name, description, and the JSON parameter schema."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "schema": self.schema.model_json_schema(),
+        }

--- a/src/osprey/services/bluesky_bridge/plans.py
+++ b/src/osprey/services/bluesky_bridge/plans.py
@@ -1,0 +1,130 @@
+"""The v1 built-in scan plan set, wrapping bluesky's ``bp.scan``/``bp.count``/
+``bp.grid_scan`` with pydantic parameter schemas that `GET /plans` serves.
+
+Device-agnostic by construction: every schema names detectors/motors by
+string, resolved against whatever device mapping the caller passes in (the
+mock factory, the EPICS factory, or a facility-injected ``get_devices()`` —
+see ``plan_loader.py``), never against a fixed device set. This module imports
+``bluesky`` and lives behind the optional ``osprey-framework[bluesky-bridge]``
+extra — keep it OUT of the lifecycle core's import path (``app.py`` only
+reaches it via a guarded import inside the `/plans` route).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bluesky import plans as bp
+from pydantic import BaseModel, Field, model_validator
+
+from .plan_types import PlanSpec
+
+
+class ScanAxis(BaseModel):
+    """One motor's sweep range, shared by ``scan`` and ``grid_scan`` schemas."""
+
+    motor: str
+    start: float
+    stop: float
+
+
+class CountParams(BaseModel):
+    """Parameters for the built-in ``count`` plan (wraps ``bp.count``)."""
+
+    detectors: list[str] = Field(..., description="Device names to read at each count.")
+    num: int = Field(1, ge=1, description="Number of readings to take.")
+    delay: float | None = Field(
+        default=None, ge=0, description="Delay in seconds between successive readings."
+    )
+
+
+class ScanParams(BaseModel):
+    """Parameters for the built-in ``scan`` plan (wraps ``bp.scan``)."""
+
+    detectors: list[str] = Field(..., description="Device names to read at each step.")
+    axes: list[ScanAxis] = Field(
+        ..., min_length=1, description="Motors to move together, each over its own start/stop."
+    )
+    num: int = Field(..., ge=2, description="Number of evenly-spaced points along the axes.")
+
+
+class GridScanParams(BaseModel):
+    """Parameters for the built-in ``grid_scan`` plan (wraps ``bp.grid_scan``)."""
+
+    detectors: list[str] = Field(..., description="Device names to read at each grid point.")
+    axes: list[ScanAxis] = Field(..., min_length=1, description="One entry per grid dimension.")
+    num_points: list[int] = Field(
+        ..., description="Points per axis; must have the same length as `axes`."
+    )
+    snake_axes: bool = Field(
+        default=False, description="Snake back-and-forth across successive axes."
+    )
+
+    @model_validator(mode="after")
+    def _num_points_matches_axes(self) -> GridScanParams:
+        """Reject a params set whose ``num_points`` and ``axes`` lengths disagree.
+
+        Enforced in the schema (not just at plan-build time) so the mismatch
+        surfaces as an ordinary parameter-validation error the moment
+        ``plan_args`` are validated in ``reinitialize()``, uniform with every
+        other schema violation — rather than as a bare ValueError deeper in
+        plan construction.
+        """
+        if len(self.num_points) != len(self.axes):
+            raise ValueError(
+                f"num_points must have one entry per axis "
+                f"(got {len(self.num_points)} num_points, {len(self.axes)} axes)"
+            )
+        return self
+
+
+def _count_plan(devices: dict[str, Any], params: CountParams) -> Any:
+    detectors = [devices[name] for name in params.detectors]
+    return bp.count(detectors, num=params.num, delay=params.delay)
+
+
+def _scan_plan(devices: dict[str, Any], params: ScanParams) -> Any:
+    detectors = [devices[name] for name in params.detectors]
+    args: list[Any] = []
+    for axis in params.axes:
+        args.extend([devices[axis.motor], axis.start, axis.stop])
+    return bp.scan(detectors, *args, num=params.num)
+
+
+def _grid_scan_plan(devices: dict[str, Any], params: GridScanParams) -> Any:
+    # GridScanParams' model_validator already guarantees equal lengths; the
+    # strict=True zip below is a backstop, not the primary check.
+    detectors = [devices[name] for name in params.detectors]
+    args: list[Any] = []
+    for axis, npts in zip(params.axes, params.num_points, strict=True):
+        args.extend([devices[axis.motor], axis.start, axis.stop, npts])
+    return bp.grid_scan(detectors, *args, snake_axes=params.snake_axes)
+
+
+# The v1 built-in plan registry, keyed by the name a `RunRequest.plan_name`
+# resolves against.
+BUILTIN_PLANS: dict[str, PlanSpec[Any]] = {
+    "count": PlanSpec(
+        name="count",
+        plan=_count_plan,
+        schema=CountParams,
+        description="Read detectors N times with no motor motion (bluesky bp.count).",
+    ),
+    "scan": PlanSpec(
+        name="scan",
+        plan=_scan_plan,
+        schema=ScanParams,
+        description="Scan one or more motors together over evenly-spaced points (bluesky bp.scan).",
+    ),
+    "grid_scan": PlanSpec(
+        name="grid_scan",
+        plan=_grid_scan_plan,
+        schema=GridScanParams,
+        description="Scan a rectangular grid of motors (bluesky bp.grid_scan).",
+    ),
+}
+
+
+def list_plan_specs() -> list[dict[str, Any]]:
+    """Serialize `BUILTIN_PLANS` for `GET /plans`."""
+    return [spec.to_dict() for spec in BUILTIN_PLANS.values()]

--- a/src/osprey/services/bluesky_bridge/runs.py
+++ b/src/osprey/services/bluesky_bridge/runs.py
@@ -1,0 +1,207 @@
+"""The bridge's in-memory run registry and lifecycle state machine.
+
+``Run`` tracks one scan from intent through completion. Creating a run never
+touches the ``Scanner`` seam (see ``scanner.py``) — that only happens once a
+run is *promoted* via ``do_promote``, the single choke point that starts a
+real scan. This module is deliberately free of bluesky/ophyd/tiled imports so
+the lifecycle core stays importable — and unit testable with a
+``FakeScanner`` — before those dependencies are ever installed. It does use
+``fastapi.HTTPException`` for its error semantics (mirroring ``security.py``),
+since FastAPI is a core bridge dependency, not one of the deferred ones.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import TYPE_CHECKING, Any
+
+from fastapi import HTTPException
+
+if TYPE_CHECKING:
+    from .scanner import Scanner
+
+# `Run.status` treats a scanner whose (lowercased, stringified) `current_state`
+# equals one of these as the one terminal-failure signal from the scanner seam
+# not already captured by `run.error` directly (e.g. a background scan thread
+# failing asynchronously). Equality, not substring match, so a state like
+# "no_error" can't false-positive. Only `FakeScanner` exists today and it sets
+# exactly "error" (see `simulate_error`); Phase 2's real bluesky-backed
+# `Scanner` should add an explicit terminal-error signal to the protocol
+# instead of leaning on `current_state` string matching.
+_ERROR_STATES = {"error"}
+
+
+@dataclass
+class Run:
+    """One scan-run's lifecycle state.
+
+    ``request`` is deliberately untyped here (see Task 1.5's pydantic
+    ``RunRequest``) so this module never has to import FastAPI/pydantic.
+    """
+
+    id: str
+    request: Any
+    created_at: float = field(default_factory=time.time)
+    promoted: bool = False
+    promoting: bool = False  # guards the promote critical section (see do_promote)
+    scanner: Scanner | None = None
+    stopped: bool = False
+    error: str | None = None
+    # Which sanctioned launch path promoted this run, e.g. "agent" (the
+    # token-gated `launch_scan` MCP tool route). Set at intent creation or,
+    # at latest, by whatever promotes the run.
+    launched_by: str | None = None
+
+    @property
+    def run_uid(self) -> str | None:
+        """The underlying scan's run identifier, once the scan has started."""
+        return self.scanner.last_run_uid if self.scanner is not None else None
+
+    @property
+    def status(self) -> str:
+        """Derive the run's lifecycle state: intent -> running -> completed | stopped | error.
+
+        ``stopped`` is checked before ``promoted`` so an intent stopped before
+        it was ever promoted correctly reports "stopped" rather than a stale
+        "intent" — `do_promote` refuses to (re-)promote a stopped run either
+        way, so "intent" would be misleading once that door is permanently
+        closed.
+        """
+        if self.error:
+            return "error"
+        if self.stopped:
+            return "stopped"
+        if not self.promoted:
+            return "intent"
+        if self.scanner is not None:
+            if self.scanner.is_scanning_active():
+                return "running"
+            if str(self.scanner.current_state).lower() in _ERROR_STATES:
+                return "error"
+        return "completed"
+
+    def to_dict(self) -> dict:
+        status = self.status
+        out: dict[str, Any] = {"id": self.id, "status": status}
+        if self.promoted and self.scanner is not None:
+            out["completion"] = self.scanner.estimate_current_completion()
+        if self.launched_by:
+            out["launched_by"] = self.launched_by
+        run_uid = self.run_uid
+        if run_uid:
+            out["run_uid"] = run_uid
+        if self.error:
+            out["error"] = self.error
+        elif status == "error" and self.scanner is not None:
+            out["error"] = f"scan ended in state {self.scanner.current_state!r}"
+        return out
+
+
+class RunRegistry:
+    """Thread-safe in-memory store of `Run` objects, keyed by id.
+
+    ``lock`` also guards `do_promote`'s promoting/promoted/stopped
+    check-and-set below — the registry is in-memory only, so a single lock
+    per bridge process is enough to admit exactly one promotion per run.
+    """
+
+    def __init__(self) -> None:
+        self._runs: dict[str, Run] = {}
+        self.lock = Lock()
+
+    def add(self, request: Any, launched_by: str | None = None) -> Run:
+        """Record a launch intent and return the new `Run`. Never touches the scanner seam."""
+        run = Run(id=uuid.uuid4().hex, request=request, launched_by=launched_by)
+        with self.lock:
+            self._runs[run.id] = run
+        return run
+
+    def get(self, run_id: str) -> Run:
+        """Look up a run by id, raising 404 if it has no record.
+
+        The registry is in-memory only, so this is also the honest answer for
+        a run id from before a process restart — there is no persisted
+        history to fall back to.
+        """
+        with self.lock:
+            run = self._runs.get(run_id)
+        if run is None:
+            raise HTTPException(status_code=404, detail=f"unknown run {run_id!r}")
+        return run
+
+    def list(self, limit: int = 20) -> list[Run]:
+        """This process's tracked runs, newest first."""
+        with self.lock:
+            records = sorted(self._runs.values(), key=lambda r: r.created_at, reverse=True)
+        return records[: max(1, min(limit, 100))]
+
+
+# Module-level singleton: the bridge process's one run registry.
+registry = RunRegistry()
+
+
+def do_promote(run: Run, scanner_factory: Callable[[], Scanner]) -> Run:
+    """The single choke point that starts a real scan.
+
+    Callers (the token-gated ``POST /runs/{id}/promote`` route, task 1.5) must
+    already have enforced their sanctioned human decision — the promote token
+    (``security.verify_promote_token``) plus `launch_scan`'s in-tool
+    ``writes_enabled`` re-check — before calling this.
+
+    ``scanner_factory`` builds a fresh `Scanner` OUTSIDE the lock (it may be
+    slow, e.g. constructing a real bluesky `RunEngine`); the lock only guards
+    the promoting/promoted/stopped check-and-set, so two concurrent promotes
+    of the same run can't both start a scan, and a stopped run can never be
+    promoted. Publishes ``promoted=True`` before clearing ``promoting`` so a
+    concurrent promote always observes either "not yet promoting" or
+    "promoted" — never a window where both are false.
+
+    A stop can race the unlocked build/start window above: ``stop_run``
+    (``app.py``) may run while this scanner is still being built, see
+    ``promoted=False``/``scanner=None`` (nothing to stop yet), and merely
+    record ``run.stopped = True``. Left unhandled, this scanner would then
+    finish starting and get published anyway — a live, untracked scan behind
+    a run that reports "stopped". So publishing re-acquires the lock and
+    re-checks ``run.stopped`` in the same critical section that sets
+    ``scanner``/``promoted``; if a stop landed during the build, the
+    just-started scanner is stopped immediately after releasing the lock.
+    """
+    with registry.lock:
+        if run.promoted:
+            raise HTTPException(status_code=409, detail=f"run {run.id!r} already promoted")
+        if run.promoting:
+            raise HTTPException(
+                status_code=409, detail=f"run {run.id!r} promotion already in progress"
+            )
+        if run.stopped:
+            raise HTTPException(
+                status_code=409, detail=f"run {run.id!r} was stopped; cannot promote"
+            )
+        run.promoting = True
+        run.error = None  # clear any prior failed-promote error before this (re)try
+
+    try:
+        scanner = scanner_factory()
+        if not scanner.reinitialize(run.request):
+            raise RuntimeError("scanner.reinitialize() returned False")
+        scanner.start_scan_thread()
+    except Exception as exc:  # surface to the run rather than raising 500 blind
+        with registry.lock:
+            run.error = str(exc)
+            run.promoting = False
+        raise HTTPException(status_code=500, detail=f"promotion failed: {exc}") from exc
+
+    with registry.lock:
+        run.scanner = scanner
+        run.promoted = True
+        run.promoting = False
+        stopped_during_build = run.stopped
+
+    if stopped_during_build:
+        scanner.stop_scanning_thread()
+
+    return run

--- a/src/osprey/services/bluesky_bridge/runs.py
+++ b/src/osprey/services/bluesky_bridge/runs.py
@@ -12,6 +12,7 @@ since FastAPI is a core bridge dependency, not one of the deferred ones.
 
 from __future__ import annotations
 
+import logging
 import time
 import uuid
 from collections.abc import Callable
@@ -24,15 +25,7 @@ from fastapi import HTTPException
 if TYPE_CHECKING:
     from .scanner import Scanner
 
-# `Run.status` treats a scanner whose (lowercased, stringified) `current_state`
-# equals one of these as the one terminal-failure signal from the scanner seam
-# not already captured by `run.error` directly (e.g. a background scan thread
-# failing asynchronously). Equality, not substring match, so a state like
-# "no_error" can't false-positive. Only `FakeScanner` exists today and it sets
-# exactly "error" (see `simulate_error`); Phase 2's real bluesky-backed
-# `Scanner` should add an explicit terminal-error signal to the protocol
-# instead of leaning on `current_state` string matching.
-_ERROR_STATES = {"error"}
+logger = logging.getLogger("osprey.services.bluesky_bridge.runs")
 
 
 @dataclass
@@ -80,7 +73,7 @@ class Run:
         if self.scanner is not None:
             if self.scanner.is_scanning_active():
                 return "running"
-            if str(self.scanner.current_state).lower() in _ERROR_STATES:
+            if self.scanner.error_message is not None:
                 return "error"
         return "completed"
 
@@ -97,7 +90,9 @@ class Run:
         if self.error:
             out["error"] = self.error
         elif status == "error" and self.scanner is not None:
-            out["error"] = f"scan ended in state {self.scanner.current_state!r}"
+            out["error"] = self.scanner.error_message or (
+                f"scan ended in state {self.scanner.current_state!r}"
+            )
         return out
 
 
@@ -169,6 +164,18 @@ def do_promote(run: Run, scanner_factory: Callable[[], Scanner]) -> Run:
     re-checks ``run.stopped`` in the same critical section that sets
     ``scanner``/``promoted``; if a stop landed during the build, the
     just-started scanner is stopped immediately after releasing the lock.
+
+    A *different* failure mode: ``scanner.start_scan_thread()`` itself raises
+    after partially starting something (e.g. a real bluesky ``Scanner``
+    spawned its daemon thread, which then failed before the thread became
+    observably "active"). Without a guard, the except branch below records
+    ``run.error`` and returns 500 — but ``run.scanner`` is never published
+    (the run reports "error", not "running"), so nothing else could ever call
+    ``stop_scanning_thread()`` on that scanner: a live, untracked, unstoppable
+    scan. So the except branch stops whatever `scanner_factory()` managed to
+    build, unconditionally, before surfacing the error — safe even if nothing
+    actually started, since every `Scanner.stop_scanning_thread()` must
+    already tolerate being called on an inactive scanner.
     """
     with registry.lock:
         if run.promoted:
@@ -184,12 +191,23 @@ def do_promote(run: Run, scanner_factory: Callable[[], Scanner]) -> Run:
         run.promoting = True
         run.error = None  # clear any prior failed-promote error before this (re)try
 
+    scanner: Scanner | None = None
     try:
         scanner = scanner_factory()
         if not scanner.reinitialize(run.request):
             raise RuntimeError("scanner.reinitialize() returned False")
         scanner.start_scan_thread()
     except Exception as exc:  # surface to the run rather than raising 500 blind
+        if scanner is not None:
+            try:
+                scanner.stop_scanning_thread()
+            except Exception:
+                logger.warning(
+                    "do_promote: stop_scanning_thread() on a failed-start scanner"
+                    " for run %r also raised",
+                    run.id,
+                    exc_info=True,
+                )
         with registry.lock:
             run.error = str(exc)
             run.promoting = False

--- a/src/osprey/services/bluesky_bridge/scanner.py
+++ b/src/osprey/services/bluesky_bridge/scanner.py
@@ -1,0 +1,119 @@
+"""The injected scanner seam: keeps the bridge lifecycle core import-clean of bluesky.
+
+``Scanner`` is the boundary the lifecycle core (``runs.py``'s ``do_promote``) is
+written against. The real implementation (a bluesky ``RunEngine`` in a daemon
+thread, wired to ophyd-async devices and a ``TiledWriter``) arrives in Phase 2 as
+``scanner_bluesky.py`` and lives behind the ``osprey-framework[scan-bridge]``
+extra. Everything in this module — the Protocol and ``FakeScanner`` — has no
+bluesky/ophyd/tiled dependency, so the lifecycle core can be built, imported, and
+unit-tested before that extra ever needs to be installed.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Scanner(Protocol):
+    """One scan's hardware/engine handle, as seen by the bridge lifecycle core.
+
+    A fresh instance is built per promoted run (see ``do_promote``): the caller
+    calls ``reinitialize`` then ``start_scan_thread``, polls ``is_scanning_active``/
+    ``estimate_current_completion``/``current_state`` for status, and may call
+    ``stop_scanning_thread`` to abort. ``last_run_uid`` surfaces the underlying
+    run identifier (e.g. a bluesky start-doc uid) once the scan has begun.
+    """
+
+    current_state: Any
+    last_run_uid: str | None
+
+    def reinitialize(self, exec_config: Any) -> bool:
+        """Prepare the scan from ``exec_config``. Returns False on setup failure."""
+        ...
+
+    def start_scan_thread(self) -> None:
+        """Start the scan running in a background thread. Non-blocking."""
+        ...
+
+    def stop_scanning_thread(self) -> None:
+        """Request the running scan stop. Safe to call even if not active."""
+        ...
+
+    def is_scanning_active(self) -> bool:
+        """True while the scan thread is running."""
+        ...
+
+    def estimate_current_completion(self) -> float:
+        """A 0.0-1.0 progress estimate."""
+        ...
+
+
+class FakeScanner:
+    """Deterministic ``Scanner`` test double — no bluesky dependency.
+
+    Tracks call counts and lets a test script the scan's progress and outcome
+    directly, instead of driving a real RunEngine thread:
+
+    - ``reinitialize_fails``: make ``reinitialize`` return False (setup failure).
+    - ``simulate_progress(fraction)``: set the completion estimate mid-run.
+    - ``simulate_completion()`` / ``simulate_error(message)``: end the scan.
+
+    ``start_scan_thread`` mints a ``last_run_uid`` (if one wasn't pre-seeded via
+    the constructor) so callers can exercise "run_uid becomes available once the
+    scan starts" behavior without a real document stream.
+    """
+
+    def __init__(self, run_uid: str | None = None, reinitialize_fails: bool = False) -> None:
+        self.current_state: str = "idle"
+        self.last_run_uid: str | None = run_uid
+        self.reinitialize_fails = reinitialize_fails
+        self.reinitialize_calls = 0
+        self.start_calls = 0
+        self.stop_calls = 0
+        self._active = False
+        self._completion = 0.0
+        self.error_message: str | None = None
+
+    def reinitialize(self, exec_config: Any) -> bool:
+        self.reinitialize_calls += 1
+        if self.reinitialize_fails:
+            self.current_state = "error"
+            return False
+        self.current_state = "armed"
+        return True
+
+    def start_scan_thread(self) -> None:
+        self.start_calls += 1
+        self._active = True
+        self.current_state = "running"
+        if self.last_run_uid is None:
+            self.last_run_uid = uuid.uuid4().hex
+
+    def stop_scanning_thread(self) -> None:
+        self.stop_calls += 1
+        self._active = False
+        self.current_state = "stopped"
+
+    def is_scanning_active(self) -> bool:
+        return self._active
+
+    def estimate_current_completion(self) -> float:
+        return self._completion
+
+    def simulate_progress(self, fraction: float) -> None:
+        """Set the completion estimate (clamped to 0.0-1.0) without ending the scan."""
+        self._completion = max(0.0, min(1.0, fraction))
+
+    def simulate_completion(self) -> None:
+        """End the scan successfully, as if the thread ran to completion."""
+        self._active = False
+        self._completion = 1.0
+        self.current_state = "completed"
+
+    def simulate_error(self, message: str = "scan failed") -> None:
+        """End the scan in a failed state, as if the thread raised."""
+        self._active = False
+        self.current_state = "error"
+        self.error_message = message

--- a/src/osprey/services/bluesky_bridge/scanner.py
+++ b/src/osprey/services/bluesky_bridge/scanner.py
@@ -2,9 +2,9 @@
 
 ``Scanner`` is the boundary the lifecycle core (``runs.py``'s ``do_promote``) is
 written against. The real implementation (a bluesky ``RunEngine`` in a daemon
-thread, wired to ophyd-async devices and a ``TiledWriter``) arrives in Phase 2 as
-``scanner_bluesky.py`` and lives behind the ``osprey-framework[scan-bridge]``
-extra. Everything in this module — the Protocol and ``FakeScanner`` — has no
+thread, wired to ophyd-async devices and a ``TiledWriter``) lives in
+``scanner_bluesky.py``, behind the ``osprey-framework[bluesky-bridge]`` extra.
+Everything in this module — the Protocol and ``FakeScanner`` — has no
 bluesky/ophyd/tiled dependency, so the lifecycle core can be built, imported, and
 unit-tested before that extra ever needs to be installed.
 """
@@ -24,10 +24,14 @@ class Scanner(Protocol):
     ``estimate_current_completion``/``current_state`` for status, and may call
     ``stop_scanning_thread`` to abort. ``last_run_uid`` surfaces the underlying
     run identifier (e.g. a bluesky start-doc uid) once the scan has begun.
+    ``error_message`` is the explicit terminal-error signal: non-None means the
+    scan ended in an unrecoverable error (``runs.py``'s ``Run.status`` reads
+    this directly, rather than string-matching ``current_state``).
     """
 
     current_state: Any
     last_run_uid: str | None
+    error_message: str | None
 
     def reinitialize(self, exec_config: Any) -> bool:
         """Prepare the scan from ``exec_config``. Returns False on setup failure."""
@@ -80,6 +84,7 @@ class FakeScanner:
         self.reinitialize_calls += 1
         if self.reinitialize_fails:
             self.current_state = "error"
+            self.error_message = "reinitialize() was configured to fail"
             return False
         self.current_state = "armed"
         return True

--- a/src/osprey/services/bluesky_bridge/scanner_bluesky.py
+++ b/src/osprey/services/bluesky_bridge/scanner_bluesky.py
@@ -1,0 +1,268 @@
+"""The real bluesky-backed ``Scanner``: a RunEngine in a daemon thread.
+
+Implements the injected ``Scanner`` seam (``scanner.py``) that ``do_promote``
+builds per promoted run. Imports bluesky, so this module lives behind the
+optional ``osprey-framework[bluesky-bridge]`` extra — it must never be
+imported from the lifecycle core's import path (``app.py``, ``runs.py``,
+``scanner.py``, ``security.py`` stay import-clean); only a deploy wiring or a
+bluesky-capable test imports this module directly.
+
+Plan resolution happens entirely inside ``reinitialize()``: ``exec_config``
+(the bridge's ``RunRequest`` — ``plan_name`` + ``plan_args``, or an equivalent
+mapping) is resolved against a plan registry (by default the same built-ins +
+facility-injected merge ``app.py``'s ``GET /plans`` route serves), its
+``plan_args`` validated against that plan's pydantic schema, and the
+resulting bluesky plan generator built and stored — all *before*
+``start_scan_thread()`` ever touches a thread. That is what makes
+``start_scan_thread()`` effectively all-or-nothing: the only way it can fail
+is daemon-thread creation itself, not plan/device resolution (see
+``runs.py``'s ``do_promote``, which also stops a partially-started scanner
+defensively on any exception, as a second line of defense).
+
+Live data: this scanner subscribes its own ``live_rows.LiveRowRecorder`` to
+the RunEngine, so ``read_scan_data`` returns real buffered rows for a real
+scan with no Tiled server needed. A ``TiledWriter`` subscription is optional
+(best-effort — its absence, or failure to connect, never blocks a scan).
+
+``error_message`` is the Scanner protocol's explicit terminal-error signal
+(see ``scanner.py``): set on a plan-resolution failure in ``reinitialize()``
+or on an uncaught exception from the RunEngine thread in ``start_scan_thread()``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import threading
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from bluesky import RunEngine
+
+from .live_rows import LiveRowRecorder
+from .plan_types import PlanSpec
+
+logger = logging.getLogger("osprey.services.bluesky_bridge.scanner_bluesky")
+
+# A device mapping, or a zero-arg callable producing one (sync) or an
+# awaitable of one (async) — mirrors `plan_loader.py`'s `get_devices() ->
+# dict[str, Any]` contract, so the same device source shape works whether it
+# comes from a facility plan module, the mock factory (`devices/mock.py`), or
+# a plain pre-built dict (tests). The callable may be sync (a plain
+# `Mapping[str, Any]` return) OR async (e.g. `devices.mock.build_devices`/
+# `devices.epics.build_devices`, which connect ophyd-async devices and are
+# `async def`) — `reinitialize()` bridges either via `_resolve_devices`.
+DeviceSource = Mapping[str, Any] | Callable[[], "Mapping[str, Any] | Awaitable[Mapping[str, Any]]"]
+
+
+def _resolve_devices(source: DeviceSource) -> Mapping[str, Any]:
+    """Resolve a `DeviceSource` to a plain device mapping, bridging async factories.
+
+    `plan_loader.py`'s facility contract calls `get_devices()` synchronously,
+    but the actual device factories (`devices/mock.py`'s `build_devices`, and
+    `devices/epics.py`'s ophyd-async equivalent) are `async def` — connecting
+    a device is an async operation. Rather than assume the factory is sync,
+    call it and await the result via `asyncio.run` if it turns out to be a
+    coroutine (or any other awaitable). This is a fresh, throwaway event loop
+    — fine for mock devices; a *real* ophyd-async device factory intended to
+    share the RunEngine's own event loop (needed for backends whose async
+    callbacks are loop-bound, e.g. real Channel Access connections) should
+    connect on `RE.loop` instead — a known follow-up for the EPICS-backed
+    device factory (task 2.6) and deploy wiring (task 2.9), not solved here.
+    """
+    result: Mapping[str, Any] | Awaitable[Mapping[str, Any]] = (
+        source() if callable(source) else source
+    )
+    if inspect.isawaitable(result):
+        return asyncio.run(_await(result))
+    return result
+
+
+async def _await(awaitable: Awaitable[Mapping[str, Any]]) -> Mapping[str, Any]:
+    """Wrap an arbitrary awaitable as a coroutine `asyncio.run` accepts."""
+    return await awaitable
+
+
+def _default_plan_registry() -> dict[str, PlanSpec[Any]]:
+    """Built-ins merged with facility-injected plans (mirrors app.py's `/plans` merge).
+
+    Duplicated locally rather than imported from `app.py` (this module must
+    never be imported by the lifecycle core, and `app.py` must never import
+    this module either — the dependency only runs one way, from a deploy
+    wiring or a test towards this module).
+    """
+    from .plan_loader import get_facility_plans
+
+    merged: dict[str, PlanSpec[Any]] = {}
+    try:
+        from .plans import BUILTIN_PLANS
+
+        merged.update(BUILTIN_PLANS)
+    except ImportError:
+        pass
+    merged.update(get_facility_plans().plans)
+    return merged
+
+
+def _plan_name_and_args(exec_config: Any) -> tuple[str | None, dict[str, Any]]:
+    """Extract ``(plan_name, plan_args)`` from either a `RunRequest` or a plain dict."""
+    if isinstance(exec_config, Mapping):
+        return exec_config.get("plan_name"), dict(exec_config.get("plan_args") or {})
+    return getattr(exec_config, "plan_name", None), dict(
+        getattr(exec_config, "plan_args", None) or {}
+    )
+
+
+class BlueskyScanner:
+    """One promoted run's real bluesky RunEngine handle.
+
+    A fresh instance is built per promotion (`do_promote`'s `scanner_factory`).
+    ``devices``/``plans`` are injected rather than resolved from global state
+    by default, so contract tests can supply mock devices (`devices/mock.py`)
+    and the real built-in plan set without any facility injection wiring.
+    """
+
+    def __init__(
+        self,
+        devices: DeviceSource,
+        plans: Mapping[str, PlanSpec[Any]] | None = None,
+        *,
+        tiled_writer_factory: Callable[[], Any] | None = None,
+    ) -> None:
+        self._devices_source = devices
+        self._plans = dict(plans) if plans is not None else None
+        self._plan_gen: Any = None
+
+        self.current_state: str = "idle"
+        self.last_run_uid: str | None = None
+        self.error_message: str | None = None
+
+        # `context_managers=[]` disables the RunEngine's default SIGINT/SIGTSTP
+        # handling, which only works on the main thread — required since
+        # `RE(...)` runs from `self._thread`, not the process's main thread.
+        self.RE = RunEngine(context_managers=[])
+        self._recorder = LiveRowRecorder()
+        self.RE.subscribe(self._on_document)
+
+        if tiled_writer_factory is not None:
+            try:
+                self.RE.subscribe(tiled_writer_factory())
+            except Exception:
+                logger.warning(
+                    "BlueskyScanner: TiledWriter subscription failed; continuing without it",
+                    exc_info=True,
+                )
+
+        self._thread: threading.Thread | None = None
+        self._stop_requested = False
+        self._completion = 0.0
+
+    def _on_document(self, name: str, doc: dict[str, Any]) -> None:
+        """Capture `last_run_uid` from the start doc, then forward to the live-row buffer.
+
+        Never raises: `dict.get` is safe, and `LiveRowRecorder.__call__` is
+        already fully exception-wrapped (see `live_rows.py`) — a recorder bug
+        must never reach the RunEngine thread running the actual scan.
+        """
+        if name == "start":
+            self.last_run_uid = doc.get("uid")
+        self._recorder(name, doc)
+
+    def reinitialize(self, exec_config: Any) -> bool:
+        """Resolve `exec_config`'s plan_name/plan_args into a ready-to-run plan generator.
+
+        Every failure mode here — unknown plan, invalid plan_args, a plan
+        callable that raises while resolving devices — returns False (and
+        sets `error_message`) rather than raising, so a bad launch request
+        never reaches `start_scan_thread()` at all.
+        """
+        plan_name, plan_args = _plan_name_and_args(exec_config)
+        if not plan_name:
+            self.current_state = "error"
+            self.error_message = "exec_config has no plan_name"
+            return False
+
+        plans = self._plans if self._plans is not None else _default_plan_registry()
+        spec = plans.get(plan_name)
+        if spec is None:
+            self.current_state = "error"
+            self.error_message = f"unknown plan {plan_name!r}"
+            return False
+
+        try:
+            params = spec.schema.model_validate(plan_args)
+            devices = _resolve_devices(self._devices_source)
+            self._plan_gen = spec.plan(dict(devices), params)
+        except Exception as exc:
+            self.current_state = "error"
+            self.error_message = f"failed to build plan {plan_name!r}: {exc}"
+            return False
+
+        self.current_state = "armed"
+        self.error_message = None
+        self._stop_requested = False
+        self._completion = 0.0
+        return True
+
+    def start_scan_thread(self) -> None:
+        """Run the plan built by `reinitialize()` in a daemon thread. Non-blocking.
+
+        Deliberately minimal: all plan resolution/validation already happened
+        in `reinitialize()`, so the only way this raises is thread creation
+        itself failing — not a partially-built scan.
+        """
+        if self._plan_gen is None:
+            raise RuntimeError("start_scan_thread() called before a successful reinitialize()")
+
+        self.current_state = "running"
+        self._thread = threading.Thread(target=self._run, name="bluesky-scanner", daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        """The daemon thread body: drive the RunEngine, classify how it ended.
+
+        `RE.abort()` called from another thread (see `stop_scanning_thread`)
+        interrupts `RE(...)` here — depending on bluesky version/timing this
+        surfaces either as `RE(...)` returning normally (an "abort" exit
+        status recorded in the stop doc) or as an exception out of `RE(...)`
+        (e.g. `RunEngineInterrupted`, confirmed against a real RunEngine).
+        Either way, `_stop_requested` (set before `RE.abort()` is called) is
+        what distinguishes an intentional stop from a genuine plan failure —
+        not the exception's presence.
+        """
+        try:
+            self.RE(self._plan_gen)
+        except Exception as exc:
+            if self._stop_requested:
+                self.current_state = "stopped"
+                self._completion = 1.0
+            else:
+                logger.warning("BlueskyScanner: RunEngine plan failed", exc_info=True)
+                self.error_message = str(exc)
+                self.current_state = "error"
+        else:
+            self.current_state = "stopped" if self._stop_requested else "completed"
+            self._completion = 1.0
+
+    def stop_scanning_thread(self) -> None:
+        """Abort the running scan. Safe to call even if not active.
+
+        `RunEngine.abort()`/`.pause()`/`.resume()` are bluesky's documented
+        cross-thread control primitives — calling `abort()` from a thread
+        other than the one running `RE(...)` is the supported way to stop a
+        RunEngine driven in a background thread (as this one is).
+        """
+        self._stop_requested = True
+        try:
+            self.RE.abort(reason="stop_scanning_thread called")
+        except Exception:
+            logger.debug("BlueskyScanner: RE.abort() raised (may not be running)", exc_info=True)
+        if self._thread is not None:
+            self._thread.join(timeout=10)
+
+    def is_scanning_active(self) -> bool:
+        return bool(self._thread is not None and self._thread.is_alive())
+
+    def estimate_current_completion(self) -> float:
+        return self._completion

--- a/src/osprey/services/bluesky_bridge/security.py
+++ b/src/osprey/services/bluesky_bridge/security.py
@@ -1,0 +1,48 @@
+"""The Bluesky bridge's promote-token gate.
+
+``POST /runs/{id}/promote`` (task 1.5's ``app.py``) is the only HTTP route that
+starts a real scan; this module is its sole guard. Fail-closed by design: if
+``BLUESKY_PROMOTE_TOKEN`` isn't set in the bridge process's environment, the
+promote path is simply not armed, regardless of what header a caller sends.
+This is arming/network protection only — the authoritative safety check is the
+agent-side ``launch_scan`` tool's in-tool ``writes_enabled`` re-read (task 1.8),
+which runs before this token is ever sent. Mirrors BELLA's
+``runs.require_armed`` / ``promote_intent`` token check.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+
+from fastapi import HTTPException
+
+_PROMOTE_TOKEN_ENV = "BLUESKY_PROMOTE_TOKEN"
+
+
+def require_armed() -> str:
+    """Return the configured promote token, or raise 503 if none is set.
+
+    Unset means the operator has not armed promotion for this bridge instance
+    at all — the failure detail names the missing env var but never a token
+    value (there isn't one to leak).
+    """
+    expected = os.environ.get(_PROMOTE_TOKEN_ENV)
+    if not expected:
+        raise HTTPException(
+            status_code=503,
+            detail=f"promotion disabled: {_PROMOTE_TOKEN_ENV} is not configured",
+        )
+    return expected
+
+
+def verify_promote_token(header: str | None) -> None:
+    """Raise 503 (unarmed) or 403 (mismatch) unless ``header`` matches the armed token.
+
+    Compares in constant time via :func:`secrets.compare_digest` so a mismatch
+    can't be distinguished by timing. The error details never echo the
+    expected or received token.
+    """
+    expected = require_armed()
+    if not secrets.compare_digest(header or "", expected):
+        raise HTTPException(status_code=403, detail="invalid or missing promote token")

--- a/src/osprey/services/bluesky_bridge/security.py
+++ b/src/osprey/services/bluesky_bridge/security.py
@@ -8,6 +8,22 @@ This is arming/network protection only — the authoritative safety check is the
 agent-side ``launch_scan`` tool's in-tool ``writes_enabled`` re-read (task 1.8),
 which runs before this token is ever sent. Mirrors BELLA's
 ``runs.require_armed`` / ``promote_intent`` token check.
+
+Threat model note (task 2.11c): arming/network protection assumes the agent's
+own code execution can't read this token back out of the deploy environment.
+That assumption holds for the python-executor's container execution_method
+(fs/network isolated from the project ``.env``), but NOT for its local
+execution_method — agent-authored code there runs unsandboxed on the host
+(cwd=project_root) and can trivially ``open(".env")`` or read
+``config.yml``'s ``scan.promote_token``, then call this route directly,
+bypassing ``launch_scan``'s ``writes_enabled`` gate entirely. Because of this,
+``osprey.deployment.container_lifecycle`` refuses to mint
+``BLUESKY_PROMOTE_TOKEN`` (leaving this bridge permanently unarmed, i.e.
+``require_armed`` keeps 503ing) whenever ``control_system.writes_enabled`` and
+``execution.execution_method: local`` are both set — see
+``container_lifecycle._local_exec_arming_unsafe``. Container execution is
+required to use this feature with writes enabled. Full write-safety
+threat-model writeup: Phase 3 task 3.6 (how-to guide, not yet written).
 """
 
 from __future__ import annotations

--- a/src/osprey/templates/services/bluesky/.dockerignore
+++ b/src/osprey/templates/services/bluesky/.dockerignore
@@ -1,0 +1,13 @@
+# Build-context hygiene for the bluesky-bridge image.
+#
+# The Dockerfile only needs the locally-built osprey wheel (*.whl) from this
+# context; everything else here is either build metadata or not needed at
+# image-build time. Keeping them out of the build context speeds the build
+# and avoids baking a stale .env into the image.
+**/__pycache__/
+*.pyc
+.git/
+.env
+# Compose files + templates are runtime/deploy artifacts, not image inputs.
+docker-compose.yml
+*.j2

--- a/src/osprey/templates/services/bluesky/Dockerfile
+++ b/src/osprey/templates/services/bluesky/Dockerfile
@@ -1,0 +1,40 @@
+# Image for the Bluesky bridge service (osprey.services.bluesky_bridge): a
+# FastAPI process owning the Bluesky RunEngine + ophyd-async devices, reached
+# by the `scan` MCP server over HTTP.
+#
+# osprey install strategy (matches the framework's --dev convention):
+#   * dev builds  — `osprey deploy up --dev` drops a locally-built wheel into the
+#     build context; if a *.whl is present we install that (so unreleased code
+#     is included).
+#   * prod builds — no wheel present, so install the pinned release from PyPI.
+# Both paths install the `bluesky-bridge` extra on top of the framework's core
+# FastAPI/uvicorn deps, pulling in bluesky/ophyd-async/tiled for the real
+# (non-Fake) Scanner implementation.
+# This image is built locally by `osprey deploy up`; override with
+# OSPREY_BLUESKY_BRIDGE_IMAGE to use a prebuilt/published image.
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install osprey: prefer a locally-built wheel (dev), else the pinned PyPI release.
+# A C toolchain is needed at install time to compile native deps; it's purged
+# in the same layer so it doesn't bloat the final image.
+ARG OSPREY_VERSION=""
+COPY . /tmp/ctx/
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential python3-dev \
+    && if ls /tmp/ctx/*.whl >/dev/null 2>&1; then \
+        echo "Installing osprey from local wheel (dev build)" \
+        && whl="$(ls /tmp/ctx/*.whl | head -n1)" \
+        && pip install --no-cache-dir "${whl}[bluesky-bridge]" ; \
+    elif [ -n "$OSPREY_VERSION" ]; then \
+        echo "Installing osprey-framework[bluesky-bridge]==$OSPREY_VERSION from PyPI" \
+        && pip install --no-cache-dir "osprey-framework[bluesky-bridge]==$OSPREY_VERSION" ; \
+    else \
+        echo "Installing osprey-framework[bluesky-bridge] (latest) from PyPI" \
+        && pip install --no-cache-dir "osprey-framework[bluesky-bridge]" ; \
+    fi \
+    && apt-get purge -y build-essential python3-dev \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* /tmp/ctx

--- a/src/osprey/templates/services/bluesky/docker-compose.yml.j2
+++ b/src/osprey/templates/services/bluesky/docker-compose.yml.j2
@@ -1,0 +1,92 @@
+# The bluesky-bridge service owns the Bluesky RunEngine + ophyd-async devices
+# behind a FastAPI HTTP boundary (see src/osprey/services/bluesky_bridge/).
+# `osprey deploy up` builds its image locally on first run; subsequent runs
+# reuse the local tag. To use a prebuilt/published image instead, set
+# OSPREY_BLUESKY_BRIDGE_IMAGE (e.g. OSPREY_BLUESKY_BRIDGE_IMAGE=my-registry/osprey-bluesky-bridge:dev).
+# Use `osprey deploy up --dev` to bake in your local osprey checkout (incl.
+# unreleased code) via a wheel; otherwise the image installs osprey from PyPI.
+
+services:
+  bluesky-bridge:
+    image: ${OSPREY_BLUESKY_BRIDGE_IMAGE:-{{ services.bluesky.image | default('osprey-bluesky-bridge:local') }}}
+    build:
+      # With multiple `-f` compose files, ALL relative paths (build contexts and
+      # bind mounts alike) resolve against the FIRST file's dir — the compose
+      # project directory, build/services/ — not this file's own subdir. So the
+      # context is ./bluesky, matching the volume-path convention below.
+      context: ./bluesky
+      dockerfile: Dockerfile
+      args:
+        OSPREY_VERSION: "{{ osprey_version | default('') }}"
+    container_name: osprey-bluesky-bridge
+    command:
+      [
+        "uvicorn",
+        "osprey.services.bluesky_bridge.app:app",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "{{ services.bluesky.port | default(8090) }}",
+      ]
+    labels:
+      osprey.project.name: "{{ osprey_labels.project_name }}"
+      osprey.project.root: "{{ osprey_labels.project_root }}"
+      osprey.deployed.at: "{{ osprey_labels.deployed_at }}"
+    restart: unless-stopped
+    ports:
+      - "{{ deployment.bind_address | default('127.0.0.1') }}:{{ services.bluesky.port | default(8090) }}:{{ services.bluesky.port | default(8090) }}"
+    environment:
+      # No :-default — an unset token must stay EMPTY so the bridge's
+      # POST /runs/{id}/promote route fails closed (HTTP 503) rather than
+      # booting with a guessable secret. `osprey deploy up` auto-generates a
+      # strong random token into the project .env when unset (see
+      # container_lifecycle.py's per-service token-mint map).
+      BLUESKY_PROMOTE_TOKEN: ${BLUESKY_PROMOTE_TOKEN}
+      TZ: {{ system.timezone }}
+{% if services.bluesky.demo_scanner | default(false) %}
+      # Deploy-smoke-demo / tutorial only: tells app.py's guarded startup hook
+      # (task 2.14a) to wire a real bluesky RunEngine against MOCK ophyd-async
+      # devices (devices/mock.py) instead of the Phase 1 no-op FakeScanner.
+      # NEVER set services.bluesky.demo_scanner for a facility wiring real
+      # EPICS hardware — it would silently override real device/plan wiring
+      # with an in-memory mock scanner.
+      BLUESKY_DEMO_SCANNER: "true"
+{% endif %}
+    networks:
+      - osprey-network
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:{{ services.bluesky.port | default(8090) }}/health').status==200 else 1)\""]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      # Grace period before failed probes count — uvicorn/FastAPI startup and
+      # the first image build (which bakes in the bluesky-bridge extra's
+      # dependencies at build time, not at container start) take a few seconds.
+      start_period: 15s
+{% if services.bluesky.tiled_enabled | default(false) %}
+
+  # OPTIONAL: a local Tiled server for the bridge's TiledWriter subscription
+  # (Task 2.7) to persist run documents to. Enabled by setting
+  # `services.bluesky.tiled_enabled: true` in config.yml; loopback/osprey-network
+  # only, same as the bridge itself. Not required for Phase 2's FakeScanner path.
+  tiled:
+    image: ${OSPREY_TILED_IMAGE:-ghcr.io/bluesky/tiled:latest}
+    container_name: osprey-bluesky-tiled
+    restart: unless-stopped
+    ports:
+      - "{{ deployment.bind_address | default('127.0.0.1') }}:{{ services.bluesky.tiled_port | default(8091) }}:8000"
+    environment:
+      TZ: {{ system.timezone }}
+    volumes:
+      - bluesky_tiled_catalog:/data
+    networks:
+      - osprey-network
+{% endif %}
+
+networks:
+  osprey-network:
+{% if services.bluesky.tiled_enabled | default(false) %}
+
+volumes:
+  bluesky_tiled_catalog:
+{% endif %}

--- a/tests/cli/test_killswitch_scan_deny.py
+++ b/tests/cli/test_killswitch_scan_deny.py
@@ -1,0 +1,144 @@
+"""Tests for the generalized kill-switch deny/remove_ask extension covering scan.
+
+``build_claude_code_context``'s writes-off kill-switch block (previously
+hardcoded to ``controls``/``python`` by name) now walks ``FRAMEWORK_SERVERS``
+for any hooks_pre rule gated by ``_WRITES_CHECK``, so a new write server (e.g.
+``scan``'s ``launch_scan``) is covered automatically with no per-server code
+change. These tests pin: scan's launch_scan is hard-denied when writes are
+off, stop_scan (approval-only, no writes-check) is NEVER denied or
+removed-from-ask (the kill switch must not block stopping a scan), the
+existing controls/python behavior is preserved, and an extends clone gets the
+rewritten-prefix matcher.
+"""
+
+import yaml
+
+from osprey.cli.templates import claude_code
+from osprey.cli.templates.manager import TemplateManager
+
+_PROJECT_COUNTER = 0
+
+
+def _build_ctx(tmp_path, *, writes_enabled: bool, claude_code_overrides: dict | None = None):
+    """Create a project, apply config overrides, and return the built context.
+
+    Each call gets a unique project name/output dir (TemplateManager refuses
+    to create a project in an already-existing directory), so callers can
+    invoke this helper more than once per test.
+    """
+    global _PROJECT_COUNTER
+    _PROJECT_COUNTER += 1
+    manager = TemplateManager()
+    project_dir = manager.create_project(
+        project_name=f"killswitch-scan-{_PROJECT_COUNTER}",
+        output_dir=tmp_path,
+        data_bundle="control_assistant",
+        context={"channel_finder_mode": "hierarchical"},
+    )
+    config = yaml.safe_load((project_dir / "config.yml").read_text())
+    config["control_system"]["writes_enabled"] = writes_enabled
+    if claude_code_overrides is not None:
+        config["claude_code"] = claude_code_overrides
+    (project_dir / "config.yml").write_text(yaml.dump(config))
+
+    return claude_code.build_claude_code_context(
+        manager.template_root, manager.jinja_env, project_dir, config
+    )
+
+
+# ---------------------------------------------------------------------------
+# scan.launch_scan — hard deny when writes are off
+# ---------------------------------------------------------------------------
+
+
+def test_scan_launch_denied_when_writes_off(tmp_path):
+    ctx = _build_ctx(
+        tmp_path,
+        writes_enabled=False,
+        claude_code_overrides={"servers": {"scan": {"enabled": True}}},
+    )
+    perms = ctx["facility_permissions"]
+    assert "mcp__scan__launch_scan" in perms["deny"]
+
+
+def test_scan_launch_not_denied_when_writes_on(tmp_path):
+    ctx = _build_ctx(
+        tmp_path,
+        writes_enabled=True,
+        claude_code_overrides={"servers": {"scan": {"enabled": True}}},
+    )
+    perms = ctx["facility_permissions"]
+    assert "mcp__scan__launch_scan" not in perms.get("deny", [])
+    assert "mcp__scan__launch_scan" not in perms.get("remove_ask", [])
+
+
+def test_scan_disabled_server_contributes_nothing(tmp_path):
+    """scan is opt-in (default_enabled=False) — an un-enabled scan server must
+    not contribute a deny entry even when writes are off."""
+    ctx = _build_ctx(tmp_path, writes_enabled=False)
+    perms = ctx["facility_permissions"]
+    assert "mcp__scan__launch_scan" not in perms.get("deny", [])
+    assert "mcp__scan__launch_scan" not in perms.get("remove_ask", [])
+
+
+# ---------------------------------------------------------------------------
+# scan.stop_scan — never denied or removed-from-ask (safe direction)
+# ---------------------------------------------------------------------------
+
+
+def test_scan_stop_never_denied_or_removed(tmp_path):
+    """stop_scan carries approval only (no _WRITES_CHECK) — the kill switch
+    must never block stopping a scan, regardless of writes_enabled."""
+    for writes_enabled in (True, False):
+        ctx = _build_ctx(
+            tmp_path,
+            writes_enabled=writes_enabled,
+            claude_code_overrides={"servers": {"scan": {"enabled": True}}},
+        )
+        perms = ctx["facility_permissions"]
+        assert "mcp__scan__stop_scan" not in perms.get("deny", [])
+        assert "mcp__scan__stop_scan" not in perms.get("remove_ask", [])
+
+
+# ---------------------------------------------------------------------------
+# Regression parity: controls/python behavior preserved after generalizing
+# ---------------------------------------------------------------------------
+
+
+def test_controls_channel_write_still_denied_when_writes_off(tmp_path):
+    ctx = _build_ctx(tmp_path, writes_enabled=False)
+    perms = ctx["facility_permissions"]
+    assert "mcp__controls__channel_write" in perms["deny"]
+
+
+def test_python_execute_still_removed_from_ask_when_writes_off(tmp_path):
+    ctx = _build_ctx(tmp_path, writes_enabled=False)
+    perms = ctx["facility_permissions"]
+    assert "mcp__python__execute" in perms["remove_ask"]
+    # Must not ALSO be hard-denied — python's execute has a legitimate
+    # read-only path and is handled via remove_ask, not deny.
+    assert "mcp__python__execute" not in perms.get("deny", [])
+
+
+def test_nothing_added_when_writes_enabled(tmp_path):
+    ctx = _build_ctx(tmp_path, writes_enabled=True)
+    perms = ctx["facility_permissions"]
+    assert "mcp__controls__channel_write" not in perms.get("deny", [])
+    assert "mcp__python__execute" not in perms.get("remove_ask", [])
+
+
+# ---------------------------------------------------------------------------
+# Extends clone: rewritten-prefix matcher
+# ---------------------------------------------------------------------------
+
+
+def test_extends_clone_of_scan_denied_with_rewritten_prefix(tmp_path):
+    ctx = _build_ctx(
+        tmp_path,
+        writes_enabled=False,
+        claude_code_overrides={"servers": {"scan2": {"extends": "scan"}}},
+    )
+    perms = ctx["facility_permissions"]
+    assert "mcp__scan2__launch_scan" in perms["deny"]
+    # The template name itself must not leak into the clone's deny entry.
+    assert "mcp__scan__launch_scan" not in perms["deny"]

--- a/tests/cli/test_killswitch_scan_driftguard.py
+++ b/tests/cli/test_killswitch_scan_driftguard.py
@@ -1,0 +1,137 @@
+"""Drift guard: the rendered settings.json kill-switch stays in sync with
+FRAMEWORK_SERVERS' write-gated tools.
+
+Task 1.11 generalized the kill-switch's writes-off deny/remove_ask block in
+``build_claude_code_context`` to walk ``FRAMEWORK_SERVERS`` for any
+``hooks_pre`` rule gated by ``_WRITES_CHECK``, so a new write server (e.g.
+scan's ``launch_scan``) is covered automatically with no per-server code
+change. ``test_killswitch_scan_deny.py`` pins that behavior at the
+``build_claude_code_context`` context-dict level.
+
+This module is the drift guard proper: it exercises the FULL render pipeline
+(``TemplateManager.create_project`` + ``regenerate_claude_code`` ->
+``settings.json.j2``) and reads the actual on-disk ``.claude/settings.json``,
+and it computes the expected write-gated tool set *dynamically* from
+``FRAMEWORK_SERVERS`` rather than hardcoding tool names. So it catches both
+kinds of drift: a future change that decouples the template from
+``facility_permissions.deny``/``remove_ask``, and a new
+``_WRITES_CHECK``-gated tool added to ``FRAMEWORK_SERVERS`` with no matching
+kill-switch coverage — including ``mcp__scan__launch_scan`` specifically, but
+not limited to it.
+"""
+
+from __future__ import annotations
+
+import json
+
+import yaml
+
+from osprey.cli.templates import claude_code
+from osprey.cli.templates.claude_code import _MIXED_READ_WRITE_TEMPLATES
+from osprey.cli.templates.manager import TemplateManager
+from osprey.registry.mcp import _WRITES_CHECK, FRAMEWORK_SERVERS
+
+_PROJECT_COUNTER = 0
+
+
+def _write_gated_matchers() -> dict[str, str]:
+    """Map {template_name: matcher} for every FRAMEWORK_SERVERS hooks_pre rule
+    gated by _WRITES_CHECK -- the full set the kill switch must cover."""
+    matchers: dict[str, str] = {}
+    for template_name, template_def in FRAMEWORK_SERVERS.items():
+        for rule in template_def.hooks_pre:
+            if _WRITES_CHECK in rule.hooks:
+                matchers[template_name] = rule.matcher
+    return matchers
+
+
+def _build_project(tmp_path, *, writes_enabled: bool):
+    """Create a real project on disk with every write-gated server enabled.
+
+    Each call gets a unique project name (TemplateManager refuses to create a
+    project in an already-existing directory).
+    """
+    global _PROJECT_COUNTER
+    _PROJECT_COUNTER += 1
+    manager = TemplateManager()
+    project_dir = manager.create_project(
+        project_name=f"killswitch-driftguard-{_PROJECT_COUNTER}",
+        output_dir=tmp_path,
+        data_bundle="control_assistant",
+        context={"channel_finder_mode": "hierarchical"},
+    )
+    config = yaml.safe_load((project_dir / "config.yml").read_text())
+    config["control_system"]["writes_enabled"] = writes_enabled
+    # Force-enable every write-gated template (some, like scan, are opt-in) so
+    # the rendered settings.json actually exercises the full write-gated set,
+    # not just whatever happens to be on by default.
+    config.setdefault("claude_code", {})["servers"] = {
+        template_name: {"enabled": True} for template_name in _write_gated_matchers()
+    }
+    (project_dir / "config.yml").write_text(yaml.dump(config))
+
+    # Re-render .claude/settings.json (and the rest of the Claude Code
+    # integration) from the just-edited config.yml -- create_project() already
+    # rendered once with the *original* config, before writes_enabled/servers
+    # were overridden above.
+    claude_code.regenerate_claude_code(manager.template_root, manager.jinja_env, project_dir)
+
+    return project_dir
+
+
+def _rendered_permissions(project_dir) -> dict:
+    settings_path = project_dir / ".claude" / "settings.json"
+    settings = json.loads(settings_path.read_text())
+    return settings["permissions"]
+
+
+def test_every_write_gated_tool_is_covered_when_writes_off(tmp_path):
+    """Drift guard: every _WRITES_CHECK-gated matcher across FRAMEWORK_SERVERS
+    ends up hard-denied (or, for the documented read/write-mixed exception,
+    pulled from ask) in the rendered settings.json when writes are off.
+
+    A future write-gated tool added to FRAMEWORK_SERVERS with no matching
+    kill-switch coverage fails this test with no code change required here.
+    """
+    project_dir = _build_project(tmp_path, writes_enabled=False)
+    perms = _rendered_permissions(project_dir)
+    deny = set(perms["deny"])
+    ask = set(perms["ask"])
+
+    matchers = _write_gated_matchers()
+    assert matchers, "no _WRITES_CHECK-gated tool found in FRAMEWORK_SERVERS at all"
+
+    for template_name, matcher in matchers.items():
+        if template_name in _MIXED_READ_WRITE_TEMPLATES:
+            assert matcher not in ask, (
+                f"{matcher!r} ({template_name}) is documented read/write-mixed and "
+                f"must be pulled from ask, but is still present"
+            )
+        else:
+            assert matcher in deny, (
+                f"{matcher!r} ({template_name}) is _WRITES_CHECK-gated but missing "
+                f"from the rendered settings.json deny list with writes disabled"
+            )
+
+
+def test_scan_launch_scan_specifically_hard_denied_when_writes_off(tmp_path):
+    """The concrete case this drift guard exists for: scan's launch_scan."""
+    project_dir = _build_project(tmp_path, writes_enabled=False)
+    perms = _rendered_permissions(project_dir)
+    assert "mcp__scan__launch_scan" in perms["deny"]
+
+
+def test_scan_launch_scan_not_denied_when_writes_on(tmp_path):
+    project_dir = _build_project(tmp_path, writes_enabled=True)
+    perms = _rendered_permissions(project_dir)
+    assert "mcp__scan__launch_scan" not in perms["deny"]
+    assert "mcp__scan__launch_scan" not in perms.get("remove_ask", [])
+
+
+def test_scan_stop_scan_never_denied_regardless_of_writes_enabled(tmp_path):
+    """stop_scan carries approval only (no _WRITES_CHECK) -- the kill switch
+    must never block stopping a scan, in either direction."""
+    for writes_enabled in (True, False):
+        project_dir = _build_project(tmp_path, writes_enabled=writes_enabled)
+        perms = _rendered_permissions(project_dir)
+        assert "mcp__scan__stop_scan" not in perms["deny"]

--- a/tests/cli/test_scan_service_registration.py
+++ b/tests/cli/test_scan_service_registration.py
@@ -1,0 +1,227 @@
+"""Tests for the ``_inject_bluesky`` build step in ``osprey.cli.build_cmd``.
+
+Covers the responsibilities of the bluesky-injection step: copying the bundled
+bluesky compose template, writing the ``services.bluesky`` config +
+registering it in ``deployed_services`` (additively) so
+``find_service_config`` resolves it, and confirming the feature stays
+opt-in — a profile with no ``bluesky:`` key injects nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+from osprey.cli.build_cmd import _inject_bluesky
+from osprey.cli.build_profile import BlueskyConfig, _parse_profile
+from osprey.deployment.compose_generator import find_service_config
+
+
+def _write_config(project_path: Path) -> None:
+    """Write a minimal config.yml with a pre-existing deployed service."""
+    yaml = YAML()
+    config = {
+        "deployed_services": ["postgresql"],
+        "services": {"postgresql": {}},
+    }
+    with open(project_path / "config.yml", "w") as fh:
+        yaml.dump(config, fh)
+
+
+def _read_config(project_path: Path) -> dict:
+    """Reload config.yml as a plain dict."""
+    yaml = YAML()
+    with open(project_path / "config.yml") as fh:
+        return yaml.load(fh)
+
+
+def test_inject_bluesky_default_config(tmp_path: Path) -> None:
+    """Default BlueskyConfig copies the template and registers config additively."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(), project_path)
+
+    # Compose template + Dockerfile copied.
+    assert (project_path / "services" / "bluesky" / "docker-compose.yml.j2").is_file()
+    assert (project_path / "services" / "bluesky" / "Dockerfile").is_file()
+
+    config = _read_config(project_path)
+    svc = config["services"]["bluesky"]
+    assert svc["path"] == "./services/bluesky"
+    assert svc["port"] == 8090
+    assert svc["tiled_enabled"] is False
+    assert svc["tiled_port"] == 8091
+    # demo_scanner defaults OFF — a facility profile must opt in explicitly;
+    # it must never silently override real device/plan wiring.
+    assert svc["demo_scanner"] is False
+    # No pinned image: the service builds the local image (compose template
+    # defaults to osprey-bluesky-bridge:local + a build: section).
+    assert "image" not in svc
+
+    # deployed_services is additive — keeps postgresql, adds bluesky.
+    deployed = [str(s) for s in config["deployed_services"]]
+    assert "postgresql" in deployed
+    assert "bluesky" in deployed
+
+
+def test_inject_bluesky_custom_ports_and_tiled(tmp_path: Path) -> None:
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(port=9500, tiled_enabled=True, tiled_port=9501), project_path)
+
+    config = _read_config(project_path)
+    svc = config["services"]["bluesky"]
+    assert svc["port"] == 9500
+    assert svc["tiled_enabled"] is True
+    assert svc["tiled_port"] == 9501
+
+
+def test_inject_bluesky_demo_scanner_opt_in(tmp_path: Path) -> None:
+    """demo_scanner=True is written through to config.yml (2.14a's app.py hook
+    reads BLUESKY_DEMO_SCANNER off the rendered compose env; this test only
+    covers this task's half — the config.yml/compose passthrough)."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(demo_scanner=True), project_path)
+
+    config = _read_config(project_path)
+    assert config["services"]["bluesky"]["demo_scanner"] is True
+
+
+def test_inject_bluesky_idempotent_rerun(tmp_path: Path) -> None:
+    """Re-running the injection (e.g. a second build) doesn't duplicate deployed_services."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(), project_path)
+    _inject_bluesky(BlueskyConfig(port=9999), project_path)
+
+    config = _read_config(project_path)
+    deployed = [str(s) for s in config["deployed_services"]]
+    assert deployed.count("bluesky") == 1
+    # Second call's config wins (last-write, matching _inject_dispatch's contract).
+    assert config["services"]["bluesky"]["port"] == 9999
+
+
+def test_inject_bluesky_missing_config_yml_is_a_noop(tmp_path: Path) -> None:
+    """No config.yml (unusual, but shouldn't crash the build) — just warns and returns."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+
+    _inject_bluesky(BlueskyConfig(), project_path)  # must not raise
+
+    # Template is still copied before the config.yml check.
+    assert (project_path / "services" / "bluesky" / "docker-compose.yml.j2").is_file()
+    assert not (project_path / "config.yml").exists()
+
+
+def test_find_service_config_resolves_bluesky(tmp_path: Path) -> None:
+    """After injection, find_service_config('bluesky') resolves path + template."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(), project_path)
+
+    config = _read_config(project_path)
+    service_config, template_path = find_service_config(config, "bluesky")
+    assert service_config is not None
+    assert service_config["path"] == "./services/bluesky"
+    assert template_path == "./services/bluesky/docker-compose.yml.j2"
+
+
+def _render_copied_compose(project_path: Path, config: dict) -> dict:
+    """Render the compose template `_inject_bluesky` copied, using the same
+    context-key contract `compose_generator.render_template` uses, and parse
+    the result. Closes the loop end-to-end: config.yml written by build_cmd.py
+    -> env var read by docker-compose.yml.j2 -> app.py's guarded startup hook
+    (2.14a) reads it back out of the container environment.
+    """
+    import yaml as pyyaml
+    from jinja2 import Environment, FileSystemLoader
+
+    env = Environment(loader=FileSystemLoader(str(project_path / "services" / "bluesky")))
+    tmpl = env.get_template("docker-compose.yml.j2")
+    ctx = {
+        "osprey_labels": {
+            "project_name": "p",
+            "project_root": str(project_path),
+            "deployed_at": "x",
+        },
+        "osprey_version": "",
+        "system": {"timezone": "UTC"},
+        "deployment": {},
+        "services": config["services"],
+    }
+    return pyyaml.safe_load(tmpl.render(ctx))
+
+
+def test_demo_scanner_env_passthrough_round_trips_through_compose(tmp_path: Path) -> None:
+    """The config.yml demo_scanner flag `_inject_bluesky` writes must actually
+    reach the container as BLUESKY_DEMO_SCANNER — the other half of 2.14a's
+    contract (app.py reads the env var this template renders)."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(demo_scanner=True), project_path)
+    config = _read_config(project_path)
+    rendered = _render_copied_compose(project_path, config)
+    assert rendered["services"]["bluesky-bridge"]["environment"]["BLUESKY_DEMO_SCANNER"] == "true"
+
+
+def test_demo_scanner_off_by_default_omits_env_var(tmp_path: Path) -> None:
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(), project_path)
+    config = _read_config(project_path)
+    rendered = _render_copied_compose(project_path, config)
+    assert "BLUESKY_DEMO_SCANNER" not in rendered["services"]["bluesky-bridge"]["environment"]
+
+
+# ---------------------------------------------------------------------------
+# Build-profile parsing: bluesky stays opt-in, not default-on.
+# ---------------------------------------------------------------------------
+
+
+def test_profile_without_bluesky_key_leaves_bluesky_none() -> None:
+    profile = _parse_profile({"name": "no-scan-here"})
+    assert profile.bluesky is None
+
+
+def test_profile_bluesky_key_parses_overrides() -> None:
+    profile = _parse_profile(
+        {
+            "name": "with-scan",
+            "bluesky": {
+                "port": 8123,
+                "tiled_enabled": True,
+                "tiled_port": 8124,
+                "demo_scanner": True,
+            },
+        }
+    )
+    assert profile.bluesky is not None
+    assert profile.bluesky.port == 8123
+    assert profile.bluesky.tiled_enabled is True
+    assert profile.bluesky.tiled_port == 8124
+    assert profile.bluesky.demo_scanner is True
+
+
+def test_profile_bluesky_key_defaults_when_empty_mapping() -> None:
+    profile = _parse_profile({"name": "with-scan-defaults", "bluesky": {}})
+    assert profile.bluesky is not None
+    assert profile.bluesky.port == 8090
+    assert profile.bluesky.tiled_enabled is False
+    assert profile.bluesky.tiled_port == 8091
+    assert profile.bluesky.demo_scanner is False

--- a/tests/deployment/test_bluesky_arming_guard.py
+++ b/tests/deployment/test_bluesky_arming_guard.py
@@ -1,0 +1,212 @@
+"""Tests for the local-exec arming guard (task 2.11c).
+
+The local python-executor path runs agent-authored code with cwd=project_root
+and no filesystem/network sandboxing, so it can read BLUESKY_PROMOTE_TOKEN
+straight out of .env/config.yml and POST the bridge's /runs/{id}/promote
+directly — bypassing launch_scan's in-tool writes_enabled re-check entirely.
+The container execution_method is fs/network isolated and doesn't have this
+exposure. Per the user ruling (2026-07-06, "guard + document"),
+container_lifecycle._ensure_service_tokens must refuse to mint
+BLUESKY_PROMOTE_TOKEN — leaving the bridge unarmed (its own require_armed()
+then 503s) — whenever control_system.writes_enabled and
+execution.execution_method=local are both true, and must otherwise behave
+exactly as task 2.10 shipped it.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from osprey.deployment import container_lifecycle
+
+
+@pytest.fixture
+def captured_argv(monkeypatch, tmp_path):
+    """Patch deploy_up's collaborators for a project with only 'bluesky' deployed."""
+    captured: dict = {}
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+
+    def _fake_run(cmd, env=None, check=False):
+        captured["cmd"] = cmd
+
+    monkeypatch.setattr(container_lifecycle.subprocess, "run", _fake_run)
+    return captured
+
+
+def _patch_prepare_compose_files(monkeypatch, config: dict) -> None:
+    monkeypatch.setattr(
+        container_lifecycle,
+        "prepare_compose_files",
+        lambda *a, **k: (config, ["docker-compose.yml"]),
+    )
+
+
+@pytest.fixture
+def _clean_token_env(monkeypatch):
+    monkeypatch.delenv("BLUESKY_PROMOTE_TOKEN", raising=False)
+    monkeypatch.delenv("EVENT_DISPATCHER_TOKEN", raising=False)
+    monkeypatch.delenv("DISPATCH_WORKER_TOKEN", raising=False)
+
+
+def _parse_env(tmp_path):
+    from osprey.utils.dotenv import parse_dotenv_file
+
+    p = tmp_path / ".env"
+    return parse_dotenv_file(p) if p.is_file() else {}
+
+
+def _config(**overrides) -> dict:
+    base: dict = {"deployed_services": ["bluesky"]}
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# _local_exec_arming_unsafe: pure function, easiest to pin down directly.
+# ---------------------------------------------------------------------------
+
+
+def test_arming_unsafe_true_when_writes_enabled_and_local():
+    config = {
+        "control_system": {"writes_enabled": True},
+        "execution": {"execution_method": "local"},
+    }
+    assert container_lifecycle._local_exec_arming_unsafe(config) is True
+
+
+def test_arming_safe_when_writes_enabled_and_container():
+    config = {
+        "control_system": {"writes_enabled": True},
+        "execution": {"execution_method": "container"},
+    }
+    assert container_lifecycle._local_exec_arming_unsafe(config) is False
+
+
+def test_arming_safe_when_writes_disabled_even_if_local():
+    config = {
+        "control_system": {"writes_enabled": False},
+        "execution": {"execution_method": "local"},
+    }
+    assert container_lifecycle._local_exec_arming_unsafe(config) is False
+
+
+def test_arming_safe_by_default_when_sections_absent():
+    # writes_enabled defaults False, execution_method defaults "container".
+    assert container_lifecycle._local_exec_arming_unsafe({}) is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through deploy_up: the guard must actually suppress the mint.
+# ---------------------------------------------------------------------------
+
+
+def test_bluesky_token_not_minted_when_writes_enabled_and_local(
+    captured_argv, _clean_token_env, monkeypatch, tmp_path, caplog
+):
+    config = _config(
+        control_system={"writes_enabled": True},
+        execution={"execution_method": "local"},
+    )
+    _patch_prepare_compose_files(monkeypatch, config)
+
+    with caplog.at_level(logging.WARNING, logger="deployment.lifecycle"):
+        container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    env = _parse_env(tmp_path)
+    assert "BLUESKY_PROMOTE_TOKEN" not in env
+    assert not (tmp_path / ".env").exists()
+
+    # caplog's handler already calls record.getMessage() (formatting in %args),
+    # so r.message here is the final rendered string — no further % needed.
+    warnings = " ".join(r.message for r in caplog.records)
+    assert "bluesky" in warnings
+    assert "writes_enabled" in warnings
+    assert "local" in warnings
+
+
+def test_bluesky_token_minted_when_writes_enabled_and_container(
+    captured_argv, _clean_token_env, monkeypatch, tmp_path
+):
+    config = _config(
+        control_system={"writes_enabled": True},
+        execution={"execution_method": "container"},
+    )
+    _patch_prepare_compose_files(monkeypatch, config)
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    env = _parse_env(tmp_path)
+    assert env.get("BLUESKY_PROMOTE_TOKEN")
+    assert len(env["BLUESKY_PROMOTE_TOKEN"]) >= 40
+
+
+def test_bluesky_token_minted_when_writes_enabled_and_execution_section_absent(
+    captured_argv, _clean_token_env, monkeypatch, tmp_path
+):
+    """Default execution_method (no `execution:` section at all) is "container" — safe."""
+    config = _config(control_system={"writes_enabled": True})
+    _patch_prepare_compose_files(monkeypatch, config)
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    env = _parse_env(tmp_path)
+    assert env.get("BLUESKY_PROMOTE_TOKEN")
+
+
+def test_bluesky_token_behavior_unchanged_when_writes_disabled(
+    captured_argv, _clean_token_env, monkeypatch, tmp_path
+):
+    """Even with local exec, writes_enabled=False means no bypass risk — mint as usual."""
+    config = _config(
+        control_system={"writes_enabled": False},
+        execution={"execution_method": "local"},
+    )
+    _patch_prepare_compose_files(monkeypatch, config)
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    env = _parse_env(tmp_path)
+    assert env.get("BLUESKY_PROMOTE_TOKEN")
+
+
+def test_guard_does_not_affect_dispatch_tokens(
+    captured_argv, _clean_token_env, monkeypatch, tmp_path
+):
+    """The guard is scoped to bluesky; dispatch tokens mint normally regardless."""
+    config = _config(
+        deployed_services=["bluesky", "event_dispatcher", "dispatch_worker"],
+        control_system={"writes_enabled": True},
+        execution={"execution_method": "local"},
+    )
+    _patch_prepare_compose_files(monkeypatch, config)
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    env = _parse_env(tmp_path)
+    assert "BLUESKY_PROMOTE_TOKEN" not in env
+    assert env.get("EVENT_DISPATCHER_TOKEN")
+    assert env.get("DISPATCH_WORKER_TOKEN")
+
+
+def test_existing_manual_token_left_untouched_under_unsafe_config(
+    captured_argv, monkeypatch, tmp_path
+):
+    """A user-set token is a deliberate override; the guard neither reads nor clobbers it."""
+    (tmp_path / ".env").write_text("BLUESKY_PROMOTE_TOKEN=manually-set\n", encoding="utf-8")
+    config = _config(
+        control_system={"writes_enabled": True},
+        execution={"execution_method": "local"},
+    )
+    _patch_prepare_compose_files(monkeypatch, config)
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    env = _parse_env(tmp_path)
+    assert env["BLUESKY_PROMOTE_TOKEN"] == "manually-set"

--- a/tests/deployment/test_scan_token_mint.py
+++ b/tests/deployment/test_scan_token_mint.py
@@ -1,0 +1,152 @@
+"""Unit tests for the bluesky-bridge auth token in the generalized token-mint map.
+
+Mirrors ``test_container_lifecycle.py``'s dispatch-token coverage, but for the
+``bluesky`` deployed-service entry added to ``_SERVICE_TOKEN_VARS``
+(container_lifecycle.py). Without this mint, the fail-closed bridge
+(``osprey.services.bluesky_bridge.security.require_armed``) 503s on every
+promote attempt after a fresh deploy.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from osprey.deployment import container_lifecycle
+
+
+@pytest.fixture
+def captured_argv(monkeypatch, tmp_path):
+    """Patch deploy_up's collaborators for a project with only 'bluesky' deployed."""
+    captured: dict = {}
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        container_lifecycle,
+        "prepare_compose_files",
+        lambda *a, **k: ({"deployed_services": ["bluesky"]}, ["docker-compose.yml"]),
+    )
+    monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+
+    def _fake_run(cmd, env=None, check=False):
+        captured["cmd"] = cmd
+
+    monkeypatch.setattr(container_lifecycle.subprocess, "run", _fake_run)
+    return captured
+
+
+@pytest.fixture
+def _clean_token_env(monkeypatch):
+    """Ensure the bluesky promote token (and dispatch tokens) are unset in the process env."""
+    monkeypatch.delenv("BLUESKY_PROMOTE_TOKEN", raising=False)
+    monkeypatch.delenv("EVENT_DISPATCHER_TOKEN", raising=False)
+    monkeypatch.delenv("DISPATCH_WORKER_TOKEN", raising=False)
+
+
+def _parse_env(tmp_path):
+    from osprey.utils.dotenv import parse_dotenv_file
+
+    p = tmp_path / ".env"
+    return parse_dotenv_file(p) if p.is_file() else {}
+
+
+def test_bluesky_deploy_generates_promote_token(captured_argv, _clean_token_env, tmp_path):
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True, dev_mode=False)
+
+    env = _parse_env(tmp_path)
+    assert env.get("BLUESKY_PROMOTE_TOKEN")
+    # token_urlsafe(32) → ~43 url-safe chars
+    assert len(env["BLUESKY_PROMOTE_TOKEN"]) >= 40
+    # A deploy with only 'bluesky' deployed must not mint unrelated dispatch tokens.
+    assert "EVENT_DISPATCHER_TOKEN" not in env
+    assert "DISPATCH_WORKER_TOKEN" not in env
+
+
+def test_bluesky_token_generation_is_idempotent(captured_argv, _clean_token_env, tmp_path):
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+    first = _parse_env(tmp_path)
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+    second = _parse_env(tmp_path)
+
+    assert first["BLUESKY_PROMOTE_TOKEN"] == second["BLUESKY_PROMOTE_TOKEN"]
+    # No duplicate keys appended on the second run.
+    text = (tmp_path / ".env").read_text()
+    assert text.count("BLUESKY_PROMOTE_TOKEN=") == 1
+
+
+def test_bluesky_existing_env_token_is_preserved(captured_argv, _clean_token_env, tmp_path):
+    (tmp_path / ".env").write_text("BLUESKY_PROMOTE_TOKEN=my-real-token\n", encoding="utf-8")
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    env = _parse_env(tmp_path)
+    assert env["BLUESKY_PROMOTE_TOKEN"] == "my-real-token"  # untouched
+
+
+def test_bluesky_process_env_token_not_written_to_dotenv(captured_argv, monkeypatch, tmp_path):
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "from-shell")
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    env = _parse_env(tmp_path)
+    # A token resolvable from the process env is not duplicated into .env.
+    assert "BLUESKY_PROMOTE_TOKEN" not in env
+
+
+def test_bluesky_expose_refuses_empty_token(captured_argv, monkeypatch, tmp_path):
+    # A token explicitly set empty must not be auto-overwritten, and --expose must
+    # refuse rather than bind a fail-open server to 0.0.0.0.
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "")
+
+    with pytest.raises(RuntimeError, match="refusing to --expose"):
+        container_lifecycle.deploy_up(
+            str(tmp_path / "config.yml"), detached=True, expose_network=True
+        )
+
+
+def test_bluesky_alongside_dispatch_mints_both_independently(
+    monkeypatch, _clean_token_env, tmp_path
+):
+    """Per-service-instance behavior: deploying bluesky AND dispatch mints all
+    three vars (no cross-service leakage or accidental sharing)."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        container_lifecycle,
+        "prepare_compose_files",
+        lambda *a, **k: (
+            {"deployed_services": ["event_dispatcher", "dispatch_worker", "bluesky"]},
+            ["docker-compose.yml"],
+        ),
+    )
+    monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+    monkeypatch.setattr(container_lifecycle.subprocess, "run", lambda *a, **k: None)
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    env = _parse_env(tmp_path)
+    assert env.get("EVENT_DISPATCHER_TOKEN")
+    assert env.get("DISPATCH_WORKER_TOKEN")
+    assert env.get("BLUESKY_PROMOTE_TOKEN")
+    # All three distinct values — no accidental sharing across services.
+    assert (
+        len(
+            {
+                env["EVENT_DISPATCHER_TOKEN"],
+                env["DISPATCH_WORKER_TOKEN"],
+                env["BLUESKY_PROMOTE_TOKEN"],
+            }
+        )
+        == 3
+    )
+
+
+def test_service_token_vars_map_includes_bluesky():
+    """Locks in the generalized map shape task 2.10 introduces."""
+    assert container_lifecycle._SERVICE_TOKEN_VARS["bluesky"] == ("BLUESKY_PROMOTE_TOKEN",)
+    assert "event_dispatcher" in container_lifecycle._SERVICE_TOKEN_VARS
+    assert "dispatch_worker" in container_lifecycle._SERVICE_TOKEN_VARS

--- a/tests/e2e/test_scan_deploy.py
+++ b/tests/e2e/test_scan_deploy.py
@@ -1,0 +1,313 @@
+"""Full-stack Docker integration test for the Bluesky scan bridge (task 2.14).
+
+Mirrors ``tests/e2e/test_dispatch_deploy.py``'s shape (real ``osprey build`` +
+``osprey deploy up --dev``, real container, real HTTP calls against the
+shipped artifacts) but for the bluesky-bridge service: unlike the dispatch
+worker, the bridge never shells out to an LLM, so this test needs no provider
+API key — ``hello-world``'s bundled ``provider``/``model`` defaults are enough
+for the build to succeed; nothing in the container talks to an LLM.
+
+Uses the ``hello-world`` preset specifically (not ``control-assistant``):
+control-assistant ships its own ``dispatch:`` block by default, which would
+deploy the whole event-dispatcher/dispatch-worker stack (Node + Claude CLI
+image, much slower to build) alongside bluesky for no reason — ``_inject_bluesky``
+only *adds* to ``deployed_services``, it doesn't replace what a preset already
+declares. ``hello-world`` declares no services of its own, so the bluesky
+bridge ends up as the ONLY deployed service, exactly what this test needs.
+
+Enables the bridge via ``--set bluesky.demo_scanner=true`` (a plain CLI
+override — no bundled preset ships ``bluesky:`` by default, since task 2.9's
+generator is opt-in-via-profile, not default-on). ``demo_scanner`` additionally
+tells app.py's guarded startup hook (task 2.14a) to wire a real
+``BlueskyScanner`` against MOCK ophyd-async devices (``devices/mock.py``)
+instead of the Phase 1 no-op ``FakeScanner`` — see that task for the actual
+wiring; this test only asserts the end-to-end behavior it enables. Also pins
+``bluesky.port`` (BRIDGE_PORT below) rather than relying on the 8090 default,
+since this is a shared dev machine and 8090 collided with an unrelated
+pre-existing process during development of this test.
+
+Asserts, against the REAL deployed container:
+  * the bridge binds to 127.0.0.1 (never 0.0.0.0) — ``docker port`` inspection.
+  * BLUESKY_PROMOTE_TOKEN was minted into the project ``.env`` (task 2.10).
+  * the built image contains the unreleased bluesky_bridge modules AND the
+    bluesky-bridge extra (task 2.8's reviewer carry-forward) — NOT merely
+    that the image builds, since a PyPI-based build would silently lack both
+    and this must fail loudly rather than pass on stale code.
+  * a demo ``count`` scan against mock devices (``det1``) promotes, runs to
+    completion, and ``GET /runs/{id}/data`` returns the buffered rows.
+
+CONTAINER SAFETY: every docker/podman invocation below names an exact
+container/image — never a wildcard, never ``system prune``/``--volumes``.
+Teardown goes through ``osprey deploy down`` (the shipped compose teardown
+path), not a raw ``docker rm``/``rmi`` sweep.
+
+Gating: needs Docker. Skipped entirely if unavailable. Lives in ``tests/e2e/``
+(not ``tests/integration/``) so the fast lane (``pytest tests/ --ignore=tests/e2e``,
+see ``ci_check.sh``/``premerge_check.sh``/ci.yml's ``test`` job) never collects
+this ~6-minute real-container build+deploy; it runs instead in its own
+``scan-deploy-e2e`` CI job (mirrors ``dispatch-deploy-e2e``'s setup, minus the
+LLM secret/pre-flight probe this test doesn't need).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+# Deliberately NOT the bluesky-bridge default (8090): this is a shared dev
+# machine with other long-running services, and 8090 was observed colliding
+# with an unrelated pre-existing process during development of this test.
+# Pinned via --set bluesky.port=... below rather than relying on the default.
+BRIDGE_PORT = 18090
+BRIDGE_URL = f"http://localhost:{BRIDGE_PORT}"
+BRIDGE_IMAGE = "osprey-bluesky-bridge:local"
+BRIDGE_CONTAINER = "osprey-bluesky-bridge"
+
+DEPLOY_UP_TIMEOUT_SEC = 600
+HEALTH_TIMEOUT_SEC = 120.0
+SCAN_TIMEOUT_SEC = 60.0
+
+# Modules that only exist in THIS worktree's unreleased code — proves the
+# --dev build actually baked in the local wheel, not a stale PyPI release
+# (task 2.8 reviewer's carry-forward: assert content, not just "it builds").
+_BLUESKY_BRIDGE_ONLY_MODULES = (
+    "osprey.services.bluesky_bridge.scanner_bluesky",
+    "osprey.services.bluesky_bridge.devices.mock",
+    "osprey.services.bluesky_bridge.plans",
+)
+
+# Rerun only on AssertionError, which is what the genuinely-flaky failures raise
+# (the container-startup health-wait in the fixture, and the HTTP-timing checks
+# in the test bodies). Deterministic setup errors — a failed `osprey build`, a
+# failed `deploy up`, a bound-port collision — surface via ``pytest.fail()`` as
+# ``Failed``, not ``AssertionError``, so they now fail fast instead of burning a
+# retry on a ~6-minute rebuild that would deterministically fail again.
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.slow,
+    pytest.mark.skipif(shutil.which("docker") is None, reason="docker not available"),
+    pytest.mark.flaky(reruns=1, only_rerun=["AssertionError"]),
+]
+
+
+def _find_osprey_console_script() -> Path:
+    candidate = Path(sys.executable).parent / "osprey"
+    if candidate.exists():
+        return candidate
+    found = shutil.which("osprey")
+    if found:
+        return Path(found)
+    raise RuntimeError("Could not locate the 'osprey' console script.")
+
+
+def _run(cmd: list[str], cwd: Path, timeout: int) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env={**os.environ, "CLAUDECODE": ""},
+    )
+
+
+@pytest.fixture(scope="module")
+def deployed_bridge(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
+    """Build + ``osprey deploy up --dev`` a bluesky-bridge-enabled project; tear down after."""
+    osprey_bin = _find_osprey_console_script()
+    base = tmp_path_factory.mktemp("scan_deploy_build")
+    project_dir = base / "proj"
+
+    build = _run(
+        [
+            str(osprey_bin),
+            "build",
+            "proj",
+            "--preset",
+            "hello-world",
+            "--set",
+            "bluesky.demo_scanner=true",
+            "--set",
+            f"bluesky.port={BRIDGE_PORT}",
+            "--skip-deps",
+            "--skip-lifecycle",
+            "--output-dir",
+            str(base),
+            "--force",
+        ],
+        cwd=base,
+        timeout=300,
+    )
+    if build.returncode != 0:
+        pytest.fail(
+            f"osprey build failed (rc={build.returncode}):\n"
+            f"--- stdout ---\n{build.stdout}\n--- stderr ---\n{build.stderr}"
+        )
+
+    # Force a fresh image build so the deployed bridge runs CURRENT source —
+    # `osprey deploy up` does not pass --build to compose, so it would
+    # otherwise silently reuse a stale cached osprey-bluesky-bridge:local.
+    # Exact-named image only.
+    subprocess.run(["docker", "rmi", "-f", BRIDGE_IMAGE], capture_output=True, text=True)
+
+    try:
+        up = _run(
+            [str(osprey_bin), "deploy", "up", "-d", "--dev"],
+            cwd=project_dir,
+            timeout=DEPLOY_UP_TIMEOUT_SEC,
+        )
+        if up.returncode != 0:
+            pytest.fail(
+                f"osprey deploy up --dev failed (rc={up.returncode}):\n"
+                f"--- stdout ---\n{up.stdout}\n--- stderr ---\n{up.stderr}"
+            )
+        _wait_for_health(f"{BRIDGE_URL}/health", HEALTH_TIMEOUT_SEC)
+        yield project_dir
+    finally:
+        down = _run([str(osprey_bin), "deploy", "down"], cwd=project_dir, timeout=300)
+        if down.returncode != 0:
+            print(  # noqa: T201 - surface teardown issues in CI logs
+                f"osprey deploy down rc={down.returncode}\n{down.stdout}\n{down.stderr}"
+            )
+
+
+def _wait_for_health(url: str, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last_err = "(no response yet)"
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=3.0) as resp:  # noqa: S310 - localhost
+                if resp.status == 200:
+                    return
+                last_err = f"HTTP {resp.status}"
+        except (urllib.error.URLError, ConnectionError, OSError) as exc:
+            last_err = str(exc)
+        time.sleep(1.0)
+    raise AssertionError(f"timed out after {timeout:.0f}s waiting for {url} (last: {last_err})")
+
+
+def _minted_token(project_dir: Path) -> str:
+    from osprey.utils.dotenv import parse_dotenv_file
+
+    env_path = project_dir / ".env"
+    assert env_path.is_file(), f"no .env written at {env_path} — token was not minted"
+    env = parse_dotenv_file(env_path)
+    token = env.get("BLUESKY_PROMOTE_TOKEN")
+    assert token, "BLUESKY_PROMOTE_TOKEN missing/empty in the project .env"
+    return token
+
+
+def _get(path: str) -> tuple[int, dict]:
+    req = urllib.request.Request(f"{BRIDGE_URL}{path}", method="GET")  # noqa: S310
+    try:
+        with urllib.request.urlopen(req, timeout=10.0) as resp:  # noqa: S310
+            return resp.status, json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode("utf-8"))
+
+
+def _post(path: str, body: dict, headers: dict | None = None) -> tuple[int, dict]:
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(  # noqa: S310
+        f"{BRIDGE_URL}{path}",
+        data=data,
+        method="POST",
+        headers={"Content-Type": "application/json", **(headers or {})},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15.0) as resp:  # noqa: S310
+            return resp.status, json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_binds_loopback_only(deployed_bridge: Path) -> None:
+    """`docker port` must show 127.0.0.1, never 0.0.0.0 (task 2.8's fail-closed bind)."""
+    proc = subprocess.run(
+        ["docker", "port", BRIDGE_CONTAINER],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, f"docker port failed: {proc.stderr}"
+    assert "127.0.0.1" in proc.stdout, f"expected a 127.0.0.1 bind, got: {proc.stdout!r}"
+    assert "0.0.0.0" not in proc.stdout, f"bridge must never bind 0.0.0.0: {proc.stdout!r}"
+
+
+def test_promote_token_was_minted(deployed_bridge: Path) -> None:
+    """task 2.10: an unset BLUESKY_PROMOTE_TOKEN is auto-generated into .env."""
+    token = _minted_token(deployed_bridge)
+    assert len(token) >= 40  # secrets.token_urlsafe(32) -> ~43 url-safe chars
+
+
+def test_image_contains_unreleased_bluesky_bridge_modules(deployed_bridge: Path) -> None:
+    """Carry-forward from the 2.8 reviewer: assert CONTENT, not just "it builds".
+
+    A PyPI-based (non---dev) build would lack both the unreleased
+    bluesky_bridge submodules and the bluesky-bridge extra on the current
+    release — this would still "build" (pip just installs the released
+    package), so a green build alone is not proof of anything. Import each
+    module inside the running container to prove the --dev wheel + extra
+    both landed.
+    """
+    failures: list[str] = []
+    for module in _BLUESKY_BRIDGE_ONLY_MODULES:
+        proc = subprocess.run(
+            ["docker", "exec", BRIDGE_CONTAINER, "python", "-c", f"import {module}"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if proc.returncode != 0:
+            failures.append(f"{module}: {proc.stderr.strip()}")
+    assert not failures, (
+        "built image is missing unreleased bluesky_bridge modules or the "
+        "bluesky-bridge extra deps (bluesky/ophyd-async) — was it built "
+        "with --dev?\n  " + "\n  ".join(failures)
+    )
+
+
+def test_demo_scan_against_mock_devices_completes(deployed_bridge: Path) -> None:
+    """End-to-end: launch -> promote -> poll -> read_scan_data, against the real container."""
+    token = _minted_token(deployed_bridge)
+
+    status, body = _post(
+        "/runs", {"plan_name": "count", "plan_args": {"detectors": ["det1"], "num": 3}}
+    )
+    assert status == 200, f"POST /runs failed: {status} {body}"
+    run_id = body["id"]
+
+    status, body = _post(f"/runs/{run_id}/promote", {}, headers={"X-Promote-Token": token})
+    assert status == 200, f"promote failed: {status} {body}"
+
+    deadline = time.monotonic() + SCAN_TIMEOUT_SEC
+    last_status_body: dict = {}
+    while time.monotonic() < deadline:
+        _, last_status_body = _get(f"/runs/{run_id}")
+        if last_status_body.get("status") in ("completed", "error", "stopped"):
+            break
+        time.sleep(1.0)
+
+    assert last_status_body.get("status") == "completed", (
+        f"demo scan did not complete: {last_status_body}"
+    )
+
+    status, data_body = _get(f"/runs/{run_id}/data")
+    assert status == 200, f"GET /runs/{run_id}/data failed: {status} {data_body}"
+    assert data_body["row_count"] == 3, f"expected 3 buffered rows: {data_body}"
+    assert len(data_body["rows"]) == 3

--- a/tests/e2e/test_scan_write_refused_e2e.py
+++ b/tests/e2e/test_scan_write_refused_e2e.py
@@ -1,0 +1,134 @@
+"""E2E safety test: ``osprey query`` refuses scan writes (``launch_scan``/``stop_scan``).
+
+Proves the read-only guarantee at the SDK layer for the scan write path:
+``mcp__scan__launch_scan`` and ``mcp__scan__stop_scan`` never appear in a
+query run's tool trace, while the read/allow-listed scan tools
+(``create_scan_intent``, ``read_scan_data``) remain structurally available.
+Direct analog of ``tests/e2e/test_query_write_refused_e2e.py`` for
+``channel_write``.
+
+The load-bearing mechanism is identical to that precedent: the SDK-level
+``disallowed_tools`` list (sourced from the framework registry via
+``read_only_disallowed_tools`` -> ``_registry_side_effect_tools``, which walks
+every ``permissions_ask`` tool including the scan server's) strips
+``launch_scan``/``stop_scan`` from the model's toolset entirely, so they can
+never execute in a headless read-only run — independent of whether a live
+Bluesky bridge is even reachable, and independent of ``control_system.writes_enabled``
+(the in-tool re-check in ``launch.py`` is a second, unit-tested guard; see
+``tests/mcp_server/test_launch_writes_enabled.py``).
+
+Do NOT mark this test flaky. Safety contracts must stay strict.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from osprey.agent_runner.write_tools import read_only_disallowed_tools
+from osprey.cli.query_cmd import query
+from tests.e2e.sdk_helpers import HAS_SDK, init_project, is_claude_code_available
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.requires_als_apg,
+    pytest.mark.skipif(not HAS_SDK, reason="claude_agent_sdk not installed"),
+    pytest.mark.skipif(not is_claude_code_available(), reason="claude CLI not available"),
+]
+
+
+def _enable_scan_server(project_dir: Path) -> None:
+    """Opt this project into the ``scan`` MCP server (``default_enabled=False``).
+
+    Mirrors ``sdk_helpers.enable_writes_in_project``'s text-patch + regen
+    pattern: the ``scan`` server isn't in ``hello_world``'s default
+    ``claude_code.servers`` block at all, so this inserts an explicit
+    ``scan: {enabled: true}`` entry next to ``controls`` and re-renders the
+    Claude Code artifacts so ``.mcp.json``/``hook_config.json`` pick it up.
+    """
+    config_path = project_dir / "config.yml"
+    text = config_path.read_text(encoding="utf-8")
+    marker = "controls: {enabled: true}"
+    assert marker in text, f"Expected {marker!r} in {config_path}; template may have changed."
+    updated = text.replace(marker, f"{marker}\n    scan: {{enabled: true}}", 1)
+    config_path.write_text(updated, encoding="utf-8")
+
+    from osprey.cli.templates.manager import TemplateManager
+
+    TemplateManager().regen_if_drift(project_dir)
+
+
+# Operator-style prompts: natural task language, no tool names hand-fed. The
+# guarantee under test is that launch_scan/stop_scan are absent from the
+# model's toolset entirely (SDK-level disallowed_tools), so it must hold
+# whether or not the operator happens to know (or say) the tool's name.
+_LAUNCH_PROMPT = "There's a scan intent for run 'abc123' that's ready to go. Please launch it."
+_STOP_PROMPT = "Run 'abc123' is scanning right now. Please stop it."
+
+
+def _run_query(project: Path, prompt: str) -> list[str]:
+    """Run ``osprey query`` with ``prompt`` and return the tool-trace names."""
+    runner = CliRunner()
+    res = runner.invoke(
+        query,
+        ["--project", str(project), "--json", prompt],
+        catch_exceptions=False,
+    )
+    output = res.output.strip()
+    assert output, f"No output from osprey query (exit {res.exit_code}). Prompt: {prompt!r}"
+    json_start = output.find("{")
+    assert json_start >= 0, f"No JSON found in command output:\n{output}"
+    payload, _ = json.JSONDecoder().raw_decode(output[json_start:].strip())
+    return [t["name"] for t in payload["tool_traces"]]
+
+
+def test_scan_write_tools_structurally_disallowed(tmp_path: Path) -> None:
+    """Guard 1 (structural): launch_scan/stop_scan are disallowed; read tools are not.
+
+    Passes even before any live run — the registry walk that produces
+    ``read_only_disallowed_tools`` is static, so this holds regardless of
+    whether the ``scan`` server is enabled in this particular project.
+    """
+    project = init_project(
+        tmp_path,
+        "scan_write_refuse_structural",
+        template="hello_world",
+        provider="als-apg",
+    )
+
+    disallowed = read_only_disallowed_tools(project)
+    assert "mcp__scan__launch_scan" in disallowed
+    assert "mcp__scan__stop_scan" in disallowed
+    assert "mcp__scan__create_scan_intent" not in disallowed
+    assert "mcp__scan__read_scan_data" not in disallowed
+
+
+def test_query_refuses_launch_scan(tmp_path: Path) -> None:
+    """Guard 2 (behavioral): an operator-style launch prompt produces no tool trace entry."""
+    project = init_project(
+        tmp_path,
+        "scan_write_refuse_launch",
+        template="hello_world",
+        provider="als-apg",
+    )
+    _enable_scan_server(project)
+
+    names = _run_query(project, _LAUNCH_PROMPT)
+    assert "mcp__scan__launch_scan" not in names, f"LAUNCH_SCAN LEAKED: {names}"
+
+
+def test_query_refuses_stop_scan(tmp_path: Path) -> None:
+    """Guard 2 (behavioral): an operator-style stop prompt produces no tool trace entry."""
+    project = init_project(
+        tmp_path,
+        "scan_write_refuse_stop",
+        template="hello_world",
+        provider="als-apg",
+    )
+    _enable_scan_server(project)
+
+    names = _run_query(project, _STOP_PROMPT)
+    assert "mcp__scan__stop_scan" not in names, f"STOP_SCAN LEAKED: {names}"

--- a/tests/mcp_server/test_executor_env_scrub.py
+++ b/tests/mcp_server/test_executor_env_scrub.py
@@ -1,0 +1,200 @@
+"""Unit tests for the python-executor sandbox environment scrub.
+
+Covers ``_scrub_sensitive_env`` (the pure filtering function) and the
+``_execute_via_local`` subprocess-spawn seam that must use it. The scrub
+prevents agent-generated code running in the local-execution sandbox from
+reading write-arming secrets (e.g. ``BLUESKY_PROMOTE_TOKEN``) and calling a
+write-gated endpoint directly, bypassing the ``writes_enabled`` re-check
+inside ``launch_scan``.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import yaml
+
+from osprey.mcp_server.python_executor.executor import execute_code
+from osprey.mcp_server.sandbox_env import (
+    _SENSITIVE_ENV_EXACT,
+    _SENSITIVE_ENV_SUFFIXES,
+    _scrub_sensitive_env,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_all_config_caches(monkeypatch):
+    """Reset ALL config caches before each test (see test_executor_adapter.py)."""
+    from osprey.utils.workspace import reset_config_cache
+
+    reset_config_cache()
+
+    import osprey.utils.config as _cfg
+
+    monkeypatch.setattr(_cfg, "_default_config", None)
+    monkeypatch.setattr(_cfg, "_default_configurable", None)
+    saved_cache = _cfg._config_cache.copy()
+    _cfg._config_cache.clear()
+
+    yield
+
+    reset_config_cache()
+    _cfg._config_cache.clear()
+    _cfg._config_cache.update(saved_cache)
+
+
+def _write_local_config(tmp_path):
+    config = {
+        "control_system": {"type": "mock", "limits_checking": {"enabled": False}},
+        "execution": {"execution_method": "local"},
+        "python_executor": {"execution_timeout_seconds": 300},
+    }
+    (tmp_path / "config.yml").write_text(yaml.dump(config))
+
+
+# ---------------------------------------------------------------------------
+# _scrub_sensitive_env — pure function
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_scrub_removes_bluesky_promote_token():
+    """BLUESKY_PROMOTE_TOKEN is dropped via the *_PROMOTE_TOKEN suffix rule."""
+    env = {"BLUESKY_PROMOTE_TOKEN": "secret", "PATH": "/usr/bin"}
+    scrubbed = _scrub_sensitive_env(env)
+    assert "BLUESKY_PROMOTE_TOKEN" not in scrubbed
+    assert scrubbed["PATH"] == "/usr/bin"
+
+
+@pytest.mark.unit
+def test_scrub_removes_event_dispatcher_token():
+    """EVENT_DISPATCHER_TOKEN is dropped via the exact-name rule."""
+    env = {"EVENT_DISPATCHER_TOKEN": "secret", "PATH": "/usr/bin"}
+    scrubbed = _scrub_sensitive_env(env)
+    assert "EVENT_DISPATCHER_TOKEN" not in scrubbed
+    assert scrubbed["PATH"] == "/usr/bin"
+
+
+@pytest.mark.unit
+def test_scrub_generalizes_to_future_promote_tokens():
+    """Any future *_PROMOTE_TOKEN name is scrubbed without a code change."""
+    env = {"SOME_OTHER_BRIDGE_PROMOTE_TOKEN": "secret", "PATH": "/usr/bin"}
+    scrubbed = _scrub_sensitive_env(env)
+    assert "SOME_OTHER_BRIDGE_PROMOTE_TOKEN" not in scrubbed
+
+
+@pytest.mark.unit
+def test_scrub_preserves_unrelated_env():
+    """Ordinary env vars (including ones merely containing "TOKEN") pass through."""
+    env = {
+        "CONFIG_FILE": "/app/config.yml",
+        "EPICS_CA_ADDR_LIST": "10.0.0.1",
+        "HOME": "/home/user",
+        # Contains "TOKEN" but is not a write-arming secret and does not match
+        # either scrub rule — must survive.
+        "TOKENIZER_CACHE_DIR": "/tmp/cache",
+    }
+    scrubbed = _scrub_sensitive_env(env)
+    assert scrubbed == env
+
+
+@pytest.mark.unit
+def test_scrub_does_not_mutate_input():
+    """_scrub_sensitive_env returns a copy; it must not mutate the caller's dict."""
+    env = {"BLUESKY_PROMOTE_TOKEN": "secret", "PATH": "/usr/bin"}
+    original = dict(env)
+    _scrub_sensitive_env(env)
+    assert env == original
+
+
+@pytest.mark.unit
+def test_scrub_empty_env():
+    assert _scrub_sensitive_env({}) == {}
+
+
+@pytest.mark.unit
+def test_sensitive_env_constants_are_tuples():
+    """Constants are tuples (immutable, module-level security constants — not config)."""
+    assert isinstance(_SENSITIVE_ENV_EXACT, tuple)
+    assert isinstance(_SENSITIVE_ENV_SUFFIXES, tuple)
+    assert "EVENT_DISPATCHER_TOKEN" in _SENSITIVE_ENV_EXACT
+    assert "_PROMOTE_TOKEN" in _SENSITIVE_ENV_SUFFIXES
+
+
+# ---------------------------------------------------------------------------
+# _execute_via_local — subprocess-spawn seam actually applies the scrub
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_local_subprocess_env_excludes_promote_token(tmp_path, monkeypatch):
+    """The local-exec subprocess is spawned with an env that excludes the token."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "super-secret-value")
+    _write_local_config(tmp_path)
+
+    mock_proc = AsyncMock()
+    mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+    mock_proc.returncode = 0
+    mock_proc.kill = MagicMock()
+    mock_proc.wait = MagicMock()  # not awaited on this path; avoids an unawaited-coroutine warning
+
+    with patch(
+        "osprey.mcp_server.python_executor.executor.asyncio.create_subprocess_exec",
+        new_callable=AsyncMock,
+        return_value=mock_proc,
+    ) as mock_spawn:
+        await execute_code("print(42)", "readonly", "test")
+
+    assert mock_spawn.await_count == 1
+    passed_env = mock_spawn.await_args.kwargs["env"]
+    assert "BLUESKY_PROMOTE_TOKEN" not in passed_env
+
+
+@pytest.mark.unit
+async def test_local_subprocess_env_excludes_event_dispatcher_token(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("EVENT_DISPATCHER_TOKEN", "super-secret-value")
+    _write_local_config(tmp_path)
+
+    mock_proc = AsyncMock()
+    mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+    mock_proc.returncode = 0
+    mock_proc.kill = MagicMock()
+    mock_proc.wait = MagicMock()  # not awaited on this path; avoids an unawaited-coroutine warning
+
+    with patch(
+        "osprey.mcp_server.python_executor.executor.asyncio.create_subprocess_exec",
+        new_callable=AsyncMock,
+        return_value=mock_proc,
+    ) as mock_spawn:
+        await execute_code("print(42)", "readonly", "test")
+
+    assert mock_spawn.await_count == 1
+    passed_env = mock_spawn.await_args.kwargs["env"]
+    assert "EVENT_DISPATCHER_TOKEN" not in passed_env
+
+
+@pytest.mark.unit
+async def test_local_subprocess_env_keeps_config_file(tmp_path, monkeypatch):
+    """Non-sensitive vars the sandbox legitimately needs (e.g. CONFIG_FILE) survive."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "super-secret-value")
+    monkeypatch.setenv("CONFIG_FILE", str(tmp_path / "config.yml"))
+    _write_local_config(tmp_path)
+
+    mock_proc = AsyncMock()
+    mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+    mock_proc.returncode = 0
+    mock_proc.kill = MagicMock()
+    mock_proc.wait = MagicMock()  # not awaited on this path; avoids an unawaited-coroutine warning
+
+    with patch(
+        "osprey.mcp_server.python_executor.executor.asyncio.create_subprocess_exec",
+        new_callable=AsyncMock,
+        return_value=mock_proc,
+    ) as mock_spawn:
+        await execute_code("print(42)", "readonly", "test")
+
+    assert mock_spawn.await_count == 1
+    passed_env = mock_spawn.await_args.kwargs["env"]
+    assert passed_env.get("CONFIG_FILE") == str(tmp_path / "config.yml")

--- a/tests/mcp_server/test_executor_env_scrub.py
+++ b/tests/mcp_server/test_executor_env_scrub.py
@@ -1,6 +1,6 @@
 """Unit tests for the python-executor sandbox environment scrub.
 
-Covers ``_scrub_sensitive_env`` (the pure filtering function) and the
+Covers ``scrub_sensitive_env`` (the pure filtering function) and the
 ``_execute_via_local`` subprocess-spawn seam that must use it. The scrub
 prevents agent-generated code running in the local-execution sandbox from
 reading write-arming secrets (e.g. ``BLUESKY_PROMOTE_TOKEN``) and calling a
@@ -17,7 +17,7 @@ from osprey.mcp_server.python_executor.executor import execute_code
 from osprey.mcp_server.sandbox_env import (
     _SENSITIVE_ENV_EXACT,
     _SENSITIVE_ENV_SUFFIXES,
-    _scrub_sensitive_env,
+    scrub_sensitive_env,
 )
 
 
@@ -52,7 +52,7 @@ def _write_local_config(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# _scrub_sensitive_env — pure function
+# scrub_sensitive_env — pure function
 # ---------------------------------------------------------------------------
 
 
@@ -60,7 +60,7 @@ def _write_local_config(tmp_path):
 def test_scrub_removes_bluesky_promote_token():
     """BLUESKY_PROMOTE_TOKEN is dropped via the *_PROMOTE_TOKEN suffix rule."""
     env = {"BLUESKY_PROMOTE_TOKEN": "secret", "PATH": "/usr/bin"}
-    scrubbed = _scrub_sensitive_env(env)
+    scrubbed = scrub_sensitive_env(env)
     assert "BLUESKY_PROMOTE_TOKEN" not in scrubbed
     assert scrubbed["PATH"] == "/usr/bin"
 
@@ -69,7 +69,7 @@ def test_scrub_removes_bluesky_promote_token():
 def test_scrub_removes_event_dispatcher_token():
     """EVENT_DISPATCHER_TOKEN is dropped via the exact-name rule."""
     env = {"EVENT_DISPATCHER_TOKEN": "secret", "PATH": "/usr/bin"}
-    scrubbed = _scrub_sensitive_env(env)
+    scrubbed = scrub_sensitive_env(env)
     assert "EVENT_DISPATCHER_TOKEN" not in scrubbed
     assert scrubbed["PATH"] == "/usr/bin"
 
@@ -78,7 +78,7 @@ def test_scrub_removes_event_dispatcher_token():
 def test_scrub_generalizes_to_future_promote_tokens():
     """Any future *_PROMOTE_TOKEN name is scrubbed without a code change."""
     env = {"SOME_OTHER_BRIDGE_PROMOTE_TOKEN": "secret", "PATH": "/usr/bin"}
-    scrubbed = _scrub_sensitive_env(env)
+    scrubbed = scrub_sensitive_env(env)
     assert "SOME_OTHER_BRIDGE_PROMOTE_TOKEN" not in scrubbed
 
 
@@ -93,22 +93,22 @@ def test_scrub_preserves_unrelated_env():
         # either scrub rule — must survive.
         "TOKENIZER_CACHE_DIR": "/tmp/cache",
     }
-    scrubbed = _scrub_sensitive_env(env)
+    scrubbed = scrub_sensitive_env(env)
     assert scrubbed == env
 
 
 @pytest.mark.unit
 def test_scrub_does_not_mutate_input():
-    """_scrub_sensitive_env returns a copy; it must not mutate the caller's dict."""
+    """scrub_sensitive_env returns a copy; it must not mutate the caller's dict."""
     env = {"BLUESKY_PROMOTE_TOKEN": "secret", "PATH": "/usr/bin"}
     original = dict(env)
-    _scrub_sensitive_env(env)
+    scrub_sensitive_env(env)
     assert env == original
 
 
 @pytest.mark.unit
 def test_scrub_empty_env():
-    assert _scrub_sensitive_env({}) == {}
+    assert scrub_sensitive_env({}) == {}
 
 
 @pytest.mark.unit

--- a/tests/mcp_server/test_executor_token_regression.py
+++ b/tests/mcp_server/test_executor_token_regression.py
@@ -1,0 +1,160 @@
+"""Pentest-style regression: agent-run code in the python-executor sandbox
+cannot read write-arming tokens from its environment.
+
+Unlike ``test_executor_env_scrub.py`` (which unit-tests the scrub function and
+inspects the ``env=`` kwarg passed to a *mocked* subprocess call), these tests
+spawn a REAL local subprocess through ``execute_code()`` end-to-end and have
+the sandboxed code itself introspect ``os.environ`` and report back what it
+can see. This guards the actual write-safety property: even if the scrub
+function had a bug that only manifested at runtime (encoding issue, wrong
+dict identity, etc.), a real execution catches it where a mocked one would
+not.
+
+Threat model: ``BLUESKY_PROMOTE_TOKEN`` authenticates callers of the Bluesky
+bridge's ``/runs/{id}/promote`` endpoint. If agent-generated code running in
+this sandbox could read that token from its environment, it could bypass
+``launch_scan``'s in-tool ``writes_enabled`` re-check and POST directly to
+``/promote``. This test proves that path is closed at the environment layer.
+"""
+
+import json
+
+import pytest
+import yaml
+
+from osprey.mcp_server.python_executor.executor import execute_code
+
+
+@pytest.fixture(autouse=True)
+def _reset_all_config_caches(monkeypatch):
+    """Reset ALL config caches before each test (see test_executor_adapter.py)."""
+    from osprey.utils.workspace import reset_config_cache
+
+    reset_config_cache()
+
+    import osprey.utils.config as _cfg
+
+    monkeypatch.setattr(_cfg, "_default_config", None)
+    monkeypatch.setattr(_cfg, "_default_configurable", None)
+    saved_cache = _cfg._config_cache.copy()
+    _cfg._config_cache.clear()
+
+    yield
+
+    reset_config_cache()
+    _cfg._config_cache.clear()
+    _cfg._config_cache.update(saved_cache)
+
+
+def _write_local_config(tmp_path):
+    config = {
+        "control_system": {"type": "mock", "limits_checking": {"enabled": False}},
+        "execution": {"execution_method": "local"},
+        "python_executor": {"execution_timeout_seconds": 60},
+    }
+    (tmp_path / "config.yml").write_text(yaml.dump(config))
+
+
+_DUMP_ENV_CODE = (
+    "import json, os\n"
+    "print('ENV_KEYS_JSON_START')\n"
+    "print(json.dumps(sorted(os.environ.keys())))\n"
+    "print('ENV_KEYS_JSON_END')\n"
+)
+
+
+def _extract_env_keys(stdout: str) -> list[str]:
+    """Pull the JSON-encoded sorted env key list out of the sandbox's stdout."""
+    start = stdout.index("ENV_KEYS_JSON_START") + len("ENV_KEYS_JSON_START")
+    end = stdout.index("ENV_KEYS_JSON_END")
+    return json.loads(stdout[start:end])
+
+
+async def test_sandbox_code_cannot_see_bluesky_promote_token(tmp_path, monkeypatch):
+    """Real sandboxed execution: BLUESKY_PROMOTE_TOKEN is absent from os.environ."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "super-secret-promote-value")
+    _write_local_config(tmp_path)
+
+    result = await execute_code(_DUMP_ENV_CODE, "readonly", "pentest env dump")
+
+    assert result.success, f"sandbox execution failed: {result.error_message}\n{result.stderr}"
+    env_keys = _extract_env_keys(result.stdout)
+    assert "BLUESKY_PROMOTE_TOKEN" not in env_keys
+    # The literal secret value must not leak into stdout/stderr either.
+    assert "super-secret-promote-value" not in result.stdout
+    assert "super-secret-promote-value" not in result.stderr
+
+
+async def test_sandbox_code_cannot_see_event_dispatcher_token(tmp_path, monkeypatch):
+    """Real sandboxed execution: EVENT_DISPATCHER_TOKEN is absent from os.environ."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("EVENT_DISPATCHER_TOKEN", "super-secret-dispatch-value")
+    _write_local_config(tmp_path)
+
+    result = await execute_code(_DUMP_ENV_CODE, "readonly", "pentest env dump")
+
+    assert result.success, f"sandbox execution failed: {result.error_message}\n{result.stderr}"
+    env_keys = _extract_env_keys(result.stdout)
+    assert "EVENT_DISPATCHER_TOKEN" not in env_keys
+    # The literal secret value must not leak into stdout/stderr either.
+    assert "super-secret-dispatch-value" not in result.stdout
+    assert "super-secret-dispatch-value" not in result.stderr
+
+
+async def test_sandbox_code_cannot_see_either_token_simultaneously(tmp_path, monkeypatch):
+    """Both tokens set in the parent process — neither reaches the sandbox."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "promote-secret")
+    monkeypatch.setenv("EVENT_DISPATCHER_TOKEN", "dispatch-secret")
+    _write_local_config(tmp_path)
+
+    result = await execute_code(_DUMP_ENV_CODE, "readonly", "pentest env dump")
+
+    assert result.success, f"sandbox execution failed: {result.error_message}\n{result.stderr}"
+    env_keys = _extract_env_keys(result.stdout)
+    assert "BLUESKY_PROMOTE_TOKEN" not in env_keys
+    assert "EVENT_DISPATCHER_TOKEN" not in env_keys
+    # Neither literal secret value may leak into stdout/stderr either.
+    for secret in ("promote-secret", "dispatch-secret"):
+        assert secret not in result.stdout
+        assert secret not in result.stderr
+
+
+async def test_sandbox_still_has_a_usable_environment(tmp_path, monkeypatch):
+    """Negative control: scrubbing must not wipe the whole env (e.g. PATH survives).
+
+    Without this, the token-absence assertions above could pass vacuously if
+    a bug handed the subprocess an empty environment instead of a scrubbed one.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "promote-secret")
+    _write_local_config(tmp_path)
+
+    result = await execute_code(_DUMP_ENV_CODE, "readonly", "pentest env dump")
+
+    assert result.success, f"sandbox execution failed: {result.error_message}\n{result.stderr}"
+    env_keys = _extract_env_keys(result.stdout)
+    assert "PATH" in env_keys
+    assert len(env_keys) > 1
+
+
+async def test_sandbox_code_cannot_reach_promote_endpoint_via_env_token(tmp_path, monkeypatch):
+    """End-to-end pentest: code that tries to read the token to forge a promote
+    call finds nothing to read — the attack surface this task closes.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "promote-secret")
+    _write_local_config(tmp_path)
+
+    attack_code = (
+        "import os\n"
+        "token = os.environ.get('BLUESKY_PROMOTE_TOKEN')\n"
+        "print('TOKEN_VALUE:', repr(token))\n"
+    )
+
+    result = await execute_code(attack_code, "readonly", "pentest promote token grab")
+
+    assert result.success, f"sandbox execution failed: {result.error_message}\n{result.stderr}"
+    assert "TOKEN_VALUE: None" in result.stdout
+    assert "promote-secret" not in result.stdout

--- a/tests/mcp_server/test_launch_scan.py
+++ b/tests/mcp_server/test_launch_scan.py
@@ -1,0 +1,191 @@
+"""Unit tests for the launch_scan MCP tool — the sole scan write path.
+
+Covers both in-tool safety layers (writes_enabled re-read, client-side token
+presence) and the bridge response mapping. The HTTP boundary
+(``_http_post_json``) is patched here so these run with no Bluesky bridge
+process and no network.
+"""
+
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from osprey.mcp_server.scan.server_context import initialize_server_context, reset_server_context
+from osprey.mcp_server.scan.tools import launch
+from tests.mcp_server.conftest import assert_raises_error, extract_response_dict, get_tool_fn
+
+pytestmark = pytest.mark.unit
+
+_MOD = "osprey.mcp_server.scan.tools.launch"
+
+
+def _fn():
+    return get_tool_fn(launch.launch_scan)
+
+
+def _write_config(tmp_path, writes_enabled: bool, promote_token: str | None = None) -> None:
+    config: dict = {"control_system": {"writes_enabled": writes_enabled}}
+    if promote_token is not None:
+        config["scan"] = {"promote_token": promote_token}
+    (tmp_path / "config.yml").write_text(yaml.dump(config))
+
+
+@pytest.fixture(autouse=True)
+def _reset_scan_context():
+    yield
+    reset_server_context()
+
+
+# ── Layer 1: in-tool writes_enabled re-check (authoritative) ────────────────
+
+
+async def test_refuses_when_writes_disabled(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, writes_enabled=False)
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "valid-token")
+    initialize_server_context()
+
+    with patch(f"{_MOD}._http_post_json") as m:
+        with assert_raises_error(error_type="writes_disabled"):
+            await _fn()(run_id="abc123")
+    m.assert_not_called()
+
+
+async def test_writes_disabled_refusal_does_not_leak_token(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, writes_enabled=False)
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "s3cr3t-token")
+    initialize_server_context()
+
+    with patch(f"{_MOD}._http_post_json"):
+        with assert_raises_error(error_type="writes_disabled") as ctx:
+            await _fn()(run_id="abc123")
+    assert "s3cr3t-token" not in ctx["envelope"]["error_message"]
+
+
+async def test_writes_disabled_wins_even_with_no_token(tmp_path, monkeypatch):
+    """writes_enabled is checked FIRST — order matters, per the module contract."""
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, writes_enabled=False)
+    monkeypatch.delenv("BLUESKY_PROMOTE_TOKEN", raising=False)
+    initialize_server_context()
+
+    with assert_raises_error(error_type="writes_disabled"):
+        await _fn()(run_id="abc123")
+
+
+async def test_writes_enabled_missing_config_fails_closed(tmp_path, monkeypatch):
+    """No config.yml at all -> writes_enabled defaults False (fail-closed)."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "valid-token")
+    initialize_server_context()
+
+    with assert_raises_error(error_type="writes_disabled"):
+        await _fn()(run_id="abc123")
+
+
+# ── Layer 2: client-side token presence (no network call) ──────────────────
+
+
+async def test_refuses_client_side_when_no_token(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, writes_enabled=True)
+    monkeypatch.delenv("BLUESKY_PROMOTE_TOKEN", raising=False)
+    initialize_server_context()
+
+    with patch(f"{_MOD}._http_post_json") as m:
+        with assert_raises_error(error_type="scan_promote_unarmed"):
+            await _fn()(run_id="abc123")
+    m.assert_not_called()
+
+
+# ── Success path + bridge response mapping ──────────────────────────────────
+
+
+async def test_launch_scan_success(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, writes_enabled=True)
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "valid-token")
+    initialize_server_context()
+
+    body = {"id": "abc123", "status": "running"}
+    with patch(f"{_MOD}._http_post_json", return_value=(200, body)) as m:
+        result = await _fn()(run_id="abc123")
+
+    assert m.call_args.args[0] == "/runs/abc123/promote"
+    assert m.call_args.args[1] == {}
+    assert m.call_args.kwargs["headers"] == {"X-Promote-Token": "valid-token"}
+    data = extract_response_dict(result)
+    assert data["status"] == "running"
+
+
+async def test_launch_scan_unknown_run(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, writes_enabled=True)
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "valid-token")
+    initialize_server_context()
+
+    with patch(f"{_MOD}._http_post_json", return_value=(404, {"detail": "unknown run 'abc123'"})):
+        with assert_raises_error(error_type="unknown_run") as ctx:
+            await _fn()(run_id="abc123")
+    assert "unknown run" in ctx["envelope"]["error_message"]
+
+
+async def test_launch_scan_forbidden_token_mismatch(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, writes_enabled=True)
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "valid-token")
+    initialize_server_context()
+
+    with patch(
+        f"{_MOD}._http_post_json",
+        return_value=(403, {"detail": "invalid or missing promote token"}),
+    ):
+        with assert_raises_error(error_type="scan_promote_forbidden"):
+            await _fn()(run_id="abc123")
+
+
+async def test_launch_scan_conflict(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, writes_enabled=True)
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "valid-token")
+    initialize_server_context()
+
+    with patch(
+        f"{_MOD}._http_post_json", return_value=(409, {"detail": "run 'abc123' already promoted"})
+    ):
+        with assert_raises_error(error_type="scan_promote_conflict") as ctx:
+            await _fn()(run_id="abc123")
+    assert "already promoted" in ctx["envelope"]["error_message"]
+
+
+async def test_launch_scan_bridge_unarmed(tmp_path, monkeypatch):
+    """The bridge process itself has no BLUESKY_PROMOTE_TOKEN configured (503)."""
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, writes_enabled=True)
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "valid-token")
+    initialize_server_context()
+
+    with patch(
+        f"{_MOD}._http_post_json",
+        return_value=(
+            503,
+            {"detail": "promotion disabled: BLUESKY_PROMOTE_TOKEN is not configured"},
+        ),
+    ):
+        with assert_raises_error(error_type="scan_promote_unarmed") as ctx:
+            await _fn()(run_id="abc123")
+    assert "not configured" in ctx["envelope"]["error_message"]
+
+
+async def test_launch_bluesky_bridge_error(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, writes_enabled=True)
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "valid-token")
+    initialize_server_context()
+
+    with patch(f"{_MOD}._http_post_json", return_value=(500, {"detail": "promotion failed: boom"})):
+        with assert_raises_error(error_type="bluesky_bridge_error") as ctx:
+            await _fn()(run_id="abc123")
+    assert "boom" in ctx["envelope"]["error_message"]

--- a/tests/mcp_server/test_launch_writes_enabled.py
+++ b/tests/mcp_server/test_launch_writes_enabled.py
@@ -1,0 +1,139 @@
+"""Safety proof: launch_scan refuses when writes are disabled, even with a
+VALID promote token — zero HTTP calls issued.
+
+This is the authoritative in-tool guard (see ``scan/tools/launch.py``): the
+``control_system.writes_enabled`` re-check runs BEFORE any HTTP call, so a
+caller that bypasses the PreToolUse approval hook entirely (e.g. a direct MCP
+call) and supplies a correct ``BLUESKY_PROMOTE_TOKEN`` is still refused. General
+unit coverage of ``launch_scan``'s error mapping lives in
+``test_launch_scan.py``; this file exists as the standalone, easy-to-locate
+proof of the one property that matters most: writes-disabled beats a valid
+token, unconditionally, with no network call ever issued.
+
+Do NOT relax this test. It is the load-bearing safety contract for the scan
+write path (analogous to ``tests/e2e/test_query_write_refused_e2e.py`` for
+``channel_write``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from osprey.mcp_server.scan.server_context import initialize_server_context, reset_server_context
+from osprey.mcp_server.scan.tools.launch import launch_scan
+from tests.mcp_server.conftest import assert_raises_error, get_tool_fn
+
+pytestmark = pytest.mark.unit
+
+_MOD = "osprey.mcp_server.scan.tools.launch"
+
+
+@pytest.fixture(autouse=True)
+def _reset_scan_context():
+    yield
+    reset_server_context()
+
+
+async def test_writes_disabled_refuses_launch_with_valid_token_and_zero_http_calls(
+    tmp_path, monkeypatch
+):
+    """The load-bearing case: writes_enabled=false + a VALID token -> refused, no network call.
+
+    A malicious or hook-bypassed caller holding a correct BLUESKY_PROMOTE_TOKEN
+    must not be able to promote a run when this deployment has writes
+    disabled. The in-tool re-check must reject before ``_http_post_json`` is
+    ever invoked — asserted directly here, not inferred from the error type.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.yml").write_text(yaml.dump({"control_system": {"writes_enabled": False}}))
+    # A genuinely VALID token — the point is that even a correct credential
+    # does not help once writes are disabled.
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "genuinely-valid-token")
+    initialize_server_context()
+
+    fn = get_tool_fn(launch_scan)
+    with patch(f"{_MOD}._http_post_json") as mock_post:
+        with assert_raises_error(error_type="writes_disabled") as ctx:
+            await fn(run_id="some-run-id")
+
+    mock_post.assert_not_called()
+    assert "genuinely-valid-token" not in ctx["envelope"]["error_message"]
+
+
+async def test_writes_disabled_refuses_launch_even_without_a_token(tmp_path, monkeypatch):
+    """Non-regression: the writes-disabled refusal doesn't depend on token presence either way."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.yml").write_text(yaml.dump({"control_system": {"writes_enabled": False}}))
+    monkeypatch.delenv("BLUESKY_PROMOTE_TOKEN", raising=False)
+    initialize_server_context()
+
+    fn = get_tool_fn(launch_scan)
+    with patch(f"{_MOD}._http_post_json") as mock_post:
+        with assert_raises_error(error_type="writes_disabled"):
+            await fn(run_id="some-run-id")
+
+    mock_post.assert_not_called()
+
+
+async def test_writes_enabled_with_valid_token_does_reach_the_bridge(tmp_path, monkeypatch):
+    """Contrast case: once writes are enabled, a valid token does reach the HTTP layer.
+
+    Confirms the refusal above is genuinely gated on writes_enabled and not
+    some unrelated failure that would make the "zero HTTP calls" assertion
+    vacuously true.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.yml").write_text(yaml.dump({"control_system": {"writes_enabled": True}}))
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "genuinely-valid-token")
+    initialize_server_context()
+
+    fn = get_tool_fn(launch_scan)
+    with patch(
+        f"{_MOD}._http_post_json", return_value=(200, {"id": "x", "status": "running"})
+    ) as m:
+        await fn(run_id="some-run-id")
+
+    m.assert_called_once()
+
+
+async def test_missing_config_fails_closed_even_with_valid_token(tmp_path, monkeypatch):
+    """No config.yml at all -> writes_enabled defaults False (fail-closed), token notwithstanding.
+
+    A project directory with no config.yml (e.g. a broken deployment, or a
+    cwd mismatch) must never be interpreted as "writes enabled" by omission —
+    ``_writes_enabled``'s except clause defaults to False on
+    FileNotFoundError/RuntimeError, mirroring ``ControlSystemConnector._writes_enabled``.
+    """
+    monkeypatch.chdir(tmp_path)  # no config.yml written here
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "genuinely-valid-token")
+    initialize_server_context()
+
+    fn = get_tool_fn(launch_scan)
+    with patch(f"{_MOD}._http_post_json") as mock_post:
+        with assert_raises_error(error_type="writes_disabled"):
+            await fn(run_id="some-run-id")
+
+    mock_post.assert_not_called()
+
+
+async def test_writes_enabled_true_but_token_unset_refused_client_side(tmp_path, monkeypatch):
+    """The second gate: writes_enabled=true is not sufficient on its own.
+
+    With no BLUESKY_PROMOTE_TOKEN configured for this MCP server, launch_scan
+    must still refuse — client-side, before any HTTP call — rather than
+    sending a promote request with no credential at all.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.yml").write_text(yaml.dump({"control_system": {"writes_enabled": True}}))
+    monkeypatch.delenv("BLUESKY_PROMOTE_TOKEN", raising=False)
+    initialize_server_context()
+
+    fn = get_tool_fn(launch_scan)
+    with patch(f"{_MOD}._http_post_json") as mock_post:
+        with assert_raises_error(error_type="scan_promote_unarmed"):
+            await fn(run_id="some-run-id")
+
+    mock_post.assert_not_called()

--- a/tests/mcp_server/test_read_scan_data_bounded.py
+++ b/tests/mcp_server/test_read_scan_data_bounded.py
@@ -1,0 +1,224 @@
+"""Unit tests for the `read_scan_data` MCP tool's bounded-read semantics (task 2.12).
+
+Complements `test_scan_read_tools.py`'s basic success/error-envelope coverage
+by focusing specifically on the bounded-read shape the bridge's
+`GET /runs/{id}/data` route (task 2.2, backed by `live_rows.py`) produces:
+`max_rows` caps, `row_count` as the true total, `truncated` flipping
+correctly, `offset`/`tail` pagination, the minimal empty-stream shape, and
+`partial: true` mid-run. The HTTP boundary (`_http_get_json`) is patched here
+(phoebus pattern) — this file exercises the tool's own param-passing and
+response-surfacing, not the network; the real end-to-end route is covered by
+the non-patched integration test in `test_read_bounded.py`.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from osprey.mcp_server.scan.tools import read_tools
+from tests.mcp_server.conftest import assert_raises_error, extract_response_dict, get_tool_fn
+
+pytestmark = pytest.mark.unit
+
+_MOD = "osprey.mcp_server.scan.tools.read_tools"
+
+
+def _fn(name):
+    return get_tool_fn(getattr(read_tools, name))
+
+
+# =========================================================================
+# max_rows caps the returned rows
+# =========================================================================
+
+
+async def test_max_rows_caps_the_returned_row_window():
+    body = {
+        "run_uid": "uid-1",
+        "columns": ["x"],
+        "rows": [[0.0], [1.0]],
+        "row_count": 5,
+        "truncated": True,
+    }
+    with patch(f"{_MOD}._http_get_json", return_value=(200, body)) as m:
+        result = await _fn("read_scan_data")(run_id="abc123", max_rows=2)
+
+    assert "max_rows=2" in m.call_args.args[0]
+    data = extract_response_dict(result)
+    assert len(data["rows"]) == 2
+
+
+# =========================================================================
+# row_count reflects the true total, independent of the returned window size
+# =========================================================================
+
+
+async def test_row_count_reflects_true_total_not_window_size():
+    body = {
+        "run_uid": "uid-1",
+        "columns": ["x"],
+        "rows": [[0.0], [1.0]],
+        "row_count": 500,
+        "truncated": True,
+    }
+    with patch(f"{_MOD}._http_get_json", return_value=(200, body)):
+        result = await _fn("read_scan_data")(run_id="abc123", max_rows=2)
+
+    data = extract_response_dict(result)
+    assert data["row_count"] == 500
+    assert len(data["rows"]) == 2
+
+
+# =========================================================================
+# truncated flips: False when the window covers everything, True otherwise
+# =========================================================================
+
+
+async def test_truncated_false_when_window_covers_every_row():
+    body = {
+        "run_uid": "uid-1",
+        "columns": ["x"],
+        "rows": [[0.0], [1.0]],
+        "row_count": 2,
+        "truncated": False,
+    }
+    with patch(f"{_MOD}._http_get_json", return_value=(200, body)):
+        result = await _fn("read_scan_data")(run_id="abc123", max_rows=100)
+
+    assert extract_response_dict(result)["truncated"] is False
+
+
+async def test_truncated_true_when_window_omits_rows():
+    body = {
+        "run_uid": "uid-1",
+        "columns": ["x"],
+        "rows": [[0.0], [1.0]],
+        "row_count": 5,
+        "truncated": True,
+    }
+    with patch(f"{_MOD}._http_get_json", return_value=(200, body)):
+        result = await _fn("read_scan_data")(run_id="abc123", max_rows=2)
+
+    assert extract_response_dict(result)["truncated"] is True
+
+
+# =========================================================================
+# offset / tail pagination: the tool must build the right query string
+# =========================================================================
+
+
+async def test_offset_is_passed_through_as_a_forward_page():
+    with patch(f"{_MOD}._http_get_json", return_value=(200, {"columns": [], "rows": []})) as m:
+        await _fn("read_scan_data")(run_id="abc123", max_rows=10, offset=20)
+
+    url = m.call_args.args[0]
+    assert "max_rows=10" in url
+    assert "offset=20" in url
+    assert "tail=true" not in url
+
+
+async def test_tail_is_passed_through_without_an_offset():
+    with patch(f"{_MOD}._http_get_json", return_value=(200, {"columns": [], "rows": []})) as m:
+        await _fn("read_scan_data")(run_id="abc123", max_rows=10, tail=True)
+
+    url = m.call_args.args[0]
+    assert "tail=true" in url
+    assert "offset=" not in url
+
+
+async def test_tail_with_offset_are_both_passed_through():
+    with patch(f"{_MOD}._http_get_json", return_value=(200, {"columns": [], "rows": []})) as m:
+        await _fn("read_scan_data")(run_id="abc123", max_rows=10, offset=5, tail=True)
+
+    url = m.call_args.args[0]
+    assert "max_rows=10" in url
+    assert "offset=5" in url
+    assert "tail=true" in url
+
+
+async def test_offset_defaults_to_omitted_from_the_query_string():
+    with patch(f"{_MOD}._http_get_json", return_value=(200, {"columns": [], "rows": []})) as m:
+        await _fn("read_scan_data")(run_id="abc123")
+
+    url = m.call_args.args[0]
+    assert "offset=" not in url
+    assert "tail=" not in url
+    assert "max_rows=100" in url  # the tool's own default
+
+
+async def test_paginated_rows_surface_unmodified_from_the_bridge_body():
+    """The tool must not re-slice or otherwise alter the bridge's own window."""
+    body = {
+        "run_uid": "uid-1",
+        "columns": ["x"],
+        "rows": [[2.0], [3.0]],
+        "row_count": 5,
+        "truncated": True,
+    }
+    with patch(f"{_MOD}._http_get_json", return_value=(200, body)):
+        result = await _fn("read_scan_data")(run_id="abc123", max_rows=2, offset=2)
+
+    data = extract_response_dict(result)
+    assert data["rows"] == [[2.0], [3.0]]
+
+
+# =========================================================================
+# Empty stream: minimal shape, no extra keys
+# =========================================================================
+
+
+async def test_empty_stream_returns_the_minimal_shape():
+    with patch(f"{_MOD}._http_get_json", return_value=(200, {"columns": [], "rows": []})):
+        result = await _fn("read_scan_data")(run_id="abc123")
+
+    assert extract_response_dict(result) == {"columns": [], "rows": []}
+
+
+# =========================================================================
+# Mid-run: partial: true surfaces through
+# =========================================================================
+
+
+async def test_mid_run_surfaces_partial_true():
+    body = {
+        "run_uid": "uid-1",
+        "columns": ["x"],
+        "rows": [[1.0]],
+        "row_count": 1,
+        "truncated": False,
+        "partial": True,
+    }
+    with patch(f"{_MOD}._http_get_json", return_value=(200, body)):
+        result = await _fn("read_scan_data")(run_id="abc123")
+
+    assert extract_response_dict(result)["partial"] is True
+
+
+async def test_completed_run_omits_partial_key():
+    body = {
+        "run_uid": "uid-1",
+        "columns": ["x"],
+        "rows": [[1.0]],
+        "row_count": 1,
+        "truncated": False,
+    }
+    with patch(f"{_MOD}._http_get_json", return_value=(200, body)):
+        result = await _fn("read_scan_data")(run_id="abc123")
+
+    assert "partial" not in extract_response_dict(result)
+
+
+# =========================================================================
+# 409: no run_uid yet -> a distinct, clear error (not a generic bridge error)
+# =========================================================================
+
+
+async def test_no_run_uid_yet_returns_a_distinct_error_type():
+    with patch(
+        f"{_MOD}._http_get_json",
+        return_value=(409, {"detail": "run 'abc123' has not started; no data yet"}),
+    ):
+        with assert_raises_error(error_type="scan_data_not_ready") as ctx:
+            await _fn("read_scan_data")(run_id="abc123")
+
+    assert "has not started" in ctx["envelope"]["error_message"]

--- a/tests/mcp_server/test_scan_client_tools.py
+++ b/tests/mcp_server/test_scan_client_tools.py
@@ -1,0 +1,224 @@
+"""Unit tests for the scan MCP client tools' request/response mapping.
+
+Complements ``test_scan_read_tools.py`` (which covers per-tool bridge-status
+translation in depth) by focusing on two things across every read/allow-listed
+client tool: that each tool builds the right bridge request and maps a normal
+response straight through, and that a genuinely unreachable bridge surfaces
+the standard ``bluesky_bridge_unreachable`` error envelope raised by the
+module-level ``_http_get_json``/``_http_post_json`` primitives — patched here
+(phoebus pattern, no network) so tools never need their own try/except
+around that failure mode.
+"""
+
+import json
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from osprey.mcp_server.errors import make_error
+from osprey.mcp_server.scan.server import mcp
+from osprey.mcp_server.scan.tools import read_tools
+from tests.mcp_server.conftest import assert_raises_error, extract_response_dict, get_tool_fn
+
+pytestmark = pytest.mark.unit
+
+_MOD = "osprey.mcp_server.scan.tools.read_tools"
+
+
+def _fn(name):
+    return get_tool_fn(getattr(read_tools, name))
+
+
+def _unreachable(*_args, **_kwargs):
+    """Simulate the real _http_* primitive's behavior on a connection failure."""
+    make_error(
+        "bluesky_bridge_unreachable",
+        "Could not reach the Bluesky bridge: connection refused",
+        ["Confirm the facility Bluesky bridge process is running."],
+    )
+
+
+# ---------------------------------------------------------------------------
+# create_scan_intent — POST /runs
+# ---------------------------------------------------------------------------
+
+
+async def test_create_scan_intent_request_response_mapping(monkeypatch):
+    captured = {}
+
+    def fake_post(path, payload, **kwargs):
+        captured["path"] = path
+        captured["payload"] = payload
+        return 201, {"id": "run-1", "status": "intent"}
+
+    monkeypatch.setattr(f"{_MOD}._http_post_json", fake_post)
+
+    result = await _fn("create_scan_intent")(
+        plan_name="grid_scan", plan_args={"motors": ["m1", "m2"], "points": 10}
+    )
+
+    assert captured["path"] == "/runs"
+    assert captured["payload"] == {
+        "plan_name": "grid_scan",
+        "plan_args": {"motors": ["m1", "m2"], "points": 10},
+    }
+    data = extract_response_dict(result)
+    assert data == {"id": "run-1", "status": "intent"}
+
+
+async def test_create_scan_intent_unreachable(monkeypatch):
+    monkeypatch.setattr(f"{_MOD}._http_post_json", _unreachable)
+    with assert_raises_error(error_type="bluesky_bridge_unreachable") as ctx:
+        await _fn("create_scan_intent")(plan_name="count")
+    assert "Could not reach the Bluesky bridge" in ctx["envelope"]["error_message"]
+
+
+# ---------------------------------------------------------------------------
+# scan_status — GET /runs/{id}
+# ---------------------------------------------------------------------------
+
+
+async def test_scan_status_request_response_mapping(monkeypatch):
+    captured = {}
+
+    def fake_get(path, **kwargs):
+        captured["path"] = path
+        return 200, {"id": "run-1", "status": "running", "completion": 0.42}
+
+    monkeypatch.setattr(f"{_MOD}._http_get_json", fake_get)
+
+    result = await _fn("scan_status")(run_id="run-1")
+
+    assert captured["path"] == "/runs/run-1"
+    data = extract_response_dict(result)
+    assert data["status"] == "running"
+    assert data["completion"] == 0.42
+
+
+async def test_scan_status_unreachable(monkeypatch):
+    monkeypatch.setattr(f"{_MOD}._http_get_json", _unreachable)
+    with assert_raises_error(error_type="bluesky_bridge_unreachable"):
+        await _fn("scan_status")(run_id="run-1")
+
+
+# ---------------------------------------------------------------------------
+# list_scan_plans — GET /plans
+# ---------------------------------------------------------------------------
+
+
+async def test_list_scan_plans_request_response_mapping(monkeypatch):
+    captured = {}
+    plans = [{"name": "count", "params": {}}, {"name": "grid_scan", "params": {"motors": []}}]
+
+    def fake_get(path, **kwargs):
+        captured["path"] = path
+        return 200, plans
+
+    monkeypatch.setattr(f"{_MOD}._http_get_json", fake_get)
+
+    result = await _fn("list_scan_plans")()
+
+    assert captured["path"] == "/plans"
+    data = extract_response_dict(result)
+    assert data["status"] == "success"
+    assert data["plans"] == plans
+
+
+async def test_list_scan_plans_unreachable(monkeypatch):
+    monkeypatch.setattr(f"{_MOD}._http_get_json", _unreachable)
+    with assert_raises_error(error_type="bluesky_bridge_unreachable"):
+        await _fn("list_scan_plans")()
+
+
+# ---------------------------------------------------------------------------
+# list_runs — GET /runs
+# ---------------------------------------------------------------------------
+
+
+async def test_list_runs_request_response_mapping(monkeypatch):
+    captured = {}
+    runs = [{"id": "run-2", "status": "completed"}, {"id": "run-1", "status": "stopped"}]
+
+    def fake_get(path, **kwargs):
+        captured["path"] = path
+        return 200, runs
+
+    monkeypatch.setattr(f"{_MOD}._http_get_json", fake_get)
+
+    result = await _fn("list_runs")(limit=5)
+
+    assert captured["path"] == "/runs?limit=5"
+    data = extract_response_dict(result)
+    assert data["status"] == "success"
+    assert data["runs"] == runs
+
+
+async def test_list_runs_unreachable(monkeypatch):
+    monkeypatch.setattr(f"{_MOD}._http_get_json", _unreachable)
+    with assert_raises_error(error_type="bluesky_bridge_unreachable"):
+        await _fn("list_runs")()
+
+
+# ---------------------------------------------------------------------------
+# read_scan_data — GET /runs/{id}/data (bounded stub)
+# ---------------------------------------------------------------------------
+
+
+async def test_read_scan_data_request_response_mapping(monkeypatch):
+    captured = {}
+    body = {
+        "run_uid": "uid-1",
+        "columns": ["m1", "det1"],
+        "rows": [[0.0, 1.1], [1.0, 2.2]],
+        "row_count": 2,
+        "truncated": False,
+        "partial": True,
+    }
+
+    def fake_get(path, **kwargs):
+        captured["path"] = path
+        return 200, body
+
+    monkeypatch.setattr(f"{_MOD}._http_get_json", fake_get)
+
+    result = await _fn("read_scan_data")(run_id="run-1", max_rows=25, offset=10, tail=False)
+
+    assert captured["path"] == "/runs/run-1/data?max_rows=25&offset=10"
+    data = extract_response_dict(result)
+    assert data == body
+
+
+async def test_read_scan_data_unreachable(monkeypatch):
+    monkeypatch.setattr(f"{_MOD}._http_get_json", _unreachable)
+    with assert_raises_error(error_type="bluesky_bridge_unreachable"):
+        await _fn("read_scan_data")(run_id="run-1")
+
+
+# ---------------------------------------------------------------------------
+# get_tool_fn unwrapping sanity check
+# ---------------------------------------------------------------------------
+
+
+async def test_all_client_tools_are_registered_fastmcp_function_tools():
+    """Every client tool is registered on the scan server as a FunctionTool."""
+    for name in (
+        "create_scan_intent",
+        "scan_status",
+        "list_scan_plans",
+        "list_runs",
+        "read_scan_data",
+    ):
+        tool = await mcp.get_tool(name)
+        assert tool.fn is getattr(read_tools, name), f"{name} was not registered via @mcp.tool()"
+        assert get_tool_fn(tool) is tool.fn
+
+
+async def test_unreachable_envelope_is_a_tool_error_with_standard_shape(monkeypatch):
+    """The propagated exception is a ToolError carrying the full standard envelope."""
+    monkeypatch.setattr(f"{_MOD}._http_get_json", _unreachable)
+    with pytest.raises(ToolError) as exc_info:
+        await _fn("list_runs")()
+    envelope = json.loads(str(exc_info.value))
+    assert envelope["error"] is True
+    assert envelope["error_type"] == "bluesky_bridge_unreachable"
+    assert envelope["suggestions"]

--- a/tests/mcp_server/test_scan_context.py
+++ b/tests/mcp_server/test_scan_context.py
@@ -1,0 +1,204 @@
+"""Tests for the scan MCP server context and HTTP boundary.
+
+Covers: ScanContext env resolution, config.yml fallback, singleton
+init/reset, and the ``_http_get_json``/``_http_post_json`` unreachable-bridge
+error envelope (patched ``httpx``, no network).
+"""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+import yaml
+from fastmcp.exceptions import ToolError
+
+from osprey.mcp_server.scan.server_context import (
+    ScanContext,
+    _http_get_json,
+    _http_post_json,
+    get_server_context,
+    initialize_server_context,
+    reset_server_context,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _write_config(tmp_path, config_dict):
+    """Write a config.yml to tmp_path and return the path."""
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(yaml.dump(config_dict))
+    return config_file
+
+
+# ---------------------------------------------------------------------------
+# Env resolution
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_url_from_env(tmp_path, monkeypatch):
+    """BLUESKY_BRIDGE_URL env var wins outright over config.yml."""
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, {"scan": {"bridge_url": "http://10.0.0.5:9000"}})
+    monkeypatch.setenv("BLUESKY_BRIDGE_URL", "http://127.0.0.1:8123/")
+
+    context = ScanContext()
+    context.initialize()
+
+    assert context.bridge_url == "http://127.0.0.1:8123"
+
+
+def test_promote_token_from_env(tmp_path, monkeypatch):
+    """BLUESKY_PROMOTE_TOKEN env var wins outright over config.yml."""
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, {"scan": {"promote_token": "config-token"}})
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "env-token")
+
+    context = ScanContext()
+    context.initialize()
+
+    assert context.promote_token == "env-token"
+
+
+def test_env_absent_no_config_uses_defaults(tmp_path, monkeypatch):
+    """With no env vars and no config.yml, sane fail-closed defaults apply."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("BLUESKY_BRIDGE_URL", raising=False)
+    monkeypatch.delenv("BLUESKY_PROMOTE_TOKEN", raising=False)
+    monkeypatch.delenv("OSPREY_CONFIG", raising=False)
+
+    context = ScanContext()
+    context.initialize()
+
+    assert context.bridge_url == "http://127.0.0.1:8090"
+    assert context.promote_token is None
+
+
+# ---------------------------------------------------------------------------
+# Config fallback
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_url_config_fallback(tmp_path, monkeypatch):
+    """scan.bridge_url in config.yml is used when the env var is unset."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("BLUESKY_BRIDGE_URL", raising=False)
+    _write_config(tmp_path, {"scan": {"bridge_url": "http://192.168.1.10:8090/"}})
+
+    context = ScanContext()
+    context.initialize()
+
+    assert context.bridge_url == "http://192.168.1.10:8090"
+
+
+def test_promote_token_config_fallback(tmp_path, monkeypatch):
+    """scan.promote_token in config.yml is used when the env var is unset."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("BLUESKY_PROMOTE_TOKEN", raising=False)
+    _write_config(tmp_path, {"scan": {"promote_token": "dev-token"}})
+
+    context = ScanContext()
+    context.initialize()
+
+    assert context.promote_token == "dev-token"
+
+
+# ---------------------------------------------------------------------------
+# Singleton init/reset
+# ---------------------------------------------------------------------------
+
+
+def test_initialize_idempotent(tmp_path, monkeypatch):
+    """Calling initialize() multiple times is a no-op after the first."""
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, {"scan": {"bridge_url": "http://127.0.0.1:8090"}})
+
+    context = ScanContext()
+    context.initialize()
+    context.initialize()  # second call should be a no-op
+
+    assert context.bridge_url == "http://127.0.0.1:8090"
+
+
+def test_singleton_access(tmp_path, monkeypatch):
+    """get_server_context() returns the same instance after initialize."""
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, {"scan": {"bridge_url": "http://127.0.0.1:8090"}})
+
+    initialize_server_context()
+    ctx1 = get_server_context()
+    ctx2 = get_server_context()
+
+    assert ctx1 is ctx2
+
+    reset_server_context()
+
+
+def test_get_before_initialize_raises():
+    """get_server_context() raises before initialize_server_context()."""
+    reset_server_context()
+    with pytest.raises(RuntimeError, match="not initialized"):
+        get_server_context()
+
+
+def test_reset_clears_singleton(tmp_path, monkeypatch):
+    """reset_server_context() clears the singleton so get raises again."""
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, {"scan": {"bridge_url": "http://127.0.0.1:8090"}})
+
+    initialize_server_context()
+    reset_server_context()
+
+    with pytest.raises(RuntimeError, match="not initialized"):
+        get_server_context()
+
+
+# ---------------------------------------------------------------------------
+# HTTP boundary — unreachable bridge
+# ---------------------------------------------------------------------------
+
+
+def test_http_get_json_unreachable_raises_error_envelope(tmp_path, monkeypatch):
+    """_http_get_json raises a bluesky_bridge_unreachable ToolError on connection failure."""
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, {"scan": {"bridge_url": "http://127.0.0.1:8090"}})
+    initialize_server_context()
+
+    with patch("httpx.get", side_effect=httpx.ConnectError("connection refused")):
+        with pytest.raises(ToolError) as exc_info:
+            _http_get_json("/runs")
+
+    assert "bluesky_bridge_unreachable" in str(exc_info.value)
+
+    reset_server_context()
+
+
+def test_http_post_json_unreachable_raises_error_envelope(tmp_path, monkeypatch):
+    """_http_post_json raises a bluesky_bridge_unreachable ToolError on connection failure."""
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, {"scan": {"bridge_url": "http://127.0.0.1:8090"}})
+    initialize_server_context()
+
+    with patch("httpx.post", side_effect=httpx.ConnectError("connection refused")):
+        with pytest.raises(ToolError) as exc_info:
+            _http_post_json("/runs/abc/promote", {}, headers={"X-Promote-Token": "t"})
+
+    assert "bluesky_bridge_unreachable" in str(exc_info.value)
+
+    reset_server_context()
+
+
+def test_http_get_json_success_returns_status_and_body(tmp_path, monkeypatch):
+    """_http_get_json returns (status_code, parsed_json) on a normal response."""
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, {"scan": {"bridge_url": "http://127.0.0.1:8090"}})
+    initialize_server_context()
+
+    fake_response = httpx.Response(200, json={"runs": []}, request=httpx.Request("GET", "http://x"))
+    with patch("httpx.get", return_value=fake_response):
+        status, body = _http_get_json("/runs")
+
+    assert status == 200
+    assert body == {"runs": []}
+
+    reset_server_context()

--- a/tests/mcp_server/test_scan_read_tools.py
+++ b/tests/mcp_server/test_scan_read_tools.py
@@ -1,0 +1,153 @@
+"""Unit tests for the scan MCP read/allow-listed tools.
+
+The HTTP boundary (``_http_get_json`` / ``_http_post_json``, imported from
+``osprey.mcp_server.scan.server_context``) is patched here so these run with
+no Bluesky bridge process and no network.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from osprey.mcp_server.scan.tools import read_tools
+from tests.mcp_server.conftest import assert_raises_error, extract_response_dict, get_tool_fn
+
+pytestmark = pytest.mark.unit
+
+_MOD = "osprey.mcp_server.scan.tools.read_tools"
+
+
+def _fn(name):
+    return get_tool_fn(getattr(read_tools, name))
+
+
+# ── create_scan_intent ──────────────────────────────────────────────────────
+async def test_create_scan_intent_success():
+    body = {"id": "abc123", "status": "intent"}
+    with patch(f"{_MOD}._http_post_json", return_value=(200, body)) as m:
+        result = await _fn("create_scan_intent")(plan_name="count", plan_args={"num": 5})
+    assert m.call_args.args[0] == "/runs"
+    assert m.call_args.args[1] == {"plan_name": "count", "plan_args": {"num": 5}}
+    data = extract_response_dict(result)
+    assert data["id"] == "abc123"
+    assert data["status"] == "intent"
+
+
+async def test_create_scan_intent_default_plan_args():
+    with patch(f"{_MOD}._http_post_json", return_value=(200, {"id": "x", "status": "intent"})) as m:
+        await _fn("create_scan_intent")(plan_name="count")
+    assert m.call_args.args[1]["plan_args"] == {}
+
+
+async def test_create_scan_intent_rejected():
+    with patch(f"{_MOD}._http_post_json", return_value=(422, {"detail": "unknown plan 'bogus'"})):
+        with assert_raises_error(error_type="scan_intent_rejected") as ctx:
+            await _fn("create_scan_intent")(plan_name="bogus")
+    assert "unknown plan" in ctx["envelope"]["error_message"]
+
+
+# ── scan_status ──────────────────────────────────────────────────────────────
+async def test_scan_status_success():
+    body = {"id": "abc123", "status": "running", "completion": 0.5}
+    with patch(f"{_MOD}._http_get_json", return_value=(200, body)) as m:
+        result = await _fn("scan_status")(run_id="abc123")
+    assert m.call_args.args[0] == "/runs/abc123"
+    data = extract_response_dict(result)
+    assert data["status"] == "running"
+
+
+async def test_scan_status_unknown_run():
+    with patch(f"{_MOD}._http_get_json", return_value=(404, {"detail": "unknown run 'abc123'"})):
+        with assert_raises_error(error_type="unknown_run") as ctx:
+            await _fn("scan_status")(run_id="abc123")
+    assert "unknown run" in ctx["envelope"]["error_message"]
+
+
+async def test_scan_status_bridge_error():
+    with patch(f"{_MOD}._http_get_json", return_value=(500, {"detail": "boom"})):
+        with assert_raises_error(error_type="bluesky_bridge_error") as ctx:
+            await _fn("scan_status")(run_id="abc123")
+    assert "boom" in ctx["envelope"]["error_message"]
+
+
+# ── list_scan_plans ──────────────────────────────────────────────────────────
+async def test_list_scan_plans_success():
+    plans = [{"name": "count", "params": {}}]
+    with patch(f"{_MOD}._http_get_json", return_value=(200, plans)) as m:
+        result = await _fn("list_scan_plans")()
+    assert m.call_args.args[0] == "/plans"
+    data = extract_response_dict(result)
+    assert data["status"] == "success"
+    assert data["plans"] == plans
+
+
+async def test_list_scan_plans_empty():
+    with patch(f"{_MOD}._http_get_json", return_value=(200, [])):
+        result = await _fn("list_scan_plans")()
+    assert extract_response_dict(result)["plans"] == []
+
+
+async def test_list_scan_plans_bridge_error():
+    with patch(f"{_MOD}._http_get_json", return_value=(500, {"detail": "boom"})):
+        with assert_raises_error(error_type="bluesky_bridge_error"):
+            await _fn("list_scan_plans")()
+
+
+# ── list_runs ────────────────────────────────────────────────────────────────
+async def test_list_runs_success():
+    runs = [{"id": "abc123", "status": "completed"}]
+    with patch(f"{_MOD}._http_get_json", return_value=(200, runs)) as m:
+        result = await _fn("list_runs")(limit=10)
+    assert m.call_args.args[0] == "/runs?limit=10"
+    data = extract_response_dict(result)
+    assert data["status"] == "success"
+    assert data["runs"] == runs
+
+
+async def test_list_runs_default_limit():
+    with patch(f"{_MOD}._http_get_json", return_value=(200, [])) as m:
+        await _fn("list_runs")()
+    assert m.call_args.args[0] == "/runs?limit=20"
+
+
+async def test_list_runs_bridge_error():
+    with patch(f"{_MOD}._http_get_json", return_value=(503, {"detail": "not armed"})):
+        with assert_raises_error(error_type="bluesky_bridge_error") as ctx:
+            await _fn("list_runs")()
+    assert "not armed" in ctx["envelope"]["error_message"]
+
+
+# ── read_scan_data ───────────────────────────────────────────────────────────
+async def test_read_scan_data_success():
+    body = {
+        "run_uid": "uid-1",
+        "columns": ["x"],
+        "rows": [[1.0]],
+        "row_count": 1,
+        "truncated": False,
+    }
+    with patch(f"{_MOD}._http_get_json", return_value=(200, body)) as m:
+        result = await _fn("read_scan_data")(run_id="abc123", max_rows=50)
+    assert m.call_args.args[0] == "/runs/abc123/data?max_rows=50"
+    data = extract_response_dict(result)
+    assert data["row_count"] == 1
+
+
+async def test_read_scan_data_query_params():
+    with patch(f"{_MOD}._http_get_json", return_value=(200, {"columns": [], "rows": []})) as m:
+        await _fn("read_scan_data")(run_id="abc123", max_rows=10, offset=5, tail=True)
+    url = m.call_args.args[0]
+    assert "max_rows=10" in url and "offset=5" in url and "tail=true" in url
+
+
+async def test_read_scan_data_unknown_run():
+    with patch(f"{_MOD}._http_get_json", return_value=(404, {"detail": "unknown run 'abc123'"})):
+        with assert_raises_error(error_type="unknown_run"):
+            await _fn("read_scan_data")(run_id="abc123")
+
+
+async def test_read_scan_data_empty_run():
+    with patch(f"{_MOD}._http_get_json", return_value=(200, {"columns": [], "rows": []})):
+        result = await _fn("read_scan_data")(run_id="abc123")
+    data = extract_response_dict(result)
+    assert data == {"columns": [], "rows": []}

--- a/tests/mcp_server/test_stop_scan.py
+++ b/tests/mcp_server/test_stop_scan.py
@@ -1,0 +1,61 @@
+"""Unit tests for the stop_scan MCP tool.
+
+The HTTP boundary (``_http_post_json``) is patched here so these run with no
+Bluesky bridge process and no network.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from osprey.mcp_server.scan.tools import stop
+from tests.mcp_server.conftest import assert_raises_error, extract_response_dict, get_tool_fn
+
+pytestmark = pytest.mark.unit
+
+_MOD = "osprey.mcp_server.scan.tools.stop"
+
+
+def _fn():
+    return get_tool_fn(stop.stop_scan)
+
+
+async def test_stop_scan_success():
+    body = {"id": "abc123", "status": "stopped"}
+    with patch(f"{_MOD}._http_post_json", return_value=(200, body)) as m:
+        result = await _fn()(run_id="abc123")
+    assert m.call_args.args[0] == "/runs/abc123/stop"
+    assert m.call_args.args[1] == {}
+    data = extract_response_dict(result)
+    assert data["status"] == "stopped"
+
+
+async def test_stop_scan_unknown_run():
+    with patch(f"{_MOD}._http_post_json", return_value=(404, {"detail": "unknown run 'abc123'"})):
+        with assert_raises_error(error_type="unknown_run") as ctx:
+            await _fn()(run_id="abc123")
+    assert "unknown run" in ctx["envelope"]["error_message"]
+
+
+async def test_stop_scan_conflict():
+    with patch(
+        f"{_MOD}._http_post_json", return_value=(409, {"detail": "run 'abc123' cannot be stopped"})
+    ):
+        with assert_raises_error(error_type="scan_stop_conflict") as ctx:
+            await _fn()(run_id="abc123")
+    assert "cannot be stopped" in ctx["envelope"]["error_message"]
+
+
+async def test_stop_bluesky_bridge_error():
+    with patch(f"{_MOD}._http_post_json", return_value=(500, {"detail": "boom"})):
+        with assert_raises_error(error_type="bluesky_bridge_error") as ctx:
+            await _fn()(run_id="abc123")
+    assert "boom" in ctx["envelope"]["error_message"]
+
+
+async def test_stop_scan_stops_an_unpromoted_intent():
+    """Halting is always allowed, even on a run that was never promoted."""
+    body = {"id": "abc123", "status": "stopped"}
+    with patch(f"{_MOD}._http_post_json", return_value=(200, body)):
+        result = await _fn()(run_id="abc123")
+    assert extract_response_dict(result)["status"] == "stopped"

--- a/tests/mcp_server/test_workspace_env_scrub.py
+++ b/tests/mcp_server/test_workspace_env_scrub.py
@@ -1,0 +1,242 @@
+"""Unit tests for the workspace sandbox's environment scrub.
+
+Mirrors ``test_executor_env_scrub.py`` for the sibling sandbox in
+``osprey.mcp_server.workspace.execution.sandbox_executor`` (used by the
+data-visualizer tools: ``create_static_plot``, ``create_interactive_plot``,
+``create_dashboard``). This sandbox has its own local subprocess-spawn seam
+(``execute_sandbox_code``'s ``asyncio.create_subprocess_exec`` call) that
+previously had no ``env=`` kwarg at all and therefore inherited the full
+parent environment — the same write-arming-token leak found and fixed in the
+python-executor sandbox (task 2.11).
+"""
+
+import textwrap
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from osprey.mcp_server.sandbox_env import (
+    _SENSITIVE_ENV_EXACT,
+    _SENSITIVE_ENV_SUFFIXES,
+    _scrub_sensitive_env,
+)
+from osprey.mcp_server.workspace.execution.sandbox_executor import execute_sandbox_code
+
+# ---------------------------------------------------------------------------
+# _scrub_sensitive_env — pure function
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_scrub_removes_bluesky_promote_token():
+    """BLUESKY_PROMOTE_TOKEN is dropped via the *_PROMOTE_TOKEN suffix rule."""
+    env = {"BLUESKY_PROMOTE_TOKEN": "secret", "PATH": "/usr/bin"}
+    scrubbed = _scrub_sensitive_env(env)
+    assert "BLUESKY_PROMOTE_TOKEN" not in scrubbed
+    assert scrubbed["PATH"] == "/usr/bin"
+
+
+@pytest.mark.unit
+def test_scrub_removes_event_dispatcher_token():
+    """EVENT_DISPATCHER_TOKEN is dropped via the exact-name rule."""
+    env = {"EVENT_DISPATCHER_TOKEN": "secret", "PATH": "/usr/bin"}
+    scrubbed = _scrub_sensitive_env(env)
+    assert "EVENT_DISPATCHER_TOKEN" not in scrubbed
+    assert scrubbed["PATH"] == "/usr/bin"
+
+
+@pytest.mark.unit
+def test_scrub_generalizes_to_future_promote_tokens():
+    """Any future *_PROMOTE_TOKEN name is scrubbed without a code change."""
+    env = {"SOME_OTHER_BRIDGE_PROMOTE_TOKEN": "secret", "PATH": "/usr/bin"}
+    scrubbed = _scrub_sensitive_env(env)
+    assert "SOME_OTHER_BRIDGE_PROMOTE_TOKEN" not in scrubbed
+
+
+@pytest.mark.unit
+def test_scrub_preserves_unrelated_env():
+    """Ordinary env vars (including ones merely containing "TOKEN") pass through."""
+    env = {
+        "HOME": "/home/user",
+        "DISPLAY": ":0",
+        # Contains "TOKEN" but is not a write-arming secret and does not match
+        # either scrub rule — must survive.
+        "TOKENIZER_CACHE_DIR": "/tmp/cache",
+    }
+    scrubbed = _scrub_sensitive_env(env)
+    assert scrubbed == env
+
+
+@pytest.mark.unit
+def test_scrub_does_not_mutate_input():
+    """_scrub_sensitive_env returns a copy; it must not mutate the caller's dict."""
+    env = {"BLUESKY_PROMOTE_TOKEN": "secret", "PATH": "/usr/bin"}
+    original = dict(env)
+    _scrub_sensitive_env(env)
+    assert env == original
+
+
+@pytest.mark.unit
+def test_scrub_empty_env():
+    assert _scrub_sensitive_env({}) == {}
+
+
+@pytest.mark.unit
+def test_sensitive_env_constants_are_tuples():
+    """Constants are tuples (immutable, module-level security constants — not config)."""
+    assert isinstance(_SENSITIVE_ENV_EXACT, tuple)
+    assert isinstance(_SENSITIVE_ENV_SUFFIXES, tuple)
+    assert "EVENT_DISPATCHER_TOKEN" in _SENSITIVE_ENV_EXACT
+    assert "_PROMOTE_TOKEN" in _SENSITIVE_ENV_SUFFIXES
+
+
+@pytest.mark.unit
+def test_scrub_shared_with_python_executor():
+    """Both sandboxes import the SAME scrub from osprey.mcp_server.sandbox_env
+
+    (not independent copies), so the deny-lists cannot drift by construction.
+    """
+    from osprey.mcp_server.python_executor import executor as python_executor_module
+
+    assert python_executor_module._scrub_sensitive_env is _scrub_sensitive_env
+
+
+# ---------------------------------------------------------------------------
+# execute_sandbox_code — subprocess-spawn seam actually applies the scrub
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def execution_folder(tmp_path):
+    folder = tmp_path / "test_execution"
+    folder.mkdir()
+    return folder
+
+
+@pytest.fixture
+def workspace_root(tmp_path):
+    ws = tmp_path / "_agent_data"
+    ws.mkdir()
+    (ws / "data").mkdir()
+    return ws
+
+
+@pytest.mark.unit
+async def test_sandbox_subprocess_env_excludes_promote_token(
+    execution_folder, workspace_root, monkeypatch
+):
+    """The sandbox subprocess is spawned with an env that excludes the token."""
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "super-secret-value")
+
+    mock_proc = AsyncMock()
+    mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+    mock_proc.returncode = 0
+    mock_proc.kill = MagicMock()
+    mock_proc.wait = MagicMock()  # not awaited on this path; avoids an unawaited-coroutine warning
+
+    with (
+        patch(
+            "osprey.utils.workspace.resolve_workspace_root",
+            return_value=workspace_root,
+        ),
+        patch(
+            "osprey.mcp_server.workspace.execution.sandbox_executor.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=mock_proc,
+        ) as mock_spawn,
+    ):
+        await execute_sandbox_code(code="print(42)", execution_folder=execution_folder)
+
+    assert mock_spawn.await_count == 1
+    passed_env = mock_spawn.await_args.kwargs["env"]
+    assert "BLUESKY_PROMOTE_TOKEN" not in passed_env
+
+
+@pytest.mark.unit
+async def test_sandbox_subprocess_env_excludes_event_dispatcher_token(
+    execution_folder, workspace_root, monkeypatch
+):
+    monkeypatch.setenv("EVENT_DISPATCHER_TOKEN", "super-secret-value")
+
+    mock_proc = AsyncMock()
+    mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+    mock_proc.returncode = 0
+    mock_proc.kill = MagicMock()
+    mock_proc.wait = MagicMock()  # not awaited on this path; avoids an unawaited-coroutine warning
+
+    with (
+        patch(
+            "osprey.utils.workspace.resolve_workspace_root",
+            return_value=workspace_root,
+        ),
+        patch(
+            "osprey.mcp_server.workspace.execution.sandbox_executor.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=mock_proc,
+        ) as mock_spawn,
+    ):
+        await execute_sandbox_code(code="print(42)", execution_folder=execution_folder)
+
+    assert mock_spawn.await_count == 1
+    passed_env = mock_spawn.await_args.kwargs["env"]
+    assert "EVENT_DISPATCHER_TOKEN" not in passed_env
+
+
+@pytest.mark.unit
+async def test_sandbox_subprocess_env_keeps_unrelated_vars(
+    execution_folder, workspace_root, monkeypatch
+):
+    """Non-sensitive vars the sandbox legitimately needs (e.g. HOME) survive."""
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "super-secret-value")
+    monkeypatch.setenv("HOME", "/home/testuser")
+
+    mock_proc = AsyncMock()
+    mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+    mock_proc.returncode = 0
+    mock_proc.kill = MagicMock()
+    mock_proc.wait = MagicMock()  # not awaited on this path; avoids an unawaited-coroutine warning
+
+    with (
+        patch(
+            "osprey.utils.workspace.resolve_workspace_root",
+            return_value=workspace_root,
+        ),
+        patch(
+            "osprey.mcp_server.workspace.execution.sandbox_executor.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=mock_proc,
+        ) as mock_spawn,
+    ):
+        await execute_sandbox_code(code="print(42)", execution_folder=execution_folder)
+
+    assert mock_spawn.await_count == 1
+    passed_env = mock_spawn.await_args.kwargs["env"]
+    assert passed_env.get("HOME") == "/home/testuser"
+
+
+# ---------------------------------------------------------------------------
+# Real end-to-end execution (pentest-style, mirrors test_executor_token_regression.py)
+# ---------------------------------------------------------------------------
+
+
+async def test_real_execution_cannot_see_promote_token(
+    execution_folder, workspace_root, monkeypatch
+):
+    """Real (unmocked) subprocess: sandboxed code cannot read BLUESKY_PROMOTE_TOKEN."""
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "super-secret-promote-value")
+
+    code = textwrap.dedent("""\
+        import os
+        token = os.environ.get('BLUESKY_PROMOTE_TOKEN')
+        print('TOKEN_VALUE:', repr(token))
+    """)
+
+    with patch(
+        "osprey.utils.workspace.resolve_workspace_root",
+        return_value=workspace_root,
+    ):
+        result = await execute_sandbox_code(code=code, execution_folder=execution_folder)
+
+    assert result.success, f"sandbox execution failed: {result.error_message}\n{result.stderr}"
+    assert "TOKEN_VALUE: None" in result.stdout
+    assert "super-secret-promote-value" not in result.stdout

--- a/tests/mcp_server/test_workspace_env_scrub.py
+++ b/tests/mcp_server/test_workspace_env_scrub.py
@@ -18,12 +18,12 @@ import pytest
 from osprey.mcp_server.sandbox_env import (
     _SENSITIVE_ENV_EXACT,
     _SENSITIVE_ENV_SUFFIXES,
-    _scrub_sensitive_env,
+    scrub_sensitive_env,
 )
 from osprey.mcp_server.workspace.execution.sandbox_executor import execute_sandbox_code
 
 # ---------------------------------------------------------------------------
-# _scrub_sensitive_env — pure function
+# scrub_sensitive_env — pure function
 # ---------------------------------------------------------------------------
 
 
@@ -31,7 +31,7 @@ from osprey.mcp_server.workspace.execution.sandbox_executor import execute_sandb
 def test_scrub_removes_bluesky_promote_token():
     """BLUESKY_PROMOTE_TOKEN is dropped via the *_PROMOTE_TOKEN suffix rule."""
     env = {"BLUESKY_PROMOTE_TOKEN": "secret", "PATH": "/usr/bin"}
-    scrubbed = _scrub_sensitive_env(env)
+    scrubbed = scrub_sensitive_env(env)
     assert "BLUESKY_PROMOTE_TOKEN" not in scrubbed
     assert scrubbed["PATH"] == "/usr/bin"
 
@@ -40,7 +40,7 @@ def test_scrub_removes_bluesky_promote_token():
 def test_scrub_removes_event_dispatcher_token():
     """EVENT_DISPATCHER_TOKEN is dropped via the exact-name rule."""
     env = {"EVENT_DISPATCHER_TOKEN": "secret", "PATH": "/usr/bin"}
-    scrubbed = _scrub_sensitive_env(env)
+    scrubbed = scrub_sensitive_env(env)
     assert "EVENT_DISPATCHER_TOKEN" not in scrubbed
     assert scrubbed["PATH"] == "/usr/bin"
 
@@ -49,7 +49,7 @@ def test_scrub_removes_event_dispatcher_token():
 def test_scrub_generalizes_to_future_promote_tokens():
     """Any future *_PROMOTE_TOKEN name is scrubbed without a code change."""
     env = {"SOME_OTHER_BRIDGE_PROMOTE_TOKEN": "secret", "PATH": "/usr/bin"}
-    scrubbed = _scrub_sensitive_env(env)
+    scrubbed = scrub_sensitive_env(env)
     assert "SOME_OTHER_BRIDGE_PROMOTE_TOKEN" not in scrubbed
 
 
@@ -63,22 +63,22 @@ def test_scrub_preserves_unrelated_env():
         # either scrub rule — must survive.
         "TOKENIZER_CACHE_DIR": "/tmp/cache",
     }
-    scrubbed = _scrub_sensitive_env(env)
+    scrubbed = scrub_sensitive_env(env)
     assert scrubbed == env
 
 
 @pytest.mark.unit
 def test_scrub_does_not_mutate_input():
-    """_scrub_sensitive_env returns a copy; it must not mutate the caller's dict."""
+    """scrub_sensitive_env returns a copy; it must not mutate the caller's dict."""
     env = {"BLUESKY_PROMOTE_TOKEN": "secret", "PATH": "/usr/bin"}
     original = dict(env)
-    _scrub_sensitive_env(env)
+    scrub_sensitive_env(env)
     assert env == original
 
 
 @pytest.mark.unit
 def test_scrub_empty_env():
-    assert _scrub_sensitive_env({}) == {}
+    assert scrub_sensitive_env({}) == {}
 
 
 @pytest.mark.unit
@@ -98,7 +98,7 @@ def test_scrub_shared_with_python_executor():
     """
     from osprey.mcp_server.python_executor import executor as python_executor_module
 
-    assert python_executor_module._scrub_sensitive_env is _scrub_sensitive_env
+    assert python_executor_module.scrub_sensitive_env is scrub_sensitive_env
 
 
 # ---------------------------------------------------------------------------

--- a/tests/registry/test_scan_server_definition.py
+++ b/tests/registry/test_scan_server_definition.py
@@ -1,0 +1,169 @@
+"""Tests for the scan ServerDefinition in FRAMEWORK_SERVERS.
+
+Covers: module/env resolution, permissions_allow/permissions_ask contents,
+hooks_pre structure (launch_scan carries writes-check + approval, stop_scan
+carries approval only — the kill switch must never block stopping a scan),
+hooks_post error guidance, opt-in default_enabled, and that the registry-driven
+read-only disallow floor (``read_only_disallowed_tools``) automatically picks
+up both ask-gated scan tools without any scan-specific code there.
+"""
+
+from pathlib import Path
+
+from osprey.registry.mcp import FRAMEWORK_SERVERS, resolve_servers
+
+
+def _base_ctx(**overrides):
+    ctx = {
+        "project_root": "/tmp/test-project",
+        "current_python_env": "/usr/bin/python3",
+    }
+    ctx.update(overrides)
+    return ctx
+
+
+def _resolve_scan(cfg=None, ctx=None):
+    servers = resolve_servers(cfg or {}, ctx or _base_ctx())
+    matches = [s for s in servers if s["name"] == "scan"]
+    assert len(matches) == 1
+    return matches[0]
+
+
+# ---------------------------------------------------------------------------
+# Module / env resolution
+# ---------------------------------------------------------------------------
+
+
+def test_scan_server_module():
+    scan = _resolve_scan()
+    assert scan["args"] == ["-m", "osprey.mcp_server.scan"]
+
+
+def test_scan_server_env():
+    scan = _resolve_scan()
+    assert scan["env"]["OSPREY_CONFIG"] == "/tmp/test-project/config.yml"
+    assert scan["env"]["CONFIG_FILE"] == "/tmp/test-project/config.yml"
+    # Shell variable references pass through untouched for runtime expansion.
+    assert scan["env"]["BLUESKY_BRIDGE_URL"] == "${BLUESKY_BRIDGE_URL:-http://127.0.0.1:8090}"
+    assert scan["env"]["BLUESKY_PROMOTE_TOKEN"] == "${BLUESKY_PROMOTE_TOKEN:-}"
+
+
+def test_scan_server_disabled_by_default():
+    """Opt-in like phoebus — running it requires a live facility Bluesky bridge."""
+    scan = _resolve_scan()
+    assert scan["enabled"] is False
+
+
+def test_scan_server_enabled_via_config_override():
+    scan = _resolve_scan(cfg={"servers": {"scan": {"enabled": True}}})
+    assert scan["enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# Permissions
+# ---------------------------------------------------------------------------
+
+
+def test_scan_permissions_allow():
+    scan = _resolve_scan()
+    assert scan["permissions_allow"] == [
+        "create_scan_intent",
+        "scan_status",
+        "list_scan_plans",
+        "list_runs",
+        "read_scan_data",
+    ]
+
+
+def test_scan_permissions_ask():
+    scan = _resolve_scan()
+    assert scan["permissions_ask"] == ["launch_scan", "stop_scan"]
+
+
+# ---------------------------------------------------------------------------
+# Hooks
+# ---------------------------------------------------------------------------
+
+
+def test_scan_hooks_pre_structure():
+    scan = _resolve_scan()
+    by_matcher = {r["matcher"]: r for r in scan["hooks_pre"]}
+    assert set(by_matcher) == {"mcp__scan__launch_scan", "mcp__scan__stop_scan"}
+
+    launch = by_matcher["mcp__scan__launch_scan"]
+    launch_commands = [h["command"] for h in launch["hooks"]]
+    assert len(launch["hooks"]) == 2
+    assert any("osprey_writes_check.py" in c for c in launch_commands)
+    assert any("osprey_approval.py" in c for c in launch_commands)
+
+    stop = by_matcher["mcp__scan__stop_scan"]
+    stop_commands = [h["command"] for h in stop["hooks"]]
+    # stop_scan must NEVER be writes-check-gated — the kill switch must not
+    # block stopping a scan (the safe direction).
+    assert len(stop["hooks"]) == 1
+    assert "osprey_approval.py" in stop_commands[0]
+    assert not any("osprey_writes_check.py" in c for c in stop_commands)
+
+
+def test_scan_hooks_post_error_guidance():
+    scan = _resolve_scan()
+    assert len(scan["hooks_post"]) == 1
+    rule = scan["hooks_post"][0]
+    assert rule["matcher"] == "mcp__scan__.*"
+    assert any("osprey_error_guidance.py" in h["command"] for h in rule["hooks"])
+
+
+# ---------------------------------------------------------------------------
+# read_only_disallowed_tools auto-derivation (headless kill-switch floor)
+# ---------------------------------------------------------------------------
+
+
+def test_read_only_disallowed_tools_covers_scan_ask_tools(tmp_path: Path):
+    """launch_scan and stop_scan must both be blocked under bypassPermissions —
+    purely from the registry's permissions_ask entry, no scan-specific code."""
+    from osprey.agent_runner.write_tools import read_only_disallowed_tools
+
+    result = set(read_only_disallowed_tools(tmp_path))
+    assert "mcp__scan__launch_scan" in result
+    assert "mcp__scan__stop_scan" in result
+
+
+def test_hook_config_template_derives_write_tools_and_approval_prefix():
+    """hook_config.json.j2's own derivation logic: launch_scan lands in
+    write_tools (writes-check-gated), and 'mcp__scan__' lands in
+    approval_prefixes (both ask tools carry the approval hook)."""
+    import jinja2
+
+    template_path = (
+        Path(__file__).resolve().parents[2]
+        / "src/osprey/templates/claude_code/claude/hooks/hook_config.json.j2"
+    )
+    env = jinja2.Environment()
+    template = env.from_string(template_path.read_text(encoding="utf-8"))
+    scan = _resolve_scan(cfg={"servers": {"scan": {"enabled": True}}})
+    rendered = template.render(servers=[scan], control_system_write_tools=[])
+
+    import json
+
+    data = json.loads(rendered)
+    assert "mcp__scan__launch_scan" in data["write_tools"]
+    assert "mcp__scan__stop_scan" not in data["write_tools"]
+    assert "mcp__scan__" in data["approval_prefixes"]
+
+
+def test_scan_can_be_extended_like_other_framework_servers():
+    """Drift guard: scan has no `condition`, so build_extended_server() (used
+    for a second bridge instance, one per BLUESKY_BRIDGE_URL/BLUESKY_PROMOTE_TOKEN
+    per the plan) must accept it exactly like phoebus's extends path."""
+    from osprey.registry.mcp import build_extended_server
+
+    clone = build_extended_server("scan2", {"extends": "scan"})
+    assert clone is not None
+    assert clone.permissions_ask == ["launch_scan", "stop_scan"]
+    matchers = {r.matcher for r in clone.hooks_pre}
+    assert matchers == {"mcp__scan2__launch_scan", "mcp__scan2__stop_scan"}
+
+
+def test_scan_present_in_framework_servers():
+    assert "scan" in FRAMEWORK_SERVERS
+    assert FRAMEWORK_SERVERS["scan"].module == "osprey.mcp_server.scan"

--- a/tests/services/bluesky_bridge/test_builtin_plans.py
+++ b/tests/services/bluesky_bridge/test_builtin_plans.py
@@ -1,0 +1,83 @@
+"""Bluesky-marked coverage for the v1 built-in plan set (`plans.py`).
+
+`plans.py` imports `bluesky`, so it lives behind the optional
+`osprey-framework[bluesky-bridge]` extra — every test here is skipped via
+`pytest.importorskip` when bluesky is absent, keeping the import-clean fast
+lane green. To run these:
+
+    uv venv /tmp/bluesky-scratch
+    /tmp/bluesky-scratch/bin/pip install -e '.[bluesky-bridge]'
+    /tmp/bluesky-scratch/bin/python -m pytest \
+        tests/services/bluesky_bridge/test_builtin_plans.py -q
+
+Focuses on the parameter schemas' contract (which are pure pydantic and need
+no RunEngine) — the RunEngine-driven execution of these plans is covered by
+`test_runengine_integration.py`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("bluesky")
+
+from pydantic import ValidationError  # noqa: E402
+
+from osprey.services.bluesky_bridge.plans import (  # noqa: E402
+    BUILTIN_PLANS,
+    GridScanParams,
+    list_plan_specs,
+)
+
+
+def test_builtin_registry_exposes_the_v1_plan_set() -> None:
+    assert set(BUILTIN_PLANS) == {"count", "scan", "grid_scan"}
+    for name, spec in BUILTIN_PLANS.items():
+        assert spec.name == name
+        assert callable(spec.plan)
+
+
+def test_list_plan_specs_serializes_each_plan_with_its_schema() -> None:
+    served = {p["name"]: p for p in list_plan_specs()}
+    assert set(served) == {"count", "scan", "grid_scan"}
+    for entry in served.values():
+        assert entry["description"]  # every built-in ships a description
+        assert entry["schema"]["type"] == "object"  # a real JSON schema
+
+
+def test_grid_scan_params_accepts_matching_num_points_and_axes() -> None:
+    params = GridScanParams(
+        detectors=["det1"],
+        axes=[
+            {"motor": "m1", "start": 0.0, "stop": 1.0},
+            {"motor": "m2", "start": 0.0, "stop": 2.0},
+        ],
+        num_points=[3, 5],
+    )
+    assert len(params.num_points) == len(params.axes) == 2
+
+
+def test_grid_scan_params_rejects_mismatched_num_points_and_axes() -> None:
+    """The `model_validator` makes the length mismatch a schema-level
+    validation error (raised on construction / `model_validate`), not a bare
+    ValueError deferred to plan-build time."""
+    with pytest.raises(ValidationError, match="num_points must have one entry per axis"):
+        GridScanParams(
+            detectors=["det1"],
+            axes=[{"motor": "m1", "start": 0.0, "stop": 1.0}],
+            num_points=[3, 5],  # 2 points, 1 axis
+        )
+
+
+def test_grid_scan_schema_validation_path_matches_reinitialize() -> None:
+    """The bridge validates plan_args via `spec.schema.model_validate(...)` in
+    `reinitialize()`; a mismatched grid_scan payload must fail there too."""
+    spec = BUILTIN_PLANS["grid_scan"]
+    with pytest.raises(ValidationError):
+        spec.schema.model_validate(
+            {
+                "detectors": ["det1"],
+                "axes": [{"motor": "m1", "start": 0.0, "stop": 1.0}],
+                "num_points": [3, 5],
+            }
+        )

--- a/tests/services/bluesky_bridge/test_demo_scanner_wiring.py
+++ b/tests/services/bluesky_bridge/test_demo_scanner_wiring.py
@@ -1,0 +1,181 @@
+"""Tests for the opt-in demo-scanner FastAPI startup wiring (task 2.14a).
+
+`app.py`'s `_lifespan` hook wires a real bluesky-backed `BlueskyScanner`
+(against mock ophyd-async devices) ONLY when `BLUESKY_DEMO_SCANNER` is truthy
+(`_is_demo_scanner_enabled`) AND bluesky is importable — mirroring the
+`/plans` route's guarded/lazy-import pattern so the Phase-1 "app.py
+import-clean of bluesky" invariant holds whether the extra is absent or the
+flag is unset. The truthy check deliberately accepts a few equivalent
+spellings ("1", "true", "yes", "on", case/whitespace-insensitive) rather than
+one exact string, so this hook can never silently drift out of sync with
+whatever value the deploy template/generator actually sets (the template's
+own house convention is `"true"`, matching `container_lifecycle.py`'s
+`DEV_MODE="true"`, but this hook is not brittle to that one spelling).
+Exercised here:
+
+- `_is_demo_scanner_enabled()` directly, across the full truthy/non-truthy
+  value matrix (fast, no TestClient/lifespan needed).
+- Flag absent, or a non-truthy value, or set but bluesky absent: app.py
+  stays import-clean and falls back to `FakeScanner` — runs entirely in the
+  main venv, no bluesky.
+- Flag truthy (both "1" and "true", the two production-relevant spellings)
+  AND bluesky present: the app wires `BlueskyScanner`, and a full
+  promote -> scan -> read_scan_data round trip returns real buffered rows.
+  Guarded with `pytest.importorskip` so these are skipped (not failed) when
+  bluesky isn't installed, keeping `ci_check` green.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+from osprey.services.bluesky_bridge import app as app_module
+from osprey.services.bluesky_bridge import live_rows
+from osprey.services.bluesky_bridge.app import app, set_scanner_factory
+from osprey.services.bluesky_bridge.runs import registry
+from osprey.services.bluesky_bridge.scanner import FakeScanner
+
+_ENV_VAR = "BLUESKY_DEMO_SCANNER"
+_TOKEN_VAR = "BLUESKY_PROMOTE_TOKEN"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(monkeypatch: pytest.MonkeyPatch):
+    """Every test gets a clean flag, registry, live-row buffer, and scanner factory."""
+    monkeypatch.delenv(_ENV_VAR, raising=False)
+    registry._runs.clear()
+    live_rows._clear()
+    set_scanner_factory(FakeScanner)
+    yield
+    registry._runs.clear()
+    live_rows._clear()
+    set_scanner_factory(FakeScanner)
+
+
+# =========================================================================
+# _is_demo_scanner_enabled(): the full truthy/non-truthy value matrix
+# =========================================================================
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", " true ", "yes", "YES", "on", "On"])
+def test_is_demo_scanner_enabled_accepts_truthy_variants(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv(_ENV_VAR, value)
+    assert app_module._is_demo_scanner_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", "off", "", "bogus"])
+def test_is_demo_scanner_enabled_rejects_non_truthy_variants(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv(_ENV_VAR, value)
+    assert app_module._is_demo_scanner_enabled() is False
+
+
+def test_is_demo_scanner_enabled_false_when_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_ENV_VAR, raising=False)
+    assert app_module._is_demo_scanner_enabled() is False
+
+
+# =========================================================================
+# Flag unset/off: app stays import-clean, FakeScanner default unchanged
+# =========================================================================
+
+
+def test_flag_unset_stays_import_clean_and_keeps_fake_scanner_default() -> None:
+    with TestClient(app) as client:
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+    assert app_module._scanner_factory is FakeScanner
+
+
+def test_flag_false_is_treated_as_off_not_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """App-level confirmation (the value matrix above already covers the
+    helper's own logic exhaustively) that an off value flows through the
+    real lifespan hook, not just the boolean helper in isolation.
+    """
+    monkeypatch.setenv(_ENV_VAR, "false")
+
+    with TestClient(app) as client:
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+    assert app_module._scanner_factory is FakeScanner
+
+
+# =========================================================================
+# Flag truthy but bluesky absent: guarded fallback, no crash
+# =========================================================================
+
+
+@pytest.mark.parametrize("value", ["1", "true"])
+def test_flag_set_but_bluesky_absent_falls_back_to_fake_scanner(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, value: str
+) -> None:
+    try:
+        import bluesky  # noqa: F401
+    except ImportError:
+        pass
+    else:
+        pytest.skip("bluesky is installed in this environment; nothing to fall back from")
+
+    monkeypatch.setenv(_ENV_VAR, value)
+
+    with caplog.at_level("WARNING", logger="osprey.services.bluesky_bridge.app"):
+        with TestClient(app) as client:
+            resp = client.get("/health")
+            assert resp.status_code == 200
+
+    assert app_module._scanner_factory is FakeScanner
+    assert any("falling back to FakeScanner" in rec.message for rec in caplog.records)
+
+
+# =========================================================================
+# Flag truthy AND bluesky present: real wiring, full round trip
+# =========================================================================
+
+
+@pytest.mark.parametrize("value", ["1", "true"])
+def test_flag_set_with_bluesky_present_wires_and_completes_a_real_scan(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    pytest.importorskip("bluesky")
+    pytest.importorskip("ophyd_async")
+
+    monkeypatch.setenv(_ENV_VAR, value)
+    monkeypatch.setenv(_TOKEN_VAR, "s3cr3t")
+
+    with TestClient(app) as client:
+        assert app_module._scanner_factory is not FakeScanner
+
+        create_resp = client.post(
+            "/runs",
+            json={"plan_name": "count", "plan_args": {"detectors": ["det1"], "num": 3}},
+        )
+        assert create_resp.status_code == 200, create_resp.text
+        run_id = create_resp.json()["id"]
+
+        promote_resp = client.post(f"/runs/{run_id}/promote", headers={"X-Promote-Token": "s3cr3t"})
+        assert promote_resp.status_code == 200, promote_resp.text
+
+        deadline = time.monotonic() + 15.0
+        while client.get(f"/runs/{run_id}").json()["status"] == "running":
+            if time.monotonic() > deadline:
+                raise AssertionError("demo scan did not complete within the timeout")
+            time.sleep(0.05)
+
+        status_body = client.get(f"/runs/{run_id}").json()
+        assert status_body["status"] == "completed"
+
+        data_resp = client.get(f"/runs/{run_id}/data")
+        assert data_resp.status_code == 200, data_resp.text
+        data_body = data_resp.json()
+        assert data_body["run_uid"] == status_body["run_uid"]
+        assert data_body["row_count"] == 3
+        assert len(data_body["rows"]) == 3
+        assert "partial" not in data_body

--- a/tests/services/bluesky_bridge/test_lifecycle.py
+++ b/tests/services/bluesky_bridge/test_lifecycle.py
@@ -1,0 +1,355 @@
+"""Unit tests for the bridge lifecycle core end-to-end over HTTP (FakeScanner, no bluesky).
+
+Exercises the assembled FastAPI app (`bluesky_bridge/app.py`) rather than calling
+`runs.py`/`security.py` directly, so these tests also stand as a contract test
+for the routes' error semantics (FR5: 404/409/403/503/500) and the run
+lifecycle state machine as seen by an HTTP client (e.g. the `scan` MCP tools).
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+from fastapi.testclient import TestClient
+
+from osprey.services.bluesky_bridge.app import app, promote_run, set_scanner_factory, stop_run
+from osprey.services.bluesky_bridge.runs import registry
+from osprey.services.bluesky_bridge.scanner import FakeScanner
+
+_ENV_VAR = "BLUESKY_PROMOTE_TOKEN"
+_TOKEN = "s3cr3t"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_bridge_state():
+    """Every test gets an empty run registry and a fresh default scanner factory.
+
+    Both `registry` and the app's `_scanner_factory` are process-wide
+    singletons (as they are in a real bridge instance), so tests must clean
+    up after themselves rather than relying on module reimport.
+    """
+    registry._runs.clear()
+    set_scanner_factory(FakeScanner)
+    yield
+    registry._runs.clear()
+    set_scanner_factory(FakeScanner)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _create_run(client: TestClient) -> str:
+    resp = client.post("/runs", json={"plan_name": "count", "plan_args": {"num": 3}})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "intent"
+    return body["id"]
+
+
+# =========================================================================
+# Token gate: 503 unarmed, 403 mismatch, 200 valid
+# =========================================================================
+
+
+def test_promote_without_token_returns_503_and_touches_no_scanner(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(_ENV_VAR, raising=False)
+    scanner = FakeScanner()
+    set_scanner_factory(lambda: scanner)
+
+    run_id = _create_run(client)
+    resp = client.post(f"/runs/{run_id}/promote")
+
+    assert resp.status_code == 503
+    assert scanner.reinitialize_calls == 0
+    assert scanner.start_calls == 0
+    assert client.get(f"/runs/{run_id}").json()["status"] == "intent"
+
+
+def test_promote_with_invalid_token_returns_403_and_touches_no_scanner(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(_ENV_VAR, _TOKEN)
+    scanner = FakeScanner()
+    set_scanner_factory(lambda: scanner)
+
+    run_id = _create_run(client)
+    resp = client.post(f"/runs/{run_id}/promote", headers={"X-Promote-Token": "wrong"})
+
+    assert resp.status_code == 403
+    assert scanner.reinitialize_calls == 0
+    assert scanner.start_calls == 0
+    assert client.get(f"/runs/{run_id}").json()["status"] == "intent"
+
+
+def test_promote_with_valid_token_starts_the_scan(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(_ENV_VAR, _TOKEN)
+    scanner = FakeScanner()
+    set_scanner_factory(lambda: scanner)
+
+    run_id = _create_run(client)
+    resp = client.post(f"/runs/{run_id}/promote", headers={"X-Promote-Token": _TOKEN})
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "running"
+    assert body["launched_by"] == "agent"
+    assert body["run_uid"]
+    assert scanner.reinitialize_calls == 1
+    assert scanner.start_calls == 1
+
+
+# =========================================================================
+# Concurrency / re-promotion guards: 409
+# =========================================================================
+
+
+def test_concurrent_second_promote_returns_409_while_active(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(_ENV_VAR, _TOKEN)
+    set_scanner_factory(FakeScanner)
+
+    run_id = _create_run(client)
+    first = client.post(f"/runs/{run_id}/promote", headers={"X-Promote-Token": _TOKEN})
+    assert first.status_code == 200
+
+    second = client.post(f"/runs/{run_id}/promote", headers={"X-Promote-Token": _TOKEN})
+    assert second.status_code == 409
+    assert "already promoted" in second.json()["detail"]
+
+
+def test_promote_after_stop_returns_409(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Stopping an intent that was never promoted still permanently forecloses
+    # promotion — do_promote's `stopped` guard fires regardless.
+    monkeypatch.setenv(_ENV_VAR, _TOKEN)
+    set_scanner_factory(FakeScanner)
+
+    run_id = _create_run(client)
+    stop_resp = client.post(f"/runs/{run_id}/stop")
+    assert stop_resp.status_code == 200
+    assert stop_resp.json()["status"] == "stopped"
+
+    promote_resp = client.post(f"/runs/{run_id}/promote", headers={"X-Promote-Token": _TOKEN})
+    assert promote_resp.status_code == 409
+    assert "stopped" in promote_resp.json()["detail"]
+
+
+def test_promote_after_stopping_an_already_promoted_run_returns_409(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(_ENV_VAR, _TOKEN)
+    set_scanner_factory(FakeScanner)
+
+    run_id = _create_run(client)
+    first_promote = client.post(f"/runs/{run_id}/promote", headers={"X-Promote-Token": _TOKEN})
+    assert first_promote.status_code == 200
+
+    stop_resp = client.post(f"/runs/{run_id}/stop")
+    assert stop_resp.status_code == 200
+    assert stop_resp.json()["status"] == "stopped"
+
+    promote_resp = client.post(f"/runs/{run_id}/promote", headers={"X-Promote-Token": _TOKEN})
+    assert promote_resp.status_code == 409
+
+
+# =========================================================================
+# State machine: intent -> running -> completed | stopped | error
+# =========================================================================
+
+
+def test_state_machine_intent_before_promotion(client: TestClient) -> None:
+    run_id = _create_run(client)
+    assert client.get(f"/runs/{run_id}").json()["status"] == "intent"
+
+
+def test_state_machine_running_after_promotion(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(_ENV_VAR, _TOKEN)
+    set_scanner_factory(FakeScanner)
+
+    run_id = _create_run(client)
+    client.post(f"/runs/{run_id}/promote", headers={"X-Promote-Token": _TOKEN})
+    assert client.get(f"/runs/{run_id}").json()["status"] == "running"
+
+
+def test_state_machine_completed_once_scan_finishes_cleanly(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(_ENV_VAR, _TOKEN)
+    scanner = FakeScanner()
+    set_scanner_factory(lambda: scanner)
+
+    run_id = _create_run(client)
+    client.post(f"/runs/{run_id}/promote", headers={"X-Promote-Token": _TOKEN})
+    scanner.simulate_completion()
+
+    body = client.get(f"/runs/{run_id}").json()
+    assert body["status"] == "completed"
+    assert body["completion"] == 1.0
+
+
+def test_state_machine_stopped_via_stop_route(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(_ENV_VAR, _TOKEN)
+    scanner = FakeScanner()
+    set_scanner_factory(lambda: scanner)
+
+    run_id = _create_run(client)
+    client.post(f"/runs/{run_id}/promote", headers={"X-Promote-Token": _TOKEN})
+    stop_resp = client.post(f"/runs/{run_id}/stop")
+
+    assert stop_resp.status_code == 200
+    assert stop_resp.json()["status"] == "stopped"
+    assert scanner.stop_calls == 1
+    assert client.get(f"/runs/{run_id}").json()["status"] == "stopped"
+
+
+def test_state_machine_error_when_scanner_ends_in_error_state(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(_ENV_VAR, _TOKEN)
+    scanner = FakeScanner()
+    set_scanner_factory(lambda: scanner)
+
+    run_id = _create_run(client)
+    client.post(f"/runs/{run_id}/promote", headers={"X-Promote-Token": _TOKEN})
+    scanner.simulate_error("device timeout")
+
+    body = client.get(f"/runs/{run_id}").json()
+    assert body["status"] == "error"
+    assert "error" in body
+
+
+def test_state_machine_error_when_reinitialize_fails_at_promote_time(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(_ENV_VAR, _TOKEN)
+    set_scanner_factory(lambda: FakeScanner(reinitialize_fails=True))
+
+    run_id = _create_run(client)
+    resp = client.post(f"/runs/{run_id}/promote", headers={"X-Promote-Token": _TOKEN})
+
+    assert resp.status_code == 500
+    assert client.get(f"/runs/{run_id}").json()["status"] == "error"
+
+
+# =========================================================================
+# Unknown run: 404
+# =========================================================================
+
+
+def test_get_unknown_run_returns_404(client: TestClient) -> None:
+    resp = client.get("/runs/does-not-exist")
+    assert resp.status_code == 404
+
+
+def test_promote_unknown_run_returns_404(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(_ENV_VAR, _TOKEN)
+    resp = client.post("/runs/does-not-exist/promote", headers={"X-Promote-Token": _TOKEN})
+    assert resp.status_code == 404
+
+
+def test_stop_unknown_run_returns_404(client: TestClient) -> None:
+    resp = client.post("/runs/does-not-exist/stop")
+    assert resp.status_code == 404
+
+
+# =========================================================================
+# Listing
+# =========================================================================
+
+
+def test_list_runs_returns_newest_first(client: TestClient) -> None:
+    first_id = _create_run(client)
+    second_id = _create_run(client)
+
+    body = client.get("/runs").json()
+    assert [run["id"] for run in body] == [second_id, first_id]
+
+
+# =========================================================================
+# Race: stop() landing during do_promote's unlocked scanner-build window
+# =========================================================================
+
+
+def test_stop_during_unlocked_build_window_never_leaves_a_live_untracked_scan(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Deterministically interleave promote and stop around the unlocked window.
+
+    `do_promote` sets `promoting=True` under the lock, then builds/starts the
+    scanner OUTSIDE the lock (it may be slow) before re-acquiring the lock to
+    publish `scanner`/`promoted`. A `stop()` landing in that unlocked window
+    used to see `promoted=False`/`scanner=None`, skip stopping anything, and
+    just record `stopped=True` — after which the just-started scanner got
+    published anyway: a live scan running behind a run reporting "stopped".
+
+    This test forces exactly that interleaving via a scanner whose
+    `reinitialize` blocks (simulating the slow build) until the stop call has
+    actually landed, and asserts the scanner is stopped exactly once and never
+    left running.
+    """
+    monkeypatch.setenv(_ENV_VAR, _TOKEN)
+
+    reinitialize_started = threading.Event()
+    stop_landed = threading.Event()
+    created: dict[str, FakeScanner] = {}
+
+    class BlockingBuildScanner(FakeScanner):
+        def reinitialize(self, exec_config: object) -> bool:
+            # Signal that do_promote has reached the unlocked build phase
+            # (past the `promoting=True` lock section), then hold here —
+            # simulating a slow scanner build — until stop() has landed.
+            reinitialize_started.set()
+            assert stop_landed.wait(timeout=5), "stop() never landed during the build window"
+            return super().reinitialize(exec_config)
+
+    def factory() -> BlockingBuildScanner:
+        scanner = BlockingBuildScanner()
+        created["scanner"] = scanner
+        return scanner
+
+    set_scanner_factory(factory)
+    run_id = _create_run(client)
+
+    promote_result: dict[str, object] = {}
+
+    def run_promote() -> None:
+        promote_result["response"] = promote_run(run_id, x_promote_token=_TOKEN)
+
+    promoter = threading.Thread(target=run_promote)
+    promoter.start()
+    try:
+        assert reinitialize_started.wait(timeout=5), "promote never reached the build phase"
+
+        # The promote thread is now blocked inside the unlocked build window
+        # (promoting=True, scanner/promoted not yet published). Stop lands here.
+        stop_run(run_id)
+        stop_landed.set()
+
+        promoter.join(timeout=5)
+        assert not promoter.is_alive(), "promote thread did not finish"
+    finally:
+        # Always unblock the background thread even if an assertion above failed.
+        stop_landed.set()
+
+    scanner = created["scanner"]
+    assert scanner.stop_calls == 1, "scanner must be stopped exactly once, not left running"
+    assert scanner.is_scanning_active() is False
+
+    run = registry.get(run_id)
+    assert run.stopped is True
+    assert run.status == "stopped"

--- a/tests/services/bluesky_bridge/test_live_rows.py
+++ b/tests/services/bluesky_bridge/test_live_rows.py
@@ -1,0 +1,235 @@
+"""Unit tests for the bounded live-row buffer (`live_rows.py`).
+
+Feeds synthetic bluesky-shaped documents (plain dicts) directly into
+`LiveRowRecorder` — no bluesky import anywhere in this file or the module
+under test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from osprey.services.bluesky_bridge import live_rows
+from osprey.services.bluesky_bridge.live_rows import LiveRowRecorder
+
+
+@pytest.fixture(autouse=True)
+def _isolated_buffers():
+    """Every test gets an empty module-level buffer store."""
+    live_rows._clear()
+    yield
+    live_rows._clear()
+
+
+def _start_doc(uid: str = "run-1") -> dict:
+    return {"uid": uid}
+
+
+def _event_doc(data: dict) -> dict:
+    return {"data": data}
+
+
+def _stop_doc(uid: str = "run-1") -> dict:
+    return {"run_start": uid}
+
+
+# =========================================================================
+# Basic recording: start -> event(s) -> stop
+# =========================================================================
+
+
+def test_unknown_run_uid_returns_none() -> None:
+    assert live_rows.get("does-not-exist") is None
+
+
+def test_start_doc_creates_an_empty_partial_buffer() -> None:
+    recorder = LiveRowRecorder()
+    recorder("start", _start_doc("run-1"))
+
+    buf = live_rows.get("run-1")
+    assert buf is not None
+    assert buf["columns"] == []
+    assert buf["rows"] == []
+    assert buf["partial"] is True
+    assert buf["total_seen"] == 0
+
+
+def test_event_docs_append_rows_in_column_order() -> None:
+    recorder = LiveRowRecorder()
+    recorder("start", _start_doc("run-1"))
+    recorder("event", _event_doc({"x": 1.0, "y": 2.0}))
+    recorder("event", _event_doc({"x": 3.0, "y": 4.0}))
+
+    buf = live_rows.get("run-1")
+    assert buf["columns"] == ["x", "y"]
+    assert buf["rows"] == [[1.0, 2.0], [3.0, 4.0]]
+    assert buf["total_seen"] == 2
+    assert buf["partial"] is True
+
+
+def test_stop_doc_flips_partial_to_false() -> None:
+    recorder = LiveRowRecorder()
+    recorder("start", _start_doc("run-1"))
+    recorder("event", _event_doc({"x": 1.0}))
+    recorder("stop", _stop_doc("run-1"))
+
+    buf = live_rows.get("run-1")
+    assert buf["partial"] is False
+    assert buf["rows"] == [[1.0]]
+
+
+def test_completed_run_stays_readable_after_stop() -> None:
+    """RETAINS completed runs — the whole point of this module vs. BELLA's demo-day eviction."""
+    recorder = LiveRowRecorder()
+    recorder("start", _start_doc("run-1"))
+    recorder("event", _event_doc({"x": 1.0}))
+    recorder("stop", _stop_doc("run-1"))
+
+    # No new run has started; the completed run's buffer must still be there.
+    buf = live_rows.get("run-1")
+    assert buf is not None
+    assert buf["partial"] is False
+    assert buf["total_seen"] == 1
+
+
+# =========================================================================
+# Column discovery: incremental, first-seen order, backfill of earlier rows
+# =========================================================================
+
+
+def test_new_column_appearing_mid_run_backfills_earlier_rows_with_none() -> None:
+    recorder = LiveRowRecorder()
+    recorder("start", _start_doc("run-1"))
+    recorder("event", _event_doc({"x": 1.0}))
+    recorder("event", _event_doc({"x": 2.0, "y": 5.0}))
+
+    buf = live_rows.get("run-1")
+    assert buf["columns"] == ["x", "y"]
+    assert buf["rows"] == [[1.0, None], [2.0, 5.0]]
+
+
+def test_event_missing_an_already_known_column_records_none() -> None:
+    recorder = LiveRowRecorder()
+    recorder("start", _start_doc("run-1"))
+    recorder("event", _event_doc({"x": 1.0, "y": 2.0}))
+    recorder("event", _event_doc({"x": 3.0}))
+
+    buf = live_rows.get("run-1")
+    assert buf["rows"] == [[1.0, 2.0], [3.0, None]]
+
+
+# =========================================================================
+# Per-run row cap: total_seen keeps counting past the storage cap
+# =========================================================================
+
+
+def test_row_storage_cap_stops_appending_but_total_seen_keeps_counting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(live_rows, "_MAX_ROWS_PER_RUN", 3)
+
+    recorder = LiveRowRecorder()
+    recorder("start", _start_doc("run-1"))
+    for i in range(5):
+        recorder("event", _event_doc({"x": float(i)}))
+
+    buf = live_rows.get("run-1")
+    assert len(buf["rows"]) == 3
+    assert buf["total_seen"] == 5
+
+
+# =========================================================================
+# Run buffer retention: LRU eviction past _MAX_RUNS
+# =========================================================================
+
+
+def test_oldest_run_buffer_evicted_once_max_runs_exceeded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(live_rows, "_MAX_RUNS", 2)
+
+    for uid in ("run-1", "run-2", "run-3"):
+        recorder = LiveRowRecorder()
+        recorder("start", _start_doc(uid))
+
+    assert live_rows.get("run-1") is None
+    assert live_rows.get("run-2") is not None
+    assert live_rows.get("run-3") is not None
+
+
+def test_writing_to_a_run_moves_it_to_the_front_of_the_eviction_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(live_rows, "_MAX_RUNS", 2)
+
+    first = LiveRowRecorder()
+    first("start", _start_doc("run-1"))
+    second = LiveRowRecorder()
+    second("start", _start_doc("run-2"))
+
+    # Touch run-1 again so it is no longer the least-recently-used entry.
+    first("event", _event_doc({"x": 1.0}))
+
+    # A brand new run-3 should now evict run-2 (least recently touched), not run-1.
+    third = LiveRowRecorder()
+    third("start", _start_doc("run-3"))
+
+    assert live_rows.get("run-1") is not None
+    assert live_rows.get("run-2") is None
+    assert live_rows.get("run-3") is not None
+
+
+# =========================================================================
+# Recorder never raises: a bad document must not propagate
+# =========================================================================
+
+
+def test_malformed_event_doc_does_not_raise() -> None:
+    recorder = LiveRowRecorder()
+    recorder("start", _start_doc("run-1"))
+    # `data` is not iterable — would normally break `for key in data`, but the
+    # recorder is fully exception-wrapped.
+    recorder("event", {"data": 42})
+
+    buf = live_rows.get("run-1")
+    assert buf["total_seen"] == 0  # exception raised before total_seen incremented
+
+
+def test_event_before_any_start_is_ignored_without_raising() -> None:
+    recorder = LiveRowRecorder()
+    recorder("event", _event_doc({"x": 1.0}))  # no prior start()
+    assert live_rows.get("run-1") is None
+
+
+def test_stop_before_any_start_is_ignored_without_raising() -> None:
+    recorder = LiveRowRecorder()
+    recorder("stop", _stop_doc("run-1"))  # no prior start()
+    assert live_rows.get("run-1") is None
+
+
+def test_unknown_document_name_is_ignored() -> None:
+    recorder = LiveRowRecorder()
+    recorder("start", _start_doc("run-1"))
+    recorder("descriptor", {"data_keys": {"x": {}}})  # not handled, must not raise
+
+    buf = live_rows.get("run-1")
+    assert buf["rows"] == []
+
+
+# =========================================================================
+# get() returns a snapshot copy, not a live reference
+# =========================================================================
+
+
+def test_get_returns_a_copy_not_a_live_reference() -> None:
+    recorder = LiveRowRecorder()
+    recorder("start", _start_doc("run-1"))
+    recorder("event", _event_doc({"x": 1.0}))
+
+    snapshot = live_rows.get("run-1")
+    snapshot["rows"].append([999.0])
+    snapshot["columns"].append("bogus")
+
+    buf = live_rows.get("run-1")
+    assert buf["rows"] == [[1.0]]
+    assert buf["columns"] == ["x"]

--- a/tests/services/bluesky_bridge/test_plan_injection.py
+++ b/tests/services/bluesky_bridge/test_plan_injection.py
@@ -1,0 +1,256 @@
+"""Contract test for the facility plan-injection seam (`plan_loader.py`).
+
+Loads a fake facility plan module from a temp dir OUTSIDE the
+`osprey.services.bluesky_bridge` package — exactly the "facility repo, not
+this framework" shape the contract promises — and asserts the bridge serves
+its plans via `GET /plans` and constructs its devices. The fake module needs
+NO bluesky import (only `osprey.services.bluesky_bridge.plan_types.PlanSpec`,
+which is itself bluesky-clean), so this test also proves `plan_loader.py`
+works in a bluesky-less bridge process.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from osprey.services.bluesky_bridge import plan_loader
+from osprey.services.bluesky_bridge.app import app
+
+_ENV_VAR = "BLUESKY_PLAN_MODULE"
+
+_FACILITY_MODULE_SOURCE = '''
+"""A fake facility plan module — deliberately outside the osprey package."""
+
+from osprey.services.bluesky_bridge.plan_types import PlanSpec
+from pydantic import BaseModel
+
+
+class WiggleParams(BaseModel):
+    amplitude: float = 1.0
+
+
+def _wiggle_plan(devices, params):
+    """No bluesky needed: just prove `devices` and `params` were threaded through."""
+    return {"device": devices["wiggler"], "amplitude": params.amplitude}
+
+
+PLANS = {
+    "wiggle": PlanSpec(
+        name="wiggle",
+        plan=_wiggle_plan,
+        schema=WiggleParams,
+        description="A facility-specific plan not in the built-in set.",
+    ),
+}
+
+
+def get_devices():
+    return {"wiggler": "fake-wiggler-device"}
+'''
+
+
+@pytest.fixture(autouse=True)
+def _isolated_facility_plans(monkeypatch: pytest.MonkeyPatch):
+    """Every test gets a clean plan_loader cache and no leftover env var."""
+    monkeypatch.delenv(_ENV_VAR, raising=False)
+    plan_loader.reset_facility_plans()
+    yield
+    plan_loader.reset_facility_plans()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _write_facility_module(tmp_path: Path) -> Path:
+    facility_dir = tmp_path / "not_the_osprey_package"
+    facility_dir.mkdir()
+    module_path = facility_dir / "my_facility_plans.py"
+    module_path.write_text(_FACILITY_MODULE_SOURCE)
+    return module_path
+
+
+def test_load_facility_plans_returns_empty_when_unconfigured() -> None:
+    result = plan_loader.load_facility_plans()
+    assert result.plans == {}
+    assert result.devices == {}
+
+
+def test_load_facility_plans_reads_plans_and_devices_from_a_temp_module(tmp_path: Path) -> None:
+    module_path = _write_facility_module(tmp_path)
+
+    result = plan_loader.load_facility_plans(str(module_path))
+
+    assert set(result.plans) == {"wiggle"}
+    assert result.plans["wiggle"].name == "wiggle"
+    assert result.devices == {"wiggler": "fake-wiggler-device"}
+
+
+def test_load_facility_plans_resolves_module_path_from_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module_path = _write_facility_module(tmp_path)
+    monkeypatch.setenv(_ENV_VAR, str(module_path))
+
+    result = plan_loader.load_facility_plans()
+
+    assert set(result.plans) == {"wiggle"}
+
+
+def test_load_facility_plans_raises_on_missing_module_file(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        plan_loader.load_facility_plans(str(tmp_path / "does_not_exist.py"))
+
+
+def test_load_facility_plans_raises_when_plans_attribute_missing(tmp_path: Path) -> None:
+    module_path = tmp_path / "no_plans.py"
+    module_path.write_text("def get_devices():\n    return {}\n")
+
+    with pytest.raises(AttributeError, match="PLANS"):
+        plan_loader.load_facility_plans(str(module_path))
+
+
+def test_load_facility_plans_raises_when_get_devices_missing(tmp_path: Path) -> None:
+    module_path = tmp_path / "no_get_devices.py"
+    module_path.write_text("PLANS = {}\n")
+
+    with pytest.raises(AttributeError, match="get_devices"):
+        plan_loader.load_facility_plans(str(module_path))
+
+
+def test_load_facility_plans_propagates_get_devices_errors(tmp_path: Path) -> None:
+    """A facility `get_devices()` that raises must surface, not be swallowed —
+    a facility that can't build its devices is misconfigured and should fail
+    loudly rather than serve plans against an empty device map."""
+    module_path = tmp_path / "boom_devices.py"
+    module_path.write_text(
+        "PLANS = {}\n\ndef get_devices():\n    raise RuntimeError('device backend unavailable')\n"
+    )
+
+    with pytest.raises(RuntimeError, match="device backend unavailable"):
+        plan_loader.load_facility_plans(str(module_path))
+
+
+def test_load_facility_plans_registers_module_in_sys_modules(tmp_path: Path) -> None:
+    """The loaded facility module is registered in `sys.modules` under its
+    synthetic name, so intra-module self-references (dataclasses, pickling)
+    resolve during import."""
+    module_path = _write_facility_module(tmp_path)
+    synthetic_name = f"_bluesky_bridge_facility_plans_{module_path.stem}"
+    sys.modules.pop(synthetic_name, None)  # clean precondition (other tests share the stem)
+
+    plan_loader.load_facility_plans(str(module_path))
+
+    assert synthetic_name in sys.modules
+    del sys.modules[synthetic_name]
+
+
+def test_load_facility_plans_does_not_leave_module_in_sys_modules_on_exec_failure(
+    tmp_path: Path,
+) -> None:
+    """A facility module that raises during import leaves no half-initialized
+    entry behind in `sys.modules` to shadow a later, fixed load."""
+    module_path = tmp_path / "explodes_on_import.py"
+    module_path.write_text("raise RuntimeError('boom at import time')\n")
+    synthetic_name = f"_bluesky_bridge_facility_plans_{module_path.stem}"
+
+    with pytest.raises(RuntimeError, match="boom at import time"):
+        plan_loader.load_facility_plans(str(module_path))
+
+    assert synthetic_name not in sys.modules
+
+
+def test_get_plans_serves_facility_injected_plan_via_http(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    """End-to-end: GET /plans includes the facility's plan, with its schema."""
+    module_path = _write_facility_module(tmp_path)
+    monkeypatch.setenv(_ENV_VAR, str(module_path))
+
+    resp = client.get("/plans")
+
+    assert resp.status_code == 200
+    plans_by_name = {p["name"]: p for p in resp.json()}
+    assert "wiggle" in plans_by_name
+    wiggle = plans_by_name["wiggle"]
+    assert wiggle["description"] == "A facility-specific plan not in the built-in set."
+    assert wiggle["schema"]["properties"]["amplitude"]["default"] == 1.0
+
+
+def test_get_facility_plans_constructs_devices_once_and_caches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`get_facility_plans()` is a cached singleton — one `get_devices()` call per process."""
+    module_path = _write_facility_module(tmp_path)
+    monkeypatch.setenv(_ENV_VAR, str(module_path))
+
+    first = plan_loader.get_facility_plans()
+    second = plan_loader.get_facility_plans()
+
+    assert first is second
+    assert first.devices == {"wiggler": "fake-wiggler-device"}
+
+
+def test_load_facility_plans_warns_when_a_plan_shadows_a_builtin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A facility plan reusing a built-in's name (e.g. `count`) logs a warning
+    at load time — silent shadowing would otherwise be a surprising way to
+    lose a built-in without any trace. Injects a fake `plans` module into
+    `sys.modules` so this is testable without bluesky installed: relative
+    imports resolve against `sys.modules` first, so `plan_loader`'s guarded
+    `from .plans import BUILTIN_PLANS` picks up the fake instead of trying
+    (and failing) to import the real bluesky-backed module.
+    """
+    fake_plans_module = types.ModuleType("osprey.services.bluesky_bridge.plans")
+    fake_plans_module.BUILTIN_PLANS = {"count": object()}  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "osprey.services.bluesky_bridge.plans", fake_plans_module)
+
+    facility_dir = tmp_path / "shadowing_facility"
+    facility_dir.mkdir()
+    module_path = facility_dir / "shadow_plans.py"
+    module_path.write_text(
+        "from osprey.services.bluesky_bridge.plan_types import PlanSpec\n"
+        "from pydantic import BaseModel\n\n"
+        "class P(BaseModel):\n"
+        "    pass\n\n"
+        "PLANS = {'count': PlanSpec(name='count', plan=lambda d, p: None, schema=P, "
+        "description='facility count')}\n\n"
+        "def get_devices():\n"
+        "    return {}\n"
+    )
+
+    with caplog.at_level(logging.WARNING, logger="osprey.services.bluesky_bridge.plan_loader"):
+        result = plan_loader.load_facility_plans(str(module_path))
+
+    assert "count" in result.plans
+    assert any(
+        record.levelno == logging.WARNING and "count" in record.message for record in caplog.records
+    )
+
+
+def test_get_plans_reraises_a_non_bridge_import_error_from_builtins(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    """`GET /plans` must only swallow an ImportError caused by a missing
+    bridge dependency (bluesky/ophyd/ophyd_async/tiled) — anything else (e.g.
+    `plans.py` itself missing an expected attribute) is a genuine bug and
+    must propagate, not silently degrade to an empty/facility-only list.
+
+    Injects a fake, attribute-less `plans` module into `sys.modules` so
+    `from .plans import BUILTIN_PLANS` raises "cannot import name", whose
+    `ImportError.name` is the `plans` module itself — not a bridge dependency
+    — so the route's allow-list must re-raise rather than swallow it.
+    """
+    broken_plans_module = types.ModuleType("osprey.services.bluesky_bridge.plans")
+    monkeypatch.setitem(sys.modules, "osprey.services.bluesky_bridge.plans", broken_plans_module)
+
+    with pytest.raises(ImportError):
+        client.get("/plans")

--- a/tests/services/bluesky_bridge/test_plan_injection_contract.py
+++ b/tests/services/bluesky_bridge/test_plan_injection_contract.py
@@ -1,0 +1,169 @@
+"""End-to-end verification of the facility plan-injection contract (task 2.4)
+via `config.yml`'s `scan.plan_module` — no framework source changes here,
+purely a test asserting the seam the framework already exposes.
+
+Unlike `test_plan_injection.py` (task 2.4's own contract test, which mostly
+drives `plan_loader.py` directly and via the `BLUESKY_PLAN_MODULE` env var),
+this test goes through the full `scan.plan_module` config.yml path — the
+"local/dev convenience" resolution tier — mirroring how
+`tests/mcp_server/test_scan_context.py` verifies `scan.bridge_url`/
+`scan.promote_token` config fallback. A custom plan module living in a temp
+dir (PLANS + get_devices, no bluesky import) is loaded purely from config,
+its plans show up over real HTTP via `GET /plans`, and its devices construct.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+from osprey.services.bluesky_bridge import plan_loader
+from osprey.services.bluesky_bridge.app import app
+
+_FACILITY_MODULE_SOURCE = '''
+"""A custom facility plan module — deliberately outside the osprey package,
+loaded purely via config.yml's `scan.plan_module`, no bluesky import."""
+
+from osprey.services.bluesky_bridge.plan_types import PlanSpec
+from pydantic import BaseModel
+
+
+class SnifflePathParams(BaseModel):
+    sniff_time: float = 0.5
+
+
+def _sniffle_plan(devices, params):
+    return {"sniffer": devices["sniffer"], "sniff_time": params.sniff_time}
+
+
+PLANS = {
+    "sniffle_path": PlanSpec(
+        name="sniffle_path",
+        plan=_sniffle_plan,
+        schema=SnifflePathParams,
+        description="A custom facility plan loaded entirely via config.yml.",
+    ),
+}
+
+
+def get_devices():
+    return {"sniffer": "constructed-sniffer-device"}
+'''
+
+
+def _write_facility_module(tmp_path: Path) -> Path:
+    facility_dir = tmp_path / "facility_repo" / "plans"
+    facility_dir.mkdir(parents=True)
+    module_path = facility_dir / "custom_plans.py"
+    module_path.write_text(_FACILITY_MODULE_SOURCE)
+    return module_path
+
+
+def _write_config(tmp_path: Path, config_dict: dict) -> Path:
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(yaml.dump(config_dict))
+    return config_file
+
+
+@pytest.fixture(autouse=True)
+def _isolated_facility_plans():
+    """Clean plan_loader cache before and after every test in this module.
+
+    `OSPREY_CONFIG`/config caching is already reset by the repo-wide
+    `reset_state_between_tests` autouse fixture (tests/conftest.py); this
+    fixture only owns the `plan_loader` singleton, which that one doesn't
+    know about.
+    """
+    plan_loader.reset_facility_plans()
+    yield
+    plan_loader.reset_facility_plans()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def test_facility_plan_module_loaded_via_config_yml_appears_in_get_plans(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    """The full config-only path: no env var, just `scan.plan_module` in config.yml."""
+    monkeypatch.delenv("BLUESKY_PLAN_MODULE", raising=False)
+    module_path = _write_facility_module(tmp_path)
+    _write_config(tmp_path, {"scan": {"plan_module": str(module_path)}})
+    monkeypatch.setenv("OSPREY_CONFIG", str(tmp_path / "config.yml"))
+
+    resp = client.get("/plans")
+
+    assert resp.status_code == 200
+    plans_by_name = {p["name"]: p for p in resp.json()}
+    assert "sniffle_path" in plans_by_name
+    sniffle = plans_by_name["sniffle_path"]
+    assert sniffle["description"] == "A custom facility plan loaded entirely via config.yml."
+    assert sniffle["schema"]["properties"]["sniff_time"]["default"] == 0.5
+
+
+def test_facility_devices_construct_from_config_loaded_module(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`get_devices()` from the config-pointed module actually runs and its
+    result is what the bridge holds — not just that the plan schema shows up."""
+    monkeypatch.delenv("BLUESKY_PLAN_MODULE", raising=False)
+    module_path = _write_facility_module(tmp_path)
+    _write_config(tmp_path, {"scan": {"plan_module": str(module_path)}})
+    monkeypatch.setenv("OSPREY_CONFIG", str(tmp_path / "config.yml"))
+
+    facility = plan_loader.get_facility_plans()
+
+    assert facility.devices == {"sniffer": "constructed-sniffer-device"}
+    assert set(facility.plans) == {"sniffle_path"}
+
+
+def test_no_plan_module_configured_means_no_facility_plans(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    """A config.yml with no `scan.plan_module` key injects nothing — sanity
+    check that the previous tests' plan really came from config, not a
+    leftover default."""
+    monkeypatch.delenv("BLUESKY_PLAN_MODULE", raising=False)
+    _write_config(tmp_path, {"scan": {"bridge_url": "http://127.0.0.1:8090"}})
+    monkeypatch.setenv("OSPREY_CONFIG", str(tmp_path / "config.yml"))
+
+    resp = client.get("/plans")
+
+    assert resp.status_code == 200
+    assert "sniffle_path" not in {p["name"] for p in resp.json()}
+
+
+def test_env_var_still_wins_over_config_plan_module(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    """`BLUESKY_PLAN_MODULE` outranks `scan.plan_module`, mirroring
+    bridge_url/promote_token's env-wins-over-config precedent."""
+    config_module_path = _write_facility_module(tmp_path)
+    _write_config(tmp_path, {"scan": {"plan_module": str(config_module_path)}})
+    monkeypatch.setenv("OSPREY_CONFIG", str(tmp_path / "config.yml"))
+
+    env_dir = tmp_path / "env_facility"
+    env_dir.mkdir()
+    env_module_path = env_dir / "env_plans.py"
+    env_module_path.write_text(
+        "from osprey.services.bluesky_bridge.plan_types import PlanSpec\n"
+        "from pydantic import BaseModel\n\n"
+        "class P(BaseModel):\n"
+        "    pass\n\n"
+        "PLANS = {'env_only_plan': PlanSpec(name='env_only_plan', plan=lambda d, p: None, "
+        "schema=P, description='from env')}\n\n"
+        "def get_devices():\n"
+        "    return {}\n"
+    )
+    monkeypatch.setenv("BLUESKY_PLAN_MODULE", str(env_module_path))
+
+    resp = client.get("/plans")
+
+    names = {p["name"] for p in resp.json()}
+    assert "env_only_plan" in names
+    assert "sniffle_path" not in names

--- a/tests/services/bluesky_bridge/test_promote.py
+++ b/tests/services/bluesky_bridge/test_promote.py
@@ -103,6 +103,56 @@ def test_do_promote_returns_500_when_scanner_factory_raises(registry: RunRegistr
     assert run.error == "could not build scanner"
 
 
+def test_do_promote_stops_a_scanner_that_partially_started_then_raised(
+    registry: RunRegistry,
+) -> None:
+    """MANDATORY handoff fix (task 2.7): a `start_scan_thread()` that raises after
+    partially starting something must not leave a live, untracked, unstoppable
+    scan behind — `run.scanner` is never published on this path, so nothing
+    else could ever call `stop_scanning_thread()` on it unless `do_promote`
+    itself does.
+    """
+    run = registry.add(request={})
+
+    class PartiallyStartingScanner(FakeScanner):
+        def start_scan_thread(self) -> None:
+            # Simulate a real Scanner whose thread partially launches before
+            # failing to fully come up.
+            self._active = True
+            raise RuntimeError("thread launch failed after partial start")
+
+    scanner = PartiallyStartingScanner()
+
+    with pytest.raises(HTTPException) as excinfo:
+        do_promote(run, lambda: scanner)
+
+    assert excinfo.value.status_code == 500
+    assert run.scanner is None
+    assert scanner.stop_calls == 1
+    assert scanner.is_scanning_active() is False
+
+
+def test_do_promote_does_not_call_stop_when_the_factory_itself_raises(
+    registry: RunRegistry,
+) -> None:
+    """No scanner instance exists in this failure mode — there is nothing to stop."""
+    run = registry.add(request={})
+    stop_calls: list[str] = []
+
+    class RecordingScanner(FakeScanner):
+        def stop_scanning_thread(self) -> None:
+            stop_calls.append("stop")
+            super().stop_scanning_thread()
+
+    def failing_factory() -> RecordingScanner:
+        raise RuntimeError("could not build scanner")
+
+    with pytest.raises(HTTPException):
+        do_promote(run, failing_factory)
+
+    assert stop_calls == []
+
+
 def test_a_failed_promote_can_be_retried(registry: RunRegistry) -> None:
     run = registry.add(request={})
 

--- a/tests/services/bluesky_bridge/test_promote.py
+++ b/tests/services/bluesky_bridge/test_promote.py
@@ -1,0 +1,119 @@
+"""Unit tests for `do_promote`, the bridge's single scan-start choke point."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from osprey.services.bluesky_bridge.runs import RunRegistry, do_promote
+from osprey.services.bluesky_bridge.scanner import FakeScanner
+
+
+@pytest.fixture
+def registry() -> RunRegistry:
+    return RunRegistry()
+
+
+def test_do_promote_builds_and_starts_the_scanner(registry: RunRegistry) -> None:
+    run = registry.add(request={"devices": ["motor1"]})
+    scanner = FakeScanner()
+
+    result = do_promote(run, lambda: scanner)
+
+    assert result is run
+    assert run.promoted is True
+    assert run.promoting is False
+    assert run.scanner is scanner
+    assert scanner.reinitialize_calls == 1
+    assert scanner.start_calls == 1
+    assert run.status == "running"
+
+
+def test_do_promote_passes_the_run_request_as_exec_config(registry: RunRegistry) -> None:
+    seen: list[object] = []
+
+    class RecordingScanner(FakeScanner):
+        def reinitialize(self, exec_config: object) -> bool:
+            seen.append(exec_config)
+            return super().reinitialize(exec_config)
+
+    run = registry.add(request={"devices": ["motor1"]})
+    do_promote(run, RecordingScanner)
+
+    assert seen == [{"devices": ["motor1"]}]
+
+
+def test_do_promote_rejects_a_second_promotion(registry: RunRegistry) -> None:
+    run = registry.add(request={})
+    do_promote(run, FakeScanner)
+
+    with pytest.raises(HTTPException) as excinfo:
+        do_promote(run, FakeScanner)
+    assert excinfo.value.status_code == 409
+
+
+def test_do_promote_rejects_promoting_a_stopped_run(registry: RunRegistry) -> None:
+    run = registry.add(request={})
+    run.stopped = True
+
+    with pytest.raises(HTTPException) as excinfo:
+        do_promote(run, FakeScanner)
+    assert excinfo.value.status_code == 409
+    assert run.promoted is False
+
+
+def test_do_promote_rejects_reentrant_promotion_in_progress(registry: RunRegistry) -> None:
+    run = registry.add(request={})
+    run.promoting = True  # simulate a promote already underway
+
+    with pytest.raises(HTTPException) as excinfo:
+        do_promote(run, FakeScanner)
+    assert excinfo.value.status_code == 409
+    assert run.promoted is False
+
+
+def test_do_promote_returns_500_and_records_error_when_reinitialize_fails(
+    registry: RunRegistry,
+) -> None:
+    run = registry.add(request={})
+    scanner = FakeScanner(reinitialize_fails=True)
+
+    with pytest.raises(HTTPException) as excinfo:
+        do_promote(run, lambda: scanner)
+
+    assert excinfo.value.status_code == 500
+    assert run.promoted is False
+    assert run.promoting is False
+    assert run.error is not None
+    assert run.status == "error"
+
+
+def test_do_promote_returns_500_when_scanner_factory_raises(registry: RunRegistry) -> None:
+    run = registry.add(request={})
+
+    def failing_factory() -> FakeScanner:
+        raise RuntimeError("could not build scanner")
+
+    with pytest.raises(HTTPException) as excinfo:
+        do_promote(run, failing_factory)
+
+    assert excinfo.value.status_code == 500
+    assert run.promoted is False
+    assert run.promoting is False
+    assert run.error == "could not build scanner"
+
+
+def test_a_failed_promote_can_be_retried(registry: RunRegistry) -> None:
+    run = registry.add(request={})
+
+    with pytest.raises(HTTPException):
+        do_promote(run, lambda: FakeScanner(reinitialize_fails=True))
+    assert run.error is not None
+
+    scanner = FakeScanner()
+    result = do_promote(run, lambda: scanner)
+
+    assert result is run
+    assert run.promoted is True
+    assert run.error is None
+    assert run.scanner is scanner

--- a/tests/services/bluesky_bridge/test_read_bounded.py
+++ b/tests/services/bluesky_bridge/test_read_bounded.py
@@ -1,0 +1,270 @@
+"""Tests for `GET /runs/{id}/data` — the bounded live-row read route (task 2.2).
+
+Two layers:
+
+1. Direct `FastAPI` `TestClient` tests against the bridge app, seeding the
+   live-row buffer via `LiveRowRecorder` (no bluesky import, no Tiled server)
+   to exercise the route's pagination/truncation/partial logic.
+2. A MANDATORY non-patched integration test (Phase 1 handoff item): a real
+   HTTP server hosting this app, hit by the *actual* `read_scan_data` MCP
+   tool over a real socket — `_http_get_json` is never mocked here, so a
+   missing/renamed bridge route can never hide behind a patched primitive
+   again.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import pytest
+import uvicorn
+from fastapi.testclient import TestClient
+
+from osprey.services.bluesky_bridge import live_rows
+from osprey.services.bluesky_bridge.app import app, set_scanner_factory
+from osprey.services.bluesky_bridge.live_rows import LiveRowRecorder
+from osprey.services.bluesky_bridge.runs import Run, do_promote, registry
+from osprey.services.bluesky_bridge.scanner import FakeScanner
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state():
+    registry._runs.clear()
+    live_rows._clear()
+    set_scanner_factory(FakeScanner)
+    yield
+    registry._runs.clear()
+    live_rows._clear()
+    set_scanner_factory(FakeScanner)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _promoted_run_with_uid(run_uid: str) -> Run:
+    """A run promoted with a FakeScanner pre-seeded with `run_uid`."""
+    run = registry.add(request={"plan_name": "count"})
+    do_promote(run, lambda: FakeScanner(run_uid=run_uid))
+    return run
+
+
+def _feed(run_uid: str, rows: list[dict], *, stop: bool = False) -> None:
+    """Push synthetic start/event[/stop] documents into the live buffer."""
+    recorder = LiveRowRecorder()
+    recorder("start", {"uid": run_uid})
+    for row in rows:
+        recorder("event", {"data": row})
+    if stop:
+        recorder("stop", {"run_start": run_uid})
+
+
+# =========================================================================
+# 409: no run_uid yet
+# =========================================================================
+
+
+def test_read_data_before_promotion_returns_409(client: TestClient) -> None:
+    run = registry.add(request={"plan_name": "count"})
+    resp = client.get(f"/runs/{run.id}/data")
+    assert resp.status_code == 409
+
+
+def test_read_data_unknown_run_returns_404(client: TestClient) -> None:
+    resp = client.get("/runs/does-not-exist/data")
+    assert resp.status_code == 404
+
+
+# =========================================================================
+# Empty stream
+# =========================================================================
+
+
+def test_read_data_with_no_buffer_returns_minimal_empty_shape(client: TestClient) -> None:
+    run = _promoted_run_with_uid("uid-empty")
+    resp = client.get(f"/runs/{run.id}/data")
+    assert resp.status_code == 200
+    assert resp.json() == {"columns": [], "rows": []}
+
+
+def test_read_data_started_but_zero_events_reports_full_shape(client: TestClient) -> None:
+    run = _promoted_run_with_uid("uid-2")
+    _feed("uid-2", [])
+    body = client.get(f"/runs/{run.id}/data").json()
+    assert body["run_uid"] == "uid-2"
+    assert body["columns"] == []
+    assert body["rows"] == []
+    assert body["row_count"] == 0
+    assert body["truncated"] is False
+    assert body["partial"] is True
+
+
+# =========================================================================
+# Pagination / truncation
+# =========================================================================
+
+
+def test_read_data_returns_all_rows_when_under_max_rows(client: TestClient) -> None:
+    run = _promoted_run_with_uid("uid-3")
+    _feed("uid-3", [{"x": 1.0}, {"x": 2.0}], stop=True)
+    body = client.get(f"/runs/{run.id}/data").json()
+    assert body["columns"] == ["x"]
+    assert body["rows"] == [[1.0], [2.0]]
+    assert body["row_count"] == 2
+    assert body["truncated"] is False
+    assert "partial" not in body
+
+
+def test_read_data_caps_at_max_rows_and_flags_truncated(client: TestClient) -> None:
+    run = _promoted_run_with_uid("uid-4")
+    _feed("uid-4", [{"x": float(i)} for i in range(5)], stop=True)
+    body = client.get(f"/runs/{run.id}/data?max_rows=2").json()
+    assert body["rows"] == [[0.0], [1.0]]
+    assert body["row_count"] == 5
+    assert body["truncated"] is True
+
+
+def test_read_data_offset_paginates_forward(client: TestClient) -> None:
+    run = _promoted_run_with_uid("uid-5")
+    _feed("uid-5", [{"x": float(i)} for i in range(5)], stop=True)
+    body = client.get(f"/runs/{run.id}/data?max_rows=2&offset=2").json()
+    assert body["rows"] == [[2.0], [3.0]]
+    assert body["truncated"] is True
+
+
+def test_read_data_tail_returns_most_recent_rows(client: TestClient) -> None:
+    run = _promoted_run_with_uid("uid-6")
+    _feed("uid-6", [{"x": float(i)} for i in range(5)], stop=True)
+    body = client.get(f"/runs/{run.id}/data?max_rows=2&tail=true").json()
+    assert body["rows"] == [[3.0], [4.0]]
+    assert body["truncated"] is True
+
+
+def test_read_data_tail_with_offset_skips_from_the_end(client: TestClient) -> None:
+    run = _promoted_run_with_uid("uid-7")
+    _feed("uid-7", [{"x": float(i)} for i in range(5)], stop=True)
+    body = client.get(f"/runs/{run.id}/data?max_rows=2&tail=true&offset=1").json()
+    # Skip the very last row (index 4), then take the 2 rows before that.
+    assert body["rows"] == [[2.0], [3.0]]
+
+
+# =========================================================================
+# Partial mid-run
+# =========================================================================
+
+
+def test_read_data_mid_run_reports_partial_true(client: TestClient) -> None:
+    run = _promoted_run_with_uid("uid-8")
+    _feed("uid-8", [{"x": 1.0}], stop=False)
+    body = client.get(f"/runs/{run.id}/data").json()
+    assert body["partial"] is True
+
+
+def test_read_data_after_stop_omits_partial(client: TestClient) -> None:
+    run = _promoted_run_with_uid("uid-9")
+    _feed("uid-9", [{"x": 1.0}], stop=True)
+    body = client.get(f"/runs/{run.id}/data").json()
+    assert "partial" not in body
+
+
+# =========================================================================
+# row_count reflects the true total even past the storage cap
+# =========================================================================
+
+
+def test_read_data_row_count_is_true_total_even_past_storage_cap(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(live_rows, "_MAX_ROWS_PER_RUN", 3)
+    run = _promoted_run_with_uid("uid-10")
+    _feed("uid-10", [{"x": float(i)} for i in range(5)], stop=True)
+    body = client.get(f"/runs/{run.id}/data").json()
+    assert len(body["rows"]) == 3
+    assert body["row_count"] == 5
+    assert body["truncated"] is True
+
+
+# =========================================================================
+# MANDATORY: non-patched, real-socket integration test through the MCP tool
+# =========================================================================
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _wait_for_port(port: int, timeout: float = 10.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                return
+        except OSError:
+            time.sleep(0.1)
+    raise RuntimeError(f"bridge did not become ready on port {port} within {timeout}s")
+
+
+@contextmanager
+def _live_bridge() -> Iterator[str]:
+    """Run the real bridge app on a real TCP port in a background thread.
+
+    Same module-level `registry`/`live_rows` singletons as the test process
+    (this is a thread, not a subprocess) — but the request/response still
+    travels over a real socket through the real ASGI app, so a missing or
+    misrouted endpoint fails exactly as it would in production.
+    """
+    port = _free_port()
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    t = threading.Thread(target=server.run, daemon=True)
+    t.start()
+    _wait_for_port(port)
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.should_exit = True
+        t.join(timeout=5)
+
+
+async def test_read_scan_data_tool_end_to_end_over_real_http(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The actual MCP tool, unpatched, talking to the actual bridge route over a real socket.
+
+    Guards against the exact gap flagged at the Phase 1 handoff: every other
+    `read_scan_data` test patches `_http_get_json`, so a renamed/missing
+    bridge route could pass every unit test while being unreachable in
+    production. This test never touches `_http_get_json` — it runs the real
+    bridge, seeds its real run registry + live-row buffer, points the scan
+    server context at the real port, and calls the real MCP tool.
+    """
+    from osprey.mcp_server.scan import server_context
+    from osprey.mcp_server.scan.tools import read_tools
+    from tests.mcp_server.conftest import extract_response_dict, get_tool_fn
+
+    run = _promoted_run_with_uid("uid-e2e")
+    _feed("uid-e2e", [{"x": float(i)} for i in range(5)], stop=True)
+
+    monkeypatch.chdir(tmp_path)  # no config.yml in scope -> env var + defaults only
+
+    with _live_bridge() as base_url:
+        monkeypatch.setenv("BLUESKY_BRIDGE_URL", base_url)
+        server_context.reset_server_context()
+        server_context.initialize_server_context()
+        try:
+            result = await get_tool_fn(read_tools.read_scan_data)(run_id=run.id, max_rows=2)
+        finally:
+            server_context.reset_server_context()
+
+    data = extract_response_dict(result)
+    assert data["run_uid"] == "uid-e2e"
+    assert data["rows"] == [[0.0], [1.0]]
+    assert data["row_count"] == 5
+    assert data["truncated"] is True

--- a/tests/services/bluesky_bridge/test_runengine_integration.py
+++ b/tests/services/bluesky_bridge/test_runengine_integration.py
@@ -1,0 +1,254 @@
+"""RunEngine integration test for `BlueskyScanner` (task 2.7).
+
+Runs ONLY in a bluesky-capable environment — `bluesky`/`ophyd-async` are
+never installed in the main worktree venv, so every test here is skipped via
+`pytest.importorskip` rather than failing, keeping `ci_check` green with no
+bluesky installed at all. To actually run this file:
+
+    uv venv /tmp/bluesky-runengine-scratch
+    /tmp/bluesky-runengine-scratch/bin/pip install -e '.[bluesky-bridge]' --python 3.11
+    /tmp/bluesky-runengine-scratch/bin/python -m pytest \
+        tests/services/bluesky_bridge/test_runengine_integration.py -q
+
+Proves the full chain end to end: a real bluesky `RunEngine` running the
+built-in `scan`/`count` plans against mock ophyd-async devices
+(`devices/mock.py`) produces documents, the run reaches `completed`, its
+`error_message` stays unset, and `read_scan_data` (via the real bridge route,
+not a patched one) returns the buffered rows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+bluesky = pytest.importorskip("bluesky")
+ophyd_async = pytest.importorskip("ophyd_async")
+
+from osprey.services.bluesky_bridge import live_rows  # noqa: E402
+from osprey.services.bluesky_bridge.app import app, set_scanner_factory  # noqa: E402
+from osprey.services.bluesky_bridge.devices.mock import build_devices  # noqa: E402
+from osprey.services.bluesky_bridge.plans import BUILTIN_PLANS  # noqa: E402
+from osprey.services.bluesky_bridge.runs import registry  # noqa: E402
+from osprey.services.bluesky_bridge.scanner import FakeScanner  # noqa: E402
+from osprey.services.bluesky_bridge.scanner_bluesky import BlueskyScanner  # noqa: E402
+
+
+def _wait_until_idle(scanner: BlueskyScanner, timeout: float = 15.0) -> None:
+    deadline = time.monotonic() + timeout
+    while scanner.is_scanning_active():
+        if time.monotonic() > deadline:
+            raise AssertionError("scan did not finish within the timeout")
+        time.sleep(0.05)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state():
+    registry._runs.clear()
+    live_rows._clear()
+    set_scanner_factory(FakeScanner)
+    yield
+    registry._runs.clear()
+    live_rows._clear()
+    set_scanner_factory(FakeScanner)
+
+
+@pytest.fixture(scope="module")
+def mock_devices() -> dict:
+    """One connected mock motor + detector, shared across this module's tests."""
+    return asyncio.run(build_devices(motor_names=["motor1"], detector_names=["det1"]))
+
+
+# =========================================================================
+# Direct scanner-level: RunEngine actually runs a bp.scan against mock devices
+# =========================================================================
+
+
+def test_scan_plan_runs_to_completion_and_buffers_rows(mock_devices: dict) -> None:
+    scanner = BlueskyScanner(devices=mock_devices, plans=BUILTIN_PLANS)
+    exec_config = {
+        "plan_name": "scan",
+        "plan_args": {
+            "detectors": ["det1"],
+            "axes": [{"motor": "motor1", "start": 0.0, "stop": 1.0}],
+            "num": 3,
+        },
+    }
+
+    assert scanner.reinitialize(exec_config) is True
+    assert scanner.current_state == "armed"
+
+    scanner.start_scan_thread()
+    _wait_until_idle(scanner)
+
+    assert scanner.error_message is None
+    assert scanner.current_state == "completed"
+    assert scanner.last_run_uid is not None
+    assert scanner.estimate_current_completion() == 1.0
+
+    buf = live_rows.get(scanner.last_run_uid)
+    assert buf is not None
+    assert buf["partial"] is False
+    assert buf["total_seen"] == 3  # 3 points along the scan axis
+    assert len(buf["rows"]) == 3
+    assert "det1" in buf["columns"] or any("det1" in col for col in buf["columns"])
+
+
+def test_count_plan_against_mock_devices(mock_devices: dict) -> None:
+    scanner = BlueskyScanner(devices=mock_devices, plans=BUILTIN_PLANS)
+    exec_config = {"plan_name": "count", "plan_args": {"detectors": ["det1"], "num": 4}}
+
+    assert scanner.reinitialize(exec_config) is True
+    scanner.start_scan_thread()
+    _wait_until_idle(scanner)
+
+    assert scanner.error_message is None
+    buf = live_rows.get(scanner.last_run_uid)
+    assert buf is not None
+    assert buf["total_seen"] == 4
+
+
+def test_reinitialize_bridges_an_async_device_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`devices/mock.py`'s `build_devices` is `async def` — a real deploy wiring
+    would pass it (or an equivalent facility factory) directly rather than a
+    pre-resolved dict. `reinitialize()` must bridge that, not assume sync.
+    """
+    scanner = BlueskyScanner(
+        devices=lambda: build_devices(motor_names=["motor1"], detector_names=["det1"]),
+        plans=BUILTIN_PLANS,
+    )
+    exec_config = {"plan_name": "count", "plan_args": {"detectors": ["det1"], "num": 2}}
+
+    assert scanner.reinitialize(exec_config) is True
+
+    scanner.start_scan_thread()
+    _wait_until_idle(scanner)
+
+    assert scanner.error_message is None
+    assert scanner.current_state == "completed"
+    buf = live_rows.get(scanner.last_run_uid)
+    assert buf is not None
+    assert buf["total_seen"] == 2
+
+
+def test_stop_scanning_thread_aborts_a_running_scan(mock_devices: dict) -> None:
+    scanner = BlueskyScanner(devices=mock_devices, plans=BUILTIN_PLANS)
+    exec_config = {"plan_name": "count", "plan_args": {"detectors": ["det1"], "num": 1000}}
+
+    assert scanner.reinitialize(exec_config) is True
+    scanner.start_scan_thread()
+    time.sleep(0.1)  # let the scan actually get going before aborting it
+
+    scanner.stop_scanning_thread()
+
+    assert scanner.is_scanning_active() is False
+    assert scanner.current_state == "stopped"  # terminal state distinguishes stop from completed
+    assert scanner.error_message is None  # an intentional stop is not an error
+
+
+def test_run_thread_sets_error_state_when_the_plan_raises_mid_run(mock_devices: dict) -> None:
+    """A plan that fails only once the RunEngine drives it in the daemon thread
+    (not during `reinitialize()`) must land the scanner in the 'error' terminal
+    state with `error_message` set. This exercises `_run()`'s thread-level
+    failure branch — distinct from `reinitialize()`'s pre-thread validation
+    failures (unknown plan/device) covered above, where no thread ever starts.
+    """
+    from pydantic import BaseModel
+
+    from osprey.services.bluesky_bridge.plan_types import PlanSpec
+
+    class _NoParams(BaseModel):
+        pass
+
+    def _boom_plan(devices: dict, params: _NoParams):
+        # `yield` makes this a generator function, so the body runs only when
+        # the RunEngine iterates it inside `_run()` — never during reinitialize.
+        raise RuntimeError("boom mid-plan")
+        yield  # pragma: no cover - unreachable; present only to make this a generator
+
+    scanner = BlueskyScanner(
+        devices=mock_devices,
+        plans={"boom": PlanSpec(name="boom", plan=_boom_plan, schema=_NoParams)},
+    )
+
+    # Resolution succeeds — the failure is deferred to the RunEngine thread.
+    assert scanner.reinitialize({"plan_name": "boom", "plan_args": {}}) is True
+    assert scanner.current_state == "armed"
+
+    scanner.start_scan_thread()
+    _wait_until_idle(scanner)
+
+    assert scanner.current_state == "error"
+    assert scanner.error_message is not None
+    assert scanner.estimate_current_completion() != 1.0  # a failed run never reports 100%
+
+
+# =========================================================================
+# Contract failures: reinitialize() returns False, never raises
+# =========================================================================
+
+
+def test_reinitialize_returns_false_for_unknown_plan_name(mock_devices: dict) -> None:
+    scanner = BlueskyScanner(devices=mock_devices, plans=BUILTIN_PLANS)
+    ok = scanner.reinitialize({"plan_name": "does_not_exist", "plan_args": {}})
+
+    assert ok is False
+    assert scanner.error_message is not None
+    assert scanner.current_state == "error"
+
+
+def test_reinitialize_returns_false_for_an_unknown_device_name(mock_devices: dict) -> None:
+    scanner = BlueskyScanner(devices=mock_devices, plans=BUILTIN_PLANS)
+    ok = scanner.reinitialize(
+        {"plan_name": "count", "plan_args": {"detectors": ["no_such_detector"], "num": 1}}
+    )
+
+    assert ok is False
+    assert scanner.error_message is not None
+
+
+# =========================================================================
+# Full lifecycle: do_promote + the real GET /runs/{id}/data route
+# =========================================================================
+
+
+def test_promoted_run_read_scan_data_returns_the_buffered_rows(
+    mock_devices: dict, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end through the real bridge route, not a patched buffer."""
+    monkeypatch.setenv("BLUESKY_PROMOTE_TOKEN", "s3cr3t")
+    set_scanner_factory(lambda: BlueskyScanner(devices=mock_devices, plans=BUILTIN_PLANS))
+
+    client = TestClient(app)
+    create_resp = client.post(
+        "/runs",
+        json={
+            "plan_name": "count",
+            "plan_args": {"detectors": ["det1"], "num": 3},
+        },
+    )
+    assert create_resp.status_code == 200, create_resp.text
+    run_id = create_resp.json()["id"]
+
+    promote_resp = client.post(f"/runs/{run_id}/promote", headers={"X-Promote-Token": "s3cr3t"})
+    assert promote_resp.status_code == 200, promote_resp.text
+
+    deadline = time.monotonic() + 15.0
+    while client.get(f"/runs/{run_id}").json()["status"] == "running":
+        if time.monotonic() > deadline:
+            raise AssertionError("promoted run did not complete within the timeout")
+        time.sleep(0.05)
+
+    status_body = client.get(f"/runs/{run_id}").json()
+    assert status_body["status"] == "completed"
+
+    data_resp = client.get(f"/runs/{run_id}/data")
+    assert data_resp.status_code == 200, data_resp.text
+    data_body = data_resp.json()
+    assert data_body["run_uid"] == status_body["run_uid"]
+    assert data_body["row_count"] == 3
+    assert len(data_body["rows"]) == 3
+    assert "partial" not in data_body

--- a/tests/services/bluesky_bridge/test_runs.py
+++ b/tests/services/bluesky_bridge/test_runs.py
@@ -1,0 +1,187 @@
+"""Unit tests for the bridge's in-memory run registry and lifecycle state machine."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from osprey.services.bluesky_bridge.runs import Run, RunRegistry
+from osprey.services.bluesky_bridge.scanner import FakeScanner
+
+# =========================================================================
+# Run dataclass: fields/defaults
+# =========================================================================
+
+
+def test_run_defaults() -> None:
+    run = Run(id="abc123", request={"devices": []})
+    assert run.id == "abc123"
+    assert run.request == {"devices": []}
+    assert isinstance(run.created_at, float)
+    assert run.promoted is False
+    assert run.promoting is False
+    assert run.scanner is None
+    assert run.stopped is False
+    assert run.error is None
+    assert run.launched_by is None
+
+
+def test_run_uid_is_none_before_a_scanner_is_attached() -> None:
+    run = Run(id="abc123", request={})
+    assert run.run_uid is None
+
+
+def test_run_uid_reflects_the_attached_scanner() -> None:
+    scanner = FakeScanner(run_uid="seeded-uid")
+    run = Run(id="abc123", request={}, scanner=scanner)
+    assert run.run_uid == "seeded-uid"
+
+
+# =========================================================================
+# status derivation
+# =========================================================================
+
+
+def test_status_is_intent_before_promotion() -> None:
+    run = Run(id="abc123", request={})
+    assert run.status == "intent"
+
+
+def test_status_is_running_while_scanner_is_active() -> None:
+    scanner = FakeScanner()
+    scanner.start_scan_thread()
+    run = Run(id="abc123", request={}, promoted=True, scanner=scanner)
+    assert run.status == "running"
+
+
+def test_status_is_completed_once_scan_finishes_cleanly() -> None:
+    scanner = FakeScanner()
+    scanner.start_scan_thread()
+    scanner.simulate_completion()
+    run = Run(id="abc123", request={}, promoted=True, scanner=scanner)
+    assert run.status == "completed"
+
+
+def test_status_is_stopped_when_the_run_was_stopped() -> None:
+    scanner = FakeScanner()
+    scanner.start_scan_thread()
+    scanner.stop_scanning_thread()
+    run = Run(id="abc123", request={}, promoted=True, scanner=scanner, stopped=True)
+    assert run.status == "stopped"
+
+
+def test_status_is_error_when_run_error_is_set() -> None:
+    run = Run(id="abc123", request={}, promoted=True, error="promotion failed: boom")
+    assert run.status == "error"
+
+
+def test_status_is_error_when_scanner_ends_in_an_error_state() -> None:
+    scanner = FakeScanner()
+    scanner.start_scan_thread()
+    scanner.simulate_error("device timeout")
+    run = Run(id="abc123", request={}, promoted=True, scanner=scanner)
+    assert run.status == "error"
+
+
+def test_run_error_takes_precedence_even_before_promotion() -> None:
+    run = Run(id="abc123", request={}, error="setup failed")
+    assert run.status == "error"
+
+
+# =========================================================================
+# to_dict shape
+# =========================================================================
+
+
+def test_to_dict_intent_is_minimal() -> None:
+    run = Run(id="abc123", request={})
+    out = run.to_dict()
+    assert out == {"id": "abc123", "status": "intent"}
+
+
+def test_to_dict_includes_completion_and_run_uid_once_promoted() -> None:
+    scanner = FakeScanner()
+    scanner.start_scan_thread()
+    scanner.simulate_progress(0.5)
+    run = Run(id="abc123", request={}, promoted=True, scanner=scanner, launched_by="agent")
+    out = run.to_dict()
+    assert out["id"] == "abc123"
+    assert out["status"] == "running"
+    assert out["completion"] == 0.5
+    assert out["launched_by"] == "agent"
+    assert out["run_uid"] == scanner.last_run_uid
+    assert "error" not in out
+
+
+def test_to_dict_omits_launched_by_when_unset() -> None:
+    run = Run(id="abc123", request={})
+    assert "launched_by" not in run.to_dict()
+
+
+def test_to_dict_surfaces_explicit_error() -> None:
+    run = Run(id="abc123", request={}, promoted=True, error="promotion failed: boom")
+    out = run.to_dict()
+    assert out["status"] == "error"
+    assert out["error"] == "promotion failed: boom"
+
+
+def test_to_dict_synthesizes_error_message_from_scanner_state() -> None:
+    scanner = FakeScanner()
+    scanner.start_scan_thread()
+    scanner.simulate_error("device timeout")
+    run = Run(id="abc123", request={}, promoted=True, scanner=scanner)
+    out = run.to_dict()
+    assert out["status"] == "error"
+    assert "error" in out
+
+
+# =========================================================================
+# RunRegistry: add/get, unknown-run semantics
+# =========================================================================
+
+
+def test_registry_add_returns_a_run_with_a_generated_id() -> None:
+    registry = RunRegistry()
+    run = registry.add(request={"devices": ["motor1"]}, launched_by="agent")
+    assert run.id
+    assert run.request == {"devices": ["motor1"]}
+    assert run.launched_by == "agent"
+
+
+def test_registry_get_returns_the_added_run() -> None:
+    registry = RunRegistry()
+    added = registry.add(request={})
+    fetched = registry.get(added.id)
+    assert fetched is added
+
+
+def test_registry_get_raises_404_for_missing_id() -> None:
+    registry = RunRegistry()
+    with pytest.raises(HTTPException) as excinfo:
+        registry.get("does-not-exist")
+    assert excinfo.value.status_code == 404
+
+
+def test_registry_get_is_honest_after_a_simulated_restart() -> None:
+    # A fresh registry has no memory of runs an earlier process created —
+    # this is the "post-restart" semantics the registry must be honest about.
+    old_registry = RunRegistry()
+    run = old_registry.add(request={})
+
+    new_registry = RunRegistry()
+    with pytest.raises(HTTPException) as excinfo:
+        new_registry.get(run.id)
+    assert excinfo.value.status_code == 404
+
+
+def test_registry_list_returns_newest_first_and_respects_limit() -> None:
+    registry = RunRegistry()
+    first = registry.add(request={})
+    second = registry.add(request={})
+    third = registry.add(request={})
+
+    all_runs = registry.list(limit=100)
+    assert [r.id for r in all_runs] == [third.id, second.id, first.id]
+
+    limited = registry.list(limit=2)
+    assert len(limited) == 2

--- a/tests/services/bluesky_bridge/test_runs.py
+++ b/tests/services/bluesky_bridge/test_runs.py
@@ -88,6 +88,38 @@ def test_run_error_takes_precedence_even_before_promotion() -> None:
     assert run.status == "error"
 
 
+def test_status_is_error_based_on_error_message_not_a_current_state_heuristic() -> None:
+    """MANDATORY handoff fix (task 2.7): the terminal-error signal is the
+    Scanner protocol's explicit `error_message`, not a `current_state` string
+    match — a scanner can report a totally custom terminal `current_state` and
+    still be recognized as errored as long as `error_message` is set.
+    """
+    scanner = FakeScanner()
+    scanner.start_scan_thread()
+    scanner._active = False
+    scanner.current_state = "some_custom_terminal_state"  # not "error"
+    scanner.error_message = "device timeout"
+
+    run = Run(id="abc123", request={}, promoted=True, scanner=scanner)
+    assert run.status == "error"
+
+
+def test_status_is_not_error_when_current_state_looks_like_error_but_error_message_is_none() -> (
+    None
+):
+    """The old heuristic matched `current_state == "error"` directly; the new
+    signal requires `error_message` to be set — proves the heuristic is gone.
+    """
+    scanner = FakeScanner()
+    scanner.start_scan_thread()
+    scanner._active = False
+    scanner.current_state = "error"  # would have matched the old heuristic
+    scanner.error_message = None
+
+    run = Run(id="abc123", request={}, promoted=True, scanner=scanner)
+    assert run.status == "completed"
+
+
 # =========================================================================
 # to_dict shape
 # =========================================================================
@@ -133,6 +165,16 @@ def test_to_dict_synthesizes_error_message_from_scanner_state() -> None:
     out = run.to_dict()
     assert out["status"] == "error"
     assert "error" in out
+
+
+def test_to_dict_uses_the_scanner_error_message_directly() -> None:
+    scanner = FakeScanner()
+    scanner.start_scan_thread()
+    scanner._active = False
+    scanner.error_message = "device timeout"
+    run = Run(id="abc123", request={}, promoted=True, scanner=scanner)
+    out = run.to_dict()
+    assert out["error"] == "device timeout"
 
 
 # =========================================================================

--- a/tests/services/bluesky_bridge/test_scanner_fake.py
+++ b/tests/services/bluesky_bridge/test_scanner_fake.py
@@ -1,0 +1,95 @@
+"""Unit tests for the injected scanner seam (no bluesky dependency)."""
+
+from __future__ import annotations
+
+from osprey.services.bluesky_bridge.scanner import FakeScanner, Scanner
+
+
+def test_fake_scanner_satisfies_scanner_protocol() -> None:
+    assert isinstance(FakeScanner(), Scanner)
+
+
+def test_initial_state_is_idle_and_inactive() -> None:
+    scanner = FakeScanner()
+    assert scanner.current_state == "idle"
+    assert scanner.last_run_uid is None
+    assert scanner.is_scanning_active() is False
+    assert scanner.estimate_current_completion() == 0.0
+
+
+def test_reinitialize_succeeds_by_default() -> None:
+    scanner = FakeScanner()
+    assert scanner.reinitialize(exec_config={}) is True
+    assert scanner.current_state == "armed"
+    assert scanner.reinitialize_calls == 1
+
+
+def test_reinitialize_can_be_made_to_fail() -> None:
+    scanner = FakeScanner(reinitialize_fails=True)
+    assert scanner.reinitialize(exec_config={}) is False
+    assert scanner.current_state == "error"
+
+
+def test_start_scan_thread_activates_and_mints_run_uid() -> None:
+    scanner = FakeScanner()
+    scanner.reinitialize(exec_config={})
+    scanner.start_scan_thread()
+    assert scanner.is_scanning_active() is True
+    assert scanner.current_state == "running"
+    assert scanner.start_calls == 1
+    assert scanner.last_run_uid is not None
+
+
+def test_start_scan_thread_preserves_seeded_run_uid() -> None:
+    scanner = FakeScanner(run_uid="seeded-uid")
+    scanner.start_scan_thread()
+    assert scanner.last_run_uid == "seeded-uid"
+
+
+def test_stop_scanning_thread_deactivates() -> None:
+    scanner = FakeScanner()
+    scanner.start_scan_thread()
+    scanner.stop_scanning_thread()
+    assert scanner.is_scanning_active() is False
+    assert scanner.current_state == "stopped"
+    assert scanner.stop_calls == 1
+
+
+def test_stop_scanning_thread_is_safe_when_not_active() -> None:
+    scanner = FakeScanner()
+    scanner.stop_scanning_thread()  # must not raise
+    assert scanner.is_scanning_active() is False
+
+
+def test_simulate_progress_updates_completion_without_ending_scan() -> None:
+    scanner = FakeScanner()
+    scanner.start_scan_thread()
+    scanner.simulate_progress(0.42)
+    assert scanner.estimate_current_completion() == 0.42
+    assert scanner.is_scanning_active() is True
+
+
+def test_simulate_progress_clamps_to_unit_interval() -> None:
+    scanner = FakeScanner()
+    scanner.simulate_progress(-1.0)
+    assert scanner.estimate_current_completion() == 0.0
+    scanner.simulate_progress(5.0)
+    assert scanner.estimate_current_completion() == 1.0
+
+
+def test_simulate_completion_ends_scan_successfully() -> None:
+    scanner = FakeScanner()
+    scanner.start_scan_thread()
+    scanner.simulate_completion()
+    assert scanner.is_scanning_active() is False
+    assert scanner.current_state == "completed"
+    assert scanner.estimate_current_completion() == 1.0
+
+
+def test_simulate_error_ends_scan_in_error_state() -> None:
+    scanner = FakeScanner()
+    scanner.start_scan_thread()
+    scanner.simulate_error("device timeout")
+    assert scanner.is_scanning_active() is False
+    assert scanner.current_state == "error"
+    assert scanner.error_message == "device timeout"

--- a/tests/services/bluesky_bridge/test_security.py
+++ b/tests/services/bluesky_bridge/test_security.py
@@ -1,0 +1,79 @@
+"""Unit tests for the Bluesky bridge's promote-token gate."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from osprey.services.bluesky_bridge.security import require_armed, verify_promote_token
+
+_ENV_VAR = "BLUESKY_PROMOTE_TOKEN"
+
+
+def test_require_armed_raises_503_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_ENV_VAR, raising=False)
+    with pytest.raises(HTTPException) as exc_info:
+        require_armed()
+    assert exc_info.value.status_code == 503
+
+
+def test_require_armed_error_does_not_leak_a_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_ENV_VAR, raising=False)
+    with pytest.raises(HTTPException) as exc_info:
+        require_armed()
+    detail = str(exc_info.value.detail)
+    assert _ENV_VAR in detail
+    # No token value exists to leak when unset, but guard against ever
+    # embedding one (e.g. an accidental default) in the error text.
+    assert "token=" not in detail.lower()
+
+
+def test_require_armed_raises_503_when_empty_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV_VAR, "")
+    with pytest.raises(HTTPException) as exc_info:
+        require_armed()
+    assert exc_info.value.status_code == 503
+
+
+def test_require_armed_returns_configured_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV_VAR, "s3cr3t")
+    assert require_armed() == "s3cr3t"
+
+
+def test_verify_promote_token_passes_on_matching_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV_VAR, "s3cr3t")
+    verify_promote_token("s3cr3t")  # must not raise
+
+
+def test_verify_promote_token_raises_403_on_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV_VAR, "s3cr3t")
+    with pytest.raises(HTTPException) as exc_info:
+        verify_promote_token("wrong-token")
+    assert exc_info.value.status_code == 403
+
+
+def test_verify_promote_token_raises_403_on_missing_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV_VAR, "s3cr3t")
+    with pytest.raises(HTTPException) as exc_info:
+        verify_promote_token(None)
+    assert exc_info.value.status_code == 403
+
+
+def test_verify_promote_token_error_does_not_leak_expected_or_received(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(_ENV_VAR, "s3cr3t")
+    with pytest.raises(HTTPException) as exc_info:
+        verify_promote_token("guessed-wrong")
+    detail = str(exc_info.value.detail).lower()
+    assert "s3cr3t" not in detail
+    assert "guessed-wrong" not in detail
+
+
+def test_verify_promote_token_raises_503_when_unarmed_even_with_a_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(_ENV_VAR, raising=False)
+    with pytest.raises(HTTPException) as exc_info:
+        verify_promote_token("anything")
+    assert exc_info.value.status_code == 503

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-27T19:07:11.493149Z"
+exclude-newer = "2026-06-29T19:40:05.19313Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -312,6 +312,78 @@ wheels = [
 ]
 
 [[package]]
+name = "awkward"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "awkward-cpp" },
+    { name = "fsspec" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "numpy" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/fb/a4a6cd419e4bbf64a1f9aa7b883f441c50e0d9bbbbe3eae62634d6d42f7b/awkward-2.9.1.tar.gz", hash = "sha256:0b91fc778e11fae9b1c2011796b08027caaf02b850d4e7ea0972d356b5b7abf7", size = 6303886, upload-time = "2026-06-08T13:10:13.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/60/ff126095a42de830b585982371a2689db27353ee6ef5ed7e96124e8cb632/awkward-2.9.1-py3-none-any.whl", hash = "sha256:a9bbf1f8f47599e3b9878f7f8d46ec57655e8ef032ac20bc6c1023571d4ac2b2", size = 924151, upload-time = "2026-06-08T13:10:11.151Z" },
+]
+
+[[package]]
+name = "awkward-cpp"
+version = "53"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/4e/394a627ba7a36603475e5268247970930a4f98844d8997e3a75005903457/awkward_cpp-53.tar.gz", hash = "sha256:a478d2b7de3754674294617e12bd6db10fce691e98f5df248d665da093cd4ffa", size = 1495744, upload-time = "2026-06-08T12:31:58.079Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/c8/d6895f9986908059d54da53c982b00e7a37dac5d6b4d2decc2cb97172ef6/awkward_cpp-53-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b4236f7e5729eb463c8d924c8b2f8933706aa32f6214fc96ab3569f26ac49b2f", size = 605167, upload-time = "2026-06-08T12:30:42.949Z" },
+    { url = "https://files.pythonhosted.org/packages/39/51/2b7e991a44c9c3d6fe9c1f797f611f2a26b646bac5b6e47b01ce78bef298/awkward_cpp-53-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:881c1bb4b6faf3fc5273d9a1fb30283ce0f52f72ab3de59291f4540e5f20da61", size = 540931, upload-time = "2026-06-08T12:30:44.82Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/40/05cc4f0eaf2430ed0e8814f221d500b12dc37816acc520351fc315a8dcc8/awkward_cpp-53-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:070bbbed2f1713dff5f209debce548966836d31da78c03ca258e49939d578a6a", size = 584833, upload-time = "2026-06-08T12:30:46.272Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d1/f5b17cc0ddd5bbcdbcde50b31e05d29c7091b40fe8cad4b0c87b04d3cdc6/awkward_cpp-53-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cebe0dfbea10ecde3777dd7d5463c208d180e14d56422a890b11449587e6779f", size = 658032, upload-time = "2026-06-08T12:30:47.731Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d9/89b568911f92b7d92be2d14ebd4b150aff56bc8bbbf4d90c8ea75b5e432e/awkward_cpp-53-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ae873102946226dbca0c0882c02715b8610f7e5ceffd51c721d683b17a955691", size = 1582336, upload-time = "2026-06-08T12:30:49.502Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/cb/02a48d41dde18b5d9b71d78a1e6ab8f690e0497175ad250b7602e6be60a2/awkward_cpp-53-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:2e4e50cca64bfd40d46c94669039ab4bb1682b6fdd3a26b0808031b8d7a42f9e", size = 1697384, upload-time = "2026-06-08T12:30:51.129Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/58/cc81df4a56091267a1394c2d380aabd3f610489edc0c3febb0a8509011bf/awkward_cpp-53-cp311-cp311-win32.whl", hash = "sha256:17f695f48129067c0c8a7e8d667000541363351fa1aa029f9f1ca3165dfc1d26", size = 527333, upload-time = "2026-06-08T12:30:52.831Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6c/9c17b737cd3cb439d3e715b28dc95ec71c01e430a87dc42209387c65e0e1/awkward_cpp-53-cp311-cp311-win_amd64.whl", hash = "sha256:c2d9e63e440c486ad486f0b137e04e3a3d76000f3cc71f8a773fb9890166db5a", size = 558412, upload-time = "2026-06-08T12:30:54.319Z" },
+    { url = "https://files.pythonhosted.org/packages/95/bb/8be848e0250ede5faed5e40c575fa14fa72b9f9e2b62c2487f0547f0d902/awkward_cpp-53-cp311-cp311-win_arm64.whl", hash = "sha256:50b921df185a580423c3ef7db03f553f0bd2514df9fa1924f21783c75d60efbd", size = 530792, upload-time = "2026-06-08T12:30:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/00/6a/3d735c6c462b64cd17ee4dfd9d6fc50e88787e65a0db143fe501c7ca9389/awkward_cpp-53-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:79b11489c738cdb66d9c6911b166639186f6795b75a0dbca361d8e1577df04f0", size = 604372, upload-time = "2026-06-08T12:30:57.39Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d6/aaeca4bb3297e0c33b8306407e8c9c052b812a5c51766394dd51a720ec01/awkward_cpp-53-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:df1d056f08294b51b7c86481da6de2c16c4c03f20cca2bd254d6e81520be4b65", size = 541394, upload-time = "2026-06-08T12:30:58.968Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0c/4f03fd69e2a018bd2f6e36f341e24a1ae74aead9c68e322cd6cfd7b8d83c/awkward_cpp-53-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9dc96e5ed35b34985cffc4fd3a154362ff8f1d83168ccfbf76d5bfebb974cd7d", size = 585062, upload-time = "2026-06-08T12:31:00.455Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5d/94db6f9113400b5853448915aca9de1e03f32ede6b3b4afcff64bbd43b49/awkward_cpp-53-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:032de84f207687a43e9d8c7d80f79d6927d1018e3fd2166c4275dfe3c951e44e", size = 657827, upload-time = "2026-06-08T12:31:01.965Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ac/751ebb4c1b46f980692025a23648da598d7f2f86f385c40332d16d7446bd/awkward_cpp-53-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1e5e1f234a6a538fcb1281b4fb48caebef104229e2c8ae087dc20807c1b8dc3d", size = 1583826, upload-time = "2026-06-08T12:31:03.502Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/4c/8a53d4f102c73ba351d8c60081bf7abe845db7eefbbb83b123ba599c11cf/awkward_cpp-53-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7846d990d8fb3fb1cc1dc6e162a7d044469c6987f765db855e1cffc9ba9c3153", size = 1699092, upload-time = "2026-06-08T12:31:04.985Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/e6/e0961a0c4c49af1e066ac6bb335d5799ba57cbdfa35bed02cdcec799f8d8/awkward_cpp-53-cp312-cp312-win32.whl", hash = "sha256:93b59df3bedc5a4ec5b772b2ba05a40686c6fd0298669204c48c853886a8dc53", size = 528571, upload-time = "2026-06-08T12:31:06.579Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a7/fb2050dbb5c15fbdb60c276ccbb255b1824c0938d37da7b564493f3f8c2b/awkward_cpp-53-cp312-cp312-win_amd64.whl", hash = "sha256:52b0c7b24253924d6aad1a8d8fe13ce54616d0ae7d39a148b21df0677d6d7c1f", size = 561976, upload-time = "2026-06-08T12:31:08.359Z" },
+    { url = "https://files.pythonhosted.org/packages/78/eb/3c387199090849f52ddf6144ca6a25326d280333fe7a0069e173e353c083/awkward_cpp-53-cp312-cp312-win_arm64.whl", hash = "sha256:dceccb4fc63c5963f53ab4e6950a9c37479a2f556d053c92b64570db1f9fdfa2", size = 529387, upload-time = "2026-06-08T12:31:10.1Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/9c/d19a250df7ad4bb171e438f34007cdc11b7d9dcceeb2d2aa75b4d91e3088/awkward_cpp-53-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:69ea9952cd51eacad4b9700f22290679ad080ff01e514d41be7091550cf88fd9", size = 604380, upload-time = "2026-06-08T12:31:11.711Z" },
+    { url = "https://files.pythonhosted.org/packages/82/10/52f142ca5811c642480a7413843af274a9689053e6de1fedd1b9a14d2454/awkward_cpp-53-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b4ee2adbfb45ba8d0ad265c471c7a18664819359a9170531b60ef00fe86f8558", size = 541403, upload-time = "2026-06-08T12:31:13.35Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/0f/7e9a0bf8cdd20697be4000f3e3b4ac715cd0563cec08829d5d905c8fba8f/awkward_cpp-53-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a29a84195f0af5f2c40792c0d4c90e48c053421967ccd5b69ea5f2c59fec0e84", size = 585100, upload-time = "2026-06-08T12:31:15.409Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/e9/5ade698ac76e9b4712a5785c65f32cdcff069f2c0f6630e60c398cb68c31/awkward_cpp-53-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:918812e3dac56fdd51f0b6f16235803318854a133f1faf4ab402a2d185749f88", size = 657852, upload-time = "2026-06-08T12:31:17.164Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2d/36fdf84987dff96c2562c4599ed5303f4febed5fc4474b61e6548d1b4117/awkward_cpp-53-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00f7dcd6a29f99ec6c30f1ce1a2b96a9353da4a5cb6d7b32bf3da016f8cc1470", size = 1583844, upload-time = "2026-06-08T12:31:18.992Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f3/7b72f57455ae7ae76e4f06a45a894fb1d2127c488ea08aa038c76ad292c1/awkward_cpp-53-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:09c01178a54d2d95dc7c51ad6af6bb88d15cb5514ac436b84977258d8fedece8", size = 1699109, upload-time = "2026-06-08T12:31:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/16/304fe655479e1fca576138ce83b525de3ef80eb37181f85a36cb87374a5c/awkward_cpp-53-cp313-cp313-win32.whl", hash = "sha256:15a599b4350854252ead58beb736546a54af6cb8c9e283e39e8fff2a2d00071c", size = 528635, upload-time = "2026-06-08T12:31:22.491Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/dd/38ce20e09e823c878cce45cffc4305e53bfb29066af20f0ce4587709e3bd/awkward_cpp-53-cp313-cp313-win_amd64.whl", hash = "sha256:06351958ea76f24533d2d708d6d1cb58ae9c8b8f289722c655dfde5607ebe58e", size = 561984, upload-time = "2026-06-08T12:31:24.121Z" },
+    { url = "https://files.pythonhosted.org/packages/60/94/e16d4e9efa3c0d06168a7da623c612cdee76498d82865cdd8f82c41d881f/awkward_cpp-53-cp313-cp313-win_arm64.whl", hash = "sha256:35c820858d6fdfc0b6a9bb19ed8f4e9b030b0125c2f32284b37a0490f4fdfd7a", size = 529413, upload-time = "2026-06-08T12:31:25.775Z" },
+    { url = "https://files.pythonhosted.org/packages/74/50/1b44d393baa94c0c6511b7305fc46c0b83433e4cf90bd7d553e115035b3e/awkward_cpp-53-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f2196c68ecc1e5ab24cc16fc03344752f7df87fd925a56382093b32e6f3ba61b", size = 605014, upload-time = "2026-06-08T12:31:27.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/94/9b8923055f9be73c930955fd111756ca5d5616eedd64611d23c74e204300/awkward_cpp-53-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bf5b5d22b19904af6399163ce4df9cae9bce12d3d2d9a62a0c17c7d740134b6e", size = 541882, upload-time = "2026-06-08T12:31:29.2Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/b7/11931a529243c35630ffb98f374b95e3ec854b85fd83f215f3a9ef8b3851/awkward_cpp-53-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d6c5402a954e695ae6b028822a5394de3d66a74ea563c847a00e05e3c97cd398", size = 585415, upload-time = "2026-06-08T12:31:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/26/99/85a0cd9601506cda69c34761f0365f68922a92cef19b1f10639a2afcad82/awkward_cpp-53-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea82ac9f966ceea9e72c6ed7bd5a2b27fec0c519ccf4244e9b2c6a605eb74e27", size = 658637, upload-time = "2026-06-08T12:31:32.743Z" },
+    { url = "https://files.pythonhosted.org/packages/62/74/77547556e73e26298a2ff5cb0ce466195d1ca9b759194c7aca46147da99b/awkward_cpp-53-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a8a4722cc228a78d067d6d5839c8bd2c7c1d0a900ab83b2f0255fa0df0f2a346", size = 1585127, upload-time = "2026-06-08T12:31:34.475Z" },
+    { url = "https://files.pythonhosted.org/packages/67/3e/e318f65b65c2b08a18d97bec2bdb5171fa1ad989fa77b5d4aab119edf070/awkward_cpp-53-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:897e0e4b064d79b13d7a48da82e2dbce562bfc5ee7ebe9f20eebb428ef8a71e3", size = 1699267, upload-time = "2026-06-08T12:31:36.438Z" },
+    { url = "https://files.pythonhosted.org/packages/61/c6/1544a0c432501cb0ab28531f23f325f7af36827c355c3df9de3795ad1b67/awkward_cpp-53-cp314-cp314-win32.whl", hash = "sha256:3dd1ac5d32e1eaa4cf4a03bb9d142b80c9cd83647bc96d0290ac738ea76bec50", size = 538346, upload-time = "2026-06-08T12:31:38.007Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/05/a1e2feff1e3827d9f3d996de6635a3c2e953676ae08ae235d26f3c82ecb5/awkward_cpp-53-cp314-cp314-win_amd64.whl", hash = "sha256:d3d2b21c3846f318eb72cebcd9009b5df9b68b1f9f9b48051c523724e78f5a77", size = 576405, upload-time = "2026-06-08T12:31:39.618Z" },
+    { url = "https://files.pythonhosted.org/packages/39/4a/848e4ebc57466ab91e369bd8184f94e9cb55ee05ae381bf2a0a2b0825912/awkward_cpp-53-cp314-cp314-win_arm64.whl", hash = "sha256:eed50ec7fe61377a325b728e7342014f612d6c75ec8b63b203302bacaa7bdee5", size = 541809, upload-time = "2026-06-08T12:31:41.087Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/04/6854ecd63caa6f36cbe2ea1910345de4d25250bc5269d442a722d1dac46a/awkward_cpp-53-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4bd8f15b1304590c5c71b7047bf4c764f32e80717634b8b67101c66c54aea57f", size = 618004, upload-time = "2026-06-08T12:31:42.837Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c6/e44e2e31a3b508f34b496bf6557551864ee48d0f92f6debc1c6a5b09766c/awkward_cpp-53-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:89dd6052c06a815d06b96daf7bb2e2a1d6fb0bdebccd4c57c2dd1cb3b8ec8fd0", size = 556676, upload-time = "2026-06-08T12:31:44.716Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/66/fd72f71a9727354f521763b84482e6d2133e569448f9b1cc8a8b50c71cae/awkward_cpp-53-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:515fd3ea2f8d86f86e2590c58fc63258547e7fd9ac6ef554b35bac2bfc86e66a", size = 590615, upload-time = "2026-06-08T12:31:46.363Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/2e/deeb5194c97d4e28fd282976070829291ce807790cb2c4dd1a6e90ea066c/awkward_cpp-53-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f04d3f7ee054da4468aa0101a3dc2d440250a4e025d48ccbc22688860a5e35a", size = 666105, upload-time = "2026-06-08T12:31:47.981Z" },
+    { url = "https://files.pythonhosted.org/packages/72/5a/cb08d76f7e6840bb45483570336e5315019f7926865f1d82e8caaa88390f/awkward_cpp-53-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2da08c4f1afd15c4a6691ba20b79179d26b6b832afa5e8ed291a43b6b0d21d9a", size = 1590040, upload-time = "2026-06-08T12:31:49.69Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/e2/cfafeffca02bbbe54d3cb9246d2d98740b563220b2c16e951312a454d46c/awkward_cpp-53-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:12e2c97d5793b122f9268f040f409ef5b110ac89d62b1d399ba7d3ea238ad21f", size = 1706402, upload-time = "2026-06-08T12:31:51.398Z" },
+    { url = "https://files.pythonhosted.org/packages/09/33/a41b1cca711242e45b8d944a0ed37798d8cea69972c879c9ba2b767010ed/awkward_cpp-53-cp314-cp314t-win32.whl", hash = "sha256:9ee37d5c05737325358ad7d960bea87d41c3e8eba84091fec5f4de26c949e931", size = 552323, upload-time = "2026-06-08T12:31:52.937Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c8/b4c8a61d7cac8d983bad0954d969d8786b3c49f6a897a86979aa2fa7d6e8/awkward_cpp-53-cp314-cp314t-win_amd64.whl", hash = "sha256:c92580267dc929e772fd1729226a664cb837a9b95065c558e13b1130e6505f4d", size = 596751, upload-time = "2026-06-08T12:31:54.709Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a1/70ebfffd6c6edc6034a547838ee46287c65ed89f710592ddc39c76b4a5a8/awkward_cpp-53-cp314-cp314t-win_arm64.whl", hash = "sha256:1be0c1d87d9f4fdf94b767a061df849f1bb21579d302b2996fb101527fc80a97", size = 551257, upload-time = "2026-06-08T12:31:56.319Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -366,6 +438,72 @@ wheels = [
 [package.optional-dependencies]
 css = [
     { name = "tinycss2" },
+]
+
+[[package]]
+name = "blosc2"
+version = "4.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msgpack" },
+    { name = "ndindex" },
+    { name = "numexpr", marker = "platform_machine != 'wasm32'" },
+    { name = "numpy" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "threadpoolctl", marker = "platform_machine != 'wasm32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/79/60e8030abe0c88c186f37e3c19e9377262d9b4e76e04d608a0474eabac4f/blosc2-4.7.0.tar.gz", hash = "sha256:7bb2482dc8efb717ba4ef52f5b1e7c8a968e49fcc88c5e9edaa6cbda84b78744", size = 5613663, upload-time = "2026-06-29T15:25:44.159Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/9a/348384842efbfac0557b34860dbf5ef66b8b8c01c231c3714d1600968408/blosc2-4.7.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e0c8c4686cfa7def9625fd920bdcd0ba1fcd645dc64492afed8bbdbce1a4352a", size = 6007637, upload-time = "2026-06-29T15:24:53.63Z" },
+    { url = "https://files.pythonhosted.org/packages/18/c8/59d4fe2858ae9147ac8a29b6bedb81eda3cedae781e5320f04fddcbc8e05/blosc2-4.7.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6b89659cf00bfb2e89eea9e28a9c90976dc0a75e03b641894e8247b8690d6f79", size = 5211239, upload-time = "2026-06-29T15:24:55.888Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/a7/53c32b9cf7bfccef2671fb9c90fa03f4c3b84663d15bfdb62e654b487d9c/blosc2-4.7.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:50d28b10a5bc358939604f56475c5b015e5449585a6115169f4b8656e6dc2b1a", size = 6503398, upload-time = "2026-06-29T15:24:57.637Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/71/64ea7e05458d13ca5350a1b9f289d3d4e4cb36b11093e32f3ba5d63a0c5e/blosc2-4.7.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c55061ca013de2764148ddf6169c3aac428f9eb26c33bb3618c04a8c741b5d7", size = 6819132, upload-time = "2026-06-29T15:24:59.566Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/07/66134352f1045ae1b3a92ddae0824ec68b18c0e030f95e44608c6916760c/blosc2-4.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:82be8faa277ef61821f0bce0ab4dfa4904bb61ab34b9ab4e3aa6715564eac242", size = 4297279, upload-time = "2026-06-29T15:25:02.027Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e8/6fa16bf48786f220e22f58c8e175a0d18c66ad37e357a554669a8f26e663/blosc2-4.7.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:aba1a0b5ea79522a4724d51e9ed1fa7bee69a621e1f5da38ef62c725952ccdc4", size = 6059208, upload-time = "2026-06-29T15:25:03.815Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/a4/21949a2cb1ce2292dcabe2110b8a2af17e11b127cf3b6780276660ef5b85/blosc2-4.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8b7294715d2c23647c04991b4633b5ac02dbaff9bf2336c98b98b1b248ac2141", size = 5209829, upload-time = "2026-06-29T15:25:05.763Z" },
+    { url = "https://files.pythonhosted.org/packages/63/47/a2fa5f48cb70798e709ec4eac19b22d083de1d80a8d7136874ecc42d9966/blosc2-4.7.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cf60594afdaf0aa82abb738ca1f539f99ca7937e5f3db90a270daac85167410", size = 6453088, upload-time = "2026-06-29T15:25:07.598Z" },
+    { url = "https://files.pythonhosted.org/packages/32/c3/e12d6ce1bec786a2fa3e65407e20b5f5cffecbd9b47216395fb0c2502e03/blosc2-4.7.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b15ea0bc6bebdd9de72e50ce5cc538399af46e67709d875e043cbdac9050ef56", size = 6753294, upload-time = "2026-06-29T15:25:09.449Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/00/ff1ed9cd834a5fd884ee3ab2f2835d1e8f999e144f2010791b09a99f1244/blosc2-4.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:0dab1bc936cb792916cfc97febc743fd19eb3037f984e5ea5af1bd66e2be09a3", size = 4294244, upload-time = "2026-06-29T15:25:11.218Z" },
+    { url = "https://files.pythonhosted.org/packages/58/9b/accd5e73ce465caabeeaa0078d751fa21a1f9cf6ea972d2518bd447f5916/blosc2-4.7.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1335672ee39fcd07bb2c43426a4e7a61bf506fca24142be366e809c01d1ed832", size = 6057668, upload-time = "2026-06-29T15:25:13.149Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/da/27d5364ac073b8ff9db93ac859f49dd7fb5316dd55e8bd605abbd7c18051/blosc2-4.7.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16582d469ab9e3068dcf93c82cc01f027bacb63ab65b3ac6d299dcad73767387", size = 5208061, upload-time = "2026-06-29T15:25:15.023Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/be/2559e7dbe824a33ccf6b8b8598216fe943f8083b072c49331960b53c76fc/blosc2-4.7.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:aab0aaa3a713309c97d32981fa544b3be54e7b7daddc279cb5ea5e4d7f814faf", size = 6458215, upload-time = "2026-06-29T15:25:16.969Z" },
+    { url = "https://files.pythonhosted.org/packages/57/8b/14d34c42feb7a7c5a938470a53670d6efb4aefde74424623c46cc357f170/blosc2-4.7.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e1b8a0abaf3bf5b3cf1bbb75d9c056e87a6ca090d14e47f0018e03a1d222ae61", size = 6752340, upload-time = "2026-06-29T15:25:18.885Z" },
+    { url = "https://files.pythonhosted.org/packages/00/45/a0a9a4f7412551a0a6a390b254eba0533b5636429951f20132a81a77079f/blosc2-4.7.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:02b8e0b7269a6883a6ae0616a3e1c5609e8865c74d2c1ef7767f54104350b0c8", size = 2275025, upload-time = "2026-06-29T15:25:20.818Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a6/221fc1b7c3280dd5fce7c081ae520b012bd9c53f6ac3f9a42c7c932bb2df/blosc2-4.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:949da4c850c0de598d501e82545d6fc525a16958378d197eadc12a52d42494d1", size = 4294154, upload-time = "2026-06-29T15:25:22.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/55/7f9b39662b53adca5b686979fd9958840a94495d1e9780ed2b46fe41a5bf/blosc2-4.7.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:83a83477f9411e85b205f27fa6cb9ad7338dc019ca1ee2bf4633034ae53b0b65", size = 6061062, upload-time = "2026-06-29T15:25:23.962Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e4/e752016fcca72b483ad3f3b6ae1fa2e359366895b4730d58e5c26874c13f/blosc2-4.7.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9cbb59fc38b0fb50c2a588dfb2ee2ab56e150e358c3904dcd586108b710a21d5", size = 5210689, upload-time = "2026-06-29T15:25:25.664Z" },
+    { url = "https://files.pythonhosted.org/packages/49/0d/04f77774b0c5b738efe2fa9909024119c56d571f3ebef5c6c8db2396831c/blosc2-4.7.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2f7af5bc0551147a384b4baf0a509d3e025362e69744ff37ad13be608b283fc4", size = 6467940, upload-time = "2026-06-29T15:25:27.448Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/8f/99f1807d3cfabe6feb5a85f9846db510b9833c7dc4d465d6a4bdaabc73de/blosc2-4.7.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9ad50bde9cedbd66159ceb993ccc47e7ce1fe22bc4e988923976d60186656b16", size = 6757685, upload-time = "2026-06-29T15:25:29.139Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/09/9cc638eae6e89d0ec0fd81b28855751b40a4546f430409fc48b315a89f45/blosc2-4.7.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:75889fd9172fbf2a098e8b8640574bf67be9b05fed855a5c3c45c247b923aa44", size = 2272298, upload-time = "2026-06-29T15:25:30.791Z" },
+    { url = "https://files.pythonhosted.org/packages/69/dc/2f270ea17248fb2f9f3c04ea0a34f14d0ccf8ca2f4d8d135f47973f4aae2/blosc2-4.7.0-cp314-cp314-win_amd64.whl", hash = "sha256:a8440e2562230d501feb2611b172f6c29ca532a6b05a34d5131008aa3793fbb0", size = 4378896, upload-time = "2026-06-29T15:25:32.479Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/68/385faca1307bcfd9776c962d62d72337cf3a03b124a102199e7c29fcf001/blosc2-4.7.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b90da8e56184e3eb7ce42238652b5d40a5c46cef6be5dd6254d50fe597383003", size = 6097379, upload-time = "2026-06-29T15:25:34.752Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/29/7d87d2e2eabdef0dbf16f41ee3f67c388fa99840b7b9b70a8de87cfbb621/blosc2-4.7.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:44034824f605f598c3e4e99049604a58682a196174a4335fad28d4d53b243ea6", size = 5258025, upload-time = "2026-06-29T15:25:36.854Z" },
+    { url = "https://files.pythonhosted.org/packages/21/ef/0e5d2070b644c730cae1a92883a687b399fd7ed2dc0c53e4df3bbd3b33e9/blosc2-4.7.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ec68f8064d21af14f80c0c9e2568a86aebb80ef4c3c114445028d64471f19b2c", size = 6421845, upload-time = "2026-06-29T15:25:38.726Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ea/c31f8752dde000aefd6cae447f0356fa52e045d30316b7027eac0e5842f1/blosc2-4.7.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d3b7f2f10a67262815c245cb3d39082bfbd32a99b31e0785e1b13c403e4ff5a", size = 6729101, upload-time = "2026-06-29T15:25:40.61Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/60/5ebfbf0f16d0a477f2a0cc5484a643eb79103e8de8ac12af04d97f740898/blosc2-4.7.0-cp314-cp314t-win_amd64.whl", hash = "sha256:60ed77ba2db273291d42345d7c1eb5672259e594fc56074f26dd729fc0dddf32", size = 4438708, upload-time = "2026-06-29T15:25:42.502Z" },
+]
+
+[[package]]
+name = "bluesky"
+version = "1.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cycler" },
+    { name = "event-model" },
+    { name = "historydict" },
+    { name = "msgpack" },
+    { name = "msgpack-numpy" },
+    { name = "numpy" },
+    { name = "opentelemetry-api" },
+    { name = "toolz" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/83/2e5d1956a1c4cd3d4f0bb34605cc2b11f2ce33e48249773292b27e6bba88/bluesky-1.15.1.tar.gz", hash = "sha256:956e161a8f34f698af28edcd501db118fa793a6c43241001e30ed8c6aaabd95c", size = 513978, upload-time = "2026-05-06T14:06:40.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/99/cc217b2a727fdf730d0c0064bc8c03473dfe5d0528f2bd0c4f59fdab4179/bluesky-1.15.1-py3-none-any.whl", hash = "sha256:7b3a0f04cf2bb0a7907771e014e59fe6fced777347df8df84adec7239f6c3d2a", size = 372701, upload-time = "2026-05-06T14:06:38.618Z" },
 ]
 
 [[package]]
@@ -628,6 +766,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -637,12 +784,38 @@ wheels = [
 ]
 
 [[package]]
+name = "colorlog"
+version = "6.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/61/f083b5ac52e505dfc1c624eafbf8c7589a0d7f32daa398d2e7590efa5fda/colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321", size = 17162, upload-time = "2025-10-16T16:14:11.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl", hash = "sha256:2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c", size = 11743, upload-time = "2025-10-16T16:14:10.512Z" },
+]
+
+[[package]]
 name = "comm"
 version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4c/13/7d740c5849255756bc17888787313b61fd38a0a8304fc4f073dfc46122aa/comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971", size = 6319, upload-time = "2025-07-25T14:02:04.452Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417", size = 7294, upload-time = "2025-07-25T14:02:02.896Z" },
+]
+
+[[package]]
+name = "compress-pickle"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/23/a448abd4e98b64ad5b99537a2b4df3f6a829e6fac749afbaf921f89c0941/compress_pickle-2.1.0.tar.gz", hash = "sha256:3e944ce0eeab5b6331324d62351c957d41c9327c8417d439843e88fe69b77991", size = 16360, upload-time = "2021-09-21T18:13:58.57Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/4f/f94ac1b84d2169cf2ebf64353ce98fd743f85d30678059c514d9b3d6644c/compress_pickle-2.1.0-py3-none-any.whl", hash = "sha256:598650da4686d9bd97bee185b61e74d7fe1872bb0c23909d5ed2d8793b4a8818", size = 24694, upload-time = "2021-09-21T18:13:57.047Z" },
+]
+
+[package.optional-dependencies]
+lz4 = [
+    { name = "lz4" },
 ]
 
 [[package]]
@@ -915,6 +1088,35 @@ wheels = [
 ]
 
 [[package]]
+name = "dask"
+version = "2026.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "cloudpickle" },
+    { name = "fsspec" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "packaging" },
+    { name = "partd" },
+    { name = "pyyaml" },
+    { name = "toolz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/ca/58434f10ebb45d2ddc6edd6e2988abcd38da1ab1897a5f6f402711a594e9/dask-2026.6.0.tar.gz", hash = "sha256:ae3436bd31ebce2be75edf952bd1fc687a1f11ec03fe8b1bec2903d222344a45", size = 11544529, upload-time = "2026-06-11T17:48:43.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl", hash = "sha256:1539859071065dca379ca592ff76e911cd7965dc466da0040354ab466179189b", size = 1488995, upload-time = "2026-06-11T17:48:41.008Z" },
+]
+
+[package.optional-dependencies]
+array = [
+    { name = "numpy" },
+]
+dataframe = [
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+]
+
+[[package]]
 name = "decorator"
 version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1038,6 +1240,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "entrypoints"
+version = "0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/8d/a7121ffe5f402dc015277d2d31eb82d2187334503a011c18f2e78ecbb9b2/entrypoints-0.4.tar.gz", hash = "sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4", size = 13974, upload-time = "2022-02-02T21:30:28.172Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/a8/365059bbcd4572cbc41de17fd5b682be5868b218c3c5479071865cab9078/entrypoints-0.4-py3-none-any.whl", hash = "sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f", size = 5294, upload-time = "2022-02-02T21:30:26.024Z" },
+]
+
+[[package]]
+name = "event-model"
+version = "1.24.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/bc/e181740329de157a5f5ba985ab8da558a77ceb710532a1636e9dc2a42e53/event_model-1.24.0.tar.gz", hash = "sha256:18e632d52a7caa0987d5d7198bc23e06f2e4ca5e8794d384d74f9e0c34a773d8", size = 185208, upload-time = "2026-06-03T10:58:03.71Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/9e/d410b0ff08a2519d197928afdc1aa36eb47e197f5ba683389b00e216f83c/event_model-1.24.0-py3-none-any.whl", hash = "sha256:87e9415b349f9c9aa7576090b671442e49548ea9b63c5e8ab64573f4df1c2d61", size = 76666, upload-time = "2026-06-03T10:58:02.598Z" },
 ]
 
 [[package]]
@@ -1643,6 +1868,15 @@ wheels = [
 ]
 
 [[package]]
+name = "historydict"
+version = "1.2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/eb/91c2bd3684147ba8deef546ff2b6d091f32ece81ceb153831bab9f2ea6a5/historydict-1.2.6.tar.gz", hash = "sha256:a800ae05d28b618fe0c913ff0d64e4aebe05d76934fa610539f70ead37dc6fb5", size = 4011, upload-time = "2023-08-05T20:42:20.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/47/deb64c73aec25af7699247e021153a6bfe9a08452f7f7337dcee4aa07a2b/historydict-1.2.6-py3-none-any.whl", hash = "sha256:b4b00a170f05502aa682caba62435da5fe1f73037e884707581fe84f8d7b43f5", size = 4501, upload-time = "2023-08-05T20:42:19.244Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -2010,6 +2244,36 @@ wheels = [
 ]
 
 [[package]]
+name = "json-merge-patch"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/eb/776e896abba05e810022a2ddd907f0b761164330f259279079ee81fe1898/json_merge_patch-0.3.0.tar.gz", hash = "sha256:4a022d78fc2f09cb49d96c646efc380d3b5ead2b5c7dabe22c3928c2c2e9c4e0", size = 5026, upload-time = "2025-03-25T09:48:41.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/c1/fb2c66d92b5d0167c57042b784456ee3f8531a997726c88cf6f012a22da6/json_merge_patch-0.3.0-py3-none-any.whl", hash = "sha256:e0a593719b293ff63858ecaae3afbcb4ff0b57f785453c6783d7b0c3e2708b76", size = 5482, upload-time = "2025-03-25T09:48:40.4Z" },
+]
+
+[[package]]
+name = "jsonpatch"
+version = "1.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpointer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade", size = 12898, upload-time = "2023-06-16T21:01:28.466Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
+]
+
+[[package]]
 name = "jsonref"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2312,6 +2576,91 @@ wheels = [
 ]
 
 [[package]]
+name = "llvmlite"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/88/a8952b6d5c21e74cbf158515b779666f692846502623e9e3c39d8e8ba25f/llvmlite-0.47.0.tar.gz", hash = "sha256:62031ce968ec74e95092184d4b0e857e444f8fdff0b8f9213707699570c33ccc", size = 193614, upload-time = "2026-03-31T18:29:53.497Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/0b/b9d1911cfefa61399821dfb37f486d83e0f42630a8d12f7194270c417002/llvmlite-0.47.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:74090f0dcfd6f24ebbef3f21f11e38111c4d7e6919b54c4416e1e357c3446b07", size = 37232770, upload-time = "2026-03-31T18:28:26.765Z" },
+    { url = "https://files.pythonhosted.org/packages/46/27/5799b020e4cdfb25a7c951c06a96397c135efcdc21b78d853bbd9c814c7d/llvmlite-0.47.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ca14f02e29134e837982497959a8e2193d6035235de1cb41a9cb2bd6da4eedbb", size = 56275177, upload-time = "2026-03-31T18:28:31.01Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/51/48a53fedf01cb1f3f43ef200be17ebf83c8d9a04018d3783c1a226c342c2/llvmlite-0.47.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12a69d4bb05f402f30477e21eeabe81911e7c251cecb192bed82cd83c9db10d8", size = 55128631, upload-time = "2026-03-31T18:28:36.046Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/50/59227d06bdc96e23322713c381af4e77420949d8cd8a042c79e0043096cc/llvmlite-0.47.0-cp311-cp311-win_amd64.whl", hash = "sha256:c37d6eb7aaabfa83ab9c2ff5b5cdb95a5e6830403937b2c588b7490724e05327", size = 38138400, upload-time = "2026-03-31T18:28:40.076Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/48/4b7fe0e34c169fa2f12532916133e0b219d2823b540733651b34fdac509a/llvmlite-0.47.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:306a265f408c259067257a732c8e159284334018b4083a9e35f67d19792b164f", size = 37232769, upload-time = "2026-03-31T18:28:43.735Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/4b/e3f2cd17822cf772a4a51a0a8080b0032e6d37b2dbe8cfb724eac4e31c52/llvmlite-0.47.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5853bf26160857c0c2573415ff4efe01c4c651e59e2c55c2a088740acfee51cd", size = 56275178, upload-time = "2026-03-31T18:28:48.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/a3b4a543185305a9bdf3d9759d53646ed96e55e7dfd43f53e7a421b8fbae/llvmlite-0.47.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:003bcf7fa579e14db59c1a1e113f93ab8a06b56a4be31c7f08264d1d4072d077", size = 55128632, upload-time = "2026-03-31T18:28:52.901Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f5/d281ae0f79378a5a91f308ea9fdb9f9cc068fddd09629edc0725a5a8fde1/llvmlite-0.47.0-cp312-cp312-win_amd64.whl", hash = "sha256:f3079f25bdc24cd9d27c4b2b5e68f5f60c4fdb7e8ad5ee2b9b006007558f9df7", size = 38138692, upload-time = "2026-03-31T18:28:57.147Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6f/4615353e016799f80fa52ccb270a843c413b22361fadda2589b2922fb9b0/llvmlite-0.47.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a3c6a735d4e1041808434f9d440faa3d78d9b4af2ee64d05a66f351883b6ceec", size = 37232771, upload-time = "2026-03-31T18:29:01.324Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b8/69f5565f1a280d032525878a86511eebed0645818492feeb169dfb20ae8e/llvmlite-0.47.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2699a74321189e812d476a43d6d7f652f51811e7b5aad9d9bba842a1c7927acb", size = 56275178, upload-time = "2026-03-31T18:29:05.748Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/da/b32cafcb926fb0ce2aa25553bf32cb8764af31438f40e2481df08884c947/llvmlite-0.47.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c6951e2b29930227963e53ee152441f0e14be92e9d4231852102d986c761e40", size = 55128632, upload-time = "2026-03-31T18:29:11.235Z" },
+    { url = "https://files.pythonhosted.org/packages/46/9f/4898b44e4042c60fafcb1162dfb7014f6f15b1ec19bf29cfea6bf26df90d/llvmlite-0.47.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2e9adf8698d813a9a5efb2d4370caf344dbc1e145019851fee6a6f319ba760e", size = 38138695, upload-time = "2026-03-31T18:29:15.43Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/d4/33c8af00f0bf6f552d74f3a054f648af2c5bc6bece97972f3bfadce4f5ec/llvmlite-0.47.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:de966c626c35c9dff5ae7bf12db25637738d0df83fc370cf793bc94d43d92d14", size = 37232773, upload-time = "2026-03-31T18:29:19.453Z" },
+    { url = "https://files.pythonhosted.org/packages/64/1d/a760e993e0c0ba6db38d46b9f48f6c7dceb8ac838824997fb9e25f97bc04/llvmlite-0.47.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ddbccff2aeaff8670368340a158abefc032fe9b3ccf7d9c496639263d00151aa", size = 56275176, upload-time = "2026-03-31T18:29:24.149Z" },
+    { url = "https://files.pythonhosted.org/packages/84/3b/e679bc3b29127182a7f4aa2d2e9e5bea42adb93fb840484147d59c236299/llvmlite-0.47.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a7b778a2e144fc64468fb9bf509ac1226c9813a00b4d7afea5d988c4e22fca", size = 55128631, upload-time = "2026-03-31T18:29:29.536Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f7/19e2a09c62809c9e63bbd14ce71fb92c6ff7b7b3045741bb00c781efc3c9/llvmlite-0.47.0-cp314-cp314-win_amd64.whl", hash = "sha256:694e3c2cdc472ed2bd8bd4555ca002eec4310961dd58ef791d508f57b5cc4c94", size = 39153826, upload-time = "2026-03-31T18:29:33.681Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a1/581a8c707b5e80efdbbe1dd94527404d33fe50bceb71f39d5a7e11bd57b7/llvmlite-0.47.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:92ec8a169a20b473c1c54d4695e371bde36489fc1efa3688e11e99beba0abf9c", size = 37232772, upload-time = "2026-03-31T18:29:37.952Z" },
+    { url = "https://files.pythonhosted.org/packages/11/03/16090dd6f74ba2b8b922276047f15962fbeea0a75d5601607edb301ba945/llvmlite-0.47.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbd800edd3b20bc141521f7fd45a6185a5b84109aa6855134e81397ffe72b", size = 56275178, upload-time = "2026-03-31T18:29:42.58Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/cb/0abf1dd4c5286a95ffe0c1d8c67aec06b515894a0dd2ac97f5e27b82ab0b/llvmlite-0.47.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6725179b89f03b17dabe236ff3422cb8291b4c1bf40af152826dfd34e350ae8", size = 55128632, upload-time = "2026-03-31T18:29:46.939Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/79/d3bbab197e86e0ff4f9c07122895b66a3e0d024247fcff7f12c473cb36d9/llvmlite-0.47.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6842cf6f707ec4be3d985a385ad03f72b2d724439e118fcbe99b2929964f0453", size = 39153839, upload-time = "2026-03-31T18:29:51.004Z" },
+]
+
+[[package]]
+name = "locket"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/83/97b29fe05cb6ae28d2dbd30b81e2e402a3eed5f460c26e9eaa5895ceacf5/locket-1.0.0.tar.gz", hash = "sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632", size = 4350, upload-time = "2022-04-20T22:04:44.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl", hash = "sha256:b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3", size = 4398, upload-time = "2022-04-20T22:04:42.23Z" },
+]
+
+[[package]]
+name = "lz4"
+version = "4.4.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/51/f1b86d93029f418033dddf9b9f79c8d2641e7454080478ee2aab5123173e/lz4-4.4.5.tar.gz", hash = "sha256:5f0b9e53c1e82e88c10d7c180069363980136b9d7a8306c4dca4f760d60c39f0", size = 172886, upload-time = "2025-11-03T13:02:36.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/5b/6edcd23319d9e28b1bedf32768c3d1fd56eed8223960a2c47dacd2cec2af/lz4-4.4.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d6da84a26b3aa5da13a62e4b89ab36a396e9327de8cd48b436a3467077f8ccd4", size = 207391, upload-time = "2025-11-03T13:01:36.644Z" },
+    { url = "https://files.pythonhosted.org/packages/34/36/5f9b772e85b3d5769367a79973b8030afad0d6b724444083bad09becd66f/lz4-4.4.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:61d0ee03e6c616f4a8b69987d03d514e8896c8b1b7cc7598ad029e5c6aedfd43", size = 207146, upload-time = "2025-11-03T13:01:37.928Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f4/f66da5647c0d72592081a37c8775feacc3d14d2625bbdaabd6307c274565/lz4-4.4.5-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:33dd86cea8375d8e5dd001e41f321d0a4b1eb7985f39be1b6a4f466cd480b8a7", size = 1292623, upload-time = "2025-11-03T13:01:39.341Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fc/5df0f17467cdda0cad464a9197a447027879197761b55faad7ca29c29a04/lz4-4.4.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:609a69c68e7cfcfa9d894dc06be13f2e00761485b62df4e2472f1b66f7b405fb", size = 1279982, upload-time = "2025-11-03T13:01:40.816Z" },
+    { url = "https://files.pythonhosted.org/packages/25/3b/b55cb577aa148ed4e383e9700c36f70b651cd434e1c07568f0a86c9d5fbb/lz4-4.4.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:75419bb1a559af00250b8f1360d508444e80ed4b26d9d40ec5b09fe7875cb989", size = 1368674, upload-time = "2025-11-03T13:01:42.118Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/31/e97e8c74c59ea479598e5c55cbe0b1334f03ee74ca97726e872944ed42df/lz4-4.4.5-cp311-cp311-win32.whl", hash = "sha256:12233624f1bc2cebc414f9efb3113a03e89acce3ab6f72035577bc61b270d24d", size = 88168, upload-time = "2025-11-03T13:01:43.282Z" },
+    { url = "https://files.pythonhosted.org/packages/18/47/715865a6c7071f417bef9b57c8644f29cb7a55b77742bd5d93a609274e7e/lz4-4.4.5-cp311-cp311-win_amd64.whl", hash = "sha256:8a842ead8ca7c0ee2f396ca5d878c4c40439a527ebad2b996b0444f0074ed004", size = 99491, upload-time = "2025-11-03T13:01:44.167Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e7/ac120c2ca8caec5c945e6356ada2aa5cfabd83a01e3170f264a5c42c8231/lz4-4.4.5-cp311-cp311-win_arm64.whl", hash = "sha256:83bc23ef65b6ae44f3287c38cbf82c269e2e96a26e560aa551735883388dcc4b", size = 91271, upload-time = "2025-11-03T13:01:45.016Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ac/016e4f6de37d806f7cc8f13add0a46c9a7cfc41a5ddc2bc831d7954cf1ce/lz4-4.4.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:df5aa4cead2044bab83e0ebae56e0944cc7fcc1505c7787e9e1057d6d549897e", size = 207163, upload-time = "2025-11-03T13:01:45.895Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/df/0fadac6e5bd31b6f34a1a8dbd4db6a7606e70715387c27368586455b7fc9/lz4-4.4.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6d0bf51e7745484d2092b3a51ae6eb58c3bd3ce0300cf2b2c14f76c536d5697a", size = 207150, upload-time = "2025-11-03T13:01:47.205Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/17/34e36cc49bb16ca73fb57fbd4c5eaa61760c6b64bce91fcb4e0f4a97f852/lz4-4.4.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7b62f94b523c251cf32aa4ab555f14d39bd1a9df385b72443fd76d7c7fb051f5", size = 1292045, upload-time = "2025-11-03T13:01:48.667Z" },
+    { url = "https://files.pythonhosted.org/packages/90/1c/b1d8e3741e9fc89ed3b5f7ef5f22586c07ed6bb04e8343c2e98f0fa7ff04/lz4-4.4.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c3ea562c3af274264444819ae9b14dbbf1ab070aff214a05e97db6896c7597e", size = 1279546, upload-time = "2025-11-03T13:01:50.159Z" },
+    { url = "https://files.pythonhosted.org/packages/55/d9/e3867222474f6c1b76e89f3bd914595af69f55bf2c1866e984c548afdc15/lz4-4.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24092635f47538b392c4eaeff14c7270d2c8e806bf4be2a6446a378591c5e69e", size = 1368249, upload-time = "2025-11-03T13:01:51.273Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e7/d667d337367686311c38b580d1ca3d5a23a6617e129f26becd4f5dc458df/lz4-4.4.5-cp312-cp312-win32.whl", hash = "sha256:214e37cfe270948ea7eb777229e211c601a3e0875541c1035ab408fbceaddf50", size = 88189, upload-time = "2025-11-03T13:01:52.605Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/0b/a54cd7406995ab097fceb907c7eb13a6ddd49e0b231e448f1a81a50af65c/lz4-4.4.5-cp312-cp312-win_amd64.whl", hash = "sha256:713a777de88a73425cf08eb11f742cd2c98628e79a8673d6a52e3c5f0c116f33", size = 99497, upload-time = "2025-11-03T13:01:53.477Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7e/dc28a952e4bfa32ca16fa2eb026e7a6ce5d1411fcd5986cd08c74ec187b9/lz4-4.4.5-cp312-cp312-win_arm64.whl", hash = "sha256:a88cbb729cc333334ccfb52f070463c21560fca63afcf636a9f160a55fac3301", size = 91279, upload-time = "2025-11-03T13:01:54.419Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/46/08fd8ef19b782f301d56a9ccfd7dafec5fd4fc1a9f017cf22a1accb585d7/lz4-4.4.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6bb05416444fafea170b07181bc70640975ecc2a8c92b3b658c554119519716c", size = 207171, upload-time = "2025-11-03T13:01:56.595Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3f/ea3334e59de30871d773963997ecdba96c4584c5f8007fd83cfc8f1ee935/lz4-4.4.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b424df1076e40d4e884cfcc4c77d815368b7fb9ebcd7e634f937725cd9a8a72a", size = 207163, upload-time = "2025-11-03T13:01:57.721Z" },
+    { url = "https://files.pythonhosted.org/packages/41/7b/7b3a2a0feb998969f4793c650bb16eff5b06e80d1f7bff867feb332f2af2/lz4-4.4.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:216ca0c6c90719731c64f41cfbd6f27a736d7e50a10b70fad2a9c9b262ec923d", size = 1292136, upload-time = "2025-11-03T13:02:00.375Z" },
+    { url = "https://files.pythonhosted.org/packages/89/d1/f1d259352227bb1c185288dd694121ea303e43404aa77560b879c90e7073/lz4-4.4.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:533298d208b58b651662dd972f52d807d48915176e5b032fb4f8c3b6f5fe535c", size = 1279639, upload-time = "2025-11-03T13:02:01.649Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/fb/ba9256c48266a09012ed1d9b0253b9aa4fe9cdff094f8febf5b26a4aa2a2/lz4-4.4.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:451039b609b9a88a934800b5fc6ee401c89ad9c175abf2f4d9f8b2e4ef1afc64", size = 1368257, upload-time = "2025-11-03T13:02:03.35Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6d/dee32a9430c8b0e01bbb4537573cabd00555827f1a0a42d4e24ca803935c/lz4-4.4.5-cp313-cp313-win32.whl", hash = "sha256:a5f197ffa6fc0e93207b0af71b302e0a2f6f29982e5de0fbda61606dd3a55832", size = 88191, upload-time = "2025-11-03T13:02:04.406Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e0/f06028aea741bbecb2a7e9648f4643235279a770c7ffaf70bd4860c73661/lz4-4.4.5-cp313-cp313-win_amd64.whl", hash = "sha256:da68497f78953017deb20edff0dba95641cc86e7423dfadf7c0264e1ac60dc22", size = 99502, upload-time = "2025-11-03T13:02:05.886Z" },
+    { url = "https://files.pythonhosted.org/packages/61/72/5bef44afb303e56078676b9f2486f13173a3c1e7f17eaac1793538174817/lz4-4.4.5-cp313-cp313-win_arm64.whl", hash = "sha256:c1cfa663468a189dab510ab231aad030970593f997746d7a324d40104db0d0a9", size = 91285, upload-time = "2025-11-03T13:02:06.77Z" },
+    { url = "https://files.pythonhosted.org/packages/49/55/6a5c2952971af73f15ed4ebfdd69774b454bd0dc905b289082ca8664fba1/lz4-4.4.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:67531da3b62f49c939e09d56492baf397175ff39926d0bd5bd2d191ac2bff95f", size = 207348, upload-time = "2025-11-03T13:02:08.117Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d7/fd62cbdbdccc35341e83aabdb3f6d5c19be2687d0a4eaf6457ddf53bba64/lz4-4.4.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a1acbbba9edbcbb982bc2cac5e7108f0f553aebac1040fbec67a011a45afa1ba", size = 207340, upload-time = "2025-11-03T13:02:09.152Z" },
+    { url = "https://files.pythonhosted.org/packages/77/69/225ffadaacb4b0e0eb5fd263541edd938f16cd21fe1eae3cd6d5b6a259dc/lz4-4.4.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a482eecc0b7829c89b498fda883dbd50e98153a116de612ee7c111c8bcf82d1d", size = 1293398, upload-time = "2025-11-03T13:02:10.272Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/9e/2ce59ba4a21ea5dc43460cba6f34584e187328019abc0e66698f2b66c881/lz4-4.4.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e099ddfaa88f59dd8d36c8a3c66bd982b4984edf127eb18e30bb49bdba68ce67", size = 1281209, upload-time = "2025-11-03T13:02:12.091Z" },
+    { url = "https://files.pythonhosted.org/packages/80/4f/4d946bd1624ec229b386a3bc8e7a85fa9a963d67d0a62043f0af0978d3da/lz4-4.4.5-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2af2897333b421360fdcce895c6f6281dc3fab018d19d341cf64d043fc8d90d", size = 1369406, upload-time = "2025-11-03T13:02:13.683Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/d429ba4720a9064722698b4b754fb93e42e625f1318b8fe834086c7c783b/lz4-4.4.5-cp313-cp313t-win32.whl", hash = "sha256:66c5de72bf4988e1b284ebdd6524c4bead2c507a2d7f172201572bac6f593901", size = 88325, upload-time = "2025-11-03T13:02:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/85/7ba10c9b97c06af6c8f7032ec942ff127558863df52d866019ce9d2425cf/lz4-4.4.5-cp313-cp313t-win_amd64.whl", hash = "sha256:cdd4bdcbaf35056086d910d219106f6a04e1ab0daa40ec0eeef1626c27d0fddb", size = 99643, upload-time = "2025-11-03T13:02:15.978Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4d/a175459fb29f909e13e57c8f475181ad8085d8d7869bd8ad99033e3ee5fa/lz4-4.4.5-cp313-cp313t-win_arm64.whl", hash = "sha256:28ccaeb7c5222454cd5f60fcd152564205bcb801bd80e125949d2dfbadc76bbd", size = 91504, upload-time = "2025-11-03T13:02:17.313Z" },
+    { url = "https://files.pythonhosted.org/packages/63/9c/70bdbdb9f54053a308b200b4678afd13efd0eafb6ddcbb7f00077213c2e5/lz4-4.4.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c216b6d5275fc060c6280936bb3bb0e0be6126afb08abccde27eed23dead135f", size = 207586, upload-time = "2025-11-03T13:02:18.263Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/cb/bfead8f437741ce51e14b3c7d404e3a1f6b409c440bad9b8f3945d4c40a7/lz4-4.4.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c8e71b14938082ebaf78144f3b3917ac715f72d14c076f384a4c062df96f9df6", size = 207161, upload-time = "2025-11-03T13:02:19.286Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/18/b192b2ce465dfbeabc4fc957ece7a1d34aded0d95a588862f1c8a86ac448/lz4-4.4.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9b5e6abca8df9f9bdc5c3085f33ff32cdc86ed04c65e0355506d46a5ac19b6e9", size = 1292415, upload-time = "2025-11-03T13:02:20.829Z" },
+    { url = "https://files.pythonhosted.org/packages/67/79/a4e91872ab60f5e89bfad3e996ea7dc74a30f27253faf95865771225ccba/lz4-4.4.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3b84a42da86e8ad8537aabef062e7f661f4a877d1c74d65606c49d835d36d668", size = 1279920, upload-time = "2025-11-03T13:02:22.013Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/01/d52c7b11eaa286d49dae619c0eec4aabc0bf3cda7a7467eb77c62c4471f3/lz4-4.4.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bba042ec5a61fa77c7e380351a61cb768277801240249841defd2ff0a10742f", size = 1368661, upload-time = "2025-11-03T13:02:23.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/137ddeea14c2cb86864838277b2607d09f8253f152156a07f84e11768a28/lz4-4.4.5-cp314-cp314-win32.whl", hash = "sha256:bd85d118316b53ed73956435bee1997bd06cc66dd2fa74073e3b1322bd520a67", size = 90139, upload-time = "2025-11-03T13:02:24.301Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2c/8332080fd293f8337779a440b3a143f85e374311705d243439a3349b81ad/lz4-4.4.5-cp314-cp314-win_amd64.whl", hash = "sha256:92159782a4502858a21e0079d77cdcaade23e8a5d252ddf46b0652604300d7be", size = 101497, upload-time = "2025-11-03T13:02:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/28/2635a8141c9a4f4bc23f5135a92bbcf48d928d8ca094088c962df1879d64/lz4-4.4.5-cp314-cp314-win_arm64.whl", hash = "sha256:d994b87abaa7a88ceb7a37c90f547b8284ff9da694e6afcfaa8568d739faf3f7", size = 93812, upload-time = "2025-11-03T13:02:26.133Z" },
+]
+
+[[package]]
 name = "markdown"
 version = "3.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2544,6 +2893,82 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
+]
+
+[[package]]
+name = "msgpack"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/f9/c0a1c127f9049db9155afc316952ea571720dd01833ff5e4d7e8e6352dbb/msgpack-1.2.1.tar.gz", hash = "sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647", size = 183960, upload-time = "2026-06-18T16:13:52.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/6b/e9b1cdc042c4458801d2545ed782a95f3d6ba8e270cce8745b8603c7f748/msgpack-1.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:29a3f6e9667868429d8240dfd063ea5ffdc1321c13d783aa23827a38de0dcb22", size = 82812, upload-time = "2026-06-18T16:12:45.022Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/3a/dd518a1bf78ed1e9ad8afe57307c079a00eafe4b3068932a27ca1ea56b4f/msgpack-1.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:aded5bdf32609dc7987a49bbbd15a8ef096193f96dd8bbeb791de729e650acf5", size = 82739, upload-time = "2026-06-18T16:12:46.025Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e0/7ba9e1542bf0771a27b8b37c1316e3f95ae9d748fd765284655c476ad4ef/msgpack-1.2.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:146ee4e9ce80b365c6d4c47073da9da7bcec473e58194ceee5dd7620ace77e06", size = 414233, upload-time = "2026-06-18T16:12:47.029Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8d/671d81534ea0e2b0e8a121be100020da09eb78861fe3aa8f3ef7dcd3bed1/msgpack-1.2.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a28d076ca7c82b9c8728ad90b7147489449557038bed50e4241eb832395169b4", size = 423843, upload-time = "2026-06-18T16:12:48.19Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b6/e5c737515ed1f166664b87601b532f58cbb73d8aa6a90b99f7c2c5037e8e/msgpack-1.2.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7d31c0ac0c640f877804c67cb2bc9f4e23dc2db97e96c2e67fa27d38283b41f8", size = 390772, upload-time = "2026-06-18T16:12:49.624Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/46/62ed8c2e87d7021eab19921594d961ef3aa3794eec76c716dc30f3bfd433/msgpack-1.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8ff92d7feeaf5bc26c51495b69e2f99ed97ab79346fb6555f44be7dd2ac6503b", size = 409559, upload-time = "2026-06-18T16:12:50.936Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/59aa3887b860bbf43532835e192b1c388a17590d6068ae4f8b2bc74c906e/msgpack-1.2.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:779197a6513bab3c3632265e3d0f7cb3227e62510841a6f34f1eaa37efbb345e", size = 387838, upload-time = "2026-06-18T16:12:52.161Z" },
+    { url = "https://files.pythonhosted.org/packages/09/11/f8563e471093420cf6478cb3271a0175d8402b82d879783d4035d2d03360/msgpack-1.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:67f6dd22fa72a93752643f07889796d62739a13415ee630169a8ce764f86cf9f", size = 421732, upload-time = "2026-06-18T16:12:53.556Z" },
+    { url = "https://files.pythonhosted.org/packages/57/cf/e673683c4c6c90c1022b24c65af4b03eda72b182a1176ef6449069d66acc/msgpack-1.2.1-cp311-cp311-win32.whl", hash = "sha256:91054a783328e0ea7954b8771095705c8d2243b814743fbaadf14552c9c52c5d", size = 64091, upload-time = "2026-06-18T16:12:54.821Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/07/ca212739d179f9083bff2c7c08c24101c3555a334fadc2b876b18768a3ae/msgpack-1.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2eda0b7ebb1283a98d3e4492ac933c8af6aff59fd3df1c3ed024f536af4b1dc8", size = 70462, upload-time = "2026-06-18T16:12:55.898Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/be/6798347b425e26f35db82e69dd83c09716c856a3714e7bffc4c0860fd830/msgpack-1.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:6ee967f7c7e1df2890c671ff2ee51a28ded0efc95da3e507176dee881ce36c66", size = 65059, upload-time = "2026-06-18T16:12:57.053Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/dd/9e8cbd8f5582ca4b590336f2b91ee5662f6a6ca562b565abaf696a0f81ff/msgpack-1.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2ef59c659f289eddf8aa6623823f19fa2f40a4029266889eac7a2505dd210c35", size = 83531, upload-time = "2026-06-18T16:12:58.249Z" },
+    { url = "https://files.pythonhosted.org/packages/50/2e/ebdb85a8da151397a2790363676b7ed7c125924fe618e4c6d8befb0cc62c/msgpack-1.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3567748a5107cb40cdf66a275430c2f87c07777698f4bfd25c35f44d533258c", size = 82657, upload-time = "2026-06-18T16:12:59.396Z" },
+    { url = "https://files.pythonhosted.org/packages/26/aa/753ad8b007b464e1d8aa0c8e650b9c5f4f725e658fc5ac8a7635c55b7f6e/msgpack-1.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60926b75d00c8e816ef98f3034f484a8bc64242d66839cef4cf7e503142316a0", size = 410634, upload-time = "2026-06-18T16:13:00.383Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fd/6adabd4f6d5e686f97dd02ce7fce3fe4cf672cbac36b8f67ff4040e8ad8b/msgpack-1.2.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:020e881a764b20d8d7ca1a54fc01b8175519d108e3c3f194fddc200bda95951a", size = 419989, upload-time = "2026-06-18T16:13:01.776Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cc/85039b7b0eb168aaad7383a23c97e291a11f08351cb45a606ce865e4e3f1/msgpack-1.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4202c74688ca06591f78cb18988228bd4cca2cc75d57b60008372892d2f1e6e6", size = 377544, upload-time = "2026-06-18T16:13:03.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/bf/35963899493b32030c85fc513b723ae66144ac70c11ebc52e889e16e3d99/msgpack-1.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8b267ce94efb76fbd1b3373511420074ee3187f0f7811bf394531de13294735a", size = 400842, upload-time = "2026-06-18T16:13:05.012Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/df/8e2ac970c8f99264cd9997d1c73df5466bc19da3301d7dc5500862a9b089/msgpack-1.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:e4f1d0f8f98ade9634e01fb704a408f9336c0a8f1117b369f5db83dc7551d8b1", size = 374108, upload-time = "2026-06-18T16:13:06.232Z" },
+    { url = "https://files.pythonhosted.org/packages/17/dd/fa8bd265110dfa51c20cb529f9e6d240a16fafe7e645004c6af2d01353ba/msgpack-1.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f02cf17a6ca1abe29b5f980644f7551f94d71f2011509b26d8625ce038f0df64", size = 414939, upload-time = "2026-06-18T16:13:07.478Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8377a5ad8953fc0437c70cc98d9ae29f27fe5ac5109fbec0812085865735/msgpack-1.2.1-cp312-cp312-win32.whl", hash = "sha256:0c0d9802354507bcba62af19c17918e3eb437cc25e6f50657d511b5856a77aac", size = 64504, upload-time = "2026-06-18T16:13:08.822Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7f/ce1e377df7e62461fefd9eb23bfb93a4a523f40a517b377b8f844d836828/msgpack-1.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c24aa15d5963051e1a5c62b12c50cd705992502b5ec1f3bece6046f33c9fc24", size = 71421, upload-time = "2026-06-18T16:13:09.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/32/ebfe84c9929f08f188d56c7a2fd913406a9ddad76a634697c1c43b8112e6/msgpack-1.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:4227224aaec8f7fbcbfbd4272319347b2bb4030366502600f8c45588c5187b07", size = 64775, upload-time = "2026-06-18T16:13:11.056Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ac/dcddcab6f6c20ecb387ca5e980371cdb3f87ff69aeca388be97eebc4c074/msgpack-1.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0a70e3cf2804a300d921bb0940426e35f4e489a23adfb77a808892241db0a064", size = 83151, upload-time = "2026-06-18T16:13:12.173Z" },
+    { url = "https://files.pythonhosted.org/packages/64/71/fbcfa83a1d6a9c6091942d1cfd070962244664b87427a9a49a6897b1b219/msgpack-1.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:491cc39455ca765fad51fb451bf2915eb2cf41192ab5801ce8d67c1d614fe056", size = 82351, upload-time = "2026-06-18T16:13:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/10/ddf7b06db879e8792d13934ddda09ff20bd2a583fd84c9b59aae9b0e650b/msgpack-1.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc", size = 407518, upload-time = "2026-06-18T16:13:14.233Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d3/36a46a8ed992b781acbc05928bd5bee3c810cb0c3563bf81a7b0c04a1a76/msgpack-1.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:787c9bebb5833e8f6fc8abca3c0597683d8d87f56a8842b6b89c75a5f3176e2d", size = 416405, upload-time = "2026-06-18T16:13:15.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/84/e8e9598b557c0ba6ddae901a73780a4c75ac667dddf59414b1e56a42fb34/msgpack-1.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dc871b997a9370d855b7394465f2f350e847a5b806dd38dcc9c989e7d87da155", size = 376257, upload-time = "2026-06-18T16:13:17.022Z" },
+    { url = "https://files.pythonhosted.org/packages/40/16/738fe6d875ad7e2a9429c165322a4ec088f4f273cdfae63d96a89c467961/msgpack-1.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:85f57e960d877f2977f6430896191b04a21f8901b3b4baf2e4604329f4db5402", size = 397469, upload-time = "2026-06-18T16:13:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/be/6d5952df75a7f24f35833af764c3a6860780364cb3a0030beb8099e1b2b4/msgpack-1.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1233ee2dd0cefba127583de50ea654677277047d238303521db35def3d7b2e7c", size = 372802, upload-time = "2026-06-18T16:13:19.685Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/39/e2ef7dbf0473bcb8dc7c50bf782a892d67414877b63e47fc88eb189ef5e6/msgpack-1.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e3dc2feb0876209d9c38aa56cb1de169bd6c4348f1aa48271f241226590993e6", size = 411273, upload-time = "2026-06-18T16:13:21.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c5/133f4512a56e983a93445c836c9d94d88f3bc2e0980ff4b9e577bd8416ce/msgpack-1.2.1-cp313-cp313-win32.whl", hash = "sha256:6d09badf350af2be9d189184e04e64cf54ad93569ab3d96fca58bd3e84aad707", size = 64471, upload-time = "2026-06-18T16:13:22.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/577e10b055096a7dd40732358cabaf7180a20c79ed1dcdbb618e4b9deac7/msgpack-1.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:33f14fba63278b714efe6ad07e50ea5f03d91537aa6a1c5f1ceca4cf44013ca9", size = 71274, upload-time = "2026-06-18T16:13:23.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ee/0c0048e7cfbef23c6a94791b8959ab28155232e7956de8a305b5ff588f05/msgpack-1.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc5febcd4c99effbc02b528e49d6fd0760b2b7d48c05239e345a5fa6e743d9a", size = 64795, upload-time = "2026-06-18T16:13:24.687Z" },
+    { url = "https://files.pythonhosted.org/packages/77/58/cce442852c6b9e1639c7c8ac8fd9143121cb32dab0f308df4d1426a8eb9c/msgpack-1.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:05f340e47e7e47d2da8db9b53e1bb1d294369e9ef45a747441309f6650b8351d", size = 83610, upload-time = "2026-06-18T16:13:25.724Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5c/15b4c7a0182f75ffa90751958ba36a9c01cafee367d49a3edc10ed140b01/msgpack-1.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:810b916696c86ef0deb3b74588480224df4c1b071136c34183e4a2a4284d7ac7", size = 83138, upload-time = "2026-06-18T16:13:26.781Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/99e58722feaffc5f2fbcc0c8c0d1451ab9f84097f7af87291b46af2390f4/msgpack-1.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ca0dacff965c47afdc3749a8469d7302a8f801d6a28758d55120d75e66ce6889", size = 406090, upload-time = "2026-06-18T16:13:28.072Z" },
+    { url = "https://files.pythonhosted.org/packages/19/03/8c63e8cf52958534ef688625965ab04c269a6cadd8caef16758b380a821a/msgpack-1.2.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e2bf9280bceb5efca998435904b5d3e9fdbcc11d90dc9df30aec7973252b720", size = 412106, upload-time = "2026-06-18T16:13:29.427Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d2/155d9e71b40e41fd934bc0c48b9b2770f22263e1ac20aad8e29fdca7be3f/msgpack-1.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6c4be5d1c02a42b066ca6ddb71adf36432868fdcdb6ee87e634e86e0674190", size = 374851, upload-time = "2026-06-18T16:13:30.631Z" },
+    { url = "https://files.pythonhosted.org/packages/98/48/deaf2326262a8d5ea3295ce9649912ecd3f551ba7ec8e33c665d2ba583f3/msgpack-1.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec0e675d59150a6269ddc9139087c722292664a37d071a849c05c473350f1f2d", size = 396168, upload-time = "2026-06-18T16:13:31.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/2a/b4410f906c2ec0008f1608d3ab5143afc3ad3f4e6da0fed3ea2231d0bef4/msgpack-1.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:dd3bfe82d53edfe4b7fc9a7ec9761e23a7a5b1dac22264505af428253c29ed24", size = 371959, upload-time = "2026-06-18T16:13:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/59/86/1edc67270099a528fa2093ea60fe191233cd238e4bd30cfacf7db79fc959/msgpack-1.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5ad5467fc3f68b5468e06c5f788d712e9f8ffc8b0cd1bcb160c105c1ee92dae7", size = 408457, upload-time = "2026-06-18T16:13:34.567Z" },
+    { url = "https://files.pythonhosted.org/packages/82/90/8b630fef07d8c5ab457b71ff2c217910c83d333c7a68472c186e87cc504a/msgpack-1.2.1-cp314-cp314-win32.whl", hash = "sha256:98b58bdb89c46190e4609bb36abe17c6d4105ad13f9c5f8f6f64d320f8ced3fb", size = 65942, upload-time = "2026-06-18T16:13:36.056Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f1/467b81e98b24dd3885d7b1857728797b4ffc76a7a7483af4fb321a07de3c/msgpack-1.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:74847557e28ce71bd3c438a447ca90e4b507e997ddbdef8a12a7b283b86c156b", size = 72627, upload-time = "2026-06-18T16:13:37.079Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/1d/5d8c4c89985feb6acefb82a09e501c60392261856d2408d20bfe4f0360b1/msgpack-1.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:b50b727bd652bdc37d950336c848ef20ec54a4cafc38dce19b1cd86ad625d0f7", size = 66908, upload-time = "2026-06-18T16:13:38.23Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ad2afb678b4de94496cd432b581759b756a92c1192d8c767edd6b132efdc/msgpack-1.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8d00f177ca88a77c1cf848d204a38f249751650b601cb6532acc68805d8a8273", size = 86000, upload-time = "2026-06-18T16:13:39.44Z" },
+    { url = "https://files.pythonhosted.org/packages/54/74/0b797484013128837f3b1cbb6cea019277c4de4e377dc512b4d9a0f92940/msgpack-1.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5bb9c386f0a329c035ddbab4b72d1028bf9627add8dda41070288563d57ed1b1", size = 86544, upload-time = "2026-06-18T16:13:40.447Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/b4/b774d7eb95561739907fec675582f83203cf41c597a418c2589b4bfb8e9d/msgpack-1.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20466cca18c49c7292a8984bc15d65857b171e7264bdcb5f96baf8be238791fc", size = 427661, upload-time = "2026-06-18T16:13:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f9/3243191dc9937e00756c8bc1b0272fed8f23758e43df2a3b46f533e5090f/msgpack-1.2.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:196300e7e5d6e74d50f1607ab9c06c4a1484c383cd22defd727902591f7e8dde", size = 426375, upload-time = "2026-06-18T16:13:42.936Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c7/1693111db9944ba4ad4b67a1e788400d78a0b6af7a6523dc7e4e58f8274b/msgpack-1.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:575957e79cd51903a4e8495a242442949641e08f1efd5197b43bebd3ea7682b4", size = 380495, upload-time = "2026-06-18T16:13:44.306Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2b/92f86956a0c13e8662f7e2ad630c4eb4db07497b967589bd5245e018b2c1/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8c2ed1e48cc0f460bf3c7780e7137ff21a4e18433451916f2442c1b21036cd7d", size = 410897, upload-time = "2026-06-18T16:13:45.629Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ea/1479f72d200313a76fc2f823a79d1e07ed052ab7b8a0280640aa7b95de42/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5f6277e5f783c36786a145e0247fc189a03f35f84b251646e53592d2bc12b355", size = 378519, upload-time = "2026-06-18T16:13:46.998Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/4d/fa006060ffa1011d32bfae826fe766fe73e02982183601633b7121058ab3/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f9389552ecf4784886345ead0647e4edc96bee37cbab05b75540f542f766c48c", size = 419815, upload-time = "2026-06-18T16:13:48.205Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/aab6c946570496b78e67804721f3d5e2d62a93081b9b37df77764ef56347/msgpack-1.2.1-cp314-cp314t-win32.whl", hash = "sha256:c1c79a604a2969a868a78b6ebd27a887e00c624f14f66b3038e0590cb23332d1", size = 70914, upload-time = "2026-06-18T16:13:49.385Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0a/e608956488a2af014cfe6e3d665e090b8ee42aa14b07f8f95b8880d66b09/msgpack-1.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f12038a35fabd52e56a3547bab42401af49a45caa6dd00b34c44de235bc93ee2", size = 77999, upload-time = "2026-06-18T16:13:50.467Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8a/27e2e57055176e366a46b85d02d68e7a5bcfbdd8474c9706375d965f24d3/msgpack-1.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0adcf06ffde0777c0e1a9b771a2b1c4226ba1bbf748c8efcc02fcdeca3299107", size = 71160, upload-time = "2026-06-18T16:13:51.498Z" },
+]
+
+[[package]]
+name = "msgpack-numpy"
+version = "0.4.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msgpack" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/94/61e8aee142733ebfdc400a05bdac6e1763c4514bba3b42743d223f388450/msgpack-numpy-0.4.8.tar.gz", hash = "sha256:c667d3180513422f9c7545be5eec5d296dcbb357e06f72ed39cc683797556e69", size = 10923, upload-time = "2022-06-09T03:43:08.739Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/5d/f25ac7d4fb77cbd53ddc6d05d833c6bf52b12770a44fa9a447eed470ca9a/msgpack_numpy-0.4.8-py2.py3-none-any.whl", hash = "sha256:773c19d4dfbae1b3c7b791083e2caf66983bb19b40901646f61d8731554ae3da", size = 6919, upload-time = "2022-06-09T03:43:06.82Z" },
 ]
 
 [[package]]
@@ -2803,6 +3228,62 @@ wheels = [
 ]
 
 [[package]]
+name = "ndindex"
+version = "1.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/92/4b9d2f4e0f3eabcfc7b02b48261f6e5ad36a3e2c1bbdcc4e3b7b6c768fa6/ndindex-1.10.1.tar.gz", hash = "sha256:0f6113c1f031248f8818cbee1aa92aa3c9472b7701debcce9fddebcd2f610f11", size = 271395, upload-time = "2025-11-19T20:40:08.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/d9/c94ab6151c9fdd199c2b560f23e3759a9fb86a7a1275855e0b97291bf05a/ndindex-1.10.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e2ad917bcdf8dc5ba1e21f01054c991d26862d4d01c3c203a50e907096d558ac", size = 172128, upload-time = "2025-11-19T20:38:28.977Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/34/880c4073750766e44492d51280d025f28e36475394ca3d741b0a4adad4b0/ndindex-1.10.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e851990a68937db5f485cd9f3e760c1fd47fa0f2a99f63a5e2cc880908faf3bb", size = 171423, upload-time = "2025-11-19T20:38:30.357Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/1e/0342da55dabe4075efc2b2ab91a6a22ed3047c5bd511ef771a7a3f822c90/ndindex-1.10.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:27385939f317b55773ea53f6bf9334810cf1d66206034c0a6a6f2a88f2001c3c", size = 519590, upload-time = "2025-11-19T20:38:32.464Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cb/7a02b6f29b15a16cd0002f4591d14493eff8e9236f7ca4c02ee4d4bcefbd/ndindex-1.10.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9fdf3ca16efcdfbb8800aa88fbab1bc6528e6a0504bcb9cf7af4cb9d50e9f5d9", size = 516676, upload-time = "2025-11-19T20:38:34.276Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d5/38da808f968a54b0fead2d7e15ca011d3df93c96a07f4914e8ef3974506e/ndindex-1.10.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3307817bdc92846b18f309fae3582856f567dd6e0742fb0b41ac68682bfc4e2a", size = 1491141, upload-time = "2025-11-19T20:38:35.785Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/1f/8c66ef982a01ae4cbdabba679a2bc711f262cedf23bfb9682293146f8a98/ndindex-1.10.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae73cd2d66b09ef2f2a7d7f93bad396d6abf168d1ee825e403c6c5fb8ae1341c", size = 1543876, upload-time = "2025-11-19T20:38:37.456Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/7c7e3a3c6e81b4284fd0d53cbaec51d9e5b90df26dd78e9bde06cb307217/ndindex-1.10.1-cp311-cp311-win32.whl", hash = "sha256:890bb92f0a779e6f16bdbcc8bd2e06c32bcc0239e5893ba246114eb924aecaaa", size = 149149, upload-time = "2025-11-19T20:38:38.911Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/38/99e1fb0effdef74b883be615ea0053ebcea28a53fd8b896263f4e99b0113/ndindex-1.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:1827a40301405b44ad709e388c5b48cf35cd90a67f77e63f0f17d87f6000fa81", size = 157246, upload-time = "2025-11-19T20:38:40.197Z" },
+    { url = "https://files.pythonhosted.org/packages/65/90/774ddd08b2a1b41faa56da111f0fbfeb4f17ee537214c938ef41d61af949/ndindex-1.10.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:87f83e8c35a7f49a68cd3a3054c406e6c22f8c1315f3905f7a778c657669187e", size = 177348, upload-time = "2025-11-19T20:38:41.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ee/a423e857f5b45da3adc8ddbcfbfd4a0e9a047edce3915d3e3d6e189b6bd9/ndindex-1.10.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cf9e05986b2eb8c5993bce0f911d6cedd15bda30b5e35dd354b1ad1f4cc3599d", size = 176561, upload-time = "2025-11-19T20:38:43.06Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/40/139b6b050ba2b2a0bb40e0381a352b1eb6551302dcb8f86fb4c97dd34e92/ndindex-1.10.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:046c1e88d46b2bd2fd3483e06d27b4e85132b55bc693f2fca2db0bb56eea1e78", size = 542901, upload-time = "2025-11-19T20:38:44.43Z" },
+    { url = "https://files.pythonhosted.org/packages/27/ae/defd665dbbeb2fffa077491365ed160acaec49274ce8d4b979f55db71f18/ndindex-1.10.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:03cf1e6cdac876bd8fc92d3b65bb223496b1581d10eab3ba113f7c195121a959", size = 546875, upload-time = "2025-11-19T20:38:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/59/43/6d54d48e8eaee25cdab70d3e4c4f579ddb0255e4f1660040d5ad55e029c6/ndindex-1.10.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:752e78a5e87911ded117c57a7246596f26c9c6da066de3c2b533b3db694949bb", size = 1510036, upload-time = "2025-11-19T20:38:47.444Z" },
+    { url = "https://files.pythonhosted.org/packages/09/61/e28ba3b98eacd18193176526526b34d7d70d2a6f9fd2b4d8309ab5692678/ndindex-1.10.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c9dd58d91220b1c1fe516324bfcf4114566c98e84b1cbbe416abe345c75bd557", size = 1571849, upload-time = "2025-11-19T20:38:48.951Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/63/83fff78a3712cb9f478dd84a19ec389acf6f8c7b01dc347a65ae74e6123d/ndindex-1.10.1-cp312-cp312-win32.whl", hash = "sha256:3b0d9ce2c8488444499ab6d40e92e09867bf4413f5cf04c01635de923f44aa67", size = 149792, upload-time = "2025-11-19T20:38:50.959Z" },
+    { url = "https://files.pythonhosted.org/packages/52/fd/a5e3c8c043d0dddea6cd4567bfaea568f022ac197301882b3d85d9c1e9b3/ndindex-1.10.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c026dbbf2455d97ce6456d8a50b349aee8fefa11027d020638c89e9be2c9c4c", size = 158164, upload-time = "2025-11-19T20:38:52.242Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ea/03676266cb38cc671679a9d258cc59bfc58c69726db87b0d6eeafb308895/ndindex-1.10.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:157b5c34a1b779f5d27b790d9bd7e7b156d284e76be83c591a3ba003984f4956", size = 176323, upload-time = "2025-11-19T20:38:53.528Z" },
+    { url = "https://files.pythonhosted.org/packages/89/f4/2d350439031b108b0bb8897cad315390c5ad88c14d87419a54c2ffa95c80/ndindex-1.10.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f99b3e89220da3244d03c9c5473669c7107d361c129fd9b064622744dee1ce15", size = 175584, upload-time = "2025-11-19T20:38:57.968Z" },
+    { url = "https://files.pythonhosted.org/packages/77/34/a51b7c6f7159718a6a0a694fc1058b94d793c416d9a4fd649f1924cce5f8/ndindex-1.10.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6928e47fb008903f2e41309b7ff1e59b16abbcd59e2e945454571c28b2433c9e", size = 524127, upload-time = "2025-11-19T20:38:59.412Z" },
+    { url = "https://files.pythonhosted.org/packages/21/91/d8f19f0b8fc9c5585b50fda44c05415da0bdc5fa9c9c69011015dac27880/ndindex-1.10.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e69a2cb1ac7be955c3c77f1def83f410775a81525c9ce2d4c0a3f2a61589ed47", size = 528213, upload-time = "2025-11-19T20:39:00.882Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a9/77d9d037e871a3faa8579b354ca2dd09cc5bbf3e085d9e3c67f786d55ee3/ndindex-1.10.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cb76e0f3f235d8b1c768b17e771de48775d281713795c3aa045e8114ad61bdda", size = 1492172, upload-time = "2025-11-19T20:39:02.387Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/29/ad13676fc9312e0aa1a80a7c04bcb0b502b877ed4956136117ad663eced0/ndindex-1.10.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7da34a78410c14341d5fff73be5ce924bd36500bf7f640fc59b8607d3a0df95e", size = 1552614, upload-time = "2025-11-19T20:39:04.232Z" },
+    { url = "https://files.pythonhosted.org/packages/63/34/e6e6fd81423810c07ae623c4d36e099f42a812994977e8e3bfa182c02472/ndindex-1.10.1-cp313-cp313-win32.whl", hash = "sha256:9599fcb7411ffe601c367f0a5d4bc0ed588e3e7d9dc7604bdb32c8f669456b9e", size = 149330, upload-time = "2025-11-19T20:39:05.727Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/d3/830a20626e2ec0e31a926be90e67068a029930f99e6cfebf2f9768e7b7b1/ndindex-1.10.1-cp313-cp313-win_amd64.whl", hash = "sha256:ef3ef22390a892d16286505083ee5b326317b21c255a0c7f744b1290a0b964a6", size = 157309, upload-time = "2025-11-19T20:39:07.394Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/73/3bdeecd1f6ec0ad81478a53d96da4ba9be74ed297c95f2b4fbe2b80843e1/ndindex-1.10.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:72af787dcee3661f36fff9d144d989aacefe32e2c8b51ceef9babd46afb93a18", size = 181022, upload-time = "2025-11-19T20:39:10.487Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b1/0d97ba134b5aa71b5ed638fac193a7ec4d987e091e2f4e4162ebdaacbda1/ndindex-1.10.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fa60637dfae1ee3fc057e420a52cc4ace38cf2c0d1a0451af2a3cba84d281842", size = 181289, upload-time = "2025-11-19T20:39:11.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d7/1df02df24880ce3f3c8137b6f3ca5a901a58d9079dcfd8c818419277ff87/ndindex-1.10.1-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d0ebdba2fade3f6916fe21fd49e2a0935af4f58c56100a60f3f2eb26e20baee7", size = 632517, upload-time = "2025-11-19T20:39:13.259Z" },
+    { url = "https://files.pythonhosted.org/packages/34/96/b509c2b14e9b10710fe6ab6ba8bda1ee6ce36ab16397ff2f5bbb33bbbba3/ndindex-1.10.1-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:346a4bf09f5771548665c8206e81daadb6b9925d409746e709894bdd98adc701", size = 616179, upload-time = "2025-11-19T20:39:14.757Z" },
+    { url = "https://files.pythonhosted.org/packages/38/e3/f89d60cf351c33a484bf1a4546a5dee6f4e7a6a973613ffa12bd316b14ad/ndindex-1.10.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:23d35696f802548143b5cc199bf2f171efb0061aa7934959251dd3bae56d038c", size = 1588373, upload-time = "2025-11-19T20:39:16.62Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/19/002fc1e6a4abeef8d92e9aa2e43aea4d462f6b170090f7752ea8887f4897/ndindex-1.10.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a91e1a0398120233d5c3b23ccb2d4b78e970d66136f1a7221fa9a53873c3d5c5", size = 1636436, upload-time = "2025-11-19T20:39:18.266Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8f/28b1ad78c787ac8fafd6e26419a80366617784b1779e3857fa687492f6bc/ndindex-1.10.1-cp313-cp313t-win32.whl", hash = "sha256:78bfe25941d2dac406391ddd9baf0b0fce163807b98ecc2c47a3030ee8466319", size = 158780, upload-time = "2025-11-19T20:39:20.454Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/56/b81060607a19865bb8be8d705b1b3e8aefb8747c0fbd383e38b4cae4bd71/ndindex-1.10.1-cp313-cp313t-win_amd64.whl", hash = "sha256:08bfdc1f7a0b408d15b3ce61d141ebbebdb47a25341967e425e104c5bd512a5c", size = 167485, upload-time = "2025-11-19T20:39:21.733Z" },
+    { url = "https://files.pythonhosted.org/packages/da/9b/aac1131e9f3a5635ba7b0312c3bfa610511ab4108f85c0d914a32887aa00/ndindex-1.10.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9b5297f207ebc068c7cdf9e3cd7b95aa5c9ec04295d0a7e56b529f66787d4685", size = 176478, upload-time = "2025-11-19T20:39:23.747Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/05/a0d8ca0432c84550bc17af6d6479a803936895b8b8403a1216c5a55475fb/ndindex-1.10.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c5e9762452b163e33cfb6e821f86e45ba0b53bdfcd23ab5d57b48a8f566898cb", size = 175480, upload-time = "2025-11-19T20:39:25.365Z" },
+    { url = "https://files.pythonhosted.org/packages/09/4a/028ab78a9f29fd2a7e86a90337cde4658eaa77b425c63045d83a1d2e4f26/ndindex-1.10.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf80241b40adffdc3276b2c9fb63a96c6c98b4a9d941892738de8add65083962", size = 528125, upload-time = "2025-11-19T20:39:26.798Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a9/bd823b345fb06c83ade6ef1c1933521d4357cd04490e684d4fa30126926c/ndindex-1.10.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf5855881884b8467dfcf45764ccf2e4279075be14b155b89c96994bb08d2e6f", size = 527328, upload-time = "2025-11-19T20:39:28.292Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4f/40b9c15588cbf9dde43c4fb88a31dd1f636a913fa29649f18f8e3ebca36a/ndindex-1.10.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e81a9bd36fe054b6c9fcc53d26bc9a28cf15d1ab52a0f5b854f894116f3a54e1", size = 1497508, upload-time = "2025-11-19T20:39:30.735Z" },
+    { url = "https://files.pythonhosted.org/packages/24/8f/b8048f7837d2e9dff0af507b398307fa84a2aa9ea3db71b4aa800b21da4a/ndindex-1.10.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:588e8875d836a93b3cd9af482c8074bb02288ae1aff92cf277e1f02d9ae0f992", size = 1552625, upload-time = "2025-11-19T20:39:32.404Z" },
+    { url = "https://files.pythonhosted.org/packages/20/aa/0ecb53c7e690a44769f2f92a843723ccb1d0ce080d93ba1ea811304cca12/ndindex-1.10.1-cp314-cp314-win32.whl", hash = "sha256:28741daca5926adff402247cd406f453ed5bb6042e82d6855938f805190e5ce9", size = 151237, upload-time = "2025-11-19T20:39:34.847Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/4e/197982fa8b4e6e6b9d15c38505c41076d1c552921f09f4d35acbbbbc0b70/ndindex-1.10.1-cp314-cp314-win_amd64.whl", hash = "sha256:59a3222befc0f7cdc85fb9b90a567ae890f70a864bdeb660517e9ebcb36bf1bc", size = 158925, upload-time = "2025-11-19T20:39:37.149Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ad/116b6154046a69fc04e2d4490905801d3839a3f21290c0b4d49b1044e251/ndindex-1.10.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:967b87b88dadb62555ec1039695c347254eccb8ca3d124c0e5dbe084c525fa93", size = 181724, upload-time = "2025-11-19T20:39:38.635Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/00/3ce4351366c890bcc87a5e9f1f90102547962eef356ac7c799bfdd0dddce/ndindex-1.10.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c67dde588c0fb89d872931a4ed5f9b4d21c1c70a3d92fdf0812a1de154239816", size = 181653, upload-time = "2025-11-19T20:39:40.048Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/05/a6fda696a2f02a3f8dd2ee9d816cb2edff6423bf0110a4876cc3b1259732/ndindex-1.10.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c65ca639a7abf72d79f22424f4abd18dece1f289a2b7b028a0ca455edd2168d4", size = 630898, upload-time = "2025-11-19T20:39:41.495Z" },
+    { url = "https://files.pythonhosted.org/packages/73/78/eb2e5d067d4c054451e33eaece74cbdcb58236dc60516e73d783dae34c7e/ndindex-1.10.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5c3634a8df43e7928122225a3d64d850c8957bd1edf2e403907deacb478af27b", size = 614419, upload-time = "2025-11-19T20:39:43.254Z" },
+    { url = "https://files.pythonhosted.org/packages/78/51/261bfb49eb7920c2a7314cacba5821930a529911dce48c7c6cd786096a5a/ndindex-1.10.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9d581f931e61f182478f18bdf5edd3955899df5da4892ed0d5de547a4cfd5b6f", size = 1587517, upload-time = "2025-11-19T20:39:44.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/37/084a332ecdf8b0049151bd78001a7baf2daf7f500d043beb8a1f95d0f4e3/ndindex-1.10.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:78ce45106ebf67aeba99714818c721d8fd5fb9534daebd2565665a2d64b50fc9", size = 1635372, upload-time = "2025-11-19T20:39:47.231Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f4/716580fbb03018ab1daa86ed12c1925c67e79689db5fee82393e840758a2/ndindex-1.10.1-cp314-cp314t-win32.whl", hash = "sha256:fe5341e24dc992b09c258456ac90a09a6d25efdc2cb86dcc91d32c8891e1df9a", size = 162186, upload-time = "2025-11-19T20:39:48.81Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/20/28f669c09a470e7f523b0cc10b94336664d9648594015e3f2a1ec29047b1/ndindex-1.10.1-cp314-cp314t-win_amd64.whl", hash = "sha256:37f87f0e7690ae0324334740e0661d6297f2e62c9bf925127d249fb7eddd0ad8", size = 171077, upload-time = "2025-11-19T20:39:50.108Z" },
+]
+
+[[package]]
 name = "nltk"
 version = "3.9.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2824,6 +3305,97 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "numba"
+version = "0.65.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llvmlite" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/c5/db2ac3685833d626c0dcae6bd2330cd68433e1fd248d15f70998160d3ad7/numba-0.65.1.tar.gz", hash = "sha256:19357146c32fe9ed25059ab915e8465fb13951cf6b0aace3826b76886373ab23", size = 2765600, upload-time = "2026-04-24T02:02:56.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/b3/650500c2eab4534d98e9166f4298e0f3c69c742afdf24e6eabccd1f16ad8/numba-0.65.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:7020d74b19cdb8cff16506542fdd510756e28c5e7f3bd0b7f574f0f42272fcd9", size = 2680563, upload-time = "2026-04-24T02:02:18.414Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0b/0615dbedb98f5b32a35a53290fbdc6e22306968109278d7e58df82d7a9f6/numba-0.65.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f80ed83774b5173abd6581cd8d2165d1d38e13d2e5c8155c0c0b421784745420", size = 3745018, upload-time = "2026-04-24T02:02:20.252Z" },
+    { url = "https://files.pythonhosted.org/packages/49/aa/4361698f35bf63bff67dfe6c90493731177f48ede954f77b0588731537bc/numba-0.65.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7ed425a43b0a5f9772f2f4e2dd0bbd12eabecae1af0b24efcfd4e053f012aac6", size = 3450962, upload-time = "2026-04-24T02:02:22.449Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9a/af61ec03b3116c161fd7a06b9e8a265729a8718458333e8ffbb06d9a3978/numba-0.65.1-cp311-cp311-win_amd64.whl", hash = "sha256:df40a5028a975b9ea66f6a2a3f7abbdbd541a863070e34ed367aff21141248e4", size = 2747417, upload-time = "2026-04-24T02:02:24.43Z" },
+    { url = "https://files.pythonhosted.org/packages/57/bc/76f8f8c5cf9adee47fdb7bbb03be8900f76f902d451d7477cf12b845e1de/numba-0.65.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:ac3f1e77c352dd0ea9712732c2d8f9ca507717435eec5b5013bf138ac33c4a08", size = 2681371, upload-time = "2026-04-24T02:02:26.105Z" },
+    { url = "https://files.pythonhosted.org/packages/69/47/a415af0283e4db0398104c6d1c11c9861a98dc67a7aa442a7769ed5d6196/numba-0.65.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:52bc6f3ceb8fcaff9b2ae26b4c6b1e9fee39db8d355534c0fe4f39a901246b84", size = 3802467, upload-time = "2026-04-24T02:02:27.712Z" },
+    { url = "https://files.pythonhosted.org/packages/46/36/246f73ec99cfeab2f2cb2ce7d4218766cc36a2da418901223f4f4da9c813/numba-0.65.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90ca10b3463bae0bd70589726fe3c77d01d6b5fc86bee54bcdf9fb6b47c28977", size = 3502628, upload-time = "2026-04-24T02:02:29.763Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9e/3c679b2ee078425b9e99a91e44f8d132a6830d8ccce5227bc5e9181aeed8/numba-0.65.1-cp312-cp312-win_amd64.whl", hash = "sha256:5971c632be2a2351500431f46213821dba8d02b18a9f7d02fd36bd2743e41a6a", size = 2750611, upload-time = "2026-04-24T02:02:31.477Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/14a4579049c1eb673afd0de0cb4842982acd55b9ce2643e763db858bcea0/numba-0.65.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:1735c15c1134a5108b4d6a5c77fc0947924ea066a738dc09a52008c13df9cad3", size = 2681344, upload-time = "2026-04-24T02:02:33.65Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/22/b8d873f6466b20aa563fc9b33acd48dec89a07803ddaa2f1c8ca1cd33126/numba-0.65.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c09f49117ef255e1f1c6dad0c7a1ed39868243862a73be5706793241a3755f1b", size = 3810619, upload-time = "2026-04-24T02:02:36.041Z" },
+    { url = "https://files.pythonhosted.org/packages/62/08/e16a8b5d9a018962ebb5c66be662317cde32b9f5dab08441f90bed5522fb/numba-0.65.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:594a8680b3fadac99e97e489b1fd89007177e5336713745c3b769528c635a464", size = 3509783, upload-time = "2026-04-24T02:02:38.245Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a5/03c970d57f4c1741354837353ce39fb5206952ae1dba8922d29c86f64805/numba-0.65.1-cp313-cp313-win_amd64.whl", hash = "sha256:85be74c0d036842699a30058f82fb88fc5ffdc59f7615cab5792ea92914c9b62", size = 2750534, upload-time = "2026-04-24T02:02:39.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/2e/8aed9b726d9ba5f11ad287645fd479e88278db3060a25cb1225d730eb2b7/numba-0.65.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:33f5eb68eb1c843511615d14663ce60258525d6a4c65ab040e2c2b0c4cf17450", size = 2681554, upload-time = "2026-04-24T02:02:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/87/96/f3eb235fafa82a34e2ab5dd7dc9ffff998ebf5f0bbc23fa56a96aeb44da6/numba-0.65.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:71e73029bf53a62cc6afcf96be4bd942290d8b4c55f0a454fb536158115790f7", size = 3779602, upload-time = "2026-04-24T02:02:43.726Z" },
+    { url = "https://files.pythonhosted.org/packages/09/90/b0f09b48752d23640b8284f22aa597737e8adaddc7fbfacc4708b7f73a4c/numba-0.65.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a07635e0be926b9bdbffb09137c230fb13f6ec0e564914ba937cee12ce3eb35", size = 3479532, upload-time = "2026-04-24T02:02:45.427Z" },
+    { url = "https://files.pythonhosted.org/packages/56/46/3f7fc04fb853559e74b210e0b62c19974ec844cefec611f9e535f4da3761/numba-0.65.1-cp314-cp314-win_amd64.whl", hash = "sha256:2a20fcdabdefbdacf88d85caf70c3b18c4bcb7ebb8f82e6a19486383dd26ab63", size = 2752637, upload-time = "2026-04-24T02:02:47.664Z" },
+    { url = "https://files.pythonhosted.org/packages/81/7b/c1a341a9067367778f4152a5f01061cf281fb09582c92c510ec4918cabf6/numba-0.65.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:548dd4b3a4508d5062768d1514b2cd7b015f9a25ec7af651c50dee243965e652", size = 2684600, upload-time = "2026-04-24T02:02:49.653Z" },
+    { url = "https://files.pythonhosted.org/packages/03/36/98ddbcf3e4f04a6dd07e1c67249955920579ba4af6bb6868e3088f4ed282/numba-0.65.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:78abc28feff2c2ff8307fff3975b6438352759c9acb797ecd6b1fb6e7e39e31d", size = 3817198, upload-time = "2026-04-24T02:02:51.266Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/83/0dad21057ece5a835599f5d24099b091703995e23dbbf894f259e91c010b/numba-0.65.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee7676cb389555805f9b9a1840cbcd1ea6c8bd5376ab6918e3a29c5ea1dbda20", size = 3533862, upload-time = "2026-04-24T02:02:52.987Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/8be7118ffd4c8440881046eac3d0982cc5ab42909508cf5d67024d62a2e4/numba-0.65.1-cp314-cp314t-win_amd64.whl", hash = "sha256:20609346e3bd75204950dcbbfe383a8d7dbf4902f442aedbf00f97fef4aa8f38", size = 2758237, upload-time = "2026-04-24T02:02:54.612Z" },
+]
+
+[[package]]
+name = "numexpr"
+version = "2.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/2f/fdba158c9dbe5caca9c3eca3eaffffb251f2fb8674bf8e2d0aed5f38d319/numexpr-2.14.1.tar.gz", hash = "sha256:4be00b1086c7b7a5c32e31558122b7b80243fe098579b170967da83f3152b48b", size = 119400, upload-time = "2025-10-13T16:17:27.351Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/67999bdd1ed1f938d38f3fedd4969632f2f197b090e50505f7cc1fa82510/numexpr-2.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2d03fcb4644a12f70a14d74006f72662824da5b6128bf1bcd10cc3ed80e64c34", size = 163195, upload-time = "2025-10-13T16:16:31.212Z" },
+    { url = "https://files.pythonhosted.org/packages/25/95/d64f680ea1fc56d165457287e0851d6708800f9fcea346fc1b9957942ee6/numexpr-2.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2773ee1133f77009a1fc2f34fe236f3d9823779f5f75450e183137d49f00499f", size = 152088, upload-time = "2025-10-13T16:16:33.186Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/7f/3bae417cb13ae08afd86d08bb0301c32440fe0cae4e6262b530e0819aeda/numexpr-2.14.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ebe4980f9494b9f94d10d2e526edc29e72516698d3bf95670ba79415492212a4", size = 451126, upload-time = "2025-10-13T16:13:22.248Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/1a/edbe839109518364ac0bd9e918cf874c755bb2c128040e920f198c494263/numexpr-2.14.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a381e5e919a745c9503bcefffc1c7f98c972c04ec58fc8e999ed1a929e01ba6", size = 442012, upload-time = "2025-10-13T16:14:51.416Z" },
+    { url = "https://files.pythonhosted.org/packages/66/b1/be4ce99bff769a5003baddac103f34681997b31d4640d5a75c0e8ed59c78/numexpr-2.14.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d08856cfc1b440eb1caaa60515235369654321995dd68eb9377577392020f6cb", size = 1415975, upload-time = "2025-10-13T16:13:26.088Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/33/b33b8fdc032a05d9ebb44a51bfcd4b92c178a2572cd3e6c1b03d8a4b45b2/numexpr-2.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:03130afa04edf83a7b590d207444f05a00363c9b9ea5d81c0f53b1ea13fad55a", size = 1464683, upload-time = "2025-10-13T16:14:58.87Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b2/ddcf0ac6cf0a1d605e5aecd4281507fd79a9628a67896795ab2e975de5df/numexpr-2.14.1-cp311-cp311-win32.whl", hash = "sha256:db78fa0c9fcbaded3ae7453faf060bd7a18b0dc10299d7fcd02d9362be1213ed", size = 166838, upload-time = "2025-10-13T16:17:06.765Z" },
+    { url = "https://files.pythonhosted.org/packages/64/72/4ca9bd97b2eb6dce9f5e70a3b6acec1a93e1fb9b079cb4cba2cdfbbf295d/numexpr-2.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:e9b2f957798c67a2428be96b04bce85439bed05efe78eb78e4c2ca43737578e7", size = 160069, upload-time = "2025-10-13T16:17:08.752Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/c473fc04a371f5e2f8c5749e04505c13e7a8ede27c09e9f099b2ad6f43d6/numexpr-2.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:91ebae0ab18c799b0e6b8c5a8d11e1fa3848eb4011271d99848b297468a39430", size = 162790, upload-time = "2025-10-13T16:16:34.903Z" },
+    { url = "https://files.pythonhosted.org/packages/45/93/b6760dd1904c2a498e5f43d1bb436f59383c3ddea3815f1461dfaa259373/numexpr-2.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:47041f2f7b9e69498fb311af672ba914a60e6e6d804011caacb17d66f639e659", size = 152196, upload-time = "2025-10-13T16:16:36.593Z" },
+    { url = "https://files.pythonhosted.org/packages/72/94/cc921e35593b820521e464cbbeaf8212bbdb07f16dc79fe283168df38195/numexpr-2.14.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d686dfb2c1382d9e6e0ee0b7647f943c1886dba3adbf606c625479f35f1956c1", size = 452468, upload-time = "2025-10-13T16:13:29.531Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/43/560e9ba23c02c904b5934496486d061bcb14cd3ebba2e3cf0e2dccb6c22b/numexpr-2.14.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee6d4fbbbc368e6cdd0772734d6249128d957b3b8ad47a100789009f4de7083", size = 443631, upload-time = "2025-10-13T16:15:02.473Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/6c/78f83b6219f61c2c22d71ab6e6c2d4e5d7381334c6c29b77204e59edb039/numexpr-2.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3a2839efa25f3c8d4133252ea7342d8f81226c7c4dda81f97a57e090b9d87a48", size = 1417670, upload-time = "2025-10-13T16:13:33.464Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/bb/1ccc9dcaf46281568ce769888bf16294c40e98a5158e4b16c241de31d0d3/numexpr-2.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9f9137f1351b310436662b5dc6f4082a245efa8950c3b0d9008028df92fefb9b", size = 1466212, upload-time = "2025-10-13T16:15:12.828Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9f/203d82b9e39dadd91d64bca55b3c8ca432e981b822468dcef41a4418626b/numexpr-2.14.1-cp312-cp312-win32.whl", hash = "sha256:36f8d5c1bd1355df93b43d766790f9046cccfc1e32b7c6163f75bcde682cda07", size = 166996, upload-time = "2025-10-13T16:17:10.369Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/67/ffe750b5452eb66de788c34e7d21ec6d886abb4d7c43ad1dc88ceb3d998f/numexpr-2.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:fdd886f4b7dbaf167633ee396478f0d0aa58ea2f9e7ccc3c6431019623e8d68f", size = 160187, upload-time = "2025-10-13T16:17:11.974Z" },
+    { url = "https://files.pythonhosted.org/packages/73/b4/9f6d637fd79df42be1be29ee7ba1f050fab63b7182cb922a0e08adc12320/numexpr-2.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:09078ba73cffe94745abfbcc2d81ab8b4b4e9d7bfbbde6cac2ee5dbf38eee222", size = 162794, upload-time = "2025-10-13T16:16:38.291Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ae/d58558d8043de0c49f385ea2fa789e3cfe4d436c96be80200c5292f45f15/numexpr-2.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dce0b5a0447baa7b44bc218ec2d7dcd175b8eee6083605293349c0c1d9b82fb6", size = 152203, upload-time = "2025-10-13T16:16:39.907Z" },
+    { url = "https://files.pythonhosted.org/packages/13/65/72b065f9c75baf8f474fd5d2b768350935989d4917db1c6c75b866d4067c/numexpr-2.14.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:06855053de7a3a8425429bd996e8ae3c50b57637ad3e757e0fa0602a7874be30", size = 455860, upload-time = "2025-10-13T16:13:35.811Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/f9/c9457652dfe28e2eb898372da2fe786c6db81af9540c0f853ee04a0699cc/numexpr-2.14.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05f9366d23a2e991fd5a8b5e61a17558f028ba86158a4552f8f239b005cdf83c", size = 446574, upload-time = "2025-10-13T16:15:17.367Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/99/8d3879c4d67d3db5560cf2de65ce1778b80b75f6fa415eb5c3e7bd37ba27/numexpr-2.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c5f1b1605695778896534dfc6e130d54a65cd52be7ed2cd0cfee3981fd676bf5", size = 1417306, upload-time = "2025-10-13T16:13:42.813Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/05/6bddac9f18598ba94281e27a6943093f7d0976544b0cb5d92272c64719bd/numexpr-2.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a4ba71db47ea99c659d88ee6233fa77b6dc83392f1d324e0c90ddf617ae3f421", size = 1466145, upload-time = "2025-10-13T16:15:27.464Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5d/cbeb67aca0c5a76ead13df7e8bd8dd5e0d49145f90da697ba1d9f07005b0/numexpr-2.14.1-cp313-cp313-win32.whl", hash = "sha256:638dce8320f4a1483d5ca4fda69f60a70ed7e66be6e68bc23fb9f1a6b78a9e3b", size = 166996, upload-time = "2025-10-13T16:17:13.803Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/23/9281bceaeb282cead95f0aa5f7f222ffc895670ea689cc1398355f6e3001/numexpr-2.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:9fdcd4735121658a313f878fd31136d1bfc6a5b913219e7274e9fca9f8dac3bb", size = 160189, upload-time = "2025-10-13T16:17:15.417Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/76/7aac965fd93a56803cbe502aee2adcad667253ae34b0badf6c5af7908b6c/numexpr-2.14.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:557887ad7f5d3c2a40fd7310e50597045a68e66b20a77b3f44d7bc7608523b4b", size = 163524, upload-time = "2025-10-13T16:16:42.213Z" },
+    { url = "https://files.pythonhosted.org/packages/58/65/79d592d5e63fbfab3b59a60c386853d9186a44a3fa3c87ba26bdc25b6195/numexpr-2.14.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:af111c8fe6fc55d15e4c7cab11920fc50740d913636d486545b080192cd0ad73", size = 152919, upload-time = "2025-10-13T16:16:44.229Z" },
+    { url = "https://files.pythonhosted.org/packages/84/78/3c8335f713d4aeb99fa758d7c62f0be1482d4947ce5b508e2052bb7aeee9/numexpr-2.14.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:33265294376e7e2ae4d264d75b798a915d2acf37b9dd2b9405e8b04f84d05cfc", size = 465972, upload-time = "2025-10-13T16:13:45.061Z" },
+    { url = "https://files.pythonhosted.org/packages/35/81/9ee5f69b811e8f18746c12d6f71848617684edd3161927f95eee7a305631/numexpr-2.14.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:83647d846d3eeeb9a9255311236135286728b398d0d41d35dedb532dca807fe9", size = 456953, upload-time = "2025-10-13T16:15:31.186Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/39/9b8bc6e294d85cbb54a634e47b833e9f3276a8bdf7ce92aa808718a0212d/numexpr-2.14.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6e575fd3ad41ddf3355d0c7ef6bd0168619dc1779a98fe46693cad5e95d25e6e", size = 1426199, upload-time = "2025-10-13T16:13:48.231Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/ce/0d4fcd31ab49319740d934fba1734d7dad13aa485532ca754e555ca16c8b/numexpr-2.14.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:67ea4771029ce818573b1998f5ca416bd255156feea017841b86176a938f7d19", size = 1474214, upload-time = "2025-10-13T16:15:38.893Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/47/b2a93cbdb3ba4e009728ad1b9ef1550e2655ea2c86958ebaf03b9615f275/numexpr-2.14.1-cp313-cp313t-win32.whl", hash = "sha256:15015d47d3d1487072d58c0e7682ef2eb608321e14099c39d52e2dd689483611", size = 167676, upload-time = "2025-10-13T16:17:17.351Z" },
+    { url = "https://files.pythonhosted.org/packages/86/99/ee3accc589ed032eea68e12172515ed96a5568534c213ad109e1f4411df1/numexpr-2.14.1-cp313-cp313t-win_amd64.whl", hash = "sha256:94c711f6d8f17dfb4606842b403699603aa591ab9f6bf23038b488ea9cfb0f09", size = 161096, upload-time = "2025-10-13T16:17:19.174Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/36/9db78dfbfdfa1f8bf0872993f1a334cdd8fca5a5b6567e47dcb128bcb7c2/numexpr-2.14.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:ede79f7ff06629f599081de644546ce7324f1581c09b0ac174da88a470d39c21", size = 162848, upload-time = "2025-10-13T16:16:46.216Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c1/a5c78ae637402c5550e2e0ba175275d2515d432ec28af0cdc23c9b476e65/numexpr-2.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2eac7a5a2f70b3768c67056445d1ceb4ecd9b853c8eda9563823b551aeaa5082", size = 152270, upload-time = "2025-10-13T16:16:47.92Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/ed/aabd8678077848dd9a751c5558c2057839f5a09e2a176d8dfcd0850ee00e/numexpr-2.14.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5aedf38d4c0c19d3cecfe0334c3f4099fb496f54c146223d30fa930084bc8574", size = 455918, upload-time = "2025-10-13T16:13:50.338Z" },
+    { url = "https://files.pythonhosted.org/packages/88/e1/3db65117f02cdefb0e5e4c440daf1c30beb45051b7f47aded25b7f4f2f34/numexpr-2.14.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:439ec4d57b853792ebe5456e3160312281c3a7071ecac5532ded3278ede614de", size = 446512, upload-time = "2025-10-13T16:15:42.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/fb/7ceb9ee55b5f67e4a3e4d73d5af4c7e37e3c9f37f54bee90361b64b17e3f/numexpr-2.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e23b87f744e04e302d82ac5e2189ae20a533566aec76a46885376e20b0645bf8", size = 1417845, upload-time = "2025-10-13T16:13:53.836Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2d/9b5764d0eafbbb2889288f80de773791358acf6fad1a55767538d8b79599/numexpr-2.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:44f84e0e5af219dbb62a081606156420815890e041b87252fbcea5df55214c4c", size = 1466211, upload-time = "2025-10-13T16:15:48.985Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/21/204db708eccd71aa8bc55bcad55bc0fc6c5a4e01ad78e14ee5714a749386/numexpr-2.14.1-cp314-cp314-win32.whl", hash = "sha256:1f1a5e817c534539351aa75d26088e9e1e0ef1b3a6ab484047618a652ccc4fc3", size = 168835, upload-time = "2025-10-13T16:17:20.82Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/3e/d83e9401a1c3449a124f7d4b3fb44084798e0d30f7c11e60712d9b94cf11/numexpr-2.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:587c41509bc373dfb1fe6086ba55a73147297247bedb6d588cda69169fc412f2", size = 162608, upload-time = "2025-10-13T16:17:22.228Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/d6/ec947806bb57836d6379a8c8a253c2aeaa602b12fef2336bfd2462bb4ed5/numexpr-2.14.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:ec368819502b64f190c3f71be14a304780b5935c42aae5bf22c27cc2cbba70b5", size = 163525, upload-time = "2025-10-13T16:16:50.133Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/77/048f30dcf661a3d52963a88c29b52b6d5ce996d38e9313a56a922451c1e0/numexpr-2.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7e87f6d203ac57239de32261c941e9748f9309cbc0da6295eabd0c438b920d3a", size = 152917, upload-time = "2025-10-13T16:16:52.055Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d3/956a13e628d722d649fbf2fded615134a308c082e122a48bad0e90a99ce9/numexpr-2.14.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd72d8c2a165fe45ea7650b16eb8cc1792a94a722022006bb97c86fe51fd2091", size = 466242, upload-time = "2025-10-13T16:13:55.795Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/dd/abe848678d82486940892f2cacf39e82eec790e8930d4d713d3f9191063b/numexpr-2.14.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70d80fcb418a54ca208e9a38e58ddc425c07f66485176b261d9a67c7f2864f73", size = 457149, upload-time = "2025-10-13T16:15:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/bb/797b583b5fb9da5700a5708ca6eb4f889c94d81abb28de4d642c0f4b3258/numexpr-2.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:edea2f20c2040df8b54ee8ca8ebda63de9545b2112872466118e9df4d0ae99f3", size = 1426493, upload-time = "2025-10-13T16:13:59.244Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c4/0519ab028fdc35e3e7ee700def7f2b4631b175cd9e1202bd7966c1695c33/numexpr-2.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:790447be6879a6c51b9545f79612d24c9ea0a41d537a84e15e6a8ddef0b6268e", size = 1474413, upload-time = "2025-10-13T16:15:59.211Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/4a/33044878c8f4a75213cfe9c11d4c02058bb710a7a063fe14f362e8de1077/numexpr-2.14.1-cp314-cp314t-win32.whl", hash = "sha256:538961096c2300ea44240209181e31fae82759d26b51713b589332b9f2a4117e", size = 169502, upload-time = "2025-10-13T16:17:23.829Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a2/5a1a2c72528b429337f49911b18c302ecd36eeab00f409147e1aa4ae4519/numexpr-2.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:a40b350cd45b4446076fa11843fa32bbe07024747aeddf6d467290bf9011b392", size = 163589, upload-time = "2025-10-13T16:17:25.696Z" },
 ]
 
 [[package]]
@@ -2972,6 +3544,95 @@ wheels = [
 ]
 
 [[package]]
+name = "ophyd-async"
+version = "0.19.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bluesky" },
+    { name = "colorlog" },
+    { name = "event-model" },
+    { name = "numpy" },
+    { name = "pydantic" },
+    { name = "pydantic-numpy" },
+    { name = "pyyaml" },
+    { name = "scanspec" },
+    { name = "stamina" },
+    { name = "velocity-profile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/20/1241051befc05c21c958206611f9ed058d81b8e8f92e3acf9f9d6936f2fc/ophyd_async-0.19.3.tar.gz", hash = "sha256:9cb76a8a08794a26c619a0420012e7248542501d036f16f3314221869e989984", size = 595679, upload-time = "2026-06-29T15:21:37.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/2c/76ac5e485f6405fc0f1dbbd1c98b7c1137d4aa5c1e49ea9e69bbd8d22ae1/ophyd_async-0.19.3-py3-none-any.whl", hash = "sha256:ef6201edb52e5a54008d57cad1808626aa6493ba4a8fd015e08d14bcffbb697a", size = 232796, upload-time = "2026-06-29T15:21:36.46Z" },
+]
+
+[[package]]
+name = "orjson"
+version = "3.11.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/0c/964746fcafbd16f8ff53219ad9f6b412b34f345c75f384ad434ceaadb538/orjson-3.11.9.tar.gz", hash = "sha256:4fef17e1f8722c11587a6ef18e35902450221da0028e65dbaaa543619e68e48f", size = 5599163, upload-time = "2026-05-06T15:11:08.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/51/3fb9e65ae76ee97bd611869a503fa3fc0a6e81dd8b737cf3003f682df7ff/orjson-3.11.9-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:f01c4818b3fc9b0da8e096722a84318071eaa118df35f6ed2344da0e73a5444f", size = 228522, upload-time = "2026-05-06T15:09:35.362Z" },
+    { url = "https://files.pythonhosted.org/packages/16/fa/9d54b07cb3f3b0bfd57841478e42d7a0ece4a9f49f9907eecf5a45461687/orjson-3.11.9-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:3ebca4179031ee716ed076ffadc29428e900512f6fccee8614c9983157fcf19c", size = 128463, upload-time = "2026-05-06T15:09:37.063Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b1/6ceafc2eefd0a553e3be77ce6c49d107e772485d9568629376171c50e634/orjson-3.11.9-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48ee05097750de0ff69ed5b7bbcf0732182fd57a24043dcc2a1da780a5ead3a5", size = 132306, upload-time = "2026-05-06T15:09:38.299Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/76/f11311285324a40aab1e3031385c50b635a7cd0734fdaf60c7e89a696f60/orjson-3.11.9-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6082706765a95a6680d812e1daf1c0cfe8adec7831b3ff3b625693f3b461b1c", size = 127988, upload-time = "2026-05-06T15:09:39.597Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/85/0ef63bcf1337f44031ce9b91b1919563f62a37527b3ea4368bb15a22e5d7/orjson-3.11.9-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:277fefe9d76ee17eb14debf399e3533d4d63b5f677a4d3719eb763536af1f4bd", size = 135188, upload-time = "2026-05-06T15:09:40.957Z" },
+    { url = "https://files.pythonhosted.org/packages/05/94/b0d27090ea8a2095db3c2bd1b1c96f96f19bbb494d7fef33130e846e613d/orjson-3.11.9-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:03db380e3780fa0015ed776a90f20e8e20bb11dde13b216ce19e5718e3dfba62", size = 145937, upload-time = "2026-05-06T15:09:42.249Z" },
+    { url = "https://files.pythonhosted.org/packages/09/eb/75d50c29c05b8054013e221e598820a365c8e64065312e75e202ed880709/orjson-3.11.9-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33d7d766701847dc6729846362dc27895d2f2d2251264f9d10e7cb9878194877", size = 132758, upload-time = "2026-05-06T15:09:43.945Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bd/360686f39348aa88827cb6fbf7dc606fd41c831a35235e1abf1db8e3a9e6/orjson-3.11.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:147302878da387104b66bb4a8b0227d1d487e976ce41a8501916161072ed87b1", size = 133971, upload-time = "2026-05-06T15:09:45.239Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/30/3178eb16f3221aeef068b6f1f1ebe05f656ea5c6dffe9f6c917329fe17a3/orjson-3.11.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3513550321f8c8c811a7c3297b8a630e82dc08e4c10216d07703c997776236cd", size = 141685, upload-time = "2026-05-06T15:09:46.858Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f1/ff2f19ed0225f9680fafa42febca3570dd59444ebf190980738d376214c2/orjson-3.11.9-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:c5d001196b89fa9cf0a4ab79766cd835b991a166e4b621ba95089edc50c429ff", size = 415167, upload-time = "2026-05-06T15:09:48.312Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/61/863bddf0da6e9e586765414debd54b4e58db05f560902b6d00658cb88636/orjson-3.11.9-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:16969c9d369c98eb084889c6e4d2d39b77c7eb38ceccf8da2a9fff62ae908980", size = 147913, upload-time = "2026-05-06T15:09:49.733Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8a/4081492586d75b073d60c5271a8d0f05a0955cabf1e34c8473f6fcd84235/orjson-3.11.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:63e0efbc991250c0b3143488fa57d95affcabbfc63c99c48d625dd37779aafe2", size = 136959, upload-time = "2026-05-06T15:09:51.311Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bd/70b6ab193594d7abb875320c0a7c8335e846f28968c432c31042409c3c8d/orjson-3.11.9-cp311-cp311-win32.whl", hash = "sha256:14ed654580c1ed2bc217352ec82f91b047aef82951aa71c7f64e0dcb03c0e180", size = 131533, upload-time = "2026-05-06T15:09:52.637Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/17/1a1a228183d62d1b77e2c30d210f47dd4768b310ebe1607c63e3c0e3a71e/orjson-3.11.9-cp311-cp311-win_amd64.whl", hash = "sha256:57ea77fb70a448ce87d18fca050193202a3da5e54598f6501ca5476fb66cfe02", size = 127106, upload-time = "2026-05-06T15:09:54.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/95/285de5fa296d09681ee9c546cd4a8aeb773b701cf343dc125994f4d52953/orjson-3.11.9-cp311-cp311-win_arm64.whl", hash = "sha256:19b72ed11572a2ee51a67a903afbe5af504f84ed6f529c0fe44b0ab3fb5cc697", size = 126848, upload-time = "2026-05-06T15:09:55.551Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6d/11867a3ffa3a3608d84a4de51ef4dd0896d6b5cc9132fbe1daf593e677bc/orjson-3.11.9-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9ef6fe90aadef185c7b128859f40beb24720b4ecea95379fc9000931179c3a49", size = 228515, upload-time = "2026-05-06T15:09:57.265Z" },
+    { url = "https://files.pythonhosted.org/packages/24/75/05912954c8b288f34fcf5cd4b9b071cb4f6e77b9961e175e56ebb258089f/orjson-3.11.9-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:e5c9b8f28e726e97d97696c826bc7bea5d71cecd63576dba92924a32c1961291", size = 128409, upload-time = "2026-05-06T15:09:59.063Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/86/1c3a47df3bc8191ea9ac51603bbb872a95167a364320c269f2557911f406/orjson-3.11.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26a473dbb4162108b27901492546f83c76fdcea3d0eadff00ae7a07e18dcce09", size = 132106, upload-time = "2026-05-06T15:10:00.798Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/cf/b33b5f3e695ae7d63feef9d915c37cc3b8f465493dcd4f8e0b4c697a2366/orjson-3.11.9-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:011382e2a60fda9d46f1cdee31068cfc52ffe952b587d683ec0463002802a0f4", size = 127864, upload-time = "2026-05-06T15:10:02.15Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6a/6cf69385a58208024fcb8c014e2141b8ce838aba6492b589f8acfff97fab/orjson-3.11.9-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c2d3dc759490128c5c1711a53eeaa8ee1d437fd0038ffd2b6008abf46db3f882", size = 135213, upload-time = "2026-05-06T15:10:03.515Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f8/0b1bd3e8f2efcdd376af5c8cfd79eaf13f018080c0089c80ebd724e3c7fb/orjson-3.11.9-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d8ea516b3726d190e1b4297e6f4e7a8650347ae053868a18163b4dd3641d1fff", size = 145994, upload-time = "2026-05-06T15:10:05.083Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/59/dab79f61044c529d2c81aecdc589b1f833a1c8dec11ba3b1c2498a02ca7e/orjson-3.11.9-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:380cdce7ba24989af81d0a7013d0aaec5d0e2a21734c0e2681b1bc4f141957fe", size = 132744, upload-time = "2026-05-06T15:10:06.853Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/82b7a2fe5d8a67a59ed831b24d59a3d46ea7d207b66e1602d376541d94a6/orjson-3.11.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be4fa4f0af7fa18951f7ab3fc2148e223af211bf03f59e1c6034ec3f97f21d61", size = 134014, upload-time = "2026-05-06T15:10:08.213Z" },
+    { url = "https://files.pythonhosted.org/packages/50/c7/375e83a76851b73b2e39f3bcf0e5a19e2b89bad13e5bca97d0b293d27f24/orjson-3.11.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a8f5f8bc7ce7d59f08d9f99fa510c06496164a24cb5f3d34537dbd9ca30132e2", size = 141509, upload-time = "2026-05-06T15:10:09.595Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/7c/49d5d82a3d3097f641f094f552131f1e2723b0b8cb0fa2874ab65ecfffa6/orjson-3.11.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:4d7fde5501b944f83b3e665e1b31343ff6e154b15560a16b7130ea1e594a4206", size = 415127, upload-time = "2026-05-06T15:10:11.049Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/dc/7446c538590d55f455647e5f3c61fc33f7108714e7afcffa6a2a033f8350/orjson-3.11.9-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cde1a448023ba7d5bb4c01c5afb48894380b5e4956e0627266526587ef4e535f", size = 148025, upload-time = "2026-05-06T15:10:12.842Z" },
+    { url = "https://files.pythonhosted.org/packages/df/e5/4d2d8af06f788329b4f78f8cc3679bb395392fcaa1e4d8d3c33e85308fa4/orjson-3.11.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e63adb0e1f1ed5d9e168f50a91ceb93ae6420731d222dc7da5c69409aa47aa", size = 136943, upload-time = "2026-05-06T15:10:14.405Z" },
+    { url = "https://files.pythonhosted.org/packages/06/69/850264ccf6d80f6b174620d30a87f65c9b1490aba33fe6b62798e618cad3/orjson-3.11.9-cp312-cp312-win32.whl", hash = "sha256:2d057a602cdd19a0ad680417527c45b6961a095081c0f46fe0e03e304aac6470", size = 131606, upload-time = "2026-05-06T15:10:15.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d5/973a43fc9c55e20f2051e9830997649f669be0cb3ca52192087c0143f118/orjson-3.11.9-cp312-cp312-win_amd64.whl", hash = "sha256:59e403b1cc5a676da8eaf31f6254801b7341b3e29efa85f92b48d272637e77be", size = 127101, upload-time = "2026-05-06T15:10:17.129Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ae/495470f0e4a18f73fa10b7f6b84b464ec4cc5291c4e0c7c2a6c400bef006/orjson-3.11.9-cp312-cp312-win_arm64.whl", hash = "sha256:9af678d6488357948f1f84c6cd1c1d397c014e1ae2f98ae082a44eb48f602624", size = 126736, upload-time = "2026-05-06T15:10:18.645Z" },
+    { url = "https://files.pythonhosted.org/packages/32/33/93fcc25907235c344ae73122f8a4e01d2d393ef062b4af7d2e2487a32c37/orjson-3.11.9-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:4bab1b2d6141fe7b32ae71dac905666ece4f94936efbfb13d55bb7739a3a6021", size = 228458, upload-time = "2026-05-06T15:10:20.079Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/27/b1e6dadb3c080313c03fdd8067b85e6a0460c7d8d6a1c3984ef77b904e4d/orjson-3.11.9-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:844417969855fc7a41be124aafe83dc424592a7f77cd4501900c67307122b92c", size = 128368, upload-time = "2026-05-06T15:10:21.549Z" },
+    { url = "https://files.pythonhosted.org/packages/21/0f/c9ede0bf052f6b4051e64a7d4fa91b725cccf8321a6a786e86eb03519f00/orjson-3.11.9-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffe02797b5e9f3a9d8292ddcd289b474ad13e81ad83cd1891a240811f1d2cb81", size = 132070, upload-time = "2026-05-06T15:10:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/26/d398e28048dc18205bbe812f2c88cb9b40313db2470778e25964796458fe/orjson-3.11.9-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e4eed3b200023042814d2fc8a5d2e880f13b52e1ed2485e83da4f3962f7dc1a", size = 127892, upload-time = "2026-05-06T15:10:24.714Z" },
+    { url = "https://files.pythonhosted.org/packages/66/60/52b0054c4c700d5aa7fc5b7ca96917400d8f061307778578e67a10e25852/orjson-3.11.9-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8aff7da9952a5ad1cef8e68017724d96c7b9a66e99e91d6252e1b133d67a7b10", size = 135217, upload-time = "2026-05-06T15:10:26.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/97/1e3dc2b2a28b7b2528f403d2fc1d79ec5f39af3bc143ab65d3ec26426385/orjson-3.11.9-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4d4e98d6f3b8afed8bc8cd9718ec0cdf46661826beefb53fe8eafb37f2bf0362", size = 145980, upload-time = "2026-05-06T15:10:28.062Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/39/31fbfe7850f2de32dee7e7e5c09f26d403ab01e440ac96001c6b01ad3c99/orjson-3.11.9-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a81d52442a7c99b3662333235b3adf96a1715864658b35bb797212be7bddb97", size = 132738, upload-time = "2026-05-06T15:10:29.727Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/08/dca0082dd2a194acb93e5457e73455388e2e2ca464a2672449a9ddbb679d/orjson-3.11.9-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e39364e726a8fff737309aff059ff67d8a8c8d5b677be7bb49a8b3e84b7e218", size = 134033, upload-time = "2026-05-06T15:10:31.152Z" },
+    { url = "https://files.pythonhosted.org/packages/11/d4/5bdb0626801230139987385554c5d4c42255218ac906525bf4347f22cd95/orjson-3.11.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4fd66214623f1b17501df9f0543bef0b833979ab5b6ded1e1d123222866aa8c9", size = 141492, upload-time = "2026-05-06T15:10:32.641Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/88/a21fb53b3ede6703aede6dce4710ed4111e5b201cfa6bbff5e544f9d47d7/orjson-3.11.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:8ecc30f10465fa1e0ce13fd01d9e22c316e5053a719a8d915d4545a09a5ff677", size = 415087, upload-time = "2026-05-06T15:10:34.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/57/1b30daf70f0d8180e9a73cefbfbdd99e4bf19eb020466502b01fba7e0e50/orjson-3.11.9-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:97db4c94a7db398a5bd636273324f0b3fd58b350bbbac8bb380ceb825a9b40f4", size = 148031, upload-time = "2026-05-06T15:10:36.358Z" },
+    { url = "https://files.pythonhosted.org/packages/04/83/45fbb6d962e260807f99441db9613cee868ceda4baceda59b3720a563f97/orjson-3.11.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9f78cf8fec5bd627f4082b8dfeac7871b43d7f3274904492a43dab39f18a19a0", size = 136915, upload-time = "2026-05-06T15:10:38.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/cc/2d10025f9056d376e4127ec05a5808b218d46f035fdc08178a5411b34250/orjson-3.11.9-cp313-cp313-win32.whl", hash = "sha256:d4087e5c0209a0a8efe4de3303c234b9c44d1174161dcd851e8eea07c7560b32", size = 131613, upload-time = "2026-05-06T15:10:39.569Z" },
+    { url = "https://files.pythonhosted.org/packages/67/bd/2775ff28bfe883b9aa1ff348300542eb2ef1ee18d8ae0e3a49846817a865/orjson-3.11.9-cp313-cp313-win_amd64.whl", hash = "sha256:051b102c93b4f634e89f3866b07b9a9a98915ada541f4ec30f177067b2694979", size = 127086, upload-time = "2026-05-06T15:10:41.262Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2b/d26799e580939e32a7da9a39531bc9e58e15ca32ffaa6a8cb3e9bb0d22cd/orjson-3.11.9-cp313-cp313-win_arm64.whl", hash = "sha256:cce9127885941bd28f080cecf1f1d288336b7e0d812c345b08be88b572796254", size = 126696, upload-time = "2026-05-06T15:10:42.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/eb/5da01e356015aee6ecfa1187ced87aef51364e306f5e695dd52719bf0e78/orjson-3.11.9-cp314-cp314-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:b6ef1979adc4bc243523f1a2ba91418030a8e29b0a99cbe7e0e2d6807d4dce6e", size = 228465, upload-time = "2026-05-06T15:10:44.097Z" },
+    { url = "https://files.pythonhosted.org/packages/64/62/3e0e0c14c957133bcd855395c62b55ed4e3b0af23ffea11b032cb1dcbdb1/orjson-3.11.9-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:f36b7f32c7c0db4a719f1fc5824db4a9c6f8bd1a354debb91faf26ebf3a4c71e", size = 128364, upload-time = "2026-05-06T15:10:45.839Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5a/07d8aa117211a8ed7630bda80c8c0b14d04e0f8dcf99bcf49656e4a710eb/orjson-3.11.9-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08f4d8ebb44925c794e535b2bebc507cebf32209df81de22ae285fb0d8d66de0", size = 132063, upload-time = "2026-05-06T15:10:47.267Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ec/4acaf21483e18aa945be74a474c74b434f284b549f275a0a39b9f98956e9/orjson-3.11.9-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6cc7923789694fd58f001cbcac7e47abc13af4d560ebbfcf3b41a8b1a0748124", size = 122356, upload-time = "2026-05-06T15:10:48.765Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d8/5f0555e7638801323b7a75850f92e7dfa891bc84fe27a1ba4449170d1200/orjson-3.11.9-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ea5c46eb2d3af39e806b986f4b09d5c2706a1f5afde3cbf7544ce6616127173c", size = 129592, upload-time = "2026-05-06T15:10:50.13Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/30/ed9860412a3603ceb3c5955bfd72d28b9d0e7ba6ed81add14f83d7114236/orjson-3.11.9-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f5d89a2ed90731df3be64bab0aa44f78bff39fdc9d71c291f4a8023aa46425b7", size = 140491, upload-time = "2026-05-06T15:10:51.582Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/17/adc514dea7ac7c505527febf884934b815d34f0c7b8693c1a8b39c5c4a57/orjson-3.11.9-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:25e4aed0312d292c09f61af25bba34e0b2c88546041472b09088c39a4d828af1", size = 127309, upload-time = "2026-05-06T15:10:53.329Z" },
+    { url = "https://files.pythonhosted.org/packages/76/3e/c0b690253f0b82d86e99949af13533363acfb5432ecb5d53dd5b3bce9c34/orjson-3.11.9-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aaea64f3f467d22e70eeed68bdccb3bc4f83f650446c4a03c59f2cba28a108db", size = 134030, upload-time = "2026-05-06T15:10:54.988Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/7a/bc82a0bb25e9faaf92dc4d9ef002732efc09737706af83e346788641d4a7/orjson-3.11.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a028425d1b440c5d92a6be1e1a020739dfe67ea87d96c6dbe828c1b30041728b", size = 141482, upload-time = "2026-05-06T15:10:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/01/55/e69188b939f77d5d32a9833745ace31ea5ccae3ab613a1ec185d3cd2c4fb/orjson-3.11.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5b192c6cf397e4455b11523c5cf2b18ed084c1bbd61b6c0926344d2129481972", size = 415178, upload-time = "2026-05-06T15:10:58.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/b8a5a7ac527e80b9cb11d51e3f6689b709279183264b9ec5c7bc680bb8b5/orjson-3.11.9-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea407d4ccf5891d667d045fecae97a7a1e5e87b3b97f97ae1803c2e741130be0", size = 148089, upload-time = "2026-05-06T15:11:00.441Z" },
+    { url = "https://files.pythonhosted.org/packages/97/4e/00503f64204bf859b37213a63927028f30fb6268cd8677fb0a5ad48155e1/orjson-3.11.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f63aaf97afd9f6dec5b1a68e1b8da12bfccb4cb9a9a65c3e0b6c847849e7586", size = 136921, upload-time = "2026-05-06T15:11:02.176Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ba/a23b82a0a8d0ed7bed4e5f5035aae751cad4ff6a1e8d2ecd14d8860f5929/orjson-3.11.9-cp314-cp314-win32.whl", hash = "sha256:e30ab17845bb9fa54ccf67fa4f9f5282652d54faa6d17452f47d0f369d038673", size = 131638, upload-time = "2026-05-06T15:11:03.696Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/0c6798456bade745c75c452342dabacce5798196483e77e643be1f53877d/orjson-3.11.9-cp314-cp314-win_amd64.whl", hash = "sha256:32ef5f4283a3be81913947d19608eacb7c6608026851123790cd9cc8982af34b", size = 127078, upload-time = "2026-05-06T15:11:05.123Z" },
+    { url = "https://files.pythonhosted.org/packages/16/21/5a3f1e8913103b703a436a5664238e5b965ec392b555fe68943ea3691e6b/orjson-3.11.9-cp314-cp314-win_arm64.whl", hash = "sha256:eebdbdeef0094e4f5aefa20dcd4eb2368ab5e7a3b4edea27f1e7b2892e009cf9", size = 126687, upload-time = "2026-05-06T15:11:06.602Z" },
+]
+
+[[package]]
 name = "osprey-framework"
 source = { editable = "." }
 dependencies = [
@@ -3071,6 +3732,11 @@ ariel = [
 ariel-proxy = [
     { name = "aiohttp-socks" },
 ]
+bluesky-bridge = [
+    { name = "bluesky" },
+    { name = "ophyd-async" },
+    { name = "tiled", extra = ["client"] },
+]
 dev = [
     { name = "build" },
     { name = "docker" },
@@ -3119,6 +3785,7 @@ requires-dist = [
     { name = "aiohttp-socks", specifier = ">=0.8.0" },
     { name = "aiohttp-socks", marker = "extra == 'ariel-proxy'", specifier = ">=0.8.0" },
     { name = "anthropic" },
+    { name = "bluesky", marker = "extra == 'bluesky-bridge'", specifier = ">=1.12" },
     { name = "bokeh", specifier = ">=3.0" },
     { name = "build", marker = "extra == 'all'" },
     { name = "build", marker = "extra == 'dev'" },
@@ -3157,6 +3824,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "ollama", specifier = ">=0.5.1" },
     { name = "openai", specifier = ">=2" },
+    { name = "ophyd-async", marker = "extra == 'bluesky-bridge'", specifier = ">=0.16,<1.0" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "pillow", marker = "extra == 'all'", specifier = ">=10.0.0" },
     { name = "pillow", marker = "extra == 'dev'", specifier = ">=10.0.0" },
@@ -3222,6 +3890,7 @@ requires-dist = [
     { name = "testcontainers", extras = ["mongodb"], marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "testcontainers", extras = ["postgres"], marker = "extra == 'all'", specifier = ">=4.0.0" },
     { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "tiled", extras = ["client"], marker = "extra == 'bluesky-bridge'", specifier = ">=0.1" },
     { name = "typing-extensions", specifier = ">=4.12.0" },
     { name = "unique-namer", specifier = ">=0.1.0" },
     { name = "urllib3", specifier = ">=2.4.0" },
@@ -3229,7 +3898,7 @@ requires-dist = [
     { name = "watchdog", specifier = ">=3.0.0" },
     { name = "websocket-client", specifier = ">=1.7.0" },
 ]
-provides-extras = ["all", "archiver-mongodb", "ariel", "ariel-proxy", "dev", "docs", "knowledge", "screen-capture-linux", "sheets"]
+provides-extras = ["all", "archiver-mongodb", "ariel", "ariel-proxy", "bluesky-bridge", "dev", "docs", "knowledge", "screen-capture-linux", "sheets"]
 
 [[package]]
 name = "packaging"
@@ -3316,6 +3985,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/76/a1e769043c0c0c9fe391b702539d594731a4362334cdf4dc25d0c09761e7/parso-0.8.6.tar.gz", hash = "sha256:2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd", size = 401621, upload-time = "2026-02-09T15:45:24.425Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl", hash = "sha256:2c549f800b70a5c4952197248825584cb00f033b29c692671d3bf08bf380baff", size = 106894, upload-time = "2026-02-09T15:45:21.391Z" },
+]
+
+[[package]]
+name = "partd"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "locket" },
+    { name = "toolz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/3a/3f06f34820a31257ddcabdfafc2672c5816be79c7e353b02c1f318daa7d4/partd-1.4.2.tar.gz", hash = "sha256:d022c33afbdc8405c226621b015e8067888173d85f7f5ecebb3cafed9a20f02c", size = 21029, upload-time = "2024-05-06T19:51:41.945Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl", hash = "sha256:978e4ac767ec4ba5b86c6eaa52e5a2a3bc748a2ca839e8cc798f1cc6ce6efb0f", size = 18905, upload-time = "2024-05-06T19:51:39.271Z" },
 ]
 
 [[package]]
@@ -3766,6 +4448,56 @@ memory = [
 ]
 
 [[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/c9/a47ab7ece0d86cbe6678418a0fbd1ac4bb493b9184a3891dfa0e7f287ae0/pyarrow-24.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:b0e131f880cda8d04e076cee175a46fc0e8bc8b65c99c6c09dff6669335fde74", size = 35068898, upload-time = "2026-04-21T10:46:36.599Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/bc/8db86617a9a58008acf8913d6fed68ea2a46acb6de928db28d724c891a68/pyarrow-24.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:1b2fe7f9a5566401a0ef2571f197eb92358925c1f0c8dba305d6e43ea0871bb3", size = 36679915, upload-time = "2026-04-21T10:46:42.602Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8e/fb178720400ef69db251eb4a9c3ccf4af269bc1feb5055529b8fc87170d1/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0b3537c00fb8d384f15ac1e79b6eb6db04a16514c8c1d22e59a9b95c8ba42868", size = 45697931, upload-time = "2026-04-21T10:46:48.403Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/27/99c42abe8e21b44f4917f62631f3aa31404882a2c41d8a4cd5c110e13d52/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:14e31a3c9e35f1ab6356c6378f6f72830e6d2d5f1791df3774a7b097d18a6a1e", size = 48837449, upload-time = "2026-04-21T10:46:55.329Z" },
+    { url = "https://files.pythonhosted.org/packages/36/b6/333749e2666e9032891125bf9c691146e92901bece62030ac1430e2e7c88/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b7d9a514e73bc42711e6a35aaccf3587c520024fe0a25d830a1a8a27c15f4f57", size = 49395949, upload-time = "2026-04-21T10:47:01.869Z" },
+    { url = "https://files.pythonhosted.org/packages/17/25/c5201706a2dd374e8ba6ee3fd7a8c89fb7ffc16eed5217a91fd2bd7f7626/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b196eb3f931862af3fa84c2a253514d859c08e0d8fe020e07be12e75a5a9780c", size = 51912986, upload-time = "2026-04-21T10:47:09.872Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d2/4d1bbba65320b21a49678d6fbdc6ff7c649251359fdcfc03568c4136231d/pyarrow-24.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:35405aecb474e683fb36af650618fd5340ee5471fc65a21b36076a18bbc6c981", size = 27255371, upload-time = "2026-04-21T10:47:15.943Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559, upload-time = "2026-04-21T10:47:22.17Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b6/0ddf0e9b6ead3474ab087ae598c76b031fc45532bf6a63f3a553440fb258/pyarrow-24.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a", size = 36663654, upload-time = "2026-04-21T10:47:28.315Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394, upload-time = "2026-04-21T10:47:34.821Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122, upload-time = "2026-04-21T10:47:42.056Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032, upload-time = "2026-04-21T10:47:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490, upload-time = "2026-04-21T10:47:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1c/e3e72c8014ad2743ca64a701652c733cc5cbcee15c0463a32a8c55518d9e/pyarrow-24.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:295f0a7f2e242dabd513737cf076007dc5b2d59237e3eca37b05c0c6446f3826", size = 27355660, upload-time = "2026-04-21T10:48:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759, upload-time = "2026-04-21T10:48:07.258Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471, upload-time = "2026-04-21T10:48:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981, upload-time = "2026-04-21T10:48:20.201Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172, upload-time = "2026-04-21T10:48:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733, upload-time = "2026-04-21T10:48:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335, upload-time = "2026-04-21T10:48:42.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748, upload-time = "2026-04-21T10:49:42.532Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554, upload-time = "2026-04-21T10:48:48.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301, upload-time = "2026-04-21T10:48:55.181Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929, upload-time = "2026-04-21T10:49:03.676Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365, upload-time = "2026-04-21T10:49:11.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819, upload-time = "2026-04-21T10:49:21.474Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252, upload-time = "2026-04-21T10:49:31.164Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127, upload-time = "2026-04-21T10:49:37.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997, upload-time = "2026-04-21T10:49:48.796Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720, upload-time = "2026-04-21T10:49:55.858Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852, upload-time = "2026-04-21T10:50:04.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852, upload-time = "2026-04-21T10:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207, upload-time = "2026-04-21T10:50:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117, upload-time = "2026-04-21T10:50:29.14Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155, upload-time = "2026-04-21T10:51:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387, upload-time = "2026-04-21T10:50:35.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102, upload-time = "2026-04-21T10:50:42.417Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118, upload-time = "2026-04-21T10:50:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765, upload-time = "2026-04-21T10:50:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
+    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3913,17 +4645,33 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-numpy"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "compress-pickle", extra = ["lz4"] },
+    { name = "numpy" },
+    { name = "pydantic" },
+    { name = "ruamel-yaml" },
+    { name = "semver" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/b8/8d03bc7bb02a6b2ed2f9da4868cd44261bc0656f9fa797140b0e4f354738/pydantic_numpy-8.0.1.tar.gz", hash = "sha256:85ae382ff4ebd23902791f6710d26f039a6215670d8c128ac30d5b79171fde13", size = 14983, upload-time = "2025-02-22T17:18:19.029Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/cb/c13d8a74419dde9590ed6fab293b516f68316ac87d06569b79b5f446d519/pydantic_numpy-8.0.1-py3-none-any.whl", hash = "sha256:bf4cd84f4f864074197e9cfeafddca76bfbd1c2ef48f88be7322cc75838de4ae", size = 20224, upload-time = "2025-02-22T17:18:17.206Z" },
+]
+
+[[package]]
 name = "pydantic-settings"
-version = "2.12.0"
+version = "2.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/c5/dbbc27b814c71676593d1c3f718e6cd7d4f00652cefa24b75f7aa3efb25e/pydantic_settings-2.11.0.tar.gz", hash = "sha256:d0e87a1c7d33593beb7194adb8470fc426e95ba02af83a0f23474a04c9a08180", size = 188394, upload-time = "2025-09-24T14:19:11.764Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d6/887a1ff844e64aa823fb4905978d882a633cfe295c32eacad582b78a7d8b/pydantic_settings-2.11.0-py3-none-any.whl", hash = "sha256:fe2cea3413b9530d10f3a5875adffb17ada5c1e1bab0b2885546d7310415207c", size = 48608, upload-time = "2025-09-24T14:19:10.015Z" },
 ]
 
 [[package]]
@@ -4366,6 +5114,19 @@ wheels = [
 ]
 
 [[package]]
+name = "ragged"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "awkward" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/87/dedd347e3546a7ea20d79c0b83589b429f96a04667642331681fa68eba2c/ragged-0.3.0.tar.gz", hash = "sha256:73876f9048c1cabf7d58f4fbc09df6d2cfc7fda672fe5670ff9557a814753073", size = 104279, upload-time = "2026-06-03T06:31:25.45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/eb/e7d23686c85d8cf6f9158f36b3a30bd717448b11ccbca75a5955a06e4459/ragged-0.3.0-py3-none-any.whl", hash = "sha256:55c42eaff6665e18558436cf25c991fe67247dcbe402269594868503a0f6f817", size = 65114, upload-time = "2026-06-03T06:31:24.125Z" },
+]
+
+[[package]]
 name = "rdflib"
 version = "7.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4680,11 +5441,62 @@ wheels = [
 
 [[package]]
 name = "ruamel-yaml"
-version = "0.19.1"
+version = "0.18.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+dependencies = [
+    { name = "ruamel-yaml-clib", marker = "python_full_version < '3.15' and platform_python_implementation == 'CPython'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/2b/7a1f1ebcd6b3f14febdc003e658778d81e76b40df2267904ee6b13f0c5c6/ruamel_yaml-0.18.17.tar.gz", hash = "sha256:9091cd6e2d93a3a4b157ddb8fabf348c3de7f1fb1381346d985b6b247dcd8d3c", size = 149602, upload-time = "2025-12-17T20:02:55.757Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
+    { url = "https://files.pythonhosted.org/packages/af/fe/b6045c782f1fd1ae317d2a6ca1884857ce5c20f59befe6ab25a8603c43a7/ruamel_yaml-0.18.17-py3-none-any.whl", hash = "sha256:9c8ba9eb3e793efdf924b60d521820869d5bf0cb9c6f1b82d82de8295e290b9d", size = 121594, upload-time = "2025-12-17T20:02:07.657Z" },
+]
+
+[[package]]
+name = "ruamel-yaml-clib"
+version = "0.2.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/97/60fda20e2fb54b83a61ae14648b0817c8f5d84a3821e40bfbdae1437026a/ruamel_yaml_clib-0.2.15.tar.gz", hash = "sha256:46e4cc8c43ef6a94885f72512094e482114a8a706d3c555a34ed4b0d20200600", size = 225794, upload-time = "2025-11-16T16:12:59.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/80/8ce7b9af532aa94dd83360f01ce4716264db73de6bc8efd22c32341f6658/ruamel_yaml_clib-0.2.15-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c583229f336682b7212a43d2fa32c30e643d3076178fb9f7a6a14dde85a2d8bd", size = 147998, upload-time = "2025-11-16T16:13:13.241Z" },
+    { url = "https://files.pythonhosted.org/packages/53/09/de9d3f6b6701ced5f276d082ad0f980edf08ca67114523d1b9264cd5e2e0/ruamel_yaml_clib-0.2.15-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:56ea19c157ed8c74b6be51b5fa1c3aff6e289a041575f0556f66e5fb848bb137", size = 132743, upload-time = "2025-11-16T16:13:14.265Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/f7/73a9b517571e214fe5c246698ff3ed232f1ef863c8ae1667486625ec688a/ruamel_yaml_clib-0.2.15-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5fea0932358e18293407feb921d4f4457db837b67ec1837f87074667449f9401", size = 731459, upload-time = "2025-11-16T20:22:44.338Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/a2/0dc0013169800f1c331a6f55b1282c1f4492a6d32660a0cf7b89e6684919/ruamel_yaml_clib-0.2.15-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef71831bd61fbdb7aa0399d5c4da06bea37107ab5c79ff884cc07f2450910262", size = 749289, upload-time = "2025-11-16T16:13:15.633Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ed/3fb20a1a96b8dc645d88c4072df481fe06e0289e4d528ebbdcc044ebc8b3/ruamel_yaml_clib-0.2.15-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:617d35dc765715fa86f8c3ccdae1e4229055832c452d4ec20856136acc75053f", size = 777630, upload-time = "2025-11-16T16:13:16.898Z" },
+    { url = "https://files.pythonhosted.org/packages/60/50/6842f4628bc98b7aa4733ab2378346e1441e150935ad3b9f3c3c429d9408/ruamel_yaml_clib-0.2.15-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b45498cc81a4724a2d42273d6cfc243c0547ad7c6b87b4f774cb7bcc131c98d", size = 744368, upload-time = "2025-11-16T16:13:18.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/128ae8e19a7d794c2e36130a72b3bb650ce1dd13fb7def6cf10656437dcf/ruamel_yaml_clib-0.2.15-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:def5663361f6771b18646620fca12968aae730132e104688766cf8a3b1d65922", size = 745233, upload-time = "2025-11-16T20:22:45.833Z" },
+    { url = "https://files.pythonhosted.org/packages/75/05/91130633602d6ba7ce3e07f8fc865b40d2a09efd4751c740df89eed5caf9/ruamel_yaml_clib-0.2.15-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:014181cdec565c8745b7cbc4de3bf2cc8ced05183d986e6d1200168e5bb59490", size = 770963, upload-time = "2025-11-16T16:13:19.344Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/4b/fd4542e7f33d7d1bc64cc9ac9ba574ce8cf145569d21f5f20133336cdc8c/ruamel_yaml_clib-0.2.15-cp311-cp311-win32.whl", hash = "sha256:d290eda8f6ada19e1771b54e5706b8f9807e6bb08e873900d5ba114ced13e02c", size = 102640, upload-time = "2025-11-16T16:13:20.498Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/eb/00ff6032c19c7537371e3119287999570867a0eafb0154fccc80e74bf57a/ruamel_yaml_clib-0.2.15-cp311-cp311-win_amd64.whl", hash = "sha256:bdc06ad71173b915167702f55d0f3f027fc61abd975bd308a0968c02db4a4c3e", size = 121996, upload-time = "2025-11-16T16:13:21.855Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4b/5fde11a0722d676e469d3d6f78c6a17591b9c7e0072ca359801c4bd17eee/ruamel_yaml_clib-0.2.15-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cb15a2e2a90c8475df45c0949793af1ff413acfb0a716b8b94e488ea95ce7cff", size = 149088, upload-time = "2025-11-16T16:13:22.836Z" },
+    { url = "https://files.pythonhosted.org/packages/85/82/4d08ac65ecf0ef3b046421985e66301a242804eb9a62c93ca3437dc94ee0/ruamel_yaml_clib-0.2.15-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:64da03cbe93c1e91af133f5bec37fd24d0d4ba2418eaf970d7166b0a26a148a2", size = 134553, upload-time = "2025-11-16T16:13:24.151Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/cb/22366d68b280e281a932403b76da7a988108287adff2bfa5ce881200107a/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f6d3655e95a80325b84c4e14c080b2470fe4f33b6846f288379ce36154993fb1", size = 737468, upload-time = "2025-11-16T20:22:47.335Z" },
+    { url = "https://files.pythonhosted.org/packages/71/73/81230babf8c9e33770d43ed9056f603f6f5f9665aea4177a2c30ae48e3f3/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:71845d377c7a47afc6592aacfea738cc8a7e876d586dfba814501d8c53c1ba60", size = 753349, upload-time = "2025-11-16T16:13:26.269Z" },
+    { url = "https://files.pythonhosted.org/packages/61/62/150c841f24cda9e30f588ef396ed83f64cfdc13b92d2f925bb96df337ba9/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11e5499db1ccbc7f4b41f0565e4f799d863ea720e01d3e99fa0b7b5fcd7802c9", size = 788211, upload-time = "2025-11-16T16:13:27.441Z" },
+    { url = "https://files.pythonhosted.org/packages/30/93/e79bd9cbecc3267499d9ead919bd61f7ddf55d793fb5ef2b1d7d92444f35/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4b293a37dc97e2b1e8a1aec62792d1e52027087c8eea4fc7b5abd2bdafdd6642", size = 743203, upload-time = "2025-11-16T16:13:28.671Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/06/1eb640065c3a27ce92d76157f8efddb184bd484ed2639b712396a20d6dce/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:512571ad41bba04eac7268fe33f7f4742210ca26a81fe0c75357fa682636c690", size = 747292, upload-time = "2025-11-16T20:22:48.584Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/21/ee353e882350beab65fcc47a91b6bdc512cace4358ee327af2962892ff16/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5e9f630c73a490b758bf14d859a39f375e6999aea5ddd2e2e9da89b9953486a", size = 771624, upload-time = "2025-11-16T16:13:29.853Z" },
+    { url = "https://files.pythonhosted.org/packages/57/34/cc1b94057aa867c963ecf9ea92ac59198ec2ee3a8d22a126af0b4d4be712/ruamel_yaml_clib-0.2.15-cp312-cp312-win32.whl", hash = "sha256:f4421ab780c37210a07d138e56dd4b51f8642187cdfb433eb687fe8c11de0144", size = 100342, upload-time = "2025-11-16T16:13:31.067Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/e5/8925a4208f131b218f9a7e459c0d6fcac8324ae35da269cb437894576366/ruamel_yaml_clib-0.2.15-cp312-cp312-win_amd64.whl", hash = "sha256:2b216904750889133d9222b7b873c199d48ecbb12912aca78970f84a5aa1a4bc", size = 119013, upload-time = "2025-11-16T16:13:32.164Z" },
+    { url = "https://files.pythonhosted.org/packages/17/5e/2f970ce4c573dc30c2f95825f2691c96d55560268ddc67603dc6ea2dd08e/ruamel_yaml_clib-0.2.15-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4dcec721fddbb62e60c2801ba08c87010bd6b700054a09998c4d09c08147b8fb", size = 147450, upload-time = "2025-11-16T16:13:33.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/03/a1baa5b94f71383913f21b96172fb3a2eb5576a4637729adbf7cd9f797f8/ruamel_yaml_clib-0.2.15-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:65f48245279f9bb301d1276f9679b82e4c080a1ae25e679f682ac62446fac471", size = 133139, upload-time = "2025-11-16T16:13:34.587Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/19/40d676802390f85784235a05788fd28940923382e3f8b943d25febbb98b7/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:46895c17ead5e22bea5e576f1db7e41cb273e8d062c04a6a49013d9f60996c25", size = 731474, upload-time = "2025-11-16T20:22:49.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/bb/6ef5abfa43b48dd55c30d53e997f8f978722f02add61efba31380d73e42e/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3eb199178b08956e5be6288ee0b05b2fb0b5c1f309725ad25d9c6ea7e27f962a", size = 748047, upload-time = "2025-11-16T16:13:35.633Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/5d/e4f84c9c448613e12bd62e90b23aa127ea4c46b697f3d760acc32cb94f25/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d1032919280ebc04a80e4fb1e93f7a738129857eaec9448310e638c8bccefcf", size = 782129, upload-time = "2025-11-16T16:13:36.781Z" },
+    { url = "https://files.pythonhosted.org/packages/de/4b/e98086e88f76c00c88a6bcf15eae27a1454f661a9eb72b111e6bbb69024d/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab0df0648d86a7ecbd9c632e8f8d6b21bb21b5fc9d9e095c796cacf32a728d2d", size = 736848, upload-time = "2025-11-16T16:13:37.952Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/5c/5964fcd1fd9acc53b7a3a5d9a05ea4f95ead9495d980003a557deb9769c7/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:331fb180858dd8534f0e61aa243b944f25e73a4dae9962bd44c46d1761126bbf", size = 741630, upload-time = "2025-11-16T20:22:51.718Z" },
+    { url = "https://files.pythonhosted.org/packages/07/1e/99660f5a30fceb58494598e7d15df883a07292346ef5696f0c0ae5dee8c6/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fd4c928ddf6bce586285daa6d90680b9c291cfd045fc40aad34e445d57b1bf51", size = 766619, upload-time = "2025-11-16T16:13:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/36/2f/fa0344a9327b58b54970e56a27b32416ffbcfe4dcc0700605516708579b2/ruamel_yaml_clib-0.2.15-cp313-cp313-win32.whl", hash = "sha256:bf0846d629e160223805db9fe8cc7aec16aaa11a07310c50c8c7164efa440aec", size = 100171, upload-time = "2025-11-16T16:13:40.456Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c4/c124fbcef0684fcf3c9b72374c2a8c35c94464d8694c50f37eef27f5a145/ruamel_yaml_clib-0.2.15-cp313-cp313-win_amd64.whl", hash = "sha256:45702dfbea1420ba3450bb3dd9a80b33f0badd57539c6aac09f42584303e0db6", size = 118845, upload-time = "2025-11-16T16:13:41.481Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/bd/ab8459c8bb759c14a146990bf07f632c1cbec0910d4853feeee4be2ab8bb/ruamel_yaml_clib-0.2.15-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:753faf20b3a5906faf1fc50e4ddb8c074cb9b251e00b14c18b28492f933ac8ef", size = 147248, upload-time = "2025-11-16T16:13:42.872Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f2/c4cec0a30f1955510fde498aac451d2e52b24afdbcb00204d3a951b772c3/ruamel_yaml_clib-0.2.15-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:480894aee0b29752560a9de46c0e5f84a82602f2bc5c6cde8db9a345319acfdf", size = 133764, upload-time = "2025-11-16T16:13:43.932Z" },
+    { url = "https://files.pythonhosted.org/packages/82/c7/2480d062281385a2ea4f7cc9476712446e0c548cd74090bff92b4b49e898/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4d3b58ab2454b4747442ac76fab66739c72b1e2bb9bd173d7694b9f9dbc9c000", size = 730537, upload-time = "2025-11-16T20:22:52.918Z" },
+    { url = "https://files.pythonhosted.org/packages/75/08/e365ee305367559f57ba6179d836ecc3d31c7d3fdff2a40ebf6c32823a1f/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bfd309b316228acecfa30670c3887dcedf9b7a44ea39e2101e75d2654522acd4", size = 746944, upload-time = "2025-11-16T16:13:45.338Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5c/8b56b08db91e569d0a4fbfa3e492ed2026081bdd7e892f63ba1c88a2f548/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2812ff359ec1f30129b62372e5f22a52936fac13d5d21e70373dbca5d64bb97c", size = 778249, upload-time = "2025-11-16T16:13:46.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1d/70dbda370bd0e1a92942754c873bd28f513da6198127d1736fa98bb2a16f/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7e74ea87307303ba91073b63e67f2c667e93f05a8c63079ee5b7a5c8d0d7b043", size = 737140, upload-time = "2025-11-16T16:13:48.349Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/87/822d95874216922e1120afb9d3fafa795a18fdd0c444f5c4c382f6dac761/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:713cd68af9dfbe0bb588e144a61aad8dcc00ef92a82d2e87183ca662d242f524", size = 741070, upload-time = "2025-11-16T20:22:54.151Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/17/4e01a602693b572149f92c983c1f25bd608df02c3f5cf50fd1f94e124a59/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:542d77b72786a35563f97069b9379ce762944e67055bea293480f7734b2c7e5e", size = 765882, upload-time = "2025-11-16T16:13:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/17/7999399081d39ebb79e807314de6b611e1d1374458924eb2a489c01fc5ad/ruamel_yaml_clib-0.2.15-cp314-cp314-win32.whl", hash = "sha256:424ead8cef3939d690c4b5c85ef5b52155a231ff8b252961b6516ed7cf05f6aa", size = 102567, upload-time = "2025-11-16T16:13:50.78Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/67/be582a7370fdc9e6846c5be4888a530dcadd055eef5b932e0e85c33c7d73/ruamel_yaml_clib-0.2.15-cp314-cp314-win_amd64.whl", hash = "sha256:ac9b8d5fa4bb7fd2917ab5027f60d4234345fd366fe39aa711d5dca090aa1467", size = 122847, upload-time = "2025-11-16T16:13:51.807Z" },
 ]
 
 [[package]]
@@ -4710,6 +5522,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/58/ac864a75067dcbd3b95be5ab4eb2b601d7fbc3d3d736a27e391a4f92a5c1/ruff-0.15.1-py3-none-win32.whl", hash = "sha256:660975d9cb49b5d5278b12b03bb9951d554543a90b74ed5d366b20e2c57c2098", size = 10462555, upload-time = "2026-02-12T23:09:29.899Z" },
     { url = "https://files.pythonhosted.org/packages/e0/5e/d4ccc8a27ecdb78116feac4935dfc39d1304536f4296168f91ed3ec00cd2/ruff-0.15.1-py3-none-win_amd64.whl", hash = "sha256:c820fef9dd5d4172a6570e5721704a96c6679b80cf7be41659ed439653f62336", size = 11599956, upload-time = "2026-02-12T23:09:01.157Z" },
     { url = "https://files.pythonhosted.org/packages/2a/07/5bda6a85b220c64c65686bc85bd0bbb23b29c62b3a9f9433fa55f17cda93/ruff-0.15.1-py3-none-win_arm64.whl", hash = "sha256:5ff7d5f0f88567850f45081fac8f4ec212be8d0b963e385c3f7d0d2eb4899416", size = 10874604, upload-time = "2026-02-12T23:09:05.515Z" },
+]
+
+[[package]]
+name = "scanspec"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "numpy" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/c3/7b3621a0eec53b7e348457de68a33a93314c5626523ab1481395811aa09e/scanspec-1.0.0.tar.gz", hash = "sha256:31d297861978e56bb6cfcaa15527bad5ba3dc158b3fc52142ecb5611a22e1b5a", size = 285029, upload-time = "2026-04-28T12:12:54.378Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/b9/f44b139096467996b4d85589d9880fd55f0c80a204d298a1b73d0adc2654/scanspec-1.0.0-py3-none-any.whl", hash = "sha256:4ad6dccd6ac19dbd8af888c80c5db53c70d6b8aee9d26c0ca174cebd3c396730", size = 37825, upload-time = "2026-04-28T12:12:53.084Z" },
 ]
 
 [[package]]
@@ -4861,6 +5687,15 @@ wheels = [
 ]
 
 [[package]]
+name = "semver"
+version = "3.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/d1/d3159231aec234a59dd7d601e9dd9fe96f3afff15efd33c1070019b26132/semver-3.0.4.tar.gz", hash = "sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602", size = 269730, upload-time = "2025-01-24T13:19:27.617Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl", hash = "sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746", size = 17912, upload-time = "2025-01-24T13:19:24.949Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -4903,6 +5738,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+]
+
+[[package]]
+name = "sparse"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numba" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/64/46da3957f8f9af03179eca946d786c56f22b9458cedf472850e02948a8c1/sparse-0.18.0.tar.gz", hash = "sha256:57f92661eb0ec0c764b450c72f3c0d869ea7f32e5e4ca0a335f9d6a7d79bbff4", size = 791987, upload-time = "2026-02-19T06:17:55.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/a9/804ac7423f5dda316d3a982f3ab071c971fb877f8961dad9f6a97d12d2ee/sparse-0.18.0-py2.py3-none-any.whl", hash = "sha256:6f4a127d5aae88eca41ea8106bbd5a7830f83d068b37291df597a43511212069", size = 151931, upload-time = "2026-02-19T06:17:53.11Z" },
 ]
 
 [[package]]
@@ -5118,6 +5966,18 @@ wheels = [
 ]
 
 [[package]]
+name = "stamina"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tenacity" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/bd/b2f71ae14368a066f103d182f25bbc6c3bf4aa695889f3ed3cba026d6f36/stamina-26.1.0.tar.gz", hash = "sha256:0214d05fdf5102c518194a4aac7520ce53cf660550ae3b940701aad88cf50c17", size = 568171, upload-time = "2026-04-13T17:44:31.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/f0/1ff90a1d1dd02de23feafdf9dffaecef3958348be5c192df56670ccb4f86/stamina-26.1.0-py3-none-any.whl", hash = "sha256:62e06829bec87c06d4cafde520b32a6097d1017c378a9eb63253c5bf5ebbbb88", size = 18508, upload-time = "2026-04-13T17:44:29.545Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5224,6 +6084,50 @@ wheels = [
 ]
 
 [[package]]
+name = "tiled"
+version = "0.2.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "json-merge-patch" },
+    { name = "jsonpatch" },
+    { name = "jsonschema" },
+    { name = "msgpack" },
+    { name = "orjson" },
+    { name = "platformdirs" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyyaml" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/22/20f3ea186642957b4110237d6bba0bec6a507b1e91101ea6c419b07ed32b/tiled-0.2.12.tar.gz", hash = "sha256:acc529b7838f6f108df693a93dfe6ee610717b43aaff13c7057f866ed0013b14", size = 2691736, upload-time = "2026-06-16T17:47:47.856Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/95/f908e8f93f4df9eb18ed8b470f152cccb6d9349c412439aa594d898ee23d/tiled-0.2.12-py3-none-any.whl", hash = "sha256:7cce5cb52c9b5261915a9e3b21321a4b672c99036a6a194b41f3cec884ec4339", size = 1803898, upload-time = "2026-06-16T17:47:45.672Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "awkward" },
+    { name = "blosc2" },
+    { name = "dask", extra = ["array", "dataframe"] },
+    { name = "entrypoints" },
+    { name = "lz4" },
+    { name = "ndindex" },
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "ragged" },
+    { name = "rich" },
+    { name = "sparse" },
+    { name = "stamina" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+    { name = "xarray" },
+    { name = "zstandard" },
+]
+
+[[package]]
 name = "tinycss2"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5313,6 +6217,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "toolz"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/d6/114b492226588d6ff54579d95847662fc69196bdeec318eb45393b24c192/toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b", size = 52613, upload-time = "2025-10-17T04:03:21.661Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8", size = 58093, upload-time = "2025-10-17T04:03:20.435Z" },
 ]
 
 [[package]]
@@ -5508,6 +6421,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "velocity-profile"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/a0/edb76fc2b71a3cd0717a40184f512f8249a64443c472541939d915fab70d/velocity_profile-1.0.0.tar.gz", hash = "sha256:520a4dbc69519744c89438571ffe542f512ae528232f51e73cde9dbaaee2e086", size = 29716, upload-time = "2024-06-13T10:49:54.951Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/89/0265b2b79424ed05b8d1e9c8fca71e1b150478e5b0c19aa50b0ae397326e/velocity_profile-1.0.0-py3-none-any.whl", hash = "sha256:b9082aedb2863748e1e6e56e7a794cd5742addd571f6ba2e13f4f5b8a09422d9", size = 16858, upload-time = "2024-06-13T10:49:53.555Z" },
 ]
 
 [[package]]
@@ -5793,6 +6718,20 @@ wheels = [
 ]
 
 [[package]]
+name = "xarray"
+version = "2026.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/a6/6fe936a798a3a38a79c7422d1a31afd2e9a14690fcb0ccff96bc01f04bf2/xarray-2026.4.0.tar.gz", hash = "sha256:c4ac9a01a945d90d5b1628e2af045099a9d4943536d4f2ee3ae963c3b222d15b", size = 3132311, upload-time = "2026-04-13T19:45:36.688Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/83/6d810a8a9ebc9c307989b418840c20e46907c74d707beb67ab566773e6fc/xarray-2026.4.0-py3-none-any.whl", hash = "sha256:d43751d9fb4a90f9249c30431684f00c41bc874f1edccd862631a40cbc0edf08", size = 1414326, upload-time = "2026-04-13T19:45:34.659Z" },
+]
+
+[[package]]
 name = "xyzservices"
 version = "2025.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5918,4 +6857,78 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/83/c3ca27c363d104980f1c9cee1101cc8ba724ac8c28a033ede6aab89585b1/zstandard-0.25.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:933b65d7680ea337180733cf9e87293cc5500cc0eb3fc8769f4d3c88d724ec5c", size = 795254, upload-time = "2025-09-14T22:16:26.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/4d/e66465c5411a7cf4866aeadc7d108081d8ceba9bc7abe6b14aa21c671ec3/zstandard-0.25.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3f79487c687b1fc69f19e487cd949bf3aae653d181dfb5fde3bf6d18894706f", size = 640559, upload-time = "2025-09-14T22:16:27.973Z" },
+    { url = "https://files.pythonhosted.org/packages/12/56/354fe655905f290d3b147b33fe946b0f27e791e4b50a5f004c802cb3eb7b/zstandard-0.25.0-cp311-cp311-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:0bbc9a0c65ce0eea3c34a691e3c4b6889f5f3909ba4822ab385fab9057099431", size = 5348020, upload-time = "2025-09-14T22:16:29.523Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/13/2b7ed68bd85e69a2069bcc72141d378f22cae5a0f3b353a2c8f50ef30c1b/zstandard-0.25.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:01582723b3ccd6939ab7b3a78622c573799d5d8737b534b86d0e06ac18dbde4a", size = 5058126, upload-time = "2025-09-14T22:16:31.811Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/dd/fdaf0674f4b10d92cb120ccff58bbb6626bf8368f00ebfd2a41ba4a0dc99/zstandard-0.25.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5f1ad7bf88535edcf30038f6919abe087f606f62c00a87d7e33e7fc57cb69fcc", size = 5405390, upload-time = "2025-09-14T22:16:33.486Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/67/354d1555575bc2490435f90d67ca4dd65238ff2f119f30f72d5cde09c2ad/zstandard-0.25.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:06acb75eebeedb77b69048031282737717a63e71e4ae3f77cc0c3b9508320df6", size = 5452914, upload-time = "2025-09-14T22:16:35.277Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/e9cfd801a3f9190bf3e759c422bbfd2247db9d7f3d54a56ecde70137791a/zstandard-0.25.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9300d02ea7c6506f00e627e287e0492a5eb0371ec1670ae852fefffa6164b072", size = 5559635, upload-time = "2025-09-14T22:16:37.141Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/5ba550f797ca953a52d708c8e4f380959e7e3280af029e38fbf47b55916e/zstandard-0.25.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bfd06b1c5584b657a2892a6014c2f4c20e0db0208c159148fa78c65f7e0b0277", size = 5048277, upload-time = "2025-09-14T22:16:38.807Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c0/ca3e533b4fa03112facbe7fbe7779cb1ebec215688e5df576fe5429172e0/zstandard-0.25.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f373da2c1757bb7f1acaf09369cdc1d51d84131e50d5fa9863982fd626466313", size = 5574377, upload-time = "2025-09-14T22:16:40.523Z" },
+    { url = "https://files.pythonhosted.org/packages/12/9b/3fb626390113f272abd0799fd677ea33d5fc3ec185e62e6be534493c4b60/zstandard-0.25.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6c0e5a65158a7946e7a7affa6418878ef97ab66636f13353b8502d7ea03c8097", size = 4961493, upload-time = "2025-09-14T22:16:43.3Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/d3/23094a6b6a4b1343b27ae68249daa17ae0651fcfec9ed4de09d14b940285/zstandard-0.25.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c8e167d5adf59476fa3e37bee730890e389410c354771a62e3c076c86f9f7778", size = 5269018, upload-time = "2025-09-14T22:16:45.292Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a7/bb5a0c1c0f3f4b5e9d5b55198e39de91e04ba7c205cc46fcb0f95f0383c1/zstandard-0.25.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:98750a309eb2f020da61e727de7d7ba3c57c97cf6213f6f6277bb7fb42a8e065", size = 5443672, upload-time = "2025-09-14T22:16:47.076Z" },
+    { url = "https://files.pythonhosted.org/packages/27/22/503347aa08d073993f25109c36c8d9f029c7d5949198050962cb568dfa5e/zstandard-0.25.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:22a086cff1b6ceca18a8dd6096ec631e430e93a8e70a9ca5efa7561a00f826fa", size = 5822753, upload-time = "2025-09-14T22:16:49.316Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/be/94267dc6ee64f0f8ba2b2ae7c7a2df934a816baaa7291db9e1aa77394c3c/zstandard-0.25.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:72d35d7aa0bba323965da807a462b0966c91608ef3a48ba761678cb20ce5d8b7", size = 5366047, upload-time = "2025-09-14T22:16:51.328Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a3/732893eab0a3a7aecff8b99052fecf9f605cf0fb5fb6d0290e36beee47a4/zstandard-0.25.0-cp311-cp311-win32.whl", hash = "sha256:f5aeea11ded7320a84dcdd62a3d95b5186834224a9e55b92ccae35d21a8b63d4", size = 436484, upload-time = "2025-09-14T22:16:55.005Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a3/c6155f5c1cce691cb80dfd38627046e50af3ee9ddc5d0b45b9b063bfb8c9/zstandard-0.25.0-cp311-cp311-win_amd64.whl", hash = "sha256:daab68faadb847063d0c56f361a289c4f268706b598afbf9ad113cbe5c38b6b2", size = 506183, upload-time = "2025-09-14T22:16:52.753Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3e/8945ab86a0820cc0e0cdbf38086a92868a9172020fdab8a03ac19662b0e5/zstandard-0.25.0-cp311-cp311-win_arm64.whl", hash = "sha256:22a06c5df3751bb7dc67406f5374734ccee8ed37fc5981bf1ad7041831fa1137", size = 462533, upload-time = "2025-09-14T22:16:53.878Z" },
+    { url = "https://files.pythonhosted.org/packages/82/fc/f26eb6ef91ae723a03e16eddb198abcfce2bc5a42e224d44cc8b6765e57e/zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b", size = 795738, upload-time = "2025-09-14T22:16:56.237Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1c/d920d64b22f8dd028a8b90e2d756e431a5d86194caa78e3819c7bf53b4b3/zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00", size = 640436, upload-time = "2025-09-14T22:16:57.774Z" },
+    { url = "https://files.pythonhosted.org/packages/53/6c/288c3f0bd9fcfe9ca41e2c2fbfd17b2097f6af57b62a81161941f09afa76/zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64", size = 5343019, upload-time = "2025-09-14T22:16:59.302Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/15/efef5a2f204a64bdb5571e6161d49f7ef0fffdbca953a615efbec045f60f/zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea", size = 5063012, upload-time = "2025-09-14T22:17:01.156Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/a6ce629ffdb43959e92e87ebdaeebb5ac81c944b6a75c9c47e300f85abdf/zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb", size = 5394148, upload-time = "2025-09-14T22:17:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/79/2bf870b3abeb5c070fe2d670a5a8d1057a8270f125ef7676d29ea900f496/zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a", size = 5451652, upload-time = "2025-09-14T22:17:04.979Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902", size = 5546993, upload-time = "2025-09-14T22:17:06.781Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c7/3483ad9ff0662623f3648479b0380d2de5510abf00990468c286c6b04017/zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f", size = 5046806, upload-time = "2025-09-14T22:17:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/206883dd25b8d1591a1caa44b54c2aad84badccf2f1de9e2d60a446f9a25/zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b", size = 5576659, upload-time = "2025-09-14T22:17:10.164Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/31/76c0779101453e6c117b0ff22565865c54f48f8bd807df2b00c2c404b8e0/zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6", size = 4953933, upload-time = "2025-09-14T22:17:11.857Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e1/97680c664a1bf9a247a280a053d98e251424af51f1b196c6d52f117c9720/zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91", size = 5268008, upload-time = "2025-09-14T22:17:13.627Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/73/316e4010de585ac798e154e88fd81bb16afc5c5cb1a72eeb16dd37e8024a/zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708", size = 5433517, upload-time = "2025-09-14T22:17:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/60/dd0f8cfa8129c5a0ce3ea6b7f70be5b33d2618013a161e1ff26c2b39787c/zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512", size = 5814292, upload-time = "2025-09-14T22:17:17.827Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5f/75aafd4b9d11b5407b641b8e41a57864097663699f23e9ad4dbb91dc6bfe/zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa", size = 5360237, upload-time = "2025-09-14T22:17:19.954Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8d/0309daffea4fcac7981021dbf21cdb2e3427a9e76bafbcdbdf5392ff99a4/zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd", size = 436922, upload-time = "2025-09-14T22:17:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3b/fa54d9015f945330510cb5d0b0501e8253c127cca7ebe8ba46a965df18c5/zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01", size = 506276, upload-time = "2025-09-14T22:17:21.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6b/8b51697e5319b1f9ac71087b0af9a40d8a6288ff8025c36486e0c12abcc4/zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9", size = 462679, upload-time = "2025-09-14T22:17:23.147Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0b/8df9c4ad06af91d39e94fa96cc010a24ac4ef1378d3efab9223cc8593d40/zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94", size = 795735, upload-time = "2025-09-14T22:17:26.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1", size = 640440, upload-time = "2025-09-14T22:17:27.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/14/933d27204c2bd404229c69f445862454dcc101cd69ef8c6068f15aaec12c/zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f", size = 5343070, upload-time = "2025-09-14T22:17:28.896Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/db/ddb11011826ed7db9d0e485d13df79b58586bfdec56e5c84a928a9a78c1c/zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea", size = 5063001, upload-time = "2025-09-14T22:17:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/db/00/87466ea3f99599d02a5238498b87bf84a6348290c19571051839ca943777/zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e", size = 5394120, upload-time = "2025-09-14T22:17:32.711Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/fc5531d9c618a679a20ff6c29e2b3ef1d1f4ad66c5e161ae6ff847d102a9/zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551", size = 5451230, upload-time = "2025-09-14T22:17:34.41Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4b/e3678b4e776db00f9f7b2fe58e547e8928ef32727d7a1ff01dea010f3f13/zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a", size = 5547173, upload-time = "2025-09-14T22:17:36.084Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d5/ba05ed95c6b8ec30bd468dfeab20589f2cf709b5c940483e31d991f2ca58/zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611", size = 5046736, upload-time = "2025-09-14T22:17:37.891Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/870aa06b3a76c73eced65c044b92286a3c4e00554005ff51962deef28e28/zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3", size = 5576368, upload-time = "2025-09-14T22:17:40.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/35/398dc2ffc89d304d59bc12f0fdd931b4ce455bddf7038a0a67733a25f550/zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b", size = 4954022, upload-time = "2025-09-14T22:17:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5c/36ba1e5507d56d2213202ec2b05e8541734af5f2ce378c5d1ceaf4d88dc4/zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851", size = 5267889, upload-time = "2025-09-14T22:17:43.577Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e8/2ec6b6fb7358b2ec0113ae202647ca7c0e9d15b61c005ae5225ad0995df5/zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250", size = 5433952, upload-time = "2025-09-14T22:17:45.271Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/01/b5f4d4dbc59ef193e870495c6f1275f5b2928e01ff5a81fecb22a06e22fb/zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98", size = 5814054, upload-time = "2025-09-14T22:17:47.08Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e5/fbd822d5c6f427cf158316d012c5a12f233473c2f9c5fe5ab1ae5d21f3d8/zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf", size = 5360113, upload-time = "2025-09-14T22:17:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/69a553d2047f9a2c7347caa225bb3a63b6d7704ad74610cb7823baa08ed7/zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09", size = 436936, upload-time = "2025-09-14T22:17:52.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/b9c06c870f3bd8767c201f1edbdf9e8dc34be5b0fbc5682c4f80fe948475/zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5", size = 506232, upload-time = "2025-09-14T22:17:50.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/60c3c01243bb81d381c9916e2a6d9e149ab8627c0c7d7abb2d73384b3c0c/zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049", size = 462671, upload-time = "2025-09-14T22:17:51.533Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5c/f8923b595b55fe49e30612987ad8bf053aef555c14f05bb659dd5dbe3e8a/zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3", size = 795887, upload-time = "2025-09-14T22:17:54.198Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/09/d0a2a14fc3439c5f874042dca72a79c70a532090b7ba0003be73fee37ae2/zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f", size = 640658, upload-time = "2025-09-14T22:17:55.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/8b6b71b1ddd517f68ffb55e10834388d4f793c49c6b83effaaa05785b0b4/zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c", size = 5379849, upload-time = "2025-09-14T22:17:57.372Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/86/a48e56320d0a17189ab7a42645387334fba2200e904ee47fc5a26c1fd8ca/zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439", size = 5058095, upload-time = "2025-09-14T22:17:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ad/eb659984ee2c0a779f9d06dbfe45e2dc39d99ff40a319895df2d3d9a48e5/zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043", size = 5551751, upload-time = "2025-09-14T22:18:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b3/b637faea43677eb7bd42ab204dfb7053bd5c4582bfe6b1baefa80ac0c47b/zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859", size = 6364818, upload-time = "2025-09-14T22:18:03.769Z" },
+    { url = "https://files.pythonhosted.org/packages/31/dc/cc50210e11e465c975462439a492516a73300ab8caa8f5e0902544fd748b/zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0", size = 5560402, upload-time = "2025-09-14T22:18:05.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ae/56523ae9c142f0c08efd5e868a6da613ae76614eca1305259c3bf6a0ed43/zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7", size = 4955108, upload-time = "2025-09-14T22:18:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cf/c899f2d6df0840d5e384cf4c4121458c72802e8bda19691f3b16619f51e9/zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2", size = 5269248, upload-time = "2025-09-14T22:18:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c0/59e912a531d91e1c192d3085fc0f6fb2852753c301a812d856d857ea03c6/zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344", size = 5430330, upload-time = "2025-09-14T22:18:11.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/7e31db1240de2df22a58e2ea9a93fc6e38cc29353e660c0272b6735d6669/zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c", size = 5811123, upload-time = "2025-09-14T22:18:13.907Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/fac46df5ad353d50535e118d6983069df68ca5908d4d65b8c466150a4ff1/zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088", size = 5359591, upload-time = "2025-09-14T22:18:16.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513, upload-time = "2025-09-14T22:18:20.61Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118, upload-time = "2025-09-14T22:18:17.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940, upload-time = "2025-09-14T22:18:19.088Z" },
 ]


### PR DESCRIPTION
## Summary

Gives the OSPREY agent a facility-agnostic way to run Bluesky scan plans as
write-safe agent actions.

A thin `scan` MCP server exposes scan capabilities to the agent and forwards to
a FastAPI "bluesky bridge" service. The bridge runs in its own container, binds
to loopback only, and owns a Bluesky RunEngine together with ophyd-async devices.
Scans follow an intent → approval → token-gated-promote lifecycle so that a scan
is only launched after explicit approval, and a bounded read-back tool lets the
agent inspect recent run data without unbounded access.

## What's included

- `scan` MCP server with a write-gated launch tool; write tools are stripped in
  read-only mode.
- `bluesky_bridge` FastAPI service owning the RunEngine, with a token-gated
  promote lifecycle for launching approved scans.
- Mock and EPICS device factories, plus a demo mode for running without hardware.
- A live data path exposing bounded read-back of recent run rows.
- Promote token excluded from the agent execution environment.
- Deploy-pipeline registration and a service template for the bridge.
- A container end-to-end test covering the scan deploy path, with a dedicated CI job.

## Testing

Unit and integration tests for the bridge (scanner, runs, security) and the
scan MCP server. A container end-to-end test exercises the full deploy path.
