### PR TITLE
feat(dispatch-worker): structured failure classes, truthful tool-call counts, /health counters

### DIFF
--- a/src/osprey/mcp_server/dispatch_worker/counters.py
+++ b/src/osprey/mcp_server/dispatch_worker/counters.py
@@ -1,0 +1,56 @@
+"""Process-lifetime failure counters for the dispatch worker.
+
+Monotonic per-failure-class error counts, incremented at *stamp time* by wiring
+:func:`increment` into ``failure_class._stamp`` through its
+``register_counter_hook`` seam (see :func:`install`).
+
+Why a dedicated counter rather than deriving counts from ``dispatch_api._runs``:
+that map is capacity-bounded (old entries are evicted once it exceeds
+``_MAX_RUNS``) and its persisted-run reload is lexical and truncated to the same
+cap, so any total derived from it is **non-monotonic** — it can shrink as runs
+age out and understates lifetime failures. These counters only ever increase
+within a process and reset to zero on restart, which the worker's boot nonce
+makes observable to pollers (a nonce change means the counters restarted).
+
+The dispatch worker runs a single asyncio event loop; ``_stamp`` (writer) and
+the ``/health`` handler (reader) are cooperatively scheduled on it and never
+touch these counters across an ``await``, so plain dict access is race-free and
+needs no lock — matching ``run_stats``.
+"""
+
+from __future__ import annotations
+
+from osprey.mcp_server.dispatch_worker.failure_class import FAILURE_CLASSES, register_counter_hook
+
+# One monotonic counter per known failure class. Seeded with every valid class
+# so a reader never has to special-case an absent key.
+_counts: dict[str, int] = dict.fromkeys(FAILURE_CLASSES, 0)
+
+
+def increment(failure_class: str) -> None:
+    """Count one stamped error of ``failure_class`` (the counter-hook callback).
+
+    Tolerates an unrecognised class by counting it under its own key, so an
+    unexpected value can never silently drop a failure from the lifetime total.
+    """
+    _counts[failure_class] = _counts.get(failure_class, 0) + 1
+
+
+def get_counts() -> dict[str, int]:
+    """Return a snapshot copy of the process-lifetime per-class counters."""
+    return dict(_counts)
+
+
+def install() -> None:
+    """Wire :func:`increment` into ``failure_class._stamp`` via the seam.
+
+    Called once at worker startup. After this, every ``_stamp`` — at any
+    dispatch error site — bumps the matching lifetime counter here.
+    """
+    register_counter_hook(increment)
+
+
+def reset() -> None:
+    """Zero every counter. For test isolation only — never called in production."""
+    for cls in _counts:
+        _counts[cls] = 0

--- a/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
+++ b/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
@@ -37,7 +37,7 @@ from osprey.interfaces.artifacts.resolve import (
     load_run_record,
     resolve_single_run_artifact,
 )
-from osprey.mcp_server.dispatch_worker import run_stats, sdk_runner
+from osprey.mcp_server.dispatch_worker import failure_class, run_stats, sdk_runner
 from osprey.utils.tool_rules import matches_denylist
 
 logger = logging.getLogger("osprey.mcp_server.dispatch_worker")
@@ -265,12 +265,22 @@ def _sweep_stale_runs() -> None:
                 logger.warning(
                     "Marking stale run %s as error (pending > %ds)", run_id, stale_cutoff
                 )
