### PR TITLE
feat(bluesky): add per-plan scan catalog exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Compatibility is documented in release notes, not encoded in the version string.
 ### Added
 
 - Explicit `--set provider=` / `--set model=` / `--set channel_finder_mode=` build overrides now propagate to the persona projects that multi-user deploys auto-render: the manifest records which of these keys were explicitly passed, and `osprey deploy up` forwards them to each persona's `osprey build` — so one override at build time retints the whole stack. Preset defaults are never forwarded, keeping per-persona provider customization intact.
+- A bluesky scan plan can now be hidden from the agent without turning off the whole scan server. Set `bluesky.excluded_plans` on the profile of the project that deploys the bridge; the deploy render carries it into the bridge as the `BLUESKY_EXCLUDED_PLANS` environment variable. An excluded plan is both absent from the agent's plan list and non-runnable — it cannot be staged or launched by name. The bare config key is a local/development convenience; the environment variable is the production channel.
 
 ### Changed
 

--- a/docs/source/how-to/build-profiles.rst
+++ b/docs/source/how-to/build-profiles.rst
@@ -193,6 +193,18 @@ profile itself is edited.
    write-capable sibling only on ``control_system.writes_enabled``, leaving
    the tool surface identical (see :doc:`web-terminal/multi-user-demo`).
 
+To keep the scan server **on** while hiding an individual plan, set
+``bluesky.excluded_plans`` on the deploying project's profile:
+
+.. code-block:: yaml
+
+   bluesky:
+     excluded_plans: [orm]
+
+The named plan is then invisible to the agent and non-runnable. The deploy render
+carries it to the bridge as ``BLUESKY_EXCLUDED_PLANS`` (the config key alone is a
+dev-only convenience).
+
 
 Quick Start
 ===========

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -1562,6 +1562,13 @@ def _inject_bluesky(bluesky: BlueskyConfig, project_path: Path) -> None:
         # key, so an unset plan_dir means no mount and no BLUESKY_PLAN_DIRS
         # env var at all (Task 1.4).
         config["services"]["bluesky"]["plan_dir"] = bluesky.plan_dir
+    if bluesky.excluded_plans:
+        # Only written when non-empty — its absence keeps a deploy with no
+        # exclusions rendering exactly as before: the compose template's
+        # {% if %} guard reads this same key, so an empty list means no
+        # BLUESKY_EXCLUDED_PLANS env var at all. The os.pathsep join is done
+        # Python-side because the Jinja render context has no `os` module.
+        config["services"]["bluesky"]["excluded_plans"] = os.pathsep.join(bluesky.excluded_plans)
     deployed = config.get("deployed_services", []) or []
     if "bluesky" not in [str(s) for s in deployed]:
         deployed.append("bluesky")

