### PR TITLE
fix(artifacts): keep session artifacts visible to the gallery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Compatibility is documented in release notes, not encoded in the version string.
 - All artifact stores are now rooted at the shared data root, so artifacts saved
   from session-scoped writers (e.g. resumed web-terminal sessions) stay visible to
   the gallery.
+- `artifact_focus`/`artifact_pin` now report gallery failures honestly instead of
+  always claiming success.
 - `web.app_name` in `config.yml` now actually labels the web terminal header: the
   runtime read the key from a nested section nothing generates, so only the
   `OSPREY_WEB_APP_NAME` env override worked. It now reads top-level `web.app_name`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- All artifact stores are now rooted at the shared data root, so artifacts saved
+  from session-scoped writers (e.g. resumed web-terminal sessions) stay visible to
+  the gallery.
 - `web.app_name` in `config.yml` now actually labels the web terminal header: the
   runtime read the key from a nested section nothing generates, so only the
   `OSPREY_WEB_APP_NAME` env override worked. It now reads top-level `web.app_name`,

--- a/src/osprey/infrastructure/server_launcher.py
+++ b/src/osprey/infrastructure/server_launcher.py
@@ -127,9 +127,12 @@ class ServerLauncher:
                 import uvicorn
 
                 if self._pass_workspace:
-                    from osprey.utils.workspace import resolve_workspace_root
+                    from osprey.utils.workspace import resolve_shared_data_root
 
-                    app = self._app_factory(workspace_root=resolve_workspace_root())
+                    # Launched servers are daemons serving the shared store (they
+                    # may be auto-launched from a session-scoped MCP process on
+                    # first artifact save).
+                    app = self._app_factory(workspace_root=resolve_shared_data_root())
                 else:
                     app = self._app_factory()
                 uvicorn.run(app, host=host, port=port, log_level="warning")

