### PR TITLE
feat(virtual-accelerator): build the VA image for the host's native architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Changed
 
+- The Virtual Accelerator image now builds for the host's native architecture instead of pinning `linux/amd64`. On Apple Silicon it compiles `accelerator-toolbox`/`softioc` from source at build time (a slower first build) and then runs natively with no x86 emulation; on x86_64 it installs the prebuilt wheels as before. A single-arch `amd64` published image on an arm64 host must supply its own `platform` override.
 - **The event-dispatch worker now runs the full project image** instead of a lean image that rebuilt its `.claude` artifacts from `config.yml` at startup. Dispatched agents now see the same facility overlays (custom skills, agents, and rules) and `data/` files as the Web Terminal agent, by construction — previously overlays and `data/` were silently absent from dispatched runs. `osprey deploy up` builds the project image (`<project>:local`; `--dev` installs the locally built wheel) and the worker references it via `OSPREY_WORKER_IMAGE`. **Requires rebuilding the dispatch worker image on redeploy.**
 - `claude-agent-sdk` upgraded to 0.2.110 (bundles CLI 2.1.191); `uv.lock` regenerated (#311).
 - README rewritten: corrected the connector claim (EPICS and Mock ship in-tree; other stacks use the connector interface), fixed the `osprey skills install` quickstart command, and removed stale release and conference notices. The PyPI package description now matches the documentation.

--- a/docker/virtual-accelerator/Containerfile
+++ b/docker/virtual-accelerator/Containerfile
@@ -18,15 +18,12 @@
 # lattice/response.py and ioc/physics_bridge.py were actually built and
 # tested against) rather than the stale 0.6.1 probe-era pin.
 #
-# accelerator-toolbox/softioc (and softioc's epicscorelibs/pvxslibs deps)
-# still publish no linux/aarch64 wheels at any version, so this image is
-# still built and run for linux/amd64 explicitly, same as the probe.
-ARG TARGET_PLATFORM=linux/amd64
-FROM --platform=${TARGET_PLATFORM} python:3.11-slim
-
-RUN pip install --no-cache-dir \
-    accelerator-toolbox==0.7.1 \
-    softioc==4.7.0
+# Native architecture: no `--platform` pin, so the image resolves to the host
+# arch. accelerator-toolbox/softioc (and softioc's epicscorelibs/pvxslibs deps)
+# publish no manylinux_aarch64 wheels at any version, so on arm64 they compile from
+# sdist at build time using the toolchain installed below (purged in the same
+# RUN layer); on x86_64 the prebuilt wheels install as before -- no emulation.
+FROM python:3.11-slim
 
 # osprey itself -- manifest/lattice/ioc/entrypoint now live under
 # src/osprey/services/virtual_accelerator/ and install as part of the
@@ -39,7 +36,19 @@ RUN pip install --no-cache-dir \
 WORKDIR /opt/osprey
 COPY pyproject.toml README.md /opt/osprey/
 COPY src/ /opt/osprey/src/
-RUN pip install --no-cache-dir .
+
+# A C toolchain is needed at install time to compile the native deps from sdist
+# on arm64; it is installed and purged in this single RUN layer so it never
+# bloats the final image. build-essential pulls in the perl it needs
+# transitively -- no explicit perl package is required. Both pip installs (the
+# pinned native deps and osprey itself) run while the toolchain is present.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential python3-dev \
+    && pip install --no-cache-dir accelerator-toolbox==0.7.1 softioc==4.7.0 \
+    && pip install --no-cache-dir . \
+    && apt-get purge -y build-essential python3-dev \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
 
 # Channel Access server port. TCP only is required -- CA name-server mode
 # (EPICS_CA_NAME_SERVERS=<host>:5064, EPICS_CA_AUTO_ADDR_LIST=NO on the

--- a/docker/virtual-accelerator/README.md
+++ b/docker/virtual-accelerator/README.md
@@ -82,12 +82,15 @@ partitions:
 
 ## Image contents and why they're pinned this way
 
-- **Base:** `python:3.11-slim`, built and run for **`linux/amd64`** only
-  (`--platform linux/amd64`; on Apple Silicon this runs under the container
-  runtime's x86_64 emulation). Neither `accelerator-toolbox` nor `softioc`
-  (nor softioc's `epicscorelibs`/`pvxslibs` dependencies) publish
-  `linux/aarch64` wheels at any version — building the EPICS base C library
-  from source for arm64 is out of scope.
+- **Base:** `python:3.11-slim`, built and run **native-arch** — no
+  `--platform` pin, so the image matches the host architecture. On x86_64,
+  `accelerator-toolbox` and `softioc` (with softioc's
+  `epicscorelibs`/`pvxslibs` dependencies) install as prebuilt
+  `manylinux2014_x86_64` wheels. On arm64 (Apple Silicon), no
+  `manylinux_aarch64` wheels are published for these packages, so they build
+  from source at image-build time — this pulls in a C toolchain and the
+  EPICS base C library, making the arm64 build slower and heavier, but it
+  runs natively with no emulation overhead.
 - **`accelerator-toolbox==0.7.1`, `softioc==4.7.0`** — *not* the
   `accelerator-toolbox==0.6.1` / `softioc==4.5.0` pins from the Phase-1
   probe investigation. Those were fine for the probe (a standalone script

--- a/scripts/va/build_and_boot_check.sh
+++ b/scripts/va/build_and_boot_check.sh
@@ -73,8 +73,8 @@ cp -R "${WORKTREE_ROOT}/src/." "${STAGING_DIR}/src/"
 cp "${VA_DIR}/Containerfile" "${STAGING_DIR}/docker/virtual-accelerator/Containerfile"
 find "${STAGING_DIR}" -name "__pycache__" -type d -prune -exec rm -rf {} +
 
-echo "--- Building ${IMAGE} (linux/amd64) ---"
-"${RUNTIME}" build --platform linux/amd64 --build-arg TARGET_PLATFORM=linux/amd64 \
+echo "--- Building ${IMAGE} (native arch) ---"
+"${RUNTIME}" build \
     -t "${IMAGE}" -f "${STAGING_DIR}/docker/virtual-accelerator/Containerfile" "${STAGING_DIR}"
 
 echo "--- Starting ${CONTAINER} (data dir: ${DATA_DIR}) ---"

--- a/scripts/va/probe_build_and_caget.sh
+++ b/scripts/va/probe_build_and_caget.sh
@@ -54,8 +54,8 @@ trap cleanup EXIT
 # Idempotency: remove any prior probe container before starting.
 "${RUNTIME}" rm -f "${CONTAINER}" >/dev/null 2>&1 || true
 
-echo "--- Building ${IMAGE} (linux/amd64) ---"
-"${RUNTIME}" build --platform linux/amd64 --build-arg TARGET_PLATFORM=linux/amd64 \
+echo "--- Building ${IMAGE} (native arch) ---"
+"${RUNTIME}" build \
     -t "${IMAGE}" -f "${PROBE_DIR}/Containerfile" "${PROBE_DIR}"
 
 echo "--- Starting ${CONTAINER} ---"

--- a/scripts/va/probe_roundtrip.py
+++ b/scripts/va/probe_roundtrip.py
@@ -98,10 +98,6 @@ def _ensure_image(runtime: str) -> None:
         [
             runtime,
             "build",
-            "--platform",
-            "linux/amd64",
-            "--build-arg",
-            "TARGET_PLATFORM=linux/amd64",
             "-t",
             IMAGE,
             "-f",

--- a/scripts/va/run_va.sh
+++ b/scripts/va/run_va.sh
@@ -76,8 +76,8 @@ if [[ "${OSPREY_VA_REBUILD:-0}" == "1" ]] || ! "${RUNTIME}" image inspect "${IMA
     cp "${VA_DIR}/Containerfile" "${STAGING_DIR}/docker/virtual-accelerator/Containerfile"
     find "${STAGING_DIR}" -name "__pycache__" -type d -prune -exec rm -rf {} +
 
-    echo "--- Building ${IMAGE} (linux/amd64) ---"
-    "${RUNTIME}" build --platform linux/amd64 --build-arg TARGET_PLATFORM=linux/amd64 \
+    echo "--- Building ${IMAGE} (native arch) ---"
+    "${RUNTIME}" build \
         -t "${IMAGE}" -f "${STAGING_DIR}/docker/virtual-accelerator/Containerfile" "${STAGING_DIR}"
 else
     echo "Reusing existing image ${IMAGE} (set OSPREY_VA_REBUILD=1 to force a rebuild)"

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -1534,8 +1534,9 @@ def _inject_va(va: VAConfig, project_path: Path) -> None:
     )
     logger.info(
         "    Images:     `osprey deploy up` builds the virtual-accelerator image "
-        "locally (first run is slow, and only on linux/amd64 — PyAT/softioc have "
-        "no aarch64 wheels). Use `--dev` to bake in your local osprey checkout; "
+        "locally for your native architecture (first run is slow — the native deps "
+        "PyAT/softioc are compiled from source, so no prebuilt aarch64 wheels are "
+        "needed). Use `--dev` to bake in your local osprey checkout; "
         "set OSPREY_VA_IMAGE to use a published image."
     )
 

--- a/src/osprey/services/virtual_accelerator/probe/Containerfile
+++ b/src/osprey/services/virtual_accelerator/probe/Containerfile
@@ -1,14 +1,12 @@
 # Phase-1 probe: minimal PyAT + pythonSoftIOC image for the hard reachability gate.
 #
-# Pinned versions (accelerator-toolbox==0.6.1, softioc==4.5.0) publish only
-# macOS and linux/x86_64 (manylinux) wheels on PyPI -- no linux/aarch64 wheels
-# exist, and softioc's epicscorelibs/pvxslibs deps would require building the
-# full EPICS base from source to run natively on linux/arm64. This image is
-# therefore built and run for linux/amd64 explicitly (see probe_build_and_caget.sh),
-# which on Apple Silicon hosts runs under the container runtime's x86_64 emulation.
+# Pinned versions (accelerator-toolbox==0.6.1, softioc==4.5.0) publish
+# macOS and manylinux2014_x86_64 wheels on PyPI. No manylinux_aarch64 wheels
+# exist, so on arm64 hosts pip builds these deps from source instead -- this
+# works natively (no emulation) and the image therefore resolves to the host's
+# native architecture on both amd64 and arm64 (see probe_build_and_caget.sh).
 # Python 3.10 is required: softioc==4.5.0 has no manylinux wheel beyond cp310.
-ARG TARGET_PLATFORM=linux/amd64
-FROM --platform=${TARGET_PLATFORM} python:3.10-slim
+FROM python:3.10-slim
 
 WORKDIR /probe
 

--- a/src/osprey/services/virtual_accelerator/probe/README.md
+++ b/src/osprey/services/virtual_accelerator/probe/README.md
@@ -37,20 +37,28 @@ this task touched it. `scripts/va/probe_build_and_caget.sh` auto-detects this
 with a cheap health-check container run and falls back to docker, so it will
 pick podman back up automatically once that machine is repaired.
 
-The probe image itself targets **`linux/amd64`** explicitly (`Containerfile`
-takes `TARGET_PLATFORM` as a build arg, default `linux/amd64`), not the
-host's native `linux/arm64`. Reason: **neither `accelerator-toolbox==0.6.1`
+**(Historical — Phase-1.)** Originally the probe was pinned to
+**`linux/amd64`** explicitly — the `Containerfile` took a `TARGET_PLATFORM`
+build arg defaulting to `linux/amd64`, rather than the host's native
+`linux/arm64`. The reason at the time: **neither `accelerator-toolbox==0.6.1`
 nor `softioc==4.5.0`** (nor softioc's `epicscorelibs`/`pvxslibs` dependencies)
 publish `manylinux_aarch64` wheels on PyPI -- only macOS and
-`manylinux2014_x86_64` wheels exist for the pinned versions. Building
-`epicscorelibs`/`pvxslibs` from source on arm64 would mean building the full
-EPICS base C library, which is out of scope for a toy probe. Running the
-image under `linux/amd64` emulation (via Docker Desktop's Rosetta/QEMU
-backend on Apple Silicon) lets both pinned packages install as prebuilt
-wheels with no compiler needed in the image. This does cost real emulation
-overhead but the probe still boots to serving PVs in about 2 seconds.
-`softioc==4.5.0` also caps at Python 3.10 for its manylinux wheel (no cp311+
-Linux wheel), so the base image is `python:3.10-slim`, not a newer Python.
+`manylinux2014_x86_64` wheels exist for those pinned versions. Building
+`epicscorelibs`/`pvxslibs` from source on arm64 means building the full EPICS
+base C library, which was judged out of scope for a toy probe, so the probe
+ran under `linux/amd64` emulation (via Docker Desktop's Rosetta/QEMU backend
+on Apple Silicon) to install both pinned packages as prebuilt wheels with no
+compiler in the image. This cost real emulation overhead but the probe still
+booted to serving PVs in about 2 seconds. `softioc==4.5.0` also caps at
+Python 3.10 for its manylinux wheel (no cp311+ Linux wheel), so the probe's
+base image is `python:3.10-slim`, not a newer Python.
+
+That amd64 pin is no longer a constraint anywhere: the probe `Containerfile`
+now builds native-arch too (no `TARGET_PLATFORM` arg), compiling these deps
+from source on arm64 exactly as the full VA image does (see
+`docker/virtual-accelerator/README.md`). Only the probe's *version* pins
+(`accelerator-toolbox==0.6.1`, `softioc==4.5.0`, and the `python:3.10-slim`
+base they require) are retained here as the historical Phase-1 record.
 
 ## Empirical CA host<->container reachability finding
 
@@ -100,9 +108,10 @@ Desktop as an artifact of this specific runtime, not a portable guarantee.
 
 - Host: Apple Silicon (arm64), macOS. Container runtime VM (`podman machine`)
   is applehv-backed arm64; Docker Desktop's engine is also `linux/arm64`.
-- `linux/amd64` container images run under Docker Desktop's built-in
-  cross-arch emulation (confirmed working here); no manual `qemu-user-static`
-  binfmt setup was needed.
+- (Historical — Phase-1.) The probe's `linux/amd64` image ran under Docker
+  Desktop's built-in cross-arch emulation (confirmed working here); no manual
+  `qemu-user-static` binfmt setup was needed. The full VA image no longer
+  pins amd64 and builds native-arch instead.
 - Host CA client used: `~/EPICS/epics-base/bin/darwin-aarch64/caget` /
   `caput` (real EPICS base build, not a Python stand-in). The gate script
   falls back to a `pyepics` one-liner via the worktree `.venv` if that binary

--- a/src/osprey/templates/services/virtual_accelerator/Dockerfile
+++ b/src/osprey/templates/services/virtual_accelerator/Dockerfile
@@ -14,10 +14,13 @@
 # here — the extra + core deps resolve them, so this Dockerfile can't drift
 # from pyproject.toml's declared constraints.
 #
-# linux/amd64 only: neither accelerator-toolbox nor softioc (nor softioc's
-# epicscorelibs/pvxslibs deps) publish manylinux_aarch64 wheels — see the
-# probe README's platform note. The compose template pins `platform:
-# linux/amd64` accordingly.
+# Architecture-agnostic: this image builds for the host's native architecture
+# (no `--platform` pin). On arm64 the native deps (accelerator-toolbox, softioc,
+# and softioc's epicscorelibs/pvxslibs deps) publish no manylinux_aarch64 wheels,
+# so pip compiles them from sdist using the build toolchain installed below —
+# purged in the same layer — for native execution with no x86 emulation. On
+# x86_64 pip installs the prebuilt wheels as before. See the probe README's
+# platform note for the historical amd64 rationale.
 #
 # This image is built locally by `osprey deploy up`; override with
 # OSPREY_VA_IMAGE to use a prebuilt/published image.

--- a/src/osprey/templates/services/virtual_accelerator/docker-compose.yml.j2
+++ b/src/osprey/templates/services/virtual_accelerator/docker-compose.yml.j2
@@ -6,15 +6,18 @@
 # Use `osprey deploy up --dev` to bake in your local osprey checkout (incl.
 # unreleased code) via a wheel; otherwise the image installs osprey from PyPI.
 #
-# linux/amd64 only: neither accelerator-toolbox nor softioc (nor softioc's
-# epicscorelibs/pvxslibs deps) publish manylinux_aarch64 wheels, so this
-# service always builds/runs under amd64 emulation on Apple Silicon hosts —
-# see src/osprey/services/virtual_accelerator/probe/README.md.
+# Native architecture: the service resolves to the host's arch (no platform
+# pin). On arm64 hosts the four native deps (accelerator-toolbox, softioc,
+# epicscorelibs, pvxslibs) have no manylinux_aarch64 wheels, so they compile
+# from sdist during the image build — a one-time cost of a couple of minutes,
+# no x86 emulation involved — see
+# src/osprey/services/virtual_accelerator/probe/README.md.
 
 services:
   virtual-accelerator:
+    # OSPREY_VA_IMAGE now inherits host-arch resolution too: a single-arch amd64
+    # published image on an arm64 host must supply its own `platform` override (VA-8).
     image: ${OSPREY_VA_IMAGE:-{{ services.virtual_accelerator.image | default('osprey-va:local') }}}
-    platform: linux/amd64
     build:
       # With multiple `-f` compose files, ALL relative paths (build contexts and
       # bind mounts alike) resolve against the FIRST file's dir — the compose
@@ -73,9 +76,10 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-      # Grace period before failed probes count — the amd64-emulated image
-      # build/boot (PyAT lattice load + softioc iocInit) takes a few seconds
-      # longer than the framework's native-arch services.
+      # Grace period before failed probes count — generous because a first-time
+      # native-arch image build (source-compiling the native deps) plus boot
+      # (PyAT lattice load + softioc iocInit) takes a few seconds longer than
+      # the framework's other native-arch services.
       start_period: 20s
 
 networks:

--- a/tests/e2e/test_orm_discovery_scenario.py
+++ b/tests/e2e/test_orm_discovery_scenario.py
@@ -77,7 +77,7 @@ judge's provider) is unavailable. Collection-validate with:
 
     .venv/bin/pytest tests/e2e/test_orm_discovery_scenario.py --collect-only -q
 
-Real run (needs Docker + amd64 + judge creds -- unlikely to be available in
+Real run (needs Docker + judge creds -- unlikely to be available in
 any given session; do not weaken the prompts or the wiring to force a local
 pass):
 
@@ -117,7 +117,7 @@ PROVIDER = "als-apg"
 AGENT_MODEL_TIER = "opus"  # diagnostic reasoning needs Opus, not the haiku default
 
 BUILD_TIMEOUT_SEC = _orm_stack.BUILD_TIMEOUT_SEC
-DEPLOY_UP_TIMEOUT_SEC = 1200  # amd64-emulated VA image build is slow (minutes)
+DEPLOY_UP_TIMEOUT_SEC = 1200  # first-time native VA source build is slow (minutes)
 HEALTH_TIMEOUT_SEC = 300.0
 
 pytestmark = [
@@ -126,13 +126,13 @@ pytestmark = [
     pytest.mark.requires_als_apg,
     pytest.mark.skipif(not HAS_SDK, reason="claude_agent_sdk not installed"),
     pytest.mark.skipif(shutil.which("docker") is None, reason="docker not available"),
-    # Skipped on CI: needs a real Docker (amd64) VA+bridge+Tiled+postgres
+    # Skipped on CI: needs a real Docker VA+bridge+Tiled+postgres
     # stack, which the default GitHub Actions runner does not provision (see
     # tests/e2e/README.md and test_va_substrate_equivalence.py's identical
     # gate).
     pytest.mark.skipif(
         os.environ.get("GITHUB_ACTIONS") == "true",
-        reason="needs a real Docker (amd64) stack; not provisioned on CI runners",
+        reason="needs a real Docker stack; not provisioned on CI runners",
     ),
 ]
 

--- a/tests/e2e/test_orm_roundtrip.py
+++ b/tests/e2e/test_orm_roundtrip.py
@@ -38,8 +38,8 @@ container/image -- never a wildcard, never ``system prune``/``--volumes``.
 Teardown goes through ``osprey deploy down``, matching every other e2e in
 this directory.
 
-Gating: needs Docker; the VA image is amd64-only (PyAT/softioc have no
-aarch64 wheels), so it builds/boots under QEMU emulation on Apple Silicon --
+Gating: needs Docker; the VA image builds natively for the host arch, so on
+Apple Silicon PyAT/softioc compile from source (no prebuilt aarch64 wheels) --
 slow (minutes) on a cold image cache. Advisory CI lane (see ci.yml); run
 locally with ``E2E_REUSE_IMAGES=1`` set for fast iteration once the image
 cache is warm.
@@ -73,10 +73,10 @@ pytestmark = [
 BRIDGE_URL = f"http://localhost:{_orm_stack.BRIDGE_PORT}"
 
 BUILD_TIMEOUT_SEC = _orm_stack.BUILD_TIMEOUT_SEC
-DEPLOY_UP_TIMEOUT_SEC = 1200  # amd64-emulated VA image build is slow (minutes)
+DEPLOY_UP_TIMEOUT_SEC = 1200  # first-time native VA source build is slow (minutes)
 HEALTH_TIMEOUT_SEC = 300.0
 # 4 correctors x 5 points x an 8-device (4 corrector + 4 BPM) bundle read per
-# point, amd64-emulated -- generous headroom over a healthy run's expected
+# point -- generous headroom over a healthy run's expected
 # few-tens-of-seconds so this stays a meaningful "did it hang" gate rather
 # than a flaky timing assertion.
 SCAN_TIMEOUT_SEC = 240.0

--- a/tests/e2e/test_va_substrate_equivalence.py
+++ b/tests/e2e/test_va_substrate_equivalence.py
@@ -33,8 +33,8 @@ Container safety: every docker invocation below names an exact container/image
 ``test_scan_deploy.py``'s precedent for forcing a fresh ``--dev`` build.
 Teardown goes through ``osprey deploy down``, never a raw ``docker rm`` sweep.
 
-Gating: needs Docker; the VA image is amd64-only (PyAT/softioc have no
-aarch64 wheels), so it builds/boots under QEMU emulation on Apple Silicon —
+Gating: needs Docker; the VA image builds natively for the host arch, so on
+Apple Silicon PyAT/softioc compile from source (no prebuilt aarch64 wheels) —
 slow (minutes) on a cold image cache. Lives in ``tests/e2e/`` (never
 collected by the fast lane, see ``ci_check.sh``/ci.yml).
 
@@ -108,7 +108,7 @@ P5_DETECTOR = "p5_det"
 PROMOTE_TOKEN = "e2e-substrate-equivalence-promote-token"
 
 BUILD_TIMEOUT_SEC = 300
-DEPLOY_UP_TIMEOUT_SEC = 1200  # amd64-emulated VA image build is slow (minutes)
+DEPLOY_UP_TIMEOUT_SEC = 1200  # first-time native VA source build is slow (minutes)
 HEALTH_TIMEOUT_SEC = 300.0
 SWEEP_TIMEOUT_SEC = 120.0  # sweep()'s own connect deadline defaults to 45s
 SCAN_TIMEOUT_SEC = 60.0
@@ -325,7 +325,7 @@ def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Deploye
     # otherwise reuse a stale cached image). Exact-named images only.
     # E2E_REUSE_IMAGES=1 skips this (dev-only: fast local iteration on the test
     # itself when the osprey source is unchanged; never set it in CI, where a
-    # source change must always rebuild). The amd64-emulated VA build is slow.
+    # source change must always rebuild). The first-time native VA build is slow.
     if not os.environ.get("E2E_REUSE_IMAGES"):
         subprocess.run(["docker", "rmi", "-f", VA_IMAGE], capture_output=True, text=True)
         subprocess.run(["docker", "rmi", "-f", BRIDGE_IMAGE], capture_output=True, text=True)
@@ -632,7 +632,7 @@ async def test_p3_read_equivalence(deployed_stack: DeployedStack) -> None:
     # SP->RB echo is asynchronous, so the host op polls the readback until it
     # reflects the write (bounded) instead of racing the echo (see
     # _va_host_ca_op.py) — the failure mode that a fixed no-wait read hits under
-    # heavy emulation load.
+    # heavy load.
     host = _run_host_ca_op(
         _host_ca_op_spec(
             deployed_stack.project_dir,


### PR DESCRIPTION
## Summary

The Virtual Accelerator image (and its Phase-1 probe) previously pinned `--platform linux/amd64`, forcing x86 emulation on Apple Silicon hosts. This drops the pin so both build for the host's native architecture.

- On **arm64**, the native deps (`accelerator-toolbox`, `softioc`, and softioc's `epicscorelibs`/`pvxslibs`) publish no `manylinux_aarch64` wheels, so a build toolchain is installed and **purged within a single image layer** to compile them from sdist — the image then runs natively with **no x86 emulation**.
- On **x86_64**, the prebuilt wheels install exactly as before.
- The compose `platform: linux/amd64` pin is removed. A single-arch amd64 *published* image on an arm64 host must now supply its own `platform` override (documented inline, VA-8).

Build scripts, `osprey build` CLI help, e2e docstrings/timeout comments, and the probe README are all updated to match; the probe README's amd64 narrative is now framed strictly as a historical Phase-1 record. CHANGELOG updated under `[Unreleased] → Changed`.

## Verification

- `test_orm_roundtrip.py` — passes on native arm64 (write SP→RB echo + BPM orbit-response physics oracle).
- `test_va_substrate_equivalence.py` P1–P5 — all pass on native arm64 (read/write echo equivalence + honest divergence).
- `osprey deploy up --dev` builds `osprey-va:local` resolving to `arm64` (`uname -m` = `aarch64` in-container), no `--platform` flag.
- No platform/`TARGET_PLATFORM` pins remain in-scope; surviving amd64 mentions are all historical or negations. Ruff clean. The x86_64 CI lane (`ci.yml`) is unchanged and remains wheel-based.