--- a/src/osprey/cli/build_profile.py
+++ b/src/osprey/cli/build_profile.py
@@ -163,6 +163,11 @@ class BlueskyConfig:
     ``plan_loader.py``. ``None`` (default) deploys the bridge with no
     facility plan directory, matching every prior bluesky-only build.
     """
+    excluded_plans: list[str] = field(default_factory=list)
+    """Named plans to hide from the agent while the bluesky server stays
+    enabled (dev/local convenience). Production uses the
+    ``BLUESKY_EXCLUDED_PLANS`` env var instead.
+    """
 
 
 @dataclass
@@ -937,12 +942,21 @@ def _parse_profile(raw: dict[str, Any]) -> BuildProfile:
     if bluesky_raw is not None:
         if not isinstance(bluesky_raw, dict):
             raise BuildProfileError("Profile 'bluesky' must be a mapping")
+        excluded_plans = bluesky_raw.get("excluded_plans", [])
+        if not isinstance(excluded_plans, list) or not all(
+            isinstance(p, str) for p in excluded_plans
+        ):
+            raise BuildProfileError(
+                "bluesky.excluded_plans must be a list of plan-name strings "
+                f"(got {excluded_plans!r})"
+            )
         bluesky = BlueskyConfig(
             port=bluesky_raw.get("port", 8090),
             tiled_enabled=bluesky_raw.get("tiled_enabled", False),
             tiled_port=bluesky_raw.get("tiled_port", 8091),
             demo_runner=bluesky_raw.get("demo_runner", False),
             plan_dir=bluesky_raw.get("plan_dir"),
+            excluded_plans=excluded_plans,
         )
 
     va_raw = raw.get("virtual_accelerator")

--- a/src/osprey/services/bluesky_bridge/plan_loader.py
+++ b/src/osprey/services/bluesky_bridge/plan_loader.py
@@ -90,6 +90,10 @@ _MODULE_PATH_ENV = "BLUESKY_PLAN_MODULE"
 # os.pathsep-separated list of directory-layer dirs, set per bridge instance.
 _PLAN_DIRS_ENV = "BLUESKY_PLAN_DIRS"
 
+# os.pathsep-separated list of plan names to exclude from the catalog, set per
+# bridge instance. Unioned with config.yml's ``bluesky.excluded_plans``.
+_EXCLUDED_PLANS_ENV = "BLUESKY_EXCLUDED_PLANS"
+
 # The in-image core plan directory shipped with this package (task 1.5
 # populates it; scanned even if absent/empty).
 _SHIPPED_PLANS_DIR = Path(__file__).parent / "plans_core"
@@ -173,6 +177,37 @@ def _resolve_plan_dir_layers() -> list[tuple[Path, Provenance]]:
     layers.append((resolve_session_plan_dir(), "session"))
 
     return layers
+
+
+def _resolve_excluded_plans() -> set[str]:
+    """Plan names to exclude from the catalog, unioned across env and config.yml.
+
+    Two sources, both contributing to the returned set:
+
+    1. ``BLUESKY_EXCLUDED_PLANS`` (env, ``os.pathsep``-separated), set per
+       bridge instance at launch — mirrors ``BLUESKY_PLAN_DIRS``.
+    2. ``bluesky.excluded_plans`` in config.yml, either a ``list[str]`` or a
+       bare ``str`` (coerced to a one-element list, mirroring
+       ``bluesky.plan_dirs``).
+
+    Empty tokens are skipped from both sources. Pure and deterministic given
+    env + config; no side effects.
+    """
+    excluded: set[str] = set()
+
+    env_value = os.environ.get(_EXCLUDED_PLANS_ENV)
+    if env_value:
+        excluded.update(t for t in env_value.split(os.pathsep) if t)
+
+    from osprey.utils.workspace import load_osprey_config
+
+    config = load_osprey_config()
+    config_excluded = config.get("bluesky", {}).get("excluded_plans") or []
+    if isinstance(config_excluded, str):
+        config_excluded = [config_excluded]
+    excluded.update(t for t in config_excluded if t)
+
+    return excluded
 
 
 def _load_module_from_path(path: Path) -> Any:
@@ -483,6 +518,11 @@ def _load_startup_layers(module_path: str | None) -> _StartupLayers:
 # ---------------------------------------------------------------------------
 _startup_layers: _StartupLayers | None = None
 _merged_plans: FacilityPlans | None = None
+# Warn-once guard for excluded names that match no registered plan. Keyed on
+# ``(frozenset(unmatched), frozenset(registry.keys()))`` so a stable
+# misconfiguration warns exactly once, re-warning only when the unmatched set or
+# the live registry keys actually change (e.g. a new session plan appears).
+_warned_exclusions: tuple[frozenset[str], frozenset[str]] | None = None
 
 
 def get_facility_plans() -> FacilityPlans:
@@ -499,7 +539,7 @@ def get_facility_plans() -> FacilityPlans:
     written and validated session plan therefore appears on the very next
     call, with no bridge restart and no explicit cache invalidation.
     """
-    global _startup_layers, _merged_plans
+    global _startup_layers, _merged_plans, _warned_exclusions
 
     if _startup_layers is None:
         _startup_layers = _load_startup_layers(None)
