### PR TITLE
docs: overhaul the GitHub landing page

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,71 @@
+name: Bug report
+description: Report something that does not work as documented.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. If this is a **security or safety issue** — an approval gate
+        that can be bypassed, a hook that fails open, or a leaked credential — please do not
+        file it here. Follow the [security policy](https://github.com/als-apg/osprey/blob/main/SECURITY.md)
+        instead.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you expect, and what did you get instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: >-
+        A reproduction using the Mock connector is far easier for us to act on than one
+        requiring live hardware. Include the command you ran.
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Osprey version
+      description: "Output of `osprey --version`."
+      placeholder: "2026.6.2"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: connector
+    attributes:
+      label: Connector
+      options:
+        - Mock
+        - EPICS
+        - Custom / other
+        - Not applicable
+    validations:
+      required: true
+
+  - type: input
+    id: provider
+    attributes:
+      label: Model provider and model
+      description: Which provider and model were configured when this occurred?
+      placeholder: "anthropic / claude-opus-4-8"
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: >-
+        Paste any error output or agent transcript. Please redact API keys and any
+        facility-internal channel names you would rather not publish.
+      render: shell
+    validations:
+      required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,13 @@ Compatibility is documented in release notes, not encoded in the version string.
 - **KNOWLEDGE web panel** — a read-only browser panel over a facility-knowledge (OKF) bundle: concept tree, markdown reader, substring search, and a bundle-health summary, served as the `KNOWLEDGE` tab in the Web Terminal (the `okf` builtin panel). Reads the bundle configured at `facility_knowledge.bundle_path`.
 - **Multi-turn agent sessions** — `agent_session(...)` holds one agent conversation open across several turns so a caller can decide each message from the agent's previous reply, with per-turn and cumulative cost tracking and a session-wide budget; `run_turns(...)` is a convenience for a fixed prompt sequence. The single-turn `osprey query` path (`run_query`) is unchanged and now shares the same provider-routing and stream-parsing code.
 
+- `CITATION.cff`, enabling GitHub's "Cite this repository" button.
+- `SECURITY.md` documenting private vulnerability reporting, plus a bug-report issue template.
+- `NOTICE`, carrying the Berkeley Lab endorsement clause, Enhancements grant, and U.S. Government rights notice that previously sat inside `LICENSE.txt`. The licensing terms are unchanged; `LICENSE.txt` is now the unmodified BSD 3-Clause text, so automated tooling identifies the license correctly.
+
 ### Changed
 
+- README rewritten: corrected the connector claim (EPICS and Mock ship in-tree; other stacks use the connector interface), fixed the `osprey skills install` quickstart command, and removed stale release and conference notices. The PyPI package description now matches the documentation.
 - The Web Terminal and ARIEL settings drawers now share one accessible `<osprey-drawer>` component (focus trap and restore, `Escape`/backdrop close, screen-reader dialog semantics, inert background); each interface keeps its own look, and the Web Terminal drawer's tabs, resizing, and unsaved-changes guard behave as before.
 - The Web Terminal's first-run theme default changed from forced-dark to `auto`; use the in-app theme toggle if you want a fixed theme regardless of OS preference.
 - All web interface factories now share one app-setup helper for CORS, middleware, and static mounts; the Lattice dashboard picks up the standardized CORS policy and two request middlewares it was previously missing.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,45 @@
+cff-version: 1.2.0
+message: "If you use Osprey in your research, please cite the article below."
+title: "Osprey"
+abstract: >-
+  An agentic interface and safety harness for safety-critical control systems,
+  built for particle accelerators, fusion experiments, beamlines, and large
+  scientific facilities.
+type: software
+license: BSD-3-Clause
+repository-code: "https://github.com/als-apg/osprey"
+url: "https://als-apg.github.io/osprey/"
+keywords:
+  - agents
+  - control-systems
+  - accelerator-physics
+  - epics
+  - human-in-the-loop
+authors:
+  - family-names: Hellert
+    given-names: Thorsten
+    affiliation: Lawrence Berkeley National Laboratory
+  - family-names: Montenegro
+    given-names: João
+  - family-names: Sulc
+    given-names: Antonin
+
+preferred-citation:
+  type: article
+  title: "Osprey: Production-ready agentic AI for safety-critical control systems"
+  authors:
+    - family-names: Hellert
+      given-names: Thorsten
+      affiliation: Lawrence Berkeley National Laboratory
+    - family-names: Montenegro
+      given-names: João
+    - family-names: Sulc
+      given-names: Antonin
+  journal: "APL Machine Learning"
+  year: 2026
+  month: 2
+  volume: 4
+  issue: 1
+  start: "016103"
+  doi: "10.1063/5.0306302"
+  url: "https://doi.org/10.1063/5.0306302"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,44 +1,28 @@
 BSD 3-Clause License
 
-Osprey Framework Copyright (c) 2025, The Regents of the University of California,
-through Lawrence Berkeley National Laboratory (subject to receipt of
-any required approvals from the U.S. Dept. of Energy). All rights reserved.
+Copyright (c) 2025, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy). All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-(1) Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-(2) Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-(3) Neither the name of the University of California, Lawrence Berkeley
-National Laboratory, U.S. Dept. of Energy nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
-
-You are under no obligation whatsoever to provide any bug fixes, patches,
-or upgrades to the features, functionality or performance of the source
-code ("Enhancements") to anyone; however, if you choose to make your
-Enhancements available either publicly, or directly to Lawrence Berkeley
-National Laboratory, without imposing a separate written license agreement
-for such Enhancements, then you hereby grant the following license: a
-non-exclusive, royalty-free perpetual license to install, use, modify,
-prepare derivative works, incorporate into other computer software,
-distribute, and sublicense such enhancements or derivative works thereof,
-in binary and source code form.
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,50 @@
+Osprey Framework
+
+Copyright (c) 2025, The Regents of the University of California, through Lawrence
+Berkeley National Laboratory (subject to receipt of any required approvals from the
+U.S. Dept. of Energy). All rights reserved.
+
+Osprey Framework is licensed under the BSD 3-Clause License. See LICENSE.txt.
+
+The notices below accompany that license.
+
+
+Endorsement
+-----------
+
+Neither the name of the University of California, Lawrence Berkeley National
+Laboratory, U.S. Dept. of Energy nor the names of its contributors may be used to
+endorse or promote products derived from this software without specific prior
+written permission.
+
+
+Enhancements
+------------
+
+You are under no obligation whatsoever to provide any bug fixes, patches, or
+upgrades to the features, functionality or performance of the source code
+("Enhancements") to anyone; however, if you choose to make your Enhancements
+available either publicly, or directly to Lawrence Berkeley National Laboratory,
+without imposing a separate written license agreement for such Enhancements, then
+you hereby grant the following license: a non-exclusive, royalty-free perpetual
+license to install, use, modify, prepare derivative works, incorporate into other
+computer software, distribute, and sublicense such enhancements or derivative works
+thereof, in binary and source code form.
+
+
+U.S. Government rights
+----------------------
+
+NOTICE. This Software was developed under funding from the U.S. Department of Energy
+and the U.S. Government consequently retains certain rights. As such, the U.S.
+Government has been granted for itself and others acting on its behalf a paid-up,
+nonexclusive, irrevocable, worldwide license in the Software to reproduce, distribute
+copies to the public, prepare derivative works, and perform publicly and display
+publicly, and to permit others to do so.
+
+
+Contact
+-------
+
+If you have questions about your rights to use or distribute this software, please
+contact Berkeley Lab's Intellectual Property Office at IPO@lbl.gov.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,25 @@
-# Osprey Framework
+# Osprey
 
