### PR TITLE
ci: de-duplicate the openobserve ghcr mirror wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,25 +20,6 @@ on:
     # benchmarks) gates on github.event_name == 'schedule'.
     - cron: '0 7 * * *'
 
-# openobserve image pulls
-# -----------------------
-# Every app template ships openobserve in `deployed_services`, so every lane
-# that runs `osprey deploy up` pulls that image. ECR Public rate-limits
-# anonymous pulls per source IP and GitHub-hosted runners share egress IPs, so
-# those pulls fail intermittently with "toomanyrequests: Rate exceeded". Those
-# lanes therefore pull the ghcr mirror (no anonymous pull-rate limit) via a
-# job-level OSPREY_OPENOBSERVE_IMAGE override.
-#
-# The mirror is populated BY HAND for one tag at a time (mirror-openobserve.yml),
-# so when the compose template's pin moves: run that workflow for the new tag
-# first, then bump the override here. A guard test keeps the two in lockstep
-# (tests/deployment/test_compose_generator.py).
-#
-# The mirrored package is private (publishing it would be AGPL redistribution),
-# so each of those lanes needs `packages: read` plus a ghcr login. A job-level
-# permissions block REPLACES the default rather than extending it, which is why
-# contents: read is restated alongside it.
-
 # Note: This workflow runs tests, linting, docs build, and package checks
 # For documentation deployment to GitHub Pages, see .github/workflows/docs.yml
 
@@ -472,22 +453,7 @@ jobs:
     # Also runs on manual workflow_dispatch to enable scoped reruns via the e2e_filter input.
     if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'workflow_dispatch'
 
-    # Pull openobserve from the ghcr mirror, not rate-limited ECR Public.
-    # See "openobserve image pulls" at the top of this file.
-    permissions:
-      contents: read
-      packages: read
-    env:
-      OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
-
     steps:
-    - name: Log in to ghcr for the openobserve mirror
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Checkout repository
       uses: actions/checkout@v7
       with:
@@ -580,22 +546,7 @@ jobs:
     # Only run on PRs from same repo (secrets unavailable on forks)
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
 
-    # Pull openobserve from the ghcr mirror, not rate-limited ECR Public.
-    # See "openobserve image pulls" at the top of this file.
-    permissions:
-      contents: read
-      packages: read
-    env:
-      OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
-
     steps:
-    - name: Log in to ghcr for the openobserve mirror
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Checkout repository
       uses: actions/checkout@v7
       with:
@@ -657,22 +608,7 @@ jobs:
     # Only run on PRs from same repo (secrets unavailable on forks).
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
 
-    # Pull openobserve from the ghcr mirror, not rate-limited ECR Public.
-    # See "openobserve image pulls" at the top of this file.
-    permissions:
-      contents: read
-      packages: read
-    env:
-      OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
-
     steps:
-    - name: Log in to ghcr for the openobserve mirror
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Checkout repository
       uses: actions/checkout@v7
       with:
@@ -739,22 +675,7 @@ jobs:
     # extra Docker-build-and-deploy job, not just secret-gated ones.
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
 
-    # Pull openobserve from the ghcr mirror, not rate-limited ECR Public.
-    # See "openobserve image pulls" at the top of this file.
-    permissions:
-      contents: read
-      packages: read
-    env:
-      OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
-
     steps:
-    - name: Log in to ghcr for the openobserve mirror
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Checkout repository
       uses: actions/checkout@v7
       with:
@@ -799,22 +720,7 @@ jobs:
     # equivalence-e2e, not bluesky-deploy-e2e.
     timeout-minutes: 45
 
-    # Pull openobserve from the ghcr mirror, not rate-limited ECR Public.
-    # See "openobserve image pulls" at the top of this file.
-    permissions:
-      contents: read
-      packages: read
-    env:
-      OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
-
     steps:
-    - name: Log in to ghcr for the openobserve mirror
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Checkout repository
       uses: actions/checkout@v7
       with:
@@ -864,22 +770,7 @@ jobs:
     # step below) — a too-tight timeout must not be what reds its first PR.
     timeout-minutes: 45
 
-    # Pull openobserve from the ghcr mirror, not rate-limited ECR Public.
-    # See "openobserve image pulls" at the top of this file.
-    permissions:
-      contents: read
-      packages: read
-    env:
-      OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
-
     steps:
-    - name: Log in to ghcr for the openobserve mirror
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Checkout repository
       uses: actions/checkout@v7
       with:
@@ -923,22 +814,7 @@ jobs:
     # timeout-minutes; this job gets one for the extra image-pull headroom.
     timeout-minutes: 20
 
-    # Pull openobserve from the ghcr mirror, not rate-limited ECR Public.
-    # See "openobserve image pulls" at the top of this file.
-    permissions:
-      contents: read
-      packages: read
-    env:
-      OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
-
     steps:
-    - name: Log in to ghcr for the openobserve mirror
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Checkout repository
       uses: actions/checkout@v7
       with:
@@ -981,22 +857,7 @@ jobs:
     # bluesky-deploy-e2e rather than va-substrate-equivalence-e2e.
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
 
-    # Pull openobserve from the ghcr mirror, not rate-limited ECR Public.
-    # See "openobserve image pulls" at the top of this file.
-    permissions:
-      contents: read
-      packages: read
-    env:
-      OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
-
     steps:
-    - name: Log in to ghcr for the openobserve mirror
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Checkout repository
       uses: actions/checkout@v7
       with:
@@ -1042,22 +903,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 45
 
-    # Pull openobserve from the ghcr mirror, not rate-limited ECR Public.
-    # See "openobserve image pulls" at the top of this file.
-    permissions:
-      contents: read
-      packages: read
-    env:
-      OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
-
     steps:
-    - name: Log in to ghcr for the openobserve mirror
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Checkout repository
       uses: actions/checkout@v7
       with:
@@ -1094,22 +940,7 @@ jobs:
     # Only run on PRs from same repo (mirrors deploy-e2e gating)
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
 
-    # Pull openobserve from the ghcr mirror, not rate-limited ECR Public.
-    # See "openobserve image pulls" at the top of this file.
-    permissions:
-      contents: read
-      packages: read
-    env:
-      OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
-
     steps:
-    - name: Log in to ghcr for the openobserve mirror
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Checkout repository
       uses: actions/checkout@v7
       with:

--- a/tests/deployment/test_compose_generator.py
+++ b/tests/deployment/test_compose_generator.py
@@ -1018,56 +1018,37 @@ def _pinned_openobserve_tag() -> str:
     return match.group(1)
 
 
-def test_ci_openobserve_override_tag_matches_compose_pin() -> None:
-    """CI's ghcr mirror override must pin the same tag as the compose template.
+def test_ci_openobserve_pinned_to_ghcr_mirror() -> None:
+    """CI must pull openobserve from the ghcr mirror, pinned to the compose tag.
 
