### PR TITLE
refactor(okf_panel): clear the enforcement ratchet and fix the deep-link highlight

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,8 @@ redundant no-ops; they are harmless and left in place.)
 Each is the single source of truth for its debt and may **only shrink** — a later
 hardening phase's exit criterion is deleting its interface's entries while keeping
 CI green. **New or edited code gets no exemption:** a new `var`, an unused variable,
-a `==`, an over-cap module, or a fresh type error fails CI immediately.
+a genuine loose equality (`==` against anything but `null`), an over-cap module, or a
+fresh type error fails CI immediately.
 
 1. **`@ts-nocheck` type allowlist** — a file that is not yet type-clean carries a
    leading `// @ts-nocheck`. List the allowlist with:
@@ -152,8 +153,8 @@ a `==`, an over-cap module, or a fresh type error fails CI immediately.
      --rule '{"max-lines":["error",{"max":450,"skipComments":true,"skipBlankLines":true}]}' \
      -f json | python3 -c 'import sys,json,os; print("\n".join(sorted({os.path.relpath(f["filePath"]) for f in json.load(sys.stdin) for m in f["messages"] if m.get("ruleId")=="max-lines"})))'
    ```
-3. **Legacy rule-exemption block** — files with grandfathered `no-unused-vars` /
-   `eqeqeq` violations, set to `off` for those files only in `eslint.config.js`.
+3. **Legacy rule-exemption block** — files with grandfathered `no-unused-vars`
+   violations, set to `off` for those files only in `eslint.config.js`.
 
 A localized one-off residual uses an inline `// eslint-disable-next-line <rule> --
 <reason>` at the site instead of a file-wide exemption.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,7 +26,7 @@ export default [
     rules: {
       'no-var': 'error',
       'prefer-const': 'error',
-      eqeqeq: 'error',
+      eqeqeq: ['error', 'always', { null: 'ignore' }],
     },
   },
 
@@ -65,18 +65,6 @@ export default [
       'tests/interfaces/web_terminal/scaffold-view.test.mjs',
     ],
     rules: { 'no-unused-vars': 'off' },
-  },
-  {
-    files: [
-      'src/osprey/interfaces/lattice_dashboard/static/js/render.js',
-      'src/osprey/interfaces/lattice_dashboard/static/js/settings.js',
-      'src/osprey/interfaces/okf_panel/static/js/app.js',
-      'src/osprey/interfaces/web_terminal/static/js/mcp-renderer.js',
-      'src/osprey/interfaces/web_terminal/static/js/panel-manager.js',
-      'src/osprey/interfaces/web_terminal/static/js/scaffold/utils.js',
-      'src/osprey/interfaces/web_terminal/static/js/settings.js',
-    ],
-    rules: { eqeqeq: 'off' },
   },
   {
     files: [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,7 @@ import globals from 'globals';
 
 export default [
   // (1) Leading SOLE-KEY global ignore — must be the ONLY key in this object so it applies globally.
-  { ignores: ['**/vendor/**', '**/*.min.js', 'docs/**'] },
+  { ignores: ['**/vendor/**', '**/*.min.js', 'docs/**', '**/.venv/**'] },
 
   // (2) Base recommended rules.
   js.configs.recommended,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -55,7 +55,6 @@ export default [
       'src/osprey/interfaces/artifacts/static/js/print.js',
       'src/osprey/interfaces/design_system/static/js/theme-boot.js',
       'src/osprey/interfaces/design_system/static/js/theme-manager.js',
-      'src/osprey/interfaces/okf_panel/static/js/app.js',
       'src/osprey/interfaces/web_terminal/static/js/app.js',
       'src/osprey/interfaces/web_terminal/static/js/panel-manager.js',
       'src/osprey/interfaces/web_terminal/static/js/session-views.js',

--- a/src/osprey/interfaces/okf_panel/static/js/app.js
+++ b/src/osprey/interfaces/okf_panel/static/js/app.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-// TODO(frontend-hardening Pn): remove & fix types when this interface is retrofitted (P2–P5)
 /*
  * OKF Knowledge Panel — read-only SPA shell.
  *
@@ -34,6 +32,8 @@ import { initTheme } from "/design-system/js/theme-manager.js";
 import { applyEmbedded } from "/design-system/js/frame-params.js";
 import { debounce } from "/design-system/js/dom.js";
 import "/design-system/js/components/osprey-theme-switcher.js";
+import { el, isFallback, readPanelParams, STRUCTURE_MARKER } from "./helpers.js";
+import { initTree, renderTree, highlightActive, highlightStructure, selectConcept } from "./tree.js";
 
 // Panel embedded in the Web Terminal hub: apply the hub's broadcast theme and
 // follow live `osprey-theme-change` messages. theme-boot.js already applied
@@ -43,18 +43,51 @@ initTheme({ role: "follower" });
 
 applyEmbedded();
 
+/**
+ * @typedef {Object} ConceptFrontmatter
+ * @property {string} [title]
+ * @property {string} [description]
+ * @property {unknown[]} [tags]
+ */
+
+/**
+ * Shape of the `/api/concept` response. `okf_panel/app.py` returns a raw
+ * dict with no pydantic response model, so any of these keys may simply be
+ * absent rather than explicitly null.
+ * @typedef {Object} ConceptDoc
+ * @property {string} [id]
+ * @property {ConceptFrontmatter} [frontmatter]
+ * @property {string} [body]
+ */
+
+/**
+ * A single `/api/search` result item.
+ * @typedef {Object} SearchResultItem
+ * @property {string} id
+ * @property {string} [title]
+ * @property {string} [snippet]
+ */
+
+/**
+ * @param {string} id
+ * @returns {HTMLElement}
+ */
+function requireEl(id) {
+  const node = document.getElementById(id);
+  if (!node) throw new Error("okf_panel: missing required element #" + id);
+  return node;
+}
+
 (function () {
   // -- DOM handles -----------------------------------------------------------
-  const treeEl = document.getElementById("tree");
-  const readerEl = document.getElementById("reader-content");
-  const searchForm = document.getElementById("search-form");
-  const searchInput = document.getElementById("search-input");
-  const searchResultsEl = document.getElementById("search-results");
+  const treeEl = requireEl("tree");
+  const readerEl = requireEl("reader-content");
+  const searchForm = requireEl("search-form");
+  const searchInput = /** @type {HTMLInputElement} */ (requireEl("search-input"));
+  const searchResultsEl = requireEl("search-results");
   const structureLink = document.getElementById("structure-link");
 
-  // History marker for the structure overview (B.3): a hash distinct from any
-  // concept id so popstate can tell the overview apart from a concept view.
-  const STRUCTURE_MARKER = "__structure";
+  initTree({ treeEl, structureLink, onSelect: loadConcept });
 
   // -------------------------------------------------------------------------
   // Render hook for task 3.2.
@@ -64,6 +97,9 @@ applyEmbedded();
   // cross-link navigation. Do NOT inline post-render work elsewhere — keep it
   // funnelled through here so 3.2 has a single integration point.
   // -------------------------------------------------------------------------
+  /**
+   * @param {HTMLElement} container
+   */
   function afterRender(container) {
     // Task 3.2: wire cross-link navigation for every anchor in the freshly
     // rendered container. Three classes of href:
@@ -79,7 +115,9 @@ applyEmbedded();
     // data-okf-wired and skip already-marked ones, so this stays correct even if
     // afterRender is ever called twice on the same container.
     if (!container) return;
-    const anchors = container.querySelectorAll("a[href]");
+    const anchors = /** @type {NodeListOf<HTMLElement>} */ (
+      container.querySelectorAll("a[href]")
+    );
     anchors.forEach(function (a) {
       if (a.dataset.okfWired === "1") return;
       const href = a.getAttribute("href") || "";
@@ -116,33 +154,6 @@ applyEmbedded();
     }
   });
 
-  // -- helpers ---------------------------------------------------------------
-
-  function el(tag, attrs, children) {
-    const node = document.createElement(tag);
-    if (attrs) {
-      for (const k in attrs) {
-        if (k === "class") node.className = attrs[k];
-        else if (k === "text") node.textContent = attrs[k];
-        else node.setAttribute(k, attrs[k]);
-      }
-    }
-    if (children) {
-      for (const child of children) {
-        if (child) node.appendChild(child);
-      }
-    }
-    return node;
-  }
-
-  // A fallback (filesystem-derived) concept is one whose title is just the
-  // last path segment of its id — those have no real human title/description.
-  function isFallback(id, title) {
-    if (!id || !title) return false;
-    const last = String(id).split("/").pop();
-    return title === last;
-  }
-
   // -- sidebar / tree --------------------------------------------------------
 
   async function loadTree() {
@@ -151,7 +162,7 @@ applyEmbedded();
       const resp = await fetch("/api/concepts");
       if (!resp.ok) throw new Error("HTTP " + resp.status);
       data = await resp.json();
-    } catch (err) {
+    } catch {
       treeEl.innerHTML = "";
       treeEl.appendChild(
         el("p", { class: "muted", text: "Failed to load concepts." })
@@ -161,84 +172,17 @@ applyEmbedded();
     renderTree(data.groups || []);
   }
 
-  function renderTree(groups) {
-    treeEl.innerHTML = "";
-    for (const group of groups) {
-      const section = el("section", { class: "group" });
-      section.appendChild(
-        el("h2", { class: "group-label", text: group.label || group.id || "" })
-      );
-
-      const concepts = group.concepts || [];
-      if (concepts.length === 0) {
-        section.appendChild(
-          el("p", { class: "muted empty-group", text: "(no concepts)" })
-        );
-      } else {
-        const list = el("ul", { class: "concept-list" });
-        for (const concept of concepts) {
-          const link = el("a", {
-            class: "concept-link",
-            href: "#",
-            text: concept.title || concept.id,
-            title: concept.description || "",
-          });
-          link.dataset.conceptId = concept.id;
-          link.addEventListener("click", function (ev) {
-            ev.preventDefault();
-            selectConcept(concept.id);
-          });
-          const li = el("li", null, [link]);
-          li.dataset.conceptId = concept.id;
-          list.appendChild(li);
-        }
-        section.appendChild(list);
-      }
-      treeEl.appendChild(section);
-    }
-  }
-
-  function highlightActive(id) {
-    if (structureLink) structureLink.classList.remove("active");
-    const links = treeEl.querySelectorAll(".concept-link");
-    let activeLink = null;
-    links.forEach(function (link) {
-      if (link.dataset.conceptId === id) {
-        link.classList.add("active");
-        activeLink = link;
-      } else {
-        link.classList.remove("active");
-      }
-    });
-    // Scroll the active entry into view so the user can always see where they
-    // are in the tree — important when jumping via an in-body cross-link to a
-    // concept far down the (scrolled) sidebar.
-    if (activeLink) activeLink.scrollIntoView({ block: "nearest", inline: "nearest" });
-  }
-
-  // Mark the structure-overview entry active and clear any concept highlight.
-  function highlightStructure() {
-    const links = treeEl.querySelectorAll(".concept-link");
-    links.forEach(function (link) {
-      link.classList.remove("active");
-    });
-    if (structureLink) structureLink.classList.add("active");
-  }
-
-  function selectConcept(id) {
-    // The sidebar highlight is applied authoritatively in renderConcept (which
-    // every navigation path funnels through), so just trigger the load here.
-    loadConcept(id);
-  }
-
   // -- reading pane ----------------------------------------------------------
 
+  /**
+   * @param {string} id
+   */
   async function loadConcept(id) {
     renderMessage("Loading…");
     let resp;
     try {
       resp = await fetch("/api/concept?id=" + encodeURIComponent(id));
-    } catch (err) {
+    } catch {
       renderMessage("Failed to load concept.");
       return;
     }
@@ -255,7 +199,7 @@ applyEmbedded();
     let doc;
     try {
       doc = await resp.json();
-    } catch (err) {
+    } catch {
       renderMessage("Failed to parse concept.");
       return;
     }
@@ -264,6 +208,9 @@ applyEmbedded();
 
   // Single render path for the reading pane — always ends by calling
   // afterRender(readerEl) so task 3.2 has one integration point.
+  /**
+   * @param {ConceptDoc} doc
+   */
   function renderConcept(doc) {
     const fm = doc.frontmatter || {};
     const id = doc.id || "";
@@ -312,7 +259,7 @@ applyEmbedded();
     const bodyEl = el("div", { class: "osprey-md-rendered" });
     try {
       bodyEl.innerHTML = marked.parse(body);
-    } catch (err) {
+    } catch {
       bodyEl.textContent = body;
     }
     readerEl.appendChild(bodyEl);
@@ -320,6 +267,9 @@ applyEmbedded();
     afterRender(readerEl);
   }
 
+  /**
+   * @param {string} msg
+   */
   function renderMessage(msg) {
     readerEl.innerHTML = "";
     readerEl.appendChild(el("p", { class: "muted", text: msg }));
@@ -331,6 +281,9 @@ applyEmbedded();
   // Fetches /api/structure (a markdown document) and renders it into the
   // reading pane as an .osprey-md-rendered container. Its concept links are in
   // the /<id>.md form, so afterRender() wires them as in-panel navigation.
+  /**
+   * @param {{push?: boolean}} [opts]
+   */
   async function loadStructure(opts) {
     const push = !opts || opts.push !== false;
     highlightStructure();
@@ -341,7 +294,7 @@ applyEmbedded();
       const resp = await fetch("/api/structure");
       if (!resp.ok) throw new Error("HTTP " + resp.status);
       data = await resp.json();
-    } catch (err) {
+    } catch {
       renderMessage("Failed to load knowledge base overview.");
       return;
     }
@@ -351,7 +304,7 @@ applyEmbedded();
     const md = data.markdown != null ? String(data.markdown) : "";
     try {
       container.innerHTML = marked.parse(md);
-    } catch (err) {
+    } catch {
       container.textContent = md;
     }
     readerEl.appendChild(container);
@@ -369,6 +322,9 @@ applyEmbedded();
     searchResultsEl.innerHTML = "";
   }
 
+  /**
+   * @param {string} query
+   */
   async function runSearch(query) {
     const q = (query || "").trim();
     if (!q) {
@@ -381,7 +337,7 @@ applyEmbedded();
       const resp = await fetch("/api/search?q=" + encodeURIComponent(q));
       if (!resp.ok) throw new Error("HTTP " + resp.status);
       data = await resp.json();
-    } catch (err) {
+    } catch {
       searchResultsEl.hidden = false;
       searchResultsEl.innerHTML = "";
       searchResultsEl.appendChild(
@@ -392,6 +348,9 @@ applyEmbedded();
     renderSearchResults(data.results || []);
   }
 
+  /**
+   * @param {SearchResultItem[]} results
+   */
   function renderSearchResults(results) {
     searchResultsEl.hidden = false;
     searchResultsEl.innerHTML = "";
@@ -460,7 +419,7 @@ applyEmbedded();
       const resp = await fetch("/api/bundle_health");
       if (!resp.ok) throw new Error("HTTP " + resp.status);
       data = await resp.json();
-    } catch (err) {
+    } catch {
       footer.hidden = true;
       return;
     }
@@ -488,32 +447,6 @@ applyEmbedded();
         })
       );
     }
-  }
-
-  // -- panel parameters / deep-link (osprey addition) ------------------------
-  //
-  // Generalizable panel-parameter shape. Today the only param is the deep-link
-  // target carried in the panel's OWN URL hash (e.g. "#control-system/channel-
-  // finding"). Keeping this as a small structured reader — rather than one-off
-  // hash parsing scattered through boot — is deliberate: when the framework-wide
-  // iframe URL-parameter convention lands (uniform theme / deep-link target /
-  // etc. for every embedded panel), this one function is where it plugs in, with
-  // no change to the navigation code below. Cross-boundary "the web terminal
-  // opens the KNOWLEDGE tab on a concept" stays OUT of scope until then.
-  function readPanelParams() {
-    const hash = (location.hash || "").replace(/^#/, "");
-    const params = { concept: null, structure: false, raw: hash };
-    if (!hash) return params;
-    if (hash === STRUCTURE_MARKER) {
-      params.structure = true;
-      return params;
-    }
-    try {
-      params.concept = decodeURIComponent(hash);
-    } catch (err) {
-      params.concept = hash;
-    }
-    return params;
   }
 
   // -- boot ------------------------------------------------------------------

--- a/src/osprey/interfaces/okf_panel/static/js/helpers.js
+++ b/src/osprey/interfaces/okf_panel/static/js/helpers.js
@@ -1,0 +1,85 @@
+// @ts-check
+/*
+ * OKF Knowledge Panel — pure DOM-leaf helpers.
+ *
+ * No imports: every function here is self-contained and side-effect-free
+ * apart from DOM node construction / reading `location.hash`. Keep it that
+ * way so this module stays trivially testable in isolation.
+ */
+
+// History marker for the structure overview (B.3): a hash distinct from any
+// concept id so popstate can tell the overview apart from a concept view.
+export const STRUCTURE_MARKER = "__structure";
+
+/**
+ * Create a DOM element with a flat string-valued attribute map and a list
+ * of child nodes.
+ *
+ * @param {string} tag
+ * @param {Record<string, string>|null} [attrs] String-valued attribute map.
+ *   The key `"class"` sets `className`; `"text"` sets `textContent`; every
+ *   other key is set via `setAttribute`.
+ * @param {(Node|null|undefined)[]} [children] Falsy entries are skipped.
+ * @returns {HTMLElement}
+ */
+export function el(tag, attrs, children) {
+  const node = document.createElement(tag);
+  if (attrs) {
+    for (const k in attrs) {
+      if (k === "class") node.className = attrs[k];
+      else if (k === "text") node.textContent = attrs[k];
+      else node.setAttribute(k, attrs[k]);
+    }
+  }
+  if (children) {
+    for (const child of children) {
+      if (child) node.appendChild(child);
+    }
+  }
+  return node;
+}
+
+// A fallback (filesystem-derived) concept is one whose title is just the
+// last path segment of its id — those have no real human title/description.
+/**
+ * @param {string|null|undefined} id
+ * @param {string|null|undefined} title
+ * @returns {boolean}
+ */
+export function isFallback(id, title) {
+  if (!id || !title) return false;
+  const last = String(id).split("/").pop();
+  return title === last;
+}
+
+/** @typedef {{concept: string|null, structure: boolean, raw: string}} PanelParams */
+
+// -- panel parameters / deep-link (osprey addition) --------------------------
+//
+// Generalizable panel-parameter shape. Today the only param is the deep-link
+// target carried in the panel's OWN URL hash (e.g. "#control-system/channel-
+// finding"). Keeping this as a small structured reader — rather than one-off
+// hash parsing scattered through boot — is deliberate: when the framework-wide
+// iframe URL-parameter convention lands (uniform theme / deep-link target /
+// etc. for every embedded panel), this one function is where it plugs in, with
+// no change to the navigation code below. Cross-boundary "the web terminal
+// opens the KNOWLEDGE tab on a concept" stays OUT of scope until then.
+/**
+ * @returns {PanelParams}
+ */
+export function readPanelParams() {
+  const hash = (location.hash || "").replace(/^#/, "");
+  /** @type {PanelParams} */
+  const params = { concept: null, structure: false, raw: hash };
+  if (!hash) return params;
+  if (hash === STRUCTURE_MARKER) {
+    params.structure = true;
+    return params;
+  }
+  try {
+    params.concept = decodeURIComponent(hash);
+  } catch {
+    params.concept = hash;
+  }
+  return params;
+}

--- a/src/osprey/interfaces/okf_panel/static/js/tree.js
+++ b/src/osprey/interfaces/okf_panel/static/js/tree.js
@@ -19,6 +19,9 @@ let treeEl;
 let structureLink = null;
 /** @type {(id: string) => void} */
 let onSelect;
+/** @type {string | null} */
+let activeConceptId = null;
+
 /**
  * Store the injected DOM handles and selection callback. Called once at
  * boot, before any other export in this module is used.
@@ -69,6 +72,7 @@ export function renderTree(groups) {
     }
     treeEl.appendChild(section);
   }
+  if (activeConceptId != null) applyConceptHighlight(activeConceptId);
 }
 
 // Shared body for the concept-link `.active` walk + scroll-into-view.
@@ -98,12 +102,14 @@ function applyConceptHighlight(id) {
  * @param {string} id
  */
 export function highlightActive(id) {
+  activeConceptId = id;
   if (structureLink) structureLink.classList.remove("active");
   applyConceptHighlight(id);
 }
 
 // Mark the structure-overview entry active and clear any concept highlight.
 export function highlightStructure() {
+  activeConceptId = null;
   const links = treeEl.querySelectorAll(".concept-link");
   links.forEach(function (link) {
     link.classList.remove("active");

--- a/src/osprey/interfaces/okf_panel/static/js/tree.js
+++ b/src/osprey/interfaces/okf_panel/static/js/tree.js
@@ -1,0 +1,121 @@
+// @ts-check
+/*
+ * OKF Knowledge Panel — sidebar tree: render, highlight, and highlight state.
+ *
+ * Boot wiring only: `initTree` stores the three injected handles once, at
+ * boot. Every other export reads those module-private handles rather than
+ * taking them as parameters, matching the closure shape this module was
+ * extracted from in app.js.
+ */
+
+import { el } from "./helpers.js";
+
+/** @typedef {{id: string, title?: string, description?: string}} Concept */
+/** @typedef {{id?: string, label?: string, concepts?: Concept[]}} Group */
+
+/** @type {HTMLElement} */
+let treeEl;
+/** @type {HTMLElement | null} */
+let structureLink = null;
+/** @type {(id: string) => void} */
+let onSelect;
+/**
+ * Store the injected DOM handles and selection callback. Called once at
+ * boot, before any other export in this module is used.
+ *
+ * @param {{treeEl: HTMLElement, structureLink: HTMLElement | null, onSelect: (id: string) => void}} handles
+ */
+export function initTree(handles) {
+  treeEl = handles.treeEl;
+  structureLink = handles.structureLink;
+  onSelect = handles.onSelect;
+}
+
+/**
+ * @param {Group[]} groups
+ */
+export function renderTree(groups) {
+  treeEl.innerHTML = "";
+  for (const group of groups) {
+    const section = el("section", { class: "group" });
+    section.appendChild(
+      el("h2", { class: "group-label", text: group.label || group.id || "" })
+    );
+
+    const concepts = group.concepts || [];
+    if (concepts.length === 0) {
+      section.appendChild(
+        el("p", { class: "muted empty-group", text: "(no concepts)" })
+      );
+    } else {
+      const list = el("ul", { class: "concept-list" });
+      for (const concept of concepts) {
+        const link = el("a", {
+          class: "concept-link",
+          href: "#",
+          text: concept.title || concept.id,
+          title: concept.description || "",
+        });
+        link.dataset.conceptId = concept.id;
+        link.addEventListener("click", function (ev) {
+          ev.preventDefault();
+          selectConcept(concept.id);
+        });
+        const li = el("li", null, [link]);
+        li.dataset.conceptId = concept.id;
+        list.appendChild(li);
+      }
+      section.appendChild(list);
+    }
+    treeEl.appendChild(section);
+  }
+}
+
+// Shared body for the concept-link `.active` walk + scroll-into-view.
+/**
+ * @param {string} id
+ */
+function applyConceptHighlight(id) {
+  const links = /** @type {NodeListOf<HTMLElement>} */ (
+    treeEl.querySelectorAll(".concept-link")
+  );
+  let activeLink = /** @type {HTMLElement | null} */ (null);
+  links.forEach(function (link) {
+    if (link.dataset.conceptId === id) {
+      link.classList.add("active");
+      activeLink = link;
+    } else {
+      link.classList.remove("active");
+    }
+  });
+  // Scroll the active entry into view so the user can always see where they
+  // are in the tree — important when jumping via an in-body cross-link to a
+  // concept far down the (scrolled) sidebar.
+  if (activeLink) activeLink.scrollIntoView({ block: "nearest", inline: "nearest" });
+}
+
+/**
+ * @param {string} id
+ */
+export function highlightActive(id) {
+  if (structureLink) structureLink.classList.remove("active");
+  applyConceptHighlight(id);
+}
+
+// Mark the structure-overview entry active and clear any concept highlight.
+export function highlightStructure() {
+  const links = treeEl.querySelectorAll(".concept-link");
+  links.forEach(function (link) {
+    link.classList.remove("active");
+  });
+  if (structureLink) structureLink.classList.add("active");
+}
+
+/**
+ * @param {string} id
+ */
+export function selectConcept(id) {
+  // The sidebar highlight is applied authoritatively in renderConcept (which
+  // every navigation path funnels through), so just trigger the load here.
+  onSelect(id);
+}

--- a/tests/interfaces/okf_panel/helpers.test.mjs
+++ b/tests/interfaces/okf_panel/helpers.test.mjs
@@ -1,0 +1,131 @@
+// @ts-check
+/**
+ * Unit tests for the OKF Knowledge Panel's pure DOM-leaf helpers
+ * (helpers.js) -- the interface's first JS unit test:
+ *   npx vitest run tests/interfaces/okf_panel/helpers.test.mjs
+ */
+
+import { test, expect, describe, beforeEach } from 'vitest';
+
+import {
+  STRUCTURE_MARKER,
+  el,
+  isFallback,
+  readPanelParams,
+} from '../../../src/osprey/interfaces/okf_panel/static/js/helpers.js';
+
+describe('el', () => {
+  test('creates an element with the given tag', () => {
+    const node = el('span');
+    expect(node.tagName).toBe('SPAN');
+  });
+
+  test('the "class" key sets className, not a class attribute', () => {
+    const node = el('div', { class: 'health-dot ok' });
+    expect(node.className).toBe('health-dot ok');
+  });
+
+  test('the "text" key sets textContent', () => {
+    const node = el('span', { text: 'hello world' });
+    expect(node.textContent).toBe('hello world');
+  });
+
+  test('text is set via textContent, never parsed as HTML', () => {
+    const node = el('div', { text: '<b>x</b>' });
+    expect(node.textContent).toBe('<b>x</b>');
+    expect(node.querySelector('b')).toBe(null);
+    expect(node.children.length).toBe(0);
+  });
+
+  test('other keys are set as attributes, readable via getAttribute', () => {
+    const node = el('a', { title: 'A title', href: '#control-system/x' });
+    expect(node.getAttribute('title')).toBe('A title');
+    expect(node.getAttribute('href')).toBe('#control-system/x');
+  });
+
+  test('children are appended in order', () => {
+    const a = el('span', { text: 'first' });
+    const b = el('span', { text: 'second' });
+    const parent = el('div', null, [a, b]);
+    expect(parent.children.length).toBe(2);
+    expect(parent.children[0]).toBe(a);
+    expect(parent.children[1]).toBe(b);
+  });
+
+  test('falsy children entries are skipped without throwing', () => {
+    const a = el('span', { text: 'only' });
+    expect(() => el('div', null, [null, a, undefined])).not.toThrow();
+    const parent = el('div', null, [null, a, undefined]);
+    expect(parent.children.length).toBe(1);
+    expect(parent.children[0]).toBe(a);
+  });
+
+  test('attrs may be null, as in el("li", null, [link])', () => {
+    const link = el('a', { href: '#x', text: 'link' });
+    const node = el('li', null, [link]);
+    expect(node.tagName).toBe('LI');
+    expect(node.children[0]).toBe(link);
+  });
+
+  test('children may be omitted entirely, as in el("span", { class: "health-dot ok" })', () => {
+    const node = el('span', { class: 'health-dot ok' });
+    expect(node.tagName).toBe('SPAN');
+    expect(node.className).toBe('health-dot ok');
+    expect(node.children.length).toBe(0);
+  });
+});
+
+describe('isFallback', () => {
+  test('true when the title equals the last "/"-separated segment of the id', () => {
+    expect(isFallback('control-system/channel-finding', 'channel-finding')).toBe(true);
+  });
+
+  test('false when the title is a real human title', () => {
+    expect(isFallback('control-system/channel-finding', 'Channel Finding')).toBe(false);
+  });
+
+  test('false for empty or missing id/title (guard clause)', () => {
+    expect(isFallback('', 'channel-finding')).toBe(false);
+    expect(isFallback('control-system/channel-finding', '')).toBe(false);
+    expect(isFallback(null, 'channel-finding')).toBe(false);
+    expect(isFallback('control-system/channel-finding', null)).toBe(false);
+    expect(isFallback(undefined, undefined)).toBe(false);
+  });
+});
+
+describe('readPanelParams', () => {
+  beforeEach(() => {
+    location.hash = '';
+  });
+
+  test('empty hash yields concept: null, structure: false, raw: ""', () => {
+    location.hash = '';
+    expect(readPanelParams()).toEqual({ concept: null, structure: false, raw: '' });
+  });
+
+  test('the structure marker hash yields structure: true, concept: null', () => {
+    location.hash = `#${STRUCTURE_MARKER}`;
+    const params = readPanelParams();
+    expect(params.structure).toBe(true);
+    expect(params.concept).toBe(null);
+  });
+
+  test('a concept hash preserves slashes and sets structure: false', () => {
+    location.hash = '#control-system/channel-finding';
+    const params = readPanelParams();
+    expect(params.concept).toBe('control-system/channel-finding');
+    expect(params.structure).toBe(false);
+  });
+
+  test('a malformed percent-escape falls back to the raw hash via the catch branch', () => {
+    // Verified to throw URIError in decodeURIComponent, and happy-dom does
+    // not normalize it away when assigned to location.hash:
+    //   node -e 'decodeURIComponent("%E0%A4%A")' -> URIError: URI malformed
+    const malformed = '%E0%A4%A';
+    expect(() => decodeURIComponent(malformed)).toThrow(URIError);
+    location.hash = `#${malformed}`;
+    const params = readPanelParams();
+    expect(params.concept).toBe(malformed);
+    expect(params.raw).toBe(malformed);
+  });
+});

