### PR TITLE
test(templates): honest hook coverage, preset hook fix, render invariants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage.json
 *.cover
 .hypothesis/
 .pytest_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ Compatibility is documented in release notes, not encoded in the version string.
   deploy/build semantics (`--force` preservation, `--dev` image builds, full
   subcommand list), telemetry now documented as on-by-default, MCP/executor error
   contracts, and the ARIEL web-interface module tables.
+- Presets that render Claude Code artifacts now ship the `osprey_focus_validate.py`
+  and `osprey_panels_context.py` hooks their `settings.json` already referenced;
+  existing rendered projects will be flagged stale and pick up the two hooks on
+  regeneration.
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -362,6 +362,12 @@ known-first-party = ["osprey", "configs", "applications", "interfaces", "deploym
 # Coverage configuration (if using pytest-cov)
 [tool.coverage.run]
 source = ["src", "interfaces", "deployment"]
+# Hooks ship as standalone scripts and are exercised by spawning them, so most of
+# their code runs in child processes. The subprocess patcher makes those children
+# measure themselves. It force-enables parallel data files; the explicit entry
+# below documents that rather than leaving it implicit.
+patch = ["subprocess"]
+parallel = true
 omit = [
     "*/tests/*",
     "*/__pycache__/*",

--- a/src/osprey/cli/templates/manifest.py
+++ b/src/osprey/cli/templates/manifest.py
@@ -60,6 +60,7 @@ REGEN_TRACKED_FILES = [
     ".claude/hooks/osprey_memory_guard.py",
     ".claude/hooks/osprey_focus_validate.py",
     ".claude/hooks/osprey_config_drift.py",
+    ".claude/hooks/osprey_panels_context.py",
     ".claude/rules/python-execution.md",
     ".claude/rules/control-system-safety.md",
     ".claude/skills/diagnose/SKILL.md",

--- a/src/osprey/profiles/presets/ariel-standalone.yml
+++ b/src/osprey/profiles/presets/ariel-standalone.yml
@@ -31,6 +31,8 @@ hooks:
   - notebook-update   # Sync CLAUDE.md notebook after each session
   - memory-guard      # Warn when context window approaches threshold
   - config-drift      # Warn at session start when config.yml drifted from generated artifacts
+  - focus-validate    # Strip stale artifact IDs from focus_state.txt on each prompt
+  - panels-context    # Inject the web terminal panel inventory into agent context
 
 rules:
   - error-handling      # Standard error handling and retry guidance

--- a/src/osprey/profiles/presets/channel-finder-standalone.yml
+++ b/src/osprey/profiles/presets/channel-finder-standalone.yml
@@ -39,6 +39,8 @@ hooks:
   - memory-guard      # Warn when context window approaches threshold
   - config-drift      # Warn at session start when config.yml drifted from generated artifacts
   - cf-feedback-capture  # Capture channel-finder accuracy feedback for tuning
+  - focus-validate    # Strip stale artifact IDs from focus_state.txt on each prompt
+  - panels-context    # Inject the web terminal panel inventory into agent context
 
 rules:
   - error-handling      # Standard error handling and retry guidance

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -36,6 +36,8 @@ hooks:
   - notebook-update   # Sync CLAUDE.md notebook after each session
   - cf-feedback-capture  # Capture channel-finder accuracy feedback for tuning
   - config-drift      # Warn at session start when config.yml drifted from generated artifacts
+  - focus-validate    # Strip stale artifact IDs from focus_state.txt on each prompt
+  - panels-context    # Inject the web terminal panel inventory into agent context
 
 rules:
   - safety              # Core safety rules: never write without approval

--- a/src/osprey/profiles/presets/hello-world.yml
+++ b/src/osprey/profiles/presets/hello-world.yml
@@ -23,6 +23,8 @@ hooks:
   - approval       # Gate hardware-write tool calls on human approval prompt
   - limits         # Enforce per-channel min/max limits before writes
   - config-drift   # Warn at session start when config.yml drifted from generated artifacts
+  - focus-validate # Strip stale artifact IDs from focus_state.txt on each prompt
+  - panels-context # Inject the web terminal panel inventory into agent context
 
 rules:
   - safety          # Core safety rules: never write without approval

--- a/src/osprey/profiles/presets/multi-user-demo.yml
+++ b/src/osprey/profiles/presets/multi-user-demo.yml
@@ -44,6 +44,8 @@ hooks:
   - memory-guard      # Warn when context window approaches threshold
   - notebook-update   # Sync CLAUDE.md notebook after each session
   - config-drift      # Warn at session start when config.yml drifted from generated artifacts
+  - focus-validate    # Strip stale artifact IDs from focus_state.txt on each prompt
+  - panels-context    # Inject the web terminal panel inventory into agent context
 
 rules:
   - safety              # Core safety rules: never write without approval

--- a/tests/cli/test_claude_regen.py
+++ b/tests/cli/test_claude_regen.py
@@ -7,6 +7,7 @@ safety hooks across regeneration cycles.
 
 import json
 import os
+import re
 
 import pytest
 import yaml
@@ -14,6 +15,29 @@ import yaml
 from osprey.build.claude_code_resolver import MANAGED_ENV_VARS
 from osprey.cli.templates import claude_code
 from osprey.cli.templates.manager import TemplateManager
+
+# Hook modules that are shipped into .claude/hooks/ as importable support code
+# rather than as hook entry points. They are deliberately absent from
+# settings.json and are excluded from the settings <-> hooks parity invariant.
+HOOK_LIBRARY_MODULES = {"osprey_hook_log.py"}
+
+_HOOK_BASENAME_RE = re.compile(r"osprey_[A-Za-z0-9_]+\.py")
+
+
+def _referenced_hook_basenames(settings: dict) -> dict[str, list[str]]:
+    """Map each ``osprey_*.py`` basename referenced in settings.json to its events.
+
+    Hook commands are shell strings whose shape varies by wiring route (quoted
+    absolute interpreter vs. literal ``python3``, trailing ``2>/dev/null || true``),
+    so the basename is extracted by pattern rather than by matching whole commands.
+    """
+    found: dict[str, list[str]] = {}
+    for event, entries in settings.get("hooks", {}).items():
+        for entry in entries:
+            for hook in entry.get("hooks", []):
+                for basename in _HOOK_BASENAME_RE.findall(hook.get("command", "")):
+                    found.setdefault(basename, []).append(event)
+    return found
 
 
 class TestBuildClaudeCodeContext:
@@ -347,6 +371,82 @@ class TestSafetyPreservation:
                 f"framework hook must launch via the resolved venv interpreter "
                 f"(absolute path), got: {cmd}"
             )
+
+    def test_every_settings_hook_reference_has_a_shipped_file(self, regen_project):
+        """Direction (a): settings.json never points at a hook that was not shipped.
+
+        A reference with no file behind it is a silently dead hook — Claude Code
+        runs the command, the interpreter fails to find the script, and (because
+        every framework hook command is fail-open) the event proceeds with the
+        guard absent. Nothing in the rendered project surfaces that, so this
+        invariant is the only place it shows up.
+
+        Hooks reach settings.json by three different routes, all of which land in
+        the same rendered ``hooks`` block and all of which this direction covers:
+
+        1. **Hardcoded template entries** — SessionStart and UserPromptSubmit
+           entries written literally into ``settings.json.j2``. These keep the
+           literal ``python3`` interpreter token and carry a
+           ``2>/dev/null || true`` suffix (the PreToolUse/PostToolUse loops, by
+           contrast, rewrite ``python3`` to the resolved venv interpreter).
+        2. **Server registry wiring** — ``hooks_pre`` / ``hooks_post`` rules
+           contributed by each enabled MCP server, plus the framework-level
+           pre/post rules.
+        3. **Frontmatter ``wiring: standalone``** — hooks whose own YAML
+           frontmatter declares the event and matcher tools, from which the
+           renderer builds the rule. Exactly two hooks use this route today:
+           ``osprey_memory_guard`` and ``osprey_notebook_update``.
+        """
+        settings = json.loads((regen_project / ".claude" / "settings.json").read_text())
+        hooks_dir = regen_project / ".claude" / "hooks"
+
+        referenced = _referenced_hook_basenames(settings)
+        assert referenced, "expected settings.json to reference osprey_*.py hooks"
+
+        missing = {
+            basename: sorted(set(events))
+            for basename, events in referenced.items()
+            if not (hooks_dir / basename).exists()
+        }
+        assert not missing, (
+            f"settings.json references hooks that were not shipped into "
+            f"{hooks_dir}: {missing}. A dangling reference fails open — the "
+            f"guard is silently absent at runtime."
+        )
+
+    def test_every_shipped_event_hook_is_wired_into_settings(self, regen_project):
+        """Direction (b): no shipped event hook sits in the project unreferenced.
+
+        The mirror of the test above. A hook file that is deployed but wired into
+        no event is dead weight that reads, to anyone inspecting the project, as
+        an active safety layer. Under the default ``control_assistant`` shape the
+        controls server is enabled and the fixture enables channel-finder, so
+        every event hook is unconditionally wired — there is no configuration in
+        this fixture under which a shipped hook is legitimately unreferenced.
+
+        ``osprey_hook_log`` is excluded: it is imported by the other hooks as a
+        logging helper and is not itself a hook entry point (see
+        ``HOOK_LIBRARY_MODULES``).
+        """
+        settings = json.loads((regen_project / ".claude" / "settings.json").read_text())
+        hooks_dir = regen_project / ".claude" / "hooks"
+
+        shipped = {p.name for p in hooks_dir.glob("osprey_*.py")}
+        event_hooks = shipped - HOOK_LIBRARY_MODULES
+        # Anti-vacuous guard: a glob that matched nothing (or only the library
+        # module) would make the subset check below trivially true.
+        assert len(event_hooks) >= 10, (
+            f"expected at least 10 shipped event hooks, found {sorted(event_hooks)}"
+        )
+
+        referenced = set(_referenced_hook_basenames(settings))
+        unwired = sorted(event_hooks - referenced)
+        assert not unwired, (
+            f"hooks shipped into {hooks_dir} but referenced by no event in "
+            f"settings.json: {unwired}. Either wire them (template entry, server "
+            f"registry hooks_pre/hooks_post, or `wiring: standalone` frontmatter) "
+            f"or stop shipping them."
+        )
 
 
 class TestUserFilePreservation:

--- a/tests/cli/test_profile_to_claude_contract.py
+++ b/tests/cli/test_profile_to_claude_contract.py
@@ -508,6 +508,98 @@ def test_extends_phoebus2_rendered_artifacts(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# hook_config.json: control_system.write_tools merge + empty-server rendering
+# ---------------------------------------------------------------------------
+
+
+def _read_hook_config(project: Path) -> dict:
+    return json.loads((project / ".claude" / "hooks" / "hook_config.json").read_text())
+
+
+def _server_names_from_prefixes(hook_cfg: dict) -> list[str]:
+    """Recover enabled server names from ``mcp__<name>__`` hook_config prefixes."""
+    return [p[len("mcp__") : -len("__")] for p in hook_cfg["server_prefixes"]]
+
+
+def test_hook_config_write_tools_dedupe(tmp_path):
+    """``control_system.write_tools`` merges into hook_config without duplicating.
+
+    The writes-check hook rules of every enabled server already contribute their
+    matcher to ``write_tools``. A facility that re-states one of those matchers
+    in ``control_system.write_tools`` (a natural thing to do when spelling out
+    the kill-switch set explicitly) must not get it twice — only genuinely new
+    entries are appended, in config order, after the server-derived ones.
+    """
+    manager = TemplateManager()
+    project = manager.create_project(
+        project_name="write-tools-dedupe",
+        output_dir=tmp_path,
+        data_bundle="hello_world",
+    )
+
+    baseline = _read_hook_config(project)["write_tools"]
+    assert "mcp__controls__channel_write" in baseline, (
+        f"expected the controls writes-check rule to seed write_tools; got {baseline}"
+    )
+
+    from osprey.utils.config_writer import config_update_fields
+
+    config_update_fields(
+        project / "config.yml",
+        {
+            "control_system.write_tools": [
+                "mcp__controls__channel_write",  # already server-derived
+                "mcp__facility__custom_write",  # genuinely new
+            ]
+        },
+    )
+    manager.regenerate_claude_code(project)
+
+    write_tools = _read_hook_config(project)["write_tools"]
+
+    assert write_tools.count("mcp__controls__channel_write") == 1, (
+        f"already-present entry duplicated by the config merge: {write_tools}"
+    )
+    assert write_tools == [*baseline, "mcp__facility__custom_write"], (
+        f"expected only the new entry appended to {baseline}; got {write_tools}"
+    )
+
+
+def test_hook_config_with_no_enabled_servers(tmp_path):
+    """Disabling every server still yields valid JSON with empty lists.
+
+    The hook runtime reads this file unconditionally, so the all-disabled corner
+    must render as a well-formed document with empty collections rather than a
+    truncated or absent one.
+    """
+    manager = TemplateManager()
+    project = manager.create_project(
+        project_name="no-servers",
+        output_dir=tmp_path,
+        data_bundle="hello_world",
+    )
+
+    enabled = _server_names_from_prefixes(_read_hook_config(project))
+    assert enabled, "fixture precondition: the preset must ship some enabled servers"
+
+    from osprey.utils.config_writer import config_update_fields
+
+    config_update_fields(
+        project / "config.yml",
+        {f"claude_code.servers.{name}.enabled": False for name in enabled},
+    )
+    manager.regenerate_claude_code(project)
+
+    # json.loads is the validity assertion — a truncated render raises here.
+    hook_cfg = _read_hook_config(project)
+    assert hook_cfg == {
+        "server_prefixes": [],
+        "approval_prefixes": [],
+        "write_tools": [],
+    }, f"all-disabled build should render empty lists; got {hook_cfg}"
+
+
+# ---------------------------------------------------------------------------
 # Crown-jewel invariant
 # ---------------------------------------------------------------------------
 

--- a/tests/cli/test_templates.py
+++ b/tests/cli/test_templates.py
@@ -593,7 +593,17 @@ class TestTemplateManifest:
         assert ".claude/skills/session-report/reference.md" in outputs
 
     def test_control_assistant_has_all_hooks(self, tmp_path):
-        """Control assistant project must have all 8 hook files."""
+        """Pin the exact set of hook files the control-assistant preset renders.
+
+        An equality check, not a subset one, so dropping a hook from the preset
+        and adding an unlisted one both fail here — the rendered set only changes
+        when someone updates this list on purpose.
+
+        This does not read settings.json; it says nothing about whether the
+        wiring matches. That parity is the two-direction invariant in
+        ``tests/cli/test_claude_regen.py`` — every settings.json reference has a
+        shipped file, and every shipped event hook is wired into settings.json.
+        """
         manager = TemplateManager()
         project_dir = manager.create_project(
             project_name="ctrl-hooks-test",
@@ -602,19 +612,23 @@ class TestTemplateManifest:
             context={"channel_finder_mode": "hierarchical"},
         )
 
-        expected_hooks = [
-            "osprey_hook_log.py",
+        expected_hooks = {
+            "hook_config.json",
             "osprey_approval.py",
-            "osprey_writes_check.py",
-            "osprey_limits.py",
+            "osprey_cf_feedback_capture.py",
+            "osprey_config_drift.py",
             "osprey_error_guidance.py",
+            "osprey_focus_validate.py",
+            "osprey_hook_log.py",
+            "osprey_limits.py",
             "osprey_memory_guard.py",
             "osprey_notebook_update.py",
-            "osprey_cf_feedback_capture.py",
-        ]
+            "osprey_panels_context.py",
+            "osprey_writes_check.py",
+        }
         hooks_dir = project_dir / ".claude" / "hooks"
-        for hook_name in expected_hooks:
-            assert (hooks_dir / hook_name).exists(), f"Missing hook: {hook_name}"
+        rendered = {p.name for p in hooks_dir.iterdir() if p.is_file()}
+        assert rendered == expected_hooks
 
     def test_backward_compat_no_manifest(self, tmp_path):
         """If manifest doesn't exist, all files are generated (backward compat)."""

--- a/tests/hooks/conftest.py
+++ b/tests/hooks/conftest.py
@@ -8,8 +8,16 @@ Hook subprocesses run with a *curated* environment rather than a copy of
 themselves read are forwarded, so a hook run cannot pick up ``OSPREY_CONFIG``,
 ``CONFIG_FILE`` or similar state leaked into the process environment by a test
 that ran earlier in the same worker.
+
+Unit tests that need a hook's *helpers* rather than its end-to-end behaviour
+import the module in-process through :func:`import_hook`, which contains the
+first of the two side effects that come with doing so: the ``sys.path`` entry
+most hooks insert for their own directory, stripped again on the way out. The
+second — ``osprey_hook_log``'s process-wide config memos — outlives any single
+import, so an autouse fixture blanks it around every test instead.
 """
 
+import importlib
 import json
 import os
 import subprocess
@@ -39,11 +47,15 @@ _SYSTEM_VARS = (
     "LANG",
     "LC_ALL",
     "VIRTUAL_ENV",
-    # pytest-cov hands subprocess coverage down through these.
-    "COV_CORE_SOURCE",
-    "COV_CORE_CONFIG",
-    "COV_CORE_DATAFILE",
-    "COV_CORE_CONTEXT",
+    # Subprocess coverage. pytest-cov 7 dropped its own subprocess measurement;
+    # coverage.py's ``patch = ["subprocess"]`` now sets COVERAGE_PROCESS_CONFIG,
+    # which the site-packages .pth bootstrap reads to start coverage in the child.
+    # COVERAGE_PROCESS_START is the older switch for driving subprocess coverage
+    # manually. COVERAGE_CORE names the measurement core, so forwarding it keeps
+    # the child measuring with the same tracer as the parent.
+    "COVERAGE_PROCESS_CONFIG",
+    "COVERAGE_PROCESS_START",
+    "COVERAGE_CORE",
 )
 
 # Hook behaviour switches. Tests that need one set it with ``monkeypatch.setenv``
@@ -60,6 +72,133 @@ _HOOK_VARS = (
 )
 
 _hook_config_seq = count()
+
+# The hooks ship as data inside the templates tree, but that tree is reachable
+# as a namespace package, so a hook can be imported by dotted path without
+# putting its directory on ``sys.path`` at import time.
+_HOOK_PACKAGE = "osprey.templates.claude_code.claude.hooks"
+
+#: Hooks whose module body only defines things (the work sits behind a
+#: ``__main__`` guard), so importing one in-process is inert.
+_SEAM_IMPORTABLE_HOOKS = frozenset(
+    {
+        "osprey_approval",
+        "osprey_config_drift",
+        "osprey_error_guidance",
+        "osprey_focus_validate",
+        "osprey_hook_log",
+        "osprey_limits",
+        "osprey_memory_guard",
+        "osprey_notebook_update",
+        "osprey_panels_context",
+        "osprey_writes_check",
+    }
+)
+
+#: Hooks that must never be imported in-process, and why.
+_UNIMPORTABLE_HOOKS = {
+    "osprey_cf_feedback_capture": (
+        "its module body runs the hook end to end and finishes with a "
+        "module-level sys.exit(0), which would tear down the importing test"
+    ),
+}
+
+
+def import_hook(name):
+    """Import a hook module in-process and hand back the module object.
+
+    For tests that exercise a hook's helper functions directly; anything that
+    depends on hook *behaviour* should go through :func:`hook_runner` instead,
+    which runs the script the way Claude Code does.
+
+    ``name`` is the module name, with or without the ``.py`` suffix. Only the
+    hooks in :data:`_SEAM_IMPORTABLE_HOOKS` may be imported; asking for one that
+    is not on the list raises :class:`ValueError` rather than executing it.
+
+    The import happens here rather than at module scope for two reasons. Most
+    hooks prepend their own directory to ``sys.path`` so they can import
+    ``osprey_hook_log`` as a sibling — that entry is removed again on the way
+    out, since leaving it there lets any later ``import osprey_hook_log``
+    anywhere in the worker resolve to the template copy. The strip is
+    unconditional, so it is simply a no-op for the few that never add it. And
+    the audit in ``tests/infrastructure/test_import_time_audit.py`` forbids
+    exactly this kind of import-time mutation in a test module, which is the
+    same rule stated as a test.
+
+    The module is cached by :mod:`importlib` for the life of the worker, so every
+    call hands back the *same* object and anything written onto it outlives the
+    test that wrote it. Mutate a hook module only through ``monkeypatch.setattr``,
+    which puts the original back at teardown. The sole state restored for you is
+    ``osprey_hook_log``'s three config memos, blanked around every test by the
+    :func:`_reset_hook_log_config_caches` autouse fixture.
+
+    ``import_hook("osprey_hook_log")`` carries one trap. It returns the copy under
+    :data:`_HOOK_PACKAGE`, which is *not* the top-level ``osprey_hook_log`` that a
+    hook binds when its own ``sys.path`` shim imports the sibling. Those are two
+    module objects with two sets of globals, so patching the one returned here
+    does not change what a hook sees. Exercise logging behaviour that has to cross
+    that boundary through :func:`hook_runner`.
+    """
+    module_name = name[:-3] if name.endswith(".py") else name
+    if module_name in _UNIMPORTABLE_HOOKS:
+        raise ValueError(
+            f"{module_name} cannot be imported in-process: "
+            f"{_UNIMPORTABLE_HOOKS[module_name]}. Run it with the hook_runner "
+            f"fixture instead."
+        )
+    if module_name not in _SEAM_IMPORTABLE_HOOKS:
+        raise ValueError(
+            f"Unknown hook {name!r}. Seam-importable hooks: "
+            f"{', '.join(sorted(_SEAM_IMPORTABLE_HOOKS))}."
+        )
+    try:
+        return importlib.import_module(f"{_HOOK_PACKAGE}.{module_name}")
+    finally:
+        hooks_dir = os.path.abspath(str(HOOKS_DIR))
+        sys.path[:] = [entry for entry in sys.path if os.path.abspath(entry) != hooks_dir]
+
+
+@pytest.fixture
+def hook_module():
+    """Give a test :func:`import_hook` without importing anything itself."""
+    return import_hook
+
+
+#: Module-level memos in ``osprey_hook_log``, all of them ``None`` when cold.
+_HOOK_LOG_CACHES = ("_hook_config_cache", "_osprey_config_cache", "_debug_from_config")
+
+
+def _reset_hook_log_caches():
+    """Blank the config memos on every loaded copy of ``osprey_hook_log``.
+
+    There are two: the one under the package path, and the top-level
+    ``osprey_hook_log`` a hook's own ``sys.path`` shim creates. They are separate
+    module objects with separate caches, and the hooks bind the top-level one.
+    """
+    for module_name in (f"{_HOOK_PACKAGE}.osprey_hook_log", "osprey_hook_log"):
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
+        for cache_name in _HOOK_LOG_CACHES:
+            setattr(module, cache_name, None)
+
+
+@pytest.fixture(autouse=True)
+def _reset_hook_log_config_caches():
+    """Isolate every test from ``osprey_hook_log``'s process-wide config memos.
+
+    ``load_hook_config``, ``load_osprey_config`` and the debug switch each read
+    their file once and keep the answer in a module global for the life of the
+    process. Any test that imports a hook in-process therefore pins whatever
+    config was visible on the first call — a later test pointing
+    ``OSPREY_HOOK_CONFIG`` at its own file would silently get the earlier one,
+    and a test that expects the shipped defaults would get a fixture's config.
+    Subprocess hook runs are unaffected (they start cold), but they share the
+    module with the in-process tests, so the reset is unconditional.
+    """
+    _reset_hook_log_caches()
+    yield
+    _reset_hook_log_caches()
 
 
 @pytest.fixture

--- a/tests/hooks/test_approval_helpers.py
+++ b/tests/hooks/test_approval_helpers.py
@@ -1,0 +1,600 @@
+"""Unit tests for `osprey_approval`'s pure helpers, imported in-process.
+
+The hook's end-to-end behaviour is covered by `test_approval_hook.py` (real
+subprocesses) and its launch enrichment by `test_approval_launch_enrichment.py`
+(a real HTTP server standing in for the bridge). What neither reaches cheaply
+is the *shape* of the individual helpers: the escape token `_sanitize_label`
+emits for each hostile code point, the exact wording `_revision_match_line`
+picks per revision pairing, the precedence `_resolve_bridge_url` applies, and
+the per-branch line list `_describe_plan_provenance` builds from a bridge
+response. Those are pure functions of their arguments, so this file calls them
+directly through the `hook_module` seam (see `conftest.import_hook`).
+
+No test here touches the network. `_bridge_get_json` is the hook's single
+egress point for the launch enrichment, and every test that exercises a caller
+of it replaces it with a routing table, which also lets the tests assert *which*
+bridge URL and paths the callers ask for.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def approval(hook_module):
+    """The `osprey_approval` module, imported through the test seam.
+
+    Imported in a fixture rather than at module scope: the hook prepends its own
+    directory to `sys.path` on import, and `import_hook` is what undoes that.
+    """
+    return hook_module("osprey_approval")
+
+
+@pytest.fixture
+def bridge_calls():
+    """Recorder for the (base_url, path) pairs a helper asks the bridge for."""
+    return []
+
+
+@pytest.fixture
+def fake_bridge(approval, bridge_calls, monkeypatch):
+    """Factory replacing `_bridge_get_json` with a routing table.
+
+    Takes ``{path: body}``; an unmapped path yields `None`, which is exactly what
+    the real helper returns for a 404, an unreachable bridge or a malformed
+    body — so a route left out of the table is a genuine failure case, not a
+    test-harness gap.
+    """
+
+    def _install(routes: dict[str, object]):
+        def _get(base_url, path, timeout=3.0):
+            bridge_calls.append((base_url, path))
+            return routes.get(path)
+
+        monkeypatch.setattr(approval, "_bridge_get_json", _get)
+
+    return _install
+
+
+# --------------------------------------------------------------------------
+# _sanitize_label
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("raw", "escaped"),
+    [
+        ("\x85", "\\x85"),
+        ("\u2028", "\\x2028"),
+        ("\u2029", "\\x2029"),
+        ("\n", "\\x0a"),
+        ("\r", "\\x0d"),
+        ("\x7f", "\\x7f"),
+        ("\x00", "\\x00"),
+    ],
+    ids=["nel", "line-sep", "para-sep", "newline", "carriage-return", "del", "nul"],
+)
+def test_sanitize_label_escapes_line_breaking_code_points(approval, raw, escaped):
+    """Every code point that could break the prompt onto a new line is escaped.
+
+    The label lands in a human approval prompt built by line concatenation, so a
+    raw break in an agent-supplied plan name would let the plan forge an
+    enrichment line of its own (a spoofed "Validation status: PASSED", say).
+    The C0 range and DEL are the obvious carriers; NEL, LINE SEPARATOR and
+    PARAGRAPH SEPARATOR are the ones a terminal may also honour.
+    """
+    result = approval._sanitize_label(f"before{raw}after")
+
+    assert raw not in result
+    assert result == f"before{escaped}after"
+
+
+@pytest.mark.unit
+def test_sanitize_label_passes_ordinary_text_through(approval):
+    """Printable text — including non-ASCII — is returned byte for byte.
+
+    The escaping must be invisible in the normal case; a label mangled into
+    ``\\xNN`` soup would train approvers to ignore the escapes that matter.
+    """
+    label = "orbit_correction_v2 (µm, 90° phase) — ARM/BPM:1"
+
+    assert approval._sanitize_label(label) == label
+
+
+@pytest.mark.unit
+def test_sanitize_label_stringifies_non_string_input(approval):
+    """Non-string metadata is coerced rather than raising.
+
+    ``PLAN_METADATA`` is agent-authored and unvalidated for type, so a numeric
+    or `None` field must render, not blow up the approval prompt.
+    """
+    assert approval._sanitize_label(42) == "42"
+    assert approval._sanitize_label(None) == "None"
+
+
+# --------------------------------------------------------------------------
+# _revision_match_line
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_revision_match_line_states_a_match_plainly(approval):
+    """Equal pinned and current revisions get the quiet wording."""
+    line = approval._revision_match_line(7, 7)
+
+    assert line == "Draft revision 7 — matches pinned revision 7."
+    assert "⚠️" not in line
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("pinned", "current"),
+    [(7, 8), (None, 8), (8, None)],
+    ids=["moved-on", "no-pin", "no-current"],
+)
+def test_revision_match_line_is_loud_on_any_mismatch(approval, pinned, current):
+    """Anything short of an exact match warns, and shows both revisions.
+
+    A missing pin is treated as a mismatch on purpose: the approver cannot tell
+    from a silent line whether the draft is the one the agent staged.
+    """
+    line = approval._revision_match_line(pinned, current)
+
+    assert "DRAFT CHANGED" in line
+    assert str(pinned) in line
+    assert str(current) in line
+    assert "CURRENT draft" in line
+
+
+# --------------------------------------------------------------------------
+# build_approval_output / build_allow_output
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_build_approval_output_emits_an_ask_envelope(approval):
+    """The ask envelope carries the event name, the decision, and the detail."""
+    output = approval.build_approval_output("Tool: execute\nPolicy: always")
+
+    assert set(output) == {"hookSpecificOutput"}
+    specific = output["hookSpecificOutput"]
+    assert specific["hookEventName"] == "PreToolUse"
+    assert specific["permissionDecision"] == "ask"
+    reason = specific["permissionDecisionReason"]
+    assert "OSPREY APPROVAL REQUIRED" in reason
+    assert "Tool: execute\nPolicy: always" in reason
+    assert reason.endswith("Review the operation above and approve to proceed.")
+
+
+@pytest.mark.unit
+def test_build_allow_output_is_silent_in_a_dispatch_run(approval, monkeypatch):
+    """Under `OSPREY_DISPATCH_RUN=1` the hook emits no decision at all.
+
+    Hook aggregation in the CLI is not deny-dominates, so an explicit allow here
+    would override the dispatch worker's per-trigger allowlist and widen a
+    sandboxed run's tool surface. Emitting nothing hands the call back to the
+    worker's own callback.
+    """
+    monkeypatch.setenv("OSPREY_DISPATCH_RUN", "1")
+
+    assert approval.build_allow_output() == {}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "dispatch_run",
+    [None, "", "0", "true", "2"],
+    ids=["unset", "empty", "zero", "true", "two"],
+)
+def test_build_allow_output_is_explicit_outside_a_dispatch_run(approval, monkeypatch, dispatch_run):
+    """Only the exact string "1" suppresses the allow; everything else allows.
+
+    The suppression is a narrow carve-out for the dispatch worker, which sets
+    the variable itself. A stray or unrelated value must not silently disable
+    the explicit allow that overrides static permission lists.
+    """
+    if dispatch_run is None:
+        monkeypatch.delenv("OSPREY_DISPATCH_RUN", raising=False)
+    else:
+        monkeypatch.setenv("OSPREY_DISPATCH_RUN", dispatch_run)
+
+    assert approval.build_allow_output() == {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+        }
+    }
+
+
+# --------------------------------------------------------------------------
+# _resolve_bridge_url
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_resolve_bridge_url_prefers_the_environment(approval, monkeypatch):
+    """`BLUESKY_BRIDGE_URL` wins outright, even with config.yml set."""
+    monkeypatch.setenv("BLUESKY_BRIDGE_URL", "http://bridge.env:9000/")
+
+    url = approval._resolve_bridge_url({"bluesky": {"bridge_url": "http://bridge.config:8000"}})
+
+    assert url == "http://bridge.env:9000"
+
+
+@pytest.mark.unit
+def test_resolve_bridge_url_falls_back_to_config(approval, monkeypatch):
+    """With no env override, `bluesky.bridge_url` from config.yml is used."""
+    monkeypatch.delenv("BLUESKY_BRIDGE_URL", raising=False)
+
+    url = approval._resolve_bridge_url({"bluesky": {"bridge_url": "http://bridge.config:8000/"}})
+
+    assert url == "http://bridge.config:8000"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "config",
+    [{}, {"bluesky": {}}],
+    ids=["no-bluesky-section", "no-bridge-url-key"],
+)
+def test_resolve_bridge_url_falls_back_to_the_loopback_default(approval, monkeypatch, config):
+    """Neither env nor config leaves the loopback default."""
+    monkeypatch.delenv("BLUESKY_BRIDGE_URL", raising=False)
+
+    assert approval._resolve_bridge_url(config) == "http://127.0.0.1:8090"
+
+
+@pytest.mark.unit
+def test_resolve_bridge_url_ignores_an_empty_environment_value(approval, monkeypatch):
+    """An empty `BLUESKY_BRIDGE_URL` is no override, not an empty base URL.
+
+    Exporting the variable unset is a common shell accident; taking it literally
+    would point every bridge call at a relative path.
+    """
+    monkeypatch.setenv("BLUESKY_BRIDGE_URL", "")
+
+    url = approval._resolve_bridge_url({"bluesky": {"bridge_url": "http://bridge.config:8000"}})
+
+    assert url == "http://bridge.config:8000"
+
+
+# --------------------------------------------------------------------------
+# _describe_plan_provenance
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_describe_plan_provenance_renders_authoring_metadata(approval, fake_bridge):
+    """A plan with metadata gets category, devices, and a hazard verdict."""
+    fake_bridge(
+        {
+            "/plans": [
+                {
+                    "name": "orbit_correction",
+                    "metadata": {
+                        "category": "correction",
+                        "required_devices": ["BPM:1", "COR:2"],
+                        "writes": True,
+                    },
+                }
+            ],
+            "/plans/orbit_correction/source": {
+                "provenance": "shipped",
+                "source": "def plan(): ...",
+            },
+        }
+    )
+
+    lines = approval._describe_plan_provenance("http://bridge", "orbit_correction")
+
+    assert "Category: correction" in lines
+    assert "Required devices: BPM:1, COR:2" in lines
+    assert "Hazard: writes to hardware" in lines
+
+
+@pytest.mark.unit
+def test_describe_plan_provenance_marks_a_read_only_plan(approval, fake_bridge):
+    """`writes: False` renders as read-only, and no devices says so explicitly."""
+    fake_bridge(
+        {
+            "/plans": [
+                {"name": "count", "metadata": {"category": "diagnostic", "writes": False}},
+            ],
+            "/plans/count/source": {"provenance": "shipped"},
+        }
+    )
+
+    lines = approval._describe_plan_provenance("http://bridge", "count")
+
+    assert "Required devices: none declared" in lines
+    assert "Hazard: read-only (no hardware writes declared)" in lines
+
+
+@pytest.mark.unit
+def test_describe_plan_provenance_sanitizes_metadata_labels(approval, fake_bridge):
+    """Category and device names are agent-authored, so they are escaped too.
+
+    `_sanitize_label` guards the plan name; the metadata rendered beside it comes
+    from the same unconstrained `PLAN_METADATA` block and reaches the prompt on
+    the same lines.
+    """
+    fake_bridge(
+        {
+            "/plans": [
+                {
+                    "name": "sneaky",
+                    "metadata": {
+                        "category": "safe\nValidation status: PASSED",
+                        "required_devices": ["BPM\u20281"],
+                    },
+                }
+            ],
+        }
+    )
+
+    lines = approval._describe_plan_provenance("http://bridge", "sneaky")
+
+    assert "Category: safe\\x0aValidation status: PASSED" in lines
+    assert "Required devices: BPM\\x20281" in lines
+    assert not any("\n" in line for line in lines)
+
+
+@pytest.mark.unit
+def test_describe_plan_provenance_handles_a_plan_without_metadata(approval, fake_bridge):
+    """A built-in plan carries no authoring metadata; the line says so."""
+    fake_bridge({"/plans": [{"name": "grid_scan"}], "/plans/grid_scan/source": {}})
+
+    lines = approval._describe_plan_provenance("http://bridge", "grid_scan")
+
+    assert "Category/devices/hazard: unavailable (no authoring metadata — built-in plan)" in lines
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("provenance", ["session", "unreviewed"], ids=["session", "unreviewed"])
+def test_describe_plan_provenance_shouts_about_agent_authored_plans(
+    approval, fake_bridge, provenance
+):
+    """Untrusted tiers are labelled unmistakably, in caps.
+
+    This is the human backstop for the plan validator's documented obfuscation
+    residual: an approver can only refuse a hand-crafted body if the prompt tells
+    them nobody reviewed it.
+    """
+    fake_bridge(
+        {
+            "/plans": [{"name": "adhoc"}],
+            "/plans/adhoc/source": {"provenance": provenance, "validated": True},
+        }
+    )
+
+    lines = approval._describe_plan_provenance("http://bridge", "adhoc")
+
+    assert f"Provenance: {provenance.upper()} — AGENT-AUTHORED, NOT REVIEWED BY A HUMAN" in lines
+    assert "Validation status: PASSED (content hash matches a recorded validation run)" in lines
+
+
+@pytest.mark.unit
+def test_describe_plan_provenance_flags_an_unvalidated_session_plan(approval, fake_bridge):
+    """No passing validation record is stated as a launch-time refusal."""
+    fake_bridge(
+        {
+            "/plans": [{"name": "adhoc"}],
+            "/plans/adhoc/source": {"provenance": "session", "validated": False},
+        }
+    )
+
+    lines = approval._describe_plan_provenance("http://bridge", "adhoc")
+
+    assert "Validation status: NO PASSING RECORD — would be refused/quarantined at launch" in lines
+
+
+@pytest.mark.unit
+def test_describe_plan_provenance_reports_an_operator_supplied_plan(approval, fake_bridge):
+    """A reviewed tier is named plainly, and validation does not apply to it."""
+    fake_bridge(
+        {
+            "/plans": [{"name": "orm"}],
+            "/plans/orm/source": {"provenance": "facility"},
+        }
+    )
+
+    lines = approval._describe_plan_provenance("http://bridge", "orm")
+
+    assert "Provenance: facility (operator-supplied)" in lines
+    assert "Validation status: not applicable (operator-supplied plan)" in lines
+
+
+@pytest.mark.unit
+def test_describe_plan_provenance_falls_back_to_the_registry_provenance(approval, fake_bridge):
+    """When `/source` is silent on provenance, the `/plans` entry supplies it."""
+    fake_bridge(
+        {
+            "/plans": [{"name": "adhoc", "provenance": "session"}],
+            "/plans/adhoc/source": {"validated": False},
+        }
+    )
+
+    lines = approval._describe_plan_provenance("http://bridge", "adhoc")
+
+    assert "Provenance: SESSION — AGENT-AUTHORED, NOT REVIEWED BY A HUMAN" in lines
+
+
+@pytest.mark.unit
+def test_describe_plan_provenance_degrades_when_the_bridge_is_silent(approval, fake_bridge):
+    """Both endpoints failing yields short lines, not an exception.
+
+    Every bridge call is fail-open by design — an unreachable bridge must never
+    block the approval prompt from rendering.
+    """
+    fake_bridge({})
+
+    lines = approval._describe_plan_provenance("http://bridge", "orm")
+
+    assert "Category/devices/hazard: unavailable (no authoring metadata — built-in plan)" in lines
+    assert "Provenance: unknown" in lines
+    assert "Validation status: unknown (could not reach the plan-source endpoint)" in lines
+    assert not any(line.startswith("\nPlan source") for line in lines)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("truncated", "note"), [(True, " (truncated)"), (False, "")], ids=["truncated", "complete"]
+)
+def test_describe_plan_provenance_appends_the_plan_source_verbatim(
+    approval, fake_bridge, truncated, note
+):
+    """The source block is rendered raw — unlike the labels — and flagged if cut.
+
+    Escaping it would defeat its purpose: the approver is meant to read the real,
+    multi-line plan body.
+    """
+    fake_bridge(
+        {
+            "/plans": [{"name": "adhoc"}],
+            "/plans/adhoc/source": {
+                "provenance": "session",
+                "validated": True,
+                "source": "def plan():\n    yield from count([det])",
+                "truncated": truncated,
+            },
+        }
+    )
+
+    lines = approval._describe_plan_provenance("http://bridge", "adhoc")
+
+    assert lines[-1] == f"\nPlan source{note}:\ndef plan():\n    yield from count([det])"
+
+
+# --------------------------------------------------------------------------
+# _describe_launch_run
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "snapshot",
+    [None, [], "not-json-object"],
+    ids=["bridge-unreachable", "wrong-shape-list", "wrong-shape-string"],
+)
+def test_describe_launch_run_returns_no_detail_for_an_unusable_draft(
+    approval, monkeypatch, snapshot
+):
+    """A missing or misshaped `GET /draft` degrades to zero enrichment lines.
+
+    The plain tool/policy reason still asks for approval; only the extra detail
+    is lost. Returning `[]` here is what keeps `main` from having to reason about
+    a half-built line list.
+    """
+    monkeypatch.setattr(approval, "_bridge_get_json", lambda *args, **kwargs: snapshot)
+
+    assert approval._describe_launch_run({"draft_revision": 3}, {}) == []
+
+
+@pytest.mark.unit
+def test_describe_launch_run_reports_an_empty_draft(approval, fake_bridge):
+    """Nothing staged means nothing to launch, and the prompt says so."""
+    fake_bridge({"/draft": {"revision": 4, "draft": {}}})
+
+    lines = approval._describe_launch_run({"draft_revision": 4}, {})
+
+    assert lines[0] == "Draft revision 4 — matches pinned revision 4."
+    assert lines[1].startswith("Draft: EMPTY")
+    assert len(lines) == 2
+
+
+@pytest.mark.unit
+def test_describe_launch_run_renders_the_staged_plan(approval, fake_bridge):
+    """A staged plan contributes its name, args, and provenance lines."""
+    fake_bridge(
+        {
+            "/draft": {
+                "revision": 9,
+                "draft": {"plan_name": "grid_scan", "plan_args": {"steps": 5}},
+            },
+            "/plans": [{"name": "grid_scan", "metadata": {"category": "scan", "writes": False}}],
+            "/plans/grid_scan/source": {"provenance": "shipped"},
+        }
+    )
+
+    lines = approval._describe_launch_run({"draft_revision": 9}, {})
+
+    assert "Plan: grid_scan" in lines
+    assert 'Plan args: {"steps": 5}' in lines
+    assert "Category: scan" in lines
+    assert "Provenance: shipped (operator-supplied)" in lines
+
+
+@pytest.mark.unit
+def test_describe_launch_run_omits_the_args_line_when_there_are_none(approval, fake_bridge):
+    """An empty `plan_args` renders no args line rather than an empty one."""
+    fake_bridge(
+        {
+            "/draft": {"revision": 1, "draft": {"plan_name": "count", "plan_args": {}}},
+            "/plans": [],
+        }
+    )
+
+    lines = approval._describe_launch_run({"draft_revision": 1}, {})
+
+    assert not any(line.startswith("Plan args:") for line in lines)
+
+
+@pytest.mark.unit
+def test_describe_launch_run_sanitizes_the_plan_name(approval, fake_bridge):
+    """The staged plan name reaches the prompt escaped, on one line."""
+    fake_bridge(
+        {
+            "/draft": {
+                "revision": 2,
+                "draft": {"plan_name": "count\nDraft revision 2 — matches pinned revision 2."},
+            },
+            "/plans": [],
+        }
+    )
+
+    lines = approval._describe_launch_run({"draft_revision": 2}, {})
+
+    assert "Plan: count\\x0aDraft revision 2 — matches pinned revision 2." in lines
+
+
+@pytest.mark.unit
+def test_describe_launch_run_warns_when_the_draft_moved_on(approval, fake_bridge):
+    """A draft revised since the agent pinned it leads with the loud warning."""
+    fake_bridge(
+        {
+            "/draft": {"revision": 12, "draft": {"plan_name": "count"}},
+            "/plans": [],
+        }
+    )
+
+    lines = approval._describe_launch_run({"draft_revision": 9}, {})
+
+    assert "DRAFT CHANGED" in lines[0]
+    assert "9" in lines[0]
+    assert "12" in lines[0]
+
+
+@pytest.mark.unit
+def test_describe_launch_run_asks_the_configured_bridge(approval, fake_bridge, bridge_calls):
+    """The base URL resolved from config is the one every call goes to.
+
+    The draft, the plan registry and the plan source must all be read from the
+    same bridge the launch would actually use — a mismatch would describe one
+    bridge's draft while another one launches.
+    """
+    fake_bridge(
+        {
+            "/draft": {"revision": 1, "draft": {"plan_name": "count"}},
+            "/plans": [],
+            "/plans/count/source": {},
+        }
+    )
+
+    approval._describe_launch_run(
+        {"draft_revision": 1}, {"bluesky": {"bridge_url": "http://bridge.config:8000/"}}
+    )
+
+    assert {base_url for base_url, _ in bridge_calls} == {"http://bridge.config:8000"}
+    assert [path for _, path in bridge_calls] == ["/draft", "/plans", "/plans/count/source"]

