### PR TITLE
feat: make stale project renders visible and safe to fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ## [Unreleased]
 
+### Added
+
+- `osprey deploy up` and `osprey deploy status` now warn when the project's render is stale — i.e. it was rendered by a different osprey version, or the preset's content has changed since the render (a content hash of the resolved preset is stamped into `.osprey-manifest.json` at build time). The warning names the exact `osprey build ... --force` command to re-render; it never blocks a deploy, and legacy projects without the stamp are unaffected.
+- Every `osprey deploy up` now ends with a service-endpoint summary (published host ports from the rendered compose files, plus the web-terminal landing URL — or an explicit "web terminal (not configured in this project)" line when the config declares no web tier).
+
+### Changed
+
+- `osprey build --force` now re-renders an existing project *in place* instead of deleting the directory: `.env` (existing values win over freshly detected ones, and keys only it carries are kept), `_agent_data/`, and the project's `.git` are preserved; everything framework-rendered, including `data/`, is rebuilt. A profile-provided `env.file` is likewise merged into an existing `.env` rather than overwriting it.
+
 ### Fixed
 
 - The AskSage provider now falls back to its static default model list when a `/models` fetch fails or credentials are missing, instead of returning a malformed value that could reach a UI caller. The fetched list is also cached across adapter instances, so an AskSage completion no longer pays a repeat `/models` round-trip on every request.

--- a/docs/source/how-to/deploy-project.rst
+++ b/docs/source/how-to/deploy-project.rst
@@ -116,6 +116,43 @@ When ``osprey deploy up`` runs:
 9. Write a flattened ``config.yml`` per service. ``${VAR}`` placeholders are preserved (secrets stay out of the rendered output and are resolved at container start).
 10. Shell out to ``docker compose`` / ``podman compose``.
 
+Keeping a Rendered Project Up to Date
+=====================================
+
+A project directory is a *rendered artifact*: ``osprey build`` writes its
+``config.yml`` and service scaffolding from the preset at build time, and
+``osprey deploy up`` deploys exactly what that rendered config describes. If
+the framework or preset gains features after the render, the stale project
+still deploys "successfully" — just without them.
+
+To update an existing project, re-run the build with ``--force``::
+
+   osprey build my-project --preset my-preset --force
+   cd my-project && osprey deploy up -d
+
+``--force`` re-renders everything framework-owned and preserves what you
+own: ``.env`` values (secrets, and the service tokens/passwords your
+existing docker volumes were initialized with), ``_agent_data/``, and the
+project's ``.git`` history. ``data/`` is re-materialized from the preset.
+Avoid guarding the build behind a directory-existence check
+(``[ -d my-project ] || osprey build ...``) — "exists" is not "current",
+and the guard silently skips exactly the re-render that an updated preset
+needs.
+
+Two guards make render drift visible:
+
+* **Staleness advisory** — ``osprey deploy up`` and ``osprey deploy status``
+  compare the project's recorded provenance (osprey version and a content
+  hash of the resolved preset, stamped into ``.osprey-manifest.json`` at
+  build time) against the installed framework, and warn with the exact
+  rebuild command when the render is out of date. The warning never blocks
+  a deploy; projects built before the hash existed get the version
+  comparison only.
+* **Endpoint summary** — every ``osprey deploy up`` ends with a summary of
+  the published service endpoints, including an explicit ``web terminal
+  (not configured in this project)`` line when the config declares no web
+  tier, so a missing service is a stated fact rather than a silent absence.
+
 Docker Compose Templates
 ========================
 

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -100,7 +100,15 @@ def _list_presets_callback(ctx: click.Context, param: click.Parameter, value: bo
     default=".",
     help="Output directory for project (default: current directory)",
 )
