### PR TITLE
feat(mcp): add provenance_locator workspace tool with OSPREY-owned session id

### DIFF
--- a/src/osprey/interfaces/web_terminal/operator_session.py
+++ b/src/osprey/interfaces/web_terminal/operator_session.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -204,11 +206,24 @@ class OperatorSession:
         for warning in validate_project_directory(self._cwd):
             logger.warning("Operator session: %s (cwd=%s)", warning, self._cwd)
 
+        # Force a known session UUID and hand it to the workspace
+        # provenance_locator tool via env, so a filed issue can point back to
+        # this session's telemetry. The same value is forced onto the SDK
+        # session (session_id below) so the OTEL emitter's session.id matches
+        # what the locator returns. env is a build_clean_env dict in production
+        # (which strips the harness's own CLAUDE_CODE_* id); inject into a copy.
+        telemetry_session_id = str(uuid.uuid4())
+        session_env = dict(self._env) if self._env is not None else None
+        if session_env is not None:
+            session_env["OSPREY_TELEMETRY_SESSION_ID"] = telemetry_session_id
+            session_env["OSPREY_TELEMETRY_SESSION_START"] = datetime.now(UTC).isoformat()
+
         options = ClaudeAgentOptions(
             system_prompt=build_system_prompt(get_facility_timezone()),
             cwd=self._cwd,
-            env=self._env,
+            env=session_env,
             setting_sources=["project"],
+            session_id=telemetry_session_id,
         )
         self._client = ClaudeSDKClient(options=options)
         await self._client.__aenter__()

--- a/src/osprey/interfaces/web_terminal/routes/websocket.py
+++ b/src/osprey/interfaces/web_terminal/routes/websocket.py
@@ -7,6 +7,7 @@ import json
 import logging
 import re
 import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 
 import yaml