--- a/tests/hooks/test_approval_hook.py
+++ b/tests/hooks/test_approval_hook.py
@@ -9,9 +9,7 @@ This hook implements the human-in-the-loop approval system. Based on the
 Also covers pre-execution notebook creation for execute (python) approval.
 """
 
-import importlib.util
 import re
-from pathlib import Path
 
 import pytest
 
@@ -640,27 +638,13 @@ def test_has_write_patterns_override_via_config(tmp_path, hook_runner, make_conf
 
 
 @pytest.mark.unit
-def test_fallback_merges_custom_patterns(tmp_path, hook_runner, make_config):
+def test_fallback_merges_custom_patterns(hook_module):
     """Fallback path merges custom patterns with _FALLBACK_WRITE_PATTERNS by default.
 
     When osprey is not importable, the fallback regex path must merge
     custom patterns (extend mode) instead of replacing the fallback list.
     """
-    hook_path = (
-        Path(__file__).resolve().parents[2]
-        / "src"
-        / "osprey"
-        / "templates"
-        / "claude_code"
-        / "claude"
-        / "hooks"
-        / "osprey_approval.py"
-    )
-    spec = importlib.util.spec_from_file_location("osprey_approval_fb", hook_path)
-    hook_module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(hook_module)
-
-    fallback_patterns = hook_module._FALLBACK_WRITE_PATTERNS
+    fallback_patterns = hook_module("osprey_approval")._FALLBACK_WRITE_PATTERNS
 
     # Simulate the fallback merge logic (extend mode, the default)
     config = {
@@ -689,21 +673,9 @@ def test_fallback_merges_custom_patterns(tmp_path, hook_runner, make_config):
 
 
 @pytest.mark.unit
-def test_fallback_override_replaces_patterns(tmp_path, hook_runner, make_config):
+def test_fallback_override_replaces_patterns(hook_module):
     """Fallback path with mode=override replaces _FALLBACK_WRITE_PATTERNS entirely."""
-    hook_path = (
-        Path(__file__).resolve().parents[2]
-        / "src"
-        / "osprey"
-        / "templates"
-        / "claude_code"
-        / "claude"
-        / "hooks"
-        / "osprey_approval.py"
-    )
-    spec = importlib.util.spec_from_file_location("osprey_approval_fb2", hook_path)
-    hook_module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(hook_module)
+    fallback_patterns = hook_module("osprey_approval")._FALLBACK_WRITE_PATTERNS
 
     config = {
         "control_system": {
@@ -717,7 +689,7 @@ def test_fallback_override_replaces_patterns(tmp_path, hook_runner, make_config)
     pat_config = config.get("control_system", {}).get("patterns", {})
     custom = pat_config.get("write")
     mode = pat_config.get("mode", "extend")
-    patterns = list(hook_module._FALLBACK_WRITE_PATTERNS)
+    patterns = list(fallback_patterns)
     if custom:
         if mode == "override":
             patterns = list(custom)
@@ -980,7 +952,7 @@ def test_entry_create_always_asks(tmp_path, hook_runner, make_config):
 
 
 @pytest.mark.unit
-def test_fallback_pattern_parity_with_framework():
+def test_fallback_pattern_parity_with_framework(hook_module):
     """Fallback write patterns in the hook must match framework standard patterns.
 
     This catches drift between the two pattern lists. If a pattern is added to