@@ -509,6 +549,25 @@ def get_facility_plans() -> FacilityPlans:
         _load_plan_file(path, "session", registry)
 
     plans = {name: spec for name, (_, _, spec) in registry.items()}
+
+    # Drop excluded plans BEFORE wrapping/caching: filtering after the
+    # `_merged_plans` equality compare below would cache and return an
+    # UNFILTERED result. An excluded name that matches no registered plan warns
+    # exactly once (guarded on the unmatched set + live registry keys), so a
+    # stable misconfiguration doesn't warn on every scan.
+    excluded = _resolve_excluded_plans()
+    unmatched = excluded - set(registry.keys())
+    if unmatched:
+        key = (frozenset(unmatched), frozenset(registry.keys()))
+        if key != _warned_exclusions:
+            logger.warning(
+                "plan_loader: excluded plan name(s) %s matched no registered plan",
+                sorted(unmatched),
+            )
+            _warned_exclusions = key
+    for name in excluded:
+        plans.pop(name, None)
+
     merged = FacilityPlans(plans=plans, devices=dict(_startup_layers.devices))
 
     if _merged_plans is not None and merged == _merged_plans:
@@ -519,6 +578,7 @@ def get_facility_plans() -> FacilityPlans:
 
 def reset_facility_plans() -> None:
     """Clear every cached layer (startup and last-merged result) — for testing."""
-    global _startup_layers, _merged_plans
+    global _startup_layers, _merged_plans, _warned_exclusions
     _startup_layers = None
     _merged_plans = None
+    _warned_exclusions = None

--- a/src/osprey/templates/services/bluesky/docker-compose.yml.j2
+++ b/src/osprey/templates/services/bluesky/docker-compose.yml.j2
@@ -77,6 +77,15 @@ services:
       # never sees the operator's host filesystem layout.
       BLUESKY_PLAN_DIRS: /app/project/plans
 {% endif %}
+{% if services.bluesky.excluded_plans %}
+      # Facility plan-catalog exclusions (Task 3.3): the plan loader
+      # (plan_loader.py) reads BLUESKY_EXCLUDED_PLANS as an os.pathsep-separated
+      # list of plan IDs to DROP from the discovered catalog, so an operator can
+      # suppress specific plans without editing any plan directory. Written by
+      # _inject_bluesky (build_cmd.py) only when non-empty — an empty exclusion
+      # set omits the key entirely, so this env var never renders.
+      BLUESKY_EXCLUDED_PLANS: "{{ services.bluesky.excluded_plans }}"
+{% endif %}
 {% if 'virtual_accelerator' in deployed_services %}
       # Reach the co-deployed Virtual Accelerator (Task 4.1) over Channel
       # Access. Name-server TCP transport is the one host<->container CA

--- a/tests/cli/test_bluesky_service_registration.py
+++ b/tests/cli/test_bluesky_service_registration.py
@@ -11,11 +11,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from ruamel.yaml import YAML
 
 from osprey.cli.build_cmd import _inject_bluesky
 from osprey.cli.build_profile import BlueskyConfig, _parse_profile
 from osprey.deployment.compose_generator import find_service_config
+from osprey.errors import BuildProfileError
 
 
 def _write_config(project_path: Path) -> None:
@@ -218,6 +220,32 @@ def test_inject_bluesky_no_plan_dir_omits_key(tmp_path: Path) -> None:
     assert "plan_dir" not in config["services"]["bluesky"]
 
 
