### PR TITLE
Multi-user support P5.1: carried fixes

### DIFF
--- a/src/osprey/deployment/compose_generator.py
+++ b/src/osprey/deployment/compose_generator.py
@@ -5,6 +5,7 @@ management, and Docker Compose file creation for container deployments.
 """
 
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -111,6 +112,26 @@ def find_service_config(config, service_name):
     return None, None
 
 
+def _normalize_compose_name(name):
+    """Normalize a string into a valid docker-compose project name.
+
+    Mirrors docker-compose's own normalization so the value OSPREY pins as
+    ``COMPOSE_PROJECT_NAME`` matches what compose would derive on its own:
+    lowercase, keep only ``[a-z0-9_-]`` (dropping everything else, including
+    whitespace), then strip any leading ``_``/``-`` so the result begins with a
+    letter or number. An input that is already a valid lowercase name passes
+    through byte-unchanged.
+
+    :param name: Raw candidate project name
+    :type name: str
+    :return: Compose-valid project name (may be empty if no valid characters
+        remain)
+    :rtype: str
+    """
+    kept = re.findall(r"[a-z0-9_-]", str(name).lower())
+    return "".join(kept).lstrip("_-")
+
+
 def resolve_project_name(config):
     """Derive the project name used for labels and the ``<project>:local`` image tag.
 
@@ -121,6 +142,11 @@ def resolve_project_name(config):
     1. Root-level ``project_name`` attribute (preferred, explicit)
     2. Last component of the ``project_root`` path (smart fallback)
     3. ``"unnamed-project"`` (final fallback)
+
+    The resolved name is normalized to a valid docker-compose project name via
+    :func:`_normalize_compose_name` so it matches the value compose itself would
+    use for volume/network namespacing. If normalization empties the candidate
+    (no valid characters), the ``"unnamed-project"`` fallback is used.
 
     :param config: Configuration dictionary
     :type config: dict
@@ -134,6 +160,8 @@ def resolve_project_name(config):
         project_root = config.get("project_root", "")
         if project_root:
             project_name = os.path.basename(str(project_root).rstrip("/"))
+
+    project_name = _normalize_compose_name(project_name) if project_name else ""
 
     if not project_name:
         # Final fallback: Default

--- a/src/osprey/templates/skills/osprey-build-deploy/templates/core/.gitlab-ci.yml
+++ b/src/osprey/templates/skills/osprey-build-deploy/templates/core/.gitlab-ci.yml
@@ -79,7 +79,6 @@ osprey-build:
     - |
       cat > .env.production << ENVEOF
       ${config.llm.api_key_env_var}=${env.${config.llm.api_key_env_var}}
-      ${config.ci.token_env_var}=${env.${config.ci.token_env_var}}
       # IF MODULE olog.enabled
       ${config.modules.olog.username_env_var}=${env.${config.modules.olog.username_env_var}}
       ${config.modules.olog.password_env_var}=${env.${config.modules.olog.password_env_var}}
@@ -89,7 +88,6 @@ osprey-build:
       # END IF
       # IF MODULE event_dispatcher.enabled
       ${config.modules.event_dispatcher.token_env_var}=${env.${config.modules.event_dispatcher.token_env_var}}
-      ${config.modules.event_dispatcher.sidecar_token_env_var}=${env.${config.modules.event_dispatcher.sidecar_token_env_var}}
       # END IF
       # IF MODULE ariel.enabled
       ARIEL_DSN=${config.modules.ariel.dsn}

--- a/tests/deployment/test_compose_generator.py
+++ b/tests/deployment/test_compose_generator.py
@@ -19,7 +19,11 @@ import yaml
 from ruamel.yaml import YAML
 
 from osprey.cli.build_cmd import _copy_service_templates
-from osprey.deployment.compose_generator import prepare_compose_files, resolve_user_volume_names
+from osprey.deployment.compose_generator import (
+    prepare_compose_files,
+    resolve_project_name,
+    resolve_user_volume_names,
+)
 
 
 def _write_config(project_path: Path, deployed_services: list[str]) -> Path:
@@ -1370,3 +1374,58 @@ def test_resolve_user_volume_names_none_config_uses_default_project_name() -> No
     claude_config, agent_data = resolve_user_volume_names(None, "dave")
     assert claude_config == "unnamed-project_dave-claude-config"
     assert agent_data == "unnamed-project_dave-agent-data"