@@ -991,23 +963,8 @@ def test_fallback_pattern_parity_with_framework():
         get_framework_standard_patterns,
     )
 
-    # Load the hook module directly (it's a template file, not an importable package)
-    hook_path = (
-        Path(__file__).resolve().parents[2]
-        / "src"
-        / "osprey"
-        / "templates"
-        / "claude_code"
-        / "claude"
-        / "hooks"
-        / "osprey_approval.py"
-    )
-    spec = importlib.util.spec_from_file_location("osprey_approval", hook_path)
-    hook_module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(hook_module)
-
     framework_patterns = get_framework_standard_patterns()["write"]
-    fallback_patterns = hook_module._FALLBACK_WRITE_PATTERNS
+    fallback_patterns = hook_module("osprey_approval")._FALLBACK_WRITE_PATTERNS
 
     assert fallback_patterns == framework_patterns, (
         f"Fallback patterns ({len(fallback_patterns)}) differ from "
@@ -1015,3 +972,25 @@ def test_fallback_pattern_parity_with_framework():
         f"Missing from fallback: {set(framework_patterns) - set(fallback_patterns)}\n"
         f"Extra in fallback: {set(fallback_patterns) - set(framework_patterns)}"
     )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("stdin", ["", "{nope", "[]"], ids=["empty", "invalid-json", "wrong-shape"])
