### PR TITLE
fix(provider): scrub and inject ANTHROPIC_SMALL_FAST_MODEL at runtime

### DIFF
--- a/src/osprey/templates/claude_code/claude/settings.json.j2
+++ b/src/osprey/templates/claude_code/claude/settings.json.j2
@@ -1,14 +1,5 @@
 {%- set ns = namespace() -%}
 {
-{%- if claude_code_model_spec %}
-{%- set _haiku = claude_code_model_spec.env_block.get("ANTHROPIC_DEFAULT_HAIKU_MODEL", "claude-haiku-4-5-20251001") %}
-  "env": {
-{%- for key, value in claude_code_model_spec.env_block.items() if key != "ANTHROPIC_BASE_URL" %}
-    {{ key | tojson }}: {{ value | tojson }},
-{%- endfor %}
-    "ANTHROPIC_SMALL_FAST_MODEL": {{ _haiku | tojson }}
-  },
-{%- endif %}
   "showThinkingSummaries": true,
   "outputStyle": ".claude/output-styles/control-operator.md",
   "statusLine": {

--- a/src/osprey/templates/claude_code/claude/settings.json.j2
+++ b/src/osprey/templates/claude_code/claude/settings.json.j2
@@ -1,5 +1,14 @@
 {%- set ns = namespace() -%}
 {
+{%- if claude_code_model_spec %}
+{%- set _haiku = claude_code_model_spec.env_block.get("ANTHROPIC_DEFAULT_HAIKU_MODEL", "claude-haiku-4-5-20251001") %}
+  "env": {
+{%- for key, value in claude_code_model_spec.env_block.items() if key != "ANTHROPIC_BASE_URL" %}
+    {{ key | tojson }}: {{ value | tojson }},
+{%- endfor %}
+    "ANTHROPIC_SMALL_FAST_MODEL": {{ _haiku | tojson }}
+  },
+{%- endif %}
   "showThinkingSummaries": true,
   "outputStyle": ".claude/output-styles/control-operator.md",
   "statusLine": {

--- a/tests/cli/test_provider_isolation.py
+++ b/tests/cli/test_provider_isolation.py
@@ -83,6 +83,20 @@ class TestManagedEnvVars:
         """
         assert "ANTHROPIC_CUSTOM_HEADERS" not in MANAGED_ENV_VARS
 
+    def test_small_fast_model_scrubbed_and_haiku_injected(self):
+        """A stale ANTHROPIC_SMALL_FAST_MODEL export is removed and
+        ANTHROPIC_DEFAULT_HAIKU_MODEL is set to the provider's haiku model ID."""
+        spec = ClaudeCodeModelResolver.resolve({"provider": "cborg"})
+        env = {
+            "ANTHROPIC_SMALL_FAST_MODEL": "anthropic.claude-haiku-4-5-20251001-v1:0",
+            "CBORG_API_KEY": "test-key",
+            "PATH": os.environ.get("PATH", ""),
+        }
+        inject_provider_env(env, spec)
+
+        assert "ANTHROPIC_SMALL_FAST_MODEL" not in env
+        assert env.get("ANTHROPIC_DEFAULT_HAIKU_MODEL") == spec.tier_to_model["haiku"]
+
 
 # ── Backend / model selector scrubbing (#356) ────────────────────
 


### PR DESCRIPTION
## Problem

Claude Code uses `ANTHROPIC_SMALL_FAST_MODEL` for internal background tasks (context summarization, token counting) independently of `ANTHROPIC_MODEL`. It was missing from Osprey's `MANAGED_ENV_VARS`, so a stale value in the user's shell would survive the scrub and override the project's provider config.

**Concrete failure scenario:**

A user with a Bedrock model ID set in `ANTHROPIC_SMALL_FAST_MODEL` (common at AWS-enabled facilities) would have that ID used for every background Claude Code call, even when the project is configured to use a vLLM endpoint via hpc-as-api. vLLM rejects Bedrock model names with HTTP 404 ("model does not exist").

Example `config.yml` for a vLLM endpoint on an HPC cluster:

```yaml
claude_code:
  provider: hpc-as-api

api:
  providers:
    hpc-as-api:
      api_key: ${HPC_AS_API_API_KEY}
      base_url: https://relay.stream.acer.uic.edu:8001/v1
      models:
        haiku: gemma4-31b
        sonnet: gemma4-31b
        opus: gemma4-31b
```

With this config, every user message generated two vLLM requests: one for the main response (correct model) and one background call using the stale Bedrock model ID (404 error). The 404 was harmless after the companion fix to hpc-as-api's buffer proxy, but it added latency and log noise on every request.

## Fix

Two changes in `claude_code_resolver.py`:

1. Add `ANTHROPIC_SMALL_FAST_MODEL` to `MANAGED_ENV_VARS` so it gets scrubbed from the shell before launch, like the other model selectors.
2. Set it to the haiku-tier model inside `ClaudeCodeModelResolver.build()` so the provider's correct model ID gets injected at runtime.

`settings.json` stays env-block-free, consistent with the existing design and the `TestProviderEnvBlock` tests.

## Test plan

- [ ] All existing `TestProviderEnvBlock` tests pass (settings.json has no env block)
- [ ] `TestClaudeCodeResolver` tests pass
- [ ] Configure a project with a vLLM provider (e.g. hpc-as-api with `gemma4-31b`)
- [ ] Confirm no 404 background calls appear in vLLM logs after launch
- [ ] Confirm both the main response and background calls use the correct model

🤖 Generated with [Claude Code](https://claude.com/claude-code)
