### PR TITLE
fix(deploy): namespace service container names per-project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Compatibility is documented in release notes, not encoded in the version string.
 - Toggling the theme (in the Web Terminal hub or any standalone interface) no longer leaves a stale `?theme=` in the URL; reloading after a toggle now falls back to your saved preference (or the OS setting in `auto` mode) instead of being pinned to whatever value was in the URL at toggle time.
 - Creating a new artifact from the Web Terminal's Scaffold gallery no longer fails with an HTTP 405 — the create-artifact request now uses `POST` directly instead of being routed through a GET-only fetch helper.
 - Artifacts gallery: filter chips no longer accumulate click listeners across live-refresh cycles, and a failed Plotly script load is retried on the next chart render instead of failing for the rest of the page's lifetime.
+- Deployed service containers are now named `<project>-<service>` (e.g. `<project>-ariel-postgres`, `<project>-virtual-accelerator`, `<project>-bluesky-bridge`) instead of host-global names, so two OSPREY projects can deploy the same services on one host concurrently without colliding on a container name. In-network service discovery is unaffected (it uses the compose service key, not the container name); the `ariel-postgres` DSN hostname is preserved via a network alias.
 
 ### Security
 

--- a/src/osprey/cli/build_profile.py
+++ b/src/osprey/cli/build_profile.py
@@ -133,7 +133,7 @@ class VAConfig:
 
     Consumed by the build pipeline's VA-injection step to deploy the single
     ``virtual_accelerator`` service (compose service ``virtual-accelerator``,
-    container ``osprey-virtual-accelerator``). Port is validated by
+    container ``<project>-virtual-accelerator``). Port is validated by
     :meth:`BuildProfile.validate`.
     """
 

--- a/src/osprey/templates/services/bluesky/docker-compose.yml.j2
+++ b/src/osprey/templates/services/bluesky/docker-compose.yml.j2
@@ -28,7 +28,11 @@ services:
       virtual-accelerator:
         condition: service_healthy
 {% endif %}
-    container_name: osprey-bluesky-bridge
+    # container_name is a HOST-GLOBAL docker identifier: namespace it per-project
+    # so two OSPREY projects can deploy the bridge on one host without colliding
+    # on one name. In-network consumers reach this service by its compose service
+    # key `bluesky-bridge` — unchanged here — so this rename needs no network alias.
+    container_name: {{ osprey_labels.project_name }}-bluesky-bridge
     command:
       [
         "uvicorn",
@@ -136,7 +140,12 @@ services:
   # only, same as the bridge itself. Not required for Phase 2's FakeScanner path.
   tiled:
     image: ${OSPREY_TILED_IMAGE:-ghcr.io/bluesky/tiled:0.2.12}
-    container_name: osprey-bluesky-tiled
+    # container_name is a HOST-GLOBAL docker identifier: namespace it per-project
+    # so two OSPREY projects can deploy Tiled on one host without colliding on one
+    # name. The bridge reaches this service by its compose service key `tiled`
+    # (BLUESKY_TILED_URI: http://tiled:8000) — unchanged here — so this rename
+    # needs no network alias.
+    container_name: {{ osprey_labels.project_name }}-bluesky-tiled
     restart: unless-stopped
     # `serve catalog` aborts without a catalog DB argument and defaults to
     # 127.0.0.1 (unreachable from the bridge container) without --host. The

--- a/src/osprey/templates/services/dispatch_worker/docker-compose.yml.j2
+++ b/src/osprey/templates/services/dispatch_worker/docker-compose.yml.j2
@@ -23,7 +23,12 @@ services:
     # is pulled normally instead.
     depends_on:
       - event-dispatcher
-    container_name: osprey-dispatch-worker-{{ i }}
+    # container_name is a HOST-GLOBAL docker identifier: namespace it per-project
+    # so two OSPREY projects can deploy workers on one host without colliding on
+    # one name. The dispatcher routes to the compose service key
+    # `dispatch-worker-{{ i }}` (see tutorial_triggers.yml dispatch_target),
+    # unchanged here — so this rename needs no network alias.
+    container_name: {{ osprey_labels.project_name }}-dispatch-worker-{{ i }}
     command: ["python", "-m", "osprey.mcp_server.dispatch_worker"]
     labels:
       osprey.project.name: "{{ osprey_labels.project_name }}"

--- a/src/osprey/templates/services/event_dispatcher/docker-compose.yml.j2
+++ b/src/osprey/templates/services/event_dispatcher/docker-compose.yml.j2
@@ -17,7 +17,12 @@ services:
       dockerfile: Dockerfile
       args:
         OSPREY_VERSION: "{{ osprey_version | default('') }}"
-    container_name: osprey-event-dispatcher
+    # container_name is a HOST-GLOBAL docker identifier: namespace it per-project
+    # so two OSPREY projects can deploy the dispatcher on one host without
+    # colliding on one name. In-network consumers reach this service by its
+    # compose service key `event-dispatcher` (the worker's depends_on) —
+    # unchanged here — so this rename needs no network alias.
+    container_name: {{ osprey_labels.project_name }}-event-dispatcher
     command: ["python", "-m", "osprey.dispatch"]
     labels:
       osprey.project.name: "{{ osprey_labels.project_name }}"

--- a/src/osprey/templates/services/postgresql/docker-compose.yml.j2
+++ b/src/osprey/templates/services/postgresql/docker-compose.yml.j2
@@ -1,7 +1,12 @@
 services:
   postgresql:
     image: pgvector/pgvector:pg16
-    container_name: ariel-postgres
+    # container_name is a HOST-GLOBAL docker identifier: a bare `ariel-postgres`
+    # collides when two OSPREY projects deploy postgres on one host, forcing them
+    # to serialize. Namespace it per-project so concurrent deploys don't fight
+    # over one name. The DNS hostname the ARIEL DSN resolves (`ariel-postgres`) is
+    # pinned separately via a network alias below, so the DSN is unaffected.
+    container_name: {{ osprey_labels.project_name }}-ariel-postgres
     labels:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
@@ -17,7 +22,14 @@ services:
     volumes:
       - ariel_postgres_data:/var/lib/postgresql/data
     networks:
-      - osprey-network
+      # The container_name above is now per-project, but the ARIEL DSN
+      # (`postgresql://ariel:ariel@ariel-postgres:5432/ariel`) hosts the stable
+      # name `ariel-postgres`. Pin it as a network alias so in-network consumers
+      # keep resolving it regardless of the namespaced container_name — without
+      # this, the DSN breaks with "could not translate host name".
+      osprey-network:
+        aliases:
+          - ariel-postgres
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U {{ services.postgresql.username | default('ariel') }} -d {{ services.postgresql.database_name | default('ariel') }}"]
       interval: 10s

--- a/src/osprey/templates/services/virtual_accelerator/docker-compose.yml.j2
+++ b/src/osprey/templates/services/virtual_accelerator/docker-compose.yml.j2
@@ -24,7 +24,12 @@ services:
       dockerfile: Dockerfile
       args:
         OSPREY_VERSION: "{{ osprey_version | default('') }}"
-    container_name: osprey-virtual-accelerator
+    # container_name is a HOST-GLOBAL docker identifier: namespace it per-project
+    # so two OSPREY projects can deploy the VA on one host without colliding on
+    # one name. In-network consumers reach this service by its compose service
+    # key `virtual-accelerator` (EPICS_CA_NAME_SERVERS, depends_on) — unchanged
+    # here — so unlike postgres this rename needs no network alias.
+    container_name: {{ osprey_labels.project_name }}-virtual-accelerator
     labels:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"

--- a/tests/deployment/test_compose_generator.py
+++ b/tests/deployment/test_compose_generator.py
@@ -958,3 +958,202 @@ def test_host_python_env_path_would_bake_host_interpreter_into_mcp_command() -> 
         controls_server = next(s for s in ctx["servers"] if s["name"] == "controls")
         assert controls_server["command"] == host_python
         assert controls_server["command"] != sys.executable
+
+
+# ---------------------------------------------------------------------------
+# postgresql service: per-project container_name (concurrent-deploy safety)
+#
+# `container_name` is a HOST-GLOBAL docker identifier, so two OSPREY projects
+# deploying postgres on one host collide on a hardcoded name (they serialize on
+# the build/up). The service key `postgresql` doubles as the intra-network DNS
+# name, but the ARIEL DSN (`postgresql://ariel:ariel@ariel-postgres:5432/ariel`)
+# resolves the host `ariel-postgres`, which today works ONLY because it is the
+# container_name. Namespacing the container_name per-project must therefore keep
+# `ariel-postgres` resolvable via an explicit network alias, or every in-network
+# DSN consumer breaks with "could not translate host name".
+# ---------------------------------------------------------------------------
+def _render_postgres_template(project_name: str) -> str:
+    from importlib import resources
+
+    from jinja2 import Template
+
+    tpl = resources.files("osprey").joinpath("templates/services/postgresql/docker-compose.yml.j2")
+    template = Template(tpl.read_text(encoding="utf-8"))
+    return template.render(
+        services={"postgresql": {"port_host": 5432}},
+        deployment={},
+        system={"timezone": "UTC"},
+        osprey_labels={
+            "project_name": project_name,
+            "project_root": f"/r/{project_name}",
+            "deployed_at": "now",
+        },
+        osprey_version="",
+    )
+
+
+def test_postgres_container_name_is_project_namespaced() -> None:
+    """Two projects render distinct, project-scoped postgres container names.
+
+    A hardcoded `container_name: ariel-postgres` is host-global, so two projects
+    deploying postgres on one host collide and serialize. The name must carry the
+    project so concurrent deploys don't fight over one identifier.
+    """
+    svc_a = yaml.safe_load(_render_postgres_template("proj-a"))["services"]["postgresql"]
+    svc_b = yaml.safe_load(_render_postgres_template("proj-b"))["services"]["postgresql"]
+
+    assert svc_a["container_name"] == "proj-a-ariel-postgres", svc_a["container_name"]
+    assert svc_b["container_name"] == "proj-b-ariel-postgres", svc_b["container_name"]
+    assert svc_a["container_name"] != svc_b["container_name"], (
+        "two projects must get distinct postgres container names or they collide "
+        "on one host and cannot deploy concurrently"
+    )
+
+
+def test_postgres_preserves_ariel_postgres_dns_alias() -> None:
+    """`ariel-postgres` stays resolvable as a network alias after namespacing.
+
+    The default ARIEL DSN hosts `ariel-postgres`; namespacing the container_name
+    must not break that hostname. An explicit `ariel-postgres` alias on
+    osprey-network keeps in-network DSN consumers resolving regardless of the
+    now-unique container_name.
+    """
+    svc = yaml.safe_load(_render_postgres_template("proj-a"))["services"]["postgresql"]
+
+    aliases = svc["networks"]["osprey-network"]["aliases"]
+    assert "ariel-postgres" in aliases, (
+        "postgres must keep the `ariel-postgres` network alias so the ARIEL DSN "
+        f"hostname resolves after the container_name is namespaced; got {aliases}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# sibling system-1 services: per-project container_name (concurrent-deploy safety)
+#
+# Every deployed system-1 service shares postgres's problem: `container_name` is
+# a HOST-GLOBAL docker identifier, so two OSPREY projects deploying the same
+# service on one host collide on a hardcoded name and cannot come up
+# concurrently. Unlike postgres, these siblings are reached IN-NETWORK only by
+# their compose *service key* (`virtual-accelerator`, `event-dispatcher`,
+# `dispatch-worker-1`, `bluesky-bridge`, `tiled`) — never by container_name — so
+# namespacing the container_name needs no network alias. The service key (and
+# thus every depends_on / EPICS_CA_NAME_SERVERS / tiled URI / dispatch route)
+# is left untouched; only the host-global container_name is namespaced.
+# ---------------------------------------------------------------------------
+def _render_service_template(rel_path: str, project_name: str, **overrides: object) -> str:
+    """Render a service compose template with a broad, sibling-agnostic context.
+
+    Mirrors ``_render_postgres_template`` but generalized: it supplies enough
+    context for any system-1 service template and lets a caller override any top
+    key (e.g. ``services`` to flip ``tiled_enabled`` or bump ``worker_count``).
+    """
+    from importlib import resources
+
+    from jinja2 import Template
+
+    tpl = resources.files("osprey").joinpath(f"templates/services/{rel_path}")
+    template = Template(tpl.read_text(encoding="utf-8"))
+    ctx: dict = {
+        "services": {
+            "virtual_accelerator": {"port": 5064},
+            "event_dispatcher": {"port": 8020},
+            "dispatch_worker": {"worker_count": 1, "workspace_mode": "isolated"},
+            "bluesky": {"port": 8090},
+        },
+        "deployment": {},
+        "system": {"timezone": "UTC"},
+        "osprey_labels": {
+            "project_name": project_name,
+            "project_root": f"/r/{project_name}",
+            "deployed_at": "now",
+        },
+        "osprey_version": "",
+        "osprey_env_present": False,
+        "deployed_services": [],
+        "control_system": {},
+    }
+    ctx.update(overrides)
+    return template.render(**ctx)
+
+
+# (template rel-path, compose service key, expected container_name suffix, render overrides)
+_SIBLING_SERVICES = [
+    ("virtual_accelerator/docker-compose.yml.j2", "virtual-accelerator", "virtual-accelerator", {}),
+    ("event_dispatcher/docker-compose.yml.j2", "event-dispatcher", "event-dispatcher", {}),
+    ("dispatch_worker/docker-compose.yml.j2", "dispatch-worker-1", "dispatch-worker-1", {}),
+    ("bluesky/docker-compose.yml.j2", "bluesky-bridge", "bluesky-bridge", {}),
+    (
+        "bluesky/docker-compose.yml.j2",
+        "tiled",
+        "bluesky-tiled",
+        {"services": {"bluesky": {"port": 8090, "tiled_enabled": True}}},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("rel_path", "service_key", "suffix", "overrides"),
+    _SIBLING_SERVICES,
+    ids=[s[1] for s in _SIBLING_SERVICES],
+)
+def test_sibling_container_name_is_project_namespaced(
+    rel_path: str, service_key: str, suffix: str, overrides: dict
+) -> None:
+    """Two projects render distinct, project-scoped sibling container names.
+
+    A hardcoded `container_name: osprey-<svc>` is host-global, so two projects
+    deploying the same service on one host collide and cannot deploy
+    concurrently. Every system-1 service must carry the project in its
+    container_name, exactly as postgres does.
+    """
+    svc_a = yaml.safe_load(_render_service_template(rel_path, "proj-a", **overrides))
+    svc_b = yaml.safe_load(_render_service_template(rel_path, "proj-b", **overrides))
+
+    name_a = svc_a["services"][service_key]["container_name"]
+    name_b = svc_b["services"][service_key]["container_name"]
+
+    assert name_a == f"proj-a-{suffix}", name_a
+    assert name_b == f"proj-b-{suffix}", name_b
+    assert name_a != name_b, (
+        f"two projects must get distinct `{suffix}` container names or they "
+        "collide on one host and cannot deploy concurrently"
+    )
+
+
+def test_sibling_container_names_carry_no_stale_osprey_prefix() -> None:
+    """No system-1 sibling template ships a bare host-global `osprey-<svc>` name.
+
+    Guards against a future service (or a reverted edit) reintroducing the
+    static prefix that defeats compose's per-project scoping.
+    """
+    for rel_path, service_key, _suffix, overrides in _SIBLING_SERVICES:
+        svc = yaml.safe_load(_render_service_template(rel_path, "proj-a", **overrides))
+        container_name = svc["services"][service_key]["container_name"]
+        assert not container_name.startswith("osprey-"), (
+            f"{service_key} still renders a host-global `{container_name}`; "
+            "namespace it with the project name"
+        )
+
+
+def test_multi_worker_dispatch_container_names_are_each_namespaced() -> None:
+    """Every dispatch worker replica gets its own project-scoped container name.
+
+    The worker service is a Jinja `for` loop over `worker_count`; namespacing
+    must apply per-replica, not just to worker-1.
+    """
+    rendered = yaml.safe_load(
+        _render_service_template(
+            "dispatch_worker/docker-compose.yml.j2",
+            "proj-a",
+            services={"dispatch_worker": {"worker_count": 2, "workspace_mode": "isolated"}},
+        )
+    )
+    names = {
+        key: svc["container_name"]
+        for key, svc in rendered["services"].items()
+        if key.startswith("dispatch-worker-")
+    }
+    assert names == {
+        "dispatch-worker-1": "proj-a-dispatch-worker-1",
+        "dispatch-worker-2": "proj-a-dispatch-worker-2",
+    }, names

--- a/tests/e2e/_orm_stack.py
+++ b/tests/e2e/_orm_stack.py
@@ -58,9 +58,11 @@ BRIDGE_PORT = 18102
 
 BRIDGE_IMAGE = "osprey-bluesky-bridge:local"
 VA_IMAGE = "osprey-va:local"
-BRIDGE_CONTAINER = "osprey-bluesky-bridge"
-VA_CONTAINER = "osprey-virtual-accelerator"
-TILED_CONTAINER = "osprey-bluesky-tiled"
+# Container names are intentionally NOT module constants here: a deployed
+# service's container_name is ``<project>-<service>``
+# (services/*/docker-compose.yml.j2), so it depends on the caller's
+# project_name. Derive it at the call site (e.g. ``f"{project_name}-bluesky-bridge"``)
+# rather than hardcode a host-global name that is wrong for any non-default project.
 
 BUILD_TIMEOUT_SEC = 300
 

--- a/tests/e2e/test_dispatch_deploy.py
+++ b/tests/e2e/test_dispatch_deploy.py
@@ -48,6 +48,14 @@ DEPLOY_UP_TIMEOUT_SEC = 900
 HEALTH_TIMEOUT_SEC = 180.0
 RUN_TIMEOUT_SEC = 300.0
 
+# The fixture builds/deploys under this project name; compose renders each
+# container_name as ``<project>-<service>`` (services/*/docker-compose.yml.j2),
+# so derive the docker targets below rather than hardcode host-global names that
+# break the moment the templates are namespaced per-project.
+PROJECT_NAME = "proj"
+DISPATCHER_CONTAINER = f"{PROJECT_NAME}-event-dispatcher"
+WORKER_CONTAINER = f"{PROJECT_NAME}-dispatch-worker-1"
+
 # hello-dispatch / triage-event / save-report should complete; denied-tool-demo
 # must be rejected by the server-side denylist.
 _COMPLETING_TRIGGERS = ("hello-dispatch", "triage-event", "save-report")
@@ -98,13 +106,13 @@ def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
 
     osprey_bin = _find_osprey_console_script()
     base = tmp_path_factory.mktemp("dispatch_deploy_build")
-    project_dir = base / "proj"
+    project_dir = base / PROJECT_NAME
 
     build = _run(
         [
             str(osprey_bin),
             "build",
-            "proj",
+            PROJECT_NAME,
             "--preset",
             "control-assistant",
             "--set",
@@ -198,13 +206,21 @@ def _dump_stack_diagnostics(context: str) -> str:
     """
     lines = [f"=== stack diagnostics ({context}) ==="]
     ps = subprocess.run(
-        ["docker", "ps", "-a", "--filter", "name=osprey-", "--format", "{{.Names}}\t{{.Status}}"],
+        [
+            "docker",
+            "ps",
+            "-a",
+            "--filter",
+            f"name={PROJECT_NAME}-",
+            "--format",
+            "{{.Names}}\t{{.Status}}",
+        ],
         capture_output=True,
         text=True,
         timeout=30,
     )
     lines.append("containers:\n" + (ps.stdout.strip() or ps.stderr.strip() or "(none)"))