@@ -80,11 +81,23 @@ async def _discover_and_notify(
 def _build_extra_env(
     websocket: WebSocket,
     claude_session_id: str | None,
+    telemetry_session_id: str | None = None,
 ) -> dict[str, str]:
-    """Build the extra environment dict for PTY sessions."""
+    """Build the extra environment dict for PTY sessions.
+
+    ``telemetry_session_id`` is the session UUID this terminal's ``claude`` is
+    forced onto (via ``--session-id``); it is handed to the workspace
+    provenance_locator tool so a filed issue can point back to this session's
+    telemetry. Kept separate from ``claude_session_id`` — which drives
+    ``OSPREY_SESSION_ID`` (artifact-store relocation) and stays unset for new
+    sessions — because the telemetry locator must NOT relocate the artifact store.
+    """
     extra_env: dict[str, str] = {}
     if claude_session_id:
         extra_env["OSPREY_SESSION_ID"] = claude_session_id
+    if telemetry_session_id:
+        extra_env["OSPREY_TELEMETRY_SESSION_ID"] = telemetry_session_id
+        extra_env["OSPREY_TELEMETRY_SESSION_START"] = datetime.now(UTC).isoformat()
     hooks_env = getattr(websocket.app.state, "hooks_env", {})
     if hooks_env:
         extra_env.update(hooks_env)
@@ -123,8 +136,17 @@ async def terminal_ws(websocket: WebSocket):
     if mode == "resume" and req_session_id:
         command: list[str] = [*base_shell_command, "--resume", req_session_id]
         claude_session_id: str | None = req_session_id
+        telemetry_session_id: str = req_session_id
     else:
-        command = [*base_shell_command]
+        # Force a known session UUID so the workspace provenance_locator tool can
+        # hand it back (via OSPREY_TELEMETRY_SESSION_ID, injected below) and it
+        # matches the value the OTEL emitter tags records with as session.id — a
+        # filed issue's provenance pointer then resolves. Leave claude_session_id
+        # None so the new-session snapshot/discovery path is unchanged: discovery
+        # simply finds the id we forced. (Not claude_session_id, which would set
+        # OSPREY_SESSION_ID and relocate the artifact store.)
+        telemetry_session_id = str(uuid.uuid4())
+        command = [*base_shell_command, "--session-id", telemetry_session_id]
         claude_session_id = None
 
     if effort:
@@ -153,7 +175,7 @@ async def terminal_ws(websocket: WebSocket):
     if claude_session_id is None:
         snapshot = discovery.snapshot_session_ids()
 
-    extra_env = _build_extra_env(websocket, claude_session_id)
+    extra_env = _build_extra_env(websocket, claude_session_id, telemetry_session_id)
 
     session, was_reused = registry.get_or_create_session(
         current_key,

--- a/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
+++ b/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
@@ -10,7 +10,9 @@ import asyncio
 import logging
 import os
 import time
+import uuid
 from collections.abc import Iterable
+from datetime import UTC, datetime
 from typing import Any
 
 logger = logging.getLogger("osprey.mcp_server.dispatch_worker.sdk_runner")
@@ -137,6 +139,10 @@ async def run_dispatch(
             duration_sec: wall-clock seconds
             cost_usd: API cost (from ResultMessage, if available)
             num_turns: agentic turn count (from ResultMessage, if available)
+            session_id: the forced telemetry session UUID for this run — the
+                value the OTEL emitter tags records with as session.id, so a
+                consumer can locate this run's full provenance in the telemetry
+                store (None if the SDK was unavailable and no run started).
     """
     if not HAS_SDK:
         return {
@@ -147,6 +153,7 @@ async def run_dispatch(
             "duration_sec": 0.0,
             "cost_usd": None,
             "num_turns": None,
+            "session_id": None,
         }
 
     project_dir = os.environ.get("OSPREY_PROJECT_DIR", _DEFAULT_PROJECT_DIR)
@@ -196,6 +203,18 @@ async def run_dispatch(
     if run_id:
         sdk_env["OSPREY_DISPATCH_RUN_ID"] = run_id
 
+    # Force a known session UUID for THIS run and hand it to the workspace
+    # provenance_locator tool via env, so a filed issue can point back to this
+    # run's telemetry. build_clean_env() strips CLAUDE_CODE_* (so the harness's
+    # own session id never reaches the MCP subprocess headless); instead OSPREY
+    # owns the id: the same value is forced onto the SDK session below
+    # (ClaudeAgentOptions.session_id) so the OTEL emitter tags records with it,
+    # making the returned locator resolve. Race-free — fixed per run at spawn,
+    # never a shared-directory mtime pick.
+    telemetry_session_id = str(uuid.uuid4())
+    sdk_env["OSPREY_TELEMETRY_SESSION_ID"] = telemetry_session_id
+    sdk_env["OSPREY_TELEMETRY_SESSION_START"] = datetime.now(UTC).isoformat()
+
     # Declared subagent tool surfaces from the provisioned .claude/agents/ —
     # each subagent is held to exactly its declared tools (web-terminal parity)
     # without the trigger having to enumerate them.
@@ -242,6 +261,9 @@ async def run_dispatch(
         max_turns=max_turns,
         stderr=lambda line: stderr_lines.append(line),
         setting_sources=["project"],
+        # Force the session id = the value injected above so the OTEL emitter's
+        # session.id matches what provenance_locator returns for this run.
+        session_id=telemetry_session_id,
     )
 
     text_parts: list[str] = []
@@ -312,6 +334,7 @@ async def run_dispatch(
                         "duration_sec": round(duration_sec, 2),
                         "cost_usd": cost_usd,
                         "num_turns": num_turns,
+                        "session_id": telemetry_session_id,
                     }
                 )
 
@@ -397,6 +420,7 @@ async def run_dispatch(
                 "duration_sec": round(duration_sec, 2),
                 "cost_usd": cost_usd,
                 "num_turns": num_turns,
+                "session_id": telemetry_session_id,
             }
         )
 
@@ -429,5 +453,6 @@ async def run_dispatch(
                 "duration_sec": round(duration_sec, 2),
                 "cost_usd": cost_usd,
                 "num_turns": num_turns,
+                "session_id": telemetry_session_id,
             }
         )

--- a/src/osprey/mcp_server/workspace/server.py
+++ b/src/osprey/mcp_server/workspace/server.py
@@ -51,6 +51,7 @@ def create_server() -> FastMCP:
             focus_tools,
             lattice_tools,
             panel_tools,
+            provenance_locator,
             screen_capture,
             session_log,
             session_summary,

--- a/src/osprey/mcp_server/workspace/tools/provenance_locator.py
+++ b/src/osprey/mcp_server/workspace/tools/provenance_locator.py
@@ -1,0 +1,144 @@
+"""MCP tool: provenance_locator.
+
+Returns generic telemetry *coordinates* for the current agent session — a
+pointer a consumer can render into a filed issue so a maintainer can retrieve
+the turn's full provenance from the OTEL store (tool calls, subagents,
+model/tokens/cost, user prompts). The telemetry store is the harness-agnostic
+source of provenance truth; this tool is the seam that hands out the locator so
+consumers never scrape harness-specific environment themselves.
+
+Design (harness-agnostic seam):
+    * ``session_id`` is OSPREY-owned. OSPREY forces a known session UUID at
+      launch and injects it as ``OSPREY_TELEMETRY_SESSION_ID`` into the MCP
+      subprocess env; this tool reads that. It falls back to the harness's own
+      ``CLAUDE_CODE_SESSION_ID`` when OSPREY did not force one (e.g. an
+      interactive surface that exports it to child processes).
+    * The id returned is exactly the value the OTEL emitter tags records with as
+      ``session.id`` — forcing guarantees they match, so the locator resolves.
+
+Contract:
+    * Returns JSON ``{session_id, service_name, org, stream, since, emitted_at}``.
+    * ``emitted_at`` is stamped server-side at call time (never agent-guessed).
+    * Never raises. When no id resolves, or telemetry is disabled/degraded for
+      this run (so any id would resolve to nothing), returns ``session_id: null``
+      with a ``note`` — honest "unavailable" rather than a dangling pointer.
+    * Facility-agnostic: no facility strings. The "how to pull it" recipe is
+      rendered by the consumer (e.g. als-profiles), not here.
+"""
+
+import json
+import logging
+import os
+from datetime import UTC, datetime
+
+from osprey.mcp_server.workspace.server import mcp
+
+logger = logging.getLogger("osprey.mcp_server.tools.provenance_locator")
+
+# Env var OSPREY injects at launch carrying the forced session UUID. Kept in
+# sync with the injection sites (dispatch_worker.sdk_runner, web_terminal
+# operator_session / PTY launch), which set the same name. A dedicated var —
+# NOT OSPREY_SESSION_ID, which has an unrelated side effect (it relocates the
+# artifact store).
+OSPREY_TELEMETRY_SESSION_ID_ENV = "OSPREY_TELEMETRY_SESSION_ID"
+# Optional ISO-8601 session-start OSPREY may inject to bound the lookback query.
+OSPREY_TELEMETRY_SESSION_START_ENV = "OSPREY_TELEMETRY_SESSION_START"
+
+
+def _telemetry_enabled() -> bool:
+    """Whether Claude Code OTEL export is actually on for this run.
+
+    If telemetry is off (or has no exporter endpoint), records for this session
+    never reach the store, so any ``session_id`` we hand out would resolve to
+    nothing. Gate on the same env the emitter itself consumes.
+    """
+    if os.environ.get("CLAUDE_CODE_ENABLE_TELEMETRY") != "1":
+        return False
+    return bool(os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT"))
+
+
+def _resolve_session_id() -> str | None:
+    """The OSPREY-forced id, else the harness's own, else None."""
+    return (
+        os.environ.get(OSPREY_TELEMETRY_SESSION_ID_ENV)
+        or os.environ.get("CLAUDE_CODE_SESSION_ID")
+        or None
+    )
+
+
+def _service_name() -> str:
+    """OTEL ``service.name`` from resource attributes, else the CC default."""
+    attrs = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
+    for pair in attrs.split(","):
+        key, _sep, val = pair.partition("=")
+        if key.strip() == "service.name" and val.strip():
+            return val.strip()
+    return "claude-code"
+
+
+def _org() -> str:
+    """OpenObserve org, parsed from the OTLP endpoint ``.../api/<org>``."""
+    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+    marker = "/api/"
+    if marker in endpoint:
+        tail = endpoint.split(marker, 1)[1].strip("/")
+        if tail:
+            return tail.split("/", 1)[0]
+    return "default"
+
+
+@mcp.tool()
+async def provenance_locator() -> str:
+    """Return telemetry coordinates locating this session in the OTEL store.
+
+    A consumer renders these into a filed issue so a maintainer can pull the
+    session's full provenance from telemetry (the harness-agnostic source of
+    truth) instead of trusting a reconstructed narration. No parameters.
+
+    Returns:
+        JSON ``{session_id, service_name, org, stream, since, emitted_at}``.
+        ``session_id`` is ``null`` (with a ``note``) when no id resolves or
+        telemetry is unavailable/degraded for this run. Never raises.
+    """
+    emitted_at = datetime.now(UTC).isoformat()
+    try:
+        session_id = _resolve_session_id()
+        if not _telemetry_enabled():
+            return json.dumps(
+                {
+                    "session_id": None,
+                    "emitted_at": emitted_at,
+                    "note": "telemetry unavailable for this run — no provenance locator",
+                },
+                indent=2,
+            )
+        if not session_id:
+            return json.dumps(
+                {
+                    "session_id": None,
+                    "emitted_at": emitted_at,
+                    "note": "session id could not be resolved — no provenance locator",
+                },
+                indent=2,
+            )
+        return json.dumps(
+            {
+                "session_id": session_id,
+                "service_name": _service_name(),
+                "org": _org(),
+                "stream": "default",
+                "since": os.environ.get(OSPREY_TELEMETRY_SESSION_START_ENV) or None,
+                "emitted_at": emitted_at,
+            },
+            indent=2,
+        )
+    except Exception as e:  # never raise: filing must not be blocked
+        logger.warning("provenance_locator degraded: %s", e, exc_info=True)
+        return json.dumps(
+            {
+                "session_id": None,
+                "emitted_at": emitted_at,
+                "note": f"provenance locator unavailable: {e}",
+            },
+            indent=2,
+        )

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -219,6 +219,7 @@ FRAMEWORK_SERVERS: dict[str, ServerDefinition] = {
             "artifact_save",
             "artifact_delete",
             "artifact_delete_all",
+            "provenance_locator",
             "session_log",
             "session_summary",
             "archiver_downsample",

--- a/tests/interfaces/web_terminal/test_terminal_provenance_env.py
+++ b/tests/interfaces/web_terminal/test_terminal_provenance_env.py
@@ -1,0 +1,45 @@
+"""Tests for the terminal PTY provenance-session env injection.
+
+The terminal surface forces its ``claude`` onto a known session UUID
+(``--session-id``) and injects that id as ``OSPREY_TELEMETRY_SESSION_ID`` so the
+workspace provenance_locator tool can hand it back for a filed issue. Crucially,
+the telemetry id must NOT be conflated with ``OSPREY_SESSION_ID`` (which
+relocates the artifact store) — a new terminal session gets the telemetry var
+but keeps its default artifact root.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+
+from osprey.interfaces.web_terminal.routes.websocket import _build_extra_env
+
+
+def _ws(hooks_env=None):
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(hooks_env=hooks_env or {})))
+
+
+def test_new_session_injects_telemetry_id_without_relocating_artifacts():
+    env = _build_extra_env(_ws(), claude_session_id=None, telemetry_session_id="forced-uuid")
+    assert env["OSPREY_TELEMETRY_SESSION_ID"] == "forced-uuid"
+    # start stamp is present and ISO-8601 parseable
+    datetime.fromisoformat(env["OSPREY_TELEMETRY_SESSION_START"])
+    # new session must NOT set the artifact-relocating var
+    assert "OSPREY_SESSION_ID" not in env
+
+
+def test_resume_sets_both_ids():
+    env = _build_extra_env(_ws(), claude_session_id="sid", telemetry_session_id="sid")
+    assert env["OSPREY_SESSION_ID"] == "sid"
+    assert env["OSPREY_TELEMETRY_SESSION_ID"] == "sid"
+
+
+def test_no_telemetry_id_sets_no_telemetry_vars():
+    env = _build_extra_env(_ws(), claude_session_id=None, telemetry_session_id=None)
+    assert "OSPREY_TELEMETRY_SESSION_ID" not in env
+    assert "OSPREY_TELEMETRY_SESSION_START" not in env
+
+
+def test_hooks_env_still_merged():
+    env = _build_extra_env(_ws(hooks_env={"OSPREY_HOOK_X": "1"}), None, "t")
+    assert env["OSPREY_HOOK_X"] == "1"
+    assert env["OSPREY_TELEMETRY_SESSION_ID"] == "t"

--- a/tests/mcp_server/workspace/test_provenance_locator.py
+++ b/tests/mcp_server/workspace/test_provenance_locator.py
@@ -1,0 +1,130 @@
+"""Tests for the provenance_locator MCP tool.
+
+Covers the return paths that matter for a filed issue's telemetry pointer:
+the OSPREY-forced id, the harness fallback id, their precedence, and the
+honest-degradation paths (telemetry disabled, or no id resolvable) that must
+return ``session_id: null`` with a note rather than a dangling pointer. The
+tool must never raise.
+"""
+
+import json
+from datetime import datetime
+
+import pytest
+
+from tests.mcp_server.conftest import get_tool_fn
+
+# Env vars the tool reads — cleared before each test so ambient values in the
+# runner environment cannot leak into an assertion.
+_RELEVANT_ENV = (
+    "OSPREY_TELEMETRY_SESSION_ID",
+    "OSPREY_TELEMETRY_SESSION_START",
+    "CLAUDE_CODE_SESSION_ID",
+    "CLAUDE_CODE_ENABLE_TELEMETRY",
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_RESOURCE_ATTRIBUTES",
+)
+
+
+def _fn():
+    from osprey.mcp_server.workspace.tools.provenance_locator import provenance_locator
+
+    return get_tool_fn(provenance_locator)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for name in _RELEVANT_ENV:
+        monkeypatch.delenv(name, raising=False)
+
+
+def _enable_telemetry(monkeypatch, org="default"):
+    monkeypatch.setenv("CLAUDE_CODE_ENABLE_TELEMETRY", "1")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", f"http://localhost:5080/api/{org}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_env_hit_returns_forced_id(monkeypatch):
+    """The OSPREY-forced id + telemetry on → full coordinates for that id."""
+    _enable_telemetry(monkeypatch, org="als")
+    monkeypatch.setenv("OSPREY_TELEMETRY_SESSION_ID", "sess-abc-123")
+    monkeypatch.setenv("OSPREY_TELEMETRY_SESSION_START", "2026-07-15T00:00:00+00:00")
+    monkeypatch.setenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=claude-code,host=x")
+
+    result = json.loads(await _fn()())
+
+    assert result["session_id"] == "sess-abc-123"
+    assert result["service_name"] == "claude-code"
+    assert result["org"] == "als"
+    assert result["stream"] == "default"
+    assert result["since"] == "2026-07-15T00:00:00+00:00"
+    assert "note" not in result
+    # emitted_at is stamped server-side and is a parseable ISO-8601 timestamp.
+    datetime.fromisoformat(result["emitted_at"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_fallback_to_harness_id(monkeypatch):
+    """No OSPREY id but the harness exports one → the harness id is used."""
+    _enable_telemetry(monkeypatch)
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "harness-xyz")
+
+    result = json.loads(await _fn()())
+
+    assert result["session_id"] == "harness-xyz"
+    assert result["service_name"] == "claude-code"  # default, no resource attrs
+    assert result["org"] == "default"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_osprey_id_takes_precedence(monkeypatch):
+    """When both are present the OSPREY-forced id wins (it is authoritative)."""
+    _enable_telemetry(monkeypatch)
+    monkeypatch.setenv("OSPREY_TELEMETRY_SESSION_ID", "osprey-wins")
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "harness-loses")
+
+    result = json.loads(await _fn()())
+
+    assert result["session_id"] == "osprey-wins"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_telemetry_disabled_degrades_honestly(monkeypatch):
+    """An id is present but telemetry is off → null + note, not a dangling id."""
+    monkeypatch.setenv("OSPREY_TELEMETRY_SESSION_ID", "sess-abc-123")
+    # CLAUDE_CODE_ENABLE_TELEMETRY intentionally unset.
+
+    result = json.loads(await _fn()())
+
+    assert result["session_id"] is None
+    assert "note" in result and "unavailable" in result["note"]
+    datetime.fromisoformat(result["emitted_at"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_no_id_resolvable_degrades_honestly(monkeypatch):
+    """Telemetry on but no id anywhere → null + note."""
+    _enable_telemetry(monkeypatch)
+
+    result = json.loads(await _fn()())
+
+    assert result["session_id"] is None
+    assert "note" in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_since_optional(monkeypatch):
+    """since is null when no session-start was injected, and the call succeeds."""
+    _enable_telemetry(monkeypatch)
+    monkeypatch.setenv("OSPREY_TELEMETRY_SESSION_ID", "sess-1")
+
+    result = json.loads(await _fn()())
+
+    assert result["session_id"] == "sess-1"
+    assert result["since"] is None


### PR DESCRIPTION
## Summary

Add a read-only `provenance_locator` workspace MCP tool that returns the current
session's telemetry coordinates (`session_id`, `service_name`, `org`, `stream`,
`since`, `emitted_at`), so a consumer can point a reader at the session's full
OTEL provenance instead of a reconstructed account.

For the returned id to resolve, OSPREY now owns it. Every agent-launch surface —
headless dispatch, the operator SDK session, and the terminal PTY — forces a
known session UUID (`ClaudeAgentOptions.session_id` / `claude --session-id`) and
injects it as `OSPREY_TELEMETRY_SESSION_ID` for the tool to read, so the id
matches what the OTEL emitter tags records with as `session.id`. The dispatch
worker also returns the id in its run result, making a run self-locating in
telemetry.

The tool degrades honestly (`session_id: null` + a note) when telemetry is
disabled or no id resolves, and never raises. Facility-agnostic — no site
strings.

## Test plan

- New unit tests for `provenance_locator` (env-hit, harness fallback, precedence,
  telemetry-disabled, no-id, `since`).
- New unit tests for the terminal PTY env injection (telemetry id set without
  relocating the artifact store; resume vs new-session paths).
- Existing workspace and web_terminal suites pass with no regressions.