--- a/tests/interfaces/okf_panel/tree.test.mjs
+++ b/tests/interfaces/okf_panel/tree.test.mjs
@@ -1,0 +1,195 @@
+// @ts-check
+/**
+ * Unit tests for the OKF Knowledge Panel's sidebar tree module (tree.js) --
+ * in particular the deterministic, browser-free regression gate for the
+ * "boot race" between `highlightActive`/`highlightStructure` and
+ * `renderTree` (Phase 4, Task 4.2):
+ *   npx vitest run tests/interfaces/okf_panel/tree.test.mjs
+ *
+ * `renderTree` rebuilds the DOM from scratch and then re-applies whatever
+ * concept highlight was set *before* the render (its tail calls
+ * `applyConceptHighlight(activeConceptId)` directly, guarded by
+ * `if (activeConceptId != null)`). Two sequences pin that guard:
+ *
+ *   7a: highlightActive(id) -> renderTree(...)      the re-apply must fire
+ *   7b: highlightActive(id) -> highlightStructure() -> renderTree(...)
+ *       the reset inside highlightStructure() must stick, so the re-apply
+ *       must NOT fire
+ *
+ * A third sequence (7b-plain) matches an earlier draft of this test's
+ * ordering but is deliberately NOT a regression gate for the guard --
+ * see the comment on that test below for why.
+ */
+
+import { test, expect, describe, beforeEach, vi } from 'vitest';
+
+/** @typedef {{id: string, title?: string, description?: string}} Concept */
+/** @typedef {{id?: string, label?: string, concepts?: Concept[]}} Group */
+
+/** @type {typeof import('../../../src/osprey/interfaces/okf_panel/static/js/tree.js')} */
+let tree;
+/** @type {HTMLElement} */
+let treeEl;
+/** @type {HTMLElement} */
+let structureLink;
+/** @type {import('vitest').Mock<(id: string) => void>} */
+let onSelect;
+
+/** @type {Group[]} */
+const GROUPS = [
+  {
+    id: 'control-system',
+    label: 'Control System',
+    concepts: [
+      {
+        id: 'control-system/channel-finding',
+        title: 'Channel Finding',
+        description: 'Find channels by name or pattern.',
+      },
+      { id: 'control-system/archiver', title: 'Archiver' },
+    ],
+  },
+  {
+    id: 'empty-group',
+    label: 'Empty Group',
+    concepts: [],
+  },
+];
+
+function mountFixture() {
+  document.body.innerHTML = `
+    <div id="tree"></div>
+    <a id="structure-link" href="#"></a>
+  `;
+  treeEl = /** @type {HTMLElement} */ (document.getElementById('tree'));
+  structureLink = /** @type {HTMLElement} */ (document.getElementById('structure-link'));
+}
+
+// Module isolation: `tree.js` keeps `activeConceptId`/`treeEl`/`structureLink`/
+// `onSelect` as module-private `let`s that persist across calls within the
+// same module instance. `initTree` only overwrites the DOM-handle/callback
+// trio -- it does NOT reset `activeConceptId` -- so re-calling `initTree` in
+// a plain `beforeEach` would leak an `activeConceptId` set by one test (e.g.
+// 7a) into the next (e.g. 7b), potentially masking a real regression.
+// `vi.resetModules()` plus a fresh dynamic `import()` per test sidesteps this
+// entirely: each test gets its own, never-before-touched module instance, so
+// there is no shared state to leak by construction.
+beforeEach(async () => {
+  vi.resetModules();
+  mountFixture();
+  onSelect = vi.fn();
+  tree = await import('../../../src/osprey/interfaces/okf_panel/static/js/tree.js');
+  tree.initTree({ treeEl, structureLink, onSelect });
+});
+
+describe('boot race: highlightActive before renderTree (7a)', () => {
+  test('renderTree re-applies a previously set activeConceptId', () => {
+    tree.highlightActive('control-system/channel-finding');
+    tree.renderTree(GROUPS);
+
+    const link = treeEl.querySelector(
+      '.concept-link.active[data-concept-id="control-system/channel-finding"]'
+    );
+    expect(link).not.toBeNull();
+  });
+});
+
+describe('boot race: highlightActive, then highlightStructure, before renderTree (7b)', () => {
+  test('highlightStructure resets activeConceptId so the later renderTree does not re-light a concept', () => {
+    tree.highlightActive('control-system/channel-finding');
+    tree.highlightStructure();
+    tree.renderTree(GROUPS);
+
+    expect(structureLink.classList.contains('active')).toBe(true);
+    expect(treeEl.querySelector('.concept-link.active')).toBeNull();
+  });
+});
+
+describe('7b-plain: highlightStructure before renderTree, with no prior highlightActive', () => {
+  // NOT mutation-sensitive for the `activeConceptId != null` guard in
+  // renderTree, and it is intentionally kept that way -- do not mistake this
+  // for the guard's regression gate (that is test 7b, above).
+  //
+  // Here `activeConceptId` is already `null` before `highlightStructure()`
+  // runs (fresh module instance), so `highlightStructure` sets it to `null`
+  // again -- a no-op -- and `renderTree`'s tail calls
+  // `applyConceptHighlight(null)` whether or not the `!= null` guard exists.
+  // `applyConceptHighlight` compares `link.dataset.conceptId === id`; since
+  // `dataset` values are always strings, `=== null` is always false, so the
+  // call just strips `.active` from every concept link (a no-op right after
+  // a fresh render) and never touches `structureLink`. Dropping the guard
+  // therefore leaves this assertion passing -- it is a purely type-level
+  // regression (`string | null` flowing into `applyConceptHighlight(id:
+  // string)`), caught by `npm run typecheck` (TS2345), not by this test.
+  test('structureLink is active and no concept link is active (assertions pass with or without the guard)', () => {
+    tree.highlightStructure();
+    tree.renderTree(GROUPS);
+
+    expect(structureLink.classList.contains('active')).toBe(true);
+    expect(treeEl.querySelector('.concept-link.active')).toBeNull();
+  });
+});
+
+describe('ordinary order: renderTree before highlightActive', () => {
+  test('highlightActive activates the concept link on an already-rendered tree', () => {
+    tree.renderTree(GROUPS);
+    tree.highlightActive('control-system/channel-finding');
+
+    const link = treeEl.querySelector(
+      '.concept-link.active[data-concept-id="control-system/channel-finding"]'
+    );
+    expect(link).not.toBeNull();
+  });
+});
+
+describe('click / dataset round-trip', () => {
+  test('clicking a concept link calls onSelect with the exact id carried in data-concept-id and prevents default', () => {
+    tree.renderTree(GROUPS);
+
+    const link = /** @type {HTMLElement | null} */ (
+      treeEl.querySelector('.concept-link[data-concept-id="control-system/channel-finding"]')
+    );
+    expect(link).not.toBeNull();
+    // The value the click handler will dispatch is carried on the element as
+    // data-concept-id; confirm it round-trips exactly before driving the
+    // click, so the assertion below on onSelect's argument is meaningfully
+    // tied to that attribute rather than an assumption about it.
+    expect(/** @type {HTMLElement} */ (link).dataset.conceptId).toBe(
+      'control-system/channel-finding'
+    );
+
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    /** @type {HTMLElement} */ (link).dispatchEvent(clickEvent);
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('control-system/channel-finding');
+    expect(clickEvent.defaultPrevented).toBe(true);
+  });
+});
+
+describe('renderTree: empty-group placeholder', () => {
+  test('a group with no concepts renders the "(no concepts)" placeholder', () => {
+    tree.renderTree(GROUPS);
+
+    const groups = Array.from(treeEl.querySelectorAll('section.group'));
+    const emptyGroup = groups.find(
+      (section) => section.querySelector('.group-label')?.textContent === 'Empty Group'
+    );
+    expect(emptyGroup).toBeDefined();
+    const placeholder = /** @type {Element} */ (emptyGroup).querySelector('.muted.empty-group');
+    expect(placeholder).not.toBeNull();
+    expect(/** @type {Element} */ (placeholder).textContent).toBe('(no concepts)');
+  });
+});
+
+describe('highlightStructure basics', () => {
+  test('marks structureLink active and clears any concept highlight', () => {
+    tree.renderTree(GROUPS);
+    tree.highlightActive('control-system/channel-finding');
+
+    tree.highlightStructure();
+
+    expect(structureLink.classList.contains('active')).toBe(true);
+    expect(treeEl.querySelectorAll('.concept-link.active').length).toBe(0);
+  });
+});