-    for name in ("osprey-dispatch-worker-1", "osprey-event-dispatcher"):
+    for name in (WORKER_CONTAINER, DISPATCHER_CONTAINER):
         logs = subprocess.run(
             ["docker", "logs", "--tail", "40", name],
             capture_output=True,
@@ -275,7 +291,7 @@ def _worker_artifact_files() -> list[str]:
     only claimed success — see the assertion in ``test_full_stack_dispatch``.
     """
     proc = subprocess.run(
-        ["docker", "exec", "osprey-dispatch-worker-1", "ls", "/app/proj/_agent_data/artifacts"],
+        ["docker", "exec", WORKER_CONTAINER, "ls", f"/app/{PROJECT_NAME}/_agent_data/artifacts"],
         capture_output=True,
         text=True,
         timeout=30,

--- a/tests/e2e/test_dispatch_overlay_visibility.py
+++ b/tests/e2e/test_dispatch_overlay_visibility.py
@@ -67,10 +67,15 @@ RUN_TIMEOUT_SEC = 300.0
 
 # The unified worker runs the PROJECT image; its in-container project dir and
 # artifact dir are named after the project ("proj"), not the old "/app/project".
-WORKER_CONTAINER = "osprey-dispatch-worker-1"
-WORKER_ARTIFACT_DIR = "/app/proj/_agent_data/artifacts"
+# The compose template renders the worker container_name as
+# ``<project>-dispatch-worker-1`` (services/dispatch_worker/docker-compose.yml.j2),
+# so derive both it and the in-container paths from the one project name rather
+# than hardcode a host-global name that breaks once the template is namespaced.
+PROJECT_NAME = "proj"
+WORKER_CONTAINER = f"{PROJECT_NAME}-dispatch-worker-1"
+WORKER_ARTIFACT_DIR = f"/app/{PROJECT_NAME}/_agent_data/artifacts"
 # The worker persists each completed run (full result incl. tool_calls) here.
-WORKER_DISPATCH_DIR = "/app/proj/_agent_data/dispatch"
+WORKER_DISPATCH_DIR = f"/app/{PROJECT_NAME}/_agent_data/dispatch"
 
 # The named volume the worker mounts at ``/app/proj/_agent_data``. Its name is
 # ``<compose-project>_<volume>_<replica>`` = ``services`` (the compose files live
@@ -248,13 +253,13 @@ def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
 
     osprey_bin = _find_osprey_console_script()
     base = tmp_path_factory.mktemp("dispatch_overlay_build")
-    project_dir = base / "proj"
+    project_dir = base / PROJECT_NAME
 
     build = _run(
         [
             str(osprey_bin),
             "build",
-            "proj",
+            PROJECT_NAME,
             "--preset",
             "control-assistant",
             "--set",
@@ -584,7 +589,7 @@ def _diagnostics(dispatch_id: str, run: dict, record: dict, artifact_body: str) 
     lines.append(f"text_output[:500]={(record.get('text_output') or '')[:500]!r}")
     lines.append(f"artifact_body[:800]={artifact_body[:800]!r}")
     skills = subprocess.run(
-        ["docker", "exec", WORKER_CONTAINER, "ls", "-la", "/app/proj/.claude/skills"],
+        ["docker", "exec", WORKER_CONTAINER, "ls", "-la", f"/app/{PROJECT_NAME}/.claude/skills"],
         capture_output=True,
         text=True,
     )

--- a/tests/e2e/test_scan_deploy.py
+++ b/tests/e2e/test_scan_deploy.py
@@ -71,7 +71,12 @@ import pytest
 BRIDGE_PORT = 18090
 BRIDGE_URL = f"http://localhost:{BRIDGE_PORT}"
 BRIDGE_IMAGE = "osprey-bluesky-bridge:local"
-BRIDGE_CONTAINER = "osprey-bluesky-bridge"
+# The fixture builds/deploys under this project name; the compose template
+# renders the bridge container_name as ``<project>-bluesky-bridge``
+# (services/bluesky/docker-compose.yml.j2), so derive it rather than hardcode a
+# host-global name that breaks the moment the template is namespaced per-project.
+PROJECT_NAME = "proj"
+BRIDGE_CONTAINER = f"{PROJECT_NAME}-bluesky-bridge"
 
 DEPLOY_UP_TIMEOUT_SEC = 600
 HEALTH_TIMEOUT_SEC = 120.0
@@ -126,13 +131,13 @@ def deployed_bridge(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
     """Build + ``osprey deploy up --dev`` a bluesky-bridge-enabled project; tear down after."""
     osprey_bin = _find_osprey_console_script()
     base = tmp_path_factory.mktemp("scan_deploy_build")
-    project_dir = base / "proj"
+    project_dir = base / PROJECT_NAME
 
     build = _run(
         [
             str(osprey_bin),
             "build",
-            "proj",
+            PROJECT_NAME,
             "--preset",
             "hello-world",
             "--set",

--- a/tests/e2e/test_tiled_roundtrip.py
+++ b/tests/e2e/test_tiled_roundtrip.py
@@ -23,7 +23,7 @@ vacuously.
 Container safety: every docker invocation below names an exact container or
 image — never a wildcard, never ``system prune``/``--volumes``. Teardown
 goes through ``osprey deploy down``, never a raw ``docker rm`` sweep. The
-restart step names ``osprey-bluesky-bridge`` only; ``osprey deploy restart``
+restart step names the ``<project>-bluesky-bridge`` container only; ``osprey deploy restart``
 is never used here because it bounces every service, including Tiled, which
 would defeat the whole proof.
 
@@ -56,8 +56,13 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 BRIDGE_PORT = 18101
 BRIDGE_URL = f"http://localhost:{BRIDGE_PORT}"
 BRIDGE_IMAGE = "osprey-bluesky-bridge:local"
-BRIDGE_CONTAINER = "osprey-bluesky-bridge"
-TILED_CONTAINER = "osprey-bluesky-tiled"
+# The fixture builds/deploys under this project name; the compose template
+# renders each container_name as ``<project>-<service>``
+# (services/bluesky/docker-compose.yml.j2), so derive them rather than hardcode
+# host-global names that break the moment the template is namespaced per-project.
+PROJECT_NAME = "proj"
+BRIDGE_CONTAINER = f"{PROJECT_NAME}-bluesky-bridge"
+TILED_CONTAINER = f"{PROJECT_NAME}-bluesky-tiled"
 
 # The demo scanner's mock device factory (devices/mock.py's build_devices())
 # defaults to a single "det1" MockDetector when the bridge's app.py lifespan
@@ -133,7 +138,7 @@ def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
     """Build + co-deploy the bridge and Tiled; yield the project directory."""
     osprey_bin = _find_osprey_console_script()
     base = tmp_path_factory.mktemp("tiled_roundtrip_build")
-    project_dir = base / "proj"
+    project_dir = base / PROJECT_NAME
 
     # `dispatch: null` drops control-assistant's default event-dispatcher
     # stack (Node + Claude CLI image) -- irrelevant to this proof and far
@@ -166,7 +171,7 @@ def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
         [
             str(osprey_bin),
             "build",
-            "proj",
+            PROJECT_NAME,
             "--preset",
             "control-assistant",
             "--override",

--- a/tests/e2e/test_va_substrate_equivalence.py
+++ b/tests/e2e/test_va_substrate_equivalence.py
@@ -80,14 +80,19 @@ HOST_CA_RESULT_MARKER = "__HOST_CA_RESULT__"
 # at this value, or the two silently drift apart.
 VA_CA_PORT = 5064
 VA_IMAGE = "osprey-va:local"
-VA_CONTAINER = "osprey-virtual-accelerator"
+# The fixture builds/deploys under this project name; the compose templates
+# render each service's container_name as ``<project>-<service>``
+# (services/*/docker-compose.yml.j2), so derive them rather than hardcode
+# host-global names that break the moment the templates are namespaced per-project.
+PROJECT_NAME = "proj"
+VA_CONTAINER = f"{PROJECT_NAME}-virtual-accelerator"
 
 # Deliberately non-default (avoids colliding with test_scan_deploy.py's 18090
 # on a shared dev machine — see that module's docstring).
 BRIDGE_PORT = 18099
 BRIDGE_URL = f"http://localhost:{BRIDGE_PORT}"
 BRIDGE_IMAGE = "osprey-bluesky-bridge:local"
-BRIDGE_CONTAINER = "osprey-bluesky-bridge"
+BRIDGE_CONTAINER = f"{PROJECT_NAME}-bluesky-bridge"
 
 # Device names wired into the bridge via BLUESKY_EPICS_MOTORS/_DETECTORS —
 # arbitrary, resolved against explicit PV addresses (see _write_scan_env
@@ -266,7 +271,7 @@ class DeployedStack:
 def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[DeployedStack]:
     osprey_bin = _find_osprey_console_script()
     base = tmp_path_factory.mktemp("va_substrate_build")
-    project_dir = base / "proj"
+    project_dir = base / PROJECT_NAME
 
     # Extends control-assistant (which already ships data/simulation/machine.json
     # + channel_limits.json) with the one flag it doesn't default to: the
@@ -289,7 +294,7 @@ def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Deploye
         [
             str(osprey_bin),
             "build",
-            "proj",
+            PROJECT_NAME,
             "--preset",
             "control-assistant",
             "--override",


### PR DESCRIPTION
## Problem

`container_name` is a **host-global** docker identifier, so two OSPREY projects deploying the same service on one host collide on a single name and cannot come up concurrently. Only postgres was previously namespaced; the sibling services (virtual accelerator, event dispatcher, dispatch workers, bluesky bridge, tiled) still shipped static `osprey-<service>` names — the same defect, one service over, plus a third naming scheme in the templates.

## Change

Namespace **every** system-1 service container as `<project>-<service>` in the compose templates, making the whole system uniform (and consistent with the scaffold system's existing `${facility.prefix}-<service>`).

The asymmetry that makes this safe:
- **In-network discovery is unaffected** — it resolves the compose *service key* (`depends_on`, `EPICS_CA_NAME_SERVERS: virtual-accelerator:5064`, `BLUESKY_TILED_URI: http://tiled:8000`, `dispatch_target: http://dispatch-worker-1`), never the container name. Service keys are untouched, so siblings need no network alias.
- **Postgres is the one exception** — its ARIEL DSN resolves the *container name* `ariel-postgres`, so it keeps an `ariel-postgres` network alias; the DSN hostname is preserved.

The deploy e2e tests are refactored to **derive** each container name from the project they build (a single `PROJECT_NAME` per file feeds the project dir, the build arg, and the container/exec targets), replacing hardcoded host-global literals so a test always targets the name the template renders. Three dead-and-wrong container constants in `_orm_stack.py` were removed.

## Verification

- New render tests reproduce the collision (red) then pass (green) for all five siblings + multi-worker replicas, plus a guard against reintroducing a bare `osprey-` prefix.
- 118 deployment tests green, including every `@ariel-postgres:5432` DSN-hostname assertion — DSN contract provably intact.
- All touched e2e tests collect cleanly; 123 CLI tests green; ruff clean.