### PR TITLE
feat: harden EPICS connector write path into a reference monitor

### DIFF
--- a/docs/source/how-to/add-connector.rst
+++ b/docs/source/how-to/add-connector.rst
@@ -225,6 +225,19 @@ Write operations are disabled by default and must be explicitly enabled at two l
 
 If ``writes_enabled`` is omitted, it defaults to ``false`` and all writes are blocked.
 
+``writes_enabled`` is a **launch-time deployment posture, not a live kill-switch.**
+It is read from config and process-cached, so flipping it in ``config.yml`` does not
+take effect in a running process. The enforced kill-switch lives at the harness layer
+(a renderer ``permissions.deny`` on the write tool, then regenerate and relaunch the
+agent); in-flight control of an active scan is the RunEngine's own ``abort`` / ``pause``.
+
+The connector applies **per-write mechanical safety** — the ``writes_enabled`` gate,
+limits validation, and the fail-closed validation path — on every Channel Access put.
+This is a separate, complementary layer from the **per-intent human authorization**
+enforced at the tool boundary (the PreToolUse approval hook, and the promote token for
+scans), which gates the *intent* to write once per intent rather than once per put.
+The approval layer cannot substitute for the connector's mechanical refusal.
+
 .. _limits-checking-config:
 
 Limits Checking

--- a/src/osprey/connectors/control_system/base.py
+++ b/src/osprey/connectors/control_system/base.py
@@ -70,6 +70,12 @@ class ChannelWriteResult:
 
     This is the control-system-agnostic result type returned by all connectors.
     Provides detailed information about write success and verification status.
+
+    The ``blocked`` / ``refusal_reason`` fields mark a *refusal*: the monitor
+    declined this write on policy grounds (writes disabled, limits, or
+    validation) and the underlying ``caput`` was never attempted. This is
+    distinct from a ``caput`` I/O failure — where the write was attempted but
+    failed — which leaves ``blocked=False``.
     """
 
     channel_address: str  # Channel that was written
@@ -77,6 +83,24 @@ class ChannelWriteResult:
     success: bool  # Whether the write command succeeded
     verification: WriteVerification | None = None  # Verification details (if performed)
     error_message: str | None = None  # Error message if write failed
+    blocked: bool = False  # True iff the monitor refused this write (policy/limits/validation)
+    # "WRITES_DISABLED" | "LIMITS" | "VALIDATION_ERROR" when blocked, else None
+    refusal_reason: str | None = None
+
+
+def _writes_disabled_result(channel_address: str, value: Any) -> ChannelWriteResult:
+    """Build the refusal result returned when writes are disabled at launch time."""
+    return ChannelWriteResult(
+        channel_address=channel_address,
+        value_written=value,
+        success=False,
+        error_message=(
+            f"Write to '{channel_address}' blocked: writes are disabled. "
+            "Set control_system.writes_enabled: true in config.yml"
+        ),
+        blocked=True,
+        refusal_reason="WRITES_DISABLED",
+    )
 
 
 class ControlSystemConnector(ABC):
@@ -102,6 +126,14 @@ class ControlSystemConnector(ABC):
         """Check whether writes are enabled via global config.
 
         Returns False (fail-safe) when config is unavailable.
+
+        ``control_system.writes_enabled`` is a **launch-time deployment posture,
+        not a live kill-switch.** It is read from config and process-cached, so
+        flipping it in ``config.yml`` does NOT take effect in a running process.
+        The enforced kill-switch lives at the harness layer: a renderer
+        ``permissions.deny`` on the write tool, followed by regenerating and
+        relaunching the agent. In-flight control of an active scan is the
+        RunEngine's own ``abort`` / ``pause`` — never a config flag.
         """
         try:
             from osprey.utils.config import get_config_value
@@ -130,15 +162,7 @@ class ControlSystemConnector(ABC):
             @functools.wraps(original_write)
             async def _guarded_write(self, channel_address, value, *args, **kwargs):
                 if not self._writes_enabled:
-                    return ChannelWriteResult(
-                        channel_address=channel_address,
-                        value_written=value,
-                        success=False,
-                        error_message=(
-                            f"Write to '{channel_address}' blocked: writes are disabled. "
-                            "Set control_system.writes_enabled: true in config.yml"
-                        ),
-                    )
+                    return _writes_disabled_result(channel_address, value)
                 return await original_write(self, channel_address, value, *args, **kwargs)
 
             cls.write_channel = _guarded_write
@@ -150,16 +174,7 @@ class ControlSystemConnector(ABC):
             async def _guarded_multi(self, operations, *args, **kwargs):
                 if not self._writes_enabled:
                     return [
-                        ChannelWriteResult(
-                            channel_address=addr,
-                            value_written=val,
-                            success=False,
-                            error_message=(
-                                f"Write to '{addr}' blocked: writes are disabled. "
-                                "Set control_system.writes_enabled: true in config.yml"
-                            ),
-                        )
-                        for addr, val in operations
+                        _writes_disabled_result(addr, val) for addr, val in operations
                     ]
                 return await original_multi(self, operations, *args, **kwargs)
 
@@ -289,8 +304,74 @@ class ControlSystemConnector(ABC):
 
             Different control systems may interpret these levels differently based on
             their native capabilities.
+
+        Two-layer safety model:
+            **Per-write mechanical safety** lives INSIDE the connector and is applied
+            per Channel Access put: the ``writes_enabled`` gate, limits validation
+            (min/max/step/writable), and the fail-closed validation path. This is
+            complete mediation at the CA write primitive — every put passes through it.
+
+            **Per-intent human authorization** is a SEPARATE layer at the tool
+            boundary: the PreToolUse approval hook (and, for scans, the promote token)
+            gate the *intent* to write, once per intent — not once per CA put.
+
+            The two are orthogonal and complementary: the connector cannot be talked
+            out of a mechanical refusal, and the approval layer cannot substitute for
+            that refusal.
         """
         pass
