### PR TITLE
fix(web, artifacts, mcp): port fallback, artifacts crash, MCP URL overrides

### DIFF
--- a/src/osprey/cli/artifacts_cmd.py
+++ b/src/osprey/cli/artifacts_cmd.py
@@ -67,7 +67,8 @@ def web(port: int | None, host: str | None, reload: bool) -> None:
             )
         else:
             from osprey.interfaces.artifacts import run_server
+            from osprey.utils.workspace import resolve_workspace_root
 
-            run_server(host=host, port=port)
+            run_server(host=host, port=port, workspace_root=resolve_workspace_root())
     except KeyboardInterrupt:
         click.echo("\nShutting down...")

--- a/src/osprey/cli/web_cmd.py
+++ b/src/osprey/cli/web_cmd.py
@@ -155,6 +155,7 @@ def web(
     wt_config = get_config_value("web_terminal", {})
     cc_config = get_config_value("claude_code", {})
     host = host or wt_config.get("host", "127.0.0.1")
+    port_specified = port is not None
     port = port or wt_config.get("port", 8087)
 
     from osprey.utils.claude_launcher import build_claude_launch_argv
@@ -197,10 +198,17 @@ def web(
         try:
             s.bind((host, port))
         except OSError as exc:
-            click.echo(f"ERROR: Port {port} is already in use.", err=True)
-            click.echo(f"  Find the process:  lsof -i :{port}", err=True)
-            click.echo(f"  Or use another:    osprey web --port {port + 1}", err=True)
-            raise SystemExit(1) from exc
+            if port_specified:
+                click.echo(f"ERROR: Port {port} is already in use.", err=True)
+                click.echo(f"  Find the process:  lsof -i :{port}", err=True)
+                click.echo(f"  Or use another:    osprey web --port {port + 1}", err=True)
+                raise SystemExit(1) from exc
+            # No explicit port — let the OS pick a free one
+            default_port = port
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as fs:
+                fs.bind((host, 0))
+                port = fs.getsockname()[1]
+            click.echo(f"Port {default_port} in use — using :{port} instead.")
 
     click.echo(f"Starting OSPREY Web Terminal on http://{host}:{port}")
     click.echo(f"Shell: {' '.join(shell_command)}")

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -378,10 +378,14 @@ def resolve_servers(claude_code_config: dict, ctx: dict) -> list[dict]:
     for name, spec in server_overrides.items():
         if name in servers:
             # Override existing framework server
-            if isinstance(spec, dict) and spec.get("enabled") is False:
+            if not isinstance(spec, dict):
+                continue
+            if spec.get("enabled") is False:
                 servers[name].default_enabled = False
-            elif isinstance(spec, dict) and spec.get("enabled") is True:
+            elif spec.get("enabled") is True:
                 servers[name].default_enabled = True
+            if spec.get("url"):
+                servers[name].url = spec["url"]
         else:
             # Custom server
             if isinstance(spec, dict) and spec.get("enabled") is not False:


### PR DESCRIPTION
## Summary

- **`osprey web`**: when no `--port` is given and the default port (8087) is busy, auto-bind to a free OS-assigned port instead of hard-exiting. Explicitly specified ports still error if taken.
- **`osprey artifacts web`**: pass `workspace_root` to `run_server()` so the command doesn't crash with `TypeError` when launched standalone.
- **`registry/mcp.py`**: apply the `url` field from `claude_code.servers` overrides to built-in framework servers, so stdio→HTTP switching via config works without `osprey claude` regen silently ignoring the key.

## Test plan

- [ ] `osprey web` with default port in use → confirms it picks a free port and prints the chosen port
- [ ] `osprey web --port <taken>` → still errors as before
- [ ] `osprey artifacts web` standalone → no longer crashes with `TypeError`
- [ ] Set `claude_code.servers.<name>.url` in config for a framework server → URL is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)