### PR DESCRIPTION
Retrofits `okf_panel`, the last interface still exempted from the front-end
enforcement ratchet, and fixes a sidebar bug the retrofit exposed.

## Ratchet

- Removes `@ts-nocheck`; all 36 `tsc --strict` diagnostics are resolved.
- `okf_panel` no longer appears anywhere in `eslint.config.js`.
- Corrects the base `eqeqeq` rule to `['error', 'always', { null: 'ignore' }]`,
  which allows the `x != null` idiom. That made every row of the 7-row `eqeqeq`
  exemption block redundant, so the block is deleted outright.
- `eslint.config.js` now ignores `**/.venv/**`. Without it, `npm run lint`
  fails with ~559 errors from vendored JS as soon as a contributor runs
  `uv sync`; CI never surfaced this because the `frontend-js` job is Node-only.
- `CONTRIBUTING.md` no longer describes `eqeqeq` as a live ratchet dimension.

## Product fix

A hash deep link on a cold bundle left the reader with no sidebar highlight.
The tree and the reading pane load in parallel, so the highlight was applied to
an empty tree or wiped when `renderTree()` rebuilt the list. `tree.js` now
records the active concept id and re-applies it at the end of `renderTree()`;
`highlightStructure()` clears it, so a default landing keeps its own highlight
rather than having it stripped by a stale concept.

## Tests

First JS unit tests for this interface: 16 covering the DOM helpers, 7 covering
the sidebar tree including the boot race. Full suite is 666 passing.

## Reviewing

Each of the five commits is independently green under lint, `tsc`, and vitest,
so `git bisect` stays meaningful. Two orderings are load-bearing rather than
cosmetic: the `eqeqeq` rule change must precede the fix, which introduces
`activeConceptId != null` into a file that is no longer exempted; and the
exemption-block removal must follow the `catch {` conversion, which would
otherwise fail lint.