+
+    async def write_channel_checked(
+        self, channel_address: str, value: Any, **kwargs: Any
+    ) -> ChannelWriteResult:
+        """Await write_channel and enforce the reference monitor's denial contract.
+
+        Refused (policy/limits/validation) -> raises ChannelWriteBlockedError.
+        Attempted but failed or unverified   -> raises ChannelWriteFailedError.
+        Native ConnectionError/TimeoutError from the CA layer -> propagate unchanged.
+        A verified successful write            -> returns the ChannelWriteResult.
+
+        A scan device setter wraps this so any raise aborts the RunEngine, while a
+        verified write returns and the scan proceeds. Extra keyword arguments
+        (verification_level, tolerance, timeout) pass straight through to
+        write_channel.
+        """
+        from osprey.errors import (
+            ChannelLimitsViolationError,
+            ChannelWriteBlockedError,
+            ChannelWriteFailedError,
+        )
+
+        try:
+            result = await self.write_channel(channel_address, value, **kwargs)
+        except ChannelLimitsViolationError as exc:
+            # A limits refusal is a REFUSAL — normalize it into the unified denial type
+            # so consumers key on one refusal signal. (ConnectionError/TimeoutError are
+            # NOT caught here, so they propagate unchanged.)
+            raise ChannelWriteBlockedError(
+                channel_address, "LIMITS", message=str(exc)
+            ) from exc
+
+        if result.blocked:
+            raise ChannelWriteBlockedError(
+                channel_address,
+                result.refusal_reason or "WRITES_DISABLED",
+                message=result.error_message,
+            )
+        if not result.success:
+            raise ChannelWriteFailedError(
+                channel_address, "CAPUT_FAILED", message=result.error_message
+            )
+        v = result.verification
+        if v is not None and v.level != "none" and not v.verified:
+            # A verification WAS requested (callback/readback) but did not verify:
+            # readback mismatch, or the readback itself failed.
+            raise ChannelWriteFailedError(
+                channel_address,
+                "READBACK_UNVERIFIED",
+                message=result.error_message or v.notes,
+            )
+        return result
 
     @abstractmethod
     async def read_multiple_channels(

--- a/src/osprey/connectors/control_system/base.py
+++ b/src/osprey/connectors/control_system/base.py
@@ -173,9 +173,7 @@ class ControlSystemConnector(ABC):
             @functools.wraps(original_multi)
             async def _guarded_multi(self, operations, *args, **kwargs):
                 if not self._writes_enabled:
-                    return [
-                        _writes_disabled_result(addr, val) for addr, val in operations
-                    ]
+                    return [_writes_disabled_result(addr, val) for addr, val in operations]
                 return await original_multi(self, operations, *args, **kwargs)
 
             cls.write_multiple_channels = _guarded_multi
@@ -348,9 +346,7 @@ class ControlSystemConnector(ABC):
             # A limits refusal is a REFUSAL — normalize it into the unified denial type
             # so consumers key on one refusal signal. (ConnectionError/TimeoutError are
             # NOT caught here, so they propagate unchanged.)
-            raise ChannelWriteBlockedError(
-                channel_address, "LIMITS", message=str(exc)
-            ) from exc
+            raise ChannelWriteBlockedError(channel_address, "LIMITS", message=str(exc)) from exc
 
         if result.blocked:
             raise ChannelWriteBlockedError(

--- a/src/osprey/connectors/control_system/epics_connector.py
+++ b/src/osprey/connectors/control_system/epics_connector.py
@@ -297,23 +297,10 @@ class EPICSConnector(ControlSystemConnector):
         """
         timeout = timeout or self._timeout
 
-        # Step 1: Validate limits (if enabled)
-        if self._limits_validator:
-            try:
-                self._limits_validator.validate(channel_address, value)
-                logger.debug(f"✓ Limits validation passed: {channel_address}={value}")
-            except Exception as e:
-                # Import here to avoid circular dependency
-                from osprey.errors import ChannelLimitsViolationError
+        # Import here to avoid circular dependency
+        from osprey.errors import ChannelLimitsViolationError
 
-                # Re-raise limits violations
-                if isinstance(e, ChannelLimitsViolationError):
-                    raise
-
-                # Log unexpected errors but don't block (fail-open for non-limit errors)
-                logger.warning(f"Limits validation error (non-blocking): {e}")
-
-        # Step 2: Auto-determine verification config if not provided
+        # Step 1: Auto-determine verification config if not provided (cheap, on-loop)
         if verification_level is None:
             verification_level, auto_tolerance = self._get_verification_config(
                 channel_address, float(value)
@@ -321,13 +308,52 @@ class EPICSConnector(ControlSystemConnector):
             if tolerance is None:
                 tolerance = auto_tolerance
 
-        # Step 3: Execute write with verification
-        if verification_level == "none":
-            # Fast path - no verification, no wait for callback
-            success = await asyncio.to_thread(
-                self._epics.caput, channel_address, value, wait=False, timeout=timeout
+        # Step 2: Validate the verification level up front — reject invalid levels
+        # BEFORE issuing any caput (preserves the no-caput-on-invalid-level behavior).
+        if verification_level not in ("none", "callback", "readback"):
+            raise ValueError(
+                f"Invalid verification_level: {verification_level}. Must be 'none', 'callback', or 'readback'"
             )
 
+        # callback/readback wait for the IOC callback; none does not.
+        wait = verification_level != "none"
+
+        # Step 3: Validate limits (FAIL CLOSED) and issue the caput in ONE thread
+        # offload, so a caller on the event loop is never stalled by the blocking
+        # caget that max_step validation performs.
+        def _validate_and_put():
+            if self._limits_validator:
+                try:
+                    self._limits_validator.validate(channel_address, value)
+                    logger.debug(f"✓ Limits validation passed: {channel_address}={value}")
+                except ChannelLimitsViolationError:
+                    raise  # limits refusal propagates unchanged (carries LIMITS semantics)
+                except Exception as e:
+                    # FAIL CLOSED: any other validation error refuses the write — no caput issued
+                    logger.warning(
+                        f"Validation error — refusing write (fail-closed): {channel_address}: {e}"
+                    )
+                    return ("refused", e)  # sentinel: no caput issued
+            success = self._epics.caput(channel_address, value, wait=wait, timeout=timeout)
+            return ("ok", success)
+
+        outcome, payload = await asyncio.to_thread(_validate_and_put)
+
+        if outcome == "refused":
+            return ChannelWriteResult(
+                channel_address=channel_address,
+                value_written=value,
+                success=False,
+                error_message=f"Write to '{channel_address}' refused: validation error: {payload}",
+                blocked=True,
+                refusal_reason="VALIDATION_ERROR",
+            )
+
+        success = payload
+
+        # Step 4: Build the per-level result (observable output identical to before)
+        if verification_level == "none":
+            # Fast path - no verification, no wait for callback
             if not success:
                 return ChannelWriteResult(
                     channel_address=channel_address,
@@ -350,15 +376,7 @@ class EPICSConnector(ControlSystemConnector):
             )
 
         elif verification_level == "callback":
-            # EPICS callback - wait for IOC to confirm processing
-            success = await asyncio.to_thread(
-                self._epics.caput,
-                channel_address,
-                value,
-                wait=True,  # Wait for IOC callback
-                timeout=timeout,
-            )
-
+            # EPICS callback - the caput above waited for the IOC to confirm processing
             if not success:
                 return ChannelWriteResult(
                     channel_address=channel_address,
@@ -381,11 +399,7 @@ class EPICSConnector(ControlSystemConnector):
             )
 
         elif verification_level == "readback":
-            # Full verification - callback + readback
-            success = await asyncio.to_thread(
-                self._epics.caput, channel_address, value, wait=True, timeout=timeout
-            )
-
+            # Full verification - the caput above waited (callback); now read back
             if not success:
                 return ChannelWriteResult(
                     channel_address=channel_address,
@@ -438,11 +452,6 @@ class EPICSConnector(ControlSystemConnector):
                     ),
                     error_message=f"Readback verification failed: {str(e)}",
                 )
-
-        else:
-            raise ValueError(
-                f"Invalid verification_level: {verification_level}. Must be 'none', 'callback', or 'readback'"
-            )
 
     async def read_multiple_channels(
         self, channel_addresses: list[str], timeout: float | None = None

--- a/src/osprey/errors.py
+++ b/src/osprey/errors.py
@@ -66,6 +66,44 @@ class ChannelLimitsViolationError(Exception):
         return "\n".join(msg)
 
 
+class ChannelWriteBlockedError(Exception):
+    """Raised when the reference monitor refused a channel write.
+
+    A refusal means the write was NEVER attempted (no caput issued): writes are
+    disabled, a limits check failed, or validation raised. Distinct from
+    ChannelWriteFailedError, which means the write was attempted and failed.
+
+    reason is one of: "WRITES_DISABLED", "LIMITS", "VALIDATION_ERROR".
+    """
+
+    _VALID_REASONS = ("WRITES_DISABLED", "LIMITS", "VALIDATION_ERROR")
+
+    def __init__(self, channel_address: str, reason: str, message: str | None = None):
+        self.channel_address = channel_address
+        self.reason = reason
+        text = message or f"Write to '{channel_address}' refused by reference monitor ({reason})"
+        super().__init__(text)
+
+
+class ChannelWriteFailedError(Exception):
+    """Raised when a channel write was attempted but did not verifiably succeed.
+
+    The caput was issued (or attempted) but the write failed or its readback did
+    not verify. Distinct from ChannelWriteBlockedError (a policy/limits/validation
+    refusal, never attempted). A scan consumer must abort on this.
+
+    reason is one of: "CAPUT_FAILED", "READBACK_UNVERIFIED".
+    """
+
+    _VALID_REASONS = ("CAPUT_FAILED", "READBACK_UNVERIFIED")
+
+    def __init__(self, channel_address: str, reason: str, message: str | None = None):
+        self.channel_address = channel_address
+        self.reason = reason
+        text = message or f"Write to '{channel_address}' failed ({reason})"
+        super().__init__(text)
+
+
 class RegistryError(Exception):
     """Exception for registry-related errors.
 

--- a/src/osprey/mcp_server/control_system/error_handling.py
+++ b/src/osprey/mcp_server/control_system/error_handling.py
@@ -13,7 +13,7 @@ from contextlib import asynccontextmanager
 
 from fastmcp.exceptions import ToolError
 
-from osprey.errors import ChannelLimitsViolationError
+from osprey.errors import ChannelLimitsViolationError, ChannelWriteBlockedError
 from osprey.mcp_server.errors import make_error
 
 logger = logging.getLogger("osprey.mcp_server.control_system.error_handling")
@@ -93,6 +93,16 @@ async def connector_error_handler(
                 "Report the violation to the operator with the allowed range.",
             ],
             details=violation,
+        )
+    except ChannelWriteBlockedError as exc:
+        make_error(
+            "write_refused",
+            f"Write refused by the reference monitor during {tool_name}: {exc}",
+            [
+                "This write was refused on policy grounds; it was never sent to the control system.",
+                "Do NOT attempt to work around the refusal.",
+            ],
+            details={"channel": exc.channel_address, "reason": exc.reason},
         )
     except Exception as exc:
         logger.exception("%s failed", tool_name)

--- a/src/osprey/mcp_server/control_system/tools/channel_write.py
+++ b/src/osprey/mcp_server/control_system/tools/channel_write.py
@@ -7,6 +7,7 @@ Tool docstring is the static prompt visible to Claude Code.
 import json
 import logging
 
+from osprey.errors import ChannelWriteBlockedError
 from osprey.mcp_server.control_system.error_handling import connector_error_handler
 from osprey.mcp_server.control_system.server import mcp
 from osprey.mcp_server.errors import make_error
@@ -139,6 +140,8 @@ async def channel_write(
                 "value_written": wr.value_written,
                 "success": wr.success,
                 "error_message": wr.error_message,
+                "blocked": wr.blocked,
+                "refusal_reason": wr.refusal_reason,
             }
             if wr.verification:
                 result_entry["verification"] = {
@@ -154,16 +157,20 @@ async def channel_write(
 
         # Build compact summary inline
         successful = sum(1 for r in results_serialised if r["success"])
+        refused = sum(1 for r in results_serialised if r.get("blocked"))
         summary = {
             "total_writes": len(results_serialised),
             "successful": successful,
             "failed": len(results_serialised) - successful,
+            "refused": refused,
             "results": [
                 {
                     "channel": r["channel"],
                     "value": r["value_written"],
                     "success": r["success"],
                     "error": r.get("error_message"),
+                    "blocked": r.get("blocked"),
+                    "refusal_reason": r.get("refusal_reason"),
                     "verification": r.get("verification"),
                 }
                 for r in results_serialised
@@ -172,6 +179,22 @@ async def channel_write(
         access_details = {"verification_level": verification_level}
 
         if results_serialised and successful == 0:
+            failures = [wr for wr in connector_results if not wr.success]
+            if failures and all(wr.blocked for wr in failures):
+                # Every failed op was a policy refusal (never sent to the control
+                # system): surface a typed write-refusal envelope, not internal_error.
+                refused_channels = [wr.channel_address for wr in failures]
+                first = failures[0]
+                raise ChannelWriteBlockedError(
+                    first.channel_address,
+                    first.refusal_reason or "WRITES_DISABLED",
+                    message=(
+                        f"All {len(failures)} write(s) refused by the reference monitor: "
+                        f"{', '.join(refused_channels)}"
+                    ),
+                )
+            # At least one failure was an attempted caput that failed (I/O failure,
+            # not a policy refusal): preserve the internal_error classification.
             errors = sorted(
                 {r["error_message"] for r in results_serialised if r.get("error_message")}
             )

--- a/tests/connectors/test_ophyd_abort_fixture.py
+++ b/tests/connectors/test_ophyd_abort_fixture.py
@@ -1,0 +1,141 @@
+"""Standalone proof that write_channel_checked is RunEngine-consumable.
+
+Task 3.2: this is a throwaway fixture that demonstrates the reference monitor's
+denial contract composes with an ophyd_async device setter — WITHOUT importing
+any of the dependent feature's device layer. A ~15-line stub setter calls
+``write_channel_checked`` inside ``AsyncStatus.wrap``; awaiting the resulting
+``AsyncStatus`` is exactly what a RunEngine does when it drives ``set()``.
+
+``AsyncStatus.wrap`` decorates an ``async def`` and returns a callable producing
+an ``AsyncStatus``. Awaiting that status runs the wrapped coroutine and re-raises
+any exception it throws — so a refused write surfaces as a failed status, which
+aborts the plan. A verified write returns and the status succeeds.
+
+The connector helper speaks only the generic interface, so a minimal in-file
+fake connector exercises it without any EPICS/DOOCS machinery.
+"""
+
+from typing import Any
+
+import pytest
+
+ophyd_async = pytest.importorskip("ophyd_async")
+from ophyd_async.core import AsyncStatus  # noqa: E402
+
+from osprey.connectors.control_system.base import (  # noqa: E402
+    ChannelMetadata,
+    ChannelValue,
+    ChannelWriteResult,
+    ControlSystemConnector,
+    WriteVerification,
+)
+from osprey.errors import ChannelWriteBlockedError  # noqa: E402
+
+
+class _FakeConnector(ControlSystemConnector):
+    """Minimal concrete connector whose write_channel returns a canned result.
+
+    Writes are forced enabled so the base __init_subclass__ guard passes straight
+    through to our stub. Every non-write abstract method is an unused stub.
+    """
+
+    def __init__(self, result: ChannelWriteResult):
+        self._canned_result = result
+
+    @property
+    def _writes_enabled(self) -> bool:
+        return True
+
+    async def write_channel(
+        self,
+        channel_address: str,
+        value: Any,
+        timeout: float | None = None,
+        verification_level: str = "callback",
+        tolerance: float | None = None,
+    ) -> ChannelWriteResult:
+        return self._canned_result
+
+    # --- Unused abstract-method stubs -------------------------------------
+    async def connect(self, config: dict[str, Any]) -> None: ...
+    async def disconnect(self) -> None: ...
+    async def read_channel(
+        self, channel_address: str, timeout: float | None = None
+    ) -> ChannelValue:
+        raise NotImplementedError
+
+    async def read_multiple_channels(
+        self, channel_addresses: list[str], timeout: float | None = None
+    ) -> dict[str, ChannelValue]:
+        raise NotImplementedError
+
+    async def subscribe(self, channel_address, callback) -> str:
+        raise NotImplementedError
+
+    async def unsubscribe(self, subscription_id: str) -> None: ...
+    async def get_metadata(self, channel_address: str) -> ChannelMetadata:
+        raise NotImplementedError
+
+    async def validate_channel(self, channel_address: str) -> bool:
+        raise NotImplementedError
+
+
+def _refusing_connector() -> _FakeConnector:
+    """Connector whose write is REFUSED (writes disabled) — checked-write raises."""
+    return _FakeConnector(
+        ChannelWriteResult(
+            channel_address="TEST:PV",
+            value_written=1.0,
+            success=False,
+            blocked=True,
+            refusal_reason="WRITES_DISABLED",
+            error_message="writes are disabled",
+        )
+    )
+
+
+def _verified_connector() -> _FakeConnector:
+    """Connector whose write is VERIFIED — checked-write returns the result."""
+    return _FakeConnector(
+        ChannelWriteResult(
+            channel_address="TEST:PV",
+            value_written=1.0,
+            success=True,
+            verification=WriteVerification(
+                level="readback", verified=True, readback_value=1.0, tolerance_used=0.1
+            ),
+        )
+    )
+
+
+class _StubConnectorSetter:
+    """Minimal stand-in for a RunEngine device setter backed by the connector."""
+
+    def __init__(self, connector, channel):
+        self._connector = connector
+        self._channel = channel
+
+    @AsyncStatus.wrap
+    async def set(self, value):
+        await self._connector.write_channel_checked(self._channel, value)
+
+
+@pytest.mark.asyncio
+async def test_refused_write_aborts_the_status():
+    """A refusal makes the AsyncStatus raise — a RunEngine plan would abort."""
+    setter = _StubConnectorSetter(_refusing_connector(), "TEST:PV")
+
+    # set() returns immediately; a RunEngine then AWAITS the status, which is
+    # where the wrapped coroutine runs and re-raises the connector's refusal.
+    status = setter.set(1.0)
+    with pytest.raises(ChannelWriteBlockedError):
+        await status
+
+
+@pytest.mark.asyncio
+async def test_verified_write_completes():
+    """A verified write lets the status succeed — the setter is usable for a pass."""
+    setter = _StubConnectorSetter(_verified_connector(), "TEST:PV")
+
+    # No raise: awaiting the status completes, proving the happy path is consumable.
+    await setter.set(1.0)

--- a/tests/connectors/test_write_channel_checked.py
+++ b/tests/connectors/test_write_channel_checked.py
@@ -1,0 +1,328 @@
+"""Denial-contract tests for ControlSystemConnector.write_channel_checked.
+
+Task 3.1: write_channel_checked is the correctness primitive a scan device
+setter wraps. It awaits the connector-agnostic write_channel and collapses its
+four documented outcomes into a single raise-or-return contract:
+
+- a REFUSAL (writes disabled, limits, or non-limits validation) -> raises
+  ChannelWriteBlockedError;
+- an ATTEMPTED-but-failed / unverified write (caput False, readback mismatch,
+  readback failed) -> raises ChannelWriteFailedError;
+- a native CA-layer ConnectionError/TimeoutError -> propagates unchanged;
+- a verified successful write (or an accepted level="none" success) -> returns
+  the ChannelWriteResult untouched.
+
+The helper lives on the base class and speaks only the generic interface, so a
+minimal in-file fake connector exercises it without any EPICS/DOOCS machinery.
+"""
+
+from typing import Any
+
+import pytest
+
+from osprey.connectors.control_system.base import (
+    ChannelMetadata,
+    ChannelValue,
+    ChannelWriteResult,
+    ControlSystemConnector,
+    WriteVerification,
+)
+from osprey.errors import (
+    ChannelLimitsViolationError,
+    ChannelWriteBlockedError,
+    ChannelWriteFailedError,
+)
+
+
+class _FakeConnector(ControlSystemConnector):
+    """Minimal concrete connector whose write_channel returns a canned result.
+
+    write_channel returns ``self._canned_result`` or, if ``self._canned_exc`` is
+    set, raises it. Writes are forced enabled so the base __init_subclass__ guard
+    passes straight through to our stub (this test targets write_channel_checked,
+    not the writes-disabled guard). Every other abstract method is an unused stub.
+    """
+
+    def __init__(
+        self,
+        result: ChannelWriteResult | None = None,
+        exc: Exception | None = None,
+    ):
+        self._canned_result = result
+        self._canned_exc = exc
+
+    @property
+    def _writes_enabled(self) -> bool:
+        return True
+
+    async def write_channel(
+        self,
+        channel_address: str,
+        value: Any,
+        timeout: float | None = None,
+        verification_level: str = "callback",
+        tolerance: float | None = None,
+    ) -> ChannelWriteResult:
+        if self._canned_exc is not None:
+            raise self._canned_exc
+        return self._canned_result
+
+    # --- Unused abstract-method stubs -------------------------------------
+    async def connect(self, config: dict[str, Any]) -> None: ...
+    async def disconnect(self) -> None: ...
+    async def read_channel(
+        self, channel_address: str, timeout: float | None = None
+    ) -> ChannelValue:
+        raise NotImplementedError
+
+    async def read_multiple_channels(
+        self, channel_addresses: list[str], timeout: float | None = None
+    ) -> dict[str, ChannelValue]:
+        raise NotImplementedError
+
+    async def subscribe(self, channel_address, callback) -> str:
+        raise NotImplementedError
+
+    async def unsubscribe(self, subscription_id: str) -> None: ...
+    async def get_metadata(self, channel_address: str) -> ChannelMetadata:
+        raise NotImplementedError
+
+    async def validate_channel(self, channel_address: str) -> bool:
+        raise NotImplementedError
+
+
+def _result(**overrides) -> ChannelWriteResult:
+    """Build a ChannelWriteResult with sensible defaults overridable per test."""
+    base = {
+        "channel_address": "TEST:PV",
+        "value_written": 42.0,
+        "success": True,
+    }
+    base.update(overrides)
+    return ChannelWriteResult(**base)
+
+
+class TestRefusals:
+    """Refused writes (never attempted) -> ChannelWriteBlockedError."""
+
+    @pytest.mark.asyncio
+    async def test_writes_disabled_result_raises_blocked(self):
+        connector = _FakeConnector(
+            result=_result(
+                success=False,
+                blocked=True,
+                refusal_reason="WRITES_DISABLED",
+                error_message="writes are disabled",
+            )
+        )
+
+        with pytest.raises(ChannelWriteBlockedError) as excinfo:
+            await connector.write_channel_checked("TEST:PV", 42.0)
+
+        assert excinfo.value.reason == "WRITES_DISABLED"
+        assert excinfo.value.channel_address == "TEST:PV"
+
+    @pytest.mark.asyncio
+    async def test_validation_error_result_raises_blocked(self):
+        connector = _FakeConnector(
+            result=_result(
+                success=False,
+                blocked=True,
+                refusal_reason="VALIDATION_ERROR",
+                error_message="validate() raised",
+            )
+        )
+
+        with pytest.raises(ChannelWriteBlockedError) as excinfo:
+            await connector.write_channel_checked("TEST:PV", 42.0)
+
+        assert excinfo.value.reason == "VALIDATION_ERROR"
+        assert excinfo.value.channel_address == "TEST:PV"
+
+    @pytest.mark.asyncio
+    async def test_limits_violation_normalized_to_blocked(self):
+        """write_channel RAISES ChannelLimitsViolationError -> helper normalizes
+        it to ChannelWriteBlockedError(reason="LIMITS") with the original chained.
+        """
+        violation = ChannelLimitsViolationError(
+            channel_address="TEST:PV",
+            value=999.0,
+            violation_type="max_value",
+            violation_reason="above max",
+        )
+        connector = _FakeConnector(exc=violation)
+
+        with pytest.raises(ChannelWriteBlockedError) as excinfo:
+            await connector.write_channel_checked("TEST:PV", 999.0)
+
+        assert excinfo.value.reason == "LIMITS"
+        assert excinfo.value.channel_address == "TEST:PV"
+        assert excinfo.value.__cause__ is violation
+
+
+class TestFailures:
+    """Attempted-but-failed / unverified writes -> ChannelWriteFailedError."""
+
+    @pytest.mark.asyncio
+    async def test_caput_failed_result_raises_failed(self):
+        connector = _FakeConnector(
+            result=_result(
+                success=False,
+                blocked=False,
+                error_message="Failed to write TEST:PV",
+            )
+        )
+
+        with pytest.raises(ChannelWriteFailedError) as excinfo:
+            await connector.write_channel_checked("TEST:PV", 42.0)
+
+        assert excinfo.value.reason == "CAPUT_FAILED"
+        assert excinfo.value.channel_address == "TEST:PV"
+
+    @pytest.mark.asyncio
+    async def test_readback_unverified_result_raises_failed(self):
+        connector = _FakeConnector(
+            result=_result(
+                success=True,
+                verification=WriteVerification(
+                    level="readback",
+                    verified=False,
+                    readback_value=41.0,
+                    tolerance_used=0.1,
+                    notes="readback 41.0 != 42.0",
+                ),
+                error_message="readback mismatch",
+            )
+        )
+
+        with pytest.raises(ChannelWriteFailedError) as excinfo:
+            await connector.write_channel_checked("TEST:PV", 42.0)
+
+        assert excinfo.value.reason == "READBACK_UNVERIFIED"
+        assert excinfo.value.channel_address == "TEST:PV"
+
+    @pytest.mark.asyncio
+    async def test_readback_unverified_uses_notes_when_no_error_message(self):
+        """When error_message is absent, the verification notes carry the detail."""
+        connector = _FakeConnector(
+            result=_result(
+                success=True,
+                verification=WriteVerification(
+                    level="readback",
+                    verified=False,
+                    notes="readback failed to connect",
+                ),
+                error_message=None,
+            )
+        )
+
+        with pytest.raises(ChannelWriteFailedError) as excinfo:
+            await connector.write_channel_checked("TEST:PV", 42.0)
+
+        assert excinfo.value.reason == "READBACK_UNVERIFIED"
+        assert "readback failed to connect" in str(excinfo.value)
+
+
+class TestPropagation:
+    """Native CA-layer errors propagate unchanged — never reclassified."""
+
+    @pytest.mark.asyncio
+    async def test_connection_error_propagates(self):
+        connector = _FakeConnector(exc=ConnectionError("gateway down"))
+
+        with pytest.raises(ConnectionError):
+            await connector.write_channel_checked("TEST:PV", 42.0)
+
+    @pytest.mark.asyncio
+    async def test_timeout_error_propagates(self):
+        connector = _FakeConnector(exc=TimeoutError("caput timed out"))
+
+        with pytest.raises(TimeoutError):
+            await connector.write_channel_checked("TEST:PV", 42.0)
+
+
+class TestSuccess:
+    """Verified successes (and accepted level="none") return unchanged."""
+
+    @pytest.mark.asyncio
+    async def test_verified_readback_success_returns_result(self):
+        result = _result(
+            success=True,
+            verification=WriteVerification(
+                level="readback",
+                verified=True,
+                readback_value=42.0,
+                tolerance_used=0.1,
+            ),
+        )
+        connector = _FakeConnector(result=result)
+
+        returned = await connector.write_channel_checked("TEST:PV", 42.0)
+
+        assert returned is result
+
+    @pytest.mark.asyncio
+    async def test_verified_callback_success_returns_result(self):
+        result = _result(
+            success=True,
+            verification=WriteVerification(level="callback", verified=True),
+        )
+        connector = _FakeConnector(result=result)
+
+        returned = await connector.write_channel_checked("TEST:PV", 42.0)
+
+        assert returned is result
+
+    @pytest.mark.asyncio
+    async def test_level_none_success_returns_despite_unverified(self):
+        """level="none" means no verification was requested: an unverified
+        success is ACCEPTED and returned (the v.level != "none" guard).
+        """
+        result = _result(
+            success=True,
+            verification=WriteVerification(level="none", verified=False),
+        )
+        connector = _FakeConnector(result=result)
+
+        returned = await connector.write_channel_checked("TEST:PV", 42.0)
+
+        assert returned is result
+
+    @pytest.mark.asyncio
+    async def test_success_with_no_verification_returns(self):
+        """A bare success with verification=None returns unchanged."""
+        result = _result(success=True, verification=None)
+        connector = _FakeConnector(result=result)
+
+        returned = await connector.write_channel_checked("TEST:PV", 42.0)
+
+        assert returned is result
+
+    @pytest.mark.asyncio
+    async def test_kwargs_pass_through_to_write_channel(self):
+        """verification_level/tolerance/timeout reach write_channel verbatim."""
+        seen: dict[str, Any] = {}
+
+        result = _result(success=True)
+        connector = _FakeConnector(result=result)
+
+        async def _capture(channel_address, value, **kwargs):
+            seen["channel_address"] = channel_address
+            seen["value"] = value
+            seen.update(kwargs)
+            return result
+
+        connector.write_channel = _capture  # type: ignore[method-assign]
+
+        returned = await connector.write_channel_checked(
+            "TEST:PV", 42.0, verification_level="readback", tolerance=0.5, timeout=3.0
+        )
+
+        assert returned is result
+        assert seen == {
+            "channel_address": "TEST:PV",
+            "value": 42.0,
+            "verification_level": "readback",
+            "tolerance": 0.5,
+            "timeout": 3.0,
+        }

--- a/tests/connectors/test_write_fail_closed.py
+++ b/tests/connectors/test_write_fail_closed.py
@@ -33,9 +33,7 @@ def _make_connector(validate_side_effect=None, caput_side_effect=None, caput_ret
     """
     connector = EPICSConnector()
     connector._epics = MagicMock()
-    connector._epics.caput = MagicMock(
-        side_effect=caput_side_effect, return_value=caput_return
-    )
+    connector._epics.caput = MagicMock(side_effect=caput_side_effect, return_value=caput_return)
     connector._limits_validator = MagicMock()
     connector._limits_validator.validate = MagicMock(side_effect=validate_side_effect)
     connector._timeout = 5.0
@@ -53,9 +51,7 @@ class TestFailClosedValidation:
             "osprey.utils.config.get_config_value",
             side_effect=_writes_enabled_config,
         ):
-            result = await connector.write_channel(
-                "TEST:PV", 42.0, verification_level="none"
-            )
+            result = await connector.write_channel("TEST:PV", 42.0, verification_level="none")
 
         assert isinstance(result, ChannelWriteResult)
         assert result.success is False

--- a/tests/connectors/test_write_fail_closed.py
+++ b/tests/connectors/test_write_fail_closed.py
@@ -1,0 +1,189 @@
+"""Fail-closed validation tests for EPICSConnector.write_channel.
+
+Task 1.3: a validation error other than a limits violation must REFUSE the
+write (blocked=True, refusal_reason="VALIDATION_ERROR") and never issue a
+caput. A ChannelLimitsViolationError still propagates unchanged, and an error
+raised by the caput itself (e.g. ConnectionError) propagates untouched — it is
+never reclassified as a refusal.
+"""
+
+import asyncio
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from osprey.connectors.control_system.base import ChannelWriteResult
+from osprey.connectors.control_system.epics_connector import EPICSConnector
+from osprey.errors import ChannelLimitsViolationError
+
+
+def _writes_enabled_config(key, default=None):
+    """Config stub: writes enabled so the base wrapper reaches write_channel."""
+    if key == "control_system.writes_enabled":
+        return True
+    return default
+
+
+def _make_connector(validate_side_effect=None, caput_side_effect=None, caput_return=True):
+    """Build an EPICSConnector wired with mock epics + limits validator.
+
+    Bypasses connect() (which imports pyepics) by setting the attributes the
+    write path depends on directly.
+    """
+    connector = EPICSConnector()
+    connector._epics = MagicMock()
+    connector._epics.caput = MagicMock(
+        side_effect=caput_side_effect, return_value=caput_return
+    )
+    connector._limits_validator = MagicMock()
+    connector._limits_validator.validate = MagicMock(side_effect=validate_side_effect)
+    connector._timeout = 5.0
+    connector._connected = True
+    return connector
+
+
+class TestFailClosedValidation:
+    @pytest.mark.asyncio
+    async def test_non_limits_validation_error_refuses_write(self):
+        """A non-limits exception from validate() refuses the write; caput never runs."""
+        connector = _make_connector(validate_side_effect=RuntimeError("boom"))
+
+        with patch(
+            "osprey.utils.config.get_config_value",
+            side_effect=_writes_enabled_config,
+        ):
+            result = await connector.write_channel(
+                "TEST:PV", 42.0, verification_level="none"
+            )
+
+        assert isinstance(result, ChannelWriteResult)
+        assert result.success is False
+        assert result.blocked is True
+        assert result.refusal_reason == "VALIDATION_ERROR"
+        assert "TEST:PV" in result.error_message
+        # The write must NEVER have been issued.
+        connector._epics.caput.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_limits_violation_propagates(self):
+        """A ChannelLimitsViolationError still propagates; caput never runs."""
+        violation = ChannelLimitsViolationError(
+            channel_address="TEST:PV",
+            value=999.0,
+            violation_type="max_value",
+            violation_reason="above max",
+        )
+        connector = _make_connector(validate_side_effect=violation)
+
+        with patch(
+            "osprey.utils.config.get_config_value",
+            side_effect=_writes_enabled_config,
+        ):
+            with pytest.raises(ChannelLimitsViolationError):
+                await connector.write_channel("TEST:PV", 999.0, verification_level="none")
+
+        connector._epics.caput.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_caput_connection_error_propagates_not_refused(self):
+        """validate passes but caput raises ConnectionError → it propagates.
+
+        Regression guard: a caput-raised error must NOT be swallowed into a
+        refusal ChannelWriteResult. It is a genuine write failure and must
+        surface as the raised exception.
+        """
+        connector = _make_connector(caput_side_effect=ConnectionError("gateway down"))
+
+        with patch(
+            "osprey.utils.config.get_config_value",
+            side_effect=_writes_enabled_config,
+        ):
+            with pytest.raises(ConnectionError):
+                await connector.write_channel("TEST:PV", 42.0, verification_level="none")
+
+        # validate passed and the caput was actually attempted.
+        connector._limits_validator.validate.assert_called_once()
+        connector._epics.caput.assert_called_once()
+
+
+class TestNonBlockingOffload:
+    """Task 2.1: validate()+caput run in ONE thread offload so a caller on the
+    event loop is never stalled by the blocking caget that max_step performs.
+    """
+
+    @pytest.mark.asyncio
+    async def test_validate_runs_off_the_event_loop(self):
+        """A slow (blocking) validate() must NOT starve the event loop.
+
+        Simulates max_step's blocking caget with a 0.3s time.sleep inside
+        validate(). While write_channel is in flight, a concurrently-awaited
+        0.05s asyncio.sleep must complete promptly. If validate ran ON the loop,
+        the loop would be blocked for the full 0.3s and the concurrent sleep
+        could not finish until then — proving validate ran OFF the loop.
+        """
+        connector = _make_connector()
+
+        def slow_validate(_addr, _val):
+            time.sleep(0.3)  # stand-in for max_step's blocking caget
+
+        connector._limits_validator.validate = MagicMock(side_effect=slow_validate)
+
+        # A concurrent ticker that can only advance if the loop is being serviced.
+        ticks = 0
+
+        async def ticker():
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0.005)
+                ticks += 1
+
+        with patch(
+            "osprey.utils.config.get_config_value",
+            side_effect=_writes_enabled_config,
+        ):
+            ticker_task = asyncio.create_task(ticker())
+            write_task = asyncio.create_task(
+                connector.write_channel("TEST:PV", 42.0, verification_level="none")
+            )
+
+            # Give the write time to reach its to_thread offload, then measure how
+            # long a short concurrent sleep takes while validate() blocks a thread.
+            start = time.monotonic()
+            await asyncio.sleep(0.05)
+            elapsed = time.monotonic() - start
+
+            result = await write_task
+            ticker_task.cancel()
+
+        # The loop stayed responsive: the 0.05s sleep did NOT get stretched to the
+        # 0.3s validate duration, and the ticker advanced during the window.
+        assert elapsed < 0.2, f"event loop was blocked for {elapsed:.3f}s"
+        assert ticks > 0, "concurrent coroutine was starved (loop blocked)"
+        # max_step-style validation was still evaluated, and the write succeeded.
+        connector._limits_validator.validate.assert_called_once()
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_max_step_violation_still_raised_through_offload(self):
+        """max_step is NOT skipped by the offload: a limits violation raised
+        inside the thread propagates out of write_channel unchanged, and no
+        caput is issued.
+        """
+        violation = ChannelLimitsViolationError(
+            channel_address="TEST:PV",
+            value=5.0,
+            violation_type="max_step",
+            violation_reason="step 5.0 exceeds max_step 1.0",
+        )
+        connector = _make_connector(validate_side_effect=violation)
+
+        with patch(
+            "osprey.utils.config.get_config_value",
+            side_effect=_writes_enabled_config,
+        ):
+            with pytest.raises(ChannelLimitsViolationError):
+                await connector.write_channel("TEST:PV", 5.0, verification_level="none")
+
+        connector._limits_validator.validate.assert_called_once()
+        connector._epics.caput.assert_not_called()

--- a/tests/mcp_server/test_channel_write_tool.py
+++ b/tests/mcp_server/test_channel_write_tool.py
@@ -20,13 +20,21 @@ from tests.mcp_server.conftest import (
 
 
 def _make_write_result(
-    channel="TEST:PV", value=1.0, success=True, error_message=None, verification_level="callback"
+    channel="TEST:PV",
+    value=1.0,
+    success=True,
+    error_message=None,
+    verification_level="callback",
+    blocked=False,
+    refusal_reason=None,
 ):
     result = MagicMock()
     result.channel_address = channel
     result.value_written = value
     result.success = success
     result.error_message = error_message
+    result.blocked = blocked
+    result.refusal_reason = refusal_reason
     result.verification = MagicMock()
     result.verification.level = verification_level
     result.verification.verified = True
@@ -293,3 +301,185 @@ async def test_channel_write_missing_channel_key(tmp_path, monkeypatch):
             await fn(operations=[{"value": 42.0}])
 
     _exc_ctx["envelope"]
+
+
+@pytest.mark.unit
+async def test_channel_write_all_refused_is_write_refused(tmp_path, monkeypatch):
+    """All-refused batch (every op blocked) yields a typed write_refused envelope.
+
+    The connector refuses every write (blocked=True, never sent to the control
+    system). The tool must raise ChannelWriteBlockedError so the error handler
+    classifies it as write_refused — NOT the generic internal_error that a bare
+    RuntimeError would produce.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.yml").write_text("control_system:\n  type: mock\n")
+    initialize_server_context()
+
+    results = [
+        _make_write_result(
+            channel="PV:A",
+            value=1.0,
+            success=False,
+            error_message="Write to 'PV:A' blocked: writes are disabled.",
+            blocked=True,
+            refusal_reason="WRITES_DISABLED",
+        ),
+        _make_write_result(
+            channel="PV:B",
+            value=2.0,
+            success=False,
+            error_message="Write to 'PV:B' blocked: writes are disabled.",
+            blocked=True,
+            refusal_reason="WRITES_DISABLED",
+        ),
+    ]
+    mock_connector = AsyncMock()
+    mock_connector.write_multiple_channels.return_value = results
+
+    with (
+        patch(
+            "osprey.connectors.factory.ConnectorFactory.create_control_system_connector",
+            new_callable=AsyncMock,
+            return_value=mock_connector,
+        ),
+        patch(
+            "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
+            return_value=None,
+        ),
+    ):
+        fn = _get_channel_write()
+        with assert_raises_error() as _exc_ctx:
+            await fn(
+                operations=[
+                    {"channel": "PV:A", "value": 1.0},
+                    {"channel": "PV:B", "value": 2.0},
+                ]
+            )
+
+    data = _exc_ctx["envelope"]
+    assert data["error_type"] == "write_refused", (
+        f"Expected write_refused but got {data['error_type']} — an all-refused "
+        "batch is a policy refusal, not an internal_error"
+    )
+    assert data["error_type"] != "internal_error"
+    # Both refused channels are named in the summary message.
+    assert "PV:A" in data["error_message"]
+    assert "PV:B" in data["error_message"]
+    # Structured details carry the refusal reason discriminator.
+    assert data["details"]["reason"] == "WRITES_DISABLED"
+
+
+@pytest.mark.unit
+async def test_channel_write_partial_refusal_reports_per_op(tmp_path, monkeypatch):
+    """Partial-rejection batch returns success JSON with per-op refusal reporting.
+
+    One op succeeds, one is refused. The tool must NOT raise (writes did happen);
+    it returns a success-status result whose per-op entries carry blocked /
+    refusal_reason and whose summary reports refused == 1, successful == 1.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.yml").write_text("control_system:\n  type: mock\n")
+    initialize_server_context()
+
+    results = [
+        _make_write_result(channel="PV:A", value=1.0, success=True),
+        _make_write_result(
+            channel="PV:B",
+            value=2.0,
+            success=False,
+            error_message="Write to 'PV:B' blocked: writes are disabled.",
+            blocked=True,
+            refusal_reason="WRITES_DISABLED",
+        ),
+    ]
+    mock_connector = AsyncMock()
+    mock_connector.write_multiple_channels.return_value = results
+
+    with (
+        patch(
+            "osprey.connectors.factory.ConnectorFactory.create_control_system_connector",
+            new_callable=AsyncMock,
+            return_value=mock_connector,
+        ),
+        patch(
+            "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
+            return_value=None,
+        ),
+    ):
+        fn = _get_channel_write()
+        result = await fn(
+            operations=[
+                {"channel": "PV:A", "value": 1.0},
+                {"channel": "PV:B", "value": 2.0},
+            ]
+        )
+
+    data = extract_response_dict(result)
+    assert data["status"] == "success"
+    summary = data["summary"]
+    assert summary["successful"] == 1
+    assert summary["refused"] == 1
+    assert summary["failed"] == 1
+    by_channel = {r["channel"]: r for r in summary["results"]}
+    assert by_channel["PV:A"]["success"] is True
+    assert by_channel["PV:A"]["blocked"] is False
+    assert by_channel["PV:B"]["success"] is False
+    assert by_channel["PV:B"]["blocked"] is True
+    assert by_channel["PV:B"]["refusal_reason"] == "WRITES_DISABLED"
+
+
+@pytest.mark.unit
+async def test_channel_write_all_failed_caput_is_internal_error(tmp_path, monkeypatch):
+    """All-failed caput (attempted, not refused) preserves internal_error.
+
+    The writes were sent to the control system and failed (blocked=False). This
+    is an I/O failure, not a policy refusal, so it must keep the RuntimeError ->
+    internal_error classification rather than becoming write_refused.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.yml").write_text("control_system:\n  type: mock\n")
+    initialize_server_context()
+
+    results = [
+        _make_write_result(
+            channel="PV:A",
+            value=1.0,
+            success=False,
+            error_message="caput failed: timeout",
+            blocked=False,
+        ),
+        _make_write_result(
+            channel="PV:B",
+            value=2.0,
+            success=False,
+            error_message="caput failed: no connection",
+            blocked=False,
+        ),
+    ]
+    mock_connector = AsyncMock()
+    mock_connector.write_multiple_channels.return_value = results
+
+    with (
+        patch(
+            "osprey.connectors.factory.ConnectorFactory.create_control_system_connector",
+            new_callable=AsyncMock,
+            return_value=mock_connector,
+        ),
+        patch(
+            "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
+            return_value=None,
+        ),
+    ):
+        fn = _get_channel_write()
+        with assert_raises_error(error_type="internal_error") as _exc_ctx:
+            await fn(
+                operations=[
+                    {"channel": "PV:A", "value": 1.0},
+                    {"channel": "PV:B", "value": 2.0},
+                ]
+            )
+
+    data = _exc_ctx["envelope"]
+    assert data["error_type"] == "internal_error"
+    assert data["error_type"] != "write_refused"

--- a/tests/mcp_server/test_error_handling_blocked.py
+++ b/tests/mcp_server/test_error_handling_blocked.py
@@ -1,0 +1,35 @@
+"""Tests for reference-monitor write-refusal classification in the error handler.
+
+A ``ChannelWriteBlockedError`` raised inside the ``connector_error_handler``
+context manager must classify as a dedicated ``write_refused`` error type
+(carrying the refusal reason and channel), NOT fall through to the generic
+``internal_error`` clause.
+"""
+
+from __future__ import annotations
+
+from osprey.errors import ChannelWriteBlockedError
+from osprey.mcp_server.control_system.error_handling import connector_error_handler
+from tests.mcp_server.conftest import assert_raises_error
+
+
+async def test_blocked_write_classifies_as_write_refused():
+    """A refusal raised in the body surfaces as a ``write_refused`` envelope."""
+    with assert_raises_error(error_type="write_refused") as ctx:
+        async with connector_error_handler("channel_write"):
+            raise ChannelWriteBlockedError("X:Y:SP", "VALIDATION_ERROR")
+
+    envelope = ctx["envelope"]
+    assert envelope["details"] == {"channel": "X:Y:SP", "reason": "VALIDATION_ERROR"}
+    assert "channel_write" in envelope["error_message"]
+
+
+async def test_blocked_write_is_not_internal_error():
+    """The refusal must NOT be swallowed by the generic ``internal_error`` clause."""
+    with assert_raises_error() as ctx:
+        async with connector_error_handler("channel_write"):
+            raise ChannelWriteBlockedError("A:B:SP", "WRITES_DISABLED")
+
+    assert ctx["envelope"]["error_type"] != "internal_error"
+    assert ctx["envelope"]["error_type"] == "write_refused"
+    assert ctx["envelope"]["details"]["reason"] == "WRITES_DISABLED"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,67 @@
+"""Unit tests for typed exceptions in osprey.errors."""
+
+import pytest
+
+from osprey.errors import ChannelWriteBlockedError, ChannelWriteFailedError
+
+
+class TestChannelWriteBlockedError:
+    def test_default_message(self):
+        err = ChannelWriteBlockedError("RING:MAG:PS:SP", "WRITES_DISABLED")
+        assert err.channel_address == "RING:MAG:PS:SP"
+        assert err.reason == "WRITES_DISABLED"
+        assert str(err) == (
+            "Write to 'RING:MAG:PS:SP' refused by reference monitor (WRITES_DISABLED)"
+        )
+
+    def test_custom_message(self):
+        err = ChannelWriteBlockedError("RING:MAG:PS:SP", "LIMITS", "value out of range")
+        assert err.channel_address == "RING:MAG:PS:SP"
+        assert err.reason == "LIMITS"
+        assert str(err) == "value out of range"
+
+    def test_is_exception(self):
+        with pytest.raises(ChannelWriteBlockedError):
+            raise ChannelWriteBlockedError("chan", "VALIDATION_ERROR")
+
+    def test_valid_reasons_reference(self):
+        assert ChannelWriteBlockedError._VALID_REASONS == (
+            "WRITES_DISABLED",
+            "LIMITS",
+            "VALIDATION_ERROR",
+        )
+
+    def test_unknown_reason_permitted(self):
+        # Constructor does not validate against _VALID_REASONS (permissive by design).
+        err = ChannelWriteBlockedError("chan", "SOMETHING_ELSE")
+        assert err.reason == "SOMETHING_ELSE"
+
+
+class TestChannelWriteFailedError:
+    def test_default_message(self):
+        err = ChannelWriteFailedError("RING:MAG:PS:SP", "CAPUT_FAILED")
+        assert err.channel_address == "RING:MAG:PS:SP"
+        assert err.reason == "CAPUT_FAILED"
+        assert str(err) == "Write to 'RING:MAG:PS:SP' failed (CAPUT_FAILED)"
+
+    def test_custom_message(self):
+        err = ChannelWriteFailedError(
+            "RING:MAG:PS:SP", "READBACK_UNVERIFIED", "readback mismatch"
+        )
+        assert err.channel_address == "RING:MAG:PS:SP"
+        assert err.reason == "READBACK_UNVERIFIED"
+        assert str(err) == "readback mismatch"
+
+    def test_is_exception(self):
+        with pytest.raises(ChannelWriteFailedError):
+            raise ChannelWriteFailedError("chan", "READBACK_UNVERIFIED")
+
+    def test_valid_reasons_reference(self):
+        assert ChannelWriteFailedError._VALID_REASONS == (
+            "CAPUT_FAILED",
+            "READBACK_UNVERIFIED",
+        )
+
+    def test_unknown_reason_permitted(self):
+        err = ChannelWriteFailedError("chan", "WHATEVER")
+        assert err.reason == "WHATEVER"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -45,9 +45,7 @@ class TestChannelWriteFailedError:
         assert str(err) == "Write to 'RING:MAG:PS:SP' failed (CAPUT_FAILED)"
 
     def test_custom_message(self):
-        err = ChannelWriteFailedError(
-            "RING:MAG:PS:SP", "READBACK_UNVERIFIED", "readback mismatch"
-        )
+        err = ChannelWriteFailedError("RING:MAG:PS:SP", "READBACK_UNVERIFIED", "readback mismatch")
         assert err.channel_address == "RING:MAG:PS:SP"
         assert err.reason == "READBACK_UNVERIFIED"
         assert str(err) == "readback mismatch"


### PR DESCRIPTION
## Summary

Harden the control-system EPICS connector write path into a proper **reference monitor** — a single, fail-closed, non-blocking mediation point for control-system writes, with an unambiguous structured signal that distinguishes *the monitor refused this write* from *the write was attempted and failed*.

## What changed

**Connector core** (`connectors/control_system/`, `errors.py`)
- **Fail closed on validation** — a non-limits exception from `validate()` now refuses the write instead of logging and proceeding; the `caput` is never issued. `ChannelLimitsViolationError` still propagates, and a `caput`-raised `ConnectionError`/`TimeoutError` still surfaces as an I/O error (never reclassified as a refusal).
- **Non-blocking** — `validate()` and the `caput` run in a single `asyncio.to_thread` offload, so a caller on an event loop is not stalled by `max_step`'s blocking `caget`, which is still evaluated against the live readback.
- **Structured refusal signal** — `ChannelWriteResult` gains additive `blocked` / `refusal_reason` fields; new `ChannelWriteBlockedError` (refusal) and `ChannelWriteFailedError` (attempted-but-failed/unverified) exceptions.
- **`write_channel_checked` helper** — raises on a refusal, failure, or unverified readback and returns only on a verified write, so a device setter can abort on any denial. `write_channel`/`write_multiple_channels` keep their value-based return contract unchanged.

**MCP seam** (`mcp_server/control_system/`)
- A connector refusal is classified as a typed `write_refused` envelope instead of `internal_error`, and partial-rejection batches are reported per operation from the structured discriminator (not only the all-failed case).

**Docs**
- `writes_enabled` is documented as a launch-time deployment posture (process-cached; the enforced kill-switch is a renderer permission denial plus relaunch, and in-flight scan control is the RunEngine's abort/pause), and per-write mechanical safety is documented as separate from per-intent human authorization.

## Testing

- New unit tests cover the fail-closed branch, the non-blocking offload (loop responsiveness + `max_step` still evaluated), the helper's four outcomes, the discriminator, and the MCP typed-envelope + partial-rejection paths.
- A test-only `ophyd_async` fixture (`importorskip`) proves the helper's raise propagates through `AsyncStatus.wrap` so a RunEngine `set()` would abort — without importing any dependent-feature code.
- Full write-path + runtime + MCP suites pass; changed-line coverage is well above 80%.

## Compatibility

Additive and internal only: the `ChannelWriteResult` field is optional/defaulted, the write return contract is unchanged, and the typed exceptions are connector-agnostic. No schema or state migration.