+def test_inject_bluesky_excluded_plans_written_to_config(tmp_path: Path) -> None:
+    """Configured excluded_plans are emitted as an os.pathsep-joined string."""
+    import os
+
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(excluded_plans=["orm", "tune"]), project_path)
+
+    config = _read_config(project_path)
+    assert config["services"]["bluesky"]["excluded_plans"] == os.pathsep.join(["orm", "tune"])
+
+
+def test_inject_bluesky_no_excluded_plans_omits_key(tmp_path: Path) -> None:
+    """Empty excluded_plans -> no excluded_plans key at all (omit-when-empty)."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(), project_path)
+
+    config = _read_config(project_path)
+    assert "excluded_plans" not in config["services"]["bluesky"]
+
+
 def test_plan_dir_mount_and_env_round_trip_through_compose(tmp_path: Path) -> None:
     """A configured plan_dir renders both the read-only bind mount and the
     in-container BLUESKY_PLAN_DIRS env var the loader (plan_loader.py) reads
@@ -251,6 +279,38 @@ def test_plan_dir_absent_omits_mount_and_env(tmp_path: Path) -> None:
     bridge = rendered["services"]["bluesky-bridge"]
     assert "BLUESKY_PLAN_DIRS" not in bridge["environment"]
     assert not any(str(v).endswith(":/app/project/plans:ro") for v in bridge["volumes"])
+
+
+def test_excluded_plans_env_round_trips_through_compose(tmp_path: Path) -> None:
+    """A configured excluded_plans renders the in-container BLUESKY_EXCLUDED_PLANS
+    env var the plan loader reads to drop catalog entries — the os.pathsep-joined
+    string flows straight through to the rendered compose environment (Task 3.3,
+    success criterion 6, asserted through the rendered artifact)."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(excluded_plans=["orm"]), project_path)
+    config = _read_config(project_path)
+    rendered = _render_copied_compose(project_path, config)
+
+    bridge = rendered["services"]["bluesky-bridge"]
+    assert bridge["environment"]["BLUESKY_EXCLUDED_PLANS"] == "orm"
+
+
+def test_excluded_plans_absent_omits_env(tmp_path: Path) -> None:
+    """Regression: a deploy with no excluded_plans renders no BLUESKY_EXCLUDED_PLANS
+    env var — an empty exclusion set contributes nothing to the container env."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(), project_path)
+    config = _read_config(project_path)
+    rendered = _render_copied_compose(project_path, config)
+
+    bridge = rendered["services"]["bluesky-bridge"]
+    assert "BLUESKY_EXCLUDED_PLANS" not in bridge["environment"]
 
 
 def test_loopback_bind_and_failclosed_token_survive_plan_dir_wiring(tmp_path: Path) -> None:
@@ -313,3 +373,32 @@ def test_profile_bluesky_key_defaults_when_empty_mapping() -> None:
     assert profile.bluesky.tiled_port == 8091
     assert profile.bluesky.demo_runner is False
     assert profile.bluesky.plan_dir is None
+    assert profile.bluesky.excluded_plans == []
+
+
+# ---------------------------------------------------------------------------
+# Plan-catalog exclusions (Task 3.1): hide named plans from the agent while the
+# bluesky server stays enabled (dev/local convenience).
+# ---------------------------------------------------------------------------
+
+
+def test_profile_bluesky_excluded_plans_parses() -> None:
+    profile = _parse_profile({"name": "with-exclusions", "bluesky": {"excluded_plans": ["orm"]}})
+    assert profile.bluesky is not None
+    assert profile.bluesky.excluded_plans == ["orm"]
+
+
+def test_profile_bluesky_excluded_plans_defaults_empty() -> None:
+    profile = _parse_profile({"name": "no-exclusions", "bluesky": {}})
+    assert profile.bluesky is not None
+    assert profile.bluesky.excluded_plans == []
+
+
+def test_profile_bluesky_excluded_plans_non_list_raises() -> None:
+    with pytest.raises(BuildProfileError):
+        _parse_profile({"name": "bad", "bluesky": {"excluded_plans": 5}})
+
+
+def test_profile_bluesky_excluded_plans_non_str_element_raises() -> None:
+    with pytest.raises(BuildProfileError):
+        _parse_profile({"name": "bad", "bluesky": {"excluded_plans": ["orm", 7]}})

