### PR TITLE
feat(dispatch): make worker inactivity watchdog configurable

### DIFF
--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -1325,6 +1325,7 @@ def _inject_dispatch(dispatch: DispatchConfig, profile_dir: Path, project_path: 
         "worker_port_base": dispatch.worker_port_base,
         "workspace_mode": dispatch.workspace_mode,
         "timeout_sec": dispatch.timeout_sec,
+        "inactivity_sec": dispatch.inactivity_sec,
     }
     deployed = config.get("deployed_services", []) or []
     for name in ("event_dispatcher", "dispatch_worker"):

--- a/src/osprey/cli/build_profile.py
+++ b/src/osprey/cli/build_profile.py
@@ -97,6 +97,7 @@ class DispatchConfig:
     dispatcher_port: int = 8020
     worker_port_base: int = 9190
     timeout_sec: int = 300
+    inactivity_sec: int = 120
     facility_name: str = ""
     pv_strip_prefix: str = ""
 
@@ -497,6 +498,8 @@ class BuildProfile:
                 errors.append(f"dispatch.max_queue_depth must be >= 1 (got {d.max_queue_depth})")
             if d.timeout_sec <= 0:
                 errors.append(f"dispatch.timeout_sec must be > 0 (got {d.timeout_sec})")
+            if d.inactivity_sec <= 0:
+                errors.append(f"dispatch.inactivity_sec must be > 0 (got {d.inactivity_sec})")
             # triggers must be a non-empty, resolvable file
             # (profile-relative OR bundled preset name)
             if not d.triggers:
@@ -714,6 +717,7 @@ def _parse_profile(raw: dict[str, Any]) -> BuildProfile:
             dispatcher_port=dispatch_raw.get("dispatcher_port", 8020),
             worker_port_base=dispatch_raw.get("worker_port_base", 9190),
             timeout_sec=dispatch_raw.get("timeout_sec", 300),
+            inactivity_sec=dispatch_raw.get("inactivity_sec", 120),
             facility_name=dispatch_raw.get("facility_name", ""),
             pv_strip_prefix=dispatch_raw.get("pv_strip_prefix", ""),
         )

--- a/src/osprey/templates/services/dispatch_worker/docker-compose.yml.j2
+++ b/src/osprey/templates/services/dispatch_worker/docker-compose.yml.j2
@@ -47,6 +47,7 @@ services:
       DISPATCH_WORKER_TOKEN: ${DISPATCH_WORKER_TOKEN}
       DISPATCH_WORKER_PORT: "{{ services.dispatch_worker.worker_port_base | default(9190) }}"
       DISPATCH_TIMEOUT_SEC: "{{ services.dispatch_worker.timeout_sec | default(300) }}"
+      DISPATCH_INACTIVITY_SEC: "{{ services.dispatch_worker.inactivity_sec | default(120) }}"
       OSPREY_PROJECT_DIR: /app/{{ osprey_labels.project_name }}
       # The worker process reads OSPREY config directly (e.g. get_facility_timezone
       # while building the agent's system prompt), and spawns a CLI subprocess with

--- a/tests/cli/test_inject_dispatch.py
+++ b/tests/cli/test_inject_dispatch.py
@@ -138,6 +138,25 @@ def test_inject_dispatch_unresolvable_triggers_raises(tmp_path: Path) -> None:
         )
 
 
+def test_inject_dispatch_propagates_inactivity_sec(tmp_path: Path) -> None:
+    """A dispatch.inactivity_sec lands in services.dispatch_worker so the compose
+    template can render DISPATCH_INACTIVITY_SEC for the worker (mirrors timeout_sec)."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    profile_dir = tmp_path / "profile"  # empty — forces bundled resolution
+    profile_dir.mkdir()
+    _write_config(project_path)
+
+    _inject_dispatch(
+        _dispatch(inactivity_sec=45),
+        profile_dir=profile_dir,
+        project_path=project_path,
+    )
+
+    dw = _read_config(project_path)["services"]["dispatch_worker"]
+    assert dw["inactivity_sec"] == 45
+
+
 def test_inject_dispatch_propagates_pool_limits(tmp_path: Path) -> None:
     """A non-default dispatch.max_concurrent_runs/max_queue_depth lands in triggers.yml.
 

--- a/tests/cli/test_profile_schema.py
+++ b/tests/cli/test_profile_schema.py
@@ -151,6 +151,24 @@ def test_parse_round_trip() -> None:
     assert profile.dispatch.workspace_mode == "isolated"
 
 
