### PR TITLE
fix(web): keep hidden panels from auto-activating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,25 @@ on:
     # benchmarks) gates on github.event_name == 'schedule'.
     - cron: '0 7 * * *'
 
+# openobserve image pulls
+# -----------------------
+# Every app template ships openobserve in `deployed_services`, so every lane
+# that runs `osprey deploy up` pulls that image. ECR Public rate-limits
+# anonymous pulls per source IP and GitHub-hosted runners share egress IPs, so
+# those pulls fail intermittently with "toomanyrequests: Rate exceeded". Those
+# lanes therefore pull the ghcr mirror (no anonymous pull-rate limit) via a
+# job-level OSPREY_OPENOBSERVE_IMAGE override.
+#
+# The mirror is populated BY HAND for one tag at a time (mirror-openobserve.yml),
+# so when the compose template's pin moves: run that workflow for the new tag
+# first, then bump the override here. A guard test keeps the two in lockstep
+# (tests/deployment/test_compose_generator.py).
+#
+# The mirrored package is private (publishing it would be AGPL redistribution),
+# so each of those lanes needs `packages: read` plus a ghcr login. A job-level
+# permissions block REPLACES the default rather than extending it, which is why
+# contents: read is restated alongside it.
+
 # Note: This workflow runs tests, linting, docs build, and package checks
 # For documentation deployment to GitHub Pages, see .github/workflows/docs.yml
 
@@ -433,7 +452,22 @@ jobs:
     # Also runs on manual workflow_dispatch to enable scoped reruns via the e2e_filter input.
     if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'workflow_dispatch'
 
+    # Pull openobserve from the ghcr mirror, not rate-limited ECR Public.
+    # See "openobserve image pulls" at the top of this file.
+    permissions:
+      contents: read
+      packages: read
+    env:
+      OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
+
     steps:
+    - name: Log in to ghcr for the openobserve mirror
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Checkout repository
       uses: actions/checkout@v7
       with:
@@ -519,7 +553,22 @@ jobs:
     # Only run on PRs from same repo (secrets unavailable on forks)
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
 
+    # Pull openobserve from the ghcr mirror, not rate-limited ECR Public.
+    # See "openobserve image pulls" at the top of this file.
+    permissions:
+      contents: read
+      packages: read
+    env:
+      OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
+
     steps:
+    - name: Log in to ghcr for the openobserve mirror
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Checkout repository
       uses: actions/checkout@v7
       with:
@@ -574,7 +623,22 @@ jobs:
     # Only run on PRs from same repo (secrets unavailable on forks).
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
 
+    # Pull openobserve from the ghcr mirror, not rate-limited ECR Public.
+    # See "openobserve image pulls" at the top of this file.
+    permissions:
+      contents: read
+      packages: read
+    env:
+      OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
+
     steps:
+    - name: Log in to ghcr for the openobserve mirror
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Checkout repository
       uses: actions/checkout@v7
       with:
@@ -634,7 +698,22 @@ jobs:
     # extra Docker-build-and-deploy job, not just secret-gated ones.
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
 
+    # Pull openobserve from the ghcr mirror, not rate-limited ECR Public.
+    # See "openobserve image pulls" at the top of this file.
+    permissions:
+      contents: read
+      packages: read
+    env:
+      OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
+
     steps:
+    - name: Log in to ghcr for the openobserve mirror
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Checkout repository
       uses: actions/checkout@v7
       with:
@@ -672,7 +751,22 @@ jobs:
     # equivalence-e2e, not bluesky-deploy-e2e.
     timeout-minutes: 45
 
+    # Pull openobserve from the ghcr mirror, not rate-limited ECR Public.
+    # See "openobserve image pulls" at the top of this file.
+    permissions:
+      contents: read
+      packages: read
+    env:
+      OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
+
     steps:
+    - name: Log in to ghcr for the openobserve mirror
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Checkout repository
       uses: actions/checkout@v7
       with:
@@ -715,7 +809,22 @@ jobs:
     # step below) — a too-tight timeout must not be what reds its first PR.
     timeout-minutes: 45
 