--- a/tests/services/bluesky_bridge/test_plan_injection.py
+++ b/tests/services/bluesky_bridge/test_plan_injection.py
@@ -246,3 +246,25 @@ def test_get_plans_serves_directory_layer_metadata_via_http(
         "required_devices": ["sniffer"],
         "writes": False,
     }
+
+
+def test_get_plans_omits_excluded_plan_via_http(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    """An excluded plan is surgically removed from `GET /plans` while its
+    siblings remain (success criteria 2 & 3 at the HTTP surface).
+
+    Because draft-staging and launch both read `get_facility_plans().plans` —
+    the same catalog `GET /plans` serves — a plan absent from `GET /plans` is
+    also un-stageable and un-runnable. `orm` and `grid_scan` are the two
+    shipped plans; excluding `orm` must drop it without touching `grid_scan`,
+    proving the exclusion is surgical, not a catalog wipe.
+    """
+    monkeypatch.setenv("BLUESKY_EXCLUDED_PLANS", "orm")
+
+    resp = client.get("/plans")
+
+    assert resp.status_code == 200
+    plan_names = {p["name"] for p in resp.json()}
+    assert "orm" not in plan_names
+    assert "grid_scan" in plan_names

--- a/tests/services/bluesky_bridge/test_plan_loader_layered.py
+++ b/tests/services/bluesky_bridge/test_plan_loader_layered.py
@@ -338,6 +338,218 @@ def test_equal_trust_collision_lets_the_later_scanned_directory_win(
     )
 
 
+def _write_excluded_config(tmp_path: Path, excluded_plans) -> Path:
+    """Write a temp config.yml carrying ``bluesky.excluded_plans`` (list or scalar)."""
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(yaml.dump({"bluesky": {"excluded_plans": excluded_plans}}))
+    return config_file
+
+
+def test_resolve_excluded_plans_env_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(plan_loader._EXCLUDED_PLANS_ENV, "orm")
+    assert plan_loader._resolve_excluded_plans() == {"orm"}
+
+
+def test_resolve_excluded_plans_config_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OSPREY_CONFIG", str(_write_excluded_config(tmp_path, ["orm"])))
+    assert plan_loader._resolve_excluded_plans() == {"orm"}
+
+
+def test_resolve_excluded_plans_unions_env_and_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(plan_loader._EXCLUDED_PLANS_ENV, "orm")
+    monkeypatch.setenv("OSPREY_CONFIG", str(_write_excluded_config(tmp_path, ["grid_scan"])))
+    assert plan_loader._resolve_excluded_plans() == {"orm", "grid_scan"}
+
+
+def test_resolve_excluded_plans_config_bare_string_is_coerced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OSPREY_CONFIG", str(_write_excluded_config(tmp_path, "orm")))
+    assert plan_loader._resolve_excluded_plans() == {"orm"}
+
+
+def test_resolve_excluded_plans_unset_env_and_no_config_is_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(plan_loader._EXCLUDED_PLANS_ENV, raising=False)
+    assert plan_loader._resolve_excluded_plans() == set()
+
+
+def test_resolve_excluded_plans_empty_env_is_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(plan_loader._EXCLUDED_PLANS_ENV, "")
+    assert plan_loader._resolve_excluded_plans() == set()
+
+
+def test_resolve_excluded_plans_trailing_pathsep_contributes_no_empty_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(plan_loader._EXCLUDED_PLANS_ENV, "orm" + os.pathsep)
+    assert plan_loader._resolve_excluded_plans() == {"orm"}
+
+
+_SESSION_PLAN_DIR_ENV = "BLUESKY_SESSION_PLAN_DIR"
+_EXCLUSION_NO_MATCH_MARKER = "matched no registered plan"
+
+
+def _register_session_plan(session_dir: Path, filename: str, name: str) -> Path:
+    """Write a session-tier plan file and record a passing validation for it,
+    so `get_facility_plans()`'s load-time gate lets it register."""
+    source = _valid_plan_source(name)
+    path = _write(session_dir, filename, source)
+    plan_loader.validation_records.record(plan_loader.hash_plan_body(source))
+    return path
+
+
+def _exclusion_no_match_warnings(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and _EXCLUSION_NO_MATCH_MARKER in r.getMessage()
+    ]
+
+
+def test_excluded_plan_absent_from_catalog_while_siblings_remain(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    shipped_dir = tmp_path / "shipped"
+    _write(shipped_dir, "keep_me.py", _valid_plan_source("keep_me"))
+    _write(shipped_dir, "drop_me.py", _valid_plan_source("drop_me"))
+
+    monkeypatch.setattr(plan_loader, "_SHIPPED_PLANS_DIR", shipped_dir)
+    monkeypatch.setenv(plan_loader._EXCLUDED_PLANS_ENV, "drop_me")
+
+    facility = plan_loader.get_facility_plans()
+
+    assert "drop_me" not in facility.plans
+    assert "keep_me" in facility.plans
+
+
+def test_exclusion_removes_a_shipped_tier_plan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    shipped_dir = tmp_path / "shipped"
+    _write(shipped_dir, "core_plan.py", _valid_plan_source("core_plan"))
+
+    monkeypatch.setattr(plan_loader, "_SHIPPED_PLANS_DIR", shipped_dir)
+    monkeypatch.setenv(plan_loader._EXCLUDED_PLANS_ENV, "core_plan")
+
+    assert "core_plan" not in plan_loader.get_facility_plans().plans
+
+
+def test_exclusion_removes_a_facility_tier_plan_via_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    facility_dir = tmp_path / "facility"
+    _write(facility_dir, "facility_plan.py", _valid_plan_source("facility_plan"))
+
+    monkeypatch.setenv(_PLAN_DIRS_ENV, str(facility_dir))
+    monkeypatch.setenv("OSPREY_CONFIG", str(_write_excluded_config(tmp_path, ["facility_plan"])))
+
+    assert "facility_plan" not in plan_loader.get_facility_plans().plans
+
+
+def test_exclusion_removes_a_session_tier_plan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    session_dir = tmp_path / "session"
+    _register_session_plan(session_dir, "authored.py", "authored_plan")
+
+    monkeypatch.setenv(_SESSION_PLAN_DIR_ENV, str(session_dir))
+
+    # Sanity: it registers when not excluded.
+    assert "authored_plan" in plan_loader.get_facility_plans().plans
+
+    plan_loader.reset_facility_plans()
+    monkeypatch.setenv(plan_loader._EXCLUDED_PLANS_ENV, "authored_plan")
+
+    assert "authored_plan" not in plan_loader.get_facility_plans().plans
+
+
+def test_unknown_excluded_name_warns_exactly_once_across_repeated_calls(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    shipped_dir = tmp_path / "shipped"
+    session_dir = tmp_path / "session"
+    _write(shipped_dir, "keep_me.py", _valid_plan_source("keep_me"))
+
+    monkeypatch.setattr(plan_loader, "_SHIPPED_PLANS_DIR", shipped_dir)
+    monkeypatch.setenv(_SESSION_PLAN_DIR_ENV, str(session_dir))
+    monkeypatch.setenv(plan_loader._EXCLUDED_PLANS_ENV, "does_not_exist")
+
+    with caplog.at_level(logging.WARNING, logger="osprey.services.bluesky_bridge.plan_loader"):
+        for _ in range(3):
+            plan_loader.get_facility_plans()
+
+    assert len(_exclusion_no_match_warnings(caplog)) == 1
+
+
+def test_exclusion_warning_refires_after_the_registry_changes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The warn-once guard is keyed on the live `registry.keys()`; adding a new
+    (session-tier) plan changes that key and must re-warn."""
+    shipped_dir = tmp_path / "shipped"
+    session_dir = tmp_path / "session"
+    _write(shipped_dir, "keep_me.py", _valid_plan_source("keep_me"))
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(plan_loader, "_SHIPPED_PLANS_DIR", shipped_dir)
+    monkeypatch.setenv(_SESSION_PLAN_DIR_ENV, str(session_dir))
+    monkeypatch.setenv(plan_loader._EXCLUDED_PLANS_ENV, "does_not_exist")
+
+    with caplog.at_level(logging.WARNING, logger="osprey.services.bluesky_bridge.plan_loader"):
+        plan_loader.get_facility_plans()
+        plan_loader.get_facility_plans()
+        assert len(_exclusion_no_match_warnings(caplog)) == 1
+
+        # The session layer is re-scanned every call: adding a validated plan
+        # changes registry.keys() without a cache reset, so the guard re-fires.
+        _register_session_plan(session_dir, "extra.py", "session_extra")
+        plan_loader.get_facility_plans()
+
+    assert len(_exclusion_no_match_warnings(caplog)) == 2
+
+
+def test_empty_exclusion_set_is_a_silent_no_op(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    shipped_dir = tmp_path / "shipped"
+    _write(shipped_dir, "keep_me.py", _valid_plan_source("keep_me"))
+
+    monkeypatch.setattr(plan_loader, "_SHIPPED_PLANS_DIR", shipped_dir)
+    monkeypatch.delenv(plan_loader._EXCLUDED_PLANS_ENV, raising=False)
+
+    with caplog.at_level(logging.WARNING, logger="osprey.services.bluesky_bridge.plan_loader"):
+        facility = plan_loader.get_facility_plans()
+
+    assert "keep_me" in facility.plans
+    assert _exclusion_no_match_warnings(caplog) == []
+
+
+def test_excluding_the_surviving_name_of_a_trust_collision_filters_it_out(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A higher-trust `facility` file wins the `shared_name` collision over a
+    `shipped` file; excluding `shared_name` must drop the survivor and the
+    rejected lower-trust loser must not resurface."""
+    shipped_dir = tmp_path / "shipped"
+    facility_dir = tmp_path / "facility"
+    _write(shipped_dir, "a.py", _valid_plan_source("shared_name"))
+    _write(facility_dir, "b.py", _valid_plan_source("shared_name"))
+
+    monkeypatch.setattr(plan_loader, "_SHIPPED_PLANS_DIR", shipped_dir)
+    monkeypatch.setenv(_PLAN_DIRS_ENV, str(facility_dir))
+    monkeypatch.setenv(plan_loader._EXCLUDED_PLANS_ENV, "shared_name")
+
+    facility = plan_loader.get_facility_plans()
+
+    assert "shared_name" not in facility.plans
+
+
 def test_shipped_plans_register_through_the_real_shipped_dir() -> None:
     """Sanity check: `plan_loader.py` is the sole plan registry — the shipped
     `orm`/`grid_scan` plans (in `plans_core/`) register through the ordinary


### PR DESCRIPTION
## Problem

The bluesky plan catalog is add-only. Enabling the scan server exposes every
shipped plan, with no supported way to hide an individual one — the only lever
is disabling the whole server.

## Change

Add a per-plan exclusion set, unioned from two sources (mirroring `plan_dirs`):

- **`BLUESKY_EXCLUDED_PLANS`** env var — the production channel, rendered into
  the deployed bridge by the compose template.
- **`bluesky.excluded_plans`** config key — local/dev convenience.

Enforced at the single registry chokepoint in `get_facility_plans()`, so an
excluded plan is both **invisible** (absent from `GET /plans`) and
**non-runnable** (unresolvable at draft-staging and launch). An unmatched
exclusion name warns once per stable registry+exclusion set. The profile key is
wired through `BlueskyConfig` → `_inject_bluesky` → compose, mirroring the
existing `plan_dir` → `BLUESKY_PLAN_DIRS` path.

## Tests

- Loader: reader union/coercion/empty-skip, filter, warn-once, per-tier exclusion.
- HTTP: excluded plan absent from `GET /plans` via `TestClient`.
- Deploy: profile parse + end-to-end compose render asserting `BLUESKY_EXCLUDED_PLANS`.
- Existing trust-tier collision tests unchanged. Full local CI green.
