### PR TITLE
feat(benchmark): split e2e matrix into agentic/harness lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ## [Unreleased]
 
+### Changed
+
+- The model-benchmark matrix now scores two lanes separately: `agentic_benchmark`
+  marks genuine model-capability e2e tests (the headline pass rate) and
+  `harness_benchmark` marks model-independent safety/plumbing assertions, so
+  harness passes no longer pad a model's capability score. Every in-scope e2e
+  test must declare its lane (gated per matrix cell and in CI); 19 non-LLM e2e
+  files moved to the matrix exclusion list. The `e2e_benchmark` marker was
+  renamed to `channel_finder_benchmark` to say what it actually covers.
+
 ### Fixed
 
 - ARIEL logbook ingestion no longer skips an otherwise-valid entry when the source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -308,7 +308,7 @@ markers = [
     "integration: Integration tests (real external services)",
     "e2e: End-to-end workflow tests - WARNING: Use 'pytest tests/e2e/' not '-m e2e' (see tests/e2e/README.md)",
     "e2e_smoke: Quick smoke tests for critical workflows",
-    "e2e_benchmark: Channel finder benchmark validation tests",
+    "channel_finder_benchmark: Channel finder benchmark validation tests",
     "e2e_tutorial: Tutorial workflow validation tests",
     "agentic_benchmark: Model-capability lane of the benchmark matrix — genuine agentic tasks (multi-tool reasoning, judged answers) where the model-under-test can fail",
     "harness_benchmark: Harness-integrity lane of the benchmark matrix — an agent runs but the assertion is model-independent OSPREY behavior (safety hooks, approval flow, plumbing)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,6 +310,8 @@ markers = [
     "e2e_smoke: Quick smoke tests for critical workflows",
     "e2e_benchmark: Channel finder benchmark validation tests",
     "e2e_tutorial: Tutorial workflow validation tests",
+    "agentic_benchmark: Model-capability lane of the benchmark matrix — genuine agentic tasks (multi-tool reasoning, judged answers) where the model-under-test can fail",
+    "harness_benchmark: Harness-integrity lane of the benchmark matrix — an agent runs but the assertion is model-independent OSPREY behavior (safety hooks, approval flow, plumbing)",
     "slow: Tests that take significant time",
     "browser: Real-browser Playwright tests (requires chromium; skips if absent)",
     "requires_api: Tests that require API credentials",

--- a/scripts/benchmark/README.md
+++ b/scripts/benchmark/README.md
@@ -75,8 +75,27 @@ set; nothing in them assumes a particular provider, key file, or machine.
 | `matrix.py [--config FILE] [--only SUBSTR] [--provider P] [--parallel N] [--dry-run]` | parse `matrix.yaml`, expand the seed-major grid, and run one isolated worker per not-yet-done cell. **Resumable** — cells whose summary json exists are skipped. Writes the `results/matrix.log` markers the live dashboard watches. |
 | `matrix.yaml` | the whole run, declaratively (providers, models, seeds, budgets, judges). |
 | `matrix_dashboard.py --results-dir DIR --out FILE` | render `results/*.json` → a self-contained `dashboard.html` (per-model summary + per-test heatmap). |
-| `check_e2e_coverage.py` | derive the pytest `--ignore` list from `matrix_e2e_config.json` and warn if the run stops covering the full e2e kit minus the explicit, documented exclusions. |
+| `check_e2e_coverage.py` | derive the pytest `--ignore` list from `matrix_e2e_config.json` and warn if the run stops covering the full e2e kit minus the explicit, documented exclusions. With `--check-lanes` it is a **gate** (run per cell by the worker): every in-scope test must carry exactly one benchmark-lane marker. |
 | `matrix_e2e_config.json` | single source of truth for the excluded e2e files (each with a reason). |
+
+### Benchmark lanes
+
+Every e2e test in matrix scope declares — via a pytest marker — what its
+pass/fail measures:
+
+- `agentic_benchmark` — **capability lane**: genuine agentic tasks (multi-tool
+  reasoning, judged answers) where the model under test can fail. This is the
+  dashboard's headline pass rate.
+- `harness_benchmark` — **harness-integrity lane**: an agent runs, but the
+  assertion is model-independent OSPREY behavior (safety hooks block the write,
+  approval flow fires, plumbing works). Scored separately so its near-constant
+  passes never pad a model's capability number.
+
+Each cell writes a `results/<model>__seed<seed>.lanes.json` manifest at pytest
+collection time (`OSPREY_E2E_LANES`, see `tests/e2e/conftest.py`); the dashboard
+joins outcomes against it. Markers on the tests are the single source of truth —
+an unmarked in-scope test fails the `--check-lanes` gate at cell startup, so the
+scope can never silently drift.
 
 ## Layer B — operator/site glue (examples to copy & adapt)
 

--- a/scripts/benchmark/check_e2e_coverage.py
+++ b/scripts/benchmark/check_e2e_coverage.py
@@ -16,15 +16,76 @@ With ``--print-ignore-args`` it prints the ``--ignore=<path>`` tokens to STDOUT
 so the bash runner can splice them straight into its pytest invocation —
 keeping the exclusion list single-sourced in the JSON config.
 
-Always exits 0: this is a warning, never a gate (per design).
+With ``--check-lanes`` it additionally collects the in-scope suite (subprocess
+``pytest --collect-only`` with the exclusion ``--ignore``s, using the
+``OSPREY_E2E_LANES`` manifest hook in tests/e2e/conftest.py) and verifies every
+collected test carries EXACTLY ONE benchmark-lane marker — ``agentic_benchmark``
+(model-capability score) or ``harness_benchmark`` (harness-integrity score).
+This closes the drift hole where a new e2e file silently joins the matrix scope
+without declaring what its pass/fail measures.
+
+Exit code: 0 in the default/audit modes (warnings only, per design) — but
+``--check-lanes`` IS a gate and exits 1 on unmarked or double-marked tests, so
+the matrix runner refuses to score a suite whose lane split is ambiguous.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
+
+
+def check_lanes(root: Path, excluded: dict[str, str]) -> list[str]:
+    """Collect the in-scope suite and return lane-marker violations (empty = OK).
+
+    Runs ``pytest tests/e2e/ --collect-only`` in a subprocess with the same
+    ``--ignore`` set the matrix runner uses, pointing ``OSPREY_E2E_LANES`` at a
+    temp manifest so the conftest hook records each collected nodeid's lane.
+    Collection failure is itself a violation — the matrix could not run either.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        lanes_path = Path(td) / "lanes.json"
+        cmd = [
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/e2e/",
+            "--collect-only",
+            "-q",
+            "-p",
+            "no:cacheprovider",
+            "-o",
+            "addopts=",
+            *[f"--ignore={p}" for p in excluded],
+        ]
+        env = {**os.environ, "OSPREY_E2E_LANES": str(lanes_path)}
+        proc = subprocess.run(cmd, cwd=root, env=env, capture_output=True, text=True)
+        if not lanes_path.exists():
+            tail = (proc.stdout + proc.stderr)[-800:]
+            return [f"lane collection produced no manifest (rc={proc.returncode}): {tail}"]
+        lanes = json.loads(lanes_path.read_text(encoding="utf-8"))
+
+    violations = []
+    unmarked = sorted(n for n, lane in lanes.items() if lane == "unmarked")
+    double = sorted(n for n, lane in lanes.items() if lane == "both")
+    if unmarked:
+        violations.append(
+            f"{len(unmarked)} in-scope test(s) carry NO benchmark-lane marker — add "
+            "@pytest.mark.agentic_benchmark or @pytest.mark.harness_benchmark (or add the "
+            "file to excluded_files in matrix_e2e_config.json):"
+        )
+        violations.extend(f"  {n}" for n in unmarked)
+    if double:
+        violations.append(f"{len(double)} test(s) carry BOTH lane markers — pick one:")
+        violations.extend(f"  {n}" for n in double)
+    if not lanes:
+        violations.append("lane manifest is empty — collection found no in-scope tests")
+    return violations
 
 
 def main() -> int:
@@ -39,6 +100,12 @@ def main() -> int:
         "--print-ignore-args",
         action="store_true",
         help="print `--ignore=<path>` tokens to stdout for the runner to consume",
+    )
+    ap.add_argument(
+        "--check-lanes",
+        action="store_true",
+        help="collect the in-scope suite and GATE (exit 1) on tests missing a "
+        "benchmark-lane marker (agentic_benchmark/harness_benchmark)",
     )
     args = ap.parse_args()
 
@@ -89,6 +156,17 @@ def main() -> int:
     if args.print_ignore_args:
         for path in excluded:
             print(f"--ignore={path}")
+
+    if args.check_lanes:
+        violations = check_lanes(root, excluded)
+        for v in violations:
+            print(f"LANE-GATE: {v}", file=sys.stderr)
+        if violations:
+            return 1
+        print(
+            "[e2e-coverage] lane markers OK — every in-scope test declares its lane.",
+            file=sys.stderr,
+        )
 
     return 0
 

--- a/scripts/benchmark/matrix_dashboard.py
+++ b/scripts/benchmark/matrix_dashboard.py
@@ -153,6 +153,8 @@ def load(results_dir: str) -> dict:
     runs = {}
     # completed runs: authoritative summary parsed from junit at end of run
     for f in glob.glob(os.path.join(results_dir, "*__seed*.json")):
+        if f.endswith(".lanes.json"):
+            continue  # per-cell lane manifest, not a run summary (load_lanes reads it)
         try:
             d = json.load(open(f))
         except Exception:
@@ -210,6 +212,52 @@ def load(results_dir: str) -> dict:
             "_stalled": stalled,
         }
     return runs
+
+
+def load_lanes(results_dir: str) -> dict[tuple, str]:
+    """(file, qualname) -> 'agentic' | 'harness', unioned across every per-cell
+    ``*.lanes.json`` manifest in the results dir.
+
+    Each matrix cell writes a manifest at collection time (tests/e2e/conftest.py,
+    ``OSPREY_E2E_LANES``) mapping pytest nodeids to their benchmark lane, derived
+    live from the ``agentic_benchmark``/``harness_benchmark`` markers — so the
+    markers on the tests are the single source of truth and this map can never
+    drift from the code. Manifests are identical across cells (same checkout);
+    unioning simply tolerates missing/partial files. Empty result = no manifest
+    yet (results predate the lane split) → the dashboard falls back to the
+    blended single-score rendering. The invalid 'both' state maps to 'agentic'
+    here only for display robustness; the runner's lane gate refuses to produce
+    results in that state.
+    """
+    lanes: dict[tuple, str] = {}
+    for f in glob.glob(os.path.join(results_dir, "*.lanes.json")):
+        try:
+            manifest = json.load(open(f))
+        except Exception:
+            continue
+        for nodeid, lane in manifest.items():
+            if lane in ("agentic", "both"):
+                lanes[canon_name(nodeid)] = "agentic"
+            elif lane == "harness":
+                lanes[canon_name(nodeid)] = "harness"
+    return lanes
+
+
+def lane_conclusive(d: dict, lane_map: dict[tuple, str], lane: str) -> tuple[int, int]:
+    """conclusive() restricted to one lane: (passed, denominator) over the cell's
+    tests whose canonical name maps to ``lane``. Tests absent from the manifest
+    (stale results of renamed tests) count toward neither lane."""
+    p = den = 0
+    for t in d.get("tests", []):
+        if lane_map.get(canon_name(t["name"])) != lane:
+            continue
+        o = t.get("outcome")
+        if o == "passed":
+            p += 1
+            den += 1
+        elif o in ("failed", "timeout", "error"):
+            den += 1
+    return p, den
 
 
 def parse_progress(results_dir: str):
@@ -422,6 +470,10 @@ def main() -> int:
     # excluded still carry its tests, so strip them here to match the footer.
     exclusions = load_exclusions(args.config)  # (rel_path, reason); rel_path == canon_name key
     apply_exclusions(runs, {rel for rel, _ in exclusions})
+    # Benchmark-lane manifest (marker-derived). Non-empty → score the capability
+    # (agentic_benchmark) and harness (harness_benchmark) lanes separately; empty
+    # (results predate the lane split) → legacy blended rendering.
+    lane_map = load_lanes(args.results_dir)
     started, ended, matrix_done = parse_progress(args.results_dir)
     running = started - ended  # combos START-ed but not END-ed in matrix.log
     # A combo with a finalized .json is done even if the driver died before
@@ -557,16 +609,27 @@ def main() -> int:
 
     # ---- model x seed matrix (full outcome breakdown per cell) ----
     H.append("<h2>Outcome breakdown by model × seed</h2>")
-    H.append(
-        "<p class=sub>Each cell shows the full mix for one run — pass% "
-        "(passed / passed+failed+timeout+error; a <b>timeout counts as a failure</b>, only skips "
-        "are excluded) plus a stacked bar and counts (✓ pass · ✗ fail · ⧗ timeout · ∅ skip · ! error).</p>"
-    )
+    if lane_map:
+        H.append(
+            "<p class=sub>The headline pass% per cell is the <b>capability lane</b> — the "
+            "<code>agentic_benchmark</code>-marked tests where the model itself can fail "
+            "(passed / passed+failed+timeout+error; a <b>timeout counts as a failure</b>, only skips "
+            "are excluded). The <i>harness</i> line below it scores the "
+            "<code>harness_benchmark</code> lane (model-independent OSPREY safety/plumbing "
+            "assertions) separately, so harness passes can never inflate a model's capability "
+            "score. Bar and counts show the full outcome mix across both lanes.</p>"
+        )
+    else:
+        H.append(
+            "<p class=sub>Each cell shows the full mix for one run — pass% "
+            "(passed / passed+failed+timeout+error; a <b>timeout counts as a failure</b>, only skips "
+            "are excluded) plus a stacked bar and counts (✓ pass · ✗ fail · ⧗ timeout · ∅ skip · ! error).</p>"
+        )
     H.append("<table>")
     H.append(
         "<tr><th class=l>model</th>"
         + "".join(f"<th>seed {s}</th>" for s in SEEDS)
-        + "<th>mean pass</th></tr>"
+        + ("<th>mean capability</th></tr>" if lane_map else "<th>mean pass</th></tr>")
     )
     sep_done = False
     for m in models:
@@ -592,7 +655,16 @@ def main() -> int:
                     # as if it were final — mark it as still running.
                     H.append("<td style='background:#fafbfc'><span class=muted>running</span></td>")
                     continue
-                p_s, den_s = conclusive(d)
+                if lane_map:
+                    # Two-lane scoring: headline = capability lane only; the
+                    # harness lane renders as its own subline so its (near-
+                    # constant) passes never pad the capability number.
+                    p_s, den_s = lane_conclusive(d, lane_map, "agentic")
+                    hp, hden = lane_conclusive(d, lane_map, "harness")
+                    harness_line = f"<div class=muted>harness {hp}/{hden}</div>" if hden else ""
+                else:
+                    p_s, den_s = conclusive(d)
+                    harness_line = ""
                 fr = (p_s / den_s) if den_s else None
                 if fr is not None and not d.get("_partial"):
                     fracs.append(fr)  # mean is over COMPLETED seeds only
@@ -607,6 +679,7 @@ def main() -> int:
                     tag = f"<div class=muted>{d['total']}t · {d['total_duration_s'] // 60}m</div>"
                 H.append(
                     f"<td><div style='font-weight:600'>{pct(p_s, den_s)}</div>"
+                    f"{harness_line}"
                     f"<div style='display:flex;justify-content:center;margin:3px 0'>{stacked_bar(c)}</div>"
                     f"<div class=muted>{counts_text(c)}</div>"
                     f"{tag}</td>"
@@ -630,29 +703,53 @@ def main() -> int:
         "(green pass · red fail · orange timeout · yellow skip · purple error · grey pending). "
         "Lets you spot a test a model passes once but times out on another seed.</p>"
     )
-    H.append(
-        "<table><tr><th class=l>test</th>"
-        + "".join(f"<th>{html.escape(label(m))}</th>" for m in models)
-        + "</tr>"
-    )
-    for file in sorted(all_tests):
-        H.append(f"<tr class=filerow><td colspan={len(models) + 1}>{html.escape(file)}</td></tr>")
-        for short in sorted(all_tests[file]):
-            H.append(f"<tr><td class=l>{html.escape(short)}</td>")
-            for m in models:
-                seeds_map = test_results[(file, short)].get(m, {})
-                m_seeds = seeds_for(m, runs)
-                dots = []
-                for s in m_seeds:  # ref models render a single square, not 3
-                    o = seeds_map.get(s)
-                    col = OUTCOME_COLORS[o] if o in OUTCOME_COLORS else "#eaeef2"
-                    dots.append(
-                        f"<span title='seed{s}: {o or 'pending'}' style='display:inline-block;"
-                        f"width:13px;height:13px;border-radius:2px;margin:1px;background:{col}'></span>"
-                    )
-                H.append(f"<td>{''.join(dots)}</td>")
-            H.append("</tr>")
-    H.append("</table>")
+
+    def render_test_table(tests_by_file: dict[str, list]) -> None:
+        H.append(
+            "<table><tr><th class=l>test</th>"
+            + "".join(f"<th>{html.escape(label(m))}</th>" for m in models)
+            + "</tr>"
+        )
+        for file in sorted(tests_by_file):
+            H.append(
+                f"<tr class=filerow><td colspan={len(models) + 1}>{html.escape(file)}</td></tr>"
+            )
+            for short in sorted(tests_by_file[file]):
+                H.append(f"<tr><td class=l>{html.escape(short)}</td>")
+                for m in models:
+                    seeds_map = test_results[(file, short)].get(m, {})
+                    m_seeds = seeds_for(m, runs)
+                    dots = []
+                    for s in m_seeds:  # ref models render a single square, not 3
+                        o = seeds_map.get(s)
+                        col = OUTCOME_COLORS[o] if o in OUTCOME_COLORS else "#eaeef2"
+                        dots.append(
+                            f"<span title='seed{s}: {o or 'pending'}' style='display:inline-block;"
+                            f"width:13px;height:13px;border-radius:2px;margin:1px;background:{col}'></span>"
+                        )
+                    H.append(f"<td>{''.join(dots)}</td>")
+                H.append("</tr>")
+        H.append("</table>")
+
+    if lane_map:
+        # Partition per-test rows by benchmark lane so a reader never mistakes a
+        # harness-integrity row for a capability signal. Tests seen in results
+        # but absent from the manifest (renamed since the run) land in a
+        # trailing "unclassified" section rather than being hidden.
+        sections: dict[str, dict[str, list]] = {"agentic": {}, "harness": {}, "other": {}}
+        for file in all_tests:
+            for short in all_tests[file]:
+                lane = lane_map.get((file, short)) or "other"
+                sections[lane].setdefault(file, []).append(short)
+        H.append("<h2 style='font-size:15px'>Capability lane (agentic_benchmark)</h2>")
+        render_test_table(sections["agentic"])
+        H.append("<h2 style='font-size:15px'>Harness-integrity lane (harness_benchmark)</h2>")
+        render_test_table(sections["harness"])
+        if sections["other"]:
+            H.append("<h2 style='font-size:15px'>Unclassified (not in lane manifest)</h2>")
+            render_test_table(sections["other"])
+    else:
+        render_test_table(all_tests)
 
     # ---- methodology ----
     # Scope sentence is DERIVED: the model-driving count from the run data and the
@@ -673,6 +770,17 @@ def main() -> int:
         scope = (
             f"The <b>{n_txt}</b> model-driving e2e tests (the full <code>tests/e2e/</code> suite minus "
             f"the files that don't call an LLM and/or don't route through the model under test) are forced"
+        )
+    if lane_map:
+        n_a = sum(1 for v in lane_map.values() if v == "agentic")
+        n_h = sum(1 for v in lane_map.values() if v == "harness")
+        scope += (
+            f" — split into a <b>{n_a}-test capability lane</b> "
+            f"(<code>agentic_benchmark</code>: multi-step agentic tasks the model itself can fail; "
+            f"the headline score) and a <b>{n_h}-test harness-integrity lane</b> "
+            f"(<code>harness_benchmark</code>: model-independent safety/plumbing assertions, scored "
+            f"separately so they never pad the capability number), with lane membership declared "
+            f"by pytest markers on the tests and re-derived from live collection every cell —"
         )
     H.append(
         "<footer><b>Methodology.</b> " + scope + " onto each "

--- a/scripts/benchmark/matrix_e2e_config.json
+++ b/scripts/benchmark/matrix_e2e_config.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Single source of truth for the model-matrix e2e scope (issue #259). The custom matrix runners (run_e2e_for_model.sh) build their pytest --ignore list from `excluded_files` here, and check_e2e_coverage.py validates at startup that the runner covers the FULL tests/e2e/ kit except these explicit exclusions — emitting a warning otherwise. Edit exclusions HERE, not in the runner scripts.",
+  "_comment": "Single source of truth for the model-matrix e2e scope (issue #259). The custom matrix runners (run_e2e_for_model.sh) build their pytest --ignore list from `excluded_files` here, and check_e2e_coverage.py validates at startup that the runner covers the FULL tests/e2e/ kit except these explicit exclusions — emitting a warning otherwise. Edit exclusions HERE, not in the runner scripts. Every test NOT excluded here must carry exactly one benchmark-lane marker (agentic_benchmark = capability score, harness_benchmark = harness-integrity score) — enforced by check_e2e_coverage.py --check-lanes at cell startup and by tests/benchmark/test_matrix_lanes.py in CI.",
   "suite_root": "tests/e2e",
   "excluded_files": [
     {
@@ -53,6 +53,82 @@
     {
       "path": "tests/e2e/test_dispatch_tutorial.py",
       "reason": "Exercises the dispatch pipeline (webhook -> dispatcher -> worker -> SDK round-trip -> persistence), not model capability — the agent task is hello-world level (one-sentence reply, summarize a payload, save a stub report), so any responding model passes and it measures nothing about the model-under-test. Compounding this, its build fixture is pinned to als-apg/haiku and ignores OSPREY_E2E_FORCE_MODEL; under CBORG cells the als-apg key is shimmed to CBORG, so the worker agent hits the real als-apg endpoint with a wrong credential and hangs to the 300s worker timeout — a fixed ~3-test infra penalty per cell."
+    },
+    {
+      "path": "tests/e2e/test_bluesky_catalog_e2e.py",
+      "reason": "Real-container bluesky-bridge deploy driven via raw HTTP (plan catalog discovery + launch/read); no LLM call anywhere."
+    },
+    {
+      "path": "tests/e2e/test_bluesky_deploy.py",
+      "reason": "Docker build/deploy smoke for the bluesky-bridge container (loopback bind, token mint, image content, mock scan) via docker + raw HTTP; no LLM."
+    },
+    {
+      "path": "tests/e2e/test_bluesky_panels_deploy.py",
+      "reason": "VA + bridge + bluesky-panels sidecar container stack exercised via raw HTTP; neither service calls an LLM."
+    },
+    {
+      "path": "tests/e2e/test_bluesky_sandbox_escape_e2e.py",
+      "reason": "Authoring-sandbox validator/load-gate/launch-gate proofs using hardcoded plan bodies over HTTP plus independent Channel Access reads; no agent session runs."
+    },
+    {
+      "path": "tests/e2e/test_deploy_lifecycle.py",
+      "reason": "Real-container deploy-lifecycle mechanics (up/seed/decommission/prune/nuke); no LLM anywhere."
+    },
+    {
+      "path": "tests/e2e/test_dispatch_allowlist_parity.py",
+      "reason": "Build fixture pinned to als-apg/haiku via subprocess `osprey build`; the dispatch worker never passes through _apply_e2e_overrides, so OSPREY_E2E_FORCE_MODEL is ignored — same fixture pattern and CBORG wrong-credential hang as test_dispatch_tutorial.py."
+    },
+    {
+      "path": "tests/e2e/test_dispatch_deploy_render.py",
+      "reason": "Pure `osprey deploy build` compose-template rendering — no Docker, no provider token, no LLM call of any kind."
+    },
+    {
+      "path": "tests/e2e/test_dispatch_overlay_visibility.py",
+      "reason": "Full Docker image build + deploy (dockerbuild marker; skips without Docker), and the in-container agent runs the baked-in als-apg/haiku project config, so OSPREY_E2E_FORCE_MODEL cannot reach it."
+    },
+    {
+      "path": "tests/e2e/test_grid_scan_roundtrip.py",
+      "reason": "Non-agentic HTTP round-trip against a Docker-deployed VA+bridge stack; the test itself drives POST /runs and asserts grid data shape — no LLM call anywhere."
+    },
+    {
+      "path": "tests/e2e/test_in_context_backend.py",
+      "reason": "Own hardcoded provider/model axis (als-apg/cborg/anthropic env-key preference with fixed haiku wire ids) — bypasses OSPREY_E2E_FORCE_MODEL."
+    },
+    {
+      "path": "tests/e2e/test_multi_user_demo.py",
+      "reason": "Multi-user-demo deploy topology and rendered write-posture/config assertions with a fake placeholder API key — no agent session ever runs."
+    },
+    {
+      "path": "tests/e2e/test_openobserve_telemetry.py",
+      "reason": "Docker deploy + synthetic OTLP ingest with no LLM; the one live-agent smoke hardcodes als-apg/haiku in config and never routes through the model-under-test."
+    },
+    {
+      "path": "tests/e2e/test_orm_roundtrip.py",
+      "reason": "Non-agentic ORM round-trip: the test constructs the orm plan request over HTTP and cross-checks the response matrix against the lattice model oracle — no LLM call anywhere."
+    },
+    {
+      "path": "tests/e2e/test_tiled_roundtrip.py",
+      "reason": "Deploy/persistence smoke: demo grid_scan over HTTP, bridge container restart, identical-data assertion via the Tiled catalog — no LLM call anywhere."
+    },
+    {
+      "path": "tests/e2e/test_va_substrate_equivalence.py",
+      "reason": "Virtual Accelerator + Bluesky bridge container substrate proofs (CA reads/writes, scan plans, fault divergence) — no LLM at all."
+    },
+    {
+      "path": "tests/e2e/web_terminals/test_loopback_chokepoint.py",
+      "reason": "No LLM anywhere: launches `osprey web` with --shell true (PTY runs /usr/bin/true, never spawns an agent) and asserts TCP bind behavior via raw socket connects."
+    },
+    {
+      "path": "tests/e2e/web_terminals/test_prefix_routing.py",
+      "reason": "Fully in-process FastAPI TestClient checks of URL-prefix routing/injection plus rendered-nginx text assertions; no LLM or agent session anywhere."
+    },
+    {
+      "path": "tests/e2e/web_terminals/test_scaffold_render_roundtrip.py",
+      "reason": "Deterministic deploy-generator checks: render/lint library calls plus an `osprey scaffold` CLI subprocess; no LLM involved."
+    },
+    {
+      "path": "tests/e2e/web_terminals/test_skills_overlay_discovery.py",
+      "reason": "Runs the claude CLI with a deliberately bogus API key and reads only the pre-model stream-json init record's skills list — no model is ever contacted."
     }
   ],
   "baseline_expected_run_min": 15

--- a/scripts/benchmark/run_e2e_for_model.sh
+++ b/scripts/benchmark/run_e2e_for_model.sh
@@ -58,6 +58,10 @@ JSON="$REPO/results/${SAFE}__seed${SEED}.json"
 # so the dashboard fills in mid-run. Fresh file per run.
 export OSPREY_E2E_LIVE="$REPO/results/${SAFE}__seed${SEED}.live.jsonl"
 : > "$OSPREY_E2E_LIVE"
+# benchmark-lane manifest (conftest writes nodeid -> agentic/harness at collection
+# time). The dashboard joins outcomes against it to score the capability lane
+# (agentic_benchmark) separately from the harness-integrity lane.
+export OSPREY_E2E_LANES="$REPO/results/${SAFE}__seed${SEED}.lanes.json"
 
 echo ">> model=$MODEL seed=$SEED provider=$OSPREY_E2E_FORCE_PROVIDER route=$ROUTE" >&2
 echo ">> junit=$XML" >&2
@@ -130,6 +134,15 @@ START=$(date +%s)
 # Still `pytest tests/e2e/` (path) for registry-safe collection; --ignore prunes.
 IGNORE_ARGS="$("$PY" "$REPO/scripts/benchmark/check_e2e_coverage.py" \
   --repo-root "$REPO" --config "$REPO/scripts/benchmark/matrix_e2e_config.json" --print-ignore-args | tr '\n' ' ')"
+# Lane gate: refuse to run (and score) a suite where any in-scope test is
+# missing its agentic_benchmark/harness_benchmark marker — an unmarked test
+# would silently pollute the capability score the matrix exists to measure.
+if ! "$PY" "$REPO/scripts/benchmark/check_e2e_coverage.py" \
+    --repo-root "$REPO" --config "$REPO/scripts/benchmark/matrix_e2e_config.json" \
+    --check-lanes >/dev/null; then
+  echo "FATAL: benchmark lane markers incomplete (see LANE-GATE lines above)." >&2
+  exit 2
+fi
 # shellcheck disable=SC2086  # intentional word-split of space-free --ignore tokens
 "$PY" -m pytest tests/e2e/ \
   $IGNORE_ARGS \

--- a/tests/benchmark/test_matrix_lanes.py
+++ b/tests/benchmark/test_matrix_lanes.py
@@ -1,0 +1,153 @@
+"""Benchmark-lane split tests (scripts/benchmark, tests/e2e lane markers).
+
+The model matrix scores two lanes separately:
+
+  * ``agentic_benchmark`` — model-capability tests (the headline score);
+  * ``harness_benchmark`` — model-independent OSPREY safety/plumbing assertions.
+
+Lane membership is declared by pytest markers on the e2e tests; each matrix
+cell re-derives a ``*.lanes.json`` manifest from live collection (conftest's
+``OSPREY_E2E_LANES`` hook), and the dashboard joins outcomes against it. Two
+invariants keep the split trustworthy:
+
+  1. every in-scope e2e test carries exactly one lane marker — gated by
+     ``check_e2e_coverage.py --check-lanes`` (also run at matrix-cell startup);
+  2. the dashboard's lane join handles both test-id formats and never mistakes
+     a lane manifest for a run summary.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_BENCH = _REPO / "scripts" / "benchmark"
+_CONFIG = _BENCH / "matrix_e2e_config.json"
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, _BENCH / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+dash = _load("matrix_dashboard")
+
+
+# ---------------------------------------------------------------------------
+# 1. The lane gate: every in-scope e2e test declares its lane
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_every_in_scope_e2e_test_declares_a_benchmark_lane():
+    """``check_e2e_coverage.py --check-lanes`` must pass against the real suite.
+
+    This is the CI half of the drift guard (the matrix runner runs the same
+    gate per cell): a new e2e file cannot silently join the matrix scope
+    without declaring whether its pass/fail measures model capability or
+    harness integrity. Collection runs in a subprocess — never in-process
+    (nested pytest against tests/e2e/ leaks registry state).
+    """
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(_BENCH / "check_e2e_coverage.py"),
+            "--repo-root",
+            str(_REPO),
+            "--config",
+            str(_CONFIG),
+            "--check-lanes",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert proc.returncode == 0, (
+        "lane gate failed — an in-scope e2e test is missing (or double-carries) its "
+        "agentic_benchmark/harness_benchmark marker:\n" + proc.stderr
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Dashboard lane join
+# ---------------------------------------------------------------------------
+
+_NODEID = "tests/e2e/claude_code/test_sdk_workflows.py::TestClaudeCodeSDKIntegration::test_a"
+_JUNIT = "tests.e2e.claude_code.test_sdk_workflows.TestClaudeCodeSDKIntegration::test_a"
+
+
+def test_load_lanes_joins_manifest_nodeids_to_junit_names(tmp_path):
+    """A lane recorded under the pytest NODEID must be found for the same test
+    named in JUnit dotted-classname form — the two formats the dashboard
+    ingests (live stream vs completed summary)."""
+    (tmp_path / "m__seed1.lanes.json").write_text(json.dumps({_NODEID: "agentic"}))
+    lanes = dash.load_lanes(str(tmp_path))
+    assert lanes[dash.canon_name(_NODEID)] == "agentic"
+    assert lanes[dash.canon_name(_JUNIT)] == "agentic"
+
+
+def test_lane_conclusive_scores_only_the_requested_lane(tmp_path):
+    """Capability pass-rate must count agentic-lane outcomes only; harness and
+    manifest-absent tests must not pad (or dilute) it. Timeouts count against
+    the denominator, skips never do."""
+    harness_id = "tests/e2e/claude_code/test_safety_writes.py::test_h"
+    stale_id = "tests/e2e/test_gone.py::test_renamed_since"
+    (tmp_path / "m__seed1.lanes.json").write_text(
+        json.dumps({_NODEID: "agentic", harness_id: "harness"})
+    )
+    lanes = dash.load_lanes(str(tmp_path))
+    cell = {
+        "tests": [
+            {"name": _JUNIT, "outcome": "passed"},
+            {"name": _NODEID.replace("test_a", "test_b"), "outcome": "timeout"},
+            {"name": harness_id, "outcome": "passed"},
+            {"name": stale_id, "outcome": "failed"},
+        ]
+    }
+    (tmp_path / "x.lanes.json").write_text(
+        json.dumps({_NODEID.replace("test_a", "test_b"): "agentic"})
+    )
+    lanes = dash.load_lanes(str(tmp_path))
+    assert dash.lane_conclusive(cell, lanes, "agentic") == (1, 2)  # pass + timeout
+    assert dash.lane_conclusive(cell, lanes, "harness") == (1, 1)
+    skipped_cell = {"tests": [{"name": _JUNIT, "outcome": "skipped"}]}
+    assert dash.lane_conclusive(skipped_cell, lanes, "agentic") == (0, 0)
+
+
+def test_load_skips_lane_manifests_in_results_dir(tmp_path):
+    """``load()`` globs ``*__seed*.json`` — a ``*__seed1.lanes.json`` manifest
+    matches that glob and must be skipped, not parsed as a run summary (it has
+    no 'model' key and used to crash the dashboard)."""
+    (tmp_path / "m__seed1.lanes.json").write_text(json.dumps({_NODEID: "agentic"}))
+    (tmp_path / "m__seed1.json").write_text(
+        json.dumps(
+            {
+                "model": "m",
+                "seed": 1,
+                "passed": 1,
+                "failed": 0,
+                "timeout": 0,
+                "skipped": 0,
+                "errors": 0,
+                "total": 1,
+                "tests": [{"name": _JUNIT, "outcome": "passed", "duration_s": 1.0}],
+            }
+        )
+    )
+    runs = dash.load(str(tmp_path))
+    assert set(runs) == {("m", 1)}
+
+
+def test_load_lanes_empty_dir_falls_back(tmp_path):
+    """No manifest (results predate the lane split) → empty map, which the
+    dashboard renders as the legacy blended single score."""
+    assert dash.load_lanes(str(tmp_path)) == {}

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -61,6 +61,26 @@ Running e2e tests together with unit tests can cause:
 - Service initialization conflicts
 - Async fixture lifecycle issues
 
+## Benchmark-lane markers (required for matrix-scope tests)
+
+The model-benchmark matrix (`scripts/benchmark/`) scores two lanes separately,
+declared by a pytest marker on every e2e test that is not in the matrix
+exclusion list (`scripts/benchmark/matrix_e2e_config.json`):
+
+- `@pytest.mark.agentic_benchmark` — the test is a genuine model-capability
+  task: the agent must choose and sequence tools, reason about results, and
+  produce an answer the assertions (or an LLM judge) actually evaluate. A weak
+  model plausibly fails it.
+- `@pytest.mark.harness_benchmark` — an agent runs, but the assertion is
+  model-independent OSPREY behavior (safety hook fires, write is blocked,
+  audit record written). Any responding model passes it.
+
+**When you add an e2e test**, either mark it with exactly one of these or add
+its file to the exclusion config with a reason. The lane gate
+(`scripts/benchmark/check_e2e_coverage.py --check-lanes`, also run as a unit
+test in `tests/benchmark/test_matrix_lanes.py` and at matrix-cell startup)
+fails on unmarked in-scope tests.
+
 ## Test Categories
 
 ### Tutorial Workflows (`test_tutorials.py`)

--- a/tests/e2e/claude_code/test_agent_delegation.py
+++ b/tests/e2e/claude_code/test_agent_delegation.py
@@ -67,6 +67,7 @@ def _is_ariel_db_available() -> bool:
 
 pytestmark = [
     pytest.mark.e2e,
+    pytest.mark.agentic_benchmark,
     pytest.mark.e2e_services,
     pytest.mark.slow,
     pytest.mark.requires_api,

--- a/tests/e2e/claude_code/test_audit_observability.py
+++ b/tests/e2e/claude_code/test_audit_observability.py
@@ -27,6 +27,8 @@ from tests.e2e.sdk_helpers import (
     run_sdk_query,
 )
 
+pytestmark = pytest.mark.agentic_benchmark
+
 
 class TestAuditObservability:
     """Natural workflow + transcript-based audit verification."""

--- a/tests/e2e/claude_code/test_channel_finder_mcp_benchmarks.py
+++ b/tests/e2e/claude_code/test_channel_finder_mcp_benchmarks.py
@@ -34,7 +34,7 @@ from tests.e2e.sdk_helpers import (
 
 pytestmark = [
     pytest.mark.e2e,
-    pytest.mark.e2e_benchmark,
+    pytest.mark.channel_finder_benchmark,
     pytest.mark.slow,
     pytest.mark.requires_als_apg,
     pytest.mark.skipif(not HAS_SDK, reason="claude_agent_sdk not installed"),

--- a/tests/e2e/claude_code/test_data_visualizer.py
+++ b/tests/e2e/claude_code/test_data_visualizer.py
@@ -22,6 +22,8 @@ from tests.e2e.sdk_helpers import (
     run_sdk_query,
 )
 
+pytestmark = pytest.mark.agentic_benchmark
+
 
 class TestDataVisualizerAgent:
     """E2E tests for the data-visualizer sub-agent."""

--- a/tests/e2e/claude_code/test_feedback_capture_e2e.py
+++ b/tests/e2e/claude_code/test_feedback_capture_e2e.py
@@ -13,6 +13,8 @@ import pytest
 
 from tests.e2e.sdk_helpers import combined_text, init_project, run_sdk_query_with_hooks
 
+pytestmark = pytest.mark.harness_benchmark
+
 
 @pytest.fixture(scope="module")
 def feedback_project(tmp_path_factory):

--- a/tests/e2e/claude_code/test_pyat_specialist_e2e.py
+++ b/tests/e2e/claude_code/test_pyat_specialist_e2e.py
@@ -52,6 +52,7 @@ from tests.e2e.sdk_helpers import (
 
 pytestmark = [
     pytest.mark.e2e,
+    pytest.mark.agentic_benchmark,
     pytest.mark.requires_als_apg,
     pytest.mark.skipif(not HAS_SDK, reason="claude_agent_sdk not installed"),
     pytest.mark.skipif(not is_claude_code_available(), reason="claude CLI not available"),

--- a/tests/e2e/claude_code/test_safety_approval_e2e.py
+++ b/tests/e2e/claude_code/test_safety_approval_e2e.py
@@ -16,6 +16,8 @@ import pytest
 
 from tests.e2e.sdk_helpers import run_sdk_query_with_hooks
 
+pytestmark = pytest.mark.harness_benchmark
+
 # ---------------------------------------------------------------------------
 # 2a: channel_write triggers approval callback (selective + auto-approve)
 # ---------------------------------------------------------------------------

--- a/tests/e2e/claude_code/test_safety_error_guidance_e2e.py
+++ b/tests/e2e/claude_code/test_safety_error_guidance_e2e.py
@@ -19,6 +19,8 @@ import pytest
 
 from tests.e2e.sdk_helpers import combined_text, run_sdk_query_with_hooks
 
+pytestmark = pytest.mark.harness_benchmark
+
 # Keywords indicating Claude reported an error (expected behavior)
 ERROR_REPORT_KEYWORDS = [
     "error",

--- a/tests/e2e/claude_code/test_safety_kill_switch.py
+++ b/tests/e2e/claude_code/test_safety_kill_switch.py
@@ -12,6 +12,8 @@ import pytest
 
 from tests.e2e.sdk_helpers import run_sdk_query_with_hooks
 
+pytestmark = pytest.mark.harness_benchmark
+
 # ---------------------------------------------------------------------------
 # Scenario 9: Writes disabled — channel_write
 # ---------------------------------------------------------------------------

--- a/tests/e2e/claude_code/test_safety_python.py
+++ b/tests/e2e/claude_code/test_safety_python.py
@@ -16,6 +16,8 @@ import pytest
 
 from tests.e2e.sdk_helpers import run_sdk_query_with_hooks
 
+pytestmark = pytest.mark.harness_benchmark
+
 
 def _combined_text(result) -> str:
     """Combine all text blocks and tool results into a single searchable string."""

--- a/tests/e2e/claude_code/test_safety_reads.py
+++ b/tests/e2e/claude_code/test_safety_reads.py
@@ -18,6 +18,8 @@ import pytest
 
 from tests.e2e.sdk_helpers import run_sdk_query_with_hooks
 
+pytestmark = pytest.mark.harness_benchmark
+
 
 @pytest.mark.requires_api
 @pytest.mark.requires_als_apg

--- a/tests/e2e/claude_code/test_safety_writes.py
+++ b/tests/e2e/claude_code/test_safety_writes.py
@@ -12,6 +12,8 @@ import pytest
 
 from tests.e2e.sdk_helpers import run_sdk_query_with_hooks
 
+pytestmark = pytest.mark.harness_benchmark
+
 # ---------------------------------------------------------------------------
 # Scenario 2: Write within limits
 # ---------------------------------------------------------------------------

--- a/tests/e2e/claude_code/test_sdk_workflows.py
+++ b/tests/e2e/claude_code/test_sdk_workflows.py
@@ -38,6 +38,7 @@ class TestClaudeCodeSDKIntegration:
     # Test 1 — Smoke test: single tool call observability
     # -------------------------------------------------------------------
 
+    @pytest.mark.harness_benchmark
     @pytest.mark.flaky(
         reruns=2, reruns_delay=5
     )  # live SDK/provider smoke; absorb rare transient query errors
@@ -108,6 +109,7 @@ class TestClaudeCodeSDKIntegration:
     # where it stops after an intermediate sub-agent result. The deterministic
     # assertions below are correct (a real regression fails all reruns); the
     # rerun only absorbs that rare LLM nondeterminism.
+    @pytest.mark.agentic_benchmark
     @pytest.mark.flaky(reruns=2, reruns_delay=5)
     @pytest.mark.slow
     @pytest.mark.requires_api
@@ -212,6 +214,7 @@ class TestClaudeCodeSDKIntegration:
     # the weakest model. 15/15 local passes; one CI miss where the orchestrator
     # stopped after channel-finder without calling archiver_read. Rerun absorbs
     # that stochastic miss without weakening the strict assertions below.
+    @pytest.mark.agentic_benchmark
     @pytest.mark.flaky(reruns=2, reruns_delay=5)
     @pytest.mark.slow
     @pytest.mark.requires_api
@@ -337,6 +340,7 @@ class TestClaudeCodeSDKIntegration:
     # Multi-step agentic pipeline (archiver -> data-visualizer subagent). Same
     # stochastic-miss class as the other pipeline tests; rerun absorbs the rare
     # LLM nondeterminism while the strict viz/3D-code assertions still gate.
+    @pytest.mark.agentic_benchmark
     @pytest.mark.flaky(reruns=2, reruns_delay=5)
     @pytest.mark.slow
     @pytest.mark.requires_api

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -89,7 +89,9 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "e2e: End-to-end workflow tests (requires API keys, slow)")
     config.addinivalue_line("markers", "e2e_smoke: Quick smoke tests for critical workflows")
     config.addinivalue_line("markers", "e2e_tutorial: Tutorial workflow validation tests")
-    config.addinivalue_line("markers", "e2e_benchmark: Channel finder benchmark validation tests")
+    config.addinivalue_line(
+        "markers", "channel_finder_benchmark: Channel finder benchmark validation tests"
+    )
     config.addinivalue_line(
         "markers",
         "agentic_benchmark: Model-capability lane of the benchmark matrix — genuine agentic "

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -49,6 +49,40 @@ def pytest_runtest_logreport(report):
             pass
 
 
+def pytest_collection_finish(session):
+    """Write the benchmark-lane manifest (nodeid -> lane) when OSPREY_E2E_LANES is set.
+
+    The model-matrix runner points OSPREY_E2E_LANES at
+    ``results/<model>__seed<seed>.lanes.json``; the dashboard joins each test
+    outcome against this manifest to score the ``agentic_benchmark``
+    (model-capability) and ``harness_benchmark`` (harness-integrity) lanes
+    separately. Markers on the tests are the single source of truth — the
+    manifest is re-derived from live collection every cell, so it can never
+    drift. No-op unless the env var is set, so normal e2e runs are unaffected.
+    """
+    lanes_path = os.environ.get("OSPREY_E2E_LANES")
+    if not lanes_path:
+        return
+    lanes = {}
+    for item in session.items:
+        agentic = item.get_closest_marker("agentic_benchmark") is not None
+        harness = item.get_closest_marker("harness_benchmark") is not None
+        if agentic and harness:
+            lane = "both"  # invalid — check_e2e_coverage --check-lanes rejects it
+        elif agentic:
+            lane = "agentic"
+        elif harness:
+            lane = "harness"
+        else:
+            lane = "unmarked"
+        lanes[item.nodeid] = lane
+    try:
+        with open(lanes_path, "w") as f:
+            json.dump(lanes, f, indent=1)
+    except Exception:
+        pass
+
+
 def pytest_configure(config):
     """Register E2E markers and warn if tests are being run incorrectly."""
     # Register custom markers
@@ -56,6 +90,16 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "e2e_smoke: Quick smoke tests for critical workflows")
     config.addinivalue_line("markers", "e2e_tutorial: Tutorial workflow validation tests")
     config.addinivalue_line("markers", "e2e_benchmark: Channel finder benchmark validation tests")
+    config.addinivalue_line(
+        "markers",
+        "agentic_benchmark: Model-capability lane of the benchmark matrix — genuine agentic "
+        "tasks where the model-under-test can fail",
+    )
+    config.addinivalue_line(
+        "markers",
+        "harness_benchmark: Harness-integrity lane of the benchmark matrix — an agent runs "
+        "but the assertion is model-independent OSPREY behavior",
+    )
 
     # Warn if invoked with `-m e2e` from outside tests/e2e/ (causes registry leaks)
     if config.option.markexpr and "e2e" in config.option.markexpr:

--- a/tests/e2e/test_answer_provenance_scenario.py
+++ b/tests/e2e/test_answer_provenance_scenario.py
@@ -54,6 +54,7 @@ from tests.e2e.test_preset_agentic import _to_workflow_result
 # agentic path is flaky on shared runners and this is a local/advisory guard.
 pytestmark = [
     pytest.mark.e2e,
+    pytest.mark.agentic_benchmark,
     pytest.mark.requires_als_apg,
     pytest.mark.skipif(not HAS_SDK, reason="claude_agent_sdk not installed"),
     pytest.mark.skipif(

--- a/tests/e2e/test_bluesky_write_refused_e2e.py
+++ b/tests/e2e/test_bluesky_write_refused_e2e.py
@@ -34,6 +34,7 @@ from tests.e2e.sdk_helpers import HAS_SDK, init_project, is_claude_code_availabl
 
 pytestmark = [
     pytest.mark.e2e,
+    pytest.mark.harness_benchmark,
     pytest.mark.requires_als_apg,
     pytest.mark.skipif(not HAS_SDK, reason="claude_agent_sdk not installed"),
     pytest.mark.skipif(not is_claude_code_available(), reason="claude CLI not available"),

--- a/tests/e2e/test_corrector_limit_honest_refusal_scenario.py
+++ b/tests/e2e/test_corrector_limit_honest_refusal_scenario.py
@@ -83,6 +83,7 @@ from tests.e2e.test_preset_agentic import _to_workflow_result
 # this on CI runners where the SDK is installed but no system ``claude`` is.
 pytestmark = [
     pytest.mark.e2e,
+    pytest.mark.agentic_benchmark,
     pytest.mark.requires_als_apg,
     pytest.mark.skipif(not HAS_SDK, reason="claude_agent_sdk not installed"),
     # Mirrors the other multi-step agentic scenario tests: passes locally,

--- a/tests/e2e/test_facility_knowledge_e2e.py
+++ b/tests/e2e/test_facility_knowledge_e2e.py
@@ -47,6 +47,7 @@ from tests.e2e.sdk_helpers import (
 
 pytestmark = [
     pytest.mark.e2e,
+    pytest.mark.agentic_benchmark,
     pytest.mark.requires_als_apg,
     pytest.mark.skipif(not HAS_SDK, reason="claude_agent_sdk not installed"),
     pytest.mark.skipif(not is_claude_code_available(), reason="claude CLI not available"),

--- a/tests/e2e/test_health_mcp_smoke.py
+++ b/tests/e2e/test_health_mcp_smoke.py
@@ -42,6 +42,7 @@ from tests.e2e.sdk_helpers import (
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.e2e_smoke,
+    pytest.mark.agentic_benchmark,
     pytest.mark.requires_als_apg,
     pytest.mark.skipif(not HAS_SDK, reason="claude_agent_sdk not installed"),
     pytest.mark.skipif(not is_claude_code_available(), reason="claude CLI not available"),

--- a/tests/e2e/test_orm_agentic_scenario.py
+++ b/tests/e2e/test_orm_agentic_scenario.py
@@ -416,6 +416,7 @@ def _deployed_dual_fault_stack(tmp_path: Path, project_name: str) -> Iterator[Pa
     os.environ.get("GITHUB_ACTIONS") == "true",
     reason="needs a real Docker stack; not provisioned on CI runners",
 )
+@pytest.mark.agentic_benchmark
 @pytest.mark.flaky(reruns=2)  # multi-step agentic; absorb rare LLM stochastic misses
 @pytest.mark.asyncio
 async def test_orm_dual_fault_agentic_localizes_both_faults(
@@ -485,6 +486,7 @@ def _synthetic_dual_fault_trace() -> list[ToolTrace]:
     ]
 
 
+@pytest.mark.harness_benchmark  # offline grading-contract check; no model-under-test session
 def test_structural_floor_accepts_orbit_response_class_sequence() -> None:
     """Floor is decoupled from any literal plan_name -- only the device-class
     shape (correctors + detectors) and the draft -> launch -> read order
@@ -493,6 +495,7 @@ def test_structural_floor_accepts_orbit_response_class_sequence() -> None:
     _assert_orbit_response_scan_ran(result)  # must not raise
 
 
+@pytest.mark.harness_benchmark  # offline grading-contract check; no model-under-test session
 def test_structural_floor_rejects_non_orbit_response_plan() -> None:
     """A draft whose plan_args_patch carry no correctors/detectors pair (e.g. a
     generic n-d grid_scan over unrelated axes) must NOT satisfy the floor --
@@ -517,6 +520,7 @@ def test_structural_floor_rejects_non_orbit_response_plan() -> None:
         _assert_orbit_response_scan_ran(SDKWorkflowResult(tool_traces=traces))
 
 
+@pytest.mark.harness_benchmark  # offline grading-contract check; no model-under-test session
 def test_structural_floor_rejects_out_of_order_sequence() -> None:
     """draft/launch/read out of trace order (e.g. a read before the scan
     was ever launched) must NOT satisfy the floor."""
@@ -550,6 +554,7 @@ _CONTROL_CONCLUSION = (
 
 
 @pytest.mark.e2e
+@pytest.mark.harness_benchmark  # judge-contract check on its own provider axis, not the model-under-test
 @pytest.mark.requires_als_apg
 @pytest.mark.asyncio
 async def test_judge_discriminates_dual_fault_conclusions() -> None:

--- a/tests/e2e/test_preset_agentic.py
+++ b/tests/e2e/test_preset_agentic.py
@@ -120,6 +120,7 @@ async def _assert_approval_hook_fires(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.harness_benchmark
 @pytest.mark.asyncio
 async def test_hello_world_canonical_flow(tmp_path: Path) -> None:
     """Hello-world preset: agent reads the example mock channel.
@@ -151,6 +152,7 @@ async def test_hello_world_canonical_flow(tmp_path: Path) -> None:
     assert eval.passed, eval.reasoning
 
 
+@pytest.mark.agentic_benchmark
 @pytest.mark.asyncio
 async def test_control_assistant_channel_finder_flow(tmp_path: Path) -> None:
     """Control-assistant preset: agent uses the channel-finder pipeline.
@@ -184,6 +186,7 @@ async def test_control_assistant_channel_finder_flow(tmp_path: Path) -> None:
     assert eval.passed, eval.reasoning
 
 
+@pytest.mark.harness_benchmark
 @pytest.mark.asyncio
 async def test_hello_world_write_triggers_approval_hook(tmp_path: Path) -> None:
     """Hello-world write probe: agent sets a mock channel; approval hook fires.
@@ -205,6 +208,7 @@ async def test_hello_world_write_triggers_approval_hook(tmp_path: Path) -> None:
     )
 
 
+@pytest.mark.harness_benchmark
 @pytest.mark.asyncio
 async def test_control_assistant_write_triggers_approval_hook(tmp_path: Path) -> None:
     """Control-assistant write probe: same contract on the heavier preset."""

--- a/tests/e2e/test_query_cmd_e2e.py
+++ b/tests/e2e/test_query_cmd_e2e.py
@@ -47,6 +47,7 @@ from tests.e2e.sdk_helpers import HAS_SDK, init_project, is_claude_code_availabl
 
 pytestmark = [
     pytest.mark.e2e,
+    pytest.mark.harness_benchmark,
     pytest.mark.requires_als_apg,
     pytest.mark.skipif(not HAS_SDK, reason="claude_agent_sdk not installed"),
     pytest.mark.skipif(not is_claude_code_available(), reason="claude CLI not available"),

--- a/tests/e2e/test_query_write_refused_e2e.py
+++ b/tests/e2e/test_query_write_refused_e2e.py
@@ -37,6 +37,7 @@ from tests.e2e.sdk_helpers import (
 
 pytestmark = [
     pytest.mark.e2e,
+    pytest.mark.harness_benchmark,
     pytest.mark.requires_als_apg,
     pytest.mark.skipif(not HAS_SDK, reason="claude_agent_sdk not installed"),
     pytest.mark.skipif(not is_claude_code_available(), reason="claude CLI not available"),

--- a/tests/e2e/test_rf_cavity_correlation_scenario.py
+++ b/tests/e2e/test_rf_cavity_correlation_scenario.py
@@ -72,6 +72,7 @@ from tests.e2e.test_preset_agentic import (
 # on CI runners where the SDK is installed but no system ``claude`` is.
 pytestmark = [
     pytest.mark.e2e,
+    pytest.mark.agentic_benchmark,
     pytest.mark.requires_als_apg,
     pytest.mark.skipif(not HAS_SDK, reason="claude_agent_sdk not installed"),
     # Skipped on CI: needs a running ARIEL logbook postgres (seeded

--- a/tests/e2e/test_vacuum_burst_scenario.py
+++ b/tests/e2e/test_vacuum_burst_scenario.py
@@ -73,6 +73,7 @@ from tests.e2e.test_preset_agentic import (
 # on CI runners where the SDK is installed but no system ``claude`` is.
 pytestmark = [
     pytest.mark.e2e,
+    pytest.mark.agentic_benchmark,
     pytest.mark.requires_als_apg,
     pytest.mark.skipif(not HAS_SDK, reason="claude_agent_sdk not installed"),
     # Skipped on CI: needs a running ARIEL logbook postgres (seeded

--- a/tests/e2e/web_terminals/test_persona_permissions.py
+++ b/tests/e2e/web_terminals/test_persona_permissions.py
@@ -68,6 +68,7 @@ from tests.e2e.sdk_helpers import (
 
 pytestmark = [
     pytest.mark.e2e,
+    pytest.mark.harness_benchmark,
     pytest.mark.skipif(not HAS_SDK, reason="claude_agent_sdk not installed"),
     pytest.mark.skipif(not is_claude_code_available(), reason="Claude Code CLI not installed"),
 ]


### PR DESCRIPTION
## Summary

The model-benchmark matrix previously blended two very different kinds of e2e tests into one pass rate: genuine agentic tasks a weak model can fail, and harness-integrity checks (safety hooks, approval flow, plumbing) that any responding model passes. The near-constant harness passes padded every model's headline number.

This PR scores the two lanes separately, declared per test by a pytest marker:

- **`agentic_benchmark`** (21 tests) — model-capability lane: multi-tool reasoning, judged answers. This is the dashboard's headline pass rate.
- **`harness_benchmark`** (35 tests) — harness-integrity lane: an agent runs, but the assertion is model-independent OSPREY behavior. Scored on its own line.

## Changes

- Register both markers (`--strict-markers` enforced) and mark every in-scope e2e test with exactly one lane.
- Move 19 non-LLM deploy/plumbing e2e files to the matrix exclusion list (`matrix_e2e_config.json`), each with a documented reason.
- Each matrix cell writes a `*.lanes.json` manifest at pytest collection time (`OSPREY_E2E_LANES` in `tests/e2e/conftest.py`) — markers are the single source of truth, re-derived every run.
- **Drift gate**: `check_e2e_coverage.py --check-lanes` fails on any in-scope test with no lane marker or both; runs at matrix-cell startup (the runner aborts rather than produce ambiguous scores) and as a unit test (`tests/benchmark/test_matrix_lanes.py`).
- **Dashboard**: capability pass rate as the headline with a muted harness line, lane-split per-test heatmap, and a legacy blended view for pre-lane results.
- Rename the `e2e_benchmark` marker to `channel_finder_benchmark` — it only ever covered channel-finder benchmark validation.

## Verification

- Lane gate green: 21 agentic + 35 harness, 0 unmarked.
- All 34 `tests/benchmark/` unit tests pass; ruff clean; `bash -n` on the runner.
- Both dashboard variants rendered against real matrix results.