+def test_malformed_stdin_fails_open(tmp_path, hook_runner_raw, stdin):
+    """Unusable stdin passes the tool through without asking for approval.
+
+    A closed pipe, a truncated write and a non-object payload each leave the
+    hook with no tool to gate, so it exits 0 and emits no decision. Emitting an
+    "ask" here would stall every tool call behind a prompt nobody can answer.
+    """
+    returncode, stdout, stderr = hook_runner_raw(
+        "osprey_approval.py",
+        tool_name=None,
+        tool_input=None,
+        cwd=tmp_path,
+        stdin_override=stdin,
+    )
+
+    assert returncode == 0
+    assert stdout.strip() == ""
+    assert "Traceback" not in stderr

--- a/tests/hooks/test_config_drift_hook.py
+++ b/tests/hooks/test_config_drift_hook.py
@@ -1,71 +1,101 @@
 """Tests for the osprey_config_drift.py SessionStart hook.
 
 The hook warns (never blocks) when config.yml has drifted from the rendered
-.claude/settings.json. It is stdlib-only and reads CLAUDE_PROJECT_DIR, so these
-tests drive it as a subprocess with an explicitly controlled environment and
-pinned mtimes — relying on the shared hook_runner (which copies os.environ) would
-leak the parent's CLAUDE_PROJECT_DIR into the subprocess.
+.claude/settings.json. Two layers of coverage:
+
+* The pure helpers (``_writes_enabled_in_config``, ``_channel_write_denied``,
+  ``_detect_drift``) are imported and called directly, one test per documented
+  return branch. The hook is stdlib-only and imports nothing at module scope, so
+  a plain import is safe — it is still written inside the test bodies so that
+  importing this file stays free of side effects (tests/README.md §5).
+* The end-to-end behaviour goes through the shared ``hook_runner_raw`` harness,
+  which runs the hook as a subprocess with a curated environment. The hook reads
+  its project root from ``CLAUDE_PROJECT_DIR``; that variable is on the harness
+  allowlist and is set per test with ``monkeypatch.setenv``, so no value from the
+  parent process can reach the subprocess.
 """
 
 from __future__ import annotations
 
 import json
 import os
-import subprocess
-import sys
-from pathlib import Path
+import stat
 
 import pytest
+import yaml
 
-HOOK = (
-    Path(__file__).parents[2]
-    / "src"
-    / "osprey"
-    / "templates"
-    / "claude_code"
-    / "claude"
-    / "hooks"
-    / "osprey_config_drift.py"
-)
+HOOK_SCRIPT = "osprey_config_drift.py"
 
+# Spelled out here rather than imported: the tests state the contract the hook is
+# supposed to implement, independently of the constant the hook happens to use.
+CHANNEL_WRITE = "mcp__controls__channel_write"
 
-def _run(project_dir: Path):
-    """Run the drift hook against project_dir; return (returncode, stdout, stderr)."""
-    env = {k: v for k, v in os.environ.items() if k not in {"OSPREY_CONFIG", "CONFIG_FILE"}}
-    env["CLAUDE_PROJECT_DIR"] = str(project_dir)
-    result = subprocess.run(
-        [sys.executable, str(HOOK)],
-        input="{}",
-        capture_output=True,
-        text=True,
-        env=env,
-    )
-    return result.returncode, result.stdout, result.stderr
+# Channel-write states a rendered settings.json can be in.
+DENIED = "denied"
+ALLOWED = "allowed"
+NO_PERMISSIONS = "no-permissions"
 
 
-def _make_project(tmp_path, *, writes_enabled: bool, channel_write_denied: bool):
-    """Create config.yml + .claude/settings.json with chosen (possibly mismatched) state."""
-    project_dir = tmp_path
+def _hook():
+    """Import the drift hook module.
+
+    Called from inside test bodies rather than at module scope so that importing
+    this test file does nothing but define functions.
+    """
+    import osprey.templates.claude_code.claude.hooks.osprey_config_drift as hook
+
+    return hook
+
+
+class _RaisingPath:
+    """A path that exists but whose reads and stats fail.
+
+    Real filesystems produce this: the file can be unlinked, or its mount can go
+    away, between the ``exists()`` probe and the ``stat()`` call that follows.
+    """
+
+    def exists(self) -> bool:
+        return True
+
+    def read_text(self, encoding: str = "utf-8") -> str:
+        raise OSError("vanished")
+
+    def stat(self):
+        raise OSError("vanished")
+
+
+# --------------------------------------------------------------------------- #
+# Project fixtures
+# --------------------------------------------------------------------------- #
+
+
+def _make_project(project_dir, *, writes_enabled: bool | None, channel_write: str):
+    """Write config.yml + .claude/settings.json in a chosen (possibly drifted) state.
+
+    ``writes_enabled=None`` omits the key entirely; ``channel_write=NO_PERMISSIONS``
+    renders a settings.json with no ``permissions`` block at all.
+    """
     (project_dir / ".claude").mkdir(parents=True, exist_ok=True)
     config_path = project_dir / "config.yml"
     settings_path = project_dir / ".claude" / "settings.json"
 
-    config_path.write_text(
-        "control_system:\n"
-        "  type: mock\n"
-        f"  writes_enabled: {'true' if writes_enabled else 'false'}\n",
-        encoding="utf-8",
-    )
-    deny = ["Bash", "Edit"]
-    if channel_write_denied:
-        deny.append("mcp__controls__channel_write")
-    settings_path.write_text(
-        json.dumps({"permissions": {"deny": deny}}, indent=2), encoding="utf-8"
-    )
+    lines = ["control_system:", "  type: mock"]
+    if writes_enabled is not None:
+        lines.append(f"  writes_enabled: {'true' if writes_enabled else 'false'}")
+    config_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    if channel_write == NO_PERMISSIONS:
+        settings = {"hooks": {}}
+    else:
+        deny = ["Bash", "Edit"]
+        if channel_write == DENIED:
+            deny.append(CHANNEL_WRITE)
+        settings = {"permissions": {"deny": deny}}
+    settings_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
     return config_path, settings_path
 
 
-def _set_mtimes(config_path: Path, settings_path: Path, *, config_newer: bool):
+def _set_mtimes(config_path, settings_path, *, config_newer: bool):
     """Pin mtimes so the mtime drift signal is deterministic."""
     base = 1_700_000_000
     if config_newer:
@@ -76,27 +106,182 @@ def _set_mtimes(config_path: Path, settings_path: Path, *, config_newer: bool):
         os.utime(settings_path, (base + 100, base + 100))
 
 
-def test_silent_when_in_sync(tmp_path):
+@pytest.fixture
+def run_drift(hook_runner_raw, monkeypatch):
+    """Run the drift hook as a SessionStart subprocess against a project dir."""
+
+    def run(project_dir):
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project_dir))
+        return hook_runner_raw(
+            HOOK_SCRIPT,
+            tool_name=None,
+            tool_input=None,
+            stdin_override=json.dumps({"hook_event_name": "SessionStart", "source": "startup"}),
+        )
+
+    return run
+
+
+# --------------------------------------------------------------------------- #
+# _writes_enabled_in_config — regex parse of the kill-switch
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("control_system:\n  writes_enabled: true\n", True),
+        ("control_system:\n  writes_enabled: false\n", False),
+        # The regex is case-insensitive, so a hand-typed capital still reads.
+        ("control_system:\n  WRITES_ENABLED: TRUE\n", True),
+        # No key at all — undeterminable, not "false".
+        ("control_system:\n  type: mock\n", None),
+        # Commented out: `^\s*` refuses to skip the '#', so it does not count.
+        ("control_system:\n  # writes_enabled: true\n", None),
+        # Only the literals true/false are accepted; YAML's other booleans are not.
+        ("control_system:\n  writes_enabled: yes\n", None),
+    ],
+    ids=["true", "false", "uppercase", "absent", "commented-out", "yaml-yes"],
+)
+def test_writes_enabled_in_config_parses(tmp_path, text, expected):
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(text, encoding="utf-8")
+
+    assert _hook()._writes_enabled_in_config(config_path) is expected
+
+
+def test_writes_enabled_in_config_is_none_when_unreadable(tmp_path):
+    # OSError (here: no such file) means undeterminable, never a guessed default.
+    assert _hook()._writes_enabled_in_config(tmp_path / "nope.yml") is None
+
+
+# --------------------------------------------------------------------------- #
+# _channel_write_denied — JSON read of permissions.deny
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (json.dumps({"permissions": {"deny": ["Bash", CHANNEL_WRITE]}}), True),
+        (json.dumps({"permissions": {"deny": ["Bash"]}}), False),
+        (json.dumps({"permissions": {"allow": ["Bash"]}}), False),  # deny defaults to []
+        (json.dumps({"hooks": {}}), None),  # no permissions block
+        (json.dumps({"permissions": None}), None),  # hand-edited null
+        (json.dumps({"permissions": {"deny": CHANNEL_WRITE}}), None),  # deny not a list
+        (json.dumps(["not", "a", "mapping"]), None),
+        ("{ this is not json", None),
+    ],
+    ids=[
+        "denied",
+        "allowed",
+        "deny-key-absent",
+        "permissions-absent",
+        "permissions-null",
+        "deny-not-a-list",
+        "top-level-not-a-mapping",
+        "malformed-json",
+    ],
+)
+def test_channel_write_denied(tmp_path, payload, expected):
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(payload, encoding="utf-8")
+
+    assert _hook()._channel_write_denied(settings_path) is expected
+
+
+def test_channel_write_denied_is_none_when_file_missing(tmp_path):
+    assert _hook()._channel_write_denied(tmp_path / "settings.json") is None
+
+
+# --------------------------------------------------------------------------- #
+# _detect_drift — branch order and fail-open
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("missing", ["config", "settings"])
+def test_detect_drift_is_none_when_an_artifact_is_missing(tmp_path, missing):
+    # A project that was never built is not "drifted" — there is nothing to compare.
+    config_path, settings_path = _make_project(tmp_path, writes_enabled=True, channel_write=DENIED)
+    (config_path if missing == "config" else settings_path).unlink()
+
+    assert _hook()._detect_drift(config_path, settings_path) is None
+
+
+def test_detect_drift_fails_open_when_stat_raises():
+    # Both signals blow up on IO: the hook returns no message rather than guessing.
+    assert _hook()._detect_drift(_RaisingPath(), _RaisingPath()) is None
+
+
+def test_detect_drift_prefers_the_targeted_check_over_mtime(tmp_path):
+    # Both signals fire at once; the specific one wins so the operator is told
+    # *what* drifted, not merely that something did.
+    config_path, settings_path = _make_project(tmp_path, writes_enabled=True, channel_write=DENIED)
+    _set_mtimes(config_path, settings_path, config_newer=True)
+
+    message = _hook()._detect_drift(config_path, settings_path)
+    assert "still blocks writes" in message
+    assert "changed since" not in message
+
+
+# --------------------------------------------------------------------------- #
+# Behavioural drift matrix (subprocess)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("writes_enabled", "channel_write", "expected_fragment"),
+    [
+        # config wants writes, artifacts still deny them → the #244 case.
+        (True, DENIED, "still blocks writes"),
+        (True, ALLOWED, None),
+        (True, NO_PERMISSIONS, None),  # deny state undeterminable → no claim
+        (False, DENIED, None),
+        # Safety-critical direction: config locked writes out, artifacts did not.
+        (False, ALLOWED, "still permits writes"),
+        (False, NO_PERMISSIONS, None),
+        (None, DENIED, None),  # config state undeterminable → no claim
+        (None, ALLOWED, None),
+        (None, NO_PERMISSIONS, None),
+    ],
+    ids=[
+        "on-denied-drift",
+        "on-allowed-sync",
+        "on-nopermissions-silent",
+        "off-denied-sync",
+        "off-allowed-drift",
+        "off-nopermissions-silent",
+        "absent-denied-silent",
+        "absent-allowed-silent",
+        "absent-nopermissions-silent",
+    ],
+)
+def test_drift_matrix(tmp_path, run_drift, writes_enabled, channel_write, expected_fragment):
     config_path, settings_path = _make_project(
-        tmp_path, writes_enabled=False, channel_write_denied=True
+        tmp_path, writes_enabled=writes_enabled, channel_write=channel_write
     )
+    # Settings newer than config, so the mtime signal never fires and every
+    # warning below is attributable to the targeted writes_enabled check.
     _set_mtimes(config_path, settings_path, config_newer=False)
 
-    code, out, err = _run(tmp_path)
+    code, out, err = run_drift(tmp_path)
+
     assert code == 0
-    assert err.strip() == ""
-    assert out.strip() == ""
+    if expected_fragment is None:
+        assert err.strip() == ""
+        assert out.strip() == ""
+    else:
+        assert expected_fragment in err
+        assert expected_fragment in json.loads(out)["hookSpecificOutput"]["additionalContext"]
 
 
-def test_warns_on_writes_mismatch(tmp_path):
+def test_warns_on_writes_mismatch(tmp_path, run_drift):
     # config says writes enabled, but artifacts still deny the write → #244 case.
-    config_path, settings_path = _make_project(
-        tmp_path, writes_enabled=True, channel_write_denied=True
-    )
+    config_path, settings_path = _make_project(tmp_path, writes_enabled=True, channel_write=DENIED)
     # Even with settings newer (mtime in sync), the targeted check still fires.
     _set_mtimes(config_path, settings_path, config_newer=False)
 
