### PR TITLE
feat(bluesky): persist scan data to a co-deployed Tiled catalog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,15 +484,21 @@ jobs:
           uv run pytest $E2E_FILTER -v --tb=short
         else
           # Tier 3 per-preset agentic flows live in their own matrix job
-          # (agentic-per-preset). The full Docker-stack tests (dispatch-deploy-e2e,
-          # scan-deploy-e2e) and the Dockerfile e2e (dockerfile-e2e) each
-          # have their own job because they build container images. Exclude all
-          # four here to avoid double-execution.
+          # (agentic-per-preset). The full Docker-stack tests
+          # (dispatch-deploy-e2e, scan-deploy-e2e, tiled-roundtrip-e2e,
+          # va-substrate-equivalence-e2e) and the Dockerfile e2e
+          # (dockerfile-e2e) each have their own job because they build
+          # container images. Exclude all six here to avoid
+          # double-execution. NOTE: "--ignore" means "not in this
+          # secret-gated LLM lane," NOT "not tested" — every ignored file
+          # below runs in its own secret-free job on every PR.
           uv run pytest tests/e2e/ -v --tb=short \
             --ignore=tests/e2e/test_preset_agentic.py \
             --ignore=tests/e2e/test_dispatch_deploy.py \
             --ignore=tests/e2e/test_scan_deploy.py \
-            --ignore=tests/e2e/test_dockerfile_e2e.py
+            --ignore=tests/e2e/test_dockerfile_e2e.py \
+            --ignore=tests/e2e/test_tiled_roundtrip.py \
+            --ignore=tests/e2e/test_va_substrate_equivalence.py
         fi
 
   deploy-e2e:
@@ -640,6 +646,86 @@ jobs:
       run: |
         uv run pytest tests/e2e/test_scan_deploy.py -v --tb=short
 
+  va-substrate-equivalence-e2e:
+    name: VA Substrate Equivalence E2E (virtual accelerator + bluesky bridge, full Docker stack)
+    runs-on: ubuntu-latest
+    # Only run on PRs from same repo (mirrors scan-deploy-e2e gating). This
+    # job needs no secrets — neither the bridge nor the virtual accelerator
+    # shells out to an LLM. Phase-1 bug fix: this test previously had no
+    # dedicated job and was only ever swept into e2e-tests' glob (the
+    # secret-gated LLM lane), contradicting its own docstring ("never
+    # collected by the fast lane"). This job is that missing lane.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    # The VA image build + `osprey deploy up` inside the test carry their own
+    # generous internal timeouts (5min build, 20min deploy-up) to absorb a
+    # cold image cache; that's 25min before the five CA proofs (P1-P5, with
+    # P1-P4 each eligible for one flaky rerun) even start. This job is
+    # materially heavier than tiled-roundtrip-e2e (co-deploys VA + bridge,
+    # builds a PyAT image), and it has never run in CI before (see the run
+    # step below) — a too-tight timeout must not be what reds its first PR.
+    timeout-minutes: 45
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+
+    - name: Set up Python
+      run: uv python install 3.11
+
+    - name: Set up Docker Compose
+      uses: docker/setup-compose-action@v2
+
+    - name: Install osprey
+      run: uv sync --extra dev
+
+    - name: Run VA substrate equivalence E2E
+      run: |
+        uv run pytest tests/e2e/test_va_substrate_equivalence.py -v --tb=short
+
+  tiled-roundtrip-e2e:
+    name: Tiled Roundtrip E2E (bluesky bridge + Tiled persistence, full Docker stack)
+    runs-on: ubuntu-latest
+    # Only run on PRs from same repo (mirrors scan-deploy-e2e gating). This
+    # job needs no secrets — the bridge never shells out to an LLM — but the
+    # same-repo restriction is the house policy for any extra
+    # Docker-build-and-deploy job, not just secret-gated ones.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    # Builds the bridge image and pulls ghcr.io/bluesky/tiled:0.2.12; ~6.5min
+    # with images cached, ~9-11min cold. scan-deploy-e2e has no explicit
+    # timeout-minutes; this job gets one for the extra image-pull headroom.
+    timeout-minutes: 20
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+
+    - name: Set up Python
+      run: uv python install 3.11
+
+    - name: Set up Docker Compose
+      uses: docker/setup-compose-action@v2
+
+    - name: Install osprey
+      run: uv sync --extra dev
+
+    - name: Run Tiled roundtrip E2E
+      run: |
+        uv run pytest tests/e2e/test_tiled_roundtrip.py -v --tb=short
+
   dockerfile-e2e:
     name: Dockerfile E2E (generated container image)
     runs-on: ubuntu-latest
@@ -677,7 +763,7 @@ jobs:
 
   all-checks-passed:
     name: All CI Checks Passed
-    needs: [test, lint, docs, package, static-checks, visual-theming, frontend-js, build-boot-smoke, e2e-tests, deploy-e2e, dispatch-deploy-e2e, scan-deploy-e2e, dockerfile-e2e, agentic-per-preset]
+    needs: [test, lint, docs, package, static-checks, visual-theming, frontend-js, build-boot-smoke, e2e-tests, deploy-e2e, dispatch-deploy-e2e, scan-deploy-e2e, va-substrate-equivalence-e2e, tiled-roundtrip-e2e, dockerfile-e2e, agentic-per-preset]
     runs-on: ubuntu-latest
     if: always()
 
@@ -755,6 +841,22 @@ jobs:
           echo "⏭️  Scan deploy E2E skipped (only run on PRs)"
         else
           echo "✅ Scan deploy E2E passed"