+    # Pull openobserve from the ghcr mirror, not rate-limited ECR Public.
+    # See "openobserve image pulls" at the top of this file.
+    permissions:
+      contents: read
+      packages: read
+    env:
+      OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
+
     steps:
+    - name: Log in to ghcr for the openobserve mirror
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Checkout repository
       uses: actions/checkout@v7
       with:
@@ -752,7 +861,22 @@ jobs:
     # timeout-minutes; this job gets one for the extra image-pull headroom.
     timeout-minutes: 20
 
+    # Pull openobserve from the ghcr mirror, not rate-limited ECR Public.
+    # See "openobserve image pulls" at the top of this file.
+    permissions:
+      contents: read
+      packages: read
+    env:
+      OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
+
     steps:
+    - name: Log in to ghcr for the openobserve mirror
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Checkout repository
       uses: actions/checkout@v7
       with:
@@ -788,7 +912,22 @@ jobs:
     # bluesky-deploy-e2e rather than va-substrate-equivalence-e2e.
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
 
+    # Pull openobserve from the ghcr mirror, not rate-limited ECR Public.
+    # See "openobserve image pulls" at the top of this file.
+    permissions:
+      contents: read
+      packages: read
+    env:
+      OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
+
     steps:
+    - name: Log in to ghcr for the openobserve mirror
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Checkout repository
       uses: actions/checkout@v7
       with:
@@ -827,7 +966,22 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 45
 
+    # Pull openobserve from the ghcr mirror, not rate-limited ECR Public.
+    # See "openobserve image pulls" at the top of this file.
+    permissions:
+      contents: read
+      packages: read
+    env:
+      OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
+
     steps:
+    - name: Log in to ghcr for the openobserve mirror
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Checkout repository
       uses: actions/checkout@v7
       with:
@@ -857,7 +1011,22 @@ jobs:
     # Only run on PRs from same repo (mirrors deploy-e2e gating)
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
 
+    # Pull openobserve from the ghcr mirror, not rate-limited ECR Public.
+    # See "openobserve image pulls" at the top of this file.
+    permissions:
+      contents: read
+      packages: read
+    env:
+      OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
+
     steps:
+    - name: Log in to ghcr for the openobserve mirror
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Checkout repository
       uses: actions/checkout@v7
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- A Web Terminal panel closed with its "×" no longer reappears on its own. A panel's backend coming back online was treated as a reason to bring the panel to the front, so a hidden panel could surface itself — most visibly when the Workspace panel was unavailable and a closed panel was the only healthy one left. Health checks now only ever affect a panel's enabled state; showing a panel remains something only you or the agent can ask for.
+
 - A stale `CLAUDE_CODE_USE_BEDROCK` (or other backend/model selector) in the operator's shell no longer reroutes the agent away from the configured provider — these are now scrubbed before launch (#356).
 - `env.example` no longer ships uncommented placeholder proxy values. Copying it to `.env` exported an unparseable `HTTP_PROXY`, which broke Claude Code launches and OSPREY's own HTTP clients.
 - The `InContextBackend` benchmark test (the sole real-LLM test outside `tests/e2e/`) moved into `tests/e2e/`, so the fast lane (`pytest tests/ --ignore=tests/e2e`) stays hermetic even when a provider key is exported — previously it made a live LLM call and failed with an unrelated gateway auth error on a blocked/expired key. A placement guard prevents recurrence for the whole credentialed `requires_*` marker family.

--- a/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
@@ -457,15 +457,36 @@ async function initPanel(panel) {
       state.healthy = true;
       enableTab(panel.id);
       updateTabState(panel);
-      if (panel.id === DEFAULT_PANEL) {
-        activateTab(panel.id, { auto: true });
-      } else if (!activeTabId) {
-        activateTab(panel.id, { auto: true });
-      }
     } else {
       startHealthPolling(panel);
     }
   }