--- a/src/osprey/interfaces/web_terminal/routes/websocket.py
+++ b/src/osprey/interfaces/web_terminal/routes/websocket.py
@@ -90,8 +90,9 @@ def _build_extra_env(
     forced onto (via ``--session-id``); it is handed to the workspace
     provenance_locator tool so a filed issue can point back to this session's
     telemetry. Kept separate from ``claude_session_id`` — which drives
-    ``OSPREY_SESSION_ID`` (artifact-store relocation) and stays unset for new
-    sessions — because the telemetry locator must NOT relocate the artifact store.
+    ``OSPREY_SESSION_ID`` (session-scoped agent-data relocation and artifact
+    session tagging) and stays unset for new sessions — because the telemetry
+    locator must not carry those side effects.
     """
     extra_env: dict[str, str] = {}
     if claude_session_id:
@@ -145,7 +146,7 @@ async def terminal_ws(websocket: WebSocket):
         # filed issue's provenance pointer then resolves. Leave claude_session_id
         # None so the new-session snapshot/discovery path is unchanged: discovery
         # simply finds the id we forced. (Not claude_session_id, which would set
-        # OSPREY_SESSION_ID and relocate the artifact store.)
+        # OSPREY_SESSION_ID and relocate session-scoped agent data.)
         telemetry_session_id = str(uuid.uuid4())
         command = [*base_shell_command, "--session-id", telemetry_session_id]
         claude_session_id = None

--- a/src/osprey/mcp_server/ariel/server.py
+++ b/src/osprey/mcp_server/ariel/server.py
@@ -172,9 +172,11 @@ def create_server() -> FastMCP:
     prime_config_builder()
     initialize_ariel_context()
 
-    workspace_root = resolve_workspace_root()
-    logger.info("ARIEL workspace root: %s", workspace_root)
-    initialize_workspace_singletons(workspace_root)
+    # Session working root used by other tools at call time; the artifact
+    # store itself is rooted at the shared data root inside
+    # initialize_workspace_singletons().
+    logger.info("ARIEL workspace root: %s", resolve_workspace_root())
+    initialize_workspace_singletons()
 
     # Import tool modules (each registers itself via @mcp.tool())
     from osprey.mcp_server.ariel.tools import (  # noqa: F401

--- a/src/osprey/mcp_server/bluesky/server.py
+++ b/src/osprey/mcp_server/bluesky/server.py
@@ -46,9 +46,11 @@ def create_server() -> FastMCP:
     with startup_timer("server_context"):
         initialize_server_context()
 
-    workspace_root = resolve_workspace_root()
-    logger.info("Workspace root: %s", workspace_root)
-    initialize_workspace_singletons(workspace_root)
+    # Session working root used by other tools at call time; the artifact
+    # store itself is rooted at the shared data root inside
+    # initialize_workspace_singletons().
+    logger.info("Workspace root: %s", resolve_workspace_root())
+    initialize_workspace_singletons()
 
     # Import tool modules (each registers itself via @mcp.tool())
     with startup_timer("tool_imports"):

--- a/src/osprey/mcp_server/channel_finder_hierarchical/server.py
+++ b/src/osprey/mcp_server/channel_finder_hierarchical/server.py
@@ -34,7 +34,6 @@ def create_server() -> FastMCP:
         initialize_workspace_singletons,
         prime_config_builder,
     )
-    from osprey.utils.workspace import resolve_workspace_root
 
     prime_config_builder()
 
@@ -44,8 +43,7 @@ def create_server() -> FastMCP:
 
     initialize_cf_hier_context()
 
-    workspace_root = resolve_workspace_root()
-    initialize_workspace_singletons(workspace_root)
+    initialize_workspace_singletons()
 
     # Import tool modules (each registers itself via @mcp.tool())
     from osprey.mcp_server.channel_finder_hierarchical.tools import (  # noqa: F401

--- a/src/osprey/mcp_server/channel_finder_in_context/server.py
+++ b/src/osprey/mcp_server/channel_finder_in_context/server.py
@@ -46,7 +46,6 @@ def create_server() -> FastMCP:
         initialize_workspace_singletons,
         prime_config_builder,
     )
-    from osprey.utils.workspace import resolve_workspace_root
 
     prime_config_builder()
 
@@ -55,8 +54,7 @@ def create_server() -> FastMCP:
     )
 
     initialize_cf_ic_context()
-    workspace_root = resolve_workspace_root()
-    initialize_workspace_singletons(workspace_root)
+    initialize_workspace_singletons()
 
     # Import tool modules (each registers itself via @mcp.tool())
     from osprey.mcp_server.channel_finder_in_context.tools import (  # noqa: F401

--- a/src/osprey/mcp_server/channel_finder_middle_layer/server.py
+++ b/src/osprey/mcp_server/channel_finder_middle_layer/server.py
@@ -31,7 +31,6 @@ def create_server() -> FastMCP:
         initialize_workspace_singletons,
         prime_config_builder,
     )
-    from osprey.utils.workspace import resolve_workspace_root
 
     prime_config_builder()
 
@@ -40,8 +39,7 @@ def create_server() -> FastMCP:
     )
 
     initialize_cf_ml_context()
-    workspace_root = resolve_workspace_root()
-    initialize_workspace_singletons(workspace_root)
+    initialize_workspace_singletons()
 
     # Import tool modules (each registers itself via @mcp.tool())
     from osprey.mcp_server.channel_finder_middle_layer.tools import (  # noqa: F401

--- a/src/osprey/mcp_server/control_system/server.py
+++ b/src/osprey/mcp_server/control_system/server.py
@@ -33,9 +33,11 @@ def create_server() -> FastMCP:
     with startup_timer("server_context"):
         initialize_server_context()
 
-    workspace_root = resolve_workspace_root()
-    logger.info("Workspace root: %s", workspace_root)
-    initialize_workspace_singletons(workspace_root)
+    # Session working root used by other tools at call time; the artifact
+    # store itself is rooted at the shared data root inside
+    # initialize_workspace_singletons().
+    logger.info("Workspace root: %s", resolve_workspace_root())
+    initialize_workspace_singletons()
 
     # Import tool modules (each registers itself via @mcp.tool())
     with startup_timer("tool_imports"):

--- a/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
+++ b/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
@@ -349,9 +349,9 @@ async def run_dispatch(
 
     # Attribute every artifact this run saves to the run, so the worker can
     # later report and serve exactly this run's plots. NOT OSPREY_SESSION_ID:
-    # that variable also relocates the artifact store into
-    # _agent_data/sessions/<id>/ (resolve_agent_data_root), which would move
-    # dispatch plots off the shared root the gallery reads.
+    # that variable relocates other session-scoped agent data (sandbox/session
+    # working dirs via resolve_agent_data_root) and tags artifacts with a
+    # session id — a dispatch run is not an interactive session.
     if run_id:
         sdk_env["OSPREY_DISPATCH_RUN_ID"] = run_id
 

--- a/src/osprey/mcp_server/phoebus/server.py
+++ b/src/osprey/mcp_server/phoebus/server.py
@@ -38,9 +38,11 @@ def create_server() -> FastMCP:
     # the workspace singletons — prime them so phoebus_snapshot can save PNGs.
     prime_config_builder()
 
-    workspace_root = resolve_workspace_root()
-    logger.info("Workspace root: %s", workspace_root)
-    initialize_workspace_singletons(workspace_root)
+    # Session working root used by other tools at call time; the artifact
+    # store itself is rooted at the shared data root inside
+    # initialize_workspace_singletons().
+    logger.info("Workspace root: %s", resolve_workspace_root())
+    initialize_workspace_singletons()
 
     # Import tool modules (each registers itself via @mcp.tool())
     with startup_timer("tool_imports"):

--- a/src/osprey/mcp_server/python_executor/server.py
+++ b/src/osprey/mcp_server/python_executor/server.py
@@ -29,9 +29,11 @@ def create_server() -> FastMCP:
 
     prime_config_builder()
 
-    workspace_root = resolve_workspace_root()
-    logger.info("Workspace root: %s", workspace_root)
-    initialize_workspace_singletons(workspace_root)
+    # Session working root used by other tools at call time; the artifact
+    # store itself is rooted at the shared data root inside
+    # initialize_workspace_singletons().
+    logger.info("Workspace root: %s", resolve_workspace_root())
+    initialize_workspace_singletons()
 
     # Import tool modules (each registers itself via @mcp.tool())
     with startup_timer("tool_imports"):

--- a/src/osprey/mcp_server/startup.py
+++ b/src/osprey/mcp_server/startup.py
@@ -4,7 +4,6 @@ import logging
 import sys
 import time
 from contextlib import contextmanager
-from pathlib import Path
 
 from rich.console import Console
 from rich.logging import RichHandler
@@ -115,12 +114,22 @@ def prime_config_builder() -> None:
             logger.warning("ConfigBuilder priming failed (non-fatal): %s", exc)
 
 
-def initialize_workspace_singletons(workspace_root: Path) -> None:
-    """Initialize ArtifactStore singleton for a workspace."""
+def initialize_workspace_singletons() -> None:
+    """Initialize the ArtifactStore singleton on the SHARED data root.
+
+    The artifact store is served by long-lived daemons (the artifact gallery)
+    that read the shared ``_agent_data/`` root. Session isolation is handled
+    at the index level via ``ArtifactEntry.session_id`` — never in the store
+    path. Rooting the store at the session-relocated path
+    (``resolve_agent_data_root`` appends ``sessions/<id>/`` when
+    ``OSPREY_SESSION_ID`` is set) would make a session's artifacts invisible
+    to the gallery.
+    """
     from osprey.stores.artifact_store import initialize_artifact_store
+    from osprey.utils.workspace import resolve_shared_data_root
 
     with startup_timer("workspace_singletons"):
-        initialize_artifact_store(workspace_root=workspace_root)
+        initialize_artifact_store(workspace_root=resolve_shared_data_root())
 
 
 def run_mcp_server(server_module: str) -> None:

--- a/src/osprey/mcp_server/workspace/server.py
+++ b/src/osprey/mcp_server/workspace/server.py
@@ -32,9 +32,11 @@ def create_server() -> FastMCP:
     # like create_static_plot call execute_code().
     prime_config_builder()
 
-    workspace_root = resolve_workspace_root()
-    logger.info("Workspace root: %s", workspace_root)
-    initialize_workspace_singletons(workspace_root)
+    # Session working root used by other tools at call time; the artifact
+    # store itself is rooted at the shared data root inside
+    # initialize_workspace_singletons().
+    logger.info("Workspace root: %s", resolve_workspace_root())
+    initialize_workspace_singletons()
 
     # Import tool modules (each registers itself via @mcp.tool())
     with startup_timer("tool_imports"):

--- a/src/osprey/mcp_server/workspace/tools/archiver_downsample.py
+++ b/src/osprey/mcp_server/workspace/tools/archiver_downsample.py
@@ -8,12 +8,9 @@ keeping the payload small enough for inline report generation.
 import json
 import logging
 
-from fastmcp.exceptions import ToolError
-
 from osprey.mcp_server.errors import make_error
 from osprey.mcp_server.workspace.server import mcp
 from osprey.utils.timeseries import extract_timeseries_frame, lttb_downsample
-from osprey.utils.workspace import resolve_workspace_root
 
 logger = logging.getLogger("osprey.mcp_server.tools.archiver_downsample")
 
@@ -42,19 +39,9 @@ async def archiver_downsample(
         JSON with labels, datasets, original_points, downsampled_points,
         and time_range suitable for Chart.js.
     """
-    try:
-        workspace_root = resolve_workspace_root()
-    except ToolError:
-        raise
-    except Exception as e:
-        return make_error(
-            "internal_error",
-            f"Could not resolve workspace root: {e}",
-        )
+    from osprey.stores.artifact_store import get_artifact_store
 
-    from osprey.stores.artifact_store import ArtifactStore
-
-    store = ArtifactStore(workspace_root=workspace_root)
+    store = get_artifact_store()
     entry = store.get_entry(entry_id)
 
     if entry is None:

--- a/src/osprey/mcp_server/workspace/tools/focus_tools.py
+++ b/src/osprey/mcp_server/workspace/tools/focus_tools.py
@@ -2,13 +2,23 @@
 
 artifact_focus selects a specific artifact in the gallery so the user sees it.
 artifact_pin toggles the pinned flag for quick access filtering.
+
+Both tools report gallery outcomes honestly instead of fire-and-forget:
+
+* ``artifact_focus``: the entire effect is gallery-side, so a failed or
+  rejected POST is a tool error (``gallery_unreachable`` / ``gallery_error``
+  — ``make_error`` raises a fastmcp ``ToolError``).
+* ``artifact_pin``: the durable pin lands in the shared index first
+  (``set_pinned``), so the response stays ``success`` but reports whether the
+  gallery was actually notified via ``gallery_notified``.
 """
 
 import json
 import logging
+import urllib.error
 
 from osprey.mcp_server.errors import make_error
-from osprey.mcp_server.http import gallery_url, post_json
+from osprey.mcp_server.http import _post_json_with_response, gallery_url
 from osprey.mcp_server.workspace.server import mcp
 
 logger = logging.getLogger("osprey.mcp_server.tools.focus")
@@ -21,6 +31,10 @@ async def artifact_focus(artifact_id: str, fullscreen: bool = False) -> str:
     Sets the gallery's current selection to the given artifact, scrolling
     it into view and showing the preview pane. Also updates focus_state.txt
     so the agent-awareness hook includes this artifact in context.
+
+    The focus effect lives entirely in the gallery, so a gallery that is
+    unreachable or rejects the request is reported as a tool error
+    (``gallery_unreachable`` / ``gallery_error``) — never as success.
 
     Args:
         artifact_id: ID of the artifact to select (from artifact_save response).
@@ -42,10 +56,32 @@ async def artifact_focus(artifact_id: str, fullscreen: bool = False) -> str:
         )
 
     base_url = gallery_url()
-    payload = {"artifact_id": artifact_id}
+    payload: dict = {"artifact_id": artifact_id}
     if fullscreen:
         payload["fullscreen"] = True
-    post_json(f"{base_url}/api/focus", payload)
+
+    try:
+        status, body = _post_json_with_response(f"{base_url}/api/focus", payload)
+    except (urllib.error.URLError, OSError) as exc:
+        file_path = store.get_file_path(artifact_id)
+        return make_error(
+            "gallery_unreachable",
+            f"Could not reach the artifact gallery at {base_url}: {exc}",
+            [
+                "Check that the artifact gallery server is running.",
+                f"The artifact file is available directly at: {file_path} "
+                "— it can be opened in a browser.",
+            ],
+        )
+
+    if not 200 <= status < 300:
+        detail = body.get("detail", "") if isinstance(body, dict) else str(body)
+        return make_error(
+            "gallery_error",
+            f"Gallery rejected the focus request (HTTP {status})"
+            + (f": {detail}" if detail else "."),
+            ["Verify the gallery serves the same artifact store this session saved to."],
+        )
 
     return json.dumps(
         {
@@ -65,12 +101,17 @@ async def artifact_pin(artifact_id: str, pinned: bool = True) -> str:
     Pinned artifacts appear at the top of the sidebar and can be filtered
     via the pin filter chip.
 
+    The pin flag is persisted in the shared artifact index first (the
+    gallery's index watcher picks it up eventually), so the tool reports
+    ``status: success`` even when the live gallery notification fails —
+    ``gallery_notified`` records whether the gallery acknowledged the update.
+
     Args:
         artifact_id: ID of the artifact to pin/unpin.
         pinned: True to pin, False to unpin. Defaults to True.
 
     Returns:
-        JSON with status and updated pinned state.
+        JSON with status, updated pinned state, and gallery_notified.
     """
     from osprey.stores.artifact_store import get_artifact_store
 
@@ -83,9 +124,16 @@ async def artifact_pin(artifact_id: str, pinned: bool = True) -> str:
             ["Check the artifact_id from a previous artifact_save response."],
         )
 
