### PR TITLE
fix: limits-database failsafe, device guard, bluesky stack as core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,12 @@ jobs:
       # import softioc, which lives in the virtual-accelerator extra (not dev).
       # Without it these unit tests error at collection on a fresh runner.
       #
-      # bluesky-bridge: tests/services/bluesky_bridge/* import bluesky,
-      # ophyd_async and tiled. Most guard with `pytest.importorskip`, so without
-      # this extra they do not error — they SKIP, and the bridge's runner,
-      # RunEngine integration and Tiled fault-isolation guards silently never
-      # run. test_ci_workflow_wiring.py pins this extra for that reason.
-      run: uv sync --extra dev --extra virtual-accelerator --extra bluesky-bridge
+      # The bluesky stack (bluesky/ophyd-async/tiled) is a core dependency, so
+      # plain `uv sync` carries it. tests/services/bluesky_bridge/* guard their
+      # imports with `pytest.importorskip` and would SKIP silently if the stack
+      # ever left the install set — test_ci_workflow_wiring.py pins the stack in
+      # [project] dependencies for that reason.
+      run: uv sync --extra dev --extra virtual-accelerator
 
     - name: Run unit tests
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,13 @@ dependencies = [
     # optional — the VA is exercised in almost all deployments, and PyAT
     # (accelerator-toolbox above) is already core, so the IOC toolkit joins it.
     "softioc",
+    # Bluesky scan stack (osprey.services.bluesky_bridge): RunEngine, ophyd-async
+    # devices, and the Tiled writer/reader. Core, not optional — Bluesky is a
+    # core part of OSPREY, joining PyAT/softioc above. ophyd-async's [ca] brings
+    # the aioca Channel Access backend the EPICS substrate devices need.
+    "bluesky>=1.15.1",
+    "ophyd-async[ca]>=0.16,<1.0",
+    "tiled[client]>=0.1",
     "duckdb>=1.5.1",
     "tenacity>=9.1.4",
     # Cross-version TypedDict/NotRequired — pydantic v2.12 rejects typing.TypedDict on py<3.12.
@@ -192,34 +199,12 @@ screen-capture-linux = [
     "python-xlib>=0.33",
 ]
 
-# Bluesky bridge (osprey.services.bluesky_bridge): the RunEngine, ophyd-async
-# devices, and Tiled writer/reader the bridge's Phase 2 submodules (plans.py,
-# plan_runner_bluesky.py, devices/*.py) import behind this extra. The bridge's
-# lifecycle core (app.py, runs.py, security.py, plan_runner.py) stays import-clean
-# of all of these — installed only in the bridge process's own container venv,
-# never required in OSPREY's main venv. fastapi/uvicorn/httpx are already core
-# dependencies, so they're not repeated here.
-bluesky-bridge = [
-    "bluesky>=1.15.1",
-    # [ca]: the aioca Channel Access backend. Required for the real EPICS-on-VA
-    # substrate scanner (EpicsMotor/EpicsDetector over epics_signal_*); without
-    # it ophyd-async's CA transport is unavailable and device construction
-    # raises "Protocol ca not available". The mock-device demo scanner doesn't
-    # need it, which is why it went unnoticed until the substrate keystone.
-    "ophyd-async[ca]>=0.16,<1.0",
-    "tiled[client]>=0.1",
-]
-
 # Virtual Accelerator: kept as an empty alias for back-compat. `softioc` is now
 # a core dependency (see [project] dependencies), so this extra installs nothing
 # extra. Retained so existing `osprey-framework[virtual-accelerator]` references
 # (CI `uv sync --extra`, the VA image Dockerfile, and pinned older-version image
 # builds where softioc was still gated here) keep resolving.
 virtual-accelerator = []
-
-# bluesky_panels sidecar: fastapi/uvicorn[standard]/httpx are already core deps;
-# this extra exists so the service image can install osprey-framework[bluesky-panels].
-bluesky-panels = []
 
 # All optional dependencies for complete installation
 all = [
@@ -288,8 +273,8 @@ ignore_missing_imports = true
 
 # Bluesky bridge (osprey.services.bluesky_bridge): the lifecycle core (runs.py,
 # app.py, security.py, plan_runner.py) stays import-clean of these, but Phase 2's
-# submodules (plan_runner_bluesky.py, devices/epics.py, plans.py, ...) will import
-# them behind the optional `osprey-framework[bluesky-bridge]` extra.
+# submodules (plan_runner_bluesky.py, devices/epics.py, plans.py, ...) import
+# them from the bluesky stack (now a core dependency).
 [[tool.mypy.overrides]]
 module = [
     "bluesky.*",

--- a/src/osprey/connectors/control_system/limits_validator.py
+++ b/src/osprey/connectors/control_system/limits_validator.py
@@ -109,7 +109,19 @@ class LimitsValidator:
                     logger.debug(f"Resolved limits database path: {resolved_path}")
             db_path = resolved_path
 
-            limits_db, raw_db = cls._load_limits_database(db_path)
+            try:
+                limits_db, raw_db = cls._load_limits_database(db_path)
+            except ValueError as e:
+                # Same failsafe as the missing-database-path case above: a
+                # missing/unparseable database must never crash the connector
+                # (a read-only deployment needs no limits) nor silently disable
+                # checking (returning None would leave writes unchecked) — an
+                # empty DB blocks every write with a clear refusal instead.
+                logger.warning(
+                    f"Limits checking enabled but the database at {db_path} could not "
+                    f"be read or parsed - blocking all writes. {e}"
+                )
+                return cls({}, {}, {})  # Empty DB = blocks all (failsafe)
             logger.debug(f"Loaded limits database with {len(limits_db)} channels")
 
             policy = {

--- a/src/osprey/services/bluesky_bridge/app.py
+++ b/src/osprey/services/bluesky_bridge/app.py
@@ -42,10 +42,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger("osprey.services.bluesky_bridge.app")
 
 # Root package names the demo-runner lifespan hook below is allowed to fail
-# on — i.e. the bridge running without the `bluesky-bridge` extra installed.
-# An ImportError naming anything else (e.g. a module missing an expected
-# attribute, or an unrelated third-party import broke) is a genuine bug and
-# must not be swallowed as "bluesky is just absent".
+# on — i.e. the bridge running without the bluesky stack importable. The stack
+# is a core dependency, so this normally succeeds; the guard stays for slimmed
+# images or partial installs. An ImportError naming anything else (e.g. a module
+# missing an expected attribute, or an unrelated third-party import broke) is a
+# genuine bug and must not be swallowed as "bluesky is just absent".
 _BRIDGE_ONLY_MODULES = {"bluesky", "ophyd", "ophyd_async", "tiled"}
 
 # Opt-in flag (task 2.14a): when truthy (see `_is_demo_runner_enabled`) AND
@@ -329,7 +330,7 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
             if root_name not in _BRIDGE_ONLY_MODULES:
                 raise
             logger.warning(
-                "%s is enabled but the bluesky-bridge extra is not installed "
+                "%s is enabled but the bluesky stack is not importable "
                 "(%s not found); falling back to FakePlanRunner",
                 _EPICS_SUBSTRATE_ENV,
                 exc.name,
@@ -469,7 +470,7 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
             if root_name not in _BRIDGE_ONLY_MODULES:
                 raise
             logger.warning(
-                "%s is enabled but the bluesky-bridge extra is not installed "
+                "%s is enabled but the bluesky stack is not importable "
                 "(%s not found); falling back to FakePlanRunner",
                 _DEMO_RUNNER_ENV,
                 exc.name,

--- a/src/osprey/services/bluesky_bridge/devices/__init__.py
+++ b/src/osprey/services/bluesky_bridge/devices/__init__.py
@@ -1,11 +1,10 @@
 """ophyd-async device factories for the Bluesky bridge.
 
-Both submodules (``mock.py``, ``connector.py``) import ophyd-async and live
-behind the optional ``osprey-framework[bluesky-bridge]`` extra — this package
-(and its submodules) must never be imported from the bridge lifecycle core
-(``app.py``, ``runs.py``, ``plan_runner.py``, ``security.py``), which stays
-import-clean of bluesky/ophyd so it can be built and unit-tested without the
-extra installed. This ``__init__.py`` itself imports nothing from either
+Both submodules (``mock.py``, ``connector.py``) import ophyd-async. ophyd-async
+is a core dependency, but this package (and its submodules) must still never be
+imported from the bridge lifecycle core (``app.py``, ``runs.py``,
+``plan_runner.py``, ``security.py``), which stays import-clean of bluesky/ophyd
+so it can be built and unit-tested without loading the device stack. This ``__init__.py`` itself imports nothing from either
 submodule, so ``from osprey.services.bluesky_bridge import devices`` alone
 stays cheap; callers import ``devices.mock`` or ``devices.connector``
 explicitly. There is no raw Channel Access device factory in this package —

--- a/src/osprey/services/bluesky_bridge/devices/_connect.py
+++ b/src/osprey/services/bluesky_bridge/devices/_connect.py
@@ -4,10 +4,9 @@ Both factories (``mock.py``, ``epics.py``) build a ``{name: device}`` mapping
 whose entries exist only as dict values, then connect them. That connect step
 is centralized here so its non-obvious rationale lives in exactly one place.
 
-Imports ophyd-async, so (like the rest of ``devices/``) this module lives
-behind the optional ``osprey-framework[bluesky-bridge]`` extra — keep it out of
-the bridge lifecycle core's import path (``app.py``, ``runs.py``,
-``plan_runner.py``, ``security.py``).
+Imports ophyd-async (a core dependency), so like the rest of ``devices/`` keep
+it out of the bridge lifecycle core's import path (``app.py``, ``runs.py``,
+``plan_runner.py``, ``security.py``), which stays import-clean of ophyd.
 """
 
 from __future__ import annotations

--- a/src/osprey/services/bluesky_bridge/devices/connector.py
+++ b/src/osprey/services/bluesky_bridge/devices/connector.py
@@ -25,10 +25,10 @@ internal extension point, while ``StandardReadable``'s ``set``/``read``/
 ``describe``/``connect`` are the stable public device contract that plans
 and the RunEngine actually consume.
 
-Imports ophyd-async, so this module (like the rest of ``devices/``) lives
-behind the optional ``osprey-framework[bluesky-bridge]`` extra — keep it
-out of the bridge lifecycle core's import path (``app.py``, ``runs.py``,
-``plan_runner.py``, ``security.py``).
+Imports ophyd-async (a core dependency), so this module (like the rest of
+``devices/``) is kept out of the bridge lifecycle core's import path
+(``app.py``, ``runs.py``, ``plan_runner.py``, ``security.py``), which stays
+import-clean of ophyd.
 """
 
 from __future__ import annotations
@@ -219,7 +219,17 @@ async def build_devices(
 
     Returns:
         Mapping of device name to connected device instance.
+
+    Raises:
+        ValueError: If ``connector`` is None — failing here, at the
+            misconfiguration site, instead of as an ``AttributeError`` deep
+            inside a device's ``set()``/``read()`` at scan time.
     """
+    if connector is None:
+        raise ValueError(
+            "build_devices requires a connector — every built device delegates "
+            "its reads and writes to it"
+        )
     devices: dict[str, Any] = {}
     for settable_spec in settables:
         devices[settable_spec.name] = ConnectorSettable(

--- a/src/osprey/services/bluesky_bridge/devices/mock.py
+++ b/src/osprey/services/bluesky_bridge/devices/mock.py
@@ -25,13 +25,13 @@ Reimplements the shape of ``ophyd_async.sim.SimMotor``/``SimPointDetector``
 (soft position signal with instant "move"; a triggerable soft readout) rather
 than importing ``ophyd_async.sim`` directly: that package's ``__init__``
 eagerly imports ``SimBlobDetector``, which pulls in ``h5py`` — a dependency
-this bridge's ``bluesky-bridge`` extra does not declare and does not need for
+OSPREY's core dependencies do not declare and this bridge does not need for
 a plain motor + detector.
 
-Imports ophyd-async, so this module (like the rest of ``devices/``) lives
-behind the optional ``osprey-framework[bluesky-bridge]`` extra — keep it out
-of the bridge lifecycle core's import path (``app.py``, ``runs.py``,
-``plan_runner.py``, ``security.py``).
+Imports ophyd-async (a core dependency), so this module (like the rest of
+``devices/``) is kept out of the bridge lifecycle core's import path
+(``app.py``, ``runs.py``, ``plan_runner.py``, ``security.py``), which stays
+import-clean of ophyd.
 """
 
 from __future__ import annotations

--- a/src/osprey/services/bluesky_bridge/devices/specs.py
+++ b/src/osprey/services/bluesky_bridge/devices/specs.py
@@ -4,8 +4,7 @@ These describe *what* a device is (a settable setpoint/readback pair, or a
 read-only value) without naming the control system that backs it. Kept in
 their own module, free of ``ophyd_async`` imports and any raw Channel Access
 client library, so consumers that only need the shape (e.g. env parsing) can
-import it without pulling in the optional ``osprey-framework[bluesky-bridge]``
-extra's device stack.
+import it without pulling in ``ophyd_async`` or the rest of the device stack.
 """
 
 from __future__ import annotations

--- a/src/osprey/services/bluesky_bridge/orm_analysis.py
+++ b/src/osprey/services/bluesky_bridge/orm_analysis.py
@@ -3,8 +3,9 @@
 Consumes the plain `dict` rows an `orm` plan run emits (bluesky's event
 document `data`, one dict per point — see `plans_core/orm.py`'s `build_plan`), never a
 live-buffer or Tiled-specific shape, so this module has no dependency on
-`bluesky`/`ophyd-async`/`tiled` and imports cleanly on the MCP side (where the
-`bluesky-bridge` extra is not installed).
+`bluesky`/`ophyd-async`/`tiled` and imports cleanly on the MCP side without
+loading the bluesky stack (a core dependency, but heavier than this pure-numpy
+analysis needs).
 
 Three pieces:
 

--- a/src/osprey/services/bluesky_bridge/plan_loader.py
+++ b/src/osprey/services/bluesky_bridge/plan_loader.py
@@ -56,8 +56,9 @@ principled tie-breaker beyond scan order.
 
 Deliberately free of bluesky/ophyd/tiled imports — this module only execs
 plan files and reads pydantic metadata; only a loaded module itself needs
-bluesky. That keeps `plan_loader.py` importable in any bridge process
-regardless of whether the `bluesky-bridge` extra is installed.
+bluesky. The bluesky stack is a core dependency now, but keeping this module
+import-clean of it still lets `plan_loader.py` be imported in any bridge process
+without loading the RunEngine.
 """
 
 from __future__ import annotations

--- a/src/osprey/services/bluesky_bridge/plan_runner.py
+++ b/src/osprey/services/bluesky_bridge/plan_runner.py
@@ -3,10 +3,11 @@
 ``PlanRunner`` is the boundary the lifecycle core (``runs.py``'s ``do_launch``) is
 written against. The real implementation (a bluesky ``RunEngine`` in a daemon
 thread, wired to ophyd-async devices and a ``TiledWriter``) lives in
-``plan_runner_bluesky.py``, behind the ``osprey-framework[bluesky-bridge]`` extra.
-Everything in this module — the Protocol and ``FakePlanRunner`` — has no
-bluesky/ophyd/tiled dependency, so the lifecycle core can be built, imported, and
-unit-tested before that extra ever needs to be installed.
+``plan_runner_bluesky.py``. The bluesky stack (bluesky/ophyd-async/tiled) is a
+core dependency, so that module always imports; this seam is an import-hygiene
+boundary, not an install-size one. Everything in this module — the Protocol and
+``FakePlanRunner`` — has no bluesky/ophyd/tiled dependency, so the lifecycle core
+can be built, imported, and unit-tested without loading the RunEngine.
 """
 
 from __future__ import annotations

--- a/src/osprey/services/bluesky_bridge/plan_runner_bluesky.py
+++ b/src/osprey/services/bluesky_bridge/plan_runner_bluesky.py
@@ -1,11 +1,11 @@
 """The real bluesky-backed ``PlanRunner``: a RunEngine in a daemon thread.
 
 Implements the injected ``PlanRunner`` seam (``plan_runner.py``) that ``do_launch``
-builds per launched run. Imports bluesky, so this module lives behind the
-optional ``osprey-framework[bluesky-bridge]`` extra — it must never be
-imported from the lifecycle core's import path (``app.py``, ``runs.py``,
-``plan_runner.py``, ``security.py`` stay import-clean); only a deploy wiring or a
-bluesky-capable test imports this module directly.
+builds per launched run. Imports bluesky; the bluesky stack is a core dependency
+now, but this module must still never be imported from the lifecycle core's
+import path (``app.py``, ``runs.py``, ``plan_runner.py``, ``security.py`` stay
+import-clean of the RunEngine) — only a deploy wiring or a bluesky-capable test
+imports this module directly.
 
 Plan resolution happens entirely inside ``reinitialize()``: ``exec_config``
 (the bridge's ``RunRequest`` — ``plan_name`` + ``plan_args``, or an equivalent

--- a/src/osprey/templates/services/bluesky/Dockerfile
+++ b/src/osprey/templates/services/bluesky/Dockerfile
@@ -7,9 +7,9 @@
 #     build context; if a *.whl is present we install that (so unreleased code
 #     is included).
 #   * prod builds — no wheel present, so install the pinned release from PyPI.
-# Both paths install the `bluesky-bridge` extra on top of the framework's core
-# FastAPI/uvicorn deps, pulling in bluesky/ophyd-async/tiled for the real
-# (non-Fake) PlanRunner implementation.
+# The framework's core dependencies already include bluesky/ophyd-async/tiled
+# (Bluesky is a core part of OSPREY), so a plain install carries everything the
+# real (non-Fake) PlanRunner implementation needs.
 # This image is built locally by `osprey deploy up`; override with
 # OSPREY_BLUESKY_BRIDGE_IMAGE to use a prebuilt/published image.
 
@@ -27,13 +27,13 @@ RUN apt-get update \
     && if ls /tmp/ctx/*.whl >/dev/null 2>&1; then \
         echo "Installing osprey from local wheel (dev build)" \
         && whl="$(ls /tmp/ctx/*.whl | head -n1)" \
-        && pip install --no-cache-dir "${whl}[bluesky-bridge]" ; \
+        && pip install --no-cache-dir "${whl}" ; \
     elif [ -n "$OSPREY_VERSION" ]; then \
-        echo "Installing osprey-framework[bluesky-bridge]==$OSPREY_VERSION from PyPI" \
-        && pip install --no-cache-dir "osprey-framework[bluesky-bridge]==$OSPREY_VERSION" ; \
+        echo "Installing osprey-framework==$OSPREY_VERSION from PyPI" \
+        && pip install --no-cache-dir "osprey-framework==$OSPREY_VERSION" ; \
     else \
-        echo "Installing osprey-framework[bluesky-bridge] (latest) from PyPI" \
-        && pip install --no-cache-dir "osprey-framework[bluesky-bridge]" ; \
+        echo "Installing osprey-framework (latest) from PyPI" \
+        && pip install --no-cache-dir "osprey-framework" ; \
     fi \
     && apt-get purge -y build-essential python3-dev \
     && apt-get autoremove -y \

--- a/src/osprey/templates/services/bluesky/docker-compose.yml.j2
+++ b/src/osprey/templates/services/bluesky/docker-compose.yml.j2
@@ -149,7 +149,7 @@ services:
       timeout: 5s
       retries: 5
       # Grace period before failed probes count — uvicorn/FastAPI startup and
-      # the first image build (which bakes in the bluesky-bridge extra's
+      # the first image build (which bakes in the bluesky stack's
       # dependencies at build time, not at container start) take a few seconds.
       start_period: 15s
 {% if services.bluesky.tiled_enabled | default(false) %}

--- a/src/osprey/templates/services/bluesky_panels/Dockerfile
+++ b/src/osprey/templates/services/bluesky_panels/Dockerfile
@@ -8,8 +8,8 @@
 #     build context; if a *.whl is present we install that (so unreleased code
 #     is included).
 #   * prod builds — no wheel present, so install the pinned release from PyPI.
-# Both paths install the `bluesky-panels` extra on top of the framework's core
-# FastAPI/uvicorn/httpx deps.
+# The framework's core FastAPI/uvicorn/httpx deps cover everything this
+# sidecar needs, so both paths are a plain install.
 # This image is built locally by `osprey deploy up`; override with
 # OSPREY_BLUESKY_PANELS_IMAGE to use a prebuilt/published image.
 
@@ -27,13 +27,13 @@ RUN apt-get update \
     && if ls /tmp/ctx/*.whl >/dev/null 2>&1; then \
         echo "Installing osprey from local wheel (dev build)" \
         && whl="$(ls /tmp/ctx/*.whl | head -n1)" \
-        && pip install --no-cache-dir "${whl}[bluesky-panels]" ; \
+        && pip install --no-cache-dir "${whl}" ; \
     elif [ -n "$OSPREY_VERSION" ]; then \
-        echo "Installing osprey-framework[bluesky-panels]==$OSPREY_VERSION from PyPI" \
-        && pip install --no-cache-dir "osprey-framework[bluesky-panels]==$OSPREY_VERSION" ; \
+        echo "Installing osprey-framework==$OSPREY_VERSION from PyPI" \
+        && pip install --no-cache-dir "osprey-framework==$OSPREY_VERSION" ; \
     else \
-        echo "Installing osprey-framework[bluesky-panels] (latest) from PyPI" \
-        && pip install --no-cache-dir "osprey-framework[bluesky-panels]" ; \
+        echo "Installing osprey-framework (latest) from PyPI" \
+        && pip install --no-cache-dir "osprey-framework" ; \
     fi \
     && apt-get purge -y build-essential python3-dev \
     && apt-get autoremove -y \

--- a/src/osprey/templates/services/bluesky_panels/docker-compose.yml.j2
+++ b/src/osprey/templates/services/bluesky_panels/docker-compose.yml.j2
@@ -89,7 +89,7 @@ services:
       timeout: 5s
       retries: 5
       # Grace period before failed probes count — uvicorn/FastAPI startup and
-      # the first image build (which bakes in the bluesky-panels extra's
+      # the first image build (which bakes in the sidecar's
       # dependencies at build time, not at container start) take a few seconds.
       start_period: 15s
 

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -276,40 +276,39 @@ def _unit_test_install_cmd(wf: dict[str, Any]) -> str:
     return _find_named_step(wf, UNIT_TEST_JOB, "Install dependencies")["run"]
 
 
-def test_unit_test_job_installs_bridge_extras(workflow: dict[str, Any]) -> None:
-    """The bridge's unit tests guard their imports with `pytest.importorskip`,
-    so a missing extra does not error — it SKIPS. Without `bluesky-bridge` the
-    scanner, RunEngine-integration and Tiled fault-isolation guards vanish from
-    CI silently, inside a green check. This pins the extra so that cannot recur.
-
-    `virtual-accelerator` is pinned for the opposite reason: tests/va/* import
-    softioc unguarded and error at collection without it.
-    """
+def test_unit_test_job_installs_required_extras(workflow: dict[str, Any]) -> None:
+    """tests/va/* import softioc unguarded and error at collection without the
+    `virtual-accelerator` extra (an empty back-compat alias today, but pinned so
+    older-version builds keep resolving); `dev` carries pytest itself."""
     cmd = _unit_test_install_cmd(workflow)
-    for extra in ("dev", "virtual-accelerator", "bluesky-bridge"):
+    for extra in ("dev", "virtual-accelerator"):
         assert f"--extra {extra}" in cmd, (
             f"unit-test job must `uv sync --extra {extra}`; got: {cmd}"
         )
 
 
-def test_unit_test_job_installs_bridge_extras__mutation_drops_bluesky_extra() -> None:
-    """Dropping the bluesky-bridge extra must fail — otherwise the guard is
-    decorative and the bridge tests resume skipping unnoticed."""
+def test_unit_test_job_installs_required_extras__mutation_drops_extra() -> None:
+    """Dropping a pinned extra must fail — otherwise the guard is decorative."""
     mutated = copy.deepcopy(_load_workflow())
     step = _find_named_step(mutated, UNIT_TEST_JOB, "Install dependencies")
-    step["run"] = step["run"].replace(" --extra bluesky-bridge", "")
+    step["run"] = step["run"].replace(" --extra virtual-accelerator", "")
     with pytest.raises(AssertionError):
-        test_unit_test_job_installs_bridge_extras(mutated)
+        test_unit_test_job_installs_required_extras(mutated)
 
 
-def test_bluesky_bridge_extra_is_declared_in_pyproject() -> None:
-    """The extra the CI job installs must actually exist. A typo'd `--extra`
-    makes `uv sync` fail loudly, but pinning the name here fails faster and
-    names the contract in one place."""
+def test_bluesky_stack_is_a_core_dependency() -> None:
+    """The bridge's unit tests guard their imports with `pytest.importorskip`,
+    so a missing bluesky stack does not error — it SKIPS, and the scanner,
+    RunEngine-integration and Tiled fault-isolation guards vanish from CI
+    silently, inside a green check. Bluesky is a core part of OSPREY: pin the
+    stack in [project] dependencies so plain `uv sync` always installs it and
+    those tests can never resume skipping unnoticed."""
     pyproject = tomllib.loads((CI_YML.parents[2] / "pyproject.toml").read_text())
-    extras = pyproject["project"]["optional-dependencies"]
-    assert "bluesky-bridge" in extras
-    assert any(dep.startswith("bluesky") for dep in extras["bluesky-bridge"])
+    core_deps = pyproject["project"]["dependencies"]
+    for stack_dep in ("bluesky", "ophyd-async", "tiled"):
+        assert any(dep.startswith(stack_dep) for dep in core_deps), (
+            f"{stack_dep} must be a core dependency"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_bluesky_deploy.py
+++ b/tests/e2e/test_bluesky_deploy.py
@@ -29,10 +29,11 @@ pre-existing process during development of this test.
 Asserts, against the REAL deployed container:
   * the bridge binds to 127.0.0.1 (never 0.0.0.0) — ``docker port`` inspection.
   * BLUESKY_LAUNCH_TOKEN was minted into the project ``.env`` (task 2.10).
-  * the built image contains the unreleased bluesky_bridge modules AND the
-    bluesky-bridge extra (task 2.8's reviewer carry-forward) — NOT merely
-    that the image builds, since a PyPI-based build would silently lack both
-    and this must fail loudly rather than pass on stale code.
+  * the built image contains the unreleased bluesky_bridge modules (task 2.8's
+    reviewer carry-forward) — NOT merely that the image builds, since a
+    PyPI-based build would silently lack them and this must fail loudly rather
+    than pass on stale code. Importing them also exercises the bluesky stack
+    (a core dependency), which must be present for the real PlanRunner.
   * a demo ``grid_scan`` against mock devices (``motor1``/``det1``) launches,
     runs to completion, and ``GET /runs/{id}/data`` returns the buffered rows.
 
@@ -263,12 +264,12 @@ def test_launch_token_was_minted(deployed_bridge: Path) -> None:
 def test_image_contains_unreleased_bluesky_bridge_modules(deployed_bridge: Path) -> None:
     """Carry-forward from the 2.8 reviewer: assert CONTENT, not just "it builds".
 
-    A PyPI-based (non---dev) build would lack both the unreleased
-    bluesky_bridge submodules and the bluesky-bridge extra on the current
-    release — this would still "build" (pip just installs the released
+    A PyPI-based (non---dev) build would lack the unreleased bluesky_bridge
+    submodules — this would still "build" (pip just installs the released
     package), so a green build alone is not proof of anything. Import each
-    module inside the running container to prove the --dev wheel + extra
-    both landed.
+    module inside the running container to prove the --dev wheel landed; the
+    imports also pull in the bluesky stack (a core dependency), proving it is
+    present for the real PlanRunner.
     """
     failures: list[str] = []
     for module in _BLUESKY_BRIDGE_ONLY_MODULES:
@@ -282,7 +283,7 @@ def test_image_contains_unreleased_bluesky_bridge_modules(deployed_bridge: Path)
             failures.append(f"{module}: {proc.stderr.strip()}")
     assert not failures, (
         "built image is missing unreleased bluesky_bridge modules or the "
-        "bluesky-bridge extra deps (bluesky/ophyd-async) — was it built "
+        "bluesky stack (bluesky/ophyd-async) — was it built "
         "with --dev?\n  " + "\n  ".join(failures)
     )
 

--- a/tests/services/bluesky_bridge/test_app_import_clean.py
+++ b/tests/services/bluesky_bridge/test_app_import_clean.py
@@ -1,8 +1,9 @@
 """Guards `app.py`'s `_BRIDGE_ONLY_MODULES` invariant (FR8): importing
 `osprey.services.bluesky_bridge.app` must never pull in `bluesky`, `ophyd`,
-`ophyd_async`, or `tiled`. A top-level import of any of those in `app.py`
-would 500 the bridge at import time in any deploy lacking the
-`bluesky-bridge` extra.
+`ophyd_async`, or `tiled`. The bluesky stack is a core dependency, so this is
+an import-hygiene boundary, not an install-size one: keeping those heavy
+imports out of the lifecycle core's import path keeps the bridge's startup
+import fast and the lifecycle/FakePlanRunner seam clean.
 
 This MUST run in a fresh subprocess. The dev venv has all four packages
 installed, and other tests in this suite legitimately import them, so by

--- a/tests/services/bluesky_bridge/test_builtin_plans.py
+++ b/tests/services/bluesky_bridge/test_builtin_plans.py
@@ -10,11 +10,12 @@ covers what that one doesn't: each plan's own `PARAMS` schema in isolation,
 and (task 2.3, CC-1) the `orm` plan's restore-in-`finally` abort safety,
 which only its own generator body can exercise.
 
-Every test here is skipped via `pytest.importorskip` when bluesky is absent,
-keeping the import-clean fast lane green. To run these:
+The bluesky stack is a core dependency, so these run in the normal unit lane;
+the `pytest.importorskip` guard only skips them in a slimmed install where
+bluesky is absent. To run this file in an isolated venv:
 
     uv venv /tmp/bluesky-scratch
-    /tmp/bluesky-scratch/bin/pip install -e '.[bluesky-bridge]'
+    /tmp/bluesky-scratch/bin/pip install -e .
     /tmp/bluesky-scratch/bin/python -m pytest \
         tests/services/bluesky_bridge/test_builtin_plans.py -q
 """

--- a/tests/services/bluesky_bridge/test_connector_devices.py
+++ b/tests/services/bluesky_bridge/test_connector_devices.py
@@ -6,7 +6,7 @@ never installed in the main worktree venv, so every test here is skipped via
 bluesky installed at all. To actually run this file:
 
     uv venv /tmp/bluesky-connector-scratch
-    /tmp/bluesky-connector-scratch/bin/pip install -e '.[bluesky-bridge]' --python 3.11
+    /tmp/bluesky-connector-scratch/bin/pip install -e . --python 3.11
     /tmp/bluesky-connector-scratch/bin/python -m pytest \
         tests/services/bluesky_bridge/test_connector_devices.py -q
 
@@ -190,6 +190,13 @@ async def test_build_devices_with_no_specs_returns_empty_mapping() -> None:
     """An empty settables/readables sequence builds an empty (but valid) device set."""
     devices = await build_devices(connector=FakeConnector())
     assert devices == {}
+
+
+async def test_build_devices_without_connector_raises_at_build_time() -> None:
+    """A missing connector fails here, at the misconfiguration site — not as an
+    ``AttributeError`` deep inside a device's ``set()``/``read()`` at scan time."""
+    with pytest.raises(ValueError, match="requires a connector"):
+        await build_devices(settables=[SettableSpec(name="hcm1", setpoint_pv="HCM1:SP")])
 
 
 def test_module_does_not_import_raw_channel_access() -> None:

--- a/tests/services/bluesky_bridge/test_epics_substrate_runner_wiring.py
+++ b/tests/services/bluesky_bridge/test_epics_substrate_runner_wiring.py
@@ -20,9 +20,9 @@ absent or the flag is unset. Exercised here:
   `connector_devices.build_devices(motors, detectors, connector)`, built
   from `BLUESKY_EPICS_MOTORS`/`BLUESKY_EPICS_DETECTORS` and the bridge's
   single long-lived connector.
-- Flag truthy but the bluesky-bridge extra absent: guarded fallback to
+- Flag truthy but the bluesky stack not importable: guarded fallback to
   `FakePlanRunner`, simulated by forcing `ophyd_async` out of `sys.modules` (see
-  `_ophyd_async_absent`) since this environment actually has the extra
+  `_ophyd_async_absent`) since this environment actually has the stack
   installed.
 - Both `BLUESKY_EPICS_SUBSTRATE` and `BLUESKY_DEMO_RUNNER` set: the EPICS
   substrate wins, with a warning logged.
@@ -76,8 +76,8 @@ def _ophyd_async_absent(monkeypatch: pytest.MonkeyPatch):
     """Force `from .devices import connector as connector_devices` to raise
     ImportError(name="ophyd_async...").
 
-    This environment actually has the `bluesky-bridge` extra installed, so
-    the only way to exercise the "extra not installed" fallback branch is to
+    This environment actually has the bluesky stack installed, so
+    the only way to exercise the "stack not importable" fallback branch is to
     simulate it: purge the bridge's `devices` submodules from `sys.modules`
     (so the next import is not served from cache) and set `ophyd_async` to
     `None` there — the documented sentinel that makes the import machinery
@@ -146,7 +146,7 @@ def test_flag_unset_stays_import_clean_and_keeps_fake_scanner_default() -> None:
 
 
 # =========================================================================
-# Flag truthy but the bluesky-bridge extra absent: guarded fallback, no crash
+# Flag truthy but the bluesky stack not importable: guarded fallback, no crash
 # =========================================================================
 
 

--- a/tests/services/bluesky_bridge/test_exemplar_plans.py
+++ b/tests/services/bluesky_bridge/test_exemplar_plans.py
@@ -7,7 +7,7 @@ never installed in the main worktree venv, so every test here is skipped via
 bluesky installed at all. To actually run this file:
 
     uv venv /tmp/bluesky-exemplar-scratch
-    /tmp/bluesky-exemplar-scratch/bin/pip install -e '.[bluesky-bridge]' --python 3.11
+    /tmp/bluesky-exemplar-scratch/bin/pip install -e . --python 3.11
     /tmp/bluesky-exemplar-scratch/bin/python -m pytest \
         tests/services/bluesky_bridge/test_exemplar_plans.py -q
 

--- a/tests/services/bluesky_bridge/test_lifespan_connector.py
+++ b/tests/services/bluesky_bridge/test_lifespan_connector.py
@@ -4,7 +4,7 @@
 `ConnectorFactory.create_control_system_connector`, built from the project's
 `control_system.type` (task 3.4; fail-safe default `"mock"`) — whenever the
 EPICS substrate is enabled (`_is_epics_substrate_enabled()`) and the
-bluesky-bridge extra is importable, holds it as the module-level `_connector`
+bluesky stack is importable, holds it as the module-level `_connector`
 singleton for the process's whole lifetime, and disconnects it exactly once
 on shutdown. The connector IS wired into the runner factory
 (`_epics_runner_factory` builds devices via `connector_devices.build_devices`,
@@ -259,7 +259,7 @@ def test_lifespan_does_not_construct_connector_when_flag_unset() -> None:
 def test_lifespan_does_not_construct_connector_when_extra_absent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Substrate flag set but the bluesky-bridge extra missing: fall back to
+    """Substrate flag set but the bluesky stack not importable: fall back to
     `FakePlanRunner` with no connector constructed at all (mirrors the existing
     `test_flag_set_but_extra_absent_falls_back_to_fake_scanner` simulation).
     """

--- a/tests/services/bluesky_bridge/test_orm_plan_integration.py
+++ b/tests/services/bluesky_bridge/test_orm_plan_integration.py
@@ -6,7 +6,7 @@ never installed in the main worktree venv, so every test here is skipped via
 bluesky installed at all. To actually run this file:
 
     uv venv /tmp/bluesky-orm-scratch
-    /tmp/bluesky-orm-scratch/bin/pip install -e '.[bluesky-bridge]' --python 3.11
+    /tmp/bluesky-orm-scratch/bin/pip install -e . --python 3.11
     /tmp/bluesky-orm-scratch/bin/python -m pytest \
         tests/services/bluesky_bridge/test_orm_plan_integration.py -q
 

--- a/tests/services/bluesky_bridge/test_runengine_integration.py
+++ b/tests/services/bluesky_bridge/test_runengine_integration.py
@@ -1,12 +1,12 @@
 """RunEngine integration test for `BlueskyPlanRunner` (task 2.7).
 
-Runs ONLY in a bluesky-capable environment — `bluesky`/`ophyd-async` are
-never installed in the main worktree venv, so every test here is skipped via
-`pytest.importorskip` rather than failing, keeping `ci_check` green with no
-bluesky installed at all. To actually run this file:
+The bluesky stack is a core dependency, so `bluesky`/`ophyd-async` are normally
+present and this file runs in the standard unit lane; the `pytest.importorskip`
+guard only skips it (rather than failing) in a slimmed install where the stack
+was stripped out. To run this file in an isolated venv:
 
     uv venv /tmp/bluesky-runengine-scratch
-    /tmp/bluesky-runengine-scratch/bin/pip install -e '.[bluesky-bridge]' --python 3.11
+    /tmp/bluesky-runengine-scratch/bin/pip install -e . --python 3.11
     /tmp/bluesky-runengine-scratch/bin/python -m pytest \
         tests/services/bluesky_bridge/test_runengine_integration.py -q
 

--- a/tests/services/bluesky_bridge/test_specs_from_env.py
+++ b/tests/services/bluesky_bridge/test_specs_from_env.py
@@ -3,9 +3,9 @@
 Covers the parse + de-duplication behavior directly (the app-wiring tests in
 ``test_epics_substrate_scanner_wiring.py`` exercise the same code through
 ``app.py``, but not the collision path). Guarded by ``importorskip`` because
-``_specs_from_env`` imports ``devices/epics.py``, which imports ophyd-async
-(the optional ``osprey-framework[bluesky-bridge]`` extra) — the base unit job
-skips this module cleanly when the extra is absent, mirroring the wiring test.
+``_specs_from_env`` imports ``devices/epics.py``, which imports ophyd-async: a
+core dependency, so this normally runs, but the guard skips cleanly in a slimmed
+install where ophyd-async is absent, mirroring the wiring test.
 """
 
 from __future__ import annotations

--- a/tests/services/bluesky_bridge/test_tiled_writer_wrapper.py
+++ b/tests/services/bluesky_bridge/test_tiled_writer_wrapper.py
@@ -20,10 +20,10 @@ from typing import Any
 import pytest
 
 # `plan_runner_bluesky` imports `bluesky.RunEngine` at module scope, so this module
-# cannot even be collected without the `bluesky-bridge` extra. Guard rather than
-# error, matching the sibling bridge tests. CI's unit job installs the extra
-# (pinned by tests/deployment/test_ci_workflow_wiring.py), so these guards run
-# there rather than skipping.
+# cannot even be collected without the bluesky stack. Guard rather than error,
+# matching the sibling bridge tests. The bluesky stack is a core dependency
+# (pinned by tests/deployment/test_ci_workflow_wiring.py), so these guards run in
+# CI's unit job rather than skipping.
 pytest.importorskip("bluesky")
 
 from osprey.services.bluesky_bridge.plan_runner_bluesky import (  # noqa: E402

--- a/tests/services/python_executor/execution/test_limits_validator.py
+++ b/tests/services/python_executor/execution/test_limits_validator.py
@@ -391,8 +391,13 @@ class TestLimitsValidator:
         assert validator.policy["allow_unlisted_channels"] is False
 
     @patch("osprey.utils.config.get_config_value")
-    def test_from_config_invalid_json_fails_fast(self, mock_get_config, tmp_path):
-        """Test that from_config raises error on invalid JSON (fail-fast at init)."""
+    def test_from_config_invalid_json_blocks_all_writes(self, mock_get_config, tmp_path):
+        """An unparseable database degrades to the empty block-all validator.
+
+        Same failsafe as the missing-database-path case: never crash the
+        connector (a read-only deployment needs no limits), never return None
+        (writes would go unchecked) — an empty DB refuses every write instead.
+        """
         db_file = tmp_path / "invalid.json"
         db_file.write_text('{"PV1": {"min_value": 0.0},}')  # Trailing comma
 
@@ -407,16 +412,15 @@ class TestLimitsValidator:
 
         mock_get_config.side_effect = config_side_effect
 
-        # Should raise ValueError during initialization (fail-fast)
-        with pytest.raises(ValueError) as exc_info:
-            LimitsValidator.from_config()
+        validator = LimitsValidator.from_config()
 
-        error_msg = str(exc_info.value)
-        assert "Invalid JSON" in error_msg
+        assert validator is not None
+        assert validator.limits == {}  # Empty database (blocks all writes)
 
     @patch("osprey.utils.config.get_config_value")
-    def test_from_config_missing_file_fails_fast(self, mock_get_config):
-        """Test that from_config raises error on missing file (fail-fast at init)."""
+    def test_from_config_missing_file_blocks_all_writes(self, mock_get_config):
+        """A missing database file degrades to the empty block-all validator
+        (same contract as the invalid-JSON case above)."""
 
         def config_side_effect(key, default):
             if key == "control_system.limits_checking.enabled":
@@ -429,12 +433,10 @@ class TestLimitsValidator:
 
         mock_get_config.side_effect = config_side_effect
 
-        # Should raise ValueError during initialization (fail-fast)
-        with pytest.raises(ValueError) as exc_info:
-            LimitsValidator.from_config()
+        validator = LimitsValidator.from_config()
 
-        error_msg = str(exc_info.value)
-        assert "Failed to load" in error_msg
+        assert validator is not None
+        assert validator.limits == {}  # Empty database (blocks all writes)
 
     # =========================================================================
     # Relative database_path resolution base (R4 container fix)

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,8 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-16T07:00:00Z"
+exclude-newer = "2026-07-11T05:26:45.490066Z"
+exclude-newer-span = "P7D"
 
 [[package]]
 name = "accelerator-toolbox"
@@ -3748,6 +3749,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "aiohttp-socks" },
     { name = "anthropic" },
+    { name = "bluesky" },
     { name = "bokeh" },
     { name = "certifi" },
     { name = "charset-normalizer" },
@@ -3772,6 +3774,7 @@ dependencies = [
     { name = "numpy" },
     { name = "ollama" },
     { name = "openai" },
+    { name = "ophyd-async", extra = ["ca"] },
     { name = "pandas" },
     { name = "playwright" },
     { name = "plotly" },
@@ -3790,6 +3793,7 @@ dependencies = [
     { name = "seaborn" },
     { name = "softioc" },
     { name = "tenacity" },
+    { name = "tiled", extra = ["client"] },
     { name = "typing-extensions" },
     { name = "unique-namer" },
     { name = "urllib3" },
@@ -3841,11 +3845,6 @@ ariel = [
 ariel-proxy = [
     { name = "aiohttp-socks" },
 ]
-bluesky-bridge = [
-    { name = "bluesky" },
-    { name = "ophyd-async", extra = ["ca"] },
-    { name = "tiled", extra = ["client"] },
-]
 dev = [
     { name = "build" },
     { name = "docker" },
@@ -3894,7 +3893,7 @@ requires-dist = [
     { name = "aiohttp-socks", specifier = ">=0.8.0" },
     { name = "aiohttp-socks", marker = "extra == 'ariel-proxy'", specifier = ">=0.8.0" },
     { name = "anthropic" },
-    { name = "bluesky", marker = "extra == 'bluesky-bridge'", specifier = ">=1.15.1" },
+    { name = "bluesky", specifier = ">=1.15.1" },
     { name = "bokeh", specifier = ">=3.9.1" },
     { name = "build", marker = "extra == 'all'" },
     { name = "build", marker = "extra == 'dev'" },
@@ -3933,7 +3932,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "ollama", specifier = ">=0.5.1" },
     { name = "openai", specifier = ">=2.45.0" },
-    { name = "ophyd-async", extras = ["ca"], marker = "extra == 'bluesky-bridge'", specifier = ">=0.16,<1.0" },
+    { name = "ophyd-async", extras = ["ca"], specifier = ">=0.16,<1.0" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "pillow", marker = "extra == 'all'", specifier = ">=12.3.0" },
     { name = "pillow", marker = "extra == 'dev'", specifier = ">=12.3.0" },
@@ -4000,7 +3999,7 @@ requires-dist = [
     { name = "testcontainers", extras = ["mongodb"], marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "testcontainers", extras = ["postgres"], marker = "extra == 'all'", specifier = ">=4.0.0" },
     { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.0.0" },
-    { name = "tiled", extras = ["client"], marker = "extra == 'bluesky-bridge'", specifier = ">=0.1" },
+    { name = "tiled", extras = ["client"], specifier = ">=0.1" },
     { name = "typing-extensions", specifier = ">=4.12.0" },
     { name = "unique-namer", specifier = ">=0.1.0" },
     { name = "urllib3", specifier = ">=2.4.0" },
@@ -4008,7 +4007,7 @@ requires-dist = [
     { name = "watchdog", specifier = ">=6.0.0" },
     { name = "websocket-client", specifier = ">=1.7.0" },
 ]
-provides-extras = ["all", "archiver-mongodb", "ariel", "ariel-proxy", "bluesky-bridge", "dev", "docs", "knowledge", "screen-capture-linux", "sheets", "virtual-accelerator"]
+provides-extras = ["all", "archiver-mongodb", "ariel", "ariel-proxy", "dev", "docs", "knowledge", "screen-capture-linux", "sheets", "virtual-accelerator"]
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
## What

Three self-contained control-system hardening and packaging changes.

### fix(limits): degrade unreadable limits database to block-all writes
With `control_system.limits_checking.enabled` set but the database missing or unparseable, `LimitsValidator.from_config` raised out of `EPICSConnector.connect()`, crashing every connector construction — including read-only deployments that never write. Swallowing the error instead would silently leave writes unchecked. The failure now routes to the failsafe the missing-database-path case already uses: an empty validator that refuses every write, with a loud warning. Read-only deploys start; writable deploys stay fail-closed; callers that read the database directly (e.g. the bluesky bridge's writable-startup preflight) still see the raw error and refuse startup.

### fix(bluesky-bridge): require a connector in build_devices
The connector is documented as required — every built device delegates its reads and writes to it — but the signature defaulted it to `None`, deferring the failure to an opaque `AttributeError` deep inside a device's `set()`/`read()` at scan time. It now raises a clear `ValueError` at build time, at the misconfiguration site.

### build(deps): make the bluesky stack a core dependency
`bluesky`, `ophyd-async[ca]`, and `tiled[client]` move into `[project]` dependencies — Bluesky is a core part of OSPREY, joining PyAT and softioc. The `bluesky-bridge` and `bluesky-panels` extras are removed outright (no compatibility aliases): the service Dockerfiles install the plain package, CI's `uv sync` drops the extra flag, and the workflow-wiring guard now pins the stack in core dependencies. The bridge lifecycle core's import-cleanliness seam is unchanged — it is an import-hygiene boundary, no longer an install-size one.

## Testing
- Full suite (minus container e2e lanes and the Postgres-backed ariel integration lane): 7,465 passed; the mongodb testcontainer file re-verified green in isolation (31/31).
- Targeted: limits-validator, connector-devices (run with the bluesky stack installed, not skipped), limits hook, channel-limits tool, CI-workflow-wiring guards, full bridge suite.
- ruff check + format clean; both lockfile and Dockerfiles regenerated/updated.