### PR TITLE
feat(va): facility-neutral channel source, optional lattice, configurable entrypoint

### DIFF
--- a/src/osprey/services/virtual_accelerator/entrypoint.py
+++ b/src/osprey/services/virtual_accelerator/entrypoint.py
@@ -16,6 +16,23 @@ Run contract (see docker/virtual-accelerator/README.md for the full version):
 
 ``VA_DATA_DIR`` overrides the mount point (default ``/data/simulation``) for
 local testing without an actual bind mount.
+
+Facility-neutral source configuration (all optional; defaults reproduce the
+historical behaviour exactly):
+
+``VA_CHANNELS_FILE``
+    Path to a ``{"channels": [...]}`` manifest JSON (see
+    ``manifest.loaders.load_manifest_file``). Relative paths resolve against
+    the data dir. Unset/empty -> the built-in generated manifest
+    (``build_manifest()``), as before. With a file source, drive limits come
+    from ``<data dir>/channel_limits.json`` when present (none otherwise)
+    and boot values from the mounted ``machine.json`` -- never from the
+    bundled tutorial data.
+``VA_LATTICE``
+    ``builtin`` or ``none``: whether to construct the PyAT-backed
+    ``PhysicsBridge``. Defaults to ``builtin`` for the built-in manifest and
+    ``none`` for a file-backed one. With ``none``, PyAT is never imported
+    and pyat-coupled setpoint writes (if any) latch without physics.
 """
 
 from __future__ import annotations
@@ -25,16 +42,25 @@ import json
 import os
 import time
 from pathlib import Path
+from typing import Any
 
 from osprey.services.virtual_accelerator.ioc.engine_source import EngineSource
-from osprey.services.virtual_accelerator.ioc.physics_bridge import PhysicsBridge
-from osprey.services.virtual_accelerator.ioc.records import build_records
-from osprey.services.virtual_accelerator.manifest import build_manifest
-from osprey.services.virtual_accelerator.manifest.loaders import load_machine_json_channels
+from osprey.services.virtual_accelerator.ioc.records import (
+    READBACK_SUBFIELD,
+    build_records,
+)
+from osprey.services.virtual_accelerator.manifest import PARTITION_SP_ECHO, build_manifest
+from osprey.services.virtual_accelerator.manifest.loaders import (
+    load_machine_json_channels,
+    load_manifest_file,
+)
 from osprey.simulation.engine import SimulationEngine
 
 DEFAULT_DATA_DIR = "/data/simulation"
 ENGINE_POLL_INTERVAL_S = 1.0
+
+LATTICE_BUILTIN = "builtin"
+LATTICE_NONE = "none"
 
 # FR4 fault-seed bounds -- "bound each magnitude at parse (reject absurd
 # values before construction)". Generous vs. plausible commissioning-error
@@ -136,6 +162,40 @@ def _parse_bpm_errors(env_var: str = "VA_BPM_ERRORS") -> dict[str, dict[str, flo
     return result
 
 
+def _resolve_channels_file(data_dir: Path) -> Path | None:
+    """Resolve ``VA_CHANNELS_FILE`` into the file-backed channel source path.
+
+    Unset or empty (the compose passthrough sends ``""`` when the host var
+    is absent) means the built-in generated manifest. A relative path
+    resolves against the data dir -- the bind mount is the natural home for
+    facility-supplied data files.
+    """
+    raw = os.environ.get("VA_CHANNELS_FILE", "").strip()
+    if not raw:
+        return None
+    path = Path(raw)
+    return path if path.is_absolute() else data_dir / path
+
+
+def _resolve_lattice_mode(channels_file: Path | None) -> str:
+    """Resolve ``VA_LATTICE`` into ``builtin`` or ``none``.
+
+    The default follows the channel source: the built-in manifest describes
+    the lattice-backed tutorial machine (so ``builtin``), while a
+    file-backed manifest comes from a facility with no PyAT model (so
+    ``none``). An explicit value overrides either default -- a facility MAY
+    pair a file manifest with the built-in lattice if its addresses map.
+    """
+    raw = os.environ.get("VA_LATTICE", "").strip().lower()
+    if not raw:
+        return LATTICE_NONE if channels_file is not None else LATTICE_BUILTIN
+    if raw not in (LATTICE_BUILTIN, LATTICE_NONE):
+        raise SystemExit(
+            f"FATAL: VA_LATTICE must be {LATTICE_BUILTIN!r} or {LATTICE_NONE!r}, got {raw!r}"
+        )
+    return raw
+
+
 def _channel_limits_path() -> Path:
     """Locate ``channel_limits.json`` from the installed ``osprey.templates``
     package -- the same convention ``manifest/paths.py`` uses for the other
@@ -153,13 +213,15 @@ def _channel_limits_path() -> Path:
     )
 
 
-def _load_drive_limits() -> dict[str, tuple[float, float]]:
+def _load_drive_limits(path: Path | None = None) -> dict[str, tuple[float, float]]:
     """Derive the ``build_records(drive_limits=...)`` map from
     ``channel_limits.json``: one ``(min_value, max_value)`` entry per
     writable ``:SP`` address with numeric bounds. ``ioc/records.py`` stays
     file-blind (see its ``build_records`` docstring) -- this is the file
-    read its ``drive_limits`` argument replaces."""
-    raw = json.loads(_channel_limits_path().read_text())
+    read its ``drive_limits`` argument replaces. ``path`` selects which
+    limits file to parse; ``None`` (the default) keeps the historical
+    bundled-template read."""
+    raw = json.loads((path or _channel_limits_path()).read_text())
     defaults = raw.get("defaults", {})
     limits: dict[str, tuple[float, float]] = {}
     for address, entry in raw.items():
@@ -176,17 +238,18 @@ def _load_drive_limits() -> dict[str, tuple[float, float]]:
     return limits
 
 
-def _load_boot_values() -> dict[str, float]:
+def _load_boot_values(machine_path: Path | None = None) -> dict[str, float]:
     """Derive the ``build_records(boot_values=...)`` map from
     machine.json's scenario-seed channels (see ``ioc/records.py``'s
     ``build_records`` docstring). A handful of derived channels (e.g. RF
     net power, computed via an ``expr`` rather than a stored ``value``)
     carry no static value and are skipped -- harmless here since none of
     them are ``:SP``/``:RB`` addresses, the only subfields this map is ever
-    consulted for."""
+    consulted for. ``machine_path`` selects which machine.json to read;
+    ``None`` (the default) keeps the historical bundled-template read."""
     return {
         address: entry["value"]
-        for address, entry in load_machine_json_channels().items()
+        for address, entry in load_machine_json_channels(machine_path).items()
         if "value" in entry
     }
 
@@ -201,8 +264,23 @@ def main() -> None:
             f"file) to {DEFAULT_DATA_DIR}, or set VA_DATA_DIR -- see README.md."
         )
 