-    # Notify gallery of the update
+    # Notify the gallery; never raise — the durable state is already set.
     base_url = gallery_url()
-    post_json(f"{base_url}/api/artifacts/{artifact_id}/pin", {"pinned": pinned})
+    gallery_notified = False
+    try:
+        status, _body = _post_json_with_response(
+            f"{base_url}/api/artifacts/{artifact_id}/pin", {"pinned": pinned}
+        )
+        gallery_notified = 200 <= status < 300
+    except (urllib.error.URLError, OSError) as exc:
+        logger.warning("Gallery pin notification failed (non-fatal): %s", exc)
 
     return json.dumps(
         {
@@ -93,5 +141,6 @@ async def artifact_pin(artifact_id: str, pinned: bool = True) -> str:
             "artifact_id": artifact_id,
             "title": entry.title,
             "pinned": entry.pinned,
+            "gallery_notified": gallery_notified,
         }
     )

--- a/src/osprey/mcp_server/workspace/tools/provenance_locator.py
+++ b/src/osprey/mcp_server/workspace/tools/provenance_locator.py
@@ -38,8 +38,8 @@ logger = logging.getLogger("osprey.mcp_server.tools.provenance_locator")
 # Env var OSPREY injects at launch carrying the forced session UUID. Kept in
 # sync with the injection sites (dispatch_worker.sdk_runner, web_terminal
 # operator_session / PTY launch), which set the same name. A dedicated var —
