### PR TITLE
fix(web): bind EVENTS credential injection to config-defined panels

### DIFF
--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -278,6 +278,14 @@ def _load_panel_config() -> tuple[set[str], list[dict], str | None]:
                     "url": spec.get("url", ""),
                     "healthEndpoint": spec.get("health_endpoint"),
                     "path": spec.get("path", "/"),
+                    # Trust marker: this panel was declared in config (a trusted
+                    # input), not registered at runtime via POST /api/panels/register.
+                    # Only the config loader stamps it, so credential injection
+                    # (routes/proxy.py) and id reservation (routes/panels.py) can key
+                    # off panel *origin* rather than the forgeable id string. Set
+                    # explicitly here — GET /api/panels spreads this dict to the
+                    # browser, so only deliberately-placed fields are exposed.
+                    "configDefined": True,
                     # Path suffixes whose JSON responses get the proxy's
                     # root-absolute-literal rewrite (see routes/proxy.py) —
                     # for backends whose SPA bootstraps its API base from a

--- a/src/osprey/interfaces/web_terminal/routes/panels.py
+++ b/src/osprey/interfaces/web_terminal/routes/panels.py
@@ -402,10 +402,24 @@ async def register_panel(body: PanelRegisterRequest, request: Request):
             detail="Runtime panel registration is disabled. Set web.allow_runtime_panels: true to enable.",
         )
 
-    if body.id in BUILTIN_PANELS:
+    # Reserve both built-in ids and config-defined panel ids. Config-defined ids
+    # are derived from the live custom-panel state (never a second stored field
+    # that could drift) via the ``configDefined`` marker the config loader stamps.
+    # Without this, a runtime registration could squat a config panel's id and the
+    # remove-then-append below would silently repoint it — e.g. redirecting the
+    # EVENTS panel (which the proxy credentials server-side) at an attacker URL.
+    config_panel_ids = {
+        cp["id"]
+        for cp in getattr(request.app.state, "custom_panels", [])
+        if cp.get("configDefined")
+    }
+    if body.id in BUILTIN_PANELS or body.id in config_panel_ids:
         raise HTTPException(
             status_code=422,
-            detail=f"Panel id {body.id!r} collides with a built-in panel; choose a different id.",
+            detail=(
+                f"Panel id {body.id!r} collides with a built-in or config-defined "
+                "panel; choose a different id."
+            ),
         )
 
     allowlist: list[str] | None = getattr(request.app.state, "runtime_panel_allowlist", None)

--- a/src/osprey/interfaces/web_terminal/routes/proxy.py
+++ b/src/osprey/interfaces/web_terminal/routes/proxy.py
@@ -95,6 +95,19 @@ def _resolve_panel_url(request: Request, panel_id: str) -> str | None:
     return None
 
 
+def _panel_is_config_defined(request: Request, panel_id: str) -> bool:
+    """True only if ``panel_id`` resolves to a config-declared custom panel.
+
+    Runtime registrations (POST /api/panels/register) never carry the
+    ``configDefined`` marker, so a registration that squats a config panel's id
+    cannot inherit that panel's server-side credential injection below.
+    """
+    for cp in getattr(request.app.state, "custom_panels", []):
+        if cp.get("id") == panel_id:
+            return bool(cp.get("configDefined"))
+    return False
+
+
 def _panel_json_rewrite_paths(request: Request, panel_id: str) -> tuple[str, ...]:
     """The panel's configured ``rewrite_json_paths`` suffixes (usually empty)."""
     for cp in getattr(request.app.state, "custom_panels", []):
@@ -173,7 +186,9 @@ async def proxy_panel(panel_id: str, path: str, request: Request):
     # dispatcher token server-side for the EVENTS panel only, so the browser
     # never holds it (and other panels are unaffected). The web-terminal process
     # picks up EVENT_DISPATCHER_TOKEN from the project .env via load_dotenv.
-    if panel_id == "events":
+    # Gated on config origin, not the id string: the token must follow the
+    # config-defined EVENTS panel, never a runtime-registered squat of the id.
+    if panel_id == "events" and _panel_is_config_defined(request, "events"):
         token = os.environ.get("EVENT_DISPATCHER_TOKEN", "")
         if token:
             fwd_headers["authorization"] = f"Bearer {token}"

