### PR TITLE
fix(web-terminal): make panel nav bar horizontally scrollable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- The Web Terminal's panel nav bar (WORKSPACE, ARIEL, CHANNELS, LATTICE, …) now scrolls horizontally when the tabs outgrow the header instead of letting the trailing tabs get clipped or slide under the header action buttons on a narrow viewport; the scroll has no visible scrollbar and the action buttons stay pinned on the right.
 - ARIEL `semantic_search` now degrades gracefully when semantic search is unavailable (no pgvector table / Ollama) — returns an empty result steering the agent to `keyword_search` instead of a tool failure (#276).
 - Workspace gallery now shows new artifacts without a manual refresh: the store index is written atomically (temp file + `os.replace`) and the watcher detects the rename (`on_moved`), so a cross-process reader no longer reads a half-written file (#289).
 - Channel Finder in-context Explore filter now searches the whole database and re-chunks results, instead of filtering only the displayed page (a match on a later page previously read as "No channels match the filter") (#299).

--- a/src/osprey/interfaces/web_terminal/static/css/drawer.css
+++ b/src/osprey/interfaces/web_terminal/static/css/drawer.css
@@ -214,6 +214,7 @@ body.drawer-resizing {
   align-items: center;
   gap: 4px;
   margin-left: 12px;
+  flex: 0 0 auto;
 }
 
 .header-icon-btn {

--- a/src/osprey/interfaces/web_terminal/static/css/terminal.css
+++ b/src/osprey/interfaces/web_terminal/static/css/terminal.css
@@ -208,7 +208,19 @@
   align-items: center;
   gap: 2px;
   height: 100%;
+  flex: 1 1 auto;
+  /* Allow the flex item to shrink below content width so overflow can scroll
+     instead of pushing tabs off-viewport / under .header-actions. */
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  /* Scroll without a visible scrollbar (Firefox, legacy Edge). */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 }
+
+/* Scroll without a visible scrollbar (Chrome, Safari, WebKit). */
+.header-tabs::-webkit-scrollbar { display: none; }
 
 .header-tab {
   display: flex;
@@ -216,6 +228,8 @@
   gap: 6px;
   padding: 0 14px;
   height: 100%;
+  flex: 0 0 auto;
+  white-space: nowrap;
   cursor: pointer;
   border: none;
   background: transparent;


### PR DESCRIPTION
## Problem

On a narrow viewport the Web Terminal's panel nav bar (WORKSPACE, ARIEL, CHANNELS, LATTICE, KNOWLEDGE, …) has no overflow handling. `.header-tabs` is a flex item with the default `min-width: auto`, so it never shrinks below its content width — the trailing tabs get clipped or slide under the header action buttons (docs / theme / settings) and become unclickable unless you resize the panes or zoom out.

## Fix (CSS only)

- **`.header-tabs`** becomes the flexible middle region that scrolls horizontally: `flex: 1 1 auto; min-width: 0; overflow-x: auto; overflow-y: hidden`. `min-width: 0` is the key that lets the flex item bound itself so overflow scrolls instead of pushing content out. Scrollbar hidden cross-browser: `scrollbar-width: none`, `-ms-overflow-style: none`, and `.header-tabs::-webkit-scrollbar { display: none }`.
- **`.header-tab`** gets `flex: 0 0 auto; white-space: nowrap` so individual tabs keep full size and overflow into the scroll region instead of compressing/wrapping.
- **`.header-actions`** gets `flex: 0 0 auto` so the icon buttons stay full-size, pinned on the right, and never absorb the overflow.

No JS or markup changes.

## Verification

Rendered the real header markup with the shipping CSS at a 620px-wide strip (8 tabs):

- content 824px vs 154px visible → overflowing
- scrolls to the end; the last tab (`ACTIVITY`) becomes fully reachable/clickable
- `.header-actions` width unchanged and still right of the tab strip (not covering tabs)
- computed `overflow-x: auto`, `min-width: 0`, `scrollbar-width: none` — no visible scrollbar

Native horizontal scroll works via trackpad, Shift+wheel, touch, and keyboard.