-    code, out, err = _run(tmp_path)
+    code, out, err = run_drift(tmp_path)
     assert code == 0
     assert "writes_enabled: true" in err
     assert "regen" in err.lower()
@@ -105,17 +290,17 @@ def test_warns_on_writes_mismatch(tmp_path):
     assert "writes_enabled: true" in payload["hookSpecificOutput"]["additionalContext"]
 
 
-def test_warns_when_config_disables_writes_but_agent_permits(tmp_path):
+def test_warns_when_config_disables_writes_but_agent_permits(tmp_path, run_drift):
     # The safety-critical direction: config.yml turned writes OFF, but the stale
     # artifacts still permit them — the agent could write hardware the operator
     # believes is locked out.
     config_path, settings_path = _make_project(
-        tmp_path, writes_enabled=False, channel_write_denied=False
+        tmp_path, writes_enabled=False, channel_write=ALLOWED
     )
     # Settings newer than config: the targeted check must fire on its own.
     _set_mtimes(config_path, settings_path, config_newer=False)
 
-    code, out, err = _run(tmp_path)
+    code, out, err = run_drift(tmp_path)
     assert code == 0
     assert "writes_enabled: false" in err
     assert "permits writes" in err
@@ -124,28 +309,68 @@ def test_warns_when_config_disables_writes_but_agent_permits(tmp_path):
     assert "permits writes" in payload["hookSpecificOutput"]["additionalContext"]
 
 
-def test_warns_on_mtime_drift(tmp_path):
+def test_warns_on_mtime_drift(tmp_path, run_drift):
     # writes_enabled is consistent, but config.yml was edited after the last regen.
-    config_path, settings_path = _make_project(
-        tmp_path, writes_enabled=False, channel_write_denied=True
-    )
+    config_path, settings_path = _make_project(tmp_path, writes_enabled=False, channel_write=DENIED)
     _set_mtimes(config_path, settings_path, config_newer=True)
 
-    code, out, err = _run(tmp_path)
+    code, _out, err = run_drift(tmp_path)
     assert code == 0
     assert "changed since" in err
     assert "regen" in err.lower()
 
 
-def test_fails_open_when_artifacts_missing(tmp_path):
+def test_warning_is_mirrored_to_stderr_and_session_context(tmp_path, run_drift):
+    # The transcript line and the injected context must be the same warning, so
+    # the agent cannot relay something the operator does not also see.
+    config_path, settings_path = _make_project(tmp_path, writes_enabled=True, channel_write=DENIED)
+    _set_mtimes(config_path, settings_path, config_newer=False)
+
+    code, out, err = run_drift(tmp_path)
+    assert code == 0
+    payload = json.loads(out)
+    assert payload["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+    assert payload["hookSpecificOutput"]["additionalContext"] == err.strip()
+    assert err.strip().startswith("⚠")
+
+
+def test_warns_on_config_that_pyyaml_cannot_parse(tmp_path, run_drift):
+    # The hook must not depend on a YAML parser: under a raw `claude` launch the
+    # interpreter running it may have no PyYAML at all. A config broken elsewhere
+    # in the file still yields the kill-switch line by regex.
+    (tmp_path / ".claude").mkdir(parents=True)
+    config_path = tmp_path / "config.yml"
+    settings_path = tmp_path / ".claude" / "settings.json"
+    broken = "control_system:\n  writes_enabled: true\n  channels: [unclosed\n\t- tab-indented\n"
+    config_path.write_text(broken, encoding="utf-8")
+    settings_path.write_text(
+        json.dumps({"permissions": {"deny": [CHANNEL_WRITE]}}), encoding="utf-8"
+    )
+    _set_mtimes(config_path, settings_path, config_newer=False)
+
+    with pytest.raises(yaml.YAMLError):
+        yaml.safe_load(broken)
+
+    code, out, err = run_drift(tmp_path)
+    assert code == 0
+    assert "still blocks writes" in err
+    assert "still blocks writes" in json.loads(out)["hookSpecificOutput"]["additionalContext"]
+
+
+# --------------------------------------------------------------------------- #
+# Fail-open paths (subprocess)
+# --------------------------------------------------------------------------- #
+
+
+def test_fails_open_when_artifacts_missing(tmp_path, run_drift):
     # No config.yml / settings.json at all → silent, never blocks the session.
-    code, out, err = _run(tmp_path)
+    code, out, err = run_drift(tmp_path)
     assert code == 0
     assert err.strip() == ""
     assert out.strip() == ""
 
 
-def test_fails_open_on_malformed_permissions(tmp_path):
+def test_fails_open_on_malformed_permissions(tmp_path, run_drift):
     # Hand-edited settings.json with `permissions: null` must not crash the targeted
     # check; it falls back to the mtime signal (here pinned in-sync → silent).
     (tmp_path / ".claude").mkdir(parents=True)
@@ -155,19 +380,52 @@ def test_fails_open_on_malformed_permissions(tmp_path):
     settings_path.write_text(json.dumps({"permissions": None}), encoding="utf-8")
     _set_mtimes(config_path, settings_path, config_newer=False)
 
-    code, out, err = _run(tmp_path)
+    code, out, err = run_drift(tmp_path)
     assert code == 0
     assert err.strip() == ""
     assert out.strip() == ""
 
 
-@pytest.mark.parametrize("writes_enabled", [True, False])
-def test_consistent_states_are_silent(tmp_path, writes_enabled):
+@pytest.mark.skipif(
+    os.name != "posix" or os.geteuid() == 0,
+    reason="needs POSIX permissions and a non-root user to make a file unreadable",
+)
+def test_fails_open_when_settings_unreadable(tmp_path, run_drift):
+    # An unreadable settings.json would look like "writes permitted" to a hook
+    # that treated a failed read as absence. It must stay silent instead: the
+    # deny list is undeterminable, so there is nothing honest to warn about.
     config_path, settings_path = _make_project(
-        tmp_path, writes_enabled=writes_enabled, channel_write_denied=not writes_enabled
+        tmp_path, writes_enabled=False, channel_write=ALLOWED
     )
     _set_mtimes(config_path, settings_path, config_newer=False)
+    os.chmod(settings_path, 0o000)
 
-    code, _out, err = _run(tmp_path)
+    code, out, err = run_drift(tmp_path)
+    os.chmod(settings_path, stat.S_IRUSR | stat.S_IWUSR)
+
     assert code == 0
     assert err.strip() == ""
+    assert out.strip() == ""
+
+
+@pytest.mark.parametrize("stdin", ["", "{nope", "[]"], ids=["empty", "invalid-json", "wrong-shape"])
+def test_stdin_is_never_read(tmp_path, hook_runner_raw, monkeypatch, stdin):
+    # SessionStart hands the hook a JSON payload it does not use: the project
+    # root comes from CLAUDE_PROJECT_DIR and everything else from the two files.
+    # A closed pipe, a truncated write and a payload of the wrong JSON type all
+    # have to produce the same warning as a well-formed one — malformed stdin
+    # must neither crash the hook nor silence a real drift.
+    config_path, settings_path = _make_project(tmp_path, writes_enabled=True, channel_write=DENIED)
+    _set_mtimes(config_path, settings_path, config_newer=False)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+    code, out, err = hook_runner_raw(
+        HOOK_SCRIPT,
+        tool_name=None,
+        tool_input=None,
+        stdin_override=stdin,
+    )
+
+    assert code == 0
+    assert "Traceback" not in err
+    assert "still blocks writes" in json.loads(out)["hookSpecificOutput"]["additionalContext"]

--- a/tests/hooks/test_error_guidance_hook.py
+++ b/tests/hooks/test_error_guidance_hook.py
@@ -560,3 +560,259 @@ def test_custom_server_prefix_triggers_guidance(hook_runner, make_config):
     ctx = result["hookSpecificOutput"]["additionalContext"]
     assert "Connection" in ctx
     assert "error-handling" in ctx.lower()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("stdin", ["", "{nope", "[]"], ids=["empty", "invalid-json", "wrong-shape"])
+def test_malformed_stdin_fails_open(tmp_path, hook_runner_raw, stdin):
+    """Unusable stdin injects nothing instead of crashing the tool call.
+
+    A closed pipe, a truncated write and a non-object payload carry no tool
+    response to inspect. A PostToolUse hook that exited non-zero here would
+    surface as a failure on a tool call that already succeeded.
+    """
+    returncode, stdout, stderr = hook_runner_raw(
+        "osprey_error_guidance.py",
+        tool_name=None,
+        tool_input=None,
+        cwd=tmp_path,
+        stdin_override=stdin,
+    )
+
+    assert returncode == 0
+    assert stdout.strip() == ""
+    assert "Traceback" not in stderr
+
+
+# ============================================================================
+# _detect_error / ERROR_CLASS_MAP — direct in-process tests
+#
+# The tests above drive the hook end to end through a subprocess, which can
+# only observe the injected guidance text. These call the classifier directly
+# to pin the parts that text cannot show: the exact return tuple, which
+# response shapes are rejected outright, and the contents of the class table.
+# ============================================================================
+
+
+@pytest.fixture
+def error_guidance(hook_module):
+    """The hook module, imported in-process through the conftest seam.
+
+    Called here rather than at module scope: importing a hook mutates
+    ``sys.path`` and touches ``osprey_hook_log``'s config caches, and the audit
+    in ``tests/infrastructure/test_import_time_audit.py`` forbids doing that
+    while a test module is being collected.
+    """
+    return hook_module("osprey_error_guidance")
+
+
+#: The error_type -> class table the hook is expected to ship with, restated
+#: so a change to the hook's own map has to be made deliberately in both
+#: places; ``test_error_class_map_matches_expected_table`` asserts they agree.
+EXPECTED_ERROR_CLASSES = {
+    "connection_error": "Connection",
+    "timeout_error": "Connection",
+    "service_unavailable": "Connection",
+    "validation_error": "Validation",
+    "limits_violation": "Validation",
+    "not_found": "Data",
+    "no_results": "Data",
+    "file_not_found": "Data",
+    "execution_error": "Execution",
+    "lattice_error": "Execution",
+    "safety_error": "Safety",
+    "internal_error": "Internal",
+    "platform_error": "Internal",
+}
+
+#: The taxonomy documented in ``.claude/rules/error-handling.md``. Every class
+#: the hook can name has to have a row there, because the guidance it injects
+#: tells Claude to go read that file for the class it just reported.
+DOCUMENTED_ERROR_CLASSES = frozenset(
+    {"Connection", "Validation", "Data", "Execution", "Safety", "Internal"}
+)
+
+
+@pytest.mark.unit
+def test_error_class_map_matches_expected_table(error_guidance):
+    """The shipped map is exactly the table above — no silent additions."""
+    assert error_guidance.ERROR_CLASS_MAP == EXPECTED_ERROR_CLASSES
+
+
+@pytest.mark.unit
+def test_error_class_map_values_are_documented_classes(error_guidance):
+    """Every class the map can produce is one the protocol doc explains.
+
+    A class with no row in error-handling.md would send Claude to the protocol
+    for advice that is not written there.
+    """
+    assert set(error_guidance.ERROR_CLASS_MAP.values()) <= DOCUMENTED_ERROR_CLASSES
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("error_type", "expected_class"),
+    sorted(EXPECTED_ERROR_CLASSES.items()),
+)
+def test_detect_error_classifies_each_mapped_type(error_guidance, error_type, expected_class):
+    """Each mapped error_type resolves to its class, with the envelope message."""
+    response = _make_error_response(error_type, "the failure message")
+
+    assert error_guidance._detect_error(response) == (expected_class, "the failure message")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "error_type",
+    ["some_new_error_type", "permission_error", ""],
+    ids=["novel", "unmapped-but-plausible", "empty-string"],
+)
+def test_detect_error_unmapped_type_falls_back_to_internal(error_guidance, error_type):
+    """An error_type outside the table is still reported, as Internal."""
+    response = _make_error_response(error_type, "unrecognised failure")
+
+    assert error_guidance._detect_error(response) == ("Internal", "unrecognised failure")
+
+
+@pytest.mark.unit
+def test_detect_error_missing_error_type_falls_back_to_internal(error_guidance):
+    """An envelope with no error_type at all classifies as Internal."""
+    response = {
+        "isError": True,
+        "content": [{"type": "text", "text": json.dumps({"error": True, "error_message": "boom"})}],
+    }
+
+    assert error_guidance._detect_error(response) == ("Internal", "boom")
+
+
+@pytest.mark.unit
+def test_detect_error_without_message_reports_the_whole_envelope(error_guidance):
+    """With no error_message field, the raw envelope stands in as the message.
+
+    Better to hand Claude the whole dict than an empty string: the guidance
+    line is the only place the failure is described.
+    """
+    envelope = {"error": True, "error_type": "connection_error"}
+    response = {"isError": True, "content": [{"type": "text", "text": json.dumps(envelope)}]}
+
+    error_class, message = error_guidance._detect_error(response)
+
+    assert error_class == "Connection"
+    assert "connection_error" in message
+
+
+@pytest.mark.unit
+def test_detect_error_scans_past_blocks_that_are_not_the_envelope(error_guidance):
+    """The envelope is found wherever it sits in the content list.
+
+    Blocks that are the wrong type, are not dicts, do not parse as JSON, or
+    parse to something other than an error envelope are skipped rather than
+    ending the search.
+    """
+    response = {
+        "isError": True,
+        "content": [
+            {"type": "image", "data": "..."},
+            "a bare string, not a block",
+            {"type": "text", "text": "not JSON at all"},
+            {"type": "text", "text": json.dumps([1, 2, 3])},
+            {"type": "text", "text": json.dumps({"error": False, "note": "fine"})},
+            {
+                "type": "text",
+                "text": json.dumps(
+                    {"error": True, "error_type": "no_results", "error_message": "nothing matched"}
+                ),
+            },
+        ],
+    }
+
+    assert error_guidance._detect_error(response) == ("Data", "nothing matched")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "content",
+    [
+        [],
+        None,
+        [{"type": "text", "text": "plain prose, no envelope"}],
+        [{"type": "text", "text": "{truncated"}],
+        [{"type": "image", "data": "..."}],
+        [{"type": "text", "text": json.dumps({"error": False})}],
+    ],
+    ids=["empty", "null", "prose", "truncated-json", "non-text-block", "error-false"],
+)
+def test_detect_error_without_envelope_still_reports_internal(error_guidance, content):
+    """isError=True with no readable envelope still fires, classed Internal.
+
+    The guidance is worth more than the classification here: something failed,
+    and staying silent would leave Claude free to work around it.
+    """
+    response = {"isError": True, "content": content}
+
+    assert error_guidance._detect_error(response) == ("Internal", "Tool returned an error")
+
+
+@pytest.mark.unit
+def test_detect_error_without_content_key_reports_internal(error_guidance):
+    """A missing content list is the same case as an empty one."""
+    assert error_guidance._detect_error({"isError": True}) == ("Internal", "Tool returned an error")
+
+
+@pytest.mark.unit
+def test_detect_error_ignores_a_serialised_envelope(error_guidance):
+    """A JSON string carrying the envelope is not an error to this helper.
+
+    OSPREY tools return ``CallToolResult(isError=True, ...)``, so the hook
+    input always arrives as a dict. Sniffing strings for ``"error": true``
+    would misread a successful response that merely quotes one — a channel
+    listing, an archiver row, a log excerpt.
+    """
+    serialised = json.dumps(
+        {"error": True, "error_type": "connection_error", "error_message": "IOC offline"}
+    )
+
+    assert error_guidance._detect_error(serialised) == (None, None)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "tool_response",
+    [
+        None,
+        "",
+        "Channel read successful: SR:CURRENT:RB = 500.1",
+        [],
+        [{"type": "text", "text": "not a CallToolResult"}],
+        {},
+        {"content": [{"type": "text", "text": '{"error": true}'}]},
+        {"isError": False, "content": [{"type": "text", "text": '{"error": true}'}]},
+        {"isError": None},
+        {"isError": "true"},
+        {"isError": 1},
+        123,
+    ],
+    ids=[
+        "none",
+        "empty-string",
+        "success-string",
+        "empty-list",
+        "list-of-blocks",
+        "empty-dict",
+        "no-isError-key",
+        "isError-false",
+        "isError-null",
+        "isError-string",
+        "isError-truthy-int",
+        "number",
+    ],
+)
+def test_detect_error_ignores_non_error_responses(error_guidance, tool_response):
+    """Anything that is not a dict flagged ``isError: True`` is a non-error.
+
+    The check is identity against ``True``, so truthy stand-ins are rejected
+    too: a tool that reports ``isError: 1`` or ``"true"`` is not speaking the
+    CallToolResult protocol, and guessing at its intent would inject error
+    guidance into calls that succeeded.
+    """
+    assert error_guidance._detect_error(tool_response) == (None, None)