-    CI overrides the image because ECR Public rate-limits anonymous pulls per
-    source IP and GitHub-hosted runners share egress IPs. The ghcr mirror is
-    populated by hand (mirror-openobserve.yml) for one tag at a time, so moving
-    the template's pin without moving CI's would leave every deploy lane pulling
-    a tag that was never mirrored — a hard, confusing failure far from the line
-    that caused it.
+    Two foot-guns in one assertion:
+
+    * If the override drifts back to ``public.ecr.aws`` the rate-limit flakiness
+      returns — ECR Public throttles anonymous pulls per source IP and
+      GitHub-hosted runners share egress IPs.
+    * The mirror is populated by hand (mirror-openobserve.yml) for one tag at a
+      time, so moving the compose template's pin without moving CI's leaves every
+      deploy lane pulling a tag that was never mirrored — a hard, confusing
+      failure far from the line that caused it.
+
+    Both remain latent until a runner happens to hit them, so guard statically.
     """
     pinned = _pinned_openobserve_tag()
     overrides = re.findall(
         r"OSPREY_OPENOBSERVE_IMAGE:\s*(\S+)", _CI_WORKFLOW.read_text(encoding="utf-8")
     )
-    assert overrides, "no CI lane overrides OSPREY_OPENOBSERVE_IMAGE"
+    assert overrides, (
+        "CI no longer overrides OSPREY_OPENOBSERVE_IMAGE — deploy lanes fall back to ECR"
+    )
     for ref in overrides:
+        assert ref.startswith("ghcr.io/"), (
+            f"CI pins {ref!r}, not the ghcr mirror. A non-ghcr ref (e.g. ECR Public) "
+            "reintroduces the anonymous-pull rate-limit flakiness."
+        )
         assert ref.endswith(f":{pinned}"), (
             f"CI pins {ref!r} but the compose template pins :{pinned}. Bump both "
             "together, and run the mirror workflow for the new tag first."
         )
-
-
-def test_ci_openobserve_override_lanes_can_authenticate() -> None:
-    """Any lane overriding the image to the ghcr mirror must be able to pull it.
-
-    The mirrored package is private (making it public would be AGPL
-    redistribution), so a lane needs both `packages: read` and a ghcr login.
-    Copying the env override into a new lane without those turns an
-    intermittent rate-limit into a deterministic auth failure.
-    """
-    workflow = yaml.safe_load(_CI_WORKFLOW.read_text(encoding="utf-8"))
-    for name, job in workflow["jobs"].items():
-        image = (job.get("env") or {}).get("OSPREY_OPENOBSERVE_IMAGE", "")
-        if "ghcr.io" not in str(image):
-            continue
-        perms = job.get("permissions") or {}
-        assert perms.get("packages") == "read", (
-            f"{name} pulls the ghcr mirror but lacks packages: read"
-        )
-        assert perms.get("contents") == "read", (
-            f"{name} sets a permissions block without contents: read — a job-level "
-            "block replaces the default, so actions/checkout would lose access"
-        )
-        logins = [
-            s
-            for s in job.get("steps", [])
-            if str(s.get("uses", "")).startswith("docker/login-action")
-            and (s.get("with") or {}).get("registry") == "ghcr.io"
-        ]
-        assert logins, f"{name} pulls the private ghcr mirror but never logs in to ghcr.io"
 
 
 def _write_openobserve_config(


### PR DESCRIPTION
## Why

Two PRs wired the E2E deploy lanes to the ghcr openobserve mirror concurrently — #411 (workflow-level env + one login per deploying job) and #410 (per-job env + a second login). Neither rebased on the other, and their hunks didn't overlap textually, so both merged into `main` without a conflict. The result:

- `OSPREY_OPENOBSERVE_IMAGE` declared **twice** — once at workflow level, once per job (identical value, so functionally harmless but confusing).
- **Nine deploying jobs log in to ghcr twice.**
- Two different conventions for the same wiring sitting side by side.

`main`'s combined state is functionally correct — both source PRs were green independently, and a docker login is idempotent — but it was never actually exercised by a single CI run, and the redundancy is a trap for the next person to edit this file.

## What

Collapse to the workflow-level form (the DRYer of the two):

- One `OSPREY_OPENOBSERVE_IMAGE` at workflow level; one ghcr login per deploying job.
- **Drop the per-job `permissions:` blocks.** The repo's default workflow token is `read`-scoped, which already grants the `packages: read` a private-package pull needs — verified against the repo's Actions settings, and demonstrated by #411's fully-green run, which had no permissions blocks at all. An explicit block earned nothing.
- **Drop the mirror wiring from `dockerfile-e2e`** — it runs `docker build`/`docker run` on the generated project image and never deploys openobserve, so it never pulled the throttled image. #411 correctly excluded it; this removes the redundant login #410 added.

The cleaned `.github/workflows/ci.yml` is **byte-identical to #411's** — i.e. this reverts exactly the #410 half of the collision and keeps #411's, nothing more.

`visual-theming`'s pre-existing `permissions: contents: write` (unrelated to openobserve) is deliberately left untouched.

## Guard test

The old per-job authentication guard keyed off a per-job env override plus a permissions block — neither of which exists anymore, so it would have passed vacuously. Replaced with `test_ci_openobserve_pinned_to_ghcr_mirror`, which asserts the workflow-level override stays pinned to the **ghcr mirror** at the **tag the compose template pins**. That catches the two real, latent foot-guns:

- a drift back to `public.ecr.aws` (reintroduces the anonymous-pull rate-limit flakiness), and
- a compose-template tag bump the mirror was never populated for (the mirror is refreshed by hand, one tag at a time).

Both verified by breaking each condition and watching the test fail with the intended message, then restoring.