### PR TITLE
feat(build): propagate --set overrides to persona renders, fail fast on deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Added
 
+- Explicit `--set provider=` / `--set model=` / `--set channel_finder_mode=` build overrides now propagate to the persona projects that multi-user deploys auto-render: the manifest records which of these keys were explicitly passed, and `osprey deploy up` forwards them to each persona's `osprey build` — so one override at build time retints the whole stack. Preset defaults are never forwarded, keeping per-persona provider customization intact.
+
+### Changed
+
+- `osprey deploy up` now runs the web-terminal preflight (persona auto-render and the fail-closed `.env.production` credential gate) *before* building any image, so a deploy doomed to abort on a missing provider secret says so in seconds instead of after the full image build. When the missing variable is exported in the caller's shell but absent from `.env`, the error now says so and names the exact copy-in command (`.env` remains the only secret source the generator reads).
+
 - `osprey deploy up` and `osprey deploy status` now warn when the project's render is stale — i.e. it was rendered by a different osprey version, or the preset's content has changed since the render (a content hash of the resolved preset is stamped into `.osprey-manifest.json` at build time). The warning names the exact `osprey build ... --force` command to re-render; it never blocks a deploy, and legacy projects without the stamp are unaffected.
 - Every `osprey deploy up` now ends with a service-endpoint summary (published host ports from the rendered compose files, plus the web-terminal landing URL — or an explicit "web terminal (not configured in this project)" line when the config declares no web tier).
 

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -183,7 +183,7 @@ def build(
       # List available presets
       $ osprey build --list-presets
     """
-    from .build_profile import resolve_build_profile
+    from .build_profile import explicit_model_override_keys, resolve_build_profile
     from .project_utils import _clear_claude_code_project_state
 
     # --emit-profile is a project-less scaffold mode. Validate its constraints
@@ -523,6 +523,12 @@ def build(
             manifest_context["channel_finder_mode"] = build_profile.channel_finder_mode
         if build_profile.claude_md_template:
             manifest_context["claude_md_template"] = build_profile.claude_md_template
+        # Mark which model-selection keys came from an explicit `--set` so the
+        # manifest can distinguish user intent from resolved preset defaults
+        # (persona auto-render forwards only the former).
+        explicit_set_keys = explicit_model_override_keys(tuple(set_pairs))
+        if explicit_set_keys:
+            manifest_context["explicit_set_keys"] = explicit_set_keys
         # Carry the invocation source forward so build_reproducible_command
         # renders the matching --preset or positional form (C12).
         if preset:

--- a/src/osprey/cli/build_profile.py
+++ b/src/osprey/cli/build_profile.py
@@ -1157,6 +1157,26 @@ def _parse_set_pairs(pairs: tuple[str, ...]) -> dict[str, Any]:
     return result
 
 
+# The model-selection shorthand keys a user can override via `--set` whose
+# explicit use is recorded in the project manifest (extract_build_args) and
+# re-applied by persona auto-render, so one parent-build override retints
+# every derived persona project.
+MODEL_SELECTION_OVERRIDE_KEYS = ("provider", "model", "channel_finder_mode")
+
+
+def explicit_model_override_keys(set_pairs: tuple[str, ...]) -> list[str]:
+    """Model-selection keys the user explicitly overrode via bare ``--set``.
+
+    Only top-level shorthand keys count (``--set provider=x``); a dotted path
+    into ``config:`` addresses the rendered config directly and carries no
+    whole-stack intent, so it is never forwarded to persona renders.
+
+    Returns the matching keys in :data:`MODEL_SELECTION_OVERRIDE_KEYS` order.
+    """
+    parsed = _parse_set_pairs(set_pairs)
+    return [key for key in MODEL_SELECTION_OVERRIDE_KEYS if key in parsed]
+
+
 def resolve_build_profile(
     profile_path: Path | None,
     preset: str | None,

--- a/src/osprey/cli/templates/manifest.py
+++ b/src/osprey/cli/templates/manifest.py
@@ -328,6 +328,21 @@ def extract_build_args(
             if isinstance(value, bool) or value:
                 build_args[arg_key] = value
 
+    # Record which of those keys the user EXPLICITLY passed via `--set`
+    # (context["explicit_set_keys"], stamped by build_cmd). The values above
+    # are resolved ones — preset defaults included — so this marker is what
+    # lets persona auto-render forward the user's overrides without ever
+    # clobbering a persona preset with a mere default.
+    explicit_raw = context.get("explicit_set_keys")
+    if isinstance(explicit_raw, (list, tuple)):
+        explicit = [
+            arg_key
+            for _, arg_key in optional_keys
+            if arg_key in explicit_raw and arg_key in build_args
+        ]
+        if explicit:
+            build_args["explicit_overrides"] = explicit
+
     return build_args
 
 

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -35,6 +35,7 @@ from osprey.deployment.staleness import warn_if_project_stale
 from osprey.deployment.web_terminals.provision import (
     deploy_down_web_terminals,
     deploy_up_web_terminals,
+    preflight_web_terminals,
 )
 from osprey.utils.config import ConfigBuilder
 from osprey.utils.dotenv import parse_dotenv_file
@@ -986,6 +987,14 @@ def deploy_up(config_path, detached=False, dev_mode=False, expose_network=False)
     if dev_mode:
         env["DEV_MODE"] = "true"
         logger.key_info("Development mode: DEV_MODE environment variable set for containers")
+
+    # Fail-fast web-terminal preflight (persona render + credential gate)
+    # BEFORE the minutes-long image build below: a deploy that is doomed to
+    # abort on a missing provider secret must say so in seconds, not after
+    # the whole project image has been built. deploy_up_web_terminals re-runs
+    # the same (idempotent) steps later, unchanged.
+    if web_terminals_enabled:
+        preflight_web_terminals(config, env)
 
     # Build the <project>:local image the dispatch worker references. The worker
     # has no compose build block (that would race the event-dispatcher on the

--- a/src/osprey/deployment/web_terminals/env_production.py
+++ b/src/osprey/deployment/web_terminals/env_production.py
@@ -318,12 +318,28 @@ def ensure_env_production(config: dict, project_root: str | Path) -> Path:
     missing = {var: origin for var, origin in required_cc_vars.items() if var not in dotenv}
     if missing:
         needs = "; ".join(f"{origin} needs {var}" for var, origin in missing.items())
+        # .env stays the only secret SOURCE (see the determinism note above) —
+        # but when a missing var is sitting right there in the caller's shell,
+        # say so and hand over the exact copy-in command instead of leaving
+        # the operator to discover the .env-only rule by archaeology. Presence
+        # check only; the value itself is never read into the message.
+        exported = [var for var in missing if os.environ.get(var)]
+        shell_hint = ""
+        if exported:
+            copy_cmds = " && ".join(f'echo "{var}=${var}" >> {env_path}' for var in exported)
+            verb = "are" if len(exported) > 1 else "is"
+            shell_hint = (
+                f" Note: {', '.join(exported)} {verb} exported in the current "
+                f"shell, but .env is the canonical secrets store for this "
+                f"deploy (generation never reads the ambient environment). "
+                f"Copy it in with: {copy_cmds}"
+            )
         raise RuntimeError(
             f"Generating {env_production_path} from {env_path} would leave web "
             f"terminals unauthenticated: {needs}, not set in {env_path}. Add "
             "the missing variable(s) there, or author .env.production yourself "
             "(an existing file is never regenerated) if this deploy "
-            "authenticates another way."
+            f"authenticates another way.{shell_hint}"
         )
 
     subset = _build_env_production_subset(config, dotenv, {**required_cc_vars, **extra_cc_vars})

--- a/src/osprey/deployment/web_terminals/persona_images.py
+++ b/src/osprey/deployment/web_terminals/persona_images.py
@@ -7,6 +7,7 @@ persona project on demand via ``osprey build``). Called from
 registry-mode deploys never enter this module.
 """
 
+import json
 import os
 import subprocess
 import sys
@@ -200,8 +201,42 @@ def _referenced_personas(config: dict, resolved_users: list[dict]) -> list[dict[
     return referenced
 
 
+def _parent_set_override_args(project_root: Path) -> list[str]:
+    """``--set KEY=VALUE`` argv fragments re-applying the parent project's
+    explicit model-selection overrides to a persona render.
+
+    Reads the parent's ``.osprey-manifest.json`` ``build_args``: only keys the
+    user explicitly passed via ``--set`` at parent build time (recorded as
+    ``explicit_overrides`` by ``extract_build_args``) are forwarded — resolved
+    preset defaults never are, so a persona preset keeps its own say over
+    anything the user didn't override. Best-effort by design: an absent,
+    unreadable, or legacy manifest yields ``[]`` (the pre-forwarding argv),
+    never an error — a render must not fail over provenance metadata.
+    """
+    manifest_path = project_root / ".osprey-manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    build_args = manifest.get("build_args") if isinstance(manifest, dict) else None
+    if not isinstance(build_args, dict):
+        return []
+    explicit = build_args.get("explicit_overrides")
+    if not isinstance(explicit, list):
+        return []
+    args: list[str] = []
+    for key in explicit:
+        value = build_args.get(key)
+        if isinstance(key, str) and isinstance(value, str | int) and value:
+            args.extend(["--set", f"{key}={value}"])
+    return args
+
+
 def auto_render_missing_personas(
-    config: dict, resolved_users: list[dict], env: dict[str, str]
+    config: dict,
+    resolved_users: list[dict],
+    env: dict[str, str],
+    project_root: Path | None = None,
 ) -> None:
     """Render each referenced persona whose project directory is absent (local mode).
 
@@ -237,10 +272,16 @@ def auto_render_missing_personas(
     :param resolved_users: :func:`osprey.deployment.web_terminals.personas.resolve_personas`'s
         output for this deploy.
     :param env: Environment for the ``osprey build`` subprocess(es).
+    :param project_root: The deploy (parent) project root. When given, the
+        parent's explicit ``--set`` model-selection overrides — recorded in
+        its ``.osprey-manifest.json`` — are forwarded to every persona render
+        (see :func:`_parent_set_override_args`), so one parent-build override
+        retints the whole stack. ``None`` forwards nothing.
     :raises ValueError: A referenced persona whose project_path is a partial
         render, or one that must be rendered but whose catalog entry lacks a
         usable ``build_profile``.
     """
+    forwarded_set_args = _parent_set_override_args(project_root) if project_root is not None else []
     for unit in _referenced_personas(config, resolved_users):
         persona_name = unit["persona"]
         project = unit["project"]
@@ -285,8 +326,14 @@ def auto_render_missing_personas(
             "-o",
             str(project_path.parent),
             "--skip-deps",
+            *forwarded_set_args,
         ]
         logger.key_info("Auto-rendering persona %r project at %s", persona_name, project_path)
+        if forwarded_set_args:
+            logger.key_info(
+                "  ↳ forwarding parent build overrides: %s",
+                " ".join(forwarded_set_args),
+            )
         logger.info("Running command:\n    %s", " ".join(cmd))
         subprocess.run(cmd, env=env, check=True)
 

--- a/src/osprey/deployment/web_terminals/provision.py
+++ b/src/osprey/deployment/web_terminals/provision.py
@@ -43,6 +43,34 @@ from osprey.utils.logger import get_logger
 logger = get_logger("deployment.lifecycle")
 
 
+def preflight_web_terminals(config: dict, env: dict[str, str]) -> None:
+    """Fail-fast web-terminal preflight, run BEFORE any image build.
+
+    ``deploy_up`` invokes this ahead of its (minutes-long) project-image
+    build so the two deploy aborts that need no image at all — an
+    unresolvable persona catalog and a missing provider auth secret
+    (:func:`ensure_env_production`'s fail-closed gate) — surface in seconds.
+    Local mode first renders any missing persona project (the credential
+    sweep reads each rendered persona's ``config.yml``), forwarding the
+    parent's explicit ``--set`` overrides exactly as the main provisioning
+    path does.
+
+    Every step is idempotent, so :func:`deploy_up_web_terminals` re-running
+    the same sequence later is a cheap no-op: rendered personas are
+    user-owned and skipped, and an existing ``.env.production`` is returned
+    as-is. Assumes the project-root cwd every other step of ``osprey deploy
+    up`` already relies on.
+    """
+    project_root = os.getcwd()
+    web_terminals = (config.get("modules") or {}).get("web_terminals") or {}
+    if effective_image_source(web_terminals) == "local":
+        facility_prefix = (config.get("facility") or {}).get("prefix") or ""
+        registry_cfg = config.get("registry") or {}
+        resolved_users = resolve_personas(web_terminals, registry_cfg, facility_prefix, strict=True)
+        auto_render_missing_personas(config, resolved_users, env, project_root=Path(project_root))
+    ensure_env_production(config, project_root)
+
+
 def deploy_up_web_terminals(
     config: dict,
     compose_files: list[str],
@@ -205,7 +233,7 @@ def deploy_up_web_terminals(
         # Render any referenced persona whose project isn't on disk yet, so the
         # image build below always finds a complete context -- the `osprey build`
         # + `osprey deploy up` demo promise, no manual per-persona builds.
-        auto_render_missing_personas(config, resolved_users, env)
+        auto_render_missing_personas(config, resolved_users, env, project_root=Path(project_root))
         # ensure_env_production AFTER auto-render (its claude_code credential
         # sweep reads each rendered persona's config.yml -- on a first deploy
         # those exist only once auto-render has run) but still BEFORE any

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -12,8 +12,9 @@ name: Control Assistant
 # bundle that includes channel databases, benchmarks, and a logbook seed.
 data_bundle: control_assistant
 
-# Default LLM provider and model.  Override here or via --provider / --model
-# flags on `osprey build`.
+# Default LLM provider and model. Override here or via `osprey build`'s
+# --set provider=... / --set model=... flags; explicit --set overrides are
+# also forwarded to the persona projects auto-rendered at deploy time.
 provider: anthropic
 model: claude-haiku-4-5
 

--- a/tests/cli/test_manifest_build_args.py
+++ b/tests/cli/test_manifest_build_args.py
@@ -1,0 +1,82 @@
+"""Explicit ``--set`` override recording in the project manifest.
+
+``extract_build_args`` has always recorded the *resolved* provider/model/
+channel_finder_mode (preset defaults included). These tests lock in the
+``explicit_overrides`` field: the subset of those keys the user actually
+passed via ``--set``, which persona auto-render re-applies to derived
+builds so one ``--set provider=`` retints the whole multi-user stack.
+"""
+
+from osprey.cli.build_profile import explicit_model_override_keys
+from osprey.cli.templates.manifest import build_reproducible_command, extract_build_args
+
+
+def _args(context):
+    return extract_build_args(
+        project_name="proj",
+        preset_name="control-assistant",
+        profile_path=None,
+        data_bundle="control_assistant",
+        context=context,
+    )
+
+
+def test_explicit_set_keys_recorded_as_explicit_overrides():
+    args = _args(
+        {
+            "default_provider": "als-apg",
+            "default_model": "anthropic/claude-opus",
+            "channel_finder_mode": "hierarchical",
+            "explicit_set_keys": ["provider", "model"],
+        }
+    )
+    assert args["explicit_overrides"] == ["provider", "model"]
+    # The resolved values themselves are recorded exactly as before.
+    assert args["provider"] == "als-apg"
+    assert args["channel_finder_mode"] == "hierarchical"
+
+
+def test_no_explicit_set_keys_omits_field():
+    args = _args({"default_provider": "anthropic", "default_model": "claude-haiku-4-5"})
+    assert "explicit_overrides" not in args
+
+
+def test_explicit_key_without_recorded_value_is_dropped():
+    # A key claimed explicit but with no recorded value (e.g. --set model=
+    # parsed to an empty string) must not be marked forwardable.
+    args = _args({"default_provider": "anthropic", "explicit_set_keys": ["model"]})
+    assert "explicit_overrides" not in args
+
+
+def test_reproducible_command_ignores_explicit_marker():
+    """The rebuild command renders --set for every recorded value, explicit or
+    not — the marker only governs persona forwarding, never the command."""
+    args = _args(
+        {
+            "default_provider": "als-apg",
+            "default_model": "anthropic/claude-opus",
+            "explicit_set_keys": ["provider"],
+        }
+    )
+    cmd = build_reproducible_command(args)
+    assert "--set provider=als-apg" in cmd
+    assert "--set model=anthropic/claude-opus" in cmd
+    assert "explicit" not in cmd
+
+
+def test_explicit_model_override_keys_top_level_only():
+    """Only bare top-level model-selection keys count; dotted paths into
+    config (or unrelated keys) never do."""
+    keys = explicit_model_override_keys(
+        (
+            "provider=als-apg",
+            "config.claude_code.provider=cborg",
+            "deploy_services=false",
+            "channel_finder_mode=in_context",
+        )
+    )
+    assert keys == ["provider", "channel_finder_mode"]
+
+
+def test_explicit_model_override_keys_empty_for_no_pairs():
+    assert explicit_model_override_keys(()) == []

--- a/tests/deployment/test_container_lifecycle.py
+++ b/tests/deployment/test_container_lifecycle.py
@@ -621,7 +621,7 @@ def _mode_wiring_collab(monkeypatch, tmp_path):
     monkeypatch.setattr(
         provision,
         "auto_render_missing_personas",
-        lambda config, resolved_users, env: None,
+        lambda config, resolved_users, env, project_root=None: None,
     )
 
     def _fake_run(cmd, **kwargs):
@@ -750,7 +750,7 @@ def test_local_mode_calls_auto_render_then_ensure_env_production_then_build_then
     monkeypatch.setattr(
         provision,
         "auto_render_missing_personas",
-        lambda cfg, resolved_users, env: order.append("auto_render"),
+        lambda cfg, resolved_users, env, project_root=None: order.append("auto_render"),
     )
 
     def _fake_build(cfg, resolved_users, dev_mode, env):
@@ -765,10 +765,14 @@ def test_local_mode_calls_auto_render_then_ensure_env_production_then_build_then
 
     container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=False)
 
-    # Exactly three compose calls (the stale-container `rm -f` preflight, the
-    # web `up -d`, then the advisory nginx config reload; no deployed_services,
-    # no pull in local mode) after all three preflight steps, in this order.
+    # The fail-fast deploy_up preflight runs auto_render + ensure_env_production
+    # once BEFORE the image-build stage, and deploy_up_web_terminals re-runs the
+    # same (idempotent) pair; then exactly three compose calls (the
+    # stale-container `rm -f` preflight, the web `up -d`, then the advisory
+    # nginx config reload; no deployed_services, no pull in local mode).
     assert order == [
+        "auto_render",
+        "ensure_env_production",
         "auto_render",
         "ensure_env_production",
         "build_persona_images",
@@ -873,7 +877,16 @@ def test_registry_mode_calls_ensure_env_production_before_pull_before_up(
 
     container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=False)
 
-    assert order == ["ensure_env_production", "rm", "pull", "up", "nginx_reload"]
+    # Twice before any compose call: once from deploy_up's fail-fast preflight
+    # (pre-image-build), once from deploy_up_web_terminals' own idempotent run.
+    assert order == [
+        "ensure_env_production",
+        "ensure_env_production",
+        "rm",
+        "pull",
+        "up",
+        "nginx_reload",
+    ]
 
 
 def test_post_up_hook_order_is_linger_then_seed_then_verify(
@@ -1734,6 +1747,7 @@ def test_deploy_up_prints_endpoint_summary_on_web_path(_wiring_calls, monkeypatc
         ),
     )
     monkeypatch.setattr(container_lifecycle, "deploy_up_web_terminals", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "preflight_web_terminals", lambda *a, **k: None)
     container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
     assert _wiring_calls["summary"] == [["docker-compose.yml"]]
 
@@ -1749,3 +1763,83 @@ def test_deploy_up_summarizes_even_when_nothing_deploys(_wiring_calls, monkeypat
     container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
     assert _wiring_calls["stale"] == [tmp_path.resolve()]
     assert _wiring_calls["summary"] == [["docker-compose.yml"]]
+
+
+# ---------------------------------------------------------------------------
+# deploy_up ordering: the web-terminal preflight (persona auto-render +
+# .env.production credential gate) must run BEFORE the expensive project-image
+# build -- a missing provider secret aborts in seconds, not after minutes of
+# docker build.
+# ---------------------------------------------------------------------------
+
+
+def test_deploy_up_runs_web_terminal_preflight_before_image_build(monkeypatch, tmp_path):
+    order: list[str] = []
+
+    web_config = {
+        "deployed_services": [],
+        "modules": {"web_terminals": {"enabled": True, "image_source": "local"}},
+    }
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        container_lifecycle,
+        "prepare_compose_files",
+        lambda *a, **k: (web_config, ["docker-compose.yml"]),
+    )
+    monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
+    monkeypatch.setattr(container_lifecycle, "_preflight_host_ports", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "_ensure_service_tokens", lambda *a, **k: None)
+    monkeypatch.setattr(
+        container_lifecycle,
+        "preflight_web_terminals",
+        lambda *a, **k: order.append("preflight"),
+    )
+    monkeypatch.setattr(
+        container_lifecycle,
+        "_build_project_image",
+        lambda *a, **k: order.append("build_image"),
+    )
+    monkeypatch.setattr(
+        container_lifecycle,
+        "deploy_up_web_terminals",
+        lambda *a, **k: order.append("web_up"),
+    )
+    monkeypatch.setattr(container_lifecycle, "log_endpoint_summary", lambda *a, **k: None)
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    assert order == ["preflight", "build_image", "web_up"]
+
+
+def test_deploy_up_no_web_terminals_skips_preflight(monkeypatch, tmp_path):
+    order: list[str] = []
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        container_lifecycle,
+        "prepare_compose_files",
+        lambda *a, **k: ({"deployed_services": ["event_dispatcher"]}, ["docker-compose.yml"]),
+    )
+    monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+    monkeypatch.setattr(container_lifecycle, "_preflight_host_ports", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "_ensure_service_tokens", lambda *a, **k: None)
+    monkeypatch.setattr(
+        container_lifecycle,
+        "preflight_web_terminals",
+        lambda *a, **k: order.append("preflight"),
+    )
+    monkeypatch.setattr(
+        container_lifecycle,
+        "_build_project_image",
+        lambda *a, **k: order.append("build_image"),
+    )
+    monkeypatch.setattr(container_lifecycle.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "log_endpoint_summary", lambda *a, **k: None)
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    assert "preflight" not in order
+    assert "build_image" in order

--- a/tests/deployment/web_terminals/test_env_production.py
+++ b/tests/deployment/web_terminals/test_env_production.py
@@ -411,3 +411,33 @@ def test_env_production_existing_file_with_credential_does_not_warn(tmp_path, ca
         env_production.ensure_env_production(config, tmp_path)
 
     assert "none of the LLM credential" not in caplog.text
+
+
+def test_env_production_missing_secret_present_in_shell_env_names_the_fix(tmp_path, monkeypatch):
+    """The gate deliberately never reads the ambient shell env as a secret
+    source -- but when the missing var IS exported there, the error must say
+    so and hand the operator the exact copy-in command, instead of leaving
+    them to discover the .env-only rule by archaeology."""
+    monkeypatch.setenv("ALS_APG_API_KEY", "exported-in-shell")
+    _write_dotenv(tmp_path / ".env", {"SOMETHING_ELSE": "x"})
+    config = _persona_config(tmp_path, {"operator": "als-apg"})
+
+    with pytest.raises(RuntimeError, match="ALS_APG_API_KEY") as excinfo:
+        env_production.ensure_env_production(config, tmp_path)
+
+    message = str(excinfo.value)
+    assert "exported in the current shell" in message
+    assert f">> {tmp_path / '.env'}" in message
+    # The secret VALUE itself must never appear in the error.
+    assert "exported-in-shell" not in message
+
+
+def test_env_production_missing_secret_absent_everywhere_has_no_shell_hint(tmp_path, monkeypatch):
+    monkeypatch.delenv("ALS_APG_API_KEY", raising=False)
+    _write_dotenv(tmp_path / ".env", {"SOMETHING_ELSE": "x"})
+    config = _persona_config(tmp_path, {"operator": "als-apg"})
+
+    with pytest.raises(RuntimeError) as excinfo:
+        env_production.ensure_env_production(config, tmp_path)
+
+    assert "exported in the current shell" not in str(excinfo.value)

--- a/tests/deployment/web_terminals/test_persona_images.py
+++ b/tests/deployment/web_terminals/test_persona_images.py
@@ -567,3 +567,115 @@ def test_auto_render_renders_each_distinct_persona_once(monkeypatch, tmp_path):
     assert len(calls) == 2
     assert any("ops-app" in c and "control-assistant" in c for c in calls)
     assert any("sci-app" in c and "physicist" in c for c in calls)
+
+
+# ---------------------------------------------------------------------------
+# auto_render_missing_personas -- forwarding the parent project's explicit
+# --set model-selection overrides (recorded in its .osprey-manifest.json) into
+# each persona render, so one `--set provider=` at parent build time retints
+# the whole multi-user stack.
+# ---------------------------------------------------------------------------
+
+
+def _write_parent_manifest(project_root: Path, build_args: dict) -> None:
+    import json
+
+    (project_root / ".osprey-manifest.json").write_text(
+        json.dumps({"schema_version": "1.0", "build_args": build_args}), encoding="utf-8"
+    )
+
+
+def test_auto_render_forwards_explicit_overrides_from_parent_manifest(monkeypatch, tmp_path):
+    """Parent manifest marks provider+model as explicit --set overrides ->
+    the persona render argv carries the same --set pairs; the non-explicit
+    channel_finder_mode (a preset default) is NOT forwarded, so a persona
+    preset keeps its own say over anything the user didn't override."""
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    _write_parent_manifest(
+        parent,
+        {
+            "provider": "als-apg",
+            "model": "anthropic/claude-opus",
+            "channel_finder_mode": "hierarchical",
+            "explicit_overrides": ["provider", "model"],
+        },
+    )
+    config = _auto_render_config(tmp_path)
+    calls = []
+    monkeypatch.setattr(persona_images.subprocess, "run", lambda cmd, **k: calls.append(cmd))
+
+    persona_images.auto_render_missing_personas(config, _AUTO_RENDER_USERS, {}, project_root=parent)
+
+    assert len(calls) == 1
+    cmd = calls[0]
+    assert cmd[-4:] == ["--set", "provider=als-apg", "--set", "model=anthropic/claude-opus"]
+    assert "channel_finder_mode=hierarchical" not in " ".join(cmd)
+
+
+def test_auto_render_without_project_root_forwards_nothing(monkeypatch, tmp_path):
+    """No project_root (legacy caller) -> argv identical to the pre-forwarding
+    form, no --set anywhere."""
+    config = _auto_render_config(tmp_path)
+    calls = []
+    monkeypatch.setattr(persona_images.subprocess, "run", lambda cmd, **k: calls.append(cmd))
+
+    persona_images.auto_render_missing_personas(config, _AUTO_RENDER_USERS, {})
+
+    assert len(calls) == 1
+    assert "--set" not in calls[0]
+
+
+def test_auto_render_legacy_manifest_without_explicit_marker_forwards_nothing(
+    monkeypatch, tmp_path
+):
+    """A manifest from before explicit_overrides existed records resolved
+    values only -> nothing is forwarded (resolved preset defaults must never
+    clobber a persona preset's own configuration)."""
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    _write_parent_manifest(parent, {"provider": "anthropic", "model": "claude-haiku-4-5"})
+    config = _auto_render_config(tmp_path)
+    calls = []
+    monkeypatch.setattr(persona_images.subprocess, "run", lambda cmd, **k: calls.append(cmd))
+
+    persona_images.auto_render_missing_personas(config, _AUTO_RENDER_USERS, {}, project_root=parent)
+
+    assert len(calls) == 1
+    assert "--set" not in calls[0]
+
+
+def test_auto_render_malformed_or_absent_manifest_is_ignored(monkeypatch, tmp_path):
+    """An unreadable/absent parent manifest degrades to no forwarding -- the
+    render itself must never fail over provenance metadata."""
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    (parent / ".osprey-manifest.json").write_text("{not json", encoding="utf-8")
+    config = _auto_render_config(tmp_path)
+    calls = []
+    monkeypatch.setattr(persona_images.subprocess, "run", lambda cmd, **k: calls.append(cmd))
+
+    persona_images.auto_render_missing_personas(config, _AUTO_RENDER_USERS, {}, project_root=parent)
+
+    assert len(calls) == 1
+    assert "--set" not in calls[0]
+
+
+def test_auto_render_forwards_only_keys_with_recorded_values(monkeypatch, tmp_path):
+    """A key listed in explicit_overrides but missing its recorded value (a
+    hand-edited or truncated manifest) is skipped, never rendered as
+    `--set key=None`."""
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    _write_parent_manifest(
+        parent, {"provider": "als-apg", "explicit_overrides": ["provider", "model"]}
+    )
+    config = _auto_render_config(tmp_path)
+    calls = []
+    monkeypatch.setattr(persona_images.subprocess, "run", lambda cmd, **k: calls.append(cmd))
+
+    persona_images.auto_render_missing_personas(config, _AUTO_RENDER_USERS, {}, project_root=parent)
+
+    cmd = calls[0]
+    assert cmd[-2:] == ["--set", "provider=als-apg"]
+    assert "model" not in " ".join(cmd)


### PR DESCRIPTION
## Summary

Makes the `--set provider= / --set model= / --set channel_finder_mode=` dev workflow work end-to-end for multi-user stacks, and makes doomed deploys fail in seconds instead of after a full image build.

- **Explicit `--set` overrides propagate to persona projects.** `osprey build` records which model-selection keys were explicitly passed via `--set` in the manifest (`build_args.explicit_overrides`); persona auto-render at deploy time forwards exactly those to each persona's `osprey build`. One `--set provider=` at parent build now retints the whole stack. Resolved preset defaults are never forwarded, so a persona preset keeps its own say over anything the user didn't override. Legacy manifests (no marker) forward nothing — behavior unchanged.
- **Fail-fast web-terminal preflight.** `deploy up` now runs persona auto-render + the fail-closed `.env.production` credential gate *before* the minutes-long project-image build. Both steps are idempotent; `deploy_up_web_terminals` re-runs them unchanged.
- **Actionable credential error.** When a required provider secret is missing from `.env` but exported in the caller's shell, the gate's error says so and names the exact copy-in command. `.env` remains the only secret source the generator reads (the documented determinism invariant is untouched — presence check only, no value ever read into the message).
- Fixes the `control-assistant` preset comment that advertised nonexistent `--provider/--model` flags.

## Test plan

- 15 new unit tests (fail-first): manifest explicit-override recording + round-trip, persona-render forwarding (explicit-only, legacy/malformed manifest degradation, value-less key skip), deploy_up preflight-before-build ordering, shell-env hint presence/absence (asserting the secret value never leaks into the message).
- Updated 5 existing lifecycle tests for the new call order/signature.
- Live-verified: a scratch parent built with `--set provider=cborg --set model=anthropic/claude-haiku` auto-rendered both persona projects with `claude_code.provider: cborg` and the model forwarded.
- `quick_check.sh` green (1830 passed; one unrelated testcontainers flake that passes from the main checkout).