--- a/tests/hooks/test_feedback_capture_hook.py
+++ b/tests/hooks/test_feedback_capture_hook.py
@@ -282,3 +282,26 @@ class TestFeedbackCaptureNoTotal:
 
         items = _pending_items(tmp_path)
         assert len(items) == 0, f"Expected no items for total=0, got: {items}"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("stdin", ["", "{nope", "[]"], ids=["empty", "invalid-json", "wrong-shape"])
+def test_malformed_stdin_fails_open(tmp_path, hook_runner_raw, stdin):
+    """Unusable stdin captures nothing and leaves the tool call untouched.
+
+    A closed pipe, a truncated write and a non-object payload give the hook no
+    channel finder result to store, so it exits 0 without writing a pending
+    review or a decision envelope.
+    """
+    returncode, stdout, stderr = hook_runner_raw(
+        "osprey_cf_feedback_capture.py",
+        tool_name=None,
+        tool_input=None,
+        cwd=tmp_path,
+        stdin_override=stdin,
+    )
+
+    assert returncode == 0
+    assert stdout.strip() == ""
+    assert "Traceback" not in stderr
+    assert _pending_items(tmp_path) == {}

--- a/tests/hooks/test_focus_validate_hook.py
+++ b/tests/hooks/test_focus_validate_hook.py
@@ -5,42 +5,36 @@ lines that reference deleted artifact IDs (by cross-checking
 ``_agent_data/artifacts/artifacts.json``), and prints the cleaned content
 to stdout. It is defensive — never blocks a prompt — so all error paths
 fail open with exit code 0.
+
+The hook has a contract no other hook in the payload shares: stdin is
+ignored entirely, and stdout is *raw text* that Claude Code injects into
+the prompt rather than the JSON envelope every other hook emits. The
+behavioural tests below pin both halves of that.
 """
 
 import json
-import os
-import subprocess
-import sys
-from pathlib import Path
 
 import pytest
 
-HOOK_SCRIPT = (
-    Path(__file__).parents[2]
-    / "src"
-    / "osprey"
-    / "templates"
-    / "claude_code"
-    / "claude"
-    / "hooks"
-    / "osprey_focus_validate.py"
-)
+HOOK_NAME = "osprey_focus_validate.py"
 
 
-def _run(project_dir: Path) -> tuple[int, str, str]:
-    env = os.environ.copy()
-    env["CLAUDE_PROJECT_DIR"] = str(project_dir)
-    result = subprocess.run(
-        [sys.executable, str(HOOK_SCRIPT)],
-        input="",
-        capture_output=True,
-        text=True,
-        env=env,
+def _run(hook_runner_raw, monkeypatch, project_dir, stdin=None):
+    """Run the hook against ``project_dir`` and return (rc, stdout, stderr).
+
+    ``CLAUDE_PROJECT_DIR`` is set with ``monkeypatch`` so the curated
+    subprocess environment forwards it and the test process reverts it.
+    """
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project_dir))
+    return hook_runner_raw(
+        HOOK_NAME,
+        "UserPromptSubmit",
+        {},
+        stdin_override=stdin,
     )
-    return result.returncode, result.stdout, result.stderr
 
 
-def _seed(project_dir: Path, focus: str, entries: list[dict] | None) -> None:
+def _seed(project_dir, focus, entries):
     agent_data = project_dir / "_agent_data"
     (agent_data / "artifacts").mkdir(parents=True, exist_ok=True)
     (agent_data / "focus_state.txt").write_text(focus)
@@ -49,7 +43,7 @@ def _seed(project_dir: Path, focus: str, entries: list[dict] | None) -> None:
 
 
 @pytest.mark.unit
-def test_focus_validator_drops_stale_ids(tmp_path):
+def test_focus_validator_drops_stale_ids(hook_runner_raw, monkeypatch, tmp_path):
     """Lines referencing missing artifact IDs are dropped; valid lines kept."""
     focus = (
         "[Gallery Focus]\n"
@@ -57,13 +51,9 @@ def test_focus_validator_drops_stale_ids(tmp_path):
         '  pinned:   "Deleted Plot" (id=stale456)\n'
         '  pinned:   "Other Live" (id=valid789)\n'
     )
-    _seed(
-        tmp_path,
-        focus,
-        entries=[{"id": "valid123"}, {"id": "valid789"}],
-    )
+    _seed(tmp_path, focus, entries=[{"id": "valid123"}, {"id": "valid789"}])
 
-    rc, stdout, _ = _run(tmp_path)
+    rc, stdout, _ = _run(hook_runner_raw, monkeypatch, tmp_path)
     assert rc == 0
     assert "id=valid123" in stdout
     assert "id=valid789" in stdout
@@ -72,59 +62,166 @@ def test_focus_validator_drops_stale_ids(tmp_path):
 
 
 @pytest.mark.unit
-def test_focus_validator_drops_all_returns_empty(tmp_path):
+def test_focus_validator_drops_all_returns_empty(hook_runner_raw, monkeypatch, tmp_path):
     """When every line is stale, output is empty (header is also dropped)."""
     focus = '[Gallery Focus]\n  artifact: "Gone" (id=stale1)\n  pinned:   "Also Gone" (id=stale2)\n'
     _seed(tmp_path, focus, entries=[])
 
-    rc, stdout, _ = _run(tmp_path)
+    rc, stdout, _ = _run(hook_runner_raw, monkeypatch, tmp_path)
     assert rc == 0
     assert stdout == ""
 
 
 @pytest.mark.unit
-def test_focus_validator_fails_open_on_missing_index(tmp_path):
+def test_focus_validator_fails_open_on_missing_index(hook_runner_raw, monkeypatch, tmp_path):
     """If artifacts.json is missing, hook prints original contents and exits 0."""
     focus = '[Gallery Focus]\n  artifact: "Anything" (id=whatever)\n'
     _seed(tmp_path, focus, entries=None)  # No artifacts.json
 
-    rc, stdout, _ = _run(tmp_path)
+    rc, stdout, _ = _run(hook_runner_raw, monkeypatch, tmp_path)
     assert rc == 0
     assert stdout == focus
 
 
 @pytest.mark.unit
-def test_focus_validator_fails_open_on_malformed_index(tmp_path):
+def test_focus_validator_fails_open_on_malformed_index(hook_runner_raw, monkeypatch, tmp_path):
     """Malformed artifacts.json is treated as 'unknown' → fail open."""
-    agent_data = tmp_path / "_agent_data"
-    (agent_data / "artifacts").mkdir(parents=True, exist_ok=True)
     focus = '[Gallery Focus]\n  artifact: "Anything" (id=whatever)\n'
-    (agent_data / "focus_state.txt").write_text(focus)
-    (agent_data / "artifacts" / "artifacts.json").write_text("not json {{{")
+    _seed(tmp_path, focus, entries=None)
+    (tmp_path / "_agent_data" / "artifacts" / "artifacts.json").write_text("not json {{{")
 
-    rc, stdout, _ = _run(tmp_path)
+    rc, stdout, _ = _run(hook_runner_raw, monkeypatch, tmp_path)
     assert rc == 0
     assert stdout == focus
 
 
 @pytest.mark.unit
-def test_focus_validator_empty_focus_file(tmp_path):
+def test_focus_validator_empty_focus_file(hook_runner_raw, monkeypatch, tmp_path):
     """Empty focus_state.txt yields empty output (no spurious header)."""
     _seed(tmp_path, "", entries=[{"id": "anything"}])
 
-    rc, stdout, _ = _run(tmp_path)
+    rc, stdout, _ = _run(hook_runner_raw, monkeypatch, tmp_path)
     assert rc == 0
     assert stdout == ""
 
 
 @pytest.mark.unit
-def test_focus_validator_missing_focus_file(tmp_path):
+def test_focus_validator_missing_focus_file(hook_runner_raw, monkeypatch, tmp_path):
     """No focus_state.txt at all yields empty output, exit 0."""
     (tmp_path / "_agent_data" / "artifacts").mkdir(parents=True)
     (tmp_path / "_agent_data" / "artifacts" / "artifacts.json").write_text(
         json.dumps({"entries": []})
     )
 
-    rc, stdout, _ = _run(tmp_path)
+    rc, stdout, _ = _run(hook_runner_raw, monkeypatch, tmp_path)
     assert rc == 0
     assert stdout == ""
+
+
+@pytest.mark.unit
+def test_focus_validator_keeps_lines_without_ids(hook_runner_raw, monkeypatch, tmp_path):
+    """Lines carrying no ``(id=...)`` pass through untouched."""
+    focus = (
+        "[Gallery Focus]\n"
+        "  (no artifacts pinned yet)\n"
+        '  artifact: "Live" (id=live1)\n'
+        '  pinned:   "Gone" (id=dead1)\n'
+        "  note: gallery refreshed manually\n"
+    )
+    _seed(tmp_path, focus, entries=[{"id": "live1"}])
+
+    rc, stdout, _ = _run(hook_runner_raw, monkeypatch, tmp_path)
+    assert rc == 0
+    assert stdout == (
+        "[Gallery Focus]\n"
+        "  (no artifacts pinned yet)\n"
+        '  artifact: "Live" (id=live1)\n'
+        "  note: gallery refreshed manually\n"
+    )
+
+
+@pytest.mark.unit
+def test_focus_validator_ignores_stdin(hook_runner_raw, monkeypatch, tmp_path):
+    """Output depends only on the files — stdin is never read.
+
+    The hook is wired to UserPromptSubmit, where Claude Code hands it a JSON
+    payload on stdin. It reads none of it: a well-formed payload naming a
+    different project, valid JSON of the wrong type, unparseable bytes and a
+    closed-empty stdin all produce byte-identical output.
+    """
+    focus = '[Gallery Focus]\n  artifact: "Live" (id=live1)\n  pinned: "Gone" (id=dead1)\n'
+    _seed(tmp_path, focus, entries=[{"id": "live1"}])
+
+    decoy = tmp_path / "decoy"
+    _seed(decoy, '[Gallery Focus]\n  artifact: "Decoy" (id=live1)\n', entries=[{"id": "live1"}])
+
+    expected = '[Gallery Focus]\n  artifact: "Live" (id=live1)\n'
+    stdins = [
+        "",
+        json.dumps({"prompt": "hello", "cwd": str(decoy), "session_id": "abc"}),
+        "not json at all {{{ \x00 binary-ish",
+        "[]",
+    ]
+    for stdin in stdins:
+        rc, stdout, stderr = _run(hook_runner_raw, monkeypatch, tmp_path, stdin=stdin)
+        assert rc == 0, f"non-zero exit for stdin {stdin!r}"
+        assert stdout == expected, f"stdout changed for stdin {stdin!r}"
+        assert "Traceback" not in stderr, f"hook crashed for stdin {stdin!r}"
+
+
+@pytest.mark.unit
+def test_focus_validator_emits_raw_text_not_json(hook_runner_raw, monkeypatch, tmp_path):
+    """stdout is the prompt text itself, not a JSON hook envelope."""
+    focus = '[Gallery Focus]\n  artifact: "Live Plot" (id=live1)\n'
+    _seed(tmp_path, focus, entries=[{"id": "live1"}])
+
+    rc, stdout, stderr = _run(hook_runner_raw, monkeypatch, tmp_path)
+    assert rc == 0
+    assert stdout == focus
+    assert stderr == ""
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(stdout)
+
+
+@pytest.mark.unit
+def test_clean_filters_lines_and_preserves_shape():
+    """``_clean`` keeps valid and id-less lines, and preserves file shape."""
+    from osprey.templates.claude_code.claude.hooks.osprey_focus_validate import _clean
+
+    assert _clean("", {"a"}) == ""
+
+    headed = '[Gallery Focus]\n  artifact: "A" (id=a)\n  pinned: "B" (id=b)\n'
+    assert _clean(headed, {"a"}) == '[Gallery Focus]\n  artifact: "A" (id=a)\n'
+    assert _clean(headed, set()) == ""
+
+    # No header: body is returned as-is, and the trailing newline tracks the input.
+    assert _clean("  x (id=a)\n  y (id=b)\n", {"a"}) == "  x (id=a)\n"
+    assert _clean("  x (id=a)", {"a"}) == "  x (id=a)"
+
+    # A line with no ``(id=...)`` is never dropped, even with no valid ids.
+    assert _clean("plain line\n", set()) == "plain line\n"
+
+
+@pytest.mark.unit
+def test_load_valid_ids_returns_none_on_unusable_index(tmp_path):
+    """``_load_valid_ids`` distinguishes 'no ids' from 'cannot tell' (``None``)."""
+    from osprey.templates.claude_code.claude.hooks.osprey_focus_validate import _load_valid_ids
+
+    index = tmp_path / "artifacts.json"
+
+    assert _load_valid_ids(index) is None  # Missing file.
+
+    index.write_text("not json {{{")
+    assert _load_valid_ids(index) is None  # Unparseable.
+
+    index.write_text(json.dumps(["a", "b"]))
+    assert _load_valid_ids(index) is None  # Top level is not a mapping.
+
+    index.write_text(json.dumps({"entries": {"id": "a"}}))
+    assert _load_valid_ids(index) is None  # ``entries`` is not a list.
+
+    index.write_text(json.dumps({"entries": []}))
+    assert _load_valid_ids(index) == set()  # Empty index means "everything is stale".
+
+    index.write_text(json.dumps({"entries": [{"id": "a"}, {"name": "no id"}, "junk", {"id": "b"}]}))
+    assert _load_valid_ids(index) == {"a", "b"}  # Malformed entries are skipped, not fatal.

--- a/tests/hooks/test_hook_docstring_frontmatter.py
+++ b/tests/hooks/test_hook_docstring_frontmatter.py
@@ -4,7 +4,7 @@ Validates that each OSPREY hook template has a properly structured docstring
 with YAML front matter (name, description, event) and an ASCII flow diagram.
 """
 
-import importlib.util
+import ast
 import re
 from pathlib import Path
 
@@ -23,21 +23,36 @@ HOOK_FILES = [
     "osprey_notebook_update.py",
     "osprey_memory_guard.py",
     "osprey_config_drift.py",
+    "osprey_focus_validate.py",
+    "osprey_panels_context.py",
+    "osprey_cf_feedback_capture.py",
 ]
 
 # Required fields for all hooks
 REQUIRED_FIELDS = {"name", "description", "event"}
 
 
+def test_hook_files_cover_every_hook():
+    """HOOK_FILES must track every hook payload so new hooks can't be silently omitted.
+
+    osprey_hook_log.py is excluded: it's the frontmatter-less shared logging
+    library imported by the hooks above, not a hook itself.
+    """
+    on_disk = {p.name for p in HOOKS_DIR.glob("osprey_*.py")} - {"osprey_hook_log.py"}
+    assert set(HOOK_FILES) == on_disk
+
+
 def _load_docstring(hook_filename: str) -> str:
-    """Import a hook module and return its __doc__ string."""
+    """Return a hook's module docstring without importing it.
+
+    Read from the AST rather than from ``__doc__`` because importing is
+    destructive here. ``osprey_cf_feedback_capture.py`` runs its whole body at
+    module scope and ends in ``sys.exit``, which would tear the test run down
+    with it, and most of the others prepend their own directory to ``sys.path``
+    at import time. This helper covers every hook, so it takes neither risk.
+    """
     path = HOOKS_DIR / hook_filename
     assert path.exists(), f"Hook file not found: {path}"
-
-    importlib.util.spec_from_file_location(hook_filename.removesuffix(".py"), path)
-    # Don't actually execute the module (it calls sys.exit) — just compile it
-    # and extract the docstring from the AST
-    import ast
 
     tree = ast.parse(path.read_text())
     docstring = ast.get_docstring(tree)
@@ -97,9 +112,10 @@ class TestHookFrontMatter:
 
         # Look for a fenced code block containing arrow characters
         assert "```" in body, "Body should contain a fenced code block with a flow diagram"
-        # Check for arrow-like characters that indicate a flow diagram
-        assert re.search(r"[─►▼▲◄┼┌┐└┘│├┤]", body), (
-            "Body should contain ASCII box-drawing characters for the flow diagram"
+        # Check for arrow-like characters that indicate a flow diagram — either
+        # box-drawing characters or plain-ASCII "-->" arrows.
+        assert re.search(r"-->|[─►▼▲◄┼┌┐└┘│├┤]", body), (
+            "Body should contain a flow diagram (box-drawing chars or ASCII arrows)"
         )
 
     def test_yaml_is_valid(self, hook_file):

--- a/tests/hooks/test_limits_hook.py
+++ b/tests/hooks/test_limits_hook.py
@@ -304,3 +304,25 @@ def test_step_size_blocks_when_current_value_unreadable(tmp_path, hook_runner):
     assert result is not None
     assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
     assert "step size" in result["hookSpecificOutput"]["permissionDecisionReason"].lower()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("stdin", ["", "{nope", "[]"], ids=["empty", "invalid-json", "wrong-shape"])
+def test_malformed_stdin_fails_open(tmp_path, hook_runner_raw, stdin):
+    """Unusable stdin allows the write through rather than denying it.
+
+    Limits validation is fail-closed once it has a channel and a value, but it
+    never gets that far here: a closed pipe, a truncated write or a non-object
+    payload leaves nothing to validate, so the hook exits 0 with no decision.
+    """
+    returncode, stdout, stderr = hook_runner_raw(
+        "osprey_limits.py",
+        tool_name=None,
+        tool_input=None,
+        cwd=tmp_path,
+        stdin_override=stdin,
+    )
+
+    assert returncode == 0
+    assert stdout.strip() == ""
+    assert "Traceback" not in stderr

--- a/tests/hooks/test_memory_guard_hook.py
+++ b/tests/hooks/test_memory_guard_hook.py
@@ -5,31 +5,114 @@ Writes targeting ``~/.claude/projects/<encoded>/memory/*.md`` are allowed;
 everything else is denied. Non-Write tools pass through without opinion.
 """
 
-from pathlib import Path
-
 import pytest
 
 from osprey.agent_runner.project_paths import encode_claude_project_path
 
 
-def _memory_dir_for(home: Path, project_dir: str) -> Path:
-    """Mirror the hook's resolve_memory_dir logic for test assertions.
+@pytest.fixture
+def memory_guard(hook_module):
+    """The hook module, for tests that call its helpers directly."""
+    return hook_module("osprey_memory_guard")
 
-    ``home`` is the curated ``$HOME`` the hook subprocess runs under (the
-    ``hook_home`` fixture), never the developer's real home directory.
+
+@pytest.fixture
+def memory_dir_for(memory_guard, hook_home):
+    """Resolve a project's memory directory the way the hook does.
+
+    Delegates to the hook's own ``resolve_memory_dir`` so the expected paths
+    cannot drift from the implementation they are meant to describe. The result
+    is pinned under ``hook_home`` — the curated ``$HOME`` the hook subprocess
+    runs under — so a break in the ``$HOME`` isolation surfaces here instead of
+    as a write into the developer's real home directory.
     """
-    encoded = encode_claude_project_path(project_dir)
-    return home / ".claude" / "projects" / encoded / "memory"
+
+    def _resolve(project_dir):
+        memory_dir = memory_guard.resolve_memory_dir(str(project_dir))
+        assert hook_home in memory_dir.parents
+        return memory_dir
+
+    return _resolve
+
+
+# -- Path encoding --
+
+
+@pytest.mark.unit
+def test_memory_dir_is_home_relative(tmp_path, memory_guard, hook_home):
+    """The memory dir is ``$HOME/.claude/projects/<encoded>/memory``."""
+    encoded = encode_claude_project_path(tmp_path)
+
+    assert memory_guard.resolve_memory_dir(str(tmp_path)) == (
+        hook_home / ".claude" / "projects" / encoded / "memory"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "project_name",
+    ["plain", "with spaces", "dotted.name.v2", "under_score+plus@sign"],
+    ids=["plain", "spaces", "dots", "non-alnum"],
+)
+def test_encoding_matches_packaged_helper(tmp_path, memory_guard, project_name):
+    """The hook's inlined encoding agrees with ``encode_claude_project_path``.
+
+    The hook duplicates the regex on purpose: it runs inside user projects where
+    the ``osprey`` package may not be importable at hook-execution time. Nothing
+    but this test keeps the copies together, and drift is silent — Claude Code
+    would store memories under one directory name while the guard allows writes
+    to another.
+    """
+    project_dir = tmp_path / project_name
+    project_dir.mkdir()
+
+    memory_dir = memory_guard.resolve_memory_dir(str(project_dir))
+
+    assert memory_dir.parent.name == encode_claude_project_path(project_dir)
+
+
+# -- Write predicate --
+
+
+@pytest.mark.unit
+def test_predicate_allows_md_direct_child(tmp_path, memory_guard, memory_dir_for):
+    """A ``.md`` file directly inside the memory dir is allowed."""
+    memory_dir = memory_dir_for(tmp_path)
+
+    assert memory_guard.is_allowed_memory_write(str(memory_dir / "channels.md"), memory_dir)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("build_path", "rejected_for"),
+    [
+        (lambda d: d / "script.py", "not a .md file"),
+        (lambda d: d.parent / "notes.md", "outside the memory directory"),
+        (lambda d: d / "subdir" / "notes.md", "nested rather than a direct child"),
+        (lambda d: d / "subdir" / ".." / "notes.md", "traversal in the raw input"),
+    ],
+    ids=["wrong-suffix", "outside-dir", "nested", "traversal"],
+)
+def test_predicate_rejects(tmp_path, memory_guard, memory_dir_for, build_path, rejected_for):
+    """Each rejection branch is reachable on its own.
+
+    The ``traversal`` case resolves back to a legitimate memory file and is
+    turned down only by the literal ``..`` check on the caller's string.
+    """
+    memory_dir = memory_dir_for(tmp_path)
+
+    assert not memory_guard.is_allowed_memory_write(str(build_path(memory_dir)), memory_dir), (
+        f"should be rejected: {rejected_for}"
+    )
 
 
 # -- Allow cases --
 
 
 @pytest.mark.unit
-def test_allows_write_to_memory_md(tmp_path, hook_runner, hook_home):
+def test_allows_write_to_memory_md(tmp_path, hook_runner, memory_dir_for):
     """Write to a .md file inside the Claude memory directory is allowed."""
-    memory_dir = _memory_dir_for(hook_home, str(tmp_path))
-    target = str(memory_dir / "channels.md")
+    target = str(memory_dir_for(tmp_path) / "channels.md")
 
     result = hook_runner(
         "osprey_memory_guard.py",
@@ -43,10 +126,9 @@ def test_allows_write_to_memory_md(tmp_path, hook_runner, hook_home):
 
 
 @pytest.mark.unit
-def test_allows_primary_memory_file(tmp_path, hook_runner, hook_home):
+def test_allows_primary_memory_file(tmp_path, hook_runner, memory_dir_for):
     """MEMORY.md (the primary memory file) is allowed."""
-    memory_dir = _memory_dir_for(hook_home, str(tmp_path))
-    target = str(memory_dir / "MEMORY.md")
+    target = str(memory_dir_for(tmp_path) / "MEMORY.md")
 
     result = hook_runner(
         "osprey_memory_guard.py",
@@ -95,10 +177,9 @@ def test_denies_write_to_project_claude_md(tmp_path, hook_runner):
 
 
 @pytest.mark.unit
-def test_denies_non_md_in_memory_dir(tmp_path, hook_runner, hook_home):
+def test_denies_non_md_in_memory_dir(tmp_path, hook_runner, memory_dir_for):
     """Write to the memory directory but with a non-.md extension is denied."""
-    memory_dir = _memory_dir_for(hook_home, str(tmp_path))
-    target = str(memory_dir / "script.py")
+    target = str(memory_dir_for(tmp_path) / "script.py")
 
     result = hook_runner(
         "osprey_memory_guard.py",
@@ -112,10 +193,9 @@ def test_denies_non_md_in_memory_dir(tmp_path, hook_runner, hook_home):
 
 
 @pytest.mark.unit
-def test_denies_subdirectory_in_memory_dir(tmp_path, hook_runner, hook_home):
+def test_denies_subdirectory_in_memory_dir(tmp_path, hook_runner, memory_dir_for):
     """Write to a subdirectory within the memory dir is denied (direct children only)."""
-    memory_dir = _memory_dir_for(hook_home, str(tmp_path))
-    target = str(memory_dir / "subdir" / "notes.md")
+    target = str(memory_dir_for(tmp_path) / "subdir" / "notes.md")
 
     result = hook_runner(
         "osprey_memory_guard.py",
@@ -129,10 +209,9 @@ def test_denies_subdirectory_in_memory_dir(tmp_path, hook_runner, hook_home):
 
 
 @pytest.mark.unit
-def test_denies_path_traversal(tmp_path, hook_runner, hook_home):
+def test_denies_path_traversal(tmp_path, hook_runner, memory_dir_for):
     """Write with path traversal components is denied."""
-    memory_dir = _memory_dir_for(hook_home, str(tmp_path))
-    target = str(memory_dir / ".." / ".." / ".." / ".bashrc")
+    target = str(memory_dir_for(tmp_path) / ".." / ".." / ".." / ".bashrc")
 
     result = hook_runner(
         "osprey_memory_guard.py",
@@ -227,12 +306,11 @@ def test_deny_message_includes_allowed_directory(tmp_path, hook_runner):
 
 
 @pytest.mark.unit
-def test_uses_claude_project_dir_env(tmp_path, hook_runner, hook_home, monkeypatch):
+def test_uses_claude_project_dir_env(tmp_path, hook_runner, memory_dir_for, monkeypatch):
     """Hook respects CLAUDE_PROJECT_DIR env var over CWD."""
     project_dir = tmp_path / "my-project"
     project_dir.mkdir()
-    memory_dir = _memory_dir_for(hook_home, str(project_dir))
-    target = str(memory_dir / "notes.md")
+    target = str(memory_dir_for(project_dir) / "notes.md")
 
     monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project_dir))
 
@@ -245,3 +323,26 @@ def test_uses_claude_project_dir_env(tmp_path, hook_runner, hook_home, monkeypat
 
     assert result is not None
     assert result["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("stdin", ["", "{nope", "[]"], ids=["empty", "invalid-json", "wrong-shape"])
+def test_malformed_stdin_fails_open(tmp_path, hook_runner_raw, stdin):
+    """Unusable stdin yields no opinion — not a deny.
+
+    The guard denies writes it can see and does not recognise, but a closed
+    pipe, a truncated write or a non-object payload names no tool at all. With
+    no ``tool_name`` to match, the hook exits 0 silently and Write is left to
+    the rest of the permission chain.
+    """
+    returncode, stdout, stderr = hook_runner_raw(
+        "osprey_memory_guard.py",
+        tool_name=None,
+        tool_input=None,
+        cwd=tmp_path,
+        stdin_override=stdin,
+    )
+
+    assert returncode == 0
+    assert stdout.strip() == ""
+    assert "Traceback" not in stderr

--- a/tests/hooks/test_notebook_update_hook.py
+++ b/tests/hooks/test_notebook_update_hook.py
@@ -2,94 +2,194 @@
 
 This hook invalidates cached rendered HTML when a notebook is edited
 via NotebookEdit, ensuring the gallery re-renders on next view.
-"""
 
-import json
-import os
-import subprocess
-import sys
-from pathlib import Path
+The observable contract is small: delete ``_notebook_cache/{stem}_rendered.html``
+when it is there, leave the tree alone when it is not, log which of the two
+happened under debug, and never fail the tool call — whatever the input or the
+state of the filesystem.
+"""
 
 import pytest
 
-HOOKS_DIR = (
-    Path(__file__).parents[2] / "src" / "osprey" / "templates" / "claude_code" / "claude" / "hooks"
-)
+HOOK_NAME = "osprey_notebook_update.py"
 
 
-def run_notebook_update_hook(tool_input, cwd=None):
-    """Run the notebook update hook as a subprocess."""
-    hook_script = HOOKS_DIR / "osprey_notebook_update.py"
-    stdin_data = json.dumps(
-        {
-            "tool_name": "NotebookEdit",
-            "tool_input": tool_input,
-        }
-    )
-    result = subprocess.run(
-        [sys.executable, str(hook_script)],
-        input=stdin_data,
-        capture_output=True,
-        text=True,
-        env=os.environ.copy(),
-        cwd=str(cwd) if cwd else None,
-    )
-    assert result.returncode == 0, f"Hook failed (exit {result.returncode}): {result.stderr}"
-    return result
+def snapshot(root):
+    """Map every path under ``root`` to its bytes (``None`` for directories)."""
+    return {
+        path.relative_to(root).as_posix(): (path.read_bytes() if path.is_file() else None)
+        for path in root.rglob("*")
+    }
+
+
+@pytest.fixture(autouse=True)
+def _project_dir_in_tmp_tree(tmp_path, monkeypatch):
+    """Pin the hook's project directory at the per-test tree.
+
+    Leak guarded: the curated hook environment forwards ``CLAUDE_PROJECT_DIR``
+    and ``OSPREY_HOOK_DEBUG`` when they are set in the parent process. Left
+    ambient, ``log_hook`` would resolve ``hooks.debug`` from the real
+    checkout's ``config.yml`` and append its JSONL record under the real
+    ``.claude/hooks/``. Debug tests opt back in with ``monkeypatch.setenv``.
+    """
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    monkeypatch.delenv("OSPREY_HOOK_DEBUG", raising=False)
+
+
+@pytest.fixture
+def run_notebook_update_hook(hook_runner_raw):
+    """Run the hook over a tmp_path project tree, returning its stderr.
+
+    Asserts the two invariants shared by every call: the hook exits 0, and it
+    writes nothing to stdout. Stdout is the channel Claude Code parses for a
+    hook decision, so a PostToolUse hook that only touches the cache must
+    leave it empty.
+    """
+
+    def _run(tool_input, cwd):
+        returncode, stdout, stderr = hook_runner_raw(
+            HOOK_NAME,
+            "NotebookEdit",
+            tool_input,
+            cwd=cwd,
+        )
+        assert returncode == 0, f"Hook failed (exit {returncode}): {stderr}"
+        assert stdout == "", f"Hook wrote to stdout: {stdout!r}"
+        return stderr
+
+    return _run
 
 
 @pytest.mark.unit
-def test_notebook_update_deletes_cache(tmp_path):
-    """Hook deletes cached HTML for the edited notebook."""
-    # Create a fake notebook and its cached HTML
+def test_notebook_update_deletes_cache(tmp_path, run_notebook_update_hook):
+    """Hook deletes the cached HTML for the edited notebook, and only that."""
     nb_path = tmp_path / "test_notebook.ipynb"
     nb_path.write_text("{}")
     cache_dir = tmp_path / "_notebook_cache"
     cache_dir.mkdir()
     cached_html = cache_dir / "test_notebook_rendered.html"
     cached_html.write_text("<html>cached</html>")
+    other_html = cache_dir / "other_notebook_rendered.html"
+    other_html.write_text("<html>other</html>")
 
-    assert cached_html.exists()
-
-    run_notebook_update_hook(
-        {"notebook_path": str(nb_path)},
-        cwd=tmp_path,
-    )
+    run_notebook_update_hook({"notebook_path": str(nb_path)}, cwd=tmp_path)
 
     assert not cached_html.exists()
+    # A different notebook's cache and the notebook itself survive.
+    assert other_html.read_text() == "<html>other</html>"
+    assert nb_path.read_text() == "{}"
 
 
 @pytest.mark.unit
-def test_notebook_update_no_cache_no_error(tmp_path):
-    """Hook succeeds even when no cache file exists."""
+def test_notebook_update_logs_invalidated_on_cache_hit(
+    tmp_path, monkeypatch, run_notebook_update_hook
+):
+    """Debug logging names the deletion: ``status=invalidated`` plus the path."""
+    monkeypatch.setenv("OSPREY_HOOK_DEBUG", "1")
+    nb_path = tmp_path / "run_log.ipynb"
+    nb_path.write_text("{}")
+    cache_dir = tmp_path / "_notebook_cache"
+    cache_dir.mkdir()
+    (cache_dir / "run_log_rendered.html").write_text("<html>cached</html>")
+
+    stderr = run_notebook_update_hook({"notebook_path": str(nb_path)}, cwd=tmp_path)
+
+    assert "[notebook-update]" in stderr
+    assert "status=invalidated" in stderr
+    assert f"path={nb_path}" in stderr
+
+
+@pytest.mark.unit
+def test_notebook_update_no_cache_leaves_tree_untouched(tmp_path, run_notebook_update_hook):
+    """The cache-miss path is a pure no-op: nothing created, nothing removed."""
+    nb_path = tmp_path / "uncached.ipynb"
+    nb_path.write_text("{}")
+    cache_dir = tmp_path / "_notebook_cache"
+    cache_dir.mkdir()
+    # Cache exists but holds no entry for this notebook.
+    (cache_dir / "different_notebook_rendered.html").write_text("<html>other</html>")
+    before = snapshot(tmp_path)
+
+    run_notebook_update_hook({"notebook_path": str(nb_path)}, cwd=tmp_path)
+
+    assert snapshot(tmp_path) == before
+
+
+@pytest.mark.unit
+def test_notebook_update_logs_no_cache_on_cache_miss(
+    tmp_path, monkeypatch, run_notebook_update_hook
+):
+    """Debug logging distinguishes the miss: ``status=no-cache``."""
+    monkeypatch.setenv("OSPREY_HOOK_DEBUG", "1")
     nb_path = tmp_path / "uncached.ipynb"
     nb_path.write_text("{}")
 
-    result = run_notebook_update_hook(
-        {"notebook_path": str(nb_path)},
-        cwd=tmp_path,
-    )
+    stderr = run_notebook_update_hook({"notebook_path": str(nb_path)}, cwd=tmp_path)
 
-    assert result.returncode == 0
+    assert "status=no-cache" in stderr
+    assert "status=invalidated" not in stderr
 
 
 @pytest.mark.unit
-def test_notebook_update_empty_path_no_error(tmp_path):
-    """Hook handles empty notebook_path gracefully."""
-    result = run_notebook_update_hook(
-        {"notebook_path": ""},
-        cwd=tmp_path,
-    )
+def test_notebook_update_empty_path_exits_before_logging(
+    tmp_path, monkeypatch, run_notebook_update_hook
+):
+    """An empty notebook_path returns early — no cache lookup, no log line."""
+    monkeypatch.setenv("OSPREY_HOOK_DEBUG", "1")
 
-    assert result.returncode == 0
+    stderr = run_notebook_update_hook({"notebook_path": ""}, cwd=tmp_path)
+
+    assert "[notebook-update]" not in stderr
 
 
 @pytest.mark.unit
-def test_notebook_update_missing_key_no_error(tmp_path):
-    """Hook handles missing notebook_path key gracefully."""
-    result = run_notebook_update_hook(
-        {},
+def test_notebook_update_missing_key_no_error(tmp_path, run_notebook_update_hook):
+    """Hook handles a tool_input with no notebook_path key at all."""
+    run_notebook_update_hook({}, cwd=tmp_path)
+
+
+@pytest.mark.unit
+def test_notebook_update_swallows_unlink_failure(tmp_path, run_notebook_update_hook):
+    """A cache entry that cannot be unlinked still exits 0 and blocks nothing.
+
+    The cache path is occupied by a directory rather than a file, so it passes
+    the ``exists()`` check and then fails the ``unlink()`` — an OSError raised
+    from inside the invalidation block. Using a directory rather than a
+    read-only parent keeps the failure deterministic: revoked write permission
+    is not enforced against a root-owned test runner.
+    """
+    nb_path = tmp_path / "wedged.ipynb"
+    nb_path.write_text("{}")
+    blocked = tmp_path / "_notebook_cache" / "wedged_rendered.html"
+    blocked.mkdir(parents=True)
+    (blocked / "keep.txt").write_text("not a cache file")
+    before = snapshot(tmp_path)
+
+    run_notebook_update_hook({"notebook_path": str(nb_path)}, cwd=tmp_path)
+
+    assert snapshot(tmp_path) == before
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("stdin", ["", "{nope", "[]"], ids=["empty", "invalid-json", "wrong-shape"])
+def test_malformed_stdin_fails_open(tmp_path, hook_runner_raw, stdin):
+    """Unusable stdin leaves the tree alone and the tool call intact.
+
+    A closed pipe, a truncated write and a non-object payload name no
+    notebook, so there is no cache entry to invalidate: exit 0, nothing on
+    stdout, and not a byte changed under the project directory.
+    """
+    before = snapshot(tmp_path)
+
+    returncode, stdout, stderr = hook_runner_raw(
+        HOOK_NAME,
+        tool_name=None,
+        tool_input=None,
         cwd=tmp_path,
+        stdin_override=stdin,
     )
 
-    assert result.returncode == 0
+    assert returncode == 0
+    assert stdout.strip() == ""
+    assert "Traceback" not in stderr
+    assert snapshot(tmp_path) == before

--- a/tests/hooks/test_osprey_panels_context.py
+++ b/tests/hooks/test_osprey_panels_context.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 import osprey.templates.claude_code.claude.hooks.osprey_panels_context as panels
 
 
@@ -160,3 +162,34 @@ def test_main_uses_configured_web_port(monkeypatch):
     monkeypatch.setattr(panels.urllib.request, "urlopen", _fake)
     panels.main()
     assert "127.0.0.1:9123/api/panels" in seen["url"]
+
+
+# ---------------------------------------------------------------------------
+# Fail-open on malformed stdin (subprocess)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("stdin", ["", "{nope", "[]"], ids=["empty", "invalid-json", "wrong-shape"])
+def test_malformed_stdin_fails_open(hook_runner_raw, monkeypatch, stdin):
+    """Stdin the hook cannot use still leaves the session start unblocked.
+
+    SessionStart hands the hook a JSON payload it never reads. Run as a real
+    subprocess, a closed pipe, a truncated write and a payload of the wrong
+    JSON type must each exit 0 with nothing on stdout. ``OSPREY_WEB_PORT``
+    points at a port nobody is listening on so the result does not depend on
+    whether a web terminal happens to be running on the developer's machine.
+    """
+    from osprey.interfaces._serving import free_port
+
+    monkeypatch.setenv("OSPREY_WEB_PORT", str(free_port()))
+
+    returncode, stdout, stderr = hook_runner_raw(
+        "osprey_panels_context.py",
+        tool_name=None,
+        tool_input=None,
+        stdin_override=stdin,
+    )
+
+    assert returncode == 0
+    assert stdout.strip() == ""
+    assert "Traceback" not in stderr

--- a/tests/hooks/test_writes_check_hook.py
+++ b/tests/hooks/test_writes_check_hook.py
@@ -251,3 +251,26 @@ def test_fallback_defaults_when_no_hook_config(tmp_path, hook_runner, make_confi
 
     assert result is not None
     assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("stdin", ["", "{nope", "[]"], ids=["empty", "invalid-json", "wrong-shape"])
+def test_malformed_stdin_fails_open(tmp_path, hook_runner_raw, stdin):
+    """Stdin the hook cannot use lets the tool through instead of blocking it.
+
+    The three shapes are a closed pipe, a truncated write, and a payload whose
+    JSON is valid but is not the expected object. A PreToolUse hook fails open
+    by exiting 0 and printing no decision — anything else would turn a bad
+    payload into a denied tool call.
+    """
+    returncode, stdout, stderr = hook_runner_raw(
+        "osprey_writes_check.py",
+        tool_name=None,
+        tool_input=None,
+        cwd=tmp_path,
+        stdin_override=stdin,
+    )
+
+    assert returncode == 0
+    assert stdout.strip() == ""
+    assert "Traceback" not in stderr


### PR DESCRIPTION
Bring `src/osprey/templates/` — the shipped Claude Code hook payload — under honest test coverage, fix the preset bug that left two wired hooks unshipped, and pin the render-side invariants that would have caught it. Zero changes to any shipped payload file; every gain comes from tests and from fixing the measurement itself.

## What changed

- **Preset fix (user-visible):** every rendered `settings.json` wires `osprey_focus_validate.py` and `osprey_panels_context.py`, but no preset shipped the files — dead references masked by the hooks' `2>/dev/null || true` suffix. The five base presets now ship both hooks, `osprey_panels_context.py` is tracked for regeneration, and `test_control_assistant_has_all_hooks` asserts the exact rendered hook set.
- **Coverage attribution:** eight of the eleven hooks run only as subprocesses, which coverage never credited — pytest-cov 7 dropped subprocess measurement, leaving the old `COV_CORE_*` env forwarding dead. Switched to coverage.py's `patch = ["subprocess"]` with `COVERAGE_PROCESS_CONFIG` forwarded through the hook test harness's curated env.
- **Import seam:** an allowlisted `import_hook()` helper in the hooks conftest imports hook modules in-process at test runtime (never module scope), strips the shim's `sys.path` entry after import, and resets `osprey_hook_log`'s config memos on both loaded module instances around every test. `osprey_cf_feedback_capture` is refused with a documented reason (its module body executes and exits).
- **Behavioral and helper tests:** full contract coverage for the three thin hooks (config-drift warning matrix, focus-validate stale-id stripping, notebook-update cache invalidation), direct helper tests for `osprey_error_guidance`, `osprey_approval`, and `osprey_memory_guard` (with the path-encoding pinned to `encode_claude_project_path` so the deliberate duplicate cannot drift), malformed-stdin fail-open assertions across all ten event hooks, and the docstring meta-test extended to all ten hooks with a glob-equality guard.
- **Render invariants:** a two-directional parity invariant over rendered projects (every `settings.json` hook reference resolves to a shipped file; every shipped event hook is wired into some event), plus assertions for the `hook_config.json.j2` `write_tools` dedupe branch and the zero-enabled-servers render, driven through the real regeneration pipeline.

## Coverage — `src/osprey/templates/`

**Package total: 87.1% (762/875 statements), against the ≥ 85% best-effort target.** Excluding the out-of-scope `osprey_cf_feedback_capture.py`, the hook scripts + statusline subset is 92.7%.

| File | Coverage |
|---|---:|
| `hooks/osprey_writes_check.py` | 100.0% |
| `hooks/osprey_error_guidance.py` | 100.0% |
| `hooks/osprey_notebook_update.py` | 100.0% |
| `hooks/osprey_config_drift.py` | 96.7% |
| `hooks/osprey_focus_validate.py` | 96.4% |
| `hooks/osprey_memory_guard.py` | 96.1% |
| `hooks/osprey_hook_log.py` | 95.4% |
| `hooks/osprey_panels_context.py` | 95.3% |
| `hooks/osprey_limits.py` | 93.2% |
| `statusline.py` | 93.2% |
| `hooks/osprey_approval.py` | 85.3% |
| `hooks/osprey_cf_feedback_capture.py` | 55.0% |

**Honest framing:** before this change the eight subprocess-only hooks were *absent from the coverage report entirely* — coverage never observed the child processes, and the hooks directory has no `__init__.py` so the unexecuted-file walk skipped it too. That absence, not genuinely untested code, produced the old 42.4% package number. The files became measurable, and the gaps that measurement exposed were then filled (`osprey_approval` 10.0% → 85.3%, `statusline` 35.6% → 93.2%).

`osprey_cf_feedback_capture.py` (55.0%) is the accepted floor: it stays subprocess-only by design and was explicitly out of scope; the gap list, not the headline number, is the completion criterion.

## Timing cost of subprocess coverage (hooks lane)

| Shape | Coverage off | Coverage on |
|---|---|---|
| serial | 89.0 s | 105.7 s |
| `-n 4 --dist loadgroup` | 51.9 s | 60.1 s |

~16–19% headline overhead; the parallel shape with subprocess coverage on is still faster than serial with it off. Stale parallel data-file fragments are erased by pytest-cov at startup (verified by planting a junk `.coverage.stale.*` file and observing its deletion), so crashed runs cannot inflate later reports.

## Gates

| Gate | Result | Wall time |
|---|---|---|
| `pytest tests/ --ignore=tests/e2e -n 4 --dist loadgroup --cov=src/osprey` | 11357 passed, 39 skipped, 1 xfailed | 6:01 |
| `pytest tests/ --ignore=tests/e2e` (serial) | 11357 passed, 39 skipped, 1 xfailed | 14:53 |

Identical pass/skip/xfail counts in both shapes — nothing is order- or worker-dependent. The coverage-enabled run deliberately spans the whole unit lane (not just `tests/hooks/`) because `patch = ["subprocess"]` is global; no suite-wide subprocess side effects appeared. All skips/xfail are pre-existing and environmental. `tests/hooks/` grew from 206 to 277 test functions.

Meta-verification: `test_ci_workflow_wiring.py`, the import-time audit (WHITELIST unchanged), and the docstring meta-test all green; zero changes under `src/osprey/templates/`, `tests/deployment/`, `scripts/`, or `.github/`.

## User-visible consequence (also in CHANGELOG)

Preset content hashes changed, so **already-rendered projects will be flagged stale** on the next drift check; regenerating adds the two hooks and their `settings.json` wiring. This is the designed drift-detection mechanism working as intended, not a regression.

## Follow-ups (deferred — payload frozen this phase)

**Truthy non-dict stdin crashes seven hooks.** A JSON payload parsing to a truthy non-dict (e.g. `["a"]`) makes `osprey_writes_check`, `osprey_limits`, `osprey_approval`, `osprey_memory_guard`, `osprey_error_guidance`, `osprey_notebook_update`, and `osprey_cf_feedback_capture` exit 1 with a traceback. For the four PreToolUse hooks among them, exit 1 **blocks the tool call** — a malformed payload becomes a hard stop instead of a fail-open. The fix is one line per hook (`if not isinstance(hook_input, dict): sys.exit(0)`), deferred because this phase froze `src/osprey/templates/`. The current fail-open tests cover the falsy shapes (`""`, invalid JSON, `[]`); the truthy-non-dict case should be added alongside the payload fix.
