### PR TITLE
ci: pull openobserve from the ghcr mirror in E2E jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,19 @@ on:
 # Note: This workflow runs tests, linting, docs build, and package checks
 # For documentation deployment to GitHub Pages, see .github/workflows/docs.yml
 
+# Pull openobserve from our ghcr mirror rather than ECR Public. ECR Public
+# rate-limits anonymous pulls per source IP and GitHub-hosted runners share
+# egress IPs, so E2E deploys intermittently died on
+# "toomanyrequests: Rate exceeded". Set at workflow level because the ref is
+# identical in every deploying job; jobs that don't deploy ignore it.
+#
+# The mirror is PRIVATE, so each deploying job also needs the ghcr login step.
+# Populate/refresh it with .github/workflows/mirror-openobserve.yml, which must
+# be re-run whenever the pin in
+# src/osprey/templates/services/openobserve/docker-compose.yml.j2 moves.
+env:
+  OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
+
 jobs:
   test:
     name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}
@@ -375,6 +388,13 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v7
 
+    - name: Log in to ghcr (openobserve mirror)
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:
@@ -438,6 +458,13 @@ jobs:
       uses: actions/checkout@v7
       with:
         fetch-depth: 0
+
+    - name: Log in to ghcr (openobserve mirror)
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
@@ -525,6 +552,13 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Log in to ghcr (openobserve mirror)
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:
@@ -579,6 +613,13 @@ jobs:
       uses: actions/checkout@v7
       with:
         fetch-depth: 0
+
+    - name: Log in to ghcr (openobserve mirror)
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
@@ -640,6 +681,13 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Log in to ghcr (openobserve mirror)
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:
@@ -677,6 +725,13 @@ jobs:
       uses: actions/checkout@v7
       with:
         fetch-depth: 0
+
+    - name: Log in to ghcr (openobserve mirror)
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
@@ -721,6 +776,13 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Log in to ghcr (openobserve mirror)
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:
@@ -758,6 +820,13 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Log in to ghcr (openobserve mirror)
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:
@@ -793,6 +862,13 @@ jobs:
       uses: actions/checkout@v7
       with:
         fetch-depth: 0
+
+    - name: Log in to ghcr (openobserve mirror)
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
@@ -832,6 +908,13 @@ jobs:
       uses: actions/checkout@v7
       with:
         fetch-depth: 0
+
+    - name: Log in to ghcr (openobserve mirror)
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
Second of two PRs. Follows #405 (the mirror workflow), now merged. Points the ten deploying E2E jobs at the private ghcr mirror instead of ECR Public.

## Why

E2E jobs intermittently failed pulling `public.ecr.aws/zinclabs/openobserve:v0.14.4`:

```
openobserve Error toomanyrequests: Rate exceeded
postgresql  Interrupted
tiled       Interrupted
```

ECR Public rate-limits anonymous pulls per source IP; GitHub-hosted runners share egress IPs. Observed in runs 29354050172 (Jul 14) and 29445303316 (Jul 15).

## What this does

- Sets `OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4` once at workflow level.
- Adds a ghcr login step (`GITHUB_TOKEN`) to the ten jobs that run `osprey deploy up` and therefore pull openobserve.

The mirror is already published and was proven pullable by CI's `GITHUB_TOKEN` (a real `docker pull`, not just a login) before this PR was opened.

## Gates already cleared

- Mirror published, digest verified verbatim (`sha256:4a397210…` matches upstream) — the AGPL analysis depends on a byte-identical copy.
- Package linked to this repo, pull confirmed from CI.

## Deliberately unchanged

- The shipped template default still points at ECR Public, so downstream OSPREY deployments are unaffected and als-apg takes on no AGPL redistribution role.
- No `permissions:` block was added to any job — the repo's read-only default token already carries `packages: read`, and a job-level block would strip `contents: read` and break checkout.

The ten jobs: `e2e-tests`, `deploy-e2e`, `dispatch-deploy-e2e`, `bluesky-deploy-e2e`, `bluesky-panels-deploy-e2e`, `va-substrate-equivalence-e2e`, `tiled-roundtrip-e2e`, `bluesky-catalog-e2e`, `bluesky-sandbox-escape-e2e`, `agentic-per-preset`. (`dockerfile-e2e` and `build-boot-smoke` don't deploy and are untouched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)