-# NOT OSPREY_SESSION_ID, which has an unrelated side effect (it relocates the
-# artifact store).
+# NOT OSPREY_SESSION_ID, which has unrelated side effects (it relocates
+# session-scoped agent data and tags saved artifacts).
 OSPREY_TELEMETRY_SESSION_ID_ENV = "OSPREY_TELEMETRY_SESSION_ID"
 # Optional ISO-8601 session-start OSPREY may inject to bound the lookback query.
 OSPREY_TELEMETRY_SESSION_START_ENV = "OSPREY_TELEMETRY_SESSION_START"

--- a/src/osprey/mcp_server/workspace/tools/session_summary.py
+++ b/src/osprey/mcp_server/workspace/tools/session_summary.py
@@ -11,11 +11,7 @@ import logging
 from collections import Counter
 from pathlib import Path
 
-from fastmcp.exceptions import ToolError
-
-from osprey.mcp_server.errors import make_error
 from osprey.mcp_server.workspace.server import mcp
-from osprey.utils.workspace import resolve_workspace_root
 
 logger = logging.getLogger("osprey.mcp_server.tools.session_summary")
 
@@ -54,20 +50,10 @@ async def session_summary() -> str:
     Returns:
         JSON with entries[], and totals.
     """
-    try:
-        workspace_root = resolve_workspace_root()
-    except ToolError:
-        raise
-    except Exception as e:
-        return make_error(
-            "internal_error",
-            f"Could not resolve workspace root: {e}",
-        )
+    # --- Unified artifact store (shared-root singleton) ---
+    from osprey.stores.artifact_store import get_artifact_store
 
-    # --- Unified artifact store ---
-    from osprey.stores.artifact_store import ArtifactStore
-
-    store = ArtifactStore(workspace_root=workspace_root)
+    store = get_artifact_store()
     all_entries = store.list_entries()
 
     entries = []

--- a/src/osprey/stores/artifact_store.py
+++ b/src/osprey/stores/artifact_store.py
@@ -75,10 +75,11 @@ class ArtifactEntry:
     """Dispatch run that produced this artifact (``OSPREY_DISPATCH_RUN_ID``),
     empty for artifacts made outside a dispatch run.
 