-@click.option("--force", "-f", is_flag=True, help="Force overwrite if project directory exists")
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    help=(
+        "Re-render an existing project directory in place "
+        "(.env, _agent_data/, and .git are preserved)"
+    ),
+)
 @click.option("--stream", "-s", is_flag=True, help="Stream lifecycle step output in real-time")
 @click.option(
     "--skip-lifecycle", is_flag=True, help="Skip pre_build, post_build, and validate phases"
@@ -326,9 +334,11 @@ def build(
         # 3. Handle --force / directory existence
         if project_path.exists():
             if force:
-                logger.warning("  Removing existing directory: %s", project_path)
-                shutil.rmtree(project_path)
-                logger.info("  ✓ Removed existing directory")
+                logger.warning("  Clearing rendered files in existing directory: %s", project_path)
+                preserved = _clear_rendered_project_dir(project_path)
+                if preserved:
+                    logger.info("  ✓ Preserved user state: %s", ", ".join(preserved))
+                logger.info("  ✓ Cleared rendered files")
             else:
                 logger.error(
                     "  ✗ Directory '%s' already exists. Use --force to overwrite, or choose a different name.",
@@ -836,10 +846,52 @@ def _run_lifecycle_phase(
                 logger.warning("  ! %s", msg)
 
 
+def _clear_rendered_project_dir(project_path: Path) -> list[str]:
+    """Clear a project directory for ``--force``, keeping user-owned state.
+
+    Removes every top-level entry the build renders, but leaves what the user
+    owns — ``.env`` (secrets and the service tokens/passwords live docker
+    volumes were initialized with), ``_agent_data/`` (agent workspace), and
+    ``.git`` (the project's own history) — in place, untouched. This is what
+    makes ``--force`` (the staleness advisory's remedy) safe to run on a
+    stale project. Mirrors the user-owned exclusion set of
+    :func:`osprey.cli.templates.manifest.calculate_file_checksums`.
+
+    Returns:
+        Names of the preserved entries that were actually present.
+    """
+    user_owned = (".env", "_agent_data", ".git")
+    preserved: list[str] = []
+    for entry in sorted(project_path.iterdir(), key=lambda p: p.name):
+        if entry.name in user_owned:
+            preserved.append(entry.name)
+            continue
+        if entry.is_dir() and not entry.is_symlink():
+            shutil.rmtree(entry)
+        else:
+            entry.unlink()
+    return preserved
+
+
 def _copy_env_file(profile_dir: Path, project_path: Path, env_file: str) -> None:
-    """Copy a profile-provided .env file to the built project."""
+    """Copy a profile-provided .env file to the built project.
+
+    An existing project ``.env`` is merged, not clobbered: its values win and
+    keys it alone carries are appended (see
+    :func:`osprey.utils.dotenv.merge_env_preserving_existing`), so a --force
+    re-render never resets user secrets to template defaults.
+    """
     src = (profile_dir / env_file).resolve()
     dst = project_path / ".env"
+    if dst.exists():
+        from osprey.utils.dotenv import merge_env_preserving_existing
+
+        merged = merge_env_preserving_existing(
+            src.read_text(encoding="utf-8"), dst.read_text(encoding="utf-8")
+        )
+        dst.write_text(merged, encoding="utf-8")
+        logger.info("  ✓ Merged %s → .env (existing values preserved)", env_file)
+        return
     shutil.copy2(src, dst)
     logger.info("  ✓ Copied %s → .env", env_file)
 

--- a/src/osprey/cli/build_profile.py
+++ b/src/osprey/cli/build_profile.py
@@ -1074,6 +1074,54 @@ def _load_preset_raw(name: str) -> tuple[dict[str, Any], Path]:
     return raw, target
 
 
+def _hash_resolved_profile(raw: dict[str, Any], profile_path: Path) -> str:
+    """Canonical content hash of a profile dict after ``extends`` resolution.
+
+    Hashes the *resolved* content (canonical JSON, sorted keys) rather than
+    file bytes, so comment/ordering churn is invisible while a change in any
+    ``extends`` parent is not.
+    """
+    import hashlib
+    import json
+
+    resolved = _resolve_extends(dict(raw), profile_path)
+    canonical = json.dumps(resolved, sort_keys=True, default=str)
+    return f"sha256:{hashlib.sha256(canonical.encode('utf-8')).hexdigest()}"
+
+
+def compute_preset_hash(preset_name: str) -> str | None:
+    """Content hash of a bundled preset as resolved (post-``extends``).
+
+    Stamped into ``.osprey-manifest.json`` at build time and compared by the
+    deploy-side staleness advisory
+    (:mod:`osprey.deployment.staleness`). Returns ``None`` when the preset is
+    unknown or unreadable — callers treat that as "cannot compare", never as
+    drift.
+    """
+    try:
+        raw, path = _load_preset_raw(preset_name)
+        return _hash_resolved_profile(raw, path)
+    except Exception:
+        return None
+
+
+def compute_profile_hash(profile_path: Path) -> str | None:
+    """Content hash of a positional profile YAML as resolved (post-``extends``).
+
+    Counterpart of :func:`compute_preset_hash` for ``osprey build NAME
+    PROFILE.yml`` invocations. Returns ``None`` when the file is missing or
+    unreadable.
+    """
+    try:
+        path = Path(profile_path)
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            return None
+        return _hash_resolved_profile(raw, path)
+    except Exception:
+        return None
+
+
 def _parse_set_pairs(pairs: tuple[str, ...]) -> dict[str, Any]:
     """Parse ``--set KEY.PATH=VALUE`` pairs into a nested dict.
 

--- a/src/osprey/cli/templates/manifest.py
+++ b/src/osprey/cli/templates/manifest.py
@@ -544,6 +544,26 @@ def generate_manifest(
         "data_bundle": template_name,
         "claude_code_only": True,
     }
+    # Stamp a content hash of the resolved preset/profile so `osprey deploy`
+    # can detect a project whose render predates the installed preset — the
+    # osprey_version alone can't, since a --dev checkout keeps one version
+    # string across commits. Best-effort: an unhashable source omits the key
+    # (staleness checks then skip the content comparison) rather than failing
+    # the build.
+    try:
+        from osprey.cli import build_profile as _build_profile
+
+        if preset_name:
+            preset_hash = _build_profile.compute_preset_hash(preset_name)
+        elif profile_path:
+            preset_hash = _build_profile.compute_profile_hash(Path(profile_path))
+        else:
+            preset_hash = None
+    except Exception:
+        preset_hash = None
+    if preset_hash:
+        creation_block["preset_hash"] = preset_hash
+
     # Preserve the CLAUDE.md template choice so `osprey claude regen` can
     # re-render against the same persona (e.g. CLAUDE.ariel.md.j2 for the
     # ARIEL standalone preset). Default is the control-system persona.

--- a/src/osprey/cli/templates/scaffolding.py
+++ b/src/osprey/cli/templates/scaffolding.py
@@ -120,6 +120,28 @@ def detect_environment_variables() -> dict[str, str]:
     return detected
 
 
+def _render_env_preserving_existing(jinja_env, project_dir: Path, ctx: dict) -> None:
+    """Render ``project/env.j2`` to ``.env``, merging with an existing file.
+
+    On a fresh build this is a plain render. On a --force re-render an
+    existing ``.env`` is authoritative: its values win over freshly detected
+    environment values and keys it alone carries are appended — the project's
+    service tokens and volume-pinned passwords must survive a re-render (see
+    :func:`osprey.utils.dotenv.merge_env_preserving_existing`).
+    """
+    env_path = project_dir / ".env"
+    rendered = jinja_env.get_template("project/env.j2").render(**ctx)
+    if env_path.exists():
+        from osprey.utils.dotenv import merge_env_preserving_existing
+
+        content = merge_env_preserving_existing(rendered, env_path.read_text(encoding="utf-8"))
+    else:
+        content = rendered if rendered.endswith("\n") else rendered + "\n"
+    env_path.write_text(content, encoding="utf-8")
+    # Owner read/write only: the file carries secrets.
+    os.chmod(env_path, 0o600)
+
+
 def create_project_structure(
     template_root: Path,
     jinja_env,
@@ -193,9 +215,7 @@ def create_project_structure(
     if has_api_keys:
         env_template = project_template_dir / "env.j2"
         if env_template.exists():
-            render_template(jinja_env, "project/env.j2", ctx, project_dir / ".env")
-            # Set proper permissions (owner read/write only)
-            os.chmod(project_dir / ".env", 0o600)
+            _render_env_preserving_existing(jinja_env, project_dir, ctx)
 
     # Copy static files
     for src_name, dst_name in static_files:

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -19,6 +19,7 @@ from osprey.deployment.compose_generator import (
     prepare_compose_files,
     resolve_project_name,
 )
+from osprey.deployment.deploy_summary import log_endpoint_summary
 from osprey.deployment.facility_config import normalize_facility_config
 from osprey.deployment.host_ports import (
     find_port_conflicts,
@@ -30,6 +31,7 @@ from osprey.deployment.runtime_helper import (
     runtime_env,
     verify_runtime_is_running,
 )
+from osprey.deployment.staleness import warn_if_project_stale
 from osprey.deployment.web_terminals.provision import (
     deploy_down_web_terminals,
     deploy_up_web_terminals,
@@ -925,6 +927,12 @@ def deploy_up(config_path, detached=False, dev_mode=False, expose_network=False)
     """
     config, compose_files = prepare_compose_files(config_path, dev_mode, expose_network)
 
+    # Advisory staleness check BEFORE anything deploys: a project rendered by
+    # an older framework/preset self-describes an out-of-date service set in
+    # config.yml, so the deploy below would "succeed" at the wrong goal with
+    # no error anywhere. Never blocks (see warn_if_project_stale).
+    warn_if_project_stale(Path(config_path).resolve().parent)
+
     web_terminals_enabled = _web_terminals_enabled(config)
 
     # A web-terminals-only deploy (no backend services) is valid, so the
@@ -934,6 +942,10 @@ def deploy_up(config_path, detached=False, dev_mode=False, expose_network=False)
             "No services configured for this project — deployed_services is empty in "
             "config.yml. Skipping osprey deploy up."
         )
+        # Still say what is (not) reachable — an unexpectedly empty deploy is
+        # the classic stale-render shape, and "web terminal (not configured)"
+        # is the line that makes it diagnosable.
+        log_endpoint_summary(config, compose_files)
         return
 
     # Shared-disk host path (if configured) must exist before either path
@@ -984,6 +996,7 @@ def deploy_up(config_path, detached=False, dev_mode=False, expose_network=False)
 
     if web_terminals_enabled:
         deploy_up_web_terminals(config, compose_files, dev_mode, env, _env_file_args())
+        log_endpoint_summary(config, compose_files)
         return
 
     # Pin COMPOSE_PROJECT_NAME so this deploy owns its own compose project (and
@@ -1038,7 +1051,11 @@ def deploy_up(config_path, detached=False, dev_mode=False, expose_network=False)
     logger.info(f"Running command:\n    {' '.join(cmd)}")
     if detached:
         subprocess.run(cmd, env=run_env, check=True)
+        log_endpoint_summary(config, compose_files)
     else:
+        # execvpe replaces this process, so the summary must print first —
+        # compose's own output follows it.
+        log_endpoint_summary(config, compose_files)
         os.execvpe(cmd[0], cmd, run_env)
 
 

--- a/src/osprey/deployment/deploy_summary.py
+++ b/src/osprey/deployment/deploy_summary.py
@@ -1,0 +1,66 @@
+"""Post-deploy endpoint summary.
+
+Every ``osprey deploy up`` ends by saying what is reachable where, derived
+from the published host ports in the rendered compose files (the same source
+:mod:`osprey.deployment.host_ports` preflights) — so the summary needs no
+per-facility knowledge. A web-terminal line is always included: a project
+*without* a web tier says "(not configured)" explicitly, turning "nothing
+listens on the landing port" from a silent absence into a stated fact.
+"""
+
+from __future__ import annotations
+
+from osprey.deployment.compose_generator import resolve_project_name
+from osprey.deployment.host_ports import _WILDCARD_HOSTS, parse_host_port_bindings
+from osprey.utils.logger import get_logger
+
+logger = get_logger("deployment.summary")
+
+# Framework services fronted by HTTP, shown as clickable URLs. Everything else
+# (databases, channel-access gateways, ...) is shown as a bare address. Keyed
+# on compose service names, mirroring host_ports._SERVICE_REMEDY_KEYS.
+_HTTP_SERVICES = {
+    "openobserve",
+    "event-dispatcher",
+    "bluesky-bridge",
+    "tiled",
+    "bluesky-panels",
+}
+
+
+def format_endpoint_summary(config: dict, compose_files: list[str]) -> str:
+    """Render the endpoint summary for a deploy of ``config``.
+
+    :param config: Loaded configuration dictionary
+    :param compose_files: Rendered compose file paths for this deploy
+    :return: Multi-line summary text
+    """
+    lines = [f"Service endpoints ({resolve_project_name(config)}):"]
+
+    try:
+        bindings = parse_host_port_bindings(compose_files)
+    except Exception:
+        bindings = []
+    for binding in sorted(bindings, key=lambda b: (b.service, b.host_port)):
+        host = "127.0.0.1" if binding.host_ip in _WILDCARD_HOSTS else binding.host_ip
+        address = f"{host}:{binding.host_port}"
+        if binding.service in _HTTP_SERVICES:
+            address = f"http://{address}"
+        lines.append(f"  {binding.service:<20} {address}")
+
+    web_terminals = (config.get("modules") or {}).get("web_terminals") or {}
+    nginx_port = web_terminals.get("nginx_port")
+    if web_terminals.get("enabled") and isinstance(nginx_port, int):
+        lines.append(f"  {'web terminal':<20} http://127.0.0.1:{nginx_port}  (landing page)")
+    else:
+        lines.append(f"  {'web terminal':<20} (not configured in this project)")
+
+    return "\n".join(lines)
+
+
+def log_endpoint_summary(config: dict, compose_files: list[str]) -> None:
+    """Log the endpoint summary; advisory, never fails a deploy."""
+    try:
+        logger.key_info(format_endpoint_summary(config, compose_files))
+    except Exception as exc:
+        logger.debug(f"Endpoint summary skipped: {exc}")

--- a/src/osprey/deployment/staleness.py
+++ b/src/osprey/deployment/staleness.py
@@ -1,0 +1,122 @@
+"""Deploy-time project staleness advisory.
+
+``osprey build`` stamps provenance into ``.osprey-manifest.json`` — the
+osprey version that rendered the project and a content hash of the resolved
+preset/profile (``creation.preset_hash``). This module reads that provenance
+back when the project is *deployed* and warns when the render predates the
+installed framework or preset, with the exact rebuild command as the remedy.
+
+Rationale: a rendered project is a generated artifact. Its ``config.yml``
+self-describes what to deploy, so a stale render deploys "successfully" while
+silently missing every service the preset gained since — with no error
+anywhere. Every other drift check in the codebase renders *from*
+``config.yml`` and therefore cannot see this; the comparison here is against
+the installed preset instead.
+
+Advisory like
+:func:`osprey.deployment.web_terminals.postup_hooks.warn_if_web_stack_unreachable`:
+it warns loudly but never fails a deploy, and it fails open — a legacy
+project without a manifest (or with a pre-hash manifest) deploys silently.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from osprey.utils.logger import get_logger
+
+logger = get_logger("deployment.staleness")
+
+_MANIFEST_FILENAME = ".osprey-manifest.json"
+
+
+def _installed_version() -> str:
+    from osprey.cli.templates.manifest import get_framework_version
+
+    return get_framework_version()
+
+
+def _load_manifest(project_dir: Path) -> dict[str, Any] | None:
+    """Read the project manifest; ``None`` on missing/corrupt (fail open)."""
+    try:
+        data = json.loads((project_dir / _MANIFEST_FILENAME).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def staleness_reasons(project_dir: Path) -> list[str]:
+    """Human-readable reasons this project's render trails the installed code.
+
+    Empty list when the project is current — or when staleness cannot be
+    determined (no manifest, unknown versions, preset no longer shipped):
+    "can't compare" must never read as drift.
+
+    :param project_dir: Project root (the directory holding config.yml and
+        the manifest)
+    """
+    project_dir = Path(project_dir)
+    manifest = _load_manifest(project_dir)
+    if not manifest:
+        return []
+
+    reasons: list[str] = []
+    creation = manifest.get("creation") or {}
+
+    stored_version = creation.get("osprey_version")
+    installed_version = _installed_version()
+    if (
+        stored_version
+        and "unknown" not in (stored_version, installed_version)
+        and stored_version != installed_version
+    ):
+        reasons.append(
+            f"rendered by osprey {stored_version}; installed osprey is {installed_version}"
+        )
+
+    stored_hash = creation.get("preset_hash")
+    if stored_hash:
+        build_args = manifest.get("build_args") or {}
+        current_hash = None
+        try:
+            from osprey.cli import build_profile
+
+            if build_args.get("preset"):
+                current_hash = build_profile.compute_preset_hash(build_args["preset"])
+            elif build_args.get("profile_path"):
+                current_hash = build_profile.compute_profile_hash(Path(build_args["profile_path"]))
+        except Exception:
+            current_hash = None
+        if current_hash is not None and current_hash != stored_hash:
+            source = build_args.get("preset") or build_args.get("profile_path") or "profile"
+            reasons.append(f"preset '{source}' has changed since this project was rendered")
+
+    return reasons
+
+
+def warn_if_project_stale(project_dir: Path) -> None:
+    """Advisory: warn (never fail) when the project's render looks stale.
+
+    Called by ``osprey deploy up`` before any container is touched, so the
+    warning lands even when the deploy then "succeeds" at deploying an
+    out-of-date service set.
+    """
+    try:
+        project_dir = Path(project_dir)
+        reasons = staleness_reasons(project_dir)
+        if not reasons:
+            return
+        manifest = _load_manifest(project_dir) or {}
+        message = (
+            f"This project looks stale ({'; '.join(reasons)}). "
+            "The deployed stack may be missing services or configuration the "
+            "current framework provides."
+        )
+        remedy = manifest.get("reproducible_command")
+        if remedy:
+            message += f" Re-render it with:\n    {remedy} --force\nthen re-run osprey deploy up."
+        logger.warning(message)
+    except Exception as exc:  # advisory must never break a deploy
+        logger.debug(f"Project staleness advisory skipped: {exc}")

--- a/src/osprey/deployment/status_display.py
+++ b/src/osprey/deployment/status_display.py
@@ -7,12 +7,14 @@ separating project containers from other Osprey containers.
 import json
 import os
 import subprocess
+from pathlib import Path
 
 from rich.table import Table
 
 from osprey.deployment.compose_generator import resolve_user_volume_names
 from osprey.deployment.facility_config import normalize_facility_config
 from osprey.deployment.runtime_helper import get_ps_command, get_runtime_command
+from osprey.deployment.staleness import staleness_reasons
 from osprey.deployment.web_terminals.naming import web_container_name
 from osprey.utils.config import ConfigBuilder
 from osprey.utils.log_filter import quiet_logger
@@ -111,6 +113,14 @@ def show_status(config_path, *, console=None, styles=None):
             config = normalize_facility_config(config.raw_config)
     except Exception as e:
         raise RuntimeError(f"Could not load config file {config_path}: {e}") from e
+
+    # Advisory render-provenance note: a stale project deploys an out-of-date
+    # service set that looks perfectly healthy here, so status is the other
+    # place (besides deploy up) the drift must be visible.
+    for reason in staleness_reasons(Path(config_path).resolve().parent):
+        console.print(
+            f"[yellow]⚠ Project render is stale: {reason} — re-run osprey build --force[/yellow]"
+        )
 
     # Get deployed services and current project name
     deployed_services = config.get("deployed_services", [])

--- a/src/osprey/utils/dotenv.py
+++ b/src/osprey/utils/dotenv.py
@@ -38,3 +38,48 @@ def parse_dotenv_file(path: Path) -> dict[str, str]:
             value = value[1:-1]
         env[key] = value
     return env
+
+
+def _dotenv_raw_lines(text: str) -> dict[str, str]:
+    """Map ``KEY`` -> its raw ``KEY=VALUE`` line (quoting intact) from ``text``."""
+    raw: dict[str, str] = {}
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        candidate = stripped[7:] if stripped.startswith("export ") else stripped
+        key = candidate.partition("=")[0].strip()
+        if key:
+            raw[key] = stripped
+    return raw
+
+
+def merge_env_preserving_existing(rendered_text: str, existing_text: str) -> str:
+    """Merge a freshly rendered ``.env`` with an existing one; existing wins.
+
+    Used when a build re-renders a project in place (``osprey build --force``)
+    or a profile ships a template ``.env``: the rendered text provides the
+    structure, comments, and any newly introduced variables, while every value
+    the user already has keeps its existing setting (their secrets, and the
+    service tokens/passwords that live containers and docker volumes were
+    initialized with). Keys present only in the existing file are appended at
+    the end so nothing the user set is ever dropped.
+    """
+    existing = _dotenv_raw_lines(existing_text)
+    consumed: set[str] = set()
+    out_lines: list[str] = []
+    for line in rendered_text.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#") and "=" in stripped:
+            candidate = stripped[7:] if stripped.startswith("export ") else stripped
+            key = candidate.partition("=")[0].strip()
+            if key in existing:
+                out_lines.append(existing[key])
+                consumed.add(key)
+                continue
+        out_lines.append(line)
+    leftovers = [existing[key] for key in existing if key not in consumed]
+    if leftovers:
+        out_lines.extend(["", "# Preserved from existing .env"])
+        out_lines.extend(leftovers)
+    return "\n".join(out_lines) + "\n"

--- a/tests/cli/test_force_preserves_user_state.py
+++ b/tests/cli/test_force_preserves_user_state.py
@@ -1,0 +1,178 @@
+"""Tests for ``osprey build --force`` preserving user-owned project state.
+
+``--force`` exists so the documented update loop (and the staleness
+advisory's remedy) can re-render a project in place. That is only safe if it
+never destroys what the user owns: ``.env`` (secrets, service tokens matching
+live docker volumes), ``_agent_data/`` (agent workspace), and ``.git`` (the
+project's own history). Everything framework-rendered is fair game.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from osprey.cli.build_cmd import _clear_rendered_project_dir, _copy_env_file
+from osprey.cli.templates.scaffolding import _render_env_preserving_existing
+from osprey.utils.dotenv import merge_env_preserving_existing
+
+# ---------------------------------------------------------------------------
+# _clear_rendered_project_dir
+# ---------------------------------------------------------------------------
+
+
+def _scaffold_project(tmp_path: Path) -> Path:
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "config.yml").write_text("services: {}\n")
+    (project / "README.md").write_text("readme\n")
+    (project / "services").mkdir()
+    (project / "services" / "docker-compose.yml").write_text("services: {}\n")
+    (project / ".env").write_text("CBORG_API_KEY=secret\n")
+    (project / "_agent_data").mkdir()
+    (project / "_agent_data" / "notebook.md").write_text("operator notes\n")
+    (project / ".git").mkdir()
+    (project / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
+    return project
+
+
+def test_clear_removes_rendered_entries(tmp_path):
+    project = _scaffold_project(tmp_path)
+    _clear_rendered_project_dir(project)
+    assert not (project / "config.yml").exists()
+    assert not (project / "README.md").exists()
+    assert not (project / "services").exists()
+
+
+def test_clear_preserves_user_owned_entries(tmp_path):
+    project = _scaffold_project(tmp_path)
+    _clear_rendered_project_dir(project)
+    assert (project / ".env").read_text() == "CBORG_API_KEY=secret\n"
+    assert (project / "_agent_data" / "notebook.md").read_text() == "operator notes\n"
+    assert (project / ".git" / "HEAD").exists()
+
+
+def test_clear_reports_what_it_preserved(tmp_path):
+    project = _scaffold_project(tmp_path)
+    preserved = _clear_rendered_project_dir(project)
+    assert set(preserved) == {".env", "_agent_data", ".git"}
+
+
+def test_clear_on_project_without_user_state(tmp_path):
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "config.yml").write_text("services: {}\n")
+    preserved = _clear_rendered_project_dir(project)
+    assert preserved == []
+    assert not (project / "config.yml").exists()
+    assert project.exists()
+
+
+# ---------------------------------------------------------------------------
+# merge_env_preserving_existing
+# ---------------------------------------------------------------------------
+
+
+def test_merge_existing_value_wins():
+    rendered = "API_KEY=fresh-default\nTZ=UTC\n"
+    existing = "API_KEY=user-secret\n"
+    merged = merge_env_preserving_existing(rendered, existing)
+    assert "API_KEY=user-secret" in merged
+    assert "fresh-default" not in merged
+    assert "TZ=UTC" in merged
+
+
+def test_merge_appends_existing_only_keys():
+    rendered = "API_KEY=fresh\n"
+    existing = "API_KEY=user\nZO_ROOT_USER_PASSWORD=pinned-in-volume\n"
+    merged = merge_env_preserving_existing(rendered, existing)
+    assert "ZO_ROOT_USER_PASSWORD=pinned-in-volume" in merged
+
+
+def test_merge_keeps_rendered_comments_and_structure():
+    rendered = "# Provider keys\nAPI_KEY=fresh\n\n# Paths\nPROJECT_ROOT=/x\n"
+    existing = "API_KEY=user\n"
+    merged = merge_env_preserving_existing(rendered, existing)
+    assert "# Provider keys" in merged
+    assert "# Paths" in merged
+    assert merged.index("API_KEY=user") < merged.index("PROJECT_ROOT=/x")
+
+
+def test_merge_ignores_comments_in_existing():
+    rendered = "A=1\n"
+    existing = "# just a comment\nA=2\n"
+    merged = merge_env_preserving_existing(rendered, existing)
+    assert "A=2" in merged
+    assert merged.count("just a comment") == 0
+
+
+# ---------------------------------------------------------------------------
+# .env writers must merge, not clobber
+# ---------------------------------------------------------------------------
+
+
+def test_copy_env_file_merges_into_existing(tmp_path):
+    profile_dir = tmp_path / "profile"
+    profile_dir.mkdir()
+    (profile_dir / "prod.env").write_text("API_KEY=template-default\nNEW_VAR=from-template\n")
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / ".env").write_text("API_KEY=user-secret\nUSER_ONLY=kept\n")
+
+    _copy_env_file(profile_dir, project, "prod.env")
+
+    content = (project / ".env").read_text()
+    assert "API_KEY=user-secret" in content
+    assert "NEW_VAR=from-template" in content
+    assert "USER_ONLY=kept" in content
+    assert "template-default" not in content
+
+
+def test_copy_env_file_plain_copy_when_no_existing(tmp_path):
+    profile_dir = tmp_path / "profile"
+    profile_dir.mkdir()
+    (profile_dir / "prod.env").write_text("API_KEY=template-default\n")
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    _copy_env_file(profile_dir, project, "prod.env")
+
+    assert (project / ".env").read_text() == "API_KEY=template-default\n"
+
+
+def test_render_env_preserving_existing_merges(tmp_path):
+    import jinja2
+
+    template_root = tmp_path / "templates"
+    (template_root / "project").mkdir(parents=True)
+    (template_root / "project" / "env.j2").write_text(
+        "CBORG_API_KEY={{ env.CBORG_API_KEY }}\nTZ={{ env.TZ }}\n"
+    )
+    jinja_env = jinja2.Environment(loader=jinja2.FileSystemLoader(str(template_root)))
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / ".env").write_text("CBORG_API_KEY=project-secret\nEVENT_DISPATCHER_TOKEN=tok\n")
+
+    _render_env_preserving_existing(
+        jinja_env, project, {"env": {"CBORG_API_KEY": "shell-value", "TZ": "UTC"}}
+    )
+
+    content = (project / ".env").read_text()
+    assert "CBORG_API_KEY=project-secret" in content
+    assert "EVENT_DISPATCHER_TOKEN=tok" in content
+    assert "TZ=UTC" in content
+    assert "shell-value" not in content
+
+
+def test_render_env_preserving_existing_fresh_render(tmp_path):
+    import jinja2
+
+    template_root = tmp_path / "templates"
+    (template_root / "project").mkdir(parents=True)
+    (template_root / "project" / "env.j2").write_text("CBORG_API_KEY={{ env.CBORG_API_KEY }}\n")
+    jinja_env = jinja2.Environment(loader=jinja2.FileSystemLoader(str(template_root)))
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    _render_env_preserving_existing(jinja_env, project, {"env": {"CBORG_API_KEY": "shell-value"}})
+
+    assert (project / ".env").read_text().startswith("CBORG_API_KEY=shell-value")

--- a/tests/cli/test_preset_hash.py
+++ b/tests/cli/test_preset_hash.py
@@ -1,0 +1,120 @@
+"""Tests for resolved-preset content hashing (deploy staleness provenance).
+
+The hash must cover the preset as *resolved* (post-``extends`` merge), so a
+change in a parent preset is visible through every child that inherits it.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from osprey.cli import build_profile
+
+
+@pytest.fixture
+def presets_dir(tmp_path, monkeypatch):
+    d = tmp_path / "presets"
+    d.mkdir()
+    monkeypatch.setattr(build_profile, "_presets_dir", lambda: d)
+    return d
+
+
+def _write(d, name, text):
+    (d / f"{name}.yml").write_text(text, encoding="utf-8")
+
+
+def test_compute_preset_hash_is_stable(presets_dir):
+    _write(presets_dir, "demo", "name: Demo\nservices: {}\n")
+    h1 = build_profile.compute_preset_hash("demo")
+    h2 = build_profile.compute_preset_hash("demo")
+    assert h1 == h2
+    assert h1.startswith("sha256:")
+
+
+def test_compute_preset_hash_ignores_formatting_only_changes(presets_dir):
+    """Reflowing YAML without changing content must not read as preset drift."""
+    _write(presets_dir, "demo", "name: Demo\nservices: {}\n")
+    before = build_profile.compute_preset_hash("demo")
+    _write(presets_dir, "demo", "# a comment\nservices: {}\nname: Demo\n")
+    assert build_profile.compute_preset_hash("demo") == before
+
+
+def test_compute_preset_hash_tracks_content_change(presets_dir):
+    _write(presets_dir, "demo", "name: Demo\n")
+    before = build_profile.compute_preset_hash("demo")
+    _write(presets_dir, "demo", "name: Demo\nmodules.web_terminals:\n  enabled: true\n")
+    assert build_profile.compute_preset_hash("demo") != before
+
+
+def test_compute_preset_hash_sees_extends_parent_change(presets_dir):
+    _write(presets_dir, "base", "name: Base\n")
+    _write(presets_dir, "child", "extends: base\nname: Child\n")
+    before = build_profile.compute_preset_hash("child")
+    _write(presets_dir, "base", "name: Base\nservices:\n  openobserve: {}\n")
+    assert build_profile.compute_preset_hash("child") != before
+
+
+def test_compute_preset_hash_unknown_preset_returns_none(presets_dir):
+    assert build_profile.compute_preset_hash("no-such-preset") is None
+
+
+def test_compute_profile_hash_tracks_content_change(tmp_path):
+    profile = tmp_path / "my-profile.yml"
+    profile.write_text("name: Custom\n", encoding="utf-8")
+    before = build_profile.compute_profile_hash(profile)
+    assert before.startswith("sha256:")
+    profile.write_text("name: Custom\nservices:\n  postgresql: {}\n", encoding="utf-8")
+    assert build_profile.compute_profile_hash(profile) != before
+
+
+def test_compute_profile_hash_missing_file_returns_none(tmp_path):
+    assert build_profile.compute_profile_hash(tmp_path / "gone.yml") is None
+
+
+def test_generate_manifest_stamps_preset_hash(presets_dir, tmp_path):
+    """A --preset build records creation.preset_hash matching the resolved preset."""
+    from osprey.cli.templates import manifest as manifest_mod
+
+    _write(presets_dir, "demo", "name: Demo\nservices: {}\n")
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+
+    data = manifest_mod.generate_manifest(
+        template_root=tmp_path / "templates",
+        jinja_env=None,
+        project_dir=project_dir,
+        project_name="proj",
+        template_name="demo_bundle",
+        context={},
+        preset_name="demo",
+    )
+
+    assert data["creation"]["preset_hash"] == build_profile.compute_preset_hash("demo")
+    on_disk = json.loads((project_dir / manifest_mod.MANIFEST_FILENAME).read_text())
+    assert on_disk["creation"]["preset_hash"] == data["creation"]["preset_hash"]
+
+
+def test_generate_manifest_survives_unhashable_preset(tmp_path, monkeypatch):
+    """Hash stamping is best-effort: a failing hash must not break the build."""
+    from osprey.cli.templates import manifest as manifest_mod
+
+    def _boom(name):
+        raise RuntimeError("hash exploded")
+
+    monkeypatch.setattr(build_profile, "compute_preset_hash", _boom)
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+
+    data = manifest_mod.generate_manifest(
+        template_root=tmp_path / "templates",
+        jinja_env=None,
+        project_dir=project_dir,
+        project_name="proj",
+        template_name="demo_bundle",
+        context={},
+        preset_name="demo",
+    )
+
+    assert "preset_hash" not in data["creation"]

--- a/tests/deployment/test_container_lifecycle.py
+++ b/tests/deployment/test_container_lifecycle.py
@@ -1674,3 +1674,78 @@ def test_warn_unignored_build_dir_silent_when_dockerignore_excludes_build(
     (tmp_path / ".dockerignore").write_text(f"*.whl\n{ignore_line}\n", encoding="utf-8")
     container_lifecycle._warn_unignored_build_dir(str(tmp_path))
     assert _captured_warnings == []
+
+
+# ---------------------------------------------------------------------------
+# Staleness advisory + endpoint summary wiring
+#
+# Both features are advisory modules that only matter if deploy_up actually
+# invokes them — an unwired check reproduces the silent-stale-deploy failure
+# they exist to prevent, so the wiring itself is under test.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _wiring_calls(monkeypatch, tmp_path):
+    """Stub deploy_up collaborators; record staleness/summary invocations."""
+    calls: dict = {}
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        container_lifecycle,
+        "prepare_compose_files",
+        lambda *a, **k: ({"deployed_services": ["event_dispatcher"]}, ["docker-compose.yml"]),
+    )
+    monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+    monkeypatch.setattr(container_lifecycle.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(
+        container_lifecycle,
+        "warn_if_project_stale",
+        lambda project_dir: calls.setdefault("stale", []).append(project_dir),
+    )
+    monkeypatch.setattr(
+        container_lifecycle,
+        "log_endpoint_summary",
+        lambda config, compose_files: calls.setdefault("summary", []).append(compose_files),
+    )
+    return calls
+
+
+def test_deploy_up_runs_staleness_check(_wiring_calls, tmp_path):
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+    assert _wiring_calls["stale"] == [tmp_path.resolve()]
+
+
+def test_deploy_up_prints_endpoint_summary_detached(_wiring_calls, tmp_path):
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+    assert _wiring_calls["summary"] == [["docker-compose.yml"]]
+
+
+def test_deploy_up_prints_endpoint_summary_on_web_path(_wiring_calls, monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        container_lifecycle,
+        "prepare_compose_files",
+        lambda *a, **k: (
+            {"modules": {"web_terminals": {"enabled": True, "nginx_port": 9080}}},
+            ["docker-compose.yml"],
+        ),
+    )
+    monkeypatch.setattr(container_lifecycle, "deploy_up_web_terminals", lambda *a, **k: None)
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+    assert _wiring_calls["summary"] == [["docker-compose.yml"]]
+
+
+def test_deploy_up_summarizes_even_when_nothing_deploys(_wiring_calls, monkeypatch, tmp_path):
+    """The maximally-stale shape: no services, no web tier. The early return
+    must still emit the summary so 'web terminal (not configured)' is seen."""
+    monkeypatch.setattr(
+        container_lifecycle,
+        "prepare_compose_files",
+        lambda *a, **k: ({"deployed_services": []}, ["docker-compose.yml"]),
+    )
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+    assert _wiring_calls["stale"] == [tmp_path.resolve()]
+    assert _wiring_calls["summary"] == [["docker-compose.yml"]]

--- a/tests/deployment/test_deploy_summary.py
+++ b/tests/deployment/test_deploy_summary.py
@@ -1,0 +1,74 @@
+"""Tests for the post-deploy endpoint summary.
+
+Every ``osprey deploy up`` ends with a summary of what is reachable where,
+derived from the rendered compose files' published host ports — plus an
+unconditional web-terminal line, so a project *without* a web tier says so
+explicitly instead of silently binding nothing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from osprey.deployment import deploy_summary
+
+
+@pytest.fixture
+def compose_file(tmp_path):
+    path = tmp_path / "docker-compose.yml"
+    path.write_text(
+        """
+services:
+  event-dispatcher:
+    ports:
+      - "127.0.0.1:8020:8020"
+  openobserve:
+    ports:
+      - "127.0.0.1:5080:5080"
+  postgresql:
+    ports:
+      - "127.0.0.1:5432:5432"
+""",
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def test_summary_lists_published_ports(compose_file):
+    text = deploy_summary.format_endpoint_summary({"project_name": "demo"}, [compose_file])
+    assert "demo" in text
+    assert "event-dispatcher" in text
+    assert "http://127.0.0.1:8020" in text
+    assert "http://127.0.0.1:5080" in text
+    # postgres is not an HTTP service — plain address, no scheme
+    assert "127.0.0.1:5432" in text
+    assert "http://127.0.0.1:5432" not in text
+
+
+def test_summary_says_web_terminal_not_configured(compose_file):
+    """The load-bearing line: absence must be an explicit negative signal."""
+    text = deploy_summary.format_endpoint_summary({"project_name": "demo"}, [compose_file])
+    assert "web terminal" in text
+    assert "not configured" in text
+
+
+def test_summary_shows_landing_url_when_web_enabled(compose_file):
+    config = {
+        "project_name": "demo",
+        "modules": {"web_terminals": {"enabled": True, "nginx_port": 9080}},
+    }
+    text = deploy_summary.format_endpoint_summary(config, [compose_file])
+    assert "http://127.0.0.1:9080" in text
+    assert "not configured" not in text
+
+
+def test_summary_handles_no_published_ports(tmp_path):
+    empty = tmp_path / "docker-compose.yml"
+    empty.write_text("services: {}\n", encoding="utf-8")
+    text = deploy_summary.format_endpoint_summary({"project_name": "demo"}, [str(empty)])
+    assert "web terminal" in text  # the unconditional line survives an empty stack
+
+
+def test_log_endpoint_summary_never_raises(tmp_path):
+    """Advisory output must not be able to fail a deploy that succeeded."""
+    deploy_summary.log_endpoint_summary({"project_name": "demo"}, [str(tmp_path / "missing.yml")])

--- a/tests/deployment/test_project_staleness.py
+++ b/tests/deployment/test_project_staleness.py
@@ -1,0 +1,147 @@
+"""Tests for the deploy-side project staleness advisory.
+
+A rendered project stamps its provenance (osprey version + resolved-preset
+hash) into ``.osprey-manifest.json`` at build time; ``deploy up`` and
+``deploy status`` compare that against the installed framework and warn —
+never fail — when the project predates the code deploying it. The check is
+fail-open by design: a legacy project without a manifest deploys silently.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from osprey.cli import build_profile
+from osprey.deployment import staleness
+
+
+@pytest.fixture
+def presets_dir(tmp_path, monkeypatch):
+    d = tmp_path / "presets"
+    d.mkdir()
+    monkeypatch.setattr(build_profile, "_presets_dir", lambda: d)
+    return d
+
+
+def _write_preset(d, name, text):
+    (d / f"{name}.yml").write_text(text, encoding="utf-8")
+
+
+def _write_manifest(project_dir, **overrides):
+    data = {
+        "schema_version": "1.2.0",
+        "creation": {
+            "osprey_version": "2026.7.0",
+            "template": "demo",
+        },
+        "build_args": {"source": "preset", "preset": "demo", "project_name": "proj"},
+        "reproducible_command": "osprey build proj --preset demo",
+    }
+    for key, value in overrides.items():
+        if isinstance(value, dict) and isinstance(data.get(key), dict):
+            data[key].update(value)
+        else:
+            data[key] = value
+    (project_dir / ".osprey-manifest.json").write_text(json.dumps(data), encoding="utf-8")
+    return data
+
+
+def test_no_manifest_is_silent(tmp_path):
+    assert staleness.staleness_reasons(tmp_path) == []
+
+
+def test_corrupt_manifest_is_silent(tmp_path):
+    (tmp_path / ".osprey-manifest.json").write_text("{not json", encoding="utf-8")
+    assert staleness.staleness_reasons(tmp_path) == []
+
+
+def test_fresh_project_yields_no_reasons(tmp_path, presets_dir, monkeypatch):
+    _write_preset(presets_dir, "demo", "name: Demo\n")
+    monkeypatch.setattr(staleness, "_installed_version", lambda: "2026.7.0")
+    _write_manifest(
+        tmp_path,
+        creation={"preset_hash": build_profile.compute_preset_hash("demo")},
+    )
+    assert staleness.staleness_reasons(tmp_path) == []
+
+
+def test_version_drift_is_reported(tmp_path, monkeypatch):
+    monkeypatch.setattr(staleness, "_installed_version", lambda: "2026.8.1")
+    _write_manifest(tmp_path)
+    reasons = staleness.staleness_reasons(tmp_path)
+    assert len(reasons) == 1
+    assert "2026.7.0" in reasons[0] and "2026.8.1" in reasons[0]
+
+
+def test_unknown_installed_version_is_silent(tmp_path, monkeypatch):
+    """A broken/partial install must not manufacture a drift warning."""
+    monkeypatch.setattr(staleness, "_installed_version", lambda: "unknown")
+    _write_manifest(tmp_path)
+    assert staleness.staleness_reasons(tmp_path) == []
+
+
+def test_preset_content_drift_is_reported(tmp_path, presets_dir, monkeypatch):
+    """Same installed version, changed preset — the --dev checkout incident."""
+    _write_preset(presets_dir, "demo", "name: Demo\n")
+    monkeypatch.setattr(staleness, "_installed_version", lambda: "2026.7.0")
+    _write_manifest(
+        tmp_path,
+        creation={"preset_hash": build_profile.compute_preset_hash("demo")},
+    )
+    _write_preset(presets_dir, "demo", "name: Demo\nmodules.web_terminals:\n  enabled: true\n")
+    reasons = staleness.staleness_reasons(tmp_path)
+    assert len(reasons) == 1
+    assert "demo" in reasons[0]
+
+
+def test_manifest_without_preset_hash_skips_content_check(tmp_path, presets_dir, monkeypatch):
+    """Manifests from before the stamp existed only get the version check."""
+    _write_preset(presets_dir, "demo", "name: Demo\n")
+    monkeypatch.setattr(staleness, "_installed_version", lambda: "2026.7.0")
+    _write_manifest(tmp_path)
+    assert staleness.staleness_reasons(tmp_path) == []
+
+
+def test_removed_preset_is_silent_on_content_check(tmp_path, presets_dir, monkeypatch):
+    """A preset that no longer ships must not crash or false-positive."""
+    monkeypatch.setattr(staleness, "_installed_version", lambda: "2026.7.0")
+    _write_manifest(tmp_path, creation={"preset_hash": "sha256:deadbeef"})
+    assert staleness.staleness_reasons(tmp_path) == []
+
+
+@pytest.fixture
+def _captured_warnings(monkeypatch):
+    warnings: list = []
+    monkeypatch.setattr(
+        staleness.logger, "warning", lambda *a, **k: warnings.append(" ".join(map(str, a)))
+    )
+    return warnings
+
+
+def test_warn_if_project_stale_logs_reasons_and_remedy(tmp_path, monkeypatch, _captured_warnings):
+    monkeypatch.setattr(staleness, "_installed_version", lambda: "2026.8.1")
+    _write_manifest(tmp_path)
+    staleness.warn_if_project_stale(tmp_path)
+    assert len(_captured_warnings) == 1
+    text = _captured_warnings[0]
+    assert "2026.7.0" in text
+    assert "osprey build proj --preset demo --force" in text
+
+
+def test_warn_if_project_stale_is_quiet_when_fresh(tmp_path, monkeypatch, _captured_warnings):
+    monkeypatch.setattr(staleness, "_installed_version", lambda: "2026.7.0")
+    _write_manifest(tmp_path)
+    staleness.warn_if_project_stale(tmp_path)
+    assert _captured_warnings == []
+
+
+def test_warn_if_project_stale_never_raises(tmp_path, monkeypatch):
+    """Advisory means advisory: internal failure must not break a deploy."""
+
+    def _boom(project_dir):
+        raise RuntimeError("staleness exploded")
+
+    monkeypatch.setattr(staleness, "staleness_reasons", _boom)
+    staleness.warn_if_project_stale(tmp_path)  # must not raise


### PR DESCRIPTION
## Problem

A rendered project is a generated artifact, but nothing ever checked it against the generator again. A project built before a preset gained a feature (e.g. the multi-user web tier) deploys "successfully" with no error anywhere: `deploy up` faithfully brings up the older service set described by the stale `config.yml`, every post-up check is gated on that same stale config, and the missing service is a silent absence. Worse, the natural fix — `osprey build --force` — deleted the entire project directory, including `.env` (secrets and the service tokens/passwords that live docker volumes were initialized with), `_agent_data/`, and the project's git history, so re-rendering in place was a trap of its own.

## Changes

**Provenance stamp (build).** `.osprey-manifest.json` now records a content hash of the resolved preset (post-`extends` merge) alongside the existing osprey version. The hash is what makes drift detectable from a `--dev` checkout, where the version string doesn't move between commits. Best-effort: an unhashable source omits the key.

**Staleness advisory (deploy).** `osprey deploy up` and `osprey deploy status` compare that provenance against the installed framework and warn — naming the versions, the consequence, and the exact `osprey build … --force` remedy — before any container is touched. Advisory and fail-open by design: it never blocks a deploy, and legacy projects without a manifest (or pre-hash manifests) deploy silently. Wiring is itself under test, since an unwired advisory would reproduce the exact silent failure this prevents.

**Endpoint summary (deploy).** Every `deploy up` now ends with a summary of published service endpoints (derived from the rendered compose files — no per-facility knowledge), plus an unconditional web-terminal line: the landing URL when configured, an explicit `web terminal (not configured in this project)` when not. Absence becomes a stated fact instead of a silent gap.

**Safe `--force` (build).** `--force` now clears only framework-rendered entries and preserves user-owned state in place: `.env` (writers merge instead of clobber — existing values win, user-only keys are kept, new template variables still appear), `_agent_data/`, and `.git` (the re-render lands as a new commit on top of the user's history). `data/` stays build-owned and is re-materialized. This is what makes the advisory's remedy safe to run.

**Docs.** New "Keeping a Rendered Project Up to Date" section in the deploy how-to, including why `[ -d proj ] || osprey build` guards are an anti-pattern ("exists" is not "current").

## Testing

- 40 new unit tests (hash stability/extends-sensitivity, staleness detection incl. fail-open paths, summary formatting, `deploy_up` wiring, `--force` preservation and `.env` merge semantics)
- `./scripts/quick_check.sh` green (8929 passed)
- Verified end-to-end on real builds: `--force` over a seeded project preserved `.env` values, agent data, and git history while re-rendering config; a doctored manifest produced the staleness warning with the correct remedy on a live `osprey deploy up`; the endpoint summary printed with the `(not configured)` web-terminal line.