### PR TITLE
fix(env): comment out proxy placeholders in env.example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- `env.example` no longer ships uncommented placeholder proxy values. Copying it to `.env` exported an unparseable `HTTP_PROXY`, which broke Claude Code launches and OSPREY's own HTTP clients.
 - The `InContextBackend` benchmark test (the sole real-LLM test outside `tests/e2e/`) moved into `tests/e2e/`, so the fast lane (`pytest tests/ --ignore=tests/e2e`) stays hermetic even when a provider key is exported — previously it made a live LLM call and failed with an unrelated gateway auth error on a blocked/expired key. A placement guard prevents recurrence for the whole credentialed `requires_*` marker family.
 - Web companion servers (Artifacts, ARIEL, Tuning, Channel Finder, Lattice, KNOWLEDGE) no longer skip their launch when a stale or foreign process briefly answers `/health` on their port during a restart, which previously left the panel unbacked and permanently 502ing. The launcher now decides ownership by whether a live TCP listener holds the port, waits out a shutting-down predecessor, and logs distinctly when it defers to a legitimate external server versus when the port is held by an unresponsive one (#327).
 - The session activity page ("Activity" / session log viewer) no longer applies its `?theme=` query parameter directly to the page; an invalid or unexpected value now falls back to the resolved default instead of being written straight into the page's theme attribute.

--- a/env.example
+++ b/env.example
@@ -19,6 +19,7 @@ STANFORD_API_KEY=your-stanford-key        # Stanford AI Playground
 OPENAI_API_KEY=your-openai-key            # OpenAI GPT models
 GOOGLE_API_KEY=your-google-key            # Google Gemini models
 
-# Firewall configuration (optional for container management)
-NO_PROXY=no-proxy-list
-HTTP_PROXY=http-proxy
+# Optional: Proxy settings (uncomment if behind corporate firewall)
+# NO_PROXY=localhost,127.0.0.1
+# HTTP_PROXY=http://proxy.example.com:8080
+# HTTPS_PROXY=http://proxy.example.com:8080


### PR DESCRIPTION
## Problem

The root `env.example` ships two proxy placeholders **uncommented**, with values that are not valid URLs:

```
NO_PROXY=no-proxy-list
HTTP_PROXY=http-proxy
```

Anyone who follows the obvious `cp env.example .env` exports `HTTP_PROXY=http-proxy` into their environment. That breaks three things:

- **Claude Code** refuses to start: `Invalid proxy URL in HTTP_PROXY: "http-proxy" cannot be parsed as a URL.`
- **OSPREY's own HTTP clients**: `httpx` raises `ConnectError`, `requests` raises `ProxyError` — so `osprey query`, Channel Finder and ARIEL fail too.
- **`services/channel_finder/databases/duckdb_import.py`** passes the value to DuckDB as a proxy host.

`inject_provider_env()` copies every key of a project's `.env` into `os.environ` before launching the agent, so the bad value propagates from the file straight into the subprocess environment.

## Fix

Comment the placeholders out and mirror the wording already used by `src/osprey/templates/project/env.example.j2`, which has always had this right. Nothing in the repo reads these variables from the root `.env` — no compose file, no Dockerfile, no script — so commenting them out is inert for existing setups.

## Test plan

- [x] `grep` confirms no compose/Dockerfile/script consumes `HTTP_PROXY`/`NO_PROXY` from the root `.env`
- [x] Verified `HTTP_PROXY=http-proxy` in the environment (not in a `.env`) is what Claude Code rejects
- [x] Verified `httpx` and `requests` both fail with the placeholder value set