### PR TITLE
feat: session-tier scan-plan authoring with a validation sandbox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,19 +492,21 @@ jobs:
           # Tier 3 per-preset agentic flows live in their own matrix job
           # (agentic-per-preset). The full Docker-stack tests
           # (dispatch-deploy-e2e, scan-deploy-e2e, tiled-roundtrip-e2e,
-          # va-substrate-equivalence-e2e) and the Dockerfile e2e
-          # (dockerfile-e2e) each have their own job because they build
-          # container images. Exclude all six here to avoid
+          # va-substrate-equivalence-e2e, scan-catalog-e2e) and the
+          # Dockerfile e2e (dockerfile-e2e) each have their own job because
+          # they build container images. Exclude all seven here to avoid
           # double-execution. NOTE: "--ignore" means "not in this
           # secret-gated LLM lane," NOT "not tested" — every ignored file
-          # below runs in its own secret-free job on every PR.
+          # below runs in its own secret-free job on every PR
+          # (scan-catalog-e2e is advisory-only — see that job's comment).
           uv run pytest tests/e2e/ -v --tb=short \
             --ignore=tests/e2e/test_preset_agentic.py \
             --ignore=tests/e2e/test_dispatch_deploy.py \
             --ignore=tests/e2e/test_scan_deploy.py \
             --ignore=tests/e2e/test_dockerfile_e2e.py \
             --ignore=tests/e2e/test_tiled_roundtrip.py \
-            --ignore=tests/e2e/test_va_substrate_equivalence.py
+            --ignore=tests/e2e/test_va_substrate_equivalence.py \
+            --ignore=tests/e2e/test_scan_catalog_e2e.py
         fi
 
   deploy-e2e:
@@ -731,6 +733,42 @@ jobs:
     - name: Run Tiled roundtrip E2E
       run: |
         uv run pytest tests/e2e/test_tiled_roundtrip.py -v --tb=short
+
+  scan-catalog-e2e:
+    name: Scan Catalog E2E (layered plan catalog, full Docker stack)
+    runs-on: ubuntu-latest
+    # ADVISORY LANE: deliberately NOT in all-checks-passed's `needs:` list —
+    # read this job's own log to see whether it passed. Only run on PRs from
+    # same repo (mirrors scan-deploy-e2e/tiled-roundtrip-e2e gating). This
+    # job needs no secrets — the bridge never shells out to an LLM — and no
+    # amd64-emulated Virtual Accelerator image (demo_scanner mode: real
+    # RunEngine, mock devices, no EPICS), so it's comparable in weight to
+    # scan-deploy-e2e rather than va-substrate-equivalence-e2e.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+
+    - name: Set up Python
+      run: uv python install 3.11
+
+    - name: Set up Docker Compose
+      uses: docker/setup-compose-action@v2
+
+    - name: Install osprey
+      run: uv sync --extra dev
+
+    - name: Run scan catalog E2E
+      run: |
+        uv run pytest tests/e2e/test_scan_catalog_e2e.py -v --tb=short
 
   dockerfile-e2e:
     name: Dockerfile E2E (generated container image)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,13 +492,15 @@ jobs:
           # Tier 3 per-preset agentic flows live in their own matrix job
           # (agentic-per-preset). The full Docker-stack tests
           # (dispatch-deploy-e2e, scan-deploy-e2e, tiled-roundtrip-e2e,
-          # va-substrate-equivalence-e2e, scan-catalog-e2e) and the
-          # Dockerfile e2e (dockerfile-e2e) each have their own job because
-          # they build container images. Exclude all seven here to avoid
+          # va-substrate-equivalence-e2e, scan-catalog-e2e,
+          # scan-sandbox-escape-e2e) and the Dockerfile e2e
+          # (dockerfile-e2e) each have their own job because they build
+          # container images. Exclude all eight here to avoid
           # double-execution. NOTE: "--ignore" means "not in this
           # secret-gated LLM lane," NOT "not tested" — every ignored file
           # below runs in its own secret-free job on every PR
-          # (scan-catalog-e2e is advisory-only — see that job's comment).
+          # (scan-catalog-e2e and scan-sandbox-escape-e2e are advisory-only —
+          # see those jobs' comments).
           uv run pytest tests/e2e/ -v --tb=short \
             --ignore=tests/e2e/test_preset_agentic.py \
             --ignore=tests/e2e/test_dispatch_deploy.py \
@@ -506,7 +508,8 @@ jobs:
             --ignore=tests/e2e/test_dockerfile_e2e.py \
             --ignore=tests/e2e/test_tiled_roundtrip.py \
             --ignore=tests/e2e/test_va_substrate_equivalence.py \
-            --ignore=tests/e2e/test_scan_catalog_e2e.py
+            --ignore=tests/e2e/test_scan_catalog_e2e.py \
+            --ignore=tests/e2e/test_scan_sandbox_escape_e2e.py
         fi
 
   deploy-e2e:
@@ -769,6 +772,45 @@ jobs:
     - name: Run scan catalog E2E
       run: |
         uv run pytest tests/e2e/test_scan_catalog_e2e.py -v --tb=short
+
+  scan-sandbox-escape-e2e:
+    name: Scan Sandbox Escape E2E (session-plan authoring gates, full Docker stack)
+    runs-on: ubuntu-latest
+    # ADVISORY LANE: deliberately NOT in all-checks-passed's `needs:` list —
+    # read this job's own log to see whether it passed (mirrors
+    # scan-catalog-e2e's advisory precedent). Only run on PRs from same repo
+    # (mirrors scan-deploy-e2e/va-substrate-equivalence-e2e gating). This job
+    # needs no secrets — neither the bridge nor the virtual accelerator
+    # shells out to an LLM — but DOES need the amd64-emulated Virtual
+    # Accelerator image (the negative case's IOC no-write proof reads a real
+    # corrector setpoint over Channel Access, independent of the bridge), so
+    # it's as heavy as va-substrate-equivalence-e2e, not scan-catalog-e2e.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 45
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+
+    - name: Set up Python
+      run: uv python install 3.11
+
+    - name: Set up Docker Compose
+      uses: docker/setup-compose-action@v2
+
+    - name: Install osprey
+      run: uv sync --extra dev
+
+    - name: Run scan sandbox escape E2E
+      run: |
+        uv run pytest tests/e2e/test_scan_sandbox_escape_e2e.py -v --tb=short
 
   dockerfile-e2e:
     name: Dockerfile E2E (generated container image)

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -1457,6 +1457,13 @@ def _inject_bluesky(bluesky: BlueskyConfig, project_path: Path) -> None:
         "tiled_port": bluesky.tiled_port,
         "demo_scanner": bluesky.demo_scanner,
     }
+    if bluesky.plan_dir:
+        # Only written when configured — its absence is what keeps a
+        # bridge-only deploy (no facility plan directory) rendering exactly
+        # as before: the compose template's {% if %} guard reads this same
+        # key, so an unset plan_dir means no mount and no BLUESKY_PLAN_DIRS
+        # env var at all (Task 1.4).
+        config["services"]["bluesky"]["plan_dir"] = bluesky.plan_dir
     deployed = config.get("deployed_services", []) or []
     if "bluesky" not in [str(s) for s in deployed]:
         deployed.append("bluesky")
@@ -1478,6 +1485,12 @@ def _inject_bluesky(bluesky: BlueskyConfig, project_path: Path) -> None:
     )
     if bluesky.tiled_enabled:
         logger.info("    Tiled:      enabled on port %d", bluesky.tiled_port)
+    if bluesky.plan_dir:
+        logger.info(
+            "    Plan dir:   %s mounted read-only into the bridge; its plans "
+            "load as the 'facility' trust tier (BLUESKY_PLAN_DIRS)",
+            bluesky.plan_dir,
+        )
     if bluesky.demo_scanner:
         logger.warning(
             "    Demo mode:  BLUESKY_DEMO_SCANNER is set — the bridge runs a real "

--- a/src/osprey/cli/build_profile.py
+++ b/src/osprey/cli/build_profile.py
@@ -124,6 +124,13 @@ class BlueskyConfig:
     this on would silently override real device/plan wiring with an
     in-memory mock scanner.
     """
+    plan_dir: str | None = None
+    """Optional host directory of facility scan-plan files (Task 1.4),
+    bind-mounted read-only into the bridge container and surfaced to the
+    plan loader as a ``BLUESKY_PLAN_DIRS`` (facility-tier) layer — see
+    ``plan_loader.py``. ``None`` (default) deploys the bridge with no
+    facility plan directory, matching every prior bluesky-only build.
+    """
 
 
 @dataclass
@@ -732,6 +739,7 @@ def _parse_profile(raw: dict[str, Any]) -> BuildProfile:
             tiled_enabled=bluesky_raw.get("tiled_enabled", False),
             tiled_port=bluesky_raw.get("tiled_port", 8091),
             demo_scanner=bluesky_raw.get("demo_scanner", False),
+            plan_dir=bluesky_raw.get("plan_dir"),
         )
 
     va_raw = raw.get("virtual_accelerator")

--- a/src/osprey/cli/templates/manifest.py
+++ b/src/osprey/cli/templates/manifest.py
@@ -64,6 +64,7 @@ REGEN_TRACKED_FILES = [
     ".claude/skills/session-report/reference.md",
     ".claude/skills/setup-mode/SKILL.md",
     ".claude/skills/demo-gallery/SKILL.md",
+    ".claude/skills/writing-bluesky-plans/SKILL.md",
     ".claude/rules/timezone.md",
     ".claude/output-styles/control-operator.md",
 ]

--- a/src/osprey/mcp_server/scan/server.py
+++ b/src/osprey/mcp_server/scan/server.py
@@ -2,9 +2,11 @@
 
 FastMCP server exposing Bluesky scan control as a thin HTTP client of the
 facility-side Bluesky bridge: list scan plans, create a scan intent, check run
-status, launch (promote) an intent to a running scan, and stop a run. This
-module and its tools make no bluesky/ophyd/tiled imports — every operation is
-an HTTP request to the bridge (see ``osprey.services.bluesky_bridge``).
+status, launch (promote) an intent to a running scan, stop a run, and author
+(write_bluesky_plan) plus validate (validate_bluesky_plan) a session-tier plan
+file. This module and its tools make no bluesky/ophyd/tiled imports — every
+operation is an HTTP request to the bridge (see
+``osprey.services.bluesky_bridge``).
 
 Usage:
     python -m osprey.mcp_server.scan
@@ -49,6 +51,7 @@ def create_server() -> FastMCP:
     # Import tool modules (each registers itself via @mcp.tool())
     with startup_timer("tool_imports"):
         from osprey.mcp_server.scan.tools import (  # noqa: F401
+            authoring,
             launch,
             read_tools,
             stop,

--- a/src/osprey/mcp_server/scan/tools/authoring.py
+++ b/src/osprey/mcp_server/scan/tools/authoring.py
@@ -1,0 +1,146 @@
+"""MCP tools: author and validate a session-tier Bluesky plan file.
+
+Both tools are thin HTTP clients of the bridge's authoring routes and reach
+NO hardware — ``write_bluesky_plan`` only writes a file (never imports or
+execs it), and ``validate_bluesky_plan``'s dry run drives mock devices only,
+in a subprocess with ``EPICS_CA_*`` neutralized (see
+``osprey.services.bluesky_bridge.plan_validation``). Both therefore work
+identically whether ``control_system.writes_enabled`` is on or off, and
+neither carries the kill-switch (``_WRITES_CHECK``) hook — see the ``scan``
+``ServerDefinition`` in ``registry/mcp.py``. Both are still approval-gated
+(``permissions_ask``) so a human sees every authored/validated plan body.
+
+==========================  =================================================
+Tool                        Bridge endpoint
+==========================  =================================================
+write_bluesky_plan          POST /plans/session
+validate_bluesky_plan       POST /plans/validate
+==========================  =================================================
+
+Same conventions as ``read_tools.py``: ``async def``, JSON string return
+(``json.dumps`` / ``make_error``), blocking HTTP dispatched via
+``anyio.to_thread.run_sync``, and the shared ``_http_post_json`` /
+``bridge_error_message`` helpers from ``scan/server_context.py``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import anyio
+
+from osprey.mcp_server.errors import make_error
+from osprey.mcp_server.scan.server import mcp
+from osprey.mcp_server.scan.server_context import _http_post_json, bridge_error_message
+
+
+# ---------------------------------------------------------------------------
+# Tool 1: write a session-tier plan file
+# ---------------------------------------------------------------------------
+@mcp.tool()
+async def write_bluesky_plan(
+    name: str,
+    category: str,
+    required_devices: list[str],
+    writes: bool,
+    body: str,
+    description: str = "",
+) -> str:
+    """Author a session-tier scan plan file on the bridge. Reaches NO hardware.
+
+    The bridge assembles a `PLAN_METADATA = {...}` block from
+    ``name``/``description``/``category``/``required_devices``/``writes`` and
+    prepends it to ``body`` (your own ``PARAMS`` + ``build_plan`` source, per
+    the layered directory catalog's file contract), writing the combined text
+    as one file. The bridge NEVER imports or execs this file — it is inert
+    until validate_bluesky_plan passes it and, later, a human approves
+    launching it. Re-authoring an existing ``name`` overwrites the file and
+    invalidates any prior passing validation (its content hash changes).
+
+    Args:
+        name: Plan name — must be a valid Python identifier; doubles as the
+            on-disk file stem and the generated metadata's ``name`` field.
+        category: Free-text grouping shown to operators (e.g. "accelerator").
+        required_devices: Names of the `PARAMS` fields naming devices the
+            plan drives/reads (e.g. ``["correctors", "detectors"]``).
+        writes: Whether this plan moves a device (vs. read-only). Authoring
+            metadata only — has no effect on whether writes actually happen;
+            that is governed entirely by ``control_system.writes_enabled``.
+        body: Your plan's own source: a `PARAMS` pydantic model (optional)
+            and a `build_plan(devices, params)` callable, exactly as a
+            directory-layer plan file needs — see the response_matrix
+            exemplar plan for the expected shape.
+        description: Human-readable summary of what the plan does.
+
+    Returns:
+        JSON ``{"name", "content_hash"}`` on success — pass ``name`` to
+        validate_bluesky_plan next. On rejection (e.g. an invalid ``name``),
+        an error envelope naming what to fix.
+    """
+    payload = {
+        "name": name,
+        "description": description,
+        "category": category,
+        "required_devices": required_devices,
+        "writes": writes,
+        "body": body,
+    }
+    status, resp_body = await anyio.to_thread.run_sync(_http_post_json, "/plans/session", payload)
+    if status != 200:
+        return make_error(
+            "plan_write_rejected",
+            bridge_error_message(resp_body, status),
+            [
+                "Check name is a valid Python identifier (used as the file stem).",
+                "Check category/required_devices/writes are present and well-typed.",
+            ],
+        )
+    return json.dumps(resp_body)
+
+
+# ---------------------------------------------------------------------------
+# Tool 2: validate a session-tier plan file
+# ---------------------------------------------------------------------------
+@mcp.tool()
+async def validate_bluesky_plan(
+    name: str,
+    sample_args: dict | None = None,
+    dry_run_timeout: float = 30.0,
+) -> str:
+    """Validate a session plan already written by write_bluesky_plan. Reaches NO hardware.
+
+    Runs the bridge's three-stage validator (static import/pattern allowlist,
+    then a mock-device dry run) against the CURRENT on-disk content of the
+    named session plan file — never a body you pass here directly, so the
+    validated bytes are always exactly the file's bytes. The dry run drives
+    in-process mock devices only, in a subprocess whose ``EPICS_CA_*``
+    variables are neutralized; it never reaches a real device regardless of
+    ``control_system.writes_enabled``. A passing validation is recorded by
+    content hash so the plan becomes loadable/promotable (tasks 2.4/2.5);
+    editing the file afterward changes its hash and drops the record, so it
+    must be re-validated.
+
+    Args:
+        name: Session plan name, as passed to write_bluesky_plan.
+        sample_args: Sample `PARAMS` field values used to build the dry run's
+            generator and mock devices (e.g. device names, point counts).
+            Omit only for a `PARAMS` with no required fields.
+        dry_run_timeout: Seconds the dry-run subprocess is given to drive the
+            plan to completion.
+
+    Returns:
+        JSON ``{"passed", "reasons", "content_hash"}``. ``reasons`` is empty
+        on a pass; on a failure it names every rejection from whichever stage
+        stopped the plan.
+    """
+    payload = {"name": name, "sample_args": sample_args, "dry_run_timeout": dry_run_timeout}
+    status, resp_body = await anyio.to_thread.run_sync(_http_post_json, "/plans/validate", payload)
+    if status == 404:
+        return make_error(
+            "unknown_session_plan",
+            bridge_error_message(resp_body, status),
+            ["Call write_bluesky_plan first to author this plan name."],
+        )
+    if status != 200:
+        return make_error("bluesky_bridge_error", bridge_error_message(resp_body, status))
+    return json.dumps(resp_body)

--- a/src/osprey/mcp_server/scan/tools/read_tools.py
+++ b/src/osprey/mcp_server/scan/tools/read_tools.py
@@ -108,10 +108,19 @@ async def scan_status(run_id: str) -> str:
 async def list_scan_plans() -> str:
     """List the plans registered on the bridge.
 
+    Each plan entry carries ``metadata`` (the plan's authoring-declared
+    ``PLAN_METADATA`` — description/category/required_devices/writes — or
+    ``null`` for a built-in that doesn't author one) and ``provenance`` (its
+    trust tier: ``shipped``/``preset``/``facility``/``session``/
+    ``unreviewed``, ascending ephemerality). Use these to prefer a
+    higher-provenance plan and to check ``required_devices``/``writes``
+    before selecting a plan for ``create_scan_intent``.
+
     Returns:
-        JSON ``{"status": "success", "plans": [...]}``. An empty list means
-        the facility has not injected a plan module (or this bridge version
-        does not yet support plan discovery).
+        JSON ``{"status": "success", "plans": [...]}``, each entry shaped
+        like ``{"name", "description", "schema", "metadata", "provenance"}``.
+        An empty list means the facility has not injected a plan module (or
+        this bridge version does not yet support plan discovery).
     """
     status, body = await anyio.to_thread.run_sync(_http_get_json, "/plans")
     if status != 200:

--- a/src/osprey/mcp_server/workspace/execution/sandbox_executor.py
+++ b/src/osprey/mcp_server/workspace/execution/sandbox_executor.py
@@ -26,6 +26,7 @@ import os
 import sys
 import time
 import uuid
+from collections.abc import Set as AbstractSet
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -171,7 +172,12 @@ _DANGEROUS_PATTERNS: list[tuple[str, str]] = [
 # ---------------------------------------------------------------------------
 # Validation
 # ---------------------------------------------------------------------------
-def validate_sandbox_code(code: str) -> tuple[bool, list[str]]:
+def validate_sandbox_code(
+    code: str,
+    *,
+    allowed_top_level: AbstractSet[str] = _ALLOWED_TOP_LEVEL,
+    dangerous_patterns: list[tuple[str, str]] = _DANGEROUS_PATTERNS,
+) -> tuple[bool, list[str]]:
     """Validate code for safety before sandboxed execution.
 
     Checks:
@@ -181,6 +187,15 @@ def validate_sandbox_code(code: str) -> tuple[bool, list[str]]:
 
     Args:
         code: Python source code to validate.
+        allowed_top_level: Top-level module names an ``import``/``import
+            from`` may reference. Defaults to this module's own
+            :data:`_ALLOWED_TOP_LEVEL` (the viz sandbox's whitelist) — pass a
+            different set (or frozenset) to reuse this function's syntax gate
+            and dangerous-pattern scan for another caller's own import policy
+            (e.g. the bluesky plan validator) without touching this module's
+            whitelist.
+        dangerous_patterns: ``(pattern, description)`` pairs scanned as plain
+            substrings. Defaults to this module's own :data:`_DANGEROUS_PATTERNS`.
 
     Returns:
         Tuple of (is_safe, list_of_violations). Empty violations list means safe.
@@ -198,16 +213,16 @@ def validate_sandbox_code(code: str) -> tuple[bool, list[str]]:
         if isinstance(node, ast.Import):
             for alias in node.names:
                 top = alias.name.split(".")[0]
-                if top not in _ALLOWED_TOP_LEVEL:
+                if top not in allowed_top_level:
                     violations.append(f"Import not allowed: '{alias.name}'")
         elif isinstance(node, ast.ImportFrom):
             if node.module:
                 top = node.module.split(".")[0]
-                if top not in _ALLOWED_TOP_LEVEL:
+                if top not in allowed_top_level:
                     violations.append(f"Import not allowed: 'from {node.module}'")
 
     # 3. Dangerous pattern scan (text-level)
-    for pattern, description in _DANGEROUS_PATTERNS:
+    for pattern, description in dangerous_patterns:
         if pattern in code:
             violations.append(f"Dangerous pattern: {description}")
 

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -52,6 +52,7 @@ skills:
   - setup-mode      # Toggle between interactive and automated operating modes
   - session-report  # Summarise session actions and outcomes to the logbook
   - demo-gallery    # Launch guided capability demonstrations
+  - writing-bluesky-plans  # Author, validate, and launch a session-tier scan plan (requires the scan MCP server)
 
 agents:
   - channel-finder          # Semantic search over channel databases (hierarchical)

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -307,7 +307,16 @@ FRAMEWORK_SERVERS: dict[str, ServerDefinition] = {
         ],
         # launch_scan starts a real scan (promote); stop_scan is the safe direction
         # and must never be kill-switch-blocked, so it carries approval only.
-        permissions_ask=["launch_scan", "stop_scan"],
+        # write_bluesky_plan/validate_bluesky_plan (task 2.3) reach NO hardware
+        # either way: write_bluesky_plan only writes a file (never imports/execs
+        # it), and validate_bluesky_plan's dry run drives mock devices only, in a
+        # subprocess with EPICS_CA_* neutralized — both work identically whether
+        # control_system.writes_enabled is on or off, so like stop_scan neither
+        # carries _WRITES_CHECK. They get their own (distinct, independently
+        # allowlistable) short-names rather than reusing launch_scan/stop_scan's
+        # tier, since an operator may want to permit authoring/validating plan
+        # bodies without also auto-approving launch_scan/stop_scan, or vice versa.
+        permissions_ask=["launch_scan", "stop_scan", "write_bluesky_plan", "validate_bluesky_plan"],
         hooks_pre=[
             HookRule(
                 matcher="mcp__scan__launch_scan",
@@ -315,6 +324,14 @@ FRAMEWORK_SERVERS: dict[str, ServerDefinition] = {
             ),
             HookRule(
                 matcher="mcp__scan__stop_scan",
+                hooks=[_APPROVAL],
+            ),
+            HookRule(
+                matcher="mcp__scan__write_bluesky_plan",
+                hooks=[_APPROVAL],
+            ),
+            HookRule(
+                matcher="mcp__scan__validate_bluesky_plan",
                 hooks=[_APPROVAL],
             ),
         ],

--- a/src/osprey/services/bluesky_bridge/app.py
+++ b/src/osprey/services/bluesky_bridge/app.py
@@ -495,6 +495,11 @@ def list_plans() -> list:
     installed. `plan_loader.py` (facility injection, task 2.4) is import-clean
     of bluesky, so facility-injected plans are always served regardless — see
     that module for how the plan module path is resolved.
+
+    Each entry (`PlanSpec.to_dict()`) carries `metadata` (the plan's
+    authoring-declared `PLAN_METADATA`, or `None` for a built-in that doesn't
+    author one) and `provenance` (its loader-assigned trust tier) alongside
+    `name`/`description`/`schema` — see `plan_types.py`.
     """
     from .plan_loader import get_facility_plans
 

--- a/src/osprey/services/bluesky_bridge/app.py
+++ b/src/osprey/services/bluesky_bridge/app.py
@@ -474,7 +474,9 @@ def get_run_status(run_id: str) -> dict:
     out = run.to_dict()
     request = run.request
     plan_name = (
-        request.get("plan_name") if isinstance(request, dict) else getattr(request, "plan_name", None)
+        request.get("plan_name")
+        if isinstance(request, dict)
+        else getattr(request, "plan_name", None)
     )
     if plan_name is not None:
         out["plan_name"] = plan_name

--- a/src/osprey/services/bluesky_bridge/app.py
+++ b/src/osprey/services/bluesky_bridge/app.py
@@ -15,8 +15,10 @@ built-in deploy smoke demo (``BLUESKY_DEMO_SCANNER``) — see below.
 
 from __future__ import annotations
 
+import ast
 import logging
 import os
+import re
 from collections.abc import Callable
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
@@ -25,9 +27,13 @@ from fastapi import FastAPI, Header, HTTPException
 from pydantic import BaseModel, Field
 
 from . import live_rows
-from .runs import do_promote, registry
+from .plan_types import Provenance
+from .plan_validation import hash_plan_body, validate_bluesky_plan
+from .runs import Run, do_promote, registry
 from .scanner import FakeScanner, Scanner
 from .security import verify_promote_token
+from .session_dir import resolve_session_plan_dir
+from .validation_record import validation_records
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -283,7 +289,6 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
         try:
             from .devices import connector as connector_devices
             from .devices._specs_from_env import specs_from_env
-            from .plans import BUILTIN_PLANS
             from .scanner_bluesky import BlueskyScanner
         except ImportError as exc:
             root_name = (getattr(exc, "name", None) or "").split(".")[0]
@@ -346,9 +351,20 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
                 # result. Every read and write these devices perform is
                 # connector-mediated (`read_channel`/`write_channel_checked`) —
                 # there is no raw Channel Access anywhere in this path.
+                #
+                # `plans` is left unset (`None`) rather than pinned to
+                # `BUILTIN_PLANS`, so `BlueskyScanner.reinitialize` resolves
+                # plan names through `_default_plan_registry()` — built-ins
+                # merged with `get_facility_plans().plans` (task 2.4), which
+                # re-scans and re-gates the session/facility layers on every
+                # call. A validated session or facility plan is therefore
+                # launchable on this connector-mediated path exactly like the
+                # demo scanner factory below; an unvalidated (or
+                # validated-then-edited) one is simply absent from the
+                # registry the next time this factory's scanner resolves it —
+                # fail-closed, with no separate gate needed here.
                 return BlueskyScanner(
                     devices=lambda: connector_devices.build_devices(motors, detectors, connector),
-                    plans=BUILTIN_PLANS,
                     tiled_writer_factory=_build_tiled_writer_factory(),
                 )
 
@@ -444,7 +460,93 @@ def list_runs(limit: int = 20) -> list[dict]:
 
 @app.get("/runs/{run_id}")
 def get_run_status(run_id: str) -> dict:
-    return registry.get(run_id).to_dict()
+    """Run status, plus (when present) the intent's ``plan_name``/``plan_args``.
+
+    ``Run.to_dict()`` itself carries neither field — the lifecycle core
+    (``runs.py``) treats ``request`` as opaque (see its own docstring). Both
+    are read straight off the stored intent here, the same
+    dict-or-attribute extraction ``_promote_validation_gate`` already uses,
+    so callers that need to know *what* is being launched (e.g. task 2.6's
+    launch-approval hook, resolving a bare ``run_id`` into a plan to render)
+    don't need a second route.
+    """
+    run = registry.get(run_id)
+    out = run.to_dict()
+    request = run.request
+    plan_name = (
+        request.get("plan_name") if isinstance(request, dict) else getattr(request, "plan_name", None)
+    )
+    if plan_name is not None:
+        out["plan_name"] = plan_name
+        out["plan_args"] = (
+            request.get("plan_args", {})
+            if isinstance(request, dict)
+            else getattr(request, "plan_args", {})
+        )
+    return out
+
+
+def _promote_validation_gate(run: Run) -> None:
+    """Refuse to promote a session/unreviewed plan with no CURRENT passing validation record.
+
+    Defense-in-depth alongside task 2.4's session-layer LOAD gate
+    (`plan_loader.py`'s `_load_plan_file`): that gate already keeps an
+    unvalidated session/unreviewed file out of `get_facility_plans().plans`
+    entirely, so in the common case this validator finds nothing to reject.
+    It exists for the narrow race the load gate can't close on its own — the
+    `PlanSpec` `get_facility_plans()` returned to resolve this run's
+    `plan_name` moments earlier could be stale by the time promote runs (e.g.
+    the session file was edited in between) — so this independently re-reads
+    the file straight from `resolve_session_plan_dir()` and re-hashes its
+    CURRENT content with `hash_plan_body`, the same normalization the record
+    was keyed on, rather than trusting the earlier snapshot.
+
+    Raises `HTTPException(409, ...)` for any plan name backed by a file in
+    `resolve_session_plan_dir()` whose current content has no passing
+    record — whether or not `get_facility_plans()` currently registers it.
+    A name the load gate is quarantining *right now* for lacking a record
+    resolves to no `PlanSpec` at all, but its file still exists under the
+    session directory; treating that as `session` provenance too (rather than
+    "not found") is what turns an already-quarantined plan's promote attempt
+    into this clear 409 instead of a confusing "unknown plan" failure further
+    downstream. A non-session provenance (`shipped`/`preset`/`facility`), or a
+    name with neither a `PlanSpec` nor a session-dir file at all, is left
+    alone — `Scanner.reinitialize`'s own "unknown plan" handling is the right
+    place for the latter.
+    """
+    request = run.request
+    plan_name = (
+        request.get("plan_name")
+        if isinstance(request, dict)
+        else getattr(request, "plan_name", None)
+    )
+    if not plan_name:
+        return
+
+    from .plan_loader import get_facility_plans
+
+    spec = get_facility_plans().plans.get(plan_name)
+    plan_path = resolve_session_plan_dir() / f"{plan_name}.py"
+    if spec is not None:
+        is_session = spec.provenance in ("session", "unreviewed")
+    else:
+        is_session = plan_path.is_file()
+
+    if not is_session or not plan_path.is_file():
+        # Not a session-tier plan at all, or its file has since vanished —
+        # either way there is nothing here to re-hash; `Scanner.reinitialize`
+        # will hit its own "unknown plan" path if the name doesn't resolve.
+        return
+
+    content = plan_path.read_text(encoding="utf-8")
+    if not validation_records.has_passing_record(hash_plan_body(content)):
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"session plan {plan_name!r} has no passing validation record; "
+                "validate it before launching"
+            ),
+        )
 
 
 @app.post("/runs/{run_id}/promote")
@@ -454,10 +556,14 @@ def promote_run(run_id: str, x_promote_token: str = Header(default="")) -> dict:
     Callable only by holders of `BLUESKY_PROMOTE_TOKEN` — in practice, the
     `launch_scan` MCP tool, whose own invocation already required a human
     approval prompt (PreToolUse) plus an in-tool `writes_enabled` re-check.
+    `_promote_validation_gate` runs inside `do_promote`'s own lock, before any
+    scanner is built (task 2.5) — a session/unreviewed plan with no current
+    passing validation record 409s here rather than surfacing downstream as a
+    confusing "unknown plan" resolution failure.
     """
     verify_promote_token(x_promote_token)
     run = registry.get(run_id)
-    promoted_run = do_promote(run, _scanner_factory)
+    promoted_run = do_promote(run, _scanner_factory, validator=_promote_validation_gate)
     # Only recorded once do_promote actually succeeds (it raises 409/500
     # otherwise) — a rejected promote attempt must not mark the run as
     # launched by anything.
@@ -520,6 +626,258 @@ def list_plans() -> list:
     merged.update(get_facility_plans().plans)
 
     return [spec.to_dict() for spec in merged.values()]
+
+
+# ---------------------------------------------------------------------------
+# Session-plan authoring + validation (task 2.3)
+# ---------------------------------------------------------------------------
+# A valid Python identifier: the sanitized name doubles as the on-disk file
+# stem (`<name>.py`) and the `PLAN_METADATA["name"]` value, so this also rules
+# out path traversal (`../`, absolute paths, path separators) in one check.
+# Anchored with `\Z`, NOT `$` — `$` matches at end-of-string OR just before a
+# single trailing "\n", so `"foo\n"` would otherwise pass this check while
+# still not being a valid identifier.
+_PLAN_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*\Z")
+
+# A generous bound well above any real plan name — exists only so an
+# absurdly long name fails closed here (400) rather than surfacing as an
+# unhandled OSError from `Path.write_text` (some filesystems reject a
+# filename this long outright, which would otherwise 500).
+_MAX_PLAN_NAME_LENGTH = 100
+
+# Neither `/plans/session` nor `/plans/validate` is gated on
+# `BLUESKY_PROMOTE_TOKEN` (`security.py`) — that token is deliberately
+# unminted whenever writes are unsafe to arm (see
+# `container_lifecycle._local_exec_arming_unsafe`), and both these routes
+# MUST keep working with writes disabled: authoring and validating a plan
+# body never touches a device (the validator's stage-3 dry run drives mock
+# devices only, in a subprocess with `EPICS_CA_*` neutralized — see
+# `plan_validation.py`). Their protection is the bridge's loopback-only bind
+# (see the compose template) plus the MCP-side approval hook
+# (`registry/mcp.py`'s `write_bluesky_plan`/`validate_bluesky_plan` tiers) —
+# not a token gate.
+
+
+def _sanitize_plan_name(name: str) -> str:
+    """Validate ``name`` as a safe plan name, or raise 400.
+
+    Enforced as a Python identifier (not merely "no path separators") because
+    the same string is written into the generated ``PLAN_METADATA["name"]``
+    block as a plain literal and used verbatim as the on-disk file stem.
+    Length-checked FIRST, before the regex echoes ``name`` back in the error
+    detail — an oversized name fails closed on its length alone rather than
+    being quoted in full into an HTTPException detail.
+    """
+    if len(name) > _MAX_PLAN_NAME_LENGTH:
+        raise HTTPException(
+            status_code=400,
+            detail=f"invalid plan name: exceeds the {_MAX_PLAN_NAME_LENGTH}-character limit",
+        )
+    if not _PLAN_NAME_RE.match(name):
+        raise HTTPException(
+            status_code=400,
+            detail=f"invalid plan name {name!r}: must be a valid Python identifier",
+        )
+    return name
+
+
+class PlanSessionWriteRequest(BaseModel):
+    """Request body for `POST /plans/session`: author a session-tier plan file.
+
+    ``body`` is the author's own source (``PARAMS`` + ``build_plan``, per the
+    layered directory catalog's file contract) — it is never exec'd by this
+    route. The remaining fields become the generated `PLAN_METADATA` block
+    prepended to it; together they must satisfy `plan_metadata.PlanMetadata`'s
+    contract once the session-tier load gate (task 2.4) parses the file.
+    """
+
+    name: str
+    description: str = ""
+    category: str
+    required_devices: list[str] = Field(default_factory=list)
+    writes: bool
+    body: str
+
+
+@app.post("/plans/session")
+def write_session_plan(request: PlanSessionWriteRequest) -> dict:
+    """Author a session-tier plan file. NEVER imports or execs it.
+
+    Assembles the final file content as ONE string — a generated
+    `PLAN_METADATA = {...}` block followed by the author's own ``body`` — and
+    writes exactly that string to ``resolve_session_plan_dir()/<name>.py``,
+    overwriting any existing file of the same name (a name reused for
+    different content is a re-authoring: its hash changes, so any prior
+    validation record no longer matches — the file becomes unvalidated again
+    until `POST /plans/validate` is called on it, which is the correct
+    fail-closed behavior).
+
+    Returns the plan name and `hash_plan_body` of the EXACT bytes written —
+    the same bytes `POST /plans/validate` re-reads and hashes, and the same
+    bytes task 2.4/2.5's gates re-hash from disk when checking for a passing
+    validation record.
+    """
+    name = _sanitize_plan_name(request.name)
+    metadata = {
+        "name": name,
+        "description": request.description,
+        "category": request.category,
+        "required_devices": list(request.required_devices),
+        "writes": request.writes,
+    }
+    final_content = f"PLAN_METADATA = {metadata!r}\n\n{request.body}"
+
+    plan_path = resolve_session_plan_dir() / f"{name}.py"
+    plan_path.write_text(final_content, encoding="utf-8")
+
+    return {"name": name, "content_hash": hash_plan_body(final_content)}
+
+
+class PlanValidateRequest(BaseModel):
+    """Request body for `POST /plans/validate`: validate a session plan by name.
+
+    ``sample_args`` supplies the stage-3 dry run's `PARAMS` field values
+    directly (the simpler of the two options `plan_validation.py`'s docstring
+    calls out — deriving minimal samples from the `PARAMS` schema would need
+    per-type generation logic this bridge does not otherwise have); omit it
+    for a `PARAMS` with no required fields.
+    """
+
+    name: str
+    sample_args: dict[str, Any] | None = None
+    dry_run_timeout: float = 30.0
+
+
+@app.post("/plans/validate")
+async def validate_session_plan(request: PlanValidateRequest) -> dict:
+    """Validate the CURRENT on-disk content of a session plan file.
+
+    Reads the file `POST /plans/session` wrote (never a separately-passed
+    body) so "validated bytes == file bytes" is structural, not a caller
+    convention. Runs `validate_bluesky_plan`'s three ordered stages; on a
+    pass, records the content hash in `validation_records` so task 2.4's load
+    gate and task 2.5's promote gate will admit this exact file content.
+
+    Raises 404 if no session plan named ``request.name`` has been written.
+    """
+    name = _sanitize_plan_name(request.name)
+    plan_path = resolve_session_plan_dir() / f"{name}.py"
+    if not plan_path.is_file():
+        raise HTTPException(status_code=404, detail=f"unknown session plan {name!r}")
+
+    content = plan_path.read_text(encoding="utf-8")
+    result = await validate_bluesky_plan(
+        content,
+        plan_name=name,
+        sample_args=request.sample_args,
+        dry_run_timeout=request.dry_run_timeout,
+    )
+    if result.passed:
+        validation_records.record(result.content_hash)
+
+    return {
+        "passed": result.passed,
+        "reasons": result.reasons,
+        "content_hash": result.content_hash,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Plan source rendering (task 2.6): backs the launch-approval hook's
+# human-legible plan excerpt — the human backstop for the plan validator's
+# documented, accepted obfuscation residual (see `plan_validation.py`'s
+# module docstring). Read-only: never execs anything, only reads file text
+# already sitting on disk.
+# ---------------------------------------------------------------------------
+
+_SOURCE_TRUNCATE_CHARS = 4000  # a few KB: enough for a human skim, bounded
+
+
+def _find_layer_source_path(name: str) -> tuple[Any, Provenance] | None:
+    """Best-effort locate the on-disk file behind a shipped/preset/facility plan.
+
+    Directory-layer files are keyed by their declared ``PLAN_METADATA["name"]``,
+    not necessarily their filename (``plans_core/grid_scan.py`` declares
+    ``"grid_scan_nd"``) — so this parses each candidate file's source with
+    ``ast`` (never execs it) purely to read the literal ``name`` off its
+    ``PLAN_METADATA`` dict. Returns `None` for a built-in with no backing
+    file at all, or a name this scan can't locate; the route degrades to a
+    404 either way.
+    """
+    from .plan_loader import _iter_plan_files, _resolve_plan_dir_layers
+
+    for directory, provenance in _resolve_plan_dir_layers():
+        if provenance == "session":
+            continue
+        for path in _iter_plan_files(directory):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except (OSError, SyntaxError, UnicodeDecodeError):
+                continue
+            for node in tree.body:
+                if not isinstance(node, ast.Assign):
+                    continue
+                if not any(
+                    isinstance(target, ast.Name) and target.id == "PLAN_METADATA"
+                    for target in node.targets
+                ):
+                    continue
+                if not isinstance(node.value, ast.Dict):
+                    continue
+                for key, value in zip(node.value.keys, node.value.values, strict=True):
+                    if (
+                        isinstance(key, ast.Constant)
+                        and key.value == "name"
+                        and isinstance(value, ast.Constant)
+                        and value.value == name
+                    ):
+                        return path, provenance
+    return None
+
+
+@app.get("/plans/{name}/source")
+def get_plan_source(name: str) -> dict:
+    """Truncated source text for one plan — the launch-approval hook's data
+    source for rendering what a `launch_scan` call would actually run.
+
+    A session-tier file is looked up directly: its filename IS its name (see
+    `write_session_plan`). Its ``validated`` flag reflects the SAME
+    `hash_plan_body`/`validation_records` check the load/promote gates use,
+    computed fresh from the file's CURRENT content — never cached — so a
+    re-authored file that invalidates a prior pass is reported honestly, even
+    if that leaves it quarantined out of `GET /plans` entirely.
+
+    A shipped/preset/facility file is located by `_find_layer_source_path`
+    (best-effort) and reported ``validated=True`` unconditionally — those
+    tiers carry no validation-record gate; they are operator-trusted by
+    construction, not by a passing record.
+
+    Raises 404 if no file can be located for ``name`` in any tier (including
+    a built-in with no backing file at all).
+    """
+    name = _sanitize_plan_name(name)
+    session_path = resolve_session_plan_dir() / f"{name}.py"
+    provenance: Provenance
+    if session_path.is_file():
+        content = session_path.read_text(encoding="utf-8")
+        validated = validation_records.has_passing_record(hash_plan_body(content))
+        provenance = "session"
+    else:
+        found = _find_layer_source_path(name)
+        if found is None:
+            raise HTTPException(status_code=404, detail=f"no source file found for plan {name!r}")
+        path, provenance = found
+        content = path.read_text(encoding="utf-8")
+        validated = True
+
+    truncated_content = content[:_SOURCE_TRUNCATE_CHARS]
+    return {
+        "name": name,
+        "provenance": provenance,
+        "validated": validated,
+        "truncated": len(truncated_content) < len(content),
+        "source": truncated_content,
+    }
 
 
 def _window(

--- a/src/osprey/services/bluesky_bridge/plan_loader.py
+++ b/src/osprey/services/bluesky_bridge/plan_loader.py
@@ -1,34 +1,68 @@
-"""The facility plan-injection contract: loads a facility's plans and devices
-from a config-pointed module path, external to this package.
+"""Loads scan plans from a layered directory catalog plus the legacy facility
+plan-injection contract, and merges both into one trust-resolved plan set.
 
-A facility plan module is any ``.py`` file exposing:
+Two kinds of plan source, both scanned into the same fail-closed registry:
 
-- ``PLANS: dict[str, PlanSpec]`` — additional (or overriding) scan plans.
-- ``get_devices() -> dict[str, Any]`` — builds and returns the device mapping
-  those plans' ``PlanSpec.plan`` callables resolve device names against.
+- **Directory layers** — ordered ``(directory, provenance)`` pairs, each
+  scanned for ``.py`` files exposing ``PLAN_METADATA``/``build_plan``
+  (optionally ``PARAMS``). Device-agnostic: these files never define
+  ``get_devices()``; their plans resolve device names against the bridge's
+  own device map at launch.
+- **The legacy single-module contract** — a single ``.py`` file exposing
+  ``PLANS: dict[str, PlanSpec]`` and ``get_devices()``, resolved from
+  ``BLUESKY_PLAN_MODULE`` (env) or ``scan.plan_module`` (config.yml). This
+  predates the layered model and is folded in as a one-entry ``facility``-tier
+  layer — it is the only source of injected devices.
 
-This module is deliberately free of bluesky/ophyd/tiled imports — it loads
-arbitrary facility modules *by path* (``importlib.util``, not a dotted import,
-since a facility module typically lives outside this installed package), and
-only the loaded module itself needs bluesky. That keeps `plan_loader.py`
-importable in any bridge process regardless of whether the `bluesky-bridge`
-extra is installed, so facility-injected plans and devices work even in a
-bluesky-less test/contract environment (see ``plans.py``'s built-in registry,
-which does need bluesky and degrades separately in ``app.py``'s `/plans`
-route).
+Layer sources and their provenance-tier mapping:
+
+1. ``shipped`` — the in-image core dir bundled with this package
+   (``plans_core/``, alongside this module). May not exist yet in a given
+   install; an absent/empty directory is not an error.
+2. ``preset`` — directories listed in ``scan.plan_dirs`` in config.yml.
+   Config-shipped and versioned with a deployment's config bundle: lower
+   operator trust than a per-instance runtime override.
+3. ``facility`` — directories listed in ``BLUESKY_PLAN_DIRS`` (env,
+   ``os.pathsep``-separated), set per bridge instance at launch. This mirrors
+   the legacy contract's existing precedent that an env override outranks
+   config (``BLUESKY_PLAN_MODULE`` wins over ``scan.plan_module``). The
+   legacy single-module contract itself is also pinned to ``facility`` —
+   it is scanned *first*, so a lower-trust directory layer (``shipped`` or
+   ``preset``) can never silently reclaim a name it already owns; only an
+   equal- or higher-trust directory layer can.
+
+Trust order (ascending): ``shipped < preset < facility < session <
+unreviewed``. A same-name collision across layers is resolved fail-closed:
+a strictly-higher-trust incoming plan overrides (warns); a strictly-lower-
+trust incoming plan is rejected outright (errors, keeps the existing
+registration); an equal-trust collision lets the later-scanned definition win
+(warns) — same-tier directories are all operator-controlled, so there is no
+principled tie-breaker beyond scan order.
+
+Deliberately free of bluesky/ophyd/tiled imports — this module only execs
+plan files and reads pydantic metadata; only a loaded module itself needs
+bluesky. That keeps `plan_loader.py` importable in any bridge process
+regardless of whether the `bluesky-bridge` extra is installed (see
+``plans.py``'s built-in registry, which does need bluesky and degrades
+separately in ``app.py``'s `/plans` route).
 """
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import logging
 import os
 import sys
-from dataclasses import dataclass, field
+from collections.abc import Iterator
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
-from .plan_types import PlanSpec
+from pydantic import BaseModel
+
+from .plan_metadata import parse_plan_metadata
+from .plan_types import PlanSpec, Provenance
 
 logger = logging.getLogger("osprey.services.bluesky_bridge.plan_loader")
 
@@ -36,25 +70,53 @@ logger = logging.getLogger("osprey.services.bluesky_bridge.plan_loader")
 # BLUESKY_BRIDGE_URL/BLUESKY_PROMOTE_TOKEN); wins outright over config.yml.
 _MODULE_PATH_ENV = "BLUESKY_PLAN_MODULE"
 
+# os.pathsep-separated list of directory-layer dirs, set per bridge instance.
+_PLAN_DIRS_ENV = "BLUESKY_PLAN_DIRS"
+
+# The in-image core plan directory shipped with this package (task 1.5
+# populates it; scanned even if absent/empty).
+_SHIPPED_PLANS_DIR = Path(__file__).parent / "plans_core"
+
+_TRUST_ORDER: dict[Provenance, int] = {
+    "shipped": 0,
+    "preset": 1,
+    "facility": 2,
+    "session": 3,
+    "unreviewed": 4,
+}
+
+
+class _EmptyParams(BaseModel):
+    """Default parameter schema for a directory-layer plan file with no ``PARAMS``.
+
+    Phase-2 session plans may not ship a schema; a permissive empty model
+    keeps the loader forward-compatible rather than rejecting such a file.
+    """
+
+
+class PlanLoaderError(ValueError):
+    """A directory-layer plan file fails its load contract (missing/uncallable
+    ``build_plan``, malformed ``PARAMS``). Always caught and quarantined by
+    the scanner — never escapes this module."""
+
 
 @dataclass
 class FacilityPlans:
-    """A facility's injected plans and devices, as loaded from its plan module."""
+    """The bridge's merged plans and devices, aggregated across every layer."""
 
     plans: dict[str, PlanSpec[Any]] = field(default_factory=dict)
     devices: dict[str, Any] = field(default_factory=dict)
 
 
 def _resolve_plan_module_path() -> str | None:
-    """Resolve the facility plan module's filesystem path.
+    """Resolve the legacy facility plan module's filesystem path.
 
     Resolution order:
 
     1. ``BLUESKY_PLAN_MODULE`` env var (a filesystem path) — set by the
        framework server definition per bridge instance; wins outright.
     2. ``scan.plan_module`` in config.yml (local/dev convenience).
-    3. ``None`` — no facility plans are injected; the bridge serves built-ins
-       only.
+    3. ``None`` — no legacy facility module is injected.
     """
     path = os.environ.get(_MODULE_PATH_ENV)
     if path:
@@ -67,8 +129,36 @@ def _resolve_plan_module_path() -> str | None:
     return str(value) if value else None
 
 
+def _resolve_plan_dir_layers() -> list[tuple[Path, Provenance]]:
+    """Ordered ``(directory, provenance)`` layers for the directory scan, ascending trust.
+
+    See the module docstring for the full source-to-tier mapping rationale.
+    """
+    layers: list[tuple[Path, Provenance]] = [(_SHIPPED_PLANS_DIR, "shipped")]
+
+    from osprey.utils.workspace import load_osprey_config
+
+    config = load_osprey_config()
+    preset_dirs = config.get("scan", {}).get("plan_dirs") or []
+    if isinstance(preset_dirs, str):
+        preset_dirs = [preset_dirs]
+    layers.extend((Path(d), "preset") for d in preset_dirs)
+
+    env_value = os.environ.get(_PLAN_DIRS_ENV)
+    if env_value:
+        layers.extend((Path(d), "facility") for d in env_value.split(os.pathsep) if d)
+
+    return layers
+
+
 def _load_module_from_path(path: Path) -> Any:
-    """Import a `.py` file at ``path`` as a standalone module, by path (not name)."""
+    """Import a `.py` file at ``path`` as a standalone module, by path (not name).
+
+    Used for the legacy single-module contract, keyed by the file's stem —
+    a colliding stem here is a genuine misconfiguration (there is only ever
+    one legacy module per bridge instance), unlike directory-layer files
+    (see `_load_plan_module_from_path`).
+    """
     if not path.is_file():
         raise FileNotFoundError(f"facility plan module not found: {path}")
     spec = importlib.util.spec_from_file_location(
@@ -90,18 +180,170 @@ def _load_module_from_path(path: Path) -> Any:
     return module
 
 
+def _load_plan_module_from_path(path: Path) -> Any:
+    """Import a directory-layer `.py` file under a unique, full-path-derived
+    `sys.modules` name.
+
+    Unlike the legacy single-module loader (keyed by stem), directory layers
+    commonly reuse stems across layers (e.g. a shipped and a facility-tier
+    `orm.py`) — hashing the resolved absolute path into the synthetic name
+    keeps every file's `sys.modules` entry distinct regardless of filename
+    collisions. Registered before `exec_module` and popped on failure,
+    mirroring `_load_module_from_path`.
+    """
+    abspath = path.resolve()
+    name = f"_osprey_bridge_plan_{hashlib.sha1(str(abspath).encode()).hexdigest()[:16]}"
+    spec = importlib.util.spec_from_file_location(name, abspath)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"could not load plan file: {abspath}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        sys.modules.pop(name, None)
+        raise
+    return module
+
+
+def _iter_plan_files(directory: Path) -> Iterator[Path]:
+    """Yield a layer directory's plan files, sorted for deterministic scan order.
+
+    Tolerates a missing/non-directory path (not an error — see the module
+    docstring). Skips `__init__.py` and any other dunder-named module.
+    """
+    if not directory.is_dir():
+        return
+    for path in sorted(directory.glob("*.py")):
+        stem = path.stem
+        if stem.startswith("__") and stem.endswith("__"):
+            continue
+        yield path
+
+
+def _register_plan(
+    registry: dict[str, tuple[Provenance, str, PlanSpec[Any]]],
+    name: str,
+    provenance: Provenance,
+    source: str,
+    spec: PlanSpec[Any],
+) -> None:
+    """Register ``spec`` under ``name``, resolving a same-name collision by trust tier.
+
+    Fail-closed: a lower-trust incoming plan never overrides a higher-trust
+    registration — it is rejected outright and the existing registration
+    stays. A strictly-higher-trust incoming plan overrides (warns). An
+    equal-trust collision lets the later-scanned definition win (warns) —
+    same-tier directories are all operator-controlled.
+    """
+    existing = registry.get(name)
+    if existing is None:
+        registry[name] = (provenance, source, spec)
+        return
+
+    existing_provenance, existing_source, _ = existing
+    incoming_rank = _TRUST_ORDER[provenance]
+    existing_rank = _TRUST_ORDER[existing_provenance]
+
+    if incoming_rank > existing_rank:
+        logger.warning(
+            "plan_loader: higher-trust plan %r from %s (%s) overrides lower-trust "
+            "registration from %s (%s)",
+            name,
+            source,
+            provenance,
+            existing_source,
+            existing_provenance,
+        )
+        registry[name] = (provenance, source, spec)
+    elif incoming_rank < existing_rank:
+        logger.error(
+            "plan_loader: rejecting lower-trust plan %r from %s (%s) — a higher-trust "
+            "registration from %s (%s) already owns this name",
+            name,
+            source,
+            provenance,
+            existing_source,
+            existing_provenance,
+        )
+    else:
+        logger.warning(
+            "plan_loader: plan %r redefined at equal trust (%s) — %s overrides %s",
+            name,
+            provenance,
+            source,
+            existing_source,
+        )
+        registry[name] = (provenance, source, spec)
+
+
+def _load_plan_file(
+    path: Path,
+    provenance: Provenance,
+    registry: dict[str, tuple[Provenance, str, PlanSpec[Any]]],
+) -> None:
+    """Load, validate, and register one directory-layer plan file.
+
+    Never raises: any failure (syntax error, missing/invalid `PLAN_METADATA`,
+    missing `build_plan`, malformed `PARAMS`) is logged as a warning and the
+    file is quarantined — skipped, without aborting the rest of the scan.
+
+    Catches `SystemExit` alongside `Exception` (it isn't an `Exception`
+    subclass) so a plan file that calls `sys.exit()` at import time is
+    quarantined like any other bad file rather than aborting the whole
+    directory scan — today's shipped/preset/facility tiers are all
+    operator-trusted, but this same scan path is where task 2.4's untrusted
+    `session`/`unreviewed` tier will land, where one authored `sys.exit()`
+    would otherwise be a sibling-plan discovery denial-of-service. Deliberately
+    NOT widened to bare `BaseException`: a genuine `KeyboardInterrupt` or
+    `GeneratorExit` must still propagate — an operator's Ctrl-C is not a
+    plan-file failure.
+    """
+    try:
+        module = _load_plan_module_from_path(path)
+        meta = parse_plan_metadata(module, source=str(path))
+        build_plan = getattr(module, "build_plan", None)
+        if not callable(build_plan):
+            raise PlanLoaderError(f"{path}: missing required build_plan callable")
+        params_attr = getattr(module, "PARAMS", None)
+        if params_attr is None:
+            params_schema: type[BaseModel] = _EmptyParams
+        elif isinstance(params_attr, type) and issubclass(params_attr, BaseModel):
+            params_schema = params_attr
+        else:
+            raise PlanLoaderError(
+                f"{path}: PARAMS must be a pydantic BaseModel subclass, got {params_attr!r}"
+            )
+        spec = PlanSpec(
+            name=meta.name,
+            plan=build_plan,
+            schema=params_schema,
+            description=meta.description,
+            metadata=meta,
+            provenance=provenance,
+        )
+    except (Exception, SystemExit) as exc:
+        logger.warning("plan_loader: quarantining %s (%s): %s", path, provenance, exc)
+        return
+    _register_plan(registry, meta.name, provenance, str(path), spec)
+
+
 def load_facility_plans(module_path: str | None = None) -> FacilityPlans:
-    """Load a facility's ``PLANS``/``get_devices()`` from a config-pointed module path.
+    """Load the legacy facility ``PLANS``/``get_devices()`` from a config-pointed module path.
 
     ``module_path`` overrides resolution (mainly for tests); production
     callers leave it unset so it's resolved via env/config.yml (see
     ``_resolve_plan_module_path``). Returns an empty `FacilityPlans` when no
-    path is configured — the bridge then serves only the built-in plan set.
+    path is configured — no legacy plans/devices are injected.
 
     A path that *is* configured but names a missing, unloadable module, or one
     missing the ``PLANS``/``get_devices`` contract, raises rather than
     silently falling back — a misconfigured facility injection should fail
     loudly, not masquerade as "no facility plans".
+
+    Every returned plan's ``provenance`` is normalized to ``"facility"``
+    regardless of what the module itself set (or left at its `PlanSpec`
+    default) — provenance is loader-assigned, never self-declared.
     """
     path_str = module_path if module_path is not None else _resolve_plan_module_path()
     if not path_str:
@@ -124,11 +366,16 @@ def load_facility_plans(module_path: str | None = None) -> FacilityPlans:
         path_str,
     )
     _warn_if_shadowing_builtins(plans)
-    return FacilityPlans(plans=dict(plans), devices=dict(devices))
+
+    normalized_plans = {
+        name: (spec if spec.provenance == "facility" else replace(spec, provenance="facility"))
+        for name, spec in plans.items()
+    }
+    return FacilityPlans(plans=normalized_plans, devices=dict(devices))
 
 
 def _warn_if_shadowing_builtins(facility_plans: dict[str, PlanSpec[Any]]) -> None:
-    """Log once, at load time, if a facility plan overrides a built-in of the same name.
+    """Log once, at load time, if a legacy facility plan overrides a built-in of the same name.
 
     Silent shadowing here would be a surprising way for an operator to lose a
     built-in plan (e.g. `count`) to a same-named facility plan without any
@@ -148,6 +395,32 @@ def _warn_if_shadowing_builtins(facility_plans: dict[str, PlanSpec[Any]]) -> Non
         )
 
 
+def _load_all_layers(module_path: str | None) -> FacilityPlans:
+    """Merge the legacy single-module contract with every directory layer.
+
+    The legacy module (if configured) is registered *first*, as a one-entry
+    ``facility``-tier layer — so a lower-trust directory layer (``shipped``,
+    ``preset``) can never silently reclaim a name it already owns; only an
+    equal- or higher-trust directory layer can (see `_register_plan`).
+    Directory layers are then scanned in ascending trust order. Devices come
+    only from the legacy module's `get_devices()` — directory layers are
+    device-agnostic.
+    """
+    registry: dict[str, tuple[Provenance, str, PlanSpec[Any]]] = {}
+
+    legacy = load_facility_plans(module_path)
+    legacy_source = module_path or _resolve_plan_module_path() or "<unconfigured>"
+    for name, spec in legacy.plans.items():
+        _register_plan(registry, name, "facility", str(legacy_source), spec)
+
+    for directory, provenance in _resolve_plan_dir_layers():
+        for path in _iter_plan_files(directory):
+            _load_plan_file(path, provenance, registry)
+
+    plans = {name: spec for name, (_, _, spec) in registry.items()}
+    return FacilityPlans(plans=plans, devices=dict(legacy.devices))
+
+
 # ---------------------------------------------------------------------------
 # Module-level singleton: loaded (and cached) once per bridge process, since
 # device construction may be expensive (e.g. real EPICS connections).
@@ -156,10 +429,15 @@ _facility_plans: FacilityPlans | None = None
 
 
 def get_facility_plans() -> FacilityPlans:
-    """The bridge process's facility-injected plans/devices, loading them on first use."""
+    """The bridge process's merged plans/devices, loading them on first use.
+
+    Aggregates the legacy single-module contract with every directory layer
+    (shipped/preset/facility) into one trust-resolved plan set — see
+    `_load_all_layers`.
+    """
     global _facility_plans
     if _facility_plans is None:
-        _facility_plans = load_facility_plans()
+        _facility_plans = _load_all_layers(None)
     return _facility_plans
 
 

--- a/src/osprey/services/bluesky_bridge/plan_loader.py
+++ b/src/osprey/services/bluesky_bridge/plan_loader.py
@@ -39,6 +39,21 @@ registration); an equal-trust collision lets the later-scanned definition win
 (warns) — same-tier directories are all operator-controlled, so there is no
 principled tie-breaker beyond scan order.
 
+4. ``session`` — the bridge-owned, writable directory resolved by
+   ``session_dir.resolve_session_plan_dir()``. Unlike every layer above, this
+   one is agent-authored, not operator-supplied — so a ``session`` (or a
+   future ``unreviewed``) file is subject to an additional LOAD-TIME gate
+   (``_load_plan_file``) before it is ever ``exec_module``'d: its current
+   on-disk content is hashed with ``plan_validation.hash_plan_body`` and
+   checked against ``validation_record.validation_records`` for a passing
+   record. No record, no exec — the file is skipped like any other
+   quarantined file, never registered, never launchable. This is the
+   feature's primary enforcement point: it runs on every scan (see
+   ``get_facility_plans``), so an edit that invalidates a previously-passing
+   file's hash re-quarantines it on the very next scan. Higher-trust tiers
+   carry no such gate — they are exec'd on discovery unconditionally, as
+   they always have been.
+
 Deliberately free of bluesky/ophyd/tiled imports — this module only execs
 plan files and reads pydantic metadata; only a loaded module itself needs
 bluesky. That keeps `plan_loader.py` importable in any bridge process
@@ -63,6 +78,9 @@ from pydantic import BaseModel
 
 from .plan_metadata import parse_plan_metadata
 from .plan_types import PlanSpec, Provenance
+from .plan_validation import hash_plan_body
+from .session_dir import resolve_session_plan_dir
+from .validation_record import validation_records
 
 logger = logging.getLogger("osprey.services.bluesky_bridge.plan_loader")
 
@@ -133,6 +151,11 @@ def _resolve_plan_dir_layers() -> list[tuple[Path, Provenance]]:
     """Ordered ``(directory, provenance)`` layers for the directory scan, ascending trust.
 
     See the module docstring for the full source-to-tier mapping rationale.
+    The ``session`` layer is appended last (highest trust so far — see
+    ``_TRUST_ORDER``) and resolves to the bridge-owned, writable directory
+    from ``session_dir.resolve_session_plan_dir()``; unlike every layer
+    above it, files landing there are gated at load time (see
+    ``_load_plan_file``) rather than trusted on discovery.
     """
     layers: list[tuple[Path, Provenance]] = [(_SHIPPED_PLANS_DIR, "shipped")]
 
@@ -147,6 +170,8 @@ def _resolve_plan_dir_layers() -> list[tuple[Path, Provenance]]:
     env_value = os.environ.get(_PLAN_DIRS_ENV)
     if env_value:
         layers.extend((Path(d), "facility") for d in env_value.split(os.pathsep) if d)
+
+    layers.append((resolve_session_plan_dir(), "session"))
 
     return layers
 
@@ -292,14 +317,38 @@ def _load_plan_file(
     subclass) so a plan file that calls `sys.exit()` at import time is
     quarantined like any other bad file rather than aborting the whole
     directory scan — today's shipped/preset/facility tiers are all
-    operator-trusted, but this same scan path is where task 2.4's untrusted
-    `session`/`unreviewed` tier will land, where one authored `sys.exit()`
+    operator-trusted, but this same scan path is where the untrusted
+    `session`/`unreviewed` tier lands, where one authored `sys.exit()`
     would otherwise be a sibling-plan discovery denial-of-service. Deliberately
     NOT widened to bare `BaseException`: a genuine `KeyboardInterrupt` or
     `GeneratorExit` must still propagate — an operator's Ctrl-C is not a
     plan-file failure.
+
+    For `provenance in ("session", "unreviewed")` only, a LOAD-TIME gate runs
+    first: the file's current content is hashed with
+    `plan_validation.hash_plan_body` and checked against
+    `validation_record.validation_records` for a passing record. No record,
+    no `exec_module` — the file is skipped exactly like a quarantined file
+    (never registered, never launchable). Higher-trust tiers (`shipped`,
+    `preset`, `facility`) carry no such gate; they are `exec_module`'d on
+    discovery unconditionally, as they always have been. Gating strictly on
+    provenance (not on "no metadata"/"no record" alone) matters: built-ins and
+    the shipped exemplars carry no validation record either, and a broader
+    gate would wrongly quarantine them too.
     """
     try:
+        if provenance in ("session", "unreviewed"):
+            content = path.read_text(encoding="utf-8")
+            content_hash = hash_plan_body(content)
+            if not validation_records.has_passing_record(content_hash):
+                logger.info(
+                    "plan_loader: skipping unvalidated %s-tier plan file %s "
+                    "(content hash %s has no passing validation record)",
+                    provenance,
+                    path,
+                    content_hash,
+                )
+                return
         module = _load_plan_module_from_path(path)
         meta = parse_plan_metadata(module, source=str(path))
         build_plan = getattr(module, "build_plan", None)
@@ -395,16 +444,32 @@ def _warn_if_shadowing_builtins(facility_plans: dict[str, PlanSpec[Any]]) -> Non
         )
 
 
-def _load_all_layers(module_path: str | None) -> FacilityPlans:
-    """Merge the legacy single-module contract with every directory layer.
+@dataclass
+class _StartupLayers:
+    """The registry and devices built from every *startup* layer: the legacy
+    single-module contract plus the `shipped`/`preset`/`facility` directory
+    layers. Cached once per process (see `_startup_layers`) since device
+    construction may be expensive (e.g. real EPICS connections) — unlike the
+    `session` layer, these are all operator-supplied and don't change without
+    a bridge restart, so there is no correctness reason to re-scan them."""
+
+    registry: dict[str, tuple[Provenance, str, PlanSpec[Any]]] = field(default_factory=dict)
+    devices: dict[str, Any] = field(default_factory=dict)
+
+
+def _load_startup_layers(module_path: str | None) -> _StartupLayers:
+    """Merge the legacy single-module contract with every startup directory layer.
 
     The legacy module (if configured) is registered *first*, as a one-entry
     ``facility``-tier layer — so a lower-trust directory layer (``shipped``,
     ``preset``) can never silently reclaim a name it already owns; only an
     equal- or higher-trust directory layer can (see `_register_plan`).
-    Directory layers are then scanned in ascending trust order. Devices come
-    only from the legacy module's `get_devices()` — directory layers are
-    device-agnostic.
+    Directory layers are then scanned in ascending trust order, *excluding*
+    the ``session`` layer — that one is deliberately left out of this
+    cached, once-per-process build and re-scanned fresh on every
+    `get_facility_plans()` call instead (see `_session_layer_signature`).
+    Devices come only from the legacy module's `get_devices()` — directory
+    layers are device-agnostic.
     """
     registry: dict[str, tuple[Provenance, str, PlanSpec[Any]]] = {}
 
@@ -414,34 +479,69 @@ def _load_all_layers(module_path: str | None) -> FacilityPlans:
         _register_plan(registry, name, "facility", str(legacy_source), spec)
 
     for directory, provenance in _resolve_plan_dir_layers():
+        if provenance == "session":
+            continue
         for path in _iter_plan_files(directory):
             _load_plan_file(path, provenance, registry)
 
-    plans = {name: spec for name, (_, _, spec) in registry.items()}
-    return FacilityPlans(plans=plans, devices=dict(legacy.devices))
+    return _StartupLayers(registry=registry, devices=dict(legacy.devices))
 
 
 # ---------------------------------------------------------------------------
-# Module-level singleton: loaded (and cached) once per bridge process, since
-# device construction may be expensive (e.g. real EPICS connections).
+# Module-level caches. `_startup_layers` is built once per process (see
+# `_StartupLayers`) — the expensive part (e.g. real device construction).
+# `_merged_plans` caches only the *previous return value*: every call still
+# re-scans and re-gates the session layer from scratch (see
+# `get_facility_plans`), but when that fresh scan produces a result equal to
+# what was last returned (the common case — an unauthored or unchanged
+# session directory), the old object is handed back instead of a new one, so
+# repeat callers that compare by identity (or just want a stable reference)
+# see one. A signature/mtime-based skip was deliberately rejected: a file's
+# mtime doesn't change when a *validation record* is added after the fact
+# (task 2.3's validate route only touches `validation_record.py`, never the
+# file), so caching on file staleness alone would keep serving a stale
+# rejection after a plan actually became valid — exactly the live-authoring
+# case this layer exists for. Re-gating on every call is the correctness
+# requirement; the equality check below is purely a reference-stability nicety.
 # ---------------------------------------------------------------------------
-_facility_plans: FacilityPlans | None = None
+_startup_layers: _StartupLayers | None = None
+_merged_plans: FacilityPlans | None = None
 
 
 def get_facility_plans() -> FacilityPlans:
-    """The bridge process's merged plans/devices, loading them on first use.
+    """The bridge process's merged plans/devices.
 
     Aggregates the legacy single-module contract with every directory layer
-    (shipped/preset/facility) into one trust-resolved plan set — see
-    `_load_all_layers`.
+    (`shipped`/`preset`/`facility`/`session`) into one trust-resolved plan
+    set. The startup layers are loaded once and cached (see
+    `_load_startup_layers`) — but the `session` layer is a live authoring
+    surface (task 2.3's `POST /plans/session` writes into it between
+    requests, and its validation status can change without the file itself
+    changing), so it is fully re-scanned and re-gated (see `_load_plan_file`)
+    on *every* call, merged fresh over the cached startup registry. A newly
+    written and validated session plan therefore appears on the very next
+    call, with no bridge restart and no explicit cache invalidation.
     """
-    global _facility_plans
-    if _facility_plans is None:
-        _facility_plans = _load_all_layers(None)
-    return _facility_plans
+    global _startup_layers, _merged_plans
+
+    if _startup_layers is None:
+        _startup_layers = _load_startup_layers(None)
+
+    registry = dict(_startup_layers.registry)
+    for path in _iter_plan_files(resolve_session_plan_dir()):
+        _load_plan_file(path, "session", registry)
+
+    plans = {name: spec for name, (_, _, spec) in registry.items()}
+    merged = FacilityPlans(plans=plans, devices=dict(_startup_layers.devices))
+
+    if _merged_plans is not None and merged == _merged_plans:
+        return _merged_plans
+    _merged_plans = merged
+    return _merged_plans
 
 
 def reset_facility_plans() -> None:
-    """Clear the cached `FacilityPlans` singleton (for testing)."""
-    global _facility_plans
-    _facility_plans = None
+    """Clear every cached layer (startup and last-merged result) — for testing."""
+    global _startup_layers, _merged_plans
+    _startup_layers = None
+    _merged_plans = None

--- a/src/osprey/services/bluesky_bridge/plan_metadata.py
+++ b/src/osprey/services/bluesky_bridge/plan_metadata.py
@@ -1,0 +1,81 @@
+"""Authoring metadata for scan plans: the ``PlanMetadata`` model and its parser.
+
+A plan module (built-in, preset, or facility-supplied) declares a module-level
+``PLAN_METADATA`` dict describing itself to operators and to the agent's
+discovery surface (`GET /plans`). This module defines the required shape of
+that dict and a fail-closed parser: a malformed or incomplete block is a typed
+`PlanMetadataError` naming the offending field(s), never a silently
+default-filled object. Provenance (trust tier) is deliberately *not* part of
+this model -- it is assigned by the loader based on which layer a file came
+from, not self-declared by the plan author.
+
+Kept pydantic-only (no bluesky/ophyd/tiled imports) so it can be imported from
+``plan_types.py`` without breaking that module's bluesky-free boundary.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ValidationError
+
+
+class PlanMetadataError(ValueError):
+    """Raised when a plan module's ``PLAN_METADATA`` is missing, malformed, or invalid.
+
+    A single exception type for every failure mode (absent attribute, wrong
+    container type, missing/mistyped field) so callers only need to catch one
+    thing; the message names the offending field(s) and the module/file the
+    metadata came from.
+    """
+
+
+class PlanMetadata(BaseModel):
+    """Authoring-declared metadata for one scan plan, surfaced via `GET /plans`.
+
+    Every field is required: a plan lacking one is an authoring error to be
+    rejected at load time, not a gap to paper over with a default. JSON-
+    serializable via `model_dump()` for direct inclusion in `PlanSpec.to_dict()`.
+    """
+
+    name: str
+    description: str
+    category: str
+    required_devices: list[str]
+    writes: bool
+
+
+def parse_plan_metadata_dict(raw: dict[str, Any], *, source: str) -> PlanMetadata:
+    """Validate ``raw`` (a plan module's ``PLAN_METADATA`` dict) into a `PlanMetadata`.
+
+    Wraps pydantic's `ValidationError` into `PlanMetadataError`, naming the
+    failing field(s) and ``source`` (a path/module label for operator
+    debugging), so every caller sees one exception type regardless of whether
+    a field is missing or wrong-typed.
+    """
+    try:
+        return PlanMetadata.model_validate(raw)
+    except ValidationError as exc:
+        fields = ", ".join(".".join(str(part) for part in error["loc"]) for error in exc.errors())
+        raise PlanMetadataError(
+            f"{source}: PLAN_METADATA is invalid for field(s): {fields}"
+        ) from exc
+
+
+def parse_plan_metadata(module: Any, *, source: str | None = None) -> PlanMetadata:
+    """Read and validate ``PLAN_METADATA`` from an already-imported plan ``module``.
+
+    Raises `PlanMetadataError` before ever reaching pydantic validation if the
+    module has no ``PLAN_METADATA`` attribute or that attribute isn't a dict.
+    ``source`` defaults to the module's ``__name__`` for the error message;
+    pass it explicitly when the module was imported under a synthetic name
+    (e.g. a path-hash `sys.modules` key) that wouldn't mean anything to an
+    operator.
+    """
+    label = source if source is not None else getattr(module, "__name__", repr(module))
+    raw = getattr(module, "PLAN_METADATA", None)
+    if raw is None:
+        raise PlanMetadataError(f"{label}: module has no PLAN_METADATA attribute")
+    if not isinstance(raw, dict):
+        raise PlanMetadataError(f"{label}: PLAN_METADATA must be a dict, got {type(raw).__name__}")
+    return parse_plan_metadata_dict(raw, source=label)

--- a/src/osprey/services/bluesky_bridge/plan_types.py
+++ b/src/osprey/services/bluesky_bridge/plan_types.py
@@ -22,11 +22,20 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Literal, TypeVar
 
 from pydantic import BaseModel
 
+from .plan_metadata import PlanMetadata
+
 SchemaT = TypeVar("SchemaT", bound=BaseModel)
+
+Provenance = Literal["shipped", "preset", "facility", "session", "unreviewed"]
+"""Trust/origin tier, in ascending ephemerality order (``shipped`` is the trust
+floor; ``session``/``unreviewed`` is agent-authored and least trusted).
+Assigned by the loader based on which layer a plan file came from — never
+self-declared in a plan's own ``PLAN_METADATA``.
+"""
 
 
 @dataclass
@@ -43,11 +52,15 @@ class PlanSpec(Generic[SchemaT]):
     plan: Callable[[dict[str, Any], SchemaT], Any]
     schema: type[SchemaT]
     description: str = ""
+    metadata: PlanMetadata | None = None
+    provenance: Provenance = "shipped"
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialize for `GET /plans`: name, description, and the JSON parameter schema."""
+        """Serialize for `GET /plans`: name, description, schema, metadata, provenance."""
         return {
             "name": self.name,
             "description": self.description,
             "schema": self.schema.model_json_schema(),
+            "metadata": self.metadata.model_dump() if self.metadata is not None else None,
+            "provenance": self.provenance,
         }

--- a/src/osprey/services/bluesky_bridge/plan_validation.py
+++ b/src/osprey/services/bluesky_bridge/plan_validation.py
@@ -255,11 +255,7 @@ def _static_allowlist_check(code: str) -> list[str]:
         # A syntax error short-circuits here — `_check_import_allowlist`
         # would only re-raise the same `SyntaxError` on its own `ast.parse`.
         return violations
-    return (
-        violations
-        + _check_future_import_position(code)
-        + _check_import_allowlist(code)
-    )
+    return violations + _check_future_import_position(code) + _check_import_allowlist(code)
 
 
 # ---------------------------------------------------------------------------
@@ -289,7 +285,9 @@ _CA_ONLY_PATTERNS: dict[str, list[str]] = {
 
 def _ca_pattern_scan(code: str) -> list[str]:
     """Stage 2: reject a body that reaches for CA/connector constructs directly."""
-    result = detect_control_system_operations(code, patterns=_CA_ONLY_PATTERNS, pattern_mode="override")
+    result = detect_control_system_operations(
+        code, patterns=_CA_ONLY_PATTERNS, pattern_mode="override"
+    )
     matched = result["detected_patterns"]["writes"] + result["detected_patterns"]["reads"]
     return [f"Control-system operation pattern matched: {pattern}" for pattern in matched]
 

--- a/src/osprey/services/bluesky_bridge/plan_validation.py
+++ b/src/osprey/services/bluesky_bridge/plan_validation.py
@@ -1,0 +1,623 @@
+"""Authoring-time validator for a session-tier bluesky plan-file BODY.
+
+An agent authoring a new plan (task 2.3's ``write_bluesky_plan``/
+``validate_bluesky_plan`` MCP tools) never gets its file exec'd directly —
+that would hand arbitrary code execution to whatever produced the body. This
+module is the gate a body must pass before anything downstream (the session
+directory layer's LOAD gate, task 2.4; the promote gate, task 2.5) will treat
+it as real: :func:`validate_bluesky_plan` runs three ordered stages, each of
+which can reject outright before the next ever runs:
+
+1. **Static AST allowlist** (:func:`_static_allowlist_check`) — a submodule-
+   aware import walk (bare top-level matching, as the shared viz sandbox
+   uses, is too coarse: ``bluesky.plan_stubs`` must be allowed while
+   ``bluesky.utils`` and bare ``bluesky`` must not) plus the shared syntax
+   gate and dangerous-substring scan reused from
+   :func:`osprey.mcp_server.workspace.execution.sandbox_executor.validate_sandbox_code`,
+   plus a positional check (:func:`_check_future_import_position`) that a
+   ``from __future__ import ...`` statement can only ever be a body's own
+   leading statement — never true once the generated ``PLAN_METADATA``
+   assignment is prepended ahead of it.
+2. **Narrowed CA/connector pattern scan** (:func:`_ca_pattern_scan`) — reuses
+   :func:`osprey.services.python_executor.analysis.pattern_detection.detect_control_system_operations`
+   with an override pattern set naming only actual CA/connector constructs
+   (``caput``, ``epics.``, ``write_channel``, ``_osprey_connector``, ...) so
+   an otherwise-benign body calling ``numpy.put``/``dict.get``/``queue.put``
+   is not falsely rejected by the framework's default (bare ``.put(``/
+   ``.get(``) patterns.
+3. **Mock-RunEngine dry-run** (:func:`_dry_run`) — actually builds and drives
+   the plan's generator, in a subprocess whose ``EPICS_CA_*`` variables are
+   neutralized to explicit inert values (no address, no auto-discovery — see
+   :data:`_EPICS_CA_INERT_ENV`), against in-process mock devices
+   (:mod:`osprey.services.bluesky_bridge.devices.mock`). This is an
+   **authoring-quality gate** ("does the body actually run"), not a
+   containment boundary — containment comes from stages 1-2 above and the
+   downstream load/promote gates that key off this module's validation
+   record, not from anything the dry-run subprocess itself prevents.
+
+Every :class:`ValidationResult` (pass or fail) carries a ``content_hash``
+computed by :func:`hash_plan_body`, the single normalization tasks 2.2/2.4/2.5
+reuse so a validation record recorded against one hash of a body's content is
+found again by a later re-hash of the same content, byte for byte.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from osprey.mcp_server.sandbox_env import scrub_sensitive_env
+from osprey.mcp_server.workspace.execution.sandbox_executor import validate_sandbox_code
+from osprey.services.python_executor.analysis.pattern_detection import (
+    detect_control_system_operations,
+)
+
+logger = logging.getLogger("osprey.services.bluesky_bridge.plan_validation")
+
+# ---------------------------------------------------------------------------
+# Stage 1: submodule-aware import allowlist
+# ---------------------------------------------------------------------------
+# `bluesky` is only ever allowed via these three exact, fully-dotted
+# submodules — a top-level `name.split(".")[0] in {"bluesky"}` match (as the
+# viz sandbox's `validate_sandbox_code` uses) would also let a plan body
+# import `bluesky.utils`, or bare `bluesky` itself, neither of which is part
+# of the authoring surface an agent-written plan body needs.
+_ALLOWED_BLUESKY_SUBMODULES: frozenset[str] = frozenset(
+    {"bluesky.plan_stubs", "bluesky.plans", "bluesky.preprocessors"}
+)
+
+# Everything else a plan body may import, checked top-level only (a plan body
+# doing numerical/stdlib bookkeeping around its bluesky calls has no reason to
+# reach past these). `pydantic` is a deliberate addition beyond the plain
+# numerical/stdlib set: the plan-file contract (`plan_loader.py`) requires
+# `PARAMS` to be a `pydantic.BaseModel` subclass whenever a plan declares one
+# at all, so a session-authored plan with any typed parameters cannot satisfy
+# that contract without importing it. `__future__` and `typing` are zero-
+# runtime-capability (no I/O, no import, no exec — `__future__` only toggles
+# compiler behavior, `typing` is erased at runtime) and are exactly what the
+# shipped exemplars use for `from __future__ import annotations` / type
+# hints. `logging` is allowed too (the exemplars log via
+# `logging.getLogger(__name__)`), but narrowed further below — see
+# `_DENIED_LOGGING_SUBMODULES`.
+_ALLOWED_TOP_LEVEL_MODULES: frozenset[str] = frozenset(
+    {
+        "numpy",
+        "scipy",
+        "math",
+        "statistics",
+        "time",
+        "collections",
+        "itertools",
+        "functools",
+        "pydantic",
+        "__future__",
+        "typing",
+        "logging",
+    }
+)
+
+# `logging.config.dictConfig`/`fileConfig` and `logging.handlers` (which
+# includes `SMTPHandler`, `SocketHandler`, etc.) do class-instantiation- and
+# callable-resolution-by-STRING — an import-by-string bypass of this very
+# AST allowlist. Bare `import logging` and `logging.getLogger(...)` attribute
+# access (all the shipped exemplars need) require neither submodule, so they
+# are denied while plain `logging` stays allowed — the inverse of how
+# `bluesky` is narrowed: there, the top level is denied and specific
+# submodules are allowed; here, the top level is allowed and these two
+# specific submodules are denied.
+_DENIED_LOGGING_SUBMODULES: frozenset[str] = frozenset({"logging.config", "logging.handlers"})
+
+# Passed to `validate_sandbox_code`'s own (coarser, top-level-only) import
+# check so it never disagrees with `_check_import_allowlist` below: `bluesky`
+# is allowed at the top level here, then narrowed to the three submodules
+# above by the finer-grained walk. Every other name in this set is identical
+# to `_ALLOWED_TOP_LEVEL_MODULES`, so the two checks agree everywhere except
+# the bluesky narrowing `validate_sandbox_code` cannot itself express.
+_VALIDATOR_TOP_LEVEL_MODULES: frozenset[str] = _ALLOWED_TOP_LEVEL_MODULES | {"bluesky"}
+
+
+def _is_allowed_import(dotted_name: str) -> bool:
+    """Whether ``dotted_name`` (an ``import``'s own dotted module path) is allowed."""
+    top = dotted_name.split(".")[0]
+    if top == "bluesky":
+        return dotted_name in _ALLOWED_BLUESKY_SUBMODULES
+    if top == "logging":
+        return dotted_name not in _DENIED_LOGGING_SUBMODULES
+    return top in _ALLOWED_TOP_LEVEL_MODULES
+
+
+def _check_import_allowlist(code: str) -> list[str]:
+    """The authoritative, submodule-aware import walk for a plan body.
+
+    Assumes ``code`` already parses — call after `validate_sandbox_code`'s
+    syntax gate has run. A `SyntaxError` here (should the caller ever skip
+    that gate) is swallowed by the caller, not this function.
+
+    ``from bluesky import plan_stubs`` and ``from bluesky.plan_stubs import
+    mv`` both name the same allowed submodule (similarly ``from logging
+    import config`` and ``from logging.config import dictConfig`` both name
+    the same denied one), but an `ast.ImportFrom`'s ``module`` only holds the
+    parent package name for the first form of each pair — the submodule
+    lives in the *imported name*, not the module path. All four forms are
+    resolved to the same fully-dotted name before checking the allowlist.
+    """
+    violations: list[str] = []
+    tree = ast.parse(code)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if not _is_allowed_import(alias.name):
+                    violations.append(f"Import not allowed for plan authoring: '{alias.name}'")
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is None:
+                violations.append(
+                    "Relative import with no module name is not allowed for plan authoring"
+                )
+            elif node.module == "bluesky":
+                for alias in node.names:
+                    dotted = f"bluesky.{alias.name}"
+                    if not _is_allowed_import(dotted):
+                        violations.append(f"Import not allowed for plan authoring: 'from {dotted}'")
+            elif node.module == "logging":
+                for alias in node.names:
+                    dotted = f"logging.{alias.name}"
+                    if dotted in _DENIED_LOGGING_SUBMODULES:
+                        violations.append(f"Import not allowed for plan authoring: 'from {dotted}'")
+            elif not _is_allowed_import(node.module):
+                violations.append(f"Import not allowed for plan authoring: 'from {node.module}'")
+    return violations
+
+
+_FUTURE_IMPORT_REJECT_MESSAGE = (
+    "session plans cannot use `from __future__` imports because plan "
+    "metadata is prepended to the file; omit it — modern type hints "
+    "(list[str], dict[str, Any]) work without it on Python 3.9+."
+)
+
+
+def _check_future_import_position(code: str) -> list[str]:
+    """Reject a `from __future__ import ...` that is not the file's own leading statement.
+
+    Python requires a `from __future__ import ...` statement to be the
+    file's literal first statement (a module docstring may precede it, and
+    further future-import statements may follow one — nothing else may).
+    Only `compile()`/the import machinery enforces this; `ast.parse` (the
+    syntax gate `validate_sandbox_code` runs above) happily parses a
+    misplaced one, since it is a semantic rule, not a grammar rule.
+
+    A session-authored body is ALWAYS preceded by a generated
+    ``PLAN_METADATA = {...}`` assignment once `write_session_plan` (app.py)
+    writes it to disk, so a future-import statement anywhere in that body
+    can never end up at a legal position in the assembled file. Left
+    uncaught here, it instead surfaces deep in stage 3's dry-run subprocess
+    as a `SyntaxError` naming a temp file and line number that point at the
+    generated metadata line, not the real cause — this check catches it
+    here instead, with a message that explains why and what to do about it.
+
+    This is a positional check, not a blanket ban: a body where the
+    future-import genuinely IS the leading statement (docstring aside) is
+    unaffected — that covers the shipped `plans_core` exemplars, which this
+    same function validates directly (never metadata-prepended) in
+    `TestShippedExemplarsPassValidation`.
+    """
+    tree = ast.parse(code)
+    body = tree.body
+    future_indices = [
+        i
+        for i, node in enumerate(body)
+        if isinstance(node, ast.ImportFrom) and node.module == "__future__"
+    ]
+    if not future_indices:
+        return []
+
+    def _is_leading_docstring(index: int, node: ast.stmt) -> bool:
+        return (
+            index == 0
+            and isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        )
+
+    for index in range(future_indices[-1]):
+        node = body[index]
+        if _is_leading_docstring(index, node):
+            continue
+        if isinstance(node, ast.ImportFrom) and node.module == "__future__":
+            continue
+        return [_FUTURE_IMPORT_REJECT_MESSAGE]
+    return []
+
+
+def _static_allowlist_check(code: str) -> list[str]:
+    """Stage 1: syntax gate + submodule-aware import allowlist + dangerous-substring scan.
+
+    Reuses `validate_sandbox_code` for the syntax gate and the dangerous-
+    pattern substring scan (its own defaults — this never touches
+    `_ALLOWED_TOP_LEVEL`/`_ALLOWED_IMPORTS`/`_DANGEROUS_PATTERNS`); the
+    submodule-aware walk above is the authoritative import gate.
+    `_check_future_import_position` additionally guards a positional rule
+    neither of those checks (nor the syntax gate's own `ast.parse`) enforces
+    — see its docstring.
+    """
+    is_safe, violations = validate_sandbox_code(
+        code, allowed_top_level=_VALIDATOR_TOP_LEVEL_MODULES
+    )
+    if not is_safe:
+        # A syntax error short-circuits here — `_check_import_allowlist`
+        # would only re-raise the same `SyntaxError` on its own `ast.parse`.
+        return violations
+    return (
+        violations
+        + _check_future_import_position(code)
+        + _check_import_allowlist(code)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stage 2: narrowed CA/connector-only pattern scan
+# ---------------------------------------------------------------------------
+# Deliberately excludes the framework-default bare `.put(`/`.get(`/
+# `.set_value(` regexes (see pattern_detection.py's
+# `get_framework_standard_patterns`) — those false-positive on
+# `numpy.put(...)`/`dict.get(...)`/`queue.put(...)`, which a benign plan body
+# is expected to use freely. Only actual CA/connector constructs are named.
+_CA_ONLY_PATTERNS: dict[str, list[str]] = {
+    "write": [
+        r"\bcaput\s*\(",
+        r"epics\.",
+        r"\baioca\b",
+        r"\bcaproto\b",
+        r"\bwrite_channel\s*\(",
+        r"_osprey_connector\b",
+        r"PV\s*\(",
+    ],
+    "read": [
+        r"\bcaget\s*\(",
+        r"\bread_channel\s*\(",
+    ],
+}
+
+
+def _ca_pattern_scan(code: str) -> list[str]:
+    """Stage 2: reject a body that reaches for CA/connector constructs directly."""
+    result = detect_control_system_operations(code, patterns=_CA_ONLY_PATTERNS, pattern_mode="override")
+    matched = result["detected_patterns"]["writes"] + result["detected_patterns"]["reads"]
+    return [f"Control-system operation pattern matched: {pattern}" for pattern in matched]
+
+
+# ---------------------------------------------------------------------------
+# Content hash — the one helper tasks 2.2/2.4/2.5 reuse to re-key/re-check a
+# validation record against a plan file's current content.
+# ---------------------------------------------------------------------------
+def hash_plan_body(body: str) -> str:
+    """SHA-256 content hash of a plan-file BODY, over a normalized encoding.
+
+    Normalization: a leading UTF-8 BOM is stripped, CRLF/CR line endings are
+    folded to LF, all trailing newlines are collapsed, and the body is left
+    with exactly one trailing newline before hashing — so a file that
+    round-trips through an editor that rewrites line endings, saves with a
+    BOM, or adds/drops trailing blank lines still hashes identically. This is
+    the one place that normalization happens; every caller that needs to
+    check "does this file content have a passing validation record"
+    (task 2.2's store, task 2.4's load gate, task 2.5's promote gate) must
+    hash through this function rather than re-deriving its own encoding.
+    """
+    normalized = body.replace("\r\n", "\n").replace("\r", "\n")
+    normalized = normalized.lstrip("﻿").rstrip("\n") + "\n"
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+@dataclass
+class ValidationResult:
+    """Outcome of validating an authored plan-file BODY.
+
+    ``passed`` is `False` if any stage rejects the body; ``reasons`` lists
+    every rejection reported by whichever stage stopped it (later stages
+    never run once an earlier one fails — see `validate_bluesky_plan`).
+    ``content_hash`` is always populated, computed before any stage runs, so a
+    caller can key a validation record (or a rejection) against the exact
+    body content regardless of which stage decided the outcome.
+    """
+
+    passed: bool
+    reasons: list[str]
+    content_hash: str
+
+
+# ---------------------------------------------------------------------------
+# Stage 3: mock-RunEngine dry-run, in a subprocess with EPICS_CA_* neutralized
+# ---------------------------------------------------------------------------
+# Set (not merely deleted) in the dry-run subprocess's environment, on top of
+# the shared `scrub_sensitive_env` deny-list. Deleting these keys outright
+# would be actively WORSE than leaving them alone: a CA client that sees
+# neither `EPICS_CA_ADDR_LIST` nor an explicit `EPICS_CA_AUTO_ADDR_LIST`
+# defaults auto-discovery to YES, which makes it BROADCAST on the local
+# subnet looking for IOCs — exactly the unsolicited network traffic this
+# scrub exists to prevent, not "no CA address to reach." Setting explicit
+# inert values (an empty address list, auto-discovery off, no name server)
+# closes that gap: even if some future bluesky/ophyd-async escape hatch let a
+# plan body reach real CA machinery despite stages 1-2 rejecting the
+# constructs to do so, there is nowhere for it to send a request.
+_EPICS_CA_INERT_ENV: dict[str, str] = {
+    "EPICS_CA_ADDR_LIST": "",
+    "EPICS_CA_AUTO_ADDR_LIST": "NO",
+    "EPICS_CA_NAME_SERVERS": "",
+}
+# Dropped outright rather than set to a value: with no address to reach and
+# auto-discovery disabled (see above), nothing ever consults a configured
+# server port.
+_EPICS_CA_ENV_NAMES_TO_DROP: tuple[str, ...] = ("EPICS_CA_SERVER_PORT",)
+
+# Extra wall-clock time (on top of the caller's `dry_run_timeout`) the parent
+# waits for the subprocess to exit after that timeout — long enough for the
+# subprocess's own internal deadline (see `_render_dry_run_script`) to fire
+# and write a graceful "did not complete" result before the parent falls back
+# to a hard `proc.kill()`, which reports only a generic timeout message.
+_DRY_RUN_GRACE_SECONDS = 5.0
+
+
+def _collect_device_names(value: Any, *, key: str | None = None) -> tuple[set[str], set[str]]:
+    """Recursively bucket device-name strings out of a plan's ``sample_args``.
+
+    A plan file's `PLAN_METADATA["required_devices"]` names PARAMS *fields*
+    (e.g. ``"correctors"``, ``"detectors"``), not a fixed shape all plans
+    share — `grid_scan_nd`'s setpoints, for instance, are nested under
+    ``axes[].setpoint`` rather than a flat field. Rather than hard-coding a
+    per-plan device-field shape, this walks ``sample_args`` itself and
+    buckets every string leaf by the nearest enclosing field name: a field
+    whose name contains ``"detect"`` contributes to the detector bucket,
+    everything else (correctors/setpoints/motors/unlabeled) to the motor
+    bucket — motors are the more capable mock (settable *and* readable), so
+    defaulting an unlabeled device name there is the safer guess for a body
+    that drives it via `bps.mv`.
+    """
+    motors: set[str] = set()
+    detectors: set[str] = set()
+    if isinstance(value, str):
+        is_detector_field = key is not None and "detect" in key.lower()
+        (detectors if is_detector_field else motors).add(value)
+    elif isinstance(value, dict):
+        for sub_key, sub_value in value.items():
+            sub_motors, sub_detectors = _collect_device_names(sub_value, key=sub_key)
+            motors |= sub_motors
+            detectors |= sub_detectors
+    elif isinstance(value, (list, tuple, set)):
+        for item in value:
+            sub_motors, sub_detectors = _collect_device_names(item, key=key)
+            motors |= sub_motors
+            detectors |= sub_detectors
+    return motors, detectors
+
+
+def _render_dry_run_script(
+    *,
+    plan_path: Path,
+    result_path: Path,
+    plan_name: str,
+    sample_args: dict[str, Any],
+    motor_names: list[str],
+    detector_names: list[str],
+    inner_timeout: float,
+) -> str:
+    """Render the subprocess script that drives the dry-run to completion.
+
+    Loads the plan body as a standalone module, wraps it in a `PlanSpec`, and
+    drives it through `BlueskyScanner` (the same real bluesky-plan-runner the
+    bridge itself uses, mirroring its own contract-test usage) against mock
+    devices built for the device names found in ``sample_args``. Writes a
+    JSON result to ``result_path`` in a ``finally`` so the parent always has
+    something to read even if construction itself raised.
+    """
+    return f"""\
+import json
+import sys
+import time
+import traceback
+from pathlib import Path
+
+_PLAN_PATH = Path(r"{plan_path}")
+_RESULT_PATH = Path(r"{result_path}")
+_PLAN_NAME = {plan_name!r}
+_SAMPLE_ARGS = {sample_args!r}
+_MOTOR_NAMES = {tuple(motor_names)!r}
+_DETECTOR_NAMES = {tuple(detector_names)!r}
+_DEADLINE_S = {inner_timeout!r}
+
+result = {{"success": False, "error": None}}
+try:
+    import importlib.util
+
+    _MODULE_NAME = "_osprey_plan_dry_run_body"
+    spec = importlib.util.spec_from_file_location(_MODULE_NAME, _PLAN_PATH)
+    module = importlib.util.module_from_spec(spec)
+    # Registered in sys.modules BEFORE exec (mirrors plan_loader.py's own
+    # module loader): a plan body with two pydantic models referencing each
+    # other by name (e.g. `grid_scan_nd`'s `PARAMS.axes: list[GridAxis]`)
+    # relies on `from __future__ import annotations` postponed-evaluation
+    # forward refs resolving against `sys.modules[cls.__module__].__dict__`
+    # -- skip this and pydantic raises "class not fully defined" the moment
+    # the model is instantiated below, even though the class body itself
+    # executed without error.
+    sys.modules[_MODULE_NAME] = module
+    spec.loader.exec_module(module)
+
+    from pydantic import BaseModel as _BaseModel
+
+    from osprey.services.bluesky_bridge.devices.mock import build_devices
+    from osprey.services.bluesky_bridge.plan_types import PlanSpec
+    from osprey.services.bluesky_bridge.scanner_bluesky import BlueskyScanner
+
+    params_cls = getattr(module, "PARAMS", None)
+    if params_cls is None:
+        class params_cls(_BaseModel):
+            pass
+
+    plan_spec = PlanSpec(name=_PLAN_NAME, plan=module.build_plan, schema=params_cls)
+
+    def _device_source():
+        return build_devices(motor_names=_MOTOR_NAMES, detector_names=_DETECTOR_NAMES)
+
+    scanner = BlueskyScanner(devices=_device_source, plans={{_PLAN_NAME: plan_spec}})
+    ok = scanner.reinitialize({{"plan_name": _PLAN_NAME, "plan_args": _SAMPLE_ARGS}})
+    if not ok:
+        raise RuntimeError(scanner.error_message or "plan resolution failed")
+
+    scanner.start_scan_thread()
+    deadline = time.monotonic() + _DEADLINE_S
+    while scanner.is_scanning_active() and time.monotonic() < deadline:
+        time.sleep(0.02)
+
+    if scanner.is_scanning_active():
+        raise TimeoutError("dry-run plan did not complete within the timeout")
+    if scanner.current_state != "completed":
+        raise RuntimeError(scanner.error_message or f"dry-run ended in state {{scanner.current_state!r}}")
+
+    result["success"] = True
+except Exception as exc:
+    result["error"] = f"{{type(exc).__name__}}: {{exc}}"
+    result["traceback"] = traceback.format_exc()
+finally:
+    _RESULT_PATH.write_text(json.dumps(result))
+"""
+
+
+async def _dry_run(
+    body: str,
+    *,
+    plan_name: str,
+    sample_args: dict[str, Any],
+    timeout: float,
+) -> list[str]:
+    """Stage 3: run the plan body to completion under a mock-device RunEngine.
+
+    Runs in a subprocess (its own interpreter, own event loop) with the
+    shared `scrub_sensitive_env` deny-list applied AND every
+    `_EPICS_CA_INERT_ENV` variable set to an inert value (never merely
+    deleted — see that constant's docstring for why deleting would be worse)
+    on top of it. Authoring-QUALITY gate only — "does it actually run" — not
+    a containment boundary (see module docstring).
+    """
+    motor_names, detector_names = _collect_device_names(sample_args)
+
+    with tempfile.TemporaryDirectory(prefix="osprey_plan_dry_run_") as tmp:
+        tmp_path = Path(tmp)
+        plan_path = tmp_path / "plan_body.py"
+        plan_path.write_text(body, encoding="utf-8")
+        result_path = tmp_path / "result.json"
+        script_path = tmp_path / "dry_run_wrapper.py"
+        script_path.write_text(
+            _render_dry_run_script(
+                plan_path=plan_path,
+                result_path=result_path,
+                plan_name=plan_name,
+                sample_args=sample_args,
+                motor_names=sorted(motor_names) or ["motor1"],
+                detector_names=sorted(detector_names) or ["det1"],
+                inner_timeout=timeout,
+            ),
+            encoding="utf-8",
+        )
+
+        env = scrub_sensitive_env(os.environ.copy())
+        env.update(_EPICS_CA_INERT_ENV)
+        for name in _EPICS_CA_ENV_NAMES_TO_DROP:
+            env.pop(name, None)
+
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            str(script_path),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        try:
+            _stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=timeout + _DRY_RUN_GRACE_SECONDS
+            )
+        except TimeoutError:
+            proc.kill()
+            await proc.wait()
+            return [f"Dry-run subprocess timed out after {timeout} seconds"]
+
+        if not result_path.exists():
+            stderr_text = stderr.decode("utf-8", errors="replace").strip()
+            return [
+                f"Dry-run subprocess produced no result (exit code {proc.returncode}): {stderr_text}"
+            ]
+
+        try:
+            payload = json.loads(result_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            return [f"Dry-run result file unreadable: {exc}"]
+
+        if not payload.get("success"):
+            return [f"Dry-run failed: {payload.get('error', 'unknown error')}"]
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+async def validate_bluesky_plan(
+    body: str,
+    *,
+    plan_name: str = "session_plan",
+    sample_args: dict[str, Any] | None = None,
+    dry_run_timeout: float = 30.0,
+) -> ValidationResult:
+    """Validate an authored plan-file BODY through all three ordered stages.
+
+    Each stage short-circuits the next on failure: a static-allowlist
+    violation is reported without ever running the CA pattern scan, and a CA
+    pattern match is reported without ever spawning the dry-run subprocess.
+
+    Args:
+        body: The plan file's full source text (``PLAN_METADATA`` + ``PARAMS``
+            + ``build_plan``, per the layered directory catalog's file
+            contract — see ``plans_core/response_matrix.py``).
+        plan_name: Name to register the body's plan under for the stage-3
+            dry-run only; unrelated to any name the body's own
+            ``PLAN_METADATA`` declares.
+        sample_args: Sample ``PARAMS`` field values used to build the stage-3
+            dry-run's generator and mock devices. `None` (no sample args)
+            still runs the dry-run against an empty-args `PARAMS()` and a
+            single default mock motor/detector — appropriate only for a body
+            whose `PARAMS` has no required fields.
+        dry_run_timeout: Seconds the stage-3 subprocess is given to drive the
+            plan to completion.
+
+    Returns:
+        A `ValidationResult` with `content_hash` always populated (hashed
+        before any stage runs), and `passed`/`reasons` reflecting whichever
+        stage accepted or rejected the body.
+    """
+    content_hash = hash_plan_body(body)
+    resolved_sample_args = dict(sample_args) if sample_args is not None else {}
+
+    reasons = _static_allowlist_check(body)
+    if reasons:
+        return ValidationResult(passed=False, reasons=reasons, content_hash=content_hash)
+
+    reasons = _ca_pattern_scan(body)
+    if reasons:
+        return ValidationResult(passed=False, reasons=reasons, content_hash=content_hash)
+
+    reasons = await _dry_run(
+        body,
+        plan_name=plan_name,
+        sample_args=resolved_sample_args,
+        timeout=dry_run_timeout,
+    )
+    if reasons:
+        return ValidationResult(passed=False, reasons=reasons, content_hash=content_hash)
+
+    return ValidationResult(passed=True, reasons=[], content_hash=content_hash)

--- a/src/osprey/services/bluesky_bridge/plans_core/__init__.py
+++ b/src/osprey/services/bluesky_bridge/plans_core/__init__.py
@@ -1,0 +1,8 @@
+"""In-image core plan directory: the ``shipped``-tier layer of the layered
+directory catalog (see ``plan_loader.py``). Every ``.py`` file directly under
+this package is scanned for the ``PLAN_METADATA``/``build_plan``/``PARAMS``
+contract; this ``__init__.py`` only makes the directory a proper package (the
+loader itself skips dunder-named files during its scan).
+"""
+
+from __future__ import annotations

--- a/src/osprey/services/bluesky_bridge/plans_core/grid_scan.py
+++ b/src/osprey/services/bluesky_bridge/plans_core/grid_scan.py
@@ -1,0 +1,87 @@
+"""File-based exemplar plan: ``grid_scan_nd``, an n-dimensional rectangular grid scan.
+
+Representative reference plan; not a physics-validated procedure. It exists to
+show authors the layered directory catalog's file contract (``PLAN_METADATA``
++ ``PARAMS`` + ``build_plan``) end to end for a multi-axis scan — step a set
+of setpoint devices over a rectangular grid, reading a set of detectors at
+every grid point, wrapping ``bluesky.plans.grid_scan``.
+
+Registered as ``grid_scan_nd`` (not ``grid_scan``) so it never shadows the
+built-in ``grid_scan`` plan (``plans.py``) at the ``GET /plans`` merge — see
+the layered loader's trust-collision rules in ``plan_loader.py``.
+
+Device-agnostic: ``setpoints``/``detectors`` are resolved by string name
+against whatever ``devices`` dict the bridge passes in; nothing here names a
+facility PV or a fixed device set.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bluesky import plans as bp
+from pydantic import BaseModel, Field, model_validator
+
+PLAN_METADATA = {
+    "name": "grid_scan_nd",
+    "description": (
+        "Scan a rectangular grid of setpoint devices, reading all detectors at "
+        "every grid point (bluesky bp.grid_scan)."
+    ),
+    "category": "accelerator",
+    "required_devices": ["setpoints", "detectors"],
+    "writes": True,
+}
+
+
+class GridAxis(BaseModel):
+    """One setpoint device's sweep range and point count, for one grid dimension."""
+
+    setpoint: str
+    start: float
+    stop: float
+    num_points: int = Field(..., ge=2, description="Points along this axis.")
+
+
+class PARAMS(BaseModel):
+    """Parameters for ``grid_scan_nd``: one `GridAxis` per grid dimension.
+
+    Steps each axis's setpoint device over its own ``[start, stop]`` range in
+    ``num_points`` evenly-spaced steps, reading every device in ``detectors``
+    at each combination of axis positions (a rectangular grid of
+    ``prod(num_points)`` total points).
+    """
+
+    detectors: list[str] = Field(
+        ..., min_length=1, description="Device names to read at each grid point."
+    )
+    axes: list[GridAxis] = Field(..., min_length=1, description="One entry per grid dimension.")
+    snake_axes: bool = Field(
+        default=False, description="Snake back-and-forth across successive axes."
+    )
+
+    @model_validator(mode="after")
+    def _setpoints_and_detectors_disjoint(self) -> PARAMS:
+        """Reject a device named as both a driven setpoint and a read detector."""
+        setpoints = {axis.setpoint for axis in self.axes}
+        overlap = setpoints & set(self.detectors)
+        if overlap:
+            raise ValueError(
+                f"setpoints and detectors must be disjoint (overlap: {sorted(overlap)})"
+            )
+        return self
+
+
+def build_plan(devices: dict[str, Any], params: PARAMS) -> Any:
+    """Build the n-dimensional grid-scan generator.
+
+    Mirrors the built-in ``grid_scan`` plan's (``plans.py``) idiom: resolves
+    each axis's setpoint/detector by string name against ``devices`` and
+    hands the flattened ``(device, start, stop, num_points)`` triples straight
+    to ``bp.grid_scan``.
+    """
+    detectors = [devices[name] for name in params.detectors]
+    args: list[Any] = []
+    for axis in params.axes:
+        args.extend([devices[axis.setpoint], axis.start, axis.stop, axis.num_points])
+    return bp.grid_scan(detectors, *args, snake_axes=params.snake_axes)

--- a/src/osprey/services/bluesky_bridge/plans_core/response_matrix.py
+++ b/src/osprey/services/bluesky_bridge/plans_core/response_matrix.py
@@ -1,0 +1,115 @@
+"""File-based exemplar plan: ``response_matrix``, an orbit-response-matrix sweep.
+
+Representative reference plan; not a physics-validated procedure. It exists to
+show authors the layered directory catalog's file contract (``PLAN_METADATA``
++ ``PARAMS`` + ``build_plan``) end to end, using the same physics the built-in
+``orm`` plan (``plans.py``) covers programmatically — sweep each corrector,
+one at a time, over a bounded current range, reading every BPM detector at
+each point.
+
+Registered as ``response_matrix`` (not ``orm``) so it never shadows the
+built-in of the same physics at the ``GET /plans`` merge — see the layered
+loader's trust-collision rules in ``plan_loader.py``.
+
+Device-agnostic: ``correctors``/``detectors`` are resolved by string name
+against whatever ``devices`` dict the bridge passes in; nothing here names a
+facility PV or a fixed device set.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from bluesky import plan_stubs as bps
+from bluesky import preprocessors as bpp
+from pydantic import BaseModel, Field, model_validator
+
+logger = logging.getLogger("osprey.services.bluesky_bridge.plans_core.response_matrix")
+
+PLAN_METADATA = {
+    "name": "response_matrix",
+    "description": (
+        "Sweep each corrector over a bounded current range, reading all BPM "
+        "detectors at every point, to measure an orbit-response matrix."
+    ),
+    "category": "accelerator",
+    "required_devices": ["correctors", "detectors"],
+    "writes": True,
+}
+
+
+class PARAMS(BaseModel):
+    """Parameters for ``response_matrix``: correctors to sweep, BPMs to read.
+
+    Sweeps each corrector in ``correctors``, one at a time, over ``num``
+    evenly-spaced currents spanning ``[-span_a, +span_a]``, reading every
+    detector in ``detectors`` at each point.
+    """
+
+    correctors: list[str] = Field(
+        ..., min_length=1, description="Corrector device names to sweep, one at a time."
+    )
+    detectors: list[str] = Field(
+        ..., min_length=1, description="BPM detector device names to read at every point."
+    )
+    span_a: float = Field(
+        ...,
+        gt=0,
+        le=10.0,
+        description="Half-width, in amps, of the symmetric current sweep around zero.",
+    )
+    num: int = Field(..., ge=3, description="Number of evenly-spaced current points per corrector.")
+
+    @model_validator(mode="after")
+    def _correctors_and_detectors_disjoint(self) -> PARAMS:
+        """Reject a device named as both a driven corrector and a read BPM."""
+        overlap = set(self.correctors) & set(self.detectors)
+        if overlap:
+            raise ValueError(
+                f"correctors and detectors must be disjoint (overlap: {sorted(overlap)})"
+            )
+        return self
+
+
+def build_plan(devices: dict[str, Any], params: PARAMS) -> Any:
+    """Build the orbit-response-matrix sweep generator.
+
+    Mirrors the built-in ``orm`` plan's (``plans.py``) idiom: for each
+    corrector, sweep ``num`` currents evenly spaced over ``[-span_a,
+    +span_a]``, moving the corrector then ``trigger_and_read``-ing every
+    corrector together with every BPM detector in one bundle, so each point
+    emits exactly one event carrying the driven corrector's current alongside
+    every BPM reading. Each corrector is restored to 0 A once its own sweep
+    finishes, including on abort (the ``try``/``finally`` runs on
+    ``GeneratorExit`` too) — a restore failure is caught and logged rather
+    than allowed to replace an in-flight sweep exception.
+    """
+    correctors = [(name, devices[name]) for name in params.correctors]
+    corrector_devices = [corrector for _, corrector in correctors]
+    detector_devices = [devices[name] for name in params.detectors]
+    step = (2 * params.span_a) / (params.num - 1)
+    currents = [-params.span_a + i * step for i in range(params.num)]
+
+    all_devices = corrector_devices + detector_devices
+
+    @bpp.stage_decorator(all_devices)
+    @bpp.run_decorator()
+    def _sweep():
+        for name, corrector in correctors:
+            try:
+                for current in currents:
+                    yield from bps.mv(corrector, current)
+                    yield from bps.trigger_and_read(all_devices)
+            finally:
+                try:
+                    yield from bps.mv(corrector, 0.0)
+                except Exception:
+                    logger.warning(
+                        "response_matrix plan: failed to restore corrector %s to 0 A "
+                        "during cleanup; preserving the original error",
+                        name,
+                        exc_info=True,
+                    )
+
+    return _sweep()

--- a/src/osprey/services/bluesky_bridge/promotion.py
+++ b/src/osprey/services/bluesky_bridge/promotion.py
@@ -1,0 +1,158 @@
+"""Prepares a validated session-tier plan for promotion to a permanent catalog.
+
+This module is thin glue, not a promotion engine: it never opens a pull/merge
+request, never commits, and never touches ``plan_loader.py``'s directory
+layers or trust order. All it does is (1) refuse to hand off a session plan
+whose *current* on-disk content lacks a passing validation record — the same
+check the load gate (task 2.4) and promote gate (task 2.5) perform — and (2)
+copy that plan's exact bytes into a checkout of the repo that owns the target
+``preset``/``facility`` plan directory, so the file is ready to ``git add``.
+
+**The promotion workflow this glue supports:**
+
+1. Author + validate a session plan (``write_bluesky_plan`` /
+   ``validate_bluesky_plan`` — task 2.3), then run it a few times via
+   ``launch_scan`` until it looks worth keeping.
+2. Call :func:`prepare_promotion` with the plan's ``name`` and a filesystem
+   path to a checkout of the repo that owns the target catalog directory —
+   one of the directories already listed in ``scan.plan_dirs`` (config.yml,
+   ``preset`` tier) or ``BLUESKY_PLAN_DIRS`` (env, ``facility`` tier); see
+   ``plan_loader.py``'s module docstring for the tier mapping. This raises
+   unless the plan has a passing validation record for its exact current
+   content.
+3. Call :func:`stage_promotion` on the result to write the file into that
+   checkout.
+4. Use the existing **``osprey-contribute``** skill (branch → commit → push
+   → PR, GitHub Flow) to open the PR/MR proposing the addition — exactly as
+   for any other change to that repo. This module supplies the file and a
+   suggested branch name / PR title / PR body; it does not re-implement any
+   part of that workflow.
+
+**The trust boundary — read this before wiring anything to auto-promote:**
+Nothing in this module (or step 1-3 above) raises the plan's provenance.
+A staged file sitting in a target repo's working tree, or even a pushed
+branch with an open PR, is still exactly as trusted as it was in the
+session: unreviewed. Provenance rises from ``session`` to ``preset``/
+``facility`` **only** at the moment a human reviews and merges that PR/MR
+into the branch the deployment actually serves plans from. The merge is the
+trust boundary — not this module, not validation, not the PR being open.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .plan_validation import hash_plan_body
+from .session_dir import resolve_session_plan_dir
+from .validation_record import validation_records
+
+
+class UnknownSessionPlanError(FileNotFoundError):
+    """No session-tier plan file named ``name`` exists."""
+
+
+class UnvalidatedPlanError(ValueError):
+    """The session plan's current on-disk content has no passing validation record."""
+
+
+@dataclass(frozen=True)
+class PromotionRequest:
+    """Everything a contributor needs to propose a session plan for promotion.
+
+    ``target_path`` is where the file should land inside a checkout of the
+    repo that owns the target ``preset``/``facility`` plan directory —
+    :func:`prepare_promotion` never writes there itself; :func:`stage_promotion`
+    does that as an explicit, separate step.
+    """
+
+    name: str
+    body: str
+    content_hash: str
+    source_path: Path
+    target_path: Path
+    suggested_branch: str
+    suggested_pr_title: str
+    suggested_pr_body: str
+
+
+def prepare_promotion(name: str, catalog_dir: str | Path) -> PromotionRequest:
+    """Build a `PromotionRequest` for a validated session plan.
+
+    Reads ``name``'s current on-disk content from the bridge's session
+    directory (``session_dir.resolve_session_plan_dir()``) and refuses to
+    proceed unless that exact content already has a passing validation
+    record (``validation_record.validation_records``) — an edit made after
+    the last successful ``validate_bluesky_plan`` call changes the content
+    hash and drops the record, exactly as it does for the load gate (2.4)
+    and promote gate (2.5). Never writes anywhere; purely a read + gate check.
+
+    Args:
+        name: Session plan name (the file stem written by ``write_bluesky_plan``).
+        catalog_dir: Filesystem path of the target `preset`/`facility` plan
+            directory, inside a local checkout of the repo that owns it.
+
+    Returns:
+        A `PromotionRequest` describing what to write where, plus a
+        suggested branch name and PR title/body for the ``osprey-contribute``
+        skill to use verbatim or adapt.
+
+    Raises:
+        UnknownSessionPlanError: No such session plan file exists.
+        UnvalidatedPlanError: The file's current content has no passing
+            validation record — call ``validate_bluesky_plan`` first.
+    """
+    source_path = resolve_session_plan_dir() / f"{name}.py"
+    if not source_path.is_file():
+        raise UnknownSessionPlanError(
+            f"No session plan named {name!r} in {source_path.parent} "
+            "— call write_bluesky_plan first."
+        )
+
+    body = source_path.read_text(encoding="utf-8")
+    content_hash = hash_plan_body(body)
+    if not validation_records.has_passing_record(content_hash):
+        raise UnvalidatedPlanError(
+            f"Session plan {name!r} (content hash {content_hash[:12]}...) has no "
+            "passing validation record for its CURRENT content — call "
+            "validate_bluesky_plan and confirm it passes before promoting. "
+            "Editing the file after validation invalidates this check, by design."
+        )
+
+    target_path = Path(catalog_dir) / f"{name}.py"
+    return PromotionRequest(
+        name=name,
+        body=body,
+        content_hash=content_hash,
+        source_path=source_path,
+        target_path=target_path,
+        suggested_branch=f"feature/promote-{name}-plan",
+        suggested_pr_title=f"Add {name} scan plan to the catalog",
+        suggested_pr_body=(
+            f"Promotes the session-authored `{name}` scan plan (validated "
+            f"content hash `{content_hash}`) to a permanent catalog plan.\n\n"
+            "This file was authored and dry-run validated (mock devices only) "
+            "in an OSPREY session; it has never run against real hardware. "
+            "Merging this PR is what raises its provenance from `session` to "
+            "reviewed — review the plan body as you would any other code "
+            "change before approving."
+        ),
+    )
+
+
+def stage_promotion(request: PromotionRequest) -> Path:
+    """Write ``request.body`` to ``request.target_path``, creating parent dirs.
+
+    The one filesystem side effect this module performs: copying the
+    validated session plan's exact bytes into a checkout of the target
+    catalog repo so the ``osprey-contribute`` skill has something to
+    ``git add``. Byte-for-byte identical to the session file — no
+    re-generation, no re-formatting — so the content hash a reviewer or a
+    future re-validation computes is unchanged by the move.
+
+    Returns:
+        The path written (``request.target_path``).
+    """
+    request.target_path.parent.mkdir(parents=True, exist_ok=True)
+    request.target_path.write_text(request.body, encoding="utf-8")
+    return request.target_path

--- a/src/osprey/services/bluesky_bridge/runs.py
+++ b/src/osprey/services/bluesky_bridge/runs.py
@@ -146,13 +146,42 @@ class RunRegistry:
 registry = RunRegistry()
 
 
-def do_promote(run: Run, scanner_factory: Callable[[], Scanner]) -> Run:
+def do_promote(
+    run: Run,
+    scanner_factory: Callable[[], Scanner],
+    *,
+    validator: Callable[[Run], None] | None = None,
+) -> Run:
     """The single choke point that starts a real scan.
 
     Callers (the token-gated ``POST /runs/{id}/promote`` route, task 1.5) must
     already have enforced their sanctioned human decision — the promote token
     (``security.verify_promote_token``) plus `launch_scan`'s in-tool
     ``writes_enabled`` re-check — before calling this.
+
+    ``validator``, if given, is called with ``run`` BEFORE ``registry.lock``
+    is acquired at all — deliberately outside the lock below, not folded into
+    its check-and-set. That lock exists to guard a fast in-memory
+    check-and-set only (see the next paragraph); a validator may do
+    unbounded author-controlled work (task 2.5's session-plan validation gate
+    re-scans and re-``exec_module``s every validated session plan via
+    ``get_facility_plans()``), and running that under the same lock
+    ``stop_run`` (``app.py``) shares would let a concurrent promote's
+    validator delay an emergency stop of an unrelated, already-running scan —
+    exactly the kind of latency this lock must never carry. It must raise
+    ``fastapi.HTTPException`` to refuse the promotion or return `None` to
+    allow it. Dependency-injected (mirroring ``scanner_factory``) so this
+    module never has to import bluesky/``plan_loader`` itself — `None` (the
+    default) skips the call entirely, preserving every existing caller that
+    doesn't pass one. Running before the lock means a validator also runs
+    ahead of the ``promoted``/``promoting``/``stopped`` checks below — a run
+    that is both stopped and unvalidated gets the validator's 409 rather than
+    the ``stopped`` 409, which is an immaterial precedence swap (both are
+    409 rejections). The validator's own correctness never depends on the
+    lock: it re-reads/re-hashes the plan file fresh off disk, and
+    ``scanner_factory().reinitialize()`` below re-resolves the plan registry
+    again regardless, which is the actual TOCTOU-safe barrier against a plan
+    that changes between the validator call and the scan actually starting.
 
     ``scanner_factory`` builds a fresh `Scanner` OUTSIDE the lock (it may be
     slow, e.g. constructing a real bluesky `RunEngine`); the lock only guards
@@ -184,6 +213,9 @@ def do_promote(run: Run, scanner_factory: Callable[[], Scanner]) -> Run:
     actually started, since every `Scanner.stop_scanning_thread()` must
     already tolerate being called on an inactive scanner.
     """
+    if validator is not None:
+        validator(run)
+
     with registry.lock:
         if run.promoted:
             raise HTTPException(status_code=409, detail=f"run {run.id!r} already promoted")

--- a/src/osprey/services/bluesky_bridge/session_dir.py
+++ b/src/osprey/services/bluesky_bridge/session_dir.py
@@ -1,0 +1,55 @@
+"""Resolves the bridge-owned, writable session-plan directory.
+
+An authored (session-tier) plan file is the one thing the bridge itself
+writes, rather than merely discovers — every directory layer
+``plan_loader.py`` otherwise scans (``shipped``/``preset``/``facility``) is
+operator-supplied and read-only from the bridge's point of view. This module
+is the single place that resolves *where* an authored plan file lives, so
+both the write path (task 2.3's ``POST /plans/session``) and the discovery
+path (task 2.4's session-tier directory layer) agree on the same directory
+without either hardcoding it.
+
+Ephemeral by design, like the run registry (``runs.py``) and the validation
+record store (``validation_record.py``): the default directory has no deploy
+volume behind it, so a container rebuild/restart loses every session plan
+along with the (equally in-memory) validation records that referenced them —
+consistent with the bridge's existing "stateless except explicit, documented
+exceptions" posture. A deploy that wants session plans to survive a restart
+sets ``BLUESKY_SESSION_PLAN_DIR`` to a mounted, writable path.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# Set per bridge instance to override the default below with a persistent
+# (e.g. volume-mounted) writable directory.
+_SESSION_PLAN_DIR_ENV = "BLUESKY_SESSION_PLAN_DIR"
+
+# In-image default: a sibling of the shipped plan directory
+# (``plan_loader.py``'s ``_SHIPPED_PLANS_DIR``), created on first use. Writable
+# in every deploy today (it lives inside the installed package tree, which is
+# not mounted read-only), but not persisted across a container rebuild —
+# see the module docstring.
+_DEFAULT_SESSION_PLAN_DIR = Path(__file__).parent / "plans_session"
+
+
+def resolve_session_plan_dir() -> Path:
+    """The bridge's writable session-plan directory, creating it if needed.
+
+    Resolution order:
+
+    1. ``BLUESKY_SESSION_PLAN_DIR`` env var — set per bridge instance to
+       point at a persistent, writable directory.
+    2. The in-image default (see :data:`_DEFAULT_SESSION_PLAN_DIR`).
+
+    Always ``mkdir(parents=True, exist_ok=True)``s the resolved directory
+    before returning it, so every caller (this task's write/validate routes,
+    task 2.4's session-tier directory layer) can rely on the directory
+    existing without each re-implementing the same check.
+    """
+    raw = os.environ.get(_SESSION_PLAN_DIR_ENV)
+    directory = Path(raw) if raw else _DEFAULT_SESSION_PLAN_DIR
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory

--- a/src/osprey/services/bluesky_bridge/validation_record.py
+++ b/src/osprey/services/bluesky_bridge/validation_record.py
@@ -1,0 +1,69 @@
+"""Content-hash-keyed store of PASSING plan-validation records.
+
+The bridge is otherwise stateless (see ``runs.py``'s module docstring for the
+run registry's own rationale) — this module is a bounded, explicit exception:
+a session-tier plan file must be validated (``plan_validation.py``'s
+:func:`~osprey.services.bluesky_bridge.plan_validation.validate_bluesky_plan`)
+before anything downstream will treat it as real, and re-validating on every
+load/promote check would mean re-running the stage-3 dry-run subprocess on
+every request. Instead, task 2.3's validate route calls
+:func:`~osprey.services.bluesky_bridge.plan_validation.hash_plan_body` once and
+records a PASS here by that hash; task 2.4's session-layer load gate and task
+2.5's promote gate re-hash the file's *current* on-disk content the same way
+and ask whether that hash has a passing record.
+
+Only a passing validation is ever recorded — a failed validation records
+nothing, so an unknown hash and a previously-failed hash are indistinguishable
+to :meth:`ValidationRecordStore.has_passing_record` (both answer ``False``).
+This also means an edit to a previously-passing file changes its content hash
+and silently drops back to "no record" until re-validated — exactly the
+re-check tasks 2.4/2.5 need.
+
+In-memory only, like ``runs.py``'s ``RunRegistry``: a bridge restart loses
+every record, so a session plan that passed validation before a restart must
+be re-validated before it can be loaded or promoted again.
+"""
+
+from __future__ import annotations
+
+from threading import Lock
+
+
+class ValidationRecordStore:
+    """Thread-safe in-memory set of content hashes with a PASSING validation.
+
+    Mirrors ``runs.py``'s ``RunRegistry``: a single :class:`threading.Lock`
+    guards the underlying set, since the bridge serves concurrent requests.
+    """
+
+    def __init__(self) -> None:
+        self._passing_hashes: set[str] = set()
+        self.lock = Lock()
+
+    def record(self, content_hash: str) -> None:
+        """Mark ``content_hash`` as having a passing validation.
+
+        Callers must only call this for a hash whose validation actually
+        passed (see :class:`~osprey.services.bluesky_bridge.plan_validation.ValidationResult`.
+        ``passed``) — recording a failing hash would defeat the "unknown or
+        failed both read as no record" contract :meth:`has_passing_record`
+        relies on. Recording an already-recorded hash is a harmless no-op.
+        """
+        with self.lock:
+            self._passing_hashes.add(content_hash)
+
+    def has_passing_record(self, content_hash: str) -> bool:
+        """Whether ``content_hash`` has a recorded passing validation.
+
+        Returns `False` for both a hash that was never recorded and a hash
+        whose only validation attempt failed (failures are never recorded —
+        see :meth:`record`), which are indistinguishable by design.
+        """
+        with self.lock:
+            return content_hash in self._passing_hashes
+
+
+# Module-level singleton: the bridge process's one validation-record store.
+# Reachable via `from .validation_record import validation_records` — task
+# 2.3's validate route records into it, tasks 2.4/2.5's gates query it.
+validation_records = ValidationRecordStore()

--- a/src/osprey/services/build_artifacts/catalog.py
+++ b/src/osprey/services/build_artifacts/catalog.py
@@ -269,6 +269,12 @@ def _get_default_artifacts() -> list[BuildArtifact]:
             output_path=".claude/skills/logbook-deep-research/SKILL.md",
             description="Multi-phase logbook investigation skill",
         ),
+        BuildArtifact(
+            canonical_name="skills/writing-bluesky-plans",
+            template_path="claude/skills/writing-bluesky-plans/SKILL.md",
+            output_path=".claude/skills/writing-bluesky-plans/SKILL.md",
+            description="Author, validate, and launch a session-tier Bluesky scan plan",
+        ),
         # ── Output Styles ────────────────────────────────────────────
         BuildArtifact(
             canonical_name="output-styles/control-operator",

--- a/src/osprey/services/python_executor/analysis/pattern_detection.py
+++ b/src/osprey/services/python_executor/analysis/pattern_detection.py
@@ -16,6 +16,7 @@ Related to Issue #18 - Control System Abstraction (Layer 1)
 """
 
 import re
+from typing import Any
 
 from osprey.utils.logger import get_logger
 
@@ -129,7 +130,7 @@ def detect_control_system_operations(
     patterns: dict[str, list[str]] | None = None,
     control_system_type: str | None = None,
     pattern_mode: str | None = None,
-) -> dict[str, any]:
+) -> dict[str, Any]:
     """
     Detect control system operations using framework-standard or custom patterns.
 

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
@@ -5,7 +5,7 @@ name: Human Approval Gate
 description: Requires human approval for dangerous operations based on per-tool policy
 summary: Requires human approval for dangerous operations
 event: PreToolUse
-tools: channel_write, execute, setup_patch, entry_create
+tools: channel_write, execute, setup_patch, entry_create, launch_scan
 safety_layer: 2
 ---
 
@@ -179,6 +179,116 @@ def _focus_artifact(gallery_base_url: str, artifact_id: str) -> None:
         urllib.request.urlopen(req, timeout=2)
     except Exception:
         pass
+
+
+# Default Bluesky bridge base URL — mirrors
+# osprey.mcp_server.scan.server_context.ScanContext._resolve_bridge_url's
+# fallback (`_DEFAULT_BRIDGE_URL`) without importing that module: this hook
+# runs standalone, in a different process/venv from OSPREY's own package.
+_DEFAULT_BRIDGE_URL = "http://127.0.0.1:8090"
+
+
+def _resolve_bridge_url(config: dict) -> str:
+    """Resolve the Bluesky bridge base URL: env wins outright over config.yml.
+
+    Resolution order mirrors `ScanContext._resolve_bridge_url` exactly:
+    ``BLUESKY_BRIDGE_URL`` env var, then ``scan.bridge_url`` in config.yml,
+    then the loopback default above.
+    """
+    full = os.environ.get("BLUESKY_BRIDGE_URL")
+    if full:
+        return full.rstrip("/")
+    url = config.get("scan", {}).get("bridge_url", _DEFAULT_BRIDGE_URL)
+    return str(url).rstrip("/")
+
+
+def _bridge_get_json(base_url: str, path: str, timeout: float = 3.0):
+    """GET ``path`` off the bridge and return parsed JSON, or `None` on ANY failure.
+
+    Fail-open (same pattern as `_focus_artifact` below): an unreachable
+    bridge, a 404, a network hiccup, or a malformed response must never block
+    the launch-approval prompt — every caller here treats `None` as "render
+    less detail", never as a reason to raise.
+    """
+    try:
+        import urllib.request
+
+        req = urllib.request.Request(f"{base_url}{path}", method="GET")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.load(resp)
+    except Exception:
+        return None
+
+
+def _describe_launch_scan(tool_input: dict, config: dict) -> list[str]:
+    """Render the launch-approval prompt's plan detail lines.
+
+    This is the human backstop for the plan-validator's documented, accepted
+    residual (a `getattr`/string-concat obfuscated body that passes the
+    sandbox's AST import/pattern scan — see `plan_validation.py`'s module
+    docstring): an approver who can actually SEE the plan's source has a
+    chance to refuse it even where the earlier automated stages could not.
+    Every bridge call goes through `_bridge_get_json`, so any fetch/parse
+    failure just yields a shorter (or empty) line list — never an exception.
+    """
+    run_id = tool_input.get("run_id")
+    if not run_id:
+        return []
+
+    base_url = _resolve_bridge_url(config)
+    run = _bridge_get_json(base_url, f"/runs/{run_id}")
+    plan_name = run.get("plan_name") if run else None
+    if not plan_name:
+        return []
+
+    lines = [f"Plan: {plan_name}"]
+
+    plan_args = run.get("plan_args") if run else None
+    if plan_args:
+        lines.append(f"Plan args: {json.dumps(plan_args)}")
+
+    plans = _bridge_get_json(base_url, "/plans") or []
+    plan_entry = next((p for p in plans if p.get("name") == plan_name), None)
+    metadata = (plan_entry or {}).get("metadata")
+    if metadata:
+        lines.append(f"Category: {metadata.get('category', 'unknown')}")
+        devices = metadata.get("required_devices") or []
+        lines.append(f"Required devices: {', '.join(devices) if devices else 'none declared'}")
+        lines.append(
+            "Hazard: writes to hardware"
+            if metadata.get("writes")
+            else "Hazard: read-only (no hardware writes declared)"
+        )
+    else:
+        lines.append("Category/devices/hazard: unavailable (no authoring metadata — built-in plan)")
+
+    source_info = _bridge_get_json(base_url, f"/plans/{plan_name}/source")
+    provenance = (source_info or {}).get("provenance") or (plan_entry or {}).get("provenance")
+    if provenance in ("session", "unreviewed"):
+        lines.append(f"Provenance: {provenance.upper()} — AGENT-AUTHORED, NOT REVIEWED BY A HUMAN")
+    elif provenance:
+        lines.append(f"Provenance: {provenance} (operator-supplied)")
+    else:
+        lines.append("Provenance: unknown")
+
+    if source_info is None:
+        lines.append("Validation status: unknown (could not reach the plan-source endpoint)")
+    elif provenance in ("session", "unreviewed"):
+        lines.append(
+            "Validation status: PASSED (content hash matches a recorded validation run)"
+            if source_info.get("validated")
+            else "Validation status: NO PASSING RECORD — would be refused/quarantined at launch"
+        )
+    else:
+        lines.append("Validation status: not applicable (operator-supplied plan)")
+
+    if source_info is not None:
+        source_text = source_info.get("source", "")
+        if source_text:
+            note = " (truncated)" if source_info.get("truncated") else ""
+            lines.append(f"\nPlan source{note}:\n{source_text}")
+
+    return lines
 
 
 def _create_pre_execution_notebook(code: str, exec_mode: str, config: dict) -> str | None:
@@ -371,6 +481,11 @@ def main():
         channel_list = ", ".join(f"{op.get('channel')}={op.get('value')}" for op in channels)
         if channel_list:
             reason_parts.append(f"Channels: {channel_list}")
+    elif short_name == "launch_scan":
+        try:
+            reason_parts.extend(_describe_launch_scan(tool_input, config))
+        except Exception:
+            pass
 
     reason = "\n".join(reason_parts)
     log_hook(

--- a/src/osprey/templates/claude_code/claude/skills/writing-bluesky-plans/SKILL.md
+++ b/src/osprey/templates/claude_code/claude/skills/writing-bluesky-plans/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: writing-bluesky-plans
+description: >
+  Author a new Bluesky scan plan for the scan MCP server: the plan-file
+  format (PLAN_METADATA/PARAMS/build_plan), the allowlist the validator
+  enforces, and the author -> validate -> run -> promote workflow. Use when
+  asked to write, draft, or author a new scan/bluesky plan, or when an
+  existing plan needs editing before re-validation. NOT for operating an
+  already-registered plan (use list_scan_plans/create_scan_intent directly).
+summary: Author, validate, and launch a session-tier Bluesky scan plan
+---
+
+# Writing Bluesky Plans
+
+Author a new scan plan as a plain-text file, get it machine-validated in a
+sandbox with no hardware access, then launch it through the normal scan
+workflow. A plan you write is inert until `validate_bluesky_plan` records a
+pass for its exact content — nothing you author here is ever imported or
+executed directly.
+
+---
+
+## The plan-file format
+
+A plan file is a single Python module exposing exactly three things:
+
+1. **`PLAN_METADATA`** — a plain dict with five required keys, all required
+   (a plan missing one is rejected at load time, not defaulted):
+   - `name` (str) — the plan's name.
+   - `description` (str) — human-readable summary.
+   - `category` (str) — free-text grouping shown to operators (e.g.
+     `"accelerator"`).
+   - `required_devices` (list[str]) — names of the `PARAMS` fields that name
+     devices the plan drives or reads (e.g. `["correctors", "detectors"]`).
+   - `writes` (bool) — whether the plan moves a device (vs. read-only).
+     Authoring metadata only; it has no effect on whether writes actually
+     happen — that is governed entirely by `control_system.writes_enabled`.
+
+2. **`PARAMS`** — a `pydantic.BaseModel` subclass declaring the plan's own
+   parameters (device names, ranges, point counts, ...). Use `Field(...)`
+   constraints and a `model_validator` where it helps (e.g. rejecting a
+   device named as both a driven setpoint and a read detector).
+
+3. **`build_plan(devices, params)`** — a callable taking `devices: dict[str,
+   Any]` (resolved by string name, injected by the bridge — never free names
+   in a namespace) and `params: PARAMS`, returning a bluesky generator
+   (typically built with `bluesky.plan_stubs`/`bluesky.plans`/
+   `bluesky.preprocessors`).
+
+**Study the two shipped exemplars for the full worked pattern — do not
+invent new accelerator physics:**
+- `response_matrix` (`src/osprey/services/bluesky_bridge/plans_core/response_matrix.py`)
+  — sweeps each corrector over a bounded current range, reading every BPM
+  detector at each point, to measure an orbit-response matrix.
+- `grid_scan_nd` (`src/osprey/services/bluesky_bridge/plans_core/grid_scan.py`)
+  — steps a set of setpoint devices over a rectangular grid, reading a set of
+  detectors at every grid point.
+
+These are the ONLY accelerator scan patterns this framework ships. Never
+propose or author a BBA (beam-based alignment) or tune-scan plan — they are
+explicitly out of scope.
+
+---
+
+## The allowlist the validator enforces
+
+`validate_bluesky_plan` runs your file's body through three ordered stages,
+any of which can reject it outright before the next ever runs:
+
+1. **Static import allowlist** — only these imports are permitted:
+   - `bluesky.plan_stubs`, `bluesky.plans`, `bluesky.preprocessors`
+     (submodule-exact — bare `import bluesky` or `bluesky.utils` is
+     rejected).
+   - `numpy`, `scipy`, `math`, `statistics`, `time`, `collections`,
+     `itertools`, `functools`, `pydantic`.
+   - Everything else (`epics`, `os`, `subprocess`, `ctypes`, `importlib`,
+     `socket`, ...) is rejected.
+2. **CA/connector pattern scan** — rejects any body matching `caput(`,
+   `caget(`, `epics.`, `aioca`, `caproto`, `write_channel(`, `read_channel(`,
+   `_osprey_connector`, or `PV(`. Ordinary numeric/stdlib calls that merely
+   share a method name (`numpy.put(...)`, `dict.get(...)`, `queue.put(...)`)
+   are NOT flagged — device I/O only ever happens through the `devices` dict
+   `build_plan` is handed, never through a raw control-system import.
+3. **Mock-device dry run** — actually builds and drives your `build_plan`
+   generator to completion against in-process mock devices, in a subprocess
+   with `EPICS_CA_*` neutralized. This is an authoring-quality check ("does
+   it actually run"), not the containment boundary — containment is stages 1
+   and 2 plus the load/promote gates that key off the validation record.
+
+**Foot-gun: use `bps.sleep(...)`, never `time.sleep(...)`.** `time.sleep`
+blocks the RunEngine's worker thread for its whole duration — no other plan
+step, status update, or stop request can be serviced until it returns.
+`bluesky.plan_stubs.sleep(...)` yields a message the RunEngine schedules
+cooperatively, so the run stays responsive. `time` is on the import
+allowlist for ordinary bookkeeping (computing a delay, timestamping) — it is
+never a substitute for `bps.sleep` inside a plan's own control flow.
+
+---
+
+## Workflow: author -> validate -> run -> promote
+
+1. **Author** — `write_bluesky_plan(name, category, required_devices,
+   writes, body, description="")`. `body` is your `PARAMS` + `build_plan`
+   source (no `PLAN_METADATA` block — the bridge assembles and prepends one
+   from your other arguments). Writes a session-tier file; reaches no
+   hardware. Re-authoring the same `name` overwrites the file and drops any
+   prior passing validation (its content hash changes).
+2. **Validate** — `validate_bluesky_plan(name, sample_args=None,
+   dry_run_timeout=30.0)`. Validates the file's CURRENT on-disk content
+   (never a body you pass directly) through the three stages above.
+   `sample_args` should supply realistic `PARAMS` field values so the dry
+   run's mock devices match what your plan expects. A pass is what makes the
+   plan loadable at all — an unvalidated session plan is never listed,
+   loaded, or launchable.
+3. **Confirm it's live** — `list_scan_plans()` to see the plan appear with
+   `provenance: "session"` alongside its `metadata`.
+4. **Run** — `create_scan_intent(plan_name, plan_args)` records an intent
+   (motion-safe, no device touched yet), then `launch_scan(run_id)` is the
+   sole promote path: it re-checks the validation record against the file's
+   current hash, requires `control_system.writes_enabled`, and needs human
+   approval. Use `scan_status(run_id)` / `read_scan_data(run_id, ...)` to
+   watch it run.
+5. **Promote to permanent** — a session plan stays session-tier (least
+   trusted, most ephemeral) until a human reviews and merges it into a
+   facility catalog directory; that is a separate follow-up step, not
+   something this skill or any MCP tool does automatically.
+
+---
+
+## Anti-patterns
+
+- **Never** import or reference EPICS/CA/connector internals directly
+  (`epics`, `caput`/`caget`, `_osprey_connector`, raw PV names) — all device
+  I/O goes through the `devices` dict `build_plan` receives.
+- **Never** use `time.sleep(...)` inside a plan body — use `bps.sleep(...)`.
+- **Never** propose a BBA or tune-scan plan — `response_matrix` (ORM) and
+  `grid_scan_nd` are the only scan patterns this framework ships.
+- **Never** hard-code a facility device name inside `build_plan` — resolve
+  every device by string name through the injected `devices` dict, exactly
+  like both exemplars.
+- **Never** treat a passing dry run as proof the plan is safe against real
+  hardware — it proves the plan *runs*, not that its device motion is
+  physically sound. Human approval at launch is the real backstop.
+- **Never** include a `from __future__ import ...` line in your body — the
+  bridge always prepends a generated `PLAN_METADATA` assignment ahead of it,
+  so it can never be the file's first statement (a hard Python requirement);
+  modern type hints (`list[str]`, `dict[str, Any]`) work without it on
+  Python 3.9+.

--- a/src/osprey/templates/services/bluesky/docker-compose.yml.j2
+++ b/src/osprey/templates/services/bluesky/docker-compose.yml.j2
@@ -64,6 +64,15 @@ services:
       # dispatch_worker's identical CONFIG_FILE convention.
       CONFIG_FILE: /app/project/config.yml
       TZ: {{ system.timezone }}
+{% if services.bluesky.plan_dir %}
+      # Facility scan-plan directory (Task 1.4): the plan loader
+      # (plan_loader.py) reads BLUESKY_PLAN_DIRS as an os.pathsep-separated
+      # list of IN-CONTAINER paths and scans each as a "facility"-tier
+      # layer. This MUST be the mount target below, never the host path
+      # configured in services.bluesky.plan_dir — the container environment
+      # never sees the operator's host filesystem layout.
+      BLUESKY_PLAN_DIRS: /app/project/plans
+{% endif %}
 {% if 'virtual_accelerator' in deployed_services %}
       # Reach the co-deployed Virtual Accelerator (Task 4.1) over Channel
       # Access. Name-server TCP transport is the one host<->container CA
@@ -107,6 +116,17 @@ services:
       # config.yml to resolve control_system settings regardless of which
       # optional services are co-deployed (Task 3.2).
       - ./bluesky/config.yml:/app/project/config.yml:ro
+{% if services.bluesky.plan_dir %}
+      # Facility plan directory (Task 1.4): operator-supplied host path via
+      # services.bluesky.plan_dir in config.yml, mounted read-only — the
+      # bridge only discovers/execs plans from here, never writes into it.
+      # An absolute host path passes through unchanged; a relative one
+      # resolves against the compose project directory (build/services/),
+      # same rule as every other bind source in this file. The container
+      # target is fixed (matches BLUESKY_PLAN_DIRS above) so plan_loader.py
+      # never needs to know the host-side location.
+      - {{ services.bluesky.plan_dir }}:/app/project/plans:ro
+{% endif %}
 {% if (control_system | default({})).writes_enabled | default(false) %}
       # Channel limits DB (Task 3.2, CC-2): only meaningful once writes are
       # enabled — a read-only deploy never opens it. Mounted under the SAME

--- a/tests/cli/test_killswitch_scan_deny.py
+++ b/tests/cli/test_killswitch_scan_deny.py
@@ -9,6 +9,12 @@ off, stop_scan (approval-only, no writes-check) is NEVER denied or
 removed-from-ask (the kill switch must not block stopping a scan), the
 existing controls/python behavior is preserved, and an extends clone gets the
 rewritten-prefix matcher.
+
+Also pins the task-2.3 authoring tools (``write_bluesky_plan``,
+``validate_bluesky_plan``): both reach no hardware regardless of
+``writes_enabled`` (write only emits a file, validate only dry-runs mock
+devices), so they carry ``_APPROVAL`` only — same as ``stop_scan`` — and must
+never be denied or removed-from-ask by the kill switch.
 """
 
 import yaml
@@ -101,6 +107,29 @@ def test_scan_stop_never_denied_or_removed(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# scan.write_bluesky_plan / scan.validate_bluesky_plan — task 2.3 authoring
+# tools; never denied or removed-from-ask (neither reaches hardware)
+# ---------------------------------------------------------------------------
+
+
+def test_scan_authoring_tools_never_denied_or_removed(tmp_path):
+    """write_bluesky_plan/validate_bluesky_plan carry approval only (no
+    _WRITES_CHECK) — like stop_scan, the kill switch must never block them,
+    regardless of writes_enabled, since neither reaches hardware."""
+    for writes_enabled in (True, False):
+        ctx = _build_ctx(
+            tmp_path,
+            writes_enabled=writes_enabled,
+            claude_code_overrides={"servers": {"scan": {"enabled": True}}},
+        )
+        perms = ctx["facility_permissions"]
+        for tool in ("write_bluesky_plan", "validate_bluesky_plan"):
+            matcher = f"mcp__scan__{tool}"
+            assert matcher not in perms.get("deny", [])
+            assert matcher not in perms.get("remove_ask", [])
+
+
+# ---------------------------------------------------------------------------
 # Regression parity: controls/python behavior preserved after generalizing
 # ---------------------------------------------------------------------------
 
@@ -142,3 +171,7 @@ def test_extends_clone_of_scan_denied_with_rewritten_prefix(tmp_path):
     assert "mcp__scan2__launch_scan" in perms["deny"]
     # The template name itself must not leak into the clone's deny entry.
     assert "mcp__scan__launch_scan" not in perms["deny"]
+    # The clone's authoring tools (approval-only, no _WRITES_CHECK) are never
+    # denied under the rewritten prefix either.
+    assert "mcp__scan2__write_bluesky_plan" not in perms.get("deny", [])
+    assert "mcp__scan2__validate_bluesky_plan" not in perms.get("deny", [])

--- a/tests/cli/test_scan_service_registration.py
+++ b/tests/cli/test_scan_service_registration.py
@@ -190,6 +190,91 @@ def test_demo_scanner_off_by_default_omits_env_var(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Facility plan-directory deploy wiring (Task 1.4).
+# ---------------------------------------------------------------------------
+
+
+def test_inject_bluesky_plan_dir_written_to_config(tmp_path: Path) -> None:
+    """A configured plan_dir is emitted into services.bluesky config."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(plan_dir="/opt/facility/scan_plans"), project_path)
+
+    config = _read_config(project_path)
+    assert config["services"]["bluesky"]["plan_dir"] == "/opt/facility/scan_plans"
+
+
+def test_inject_bluesky_no_plan_dir_omits_key(tmp_path: Path) -> None:
+    """No plan_dir configured -> no plan_dir key at all (bridge-only deploy unchanged)."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(), project_path)
+
+    config = _read_config(project_path)
+    assert "plan_dir" not in config["services"]["bluesky"]
+
+
+def test_plan_dir_mount_and_env_round_trip_through_compose(tmp_path: Path) -> None:
+    """A configured plan_dir renders both the read-only bind mount and the
+    in-container BLUESKY_PLAN_DIRS env var the loader (plan_loader.py) reads
+    — the host path must never leak into the container environment."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(plan_dir="/opt/facility/scan_plans"), project_path)
+    config = _read_config(project_path)
+    rendered = _render_copied_compose(project_path, config)
+
+    bridge = rendered["services"]["bluesky-bridge"]
+    assert bridge["environment"]["BLUESKY_PLAN_DIRS"] == "/app/project/plans"
+    assert "/opt/facility/scan_plans:/app/project/plans:ro" in bridge["volumes"]
+    # The host path never appears in the container's environment block.
+    assert "/opt/facility/scan_plans" not in bridge["environment"].values()
+
+
+def test_plan_dir_absent_omits_mount_and_env(tmp_path: Path) -> None:
+    """Regression: a bridge-only deploy (no plan_dir) renders no plan mount
+    and no BLUESKY_PLAN_DIRS env var — unchanged from every prior build."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(), project_path)
+    config = _read_config(project_path)
+    rendered = _render_copied_compose(project_path, config)
+
+    bridge = rendered["services"]["bluesky-bridge"]
+    assert "BLUESKY_PLAN_DIRS" not in bridge["environment"]
+    assert not any(str(v).endswith(":/app/project/plans:ro") for v in bridge["volumes"])
+
+
+def test_loopback_bind_and_failclosed_token_survive_plan_dir_wiring(tmp_path: Path) -> None:
+    """Regression guard for the two invariants this task must not touch:
+    the port bind stays loopback-only and BLUESKY_PROMOTE_TOKEN keeps no
+    ``:-`` default (an unset token must fail closed, never boot with a
+    guessable secret)."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(plan_dir="/opt/facility/scan_plans"), project_path)
+
+    template_text = (project_path / "services" / "bluesky" / "docker-compose.yml.j2").read_text()
+    assert (
+        "\"{{ deployment.bind_address | default('127.0.0.1') }}:"
+        "{{ services.bluesky.port | default(8090) }}:"
+        '{{ services.bluesky.port | default(8090) }}"' in template_text
+    )
+    assert "BLUESKY_PROMOTE_TOKEN: ${BLUESKY_PROMOTE_TOKEN}" in template_text
+    assert "BLUESKY_PROMOTE_TOKEN: ${BLUESKY_PROMOTE_TOKEN:-" not in template_text
+
+
+# ---------------------------------------------------------------------------
 # Build-profile parsing: bluesky stays opt-in, not default-on.
 # ---------------------------------------------------------------------------
 
@@ -208,6 +293,7 @@ def test_profile_bluesky_key_parses_overrides() -> None:
                 "tiled_enabled": True,
                 "tiled_port": 8124,
                 "demo_scanner": True,
+                "plan_dir": "/opt/facility/scan_plans",
             },
         }
     )
@@ -216,6 +302,7 @@ def test_profile_bluesky_key_parses_overrides() -> None:
     assert profile.bluesky.tiled_enabled is True
     assert profile.bluesky.tiled_port == 8124
     assert profile.bluesky.demo_scanner is True
+    assert profile.bluesky.plan_dir == "/opt/facility/scan_plans"
 
 
 def test_profile_bluesky_key_defaults_when_empty_mapping() -> None:
@@ -225,3 +312,4 @@ def test_profile_bluesky_key_defaults_when_empty_mapping() -> None:
     assert profile.bluesky.tiled_enabled is False
     assert profile.bluesky.tiled_port == 8091
     assert profile.bluesky.demo_scanner is False
+    assert profile.bluesky.plan_dir is None

--- a/tests/cli/test_writing_bluesky_plans_skill_install.py
+++ b/tests/cli/test_writing_bluesky_plans_skill_install.py
@@ -1,0 +1,179 @@
+"""Tests for the writing-bluesky-plans skill and its 4-point framework wiring.
+
+Mirrors ``test_session_report_skill.py``'s registry/template/content pattern,
+plus a real ``TemplateManager.create_project`` build (the standard
+skill-install path for the ``templates/claude_code/claude/skills/`` family --
+these skills are NOT installed via the ``osprey skills install`` CLI, which
+only serves the separate ``templates/skills/`` global-skill family) to verify
+the skill actually lands on disk end to end.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from osprey.cli.templates import manifest
+from osprey.cli.templates.manager import TemplateManager
+from osprey.services.build_artifacts.catalog import BuildArtifactCatalog
+
+TEMPLATE_ROOT = Path(__file__).parent.parent.parent / "src" / "osprey" / "templates" / "claude_code"
+PRESETS_DIR = Path(__file__).parent.parent.parent / "src" / "osprey" / "profiles" / "presets"
+
+
+class TestWritingBlueskyPlansRegistry:
+    """Wiring point 1: BuildArtifactCatalog registration."""
+
+    @pytest.fixture()
+    def registry(self):
+        return BuildArtifactCatalog.default()
+
+    def test_registered(self, registry):
+        art = registry.get("skills/writing-bluesky-plans")
+        assert art is not None
+        assert art.output_path == ".claude/skills/writing-bluesky-plans/SKILL.md"
+        assert art.template_path == "claude/skills/writing-bluesky-plans/SKILL.md"
+
+
+class TestWritingBlueskyPlansTemplateExists:
+    """Wiring point 2: the skill bundle template file itself."""
+
+    def test_skill_file_exists(self):
+        path = TEMPLATE_ROOT / "claude" / "skills" / "writing-bluesky-plans" / "SKILL.md"
+        assert path.exists(), f"SKILL.md not found at {path}"
+
+
+class TestWritingBlueskyPlansPresetWiring:
+    """Wiring point 3: the preset's ``skills:`` directive."""
+
+    def test_control_assistant_lists_the_skill(self):
+        profile_text = (PRESETS_DIR / "control-assistant.yml").read_text(encoding="utf-8")
+        profile = yaml.safe_load(profile_text)
+        assert "writing-bluesky-plans" in profile["skills"]
+
+
+class TestWritingBlueskyPlansManifestWiring:
+    """Wiring point 4: the regen-tracked-files fallback list."""
+
+    def test_in_regen_tracked_files(self):
+        assert ".claude/skills/writing-bluesky-plans/SKILL.md" in manifest.REGEN_TRACKED_FILES
+
+
+class TestWritingBlueskyPlansSkillStructure:
+    """Content assertions: allowlist, validate-before-launch flow, bps.sleep guidance."""
+
+    @pytest.fixture()
+    def skill_text(self):
+        path = TEMPLATE_ROOT / "claude" / "skills" / "writing-bluesky-plans" / "SKILL.md"
+        return path.read_text(encoding="utf-8")
+
+    def test_has_frontmatter(self, skill_text):
+        assert skill_text.startswith("---")
+        assert "name: writing-bluesky-plans" in skill_text
+
+    # --- plan-file format ---
+
+    def test_documents_plan_metadata(self, skill_text):
+        assert "PLAN_METADATA" in skill_text
+        for field in ("name", "description", "category", "required_devices", "writes"):
+            assert field in skill_text
+
+    def test_documents_params_and_build_plan(self, skill_text):
+        assert "PARAMS" in skill_text
+        assert "build_plan" in skill_text
+        assert "pydantic.BaseModel" in skill_text or "BaseModel" in skill_text
+
+    def test_references_exemplars(self, skill_text):
+        assert "response_matrix" in skill_text
+        assert "grid_scan_nd" in skill_text
+        assert "plans_core/response_matrix.py" in skill_text
+        assert "plans_core/grid_scan.py" in skill_text
+
+    # --- the allowlist ---
+
+    def test_documents_allowed_imports(self, skill_text):
+        for allowed in (
+            "bluesky.plan_stubs",
+            "bluesky.plans",
+            "bluesky.preprocessors",
+            "numpy",
+            "scipy",
+            "math",
+            "statistics",
+            "collections",
+            "itertools",
+            "functools",
+            "pydantic",
+        ):
+            assert allowed in skill_text, f"Missing allowed import: {allowed}"
+
+    def test_documents_forbidden_imports(self, skill_text):
+        for forbidden in ("epics", "os", "subprocess", "ctypes", "importlib", "socket"):
+            assert forbidden in skill_text, f"Missing forbidden import mention: {forbidden}"
+
+    def test_documents_ca_pattern_scan(self, skill_text):
+        for pattern in ("caput(", "caget(", "_osprey_connector", "write_channel("):
+            assert pattern in skill_text
+
+    # --- the foot-gun ---
+
+    def test_documents_bps_sleep_guidance(self, skill_text):
+        assert "bps.sleep" in skill_text
+        assert "time.sleep" in skill_text
+        assert "RunEngine" in skill_text
+
+    # --- author -> validate -> run -> promote workflow ---
+
+    def test_documents_write_and_validate_tools(self, skill_text):
+        assert "write_bluesky_plan" in skill_text
+        assert "validate_bluesky_plan" in skill_text
+
+    def test_documents_run_tools(self, skill_text):
+        for tool in ("create_scan_intent", "launch_scan", "list_scan_plans"):
+            assert tool in skill_text, f"Missing tool reference: {tool}"
+
+    def test_documents_promote_to_permanent_pointer(self, skill_text):
+        assert "promote" in skill_text.lower()
+
+    # --- explicit out-of-scope guidance ---
+
+    def test_explicitly_rules_out_bba_and_tune_scan(self, skill_text):
+        """BBA/tune-scan must appear only as a named anti-pattern, never as a
+        plan option to author (memory: shipped scan plans are response_matrix
+        (ORM) + n-d grid_scan ONLY; bba/tune_scan "always creeps in")."""
+        assert "propose a BBA or tune-scan plan" in skill_text
+        assert "tune-scan" in skill_text
+        assert "out of scope" in skill_text.lower()
+        assert "ONLY accelerator scan patterns" in skill_text
+
+
+class TestWritingBlueskyPlansInstall:
+    """End-to-end: the skill must actually land on disk via the standard build path.
+
+    ``templates/claude_code/claude/skills/`` artifacts are installed by
+    ``osprey build`` / ``TemplateManager.create_project`` (BuildArtifactCatalog
+    + preset artifact resolution), not by the ``osprey skills install`` CLI
+    (that command only serves ``templates/skills/`` global skills).
+    """
+
+    def test_control_assistant_build_installs_the_skill(self, tmp_path):
+        manager = TemplateManager()
+        project_dir = manager.create_project(
+            project_name="writing-bluesky-plans-install-test",
+            output_dir=tmp_path,
+            data_bundle="control_assistant",
+            context={"channel_finder_mode": "hierarchical"},
+        )
+
+        installed = project_dir / ".claude" / "skills" / "writing-bluesky-plans" / "SKILL.md"
+        assert installed.exists(), f"Skill not installed at {installed}"
+
+        template_text = (
+            TEMPLATE_ROOT / "claude" / "skills" / "writing-bluesky-plans" / "SKILL.md"
+        ).read_text(encoding="utf-8")
+        assert installed.read_text(encoding="utf-8") == template_text
+
+    def test_resolve_manifest_outputs_includes_the_skill(self):
+        mf = {"artifacts": {"skills": ["writing-bluesky-plans"]}}
+        outputs = manifest.resolve_manifest_outputs(mf)
+        assert ".claude/skills/writing-bluesky-plans/SKILL.md" in outputs

--- a/tests/deployment/test_bluesky_arming_guard.py
+++ b/tests/deployment/test_bluesky_arming_guard.py
@@ -237,6 +237,20 @@ def test_every_declared_var_is_classified():
     assert container_lifecycle._LOCAL_EXEC_SAFE_VARS <= declared
 
 
+def test_authoring_tools_declare_no_new_bluesky_arming_token():
+    """The task-2.3 authoring MCP tools (write_bluesky_plan, validate_bluesky_plan)
+    reach no hardware and gate on ``_APPROVAL`` only in the registry (see
+    ``tests/registry/test_scan_server_definition.py``) — they need no arming
+    token of their own. Pin that ``bluesky``'s declared token vars are still
+    exactly the pre-2.3 pair, so this guard's promote-token-withheld
+    invariant (asserted above) still covers the whole deployed surface and
+    hasn't silently been left behind by an unclassified third var."""
+    assert container_lifecycle._SERVICE_TOKEN_VARS["bluesky"] == (
+        "BLUESKY_PROMOTE_TOKEN",
+        "BLUESKY_TILED_API_KEY",
+    )
+
+
 def test_unlisted_arming_token_fails_closed_under_unsafe_local_exec(
     captured_argv, _clean_token_env, monkeypatch, tmp_path, caplog
 ):

--- a/tests/e2e/test_orm_roundtrip.py
+++ b/tests/e2e/test_orm_roundtrip.py
@@ -14,11 +14,12 @@ proves two things end to end:
       HTTP+container stack rather than a direct ``PhysicsBridge`` call).
   (b) the scan reaches a terminal "completed" status within a bounded
       timeout -- i.e. no corrector step ever hangs the bridge's
-      ``EpicsMotor.set()`` settle-wait. A corrector readback that never
-      leaves 0.0 (the FR10 regression this deploy config's
-      ``echo-pyat-coupled-sp-to-rb`` fix addresses) blocks exactly there, so
-      a fixture-level timeout on this assertion IS the regression signature,
-      not an incidentally slow test.
+      ``ConnectorSettable.set()`` settle-wait (``devices/connector.py`` --
+      the connector-mediated device layer replacing the old direct-CA
+      ``EpicsMotor``). A corrector readback that never leaves 0.0 (the FR10
+      regression this deploy config's ``echo-pyat-coupled-sp-to-rb`` fix
+      addresses) blocks exactly there, so a fixture-level timeout on this
+      assertion IS the regression signature, not an incidentally slow test.
 
 No physics fault is seeded on this stack (no ``VA_QUAD_MISALIGN``/
 ``VA_BPM_ERRORS``/``VA_CORR_GAIN`` in the written ``.env`` -- see
@@ -298,9 +299,9 @@ def test_orm_roundtrip_matches_model_with_no_corrector_hang(
 
     # (b) no corrector-step hang: poll to a terminal status within a bounded
     # deadline. A corrector whose :RB never echoes its :SP (the FR10
-    # regression) blocks the bridge's EpicsMotor.set() settle-wait forever --
-    # so a non-"completed" status here, after the deadline, IS the failure
-    # this proves absent, not merely a slow run.
+    # regression) blocks the bridge's ConnectorSettable.set() settle-wait
+    # forever -- so a non-"completed" status here, after the deadline, IS the
+    # failure this proves absent, not merely a slow run.
     deadline = time.monotonic() + SCAN_TIMEOUT_SEC
     status_body: dict = {}
     while time.monotonic() < deadline:
@@ -311,7 +312,7 @@ def test_orm_roundtrip_matches_model_with_no_corrector_hang(
     assert status_body.get("status") == "completed", (
         f"orm scan did not complete within {SCAN_TIMEOUT_SEC:.0f}s (status={status_body}) -- "
         "a corrector step whose :RB never echoes its :SP (the FR10 echo regression) hangs "
-        "exactly here, at the bridge's EpicsMotor.set() settle-wait"
+        "exactly here, at the bridge's ConnectorSettable.set() settle-wait"
     )
 
     status, data = _get(f"/runs/{run_id}/data")

--- a/tests/e2e/test_scan_catalog_e2e.py
+++ b/tests/e2e/test_scan_catalog_e2e.py
@@ -1,0 +1,365 @@
+"""Real-container e2e for the layered scan-plan catalog (task 1.6, closing
+Phase 1 of the plan-catalog epic).
+
+Mocked-client tests (``tests/services/bluesky_bridge/test_plan_loader_layered.py``,
+``test_exemplar_plans.py``) only exercise OSPREY's half of the contract: that
+the loader in this repo resolves layers and trust tiers correctly in-process.
+They never prove that a *deployed* bridge container -- built from the shipped
+image, reading its own filesystem layers -- actually serves the same catalog
+over HTTP. This is the other half: it deploys a real bluesky-bridge container
+and asserts the layered catalog (shipped exemplars + an externally-injected
+facility plan + the built-ins) is discoverable via ``GET /plans`` with correct
+provenance/metadata, and that a facility-injected plan file is not just
+discoverable but actually executable end to end (launch -> promote -> read).
+
+Uses the ``hello-world`` preset with ``services.bluesky.demo_scanner=true``
+(real bluesky RunEngine, MOCK ophyd-async devices -- ``devices/mock.py``, no
+EPICS/Virtual Accelerator at all) rather than the VA-backed stack
+``tests/e2e/_orm_stack.py`` builds -- this test's point is the plan catalog,
+not accelerator physics, so it skips the VA image's amd64-emulated build
+entirely (mirrors ``test_scan_deploy.py``'s identical rationale). The one
+facility plan (``facility_probe``, below) is authored against the demo
+scanner's fixed mock device names (``motor1``/``det1``) so it can actually
+run against this stack.
+
+Container safety: every docker invocation below names an exact
+container/image -- never a wildcard, never ``system prune``/``--volumes``.
+Teardown goes through ``osprey deploy down``, matching every other e2e in
+this directory.
+
+Gating: needs Docker. Much lighter than the VA-backed e2e (no amd64
+emulation) -- comparable to ``test_scan_deploy.py``'s build+deploy time.
+Advisory CI lane (see ci.yml's ``scan-catalog-e2e`` job); run locally with
+``E2E_REUSE_IMAGES=1`` set for fast iteration once the image cache is warm.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.e2e import _orm_stack
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.slow,
+    pytest.mark.skipif(shutil.which("docker") is None, reason="docker not available"),
+]
+
+# Distinct from the sibling e2e modules' pinned ports (_orm_stack.py's 18102,
+# test_scan_deploy.py's 18090, test_va_substrate_equivalence.py's 18099,
+# test_tiled_roundtrip.py's 18101) so all five can run concurrently on a
+# shared dev machine without a port collision.
+BRIDGE_PORT = 18103
+BRIDGE_URL = f"http://localhost:{BRIDGE_PORT}"
+
+BUILD_TIMEOUT_SEC = _orm_stack.BUILD_TIMEOUT_SEC
+DEPLOY_UP_TIMEOUT_SEC = 600
+HEALTH_TIMEOUT_SEC = 120.0
+SCAN_TIMEOUT_SEC = 60.0
+
+# Authored against `devices/mock.py`'s `build_devices()` defaults -- the
+# demo scanner's fixed single motor/detector pair -- so this plan can
+# actually run against the deployed stack (no BLUESKY_EPICS_MOTORS/_DETECTORS
+# wiring applies to the demo-scanner branch; see app.py's `_lifespan`).
+_FACILITY_PLAN_SOURCE = '''"""Test-authored facility-tier plan for the layered plan catalog e2e
+(tests/e2e/test_scan_catalog_e2e.py).
+
+Not part of the shipped OSPREY package: this file is written to a throwaway
+host directory and injected via `services.bluesky.plan_dir`
+(BLUESKY_PLAN_DIRS), so the deployed bridge discovers it as a `facility`-tier
+layer (plan_loader.py). Named `facility_probe` -- distinct from every
+shipped/built-in plan name, so it never collides at the `GET /plans` merge.
+
+Authored against the demo scanner's mock device names (`devices/mock.py`'s
+`build_devices()` defaults: a single `motor1`/`det1` pair), since this e2e
+deploys with `services.bluesky.demo_scanner=true` (no EPICS/Virtual
+Accelerator) -- the point is proving an externally-injected plan file is
+discoverable AND executable, not exercising accelerator physics.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bluesky import plans as bp
+from pydantic import BaseModel, Field, model_validator
+
+PLAN_METADATA = {
+    "name": "facility_probe",
+    "description": "Probe scan: sweep one setpoint device, reading one detector at each point.",
+    "category": "diagnostic",
+    "required_devices": ["motor", "detector"],
+    "writes": True,
+}
+
+
+class PARAMS(BaseModel):
+    """Parameters for `facility_probe`: one setpoint swept over [start, stop]."""
+
+    motor: str = Field(..., description="Setpoint device name to sweep.")
+    detector: str = Field(..., description="Detector device name to read at each point.")
+    start: float
+    stop: float
+    num: int = Field(..., ge=2, description="Number of evenly-spaced points.")
+
+    @model_validator(mode="after")
+    def _motor_and_detector_disjoint(self) -> "PARAMS":
+        if self.motor == self.detector:
+            raise ValueError(f"motor and detector must be distinct (got {self.motor!r} twice)")
+        return self
+
+
+def build_plan(devices: dict[str, Any], params: PARAMS) -> Any:
+    """Wrap `bluesky.plans.scan`: move `motor` over `[start, stop]` in `num`
+    steps, reading `detector` at each point."""
+    motor = devices[params.motor]
+    detector = devices[params.detector]
+    return bp.scan([detector], motor, params.start, params.stop, num=params.num)
+'''
+
+
+def _wait_for_health(url: str, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last_err = "(no response yet)"
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=3.0) as resp:  # noqa: S310 - localhost
+                if resp.status == 200:
+                    return
+                last_err = f"HTTP {resp.status}"
+        except (urllib.error.URLError, ConnectionError, OSError) as exc:
+            last_err = str(exc)
+        time.sleep(1.0)
+    raise AssertionError(f"timed out after {timeout:.0f}s waiting for {url} (last: {last_err})")
+
+
+def _minted_token(project_dir: Path) -> str:
+    from osprey.utils.dotenv import parse_dotenv_file
+
+    env_path = project_dir / ".env"
+    assert env_path.is_file(), f"no .env written at {env_path} — token was not minted"
+    env = parse_dotenv_file(env_path)
+    token = env.get("BLUESKY_PROMOTE_TOKEN")
+    assert token, "BLUESKY_PROMOTE_TOKEN missing/empty in the project .env"
+    return token
+
+
+def _get(path: str) -> tuple[int, Any]:
+    req = urllib.request.Request(f"{BRIDGE_URL}{path}", method="GET")  # noqa: S310
+    try:
+        with urllib.request.urlopen(req, timeout=10.0) as resp:  # noqa: S310
+            return resp.status, json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode("utf-8"))
+
+
+def _post(path: str, body: dict, headers: dict | None = None) -> tuple[int, dict]:
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(  # noqa: S310
+        f"{BRIDGE_URL}{path}",
+        data=data,
+        method="POST",
+        headers={"Content-Type": "application/json", **(headers or {})},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15.0) as resp:  # noqa: S310
+            return resp.status, json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode("utf-8"))
+
+
+@pytest.fixture(scope="module")
+def deployed_catalog_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
+    """Build + ``osprey deploy up --dev`` a demo-scanner bluesky-bridge
+    project with one facility-injected plan file; tear down after.
+
+    ``hello-world`` + ``bluesky.demo_scanner=true`` (mirrors
+    ``test_scan_deploy.py``): no VA co-deploy, no LLM secret needed, no
+    amd64-emulated image build. ``bluesky.plan_dir`` points at a throwaway
+    host directory containing ``_FACILITY_PLAN_SOURCE`` -- the deploy wiring
+    (Task 1.4) bind-mounts it read-only and sets ``BLUESKY_PLAN_DIRS``, so
+    ``plan_loader.py`` scans it as a ``facility``-tier layer.
+    """
+    osprey_bin = _orm_stack.find_osprey_console_script()
+    base = tmp_path_factory.mktemp("scan_catalog_build")
+    plan_dir = tmp_path_factory.mktemp("scan_catalog_plans")
+    (plan_dir / "facility_probe.py").write_text(_FACILITY_PLAN_SOURCE, encoding="utf-8")
+    project_dir = base / "proj"
+
+    build = subprocess.run(
+        [
+            str(osprey_bin),
+            "build",
+            "proj",
+            "--preset",
+            "hello-world",
+            "--set",
+            "bluesky.demo_scanner=true",
+            "--set",
+            f"bluesky.port={BRIDGE_PORT}",
+            "--set",
+            f"bluesky.plan_dir={plan_dir}",
+            "--skip-deps",
+            "--skip-lifecycle",
+            "--output-dir",
+            str(base),
+            "--force",
+        ],
+        cwd=str(base),
+        capture_output=True,
+        text=True,
+        timeout=BUILD_TIMEOUT_SEC,
+        env={**os.environ, "CLAUDECODE": ""},
+    )
+    if build.returncode != 0:
+        pytest.fail(
+            f"osprey build failed (rc={build.returncode}):\n"
+            f"--- stdout ---\n{build.stdout}\n--- stderr ---\n{build.stderr}"
+        )
+
+    # Force a fresh --dev build so the deployed bridge runs CURRENT source
+    # (osprey deploy up does not pass --build to compose, so it would
+    # otherwise reuse a stale cached image). Exact-named image only.
+    # E2E_REUSE_IMAGES=1 skips this for fast local iteration once the image
+    # cache is warm; never set it in CI.
+    if not os.environ.get("E2E_REUSE_IMAGES"):
+        subprocess.run(
+            ["docker", "rmi", "-f", _orm_stack.BRIDGE_IMAGE], capture_output=True, text=True
+        )
+
+    try:
+        up = subprocess.run(
+            [str(osprey_bin), "deploy", "up", "-d", "--dev"],
+            cwd=str(project_dir),
+            capture_output=True,
+            text=True,
+            timeout=DEPLOY_UP_TIMEOUT_SEC,
+            env={**os.environ, "CLAUDECODE": ""},
+        )
+        if up.returncode != 0:
+            pytest.fail(
+                f"osprey deploy up -d --dev failed (rc={up.returncode}):\n"
+                f"--- stdout ---\n{up.stdout}\n--- stderr ---\n{up.stderr}"
+            )
+        _wait_for_health(f"{BRIDGE_URL}/health", HEALTH_TIMEOUT_SEC)
+        yield project_dir
+    finally:
+        down = subprocess.run(
+            [str(osprey_bin), "deploy", "down"],
+            cwd=str(project_dir),
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        if down.returncode != 0:
+            print(  # noqa: T201 - surface teardown issues in CI logs
+                f"osprey deploy down rc={down.returncode}\n{down.stdout}\n{down.stderr}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Discovery: the layered catalog's provenance/metadata, over the real
+# deployed HTTP API. Strict -- no @flaky -- since this is the core deliverable.
+# ---------------------------------------------------------------------------
+
+
+def test_plans_endpoint_shows_shipped_and_facility_provenance(
+    deployed_catalog_stack: Path,
+) -> None:
+    """``GET /plans`` against the real container must show, in one response:
+
+    - the shipped exemplars (``response_matrix``, ``grid_scan_nd``) with
+      ``provenance == "shipped"`` and non-null ``metadata`` (Task 1.5's
+      in-image ``plans_core/`` files);
+    - the externally-injected ``facility_probe`` plan with
+      ``provenance == "facility"`` and its authored metadata round-tripped
+      byte-for-byte through the loader's ``PLAN_METADATA`` parser;
+    - the built-in plans (``count``/``scan``/``grid_scan``/``orm``) still
+      present (``plans.py``'s hand-built ``PlanSpec`` set, merged in by
+      ``app.py``'s ``/plans`` route regardless of the directory catalog).
+    """
+    status, plans = _get("/plans")
+    assert status == 200, f"GET /plans failed: {status} {plans}"
+    by_name = {p["name"]: p for p in plans}
+
+    for shipped_name in ("response_matrix", "grid_scan_nd"):
+        assert shipped_name in by_name, f"{shipped_name!r} missing from GET /plans: {sorted(by_name)}"
+        entry = by_name[shipped_name]
+        assert entry["provenance"] == "shipped", (
+            f"{shipped_name!r}: expected provenance 'shipped', got {entry['provenance']!r}"
+        )
+        assert entry["metadata"] is not None, f"{shipped_name!r}: metadata is None"
+
+    assert "facility_probe" in by_name, f"facility_probe missing from GET /plans: {sorted(by_name)}"
+    facility_entry = by_name["facility_probe"]
+    assert facility_entry["provenance"] == "facility", (
+        "facility_probe: expected provenance 'facility' (injected via "
+        f"services.bluesky.plan_dir/BLUESKY_PLAN_DIRS), got {facility_entry['provenance']!r}"
+    )
+    metadata = facility_entry["metadata"]
+    assert metadata is not None, "facility_probe: metadata is None"
+    assert metadata["name"] == "facility_probe"
+    assert metadata["category"] == "diagnostic"
+    assert metadata["required_devices"] == ["motor", "detector"]
+    assert metadata["writes"] is True
+
+    for builtin_name in ("count", "scan", "grid_scan", "orm"):
+        assert builtin_name in by_name, (
+            f"built-in plan {builtin_name!r} missing from GET /plans: {sorted(by_name)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scan-drive: the facility-injected plan is not just discoverable, it runs.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.flaky(reruns=2, only_rerun=["AssertionError"])
+def test_facility_probe_launch_promote_read_round_trip(deployed_catalog_stack: Path) -> None:
+    """Drive ``facility_probe`` -- the facility-injected plan (not a
+    built-in) -- through the full deployed launch -> promote -> read path.
+
+    ``motor1``/``det1`` are the demo scanner's fixed mock device names
+    (``devices/mock.py``'s ``build_devices()`` defaults), which is exactly
+    what ``facility_probe`` was authored against.
+    """
+    token = _minted_token(deployed_catalog_stack)
+
+    plan_args = {"motor": "motor1", "detector": "det1", "start": 0.0, "stop": 2.0, "num": 3}
+    status, body = _post("/runs", {"plan_name": "facility_probe", "plan_args": plan_args})
+    assert status == 200, f"POST /runs failed: {status} {body}"
+    run_id = body["id"]
+
+    status, body = _post(f"/runs/{run_id}/promote", {}, headers={"X-Promote-Token": token})
+    assert status == 200, f"promote failed: {status} {body}"
+
+    deadline = time.monotonic() + SCAN_TIMEOUT_SEC
+    status_body: dict = {}
+    while time.monotonic() < deadline:
+        _, status_body = _get(f"/runs/{run_id}")
+        if status_body.get("status") in ("completed", "error", "stopped"):
+            break
+        time.sleep(0.5)
+    assert status_body.get("status") == "completed", (
+        f"facility_probe scan did not complete within {SCAN_TIMEOUT_SEC:.0f}s "
+        f"(status={status_body})"
+    )
+
+    status, data = _get(f"/runs/{run_id}/data")
+    assert status == 200, f"GET /runs/{run_id}/data failed: {status} {data}"
+    expected_rows = plan_args["num"]
+    assert data["row_count"] == expected_rows, (
+        f"expected {expected_rows} rows, got {data['row_count']}: {data}"
+    )
+    assert len(data["rows"]) == expected_rows

--- a/tests/e2e/test_scan_catalog_e2e.py
+++ b/tests/e2e/test_scan_catalog_e2e.py
@@ -294,7 +294,9 @@ def test_plans_endpoint_shows_shipped_and_facility_provenance(
     by_name = {p["name"]: p for p in plans}
 
     for shipped_name in ("response_matrix", "grid_scan_nd"):
-        assert shipped_name in by_name, f"{shipped_name!r} missing from GET /plans: {sorted(by_name)}"
+        assert shipped_name in by_name, (
+            f"{shipped_name!r} missing from GET /plans: {sorted(by_name)}"
+        )
         entry = by_name[shipped_name]
         assert entry["provenance"] == "shipped", (
             f"{shipped_name!r}: expected provenance 'shipped', got {entry['provenance']!r}"

--- a/tests/e2e/test_scan_sandbox_escape_e2e.py
+++ b/tests/e2e/test_scan_sandbox_escape_e2e.py
@@ -408,9 +408,7 @@ def deployed_sandbox_stack(
     correctors = _orm_stack.select_correctors(limits, count=CORRECTOR_COUNT)
     bpms = _orm_stack.select_bpms(limits, count=BPM_COUNT)
     escape_name, (escape_sp, escape_rb) = sorted(correctors.items())[0]
-    positive_correctors = {
-        name: pair for name, pair in correctors.items() if name != escape_name
-    }
+    positive_correctors = {name: pair for name, pair in correctors.items() if name != escape_name}
     _orm_stack.write_scan_env(project_dir, correctors=correctors, bpms=bpms)
 
     osprey_bin = _orm_stack.find_osprey_console_script()
@@ -517,7 +515,9 @@ def test_sandbox_escape_is_caught_and_no_write_reaches_the_ioc(
 
     token = _minted_token(deployed_sandbox_stack.project_dir)
     status, body = _post(f"/runs/{run_id}/promote", {}, headers={"X-Promote-Token": token})
-    assert status == 409, f"expected 409 promoting an unvalidated session plan, got {status}: {body}"
+    assert status == 409, (
+        f"expected 409 promoting an unvalidated session plan, got {status}: {body}"
+    )
     assert "validation record" in body.get("detail", ""), (
         f"409 detail doesn't name the validation-record gate: {body}"
     )
@@ -565,9 +565,7 @@ def test_obfuscated_residual_is_a_documented_known_uncaught_case(
     # Bounded dry-run timeout: keeps this test's worst case (the reflected
     # caput's connection attempt against an intentionally inert CA env)
     # bounded, without asserting anything about how it resolves.
-    status, body = _post(
-        "/plans/validate", {"name": _RESIDUAL_PLAN_NAME, "dry_run_timeout": 10.0}
-    )
+    status, body = _post("/plans/validate", {"name": _RESIDUAL_PLAN_NAME, "dry_run_timeout": 10.0})
     assert status == 200, f"POST /plans/validate failed: {status} {body}"
     assert isinstance(body.get("content_hash"), str) and body["content_hash"], (
         f"validate response missing a content_hash: {body}"

--- a/tests/e2e/test_scan_sandbox_escape_e2e.py
+++ b/tests/e2e/test_scan_sandbox_escape_e2e.py
@@ -1,0 +1,669 @@
+"""Real-container sandbox-escape e2e (task 2.10) -- the authoritative proof of
+the authoring-sandbox feature's central invariant: an agent-authored
+session-tier plan can never reach real hardware unless it is validated AND
+that exact validated content is what actually launches.
+
+Deploys the VA-backed turn-key scan-stack (``tests/e2e/_orm_stack.py`` -- the
+same real Virtual Accelerator + bluesky-bridge container pair
+``test_orm_roundtrip.py`` uses) and drives the session-authoring HTTP surface
+(``POST /plans/session``, ``POST /plans/validate``, ``POST /runs`` ->
+``promote``) end to end against it, then reads a real corrector setpoint back
+over Channel Access -- from this test process, independent of the bridge --
+to prove a rejected write never lands, not merely that the bridge's own HTTP
+responses claim it didn't.
+
+Mocked-client tests (``tests/services/bluesky_bridge/test_plan_validation.py``,
+``test_session_load_gate.py``, ``test_promote_validation_gate.py``) only
+exercise OSPREY's own half of this contract in-process. This is the other
+half: a real deployed bridge container, a real deployed IOC, and an
+independent CA read that never goes through the bridge at all.
+
+CRITICAL INTEGRATION CONTRACT (see ``plan_validation.py``'s module docstring
+and the P5 Phase 2 research digest): the bytes ``validate_bluesky_plan``
+hashes for its validation record must be byte-identical to what the session
+directory's load gate (task 2.4) and the promote gate (task 2.5) re-hash from
+disk. ``POST /plans/session`` writes the body once; ``POST /plans/validate``
+re-reads and hashes that SAME file -- never a body passed separately -- so
+"validated bytes == file bytes" is structural here, not a test convention
+this e2e has to arrange for itself.
+
+LOAD-BEARING SECURITY ASSUMPTION -- read before touching this file's
+obfuscation-residual test: the stage-1/stage-2 static validator (AST import
+walk + CA/connector substring-and-regex pattern scan) is NOT a containment
+boundary. A sufficiently obfuscated body (reflected ``__import__``, a
+getattr'd/concatenated attribute name for the call itself) can evade both
+stages by construction -- neither stage's source text or AST ever contains a
+literal "epics"/"caput" token for such a body. This is the DOCUMENTED,
+ACCEPTED residual (task 2.1's ``TestKnownObfuscationResidual``, xfail,
+strict) -- the real backstop for this exact case is human approval
+RENDERING THE PLAN SOURCE at launch (task 2.6), not this validator, not the
+session-layer load gate, not this test. ``test_obfuscated_residual_is_a_
+documented_known_uncaught_case`` below records that case; it does NOT assert
+the sandbox catches it -- doing so would misrepresent what the feature
+actually guarantees.
+
+Container safety: every docker invocation here names an exact
+container/image -- never a wildcard, never ``system prune``/``--volumes``.
+Teardown goes through ``osprey deploy down``, matching every other e2e in
+this directory. ``BRIDGE_PORT`` below is distinct from every sibling e2e
+module's pinned port; the VA's Channel Access port is NOT freely overridable
+(see ``_orm_stack.VA_CA_PORT``'s docstring) so this test shares that fixed
+port with ``test_orm_roundtrip.py``/``test_va_substrate_equivalence.py`` --
+safe sequentially (each tears its own container down by exact name before
+the next starts), not intended to run concurrently with them on one host.
+
+Gating: needs Docker; the VA image is amd64-only (PyAT/softioc have no
+aarch64 wheels), so it builds/boots under QEMU emulation on Apple Silicon --
+as heavy as ``test_va_substrate_equivalence.py``. Advisory CI lane (see
+ci.yml's ``scan-sandbox-escape-e2e`` job); run locally with
+``E2E_REUSE_IMAGES=1`` set for fast iteration once the image cache is warm.
+
+GAP FOUND WHILE WRITING THIS E2E, NOW FIXED: ``plan_validation.py``'s stage-1
+``_ALLOWED_TOP_LEVEL_MODULES`` originally never added ``typing``/
+``__future__``/``logging`` -- the shipped ``plans_core/response_matrix.py``
+exemplar this test's positive plan body mirrors uses all three
+(`from __future__ import annotations`, `from typing import Any`,
+`import logging`), so an author copying that exact, idiomatic house style
+verbatim (as the writing-bluesky-plans skill's own format spec shows) would
+have had an otherwise entirely benign plan rejected at stage 1 for reasons
+unrelated to control-system safety. That allowlist gap has since landed
+(task 2.1's `_ALLOWED_TOP_LEVEL_MODULES` now includes all three) --
+``_POSITIVE_PLAN_BODY`` below uses the full idiomatic style unmodified.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.e2e import _orm_stack
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.slow,
+    pytest.mark.skipif(shutil.which("docker") is None, reason="docker not available"),
+]
+
+# Distinct from every sibling e2e module's pinned bridge port (_orm_stack.py's
+# 18102, test_scan_deploy.py's 18090, test_va_substrate_equivalence.py's
+# 18099, test_tiled_roundtrip.py's 18101, test_scan_catalog_e2e.py's 18103).
+BRIDGE_PORT = 18105
+BRIDGE_URL = f"http://localhost:{BRIDGE_PORT}"
+
+BUILD_TIMEOUT_SEC = _orm_stack.BUILD_TIMEOUT_SEC
+DEPLOY_UP_TIMEOUT_SEC = 1200  # amd64-emulated VA image build is slow (minutes)
+HEALTH_TIMEOUT_SEC = 300.0
+SCAN_TIMEOUT_SEC = 120.0
+
+# Three correctors total: one reserved exclusively as the escape/residual
+# probe TARGET (never promoted/launched in this test, by either the negative
+# or the obfuscation-residual case), two driven for real by the positive
+# author -> validate -> launch -> promote -> read round trip. Disjoint by
+# construction, so a run-order change can never let the positive scan's
+# legitimate write be mistaken for evidence the negative case's write landed.
+CORRECTOR_COUNT = 3
+BPM_COUNT = 2
+
+# Within the corrector channel_limits band (+-12A, see
+# tests/va/e2e/test_limits_enforcement.py) but far from the identity-state
+# baseline (0.0 A) -- unambiguous if it ever actually lands.
+POISON_CURRENT = 5.0
+
+SPAN_A = 2.0
+NUM_POINTS = 3
+
+_ESCAPE_PLAN_NAME = "sandbox_escape_probe"
+_RESIDUAL_PLAN_NAME = "sandbox_escape_obfuscated_residual"
+_POSITIVE_PLAN_NAME = "session_orbit_probe"
+
+
+# ---------------------------------------------------------------------------
+# Malicious / residual plan bodies
+# ---------------------------------------------------------------------------
+def _escape_plan_body(target_sp: str, poison_current: float) -> str:
+    """MUST-CATCH plan body: reaches raw Channel Access AT MODULE SCOPE.
+
+    ``epics.caput(...)`` sits directly at module level, outside ``build_plan``
+    entirely -- if the session-tier LOAD gate (task 2.4) ever ``exec_module``'d
+    this file despite it lacking a passing validation record, the poison write
+    would fire on the very first ``GET /plans`` call that re-scans the session
+    directory (``get_facility_plans()`` re-scans on every call), with no
+    launch/promote needed at all. This also makes ``import epics`` itself
+    task 2.1's REJECT case (its unit table asserts against exactly this
+    import) -- caught at stage 1, long before any exec is even attempted.
+    """
+    return f'''"""MUST-CATCH plan body for the sandbox-escape e2e
+(tests/e2e/test_scan_sandbox_escape_e2e.py). Never meant to run -- see this
+test module's docstring."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import epics
+from pydantic import BaseModel
+
+# Fires the instant this module is ever exec'd -- not gated behind
+# build_plan at all, so a load-gate bypass would be provable without this
+# test ever needing to launch/promote a run.
+epics.caput({target_sp!r}, {poison_current!r})
+
+
+class PARAMS(BaseModel):
+    """No parameters needed -- this body never legitimately runs."""
+
+
+def build_plan(devices: dict[str, Any], params: PARAMS) -> Any:
+    yield from ()
+'''
+
+
+def _obfuscated_residual_plan_body(target_sp: str, poison_current: float) -> str:
+    """KNOWN-UNCAUGHT residual plan body -- see this module's docstring.
+
+    Extends task 2.1's exact documented obfuscation
+    (``test_plan_validation.py::TestKnownObfuscationResidual``, xfail,
+    strict) -- a getattr/string-concatenation reflected ``__import__("epics")``
+    call, which neither stage 1's AST import walk nor stage 2's
+    substring/regex pattern scan ever see (no literal ``import`` statement,
+    no "epics." substring) -- one step further, ALSO reaching the write
+    itself via a getattr'd, concatenated attribute name (``"ca" + "put"``) so
+    the literal substring "caput(" stage 2 scans for never appears in this
+    source either. Deliberately NOT asserted refused anywhere in this test
+    module -- see ``test_obfuscated_residual_is_a_documented_known_uncaught_case``.
+    """
+    return f'''"""KNOWN-UNCAUGHT residual plan body for the sandbox-escape e2e
+(tests/e2e/test_scan_sandbox_escape_e2e.py). Documented, accepted residual --
+see this test module's docstring. Never promoted/launched by this test."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class PARAMS(BaseModel):
+    """No parameters needed -- this body never legitimately runs."""
+
+
+def build_plan(devices: dict[str, Any], params: PARAMS) -> Any:
+    _builtins = __builtins__ if isinstance(__builtins__, dict) else vars(__builtins__)
+    _import_name = "".join(["__", "imp", "ort", "__"])
+    _module_name = "".join(["ep", "ics"])
+    _reflected = _builtins[_import_name](_module_name)
+    _write = getattr(_reflected, "".join(["ca", "put"]))
+    _write({target_sp!r}, {poison_current!r})
+    yield from ()
+'''
+
+
+# response_matrix-shaped (mirrors plans_core/response_matrix.py's PARAMS/
+# build_plan in spirit, and now also its typing/logging imports verbatim --
+# see the module docstring's "GAP FOUND ... NOW FIXED" note): device-agnostic,
+# resolves correctors/detectors by string name against whatever `devices`
+# dict the bridge passes in. Authored via write_bluesky_plan (which prepends
+# the generated PLAN_METADATA block), so only the author's own body -- no
+# PLAN_METADATA -- lives here.
+#
+# SEPARATE, STRUCTURAL CONSTRAINT (found running this e2e for real, distinct
+# from the now-fixed allowlist gap): unlike `plans_core/response_matrix.py`
+# (a shipped file, never passed through this prepending), this body's own
+# text is NOT position 0 in the file `write_session_plan` actually writes --
+# `POST /plans/session` assembles `f"PLAN_METADATA = {metadata!r}\\n\\n{body}"`,
+# so the generated `PLAN_METADATA` assignment always sits ahead of it. Python
+# requires `from __future__ import ...` to be the file's first statement
+# (only a docstring/comments may precede it) -- with PLAN_METADATA occupying
+# that slot, ANY session-authored body containing `from __future__ import
+# annotations` fails stage 3's dry-run with a SyntaxError, regardless of the
+# allowlist. This is an inherent consequence of the metadata-prepending
+# design, not a bug worth fixing (`list[str]`/`dict[str, Any]` hints work
+# natively on Python 3.9+ without it -- see PEP 585), so this body simply
+# omits the future import; `typing`/`logging` have no such positional rule
+# and are used exactly as the shipped exemplar does.
+_POSITIVE_PLAN_BODY = '''"""Session-authored positive plan body for the sandbox-escape e2e
+(tests/e2e/test_scan_sandbox_escape_e2e.py) -- mirrors plans_core/
+response_matrix.py's PARAMS/build_plan, proving the author -> validate ->
+launch -> promote -> read path works end to end for a legitimately-authored
+session plan, in the same deployed stack the negative case runs against.
+"""
+
+import logging
+from typing import Any
+
+from bluesky import plan_stubs as bps
+from bluesky import preprocessors as bpp
+from pydantic import BaseModel, Field, model_validator
+
+logger = logging.getLogger(__name__)
+
+
+class PARAMS(BaseModel):
+    correctors: list[str] = Field(..., min_length=1)
+    detectors: list[str] = Field(..., min_length=1)
+    span_a: float = Field(..., gt=0, le=10.0)
+    num: int = Field(..., ge=3)
+
+    @model_validator(mode="after")
+    def _disjoint(self) -> "PARAMS":
+        overlap = set(self.correctors) & set(self.detectors)
+        if overlap:
+            raise ValueError(f"correctors and detectors must be disjoint (overlap: {sorted(overlap)})")
+        return self
+
+
+def build_plan(devices: dict[str, Any], params: PARAMS) -> Any:
+    correctors = [(name, devices[name]) for name in params.correctors]
+    corrector_devices = [corrector for _, corrector in correctors]
+    detector_devices = [devices[name] for name in params.detectors]
+    step = (2 * params.span_a) / (params.num - 1)
+    currents = [-params.span_a + i * step for i in range(params.num)]
+    all_devices = corrector_devices + detector_devices
+
+    @bpp.stage_decorator(all_devices)
+    @bpp.run_decorator()
+    def _sweep():
+        for name, corrector in correctors:
+            try:
+                for current in currents:
+                    yield from bps.mv(corrector, current)
+                    yield from bps.trigger_and_read(all_devices)
+            finally:
+                try:
+                    yield from bps.mv(corrector, 0.0)
+                except Exception:
+                    logger.warning("failed to restore corrector %s to 0", name, exc_info=True)
+
+    return _sweep()
+'''
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers (mirrors test_orm_roundtrip.py / test_scan_catalog_e2e.py)
+# ---------------------------------------------------------------------------
+def _get(path: str) -> tuple[int, Any]:
+    req = urllib.request.Request(f"{BRIDGE_URL}{path}", method="GET")  # noqa: S310
+    try:
+        with urllib.request.urlopen(req, timeout=10.0) as resp:  # noqa: S310
+            return resp.status, json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode("utf-8"))
+
+
+def _post(path: str, body: dict, headers: dict | None = None) -> tuple[int, dict]:
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(  # noqa: S310
+        f"{BRIDGE_URL}{path}",
+        data=data,
+        method="POST",
+        headers={"Content-Type": "application/json", **(headers or {})},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30.0) as resp:  # noqa: S310
+            return resp.status, json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode("utf-8"))
+
+
+def _wait_for_health(url: str, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last_err = "(no response yet)"
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=3.0) as resp:  # noqa: S310 - localhost
+                if resp.status == 200:
+                    return
+                last_err = f"HTTP {resp.status}"
+        except (urllib.error.URLError, ConnectionError, OSError) as exc:
+            last_err = str(exc)
+        time.sleep(1.0)
+    raise AssertionError(f"timed out after {timeout:.0f}s waiting for {url} (last: {last_err})")
+
+
+def _minted_token(project_dir: Path) -> str:
+    from osprey.utils.dotenv import parse_dotenv_file
+
+    env_path = project_dir / ".env"
+    assert env_path.is_file(), f"no .env written at {env_path} — token was not minted"
+    env = parse_dotenv_file(env_path)
+    token = env.get("BLUESKY_PROMOTE_TOKEN")
+    assert token, "BLUESKY_PROMOTE_TOKEN missing/empty in the project .env"
+    return token
+
+
+def _channel_limits(project_dir: Path) -> dict[str, Any]:
+    return json.loads((project_dir / "data" / "channel_limits.json").read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Real EPICS CA probe -- from this test PROCESS, never through the bridge.
+# Subprocess-based (mirrors tests/va/e2e/conftest.py's `_readiness_pv_served`):
+# an in-process pyepics CA context in the main pytest process can deadlock
+# unrelated executor-thread CA calls elsewhere in the same run, so every read
+# below runs out-of-process against the VA's published CA port.
+# ---------------------------------------------------------------------------
+def _caget(address: str, *, timeout: float = 5.0) -> float | None:
+    code = (
+        "import sys, epics\n"
+        f"v = epics.caget({address!r}, timeout={timeout!r}, connection_timeout={timeout!r})\n"
+        "sys.stdout.write(repr(v))\n"
+    )
+    env = {
+        **os.environ,
+        "EPICS_CA_NAME_SERVERS": f"localhost:{_orm_stack.VA_CA_PORT}",
+        "EPICS_CA_AUTO_ADDR_LIST": "NO",
+    }
+    env.pop("EPICS_CA_ADDR_LIST", None)
+    env.pop("EPICS_CA_SERVER_PORT", None)
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=timeout + 10.0,
+        env=env,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"caget({address!r}) subprocess failed (rc={proc.returncode}): "
+            f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+        )
+    return ast.literal_eval(proc.stdout.strip())
+
+
+# ---------------------------------------------------------------------------
+# Fixture: deploy the VA-backed stack once, shared by every test below.
+# ---------------------------------------------------------------------------
+@dataclass
+class DeployedSandboxStack:
+    project_dir: Path
+    escape_target_sp: str
+    escape_target_rb: str
+    positive_correctors: dict[str, tuple[str, str]]
+    positive_bpms: dict[str, str]
+
+
+@pytest.fixture(scope="module")
+def deployed_sandbox_stack(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[DeployedSandboxStack]:
+    base = tmp_path_factory.mktemp("sandbox_escape_build")
+    project_dir = _orm_stack.build_project_subprocess(
+        "sandbox-escape", output_dir=base, bridge_port=BRIDGE_PORT, timeout=BUILD_TIMEOUT_SEC
+    )
+
+    limits = _channel_limits(project_dir)
+    correctors = _orm_stack.select_correctors(limits, count=CORRECTOR_COUNT)
+    bpms = _orm_stack.select_bpms(limits, count=BPM_COUNT)
+    escape_name, (escape_sp, escape_rb) = sorted(correctors.items())[0]
+    positive_correctors = {
+        name: pair for name, pair in correctors.items() if name != escape_name
+    }
+    _orm_stack.write_scan_env(project_dir, correctors=correctors, bpms=bpms)
+
+    osprey_bin = _orm_stack.find_osprey_console_script()
+
+    # Force fresh --dev builds so the deployed containers run CURRENT source
+    # (osprey deploy up does not pass --build to compose, so it would
+    # otherwise reuse a stale cached image). Exact-named images only.
+    if not os.environ.get("E2E_REUSE_IMAGES"):
+        subprocess.run(["docker", "rmi", "-f", _orm_stack.VA_IMAGE], capture_output=True, text=True)
+        subprocess.run(
+            ["docker", "rmi", "-f", _orm_stack.BRIDGE_IMAGE], capture_output=True, text=True
+        )
+
+    try:
+        up = subprocess.run(
+            [str(osprey_bin), "deploy", "up", "-d", "--dev"],
+            cwd=str(project_dir),
+            capture_output=True,
+            text=True,
+            timeout=DEPLOY_UP_TIMEOUT_SEC,
+            env={**os.environ, "CLAUDECODE": ""},
+        )
+        if up.returncode != 0:
+            pytest.fail(
+                f"osprey deploy up -d --dev failed (rc={up.returncode}):\n"
+                f"--- stdout ---\n{up.stdout}\n--- stderr ---\n{up.stderr}"
+            )
+        _wait_for_health(f"{BRIDGE_URL}/health", HEALTH_TIMEOUT_SEC)
+        yield DeployedSandboxStack(
+            project_dir=project_dir,
+            escape_target_sp=escape_sp,
+            escape_target_rb=escape_rb,
+            positive_correctors=positive_correctors,
+            positive_bpms=bpms,
+        )
+    finally:
+        down = subprocess.run(
+            [str(osprey_bin), "deploy", "down"],
+            cwd=str(project_dir),
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        if down.returncode != 0:
+            print(  # noqa: T201 - surface teardown issues in CI logs
+                f"osprey deploy down rc={down.returncode}\n{down.stdout}\n{down.stderr}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Negative (MUST-CATCH, strict): the escape plan is refused by all three
+# gates, and the real corrector it targets never moves.
+# ---------------------------------------------------------------------------
+def test_sandbox_escape_is_caught_and_no_write_reaches_the_ioc(
+    deployed_sandbox_stack: DeployedSandboxStack,
+) -> None:
+    """Every gate refuses ``sandbox_escape_probe``, and its target corrector
+    never moves -- read directly over Channel Access, independent of the
+    bridge's own claims.
+    """
+    target_sp = deployed_sandbox_stack.escape_target_sp
+    sp_baseline = _caget(target_sp)
+    assert sp_baseline is not None, f"could not read baseline {target_sp!r} over CA"
+
+    # --- author: writes a file, never execs it ---
+    status, body = _post(
+        "/plans/session",
+        {
+            "name": _ESCAPE_PLAN_NAME,
+            "description": "MUST-CATCH sandbox-escape probe (never meant to run)",
+            "category": "test",
+            "required_devices": [],
+            "writes": True,
+            "body": _escape_plan_body(target_sp, POISON_CURRENT),
+        },
+    )
+    assert status == 200, f"POST /plans/session failed: {status} {body}"
+
+    # --- gate (a): validate_bluesky_plan rejects it (stage 1: import epics) ---
+    status, body = _post("/plans/validate", {"name": _ESCAPE_PLAN_NAME})
+    assert status == 200, f"POST /plans/validate failed: {status} {body}"
+    assert body["passed"] is False, f"escape plan validation unexpectedly passed: {body}"
+    assert any("epics" in reason for reason in body["reasons"]), (
+        f"expected an 'epics' import rejection reason, got: {body['reasons']}"
+    )
+
+    # --- gate (b): the session-tier LOAD gate never exec_module's it, so it
+    # never appears in GET /plans (checked twice -- get_facility_plans()
+    # re-scans the session directory on every call, so a gate that only
+    # worked "once" would still leak the plan in on a later poll). ---
+    for _ in range(2):
+        status, plans = _get("/plans")
+        assert status == 200, f"GET /plans failed: {status} {plans}"
+        names = {p["name"] for p in plans}
+        assert _ESCAPE_PLAN_NAME not in names, (
+            f"{_ESCAPE_PLAN_NAME!r} is discoverable via GET /plans despite failing "
+            f"validation -- the session-tier load gate did not refuse it: {sorted(names)}"
+        )
+
+    # --- gate (c): promote 409s (the promote-validation gate, task 2.5) ---
+    status, body = _post("/runs", {"plan_name": _ESCAPE_PLAN_NAME, "plan_args": {}})
+    assert status == 200, f"POST /runs failed: {status} {body}"
+    run_id = body["id"]
+
+    token = _minted_token(deployed_sandbox_stack.project_dir)
+    status, body = _post(f"/runs/{run_id}/promote", {}, headers={"X-Promote-Token": token})
+    assert status == 409, f"expected 409 promoting an unvalidated session plan, got {status}: {body}"
+    assert "validation record" in body.get("detail", ""), (
+        f"409 detail doesn't name the validation-record gate: {body}"
+    )
+
+    # --- the IOC probe: the IOC itself confirms nothing ever landed, whether
+    # or not any of the HTTP gates above had actually worked. ---
+    sp_after = _caget(target_sp)
+    assert sp_after == pytest.approx(sp_baseline), (
+        f"{target_sp} changed from {sp_baseline} to {sp_after} despite every gate "
+        "refusing the escape plan -- a write reached the IOC"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Obfuscation residual: DOCUMENTED, ACCEPTED, KNOWN-UNCAUGHT. NOT asserted
+# refused -- see this module's docstring and plan_validation.py's own.
+# ---------------------------------------------------------------------------
+def test_obfuscated_residual_is_a_documented_known_uncaught_case(
+    deployed_sandbox_stack: DeployedSandboxStack,
+) -> None:
+    """Records the getattr/string-concat obfuscation residual. Deliberately
+    does NOT assert the validator refuses it -- stages 1-2 are AST/regex
+    checks, not a containment boundary (see module docstring); asserting
+    refusal here would misrepresent what this feature actually guarantees.
+    This plan is never launched/promoted by this test either way, so nothing
+    here depends on -- or claims anything about -- whether the dry run's own
+    independent EPICS_CA_* neutralization (plan_validation.py) happens to
+    let stage 3 complete or fail for this particular body.
+    """
+    target_sp = deployed_sandbox_stack.escape_target_sp
+
+    status, body = _post(
+        "/plans/session",
+        {
+            "name": _RESIDUAL_PLAN_NAME,
+            "description": "Known-uncaught obfuscation residual (never promoted)",
+            "category": "test",
+            "required_devices": [],
+            "writes": True,
+            "body": _obfuscated_residual_plan_body(target_sp, POISON_CURRENT),
+        },
+    )
+    assert status == 200, f"POST /plans/session failed: {status} {body}"
+
+    # Bounded dry-run timeout: keeps this test's worst case (the reflected
+    # caput's connection attempt against an intentionally inert CA env)
+    # bounded, without asserting anything about how it resolves.
+    status, body = _post(
+        "/plans/validate", {"name": _RESIDUAL_PLAN_NAME, "dry_run_timeout": 10.0}
+    )
+    assert status == 200, f"POST /plans/validate failed: {status} {body}"
+    assert isinstance(body.get("content_hash"), str) and body["content_hash"], (
+        f"validate response missing a content_hash: {body}"
+    )
+    print(  # noqa: T201 - informational only, not asserted on
+        f"obfuscated residual {_RESIDUAL_PLAN_NAME!r}: passed={body['passed']!r} "
+        f"reasons={body['reasons']!r} (documented known-uncaught case; not asserted)"
+    )
+
+    # Non-asserting probe: this plan is never promoted/launched by this test,
+    # so nothing should have moved regardless of the validate outcome above --
+    # but this is recorded as an observation, not an assertion (see docstring).
+    sp_value = _caget(target_sp)
+    print(f"{target_sp} reads {sp_value!r} after the obfuscated-residual validate call")  # noqa: T201
+
+
+# ---------------------------------------------------------------------------
+# Positive: author -> validate -> launch -> promote -> read, over the same
+# deployed stack. May flake on the launch->read leg (bounded scan timing);
+# the negative case above stays strict.
+# ---------------------------------------------------------------------------
+@pytest.mark.flaky(reruns=2, only_rerun=["AssertionError"])
+def test_session_plan_author_validate_launch_promote_read_round_trip(
+    deployed_sandbox_stack: DeployedSandboxStack,
+) -> None:
+    correctors = deployed_sandbox_stack.positive_correctors
+    bpms = deployed_sandbox_stack.positive_bpms
+
+    status, body = _post(
+        "/plans/session",
+        {
+            "name": _POSITIVE_PLAN_NAME,
+            "description": "Legit session-authored orbit-response probe",
+            "category": "accelerator",
+            "required_devices": ["correctors", "detectors"],
+            "writes": True,
+            "body": _POSITIVE_PLAN_BODY,
+        },
+    )
+    assert status == 200, f"POST /plans/session failed: {status} {body}"
+
+    status, body = _post(
+        "/plans/validate",
+        {
+            "name": _POSITIVE_PLAN_NAME,
+            "sample_args": {
+                "correctors": list(correctors)[:1],
+                "detectors": list(bpms)[:1],
+                "span_a": 1.0,
+                "num": 3,
+            },
+        },
+    )
+    assert status == 200, f"POST /plans/validate failed: {status} {body}"
+    assert body["passed"] is True, f"legit session plan failed validation: {body['reasons']}"
+
+    status, plans = _get("/plans")
+    assert status == 200, f"GET /plans failed: {status} {plans}"
+    by_name = {p["name"]: p for p in plans}
+    assert _POSITIVE_PLAN_NAME in by_name, (
+        f"validated session plan {_POSITIVE_PLAN_NAME!r} not discoverable: {sorted(by_name)}"
+    )
+    assert by_name[_POSITIVE_PLAN_NAME]["provenance"] == "session", (
+        f"expected provenance 'session', got {by_name[_POSITIVE_PLAN_NAME]['provenance']!r}"
+    )
+
+    plan_args = {
+        "correctors": list(correctors),
+        "detectors": list(bpms),
+        "span_a": SPAN_A,
+        "num": NUM_POINTS,
+    }
+    status, body = _post("/runs", {"plan_name": _POSITIVE_PLAN_NAME, "plan_args": plan_args})
+    assert status == 200, f"POST /runs failed: {status} {body}"
+    run_id = body["id"]
+
+    token = _minted_token(deployed_sandbox_stack.project_dir)
+    status, body = _post(f"/runs/{run_id}/promote", {}, headers={"X-Promote-Token": token})
+    assert status == 200, f"promote failed: {status} {body}"
+
+    deadline = time.monotonic() + SCAN_TIMEOUT_SEC
+    status_body: dict = {}
+    while time.monotonic() < deadline:
+        _, status_body = _get(f"/runs/{run_id}")
+        if status_body.get("status") in ("completed", "error", "stopped"):
+            break
+        time.sleep(0.5)
+    assert status_body.get("status") == "completed", (
+        f"session_orbit_probe scan did not complete within {SCAN_TIMEOUT_SEC:.0f}s "
+        f"(status={status_body})"
+    )
+
+    status, data = _get(f"/runs/{run_id}/data")
+    assert status == 200, f"GET /runs/{run_id}/data failed: {status} {data}"
+    expected_rows = len(correctors) * NUM_POINTS
+    assert data["row_count"] == expected_rows, (
+        f"expected {expected_rows} rows, got {data['row_count']}: {data}"
+    )
+    assert len(data["rows"]) == expected_rows

--- a/tests/hooks/test_approval_launch_enrichment.py
+++ b/tests/hooks/test_approval_launch_enrichment.py
@@ -1,0 +1,344 @@
+"""Tests for the `osprey_approval` hook's `launch_scan` enrichment (task 2.6).
+
+`launch_scan` is the sole promote path for a Bluesky scan (see
+`mcp_server/scan/tools/launch.py`) — its own tool_input carries nothing but a
+bare `run_id`. This enrichment resolves that id against the bridge's
+`/runs/{id}`, `/plans`, and `/plans/{name}/source` routes (task 2.6's new
+endpoint) to render the plan actually about to launch: its metadata,
+provenance/trust tier, validation status, and a truncated source excerpt.
+
+This is the human backstop for the plan validator's documented, accepted
+obfuscation residual (a `getattr`/string-concat body that passes the
+sandbox's AST import/pattern scan — see `plan_validation.py`'s module
+docstring): an approver who can SEE the actual source has a chance to refuse
+it even where the earlier automated stages could not. So the tests below
+assert the rendered reason both surfaces that source text AND labels a
+session/unreviewed plan unmistakably as agent-authored/unreviewed.
+
+The hook runs as a real subprocess (see `hook_runner` in conftest.py) and
+talks to the bridge over `urllib.request` — these tests stand up a tiny
+real HTTP server (stdlib `http.server`) to play the bridge's part, so the
+hook's actual network code path is exercised, not a mock.
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import socket
+import threading
+from contextlib import contextmanager
+
+import pytest
+
+SCAN_HOOK_CONFIG = {
+    "server_prefixes": ["mcp__scan__"],
+    "approval_prefixes": ["mcp__scan__"],
+}
+
+
+class _FakeBridgeHandler(http.server.BaseHTTPRequestHandler):
+    """Serves canned JSON bodies for whatever paths `routes` maps."""
+
+    routes: dict[str, object] = {}
+
+    def do_GET(self):  # noqa: N802 (stdlib method name)
+        body = self.routes.get(self.path)
+        if body is None:
+            payload = b'{"detail": "not found"}'
+            self.send_response(404)
+        else:
+            payload = json.dumps(body).encode()
+            self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, format, *args):  # noqa: A002 (stdlib signature)
+        pass  # keep test output quiet
+
+
+@contextmanager
+def fake_bridge(routes: dict[str, object]):
+    """Runs a real threaded HTTP server for the duration of the `with` block."""
+    handler_cls = type("_Handler", (_FakeBridgeHandler,), {"routes": routes})
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}"
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+def _unused_port() -> int:
+    """A port nothing is listening on, for the fail-open (unreachable) test."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+_SHIPPED_SOURCE = (
+    'PLAN_METADATA = {"name": "response_matrix", "description": "orm", '
+    '"category": "accelerator", "required_devices": ["correctors", "detectors"], '
+    '"writes": True}\n\n'
+    "def build_plan(devices, params):\n"
+    "    yield from ()\n"
+)
+
+_OBFUSCATED_SESSION_SOURCE = (
+    'PLAN_METADATA = {"name": "sneaky_plan", "description": "", '
+    '"category": "accelerator", "required_devices": [], "writes": False}\n\n'
+    "def build_plan(devices, params):\n"
+    "    leak = ().__class__.__base__.__subclasses__()\n"
+    "    yield from ()\n"
+)
+
+
+@pytest.mark.unit
+def test_launch_scan_renders_shipped_plan_metadata_and_source(
+    tmp_path, hook_runner, make_config, monkeypatch
+):
+    """A shipped (operator-trusted) plan renders category/devices/hazard/
+    provenance/validation-status/source without any UNTRUSTED labeling."""
+    config = make_config(
+        {
+            "approval": {"enabled": True, "default_policy": "always"},
+            "control_system": {"writes_enabled": True},
+        }
+    )
+    routes = {
+        "/runs/run-1": {
+            "id": "run-1",
+            "status": "intent",
+            "plan_name": "response_matrix",
+            "plan_args": {"num_points": 5},
+        },
+        "/plans": [
+            {
+                "name": "response_matrix",
+                "description": "orm",
+                "schema": {},
+                "metadata": {
+                    "name": "response_matrix",
+                    "description": "orm",
+                    "category": "accelerator",
+                    "required_devices": ["correctors", "detectors"],
+                    "writes": True,
+                },
+                "provenance": "shipped",
+            }
+        ],
+        "/plans/response_matrix/source": {
+            "name": "response_matrix",
+            "provenance": "shipped",
+            "validated": True,
+            "truncated": False,
+            "source": _SHIPPED_SOURCE,
+        },
+    }
+
+    with fake_bridge(routes) as base_url:
+        monkeypatch.setenv("BLUESKY_BRIDGE_URL", base_url)
+        result = hook_runner(
+            "osprey_approval.py",
+            "mcp__scan__launch_scan",
+            {"run_id": "run-1"},
+            config_path=config,
+            cwd=tmp_path,
+            hook_config=SCAN_HOOK_CONFIG,
+        )
+
+    assert result is not None
+    output = result["hookSpecificOutput"]
+    assert output["permissionDecision"] == "ask"
+    reason = output["permissionDecisionReason"]
+
+    assert "Plan: response_matrix" in reason
+    assert "Category: accelerator" in reason
+    assert "correctors" in reason and "detectors" in reason
+    assert "Hazard: writes to hardware" in reason
+    assert "Provenance: shipped" in reason
+    assert "Validation status: not applicable" in reason
+    assert _SHIPPED_SOURCE in reason
+    assert "num_points" in reason
+    # A trusted tier must never be mislabeled as agent-authored/unreviewed.
+    assert "AGENT-AUTHORED" not in reason
+
+
+@pytest.mark.unit
+def test_launch_scan_labels_unvalidated_session_plan_as_untrusted(
+    tmp_path, hook_runner, make_config, monkeypatch
+):
+    """A session-tier plan with NO passing validation record is clearly
+    labelled agent-authored/unreviewed, and the obfuscated body itself is
+    rendered legibly — the human backstop the plan validator's documented
+    residual relies on."""
+    config = make_config(
+        {
+            "approval": {"enabled": True, "default_policy": "always"},
+            "control_system": {"writes_enabled": True},
+        }
+    )
+    routes = {
+        "/runs/run-2": {
+            "id": "run-2",
+            "status": "intent",
+            "plan_name": "sneaky_plan",
+            "plan_args": {},
+        },
+        "/plans": [],  # quarantined: absent from GET /plans entirely
+        "/plans/sneaky_plan/source": {
+            "name": "sneaky_plan",
+            "provenance": "session",
+            "validated": False,
+            "truncated": False,
+            "source": _OBFUSCATED_SESSION_SOURCE,
+        },
+    }
+
+    with fake_bridge(routes) as base_url:
+        monkeypatch.setenv("BLUESKY_BRIDGE_URL", base_url)
+        result = hook_runner(
+            "osprey_approval.py",
+            "mcp__scan__launch_scan",
+            {"run_id": "run-2"},
+            config_path=config,
+            cwd=tmp_path,
+            hook_config=SCAN_HOOK_CONFIG,
+        )
+
+    assert result is not None
+    output = result["hookSpecificOutput"]
+    assert output["permissionDecision"] == "ask"
+    reason = output["permissionDecisionReason"]
+
+    assert "Plan: sneaky_plan" in reason
+    assert "SESSION" in reason
+    assert "AGENT-AUTHORED, NOT REVIEWED BY A HUMAN" in reason
+    assert "NO PASSING RECORD" in reason
+    # The obfuscated body itself must be visible to the approver.
+    assert "__subclasses__" in reason
+
+
+@pytest.mark.unit
+def test_launch_scan_reports_a_validated_session_plan_as_passed(
+    tmp_path, hook_runner, make_config, monkeypatch
+):
+    config = make_config(
+        {
+            "approval": {"enabled": True, "default_policy": "always"},
+            "control_system": {"writes_enabled": True},
+        }
+    )
+    routes = {
+        "/runs/run-3": {
+            "id": "run-3",
+            "status": "intent",
+            "plan_name": "reviewed_ish_plan",
+            "plan_args": {},
+        },
+        "/plans": [
+            {
+                "name": "reviewed_ish_plan",
+                "description": "",
+                "schema": {},
+                "metadata": {
+                    "name": "reviewed_ish_plan",
+                    "description": "",
+                    "category": "accelerator",
+                    "required_devices": [],
+                    "writes": False,
+                },
+                "provenance": "session",
+            }
+        ],
+        "/plans/reviewed_ish_plan/source": {
+            "name": "reviewed_ish_plan",
+            "provenance": "session",
+            "validated": True,
+            "truncated": False,
+            "source": "PLAN_METADATA = {}\n",
+        },
+    }
+
+    with fake_bridge(routes) as base_url:
+        monkeypatch.setenv("BLUESKY_BRIDGE_URL", base_url)
+        result = hook_runner(
+            "osprey_approval.py",
+            "mcp__scan__launch_scan",
+            {"run_id": "run-3"},
+            config_path=config,
+            cwd=tmp_path,
+            hook_config=SCAN_HOOK_CONFIG,
+        )
+
+    reason = result["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "AGENT-AUTHORED, NOT REVIEWED BY A HUMAN" in reason
+    assert "Validation status: PASSED" in reason
+
+
+@pytest.mark.unit
+def test_launch_scan_fails_open_when_bridge_is_unreachable(
+    tmp_path, hook_runner, make_config, monkeypatch
+):
+    """A dead bridge must never block the approval prompt: the hook still
+    asks, just with the plain tool/policy reason instead of any plan detail.
+    `hook_runner` itself asserts a zero exit code, so this also proves the
+    enrichment code never raises out to the subprocess boundary.
+    """
+    config = make_config(
+        {
+            "approval": {"enabled": True, "default_policy": "always"},
+            "control_system": {"writes_enabled": True},
+        }
+    )
+    monkeypatch.setenv("BLUESKY_BRIDGE_URL", f"http://127.0.0.1:{_unused_port()}")
+
+    result = hook_runner(
+        "osprey_approval.py",
+        "mcp__scan__launch_scan",
+        {"run_id": "run-unreachable"},
+        config_path=config,
+        cwd=tmp_path,
+        hook_config=SCAN_HOOK_CONFIG,
+    )
+
+    assert result is not None
+    output = result["hookSpecificOutput"]
+    assert output["permissionDecision"] == "ask"
+    reason = output["permissionDecisionReason"]
+    assert "Tool: launch_scan" in reason
+    assert "Approval policy: always" in reason
+    assert "Plan:" not in reason
+
+
+@pytest.mark.unit
+def test_launch_scan_without_a_run_id_degrades_to_the_plain_reason(
+    tmp_path, hook_runner, make_config, monkeypatch
+):
+    """Malformed tool_input (no run_id) degrades gracefully — never a crash."""
+    config = make_config(
+        {
+            "approval": {"enabled": True, "default_policy": "always"},
+            "control_system": {"writes_enabled": True},
+        }
+    )
+    monkeypatch.setenv("BLUESKY_BRIDGE_URL", f"http://127.0.0.1:{_unused_port()}")
+
+    result = hook_runner(
+        "osprey_approval.py",
+        "mcp__scan__launch_scan",
+        {},
+        config_path=config,
+        cwd=tmp_path,
+        hook_config=SCAN_HOOK_CONFIG,
+    )
+
+    assert result is not None
+    output = result["hookSpecificOutput"]
+    assert output["permissionDecision"] == "ask"
+    assert "Tool: launch_scan" in output["permissionDecisionReason"]

--- a/tests/mcp_server/scan/test_authoring_tools.py
+++ b/tests/mcp_server/scan/test_authoring_tools.py
@@ -1,0 +1,462 @@
+"""Tests for the session-plan authoring/validation surface (task 2.3):
+`write_bluesky_plan` / `validate_bluesky_plan` MCP tools, their bridge routes
+(`POST /plans/session`, `POST /plans/validate`), and their permission tier.
+
+Two layers are covered:
+
+- MCP-tool level (`osprey.mcp_server.scan.tools.authoring`): payload shape and
+  error-envelope mapping, with `_http_post_json` mocked out (no bridge process
+  needed) — mirrors `test_launch_scan.py`'s conventions.
+- Bridge-route level (`osprey.services.bluesky_bridge.app`): exercised via
+  FastAPI's `TestClient` against the real routes, proving the write path never
+  imports/execs the authored body, the HASH CONTRACT (the bytes validated are
+  the exact bytes persisted and later re-hashed), and that neither route is
+  gated on `control_system.writes_enabled` or `BLUESKY_PROMOTE_TOKEN`.
+
+The full write-then-validate round trip needs a real bluesky dry run, so
+those tests are guarded by `pytest.importorskip`, matching every other
+bluesky-capable test in this suite (see `test_plan_validation.py`).
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from osprey.mcp_server.scan.server_context import initialize_server_context, reset_server_context
+from osprey.mcp_server.scan.tools import authoring
+from osprey.registry.mcp import FRAMEWORK_SERVERS
+from osprey.services.bluesky_bridge.app import app
+from osprey.services.bluesky_bridge.plan_validation import hash_plan_body
+from osprey.services.bluesky_bridge.validation_record import validation_records
+from tests.mcp_server.conftest import assert_raises_error, extract_response_dict, get_tool_fn
+
+_MOD = "osprey.mcp_server.scan.tools.authoring"
+
+_BENIGN_BODY = textwrap.dedent(
+    """\
+    from bluesky import plan_stubs as bps
+    from bluesky import preprocessors as bpp
+    from pydantic import BaseModel, Field
+
+
+    class PARAMS(BaseModel):
+        correctors: list[str] = Field(..., min_length=1)
+        detectors: list[str] = Field(..., min_length=1)
+        num: int = Field(..., ge=1)
+
+
+    def build_plan(devices, params):
+        corrector = devices[params.correctors[0]]
+        detector = devices[params.detectors[0]]
+
+        @bpp.stage_decorator([corrector, detector])
+        @bpp.run_decorator()
+        def _sweep():
+            for i in range(params.num):
+                yield from bps.mv(corrector, float(i))
+                yield from bps.trigger_and_read([corrector, detector])
+
+        return _sweep()
+    """
+)
+_BENIGN_SAMPLE_ARGS = {"correctors": ["c1"], "detectors": ["d1"], "num": 3}
+
+
+# =========================================================================
+# Registry permission tier (task 2.3's (D)): both tools approval-only, no
+# _WRITES_CHECK — must work identically whether writes_enabled is on or off.
+# =========================================================================
+
+
+def test_both_tools_are_approval_ask_tier_never_writes_checked():
+    scan = FRAMEWORK_SERVERS["scan"]
+    assert "write_bluesky_plan" in scan.permissions_ask
+    assert "validate_bluesky_plan" in scan.permissions_ask
+
+    by_matcher = {rule.matcher: rule for rule in scan.hooks_pre}
+    for tool in ("write_bluesky_plan", "validate_bluesky_plan"):
+        matcher = f"mcp__scan__{tool}"
+        assert matcher in by_matcher, f"no hooks_pre rule for {matcher}"
+        commands = [h.command for h in by_matcher[matcher].hooks]
+        assert any("osprey_approval.py" in c for c in commands), (
+            f"{matcher} must carry the approval hook"
+        )
+        assert not any("osprey_writes_check.py" in c for c in commands), (
+            f"{matcher} must NEVER be kill-switch-gated — it reaches no hardware"
+        )
+
+
+def test_both_tools_get_distinct_independently_allowlistable_short_names():
+    scan = FRAMEWORK_SERVERS["scan"]
+    # Distinct from launch_scan/stop_scan's own tier, and from each other.
+    assert len({"launch_scan", "stop_scan", "write_bluesky_plan", "validate_bluesky_plan"}) == 4
+    assert set(scan.permissions_ask) >= {
+        "write_bluesky_plan",
+        "validate_bluesky_plan",
+        "launch_scan",
+        "stop_scan",
+    }
+
+
+# =========================================================================
+# MCP-tool level: payload shape + error mapping (HTTP boundary mocked)
+# =========================================================================
+
+
+def _write_fn():
+    return get_tool_fn(authoring.write_bluesky_plan)
+
+
+def _validate_fn():
+    return get_tool_fn(authoring.validate_bluesky_plan)
+
+
+@pytest.fixture(autouse=True)
+def _reset_scan_context():
+    yield
+    reset_server_context()
+
+
+async def test_write_bluesky_plan_posts_the_structured_payload(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    initialize_server_context()
+
+    with patch(
+        f"{_MOD}._http_post_json",
+        return_value=(200, {"name": "tiny", "content_hash": "deadbeef"}),
+    ) as m:
+        result = await _write_fn()(
+            name="tiny",
+            category="accelerator",
+            required_devices=["correctors", "detectors"],
+            writes=True,
+            body="def build_plan(devices, params):\n    yield\n",
+            description="A tiny plan.",
+        )
+
+    assert m.call_args.args[0] == "/plans/session"
+    payload = m.call_args.args[1]
+    assert payload == {
+        "name": "tiny",
+        "description": "A tiny plan.",
+        "category": "accelerator",
+        "required_devices": ["correctors", "detectors"],
+        "writes": True,
+        "body": "def build_plan(devices, params):\n    yield\n",
+    }
+    data = extract_response_dict(result)
+    assert data == {"name": "tiny", "content_hash": "deadbeef"}
+
+
+async def test_write_bluesky_plan_rejected_maps_to_error_envelope(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    initialize_server_context()
+
+    with patch(
+        f"{_MOD}._http_post_json",
+        return_value=(400, {"detail": "invalid plan name '1bad': must be a valid Python identifier"}),
+    ):
+        with assert_raises_error(error_type="plan_write_rejected") as ctx:
+            await _write_fn()(
+                name="1bad", category="x", required_devices=[], writes=False, body=""
+            )
+    assert "invalid plan name" in ctx["envelope"]["error_message"]
+
+
+async def test_validate_bluesky_plan_posts_name_and_sample_args(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    initialize_server_context()
+
+    body = {"passed": True, "reasons": [], "content_hash": "deadbeef"}
+    with patch(f"{_MOD}._http_post_json", return_value=(200, body)) as m:
+        result = await _validate_fn()(name="tiny", sample_args={"correctors": ["c1"]})
+
+    assert m.call_args.args[0] == "/plans/validate"
+    assert m.call_args.args[1] == {
+        "name": "tiny",
+        "sample_args": {"correctors": ["c1"]},
+        "dry_run_timeout": 30.0,
+    }
+    data = extract_response_dict(result)
+    assert data["passed"] is True
+
+
+async def test_validate_bluesky_plan_unknown_name_maps_to_error_envelope(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    initialize_server_context()
+
+    with patch(
+        f"{_MOD}._http_post_json",
+        return_value=(404, {"detail": "unknown session plan 'nope'"}),
+    ):
+        with assert_raises_error(error_type="unknown_session_plan") as ctx:
+            await _validate_fn()(name="nope")
+    assert "unknown session plan" in ctx["envelope"]["error_message"]
+
+
+# =========================================================================
+# Bridge-route level: real routes via TestClient, no HTTP mocking.
+# =========================================================================
+
+
+@pytest.fixture(autouse=True)
+def _isolated_session_dir_and_records(tmp_path, monkeypatch):
+    """Every test gets its own session-plan directory and a clean record store.
+
+    The bridge's `validation_records` is a module-level singleton (like
+    `runs.py`'s registry) — clearing it around each test keeps a passing
+    record from one test invisible to (and unpolluted by) another.
+    """
+    monkeypatch.setenv("BLUESKY_SESSION_PLAN_DIR", str(tmp_path / "session_plans"))
+    with validation_records.lock:
+        validation_records._passing_hashes.clear()
+    yield
+    with validation_records.lock:
+        validation_records._passing_hashes.clear()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def test_write_session_plan_persists_generated_metadata_plus_body(
+    client: TestClient, tmp_path: Path
+):
+    resp = client.post(
+        "/plans/session",
+        json={
+            "name": "tiny_sweep",
+            "description": "A tiny sweep.",
+            "category": "accelerator",
+            "required_devices": ["correctors", "detectors"],
+            "writes": True,
+            "body": "def build_plan(devices, params):\n    yield\n",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "tiny_sweep"
+
+    from osprey.services.bluesky_bridge.session_dir import resolve_session_plan_dir
+
+    persisted = (resolve_session_plan_dir() / "tiny_sweep.py").read_text(encoding="utf-8")
+    assert "PLAN_METADATA = {" in persisted
+    assert "'name': 'tiny_sweep'" in persisted
+    assert "'writes': True" in persisted
+    assert persisted.endswith("def build_plan(devices, params):\n    yield\n")
+    # HASH CONTRACT: the returned hash is the hash of the EXACT persisted bytes.
+    assert data["content_hash"] == hash_plan_body(persisted)
+
+
+def test_write_session_plan_overwrite_changes_the_hash(client: TestClient):
+    first = client.post(
+        "/plans/session",
+        json={
+            "name": "reauthored",
+            "category": "accelerator",
+            "required_devices": [],
+            "writes": False,
+            "body": "x = 1\n",
+        },
+    ).json()
+    second = client.post(
+        "/plans/session",
+        json={
+            "name": "reauthored",
+            "category": "accelerator",
+            "required_devices": [],
+            "writes": False,
+            "body": "x = 2\n",
+        },
+    ).json()
+    assert first["content_hash"] != second["content_hash"]
+
+
+def test_write_session_plan_rejects_an_unsafe_name(client: TestClient):
+    resp = client.post(
+        "/plans/session",
+        json={
+            "name": "../escape",
+            "category": "accelerator",
+            "required_devices": [],
+            "writes": False,
+            "body": "x = 1\n",
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_write_session_plan_rejects_a_trailing_newline_name(client: TestClient):
+    """Regression: `$` matches at end-of-string OR just before a single
+    trailing "\\n", so a naive `^...$` anchor would let "foo\\n" through —
+    producing a file literally named "foo\\n.py" and a `PLAN_METADATA["name"]`
+    that is not a valid identifier. The route must anchor with `\\Z` (or
+    `re.fullmatch`) instead, so this must be rejected exactly like any other
+    non-identifier name."""
+    resp = client.post(
+        "/plans/session",
+        json={
+            "name": "foo\n",
+            "category": "accelerator",
+            "required_devices": [],
+            "writes": False,
+            "body": "x = 1\n",
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_write_session_plan_rejects_an_overlong_name(client: TestClient):
+    """An absurdly long name must fail closed with a clean 400, not surface
+    as an unhandled 500 (e.g. an OSError from `Path.write_text` on a
+    filesystem that rejects overlong filenames)."""
+    resp = client.post(
+        "/plans/session",
+        json={
+            "name": "a" * 5000,
+            "category": "accelerator",
+            "required_devices": [],
+            "writes": False,
+            "body": "x = 1\n",
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_write_session_plan_never_imports_or_execs_the_body(
+    client: TestClient, tmp_path: Path
+):
+    """A sentinel top-level side effect in the authored body must NEVER fire —
+    proving the write route only writes bytes, never imports/execs them."""
+    sentinel_path = tmp_path / "sentinel.txt"
+    body = (
+        f'from pathlib import Path\nPath(r"{sentinel_path}").write_text("fired")\n\n'
+        "def build_plan(devices, params):\n    yield\n"
+    )
+    resp = client.post(
+        "/plans/session",
+        json={
+            "name": "sentinel_plan",
+            "category": "test",
+            "required_devices": [],
+            "writes": False,
+            "body": body,
+        },
+    )
+    assert resp.status_code == 200
+    assert not sentinel_path.exists(), "write_session_plan must never exec the authored body"
+
+
+def test_validate_unknown_session_plan_is_404(client: TestClient):
+    resp = client.post("/plans/validate", json={"name": "never_written"})
+    assert resp.status_code == 404
+
+
+def test_session_authoring_routes_ignore_writes_enabled_and_promote_token(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Neither route is gated on control_system.writes_enabled or
+    BLUESKY_PROMOTE_TOKEN — both must keep working with writes fully off and
+    no promote token configured at all (their protection is the loopback
+    bind + MCP approval hook, not a token or the writes kill switch)."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / "config.yml").write_text("control_system:\n  writes_enabled: false\n")
+    monkeypatch.chdir(project_dir)
+    monkeypatch.delenv("BLUESKY_PROMOTE_TOKEN", raising=False)
+
+    write_resp = client.post(
+        "/plans/session",
+        json={
+            "name": "writes_off_ok",
+            "category": "accelerator",
+            "required_devices": [],
+            "writes": False,
+            "body": "def build_plan(devices, params):\n    yield\n",
+        },
+    )
+    assert write_resp.status_code == 200
+
+    validate_resp = client.post(
+        "/plans/validate", json={"name": "writes_off_ok", "sample_args": {}}
+    )
+    # Reaches the validator (no 401/403/503 from any token/writes gate);
+    # the plan itself fails stage 3 (no PARAMS/real generator) but that is
+    # an authoring-quality rejection, not an authorization one.
+    assert validate_resp.status_code == 200
+
+
+# =========================================================================
+# Full pipeline (needs a real bluesky dry run): write -> validate -> HASH
+# CONTRACT between the persisted file and the recorded validation hash.
+#
+# Only THIS test needs bluesky/ophyd_async importable (stage 3's dry run
+# actually drives a RunEngine) — every other test in this file is
+# bluesky-independent and must keep running even where those extras aren't
+# installed, so the importorskip guard lives inside this one test only
+# rather than at module scope (unlike `test_plan_validation.py`, where every
+# test is dry-run-adjacent and a module-level guard is appropriate).
+# =========================================================================
+
+
+def test_hash_contract_write_then_validate_same_hash(client: TestClient):
+    pytest.importorskip("bluesky")
+    pytest.importorskip("ophyd_async")
+
+    write_resp = client.post(
+        "/plans/session",
+        json={
+            "name": "tiny_session_sweep",
+            "description": "Session-authored sweep for the hash-contract test.",
+            "category": "accelerator",
+            "required_devices": ["correctors", "detectors"],
+            "writes": True,
+            "body": _BENIGN_BODY,
+        },
+    )
+    assert write_resp.status_code == 200
+    written = write_resp.json()
+
+    from osprey.services.bluesky_bridge.session_dir import resolve_session_plan_dir
+
+    persisted = (resolve_session_plan_dir() / "tiny_session_sweep.py").read_text(encoding="utf-8")
+    assert written["content_hash"] == hash_plan_body(persisted)
+
+    validate_resp = client.post(
+        "/plans/validate",
+        json={"name": "tiny_session_sweep", "sample_args": _BENIGN_SAMPLE_ARGS},
+    )
+    assert validate_resp.status_code == 200
+    validated = validate_resp.json()
+
+    assert validated["passed"] is True, validated["reasons"]
+    # THE HASH CONTRACT: the hash validate recorded is the hash of the exact
+    # persisted file content, re-hashed independently of the write response.
+    assert validated["content_hash"] == hash_plan_body(persisted)
+    assert validated["content_hash"] == written["content_hash"]
+    assert validation_records.has_passing_record(validated["content_hash"]) is True
+
+
+def test_a_failing_validation_records_nothing(client: TestClient):
+    client.post(
+        "/plans/session",
+        json={
+            "name": "unsafe_plan",
+            "category": "accelerator",
+            "required_devices": [],
+            "writes": True,
+            "body": "import epics\n\n\ndef build_plan(devices, params):\n    epics.caput('X', 1)\n    yield\n",
+        },
+    )
+    resp = client.post("/plans/validate", json={"name": "unsafe_plan"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["passed"] is False
+    assert data["reasons"]
+    assert validation_records.has_passing_record(data["content_hash"]) is False

--- a/tests/mcp_server/scan/test_authoring_tools.py
+++ b/tests/mcp_server/scan/test_authoring_tools.py
@@ -159,12 +159,13 @@ async def test_write_bluesky_plan_rejected_maps_to_error_envelope(tmp_path, monk
 
     with patch(
         f"{_MOD}._http_post_json",
-        return_value=(400, {"detail": "invalid plan name '1bad': must be a valid Python identifier"}),
+        return_value=(
+            400,
+            {"detail": "invalid plan name '1bad': must be a valid Python identifier"},
+        ),
     ):
         with assert_raises_error(error_type="plan_write_rejected") as ctx:
-            await _write_fn()(
-                name="1bad", category="x", required_devices=[], writes=False, body=""
-            )
+            await _write_fn()(name="1bad", category="x", required_devices=[], writes=False, body="")
     assert "invalid plan name" in ctx["envelope"]["error_message"]
 
 
@@ -329,9 +330,7 @@ def test_write_session_plan_rejects_an_overlong_name(client: TestClient):
     assert resp.status_code == 400
 
 
-def test_write_session_plan_never_imports_or_execs_the_body(
-    client: TestClient, tmp_path: Path
-):
+def test_write_session_plan_never_imports_or_execs_the_body(client: TestClient, tmp_path: Path):
     """A sentinel top-level side effect in the authored body must NEVER fire —
     proving the write route only writes bytes, never imports/execs them."""
     sentinel_path = tmp_path / "sentinel.txt"

--- a/tests/mcp_server/test_scan_read_tools.py
+++ b/tests/mcp_server/test_scan_read_tools.py
@@ -81,6 +81,38 @@ async def test_list_scan_plans_success():
     assert data["plans"] == plans
 
 
+async def test_list_scan_plans_passes_through_metadata_and_provenance():
+    """The bridge's `metadata`/`provenance` fields (task 1.3) must survive the
+    tool's JSON round-trip unmodified — an agent picking a plan needs both to
+    weigh trust tier and required devices."""
+    plans = [
+        {
+            "name": "count",
+            "description": "",
+            "schema": {},
+            "metadata": None,
+            "provenance": "shipped",
+        },
+        {
+            "name": "sniff",
+            "description": "A directory-layer test plan.",
+            "schema": {},
+            "metadata": {
+                "name": "sniff",
+                "description": "A directory-layer test plan.",
+                "category": "accelerator",
+                "required_devices": ["sniffer"],
+                "writes": False,
+            },
+            "provenance": "facility",
+        },
+    ]
+    with patch(f"{_MOD}._http_get_json", return_value=(200, plans)):
+        result = await _fn("list_scan_plans")()
+    data = extract_response_dict(result)
+    assert data["plans"] == plans
+
+
 async def test_list_scan_plans_empty():
     with patch(f"{_MOD}._http_get_json", return_value=(200, [])):
         result = await _fn("list_scan_plans")()

--- a/tests/registry/test_scan_server_definition.py
+++ b/tests/registry/test_scan_server_definition.py
@@ -6,6 +6,11 @@ carries approval only — the kill switch must never block stopping a scan),
 hooks_post error guidance, opt-in default_enabled, and that the registry-driven
 read-only disallow floor (``read_only_disallowed_tools``) automatically picks
 up both ask-gated scan tools without any scan-specific code there.
+
+Also covers the authoring tools added in task 2.3 — ``write_bluesky_plan`` and
+``validate_bluesky_plan`` — which reach no hardware either way (write only
+emits a file, validate only dry-runs mock devices in an EPICS_CA_*-scrubbed
+subprocess), so both carry ``_APPROVAL`` only and must never be kill-switched.
 """
 
 from pathlib import Path
@@ -77,7 +82,12 @@ def test_scan_permissions_allow():
 
 def test_scan_permissions_ask():
     scan = _resolve_scan()
-    assert scan["permissions_ask"] == ["launch_scan", "stop_scan"]
+    assert scan["permissions_ask"] == [
+        "launch_scan",
+        "stop_scan",
+        "write_bluesky_plan",
+        "validate_bluesky_plan",
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -88,7 +98,12 @@ def test_scan_permissions_ask():
 def test_scan_hooks_pre_structure():
     scan = _resolve_scan()
     by_matcher = {r["matcher"]: r for r in scan["hooks_pre"]}
-    assert set(by_matcher) == {"mcp__scan__launch_scan", "mcp__scan__stop_scan"}
+    assert set(by_matcher) == {
+        "mcp__scan__launch_scan",
+        "mcp__scan__stop_scan",
+        "mcp__scan__write_bluesky_plan",
+        "mcp__scan__validate_bluesky_plan",
+    }
 
     launch = by_matcher["mcp__scan__launch_scan"]
     launch_commands = [h["command"] for h in launch["hooks"]]
@@ -103,6 +118,56 @@ def test_scan_hooks_pre_structure():
     assert len(stop["hooks"]) == 1
     assert "osprey_approval.py" in stop_commands[0]
     assert not any("osprey_writes_check.py" in c for c in stop_commands)
+
+    # write_bluesky_plan/validate_bluesky_plan (task 2.3) reach no hardware
+    # either way — write only emits a file, validate only dry-runs mock
+    # devices in an EPICS_CA_*-scrubbed subprocess — so both are
+    # approval-gated but NEVER kill-switchable, exactly like stop_scan.
+    for tool in ("write_bluesky_plan", "validate_bluesky_plan"):
+        rule = by_matcher[f"mcp__scan__{tool}"]
+        commands = [h["command"] for h in rule["hooks"]]
+        assert len(rule["hooks"]) == 1
+        assert "osprey_approval.py" in commands[0]
+        assert not any("osprey_writes_check.py" in c for c in commands)
+
+
+def test_scan_authoring_tools_never_writes_check_gated():
+    """Regression: assert directly on the dataclass HookRule/HookEntry objects
+    (not the resolved dict form) that write_bluesky_plan and
+    validate_bluesky_plan carry _APPROVAL but never _WRITES_CHECK — the
+    safety posture that keeps them permitted when control_system.writes_enabled
+    is off, since neither reaches hardware."""
+    from osprey.registry.mcp import FRAMEWORK_SERVERS
+
+    scan_def = FRAMEWORK_SERVERS["scan"]
+    by_matcher = {rule.matcher: rule for rule in scan_def.hooks_pre}
+
+    for tool in ("write_bluesky_plan", "validate_bluesky_plan"):
+        rule = by_matcher[f"mcp__scan__{tool}"]
+        assert tool in scan_def.permissions_ask
+        assert len(rule.hooks) == 1
+        assert "osprey_approval.py" in rule.hooks[0].command
+        assert not any("osprey_writes_check.py" in h.command for h in rule.hooks)
+
+    # launch_scan stays kill-switchable; stop_scan stays approval-only —
+    # unchanged by the new authoring tools.
+    launch_rule = by_matcher["mcp__scan__launch_scan"]
+    assert any("osprey_writes_check.py" in h.command for h in launch_rule.hooks)
+    assert any("osprey_approval.py" in h.command for h in launch_rule.hooks)
+
+    stop_rule = by_matcher["mcp__scan__stop_scan"]
+    assert len(stop_rule.hooks) == 1
+    assert "osprey_approval.py" in stop_rule.hooks[0].command
+    assert not any("osprey_writes_check.py" in h.command for h in stop_rule.hooks)
+
+    # The read tiers are unchanged by task 2.3's authoring additions.
+    assert scan_def.permissions_allow == [
+        "create_scan_intent",
+        "scan_status",
+        "list_scan_plans",
+        "list_runs",
+        "read_scan_data",
+    ]
 
 
 def test_scan_hooks_post_error_guidance():
@@ -159,9 +224,19 @@ def test_scan_can_be_extended_like_other_framework_servers():
 
     clone = build_extended_server("scan2", {"extends": "scan"})
     assert clone is not None
-    assert clone.permissions_ask == ["launch_scan", "stop_scan"]
+    assert clone.permissions_ask == [
+        "launch_scan",
+        "stop_scan",
+        "write_bluesky_plan",
+        "validate_bluesky_plan",
+    ]
     matchers = {r.matcher for r in clone.hooks_pre}
-    assert matchers == {"mcp__scan2__launch_scan", "mcp__scan2__stop_scan"}
+    assert matchers == {
+        "mcp__scan2__launch_scan",
+        "mcp__scan2__stop_scan",
+        "mcp__scan2__write_bluesky_plan",
+        "mcp__scan2__validate_bluesky_plan",
+    }
 
 
 def test_scan_present_in_framework_servers():

--- a/tests/services/bluesky_bridge/test_device_no_raw_ca_attr.py
+++ b/tests/services/bluesky_bridge/test_device_no_raw_ca_attr.py
@@ -1,0 +1,199 @@
+"""CA-attribute audit for the connector-mediated device layer (task 2.7).
+
+`ConnectorSettable`/`ConnectorReadable` (`devices/connector.py`) hold the live
+`ControlSystemConnector` directly on the instance, because the in-process
+Bluesky plan body IS handed the device object and must be able to call
+`connector.read_channel`/`write_channel_checked` from `set()`/`read()`/
+`describe()`. That makes this device object the load-bearing surface for the
+"the connector is the sole reachable CA path" claim (CC-2): if a device's
+*public* API leaked the raw connector, or an unchecked write method, any plan
+author could bypass `write_channel_checked`'s refusal/verification path.
+
+This module enumerates the PUBLIC attribute surface (no leading underscore)
+of both device classes and asserts none of it is the connector itself, and
+none of it is an unchecked write path. It passes as-is — the public surface
+(`read`/`describe`/`set`/`name`/`connect`/`parent`/... — see
+`_PUBLIC_ATTRS_ARE_STABLE` below) is already clean. The point of this test is
+to LOCK that in as a regression: if a future edit to `connector.py` (or an
+ophyd-async version bump that adds a new public `Device`/`StandardReadable`
+attribute) exposes the connector or a bare `write_channel`, this test fails.
+
+Known accepted residual (NOT closed by this test, and not closeable by
+attribute hiding): the connector reference is stored as
+`self._osprey_connector` (connector.py:98, 177) — single-underscore, i.e.
+reachable-but-not-public. A plan body holding the device can still reach
+`device._osprey_connector.write_channel(...)` (the UNCHECKED write, as
+opposed to `write_channel_checked`) via ordinary Python attribute access;
+Python has no enforced private attributes, so no naming convention closes
+this off, only obfuscates it. The real defense against that path is NOT this
+device layer — it's task 2.1's static plan validator (which flags
+`write_channel(` and `_osprey_connector` as dangerous patterns before a plan
+is ever exec'd), the load-time provenance gate (task 2.4), and human
+approval (task 2.6). This test does not claim, and must not be read as
+claiming, that the device layer contains an adversarial plan body — see
+`connectors/control_system/base.py` (`write_channel` vs
+`write_channel_checked`, lines ~270 and ~322) for the deeper audit target of
+the unchecked-write surface itself.
+
+Runs ONLY in a bluesky-capable environment, same as `test_connector_devices.py`
+(bluesky/ophyd-async are never installed in the main worktree venv):
+
+    <worktree>/.venv/bin/python -m pytest \
+        tests/services/bluesky_bridge/test_device_no_raw_ca_attr.py -q
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+bluesky = pytest.importorskip("bluesky")
+ophyd_async = pytest.importorskip("ophyd_async")
+
+from osprey.services.bluesky_bridge.devices.connector import (  # noqa: E402
+    ConnectorReadable,
+    ConnectorSettable,
+)
+
+
+class FakeConnector:
+    """A minimal async double exposing both the checked and unchecked write paths.
+
+    Mirrors `ControlSystemConnector`'s two write methods (`base.py:270`,
+    `base.py:322`) just enough to make the asymmetry this test cares about
+    checkable: `write_channel` is the raw/unchecked path, `write_channel_checked`
+    is the refusal-raising path the device layer is supposed to use exclusively.
+    """
+
+    def __init__(self) -> None:
+        self.checked_calls: list[tuple[str, Any]] = []
+        self.unchecked_calls: list[tuple[str, Any]] = []
+
+    async def read_channel(self, channel_address: str, timeout: float | None = None):
+        class _Reading:
+            value = 1.0
+
+        return _Reading()
+
+    async def write_channel_checked(self, channel_address: str, value: Any, **kwargs: Any):
+        self.checked_calls.append((channel_address, value))
+
+    async def write_channel(self, channel_address: str, value: Any, **kwargs: Any):
+        """The unchecked write path — never called by the device layer itself."""
+        self.unchecked_calls.append((channel_address, value))
+
+
+def _public_attrs(obj: Any) -> list[str]:
+    """Public attribute names: no leading underscore, dunders excluded."""
+    return sorted(name for name in dir(obj) if not name.startswith("_"))
+
+
+# Locked-in public surface for each class (task 2.7 regression lock). A
+# failure here means either `connector.py` grew a new public attribute, or an
+# ophyd-async version bump added one to `StandardReadable`/`Device` — audit
+# the new name against `base.py`'s write_channel/write_channel_checked before
+# updating this set.
+_EXPECTED_SETTABLE_PUBLIC_ATTRS = [
+    "add_children_as_readables",
+    "add_readables",
+    "children",
+    "connect",
+    "describe",
+    "describe_configuration",
+    "hints",
+    "log",
+    "name",
+    "parent",
+    "read",
+    "read_configuration",
+    "set",
+    "set_name",
+    "stage",
+    "unstage",
+]
+
+_EXPECTED_READABLE_PUBLIC_ATTRS = [
+    "add_children_as_readables",
+    "add_readables",
+    "children",
+    "connect",
+    "describe",
+    "describe_configuration",
+    "hints",
+    "log",
+    "name",
+    "parent",
+    "read",
+    "read_configuration",
+    "set_name",
+    "stage",
+    "unstage",
+]
+
+
+def _assert_no_raw_ca_or_unchecked_write(device: Any, fake: FakeConnector) -> None:
+    """Common assertion body for both device classes' public surface."""
+    public_attrs = _public_attrs(device)
+
+    assert "write_channel" not in public_attrs, (
+        "the unchecked write path must never be a public device attribute"
+    )
+    assert "_osprey_connector" not in public_attrs, (
+        "the connector reference is a known private residual, not public — "
+        "see this module's docstring"
+    )
+
+    for attr_name in public_attrs:
+        value = getattr(device, attr_name)
+
+        assert value is not fake, (
+            f"public attribute {attr_name!r} must not return the raw connector"
+        )
+        assert not hasattr(value, "write_channel"), (
+            f"public attribute {attr_name!r} exposes an unchecked write_channel path"
+        )
+        assert not hasattr(value, "read_channel"), (
+            f"public attribute {attr_name!r} exposes a raw read_channel/CA handle"
+        )
+
+
+def test_connector_settable_public_surface_has_no_raw_ca_or_unchecked_write() -> None:
+    """`ConnectorSettable`'s public API never leaks the connector or `write_channel`."""
+    fake = FakeConnector()
+    device = ConnectorSettable(fake, "SP", name="motor")
+
+    assert _public_attrs(device) == _EXPECTED_SETTABLE_PUBLIC_ATTRS
+    _assert_no_raw_ca_or_unchecked_write(device, fake)
+
+
+def test_connector_readable_public_surface_has_no_raw_ca_or_unchecked_write() -> None:
+    """`ConnectorReadable`'s public API never leaks the connector or `write_channel`."""
+    fake = FakeConnector()
+    device = ConnectorReadable(fake, "PV", name="detector")
+
+    assert _public_attrs(device) == _EXPECTED_READABLE_PUBLIC_ATTRS
+    _assert_no_raw_ca_or_unchecked_write(device, fake)
+
+
+def test_osprey_connector_residual_is_reachable_but_not_public() -> None:
+    """Documents the accepted residual: `_osprey_connector` is reachable, not public.
+
+    This is NOT a vulnerability this test asserts should be silently accepted
+    in the abstract — it is the documented boundary of what this device layer
+    can and cannot enforce in-process. Python has no attribute access control,
+    so a plan body holding the device can always reach a single-underscore
+    attribute; the containment claim rests on the plan NEVER containing this
+    call in the first place (task 2.1's static validator flags exactly
+    `write_channel(` and `_osprey_connector`), not on this attribute being
+    hidden. See `connectors/control_system/base.py` for the unchecked
+    `write_channel` this residual reaches.
+    """
+    fake = FakeConnector()
+    device = ConnectorSettable(fake, "SP", name="motor")
+
+    # Not part of the public surface...
+    assert "_osprey_connector" not in _public_attrs(device)
+    # ...but ordinary attribute access still reaches it. This is the residual.
+    assert device._osprey_connector is fake
+    assert hasattr(device._osprey_connector, "write_channel")

--- a/tests/services/bluesky_bridge/test_epics_substrate_scanner_wiring.py
+++ b/tests/services/bluesky_bridge/test_epics_substrate_scanner_wiring.py
@@ -272,9 +272,12 @@ def test_both_flags_set_epics_substrate_wins(
 
     scanner = app_module._scanner_factory()
     assert isinstance(scanner, BlueskyScanner)
-    # Substrate scanners are built with the explicit built-in plan set, not
-    # the demo path's default (None -> merged built-ins + facility plans).
-    assert scanner._plans is not None
+    # Substrate scanners are built with `plans=None` too (task 2.5), same as
+    # the demo path — so `reinitialize()` resolves plan names through
+    # `_default_plan_registry()` (built-ins merged with the gated
+    # `get_facility_plans().plans`), letting a validated session/facility
+    # plan launch on this connector-mediated path.
+    assert scanner._plans is None
 
 
 # =========================================================================

--- a/tests/services/bluesky_bridge/test_exemplar_plans.py
+++ b/tests/services/bluesky_bridge/test_exemplar_plans.py
@@ -1,0 +1,181 @@
+"""Coverage for the shipped exemplar accelerator plans (task 1.5):
+``plans_core/response_matrix.py`` and ``plans_core/grid_scan.py``.
+
+Runs ONLY in a bluesky-capable environment — `bluesky`/`ophyd-async` are
+never installed in the main worktree venv, so every test here is skipped via
+`pytest.importorskip` rather than failing, keeping `ci_check` green with no
+bluesky installed at all. To actually run this file:
+
+    uv venv /tmp/bluesky-exemplar-scratch
+    /tmp/bluesky-exemplar-scratch/bin/pip install -e '.[bluesky-bridge]' --python 3.11
+    /tmp/bluesky-exemplar-scratch/bin/python -m pytest \
+        tests/services/bluesky_bridge/test_exemplar_plans.py -q
+
+Two things are proven for each exemplar: (1) it registers through the real
+layered-directory loader (`plan_loader.get_facility_plans`) with valid
+metadata and `provenance == "shipped"` — i.e. the file satisfies the catalog
+contract, not a hand-built `PlanSpec`; and (2) its `build_plan` drives a real
+bluesky `RunEngine` (via `BlueskyScanner`, mirroring
+`test_orm_plan_integration.py`/`test_runengine_integration.py`'s harness) to
+completion against mock devices, emitting documents.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+bluesky = pytest.importorskip("bluesky")
+ophyd_async = pytest.importorskip("ophyd_async")
+
+from osprey.services.bluesky_bridge import live_rows, plan_loader  # noqa: E402
+from osprey.services.bluesky_bridge.devices.mock import build_devices  # noqa: E402
+from osprey.services.bluesky_bridge.plans_core import grid_scan, response_matrix  # noqa: E402
+from osprey.services.bluesky_bridge.scanner_bluesky import BlueskyScanner  # noqa: E402
+
+
+def _wait_until_idle(scanner: BlueskyScanner, timeout: float = 15.0) -> None:
+    deadline = time.monotonic() + timeout
+    while scanner.is_scanning_active():
+        if time.monotonic() > deadline:
+            raise AssertionError("scan did not finish within the timeout")
+        time.sleep(0.05)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state():
+    live_rows._clear()
+    plan_loader.reset_facility_plans()
+    yield
+    live_rows._clear()
+    plan_loader.reset_facility_plans()
+
+
+# =========================================================================
+# Registration through the real layered-directory loader
+# =========================================================================
+
+
+def test_response_matrix_and_grid_scan_nd_register_as_shipped_with_valid_metadata() -> None:
+    facility = plan_loader.get_facility_plans()
+
+    assert "response_matrix" in facility.plans
+    assert "grid_scan_nd" in facility.plans
+
+    rm_spec = facility.plans["response_matrix"]
+    gs_spec = facility.plans["grid_scan_nd"]
+
+    assert rm_spec.provenance == "shipped"
+    assert gs_spec.provenance == "shipped"
+
+    assert rm_spec.metadata is not None
+    assert gs_spec.metadata is not None
+    assert rm_spec.metadata.writes is True
+    assert gs_spec.metadata.writes is True
+
+    # Distinct from the built-in `orm`/`grid_scan` names -- no same-name shadow
+    # at the app.py BUILTIN_PLANS + catalog merge.
+    assert rm_spec.name == "response_matrix"
+    assert gs_spec.name == "grid_scan_nd"
+    assert gs_spec.name != "grid_scan"
+
+
+def test_exemplar_docstrings_carry_the_representative_not_validated_caveat() -> None:
+    assert "not a physics-validated" in response_matrix.__doc__
+    assert "not a physics-validated" in grid_scan.__doc__
+
+
+# =========================================================================
+# RunEngine dry-run against mock devices: a real run, not a no-op
+# =========================================================================
+
+
+@pytest.fixture
+def rm_devices() -> dict:
+    return asyncio.run(
+        build_devices(
+            motor_names=["hcm1", "hcm2"],
+            detector_names=["bpm1", "bpm2"],
+        )
+    )
+
+
+def test_response_matrix_plan_runs_to_completion_and_buffers_rows(rm_devices: dict) -> None:
+    facility = plan_loader.get_facility_plans()
+    scanner = BlueskyScanner(devices=rm_devices, plans=facility.plans)
+    exec_config = {
+        "plan_name": "response_matrix",
+        "plan_args": {
+            "correctors": ["hcm1", "hcm2"],
+            "detectors": ["bpm1", "bpm2"],
+            "span_a": 2.0,
+            "num": 3,
+        },
+    }
+
+    assert scanner.reinitialize(exec_config) is True
+    assert scanner.current_state == "armed"
+
+    scanner.start_scan_thread()
+    _wait_until_idle(scanner)
+
+    assert scanner.error_message is None
+    assert scanner.current_state == "completed"
+    assert scanner.last_run_uid is not None
+
+    buf = live_rows.get(scanner.last_run_uid)
+    assert buf is not None
+    # 2 correctors x 3 points each = one event (row) per (corrector, current).
+    assert buf["total_seen"] == 6
+    assert len(buf["rows"]) == 6
+    for row in buf["rows"]:
+        assert all(value is not None for value in row)
+
+    # Each corrector restored to 0 A after its own sweep.
+    assert asyncio.run(rm_devices["hcm1"].readback.get_value()) == 0.0
+    assert asyncio.run(rm_devices["hcm2"].readback.get_value()) == 0.0
+
+
+@pytest.fixture
+def gs_devices() -> dict:
+    return asyncio.run(
+        build_devices(
+            motor_names=["motor1", "motor2"],
+            detector_names=["det1"],
+        )
+    )
+
+
+def test_grid_scan_nd_plan_runs_to_completion_and_buffers_rows(gs_devices: dict) -> None:
+    facility = plan_loader.get_facility_plans()
+    scanner = BlueskyScanner(devices=gs_devices, plans=facility.plans)
+    exec_config = {
+        "plan_name": "grid_scan_nd",
+        "plan_args": {
+            "detectors": ["det1"],
+            "axes": [
+                {"setpoint": "motor1", "start": 0.0, "stop": 1.0, "num_points": 2},
+                {"setpoint": "motor2", "start": 0.0, "stop": 1.0, "num_points": 3},
+            ],
+        },
+    }
+
+    assert scanner.reinitialize(exec_config) is True
+    assert scanner.current_state == "armed"
+
+    scanner.start_scan_thread()
+    _wait_until_idle(scanner)
+
+    assert scanner.error_message is None
+    assert scanner.current_state == "completed"
+    assert scanner.last_run_uid is not None
+    assert scanner.estimate_current_completion() == 1.0
+
+    buf = live_rows.get(scanner.last_run_uid)
+    assert buf is not None
+    # 2 x 3 grid = 6 total points.
+    assert buf["total_seen"] == 6
+    assert len(buf["rows"]) == 6
+    assert any("det1" in col for col in buf["columns"])

--- a/tests/services/bluesky_bridge/test_plan_injection.py
+++ b/tests/services/bluesky_bridge/test_plan_injection.py
@@ -170,7 +170,17 @@ def test_load_facility_plans_does_not_leave_module_in_sys_modules_on_exec_failur
 def test_get_plans_serves_facility_injected_plan_via_http(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, client: TestClient
 ) -> None:
-    """End-to-end: GET /plans includes the facility's plan, with its schema."""
+    """End-to-end: GET /plans includes the facility's plan, with its schema.
+
+    Also asserts every plan carries `metadata`/`provenance` keys (task 1.3):
+    the legacy contract's `wiggle` plan never set `PlanSpec.metadata`, so it
+    stays `None`, but its `provenance` is loader-normalized to `"facility"`
+    regardless of what the module declared (see `load_facility_plans`). A
+    built-in (`count`) is the other half of the contract: `provenance ==
+    "shipped"` with `metadata: None`, since built-ins don't author
+    `PLAN_METADATA` — see `test_plan_loader_layered.py` for the directory-layer
+    case where `metadata` is populated.
+    """
     module_path = _write_facility_module(tmp_path)
     monkeypatch.setenv(_ENV_VAR, str(module_path))
 
@@ -182,6 +192,12 @@ def test_get_plans_serves_facility_injected_plan_via_http(
     wiggle = plans_by_name["wiggle"]
     assert wiggle["description"] == "A facility-specific plan not in the built-in set."
     assert wiggle["schema"]["properties"]["amplitude"]["default"] == 1.0
+    assert wiggle["metadata"] is None
+    assert wiggle["provenance"] == "facility"
+
+    count = plans_by_name["count"]
+    assert count["metadata"] is None
+    assert count["provenance"] == "shipped"
 
 
 def test_get_facility_plans_constructs_devices_once_and_caches(
@@ -254,3 +270,40 @@ def test_get_plans_reraises_a_non_bridge_import_error_from_builtins(
 
     with pytest.raises(ImportError):
         client.get("/plans")
+
+
+def test_get_plans_serves_directory_layer_metadata_via_http(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    """A directory-layer plan (task 1.2's `BLUESKY_PLAN_DIRS`, `facility` tier)
+    authors real `PLAN_METADATA` — unlike the legacy single-module contract
+    above, `GET /plans` must surface it verbatim, not just `provenance`."""
+    facility_dir = tmp_path / "facility_layer"
+    facility_dir.mkdir()
+    (facility_dir / "sniff.py").write_text(
+        "from pydantic import BaseModel\n\n\n"
+        "PLAN_METADATA = {\n"
+        '    "name": "sniff",\n'
+        '    "description": "A directory-layer test plan.",\n'
+        '    "category": "accelerator",\n'
+        '    "required_devices": ["sniffer"],\n'
+        '    "writes": False,\n'
+        "}\n\n\n"
+        "def build_plan(devices, params):\n"
+        '    return {"plan": "sniff"}\n'
+    )
+    monkeypatch.setenv("BLUESKY_PLAN_DIRS", str(facility_dir))
+
+    resp = client.get("/plans")
+
+    assert resp.status_code == 200
+    plans_by_name = {p["name"]: p for p in resp.json()}
+    sniff = plans_by_name["sniff"]
+    assert sniff["provenance"] == "facility"
+    assert sniff["metadata"] == {
+        "name": "sniff",
+        "description": "A directory-layer test plan.",
+        "category": "accelerator",
+        "required_devices": ["sniffer"],
+        "writes": False,
+    }

--- a/tests/services/bluesky_bridge/test_plan_injection_contract.py
+++ b/tests/services/bluesky_bridge/test_plan_injection_contract.py
@@ -110,8 +110,16 @@ def test_facility_devices_construct_from_config_loaded_module(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """`get_devices()` from the config-pointed module actually runs and its
-    result is what the bridge holds — not just that the plan schema shows up."""
+    result is what the bridge holds — not just that the plan schema shows up.
+
+    Isolates the aggregate from the shipped/facility directory layers (an
+    empty `_SHIPPED_PLANS_DIR`, no `BLUESKY_PLAN_DIRS`) so the exact-set
+    assertion below reflects only the config-loaded legacy module, not
+    whatever exemplar plans the real `plans_core/` dir happens to ship.
+    """
     monkeypatch.delenv("BLUESKY_PLAN_MODULE", raising=False)
+    monkeypatch.delenv("BLUESKY_PLAN_DIRS", raising=False)
+    monkeypatch.setattr(plan_loader, "_SHIPPED_PLANS_DIR", tmp_path / "no_shipped_plans")
     module_path = _write_facility_module(tmp_path)
     _write_config(tmp_path, {"scan": {"plan_module": str(module_path)}})
     monkeypatch.setenv("OSPREY_CONFIG", str(tmp_path / "config.yml"))

--- a/tests/services/bluesky_bridge/test_plan_loader_layered.py
+++ b/tests/services/bluesky_bridge/test_plan_loader_layered.py
@@ -1,0 +1,348 @@
+"""Coverage for the layered directory plan loader (task 1.2): ordered
+directory-layer scanning, per-file quarantine, fail-closed trust-collision
+resolution, and the preserved legacy single-module contract folded in as a
+one-entry `facility`-tier layer.
+
+Directory layers are exercised by monkeypatching `plan_loader._SHIPPED_PLANS_DIR`
+(the in-image core dir doesn't exist in this checkout yet — task 1.5) and by
+setting `BLUESKY_PLAN_DIRS` (env, `facility` tier) / `scan.plan_dirs` in a
+temp config.yml (`preset` tier). All plan files here are pure pydantic/stdlib
+— no bluesky import — so this suite runs in the bluesky-less lane alongside
+`test_plan_injection.py`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from osprey.services.bluesky_bridge import plan_loader
+
+_PLAN_DIRS_ENV = "BLUESKY_PLAN_DIRS"
+_PLAN_MODULE_ENV = "BLUESKY_PLAN_MODULE"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_plan_loader(monkeypatch: pytest.MonkeyPatch):
+    """Every test gets a clean loader cache and no leftover layer env vars."""
+    monkeypatch.delenv(_PLAN_DIRS_ENV, raising=False)
+    monkeypatch.delenv(_PLAN_MODULE_ENV, raising=False)
+    plan_loader.reset_facility_plans()
+    yield
+    plan_loader.reset_facility_plans()
+
+
+def _valid_plan_source(name: str, *, with_params: bool = False) -> str:
+    """A minimal, well-formed directory-layer plan file defining ``name``."""
+    params_block = (
+        "class PARAMS(BaseModel):\n    amplitude: float = 2.0\n\n\n" if with_params else ""
+    )
+    return (
+        "from pydantic import BaseModel\n\n\n"
+        "PLAN_METADATA = {\n"
+        f'    "name": {name!r},\n'
+        '    "description": "A layered test plan.",\n'
+        '    "category": "accelerator",\n'
+        '    "required_devices": [],\n'
+        '    "writes": False,\n'
+        "}\n\n\n"
+        f"{params_block}"
+        "def build_plan(devices, params):\n"
+        f'    return {{"plan": {name!r}}}\n'
+    )
+
+
+def _write(directory: Path, filename: str, source: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / filename
+    path.write_text(source)
+    return path
+
+
+def _synthetic_module_name(path: Path) -> str:
+    digest = hashlib.sha1(str(path.resolve()).encode()).hexdigest()[:16]
+    return f"_osprey_bridge_plan_{digest}"
+
+
+def _write_config(tmp_path: Path, plan_dirs: list[str]) -> Path:
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(yaml.dump({"scan": {"plan_dirs": plan_dirs}}))
+    return config_file
+
+
+def test_layered_scan_registers_plans_from_each_directory_with_correct_provenance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    shipped_dir = tmp_path / "shipped"
+    preset_dir = tmp_path / "preset"
+    facility_dir = tmp_path / "facility"
+    _write(shipped_dir, "core_plan.py", _valid_plan_source("core_plan"))
+    _write(preset_dir, "preset_plan.py", _valid_plan_source("preset_plan"))
+    _write(facility_dir, "facility_plan.py", _valid_plan_source("facility_plan"))
+
+    monkeypatch.setattr(plan_loader, "_SHIPPED_PLANS_DIR", shipped_dir)
+    monkeypatch.setenv("OSPREY_CONFIG", str(_write_config(tmp_path, [str(preset_dir)])))
+    monkeypatch.setenv(_PLAN_DIRS_ENV, str(facility_dir))
+
+    facility = plan_loader.get_facility_plans()
+
+    assert facility.plans["core_plan"].provenance == "shipped"
+    assert facility.plans["preset_plan"].provenance == "preset"
+    assert facility.plans["facility_plan"].provenance == "facility"
+
+
+def test_same_stem_files_across_layers_both_load_without_sys_modules_collision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    shipped_dir = tmp_path / "shipped"
+    facility_dir = tmp_path / "facility"
+    shipped_path = _write(shipped_dir, "myplan.py", _valid_plan_source("plan_a"))
+    facility_path = _write(facility_dir, "myplan.py", _valid_plan_source("plan_b"))
+
+    monkeypatch.setattr(plan_loader, "_SHIPPED_PLANS_DIR", shipped_dir)
+    monkeypatch.setenv(_PLAN_DIRS_ENV, str(facility_dir))
+
+    facility = plan_loader.get_facility_plans()
+
+    assert facility.plans["plan_a"].provenance == "shipped"
+    assert facility.plans["plan_b"].provenance == "facility"
+
+    name_a = _synthetic_module_name(shipped_path)
+    name_b = _synthetic_module_name(facility_path)
+    assert name_a in sys.modules
+    assert name_b in sys.modules
+    assert sys.modules[name_a] is not sys.modules[name_b]
+    del sys.modules[name_a]
+    del sys.modules[name_b]
+
+
+def test_malformed_file_is_quarantined_and_other_plans_still_register(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    layer_dir = tmp_path / "layer"
+    _write(layer_dir, "good_plan.py", _valid_plan_source("good_plan"))
+    _write(layer_dir, "syntax_error.py", "def broken(:\n    pass\n")
+    _write(layer_dir, "missing_metadata.py", "def build_plan(devices, params):\n    return None\n")
+    _write(
+        layer_dir,
+        "missing_build_plan.py",
+        "PLAN_METADATA = {'name': 'no_build', 'description': 'd', 'category': 'accelerator', "
+        "'required_devices': [], 'writes': False}\n",
+    )
+
+    monkeypatch.setattr(plan_loader, "_SHIPPED_PLANS_DIR", layer_dir)
+
+    with caplog.at_level(logging.WARNING, logger="osprey.services.bluesky_bridge.plan_loader"):
+        facility = plan_loader.get_facility_plans()
+
+    assert "good_plan" in facility.plans
+    assert "no_build" not in facility.plans
+    quarantine_warnings = [
+        r for r in caplog.records if r.levelno == logging.WARNING and "quarantining" in r.message
+    ]
+    assert len(quarantine_warnings) == 3
+
+
+def test_higher_trust_directory_layer_overrides_lower_trust_and_warns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    shipped_dir = tmp_path / "shipped"
+    facility_dir = tmp_path / "facility"
+    _write(shipped_dir, "a.py", _valid_plan_source("shared_name"))
+    _write(facility_dir, "b.py", _valid_plan_source("shared_name"))
+
+    monkeypatch.setattr(plan_loader, "_SHIPPED_PLANS_DIR", shipped_dir)
+    monkeypatch.setenv(_PLAN_DIRS_ENV, str(facility_dir))
+
+    with caplog.at_level(logging.WARNING, logger="osprey.services.bluesky_bridge.plan_loader"):
+        facility = plan_loader.get_facility_plans()
+
+    assert facility.plans["shared_name"].provenance == "facility"
+    assert any(r.levelno == logging.WARNING and "overrides" in r.message for r in caplog.records)
+
+
+def test_lower_trust_directory_layer_is_rejected_when_legacy_module_already_owns_the_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The legacy single-module contract is a `facility`-tier layer scanned
+    first — a `shipped`-tier directory file defining the same name must be
+    rejected outright, not silently clobber it."""
+    legacy_dir = tmp_path / "legacy"
+    legacy_path = _write(
+        legacy_dir,
+        "legacy_plans.py",
+        "from osprey.services.bluesky_bridge.plan_types import PlanSpec\n"
+        "from pydantic import BaseModel\n\n"
+        "class P(BaseModel):\n"
+        "    pass\n\n"
+        "PLANS = {'shared_name': PlanSpec(name='shared_name', plan=lambda d, p: None, "
+        "schema=P, description='from legacy module')}\n\n"
+        "def get_devices():\n"
+        "    return {}\n",
+    )
+    shipped_dir = tmp_path / "shipped"
+    _write(shipped_dir, "a.py", _valid_plan_source("shared_name"))
+
+    monkeypatch.setenv(_PLAN_MODULE_ENV, str(legacy_path))
+    monkeypatch.setattr(plan_loader, "_SHIPPED_PLANS_DIR", shipped_dir)
+
+    with caplog.at_level(logging.WARNING, logger="osprey.services.bluesky_bridge.plan_loader"):
+        facility = plan_loader.get_facility_plans()
+
+    assert facility.plans["shared_name"].description == "from legacy module"
+    assert facility.plans["shared_name"].provenance == "facility"
+    assert any(r.levelno == logging.ERROR and "rejecting" in r.message for r in caplog.records)
+
+
+def test_legacy_single_module_contract_still_loads_and_is_tagged_facility(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: the pre-existing `PLANS`/`get_devices()` contract still
+    loads via `load_facility_plans`, and `get_facility_plans()` folds it in."""
+    module_path = _write(
+        tmp_path / "facility_repo",
+        "my_facility_plans.py",
+        "from osprey.services.bluesky_bridge.plan_types import PlanSpec\n"
+        "from pydantic import BaseModel\n\n"
+        "class WiggleParams(BaseModel):\n"
+        "    amplitude: float = 1.0\n\n"
+        "def _wiggle_plan(devices, params):\n"
+        "    return {'device': devices['wiggler'], 'amplitude': params.amplitude}\n\n"
+        "PLANS = {'wiggle': PlanSpec(name='wiggle', plan=_wiggle_plan, schema=WiggleParams, "
+        "description='A facility-specific plan.')}\n\n"
+        "def get_devices():\n"
+        "    return {'wiggler': 'fake-wiggler-device'}\n",
+    )
+
+    direct = plan_loader.load_facility_plans(str(module_path))
+    assert set(direct.plans) == {"wiggle"}
+    assert direct.plans["wiggle"].provenance == "facility"
+    assert direct.devices == {"wiggler": "fake-wiggler-device"}
+
+    monkeypatch.setenv(_PLAN_MODULE_ENV, str(module_path))
+    facility = plan_loader.get_facility_plans()
+    assert "wiggle" in facility.plans
+    assert facility.devices == {"wiggler": "fake-wiggler-device"}
+
+
+def test_params_not_a_type_is_quarantined_and_other_plans_still_register(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    layer_dir = tmp_path / "layer"
+    _write(layer_dir, "good_plan.py", _valid_plan_source("good_plan"))
+    _write(
+        layer_dir,
+        "params_not_a_type.py",
+        "PLAN_METADATA = {\n"
+        "    'name': 'bad_params',\n"
+        "    'description': 'd',\n"
+        "    'category': 'accelerator',\n"
+        "    'required_devices': [],\n"
+        "    'writes': False,\n"
+        "}\n\n"
+        "PARAMS = 123\n\n"
+        "def build_plan(devices, params):\n"
+        "    return None\n",
+    )
+
+    monkeypatch.setattr(plan_loader, "_SHIPPED_PLANS_DIR", layer_dir)
+
+    with caplog.at_level(logging.WARNING, logger="osprey.services.bluesky_bridge.plan_loader"):
+        facility = plan_loader.get_facility_plans()
+
+    assert "good_plan" in facility.plans
+    assert "bad_params" not in facility.plans
+    assert any(r.levelno == logging.WARNING and "quarantining" in r.message for r in caplog.records)
+
+
+def test_params_instance_not_subclass_is_quarantined_and_other_plans_still_register(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """`PARAMS` must be a `BaseModel` *subclass*, not an instance of one."""
+    layer_dir = tmp_path / "layer"
+    _write(layer_dir, "good_plan.py", _valid_plan_source("good_plan"))
+    _write(
+        layer_dir,
+        "params_is_instance.py",
+        "from pydantic import BaseModel\n\n\n"
+        "class _P(BaseModel):\n"
+        "    pass\n\n\n"
+        "PLAN_METADATA = {\n"
+        "    'name': 'bad_params_instance',\n"
+        "    'description': 'd',\n"
+        "    'category': 'accelerator',\n"
+        "    'required_devices': [],\n"
+        "    'writes': False,\n"
+        "}\n\n"
+        "PARAMS = _P()\n\n"
+        "def build_plan(devices, params):\n"
+        "    return None\n",
+    )
+
+    monkeypatch.setattr(plan_loader, "_SHIPPED_PLANS_DIR", layer_dir)
+
+    with caplog.at_level(logging.WARNING, logger="osprey.services.bluesky_bridge.plan_loader"):
+        facility = plan_loader.get_facility_plans()
+
+    assert "good_plan" in facility.plans
+    assert "bad_params_instance" not in facility.plans
+    assert any(r.levelno == logging.WARNING and "quarantining" in r.message for r in caplog.records)
+
+
+def test_system_exit_at_import_time_is_quarantined_and_siblings_still_register(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Regression for the `SystemExit`-at-import-time hardening: a plan file
+    calling `sys.exit()` must be quarantined like any other bad file, not
+    abort the rest of the directory scan."""
+    layer_dir = tmp_path / "layer"
+    _write(layer_dir, "good_plan.py", _valid_plan_source("good_plan"))
+    _write(layer_dir, "exits_on_import.py", "import sys\n\nsys.exit(1)\n")
+
+    monkeypatch.setattr(plan_loader, "_SHIPPED_PLANS_DIR", layer_dir)
+
+    with caplog.at_level(logging.WARNING, logger="osprey.services.bluesky_bridge.plan_loader"):
+        facility = plan_loader.get_facility_plans()
+
+    assert "good_plan" in facility.plans
+    assert any(r.levelno == logging.WARNING and "quarantining" in r.message for r in caplog.records)
+
+
+def test_equal_trust_collision_lets_the_later_scanned_directory_win(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Two `facility`-tier directories (both from `BLUESKY_PLAN_DIRS`) defining
+    the same plan name is an equal-trust collision: the later-scanned
+    directory wins, with a warning (same-tier dirs are all operator-
+    controlled, so scan order is the only tie-breaker)."""
+    first_dir = tmp_path / "facility_first"
+    second_dir = tmp_path / "facility_second"
+    _write(first_dir, "a.py", _valid_plan_source("shared_equal"))
+    _write(second_dir, "b.py", _valid_plan_source("shared_equal"))
+
+    monkeypatch.setenv(_PLAN_DIRS_ENV, os.pathsep.join([str(first_dir), str(second_dir)]))
+
+    with caplog.at_level(logging.WARNING, logger="osprey.services.bluesky_bridge.plan_loader"):
+        facility = plan_loader.get_facility_plans()
+
+    assert facility.plans["shared_equal"].provenance == "facility"
+    assert any(
+        r.levelno == logging.WARNING and "redefined at equal trust" in r.message
+        for r in caplog.records
+    )
+
+
+def test_builtin_plans_still_import_and_are_unaffected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sanity check: `plans.py`'s programmatic built-in set (registered
+    through `app.py`, not this loader) is untouched by the layered rewrite."""
+    pytest.importorskip("bluesky")
+    from osprey.services.bluesky_bridge.plans import BUILTIN_PLANS
+
+    assert BUILTIN_PLANS
+    assert all(spec.provenance == "shipped" for spec in BUILTIN_PLANS.values())

--- a/tests/services/bluesky_bridge/test_plan_metadata.py
+++ b/tests/services/bluesky_bridge/test_plan_metadata.py
@@ -1,0 +1,140 @@
+"""Coverage for the plan-metadata model, its parser, and `PlanSpec`'s new
+`metadata`/`provenance` fields (task 1.1).
+
+Pure pydantic — no bluesky import, so this runs in the fast import-clean lane
+alongside the rest of `plan_types.py`'s own tests.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+from pydantic import BaseModel
+
+from osprey.services.bluesky_bridge.plan_metadata import (
+    PlanMetadata,
+    PlanMetadataError,
+    parse_plan_metadata,
+    parse_plan_metadata_dict,
+)
+from osprey.services.bluesky_bridge.plan_types import PlanSpec
+
+_WELL_FORMED = {
+    "name": "response_matrix",
+    "description": "Sweep each corrector, reading all BPMs at every point.",
+    "category": "accelerator",
+    "required_devices": ["SR:MAG:HCM:01:CURRENT:SP", "SR:DIAG:BPM:01:X"],
+    "writes": True,
+}
+
+
+class _Params(BaseModel):
+    pass
+
+
+def test_well_formed_dict_parses_into_plan_metadata_with_all_fields() -> None:
+    metadata = parse_plan_metadata_dict(_WELL_FORMED, source="test")
+
+    assert metadata.name == "response_matrix"
+    assert metadata.description == _WELL_FORMED["description"]
+    assert metadata.category == "accelerator"
+    assert metadata.required_devices == _WELL_FORMED["required_devices"]
+    assert metadata.writes is True
+
+
+def test_well_formed_module_parses_via_parse_plan_metadata() -> None:
+    module = types.SimpleNamespace(PLAN_METADATA=dict(_WELL_FORMED), __name__="a_plan_module")
+
+    metadata = parse_plan_metadata(module)
+
+    assert metadata == PlanMetadata(**_WELL_FORMED)
+
+
+def test_module_without_plan_metadata_attribute_raises_typed_error() -> None:
+    module = types.SimpleNamespace(__name__="no_metadata_module")
+
+    with pytest.raises(PlanMetadataError, match="no_metadata_module"):
+        parse_plan_metadata(module)
+
+
+def test_plan_metadata_not_a_dict_raises_typed_error() -> None:
+    module = types.SimpleNamespace(PLAN_METADATA=["not", "a", "dict"], __name__="bad_module")
+
+    with pytest.raises(PlanMetadataError, match="bad_module"):
+        parse_plan_metadata(module)
+
+
+def test_source_label_appears_in_error_message() -> None:
+    with pytest.raises(PlanMetadataError, match="my/facility/plan.py"):
+        parse_plan_metadata_dict({}, source="my/facility/plan.py")
+
+
+@pytest.mark.parametrize("missing_field", sorted(_WELL_FORMED))
+def test_missing_required_field_raises_typed_error_naming_the_field(missing_field: str) -> None:
+    raw = {k: v for k, v in _WELL_FORMED.items() if k != missing_field}
+
+    with pytest.raises(PlanMetadataError, match=missing_field) as excinfo:
+        parse_plan_metadata_dict(raw, source="test")
+
+    assert isinstance(excinfo.value, PlanMetadataError)
+
+
+def test_wrong_type_required_devices_raises_typed_error() -> None:
+    raw = {**_WELL_FORMED, "required_devices": "not-a-list"}
+
+    with pytest.raises(PlanMetadataError, match="required_devices"):
+        parse_plan_metadata_dict(raw, source="test")
+
+
+def test_wrong_type_writes_raises_typed_error() -> None:
+    raw = {**_WELL_FORMED, "writes": "not-a-bool"}
+
+    with pytest.raises(PlanMetadataError, match="writes"):
+        parse_plan_metadata_dict(raw, source="test")
+
+
+def test_plan_spec_to_dict_includes_metadata_when_set() -> None:
+    metadata = PlanMetadata(**_WELL_FORMED)
+    spec = PlanSpec(
+        name="response_matrix",
+        plan=lambda devices, params: None,
+        schema=_Params,
+        description="A plan with metadata.",
+        metadata=metadata,
+        provenance="facility",
+    )
+
+    payload = spec.to_dict()
+
+    assert payload["metadata"] == metadata.model_dump()
+    assert payload["provenance"] == "facility"
+
+
+def test_plan_spec_to_dict_metadata_is_none_when_unset() -> None:
+    spec = PlanSpec(
+        name="bare",
+        plan=lambda devices, params: None,
+        schema=_Params,
+        description="No metadata attached.",
+    )
+
+    payload = spec.to_dict()
+
+    assert payload["metadata"] is None
+
+
+def test_plan_spec_old_style_construction_still_works_and_defaults_provenance() -> None:
+    """Regression: the pre-existing `BUILTIN_PLANS` construction style (name/
+    plan/schema/description only, no metadata/provenance kwargs) must keep
+    working unchanged."""
+    spec = PlanSpec(
+        name="count",
+        plan=lambda devices, params: None,
+        schema=_Params,
+        description="Read detectors N times with no motor motion.",
+    )
+
+    assert spec.metadata is None
+    assert spec.provenance == "shipped"
+    assert spec.to_dict()["provenance"] == "shipped"

--- a/tests/services/bluesky_bridge/test_plan_source_endpoint.py
+++ b/tests/services/bluesky_bridge/test_plan_source_endpoint.py
@@ -1,0 +1,197 @@
+"""Coverage for `GET /plans/{name}/source` (task 2.6).
+
+This route is the data source for the launch-approval hook's plan-source
+excerpt — the human backstop for the plan validator's documented, accepted
+obfuscation residual (see `plan_validation.py`'s module docstring): an
+approver who can actually SEE a plan's source has a chance to refuse an
+obfuscated body even where the earlier automated stages could not catch it.
+
+Mirrors `test_promote_validation_gate.py`'s isolation fixture and session-plan
+helpers — every plan file here is pure pydantic/stdlib (no bluesky import).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from osprey.services.bluesky_bridge import plan_loader
+from osprey.services.bluesky_bridge.app import (
+    _SOURCE_TRUNCATE_CHARS,
+    app,
+)
+from osprey.services.bluesky_bridge.plan_validation import hash_plan_body
+from osprey.services.bluesky_bridge.validation_record import validation_records
+
+_SESSION_PLAN_DIR_ENV = "BLUESKY_SESSION_PLAN_DIR"
+_PLAN_DIRS_ENV = "BLUESKY_PLAN_DIRS"
+_PLAN_MODULE_ENV = "BLUESKY_PLAN_MODULE"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(_PLAN_DIRS_ENV, raising=False)
+    monkeypatch.delenv(_PLAN_MODULE_ENV, raising=False)
+    monkeypatch.setenv(_SESSION_PLAN_DIR_ENV, str(tmp_path / "plans_session"))
+    plan_loader.reset_facility_plans()
+
+    with validation_records.lock:
+        saved_hashes = set(validation_records._passing_hashes)
+        validation_records._passing_hashes.clear()
+
+    yield
+
+    plan_loader.reset_facility_plans()
+    with validation_records.lock:
+        validation_records._passing_hashes.clear()
+        validation_records._passing_hashes.update(saved_hashes)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _session_plan_source(name: str, *, body: str = "") -> str:
+    return (
+        "PLAN_METADATA = {\n"
+        f'    "name": {name!r},\n'
+        '    "description": "A session-tier test plan.",\n'
+        '    "category": "accelerator",\n'
+        '    "required_devices": [],\n'
+        '    "writes": False,\n'
+        "}\n\n\n"
+        "def build_plan(devices, params):\n"
+        f'    return {{"plan": {name!r}}}\n'
+        f"{body}"
+    )
+
+
+def _write_session_plan(tmp_path: Path, name: str, source: str) -> Path:
+    session_dir = tmp_path / "plans_session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    path = session_dir / f"{name}.py"
+    path.write_text(source)
+    return path
+
+
+def test_session_plan_with_no_passing_record_is_unvalidated(
+    tmp_path: Path, client: TestClient
+) -> None:
+    source = _session_plan_source("unvalidated_plan")
+    _write_session_plan(tmp_path, "unvalidated_plan", source)
+
+    resp = client.get("/plans/unvalidated_plan/source")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["provenance"] == "session"
+    assert body["validated"] is False
+    assert body["truncated"] is False
+    assert body["source"] == source
+
+
+def test_session_plan_with_a_passing_record_is_validated(
+    tmp_path: Path, client: TestClient
+) -> None:
+    source = _session_plan_source("validated_plan")
+    _write_session_plan(tmp_path, "validated_plan", source)
+    validation_records.record(hash_plan_body(source))
+
+    resp = client.get("/plans/validated_plan/source")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["provenance"] == "session"
+    assert body["validated"] is True
+
+
+def test_session_plan_source_is_truncated_beyond_the_bound(
+    tmp_path: Path, client: TestClient
+) -> None:
+    oversized_body = "\n# padding\n" * (_SOURCE_TRUNCATE_CHARS // 5)
+    source = _session_plan_source("huge_plan", body=oversized_body)
+    assert len(source) > _SOURCE_TRUNCATE_CHARS
+    _write_session_plan(tmp_path, "huge_plan", source)
+
+    resp = client.get("/plans/huge_plan/source")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["truncated"] is True
+    assert len(body["source"]) == _SOURCE_TRUNCATE_CHARS
+    assert body["source"] == source[:_SOURCE_TRUNCATE_CHARS]
+
+
+def test_unknown_plan_name_is_404(client: TestClient) -> None:
+    resp = client.get("/plans/does_not_exist_anywhere/source")
+    assert resp.status_code == 404
+
+
+def test_non_identifier_name_is_400(client: TestClient) -> None:
+    """`name` is sanitized the SAME way `/plans/session` and `/plans/validate`
+    already do (task 2.3's `_sanitize_plan_name`) before it ever touches a
+    filesystem path — a file-reading route must not rely implicitly on
+    FastAPI's no-slash-in-path-param behavior for traversal safety. A bare
+    single-segment name that isn't a valid identifier reaches the handler
+    (no embedded slash to trip routing) and must 400 from the sanitizer."""
+    resp = client.get("/plans/..%2E%2E/source")
+    assert resp.status_code == 400
+
+    resp = client.get("/plans/not-a-valid-identifier/source")
+    assert resp.status_code == 400
+
+
+def test_embedded_slash_name_never_reaches_the_handler(client: TestClient) -> None:
+    """An encoded-slash traversal attempt (`..%2F..%2Fetc%2Fpasswd`) doesn't
+    even match the single-segment `{name}` path parameter — FastAPI's own
+    routing 404s it before `_sanitize_plan_name` ever runs. Documented here
+    so a routing change that started letting such paths through would be
+    caught by a test, not just an implicit assumption."""
+    resp = client.get("/plans/..%2F..%2Fetc%2Fpasswd/source")
+    assert resp.status_code == 404
+
+    resp = client.get("/plans/not a valid identifier/source")
+    assert resp.status_code == 400
+
+
+def test_shipped_plan_is_located_by_declared_name_not_file_stem(
+    tmp_path: Path, client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A shipped-tier file may declare a `PLAN_METADATA["name"]` different
+    from its own filename (e.g. `plans_core/grid_scan.py` -> "grid_scan_nd")
+    — the source route must resolve by the declared name, not the stem."""
+    shipped_dir = tmp_path / "shipped"
+    shipped_dir.mkdir()
+    (shipped_dir / "some_file_stem.py").write_text(
+        _session_plan_source("declared_plan_name")
+    )
+    monkeypatch.setattr(plan_loader, "_SHIPPED_PLANS_DIR", shipped_dir)
+
+    resp = client.get("/plans/declared_plan_name/source")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["provenance"] == "shipped"
+    # Shipped/preset/facility tiers carry no validation-record gate at all —
+    # trusted by construction, not by a passing record.
+    assert body["validated"] is True
+    assert "declared_plan_name" in body["source"]
+
+
+def test_re_authored_session_plan_re_reflects_unvalidated_after_edit(
+    tmp_path: Path, client: TestClient
+) -> None:
+    """A previously-validated session file, edited afterward, is honestly
+    reported as unvalidated again — mirrors the load/promote gates' own
+    re-hash-on-every-check behavior (never a stale cached verdict)."""
+    original = _session_plan_source("edited_plan")
+    path = _write_session_plan(tmp_path, "edited_plan", original)
+    validation_records.record(hash_plan_body(original))
+    assert client.get("/plans/edited_plan/source").json()["validated"] is True
+
+    edited = _session_plan_source("edited_plan", body="\n# an edit\n")
+    path.write_text(edited)
+
+    resp = client.get("/plans/edited_plan/source")
+    body = resp.json()
+    assert body["validated"] is False
+    assert body["source"] == edited

--- a/tests/services/bluesky_bridge/test_plan_source_endpoint.py
+++ b/tests/services/bluesky_bridge/test_plan_source_endpoint.py
@@ -162,9 +162,7 @@ def test_shipped_plan_is_located_by_declared_name_not_file_stem(
     — the source route must resolve by the declared name, not the stem."""
     shipped_dir = tmp_path / "shipped"
     shipped_dir.mkdir()
-    (shipped_dir / "some_file_stem.py").write_text(
-        _session_plan_source("declared_plan_name")
-    )
+    (shipped_dir / "some_file_stem.py").write_text(_session_plan_source("declared_plan_name"))
     monkeypatch.setattr(plan_loader, "_SHIPPED_PLANS_DIR", shipped_dir)
 
     resp = client.get("/plans/declared_plan_name/source")

--- a/tests/services/bluesky_bridge/test_plan_validation.py
+++ b/tests/services/bluesky_bridge/test_plan_validation.py
@@ -48,7 +48,7 @@ from osprey.services.bluesky_bridge.plan_validation import (  # noqa: E402
 # accept-path and dry-run tests below.
 # ---------------------------------------------------------------------------
 BENIGN_PLAN_BODY = textwrap.dedent(
-    '''\
+    """\
     import numpy as np
     from bluesky import plan_stubs as bps
     from bluesky import preprocessors as bpp
@@ -87,7 +87,7 @@ BENIGN_PLAN_BODY = textwrap.dedent(
                 yield from bps.trigger_and_read([corrector, detector])
 
         return _sweep()
-    '''
+    """
 )
 
 BENIGN_SAMPLE_ARGS = {"correctors": ["c1"], "detectors": ["d1"], "num": 3}
@@ -102,7 +102,7 @@ BENIGN_SAMPLE_ARGS = {"correctors": ["c1"], "detectors": ["d1"], "num": 3}
 # task 2.12 bug rather than a synthetic approximation of it.
 # ---------------------------------------------------------------------------
 _SESSION_BODY = textwrap.dedent(
-    '''\
+    """\
     from bluesky import plan_stubs as bps
     from bluesky import preprocessors as bpp
     from pydantic import BaseModel, Field
@@ -126,7 +126,7 @@ _SESSION_BODY = textwrap.dedent(
                 yield from bps.trigger_and_read([corrector, detector])
 
         return _sweep()
-    '''
+    """
 )
 
 

--- a/tests/services/bluesky_bridge/test_plan_validation.py
+++ b/tests/services/bluesky_bridge/test_plan_validation.py
@@ -1,0 +1,700 @@
+"""Tests for `plan_validation.py` (task 2.1): the three-stage authoring
+validator for a session-tier plan-file body — static AST allowlist, narrowed
+CA/connector pattern scan, and a mock-RunEngine dry-run.
+
+The dry-run stage actually drives a real bluesky `RunEngine` (in a
+subprocess) against real ophyd-async mock devices, so — like every other
+bluesky-capable test in this directory — the dry-run tests are guarded by
+`pytest.importorskip` rather than failing outright when `bluesky`/
+`ophyd_async` aren't installed. The static-allowlist and pattern-scan stages
+need neither, but this file keeps the same guard for every test for
+consistency with its siblings (`test_exemplar_plans.py`,
+`test_runengine_integration.py`).
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+bluesky = pytest.importorskip("bluesky")
+ophyd_async = pytest.importorskip("ophyd_async")
+
+from osprey.mcp_server.workspace.execution.sandbox_executor import (  # noqa: E402
+    _ALLOWED_IMPORTS,
+    _ALLOWED_TOP_LEVEL,
+    _DANGEROUS_PATTERNS,
+    validate_sandbox_code,
+)
+from osprey.services.bluesky_bridge import plan_validation  # noqa: E402
+from osprey.services.bluesky_bridge.plan_validation import (  # noqa: E402
+    _CA_ONLY_PATTERNS,
+    _EPICS_CA_ENV_NAMES_TO_DROP,
+    _EPICS_CA_INERT_ENV,
+    _ca_pattern_scan,
+    _collect_device_names,
+    _static_allowlist_check,
+    hash_plan_body,
+    validate_bluesky_plan,
+)
+
+# ---------------------------------------------------------------------------
+# A tiny, fully-contract-compliant benign plan body: one corrector, one
+# detector, harmless (non-control-system) `.put`/`.get` usage that a naive
+# pattern scan could mistake for a CA write/read. Reused across the
+# accept-path and dry-run tests below.
+# ---------------------------------------------------------------------------
+BENIGN_PLAN_BODY = textwrap.dedent(
+    '''\
+    import numpy as np
+    from bluesky import plan_stubs as bps
+    from bluesky import preprocessors as bpp
+    from pydantic import BaseModel, Field
+
+    PLAN_METADATA = {
+        "name": "tiny_sweep",
+        "description": "Sweep one corrector, reading one detector at each point.",
+        "category": "accelerator",
+        "required_devices": ["correctors", "detectors"],
+        "writes": True,
+    }
+
+
+    class PARAMS(BaseModel):
+        correctors: list[str] = Field(..., min_length=1)
+        detectors: list[str] = Field(..., min_length=1)
+        num: int = Field(..., ge=1)
+
+
+    def build_plan(devices, params):
+        # Harmless, non-control-system ".get"/".put" usage that must NOT be
+        # mistaken for a CA/connector read or write.
+        {}.get("missing")
+        arr = np.zeros(params.num)
+        np.put(arr, list(range(params.num)), 1.0)
+
+        corrector = devices[params.correctors[0]]
+        detector = devices[params.detectors[0]]
+
+        @bpp.stage_decorator([corrector, detector])
+        @bpp.run_decorator()
+        def _sweep():
+            for i in range(params.num):
+                yield from bps.mv(corrector, float(i))
+                yield from bps.trigger_and_read([corrector, detector])
+
+        return _sweep()
+    '''
+)
+
+BENIGN_SAMPLE_ARGS = {"correctors": ["c1"], "detectors": ["d1"], "num": 3}
+
+# ---------------------------------------------------------------------------
+# A raw "author-submitted body" shaped like an actual `PlanSessionWriteRequest
+# .body` (task 2.3) -- unlike `BENIGN_PLAN_BODY` above, this has NO embedded
+# `PLAN_METADATA` of its own (the real field never does; `write_session_plan`
+# in app.py generates and prepends that separately). Used by
+# `TestFutureImportPosition` to assemble content exactly the way
+# `write_session_plan` does, so those tests exercise the real shape of the
+# task 2.12 bug rather than a synthetic approximation of it.
+# ---------------------------------------------------------------------------
+_SESSION_BODY = textwrap.dedent(
+    '''\
+    from bluesky import plan_stubs as bps
+    from bluesky import preprocessors as bpp
+    from pydantic import BaseModel, Field
+
+
+    class PARAMS(BaseModel):
+        correctors: list[str] = Field(..., min_length=1)
+        detectors: list[str] = Field(..., min_length=1)
+        num: int = Field(..., ge=1)
+
+
+    def build_plan(devices, params):
+        corrector = devices[params.correctors[0]]
+        detector = devices[params.detectors[0]]
+
+        @bpp.stage_decorator([corrector, detector])
+        @bpp.run_decorator()
+        def _sweep():
+            for i in range(params.num):
+                yield from bps.mv(corrector, float(i))
+                yield from bps.trigger_and_read([corrector, detector])
+
+        return _sweep()
+    '''
+)
+
+
+def _assembled_session_content(body: str) -> str:
+    """Mirror `write_session_plan`'s (app.py) file assembly exactly: a
+    generated `PLAN_METADATA = {...}` assignment prepended ahead of the
+    author's own body -- the shape task 2.12's future-import-position check
+    exists to guard.
+    """
+    metadata = {
+        "name": "tiny_sweep",
+        "description": "",
+        "category": "accelerator",
+        "required_devices": ["correctors", "detectors"],
+        "writes": True,
+    }
+    return f"PLAN_METADATA = {metadata!r}\n\n{body}"
+
+
+# =========================================================================
+# Regression: the viz sandbox's own constants/behavior are untouched (C10)
+# =========================================================================
+
+
+class TestVizSandboxRegression:
+    def test_allowed_top_level_and_imports_unmodified(self):
+        """`_ALLOWED_TOP_LEVEL`/`_ALLOWED_IMPORTS` still hold every original
+        viz-sandbox entry, and `_ALLOWED_TOP_LEVEL` is still derived from
+        `_ALLOWED_IMPORTS` — task 2.1 must never rename or mutate either.
+        """
+        assert _ALLOWED_TOP_LEVEL == {m.split(".")[0] for m in _ALLOWED_IMPORTS}
+        # A representative sample of the original viz whitelist, untouched.
+        for name in ("numpy", "pandas", "matplotlib", "plotly", "bokeh", "os", "pathlib"):
+            assert name in _ALLOWED_IMPORTS
+        # Never widened to admit bluesky or CA-adjacent names by this change.
+        assert "bluesky" not in _ALLOWED_TOP_LEVEL
+        assert "epics" not in _ALLOWED_TOP_LEVEL
+
+    def test_dangerous_patterns_unmodified(self):
+        assert ("epics", "epics module") in _DANGEROUS_PATTERNS
+        assert ("write_channel", "write_channel()") in _DANGEROUS_PATTERNS
+        assert ("ctypes", "ctypes module") in _DANGEROUS_PATTERNS
+
+    def test_viz_single_arg_call_still_behaves_identically(self):
+        """The pre-existing single-positional-arg call (the viz sandbox's own
+        caller, `sandbox_executor.py`'s `execute_sandbox_code`) must see the
+        exact same behavior after parameterization: same signature, same
+        defaults, no keyword required.
+        """
+        is_safe, violations = validate_sandbox_code(
+            "import numpy as np\nimport matplotlib.pyplot as plt\nplt.plot(np.arange(3))"
+        )
+        assert is_safe
+        assert violations == []
+
+        is_safe, violations = validate_sandbox_code("import epics\nepics.caput('PV', 1)")
+        assert not is_safe
+        assert any("epics" in v for v in violations)
+
+        is_safe, violations = validate_sandbox_code("import bluesky")
+        assert not is_safe
+        assert any("bluesky" in v for v in violations)
+
+
+# =========================================================================
+# Stage 1: static AST allowlist
+# =========================================================================
+
+
+class TestStaticAllowlistCheck:
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "import epics",
+            "import epics as e",  # aliasing must not evade the import-name check
+            "from epics import caput",
+            '__import__("epics")',
+            "import ctypes",
+            "import os",
+            "import importlib",
+            "import subprocess",
+            "import socket",
+            "import aioca",
+            "import caproto",
+            "import bluesky",  # bare bluesky, no submodule
+            "import bluesky.utils",  # a real submodule, but not one of the 3 allowed
+            "from bluesky.callbacks import LiveTable",
+            "import logging.config",  # dictConfig/fileConfig do instantiation-by-string
+            "import logging.handlers",  # e.g. SMTPHandler/SocketHandler
+            "from logging import config",  # same submodule, "from X import Y" form
+            "from logging import handlers",
+            "from logging.config import dictConfig",
+        ],
+    )
+    def test_rejects_disallowed_imports(self, code):
+        violations = _static_allowlist_check(code)
+        assert violations, f"expected a rejection for: {code!r}"
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "from bluesky import plan_stubs as bps",
+            "from bluesky.plan_stubs import mv",
+            "import bluesky.plan_stubs",
+            "from bluesky import plans as bp",
+            "from bluesky import preprocessors as bpp",
+            "import numpy as np",
+            "from scipy import stats",
+            "import math",
+            "import statistics",
+            "import time",
+            "import collections",
+            "import itertools",
+            "import functools",
+            "from pydantic import BaseModel, Field",
+            "from __future__ import annotations",
+            "from typing import Any",
+            "import typing",
+            "import logging",
+            "from logging import getLogger",
+        ],
+    )
+    def test_accepts_allowed_imports(self, code):
+        assert _static_allowlist_check(code) == []
+
+    def test_logging_submodule_granularity_bare_accept_config_and_handlers_reject(self):
+        """The `logging` top level is allowed (the shipped exemplars need
+        `logging.getLogger(...)`), but `logging.config`/`logging.handlers`
+        must stay rejected in every import form — mirrors the `bluesky`
+        submodule granularity test, inverted (allow the top level, deny
+        specific submodules rather than the reverse).
+        """
+        assert _static_allowlist_check("import logging") == []
+        assert _static_allowlist_check("from logging import getLogger") == []
+        assert _static_allowlist_check("import logging.config") != []
+        assert _static_allowlist_check("import logging.handlers") != []
+        assert _static_allowlist_check("from logging import config") != []
+        assert _static_allowlist_check("from logging.config import dictConfig") != []
+
+    def test_submodule_granularity_plan_stubs_accept_some_other_reject(self):
+        assert _static_allowlist_check("from bluesky import plan_stubs") == []
+        assert _static_allowlist_check("from bluesky import some_other") != []
+
+    def test_dunder_import_variant_rejected(self):
+        violations = _static_allowlist_check("x = __import__('epics')")
+        assert any("__import__" in v for v in violations)
+
+    def test_syntax_error_reported_and_short_circuits(self):
+        violations = _static_allowlist_check("def f(:\n  pass")
+        assert any("Syntax error" in v for v in violations)
+
+
+# =========================================================================
+# Task 2.12: `from __future__ import ...` cannot survive `write_session_plan`
+# (app.py)'s metadata-prepend assembly -- Python requires a future-import to
+# be the file's literal first statement (module docstring aside), but
+# `write_session_plan` always writes a generated `PLAN_METADATA = {...}`
+# assignment ahead of the author's body. `ast.parse` (the syntax gate
+# `validate_sandbox_code` runs) does not enforce that positional rule --
+# only `compile()`/the import machinery does -- so an unflagged body would
+# otherwise sail through stages 1-2 clean and only fail deep in stage 3's
+# dry-run subprocess, as a `SyntaxError` naming a temp file and line number
+# that point at the generated metadata line, not the real cause.
+# =========================================================================
+
+_FUTURE_IMPORT_REJECT_MESSAGE = (
+    "session plans cannot use `from __future__` imports because plan "
+    "metadata is prepended to the file; omit it — modern type hints "
+    "(list[str], dict[str, Any]) work without it on Python 3.9+."
+)
+
+
+class TestFutureImportPosition:
+    def test_bare_future_import_at_position_zero_still_accepted(self):
+        """A positional check, not a blanket ban: `from __future__ import`
+        genuinely at the leading position (as in the shipped `plans_core`
+        exemplars, read and validated directly -- never metadata-prepended,
+        see `TestShippedExemplarsPassValidation` below) is legal Python and
+        must still pass.
+        """
+        assert _static_allowlist_check("from __future__ import annotations") == []
+
+    def test_future_import_rejected_once_metadata_is_prepended(self):
+        content = _assembled_session_content(
+            "from __future__ import annotations\n\n" + _SESSION_BODY
+        )
+        assert _static_allowlist_check(content) == [_FUTURE_IMPORT_REJECT_MESSAGE]
+
+    async def test_validate_bluesky_plan_rejects_with_clear_message_not_a_syntax_error(self):
+        content = _assembled_session_content(
+            "from __future__ import annotations\n\n" + _SESSION_BODY
+        )
+        result = await validate_bluesky_plan(
+            content, plan_name="tiny_sweep", sample_args=BENIGN_SAMPLE_ARGS
+        )
+        assert result.passed is False
+        assert result.reasons == [_FUTURE_IMPORT_REJECT_MESSAGE]
+        assert not any("SyntaxError" in r for r in result.reasons)
+
+    async def test_validate_bluesky_plan_accepts_the_same_body_without_future_import(self):
+        content = _assembled_session_content(_SESSION_BODY)
+        result = await validate_bluesky_plan(
+            content, plan_name="tiny_sweep", sample_args=BENIGN_SAMPLE_ARGS
+        )
+        assert result.passed is True, result.reasons
+
+
+# =========================================================================
+# Stage 2: narrowed CA/connector pattern scan
+# =========================================================================
+
+
+class TestCaPatternScan:
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "caput('BEAM:CURRENT', 1.0)",
+            "epics.caget('BEAM:CURRENT')",
+            "write_channel('BEAM:CURRENT', 1.0)",
+            "read_channel('BEAM:CURRENT')",
+            "device._osprey_connector.write_channel('X', 1.0)",
+            "pv = PV('BEAM:CURRENT')",
+            "import aioca",
+            "import caproto",
+        ],
+    )
+    def test_flags_ca_constructs(self, code):
+        assert _ca_pattern_scan(code) != []
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "np.put(arr, [0], 1.0)",
+            "numpy.put(arr, [0], 1.0)",
+            "{}.get('missing')",
+            "config.get('key', default)",
+            "queue.put(1)",
+            "q = queue.Queue()\nq.put(1)",
+        ],
+    )
+    def test_does_not_flag_benign_put_get(self, code):
+        assert _ca_pattern_scan(code) == []
+
+    def test_bare_framework_default_patterns_would_have_false_positived(self):
+        """Sanity check that this is a real narrowing, not a no-op: the
+        framework's own default write patterns (`.put(`) DO match
+        `numpy.put(...)` — confirming `_CA_ONLY_PATTERNS` deliberately
+        excludes it rather than happening to not match by accident.
+        """
+        from osprey.services.python_executor.analysis.pattern_detection import (
+            detect_control_system_operations,
+        )
+
+        default_result = detect_control_system_operations("np.put(arr, [0], 1.0)")
+        assert default_result["has_writes"] is True  # the framework default DOES false-positive
+
+        narrowed_result = detect_control_system_operations(
+            "np.put(arr, [0], 1.0)", patterns=_CA_ONLY_PATTERNS, pattern_mode="override"
+        )
+        assert narrowed_result["has_writes"] is False
+
+
+# =========================================================================
+# Content hash helper
+# =========================================================================
+
+
+class TestHashPlanBody:
+    def test_stable_and_deterministic(self):
+        h1 = hash_plan_body("x = 1\n")
+        h2 = hash_plan_body("x = 1\n")
+        assert h1 == h2
+        assert len(h1) == 64  # sha256 hex digest
+
+    def test_differs_for_different_content(self):
+        assert hash_plan_body("x = 1\n") != hash_plan_body("x = 2\n")
+
+    def test_normalizes_line_endings(self):
+        assert hash_plan_body("x = 1\r\n") == hash_plan_body("x = 1\n")
+
+    def test_normalizes_trailing_newline_variants_and_bom(self):
+        """`hash_plan_body("x")`, `("x\\n")`, `("x\\n\\n\\n")`, and a
+        BOM-prefixed `("\\ufeffx\\n")` must all hash IDENTICALLY: this is the
+        cross-task key (2.2's store / 2.4's load gate / 2.5's promote gate
+        match an in-memory body against an on-disk re-hash), so any of these
+        harmless round-trip variations silently diverging would be a real
+        mismatch, not a cosmetic one.
+        """
+        reference = hash_plan_body("x")
+        assert hash_plan_body("x\n") == reference
+        assert hash_plan_body("x\n\n\n") == reference
+        assert hash_plan_body("﻿x\n") == reference
+
+    def test_bom_and_extra_trailing_newlines_alone_still_differ_from_other_content(self):
+        assert hash_plan_body("x\n\n\n") != hash_plan_body("y\n\n\n")
+
+
+# =========================================================================
+# Device-name bucketing for the dry-run's mock device factory
+# =========================================================================
+
+
+class TestCollectDeviceNames:
+    def test_flat_correctors_and_detectors_fields(self):
+        motors, detectors = _collect_device_names(
+            {"correctors": ["c1", "c2"], "detectors": ["d1"], "span_a": 1.0, "num": 3}
+        )
+        assert motors == {"c1", "c2"}
+        assert detectors == {"d1"}
+
+    def test_nested_axes_setpoint_field(self):
+        """Mirrors `grid_scan_nd`'s PARAMS shape: setpoints nested under
+        `axes[].setpoint`, not a flat field named "setpoints"."""
+        motors, detectors = _collect_device_names(
+            {
+                "detectors": ["d1"],
+                "axes": [
+                    {"setpoint": "m1", "start": 0.0, "stop": 1.0, "num_points": 2},
+                    {"setpoint": "m2", "start": 0.0, "stop": 1.0, "num_points": 3},
+                ],
+            }
+        )
+        assert motors == {"m1", "m2"}
+        assert detectors == {"d1"}
+
+    def test_empty_sample_args(self):
+        assert _collect_device_names({}) == (set(), set())
+
+
+# =========================================================================
+# Stage 3: dry-run — environment scrub wiring (subprocess spawn mocked out)
+# =========================================================================
+
+
+class TestDryRunEnvScrub:
+    async def test_epics_ca_vars_are_neutralized_in_the_subprocess_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Asserts `_dry_run` passes a neutralized env to
+        `create_subprocess_exec` — the real subprocess spawn is mocked out so
+        this test stays fast and doesn't need a real bluesky dry-run to prove
+        the env wiring specifically.
+
+        Deliberately asserts the SET values, not merely "key absent": a CA
+        client that sees neither `EPICS_CA_ADDR_LIST` nor an explicit
+        `EPICS_CA_AUTO_ADDR_LIST` defaults auto-discovery to YES and
+        broadcasts on the local subnet looking for IOCs — so simply deleting
+        these keys would have been worse than leaving them alone. The
+        assertions below are what actually proves that gap is closed.
+        """
+        captured_env: dict[str, str] = {}
+
+        class _FakeProc:
+            returncode = 0
+
+            async def communicate(self):
+                return b"", b""
+
+            def kill(self):
+                pass
+
+            async def wait(self):
+                pass
+
+        async def _fake_create_subprocess_exec(*args, **kwargs):
+            captured_env.update(kwargs["env"])
+            script_path = Path(args[1])
+            result_path = script_path.parent / "result.json"
+            result_path.write_text(json.dumps({"success": True}))
+            return _FakeProc()
+
+        monkeypatch.setenv("EPICS_CA_ADDR_LIST", "10.0.0.1")
+        monkeypatch.setenv("EPICS_CA_NAME_SERVERS", "10.0.0.1:5064")
+        monkeypatch.setenv("EPICS_CA_AUTO_ADDR_LIST", "YES")
+        monkeypatch.setenv("EPICS_CA_SERVER_PORT", "5064")
+        monkeypatch.setattr(
+            plan_validation.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec
+        )
+
+        reasons = await plan_validation._dry_run(
+            BENIGN_PLAN_BODY, plan_name="tiny_sweep", sample_args=BENIGN_SAMPLE_ARGS, timeout=5.0
+        )
+
+        assert reasons == []
+        assert captured_env["EPICS_CA_AUTO_ADDR_LIST"] == "NO"
+        assert captured_env["EPICS_CA_ADDR_LIST"] == ""
+        assert captured_env["EPICS_CA_NAME_SERVERS"] == ""
+        for name in _EPICS_CA_ENV_NAMES_TO_DROP:
+            assert name not in captured_env
+
+    def test_inert_env_constants_are_actually_inert(self):
+        """`_EPICS_CA_INERT_ENV` is the source of truth the assertions above
+        rely on — pin its exact values so a future edit can't quietly
+        reintroduce the broadcast-discovery gap this fix closed.
+        """
+        assert _EPICS_CA_INERT_ENV == {
+            "EPICS_CA_ADDR_LIST": "",
+            "EPICS_CA_AUTO_ADDR_LIST": "NO",
+            "EPICS_CA_NAME_SERVERS": "",
+        }
+
+
+# =========================================================================
+# Full pipeline: validate_bluesky_plan
+# =========================================================================
+
+
+class TestValidateBlueskyPlanRejects:
+    async def test_rejects_at_stage_1_for_a_disallowed_import(self):
+        result = await validate_bluesky_plan("import epics\nepics.caput('X', 1)\n")
+        assert result.passed is False
+        assert any("epics" in r or "Import not allowed" in r for r in result.reasons)
+        assert len(result.content_hash) == 64
+
+    async def test_rejects_at_stage_2_for_a_ca_construct_with_no_import(self):
+        # `caget(`/`read_channel(` are in `_CA_ONLY_PATTERNS` but NOT in
+        # `_DANGEROUS_PATTERNS` (unlike `caput`/`write_channel`, which stage 1
+        # already catches via its reused dangerous-pattern scan) — so this
+        # body only gets caught once stage 2 actually runs.
+        code = "PLAN_METADATA = {}\nvalue = read_channel('BEAM:CURRENT')\n"
+        result = await validate_bluesky_plan(code)
+        assert result.passed is False
+        assert any("Control-system operation" in r for r in result.reasons)
+
+    async def test_stage_1_short_circuits_before_stage_2(self):
+        """A body with BOTH a disallowed import AND a CA construct is
+        rejected for the import (stage 1 never reaches stage 2)."""
+        code = "import epics\nvalue = read_channel('BEAM:CURRENT')\n"
+        result = await validate_bluesky_plan(code)
+        assert result.passed is False
+        assert not any("Control-system operation" in r for r in result.reasons)
+
+
+class TestValidateBlueskyPlanAccepts:
+    async def test_benign_plan_passes_all_stages_and_drives_to_completion(self):
+        result = await validate_bluesky_plan(
+            BENIGN_PLAN_BODY,
+            plan_name="tiny_sweep",
+            sample_args=BENIGN_SAMPLE_ARGS,
+            dry_run_timeout=30.0,
+        )
+
+        assert result.passed is True, result.reasons
+        assert result.reasons == []
+        assert result.content_hash == hash_plan_body(BENIGN_PLAN_BODY)
+
+    async def test_a_body_that_raises_at_dry_run_time_fails_stage_3_only(self):
+        """Imports/patterns are clean, but the plan body itself blows up once
+        actually driven — proves stage 3 catches runtime failures stages 1-2
+        cannot (they never execute the body)."""
+        code = textwrap.dedent(
+            """\
+            from pydantic import BaseModel
+
+            PLAN_METADATA = {
+                "name": "boom",
+                "description": "raises at runtime",
+                "category": "accelerator",
+                "required_devices": [],
+                "writes": False,
+            }
+
+
+            class PARAMS(BaseModel):
+                pass
+
+
+            def build_plan(devices, params):
+                raise RuntimeError("boom")
+                yield  # pragma: no cover - unreachable; makes this a generator
+            """
+        )
+        result = await validate_bluesky_plan(code, plan_name="boom", sample_args={})
+        assert result.passed is False
+        assert any("Dry-run failed" in r for r in result.reasons)
+
+
+# =========================================================================
+# Regression: the shipped exemplars (task 1.5) — THE format the
+# writing-bluesky-plans skill tells authors to copy — must themselves pass
+# validation. Stage 1 rejecting them for reasons unrelated to control-system
+# safety (a missing `__future__`/`typing`/`logging` allowlist entry) would
+# mean the documented reference format doesn't actually validate.
+# =========================================================================
+
+_PLANS_CORE_DIR = (
+    Path(__file__).parents[3] / "src" / "osprey" / "services" / "bluesky_bridge" / "plans_core"
+)
+
+
+class TestShippedExemplarsPassValidation:
+    def test_response_matrix_source_passes_the_static_and_pattern_stages(self):
+        source = (_PLANS_CORE_DIR / "response_matrix.py").read_text(encoding="utf-8")
+        assert _static_allowlist_check(source) == []
+        assert _ca_pattern_scan(source) == []
+
+    def test_grid_scan_source_passes_the_static_and_pattern_stages(self):
+        source = (_PLANS_CORE_DIR / "grid_scan.py").read_text(encoding="utf-8")
+        assert _static_allowlist_check(source) == []
+        assert _ca_pattern_scan(source) == []
+
+    async def test_response_matrix_source_passes_full_validation_including_dry_run(self):
+        source = (_PLANS_CORE_DIR / "response_matrix.py").read_text(encoding="utf-8")
+        result = await validate_bluesky_plan(
+            source,
+            plan_name="response_matrix",
+            sample_args={
+                "correctors": ["hcm1", "hcm2"],
+                "detectors": ["bpm1", "bpm2"],
+                "span_a": 2.0,
+                "num": 3,
+            },
+        )
+        assert result.passed is True, result.reasons
+
+    async def test_grid_scan_source_passes_full_validation_including_dry_run(self):
+        source = (_PLANS_CORE_DIR / "grid_scan.py").read_text(encoding="utf-8")
+        result = await validate_bluesky_plan(
+            source,
+            plan_name="grid_scan_nd",
+            sample_args={
+                "detectors": ["det1"],
+                "axes": [
+                    {"setpoint": "motor1", "start": 0.0, "stop": 1.0, "num_points": 2},
+                    {"setpoint": "motor2", "start": 0.0, "stop": 1.0, "num_points": 3},
+                ],
+            },
+        )
+        assert result.passed is True, result.reasons
+
+
+# =========================================================================
+# Documented, accepted residual: obfuscated imports are not a containment
+# boundary (see module docstring — stages 1-2 are AST/regex checks, not a
+# sandbox; the real backstop is human approval rendering the plan source at
+# launch, task 2.6).
+# =========================================================================
+
+
+class TestKnownObfuscationResidual:
+    @pytest.mark.xfail(
+        reason=(
+            "known-uncaught residual: a getattr/string-concatenation-obfuscated "
+            "__import__ call evades both the AST import walk and the substring/"
+            "regex pattern scan by construction (neither stage's source text nor "
+            "AST ever contains a literal 'epics' import or CA-construct name) -- "
+            "ACCEPTED, not a bug. See the module docstring's 'not a containment "
+            "boundary' note; the real backstop is human approval at launch "
+            "(task 2.6), not this validator."
+        ),
+        strict=True,
+    )
+    def test_obfuscated_import_evades_the_static_and_pattern_stages(self):
+        code = textwrap.dedent(
+            """\
+            PLAN_METADATA = {}
+
+
+            def build_plan(devices, params):
+                _import_name = "".join(["__", "imp", "ort", "__"])
+                _module_name = "".join(["ep", "ics"])
+                _reflected = getattr(__builtins__, _import_name)(_module_name)
+                return _reflected
+            """
+        )
+        violations = _static_allowlist_check(code) + _ca_pattern_scan(code)
+        assert violations != [], (
+            "this obfuscated import is now being caught -- if that's a real "
+            "improvement, update the module docstring's residual claim and "
+            "flip this test's polarity rather than leaving it stale"
+        )

--- a/tests/services/bluesky_bridge/test_promote_validation_gate.py
+++ b/tests/services/bluesky_bridge/test_promote_validation_gate.py
@@ -141,7 +141,9 @@ def test_gate_reblocks_after_the_session_file_is_edited(tmp_path: Path) -> None:
 
     # Edit the file (still a well-formed plan, just different content) without
     # re-validating it.
-    edited = original.replace('"description": "A session-tier test plan."', '"description": "edited"')
+    edited = original.replace(
+        '"description": "A session-tier test plan."', '"description": "edited"'
+    )
     assert edited != original
     path.write_text(edited)
 
@@ -223,14 +225,14 @@ def test_promote_succeeds_once_the_session_plan_is_validated(
     assert resp.json()["status"] == "running"
 
 
-def test_promote_reblocks_after_a_post_validation_edit(
-    tmp_path: Path, client: TestClient
-) -> None:
+def test_promote_reblocks_after_a_post_validation_edit(tmp_path: Path, client: TestClient) -> None:
     original = _session_plan_source("http_edited")
     path = _write_session_plan(tmp_path, "http_edited", original)
     validation_records.record(hash_plan_body(original))
 
-    edited = original.replace('"description": "A session-tier test plan."', '"description": "edited"')
+    edited = original.replace(
+        '"description": "A session-tier test plan."', '"description": "edited"'
+    )
     path.write_text(edited)
 
     run_id = _create_run(client, "http_edited")

--- a/tests/services/bluesky_bridge/test_promote_validation_gate.py
+++ b/tests/services/bluesky_bridge/test_promote_validation_gate.py
@@ -1,0 +1,359 @@
+"""Coverage for the promote-time session-plan validation gate (task 2.5).
+
+Two parts, per the task split:
+
+- **Part A**: `app.py`'s `_epics_scanner_factory` now resolves plan names
+  through the gated registry (``plans=None`` -> `BlueskyScanner.reinitialize`
+  falls back to `_default_plan_registry()`, which merges built-ins with the
+  re-scanned, re-gated `get_facility_plans().plans`) instead of a fixed
+  `BUILTIN_PLANS` snapshot — so a validated session/facility plan is
+  launchable on the connector-mediated path, and an unvalidated one is not.
+- **Part B**: `app.py`'s `_promote_validation_gate`, dependency-injected into
+  `runs.do_promote` as its `validator` keyword, 409s a promote attempt for a
+  session/unreviewed plan whose CURRENT on-disk content hash has no passing
+  record in `validation_record.validation_records` — defense-in-depth
+  alongside task 2.4's session-layer LOAD gate, re-hashing fresh at promote
+  time rather than trusting an earlier snapshot.
+
+All Part B plan files here are pure pydantic/stdlib (no bluesky import),
+matching `test_session_load_gate.py`'s bluesky-less lane; `FakeScanner` is
+used throughout so these tests never need bluesky either — the gate runs
+entirely before any scanner is built.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from osprey.services.bluesky_bridge import app as app_module
+from osprey.services.bluesky_bridge import plan_loader
+from osprey.services.bluesky_bridge.app import app, set_scanner_factory
+from osprey.services.bluesky_bridge.plan_validation import hash_plan_body
+from osprey.services.bluesky_bridge.runs import Run, do_promote, registry
+from osprey.services.bluesky_bridge.scanner import FakeScanner
+from osprey.services.bluesky_bridge.validation_record import validation_records
+
+_SESSION_PLAN_DIR_ENV = "BLUESKY_SESSION_PLAN_DIR"
+_PLAN_DIRS_ENV = "BLUESKY_PLAN_DIRS"
+_PLAN_MODULE_ENV = "BLUESKY_PLAN_MODULE"
+_PROMOTE_TOKEN_ENV = "BLUESKY_PROMOTE_TOKEN"
+_TOKEN = "s3cr3t"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A fresh session-plan directory, loader cache, validation-record store,
+    run registry, and scanner factory for every test — every one of these is
+    a process-wide singleton in the real bridge, same as `test_session_load_gate.py`.
+    """
+    monkeypatch.delenv(_PLAN_DIRS_ENV, raising=False)
+    monkeypatch.delenv(_PLAN_MODULE_ENV, raising=False)
+    monkeypatch.setenv(_SESSION_PLAN_DIR_ENV, str(tmp_path / "plans_session"))
+    plan_loader.reset_facility_plans()
+
+    with validation_records.lock:
+        saved_hashes = set(validation_records._passing_hashes)
+        validation_records._passing_hashes.clear()
+
+    registry._runs.clear()
+    set_scanner_factory(FakeScanner)
+
+    yield
+
+    plan_loader.reset_facility_plans()
+    with validation_records.lock:
+        validation_records._passing_hashes.clear()
+        validation_records._passing_hashes.update(saved_hashes)
+    registry._runs.clear()
+    set_scanner_factory(FakeScanner)
+
+
+def _session_plan_source(name: str) -> str:
+    """A minimal, bluesky-free session-tier plan file satisfying the load contract."""
+    return (
+        "PLAN_METADATA = {\n"
+        f'    "name": {name!r},\n'
+        '    "description": "A session-tier test plan.",\n'
+        '    "category": "accelerator",\n'
+        '    "required_devices": [],\n'
+        '    "writes": False,\n'
+        "}\n\n\n"
+        "def build_plan(devices, params):\n"
+        f'    return {{"plan": {name!r}}}\n'
+    )
+
+
+def _write_session_plan(tmp_path: Path, name: str, source: str) -> Path:
+    session_dir = tmp_path / "plans_session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    path = session_dir / f"{name}.py"
+    path.write_text(source)
+    return path
+
+
+# =========================================================================
+# Part B: `_promote_validation_gate` unit coverage
+# =========================================================================
+
+
+def _run_for(plan_name: str) -> Run:
+    return registry.add(request={"plan_name": plan_name, "plan_args": {}})
+
+
+def test_gate_blocks_a_session_plan_with_no_passing_record(tmp_path: Path) -> None:
+    source = _session_plan_source("unvalidated_plan")
+    _write_session_plan(tmp_path, "unvalidated_plan", source)
+    # Deliberately not recording a passing validation for this content hash.
+
+    run = _run_for("unvalidated_plan")
+
+    with pytest.raises(HTTPException) as excinfo:
+        app_module._promote_validation_gate(run)
+    assert excinfo.value.status_code == 409
+    assert "unvalidated_plan" in excinfo.value.detail
+    assert "no passing validation record" in excinfo.value.detail
+
+
+def test_gate_allows_a_session_plan_once_validated(tmp_path: Path) -> None:
+    source = _session_plan_source("validated_plan")
+    _write_session_plan(tmp_path, "validated_plan", source)
+    validation_records.record(hash_plan_body(source))
+
+    run = _run_for("validated_plan")
+
+    assert app_module._promote_validation_gate(run) is None
+
+
+def test_gate_reblocks_after_the_session_file_is_edited(tmp_path: Path) -> None:
+    """A post-validation edit changes the content hash: the fresh re-hash at
+    promote catches it even though the file still exists under the same name.
+    """
+    original = _session_plan_source("edited_plan")
+    path = _write_session_plan(tmp_path, "edited_plan", original)
+    validation_records.record(hash_plan_body(original))
+
+    # Passes right after validation.
+    assert app_module._promote_validation_gate(_run_for("edited_plan")) is None
+
+    # Edit the file (still a well-formed plan, just different content) without
+    # re-validating it.
+    edited = original.replace('"description": "A session-tier test plan."', '"description": "edited"')
+    assert edited != original
+    path.write_text(edited)
+
+    with pytest.raises(HTTPException) as excinfo:
+        app_module._promote_validation_gate(_run_for("edited_plan"))
+    assert excinfo.value.status_code == 409
+
+
+def test_gate_ignores_a_non_session_plan(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A shipped-tier plan (no validation record, never gated) is unaffected."""
+    shipped_dir = tmp_path / "shipped"
+    shipped_dir.mkdir()
+    (shipped_dir / "startup_plan.py").write_text(_session_plan_source("startup_plan"))
+    monkeypatch.setattr(plan_loader, "_SHIPPED_PLANS_DIR", shipped_dir)
+
+    facility = plan_loader.get_facility_plans()
+    assert facility.plans["startup_plan"].provenance == "shipped"
+
+    run = _run_for("startup_plan")
+    assert app_module._promote_validation_gate(run) is None
+
+
+def test_gate_ignores_a_plan_name_with_no_session_file_and_no_registration() -> None:
+    """A genuinely unknown plan name is left to `Scanner.reinitialize`'s own
+    "unknown plan" handling — the gate never 409s for it."""
+    run = _run_for("nonexistent_plan")
+    assert app_module._promote_validation_gate(run) is None
+
+
+def test_gate_ignores_a_run_with_no_plan_name() -> None:
+    run = registry.add(request={})
+    assert app_module._promote_validation_gate(run) is None
+
+
+# =========================================================================
+# Part B: end-to-end through `POST /runs/{id}/promote`
+# =========================================================================
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv(_PROMOTE_TOKEN_ENV, _TOKEN)
+    return TestClient(app)
+
+
+def _create_run(client: TestClient, plan_name: str) -> str:
+    resp = client.post("/runs", json={"plan_name": plan_name, "plan_args": {}})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+def _promote(client: TestClient, run_id: str):
+    return client.post(f"/runs/{run_id}/promote", headers={"X-Promote-Token": _TOKEN})
+
+
+def test_promote_409s_an_unvalidated_session_plan(tmp_path: Path, client: TestClient) -> None:
+    source = _session_plan_source("http_unvalidated")
+    _write_session_plan(tmp_path, "http_unvalidated", source)
+
+    run_id = _create_run(client, "http_unvalidated")
+    resp = _promote(client, run_id)
+
+    assert resp.status_code == 409
+    assert "no passing validation record" in resp.json()["detail"]
+    assert client.get(f"/runs/{run_id}").json()["status"] == "intent"
+
+
+def test_promote_succeeds_once_the_session_plan_is_validated(
+    tmp_path: Path, client: TestClient
+) -> None:
+    source = _session_plan_source("http_validated")
+    _write_session_plan(tmp_path, "http_validated", source)
+    validation_records.record(hash_plan_body(source))
+
+    run_id = _create_run(client, "http_validated")
+    resp = _promote(client, run_id)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "running"
+
+
+def test_promote_reblocks_after_a_post_validation_edit(
+    tmp_path: Path, client: TestClient
+) -> None:
+    original = _session_plan_source("http_edited")
+    path = _write_session_plan(tmp_path, "http_edited", original)
+    validation_records.record(hash_plan_body(original))
+
+    edited = original.replace('"description": "A session-tier test plan."', '"description": "edited"')
+    path.write_text(edited)
+
+    run_id = _create_run(client, "http_edited")
+    resp = _promote(client, run_id)
+
+    assert resp.status_code == 409
+    assert "no passing validation record" in resp.json()["detail"]
+
+
+def test_promote_of_a_shipped_plan_is_unaffected(
+    tmp_path: Path, client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    shipped_dir = tmp_path / "shipped"
+    shipped_dir.mkdir()
+    (shipped_dir / "startup_plan.py").write_text(_session_plan_source("startup_plan"))
+    monkeypatch.setattr(plan_loader, "_SHIPPED_PLANS_DIR", shipped_dir)
+
+    run_id = _create_run(client, "startup_plan")
+    resp = _promote(client, run_id)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "running"
+
+
+# =========================================================================
+# `do_promote(..., validator=None)` — the default preserves every existing
+# caller that never passes one (contract-test path unbroken).
+# =========================================================================
+
+
+def test_do_promote_without_a_validator_is_unaffected_by_the_gate(tmp_path: Path) -> None:
+    """An unvalidated session plan is only refused when a validator is wired
+    in — `runs.py` itself stays import-clean of `plan_loader`/bluesky, and
+    every pre-2.5 caller that never passes `validator` sees no new behavior.
+    """
+    source = _session_plan_source("no_validator_plan")
+    _write_session_plan(tmp_path, "no_validator_plan", source)
+
+    run = _run_for("no_validator_plan")
+    scanner = FakeScanner()
+
+    result = do_promote(run, lambda: scanner)
+
+    assert result is run
+    assert run.promoted is True
+    assert scanner.reinitialize_calls == 1
+
+
+def test_do_promote_with_validator_none_explicit_matches_default() -> None:
+    run = registry.add(request={})
+    scanner = FakeScanner()
+
+    result = do_promote(run, lambda: scanner, validator=None)
+
+    assert result is run
+    assert run.promoted is True
+
+
+# =========================================================================
+# Part A: `_epics_scanner_factory` resolves plans through the gated registry
+# =========================================================================
+
+
+@pytest.fixture
+def _clean_epics_env(monkeypatch: pytest.MonkeyPatch):
+    for var in (
+        "BLUESKY_EPICS_SUBSTRATE",
+        "BLUESKY_DEMO_SCANNER",
+        "BLUESKY_EPICS_MOTORS",
+        "BLUESKY_EPICS_DETECTORS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    app_module._connector = None
+    yield
+    app_module._connector = None
+
+
+def test_epics_scanner_factory_resolves_a_validated_session_plan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _clean_epics_env: None
+) -> None:
+    """`_epics_scanner_factory` no longer pins `plans=BUILTIN_PLANS` — a
+    validated session plan (re-gated by `_default_plan_registry()` on every
+    `reinitialize()` call) is resolvable through the connector-mediated
+    launch path, and an unvalidated one is not.
+    """
+    pytest.importorskip("bluesky")
+    pytest.importorskip("ophyd_async")
+
+    from osprey.connectors.factory import ConnectorFactory
+
+    class _SpyConnector:
+        async def disconnect(self) -> None:
+            pass
+
+    async def fake_create_control_system_connector(config):
+        return _SpyConnector()
+
+    monkeypatch.setattr(
+        ConnectorFactory, "create_control_system_connector", fake_create_control_system_connector
+    )
+    monkeypatch.setenv("BLUESKY_EPICS_SUBSTRATE", "true")
+
+    validated_source = _session_plan_source("gated_validated_plan")
+    _write_session_plan(tmp_path, "gated_validated_plan", validated_source)
+    validation_records.record(hash_plan_body(validated_source))
+
+    unvalidated_source = _session_plan_source("gated_unvalidated_plan")
+    _write_session_plan(tmp_path, "gated_unvalidated_plan", unvalidated_source)
+    # Deliberately not recording a passing validation for this one.
+
+    with TestClient(app):
+        pass
+
+    assert app_module._scanner_factory is not FakeScanner
+    scanner = app_module._scanner_factory()
+    # `plans=None` — resolution happens lazily via `_default_plan_registry()`,
+    # not a fixed built-in snapshot, on every `reinitialize()` call.
+    assert scanner._plans is None
+
+    ok = scanner.reinitialize({"plan_name": "gated_validated_plan", "plan_args": {}})
+    assert ok is True, scanner.error_message
+
+    other_scanner = app_module._scanner_factory()
+    not_ok = other_scanner.reinitialize({"plan_name": "gated_unvalidated_plan", "plan_args": {}})
+    assert not_ok is False
+    assert "unknown plan" in (other_scanner.error_message or "")

--- a/tests/services/bluesky_bridge/test_promotion.py
+++ b/tests/services/bluesky_bridge/test_promotion.py
@@ -1,0 +1,112 @@
+"""Unit tests for `promotion.py` (task 2.9): the thin glue that hands a
+validated session-tier plan off to the existing `osprey-contribute` skill for
+a promotion PR/MR.
+
+`prepare_promotion`/`stage_promotion` never open a PR themselves and never
+touch `plan_loader.py`'s trust order — these tests cover only the glue's own
+contract: refuse an unknown or unvalidated plan, and copy validated bytes
+byte-for-byte into the target catalog directory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from osprey.services.bluesky_bridge.plan_validation import hash_plan_body
+from osprey.services.bluesky_bridge.promotion import (
+    PromotionRequest,
+    UnknownSessionPlanError,
+    UnvalidatedPlanError,
+    prepare_promotion,
+    stage_promotion,
+)
+from osprey.services.bluesky_bridge.session_dir import resolve_session_plan_dir
+from osprey.services.bluesky_bridge.validation_record import validation_records
+
+_SESSION_PLAN_DIR_ENV = "BLUESKY_SESSION_PLAN_DIR"
+
+_PLAN_BODY = "PLAN_METADATA = {'name': 'orbit_bump'}\n"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_session_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Give every test its own session-plan directory and a clean validation
+    store — the module-level `validation_records` singleton is shared
+    process-wide (mirrors `test_session_load_gate.py`'s fixture)."""
+    monkeypatch.setenv(_SESSION_PLAN_DIR_ENV, str(tmp_path / "plans_session"))
+
+    with validation_records.lock:
+        saved_hashes = set(validation_records._passing_hashes)
+        validation_records._passing_hashes.clear()
+
+    yield
+
+    with validation_records.lock:
+        validation_records._passing_hashes.clear()
+        validation_records._passing_hashes.update(saved_hashes)
+
+
+def _write_session_plan(name: str, body: str = _PLAN_BODY) -> Path:
+    session_dir = resolve_session_plan_dir()
+    path = session_dir / f"{name}.py"
+    path.write_text(body)
+    return path
+
+
+def test_unknown_plan_raises(tmp_path: Path) -> None:
+    with pytest.raises(UnknownSessionPlanError):
+        prepare_promotion("nonexistent_plan", tmp_path / "catalog")
+
+
+def test_unvalidated_plan_raises(tmp_path: Path) -> None:
+    _write_session_plan("orbit_bump")
+    # No validation_records.record() call — hash was never recorded as passing.
+    with pytest.raises(UnvalidatedPlanError):
+        prepare_promotion("orbit_bump", tmp_path / "catalog")
+
+
+def test_validated_plan_prepares_request(tmp_path: Path) -> None:
+    source_path = _write_session_plan("orbit_bump")
+    validation_records.record(hash_plan_body(_PLAN_BODY))
+
+    catalog_dir = tmp_path / "catalog"
+    request = prepare_promotion("orbit_bump", catalog_dir)
+
+    assert isinstance(request, PromotionRequest)
+    assert request.name == "orbit_bump"
+    assert request.body == _PLAN_BODY
+    assert request.content_hash == hash_plan_body(_PLAN_BODY)
+    assert request.source_path == source_path
+    assert request.target_path == catalog_dir / "orbit_bump.py"
+    assert "orbit_bump" in request.suggested_branch
+    assert "orbit_bump" in request.suggested_pr_title
+    assert request.content_hash in request.suggested_pr_body
+
+
+def test_editing_after_validation_re_raises_unvalidated(tmp_path: Path) -> None:
+    """Matches the 2.4/2.5 re-check contract: an edit after validation drops
+    the hash's passing record until re-validated."""
+    _write_session_plan("orbit_bump")
+    validation_records.record(hash_plan_body(_PLAN_BODY))
+
+    # Edit the file after validation — its content hash changes.
+    _write_session_plan("orbit_bump", body=_PLAN_BODY + "# tweak\n")
+
+    with pytest.raises(UnvalidatedPlanError):
+        prepare_promotion("orbit_bump", tmp_path / "catalog")
+
+
+def test_stage_promotion_copies_bytes_identically(tmp_path: Path) -> None:
+    _write_session_plan("orbit_bump")
+    validation_records.record(hash_plan_body(_PLAN_BODY))
+
+    catalog_dir = tmp_path / "catalog" / "nested"  # doesn't exist yet
+    request = prepare_promotion("orbit_bump", catalog_dir)
+    written_path = stage_promotion(request)
+
+    assert written_path == catalog_dir / "orbit_bump.py"
+    assert written_path.read_text() == _PLAN_BODY
+    # The staged copy re-hashes identically to the session file it came from.
+    assert hash_plan_body(written_path.read_text()) == request.content_hash

--- a/tests/services/bluesky_bridge/test_session_load_gate.py
+++ b/tests/services/bluesky_bridge/test_session_load_gate.py
@@ -197,9 +197,7 @@ def test_malformed_session_file_is_quarantined_and_siblings_still_register(
 
     assert "good_session_plan" in facility.plans
     assert "missing_build_plan" not in facility.plans
-    assert any(
-        r.levelno == logging.WARNING and "quarantining" in r.message for r in caplog.records
-    )
+    assert any(r.levelno == logging.WARNING and "quarantining" in r.message for r in caplog.records)
 
 
 def test_builtins_and_shipped_exemplars_are_not_gated() -> None:

--- a/tests/services/bluesky_bridge/test_session_load_gate.py
+++ b/tests/services/bluesky_bridge/test_session_load_gate.py
@@ -1,0 +1,222 @@
+"""Coverage for the `session`-tier directory layer and its LOAD-TIME gate
+(task 2.4): `plan_loader.py`'s CF-1 core enforcement point.
+
+A `session`-tier plan file (written by task 2.3's `POST /plans/session`,
+never itself exec'd by that route) must never be `exec_module`'d, registered,
+or discoverable via `get_facility_plans()` unless its *current* on-disk
+content hash has a passing record in `validation_record.validation_records`.
+This is proven directly — not just "the plan is absent from `facility.plans`"
+but "the file's own top-level code never ran at all" — via a sentinel file
+write a gated body would perform at import time.
+
+All plan files here are pure pydantic/stdlib (no bluesky import), matching
+`test_plan_loader_layered.py`'s bluesky-less lane; the one exception (shipped
+exemplar regression) is guarded by `pytest.importorskip`.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from osprey.services.bluesky_bridge import plan_loader
+from osprey.services.bluesky_bridge.plan_validation import hash_plan_body
+from osprey.services.bluesky_bridge.validation_record import validation_records
+
+_SESSION_PLAN_DIR_ENV = "BLUESKY_SESSION_PLAN_DIR"
+_PLAN_DIRS_ENV = "BLUESKY_PLAN_DIRS"
+_PLAN_MODULE_ENV = "BLUESKY_PLAN_MODULE"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_plan_loader(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Every test gets its own session-plan directory, a clean loader cache,
+    and a clean validation-record store (the module-level singleton is shared
+    process-wide, so it must be snapshotted and restored like any other
+    global test double)."""
+    monkeypatch.delenv(_PLAN_DIRS_ENV, raising=False)
+    monkeypatch.delenv(_PLAN_MODULE_ENV, raising=False)
+    monkeypatch.setenv(_SESSION_PLAN_DIR_ENV, str(tmp_path / "plans_session"))
+    plan_loader.reset_facility_plans()
+
+    with validation_records.lock:
+        saved_hashes = set(validation_records._passing_hashes)
+        validation_records._passing_hashes.clear()
+
+    yield
+
+    plan_loader.reset_facility_plans()
+    with validation_records.lock:
+        validation_records._passing_hashes.clear()
+        validation_records._passing_hashes.update(saved_hashes)
+
+
+def _sentinel_plan_source(name: str, sentinel_path: Path) -> str:
+    """A session-tier plan file whose top-level code writes ``sentinel_path``
+    on import, so a test can assert the file was (or was never) `exec_module`'d
+    without relying solely on absence from the resolved plan set."""
+    return (
+        "from pathlib import Path\n\n\n"
+        f"Path({str(sentinel_path)!r}).write_text('executed')\n\n\n"
+        "PLAN_METADATA = {\n"
+        f'    "name": {name!r},\n'
+        '    "description": "A session-tier test plan.",\n'
+        '    "category": "accelerator",\n'
+        '    "required_devices": [],\n'
+        '    "writes": False,\n'
+        "}\n\n\n"
+        "def build_plan(devices, params):\n"
+        f'    return {{"plan": {name!r}}}\n'
+    )
+
+
+def _write_session_plan(tmp_path: Path, filename: str, source: str) -> Path:
+    session_dir = tmp_path / "plans_session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    path = session_dir / filename
+    path.write_text(source)
+    return path
+
+
+def test_unvalidated_session_file_is_never_exec_moduled_or_discovered(
+    tmp_path: Path,
+) -> None:
+    sentinel_path = tmp_path / "sentinel_unvalidated.txt"
+    source = _sentinel_plan_source("unvalidated_plan", sentinel_path)
+    _write_session_plan(tmp_path, "unvalidated_plan.py", source)
+    # Deliberately NOT recording a passing validation for this content hash.
+
+    facility = plan_loader.get_facility_plans()
+
+    assert not sentinel_path.exists(), "the gated file's top-level code ran"
+    assert "unvalidated_plan" not in facility.plans
+
+
+def test_same_file_once_hash_is_recorded_loads_and_registers_as_session(
+    tmp_path: Path,
+) -> None:
+    sentinel_path = tmp_path / "sentinel_validated.txt"
+    source = _sentinel_plan_source("validated_plan", sentinel_path)
+    _write_session_plan(tmp_path, "validated_plan.py", source)
+    validation_records.record(hash_plan_body(source))
+
+    facility = plan_loader.get_facility_plans()
+
+    assert sentinel_path.exists(), "a validated file's top-level code never ran"
+    assert "validated_plan" in facility.plans
+    assert facility.plans["validated_plan"].provenance == "session"
+
+
+def test_session_layer_rescans_on_write_without_reset(tmp_path: Path) -> None:
+    """A session plan written and validated *after* the first
+    `get_facility_plans()` call must appear on the next call with no
+    `reset_facility_plans()` in between — the live-authoring contract."""
+    first = plan_loader.get_facility_plans()
+    assert "new_session_plan" not in first.plans
+
+    source = _sentinel_plan_source("new_session_plan", tmp_path / "unused_sentinel.txt")
+    _write_session_plan(tmp_path, "new_session_plan.py", source)
+    validation_records.record(hash_plan_body(source))
+
+    second = plan_loader.get_facility_plans()
+    assert "new_session_plan" in second.plans
+    assert second.plans["new_session_plan"].provenance == "session"
+
+
+def test_startup_layers_stay_cached_across_session_rescans(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The expensive startup layers (shipped/preset/facility, plus legacy
+    device construction) are built once, not re-scanned on every
+    `get_facility_plans()` call — only the session layer is live."""
+    shipped_dir = tmp_path / "shipped"
+    shipped_dir.mkdir()
+    (shipped_dir / "startup_plan.py").write_text(
+        "PLAN_METADATA = {\n"
+        '    "name": "startup_plan",\n'
+        '    "description": "A startup-tier plan.",\n'
+        '    "category": "accelerator",\n'
+        '    "required_devices": [],\n'
+        '    "writes": False,\n'
+        "}\n\n\n"
+        "def build_plan(devices, params):\n"
+        '    return {"plan": "startup_plan"}\n'
+    )
+    monkeypatch.setattr(plan_loader, "_SHIPPED_PLANS_DIR", shipped_dir)
+
+    first = plan_loader.get_facility_plans()
+    assert "startup_plan" in first.plans
+    startup_layers_after_first_call = plan_loader._startup_layers
+    assert startup_layers_after_first_call is not None
+
+    # Write and validate a session plan, forcing a fresh session-layer scan.
+    source = _sentinel_plan_source("another_session_plan", tmp_path / "unused.txt")
+    _write_session_plan(tmp_path, "another_session_plan.py", source)
+    validation_records.record(hash_plan_body(source))
+
+    second = plan_loader.get_facility_plans()
+    assert "startup_plan" in second.plans
+    assert "another_session_plan" in second.plans
+    # The startup registry object itself was never rebuilt.
+    assert plan_loader._startup_layers is startup_layers_after_first_call
+
+
+def test_malformed_session_file_is_quarantined_and_siblings_still_register(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """One malformed session file must never break discovery of its siblings,
+    regardless of *which* failure path it hits: a validated-but-structurally-
+    broken file (missing `build_plan`) still exec's (it passed the gate) but
+    is quarantined by the existing `except (Exception, SystemExit)` path; an
+    unvalidated file never even reaches that far — it is skipped by the gate
+    itself (see `test_unvalidated_session_file_is_never_exec_moduled_or_discovered`).
+    Both must leave a well-formed, validated sibling plan registered."""
+    good_source = _sentinel_plan_source("good_session_plan", tmp_path / "good_sentinel.txt")
+    _write_session_plan(tmp_path, "good_session_plan.py", good_source)
+    validation_records.record(hash_plan_body(good_source))
+
+    # Syntactically valid, PLAN_METADATA present, but no `build_plan` — and
+    # its hash IS recorded, so this exercises the post-gate quarantine path
+    # (not the gate itself).
+    missing_build_plan_source = (
+        "PLAN_METADATA = {\n"
+        '    "name": "missing_build_plan",\n'
+        '    "description": "d",\n'
+        '    "category": "accelerator",\n'
+        '    "required_devices": [],\n'
+        '    "writes": False,\n'
+        "}\n"
+    )
+    _write_session_plan(tmp_path, "missing_build_plan.py", missing_build_plan_source)
+    validation_records.record(hash_plan_body(missing_build_plan_source))
+
+    with caplog.at_level(logging.WARNING, logger="osprey.services.bluesky_bridge.plan_loader"):
+        facility = plan_loader.get_facility_plans()
+
+    assert "good_session_plan" in facility.plans
+    assert "missing_build_plan" not in facility.plans
+    assert any(
+        r.levelno == logging.WARNING and "quarantining" in r.message for r in caplog.records
+    )
+
+
+def test_builtins_and_shipped_exemplars_are_not_gated() -> None:
+    """Regression: built-ins (count/scan/grid_scan/orm) carry no validation
+    record and are registered through a wholly separate path (`plans.py`'s
+    `BUILTIN_PLANS`, merged in `app.py`/`scanner_bluesky.py`, never through
+    this loader's registry) — the session gate must never touch them. The
+    shipped exemplars in `plans_core/` are `provenance="shipped"`, not
+    `session`/`unreviewed`, so they load unconditionally too."""
+    pytest.importorskip("bluesky")
+    from osprey.services.bluesky_bridge.plans import BUILTIN_PLANS
+
+    assert BUILTIN_PLANS
+    assert all(spec.provenance == "shipped" for spec in BUILTIN_PLANS.values())
+
+    facility = plan_loader.get_facility_plans()
+    assert "response_matrix" in facility.plans
+    assert "grid_scan_nd" in facility.plans
+    assert facility.plans["response_matrix"].provenance == "shipped"
+    assert facility.plans["grid_scan_nd"].provenance == "shipped"

--- a/tests/services/bluesky_bridge/test_validation_record.py
+++ b/tests/services/bluesky_bridge/test_validation_record.py
@@ -1,0 +1,83 @@
+"""Unit tests for `validation_record.py` (task 2.2): the content-hash-keyed
+store of PASSING plan-validation records that task 2.4's session-layer load
+gate and task 2.5's promote gate query after re-hashing a file's on-disk
+content.
+
+Each test builds its own `ValidationRecordStore` rather than reaching for the
+module-level `validation_records` singleton, so tests never leak state into
+each other (or into whatever else imports the singleton within the same
+process).
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+from osprey.services.bluesky_bridge.plan_validation import hash_plan_body
+from osprey.services.bluesky_bridge.validation_record import (
+    ValidationRecordStore,
+    validation_records,
+)
+
+
+def test_singleton_is_reachable_and_starts_empty() -> None:
+    # The bridge-process singleton other tasks (2.3/2.4/2.5) import.
+    assert isinstance(validation_records, ValidationRecordStore)
+
+
+def test_unknown_hash_returns_false() -> None:
+    store = ValidationRecordStore()
+    assert store.has_passing_record("deadbeef") is False
+
+
+def test_record_then_query_returns_true() -> None:
+    store = ValidationRecordStore()
+    store.record("abc123")
+    assert store.has_passing_record("abc123") is True
+
+
+def test_a_hash_that_was_never_recorded_stays_false() -> None:
+    """No "record a failure" API exists — a failed validation records
+    nothing, so a hash that only ever failed is indistinguishable from one
+    that was never validated at all: both read as `False`.
+    """
+    store = ValidationRecordStore()
+    store.record("some-other-hash")
+    assert store.has_passing_record("never-recorded-hash") is False
+
+
+def test_recording_the_same_hash_twice_is_a_harmless_noop() -> None:
+    store = ValidationRecordStore()
+    store.record("abc123")
+    store.record("abc123")
+    assert store.has_passing_record("abc123") is True
+
+
+def test_round_trip_through_hash_plan_body() -> None:
+    """Ties the store to the shared `hash_plan_body` normalization: a record
+    made against one hashing of a body's content is found by a later re-hash
+    of the same content, byte for byte — the exact contract 2.4/2.5 rely on.
+    """
+    body = "PLAN_METADATA = {'name': 'tiny'}\n"
+    store = ValidationRecordStore()
+
+    content_hash = hash_plan_body(body)
+    store.record(content_hash)
+
+    # A later caller (e.g. the load gate) re-hashes the file's current
+    # on-disk content independently and must still find the same record.
+    assert store.has_passing_record(hash_plan_body(body)) is True
+
+
+def test_concurrent_record_and_query_is_thread_safe() -> None:
+    store = ValidationRecordStore()
+    hashes = [f"hash-{i}" for i in range(200)]
+
+    def _record(content_hash: str) -> None:
+        store.record(content_hash)
+
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        list(pool.map(_record, hashes))
+
+    assert all(store.has_passing_record(h) for h in hashes)
+    assert store.has_passing_record("not-one-of-them") is False


### PR DESCRIPTION
## Summary

Adds an authoring path for session-tier Bluesky scan plans, gated by a static validation sandbox so an operator can write, validate, launch, and promote a plan without any untrusted code reaching Channel Access.

## What's included

- **Validation sandbox + records** — a static AST/pattern validator screens session-authored plans; each verdict is persisted as a validation record.
- **Session lifecycle** — plans are authored to a per-session directory, loaded only behind a passing validation record, and promoted to the permanent layer only after a promote-validation gate.
- **Scan MCP tools** — write/validate tools expose authoring through the scan server.
- **Launch approvals** — approval prompts surface plan metadata, provenance, and validation status.
- **writing-bluesky-plans skill** — guides an operator through authoring a valid plan.
- **control-assistant preset** — enables the authoring path.

## Safety model

Session plans cannot load or launch without a passing validation record, and promotion is gated the same way. A `from __future__` import in a session body (which can never be the file's first statement once plan metadata is prepended) is rejected up front with an actionable message rather than surfacing as a cryptic `SyntaxError`.

## Testing

- Unit/service: bridge, scan-tools, registry, and approval-hook surfaces pass.
- Real-container e2e: the full author → validate → launch → read path runs against a live Virtual Accelerator. An escape plan (`import epics; epics.caput(...)`) is refused end-to-end — absent from plan discovery, promotion returns 409, and an out-of-band Channel Access read confirms the corrector setpoint is unchanged. Wired as an advisory CI job.
