### PR TITLE
Close a DOM-XSS in `ariel` by removing inline event handlers

### DIFF
--- a/src/osprey/interfaces/ariel/static/js/components.js
+++ b/src/osprey/interfaces/ariel/static/js/components.js
@@ -167,7 +167,7 @@ export function renderEntryCard(entry, isCited = false) {
   }
 
   return `
-    <article class="entry-card${citedClass}" data-entry-id="${escapeHtml(entry.entry_id)}" onclick="window.app.showEntry('${escapeHtml(entry.entry_id)}')">
+    <article class="entry-card${citedClass}" data-entry-id="${escapeHtml(entry.entry_id)}">
       <div class="entry-card-header">
         <div class="entry-card-meta">
           <span class="entry-id">${escapeHtml(entry.entry_id)}</span>
@@ -209,7 +209,7 @@ export function renderAnswerBox(answer, sources = [], mode = 'keyword', toolsUse
   const label = `${modeName} Answer${toolsSuffix}`;
 
   const sourceLinks = sources.map(id =>
-    `<a href="#" onclick="window.app.showEntry('${escapeHtml(id)}'); return false;">${escapeHtml(id)}</a>`
+    `<a href="#" data-entry-id="${escapeHtml(id)}">${escapeHtml(id)}</a>`
   ).join(', ');
 
   return `

--- a/src/osprey/interfaces/ariel/static/js/entries-detail.js
+++ b/src/osprey/interfaces/ariel/static/js/entries-detail.js
@@ -20,6 +20,25 @@ import { isImageAttachment, parseEntryText } from './entries-helpers.js';
 let currentEntry = null;
 
 /**
+ * Wire up delegated click handling for the entry detail modal.
+ *
+ * #entry-modal-body's innerHTML is replaced wholesale on every showEntry()
+ * call, so the listener is delegated on the stable modal-body container
+ * (attached once, at init) instead of bound to the attachment thumbnails
+ * that get discarded on the next render.
+ */
+export function initEntryDetail() {
+  const modalBody = document.getElementById('entry-modal-body');
+  modalBody?.addEventListener('click', (e) => {
+    const thumb = /** @type {HTMLElement} */ (e.target).closest('[data-lightbox-url]');
+    if (!thumb) return;
+    const url = /** @type {HTMLElement} */ (thumb).dataset.lightboxUrl;
+    const name = /** @type {HTMLElement} */ (thumb).dataset.lightboxName;
+    if (url) showImageLightbox(url, name || '');
+  });
+}
+
+/**
  * Show entry detail view.
  * @param {string} entryId - Entry ID
  */
