### PR TITLE
feat(dispatch): input files for dispatched runs

### DIFF
--- a/src/osprey/dispatch/server.py
+++ b/src/osprey/dispatch/server.py
@@ -17,6 +17,7 @@ import hmac
 import json
 import logging
 import os
+import time
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
@@ -39,6 +40,7 @@ from osprey.dispatch.trigger_config import (
 from osprey.dispatch.worker_client import (
     AuthError,
     DispatchError,
+    FatalDispatchError,
     cancel_worker_run,
     dispatch_to_worker,
     fetch_worker_runs,
@@ -47,10 +49,44 @@ from osprey.dispatch.worker_client import (
 
 logger = logging.getLogger("osprey.dispatch.server")
 
+# Capabilities this dispatcher advertises on /health. A downstream bridge gates
+# feature use on BOTH the dispatcher's and the worker's /health carrying the
+# capability, so the list is a plain JSON array on both bodies.
+_CAPABILITIES: list[str] = ["input_files"]
+
+# Boot nonce: this dispatcher process's start timestamp, captured once at import.
+# Stable for the process lifetime and different across restarts, mirroring the
+# worker's boot_nonce so a poller can detect a dispatcher restart.
+_BOOT_NONCE: float = time.time()
+
+# Sentinel: distinguishes "no input_files threaded yet" (first call) from an
+# explicit ``None`` payload once popped, so retries reuse the already-popped batch.
+_INPUT_FILES_UNSET: Any = object()
+
 
 # ---------------------------------------------------------------------------
 # Dispatch helper with on_error policy handling
 # ---------------------------------------------------------------------------
+
+
+def _log_input_files(trigger_name: str, input_files: list[dict[str, Any]]) -> None:
+    """Log the carried input files by filename and approximate decoded size only.
+
+    Never logs ``content_b64`` — only the filename and a byte-size estimate
+    (derived arithmetically from the base64 length, so no bytes are decoded just
+    to log them). The estimate is close enough for an operational log line.
+    """
+    parts = []
+    for f in input_files:
+        b64 = f.get("content_b64") or ""
+        approx = (len(b64) * 3) // 4 if isinstance(b64, str) else 0
+        parts.append(f"{f.get('filename')!r}=~{approx}B")
+    logger.info(
+        "Trigger '%s' carries %d input file(s): %s",
+        trigger_name,
+        len(input_files),
+        ", ".join(parts),
+    )
 
 
 async def _dispatch_with_policy(
@@ -60,12 +96,25 @@ async def _dispatch_with_policy(
     dispatch_target: str,
     dispatch_token: str,
     attempt: int = 1,
+    input_files: Any = _INPUT_FILES_UNSET,
 ) -> dict | None:
     """Execute the trigger action and handle on_error policy.
 
-    Returns the worker response dict on success (contains run_id, status),
-    or None if the dispatch was dropped/failed after retries.
+    Returns the worker response dict on success (contains run_id, status), a
+    ``{"status": "error", "error_code": ...}`` sentinel on a fatal (4xx) worker
+    rejection, or None if the dispatch was dropped/failed after retries.
     """
+    # Pop the caller's input-file batch OUT of the payload on the FIRST call,
+    # before the payload is folded into the prompt or persisted to history — the
+    # base64 bytes must never land in either. Threaded through the retry
+    # recursion via ``input_files`` so a re-dispatch still carries the files
+    # (the payload dict no longer holds them after the pop).
+    if input_files is _INPUT_FILES_UNSET:
+        popped = payload.pop("input_files", None)
+        input_files = popped if isinstance(popped, list) else None
+        if input_files:
+            _log_input_files(trigger.name, input_files)
+
     action = trigger.action
     prompt = action.get("prompt", "")
     allowed_tools = action.get("allowed_tools", [])
@@ -98,9 +147,22 @@ async def _dispatch_with_policy(
             token=dispatch_token,
             surface_prompt=surface_prompt,
             surface_tools=surface_tools,
+            input_files=input_files,
         )
         await registry.record_event(trigger.name, payload, "dispatched")
         return result
+
+    except FatalDispatchError as exc:
+        # A deterministic 4xx rejection (e.g. input_files over cap / invalid).
+        # NOT retryable and must NOT drop to None: surface a sentinel error dict
+        # carrying the machine-readable error_code. The pool wraps this return
+        # value; ``get_dispatch_result`` unwraps the sentinel into a top-level
+        # pool error so the poll body exposes ``error_code``. Log the code only,
+        # never the worker's body.
+        code = exc.error_code
+        logger.warning("Fatal dispatch rejection for trigger '%s': %s", trigger.name, code or "4xx")
+        await registry.record_event(trigger.name, payload, f"rejected: {code or '4xx'}")
+        return {"status": "error", "error_code": code, "error": str(exc)}
 
     except (DispatchError, AuthError) as exc:
         # Only dispatch/auth failures flow through the on_error policy. A genuine
@@ -133,7 +195,13 @@ async def _dispatch_with_policy(
             if backoff_sec > 0:
                 await asyncio.sleep(backoff_sec)
             return await _dispatch_with_policy(
-                trigger, payload, registry, dispatch_target, dispatch_token, attempt + 1
+                trigger,
+                payload,
+                registry,
+                dispatch_target,
+                dispatch_token,
+                attempt + 1,
+                input_files=input_files,
             )
         else:
             # drop (or retry exhausted)
@@ -235,6 +303,8 @@ async def health(request: Request) -> JSONResponse:
             "status": "ok",
             "trigger_count": trigger_count,
             "pool": pool_status,
+            "capabilities": _CAPABILITIES,
+            "boot_nonce": _BOOT_NONCE,
         }
     )
 
@@ -255,6 +325,28 @@ async def get_dispatch_result(request: Request) -> JSONResponse:
     result = _pool.get_result(dispatch_id)
     if result is None:
         return JSONResponse({"detail": f"dispatch_id {dispatch_id!r} not found"}, status_code=404)
+
+    # A fatal (4xx) worker rejection creates no run: ``_dispatch_with_policy``
+    # returns a ``{"status": "error", "error_code": ...}`` sentinel, which the
+    # pool wraps as ``{"status": "completed", "result": <sentinel>}``. Unwrap it
+    # into a TOP-LEVEL pool error carrying ``error_code``, which is what a polling
+    # client keys on (status == "error" -> read error_code). A genuine worker
+    # response reports status "accepted", never "error", so this only fires for
+    # the sentinel.
+    inner = result.get("result")
+    if (
+        result.get("status") == "completed"
+        and isinstance(inner, dict)
+        and inner.get("status") == "error"
+    ):
+        return JSONResponse(
+            {
+                "status": "error",
+                "error": inner.get("error"),
+                "error_code": inner.get("error_code"),
+                "trigger_name": result.get("trigger_name"),
+            }
+        )
 
     # Do NOT echo the internal worker URL (_dispatch_target) back to callers — it
     # is an internal topology detail and the poll response should carry only the

--- a/src/osprey/dispatch/sources/webhook.py
+++ b/src/osprey/dispatch/sources/webhook.py
@@ -26,6 +26,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("osprey.dispatch.sources.webhook")
 
+# Explicit request-body ceiling for the webhook route. A legit body carrying an
+# input-files batch tops out near ~24 MB (base64 + history); 32 MB leaves ~25%
+# headroom while bounding memory a hostile caller can force the dispatcher to
+# buffer. Enforced from the Content-Length header before the body is read.
+_MAX_WEBHOOK_BYTES = 32 * 1024 * 1024
+
 
 class WebhookSource:
     """Event source that fires triggers from authenticated webhook POSTs."""
@@ -48,6 +54,18 @@ class WebhookSource:
         @mcp_app.custom_route("/webhook/{trigger_name}", methods=["POST"])
         async def handle_webhook(request: Request) -> JSONResponse:
             trigger_name = request.path_params["trigger_name"]
+            # Reject an over-size body up front (413) from its declared
+            # Content-Length, before reading/parsing it — so a huge payload never
+            # gets buffered. A missing/unparseable header falls through to normal
+            # handling (our own callers always set Content-Length).
+            content_length = request.headers.get("content-length")
+            if content_length is not None:
+                try:
+                    declared = int(content_length)
+                except ValueError:
+                    declared = -1
+                if declared > _MAX_WEBHOOK_BYTES:
+                    return JSONResponse({"detail": "Request body too large"}, status_code=413)
             auth_header = request.headers.get("Authorization", "")
             try:
                 payload = await request.json()

--- a/src/osprey/dispatch/worker_client.py
+++ b/src/osprey/dispatch/worker_client.py
@@ -9,11 +9,54 @@ import httpx
 
 
 class DispatchError(Exception):
-    """Raised on connection errors or timeouts when dispatching to a worker."""
+    """Raised on connection errors, timeouts, or a retryable (5xx) worker error."""
 
 
 class AuthError(Exception):
     """Raised when the worker returns HTTP 401 Unauthorized."""
+
+
+class FatalDispatchError(Exception):
+    """Raised on a deterministic 4xx rejection from the worker.
+
+    A 4xx means the request itself is malformed/oversized (e.g. an input-files
+    batch over cap, or a body past the size limit): an identical redispatch is
+    rejected identically, so this is NOT retryable. ``error_code`` carries the
+    machine-readable ``detail`` whitelisted from the worker's 4xx JSON body (one
+    of :data:`KNOWN_REJECTION_CODES`), or ``None`` when the body carried no
+    recognised code. The caller surfaces this as a pool error carrying
+    ``error_code`` rather than routing it through the retry/drop policy.
+    """
+
+    def __init__(self, message: str, *, error_code: str | None = None) -> None:
+        super().__init__(message)
+        self.error_code = error_code
+
+
+# Machine-readable 4xx ``detail`` codes the client is willing to propagate. Kept
+# in lock-step with ``dispatch_worker.input_files_policy`` (DETAIL_CAP_EXCEEDED /
+# DETAIL_INVALID). Whitelisting — rather than echoing whatever ``detail`` the
+# body carries — keeps arbitrary worker-internal text out of the dispatcher.
+KNOWN_REJECTION_CODES: frozenset[str] = frozenset(
+    {"input_files_cap_exceeded", "input_files_invalid"}
+)
+
+
+def _extract_rejection_code(response: httpx.Response) -> str | None:
+    """Whitelist the machine-readable ``detail`` code from a worker 4xx body.
+
+    Returns the code only when it is one of :data:`KNOWN_REJECTION_CODES`; any
+    other, absent, or unparseable ``detail`` yields ``None`` (generic). Never
+    returns arbitrary body text — a 4xx body may still carry internal detail.
+    """
+    try:
+        body = response.json()
+    except ValueError:
+        return None
+    if not isinstance(body, dict):
+        return None
+    detail = body.get("detail")
+    return detail if detail in KNOWN_REJECTION_CODES else None
 
 
 async def dispatch_to_worker(
@@ -24,6 +67,7 @@ async def dispatch_to_worker(
     timeout: float = 30.0,
     surface_prompt: str | None = None,
     surface_tools: list[str] | None = None,
+    input_files: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """POST a prompt to a dispatch worker's /dispatch endpoint.
 
@@ -32,19 +76,27 @@ async def dispatch_to_worker(
         prompt: The prompt text to dispatch.
         allowed_tools: List of tool names the agent is allowed to use.
         token: Bearer token for authentication.
-        timeout: Request timeout in seconds.
+        timeout: Base request timeout (seconds). Used as the read/pool timeout; the
+            connect and write timeouts are widened independently (see below) so a
+            large ``input_files`` upload is not killed by a modest read timeout.
         surface_prompt: Optional per-surface system-prompt fragment. Omitted from the
             request payload entirely when ``None`` or empty, so a worker predating this
             field sees an unchanged request.
         surface_tools: Optional per-surface tool-scope narrowing. Omitted from the
             request payload entirely when ``None`` or empty, same as ``surface_prompt``.
+        input_files: Optional caller-supplied file batch (already validated upstream),
+            each item ``{"filename", "mime", "content_b64", "ingest"}``. Omitted from
+            the payload when ``None`` or empty, so a worker predating the field sees an
+            unchanged request.
 
     Returns:
         Response JSON dict (typically contains ``run_id`` and ``status``).
 
     Raises:
         AuthError: If the server returns HTTP 401.
-        DispatchError: On connection errors or timeout.
+        FatalDispatchError: On a non-401 4xx (deterministic, non-retryable rejection),
+            carrying a whitelisted ``error_code`` when the body supplied one.
+        DispatchError: On connection errors, timeout, or a retryable 5xx.
     """
     dispatch_url = url.rstrip("/") + "/dispatch"
     headers = {"Authorization": f"Bearer {token}"}
@@ -56,9 +108,16 @@ async def dispatch_to_worker(
         payload["surface_prompt"] = surface_prompt
     if surface_tools:
         payload["surface_tools"] = surface_tools
+    if input_files:
+        payload["input_files"] = input_files
 
+    # A dispatch body carrying input_files can reach ~24 MB. httpx's single-float
+    # timeout would apply that same short window to the write phase and abort the
+    # upload; give connect/write generous windows while keeping the read/pool
+    # timeout at ``timeout`` (the worker returns 202 as soon as it enqueues).
+    client_timeout = httpx.Timeout(timeout, connect=10.0, write=120.0)
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
+        async with httpx.AsyncClient(timeout=client_timeout) as client:
             response = await client.post(dispatch_url, json=payload, headers=headers)
     except httpx.TimeoutException as exc:
         raise DispatchError(f"Timeout dispatching to {dispatch_url}: {exc}") from exc
@@ -70,13 +129,23 @@ async def dispatch_to_worker(
     if response.status_code == 401:
         raise AuthError(f"Unauthorized (401) from {dispatch_url}")
 
+    # A non-401 4xx is a deterministic rejection of THIS request — never retry it,
+    # and never drop it to a silent None. Surface a typed FatalDispatchError
+    # carrying a whitelisted machine-readable code (or None) so the caller records
+    # it as a non-retryable pool error. 413 (body too large) is included here.
+    if 400 <= response.status_code < 500:
+        raise FatalDispatchError(
+            f"HTTP {response.status_code} from worker",
+            error_code=_extract_rejection_code(response),
+        )
+
     try:
         response.raise_for_status()
     except httpx.HTTPStatusError as exc:
         # Surface only the status code — never echo the worker's response body
         # into the dispatcher's registry history; it can carry a stack trace or
         # other internal detail. Raise a typed DispatchError so the on_error
-        # policy treats it like any other dispatch failure.
+        # policy treats it like any other (retryable) dispatch failure.
         raise DispatchError(f"HTTP {response.status_code} from worker") from exc
     return cast(dict[str, Any], response.json())
 

--- a/src/osprey/interfaces/artifacts/resolve.py
+++ b/src/osprey/interfaces/artifacts/resolve.py
@@ -125,6 +125,18 @@ def _get_store() -> ArtifactStore:
     return ArtifactStore(workspace_root=_agent_data_root())
 
 
+def get_run_store() -> ArtifactStore:
+    """Public accessor for the run-scoped artifact store used by dispatch.
+
+    The single source of truth for the store root shared by everything that
+    reads or writes a dispatch run's artifacts — the resolver's descriptors and
+    byte route here, and the worker's pre-run input-file ingestion. Routing both
+    through one constructor keeps them on the same ``_agent_data`` root, so a
+    file the worker writes is exactly the file the byte route later serves.
+    """
+    return _get_store()
+
+
 # ---------------------------------------------------------------------------
 # Delivery prediction (render-free)
 # ---------------------------------------------------------------------------
@@ -187,6 +199,11 @@ def describe_run_artifacts(run_id: str) -> list[dict[str, Any]]:
         return []
     out: list[dict[str, Any]] = []
     for e in entries:
+        # Caller-supplied inputs (origin="input") are not things the run
+        # produced — they are surfaced separately (see describe_run_input_artifacts)
+        # so a consumer never mistakes an ingested image for agent output.
+        if e.origin == "input":
+            continue
         delivered_mime, convertible = predict_delivery(e.mime_type)
         out.append(
             {
@@ -195,6 +212,41 @@ def describe_run_artifacts(run_id: str) -> list[dict[str, Any]]:
                 "source_mime": e.mime_type,
                 "delivered_mime": delivered_mime,
                 "convertible": convertible,
+            }
+        )
+    return out
+
+
+def describe_run_input_artifacts(run_id: str) -> list[dict[str, Any]]:
+    """Descriptors of the caller-supplied files ingested into a run, oldest first.
+
+    The counterpart to :func:`describe_run_artifacts`: it returns only the
+    ``origin="input"`` entries (the files the worker stored before the agent
+    ran), which that function excludes. Reads only the store index via the
+    strict created-by ``run_filter`` tag, so it is cheap and cannot cross runs.
+    Returns ``[]`` for an unknown/empty run or one with no ingested inputs.
+
+    Each descriptor is exactly ``{entry_id, filename, mime}`` — ``entry_id`` is
+    the store id the byte route resolves, ``filename`` the caller's (sanitised)
+    name, ``mime`` the stored content type. These keys are a consumed contract;
+    do not rename them.
+    """
+    if not run_id:
+        return []
+    try:
+        entries = _get_store().list_entries(run_filter=run_id)
+    except Exception:
+        logger.warning("Could not read artifact store for run %s", run_id, exc_info=True)
+        return []
+    out: list[dict[str, Any]] = []
+    for e in entries:
+        if e.origin != "input":
+            continue
+        out.append(
+            {
+                "entry_id": e.id,
+                "filename": e.metadata.get("input_filename", e.filename),
+                "mime": e.mime_type,
             }
         )
     return out

--- a/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
+++ b/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
@@ -18,6 +18,7 @@ cannot disagree. See ``osprey.interfaces.artifacts.resolve``.
 from __future__ import annotations
 
 import asyncio
+import base64
 import hmac
 import json
 import logging
@@ -34,6 +35,8 @@ from pydantic import BaseModel, field_validator
 
 from osprey.interfaces.artifacts.resolve import (
     describe_run_artifacts,
+    describe_run_input_artifacts,
+    get_run_store,
     load_run_record,
     resolve_single_run_artifact,
 )
@@ -430,6 +433,90 @@ class DispatchResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Input-file ingestion
+# ---------------------------------------------------------------------------
+
+# Prompt-assembly seam, keyed by run_id: the per-input-file descriptors that
+# ingestion hands to the (downstream) prompt-assembly step. Held in memory only
+# for the brief window between ingestion (start of the run task) and prompt
+# assembly; the run task's ``finally`` drops any entry a consumer left behind.
+_run_input_seam: dict[str, list[dict[str, Any]]] = {}
+
+
+def take_input_seam(run_id: str) -> list[dict[str, Any]]:
+    """Pop and return the input-file seam for ``run_id`` (``[]`` if none).
+
+    The handoff from ingestion to prompt assembly. Each item is
+    ``{"filename": str, "mime": str, "entry_id": str | None, "content_b64": str | None}``:
+    for an ingested (``ingest=True``) file ``entry_id`` is its artifact-store id
+    and ``content_b64`` is ``None`` (fetch the bytes via the byte route); for an
+    ``ingest=False`` file ``entry_id`` is ``None`` and ``content_b64`` carries
+    the original bytes to inline directly. Pop-once: a second call returns
+    ``[]``.
+    """
+    return _run_input_seam.pop(run_id, [])
+
+
+def _input_artifact_type(mime: str) -> str:
+    """Coarse ``artifact_type`` for an ingested input file, from its mime."""
+    if mime.startswith("image/"):
+        return "image"
+    if mime == "application/json":
+        return "json"
+    if mime.startswith("text/"):
+        return "text"
+    return "file"
+
+
+def ingest_input_files(run_id: str, input_files: list[InputFile]) -> list[dict[str, Any]]:
+    """Ingest a validated input-file batch for ``run_id`` before its SDK run.
+
+    ``ingest=True`` files are base64-decoded and written to the artifact store
+    tagged with this run's ``run_id`` and ``origin="input"`` — so the byte route
+    serves them and the status body's ``input_artifacts`` lists them, while the
+    agent's produced-artifact listing excludes them. ``ingest=False`` files are
+    never stored; their bytes ride the returned seam straight to prompt
+    assembly. Returns the seam (one item per file, in request order) documented
+    on :func:`take_input_seam`.
+
+    The batch was validated at request time (mime allowlist, decodable base64,
+    size caps), so this never re-rejects — it only decodes and writes. Filenames
+    are already sanitised on the model, so the stored name is safe.
+    """
+    if not input_files:
+        return []
+    store = get_run_store()
+    seam: list[dict[str, Any]] = []
+    for f in input_files:
+        if f.ingest:
+            raw = base64.b64decode(f.content_b64)
+            entry = store.save_file(
+                file_content=raw,
+                filename=f.filename,
+                artifact_type=_input_artifact_type(f.mime),
+                title=f.filename,
+                mime_type=f.mime,
+                tool_source="input",
+                metadata={"input_filename": f.filename},
+                run_id=run_id,
+                origin="input",
+            )
+            seam.append(
+                {"filename": f.filename, "mime": f.mime, "entry_id": entry.id, "content_b64": None}
+            )
+        else:
+            seam.append(
+                {
+                    "filename": f.filename,
+                    "mime": f.mime,
+                    "entry_id": None,
+                    "content_b64": f.content_b64,
+                }
+            )
+    return seam
+
+
+# ---------------------------------------------------------------------------
 # Background task
 # ---------------------------------------------------------------------------
 
@@ -488,6 +575,14 @@ async def _run_dispatch_task(run_id: str, request: DispatchRequest) -> None:
         request.max_turns,
     )
     try:
+        # Ingest caller-supplied input files BEFORE the SDK run: ingest=true
+        # files are decoded into the artifact store (run_id tag + origin="input")
+        # so their entry_ids exist for prompt assembly and the status body, while
+        # ingest=false files pass through untouched. The returned seam is stashed
+        # for the prompt-assembly step to consume via take_input_seam(); the
+        # finally drops it if nothing consumed it.
+        _run_input_seam[run_id] = ingest_input_files(run_id, request.input_files or [])
+
         result = await asyncio.wait_for(
             sdk_runner.run_dispatch(
                 prompt=request.prompt,
@@ -508,6 +603,9 @@ async def _run_dispatch_task(run_id: str, request: DispatchRequest) -> None:
         # computed once at completion from the store tag and persisted with the
         # run so it survives restart and never disagrees with the live routes.
         result["artifacts"] = describe_run_artifacts(run_id)
+        # Caller-supplied inputs ingested for this run, kept separate from the
+        # agent's produced ``artifacts`` (both read the same created-by store tag).
+        result["input_artifacts"] = describe_run_input_artifacts(run_id)
         _runs[run_id] = result
         _persist_run(run_id, result)
         logger.info("Dispatch %s completed: status=%s", run_id, result.get("status"))
@@ -571,6 +669,7 @@ async def _run_dispatch_task(run_id: str, request: DispatchRequest) -> None:
     finally:
         _tasks.pop(run_id, None)
         run_stats.pop_run_stats(run_id)
+        _run_input_seam.pop(run_id, None)
 
 
 # ---------------------------------------------------------------------------

--- a/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
+++ b/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
@@ -37,7 +37,13 @@ from osprey.interfaces.artifacts.resolve import (
     load_run_record,
     resolve_single_run_artifact,
 )
-from osprey.mcp_server.dispatch_worker import counters, failure_class, run_stats, sdk_runner
+from osprey.mcp_server.dispatch_worker import (
+    counters,
+    failure_class,
+    retention,
+    run_stats,
+    sdk_runner,
+)
 from osprey.mcp_server.dispatch_worker.input_files_policy import (
     InputFilesError,
     sanitize_filename,
@@ -220,8 +226,11 @@ async def _lifespan(app: FastAPI):
     counters.install()
     _load_persisted_runs()
     task = asyncio.create_task(_stale_run_cleanup())
+    retention_task = _start_retention_sweep()
     yield
     task.cancel()
+    if retention_task is not None:
+        retention_task.cancel()
 
 
 app = FastAPI(title="dispatch-worker", version="1.0.0", lifespan=_lifespan)
@@ -314,6 +323,34 @@ async def _stale_run_cleanup() -> None:
     while True:
         await asyncio.sleep(60)
         _sweep_stale_runs()
+
+
+def _in_flight_run_ids() -> frozenset[str]:
+    """Run ids of currently-pending (in-flight) runs — never swept by retention."""
+    return frozenset(rid for rid, run in _runs.items() if run.get("status") == "pending")
+
+
+def _start_retention_sweep() -> asyncio.Task | None:
+    """Start the opt-in retention sweep task, or return ``None`` when disabled.
+
+    Enabled only when ``RETENTION_DAYS`` is a positive integer. The store factory
+    mirrors the artifact resolver's root logic (the module singleton is rooted at
+    the wrong CWD in the worker process).
+    """
+    retention_days = retention.retention_days_from_env()
+    if retention_days <= 0:
+        return None
+
+    from osprey.interfaces.artifacts.resolve import _get_store
+
+    return asyncio.create_task(
+        retention.retention_loop(
+            _LOG_DIR,
+            _get_store,
+            retention_days,
+            _in_flight_run_ids,
+        )
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
+++ b/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
@@ -29,7 +29,7 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 from fastapi import Depends, FastAPI, HTTPException, Request, status
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, field_validator
 
@@ -62,6 +62,17 @@ logger = logging.getLogger("osprey.mcp_server.dispatch_worker")
 
 DISPATCH_TIMEOUT_SEC = int(os.environ.get("DISPATCH_TIMEOUT_SEC", "300"))
 _QUEUE_TTL_SEC = 60  # discard unconsumed SSE queues after this many seconds post-completion
+
+# Explicit request-body ceiling. A legit /dispatch body carrying an input-files
+# batch tops out near ~24 MB (base64 + prompt); 32 MB leaves ~25% headroom while
+# bounding the memory a hostile caller can force the worker to buffer. Enforced
+# from Content-Length before the body is read (see ``_limit_request_body``).
+MAX_REQUEST_BYTES = 32 * 1024 * 1024
+
+# Capabilities this worker advertises on /health. A downstream bridge gates
+# feature use on BOTH the dispatcher's and the worker's /health carrying the
+# capability, so the list is a plain JSON array on both bodies.
+_CAPABILITIES: list[str] = ["input_files"]
 
 # ---------------------------------------------------------------------------
 # App setup
@@ -237,6 +248,28 @@ async def _lifespan(app: FastAPI):
 
 
 app = FastAPI(title="dispatch-worker", version="1.0.0", lifespan=_lifespan)
+
+
+@app.middleware("http")
+async def _limit_request_body(request: Request, call_next):  # noqa: ANN001, ANN202
+    """Reject an over-size request body (413) before the route reads it.
+
+    Guards every route from the declared Content-Length; only /dispatch carries a
+    large body in practice, but a global guard is simplest and GET routes carry no
+    body. A missing/unparseable Content-Length falls through to normal handling
+    (our own callers always set it), so this is a cheap bound, not a hard cap on a
+    lying/chunked client.
+    """
+    content_length = request.headers.get("content-length")
+    if content_length is not None:
+        try:
+            declared = int(content_length)
+        except ValueError:
+            declared = -1
+        if declared > MAX_REQUEST_BYTES:
+            return JSONResponse({"detail": "Request body too large"}, status_code=413)
+    return await call_next(request)
+
 
 _bearer_scheme = HTTPBearer()
 
@@ -855,6 +888,7 @@ async def health() -> dict[str, Any]:
         "provider_errors": lifetime[failure_class.FAILURE_PROVIDER],
         "infrastructure_errors": lifetime[failure_class.FAILURE_INFRASTRUCTURE],
         "boot_nonce": _BOOT_NONCE,
+        "capabilities": _CAPABILITIES,
     }
 
 

--- a/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
+++ b/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
@@ -30,7 +30,7 @@ from typing import Any
 from fastapi import Depends, FastAPI, HTTPException, Request, status
 from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from osprey.interfaces.artifacts.resolve import (
     describe_run_artifacts,
@@ -38,6 +38,11 @@ from osprey.interfaces.artifacts.resolve import (
     resolve_single_run_artifact,
 )
 from osprey.mcp_server.dispatch_worker import counters, failure_class, run_stats, sdk_runner
+from osprey.mcp_server.dispatch_worker.input_files_policy import (
+    InputFilesError,
+    sanitize_filename,
+    validate_input_files,
+)
 from osprey.utils.tool_rules import matches_denylist
 
 logger = logging.getLogger("osprey.mcp_server.dispatch_worker")
@@ -337,6 +342,29 @@ def _verify_token(credentials: HTTPAuthorizationCredentials = Depends(_bearer_sc
 # ---------------------------------------------------------------------------
 
 
+class InputFile(BaseModel):
+    """One caller-supplied file carried alongside a dispatch prompt.
+
+    ``ingest`` defaults to ``True`` (the file is meant to be handed to the
+    agent). ``filename`` is sanitised to a safe basename on construction — no
+    directory or traversal components survive — so every downstream consumer
+    sees an already-safe name. Caps and the mime allowlist are enforced at
+    request time by :func:`osprey.mcp_server.dispatch_worker.input_files_policy.validate_input_files`,
+    not on this model, so an invalid batch rejects the whole request with one
+    machine-readable code rather than a field-level 422.
+    """
+
+    filename: str
+    mime: str
+    content_b64: str
+    ingest: bool = True
+
+    @field_validator("filename")
+    @classmethod
+    def _sanitize_filename(cls, value: str) -> str:
+        return sanitize_filename(value)
+
+
 class DispatchRequest(BaseModel):
     """Request body for ``POST /dispatch``.
 
@@ -345,6 +373,10 @@ class DispatchRequest(BaseModel):
     a pure no-op for the dispatched run. Consuming them (system-prompt
     injection, tool narrowing) is left to downstream tasks; this model only
     carries the values across the dispatcher→worker boundary.
+
+    ``input_files`` is likewise additive and defaults to ``None``. When present
+    it is validated fail-closed at request time (see :func:`dispatch`); this
+    model only carries the batch — ingestion is a downstream task.
     """
 
     prompt: str
@@ -352,6 +384,7 @@ class DispatchRequest(BaseModel):
     max_turns: int = 25
     surface_prompt: str | None = None
     surface_tools: list[str] | None = None
+    input_files: list[InputFile] | None = None
 
 
 class DispatchResponse(BaseModel):
@@ -524,6 +557,20 @@ async def dispatch(request: DispatchRequest) -> DispatchResponse:
             status_code=status.HTTP_403_FORBIDDEN,
             detail=f"Tools blocked by server denylist: {denied}",
         )
+
+    # Fail-closed input-file validation BEFORE any run is created: mime
+    # allowlist, per-file and total decoded-size caps, ingest-file count. A
+    # violation rejects the whole request with a machine-readable 400 detail
+    # (a bridge maps it to a non-retryable failure class).
+    if request.input_files:
+        try:
+            validate_input_files(request.input_files)
+        except InputFilesError as exc:
+            logger.warning("Rejected dispatch: input files invalid (%s): %s", exc.detail, exc)
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=exc.detail,
+            ) from exc
 
     # Evict oldest entries if store exceeds capacity
     if len(_runs) >= _MAX_RUNS:

--- a/src/osprey/mcp_server/dispatch_worker/input_files_policy.py
+++ b/src/osprey/mcp_server/dispatch_worker/input_files_policy.py
@@ -1,0 +1,142 @@
+"""Policy constants and fail-closed validation for dispatch-worker input files.
+
+A dispatch request may carry a batch of caller-supplied files (images, text,
+JSON) alongside the prompt. This module is the single source of truth for what
+that batch may contain: the mime allowlist, the per-file and total decoded-size
+caps, the ingest-file count cap, and filename sanitisation. The request model
+and its request-time validation live in ``dispatch_api``; the follow-on
+ingestion step imports the same constants and helpers here so both surfaces
+agree byte-for-byte on the policy.
+
+The module is framework-free (no FastAPI import): validation raises
+:class:`InputFilesError` carrying a machine-readable ``detail`` code, and the
+HTTP layer maps that to a 400 response.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import re
+from collections.abc import Sequence
+from typing import Any
+
+# Mime allowlist — the only content types a caller may push as input files.
+ALLOWED_MIMES: frozenset[str] = frozenset(
+    {
+        "image/png",
+        "image/jpeg",
+        "image/gif",
+        "image/webp",
+        "text/csv",
+        "text/plain",
+        "text/markdown",
+        "application/json",
+    }
+)
+
+# Per-file decoded-size caps, keyed on mime family.
+MAX_IMAGE_BYTES = 5 * 1024 * 1024  # 5 MB per image/* file
+MAX_TEXT_BYTES = 100 * 1024  # 100 KB per text/* or application/json file
+
+# At most this many files may request ingestion (ingest=True).
+MAX_INGEST_FILES = 5
+
+# Ceiling on the combined decoded size of ALL carried files (ingest=True and
+# ingest=False alike). The headroom above the ~10 MB working budget exists so a
+# request can re-inject prior images (carried ingest=False) without tripping the
+# total.
+MAX_TOTAL_DECODED_BYTES = 18 * 1024 * 1024  # 18 MB
+
+# Machine-readable HTTP 400 detail codes. A bridge maps these to a non-retryable
+# failure class, so the exact strings are load-bearing — do not reword.
+DETAIL_CAP_EXCEEDED = "input_files_cap_exceeded"
+DETAIL_INVALID = "input_files_invalid"
+
+
+class InputFilesError(Exception):
+    """Raised when a batch of input files violates policy.
+
+    ``detail`` is one of :data:`DETAIL_CAP_EXCEEDED` / :data:`DETAIL_INVALID`;
+    the HTTP layer copies it verbatim into the 400 response body. ``message`` is
+    a human-readable explanation for logs only.
+    """
+
+    def __init__(self, detail: str, message: str = "") -> None:
+        super().__init__(message or detail)
+        self.detail = detail
+
+
+_UNSAFE_CHARS = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def sanitize_filename(name: str) -> str:
+    """Reduce ``name`` to a safe basename — no directory or traversal parts.
+
+    Strips any path components (either separator), drops NUL bytes, collapses
+    every character outside ``[A-Za-z0-9._-]`` to ``_``, and removes leading
+    dots so the result can never be ``""``, ``"."``, ``".."`` or a bare dotfile.
+    Always returns a non-empty string (``"file"`` as a last resort).
+    """
+    base = name.replace("\\", "/").split("/")[-1].replace("\x00", "")
+    base = _UNSAFE_CHARS.sub("_", base)
+    base = base.lstrip(".")
+    return base or "file"
+
+
+def decoded_size(content_b64: str) -> int:
+    """Return the decoded byte length of ``content_b64``.
+
+    Raises :class:`InputFilesError` with :data:`DETAIL_INVALID` if the string is
+    not valid (strict) base64.
+    """
+    try:
+        raw = base64.b64decode(content_b64, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise InputFilesError(DETAIL_INVALID, f"undecodable base64: {exc}") from exc
+    return len(raw)
+
+
+def validate_input_files(files: Sequence[Any]) -> None:
+    """Fail-closed validation of a dispatch request's input files.
+
+    Each element is duck-typed as an input file: attributes ``mime`` (str),
+    ``content_b64`` (str), and ``ingest`` (bool). Enforces, in order: the
+    ingest-file count cap, then per file the mime allowlist and decoded-size
+    cap, then the combined decoded-size ceiling across every file. Raises
+    :class:`InputFilesError` on the first violation (the whole request is
+    rejected); a valid or empty batch returns ``None``.
+    """
+    if not files:
+        return
+
+    ingest_count = sum(1 for f in files if f.ingest)
+    if ingest_count > MAX_INGEST_FILES:
+        raise InputFilesError(
+            DETAIL_CAP_EXCEEDED,
+            f"{ingest_count} ingest files exceeds cap of {MAX_INGEST_FILES}",
+        )
+
+    total = 0
+    for f in files:
+        if f.mime not in ALLOWED_MIMES:
+            raise InputFilesError(DETAIL_INVALID, f"mime not allowed: {f.mime!r}")
+        size = decoded_size(f.content_b64)
+        if f.mime.startswith("image/"):
+            if size > MAX_IMAGE_BYTES:
+                raise InputFilesError(
+                    DETAIL_CAP_EXCEEDED,
+                    f"image {size} bytes exceeds per-file cap of {MAX_IMAGE_BYTES}",
+                )
+        elif size > MAX_TEXT_BYTES:
+            raise InputFilesError(
+                DETAIL_CAP_EXCEEDED,
+                f"text/json {size} bytes exceeds per-file cap of {MAX_TEXT_BYTES}",
+            )
+        total += size
+
+    if total > MAX_TOTAL_DECODED_BYTES:
+        raise InputFilesError(
+            DETAIL_CAP_EXCEEDED,
+            f"total decoded {total} bytes exceeds cap of {MAX_TOTAL_DECODED_BYTES}",
+        )

--- a/src/osprey/mcp_server/dispatch_worker/retention.py
+++ b/src/osprey/mcp_server/dispatch_worker/retention.py
@@ -1,0 +1,236 @@
+"""Opt-in retention sweep for dispatch run records and artifacts.
+
+Disabled by default. Set the ``RETENTION_DAYS`` env var to a positive integer to
+enable it; unset, empty, ``0``, or a non-integer all mean *disabled* (nothing is
+ever deleted). When enabled, a periodic background task deletes:
+
+  * persisted dispatch run records (``_agent_data/dispatch/{run_id}.json``), and
+  * ``ArtifactStore`` entries (index row + on-disk file),
+
+whose age exceeds the threshold. Age is measured from a record's completion (a
+run record's ``completed_at``, falling back to ``created_at``; an artifact's
+``timestamp``). A record is deleted only when it is strictly older than
+``RETENTION_DAYS`` days — a record aged exactly ``N-1`` days survives, one aged
+``N+1`` days is deleted.
+
+In-flight runs are never swept regardless of age: a run record whose status is
+not terminal is skipped, and any run id currently pending in the worker (passed
+in as ``in_flight_run_ids``) is skipped along with the artifacts it produced.
+
+This is a generic OSPREY-core capability with no channel awareness. The sweep
+functions are pure (they take the log dir, an ``ArtifactStore``, and an injected
+``now``) so they can be driven directly in tests without a clock or sleeps.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from collections.abc import Callable, Iterable
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from osprey.stores.artifact_store import ArtifactStore
+
+logger = logging.getLogger("osprey.mcp_server.dispatch_worker.retention")
+
+_SECONDS_PER_DAY = 86400.0
+
+# Only terminal run records are eligible for deletion. A non-terminal (pending)
+# record represents an in-flight run and must survive regardless of age. Kept in
+# sync with dispatch_api._TERMINAL_STATUSES.
+_TERMINAL_STATUSES = frozenset({"completed", "error"})
+
+# Default interval between periodic sweeps when enabled.
+DEFAULT_SWEEP_INTERVAL_SEC = 3600.0
+
+
+def retention_days_from_env(env: dict[str, str] | None = None) -> int:
+    """Parse ``RETENTION_DAYS``. Unset, empty, ``0``, or non-integer → ``0`` (off).
+
+    Only a positive integer enables retention; every other value disables it, so
+    a typo can never silently start deleting data on a shorter horizon than
+    intended.
+    """
+    raw = (env if env is not None else os.environ).get("RETENTION_DAYS", "").strip()
+    if not raw:
+        return 0
+    try:
+        days = int(raw)
+    except ValueError:
+        logger.warning("Ignoring invalid RETENTION_DAYS=%r — retention disabled", raw)
+        return 0
+    if days <= 0:
+        return 0
+    return days
+
+
+def _parse_iso_timestamp(value: str) -> float | None:
+    """Convert an ISO-8601 artifact timestamp to epoch seconds, or ``None``."""
+    try:
+        return datetime.fromisoformat(value).timestamp()
+    except (TypeError, ValueError):
+        return None
+
+
+def sweep_dispatch_runs(
+    log_dir: str | Path,
+    retention_days: int,
+    now: float,
+    in_flight_run_ids: Iterable[str] = (),
+) -> int:
+    """Delete persisted run records older than the threshold. Returns the count.
+
+    Skips any record that is non-terminal or whose run id is in
+    ``in_flight_run_ids`` (an in-flight run is never swept). Unreadable files are
+    left in place. A no-op when ``retention_days <= 0`` or the dir is absent.
+    """
+    if retention_days <= 0:
+        return 0
+    log_dir = Path(log_dir)
+    if not log_dir.is_dir():
+        return 0
+
+    in_flight = frozenset(in_flight_run_ids)
+    cutoff = now - retention_days * _SECONDS_PER_DAY
+    deleted = 0
+
+    for path in log_dir.glob("*.json"):
+        run_id = path.name.removesuffix(".json")
+        if run_id in in_flight:
+            continue
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            logger.warning("Retention: could not read %s — skipping", path, exc_info=True)
+            continue
+
+        if data.get("status") not in _TERMINAL_STATUSES:
+            # In-flight / non-terminal record — never sweep it.
+            continue
+
+        ts = data.get("completed_at")
+        if ts is None:
+            ts = data.get("created_at")
+        try:
+            ts = float(ts)
+        except (TypeError, ValueError):
+            continue
+
+        # Strictly older than the window: age exactly N days survives (ts == cutoff).
+        if ts >= cutoff:
+            continue
+
+        try:
+            path.unlink()
+            deleted += 1
+        except OSError:
+            logger.warning("Retention: failed to delete %s", path, exc_info=True)
+
+    return deleted
+
+
+def sweep_artifacts(
+    store: ArtifactStore,
+    retention_days: int,
+    now: float,
+    in_flight_run_ids: Iterable[str] = (),
+) -> int:
+    """Delete artifact entries older than the threshold. Returns the count.
+
+    An artifact produced by an in-flight run (its ``run_id`` tag is in
+    ``in_flight_run_ids``) survives regardless of age. Both the index row and the
+    on-disk file are removed via ``ArtifactStore.delete_entry``. A no-op when
+    ``retention_days <= 0``.
+    """
+    if retention_days <= 0:
+        return 0
+
+    in_flight = frozenset(in_flight_run_ids)
+    cutoff = now - retention_days * _SECONDS_PER_DAY
+    deleted = 0
+
+    # Snapshot the entry ids first: delete_entry mutates the index under a lock,
+    # so iterate over a stable list rather than the live entry collection.
+    for entry in list(store.list_entries()):
+        if entry.run_id and entry.run_id in in_flight:
+            continue
+        ts = _parse_iso_timestamp(entry.timestamp)
+        if ts is None or ts >= cutoff:
+            continue
+        if store.delete_entry(entry.id):
+            deleted += 1
+
+    return deleted
+
+
+def run_sweep(
+    log_dir: str | Path,
+    store: ArtifactStore,
+    retention_days: int,
+    now: float | None = None,
+    in_flight_run_ids: Iterable[str] = (),
+) -> dict[str, int]:
+    """Run one full retention sweep (run records + artifacts). Returns counts.
+
+    Pure and directly callable in tests. Logs a single line with the deleted
+    counts when anything was removed.
+    """
+    if retention_days <= 0:
+        return {"runs": 0, "artifacts": 0}
+    if now is None:
+        now = time.time()
+
+    in_flight = frozenset(in_flight_run_ids)
+    runs_deleted = sweep_dispatch_runs(log_dir, retention_days, now, in_flight)
+    artifacts_deleted = sweep_artifacts(store, retention_days, now, in_flight)
+
+    if runs_deleted or artifacts_deleted:
+        logger.info(
+            "Retention sweep (older than %dd): deleted %d run record(s), %d artifact(s)",
+            retention_days,
+            runs_deleted,
+            artifacts_deleted,
+        )
+    return {"runs": runs_deleted, "artifacts": artifacts_deleted}
+
+
+async def retention_loop(
+    log_dir: str | Path,
+    store_factory: Callable[[], ArtifactStore],
+    retention_days: int,
+    in_flight_run_ids: Callable[[], Iterable[str]],
+    interval_sec: float = DEFAULT_SWEEP_INTERVAL_SEC,
+) -> None:
+    """Periodically run :func:`run_sweep` every ``interval_sec`` seconds.
+
+    ``store_factory`` builds a fresh ``ArtifactStore`` each cycle (the worker's
+    module singleton is rooted at the wrong CWD — see
+    ``osprey.interfaces.artifacts.resolve._get_store``). ``in_flight_run_ids`` is
+    re-read each cycle so a run that starts mid-sweep-interval is protected.
+
+    A failing sweep is logged and the loop continues — retention must never take
+    the worker down. Returns only on cancellation.
+    """
+    import asyncio
+
+    logger.info(
+        "Retention sweep enabled: deleting records older than %d day(s), every %.0fs",
+        retention_days,
+        interval_sec,
+    )
+    while True:
+        await asyncio.sleep(interval_sec)
+        try:
+            run_sweep(
+                log_dir,
+                store_factory(),
+                retention_days,
+                in_flight_run_ids=in_flight_run_ids(),
+            )
+        except Exception:
+            logger.exception("Retention sweep cycle failed — continuing")

--- a/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
+++ b/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
@@ -7,8 +7,10 @@ structured results for use by the dispatch API endpoint.
 from __future__ import annotations
 
 import asyncio
+import base64
 import logging
 import os
+import re
 import time
 import uuid
 from collections.abc import Iterable
@@ -18,6 +20,32 @@ from typing import Any
 from osprey.mcp_server.dispatch_worker import failure_class, run_stats
 
 logger = logging.getLogger("osprey.mcp_server.dispatch_worker.sdk_runner")
+
+# Any base64-ish run this long is not something this module ever intends to
+# log — the sole source of such a run here is an inlined image input's bytes
+# (content_b64). Redact it defensively so no current or future log statement in
+# this module can leak inlined image bytes to a sink. Session/run UUIDs carry
+# hyphens (max alnum run ~12 chars), so they are never touched. Hygiene
+# invariant — unit-asserted alongside "never in the prompt string / run record".
+_B64_RUN_RE = re.compile(r"[A-Za-z0-9+/]{64,}={0,2}")
+
+
+class _Base64RedactingFilter(logging.Filter):
+    """Redact long base64-ish runs from this logger's records (defense-in-depth)."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            message = record.getMessage()
+        except Exception:
+            return True
+        redacted = _B64_RUN_RE.sub("[redacted-b64]", message)
+        if redacted != message:
+            record.msg = redacted
+            record.args = ()
+        return True
+
+
+logger.addFilter(_Base64RedactingFilter())
 
 # SDK imports -- guard so module loads even when SDK is not installed
 # (SDK is only available inside the worker container).
@@ -97,6 +125,120 @@ def _cap_text(text: str) -> str:
         dropped = len(text) - _MAX_TEXT_OUTPUT
         return text[:_MAX_TEXT_OUTPUT] + f"\n…[truncated {dropped} chars]"
     return text
+
+
+# ---------------------------------------------------------------------------
+# Input-file prompt assembly
+# ---------------------------------------------------------------------------
+
+# Header introducing the per-input-file descriptor block appended to the prompt.
+# Generic and mechanism-only: it names no channel and states no policy, so it
+# never contradicts a channel-specific system-prompt fragment.
+_INPUT_FILES_HEADER = "Files provided with this request:"
+
+
+def _take_seam(run_id: str | None) -> list[dict[str, Any]]:
+    """Pop this run's input-file seam exactly once (``[]`` when there is none).
+
+    Deferred, function-local import of ``take_input_seam``: a top-level import
+    would be circular (``dispatch_api`` imports ``sdk_runner``). Pop-once — the
+    dispatch task populated the seam before invoking the run, and the task's
+    ``finally`` drops anything left behind. A run with no ``run_id`` (unit tests,
+    ad-hoc calls) has no seam.
+    """
+    if not run_id:
+        return []
+    from osprey.mcp_server.dispatch_worker.dispatch_api import take_input_seam
+
+    return take_input_seam(run_id)
+
+
+def _load_entry_b64(entry_id: str) -> str | None:
+    """Return an ingested artifact's bytes as raw base64, or ``None`` if absent.
+
+    Used to re-inline an ``ingest=True`` image input (its bytes already live in
+    the ArtifactStore, so the seam item carries no ``content_b64``) as an image
+    content block. The store copy is retained — the same entry stays readable
+    later via ``data_read`` — so this only reads, never removes.
+    """
+    try:
+        from osprey.interfaces.artifacts.resolve import get_run_store
+
+        path = get_run_store().get_file_path(entry_id)
+        if path is None or not path.exists():
+            return None
+        return base64.b64encode(path.read_bytes()).decode("ascii")
+    except Exception:
+        logger.warning("Could not load input artifact %s for inlining", entry_id, exc_info=True)
+        return None
+
+
+def _descriptor_line(item: dict[str, Any], *, inlined: bool) -> str:
+    """One mechanism-only descriptor line for an input file.
+
+    An inlined image is marked ``image shown inline [shown_inline]`` — the
+    literal ``shown_inline`` token is a consumed marker (a downstream channel
+    prompt keys on it). A store-resident file is referenced by the mechanism a
+    reader uses to open it: ``data_read("<entry_id>")``. No mention of
+    base64/ingest/caps — mechanism only.
+    """
+    filename = item.get("filename")
+    mime = item.get("mime")
+    if inlined:
+        return f"- {filename} ({mime}) — image shown inline [shown_inline]"
+    entry_id = item.get("entry_id")
+    if entry_id:
+        return f'- {filename} ({mime}) — read with data_read("{entry_id}")'
+    # Degenerate: a non-image seam item with neither an entry_id nor a way to
+    # inline it. The seam contract makes text-mime inputs store-resident, so this
+    # is not expected; emit a bare descriptor rather than a false access hint.
+    return f"- {filename} ({mime})"
+
+
+def _assemble_user_content(
+    prompt: str, seam_items: list[dict[str, Any]]
+) -> str | list[dict[str, Any]]:
+    """Build the user-message ``content`` from the prompt and the input seam.
+
+    Routing by mime: ``image/*`` items become base64 image content blocks in the
+    same user message (from the seam's ``content_b64`` when present, else the
+    stored bytes via ``entry_id``); every other item is referenced by descriptor
+    only. Every input file — inlined or not — contributes one descriptor line to
+    a block appended to the prompt text.
+
+    Returns the raw ``prompt`` string when there are no input files (unchanged
+    legacy shape), a ``[*image_blocks, {text}]`` list when at least one image is
+    inlined, and a ``prompt + descriptor`` string when there are inputs but none
+    inline. ``content_b64`` rides only an image block's ``source.data`` — never
+    the returned text — so it cannot reach the prompt string or the run record.
+    """
+    if not seam_items:
+        return prompt
+
+    image_blocks: list[dict[str, Any]] = []
+    descriptor_lines: list[str] = []
+    for item in seam_items:
+        mime = item.get("mime") or ""
+        inlined = False
+        if mime.startswith("image/"):
+            data_b64 = item.get("content_b64")
+            if data_b64 is None and item.get("entry_id"):
+                data_b64 = _load_entry_b64(item["entry_id"])
+            if data_b64:
+                image_blocks.append(
+                    {
+                        "type": "image",
+                        "source": {"type": "base64", "media_type": mime, "data": data_b64},
+                    }
+                )
+                inlined = True
+        descriptor_lines.append(_descriptor_line(item, inlined=inlined))
+
+    text = f"{prompt}\n\n{_INPUT_FILES_HEADER}\n" + "\n".join(descriptor_lines)
+    if not image_blocks:
+        return text
+    # Image-then-text order verified by the SDK spike; block ordering is free.
+    return [*image_blocks, {"type": "text", "text": text}]
 
 
 async def run_dispatch(
@@ -318,9 +460,16 @@ async def run_dispatch(
         if event_queue is not None:
             await event_queue.put(event)
 
+    # Assemble the user-message content once, before streaming: pop this run's
+    # input-file seam (pop-once) and route each item by type — image inputs
+    # become base64 image content blocks in this same user message, every input
+    # file adds a mechanism-only descriptor line to the prompt. content_b64
+    # rides only an image block's source.data, never the prompt text or a log.
+    user_content = _assemble_user_content(prompt, _take_seam(run_id))
+
     # can_use_tool requires streaming-mode input (AsyncIterable), not str.
     async def _prompt_stream():
-        yield {"type": "user", "message": {"role": "user", "content": prompt}}
+        yield {"type": "user", "message": {"role": "user", "content": user_content}}
 
     t0 = time.monotonic()
     agen = query(prompt=_prompt_stream(), options=options)

--- a/src/osprey/stores/artifact_store.py
+++ b/src/osprey/stores/artifact_store.py
@@ -79,6 +79,13 @@ class ArtifactEntry:
     relocates the whole store into ``_agent_data/sessions/<id>/`` (see
     ``resolve_agent_data_root``), so it cannot be reused to tag a dispatch run
     without moving its artifacts off the shared root the gallery reads."""
+    origin: str = ""
+    """Provenance of the artifact within its run. Empty (the default) for the
+    agent's own output. ``"input"`` marks a caller-supplied file ingested into
+    the run *before* the agent starts: such entries are excluded from the run's
+    produced-artifact listing yet remain reachable through the created-by byte
+    route, so an input image can be served back without appearing as something
+    the agent generated."""
 
     def to_dict(self) -> dict[str, Any]:
         return _sanitize_for_json(asdict(self))
@@ -223,6 +230,7 @@ class ArtifactStore(BaseStore[ArtifactEntry]):
         d.setdefault("source_agent", "")
         d.setdefault("session_id", "")
         d.setdefault("run_id", "")
+        d.setdefault("origin", "")
         return ArtifactEntry(**d)
 
     def _entry_to_dict(self, entry: ArtifactEntry) -> dict:
@@ -248,8 +256,17 @@ class ArtifactStore(BaseStore[ArtifactEntry]):
         tool_source: str = "unknown",
         metadata: dict[str, Any] | None = None,
         category: str = "",
+        run_id: str | None = None,
+        origin: str = "",
     ) -> ArtifactEntry:
-        """Low-level save: write raw bytes to disk and register in the index."""
+        """Low-level save: write raw bytes to disk and register in the index.
+
+        ``run_id`` defaults to the ``OSPREY_DISPATCH_RUN_ID`` env var (how the
+        dispatched agent's own tools tag their output). A caller that writes on
+        behalf of a run whose id is not in its environment — e.g. the worker
+        ingesting input files before the agent starts — passes it explicitly.
+        ``origin`` tags the entry's provenance within the run (``"input"`` for
+        an ingested caller file; empty for produced output)."""
         if category:
             from osprey.stores.type_registry import valid_category_keys
 
@@ -276,7 +293,10 @@ class ArtifactStore(BaseStore[ArtifactEntry]):
                 metadata=metadata or {},
                 category=category,
                 session_id=os.environ.get("OSPREY_SESSION_ID", ""),
-                run_id=os.environ.get("OSPREY_DISPATCH_RUN_ID", ""),
+                run_id=(
+                    run_id if run_id is not None else os.environ.get("OSPREY_DISPATCH_RUN_ID", "")
+                ),
+                origin=origin,
             )
             self._entries.append(entry)
             self._save_index()

--- a/tests/dispatch_worker/test_input_files_caps.py
+++ b/tests/dispatch_worker/test_input_files_caps.py
@@ -1,0 +1,262 @@
+"""Cap / validation tests for dispatch input files.
+
+Two layers:
+
+* the pure ``validate_input_files`` policy function (duck-typed on ``mime`` /
+  ``content_b64`` / ``ingest``), covering every cap and the invalid-input codes;
+* the HTTP surface — a valid batch is accepted (202) and each violation class
+  rejects the whole request with the exact machine-readable 400 ``detail``.
+
+Hermetic: FastAPI ``TestClient`` and direct calls, no network, no real SDK.
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from osprey.mcp_server.dispatch_worker import dispatch_api
+from osprey.mcp_server.dispatch_worker import input_files_policy as policy
+from osprey.mcp_server.dispatch_worker.input_files_policy import (
+    DETAIL_CAP_EXCEEDED,
+    DETAIL_INVALID,
+    MAX_IMAGE_BYTES,
+    MAX_INGEST_FILES,
+    MAX_TEXT_BYTES,
+    InputFilesError,
+    validate_input_files,
+)
+
+_TOKEN = "test-secret-token"
+
+
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+
+
+def _b64(nbytes: int) -> str:
+    """Base64 of ``nbytes`` zero bytes (decodes back to exactly ``nbytes``)."""
+    return base64.b64encode(b"\x00" * nbytes).decode("ascii")
+
+
+@dataclass
+class _Spec:
+    """Duck-typed stand-in for an InputFile at the policy layer."""
+
+    mime: str
+    content_b64: str
+    ingest: bool = True
+
+
+def _payload(specs: list[_Spec]) -> list[dict[str, Any]]:
+    """Turn policy specs into request-body input_files dicts."""
+    return [
+        {"filename": f"f{i}", "mime": s.mime, "content_b64": s.content_b64, "ingest": s.ingest}
+        for i, s in enumerate(specs)
+    ]
+
+
+# --------------------------------------------------------------------------
+# pure validate_input_files — caps
+# --------------------------------------------------------------------------
+
+
+def test_input_files_caps_empty_and_none_pass():
+    validate_input_files([])
+    validate_input_files(None)  # falsy short-circuit
+
+
+def test_input_files_caps_valid_batch_passes():
+    validate_input_files(
+        [
+            _Spec("image/png", _b64(1024)),
+            _Spec("text/csv", _b64(2048), ingest=False),
+            _Spec("application/json", _b64(10)),
+        ]
+    )
+
+
+def test_input_files_caps_ingest_count_boundary_ok():
+    validate_input_files([_Spec("text/plain", _b64(10)) for _ in range(MAX_INGEST_FILES)])
+
+
+def test_input_files_caps_ingest_count_exceeded():
+    specs = [_Spec("text/plain", _b64(10)) for _ in range(MAX_INGEST_FILES + 1)]
+    with pytest.raises(InputFilesError) as ei:
+        validate_input_files(specs)
+    assert ei.value.detail == DETAIL_CAP_EXCEEDED
+
+
+def test_input_files_caps_ingest_false_not_counted():
+    # 10 files but only ingest=True ones count toward MAX_INGEST_FILES.
+    specs = [_Spec("text/plain", _b64(10), ingest=False) for _ in range(10)]
+    validate_input_files(specs)
+
+
+def test_input_files_caps_image_per_file_boundary_ok():
+    validate_input_files([_Spec("image/png", _b64(MAX_IMAGE_BYTES))])
+
+
+def test_input_files_caps_image_per_file_exceeded():
+    with pytest.raises(InputFilesError) as ei:
+        validate_input_files([_Spec("image/png", _b64(MAX_IMAGE_BYTES + 1))])
+    assert ei.value.detail == DETAIL_CAP_EXCEEDED
+
+
+def test_input_files_caps_text_per_file_boundary_ok():
+    validate_input_files([_Spec("text/csv", _b64(MAX_TEXT_BYTES))])
+
+
+def test_input_files_caps_text_per_file_exceeded():
+    with pytest.raises(InputFilesError) as ei:
+        validate_input_files([_Spec("application/json", _b64(MAX_TEXT_BYTES + 1))])
+    assert ei.value.detail == DETAIL_CAP_EXCEEDED
+
+
+def test_input_files_caps_total_exceeded_via_non_ingest():
+    # Four 5 MB images (each within the per-file image cap) but ingest=False, so
+    # the ingest-count cap is untouched — only the 18 MB total ceiling trips.
+    specs = [_Spec("image/png", _b64(MAX_IMAGE_BYTES), ingest=False) for _ in range(4)]
+    with pytest.raises(InputFilesError) as ei:
+        validate_input_files(specs)
+    assert ei.value.detail == DETAIL_CAP_EXCEEDED
+
+
+# --------------------------------------------------------------------------
+# pure validate_input_files — invalid
+# --------------------------------------------------------------------------
+
+
+def test_input_files_caps_disallowed_mime_invalid():
+    with pytest.raises(InputFilesError) as ei:
+        validate_input_files([_Spec("application/pdf", _b64(10))])
+    assert ei.value.detail == DETAIL_INVALID
+
+
+def test_input_files_caps_undecodable_b64_invalid():
+    with pytest.raises(InputFilesError) as ei:
+        validate_input_files([_Spec("text/plain", "not valid base64!!!")])
+    assert ei.value.detail == DETAIL_INVALID
+
+
+def test_input_files_caps_decoded_size_roundtrips():
+    assert policy.decoded_size(_b64(1234)) == 1234
+
+
+# --------------------------------------------------------------------------
+# HTTP surface
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("DISPATCH_WORKER_TOKEN", _TOKEN)
+    monkeypatch.setattr(dispatch_api, "_runs", {})
+    monkeypatch.setattr(dispatch_api, "_queues", {})
+    monkeypatch.setattr(dispatch_api, "_tasks", {})
+
+    async def _fake_run_dispatch(*, event_queue=None, **_kwargs):
+        if event_queue is not None:
+            await event_queue.put({"type": "done"})
+        return {
+            "status": "completed",
+            "text_output": "ok",
+            "tool_calls": [],
+            "error": None,
+            "duration_sec": 0.01,
+            "cost_usd": 0.0,
+            "num_turns": 1,
+        }
+
+    monkeypatch.setattr(dispatch_api.sdk_runner, "run_dispatch", _fake_run_dispatch)
+    monkeypatch.setattr(dispatch_api, "_persist_run", lambda run_id, run: None)
+    with TestClient(dispatch_api.app) as c:
+        yield c
+
+
+def _auth() -> dict[str, str]:
+    return {"Authorization": f"Bearer {_TOKEN}"}
+
+
+def test_input_files_caps_http_valid_accepted(client):
+    resp = client.post(
+        "/dispatch",
+        json={
+            "prompt": "look",
+            "allowed_tools": ["Read"],
+            "input_files": _payload([_Spec("image/png", _b64(1024))]),
+        },
+        headers=_auth(),
+    )
+    assert resp.status_code == 202
+    assert resp.json()["status"] == "accepted"
+
+
+def test_input_files_caps_http_omitted_accepted(client):
+    resp = client.post(
+        "/dispatch",
+        json={"prompt": "look", "allowed_tools": ["Read"]},
+        headers=_auth(),
+    )
+    assert resp.status_code == 202
+
+
+def test_input_files_caps_http_count_exceeded_400(client):
+    specs = [_Spec("text/plain", _b64(10)) for _ in range(MAX_INGEST_FILES + 1)]
+    resp = client.post(
+        "/dispatch",
+        json={"prompt": "x", "allowed_tools": ["Read"], "input_files": _payload(specs)},
+        headers=_auth(),
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == DETAIL_CAP_EXCEEDED
+    # Rejected before any run was created.
+    assert dispatch_api._runs == {}
+    assert dispatch_api._tasks == {}
+
+
+def test_input_files_caps_http_image_too_large_400(client):
+    resp = client.post(
+        "/dispatch",
+        json={
+            "prompt": "x",
+            "allowed_tools": ["Read"],
+            "input_files": _payload([_Spec("image/png", _b64(MAX_IMAGE_BYTES + 1))]),
+        },
+        headers=_auth(),
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == DETAIL_CAP_EXCEEDED
+
+
+def test_input_files_caps_http_bad_mime_invalid_400(client):
+    resp = client.post(
+        "/dispatch",
+        json={
+            "prompt": "x",
+            "allowed_tools": ["Read"],
+            "input_files": _payload([_Spec("application/pdf", _b64(10))]),
+        },
+        headers=_auth(),
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == DETAIL_INVALID
+
+
+def test_input_files_caps_http_bad_b64_invalid_400(client):
+    resp = client.post(
+        "/dispatch",
+        json={
+            "prompt": "x",
+            "allowed_tools": ["Read"],
+            "input_files": _payload([_Spec("text/plain", "@@@not-b64@@@")]),
+        },
+        headers=_auth(),
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == DETAIL_INVALID

--- a/tests/dispatch_worker/test_input_files_ingest.py
+++ b/tests/dispatch_worker/test_input_files_ingest.py
@@ -1,0 +1,257 @@
+"""Worker-side ingestion of dispatch input files.
+
+Covers the whole ingest path: ``ingest=True`` files are decoded into the
+artifact store tagged with the run's ``run_id`` and ``origin="input"``;
+``ingest=False`` files are never stored and pass through the seam; the run's
+produced-artifact listing excludes inputs while ``input_artifacts`` surfaces
+them; the created-by byte route still serves an input entry; and the run-status
+body carries ``input_artifacts`` after a completed run.
+
+Hermetic: a tmp-rooted store (so the resolver and worker share one root),
+direct calls, and a FastAPI ``TestClient`` — no network, no real SDK.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from osprey.interfaces.artifacts import resolve as resolve_mod
+from osprey.mcp_server.dispatch_worker import dispatch_api
+from osprey.mcp_server.dispatch_worker.dispatch_api import DispatchRequest, InputFile
+from osprey.stores.artifact_store import ArtifactStore
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"fake-png-body"
+CSV_BYTES = b"a,b,c\n1,2,3\n"
+TOKEN = "test-worker-token"
+
+
+def _b64(body: bytes) -> str:
+    return base64.b64encode(body).decode("ascii")
+
+
+def _root(tmp_path: Path, monkeypatch) -> Path:
+    """Point OSPREY_PROJECT_DIR at a tmp project so get_run_store() roots there."""
+    project = tmp_path / "project"
+    (project / "_agent_data" / "artifacts").mkdir(parents=True)
+    monkeypatch.setenv("OSPREY_PROJECT_DIR", str(project))
+    monkeypatch.delenv("OSPREY_CONFIG", raising=False)
+    return project
+
+
+def _infile(name: str, mime: str, body: bytes, ingest: bool = True) -> InputFile:
+    return InputFile(filename=name, mime=mime, content_b64=_b64(body), ingest=ingest)
+
+
+# ---------------------------------------------------------------------------
+# ingest_input_files — store writes + seam
+# ---------------------------------------------------------------------------
+
+
+def test_input_files_ingest_true_stored_with_origin_and_run_id(tmp_path, monkeypatch):
+    _root(tmp_path, monkeypatch)
+    seam = dispatch_api.ingest_input_files("run-1", [_infile("plot.png", "image/png", PNG_BYTES)])
+    store = resolve_mod.get_run_store()
+    [entry] = store.list_entries(run_filter="run-1")
+    assert entry.origin == "input"
+    assert entry.run_id == "run-1"
+    assert entry.mime_type == "image/png"
+    # bytes round-trip to disk
+    assert store.get_file_path(entry.id).read_bytes() == PNG_BYTES
+    # seam item for a stored file: entry_id set, no passthrough bytes
+    assert seam == [
+        {"filename": "plot.png", "mime": "image/png", "entry_id": entry.id, "content_b64": None}
+    ]
+
+
+def test_input_files_ingest_false_never_stored(tmp_path, monkeypatch):
+    _root(tmp_path, monkeypatch)
+    b64 = _b64(PNG_BYTES)
+    seam = dispatch_api.ingest_input_files(
+        "run-1", [InputFile(filename="keep.png", mime="image/png", content_b64=b64, ingest=False)]
+    )
+    store = resolve_mod.get_run_store()
+    assert store.list_entries(run_filter="run-1") == []  # nothing written
+    # seam carries the original bytes for pass-through, no entry_id
+    assert seam == [
+        {"filename": "keep.png", "mime": "image/png", "entry_id": None, "content_b64": b64}
+    ]
+
+
+def test_input_files_ingest_mixed_batch_preserves_order(tmp_path, monkeypatch):
+    _root(tmp_path, monkeypatch)
+    seam = dispatch_api.ingest_input_files(
+        "run-1",
+        [
+            _infile("a.png", "image/png", PNG_BYTES),
+            _infile("b.csv", "text/csv", CSV_BYTES, ingest=False),
+            _infile("c.json", "application/json", b"{}"),
+        ],
+    )
+    assert [s["filename"] for s in seam] == ["a.png", "b.csv", "c.json"]
+    assert seam[0]["entry_id"] is not None and seam[0]["content_b64"] is None
+    assert seam[1]["entry_id"] is None and seam[1]["content_b64"] == _b64(CSV_BYTES)
+    assert seam[2]["entry_id"] is not None
+    # only the two ingest=true files are stored
+    assert len(resolve_mod.get_run_store().list_entries(run_filter="run-1")) == 2
+
+
+def test_input_files_ingest_empty_batch_returns_empty(tmp_path, monkeypatch):
+    _root(tmp_path, monkeypatch)
+    assert dispatch_api.ingest_input_files("run-1", []) == []
+
+
+# ---------------------------------------------------------------------------
+# resolve descriptors: exclusion + input_artifacts shape
+# ---------------------------------------------------------------------------
+
+
+def test_input_files_ingest_excluded_from_produced_artifacts(tmp_path, monkeypatch):
+    _root(tmp_path, monkeypatch)
+    dispatch_api.ingest_input_files("run-1", [_infile("in.png", "image/png", PNG_BYTES)])
+    # An input artifact is NOT a produced artifact.
+    assert resolve_mod.describe_run_artifacts("run-1") == []
+
+
+def test_input_files_input_artifacts_descriptor_shape(tmp_path, monkeypatch):
+    _root(tmp_path, monkeypatch)
+    seam = dispatch_api.ingest_input_files("run-1", [_infile("in.png", "image/png", PNG_BYTES)])
+    entry_id = seam[0]["entry_id"]
+    [d] = resolve_mod.describe_run_input_artifacts("run-1")
+    assert d == {"entry_id": entry_id, "filename": "in.png", "mime": "image/png"}
+
+
+def test_input_files_input_artifacts_filename_is_caller_name(tmp_path, monkeypatch):
+    # The descriptor filename is the caller's name, not the id-prefixed store name.
+    _root(tmp_path, monkeypatch)
+    dispatch_api.ingest_input_files("run-1", [_infile("report.csv", "text/csv", CSV_BYTES)])
+    [d] = resolve_mod.describe_run_input_artifacts("run-1")
+    assert d["filename"] == "report.csv"
+
+
+def test_input_files_input_artifacts_only_input_origin(tmp_path, monkeypatch):
+    # A produced artifact (origin empty) must not appear among input_artifacts.
+    project = _root(tmp_path, monkeypatch)
+    store = ArtifactStore(workspace_root=project / "_agent_data")
+    store.save_file(
+        file_content=PNG_BYTES,
+        filename="made.png",
+        title="made",
+        artifact_type="image",
+        mime_type="image/png",
+        run_id="run-1",
+    )
+    dispatch_api.ingest_input_files("run-1", [_infile("in.png", "image/png", PNG_BYTES)])
+    input_names = {d["filename"] for d in resolve_mod.describe_run_input_artifacts("run-1")}
+    produced = {d["filename"] for d in resolve_mod.describe_run_artifacts("run-1")}
+    assert input_names == {"in.png"}
+    assert "made.png" not in input_names
+    assert "in.png" not in produced
+
+
+def test_input_files_input_artifacts_unknown_run_empty(tmp_path, monkeypatch):
+    _root(tmp_path, monkeypatch)
+    assert resolve_mod.describe_run_input_artifacts("nope") == []
+    assert resolve_mod.describe_run_input_artifacts("") == []
+
+
+# ---------------------------------------------------------------------------
+# take_input_seam pop-once
+# ---------------------------------------------------------------------------
+
+
+def test_input_files_ingest_take_seam_pop_once(monkeypatch):
+    monkeypatch.setattr(dispatch_api, "_run_input_seam", {"run-1": [{"filename": "x"}]})
+    assert dispatch_api.take_input_seam("run-1") == [{"filename": "x"}]
+    assert dispatch_api.take_input_seam("run-1") == []  # popped
+    assert dispatch_api.take_input_seam("absent") == []
+
+
+# ---------------------------------------------------------------------------
+# HTTP: byte route serves input entries; list route excludes them
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch) -> Iterator[tuple[TestClient, str]]:
+    monkeypatch.setenv("DISPATCH_WORKER_TOKEN", TOKEN)
+    _root(tmp_path, monkeypatch)
+    seam = dispatch_api.ingest_input_files("run-1", [_infile("in.png", "image/png", PNG_BYTES)])
+    entry_id = seam[0]["entry_id"]
+    monkeypatch.setattr(dispatch_api, "_runs", {"run-1": {"status": "completed"}})
+    monkeypatch.setattr(dispatch_api, "_queues", {})
+    monkeypatch.setattr(dispatch_api, "_tasks", {})
+    with TestClient(dispatch_api.app) as c:
+        yield c, entry_id
+
+
+def _auth() -> dict[str, str]:
+    return {"Authorization": f"Bearer {TOKEN}"}
+
+
+def test_input_files_ingest_byte_route_serves_input_entry(client):
+    c, entry_id = client
+    r = c.get(f"/dispatch/run-1/artifacts/{entry_id}", headers=_auth())
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("image/png")
+    assert r.content == PNG_BYTES
+
+
+def test_input_files_ingest_byte_route_cross_run_still_404(client):
+    c, entry_id = client
+    r = c.get(f"/dispatch/other-run/artifacts/{entry_id}", headers=_auth())
+    assert r.status_code == 404
+
+
+def test_input_files_ingest_excluded_from_list_route(client):
+    c, _ = client
+    r = c.get("/dispatch/run-1/artifacts", headers=_auth())
+    assert r.status_code == 200
+    assert r.json() == []  # input artifact is not a produced artifact
+
+
+# ---------------------------------------------------------------------------
+# Status body carries input_artifacts after a completed run
+# ---------------------------------------------------------------------------
+
+
+async def test_input_files_input_artifacts_on_status_body(tmp_path, monkeypatch):
+    _root(tmp_path, monkeypatch)
+    monkeypatch.setattr(dispatch_api, "_runs", {})
+    monkeypatch.setattr(dispatch_api, "_queues", {})
+    monkeypatch.setattr(dispatch_api, "_tasks", {})
+    monkeypatch.setattr(dispatch_api, "_run_input_seam", {})
+    monkeypatch.setattr(dispatch_api, "_persist_run", lambda rid, r: None)
+
+    async def _fake_run(**kw):
+        return {
+            "status": "completed",
+            "text_output": "ok",
+            "tool_calls": [],
+            "error": None,
+            "duration_sec": 0.01,
+            "cost_usd": 0.0,
+            "num_turns": 1,
+        }
+
+    monkeypatch.setattr(dispatch_api.sdk_runner, "run_dispatch", _fake_run)
+
+    req = DispatchRequest(
+        prompt="describe this",
+        allowed_tools=[],
+        input_files=[_infile("in.png", "image/png", PNG_BYTES)],
+    )
+    await dispatch_api._run_dispatch_task("run-x", req)
+
+    result = dispatch_api._runs["run-x"]
+    assert result["status"] == "completed"
+    assert result["artifacts"] == []  # input is excluded from produced
+    assert [d["filename"] for d in result["input_artifacts"]] == ["in.png"]
+    assert result["input_artifacts"][0]["mime"] == "image/png"
+    assert "entry_id" in result["input_artifacts"][0]
+    # seam cleaned up by the task's finally
+    assert dispatch_api._run_input_seam.get("run-x") is None

--- a/tests/dispatch_worker/test_input_files_model.py
+++ b/tests/dispatch_worker/test_input_files_model.py
@@ -1,0 +1,79 @@
+"""Model-level tests for dispatch input files.
+
+Covers the ``InputFile`` / ``DispatchRequest`` pydantic models: the additive
+``input_files`` field, the ``ingest`` default, and the filename-sanitisation
+field validator. Pure model construction — no network, no HTTP client.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from osprey.mcp_server.dispatch_worker.dispatch_api import DispatchRequest, InputFile
+from osprey.mcp_server.dispatch_worker.input_files_policy import sanitize_filename
+
+
+def test_input_files_model_ingest_defaults_true():
+    f = InputFile(filename="a.png", mime="image/png", content_b64="AAAA")
+    assert f.ingest is True
+
+
+def test_input_files_model_ingest_explicit_false():
+    f = InputFile(filename="a.png", mime="image/png", content_b64="AAAA", ingest=False)
+    assert f.ingest is False
+
+
+def test_input_files_model_defaults_to_none_on_request():
+    req = DispatchRequest(prompt="hi", allowed_tools=["Read"])
+    assert req.input_files is None
+
+
+def test_input_files_model_carries_batch():
+    req = DispatchRequest(
+        prompt="hi",
+        allowed_tools=["Read"],
+        input_files=[
+            {"filename": "a.png", "mime": "image/png", "content_b64": "AAAA"},
+            {"filename": "b.csv", "mime": "text/csv", "content_b64": "AAAA", "ingest": False},
+        ],
+    )
+    assert req.input_files is not None
+    assert len(req.input_files) == 2
+    assert req.input_files[0].ingest is True
+    assert req.input_files[1].ingest is False
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("../../etc/passwd", "passwd"),  # basename only, traversal stripped
+        ("plot.png", "plot.png"),
+        ("a/b/c.txt", "c.txt"),
+        ("weird name!.csv", "weird_name_.csv"),
+        ("..", "file"),
+        (".", "file"),
+        ("", "file"),
+        (".hidden", "hidden"),
+        ("with\x00nul.png", "withnul.png"),
+        ("back\\slash\\x.json", "x.json"),
+    ],
+)
+def test_input_files_model_sanitize_filename_helper(raw, expected):
+    assert sanitize_filename(raw) == expected
+
+
+def test_input_files_model_sanitizes_traversal_on_construction():
+    f = InputFile(filename="../../secret.png", mime="image/png", content_b64="AAAA")
+    assert f.filename == "secret.png"
+    assert "/" not in f.filename and ".." not in f.filename
+
+
+def test_input_files_model_sanitizes_via_request():
+    req = DispatchRequest(
+        prompt="hi",
+        allowed_tools=["Read"],
+        input_files=[
+            {"filename": "a/b/../evil.json", "mime": "application/json", "content_b64": "AAAA"}
+        ],
+    )
+    assert req.input_files[0].filename == "evil.json"

--- a/tests/dispatch_worker/test_input_files_origin.py
+++ b/tests/dispatch_worker/test_input_files_origin.py
@@ -1,0 +1,98 @@
+"""Store-level provenance for ingested input files: the ``origin`` tag.
+
+``ArtifactEntry.origin`` marks how an artifact entered a run — empty for the
+agent's own output, ``"input"`` for a caller-supplied file the worker ingested
+before the run. These tests pin the field default, its index round-trip, and
+the ``save_file`` ``origin`` / explicit-``run_id`` parameters the worker uses to
+write on behalf of a run whose id is not in its environment.
+"""
+
+from __future__ import annotations
+
+import json
+
+from osprey.stores.artifact_store import ArtifactStore
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"fake-png-body"
+
+
+def _save(store: ArtifactStore, **kw) -> object:
+    return store.save_file(
+        file_content=PNG_BYTES,
+        filename="p.png",
+        title="p",
+        artifact_type="image",
+        mime_type="image/png",
+        **kw,
+    )
+
+
+def test_input_files_origin_defaults_empty(tmp_path, monkeypatch):
+    monkeypatch.delenv("OSPREY_DISPATCH_RUN_ID", raising=False)
+    store = ArtifactStore(workspace_root=tmp_path)
+    entry = _save(store)
+    assert entry.origin == ""
+
+
+def test_input_files_origin_set_to_input(tmp_path, monkeypatch):
+    monkeypatch.delenv("OSPREY_DISPATCH_RUN_ID", raising=False)
+    store = ArtifactStore(workspace_root=tmp_path)
+    entry = _save(store, origin="input")
+    assert entry.origin == "input"
+
+
+def test_input_files_origin_explicit_run_id_overrides_env(tmp_path, monkeypatch):
+    # The worker ingests before the agent starts, so the run id is not in its
+    # environment — it passes run_id explicitly and it must win over the env.
+    monkeypatch.setenv("OSPREY_DISPATCH_RUN_ID", "env-run")
+    store = ArtifactStore(workspace_root=tmp_path)
+    entry = _save(store, run_id="explicit-run", origin="input")
+    assert entry.run_id == "explicit-run"
+    assert entry.origin == "input"
+
+
+def test_input_files_origin_run_id_none_falls_back_to_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("OSPREY_DISPATCH_RUN_ID", "env-run")
+    store = ArtifactStore(workspace_root=tmp_path)
+    entry = _save(store)  # run_id defaults to None -> env
+    assert entry.run_id == "env-run"
+
+
+def test_input_files_origin_survives_index_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.delenv("OSPREY_DISPATCH_RUN_ID", raising=False)
+    store = ArtifactStore(workspace_root=tmp_path)
+    _save(store, run_id="run-1", origin="input")
+    # A fresh store reads the persisted index from disk.
+    reloaded = ArtifactStore(workspace_root=tmp_path)
+    [entry] = reloaded.list_entries(run_filter="run-1")
+    assert entry.origin == "input"
+
+
+def test_input_files_origin_absent_in_old_index_loads_empty(tmp_path):
+    d = tmp_path / "artifacts"
+    d.mkdir(parents=True)
+    (d / "artifacts.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "updated": "2026-01-01T00:00:00Z",
+                "entry_count": 1,
+                "entries": [
+                    {
+                        "id": "old1",
+                        "artifact_type": "image",
+                        "title": "t",
+                        "description": "",
+                        "filename": "t.png",
+                        "mime_type": "image/png",
+                        "size_bytes": 3,
+                        "timestamp": "2026-01-01T00:00:00Z",
+                        "tool_source": "x",
+                    }
+                ],
+            }
+        )
+    )
+    store = ArtifactStore(workspace_root=tmp_path)
+    [entry] = store.list_entries()
+    assert entry.origin == ""

--- a/tests/dispatch_worker/test_retention.py
+++ b/tests/dispatch_worker/test_retention.py
@@ -1,0 +1,299 @@
+"""Tests for the opt-in dispatch retention sweep.
+
+Hermetic: ``tmp_path`` for the run-record log dir and the ArtifactStore, an
+injected ``now`` for all age math (no real clock), and the periodic loop driven
+one iteration via a monkeypatched ``asyncio.sleep`` (no real sleeps).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from osprey.mcp_server.dispatch_worker import retention
+from osprey.stores.artifact_store import ArtifactStore
+
+_DAY = retention._SECONDS_PER_DAY
+_NOW = 1_000_000_000.0  # fixed reference epoch for every age computation
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_run(
+    log_dir: Path,
+    run_id: str,
+    *,
+    status: str = "completed",
+    completed_at: float | None = None,
+    created_at: float | None = None,
+) -> Path:
+    """Write a persisted run record shaped like dispatch_api._persist_run."""
+    log_dir.mkdir(parents=True, exist_ok=True)
+    record: dict = {"run_id": run_id, "status": status}
+    if completed_at is not None:
+        record["completed_at"] = completed_at
+    if created_at is not None:
+        record["created_at"] = created_at
+    path = log_dir / f"{run_id}.json"
+    path.write_text(json.dumps(record))
+    return path
+
+
+def _save_artifact(store: ArtifactStore, title: str, *, run_id: str = "") -> str:
+    """Save a trivial artifact; return its id. run_id tags the created-by run."""
+    import os
+
+    prev = os.environ.get("OSPREY_DISPATCH_RUN_ID")
+    if run_id:
+        os.environ["OSPREY_DISPATCH_RUN_ID"] = run_id
+    else:
+        os.environ.pop("OSPREY_DISPATCH_RUN_ID", None)
+    try:
+        entry = store.save_file(
+            file_content=b"x",
+            filename="a.txt",
+            artifact_type="text",
+            title=title,
+            mime_type="text/plain",
+            tool_source="test",
+        )
+    finally:
+        if prev is None:
+            os.environ.pop("OSPREY_DISPATCH_RUN_ID", None)
+        else:
+            os.environ["OSPREY_DISPATCH_RUN_ID"] = prev
+    return entry.id
+
+
+def _set_artifact_age_days(store: ArtifactStore, artifact_id: str, days_old: float) -> None:
+    """Rewrite an artifact's stored timestamp to ``days_old`` days before _NOW."""
+    ts = datetime.fromtimestamp(_NOW - days_old * _DAY, tz=UTC).isoformat()
+    for e in store._entries:
+        if e.id == artifact_id:
+            e.timestamp = ts
+    store._save_index()
+
+
+# ---------------------------------------------------------------------------
+# retention_days_from_env
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, 0),
+        ("", 0),
+        ("   ", 0),
+        ("0", 0),
+        ("-5", 0),
+        ("abc", 0),
+        ("1.5", 0),
+        ("7", 7),
+        (" 30 ", 30),
+    ],
+)
+def test_retention_days_from_env(raw, expected):
+    env = {} if raw is None else {"RETENTION_DAYS": raw}
+    assert retention.retention_days_from_env(env) == expected
+
+
+def test_retention_days_reads_os_environ(monkeypatch):
+    monkeypatch.setenv("RETENTION_DAYS", "14")
+    assert retention.retention_days_from_env() == 14
+
+
+# ---------------------------------------------------------------------------
+# sweep_dispatch_runs — age boundary + in-flight protection
+# ---------------------------------------------------------------------------
+
+
+def test_run_age_boundary_unit_pinned(tmp_path):
+    """N-1 days survives, exactly N survives, N+1 days is deleted."""
+    log_dir = tmp_path / "dispatch"
+    _write_run(log_dir, "younger", completed_at=_NOW - 4 * _DAY)  # N-1
+    _write_run(log_dir, "boundary", completed_at=_NOW - 5 * _DAY)  # exactly N
+    _write_run(log_dir, "older", completed_at=_NOW - 6 * _DAY)  # N+1
+
+    deleted = retention.sweep_dispatch_runs(log_dir, retention_days=5, now=_NOW)
+
+    assert deleted == 1
+    assert (log_dir / "younger.json").exists()
+    assert (log_dir / "boundary.json").exists()
+    assert not (log_dir / "older.json").exists()
+
+
+def test_run_sweep_uses_created_at_when_no_completed_at(tmp_path):
+    log_dir = tmp_path / "dispatch"
+    _write_run(log_dir, "old", status="error", created_at=_NOW - 10 * _DAY)
+
+    deleted = retention.sweep_dispatch_runs(log_dir, retention_days=5, now=_NOW)
+
+    assert deleted == 1
+    assert not (log_dir / "old.json").exists()
+
+
+def test_nonterminal_run_never_swept_regardless_of_age(tmp_path):
+    log_dir = tmp_path / "dispatch"
+    _write_run(log_dir, "pending", status="pending", created_at=_NOW - 100 * _DAY)
+
+    deleted = retention.sweep_dispatch_runs(log_dir, retention_days=5, now=_NOW)
+
+    assert deleted == 0
+    assert (log_dir / "pending.json").exists()
+
+
+def test_in_flight_id_never_swept(tmp_path):
+    """A terminal-looking record whose id is in-flight is still protected."""
+    log_dir = tmp_path / "dispatch"
+    _write_run(log_dir, "live", status="completed", completed_at=_NOW - 100 * _DAY)
+
+    deleted = retention.sweep_dispatch_runs(
+        log_dir, retention_days=5, now=_NOW, in_flight_run_ids={"live"}
+    )
+
+    assert deleted == 0
+    assert (log_dir / "live.json").exists()
+
+
+def test_unreadable_run_file_skipped(tmp_path):
+    log_dir = tmp_path / "dispatch"
+    log_dir.mkdir(parents=True)
+    (log_dir / "broken.json").write_text("{not json")
+    _write_run(log_dir, "old", completed_at=_NOW - 10 * _DAY)
+
+    deleted = retention.sweep_dispatch_runs(log_dir, retention_days=5, now=_NOW)
+
+    assert deleted == 1
+    assert (log_dir / "broken.json").exists()
+    assert not (log_dir / "old.json").exists()
+
+
+def test_run_sweep_disabled_and_missing_dir(tmp_path):
+    log_dir = tmp_path / "dispatch"
+    _write_run(log_dir, "old", completed_at=_NOW - 10 * _DAY)
+    # Disabled → no-op
+    assert retention.sweep_dispatch_runs(log_dir, retention_days=0, now=_NOW) == 0
+    assert (log_dir / "old.json").exists()
+    # Missing dir → no-op
+    assert retention.sweep_dispatch_runs(tmp_path / "nope", retention_days=5, now=_NOW) == 0
+
+
+# ---------------------------------------------------------------------------
+# sweep_artifacts
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_age_boundary(tmp_path):
+    store = ArtifactStore(workspace_root=tmp_path)
+    young = _save_artifact(store, "young")
+    old = _save_artifact(store, "old")
+    _set_artifact_age_days(store, young, 4)  # N-1
+    _set_artifact_age_days(store, old, 6)  # N+1
+
+    deleted = retention.sweep_artifacts(store, retention_days=5, now=_NOW)
+
+    assert deleted == 1
+    assert store.get_entry(young) is not None
+    assert store.get_entry(old) is None
+
+
+def test_artifact_of_in_flight_run_survives(tmp_path):
+    store = ArtifactStore(workspace_root=tmp_path)
+    art = _save_artifact(store, "live-art", run_id="live-run")
+    _set_artifact_age_days(store, art, 100)
+
+    deleted = retention.sweep_artifacts(
+        store, retention_days=5, now=_NOW, in_flight_run_ids={"live-run"}
+    )
+
+    assert deleted == 0
+    assert store.get_entry(art) is not None
+
+
+def test_artifact_sweep_disabled(tmp_path):
+    store = ArtifactStore(workspace_root=tmp_path)
+    art = _save_artifact(store, "old")
+    _set_artifact_age_days(store, art, 100)
+
+    assert retention.sweep_artifacts(store, retention_days=0, now=_NOW) == 0
+    assert store.get_entry(art) is not None
+
+
+# ---------------------------------------------------------------------------
+# run_sweep (combined)
+# ---------------------------------------------------------------------------
+
+
+def test_run_sweep_combined_counts(tmp_path):
+    log_dir = tmp_path / "dispatch"
+    _write_run(log_dir, "old", completed_at=_NOW - 10 * _DAY)
+    _write_run(log_dir, "recent", completed_at=_NOW - 1 * _DAY)
+
+    store = ArtifactStore(workspace_root=tmp_path)
+    old_art = _save_artifact(store, "old")
+    _set_artifact_age_days(store, old_art, 10)
+    young_art = _save_artifact(store, "young")
+    _set_artifact_age_days(store, young_art, 1)
+
+    counts = retention.run_sweep(log_dir, store, retention_days=5, now=_NOW)
+
+    assert counts == {"runs": 1, "artifacts": 1}
+    assert not (log_dir / "old.json").exists()
+    assert (log_dir / "recent.json").exists()
+    assert store.get_entry(old_art) is None
+    assert store.get_entry(young_art) is not None
+
+
+def test_run_sweep_disabled_is_noop(tmp_path):
+    log_dir = tmp_path / "dispatch"
+    _write_run(log_dir, "old", completed_at=_NOW - 10 * _DAY)
+    store = ArtifactStore(workspace_root=tmp_path)
+
+    counts = retention.run_sweep(log_dir, store, retention_days=0, now=_NOW)
+
+    assert counts == {"runs": 0, "artifacts": 0}
+    assert (log_dir / "old.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# retention_loop — one iteration, no real sleeps
+# ---------------------------------------------------------------------------
+
+
+def test_retention_loop_runs_one_iteration(tmp_path, monkeypatch):
+    log_dir = tmp_path / "dispatch"
+    _write_run(log_dir, "old", completed_at=_NOW - 10 * _DAY)
+    store = ArtifactStore(workspace_root=tmp_path)
+
+    calls: list[float] = []
+
+    async def fake_sleep(interval):
+        # Let the first sleep return so one sweep runs, then cancel the loop.
+        calls.append(interval)
+        if len(calls) >= 2:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    async def drive():
+        with pytest.raises(asyncio.CancelledError):
+            await retention.retention_loop(
+                log_dir,
+                lambda: store,
+                retention_days=5,
+                in_flight_run_ids=lambda: frozenset(),
+                interval_sec=123.0,
+            )
+
+    asyncio.run(drive())
+
+    assert calls == [123.0, 123.0]
+    assert not (log_dir / "old.json").exists()  # the one iteration swept it

--- a/tests/dispatch_worker/test_sdk_runner_prompt_assembly.py
+++ b/tests/dispatch_worker/test_sdk_runner_prompt_assembly.py
@@ -1,0 +1,297 @@
+"""Prompt-assembly: routing input-file seam items into the SDK user message.
+
+``run_dispatch`` pops the per-run input-file seam once, inlines ``image/*``
+inputs as base64 image content blocks in the user message, and appends a
+mechanism-only descriptor line for every input file. These tests pin:
+
+  * the assembled ``content`` shape (plain string with no inputs; a
+    ``[*image_blocks, {text}]`` list once an image is inlined; a
+    prompt+descriptor string for non-inlining inputs),
+  * the image content block shape (Anthropic native base64 block, raw b64 in
+    ``source.data``, correct ``media_type``),
+  * both descriptor line formats (``data_read("<entry_id>")`` for a stored file;
+    the ``[shown_inline]`` marker for an inlined image),
+  * the hygiene invariant: ``content_b64`` never enters the prompt text or any
+    log record (the sdk_runner base64-redacting logging filter).
+
+Hermetic: fake seam data, no real SDK — ``query`` is monkeypatched with a fake
+async generator that drains the streamed prompt to capture the user message.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+
+from osprey.mcp_server.dispatch_worker import sdk_runner
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"solid-red-square-body" * 8
+PNG_B64 = base64.b64encode(PNG_BYTES).decode("ascii")
+
+
+@pytest.fixture(autouse=True)
+def _stub_osprey_helpers(monkeypatch):
+    """Stub the deferred OSPREY helper imports so run_dispatch can be driven."""
+    monkeypatch.setattr(
+        "osprey.interfaces.web_terminal.operator_session.build_clean_env",
+        lambda **kw: {},
+    )
+    monkeypatch.setattr(
+        "osprey.interfaces.web_terminal.sdk_context.build_system_prompt",
+        lambda *a, **k: "system",
+    )
+    monkeypatch.setattr(
+        "osprey.utils.config.get_facility_timezone",
+        lambda *a, **k: "UTC",
+    )
+
+
+def _result_message(cost_usd: float = 0.1, num_turns: int = 1) -> ResultMessage:
+    rm = MagicMock(spec=ResultMessage)
+    rm.cost_usd = cost_usd
+    rm.num_turns = num_turns
+    return rm
+
+
+async def _capture_user_message(monkeypatch, prompt: str, seam: list[dict], run_id: str = "run-1"):
+    """Run run_dispatch with a seam preset; return the streamed user message dict."""
+    from osprey.mcp_server.dispatch_worker import dispatch_api
+
+    monkeypatch.setattr(dispatch_api, "_run_input_seam", {run_id: seam})
+    captured: dict = {}
+
+    async def fake_query(prompt, options):  # noqa: A002 - matches SDK signature
+        messages = []
+        async for m in prompt:
+            messages.append(m)
+        captured["messages"] = messages
+        yield AssistantMessage(content=[TextBlock(text="ok")], model="m")
+        yield _result_message()
+
+    monkeypatch.setattr(sdk_runner, "query", fake_query)
+    await sdk_runner.run_dispatch(prompt, ["Read"], event_queue=asyncio.Queue(), run_id=run_id)
+    return captured["messages"][0]
+
+
+# ---------------------------------------------------------------------------
+# _assemble_user_content — pure routing
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_stream_no_input_files_is_plain_string():
+    """No inputs → content is the raw prompt string (unchanged legacy shape)."""
+    assert sdk_runner._assemble_user_content("just do it", []) == "just do it"
+
+
+def test_content_block_ingest_false_image_inlined_from_content_b64():
+    """An ingest=False image inlines directly from the seam's content_b64."""
+    content = sdk_runner._assemble_user_content(
+        "look",
+        [{"filename": "p.png", "mime": "image/png", "entry_id": None, "content_b64": PNG_B64}],
+    )
+    assert isinstance(content, list)
+    block = content[0]
+    assert block == {
+        "type": "image",
+        "source": {"type": "base64", "media_type": "image/png", "data": PNG_B64},
+    }
+    assert content[-1]["type"] == "text"
+
+
+def test_content_block_ingest_true_image_inlined_from_store(monkeypatch):
+    """An ingest=True image (entry_id, no content_b64) inlines from stored bytes."""
+    monkeypatch.setattr(sdk_runner, "_load_entry_b64", lambda eid: PNG_B64)
+    content = sdk_runner._assemble_user_content(
+        "look",
+        [{"filename": "p.png", "mime": "image/png", "entry_id": "art-1", "content_b64": None}],
+    )
+    assert isinstance(content, list)
+    assert content[0]["source"]["data"] == PNG_B64
+    # An inlined image is described as shown inline, not as a data_read target.
+    assert "shown_inline" in content[-1]["text"]
+
+
+def test_content_block_non_image_not_inlined():
+    """A text-mime input is referenced by descriptor only — never an image block."""
+    content = sdk_runner._assemble_user_content(
+        "read it",
+        [{"filename": "d.csv", "mime": "text/csv", "entry_id": "art-9", "content_b64": None}],
+    )
+    # No image block ⇒ content stays a string (prompt + descriptor).
+    assert isinstance(content, str)
+    assert 'data_read("art-9")' in content
+
+
+def test_prompt_stream_image_missing_from_store_falls_back_to_descriptor(monkeypatch):
+    """If stored bytes are gone, the image is not inlined but still described."""
+    monkeypatch.setattr(sdk_runner, "_load_entry_b64", lambda eid: None)
+    content = sdk_runner._assemble_user_content(
+        "look",
+        [{"filename": "p.png", "mime": "image/png", "entry_id": "art-1", "content_b64": None}],
+    )
+    # No inlinable bytes ⇒ no image block; falls back to a data_read descriptor.
+    assert isinstance(content, str)
+    assert 'data_read("art-1")' in content
+
+
+# ---------------------------------------------------------------------------
+# Descriptor block
+# ---------------------------------------------------------------------------
+
+
+def test_descriptor_line_for_stored_file_uses_data_read():
+    line = sdk_runner._descriptor_line(
+        {"filename": "d.csv", "mime": "text/csv", "entry_id": "art-9"}, inlined=False
+    )
+    assert line == '- d.csv (text/csv) — read with data_read("art-9")'
+
+
+def test_descriptor_line_for_inlined_image_has_shown_inline_marker():
+    line = sdk_runner._descriptor_line(
+        {"filename": "p.png", "mime": "image/png", "entry_id": None}, inlined=True
+    )
+    assert "image shown inline" in line  # human-readable
+    assert "[shown_inline]" in line  # machine-readable marker
+
+
+def test_descriptor_block_one_line_per_input_file():
+    content = sdk_runner._assemble_user_content(
+        "go",
+        [
+            {"filename": "a.png", "mime": "image/png", "entry_id": None, "content_b64": PNG_B64},
+            {"filename": "b.csv", "mime": "text/csv", "entry_id": "art-2", "content_b64": None},
+            {
+                "filename": "c.json",
+                "mime": "application/json",
+                "entry_id": "art-3",
+                "content_b64": None,
+            },
+        ],
+    )
+    text = content[-1]["text"]
+    descriptor_lines = [ln for ln in text.splitlines() if ln.startswith("- ")]
+    assert len(descriptor_lines) == 3
+    assert sdk_runner._INPUT_FILES_HEADER in text
+    # Order preserved, each with the mechanism appropriate to its routing.
+    assert "[shown_inline]" in descriptor_lines[0]
+    assert 'data_read("art-2")' in descriptor_lines[1]
+    assert 'data_read("art-3")' in descriptor_lines[2]
+
+
+# ---------------------------------------------------------------------------
+# Hygiene: content_b64 never leaks
+# ---------------------------------------------------------------------------
+
+
+def test_content_block_b64_never_in_prompt_text():
+    """The inlined b64 rides source.data only — never the text block."""
+    content = sdk_runner._assemble_user_content(
+        "look",
+        [{"filename": "p.png", "mime": "image/png", "entry_id": None, "content_b64": PNG_B64}],
+    )
+    assert content[0]["source"]["data"] == PNG_B64  # present in the image block
+    assert PNG_B64 not in content[-1]["text"]  # absent from the prompt text
+
+
+def test_content_block_b64_redacted_from_logs(caplog):
+    """The logger's redacting filter scrubs long base64 runs from any record."""
+    with caplog.at_level(logging.DEBUG, logger=sdk_runner.logger.name):
+        sdk_runner.logger.info("would-be leak: %s", PNG_B64)
+    assert PNG_B64 not in caplog.text
+    assert "[redacted-b64]" in caplog.text
+
+
+def test_content_block_b64_absent_from_logs_during_run(monkeypatch, caplog):
+    """A full run that inlines an image logs nothing containing the b64 payload."""
+    with caplog.at_level(logging.DEBUG, logger=sdk_runner.logger.name):
+        msg = asyncio.run(
+            _capture_user_message(
+                monkeypatch,
+                "look",
+                [
+                    {
+                        "filename": "p.png",
+                        "mime": "image/png",
+                        "entry_id": None,
+                        "content_b64": PNG_B64,
+                    }
+                ],
+            )
+        )
+    # The image reached the message content ...
+    assert msg["message"]["content"][0]["source"]["data"] == PNG_B64
+    # ... but never a log record.
+    assert PNG_B64 not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through run_dispatch (pop-once seam + streamed message)
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_stream_inlines_image_and_appends_descriptor(monkeypatch):
+    """run_dispatch streams one user message with the image block + descriptor."""
+    msg = asyncio.run(
+        _capture_user_message(
+            monkeypatch,
+            "hello",
+            [
+                {
+                    "filename": "plot.png",
+                    "mime": "image/png",
+                    "entry_id": None,
+                    "content_b64": PNG_B64,
+                },
+                {
+                    "filename": "data.csv",
+                    "mime": "text/csv",
+                    "entry_id": "art-9",
+                    "content_b64": None,
+                },
+            ],
+        )
+    )
+    assert msg["type"] == "user"
+    content = msg["message"]["content"]
+    assert isinstance(content, list)
+    assert content[0]["type"] == "image"
+    assert content[0]["source"]["media_type"] == "image/png"
+    text = content[-1]["text"]
+    assert text.startswith("hello")
+    assert "[shown_inline]" in text  # the image
+    assert 'data_read("art-9")' in text  # the csv
+    assert PNG_B64 not in text
+
+
+def test_prompt_stream_pops_seam_once(monkeypatch):
+    """The seam is consumed pop-once: a second take returns nothing."""
+    from osprey.mcp_server.dispatch_worker import dispatch_api
+
+    asyncio.run(
+        _capture_user_message(
+            monkeypatch,
+            "hello",
+            [{"filename": "p.png", "mime": "image/png", "entry_id": None, "content_b64": PNG_B64}],
+        )
+    )
+    assert dispatch_api.take_input_seam("run-1") == []
+
+
+def test_prompt_stream_no_run_id_leaves_content_plain(monkeypatch):
+    """A run without a run_id has no seam — content is the untouched prompt."""
+    captured: dict = {}
+
+    async def fake_query(prompt, options):  # noqa: A002
+        async for m in prompt:
+            captured.setdefault("messages", []).append(m)
+        yield AssistantMessage(content=[TextBlock(text="ok")], model="m")
+        yield _result_message()
+
+    monkeypatch.setattr(sdk_runner, "query", fake_query)
+    asyncio.run(sdk_runner.run_dispatch("plain prompt", ["Read"], event_queue=asyncio.Queue()))
+    assert captured["messages"][0]["message"]["content"] == "plain prompt"

--- a/tests/integration/test_input_files_cross_cutting.py
+++ b/tests/integration/test_input_files_cross_cutting.py
@@ -1,0 +1,452 @@
+"""Cross-cutting integration tests for dispatch input files.
+
+These pin the guarantees that span the worker and the dispatcher together and so
+belong to neither single unit's test module:
+
+1. **Combined-cap arithmetic** — the caller-file cap, the follow-up re-injection
+   cap, and a folded-history budget are sized so a worst-case request body still
+   fits the 32 MB request-body limit with roughly a quarter to spare. A change to
+   any one constant that eroded that headroom is caught here.
+2. **No base64 payload leak, end to end** — a file's ``content_b64`` bytes ride
+   only an image content block; they must never reach the assembled prompt text,
+   the persisted run record, the dispatcher's recorded history, or any log sink.
+3. **Version skew** — a request carrying ``input_files`` against a model that
+   predates the field is silently dropped, not rejected. This is why a bridge
+   must gate the feature on the ``/health`` capability rather than assume the
+   worker consumed the batch.
+4. **Fatal-4xx error_code propagation** — a worker 400 with a machine-readable
+   ``detail`` travels webhook -> worker_client ``FatalDispatchError`` -> pool
+   record -> the dispatcher's ``/dispatch/{id}`` poll body as a top-level error
+   carrying the same ``error_code``.
+
+Hermetic: FastAPI/Starlette ``TestClient`` and direct calls, fake ``query`` and
+``dispatch_to_worker`` stand-ins, tmp-rooted artifact stores — no network, no
+real SDK, no real worker.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+from pydantic import BaseModel
+from starlette.testclient import TestClient
+
+from osprey.dispatch import server
+from osprey.dispatch.sources.webhook import _MAX_WEBHOOK_BYTES, WebhookSource
+from osprey.dispatch.trigger_config import TriggerConfig
+from osprey.dispatch.worker_client import FatalDispatchError
+from osprey.mcp_server.dispatch_worker import dispatch_api, sdk_runner
+from osprey.mcp_server.dispatch_worker.dispatch_api import (
+    MAX_REQUEST_BYTES,
+    DispatchRequest,
+    InputFile,
+)
+from osprey.mcp_server.dispatch_worker.input_files_policy import (
+    MAX_IMAGE_BYTES,
+    MAX_INGEST_FILES,
+    MAX_TOTAL_DECODED_BYTES,
+)
+
+_MiB = 1024 * 1024
+
+
+# ===========================================================================
+# 1. Combined-cap arithmetic pin
+# ===========================================================================
+
+# Bridge-side inbound caps, mirrored here as documented literals because the
+# bridge lives in a separate repository and cannot be imported. A follow-up
+# request may carry, at most, a batch of newly-attached caller files PLUS a
+# re-injection of a few recent prior images:
+#   * new caller files: at most 5 files, 10 MiB decoded in total (inbound);
+#   * re-injected prior images: at most 3 images, 8 MiB decoded in total.
+# The worker's own ceiling (MAX_TOTAL_DECODED_BYTES) is what actually bounds the
+# sum; these two caps are sized so their sum lands exactly on it.
+_BRIDGE_NEW_FILES_MAX_DECODED = 10 * _MiB
+_BRIDGE_REINJECT_MAX_DECODED = 8 * _MiB
+_BRIDGE_NEW_FILES_MAX_COUNT = 5
+_BRIDGE_REINJECT_MAX_COUNT = 3
+
+# Prior-turn conversation history folded into the prompt on a follow-up dispatch.
+_HISTORY_BUDGET_BYTES = 40 * 1024
+
+# Generous allowance for the JSON envelope around the batch (field names, quotes,
+# per-file filename/mime, the prompt text itself). The real overhead for <=8
+# files is a few hundred bytes; 64 KiB is a deliberate over-estimate so the
+# headroom this test asserts is a floor, not a knife's edge.
+_ENVELOPE_OVERHEAD_BYTES = 64 * 1024
+
+
+def _b64_len(decoded_bytes: int) -> int:
+    """Length of the base64 encoding of ``decoded_bytes`` raw bytes."""
+    return ((decoded_bytes + 2) // 3) * 4
+
+
+def test_input_files_combined_caps_sum_to_worker_total_ceiling():
+    """New-file and re-injection caps are sized to exactly saturate the worker
+    ceiling — never to exceed it."""
+    assert _BRIDGE_NEW_FILES_MAX_DECODED + _BRIDGE_REINJECT_MAX_DECODED == MAX_TOTAL_DECODED_BYTES
+    # The two per-batch count caps stay within the worker's ingest-file cap when
+    # the new files are all ingested (re-injected images ride ingest=False).
+    assert _BRIDGE_NEW_FILES_MAX_COUNT <= MAX_INGEST_FILES
+    # Each re-injected image is itself within the per-image cap.
+    assert _BRIDGE_REINJECT_MAX_DECODED <= _BRIDGE_REINJECT_MAX_COUNT * MAX_IMAGE_BYTES
+
+
+def test_input_files_worst_case_body_fits_request_limit_with_headroom():
+    """The worst-case decoded batch, base64-encoded, plus folded history and JSON
+    envelope, fits the 32 MB request-body limit with ~25% headroom."""
+    # Worst-case decoded content is the worker ceiling (the two bridge caps sum to
+    # it); base64 inflates it by 4/3.
+    worst_body = (
+        _b64_len(MAX_TOTAL_DECODED_BYTES) + _HISTORY_BUDGET_BYTES + _ENVELOPE_OVERHEAD_BYTES
+    )
+    assert worst_body <= MAX_REQUEST_BYTES
+
+    headroom_fraction = (MAX_REQUEST_BYTES - worst_body) / MAX_REQUEST_BYTES
+    # "~25% headroom" — pin it to a band so eroding it (bigger caps) or bloating
+    # it (a needlessly huge limit) both trip the test.
+    assert 0.20 <= headroom_fraction <= 0.30
+
+
+def test_input_files_worker_and_dispatcher_body_limits_agree():
+    """The worker and the dispatcher enforce the same 32 MB request-body limit, so
+    a body sized against one is not surprised by the other."""
+    assert MAX_REQUEST_BYTES == _MAX_WEBHOOK_BYTES == 32 * 1024 * 1024
+
+
+# ===========================================================================
+# 2. End-to-end: content_b64 never leaks (prompt / record / logs)
+# ===========================================================================
+
+# A distinctive image body whose base64 is a single >64-char run — long enough to
+# be caught by the sdk_runner redaction filter if it ever reached a log record.
+_LEAK_MARKER_BYTES = b"\x89PNG\r\n\x1a\n" + b"LEAK-MARKER-PAYLOAD-BODY" * 16
+_LEAK_MARKER_B64 = base64.b64encode(_LEAK_MARKER_BYTES).decode("ascii")
+
+
+def _project_root(tmp_path: Path, monkeypatch) -> Path:
+    """Point OSPREY_PROJECT_DIR at a tmp project so the artifact store roots there."""
+    project = tmp_path / "project"
+    (project / "_agent_data" / "artifacts").mkdir(parents=True)
+    monkeypatch.setenv("OSPREY_PROJECT_DIR", str(project))
+    monkeypatch.delenv("OSPREY_CONFIG", raising=False)
+    return project
+
+
+@pytest.fixture
+def _stub_sdk_helpers(monkeypatch):
+    """Stub the deferred OSPREY helper imports so run_dispatch can be driven."""
+    monkeypatch.setattr(
+        "osprey.interfaces.web_terminal.operator_session.build_clean_env",
+        lambda **kw: {},
+    )
+    monkeypatch.setattr(
+        "osprey.interfaces.web_terminal.sdk_context.build_system_prompt",
+        lambda *a, **k: "system",
+    )
+    monkeypatch.setattr(
+        "osprey.utils.config.get_facility_timezone",
+        lambda *a, **k: "UTC",
+    )
+
+
+async def test_input_files_content_b64_absent_from_worker_record_and_logs(
+    tmp_path, monkeypatch, caplog, _stub_sdk_helpers
+):
+    """A full worker run that ingests and re-inlines an image never leaks its
+    content_b64 into the prompt text, the persisted run record, or any log."""
+    _project_root(tmp_path, monkeypatch)
+    monkeypatch.setattr(dispatch_api, "_runs", {})
+    monkeypatch.setattr(dispatch_api, "_queues", {})
+    monkeypatch.setattr(dispatch_api, "_tasks", {})
+    monkeypatch.setattr(dispatch_api, "_run_input_seam", {})
+
+    # Capture exactly what would be persisted to disk (the terminal run record).
+    persisted: dict = {}
+    monkeypatch.setattr(dispatch_api, "_persist_run", lambda rid, r: persisted.update(r))
+
+    # Fake SDK generator: drain the streamed prompt to capture the user message,
+    # then return a normal completion.
+    captured: dict = {}
+
+    async def fake_query(prompt, options):  # noqa: A002 - matches SDK signature
+        messages = []
+        async for m in prompt:
+            messages.append(m)
+        captured["user_message"] = messages[0]
+        yield AssistantMessage(content=[TextBlock(text="ok")], model="m")
+        # Spec'd mock passes the isinstance(message, ResultMessage) branch; set the
+        # exact fields run_dispatch reads for a clean (non-error) completion.
+        rm = MagicMock(spec=ResultMessage)
+        rm.num_turns = 1
+        rm.is_error = False
+        rm.subtype = "success"
+        rm.result = "ok"
+        rm.api_error_status = None
+        yield rm
+
+    monkeypatch.setattr(sdk_runner, "query", fake_query)
+
+    req = DispatchRequest(
+        prompt="describe this",
+        allowed_tools=[],
+        input_files=[
+            InputFile(filename="plot.png", mime="image/png", content_b64=_LEAK_MARKER_B64),
+        ],
+    )
+    with caplog.at_level(logging.DEBUG, logger="osprey.mcp_server.dispatch_worker"):
+        await dispatch_api._run_dispatch_task("run-leak", req)
+
+    # The image reached the model — its bytes ride source.data of an image block.
+    content = captured["user_message"]["message"]["content"]
+    assert isinstance(content, list)
+    image_block = content[0]
+    assert image_block["type"] == "image"
+    assert image_block["source"]["data"] == _LEAK_MARKER_B64
+    # ... but never the prompt text block accompanying it.
+    text_block = content[-1]
+    assert text_block["type"] == "text"
+    assert _LEAK_MARKER_B64 not in text_block["text"]
+
+    # The persisted terminal record — every field, serialized — carries no b64.
+    result = dispatch_api._runs["run-leak"]
+    assert result["status"] == "completed"
+    assert _LEAK_MARKER_B64 not in json.dumps(result, default=str)
+    assert persisted and _LEAK_MARKER_B64 not in json.dumps(persisted, default=str)
+    # The input file is surfaced by descriptor only (filename/mime/entry_id).
+    assert [d["filename"] for d in result["input_artifacts"]] == ["plot.png"]
+
+    # No log record anywhere in the dispatch loggers carries the payload.
+    assert _LEAK_MARKER_B64 not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_input_files_content_b64_absent_from_dispatcher_prompt_record_logs(caplog):
+    """On the dispatcher, the popped batch is forwarded to the worker but its
+    content_b64 reaches neither the folded prompt, the recorded history, nor a log."""
+    from osprey.dispatch.registry import TriggerRegistry
+
+    trigger = TriggerConfig(
+        name="deploy", source="webhook", action={"prompt": "do it", "allowed_tools": []}
+    )
+    registry = TriggerRegistry()
+    await registry.register(trigger)
+
+    captured: dict = {}
+
+    async def _fake_dispatch(**kwargs):
+        captured.update(kwargs)
+        return {"run_id": "r1", "status": "accepted"}
+
+    payload = {
+        "question": "hello",
+        "input_files": [
+            {
+                "filename": "plot.png",
+                "mime": "image/png",
+                "content_b64": _LEAK_MARKER_B64,
+                "ingest": True,
+            }
+        ],
+    }
+    with caplog.at_level(logging.DEBUG, logger="osprey.dispatch"):
+        with patch.object(server, "dispatch_to_worker", _fake_dispatch):
+            result = await server._dispatch_with_policy(
+                trigger, payload, registry, "http://worker", "tok"
+            )
+
+    assert result == {"run_id": "r1", "status": "accepted"}
+    # Forwarded to the worker as a structured batch (bytes intact there)...
+    assert captured["input_files"][0]["content_b64"] == _LEAK_MARKER_B64
+    # ... but absent from the prompt the worker was asked to fold/run.
+    assert _LEAK_MARKER_B64 not in captured["prompt"]
+
+    # The durable trigger history — serialized — never carries the payload bytes.
+    history = await registry.get_history("deploy")
+    assert history and _LEAK_MARKER_B64 not in json.dumps(history, default=str)
+
+    # And no dispatcher log line leaks it (the input-file log is size-only).
+    assert _LEAK_MARKER_B64 not in caplog.text
+
+
+# ===========================================================================
+# 3. Version skew: input_files against a model that predates the field
+# ===========================================================================
+
+
+class _LegacyDispatchRequest(BaseModel):
+    """A stand-in for a worker request model that predates ``input_files``.
+
+    Mirrors the pre-feature ``DispatchRequest`` field set exactly. Pydantic's
+    default ``extra='ignore'`` means an ``input_files`` key in the incoming JSON
+    is silently dropped rather than rejected — the exact skew a bridge must guard
+    against by gating on the ``/health`` capability.
+    """
+
+    prompt: str
+    allowed_tools: list[str]
+    max_turns: int = 25
+    surface_prompt: str | None = None
+    surface_tools: list[str] | None = None
+
+
+def test_input_files_skew_old_model_silently_drops_field():
+    """A payload with input_files parsed by a pre-field model drops it silently."""
+    wire_payload = {
+        "prompt": "look",
+        "allowed_tools": ["Read"],
+        "input_files": [
+            {"filename": "plot.png", "mime": "image/png", "content_b64": "QUJD", "ingest": True}
+        ],
+    }
+    legacy = _LegacyDispatchRequest(**wire_payload)
+    # Not rejected — constructed fine — but the batch is gone: the field does not
+    # exist on the model and no error was raised.
+    assert not hasattr(legacy, "input_files")
+    assert "input_files" not in legacy.model_dump()
+    assert legacy.prompt == "look"
+
+
+def test_input_files_skew_current_model_captures_field():
+    """Positive control: the current model DOES carry the batch, so the skew is
+    strictly a property of the old model, not of the wire payload."""
+    wire_payload = {
+        "prompt": "look",
+        "allowed_tools": ["Read"],
+        "input_files": [
+            {"filename": "plot.png", "mime": "image/png", "content_b64": "QUJD", "ingest": True}
+        ],
+    }
+    current = DispatchRequest(**wire_payload)
+    assert current.input_files is not None
+    assert len(current.input_files) == 1
+    assert current.input_files[0].filename == "plot.png"
+
+
+# ===========================================================================
+# 4. Fatal-4xx error_code propagation: webhook -> pool -> poll body
+# ===========================================================================
+
+
+class _FakeEntryPoint:
+    def __init__(self, name: str, cls: type) -> None:
+        self.name = name
+        self._cls = cls
+
+    def load(self) -> type:
+        return self._cls
+
+
+@pytest.fixture(autouse=True)
+def _reset_mcp_routes():
+    baseline = list(server.mcp._additional_http_routes)
+    yield
+    server.mcp._additional_http_routes = baseline
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    path = tmp_path / "triggers.yml"
+    path.write_text(
+        "dispatcher:\n"
+        "  dispatch_target: http://localhost:9999\n"
+        "  max_concurrent_runs: 2\n"
+        "  max_queue_depth: 10\n"
+        "triggers:\n"
+        "  - name: deploy\n"
+        "    source: webhook\n"
+        "    action:\n"
+        "      prompt: do the thing\n"
+        "      allowed_tools: []\n"
+    )
+    monkeypatch.setenv("TRIGGERS_YML", str(path))
+    monkeypatch.setenv("EVENT_DISPATCHER_TOKEN", "secret")
+    monkeypatch.setenv("DISPATCH_WORKER_TOKEN", "worker-secret")
+
+    def fake_entry_points(*, group):
+        assert group == "osprey.trigger_sources"
+        return [_FakeEntryPoint("webhook", WebhookSource)]
+
+    monkeypatch.setattr("osprey.dispatch.source_registry.entry_points", fake_entry_points)
+    return server.create_server().http_app()
+
+
+def _poll_until_terminal(client: TestClient, dispatch_id: str, tries: int = 50) -> dict:
+    """Poll /dispatch/{id} until the pool result leaves 'pending' (or give up)."""
+    body: dict = {}
+    for _ in range(tries):
+        resp = client.get(f"/dispatch/{dispatch_id}", headers={"Authorization": "Bearer secret"})
+        assert resp.status_code == 200
+        body = resp.json()
+        if body.get("status") != "pending":
+            return body
+    return body
+
+
+def test_input_files_fatal_400_propagates_webhook_to_poll_body(app):
+    """A worker 400 (input_files_cap_exceeded) surfaces on the dispatcher's poll
+    body as a top-level error carrying the same error_code and trigger name."""
+
+    async def _fake_dispatch(**kwargs):
+        raise FatalDispatchError("HTTP 400 from worker", error_code="input_files_cap_exceeded")
+
+    with patch.object(server, "dispatch_to_worker", _fake_dispatch):
+        with TestClient(app) as client:
+            resp = client.post(
+                "/webhook/deploy",
+                headers={"Authorization": "Bearer secret"},
+                content=json.dumps(
+                    {
+                        "question": "hi",
+                        "input_files": [
+                            {
+                                "filename": "big.png",
+                                "mime": "image/png",
+                                "content_b64": "QUJD",
+                                "ingest": True,
+                            }
+                        ],
+                    }
+                ),
+            )
+            assert resp.status_code == 202
+            dispatch_id = resp.json()["dispatch_id"]
+
+            body = _poll_until_terminal(client, dispatch_id)
+
+    # The fatal rejection is unwrapped to a TOP-LEVEL pool error, not a
+    # completed run and not a silent drop.
+    assert body["status"] == "error"
+    assert body["error_code"] == "input_files_cap_exceeded"
+    assert body["error"]  # human-readable message present (status-only, no body echo)
+    assert body["trigger_name"] == "deploy"
+
+
+def test_input_files_fatal_generic_4xx_propagates_null_error_code(app):
+    """A non-whitelisted 4xx (e.g. denied tools) still surfaces as a top-level
+    error, with error_code None rather than an echoed internal detail."""
+
+    async def _fake_dispatch(**kwargs):
+        raise FatalDispatchError("HTTP 403 from worker", error_code=None)
+
+    with patch.object(server, "dispatch_to_worker", _fake_dispatch):
+        with TestClient(app) as client:
+            resp = client.post(
+                "/webhook/deploy",
+                headers={"Authorization": "Bearer secret"},
+                content=json.dumps({"question": "hi"}),
+            )
+            assert resp.status_code == 202
+            dispatch_id = resp.json()["dispatch_id"]
+            body = _poll_until_terminal(client, dispatch_id)
+
+    assert body["status"] == "error"
+    assert body["error_code"] is None
+    assert body["trigger_name"] == "deploy"

--- a/tests/manual/test_sdk_image_block.py
+++ b/tests/manual/test_sdk_image_block.py
@@ -1,0 +1,258 @@
+"""Manual spike: prove the Agent SDK streams a base64 image block to the CLI.
+
+This harness empirically verifies a single load-bearing assumption: that
+``claude_agent_sdk``'s *stream-json input* path accepts a user message whose
+``content`` is a **block list** containing a base64-encoded image block, and
+that the block reaches the model end-to-end through the ``claude`` CLI
+subprocess. Static research only confirmed the assumption up to the SDK
+boundary (``_internal/client.py`` writes each streamed dict verbatim to the
+CLI's stdin via ``json.dumps(dict) + "\n"``); this run closes the gap by
+sending a real image and checking the model names its color.
+
+The exact message dict shape the CLI accepted (the deliverable for the
+downstream prompt-assembly task):
+
+    {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": "<base64 PNG bytes, no data: URI prefix>",
+                    },
+                },
+                {"type": "text", "text": "What color is this square? ..."},
+            ],
+        },
+    }
+
+Gotchas discovered (for the prompt-assembly task):
+
+  * The top-level envelope is ``{"type": "user", "message": {...}}`` — the
+    image/text blocks live under ``message.content``, NOT at the top level.
+    ``message`` mirrors the Anthropic Messages API user-turn shape exactly.
+  * The image block is the Anthropic native shape
+    ``{"type": "image", "source": {"type": "base64", "media_type": ...,
+    "data": ...}}``. ``data`` is the **raw base64 string** — no ``data:``
+    URI prefix, no whitespace/newlines.
+  * Block ordering is free: image-then-text works (verified here). The model
+    resolves "this square" against the image regardless.
+  * The SDK writes the dict verbatim — it does no validation of the block
+    schema. A malformed block is only rejected downstream by the CLI/API, so
+    the caller owns getting ``media_type`` and base64 right.
+  * Provider env (base_url / auth token / model) must be delivered via
+    ``ClaudeAgentOptions.env`` (or the ambient process env). ``options.env``
+    overrides the inherited environment for the spawned CLI subprocess.
+
+Skipped by default. To run it once against a real provider::
+
+    OSPREY_RUN_SDK_IMAGE_SPIKE=1 \
+      PYTHONPATH=$WORKTREE/src \
+      $VENV/bin/python -m pytest tests/manual/test_sdk_image_block.py -s
+
+It also runs standalone: ``python tests/manual/test_sdk_image_block.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import os
+import struct
+import tempfile
+import zlib
+from collections.abc import AsyncIterator
+
+import pytest
+
+# --------------------------------------------------------------------------
+# Provider wiring — als-apg is Anthropic-native (no translation proxy) and
+# IP-unrestricted (works off-VPN / from CI), so it is the default here. CBORG
+# is LBLnet-gated and would 403 off-VPN. Values mirror osprey's own resolver
+# (CLAUDE_CODE_PROVIDERS in osprey.cli.claude_code_resolver).
+# --------------------------------------------------------------------------
+_PROVIDERS = [
+    ("ALS_APG_API_KEY", "https://llm.gianlucamartino.com", "claude-haiku-4-5-20251001"),
+    ("CBORG_API_KEY", "https://api.cborg.lbl.gov", "claude-haiku-4-5"),
+    ("ANTHROPIC_API_KEY", None, "claude-haiku-4-5-20251001"),
+]
+
+
+def _select_provider() -> tuple[str, str | None, str] | None:
+    """Return (secret, base_url, model) for the first provider with a key."""
+    for env_var, base_url, model in _PROVIDERS:
+        secret = os.environ.get(env_var)
+        if secret and "${" not in secret:
+            return secret, base_url, model
+    return None
+
+
+def _provider_env(secret: str, base_url: str | None, model: str) -> dict[str, str]:
+    """Build the CLI subprocess env for the chosen provider.
+
+    Proxy providers authenticate with ANTHROPIC_AUTH_TOKEN + ANTHROPIC_BASE_URL
+    (bare origin, no /v1). Direct Anthropic uses ANTHROPIC_API_KEY only. The
+    three tier-model vars plus ANTHROPIC_MODEL pin every model the CLI might
+    reach to the one cheap haiku-class model.
+    """
+    env = {
+        "ANTHROPIC_MODEL": model,
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL": model,
+        "ANTHROPIC_DEFAULT_SONNET_MODEL": model,
+        "ANTHROPIC_DEFAULT_OPUS_MODEL": model,
+        "ANTHROPIC_SMALL_FAST_MODEL": model,
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+    }
+    if base_url:
+        env["ANTHROPIC_BASE_URL"] = base_url.rstrip("/").removesuffix("/v1")
+        env["ANTHROPIC_AUTH_TOKEN"] = secret
+    else:
+        env["ANTHROPIC_API_KEY"] = secret
+    return env
+
+
+# --------------------------------------------------------------------------
+# Test image — a 32x32 solid-red PNG built in-process (no binary fixture,
+# no PIL dependency): raw RGB scanlines, zlib-compressed, wrapped in the
+# minimal IHDR/IDAT/IEND chunk structure.
+# --------------------------------------------------------------------------
+def _red_png_b64(size: int = 32) -> str:
+    def _chunk(tag: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data))
+            + tag
+            + data
+            + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+        )
+
+    ihdr = struct.pack(">IIBBBBB", size, size, 8, 2, 0, 0, 0)  # RGB, 8-bit
+    row = b"\x00" + b"\xff\x00\x00" * size  # filter byte 0 + red pixels
+    idat = zlib.compress(row * size, 9)
+    png = (
+        b"\x89PNG\r\n\x1a\n" + _chunk(b"IHDR", ihdr) + _chunk(b"IDAT", idat) + _chunk(b"IEND", b"")
+    )
+    return base64.b64encode(png).decode("ascii")
+
+
+def _image_message() -> dict:
+    """The exact stream-json user message the CLI is expected to accept."""
+    return {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": _red_png_b64(),
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": (
+                        "What color is this square? Answer with a single "
+                        "lowercase color word and nothing else."
+                    ),
+                },
+            ],
+        },
+    }
+
+
+async def _stream_once(message: dict) -> AsyncIterator[dict]:
+    """Yield exactly one streamed message, then close the input stream.
+
+    Returning after the single yield exhausts the async iterable, which the
+    SDK turns into an EOF on the CLI's stdin — the CLI processes the one turn
+    and emits its result.
+    """
+    yield message
+
+
+async def _run_spike() -> tuple[str, object]:
+    """Send the image message through the SDK/CLI; return (reply_text, result)."""
+    from claude_agent_sdk import (
+        AssistantMessage,
+        ClaudeAgentOptions,
+        ResultMessage,
+        TextBlock,
+        query,
+    )
+
+    selected = _select_provider()
+    if selected is None:
+        raise RuntimeError("no provider key available")
+    env = _provider_env(*selected)
+
+    reply_parts: list[str] = []
+    result: object = None
+
+    # Clean cwd + empty setting_sources = SDK isolation: no project/user
+    # settings files can override the provider env we inject.
+    with tempfile.TemporaryDirectory() as cwd:
+        options = ClaudeAgentOptions(
+            env=env,
+            model=env["ANTHROPIC_MODEL"],
+            max_turns=1,
+            allowed_tools=[],
+            setting_sources=[],
+            permission_mode="bypassPermissions",
+            cwd=cwd,
+        )
+        async for msg in query(prompt=_stream_once(_image_message()), options=options):
+            if isinstance(msg, AssistantMessage):
+                for block in msg.content:
+                    if isinstance(block, TextBlock):
+                        reply_parts.append(block.text)
+            elif isinstance(msg, ResultMessage):
+                result = msg
+
+    return " ".join(reply_parts).strip(), result
+
+
+# Skip-by-default gates:
+#   * requires_als_apg / provider key — auto-skips in CI (no key present).
+#   * OSPREY_RUN_SDK_IMAGE_SPIKE — explicit opt-in so a local `pytest tests/`
+#     with keys present still skips this real-API, cost-incurring run.
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(
+        not os.environ.get("OSPREY_RUN_SDK_IMAGE_SPIKE"),
+        reason="manual spike; set OSPREY_RUN_SDK_IMAGE_SPIKE=1 to run",
+    ),
+    pytest.mark.skipif(
+        _select_provider() is None,
+        reason="no provider API key (ALS_APG_API_KEY / CBORG_API_KEY / ANTHROPIC_API_KEY)",
+    ),
+]
+
+
+def test_sdk_accepts_base64_image_block():
+    """The CLI accepts a streamed base64 image block and the model reads it."""
+    reply, result = asyncio.run(_run_spike())
+    print(f"\n[spike] model reply: {reply!r}")
+    if result is not None:
+        print(
+            f"[spike] result: subtype={getattr(result, 'subtype', None)!r} "
+            f"is_error={getattr(result, 'is_error', None)!r} "
+            f"cost_usd={getattr(result, 'total_cost_usd', None)!r}"
+        )
+    assert result is None or not getattr(result, "is_error", False), (
+        f"CLI returned an error result: {result!r}"
+    )
+    assert "red" in reply.lower(), f"expected the model to name red, got: {reply!r}"
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("OSPREY_RUN_SDK_IMAGE_SPIKE", "1")
+    _reply, _result = asyncio.run(_run_spike())
+    print(f"model reply: {_reply!r}")
+    print(f"result: {_result!r}")
+    assert "red" in _reply.lower(), f"expected red, got {_reply!r}"
+    print("PASS: CLI accepted the base64 image block and the model named the color.")

--- a/tests/unit/dispatch/test_server_error_code.py
+++ b/tests/unit/dispatch/test_server_error_code.py
@@ -1,0 +1,265 @@
+"""Dispatcher-side input_files passthrough hygiene, fatal-4xx error_code
+surfacing, /health capability advertisement, and webhook body-limit.
+
+The direct-call tests exercise ``_dispatch_with_policy`` with a stubbed
+``dispatch_to_worker`` and an AsyncMock registry; the route tests drive the real
+FastMCP app through a Starlette ``TestClient`` (same harness as
+``test_server_routes``)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from osprey.dispatch import server
+from osprey.dispatch.sources.webhook import WebhookSource
+from osprey.dispatch.trigger_config import TriggerConfig
+from osprey.dispatch.worker_client import FatalDispatchError
+
+_FILES = [
+    {"filename": "plot.png", "mime": "image/png", "content_b64": "QUJD" * 100, "ingest": True},
+]
+
+
+def _trigger() -> TriggerConfig:
+    return TriggerConfig(
+        name="deploy", source="webhook", action={"prompt": "do it", "allowed_tools": []}
+    )
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_with_policy: input_files passthrough hygiene
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_passthrough_pops_input_files_before_fold_and_record():
+    registry = AsyncMock()
+    captured: dict[str, Any] = {}
+
+    async def _fake_dispatch(**kwargs):
+        captured.update(kwargs)
+        return {"run_id": "r1", "status": "accepted"}
+
+    payload = {"question": "hello", "input_files": _FILES}
+    with patch.object(server, "dispatch_to_worker", _fake_dispatch):
+        result = await server._dispatch_with_policy(
+            _trigger(), payload, registry, "http://worker", "tok"
+        )
+
+    assert result == {"run_id": "r1", "status": "accepted"}
+    # Forwarded to the worker...
+    assert captured["input_files"] == _FILES
+    # ...but stripped from the payload, so it never lands in the prompt fold...
+    assert "input_files" not in payload
+    assert "content_b64" not in captured["prompt"]
+    # ...nor in the recorded history event (record_event got the popped payload).
+    recorded_payload = registry.record_event.await_args.args[1]
+    assert "input_files" not in recorded_payload
+
+
+@pytest.mark.asyncio
+async def test_dispatch_passthrough_no_input_files_forwards_none():
+    registry = AsyncMock()
+    captured: dict[str, Any] = {}
+
+    async def _fake_dispatch(**kwargs):
+        captured.update(kwargs)
+        return {"run_id": "r1", "status": "accepted"}
+
+    with patch.object(server, "dispatch_to_worker", _fake_dispatch):
+        await server._dispatch_with_policy(
+            _trigger(), {"question": "hi"}, registry, "http://worker", "tok"
+        )
+    assert captured["input_files"] is None
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_with_policy: fatal 4xx -> sentinel error dict carrying error_code
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_error_code_fatal_4xx_returns_sentinel_not_none():
+    registry = AsyncMock()
+
+    async def _fake_dispatch(**kwargs):
+        raise FatalDispatchError("HTTP 400 from worker", error_code="input_files_cap_exceeded")
+
+    with patch.object(server, "dispatch_to_worker", _fake_dispatch):
+        result = await server._dispatch_with_policy(
+            _trigger(), {"input_files": _FILES}, registry, "http://worker", "tok"
+        )
+
+    # Never drop-to-None for a 4xx: a sentinel error dict carries the code.
+    assert result is not None
+    assert result["status"] == "error"
+    assert result["error_code"] == "input_files_cap_exceeded"
+    # It is NOT routed through the retry/drop policy (recorded as a rejection).
+    recorded_status = registry.record_event.await_args.args[2]
+    assert recorded_status.startswith("rejected")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_error_code_generic_4xx_returns_sentinel_none_code():
+    registry = AsyncMock()
+
+    async def _fake_dispatch(**kwargs):
+        raise FatalDispatchError("HTTP 403 from worker", error_code=None)
+
+    with patch.object(server, "dispatch_to_worker", _fake_dispatch):
+        result = await server._dispatch_with_policy(
+            _trigger(), {}, registry, "http://worker", "tok"
+        )
+    assert result["status"] == "error"
+    assert result["error_code"] is None
+
+
+@pytest.mark.asyncio
+async def test_dispatch_passthrough_retry_rethreads_input_files():
+    """A retryable failure then success must re-forward the popped input_files."""
+    registry = AsyncMock()
+    calls: list = []
+
+    async def _fake_dispatch(**kwargs):
+        calls.append(kwargs["input_files"])
+        if len(calls) == 1:
+            from osprey.dispatch.worker_client import DispatchError
+
+            raise DispatchError("transient")
+        return {"run_id": "r2", "status": "accepted"}
+
+    trigger = TriggerConfig(
+        name="deploy",
+        source="webhook",
+        action={"prompt": "p", "allowed_tools": []},
+        on_error={"action": "retry", "max_retries": 1, "backoff_sec": 0.0},
+    )
+    with patch.object(server, "dispatch_to_worker", _fake_dispatch):
+        result = await server._dispatch_with_policy(
+            trigger, {"input_files": _FILES}, registry, "http://worker", "tok"
+        )
+    assert result == {"run_id": "r2", "status": "accepted"}
+    # Both the initial attempt and the retry carried the same files (payload was
+    # mutated by the pop, so only the threaded value keeps them alive).
+    assert calls == [_FILES, _FILES]
+
+
+# ---------------------------------------------------------------------------
+# Route-level: /health capability, get_dispatch_result reshape, webhook body_limit
+# ---------------------------------------------------------------------------
+
+
+class _FakeEntryPoint:
+    def __init__(self, name: str, cls: type) -> None:
+        self.name = name
+        self._cls = cls
+
+    def load(self) -> type:
+        return self._cls
+
+
+@pytest.fixture(autouse=True)
+def _reset_mcp_routes():
+    baseline = list(server.mcp._additional_http_routes)
+    yield
+    server.mcp._additional_http_routes = baseline
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    path = tmp_path / "triggers.yml"
+    path.write_text(
+        "dispatcher:\n"
+        "  dispatch_target: http://localhost:9999\n"
+        "  max_concurrent_runs: 2\n"
+        "  max_queue_depth: 10\n"
+        "triggers:\n"
+        "  - name: deploy\n"
+        "    source: webhook\n"
+        "    action:\n"
+        "      prompt: do the thing\n"
+        "      allowed_tools: []\n"
+    )
+    monkeypatch.setenv("TRIGGERS_YML", str(path))
+    monkeypatch.setenv("EVENT_DISPATCHER_TOKEN", "secret")
+
+    def fake_entry_points(*, group):
+        assert group == "osprey.trigger_sources"
+        return [_FakeEntryPoint("webhook", WebhookSource)]
+
+    monkeypatch.setattr("osprey.dispatch.source_registry.entry_points", fake_entry_points)
+    return server.create_server().http_app()
+
+
+def test_health_capability_advertised(app):
+    with TestClient(app) as client:
+        resp = client.get("/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["capabilities"] == ["input_files"]
+    assert isinstance(body["boot_nonce"], (int, float))
+
+
+def test_get_dispatch_result_error_code_surfaced_top_level(app):
+    """A pool result wrapping a fatal sentinel surfaces top-level status+error_code."""
+    with TestClient(app) as client:
+        pool = server.mcp._dispatcher_pool
+        pool._results["did-1"] = {
+            "status": "completed",
+            "result": {
+                "status": "error",
+                "error_code": "input_files_invalid",
+                "error": "HTTP 400 from worker",
+            },
+            "trigger_name": "deploy",
+        }
+        resp = client.get("/dispatch/did-1", headers={"Authorization": "Bearer secret"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "error"
+    assert body["error_code"] == "input_files_invalid"
+
+
+def test_get_dispatch_result_normal_completion_unchanged(app):
+    """A genuine worker completion (status 'accepted', has run_id) is passed through."""
+    with TestClient(app) as client:
+        pool = server.mcp._dispatcher_pool
+        pool._results["did-2"] = {
+            "status": "completed",
+            "result": {"status": "accepted", "run_id": "run-xyz"},
+            "trigger_name": "deploy",
+        }
+        resp = client.get("/dispatch/did-2", headers={"Authorization": "Bearer secret"})
+    body = resp.json()
+    assert body["status"] == "completed"
+    assert body["result"]["run_id"] == "run-xyz"
+    assert "error_code" not in body
+
+
+def test_webhook_body_limit_rejects_oversize_413(app):
+    # A genuinely oversize body so httpx sets a real >32MB Content-Length; the
+    # route must reject with 413 from the header before parsing the body.
+    oversize = ('{"question":"' + "a" * (33 * 1024 * 1024) + '"}').encode()
+    with TestClient(app) as client:
+        resp = client.post(
+            "/webhook/deploy",
+            headers={"Authorization": "Bearer secret"},
+            content=oversize,
+        )
+    assert resp.status_code == 413
+
+
+def test_webhook_body_limit_allows_normal_body(app):
+    with TestClient(app) as client:
+        resp = client.post(
+            "/webhook/deploy",
+            headers={"Authorization": "Bearer secret"},
+            content=json.dumps({"question": "hi"}),
+        )
+    # Small body sails past the limit (202 dispatched, or 409 disabled — never 413).
+    assert resp.status_code != 413

--- a/tests/unit/dispatch/test_worker_client_passthrough.py
+++ b/tests/unit/dispatch/test_worker_client_passthrough.py
@@ -1,0 +1,195 @@
+"""input_files passthrough, fatal-4xx error_code extraction, and upload-sized
+timeouts for ``dispatch_to_worker`` (worker_client), driven with httpx.MockTransport."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from osprey.dispatch.worker_client import (
+    AuthError,
+    DispatchError,
+    FatalDispatchError,
+    dispatch_to_worker,
+)
+
+
+def _capturing_transport(
+    captured: dict[str, Any], status_code: int = 200, body: dict | None = None
+) -> httpx.MockTransport:
+    """MockTransport that records the request body/JSON then returns status+body."""
+    if body is None:
+        body = {"run_id": "abc123", "status": "accepted"}
+    encoded = json.dumps(body).encode()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["content"] = request.content
+        try:
+            captured["json"] = json.loads(request.content)
+        except ValueError:
+            captured["json"] = None
+        return httpx.Response(
+            status_code=status_code,
+            content=encoded,
+            headers={"content-type": "application/json"},
+            request=request,
+        )
+
+    return httpx.MockTransport(handler)
+
+
+def _patch_asyncclient(transport: httpx.MockTransport, captured_kwargs: dict | None = None):
+    """Patch worker_client's AsyncClient to use ``transport`` and record its kwargs."""
+    original_cls = httpx.AsyncClient
+
+    class PatchedClient(original_cls):
+        def __init__(self, **kwargs):
+            if captured_kwargs is not None:
+                captured_kwargs.update(kwargs)
+            kwargs["transport"] = transport
+            super().__init__(**kwargs)
+
+    return patch("osprey.dispatch.worker_client.httpx.AsyncClient", PatchedClient)
+
+
+_FILES = [
+    {"filename": "plot.png", "mime": "image/png", "content_b64": "AAECAwQF", "ingest": True},
+]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_passthrough_forwards_input_files():
+    captured: dict[str, Any] = {}
+    transport = _capturing_transport(captured)
+    with _patch_asyncclient(transport):
+        result = await dispatch_to_worker(
+            url="http://worker:9190",
+            prompt="hi",
+            allowed_tools=[],
+            token="tok",
+            input_files=_FILES,
+        )
+    assert result == {"run_id": "abc123", "status": "accepted"}
+    assert captured["json"]["input_files"] == _FILES
+
+
+@pytest.mark.asyncio
+async def test_dispatch_passthrough_omits_input_files_when_absent():
+    """No input_files -> the key is absent, so a worker predating the field is unaffected."""
+    captured: dict[str, Any] = {}
+    transport = _capturing_transport(captured)
+    with _patch_asyncclient(transport):
+        await dispatch_to_worker(
+            url="http://worker:9190", prompt="hi", allowed_tools=[], token="tok"
+        )
+    assert "input_files" not in captured["json"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_passthrough_empty_input_files_is_omitted():
+    captured: dict[str, Any] = {}
+    transport = _capturing_transport(captured)
+    with _patch_asyncclient(transport):
+        await dispatch_to_worker(
+            url="http://worker:9190",
+            prompt="hi",
+            allowed_tools=[],
+            token="tok",
+            input_files=[],
+        )
+    assert "input_files" not in captured["json"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_upload_timeout_widens_connect_and_write():
+    """An input_files upload can be ~24MB; connect/write timeouts must be generous."""
+    captured_kwargs: dict[str, Any] = {}
+    transport = _capturing_transport({})
+    with _patch_asyncclient(transport, captured_kwargs):
+        await dispatch_to_worker(
+            url="http://worker:9190",
+            prompt="hi",
+            allowed_tools=[],
+            token="tok",
+            timeout=30.0,
+            input_files=_FILES,
+        )
+    timeout = captured_kwargs["timeout"]
+    assert isinstance(timeout, httpx.Timeout)
+    assert timeout.connect == 10.0
+    assert timeout.write == 120.0
+    # Read stays at the base timeout — the worker returns 202 immediately.
+    assert timeout.read == 30.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "detail, expected_code",
+    [
+        ("input_files_cap_exceeded", "input_files_cap_exceeded"),
+        ("input_files_invalid", "input_files_invalid"),
+        ("some_other_internal_detail", None),
+        (None, None),
+    ],
+)
+async def test_dispatch_fatal_400_extracts_whitelisted_error_code(detail, expected_code):
+    body = {"detail": detail} if detail is not None else {}
+    transport = _capturing_transport({}, status_code=400, body=body)
+    with _patch_asyncclient(transport):
+        with pytest.raises(FatalDispatchError) as exc_info:
+            await dispatch_to_worker(
+                url="http://worker:9190", prompt="x", allowed_tools=[], token="tok"
+            )
+    assert exc_info.value.error_code == expected_code
+    # Body text is never echoed into the exception message — only the status.
+    assert "HTTP 400" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_fatal_413_body_too_large_is_fatal():
+    transport = _capturing_transport({}, status_code=413, body={"detail": "Request body too large"})
+    with _patch_asyncclient(transport):
+        with pytest.raises(FatalDispatchError) as exc_info:
+            await dispatch_to_worker(
+                url="http://worker:9190", prompt="x", allowed_tools=[], token="tok"
+            )
+    # 413 is not a whitelisted rejection code -> generic (None), still fatal.
+    assert exc_info.value.error_code is None
+
+
+@pytest.mark.asyncio
+async def test_dispatch_fatal_403_denied_tools_is_fatal_generic():
+    transport = _capturing_transport({}, status_code=403, body={"detail": "Tools blocked"})
+    with _patch_asyncclient(transport):
+        with pytest.raises(FatalDispatchError):
+            await dispatch_to_worker(
+                url="http://worker:9190", prompt="x", allowed_tools=[], token="tok"
+            )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_401_still_auth_error_not_fatal():
+    """401 stays AuthError (dispatcher<->worker token), distinct from the 4xx fatal path."""
+    transport = _capturing_transport({}, status_code=401, body={"detail": "no"})
+    with _patch_asyncclient(transport):
+        with pytest.raises(AuthError):
+            await dispatch_to_worker(
+                url="http://worker:9190", prompt="x", allowed_tools=[], token="bad"
+            )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_500_still_retryable_dispatch_error():
+    """5xx remains a retryable DispatchError, not a FatalDispatchError."""
+    transport = _capturing_transport({}, status_code=500, body={"detail": "boom"})
+    with _patch_asyncclient(transport):
+        with pytest.raises(DispatchError) as exc_info:
+            await dispatch_to_worker(
+                url="http://worker:9190", prompt="x", allowed_tools=[], token="tok"
+            )
+    assert not isinstance(exc_info.value, FatalDispatchError)
+    assert "HTTP 500" in str(exc_info.value)

--- a/tests/unit/dispatch_worker/test_dispatch_api_capability_body_limit.py
+++ b/tests/unit/dispatch_worker/test_dispatch_api_capability_body_limit.py
@@ -1,0 +1,59 @@
+"""Worker /health capability advertisement and the 32MB request body-limit guard."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from osprey.mcp_server.dispatch_worker import dispatch_api
+
+_TOKEN = "test-secret-token"
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("DISPATCH_WORKER_TOKEN", _TOKEN)
+    monkeypatch.setattr(dispatch_api, "_runs", {})
+    monkeypatch.setattr(dispatch_api, "_queues", {})
+    monkeypatch.setattr(dispatch_api, "_tasks", {})
+    monkeypatch.setattr(dispatch_api, "_persist_run", lambda run_id, run: None)
+
+    async def _fake_run_dispatch(*, event_queue=None, **kwargs):
+        if event_queue is not None:
+            await event_queue.put({"type": "done"})
+        return {"status": "completed", "text_output": "ok", "tool_calls": []}
+
+    monkeypatch.setattr(dispatch_api.sdk_runner, "run_dispatch", _fake_run_dispatch)
+    with TestClient(dispatch_api.app) as c:
+        yield c
+
+
+def test_health_capability_advertised(client):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["capabilities"] == ["input_files"]
+    # boot_nonce already present on the worker — unchanged, still exposed.
+    assert isinstance(body["boot_nonce"], (int, float))
+
+
+def test_dispatch_body_limit_rejects_oversize_413(client):
+    # A real >32MB body so httpx sets a genuine Content-Length; the middleware
+    # must reject with 413 before the route (or even auth) reads it.
+    oversize = ('{"prompt":"' + "a" * (33 * 1024 * 1024) + '","allowed_tools":[]}').encode()
+    resp = client.post(
+        "/dispatch",
+        headers={"Authorization": f"Bearer {_TOKEN}", "content-type": "application/json"},
+        content=oversize,
+    )
+    assert resp.status_code == 413
+
+
+def test_dispatch_body_limit_allows_normal_body(client):
+    resp = client.post(
+        "/dispatch",
+        headers={"Authorization": f"Bearer {_TOKEN}"},
+        json={"prompt": "hi", "allowed_tools": []},
+    )
+    # A small body is never blocked by the size guard (202 accepted here).
+    assert resp.status_code != 413


### PR DESCRIPTION
## Summary

Adds first-class support for caller-supplied **input files** on dispatched agent
runs — images and small text/JSON payloads that the caller attaches to a request
and that the agent can see and read.

## What's included

- **Request model + fail-closed validation.** The worker `DispatchRequest` grows
  an optional `input_files` batch. Each `InputFile` has a sanitised basename,
  mime, base64 content, and an `ingest` flag (default true). Validation runs at
  request time, before any run is created: mime allowlist, per-file decoded-size
  caps (5 MB images, 100 KB text/json), at most five ingest files, and an 18 MB
  combined decoded ceiling. Violations reject the whole request with HTTP 400 and
  a machine-readable detail code (`input_files_cap_exceeded` /
  `input_files_invalid`). The caps, allowlist, sanitiser, and validator live in a
  framework-free policy module so ingestion shares one source of truth.

- **Worker-side ingestion into the artifact store.** `ingest=true` files are
  decoded into the artifact store before the agent starts, each tagged with the
  run's id and a new `origin="input"` provenance marker. Ingested inputs are kept
  distinct from the agent's own output: excluded from the produced-artifact
  listing, surfaced separately as `input_artifacts` descriptors on the run-status
  body, with the created-by byte route still serving their bytes. `ingest=false`
  files are never stored — their bytes pass through a per-run in-memory seam to
  prompt assembly. The store gains an `origin` field (index-round-tripped,
  backward-compatible with older indexes) and `save_file` grows `origin` and
  explicit `run_id` parameters.

- **Image inlining + descriptor block in the prompt.** When assembling the SDK
  user message, `image/*` inputs become base64 image content blocks in the same
  message; every input file also contributes a mechanism-only descriptor line
  (`data_read(<entry_id>)` for a stored file, a `shown_inline` marker for an
  inlined image) to a block appended to the prompt. A base64-redacting logging
  filter on the runner logger prevents inlined image bytes from leaking to a log
  sink, and tests assert the base64 payload never reaches the prompt text or the
  run record.

- **Dispatcher passthrough + typed 4xx error codes.** The dispatcher forwards an
  `input_files` batch to the worker POST, popping it from the webhook payload
  before the prompt fold and history record so its base64 bytes never land in
  either. A non-401 4xx from the worker maps to a typed, non-retryable error
  carrying a whitelisted `error_code`, surfaced as a pool `status="error"` rather
  than dropped to a silent retry. The dispatcher→worker HTTP timeout is sized for
  large uploads, and both the webhook route and the worker `/dispatch` enforce an
  explicit 32 MB request-body limit.

- **`/health` capability advertisement.** Both dispatcher and worker `/health`
  advertise an `input_files` capability (plus a `boot_nonce`), so a caller can
  detect support before sending.

- **Opt-in retention sweep.** A periodic background task deletes persisted run
  records and artifact-store entries older than a configurable threshold,
  controlled by `RETENTION_DAYS`. Unset/empty/0/non-integer all mean disabled (the
  default); only a positive integer enables it, so a typo cannot silently start
  deleting data. Age is measured from completion; in-flight and pending runs are
  never swept. The sweep functions are pure (injected clock) so boundaries and
  in-flight protection are unit-tested without sleeps.

## Tests

New unit and integration coverage across caps/validation, ingestion, origin
tagging, model construction, prompt assembly, dispatcher passthrough, and
end-to-end error-code propagation. A skipped-by-default manual spike documents the
exact SDK message shape accepted for base64 image blocks. `pytest -k input_files`:
73 passed, 1 skipped. `ruff check` and `ruff format --check` clean.