+
+
+# ---------------------------------------------------------------------------
+# resolve_project_name normalizes its result to a valid docker-compose project
+# name (lowercase; only [a-z0-9_-]; must start with a letter or number), so the
+# value OSPREY pins as COMPOSE_PROJECT_NAME matches what compose would derive on
+# its own. Already-valid lowercase names must pass through byte-unchanged.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_project_name_valid_lowercase_unchanged() -> None:
+    """An already-valid lowercase name passes through byte-for-byte."""
+    assert resolve_project_name({"project_name": "my-facility-project"}) == "my-facility-project"
+    assert resolve_project_name({"project_name": "als_beamline-7"}) == "als_beamline-7"
+
+
+def test_resolve_project_name_lowercases_mixed_case() -> None:
+    """Mixed-case names are lowercased, matching compose normalization."""
+    assert resolve_project_name({"project_name": "MyProject"}) == "myproject"
+    assert resolve_project_name({"project_name": "ALS-Booster"}) == "als-booster"
+
+
+def test_resolve_project_name_drops_spaces() -> None:
+    """Whitespace is dropped (not replaced), matching compose normalization."""
+    assert resolve_project_name({"project_name": "my project"}) == "myproject"
+    assert resolve_project_name({"project_name": "  Spaced  Name  "}) == "spacedname"
+
+
+def test_resolve_project_name_drops_invalid_characters() -> None:
+    """Characters outside [a-z0-9_-] are dropped."""
+    assert resolve_project_name({"project_name": "proj@2024!"}) == "proj2024"
+    assert resolve_project_name({"project_name": "a.b/c:d"}) == "abcd"
+
+
+def test_resolve_project_name_strips_leading_invalid_chars() -> None:
+    """Leading ``_``/``-`` are stripped so the name starts with a letter or number."""
+    assert resolve_project_name({"project_name": "-leading-dash"}) == "leading-dash"
+    assert resolve_project_name({"project_name": "__underscored"}) == "underscored"
+    assert resolve_project_name({"project_name": "-_-mixed"}) == "mixed"
+
+
+def test_resolve_project_name_normalizes_project_root_fallback() -> None:
+    """The basename(project_root) fallback is normalized just like project_name."""
+    assert resolve_project_name({"project_root": "/home/user/My Facility"}) == "myfacility"
+
+
+def test_resolve_project_name_all_invalid_falls_back_to_default() -> None:
+    """A candidate with no valid characters falls back to ``unnamed-project``."""
+    assert resolve_project_name({"project_name": "@#$%"}) == "unnamed-project"
+    assert resolve_project_name({"project_name": "---"}) == "unnamed-project"
+
+
+def test_resolve_project_name_empty_config_uses_default() -> None:
+    """With neither project_name nor project_root, the default name applies."""
+    assert resolve_project_name({}) == "unnamed-project"

--- a/tests/deployment/test_gitlab_ci_template.py
+++ b/tests/deployment/test_gitlab_ci_template.py
@@ -1,0 +1,78 @@
+"""Security regression tests for the shipped ``.gitlab-ci.yml`` template.
+
+The ``osprey-build`` job assembles ``.env.production`` from masked CI variables
+via a heredoc. That file is COPYed into the runtime web-terminal image, so it
+must contain only the runtime secrets the running containers need — never the
+build/push/registry tokens that gate CI-registry access.
+
+These tests lock in that heredoc's contents against the same allowlist the
+local-mode deploy path enforces in
+``osprey.deployment.container_lifecycle._build_env_production_subset`` (its
+docstring is the security spec). They mirror the local-path token-absence tests
+in ``tests/deployment/test_container_lifecycle.py``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+import osprey
+
+TEMPLATE_PATH = (
+    Path(osprey.__file__).parent
+    / "templates"
+    / "skills"
+    / "osprey-build-deploy"
+    / "templates"
+    / "core"
+    / ".gitlab-ci.yml"
+)
+
+
+@pytest.fixture(scope="module")
+def template_text() -> str:
+    return TEMPLATE_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def env_production_heredoc(template_text: str) -> str:
+    """Return only the body of the ``.env.production`` heredoc.
+
+    The template documents ``ci.token_env_var`` elsewhere (the header comment
+    listing required CI/CD variables — legitimately, that token still gates
+    build/push), so the token-absence assertions must be scoped to the heredoc
+    body, not the whole file.
+    """
+    match = re.search(
+        r"cat > \.env\.production << ENVEOF\n(.*?)\n\s*ENVEOF",
+        template_text,
+        re.DOTALL,
+    )
+    assert match, "could not locate the .env.production heredoc in the template"
+    return match.group(1)
+
+
+def test_ci_token_absent_from_env_production(env_production_heredoc: str) -> None:
+    """The CI/registry token must never be written into ``.env.production``."""
+    assert "ci.token_env_var" not in env_production_heredoc
+    assert "token_env_var}=${env.${config.ci." not in env_production_heredoc
+
+
+def test_sidecar_token_absent_from_env_production(env_production_heredoc: str) -> None:
+    """The dispatcher sidecar token gates build/push, not runtime — excluded."""
+    assert "sidecar_token_env_var" not in env_production_heredoc
+
+
+def test_allowlisted_vars_present_in_env_production(env_production_heredoc: str) -> None:
+    """The heredoc still writes the runtime secrets the allowlist permits.
+
+    Guards against an over-broad edit that strips the whole heredoc: these are
+    the entries ``_build_env_production_subset`` enumerates.
+    """
+    assert "${config.llm.api_key_env_var}" in env_production_heredoc
+    assert "${config.modules.event_dispatcher.token_env_var}" in env_production_heredoc
+    assert "ARIEL_DSN=" in env_production_heredoc
+    assert "TZ=" in env_production_heredoc


### PR DESCRIPTION
Two small, independently reviewable fixes ahead of the P5 capstone:

- **fix(scaffold): drop build tokens from CI template .env.production** — the scaffolded GitLab CI template's osprey-build job wrote the CI and dispatch-sidecar token values into `.env.production`. The written set now aligns with the runtime env allowlist, pinned by a new template test.
- **fix(deploy): compose-normalize resolve_project_name** — normalize (lowercase, invalid characters, valid leading character) at the single source so `COMPOSE_PROJECT_NAME`, labels, image tags, and volume names agree for mixed-case or spaced project roots.

Both are unit-tested in the light per-phase gate. No deployments exist that depend on the previous raw project names, so no migration notes.