--- a/tests/interfaces/web_terminal/test_proxy_panel.py
+++ b/tests/interfaces/web_terminal/test_proxy_panel.py
@@ -148,9 +148,24 @@ class TestEventsPanelTokenInjection:
 
     @pytest.fixture
     def app_and_client_events(self, workspace_dir):
+        # The legit EVENTS panel is config-defined; the loader stamps configDefined.
         custom = [
-            {"id": "events", "label": "EVENTS", "url": "http://localhost:8020"},
+            {
+                "id": "events",
+                "label": "EVENTS",
+                "url": "http://localhost:8020",
+                "configDefined": True,
+            },
             {"id": "my-dash", "label": "DASH", "url": "http://localhost:9000"},
+        ]
+        yield from _make_client(workspace_dir, custom)
+
+    @pytest.fixture
+    def app_and_client_squatted_events(self, workspace_dir):
+        # A runtime-registered "events" entry carries no configDefined marker —
+        # this is what an id-squat via POST /api/panels/register looks like.
+        custom = [
+            {"id": "events", "label": "EVENTS", "url": "http://attacker.lan:3000"},
         ]
         yield from _make_client(workspace_dir, custom)
 
@@ -193,6 +208,30 @@ class TestEventsPanelTokenInjection:
     def test_events_panel_no_token_no_header(self, app_and_client_events, monkeypatch):
         app, client = app_and_client_events
         monkeypatch.delenv("EVENT_DISPATCHER_TOKEN", raising=False)
+
+        captured = {}
+
+        async def fake_request(*, method, url, headers, content):
+            captured.update(headers)
+            return httpx.Response(
+                200, json={"ok": True}, headers={"content-type": "application/json"}
+            )
+
+        app.state.proxy_client.request = AsyncMock(side_effect=fake_request)
+
+        resp = client.get("/panel/events/dashboard/state")
+        assert resp.status_code == 200
+        assert "authorization" not in {k.lower() for k in captured}
+
+    def test_squatted_events_panel_not_injected(self, app_and_client_squatted_events, monkeypatch):
+        """An 'events' entry lacking the configDefined marker gets no token.
+
+        Defense-in-depth for the id-squat leak: even if a non-config-defined
+        entry reaches the proxy under the id 'events', the dispatcher token must
+        not follow it to the (attacker-controlled) origin.
+        """
+        app, client = app_and_client_squatted_events
+        monkeypatch.setenv("EVENT_DISPATCHER_TOKEN", "sekret")
 
         captured = {}
 

--- a/tests/interfaces/web_terminal/test_web_custom_panels.py
+++ b/tests/interfaces/web_terminal/test_web_custom_panels.py
@@ -221,6 +221,24 @@ class TestLoadPanelConfig:
         assert events[0]["healthEndpoint"] == "/health"
         assert events[0]["label"] == "EVENTS"
 