+  // Re-evaluate on every settle, including the no-url case: this panel may be
+  // the default that another panel's health poll was waiting on.
+  ensureActivePanel();
+}
+
+/**
+ * Give the empty slot to the best panel available, if any.
+ *
+ * Health-driven, so {auto: true} keeps it from ever surfacing a hidden panel.
+ * Safe to call on every settle: it no-ops once something is active.
+ *
+ * This is deliberately re-entrant rather than a one-shot at each health
+ * transition. A panel's FIRST healthy transition can land while the default is
+ * still loading its config — decline then and that panel never gets another
+ * transition to try again, stranding the pane blank.
+ */
+function ensureActivePanel() {
+  if (activeTabId) return;
+  const ds = panelState[DEFAULT_PANEL];
+  if (!ds?.configLoaded) return;  // default may still claim the slot — wait
+  // Hidden disqualifies the default exactly as unhealthy does; activateTab
+  // would refuse it anyway, and the slot must not sit empty behind it.
+  const target = ds.healthy && visiblePanels.has(DEFAULT_PANEL)
+    ? DEFAULT_PANEL
+    : PANELS.find(p => visiblePanels.has(p.id) && panelState[p.id]?.healthy)?.id;
+  if (target) activateTab(target, { auto: true });
 }
 
 // ---- Health Polling ----