-    print(f"Building channel manifest and IOC records (data dir: {data_dir}) ...", flush=True)
-    channels = build_manifest()["channels"]
+    channels_file = _resolve_channels_file(data_dir)
+    lattice_mode = _resolve_lattice_mode(channels_file)
+
+    if channels_file is not None:
+        # File-backed facility: every data file comes from the mount, never
+        # from the bundled tutorial data (whose addresses belong to another
+        # facility's namespace).
+        print(f"Loading channel manifest from {channels_file} ...", flush=True)
+        channels = load_manifest_file(channels_file)
+        limits_path = data_dir / "channel_limits.json"
+        drive_limits = _load_drive_limits(limits_path) if limits_path.is_file() else {}
+        boot_values = _load_boot_values(machine_path)
+    else:
+        print(f"Building channel manifest and IOC records (data dir: {data_dir}) ...", flush=True)
+        channels = build_manifest()["channels"]
+        drive_limits = _load_drive_limits()
+        boot_values = _load_boot_values()
 
     stuck_setpoints = frozenset(
         addr.strip() for addr in os.environ.get("VA_STUCK_SETPOINTS", "").split(",") if addr.strip()
@@ -220,22 +298,63 @@ def main() -> None:
     if corrector_gains:
         print(f"VA apply-fault active: corrector_gains={corrector_gains}", flush=True)
 
-    bridge = PhysicsBridge(
-        bpm_errors=bpm_errors or None,
-        corrector_gains=corrector_gains or None,
-    )
+    if lattice_mode == LATTICE_BUILTIN:
+        # Deferred import: physics_bridge imports PyAT at module level, and
+        # the whole point of VA_LATTICE=none is booting without PyAT
+        # installed or importable.
+        from osprey.services.virtual_accelerator.ioc.physics_bridge import PhysicsBridge
+
+        bridge = PhysicsBridge(
+            bpm_errors=bpm_errors or None,
+            corrector_gains=corrector_gains or None,
+        )
+        on_pyat_setpoint = bridge.on_setpoint
+    else:
+        if bpm_errors or corrector_gains:
+            raise SystemExit(
+                "FATAL: VA_BPM_ERRORS/VA_CORR_GAIN are lattice-physics faults "
+                f"and require VA_LATTICE={LATTICE_BUILTIN!r}"
+            )
+        print("No lattice configured (VA_LATTICE=none): PhysicsBridge skipped", flush=True)
+        bridge = None
+        on_pyat_setpoint = None
+
     records = build_records(
         channels,
-        on_pyat_setpoint=bridge.on_setpoint,
+        on_pyat_setpoint=on_pyat_setpoint,
         stuck_setpoints=stuck_setpoints,
-        drive_limits=_load_drive_limits(),
-        boot_values=_load_boot_values(),
+        drive_limits=drive_limits,
+        boot_values=boot_values,
     )
-    bridge.bind(records.pyat_coupled)
+    if bridge is not None:
+        bridge.bind(records.pyat_coupled)
 
     print(f"Loading simulation engine from {machine_path} ...", flush=True)
     engine = SimulationEngine.from_file(machine_path)
-    engine_source = EngineSource(engine, channels, records.static_noisy, data_dir)
+
+    # With no lattice, the engine is the only physics in the process: sync
+    # each sp-echo readback into it every tick so machine-file expression
+    # channels can respond to accepted setpoints (see EngineSource's
+    # setpoint_echo_records docstring). With a lattice, physics coupling
+    # flows through PhysicsBridge and the engine stays a pure scenario
+    # source -- exactly the historical behaviour.
+    setpoint_echoes: dict[str, Any] | None = None
+    if lattice_mode == LATTICE_NONE:
+        setpoint_echoes = {
+            ch["address"]: records.all[ch["address"]]
+            for ch in channels
+            if ch["partition"] == PARTITION_SP_ECHO
+            and ch["subfield"] == READBACK_SUBFIELD
+            and ch["address"] in records.all
+        }
+
+    engine_source = EngineSource(
+        engine,
+        channels,
+        records.static_noisy,
+        data_dir,
+        setpoint_echo_records=setpoint_echoes,
+    )
 
     # Import softioc only now: constructing softioc records (build_records/
     # PhysicsBridge above, both already done) must happen before iocInit, and

--- a/src/osprey/services/virtual_accelerator/ioc/__init__.py
+++ b/src/osprey/services/virtual_accelerator/ioc/__init__.py
@@ -11,7 +11,8 @@ callback slots for the physics bridge (partition a) and engine source
 `IOCRecords.pyat_coupled` BPM records to receive recomputed positions.
 """
 
-from .physics_bridge import OrbitSolveError, PhysicsBridge, UnknownDeviceError
+from typing import Any
+
 from .records import IOCRecords, ManifestContractError, build_records
 
 __all__ = [
@@ -22,3 +23,20 @@ __all__ = [
     "OrbitSolveError",
     "UnknownDeviceError",
 ]
+
+# The physics-bridge names are re-exported lazily (PEP 562):
+# physics_bridge.py imports PyAT at module level, and importing this package
+# must not require PyAT -- the no-lattice entrypoint path (VA_LATTICE=none)
+# imports sibling modules (records, engine_source) from a process where PyAT
+# may not even be installed. Attribute access is unchanged for callers:
+# ``from ...ioc import PhysicsBridge`` still works, it just pays the PyAT
+# import only when actually used.
+_PHYSICS_BRIDGE_NAMES = frozenset({"PhysicsBridge", "OrbitSolveError", "UnknownDeviceError"})
+
+
+def __getattr__(name: str) -> Any:
+    if name in _PHYSICS_BRIDGE_NAMES:
+        from . import physics_bridge
+
+        return getattr(physics_bridge, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/osprey/services/virtual_accelerator/ioc/engine_source.py
+++ b/src/osprey/services/virtual_accelerator/ioc/engine_source.py
@@ -69,6 +69,17 @@ class EngineSource:
             directory-level atomic-rename swap is always observed.
         noise_level: Relative noise fraction for the legacy-fallback
             synthesis path (mirrors ``MockConnector``'s own default).
+        setpoint_echo_records: Optional ``address -> record`` map of sp-echo
+            READBACK records whose current values are synced into the engine
+            (``engine.write``) at the top of every poll tick, BEFORE the
+            driven records are computed. This is what lets a machine-file
+            expression channel (e.g. a camera response curve) depend on the
+            latest accepted setpoint state when the engine is the only
+            physics in the process -- the no-lattice entrypoint path wires
+            it. With a PhysicsBridge, physics coupling flows through the
+            bridge instead and this stays ``None`` (the default; behaviour
+            unchanged). Addresses the engine does not serve are dropped at
+            construction.
     """
 
     def __init__(
@@ -79,12 +90,18 @@ class EngineSource:
         data_dir: Path,
         *,
         noise_level: float = DEFAULT_NOISE_LEVEL,
+        setpoint_echo_records: dict[str, Any] | None = None,
     ) -> None:
         self._engine = engine
         self._records = dict(static_noisy_records)
         self._noise_level = noise_level
         self._rng = np.random.default_rng()
         self._legacy_base: dict[str, float] = {}
+        self._setpoint_echo_records = {
+            address: record
+            for address, record in (setpoint_echo_records or {}).items()
+            if engine_serves(engine, address)
+        }
 
         self._channel_info: dict[str, tuple[str, bool]] = {
             c["address"]: (c["record_type"], bool(c["noise"]))
@@ -106,6 +123,20 @@ class EngineSource:
             yet), even though it establishes the baseline signature.
         """
         switched = self._detect_scenario_switch()
+        # Sync accepted setpoint state into the engine first, so every
+        # expression evaluated below sees this tick's setpoints.
+        for address, record in self._setpoint_echo_records.items():
+            try:
+                self._engine.write(address, record.get())
+            except Exception:  # noqa: BLE001 -- same isolation rationale as below
+                import traceback
+
+                print(
+                    f"EngineSource: failed to sync setpoint echo {address!r} into the engine:",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                traceback.print_exc()
         for address, record in self._records.items():
             try:
                 record.set(self._read_value(address))

--- a/src/osprey/services/virtual_accelerator/ioc/records.py
+++ b/src/osprey/services/virtual_accelerator/ioc/records.py
@@ -42,27 +42,70 @@ from osprey.services.virtual_accelerator.manifest import (
     PARTITION_STATIC_NOISY,
     RECORD_TYPE_ANALOG,
     RECORD_TYPE_BINARY,
+    RECORD_TYPE_LONG_STRING,
+    RECORD_TYPE_MBB,
     RECORD_TYPE_STRING,
 )
 
 SETPOINT_SUBFIELD = "SP"
 READBACK_SUBFIELD = "RB"
 
+# Gateway "long string" channels are 512-byte char waveforms (NELM=512,
+# FTVL='CHAR'). Pass length=512 EXPLICITLY: longStringIn/Out otherwise
+# default to 256 -- or to len(initial_value)+1 when an initial value is
+# given -- either of which would silently truncate a wire value the real
+# channel carries in full.
+_LONG_STRING_LENGTH = 512
+
+
+def _long_string_in(name: str, **fields: Any) -> Any:
+    return builder.longStringIn(name, length=_LONG_STRING_LENGTH, **fields)
+
+
+def _long_string_out(name: str, **fields: Any) -> Any:
+    return builder.longStringOut(name, length=_LONG_STRING_LENGTH, **fields)
+
+
+# mbbIn/mbbOut take their enum state labels as *positional* options
+# (``mbbIn(name, "OFF", "ON", ...)``), so they cannot sit in the flat
+# keyword-only dispatch tables directly. The manifest schema carries no
+# state labels -- an mbb channel is served as a plain numeric enum -- so
+# these wrappers simply pass no options; they exist to pin the calling
+# convention (and to hold state labels, should the manifest ever grow them).
+def _mbb_in(name: str, **fields: Any) -> Any:
+    return builder.mbbIn(name, **fields)
+
+
+def _mbb_out(name: str, **fields: Any) -> Any:
+    return builder.mbbOut(name, **fields)
+
+
 _IN_BUILDERS = {
     RECORD_TYPE_ANALOG: builder.aIn,
     RECORD_TYPE_BINARY: builder.boolIn,
     RECORD_TYPE_STRING: builder.stringIn,
+    RECORD_TYPE_LONG_STRING: _long_string_in,
+    RECORD_TYPE_MBB: _mbb_in,
 }
 _OUT_BUILDERS = {
     RECORD_TYPE_ANALOG: builder.aOut,
     RECORD_TYPE_BINARY: builder.boolOut,
     RECORD_TYPE_STRING: builder.stringOut,
+    RECORD_TYPE_LONG_STRING: _long_string_out,
+    RECORD_TYPE_MBB: _mbb_out,
 }
 _DEFAULT_VALUE = {
     RECORD_TYPE_ANALOG: 0.0,
     RECORD_TYPE_BINARY: False,
     RECORD_TYPE_STRING: "",
+    RECORD_TYPE_LONG_STRING: "",
+    RECORD_TYPE_MBB: 0,
 }
+
+# Record types whose values are discrete or textual: simulated measurement
+# noise is meaningless for them, so a manifest flagging one noisy is a
+# contract violation (same rationale as the long-standing bi rejection).
+_NOISE_REJECTING_TYPES = frozenset({RECORD_TYPE_BINARY, RECORD_TYPE_MBB, RECORD_TYPE_LONG_STRING})
 
 
 class ManifestContractError(ValueError):
@@ -188,9 +231,10 @@ def build_records(
             raise ManifestContractError(
                 f"unknown record_type {record_type!r} for {channel['address']!r}"
             )
-        if record_type == RECORD_TYPE_BINARY and channel["noise"]:
+        if record_type in _NOISE_REJECTING_TYPES and channel["noise"]:
             raise ManifestContractError(
-                f"binary channel {channel['address']!r} is flagged noisy -- bi records reject noise"
+                f"channel {channel['address']!r} is flagged noisy -- "
+                f"{record_type} records reject noise"
             )
 
         if channel["subfield"] == SETPOINT_SUBFIELD:

--- a/src/osprey/services/virtual_accelerator/manifest/__init__.py
+++ b/src/osprey/services/virtual_accelerator/manifest/__init__.py
@@ -29,11 +29,15 @@ from .classify import (
     classify_partition,
     derive_record_type,
 )
+from .loaders import MANIFEST_CHANNEL_KEYS, ManifestFileError, load_manifest_file
 
 __all__ = [
     "build_manifest",
     "classify_partition",
     "derive_record_type",
+    "load_manifest_file",
+    "ManifestFileError",
+    "MANIFEST_CHANNEL_KEYS",
     "PARTITION_PYAT_COUPLED",
     "PARTITION_SP_ECHO",
     "PARTITION_STATIC_NOISY",

--- a/src/osprey/services/virtual_accelerator/manifest/__init__.py
+++ b/src/osprey/services/virtual_accelerator/manifest/__init__.py
@@ -23,6 +23,8 @@ from .classify import (
     PARTITION_STATIC_NOISY,
     RECORD_TYPE_ANALOG,
     RECORD_TYPE_BINARY,
+    RECORD_TYPE_LONG_STRING,
+    RECORD_TYPE_MBB,
     RECORD_TYPE_STRING,
     classify_partition,
     derive_record_type,
@@ -37,5 +39,7 @@ __all__ = [
     "PARTITION_STATIC_NOISY",
     "RECORD_TYPE_ANALOG",
     "RECORD_TYPE_BINARY",
+    "RECORD_TYPE_LONG_STRING",
+    "RECORD_TYPE_MBB",
     "RECORD_TYPE_STRING",
 ]

--- a/src/osprey/services/virtual_accelerator/manifest/classify.py
+++ b/src/osprey/services/virtual_accelerator/manifest/classify.py
@@ -94,6 +94,14 @@ def classify_partition(path: dict[str, str]) -> str:
 RECORD_TYPE_BINARY = "bi"
 RECORD_TYPE_ANALOG = "ai"
 RECORD_TYPE_STRING = "stringin"
+# The two remaining gateway channel shapes: a 512-byte char waveform ("long
+# string", e.g. a status/message channel wider than stringin's 40 bytes) and
+# a multi-bit binary (discrete enum state). `derive_record_type` never emits
+# either -- the tutorial namespace has no such channel -- but a file-backed
+# manifest (see loaders.load_manifest_file) may declare them, and
+# ioc/records.py dispatches on them like any other record type.
+RECORD_TYPE_LONG_STRING = "longstringin"
+RECORD_TYPE_MBB = "mbbi"
 
 # Field/subfield tokens that indicate a two-state boolean signal rather than
 # a continuous measurement.

--- a/src/osprey/services/virtual_accelerator/manifest/loaders.py
+++ b/src/osprey/services/virtual_accelerator/manifest/loaders.py
@@ -2,9 +2,11 @@
 
 Reuses osprey's own channel_finder database parsers (the same code that
 loads these files at runtime) so this generator never re-implements
-``_expansion`` range/list parsing. This is a generation-time dependency
-only: the emitted ``channel_manifest.json`` has no osprey import
-requirement for downstream consumers (the future IOC just reads the JSON).
+``_expansion`` range/list parsing. Note the IOC does *not* read the emitted
+``channel_manifest.json``: ``entrypoint.py`` regenerates the manifest
+in-process via ``build_manifest()``, and the committed JSON serves only as a
+drift guard. (An IOC *can* be pointed at a manifest JSON explicitly -- that
+is the file-backed channel source below, :func:`load_manifest_file`.)
 """
 
 from __future__ import annotations
@@ -12,6 +14,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass
+from pathlib import Path
 
 from osprey.services.channel_finder.databases.hierarchical import (
     HierarchicalChannelDatabase,
@@ -70,10 +73,101 @@ def load_middle_layer_addresses() -> set[str]:
     return {ch["address"] for ch in db.get_all_channels()}
 
 
-def load_machine_json_channels() -> dict[str, dict]:
-    """Return the scenario-seed machine.json channels keyed by address."""
-    data = json.loads(paths.MACHINE_JSON.read_text())
-    return data["channels"]
+def load_machine_json_channels(path: Path | None = None) -> dict[str, dict]:
+    """Return the scenario-seed machine.json channels keyed by address.
+
+    ``path`` selects which machine.json to read: ``None`` (the default)
+    keeps the historical behaviour of reading the bundled control-assistant
+    template's copy; a file-backed facility passes its own mounted
+    machine.json instead (see ``entrypoint.py``).
+    """
+    data = json.loads((path or paths.MACHINE_JSON).read_text())
+    channels: dict[str, dict] = data["channels"]
+    return channels
+
+
+# --- file-backed channel source ------------------------------------------
+
+# The full per-channel schema build_records() consumes -- identical to the
+# in-memory shape build_manifest()["channels"] produces. A file-backed
+# manifest must supply every key for every channel; the identity keys
+# (ring/system/family/device/field) may be empty strings only if the
+# facility accepts the pairing collisions that implies (setpoint/readback
+# pairs are matched on exactly those five keys).
+MANIFEST_CHANNEL_KEYS = frozenset(
+    {
+        "address",
+        "ring",
+        "system",
+        "family",
+        "device",
+        "field",
+        "subfield",
+        "partition",
+        "record_type",
+        "noise",
+    }
+)
+
+
+class ManifestFileError(RuntimeError):
+    """A file-backed channel manifest is missing, unreadable, or malformed.
+
+    Raised eagerly at load time so a misconfigured IOC dies at boot with a
+    named cause, never serving a partial channel set.
+    """
+
+
+def load_manifest_file(path: Path) -> list[dict]:
+    """Load the channel list from a manifest JSON file.
+
+    This is the file-backed channel source: a facility that does not use the
+    built-in generated manifest supplies ``{"channels": [...]}`` where each
+    entry carries the exact per-channel schema ``build_manifest()`` produces
+    (see ``MANIFEST_CHANNEL_KEYS``). Facility-neutral by construction -- no
+    address grammar is imposed beyond the presence of the schema keys, so
+    any facility's namespace (three-part addresses included) loads through
+    the same call.
+
+    Raises:
+        ManifestFileError: if the file is absent, not valid JSON, lacks a
+            top-level ``channels`` list, contains a channel missing schema
+            keys, or declares the same address twice.
+    """
+    if not path.is_file():
+        raise ManifestFileError(f"channel manifest file not found: {path}")
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ManifestFileError(f"channel manifest {path} is not valid JSON: {exc}") from exc
+
+    channels = data.get("channels") if isinstance(data, dict) else None
+    if not isinstance(channels, list):
+        raise ManifestFileError(
+            f"channel manifest {path} must be a JSON object with a 'channels' list"
+        )
+
+    seen: set[str] = set()
+    for index, channel in enumerate(channels):
+        if not isinstance(channel, dict):
+            raise ManifestFileError(f"channel manifest {path}: channels[{index}] is not an object")
+        missing = MANIFEST_CHANNEL_KEYS - channel.keys()
+        if missing:
+            raise ManifestFileError(
+                f"channel manifest {path}: channels[{index}] "
+                f"({channel.get('address', '<no address>')!r}) is missing "
+                f"key(s): {', '.join(sorted(missing))}"
+            )
+        address = channel["address"]
+        if not address:
+            raise ManifestFileError(
+                f"channel manifest {path}: channels[{index}] has an empty address"
+            )
+        if address in seen:
+            raise ManifestFileError(f"channel manifest {path}: duplicate address {address!r}")
+        seen.add(address)
+
+    return channels
 
 
 # Matches `"<address>": { "label": ...` entries in machine_state_channels.json.j2

--- a/src/osprey/templates/services/virtual_accelerator/Dockerfile
+++ b/src/osprey/templates/services/virtual_accelerator/Dockerfile
@@ -97,7 +97,13 @@ RUN if ls /tmp/ctx/*.whl >/dev/null 2>&1; then \
     fi \
     && rm -rf /tmp/ctx
 
-CMD ["python", "-m", "osprey.services.virtual_accelerator.entrypoint"]
+# The entrypoint module is configuration, not a bake-time constant: a
+# facility may supply its own entrypoint module (e.g. one serving a
+# file-backed manifest with no lattice) without rebuilding the image.
+# `exec` replaces the shell so SIGTERM reaches python directly and the
+# IOC's wait_for_quit() shutdown path still runs on `docker stop`.
+# `:-` treats the compose passthrough's empty string the same as unset.
+CMD ["/bin/sh", "-c", "exec python -m ${VA_ENTRYPOINT_MODULE:-osprey.services.virtual_accelerator.entrypoint}"]
 
 # Project metadata, kept as the final metadata-only layer so the shared deps
 # cache chain above stays identical across projects (a per-project value here

--- a/src/osprey/templates/services/virtual_accelerator/docker-compose.yml.j2
+++ b/src/osprey/templates/services/virtual_accelerator/docker-compose.yml.j2
@@ -60,6 +60,14 @@ services:
       # Passthrough from the project .env; unset -> no fault.
       VA_BPM_ERRORS: "${VA_BPM_ERRORS:-}"
       VA_CORR_GAIN: "${VA_CORR_GAIN:-}"
+      # Facility-neutral source configuration (entrypoint.py + Dockerfile CMD
+      # read these; empty means default): the entrypoint module to run, the
+      # file-backed channel manifest, and whether the PyAT lattice is
+      # constructed. Passthrough from the project .env; unset -> the
+      # historical built-in behavior.
+      VA_ENTRYPOINT_MODULE: "${VA_ENTRYPOINT_MODULE:-}"
+      VA_CHANNELS_FILE: "${VA_CHANNELS_FILE:-}"
+      VA_LATTICE: "${VA_LATTICE:-}"
       TZ: {{ system.timezone }}
     # Bind-mount source is relative to the compose project directory
     # (build/services/), not this file's own subdir — hence the ../../ prefix

--- a/tests/va/test_entrypoint_sources.py
+++ b/tests/va/test_entrypoint_sources.py
@@ -1,0 +1,119 @@
+"""Tests for entrypoint.py's facility-neutral source configuration.
+
+Exercises the resolution helpers directly (not ``main()``, which also needs
+a real ``machine.json`` and softioc) -- same shape as
+``test_entrypoint_fault_env.py``. Each helper reads ``os.environ`` itself,
+so tests set env vars via ``monkeypatch``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from osprey.services.virtual_accelerator import entrypoint
+
+
+class TestResolveChannelsFile:
+    """Backs VA_CHANNELS_FILE -- the file-backed channel source selector."""
+
+    def test_unset_means_builtin_manifest(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("VA_CHANNELS_FILE", raising=False)
+        assert entrypoint._resolve_channels_file(tmp_path) is None
+
+    def test_empty_means_builtin_manifest(self, monkeypatch, tmp_path):
+        # The compose passthrough sends "" when the host var is absent --
+        # empty must behave exactly like unset.
+        monkeypatch.setenv("VA_CHANNELS_FILE", "")
+        assert entrypoint._resolve_channels_file(tmp_path) is None
+
+    def test_relative_path_resolves_against_data_dir(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("VA_CHANNELS_FILE", "channels_manifest.json")
+        assert entrypoint._resolve_channels_file(tmp_path) == tmp_path / "channels_manifest.json"
+
+    def test_absolute_path_is_kept(self, monkeypatch, tmp_path):
+        absolute = tmp_path / "elsewhere" / "manifest.json"
+        monkeypatch.setenv("VA_CHANNELS_FILE", str(absolute))
+        assert entrypoint._resolve_channels_file(tmp_path / "data") == absolute
+
+
+class TestResolveLatticeMode:
+    """Backs VA_LATTICE -- whether PhysicsBridge (hence PyAT) is constructed."""
+
+    def test_default_is_builtin_for_builtin_manifest(self, monkeypatch):
+        monkeypatch.delenv("VA_LATTICE", raising=False)
+        assert entrypoint._resolve_lattice_mode(None) == entrypoint.LATTICE_BUILTIN
+
+    def test_default_is_none_for_file_backed_manifest(self, monkeypatch):
+        monkeypatch.delenv("VA_LATTICE", raising=False)
+        assert entrypoint._resolve_lattice_mode(Path("/x/manifest.json")) == entrypoint.LATTICE_NONE
+
+    def test_explicit_builtin_overrides_file_backed_default(self, monkeypatch):
+        monkeypatch.setenv("VA_LATTICE", "builtin")
+        assert (
+            entrypoint._resolve_lattice_mode(Path("/x/manifest.json")) == entrypoint.LATTICE_BUILTIN
+        )
+
+    def test_explicit_none_overrides_builtin_default(self, monkeypatch):
+        monkeypatch.setenv("VA_LATTICE", "none")
+        assert entrypoint._resolve_lattice_mode(None) == entrypoint.LATTICE_NONE
+
+    def test_empty_behaves_like_unset(self, monkeypatch):
+        monkeypatch.setenv("VA_LATTICE", "")
+        assert entrypoint._resolve_lattice_mode(None) == entrypoint.LATTICE_BUILTIN
+
+    def test_value_is_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv("VA_LATTICE", "NONE")
+        assert entrypoint._resolve_lattice_mode(None) == entrypoint.LATTICE_NONE
+
+    def test_unknown_value_is_fatal(self, monkeypatch):
+        monkeypatch.setenv("VA_LATTICE", "als")
+        with pytest.raises(SystemExit, match="VA_LATTICE"):
+            entrypoint._resolve_lattice_mode(None)
+
+
+class TestParameterizedDataLoads:
+    """The file-backed path reads facility data from the mount, never from
+    the bundled tutorial files; the no-arg defaults keep the historical
+    bundled-template reads byte-identical for the built-in path."""
+
+    def test_boot_values_from_explicit_machine_json(self, tmp_path):
+        machine = tmp_path / "machine.json"
+        machine.write_text(
+            json.dumps(
+                {
+                    "channels": {
+                        "ZZEXP:LASER:ENERGY:RB": {"value": 1.25},
+                        "ZZEXP:LASER:MODE:RB": {"expr": "derived, no value"},
+                    }
+                }
+            )
+        )
+        assert entrypoint._load_boot_values(machine) == {"ZZEXP:LASER:ENERGY:RB": 1.25}
+
+    def test_drive_limits_from_explicit_limits_file(self, tmp_path):
+        limits = tmp_path / "channel_limits.json"
+        limits.write_text(
+            json.dumps(
+                {
+                    "defaults": {"writable": False},
+                    "ZZEXP:JET:STAGE:SP": {
+                        "writable": True,
+                        "min_value": -5.0,
+                        "max_value": 5.0,
+                    },
+                    "ZZEXP:LOCKED:DOWN:SP": {"min_value": 0, "max_value": 1},
+                }
+            )
+        )
+        # The non-writable default suppresses the second entry; only the
+        # explicitly writable one yields a clamp band.
+        assert entrypoint._load_drive_limits(limits) == {"ZZEXP:JET:STAGE:SP": (-5.0, 5.0)}
+
+    def test_no_arg_defaults_still_read_the_bundled_data(self):
+        # The ALS regression half of the seam: calling with no argument must
+        # keep returning the bundled tutorial data (non-empty, known shape).
+        assert entrypoint._load_boot_values()
+        assert entrypoint._load_drive_limits()

--- a/tests/va/test_facility_seam.py
+++ b/tests/va/test_facility_seam.py
@@ -1,0 +1,309 @@
+"""The facility-seam regression gate.
+
+Two halves, matching the seam's two promises:
+
+* **The historical path is unchanged.** With none of the source env vars
+  set, the entrypoint resolves to exactly the pre-seam behaviour: built-in
+  generated manifest, PyAT lattice, bundled drive-limit/boot-value data.
+  (The deep guarantee is the rest of ``tests/va`` -- every pre-seam test
+  still runs against the default path -- so this half only pins the
+  resolution itself.)
+
+* **A file-backed facility boots without PyAT.** A manifest of three-part
+  addresses (identity carried in the hierarchy keys, not the address text)
+  boots the *real* ``entrypoint.main()`` -- records, engine source, iocInit,
+  serving announcement -- in a subprocess whose import machinery makes any
+  ``import at`` fatal. A change that sneaks a PyAT dependency onto the
+  no-lattice path turns that subprocess boot into a crash, and this test
+  red.
+
+The subprocess split follows ``test_record_factory.py``: softioc state is
+process-global and ``iocInit`` is once-per-process, so the boot runs in its
+own dedicated process, never pytest's.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _run_seam_ioc_subprocess() -> None:
+    """Subprocess entry point: make PyAT unimportable, then boot main().
+
+    The blocker sits at the front of ``sys.meta_path``, so even an installed
+    PyAT cannot be imported in this process -- equivalent to (and stricter
+    than) running on a machine without PyAT.
+    """
+    import importlib.abc
+
+    class ATBlocker(importlib.abc.MetaPathFinder):
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname == "at" or fullname.startswith("at."):
+                raise ImportError("SEAM VIOLATION: PyAT imported on the no-lattice path")
+            return None
+
+    sys.meta_path.insert(0, ATBlocker())
+
+    from osprey.services.virtual_accelerator import entrypoint
+
+    entrypoint.main()
+
+
+if __name__ == "__main__" and len(sys.argv) > 1 and sys.argv[1] == "--run-seam-ioc-subprocess":
+    _run_seam_ioc_subprocess()
+    sys.exit(0)
+
+
+from osprey.services.virtual_accelerator import entrypoint  # noqa: E402
+from osprey.services.virtual_accelerator.manifest import (  # noqa: E402
+    PARTITION_SP_ECHO,
+    PARTITION_STATIC_NOISY,
+    RECORD_TYPE_ANALOG,
+    RECORD_TYPE_LONG_STRING,
+)
+
+# A three-part-address facility: the address text carries no six-level
+# grammar; identity (SP<->RB pairing) rides entirely in the hierarchy keys.
+_SEAM_CHANNELS = [
+    {
+        "address": "ZZSEAM:JET:PRESSURE",
+        "ring": "ZZSEAM",
+        "system": "JET",
+        "family": "TARGET",
+        "device": "01",
+        "field": "PRESSURE",
+        "subfield": "RB",
+        "partition": PARTITION_STATIC_NOISY,
+        "record_type": RECORD_TYPE_ANALOG,
+        "noise": True,
+    },
+    {
+        "address": "ZZSEAM:STAGE:POS:SP",
+        "ring": "ZZSEAM",
+        "system": "STAGE",
+        "family": "MOTOR",
+        "device": "01",
+        "field": "POS",
+        "subfield": "SP",
+        "partition": PARTITION_SP_ECHO,
+        "record_type": RECORD_TYPE_ANALOG,
+        "noise": False,
+    },
+    {
+        "address": "ZZSEAM:STAGE:POS",
+        "ring": "ZZSEAM",
+        "system": "STAGE",
+        "family": "MOTOR",
+        "device": "01",
+        "field": "POS",
+        "subfield": "RB",
+        "partition": PARTITION_SP_ECHO,
+        "record_type": RECORD_TYPE_ANALOG,
+        "noise": False,
+    },
+    {
+        "address": "ZZSEAM:STATUS:MSG",
+        "ring": "ZZSEAM",
+        "system": "STATUS",
+        "family": "MSG",
+        "device": "01",
+        "field": "TEXT",
+        "subfield": "RB",
+        "partition": PARTITION_STATIC_NOISY,
+        "record_type": RECORD_TYPE_LONG_STRING,
+        "noise": False,
+    },
+]
+
+
+class TestDefaultResolutionIsThePreSeamPath:
+    """ALS half: no env vars -> built-in manifest + built-in lattice."""
+
+    def test_no_env_resolves_to_builtin_manifest_and_lattice(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("VA_CHANNELS_FILE", raising=False)
+        monkeypatch.delenv("VA_LATTICE", raising=False)
+        channels_file = entrypoint._resolve_channels_file(tmp_path)
+        assert channels_file is None
+        assert entrypoint._resolve_lattice_mode(channels_file) == entrypoint.LATTICE_BUILTIN
+
+
+class TestSetpointEchoEngineSync:
+    """No-lattice physics coupling: sp-echo readback values are synced into
+    the engine each tick, so a machine-file expression channel (the camera
+    response) follows the latest accepted setpoint."""
+
+    class _FakeRecord:
+        def __init__(self, value: float) -> None:
+            self._value = value
+
+        def get(self) -> float:
+            return self._value
+
+        def set(self, value: float) -> None:
+            self._value = value
+
+    def test_expression_channel_follows_synced_setpoint(self, tmp_path: Path):
+        from osprey.services.virtual_accelerator.ioc.engine_source import EngineSource
+        from osprey.simulation.engine import SimulationEngine
+
+        machine = tmp_path / "machine.json"
+        machine.write_text(
+            json.dumps(
+                {
+                    "name": "sync-test",
+                    "description": "engine-sync unit machine",
+                    "channels": {
+                        "ZZSYNC:STAGE:POS": {"value": 0.0, "noise": 0},
+                        "ZZSYNC:CAM:INTENSITY": {
+                            "expr": "1000 * exp(-((ch('ZZSYNC:STAGE:POS') - 2.0) ** 2))",
+                            "noise": 0,
+                        },
+                    },
+                }
+            )
+        )
+        engine = SimulationEngine.from_file(machine)
+        stage_rb = self._FakeRecord(0.0)
+        intensity = self._FakeRecord(0.0)
+        channels = [
+            {
+                "address": "ZZSYNC:CAM:INTENSITY",
+                "partition": PARTITION_STATIC_NOISY,
+                "record_type": RECORD_TYPE_ANALOG,
+                "noise": False,
+            }
+        ]
+        source = EngineSource(
+            engine,
+            channels,
+            {"ZZSYNC:CAM:INTENSITY": intensity},
+            tmp_path,
+            setpoint_echo_records={
+                "ZZSYNC:STAGE:POS": stage_rb,
+                "ZZSYNC:NOT:SERVED": self._FakeRecord(1.0),  # dropped, engine-unknown
+            },
+        )
+
+        source.poll_once()
+        off_peak = intensity.get()
+
+        stage_rb.set(2.0)  # the accepted setpoint echo moves the readback...
+        source.poll_once()
+        on_peak = intensity.get()
+
+        # ...and the expression channel responds: on-peak beats off-peak by
+        # the Gaussian's e^{-4} contrast.
+        assert on_peak == pytest.approx(1000.0)
+        assert off_peak == pytest.approx(1000.0 * 0.0183156, rel=1e-3)
+
+    def test_without_sync_map_behaviour_is_unchanged(self, tmp_path: Path):
+        from osprey.services.virtual_accelerator.ioc.engine_source import EngineSource
+        from osprey.simulation.engine import SimulationEngine
+
+        machine = tmp_path / "machine.json"
+        machine.write_text(
+            json.dumps(
+                {
+                    "name": "sync-default-test",
+                    "description": "no sync map -> pure scenario source",
+                    "channels": {"ZZSYNC2:TEMP:RB": {"value": 21.5, "noise": 0}},
+                }
+            )
+        )
+        engine = SimulationEngine.from_file(machine)
+        temp = self._FakeRecord(0.0)
+        channels = [
+            {
+                "address": "ZZSYNC2:TEMP:RB",
+                "partition": PARTITION_STATIC_NOISY,
+                "record_type": RECORD_TYPE_ANALOG,
+                "noise": False,
+            }
+        ]
+        EngineSource(engine, channels, {"ZZSYNC2:TEMP:RB": temp}, tmp_path).poll_once()
+        assert temp.get() == pytest.approx(21.5)
+
+
+class TestFileBackedBootWithoutPyat:
+    """Facility half: real main() boot, file manifest, PyAT import fatal."""
+
+    @pytest.fixture()
+    def seam_data_dir(self, tmp_path: Path) -> Path:
+        (tmp_path / "channels_manifest.json").write_text(json.dumps({"channels": _SEAM_CHANNELS}))
+        (tmp_path / "machine.json").write_text(
+            json.dumps(
+                {
+                    "name": "seam-test facility",
+                    "description": "minimal machine for the facility-seam boot test",
+                    "channels": {
+                        "ZZSEAM:JET:PRESSURE": {
+                            "label": "jet backing pressure",
+                            "value": 30.0,
+                        }
+                    },
+                }
+            )
+        )
+        return tmp_path
+
+    def test_boots_serves_and_never_imports_pyat(self, seam_data_dir: Path):
+        env = dict(os.environ)
+        env.update(
+            VA_DATA_DIR=str(seam_data_dir),
+            VA_CHANNELS_FILE="channels_manifest.json",
+            # VA_LATTICE deliberately unset: file-backed default must be "none".
+            EPICS_CA_ADDR_LIST="127.0.0.1",
+            EPICS_CA_AUTO_ADDR_LIST="NO",
+            EPICS_CA_SERVER_PORT=str(_free_port()),
+            EPICS_CA_REPEATER_PORT=str(_free_port()),
+        )
+        env.pop("VA_LATTICE", None)
+
+        proc = subprocess.Popen(
+            [sys.executable, __file__, "--run-seam-ioc-subprocess"],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        try:
+            lines: list[str] = []
+            deadline = time.monotonic() + 60
+            served = False
+            while time.monotonic() < deadline:
+                line = proc.stdout.readline()
+                if not line:
+                    break  # process exited (a crash -- asserted below)
+                lines.append(line)
+                if "serving PVs" in line:
+                    served = True
+                    break
+            output = "".join(lines)
+            assert served, f"IOC never reached the serving announcement:\n{output}"
+            # The no-lattice notice proves the PhysicsBridge branch was
+            # skipped by DEFAULT (VA_LATTICE unset), not by explicit opt-out.
+            assert "PhysicsBridge skipped" in output
+            # All four manifest channels (and nothing else) were built.
+            assert f"serving PVs: {len(_SEAM_CHANNELS)} channels" in output
+        finally:
+            proc.send_signal(signal.SIGTERM)
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=10)

--- a/tests/va/test_manifest_file_source.py
+++ b/tests/va/test_manifest_file_source.py
@@ -1,0 +1,119 @@
+"""Tests for the file-backed channel source (``loaders.load_manifest_file``).
+
+This is the facility-neutral seam: a facility that does not use the built-in
+generated manifest supplies a ``{"channels": [...]}`` JSON file carrying the
+same per-channel schema ``build_manifest()`` produces. Pure-python and
+file-level -- no softioc, no lattice, no CA.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from osprey.services.virtual_accelerator.manifest import (
+    MANIFEST_CHANNEL_KEYS,
+    ManifestFileError,
+    load_manifest_file,
+)
+
+
+def _channel_entry(address: str, **overrides) -> dict:
+    """One schema-complete manifest channel entry. Hierarchy defaults use a
+    three-part-address facility's convention: the experiment rides in
+    ``ring`` and unused levels are empty strings."""
+    entry = {
+        "address": address,
+        "ring": "ZZEXP",
+        "system": "DIAG",
+        "family": "CAM",
+        "device": "01",
+        "field": "EXPOSURE",
+        "subfield": "RB",
+        "partition": "static-noisy",
+        "record_type": "ai",
+        "noise": True,
+    }
+    entry.update(overrides)
+    return entry
+
+
+def _write_manifest(tmp_path, channels) -> Path:
+    path = tmp_path / "channels_manifest.json"
+    path.write_text(json.dumps({"channels": channels}))
+    return path
+
+
+class TestLoadManifestFile:
+    def test_loads_channels_from_valid_file(self, tmp_path):
+        channels = [
+            _channel_entry("ZZEXP:DIAG:CAM:01:EXPOSURE:RB"),
+            _channel_entry("ZZEXP:DIAG:CAM:01:EXPOSURE:SP", subfield="SP", partition="sp-echo"),
+        ]
+        loaded = load_manifest_file(_write_manifest(tmp_path, channels))
+        assert loaded == channels
+
+    def test_three_part_addresses_load_without_grammar_constraint(self, tmp_path):
+        # The seam imposes no address grammar: a facility whose real PV names
+        # are three-part strings loads through the same call, carrying its
+        # identity in the hierarchy keys rather than the address text.
+        channels = [
+            _channel_entry(
+                "ZZEXP:JET:PRESSURE",
+                system="JET",
+                family="TARGET",
+                field="PRESSURE",
+            )
+        ]
+        loaded = load_manifest_file(_write_manifest(tmp_path, channels))
+        assert loaded[0]["address"] == "ZZEXP:JET:PRESSURE"
+
+    def test_missing_file_raises_named_error(self, tmp_path):
+        with pytest.raises(ManifestFileError, match="not found"):
+            load_manifest_file(tmp_path / "absent.json")
+
+    def test_invalid_json_raises_named_error(self, tmp_path):
+        path = tmp_path / "broken.json"
+        path.write_text("{not json")
+        with pytest.raises(ManifestFileError, match="not valid JSON"):
+            load_manifest_file(path)
+
+    def test_top_level_must_carry_a_channels_list(self, tmp_path):
+        path = tmp_path / "shapeless.json"
+        path.write_text(json.dumps({"pvs": []}))
+        with pytest.raises(ManifestFileError, match="'channels' list"):
+            load_manifest_file(path)
+
+    def test_channel_missing_schema_keys_is_named_in_the_error(self, tmp_path):
+        incomplete = _channel_entry("ZZEXP:DIAG:CAM:02:EXPOSURE:RB")
+        del incomplete["partition"], incomplete["noise"]
+        with pytest.raises(ManifestFileError, match="noise, partition"):
+            load_manifest_file(_write_manifest(tmp_path, [incomplete]))
+
+    def test_duplicate_address_raises(self, tmp_path):
+        dup = _channel_entry("ZZEXP:DIAG:CAM:03:EXPOSURE:RB")
+        with pytest.raises(ManifestFileError, match="duplicate address"):
+            load_manifest_file(_write_manifest(tmp_path, [dup, dict(dup)]))
+
+    def test_empty_address_raises(self, tmp_path):
+        with pytest.raises(ManifestFileError, match="empty address"):
+            load_manifest_file(_write_manifest(tmp_path, [_channel_entry("")]))
+
+    def test_schema_keys_match_build_records_consumption(self):
+        # The documented schema is exactly what ioc/records.py's
+        # build_records() reads off each channel dict -- keep the frozen set
+        # honest against the factory's field accesses.
+        assert MANIFEST_CHANNEL_KEYS == {
+            "address",
+            "ring",
+            "system",
+            "family",
+            "device",
+            "field",
+            "subfield",
+            "partition",
+            "record_type",
+            "noise",
+        }

--- a/tests/va/test_record_factory.py
+++ b/tests/va/test_record_factory.py
@@ -111,6 +111,8 @@ from osprey.services.virtual_accelerator.manifest import (  # noqa: E402
     PARTITION_STATIC_NOISY,
     RECORD_TYPE_ANALOG,
     RECORD_TYPE_BINARY,
+    RECORD_TYPE_LONG_STRING,
+    RECORD_TYPE_MBB,
     build_manifest,
 )
 from osprey.services.virtual_accelerator.manifest.loaders import (  # noqa: E402
@@ -370,6 +372,77 @@ class TestBiRecordsRejectNoise:
         )
         records = build_records([ok])
         assert set(records.all) == {"ZZTEST:MAG:OK:01:STATUS:FAULT"}
+
+
+class TestGatewayRecordTypes:
+    """The longstringin/mbbi dispatch additions: the two gateway channel
+    shapes (512-byte char waveform, multi-bit binary) the original three
+    record types didn't cover. Build-time coverage only -- value round-trips
+    ride the same live-CA machinery as every other type."""
+
+    def test_long_string_sp_echo_pair_builds(self):
+        channels = [
+            _channel(
+                "ZZTEST:GW:LSTR:01:MSG:RB",
+                partition=PARTITION_SP_ECHO,
+                subfield="RB",
+                record_type=RECORD_TYPE_LONG_STRING,
+                family="LSTR",
+                field="MSG",
+            ),
+            _channel(
+                "ZZTEST:GW:LSTR:01:MSG:SP",
+                partition=PARTITION_SP_ECHO,
+                subfield="SP",
+                record_type=RECORD_TYPE_LONG_STRING,
+                family="LSTR",
+                field="MSG",
+            ),
+        ]
+        records = build_records(channels)
+        assert set(records.all) == {"ZZTEST:GW:LSTR:01:MSG:RB", "ZZTEST:GW:LSTR:01:MSG:SP"}
+
+    def test_mbb_static_channel_builds(self):
+        state = _channel(
+            "ZZTEST:GW:MODE:01:STATE:RB",
+            partition=PARTITION_STATIC_NOISY,
+            subfield="RB",
+            record_type=RECORD_TYPE_MBB,
+            family="MODE",
+            field="STATE",
+        )
+        records = build_records([state])
+        assert "ZZTEST:GW:MODE:01:STATE:RB" in records.static_noisy
+
+    def test_noisy_mbb_channel_raises(self):
+        bad = _channel(
+            "ZZTEST:GW:MODE:02:STATE:RB",
+            partition=PARTITION_STATIC_NOISY,
+            subfield="RB",
+            record_type=RECORD_TYPE_MBB,
+            noise=True,
+        )
+        with pytest.raises(ManifestContractError, match="reject noise"):
+            build_records([bad])
+
+    def test_noisy_long_string_channel_raises(self):
+        bad = _channel(
+            "ZZTEST:GW:LSTR:02:MSG:RB",
+            partition=PARTITION_STATIC_NOISY,
+            subfield="RB",
+            record_type=RECORD_TYPE_LONG_STRING,
+            noise=True,
+        )
+        with pytest.raises(ManifestContractError, match="reject noise"):
+            build_records([bad])
+
+    def test_long_string_records_declare_full_gateway_width(self):
+        # NELM must be 512 explicitly: the builder's own default (256, or
+        # len(initial_value)+1) would silently truncate a full-width wire
+        # value. Asserted at the wrapper level so a future builder-default
+        # change upstream cannot quietly shrink the record.
+        rec = ioc_records_module._long_string_in("ZZTEST:GW:LSTR:03:MSG:RB")
+        assert int(rec.NELM.Value()) == 512
 
 
 class TestContractViolations:


### PR DESCRIPTION
Lets the virtual accelerator serve a facility that has no PyAT lattice model and supplies its own channel namespace, without changing the existing path.

Three opt-in axes, each defaulting to current behaviour:

- `VA_CHANNELS_FILE` selects a file-backed channel manifest (`{"channels": [...]}`, the same per-channel schema `build_manifest()` produces). Unset keeps the built-in generated manifest. With a file source, drive limits and boot values come from the mount rather than the bundled tutorial data.
- `VA_LATTICE` (`builtin`|`none`) controls PhysicsBridge construction. With `none`, PyAT is never imported: the bridge import is deferred and `ioc/__init__` re-exports its names lazily (PEP 562). Lattice-physics faults become fatal without a lattice rather than silently inert. On that path, sp-echo readbacks sync into the simulation engine each poll tick so machine-file expression channels respond to accepted setpoints.
- `VA_ENTRYPOINT_MODULE` parameterizes the container CMD (exec-ed so SIGTERM still reaches the IOC shutdown path). The compose template passes all three through from the project environment.

Also adds `longstringin`/`mbbi` to the record dispatch, covering the remaining two gateway channel shapes. `longStringIn/Out` is called with an explicit `length=512` — the builder default of 256 (or `len(initial_value)+1`) silently truncates full-width values.

`tests/va/test_facility_seam.py` is the regression gate: the default path resolves to the pre-change behaviour, and a file-backed manifest of three-part addresses boots the real entrypoint to its serving announcement inside a subprocess whose import machinery makes any PyAT import fatal.