### PR TITLE
ci: parallelize e2e lane, trim redundant coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,21 @@ jobs:
       run: uv sync --extra dev --extra virtual-accelerator
 
     - name: Run unit tests
+      # Coverage is measured only on the cell that uploads to Codecov below —
+      # the other three cells were paying ~25% runtime (measured) for a report
+      # nobody reads. Deliberately NOT pytest-xdist-parallelized: the unit
+      # suite relies on serial collection order to dodge cross-test
+      # global-state bleed (stdlib subprocess.run monkeypatches, loguru sink
+      # reconfiguration), and under -n 4 it flakes ~1 test per run with a
+      # different victim each time. Parallelizing this lane first requires
+      # fixing that isolation debt.
       run: |
-        uv run pytest tests/ --ignore=tests/e2e -v --tb=short --cov=src/osprey --cov-report=xml --cov-report=term
+        if [ "${{ matrix.python-version }}" = "3.11" ] && [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+          COV_ARGS="--cov=src/osprey --cov-report=xml --cov-report=term"
+        else
+          COV_ARGS=""
+        fi
+        uv run pytest tests/ --ignore=tests/e2e -v --tb=short $COV_ARGS
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v7
@@ -556,7 +569,15 @@ jobs:
           # dispatch input (channel-finder-benchmarks): they are a
           # statistical quality score with flaky reruns, not a per-PR
           # correctness gate.
-          uv run pytest tests/e2e/ -v --tb=short \
+          # -n 4 --dist loadfile (pytest-xdist): this lane is ~18 min of
+          # real-LLM round-trips at near-zero CPU, so four workers cut it to
+          # roughly the slowest single file. loadfile (not load) keeps every
+          # file's tests on one worker, preserving in-file ordering and
+          # module-scoped fixtures — the documented registry-order hazard is
+          # about mixing e2e with unit tests, not about file-level
+          # parallelism. The only fixed-port stacks in this lane
+          # (grid-scan/ORM VA on 5064) are GitHub-Actions-skipped anyway.
+          uv run pytest tests/e2e/ -v --tb=short -n 4 --dist loadfile \
             --ignore=tests/e2e/test_preset_agentic.py \
             --ignore=tests/e2e/test_dispatch_deploy.py \
             --ignore=tests/e2e/test_dispatch_overlay_visibility.py \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ dev = [
     "pytest-order",  # Run flaky/in-debug e2e tests first via @pytest.mark.order
     "pytest-rerunfailures",  # Absorb rare LLM nondeterminism in agentic e2e via @pytest.mark.flaky
     "pytest-timeout",  # Deadlock-breaker for the model-matrix benchmark runner (--timeout)
+    "pytest-xdist",  # Parallel e2e lane in CI (-n 4 --dist loadfile; LLM-bound, file-isolated)
     "mypy",
     "pre-commit",
     "ruff",

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-11T05:26:45.490066Z"
+exclude-newer = "2026-07-13T05:11:56.411096Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -1326,6 +1326,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -3823,6 +3832,7 @@ all = [
     { name = "pytest-order" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "python-xlib" },
     { name = "rdflib" },
     { name = "ruff" },
@@ -3859,6 +3869,7 @@ dev = [
     { name = "pytest-order" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "testcontainers", extra = ["mongodb"] },
 ]
@@ -3966,6 +3977,8 @@ requires-dist = [
     { name = "pytest-rerunfailures", marker = "extra == 'dev'" },
     { name = "pytest-timeout", marker = "extra == 'all'" },
     { name = "pytest-timeout", marker = "extra == 'dev'" },
+    { name = "pytest-xdist", marker = "extra == 'all'" },
+    { name = "pytest-xdist", marker = "extra == 'dev'" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "python-xlib", marker = "extra == 'all'", specifier = ">=0.33" },
     { name = "python-xlib", marker = "extra == 'screen-capture-linux'", specifier = ">=0.33" },
@@ -5039,6 +5052,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Two measured wall-clock cuts to the CI pipeline, no change to what is tested:

1. **Shared E2E lane → pytest-xdist `-n 4 --dist loadfile`.** The lane is ~18 min of real-LLM round-trips at near-zero CPU (slowest file: `test_sdk_workflows.py` at ~221 s). Four file-parallel workers cut it to roughly the slowest single file. `loadfile` keeps every file's tests on one worker, preserving in-file ordering and module-scoped fixtures; the documented registry-order hazard applies to mixing e2e with unit tests, not file-level parallelism. The only fixed-port stacks in this lane (grid-scan/ORM VA on 5064) are GitHub-Actions-skipped.
2. **Coverage only where it is uploaded.** `--cov` ran on all four unit-matrix cells but only the ubuntu/3.11 cell uploads to Codecov. Measured overhead: ~25% of suite runtime per cell. The other three cells now run without it.

Plus `pytest-xdist` in the dev extra and the lock refresh that carries it.

## What was deliberately NOT done

The unit-test matrix stays **serial**. Under `-n 4` it flakes ~1 test per run with a different victim each time (three distinct signatures observed locally: a stale stdlib `subprocess.run` monkeypatch surfacing as `NoneType.returncode`, a loguru-sink rebind swallowing CLI diagnostics, and a spy-vs-real wheel digest mismatch). The suite currently leans on serial collection order to dodge this cross-test global-state bleed; parallelizing those lanes first requires paying down that isolation debt. The workflow comment documents this so nobody flips `-n auto` on casually.

## Expected effect

Critical path shifts from the E2E lane (~19.5 min end-to-end) and macOS unit cell (~23.7 min) toward ~16-17 min total, bounded by the macOS unit cell at ~15.5 min plus queue.