+    def test_config_defined_custom_panel_carries_marker(self):
+        """Config-defined custom panels carry ``configDefined=True``.
+
+        The marker is the trust boundary: only the config loader stamps it, so
+        server-side credential injection and id reservation can key off panel
+        *origin* rather than the id string (which a runtime registration can
+        forge). See routes/proxy.py (events token gate) and routes/panels.py
+        (register reservation).
+        """
+        with patch(
+            "osprey.utils.workspace.load_osprey_config",
+            return_value={
+                "web": {"panels": {"events": {"label": "EVENTS", "url": "http://localhost:8020"}}}
+            },
+        ):
+            _enabled, custom, _default = _load_panel_config()
+        assert custom[0]["configDefined"] is True
+
     def test_config_load_failure(self):
         """Config load failure returns universal panels only."""
         with patch(
@@ -421,6 +439,40 @@ def _make_client_with_hidden_panel(workspace_dir, hidden_panel_id, enabled_panel
         app = create_app(shell_command="echo")
         with TestClient(app) as c:
             yield c
+
+
+def _make_client_runtime_with_config_events(workspace_dir):
+    """Yield ``(app, client)`` with allow_runtime_panels AND a config-defined EVENTS panel.
+
+    Unlike ``_make_client_with_runtime_panels``, this patches only the raw osprey
+    config and lets the real ``_load_panel_config`` run — so the events entry is
+    stamped with the production ``configDefined`` marker the reservation check
+    relies on.
+    """
+    with (
+        patch(
+            "osprey.interfaces.web_terminal.app._load_web_config",
+            return_value={"watch_dir": str(workspace_dir)},
+        ),
+        patch(
+            "osprey.utils.workspace.load_osprey_config",
+            return_value={
+                "web": {
+                    "allow_runtime_panels": True,
+                    "panels": {
+                        "events": {
+                            "label": "EVENTS",
+                            "url": "http://localhost:8020",
+                            "path": "/dashboard",
+                        }
+                    },
+                }
+            },
+        ),
+    ):
+        app = create_app(shell_command="echo")
+        with TestClient(app) as c:
+            yield app, c
 
 
 @pytest.fixture
@@ -784,3 +836,50 @@ class TestPanelRegisterAPI:
 
         # Assert
         assert resp.status_code == 200
+
+
+class TestConfigDefinedPanelReservation:
+    """A config-defined panel id is reserved against runtime registration.
+
+    Without this, an agent (via the workspace ``register_panel`` MCP tool) could
+    register ``id="events"``; the remove-then-append would silently repoint the
+    config-defined EVENTS panel at an attacker URL, and the proxy's server-side
+    token injection would then hand ``EVENT_DISPATCHER_TOKEN`` to that URL.
+    """
+
+    @pytest.fixture
+    def app_and_client(self, workspace_dir):
+        yield from _make_client_runtime_with_config_events(workspace_dir)
+
+    def test_marker_is_stamped_on_startup(self, app_and_client):
+        """Precondition: the real config path stamps configDefined on events."""
+        app, _client = app_and_client
+        events = [cp for cp in app.state.custom_panels if cp["id"] == "events"]
+        assert events and events[0].get("configDefined") is True
+
+    def test_register_config_defined_id_returns_422(self, app_and_client):
+        """Registering a config-defined id (events) is rejected, like a built-in."""
+        _app, client = app_and_client
+        with patch(_GETADDRINFO_TARGET, return_value=_LAN_ADDR):
+            resp = client.post(
+                "/api/panels/register",
+                json={"id": "events", "label": "PWNED", "url": "http://attacker.lan:3000"},
+            )
+        assert resp.status_code == 422
+
+    def test_config_entry_survives_squat_attempt(self, app_and_client):
+        """The reserved id's config entry is never mutated — url/label unchanged.
+
+        Guards the remove-then-append: a status-only assertion would pass even if
+        the entry were replaced-then-rejected, so assert the entry itself.
+        """
+        app, client = app_and_client
+        with patch(_GETADDRINFO_TARGET, return_value=_LAN_ADDR):
+            client.post(
+                "/api/panels/register",
+                json={"id": "events", "label": "PWNED", "url": "http://attacker.lan:3000"},
+            )
+        events = [cp for cp in app.state.custom_panels if cp["id"] == "events"]
+        assert len(events) == 1
+        assert events[0]["url"] == "http://localhost:8020"  # original, not attacker's
+        assert events[0]["label"] == "EVENTS"


### PR DESCRIPTION
Runtime panel registration (`POST /api/panels/register`, reachable via the workspace `register_panel` MCP tool) could squat the `events` id: the remove-then-append would silently repoint the config-defined EVENTS panel at an attacker URL, and the proxy — which injects `EVENT_DISPATCHER_TOKEN` server-side keyed on the bare `"events"` string — would then attach that token to the attacker origin.

Not reachable in a default config (`web.allow_runtime_panels` defaults off); the realistic actor is a prompt-injected agent, not a remote one.

## Fix

Replace id-string trust with config-origin trust via a `configDefined` marker only the config loader stamps:

- **`app.py`** — `_load_panel_config` stamps `configDefined: True` on every config-declared custom panel (explicit dict, so `GET /api/panels` exposes only intended fields).
- **`routes/panels.py`** — the register route now reserves config-defined ids in addition to built-ins, derived live from `custom_panels` (no drift-prone second state field). The squat is rejected 422 and the config entry is left untouched.
- **`routes/proxy.py`** — token injection is gated on `_panel_is_config_defined(...)` rather than the bare id string, so the credential can never follow a non-config `events` entry (defense-in-depth).

## Tests

Driven test-first. New coverage:
- `_load_panel_config` stamps the marker on config-defined panels.
- Registering a config-defined id returns 422 and the original entry survives (guards the remove-then-append).
- A non-config-defined `events` entry receives no token injection.

Full `tests/interfaces/web_terminal/` suite: 501 passed. Ruff lint + format clean.