@@ -87,11 +106,10 @@ function renderEntryDetail(container, entry) {
                   if (image) {
                     return `
                     <div class="card" style="width: 150px; cursor: pointer;"
-                         onclick="window.app.showImageLightbox('${escapedUrl}', '${escapedName}')">
+                         data-lightbox-url="${escapedUrl}" data-lightbox-name="${escapedName}">
                       <div class="card-body" style="padding: 12px; text-align: center;">
                         <img src="${escapedUrl}" alt="${escapedName}"
-                             style="width: 126px; height: 100px; object-fit: cover; border-radius: 4px; margin-bottom: 8px;"
-                             onerror="this.outerHTML='<div style=&quot;font-size: 32px; margin-bottom: 8px;&quot;>\u{1F4CE}</div>'">
+                             style="width: 126px; height: 100px; object-fit: cover; border-radius: 4px; margin-bottom: 8px;">
                         <div class="truncate text-sm">${escapedName}</div>
                         <div class="text-xs text-muted">${escapeHtml(att.type || 'image')}</div>
                       </div>
@@ -191,6 +209,17 @@ function renderEntryDetail(container, entry) {
       </div>
     </div>
   `;
+
+  // Broken-image fallback for attachment thumbnails, bound here rather than
+  // as an inline onerror: the `error` event doesn't bubble, so it can't be
+  // handled by the modal-body delegation above, but these <img> elements are
+  // freshly created by the innerHTML assignment on every render, so binding
+  // directly (once each) can never double-bind.
+  container.querySelectorAll('[data-lightbox-url] img').forEach(img => {
+    img.addEventListener('error', () => {
+      img.outerHTML = '<div style="font-size: 32px; margin-bottom: 8px;">\u{1F4CE}</div>';
+    }, { once: true });
+  });
 }
 
 /**
@@ -225,16 +254,28 @@ export function showImageLightbox(url, filename) {
 
   overlay.innerHTML = `
     <img src="${escapeHtml(url)}" alt="${escapeHtml(filename)}"
-         style="max-width: 90vw; max-height: 80vh; object-fit: contain; border-radius: 8px; cursor: default;"
-         onclick="event.stopPropagation()"
-         onerror="this.outerHTML='<div style=&quot;color:white;font-size:1.2rem;&quot;>Failed to load image</div>'">
+         style="max-width: 90vw; max-height: 80vh; object-fit: contain; border-radius: 8px; cursor: default;">
     <div style="margin-top: 16px; display: flex; align-items: center; gap: 16px;">
       <span style="color: silver; font-size: 0.9rem;">${escapeHtml(filename)}</span>
       <a href="${escapeHtml(url)}" target="_blank" rel="noopener"
-         style="color: var(--color-amber); font-size: 0.85rem; text-decoration: none;"
-         onclick="event.stopPropagation()">Open in new tab &#x2197;</a>
+         style="color: var(--color-amber); font-size: 0.85rem; text-decoration: none;">Open in new tab &#x2197;</a>
     </div>
   `;
+
+  // Clicking the image or the "open in new tab" link must not bubble to the
+  // overlay's own click handler (which dismisses the lightbox), and a broken
+  // image needs its fallback markup — all bound directly here (no
+  // delegation) rather than as inline attributes, since these elements are
+  // created fresh on every call, so this can never double-bind. (The `error`
+  // event doesn't bubble, so delegation wouldn't reach it anyway.)
+  const lightboxImg = overlay.querySelector('img');
+  if (lightboxImg) {
+    lightboxImg.addEventListener('click', (e) => e.stopPropagation());
+    lightboxImg.addEventListener('error', () => {
+      lightboxImg.outerHTML = '<div style="color:white;font-size:1.2rem;">Failed to load image</div>';
+    }, { once: true });
+  }
+  overlay.querySelector('a')?.addEventListener('click', (e) => e.stopPropagation());
 
   overlay.addEventListener('click', () => overlay.remove());
   document.addEventListener('keydown', function onKey(e) {
@@ -256,6 +297,7 @@ export function getCurrentEntry() {
 }
 
 export default {
+  initEntryDetail,
   showEntry,
   closeEntryModal,
   showImageLightbox,

--- a/src/osprey/interfaces/ariel/static/js/entries-form.js
+++ b/src/osprey/interfaces/ariel/static/js/entries-form.js
@@ -7,6 +7,7 @@
 
 import { entriesApi, draftsApi, ApiError } from './api.js';
 import { escapeHtml } from './components.js';
+import { showEntry } from './entries-detail.js';
 import { formatFileSize } from './entries-helpers.js';
 import { messageOf } from './utils.js';
 
@@ -99,7 +100,7 @@ export async function handleCreateEntry(e) {
     if (draftBanner) draftBanner.remove();
 
     // Navigate to entry
-    /** @type {any} */ (window).app.showEntry(result.entry_id);
+    showEntry(result.entry_id);
 
   } catch (error) {
     console.error('Failed to create entry:', error);
@@ -154,9 +155,25 @@ function addTag(value) {
   tag.dataset.value = value;
   tag.innerHTML = `
     ${escapeHtml(value)}
-    <button type="button" onclick="this.parentElement.remove()" style="background: none; border: none; cursor: pointer; color: inherit; margin-left: 4px;">&times;</button>
+    <button type="button" data-tag-remove style="background: none; border: none; cursor: pointer; color: inherit; margin-left: 4px;">&times;</button>
   `;
   container.appendChild(tag);
+}
+
+/**
+ * Wire up delegated click handling for tag removal.
+ *
+ * #entry-tags gets new `.tag` chips appended/cleared throughout the form's
+ * lifetime (addTag, loadDraft), so the remove button's listener is
+ * delegated on the stable tags container (attached once, at init) rather
+ * than bound per-chip.
+ */
+export function initEntryTags() {
+  const container = document.getElementById('entry-tags');
+  container?.addEventListener('click', (e) => {
+    const btn = /** @type {HTMLElement} */ (e.target).closest('[data-tag-remove]');
+    btn?.closest('.tag')?.remove();
+  });
 }
 
 /**

--- a/src/osprey/interfaces/ariel/static/js/entries.js
+++ b/src/osprey/interfaces/ariel/static/js/entries.js
@@ -12,13 +12,39 @@ import {
   renderEmptyState,
   renderErrorState,
 } from './components.js';
-import { showEntry, closeEntryModal, showImageLightbox, getCurrentEntry } from './entries-detail.js';
-import { handleCreateEntry, handleTagInput, handleFilePreview, loadDraft } from './entries-form.js';
+import { showEntry, closeEntryModal, showImageLightbox, getCurrentEntry, initEntryDetail } from './entries-detail.js';
+import { handleCreateEntry, handleTagInput, handleFilePreview, loadDraft, initEntryTags } from './entries-form.js';
 
 // Re-export the detail-view and form public surface — app.js and window.app
 // import these from entries.js, so this module stays their single point of entry.
 export { showEntry, closeEntryModal, showImageLightbox, getCurrentEntry };
 export { loadDraft };
+
+/**
+ * Wire up delegated click handling for entry cards and pagination.
+ *
+ * #entries-list's innerHTML is replaced wholesale on every loadEntries()
+ * call, so the listener is delegated on the stable list container
+ * (attached once, at init) instead of bound to child elements that get
+ * discarded on the next render.
+ */
+export function initEntriesListDelegation() {
+  const entriesList = document.getElementById('entries-list');
+  entriesList?.addEventListener('click', (e) => {
+    const target = /** @type {HTMLElement} */ (e.target);
+    const pageBtn = target.closest('[data-page]');
+    if (pageBtn) {
+      const page = parseInt(/** @type {HTMLElement} */ (pageBtn).dataset.page ?? '', 10);
+      if (!Number.isNaN(page)) loadEntries({ page });
+      return;
+    }
+    const card = target.closest('[data-entry-id]');
+    if (card) {
+      const entryId = /** @type {HTMLElement} */ (card).dataset.entryId;
+      if (entryId) showEntry(entryId);
+    }
+  });
+}
 
 /**
  * Initialize entries module.
@@ -35,6 +61,11 @@ export function initEntries() {
   // File input preview
   const fileInput = document.getElementById('entry-files');
   fileInput?.addEventListener('change', handleFilePreview);
+
+  // Delegated handlers for the entries list, the detail modal, and the tags input.
+  initEntriesListDelegation();
+  initEntryDetail();
+  initEntryTags();
 
   // Adapt the publishing section to the configured logbook adapter.
   adaptPublishingSection();
@@ -140,13 +171,13 @@ function renderPagination(currentPage, totalPages) {
   let html = '<div class="pagination" style="display: flex; justify-content: center; gap: 8px; margin-top: 24px;">';
 
   if (currentPage > 1) {
-    html += `<button class="btn btn-secondary btn-sm" onclick="window.app.loadEntriesPage(${currentPage - 1})">Previous</button>`;
+    html += `<button class="btn btn-secondary btn-sm" data-page="${currentPage - 1}">Previous</button>`;
   }
 
   html += `<span class="text-muted" style="padding: 8px;">Page ${currentPage} of ${totalPages}</span>`;
 
   if (currentPage < totalPages) {
-    html += `<button class="btn btn-secondary btn-sm" onclick="window.app.loadEntriesPage(${currentPage + 1})">Next</button>`;
+    html += `<button class="btn btn-secondary btn-sm" data-page="${currentPage + 1}">Next</button>`;
   }
 
   html += '</div>';

--- a/src/osprey/interfaces/ariel/static/js/search.js
+++ b/src/osprey/interfaces/ariel/static/js/search.js
@@ -16,6 +16,7 @@ import {
   escapeHtml,
 } from './components.js';
 import { getCurrentMode, getAdvancedParams, closeAdvancedPanel } from './advanced-options.js';
+import { showEntry } from './entries-detail.js';
 
 /**
  * @typedef {Object} SearchResults
@@ -33,6 +34,33 @@ let currentQuery = '';
 let isSearching = false;
 /** @type {SearchResults|null} */
 let lastResults = null;
+
+/**
+ * Wire up delegated click handling for entry cards and cited-source links.
+ *
+ * #search-results' innerHTML is replaced wholesale on every search, so the
+ * listener is delegated on the stable results container (attached once, at
+ * init) instead of bound to child elements that get discarded on the next
+ * render.
+ */
+export function initSearchResultsDelegation() {
+  const resultsContainer = document.getElementById('search-results');
+  resultsContainer?.addEventListener('click', (e) => {
+    const target = /** @type {HTMLElement} */ (e.target);
+    const sourceLink = target.closest('a[data-entry-id]');
+    if (sourceLink) {
+      e.preventDefault();
+      const entryId = /** @type {HTMLElement} */ (sourceLink).dataset.entryId;
+      if (entryId) showEntry(entryId);
+      return;
+    }
+    const card = target.closest('[data-entry-id]');
+    if (card) {
+      const entryId = /** @type {HTMLElement} */ (card).dataset.entryId;
+      if (entryId) showEntry(entryId);
+    }
+  });
+}
 
 /**
  * Initialize search module.
@@ -69,6 +97,8 @@ export function initSearch() {
       searchInput.blur();
     }
   });
+
+  initSearchResultsDelegation();
 }
 
 /**

--- a/tests/interfaces/ariel/render-xss.test.mjs
+++ b/tests/interfaces/ariel/render-xss.test.mjs
@@ -10,6 +10,17 @@
  *   - showImageLightbox (entries-detail.js, exported directly)
  *   - renderSessionInfoPanel (entries-form.js, via the exported loadDraft)
  *
+ * Task 4.3 extends this file with the onclick -> delegated-listener
+ * conversion's own regression: every site that used to interpolate a value
+ * into an inline `onclick="..."` string (a JS-string-context sink that
+ * escapeHtml's HTML-context escaping cannot make safe — see dom.js) now
+ * carries that value only as a `data-*` attribute, read back via
+ * `.dataset` and never re-parsed as JavaScript. The describes below drive a
+ * JS-string-breakout payload through each converted sink and assert both
+ * halves of the fix: (a) no element anywhere in the rendered surface carries
+ * an `on*` attribute, and (b) the original click behavior still works,
+ * unchanged, via the delegated listener.
+ *
  *   npx vitest run tests/interfaces/ariel/render-xss.test.mjs
  *
  * Runs under happy-dom (vitest.config.js). Only api.js is mocked (the network
@@ -25,13 +36,15 @@ vi.mock('../../../src/osprey/interfaces/ariel/static/js/api.js', async (importOr
     ...actual,
     entriesApi: { ...actual.entriesApi, list: vi.fn(), get: vi.fn() },
     draftsApi: { ...actual.draftsApi, get: vi.fn() },
+    searchApi: { ...actual.searchApi, search: vi.fn() },
   };
 });
 
-import { entriesApi, draftsApi } from '../../../src/osprey/interfaces/ariel/static/js/api.js';
-import { loadEntries } from '../../../src/osprey/interfaces/ariel/static/js/entries.js';
-import { showEntry, showImageLightbox } from '../../../src/osprey/interfaces/ariel/static/js/entries-detail.js';
-import { loadDraft } from '../../../src/osprey/interfaces/ariel/static/js/entries-form.js';
+import { entriesApi, draftsApi, searchApi } from '../../../src/osprey/interfaces/ariel/static/js/api.js';
+import { loadEntries, initEntriesListDelegation } from '../../../src/osprey/interfaces/ariel/static/js/entries.js';
+import { showEntry, showImageLightbox, initEntryDetail } from '../../../src/osprey/interfaces/ariel/static/js/entries-detail.js';
+import { loadDraft, initEntryTags } from '../../../src/osprey/interfaces/ariel/static/js/entries-form.js';
+import { performSearch, initSearchResultsDelegation } from '../../../src/osprey/interfaces/ariel/static/js/search.js';
 
 /**
  * Single-quote-based payload: breaks out of any `"`-quoted HTML attribute
@@ -41,6 +54,19 @@ import { loadDraft } from '../../../src/osprey/interfaces/ariel/static/js/entrie
  * same constant is safe to drive through every sink in this file.
  */
 const PAYLOAD = "'><img src=x onerror=alert(1)>";
+
+/**
+ * The payload that demonstrates the JS-string-context breakout the onclick
+ * conversion (Task 4.3) fixes: reflected unescaped into
+ * `onclick="window.app.showEntry('${id}')"`, the browser HTML-decodes the
+ * attribute *before* the JS parser runs, so this closes the string early and
+ * executes `alert(1)` on click — see the module docstring above. Every
+ * converted sink must now carry it inertly as a `data-*` attribute instead.
+ */
+const JS_BREAKOUT_PAYLOAD = "'-alert(1)-'";
+
+/** Both payload shapes the onclick-conversion tests drive through the converted sinks. */
+const HOSTILE_PAYLOADS = [JS_BREAKOUT_PAYLOAD, PAYLOAD];
 
 /**
  * Assert the PAYLOAD reached `root` as inert text: none of these templates
@@ -63,10 +89,27 @@ function assertPayloadInert(root) {
   expect(el.textContent).toContain(PAYLOAD);
 }
 
-/** Fresh DOM fixture covering every container the five sinks under test read. */
+/**
+ * Assert no element in `root` (inclusive) carries any `on*` attribute —
+ * the direct proof that no interpolated value is reachable as an inline
+ * event-handler string anymore, regardless of how it was escaped.
+ * @param {Element|null} root
+ */
+function assertNoEventHandlerAttributes(root) {
+  expect(root, 'root exists').not.toBeNull();
+  const el = /** @type {Element} */ (root);
+  const all = [el, ...Array.from(el.querySelectorAll('*'))];
+  for (const node of all) {
+    const offenders = node.getAttributeNames().filter(n => n.startsWith('on'));
+    expect(offenders, `<${node.tagName.toLowerCase()}> has no on* attributes`).toEqual([]);
+  }
+}
+
+/** Fresh DOM fixture covering every container the sinks under test read. */
 function mountFixture() {
   document.body.innerHTML = `
     <div id="entries-list"></div>
+    <div id="search-results"></div>
     <div id="entry-modal" class="hidden"><div id="entry-modal-body"></div></div>
     <div id="create-entry-form">
       <div id="entry-tags"></div>
@@ -77,6 +120,14 @@ function mountFixture() {
 
 beforeEach(() => {
   mountFixture();
+  // Attach the delegated listeners once per test, matching production init
+  // (initEntries/initSearch) — the fixture's containers exist before each
+  // render, so this proves the listeners survive the innerHTML replacement
+  // every loadEntries()/showEntry()/performSearch() call performs.
+  initEntriesListDelegation();
+  initEntryDetail();
+  initEntryTags();
+  initSearchResultsDelegation();
   vi.clearAllMocks();
 });
 
@@ -177,5 +228,195 @@ describe('showImageLightbox (entries-detail.js, direct)', () => {
     // `<img src=x ...>` did not parse as a second, live element.
     expect(el.querySelectorAll('img').length, 'exactly one legitimate <img>').toBe(1);
     expect(el.textContent).toContain(PAYLOAD);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Task 4.3: onclick -> delegated-listener conversion. Each describe below
+// covers one converted sink: no on* attribute anywhere, the hostile value
+// round-trips through `.dataset` unmangled, and the original click behavior
+// still fires through the delegated listener attached in beforeEach.
+// ---------------------------------------------------------------------------
+
+describe('entry card (components.js renderEntryCard, via loadEntries + delegated click)', () => {
+  test.each(HOSTILE_PAYLOADS)('carries entry_id %j as data only and dispatches showEntry via the delegated click', async (payload) => {
+    vi.mocked(entriesApi.list).mockResolvedValueOnce({
+      entries: [{
+        entry_id: payload,
+        timestamp: '2026-01-01T00:00:00Z',
+        author: 'author',
+        source_system: 'sys',
+        raw_text: 'body',
+        score: null,
+        attachments: [],
+        keywords: [],
+        highlights: [],
+      }],
+      total: 1,
+      page: 1,
+      total_pages: 1,
+    });
+
+    await loadEntries();
+
+    const list = /** @type {HTMLElement} */ (document.getElementById('entries-list'));
+    assertNoEventHandlerAttributes(list);
+
+    const card = /** @type {HTMLElement|null} */ (list.querySelector('[data-entry-id]'));
+    expect(card, 'entry card rendered').not.toBeNull();
+    // Exact round-trip through dataset — the value is carried as data, never
+    // re-parsed as JavaScript (the bug: escapeHtml's `'` -> `&#39;` decodes
+    // back to a literal `'` inside an inline onclick's JS string, breaking
+    // out of it).
+    expect(/** @type {HTMLElement} */ (card).dataset.entryId).toBe(payload);
+
+    vi.mocked(entriesApi.get).mockResolvedValueOnce({
+      entry_id: payload,
+      timestamp: '2026-01-01T00:00:00Z',
+      author: 'author',
+      source_system: 'sys',
+      raw_text: 'body',
+      keywords: [],
+      attachments: [],
+    });
+
+    /** @type {HTMLElement} */ (card).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    // Proves the click reached the delegated handler AND carried the exact,
+    // unmangled id through — not a JS-string-parsed fragment of it.
+    await vi.waitFor(() => expect(entriesApi.get).toHaveBeenCalledWith(payload));
+  });
+});
+
+describe('pagination (entries.js renderPagination, via delegated click)', () => {
+  test('clicking Next re-loads the next page through the listener attached on #entries-list itself', async () => {
+    vi.mocked(entriesApi.list).mockResolvedValueOnce({
+      entries: [{
+        entry_id: 'e1',
+        timestamp: '2026-01-01T00:00:00Z',
+        author: 'a',
+        source_system: 's',
+        raw_text: 'body',
+        score: null,
+        attachments: [],
+        keywords: [],
+        highlights: [],
+      }],
+      total: 40,
+      page: 1,
+      total_pages: 2,
+    });
+
+    await loadEntries();
+
+    const list = /** @type {HTMLElement} */ (document.getElementById('entries-list'));
+    assertNoEventHandlerAttributes(list);
+
+    const nextBtn = /** @type {HTMLElement|null} */ (list.querySelector('[data-page="2"]'));
+    expect(nextBtn, 'Next button rendered with data-page').not.toBeNull();
+
+    vi.mocked(entriesApi.list).mockResolvedValueOnce({ entries: [], total: 40, page: 2, total_pages: 2 });
+
+    // list.innerHTML was replaced wholesale by the loadEntries() call above —
+    // this click only works if the listener lives on #entries-list itself
+    // (attached once, in beforeEach) rather than on the discarded button.
+    /** @type {HTMLElement} */ (nextBtn).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    await vi.waitFor(() => expect(entriesApi.list).toHaveBeenCalledTimes(2));
+    expect(vi.mocked(entriesApi.list).mock.calls[1][0]).toMatchObject({ page: 2 });
+  });
+});
+
+describe('cited-source link (components.js renderAnswerBox, via performSearch + delegated click)', () => {
+  test.each(HOSTILE_PAYLOADS)('carries source id %j as data only, suppresses navigation, and dispatches showEntry', async (payload) => {
+    vi.mocked(searchApi.search).mockResolvedValueOnce({
+      answer: 'The answer.',
+      sources: [payload],
+      search_modes_used: ['keyword'],
+      execution_time_ms: 5,
+      total_results: 0,
+      entries: [],
+      diagnostics: [],
+    });
+
+    await performSearch('some query');
+
+    const results = /** @type {HTMLElement} */ (document.getElementById('search-results'));
+    assertNoEventHandlerAttributes(results);
+
+    const link = /** @type {HTMLElement|null} */ (results.querySelector('a[data-entry-id]'));
+    expect(link, 'cited-source link rendered').not.toBeNull();
+    expect(/** @type {HTMLElement} */ (link).dataset.entryId).toBe(payload);
+
+    vi.mocked(entriesApi.get).mockResolvedValueOnce({
+      entry_id: payload,
+      timestamp: '2026-01-01T00:00:00Z',
+      author: 'a',
+      source_system: 's',
+      raw_text: 'body',
+      keywords: [],
+      attachments: [],
+    });
+
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    /** @type {HTMLElement} */ (link).dispatchEvent(clickEvent);
+
+    // The link is `href="#"`; the delegated handler must call preventDefault()
+    // to preserve the old inline handler's `return false` (no navigation).
+    expect(clickEvent.defaultPrevented, 'navigation suppressed').toBe(true);
+    await vi.waitFor(() => expect(entriesApi.get).toHaveBeenCalledWith(payload));
+  });
+});
+
+describe('attachment thumbnail (entries-detail.js renderEntryDetail, via showEntry + delegated click)', () => {
+  test.each(HOSTILE_PAYLOADS)('carries lightbox url/filename %j as data only and opens the lightbox via delegated click', async (payload) => {
+    vi.mocked(entriesApi.get).mockResolvedValueOnce({
+      entry_id: 'entry-1',
+      timestamp: '2026-01-01T00:00:00Z',
+      author: 'author',
+      source_system: 'sys',
+      raw_text: 'body',
+      keywords: [],
+      attachments: [{ filename: payload, url: payload, type: 'image/png' }],
+    });
+
+    await showEntry('entry-1');
+
+    const modalBody = /** @type {HTMLElement} */ (document.getElementById('entry-modal-body'));
+    assertNoEventHandlerAttributes(modalBody);
+
+    const thumb = /** @type {HTMLElement|null} */ (modalBody.querySelector('[data-lightbox-url]'));
+    expect(thumb, 'attachment thumbnail rendered').not.toBeNull();
+    expect(/** @type {HTMLElement} */ (thumb).dataset.lightboxUrl).toBe(payload);
+    expect(/** @type {HTMLElement} */ (thumb).dataset.lightboxName).toBe(payload);
+
+    /** @type {HTMLElement} */ (thumb).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    const overlay = document.getElementById('image-lightbox');
+    expect(overlay, 'lightbox overlay opened via delegated click').not.toBeNull();
+    expect(/** @type {Element} */ (overlay).textContent).toContain(payload);
+  });
+});
+
+describe('tag remove button (entries-form.js addTag, via loadDraft + delegated click)', () => {
+  test.each(HOSTILE_PAYLOADS)('renders hostile tag %j with no on* attributes and removes the chip via delegated click', async (payload) => {
+    vi.mocked(draftsApi.get).mockResolvedValueOnce({
+      subject: '', details: '', author: '', logbook: '', shift: '',
+      tags: [payload],
+      metadata: null,
+    });
+
+    await loadDraft('draft-1');
+
+    const tagsContainer = /** @type {HTMLElement} */ (document.getElementById('entry-tags'));
+    assertNoEventHandlerAttributes(tagsContainer);
+
+    expect(tagsContainer.querySelector('.tag'), 'tag chip rendered').not.toBeNull();
+    const removeBtn = /** @type {HTMLElement|null} */ (tagsContainer.querySelector('[data-tag-remove]'));
+    expect(removeBtn, 'tag remove button rendered').not.toBeNull();
+
+    /** @type {HTMLElement} */ (removeBtn).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(tagsContainer.querySelector('.tag'), 'tag chip removed by the delegated click').toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Removes every inline event handler from the `ariel` interface, closing a click-triggered DOM-XSS and bringing the interface onto the same event-handling pattern `tuning` and `channel_finder` already use.

## The problem

Values interpolated into inline `onclick` handlers were escaped with `escapeHtml`. That is HTML-context safe, but **not** JS-string-context safe: a browser HTML-decodes an attribute value *before* the JS parser sees it, so an entity-encoded quote reopens as a literal quote and terminates the handler's string argument early.

An attacker-influenceable value containing a single quote — an ingested entry id, or an uploaded attachment filename — could therefore execute arbitrary script when a user clicked the element. Affected sinks were the entry card, the cited-source links in the answer box, and the attachment thumbnail.

Escaping harder is not the fix here: the value crosses two nested parsing contexts (HTML attribute, then JavaScript string), and `escapeHtml` only addresses the first.

## The fix

Every inline handler is replaced with a delegated listener bound to a stable container, with values carried through `data-*` attributes and read back via `dataset`. **A value carried as a data attribute is never reparsed as JavaScript**, so the vector is removed structurally rather than escaped around.

- Entry cards, cited-source links, attachment thumbnails, pagination controls and tag chips now dispatch through delegated `click` handlers anchored on their static containers (`#entries-list`, `#search-results`, `#entry-modal-body`, `#entry-tags`).
- The two inline image `onerror` fallbacks bind with `addEventListener`.
- The create-entry success path calls `showEntry` directly rather than routing through the `window.app` global.

Behavior is preserved: every element clickable before is clickable after, with the same effect, including navigation suppression on the cited-source links.

## Verification

- `grep -rn 'on[a-z]*=' src/osprey/interfaces/ariel/static/js/` returns nothing — no event-handler attribute is emitted anywhere.
- New tests assert, for hostile payloads, that **no `on*` attribute** appears in the rendered DOM, that payloads round-trip **exactly** through `dataset`, and that click behavior is preserved — including that a delegated listener survives its container's `innerHTML` being re-rendered. These tests fail against the previous implementation.
- `npm run typecheck`, `npm run lint`, `npm run test:js` all green (40 files / 643 tests, up from 634).