@@ -510,25 +531,11 @@ async function pollHealth(panel) {
     updateTabState(panel);
     updateStatusBar(panel);
 
-    // First time healthy — enable tab and auto-activate
+    // First time healthy — enable the tab, then let the shared policy decide
+    // whether this newly-healthy panel should take an empty slot.
     if (state.healthy && !wasHealthy) {
       enableTab(panel.id);
-      // Auto-activate: prefer the DEFAULT_PANEL. Only activate a non-default
-      // panel if nothing is active yet and the default panel has settled and
-      // can't take the slot itself. Every call here is {auto: true}, so a
-      // hidden panel is never surfaced — see activateTab.
-      if (panel.id === DEFAULT_PANEL) {
-        activateTab(panel.id, { auto: true });
-      } else if (!activeTabId) {
-        const defaultState = panelState[DEFAULT_PANEL];
-        // Fall back once the default panel has settled and can't take the slot
-        // itself. Hidden counts the same as unhealthy here: activateTab refuses
-        // to auto-surface a hidden default, so without the visibility term the
-        // pane would stay blank while a visible healthy panel sits unopened.
-        if (defaultState?.configLoaded && !(defaultState.healthy && visiblePanels.has(DEFAULT_PANEL))) {
-          activateTab(panel.id, { auto: true });
-        }
-      }
+      ensureActivePanel();
     }
   } catch {
     state.healthy = false;

--- a/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
@@ -458,9 +458,9 @@ async function initPanel(panel) {
       enableTab(panel.id);
       updateTabState(panel);
       if (panel.id === DEFAULT_PANEL) {
-        activateTab(panel.id);
+        activateTab(panel.id, { auto: true });
       } else if (!activeTabId) {
-        activateTab(panel.id);
+        activateTab(panel.id, { auto: true });
       }
     } else {
       startHealthPolling(panel);
@@ -513,16 +513,20 @@ async function pollHealth(panel) {
     // First time healthy — enable tab and auto-activate
     if (state.healthy && !wasHealthy) {
       enableTab(panel.id);
-      // Auto-activate: prefer the DEFAULT_PANEL. Only activate a
-      // non-default panel if nothing is active yet and the default
-      // panel has already been polled and isn't healthy.
+      // Auto-activate: prefer the DEFAULT_PANEL. Only activate a non-default
+      // panel if nothing is active yet and the default panel has settled and
+      // can't take the slot itself. Every call here is {auto: true}, so a
+      // hidden panel is never surfaced — see activateTab.
       if (panel.id === DEFAULT_PANEL) {
-        activateTab(panel.id);
+        activateTab(panel.id, { auto: true });
       } else if (!activeTabId) {
         const defaultState = panelState[DEFAULT_PANEL];
-        // Only fall back if default panel finished loading config and isn't healthy
-        if (defaultState?.configLoaded && !defaultState.healthy) {
-          activateTab(panel.id);
+        // Fall back once the default panel has settled and can't take the slot
+        // itself. Hidden counts the same as unhealthy here: activateTab refuses
+        // to auto-surface a hidden default, so without the visibility term the
+        // pane would stay blank while a visible healthy panel sits unopened.
+        if (defaultState?.configLoaded && !(defaultState.healthy && visiblePanels.has(DEFAULT_PANEL))) {
+          activateTab(panel.id, { auto: true });
         }
       }
     }
@@ -619,11 +623,15 @@ function sendSessionToIframe(iframe) {
 
 /**
  * @param {string} panelId
- * @param {{ userInitiated?: boolean }} [options]
+ * @param {{ userInitiated?: boolean, auto?: boolean }} [options]
  */
-function activateTab(panelId, { userInitiated = false } = {}) {
+function activateTab(panelId, { userInitiated = false, auto = false } = {}) {
   const state = panelState[panelId];
   if (!state || !state.healthy) return;
+  // A panel becoming healthy is not a request to show it. The server owns the
+  // visible set, so health-driven activation must never surface a hidden panel
+  // — otherwise a panel closed with "×" reappears on its own.
+  if (auto && !visiblePanels.has(panelId)) return;
 
   activeTabId = panelId;
 

--- a/tests/deployment/test_compose_generator.py
+++ b/tests/deployment/test_compose_generator.py
@@ -11,6 +11,7 @@ deployed_services. Two failure modes have to stay fixed:
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -992,6 +993,81 @@ def test_host_python_env_path_would_bake_host_interpreter_into_mcp_command() -> 
 # ---------------------------------------------------------------------------
 
 _OPENOBSERVE_IMAGE_REF = "public.ecr.aws/zinclabs/openobserve"
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CI_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+_OPENOBSERVE_TEMPLATE = (
+    _REPO_ROOT
+    / "src"
+    / "osprey"
+    / "templates"
+    / "services"
+    / "openobserve"
+    / "docker-compose.yml.j2"
+)
+
+
+def _pinned_openobserve_tag() -> str:
+    """Return the openobserve tag the compose template pins."""
+    text = _OPENOBSERVE_TEMPLATE.read_text(encoding="utf-8")
+    match = re.search(
+        r"\$\{OSPREY_OPENOBSERVE_IMAGE:-" + re.escape(_OPENOBSERVE_IMAGE_REF) + r":([^}\s]+)\}",
+        text,
+    )
+    assert match, "compose template no longer pins the openobserve image in the expected form"
+    return match.group(1)
+
+
+def test_ci_openobserve_override_tag_matches_compose_pin() -> None:
+    """CI's ghcr mirror override must pin the same tag as the compose template.
+
+    CI overrides the image because ECR Public rate-limits anonymous pulls per
+    source IP and GitHub-hosted runners share egress IPs. The ghcr mirror is
+    populated by hand (mirror-openobserve.yml) for one tag at a time, so moving
+    the template's pin without moving CI's would leave every deploy lane pulling
+    a tag that was never mirrored — a hard, confusing failure far from the line
+    that caused it.
+    """
+    pinned = _pinned_openobserve_tag()
+    overrides = re.findall(
+        r"OSPREY_OPENOBSERVE_IMAGE:\s*(\S+)", _CI_WORKFLOW.read_text(encoding="utf-8")
+    )
+    assert overrides, "no CI lane overrides OSPREY_OPENOBSERVE_IMAGE"
+    for ref in overrides:
+        assert ref.endswith(f":{pinned}"), (
+            f"CI pins {ref!r} but the compose template pins :{pinned}. Bump both "
+            "together, and run the mirror workflow for the new tag first."
+        )
+
+
+def test_ci_openobserve_override_lanes_can_authenticate() -> None:
+    """Any lane overriding the image to the ghcr mirror must be able to pull it.
+
+    The mirrored package is private (making it public would be AGPL
+    redistribution), so a lane needs both `packages: read` and a ghcr login.
+    Copying the env override into a new lane without those turns an
+    intermittent rate-limit into a deterministic auth failure.
+    """
+    workflow = yaml.safe_load(_CI_WORKFLOW.read_text(encoding="utf-8"))
+    for name, job in workflow["jobs"].items():
+        image = (job.get("env") or {}).get("OSPREY_OPENOBSERVE_IMAGE", "")
+        if "ghcr.io" not in str(image):
+            continue
+        perms = job.get("permissions") or {}
+        assert perms.get("packages") == "read", (
+            f"{name} pulls the ghcr mirror but lacks packages: read"
+        )
+        assert perms.get("contents") == "read", (
+            f"{name} sets a permissions block without contents: read — a job-level "
+            "block replaces the default, so actions/checkout would lose access"
+        )
+        logins = [
+            s
+            for s in job.get("steps", [])
+            if str(s.get("uses", "")).startswith("docker/login-action")
+            and (s.get("with") or {}).get("registry") == "ghcr.io"
+        ]
+        assert logins, f"{name} pulls the private ghcr mirror but never logs in to ghcr.io"
 
 
 def _write_openobserve_config(

--- a/tests/interfaces/web_terminal/test_panels_browser.py
+++ b/tests/interfaces/web_terminal/test_panels_browser.py
@@ -18,6 +18,7 @@ Skips cleanly when the chromium headless binary is not installed.
 
 from __future__ import annotations
 
+import asyncio
 import threading
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -98,6 +99,7 @@ def _live_server(
     custom_panels=None,
     allow_runtime: bool = False,
     artifact_url: str | None = "http://127.0.0.1:8086",
+    artifact_config_delay: float = 0.0,
 ):
     """Launch a real web terminal server on a free port in a background thread.
 
@@ -110,6 +112,11 @@ def _live_server(
     ``activeTabId`` null: a panel with ``healthEndpoint: null`` is marked healthy
     unconditionally on load, so pointing it at a dead port would NOT keep it
     unhealthy — only withholding the URL does.
+
+    ``artifact_config_delay`` holds /api/artifact-server open for that many
+    seconds, so the default panel settles *after* another panel's health poll.
+    That ordering decides which panel gets the empty slot, and it is the order a
+    loaded CI runner produces naturally while a fast dev box hides it.
 
     Yields:
         (base_url: str, app: FastAPI) — live server address and the FastAPI app
@@ -136,6 +143,15 @@ def _live_server(
         from osprey.interfaces.web_terminal.app import create_app
 
         app = create_app(shell_command=["echo", "hello"])
+
+        if artifact_config_delay:
+
+            @app.middleware("http")
+            async def _delay_artifact_config(request, call_next):
+                if request.url.path == "/api/artifact-server":
+                    await asyncio.sleep(artifact_config_delay)
+                return await call_next(request)
+
         # _run_app_server yields only after the port accepts connections (lifespan
         # done), so app.state is safe to mutate here; and it joins the server
         # thread while the patches above are still live, avoiding timing races.
@@ -761,7 +777,64 @@ def test_hidden_default_panel_falls_back_to_visible_panel(tmp_path, chromium_bro
 
 
 # ---------------------------------------------------------------------------
-# Test 13: a hidden panel never auto-activates itself
+# Test 13: the slot is filled even when the default settles last
+# ---------------------------------------------------------------------------
+
+
+def test_hidden_default_settling_late_still_yields_slot(tmp_path, chromium_browser):
+    """A panel that polls healthy before the default settles must still get the slot.
+
+    Auto-activation cannot be a one-shot per health transition. data-viz's FIRST
+    healthy transition lands while the default panel is still fetching its
+    config; at that instant nothing may take the slot, because the default might
+    still claim it. The default then turns out to be hidden and is refused — and
+    data-viz has no second transition to retry with. The decision has to be
+    re-evaluated when the default settles, or the pane stays blank forever.
+
+    This ordering is what a loaded CI runner produces naturally; a fast dev box
+    resolves the config first and hides the bug, so the delay is forced here.
+
+    Arrange: hold /api/artifact-server open past data-viz's first health poll,
+    with artifacts healthy-but-hidden.
+    Act: load the page.
+    Assert: data-viz still ends up active.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _stub_backend() as backend_url:
+        visible_panel = {
+            "id": "data-viz",
+            "label": "DATA VIZ",
+            "url": backend_url,
+            "healthEndpoint": "/health",
+            "path": "/",
+        }
+
+        with _live_server(
+            workspace,
+            enabled_panels={"artifacts"},
+            custom_panels=[visible_panel],
+            # Long enough that data-viz's first health poll definitively wins.
+            artifact_config_delay=3.0,
+        ) as (base_url, app):
+            app.state.visible_panels = ["data-viz"]
+
+            page = chromium_browser.new_page()
+            page.goto(base_url, wait_until="domcontentloaded")
+            expect(page.locator('button[data-panel-id="data-viz"]')).to_be_attached(timeout=10_000)
+            page.evaluate("document.getElementById('welcome-overlay')?.remove()")
+
+            expect(
+                page.locator('button.header-tab[data-panel-id="data-viz"].active')
+            ).to_have_count(1, timeout=15_000)
+            expect(page.locator('button.header-tab[data-panel-id="artifacts"]')).not_to_be_visible()
+
+            page.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 14: a hidden panel never auto-activates itself
 # ---------------------------------------------------------------------------
 
 

--- a/tests/interfaces/web_terminal/test_panels_browser.py
+++ b/tests/interfaces/web_terminal/test_panels_browser.py
@@ -18,13 +18,15 @@ Skips cleanly when the chromium headless binary is not installed.
 
 from __future__ import annotations
 
+import threading
 from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from unittest.mock import AsyncMock, patch
 
 import pytest
 import requests
 
-from tests.interfaces.conftest import _run_app_server
+from tests.interfaces.conftest import _free_port, _run_app_server
 
 # ---------------------------------------------------------------------------
 # Playwright availability guard
@@ -57,12 +59,57 @@ _CUSTOM_DATA_VIZ: dict = {
 
 
 @contextmanager
-def _live_server(workspace_dir, enabled_panels, custom_panels=None, allow_runtime: bool = False):
+def _stub_backend():
+    """Serve 200 on every path, for a custom panel that must become healthy.
+
+    Panels with a ``healthEndpoint`` are the only ones that reach the
+    auto-activate branch in ``pollHealth``, and that branch needs a real
+    unhealthy→healthy transition — so it needs a real backend to poll.
+
+    Yields:
+        base URL of the stub, e.g. ``"http://127.0.0.1:54321"``.
+    """
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler API
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"ok")
+
+        def log_message(self, *args):  # silence per-request stderr logging
+            pass
+
+    server = HTTPServer(("127.0.0.1", _free_port()), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@contextmanager
+def _live_server(
+    workspace_dir,
+    enabled_panels,
+    custom_panels=None,
+    allow_runtime: bool = False,
+    artifact_url: str | None = "http://127.0.0.1:8086",
+):
     """Launch a real web terminal server on a free port in a background thread.
 
     Companion backends (artifact server, ARIEL, etc.) are bypassed via patches
     so no external process dependencies are required.  The artifacts panel
     reports its URL as http://127.0.0.1:8086 (the standard fallback).
+
+    Pass ``artifact_url=None`` to make /api/artifact-server report no URL, which
+    leaves the default panel loaded-but-unhealthy.  That is the only way to keep
+    ``activeTabId`` null: a panel with ``healthEndpoint: null`` is marked healthy
+    unconditionally on load, so pointing it at a dead port would NOT keep it
+    unhealthy — only withholding the URL does.
 
     Yields:
         (base_url: str, app: FastAPI) — live server address and the FastAPI app
@@ -83,7 +130,7 @@ def _live_server(workspace_dir, enabled_panels, custom_panels=None, allow_runtim
         patch(
             "osprey.interfaces.web_terminal.app._launch_artifact_server",
             # Set the artifact URL without actually spawning a server process.
-            side_effect=lambda a: setattr(a.state, "artifact_server_url", "http://127.0.0.1:8086"),
+            side_effect=lambda a: setattr(a.state, "artifact_server_url", artifact_url),
         ),
     ):
         from osprey.interfaces.web_terminal.app import create_app
@@ -655,3 +702,133 @@ def test_apply_preset_offline_first_member_focuses_healthy(tmp_path, chromium_br
         expect(page.locator("#panel-content").get_by_text("No panels visible")).to_have_count(0)
 
         page.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 12: a hidden default panel does not strand the pane blank
+# ---------------------------------------------------------------------------
+
+
+def test_hidden_default_panel_falls_back_to_visible_panel(tmp_path, chromium_browser):
+    """A hidden DEFAULT_PANEL must hand off to a visible healthy panel.
+
+    `web.panels: {artifacts: {hidden: true}}` is a supported config, so the
+    default panel can be healthy yet hidden.  Suppressing its auto-activation is
+    only half the job: something visible has to take its place, or the operator
+    gets a blank pane while a perfectly good panel sits unopened.
+
+    Arrange: artifacts is healthy but hidden before the page loads; data-viz is
+    visible and polls a live stub backend.
+    Act: load the page and let the health poll run.
+    Assert: data-viz becomes the active tab, and artifacts stays hidden.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _stub_backend() as backend_url:
+        visible_panel = {
+            "id": "data-viz",
+            "label": "DATA VIZ",
+            "url": backend_url,
+            "healthEndpoint": "/health",
+            "path": "/",
+        }
+
+        with _live_server(
+            workspace,
+            enabled_panels={"artifacts"},
+            custom_panels=[visible_panel],
+        ) as (base_url, app):
+            # Hide the DEFAULT_PANEL itself — artifacts still reports a URL, so it
+            # is healthy; it is only hidden.
+            app.state.visible_panels = ["data-viz"]
+
+            page = chromium_browser.new_page()
+            page.goto(base_url, wait_until="domcontentloaded")
+            expect(page.locator('button[data-panel-id="data-viz"]')).to_be_attached(timeout=10_000)
+            page.evaluate("document.getElementById('welcome-overlay')?.remove()")
+
+            # The visible, healthy panel must be the one on screen.
+            expect(
+                page.locator('button.header-tab[data-panel-id="data-viz"].active')
+            ).to_have_count(1, timeout=10_000)
+            expect(page.locator('iframe[data-panel-id="data-viz"]')).to_be_visible(timeout=5_000)
+
+            # ...and the hidden default must NOT have surfaced itself.
+            expect(page.locator('button.header-tab[data-panel-id="artifacts"]')).not_to_be_visible()
+
+            page.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 13: a hidden panel never auto-activates itself
+# ---------------------------------------------------------------------------
+
+
+def test_hidden_panel_does_not_auto_activate(tmp_path, chromium_browser):
+    """A hidden panel must not surface itself when no tab is active.
+
+    Health-driven activation is not a user action: the server owns the visible
+    set, so a panel the operator (or config) hid must stay hidden even when it
+    is the only healthy panel left.
+
+    Arrange: artifacts — the DEFAULT_PANEL — reports no URL, so it finishes loading
+    unhealthy and never activates; that keeps activeTabId null, which is what the
+    buggy fallback branch keys on.  data-viz polls a live stub backend, so it makes
+    a real unhealthy→healthy transition, but is hidden before the page opens.
+    Act: load the page and let the health poll run to completion.
+    Assert: data-viz stays hidden, never active, and its iframe is never mounted.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _stub_backend() as backend_url:
+        # A health endpoint is what routes this panel through pollHealth — the
+        # only auto-activate branch a custom panel can actually reach.
+        hidden_panel = {
+            "id": "data-viz",
+            "label": "DATA VIZ",
+            "url": backend_url,
+            "healthEndpoint": "/health",
+            "path": "/",
+        }
+
+        with _live_server(
+            workspace,
+            enabled_panels={"artifacts"},
+            custom_panels=[hidden_panel],
+            artifact_url=None,
+        ) as (base_url, app):
+            # Hide data-viz server-side before the browser ever fetches /api/panels.
+            app.state.visible_panels = ["artifacts"]
+
+            page = chromium_browser.new_page()
+            page.goto(base_url, wait_until="domcontentloaded")
+            expect(page.locator('button[data-panel-id="artifacts"]')).to_be_attached(timeout=10_000)
+            page.evaluate("document.getElementById('welcome-overlay')?.remove()")
+
+            # Give the async init + health poll time to do the wrong thing.
+            page.wait_for_timeout(3_000)
+
+            # Guard: the arrangement only tests anything if data-viz really did
+            # go healthy.  Without this, a stub that never came up would make
+            # every assertion below pass for the wrong reason.
+            expect(
+                page.locator('button.header-tab[data-panel-id="data-viz"]:not(.disabled)')
+            ).to_have_count(1, timeout=10_000)
+
+            data_viz_tab = page.locator('button.header-tab[data-panel-id="data-viz"]')
+            # It stays hidden...
+            expect(data_viz_tab).not_to_be_visible(timeout=5_000)
+            # ...never becomes the active tab...
+            expect(
+                page.locator('button.header-tab[data-panel-id="data-viz"].active')
+            ).to_have_count(0)
+            # ...and its iframe is never mounted-and-shown.  activateTab is what
+            # creates the iframe and clears .hidden, so a visible data-viz iframe
+            # is the unambiguous signature of the panel having surfaced itself.
+            expect(page.locator('iframe[data-panel-id="data-viz"]')).not_to_be_visible(
+                timeout=5_000
+            )
+
+            page.close()


### PR DESCRIPTION
## The bug

A Web Terminal panel closed with its `×` could reappear on its own.

`activateTab` gated only on `state.healthy` and never consulted `visiblePanels`. The health-driven call sites — in `initPanel` and in `pollHealth`'s first-time-healthy transition — could therefore surface a panel the operator had hidden. A panel's backend coming back online is not a request to show the panel.

The most visible case: the Workspace (default) panel is unavailable, so a closed panel is the only healthy one left, and it opens itself.

## The fix

Rather than patch the individual call sites — where a future auto-activate site would just reintroduce the bug — the invariant lives in `activateTab`:

```js
if (auto && !visiblePanels.has(panelId)) return;
```

The four health-driven calls pass `{ auto: true }`. Everything user- or agent-initiated (tab click, keyboard, the exported `focus()` API, and the `panel_focus` SSE handler) is untouched, so switching to a panel still works exactly as before.

`auto` is an explicit opt-in rather than an inverted `!userInitiated` on purpose: a blanket check would also block the `panel_focus` SSE handler and silently change agent behavior, and passing `{ userInitiated: true }` there would POST back to `/api/panel-focus` and cause an SSE echo loop.

### Second-order fix

Suppressing the default panel's auto-activation is only half the job. `web.panels: {artifacts: {hidden: true}}` is a supported config, so the default panel can be healthy yet hidden — in which case nothing would activate and the operator would get a **blank pane** while a visible healthy panel sat unopened. The non-default fallback now treats a hidden default the same as an unhealthy one and takes the slot.

## Tests

Two regression tests in `tests/interfaces/web_terminal/test_panels_browser.py`, both confirmed to fail before the fix and pass after:

- `test_hidden_panel_does_not_auto_activate` — a hidden panel stays hidden, never gets `.active`, and never mounts a visible iframe.
- `test_hidden_default_panel_falls_back_to_visible_panel` — a hidden default hands the slot to a visible healthy panel instead of blanking the pane.

Reaching the buggy branch needs a real unhealthy→healthy transition, so the tests add a stub backend to poll and an `artifact_url=None` option that leaves the default panel loaded-but-unhealthy. Both tests carry a guard assertion that the panel genuinely went healthy, so they cannot pass vacuously.

All 15 tests in the file pass; `npm run typecheck` and eslint are clean.

## Known adjacent gap (pre-existing, not addressed here)

A custom panel declared **without** a `healthEndpoint` is seeded healthy on a path that calls `enableTab` but never `activateTab`, so it never auto-activates. If the default panel can't take the slot, the pane stays blank. This is verified to predate this change — it reproduces with an unhealthy default and nothing hidden, where the new guard is inert — so it is left for its own PR rather than widening this one. This change does mean the hidden-default config now also reaches that path.