### PR TITLE
ci: add manual openobserve ghcr mirror workflow

### DIFF
--- a/.github/workflows/mirror-openobserve.yml
+++ b/.github/workflows/mirror-openobserve.yml
@@ -1,0 +1,76 @@
+name: Mirror openobserve to ghcr
+
+# Manual only. The image tag is PINNED in
+# src/osprey/templates/services/openobserve/docker-compose.yml.j2, so there is
+# nothing for a cron schedule to catch -- it would re-push identical bytes
+# forever. Run this by hand when that pin moves.
+#
+# Why this mirror exists: ECR Public rate-limits anonymous pulls per source IP
+# and GitHub-hosted runners share egress IPs, so E2E jobs intermittently fail
+# with "toomanyrequests: Rate exceeded" pulling openobserve. ghcr has no
+# anonymous pull-rate limit.
+#
+# The mirrored image is AGPL-3.0 (github.com/openobserve/openobserve). The
+# package is PRIVATE -- internal use, which AGPL does not restrict. Making it
+# public would be redistribution and would oblige us to provide corresponding
+# source. Do not flip visibility without reading the design doc.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'openobserve tag to mirror (must match the pin in the openobserve compose template)'
+        required: true
+        default: 'v0.14.4'
+
+jobs:
+  mirror:
+    name: Copy openobserve ${{ inputs.tag }} to ghcr
+    runs-on: ubuntu-latest
+    # packages: write is NOT in the repo's read-only default token, so it must
+    # be granted explicitly. contents: read is restated because a job-level
+    # permissions block REPLACES the default rather than extending it.
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Log in to ghcr
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Copy image registry-to-registry
+      # imagetools copies the manifest LIST server-side. Do not replace this
+      # with docker pull/tag/push: that resolves to the runner's single
+      # architecture and would silently publish an amd64-only image under a
+      # multi-arch tag.
+      run: |
+        docker buildx imagetools create \
+          --tag ghcr.io/als-apg/openobserve:${{ inputs.tag }} \
+          public.ecr.aws/zinclabs/openobserve:${{ inputs.tag }}
+
+    - name: Verify the copy is verbatim
+      # Digest equality proves a byte-for-byte copy. This is a licensing
+      # requirement (AGPL verbatim redistribution), not only a sanity check.
+      # Note: GitHub Actions only interpolates ${{ ... }}. A bare {{ ... }} Go
+      # template passes through untouched, so it needs no escaping here.
+      run: |
+        UPSTREAM=$(docker buildx imagetools inspect \
+          public.ecr.aws/zinclabs/openobserve:${{ inputs.tag }} \
+          --format '{{.Manifest.Digest}}')
+        MIRROR=$(docker buildx imagetools inspect \
+          ghcr.io/als-apg/openobserve:${{ inputs.tag }} \
+          --format '{{.Manifest.Digest}}')
+        echo "upstream: $UPSTREAM"
+        echo "mirror:   $MIRROR"
+        if [ "$UPSTREAM" != "$MIRROR" ]; then
+          echo "::error::Digest mismatch - mirror is NOT a verbatim copy"
+          exit 1
+        fi
+        echo "Digests match."


### PR DESCRIPTION
First of two PRs. **This one is inert** — it adds a `workflow_dispatch`-only workflow that nothing triggers and nothing references. No existing CI behavior changes.

## Why

E2E jobs intermittently fail pulling `public.ecr.aws/zinclabs/openobserve:v0.14.4`:

```
openobserve Error toomanyrequests: Rate exceeded
postgresql  Interrupted
tiled       Interrupted
```

ECR Public rate-limits anonymous pulls per source IP, and GitHub-hosted runners share egress IPs — so we compete with every other Actions user. Observed in runs 29354050172 (Jul 14) and 29445303316 (Jul 15).

Two things this is **not**:

- **Not tiled.** `tiled` is already `ghcr.io/bluesky/tiled:0.2.12` and has never rate-limited — it appears only as `Interrupted`, which is Compose aborting sibling pulls when openobserve's fails. The job *name* ("Tiled Roundtrip E2E") misleads; the failing *image* inside it is openobserve.
- **Not Docker Hub.** `toomanyrequests: Rate exceeded` is ECR Public's wording; Docker Hub's is `You have reached your pull rate limit`. A Docker Hub login would authenticate to the wrong registry and fix nothing.

## What this adds

A manual workflow that copies the pinned tag into `ghcr.io/als-apg/openobserve` (private) using `docker buildx imagetools create` — a registry-to-registry manifest-list copy, not `pull`/`tag`/`push`, which would silently flatten the image to the runner's single architecture.

It then verifies upstream and mirror digests match. That check is a licensing requirement, not just a sanity check: the image is AGPL-3.0, and a private verbatim mirror is internal use, which AGPL does not restrict.

`workflow_dispatch` only — the tag is pinned, so a cron schedule would re-push identical bytes forever and could never catch a change. Re-run it by hand when the pin moves.

## Why this is split from the CI change

`workflow_dispatch` only works once the workflow file is on the default branch, so the mirror cannot run until this merges. The follow-up PR points the nine deploying E2E jobs at the mirror — and only after the package is published and proven pullable, since a misconfigured package would fail all nine jobs at once, which is worse than the intermittent flake.

The shipped template default is untouched: downstream OSPREY deployments keep pulling upstream, so als-apg takes on no AGPL redistribution role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)