-[![CI](https://github.com/als-apg/osprey/workflows/CI/badge.svg)](https://github.com/als-apg/osprey/actions/workflows/ci.yml)
-[![Documentation](https://readthedocs.org/projects/osprey-framework/badge/?version=latest)](https://als-apg.github.io/osprey/)
-[![codecov](https://codecov.io/gh/als-apg/osprey/branch/main/graph/badge.svg)](https://codecov.io/gh/als-apg/osprey)
-[![PyPI version](https://badge.fury.io/py/osprey-framework.svg)](https://badge.fury.io/py/osprey-framework)
+[![CI](https://github.com/als-apg/osprey/actions/workflows/ci.yml/badge.svg)](https://github.com/als-apg/osprey/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/osprey-framework)](https://pypi.org/project/osprey-framework/)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
-[![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+[![License: BSD 3-Clause](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](LICENSE.txt)
+[![DOI](https://img.shields.io/badge/DOI-10.1063%2F5.0306302-blue)](https://doi.org/10.1063/5.0306302)
 
-**🎉 Latest Release: v2026.6.2** - Open & self-hosted model support: run the agent on any OpenAI-protocol model as a configuration change, with a new model-capability benchmark; plus facility-timezone unification, ARIEL publishing fixes, and hardening
+**An agentic interface and safety harness for safety-critical control systems.**
 
-> **🚧 Early Access Release**
-> This is an early access version of the Osprey Framework. While the core functionality is stable and ready for experimentation, documentation and APIs may still evolve. We welcome feedback and contributions!
+Osprey addresses control-specific challenges: semantic addressing across large channel
+namespaces, protocol-agnostic integration with control stacks, intelligent logbook search
+across facility electronic logbooks, and mandatory human oversight for every hardware write.
 
-A production-ready framework for deploying agentic AI in large-scale, safety-critical control system environments—particle accelerators, fusion experiments, beamlines, and complex scientific facilities.
+Built for particle accelerators, fusion experiments, beamlines, and large scientific facilities.
 
-**📄 Research**
-This work was presented as a contributed oral presentation at [ICALEPCS'25](https://indico.jacow.org/event/86/overview) and will be featured at the [Machine Learning and the Physical Sciences Workshop](https://ml4physicalsciences.github.io/2025/) at NeurIPS 2025.
+<p align="center">
+  <img src="docs/source/_static/resources/architecture.png" width="100%"
+       alt="Osprey system architecture, from operator to facility, with the safety gate and approval workflow in-line." />
+</p>
 
-
-## 🚀 Quick Start
+## Quick start
 
 ```bash
 # Install the framework as a standalone CLI tool (using uv, recommended)
@@ -31,89 +32,64 @@ cd quickstart
 # If API keys aren't already in your environment, copy and edit .env:
 # cp .env.example .env
 
-# Start a Claude Code agent session
+# Start an agent session
 claude
 ```
 
-For a production project tailored to your detector, beamline, or accelerator
-subsystem, install the guided osprey-build-interview skill and run it from Claude Code:
+For a project tailored to your detector, beamline, or accelerator subsystem, install the
+guided build-interview skill and run it from your agent session:
 
 ```bash
-# Install the /osprey-build-interview skill into ~/.claude/skills/
-uv run osprey skills install osprey-build-interview
+osprey skills install osprey-build-interview
 ```
 
-Then start Claude Code in an empty directory and type `/osprey-build-interview`. The
-skill walks you through a guided conversation, produces a build profile, and
+Then start the agent in an empty directory and type `/osprey-build-interview`. The skill
+walks you through a guided conversation, produces a build profile, and
 `osprey build profile.yml` generates a ready-to-use project.
 
+## Key features
 
-## 📚 Documentation
+- **Agent-driven orchestration** — Skills, MCP tools, and explicit dependency declarations
+  let the Osprey agent decompose operator requests into auditable steps with mandatory
+  approval gates.
+- **Control-system safety** — Pattern detection, channel boundary checking, and mandatory
+  human approval for every hardware write.
+- **Protocol-agnostic integration** — EPICS and Mock connectors ship in-tree; LabVIEW, Tango,
+  and other stacks connect through the
+  [connector interface](https://als-apg.github.io/osprey/how-to/add-connector.html).
+- **Replaceable backends** — The agent harness, the underlying model, and the compute backend
+  are each swappable by configuration, without changing what the operator sees.
+- **Scalable capability management** — Dynamic classification prevents prompt explosion as
+  toolsets grow.
 
-**[📖 Read the Full Documentation →](https://als-apg.github.io/osprey)**
+## Documentation
 
-### 🧪 Testing
+**[Read the full documentation →](https://als-apg.github.io/osprey)**
 
-```bash
-# Run unit tests (fast, no API keys required)
-pytest tests/ --ignore=tests/e2e -v
+Osprey follows CalVer (`vYYYY.M.P`). Public APIs may change between releases — pin a version
+and check the [changelog](CHANGELOG.md) before upgrading.
 
-# Run e2e tests (slow, requires API keys)
-# ⚠️ IMPORTANT: Use 'pytest tests/e2e/' NOT 'pytest -m e2e'
-pytest tests/e2e/ -v
-```
+## Contributing
 
-See [tests/e2e/README.md](tests/e2e/README.md) and the [Contributing Guide](https://als-apg.github.io/osprey/contributing/) for details.
+Contributions are welcome. See the [Contributing Guide](CONTRIBUTING.md) for development
+setup, coding standards, and the pull-request workflow. To report a security issue, please
+follow the [security policy](SECURITY.md) rather than opening a public issue.
 
+## Citation
 
-## Key Features
+If you use Osprey in your research, please cite the
+[paper](https://doi.org/10.1063/5.0306302). GitHub's **Cite this repository** button, in the
+sidebar, exports BibTeX and APA directly.
 
-- **Agent-Driven Orchestration** - Skills, MCP tools, and explicit dependency declarations let the Osprey agent decompose operator requests into auditable steps with mandatory approval gates
-- **Control-System Safety** - Pattern detection, PV boundary checking, and mandatory approval for hardware writes
-- **Protocol-Agnostic Integration** - Seamless connection to EPICS, LabVIEW, Tango, and mock environments
-- **Scalable Capability Management** - Dynamic classification prevents prompt explosion as toolsets grow
-- **Production-Proven** - Deployed at major facilities including LBNL's Advanced Light Source accelerator
+## License
 
----
+BSD 3-Clause — see [LICENSE.txt](LICENSE.txt). Additional notices, including the
+U.S. Department of Energy's retained rights and Berkeley Lab's Enhancements grant, are in
+[NOTICE](NOTICE).
 
-## 📖 Citation
+Copyright (c) 2025, The Regents of the University of California, through Lawrence Berkeley
+National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of
+Energy). All rights reserved.
 
-If you use the Osprey Framework in your research or projects, please cite our [paper](https://doi.org/10.1063/5.0306302):
-
-```bibtex
-@article{10.1063/5.0306302,
-      author = {Hellert, Thorsten and Montenegro, João and Sulc, Antonin},
-      title = {Osprey: Production-ready agentic AI for safety-critical control systems},
-      journal = {APL Machine Learning},
-      volume = {4},
-      number = {1},
-      pages = {016103},
-      year = {2026},
-      month = {02},
-      doi = {10.1063/5.0306302},
-      url = {https://doi.org/10.1063/5.0306302},
-}
-```
-
----
-
-*For detailed installation instructions, tutorials, and API reference, please visit our [complete documentation](https://als-apg.github.io/osprey).*
-
----
-
-**Copyright Notice**
-
-Osprey Framework Copyright (c) 2025, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy). All rights reserved.
-
-If you have questions about your rights to use or distribute this software,
-please contact Berkeley Lab's Intellectual Property Office at
-IPO@lbl.gov.
-
-NOTICE.  This Software was developed under funding from the U.S. Department
-of Energy and the U.S. Government consequently retains certain rights.  As
-such, the U.S. Government has been granted for itself and others acting on
-its behalf a paid-up, nonexclusive, irrevocable, worldwide license in the
-Software to reproduce, distribute copies to the public, prepare derivative
-works, and perform publicly and display publicly, and to permit others to do so.
-
----
+Questions about your rights to use or distribute this software: contact Berkeley Lab's
+Intellectual Property Office at IPO@lbl.gov.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+Osprey mediates access to control systems that can move real hardware. A defect in the
+approval chain, the safety hooks, or a connector's write path is a safety issue as much as a
+security one. Please report those privately.
+
+## Reporting a vulnerability
+
+**Do not open a public issue.** Use GitHub's private vulnerability reporting:
+
+**[Report a vulnerability →](https://github.com/als-apg/osprey/security/advisories/new)**
+
+The report stays private between you and the maintainers until an advisory is published.
+
+Please include, as far as you are able:
+
+- What the issue allows an attacker or an unattended agent to do.
+- The affected version, and the connector and model provider in use.
+- A minimal reproduction. A Mock-connector reproduction is preferred over one that requires
+  live hardware.
+
+Reports are handled on a best-effort basis by a small team. We will acknowledge your report
+and keep you informed as we investigate; we do not commit to a fixed response deadline.
+
+## Scope
+
+In scope:
+
+- Bypasses of the human-approval gate for hardware writes.
+- Hooks that fail open — a guard that silently does nothing rather than blocking.
+- Privilege escalation through MCP servers, the Python executor sandbox, or the runtime API.
+- Credential or secret leakage through logs, artifacts, or agent transcripts.
+
+Out of scope:
+
+- Findings that require an operator to have already granted the agent write permission and
+  approved the write. That is the system working as designed.
+- Prompt injection that produces an *unapproved* action being *proposed*. Osprey's threat
+  model assumes model output is untrusted; the approval gate is the control. A finding is
+  in scope if injection causes an action to be **executed** without approval.
+- Vulnerabilities in an upstream model provider, EPICS itself, or other third-party
+  dependencies. Please report those to the relevant project, though we appreciate a
+  heads-up if Osprey's usage makes the impact worse.
+
+## Supported versions
+
+Osprey follows CalVer (`vYYYY.M.P`). Security fixes land on `main` and ship in the next
+release. Older releases are not backported.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 Osprey Framework Documentation
 ================================
 
-**An agentic interface for safety-critical control systems.**
+**An agentic interface and safety harness for safety-critical control systems.**
 
 .. admonition:: New architecture (April 2026)
 
@@ -60,12 +60,6 @@ Documentation Structure
 
       Development setup, coding standards, testing guidelines, and the
       contribution workflow.
-
-
-Proven in Production
---------------------
-
-Osprey is deployed at Lawrence Berkeley National Laboratory's Advanced Light Source, managing tens of thousands of control channels across accelerator operations.
 
 
 .. dropdown:: Citation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "osprey-framework"
 dynamic = ["version"]
-description = "An open-source, domain-agnostic, capability-based architecture for building intelligent agents"
+description = "An agentic interface and safety harness for safety-critical control systems"
 readme = "README.md"
 requires-python = ">=3.11"
 license = {text = "BSD-3-Clause"}
@@ -18,7 +18,7 @@ maintainers = [
 keywords = [
     "ai", "agents", "framework", "scientific-computing",
     "epics", "accelerator-physics", "als", "berkeley", "agent-framework",
-    "capability-based", "human-in-the-loop", "container-orchestration"
+    "control-systems", "mcp", "human-in-the-loop", "container-orchestration"
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
The repository's GitHub surface had never been maintained, while the documentation site had. This brings the landing page up to the same standard and fixes several claims that were wrong rather than merely stale.

## Accuracy fixes

- **The connector claim was false.** The README advertised "seamless connection to EPICS, LabVIEW, Tango," while the docs correctly state that EPICS and Mock ship in-tree and other stacks require a custom connector. Corrected to match.
- **The quickstart did not work.** It instructed `uv tool install osprey-framework` followed by `uv run osprey skills install …`, which fails outside a uv project. Now `osprey skills install …`.
- **Two badges rendered the word `unknown`.** The Documentation badge pointed at a ReadTheDocs project that does not exist (docs are built by Actions and served from GitHub Pages), and codecov has no data. Both removed. The CI badge used a legacy URL form and now points at `ci.yml`. Every remaining badge was checked to render a real value.
- **Maturity was asserted three different ways** within sixty lines: an "Early Access" banner, "a production-ready framework," and "Production-Proven — deployed at major facilities." Deployment claims are removed from the README, the Key Features list, and the docs landing page. Stability is now stated once, next to the changelog link.

## Removed because it decays on its own

The pinned `Latest Release: v2026.6.2` line (the PyPI badge reports this automatically and correctly), and the conference notice, which had been in the future tense for eight months. The testing section moves out — it duplicates the contributing guide.

## Added

- `CITATION.cff` — the repository now exposes GitHub's native **Cite this repository** button. Metadata was verified against Crossref rather than copied from the old BibTeX block. The inline BibTeX in the README is now redundant and has been removed; the docs retain theirs.
- `SECURITY.md` — a private disclosure path via GitHub vulnerability reporting, with an explicit threat model. Notably: prompt injection that causes an action to be *proposed* is out of scope, since the approval gate is the control; injection that causes an action to be *executed* without approval is in scope.
- A bug-report issue template that asks for connector, provider, and version, and steers reporters toward Mock-connector reproductions.

## Licence file split

`LICENSE.txt` previously combined the BSD 3-Clause text with Berkeley Lab's Enhancements grant and the U.S. Government rights notice. The extra terms pushed it below GitHub's similarity threshold, so the sidebar reported the licence as `Other`.

`LICENSE.txt` now carries the unmodified BSD 3-Clause text and `NOTICE` carries the additional notices. **The licensing terms are unchanged** — every clause of the original is preserved across the two files. Measured against the SPDX canonical text with the detector's own normalisation, similarity goes from 74% to 100%.

## Follow-up, not in this PR

Two repository settings must be applied by an admin for this to take full effect:

- Set the repository **description** and **topics** — both are currently empty.
- Enable **private vulnerability reporting**, which is where `SECURITY.md` sends reporters.