+        fi
+        # VA Substrate Equivalence E2E: advisory (Docker-dependent, no LLM involved)
+        if [[ "${{ needs.va-substrate-equivalence-e2e.result }}" == "failure" ]]; then
+          echo "⚠️  VA substrate equivalence E2E failed (non-blocking, Docker-dependent)"
+        elif [[ "${{ needs.va-substrate-equivalence-e2e.result }}" == "skipped" ]]; then
+          echo "⏭️  VA substrate equivalence E2E skipped (only run on PRs)"
+        else
+          echo "✅ VA substrate equivalence E2E passed"
+        fi
+        # Tiled Roundtrip E2E: advisory (Docker-dependent, no LLM involved)
+        if [[ "${{ needs.tiled-roundtrip-e2e.result }}" == "failure" ]]; then
+          echo "⚠️  Tiled roundtrip E2E failed (non-blocking, Docker-dependent)"
+        elif [[ "${{ needs.tiled-roundtrip-e2e.result }}" == "skipped" ]]; then
+          echo "⏭️  Tiled roundtrip E2E skipped (only run on PRs)"
+        else
+          echo "✅ Tiled roundtrip E2E passed"
         fi
         # Dockerfile E2E: advisory (network-dependent: PyPI, claude.ai installer)
         if [[ "${{ needs.dockerfile-e2e.result }}" == "failure" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,13 @@ jobs:
       # virtual-accelerator: tests/va/{test_record_factory,test_apply_fault}.py
       # import softioc, which lives in the virtual-accelerator extra (not dev).
       # Without it these unit tests error at collection on a fresh runner.
-      run: uv sync --extra dev --extra virtual-accelerator
+      #
+      # bluesky-bridge: tests/services/bluesky_bridge/* import bluesky,
+      # ophyd_async and tiled. Most guard with `pytest.importorskip`, so without
+      # this extra they do not error — they SKIP, and the bridge's scanner,
+      # RunEngine integration and Tiled fault-isolation guards silently never
+      # run. test_ci_workflow_wiring.py pins this extra for that reason.
+      run: uv sync --extra dev --extra virtual-accelerator --extra bluesky-bridge
 
     - name: Run unit tests
       run: |

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -7,6 +7,7 @@ Docker or Podman compose.
 import os
 import secrets
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
 
 from osprey.deployment.compose_generator import (
@@ -29,24 +30,70 @@ logger = get_logger("deployment.lifecycle")
 # deployed-service name to the token env var(s) it requires. event_dispatcher
 # and dispatch_worker both list the same pair because they share one .env:
 # the dispatcher forwards routed requests to workers using DISPATCH_WORKER_TOKEN,
-# so either service alone still needs both vars minted. bluesky is a single
-# fail-closed bridge instance needing only its own promote token — see
-# ``security.require_armed`` in ``osprey.services.bluesky_bridge``.
+# so either service alone still needs both vars minted. bluesky needs its own
+# promote token (see ``security.require_armed`` in
+# ``osprey.services.bluesky_bridge``) plus the API key the bridge presents to
+# the co-deployed Tiled catalog. The Tiled key hangs off "bluesky" rather than a
+# "tiled" key of its own because "tiled" is never a member of
+# ``deployed_services``, so the membership guard in ``_ensure_service_tokens``
+# would skip it and the key would never mint.
 _SERVICE_TOKEN_VARS: dict[str, tuple[str, ...]] = {
     "event_dispatcher": ("EVENT_DISPATCHER_TOKEN", "DISPATCH_WORKER_TOKEN"),
     "dispatch_worker": ("EVENT_DISPATCHER_TOKEN", "DISPATCH_WORKER_TOKEN"),
-    "bluesky": ("BLUESKY_PROMOTE_TOKEN",),
+    "bluesky": ("BLUESKY_PROMOTE_TOKEN", "BLUESKY_TILED_API_KEY"),
 }
 
-# Services whose fail-closed token must NOT be auto-armed when the agent's code
-# execution is unsandboxed on the host (see _local_exec_arming_unsafe below).
-# Their bearer token gates a write-capable HTTP route (bluesky-bridge's
-# POST /runs/{id}/promote); under local exec, agent-authored code can read that
-# token straight out of .env/config.yml and call the route directly, bypassing
-# the in-tool writes_enabled re-check that's supposed to gate it. The
-# event-dispatch services aren't in this set: their tokens gate an inbound
-# webhook/worker-routing boundary, not a write path the agent itself walks.
-_LOCAL_EXEC_GATED_SERVICES = {"bluesky"}
+# Token vars that are safe to auto-mint even when the agent's code execution is
+# unsandboxed on the host (see _local_exec_arming_unsafe below). Every *other*
+# declared token var is withheld under that config — a var nobody has triaged
+# fails CLOSED by omission.
+#
+# This is an allowlist, not a blocklist, because a security gate must fail
+# closed on the paths its author did not enumerate. Under a blocklist, a service
+# later added to _SERVICE_TOKEN_VARS with an arming token would mint it under
+# writes_enabled + local exec, warn about nothing, and break no test.
+#
+# The gate is per *variable*, not per service: one service can declare both an
+# arming token and non-arming credentials. The bar for adding a var here is that
+# it grants no write-capable route the agent itself can walk. Under local exec,
+# agent-authored code can read any minted token straight out of .env/config.yml
+# and call the route it gates directly, bypassing the in-tool writes_enabled
+# re-check. BLUESKY_PROMOTE_TOKEN is therefore absent: it gates the bridge's
+# POST /runs/{id}/promote.
+_LOCAL_EXEC_SAFE_VARS = {
+    "BLUESKY_TILED_API_KEY",  # outbound credential to the Tiled catalog; gates no bridge route
+    "EVENT_DISPATCHER_TOKEN",  # inbound webhook boundary, not a write path the agent walks
+    "DISPATCH_WORKER_TOKEN",  # worker-routing boundary, same
+}
+
+
+def _default_token() -> str:
+    """The default secret recipe, also the one ``.env.template`` documents."""
+    return secrets.token_urlsafe(32)
+
+
+# Per-variable overrides of the default recipe. A var absent here gets
+# ``_default_token``.
+#
+# BLUESKY_TILED_API_KEY: Tiled validates its ``--api-key`` during server startup
+# and raises ``ValueError("The API key must only contain alphanumeric
+# characters")`` for anything else, so a rejected key makes the container exit
+# before it ever listens. ``token_urlsafe``'s alphabet includes ``-`` and ``_``,
+# which land in roughly 7 of 10 values, so that recipe crash-loops Tiled on most
+# deploys — non-deterministically. ``token_hex(32)`` draws from ``[0-9a-f]``:
+# alphanumeric by construction, and the same 256 bits of entropy.
+#
+# Generate from an alphanumeric alphabet rather than stripping ``-``/``_`` out of
+# a urlsafe value, which would shorten the secret by a variable amount and drop
+# entropy silently.
+_VAR_GENERATORS: dict[str, Callable[[], str]] = {
+    "BLUESKY_TILED_API_KEY": lambda: secrets.token_hex(32),
+}
+
+
+def _generate_token(var: str) -> str:
+    """Mint one secret for ``var`` using its registered recipe."""
+    return _VAR_GENERATORS.get(var, _default_token)()
 
 
 def _local_exec_arming_unsafe(config: dict) -> bool:
@@ -74,8 +121,9 @@ def _ensure_service_tokens(
 
     For any token var (per ``_SERVICE_TOKEN_VARS``, keyed by the deployed
     services present) unset in BOTH the process env and the project ``.env``,
-    generate a strong random value (``secrets.token_urlsafe(32)``, the same
-    recipe the ``.env.template`` documents) and append it to ``.env``
+    generate a strong random value (``_generate_token``: ``token_urlsafe(32)``
+    unless the var registers a different alphabet in ``_VAR_GENERATORS``) and
+    append it to ``.env``
     (``chmod 0o600``, matching the build-time convention). Existing values are
     never overwritten, so re-running ``deploy up`` is idempotent. No-op unless
     a token-requiring service is actually deployed.
@@ -86,12 +134,19 @@ def _ensure_service_tokens(
     an exposed deploy (``--expose`` / bind 0.0.0.0) we refuse rather than bind a
     fail-open-at-bind server to all interfaces.
 
-    A service in ``_LOCAL_EXEC_GATED_SERVICES`` is skipped entirely (no token
-    minted, existing values in .env/env left untouched but not read either) when
-    ``_local_exec_arming_unsafe(config)`` — see that function's docstring. The
-    bridge's own ``require_armed()`` then keeps returning 503, i.e. it never
-    arms, rather than being armed with a token any local agent-code execution
-    can trivially read back out of ``.env``.
+    When ``_local_exec_arming_unsafe(config)`` — see that function's docstring —
+    the mint is restricted to the ``_LOCAL_EXEC_SAFE_VARS`` allowlist: any other
+    declared var is skipped (never minted; an existing value in .env/env is left
+    untouched but not read either). For the withheld ``BLUESKY_PROMOTE_TOKEN``
+    the bridge's own ``require_armed()`` then keeps returning 503, i.e. this
+    deploy never arms it, rather than arming it with a token any local
+    agent-code execution can trivially read back out of ``.env``.
+
+    The restriction is per var, not per service: the allowlisted vars a service
+    declares (e.g. bluesky's ``BLUESKY_TILED_API_KEY``, which grants catalog
+    access, not the ability to move the machine) still mint under the same
+    unsafe config. And because it is an allowlist, a token var added later
+    without being triaged fails closed rather than arming silently.
     """
     deployed_services = config.get("deployed_services")
     services = {str(s) for s in (deployed_services or [])}
@@ -101,25 +156,29 @@ def _ensure_service_tokens(
     # deterministic regardless of set iteration order or config.yml ordering.
     required_vars: list[str] = []
     seen: set[str] = set()
+    warned: set[str] = set()
     for svc_name, token_vars in _SERVICE_TOKEN_VARS.items():
         if svc_name not in services:
             continue
-        if svc_name in _LOCAL_EXEC_GATED_SERVICES and unsafe_local_exec:
-            logger.warning(
-                "Refusing to arm %r: control_system.writes_enabled is true but "
-                "execution.execution_method is 'local' (agent code runs unsandboxed "
-                "on the host, cwd=project_root). Local execution can read %s "
-                "straight out of .env/config.yml and call the write-capable route "
-                "it gates directly, bypassing the in-tool writes_enabled re-check. "
-                "NOT minting %s — the service stays unarmed. Set "
-                "execution.execution_method: container to use this feature with "
-                "writes_enabled: true.",
-                svc_name,
-                ", ".join(token_vars),
-                ", ".join(token_vars),
-            )
-            continue
         for var in token_vars:
+            if unsafe_local_exec and var not in _LOCAL_EXEC_SAFE_VARS:
+                if var not in warned:
+                    warned.add(var)
+                    logger.warning(
+                        "Refusing to arm %r: control_system.writes_enabled is true but "
+                        "execution.execution_method is 'local' (agent code runs unsandboxed "
+                        "on the host, cwd=project_root). Local execution can read %s "
+                        "straight out of .env/config.yml and call the write-capable route "
+                        "it gates directly, bypassing the in-tool writes_enabled re-check. "
+                        "NOT minting %s — this deploy will not arm it (an existing value "
+                        "in .env or the environment is left in place and still arms the "
+                        "service). Set execution.execution_method: container to use this "
+                        "feature with writes_enabled: true.",
+                        svc_name,
+                        var,
+                        var,
+                    )
+                continue
             if var not in seen:
                 seen.add(var)
                 required_vars.append(var)
@@ -138,7 +197,7 @@ def _ensure_service_tokens(
         present = name in os.environ or name in existing
         if present:
             continue  # keep the user's value (even an empty one — see docstring)
-        generated[name] = secrets.token_urlsafe(32)
+        generated[name] = _generate_token(name)
 
     if generated:
         prefix = ""

--- a/src/osprey/mcp_server/scan/tools/read_tools.py
+++ b/src/osprey/mcp_server/scan/tools/read_tools.py
@@ -87,9 +87,11 @@ async def scan_status(run_id: str) -> str:
         run_id: Run id returned by create_scan_intent or list_runs.
 
     Returns:
-        JSON run record: ``{"id", "status", ["completion"], ["launched_by"],
-        ["run_uid"], ["error"]}``. ``status`` is one of "intent", "running",
-        "completed", "stopped", "error".
+        JSON run record: ``{"id", "status", "tiled_degraded", ["completion"],
+        ["launched_by"], ["run_uid"], ["error"]}``. ``status`` is one of "intent",
+        "running", "completed", "stopped", "error". ``tiled_degraded`` is True when
+        durable persistence to Tiled failed for this run; False when healthy or when
+        Tiled is not deployed.
     """
     status, body = await anyio.to_thread.run_sync(_http_get_json, f"/runs/{run_id}")
     if status == 404:

--- a/src/osprey/services/bluesky_bridge/app.py
+++ b/src/osprey/services/bluesky_bridge/app.py
@@ -67,6 +67,16 @@ _TRUTHY_VALUES = {"1", "true", "yes", "on"}
 # must never silently get the mock demo instead.
 _EPICS_SUBSTRATE_ENV = "BLUESKY_EPICS_SUBSTRATE"
 
+# Task 2.5: when set, both scanner-factory branches below subscribe a
+# `TiledWriter` (via `_FaultIsolatedTiledWriter`, see `scanner_bluesky.py`) so
+# scan data survives a bridge restart. Orthogonal to `_DEMO_SCANNER_ENV`/
+# `_EPICS_SUBSTRATE_ENV` — it augments whichever scanner those two flags pick,
+# rather than picking one itself. `BLUESKY_TILED_API_KEY` grants catalog
+# access only, never promote authority — see `container_lifecycle.py`'s
+# `_SERVICE_TOKEN_VARS`.
+_TILED_URI_ENV = "BLUESKY_TILED_URI"
+_TILED_API_KEY_ENV = "BLUESKY_TILED_API_KEY"
+
 # The `Scanner` implementation `do_promote` builds for every promotion.
 _scanner_factory: Callable[[], Scanner] = FakeScanner
 
@@ -99,6 +109,34 @@ def _is_epics_substrate_enabled() -> bool:
     see that function's docstring for why.
     """
     return os.environ.get(_EPICS_SUBSTRATE_ENV, "").strip().lower() in _TRUTHY_VALUES
+
+
+def _build_tiled_writer_factory() -> Callable[[], Any] | None:
+    """Build the `tiled_writer_factory` `BlueskyScanner` accepts, or `None` if Tiled is unconfigured.
+
+    Reads `BLUESKY_TILED_URI` fresh on every call (never cached), so each
+    promotion's `BlueskyScanner` picks up the current env — matching
+    `do_promote`'s "fresh scanner per promotion" contract (`scanner_bluesky.py`'s
+    `_FaultIsolatedTiledWriter` docstring: "no cross-run state to reset").
+    `None` when the URI is unset: `BlueskyScanner.__init__` treats that as "no
+    Tiled subscription", identical to Phase 1's no-Tiled-server behavior.
+
+    The returned closure imports `TiledWriter` from
+    `bluesky.callbacks.tiled_writer` — NOT from `tiled` (TR2) — lazily,
+    inside itself, so this module stays import-clean of both `bluesky` and
+    `tiled` (`_BRIDGE_ONLY_MODULES`) even when a caller holds onto the
+    returned factory without ever invoking it.
+    """
+    uri = os.environ.get(_TILED_URI_ENV)
+    if not uri:
+        return None
+
+    def factory() -> Any:
+        from bluesky.callbacks.tiled_writer import TiledWriter
+
+        return TiledWriter.from_uri(uri, api_key=os.environ[_TILED_API_KEY_ENV])
+
+    return factory
 
 
 @asynccontextmanager
@@ -159,6 +197,7 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
                 return BlueskyScanner(
                     devices=lambda: epics.build_devices(motors, detectors),
                     plans=BUILTIN_PLANS,
+                    tiled_writer_factory=_build_tiled_writer_factory(),
                 )
 
             set_scanner_factory(_epics_scanner_factory)
@@ -201,7 +240,10 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
                 # `build_devices` is `async def` (it connects ophyd-async
                 # devices) — `BlueskyScanner._resolve_devices` bridges that
                 # for us; passing the bare callable here, not its result.
-                return BlueskyScanner(devices=lambda: build_devices())
+                return BlueskyScanner(
+                    devices=lambda: build_devices(),
+                    tiled_writer_factory=_build_tiled_writer_factory(),
+                )
 
             set_scanner_factory(_demo_scanner_factory)
             logger.info(
@@ -319,34 +361,27 @@ def list_plans() -> list:
     return [spec.to_dict() for spec in merged.values()]
 
 
-@app.get("/runs/{run_id}/data")
-def read_run_data(
-    run_id: str, max_rows: int = 100, offset: int | None = None, tail: bool = False
-) -> dict:
-    """Read a bounded window of a run's recorded data (see `live_rows.py`).
+def _window(
+    columns: list[str],
+    rows: list[Any],
+    total_seen: int,
+    max_rows: int,
+    offset: int | None,
+    tail: bool,
+) -> dict[str, Any]:
+    """Compute a bounded, paginated window over a row buffer.
 
-    Row-bounded by design — this never returns an unbounded table. Serves
-    from the in-process live-row buffer, so reads work with no Tiled server:
-    ``partial: true`` while the run is still filling in (before its stop doc
-    lands), permanently readable once it's marked completed (see
-    `live_rows.py`'s retention bound). ``row_count`` is the *true* total rows
-    the run has produced so far, even if that's more than what's physically
-    stored — ``truncated`` reflects whether this response's window omits any
-    of them.
+    Shared by every data source `read_run_data` serves from (today: the live
+    buffer; later: Tiled) — one implementation is what makes pagination
+    parity across sources structural rather than something tests have to
+    police across copies.
 
-    Raises 409 if the run has no `run_uid` yet (never promoted, or promoted
-    but the scan hasn't emitted a start doc) — there is nothing to read.
+    ``row_count`` is `total_seen` — the *true* total rows the run has
+    produced, even if that's more than what's physically passed in via
+    ``rows`` — not ``len(rows)``. ``truncated`` reflects whether this
+    response's window omits any of the passed-in rows, or whether more rows
+    exist than were passed in at all.
     """
-    run = registry.get(run_id)
-    run_uid = run.run_uid
-    if run_uid is None:
-        raise HTTPException(status_code=409, detail=f"run {run_id!r} has not started; no data yet")
-
-    buf = live_rows.get(run_uid)
-    if buf is None:
-        return {"columns": [], "rows": []}
-
-    rows = buf["rows"]
     stored_count = len(rows)
     max_rows = max(0, max_rows)
     skip = max(0, offset) if offset is not None else 0
@@ -359,15 +394,145 @@ def read_run_data(
         end = start + max_rows
     window = rows[start:end]
 
-    truncated = start > 0 or end < stored_count or buf["total_seen"] > stored_count
+    truncated = start > 0 or end < stored_count or total_seen > stored_count
 
-    result: dict[str, Any] = {
-        "run_uid": run_uid,
-        "columns": list(buf["columns"]),
+    return {
+        "columns": list(columns),
         "rows": window,
-        "row_count": buf["total_seen"],
+        "row_count": total_seen,
         "truncated": truncated,
     }
-    if buf["partial"]:
-        result["partial"] = True
+
+
+def _from_tiled(
+    run_id: str, max_rows: int, offset: int | None, tail: bool
+) -> dict[str, Any] | None:
+    """Serve `read_run_data` from the durable Tiled catalog once a run's live buffer is gone.
+
+    Two situations fall through the live path in `read_run_data` and land here: a registry
+    miss after a bridge restart (the whole in-memory registry — including `run.run_uid` —
+    is gone, so the search below keys on `osprey_run_id`, the durable stamp `do_promote`
+    writes into the start doc, never the lost `run_uid`), and a registry hit whose buffer
+    was evicted past `live_rows._MAX_RUNS`.
+
+    Returns `None` when Tiled is unconfigured (`BLUESKY_TILED_URI` unset — logged, not an
+    error) or when no run in the catalog matches `run_id`; the caller turns either into a
+    404, exactly like an unknown live `run_uid` today.
+
+    `tiled` is imported here, never at module level, so `app.py` stays import-clean of it
+    (`_BRIDGE_ONLY_MODULES`) even when Tiled *is* configured for this deploy.
+    """
+    uri = os.environ.get(_TILED_URI_ENV)
+    if not uri:
+        logger.info(
+            "_from_tiled: %s is unset; Tiled is not configured for this deploy", _TILED_URI_ENV
+        )
+        return None
+
+    from tiled.client import from_uri
+    from tiled.queries import Key
+
+    client = from_uri(uri, api_key=os.environ[_TILED_API_KEY_ENV])
+    # The start doc `TiledWriter.start` records lives under `metadata["start"]`
+    # on the run container — a bare `Key("osprey_run_id")` matches nothing.
+    matches = list(client.search(Key("start.osprey_run_id") == run_id).values())
+    if not matches:
+        return None
+    run_node = matches[0]
+
+    run_uid = dict(run_node.metadata).get("start", {}).get("uid")
+
+    if "primary" not in run_node:
+        # Start doc landed but no Event ever arrived (e.g. a scan that
+        # errored before its first point) — the run is real, so this is the
+        # "nothing to read yet" shape, not a 404. Deliberately a membership
+        # check on `"primary"` alone, never a `try`/`except KeyError` around
+        # the whole traversal below: `CompositeClient.__getitem__` raises
+        # `KeyError` for `"internal"` too (it exposes the table's *columns*,
+        # not the table), so a broad guard here would silently convert a
+        # wrong traversal into this empty-but-successful answer.
+        columns: list[str] = []
+        rows: list[Any] = []
+        total_seen = 0
+    else:
+        # `run_node["primary"]` is a `CompositeClient`, whose keys are the
+        # flattened column names; the appendable table itself hangs off its
+        # `.base` container.
+        internal_table = run_node["primary"].base["internal"]
+        table = internal_table.read()
+        # Tiled's stored rows carry `seq_num`, `time`, and per-signal `ts_*`
+        # timestamp columns the live buffer never had (see `LiveRowRecorder`)
+        # — project those away so both sources return the identical column set.
+        columns = [
+            c for c in table.columns if c != "seq_num" and c != "time" and not c.startswith("ts_")
+        ]
+        rows = table[columns].values.tolist()
+        total_seen = len(table)
+
+    result: dict[str, Any] = {"run_uid": run_uid}
+    result.update(_window(columns, rows, total_seen, max_rows, offset, tail))
     return result
+
+
+@app.get("/runs/{run_id}/data")
+def read_run_data(
+    run_id: str, max_rows: int = 100, offset: int | None = None, tail: bool = False
+) -> dict:
+    """Read a bounded window of a run's recorded data — dual-source (task 3.3).
+
+    Row-bounded by design — this never returns an unbounded table. Prefers the
+    in-process live-row buffer (see `live_rows.py`) whenever it has one:
+    ``partial: true`` while the run is still filling in (before its stop doc
+    lands), permanently readable once it's marked completed (see
+    `live_rows.py`'s retention bound). ``row_count`` is the *true* total rows
+    the run has produced so far, even if that's more than what's physically
+    stored — ``truncated`` reflects whether this response's window omits any
+    of them.
+
+    Falls back to `_from_tiled` (task 3.2) whenever there is no live buffer to
+    serve — this is the SAME branch for two different situations: a registry
+    miss (the whole in-memory registry, including `run.run_uid`, is gone after
+    a bridge restart — so the fallback searches Tiled by `run_id` directly,
+    never a `run_uid` that no longer exists to look up), and a registry hit
+    whose buffer was evicted past `live_rows._MAX_RUNS`. The fallback trigger
+    is always ``buf is None`` — a present-but-empty buffer (``partial: true``,
+    zero rows) is a real in-flight run and stays on the live path; checking
+    "falsy rows" instead would incorrectly divert a running scan to Tiled
+    before it has ever written anything there.
+
+    Raises 409 if the registry has the run but it has no `run_uid` yet (never
+    promoted, or promoted but the scan hasn't emitted a start doc) — there is
+    nothing to read from either source, so Tiled is never consulted for this
+    case. Raises 404 when neither source has the run — the MCP `read_scan_data`
+    tool maps 404 to `unknown_run`, and a 200-empty response would make a
+    nonexistent run look like a valid empty scan.
+    """
+    try:
+        run = registry.get(run_id)
+    except HTTPException:
+        run = None
+
+    buf = None
+    run_uid: str | None = None
+    if run is not None:
+        run_uid = run.run_uid
+        if run_uid is None:
+            raise HTTPException(
+                status_code=409, detail=f"run {run_id!r} has not started; no data yet"
+            )
+        buf = live_rows.get(run_uid)
+
+    if buf is not None:
+        result: dict[str, Any] = {"run_uid": run_uid}
+        result.update(
+            _window(buf["columns"], buf["rows"], buf["total_seen"], max_rows, offset, tail)
+        )
+        if buf["partial"]:
+            result["partial"] = True
+        return result
+
+    tiled_result = _from_tiled(run_id, max_rows, offset, tail)
+    if tiled_result is not None:
+        return tiled_result
+
+    raise HTTPException(status_code=404, detail=f"unknown run {run_id!r}")

--- a/src/osprey/services/bluesky_bridge/runs.py
+++ b/src/osprey/services/bluesky_bridge/runs.py
@@ -80,6 +80,13 @@ class Run:
     def to_dict(self) -> dict:
         status = self.status
         out: dict[str, Any] = {"id": self.id, "status": status}
+        # Always present, never absent: `False` both before promotion (no
+        # scanner yet) and for a scanner that doesn't expose the attribute
+        # (`FakeScanner`) — a missing key would read as "unknown", not the
+        # same thing as "Tiled persistence is fine" (FR5). `bool(...)` makes
+        # the field's JSON type structural rather than a property of whatever
+        # duck-typed scanner happens to be attached.
+        out["tiled_degraded"] = bool(getattr(self.scanner, "tiled_degraded", False))
         if self.promoted and self.scanner is not None:
             out["completion"] = self.scanner.estimate_current_completion()
         if self.launched_by:
@@ -196,6 +203,11 @@ def do_promote(run: Run, scanner_factory: Callable[[], Scanner]) -> Run:
         scanner = scanner_factory()
         if not scanner.reinitialize(run.request):
             raise RuntimeError("scanner.reinitialize() returned False")
+        # Threads the registry's durable run id into the RunEngine start doc
+        # (see `BlueskyScanner._run`), so a Tiled-persisted run can still be
+        # found after the in-memory registry — and `run_uid` with it — is
+        # gone. Not part of the `Scanner` Protocol: `FakeScanner` ignores it.
+        scanner.osprey_run_id = run.id  # type: ignore[attr-defined]
         scanner.start_scan_thread()
     except Exception as exc:  # surface to the run rather than raising 500 blind
         if scanner is not None:

--- a/src/osprey/services/bluesky_bridge/scanner_bluesky.py
+++ b/src/osprey/services/bluesky_bridge/scanner_bluesky.py
@@ -97,6 +97,38 @@ def _plan_name_and_args(exec_config: Any) -> tuple[str | None, dict[str, Any]]:
     )
 
 
+class _FaultIsolatedTiledWriter:
+    """Wraps a `(name, doc)` callback so a Tiled outage degrades persistence, never a scan.
+
+    `TiledWriter` is a synchronous RunEngine callback, and bluesky's
+    `RunEngine` does not swallow callback exceptions by default — an
+    exception escaping `__call__` aborts the running plan. This wrapper
+    catches any exception from the inner writer, latches `degraded = True`,
+    logs once with `exc_info`, and never re-raises. Once latched, subsequent
+    documents short-circuit without touching the inner writer again.
+
+    Latch semantics are per-instance: `BlueskyScanner` builds a fresh writer
+    (and fresh wrapper) per promotion, so there is no cross-run state to reset.
+    """
+
+    def __init__(self, inner: Callable[[str, dict[str, Any]], Any]) -> None:
+        self._inner = inner
+        self.degraded = False
+
+    def __call__(self, name: str, doc: dict[str, Any]) -> None:
+        if self.degraded:
+            return
+        try:
+            self._inner(name, doc)
+        except Exception:
+            self.degraded = True
+            logger.error(
+                "BlueskyScanner: TiledWriter failed on %r document; persistence degraded",
+                name,
+                exc_info=True,
+            )
+
+
 class BlueskyScanner:
     """One promoted run's real bluesky RunEngine handle.
 
@@ -128,18 +160,53 @@ class BlueskyScanner:
         self._recorder = LiveRowRecorder()
         self.RE.subscribe(self._on_document)
 
+        # `None` means Tiled is disabled entirely (no factory supplied) —
+        # distinct from a wired-but-degraded writer (see `tiled_degraded`).
+        self._tiled_writer: _FaultIsolatedTiledWriter | None = None
         if tiled_writer_factory is not None:
+            # Pre-latch a no-op placeholder so `tiled_degraded` has something
+            # to read even if `tiled_writer_factory()` itself raises below;
+            # reassigned to wrap the real inner writer the moment it exists.
+            self._tiled_writer = _FaultIsolatedTiledWriter(lambda name, doc: None)
             try:
-                self.RE.subscribe(tiled_writer_factory())
+                # BOTH construction and subscription are inside this guard: a
+                # Tiled server down at promote time can fail either call, and
+                # either failure must degrade persistence, never abort the
+                # promotion (FR4) — a raising `subscribe()` outside the guard
+                # would propagate out of `__init__` -> `scanner_factory()` ->
+                # `do_promote`, turning a Tiled outage into a failed promote.
+                inner_writer = tiled_writer_factory()
+                self._tiled_writer = _FaultIsolatedTiledWriter(inner_writer)
+                self.RE.subscribe(self._tiled_writer)
             except Exception:
                 logger.warning(
-                    "BlueskyScanner: TiledWriter subscription failed; continuing without it",
+                    "BlueskyScanner: TiledWriter construction/subscription failed;"
+                    " persistence degraded",
                     exc_info=True,
                 )
+                # Whichever wrapper is currently referenced (the placeholder,
+                # if the factory itself raised, or the real one, if only
+                # `subscribe` raised) is latched degraded either way — it is
+                # already a no-op past this point even if `subscribe` had
+                # partially registered it before raising.
+                self._tiled_writer.degraded = True
 
         self._thread: threading.Thread | None = None
         self._stop_requested = False
         self._completion = 0.0
+
+    @property
+    def tiled_degraded(self) -> bool:
+        """Whether Tiled persistence has failed (construction or per-document).
+
+        `False` both when Tiled is disabled entirely (no `tiled_writer_factory`
+        supplied) and while a wired writer is healthy — never `True` merely
+        because Tiled is absent. Reflects the fault-isolated wrapper's latch
+        once a writer is wired.
+        """
+        if self._tiled_writer is None:
+            return False
+        return self._tiled_writer.degraded
 
     def _on_document(self, name: str, doc: dict[str, Any]) -> None:
         """Capture `last_run_uid` from the start doc, then forward to the live-row buffer.
@@ -243,9 +310,20 @@ class BlueskyScanner:
         Either way, `_stop_requested` (set before `RE.abort()` is called) is
         what distinguishes an intentional stop from a genuine plan failure —
         not the exception's presence.
+
+        `osprey_run_id` (set by `do_promote`, `runs.py`, after `reinitialize`
+        and before `start_scan_thread`) is not part of the `Scanner` Protocol,
+        so it is read defensively via `getattr` — absent for any caller that
+        doesn't set it (contract tests constructing a `BlueskyScanner`
+        directly). When present it is passed as a `RunEngine.__call__`
+        metadata kwarg — `RE(plan, osprey_run_id=...)` — which bluesky records
+        onto the start doc. A literal `md={...}` would nest it under an `md`
+        key instead, which is not what the durable Tiled lookup expects.
         """
+        osprey_run_id = getattr(self, "osprey_run_id", None)
+        metadata_kw = {"osprey_run_id": osprey_run_id} if osprey_run_id is not None else {}
         try:
-            self.RE(self._plan_gen)
+            self.RE(self._plan_gen, **metadata_kw)
         except Exception as exc:
             if self._stop_requested:
                 self.current_state = "stopped"

--- a/src/osprey/templates/services/bluesky/docker-compose.yml.j2
+++ b/src/osprey/templates/services/bluesky/docker-compose.yml.j2
@@ -79,6 +79,15 @@ services:
       # with an in-memory mock scanner.
       BLUESKY_DEMO_SCANNER: "true"
 {% endif %}
+{% if services.bluesky.tiled_enabled | default(false) %}
+      # Tiled persistence (Task 2.7): the bridge's TiledWriter connects to the
+      # co-deployed Tiled server over osprey-network at its container port
+      # (never the host-published tiled_port). No :- default on the API key —
+      # an unset key must fail closed rather than let the writer connect
+      # unauthenticated.
+      BLUESKY_TILED_URI: "http://tiled:8000"
+      BLUESKY_TILED_API_KEY: ${BLUESKY_TILED_API_KEY}
+{% endif %}
     networks:
       - osprey-network
     healthcheck:
@@ -97,17 +106,62 @@ services:
   # `services.bluesky.tiled_enabled: true` in config.yml; loopback/osprey-network
   # only, same as the bridge itself. Not required for Phase 2's FakeScanner path.
   tiled:
-    image: ${OSPREY_TILED_IMAGE:-ghcr.io/bluesky/tiled:latest}
+    image: ${OSPREY_TILED_IMAGE:-ghcr.io/bluesky/tiled:0.2.12}
     container_name: osprey-bluesky-tiled
     restart: unless-stopped
+    # `serve catalog` aborts without a catalog DB argument and defaults to
+    # 127.0.0.1 (unreachable from the bridge container) without --host. The
+    # duckdb:// writable target is required alongside the filesystem one:
+    # bluesky's TiledWriter appends event tables via create_appendable_table
+    # + append_partition, which need SQL-family storage.
+    #
+    # Mounted at /storage: the image ships that path pre-owned by uid=999
+    # (app), the user the container runs as, so a fresh named volume
+    # inherits that ownership from the image on first mount. Any mount
+    # point absent from the image gets created root-owned by Docker
+    # instead, and the uid=999 process can't open a catalog DB under a
+    # root-owned directory (fails closed with "unable to open database
+    # file") — so this path must stay pinned to one the image ships.
+    #
+    # The duckdb:// target below uses FOUR slashes, NOT a typo: this is
+    # the standard SQLAlchemy DBAPI URI convention (driver://[host]/path),
+    # where an empty host segment leaves the path either RELATIVE (three
+    # slashes: driver:///relative/path, resolved against the container's
+    # CWD) or ABSOLUTE (four slashes: driver:////absolute/path). Three
+    # slashes here resolves to a relative "storage/data.duckdb" against
+    # /app and fails server-side with "The directory storage does not
+    # exist." — a failure that surfaces to the client only as an opaque
+    # 409 on the run's metadata POST, not as a storage-URI error. Tiled's
+    # own catalog DB argument above (the sqlite backend under the covers)
+    # follows the identical four-slash-for-absolute convention. Do not
+    # "fix" this back to three slashes.
+    #
+    # --api-key is quoted with a `:?` guard, not the bare `${BLUESKY_TILED_API_KEY}`
+    # used elsewhere in this file: compose splits this string `command:` form
+    # shlex-style, so an unset-or-empty value contributes NO argument at all —
+    # not an empty one. `--api-key` then silently swallows the next token
+    # (`-w`) as its operand and a writable target vanishes, with the resulting
+    # error pointing at `-w`, never at the empty key. `:?` aborts `deploy up`
+    # with an explicit message instead. The quotes are belt-and-braces: if the
+    # `:?` is ever relaxed, an empty value becomes an explicit empty argument
+    # rather than a vanished one.
+    command: tiled serve catalog /storage/catalog.db --init --host 0.0.0.0 --port 8000 --api-key "${BLUESKY_TILED_API_KEY:?must be a non-empty alphanumeric key}" -w /storage/files -w duckdb:////storage/data.duckdb
     ports:
       - "{{ deployment.bind_address | default('127.0.0.1') }}:{{ services.bluesky.tiled_port | default(8091) }}:8000"
     environment:
       TZ: {{ system.timezone }}
     volumes:
-      - bluesky_tiled_catalog:/data
+      - bluesky_tiled_catalog:/storage
     networks:
       - osprey-network
+    healthcheck:
+      # /healthz is unauthenticated and always 200 — curl isn't in the image,
+      # so probe in-image with python, matching the bridge's own healthcheck.
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/healthz').status==200 else 1)\""]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
 {% endif %}
 
 networks:

--- a/src/osprey/templates/skills/osprey-build-deploy/templates/core/.env.template
+++ b/src/osprey/templates/skills/osprey-build-deploy/templates/core/.env.template
@@ -113,6 +113,19 @@ ${config.modules.event_dispatcher.sidecar_token_env_var}=
 # END IF
 
 
+# -----------------------------------------------------------------------------
+# Tiled catalog API key — the bridge presents this to the co-deployed Tiled
+# server, which validates it at startup.
+#
+# BLUESKY_TILED_API_KEY must be ALPHANUMERIC — Tiled exits at startup otherwise
+# ("ValueError: The API key must only contain alphanumeric characters").
+# Generate with:  python3 -c 'import secrets; print(secrets.token_hex(32))'
+# The urlsafe recipe above (used for the event dispatcher's tokens) does NOT
+# work here: its alphabet includes "-"/"_", which Tiled rejects.
+# -----------------------------------------------------------------------------
+BLUESKY_TILED_API_KEY=
+
+
 # IF MODULE ariel.enabled
 # -----------------------------------------------------------------------------
 # ARIEL Postgres DSN. Emitted for BOTH deployment modes:

--- a/tests/deployment/test_bluesky_arming_guard.py
+++ b/tests/deployment/test_bluesky_arming_guard.py
@@ -1,4 +1,4 @@
-"""Tests for the local-exec arming guard (task 2.11c).
+"""Tests for the local-exec arming guard.
 
 The local python-executor path runs agent-authored code with cwd=project_root
 and no filesystem/network sandboxing, so it can read BLUESKY_PROMOTE_TOKEN
@@ -9,8 +9,18 @@ exposure. Per the user ruling (2026-07-06, "guard + document"),
 container_lifecycle._ensure_service_tokens must refuse to mint
 BLUESKY_PROMOTE_TOKEN — leaving the bridge unarmed (its own require_armed()
 then 503s) — whenever control_system.writes_enabled and
-execution.execution_method=local are both true, and must otherwise behave
-exactly as task 2.10 shipped it.
+execution.execution_method=local are both true.
+
+The guard is *per token variable*, not per service, and is a fail-closed
+allowlist: under the unsafe config a declared var mints only if it appears in
+_LOCAL_EXEC_SAFE_VARS. BLUESKY_TILED_API_KEY hangs off the same deployed
+'bluesky' service but gates catalog access, not an arming capability, so it is
+allowlisted and must still mint. A var nobody triaged — e.g. an arming token a
+future service declares — is withheld by omission rather than minted silently.
+
+Every test that asserts the promote token is withheld therefore also asserts the
+Tiled key is present: a one-sided assertion cannot distinguish the correct gate
+from an inverted one.
 """
 
 from __future__ import annotations
@@ -51,15 +61,19 @@ def _patch_prepare_compose_files(monkeypatch, config: dict) -> None:
 @pytest.fixture
 def _clean_token_env(monkeypatch):
     monkeypatch.delenv("BLUESKY_PROMOTE_TOKEN", raising=False)
+    monkeypatch.delenv("BLUESKY_TILED_API_KEY", raising=False)
     monkeypatch.delenv("EVENT_DISPATCHER_TOKEN", raising=False)
     monkeypatch.delenv("DISPATCH_WORKER_TOKEN", raising=False)
 
 
-def _parse_env(tmp_path):
+def _parse_dotenv(path):
     from osprey.utils.dotenv import parse_dotenv_file
 
-    p = tmp_path / ".env"
-    return parse_dotenv_file(p) if p.is_file() else {}
+    return parse_dotenv_file(path) if path.is_file() else {}
+
+
+def _parse_env(tmp_path):
+    return _parse_dotenv(tmp_path / ".env")
 
 
 def _config(**overrides) -> dict:
@@ -107,9 +121,16 @@ def test_arming_safe_by_default_when_sections_absent():
 # ---------------------------------------------------------------------------
 
 
-def test_bluesky_token_not_minted_when_writes_enabled_and_local(
+def test_promote_token_withheld_but_tiled_key_minted_when_writes_enabled_and_local(
     captured_argv, _clean_token_env, monkeypatch, tmp_path, caplog
 ):
+    """The gate is variable-scoped: it withholds exactly the arming token.
+
+    Both directions are asserted in one run. An inverted membership check —
+    gating BLUESKY_TILED_API_KEY instead of BLUESKY_PROMOTE_TOKEN — silently
+    arms the promote path under local execution, and a test that only checked
+    for the Tiled key would still pass.
+    """
     config = _config(
         control_system={"writes_enabled": True},
         execution={"execution_method": "local"},
@@ -120,18 +141,56 @@ def test_bluesky_token_not_minted_when_writes_enabled_and_local(
         container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
 
     env = _parse_env(tmp_path)
+    # The arming token is withheld: the bridge's require_armed() keeps 503ing.
     assert "BLUESKY_PROMOTE_TOKEN" not in env
-    assert not (tmp_path / ".env").exists()
+    # Tiled persistence is not an arming capability — its key still mints.
+    assert env.get("BLUESKY_TILED_API_KEY")
+    assert len(env["BLUESKY_TILED_API_KEY"]) >= 40
+    # Smoke assertion only — a single sample is ~29% likely to pass even against
+    # a `token_urlsafe` recipe. The real guard on this invariant is
+    # `test_allowlisted_tiled_key_is_alphanumeric_on_every_unsafe_local_mint`
+    # below, which asserts it across 50 independent mints. Do not delete that
+    # one on the strength of this one.
+    assert env["BLUESKY_TILED_API_KEY"].isalnum()
 
     # caplog's handler already calls record.getMessage() (formatting in %args),
     # so r.message here is the final rendered string — no further % needed.
     warnings = " ".join(r.message for r in caplog.records)
+    assert "BLUESKY_PROMOTE_TOKEN" in warnings
+    assert "BLUESKY_TILED_API_KEY" not in warnings
     assert "bluesky" in warnings
     assert "writes_enabled" in warnings
     assert "local" in warnings
 
 
-def test_bluesky_token_minted_when_writes_enabled_and_container(
+def test_allowlisted_tiled_key_is_alphanumeric_on_every_unsafe_local_mint(
+    _clean_token_env, tmp_path
+):
+    """The allowlist path mints a key Tiled will actually accept.
+
+    ``.isalnum()`` on a single mint is not a guard: a token_urlsafe(32) value is
+    all-alphanumeric ~29% of the time, so one sample would pass by luck against
+    the recipe that crash-loops the Tiled container. Asserting the invariant
+    across 50 independent mints drops that to 0.29**50.
+
+    This is the guard for the *withheld-promote* configuration specifically: the
+    two behaviors are coupled — the promote token stays absent while this key
+    must still mint, and mint usably.
+    """
+    config = _config(
+        control_system={"writes_enabled": True},
+        execution={"execution_method": "local"},
+    )
+
+    for i in range(50):
+        env_path = tmp_path / f"{i}.env"
+        container_lifecycle._ensure_service_tokens(config, expose_network=False, env_path=env_path)
+        env = _parse_dotenv(env_path)
+        assert "BLUESKY_PROMOTE_TOKEN" not in env
+        assert env["BLUESKY_TILED_API_KEY"].isalnum(), f"mint {i}: {env['BLUESKY_TILED_API_KEY']!r}"
+
+
+def test_both_bluesky_tokens_minted_when_writes_enabled_and_container(
     captured_argv, _clean_token_env, monkeypatch, tmp_path
 ):
     config = _config(
@@ -145,6 +204,95 @@ def test_bluesky_token_minted_when_writes_enabled_and_container(
     env = _parse_env(tmp_path)
     assert env.get("BLUESKY_PROMOTE_TOKEN")
     assert len(env["BLUESKY_PROMOTE_TOKEN"]) >= 40
+    assert env.get("BLUESKY_TILED_API_KEY")
+    assert env["BLUESKY_TILED_API_KEY"] != env["BLUESKY_PROMOTE_TOKEN"]
+
+
+def test_allowlist_membership_is_pinned():
+    """Pin the allowlist so an inverted edit fails loudly, not silently."""
+    assert container_lifecycle._LOCAL_EXEC_SAFE_VARS == {
+        "BLUESKY_TILED_API_KEY",
+        "EVENT_DISPATCHER_TOKEN",
+        "DISPATCH_WORKER_TOKEN",
+    }
+    assert "BLUESKY_PROMOTE_TOKEN" not in container_lifecycle._LOCAL_EXEC_SAFE_VARS
+
+
+def test_every_declared_var_is_classified():
+    """No declared token var may be un-triaged.
+
+    Under the allowlist an unclassified var fails *closed*, so this test never
+    guards a security hole — it guards against a var silently ceasing to mint
+    because nobody reviewed it. If this fails, triage the new var: add it to
+    ``_LOCAL_EXEC_SAFE_VARS`` only if it grants no write-capable route the agent
+    can walk. Never edit the allowlist merely to make this pass.
+    """
+    declared = {
+        var for token_vars in container_lifecycle._SERVICE_TOKEN_VARS.values() for var in token_vars
+    }
+    unclassified = declared - container_lifecycle._LOCAL_EXEC_SAFE_VARS
+    assert unclassified == {"BLUESKY_PROMOTE_TOKEN"}
+    # Every allowlist entry is actually declared by some service — no dead entries.
+    assert container_lifecycle._LOCAL_EXEC_SAFE_VARS <= declared
+
+
+def test_unlisted_arming_token_fails_closed_under_unsafe_local_exec(
+    captured_argv, _clean_token_env, monkeypatch, tmp_path, caplog
+):
+    """A future service's arming token is withheld by *omission* from the allowlist.
+
+    This is the whole reason the gate is an allowlist rather than a blocklist. A
+    blocklist mints this token, warns about nothing, and leaves every other test
+    in the suite green.
+    """
+    monkeypatch.setattr(
+        container_lifecycle,
+        "_SERVICE_TOKEN_VARS",
+        {**container_lifecycle._SERVICE_TOKEN_VARS, "scan_engine": ("SCAN_ENGINE_ARM_TOKEN",)},
+    )
+    monkeypatch.delenv("SCAN_ENGINE_ARM_TOKEN", raising=False)
+    config = _config(
+        deployed_services=["bluesky", "scan_engine"],
+        control_system={"writes_enabled": True},
+        execution={"execution_method": "local"},
+    )
+    _patch_prepare_compose_files(monkeypatch, config)
+
+    with caplog.at_level(logging.WARNING, logger="deployment.lifecycle"):
+        container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    env = _parse_env(tmp_path)
+    assert "SCAN_ENGINE_ARM_TOKEN" not in env
+    assert "BLUESKY_PROMOTE_TOKEN" not in env
+    # The allowlisted key still mints — the gate withholds, it does not disable.
+    assert env.get("BLUESKY_TILED_API_KEY")
+
+    warnings = " ".join(r.message for r in caplog.records)
+    assert "SCAN_ENGINE_ARM_TOKEN" in warnings
+    assert "scan_engine" in warnings
+
+
+def test_unlisted_token_still_mints_under_safe_config(
+    captured_argv, _clean_token_env, monkeypatch, tmp_path
+):
+    """Fail-closed applies only under unsafe local exec, not to every unlisted var."""
+    monkeypatch.setattr(
+        container_lifecycle,
+        "_SERVICE_TOKEN_VARS",
+        {**container_lifecycle._SERVICE_TOKEN_VARS, "scan_engine": ("SCAN_ENGINE_ARM_TOKEN",)},
+    )
+    monkeypatch.delenv("SCAN_ENGINE_ARM_TOKEN", raising=False)
+    config = _config(
+        deployed_services=["scan_engine"],
+        control_system={"writes_enabled": True},
+        execution={"execution_method": "container"},
+    )
+    _patch_prepare_compose_files(monkeypatch, config)
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    env = _parse_env(tmp_path)
+    assert env.get("SCAN_ENGINE_ARM_TOKEN")
 
 
 def test_bluesky_token_minted_when_writes_enabled_and_execution_section_absent(
@@ -179,7 +327,11 @@ def test_bluesky_token_behavior_unchanged_when_writes_disabled(
 def test_guard_does_not_affect_dispatch_tokens(
     captured_argv, _clean_token_env, monkeypatch, tmp_path
 ):
-    """The guard is scoped to bluesky; dispatch tokens mint normally regardless."""
+    """The dispatch tokens are allowlisted, so they mint normally under unsafe local exec.
+
+    They gate an inbound webhook / worker-routing boundary, not a write-capable
+    route the agent itself walks.
+    """
     config = _config(
         deployed_services=["bluesky", "event_dispatcher", "dispatch_worker"],
         control_system={"writes_enabled": True},
@@ -191,12 +343,13 @@ def test_guard_does_not_affect_dispatch_tokens(
 
     env = _parse_env(tmp_path)
     assert "BLUESKY_PROMOTE_TOKEN" not in env
+    assert env.get("BLUESKY_TILED_API_KEY")
     assert env.get("EVENT_DISPATCHER_TOKEN")
     assert env.get("DISPATCH_WORKER_TOKEN")
 
 
 def test_existing_manual_token_left_untouched_under_unsafe_config(
-    captured_argv, monkeypatch, tmp_path
+    captured_argv, _clean_token_env, monkeypatch, tmp_path
 ):
     """A user-set token is a deliberate override; the guard neither reads nor clobbers it."""
     (tmp_path / ".env").write_text("BLUESKY_PROMOTE_TOKEN=manually-set\n", encoding="utf-8")
@@ -210,3 +363,5 @@ def test_existing_manual_token_left_untouched_under_unsafe_config(
 
     env = _parse_env(tmp_path)
     assert env["BLUESKY_PROMOTE_TOKEN"] == "manually-set"
+    # The Tiled key still mints alongside the operator's token.
+    assert env.get("BLUESKY_TILED_API_KEY")

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -1,0 +1,279 @@
+"""Assertions against the parsed `.github/workflows/ci.yml`, proving the two
+secret-free Docker-stack e2e lanes (Tiled roundtrip, VA substrate
+equivalence) are correctly wired.
+
+Everything here loads ci.yml with ``yaml.safe_load`` and asserts against the
+parsed structure — never a text/regex match, so re-flowing YAML style can't
+fool a check. YAML 1.1 parses the bare `on:` workflow-trigger key to the
+Python boolean ``True``; this module never indexes ``workflow["on"]``.
+
+Two secret-free jobs exist because two e2e files needed one each:
+
+* ``test_tiled_roundtrip.py`` (Task 4.1) is new in this phase and never had
+  a lane at all.
+* ``test_va_substrate_equivalence.py`` (Phase 1) had a CI bug: it carried no
+  dedicated job and was only ever swept up by ``e2e-tests``' glob over
+  ``tests/e2e/`` — contradicting its own module docstring ("never collected
+  by the fast lane"). Fixing that means giving it a real lane, not just
+  removing its only lane via ``--ignore``.
+
+Every assertion is paired with a mutation test: a fresh, in-memory-mutated
+copy of the parsed workflow reintroduces exactly the bug the assertion
+exists to catch, and the same assertion must then fail. ci.yml itself is
+never edited by this module.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+CI_YML = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "ci.yml"
+
+TILED_JOB = "tiled-roundtrip-e2e"
+VA_JOB = "va-substrate-equivalence-e2e"
+E2E_TESTS_JOB = "e2e-tests"
+GATE_JOB = "all-checks-passed"
+SECRET_TOKEN = "secrets.ALS_APG_API_KEY"
+TILED_TEST_FILE = "tests/e2e/test_tiled_roundtrip.py"
+VA_TEST_FILE = "tests/e2e/test_va_substrate_equivalence.py"
+
+
+def _load_workflow() -> dict[str, Any]:
+    with CI_YML.open() as f:
+        loaded = yaml.safe_load(f)
+    assert loaded is not None, f"{CI_YML} parsed to None"
+    return loaded
+
+
+@pytest.fixture()
+def workflow() -> dict[str, Any]:
+    return _load_workflow()
+
+
+def _jobs(wf: dict[str, Any]) -> dict[str, Any]:
+    return wf["jobs"]
+
+
+def _job_declares_secret(wf: dict[str, Any], job_name: str, token: str) -> bool:
+    """Search a job's fully serialized form for a secret-expression token.
+
+    Serializing the whole job (not just top-level keys) so the search also
+    covers step-level ``env:``/``run:`` blocks, matching how
+    ``ALS_APG_API_KEY`` actually appears in the secret-gated jobs (e.g.
+    ``e2e-tests``'s pre-flight probe step).
+    """
+    return token in json.dumps(_jobs(wf)[job_name])
+
+
+def _find_named_step(wf: dict[str, Any], job_name: str, step_name: str) -> dict[str, Any]:
+    for step in _jobs(wf)[job_name]["steps"]:
+        if step.get("name") == step_name:
+            return step
+    raise AssertionError(f"job '{job_name}' has no step named '{step_name}'")
+
+
+# ---------------------------------------------------------------------------
+# (a) tiled-roundtrip-e2e job exists
+# ---------------------------------------------------------------------------
+
+
+def test_tiled_roundtrip_job_exists(workflow: dict[str, Any]) -> None:
+    assert TILED_JOB in _jobs(workflow)
+
+
+def test_tiled_roundtrip_job_exists__mutation_drops_job() -> None:
+    """Dropping the job from the parsed dict must fail the existence check."""
+    mutated = copy.deepcopy(_load_workflow())
+    del mutated["jobs"][TILED_JOB]
+    with pytest.raises(AssertionError):
+        assert TILED_JOB in _jobs(mutated)
+
+
+# ---------------------------------------------------------------------------
+# (a) va-substrate-equivalence-e2e job exists (the Phase-1 gap fix)
+# ---------------------------------------------------------------------------
+
+
+def test_va_substrate_equivalence_job_exists(workflow: dict[str, Any]) -> None:
+    assert VA_JOB in _jobs(workflow)
+
+
+def test_va_substrate_equivalence_job_exists__mutation_drops_job() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    del mutated["jobs"][VA_JOB]
+    with pytest.raises(AssertionError):
+        assert VA_JOB in _jobs(mutated)
+
+
+# ---------------------------------------------------------------------------
+# (b) tiled-roundtrip-e2e declares no ALS_APG_API_KEY secret anywhere in it
+# ---------------------------------------------------------------------------
+
+
+def test_tiled_roundtrip_job_has_no_llm_secret(workflow: dict[str, Any]) -> None:
+    assert not _job_declares_secret(workflow, TILED_JOB, SECRET_TOKEN)
+
+
+def test_tiled_roundtrip_job_has_no_llm_secret__mutation_adds_secret() -> None:
+    """Injecting the secret into a step env must flip the check to failing."""
+    mutated = copy.deepcopy(_load_workflow())
+    mutated["jobs"][TILED_JOB]["steps"].append(
+        {"name": "inject", "env": {"ALS_APG_API_KEY": "${{ secrets.ALS_APG_API_KEY }}"}}
+    )
+    with pytest.raises(AssertionError):
+        assert not _job_declares_secret(mutated, TILED_JOB, SECRET_TOKEN)
+
+
+def test_tiled_roundtrip_job_has_no_llm_secret__mutation_survives_lookalike() -> None:
+    """A differently-spelled secret expression must NOT trip the assertion —
+    proves the check matches the real token, not any 'secrets.' substring."""
+    mutated = copy.deepcopy(_load_workflow())
+    mutated["jobs"][TILED_JOB]["steps"].append(
+        {"name": "unrelated", "env": {"CODECOV_TOKEN": "${{ secrets.CODECOV_TOKEN }}"}}
+    )
+    assert not _job_declares_secret(mutated, TILED_JOB, SECRET_TOKEN)
+
+
+# ---------------------------------------------------------------------------
+# (b) va-substrate-equivalence-e2e declares no ALS_APG_API_KEY secret either
+# ---------------------------------------------------------------------------
+
+
+def test_va_substrate_equivalence_job_has_no_llm_secret(workflow: dict[str, Any]) -> None:
+    assert not _job_declares_secret(workflow, VA_JOB, SECRET_TOKEN)
+
+
+def test_va_substrate_equivalence_job_has_no_llm_secret__mutation_adds_secret() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    mutated["jobs"][VA_JOB]["steps"].append(
+        {"name": "inject", "env": {"ALS_APG_API_KEY": "${{ secrets.ALS_APG_API_KEY }}"}}
+    )
+    with pytest.raises(AssertionError):
+        assert not _job_declares_secret(mutated, VA_JOB, SECRET_TOKEN)
+
+
+# ---------------------------------------------------------------------------
+# (c) e2e-tests' run step --ignores both new-lane files
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_tests_ignores_both_new_lane_files(workflow: dict[str, Any]) -> None:
+    step = _find_named_step(workflow, E2E_TESTS_JOB, "Run E2E tests")
+    run_text = step["run"]
+    assert f"--ignore={TILED_TEST_FILE}" in run_text
+    assert f"--ignore={VA_TEST_FILE}" in run_text
+
+
+def _drop_ignore_line(run_text: str, target_file: str) -> str:
+    """Remove the `--ignore=<target_file>` line, whichever way it happens to
+    be terminated (line-continuation backslash mid-list, or bare newline on
+    the last entry)."""
+    lines = run_text.splitlines(keepends=True)
+    kept = [line for line in lines if f"--ignore={target_file}" not in line]
+    assert len(kept) == len(lines) - 1, f"expected exactly one line dropped for {target_file}"
+    return "".join(kept)
+
+
+def test_e2e_tests_ignores_both_new_lane_files__mutation_drops_tiled_ignore() -> None:
+    """Removing only the tiled-roundtrip ignore line must fail — proves the
+    two ignore assertions are independent, not satisfied by either alone."""
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, E2E_TESTS_JOB, "Run E2E tests")
+    step["run"] = _drop_ignore_line(step["run"], TILED_TEST_FILE)
+    assert f"--ignore={VA_TEST_FILE}" in step["run"]  # the other survives untouched
+    with pytest.raises(AssertionError):
+        assert f"--ignore={TILED_TEST_FILE}" in step["run"]
+
+
+def test_e2e_tests_ignores_both_new_lane_files__mutation_drops_va_ignore() -> None:
+    """Removing only the VA-substrate ignore line must fail the same way,
+    confirming the two files are checked independently in the real assertion."""
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, E2E_TESTS_JOB, "Run E2E tests")
+    step["run"] = _drop_ignore_line(step["run"], VA_TEST_FILE)
+    assert f"--ignore={TILED_TEST_FILE}" in step["run"]  # the other survives untouched
+    with pytest.raises(AssertionError):
+        assert f"--ignore={VA_TEST_FILE}" in step["run"]
+
+
+# ---------------------------------------------------------------------------
+# (d) all-checks-passed depends on the new job(s)
+# ---------------------------------------------------------------------------
+
+
+def test_all_checks_passed_needs_tiled_roundtrip(workflow: dict[str, Any]) -> None:
+    assert TILED_JOB in _jobs(workflow)[GATE_JOB]["needs"]
+
+
+def test_all_checks_passed_needs_tiled_roundtrip__mutation_drops_needs_entry() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    needs = _jobs(mutated)[GATE_JOB]["needs"]
+    needs.remove(TILED_JOB)
+    with pytest.raises(AssertionError):
+        assert TILED_JOB in _jobs(mutated)[GATE_JOB]["needs"]
+
+
+def test_all_checks_passed_needs_va_substrate_equivalence(workflow: dict[str, Any]) -> None:
+    assert VA_JOB in _jobs(workflow)[GATE_JOB]["needs"]
+
+
+def test_all_checks_passed_needs_va_substrate_equivalence__mutation_drops_needs_entry() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    needs = _jobs(mutated)[GATE_JOB]["needs"]
+    needs.remove(VA_JOB)
+    with pytest.raises(AssertionError):
+        assert VA_JOB in _jobs(mutated)[GATE_JOB]["needs"]
+
+
+def _needs_contains_both_new_jobs(wf: dict[str, Any]) -> bool:
+    """Deliberately `all(...)`, not `any(...)`. An `any`-shaped check would
+    pass with only one of the two new jobs wired into the gate — exactly the
+    silent-partial-fix shape this phase has repeatedly caught elsewhere."""
+    needs = _jobs(wf)[GATE_JOB]["needs"]
+    return all(job in needs for job in (TILED_JOB, VA_JOB))
+
+
+def test_all_checks_passed_needs_both_new_jobs(workflow: dict[str, Any]) -> None:
+    """(g) A single job nobody depends on can go red forever without
+    blocking a merge; both new e2e lanes must actually gate the merge."""
+    assert _needs_contains_both_new_jobs(workflow)
+
+
+def test_all_checks_passed_needs_both_new_jobs__mutation_drops_only_tiled() -> None:
+    """Dropping just tiled-roundtrip-e2e (VA stays) must still fail the
+    'both' check — proves it isn't secretly an `any`."""
+    mutated = copy.deepcopy(_load_workflow())
+    _jobs(mutated)[GATE_JOB]["needs"].remove(TILED_JOB)
+    assert VA_JOB in _jobs(mutated)[GATE_JOB]["needs"]  # the other survives untouched
+    with pytest.raises(AssertionError):
+        assert _needs_contains_both_new_jobs(mutated)
+
+
+def test_all_checks_passed_needs_both_new_jobs__mutation_drops_only_va() -> None:
+    """Dropping just va-substrate-equivalence-e2e (tiled stays) must also
+    fail the 'both' check, confirming both entries are independently load-bearing."""
+    mutated = copy.deepcopy(_load_workflow())
+    _jobs(mutated)[GATE_JOB]["needs"].remove(VA_JOB)
+    assert TILED_JOB in _jobs(mutated)[GATE_JOB]["needs"]  # the other survives untouched
+    with pytest.raises(AssertionError):
+        assert _needs_contains_both_new_jobs(mutated)
+
+
+# ---------------------------------------------------------------------------
+# YAML 1.1 `on:` gotcha regression guard
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_on_key_parses_to_bool_true_not_string(workflow: dict[str, Any]) -> None:
+    """Documents the YAML 1.1 footgun this module deliberately avoids: the
+    bare `on:` trigger key parses to the Python bool True, not the string
+    'on'. Indexing workflow['on'] would KeyError; every fixture/helper above
+    only ever indexes workflow['jobs']."""
+    assert True in workflow
+    assert "on" not in workflow

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -287,7 +287,9 @@ def test_unit_test_job_installs_bridge_extras(workflow: dict[str, Any]) -> None:
     """
     cmd = _unit_test_install_cmd(workflow)
     for extra in ("dev", "virtual-accelerator", "bluesky-bridge"):
-        assert f"--extra {extra}" in cmd, f"unit-test job must `uv sync --extra {extra}`; got: {cmd}"
+        assert f"--extra {extra}" in cmd, (
+            f"unit-test job must `uv sync --extra {extra}`; got: {cmd}"
+        )
 
 
 def test_unit_test_job_installs_bridge_extras__mutation_drops_bluesky_extra() -> None:

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import copy
 import json
+import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -37,6 +38,7 @@ CI_YML = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "ci.yml
 
 TILED_JOB = "tiled-roundtrip-e2e"
 VA_JOB = "va-substrate-equivalence-e2e"
+UNIT_TEST_JOB = "test"
 E2E_TESTS_JOB = "e2e-tests"
 GATE_JOB = "all-checks-passed"
 SECRET_TOKEN = "secrets.ALS_APG_API_KEY"
@@ -263,6 +265,49 @@ def test_all_checks_passed_needs_both_new_jobs__mutation_drops_only_va() -> None
     assert TILED_JOB in _jobs(mutated)[GATE_JOB]["needs"]  # the other survives untouched
     with pytest.raises(AssertionError):
         assert _needs_contains_both_new_jobs(mutated)
+
+
+# ---------------------------------------------------------------------------
+# The unit-test job must install the extras its tests import
+# ---------------------------------------------------------------------------
+
+
+def _unit_test_install_cmd(wf: dict[str, Any]) -> str:
+    return _find_named_step(wf, UNIT_TEST_JOB, "Install dependencies")["run"]
+
+
+def test_unit_test_job_installs_bridge_extras(workflow: dict[str, Any]) -> None:
+    """The bridge's unit tests guard their imports with `pytest.importorskip`,
+    so a missing extra does not error — it SKIPS. Without `bluesky-bridge` the
+    scanner, RunEngine-integration and Tiled fault-isolation guards vanish from
+    CI silently, inside a green check. This pins the extra so that cannot recur.
+
+    `virtual-accelerator` is pinned for the opposite reason: tests/va/* import
+    softioc unguarded and error at collection without it.
+    """
+    cmd = _unit_test_install_cmd(workflow)
+    for extra in ("dev", "virtual-accelerator", "bluesky-bridge"):
+        assert f"--extra {extra}" in cmd, f"unit-test job must `uv sync --extra {extra}`; got: {cmd}"
+
+
+def test_unit_test_job_installs_bridge_extras__mutation_drops_bluesky_extra() -> None:
+    """Dropping the bluesky-bridge extra must fail — otherwise the guard is
+    decorative and the bridge tests resume skipping unnoticed."""
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, UNIT_TEST_JOB, "Install dependencies")
+    step["run"] = step["run"].replace(" --extra bluesky-bridge", "")
+    with pytest.raises(AssertionError):
+        test_unit_test_job_installs_bridge_extras(mutated)
+
+
+def test_bluesky_bridge_extra_is_declared_in_pyproject() -> None:
+    """The extra the CI job installs must actually exist. A typo'd `--extra`
+    makes `uv sync` fail loudly, but pinning the name here fails faster and
+    names the contract in one place."""
+    pyproject = tomllib.loads((CI_YML.parents[2] / "pyproject.toml").read_text())
+    extras = pyproject["project"]["optional-dependencies"]
+    assert "bluesky-bridge" in extras
+    assert any(dep.startswith("bluesky") for dep in extras["bluesky-bridge"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/deployment/test_compose_generator.py
+++ b/tests/deployment/test_compose_generator.py
@@ -309,3 +309,121 @@ def test_bluesky_va_ca_port_defaults_when_va_config_block_absent() -> None:
         services={"bluesky": {"port": 8090}},  # no virtual_accelerator key
     )
     assert 'EPICS_CA_NAME_SERVERS: "virtual-accelerator:5064"' in rendered
+
+
+def _render_bluesky_tiled(*, tiled_enabled: bool, va_deployed: bool = False) -> str:
+    return _render_bluesky_template(
+        va_deployed=va_deployed,
+        services={"bluesky": {"port": 8090, "tiled_enabled": tiled_enabled}},
+    )
+
+
+def test_bluesky_tiled_service_renders_when_enabled() -> None:
+    """Task 1.1: ``tiled_enabled: true`` must render a writable-catalog Tiled
+    server wired for the bridge's TiledWriter subscription (Task 2.7).
+
+    ``serve catalog`` aborts without a catalog DB argument and defaults to
+    127.0.0.1 (unreachable from the bridge container) without ``--host``.
+    ``TiledWriter`` appends event tables via ``create_appendable_table`` +
+    ``append_partition``, which need SQL-family storage — hence the
+    ``duckdb://`` writable target alongside the filesystem one.
+
+    The duckdb:// target uses FOUR slashes (Task 1.5 fix), not three: this
+    is the standard SQLAlchemy DBAPI URI convention where an empty host
+    segment leaves the path relative (three slashes, resolved against the
+    container's CWD) or absolute (four slashes). Three slashes resolved to
+    the relative path "storage/data.duckdb" against /app and failed
+    server-side ("The directory storage does not exist."), which
+    ``_FaultIsolatedTiledWriter`` caught and silently latched
+    ``tiled_degraded=True`` — the scan still completed, so nothing crashed
+    and persistence just silently didn't happen. The client-visible symptom
+    (a 409 on the run's metadata POST) points at TiledWriter's write logic,
+    not at the storage URI — the real cause is visible only server-side.
+
+    The catalog volume mounts at /storage, NOT /data (Task 1.3 fix):
+    ``ghcr.io/bluesky/tiled:0.2.12`` ships /storage pre-owned by uid=999(app),
+    the user the container runs as, so a fresh named volume inherits that
+    ownership from the image. /data does not exist in the image, so Docker
+    creates it root:root and the uid=999 tiled process can't open a catalog
+    DB there — the container exits 1 immediately and /healthz never answers.
+    This is a render-time assertion only: it pins the path the fix depends
+    on, but rendering a template can't execute the image or verify volume
+    ownership — that's the round-trip e2e's job.
+    """
+    rendered = _render_bluesky_tiled(tiled_enabled=True)
+
+    assert "\n  tiled:\n" in rendered
+    assert "ghcr.io/bluesky/tiled:0.2.12" in rendered
+
+    assert "tiled serve catalog /storage/catalog.db" in rendered
+    assert "--init" in rendered
+    assert "--host 0.0.0.0" in rendered
+    assert "--port 8000" in rendered
+    assert "-w /storage/files" in rendered
+    assert "bluesky_tiled_catalog:/storage" in rendered
+
+    # Task 1.6: --api-key must be the QUOTED form with a `:?` fail-closed
+    # default, never the bare unquoted `${BLUESKY_TILED_API_KEY}`. Compose
+    # splits this string `command:` form shlex-style, so an unset/empty
+    # value in the bare form contributes NO argument at all (not an empty
+    # one) — `--api-key` then silently swallows the next token (`-w`) as
+    # its operand and a writable target vanishes, with the resulting error
+    # pointing at `-w`, never at the empty key. A substring check for just
+    # "--api-key" passes for both forms, so it can't discriminate; these
+    # two must.
+    assert '--api-key "${BLUESKY_TILED_API_KEY:?must be a non-empty alphanumeric key}"' in rendered
+    assert "--api-key ${BLUESKY_TILED_API_KEY}" not in rendered
+
+    # Neither the mount point nor the command paths may regress to /data:
+    # that was the Task 1.3 bug (a root-owned mount point uid=999 can't
+    # write to), and together these two absent-assertions are what would
+    # catch a regression back to it.
+    #
+    # ":/data" pins the volume MOUNT (the actual root cause — e.g. a
+    # regressed "bluesky_tiled_catalog:/data" line, which has no trailing
+    # slash so a bare "/data/" check would miss it entirely).
+    # "/data/" pins the COMMAND paths (catalog.db, files, duckdb target).
+    # Bare "/data" isn't usable for either: it false-positives on
+    # "duckdb:////storage/data.duckdb", whose filename legitimately
+    # contains "data" as a substring of "storage".
+    assert ":/data" not in rendered
+    assert "/data/" not in rendered
+
+    # The duckdb writable target must use exactly FOUR slashes (Task 1.5
+    # fix) for an absolute path, never three (which SQLAlchemy resolves as
+    # a CWD-relative path and Tiled rejects server-side). A bare
+    # "duckdb://" in rendered assertion is useless here: it passes for
+    # both the correct four-slash form and the buggy three-slash form.
+    assert "-w duckdb:////storage/data.duckdb" in rendered
+    assert "duckdb:///storage/data.duckdb" not in rendered
+
+    # /healthz must be probed in-image via python (curl is not in the image).
+    assert "localhost:8000/healthz" in rendered
+    assert "python -c" in rendered
+
+    # bridge env, fail-closed (no `:-` default on the API key)
+    assert 'BLUESKY_TILED_URI: "http://tiled:8000"' in rendered
+    assert "BLUESKY_TILED_API_KEY: ${BLUESKY_TILED_API_KEY}" in rendered
+
+
+def test_bluesky_tiled_absent_when_disabled() -> None:
+    """``tiled_enabled: false`` (the default) must render neither the tiled
+    service nor any ``BLUESKY_TILED_*`` bridge env — Tiled is fully optional.
+    """
+    rendered = _render_bluesky_tiled(tiled_enabled=False)
+
+    assert "\n  tiled:\n" not in rendered
+    assert "BLUESKY_TILED_URI" not in rendered
+    assert "BLUESKY_TILED_API_KEY" not in rendered
+    assert "bluesky_tiled_catalog" not in rendered
+
+
+@pytest.mark.parametrize("tiled_enabled", [True, False])
+def test_bluesky_bridge_never_depends_on_tiled(tiled_enabled: bool) -> None:
+    """A Tiled outage must never block the bridge from starting (FR4): the
+    bridge must never get ``depends_on: tiled`` / ``condition:
+    service_healthy`` gating on the tiled service, whether or not Tiled
+    itself is deployed.
+    """
+    rendered = _render_bluesky_tiled(tiled_enabled=tiled_enabled)
+    assert "depends_on:\n      tiled:" not in rendered

--- a/tests/deployment/test_scan_token_mint.py
+++ b/tests/deployment/test_scan_token_mint.py
@@ -9,9 +9,15 @@ promote attempt after a fresh deploy.
 
 from __future__ import annotations
 
+import secrets
+
 import pytest
 
 from osprey.deployment import container_lifecycle
+
+# Every var any service declares, so the scoping tests below cannot silently
+# stop covering a var that gets added later.
+_NON_TILED_VARS = ("BLUESKY_PROMOTE_TOKEN", "EVENT_DISPATCHER_TOKEN", "DISPATCH_WORKER_TOKEN")
 
 
 @pytest.fixture
@@ -39,17 +45,21 @@ def captured_argv(monkeypatch, tmp_path):
 
 @pytest.fixture
 def _clean_token_env(monkeypatch):
-    """Ensure the bluesky promote token (and dispatch tokens) are unset in the process env."""
+    """Ensure the bluesky tokens (and dispatch tokens) are unset in the process env."""
     monkeypatch.delenv("BLUESKY_PROMOTE_TOKEN", raising=False)
+    monkeypatch.delenv("BLUESKY_TILED_API_KEY", raising=False)
     monkeypatch.delenv("EVENT_DISPATCHER_TOKEN", raising=False)
     monkeypatch.delenv("DISPATCH_WORKER_TOKEN", raising=False)
 
 
-def _parse_env(tmp_path):
+def _parse_dotenv(path):
     from osprey.utils.dotenv import parse_dotenv_file
 
-    p = tmp_path / ".env"
-    return parse_dotenv_file(p) if p.is_file() else {}
+    return parse_dotenv_file(path) if path.is_file() else {}
+
+
+def _parse_env(tmp_path):
+    return _parse_dotenv(tmp_path / ".env")
 
 
 def test_bluesky_deploy_generates_promote_token(captured_argv, _clean_token_env, tmp_path):
@@ -64,6 +74,20 @@ def test_bluesky_deploy_generates_promote_token(captured_argv, _clean_token_env,
     assert "DISPATCH_WORKER_TOKEN" not in env
 
 
+def test_bluesky_deploy_generates_tiled_api_key(captured_argv, _clean_token_env, tmp_path):
+    """The Tiled catalog key hangs off the deployed 'bluesky' service.
+
+    Keying it off a 'tiled' service would never mint: 'tiled' is never in
+    deployed_services, so the membership guard skips it before any minting.
+    """
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True, dev_mode=False)
+
+    env = _parse_env(tmp_path)
+    assert env.get("BLUESKY_TILED_API_KEY")
+    assert len(env["BLUESKY_TILED_API_KEY"]) >= 40
+    assert env["BLUESKY_TILED_API_KEY"] != env["BLUESKY_PROMOTE_TOKEN"]
+
+
 def test_bluesky_token_generation_is_idempotent(captured_argv, _clean_token_env, tmp_path):
     container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
     first = _parse_env(tmp_path)
@@ -71,9 +95,11 @@ def test_bluesky_token_generation_is_idempotent(captured_argv, _clean_token_env,
     second = _parse_env(tmp_path)
 
     assert first["BLUESKY_PROMOTE_TOKEN"] == second["BLUESKY_PROMOTE_TOKEN"]
+    assert first["BLUESKY_TILED_API_KEY"] == second["BLUESKY_TILED_API_KEY"]
     # No duplicate keys appended on the second run.
     text = (tmp_path / ".env").read_text()
     assert text.count("BLUESKY_PROMOTE_TOKEN=") == 1
+    assert text.count("BLUESKY_TILED_API_KEY=") == 1
 
 
 def test_bluesky_existing_env_token_is_preserved(captured_argv, _clean_token_env, tmp_path):
@@ -146,7 +172,115 @@ def test_bluesky_alongside_dispatch_mints_both_independently(
 
 
 def test_service_token_vars_map_includes_bluesky():
-    """Locks in the generalized map shape task 2.10 introduces."""
-    assert container_lifecycle._SERVICE_TOKEN_VARS["bluesky"] == ("BLUESKY_PROMOTE_TOKEN",)
+    """Locks in the generalized map shape."""
+    assert container_lifecycle._SERVICE_TOKEN_VARS["bluesky"] == (
+        "BLUESKY_PROMOTE_TOKEN",
+        "BLUESKY_TILED_API_KEY",
+    )
     assert "event_dispatcher" in container_lifecycle._SERVICE_TOKEN_VARS
     assert "dispatch_worker" in container_lifecycle._SERVICE_TOKEN_VARS
+
+
+# ---------------------------------------------------------------------------
+# Per-variable secret alphabets.
+#
+# Tiled validates its --api-key at server startup and exits with
+# ValueError("The API key must only contain alphanumeric characters") on
+# anything else, so a key drawn from token_urlsafe's alphabet (which includes
+# '-' and '_') crash-loops the container. Roughly 71% of token_urlsafe(32)
+# values contain at least one such character, which makes the failure a
+# non-deterministic property of the deploy rather than of the code.
+# ---------------------------------------------------------------------------
+
+_MINT_SAMPLES = 200
+
+
+def test_tiled_api_key_generator_is_always_alphanumeric():
+    """Assert over many mints: a single sample proves nothing here.
+
+    A token_urlsafe(32) value happens to be all-alphanumeric about 29% of the
+    time, so a one-shot ``.isalnum()`` assertion would pass by luck on roughly
+    three runs in ten even against the unfixed generator — a flaky test, not a
+    guard. Over ``_MINT_SAMPLES`` draws the regression's survival probability is
+    0.29**200, i.e. zero for any practical purpose.
+    """
+    keys = [
+        container_lifecycle._generate_token("BLUESKY_TILED_API_KEY") for _ in range(_MINT_SAMPLES)
+    ]
+
+    assert all(k for k in keys), "minted an empty API key"
+    offenders = [k for k in keys if not k.isalnum()]
+    assert not offenders, (
+        f"{len(offenders)}/{_MINT_SAMPLES} keys are not alphanumeric: {offenders[:3]}"
+    )
+    # token_hex(32): 64 hex chars, 256 bits — no weaker than token_urlsafe(32).
+    assert {len(k) for k in keys} == {64}
+    assert len(set(keys)) == _MINT_SAMPLES, "generator is not random"
+
+
+def test_ensure_service_tokens_writes_an_alphanumeric_tiled_key_every_time(
+    tmp_path, _clean_token_env
+):
+    """The alphanumeric alphabet survives the real mint path, not just the generator.
+
+    Same reasoning as above on the sample count: the value that reaches ``.env``
+    is what Tiled parses, so the property is asserted end-to-end over many
+    independent mints rather than once.
+    """
+    config = {"deployed_services": ["bluesky"]}
+
+    for i in range(50):
+        env_path = tmp_path / f"{i}.env"
+        container_lifecycle._ensure_service_tokens(config, expose_network=False, env_path=env_path)
+        key = _parse_dotenv(env_path)["BLUESKY_TILED_API_KEY"]
+        assert key.isalnum(), f"mint {i} produced a Tiled-rejecting key: {key!r}"
+
+
+def test_only_the_tiled_key_overrides_the_default_generator():
+    """Pin the blast radius: exactly one var changed alphabets."""
+    assert set(container_lifecycle._VAR_GENERATORS) == {"BLUESKY_TILED_API_KEY"}
+    declared = {
+        var for token_vars in container_lifecycle._SERVICE_TOKEN_VARS.values() for var in token_vars
+    }
+    # Every overridden var is one some service actually declares — no dead entries.
+    assert set(container_lifecycle._VAR_GENERATORS) <= declared
+
+
+@pytest.mark.parametrize("var", _NON_TILED_VARS)
+def test_non_tiled_vars_still_use_token_urlsafe(monkeypatch, var):
+    """Deterministic proof of routing: patch both recipes and see which is called."""
+    monkeypatch.setattr(secrets, "token_urlsafe", lambda n: f"urlsafe-{n}")
+    monkeypatch.setattr(secrets, "token_hex", lambda n: f"hex{n}")
+
+    assert container_lifecycle._generate_token(var) == "urlsafe-32"
+    assert container_lifecycle._generate_token("BLUESKY_TILED_API_KEY") == "hex32"
+
+
+@pytest.mark.parametrize("var", _NON_TILED_VARS)
+def test_non_tiled_vars_are_not_forced_alphanumeric(var):
+    """The other tokens keep the url-safe alphabet; they were never the problem.
+
+    Behavioral counterpart to the routing test above: a '-' or '_' must still
+    appear across many mints. (P(false failure) = 0.29**200.)
+    """
+    minted = [container_lifecycle._generate_token(var) for _ in range(_MINT_SAMPLES)]
+
+    assert any(not t.isalnum() for t in minted), (
+        f"{var} looks forced-alphanumeric — the fix should have been scoped to "
+        "BLUESKY_TILED_API_KEY alone"
+    )
+    assert all(len(t) >= 40 for t in minted)
+
+
+def test_deploy_up_routes_each_var_through_its_own_generator(
+    captured_argv, _clean_token_env, monkeypatch, tmp_path
+):
+    """The mint site consults the registry — it does not hardcode one recipe."""
+    monkeypatch.setattr(secrets, "token_urlsafe", lambda n: "sentinel-urlsafe_value")
+    monkeypatch.setattr(secrets, "token_hex", lambda n: "sentinelhexvalue")
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    env = _parse_env(tmp_path)
+    assert env["BLUESKY_TILED_API_KEY"] == "sentinelhexvalue"
+    assert env["BLUESKY_PROMOTE_TOKEN"] == "sentinel-urlsafe_value"

--- a/tests/e2e/test_tiled_roundtrip.py
+++ b/tests/e2e/test_tiled_roundtrip.py
@@ -1,0 +1,381 @@
+"""Phase 2 acceptance proof: scan data survives a Bluesky bridge restart via
+the co-deployed Tiled catalog (PROPOSAL.md's success criterion 11).
+
+Deploys the bridge + Tiled with the mock-devices demo scanner
+(``bluesky.demo_scanner=true``, ``bluesky.tiled_enabled=true`` — no virtual
+accelerator, no EPICS, no QEMU: the demo scanner runs a real bluesky
+RunEngine against in-process mock devices), runs a scan to completion,
+restarts ONLY the bridge container, and reads the same run back through the
+same agent-facing endpoint (``GET /runs/{run_id}/data``). The in-memory run
+registry and live-row buffer die with the bridge; the only thing that can
+make the post-restart read return anything is the durable Tiled catalog,
+found via ``osprey_run_id`` stamped into the RunEngine start doc (task 2.3)
+and searched for by ``_from_tiled`` (task 3.2/3.3) after the registry lookup
+misses.
+
+This is why the pre-restart poll waits for ``status == "completed"``, not
+merely "promoted" or "running": ``TiledWriter`` caches events and flushes
+only at the stop doc (or its own ``batch_size`` cap), so restarting before
+completion would lose every cached event while ``tiled_degraded`` still read
+``False`` (Landmine 4 in the research brief) — a proof that would pass
+vacuously.
+
+Container safety: every docker invocation below names an exact container or
+image — never a wildcard, never ``system prune``/``--volumes``. Teardown
+goes through ``osprey deploy down``, never a raw ``docker rm`` sweep. The
+restart step names ``osprey-bluesky-bridge`` only; ``osprey deploy restart``
+is never used here because it bounces every service, including Tiled, which
+would defeat the whole proof.
+
+Markers: no ``pytest.mark.flaky`` anywhere in this module — this file's
+entire body IS the acceptance proof, so the round-trip assertions must stay
+strict (mirrors ``test_va_substrate_equivalence.py``'s P5 convention: the
+safety/acceptance proof is never swept into lenient reruns).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Deliberately distinct from test_scan_deploy.py's 18090 and
+# test_va_substrate_equivalence.py's 18099 so all three can run concurrently
+# on a shared dev machine without a port collision.
+BRIDGE_PORT = 18101
+BRIDGE_URL = f"http://localhost:{BRIDGE_PORT}"
+BRIDGE_IMAGE = "osprey-bluesky-bridge:local"
+BRIDGE_CONTAINER = "osprey-bluesky-bridge"
+TILED_CONTAINER = "osprey-bluesky-tiled"
+
+# The demo scanner's mock device factory (devices/mock.py's build_devices())
+# defaults to a single "det1" MockDetector when the bridge's app.py lifespan
+# hook wires it with no explicit motor/detector names.
+DEMO_DETECTOR = "det1"
+
+# The bridge's promote route (POST /runs/{id}/promote) fails closed on an
+# unset BLUESKY_PROMOTE_TOKEN. The control-assistant preset deploys with
+# control_system.writes_enabled: true AND execution.execution_method: local,
+# which deliberately gates auto-arming off for that token
+# (container_lifecycle._local_exec_arming_unsafe) — a local unsandboxed agent
+# could otherwise read the token straight out of .env and bypass the write
+# gate. This e2e is a controlled test, not agent code, so it supplies its own
+# token explicitly (the supported operator-provides-a-token path) rather than
+# exercise that arming policy here. BLUESKY_TILED_API_KEY, by contrast, is on
+# the local-exec-safe allowlist (it grants catalog access only, no
+# write-capable bridge route) and auto-mints regardless — no need to supply
+# it ourselves.
+PROMOTE_TOKEN = "e2e-tiled-roundtrip-promote-token"
+
+BUILD_TIMEOUT_SEC = 300
+DEPLOY_UP_TIMEOUT_SEC = 600
+HEALTH_TIMEOUT_SEC = 300.0
+CONTAINER_HEALTH_TIMEOUT_SEC = 90.0  # docker healthcheck start_period + a few intervals
+SCAN_TIMEOUT_SEC = 60.0
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.slow,
+    pytest.mark.skipif(shutil.which("docker") is None, reason="docker not available"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Build/deploy scaffold (mirrors tests/e2e/test_va_substrate_equivalence.py's shape)
+# ---------------------------------------------------------------------------
+
+
+def _find_osprey_console_script() -> Path:
+    candidate = Path(sys.executable).parent / "osprey"
+    if candidate.exists():
+        return candidate
+    found = shutil.which("osprey")
+    if found:
+        return Path(found)
+    raise RuntimeError("Could not locate the 'osprey' console script.")
+
+
+def _run(cmd: list[str], cwd: Path, timeout: int) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env={**os.environ, "CLAUDECODE": ""},
+    )
+
+
+def _write_promote_token(project_dir: Path) -> None:
+    """Append BLUESKY_PROMOTE_TOKEN to the project .env BEFORE ``osprey deploy
+    up`` -- the bridge compose template passes it through from the project
+    .env, same mechanism as task 4.2's substrate-equivalence e2e."""
+    env_path = project_dir / ".env"
+    existing = env_path.read_text(encoding="utf-8") if env_path.exists() else ""
+    if existing and not existing.endswith("\n"):
+        existing += "\n"
+    env_path.write_text(existing + f"BLUESKY_PROMOTE_TOKEN={PROMOTE_TOKEN}\n", encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
+    """Build + co-deploy the bridge and Tiled; yield the project directory."""
+    osprey_bin = _find_osprey_console_script()
+    base = tmp_path_factory.mktemp("tiled_roundtrip_build")
+    project_dir = base / "proj"
+
+    # `dispatch: null` drops control-assistant's default event-dispatcher
+    # stack (Node + Claude CLI image) -- irrelevant to this proof and far
+    # slower to build than the bridge/Tiled images already are. Only
+    # top-level profile-key overrides go through -O (a flat-dotted `--set`
+    # would build a nested dict for `dispatch`, not null it out).
+    #
+    # services.postgresql.port_host: the control-assistant preset always
+    # deploys an ariel-postgres service (config.yml.j2 bakes it into
+    # deployed_services unconditionally, for ARIEL logbook search -- there is
+    # no profile knob to drop it), hardcoded to host port 5432. This proof
+    # never touches ariel/postgres at all, but a colliding local Postgres
+    # (or another project's container already bound to 5432) would abort
+    # `deploy up` before the bridge/Tiled containers it creates alongside it
+    # ever start. Moved to a high, unassigned port -- same defensive
+    # convention as this fixture's own BRIDGE_PORT choice above.
+    override_path = base / "override.yml"
+    override_path.write_text(
+        "dispatch: null\nconfig:\n  services.postgresql.port_host: 15432\n", encoding="utf-8"
+    )
+
+    # bluesky.port/demo_scanner/tiled_enabled are all leaf scalars under the
+    # top-level `bluesky:` profile key, so plain --set works (a dotted --set
+    # only becomes unsafe for keys nested under an existing block you don't
+    # want replaced wholesale, e.g. control_system.type -- not the case
+    # here: we don't touch control_system at all, so the preset's default
+    # `control_system.type: mock` stands, which is all the demo scanner
+    # needs -- no CA, no virtual accelerator).
+    build = _run(
+        [
+            str(osprey_bin),
+            "build",
+            "proj",
+            "--preset",
+            "control-assistant",
+            "--override",
+            str(override_path),
+            "--set",
+            f"bluesky.port={BRIDGE_PORT}",
+            "--set",
+            "bluesky.demo_scanner=true",
+            "--set",
+            "bluesky.tiled_enabled=true",
+            "--skip-deps",
+            "--skip-lifecycle",
+            "--output-dir",
+            str(base),
+            "--force",
+        ],
+        cwd=base,
+        timeout=BUILD_TIMEOUT_SEC,
+    )
+    if build.returncode != 0:
+        pytest.fail(
+            f"osprey build failed (rc={build.returncode}):\n"
+            f"--- stdout ---\n{build.stdout}\n--- stderr ---\n{build.stderr}"
+        )
+
+    _write_promote_token(project_dir)
+
+    # Force a fresh --dev build so the deployed bridge container runs CURRENT
+    # source (osprey deploy up does not pass --build to compose, so it would
+    # otherwise reuse a stale cached image). Exact-named image only.
+    # E2E_REUSE_IMAGES=1 skips this (dev-only fast local iteration on the
+    # test itself when the osprey source is unchanged; never set in CI).
+    if not os.environ.get("E2E_REUSE_IMAGES"):
+        subprocess.run(["docker", "rmi", "-f", BRIDGE_IMAGE], capture_output=True, text=True)
+
+    try:
+        up = _run(
+            [str(osprey_bin), "deploy", "up", "-d", "--dev"],
+            cwd=project_dir,
+            timeout=DEPLOY_UP_TIMEOUT_SEC,
+        )
+        if up.returncode != 0:
+            pytest.fail(
+                f"osprey deploy up -d --dev failed (rc={up.returncode}):\n"
+                f"--- stdout ---\n{up.stdout}\n--- stderr ---\n{up.stderr}"
+            )
+        _wait_for_health(f"{BRIDGE_URL}/health", HEALTH_TIMEOUT_SEC)
+        _wait_for_container_health(BRIDGE_CONTAINER, CONTAINER_HEALTH_TIMEOUT_SEC)
+        _wait_for_container_health(TILED_CONTAINER, CONTAINER_HEALTH_TIMEOUT_SEC)
+        yield project_dir
+    finally:
+        down = _run([str(osprey_bin), "deploy", "down"], cwd=project_dir, timeout=300)
+        if down.returncode != 0:
+            print(  # noqa: T201 - surface teardown issues in CI logs
+                f"osprey deploy down rc={down.returncode}\n{down.stdout}\n{down.stderr}"
+            )
+
+
+def _wait_for_health(url: str, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last_err = "(no response yet)"
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=3.0) as resp:  # noqa: S310 - localhost
+                if resp.status == 200:
+                    return
+                last_err = f"HTTP {resp.status}"
+        except (urllib.error.URLError, ConnectionError, OSError) as exc:
+            last_err = str(exc)
+        time.sleep(1.0)
+    raise AssertionError(f"timed out after {timeout:.0f}s waiting for {url} (last: {last_err})")
+
+
+def _wait_for_container_health(container: str, timeout: float) -> None:
+    """Poll ``docker inspect .State.Health.Status`` until ``healthy`` or timeout.
+
+    The fixture's HTTP-readiness gate can pass while Docker still reports
+    ``starting`` (the healthcheck runs only on its interval, after
+    ``start_period``), so an instant equality assert is racy. Also used after
+    the bridge restart below, where there is no HTTP-readiness gate at all.
+    """
+    deadline = time.monotonic() + timeout
+    last = "(no status yet)"
+    while time.monotonic() < deadline:
+        last = _docker_inspect(container, "{{.State.Health.Status}}")
+        if last == "healthy":
+            return
+        time.sleep(2.0)
+    raise AssertionError(
+        f"{container} did not reach 'healthy' within {timeout:.0f}s (last status: {last!r})"
+    )
+
+
+def _docker_inspect(container: str, fmt: str) -> str:
+    proc = subprocess.run(
+        ["docker", "inspect", "--format", fmt, container],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, f"docker inspect {container} failed: {proc.stderr}"
+    return proc.stdout.strip()
+
+
+def _get(path: str) -> tuple[int, dict]:
+    req = urllib.request.Request(f"{BRIDGE_URL}{path}", method="GET")  # noqa: S310
+    try:
+        with urllib.request.urlopen(req, timeout=10.0) as resp:  # noqa: S310
+            return resp.status, json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode("utf-8"))
+
+
+def _post(path: str, body: dict, headers: dict | None = None) -> tuple[int, dict]:
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(  # noqa: S310
+        f"{BRIDGE_URL}{path}",
+        data=data,
+        method="POST",
+        headers={"Content-Type": "application/json", **(headers or {})},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15.0) as resp:  # noqa: S310
+            return resp.status, json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# The round-trip proof (STRICT -- no flaky mark, see module docstring)
+# ---------------------------------------------------------------------------
+
+
+def test_tiled_roundtrip(deployed_stack: Path) -> None:
+    # `deployed_stack` is requested for its side effect: it builds the project,
+    # brings up bridge + Tiled, and waits for both to report healthy.
+
+    # --- 2. create + promote a scan --------------------------------------
+    status, body = _post(
+        "/runs", {"plan_name": "count", "plan_args": {"detectors": [DEMO_DETECTOR], "num": 3}}
+    )
+    assert status == 200, f"POST /runs failed: {status} {body}"
+    run_id = body["id"]
+
+    status, body = _post(f"/runs/{run_id}/promote", {}, headers={"X-Promote-Token": PROMOTE_TOKEN})
+    assert status == 200, f"promote failed: {status} {body}"
+
+    # --- 3. poll to completion --------------------------------------------
+    # Not politeness: TiledWriter caches events and flushes only at the stop
+    # doc (or its own batch_size cap). Restarting before the run completes
+    # would lose every cached event while tiled_degraded still reads False --
+    # the poll is what makes the proof meaningful (see module docstring).
+    deadline = time.monotonic() + SCAN_TIMEOUT_SEC
+    status_body: dict = {}
+    while time.monotonic() < deadline:
+        _, status_body = _get(f"/runs/{run_id}")
+        if status_body.get("status") in ("completed", "error", "stopped"):
+            break
+        time.sleep(0.2)
+    assert status_body.get("status") == "completed", f"scan did not complete: {status_body}"
+
+    # --- 4. capture the pre-restart read; guard against a vacuous proof --
+    assert status_body.get("tiled_degraded") is False, (
+        f"tiled_degraded must be False for a meaningful round-trip proof: {status_body}"
+    )
+
+    status, pre_data = _get(f"/runs/{run_id}/data")
+    assert status == 200, f"GET /runs/{run_id}/data (pre-restart) failed: {status} {pre_data}"
+    pre_columns = pre_data["columns"]
+    pre_rows = pre_data["rows"]
+    pre_row_count = pre_data["row_count"]
+    # Without this guard the whole proof would pass vacuously at 0 == 0 after
+    # the restart -- a degraded/never-persisted writer would look identical
+    # to a working one if both sides were simply empty.
+    assert pre_row_count > 0, f"expected a non-zero pre-restart row count: {pre_data}"
+    assert len(pre_rows) == pre_row_count, (
+        f"pre-restart row_count ({pre_row_count}) does not match len(rows) "
+        f"({len(pre_rows)}): {pre_data}"
+    )
+
+    # --- 5. restart ONLY the bridge; Tiled must stay up -------------------
+    restart = subprocess.run(
+        ["docker", "restart", BRIDGE_CONTAINER],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert restart.returncode == 0, f"docker restart {BRIDGE_CONTAINER} failed: {restart.stderr}"
+
+    # --- 6. wait for the bridge to come back healthy -----------------------
+    _wait_for_health(f"{BRIDGE_URL}/health", HEALTH_TIMEOUT_SEC)
+    _wait_for_container_health(BRIDGE_CONTAINER, CONTAINER_HEALTH_TIMEOUT_SEC)
+
+    # --- 7. read the SAME run id back through the SAME endpoint -----------
+    # The in-memory registry (and run.run_uid with it) died with the bridge
+    # process; the only thread back to this run's data is osprey_run_id,
+    # stamped into the RunEngine start doc by do_promote and searched for by
+    # _from_tiled via Key("start.osprey_run_id") == run_id.
+    status, post_data = _get(f"/runs/{run_id}/data")
+    assert status == 200, f"GET /runs/{run_id}/data (post-restart) failed: {status} {post_data}"
+
+    assert post_data["columns"] == pre_columns, (
+        f"columns diverged across the restart:\npre:  {pre_columns}\npost: {post_data['columns']}"
+    )
+    assert post_data["row_count"] == pre_row_count, (
+        f"row_count diverged across the restart: pre={pre_row_count} post={post_data['row_count']}"
+    )
+    # Content, not just count: an identical row_count with different row
+    # values would pass a length-only check.
+    assert post_data["rows"] == pre_rows, (
+        f"row content diverged across the restart:\npre:  {pre_rows}\npost: {post_data['rows']}"
+    )

--- a/tests/mcp_server/test_scan_client_tools.py
+++ b/tests/mcp_server/test_scan_client_tools.py
@@ -101,6 +101,43 @@ async def test_scan_status_unreachable(monkeypatch):
         await _fn("scan_status")(run_id="run-1")
 
 
+def test_scan_status_docstring_names_every_key_run_to_dict_can_emit():
+    """The docstring IS the contract: it's the only description of the JSON
+    run record an agent ever sees, and nothing in the bridge/MCP path is
+    typed to catch drift between it and `Run.to_dict` (`runs.py`) — this is
+    exactly how `tiled_degraded` (FR5) slipped through unseen originally.
+    Exercises `to_dict` across intent/healthy-promoted/errored-promoted runs
+    and asserts every key any of them can emit is literally named (quoted)
+    in `scan_status`'s docstring, so a future key added to `to_dict` without
+    a docstring update fails here rather than staying silently invisible.
+    """
+    from osprey.services.bluesky_bridge.runs import Run
+    from osprey.services.bluesky_bridge.scanner import FakeScanner
+
+    intent_run = Run(id="r", request={})
+
+    healthy_scanner = FakeScanner()
+    healthy_scanner.start_scan_thread()
+    healthy_scanner.simulate_progress(0.5)
+    healthy_scanner.tiled_degraded = False
+    healthy_run = Run(
+        id="r", request={}, promoted=True, scanner=healthy_scanner, launched_by="agent"
+    )
+
+    errored_scanner = FakeScanner()
+    errored_scanner.start_scan_thread()
+    errored_scanner.simulate_error("device timeout")
+    errored_run = Run(id="r", request={}, promoted=True, scanner=errored_scanner)
+
+    all_keys: set[str] = set()
+    for run in (intent_run, healthy_run, errored_run):
+        all_keys.update(run.to_dict().keys())
+
+    doc = read_tools.scan_status.__doc__ or ""
+    missing = {key for key in all_keys if f'"{key}"' not in doc}
+    assert not missing, f"scan_status docstring is missing keys Run.to_dict emits: {missing}"
+
+
 # ---------------------------------------------------------------------------
 # list_scan_plans — GET /plans
 # ---------------------------------------------------------------------------

--- a/tests/services/bluesky_bridge/test_app_import_clean.py
+++ b/tests/services/bluesky_bridge/test_app_import_clean.py
@@ -1,0 +1,57 @@
+"""Guards `app.py`'s `_BRIDGE_ONLY_MODULES` invariant (FR8): importing
+`osprey.services.bluesky_bridge.app` must never pull in `bluesky`, `ophyd`,
+`ophyd_async`, or `tiled`. A top-level import of any of those in `app.py`
+would 500 the bridge at import time in any deploy lacking the
+`bluesky-bridge` extra.
+
+This MUST run in a fresh subprocess. The dev venv has all four packages
+installed, and other tests in this suite legitimately import them, so by
+the time an in-process test runs, `sys.modules` is already contaminated —
+an in-process assertion would pass or fail depending on test order, not on
+what `app.py` actually imports. Only a fresh interpreter, spawned before
+anything else has touched `sys.modules`, can answer the question.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from osprey.services.bluesky_bridge.app import _BRIDGE_ONLY_MODULES
+
+
+def _run_import_check(module: str) -> subprocess.CompletedProcess[str]:
+    code = f"import osprey.services.bluesky_bridge.app, sys; assert {module!r} not in sys.modules"
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_bridge_only_modules_is_nonempty() -> None:
+    # Guards against a vacuously-passing suite if the constant is ever
+    # emptied out from under this test.
+    assert _BRIDGE_ONLY_MODULES == {"bluesky", "ophyd", "ophyd_async", "tiled"}
+
+
+def test_importing_app_does_not_import_tiled() -> None:
+    result = _run_import_check("tiled")
+    assert result.returncode == 0, (
+        "importing osprey.services.bluesky_bridge.app leaked a top-level "
+        f"import of 'tiled' (child exit {result.returncode}):\n{result.stderr}"
+    )
+
+
+def test_importing_app_does_not_import_bridge_only_modules() -> None:
+    failures: dict[str, subprocess.CompletedProcess[str]] = {}
+    for module in sorted(_BRIDGE_ONLY_MODULES):
+        result = _run_import_check(module)
+        if result.returncode != 0:
+            failures[module] = result
+
+    assert not failures, "\n".join(
+        f"importing osprey.services.bluesky_bridge.app leaked a top-level "
+        f"import of {module!r} (child exit {result.returncode}):\n{result.stderr}"
+        for module, result in failures.items()
+    )

--- a/tests/services/bluesky_bridge/test_demo_scanner_wiring.py
+++ b/tests/services/bluesky_bridge/test_demo_scanner_wiring.py
@@ -23,6 +23,9 @@ Exercised here:
   promote -> scan -> read_scan_data round trip returns real buffered rows.
   Guarded with `pytest.importorskip` so these are skipped (not failed) when
   bluesky isn't installed, keeping `ci_check` green.
+- Task 2.5: `BLUESKY_TILED_URI` wires a `TiledWriter` subscription onto the
+  demo scanner, without disturbing the mock-devices round trip above (the
+  real e2e coverage for this path).
 """
 
 from __future__ import annotations
@@ -40,12 +43,15 @@ from osprey.services.bluesky_bridge.scanner import FakeScanner
 
 _ENV_VAR = "BLUESKY_DEMO_SCANNER"
 _TOKEN_VAR = "BLUESKY_PROMOTE_TOKEN"
+_TILED_URI_ENV = "BLUESKY_TILED_URI"
+_TILED_API_KEY_ENV = "BLUESKY_TILED_API_KEY"
 
 
 @pytest.fixture(autouse=True)
 def _isolated_state(monkeypatch: pytest.MonkeyPatch):
     """Every test gets a clean flag, registry, live-row buffer, and scanner factory."""
-    monkeypatch.delenv(_ENV_VAR, raising=False)
+    for var in (_ENV_VAR, _TILED_URI_ENV, _TILED_API_KEY_ENV):
+        monkeypatch.delenv(var, raising=False)
     registry._runs.clear()
     live_rows._clear()
     set_scanner_factory(FakeScanner)
@@ -179,3 +185,64 @@ def test_flag_set_with_bluesky_present_wires_and_completes_a_real_scan(
         assert data_body["row_count"] == 3
         assert len(data_body["rows"]) == 3
         assert "partial" not in data_body
+
+
+# =========================================================================
+# Task 2.5: BLUESKY_TILED_URI wires a TiledWriter subscription
+# =========================================================================
+
+
+def test_tiled_uri_set_subscribes_a_tiled_writer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mirrors `test_epics_substrate_scanner_wiring.py`'s equivalent assertion
+    for the demo scanner factory — spying on `TiledWriter.from_uri` keeps this
+    a fast unit test while still exercising the real wiring path end to end,
+    independent of the mock-devices round trip above (the real e2e coverage
+    for this path).
+    """
+    pytest.importorskip("bluesky")
+    pytest.importorskip("ophyd_async")
+
+    from bluesky.callbacks.tiled_writer import TiledWriter
+
+    calls: list[tuple[str, dict]] = []
+
+    def fake_from_uri(uri, **kwargs):
+        calls.append((uri, kwargs))
+        return lambda name, doc: None
+
+    monkeypatch.setattr(TiledWriter, "from_uri", fake_from_uri)
+    monkeypatch.setenv(_ENV_VAR, "true")
+    monkeypatch.setenv(_TILED_URI_ENV, "http://tiled:8000")
+    monkeypatch.setenv(_TILED_API_KEY_ENV, "test-api-key")
+
+    with TestClient(app):
+        pass
+
+    from osprey.services.bluesky_bridge.scanner_bluesky import BlueskyScanner
+
+    scanner = app_module._scanner_factory()
+    assert isinstance(scanner, BlueskyScanner)
+    assert calls == [("http://tiled:8000", {"api_key": "test-api-key"})]
+    assert scanner.tiled_degraded is False
+
+
+def test_tiled_uri_unset_builds_scanner_with_no_tiled_subscription(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default (no Tiled configured) behaves exactly like Phase 1: `_build_tiled_writer_factory`
+    returns `None`, so `BlueskyScanner.__init__` never imports or calls `TiledWriter` at all.
+    """
+    pytest.importorskip("bluesky")
+    pytest.importorskip("ophyd_async")
+
+    monkeypatch.setenv(_ENV_VAR, "true")
+
+    with TestClient(app):
+        pass
+
+    assert app_module._build_tiled_writer_factory() is None
+
+    from osprey.services.bluesky_bridge.scanner_bluesky import BlueskyScanner
+
+    scanner = app_module._scanner_factory()
+    assert isinstance(scanner, BlueskyScanner)

--- a/tests/services/bluesky_bridge/test_dual_source_read.py
+++ b/tests/services/bluesky_bridge/test_dual_source_read.py
@@ -1,0 +1,321 @@
+"""Tests for `read_run_data`'s dual-source branching (task 3.3).
+
+`GET /runs/{run_id}/data` now has two data sources: the live-row buffer
+(`live_rows.py`, task 2.2) and Tiled (`_from_tiled`, task 3.2). This file
+tests only the BRANCHING between them — which source gets consulted, and in
+what order — by mocking `app_module._from_tiled` directly rather than a real
+or faked Tiled client (that boundary is already covered by
+`test_tiled_read_source.py`). `_window`'s pagination/truncation math is
+already covered by `test_read_bounded.py`'s live-path tests and
+`test_tiled_read_source.py`'s Tiled-path tests; this file does not re-test it.
+
+Exercised here:
+
+- Live buffer present (even empty-but-partial): served from live, `_from_tiled`
+  never called. The fallback trigger is `buf is None`, never falsy rows — a
+  present-but-empty in-flight buffer must NOT be diverted to Tiled.
+- Live buffer evicted (`live_rows._MAX_RUNS` exceeded) but the run is still in
+  the registry: falls back to `_from_tiled(run_id, ...)`.
+- Registry miss (simulating a post-restart lookup, where the whole in-memory
+  registry — including `run.run_uid` — is gone): also falls back to
+  `_from_tiled(run_id, ...)`, called with the OSPREY `run_id`, never a
+  `run_uid` (there is none to find).
+- Neither source has the run: 404, not a 200-empty (the MCP tool maps 404 to
+  `unknown_run`; a 200-empty would make a nonexistent run look like a valid
+  empty scan).
+- Schema parity: a completed live-sourced response and a Tiled-sourced
+  response carry the identical key set.
+- The pre-existing 409 (run known, never promoted) still short-circuits
+  before Tiled is ever consulted — there's provably nothing to read from
+  either source in that case.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from osprey.services.bluesky_bridge import app as app_module
+from osprey.services.bluesky_bridge import live_rows
+from osprey.services.bluesky_bridge.app import app, set_scanner_factory
+from osprey.services.bluesky_bridge.live_rows import LiveRowRecorder
+from osprey.services.bluesky_bridge.runs import Run, do_promote, registry
+from osprey.services.bluesky_bridge.scanner import FakeScanner
+
+_TILED_URI_ENV = "BLUESKY_TILED_URI"
+_TILED_API_KEY_ENV = "BLUESKY_TILED_API_KEY"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(monkeypatch: pytest.MonkeyPatch):
+    """Every test in this file monkeypatches `app_module._from_tiled` directly
+    rather than relying on the real one, so none is *currently* sensitive to
+    ambient Tiled env — but clearing both vars here too means a future test
+    that forgets to mock `_from_tiled` fails loudly (wrong branch exercised)
+    rather than passing by accident against whatever happens to be unset in
+    the ambient environment. See `test_read_bounded.py`'s matching fixture
+    for the concrete failure mode this guards against.
+    """
+    registry._runs.clear()
+    live_rows._clear()
+    set_scanner_factory(FakeScanner)
+    monkeypatch.delenv(_TILED_URI_ENV, raising=False)
+    monkeypatch.delenv(_TILED_API_KEY_ENV, raising=False)
+    yield
+    registry._runs.clear()
+    live_rows._clear()
+    set_scanner_factory(FakeScanner)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _promoted_run_with_uid(run_uid: str) -> Run:
+    """A run promoted with a FakeScanner pre-seeded with `run_uid`."""
+    run = registry.add(request={"plan_name": "count"})
+    do_promote(run, lambda: FakeScanner(run_uid=run_uid))
+    return run
+
+
+def _feed(run_uid: str, rows: list[dict], *, stop: bool = False) -> None:
+    """Push synthetic start/event[/stop] documents into the live buffer."""
+    recorder = LiveRowRecorder()
+    recorder("start", {"uid": run_uid})
+    for row in rows:
+        recorder("event", {"data": row})
+    if stop:
+        recorder("stop", {"run_start": run_uid})
+
+
+def _refusing_from_tiled(*args: Any, **kwargs: Any) -> dict | None:
+    raise AssertionError("_from_tiled must not be called when a live buffer is present")
+
+
+# =========================================================================
+# Live buffer present -> served live, Tiled never consulted
+# =========================================================================
+
+
+def test_live_buffer_present_serves_live_and_skips_tiled(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(app_module, "_from_tiled", _refusing_from_tiled)
+    run = _promoted_run_with_uid("uid-live")
+    _feed("uid-live", [{"x": 1.0}, {"x": 2.0}], stop=True)
+
+    resp = client.get(f"/runs/{run.id}/data")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["run_uid"] == "uid-live"
+    assert body["rows"] == [[1.0], [2.0]]
+
+
+def test_in_flight_empty_buffer_stays_on_live_path_not_tiled(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CRITICAL: a present-but-empty buffer (`partial: true`, zero rows) is an
+    in-flight run, not a "nothing here" signal — the fallback trigger must be
+    `buf is None`, never falsy rows. If this regresses to a falsy-rows check,
+    every in-flight scan with zero events so far gets incorrectly diverted to
+    Tiled (which has nothing yet either, since TiledWriter only flushes at
+    the stop doc) on every poll until its first event arrives.
+    """
+    monkeypatch.setattr(app_module, "_from_tiled", _refusing_from_tiled)
+    run = _promoted_run_with_uid("uid-empty-partial")
+    _feed("uid-empty-partial", [], stop=False)
+
+    resp = client.get(f"/runs/{run.id}/data")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["rows"] == []
+    assert body["partial"] is True
+
+
+# =========================================================================
+# Live buffer evicted (registry still has the run) -> falls back to Tiled
+# =========================================================================
+
+
+def test_evicted_live_buffer_falls_back_to_tiled(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`live_rows._MAX_RUNS` eviction is independent of the registry (which
+    never evicts) — a run can still be tracked in the registry while its
+    buffer is long gone.
+    """
+    monkeypatch.setattr(live_rows, "_MAX_RUNS", 1)
+    run_a = _promoted_run_with_uid("uid-evicted-a")
+    _feed("uid-evicted-a", [{"x": 1.0}], stop=True)
+    # A second run's start doc evicts run A's buffer (_MAX_RUNS=1).
+    _feed("uid-evicted-b", [{"x": 9.0}], stop=True)
+    assert live_rows.get("uid-evicted-a") is None  # sanity: eviction happened
+
+    tiled_body = {
+        "run_uid": "uid-evicted-a",
+        "columns": ["x"],
+        "rows": [[1.0]],
+        "row_count": 1,
+        "truncated": False,
+    }
+    calls: list[tuple] = []
+
+    def fake_from_tiled(run_id: str, max_rows: int, offset: int | None, tail: bool) -> dict | None:
+        calls.append((run_id, max_rows, offset, tail))
+        return tiled_body
+
+    monkeypatch.setattr(app_module, "_from_tiled", fake_from_tiled)
+
+    resp = client.get(f"/runs/{run_a.id}/data?max_rows=50&offset=1&tail=true")
+
+    assert resp.status_code == 200
+    assert resp.json() == tiled_body
+    # `_from_tiled` gets the OSPREY run_id (still known from the registry
+    # hit here), and the pagination params flow through unchanged.
+    assert calls == [(run_a.id, 50, 1, True)]
+
+
+# =========================================================================
+# Registry miss (post-restart) -> falls back to Tiled by run_id, not run_uid
+# =========================================================================
+
+
+def test_registry_miss_falls_back_to_tiled_by_run_id(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Simulates a bridge restart: the in-memory registry (and therefore
+    `run.run_uid`) is gone, but Tiled still has the run under its durable
+    `osprey_run_id` stamp. There is no `run_uid` to look anything up by here
+    — `_from_tiled` must be called with the caller's `run_id` directly.
+    """
+    tiled_body = {
+        "run_uid": "bluesky-uid-after-restart",
+        "columns": ["motor"],
+        "rows": [[1.0], [2.0]],
+        "row_count": 2,
+        "truncated": False,
+    }
+    calls: list[tuple] = []
+
+    def fake_from_tiled(run_id: str, max_rows: int, offset: int | None, tail: bool) -> dict | None:
+        calls.append((run_id, max_rows, offset, tail))
+        return tiled_body
+
+    monkeypatch.setattr(app_module, "_from_tiled", fake_from_tiled)
+
+    # No registry.add() at all -> "post-restart" registry miss.
+    resp = client.get("/runs/some-run-id-from-before-restart/data")
+
+    assert resp.status_code == 200
+    assert resp.json() == tiled_body
+    assert calls == [("some-run-id-from-before-restart", 100, None, False)]
+
+
+# =========================================================================
+# Matched-but-empty Tiled run -> 200 with zero rows, NOT a 404
+#
+# `None` from `_from_tiled` means "no run matched the search" -> 404. A run
+# that matched but never got a "primary" stream (e.g. it errored before its
+# first point) is a different thing entirely: it genuinely exists in the
+# catalog, so `_from_tiled` returns the empty-but-real shape (task 3.2), and
+# this route must pass that straight through as a 200 — using `is None`, not
+# falsiness, is exactly what keeps this branch from ever converting a real,
+# if dataless, run into a bogus `unknown_run`.
+# =========================================================================
+
+
+def test_matched_but_empty_tiled_run_returns_200_not_404(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    empty_but_real = {
+        "run_uid": "bluesky-uid-errored-early",
+        "columns": [],
+        "rows": [],
+        "row_count": 0,
+        "truncated": False,
+    }
+    monkeypatch.setattr(app_module, "_from_tiled", lambda *a, **kw: empty_but_real)
+
+    resp = client.get("/runs/errored-before-first-point/data")
+
+    assert resp.status_code == 200
+    assert resp.json() == empty_but_real
+
+
+# =========================================================================
+# Neither source has the run -> 404, never a 200-empty
+# =========================================================================
+
+
+def test_registry_miss_and_no_tiled_match_returns_404(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(app_module, "_from_tiled", lambda *a, **kw: None)
+
+    resp = client.get("/runs/truly-unknown-run/data")
+
+    assert resp.status_code == 404
+
+
+def test_registry_hit_never_had_a_buffer_and_no_tiled_match_returns_404(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Distinct from `test_evicted_live_buffer_falls_back_to_tiled` above: this
+    run's buffer was never created at all (no `_feed` call), not evicted after
+    existing — same `buf is None` branch, different one of the two reasons it
+    can be `None`, both landing on 404 when Tiled has nothing either.
+    """
+    run = _promoted_run_with_uid("uid-gone")
+    monkeypatch.setattr(app_module, "_from_tiled", lambda *a, **kw: None)
+
+    resp = client.get(f"/runs/{run.id}/data")
+
+    assert resp.status_code == 404
+
+
+# =========================================================================
+# 409 still short-circuits before Tiled is ever consulted
+# =========================================================================
+
+
+def test_unpromoted_run_returns_409_without_consulting_tiled(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(app_module, "_from_tiled", _refusing_from_tiled)
+    run = registry.add(request={"plan_name": "count"})
+
+    resp = client.get(f"/runs/{run.id}/data")
+
+    assert resp.status_code == 409
+
+
+# =========================================================================
+# Schema parity: live-sourced and Tiled-sourced completed-run responses
+# carry the identical key set
+# =========================================================================
+
+
+def test_schema_parity_between_live_and_tiled_sourced_responses(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    live_run = _promoted_run_with_uid("uid-schema-live")
+    _feed("uid-schema-live", [{"x": 1.0}], stop=True)
+    live_body = client.get(f"/runs/{live_run.id}/data").json()
+
+    tiled_body_payload = {
+        "run_uid": "uid-schema-tiled",
+        "columns": ["x"],
+        "rows": [[1.0]],
+        "row_count": 1,
+        "truncated": False,
+    }
+    monkeypatch.setattr(app_module, "_from_tiled", lambda *a, **kw: tiled_body_payload)
+    tiled_body = client.get("/runs/some-restart-era-run-id/data").json()
+
+    assert set(live_body.keys()) == set(tiled_body.keys())
+    assert set(live_body.keys()) == {"run_uid", "columns", "rows", "row_count", "truncated"}

--- a/tests/services/bluesky_bridge/test_epics_substrate_scanner_wiring.py
+++ b/tests/services/bluesky_bridge/test_epics_substrate_scanner_wiring.py
@@ -23,6 +23,10 @@ absent or the flag is unset. Exercised here:
   installed.
 - Both `BLUESKY_EPICS_SUBSTRATE` and `BLUESKY_DEMO_SCANNER` set: the EPICS
   substrate wins, with a warning logged.
+- Task 2.5: `BLUESKY_TILED_URI` wires a `TiledWriter` subscription onto the
+  EPICS-substrate scanner. This path has no e2e coverage (unlike the demo
+  scanner's real-scan round trip in `test_demo_scanner_wiring.py`), so its
+  wiring is asserted explicitly here rather than left to an integration test.
 """
 
 from __future__ import annotations
@@ -41,12 +45,21 @@ _SUBSTRATE_ENV = "BLUESKY_EPICS_SUBSTRATE"
 _DEMO_ENV = "BLUESKY_DEMO_SCANNER"
 _MOTORS_ENV = "BLUESKY_EPICS_MOTORS"
 _DETECTORS_ENV = "BLUESKY_EPICS_DETECTORS"
+_TILED_URI_ENV = "BLUESKY_TILED_URI"
+_TILED_API_KEY_ENV = "BLUESKY_TILED_API_KEY"
 
 
 @pytest.fixture(autouse=True)
 def _isolated_state(monkeypatch: pytest.MonkeyPatch):
     """Every test gets a clean flag set, registry, and scanner factory."""
-    for var in (_SUBSTRATE_ENV, _DEMO_ENV, _MOTORS_ENV, _DETECTORS_ENV):
+    for var in (
+        _SUBSTRATE_ENV,
+        _DEMO_ENV,
+        _MOTORS_ENV,
+        _DETECTORS_ENV,
+        _TILED_URI_ENV,
+        _TILED_API_KEY_ENV,
+    ):
         monkeypatch.delenv(var, raising=False)
     registry._runs.clear()
     set_scanner_factory(FakeScanner)
@@ -226,3 +239,65 @@ def test_both_flags_set_epics_substrate_wins(
     # Substrate scanners are built with the explicit built-in plan set, not
     # the demo path's default (None -> merged built-ins + facility plans).
     assert scanner._plans is not None
+
+
+# =========================================================================
+# Task 2.5: BLUESKY_TILED_URI wires a TiledWriter subscription
+# =========================================================================
+
+
+def test_tiled_uri_set_subscribes_a_tiled_writer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`_build_tiled_writer_factory` reaches all the way through to a real
+    `TiledWriter.from_uri(uri, api_key=...)` call once `BlueskyScanner` is
+    built — spying on `from_uri` (rather than actually connecting) keeps this
+    a unit test while still exercising the real wiring path end to end.
+    """
+    pytest.importorskip("bluesky")
+    pytest.importorskip("ophyd_async")
+
+    from bluesky.callbacks.tiled_writer import TiledWriter
+
+    calls: list[tuple[str, dict]] = []
+
+    def fake_from_uri(uri, **kwargs):
+        calls.append((uri, kwargs))
+        return lambda name, doc: None
+
+    monkeypatch.setattr(TiledWriter, "from_uri", fake_from_uri)
+    monkeypatch.setenv(_SUBSTRATE_ENV, "true")
+    monkeypatch.setenv(_MOTORS_ENV, "mot1=TEST:MOTOR:01:SP")
+    monkeypatch.setenv(_TILED_URI_ENV, "http://tiled:8000")
+    monkeypatch.setenv(_TILED_API_KEY_ENV, "test-api-key")
+
+    with TestClient(app):
+        pass
+
+    from osprey.services.bluesky_bridge.scanner_bluesky import BlueskyScanner
+
+    scanner = app_module._scanner_factory()
+    assert isinstance(scanner, BlueskyScanner)
+    assert calls == [("http://tiled:8000", {"api_key": "test-api-key"})]
+    assert scanner.tiled_degraded is False
+
+
+def test_tiled_uri_unset_builds_scanner_with_no_tiled_subscription(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default (no Tiled configured) behaves exactly like Phase 1: `_build_tiled_writer_factory`
+    returns `None`, so `BlueskyScanner.__init__` never imports or calls `TiledWriter` at all.
+    """
+    pytest.importorskip("bluesky")
+    pytest.importorskip("ophyd_async")
+
+    monkeypatch.setenv(_SUBSTRATE_ENV, "true")
+    monkeypatch.setenv(_MOTORS_ENV, "mot1=TEST:MOTOR:01:SP")
+
+    with TestClient(app):
+        pass
+
+    assert app_module._build_tiled_writer_factory() is None
+
+    from osprey.services.bluesky_bridge.scanner_bluesky import BlueskyScanner
+
+    scanner = app_module._scanner_factory()
+    assert isinstance(scanner, BlueskyScanner)

--- a/tests/services/bluesky_bridge/test_read_bounded.py
+++ b/tests/services/bluesky_bridge/test_read_bounded.py
@@ -30,12 +30,25 @@ from osprey.services.bluesky_bridge.live_rows import LiveRowRecorder
 from osprey.services.bluesky_bridge.runs import Run, do_promote, registry
 from osprey.services.bluesky_bridge.scanner import FakeScanner
 
+_TILED_URI_ENV = "BLUESKY_TILED_URI"
+_TILED_API_KEY_ENV = "BLUESKY_TILED_API_KEY"
+
 
 @pytest.fixture(autouse=True)
-def _isolated_state():
+def _isolated_state(monkeypatch: pytest.MonkeyPatch):
+    """Every test also gets Tiled unconfigured: several tests below (any run
+    with no live buffer) fall through `read_run_data` to the real
+    `_from_tiled`, not a mock. Left to ambient env, an exported
+    `BLUESKY_TILED_URI` would make those tests attempt a real Tiled
+    connection instead of exercising the "not configured" branch they claim
+    to — hanging, or raising `KeyError` on the unset `BLUESKY_TILED_API_KEY`
+    and surfacing as a 500 instead of the asserted 404.
+    """
     registry._runs.clear()
     live_rows._clear()
     set_scanner_factory(FakeScanner)
+    monkeypatch.delenv(_TILED_URI_ENV, raising=False)
+    monkeypatch.delenv(_TILED_API_KEY_ENV, raising=False)
     yield
     registry._runs.clear()
     live_rows._clear()
@@ -85,11 +98,17 @@ def test_read_data_unknown_run_returns_404(client: TestClient) -> None:
 # =========================================================================
 
 
-def test_read_data_with_no_buffer_returns_minimal_empty_shape(client: TestClient) -> None:
+def test_read_data_with_no_buffer_and_no_tiled_returns_404(client: TestClient) -> None:
+    """Task 3.3: a promoted run with no live buffer falls back to `_from_tiled`,
+    which returns `None` here (BLUESKY_TILED_URI unset in this test env) — so
+    this is a 404, not the old Phase-1 200-empty shape. A 200-empty would make
+    a run whose data genuinely can't be found look like a valid empty scan;
+    see `test_dual_source_read.py` for the full dual-source branching matrix
+    (evicted-buffer fallback, schema parity, registry-miss handling).
+    """
     run = _promoted_run_with_uid("uid-empty")
     resp = client.get(f"/runs/{run.id}/data")
-    assert resp.status_code == 200
-    assert resp.json() == {"columns": [], "rows": []}
+    assert resp.status_code == 404
 
 
 def test_read_data_started_but_zero_events_reports_full_shape(client: TestClient) -> None:

--- a/tests/services/bluesky_bridge/test_runengine_integration.py
+++ b/tests/services/bluesky_bridge/test_runengine_integration.py
@@ -32,7 +32,7 @@ from osprey.services.bluesky_bridge import live_rows  # noqa: E402
 from osprey.services.bluesky_bridge.app import app, set_scanner_factory  # noqa: E402
 from osprey.services.bluesky_bridge.devices.mock import build_devices  # noqa: E402
 from osprey.services.bluesky_bridge.plans import BUILTIN_PLANS  # noqa: E402
-from osprey.services.bluesky_bridge.runs import registry  # noqa: E402
+from osprey.services.bluesky_bridge.runs import do_promote, registry  # noqa: E402
 from osprey.services.bluesky_bridge.scanner import FakeScanner  # noqa: E402
 from osprey.services.bluesky_bridge.scanner_bluesky import BlueskyScanner  # noqa: E402
 
@@ -252,3 +252,32 @@ def test_promoted_run_read_scan_data_returns_the_buffered_rows(
     assert data_body["row_count"] == 3
     assert len(data_body["rows"]) == 3
     assert "partial" not in data_body
+
+
+def test_do_promote_stamps_osprey_run_id_onto_the_start_doc(mock_devices: dict) -> None:
+    """`do_promote` (runs.py) sets `scanner.osprey_run_id = run.id`, and `_run`
+    (scanner_bluesky.py) must thread it onto the RunEngine start doc as
+    metadata — not nested under an `md` key — so a Tiled-persisted run can be
+    found again by `run.id` after the in-memory registry (and `run_uid` with
+    it) is gone.
+    """
+    docs: list[tuple[str, dict]] = []
+
+    def scanner_factory() -> BlueskyScanner:
+        scanner = BlueskyScanner(devices=mock_devices, plans=BUILTIN_PLANS)
+        scanner.RE.subscribe(lambda name, doc: docs.append((name, dict(doc))))
+        return scanner
+
+    run = registry.add(
+        request={"plan_name": "count", "plan_args": {"detectors": ["det1"], "num": 2}}
+    )
+
+    do_promote(run, scanner_factory)
+    _wait_until_idle(run.scanner)
+
+    assert run.scanner.osprey_run_id == run.id  # type: ignore[union-attr]
+
+    start_docs = [doc for name, doc in docs if name == "start"]
+    assert len(start_docs) == 1
+    assert start_docs[0]["osprey_run_id"] == run.id
+    assert "md" not in start_docs[0]

--- a/tests/services/bluesky_bridge/test_runs.py
+++ b/tests/services/bluesky_bridge/test_runs.py
@@ -128,7 +128,7 @@ def test_status_is_not_error_when_current_state_looks_like_error_but_error_messa
 def test_to_dict_intent_is_minimal() -> None:
     run = Run(id="abc123", request={})
     out = run.to_dict()
-    assert out == {"id": "abc123", "status": "intent"}
+    assert out == {"id": "abc123", "status": "intent", "tiled_degraded": False}
 
 
 def test_to_dict_includes_completion_and_run_uid_once_promoted() -> None:
@@ -175,6 +175,102 @@ def test_to_dict_uses_the_scanner_error_message_directly() -> None:
     run = Run(id="abc123", request={}, promoted=True, scanner=scanner)
     out = run.to_dict()
     assert out["error"] == "device timeout"
+
+
+# =========================================================================
+# to_dict: tiled_degraded (task 2.4)
+# =========================================================================
+
+
+def test_to_dict_tiled_degraded_is_false_for_a_promoted_healthy_writer() -> None:
+    """A scanner that exposes `tiled_degraded = False` (a healthy wired Tiled
+    writer) must surface `False` on the run, with the key present.
+    """
+    scanner = FakeScanner()
+    scanner.start_scan_thread()
+    scanner.tiled_degraded = False  # duck-typed, like BlueskyScanner's property
+    run = Run(id="abc123", request={}, promoted=True, scanner=scanner)
+
+    out = run.to_dict()
+
+    assert "tiled_degraded" in out
+    assert out["tiled_degraded"] is False
+
+
+def test_to_dict_tiled_degraded_is_true_for_a_promoted_degraded_writer() -> None:
+    scanner = FakeScanner()
+    scanner.start_scan_thread()
+    scanner.tiled_degraded = True
+    run = Run(id="abc123", request={}, promoted=True, scanner=scanner)
+
+    out = run.to_dict()
+
+    assert out["tiled_degraded"] is True
+
+
+def test_to_dict_tiled_degraded_is_false_and_present_for_an_unpromoted_run() -> None:
+    """No scanner at all (never promoted) must read `False`, key present —
+    never absent, and never `True` merely because nothing has run yet.
+    """
+    run = Run(id="abc123", request={})
+
+    out = run.to_dict()
+
+    assert "tiled_degraded" in out
+    assert out["tiled_degraded"] is False
+
+
+def test_to_dict_tiled_degraded_is_false_and_present_for_a_scanner_without_the_attribute() -> None:
+    """`FakeScanner` (and any `Scanner` that never wires Tiled at all) has no
+    `tiled_degraded` attribute — must default to `False`, key still present,
+    never raise `AttributeError`.
+    """
+    scanner = FakeScanner()
+    scanner.start_scan_thread()
+    assert not hasattr(scanner, "tiled_degraded")  # sanity: FakeScanner truly lacks it
+    run = Run(id="abc123", request={}, promoted=True, scanner=scanner)
+
+    out = run.to_dict()
+
+    assert "tiled_degraded" in out
+    assert out["tiled_degraded"] is False
+
+
+def test_to_dict_key_set_is_unchanged_apart_from_tiled_degraded() -> None:
+    """Existing keys and their meanings must not shift — this is an additive
+    HTTP-contract change consumed by the MCP scan tools. Pin the full key set
+    for a minimal intent, a fully-populated healthy promoted run, and a
+    failed-promote run, so an accidental rename or drop (e.g. `error` ->
+    `err`) is caught here rather than downstream — the two-key-set-only
+    version of this test left `error` unpinned by any exhaustive assertion.
+    """
+    intent_run = Run(id="abc123", request={})
+    assert set(intent_run.to_dict().keys()) == {"id", "status", "tiled_degraded"}
+
+    scanner = FakeScanner()
+    scanner.start_scan_thread()
+    scanner.simulate_progress(0.5)
+    scanner.tiled_degraded = False
+    full_run = Run(id="abc123", request={}, promoted=True, scanner=scanner, launched_by="agent")
+    assert set(full_run.to_dict().keys()) == {
+        "id",
+        "status",
+        "tiled_degraded",
+        "completion",
+        "launched_by",
+        "run_uid",
+    }
+
+    # A failed-promote run: `do_promote` (`runs.py`) only publishes
+    # `run.scanner` on success, so a promotion that raised (unknown plan,
+    # a Tiled construction failure that somehow escaped the fault-isolated
+    # wrapper, thread creation itself failing, etc.) leaves `scanner is None`
+    # with `error` set — exactly what an operator sees after a failed
+    # promote. `tiled_degraded` must still read `False`, present, here: a
+    # failed promote is not evidence Tiled specifically was the cause.
+    failed_promote_run = Run(id="abc123", request={}, error="promotion failed: boom")
+    assert set(failed_promote_run.to_dict().keys()) == {"id", "status", "tiled_degraded", "error"}
+    assert failed_promote_run.to_dict()["tiled_degraded"] is False
 
 
 # =========================================================================

--- a/tests/services/bluesky_bridge/test_tiled_read_source.py
+++ b/tests/services/bluesky_bridge/test_tiled_read_source.py
@@ -1,0 +1,443 @@
+"""Tests for `_from_tiled` (task 3.2) — the durable read source `read_run_data`
+
+falls back to once a run's live buffer is gone (post-restart, or evicted past
+`live_rows._MAX_RUNS`). This environment has `tiled[client]` but not
+`tiled[server]` (no `sqlalchemy`), so there is no in-process Tiled server to
+run against — these tests fake the client boundary (`tiled.client.from_uri`)
+instead, which is exactly the seam `_from_tiled` itself is built around.
+Real-server coverage is the e2e round trip (task 4.1).
+
+Exercised here:
+
+- `BLUESKY_TILED_URI` unset: `_from_tiled` returns `None` without importing
+  `tiled` at all (logged, not an error) — matches "Tiled not configured"
+  everywhere else in this phase (`_build_tiled_writer_factory`, task 2.5).
+- The search query is built as `Key("start.osprey_run_id") == run_id`, NOT a
+  bare `Key("osprey_run_id")` — the start doc lives under `metadata["start"]`
+  on the run container `TiledWriter.start` creates.
+- No matching run: `_from_tiled` returns `None` (caller raises 404).
+- A matching run with recorded events: the internal appendable table is read
+  and projected onto the live-buffer column set — `seq_num`, `time`, and
+  every `ts_*` column dropped — then windowed via `_window` (task 3.1), with
+  `run_uid` taken from the start doc's `uid`, never from the caller's
+  `run_id`.
+- A matching run whose start doc landed but which never got a `"primary"`
+  event stream (e.g. it errored before its first point): treated as a real,
+  empty run — `{"columns": [], "rows": [], "row_count": 0, "truncated":
+  False}` — not a 404.
+- A matching run whose `"primary"` stream exists but whose `.base` holds no
+  `"internal"` table: NOT the empty-run shape. That is a broken catalog (or
+  a broken traversal), and it must surface rather than be laundered into a
+  successful empty read.
+- Pagination (`max_rows`/`offset`/`tail`) flows through unchanged, proving
+  `_from_tiled` delegates to `_window` rather than reimplementing it.
+
+The fakes below model the real Tiled 0.2.12 client surface, which is the
+whole point of this file. Against a live server, a run's `"primary"` child is
+a `CompositeClient` whose keys are the *flattened column names* — `seq_num`,
+`time`, `det1-value`, `ts_det1-value` — NOT the table. Asking it for
+`"internal"` raises::
+
+    KeyError: "Key 'internal' not found. If it refers to a table, access it
+    via the base Container client using `.base['internal']` instead."
+
+The appendable `DataFrameClient` lives at `primary.base["internal"]`. A fake
+that answers `primary["internal"]` directly would let a wrong traversal pass
+here and fail only in production — and because `_from_tiled`'s empty-run
+branch keys off `"primary"` membership rather than catching `KeyError`, a
+wrong traversal now raises instead of returning a plausible empty result.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from osprey.services.bluesky_bridge import app as app_module
+
+_TILED_URI_ENV = "BLUESKY_TILED_URI"
+_TILED_API_KEY_ENV = "BLUESKY_TILED_API_KEY"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(_TILED_URI_ENV, raising=False)
+    monkeypatch.delenv(_TILED_API_KEY_ENV, raising=False)
+    yield
+
+
+# =========================================================================
+# Fakes for the `tiled.client.from_uri` boundary
+# =========================================================================
+
+
+class _FakeInternalTable:
+    """Stands in for a Tiled `DataFrameClient` (the "internal" appendable table)."""
+
+    def __init__(self, df: pd.DataFrame) -> None:
+        self._df = df
+
+    def read(self) -> pd.DataFrame:
+        return self._df
+
+
+class _FakeBaseContainer:
+    """Stands in for `CompositeClient.base` — a plain Container of table nodes.
+
+    Raises a bare `KeyError` for a missing child, exactly as a real Container
+    does. `_from_tiled` must NOT swallow that: an absent `"internal"` here is
+    a broken catalog, not an empty run.
+    """
+
+    def __init__(self, tables: dict) -> None:
+        self._tables = tables
+
+    def __getitem__(self, key: str):
+        return self._tables[key]
+
+    def keys(self):
+        return list(self._tables)
+
+
+class _FakeCompositeClient:
+    """Stands in for the `CompositeClient` a run's `"primary"` child really is.
+
+    The fidelity that matters: its `__getitem__` exposes the table's flattened
+    *columns*, and raises `KeyError` — with the real 0.2.12 message — for any
+    other key, `"internal"` included. The table is reachable only via `.base`.
+
+    Modelling this is the entire reason this fake exists. A fake that answered
+    `primary["internal"]` would encode the bug it is meant to catch.
+    """
+
+    # Verbatim from `tiled.client.composite.CompositeClient.__getitem__` (0.2.12).
+    _NOT_FOUND_TEMPLATE = (
+        "Key '{key}' not found. If it refers to a table, access it via "
+        "the base Container client using `.base['{key}']` instead."
+    )
+
+    def __init__(self, columns: list[str], base: _FakeBaseContainer) -> None:
+        self._columns = list(columns)
+        self.base = base
+
+    def __getitem__(self, key: str):
+        if key in self._columns:
+            return object()  # a column client; `_from_tiled` never asks for one
+        raise KeyError(self._NOT_FOUND_TEMPLATE.format(key=key))
+
+    def keys(self):
+        return list(self._columns)
+
+
+class _FakeRunNode:
+    """Stands in for a Tiled run container: `.metadata` plus stream-node lookup.
+
+    `__contains__` mirrors `Mapping.__contains__` (which is what tiled's
+    `Container` inherits): a missing key is a `KeyError` from `__getitem__`,
+    reported as `False`. `_from_tiled`'s `"primary" not in run_node` guard
+    rides on exactly this.
+    """
+
+    def __init__(self, metadata: dict, streams: dict | None = None) -> None:
+        self.metadata = metadata
+        self._streams = streams or {}
+
+    def __getitem__(self, key: str):
+        return self._streams[key]
+
+    def __contains__(self, key: str) -> bool:
+        try:
+            self[key]
+        except KeyError:
+            return False
+        return True
+
+
+class _FakeSearchResult:
+    def __init__(self, nodes: list[_FakeRunNode]) -> None:
+        self._nodes = nodes
+
+    def values(self) -> list[_FakeRunNode]:
+        return self._nodes
+
+
+class _FakeTiledClient:
+    """Stands in for the client `tiled.client.from_uri(...)` returns.
+
+    Records every `.search()` query and every `from_uri(...)` call's kwargs
+    so tests can assert on the exact query shape and auth used, not just the
+    end result.
+    """
+
+    def __init__(self, nodes_by_run_id: dict[str, _FakeRunNode]) -> None:
+        self._nodes_by_run_id = nodes_by_run_id
+        self.search_queries: list[object] = []
+
+    def search(self, query) -> _FakeSearchResult:
+        self.search_queries.append(query)
+        node = self._nodes_by_run_id.get(query.value)
+        return _FakeSearchResult([node] if node is not None else [])
+
+
+def _install_fake_client(monkeypatch: pytest.MonkeyPatch, client: _FakeTiledClient) -> list[tuple]:
+    """Patch `tiled.client.from_uri` to return `client`; return a list `from_uri` calls append to."""
+    pytest.importorskip("tiled")
+
+    from tiled.client import from_uri as real_from_uri  # noqa: F401 (import sanity only)
+
+    calls: list[tuple] = []
+
+    def fake_from_uri(uri, **kwargs):
+        calls.append((uri, kwargs))
+        return client
+
+    monkeypatch.setattr("tiled.client.from_uri", fake_from_uri)
+    return calls
+
+
+def _run_node_with_events(run_uid: str, run_id: str, rows: list[dict]) -> _FakeRunNode:
+    """A run container whose `"primary"` composite wraps a table shaped like TiledWriter's
+    output: `seq_num`, `time`, the real data columns, then `ts_<key>` per data column.
+
+    The composite's own keys are those column names (matching a live server);
+    the table hangs off `.base["internal"]`.
+    """
+    metadata = {"start": {"uid": run_uid, "osprey_run_id": run_id}, "stop": {}}
+    table_rows = []
+    for i, row in enumerate(rows):
+        table_row = {"seq_num": i + 1, "time": 1000.0 + i, **row}
+        table_row.update({f"ts_{k}": 1000.0 + i for k in row})
+        table_rows.append(table_row)
+    df = pd.DataFrame(table_rows)
+    primary = _FakeCompositeClient(
+        columns=list(df.columns),
+        base=_FakeBaseContainer({"internal": _FakeInternalTable(df)}),
+    )
+    return _FakeRunNode(metadata=metadata, streams={"primary": primary})
+
+
+# =========================================================================
+# BLUESKY_TILED_URI unset: None, no client built
+#
+# (Whether `tiled` itself stays unimported in this branch is a module-level
+# import-cleanliness property this in-process test cannot observe reliably —
+# this venv already has `tiled` loaded from other tests. That invariant is
+# enforced by `test_app_import_clean.py`'s subprocess check, task 3.4.)
+# =========================================================================
+
+
+def test_tiled_uri_unset_returns_none() -> None:
+    assert app_module._from_tiled("run-1", max_rows=100, offset=None, tail=False) is None
+
+
+# =========================================================================
+# Query shape: Key("start.osprey_run_id") == run_id
+# =========================================================================
+
+
+def test_search_query_targets_start_dot_osprey_run_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tiled.queries import Key
+
+    monkeypatch.setenv(_TILED_URI_ENV, "http://tiled:8000")
+    monkeypatch.setenv(_TILED_API_KEY_ENV, "test-api-key")
+
+    client = _FakeTiledClient(nodes_by_run_id={})
+    _install_fake_client(monkeypatch, client)
+
+    result = app_module._from_tiled("run-xyz", max_rows=100, offset=None, tail=False)
+
+    assert result is None  # no match seeded
+    assert len(client.search_queries) == 1
+    assert client.search_queries[0] == (Key("start.osprey_run_id") == "run-xyz")
+
+
+def test_from_uri_called_with_configured_uri_and_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_TILED_URI_ENV, "http://tiled:8000")
+    monkeypatch.setenv(_TILED_API_KEY_ENV, "test-api-key")
+
+    client = _FakeTiledClient(nodes_by_run_id={})
+    calls = _install_fake_client(monkeypatch, client)
+
+    app_module._from_tiled("run-xyz", max_rows=100, offset=None, tail=False)
+
+    assert calls == [("http://tiled:8000", {"api_key": "test-api-key"})]
+
+
+# =========================================================================
+# No match -> None (caller raises 404)
+# =========================================================================
+
+
+def test_no_matching_run_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_TILED_URI_ENV, "http://tiled:8000")
+    monkeypatch.setenv(_TILED_API_KEY_ENV, "test-api-key")
+
+    client = _FakeTiledClient(nodes_by_run_id={})
+    _install_fake_client(monkeypatch, client)
+
+    assert app_module._from_tiled("does-not-exist", max_rows=100, offset=None, tail=False) is None
+
+
+# =========================================================================
+# Matching run with events: projection + windowing
+# =========================================================================
+
+
+def test_matching_run_projects_away_seq_num_time_and_ts_columns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(_TILED_URI_ENV, "http://tiled:8000")
+    monkeypatch.setenv(_TILED_API_KEY_ENV, "test-api-key")
+
+    run_node = _run_node_with_events(
+        run_uid="bluesky-uid-1",
+        run_id="run-1",
+        rows=[{"motor": 1.0, "det": 10}, {"motor": 2.0, "det": 20}, {"motor": 3.0, "det": 30}],
+    )
+    client = _FakeTiledClient(nodes_by_run_id={"run-1": run_node})
+    _install_fake_client(monkeypatch, client)
+
+    result = app_module._from_tiled("run-1", max_rows=100, offset=None, tail=False)
+
+    assert result is not None
+    assert result["run_uid"] == "bluesky-uid-1"
+    assert set(result["columns"]) == {"motor", "det"}
+    assert "seq_num" not in result["columns"]
+    assert "time" not in result["columns"]
+    assert not any(c.startswith("ts_") for c in result["columns"])
+    assert result["row_count"] == 3
+    assert len(result["rows"]) == 3
+    assert result["truncated"] is False
+    assert "partial" not in result  # Tiled-sourced data is always for a completed run
+
+
+def test_matching_run_pagination_delegates_to_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same `_window` semantics as the live path (task 3.1) — proven here by
+    reusing max_rows/offset/tail rather than re-deriving truncation logic.
+    """
+    monkeypatch.setenv(_TILED_URI_ENV, "http://tiled:8000")
+    monkeypatch.setenv(_TILED_API_KEY_ENV, "test-api-key")
+
+    rows = [{"motor": float(i)} for i in range(10)]
+    run_node = _run_node_with_events(run_uid="bluesky-uid-2", run_id="run-2", rows=rows)
+    client = _FakeTiledClient(nodes_by_run_id={"run-2": run_node})
+    _install_fake_client(monkeypatch, client)
+
+    result = app_module._from_tiled("run-2", max_rows=3, offset=2, tail=False)
+
+    assert result["row_count"] == 10
+    assert result["rows"] == [[2.0], [3.0], [4.0]]
+    assert result["truncated"] is True
+
+    tail_result = app_module._from_tiled("run-2", max_rows=3, offset=0, tail=True)
+    assert tail_result["rows"] == [[7.0], [8.0], [9.0]]
+    assert tail_result["truncated"] is True
+
+
+# =========================================================================
+# Matching run, no "primary" stream: real empty run, not a 404
+# =========================================================================
+
+
+def test_matching_run_with_no_primary_stream_reports_empty_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(_TILED_URI_ENV, "http://tiled:8000")
+    monkeypatch.setenv(_TILED_API_KEY_ENV, "test-api-key")
+
+    run_node = _FakeRunNode(
+        metadata={"start": {"uid": "bluesky-uid-3", "osprey_run_id": "run-3"}, "stop": {}},
+        streams={},  # no "primary" child at all
+    )
+    client = _FakeTiledClient(nodes_by_run_id={"run-3": run_node})
+    _install_fake_client(monkeypatch, client)
+
+    result = app_module._from_tiled("run-3", max_rows=100, offset=None, tail=False)
+
+    assert result == {
+        "run_uid": "bluesky-uid-3",
+        "columns": [],
+        "rows": [],
+        "row_count": 0,
+        "truncated": False,
+    }
+
+
+# =========================================================================
+# The composite traversal itself
+# =========================================================================
+
+
+def test_fake_primary_rejects_direct_internal_lookup_like_a_real_composite() -> None:
+    """Guards the fake, not `_from_tiled`.
+
+    If this ever passes by returning a table, the fake has drifted back to the
+    wrong shape and every test below it stops proving anything about the real
+    traversal.
+    """
+    run_node = _run_node_with_events("uid", "run", [{"det1-value": 1.0}])
+    primary = run_node["primary"]
+
+    with pytest.raises(KeyError, match=r"access it via the base Container client"):
+        primary["internal"]
+
+    assert primary.base["internal"].read() is not None
+
+
+def test_real_tiled_column_set_projects_to_the_live_buffer_columns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The exact column set a live Tiled 0.2.12 server returns for a one-detector
+    `count` — `['seq_num', 'time', 'det1-value', 'ts_det1-value']` — must project
+    down to the single real column `['det1-value']`.
+    """
+    monkeypatch.setenv(_TILED_URI_ENV, "http://tiled:8000")
+    monkeypatch.setenv(_TILED_API_KEY_ENV, "test-api-key")
+
+    run_node = _run_node_with_events(
+        run_uid="bluesky-uid-real",
+        run_id="repro-run-id-123",
+        rows=[{"det1-value": 1.0}, {"det1-value": 2.0}, {"det1-value": 3.0}],
+    )
+    assert run_node["primary"].keys() == ["seq_num", "time", "det1-value", "ts_det1-value"]
+
+    client = _FakeTiledClient(nodes_by_run_id={"repro-run-id-123": run_node})
+    _install_fake_client(monkeypatch, client)
+
+    result = app_module._from_tiled("repro-run-id-123", max_rows=100, offset=None, tail=False)
+
+    assert result is not None
+    assert result["columns"] == ["det1-value"]
+    assert result["rows"] == [[1.0], [2.0], [3.0]]
+    assert result["row_count"] == 3
+
+
+def test_primary_present_but_base_internal_missing_is_not_swallowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A `"primary"` composite with no `"internal"` table under `.base` is a bug —
+    a broken catalog, or a broken traversal — and must NOT be laundered into the
+    empty-but-real 200 that the *missing-`"primary"`* case legitimately produces.
+
+    This is the regression that a `try`/`except KeyError` wrapped around the whole
+    traversal caused: it returned `{"columns": [], "rows": [], "row_count": 0}` for
+    a run holding persisted data. Silent data loss, served as HTTP 200.
+    """
+    monkeypatch.setenv(_TILED_URI_ENV, "http://tiled:8000")
+    monkeypatch.setenv(_TILED_API_KEY_ENV, "test-api-key")
+
+    run_node = _FakeRunNode(
+        metadata={"start": {"uid": "bluesky-uid-4", "osprey_run_id": "run-4"}, "stop": {}},
+        streams={"primary": _FakeCompositeClient(columns=["seq_num"], base=_FakeBaseContainer({}))},
+    )
+    client = _FakeTiledClient(nodes_by_run_id={"run-4": run_node})
+    _install_fake_client(monkeypatch, client)
+
+    # `match` pins *which* KeyError. A traversal that regressed to
+    # `primary["internal"]` also raises `KeyError` — with the composite's
+    # "Key 'internal' not found. ... use `.base[...]`" guidance — so a bare
+    # `pytest.raises(KeyError)`, or even `match=r"internal"`, would pass for
+    # the wrong reason. Anchoring to the bare `KeyError("internal")` that a
+    # plain Container raises is what makes this test self-sufficient.
+    with pytest.raises(KeyError, match=r"^'internal'$"):
+        app_module._from_tiled("run-4", max_rows=100, offset=None, tail=False)

--- a/tests/services/bluesky_bridge/test_tiled_writer_wrapper.py
+++ b/tests/services/bluesky_bridge/test_tiled_writer_wrapper.py
@@ -19,7 +19,17 @@ from typing import Any
 
 import pytest
 
-from osprey.services.bluesky_bridge.scanner_bluesky import BlueskyScanner, _FaultIsolatedTiledWriter
+# `scanner_bluesky` imports `bluesky.RunEngine` at module scope, so this module
+# cannot even be collected without the `bluesky-bridge` extra. Guard rather than
+# error, matching the sibling bridge tests. CI's unit job installs the extra
+# (pinned by tests/deployment/test_ci_workflow_wiring.py), so these guards run
+# there rather than skipping.
+pytest.importorskip("bluesky")
+
+from osprey.services.bluesky_bridge.scanner_bluesky import (  # noqa: E402
+    BlueskyScanner,
+    _FaultIsolatedTiledWriter,
+)
 
 
 class _RecordingWriter:

--- a/tests/services/bluesky_bridge/test_tiled_writer_wrapper.py
+++ b/tests/services/bluesky_bridge/test_tiled_writer_wrapper.py
@@ -1,0 +1,190 @@
+"""Tests for `_FaultIsolatedTiledWriter` (task 2.1) and `BlueskyScanner.tiled_degraded` (task 2.2).
+
+`TiledWriter` is a synchronous RunEngine callback, and bluesky's `RunEngine`
+does not swallow callback exceptions by default — an exception escaping a
+subscribed callback aborts the running plan. This wrapper exists so a Tiled
+outage degrades persistence instead of killing a scan: it must never let an
+inner-writer exception propagate, and once degraded it must stop calling the
+inner writer at all.
+
+`BlueskyScanner.tiled_degraded` surfaces that latch (or a construction-time
+failure) at the scanner level, distinguishing "Tiled disabled" (`False`, no
+factory supplied) from "Tiled wired but failing" (`True`).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from osprey.services.bluesky_bridge.scanner_bluesky import BlueskyScanner, _FaultIsolatedTiledWriter
+
+
+class _RecordingWriter:
+    """A `(name, doc)` callback that records calls and optionally raises."""
+
+    def __init__(self, raise_on: str | None = None) -> None:
+        self.raise_on = raise_on
+        self.calls: list[tuple[str, dict]] = []
+
+    def __call__(self, name: str, doc: dict) -> None:
+        self.calls.append((name, doc))
+        if name == self.raise_on:
+            raise RuntimeError("Tiled write failed")
+
+
+def test_healthy_inner_writer_forwards_every_document_and_stays_not_degraded():
+    inner = _RecordingWriter()
+    wrapper = _FaultIsolatedTiledWriter(inner)
+
+    assert wrapper.degraded is False
+
+    wrapper("start", {"uid": "run-1"})
+    wrapper("descriptor", {"uid": "desc-1"})
+    wrapper("event", {"uid": "event-1"})
+    wrapper("stop", {"uid": "stop-1"})
+
+    assert inner.calls == [
+        ("start", {"uid": "run-1"}),
+        ("descriptor", {"uid": "desc-1"}),
+        ("event", {"uid": "event-1"}),
+        ("stop", {"uid": "stop-1"}),
+    ]
+    assert wrapper.degraded is False
+
+
+def test_inner_exception_is_swallowed_and_latches_degraded():
+    inner = _RecordingWriter(raise_on="event")
+    wrapper = _FaultIsolatedTiledWriter(inner)
+
+    wrapper("start", {"uid": "run-1"})
+    assert wrapper.degraded is False
+
+    # Must not raise: an escaping exception would abort the RunEngine's plan.
+    wrapper("event", {"uid": "event-1"})
+
+    assert wrapper.degraded is True
+
+
+def test_subsequent_documents_short_circuit_after_latch():
+    inner = _RecordingWriter(raise_on="event")
+    wrapper = _FaultIsolatedTiledWriter(inner)
+
+    wrapper("start", {"uid": "run-1"})
+    wrapper("event", {"uid": "event-1"})  # raises inside inner, latches degraded
+    assert wrapper.degraded is True
+    assert len(inner.calls) == 2
+
+    # Further documents must not reach the inner writer at all.
+    wrapper("event", {"uid": "event-2"})
+    wrapper("stop", {"uid": "stop-1"})
+
+    assert len(inner.calls) == 2
+    assert wrapper.degraded is True
+
+
+def test_exception_logged_once_with_exc_info(caplog: pytest.LogCaptureFixture):
+    inner = _RecordingWriter(raise_on="event")
+    wrapper = _FaultIsolatedTiledWriter(inner)
+
+    with caplog.at_level(logging.ERROR, logger="osprey.services.bluesky_bridge.scanner_bluesky"):
+        wrapper("start", {"uid": "run-1"})
+        wrapper("event", {"uid": "event-1"})
+        # Further calls short-circuit, so no additional log records.
+        wrapper("event", {"uid": "event-2"})
+        wrapper("stop", {"uid": "stop-1"})
+
+    error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(error_records) == 1
+    assert error_records[0].exc_info is not None
+
+
+# =========================================================================
+# `BlueskyScanner.tiled_degraded` (task 2.2)
+# =========================================================================
+
+
+def test_tiled_degraded_is_false_when_no_writer_is_wired():
+    """Tiled disabled entirely (no `tiled_writer_factory`) must never read degraded."""
+    scanner = BlueskyScanner(devices={})
+
+    assert scanner.tiled_degraded is False
+
+
+def test_tiled_degraded_is_false_for_a_healthy_wired_writer():
+    inner = _RecordingWriter()
+    scanner = BlueskyScanner(devices={}, tiled_writer_factory=lambda: inner)
+
+    assert scanner.tiled_degraded is False
+
+
+def test_tiled_degraded_is_true_when_the_factory_raises_at_construction(
+    caplog: pytest.LogCaptureFixture,
+):
+    """A Tiled server down at promote time must leave the scanner degraded,
+    not silently continue with `tiled_degraded=False`.
+    """
+
+    def _boom() -> None:
+        raise RuntimeError("Tiled unreachable")
+
+    with caplog.at_level(logging.WARNING, logger="osprey.services.bluesky_bridge.scanner_bluesky"):
+        scanner = BlueskyScanner(devices={}, tiled_writer_factory=_boom)
+
+    assert scanner.tiled_degraded is True
+
+
+def test_tiled_degraded_becomes_true_after_a_document_raises():
+    inner = _RecordingWriter(raise_on="event")
+    scanner = BlueskyScanner(devices={}, tiled_writer_factory=lambda: inner)
+    assert scanner.tiled_degraded is False
+
+    # White-box: exercise the same wrapper `RE.subscribe` was given, without
+    # driving a real RunEngine plan through this unit test.
+    scanner._tiled_writer("start", {"uid": "run-1"})
+    assert scanner.tiled_degraded is False
+    scanner._tiled_writer("event", {"uid": "event-1"})
+
+    assert scanner.tiled_degraded is True
+
+
+def test_tiled_degraded_is_true_when_subscribe_raises_after_successful_construction(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A raising `RE.subscribe(...)` must degrade, not propagate.
+
+    Pre-2.2-fix, `RE.subscribe(self._tiled_writer)` lived in the `else:`
+    clause of the construction `try` — outside the exception guard — so a
+    raising `subscribe()` would escape `BlueskyScanner.__init__` entirely,
+    turning a Tiled outage into a failed `do_promote` (FR4 violation). The
+    inner writer factory here succeeds; only `RE.subscribe` is made to fail,
+    and only on its *second* call (the first, inside `__init__`, wires
+    `_on_document` and must keep working) — so this exercises exactly the
+    call the earlier fix left unguarded.
+    """
+    from bluesky import RunEngine
+
+    original_subscribe = RunEngine.subscribe
+    calls = {"n": 0}
+
+    def _flaky_subscribe(self: RunEngine, func: Any, name: str = "all") -> Any:
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("RE.subscribe failed")
+        return original_subscribe(self, func, name=name)
+
+    monkeypatch.setattr(RunEngine, "subscribe", _flaky_subscribe)
+
+    inner = _RecordingWriter()
+    # Must not raise: a Tiled outage degrades the scanner, never the promote.
+    scanner = BlueskyScanner(devices={}, tiled_writer_factory=lambda: inner)
+
+    assert scanner.tiled_degraded is True
+    # No partially-wired writer left behind: even if `subscribe` had managed
+    # to register the wrapper before raising, the wrapper is already latched
+    # degraded, so it would still no-op on any document it receives.
+    assert scanner._tiled_writer is not None
+    scanner._tiled_writer("start", {"uid": "run-1"})
+    assert inner.calls == []  # never reached — latched before any document arrived


### PR DESCRIPTION
## What this does

The Bluesky scan bridge kept scan data only in an in-process buffer, so a run's rows
disappeared when the service restarted and there was no durable read source. This
co-deploys a writable Tiled catalog with the bridge and makes the scan read path
dual-source.

- **Tiled catalog service** — optional, enabled by `services.bluesky.tiled_enabled`.
  Serves a DuckDB-backed appendable catalog on `osprey-network`. The bridge carries no
  `depends_on: tiled`, so a crash-looping catalog cannot block scans.
- **Dual-source reads** — `GET /runs/{id}/data` serves the live in-process buffer while
  a run is in flight, and reads from Tiled once the run is durable. A run now survives a
  bridge restart and remains readable afterwards.
- **Fault-isolated writes** — a Tiled write failure latches a `degraded` flag rather than
  propagating. An outage degrades persistence; it never fails a scan promotion. The state
  surfaces as `tiled_degraded` on `GET /runs/{id}` and in the `scan_status` MCP tool.
- **Per-variable token minting** — `BLUESKY_TILED_API_KEY` is minted with
  `secrets.token_hex(32)`: Tiled rejects the `-` and `_` that `token_urlsafe` emits.
  Compose fails closed on an empty key rather than letting `--api-key` swallow the next
  argument.
- **Fail-closed agent environment** — the variables exposed to the agent execution
  environment are now an explicit allowlist (`_LOCAL_EXEC_SAFE_VARS`) instead of a
  blocklist, so a newly introduced secret is excluded by default.

## Testing

293 unit tests across the bridge, deployment, and scan MCP surfaces. Adds
`tests/e2e/test_tiled_roundtrip.py`, which deploys the stack under Docker, runs a scan,
restarts the bridge, and asserts the rows are served back from Tiled.

## CI

Two secret-free e2e lanes: `tiled-roundtrip-e2e`, and `va-substrate-equivalence-e2e`
(which had no job and therefore never ran). Both follow this repo's existing convention
for e2e lanes — they appear in `all-checks-passed`'s `needs:` but are advisory, so a
failure warns rather than blocking the merge.