-                _runs[run_id] = {
+                swept = {
                     **run,
                     "status": "error",
                     "error": f"Timed out after {stale_cutoff}s",
                     "completed_at": now,
+                    "tool_calls": run.get("tool_calls", []),
                 }
+                # A stale run is a worker-side fault: stamp it infrastructure with
+                # the honest tool-call count and persist it as THE terminal record.
+                # When this run's orphaned coroutine later unwinds with
+                # CancelledError, that branch sees an already-terminal record and
+                # merges instead of stamping again — one terminal record, one count.
+                num_tool_calls = run_stats.get_run_stats(run_id)["num_tool_calls"]
+                failure_class._stamp(swept, failure_class.FAILURE_INFRASTRUCTURE, num_tool_calls)
+                _runs[run_id] = swept
+                _persist_run(run_id, swept)
                 # Cancel the orphaned task so its Claude CLI subprocess exits;
                 # marking the run error alone would leave it running.
                 task = _tasks.get(run_id)
@@ -345,6 +355,49 @@ class DispatchResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+# Statuses that mark a run's record as final. ``pending`` is the only
+# non-terminal state; the stale-run sweep and the task's own error branches all
+# transition it to one of these.
+_TERMINAL_STATUSES = frozenset({"completed", "error"})
+
+
+def _is_terminal(run: dict[str, Any]) -> bool:
+    """True when ``run`` already holds a final (completed/error) record."""
+    return run.get("status") in _TERMINAL_STATUSES
+
+
+def _build_stamped_error(
+    run_id: str,
+    error: str,
+    failure_cls: str,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a terminal error record for ``run_id`` and stamp its failure class.
+
+    Centralises the two things every ``_run_dispatch_task`` error branch must do
+    identically: read the honest tool-call count from the shared stats map
+    (while it is still live — before the ``finally`` pops it) and stamp the
+    class plus count. ``extra`` overrides defaults (e.g. the timeout branch's
+    ``duration_sec``).
+    """
+    result: dict[str, Any] = {
+        "status": "error",
+        "text_output": "",
+        "tool_calls": [],
+        "error": error,
+        "duration_sec": 0.0,
+        "cost_usd": None,
+        "num_turns": None,
+        "completed_at": time.time(),
+        "artifacts": [],
+    }
+    if extra:
+        result.update(extra)
+    num_tool_calls = run_stats.get_run_stats(run_id)["num_tool_calls"]
+    failure_class._stamp(result, failure_cls, num_tool_calls)
+    return result
+
+
 async def _run_dispatch_task(run_id: str, request: DispatchRequest) -> None:
     queue = asyncio.Queue()
     _queues[run_id] = queue
@@ -381,34 +434,41 @@ async def _run_dispatch_task(run_id: str, request: DispatchRequest) -> None:
         logger.info("Dispatch %s completed: status=%s", run_id, result.get("status"))
     except TimeoutError:
         logger.error("Dispatch %s timed out after %ds", run_id, DISPATCH_TIMEOUT_SEC)
-        err_result = {
-            "status": "error",
-            "text_output": "",
-            "tool_calls": [],
-            "error": f"Timed out after {DISPATCH_TIMEOUT_SEC}s",
-            "duration_sec": DISPATCH_TIMEOUT_SEC,
-            "cost_usd": None,
-            "num_turns": None,
-            "completed_at": time.time(),
-            "artifacts": [],
-        }
+        err_result = _build_stamped_error(
+            run_id,
+            f"Timed out after {DISPATCH_TIMEOUT_SEC}s",
+            failure_class.FAILURE_INFRASTRUCTURE,
+            extra={"duration_sec": DISPATCH_TIMEOUT_SEC},
+        )
         _runs[run_id] = err_result
         _persist_run(run_id, err_result)
         await queue.put({"type": "error", "message": f"Timed out after {DISPATCH_TIMEOUT_SEC}s"})
     except asyncio.CancelledError:
+        existing = _runs.get(run_id)
+        if existing is not None and _is_terminal(existing):
+            # Race lost to the stale-run sweep: it already wrote and stamped the
+            # terminal record (infrastructure) and then cancelled this coroutine.
+            # Preserve that record — do not overwrite it with "cancelled by user"
+            # and do not stamp again — so the run keeps exactly one terminal
+            # record and one counter increment.
+            logger.warning(
+                "Dispatch %s cancelled after already terminal; preserving swept record (%s)",
+                run_id,
+                existing.get("error"),
+            )
+            try:
+                await queue.put({"type": "error", "message": existing.get("error", "cancelled")})
+            except Exception:
+                pass
+            raise
+        # Genuine user cancel of a still-pending run: a run-level terminal state.
         logger.warning("Dispatch %s cancelled by user", run_id)
-        err_result = {
-            "status": "error",
-            "text_output": "",
-            "tool_calls": [],
-            "error": "cancelled by user",
-            "cancelled": True,
-            "duration_sec": 0.0,
-            "cost_usd": None,
-            "num_turns": None,
-            "completed_at": time.time(),
-            "artifacts": [],
-        }
+        err_result = _build_stamped_error(
+            run_id,
+            "cancelled by user",
+            failure_class.FAILURE_RUN,
+            extra={"cancelled": True},
+        )
         _runs[run_id] = err_result
         _persist_run(run_id, err_result)
         try:
@@ -420,17 +480,12 @@ async def _run_dispatch_task(run_id: str, request: DispatchRequest) -> None:
         raise
     except Exception as exc:
         logger.error("Dispatch %s failed: %s", run_id, exc, exc_info=True)
-        err_result = {
-            "status": "error",
-            "text_output": "",
-            "tool_calls": [],
-            "error": str(exc),
-            "duration_sec": 0.0,
-            "cost_usd": None,
-            "num_turns": None,
-            "completed_at": time.time(),
-            "artifacts": [],
-        }
+        # Reached only for faults in the worker's own orchestration around the
+        # run: run_dispatch handles provider/agent errors internally and returns
+        # them already stamped, so anything raised out to this layer is
+        # structurally an infrastructure fault (hence the literal class rather
+        # than routing through classify_exception).
+        err_result = _build_stamped_error(run_id, str(exc), failure_class.FAILURE_INFRASTRUCTURE)
         _runs[run_id] = err_result
         _persist_run(run_id, err_result)
         await queue.put({"type": "error", "message": str(exc)})

--- a/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
+++ b/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
@@ -37,7 +37,7 @@ from osprey.interfaces.artifacts.resolve import (
     load_run_record,
     resolve_single_run_artifact,
 )
-from osprey.mcp_server.dispatch_worker import sdk_runner
+from osprey.mcp_server.dispatch_worker import run_stats, sdk_runner
 from osprey.utils.tool_rules import matches_denylist
 
 logger = logging.getLogger("osprey.mcp_server.dispatch_worker")
@@ -436,6 +436,7 @@ async def _run_dispatch_task(run_id: str, request: DispatchRequest) -> None:
         await queue.put({"type": "error", "message": str(exc)})
     finally:
         _tasks.pop(run_id, None)
+        run_stats.pop_run_stats(run_id)
 
 
 # ---------------------------------------------------------------------------

--- a/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
+++ b/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
@@ -37,7 +37,7 @@ from osprey.interfaces.artifacts.resolve import (
     load_run_record,
     resolve_single_run_artifact,
 )
-from osprey.mcp_server.dispatch_worker import failure_class, run_stats, sdk_runner
+from osprey.mcp_server.dispatch_worker import counters, failure_class, run_stats, sdk_runner
 from osprey.utils.tool_rules import matches_denylist
 
 logger = logging.getLogger("osprey.mcp_server.dispatch_worker")
@@ -52,6 +52,12 @@ _QUEUE_TTL_SEC = 60  # discard unconsumed SSE queues after this many seconds pos
 # ---------------------------------------------------------------------------
 # App setup
 # ---------------------------------------------------------------------------
+
+# Boot nonce: the worker process's start timestamp, captured once at import.
+# Stable for the life of the process and different across restarts, so a poller
+# can detect a worker restart (and the accompanying reset of the process-lifetime
+# failure counters in ``counters``) by watching this value change.
+_BOOT_NONCE: float = time.time()
 
 # In-memory run store: run_id -> result dict (includes created_at, completed_at)
 _runs: dict[str, dict[str, Any]] = {}
@@ -204,6 +210,9 @@ async def _lifespan(app: FastAPI):
     startup, since they depend on the mounted ``config.yml`` and environment.
     """
     _inject_provider_env_once()
+    # Route every _stamp's per-class increment into the process-lifetime counters
+    # before any run can fail, so no early failure goes uncounted.
+    counters.install()
     _load_persisted_runs()
     task = asyncio.create_task(_stale_run_cleanup())
     yield
@@ -650,12 +659,19 @@ async def health() -> dict[str, Any]:
         s = run.get("status", "")
         if s in counts:
             counts[s] += 1
+    # Process-lifetime failure counters — monotonic and independent of the
+    # evictable _runs map above (see counters module docstring). The _runs-derived
+    # error_runs field is retained unchanged for compatibility.
+    lifetime = counters.get_counts()
     return {
         "status": "ok",
         "pending_runs": counts["pending"],
         "completed_runs": counts["completed"],
         "error_runs": counts["error"],
         "total_runs": len(_runs),
+        "provider_errors": lifetime[failure_class.FAILURE_PROVIDER],
+        "infrastructure_errors": lifetime[failure_class.FAILURE_INFRASTRUCTURE],
+        "boot_nonce": _BOOT_NONCE,
     }
 
 

--- a/src/osprey/mcp_server/dispatch_worker/failure_class.py
+++ b/src/osprey/mcp_server/dispatch_worker/failure_class.py
@@ -1,0 +1,250 @@
+"""Failure-class taxonomy and error-result stamping for dispatch worker runs.
+
+Every error result a dispatch run can produce is stamped with exactly one
+``failure_class`` string so downstream consumers (retry logic, dashboards,
+conversational bridges) can decide uniformly whether a failure is worth
+retrying and where the fault lies.
+
+Taxonomy — three mutually exclusive classes:
+
+* ``provider`` — the model provider / upstream API is at fault: authentication
+  or API errors, HTTP 429 rate limits, and the inactivity watchdog firing (no
+  bytes from the provider within the window). Generally retryable.
+* ``infrastructure`` — the dispatch worker's own machinery failed before or
+  around the run: the outer worker timeout, the stale-run sweep, and the SDK
+  not being installed. Retryable once the infra recovers.
+* ``run`` — the agent run itself reached a terminal state that is neither the
+  provider's nor the worker's fault: an agent-level exception, a user
+  cancellation, or a resource cap (``max_turns`` / ``max_budget_usd``). Not
+  usefully retryable as-is.
+
+Public API — consumed by the ``sdk_runner`` and ``dispatch_api`` stamp sites
+(Tasks 1.3 / 1.4):
+
+* :data:`FAILURE_PROVIDER` / :data:`FAILURE_INFRASTRUCTURE` / :data:`FAILURE_RUN`
+  — the three class strings.
+* :data:`FAILURE_CLASSES` — frozenset of the three valid values.
+* :func:`classify_exception` — table-driven exception→class mapping for use at
+  the *generic* ``except Exception`` sites, where the cause is not known from
+  the call site. Known-cause sites (the inactivity watchdog, the worker
+  timeout, the stale sweep, user cancel, SDK-missing) must stamp their literal
+  class directly rather than route a synthetic exception through here.
+* :func:`is_budget_subtype` — ``True`` for a ``ResultMessage`` subtype that
+  signals a resource cap; reuses ``agent_runner.verdict._BUDGET_SUBTYPES`` (the
+  single source of truth) rather than re-listing the subtypes.
+* :func:`register_counter_hook` — install the process-lifetime per-class
+  counter callback. The counters module is owned by a separate task; until a
+  hook is registered, :func:`_stamp` only stamps and does not count.
+* :func:`_stamp` — write the class and tool-call count onto an error result and
+  bump the per-class counter via the registered hook.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+# Single source of truth for the resource-cap subtypes. Reused, not duplicated,
+# so a change to the verdict taxonomy propagates here automatically.
+from osprey.agent_runner.verdict import _BUDGET_SUBTYPES
+
+logger = logging.getLogger("osprey.mcp_server.dispatch_worker.failure_class")
+
+# ---------------------------------------------------------------------------
+# Class constants
+# ---------------------------------------------------------------------------
+
+FAILURE_PROVIDER: str = "provider"
+"""Upstream provider / API fault (auth, API errors, 429, inactivity stall)."""
+
+FAILURE_INFRASTRUCTURE: str = "infrastructure"
+"""Worker-side fault (outer timeout, stale sweep, SDK not installed)."""
+
+FAILURE_RUN: str = "run"
+"""Agent-level terminal state (agent error, user cancel, resource cap)."""
+
+FAILURE_CLASSES: frozenset[str] = frozenset({FAILURE_PROVIDER, FAILURE_INFRASTRUCTURE, FAILURE_RUN})
+"""The complete set of valid ``failure_class`` values."""
+
+# ---------------------------------------------------------------------------
+# Exception → class mapping (table-driven)
+# ---------------------------------------------------------------------------
+
+# Exception *type names* that unambiguously indicate a provider / upstream-API
+# fault. Matched by ``type(exc).__name__`` so we do not need to import the
+# provider SDK's exception classes (they are only present inside the worker
+# container, and matching by name keeps this module import-light and testable).
+_PROVIDER_TYPE_NAMES: frozenset[str] = frozenset(
+    {
+        "AuthenticationError",
+        "PermissionDeniedError",
+        "RateLimitError",
+        "APIError",
+        "APIStatusError",
+        "APIConnectionError",
+        "APITimeoutError",
+        "APIResponseValidationError",
+        "InternalServerError",
+        "OverloadedError",
+    }
+)
+
+# Case-insensitive substrings in the exception message that indicate a provider
+# fault. Kept broad because generic exceptions surfaced by the CLI often carry
+# only a formatted message, not a typed class.
+_PROVIDER_MESSAGE_SUBSTRINGS: tuple[str, ...] = (
+    "rate limit",
+    "429",
+    "overloaded",
+    "529",
+    "authentication",
+    "unauthorized",
+    "401 ",
+    "403 ",
+    "invalid api key",
+    "invalid x-api-key",
+    "api key",
+    "credential",
+    "permission denied",
+    "insufficient_quota",
+)
+
+# Maximum depth to walk the ``__cause__`` / ``__context__`` chain so a provider
+# error wrapped in a generic exception is still classified correctly, without
+# risking an unbounded walk on a pathological cycle.
+_MAX_CAUSE_DEPTH = 8
+
+
+def _exception_chain(exc: BaseException) -> list[BaseException]:
+    """Return ``exc`` followed by its cause/context chain (bounded, cycle-safe)."""
+    chain: list[BaseException] = []
+    seen: set[int] = set()
+    cur: BaseException | None = exc
+    while cur is not None and len(chain) < _MAX_CAUSE_DEPTH and id(cur) not in seen:
+        chain.append(cur)
+        seen.add(id(cur))
+        cur = cur.__cause__ or cur.__context__
+    return chain
+
+
+def classify_exception(exc: BaseException) -> str:
+    """Map an exception raised at a *generic* error site to a failure class.
+
+    Resolution order:
+
+    1. If any exception in the cause chain has a type name in
+       :data:`_PROVIDER_TYPE_NAMES`, the class is :data:`FAILURE_PROVIDER`.
+    2. Otherwise, if the message contains a provider substring, likewise
+       :data:`FAILURE_PROVIDER`.
+    3. Otherwise the fault is attributed to the agent run itself:
+       :data:`FAILURE_RUN`.
+
+    This function is deliberately conservative about ``infrastructure``: worker
+    machinery faults (timeout, stale sweep, SDK-missing) are known at their
+    call sites and must be stamped with the literal class there, so nothing
+    routed through this generic mapping is classified as infrastructure.
+
+    Args:
+        exc: The caught exception.
+
+    Returns:
+        One of :data:`FAILURE_PROVIDER` or :data:`FAILURE_RUN`.
+    """
+    chain = _exception_chain(exc)
+    for e in chain:
+        if type(e).__name__ in _PROVIDER_TYPE_NAMES:
+            return FAILURE_PROVIDER
+    for e in chain:
+        msg = str(e).lower()
+        if any(sub in msg for sub in _PROVIDER_MESSAGE_SUBSTRINGS):
+            return FAILURE_PROVIDER
+    return FAILURE_RUN
+
+
+def is_budget_subtype(subtype: str | None) -> bool:
+    """Return ``True`` when ``subtype`` marks a resource cap (turns / budget).
+
+    A completed ``ResultMessage`` carrying one of these subtypes is an
+    agent-level terminal state and should be stamped :data:`FAILURE_RUN`.
+    """
+    return subtype is not None and subtype in _BUDGET_SUBTYPES
+
+
+# ---------------------------------------------------------------------------
+# Per-class counter seam
+# ---------------------------------------------------------------------------
+
+# Decoupling seam for the process-lifetime per-class counters, whose module is
+# owned by a later task. That module calls :func:`register_counter_hook` once at
+# import/boot to install a callback; :func:`_stamp` invokes it (if present) with
+# the failure class it just stamped. Keeping the dependency inverted this way
+# lets the two modules ship and be tested independently.
+_counter_hook: Callable[[str], None] | None = None
+
+
+def register_counter_hook(hook: Callable[[str], None] | None) -> None:
+    """Install (or clear, with ``None``) the per-class counter callback.
+
+    The callback receives the stamped ``failure_class`` string and is expected
+    to increment a process-lifetime counter for it. Passing ``None`` detaches
+    the hook (useful for test isolation).
+    """
+    global _counter_hook
+    _counter_hook = hook
+
+
+def _bump_counter(failure_class: str) -> None:
+    """Invoke the registered counter hook, swallowing any error it raises.
+
+    Counting is observability, never load-bearing: a broken or absent hook must
+    not turn a stamped error result into a second failure.
+    """
+    hook = _counter_hook
+    if hook is None:
+        return
+    try:
+        hook(failure_class)
+    except Exception:  # pragma: no cover - defensive
+        logger.debug("failure-class counter hook raised for %r", failure_class, exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Stamping
+# ---------------------------------------------------------------------------
+
+
+def _stamp(
+    result: dict[str, Any], failure_class: str, num_tool_calls: int | None
+) -> dict[str, Any]:
+    """Stamp a failure class and tool-call count onto an error ``result``.
+
+    Mutates ``result`` in place (and returns it, for convenient chaining):
+
+    * ``result["failure_class"]`` is set to ``failure_class``.
+    * ``result["num_tool_calls"]`` is set to ``num_tool_calls`` (``None`` is a
+      valid value — the count is unknown at some sites).
+
+    The process-lifetime per-class counter for ``failure_class`` is bumped via
+    the registered hook (a no-op until one is registered).
+
+    Args:
+        result: The error-result dict to annotate.
+        failure_class: One of :data:`FAILURE_CLASSES`.
+        num_tool_calls: Number of tool calls the run made before failing, or
+            ``None`` when unavailable.
+
+    Returns:
+        The same ``result`` dict, annotated.
+
+    Raises:
+        ValueError: If ``failure_class`` is not a recognised class.
+    """
+    if failure_class not in FAILURE_CLASSES:
+        raise ValueError(
+            f"unknown failure_class {failure_class!r}; expected one of {sorted(FAILURE_CLASSES)}"
+        )
+    result["failure_class"] = failure_class
+    result["num_tool_calls"] = num_tool_calls
+    _bump_counter(failure_class)
+    return result

--- a/src/osprey/mcp_server/dispatch_worker/run_stats.py
+++ b/src/osprey/mcp_server/dispatch_worker/run_stats.py
@@ -1,0 +1,47 @@
+"""Per-run execution stats for the dispatch worker.
+
+A module-level dict keyed by dispatch ``run_id`` holding counters that the run's
+coroutine observes as it streams SDK messages (e.g. ``num_tool_calls``). The
+value is that these counters remain readable from code paths that cannot see the
+coroutine's locals: the timeout/cancel branches in ``dispatch_api`` build their
+result dict without the runner's return value, so they otherwise have no honest
+tool-call count to report. Both the runner (writer) and those stamp sites
+(reader) go through this shared map.
+
+The dispatch worker runs a single asyncio event loop; the run coroutine and the
+stale-run sweep are cooperatively scheduled on it, never on separate threads, so
+plain dict access is race-free and needs no lock.
+"""
+
+from __future__ import annotations
+
+# run_id -> {"num_tool_calls": int}. Entries are created lazily on the first
+# counted event and removed in dispatch_api._run_dispatch_task's finally.
+_run_stats: dict[str, dict[str, int]] = {}
+
+
+def increment_tool_calls(run_id: str) -> None:
+    """Count one tool call for ``run_id``, creating its entry if absent."""
+    stats = _run_stats.get(run_id)
+    if stats is None:
+        stats = {"num_tool_calls": 0}
+        _run_stats[run_id] = stats
+    stats["num_tool_calls"] += 1
+
+
+def get_run_stats(run_id: str) -> dict[str, int]:
+    """Return the live stats for ``run_id``, or a zeroed default if none exist.
+
+    Read by the dispatch-API stamp sites; the returned dict is the live entry
+    when present, so a caller sees the latest count.
+    """
+    return _run_stats.get(run_id, {"num_tool_calls": 0})
+
+
+def pop_run_stats(run_id: str) -> dict[str, int]:
+    """Remove and return ``run_id``'s stats (called once the run is done).
+
+    Returns a zeroed default when no entry was ever created (e.g. a run that
+    made no tool calls), so the caller need not special-case absence.
+    """
+    return _run_stats.pop(run_id, {"num_tool_calls": 0})

--- a/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
+++ b/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
@@ -15,7 +15,7 @@ from collections.abc import Iterable
 from datetime import UTC, datetime
 from typing import Any
 
-from osprey.mcp_server.dispatch_worker import run_stats
+from osprey.mcp_server.dispatch_worker import failure_class, run_stats
 
 logger = logging.getLogger("osprey.mcp_server.dispatch_worker.sdk_runner")
 
@@ -145,18 +145,26 @@ async def run_dispatch(
                 value the OTEL emitter tags records with as session.id, so a
                 consumer can locate this run's full provenance in the telemetry
                 store (None if the SDK was unavailable and no run started).
+            failure_class: (error results only) the class this failure was
+                stamped with — one of ``failure_class.FAILURE_*``.
+            num_tool_calls: (error results only) truthful count of tool calls
+                the run made before failing (survives the retained-list cap).
     """
     if not HAS_SDK:
-        return {
-            "status": "error",
-            "text_output": "",
-            "tool_calls": [],
-            "error": "claude_agent_sdk is not installed",
-            "duration_sec": 0.0,
-            "cost_usd": None,
-            "num_turns": None,
-            "session_id": None,
-        }
+        return failure_class._stamp(
+            {
+                "status": "error",
+                "text_output": "",
+                "tool_calls": [],
+                "error": "claude_agent_sdk is not installed",
+                "duration_sec": 0.0,
+                "cost_usd": None,
+                "num_turns": None,
+                "session_id": None,
+            },
+            failure_class.FAILURE_INFRASTRUCTURE,
+            0,
+        )
 
     project_dir = os.environ.get("OSPREY_PROJECT_DIR", _DEFAULT_PROJECT_DIR)
     stderr_lines: list[str] = []
@@ -274,9 +282,23 @@ async def run_dispatch(
     pending_tools: dict[str, int] = {}
     cost_usd: float | None = None
     num_turns: int | None = None
+    # Terminal error state read off the ResultMessage. Captured in the handler
+    # below and consulted once the generator drains, so the completed branch can
+    # flip a failed run to status "error" from a single decision point (poll
+    # body, SSE stream, persisted record, and counters all follow from it).
+    result_is_error = False
+    result_subtype: str | None = None
+    result_error_text: str | None = None
+    result_api_error_status: Any = None
     # Snapshot secret values once so we can scrub them from anything we persist
     # or return (the SDK env carries provider/auth tokens).
     secret_values = _secret_values()
+
+    def _num_calls() -> int:
+        """Truthful tool-call count for this run (survives the retained cap)."""
+        if run_id:
+            return run_stats.get_run_stats(run_id)["num_tool_calls"]
+        return len(tool_calls)
 
     def _finalize(result: dict[str, Any]) -> dict[str, Any]:
         """Scrub secrets and cap oversized fields before persist/return."""
@@ -326,18 +348,23 @@ async def run_dispatch(
                 )
                 logger.error("Dispatch aborted after %.1fs: %s", duration_sec, msg)
                 await _push({"type": "error", "message": msg})
-                return _finalize(
-                    {
-                        "status": "error",
-                        "text_output": "".join(text_parts),
-                        "tool_calls": tool_calls,
-                        "error": msg,
-                        "stderr": "\n".join(stderr_lines) if stderr_lines else None,
-                        "duration_sec": round(duration_sec, 2),
-                        "cost_usd": cost_usd,
-                        "num_turns": num_turns,
-                        "session_id": telemetry_session_id,
-                    }
+                # No bytes from the provider within the window — a provider fault.
+                return failure_class._stamp(
+                    _finalize(
+                        {
+                            "status": "error",
+                            "text_output": "".join(text_parts),
+                            "tool_calls": tool_calls,
+                            "error": msg,
+                            "stderr": "\n".join(stderr_lines) if stderr_lines else None,
+                            "duration_sec": round(duration_sec, 2),
+                            "cost_usd": cost_usd,
+                            "num_turns": num_turns,
+                            "session_id": telemetry_session_id,
+                        }
+                    ),
+                    failure_class.FAILURE_PROVIDER,
+                    _num_calls(),
                 )
 
             # Tool RESULTS arrive as ToolResultBlock inside UserMessage (the
@@ -405,12 +432,56 @@ async def run_dispatch(
             elif isinstance(message, ResultMessage):
                 cost_usd = getattr(message, "cost_usd", None)
                 num_turns = getattr(message, "num_turns", None)
+                result_is_error = bool(getattr(message, "is_error", False))
+                result_subtype = getattr(message, "subtype", None)
+                result_error_text = getattr(message, "result", None)
+                result_api_error_status = getattr(message, "api_error_status", None)
                 await _push({"type": "result", "cost_usd": cost_usd, "num_turns": num_turns})
 
             elif isinstance(message, SystemMessage):
                 logger.debug("SystemMessage: %s", message)
 
         duration_sec = time.monotonic() - t0
+
+        # The SDK reported a terminal error (``is_error`` or a resource-cap
+        # subtype): flip the run to status "error" here rather than reporting a
+        # false "completed". Doing it at this one point keeps the poll body, SSE
+        # stream, persisted record, and per-class counters mutually consistent.
+        if result_is_error or failure_class.is_budget_subtype(result_subtype):
+            error_text = result_error_text or f"Agent run ended in error (subtype={result_subtype})"
+            if result_api_error_status and str(result_api_error_status) not in error_text:
+                error_text = f"{error_text} (api_error_status={result_api_error_status})"
+            # Resource caps (max_turns / max_budget) are a run-level terminal
+            # state; any other reported error is classified from its text so a
+            # provider fault surfaced as a result (e.g. a 429) is still tagged
+            # provider and therefore stays retryable downstream.
+            if failure_class.is_budget_subtype(result_subtype):
+                cls = failure_class.FAILURE_RUN
+            else:
+                cls = failure_class.classify_exception(Exception(error_text))
+            logger.info(
+                "Dispatch ended in error after %.1fs: subtype=%s class=%s",
+                duration_sec,
+                result_subtype,
+                cls,
+            )
+            await _push({"type": "error", "message": error_text})
+            return failure_class._stamp(
+                _finalize(
+                    {
+                        "status": "error",
+                        "text_output": "".join(text_parts),
+                        "tool_calls": tool_calls,
+                        "error": error_text,
+                        "duration_sec": round(duration_sec, 2),
+                        "cost_usd": cost_usd,
+                        "num_turns": num_turns,
+                    }
+                ),
+                cls,
+                _num_calls(),
+            )
+
         logger.info(
             "Dispatch completed: %d text blocks, %d tool calls, %.1fs",
             len(text_parts),
@@ -450,16 +521,22 @@ async def run_dispatch(
             exc_info=True,
         )
         await _push({"type": "error", "message": _scrub(str(exc), secret_values)})
-        return _finalize(
-            {
-                "status": "error",
-                "text_output": "".join(text_parts),
-                "tool_calls": tool_calls,
-                "error": str(exc),
-                "stderr": stderr_output,
-                "duration_sec": round(duration_sec, 2),
-                "cost_usd": cost_usd,
-                "num_turns": num_turns,
-                "session_id": telemetry_session_id,
-            }
+        # Cause is not known from this catch-all site — let the table-driven
+        # classifier decide provider-vs-run from the exception and its chain.
+        return failure_class._stamp(
+            _finalize(
+                {
+                    "status": "error",
+                    "text_output": "".join(text_parts),
+                    "tool_calls": tool_calls,
+                    "error": str(exc),
+                    "stderr": stderr_output,
+                    "duration_sec": round(duration_sec, 2),
+                    "cost_usd": cost_usd,
+                    "num_turns": num_turns,
+                    "session_id": telemetry_session_id,
+                }
+            ),
+            failure_class.classify_exception(exc),
+            _num_calls(),
         )

--- a/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
+++ b/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
@@ -15,6 +15,8 @@ from collections.abc import Iterable
 from datetime import UTC, datetime
 from typing import Any
 
+from osprey.mcp_server.dispatch_worker import run_stats
+
 logger = logging.getLogger("osprey.mcp_server.dispatch_worker.sdk_runner")
 
 # SDK imports -- guard so module loads even when SDK is not installed
@@ -350,6 +352,11 @@ async def run_dispatch(
                         text_parts.append(block.text)
                         await _push({"type": "text", "content": block.text})
                     elif isinstance(block, ToolUseBlock):
+                        # Count every tool call for a truthful total, even beyond
+                        # the retained-list cap below, so the stamp sites can
+                        # report the real number rather than len(tool_calls).
+                        if run_id:
+                            run_stats.increment_tool_calls(run_id)
                         # Bound the retained tool-call list; excess calls still
                         # stream as events but are not accumulated in memory.
                         if len(tool_calls) < _MAX_TOOL_CALLS:

--- a/tests/dispatch_worker/test_dispatch_api_stamp_sites.py
+++ b/tests/dispatch_worker/test_dispatch_api_stamp_sites.py
@@ -1,0 +1,261 @@
+"""Failure-class stamping at the dispatch_api terminal error sites.
+
+Covers every site that produces a terminal error record for a run — the outer
+worker timeout, the generic orchestration except, the stale-run sweep, and the
+user-cancel branch (including the sweep-won-the-race merge) — and asserts the
+core invariant: each run ends with exactly one terminal record and exactly one
+per-class counter increment, carrying the honest tool-call count from the shared
+stats map.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from osprey.mcp_server.dispatch_worker import dispatch_api, failure_class, run_stats, sdk_runner
+from osprey.mcp_server.dispatch_worker.dispatch_api import DispatchRequest
+
+
+@pytest.fixture
+def counter_calls(monkeypatch):
+    """Observe every _stamp counter increment via the register_counter_hook seam."""
+    calls: list[str] = []
+    failure_class.register_counter_hook(calls.append)
+    yield calls
+    failure_class.register_counter_hook(None)
+
+
+@pytest.fixture
+def persist_calls(monkeypatch):
+    """Record persisted run_ids and neutralise the on-disk write during tests."""
+    calls: list[str] = []
+
+    def _fake_persist(run_id, run):
+        calls.append(run_id)
+
+    monkeypatch.setattr(dispatch_api, "_persist_run", _fake_persist)
+    return calls
+
+
+@pytest.fixture(autouse=True)
+def _clean_state(monkeypatch):
+    """Isolate the module-level run/stats maps between tests."""
+    dispatch_api._runs.clear()
+    dispatch_api._queues.clear()
+    dispatch_api._tasks.clear()
+    run_stats._run_stats.clear()
+    yield
+    dispatch_api._runs.clear()
+    dispatch_api._queues.clear()
+    dispatch_api._tasks.clear()
+    run_stats._run_stats.clear()
+
+
+def _req() -> DispatchRequest:
+    return DispatchRequest(prompt="hello", allowed_tools=[])
+
+
+# ---------------------------------------------------------------------------
+# Per-site drivers: each drives one terminal error site to completion and
+# leaves the terminal record in dispatch_api._runs[run_id].
+# ---------------------------------------------------------------------------
+
+
+async def _drive_timeout(monkeypatch, run_id: str) -> None:
+    monkeypatch.setattr(dispatch_api, "DISPATCH_TIMEOUT_SEC", 0.05)
+
+    async def _slow(**_kwargs):
+        await asyncio.sleep(5)
+
+    monkeypatch.setattr(sdk_runner, "run_dispatch", _slow)
+    await dispatch_api._run_dispatch_task(run_id, _req())
+
+
+async def _drive_generic(monkeypatch, run_id: str) -> None:
+    async def _boom(**_kwargs):
+        raise ValueError("orchestration blew up")
+
+    monkeypatch.setattr(sdk_runner, "run_dispatch", _boom)
+    await dispatch_api._run_dispatch_task(run_id, _req())
+
+
+async def _drive_cancel(monkeypatch, run_id: str) -> None:
+    async def _slow(**_kwargs):
+        await asyncio.sleep(5)
+
+    monkeypatch.setattr(sdk_runner, "run_dispatch", _slow)
+    dispatch_api._runs[run_id] = {"status": "pending", "created_at": time.time()}
+    task = asyncio.create_task(dispatch_api._run_dispatch_task(run_id, _req()))
+    await asyncio.sleep(0.05)  # let the coroutine enter run_dispatch
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+async def _drive_sweep(monkeypatch, run_id: str) -> None:
+    # A stale *pending* run, created long enough ago to exceed the sweep cutoff.
+    stale_age = dispatch_api.DISPATCH_TIMEOUT_SEC + 100
+    dispatch_api._runs[run_id] = {"status": "pending", "created_at": time.time() - stale_age}
+    dispatch_api._sweep_stale_runs()
+
+
+_DRIVERS = {
+    "timeout": (_drive_timeout, failure_class.FAILURE_INFRASTRUCTURE),
+    "generic": (_drive_generic, failure_class.FAILURE_INFRASTRUCTURE),
+    "cancel": (_drive_cancel, failure_class.FAILURE_RUN),
+    "sweep": (_drive_sweep, failure_class.FAILURE_INFRASTRUCTURE),
+}
+
+
+# ---------------------------------------------------------------------------
+# Core invariant, parametrized across every site
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("site", sorted(_DRIVERS))
+async def test_site_stamps_expected_class_exactly_once(
+    site, monkeypatch, counter_calls, persist_calls
+):
+    driver, expected_class = _DRIVERS[site]
+    run_id = f"run-{site}"
+
+    await driver(monkeypatch, run_id)
+
+    record = dispatch_api._runs[run_id]
+    # Exactly one terminal record, stamped with the expected class...
+    assert record["status"] == "error"
+    assert record["failure_class"] == expected_class
+    # ...and exactly one counter increment for this run.
+    assert counter_calls == [expected_class]
+    # Every terminal record is persisted.
+    assert persist_calls.count(run_id) == 1
+
+
+# ---------------------------------------------------------------------------
+# Honest tool-call count sourced from the stats map (not hardcoded [])
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("site", sorted(_DRIVERS))
+async def test_site_stamps_honest_tool_call_count(site, monkeypatch, counter_calls, persist_calls):
+    driver, _expected_class = _DRIVERS[site]
+    run_id = f"count-{site}"
+    for _ in range(3):
+        run_stats.increment_tool_calls(run_id)
+
+    await driver(monkeypatch, run_id)
+
+    record = dispatch_api._runs[run_id]
+    assert record["num_tool_calls"] == 3
+
+
+async def test_zero_tool_calls_defaults_to_zero(monkeypatch, counter_calls, persist_calls):
+    run_id = "count-none"
+    await _drive_generic(monkeypatch, run_id)
+    assert dispatch_api._runs[run_id]["num_tool_calls"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Site-specific record shape
+# ---------------------------------------------------------------------------
+
+
+async def test_timeout_record_carries_timeout_message_and_duration(
+    monkeypatch, counter_calls, persist_calls
+):
+    await _drive_timeout(monkeypatch, "r-timeout")
+    record = dispatch_api._runs["r-timeout"]
+    assert record["error"] == "Timed out after 0.05s"
+    assert record["duration_sec"] == 0.05
+
+
+async def test_generic_record_carries_exception_message(monkeypatch, counter_calls, persist_calls):
+    await _drive_generic(monkeypatch, "r-generic")
+    record = dispatch_api._runs["r-generic"]
+    assert record["error"] == "orchestration blew up"
+
+
+async def test_genuine_cancel_marks_cancelled_flag(monkeypatch, counter_calls, persist_calls):
+    await _drive_cancel(monkeypatch, "r-cancel")
+    record = dispatch_api._runs["r-cancel"]
+    assert record["error"] == "cancelled by user"
+    assert record["cancelled"] is True
+    assert record["failure_class"] == failure_class.FAILURE_RUN
+
+
+# ---------------------------------------------------------------------------
+# CancelledError merge when the stale sweep won the race
+# ---------------------------------------------------------------------------
+
+
+async def test_cancel_merges_preserving_swept_record(monkeypatch, counter_calls, persist_calls):
+    """Sweep wins the race: the cancel branch must not re-stamp or re-count."""
+    run_id = "r-merge"
+
+    async def _slow(**_kwargs):
+        await asyncio.sleep(5)
+
+    monkeypatch.setattr(sdk_runner, "run_dispatch", _slow)
+    dispatch_api._runs[run_id] = {"status": "pending", "created_at": time.time()}
+    task = asyncio.create_task(dispatch_api._run_dispatch_task(run_id, _req()))
+    await asyncio.sleep(0.05)  # coroutine is now suspended inside run_dispatch
+
+    # Simulate the sweep having already written + stamped a terminal record and
+    # incremented the counter once. Clear counter_calls so we observe only what
+    # the cancel branch adds after this point.
+    swept = {
+        "status": "error",
+        "error": "Timed out after 330s",
+        "failure_class": failure_class.FAILURE_INFRASTRUCTURE,
+        "num_tool_calls": 0,
+        "completed_at": time.time(),
+    }
+    dispatch_api._runs[run_id] = swept
+    counter_calls.clear()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    record = dispatch_api._runs[run_id]
+    # Swept record preserved verbatim; NOT overwritten with "cancelled by user".
+    assert record["error"] == "Timed out after 330s"
+    assert record["failure_class"] == failure_class.FAILURE_INFRASTRUCTURE
+    # The cancel branch stamped nothing and counted nothing on top of the sweep.
+    assert counter_calls == []
+
+
+async def test_sweep_then_cancel_yields_single_record_and_increment(
+    monkeypatch, counter_calls, persist_calls
+):
+    """End-to-end race: real sweep marks the run terminal, cancels its orphaned
+    coroutine, and the coroutine's cancel branch merges — one record, one count."""
+    run_id = "r-e2e"
+
+    async def _slow(**_kwargs):
+        await asyncio.sleep(5)
+
+    monkeypatch.setattr(sdk_runner, "run_dispatch", _slow)
+    run_stats.increment_tool_calls(run_id)  # honest count = 1
+
+    stale_age = dispatch_api.DISPATCH_TIMEOUT_SEC + 100
+    dispatch_api._runs[run_id] = {"status": "pending", "created_at": time.time() - stale_age}
+    task = asyncio.create_task(dispatch_api._run_dispatch_task(run_id, _req()))
+    dispatch_api._tasks[run_id] = task
+    await asyncio.sleep(0.05)  # coroutine enters run_dispatch
+
+    dispatch_api._sweep_stale_runs()  # stamps infrastructure + cancels the task
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    record = dispatch_api._runs[run_id]
+    assert record["status"] == "error"
+    assert record["failure_class"] == failure_class.FAILURE_INFRASTRUCTURE
+    assert record["num_tool_calls"] == 1
+    # Exactly one increment total across sweep + cancel-merge.
+    assert counter_calls == [failure_class.FAILURE_INFRASTRUCTURE]
+    # The sweep persisted the terminal record; the merge branch did not re-persist.
+    assert persist_calls.count(run_id) == 1

--- a/tests/dispatch_worker/test_failure_class.py
+++ b/tests/dispatch_worker/test_failure_class.py
@@ -1,0 +1,226 @@
+"""Unit tests for the dispatch-worker failure-class taxonomy and stamping."""
+
+from __future__ import annotations
+
+import pytest
+
+from osprey.agent_runner.verdict import _BUDGET_SUBTYPES
+from osprey.mcp_server.dispatch_worker import failure_class as fc
+
+# ---------------------------------------------------------------------------
+# Class constants
+# ---------------------------------------------------------------------------
+
+
+def test_class_constants_are_the_three_expected_values():
+    assert fc.FAILURE_PROVIDER == "provider"
+    assert fc.FAILURE_INFRASTRUCTURE == "infrastructure"
+    assert fc.FAILURE_RUN == "run"
+    assert fc.FAILURE_CLASSES == {"provider", "infrastructure", "run"}
+
+
+# ---------------------------------------------------------------------------
+# classify_exception — provider by type name
+# ---------------------------------------------------------------------------
+
+
+def _make_exc(type_name: str, message: str = "") -> BaseException:
+    """Build a throwaway exception whose class name is ``type_name``."""
+    exc_cls = type(type_name, (Exception,), {})
+    return exc_cls(message)
+
+
+@pytest.mark.parametrize(
+    "type_name",
+    [
+        "AuthenticationError",
+        "PermissionDeniedError",
+        "RateLimitError",
+        "APIError",
+        "APIStatusError",
+        "APIConnectionError",
+        "APITimeoutError",
+        "APIResponseValidationError",
+        "InternalServerError",
+        "OverloadedError",
+    ],
+)
+def test_provider_exception_type_names_map_to_provider(type_name):
+    assert fc.classify_exception(_make_exc(type_name)) == fc.FAILURE_PROVIDER
+
+
+# ---------------------------------------------------------------------------
+# classify_exception — provider by message substring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Error code: 429 - rate limit exceeded",
+        "The upstream provider is Overloaded",
+        "HTTP 529 from provider",
+        "authentication_error: invalid x-api-key",
+        "401 Unauthorized",
+        "403 Forbidden",
+        "Invalid API key provided",
+        "expired credential",
+        "insufficient_quota for this key",
+    ],
+)
+def test_provider_message_substrings_map_to_provider(message):
+    # A plain Exception whose *type* is not a known provider class still gets
+    # classified by its message.
+    assert fc.classify_exception(ValueError(message)) == fc.FAILURE_PROVIDER
+
+
+def test_message_match_is_case_insensitive():
+    assert fc.classify_exception(RuntimeError("RATE LIMIT hit")) == fc.FAILURE_PROVIDER
+
+
+# ---------------------------------------------------------------------------
+# classify_exception — run (default) and cause-chain walking
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_exception_defaults_to_run():
+    assert fc.classify_exception(ValueError("something went wrong in the agent")) == fc.FAILURE_RUN
+
+
+def test_generic_runtime_error_defaults_to_run():
+    assert fc.classify_exception(RuntimeError("tool raised")) == fc.FAILURE_RUN
+
+
+def test_provider_cause_wrapped_in_generic_is_detected():
+    root = _make_exc("RateLimitError", "429")
+    try:
+        try:
+            raise root
+        except BaseException as inner:
+            raise RuntimeError("wrapper") from inner
+    except RuntimeError as wrapper:
+        assert fc.classify_exception(wrapper) == fc.FAILURE_PROVIDER
+
+
+def test_provider_context_chain_is_detected():
+    # Implicit chaining via __context__ (no explicit ``from``).
+    try:
+        try:
+            raise _make_exc("AuthenticationError", "bad key")
+        except BaseException:
+            raise RuntimeError("later failure")  # noqa: B904 - exercises implicit __context__
+    except RuntimeError as wrapper:
+        assert fc.classify_exception(wrapper) == fc.FAILURE_PROVIDER
+
+
+def test_cause_chain_walk_is_cycle_safe():
+    a = RuntimeError("a")
+    b = RuntimeError("b")
+    a.__cause__ = b
+    b.__cause__ = a  # deliberate cycle
+    # Must terminate and classify without hanging.
+    assert fc.classify_exception(a) == fc.FAILURE_RUN
+
+
+# ---------------------------------------------------------------------------
+# is_budget_subtype
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("subtype", sorted(_BUDGET_SUBTYPES))
+def test_budget_subtypes_are_recognised(subtype):
+    assert fc.is_budget_subtype(subtype) is True
+
+
+@pytest.mark.parametrize("subtype", [None, "", "success", "error_during_execution"])
+def test_non_budget_subtypes_are_not_recognised(subtype):
+    assert fc.is_budget_subtype(subtype) is False
+
+
+def test_is_budget_subtype_reuses_verdict_constant():
+    # Guard against duplication: the module must not redefine its own copy.
+    assert fc._BUDGET_SUBTYPES is _BUDGET_SUBTYPES
+
+
+# ---------------------------------------------------------------------------
+# _stamp
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_counter_hook():
+    """Ensure counter-hook state never leaks between tests."""
+    fc.register_counter_hook(None)
+    yield
+    fc.register_counter_hook(None)
+
+
+@pytest.mark.parametrize(
+    "failure_class",
+    [fc.FAILURE_PROVIDER, fc.FAILURE_INFRASTRUCTURE, fc.FAILURE_RUN],
+)
+def test_stamp_writes_class_and_tool_count(failure_class):
+    result: dict = {"status": "error", "error": "boom"}
+    returned = fc._stamp(result, failure_class, 3)
+    assert returned is result  # mutates in place and returns the same dict
+    assert result["failure_class"] == failure_class
+    assert result["num_tool_calls"] == 3
+
+
+def test_stamp_preserves_none_tool_count():
+    result: dict = {"status": "error"}
+    fc._stamp(result, fc.FAILURE_INFRASTRUCTURE, None)
+    assert result["num_tool_calls"] is None
+
+
+def test_stamp_rejects_unknown_class():
+    with pytest.raises(ValueError, match="unknown failure_class"):
+        fc._stamp({"status": "error"}, "bogus", 0)
+
+
+def test_stamp_does_not_mutate_on_bad_class():
+    result: dict = {"status": "error"}
+    with pytest.raises(ValueError):
+        fc._stamp(result, "nope", 1)
+    assert "failure_class" not in result
+    assert "num_tool_calls" not in result
+
+
+# ---------------------------------------------------------------------------
+# Counter hook seam
+# ---------------------------------------------------------------------------
+
+
+def test_stamp_invokes_registered_counter_hook():
+    seen: list[str] = []
+    fc.register_counter_hook(seen.append)
+    fc._stamp({"status": "error"}, fc.FAILURE_PROVIDER, 1)
+    fc._stamp({"status": "error"}, fc.FAILURE_PROVIDER, 2)
+    fc._stamp({"status": "error"}, fc.FAILURE_RUN, 0)
+    assert seen == [fc.FAILURE_PROVIDER, fc.FAILURE_PROVIDER, fc.FAILURE_RUN]
+
+
+def test_stamp_without_hook_is_a_noop_for_counting():
+    # No hook registered (autouse fixture cleared it) -> stamping still works.
+    result = fc._stamp({"status": "error"}, fc.FAILURE_RUN, None)
+    assert result["failure_class"] == fc.FAILURE_RUN
+
+
+def test_counter_hook_exception_does_not_break_stamping():
+    def _boom(_cls: str) -> None:
+        raise RuntimeError("counter backend down")
+
+    fc.register_counter_hook(_boom)
+    # The stamp must still succeed even though the hook raised.
+    result = fc._stamp({"status": "error"}, fc.FAILURE_INFRASTRUCTURE, 5)
+    assert result["failure_class"] == fc.FAILURE_INFRASTRUCTURE
+    assert result["num_tool_calls"] == 5
+
+
+def test_register_counter_hook_none_detaches():
+    seen: list[str] = []
+    fc.register_counter_hook(seen.append)
+    fc._stamp({"status": "error"}, fc.FAILURE_RUN, 0)
+    fc.register_counter_hook(None)
+    fc._stamp({"status": "error"}, fc.FAILURE_RUN, 0)
+    assert seen == [fc.FAILURE_RUN]  # only the first call was counted

--- a/tests/dispatch_worker/test_health_counters.py
+++ b/tests/dispatch_worker/test_health_counters.py
@@ -1,0 +1,116 @@
+"""Process-lifetime failure counters and boot nonce on the worker /health payload.
+
+Verifies the counters are driven by _stamp (via the counter-hook seam), are
+exposed on /health as provider_errors / infrastructure_errors, stay monotonic
+and independent of the evictable _runs map, and that the boot nonce is stable
+within a process. Existing /health fields are unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from osprey.mcp_server.dispatch_worker import counters, dispatch_api, failure_class
+
+
+@pytest.fixture(autouse=True)
+def _wired_counters():
+    """Install the counter hook and isolate counter + run state per test."""
+    counters.reset()
+    counters.install()  # register_counter_hook(increment)
+    dispatch_api._runs.clear()
+    yield
+    failure_class.register_counter_hook(None)
+    counters.reset()
+    dispatch_api._runs.clear()
+
+
+def _stamp(cls: str, n: int) -> None:
+    """Stamp ``n`` error results of class ``cls`` (each bumps the lifetime counter)."""
+    for _ in range(n):
+        failure_class._stamp({"status": "error"}, cls, None)
+
+
+# ---------------------------------------------------------------------------
+# counters module
+# ---------------------------------------------------------------------------
+
+
+def test_increment_is_wired_to_stamp():
+    _stamp(failure_class.FAILURE_PROVIDER, 2)
+    _stamp(failure_class.FAILURE_INFRASTRUCTURE, 1)
+    _stamp(failure_class.FAILURE_RUN, 4)
+    assert counters.get_counts() == {
+        failure_class.FAILURE_PROVIDER: 2,
+        failure_class.FAILURE_INFRASTRUCTURE: 1,
+        failure_class.FAILURE_RUN: 4,
+    }
+
+
+def test_get_counts_returns_a_copy():
+    snapshot = counters.get_counts()
+    snapshot[failure_class.FAILURE_PROVIDER] = 999
+    assert counters.get_counts()[failure_class.FAILURE_PROVIDER] == 0
+
+
+def test_counters_are_monotonic():
+    _stamp(failure_class.FAILURE_PROVIDER, 1)
+    first = counters.get_counts()[failure_class.FAILURE_PROVIDER]
+    _stamp(failure_class.FAILURE_PROVIDER, 1)
+    second = counters.get_counts()[failure_class.FAILURE_PROVIDER]
+    assert second == first + 1
+
+
+def test_unknown_class_is_still_counted():
+    # Defensive path: increment() must not drop an unexpected class.
+    counters.increment("mystery")
+    assert counters.get_counts()["mystery"] == 1
+
+
+# ---------------------------------------------------------------------------
+# /health payload
+# ---------------------------------------------------------------------------
+
+
+async def test_health_exposes_lifetime_counters():
+    _stamp(failure_class.FAILURE_PROVIDER, 3)
+    _stamp(failure_class.FAILURE_INFRASTRUCTURE, 2)
+    payload = await dispatch_api.health()
+    assert payload["provider_errors"] == 3
+    assert payload["infrastructure_errors"] == 2
+
+
+async def test_health_preserves_existing_fields():
+    dispatch_api._runs["a"] = {"status": "completed"}
+    dispatch_api._runs["b"] = {"status": "error"}
+    dispatch_api._runs["c"] = {"status": "pending"}
+    payload = await dispatch_api.health()
+    assert payload["status"] == "ok"
+    assert payload["completed_runs"] == 1
+    assert payload["error_runs"] == 1
+    assert payload["pending_runs"] == 1
+    assert payload["total_runs"] == 3
+
+
+async def test_counters_survive_runs_eviction():
+    """The lifetime counters must NOT be derived from the evictable _runs map."""
+    _stamp(failure_class.FAILURE_PROVIDER, 5)
+    _stamp(failure_class.FAILURE_INFRASTRUCTURE, 4)
+
+    before = await dispatch_api.health()
+    assert (before["provider_errors"], before["infrastructure_errors"]) == (5, 4)
+
+    # Simulate eviction / lexical persisted-run reload wiping the run store.
+    dispatch_api._runs.clear()
+
+    after = await dispatch_api.health()
+    assert (after["provider_errors"], after["infrastructure_errors"]) == (5, 4)
+    # The _runs-derived counts collapse, but the lifetime counters do not.
+    assert after["error_runs"] == 0
+
+
+async def test_boot_nonce_is_present_and_stable_within_process():
+    first = await dispatch_api.health()
+    second = await dispatch_api.health()
+    assert first["boot_nonce"] == dispatch_api._BOOT_NONCE
+    assert first["boot_nonce"] == second["boot_nonce"]

--- a/tests/dispatch_worker/test_run_stats.py
+++ b/tests/dispatch_worker/test_run_stats.py
@@ -1,0 +1,237 @@
+"""Unit tests for the dispatch-worker per-run stats map.
+
+Covers the ``run_stats`` module in isolation (increment/get/pop semantics and
+defaults), the runner's increment-per-ToolUseBlock wiring, and the dispatch-API
+contract that the stats entry is popped in the same ``finally`` that pops
+``_tasks`` (no leak).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from claude_agent_sdk import (
+    AssistantMessage,
+    ResultMessage,
+    ToolUseBlock,
+)
+
+from osprey.mcp_server.dispatch_worker import run_stats, sdk_runner
+
+
+@pytest.fixture(autouse=True)
+def _clean_stats():
+    """Isolate the module-level stats map between tests."""
+    run_stats._run_stats.clear()
+    yield
+    run_stats._run_stats.clear()
+
+
+# ---------------------------------------------------------------------------
+# run_stats module in isolation
+# ---------------------------------------------------------------------------
+
+
+def test_increment_creates_entry_lazily():
+    run_stats.increment_tool_calls("r1")
+    assert run_stats.get_run_stats("r1") == {"num_tool_calls": 1}
+
+
+def test_increment_accumulates():
+    for _ in range(3):
+        run_stats.increment_tool_calls("r1")
+    assert run_stats.get_run_stats("r1")["num_tool_calls"] == 3
+
+
+def test_runs_are_isolated_by_id():
+    run_stats.increment_tool_calls("r1")
+    run_stats.increment_tool_calls("r1")
+    run_stats.increment_tool_calls("r2")
+    assert run_stats.get_run_stats("r1")["num_tool_calls"] == 2
+    assert run_stats.get_run_stats("r2")["num_tool_calls"] == 1
+
+
+def test_get_returns_zeroed_default_when_absent():
+    assert run_stats.get_run_stats("missing") == {"num_tool_calls": 0}
+    # A default read must not create an entry (no accidental leak/count).
+    assert "missing" not in run_stats._run_stats
+
+
+def test_get_returns_live_entry():
+    run_stats.increment_tool_calls("r1")
+    live = run_stats.get_run_stats("r1")
+    run_stats.increment_tool_calls("r1")
+    # The returned dict is the live entry, so a later increment is visible.
+    assert live["num_tool_calls"] == 2
+
+
+def test_pop_removes_and_returns():
+    run_stats.increment_tool_calls("r1")
+    run_stats.increment_tool_calls("r1")
+    popped = run_stats.pop_run_stats("r1")
+    assert popped == {"num_tool_calls": 2}
+    assert "r1" not in run_stats._run_stats
+
+
+def test_pop_absent_returns_default():
+    assert run_stats.pop_run_stats("missing") == {"num_tool_calls": 0}
+
+
+def test_pop_is_idempotent():
+    run_stats.increment_tool_calls("r1")
+    run_stats.pop_run_stats("r1")
+    # A second pop (e.g. finally after an already-cleaned entry) must not raise.
+    assert run_stats.pop_run_stats("r1") == {"num_tool_calls": 0}
+
+
+# ---------------------------------------------------------------------------
+# sdk_runner increments the map per ToolUseBlock
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _stub_osprey_helpers(monkeypatch):
+    """Stub the deferred OSPREY helpers so run_dispatch runs without a project."""
+    monkeypatch.setattr(
+        "osprey.interfaces.web_terminal.operator_session.build_clean_env",
+        lambda **kw: {},
+    )
+    monkeypatch.setattr(
+        "osprey.interfaces.web_terminal.sdk_context.build_system_prompt",
+        lambda *a, **k: "system",
+    )
+    monkeypatch.setattr(
+        "osprey.utils.config.get_facility_timezone",
+        lambda *a, **k: "UTC",
+    )
+
+
+def _result_message(cost_usd: float, num_turns: int) -> ResultMessage:
+    rm = MagicMock(spec=ResultMessage)
+    rm.cost_usd = cost_usd
+    rm.num_turns = num_turns
+    return rm
+
+
+@pytest.mark.asyncio
+async def test_run_dispatch_increments_per_tool_use(monkeypatch, _stub_osprey_helpers):
+    async def fake_query(prompt, options):
+        yield AssistantMessage(
+            content=[
+                ToolUseBlock(id="t1", name="Read", input={}),
+                ToolUseBlock(id="t2", name="Read", input={}),
+            ],
+            model="m",
+        )
+        yield AssistantMessage(content=[ToolUseBlock(id="t3", name="Grep", input={})], model="m")
+        yield _result_message(cost_usd=0.1, num_turns=2)
+
+    monkeypatch.setattr(sdk_runner, "query", fake_query)
+
+    result = await sdk_runner.run_dispatch(
+        "go", ["Read", "Grep"], event_queue=asyncio.Queue(), run_id="run-xyz"
+    )
+
+    assert result["status"] == "completed"
+    # Three ToolUseBlocks processed -> truthful count of 3. The runner does not
+    # pop the entry (dispatch_api owns cleanup), so it is still readable here.
+    assert run_stats.get_run_stats("run-xyz")["num_tool_calls"] == 3
+
+
+@pytest.mark.asyncio
+async def test_run_dispatch_counts_beyond_retained_cap(monkeypatch, _stub_osprey_helpers):
+    """num_tool_calls stays truthful past the retained tool_calls cap."""
+    monkeypatch.setattr(sdk_runner, "_MAX_TOOL_CALLS", 2)
+
+    async def fake_query(prompt, options):
+        for i in range(5):
+            yield AssistantMessage(
+                content=[ToolUseBlock(id=f"t{i}", name="Read", input={})], model="m"
+            )
+        yield _result_message(cost_usd=0.1, num_turns=5)
+
+    monkeypatch.setattr(sdk_runner, "query", fake_query)
+
+    result = await sdk_runner.run_dispatch(
+        "go", ["Read"], event_queue=asyncio.Queue(), run_id="run-cap"
+    )
+
+    # Only 2 retained in memory, but all 5 counted.
+    assert len(result["tool_calls"]) == 2
+    assert run_stats.get_run_stats("run-cap")["num_tool_calls"] == 5
+
+
+@pytest.mark.asyncio
+async def test_run_dispatch_without_run_id_creates_no_entry(monkeypatch, _stub_osprey_helpers):
+    async def fake_query(prompt, options):
+        yield AssistantMessage(content=[ToolUseBlock(id="t1", name="Read", input={})], model="m")
+        yield _result_message(cost_usd=0.1, num_turns=1)
+
+    monkeypatch.setattr(sdk_runner, "query", fake_query)
+
+    await sdk_runner.run_dispatch("go", ["Read"], event_queue=asyncio.Queue())
+
+    # No run_id -> nothing keyed (guards against a leaked ``None`` entry).
+    assert run_stats._run_stats == {}
+
+
+# ---------------------------------------------------------------------------
+# dispatch_api pops the entry in its finally (no leak)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_task_pops_stats_on_completion(monkeypatch):
+    from osprey.mcp_server.dispatch_worker import dispatch_api
+
+    monkeypatch.setattr(dispatch_api, "_runs", {})
+    monkeypatch.setattr(dispatch_api, "_queues", {})
+    monkeypatch.setattr(dispatch_api, "_tasks", {})
+    monkeypatch.setattr(dispatch_api, "_persist_run", lambda run_id, run: None)
+    monkeypatch.setattr(dispatch_api, "describe_run_artifacts", lambda run_id: [])
+
+    async def _fake_run_dispatch(*, run_id, event_queue, **kw):
+        run_stats.increment_tool_calls(run_id)
+        run_stats.increment_tool_calls(run_id)
+        return {
+            "status": "completed",
+            "text_output": "ok",
+            "tool_calls": [],
+            "error": None,
+            "duration_sec": 0.0,
+            "cost_usd": 0.0,
+            "num_turns": 1,
+        }
+
+    monkeypatch.setattr(dispatch_api.sdk_runner, "run_dispatch", _fake_run_dispatch)
+
+    request = dispatch_api.DispatchRequest(prompt="go", allowed_tools=["Read"])
+    await dispatch_api._run_dispatch_task("run-done", request)
+
+    # finally popped both the task handle and the stats entry.
+    assert "run-done" not in dispatch_api._tasks
+    assert "run-done" not in run_stats._run_stats
+
+
+@pytest.mark.asyncio
+async def test_dispatch_task_pops_stats_on_error(monkeypatch):
+    from osprey.mcp_server.dispatch_worker import dispatch_api
+
+    monkeypatch.setattr(dispatch_api, "_runs", {})
+    monkeypatch.setattr(dispatch_api, "_queues", {})
+    monkeypatch.setattr(dispatch_api, "_tasks", {})
+    monkeypatch.setattr(dispatch_api, "_persist_run", lambda run_id, run: None)
+
+    async def _boom(*, run_id, event_queue, **kw):
+        run_stats.increment_tool_calls(run_id)
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(dispatch_api.sdk_runner, "run_dispatch", _boom)
+
+    request = dispatch_api.DispatchRequest(prompt="go", allowed_tools=["Read"])
+    await dispatch_api._run_dispatch_task("run-err", request)
+
+    # Even on the error branch the finally must clear the stats entry.
+    assert "run-err" not in run_stats._run_stats

--- a/tests/dispatch_worker/test_sdk_runner_failure_class.py
+++ b/tests/dispatch_worker/test_sdk_runner_failure_class.py
@@ -1,0 +1,309 @@
+"""Failure-class stamping and error-flip behavior of ``sdk_runner.run_dispatch``.
+
+The runner translates the Claude Agent SDK message stream into a result dict.
+These tests exercise the four error exits — a terminal error ``ResultMessage``
+(the "completed" branch flipping to status ``error``), the inactivity watchdog,
+the generic ``except``, and the SDK-missing guard — asserting each stamps the
+right ``failure_class`` and a truthful ``num_tool_calls`` (from the run-stats
+map), and that a successful run is left untouched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from claude_agent_sdk import (
+    AssistantMessage,
+    ResultMessage,
+    TextBlock,
+    ToolUseBlock,
+)
+
+from osprey.mcp_server.dispatch_worker import failure_class, run_stats, sdk_runner
+
+
+@pytest.fixture(autouse=True)
+def _isolation():
+    """Reset the stats map and detach any counter hook between tests."""
+    run_stats._run_stats.clear()
+    failure_class.register_counter_hook(None)
+    yield
+    run_stats._run_stats.clear()
+    failure_class.register_counter_hook(None)
+
+
+@pytest.fixture(autouse=True)
+def _stub_osprey_helpers(monkeypatch):
+    """Stub the deferred OSPREY helpers so run_dispatch runs without a project."""
+    monkeypatch.setattr(
+        "osprey.interfaces.web_terminal.operator_session.build_clean_env",
+        lambda **kw: {},
+    )
+    monkeypatch.setattr(
+        "osprey.interfaces.web_terminal.sdk_context.build_system_prompt",
+        lambda *a, **k: "system",
+    )
+    monkeypatch.setattr(
+        "osprey.utils.config.get_facility_timezone",
+        lambda *a, **k: "UTC",
+    )
+
+
+def _result_message(
+    *,
+    is_error: bool = False,
+    subtype: str = "success",
+    result: str | None = None,
+    api_error_status: object | None = None,
+    cost_usd: float = 0.1,
+    num_turns: int = 1,
+) -> ResultMessage:
+    """A ResultMessage stand-in with all fields the runner reads set explicitly.
+
+    ``MagicMock(spec=ResultMessage)`` returns truthy mocks for unset attributes,
+    so every field the runner inspects must be assigned (``is_error`` in
+    particular, else a success case would read as an error).
+    """
+    rm = MagicMock(spec=ResultMessage)
+    rm.is_error = is_error
+    rm.subtype = subtype
+    rm.result = result
+    rm.api_error_status = api_error_status
+    rm.cost_usd = cost_usd
+    rm.num_turns = num_turns
+    return rm
+
+
+async def _drain(queue: asyncio.Queue) -> list[dict]:
+    events = []
+    while not queue.empty():
+        events.append(await queue.get())
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Successful run — unchanged behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_success_is_unchanged(monkeypatch):
+    async def fake_query(prompt, options):
+        yield AssistantMessage(content=[TextBlock(text="hi")], model="m")
+        yield _result_message(is_error=False, subtype="success")
+
+    monkeypatch.setattr(sdk_runner, "query", fake_query)
+
+    queue: asyncio.Queue = asyncio.Queue()
+    result = await sdk_runner.run_dispatch("go", ["Read"], event_queue=queue, run_id="ok")
+
+    assert result["status"] == "completed"
+    assert result["error"] is None
+    # Success results carry no failure taxonomy fields.
+    assert "failure_class" not in result
+    types = [e["type"] for e in await _drain(queue)]
+    assert "done" in types
+    assert "error" not in types
+
+
+# ---------------------------------------------------------------------------
+# Terminal error ResultMessage — completed branch flips to error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_budget_cap_subtype_flips_to_run(monkeypatch):
+    async def fake_query(prompt, options):
+        yield AssistantMessage(content=[ToolUseBlock(id="t1", name="Read", input={})], model="m")
+        yield _result_message(
+            is_error=True, subtype="error_max_budget_usd", result="Budget exceeded"
+        )
+
+    monkeypatch.setattr(sdk_runner, "query", fake_query)
+
+    queue: asyncio.Queue = asyncio.Queue()
+    result = await sdk_runner.run_dispatch("go", ["Read"], event_queue=queue, run_id="r")
+
+    assert result["status"] == "error"
+    assert result["failure_class"] == failure_class.FAILURE_RUN
+    assert result["error"] == "Budget exceeded"
+    assert result["num_tool_calls"] == 1
+    # SSE gets an error, not a done, so stream consumers see the failure.
+    types = [e["type"] for e in await _drain(queue)]
+    assert "error" in types
+    assert "done" not in types
+
+
+@pytest.mark.asyncio
+async def test_max_turns_subtype_flips_to_run(monkeypatch):
+    async def fake_query(prompt, options):
+        yield _result_message(is_error=True, subtype="error_max_turns", result="Max turns")
+
+    monkeypatch.setattr(sdk_runner, "query", fake_query)
+
+    result = await sdk_runner.run_dispatch("go", ["Read"], event_queue=asyncio.Queue(), run_id="r")
+
+    assert result["status"] == "error"
+    assert result["failure_class"] == failure_class.FAILURE_RUN
+
+
+@pytest.mark.asyncio
+async def test_error_result_with_provider_text_is_provider(monkeypatch):
+    """A non-budget error whose text reads as a provider fault stays retryable."""
+
+    async def fake_query(prompt, options):
+        yield _result_message(
+            is_error=True,
+            subtype="error_during_execution",
+            result="upstream 429 rate limit exceeded",
+        )
+
+    monkeypatch.setattr(sdk_runner, "query", fake_query)
+
+    result = await sdk_runner.run_dispatch("go", ["Read"], event_queue=asyncio.Queue(), run_id="r")
+
+    assert result["status"] == "error"
+    assert result["failure_class"] == failure_class.FAILURE_PROVIDER
+
+
+@pytest.mark.asyncio
+async def test_error_result_api_status_folds_into_classification(monkeypatch):
+    """api_error_status is appended to the error text and drives classification."""
+
+    async def fake_query(prompt, options):
+        yield _result_message(
+            is_error=True,
+            subtype="error_during_execution",
+            result="request failed",
+            api_error_status=429,
+        )
+
+    monkeypatch.setattr(sdk_runner, "query", fake_query)
+
+    result = await sdk_runner.run_dispatch("go", ["Read"], event_queue=asyncio.Queue(), run_id="r")
+
+    assert result["failure_class"] == failure_class.FAILURE_PROVIDER
+    assert "429" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_error_result_generic_is_run(monkeypatch):
+    async def fake_query(prompt, options):
+        yield _result_message(
+            is_error=True, subtype="error_during_execution", result="a tool crashed mid-run"
+        )
+
+    monkeypatch.setattr(sdk_runner, "query", fake_query)
+
+    result = await sdk_runner.run_dispatch("go", ["Read"], event_queue=asyncio.Queue(), run_id="r")
+
+    assert result["failure_class"] == failure_class.FAILURE_RUN
+
+
+@pytest.mark.asyncio
+async def test_error_result_without_text_gets_synthesized_message(monkeypatch):
+    async def fake_query(prompt, options):
+        yield _result_message(is_error=True, subtype="error_during_execution", result=None)
+
+    monkeypatch.setattr(sdk_runner, "query", fake_query)
+
+    result = await sdk_runner.run_dispatch("go", ["Read"], event_queue=asyncio.Queue(), run_id="r")
+
+    assert result["status"] == "error"
+    assert "error_during_execution" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Inactivity watchdog — provider fault
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inactivity_timeout_is_provider(monkeypatch):
+    monkeypatch.setattr(sdk_runner, "_INACTIVITY_TIMEOUT_SEC", 0.05)
+
+    async def fake_query(prompt, options):
+        yield AssistantMessage(content=[ToolUseBlock(id="t1", name="Read", input={})], model="m")
+        await asyncio.sleep(10)  # provider goes silent -> watchdog trips
+        yield _result_message()
+
+    monkeypatch.setattr(sdk_runner, "query", fake_query)
+
+    result = await sdk_runner.run_dispatch("go", ["Read"], event_queue=asyncio.Queue(), run_id="r")
+
+    assert result["status"] == "error"
+    assert result["failure_class"] == failure_class.FAILURE_PROVIDER
+    # One tool call was processed before the stall — the count is truthful.
+    assert result["num_tool_calls"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Generic exception — classified from the exception
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generic_exception_run(monkeypatch):
+    async def fake_query(prompt, options):
+        yield AssistantMessage(content=[ToolUseBlock(id="t1", name="Read", input={})], model="m")
+        raise RuntimeError("something broke")
+
+    monkeypatch.setattr(sdk_runner, "query", fake_query)
+
+    result = await sdk_runner.run_dispatch("go", ["Read"], event_queue=asyncio.Queue(), run_id="r")
+
+    assert result["status"] == "error"
+    assert result["failure_class"] == failure_class.FAILURE_RUN
+    assert result["num_tool_calls"] == 1
+
+
+@pytest.mark.asyncio
+async def test_generic_exception_provider_message(monkeypatch):
+    async def fake_query(prompt, options):
+        raise RuntimeError("401 unauthorized: invalid api key")
+        yield  # unreachable — makes this an async generator, like the real query
+
+    monkeypatch.setattr(sdk_runner, "query", fake_query)
+
+    result = await sdk_runner.run_dispatch("go", ["Read"], event_queue=asyncio.Queue(), run_id="r")
+
+    assert result["failure_class"] == failure_class.FAILURE_PROVIDER
+
+
+# ---------------------------------------------------------------------------
+# SDK missing — infrastructure fault
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sdk_missing_is_infrastructure(monkeypatch):
+    monkeypatch.setattr(sdk_runner, "HAS_SDK", False)
+
+    result = await sdk_runner.run_dispatch("go", ["Read"], run_id="r")
+
+    assert result["status"] == "error"
+    assert result["failure_class"] == failure_class.FAILURE_INFRASTRUCTURE
+    assert result["num_tool_calls"] == 0
+    assert result["error"] == "claude_agent_sdk is not installed"
+
+
+# ---------------------------------------------------------------------------
+# Counter hook integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_counter_hook_bumped_on_error(monkeypatch):
+    seen: list[str] = []
+    failure_class.register_counter_hook(seen.append)
+
+    async def fake_query(prompt, options):
+        yield _result_message(is_error=True, subtype="error_during_execution", result="crash")
+
+    monkeypatch.setattr(sdk_runner, "query", fake_query)
+
+    await sdk_runner.run_dispatch("go", ["Read"], event_queue=asyncio.Queue(), run_id="r")
+
+    assert seen == [failure_class.FAILURE_RUN]


### PR DESCRIPTION
## Summary

Give dispatch runs a structured, machine-readable failure taxonomy so a consumer can tell a **provider** outage from an **infrastructure** fault from a genuine **run**-level error, and can trust the reported tool-call count on a failed run.

- **Failure-class taxonomy** (`failure_class.py`): three classes — `provider`, `infrastructure`, `run` — with a table-driven exception classifier, a budget-cap subtype check reusing the verdict constants, and a `_stamp()` helper that annotates an error result with its class and tool-call count. Per-class process-lifetime counting is wired through an inverted counter-hook seam, so the counter module carries no hard import dependency.
- **Truthful `num_tool_calls`** (`run_stats.py`): a `run_id`-keyed stats map incremented for every `ToolUseBlock` (counting past the retained-list cap) and popped in the dispatch task's `finally`, so error stamps report the real count rather than `len(tool_calls)`.
- **`error` status from one decision point**: `run_dispatch` inspects the terminal `ResultMessage` — an `is_error` result or a resource-cap subtype flips the run from `completed` to `error`, and the poll body, SSE stream, persisted record, and per-class counters all derive from that single flip. Every error exit (terminal result, inactivity watchdog, generic `except`, SDK-missing guard) is stamped with its class and truthful count.
- **`dispatch_api` error sites** stamped consistently (outer worker timeout, stale-run sweep, orchestration `except`). The stale sweep and a run's own cancellation branch race to finalize the same run; the sweep now writes, stamps, and persists the terminal record, and the orphaned coroutine merges rather than overwrites — preserving exactly one terminal record and one counter increment per run.
- **`/health` lifetime counters**: monotonic per-class error counts plus a boot nonce (process start), kept independent of the evictable in-memory run store, whose capacity bound and truncated reload would understate lifetime failures. Existing `/health` fields are unchanged.

## Tests

Adds `tests/dispatch_worker/` — 90 tests covering the classifier, the `dispatch_api` stamp sites, the run-stats lifecycle, the `/health` counters, and the `sdk_runner` error paths.

## Compatibility

Additive. The new result keys (`failure_class`, `num_tool_calls`) appear only on error results; all existing result fields are unchanged, so consumers that do not read the new fields are unaffected.