-    Deliberately separate from ``session_id``: ``OSPREY_SESSION_ID`` also
-    relocates the whole store into ``_agent_data/sessions/<id>/`` (see
-    ``resolve_agent_data_root``), so it cannot be reused to tag a dispatch run
-    without moving its artifacts off the shared root the gallery reads."""
+    Deliberately separate from ``session_id``: a session id is not a run id —
+    ``OSPREY_SESSION_ID`` tags an interactive session's artifacts, while a
+    dispatch run needs its own scope so the worker can report and serve
+    exactly this run's artifacts. The store itself always lives on the shared
+    data root; both fields are index-level tags."""
     origin: str = ""
     """Provenance of the artifact within its run. Empty (the default) for the
     agent's own output. ``"input"`` marks a caller-supplied file ingested into

--- a/tests/mcp_server/test_artifact_focus.py
+++ b/tests/mcp_server/test_artifact_focus.py
@@ -1,5 +1,7 @@
 """Tests for the artifact_focus MCP tool."""
 
+from unittest.mock import patch
+
 import pytest
 
 from tests.mcp_server.conftest import (
@@ -37,7 +39,7 @@ class TestArtifactFocusTool:
 
     @pytest.mark.asyncio
     async def test_focus_valid_artifact(self, tmp_path, monkeypatch):
-        """Focusing a valid artifact returns success (gallery POST is non-fatal)."""
+        """Focusing a valid artifact returns success when the gallery accepts."""
         monkeypatch.chdir(tmp_path)
 
         # First save an artifact
@@ -50,9 +52,13 @@ class TestArtifactFocusTool:
         save_data = extract_response_dict(save_result)
         artifact_id = save_data["artifact_id"]
 
-        # Now focus on it
+        # Now focus on it (gallery acknowledges the POST)
         fn = _get_artifact_focus()
-        result = await fn(artifact_id=artifact_id)
+        with patch(
+            "osprey.mcp_server.workspace.tools.focus_tools._post_json_with_response",
+            return_value=(200, {"status": "ok"}),
+        ):
+            result = await fn(artifact_id=artifact_id)
 
         data = extract_response_dict(result)
         assert data["status"] == "success"

--- a/tests/mcp_server/test_startup_singletons.py
+++ b/tests/mcp_server/test_startup_singletons.py
@@ -1,0 +1,109 @@
+"""Regression tests: the ArtifactStore singleton lives on the SHARED data root.
+
+The artifact gallery is a long-lived daemon serving the shared
+``_agent_data/artifacts/`` store. If an MCP server roots its ArtifactStore at
+the session-relocated path (``OSPREY_SESSION_ID`` appends
+``sessions/<id>/`` in ``resolve_agent_data_root``), everything the session
+saves lands in a store the gallery never reads — artifacts silently vanish
+from the UI. Session attribution belongs in the index
+(``ArtifactEntry.session_id``), never in the store path
+(see ``resolve_shared_data_root``).
+"""
+
+import sys
+import threading
+import types
+
+import pytest
+
+from osprey.stores.artifact_store import get_artifact_store
+
+SESSION_ID = "f5c059b4-sess"
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    """Minimal deployed project: config.yml with auto-launch disabled."""
+    (tmp_path / "config.yml").write_text(
+        "agent_data:\n  base_dir: ./_agent_data\nartifact_server:\n  auto_launch: false\n"
+    )
+    monkeypatch.setenv("OSPREY_CONFIG", str(tmp_path / "config.yml"))
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.mark.unit
+def test_singleton_ignores_session_relocation(project, monkeypatch):
+    """With OSPREY_SESSION_ID set, the store must still root at the shared path."""
+    monkeypatch.setenv("OSPREY_SESSION_ID", SESSION_ID)
+    from osprey.mcp_server.startup import initialize_workspace_singletons
+
+    initialize_workspace_singletons()
+    store = get_artifact_store()
+
+    assert store.artifact_dir == project / "_agent_data" / "artifacts"
+    assert "sessions" not in store.artifact_dir.parts
+
+
+@pytest.mark.unit
+def test_saved_entry_carries_session_tag_on_shared_root(project, monkeypatch):
+    """Session isolation happens at the index level: shared path, tagged entry."""
+    monkeypatch.setenv("OSPREY_SESSION_ID", SESSION_ID)
+    from osprey.mcp_server.startup import initialize_workspace_singletons
+
+    initialize_workspace_singletons()
+    store = get_artifact_store()
+    entry = store.save_file(
+        file_content=b"<html></html>",
+        filename="plot.html",
+        artifact_type="plot_html",
+        title="Session plot",
+    )
+
+    assert entry.session_id == SESSION_ID
+    # The gallery reads the shared root — the file must physically be there.
+    assert (project / "_agent_data" / "artifacts" / entry.filename).exists()
+
+
+@pytest.mark.unit
+def test_singleton_root_without_session_env(project):
+    """Sanity: without OSPREY_SESSION_ID the root is unchanged."""
+    from osprey.mcp_server.startup import initialize_workspace_singletons
+
+    initialize_workspace_singletons()
+    assert get_artifact_store().artifact_dir == project / "_agent_data" / "artifacts"
+
+
+@pytest.mark.unit
+def test_daemon_web_server_receives_shared_root(project, monkeypatch):
+    """ServerLauncher hands daemons the shared root even in session-scoped processes.
+
+    The gallery may be auto-launched from inside an MCP server process (on
+    first artifact save) where OSPREY_SESSION_ID is set; it must still serve
+    the shared store.
+    """
+    monkeypatch.setenv("OSPREY_SESSION_ID", SESSION_ID)
+    from osprey.infrastructure.server_launcher import ServerLauncher
+
+    seen: dict = {}
+    factory_called = threading.Event()
+
+    def factory(workspace_root=None):
+        seen["root"] = workspace_root
+        factory_called.set()
+        return object()
+
+    monkeypatch.setitem(sys.modules, "uvicorn", types.SimpleNamespace(run=lambda *a, **k: None))
+
+    launcher = ServerLauncher(
+        name="test gallery",
+        config_reader=lambda: ("127.0.0.1", 65500),
+        auto_launch_checker=lambda: True,
+        app_factory=factory,
+        pass_workspace=True,
+    )
+    launcher._launch_in_thread("127.0.0.1", 65500)
+
+    assert factory_called.wait(5), "app factory was never invoked"
+    assert seen["root"] == project / "_agent_data"
+    assert "sessions" not in seen["root"].parts

--- a/tests/mcp_server/workspace/test_archiver_downsample.py
+++ b/tests/mcp_server/workspace/test_archiver_downsample.py
@@ -31,20 +31,17 @@ def _make_timeseries_data(n_points: int, n_channels: int = 2):
 
 
 @pytest.fixture
-def workspace(tmp_path, monkeypatch):
+def workspace(tmp_path):
     ws = tmp_path / "_agent_data"
     ws.mkdir()
     (ws / "artifacts").mkdir()
-    monkeypatch.setattr(
-        "osprey.mcp_server.workspace.tools.archiver_downsample.resolve_workspace_root",
-        lambda: ws,
-    )
     return ws
 
 
 @pytest.fixture
 def art_store(workspace):
-    return initialize_artifact_store(workspace)
+    """Initialize the ArtifactStore singleton the tool reads via get_artifact_store()."""
+    return initialize_artifact_store(workspace_root=workspace)
 
 
 class TestArchiverDownsampleBasic:

--- a/tests/mcp_server/workspace/test_focus_tools.py
+++ b/tests/mcp_server/workspace/test_focus_tools.py
@@ -1,0 +1,131 @@
+"""Tests for artifact_focus / artifact_pin honest gallery reporting.
+
+These tools previously fired a fire-and-forget POST at the gallery and
+returned ``"status": "success"`` unconditionally — a focus that never
+happened (gallery down, or gallery serving a different store) was still
+reported as done. The contract under test:
+
+  - artifact_focus: the entire effect is gallery-side, so a failed or
+    rejected POST is a tool error (gallery_unreachable / gallery_error).
+  - artifact_pin: the durable pin lands in the shared index regardless, so
+    the response stays success but reports ``gallery_notified`` honestly.
+"""
+
+import json
+import urllib.error
+from unittest.mock import patch
+
+import pytest
+
+from osprey.stores.artifact_store import initialize_artifact_store
+from tests.mcp_server.conftest import assert_raises_error, get_tool_fn
+
+_MODULE = "osprey.mcp_server.workspace.tools.focus_tools"
+
+
+@pytest.fixture
+def store(tmp_path):
+    return initialize_artifact_store(workspace_root=tmp_path / "_agent_data")
+
+
+@pytest.fixture
+def entry(store):
+    return store.save_file(
+        file_content=b"<html></html>",
+        filename="plot.html",
+        artifact_type="plot_html",
+        title="Test plot",
+    )
+
+
+@pytest.fixture
+def _gallery_url():
+    with patch(f"{_MODULE}.gallery_url", return_value="http://127.0.0.1:8086"):
+        yield
+
+
+def _focus_fn():
+    from osprey.mcp_server.workspace.tools.focus_tools import artifact_focus
+
+    return get_tool_fn(artifact_focus)
+
+
+def _pin_fn():
+    from osprey.mcp_server.workspace.tools.focus_tools import artifact_pin
+
+    return get_tool_fn(artifact_pin)
+
+
+class TestArtifactFocus:
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_success_when_gallery_accepts(self, entry, _gallery_url):
+        with patch(
+            f"{_MODULE}._post_json_with_response",
+            return_value=(200, {"status": "ok", "artifact_id": entry.id}),
+        ):
+            result = json.loads(await _focus_fn()(artifact_id=entry.id))
+        assert result["status"] == "success"
+        assert result["artifact_id"] == entry.id
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_error_when_gallery_unreachable(self, entry, _gallery_url):
+        with patch(
+            f"{_MODULE}._post_json_with_response",
+            side_effect=urllib.error.URLError("connection refused"),
+        ):
+            with assert_raises_error(error_type="gallery_unreachable"):
+                await _focus_fn()(artifact_id=entry.id)
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_error_when_gallery_rejects(self, entry, _gallery_url):
+        """A gallery 404 means the user never saw the focus — never claim success."""
+        with patch(
+            f"{_MODULE}._post_json_with_response",
+            return_value=(404, {"detail": f"Artifact {entry.id} not found"}),
+        ):
+            with assert_raises_error(error_type="gallery_error"):
+                await _focus_fn()(artifact_id=entry.id)
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_unknown_artifact_is_not_found(self, store, _gallery_url):
+        with assert_raises_error(error_type="not_found"):
+            await _focus_fn()(artifact_id="nonexistent")
+
+
+class TestArtifactPin:
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_pin_reports_gallery_notified(self, entry, _gallery_url):
+        with patch(
+            f"{_MODULE}._post_json_with_response",
+            return_value=(200, {"status": "ok"}),
+        ):
+            result = json.loads(await _pin_fn()(artifact_id=entry.id))
+        assert result["status"] == "success"
+        assert result["pinned"] is True
+        assert result["gallery_notified"] is True
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_pin_persists_but_reports_failed_notify(self, store, entry, _gallery_url):
+        """Pin lands in the shared index even when the gallery POST fails."""
+        with patch(
+            f"{_MODULE}._post_json_with_response",
+            side_effect=urllib.error.URLError("connection refused"),
+        ):
+            result = json.loads(await _pin_fn()(artifact_id=entry.id))
+        assert result["status"] == "success"
+        assert result["pinned"] is True
+        assert result["gallery_notified"] is False
+        # Durable state is set regardless of the gallery being reachable.
+        assert store.get_entry(entry.id).pinned is True
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_pin_unknown_artifact_is_not_found(self, store, _gallery_url):
+        with assert_raises_error(error_type="not_found"):
+            await _pin_fn()(artifact_id="nonexistent")

--- a/tests/mcp_server/workspace/test_session_summary.py
+++ b/tests/mcp_server/workspace/test_session_summary.py
@@ -19,23 +19,22 @@ def _get_session_summary():
 
 
 @pytest.fixture
-def workspace(tmp_path, monkeypatch):
+def workspace(tmp_path):
     """Set up a temporary workspace with an artifacts dir."""
     ws = tmp_path / "_agent_data"
     ws.mkdir()
     (ws / "artifacts").mkdir()
-    monkeypatch.setenv("OSPREY_WORKSPACE", str(ws))
-    monkeypatch.setattr(
-        "osprey.mcp_server.workspace.tools.session_summary.resolve_workspace_root",
-        lambda: ws,
-    )
     return ws
 
 
 @pytest.fixture
 def art_store(workspace):
-    """Initialize an artifact store in the test workspace."""
-    return initialize_artifact_store(workspace)
+    """Initialize the ArtifactStore singleton in the test workspace.
+
+    The tool reads the singleton (``get_artifact_store``), so the store must
+    be initialized rather than monkeypatched onto a workspace resolver.
+    """
+    return initialize_artifact_store(workspace_root=workspace)
 
 
 class TestSessionSummaryEmpty:


### PR DESCRIPTION
## Summary

Artifacts saved during a resumed web-terminal session could vanish from the artifact gallery: the session sets `OSPREY_SESSION_ID`, which made every MCP server root its `ArtifactStore` at the session-relocated path `_agent_data/sessions/<id>/`, while the gallery daemon serves the shared `_agent_data/artifacts/` store. The plot existed on disk but the gallery never saw it — and `artifact_focus`/`artifact_pin` masked the failure by returning success unconditionally.

## Changes

- **Root all artifact stores at the shared data root** (`resolve_shared_data_root()`): the MCP-server singleton (`initialize_workspace_singletons` — parameter removed so a session-scoped root cannot be reintroduced), the `ServerLauncher` daemon app factories (the gallery can be auto-launched from a session-scoped process on first save), and the ad-hoc stores in `session_summary`/`archiver_downsample`. Session isolation stays at the index level via `ArtifactEntry.session_id`, unchanged and already stamped at save time.
- **Honest gallery reporting:** `artifact_focus` now raises `gallery_unreachable`/`gallery_error` when the gallery can't be reached or rejects the request (its entire effect is gallery-side), with the artifact's direct file path as a fallback suggestion. `artifact_pin` persists the flag in the shared index first and reports `gallery_notified` in its response.
- Corrected comments that documented the old relocation behavior.

## Testing

- New regression tests: `tests/mcp_server/test_startup_singletons.py` (store stays on the shared root with `OSPREY_SESSION_ID` set; entries carry the session tag; launcher hands daemons the shared root) and `tests/mcp_server/workspace/test_focus_tools.py` (focus/pin gallery-failure contract).
- Full fast suite green locally (6863+ passed).