### PR TITLE
feat(dispatch): expose the artifacts a run produced

### DIFF
--- a/src/osprey/interfaces/artifacts/resolve.py
+++ b/src/osprey/interfaces/artifacts/resolve.py
@@ -1,0 +1,338 @@
+"""Read-only resolution of a dispatch run's artifacts to renderable bytes.
+
+Generic OSPREY-core capability: given a headless dispatch ``run_id``, discover
+the artifacts the run produced (via the artifact store's write-time ``run_id``
+tag — ``ArtifactStore.list_entries(run_filter=...)`` / ``get_run_entry``) and
+resolve each to a file on disk that an external caller can fetch as image/PDF
+bytes.
+
+Association is **created-by, not referenced-by**: a run owns exactly the
+artifacts it *wrote* (tagged from ``OSPREY_DISPATCH_RUN_ID`` at save time),
+never merely the ones its tool-call results happen to mention. Authorization
+therefore never reads agent-controllable data, so a prompt-injected run cannot
+widen its own artifact set or reach another run's bytes.
+
+Resolution rules per artifact MIME type:
+  * ``image/*`` and ``application/pdf`` — passthrough, served as-is.
+  * HTML / Markdown / notebook / JSON / text — converted to PNG via the shared
+    converter registry, and the temp PNG path is returned.
+  * If the converter or one of its runtime dependencies (e.g. Playwright) is
+    unavailable, the original file is returned with ``convertible=False`` rather
+    than failing the whole call.
+
+Depends only on ``osprey.stores`` (artifact index/files) and the artifact
+converter registry (``osprey.mcp_server.ariel.converters``). It deliberately
+does NOT import the ARIEL FastMCP server, so it is safe to import and call from
+the dispatch worker without coupling the worker to that server.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from osprey.stores.artifact_store import ArtifactStore
+
+logger = logging.getLogger("osprey.interfaces.artifacts.resolve")
+
+
+@dataclass
+class ArtifactRef:
+    """A resolved, fetchable reference to one artifact produced by a run.
+
+    Attributes:
+        artifact_id: The artifact store ID.
+        filename: Basename of the file that will be served (post-conversion).
+        mime_type: MIME type of the bytes at ``abs_path`` (``image/png`` for a
+            converted artifact; the original type for a passthrough/fallback).
+        abs_path: Absolute path to the file to stream to the caller.
+        convertible: ``True`` when the artifact is directly renderable — either a
+            passthrough image/PDF or a successful conversion to PNG. ``False``
+            when conversion was attempted but a converter/dependency was
+            unavailable, in which case ``abs_path`` is the original file.
+    """
+
+    artifact_id: str
+    filename: str
+    mime_type: str
+    abs_path: str
+    convertible: bool
+
+
+# ---------------------------------------------------------------------------
+# Run-record + store location
+# ---------------------------------------------------------------------------
+
+
+def _agent_data_root() -> Path:
+    """Return the ``_agent_data`` root for the deployed project.
+
+    Mirrors the dispatch worker's persistence layout (see
+    ``dispatch_api._LOG_DIR``): both derive from ``OSPREY_PROJECT_DIR`` so a
+    resolver running in the worker process (whose CWD is the image WORKDIR, not
+    the project dir) reads the same location the dispatched agent wrote to.
+    """
+    project_dir = os.environ.get("OSPREY_PROJECT_DIR", "/app/project")
+    return Path(project_dir) / "_agent_data"
+
+
+def _dispatch_log_dir() -> Path:
+    return _agent_data_root() / "dispatch"
+
+
+def _run_artifacts_dir(run_id: str) -> Path:
+    """Deterministic, reused per-run scratch dir for converted (PNG) artifacts.
+
+    Keyed by ``run_id`` rather than a fresh ``mkdtemp`` per call, so repeated
+    resolution of the same run overwrites the same files (bounded by run count,
+    not request count) instead of leaking a new temp dir on every request.
+    """
+    out = _agent_data_root() / "dispatch" / "artifacts" / run_id
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def load_run_record(run_id: str) -> dict[str, Any] | None:
+    """Load a persisted dispatch run record by ID, or ``None`` if absent.
+
+    Used only for the run-status disk fallback (a completed run evicted from the
+    worker's in-memory cap is still readable on disk). It is NOT used for
+    artifact association — that is the store's write-time ``run_id`` tag.
+    """
+    path = _dispatch_log_dir() / f"{run_id}.json"
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        logger.warning("Failed to read dispatch run record %s", path, exc_info=True)
+        return None
+
+
+def _get_store() -> ArtifactStore:
+    """Build an ArtifactStore rooted at the project's ``_agent_data``.
+
+    Not the module-level singleton: the worker process CWD differs from the
+    project dir, so the singleton's default root would point at the wrong place.
+    """
+    from osprey.stores.artifact_store import ArtifactStore
+
+    return ArtifactStore(workspace_root=_agent_data_root())
+
+
+# ---------------------------------------------------------------------------
+# Delivery prediction (render-free)
+# ---------------------------------------------------------------------------
+
+
+def predict_delivery(source_mime: str) -> tuple[str, bool]:
+    """Predict how the byte route will deliver an artifact, WITHOUT rendering.
+
+    Returns ``(delivered_mime, convertible)``:
+      * passthrough types (``image/*``, ``application/pdf``,
+        ``application/octet-stream``) → ``(source_mime, True)`` — served as-is.
+      * everything else → ``("image/png", True)`` — rendered to PNG on fetch.
+
+    ``convertible`` is optimistic: it reflects the intended (success-path)
+    outcome. If a converter dependency (e.g. Playwright) is unavailable at fetch
+    time, the byte route falls back to the original bytes with the ref's
+    ``convertible`` set to ``False`` — the byte route's actual Content-Type is
+    always authoritative. Kept render-free so listing a run's artifacts never
+    triggers O(N) conversions.
+    """
+    from osprey.mcp_server.ariel.converters import get_converter, passthrough
+
+    if get_converter(source_mime) is passthrough:
+        return source_mime, True
+    return "image/png", True
+
+
+def _predicted_filename(entry_filename: str, delivered_mime: str) -> str:
+    """Best-effort delivered basename for descriptors (display/caption only).
+
+    The byte route's Content-Disposition filename (post-conversion) is
+    authoritative; this is a render-free prediction: a rendered artifact is
+    delivered as ``<stem>.png``, a passthrough keeps its stored name.
+    """
+    name = Path(entry_filename).name
+    if delivered_mime == "image/png" and not name.lower().endswith(".png"):
+        name = Path(name).stem + ".png"
+    return name
+
+
+def describe_run_artifacts(run_id: str) -> list[dict[str, Any]]:
+    """Render-free descriptors of the artifacts a run produced, oldest first.
+
+    Feeds BOTH the run-status ``artifacts`` list and the list route, so they can
+    never disagree. Reads only the store index (via the strict ``run_filter``
+    created-by tag) and predicts delivery — it never invokes a converter, so it
+    is cheap regardless of artifact count. Returns ``[]`` for an unknown/empty
+    ``run_id`` or a run that produced no artifacts.
+
+    Each descriptor is ``{artifact_id, filename, source_mime, delivered_mime,
+    convertible}``. ``source_mime`` is retained so a consumer always knows the
+    real original bytes even when ``delivered_mime`` differs (rendered to PNG).
+    """
+    if not run_id:
+        return []
+    try:
+        entries = _get_store().list_entries(run_filter=run_id)
+    except Exception:
+        logger.warning("Could not read artifact store for run %s", run_id, exc_info=True)
+        return []
+    out: list[dict[str, Any]] = []
+    for e in entries:
+        delivered_mime, convertible = predict_delivery(e.mime_type)
+        out.append(
+            {
+                "artifact_id": e.id,
+                "filename": _predicted_filename(e.filename, delivered_mime),
+                "source_mime": e.mime_type,
+                "delivered_mime": delivered_mime,
+                "convertible": convertible,
+            }
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Single-artifact resolution
+# ---------------------------------------------------------------------------
+
+
+async def resolve_artifact_path(store: ArtifactStore, artifact_id: str, output_dir: Path) -> str:
+    """Resolve one artifact ID to a renderable file path (strict).
+
+    Shared core used by callers that want failure to surface (e.g. the ARIEL
+    logbook attachment path). Images/PDFs pass through; rendered content types
+    are converted to PNG in ``output_dir``.
+
+    Raises:
+        ValueError: If the artifact ID or its on-disk file is missing.
+
+    Converter errors (e.g. a missing Playwright dependency) propagate to the
+    caller unchanged.
+    """
+    from osprey.mcp_server.ariel.converters import get_converter
+
+    entry = store.get_entry(artifact_id)
+    if entry is None:
+        raise ValueError(f"Artifact '{artifact_id}' not found.")
+
+    file_path = store.get_file_path(artifact_id)
+    if file_path is None or not file_path.exists():
+        raise ValueError(f"Artifact file not found on disk for '{artifact_id}'.")
+
+    converter = get_converter(entry.mime_type)
+    result_path = await converter(file_path, output_dir)
+    return str(result_path)
+
+
+async def _resolve_one(
+    store: ArtifactStore, artifact_id: str, output_dir: Path
+) -> ArtifactRef | None:
+    """Resolve one artifact to an :class:`ArtifactRef` (lenient).
+
+    Returns ``None`` if the artifact or its file is missing (the run's tag
+    survives but the file was deleted). Converter failures are caught and yield a
+    ``convertible=False`` ref pointing at the original bytes rather than aborting
+    the whole run resolution.
+    """
+    from osprey.mcp_server.ariel.converters import get_converter
+
+    entry = store.get_entry(artifact_id)
+    if entry is None:
+        logger.warning("Artifact %s not found in store", artifact_id)
+        return None
+
+    file_path = store.get_file_path(artifact_id)
+    if file_path is None or not file_path.exists():
+        logger.warning("Artifact %s has no file on disk", artifact_id)
+        return None
+
+    converter = get_converter(entry.mime_type)
+    try:
+        result_path = Path(await converter(file_path, output_dir))
+    except Exception:
+        # Converter or a runtime dependency (e.g. Playwright) is unavailable —
+        # fall back to the original bytes so the caller still gets something.
+        logger.warning(
+            "Artifact %s conversion failed; serving original bytes",
+            artifact_id,
+            exc_info=True,
+        )
+        return ArtifactRef(
+            artifact_id=artifact_id,
+            filename=file_path.name,
+            mime_type=entry.mime_type,
+            abs_path=str(file_path),
+            convertible=False,
+        )
+
+    if result_path == file_path:
+        # Passthrough (image/PDF) — served as-is with its original MIME type.
+        mime_type = entry.mime_type
+    else:
+        # Rendered to PNG by the converter registry.
+        mime_type = "image/png"
+
+    return ArtifactRef(
+        artifact_id=artifact_id,
+        filename=result_path.name,
+        mime_type=mime_type,
+        abs_path=str(result_path),
+        convertible=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Run resolution (created-by tag)
+# ---------------------------------------------------------------------------
+
+
+async def resolve_run_artifacts(run_id: str) -> list[ArtifactRef]:
+    """Resolve every artifact a dispatch run produced to a fetchable file.
+
+    Association is the store's write-time ``run_id`` tag (created-by), NOT the
+    run's tool-call results. Returns an empty list for an unknown/empty run or a
+    run that produced no artifacts. Artifacts whose files are missing from the
+    store are skipped. Converts one PNG per rendered artifact, so callers that
+    only need metadata should use :func:`describe_run_artifacts` instead.
+    """
+    if not run_id:
+        return []
+
+    store = _get_store()
+    entries = store.list_entries(run_filter=run_id)
+    if not entries:
+        return []
+
+    output_dir = _run_artifacts_dir(run_id)
+    refs: list[ArtifactRef] = []
+    for entry in entries:
+        ref = await _resolve_one(store, entry.id, output_dir)
+        if ref is not None:
+            refs.append(ref)
+    return refs
+
+
+async def resolve_single_run_artifact(run_id: str, artifact_id: str) -> ArtifactRef | None:
+    """Resolve ONE artifact of a run, converting only that artifact.
+
+    The cross-run gate is the store's created-by tag: ``get_run_entry`` returns
+    the entry only when it was *written* by ``run_id`` (non-empty tag, exact
+    match). An unknown run, an artifact created by another run (or by no run), a
+    traversal-shaped ``artifact_id``, or a missing on-disk file all return
+    ``None`` — indistinguishable, so this is never a cross-run existence oracle.
+    """
+    store = _get_store()
+    if store.get_run_entry(run_id, artifact_id) is None:
+        return None
+
+    output_dir = _run_artifacts_dir(run_id)
+    return await _resolve_one(store, artifact_id, output_dir)

--- a/src/osprey/mcp_server/ariel/tools/entry.py
+++ b/src/osprey/mcp_server/ariel/tools/entry.py
@@ -43,7 +43,7 @@ async def _resolve_artifacts(artifact_ids: list[str]) -> list[str]:
     """
     import tempfile
 
-    from osprey.mcp_server.ariel.converters import get_converter
+    from osprey.interfaces.artifacts.resolve import resolve_artifact_path
     from osprey.stores.artifact_store import get_artifact_store
 
     store = get_artifact_store()
@@ -51,17 +51,7 @@ async def _resolve_artifacts(artifact_ids: list[str]) -> list[str]:
     output_dir = Path(tempfile.mkdtemp(prefix="ariel_convert_"))
 
     for aid in artifact_ids:
-        entry = store.get_entry(aid)
-        if entry is None:
-            raise ValueError(f"Artifact '{aid}' not found.")
-
-        file_path = store.get_file_path(aid)
-        if file_path is None or not file_path.exists():
-            raise ValueError(f"Artifact file not found on disk for '{aid}'.")
-
-        converter = get_converter(entry.mime_type)
-        result_path = await converter(file_path, output_dir)
-        resolved.append(str(result_path))
+        resolved.append(await resolve_artifact_path(store, aid, output_dir))
 
     return resolved
 

--- a/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
+++ b/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
@@ -2,11 +2,17 @@
 
 Exposes:
   POST /dispatch                      — enqueue an agent prompt, returns 202 + run_id
-  GET  /dispatch/{id}                 — poll a run for completion
+  GET  /dispatch/{id}                 — poll a run for completion (body carries artifact descriptors)
   GET  /dispatch/{id}/stream          — SSE stream of run events
-  GET  /dispatch/{id}/artifacts/{aid} — raw bytes of one artifact the run produced
+  GET  /dispatch/{id}/artifacts       — descriptors of the artifacts the run produced
+  GET  /dispatch/{id}/artifacts/{aid} — resolved (renderable) bytes of one artifact the run produced
   GET  /health                        — liveness check with run statistics
   GET  /dashboard/runs                — JSON feed consumed by the dispatcher dashboard (token-gated)
+
+Which artifacts belong to a run is decided by the artifact store's write-time
+``run_id`` tag (created-by), so all three artifact surfaces — the status-body
+list, the list route, and the byte route — share one strict isolation gate and
+cannot disagree. See ``osprey.interfaces.artifacts.resolve``.
 """
 
 from __future__ import annotations
@@ -26,6 +32,11 @@ from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 
+from osprey.interfaces.artifacts.resolve import (
+    describe_run_artifacts,
+    load_run_record,
+    resolve_single_run_artifact,
+)
 from osprey.mcp_server.dispatch_worker import sdk_runner
 from osprey.utils.tool_rules import matches_denylist
 
@@ -297,37 +308,6 @@ async def _stale_run_cleanup() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _artifact_store():
-    """ArtifactStore rooted at this worker's agent-data dir.
-
-    Not session-scoped: the dispatched agent's tools write there (the worker
-    process sets no OSPREY_SESSION_ID), and it is the same root the artifact
-    gallery reads. Built per call — the index is re-read from disk, so
-    artifacts written by the agent's MCP subprocesses are visible here.
-    """
-    from pathlib import Path
-
-    from osprey.stores.artifact_store import ArtifactStore
-
-    return ArtifactStore(workspace_root=Path(_agent_data_dir()))
-
-
-def _artifact_ids_for_run(run_id: str) -> list[str]:
-    """Ids of the artifacts this run produced, oldest first.
-
-    Strict equality on ``run_id`` — deliberately NOT
-    ``list_entries(session_filter=...)``, which also matches entries with an
-    EMPTY session id and would therefore attach every untagged legacy artifact
-    in the store to every run.
-    """
-    try:
-        entries = _artifact_store().list_entries()
-    except Exception:
-        logger.warning("Could not read artifact store for run %s", run_id, exc_info=True)
-        return []
-    return [e.id for e in entries if e.run_id == run_id]
-
-
 def _verify_token(credentials: HTTPAuthorizationCredentials = Depends(_bearer_scheme)) -> None:
     expected = os.environ.get("DISPATCH_WORKER_TOKEN", "")
     if not expected:
@@ -389,9 +369,11 @@ async def _run_dispatch_task(run_id: str, request: DispatchRequest) -> None:
         )
         result["completed_at"] = time.time()
         result["prompt"] = request.prompt
-        # Artifacts the agent saved during this run, for consumers that
-        # republish them (see GET /dispatch/{run_id}/artifacts/{artifact_id}).
-        result["artifacts"] = _artifact_ids_for_run(run_id)
+        # Descriptors of the artifacts this run produced (created-by tag), for
+        # consumers that republish them (see the /artifacts routes). Render-free:
+        # computed once at completion from the store tag and persisted with the
+        # run so it survives restart and never disagrees with the live routes.
+        result["artifacts"] = describe_run_artifacts(run_id)
         _runs[run_id] = result
         _persist_run(run_id, result)
         logger.info("Dispatch %s completed: status=%s", run_id, result.get("status"))
@@ -406,6 +388,7 @@ async def _run_dispatch_task(run_id: str, request: DispatchRequest) -> None:
             "cost_usd": None,
             "num_turns": None,
             "completed_at": time.time(),
+            "artifacts": [],
         }
         _runs[run_id] = err_result
         _persist_run(run_id, err_result)
@@ -422,6 +405,7 @@ async def _run_dispatch_task(run_id: str, request: DispatchRequest) -> None:
             "cost_usd": None,
             "num_turns": None,
             "completed_at": time.time(),
+            "artifacts": [],
         }
         _runs[run_id] = err_result
         _persist_run(run_id, err_result)
@@ -443,6 +427,7 @@ async def _run_dispatch_task(run_id: str, request: DispatchRequest) -> None:
             "cost_usd": None,
             "num_turns": None,
             "completed_at": time.time(),
+            "artifacts": [],
         }
         _runs[run_id] = err_result
         _persist_run(run_id, err_result)
@@ -516,39 +501,57 @@ async def cancel_dispatch(run_id: str) -> dict[str, Any]:
 
 @app.get("/dispatch/{run_id}", dependencies=[Depends(_verify_token)])
 async def get_dispatch_result(run_id: str) -> dict[str, Any]:
-    """Poll a run by its run_id. Returns the stored result dict."""
+    """Poll a run by its run_id. Returns the stored result dict.
+
+    Falls through to the persisted on-disk record when the run has aged out of
+    the in-memory ``_runs`` cap, so the status body (and its ``artifacts``
+    descriptors) stays available for exactly as long as the artifact routes,
+    which resolve from the same on-disk store.
+    """
     result = _runs.get(run_id)
+    if result is None:
+        result = load_run_record(run_id)
     if result is None:
         raise HTTPException(status_code=404, detail=f"run_id {run_id!r} not found")
     return result
 
 
+@app.get("/dispatch/{run_id}/artifacts", dependencies=[Depends(_verify_token)])
+async def list_dispatch_artifacts(run_id: str) -> list[dict[str, Any]]:
+    """List descriptors of the artifacts a run produced (created-by tag).
+
+    Metadata only — never renders a converter, so it is cheap regardless of
+    artifact count. Returns ``[]`` for a run with no artifacts AND for an
+    unknown run: the strict store-tag filter is itself the existence check (a
+    bogus run_id matches nothing), and returning ``[]`` rather than 404 avoids
+    a cross-run existence oracle. Use the status body to distinguish known vs
+    unknown runs. Item shape is identical to the status body's ``artifacts``.
+    """
+    return describe_run_artifacts(run_id)
+
+
 @app.get("/dispatch/{run_id}/artifacts/{artifact_id}", dependencies=[Depends(_verify_token)])
 async def get_dispatch_artifact(run_id: str, artifact_id: str) -> FileResponse:
-    """Serve the raw bytes of one artifact produced by ``run_id``.
+    """Serve the resolved (renderable) bytes of one artifact produced by ``run_id``.
 
-    The artifact must be attributed to this run: an artifact belonging to a
-    different run (or to no run) is a 404 here, so a caller holding one run_id
-    cannot enumerate or read another run's output. ``artifact_id`` is never
-    joined into a path directly — it is resolved through the store's index, so
-    a traversal-shaped id simply fails to match an entry.
+    The artifact must have been *created by* this run (the store's write-time
+    ``run_id`` tag): an artifact belonging to a different run, to no run, an
+    unknown or traversal-shaped ``artifact_id``, and a missing on-disk file all
+    collapse to the same 404 — so a caller holding one run_id can neither read
+    nor probe for another run's output. ``artifact_id`` is resolved through the
+    store index, never joined into a path. HTML/notebook/etc. artifacts are
+    converted to PNG here (only the requested one); images/PDFs pass through.
     """
-    if run_id not in _runs:
-        raise HTTPException(status_code=404, detail=f"run_id {run_id!r} not found")
-
-    store = _artifact_store()
-    entry = store.get_entry(artifact_id)
-    if entry is None or entry.run_id != run_id:
-        raise HTTPException(status_code=404, detail=f"artifact {artifact_id!r} not found for run")
-
-    path = store.get_file_path(artifact_id)
-    if path is None or not path.is_file():
-        raise HTTPException(status_code=404, detail=f"artifact {artifact_id!r} has no file")
+    ref = await resolve_single_run_artifact(run_id, artifact_id)
+    if ref is None:
+        # Constant, input-free 404 for every deny reason (unknown run / cross-run /
+        # unknown id / missing file), so the response is never an existence oracle.
+        raise HTTPException(status_code=404, detail="artifact not found for run")
 
     return FileResponse(
-        path,
-        media_type=entry.mime_type or "application/octet-stream",
-        filename=entry.filename,
+        ref.abs_path,
+        media_type=ref.mime_type or "application/octet-stream",
+        filename=ref.filename,
     )
 
 

--- a/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
+++ b/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
@@ -54,13 +54,19 @@ _tasks: dict[str, asyncio.Task] = {}
 # Maximum entries in _runs before old entries are evicted (prevents unbounded growth)
 _MAX_RUNS = 1000
 
+
+# Agent-data root for THIS worker. Anchored to OSPREY_PROJECT_DIR rather than
+# resolve_shared_data_root(): that helper locates the project via OSPREY_CONFIG
+# and falls back to CWD, but the worker is configured with CONFIG_FILE and its
+# CWD is the image WORKDIR (/app) — so it would resolve to /app/_agent_data
+# while the agent's tools write to <project>/_agent_data.
+def _agent_data_dir() -> str:
+    return os.path.join(os.environ.get("OSPREY_PROJECT_DIR", "/app/project"), "_agent_data")
+
+
 # Persistent log directory — lives on the _agent_data volume mount so it
 # survives container restarts.
-_LOG_DIR = os.path.join(
-    os.environ.get("OSPREY_PROJECT_DIR", "/app/project"),
-    "_agent_data",
-    "dispatch",
-)
+_LOG_DIR = os.path.join(_agent_data_dir(), "dispatch")
 
 
 def _persist_run(run_id: str, run: dict[str, Any]) -> None:
@@ -292,17 +298,18 @@ async def _stale_run_cleanup() -> None:
 
 
 def _artifact_store():
-    """ArtifactStore rooted at the SHARED agent-data root.
+    """ArtifactStore rooted at this worker's agent-data dir.
 
-    Shared, not session-scoped: the dispatched agent's tools write there (the
-    worker process sets no OSPREY_SESSION_ID), and it is the same root the
-    artifact gallery reads. Built per call — the index is re-read from disk, so
+    Not session-scoped: the dispatched agent's tools write there (the worker
+    process sets no OSPREY_SESSION_ID), and it is the same root the artifact
+    gallery reads. Built per call — the index is re-read from disk, so
     artifacts written by the agent's MCP subprocesses are visible here.
     """
-    from osprey.stores.artifact_store import ArtifactStore
-    from osprey.utils.workspace import resolve_shared_data_root
+    from pathlib import Path
 
-    return ArtifactStore(workspace_root=resolve_shared_data_root())
+    from osprey.stores.artifact_store import ArtifactStore
+
+    return ArtifactStore(workspace_root=Path(_agent_data_dir()))
 
 
 def _artifact_ids_for_run(run_id: str) -> list[str]:

--- a/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
+++ b/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
@@ -1,11 +1,12 @@
 """FastAPI dispatch API for the OSPREY dispatch worker service.
 
 Exposes:
-  POST /dispatch              — enqueue an agent prompt, returns 202 + run_id
-  GET  /dispatch/{id}         — poll a run for completion
-  GET  /dispatch/{id}/stream  — SSE stream of run events
-  GET  /health                — liveness check with run statistics
-  GET  /dashboard/runs        — JSON feed consumed by the dispatcher dashboard (token-gated)
+  POST /dispatch                      — enqueue an agent prompt, returns 202 + run_id
+  GET  /dispatch/{id}                 — poll a run for completion
+  GET  /dispatch/{id}/stream          — SSE stream of run events
+  GET  /dispatch/{id}/artifacts/{aid} — raw bytes of one artifact the run produced
+  GET  /health                        — liveness check with run statistics
+  GET  /dashboard/runs                — JSON feed consumed by the dispatcher dashboard (token-gated)
 """
 
 from __future__ import annotations
@@ -21,7 +22,7 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 from fastapi import Depends, FastAPI, HTTPException, Request, status
-from fastapi.responses import StreamingResponse
+from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 
@@ -290,6 +291,36 @@ async def _stale_run_cleanup() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _artifact_store():
+    """ArtifactStore rooted at the SHARED agent-data root.
+
+    Shared, not session-scoped: the dispatched agent's tools write there (the
+    worker process sets no OSPREY_SESSION_ID), and it is the same root the
+    artifact gallery reads. Built per call — the index is re-read from disk, so
+    artifacts written by the agent's MCP subprocesses are visible here.
+    """
+    from osprey.stores.artifact_store import ArtifactStore
+    from osprey.utils.workspace import resolve_shared_data_root
+
+    return ArtifactStore(workspace_root=resolve_shared_data_root())
+
+
+def _artifact_ids_for_run(run_id: str) -> list[str]:
+    """Ids of the artifacts this run produced, oldest first.
+
+    Strict equality on ``run_id`` — deliberately NOT
+    ``list_entries(session_filter=...)``, which also matches entries with an
+    EMPTY session id and would therefore attach every untagged legacy artifact
+    in the store to every run.
+    """
+    try:
+        entries = _artifact_store().list_entries()
+    except Exception:
+        logger.warning("Could not read artifact store for run %s", run_id, exc_info=True)
+        return []
+    return [e.id for e in entries if e.run_id == run_id]
+
+
 def _verify_token(credentials: HTTPAuthorizationCredentials = Depends(_bearer_scheme)) -> None:
     expected = os.environ.get("DISPATCH_WORKER_TOKEN", "")
     if not expected:
@@ -345,11 +376,15 @@ async def _run_dispatch_task(run_id: str, request: DispatchRequest) -> None:
                 max_turns=request.max_turns,
                 event_queue=queue,
                 denied_tools=DENIED_TOOLS,
+                run_id=run_id,
             ),
             timeout=DISPATCH_TIMEOUT_SEC,
         )
         result["completed_at"] = time.time()
         result["prompt"] = request.prompt
+        # Artifacts the agent saved during this run, for consumers that
+        # republish them (see GET /dispatch/{run_id}/artifacts/{artifact_id}).
+        result["artifacts"] = _artifact_ids_for_run(run_id)
         _runs[run_id] = result
         _persist_run(run_id, result)
         logger.info("Dispatch %s completed: status=%s", run_id, result.get("status"))
@@ -479,6 +514,35 @@ async def get_dispatch_result(run_id: str) -> dict[str, Any]:
     if result is None:
         raise HTTPException(status_code=404, detail=f"run_id {run_id!r} not found")
     return result
+
+
+@app.get("/dispatch/{run_id}/artifacts/{artifact_id}", dependencies=[Depends(_verify_token)])
+async def get_dispatch_artifact(run_id: str, artifact_id: str) -> FileResponse:
+    """Serve the raw bytes of one artifact produced by ``run_id``.
+
+    The artifact must be attributed to this run: an artifact belonging to a
+    different run (or to no run) is a 404 here, so a caller holding one run_id
+    cannot enumerate or read another run's output. ``artifact_id`` is never
+    joined into a path directly — it is resolved through the store's index, so
+    a traversal-shaped id simply fails to match an entry.
+    """
+    if run_id not in _runs:
+        raise HTTPException(status_code=404, detail=f"run_id {run_id!r} not found")
+
+    store = _artifact_store()
+    entry = store.get_entry(artifact_id)
+    if entry is None or entry.run_id != run_id:
+        raise HTTPException(status_code=404, detail=f"artifact {artifact_id!r} not found for run")
+
+    path = store.get_file_path(artifact_id)
+    if path is None or not path.is_file():
+        raise HTTPException(status_code=404, detail=f"artifact {artifact_id!r} has no file")
+
+    return FileResponse(
+        path,
+        media_type=entry.mime_type or "application/octet-stream",
+        filename=entry.filename,
+    )
 
 
 @app.get("/dispatch/{run_id}/stream", dependencies=[Depends(_verify_token)])

--- a/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
+++ b/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
@@ -101,6 +101,7 @@ async def run_dispatch(
     max_turns: int = 25,
     event_queue: asyncio.Queue | None = None,
     denied_tools: Iterable[str] = (),
+    run_id: str | None = None,
 ) -> dict[str, Any]:
     """Run a prompt headlessly via the Claude Agent SDK.
 
@@ -111,6 +112,9 @@ async def run_dispatch(
         denied_tools: Hard denylist enforced at the permission layer regardless
             of ``allowed_tools`` (defense-in-depth; the worker threads its
             ``DENIED_TOOLS`` here). Entries ending in ``*`` match by prefix.
+        run_id: Dispatch run id. Exported to the agent (and the MCP tool
+            subprocesses it spawns) as ``OSPREY_DISPATCH_RUN_ID`` so every
+            artifact saved during the run is attributed to it.
 
     Returns:
         dict with keys:
@@ -170,6 +174,14 @@ async def run_dispatch(
     # hook aggregation is not deny-dominates, so an allow would override the
     # trigger-allowlist hook below).
     sdk_env["OSPREY_DISPATCH_RUN"] = "1"
+
+    # Attribute every artifact this run saves to the run, so the worker can
+    # later report and serve exactly this run's plots. NOT OSPREY_SESSION_ID:
+    # that variable also relocates the artifact store into
+    # _agent_data/sessions/<id>/ (resolve_agent_data_root), which would move
+    # dispatch plots off the shared root the gallery reads.
+    if run_id:
+        sdk_env["OSPREY_DISPATCH_RUN_ID"] = run_id
 
     # Declared subagent tool surfaces from the provisioned .claude/agents/ —
     # each subagent is held to exactly its declared tools (web-terminal parity)

--- a/src/osprey/stores/artifact_store.py
+++ b/src/osprey/stores/artifact_store.py
@@ -436,9 +436,15 @@ class ArtifactStore(BaseStore[ArtifactEntry]):
         tool_filter: str | None = None,
         source_agent_filter: str | None = None,
         session_filter: str | None = None,
+        run_filter: str | None = None,
         last_n: int | None = None,
     ) -> list[ArtifactEntry]:
-        """Return artifact entries, optionally filtered."""
+        """Return artifact entries, optionally filtered.
+
+        ``run_filter`` is the strict dispatch-run isolation boundary — see the
+        note on its clause below. ``session_filter`` is deliberately NOT such a
+        boundary (it also matches untagged artifacts).
+        """
         self._refresh_if_stale()
         entries = list(self._entries)
         if type_filter:
@@ -450,7 +456,19 @@ class ArtifactStore(BaseStore[ArtifactEntry]):
         if source_agent_filter:
             entries = [e for e in entries if e.source_agent == source_agent_filter]
         if session_filter:
+            # NOT an isolation boundary: this OR-empty clause also matches
+            # untagged (empty session_id) artifacts. Dispatch callers needing
+            # strict per-run isolation must use ``run_filter`` / ``get_run_entry``
+            # instead, which never match empty tags.
             entries = [e for e in entries if e.session_id == session_filter or not e.session_id]
+        if run_filter is not None:
+            # Strict created-by isolation: an artifact belongs to a run only if
+            # it was tagged with that run's id at WRITE time. Deliberately does
+            # NOT match empty run_ids, so untagged/legacy artifacts are never
+            # attributed to any dispatch run. An empty filter matches nothing.
+            if run_filter == "":
+                return []
+            entries = [e for e in entries if e.run_id == run_filter]
         if pinned is not None:
             entries = [e for e in entries if e.pinned == pinned]
         if search:
@@ -476,6 +494,20 @@ class ArtifactStore(BaseStore[ArtifactEntry]):
             if e.id == artifact_id:
                 return e
         return None
+
+    def get_run_entry(self, run_id: str, artifact_id: str) -> ArtifactEntry | None:
+        """Return the artifact only if the run created it — the cross-run gate.
+
+        The single authoritative isolation predicate: an entry resolves only
+        when its write-time ``run_id`` tag is non-empty and exactly equals
+        ``run_id``. An empty ``run_id`` argument, an untagged entry, or a tag
+        mismatch all return ``None`` — indistinguishable from an unknown id, so
+        callers cannot use this as a cross-run existence oracle.
+        """
+        entry = self.get_entry(artifact_id)
+        if entry is None or not entry.run_id or entry.run_id != run_id:
+            return None
+        return entry
 
     def delete_entry(self, artifact_id: str) -> bool:
         """Delete an artifact by ID, removing both the index entry and physical file.

--- a/src/osprey/stores/artifact_store.py
+++ b/src/osprey/stores/artifact_store.py
@@ -71,6 +71,14 @@ class ArtifactEntry:
     data_file: str = ""
     source_agent: str = ""
     session_id: str = ""
+    run_id: str = ""
+    """Dispatch run that produced this artifact (``OSPREY_DISPATCH_RUN_ID``),
+    empty for artifacts made outside a dispatch run.
+
+    Deliberately separate from ``session_id``: ``OSPREY_SESSION_ID`` also
+    relocates the whole store into ``_agent_data/sessions/<id>/`` (see
+    ``resolve_agent_data_root``), so it cannot be reused to tag a dispatch run
+    without moving its artifacts off the shared root the gallery reads."""
 
     def to_dict(self) -> dict[str, Any]:
         return _sanitize_for_json(asdict(self))
@@ -214,6 +222,7 @@ class ArtifactStore(BaseStore[ArtifactEntry]):
         d.setdefault("data_file", "")
         d.setdefault("source_agent", "")
         d.setdefault("session_id", "")
+        d.setdefault("run_id", "")
         return ArtifactEntry(**d)
 
     def _entry_to_dict(self, entry: ArtifactEntry) -> dict:
@@ -267,6 +276,7 @@ class ArtifactStore(BaseStore[ArtifactEntry]):
                 metadata=metadata or {},
                 category=category,
                 session_id=os.environ.get("OSPREY_SESSION_ID", ""),
+                run_id=os.environ.get("OSPREY_DISPATCH_RUN_ID", ""),
             )
             self._entries.append(entry)
             self._save_index()
@@ -401,6 +411,7 @@ class ArtifactStore(BaseStore[ArtifactEntry]):
                 data_file=agent_path,
                 source_agent=source_agent,
                 session_id=os.environ.get("OSPREY_SESSION_ID", ""),
+                run_id=os.environ.get("OSPREY_DISPATCH_RUN_ID", ""),
             )
             self._entries.append(entry)
             self._save_index()

--- a/tests/dispatch/test_run_artifacts.py
+++ b/tests/dispatch/test_run_artifacts.py
@@ -1,0 +1,201 @@
+"""Dispatch runs expose the artifacts they produced.
+
+A dispatched agent writes plot PNGs into the shared artifact store. The worker
+must be able to say *which* artifacts a given run produced, and hand back their
+bytes, so an external consumer (e.g. a chat bridge) can republish them.
+
+Attribution rides on ``ArtifactEntry.run_id``, stamped from
+``OSPREY_DISPATCH_RUN_ID``. It is deliberately NOT ``OSPREY_SESSION_ID``: that
+variable also relocates the store into ``_agent_data/sessions/<id>/`` via
+``resolve_agent_data_root``, which would move dispatch plots off the shared
+root the gallery reads.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from osprey.stores.artifact_store import ArtifactStore
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"fake-png-body"
+TOKEN = "test-worker-token"
+
+
+def _store_with(tmp_path: Path, entries: list[tuple[str, str]]) -> ArtifactStore:
+    """Build a store under tmp_path containing one PNG per (run_id, title)."""
+    store = ArtifactStore(workspace_root=tmp_path)
+    for run_id, title in entries:
+        import os
+
+        prev = os.environ.get("OSPREY_DISPATCH_RUN_ID")
+        if run_id:
+            os.environ["OSPREY_DISPATCH_RUN_ID"] = run_id
+        else:
+            os.environ.pop("OSPREY_DISPATCH_RUN_ID", None)
+        try:
+            store.save_file(
+                file_content=PNG_BYTES,
+                filename=f"{title}.png",
+                title=title,
+                artifact_type="image",
+                mime_type="image/png",
+            )
+        finally:
+            if prev is None:
+                os.environ.pop("OSPREY_DISPATCH_RUN_ID", None)
+            else:
+                os.environ["OSPREY_DISPATCH_RUN_ID"] = prev
+    return store
+
+
+class TestArtifactEntryRunId:
+    def test_save_file_stamps_run_id_from_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OSPREY_DISPATCH_RUN_ID", "run-abc")
+        store = ArtifactStore(workspace_root=tmp_path)
+        entry = store.save_file(
+            file_content=PNG_BYTES,
+            filename="p.png",
+            title="p",
+            artifact_type="image",
+            mime_type="image/png",
+        )
+        assert entry.run_id == "run-abc"
+
+    def test_run_id_defaults_empty_when_env_unset(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("OSPREY_DISPATCH_RUN_ID", raising=False)
+        store = ArtifactStore(workspace_root=tmp_path)
+        entry = store.save_file(
+            file_content=PNG_BYTES,
+            filename="p.png",
+            title="p",
+            artifact_type="image",
+            mime_type="image/png",
+        )
+        assert entry.run_id == ""
+
+    def test_old_index_without_run_id_still_loads(self, tmp_path):
+        """A pre-existing artifacts.json has no run_id key; loading must not raise."""
+        import json
+
+        d = tmp_path / "artifacts"
+        d.mkdir(parents=True)
+        (d / "artifacts.json").write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "updated": "2026-01-01T00:00:00Z",
+                    "entry_count": 1,
+                    "entries": [
+                        {
+                            "id": "old1",
+                            "artifact_type": "image",
+                            "title": "t",
+                            "description": "",
+                            "filename": "t.png",
+                            "mime_type": "image/png",
+                            "size_bytes": 3,
+                            "timestamp": "2026-01-01T00:00:00Z",
+                            "tool_source": "x",
+                        }
+                    ],
+                }
+            )
+        )
+        store = ArtifactStore(workspace_root=tmp_path)
+        entries = store.list_entries()
+        assert len(entries) == 1
+        assert entries[0].run_id == ""
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("DISPATCH_WORKER_TOKEN", TOKEN)
+    from osprey.mcp_server.dispatch_worker import dispatch_api
+
+    store = _store_with(
+        tmp_path,
+        [("run-1", "mine"), ("run-2", "theirs"), ("", "untagged-legacy")],
+    )
+    monkeypatch.setattr(dispatch_api, "_artifact_store", lambda: store)
+    dispatch_api._runs.clear()
+    dispatch_api._runs["run-1"] = {"status": "completed"}
+    dispatch_api._runs["run-2"] = {"status": "completed"}
+    with TestClient(dispatch_api.app) as c:
+        yield c, store
+
+
+def _ids(store, run_id):
+    return [e.id for e in store.list_entries() if e.run_id == run_id]
+
+
+class TestArtifactIdsForRun:
+    def test_only_this_runs_artifacts(self, client):
+        _, store = client
+        from osprey.mcp_server.dispatch_worker import dispatch_api
+
+        ids = dispatch_api._artifact_ids_for_run("run-1")
+        assert ids == _ids(store, "run-1")
+        assert len(ids) == 1
+
+    def test_excludes_untagged_legacy_artifacts(self, client):
+        _, store = client
+        from osprey.mcp_server.dispatch_worker import dispatch_api
+
+        ids = dispatch_api._artifact_ids_for_run("run-1")
+        untagged = [e.id for e in store.list_entries() if not e.run_id]
+        assert untagged, "fixture should contain an untagged artifact"
+        assert not set(ids) & set(untagged)
+
+    def test_unknown_run_yields_nothing(self):
+        from osprey.mcp_server.dispatch_worker import dispatch_api
+
+        assert dispatch_api._artifact_ids_for_run("nope") == []
+
+
+class TestArtifactBytesRoute:
+    def test_serves_png_bytes(self, client):
+        c, store = client
+        art_id = _ids(store, "run-1")[0]
+        r = c.get(
+            f"/dispatch/run-1/artifacts/{art_id}",
+            headers={"Authorization": f"Bearer {TOKEN}"},
+        )
+        assert r.status_code == 200
+        assert r.headers["content-type"].startswith("image/png")
+        assert r.content == PNG_BYTES
+
+    def test_requires_auth(self, client):
+        c, store = client
+        art_id = _ids(store, "run-1")[0]
+        r = c.get(f"/dispatch/run-1/artifacts/{art_id}")
+        assert r.status_code in (401, 403)
+
+    def test_cross_run_artifact_is_not_served(self, client):
+        """An artifact belonging to run-2 must not be reachable under run-1."""
+        c, store = client
+        other = _ids(store, "run-2")[0]
+        r = c.get(
+            f"/dispatch/run-1/artifacts/{other}",
+            headers={"Authorization": f"Bearer {TOKEN}"},
+        )
+        assert r.status_code == 404
+
+    def test_unknown_artifact_404(self, client):
+        c, _ = client
+        r = c.get(
+            "/dispatch/run-1/artifacts/does-not-exist",
+            headers={"Authorization": f"Bearer {TOKEN}"},
+        )
+        assert r.status_code == 404
+
+    def test_unknown_run_404(self, client):
+        c, store = client
+        art_id = _ids(store, "run-1")[0]
+        r = c.get(
+            f"/dispatch/no-such-run/artifacts/{art_id}",
+            headers={"Authorization": f"Bearer {TOKEN}"},
+        )
+        assert r.status_code == 404

--- a/tests/dispatch/test_run_artifacts.py
+++ b/tests/dispatch/test_run_artifacts.py
@@ -110,6 +110,51 @@ class TestArtifactEntryRunId:
         assert entries[0].run_id == ""
 
 
+class TestArtifactStoreRooting:
+    """The store must be rooted where the agent's tools actually write.
+
+    Regression: rooting via ``resolve_shared_data_root()`` located the project
+    through ``OSPREY_CONFIG`` and fell back to CWD. The worker is configured
+    with ``CONFIG_FILE`` and runs from the image WORKDIR, so it resolved to
+    ``<cwd>/_agent_data`` while the agent wrote to
+    ``$OSPREY_PROJECT_DIR/_agent_data`` — every lookup returned nothing.
+    """
+
+    def test_root_follows_project_dir_not_cwd(self, tmp_path, monkeypatch):
+        from osprey.mcp_server.dispatch_worker import dispatch_api
+
+        project = tmp_path / "project"
+        (project / "_agent_data" / "artifacts").mkdir(parents=True)
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+
+        monkeypatch.setenv("OSPREY_PROJECT_DIR", str(project))
+        monkeypatch.delenv("OSPREY_CONFIG", raising=False)
+        monkeypatch.chdir(elsewhere)
+
+        store = dispatch_api._artifact_store()
+        assert store._store_dir == project / "_agent_data" / "artifacts"
+
+    def test_finds_artifacts_the_agent_wrote(self, tmp_path, monkeypatch):
+        """End-to-end of the rooting: write via the agent's root, read via the worker."""
+        from osprey.mcp_server.dispatch_worker import dispatch_api
+
+        project = tmp_path / "project"
+        (project / "_agent_data").mkdir(parents=True)
+        monkeypatch.setenv("OSPREY_PROJECT_DIR", str(project))
+        monkeypatch.chdir(tmp_path)
+
+        monkeypatch.setenv("OSPREY_DISPATCH_RUN_ID", "run-x")
+        ArtifactStore(workspace_root=project / "_agent_data").save_file(
+            file_content=PNG_BYTES,
+            filename="p.png",
+            title="p",
+            artifact_type="image",
+            mime_type="image/png",
+        )
+        assert dispatch_api._artifact_ids_for_run("run-x")
+
+
 @pytest.fixture
 def client(tmp_path, monkeypatch):
     monkeypatch.setenv("DISPATCH_WORKER_TOKEN", TOKEN)

--- a/tests/dispatch/test_run_artifacts.py
+++ b/tests/dispatch/test_run_artifacts.py
@@ -1,54 +1,85 @@
-"""Dispatch runs expose the artifacts they produced.
+"""Dispatch runs expose the artifacts they produced — created-by isolation.
 
-A dispatched agent writes plot PNGs into the shared artifact store. The worker
-must be able to say *which* artifacts a given run produced, and hand back their
-bytes, so an external consumer (e.g. a chat bridge) can republish them.
+A dispatched agent writes plots into the shared artifact store. The worker must
+say *which* artifacts a run produced and hand back their (renderable) bytes, so
+a bridge can republish them — WITHOUT one run ever reading another run's output.
 
-Attribution rides on ``ArtifactEntry.run_id``, stamped from
-``OSPREY_DISPATCH_RUN_ID``. It is deliberately NOT ``OSPREY_SESSION_ID``: that
-variable also relocates the store into ``_agent_data/sessions/<id>/`` via
-``resolve_agent_data_root``, which would move dispatch plots off the shared
-root the gallery reads.
+Association is **created-by**: ``ArtifactEntry.run_id`` is stamped from
+``OSPREY_DISPATCH_RUN_ID`` at write time inside the trusted store, and every
+artifact surface (the run-status ``artifacts`` list, the list route, and the
+byte route) bottoms out in the single strict predicate ``entry.run_id ==
+run_id``. Authorization never reads agent-controllable data, so a prompt-injected
+run cannot widen its artifact set or reach another run's bytes. This is
+deliberately NOT ``OSPREY_SESSION_ID`` (which relocates the whole store root).
 """
 
 from __future__ import annotations
 
+import asyncio
+import json
+import os
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
 
+from osprey.interfaces.artifacts import resolve as resolve_mod
 from osprey.stores.artifact_store import ArtifactStore
 
 PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"fake-png-body"
+PDF_BYTES = b"%PDF-1.4\nfake-pdf-body\n%%EOF"
+HTML_BYTES = b"<html><body><h1>plot</h1></body></html>"
 TOKEN = "test-worker-token"
 
 
-def _store_with(tmp_path: Path, entries: list[tuple[str, str]]) -> ArtifactStore:
-    """Build a store under tmp_path containing one PNG per (run_id, title)."""
-    store = ArtifactStore(workspace_root=tmp_path)
-    for run_id, title in entries:
-        import os
-
-        prev = os.environ.get("OSPREY_DISPATCH_RUN_ID")
-        if run_id:
-            os.environ["OSPREY_DISPATCH_RUN_ID"] = run_id
-        else:
+def _save(
+    store: ArtifactStore,
+    run_id: str,
+    *,
+    title: str,
+    filename: str,
+    mime: str,
+    body: bytes,
+) -> str:
+    """Save one artifact tagged with ``run_id`` (via the env the store reads)."""
+    prev = os.environ.get("OSPREY_DISPATCH_RUN_ID")
+    if run_id:
+        os.environ["OSPREY_DISPATCH_RUN_ID"] = run_id
+    else:
+        os.environ.pop("OSPREY_DISPATCH_RUN_ID", None)
+    try:
+        entry = store.save_file(
+            file_content=body,
+            filename=filename,
+            title=title,
+            artifact_type="image",
+            mime_type=mime,
+        )
+    finally:
+        if prev is None:
             os.environ.pop("OSPREY_DISPATCH_RUN_ID", None)
-        try:
-            store.save_file(
-                file_content=PNG_BYTES,
-                filename=f"{title}.png",
-                title=title,
-                artifact_type="image",
-                mime_type="image/png",
-            )
-        finally:
-            if prev is None:
-                os.environ.pop("OSPREY_DISPATCH_RUN_ID", None)
-            else:
-                os.environ["OSPREY_DISPATCH_RUN_ID"] = prev
-    return store
+        else:
+            os.environ["OSPREY_DISPATCH_RUN_ID"] = prev
+    return entry.id
+
+
+def _rooted_store(tmp_path: Path, monkeypatch) -> ArtifactStore:
+    """Store rooted so ``resolve._get_store()`` reads the same place.
+
+    ``_get_store()`` roots at ``$OSPREY_PROJECT_DIR/_agent_data``; the byte/list/
+    describe surfaces all go through it, so tests must write there too.
+    """
+    project = tmp_path / "project"
+    (project / "_agent_data").mkdir(parents=True)
+    monkeypatch.setenv("OSPREY_PROJECT_DIR", str(project))
+    monkeypatch.delenv("OSPREY_CONFIG", raising=False)
+    return ArtifactStore(workspace_root=project / "_agent_data")
+
+
+# ---------------------------------------------------------------------------
+# Store-level provenance (Slot 1)
+# ---------------------------------------------------------------------------
 
 
 class TestArtifactEntryRunId:
@@ -77,9 +108,6 @@ class TestArtifactEntryRunId:
         assert entry.run_id == ""
 
     def test_old_index_without_run_id_still_loads(self, tmp_path):
-        """A pre-existing artifacts.json has no run_id key; loading must not raise."""
-        import json
-
         d = tmp_path / "artifacts"
         d.mkdir(parents=True)
         (d / "artifacts.json").write_text(
@@ -110,137 +138,496 @@ class TestArtifactEntryRunId:
         assert entries[0].run_id == ""
 
 
-class TestArtifactStoreRooting:
-    """The store must be rooted where the agent's tools actually write.
+class TestRunFilter:
+    """``list_entries(run_filter=...)`` is the strict created-by boundary."""
 
-    Regression: rooting via ``resolve_shared_data_root()`` located the project
-    through ``OSPREY_CONFIG`` and fell back to CWD. The worker is configured
-    with ``CONFIG_FILE`` and runs from the image WORKDIR, so it resolved to
-    ``<cwd>/_agent_data`` while the agent wrote to
-    ``$OSPREY_PROJECT_DIR/_agent_data`` — every lookup returned nothing.
-    """
+    @pytest.fixture
+    def store(self, tmp_path) -> ArtifactStore:
+        s = ArtifactStore(workspace_root=tmp_path)
+        _save(s, "run-1", title="mine", filename="a.png", mime="image/png", body=PNG_BYTES)
+        _save(s, "run-1", title="mine2", filename="b.png", mime="image/png", body=PNG_BYTES)
+        _save(s, "run-2", title="theirs", filename="c.png", mime="image/png", body=PNG_BYTES)
+        _save(s, "", title="legacy", filename="d.png", mime="image/png", body=PNG_BYTES)
+        return s
+
+    def test_returns_only_this_runs_entries(self, store):
+        got = {e.title for e in store.list_entries(run_filter="run-1")}
+        assert got == {"mine", "mine2"}
+
+    def test_excludes_other_runs(self, store):
+        titles = {e.title for e in store.list_entries(run_filter="run-1")}
+        assert "theirs" not in titles
+
+    def test_excludes_untagged_legacy(self, store):
+        titles = {e.title for e in store.list_entries(run_filter="run-1")}
+        assert "legacy" not in titles
+
+    def test_empty_run_filter_matches_nothing(self, store):
+        # Symmetric foot-gun guard: an empty run tag must NOT match untagged
+        # artifacts (unlike session_filter's OR-empty clause).
+        assert store.list_entries(run_filter="") == []
+
+    def test_none_run_filter_returns_all(self, store):
+        assert len(store.list_entries(run_filter=None)) == 4
+
+
+class TestGetRunEntry:
+    """The single centralized cross-run gate."""
+
+    @pytest.fixture
+    def store(self, tmp_path):
+        s = ArtifactStore(workspace_root=tmp_path)
+        a1 = _save(s, "run-1", title="a", filename="a.png", mime="image/png", body=PNG_BYTES)
+        a2 = _save(s, "run-2", title="b", filename="b.png", mime="image/png", body=PNG_BYTES)
+        leg = _save(s, "", title="c", filename="c.png", mime="image/png", body=PNG_BYTES)
+        return s, a1, a2, leg
+
+    def test_exact_match_returns_entry(self, store):
+        s, a1, _, _ = store
+        assert s.get_run_entry("run-1", a1).id == a1
+
+    def test_wrong_run_returns_none(self, store):
+        s, _, a2, _ = store
+        assert s.get_run_entry("run-1", a2) is None
+
+    def test_untagged_entry_returns_none(self, store):
+        s, _, _, leg = store
+        assert s.get_run_entry("run-1", leg) is None
+
+    def test_empty_run_id_returns_none(self, store):
+        s, _, _, leg = store
+        # Even against the untagged entry, an empty run_id must never match.
+        assert s.get_run_entry("", leg) is None
+
+    def test_unknown_id_returns_none(self, store):
+        s, _, _, _ = store
+        assert s.get_run_entry("run-1", "does-not-exist") is None
+
+
+class TestStoreRooting:
+    """resolve._get_store() must root where the agent's tools write."""
 
     def test_root_follows_project_dir_not_cwd(self, tmp_path, monkeypatch):
-        from osprey.mcp_server.dispatch_worker import dispatch_api
-
         project = tmp_path / "project"
         (project / "_agent_data" / "artifacts").mkdir(parents=True)
         elsewhere = tmp_path / "elsewhere"
         elsewhere.mkdir()
-
         monkeypatch.setenv("OSPREY_PROJECT_DIR", str(project))
         monkeypatch.delenv("OSPREY_CONFIG", raising=False)
         monkeypatch.chdir(elsewhere)
+        assert resolve_mod._get_store()._store_dir == project / "_agent_data" / "artifacts"
 
-        store = dispatch_api._artifact_store()
-        assert store._store_dir == project / "_agent_data" / "artifacts"
 
-    def test_finds_artifacts_the_agent_wrote(self, tmp_path, monkeypatch):
-        """End-to-end of the rooting: write via the agent's root, read via the worker."""
-        from osprey.mcp_server.dispatch_worker import dispatch_api
+# ---------------------------------------------------------------------------
+# Render-free descriptors (Slot 2)
+# ---------------------------------------------------------------------------
 
-        project = tmp_path / "project"
-        (project / "_agent_data").mkdir(parents=True)
-        monkeypatch.setenv("OSPREY_PROJECT_DIR", str(project))
-        monkeypatch.chdir(tmp_path)
 
-        monkeypatch.setenv("OSPREY_DISPATCH_RUN_ID", "run-x")
-        ArtifactStore(workspace_root=project / "_agent_data").save_file(
-            file_content=PNG_BYTES,
-            filename="p.png",
-            title="p",
-            artifact_type="image",
-            mime_type="image/png",
-        )
-        assert dispatch_api._artifact_ids_for_run("run-x")
+class TestPredictDelivery:
+    def test_image_passthrough(self):
+        assert resolve_mod.predict_delivery("image/png") == ("image/png", True)
+
+    def test_pdf_passthrough(self):
+        assert resolve_mod.predict_delivery("application/pdf") == ("application/pdf", True)
+
+    def test_html_renders_to_png(self):
+        assert resolve_mod.predict_delivery("text/html") == ("image/png", True)
+
+    def test_unknown_renders_to_png(self):
+        assert resolve_mod.predict_delivery("application/whatever") == ("image/png", True)
+
+
+class TestDescribeRunArtifacts:
+    def test_unknown_run_is_empty(self, tmp_path, monkeypatch):
+        _rooted_store(tmp_path, monkeypatch)
+        assert resolve_mod.describe_run_artifacts("nope") == []
+
+    def test_empty_run_id_is_empty(self, tmp_path, monkeypatch):
+        _rooted_store(tmp_path, monkeypatch)
+        assert resolve_mod.describe_run_artifacts("") == []
+
+    def test_descriptor_shape_and_source_mime(self, tmp_path, monkeypatch):
+        store = _rooted_store(tmp_path, monkeypatch)
+        _save(store, "run-1", title="h", filename="h.html", mime="text/html", body=HTML_BYTES)
+        [d] = resolve_mod.describe_run_artifacts("run-1")
+        assert set(d) == {"artifact_id", "filename", "source_mime", "delivered_mime", "convertible"}
+        assert d["source_mime"] == "text/html"
+        assert d["delivered_mime"] == "image/png"  # rendered
+        assert d["filename"].endswith(".png")  # predicted delivered name
+
+    def test_render_free_never_invokes_converter(self, tmp_path, monkeypatch):
+        store = _rooted_store(tmp_path, monkeypatch)
+        _save(store, "run-1", title="h", filename="h.html", mime="text/html", body=HTML_BYTES)
+
+        async def _boom(*a, **k):  # pragma: no cover - must never run
+            raise AssertionError("describe must not render")
+
+        import osprey.mcp_server.ariel.converters as conv
+
+        monkeypatch.setitem(conv.CONVERTER_REGISTRY, "text/html", _boom)
+        # describe only classifies (get_converter lookup), never calls the converter
+        [d] = resolve_mod.describe_run_artifacts("run-1")
+        assert d["delivered_mime"] == "image/png"
+
+
+class TestResolveRunArtifacts:
+    """The public bulk resolver: created-by scoped, lenient about missing files."""
+
+    async def test_resolves_only_this_runs_artifacts(self, tmp_path, monkeypatch):
+        store = _rooted_store(tmp_path, monkeypatch)
+        a1 = _save(store, "run-1", title="a", filename="a.png", mime="image/png", body=PNG_BYTES)
+        _save(store, "run-1", title="b", filename="b.png", mime="image/png", body=PNG_BYTES)
+        _save(store, "run-2", title="c", filename="c.png", mime="image/png", body=PNG_BYTES)
+        refs = await resolve_mod.resolve_run_artifacts("run-1")
+        assert {r.artifact_id for r in refs} == {a1, refs[1].artifact_id}
+        assert len(refs) == 2  # run-2's artifact excluded
+
+    async def test_unknown_run_is_empty(self, tmp_path, monkeypatch):
+        _rooted_store(tmp_path, monkeypatch)
+        assert await resolve_mod.resolve_run_artifacts("nope") == []
+
+    async def test_skips_artifact_whose_file_was_deleted(self, tmp_path, monkeypatch):
+        store = _rooted_store(tmp_path, monkeypatch)
+        keep = _save(store, "run-1", title="k", filename="k.png", mime="image/png", body=PNG_BYTES)
+        gone = _save(store, "run-1", title="g", filename="g.png", mime="image/png", body=PNG_BYTES)
+        (store.get_file_path(gone)).unlink()  # tag survives, file removed
+        refs = await resolve_mod.resolve_run_artifacts("run-1")
+        assert [r.artifact_id for r in refs] == [keep]
+
+
+# ---------------------------------------------------------------------------
+# HTTP surfaces (Slot 3): client fixture
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
-def client(tmp_path, monkeypatch):
+def client(tmp_path, monkeypatch) -> Iterator[tuple[TestClient, ArtifactStore, dict]]:
     monkeypatch.setenv("DISPATCH_WORKER_TOKEN", TOKEN)
+    store = _rooted_store(tmp_path, monkeypatch)
+    ids = {
+        "a1": _save(
+            store, "run-1", title="mine", filename="a.png", mime="image/png", body=PNG_BYTES
+        ),
+        "a2": _save(
+            store, "run-1", title="mine2", filename="b.png", mime="image/png", body=PNG_BYTES
+        ),
+        "other": _save(
+            store, "run-2", title="theirs", filename="c.png", mime="image/png", body=PNG_BYTES
+        ),
+        "legacy": _save(
+            store, "", title="legacy", filename="d.png", mime="image/png", body=PNG_BYTES
+        ),
+    }
     from osprey.mcp_server.dispatch_worker import dispatch_api
 
-    store = _store_with(
-        tmp_path,
-        [("run-1", "mine"), ("run-2", "theirs"), ("", "untagged-legacy")],
+    monkeypatch.setattr(
+        dispatch_api, "_runs", {"run-1": {"status": "completed"}, "run-2": {"status": "completed"}}
     )
-    monkeypatch.setattr(dispatch_api, "_artifact_store", lambda: store)
-    dispatch_api._runs.clear()
-    dispatch_api._runs["run-1"] = {"status": "completed"}
-    dispatch_api._runs["run-2"] = {"status": "completed"}
+    monkeypatch.setattr(dispatch_api, "_queues", {})
+    monkeypatch.setattr(dispatch_api, "_tasks", {})
     with TestClient(dispatch_api.app) as c:
-        yield c, store
+        yield c, store, ids
 
 
-def _ids(store, run_id):
-    return [e.id for e in store.list_entries() if e.run_id == run_id]
+def _auth():
+    return {"Authorization": f"Bearer {TOKEN}"}
 
 
-class TestArtifactIdsForRun:
-    def test_only_this_runs_artifacts(self, client):
-        _, store = client
-        from osprey.mcp_server.dispatch_worker import dispatch_api
+class TestByteRouteIsolation:
+    """The byte route: identical, non-distinguishing 404 for every deny reason."""
 
-        ids = dispatch_api._artifact_ids_for_run("run-1")
-        assert ids == _ids(store, "run-1")
-        assert len(ids) == 1
-
-    def test_excludes_untagged_legacy_artifacts(self, client):
-        _, store = client
-        from osprey.mcp_server.dispatch_worker import dispatch_api
-
-        ids = dispatch_api._artifact_ids_for_run("run-1")
-        untagged = [e.id for e in store.list_entries() if not e.run_id]
-        assert untagged, "fixture should contain an untagged artifact"
-        assert not set(ids) & set(untagged)
-
-    def test_unknown_run_yields_nothing(self):
-        from osprey.mcp_server.dispatch_worker import dispatch_api
-
-        assert dispatch_api._artifact_ids_for_run("nope") == []
-
-
-class TestArtifactBytesRoute:
-    def test_serves_png_bytes(self, client):
-        c, store = client
-        art_id = _ids(store, "run-1")[0]
-        r = c.get(
-            f"/dispatch/run-1/artifacts/{art_id}",
-            headers={"Authorization": f"Bearer {TOKEN}"},
-        )
+    def test_serves_own_png_bytes(self, client):
+        c, _, ids = client
+        r = c.get(f"/dispatch/run-1/artifacts/{ids['a1']}", headers=_auth())
         assert r.status_code == 200
         assert r.headers["content-type"].startswith("image/png")
         assert r.content == PNG_BYTES
 
+    def test_cross_run_is_404(self, client):
+        c, _, ids = client
+        r = c.get(f"/dispatch/run-1/artifacts/{ids['other']}", headers=_auth())
+        assert r.status_code == 404
+
+    def test_untagged_legacy_is_404(self, client):
+        c, _, ids = client
+        r = c.get(f"/dispatch/run-1/artifacts/{ids['legacy']}", headers=_auth())
+        assert r.status_code == 404
+
+    def test_unknown_id_is_404(self, client):
+        c, _, _ = client
+        r = c.get("/dispatch/run-1/artifacts/does-not-exist", headers=_auth())
+        assert r.status_code == 404
+
+    def test_unknown_run_is_404(self, client):
+        c, _, ids = client
+        r = c.get(f"/dispatch/no-such-run/artifacts/{ids['a1']}", headers=_auth())
+        assert r.status_code == 404
+
+    def test_traversal_shaped_id_is_404(self, client):
+        c, _, _ = client
+        r = c.get("/dispatch/run-1/artifacts/..%2f..%2fetc%2fpasswd", headers=_auth())
+        assert r.status_code == 404
+
+    def test_deny_reasons_are_indistinguishable(self, client):
+        """Cross-run, unknown-id, and unknown-run all return the SAME 404 body."""
+        c, _, ids = client
+        bodies = {
+            c.get(f"/dispatch/run-1/artifacts/{ids['other']}", headers=_auth()).text,
+            c.get("/dispatch/run-1/artifacts/nope", headers=_auth()).text,
+            c.get(f"/dispatch/no-run/artifacts/{ids['a1']}", headers=_auth()).text,
+        }
+        assert len(bodies) == 1  # no existence oracle
+
+
+class TestInjectionResistance:
+    """HEADLINE: a run referencing another run's artifact-id cannot fetch it.
+
+    Under the old referenced-by model, an artifact-id appearing in a run's
+    tool_calls[].result would authorize the fetch. Created-by ignores the
+    reference entirely — only the write-time tag counts.
+    """
+
+    def test_referenced_but_not_created_is_404(self, client, tmp_path):
+        c, _, ids = client
+        # Plant a persisted run record for run-1 whose results "reference" run-2's
+        # artifact (as a prompt-injected agent might emit).
+        log_dir = tmp_path / "project" / "_agent_data" / "dispatch"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        (log_dir / "run-1.json").write_text(
+            json.dumps(
+                {
+                    "status": "completed",
+                    "tool_calls": [{"result": json.dumps({"artifact_id": ids["other"]})}],
+                }
+            )
+        )
+        r = c.get(f"/dispatch/run-1/artifacts/{ids['other']}", headers=_auth())
+        assert r.status_code == 404  # created-by wins; the reference is irrelevant
+
+
+class TestListRoute:
+    def test_lists_only_own_descriptors(self, client):
+        c, _, ids = client
+        r = c.get("/dispatch/run-1/artifacts", headers=_auth())
+        assert r.status_code == 200
+        got = {d["artifact_id"] for d in r.json()}
+        assert got == {ids["a1"], ids["a2"]}
+
+    def test_unknown_run_is_empty_not_404(self, client):
+        c, _, _ = client
+        r = c.get("/dispatch/no-such-run/artifacts", headers=_auth())
+        assert r.status_code == 200
+        assert r.json() == []
+
+    def test_metadata_only_no_render(self, client, monkeypatch):
+        """Listing must not invoke a converter even for renderable artifacts."""
+        c, store, _ = client
+        _save(store, "run-1", title="h", filename="h.html", mime="text/html", body=HTML_BYTES)
+        import osprey.mcp_server.ariel.converters as conv
+
+        async def _boom(*a, **k):  # pragma: no cover
+            raise AssertionError("list must not render")
+
+        monkeypatch.setitem(conv.CONVERTER_REGISTRY, "text/html", _boom)
+        r = c.get("/dispatch/run-1/artifacts", headers=_auth())
+        assert r.status_code == 200
+        html_desc = [d for d in r.json() if d["source_mime"] == "text/html"]
+        assert html_desc and html_desc[0]["delivered_mime"] == "image/png"
+
     def test_requires_auth(self, client):
-        c, store = client
-        art_id = _ids(store, "run-1")[0]
-        r = c.get(f"/dispatch/run-1/artifacts/{art_id}")
-        assert r.status_code in (401, 403)
+        c, _, _ = client
+        assert c.get("/dispatch/run-1/artifacts").status_code in (401, 403)
 
-    def test_cross_run_artifact_is_not_served(self, client):
-        """An artifact belonging to run-2 must not be reachable under run-1."""
-        c, store = client
-        other = _ids(store, "run-2")[0]
-        r = c.get(
-            f"/dispatch/run-1/artifacts/{other}",
-            headers={"Authorization": f"Bearer {TOKEN}"},
-        )
-        assert r.status_code == 404
 
-    def test_unknown_artifact_404(self, client):
-        c, _ = client
-        r = c.get(
-            "/dispatch/run-1/artifacts/does-not-exist",
-            headers={"Authorization": f"Bearer {TOKEN}"},
-        )
-        assert r.status_code == 404
+class TestCoherence:
+    """KEYSTONE: status body, list route, and byte route agree on one set."""
 
-    def test_unknown_run_404(self, client):
-        c, store = client
-        art_id = _ids(store, "run-1")[0]
-        r = c.get(
-            f"/dispatch/no-such-run/artifacts/{art_id}",
-            headers={"Authorization": f"Bearer {TOKEN}"},
+    def test_all_surfaces_agree(self, client):
+        c, _, ids = client
+        # status body carries descriptors for run-1's artifacts
+        status_ids = {d["artifact_id"] for d in _list_via_status(c, "run-1")}
+        list_ids = {
+            d["artifact_id"] for d in c.get("/dispatch/run-1/artifacts", headers=_auth()).json()
+        }
+        served = {
+            aid
+            for aid in (ids["a1"], ids["a2"], ids["other"])
+            if c.get(f"/dispatch/run-1/artifacts/{aid}", headers=_auth()).status_code == 200
+        }
+        assert status_ids == list_ids == served == {ids["a1"], ids["a2"]}
+        assert ids["other"] not in status_ids  # run-2's artifact appears nowhere under run-1
+
+
+def _list_via_status(c, run_id):
+    """Read the artifact descriptors from the run-status body."""
+    from osprey.mcp_server.dispatch_worker import dispatch_api
+
+    # Seed the status body the way completion does, then read it back over HTTP.
+    dispatch_api._runs[run_id] = {
+        "status": "completed",
+        "artifacts": resolve_mod.describe_run_artifacts(run_id),
+    }
+    return c.get(f"/dispatch/{run_id}", headers=_auth()).json()["artifacts"]
+
+
+class TestStatusBodyDiskFallback:
+    def test_evicted_run_still_served_from_disk(self, client, tmp_path):
+        c, _, _ = client
+        from osprey.mcp_server.dispatch_worker import dispatch_api
+
+        dispatch_api._runs.pop("run-1", None)  # evicted from memory
+        log_dir = tmp_path / "project" / "_agent_data" / "dispatch"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        (log_dir / "run-1.json").write_text(json.dumps({"status": "completed", "artifacts": []}))
+        r = c.get("/dispatch/run-1", headers=_auth())
+        assert r.status_code == 200
+        assert r.json()["status"] == "completed"
+
+    def test_truly_unknown_run_is_404(self, client):
+        c, _, _ = client
+        assert c.get("/dispatch/ghost", headers=_auth()).status_code == 404
+
+
+class TestConversionFidelity:
+    def test_pdf_passthrough(self, client):
+        c, store, _ = client
+        pid = _save(
+            store, "run-1", title="doc", filename="d.pdf", mime="application/pdf", body=PDF_BYTES
         )
-        assert r.status_code == 404
+        r = c.get(f"/dispatch/run-1/artifacts/{pid}", headers=_auth())
+        assert r.status_code == 200
+        assert r.headers["content-type"].startswith("application/pdf")
+        assert r.content == PDF_BYTES
+
+    def test_html_renders_to_png(self, client, monkeypatch):
+        c, store, _ = client
+        hid = _save(store, "run-1", title="h", filename="h.html", mime="text/html", body=HTML_BYTES)
+        import osprey.mcp_server.ariel.converters as conv
+
+        async def _fake_png(source: Path, output_dir: Path) -> Path:
+            out = output_dir / f"{source.stem}.png"
+            out.write_bytes(PNG_BYTES)
+            return out
+
+        monkeypatch.setitem(conv.CONVERTER_REGISTRY, "text/html", _fake_png)
+        r = c.get(f"/dispatch/run-1/artifacts/{hid}", headers=_auth())
+        assert r.status_code == 200
+        assert r.headers["content-type"].startswith("image/png")
+        assert r.content == PNG_BYTES
+
+    def test_converter_failure_falls_back_to_original(self, client, monkeypatch):
+        c, store, _ = client
+        hid = _save(store, "run-1", title="h", filename="h.html", mime="text/html", body=HTML_BYTES)
+        import osprey.mcp_server.ariel.converters as conv
+
+        async def _broken(*a, **k):
+            raise RuntimeError("no playwright")
+
+        monkeypatch.setitem(conv.CONVERTER_REGISTRY, "text/html", _broken)
+        r = c.get(f"/dispatch/run-1/artifacts/{hid}", headers=_auth())
+        assert r.status_code == 200  # graceful: original bytes, not a 500
+        assert r.content == HTML_BYTES
+        assert r.headers["content-type"].startswith("text/html")
+
+
+class TestAuthMatrix:
+    def test_all_artifact_routes_require_token(self, client):
+        c, _, ids = client
+        for path in (
+            "/dispatch/run-1",
+            "/dispatch/run-1/artifacts",
+            f"/dispatch/run-1/artifacts/{ids['a1']}",
+        ):
+            assert c.get(path).status_code in (401, 403), path
+
+    def test_unset_worker_token_fails_closed(self, client, monkeypatch):
+        c, _, ids = client
+        monkeypatch.delenv("DISPATCH_WORKER_TOKEN", raising=False)
+        r = c.get(f"/dispatch/run-1/artifacts/{ids['a1']}", headers={"Authorization": "Bearer x"})
+        assert r.status_code == 500  # never serve when the gate is misconfigured
+
+    def test_health_is_open(self, client):
+        c, _, _ = client
+        assert c.get("/health").status_code == 200
+
+
+class TestDeniedToolsInvariant:
+    """The created-by tag is only spoof-proof while the agent has no shell.
+
+    Binds that load-bearing assumption to a test: if a future change re-enabled
+    a shell/exec tool for dispatch, an agent could forge OSPREY_DISPATCH_RUN_ID
+    and mis-tag its artifacts. Keep these denied.
+    """
+
+    def test_shell_tools_denied(self):
+        from osprey.mcp_server.dispatch_worker.dispatch_api import DENIED_TOOLS
+
+        assert {"Bash", "BashOutput", "KillShell"} <= set(DENIED_TOOLS)
+
+
+# ---------------------------------------------------------------------------
+# Terminal-state contract: every finished result carries artifacts (Slot 3)
+# ---------------------------------------------------------------------------
+
+
+async def _drive_failing_task(monkeypatch, tmp_path, *, kind: str) -> dict:
+    monkeypatch.setenv("OSPREY_PROJECT_DIR", str(tmp_path))
+    from osprey.mcp_server.dispatch_worker import dispatch_api
+
+    monkeypatch.setattr(dispatch_api, "_runs", {})
+    monkeypatch.setattr(dispatch_api, "_queues", {})
+    monkeypatch.setattr(dispatch_api, "_tasks", {})
+    monkeypatch.setattr(dispatch_api, "_persist_run", lambda rid, r: None)
+
+    if kind == "exception":
+
+        async def _run(**kw):
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr(dispatch_api.sdk_runner, "run_dispatch", _run)
+        await dispatch_api._run_dispatch_task(
+            "run-x", dispatch_api.DispatchRequest(prompt="p", allowed_tools=[])
+        )
+    elif kind == "timeout":
+        monkeypatch.setattr(dispatch_api, "DISPATCH_TIMEOUT_SEC", 0)
+
+        async def _slow(**kw):
+            await asyncio.sleep(1)
+
+        monkeypatch.setattr(dispatch_api.sdk_runner, "run_dispatch", _slow)
+        await dispatch_api._run_dispatch_task(
+            "run-x", dispatch_api.DispatchRequest(prompt="p", allowed_tools=[])
+        )
+    elif kind == "cancel":
+
+        async def _hang(**kw):
+            await asyncio.sleep(10)
+
+        monkeypatch.setattr(dispatch_api.sdk_runner, "run_dispatch", _hang)
+        task = asyncio.create_task(
+            dispatch_api._run_dispatch_task(
+                "run-x", dispatch_api.DispatchRequest(prompt="p", allowed_tools=[])
+            )
+        )
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    return dispatch_api._runs["run-x"]
+
+
+class TestTerminalStateContract:
+    async def test_exception_result_has_empty_artifacts(self, monkeypatch, tmp_path):
+        result = await _drive_failing_task(monkeypatch, tmp_path, kind="exception")
+        assert result["status"] == "error"
+        assert result["artifacts"] == []
+
+    async def test_timeout_result_has_empty_artifacts(self, monkeypatch, tmp_path):
+        result = await _drive_failing_task(monkeypatch, tmp_path, kind="timeout")
+        assert result["status"] == "error"
+        assert result["artifacts"] == []
+
+    async def test_cancel_result_has_empty_artifacts(self, monkeypatch, tmp_path):
+        result = await _drive_failing_task(monkeypatch, tmp_path, kind="cancel")
+        assert result["status"] == "error"
+        assert result["artifacts"] == []

--- a/tests/unit/dispatch_worker/test_dispatch_api.py
+++ b/tests/unit/dispatch_worker/test_dispatch_api.py
@@ -46,7 +46,9 @@ def client(monkeypatch):
     monkeypatch.setattr(dispatch_api, "_queues", {})
     monkeypatch.setattr(dispatch_api, "_tasks", {})
 
-    async def _fake_run_dispatch(*, prompt, allowed_tools, max_turns, event_queue, denied_tools=(), run_id=None):
+    async def _fake_run_dispatch(
+        *, prompt, allowed_tools, max_turns, event_queue, denied_tools=(), run_id=None
+    ):
         if event_queue is not None:
             await event_queue.put({"type": "done"})
         return dict(_CANNED_RESULT)

--- a/tests/unit/dispatch_worker/test_dispatch_api.py
+++ b/tests/unit/dispatch_worker/test_dispatch_api.py
@@ -46,7 +46,7 @@ def client(monkeypatch):
     monkeypatch.setattr(dispatch_api, "_queues", {})
     monkeypatch.setattr(dispatch_api, "_tasks", {})
 
-    async def _fake_run_dispatch(*, prompt, allowed_tools, max_turns, event_queue, denied_tools=()):
+    async def _fake_run_dispatch(*, prompt, allowed_tools, max_turns, event_queue, denied_tools=(), run_id=None):
         if event_queue is not None:
             await event_queue.put({"type": "done"})
         return dict(_CANNED_RESULT)


### PR DESCRIPTION
A dispatched agent saves plots into the shared artifact store, but the worker had no way to say which artifacts belonged to a run, nor to hand back their bytes. Consumers that want to republish a run's plots (a chat or email bridge) had nothing to call.

## Association: created-by, at write time

Attribute artifacts to their run via `ArtifactEntry.run_id`, stamped from `OSPREY_DISPATCH_RUN_ID`, which `sdk_runner` exports into the agent env (and thus into the MCP tool subprocesses it spawns). The field is additive and defaults to empty, so existing indexes and artifacts created outside a dispatch run keep loading unchanged.

The single strict predicate `entry.run_id == run_id` (non-empty) is the sole gate behind every artifact surface, so they cannot disagree about which artifacts a run owns. Authorization never reads agent-controllable data (a run's `tool_calls` results are never scanned), so a prompt-injected run cannot widen its artifact set or reach another run's bytes. `run_id` is deliberately **not** `OSPREY_SESSION_ID`, which also relocates the store into `_agent_data/sessions/<id>/` and would move dispatch plots off the shared root the gallery reads.

Lookup filters on strict `run_id` equality via `list_entries(run_filter=...)` and a centralized `get_run_entry()` gate — never `session_filter`, whose OR-empty clause would attach every untagged legacy artifact to every run.

## Three coherent HTTP surfaces

- `GET /dispatch/{run_id}` — the run-status body carries render-free artifact **descriptors** (`{artifact_id, filename, source_mime, delivered_mime, convertible}`), computed once at completion and set on **every** terminal result (completed, error, timeout, cancel). Falls back to the persisted on-disk record when the run has aged out of the in-memory cap, so the manifest stays available as long as the artifact routes.
- `GET /dispatch/{run_id}/artifacts` — lists those descriptors. Metadata only: it predicts delivery without invoking a converter, so listing is cheap regardless of artifact count.
- `GET /dispatch/{run_id}/artifacts/{artifact_id}` — resolves and streams one artifact's bytes with its authoritative content-type: images and PDFs pass through, other types render to PNG (only the requested one). Every deny reason (cross-run, unknown id, unknown run, missing file, traversal-shaped id) collapses to one constant, input-free 404, so the response is never an existence oracle.

Artifact resolution/conversion lives in a shared `interfaces/artifacts/resolve.py`; ARIEL's logbook-attachment path reuses the same resolver.

## Security scope

Confidentiality is enforced structurally: a caller fetching under run A only matches entries tagged A. The write-time tag is spoof-safe for integrity only while dispatch denies shell/exec tools (`Bash`/`BashOutput`/`KillShell` remain on the denylist) — a run with a shell could otherwise forge the env var. A guard test binds that invariant.

Tests cover the isolation matrix, a prompt-injection resistance case (a run referencing another run's id still 404s), status/list/byte-route coherence, render-free listing, conversion fidelity and graceful fallback, disk-fallback, the terminal-state contract, and the auth matrix.