+def test_inactivity_sec_below_one_raises(tmp_path: Path) -> None:
+    triggers = _write_triggers(tmp_path)
+    profile = BuildProfile(name="x", dispatch=DispatchConfig(triggers=triggers, inactivity_sec=0))
+    with pytest.raises(BuildProfileError, match="inactivity_sec"):
+        profile.validate(tmp_path)
+
+
+def test_inactivity_sec_parses_and_defaults() -> None:
+    # An explicit value round-trips through _parse_profile.
+    p = _parse_profile({"name": "x", "dispatch": {"triggers": "t.yml", "inactivity_sec": 600}})
+    assert p.dispatch is not None
+    assert p.dispatch.inactivity_sec == 600
+    # Absent -> matches the worker's built-in 120s inactivity-watchdog default.
+    p2 = _parse_profile({"name": "x", "dispatch": {"triggers": "t.yml"}})
+    assert p2.dispatch is not None
+    assert p2.dispatch.inactivity_sec == 120
+
+
 def test_dispatch_not_a_mapping_raises() -> None:
     with pytest.raises(BuildProfileError, match="dispatch"):
         _parse_profile({"name": "x", "dispatch": "nope"})

--- a/tests/deployment/test_compose_generator.py
+++ b/tests/deployment/test_compose_generator.py
@@ -350,6 +350,37 @@ def test_worker_agent_data_volume_shared_mode_targets_project_layout() -> None:
     assert f"- dispatch_workspace_1:/app/{_WORKER_PROJECT_NAME}/_agent_data" in rendered
 
 
+def test_worker_template_inactivity_defaults_to_120() -> None:
+    """With no inactivity_sec configured, the worker env pins the watchdog to the
+    built-in 120s default — older configs missing the field still render cleanly."""
+    rendered = _render_worker_template(env_present=True)
+    assert 'DISPATCH_INACTIVITY_SEC: "120"' in rendered
+
+
+def test_worker_template_inactivity_reflects_injected_value() -> None:
+    """A configured services.dispatch_worker.inactivity_sec flows to the worker's
+    DISPATCH_INACTIVITY_SEC env, so a long single step is not cut off at 120s."""
+    from importlib import resources
+
+    from jinja2 import Template
+
+    from osprey.deployment.compose_generator import _inject_project_metadata
+
+    config = _inject_project_metadata(
+        {
+            "project_name": "p",
+            "project_root": "/r/p",
+            "services": {"dispatch_worker": {"inactivity_sec": 600}},
+            "system": {"timezone": "UTC"},
+        }
+    )
+    tpl = resources.files("osprey").joinpath(
+        "templates/services/dispatch_worker/docker-compose.yml.j2"
+    )
+    rendered = Template(tpl.read_text(encoding="utf-8")).render(**config)
+    assert 'DISPATCH_INACTIVITY_SEC: "600"' in rendered
+
+
 def test_worker_command_unchanged() -> None:
     """The worker overrides only ``command:`` — it must still launch the
     dispatch-worker MCP server, unchanged by the image/layout repoint."""


### PR DESCRIPTION
## What

The dispatch worker enforces two independent timers on a run:

- **`DISPATCH_TIMEOUT_SEC`** — total run wall-clock budget. Already a first-class build-profile field (`dispatch.timeout_sec`), rendered into the worker compose template.
- **`DISPATCH_INACTIVITY_SEC`** — the inactivity watchdog: max seconds to wait for the *next* SDK message before treating a run as stalled (each message resets it). Until now this was reachable **only** by hand-setting the env var — it was absent from the profile schema and the compose template.

The asymmetry bites long-running dispatches: a single step that emits no intermediate output for longer than the 120s default (a slow query, a heavy computation) trips the watchdog **even when `timeout_sec` has been raised**.

## Change

Expose `dispatch.inactivity_sec` the same way `timeout_sec` already is:

- `DispatchConfig.inactivity_sec` (default `120`), validated `> 0` in `BuildProfile.validate`.
- Threaded into the `services.dispatch_worker` config in `_inject_dispatch`.
- Rendered as `DISPATCH_INACTIVITY_SEC` in the worker compose template (`| default(120)`, so pre-existing configs missing the field render unchanged).

Behavior is unchanged for any profile that doesn't set the field (still 120s).

## Tests

Mirrors the existing `timeout_sec` coverage across all three layers:
- schema parse + default + `> 0` validation (`test_profile_schema.py`)
- build injection into `services.dispatch_worker` (`test_inject_dispatch.py`)
- compose template render, default and injected value (`test_compose_generator.py`)

170 passed in the affected suites; `ruff check` + `ruff format --check` clean.