### PR TITLE
fix(cli): scrub backend and model selectors before agent launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- A stale `CLAUDE_CODE_USE_BEDROCK` (or other backend/model selector) in the operator's shell no longer reroutes the agent away from the configured provider — these are now scrubbed before launch (#356).
 - `env.example` no longer ships uncommented placeholder proxy values. Copying it to `.env` exported an unparseable `HTTP_PROXY`, which broke Claude Code launches and OSPREY's own HTTP clients.
 - The `InContextBackend` benchmark test (the sole real-LLM test outside `tests/e2e/`) moved into `tests/e2e/`, so the fast lane (`pytest tests/ --ignore=tests/e2e`) stays hermetic even when a provider key is exported — previously it made a live LLM call and failed with an unrelated gateway auth error on a blocked/expired key. A placement guard prevents recurrence for the whole credentialed `requires_*` marker family.
 - Web companion servers (Artifacts, ARIEL, Tuning, Channel Finder, Lattice, KNOWLEDGE) no longer skip their launch when a stale or foreign process briefly answers `/health` on their port during a restart, which previously left the panel unbacked and permanently 502ing. The launcher now decides ownership by whether a live TCP listener holds the port, waits out a shutting-down predecessor, and logs distinctly when it defers to a legitimate external server versus when the port is held by an unresponsive one (#327).

--- a/src/osprey/cli/claude_code_resolver.py
+++ b/src/osprey/cli/claude_code_resolver.py
@@ -73,15 +73,48 @@ AGENT_DEFAULT_TIERS: dict[str, str] = {
 
 # Env vars that settings.json controls — scrubbed from shell before launch
 # so runtime-injected provider vars are authoritative.
+#
+# The rule: scrub every ANTHROPIC_* / CLAUDE_CODE_* var that selects a *backend*
+# or a *model*. A stale one of these reroutes the agent away from the configured
+# provider without any error — the worst failure mode for a framework that talks
+# to control systems. Shared cloud-SDK vars (AWS_REGION, GCLOUD_PROJECT,
+# CLOUD_ML_REGION) are deliberately left alone: they belong to other tooling in
+# the operator's shell, and only reach Claude Code when a CLAUDE_CODE_USE_* flag
+# is set — which is scrubbed here. ANTHROPIC_CUSTOM_HEADERS is likewise left
+# alone: headers cannot redirect the endpoint, so a stale value fails loudly,
+# and it is the only way to supply corporate-proxy headers.
 MANAGED_ENV_VARS = frozenset(
     {
+        # Auth + endpoint
         "ANTHROPIC_API_KEY",
         "ANTHROPIC_AUTH_TOKEN",
         "ANTHROPIC_BASE_URL",
+        # Model selectors (ANTHROPIC_SMALL_FAST_MODEL is deprecated upstream
+        # but still honored; CLAUDE_CODE_SUBAGENT_MODEL overrides AGENT_DEFAULT_TIERS)
         "ANTHROPIC_MODEL",
         "ANTHROPIC_DEFAULT_HAIKU_MODEL",
         "ANTHROPIC_DEFAULT_SONNET_MODEL",
         "ANTHROPIC_DEFAULT_OPUS_MODEL",
+        "ANTHROPIC_DEFAULT_FABLE_MODEL",
+        "ANTHROPIC_SMALL_FAST_MODEL",
+        "CLAUDE_CODE_SUBAGENT_MODEL",
+        # Backend selectors — no OSPREY provider sets these; Bedrock and friends
+        # are reached through a proxy base_url, never Claude Code's native backend.
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_VERTEX",
+        "CLAUDE_CODE_USE_FOUNDRY",
+        "CLAUDE_CODE_USE_MANTLE",
+        # Backend endpoint / auth overrides — inert once the flags above are
+        # scrubbed, cleared anyway so the agent environment carries no stale
+        # backend configuration at all.
+        "ANTHROPIC_BEDROCK_BASE_URL",
+        "ANTHROPIC_VERTEX_BASE_URL",
+        "ANTHROPIC_FOUNDRY_BASE_URL",
+        "ANTHROPIC_FOUNDRY_RESOURCE",
+        "ANTHROPIC_VERTEX_PROJECT_ID",
+        "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
+        "CLAUDE_CODE_SKIP_VERTEX_AUTH",
+        "CLAUDE_CODE_SKIP_FOUNDRY_AUTH",
     }
 )
 

--- a/tests/cli/test_provider_isolation.py
+++ b/tests/cli/test_provider_isolation.py
@@ -17,6 +17,7 @@ from osprey.cli.claude_code_resolver import (
     MANAGED_ENV_VARS,
     ClaudeCodeModelResolver,
     ClaudeCodeModelSpec,
+    inject_provider_env,
 )
 
 # ── MANAGED_ENV_VARS ─────────────────────────────────────────────
@@ -26,13 +27,32 @@ class TestManagedEnvVars:
     """MANAGED_ENV_VARS contains the right vars."""
 
     EXPECTED = {
+        # Auth + endpoint
         "ANTHROPIC_API_KEY",
         "ANTHROPIC_AUTH_TOKEN",
         "ANTHROPIC_BASE_URL",
+        # Model selectors
         "ANTHROPIC_MODEL",
         "ANTHROPIC_DEFAULT_HAIKU_MODEL",
         "ANTHROPIC_DEFAULT_SONNET_MODEL",
         "ANTHROPIC_DEFAULT_OPUS_MODEL",
+        "ANTHROPIC_DEFAULT_FABLE_MODEL",
+        "ANTHROPIC_SMALL_FAST_MODEL",
+        "CLAUDE_CODE_SUBAGENT_MODEL",
+        # Backend selectors
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_VERTEX",
+        "CLAUDE_CODE_USE_FOUNDRY",
+        "CLAUDE_CODE_USE_MANTLE",
+        # Backend endpoint / auth overrides
+        "ANTHROPIC_BEDROCK_BASE_URL",
+        "ANTHROPIC_VERTEX_BASE_URL",
+        "ANTHROPIC_FOUNDRY_BASE_URL",
+        "ANTHROPIC_FOUNDRY_RESOURCE",
+        "ANTHROPIC_VERTEX_PROJECT_ID",
+        "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
+        "CLAUDE_CODE_SKIP_VERTEX_AUTH",
+        "CLAUDE_CODE_SKIP_FOUNDRY_AUTH",
     }
 
     def test_contains_expected(self):
@@ -42,6 +62,106 @@ class TestManagedEnvVars:
         """Provider-specific secret keys should NOT be in the managed set."""
         assert "CBORG_API_KEY" not in MANAGED_ENV_VARS
         assert "ALS_APG_API_KEY" not in MANAGED_ENV_VARS
+
+    def test_excludes_shared_cloud_sdk_vars(self):
+        """Cloud-SDK vars are shared with non-Claude tooling in the same shell.
+
+        They only affect Claude Code when a CLAUDE_CODE_USE_* backend flag is
+        set, and that flag is scrubbed. Clearing them would break boto3, gcloud,
+        and anything else the operator runs alongside the agent.
+        """
+        for var in ("AWS_REGION", "GCLOUD_PROJECT", "CLOUD_ML_REGION"):
+            assert var not in MANAGED_ENV_VARS
+
+    def test_excludes_custom_headers(self):
+        """ANTHROPIC_CUSTOM_HEADERS is additive, not a selector.
+
+        Headers cannot redirect the endpoint, so a stale value fails loudly
+        (401 against the configured provider) rather than silently rerouting.
+        It is also the only way to add corporate-proxy headers, since env_block
+        has no key for them — so OSPREY passes it through.
+        """
+        assert "ANTHROPIC_CUSTOM_HEADERS" not in MANAGED_ENV_VARS
+
+
+# ── Backend / model selector scrubbing (#356) ────────────────────
+
+
+class TestBackendSelectorScrubbing:
+    """A stale backend selector must not survive into the agent's environment.
+
+    Regression guard for #356: a leftover ``export CLAUDE_CODE_USE_BEDROCK=1``
+    in an operator's shell profile silently routed the whole agent — main model
+    and subagents — to a different backend than the project configured.
+    """
+
+    BACKEND_SELECTORS = [
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_VERTEX",
+        "CLAUDE_CODE_USE_FOUNDRY",
+        "CLAUDE_CODE_USE_MANTLE",
+    ]
+
+    MODEL_SELECTORS = [
+        "CLAUDE_CODE_SUBAGENT_MODEL",
+        "ANTHROPIC_DEFAULT_FABLE_MODEL",
+        "ANTHROPIC_SMALL_FAST_MODEL",
+    ]
+
+    BACKEND_OVERRIDES = [
+        "ANTHROPIC_BEDROCK_BASE_URL",
+        "ANTHROPIC_VERTEX_BASE_URL",
+        "ANTHROPIC_FOUNDRY_BASE_URL",
+        "ANTHROPIC_FOUNDRY_RESOURCE",
+        "ANTHROPIC_VERTEX_PROJECT_ID",
+        "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
+        "CLAUDE_CODE_SKIP_VERTEX_AUTH",
+        "CLAUDE_CODE_SKIP_FOUNDRY_AUTH",
+    ]
+
+    @pytest.mark.parametrize("var", BACKEND_SELECTORS + MODEL_SELECTORS + BACKEND_OVERRIDES)
+    def test_stale_selector_is_scrubbed(self, var):
+        spec = ClaudeCodeModelResolver.resolve({"provider": "anthropic"})
+        environ = {"ANTHROPIC_API_KEY": "secret-123", var: "1"}
+
+        inject_provider_env(environ, spec)
+
+        assert var not in environ
+
+    def test_all_selectors_scrubbed_together(self):
+        """The realistic case: a shell profile that configured Bedrock wholesale."""
+        spec = ClaudeCodeModelResolver.resolve({"provider": "anthropic"})
+        environ = {
+            "ANTHROPIC_API_KEY": "secret-123",
+            "CLAUDE_CODE_USE_BEDROCK": "1",
+            "CLAUDE_CODE_SKIP_BEDROCK_AUTH": "1",
+            "ANTHROPIC_BEDROCK_BASE_URL": "https://gateway.internal/bedrock",
+            "CLAUDE_CODE_SUBAGENT_MODEL": "some-other-model",
+            "AWS_REGION": "us-west-2",
+        }
+
+        inject_provider_env(environ, spec)
+
+        assert "CLAUDE_CODE_USE_BEDROCK" not in environ
+        assert "CLAUDE_CODE_SKIP_BEDROCK_AUTH" not in environ
+        assert "ANTHROPIC_BEDROCK_BASE_URL" not in environ
+        assert "CLAUDE_CODE_SUBAGENT_MODEL" not in environ
+        # Project auth survives, re-injected after the scrub:
+        assert environ["ANTHROPIC_API_KEY"] == "secret-123"
+        # Shared cloud-SDK var is left alone for other tooling:
+        assert environ["AWS_REGION"] == "us-west-2"
+
+    def test_custom_headers_survive(self):
+        """Corporate-proxy headers are passed through, not scrubbed."""
+        spec = ClaudeCodeModelResolver.resolve({"provider": "anthropic"})
+        environ = {
+            "ANTHROPIC_API_KEY": "secret-123",
+            "ANTHROPIC_CUSTOM_HEADERS": "X-Corp-Trace: abc123",
+        }
+
+        inject_provider_env(environ, spec)
+
+        assert environ["ANTHROPIC_CUSTOM_HEADERS"] == "X-Corp-Trace: abc123"
 
 
 # ── Auth field passthrough ───────────────────────────────────────


### PR DESCRIPTION
Closes #356.

## Problem

`MANAGED_ENV_VARS` scrubbed auth and the three tier-model variables, but left Claude Code's **backend selectors** untouched. A stale `export CLAUDE_CODE_USE_BEDROCK=1` in an operator's shell profile silently routed the whole agent — main model and subagents — to a different backend than the project configured, regardless of the model IDs OSPREY injects.

For a framework whose invariant is that the project's provider configuration is authoritative, and which is deployed against control systems, silently talking to a different backend is the wrong failure mode.

## Scope correction vs. the issue

The issue named five variables. Verifying each against the current Claude Code docs changed the list in two ways:

**The list was incomplete.** Also honored, also unscrubbed: `CLAUDE_CODE_USE_MANTLE`, `ANTHROPIC_DEFAULT_FABLE_MODEL`, `ANTHROPIC_SMALL_FAST_MODEL` (deprecated upstream, still read), the three `ANTHROPIC_*_BASE_URL` endpoint overrides, `ANTHROPIC_FOUNDRY_RESOURCE`, `ANTHROPIC_VERTEX_PROJECT_ID`, and the three `CLAUDE_CODE_SKIP_*_AUTH` flags. `ANTHROPIC_DEFAULT_FABLE_MODEL` is the notable one — the same class as the three tier variables already scrubbed, simply missed.

**One variable on the issue's list should not be scrubbed.** `ANTHROPIC_CUSTOM_HEADERS` is additive, not a selector. Headers cannot redirect an endpoint, so a stale value produces a loud 401 against the *configured* provider rather than the silent misroute this issue is about. It is also the only way to supply corporate-proxy headers, since `env_block` has no key for them. Scrubbing it would remove a working capability to defend against a failure mode it cannot cause. Left as passthrough, with a regression test.

## The rule

Scrub every `ANTHROPIC_*` / `CLAUDE_CODE_*` variable that selects a **backend** or a **model**. Never touch shared cloud-SDK variables (`AWS_REGION`, `GCLOUD_PROJECT`, `CLOUD_ML_REGION`) — they belong to other tooling in the same shell, and only reach Claude Code when a `CLAUDE_CODE_USE_*` flag is set, which is now scrubbed.

No OSPREY provider sets any of these: Bedrock and friends are reached through a proxy `base_url`, never Claude Code's native backend. So nothing in the framework depends on them surviving.

## Tests

Behavioral, per the issue — asserting on the environ dict after `inject_provider_env()`, not just on the `EXPECTED` frozenset:

- parametrized scrub assertion over all 15 newly-managed variables
- a combined case modelling a shell profile that configured Bedrock wholesale, asserting project auth is re-injected and `AWS_REGION` survives
- passthrough guards for `ANTHROPIC_CUSTOM_HEADERS` and the shared cloud-SDK variables, so a future over-scrub fails

Full unit suite: 6165 passed. The only failures on my machine are `tests/services/ariel_search` embedding tests, which need a locally-pulled Ollama model and never import the changed module.

## Follow-ups (unchanged by this PR)

Scrubbing does not defend against these variables appearing in a settings-file `env` block — that is #355.