### PR TITLE
test(ariel-search): raise unit coverage from 79% to 99% with faked tests

### DIFF
--- a/src/osprey/services/ariel_search/ingestion/adapters/__init__.py
+++ b/src/osprey/services/ariel_search/ingestion/adapters/__init__.py
@@ -33,8 +33,7 @@ def get_adapter(config: ARIELConfig) -> FacilityAdapter:
 
     registry = get_registry()
 
-    if not registry._initialized:
-        registry.initialize(silent=True)
+    registry.initialize(silent=True)
 
     if not config.ingestion:
         raise AdapterNotFoundError(

--- a/tests/services/ariel_search/_cli_ops_doubles.py
+++ b/tests/services/ariel_search/_cli_ops_doubles.py
@@ -1,0 +1,208 @@
+"""Shared test doubles and seam patchers for the ``cli_operations`` test modules.
+
+``test_cli_operations_pipeline.py`` (ingest-side operations) and
+``test_cli_operations_maintenance.py`` (database-reshaping operations) drive the
+same collaborators through the same seams, so the stand-ins and the
+monkeypatching live here once.
+
+``cli_operations`` imports every collaborator lazily, inside the function that
+uses it, so a patch must name the module that *owns* the symbol rather than
+``cli_operations`` itself: ``create_ariel_service`` on the ``ariel_search``
+package, ``create_connection_pool`` on ``database.connection``, ``run_migrations``
+on ``database.migrations``, ``get_adapter`` on ``ingestion`` and
+``create_enhancers_from_config`` on ``enhancement``. Each helper below patches at
+that source and returns the arguments it observed, so a test can assert on what
+the operation passed down without reaching into the real module.
+
+The module name is underscore-prefixed so pytest does not collect it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _StubService:
+    """Async-context-manager stand-in for ``ARIELSearchService``.
+
+    ``pool`` defaults to the repository's :class:`_FakePool` -- the real service
+    and its repository share one pool -- so anything the code under test runs
+    through ``service.pool.connection()`` is recorded on ``repo.pool.calls``.
+    ``enters``/``exits`` prove the ``async with service`` block was left even on
+    the error paths.
+    """
+
+    def __init__(self, repository: Any, pool: Any = None) -> None:
+        self.repository = repository
+        self.pool = repository.pool if pool is None else pool
+        self.enters = 0
+        self.exits = 0
+
+    async def __aenter__(self) -> _StubService:
+        self.enters += 1
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        self.exits += 1
+        return False
+
+
+class _Adapter:
+    """Ingestion adapter yielding scripted entries from an async generator.
+
+    Args:
+        entries: Entries to yield, in order.
+        raise_at: Index at which ``fetch_entries`` raises instead of yielding,
+            for the "stream dies mid-ingest" path.
+    """
+
+    def __init__(
+        self,
+        entries: Iterable[dict[str, Any]] = (),
+        source_system_name: str = "TestSource",
+        raise_at: int | None = None,
+    ) -> None:
+        self.entries = list(entries)
+        self.source_system_name = source_system_name
+        self.raise_at = raise_at
+        self.fetch_calls: list[dict[str, Any]] = []
+
+    async def fetch_entries(self, since: Any = None, limit: int | None = None):
+        self.fetch_calls.append({"since": since, "limit": limit})
+        for index, entry in enumerate(self.entries):
+            if self.raise_at is not None and index == self.raise_at:
+                raise RuntimeError("adapter stream failed")
+            yield entry
+
+
+class _Enhancer:
+    """Enhancement module recording every ``enhance`` call.
+
+    Failures drive the ``mark_enhancement_failed`` branch, and the two knobs are
+    independent:
+
+    Args:
+        fails_on: Entry ids for which ``enhance`` raises a generated
+            ``RuntimeError`` naming the entry.
+        error: Exception raised for *every* entry, when the operation under test
+            cares about the message that reaches ``mark_enhancement_failed``.
+
+    ``seen`` records the entry ids in order; ``conns`` records the connection
+    each call was handed, positionally aligned with ``seen``.
+    """
+
+    def __init__(
+        self,
+        name: str = "text_embedding",
+        fails_on: Iterable[str] = (),
+        error: Exception | None = None,
+    ) -> None:
+        self.name = name
+        self.fails_on = set(fails_on)
+        self.error = error
+        self.seen: list[str] = []
+        self.conns: list[Any] = []
+
+    async def enhance(self, entry: dict[str, Any], conn: Any) -> None:
+        entry_id = entry["entry_id"]
+        self.seen.append(entry_id)
+        self.conns.append(conn)
+        if self.error is not None:
+            raise self.error
+        if entry_id in self.fails_on:
+            raise RuntimeError(f"enhance failed on {entry_id}")
+
+
+# ---------------------------------------------------------------------------
+# Patch helpers -- each names the module that owns the symbol
+# ---------------------------------------------------------------------------
+
+
+def _patch_service(monkeypatch: pytest.MonkeyPatch, service: Any) -> list[Any]:
+    """Route ``create_ariel_service`` to *service*; returns the configs it saw."""
+    import osprey.services.ariel_search as ariel_pkg
+
+    configs: list[Any] = []
+
+    async def _fake_create(config):
+        configs.append(config)
+        return service
+
+    monkeypatch.setattr(ariel_pkg, "create_ariel_service", _fake_create)
+    return configs
+
+
+def _forbid_service(
+    monkeypatch: pytest.MonkeyPatch, reason: str = "service should not be created"
+) -> None:
+    """Make service creation an error, for paths that must not reach it."""
+    import osprey.services.ariel_search as ariel_pkg
+
+    async def _fake_create(config):
+        raise AssertionError(reason)
+
+    monkeypatch.setattr(ariel_pkg, "create_ariel_service", _fake_create)
+
+
+def _patch_adapter(monkeypatch: pytest.MonkeyPatch, adapter: Any) -> None:
+    """Route ``get_adapter`` to *adapter*, or raise it if it is an exception."""
+    import osprey.services.ariel_search.ingestion as ing
+
+    def _fake_get(config):
+        if isinstance(adapter, Exception):
+            raise adapter
+        return adapter
+
+    monkeypatch.setattr(ing, "get_adapter", _fake_get)
+
+
+def _patch_enhancers(monkeypatch: pytest.MonkeyPatch, enhancers: Iterable[Any]) -> None:
+    """Route ``create_enhancers_from_config`` to *enhancers*."""
+    import osprey.services.ariel_search.enhancement as enh
+
+    listed = list(enhancers)
+    monkeypatch.setattr(enh, "create_enhancers_from_config", lambda config: list(listed))
+
+
+def _patch_pool(monkeypatch: pytest.MonkeyPatch, pool: Any) -> list[Any]:
+    """Route ``create_connection_pool`` to *pool*; returns the db configs it saw."""
+    import osprey.services.ariel_search.database.connection as conn_mod
+
+    seen: list[Any] = []
+
+    async def _fake_create_pool(db_config):
+        seen.append(db_config)
+        return pool
+
+    monkeypatch.setattr(conn_mod, "create_connection_pool", _fake_create_pool)
+    return seen
+
+
+def _patch_migrations(
+    monkeypatch: pytest.MonkeyPatch,
+    applied: list[str] | None = None,
+    error: Exception | None = None,
+) -> list[Any]:
+    """Route ``run_migrations``; returns the ``(pool, config)`` pairs it saw."""
+    import osprey.services.ariel_search.database.migrations as mig_mod
+
+    seen: list[Any] = []
+
+    async def _fake_run_migrations(pool, config):
+        seen.append((pool, config))
+        if error is not None:
+            raise error
+        return list(applied or [])
+
+    monkeypatch.setattr(mig_mod, "run_migrations", _fake_run_migrations)
+    return seen

--- a/tests/services/ariel_search/conftest.py
+++ b/tests/services/ariel_search/conftest.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 import logging
 import os
 import types
+import warnings
 from datetime import UTC
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -138,6 +139,37 @@ def _mock_ariel_registry():
     registry = _build_ariel_mock_registry()
     with patch("osprey.registry.get_registry", return_value=registry):
         yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_ariel_service_singleton():
+    """Reset the ARIEL service singleton around every test in this package.
+
+    The leak: ``capability._ariel_service_instance`` is a module-global
+    ``ARIELSearchService`` holding an open connection pool. A test that builds
+    one and does not close it leaves both the instance and its pool live for
+    whatever runs next on the same worker, so the next caller of
+    ``get_ariel_search_service()`` silently gets the previous test's service.
+
+    Reset happens *before* yield so a test never inherits a stale instance. At
+    teardown a still-live instance is reported with a ``ResourceWarning`` naming
+    ``close_ariel_service()`` before being dropped -- resetting a live service
+    silently would leak its pool with no trace. Tests that legitimately build a
+    real service (``integration/test_capability.py``) close it in their own
+    fixture; autouse fixtures finalize last, so that cleanup runs first and no
+    spurious warning fires.
+    """
+    from osprey.services.ariel_search import capability
+
+    capability.reset_ariel_service()
+    yield
+    if capability._ariel_service_instance is not None:
+        warnings.warn(
+            "ariel service singleton left live; use close_ariel_service()",
+            ResourceWarning,
+            stacklevel=1,
+        )
+        capability.reset_ariel_service()
 
 
 # Dev database URLs - try port 5432 (ariel-postgres), then 5433 (ariel-dev-db)
@@ -290,7 +322,11 @@ def integration_ariel_config(database_url: str) -> ARIELConfig:
     )
 
 
-# Track if migrations have been applied in this session
+# Track if migrations have been applied in this session.
+# Intentionally session-scoped with no reset seam: migrations are idempotent and
+# every test in the docker group shares the one `ariel_test` database, so a
+# per-test reset would buy nothing and re-run the full migration set once per
+# test on the docker worker.
 _migrations_applied: bool = False
 
 
@@ -358,6 +394,339 @@ async def repository(migrated_pool, integration_ariel_config: ARIELConfig) -> AR
 # ============================================================================
 # Unit test fixtures (no Docker required)
 # ============================================================================
+#
+# Database fakes. The package acquires results in three different shapes, and
+# the fakes below serve all three from one shared call log:
+#
+#   (a) result = await conn.execute(sql, params)      -> result.fetchone/fetchall
+#   (b) async with conn.cursor(row_factory=dict_row)  -> dict rows
+#   (c) async with conn.cursor()                      -> positional tuple rows
+#
+# Tests script the results and then assert on the recorded ``(sql, params)``
+# sequence; nothing here talks to Postgres.
+
+
+def _normalize_sql(sql: str) -> str:
+    """Collapse SQL whitespace so multi-line literals match single-line patterns."""
+    return " ".join(str(sql).split())
+
+
+class _SQLRecorder:
+    """Canned-result script plus the ordered ``(sql, params)`` call log.
+
+    A pool, its connection and every cursor handed out from it share one
+    recorder, so ``recorder.calls`` is the whole conversation with the database
+    in order, whichever acquisition shape the code under test used.
+
+    Result lookup per ``execute``, in order:
+
+    1. ``rows_for`` -- the first pattern found in the (whitespace-normalized)
+       SQL wins. Not consumed, so a repeated query keeps returning it.
+    2. ``results`` -- a queue popped from the left, for scripts where the same
+       SQL must return different rows on successive calls. This queue is popped
+       by *every* ``execute``, including bookkeeping statements the code under
+       test issues around the query you care about (``BEGIN READ ONLY``,
+       ``SET LOCAL``, ``ROLLBACK``, ...), so a positional ``results`` script is
+       easy to misalign. Prefer ``rows_for`` whenever the code under test issues
+       such bookkeeping SQL (e.g. ``search/sql_query.py``).
+    3. ``[]``.
+
+    A scripted result that is an ``Exception`` instance is raised rather than
+    returned; that is how a failure at one specific query is injected.
+    """
+
+    def __init__(
+        self,
+        results: list[Any] | None = None,
+        rows_for: dict[str, Any] | None = None,
+    ) -> None:
+        self.calls: list[tuple[str, Any]] = []
+        self.results: list[Any] = list(results or [])
+        self.rows_for: dict[str, Any] = dict(rows_for or {})
+
+    @property
+    def sql(self) -> list[str]:
+        """SQL text of every recorded call, in order."""
+        return [sql for sql, _ in self.calls]
+
+    def matching(self, pattern: str) -> list[tuple[str, Any]]:
+        """Recorded calls whose SQL contains `pattern`, ignoring whitespace."""
+        needle = _normalize_sql(pattern)
+        return [call for call in self.calls if needle in _normalize_sql(call[0])]
+
+    def record(self, sql: str, params: Any = None) -> list[Any]:
+        """Log one execute and return (or raise) its scripted result."""
+        self.calls.append((sql, params))
+        rows = self._next_rows(sql)
+        if isinstance(rows, Exception):
+            raise rows
+        return list(rows)
+
+    def _next_rows(self, sql: str) -> Any:
+        normalized = _normalize_sql(sql)
+        for pattern, rows in self.rows_for.items():
+            if _normalize_sql(pattern) in normalized:
+                return rows
+        if self.results:
+            return self.results.pop(0)
+        return []
+
+
+class _FakeCursor:
+    """Cursor stand-in serving both ``conn.cursor()`` shapes and ``conn.execute()``.
+
+    Usable as an async context manager (``async with conn.cursor(...) as cur``)
+    and as the plain handle returned by ``await conn.execute(...)``. Rows come
+    back exactly as scripted -- supply dicts for a ``row_factory=dict_row``
+    cursor and tuples for a bare one; the requested factory is kept on
+    ``row_factory`` for tests that assert which shape was asked for.
+
+    Fetching is non-consuming: ``fetchone()`` always returns ``rows[0]`` and
+    ``fetchmany(n)`` always returns ``rows[:n]``, with no cursor advance
+    between calls. A drain loop written as
+    ``while (row := await cur.fetchone()): ...`` will spin forever against
+    this fake -- iterate ``fetchall()`` instead.
+    """
+
+    def __init__(self, recorder: _SQLRecorder, row_factory: Any = None) -> None:
+        self.recorder = recorder
+        self.row_factory = row_factory
+        self.rows: list[Any] = []
+
+    async def __aenter__(self) -> _FakeCursor:
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> bool:
+        return False
+
+    async def execute(self, sql: str, params: Any = None) -> _FakeCursor:
+        self.rows = self.recorder.record(sql, params)
+        return self
+
+    async def fetchone(self) -> Any:
+        return self.rows[0] if self.rows else None
+
+    async def fetchall(self) -> list[Any]:
+        return list(self.rows)
+
+    async def fetchmany(self, size: int | None = None) -> list[Any]:
+        return list(self.rows) if size is None else list(self.rows[:size])
+
+
+class _FakeConnection:
+    """Connection stand-in supporting every acquisition shape in the package.
+
+    Doubles as the object yielded by :meth:`_FakePool.connection` and as the
+    recording DDL connection that migration ``up``/``down`` bodies write
+    through -- pass one straight to a migration and read ``conn.sql`` for the
+    ordered DDL text.
+
+    Args:
+        recorder: Share the pool's recorder. Omit for a standalone connection,
+            which builds its own from `results`/`rows_for`.
+        error: Raised on entering ``async with pool.connection()``.
+    """
+
+    def __init__(
+        self,
+        recorder: _SQLRecorder | None = None,
+        results: list[Any] | None = None,
+        rows_for: dict[str, Any] | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self.recorder = recorder if recorder is not None else _SQLRecorder(results, rows_for)
+        self.error = error
+        self.cursors: list[_FakeCursor] = []
+
+    @property
+    def calls(self) -> list[tuple[str, Any]]:
+        """Ordered ``(sql, params)`` of everything executed on this connection."""
+        return self.recorder.calls
+
+    @property
+    def sql(self) -> list[str]:
+        """SQL text of every call on this connection, in order."""
+        return self.recorder.sql
+
+    async def __aenter__(self) -> _FakeConnection:
+        if self.error is not None:
+            raise self.error
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> bool:
+        return False
+
+    def cursor(self, row_factory: Any = None) -> _FakeCursor:
+        """Hand out a cursor; ``row_factory`` is recorded, never applied."""
+        cur = _FakeCursor(self.recorder, row_factory=row_factory)
+        self.cursors.append(cur)
+        return cur
+
+    async def execute(self, sql: str, params: Any = None) -> _FakeCursor:
+        """Run one statement and return the cursor holding its result."""
+        cur = self.cursor()
+        await cur.execute(sql, params)
+        return cur
+
+
+class _FakePool:
+    """Duck-typed stand-in for the psycopg ``AsyncConnectionPool``.
+
+    ``async with pool.connection() as conn`` yields one shared
+    :class:`_FakeConnection`, so ``pool.calls`` / ``pool.sql`` stay the ordered
+    record across every block the code under test opens. ``await pool.close()``
+    is recorded on ``closed`` and ``close_calls``.
+
+    Args:
+        results: Result queue, consumed one entry per ``execute``.
+        rows_for: SQL-substring -> rows, matched before the queue.
+        error: The raising variant for error-wrap tests. Entering the
+            connection block raises it, so every repository method funnels
+            into its ``except`` branch.
+    """
+
+    def __init__(
+        self,
+        results: list[Any] | None = None,
+        rows_for: dict[str, Any] | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self.recorder = _SQLRecorder(results, rows_for)
+        self.conn = _FakeConnection(self.recorder, error=error)
+        self.close_calls = 0
+
+    @property
+    def calls(self) -> list[tuple[str, Any]]:
+        """Ordered ``(sql, params)`` of everything executed through this pool."""
+        return self.recorder.calls
+
+    @property
+    def sql(self) -> list[str]:
+        """SQL text of every call through this pool, in order."""
+        return self.recorder.sql
+
+    @property
+    def closed(self) -> bool:
+        """True once ``close()`` has been awaited at least once."""
+        return self.close_calls > 0
+
+    def matching(self, pattern: str) -> list[tuple[str, Any]]:
+        """Recorded calls whose SQL contains `pattern`, ignoring whitespace."""
+        return self.recorder.matching(pattern)
+
+    def connection(self) -> _FakeConnection:
+        return self.conn
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+class _FakeEmbeddingProvider:
+    """Stand-in for the ``BaseEmbeddingProvider`` that ``get_embedding_provider`` returns.
+
+    ``execute_embedding`` is synchronous, matching the real provider: ARIEL
+    calls it from async code without awaiting. It returns one `dimension`-long
+    vector per text (or the scripted `vectors`) and appends every call to
+    ``calls``; pass `error` to make it raise, which is how the
+    embedding-failure branches are reached.
+    """
+
+    name = "fake"
+
+    def __init__(
+        self,
+        dimension: int = 4,
+        default_base_url: str = "http://fake-embeddings.invalid:11434",
+        default_model_id: str = "nomic-embed-text",
+        vectors: list[list[float]] | None = None,
+        error: Exception | None = None,
+        healthy: tuple[bool, str] = (True, "ok"),
+    ) -> None:
+        self.dimension = dimension
+        self.default_base_url = default_base_url
+        self.default_model_id = default_model_id
+        self.vectors = vectors
+        self.error = error
+        self.healthy = healthy
+        self.calls: list[dict[str, Any]] = []
+
+    def execute_embedding(
+        self,
+        texts: list[str],
+        model_id: str | None = None,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        **kwargs: Any,
+    ) -> list[list[float]]:
+        self.calls.append(
+            {
+                "texts": list(texts),
+                "model_id": model_id,
+                "api_key": api_key,
+                "base_url": base_url,
+                **kwargs,
+            }
+        )
+        if self.error is not None:
+            raise self.error
+        if self.vectors is not None:
+            return [list(vector) for vector in self.vectors]
+        return [[0.1] * self.dimension for _ in texts]
+
+    def check_health(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        model_id: str | None = None,
+        timeout: float = 10.0,
+    ) -> tuple[bool, str]:
+        self.calls.append({"check_health": True, "api_key": api_key, "base_url": base_url})
+        return self.healthy
+
+
+@pytest.fixture
+def fake_pool_factory():
+    """Factory for scripted :class:`_FakePool` instances.
+
+    Returns:
+        Callable ``(results=None, rows_for=None, error=None) -> _FakePool``.
+        Pass ``error=`` for the raising variant used by error-wrap tests.
+    """
+
+    def _make(
+        results: list[Any] | None = None,
+        rows_for: dict[str, Any] | None = None,
+        error: Exception | None = None,
+    ) -> _FakePool:
+        return _FakePool(results=results, rows_for=rows_for, error=error)
+
+    return _make
+
+
+@pytest.fixture
+def fake_pool(fake_pool_factory) -> _FakePool:
+    """Empty-script :class:`_FakePool`; every query returns no rows.
+
+    Script it after the fact via ``fake_pool.recorder.results`` /
+    ``fake_pool.recorder.rows_for`` when the shape is only known mid-test.
+    """
+    return fake_pool_factory()
+
+
+@pytest.fixture
+def ddl_conn() -> _FakeConnection:
+    """Recording connection for migration ``up``/``down`` bodies.
+
+    Migrations take a ``conn`` parameter, so they can be driven directly:
+    ``await migration.up(ddl_conn)``, then assert on ``ddl_conn.sql``.
+    """
+    return _FakeConnection()
+
+
+@pytest.fixture
+def fake_embedding_provider() -> _FakeEmbeddingProvider:
+    """Default :class:`_FakeEmbeddingProvider` (4-dimensional vectors)."""
+    return _FakeEmbeddingProvider()
 
 
 @pytest.fixture
@@ -376,6 +745,10 @@ def mock_ariel_config() -> ARIELConfig:
 def mock_repository() -> MagicMock:
     """Mocked ARIELRepository for unit tests.
 
+    ``repo.pool`` is a real :class:`_FakePool`, so code that opens
+    ``async with repo.pool.connection() as conn`` works and its SQL lands in
+    ``repo.pool.calls``. Script it through ``repo.pool.recorder``.
+
     Returns:
         MagicMock with common repository methods stubbed
     """
@@ -384,6 +757,7 @@ def mock_repository() -> MagicMock:
     config = ARIELConfig(database=DatabaseConfig(uri="postgresql://mock/test"))
     repo = MagicMock()
     repo.config = config
+    repo.pool = _FakePool()
     repo.get_entry = AsyncMock(return_value=None)
     repo.upsert_entry = AsyncMock()
     repo.keyword_search = AsyncMock(return_value=[])
@@ -395,29 +769,11 @@ def mock_repository() -> MagicMock:
     repo.health_check = AsyncMock(return_value=(True, "OK"))
     repo.mark_enhancement_complete = AsyncMock()
     repo.mark_enhancement_failed = AsyncMock()
+    repo.start_ingestion_run = AsyncMock(return_value=1)
+    repo.complete_ingestion_run = AsyncMock()
+    repo.fail_ingestion_run = AsyncMock()
+    repo.get_last_successful_run = AsyncMock(return_value=None)
     return repo
-
-
-@pytest.fixture
-def mock_search_service() -> MagicMock:
-    """Mocked ARIELSearchService for capability tests.
-
-    Returns:
-        MagicMock with common service methods stubbed
-    """
-    from osprey.services.ariel_search.models import ARIELSearchResult
-
-    service = MagicMock()
-    service.health_check = AsyncMock(return_value=(True, "OK"))
-    service.search = AsyncMock(
-        return_value=ARIELSearchResult(
-            entries=[],
-            total_count=0,
-            search_mode="keyword",
-            query="test",
-        )
-    )
-    return service
 
 
 @pytest.fixture

--- a/tests/services/ariel_search/test_cli_operations_maintenance.py
+++ b/tests/services/ariel_search/test_cli_operations_maintenance.py
@@ -1,0 +1,743 @@
+"""Unit tests for the *maintenance* half of ``ariel_search.cli_operations``.
+
+These are the operations that reshape the database rather than read it:
+``run_migrate``, ``run_reembed`` (+ its ``_embed_batch`` helper),
+``run_quickstart``, ``get_purge_info`` and ``execute_purge``. The pure-logic
+and error-translation contracts live in ``test_cli_operations.py``; the
+pipeline operations in ``test_cli_operations_pipeline.py``.
+
+Everything here runs against the fake pool/connection/cursor family in
+``conftest.py``, so the assertions are about the *SQL that gets emitted*, the
+progress narration, and the accounting the functions return. Two shapes matter:
+
+* ``conn.cursor()`` with no ``row_factory`` yields **positional tuple** rows —
+  ``get_purge_info``, ``execute_purge``, ``run_reembed`` and ``_embed_batch``
+  all read them positionally, so the scripts below supply tuples.
+* ``get_embedding_provider`` returns a provider whose ``execute_embedding`` is
+  **synchronous**; ARIEL calls it from async code without awaiting.
+
+``cli_operations`` imports its collaborators lazily inside each function, so
+each is monkeypatched at its *source* module: ``create_connection_pool`` on
+``...database.connection``, ``run_migrations`` on ``...database.migrations``,
+``get_embedding_provider`` on ``osprey.models.embeddings``. No real database,
+network or embedding backend is touched.
+
+One purge contract is asserted here at the SQL level only: both
+``execute_purge`` branches must delete the ``text_embedding`` row from
+``ariel_migrations``, guarded by an existence check on the table itself,
+otherwise a later ``osprey ariel migrate`` is a silent no-op and the dropped
+tables never come back. That the statement really fires against Postgres
+stays covered by the container tests in ``test_apply_seed.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from osprey.services.ariel_search import cli_operations as ops
+from tests.services.ariel_search._cli_ops_doubles import (
+    _Adapter,
+    _Enhancer,
+    _forbid_service,
+    _patch_adapter,
+    _patch_enhancers,
+    _patch_migrations,
+    _patch_pool,
+    _patch_service,
+    _StubService,
+)
+from tests.services.ariel_search.conftest import _FakeEmbeddingProvider
+
+# Minimal config dict accepted by ARIELConfig.from_dict.
+_DB = {"database": {"uri": "postgresql://localhost/test"}}
+
+# The table run_reembed derives for the model used throughout this module.
+_MODEL = "nomic-embed-text"
+_TABLE = "text_embeddings_nomic_embed_text"
+
+# SQL fragments the code under test emits, quoted here once.
+_SELECT_ENTRIES = "SELECT entry_id, raw_text FROM enhanced_entries"
+_SELECT_EMBEDDING_TABLES = "SELECT table_name FROM information_schema.tables"
+_PGVECTOR_PROBE = "pg_available_extensions"
+
+# Includes the existence-check guard around the DELETE, not just the DELETE
+# itself: without ``IF EXISTS (...ariel_migrations...) THEN`` wrapping it, the
+# statement aborts with an UndefinedTable error against a database that has
+# never run migrations, instead of the intended no-op.
+_UNRECORD_MIGRATION = (
+    "IF EXISTS (SELECT 1 FROM information_schema.tables "
+    "WHERE table_schema = 'public' AND table_name = 'ariel_migrations') "
+    "THEN DELETE FROM ariel_migrations WHERE name = 'text_embedding'"
+)
+
+
+# ---------------------------------------------------------------------------
+# Embedding seam and repository stubs -- shared doubles in ``_cli_ops_doubles``
+# ---------------------------------------------------------------------------
+
+
+def _patch_embedding_provider(monkeypatch, provider):
+    """Route ``get_embedding_provider``; returns the provider names requested."""
+    import osprey.models.embeddings as embeddings_mod
+
+    asked: list[str] = []
+
+    def _fake_get(name):
+        asked.append(name)
+        if isinstance(provider, Exception):
+            raise provider
+        return provider
+
+    monkeypatch.setattr(embeddings_mod, "get_embedding_provider", _fake_get)
+    return asked
+
+
+def _reembed_repo(*, tables=(), entry_count=0):
+    """Repository mock with just what ``run_reembed`` awaits."""
+    repo = MagicMock()
+    repo.get_embedding_tables = AsyncMock(return_value=list(tables))
+    repo.count_entries = AsyncMock(return_value=entry_count)
+    return repo
+
+
+def _embedding_table(name):
+    table = MagicMock()
+    table.table_name = name
+    return table
+
+
+# ---------------------------------------------------------------------------
+# run_migrate
+# ---------------------------------------------------------------------------
+
+
+class TestRunMigrate:
+    async def test_progress_narrates_connect_run_and_complete(self, monkeypatch, fake_pool):
+        _patch_pool(monkeypatch, fake_pool)
+        calls = _patch_migrations(monkeypatch, applied=["core_schema"])
+
+        messages: list[str] = []
+        await ops.run_migrate(
+            {"database": {"uri": "postgresql://user:secret@dbhost:5432/ariel"}},
+            progress=messages.append,
+        )
+
+        assert messages == [
+            "Connecting to database: dbhost:5432/ariel",
+            "Running migrations...",
+            "Migrations complete.",
+        ]
+        # Credentials are stripped from the connection banner.
+        assert not any("secret" in m for m in messages)
+        assert len(calls) == 1
+        assert calls[0][0] is fake_pool
+        assert fake_pool.closed
+
+    async def test_runs_and_closes_without_a_progress_callback(self, monkeypatch, fake_pool):
+        _patch_pool(monkeypatch, fake_pool)
+        calls = _patch_migrations(monkeypatch)
+
+        assert await ops.run_migrate(dict(_DB)) is None
+
+        assert len(calls) == 1
+        assert fake_pool.closed
+
+    async def test_pool_is_closed_when_migrations_raise(self, monkeypatch, fake_pool):
+        _patch_pool(monkeypatch, fake_pool)
+        _patch_migrations(monkeypatch, error=RuntimeError("migration exploded"))
+
+        messages: list[str] = []
+        with pytest.raises(RuntimeError, match="migration exploded"):
+            await ops.run_migrate(dict(_DB), progress=messages.append)
+
+        # The completion line is never reached, but the pool is still released.
+        assert "Migrations complete." not in messages
+        assert fake_pool.closed
+
+
+# ---------------------------------------------------------------------------
+# run_reembed — non-dry-run
+# ---------------------------------------------------------------------------
+
+
+class TestRunReembed:
+    async def test_missing_table_is_created_before_embedding(
+        self, monkeypatch, fake_pool_factory, fake_embedding_provider
+    ):
+        pool = fake_pool_factory(
+            rows_for={
+                _PGVECTOR_PROBE: [(True,)],
+                _SELECT_ENTRIES: [("E1", "first text")],
+                f"SELECT 1 FROM {_TABLE}": [],
+            }
+        )
+        repo = _reembed_repo(tables=[], entry_count=1)
+        _patch_service(monkeypatch, _StubService(repo, pool))
+        _patch_embedding_provider(monkeypatch, fake_embedding_provider)
+
+        messages: list[str] = []
+        result = await ops.run_reembed(
+            dict(_DB),
+            model=_MODEL,
+            dimension=4,
+            batch_size=10,
+            dry_run=False,
+            force=False,
+            progress=messages.append,
+        )
+
+        assert result.dry_run is False
+        assert result.processed == 1
+        # The real TextEmbeddingMigration ran against the fake connection.
+        assert pool.matching(f"CREATE TABLE IF NOT EXISTS {_TABLE}")
+        assert pool.matching("CREATE EXTENSION IF NOT EXISTS vector")
+        assert f"Creating embedding table: {_TABLE}" in messages
+        assert f"  Table created: {_TABLE}" in messages
+
+    async def test_existing_table_is_not_recreated(
+        self, monkeypatch, fake_pool_factory, fake_embedding_provider
+    ):
+        pool = fake_pool_factory(
+            rows_for={
+                _SELECT_ENTRIES: [("E1", "first text")],
+                f"SELECT 1 FROM {_TABLE}": [],
+            }
+        )
+        repo = _reembed_repo(tables=[_embedding_table(_TABLE)], entry_count=1)
+        _patch_service(monkeypatch, _StubService(repo, pool))
+        _patch_embedding_provider(monkeypatch, fake_embedding_provider)
+
+        messages: list[str] = []
+        result = await ops.run_reembed(
+            dict(_DB),
+            model=_MODEL,
+            dimension=4,
+            batch_size=10,
+            dry_run=False,
+            force=False,
+            progress=messages.append,
+        )
+
+        assert result.processed == 1
+        assert not pool.matching("CREATE TABLE IF NOT EXISTS")
+        assert not any("Creating embedding table" in m for m in messages)
+
+    async def test_zero_entries_short_circuits_before_the_provider(self, monkeypatch, fake_pool):
+        repo = _reembed_repo(tables=[_embedding_table(_TABLE)], entry_count=0)
+        _patch_service(monkeypatch, _StubService(repo, fake_pool))
+        # The provider lookup sits *after* the count check; reaching it is a bug.
+        _patch_embedding_provider(monkeypatch, AssertionError("provider must not be resolved"))
+
+        messages: list[str] = []
+        result = await ops.run_reembed(
+            dict(_DB),
+            model=_MODEL,
+            dimension=4,
+            batch_size=10,
+            dry_run=False,
+            force=False,
+            progress=messages.append,
+        )
+
+        assert (result.processed, result.skipped, result.errors) == (0, 0, 0)
+        assert result.dry_run is False
+        assert "Found 0 entries to embed" in messages
+        assert "No entries to embed." in messages
+        # Nothing was read from or written to the database.
+        assert fake_pool.calls == []
+
+    async def test_force_skips_the_existence_probe_and_upserts(
+        self, monkeypatch, fake_pool_factory, fake_embedding_provider
+    ):
+        rows = [("E1", "one"), ("E2", "two"), ("E3", "three")]
+        pool = fake_pool_factory(rows_for={_SELECT_ENTRIES: rows})
+        repo = _reembed_repo(tables=[_embedding_table(_TABLE)], entry_count=3)
+        _patch_service(monkeypatch, _StubService(repo, pool))
+        _patch_embedding_provider(monkeypatch, fake_embedding_provider)
+
+        result = await ops.run_reembed(
+            dict(_DB),
+            model=_MODEL,
+            dimension=4,
+            batch_size=2,
+            dry_run=False,
+            force=True,
+            progress=None,
+        )
+
+        assert (result.processed, result.skipped, result.errors) == (3, 0, 0)
+        # force=True means the "already embedded?" probe is never issued.
+        assert not pool.matching(f"SELECT 1 FROM {_TABLE} WHERE entry_id")
+        # batch_size=2 over 3 rows -> a mid-loop flush plus the trailing flush.
+        assert [len(call["texts"]) for call in fake_embedding_provider.calls] == [2, 1]
+        assert len(pool.matching(f"INSERT INTO {_TABLE}")) == 3
+        assert pool.matching("ON CONFLICT (entry_id) DO UPDATE SET embedding = EXCLUDED.embedding")
+
+    async def test_already_embedded_rows_are_skipped_when_not_forcing(
+        self, monkeypatch, fake_pool_factory, fake_embedding_provider
+    ):
+        rows = [("E1", "one"), ("E2", "two")]
+        pool = fake_pool_factory(
+            rows_for={
+                _SELECT_ENTRIES: rows,
+                f"SELECT 1 FROM {_TABLE}": [(1,)],
+            }
+        )
+        repo = _reembed_repo(tables=[_embedding_table(_TABLE)], entry_count=2)
+        _patch_service(monkeypatch, _StubService(repo, pool))
+        _patch_embedding_provider(monkeypatch, fake_embedding_provider)
+
+        result = await ops.run_reembed(
+            dict(_DB),
+            model=_MODEL,
+            dimension=4,
+            batch_size=10,
+            dry_run=False,
+            force=False,
+            progress=None,
+        )
+
+        assert (result.processed, result.skipped, result.errors) == (0, 2, 0)
+        assert fake_embedding_provider.calls == []
+        assert not pool.matching(f"INSERT INTO {_TABLE}")
+
+    async def test_non_force_insert_uses_do_nothing_and_provider_defaults(
+        self, monkeypatch, fake_pool_factory, fake_embedding_provider
+    ):
+        pool = fake_pool_factory(
+            rows_for={
+                _SELECT_ENTRIES: [("E1", None)],
+                f"SELECT 1 FROM {_TABLE}": [],
+            }
+        )
+        repo = _reembed_repo(tables=[_embedding_table(_TABLE)], entry_count=1)
+        _patch_service(monkeypatch, _StubService(repo, pool))
+        asked = _patch_embedding_provider(monkeypatch, fake_embedding_provider)
+
+        result = await ops.run_reembed(
+            dict(_DB),
+            model=_MODEL,
+            dimension=4,
+            batch_size=10,
+            dry_run=False,
+            force=False,
+            progress=None,
+        )
+
+        assert result.processed == 1
+        assert pool.matching("ON CONFLICT (entry_id) DO NOTHING")
+        assert not pool.matching("DO UPDATE SET")
+        # Provider comes from config.embedding.provider; base_url falls back to
+        # the provider's own default because ARIEL config carries none.
+        assert asked == ["ollama"]
+        call = fake_embedding_provider.calls[0]
+        assert call["model_id"] == _MODEL
+        assert call["base_url"] == fake_embedding_provider.default_base_url
+        # A NULL raw_text is embedded as the empty string, not None.
+        assert call["texts"] == [""]
+
+
+# ---------------------------------------------------------------------------
+# _embed_batch
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedBatch:
+    async def test_force_emits_do_update_conflict_clause(self, fake_pool, fake_embedding_provider):
+        cur = fake_pool.conn.cursor()
+
+        messages: list[str] = []
+        processed, errors = await ops._embed_batch(
+            cur,
+            fake_embedding_provider,
+            ["alpha", "beta"],
+            ["E1", "E2"],
+            _MODEL,
+            "http://embed.invalid",
+            _TABLE,
+            True,
+            messages.append,
+        )
+
+        assert (processed, errors) == (2, 0)
+        inserts = fake_pool.matching(f"INSERT INTO {_TABLE} (entry_id, embedding)")
+        assert len(inserts) == 2
+        assert [params[0] for _, params in inserts] == ["E1", "E2"]
+        assert fake_pool.matching(
+            "ON CONFLICT (entry_id) DO UPDATE SET embedding = EXCLUDED.embedding"
+        )
+        assert messages == ["  Processed 2 entries in batch..."]
+        assert fake_embedding_provider.calls[0]["base_url"] == "http://embed.invalid"
+
+    async def test_non_force_emits_do_nothing_conflict_clause(
+        self, fake_pool, fake_embedding_provider
+    ):
+        cur = fake_pool.conn.cursor()
+
+        processed, errors = await ops._embed_batch(
+            cur,
+            fake_embedding_provider,
+            ["alpha"],
+            ["E1"],
+            _MODEL,
+            "http://embed.invalid",
+            _TABLE,
+            False,
+            None,
+        )
+
+        assert (processed, errors) == (1, 0)
+        assert fake_pool.matching("ON CONFLICT (entry_id) DO NOTHING")
+        assert not fake_pool.matching("DO UPDATE SET")
+
+    async def test_embedding_failure_counts_the_whole_batch_as_errors(self, fake_pool):
+        provider = _FakeEmbeddingProvider(error=RuntimeError("embedding backend down"))
+        cur = fake_pool.conn.cursor()
+
+        messages: list[str] = []
+        processed, errors = await ops._embed_batch(
+            cur,
+            provider,
+            ["alpha", "beta", "gamma"],
+            ["E1", "E2", "E3"],
+            _MODEL,
+            "http://embed.invalid",
+            _TABLE,
+            False,
+            messages.append,
+        )
+
+        assert (processed, errors) == (0, 3)
+        assert fake_pool.calls == []
+        assert messages == ["  Error in batch: embedding backend down"]
+
+    async def test_vector_count_mismatch_is_an_error_not_a_partial_write(self, fake_pool):
+        # Provider returns fewer vectors than texts -> zip(strict=True) rejects it.
+        provider = _FakeEmbeddingProvider(vectors=[[0.1, 0.2]])
+        cur = fake_pool.conn.cursor()
+
+        processed, errors = await ops._embed_batch(
+            cur,
+            provider,
+            ["alpha", "beta"],
+            ["E1", "E2"],
+            _MODEL,
+            "http://embed.invalid",
+            _TABLE,
+            False,
+            None,
+        )
+
+        assert (processed, errors) == (0, 2)
+        # The first row was written before the mismatch surfaced; the batch is
+        # still reported as failed rather than partially processed.
+        assert len(fake_pool.matching(f"INSERT INTO {_TABLE}")) == 1
+
+    async def test_failure_without_progress_callback_is_silent(self, fake_pool):
+        provider = _FakeEmbeddingProvider(error=RuntimeError("boom"))
+        cur = fake_pool.conn.cursor()
+
+        assert await ops._embed_batch(
+            cur, provider, ["a"], ["E1"], _MODEL, "http://x", _TABLE, False, None
+        ) == (0, 1)
+
+
+# ---------------------------------------------------------------------------
+# run_quickstart
+# ---------------------------------------------------------------------------
+
+
+class TestRunQuickstart:
+    async def test_source_argument_selects_the_generic_json_adapter(
+        self, monkeypatch, fake_pool, mock_repository
+    ):
+        _patch_pool(monkeypatch, fake_pool)
+        _patch_migrations(monkeypatch, applied=["core_schema"])
+        _patch_adapter(monkeypatch, _Adapter([{"entry_id": "E1"}, {"entry_id": "E2"}]))
+        _patch_enhancers(monkeypatch, [])
+        _patch_service(monkeypatch, _StubService(mock_repository, mock_repository.pool))
+
+        config_dict = dict(_DB)
+        messages: list[str] = []
+        result = await ops.run_quickstart(
+            config_dict,
+            source="file:///entries.json",
+            progress=messages.append,
+        )
+
+        assert config_dict["ingestion"] == {
+            "source_url": "file:///entries.json",
+            "adapter": "generic_json",
+        }
+        assert result.count == 2
+        assert result.enhanced_count == 0
+        assert result.failed_count == 0
+        assert result.migrations_applied == 1
+        assert mock_repository.upsert_entry.await_count == 2
+        assert "  Entries: 2 ingested" in messages
+        assert fake_pool.closed
+
+    async def test_no_source_configured_skips_ingestion_entirely(self, monkeypatch, fake_pool):
+        _patch_pool(monkeypatch, fake_pool)
+        _patch_migrations(monkeypatch, applied=[])
+        _patch_adapter(monkeypatch, AssertionError("adapter must not be built"))
+        _forbid_service(monkeypatch, "service must not be created")
+
+        messages: list[str] = []
+        result = await ops.run_quickstart(dict(_DB), source=None, progress=messages.append)
+
+        assert result.count == 0
+        assert result.migrations_applied == 0
+        assert any("Skipping data ingestion" in m for m in messages)
+        assert "  Tables: already up to date" in messages
+        assert fake_pool.closed
+
+    async def test_applied_migrations_are_reported_as_created(self, monkeypatch, fake_pool):
+        _patch_pool(monkeypatch, fake_pool)
+        _patch_migrations(monkeypatch, applied=["core_schema", "text_embedding"])
+        _forbid_service(monkeypatch, "service must not be created")
+
+        messages: list[str] = []
+        result = await ops.run_quickstart(dict(_DB), source=None, progress=messages.append)
+
+        assert result.migrations_applied == 2
+        assert "  Tables: created (2 migrations applied)" in messages
+
+    async def test_enhancers_run_per_entry_and_successes_are_counted(
+        self, monkeypatch, fake_pool, mock_repository
+    ):
+        _patch_pool(monkeypatch, fake_pool)
+        _patch_migrations(monkeypatch, applied=[])
+        _patch_adapter(monkeypatch, _Adapter([{"entry_id": "E1"}, {"entry_id": "E2"}]))
+        enhancer = _Enhancer(name="text_embedding")
+        _patch_enhancers(monkeypatch, [enhancer])
+        _patch_service(monkeypatch, _StubService(mock_repository, mock_repository.pool))
+
+        messages: list[str] = []
+        result = await ops.run_quickstart(
+            {**_DB, "ingestion": {"source_url": "file:///entries.json"}},
+            source=None,
+            progress=messages.append,
+        )
+
+        assert result.enhanced_count == 2
+        assert result.failed_count == 0
+        assert enhancer.seen == ["E1", "E2"]
+        assert mock_repository.mark_enhancement_complete.await_count == 2
+        assert "  Enhancement modules: ['text_embedding']" in messages
+        assert "  Enhancements: 2 applied" in messages
+
+    async def test_enhancer_failures_are_counted_marked_and_logged(
+        self, monkeypatch, fake_pool, mock_repository, caplog
+    ):
+        _patch_pool(monkeypatch, fake_pool)
+        _patch_migrations(monkeypatch, applied=[])
+        _patch_adapter(monkeypatch, _Adapter([{"entry_id": "E1"}]))
+        _patch_enhancers(
+            monkeypatch,
+            [_Enhancer(name="text_embedding", error=RuntimeError("no embedding backend"))],
+        )
+        _patch_service(monkeypatch, _StubService(mock_repository, mock_repository.pool))
+
+        messages: list[str] = []
+        with caplog.at_level(logging.DEBUG, logger="ariel"):
+            result = await ops.run_quickstart(
+                {**_DB, "ingestion": {"source_url": "file:///entries.json"}},
+                source=None,
+                progress=messages.append,
+            )
+
+        assert result.count == 1
+        assert result.enhanced_count == 0
+        assert result.failed_count == 1
+        mock_repository.mark_enhancement_failed.assert_awaited_once_with(
+            "E1", "text_embedding", "no embedding backend"
+        )
+        assert "Enhancement failed for E1" in caplog.text
+        # The failure count rides along on the enhancement summary line.
+        assert "  Enhancements: 0 applied, 1 failed" in messages
+
+    async def test_enabled_search_modules_are_reported(self, monkeypatch, fake_pool):
+        _patch_pool(monkeypatch, fake_pool)
+        _patch_migrations(monkeypatch, applied=[])
+        _forbid_service(monkeypatch, "service must not be created")
+
+        messages: list[str] = []
+        result = await ops.run_quickstart(
+            {**_DB, "search_modules": {"keyword": {"enabled": True}}},
+            source=None,
+            progress=messages.append,
+        )
+
+        assert "keyword" in result.enabled_search
+        assert any("Search modules: " in m for m in messages)
+        assert any("osprey ariel search" in m for m in messages)
+
+    async def test_runs_without_a_progress_callback(self, monkeypatch, fake_pool):
+        _patch_pool(monkeypatch, fake_pool)
+        _patch_migrations(monkeypatch, applied=["core_schema"])
+        _forbid_service(monkeypatch, "service must not be created")
+
+        result = await ops.run_quickstart(dict(_DB), source=None)
+
+        assert result.migrations_applied == 1
+        assert fake_pool.closed
+
+    async def test_pool_is_closed_when_migrations_fail(self, monkeypatch, fake_pool):
+        _patch_pool(monkeypatch, fake_pool)
+        _patch_migrations(monkeypatch, error=RuntimeError("no such database"))
+        _forbid_service(monkeypatch, "service must not be created")
+
+        with pytest.raises(RuntimeError, match="no such database"):
+            await ops.run_quickstart(dict(_DB), source=None)
+
+        assert fake_pool.closed
+
+
+# ---------------------------------------------------------------------------
+# get_purge_info
+# ---------------------------------------------------------------------------
+
+
+class TestGetPurgeInfo:
+    async def test_reports_entry_count_and_embedding_tables(self, monkeypatch, fake_pool_factory):
+        pool = fake_pool_factory(
+            rows_for={
+                "SELECT COUNT(*) FROM enhanced_entries": [(7,)],
+                _SELECT_EMBEDDING_TABLES: [
+                    ("text_embeddings_nomic_embed_text",),
+                    ("text_embeddings_mxbai",),
+                ],
+            }
+        )
+        _patch_pool(monkeypatch, pool)
+
+        info = await ops.get_purge_info(dict(_DB))
+
+        assert info.entry_count == 7
+        assert info.embedding_tables == [
+            "text_embeddings_nomic_embed_text",
+            "text_embeddings_mxbai",
+        ]
+        assert pool.closed
+
+    async def test_missing_count_row_defaults_to_zero(self, monkeypatch, fake_pool):
+        _patch_pool(monkeypatch, fake_pool)
+
+        info = await ops.get_purge_info(dict(_DB))
+
+        assert info.entry_count == 0
+        assert info.embedding_tables == []
+
+    async def test_pool_is_closed_when_the_count_query_fails(self, monkeypatch, fake_pool_factory):
+        pool = fake_pool_factory(
+            rows_for={"SELECT COUNT(*) FROM enhanced_entries": RuntimeError("table is gone")}
+        )
+        _patch_pool(monkeypatch, pool)
+
+        with pytest.raises(RuntimeError, match="table is gone"):
+            await ops.get_purge_info(dict(_DB))
+
+        assert pool.closed
+
+
+# ---------------------------------------------------------------------------
+# execute_purge
+# ---------------------------------------------------------------------------
+
+
+class TestExecutePurge:
+    """Both branches must unrecord the ``text_embedding`` migration.
+
+    Purging drops the migration-owned ``text_embeddings_*`` tables. If the
+    migration stays recorded as applied, the next ``osprey ariel migrate`` is a
+    no-op and the tables are never recreated — so both the ``DELETE FROM
+    ariel_migrations`` and the ``IF EXISTS`` guard wrapping it (dropping the
+    guard would abort with UndefinedTable on a database that never migrated)
+    are asserted on both paths.
+    """
+
+    async def test_embeddings_only_drops_tables_and_preserves_entries(
+        self, monkeypatch, fake_pool_factory
+    ):
+        pool = fake_pool_factory(
+            rows_for={
+                _SELECT_EMBEDDING_TABLES: [
+                    ("text_embeddings_nomic_embed_text",),
+                    ("text_embeddings_mxbai",),
+                ]
+            }
+        )
+        _patch_pool(monkeypatch, pool)
+
+        messages: list[str] = []
+        await ops.execute_purge(dict(_DB), embeddings_only=True, progress=messages.append)
+
+        assert pool.matching("DROP TABLE IF EXISTS text_embeddings_nomic_embed_text CASCADE")
+        assert pool.matching("DROP TABLE IF EXISTS text_embeddings_mxbai CASCADE")
+        assert pool.matching(_UNRECORD_MIGRATION)
+        # Entries survive an embeddings-only purge.
+        assert not pool.matching("TRUNCATE enhanced_entries")
+        assert not pool.matching("TRUNCATE ingestion_runs")
+        assert "  Dropped text_embeddings_mxbai" in messages
+        assert any("Embedding tables purged" in m for m in messages)
+        assert pool.closed
+
+    async def test_full_purge_truncates_drops_and_unrecords_migration(
+        self, monkeypatch, fake_pool_factory
+    ):
+        pool = fake_pool_factory(
+            rows_for={_SELECT_EMBEDDING_TABLES: [("text_embeddings_nomic_embed_text",)]}
+        )
+        _patch_pool(monkeypatch, pool)
+
+        messages: list[str] = []
+        await ops.execute_purge(dict(_DB), embeddings_only=False, progress=messages.append)
+
+        assert pool.matching("TRUNCATE enhanced_entries CASCADE")
+        assert pool.matching("TRUNCATE ingestion_runs CASCADE")
+        assert pool.matching("DROP TABLE IF EXISTS text_embeddings_nomic_embed_text CASCADE")
+        assert pool.matching(_UNRECORD_MIGRATION)
+        assert any("All ARIEL data purged" in m for m in messages)
+        # The full purge does not narrate individual drops.
+        assert not any(m.startswith("  Dropped ") for m in messages)
+        assert pool.closed
+
+    async def test_full_purge_unrecords_migration_even_with_no_embedding_tables(
+        self, monkeypatch, fake_pool
+    ):
+        _patch_pool(monkeypatch, fake_pool)
+
+        await ops.execute_purge(dict(_DB), embeddings_only=False, progress=None)
+
+        assert not fake_pool.matching("DROP TABLE IF EXISTS")
+        assert fake_pool.matching(_UNRECORD_MIGRATION)
+
+    async def test_embeddings_only_unrecords_migration_with_no_tables_present(
+        self, monkeypatch, fake_pool
+    ):
+        _patch_pool(monkeypatch, fake_pool)
+
+        await ops.execute_purge(dict(_DB), embeddings_only=True, progress=None)
+
+        assert not fake_pool.matching("DROP TABLE IF EXISTS")
+        assert fake_pool.matching(_UNRECORD_MIGRATION)
+
+    async def test_pool_is_closed_when_a_drop_fails(self, monkeypatch, fake_pool_factory):
+        pool = fake_pool_factory(
+            rows_for={
+                _SELECT_EMBEDDING_TABLES: [("text_embeddings_nomic_embed_text",)],
+                "DROP TABLE IF EXISTS": RuntimeError("permission denied"),
+            }
+        )
+        _patch_pool(monkeypatch, pool)
+
+        with pytest.raises(RuntimeError, match="permission denied"):
+            await ops.execute_purge(dict(_DB), embeddings_only=True)
+
+        assert pool.closed
+        # The migration row is left recorded because the purge never finished.
+        assert not pool.matching(_UNRECORD_MIGRATION)

--- a/tests/services/ariel_search/test_cli_operations_pipeline.py
+++ b/tests/services/ariel_search/test_cli_operations_pipeline.py
@@ -1,0 +1,874 @@
+"""Ingest-side pipeline tests for :mod:`osprey.services.ariel_search.cli_operations`.
+
+Companion to ``test_cli_operations.py``, which covers the pure-logic and
+error-translation contracts. This module drives the *storing* paths — the ones
+that open the ARIEL service, walk an adapter stream, run enhancers and record an
+ingestion run:
+
+* ``run_sync`` — migrate, incremental poll, enhance cleanup, and the deep-copied
+  ``require_initial_ingest=False`` override that lets sync do a full ingest on a
+  fresh database without editing the caller's config dict.
+* ``run_ingest`` — the storing branch: upsert, per-enhancer success/failure
+  accounting, run bookkeeping, and the every-100-entries progress lines.
+* ``run_watch`` — the source/adapter/interval config overrides, the single-poll
+  result projection, and daemon mode with its SIGINT/SIGTERM handlers.
+* ``run_enhance`` — entry selection (force / single module / dedupe across all
+  enhancers) and the per-entry enhancement loop.
+* ``seed_logbook_entries`` — the progress branches.
+* ``IngestionScheduler.poll_once`` — the per-entry exception handler, reached
+  through ``run_watch(once=True)`` with a repository that rejects one entry.
+
+Everything crossing a process boundary is faked. Following the package rule that
+a patch must name the module that *owns* the symbol (``cli_operations`` imports
+each of these lazily, inside the function), the seams are patched at their
+source: ``create_ariel_service`` on the ``ariel_search`` package,
+``create_connection_pool`` on ``database.connection``, ``run_migrations`` on
+``database.migrations``, ``IngestionScheduler`` on ``ingestion.scheduler``,
+``get_adapter`` on ``ingestion`` and ``create_enhancers_from_config`` on
+``enhancement``. The service stub carries a ``_FakePool`` from the shared
+``mock_repository`` fixture, so ``async with service.pool.connection()`` works
+and every statement lands in ``repo.pool.calls``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from osprey.services.ariel_search import cli_operations as ops
+from tests.services.ariel_search._cli_ops_doubles import (
+    _Adapter,
+    _Enhancer,
+    _forbid_service,
+    _patch_adapter,
+    _patch_enhancers,
+    _patch_migrations,
+    _patch_pool,
+    _patch_service,
+    _StubService,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# A minimal config dict accepted by ARIELConfig.from_dict.
+_DB: dict[str, Any] = {"database": {"uri": "postgresql://localhost/test"}}
+_SOURCE = "file:///entries.json"
+
+
+def _config(**ingestion: Any) -> dict[str, Any]:
+    """Fresh config dict; ``ingestion`` kwargs become the ``ingestion`` block."""
+    cfg: dict[str, Any] = {"database": dict(_DB["database"])}
+    if ingestion:
+        cfg["ingestion"] = dict(ingestion)
+    return cfg
+
+
+@pytest.fixture(autouse=True)
+def _no_ariel_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep ingestion config assertions independent of the developer's shell.
+
+    ``IngestionConfig``/``WriteConfig`` fall back to ``ARIEL_SOCKS_PROXY`` /
+    ``ARIEL_WRITE_USER`` / ``ARIEL_WRITE_PASSWORD`` when the dict omits them, so
+    a host that exports any of them would otherwise leak into the config objects
+    these tests build.
+    """
+    for name in ("ARIEL_SOCKS_PROXY", "ARIEL_WRITE_USER", "ARIEL_WRITE_PASSWORD"):
+        monkeypatch.delenv(name, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Entry and result factories -- the shared doubles live in ``_cli_ops_doubles``
+# ---------------------------------------------------------------------------
+
+
+def _entries(count: int, prefix: str = "E") -> list[dict[str, Any]]:
+    return [{"entry_id": f"{prefix}{i}", "raw_text": f"entry {i}"} for i in range(count)]
+
+
+def _async_return(value: Any) -> AsyncMock:
+    """An awaitable repository stub returning *value* on every call."""
+    return AsyncMock(return_value=value)
+
+
+def _poll_result(added: int = 0, failed: int = 0, duration: float = 0.5, since: Any = None):
+    from osprey.services.ariel_search.ingestion.scheduler import IngestionPollResult
+
+    return IngestionPollResult(
+        entries_added=added,
+        entries_updated=0,
+        entries_failed=failed,
+        duration_seconds=duration,
+        since=since,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scheduler double -- the only seam unique to the pipeline operations
+# ---------------------------------------------------------------------------
+
+
+class _StubScheduler:
+    """Recording stand-in for ``IngestionScheduler`` (built by the patch below)."""
+
+    poll_result: Any = None
+    made: list[_StubScheduler] = []
+
+    def __init__(self, config: Any, repository: Any) -> None:
+        self.config = config
+        self.repository = repository
+        self.poll_calls: list[dict[str, Any]] = []
+        self.start_calls = 0
+        self.stop_calls = 0
+
+    async def poll_once(self, dry_run: bool = False, limit: int | None = None):
+        self.poll_calls.append({"dry_run": dry_run, "limit": limit})
+        return self.poll_result
+
+    async def start(self) -> None:
+        self.start_calls += 1
+
+    async def stop(self) -> None:
+        self.stop_calls += 1
+
+
+def _patch_scheduler(monkeypatch: pytest.MonkeyPatch, poll_result: Any = None) -> list[Any]:
+    """Route ``IngestionScheduler`` to a recording stub; returns its instances."""
+    import osprey.services.ariel_search.ingestion.scheduler as sched_mod
+
+    made: list[Any] = []
+
+    class _Recorded(_StubScheduler):
+        def __init__(self, config, repository):
+            super().__init__(config, repository)
+            self.poll_result = poll_result if poll_result is not None else _poll_result()
+            made.append(self)
+
+    monkeypatch.setattr(sched_mod, "IngestionScheduler", _Recorded)
+    return made
+
+
+# ---------------------------------------------------------------------------
+# run_sync -- migrate, incremental poll, enhance cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestRunSync:
+    async def test_full_cycle_reports_every_stage(self, monkeypatch, mock_repository, fake_pool):
+        _patch_pool(monkeypatch, fake_pool)
+        _patch_migrations(monkeypatch, applied=["001_initial", "002_embeddings"])
+        schedulers = _patch_scheduler(monkeypatch, _poll_result(added=3, failed=1, since=None))
+        service = _StubService(mock_repository)
+        _patch_service(monkeypatch, service)
+        _patch_enhancers(monkeypatch, [_Enhancer("text_embedding")])
+        mock_repository.get_incomplete_entries = _async_return([{"entry_id": "OLD1"}])
+
+        config_dict = _config(adapter="generic_json", source_url=_SOURCE)
+        messages: list[str] = []
+
+        out = await ops.run_sync(config_dict, limit=5, progress=messages.append)
+
+        assert out.migrations_applied == 2
+        assert out.entries_ingested == 3
+        assert out.entries_failed == 1
+        assert out.was_initial_ingest is True
+        # Step 3 catches up the one entry left incomplete by an earlier run.
+        assert out.entries_enhanced == 1
+
+        assert fake_pool.closed is True
+        assert schedulers[0].poll_calls == [{"dry_run": False, "limit": 5}]
+        assert messages[:2] == ["Running migrations...", "  2 migrations applied"]
+        assert f"Polling for new entries (source: {_SOURCE})..." in messages
+        assert "  3 entries ingested" in messages
+        assert "  (initial full ingest)" in messages
+
+    async def test_sync_overrides_require_initial_ingest_without_touching_caller_config(
+        self, monkeypatch, mock_repository, fake_pool
+    ):
+        _patch_pool(monkeypatch, fake_pool)
+        _patch_migrations(monkeypatch, applied=[])
+        schedulers = _patch_scheduler(monkeypatch, _poll_result(added=0))
+        _patch_service(monkeypatch, _StubService(mock_repository))
+        _patch_enhancers(monkeypatch, [])
+
+        config_dict = _config(adapter="generic_json", source_url=_SOURCE)
+        config_dict["ingestion"]["watch"] = {
+            "require_initial_ingest": True,
+            "max_consecutive_failures": 3,
+        }
+
+        await ops.run_sync(config_dict)
+
+        watch = schedulers[0].config.ingestion.watch
+        # Only the one key is overridden; the rest of the watch block survives.
+        assert watch.require_initial_ingest is False
+        assert watch.max_consecutive_failures == 3
+        # The caller's dict is deep-copied, so its own watch block is untouched.
+        assert config_dict["ingestion"]["watch"] == {
+            "require_initial_ingest": True,
+            "max_consecutive_failures": 3,
+        }
+
+    async def test_missing_ingestion_block_gets_the_override_too(
+        self, monkeypatch, mock_repository, fake_pool
+    ):
+        _patch_pool(monkeypatch, fake_pool)
+        _patch_migrations(monkeypatch, applied=[])
+        schedulers = _patch_scheduler(monkeypatch, _poll_result(added=0))
+        _patch_service(monkeypatch, _StubService(mock_repository))
+        _patch_enhancers(monkeypatch, [])
+
+        config_dict = dict(_DB)
+
+        await ops.run_sync(config_dict)
+
+        assert schedulers[0].config.ingestion.watch.require_initial_ingest is False
+        # The synthesized block never leaks back to the caller.
+        assert "ingestion" not in config_dict
+
+    async def test_up_to_date_and_incremental_poll_report_no_initial_ingest(
+        self, monkeypatch, mock_repository, fake_pool
+    ):
+        since = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+        _patch_pool(monkeypatch, fake_pool)
+        _patch_migrations(monkeypatch, applied=[])
+        _patch_scheduler(monkeypatch, _poll_result(added=2, since=since))
+        _patch_service(monkeypatch, _StubService(mock_repository))
+        _patch_enhancers(monkeypatch, [])
+
+        messages: list[str] = []
+        out = await ops.run_sync(_config(source_url=_SOURCE), progress=messages.append)
+
+        assert out.migrations_applied == 0
+        assert out.was_initial_ingest is False
+        assert out.entries_enhanced == 0
+        assert "  Already up to date" in messages
+        assert "  (initial full ingest)" not in messages
+        # Step 3 short-circuits when nothing is enabled.
+        assert "No enhancement modules enabled or selected" in messages
+
+    async def test_unset_source_url_is_reported_verbatim(
+        self, monkeypatch, mock_repository, fake_pool
+    ):
+        _patch_pool(monkeypatch, fake_pool)
+        _patch_migrations(monkeypatch, applied=[])
+        _patch_scheduler(monkeypatch, _poll_result())
+        _patch_service(monkeypatch, _StubService(mock_repository))
+        _patch_enhancers(monkeypatch, [])
+
+        messages: list[str] = []
+        await ops.run_sync(_config(adapter="generic_json"), progress=messages.append)
+
+        # The "unknown" fallback in the progress line is unreachable: the
+        # deep-copied dict always gains an ``ingestion`` block, so
+        # ``sync_config.ingestion`` is an always-truthy dataclass and an unset
+        # ``source_url`` prints as None.
+        assert "Polling for new entries (source: None)..." in messages
+
+    async def test_runs_silently_without_a_progress_callback(
+        self, monkeypatch, mock_repository, fake_pool
+    ):
+        _patch_pool(monkeypatch, fake_pool)
+        _patch_migrations(monkeypatch, applied=["001_initial"])
+        _patch_scheduler(monkeypatch, _poll_result(added=1, since=None))
+        _patch_service(monkeypatch, _StubService(mock_repository))
+        _patch_enhancers(monkeypatch, [])
+
+        out = await ops.run_sync(_config(source_url=_SOURCE))
+
+        assert out.migrations_applied == 1
+        assert out.entries_ingested == 1
+
+    async def test_migration_failure_closes_the_pool_and_propagates(self, monkeypatch, fake_pool):
+        _patch_pool(monkeypatch, fake_pool)
+        _patch_migrations(monkeypatch, error=RuntimeError("migration blew up"))
+        _forbid_service(monkeypatch)
+
+        with pytest.raises(RuntimeError, match="migration blew up"):
+            await ops.run_sync(_config(source_url=_SOURCE))
+
+        assert fake_pool.closed is True
+
+
+# ---------------------------------------------------------------------------
+# run_ingest -- the storing branch
+# ---------------------------------------------------------------------------
+
+
+class TestRunIngestStoring:
+    async def test_stores_entries_and_records_the_run(self, monkeypatch, mock_repository):
+        adapter = _Adapter(_entries(2), source_system_name="ALS eLog")
+        enhancer = _Enhancer("text_embedding")
+        _patch_adapter(monkeypatch, adapter)
+        _patch_enhancers(monkeypatch, [enhancer])
+        service = _StubService(mock_repository)
+        _patch_service(monkeypatch, service)
+
+        config_dict = dict(_DB)
+        out = await ops.run_ingest(
+            config_dict,
+            source=_SOURCE,
+            adapter="generic_json",
+            since=None,
+            limit=None,
+            dry_run=False,
+        )
+
+        assert (out.count, out.enhanced_count, out.failed_count) == (2, 2, 0)
+        assert out.dry_run is False
+        assert out.enhancer_names == ["text_embedding"]
+        assert mock_repository.upsert_entry.await_count == 2
+        mock_repository.start_ingestion_run.assert_awaited_once_with("ALS eLog")
+        mock_repository.complete_ingestion_run.assert_awaited_once_with(
+            1, entries_added=2, entries_updated=0, entries_failed=0
+        )
+        mock_repository.fail_ingestion_run.assert_not_awaited()
+        # Every enhancer runs against the connection opened from the service pool.
+        assert enhancer.seen == ["E0", "E1"]
+        assert set(enhancer.conns) == {service.pool.conn}
+        assert service.exits == service.enters == 1
+
+    async def test_source_and_adapter_are_written_into_the_caller_config(
+        self, monkeypatch, mock_repository
+    ):
+        _patch_adapter(monkeypatch, _Adapter())
+        _patch_enhancers(monkeypatch, [])
+        _patch_service(monkeypatch, _StubService(mock_repository))
+
+        config_dict = dict(_DB)
+        await ops.run_ingest(
+            config_dict,
+            source=_SOURCE,
+            adapter="als_logbook",
+            since=None,
+            limit=None,
+            dry_run=False,
+        )
+
+        # Unlike run_sync, run_ingest edits the dict it is handed.
+        assert config_dict["ingestion"] == {"source_url": _SOURCE, "adapter": "als_logbook"}
+
+    async def test_since_and_limit_reach_the_adapter(self, monkeypatch, mock_repository):
+        since = datetime(2026, 5, 5, tzinfo=UTC)
+        adapter = _Adapter(_entries(1))
+        _patch_adapter(monkeypatch, adapter)
+        _patch_enhancers(monkeypatch, [])
+        _patch_service(monkeypatch, _StubService(mock_repository))
+
+        await ops.run_ingest(
+            dict(_DB),
+            source=_SOURCE,
+            adapter="generic_json",
+            since=since,
+            limit=7,
+            dry_run=False,
+        )
+
+        assert adapter.fetch_calls == [{"since": since, "limit": 7}]
+
+    async def test_enhancer_failure_is_recorded_per_entry_and_does_not_abort(
+        self, monkeypatch, mock_repository
+    ):
+        _patch_adapter(monkeypatch, _Adapter(_entries(3)))
+        _patch_enhancers(monkeypatch, [_Enhancer("text_embedding", fails_on={"E1"})])
+        _patch_service(monkeypatch, _StubService(mock_repository))
+
+        out = await ops.run_ingest(
+            dict(_DB),
+            source=_SOURCE,
+            adapter="generic_json",
+            since=None,
+            limit=None,
+            dry_run=False,
+        )
+
+        # All three entries still land; only the one enhancement is counted failed.
+        assert (out.count, out.enhanced_count, out.failed_count) == (3, 2, 1)
+        mock_repository.mark_enhancement_failed.assert_awaited_once_with(
+            "E1", "text_embedding", "enhance failed on E1"
+        )
+        mock_repository.complete_ingestion_run.assert_awaited_once_with(
+            1, entries_added=3, entries_updated=0, entries_failed=1
+        )
+
+    async def test_counts_are_per_enhancer_not_per_entry(self, monkeypatch, mock_repository):
+        good = _Enhancer("text_embedding")
+        bad = _Enhancer("semantic_processor", fails_on={"E0", "E1"})
+        _patch_adapter(monkeypatch, _Adapter(_entries(2)))
+        _patch_enhancers(monkeypatch, [good, bad])
+        _patch_service(monkeypatch, _StubService(mock_repository))
+
+        out = await ops.run_ingest(
+            dict(_DB),
+            source=_SOURCE,
+            adapter="generic_json",
+            since=None,
+            limit=None,
+            dry_run=False,
+        )
+
+        # 2 entries x 2 enhancers = 4 attempts: 2 complete, 2 failed.
+        assert (out.count, out.enhanced_count, out.failed_count) == (2, 2, 2)
+        assert out.enhancer_names == ["text_embedding", "semantic_processor"]
+
+    async def test_upsert_failure_marks_the_run_failed_and_reraises(
+        self, monkeypatch, mock_repository
+    ):
+        _patch_adapter(monkeypatch, _Adapter(_entries(2)))
+        _patch_enhancers(monkeypatch, [])
+        service = _StubService(mock_repository)
+        _patch_service(monkeypatch, service)
+        mock_repository.upsert_entry.side_effect = RuntimeError("db is gone")
+
+        with pytest.raises(RuntimeError, match="db is gone"):
+            await ops.run_ingest(
+                dict(_DB),
+                source=_SOURCE,
+                adapter="generic_json",
+                since=None,
+                limit=None,
+                dry_run=False,
+            )
+
+        mock_repository.fail_ingestion_run.assert_awaited_once_with(1, "db is gone")
+        mock_repository.complete_ingestion_run.assert_not_awaited()
+        assert service.exits == 1
+
+    async def test_adapter_stream_failure_marks_the_run_failed(self, monkeypatch, mock_repository):
+        _patch_adapter(monkeypatch, _Adapter(_entries(3), raise_at=2))
+        _patch_enhancers(monkeypatch, [])
+        _patch_service(monkeypatch, _StubService(mock_repository))
+
+        with pytest.raises(RuntimeError, match="adapter stream failed"):
+            await ops.run_ingest(
+                dict(_DB),
+                source=_SOURCE,
+                adapter="generic_json",
+                since=None,
+                limit=None,
+                dry_run=False,
+            )
+
+        # The two entries that arrived before the stream died are already stored;
+        # the run itself is recorded as failed.
+        assert mock_repository.upsert_entry.await_count == 2
+        mock_repository.fail_ingestion_run.assert_awaited_once_with(1, "adapter stream failed")
+
+    async def test_progress_every_hundred_entries_names_enhancement(
+        self, monkeypatch, mock_repository
+    ):
+        _patch_adapter(monkeypatch, _Adapter(_entries(100)))
+        _patch_enhancers(monkeypatch, [_Enhancer("text_embedding")])
+        _patch_service(monkeypatch, _StubService(mock_repository))
+
+        messages: list[str] = []
+        out = await ops.run_ingest(
+            dict(_DB),
+            source=_SOURCE,
+            adapter="generic_json",
+            since=None,
+            limit=None,
+            dry_run=False,
+            progress=messages.append,
+        )
+
+        assert out.count == 100
+        assert "  Ingested and enhanced 100 entries..." in messages
+        assert not any("Ingested 100 entries" in m for m in messages)
+
+    async def test_progress_every_hundred_entries_without_enhancers(
+        self, monkeypatch, mock_repository
+    ):
+        _patch_adapter(monkeypatch, _Adapter(_entries(100)))
+        _patch_enhancers(monkeypatch, [])
+        _patch_service(monkeypatch, _StubService(mock_repository))
+
+        messages: list[str] = []
+        await ops.run_ingest(
+            dict(_DB),
+            source=_SOURCE,
+            adapter="generic_json",
+            since=None,
+            limit=None,
+            dry_run=False,
+            progress=messages.append,
+        )
+
+        assert "  Ingested 100 entries..." in messages
+
+    async def test_dry_run_reports_progress_every_hundred_entries(self, monkeypatch):
+        _patch_adapter(monkeypatch, _Adapter(_entries(100)))
+        _patch_enhancers(monkeypatch, [])
+        _forbid_service(monkeypatch)
+
+        messages: list[str] = []
+        out = await ops.run_ingest(
+            dict(_DB),
+            source=_SOURCE,
+            adapter="generic_json",
+            since=None,
+            limit=None,
+            dry_run=True,
+            progress=messages.append,
+        )
+
+        assert out.count == 100
+        assert "  Parsed 100 entries..." in messages
+
+
+# ---------------------------------------------------------------------------
+# run_watch -- config overrides and the single-poll projection
+# ---------------------------------------------------------------------------
+
+
+class TestRunWatchOnce:
+    async def test_source_and_adapter_overrides_create_the_ingestion_block(
+        self, monkeypatch, mock_repository
+    ):
+        since = datetime(2026, 4, 1, 9, 30, tzinfo=UTC)
+        schedulers = _patch_scheduler(
+            monkeypatch, _poll_result(added=4, failed=2, duration=1.25, since=since)
+        )
+        _patch_service(monkeypatch, _StubService(mock_repository))
+
+        config_dict = dict(_DB)
+        messages: list[str] = []
+        out = await ops.run_watch(
+            config_dict,
+            source=_SOURCE,
+            adapter="als_logbook",
+            once=True,
+            interval=None,
+            dry_run=False,
+            progress=messages.append,
+        )
+
+        assert config_dict["ingestion"] == {"source_url": _SOURCE, "adapter": "als_logbook"}
+        assert schedulers[0].config.ingestion.adapter == "als_logbook"
+        assert out is not None
+        assert (out.entries_added, out.entries_failed) == (4, 2)
+        assert out.duration_seconds == 1.25
+        assert out.since == since
+        assert out.dry_run is False
+        assert f"Running single poll cycle (source: {_SOURCE})" in messages
+
+    async def test_interval_override_reaches_the_scheduler_config(
+        self, monkeypatch, mock_repository
+    ):
+        schedulers = _patch_scheduler(monkeypatch, _poll_result())
+        _patch_service(monkeypatch, _StubService(mock_repository))
+
+        config_dict = _config(adapter="generic_json", source_url=_SOURCE)
+        await ops.run_watch(
+            config_dict,
+            source=None,
+            adapter=None,
+            once=True,
+            interval=30,
+            dry_run=False,
+        )
+
+        assert config_dict["ingestion"]["poll_interval_seconds"] == 30
+        assert schedulers[0].config.ingestion.poll_interval_seconds == 30
+
+    async def test_interval_without_a_source_is_recorded_then_rejected(self, monkeypatch):
+        _forbid_service(monkeypatch)
+
+        config_dict = dict(_DB)
+        with pytest.raises(ValueError, match="No ingestion source configured"):
+            await ops.run_watch(
+                config_dict,
+                source=None,
+                adapter=None,
+                once=True,
+                interval=45,
+                dry_run=False,
+            )
+
+        # The override is applied before the source check, so the synthesized
+        # block is left behind even though the call is rejected.
+        assert config_dict["ingestion"] == {"poll_interval_seconds": 45}
+
+    async def test_dry_run_flag_reaches_poll_once_and_the_result(
+        self, monkeypatch, mock_repository
+    ):
+        schedulers = _patch_scheduler(monkeypatch, _poll_result(added=6))
+        _patch_service(monkeypatch, _StubService(mock_repository))
+
+        out = await ops.run_watch(
+            _config(source_url=_SOURCE),
+            source=None,
+            adapter=None,
+            once=True,
+            interval=None,
+            dry_run=True,
+        )
+
+        assert schedulers[0].poll_calls == [{"dry_run": True, "limit": None}]
+        assert out is not None
+        assert out.dry_run is True
+        assert out.entries_added == 6
+
+
+class TestRunWatchDaemon:
+    async def test_daemon_mode_installs_signal_handlers_and_runs_the_loop(
+        self, monkeypatch, mock_repository
+    ):
+        schedulers = _patch_scheduler(monkeypatch)
+        _patch_service(monkeypatch, _StubService(mock_repository))
+        loop = asyncio.get_running_loop()
+
+        messages: list[str] = []
+        try:
+            out = await ops.run_watch(
+                _config(source_url=_SOURCE, poll_interval_seconds=120),
+                source=None,
+                adapter=None,
+                once=False,
+                interval=None,
+                dry_run=False,
+                progress=messages.append,
+            )
+
+            assert out is None
+            assert schedulers[0].start_calls == 1
+            assert schedulers[0].poll_calls == []
+            assert messages == [
+                f"Watching: {_SOURCE}",
+                "Poll interval: 120s",
+                "Press Ctrl+C to stop\n",
+            ]
+            # remove_signal_handler reports whether one was installed -- and
+            # takes it back off the loop.
+            assert loop.remove_signal_handler(signal.SIGINT) is True
+            assert loop.remove_signal_handler(signal.SIGTERM) is True
+        finally:
+            loop.remove_signal_handler(signal.SIGINT)
+            loop.remove_signal_handler(signal.SIGTERM)
+
+    async def test_installed_handler_stops_the_scheduler(self, monkeypatch, mock_repository):
+        schedulers = _patch_scheduler(monkeypatch)
+        _patch_service(monkeypatch, _StubService(mock_repository))
+
+        loop = asyncio.get_running_loop()
+        handlers: dict[int, Callable[[], None]] = {}
+        real_add = loop.add_signal_handler
+
+        def _record(sig, callback, *args):
+            handlers[sig] = callback
+            real_add(sig, callback, *args)
+
+        monkeypatch.setattr(loop, "add_signal_handler", _record)
+
+        try:
+            await ops.run_watch(
+                _config(source_url=_SOURCE),
+                source=None,
+                adapter=None,
+                once=False,
+                interval=None,
+                dry_run=False,
+            )
+
+            assert set(handlers) == {signal.SIGINT, signal.SIGTERM}
+
+            handlers[signal.SIGTERM]()
+            # The handler schedules stop() as a task; give the loop one turn.
+            await asyncio.sleep(0)
+            assert schedulers[0].stop_calls == 1
+        finally:
+            for sig in handlers:
+                loop.remove_signal_handler(sig)
+
+
+# ---------------------------------------------------------------------------
+# run_enhance -- entry selection and the enhancement loop
+# ---------------------------------------------------------------------------
+
+
+class TestRunEnhance:
+    async def test_no_enhancers_reports_through_progress(self, monkeypatch):
+        _patch_enhancers(monkeypatch, [])
+        _forbid_service(monkeypatch)
+
+        messages: list[str] = []
+        out = await ops.run_enhance(
+            dict(_DB), module=None, force=False, limit=10, progress=messages.append
+        )
+
+        assert out.entries_processed == 0
+        assert messages == ["No enhancement modules enabled or selected"]
+
+    async def test_force_reprocesses_the_time_range_instead_of_incomplete_entries(
+        self, monkeypatch, mock_repository
+    ):
+        enhancer = _Enhancer("text_embedding")
+        _patch_enhancers(monkeypatch, [enhancer])
+        _patch_service(monkeypatch, _StubService(mock_repository))
+        mock_repository.search_by_time_range = _async_return(_entries(2))
+        mock_repository.get_incomplete_entries = _async_return([])
+
+        out = await ops.run_enhance(dict(_DB), module=None, force=True, limit=25)
+
+        assert out.entries_processed == 2
+        assert out.module_names == ["text_embedding"]
+        mock_repository.search_by_time_range.assert_awaited_once_with(limit=25)
+        mock_repository.get_incomplete_entries.assert_not_awaited()
+        assert enhancer.seen == ["E0", "E1"]
+        assert mock_repository.mark_enhancement_complete.await_count == 2
+
+    async def test_named_module_narrows_both_the_query_and_the_enhancers(
+        self, monkeypatch, mock_repository
+    ):
+        wanted = _Enhancer("text_embedding")
+        other = _Enhancer("semantic_processor")
+        _patch_enhancers(monkeypatch, [wanted, other])
+        _patch_service(monkeypatch, _StubService(mock_repository))
+        mock_repository.get_incomplete_entries = _async_return(_entries(1))
+
+        out = await ops.run_enhance(dict(_DB), module="text_embedding", force=False, limit=5)
+
+        assert out.module_names == ["text_embedding"]
+        assert out.entries_processed == 1
+        mock_repository.get_incomplete_entries.assert_awaited_once_with(
+            module_name="text_embedding", limit=5
+        )
+        assert other.seen == []
+
+    async def test_all_modules_dedupes_entries_incomplete_for_more_than_one(
+        self, monkeypatch, mock_repository
+    ):
+        from unittest.mock import AsyncMock
+
+        first = _Enhancer("text_embedding")
+        second = _Enhancer("semantic_processor")
+        _patch_enhancers(monkeypatch, [first, second])
+        _patch_service(monkeypatch, _StubService(mock_repository))
+        # E2 is incomplete for both modules and must be collected once.
+        mock_repository.get_incomplete_entries = AsyncMock(
+            side_effect=[
+                [{"entry_id": "E1"}, {"entry_id": "E2"}],
+                [{"entry_id": "E2"}, {"entry_id": "E3"}],
+            ]
+        )
+
+        out = await ops.run_enhance(dict(_DB), module=None, force=False, limit=50)
+
+        assert out.entries_processed == 3
+        assert first.seen == ["E1", "E2", "E3"]
+        # Every collected entry is offered to every enhancer, not just the one
+        # whose query produced it.
+        assert second.seen == ["E1", "E2", "E3"]
+        assert mock_repository.get_incomplete_entries.await_count == 2
+
+    async def test_enhancement_failure_is_recorded_and_the_loop_continues(
+        self, monkeypatch, mock_repository
+    ):
+        _patch_enhancers(monkeypatch, [_Enhancer("text_embedding", fails_on={"E0"})])
+        _patch_service(monkeypatch, _StubService(mock_repository))
+        mock_repository.get_incomplete_entries = _async_return(_entries(2))
+
+        out = await ops.run_enhance(dict(_DB), module=None, force=False, limit=10)
+
+        assert out.entries_processed == 2
+        mock_repository.mark_enhancement_failed.assert_awaited_once_with(
+            "E0", "text_embedding", "enhance failed on E0"
+        )
+        mock_repository.mark_enhancement_complete.assert_awaited_once_with("E1", "text_embedding")
+
+    async def test_progress_reports_the_batch_and_every_tenth_entry(
+        self, monkeypatch, mock_repository
+    ):
+        _patch_enhancers(monkeypatch, [_Enhancer("text_embedding")])
+        _patch_service(monkeypatch, _StubService(mock_repository))
+        mock_repository.get_incomplete_entries = _async_return(_entries(10))
+
+        messages: list[str] = []
+        await ops.run_enhance(
+            dict(_DB), module=None, force=False, limit=10, progress=messages.append
+        )
+
+        assert "Enhancement modules: ['text_embedding']" in messages
+        assert "Processing 10 entries..." in messages
+        assert "  Processed 10 entries..." in messages
+
+
+# ---------------------------------------------------------------------------
+# seed_logbook_entries -- progress branches
+# ---------------------------------------------------------------------------
+
+
+class TestSeedLogbookEntriesProgress:
+    async def test_progress_reports_every_hundred_and_a_final_total(
+        self, monkeypatch, mock_repository
+    ):
+        _patch_service(monkeypatch, _StubService(mock_repository))
+
+        messages: list[str] = []
+        count = await ops.seed_logbook_entries(dict(_DB), _entries(100), progress=messages.append)
+
+        assert count == 100
+        assert messages == [
+            "  Seeded 100 entries...",
+            "✓ Seeded 100 logbook entries.",
+        ]
+
+    async def test_final_total_is_reported_even_below_the_batch_size(
+        self, monkeypatch, mock_repository
+    ):
+        _patch_service(monkeypatch, _StubService(mock_repository))
+
+        messages: list[str] = []
+        await ops.seed_logbook_entries(dict(_DB), _entries(2), progress=messages.append)
+
+        assert messages == ["✓ Seeded 2 logbook entries."]
+
+
+# ---------------------------------------------------------------------------
+# IngestionScheduler.poll_once -- per-entry failure, driven through run_watch
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulerPollOnceEntryFailures:
+    async def test_one_bad_entry_is_counted_and_logged_without_stopping_the_poll(
+        self, monkeypatch, mock_repository, caplog
+    ):
+        # The real scheduler here -- only the adapter, the enhancers and the
+        # service are faked.
+        _patch_adapter(monkeypatch, _Adapter(_entries(3)))
+        _patch_enhancers(monkeypatch, [])
+        _patch_service(monkeypatch, _StubService(mock_repository))
+        mock_repository.get_last_successful_run = _async_return(datetime(2026, 3, 3, tzinfo=UTC))
+
+        def _reject_e1(entry):
+            if entry["entry_id"] == "E1":
+                raise RuntimeError("entry rejected")
+
+        mock_repository.upsert_entry.side_effect = _reject_e1
+
+        with caplog.at_level(logging.ERROR, logger="ariel"):
+            out = await ops.run_watch(
+                _config(adapter="generic_json", source_url=_SOURCE),
+                source=None,
+                adapter=None,
+                once=True,
+                interval=None,
+                dry_run=False,
+            )
+
+        assert out is not None
+        assert (out.entries_added, out.entries_failed) == (2, 1)
+        assert out.since == datetime(2026, 3, 3, tzinfo=UTC)
+        # The poll still completes its run rather than failing it.
+        mock_repository.complete_ingestion_run.assert_awaited_once_with(
+            1, entries_added=2, entries_updated=0, entries_failed=1
+        )
+        mock_repository.fail_ingestion_run.assert_not_awaited()
+        assert "Failed to process entry" in caplog.text
+        assert "entry rejected" in caplog.text

--- a/tests/services/ariel_search/test_database.py
+++ b/tests/services/ariel_search/test_database.py
@@ -4,17 +4,135 @@ Note: These tests run without psycopg installed by testing only the
 migration logic and configuration parts that don't require database access.
 """
 
+import logging
+
 import pytest
 
 from osprey.services.ariel_search.config import ARIELConfig, DatabaseConfig
+from osprey.services.ariel_search.database import migrations as migrations_module
+from osprey.services.ariel_search.database.attachment_migration import AttachmentMigration
 from osprey.services.ariel_search.database.core_migration import CoreMigration
-from osprey.services.ariel_search.database.migrations import BaseMigration, model_to_table_name
+from osprey.services.ariel_search.database.migrations import (
+    BaseMigration,
+    MigrationRunner,
+    MigrationSkippedError,
+    model_to_table_name,
+    run_migrations,
+)
 from osprey.services.ariel_search.enhancement.semantic_processor.migration import (
     SemanticProcessorMigration,
 )
 from osprey.services.ariel_search.enhancement.text_embedding.migration import (
     TextEmbeddingMigration,
 )
+
+
+class StubMigration(BaseMigration):
+    """Minimal migration used to exercise dependency ordering."""
+
+    def __init__(self, name: str, deps: list[str]) -> None:
+        self._name = name
+        self._deps = deps
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def depends_on(self) -> list[str]:
+        return self._deps
+
+    async def up(self, conn) -> None:
+        pass
+
+
+class BareMigration(BaseMigration):
+    """Migration overriding only the two abstract members.
+
+    Exists to exercise the base-class defaults that every other migration in
+    the tree replaces: the empty ``depends_on`` and the ``down()`` that refuses.
+    """
+
+    @property
+    def name(self) -> str:
+        return "bare"
+
+    async def up(self, conn) -> None:
+        pass
+
+
+class RecordingMigration(StubMigration):
+    """Stub that records how the runner drove it and can fail on demand.
+
+    ``is_applied``/``mark_applied``/``mark_unapplied`` are answered in memory so
+    a runner test controls the applied state without scripting the connection,
+    and ``events`` shows exactly which of them the runner reached. ``up_error``
+    and ``down_error`` are raised from ``up()``/``down()`` to reach the runner's
+    skip, failure and rollback-failure branches.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        deps: list[str] | None = None,
+        *,
+        applied: bool = False,
+        up_error: Exception | None = None,
+        down_error: Exception | None = None,
+    ) -> None:
+        super().__init__(name, deps or [])
+        self.applied = applied
+        self.up_error = up_error
+        self.down_error = down_error
+        self.events: list[str] = []
+
+    async def is_applied(self, conn) -> bool:
+        self.events.append("is_applied")
+        return self.applied
+
+    async def up(self, conn) -> None:
+        self.events.append("up")
+        if self.up_error is not None:
+            raise self.up_error
+
+    async def down(self, conn) -> None:
+        self.events.append("down")
+        if self.down_error is not None:
+            raise self.down_error
+
+    async def mark_applied(self, conn) -> None:
+        self.events.append("mark_applied")
+
+    async def mark_unapplied(self, conn) -> None:
+        self.events.append("mark_unapplied")
+
+
+def make_runner(pool=None, config: ARIELConfig | None = None) -> MigrationRunner:
+    """Build a MigrationRunner that needs no real database.
+
+    Args:
+        pool: Fake pool for the tests that drive ``run``/``rollback``/``status``.
+            The default ``None`` is enough for the sort- and config-only paths,
+            which never open a connection.
+        config: Configuration to run against; defaults to a database-only config
+            with every enhancement module off.
+    """
+    if config is None:
+        config = ARIELConfig(database=DatabaseConfig(uri="postgresql://localhost:5432/test"))
+    return MigrationRunner(pool=pool, config=config)  # type: ignore[arg-type]
+
+
+def sql_index(conn, needle: str) -> int:
+    """Position of the first statement executed on `conn` containing `needle`.
+
+    Both sides are whitespace-normalized so a single-line needle matches the
+    multi-line DDL literals the migrations emit.
+    """
+    wanted = " ".join(needle.split())
+    for position, statement in enumerate(conn.sql):
+        if wanted in " ".join(statement.split()):
+            return position
+    raise AssertionError(f"no statement containing {needle!r} in {conn.sql}")
 
 
 class TestModelToTableName:
@@ -78,67 +196,11 @@ class TestMigrationTopologicalSort:
 
     def test_topological_sort_simple(self) -> None:
         """Test topological sort with simple dependencies."""
+        core = StubMigration("core_schema", [])
+        semantic = StubMigration("semantic_processor", ["core_schema"])
+        text_emb = StubMigration("text_embedding", ["core_schema"])
 
-        class MockMigration(BaseMigration):
-            def __init__(self, name: str, deps: list[str]) -> None:
-                self._name = name
-                self._deps = deps
-
-            @property
-            def name(self) -> str:
-                return self._name
-
-            @property
-            def depends_on(self) -> list[str]:
-                return self._deps
-
-            async def up(self, conn) -> None:
-                pass
-
-        # Create migrations with dependencies
-        core = MockMigration("core_schema", [])
-        semantic = MockMigration("semantic_processor", ["core_schema"])
-        text_emb = MockMigration("text_embedding", ["core_schema"])
-
-        # Create a mock runner (we'll test the sort method directly)
-        class MockRunner:
-            def __init__(self) -> None:
-                pass
-
-            def _topological_sort(self, migrations: list[BaseMigration]) -> list[BaseMigration]:
-                from osprey.services.ariel_search.exceptions import ConfigurationError
-
-                migration_map = {m.name: m for m in migrations}
-                in_degree: dict[str, int] = {m.name: 0 for m in migrations}
-                graph: dict[str, list[str]] = {m.name: [] for m in migrations}
-
-                for migration in migrations:
-                    for dep in migration.depends_on:
-                        if dep in migration_map:
-                            graph[dep].append(migration.name)
-                            in_degree[migration.name] += 1
-
-                queue = [name for name, degree in in_degree.items() if degree == 0]
-                sorted_names: list[str] = []
-
-                while queue:
-                    name = queue.pop(0)
-                    sorted_names.append(name)
-                    for dependent in graph[name]:
-                        in_degree[dependent] -= 1
-                        if in_degree[dependent] == 0:
-                            queue.append(dependent)
-
-                if len(sorted_names) != len(migrations):
-                    raise ConfigurationError(
-                        "Circular dependency detected",
-                        config_key="test",
-                    )
-
-                return [migration_map[name] for name in sorted_names]
-
-        runner = MockRunner()
-        sorted_migrations = runner._topological_sort([semantic, text_emb, core])
+        sorted_migrations = make_runner()._topological_sort([semantic, text_emb, core])
 
         # Core should be first
         assert sorted_migrations[0].name == "core_schema"
@@ -150,60 +212,32 @@ class TestMigrationTopologicalSort:
         """Test that circular dependency is detected."""
         from osprey.services.ariel_search.exceptions import ConfigurationError
 
-        class MockMigration(BaseMigration):
-            def __init__(self, name: str, deps: list[str]) -> None:
-                self._name = name
-                self._deps = deps
+        a = StubMigration("a", ["b"])
+        b = StubMigration("b", ["a"])
 
-            @property
-            def name(self) -> str:
-                return self._name
+        with pytest.raises(ConfigurationError, match="Circular dependency") as exc_info:
+            make_runner()._topological_sort([a, b])
 
-            @property
-            def depends_on(self) -> list[str]:
-                return self._deps
+        assert exc_info.value.config_key == "ariel.migrations"
 
-            async def up(self, conn) -> None:
-                pass
+    def test_topological_sort_self_dependency_is_circular(self) -> None:
+        """A migration depending on itself is rejected as circular."""
+        from osprey.services.ariel_search.exceptions import ConfigurationError
 
-        # Create circular dependency
-        a = MockMigration("a", ["b"])
-        b = MockMigration("b", ["a"])
-
-        class MockRunner:
-            def _topological_sort(self, migrations: list[BaseMigration]) -> list[BaseMigration]:
-                migration_map = {m.name: m for m in migrations}
-                in_degree: dict[str, int] = {m.name: 0 for m in migrations}
-                graph: dict[str, list[str]] = {m.name: [] for m in migrations}
-
-                for migration in migrations:
-                    for dep in migration.depends_on:
-                        if dep in migration_map:
-                            graph[dep].append(migration.name)
-                            in_degree[migration.name] += 1
-
-                queue = [name for name, degree in in_degree.items() if degree == 0]
-                sorted_names: list[str] = []
-
-                while queue:
-                    name = queue.pop(0)
-                    sorted_names.append(name)
-                    for dependent in graph[name]:
-                        in_degree[dependent] -= 1
-                        if in_degree[dependent] == 0:
-                            queue.append(dependent)
-
-                if len(sorted_names) != len(migrations):
-                    raise ConfigurationError(
-                        "Circular dependency detected",
-                        config_key="test",
-                    )
-
-                return [migration_map[name] for name in sorted_names]
-
-        runner = MockRunner()
         with pytest.raises(ConfigurationError, match="Circular dependency"):
-            runner._topological_sort([a, b])
+            make_runner()._topological_sort([StubMigration("a", ["a"])])
+
+    def test_topological_sort_ignores_unknown_dependency(self) -> None:
+        """Dependencies outside the given list do not block sorting."""
+        migration = StubMigration("text_embedding", ["not_enabled"])
+
+        sorted_migrations = make_runner()._topological_sort([migration])
+
+        assert [m.name for m in sorted_migrations] == ["text_embedding"]
+
+    def test_topological_sort_empty_list(self) -> None:
+        """Sorting no migrations yields no migrations."""
+        assert make_runner()._topological_sort([]) == []
 
 
 class TestRequiresModule:
@@ -392,66 +426,18 @@ class TestMigrationRunnerLogic:
     """Tests for MigrationRunner logic without database."""
 
     def test_topological_sort_algorithm(self) -> None:
-        """Test topological sort algorithm via standalone function."""
-        from osprey.services.ariel_search.exceptions import ConfigurationError
+        """Test topological sort orders a transitive dependency chain."""
+        core = StubMigration("core_schema", [])
+        semantic = StubMigration("semantic_processor", ["core_schema"])
+        text_emb = StubMigration("text_embedding", ["semantic_processor"])
 
-        def topological_sort(migrations: list[BaseMigration]) -> list[BaseMigration]:
-            """Standalone topological sort for testing."""
-            migration_map = {m.name: m for m in migrations}
-            in_degree: dict[str, int] = {m.name: 0 for m in migrations}
-            graph: dict[str, list[str]] = {m.name: [] for m in migrations}
+        sorted_migs = make_runner()._topological_sort([text_emb, semantic, core])
 
-            for migration in migrations:
-                for dep in migration.depends_on:
-                    if dep in migration_map:
-                        graph[dep].append(migration.name)
-                        in_degree[migration.name] += 1
-
-            queue = [name for name, degree in in_degree.items() if degree == 0]
-            sorted_names: list[str] = []
-
-            while queue:
-                name = queue.pop(0)
-                sorted_names.append(name)
-                for dependent in graph[name]:
-                    in_degree[dependent] -= 1
-                    if in_degree[dependent] == 0:
-                        queue.append(dependent)
-
-            if len(sorted_names) != len(migrations):
-                raise ConfigurationError(
-                    "Circular dependency detected",
-                    config_key="test",
-                )
-
-            return [migration_map[name] for name in sorted_names]
-
-        # Create mock migrations
-        class MockMigration(BaseMigration):
-            def __init__(self, name: str, deps: list[str]) -> None:
-                self._name = name
-                self._deps = deps
-
-            @property
-            def name(self) -> str:
-                return self._name
-
-            @property
-            def depends_on(self) -> list[str]:
-                return self._deps
-
-            async def up(self, conn) -> None:
-                pass
-
-        core = MockMigration("core_schema", [])
-        semantic = MockMigration("semantic_processor", ["core_schema"])
-        text_emb = MockMigration("text_embedding", ["core_schema"])
-
-        # Sort should work
-        sorted_migs = topological_sort([text_emb, semantic, core])
-        assert sorted_migs[0].name == "core_schema"
-        remaining = {m.name for m in sorted_migs[1:]}
-        assert remaining == {"semantic_processor", "text_embedding"}
+        assert [m.name for m in sorted_migs] == [
+            "core_schema",
+            "semantic_processor",
+            "text_embedding",
+        ]
 
     def test_known_migrations_registry(self) -> None:
         """Test that KNOWN_MIGRATIONS registry exists and has expected entries."""
@@ -720,3 +706,462 @@ class TestEnhancementFactory:
         assert len(enhancers) >= 1
         enhancer_types = [type(e) for e in enhancers]
         assert SemanticProcessorModule in enhancer_types
+
+
+class TestBaseMigrationTracking:
+    """Tests for the ariel_migrations bookkeeping on BaseMigration."""
+
+    async def test_is_applied_false_before_tracking_table_exists(self, ddl_conn) -> None:
+        """A fresh database has no ariel_migrations table, so nothing is applied.
+
+        The bootstrap check must short-circuit: querying ariel_migrations before
+        it exists would error out on the very first migration of a new install.
+        """
+        ddl_conn.recorder.rows_for = {"FROM information_schema.tables": [(False,)]}
+
+        assert await StubMigration("core_schema", []).is_applied(ddl_conn) is False
+        assert len(ddl_conn.sql) == 1
+
+    async def test_is_applied_false_when_bootstrap_query_returns_no_row(self, ddl_conn) -> None:
+        """A missing row from the existence probe is treated as 'not applied'."""
+        assert await StubMigration("core_schema", []).is_applied(ddl_conn) is False
+        assert len(ddl_conn.sql) == 1
+
+    async def test_is_applied_false_when_migration_row_absent(self, ddl_conn) -> None:
+        """With the table present but no row, the second query decides."""
+        ddl_conn.recorder.rows_for = {
+            "FROM information_schema.tables": [(True,)],
+            "SELECT EXISTS (SELECT 1 FROM ariel_migrations": [(False,)],
+        }
+
+        assert await StubMigration("text_embedding", []).is_applied(ddl_conn) is False
+        assert len(ddl_conn.sql) == 2
+        assert ddl_conn.calls[1][1] == ["text_embedding"]
+
+    async def test_is_applied_true_when_row_present(self, ddl_conn) -> None:
+        """A row in ariel_migrations means the migration already ran."""
+        ddl_conn.recorder.rows_for = {
+            "FROM information_schema.tables": [(True,)],
+            "SELECT EXISTS (SELECT 1 FROM ariel_migrations": [(True,)],
+        }
+
+        assert await StubMigration("text_embedding", []).is_applied(ddl_conn) is True
+
+    async def test_mark_applied_is_idempotent(self, ddl_conn) -> None:
+        """Marking applied twice must not raise, so re-running migrations is safe."""
+        await StubMigration("core_schema", []).mark_applied(ddl_conn)
+
+        statement = " ".join(ddl_conn.sql[0].split())
+        assert "INSERT INTO ariel_migrations (name, applied_at)" in statement
+        assert "ON CONFLICT (name) DO NOTHING" in statement
+        assert ddl_conn.calls[0][1] == ["core_schema"]
+
+    async def test_mark_unapplied_deletes_only_this_migration(self, ddl_conn) -> None:
+        """Rollback bookkeeping is scoped by name, not a table-wide delete."""
+        await StubMigration("text_embedding", []).mark_unapplied(ddl_conn)
+
+        assert " ".join(ddl_conn.sql[0].split()) == ("DELETE FROM ariel_migrations WHERE name = %s")
+        assert ddl_conn.calls[0][1] == ["text_embedding"]
+
+    def test_depends_on_defaults_to_empty(self) -> None:
+        """A migration that declares no dependencies sorts first."""
+        assert BareMigration().depends_on == []
+
+    async def test_down_defaults_to_not_implemented(self, ddl_conn) -> None:
+        """Rollback is opt-in; the default refuses and names the migration."""
+        with pytest.raises(NotImplementedError, match="bare"):
+            await BareMigration().down(ddl_conn)
+
+        assert ddl_conn.sql == []
+
+
+class TestGetEnabledMigrations:
+    """Tests for MigrationRunner._get_enabled_migrations."""
+
+    def test_disabled_module_migration_is_not_loaded(self) -> None:
+        """Only the always-run migrations load when no module is enabled."""
+        names = [m.name for m in make_runner()._get_enabled_migrations()]
+
+        assert names == ["core_schema", "attachment_files"]
+
+    def test_unimportable_migration_is_skipped_with_warning(self, monkeypatch, caplog) -> None:
+        """A migration whose module is gone must not break the whole run."""
+        caplog.set_level(logging.WARNING, logger="ariel")
+        monkeypatch.setattr(
+            migrations_module,
+            "KNOWN_MIGRATIONS",
+            [("ghost", "osprey.services.ariel_search.database.no_such_module", "Ghost", None)],
+        )
+
+        assert make_runner()._get_enabled_migrations() == []
+        assert "Failed to load migration ghost" in caplog.text
+
+    def test_missing_migration_class_is_skipped_with_warning(self, monkeypatch, caplog) -> None:
+        """A renamed class is reported the same way as a missing module."""
+        caplog.set_level(logging.WARNING, logger="ariel")
+        monkeypatch.setattr(
+            migrations_module,
+            "KNOWN_MIGRATIONS",
+            [
+                (
+                    "core_schema",
+                    "osprey.services.ariel_search.database.core_migration",
+                    "RenamedMigration",
+                    None,
+                )
+            ],
+        )
+
+        assert make_runner()._get_enabled_migrations() == []
+        assert "Failed to load migration core_schema" in caplog.text
+
+    def test_embedding_migration_falls_back_to_default_models(self) -> None:
+        """text_embedding enabled without a models list keeps the built-in default."""
+        config = ARIELConfig.from_dict(
+            {
+                "database": {"uri": "postgresql://localhost:5432/test"},
+                "enhancement_modules": {"text_embedding": {"enabled": True}},
+            }
+        )
+        runner = make_runner(config=config)
+
+        assert runner._configured_embedding_models() is None
+
+        text_embedding = next(
+            m for m in runner._get_enabled_migrations() if m.name == "text_embedding"
+        )
+        assert text_embedding._get_models() == [("nomic-embed-text", 768)]
+
+
+class TestMigrationRunnerRun:
+    """Tests for MigrationRunner.run."""
+
+    async def test_applies_pending_migrations_in_dependency_order(self, fake_pool) -> None:
+        """Dependencies run before dependents regardless of registry order."""
+        core = RecordingMigration("core_schema")
+        embedding = RecordingMigration("text_embedding", ["core_schema"])
+        runner = make_runner(pool=fake_pool)
+        runner._get_enabled_migrations = lambda: [embedding, core]  # type: ignore[method-assign]
+
+        assert await runner.run() == ["core_schema", "text_embedding"]
+        assert core.events == ["is_applied", "up", "mark_applied"]
+        assert embedding.events == ["is_applied", "up", "mark_applied"]
+
+    async def test_already_applied_migration_is_left_alone(self, fake_pool) -> None:
+        """An applied migration is neither re-run nor re-reported."""
+        migration = RecordingMigration("core_schema", applied=True)
+        runner = make_runner(pool=fake_pool)
+        runner._get_enabled_migrations = lambda: [migration]  # type: ignore[method-assign]
+
+        assert await runner.run() == []
+        assert migration.events == ["is_applied"]
+
+    async def test_dry_run_reports_without_touching_the_schema(self, fake_pool, caplog) -> None:
+        """Dry run names what would be applied but emits no DDL."""
+        caplog.set_level(logging.INFO, logger="ariel")
+        migration = RecordingMigration("core_schema")
+        runner = make_runner(pool=fake_pool)
+        runner._get_enabled_migrations = lambda: [migration]  # type: ignore[method-assign]
+
+        assert await runner.run(dry_run=True) == ["core_schema"]
+        assert migration.events == ["is_applied"]
+        assert "Would apply migration: core_schema" in caplog.text
+
+    async def test_skipped_migration_is_not_marked_and_run_continues(
+        self, fake_pool, caplog
+    ) -> None:
+        """A missing prerequisite (e.g. pgvector) downgrades to a warning.
+
+        The migration must stay unmarked so it retries once the prerequisite is
+        installed, and later migrations must still get their turn.
+        """
+        caplog.set_level(logging.WARNING, logger="ariel")
+        skipped = RecordingMigration(
+            "text_embedding", up_error=MigrationSkippedError("pgvector is not available")
+        )
+        follower = RecordingMigration("attachment_files", ["text_embedding"])
+        runner = make_runner(pool=fake_pool)
+        runner._get_enabled_migrations = lambda: [skipped, follower]  # type: ignore[method-assign]
+
+        assert await runner.run() == ["attachment_files"]
+        assert skipped.events == ["is_applied", "up"]
+        assert "Migration text_embedding skipped: pgvector is not available" in caplog.text
+
+    async def test_unexpected_failure_aborts_the_run(self, fake_pool, caplog) -> None:
+        """Any non-skip error propagates and stops later migrations."""
+        caplog.set_level(logging.ERROR, logger="ariel")
+        failing = RecordingMigration("core_schema", up_error=RuntimeError("boom"))
+        follower = RecordingMigration("attachment_files", ["core_schema"])
+        runner = make_runner(pool=fake_pool)
+        runner._get_enabled_migrations = lambda: [failing, follower]  # type: ignore[method-assign]
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await runner.run()
+
+        assert failing.events == ["is_applied", "up"]
+        assert follower.events == []
+        assert "Failed to apply migration core_schema: boom" in caplog.text
+
+    async def test_run_migrations_helper_drives_a_runner(self, fake_pool, monkeypatch) -> None:
+        """The module-level convenience function is a thin wrapper over run()."""
+        migration = RecordingMigration("core_schema")
+        monkeypatch.setattr(MigrationRunner, "_get_enabled_migrations", lambda self: [migration])
+        config = ARIELConfig(database=DatabaseConfig(uri="postgresql://localhost:5432/test"))
+
+        assert await run_migrations(fake_pool, config) == ["core_schema"]
+        assert migration.events == ["is_applied", "up", "mark_applied"]
+
+
+class TestMigrationRunnerRollback:
+    """Tests for MigrationRunner.rollback."""
+
+    async def test_unknown_migration_reports_failure(self, fake_pool, caplog) -> None:
+        """Rolling back a name that is not enabled fails rather than no-ops silently."""
+        caplog.set_level(logging.ERROR, logger="ariel")
+        runner = make_runner(pool=fake_pool)
+        runner._get_enabled_migrations = lambda: [RecordingMigration("core_schema")]  # type: ignore[method-assign]
+
+        assert await runner.rollback("text_embedding") is False
+        assert "Migration not found: text_embedding" in caplog.text
+
+    async def test_unapplied_migration_rolls_back_trivially(self, fake_pool, caplog) -> None:
+        """Rollback of a migration that never ran succeeds without calling down()."""
+        caplog.set_level(logging.INFO, logger="ariel")
+        migration = RecordingMigration("core_schema", applied=False)
+        runner = make_runner(pool=fake_pool)
+        runner._get_enabled_migrations = lambda: [migration]  # type: ignore[method-assign]
+
+        assert await runner.rollback("core_schema") is True
+        assert migration.events == ["is_applied"]
+        assert "Migration core_schema is not applied" in caplog.text
+
+    async def test_applied_migration_is_reverted_and_unmarked(self, fake_pool) -> None:
+        """A successful rollback both reverts the schema and clears the tracking row."""
+        migration = RecordingMigration("core_schema", applied=True)
+        runner = make_runner(pool=fake_pool)
+        runner._get_enabled_migrations = lambda: [migration]  # type: ignore[method-assign]
+
+        assert await runner.rollback("core_schema") is True
+        assert migration.events == ["is_applied", "down", "mark_unapplied"]
+
+    async def test_migration_without_rollback_support_reports_failure(
+        self, fake_pool, caplog
+    ) -> None:
+        """A migration that never implemented down() stays marked as applied."""
+        caplog.set_level(logging.ERROR, logger="ariel")
+        fake_pool.recorder.rows_for = {
+            "FROM information_schema.tables": [(True,)],
+            "SELECT EXISTS (SELECT 1 FROM ariel_migrations": [(True,)],
+        }
+        runner = make_runner(pool=fake_pool)
+        runner._get_enabled_migrations = lambda: [StubMigration("text_embedding", [])]  # type: ignore[method-assign]
+
+        assert await runner.rollback("text_embedding") is False
+        assert "Rollback not implemented for migration: text_embedding" in caplog.text
+        assert fake_pool.matching("DELETE FROM ariel_migrations") == []
+
+    async def test_unexpected_rollback_failure_propagates(self, fake_pool, caplog) -> None:
+        """A failing down() surfaces rather than being reported as a clean rollback."""
+        caplog.set_level(logging.ERROR, logger="ariel")
+        migration = RecordingMigration(
+            "core_schema", applied=True, down_error=RuntimeError("drop failed")
+        )
+        runner = make_runner(pool=fake_pool)
+        runner._get_enabled_migrations = lambda: [migration]  # type: ignore[method-assign]
+
+        with pytest.raises(RuntimeError, match="drop failed"):
+            await runner.rollback("core_schema")
+
+        assert migration.events == ["is_applied", "down"]
+        assert "Failed to rollback migration core_schema: drop failed" in caplog.text
+
+
+class TestMigrationRunnerStatus:
+    """Tests for MigrationRunner.status."""
+
+    async def test_status_reports_applied_state_and_dependencies(self, fake_pool) -> None:
+        """Status covers every enabled migration, applied or not."""
+        runner = make_runner(pool=fake_pool)
+        runner._get_enabled_migrations = lambda: [  # type: ignore[method-assign]
+            RecordingMigration("core_schema", applied=True),
+            RecordingMigration("text_embedding", ["core_schema", "semantic_processor"]),
+        ]
+
+        assert await runner.status() == {
+            "core_schema": {"applied": True, "depends_on": "(none)"},
+            "text_embedding": {
+                "applied": False,
+                "depends_on": "core_schema, semantic_processor",
+            },
+        }
+
+
+class TestCoreMigrationDDL:
+    """Tests for the SQL CoreMigration emits."""
+
+    async def test_up_creates_objects_in_dependency_order(self, ddl_conn) -> None:
+        """Each object is created after whatever it is built on."""
+        await CoreMigration().up(ddl_conn)
+
+        # pg_trgm must exist before the GIN trigram index that uses its operators.
+        assert sql_index(ddl_conn, "CREATE EXTENSION IF NOT EXISTS pg_trgm") < sql_index(
+            ddl_conn, "idx_entries_raw_text_trgm"
+        )
+        # The table precedes every index and the trigger placed on it.
+        entries_table = sql_index(ddl_conn, "CREATE TABLE IF NOT EXISTS enhanced_entries")
+        assert entries_table < sql_index(ddl_conn, "idx_entries_timestamp")
+        assert entries_table < sql_index(ddl_conn, "CREATE TRIGGER")
+        # The trigger function is defined before the trigger references it.
+        assert sql_index(ddl_conn, "CREATE OR REPLACE FUNCTION update_updated_at_column") < (
+            sql_index(ddl_conn, "CREATE TRIGGER update_enhanced_entries_updated_at")
+        )
+        assert sql_index(ddl_conn, "CREATE TABLE IF NOT EXISTS ingestion_runs") < sql_index(
+            ddl_conn, "idx_ingestion_runs_started"
+        )
+        # The tracking table the runner writes to is part of the core schema.
+        assert sql_index(ddl_conn, "CREATE TABLE IF NOT EXISTS ariel_migrations") >= 0
+
+    async def test_up_is_rerunnable(self, ddl_conn) -> None:
+        """Every created object is guarded, so a second migrate run is a no-op."""
+        await CoreMigration().up(ddl_conn)
+
+        for statement in ddl_conn.sql:
+            normalized = " ".join(statement.split())
+            if normalized.startswith(("CREATE TABLE", "CREATE INDEX", "CREATE EXTENSION")):
+                assert "IF NOT EXISTS" in normalized, normalized
+        # The two objects that cannot take IF NOT EXISTS carry their own guards.
+        assert "CREATE OR REPLACE FUNCTION" in " ".join(
+            ddl_conn.sql[sql_index(ddl_conn, "update_updated_at_column()")].split()
+        )
+        trigger_ddl = " ".join(ddl_conn.sql[sql_index(ddl_conn, "CREATE TRIGGER")].split())
+        assert "IF NOT EXISTS ( SELECT 1 FROM pg_trigger" in trigger_ddl
+
+    async def test_down_drops_dependents_before_their_dependencies(self, ddl_conn) -> None:
+        """Rollback unwinds the core schema in reverse creation order."""
+        await CoreMigration().down(ddl_conn)
+
+        assert [" ".join(s.split()) for s in ddl_conn.sql] == [
+            "DROP TABLE IF EXISTS ariel_migrations CASCADE",
+            "DROP TABLE IF EXISTS ingestion_runs CASCADE",
+            "DROP TABLE IF EXISTS enhanced_entries CASCADE",
+            "DROP FUNCTION IF EXISTS update_updated_at_column() CASCADE",
+        ]
+
+
+class TestAttachmentMigrationDDL:
+    """Tests for AttachmentMigration."""
+
+    def test_properties(self) -> None:
+        """Attachments hang off enhanced_entries, so core_schema comes first."""
+        migration = AttachmentMigration()
+        assert migration.name == "attachment_files"
+        assert migration.depends_on == ["core_schema"]
+
+    async def test_up_creates_table_then_lookup_index(self, ddl_conn) -> None:
+        """The table stores file bytes and cascades from its entry."""
+        await AttachmentMigration().up(ddl_conn)
+
+        table_ddl = " ".join(ddl_conn.sql[0].split())
+        assert "CREATE TABLE IF NOT EXISTS attachment_files" in table_ddl
+        assert "data BYTEA NOT NULL" in table_ddl
+        assert "REFERENCES enhanced_entries(entry_id) ON DELETE CASCADE" in table_ddl
+
+        index_ddl = " ".join(ddl_conn.sql[1].split())
+        assert "CREATE INDEX IF NOT EXISTS idx_attachment_files_entry_id" in index_ddl
+        assert "ON attachment_files(entry_id)" in index_ddl
+
+    async def test_down_drops_the_table(self, ddl_conn) -> None:
+        """Rollback removes the table; the index goes with it."""
+        await AttachmentMigration().down(ddl_conn)
+
+        assert ddl_conn.sql == ["DROP TABLE IF EXISTS attachment_files CASCADE"]
+
+
+class TestSemanticProcessorMigrationDDL:
+    """Tests for SemanticProcessorMigration."""
+
+    async def test_up_adds_columns_before_indexing_them(self, ddl_conn) -> None:
+        """Columns are added first, then the indexes that read them."""
+        await SemanticProcessorMigration().up(ddl_conn)
+
+        statements = [" ".join(s.split()) for s in ddl_conn.sql]
+        assert statements[0] == "ALTER TABLE enhanced_entries ADD COLUMN IF NOT EXISTS summary TEXT"
+        assert statements[1] == (
+            "ALTER TABLE enhanced_entries ADD COLUMN IF NOT EXISTS keywords TEXT[] DEFAULT '{}'"
+        )
+        assert "CREATE INDEX IF NOT EXISTS idx_entries_keywords" in statements[2]
+        assert "USING GIN(keywords)" in statements[2]
+        assert "CREATE INDEX IF NOT EXISTS idx_entries_text_search" in statements[3]
+        assert "to_tsvector('english', raw_text || ' ' || COALESCE(summary, ''))" in statements[3]
+
+    async def test_down_drops_indexes_before_columns(self, ddl_conn) -> None:
+        """Dropping the indexed columns first would leave the drops to CASCADE."""
+        await SemanticProcessorMigration().down(ddl_conn)
+
+        assert [" ".join(s.split()) for s in ddl_conn.sql] == [
+            "DROP INDEX IF EXISTS idx_entries_text_search",
+            "DROP INDEX IF EXISTS idx_entries_keywords",
+            "ALTER TABLE enhanced_entries DROP COLUMN IF EXISTS keywords",
+            "ALTER TABLE enhanced_entries DROP COLUMN IF EXISTS summary",
+        ]
+
+
+class TestTextEmbeddingMigrationDDL:
+    """Tests for TextEmbeddingMigration."""
+
+    async def test_up_skips_when_pgvector_is_unavailable(self, ddl_conn) -> None:
+        """Without pgvector the migration skips instead of failing the whole run.
+
+        Skipping (rather than raising) is what keeps ARIEL usable in
+        keyword-only mode on a stock PostgreSQL.
+        """
+        with pytest.raises(MigrationSkippedError, match="pgvector"):
+            await TextEmbeddingMigration().up(ddl_conn)
+
+        assert len(ddl_conn.sql) == 1
+        assert "pg_available_extensions" in ddl_conn.sql[0]
+
+    async def test_up_creates_a_table_and_index_per_model(self, ddl_conn) -> None:
+        """Each configured model gets its own dimensioned table and vector index."""
+        ddl_conn.recorder.rows_for = {"pg_available_extensions": [(True,)]}
+
+        await TextEmbeddingMigration(models=[("model-a", 512), ("model-b", 1024)]).up(ddl_conn)
+
+        extension = sql_index(ddl_conn, "CREATE EXTENSION IF NOT EXISTS vector")
+        table_a = sql_index(ddl_conn, "CREATE TABLE IF NOT EXISTS text_embeddings_model_a")
+        assert extension < table_a
+
+        assert "embedding vector(512)" in " ".join(ddl_conn.sql[table_a].split())
+        assert "REFERENCES enhanced_entries(entry_id) ON DELETE CASCADE" in " ".join(
+            ddl_conn.sql[table_a].split()
+        )
+
+        index_a = sql_index(
+            ddl_conn, "CREATE INDEX IF NOT EXISTS idx_text_embeddings_model_a_vector"
+        )
+        assert table_a < index_a
+        assert "USING ivfflat (embedding vector_cosine_ops)" in " ".join(
+            ddl_conn.sql[index_a].split()
+        )
+
+        table_b = sql_index(ddl_conn, "CREATE TABLE IF NOT EXISTS text_embeddings_model_b")
+        assert "embedding vector(1024)" in " ".join(ddl_conn.sql[table_b].split())
+
+    async def test_up_uses_the_default_model_when_none_configured(self, ddl_conn) -> None:
+        """An unconfigured migration still creates the default nomic table."""
+        ddl_conn.recorder.rows_for = {"pg_available_extensions": [(True,)]}
+
+        await TextEmbeddingMigration().up(ddl_conn)
+
+        table = sql_index(ddl_conn, "CREATE TABLE IF NOT EXISTS text_embeddings_nomic_embed_text")
+        assert "embedding vector(768)" in " ".join(ddl_conn.sql[table].split())
+
+    async def test_down_drops_one_table_per_model(self, ddl_conn) -> None:
+        """Rollback drops the per-model tables but leaves the shared extension."""
+        await TextEmbeddingMigration(models=[("model-a", 512), ("model-b", 1024)]).down(ddl_conn)
+
+        assert ddl_conn.sql == [
+            "DROP TABLE IF EXISTS text_embeddings_model_a CASCADE",
+            "DROP TABLE IF EXISTS text_embeddings_model_b CASCADE",
+        ]
+        assert ddl_conn.recorder.matching("DROP EXTENSION") == []

--- a/tests/services/ariel_search/test_enhancement.py
+++ b/tests/services/ariel_search/test_enhancement.py
@@ -3,6 +3,8 @@
 Tests for base enhancement module, factory, and module implementations.
 """
 
+import logging
+import sys
 from datetime import UTC
 
 import pytest
@@ -20,6 +22,9 @@ from osprey.services.ariel_search.enhancement.semantic_processor import (
 from osprey.services.ariel_search.enhancement.text_embedding import (
     TextEmbeddingModule,
 )
+from tests.services.ariel_search.conftest import _FakeConnection, _FakeEmbeddingProvider
+
+TABLES_QUERY = "information_schema.tables"
 
 
 class TestEnhancementFactory:
@@ -717,3 +722,569 @@ class TestGetEnhancementModuleConfigDetails:
         assert te_config.models is not None
         assert len(te_config.models) == 1
         assert te_config.models[0].name == "nomic-embed-text"
+
+
+class TestSemanticProcessorConfigureModelResolution:
+    """Tests for SemanticProcessorModule.configure tier resolution."""
+
+    def test_configure_resolves_model_id_when_provider_given(self, monkeypatch):
+        """A provider plus a model_id routes the id through resolve_model_id."""
+        calls = []
+
+        def fake_resolve(provider, model_id):
+            calls.append((provider, model_id))
+            return f"{provider}/{model_id}-resolved"
+
+        monkeypatch.setattr("osprey.models.tiers.resolve_model_id", fake_resolve)
+
+        module = SemanticProcessorModule()
+        module.configure(
+            {
+                "provider": "ollama",
+                "model": {"model_id": "fast", "temperature": 0.1},
+            }
+        )
+
+        assert calls == [("ollama", "fast")]
+        assert module._model_config == {
+            "model_id": "ollama/fast-resolved",
+            "temperature": 0.1,
+        }
+
+    def test_configure_without_provider_leaves_model_id_verbatim(self, monkeypatch):
+        """No provider means no resolution — the configured id is used as-is."""
+
+        def boom(provider, model_id):
+            raise AssertionError("resolve_model_id must not run without a provider")
+
+        monkeypatch.setattr("osprey.models.tiers.resolve_model_id", boom)
+
+        module = SemanticProcessorModule()
+        module.configure({"model": {"model_id": "llama3"}})
+
+        assert module._model_config == {"model_id": "llama3"}
+
+    def test_configure_with_provider_but_no_model_id_skips_resolution(self, monkeypatch):
+        """A provider alone is not enough — resolution needs a model_id too."""
+
+        def boom(provider, model_id):
+            raise AssertionError("resolve_model_id must not run without a model_id")
+
+        monkeypatch.setattr("osprey.models.tiers.resolve_model_id", boom)
+
+        module = SemanticProcessorModule()
+        module.configure({"provider": "ollama", "model": {"temperature": 0.2}})
+
+        assert module._model_config == {"temperature": 0.2}
+
+
+class TestSemanticProcessorProcessText:
+    """Tests for SemanticProcessorModule._process_text with a patched LLM."""
+
+    @pytest.fixture
+    def module(self):
+        """Module configured with a model config (no tier resolution)."""
+        m = SemanticProcessorModule()
+        m.configure({"model": {"model_id": "llama3"}})
+        return m
+
+    @pytest.mark.asyncio
+    async def test_process_text_parses_llm_json(self, module, monkeypatch):
+        """A JSON completion becomes a SemanticProcessorResult."""
+        calls = []
+
+        def fake_completion(message, model_config=None):
+            calls.append({"message": message, "model_config": model_config})
+            return '{"keywords": ["vacuum", "pump"], "summary": "Pump replaced."}'
+
+        monkeypatch.setattr(
+            "osprey.models.completion.get_chat_completion",
+            fake_completion,
+        )
+
+        result = await module._process_text("Replaced vacuum pump VP-103.")
+
+        assert result is not None
+        assert result.keywords == ["vacuum", "pump"]
+        assert result.summary == "Pump replaced."
+        assert calls[0]["model_config"] == {"model_id": "llama3"}
+        assert "Replaced vacuum pump VP-103." in calls[0]["message"]
+
+    @pytest.mark.asyncio
+    async def test_process_text_truncates_entry_to_8000_chars(self, module, monkeypatch):
+        """Entry text is clipped to 8000 characters before prompting."""
+        calls = []
+
+        def fake_completion(message, model_config=None):
+            calls.append(message)
+            return '{"keywords": [], "summary": "s"}'
+
+        monkeypatch.setattr(
+            "osprey.models.completion.get_chat_completion",
+            fake_completion,
+        )
+
+        await module._process_text("a" * 8000 + "TAIL")
+
+        assert "TAIL" not in calls[0]
+        assert "a" * 8000 in calls[0]
+
+    @pytest.mark.asyncio
+    async def test_process_text_stringifies_non_string_response(self, module, monkeypatch):
+        """A non-str completion is coerced with str() before parsing."""
+
+        class _JSONish:
+            def __str__(self) -> str:
+                return '{"keywords": ["rf"], "summary": "RF fault."}'
+
+        monkeypatch.setattr(
+            "osprey.models.completion.get_chat_completion",
+            lambda message, model_config=None: _JSONish(),
+        )
+
+        result = await module._process_text("RF cavity fault.")
+
+        assert result is not None
+        assert result.keywords == ["rf"]
+
+    @pytest.mark.asyncio
+    async def test_process_text_passes_none_model_config_when_unconfigured(self, monkeypatch):
+        """An unconfigured module sends model_config=None, not an empty dict."""
+        calls = []
+
+        def fake_completion(message, model_config=None):
+            calls.append(model_config)
+            return '{"keywords": [], "summary": "s"}'
+
+        monkeypatch.setattr(
+            "osprey.models.completion.get_chat_completion",
+            fake_completion,
+        )
+
+        await SemanticProcessorModule()._process_text("some text")
+
+        assert calls == [None]
+
+    @pytest.mark.asyncio
+    async def test_process_text_import_error_degrades_gracefully(self, module, monkeypatch, caplog):
+        """An unimportable completion module yields None plus a warning."""
+        monkeypatch.setitem(sys.modules, "osprey.models.completion", None)
+
+        with caplog.at_level(logging.WARNING, logger="ariel"):
+            result = await module._process_text("some text")
+
+        assert result is None
+        assert "osprey.models.completion not available" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_process_text_llm_failure_returns_none(self, module, monkeypatch, caplog):
+        """An LLM exception is logged and reported as no result."""
+
+        def boom(message, model_config=None):
+            raise RuntimeError("model server down")
+
+        monkeypatch.setattr("osprey.models.completion.get_chat_completion", boom)
+
+        with caplog.at_level(logging.WARNING, logger="ariel"):
+            result = await module._process_text("some text")
+
+        assert result is None
+        assert "LLM processing failed: model server down" in caplog.text
+
+
+class TestSemanticProcessorEnhanceBranches:
+    """Tests for SemanticProcessorModule.enhance store/skip/swallow branches."""
+
+    @pytest.fixture
+    def module(self):
+        """Module configured with a model config."""
+        m = SemanticProcessorModule()
+        m.configure({"model": {"model_id": "llama3"}})
+        return m
+
+    @pytest.fixture
+    def entry(self):
+        """Non-empty sample entry."""
+        return {"entry_id": "entry-001", "raw_text": "Replaced vacuum pump VP-103."}
+
+    @pytest.mark.asyncio
+    async def test_enhance_stores_keywords_and_summary(self, module, entry, monkeypatch):
+        """A parsed result is written to enhanced_entries."""
+        monkeypatch.setattr(
+            "osprey.models.completion.get_chat_completion",
+            lambda message, model_config=None: (
+                '{"keywords": ["vacuum", "pump"], "summary": "Pump replaced."}'
+            ),
+        )
+        conn = _FakeConnection()
+
+        await module.enhance(entry, conn)
+
+        assert len(conn.calls) == 1
+        sql, params = conn.calls[0]
+        assert "UPDATE enhanced_entries" in sql
+        assert params == [["vacuum", "pump"], "Pump replaced.", "entry-001"]
+
+    @pytest.mark.asyncio
+    async def test_enhance_skips_store_when_parsing_fails(self, module, entry, monkeypatch):
+        """An unparseable completion leaves the database untouched."""
+        monkeypatch.setattr(
+            "osprey.models.completion.get_chat_completion",
+            lambda message, model_config=None: "not JSON at all",
+        )
+        conn = _FakeConnection()
+
+        await module.enhance(entry, conn)
+
+        assert conn.calls == []
+
+    @pytest.mark.asyncio
+    async def test_enhance_swallows_store_failure(self, module, entry, monkeypatch, caplog):
+        """A failing UPDATE is logged, not raised — enhancement is best-effort."""
+        monkeypatch.setattr(
+            "osprey.models.completion.get_chat_completion",
+            lambda message, model_config=None: '{"keywords": ["a"], "summary": "s"}',
+        )
+        conn = _FakeConnection(results=[RuntimeError("connection reset")])
+
+        with caplog.at_level(logging.WARNING, logger="ariel"):
+            await module.enhance(entry, conn)
+
+        assert "Failed to process entry entry-001: connection reset" in caplog.text
+
+
+class TestSemanticProcessorParseResponseFences:
+    """Tests for _parse_response markdown-fence stripping."""
+
+    def test_parse_response_plain_triple_backtick_fence(self):
+        """A bare ``` fence (no json tag) is stripped before parsing."""
+        module = SemanticProcessorModule()
+        response = '```\n{"keywords": ["beam"], "summary": "Beam lost."}\n```'
+
+        result = module._parse_response(response)
+
+        assert result is not None
+        assert result.keywords == ["beam"]
+        assert result.summary == "Beam lost."
+
+    def test_parse_response_json_fence_without_closing_fence(self):
+        """An unterminated ```json fence still parses."""
+        module = SemanticProcessorModule()
+        response = '```json\n{"keywords": ["rf"], "summary": "RF trip."}'
+
+        result = module._parse_response(response)
+
+        assert result is not None
+        assert result.keywords == ["rf"]
+
+
+class TestSemanticProcessorHealthCheckBranches:
+    """Tests for SemanticProcessorModule.health_check outcomes."""
+
+    @pytest.mark.asyncio
+    async def test_health_check_ok_when_llm_responds(self, monkeypatch):
+        """A truthy completion reports healthy."""
+        calls = []
+
+        def fake_completion(message, model_config=None):
+            calls.append(message)
+            return "OK"
+
+        monkeypatch.setattr(
+            "osprey.models.completion.get_chat_completion",
+            fake_completion,
+        )
+
+        healthy, message = await SemanticProcessorModule().health_check()
+
+        assert (healthy, message) == (True, "OK")
+        assert calls == ["Say OK"]
+
+    @pytest.mark.asyncio
+    async def test_health_check_unhealthy_on_empty_response(self, monkeypatch):
+        """An empty completion reports unhealthy."""
+        monkeypatch.setattr(
+            "osprey.models.completion.get_chat_completion",
+            lambda message, model_config=None: "",
+        )
+
+        healthy, message = await SemanticProcessorModule().health_check()
+
+        assert (healthy, message) == (False, "Empty response from LLM")
+
+    @pytest.mark.asyncio
+    async def test_health_check_unhealthy_on_import_error(self, monkeypatch):
+        """An unimportable completion module reports unhealthy."""
+        monkeypatch.setitem(sys.modules, "osprey.models.completion", None)
+
+        healthy, message = await SemanticProcessorModule().health_check()
+
+        assert (healthy, message) == (False, "osprey.models.completion not available")
+
+    @pytest.mark.asyncio
+    async def test_health_check_unhealthy_on_llm_error(self, monkeypatch):
+        """An LLM exception surfaces as the unhealthy message."""
+
+        def boom(message, model_config=None):
+            raise RuntimeError("no route to host")
+
+        monkeypatch.setattr("osprey.models.completion.get_chat_completion", boom)
+
+        healthy, message = await SemanticProcessorModule().health_check()
+
+        assert (healthy, message) == (False, "no route to host")
+
+
+def _embedding_module(models=None, provider=None):
+    """Build a TextEmbeddingModule with an inline provider config."""
+    module = TextEmbeddingModule()
+    module.configure(
+        {
+            "models": models if models is not None else [{"name": "test-model", "dimension": 4}],
+            "provider": provider
+            if provider is not None
+            else {"name": "fake", "base_url": "http://fake:11434"},
+        }
+    )
+    return module
+
+
+class TestTextEmbeddingCheckTablesExist:
+    """Tests for TextEmbeddingModule._check_tables_exist caching and latching."""
+
+    @pytest.mark.asyncio
+    async def test_tables_present_is_cached_after_first_probe(self):
+        """A positive probe is cached — the second call issues no SQL."""
+        module = _embedding_module()
+        conn = _FakeConnection(rows_for={TABLES_QUERY: [(True,)]})
+
+        assert await module._check_tables_exist(conn) is True
+        assert len(conn.calls) == 1
+
+        assert await module._check_tables_exist(conn) is True
+        assert len(conn.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_tables_absent_warns_and_caches_negative(self, caplog):
+        """A negative probe warns once and caches False."""
+        module = _embedding_module()
+        conn = _FakeConnection(rows_for={TABLES_QUERY: [(False,)]})
+
+        with caplog.at_level(logging.WARNING, logger="ariel"):
+            assert await module._check_tables_exist(conn) is False
+
+        assert "Embedding tables do not exist" in caplog.text
+        assert module._tables_exist is False
+        assert len(conn.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_probe_stops_at_first_existing_table(self):
+        """The scan short-circuits on the first model whose table exists."""
+        module = _embedding_module(
+            models=[{"name": "model-a", "dimension": 4}, {"name": "model-b", "dimension": 4}]
+        )
+        conn = _FakeConnection(rows_for={TABLES_QUERY: [(True,)]})
+
+        assert await module._check_tables_exist(conn) is True
+        assert len(conn.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_check_tables_exist_latches_first_outcome_permanently(self):
+        """HAZARD: the tri-state latch is permanent for the module instance.
+
+        ``_tables_exist`` starts as None and is written exactly once, by the
+        first probe. Whatever that probe decided is returned forever after —
+        the module never re-probes, so a table created *after* a negative probe
+        stays invisible for the lifetime of the instance (and, in the service,
+        for the lifetime of the process). A run that starts before the pgvector
+        migration lands will skip text embedding for every entry even once the
+        tables are there; only a fresh module instance clears the latch.
+        """
+        module = _embedding_module()
+        conn = _FakeConnection(rows_for={TABLES_QUERY: [(False,)]})
+
+        assert await module._check_tables_exist(conn) is False
+        assert len(conn.calls) == 1
+
+        # The world changes: the migration runs and the table now exists.
+        conn.recorder.rows_for[TABLES_QUERY] = [(True,)]
+
+        assert await module._check_tables_exist(conn) is False, (
+            "latched negative must survive the table appearing"
+        )
+        assert len(conn.calls) == 1, "no re-probe is ever issued"
+
+        # A fresh instance is the only way back.
+        assert await _embedding_module()._check_tables_exist(conn) is True
+
+    @pytest.mark.asyncio
+    async def test_enhance_returns_early_when_tables_missing(self):
+        """enhance() stops at the table check — no provider, no INSERT."""
+        module = _embedding_module()
+        conn = _FakeConnection(rows_for={TABLES_QUERY: [(False,)]})
+
+        await module.enhance({"entry_id": "entry-001", "raw_text": "Beam at 500mA."}, conn)
+
+        assert len(conn.calls) == 1
+        assert not any("INSERT" in sql for sql in conn.sql)
+        assert module._provider is None
+
+
+class TestTextEmbeddingEnhanceWithProvider:
+    """Tests for TextEmbeddingModule.enhance against a fake embedding provider."""
+
+    @pytest.fixture
+    def entry(self):
+        """Non-empty sample entry."""
+        return {"entry_id": "entry-001", "raw_text": "Beam current stabilized at 500mA."}
+
+    @pytest.mark.asyncio
+    async def test_enhance_stores_embedding_in_model_table(self, entry, monkeypatch):
+        """A successful embedding is upserted into the model's own table."""
+        provider = _FakeEmbeddingProvider(vectors=[[0.1, 0.2, 0.3, 0.4]])
+        monkeypatch.setattr(
+            "osprey.models.embeddings.get_embedding_provider",
+            lambda name: provider,
+        )
+        module = _embedding_module(
+            provider={"name": "fake", "base_url": "http://fake:11434", "api_key": "secret"}
+        )
+        conn = _FakeConnection(rows_for={TABLES_QUERY: [(True,)]})
+
+        await module.enhance(entry, conn)
+
+        insert_sql = [sql for sql in conn.sql if "INSERT INTO" in sql]
+        assert len(insert_sql) == 1
+        assert "embeddings_test_model" in insert_sql[0]
+        assert conn.calls[-1][1] == ["entry-001", [0.1, 0.2, 0.3, 0.4]]
+
+        assert provider.calls == [
+            {
+                "texts": ["Beam current stabilized at 500mA."],
+                "model_id": "test-model",
+                "api_key": "secret",
+                "base_url": "http://fake:11434",
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_enhance_falls_back_to_provider_default_base_url(self, entry, monkeypatch):
+        """With no configured base_url the provider's own default is used."""
+        provider = _FakeEmbeddingProvider(default_base_url="http://provider-default:11434")
+        monkeypatch.setattr(
+            "osprey.models.embeddings.get_embedding_provider",
+            lambda name: provider,
+        )
+        module = _embedding_module(provider={"name": "fake"})
+        conn = _FakeConnection(rows_for={TABLES_QUERY: [(True,)]})
+
+        await module.enhance(entry, conn)
+
+        assert provider.calls[0]["base_url"] == "http://provider-default:11434"
+        assert provider.calls[0]["api_key"] is None
+
+    @pytest.mark.asyncio
+    async def test_enhance_truncates_text_to_model_token_budget(self, monkeypatch):
+        """Text is clipped to max_input_tokens * 4 characters."""
+        provider = _FakeEmbeddingProvider()
+        monkeypatch.setattr(
+            "osprey.models.embeddings.get_embedding_provider",
+            lambda name: provider,
+        )
+        module = _embedding_module(
+            models=[{"name": "test-model", "dimension": 4, "max_input_tokens": 10}]
+        )
+        conn = _FakeConnection(rows_for={TABLES_QUERY: [(True,)]})
+
+        await module.enhance({"entry_id": "entry-001", "raw_text": "x" * 100}, conn)
+
+        assert provider.calls[0]["texts"] == ["x" * 40]
+
+    @pytest.mark.asyncio
+    async def test_enhance_loads_provider_once_across_entries(self, entry, monkeypatch):
+        """The provider is looked up lazily and then reused."""
+        lookups = []
+        provider = _FakeEmbeddingProvider()
+
+        def fake_lookup(name):
+            lookups.append(name)
+            return provider
+
+        monkeypatch.setattr("osprey.models.embeddings.get_embedding_provider", fake_lookup)
+        module = _embedding_module(provider="ollama")
+        conn = _FakeConnection(rows_for={TABLES_QUERY: [(True,)]})
+
+        await module.enhance(entry, conn)
+        await module.enhance(entry, conn)
+
+        assert lookups == ["ollama"]
+
+    @pytest.mark.asyncio
+    async def test_enhance_raises_when_provider_fails_for_every_model(
+        self, entry, monkeypatch, caplog
+    ):
+        """Every model failing escalates to RuntimeError naming each one."""
+        provider = _FakeEmbeddingProvider(error=RuntimeError("embedding backend down"))
+        monkeypatch.setattr(
+            "osprey.models.embeddings.get_embedding_provider",
+            lambda name: provider,
+        )
+        module = _embedding_module(
+            models=[{"name": "model-a", "dimension": 4}, {"name": "model-b", "dimension": 4}]
+        )
+        conn = _FakeConnection(rows_for={TABLES_QUERY: [(True,)]})
+
+        with caplog.at_level(logging.WARNING, logger="ariel"), pytest.raises(RuntimeError) as exc:
+            await module.enhance(entry, conn)
+
+        assert "All embedding models failed for entry entry-001" in str(exc.value)
+        assert "model-a: embedding backend down" in str(exc.value)
+        assert "model-b: embedding backend down" in str(exc.value)
+        assert "Failed to generate embedding for entry entry-001" in caplog.text
+        assert not any("INSERT" in sql for sql in conn.sql)
+
+
+class TestTextEmbeddingHealthCheckBranches:
+    """Tests for TextEmbeddingModule.health_check outcomes."""
+
+    @pytest.mark.asyncio
+    async def test_health_check_delegates_to_provider(self, monkeypatch):
+        """A healthy provider's verdict is returned, with credentials passed through."""
+        provider = _FakeEmbeddingProvider(healthy=(True, "ollama reachable"))
+        monkeypatch.setattr(
+            "osprey.models.embeddings.get_embedding_provider",
+            lambda name: provider,
+        )
+        module = _embedding_module(
+            provider={"name": "fake", "base_url": "http://fake:11434", "api_key": "secret"}
+        )
+
+        assert await module.health_check() == (True, "ollama reachable")
+        assert provider.calls == [
+            {"check_health": True, "api_key": "secret", "base_url": "http://fake:11434"}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_health_check_reports_provider_unhealthy(self, monkeypatch):
+        """An unhealthy provider's message is surfaced verbatim."""
+        provider = _FakeEmbeddingProvider(healthy=(False, "connection refused"))
+        monkeypatch.setattr(
+            "osprey.models.embeddings.get_embedding_provider",
+            lambda name: provider,
+        )
+
+        assert await _embedding_module().health_check() == (False, "connection refused")
+
+    @pytest.mark.asyncio
+    async def test_health_check_unhealthy_when_provider_lookup_fails(self, monkeypatch):
+        """A provider that cannot be loaded reports unhealthy rather than raising."""
+
+        def boom(name):
+            raise ValueError("unknown embedding provider 'fake'")
+
+        monkeypatch.setattr("osprey.models.embeddings.get_embedding_provider", boom)
+
+        healthy, message = await _embedding_module().health_check()
+
+        assert healthy is False
+        assert message == "unknown embedding provider 'fake'"

--- a/tests/services/ariel_search/test_ingestion.py
+++ b/tests/services/ariel_search/test_ingestion.py
@@ -79,6 +79,25 @@ class TestGetAdapter:
             get_adapter(config)
         assert "(none)" in str(exc_info.value.adapter_name)
 
+    def test_get_adapter_initializes_registry(self):
+        """Registry is initialized unconditionally before adapter lookup."""
+        registry = MagicMock()
+        adapter_class = MagicMock()
+        registry.get_ariel_ingestion_adapter.return_value = (adapter_class, None)
+        config = ARIELConfig.from_dict(
+            {
+                "database": {"uri": "test"},
+                "ingestion": {"adapter": "generic_json", "source_url": "/test"},
+            }
+        )
+
+        with patch("osprey.registry.get_registry", return_value=registry):
+            adapter = get_adapter(config)
+
+        registry.initialize.assert_called_once_with(silent=True)
+        adapter_class.assert_called_once_with(config)
+        assert adapter is adapter_class.return_value
+
     def test_get_adapter_unknown_raises(self):
         """Raises AdapterNotFoundError for unknown adapter."""
         config = ARIELConfig.from_dict(

--- a/tests/services/ariel_search/test_ingestion_branches.py
+++ b/tests/services/ariel_search/test_ingestion_branches.py
@@ -1,0 +1,1835 @@
+"""Branch coverage for the four ARIEL ingestion adapters.
+
+Companion to ``test_ingestion.py``, which pins the happy paths. This file pins
+the branches that only run when a logbook misbehaves: HTTP failures, retries,
+unparseable payloads, missing files, and the tolerance fallbacks that let a
+malformed entry through instead of stopping the ingest.
+
+Two conventions carry through the file:
+
+* **No network.** Every HTTP path goes through ``patch("aiohttp.ClientSession")``,
+  following the precedent already in ``test_ingestion.py``.
+* **No real sleeping.** Retry backoff is observed by rebinding the adapter
+  module's own ``asyncio`` name to :class:`_RecordingAsyncio`. Rebinding the
+  module attribute (rather than patching ``asyncio.sleep`` itself) keeps the
+  fake from leaking into every other coroutine in the process.
+"""
+
+import json
+import logging
+import ssl
+import sys
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from zoneinfo import ZoneInfo
+
+import aiohttp
+import pytest
+
+from osprey.services.ariel_search.config import ARIELConfig
+from osprey.services.ariel_search.exceptions import (
+    AuthenticationRequiredError,
+    IngestionError,
+)
+from osprey.services.ariel_search.ingestion.adapters import als as als_module
+from osprey.services.ariel_search.ingestion.adapters import generic as generic_module
+from osprey.services.ariel_search.ingestion.adapters.als import ALSLogbookAdapter
+from osprey.services.ariel_search.ingestion.adapters.generic import GenericJSONAdapter
+from osprey.services.ariel_search.ingestion.adapters.jlab import JLabLogbookAdapter
+from osprey.services.ariel_search.ingestion.adapters.ornl import ORNLLogbookAdapter
+from osprey.services.ariel_search.models import FacilityEntryCreateRequest
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+class _RecordingAsyncio:
+    """Scoped stand-in for the ``asyncio`` name inside an adapter module.
+
+    ``sleep`` records its delay and returns immediately, so retry backoff is
+    asserted rather than waited out. Every other attribute delegates to the real
+    module. Install with ``monkeypatch.setattr(<module>, "asyncio", shim)`` —
+    patching ``asyncio.sleep`` directly would be process-global.
+    """
+
+    def __init__(self) -> None:
+        self.delays: list[float] = []
+
+    async def sleep(self, delay: float) -> None:
+        self.delays.append(delay)
+
+    def __getattr__(self, name: str) -> Any:
+        import asyncio
+
+        return getattr(asyncio, name)
+
+
+def _http_response(
+    *,
+    status: int = 200,
+    text: str | None = None,
+    json_data: Any = None,
+    raise_for_status: Exception | None = None,
+) -> AsyncMock:
+    """Build an aiohttp response double usable as an async context manager."""
+    response = AsyncMock()
+    response.status = status
+    response.raise_for_status = MagicMock(side_effect=raise_for_status)
+    response.text = AsyncMock(return_value=text if text is not None else "")
+    response.json = AsyncMock(return_value=json_data)
+    response.__aenter__ = AsyncMock(return_value=response)
+    response.__aexit__ = AsyncMock(return_value=None)
+    return response
+
+
+def _request_mock(outcome: Any) -> MagicMock:
+    """Turn a response double, an exception, or a per-attempt list into a call mock."""
+    if isinstance(outcome, (list, Exception)):
+        return MagicMock(side_effect=outcome)
+    return MagicMock(return_value=outcome)
+
+
+def _http_session(*, get: Any = None, post: Any = None) -> MagicMock:
+    """Build an aiohttp session double.
+
+    ``get``/``post`` take a response double, an exception instance (raised on
+    every attempt, modelling a persistent connection failure), or a list used as
+    a ``side_effect`` to script one outcome per attempt.
+    """
+    session = MagicMock()
+    if get is not None:
+        session.get = _request_mock(get)
+    if post is not None:
+        session.post = _request_mock(post)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+    return session
+
+
+@contextmanager
+def _patched_session(adapter: Any, session: MagicMock):
+    """Route an adapter's HTTP calls to ``session`` and stub out the connector.
+
+    The connector is stubbed because a real ``TCPConnector`` built against a
+    mocked session is never closed by anything.
+    """
+    with (
+        patch("aiohttp.ClientSession", return_value=session),
+        patch.object(adapter, "_create_connector", return_value=MagicMock()),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _clear_ariel_env(monkeypatch):
+    """Clear the ARIEL_* environment fallbacks read by config/adapter construction.
+
+    ``WriteConfig.from_dict`` and ``IngestionConfig.from_dict`` fold these into
+    the config object, so a developer shell that exports them would otherwise
+    decide which branch a test takes. Tests that exercise the fallbacks set them
+    back explicitly.
+    """
+    for var in ("ARIEL_SOCKS_PROXY", "ARIEL_WRITE_USER", "ARIEL_WRITE_PASSWORD"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _config(adapter: str, source_url: str | None, **ingestion: Any) -> ARIELConfig:
+    """Build an ARIELConfig with one ingestion block."""
+    block: dict[str, Any] = {"adapter": adapter}
+    if source_url is not None:
+        block["source_url"] = source_url
+    block.update(ingestion)
+    return ARIELConfig.from_dict({"database": {"uri": "postgresql://test"}, "ingestion": block})
+
+
+def _als_adapter(
+    source_url: str = "https://web7.als.invalid/olog/rpc.php", **ingestion: Any
+) -> ALSLogbookAdapter:
+    return ALSLogbookAdapter(_config("als_logbook", source_url, **ingestion))
+
+
+def _als_write_adapter(
+    *,
+    auth: bool = True,
+    **ingestion: Any,
+) -> ALSLogbookAdapter:
+    """ALS adapter with write enabled, optionally carrying config credentials."""
+    write: dict[str, Any] = {
+        "enabled": True,
+        "write_url": "https://elog.als.invalid/olog/rpc.php",
+    }
+    if auth:
+        write["auth_user"] = "operator"
+        write["auth_password"] = "hunter2"
+    return _als_adapter(write=write, **ingestion)
+
+
+def _generic_adapter(source_url: str) -> GenericJSONAdapter:
+    return GenericJSONAdapter(_config("generic_json", source_url))
+
+
+def _jlab_adapter(source_url: str) -> JLabLogbookAdapter:
+    return JLabLogbookAdapter(_config("jlab_logbook", source_url))
+
+
+def _ornl_adapter(source_url: str) -> ORNLLogbookAdapter:
+    return ORNLLogbookAdapter(_config("ornl_logbook", source_url))
+
+
+async def _collect(agen: Any) -> list[Any]:
+    return [item async for item in agen]
+
+
+# ---------------------------------------------------------------------------
+# ALS — construction and configuration guards
+# ---------------------------------------------------------------------------
+
+
+class TestALSConfigGuards:
+    """Construction guards and environment fallbacks for the ALS adapter."""
+
+    def test_missing_source_url_raises(self):
+        """source_url is mandatory: the adapter has nothing to read otherwise."""
+        with pytest.raises(IngestionError) as exc_info:
+            ALSLogbookAdapter(_config("als_logbook", None))
+
+        assert "source_url is required" in str(exc_info.value)
+        assert exc_info.value.source_system == "ALS eLog"
+
+    def test_supports_write_false_when_ingestion_block_absent(self):
+        """supports_write is fail-closed when the config carries no ingestion block."""
+        adapter = _als_write_adapter()
+        assert adapter.supports_write is True
+
+        adapter.config = ARIELConfig.from_dict({"database": {"uri": "postgresql://test"}})
+        assert adapter.supports_write is False
+
+    def test_socks_proxy_read_from_environment(self, monkeypatch):
+        """ARIEL_SOCKS_PROXY supplies the proxy when the config omits proxy_url."""
+        monkeypatch.setenv("ARIEL_SOCKS_PROXY", "socks5://tunnel.invalid:9095")
+
+        adapter = _als_adapter()
+
+        assert adapter.proxy_url == "socks5://tunnel.invalid:9095"
+
+    def test_no_proxy_without_config_or_environment(self):
+        """With neither source, proxy_url stays None and a plain TCP connector is used."""
+        adapter = _als_adapter()
+        assert adapter.proxy_url is None
+
+    def test_explicit_proxy_wins_over_environment(self, monkeypatch):
+        """An explicit proxy_url is not overridden by the environment fallback."""
+        monkeypatch.setenv("ARIEL_SOCKS_PROXY", "socks5://tunnel.invalid:9095")
+
+        adapter = _als_adapter(proxy_url="socks5://explicit.invalid:1080")
+
+        assert adapter.proxy_url == "socks5://explicit.invalid:1080"
+
+
+# ---------------------------------------------------------------------------
+# ALS — file-backed source
+# ---------------------------------------------------------------------------
+
+
+class TestALSFileSource:
+    """JSONL file mode: per-line tolerance and the missing-file guard."""
+
+    @pytest.mark.asyncio
+    async def test_http_source_delegates_to_http_reader(self):
+        """An http(s) source_url routes fetch_entries to the windowed HTTP reader."""
+        adapter = _als_adapter()
+        seen: dict[str, Any] = {}
+
+        async def fake_http(since, until, limit):
+            seen["args"] = (since, until, limit)
+            yield {"entry_id": "from-http"}
+
+        with patch.object(adapter, "_fetch_entries_http", fake_http):
+            entries = await _collect(adapter.fetch_entries(limit=7))
+
+        assert [e["entry_id"] for e in entries] == ["from-http"]
+        assert seen["args"] == (None, None, 7)
+
+    @pytest.mark.asyncio
+    async def test_missing_file_raises(self, tmp_path):
+        """A file source that does not exist fails loudly rather than yielding nothing."""
+        adapter = _als_adapter(str(tmp_path / "absent.jsonl"))
+
+        with pytest.raises(IngestionError) as exc_info:
+            await _collect(adapter.fetch_entries())
+
+        assert "Source file not found" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_blank_lines_and_empty_entries_are_skipped(self, tmp_path):
+        """Blank lines and text-free entries never reach the database."""
+        path = tmp_path / "entries.jsonl"
+        path.write_text(
+            "\n".join(
+                [
+                    "",
+                    json.dumps(
+                        {"id": "1", "timestamp": "1704067200", "subject": "", "details": ""}
+                    ),
+                    "   ",
+                    json.dumps(
+                        {"id": "2", "timestamp": "1704067200", "subject": "Kept", "details": ""}
+                    ),
+                ]
+            )
+            + "\n"
+        )
+        adapter = _als_adapter(str(path))
+
+        entries = await _collect(adapter.fetch_entries())
+
+        assert [e["entry_id"] for e in entries] == ["2"]
+
+    @pytest.mark.asyncio
+    async def test_since_and_until_bounds_are_exclusive(self, tmp_path):
+        """Entries exactly on either bound are dropped (``<=`` since, ``>=`` until)."""
+        path = tmp_path / "entries.jsonl"
+        stamps = {
+            "early": int(datetime(2024, 1, 1, tzinfo=UTC).timestamp()),
+            "middle": int(datetime(2024, 1, 5, tzinfo=UTC).timestamp()),
+            "late": int(datetime(2024, 1, 9, tzinfo=UTC).timestamp()),
+        }
+        path.write_text(
+            "\n".join(
+                json.dumps({"id": name, "timestamp": str(ts), "subject": name, "details": ""})
+                for name, ts in stamps.items()
+            )
+        )
+        adapter = _als_adapter(str(path))
+
+        entries = await _collect(
+            adapter.fetch_entries(
+                since=datetime(2024, 1, 1, tzinfo=UTC),
+                until=datetime(2024, 1, 9, tzinfo=UTC),
+            )
+        )
+
+        assert [e["entry_id"] for e in entries] == ["middle"]
+
+    @pytest.mark.asyncio
+    async def test_limit_stops_reading(self, tmp_path):
+        """limit stops the read mid-file instead of converting the whole export."""
+        path = tmp_path / "entries.jsonl"
+        path.write_text(
+            "\n".join(
+                json.dumps({"id": str(i), "timestamp": "1704067200", "subject": f"e{i}"})
+                for i in range(5)
+            )
+        )
+        adapter = _als_adapter(str(path))
+
+        entries = await _collect(adapter.fetch_entries(limit=2))
+
+        assert [e["entry_id"] for e in entries] == ["0", "1"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_line_is_logged_and_skipped(self, tmp_path, caplog):
+        """One corrupt line does not abort the ingest of the rest of the file."""
+        path = tmp_path / "entries.jsonl"
+        path.write_text(
+            "{not json\n"
+            + json.dumps({"id": "ok", "timestamp": "1704067200", "subject": "Fine"})
+            + "\n"
+        )
+        adapter = _als_adapter(str(path))
+
+        with caplog.at_level(logging.WARNING, logger="ariel"):
+            entries = await _collect(adapter.fetch_entries())
+
+        assert [e["entry_id"] for e in entries] == ["ok"]
+        assert "Invalid JSON at line 1" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_unconvertible_line_is_logged_and_skipped(self, tmp_path, caplog):
+        """A syntactically valid line of the wrong shape is skipped, not fatal."""
+        path = tmp_path / "entries.jsonl"
+        path.write_text(
+            "[1, 2, 3]\n"
+            + json.dumps({"id": "ok", "timestamp": "1704067200", "subject": "Fine"})
+            + "\n"
+        )
+        adapter = _als_adapter(str(path))
+
+        with caplog.at_level(logging.WARNING, logger="ariel"):
+            entries = await _collect(adapter.fetch_entries())
+
+        assert [e["entry_id"] for e in entries] == ["ok"]
+        assert "Failed to convert entry at line 1" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# ALS — write path (_post_entry)
+# ---------------------------------------------------------------------------
+
+
+class TestALSPostEntry:
+    """The olog RPC write: TLS mode, error surfacing, ID parsing, and retries."""
+
+    @pytest.mark.asyncio
+    async def test_verify_ssl_true_passes_certificate_verification(self):
+        """verify_ssl=True hands aiohttp its default verifying context."""
+        adapter = _als_write_adapter(verify_ssl=True)
+        session = _http_session(post=_http_response(text="<response><id>7</id></response>"))
+
+        with _patched_session(adapter, session):
+            await adapter._post_entry("https://elog.als.invalid/olog", "<root/>")
+
+        assert session.post.call_args.kwargs["ssl"] is True
+
+    @pytest.mark.asyncio
+    async def test_verify_ssl_false_builds_permissive_context(self):
+        """verify_ssl=False (the default) disables hostname and certificate checks.
+
+        Internal olog servers carry self-signed certificates; the default is
+        permissive so ingestion works, and this pins exactly how permissive.
+        """
+        adapter = _als_write_adapter()
+        session = _http_session(post=_http_response(text="<response><id>7</id></response>"))
+
+        with _patched_session(adapter, session):
+            await adapter._post_entry("https://elog.als.invalid/olog", "<root/>")
+
+        context = session.post.call_args.kwargs["ssl"]
+        assert isinstance(context, ssl.SSLContext)
+        assert context.check_hostname is False
+        assert context.verify_mode == ssl.CERT_NONE
+
+    @pytest.mark.asyncio
+    async def test_http_error_carries_response_body(self, monkeypatch):
+        """A >=400 response puts the server's body in the error, and is not retried.
+
+        The olog RPC explains rejections in the body (bad credentials, unknown
+        logbook), so discarding it would leave the operator with a bare status code.
+        """
+        adapter = _als_write_adapter()
+        shim = _RecordingAsyncio()
+        monkeypatch.setattr(als_module, "asyncio", shim)
+        session = _http_session(
+            post=_http_response(status=403, text="unknown logbook 'Operations'")
+        )
+
+        with _patched_session(adapter, session):
+            with pytest.raises(IngestionError) as exc_info:
+                await adapter._post_entry("https://elog.als.invalid/olog", "<root/>")
+
+        assert "HTTP 403" in str(exc_info.value)
+        assert "unknown logbook 'Operations'" in str(exc_info.value)
+        assert session.post.call_count == 1
+        assert shim.delays == []
+
+    @pytest.mark.asyncio
+    async def test_entry_id_from_id_element(self):
+        """The nested ``<id>`` element is the primary source of the entry ID."""
+        adapter = _als_write_adapter()
+        session = _http_session(
+            post=_http_response(text="<response><entry><id>4242</id></entry></response>")
+        )
+
+        with _patched_session(adapter, session):
+            entry_id = await adapter._post_entry("https://elog.als.invalid/olog", "<root/>")
+
+        assert entry_id == "4242"
+
+    @pytest.mark.asyncio
+    async def test_entry_id_from_root_attribute(self):
+        """With no ``<id>`` element, a root ``id`` attribute is the next fallback."""
+        adapter = _als_write_adapter()
+        session = _http_session(post=_http_response(text='<response id="4243" />'))
+
+        with _patched_session(adapter, session):
+            entry_id = await adapter._post_entry("https://elog.als.invalid/olog", "<root/>")
+
+        assert entry_id == "4243"
+
+    @pytest.mark.asyncio
+    async def test_unparseable_response_falls_back_to_response_text(self):
+        """HAZARD: a non-XML success body becomes the entry ID verbatim.
+
+        The write succeeded, so the adapter refuses to fail; the cost is that a
+        plain-text or HTML body is stored as the facility entry ID and will not
+        match anything on re-ingestion.
+        """
+        adapter = _als_write_adapter()
+        session = _http_session(post=_http_response(text="  saved ok  "))
+
+        with _patched_session(adapter, session):
+            entry_id = await adapter._post_entry("https://elog.als.invalid/olog", "<root/>")
+
+        assert entry_id == "saved ok"
+
+    @pytest.mark.asyncio
+    async def test_empty_id_element_falls_back_to_whole_body(self):
+        """HAZARD: an ``<id>`` element with no text yields the raw XML body as the ID.
+
+        ``find(".//id")`` matches but ``.text`` is None, so neither the element
+        nor the attribute fallback fires and the whole response becomes the ID.
+        """
+        adapter = _als_write_adapter()
+        body = "<response><id></id></response>"
+        session = _http_session(post=_http_response(text=body))
+
+        with _patched_session(adapter, session):
+            entry_id = await adapter._post_entry("https://elog.als.invalid/olog", "<root/>")
+
+        assert entry_id == body
+
+    @pytest.mark.asyncio
+    async def test_blank_response_gets_synthetic_id(self):
+        """An empty success body yields a synthetic ``als-<epoch>`` identifier."""
+        adapter = _als_write_adapter()
+        session = _http_session(post=_http_response(text="   "))
+
+        with _patched_session(adapter, session):
+            entry_id = await adapter._post_entry("https://elog.als.invalid/olog", "<root/>")
+
+        assert entry_id.startswith("als-")
+
+    @pytest.mark.asyncio
+    async def test_transient_failure_retries_with_backoff(self, monkeypatch):
+        """A connection error is retried after ``retry_delay * 2**attempt`` seconds."""
+        adapter = _als_write_adapter(max_retries=3, retry_delay_seconds=5)
+        shim = _RecordingAsyncio()
+        monkeypatch.setattr(als_module, "asyncio", shim)
+        session = _http_session(
+            post=[
+                aiohttp.ClientError("connection reset"),
+                TimeoutError("read timeout"),
+                _http_response(text="<response><id>99</id></response>"),
+            ]
+        )
+
+        with _patched_session(adapter, session):
+            entry_id = await adapter._post_entry("https://elog.als.invalid/olog", "<root/>")
+
+        assert entry_id == "99"
+        assert shim.delays == [5, 10]
+
+    @pytest.mark.asyncio
+    async def test_max_retries_exceeded_names_last_error(self, monkeypatch):
+        """After the final attempt the adapter raises, naming the last failure.
+
+        The last attempt does not sleep — the retry budget is spent, so waiting
+        would only delay the error.
+        """
+        adapter = _als_write_adapter(max_retries=2, retry_delay_seconds=5)
+        shim = _RecordingAsyncio()
+        monkeypatch.setattr(als_module, "asyncio", shim)
+        session = _http_session(post=aiohttp.ClientError("connection reset"))
+
+        with _patched_session(adapter, session):
+            with pytest.raises(IngestionError) as exc_info:
+                await adapter._post_entry("https://elog.als.invalid/olog", "<root/>")
+
+        assert "Max retries (2) exceeded" in str(exc_info.value)
+        assert "connection reset" in str(exc_info.value)
+        assert session.post.call_count == 2
+        assert shim.delays == [5]
+
+
+class TestALSCreateEntryCredentials:
+    """Credential resolution for the write path."""
+
+    @pytest.mark.asyncio
+    async def test_environment_credentials_are_folded_in_at_config_load(self, monkeypatch):
+        """ARIEL_WRITE_USER/PASSWORD supply credentials when the request omits them."""
+        monkeypatch.setenv("ARIEL_WRITE_USER", "env-operator")
+        monkeypatch.setenv("ARIEL_WRITE_PASSWORD", "env-secret")
+        adapter = _als_write_adapter(auth=False)
+        session = _http_session(post=_http_response(text="<response><id>1</id></response>"))
+
+        with _patched_session(adapter, session):
+            await adapter.create_entry(
+                FacilityEntryCreateRequest(subject="Subject", details="Details")
+            )
+
+        payload = session.post.call_args.kwargs["data"]
+        assert "<author>env-operator</author>" in payload
+        assert "<password>env-secret</password>" in payload
+
+    @pytest.mark.asyncio
+    async def test_environment_is_read_at_config_load_not_at_write(self, monkeypatch):
+        """HAZARD: credentials exported after the config was built are not picked up.
+
+        ``WriteConfig.from_dict`` snapshots the environment, so a service that
+        loaded its config before the credentials were exported keeps refusing to
+        publish until it is restarted.
+        """
+        adapter = _als_write_adapter(auth=False)
+        monkeypatch.setenv("ARIEL_WRITE_USER", "late-operator")
+        monkeypatch.setenv("ARIEL_WRITE_PASSWORD", "late-secret")
+
+        with pytest.raises(AuthenticationRequiredError):
+            await adapter.create_entry(
+                FacilityEntryCreateRequest(subject="Subject", details="Details")
+            )
+
+    @pytest.mark.asyncio
+    async def test_request_credentials_override_config(self):
+        """Per-request credentials take precedence over the configured ones."""
+        adapter = _als_write_adapter()
+        session = _http_session(post=_http_response(text="<response><id>1</id></response>"))
+
+        with _patched_session(adapter, session):
+            await adapter.create_entry(
+                FacilityEntryCreateRequest(
+                    subject="Subject",
+                    details="Details",
+                    auth_user="request-user",
+                    auth_password="request-secret",
+                )
+            )
+
+        payload = session.post.call_args.kwargs["data"]
+        assert "<author>request-user</author>" in payload
+
+    @pytest.mark.asyncio
+    async def test_missing_credentials_raise_authentication_required(self):
+        """Absent credentials raise the auth-specific error, not a generic one.
+
+        The API layer maps this to HTTP 401 so the operator is prompted, rather
+        than the publish silently failing.
+        """
+        adapter = _als_write_adapter(auth=False)
+
+        with pytest.raises(AuthenticationRequiredError) as exc_info:
+            await adapter.create_entry(
+                FacilityEntryCreateRequest(subject="Subject", details="Details")
+            )
+
+        assert "ARIEL_WRITE_USER" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# ALS — windowed HTTP read
+# ---------------------------------------------------------------------------
+
+
+class TestALSFetchEntriesHTTP:
+    """Window generation, TLS mode, and per-window error handling."""
+
+    @pytest.mark.asyncio
+    async def test_naive_bounds_are_interpreted_as_utc(self):
+        """Timezone-naive since/until are treated as UTC before windowing."""
+        adapter = _als_adapter()
+        session = _http_session(get=_http_response(text="[]"))
+
+        with _patched_session(adapter, session):
+            entries = await _collect(
+                adapter._fetch_entries_http(since=datetime(2024, 1, 1), until=datetime(2024, 1, 2))
+            )
+
+        assert entries == []
+        params = session.get.call_args.kwargs["params"]
+        assert params["start"] == str(int(datetime(2024, 1, 1, tzinfo=UTC).timestamp()))
+        assert params["end"] == str(int(datetime(2024, 1, 2, tzinfo=UTC).timestamp()))
+
+    @pytest.mark.asyncio
+    async def test_verify_ssl_true_passes_certificate_verification(self):
+        """verify_ssl=True hands aiohttp its default verifying context on reads too."""
+        adapter = _als_adapter(verify_ssl=True)
+        session = _http_session(get=_http_response(text="[]"))
+
+        with _patched_session(adapter, session):
+            await _collect(
+                adapter._fetch_entries_http(
+                    since=datetime(2024, 1, 1, tzinfo=UTC), until=datetime(2024, 1, 2, tzinfo=UTC)
+                )
+            )
+
+        assert session.get.call_args.kwargs["ssl"] is True
+
+    @pytest.mark.asyncio
+    async def test_ingestion_error_from_a_window_aborts_the_fetch(self):
+        """An IngestionError (exhausted retries, 4xx) stops the whole fetch."""
+        adapter = _als_adapter()
+        session = _http_session(get=_http_response(text="[]"))
+        failure = IngestionError("HTTP 404 error from ALS API", source_system="ALS eLog")
+
+        with _patched_session(adapter, session):
+            with patch.object(adapter, "_fetch_window_with_retry", side_effect=failure):
+                with pytest.raises(IngestionError):
+                    await _collect(
+                        adapter._fetch_entries_http(
+                            since=datetime(2024, 1, 1, tzinfo=UTC),
+                            until=datetime(2024, 1, 2, tzinfo=UTC),
+                        )
+                    )
+
+    @pytest.mark.asyncio
+    async def test_unexpected_window_error_skips_only_that_window(self, caplog):
+        """An unexpected error is logged and the remaining windows still run."""
+        adapter = _als_adapter(chunk_days=1)
+        session = _http_session(get=_http_response(text="[]"))
+        good = [{"id": "5", "timestamp": "1704067200", "subject": "Second window"}]
+
+        with _patched_session(adapter, session):
+            with patch.object(
+                adapter,
+                "_fetch_window_with_retry",
+                side_effect=[RuntimeError("adapter bug"), good],
+            ):
+                with caplog.at_level(logging.ERROR, logger="ariel"):
+                    entries = await _collect(
+                        adapter._fetch_entries_http(
+                            since=datetime(2024, 1, 1, tzinfo=UTC),
+                            until=datetime(2024, 1, 3, tzinfo=UTC),
+                        )
+                    )
+
+        assert [e["entry_id"] for e in entries] == ["5"]
+        assert "Failed to fetch window" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_unconvertible_entry_is_logged_and_skipped(self, caplog):
+        """One entry the converter chokes on does not lose the rest of the window."""
+        adapter = _als_adapter()
+        payload = [
+            {"id": "bad", "timestamp": "1704067200", "subject": "Bad"},
+            {"id": "good", "timestamp": "1704067200", "subject": "Good"},
+        ]
+        session = _http_session(get=_http_response(text=json.dumps(payload)))
+        real_convert = adapter._convert_entry
+
+        def convert(data):
+            if data["id"] == "bad":
+                raise ValueError("unconvertible")
+            return real_convert(data)
+
+        with _patched_session(adapter, session):
+            with patch.object(adapter, "_convert_entry", side_effect=convert):
+                with caplog.at_level(logging.WARNING, logger="ariel"):
+                    entries = await _collect(
+                        adapter._fetch_entries_http(
+                            since=datetime(2024, 1, 1, tzinfo=UTC),
+                            until=datetime(2024, 1, 2, tzinfo=UTC),
+                        )
+                    )
+
+        assert [e["entry_id"] for e in entries] == ["good"]
+        assert "Failed to convert entry bad" in caplog.text
+
+
+class TestALSFetchWindowResponses:
+    """The olog endpoint answers with several non-JSON shapes; all mean 'empty'."""
+
+    def _adapter(self) -> ALSLogbookAdapter:
+        return _als_adapter()
+
+    async def _fetch(self, body: str) -> list[dict[str, Any]]:
+        adapter = self._adapter()
+        session = _http_session(get=_http_response(text=body))
+        return await adapter._fetch_window(
+            session, datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 1, 2, tzinfo=UTC), True
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_body_is_empty_window(self):
+        """An empty body means no entries in the range, not a failure."""
+        assert await self._fetch("   ") == []
+
+    @pytest.mark.asyncio
+    async def test_html_body_is_empty_window(self):
+        """The endpoint returns an HTML page for an empty date range."""
+        assert await self._fetch("<html><body>No entries</body></html>") == []
+
+    @pytest.mark.asyncio
+    async def test_doctype_body_is_empty_window(self):
+        """A leading doctype declaration is recognised as HTML too."""
+        assert await self._fetch("<!DOCTYPE html><html></html>") == []
+
+    @pytest.mark.asyncio
+    async def test_non_json_body_is_empty_window(self):
+        """A body that is neither HTML nor JSON is treated as an empty window."""
+        assert await self._fetch("retrieve: no records") == []
+
+    @pytest.mark.asyncio
+    async def test_non_list_json_is_empty_window(self, caplog):
+        """A JSON object where a list was expected is dropped with a warning."""
+        with caplog.at_level(logging.WARNING, logger="ariel"):
+            result = await self._fetch(json.dumps({"error": "bad range"}))
+
+        assert result == []
+        assert "Unexpected response type" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_json_list_is_returned(self):
+        """A JSON array is returned as-is despite the text/html content type."""
+        assert await self._fetch(json.dumps([{"id": "1"}])) == [{"id": "1"}]
+
+    @pytest.mark.asyncio
+    async def test_server_error_is_retried(self, monkeypatch):
+        """A 5xx is retried, unlike a 4xx which fails immediately."""
+        adapter = _als_adapter(max_retries=2, retry_delay_seconds=5)
+        shim = _RecordingAsyncio()
+        monkeypatch.setattr(als_module, "asyncio", shim)
+        server_error = aiohttp.ClientResponseError(
+            request_info=MagicMock(), history=(), status=503, message="Service Unavailable"
+        )
+
+        with patch.object(adapter, "_fetch_window", side_effect=[server_error, [{"id": "1"}]]):
+            result = await adapter._fetch_window_with_retry(
+                MagicMock(),
+                datetime(2024, 1, 1, tzinfo=UTC),
+                datetime(2024, 1, 2, tzinfo=UTC),
+                True,
+            )
+
+        assert result == [{"id": "1"}]
+        assert shim.delays == [5]
+
+
+class TestALSConnector:
+    """SOCKS proxy connector construction."""
+
+    @pytest.mark.asyncio
+    async def test_proxy_connector_built_from_url(self):
+        """A configured SOCKS proxy produces an aiohttp-socks connector."""
+        from aiohttp_socks import ProxyConnector
+
+        adapter = _als_adapter(proxy_url="socks5://127.0.0.1:9095")
+
+        connector = adapter._create_connector()
+        try:
+            assert isinstance(connector, ProxyConnector)
+        finally:
+            await connector.close()
+
+    def test_proxy_without_aiohttp_socks_raises(self, monkeypatch):
+        """A proxy without the optional dependency installed fails with an install hint."""
+        adapter = _als_adapter(proxy_url="socks5://127.0.0.1:9095")
+        monkeypatch.setitem(sys.modules, "aiohttp_socks", None)
+
+        with pytest.raises(IngestionError) as exc_info:
+            adapter._create_connector()
+
+        assert "aiohttp-socks is not installed" in str(exc_info.value)
+
+
+class TestALSConvertEntry:
+    """Field-level tolerance in the ALS converter."""
+
+    def test_malformed_timestamp_falls_back_to_now(self):
+        """HAZARD: an unparseable timestamp silently becomes ingest time.
+
+        The entry is kept rather than dropped, so a facility export with broken
+        timestamps lands as a block of entries all dated at the moment of the
+        ingest run — searchable, but chronologically wrong.
+        """
+        adapter = _als_adapter()
+
+        entry = adapter._convert_entry(
+            {"id": "1", "timestamp": "not-an-epoch", "subject": "Subject"}
+        )
+
+        assert entry["timestamp"] == entry["created_at"]
+
+    def test_null_timestamp_falls_back_to_now(self):
+        """A null timestamp takes the same ingest-time fallback as a malformed one."""
+        adapter = _als_adapter()
+
+        entry = adapter._convert_entry({"id": "1", "timestamp": None, "subject": "Subject"})
+
+        assert entry["timestamp"] == entry["created_at"]
+
+    def test_missing_id_yields_empty_entry_id(self):
+        """HAZARD: an entry with no id becomes entry_id '' — and '' is a single row.
+
+        ``enhanced_entries`` upserts ``ON CONFLICT (entry_id)``, so every id-less
+        entry in an export overwrites the same row: N entries ingest as one, and
+        only the last one survives.
+        """
+        adapter = _als_adapter()
+
+        first = adapter._convert_entry({"timestamp": "1704067200", "subject": "First"})
+        second = adapter._convert_entry({"timestamp": "1704067200", "subject": "Second"})
+
+        assert first["entry_id"] == ""
+        assert second["entry_id"] == first["entry_id"]
+
+    def test_explicit_metadata_overrides_derived_fields(self):
+        """A ``metadata`` dict on the source entry is merged last and wins."""
+        adapter = _als_adapter()
+
+        entry = adapter._convert_entry(
+            {
+                "id": "1",
+                "timestamp": "1704067200",
+                "subject": "Derived",
+                "level": "Info",
+                "metadata": {"subject": "Explicit", "extra": "kept"},
+            }
+        )
+
+        assert entry["metadata"]["subject"] == "Explicit"
+        assert entry["metadata"]["extra"] == "kept"
+        assert entry["metadata"]["level"] == "Info"
+
+    def test_zero_sentinels_are_normalised_to_absent(self):
+        """ALS writes "0" for an unset tag/link; it must not become metadata."""
+        adapter = _als_adapter()
+
+        entry = adapter._convert_entry(
+            {"id": "1", "timestamp": "1704067200", "subject": "S", "tag": "0", "linkedto": "0"}
+        )
+
+        assert "loto_tag" not in entry["metadata"]
+        assert "linked_to" not in entry["metadata"]
+
+
+# ---------------------------------------------------------------------------
+# Generic JSON adapter
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def facility_tz(monkeypatch) -> ZoneInfo:
+    """Pin the facility timezone the generic converter anchors relative times in.
+
+    ``_convert_entry`` builds its ``now`` from ``get_facility_timezone()``, so an
+    unpinned zone would make the resolved wall-clock time depend on whatever
+    config the test host happens to load.
+    """
+    zone = ZoneInfo("America/Los_Angeles")
+    monkeypatch.setattr(generic_module, "get_facility_timezone", lambda: zone)
+    return zone
+
+
+class TestGenericAdapterGuards:
+    """Construction and read-loop guards for the generic JSON adapter."""
+
+    def test_missing_source_url_raises(self):
+        """source_url is mandatory for the generic adapter too."""
+        with pytest.raises(IngestionError) as exc_info:
+            GenericJSONAdapter(_config("generic_json", None))
+
+        assert "source_url is required" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_since_and_until_bounds_are_exclusive(self, tmp_path, facility_tz):
+        """Entries on either bound are dropped, matching the other adapters."""
+        path = tmp_path / "entries.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "entries": [
+                        {"id": "early", "timestamp": "2024-01-01T00:00:00Z", "title": "e"},
+                        {"id": "middle", "timestamp": "2024-01-05T00:00:00Z", "title": "m"},
+                        {"id": "late", "timestamp": "2024-01-09T00:00:00Z", "title": "l"},
+                    ]
+                }
+            )
+        )
+        adapter = _generic_adapter(str(path))
+
+        entries = await _collect(
+            adapter.fetch_entries(
+                since=datetime(2024, 1, 1, tzinfo=UTC),
+                until=datetime(2024, 1, 9, tzinfo=UTC),
+            )
+        )
+
+        assert [e["entry_id"] for e in entries] == ["middle"]
+
+    @pytest.mark.asyncio
+    async def test_limit_stops_reading(self, tmp_path, facility_tz):
+        """limit truncates the yielded entries."""
+        path = tmp_path / "entries.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "entries": [
+                        {"id": str(i), "timestamp": "2024-01-05T00:00:00Z", "title": f"e{i}"}
+                        for i in range(4)
+                    ]
+                }
+            )
+        )
+        adapter = _generic_adapter(str(path))
+
+        entries = await _collect(adapter.fetch_entries(limit=2))
+
+        assert [e["entry_id"] for e in entries] == ["0", "1"]
+
+    @pytest.mark.asyncio
+    async def test_unparseable_timestamp_drops_the_entry(self, tmp_path, facility_tz, caplog):
+        """The generic adapter drops an entry with a bad timestamp, unlike ALS/ORNL.
+
+        ``_parse_timestamp`` raises rather than defaulting to now, and
+        ``fetch_entries`` turns that into a warning plus a skipped entry — so a
+        malformed export loses rows instead of misdating them.
+        """
+        path = tmp_path / "entries.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "entries": [
+                        {"id": "bad", "timestamp": "yesterday-ish", "title": "Bad"},
+                        {"id": "good", "timestamp": "2024-01-05T00:00:00Z", "title": "Good"},
+                    ]
+                }
+            )
+        )
+        adapter = _generic_adapter(str(path))
+
+        with caplog.at_level(logging.WARNING, logger="ariel"):
+            entries = await _collect(adapter.fetch_entries())
+
+        assert [e["entry_id"] for e in entries] == ["good"]
+        assert "Failed to convert entry" in caplog.text
+
+
+class TestGenericLoadData:
+    """Source loading: local file guards and the HTTP branch."""
+
+    @pytest.mark.asyncio
+    async def test_missing_file_raises(self, tmp_path):
+        """A missing local file is an ingestion failure, not an empty result."""
+        adapter = _generic_adapter(str(tmp_path / "absent.json"))
+
+        with pytest.raises(IngestionError) as exc_info:
+            await adapter._load_data()
+
+        assert "Source file not found" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_http_source_returns_decoded_json(self):
+        """An http(s) source is fetched and decoded as JSON."""
+        adapter = _generic_adapter("https://logbook.invalid/entries.json")
+        session = _http_session(get=_http_response(json_data={"entries": [{"id": "1"}]}))
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            data = await adapter._load_data()
+
+        assert data == {"entries": [{"id": "1"}]}
+
+    @pytest.mark.asyncio
+    async def test_http_non_200_raises(self):
+        """Any non-200 status fails the load with the status in the message."""
+        adapter = _generic_adapter("https://logbook.invalid/entries.json")
+        session = _http_session(get=_http_response(status=503))
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            with pytest.raises(IngestionError) as exc_info:
+                await adapter._load_data()
+
+        assert "status 503" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_missing_aiohttp_raises_install_hint(self, monkeypatch):
+        """aiohttp is optional for file sources; an HTTP source says how to get it."""
+        adapter = _generic_adapter("https://logbook.invalid/entries.json")
+        monkeypatch.setitem(sys.modules, "aiohttp", None)
+
+        with pytest.raises(IngestionError) as exc_info:
+            await adapter._load_data()
+
+        assert "pip install aiohttp" in str(exc_info.value)
+
+
+class TestGenericAppendEntry:
+    """The local-file write path and its failure handling."""
+
+    @pytest.mark.asyncio
+    async def test_corrupt_target_file_raises(self, tmp_path):
+        """A corrupt target file fails the write instead of silently rewriting it."""
+        path = tmp_path / "entries.json"
+        path.write_text("{ this is not json")
+        adapter = _generic_adapter(str(path))
+
+        with pytest.raises(IngestionError) as exc_info:
+            await adapter.create_entry(
+                FacilityEntryCreateRequest(subject="Subject", details="Details")
+            )
+
+        assert "Failed to append entry" in str(exc_info.value)
+        assert path.read_text() == "{ this is not json"
+
+    @pytest.mark.asyncio
+    async def test_unreadable_target_raises(self, tmp_path):
+        """An OSError reading the target (here: a directory) is wrapped, not leaked."""
+        path = tmp_path / "entries.json"
+        path.mkdir()
+        adapter = _generic_adapter(str(path))
+
+        with pytest.raises(IngestionError) as exc_info:
+            await adapter.create_entry(
+                FacilityEntryCreateRequest(subject="Subject", details="Details")
+            )
+
+        assert "Failed to append entry" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_failed_write_removes_the_temp_file(self, tmp_path, monkeypatch):
+        """A failure mid-write cleans up the temp file and leaves the target intact.
+
+        The write is staged through ``<name>.tmp`` and promoted with an atomic
+        replace, so a crash must not leave the staging file behind for the next
+        run to trip over.
+        """
+        path = tmp_path / "entries.json"
+        path.write_text(json.dumps({"entries": []}))
+        adapter = _generic_adapter(str(path))
+
+        def failing_dump(*args, **kwargs):
+            raise OSError("no space left on device")
+
+        # Rebind the module's own ``json`` name so the fake cannot escape this module.
+        monkeypatch.setattr(
+            generic_module,
+            "json",
+            SimpleNamespace(
+                load=json.load, dump=failing_dump, JSONDecodeError=json.JSONDecodeError
+            ),
+        )
+
+        with pytest.raises(IngestionError):
+            await adapter.create_entry(
+                FacilityEntryCreateRequest(subject="Subject", details="Details")
+            )
+
+        assert not (tmp_path / "entries.tmp").exists()
+        assert json.loads(path.read_text()) == {"entries": []}
+
+    @pytest.mark.asyncio
+    async def test_entry_without_entries_key_is_seeded(self, tmp_path):
+        """A JSON file lacking an ``entries`` key gains one rather than failing."""
+        path = tmp_path / "entries.json"
+        path.write_text(json.dumps({"meta": "no entries key"}))
+        adapter = _generic_adapter(str(path))
+
+        entry_id = await adapter.create_entry(
+            FacilityEntryCreateRequest(subject="Subject", details="Details")
+        )
+
+        data = json.loads(path.read_text())
+        assert [e["id"] for e in data["entries"]] == [entry_id]
+        assert data["meta"] == "no entries key"
+
+
+class TestGenericConvertEntry:
+    """Metadata passthrough and timestamp resolution."""
+
+    def test_optional_metadata_fields_are_carried(self, facility_tz):
+        """Every optional source field lands under its ARIEL metadata key."""
+        adapter = _generic_adapter("/tmp/entries.json")
+
+        entry = adapter._convert_entry(
+            {
+                "id": "1",
+                "timestamp": "2024-01-05T00:00:00Z",
+                "title": "Title",
+                "text": "Body",
+                "books": ["Operations"],
+                "tags": ["rf"],
+                "linked_to": "99",
+                "level": "Warning",
+                "categories": ["RF Systems"],
+                "loto_tag": "LOTO-7",
+                "event_time": "2024-01-05T01:00:00Z",
+                "segment_area": "Booster",
+                "body_format": "markdown",
+                "entrymakers": ["operator"],
+                "num_comments": 0,
+                "needs_attention": False,
+                "metadata": {"custom": "value"},
+            }
+        )
+
+        assert entry["metadata"] == {
+            "title": "Title",
+            "books": ["Operations"],
+            "tags": ["rf"],
+            "linked_to": "99",
+            "level": "Warning",
+            "categories": ["RF Systems"],
+            "loto_tag": "LOTO-7",
+            "event_time": "2024-01-05T01:00:00Z",
+            "segment_area": "Booster",
+            "body_format": "markdown",
+            "entrymakers": ["operator"],
+            "num_comments": 0,
+            "needs_attention": False,
+            "custom": "value",
+        }
+        assert entry["raw_text"] == "Title\n\nBody"
+
+    def test_attachments_carry_optional_fields(self, facility_tz):
+        """Attachment dicts without a url are skipped; the rest keep their extras."""
+        adapter = _generic_adapter("/tmp/entries.json")
+
+        entry = adapter._convert_entry(
+            {
+                "id": "1",
+                "timestamp": "2024-01-05T00:00:00Z",
+                "title": "T",
+                "attachments": [
+                    "not-a-dict",
+                    {"caption": "no url"},
+                    {
+                        "url": "https://logbook.invalid/a.png",
+                        "type": "image/png",
+                        "filename": "a.png",
+                        "thumbnail_url": "https://logbook.invalid/a-thumb.png",
+                        "caption": "Orbit",
+                    },
+                ],
+            }
+        )
+
+        assert entry["attachments"] == [
+            {
+                "url": "https://logbook.invalid/a.png",
+                "type": "image/png",
+                "filename": "a.png",
+                "thumbnail_url": "https://logbook.invalid/a-thumb.png",
+                "caption": "Orbit",
+            }
+        ]
+
+    def test_relative_when_resolves_in_facility_zone(self, facility_tz):
+        """A relative ``when`` resolves to that wall-clock time in the facility zone.
+
+        Seeded demo data uses this so narrative prose citing a clock time stays
+        consistent with the ingested timestamp, whatever day it is ingested.
+        """
+        adapter = _generic_adapter("/tmp/entries.json")
+
+        entry = adapter._convert_entry(
+            {"id": "1", "title": "T", "when": {"days_ago": 2, "time": "13:45:00"}}
+        )
+
+        expected_date = (datetime.now(facility_tz) - timedelta(days=2)).date()
+        assert entry["timestamp"].tzinfo is facility_tz
+        assert entry["timestamp"].date() == expected_date
+        assert entry["timestamp"].strftime("%H:%M:%S") == "13:45:00"
+
+    def test_relative_when_defaults_to_midnight(self, facility_tz):
+        """``when`` without a ``time`` resolves to midnight facility time."""
+        adapter = _generic_adapter("/tmp/entries.json")
+
+        entry = adapter._convert_entry({"id": "1", "title": "T", "when": {"days_ago": 0}})
+
+        assert entry["timestamp"].strftime("%H:%M:%S") == "00:00:00"
+
+    @pytest.mark.parametrize(
+        "days_ago",
+        [-1, True, "3", 1.5, None],
+        ids=["negative", "bool", "string", "float", "none"],
+    )
+    def test_invalid_days_ago_raises(self, facility_tz, days_ago):
+        """``days_ago`` must be a non-negative int; bools are rejected explicitly."""
+        adapter = _generic_adapter("/tmp/entries.json")
+
+        with pytest.raises(ValueError, match="non-negative integer"):
+            adapter._convert_entry(
+                {"id": "1", "title": "T", "when": {"days_ago": days_ago, "time": "01:00:00"}}
+            )
+
+    @pytest.mark.parametrize("time_value", ["25:99", 5, None], ids=["malformed", "int", "none"])
+    def test_invalid_when_time_raises(self, facility_tz, time_value):
+        """``when.time`` must be an 'HH:MM:SS' string."""
+        adapter = _generic_adapter("/tmp/entries.json")
+
+        with pytest.raises(ValueError, match="HH:MM:SS"):
+            adapter._convert_entry(
+                {"id": "1", "title": "T", "when": {"days_ago": 1, "time": time_value}}
+            )
+
+    def test_absolute_timestamp_ignores_the_facility_anchor(self, facility_tz):
+        """An absolute timestamp is parsed verbatim, not shifted toward ``now``."""
+        adapter = _generic_adapter("/tmp/entries.json")
+
+        entry = adapter._convert_entry(
+            {"id": "1", "title": "T", "timestamp": "2024-01-05T06:00:00Z"}
+        )
+
+        assert entry["timestamp"] == datetime(2024, 1, 5, 6, 0, tzinfo=UTC)
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (1704412800, datetime(2024, 1, 5, tzinfo=UTC)),
+            ("1704412800", datetime(2024, 1, 5, tzinfo=UTC)),
+            ("2024-01-05T00:00:00Z", datetime(2024, 1, 5, tzinfo=UTC)),
+            ("2024-01-05T00:00:00+00:00", datetime(2024, 1, 5, tzinfo=UTC)),
+        ],
+        ids=["epoch-int", "epoch-string", "iso-z", "iso-offset"],
+    )
+    def test_parse_timestamp_accepted_formats(self, value, expected):
+        """Epoch numbers, epoch strings, and ISO 8601 (Z or offset) all parse."""
+        adapter = _generic_adapter("/tmp/entries.json")
+
+        assert adapter._parse_timestamp(value) == expected
+
+    @pytest.mark.parametrize("value", ["yesterday", "", None], ids=["prose", "empty", "none"])
+    def test_parse_timestamp_rejects_unparseable(self, value):
+        """Unparseable values raise rather than defaulting, so the entry is dropped."""
+        adapter = _generic_adapter("/tmp/entries.json")
+
+        with pytest.raises(ValueError, match="Cannot parse timestamp"):
+            adapter._parse_timestamp(value)
+
+
+# ---------------------------------------------------------------------------
+# JLab adapter
+# ---------------------------------------------------------------------------
+
+
+class TestJLabAdapter:
+    """Payload shapes, filters, and field tolerance for the JLab adapter."""
+
+    def test_missing_source_url_raises(self):
+        """source_url is mandatory."""
+        with pytest.raises(IngestionError) as exc_info:
+            JLabLogbookAdapter(_config("jlab_logbook", None))
+
+        assert "source_url is required" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"data": {"entries": [{"lognumber": "1", "title": "T"}]}},
+            {"entries": [{"lognumber": "1", "title": "T"}]},
+            [{"lognumber": "1", "title": "T"}],
+        ],
+        ids=["nested-data", "top-level-entries", "bare-list"],
+    )
+    async def test_accepted_payload_shapes(self, tmp_path, payload):
+        """The API has shipped three envelope shapes; all three are read."""
+        path = tmp_path / "entries.json"
+        path.write_text(json.dumps(payload))
+        adapter = _jlab_adapter(str(path))
+
+        entries = await _collect(adapter.fetch_entries())
+
+        assert [e["entry_id"] for e in entries] == ["1"]
+
+    @pytest.mark.asyncio
+    async def test_unrecognised_payload_yields_nothing(self, tmp_path):
+        """A payload of an unknown shape reads as empty rather than raising."""
+        path = tmp_path / "entries.json"
+        path.write_text(json.dumps("just a string"))
+        adapter = _jlab_adapter(str(path))
+
+        assert await _collect(adapter.fetch_entries()) == []
+
+    @pytest.mark.asyncio
+    async def test_books_filter_excludes_other_logbooks(self, tmp_path):
+        """books_filter keeps only entries filed in the configured logbooks."""
+        path = tmp_path / "entries.json"
+        path.write_text(
+            json.dumps(
+                [
+                    {"lognumber": "1", "title": "Ops", "books": ["Operations"]},
+                    {"lognumber": "2", "title": "RF", "books": ["RF"]},
+                    {"lognumber": "3", "title": "Unfiled"},
+                ]
+            )
+        )
+        adapter = _jlab_adapter(str(path))
+        adapter.books_filter = ["Operations"]
+
+        entries = await _collect(adapter.fetch_entries())
+
+        assert [e["entry_id"] for e in entries] == ["1"]
+
+    @pytest.mark.asyncio
+    async def test_since_and_until_bounds_are_exclusive(self, tmp_path):
+        """Entries on either bound are dropped."""
+        path = tmp_path / "entries.json"
+        path.write_text(
+            json.dumps(
+                [
+                    {"lognumber": "early", "created": {"timestamp": "1704067200"}, "title": "e"},
+                    {"lognumber": "middle", "created": {"timestamp": "1704412800"}, "title": "m"},
+                    {"lognumber": "late", "created": {"timestamp": "1704758400"}, "title": "l"},
+                ]
+            )
+        )
+        adapter = _jlab_adapter(str(path))
+
+        entries = await _collect(
+            adapter.fetch_entries(
+                since=datetime(2024, 1, 1, tzinfo=UTC),
+                until=datetime(2024, 1, 9, tzinfo=UTC),
+            )
+        )
+
+        assert [e["entry_id"] for e in entries] == ["middle"]
+
+    @pytest.mark.asyncio
+    async def test_limit_stops_reading(self, tmp_path):
+        """limit truncates the yielded entries."""
+        path = tmp_path / "entries.json"
+        path.write_text(json.dumps([{"lognumber": str(i), "title": f"e{i}"} for i in range(4)]))
+        adapter = _jlab_adapter(str(path))
+
+        entries = await _collect(adapter.fetch_entries(limit=2))
+
+        assert [e["entry_id"] for e in entries] == ["0", "1"]
+
+    @pytest.mark.asyncio
+    async def test_unconvertible_entry_is_logged_and_skipped(self, tmp_path, caplog):
+        """A malformed entry is skipped with a warning; the rest still ingest."""
+        path = tmp_path / "entries.json"
+        path.write_text(json.dumps(["not-a-dict", {"lognumber": "ok", "title": "Fine"}]))
+        adapter = _jlab_adapter(str(path))
+
+        with caplog.at_level(logging.WARNING, logger="ariel"):
+            entries = await _collect(adapter.fetch_entries())
+
+        assert [e["entry_id"] for e in entries] == ["ok"]
+        assert "Failed to convert entry" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_missing_file_raises(self, tmp_path):
+        """A missing local file is an ingestion failure."""
+        adapter = _jlab_adapter(str(tmp_path / "absent.json"))
+
+        with pytest.raises(IngestionError) as exc_info:
+            await adapter._load_data()
+
+        assert "Source file not found" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_http_source_returns_decoded_json(self):
+        """An http(s) source is fetched and decoded as JSON."""
+        adapter = _jlab_adapter("https://logbook.invalid/api/entries")
+        session = _http_session(get=_http_response(json_data={"entries": []}))
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            assert await adapter._load_data() == {"entries": []}
+
+    @pytest.mark.asyncio
+    async def test_http_non_200_raises(self):
+        """Any non-200 status fails the load with the status in the message."""
+        adapter = _jlab_adapter("https://logbook.invalid/api/entries")
+        session = _http_session(get=_http_response(status=500))
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            with pytest.raises(IngestionError) as exc_info:
+                await adapter._load_data()
+
+        assert "status 500" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_missing_aiohttp_raises(self, monkeypatch):
+        """An HTTP source without aiohttp installed fails with a clear message."""
+        adapter = _jlab_adapter("https://logbook.invalid/api/entries")
+        monkeypatch.setitem(sys.modules, "aiohttp", None)
+
+        with pytest.raises(IngestionError) as exc_info:
+            await adapter._load_data()
+
+        assert "aiohttp is required" in str(exc_info.value)
+
+    def test_malformed_created_timestamp_falls_back_to_now(self):
+        """HAZARD: an unparseable created.timestamp silently becomes ingest time."""
+        adapter = _jlab_adapter("/tmp/entries.json")
+
+        entry = adapter._convert_entry(
+            {"lognumber": "1", "created": {"timestamp": "not-an-epoch"}, "title": "T"}
+        )
+
+        assert entry["timestamp"] == entry["created_at"]
+
+    def test_non_dict_created_block_falls_back_to_epoch_zero(self):
+        """A ``created`` block of the wrong type reads as epoch 0, not as an error."""
+        adapter = _jlab_adapter("/tmp/entries.json")
+
+        entry = adapter._convert_entry({"lognumber": "1", "created": "2024-01-05", "title": "T"})
+
+        assert entry["timestamp"] == datetime(1970, 1, 1, tzinfo=UTC)
+
+    def test_missing_lognumber_and_id_yields_empty_entry_id(self):
+        """HAZARD: with neither lognumber nor id the entry_id is '' — one shared row.
+
+        ``enhanced_entries`` upserts ``ON CONFLICT (entry_id)``, so every id-less
+        entry collapses onto the same row.
+        """
+        adapter = _jlab_adapter("/tmp/entries.json")
+
+        assert adapter._convert_entry({"title": "T"})["entry_id"] == ""
+        assert adapter._convert_entry({"id": "99", "title": "T"})["entry_id"] == "99"
+
+    def test_title_only_entry_keeps_its_title(self):
+        """With no body content the title alone becomes the searchable text."""
+        adapter = _jlab_adapter("/tmp/entries.json")
+
+        entry = adapter._convert_entry({"lognumber": "1", "title": "Title only"})
+
+        assert entry["raw_text"] == "Title only"
+
+    def test_optional_metadata_fields_are_carried(self):
+        """Body format, entrymakers, comment count, and the attention flag survive."""
+        adapter = _jlab_adapter("/tmp/entries.json")
+
+        entry = adapter._convert_entry(
+            {
+                "lognumber": "1",
+                "title": "Title",
+                "body": {"content": "Body", "format": "html"},
+                "books": ["Operations"],
+                "tags": ["rf"],
+                "entrymakers": ["operator"],
+                "numComments": 0,
+                "needsAttention": False,
+                "metadata": {"custom": "value"},
+            }
+        )
+
+        assert entry["metadata"] == {
+            "title": "Title",
+            "books": ["Operations"],
+            "tags": ["rf"],
+            "body_format": "html",
+            "entrymakers": ["operator"],
+            "num_comments": 0,
+            "needs_attention": False,
+            "custom": "value",
+        }
+
+    def test_attachment_transform_skips_unusable_entries(self):
+        """Non-dicts and url-less dicts are dropped; thumbnails and captions kept."""
+        adapter = _jlab_adapter("/tmp/entries.json")
+
+        result = adapter._transform_attachments(
+            [
+                "not-a-dict",
+                {"type": "image/png"},
+                {
+                    "url": "https://logbook.invalid/img/a.png",
+                    "type": "image/png",
+                    "thumbnail": "https://logbook.invalid/img/a-thumb.png",
+                    "caption": "Orbit",
+                },
+                {"url": "bare-name.txt"},
+            ]
+        )
+
+        assert result == [
+            {
+                "url": "https://logbook.invalid/img/a.png",
+                "type": "image/png",
+                "filename": "a.png",
+                "thumbnail_url": "https://logbook.invalid/img/a-thumb.png",
+                "caption": "Orbit",
+            },
+            {"url": "bare-name.txt", "type": None, "filename": "bare-name.txt"},
+        ]
+
+    def test_thumbnails_can_be_disabled(self):
+        """include_thumbnails=False drops the thumbnail URL from the attachment."""
+        adapter = _jlab_adapter("/tmp/entries.json")
+        adapter.include_thumbnails = False
+
+        result = adapter._transform_attachments(
+            [{"url": "https://logbook.invalid/a.png", "thumbnail": "https://x.invalid/t.png"}]
+        )
+
+        assert "thumbnail_url" not in result[0]
+
+
+# ---------------------------------------------------------------------------
+# ORNL adapter
+# ---------------------------------------------------------------------------
+
+
+class TestORNLAdapter:
+    """Payload shapes, filters, timestamps, and attachment headers for ORNL."""
+
+    def test_missing_source_url_raises(self):
+        """source_url is mandatory."""
+        with pytest.raises(IngestionError) as exc_info:
+            ORNLLogbookAdapter(_config("ornl_logbook", None))
+
+        assert "source_url is required" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "payload",
+        [{"entries": [{"ID": "1", "title": "T"}]}, [{"ID": "1", "title": "T"}]],
+        ids=["entries-envelope", "bare-list"],
+    )
+    async def test_accepted_payload_shapes(self, tmp_path, payload):
+        """Both the enveloped and bare-list exports are read."""
+        path = tmp_path / "entries.json"
+        path.write_text(json.dumps(payload))
+        adapter = _ornl_adapter(str(path))
+
+        entries = await _collect(adapter.fetch_entries())
+
+        assert [e["entry_id"] for e in entries] == ["1"]
+
+    @pytest.mark.asyncio
+    async def test_unrecognised_payload_yields_nothing(self, tmp_path):
+        """A payload of an unknown shape reads as empty rather than raising."""
+        path = tmp_path / "entries.json"
+        path.write_text(json.dumps({"unexpected": "shape"}))
+        adapter = _ornl_adapter(str(path))
+
+        assert await _collect(adapter.fetch_entries()) == []
+
+    @pytest.mark.asyncio
+    async def test_logbooks_filter_excludes_other_logbooks(self, tmp_path):
+        """logbooks_filter keeps only entries filed in the configured logbooks."""
+        path = tmp_path / "entries.json"
+        path.write_text(
+            json.dumps(
+                [
+                    {"ID": "1", "title": "Ops", "logbook": "Operations"},
+                    {"ID": "2", "title": "RF", "logbook": "RF"},
+                    {"ID": "3", "title": "Unfiled"},
+                ]
+            )
+        )
+        adapter = _ornl_adapter(str(path))
+        adapter.logbooks_filter = ["Operations"]
+
+        entries = await _collect(adapter.fetch_entries())
+
+        assert [e["entry_id"] for e in entries] == ["1"]
+
+    @pytest.mark.asyncio
+    async def test_since_and_until_bounds_are_exclusive(self, tmp_path):
+        """Entries on either bound are dropped."""
+        path = tmp_path / "entries.json"
+        path.write_text(
+            json.dumps(
+                [
+                    {"ID": "early", "entry_time": "2024-01-01T00:00:00Z", "title": "e"},
+                    {"ID": "middle", "entry_time": "2024-01-05T00:00:00Z", "title": "m"},
+                    {"ID": "late", "entry_time": "2024-01-09T00:00:00Z", "title": "l"},
+                ]
+            )
+        )
+        adapter = _ornl_adapter(str(path))
+
+        entries = await _collect(
+            adapter.fetch_entries(
+                since=datetime(2024, 1, 1, tzinfo=UTC),
+                until=datetime(2024, 1, 9, tzinfo=UTC),
+            )
+        )
+
+        assert [e["entry_id"] for e in entries] == ["middle"]
+
+    @pytest.mark.asyncio
+    async def test_limit_stops_reading(self, tmp_path):
+        """limit truncates the yielded entries."""
+        path = tmp_path / "entries.json"
+        path.write_text(json.dumps([{"ID": str(i), "title": f"e{i}"} for i in range(4)]))
+        adapter = _ornl_adapter(str(path))
+
+        entries = await _collect(adapter.fetch_entries(limit=2))
+
+        assert [e["entry_id"] for e in entries] == ["0", "1"]
+
+    @pytest.mark.asyncio
+    async def test_unconvertible_entry_is_logged_and_skipped(self, tmp_path, caplog):
+        """A malformed entry is skipped with a warning; the rest still ingest."""
+        path = tmp_path / "entries.json"
+        path.write_text(json.dumps(["not-a-dict", {"ID": "ok", "title": "Fine"}]))
+        adapter = _ornl_adapter(str(path))
+
+        with caplog.at_level(logging.WARNING, logger="ariel"):
+            entries = await _collect(adapter.fetch_entries())
+
+        assert [e["entry_id"] for e in entries] == ["ok"]
+        assert "Failed to convert entry" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_missing_file_raises(self, tmp_path):
+        """A missing local file is an ingestion failure."""
+        adapter = _ornl_adapter(str(tmp_path / "absent.json"))
+
+        with pytest.raises(IngestionError) as exc_info:
+            await adapter._load_data()
+
+        assert "Source file not found" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_http_source_returns_decoded_json(self):
+        """An http(s) source is fetched and decoded as JSON."""
+        adapter = _ornl_adapter("https://logbook.invalid/api/entries")
+        session = _http_session(get=_http_response(json_data=[{"ID": "1"}]))
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            assert await adapter._load_data() == [{"ID": "1"}]
+
+    @pytest.mark.asyncio
+    async def test_http_non_200_raises(self):
+        """Any non-200 status fails the load with the status in the message."""
+        adapter = _ornl_adapter("https://logbook.invalid/api/entries")
+        session = _http_session(get=_http_response(status=404))
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            with pytest.raises(IngestionError) as exc_info:
+                await adapter._load_data()
+
+        assert "status 404" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_missing_aiohttp_raises(self, monkeypatch):
+        """An HTTP source without aiohttp installed fails with a clear message."""
+        adapter = _ornl_adapter("https://logbook.invalid/api/entries")
+        monkeypatch.setitem(sys.modules, "aiohttp", None)
+
+        with pytest.raises(IngestionError) as exc_info:
+            await adapter._load_data()
+
+        assert "aiohttp is required" in str(exc_info.value)
+
+    def test_missing_entry_time_falls_back_to_now(self):
+        """An entry with no entry_time is dated at ingest time."""
+        adapter = _ornl_adapter("/tmp/entries.json")
+
+        entry = adapter._convert_entry({"ID": "1", "title": "T"})
+
+        assert entry["timestamp"] == entry["created_at"]
+
+    def test_missing_id_yields_empty_entry_id(self):
+        """HAZARD: with neither ID nor id the entry_id is '' — one shared row.
+
+        ``enhanced_entries`` upserts ``ON CONFLICT (entry_id)``, so every id-less
+        entry collapses onto the same row.
+        """
+        adapter = _ornl_adapter("/tmp/entries.json")
+
+        assert adapter._convert_entry({"title": "T"})["entry_id"] == ""
+        assert adapter._convert_entry({"id": "99", "title": "T"})["entry_id"] == "99"
+
+    def test_title_only_entry_keeps_its_title(self):
+        """With no content the title alone becomes the searchable text."""
+        adapter = _ornl_adapter("/tmp/entries.json")
+
+        assert adapter._convert_entry({"ID": "1", "title": "Title only"})["raw_text"] == (
+            "Title only"
+        )
+
+    def test_optional_metadata_fields_are_carried(self):
+        """Area, reference, attachment headers, and explicit metadata all survive."""
+        adapter = _ornl_adapter("/tmp/entries.json")
+
+        entry = adapter._convert_entry(
+            {
+                "ID": "1",
+                "title": "Title",
+                "content": "Body",
+                "entry_time": "2024-01-05T00:00:00Z",
+                "event_time": "2024-01-05T01:00:00Z",
+                "logbook": "Operations",
+                "segment/area": "Booster",
+                "reference": "99",
+                "attachment_header": ["a.png", "b.png"],
+                "metadata": {"custom": "value"},
+            }
+        )
+
+        assert entry["metadata"] == {
+            "title": "Title",
+            "books": ["Operations"],
+            "segment_area": "Booster",
+            "event_time": "2024-01-05T01:00:00+00:00",
+            "linked_to": "99",
+            "attachment_headers": ["a.png", "b.png"],
+            "custom": "value",
+        }
+
+    def test_logbook_list_and_single_attachment_header(self):
+        """A list logbook is kept as-is; a lone attachment header is wrapped."""
+        adapter = _ornl_adapter("/tmp/entries.json")
+
+        entry = adapter._convert_entry(
+            {
+                "ID": "1",
+                "title": "T",
+                "logbook": ["Operations", "RF"],
+                "attachment_header": "only.png",
+            }
+        )
+
+        assert entry["metadata"]["books"] == ["Operations", "RF"]
+        assert entry["metadata"]["attachment_headers"] == ["only.png"]
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (1704412800, datetime(2024, 1, 5, tzinfo=UTC)),
+            ("1704412800", datetime(2024, 1, 5, tzinfo=UTC)),
+            ("2024-01-05T00:00:00Z", datetime(2024, 1, 5, tzinfo=UTC)),
+            ("2024-01-05T00:00:00+00:00", datetime(2024, 1, 5, tzinfo=UTC)),
+        ],
+        ids=["epoch-int", "epoch-string", "iso-z", "iso-offset"],
+    )
+    def test_parse_timestamp_accepted_formats(self, value, expected):
+        """Epoch numbers, epoch strings, and ISO 8601 (Z or offset) all parse."""
+        adapter = _ornl_adapter("/tmp/entries.json")
+
+        assert adapter._parse_timestamp(value) == expected
+
+    @pytest.mark.parametrize("value", ["yesterday", None], ids=["prose", "none"])
+    def test_parse_timestamp_falls_back_to_now(self, value):
+        """HAZARD: ORNL defaults an unparseable timestamp to now instead of raising.
+
+        Unlike the generic adapter — which raises and loses the entry — ORNL keeps
+        the entry and misdates it to the moment of the ingest run.
+        """
+        adapter = _ornl_adapter("/tmp/entries.json")
+
+        before = datetime.now(UTC)
+        parsed = adapter._parse_timestamp(value)
+
+        assert before <= parsed <= datetime.now(UTC)
+
+    def test_attachment_flag_without_urls_uses_headers(self):
+        """``attachment: "Y"`` with no attachment list yields url-less placeholders.
+
+        ORNL's export names the files but not their locations, so the filename is
+        preserved and the URL left empty rather than the attachment being dropped.
+        """
+        adapter = _ornl_adapter("/tmp/entries.json")
+
+        result = adapter._transform_attachments(
+            {"attachment": "Y", "attachment_header": ["a.png", "b.png"]}
+        )
+
+        assert result == [
+            {"url": "", "filename": "a.png", "type": None},
+            {"url": "", "filename": "b.png", "type": None},
+        ]
+
+    def test_attachment_flag_with_single_header(self):
+        """A lone header string is wrapped into one placeholder attachment."""
+        adapter = _ornl_adapter("/tmp/entries.json")
+
+        result = adapter._transform_attachments({"attachment": "Y", "attachment_header": "a.png"})
+
+        assert result == [{"url": "", "filename": "a.png", "type": None}]
+
+    def test_attachment_list_skips_non_dicts(self):
+        """A real attachment list is transformed, with non-dict members skipped."""
+        adapter = _ornl_adapter("/tmp/entries.json")
+
+        result = adapter._transform_attachments(
+            {
+                "attachments": [
+                    "not-a-dict",
+                    {"url": "https://logbook.invalid/a.png", "type": "image/png"},
+                ]
+            }
+        )
+
+        assert result == [
+            {"url": "https://logbook.invalid/a.png", "type": "image/png", "filename": None}
+        ]

--- a/tests/services/ariel_search/test_repository_unit.py
+++ b/tests/services/ariel_search/test_repository_unit.py
@@ -1,0 +1,1107 @@
+"""Unit tests for :class:`ARIELRepository`, driven by the fake connection pool.
+
+These tests assert on what the repository *emits* -- the SQL text, the bound
+parameters, and the exception it raises when a query fails -- never on a
+database outcome. Ordering, ranking, jsonb merge semantics and index behaviour
+are the container-backed integration suite's job; pinning them here would only
+pin the fake.
+
+The error-wrap suite is the reason this file exists in bulk: nearly every
+repository method ends in the same ``except Exception -> DatabaseQueryError``
+shape, and the ``query=`` breadcrumb it attaches is the only thing that tells an
+operator reading a log which statement died. The parametrized case below pins
+one breadcrumb per method, and the two methods that deviate from the shape get
+their own cases.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from osprey.services.ariel_search.config import ARIELConfig
+from osprey.services.ariel_search.database.repository import ARIELRepository
+from osprey.services.ariel_search.exceptions import (
+    ConfigurationError,
+    DatabaseQueryError,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**overrides: Any) -> ARIELConfig:
+    """Config with every search and enhancement module the repository gates on."""
+    data: dict[str, Any] = {
+        "database": {"uri": "postgresql://unit-test/ariel"},
+        "search_modules": {
+            "keyword": {"enabled": True},
+            "semantic": {"enabled": True, "model": "nomic-embed-text"},
+        },
+        "enhancement_modules": {
+            "text_embedding": {
+                "enabled": True,
+                "models": [{"name": "nomic-embed-text", "dimension": 768}],
+            },
+            "semantic_processor": {"enabled": True},
+        },
+    }
+    data.update(overrides)
+    return ARIELConfig.from_dict(data)
+
+
+def _entry_row(**overrides: Any) -> dict[str, Any]:
+    """One ``dict_row`` row shaped like ``enhanced_entries``."""
+    now = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
+    row: dict[str, Any] = {
+        "entry_id": "e-1",
+        "source_system": "als_logbook",
+        "timestamp": now,
+        "author": "operator",
+        "raw_text": "beam lost at 03:04",
+        "attachments": [],
+        "metadata": {},
+        "created_at": now,
+        "updated_at": now,
+    }
+    row.update(overrides)
+    return row
+
+
+def _sql_body(sql: str) -> str:
+    """SQL with ``--`` comments dropped and whitespace collapsed.
+
+    The upsert statement carries a long explanatory comment; assertions target
+    the executable text so a reworded comment never passes or fails a test.
+    """
+    lines = [line.split("--", 1)[0] for line in sql.splitlines()]
+    return " ".join(" ".join(lines).split())
+
+
+# ---------------------------------------------------------------------------
+# Error wrapping
+# ---------------------------------------------------------------------------
+
+#: ``(method label, coroutine factory, expected ``query=`` breadcrumb)``.
+ERROR_WRAP_CASES = [
+    pytest.param(
+        lambda r: r.get_entry("e-1"),
+        "SELECT entry_id=e-1",
+        id="get_entry",
+    ),
+    pytest.param(
+        lambda r: r.get_entries_by_ids(["e-1", "e-2"]),
+        "SELECT entry_ids=ANY([2 ids])",
+        id="get_entries_by_ids",
+    ),
+    pytest.param(
+        lambda r: r.upsert_entry(
+            {
+                "entry_id": "e-1",
+                "source_system": "als_logbook",
+                "timestamp": datetime(2026, 1, 2, tzinfo=UTC),
+                "raw_text": "text",
+            }
+        ),
+        "UPSERT entry_id=e-1",
+        id="upsert_entry",
+    ),
+    pytest.param(
+        lambda r: r.search_by_time_range(),
+        "SELECT time_range=(None, None)",
+        id="search_by_time_range",
+    ),
+    pytest.param(
+        lambda r: r.count_entries(),
+        "SELECT COUNT(*)",
+        id="count_entries",
+    ),
+    pytest.param(
+        lambda r: r.get_distinct_authors(),
+        "SELECT DISTINCT author",
+        id="get_distinct_authors",
+    ),
+    pytest.param(
+        lambda r: r.get_distinct_source_systems(),
+        "SELECT DISTINCT source_system",
+        id="get_distinct_source_systems",
+    ),
+    pytest.param(
+        lambda r: r.store_attachment("e-1", "a-1", "shot.png", "image/png", b"data", 4),
+        "INSERT attachment_files attachment_id=a-1",
+        id="store_attachment",
+    ),
+    pytest.param(
+        lambda r: r.get_attachment("a-1"),
+        "SELECT attachment_id=a-1",
+        id="get_attachment",
+    ),
+    pytest.param(
+        lambda r: r.get_attachments_for_entry("e-1"),
+        "SELECT attachments entry_id=e-1",
+        id="get_attachments_for_entry",
+    ),
+    pytest.param(
+        lambda r: r.get_incomplete_entries(module_name="text_embedding"),
+        "SELECT incomplete module=text_embedding",
+        id="get_incomplete_entries",
+    ),
+    pytest.param(
+        lambda r: r.get_enhancement_stats(),
+        "SELECT enhancement_stats",
+        id="get_enhancement_stats",
+    ),
+    pytest.param(
+        lambda r: r.mark_enhancement_complete("e-1", "text_embedding"),
+        "UPDATE entry_id=e-1 module=text_embedding",
+        id="mark_enhancement_complete",
+    ),
+    pytest.param(
+        lambda r: r.mark_enhancement_failed("e-1", "text_embedding", "nope"),
+        "UPDATE entry_id=e-1 module=text_embedding",
+        id="mark_enhancement_failed",
+    ),
+    pytest.param(
+        lambda r: r.get_embedding_tables(),
+        "SELECT embedding tables",
+        id="get_embedding_tables",
+    ),
+    pytest.param(
+        lambda r: r.validate_search_model_table("nomic-embed-text"),
+        "SELECT table exists text_embeddings_nomic_embed_text",
+        id="validate_search_model_table",
+    ),
+    pytest.param(
+        lambda r: r.store_text_embedding("e-1", [0.1, 0.2], "nomic-embed-text"),
+        "INSERT text_embeddings_nomic_embed_text entry_id=e-1",
+        id="store_text_embedding",
+    ),
+    pytest.param(
+        lambda r: r.keyword_search([], [], "quench"),
+        "KEYWORD SEARCH: quench",
+        id="keyword_search",
+    ),
+    pytest.param(
+        lambda r: r.fuzzy_search("quench"),
+        "FUZZY SEARCH: quench",
+        id="fuzzy_search",
+    ),
+    pytest.param(
+        lambda r: r.semantic_search([0.1, 0.2], "nomic-embed-text"),
+        "SEMANTIC SEARCH model=nomic-embed-text",
+        id="semantic_search",
+    ),
+    pytest.param(
+        lambda r: r.start_ingestion_run("als_logbook"),
+        "INSERT ingestion_runs",
+        id="start_ingestion_run",
+    ),
+    pytest.param(
+        lambda r: r.complete_ingestion_run(7, 1, 2, 3),
+        "UPDATE ingestion_runs id=7",
+        id="complete_ingestion_run",
+    ),
+    pytest.param(
+        lambda r: r.fail_ingestion_run(7, "boom"),
+        "UPDATE ingestion_runs id=7",
+        id="fail_ingestion_run",
+    ),
+    pytest.param(
+        lambda r: r.get_last_successful_run("als_logbook"),
+        "SELECT MAX(completed_at) source_system=als_logbook",
+        id="get_last_successful_run",
+    ),
+]
+
+
+class TestErrorWrapping:
+    """Every query method turns a driver failure into DatabaseQueryError."""
+
+    @pytest.mark.parametrize(("call", "expected_query"), ERROR_WRAP_CASES)
+    async def test_driver_failure_becomes_database_query_error(
+        self,
+        fake_pool_factory,
+        call,
+        expected_query: str,
+    ) -> None:
+        """A failed query is wrapped with the breadcrumb naming what was run.
+
+        ``DatabaseQueryError.technical_details["query"]`` is the only record of
+        *which* statement failed once the psycopg exception has been swallowed,
+        so each method's breadcrumb is pinned individually. The original
+        exception must stay chained -- dropping ``from e`` would leave an
+        operator with a message and no traceback into the driver.
+        """
+        driver_error = RuntimeError("connection reset by peer")
+        repo = ARIELRepository(fake_pool_factory(error=driver_error), _make_config())
+
+        with pytest.raises(DatabaseQueryError) as exc_info:
+            await call(repo)
+
+        assert exc_info.value.technical_details["query"] == expected_query
+        assert "connection reset by peer" in exc_info.value.message
+        assert exc_info.value.__cause__ is driver_error
+
+    async def test_validate_search_model_table_reraises_configuration_error(
+        self,
+        fake_pool_factory,
+    ) -> None:
+        """A missing embedding table stays a ConfigurationError, not a query error.
+
+        Deviant from the shared shape: the ``except ConfigurationError: raise``
+        arm sits ahead of the generic wrap. Without it the actionable
+        "run 'osprey ariel migrate'" message would be reboxed as a database
+        failure and read as a transient outage.
+        """
+        repo = ARIELRepository(fake_pool_factory(results=[[(False,)]]), _make_config())
+
+        with pytest.raises(ConfigurationError) as exc_info:
+            await repo.validate_search_model_table("nomic-embed-text")
+
+        assert exc_info.value.technical_details["config_key"] == "search_modules.semantic.model"
+        assert "text_embeddings_nomic_embed_text" in exc_info.value.message
+        assert "osprey ariel migrate" in exc_info.value.message
+
+    async def test_validate_search_model_table_treats_missing_row_as_absent(
+        self,
+        fake_pool_factory,
+    ) -> None:
+        """No row back from the EXISTS probe is read as "table absent"."""
+        repo = ARIELRepository(fake_pool_factory(results=[[]]), _make_config())
+
+        with pytest.raises(ConfigurationError):
+            await repo.validate_search_model_table("nomic-embed-text")
+
+    async def test_validate_search_model_table_passes_when_table_exists(
+        self,
+        fake_pool_factory,
+    ) -> None:
+        """An existing table validates silently and probes by table name."""
+        pool = fake_pool_factory(results=[[(True,)]])
+        repo = ARIELRepository(pool, _make_config())
+
+        await repo.validate_search_model_table("nomic-embed-text")
+
+        assert pool.calls[0][1] == ["text_embeddings_nomic_embed_text"]
+
+    async def test_start_ingestion_run_reraises_its_own_query_error(
+        self,
+        fake_pool_factory,
+    ) -> None:
+        """The "no ID returned" DatabaseQueryError passes through unwrapped.
+
+        Deviant from the shared shape: the method raises DatabaseQueryError from
+        inside its own ``try``, so it needs ``except DatabaseQueryError: raise``
+        ahead of the generic arm. Without it the specific message would be
+        wrapped into a second, vaguer one naming an exception instead of the
+        missing RETURNING row.
+        """
+        repo = ARIELRepository(fake_pool_factory(results=[[]]), _make_config())
+
+        with pytest.raises(DatabaseQueryError) as exc_info:
+            await repo.start_ingestion_run("als_logbook")
+
+        assert exc_info.value.message == "Failed to start ingestion run: no ID returned"
+        assert exc_info.value.__cause__ is None
+
+    async def test_health_check_reports_failure_instead_of_raising(
+        self,
+        fake_pool_factory,
+    ) -> None:
+        """health_check is the one method that returns its failure.
+
+        It backs a status endpoint, so an unreachable database has to come back
+        as ``(False, message)``; raising would turn a red health tile into a 500.
+        """
+        repo = ARIELRepository(fake_pool_factory(error=RuntimeError("no route")), _make_config())
+
+        healthy, message = await repo.health_check()
+
+        assert healthy is False
+        assert message == "Database unreachable: no route"
+
+    async def test_health_check_probes_with_select_1(self, fake_pool) -> None:
+        """A reachable database answers healthy after a trivial probe."""
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        assert await repo.health_check() == (True, "Database connected")
+        assert fake_pool.sql == ["SELECT 1"]
+
+
+# ---------------------------------------------------------------------------
+# Re-ingest hazards (upsert_entry)
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertEntryReingestHazards:
+    """The ON CONFLICT clause is re-ingestion's only data-loss guard."""
+
+    @staticmethod
+    def _update_clause(pool) -> str:
+        sql = _sql_body(pool.sql[0])
+        assert "ON CONFLICT (entry_id) DO UPDATE SET" in sql
+        return sql.split("DO UPDATE SET", 1)[1]
+
+    async def test_upstream_owned_columns_are_overwritten_unconditionally(
+        self,
+        fake_pool,
+        seed_entry_factory,
+    ) -> None:
+        """Pins the unconditional overwrite set in ON CONFLICT DO UPDATE.
+
+        Hazard: a re-ingestion poll re-fetches entries that already exist, and
+        those five columns are upstream's to own. If one is dropped from the
+        DO UPDATE set, an entry edited in the source logbook silently stays
+        frozen at whatever ARIEL first saw, with no error anywhere.
+        """
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        await repo.upsert_entry(seed_entry_factory())
+
+        update_clause = self._update_clause(fake_pool)
+        for column in ("source_system", "timestamp", "author", "raw_text", "metadata"):
+            assert f"{column} = EXCLUDED.{column}" in update_clause
+
+    async def test_empty_incoming_attachments_preserve_stored_ones(
+        self,
+        fake_pool,
+        seed_entry_factory,
+    ) -> None:
+        """Pins the ``'[]'::jsonb`` CASE that protects ARIEL-native attachments.
+
+        Hazard: the upstream write API cannot accept file uploads, so an entry
+        published by ARIEL comes back from the next poll with
+        ``attachments = '[]'::jsonb``. Collapsing the CASE into a plain
+        ``attachments = EXCLUDED.attachments`` erases web-uploaded attachments
+        and orphans their stored blobs -- unrecoverable, and invisible until
+        someone opens the entry.
+        """
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        await repo.upsert_entry(seed_entry_factory(attachments=[]))
+
+        update_clause = self._update_clause(fake_pool)
+        assert (
+            "attachments = CASE WHEN EXCLUDED.attachments = '[]'::jsonb "
+            "THEN enhanced_entries.attachments ELSE EXCLUDED.attachments END" in update_clause
+        )
+        assert "attachments = EXCLUDED.attachments" not in update_clause
+
+    async def test_enhancement_status_is_absent_from_the_update_set(
+        self,
+        fake_pool,
+        seed_entry_factory,
+    ) -> None:
+        """Pins enhancement_status's absence from ON CONFLICT DO UPDATE.
+
+        Hazard: the column is written on INSERT but must never be re-written on
+        conflict. Adding it to the DO UPDATE set would reset every module on an
+        already-enhanced entry back to the incoming (usually empty) status on
+        each poll, silently re-queueing the whole corpus for re-enhancement.
+        """
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        await repo.upsert_entry(seed_entry_factory(enhancement_status={"text_embedding": {}}))
+
+        sql = _sql_body(fake_pool.sql[0])
+        insert_clause, update_clause = sql.split("DO UPDATE SET", 1)
+        assert "enhancement_status" in insert_clause
+        assert "enhancement_status" not in update_clause
+
+    async def test_json_columns_are_serialized_in_column_order(
+        self,
+        fake_pool,
+        seed_entry_factory,
+    ) -> None:
+        """The three jsonb columns are bound as JSON text, positionally."""
+        entry = seed_entry_factory(
+            attachments=[{"url": "http://logbook.invalid/a.png"}],
+            metadata={"logbook": "operations"},
+            enhancement_status={"text_embedding": {"status": "complete"}},
+        )
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        await repo.upsert_entry(entry)
+
+        params = fake_pool.calls[0][1]
+        assert params[:5] == [
+            entry["entry_id"],
+            entry["source_system"],
+            entry["timestamp"],
+            entry["author"],
+            entry["raw_text"],
+        ]
+        assert params[5] == json.dumps(entry["attachments"])
+        assert params[6] == json.dumps(entry["metadata"])
+        assert params[7] == json.dumps(entry["enhancement_status"])
+
+    async def test_missing_optional_fields_fall_back_to_empty(
+        self,
+        fake_pool,
+    ) -> None:
+        """An entry without author/attachments/metadata still binds every slot."""
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        await repo.upsert_entry(
+            {
+                "entry_id": "e-1",
+                "source_system": "als_logbook",
+                "timestamp": datetime(2026, 1, 2, tzinfo=UTC),
+                "raw_text": "text",
+            }
+        )
+
+        params = fake_pool.calls[0][1]
+        assert params[3] == ""
+        assert params[5:] == ["[]", "{}", "{}"]
+
+
+# ---------------------------------------------------------------------------
+# Entry reads
+# ---------------------------------------------------------------------------
+
+
+class TestEntryReads:
+    """get_entry / get_entries_by_ids / search_by_time_range / count_entries."""
+
+    async def test_get_entry_returns_converted_row(self, fake_pool_factory) -> None:
+        """A found row is converted to an EnhancedLogbookEntry."""
+        pool = fake_pool_factory(results=[[_entry_row(entry_id="e-42")]])
+        repo = ARIELRepository(pool, _make_config())
+
+        entry = await repo.get_entry("e-42")
+
+        assert entry is not None
+        assert entry["entry_id"] == "e-42"
+        assert pool.calls[0] == (
+            "SELECT * FROM enhanced_entries WHERE entry_id = %s",
+            ["e-42"],
+        )
+
+    async def test_get_entry_returns_none_when_absent(self, fake_pool) -> None:
+        """No row means None, not an exception."""
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        assert await repo.get_entry("missing") is None
+
+    async def test_get_entries_by_ids_short_circuits_on_empty_input(self, fake_pool) -> None:
+        """An empty id list returns [] without opening a connection.
+
+        Hazard: ``= ANY(%s)`` with an empty array is a full-table scan waiting
+        to happen on the caller's next refactor; the guard keeps the degenerate
+        case off the database entirely.
+        """
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        assert await repo.get_entries_by_ids([]) == []
+        assert fake_pool.calls == []
+
+    async def test_get_entries_by_ids_returns_all_found_rows(self, fake_pool_factory) -> None:
+        """Ids are bound as one array parameter."""
+        rows = [_entry_row(entry_id="e-1"), _entry_row(entry_id="e-2")]
+        pool = fake_pool_factory(results=[rows])
+        repo = ARIELRepository(pool, _make_config())
+
+        entries = await repo.get_entries_by_ids(["e-1", "e-2", "gone"])
+
+        assert [e["entry_id"] for e in entries] == ["e-1", "e-2"]
+        assert pool.calls[0][1] == [["e-1", "e-2", "gone"]]
+
+    async def test_search_by_time_range_without_filters_uses_true(self, fake_pool) -> None:
+        """No filters means ``WHERE TRUE``, with only limit and offset bound."""
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        assert await repo.search_by_time_range(limit=25, offset=50) == []
+
+        sql, params = fake_pool.calls[0]
+        assert "WHERE TRUE" in _sql_body(sql)
+        assert params == [25, 50]
+
+    async def test_search_by_time_range_appends_each_filter(self, fake_pool_factory) -> None:
+        """Filters are ANDed in declaration order, ahead of limit/offset."""
+        start = datetime(2026, 1, 1, tzinfo=UTC)
+        end = datetime(2026, 2, 1, tzinfo=UTC)
+        pool = fake_pool_factory(results=[[_entry_row()]])
+        repo = ARIELRepository(pool, _make_config())
+
+        entries = await repo.search_by_time_range(
+            start=start,
+            end=end,
+            limit=10,
+            offset=0,
+            author="operator",
+            source_system="als_logbook",
+        )
+
+        assert len(entries) == 1
+        sql, params = pool.calls[0]
+        assert (
+            "WHERE timestamp >= %s AND timestamp <= %s AND author = %s AND source_system = %s"
+            in _sql_body(sql)
+        )
+        assert params == [start, end, "operator", "als_logbook", 10, 0]
+
+    async def test_count_entries_without_filters(self, fake_pool_factory) -> None:
+        """An unfiltered count binds no parameters."""
+        pool = fake_pool_factory(results=[[(17,)]])
+        repo = ARIELRepository(pool, _make_config())
+
+        assert await repo.count_entries() == 17
+        assert pool.calls[0] == ("SELECT COUNT(*) FROM enhanced_entries WHERE TRUE", [])
+
+    async def test_count_entries_mirrors_search_filters(self, fake_pool_factory) -> None:
+        """The count applies the same filters as ``search_by_time_range``.
+
+        Hazard: the two must stay in step -- a paginated listing derives
+        ``total_pages`` from this count, so a filter honoured by one and not the
+        other yields pages that render empty.
+        """
+        start = datetime(2026, 1, 1, tzinfo=UTC)
+        end = datetime(2026, 2, 1, tzinfo=UTC)
+        pool = fake_pool_factory(results=[[(3,)]])
+        repo = ARIELRepository(pool, _make_config())
+
+        total = await repo.count_entries(
+            start=start,
+            end=end,
+            author="operator",
+            source_system="als_logbook",
+        )
+
+        assert total == 3
+        sql, params = pool.calls[0]
+        assert (
+            "WHERE timestamp >= %s AND timestamp <= %s AND author = %s AND source_system = %s"
+            in _sql_body(sql)
+        )
+        assert params == [start, end, "operator", "als_logbook"]
+
+    async def test_count_entries_returns_zero_without_a_row(self, fake_pool) -> None:
+        """A missing count row reads as zero rather than raising."""
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        assert await repo.count_entries() == 0
+
+    async def test_get_distinct_authors_flattens_rows(self, fake_pool_factory) -> None:
+        """Distinct authors come back as a flat list of strings."""
+        pool = fake_pool_factory(results=[[("alice",), ("bob",)]])
+        repo = ARIELRepository(pool, _make_config())
+
+        assert await repo.get_distinct_authors() == ["alice", "bob"]
+        assert "SELECT DISTINCT author FROM enhanced_entries" in _sql_body(pool.sql[0])
+
+    async def test_get_distinct_source_systems_flattens_rows(self, fake_pool_factory) -> None:
+        """Distinct source systems come back as a flat list of strings."""
+        pool = fake_pool_factory(results=[[("als_logbook",)]])
+        repo = ARIELRepository(pool, _make_config())
+
+        assert await repo.get_distinct_source_systems() == ["als_logbook"]
+        assert "SELECT DISTINCT source_system FROM enhanced_entries" in _sql_body(pool.sql[0])
+
+
+# ---------------------------------------------------------------------------
+# Attachments
+# ---------------------------------------------------------------------------
+
+
+class TestAttachments:
+    """Attachment blobs live in their own table, keyed by attachment_id."""
+
+    async def test_store_attachment_binds_columns_in_order(self, fake_pool) -> None:
+        """The INSERT binds (attachment_id, entry_id, filename, mime, data, size)."""
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        await repo.store_attachment(
+            entry_id="e-1",
+            attachment_id="a-1",
+            filename="shot.png",
+            mime_type="image/png",
+            data=b"\x89PNG",
+            size_bytes=4,
+        )
+
+        sql, params = fake_pool.calls[0]
+        assert "INSERT INTO attachment_files" in _sql_body(sql)
+        assert params == ["a-1", "e-1", "shot.png", "image/png", b"\x89PNG", 4]
+
+    async def test_get_attachment_returns_row_as_dict(self, fake_pool_factory) -> None:
+        """A found attachment comes back as a plain dict including its bytes."""
+        row = {"attachment_id": "a-1", "filename": "shot.png", "data": b"\x89PNG"}
+        pool = fake_pool_factory(results=[[row]])
+        repo = ARIELRepository(pool, _make_config())
+
+        assert await repo.get_attachment("a-1") == row
+        assert pool.calls[0][1] == ["a-1"]
+
+    async def test_get_attachment_returns_none_when_absent(self, fake_pool) -> None:
+        """A missing attachment is None, not an empty dict."""
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        assert await repo.get_attachment("gone") is None
+
+    async def test_get_attachments_for_entry_omits_blob_column(self, fake_pool_factory) -> None:
+        """The per-entry listing selects metadata only, never ``data``.
+
+        Hazard: this feeds an entry view that may list many attachments, so
+        adding ``data`` to the projection would pull every blob into memory to
+        render a filename list.
+        """
+        pool = fake_pool_factory(results=[[{"attachment_id": "a-1", "filename": "shot.png"}]])
+        repo = ARIELRepository(pool, _make_config())
+
+        rows = await repo.get_attachments_for_entry("e-1")
+
+        assert rows == [{"attachment_id": "a-1", "filename": "shot.png"}]
+        select_clause = _sql_body(pool.sql[0]).split("FROM", 1)[0]
+        assert "size_bytes" in select_clause
+        assert "data" not in select_clause
+
+
+# ---------------------------------------------------------------------------
+# Enhancement status
+# ---------------------------------------------------------------------------
+
+
+class TestEnhancementStatus:
+    """Incomplete-entry queries, stats, and the two status transitions."""
+
+    async def test_get_incomplete_entries_filters_by_module_and_status(
+        self,
+        fake_pool_factory,
+    ) -> None:
+        """Both filters present narrows to one module's exact status."""
+        pool = fake_pool_factory(results=[[_entry_row()]])
+        repo = ARIELRepository(pool, _make_config())
+
+        entries = await repo.get_incomplete_entries(
+            module_name="text_embedding", status="failed", limit=5
+        )
+
+        assert len(entries) == 1
+        sql, params = pool.calls[0]
+        assert "WHERE enhancement_status->%s->>'status' = %s" in _sql_body(sql)
+        assert params == ["text_embedding", "failed", 5]
+
+    async def test_get_incomplete_entries_by_module_includes_never_attempted(
+        self,
+        fake_pool,
+    ) -> None:
+        """Module without status also matches entries the module never touched.
+
+        Hazard: the ``NOT (enhancement_status ? %s)`` arm is what lets a newly
+        enabled module pick up the existing corpus; matching only 'failed' and
+        'pending' would leave every pre-existing entry permanently unenhanced.
+        """
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        await repo.get_incomplete_entries(module_name="text_embedding")
+
+        sql, params = fake_pool.calls[0]
+        body = _sql_body(sql)
+        assert "NOT (enhancement_status ? %s)" in body
+        assert "enhancement_status->%s->>'status' IN ('failed', 'pending')" in body
+        assert params == ["text_embedding", "text_embedding", 100]
+
+    async def test_get_incomplete_entries_without_module_scans_all(self, fake_pool) -> None:
+        """No module filter selects every entry, oldest first."""
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        await repo.get_incomplete_entries(limit=7)
+
+        sql, params = fake_pool.calls[0]
+        body = _sql_body(sql)
+        assert "WHERE" not in body
+        assert "ORDER BY created_at ASC LIMIT %s" in body
+        assert params == [7]
+
+    async def test_get_enhancement_stats_maps_row_positions(self, fake_pool_factory) -> None:
+        """The seven aggregate columns are unpacked positionally.
+
+        Hazard: the SELECT list order and this mapping are one contract with no
+        column names between them -- reordering the FILTER clauses without
+        reordering the indices would silently swap 'failed' and 'pending'.
+        """
+        pool = fake_pool_factory(results=[[(100, 90, 5, 5, 80, 10, 10)]])
+        repo = ARIELRepository(pool, _make_config())
+
+        stats = await repo.get_enhancement_stats()
+
+        assert stats == {
+            "total_entries": 100,
+            "text_embedding": {"complete": 90, "failed": 5, "pending": 5},
+            "semantic_processor": {"complete": 80, "failed": 10, "pending": 10},
+        }
+
+    async def test_get_enhancement_stats_on_empty_database(self, fake_pool) -> None:
+        """No aggregate row degrades to a zero total rather than raising."""
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        assert await repo.get_enhancement_stats() == {"total_entries": 0}
+
+    async def test_mark_enhancement_complete_targets_module_key(self, fake_pool) -> None:
+        """Completion is written under the module's own jsonb key."""
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        await repo.mark_enhancement_complete("e-1", "text_embedding")
+
+        sql, params = fake_pool.calls[0]
+        body = _sql_body(sql)
+        assert "UPDATE enhanced_entries SET enhancement_status = jsonb_set(" in body
+        assert "'status', 'complete'" in body
+        assert params == [["text_embedding"], "e-1"]
+
+    async def test_mark_enhancement_failed_truncates_the_error(self, fake_pool) -> None:
+        """A long error message is truncated to 500 characters before binding.
+
+        Hazard: enhancement errors can carry a whole provider response body;
+        without the cap every failure would bloat the entry's jsonb status and,
+        via the same row, every subsequent read of that entry.
+        """
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        await repo.mark_enhancement_failed("e-1", "text_embedding", "x" * 600)
+
+        params = fake_pool.calls[0][1]
+        assert params[1] == "x" * 500
+        assert params == [["text_embedding"], "x" * 500, "e-1"]
+
+    async def test_mark_enhancement_failed_keeps_short_errors_intact(self, fake_pool) -> None:
+        """An error under the cap is bound verbatim."""
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        await repo.mark_enhancement_failed("e-1", "text_embedding", "model timed out")
+
+        assert fake_pool.calls[0][1][1] == "model timed out"
+
+
+# ---------------------------------------------------------------------------
+# Embedding tables
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingTables:
+    """Discovery of ``text_embeddings_*`` tables and their per-table probes."""
+
+    async def test_each_table_is_probed_for_count_and_dimension(
+        self,
+        fake_pool_factory,
+    ) -> None:
+        """Per table: a COUNT and an ``atttypmod`` lookup, flagged against config.
+
+        The result script is positional and mirrors the emitted order --
+        discovery, then (count, dimension) for each table in turn.
+        """
+        pool = fake_pool_factory(
+            results=[
+                [("text_embeddings_nomic_embed_text",), ("text_embeddings_mxbai_embed_large",)],
+                [(7,)],
+                [(768,)],
+                [(0,)],
+                [(1024,)],
+            ]
+        )
+        repo = ARIELRepository(pool, _make_config())
+
+        tables = await repo.get_embedding_tables()
+
+        assert [(t.table_name, t.entry_count, t.dimension, t.is_active) for t in tables] == [
+            ("text_embeddings_nomic_embed_text", 7, 768, True),
+            ("text_embeddings_mxbai_embed_large", 0, 1024, False),
+        ]
+        assert "information_schema.tables" in _sql_body(pool.sql[0])
+        assert pool.sql[1] == "SELECT COUNT(*) FROM text_embeddings_nomic_embed_text"
+
+    async def test_unmeasurable_table_reports_zero_count_and_no_dimension(
+        self,
+        fake_pool_factory,
+    ) -> None:
+        """A table whose probes return nothing usable degrades, not raises.
+
+        ``atttypmod`` is -1 for a column declared without a type modifier, and
+        the COUNT can come back empty; both mean "unknown", which the caller
+        renders rather than crashing the diagnostics page on.
+        """
+        pool = fake_pool_factory(
+            results=[
+                [("text_embeddings_unknown",)],
+                [],
+                [(-1,)],
+            ]
+        )
+        repo = ARIELRepository(pool, _make_config())
+
+        (table,) = await repo.get_embedding_tables()
+
+        assert table.entry_count == 0
+        assert table.dimension is None
+        assert table.is_active is False
+
+    async def test_no_table_is_active_when_semantic_search_is_off(
+        self,
+        fake_pool_factory,
+    ) -> None:
+        """Without a configured search model nothing can be the active table."""
+        config = _make_config(search_modules={"semantic": {"enabled": False}})
+        pool = fake_pool_factory(
+            results=[
+                [("text_embeddings_nomic_embed_text",)],
+                [(7,)],
+                [(768,)],
+            ]
+        )
+        repo = ARIELRepository(pool, config)
+
+        (table,) = await repo.get_embedding_tables()
+
+        assert table.is_active is False
+
+    async def test_store_text_embedding_formats_vector_literal(self, fake_pool) -> None:
+        """The vector is bound as a pgvector literal and upserted by entry_id."""
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        await repo.store_text_embedding("e-1", [0.1, 0.2, 0.3], "nomic-embed-text")
+
+        sql, params = fake_pool.calls[0]
+        body = _sql_body(sql)
+        assert "INSERT INTO text_embeddings_nomic_embed_text (entry_id, embedding)" in body
+        assert "ON CONFLICT (entry_id) DO UPDATE SET embedding = EXCLUDED.embedding" in body
+        assert params == ["e-1", "[0.1,0.2,0.3]"]
+
+
+# ---------------------------------------------------------------------------
+# Search
+# ---------------------------------------------------------------------------
+
+
+class TestSearchQueries:
+    """Keyword, fuzzy and semantic search all emit one parametrized statement."""
+
+    async def test_keyword_search_with_highlights(self, fake_pool_factory) -> None:
+        """Highlighted search binds the search text twice, ahead of the filters."""
+        rows = [
+            _entry_row(entry_id="e-1", rank=0.8, headline="beam <b>lost</b>"),
+            _entry_row(entry_id="e-2", rank=None, headline=None),
+        ]
+        pool = fake_pool_factory(results=[rows])
+        repo = ARIELRepository(pool, _make_config())
+
+        results = await repo.keyword_search(
+            where_clauses=["author = %s"],
+            params=["operator"],
+            search_text="beam lost",
+            max_results=5,
+        )
+
+        assert [(entry["entry_id"], score, hl) for entry, score, hl in results] == [
+            ("e-1", 0.8, ["beam <b>lost</b>"]),
+            ("e-2", 0.0, []),
+        ]
+        sql, params = pool.calls[0]
+        body = _sql_body(sql)
+        assert "ts_headline('english', raw_text" in body
+        assert "WHERE author = %s" in body
+        assert params == ["beam lost", "beam lost", "operator", 5]
+
+    async def test_keyword_search_without_highlights(self, fake_pool) -> None:
+        """Skipping highlights drops the ts_headline call and one bound copy."""
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        assert (
+            await repo.keyword_search(
+                where_clauses=[],
+                params=[],
+                search_text="quench",
+                include_highlights=False,
+            )
+            == []
+        )
+
+        sql, params = fake_pool.calls[0]
+        body = _sql_body(sql)
+        assert "ts_headline" not in body
+        assert "NULL AS headline" in body
+        assert "WHERE TRUE" in body
+        assert params == ["quench", 10]
+
+    async def test_fuzzy_search_without_date_filters(self, fake_pool_factory) -> None:
+        """Similarity threshold is the only filter when no dates are given."""
+        pool = fake_pool_factory(results=[[_entry_row(sim=0.42)]])
+        repo = ARIELRepository(pool, _make_config())
+
+        ((entry, score, highlights),) = await repo.fuzzy_search("quench", threshold=0.25)
+
+        assert (entry["entry_id"], score, highlights) == ("e-1", 0.42, [])
+        sql, params = pool.calls[0]
+        assert "WHERE similarity(raw_text, %s) >= %s" in _sql_body(sql)
+        assert params == ["quench", "quench", 0.25, 10]
+
+    async def test_fuzzy_search_appends_date_filters(self, fake_pool) -> None:
+        """Start and end dates are ANDed after the similarity predicate."""
+        start = datetime(2026, 1, 1, tzinfo=UTC)
+        end = datetime(2026, 2, 1, tzinfo=UTC)
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        await repo.fuzzy_search("quench", start_date=start, end_date=end, max_results=3)
+
+        sql, params = fake_pool.calls[0]
+        body = _sql_body(sql)
+        assert "timestamp >= %s AND timestamp <= %s" in body
+        assert params == ["quench", "quench", 0.3, start, end, 3]
+
+    async def test_fuzzy_search_reports_zero_for_null_similarity(
+        self,
+        fake_pool_factory,
+    ) -> None:
+        """A NULL similarity scores 0.0 rather than crashing the conversion."""
+        pool = fake_pool_factory(results=[[_entry_row(sim=None)]])
+        repo = ARIELRepository(pool, _make_config())
+
+        ((_entry, score, _highlights),) = await repo.fuzzy_search("quench")
+
+        assert score == 0.0
+
+    async def test_semantic_search_without_filters(self, fake_pool_factory) -> None:
+        """The embedding is bound twice: once for the projection, once for WHERE."""
+        pool = fake_pool_factory(results=[[_entry_row(similarity=0.91)]])
+        repo = ARIELRepository(pool, _make_config())
+
+        ((entry, similarity),) = await repo.semantic_search(
+            [0.1, 0.2], "nomic-embed-text", max_results=4, similarity_threshold=0.6
+        )
+
+        assert (entry["entry_id"], similarity) == ("e-1", 0.91)
+        sql, params = pool.calls[0]
+        body = _sql_body(sql)
+        assert "JOIN text_embeddings_nomic_embed_text emb ON e.entry_id = emb.entry_id" in body
+        assert "WHERE 1 - (emb.embedding <=> %s::vector) >= %s" in body
+        assert params == ["[0.1,0.2]", "[0.1,0.2]", 0.6, 4]
+
+    async def test_semantic_search_appends_every_filter(self, fake_pool) -> None:
+        """Date, author and source filters are ANDed in declaration order.
+
+        Author matches with ILIKE and wildcards while source_system is exact --
+        the asymmetry is deliberate and worth pinning, since a stray wildcard on
+        source_system would silently widen every filtered search.
+        """
+        start = datetime(2026, 1, 1, tzinfo=UTC)
+        end = datetime(2026, 2, 1, tzinfo=UTC)
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        await repo.semantic_search(
+            [0.5],
+            "nomic-embed-text",
+            start_date=start,
+            end_date=end,
+            author="oper",
+            source_system="als_logbook",
+        )
+
+        sql, params = fake_pool.calls[0]
+        body = _sql_body(sql)
+        assert "e.timestamp >= %s AND e.timestamp <= %s" in body
+        assert "e.author ILIKE %s AND e.source_system = %s" in body
+        assert params == ["[0.5]", "[0.5]", 0.5, start, end, "%oper%", "als_logbook", 10]
+
+    async def test_semantic_search_reports_zero_for_null_similarity(
+        self,
+        fake_pool_factory,
+    ) -> None:
+        """A NULL similarity scores 0.0 rather than crashing the conversion."""
+        pool = fake_pool_factory(results=[[_entry_row(similarity=None)]])
+        repo = ARIELRepository(pool, _make_config())
+
+        ((_entry, similarity),) = await repo.semantic_search([0.1], "nomic-embed-text")
+
+        assert similarity == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Ingestion runs
+# ---------------------------------------------------------------------------
+
+
+class TestIngestionRuns:
+    """The ingestion_runs bookkeeping row, from start to terminal state."""
+
+    async def test_start_ingestion_run_returns_the_new_id(self, fake_pool_factory) -> None:
+        """The RETURNING id is what callers pass to complete/fail."""
+        pool = fake_pool_factory(results=[[(42,)]])
+        repo = ARIELRepository(pool, _make_config())
+
+        assert await repo.start_ingestion_run("als_logbook") == 42
+
+        sql, params = pool.calls[0]
+        body = _sql_body(sql)
+        assert "INSERT INTO ingestion_runs (started_at, source_system, status)" in body
+        assert "'running'" in body
+        assert "RETURNING id" in body
+        assert params == ["als_logbook"]
+
+    async def test_complete_ingestion_run_binds_counts_then_id(self, fake_pool) -> None:
+        """Success closes the row with the three entry counts."""
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        await repo.complete_ingestion_run(
+            run_id=7, entries_added=3, entries_updated=2, entries_failed=1
+        )
+
+        sql, params = fake_pool.calls[0]
+        assert "status = 'success'" in _sql_body(sql)
+        assert params == [3, 2, 1, 7]
+
+    async def test_fail_ingestion_run_truncates_the_error(self, fake_pool) -> None:
+        """The failure message is truncated to 500 characters before binding.
+
+        Hazard: the error recorded here is whatever the adapter raised, which
+        for an HTTP adapter can be an entire response body; without the cap one
+        bad poll writes an unbounded string into the run history.
+        """
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        await repo.fail_ingestion_run(7, "y" * 600)
+
+        sql, params = fake_pool.calls[0]
+        assert "status = 'failed'" in _sql_body(sql)
+        assert params == ["y" * 500, 7]
+
+    async def test_get_last_successful_run_returns_completion_time(
+        self,
+        fake_pool_factory,
+    ) -> None:
+        """The watermark is the MAX(completed_at) over successful runs only."""
+        completed = datetime(2026, 3, 4, 5, 6, tzinfo=UTC)
+        pool = fake_pool_factory(results=[[(completed,)]])
+        repo = ARIELRepository(pool, _make_config())
+
+        assert await repo.get_last_successful_run("als_logbook") == completed
+
+        sql, params = pool.calls[0]
+        body = _sql_body(sql)
+        assert "SELECT MAX(completed_at) FROM ingestion_runs" in body
+        assert "status = 'success'" in body
+        assert params == ["als_logbook"]
+
+    async def test_get_last_successful_run_without_any_run(self, fake_pool) -> None:
+        """No rows at all means no watermark."""
+        repo = ARIELRepository(fake_pool, _make_config())
+
+        assert await repo.get_last_successful_run("als_logbook") is None
+
+    async def test_get_last_successful_run_with_null_aggregate(
+        self,
+        fake_pool_factory,
+    ) -> None:
+        """MAX over zero successful runs is a NULL, which is also no watermark.
+
+        Hazard: the aggregate always returns one row, so a truthiness check on
+        the row alone would hand callers a None timestamp and make the next
+        incremental poll compare against nothing.
+        """
+        pool = fake_pool_factory(results=[[(None,)]])
+        repo = ARIELRepository(pool, _make_config())
+
+        assert await repo.get_last_successful_run("als_logbook") is None

--- a/tests/services/ariel_search/test_search.py
+++ b/tests/services/ariel_search/test_search.py
@@ -1388,3 +1388,227 @@ class TestThresholdInSQLVerification:
         )
 
         assert DEFAULT_SIMILARITY_THRESHOLD == 0.5
+
+
+class TestKeywordSearchFilterParameters:
+    """Tests for keyword_search filter clauses built from call parameters."""
+
+    @pytest.fixture
+    def mock_config(self):
+        """Create mock ARIEL config with keyword search enabled."""
+        from osprey.services.ariel_search.config import ARIELConfig
+
+        return ARIELConfig.from_dict(
+            {
+                "database": {"uri": "postgresql://localhost/test"},
+                "search_modules": {"keyword": {"enabled": True}},
+            }
+        )
+
+    @pytest.fixture
+    def mock_repository(self, mock_config):
+        """Create mock repository returning no rows."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        repo = MagicMock()
+        repo.config = mock_config
+        repo.keyword_search = AsyncMock(return_value=[])
+        repo.fuzzy_search = AsyncMock(return_value=[])
+        return repo
+
+    @pytest.mark.asyncio
+    async def test_quoted_phrases_become_query_params(self, mock_repository, mock_config):
+        """Each quoted phrase is bound as its own parameter, after the free text."""
+        from osprey.services.ariel_search.search.keyword import keyword_search
+
+        await keyword_search(
+            'fault "beam current" "vacuum pump"',
+            mock_repository,
+            mock_config,
+            fuzzy_fallback=False,
+        )
+
+        kwargs = mock_repository.keyword_search.call_args.kwargs
+        assert kwargs["params"] == ["fault", "beam current", "vacuum pump"]
+        assert kwargs["where_clauses"][0].count("phraseto_tsquery") == 2
+
+    @pytest.mark.asyncio
+    async def test_author_parameter_adds_ilike_clause(self, mock_repository, mock_config):
+        """The author= parameter contributes an ILIKE clause with % wildcards."""
+        from osprey.services.ariel_search.search.keyword import keyword_search
+
+        await keyword_search(
+            "beam",
+            mock_repository,
+            mock_config,
+            author="jsmith",
+            fuzzy_fallback=False,
+        )
+
+        kwargs = mock_repository.keyword_search.call_args.kwargs
+        assert "author ILIKE %s" in kwargs["where_clauses"]
+        assert "%jsmith%" in kwargs["params"]
+
+    @pytest.mark.asyncio
+    async def test_author_field_filter_wins_over_parameter(self, mock_repository, mock_config):
+        """An author: field filter in the query suppresses the author= parameter."""
+        from osprey.services.ariel_search.search.keyword import keyword_search
+
+        await keyword_search(
+            "beam author:smith",
+            mock_repository,
+            mock_config,
+            author="jsmith",
+            fuzzy_fallback=False,
+        )
+
+        kwargs = mock_repository.keyword_search.call_args.kwargs
+        assert kwargs["where_clauses"].count("author ILIKE %s") == 1
+        assert "%smith%" in kwargs["params"]
+        assert "%jsmith%" not in kwargs["params"]
+
+    @pytest.mark.asyncio
+    async def test_source_system_parameter_adds_exact_clause(self, mock_repository, mock_config):
+        """The source_system= parameter matches exactly, not by ILIKE."""
+        from osprey.services.ariel_search.search.keyword import keyword_search
+
+        await keyword_search(
+            "beam",
+            mock_repository,
+            mock_config,
+            source_system="ALS eLog",
+            fuzzy_fallback=False,
+        )
+
+        kwargs = mock_repository.keyword_search.call_args.kwargs
+        assert "source_system = %s" in kwargs["where_clauses"]
+        assert "ALS eLog" in kwargs["params"]
+
+
+class TestSemanticSearchDiagnostics:
+    """Tests for semantic_search dimension and empty-index diagnostics."""
+
+    @pytest.fixture
+    def mock_embedder(self):
+        """Embedder returning a 3-dimensional vector."""
+        from unittest.mock import MagicMock
+
+        embedder = MagicMock()
+        embedder.default_base_url = "http://localhost:11434"
+        embedder.execute_embedding = MagicMock(return_value=[[0.1, 0.2, 0.3]])
+        return embedder
+
+    @pytest.fixture
+    def mock_repository(self):
+        """Repository returning no semantic matches."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        repo = MagicMock()
+        repo.semantic_search = AsyncMock(return_value=[])
+        repo.get_embedding_tables = AsyncMock(return_value=[])
+        return repo
+
+    def _config(self, settings):
+        from osprey.services.ariel_search.config import ARIELConfig
+
+        return ARIELConfig.from_dict(
+            {
+                "database": {"uri": "postgresql://localhost/test"},
+                "search_modules": {
+                    "semantic": {
+                        "enabled": True,
+                        "model": "nomic-embed-text",
+                        "settings": settings,
+                    },
+                },
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_dimension_mismatch_warns_but_still_searches(
+        self, mock_repository, mock_embedder, caplog
+    ):
+        """A query embedding of the wrong width warns and proceeds."""
+        import logging
+
+        from osprey.services.ariel_search.search.semantic import semantic_search
+
+        config = self._config({"embedding_dimension": 768})
+
+        with caplog.at_level(logging.WARNING, logger="ariel"):
+            await semantic_search("beam", mock_repository, config, mock_embedder)
+
+        assert "Embedding dimension mismatch" in caplog.text
+        assert "3 dimensions but config expects 768" in caplog.text
+        mock_repository.semantic_search.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_matching_dimension_does_not_warn(self, mock_repository, mock_embedder, caplog):
+        """A correctly sized query embedding produces no mismatch warning."""
+        import logging
+
+        from osprey.services.ariel_search.search.semantic import semantic_search
+
+        config = self._config({"embedding_dimension": 3})
+
+        with caplog.at_level(logging.WARNING, logger="ariel"):
+            await semantic_search("beam", mock_repository, config, mock_embedder)
+
+        assert "Embedding dimension mismatch" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_zero_results_with_no_embedding_tables_warns(
+        self, mock_repository, mock_embedder, caplog
+    ):
+        """Zero hits with no embedding tables at all points at the ingest step."""
+        import logging
+
+        from osprey.services.ariel_search.search.semantic import semantic_search
+
+        config = self._config({"similarity_threshold": 0.5})
+
+        with caplog.at_level(logging.WARNING, logger="ariel"):
+            results = await semantic_search("beam", mock_repository, config, mock_embedder)
+
+        assert results == []
+        assert "no embeddings exist" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_zero_results_with_empty_embedding_tables_warns(
+        self, mock_repository, mock_embedder, caplog
+    ):
+        """Tables that exist but hold no rows produce the same diagnostic."""
+        import logging
+        from unittest.mock import MagicMock
+
+        from osprey.services.ariel_search.search.semantic import semantic_search
+
+        empty_table = MagicMock()
+        empty_table.entry_count = 0
+        mock_repository.get_embedding_tables.return_value = [empty_table]
+        config = self._config({"similarity_threshold": 0.5})
+
+        with caplog.at_level(logging.WARNING, logger="ariel"):
+            await semantic_search("beam", mock_repository, config, mock_embedder)
+
+        assert "no embeddings exist" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_zero_results_with_populated_tables_stays_quiet(
+        self, mock_repository, mock_embedder, caplog
+    ):
+        """Populated tables mean the miss is genuine — no diagnostic warning."""
+        import logging
+        from unittest.mock import MagicMock
+
+        from osprey.services.ariel_search.search.semantic import semantic_search
+
+        populated = MagicMock()
+        populated.entry_count = 42
+        mock_repository.get_embedding_tables.return_value = [populated]
+        config = self._config({"similarity_threshold": 0.5})
+
+        with caplog.at_level(logging.WARNING, logger="ariel"):
+            await semantic_search("beam", mock_repository, config, mock_embedder)
+
+        assert "no embeddings exist" not in caplog.text

--- a/tests/services/ariel_search/test_service.py
+++ b/tests/services/ariel_search/test_service.py
@@ -3,6 +3,7 @@
 Tests for service routing and formatting functionality.
 """
 
+import logging
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
@@ -372,6 +373,82 @@ class TestServiceRouting:
         assert result.diagnostics
         assert all(d.level is DiagnosticLevel.INFO for d in result.diagnostics)
 
+    @pytest.mark.asyncio
+    async def test_unroutable_mode_raises_configuration_error(self):
+        """A mode with no routing arm raises ConfigurationError naming the mode.
+
+        SearchMode carries SQL, which ainvoke's match statement does not route,
+        so it falls through to the catch-all arm. ConfigurationError is an
+        ARIELException, so it propagates rather than being wrapped.
+        """
+        from osprey.services.ariel_search.exceptions import ConfigurationError
+
+        service = self._create_mock_service(search_modules={"keyword": {"enabled": True}})
+
+        with pytest.raises(ConfigurationError) as exc_info:
+            await service.search("test query", mode=SearchMode.SQL)
+
+        assert "sql_query" in str(exc_info.value)
+        assert exc_info.value.config_key == "modes"
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_wrapped_in_search_execution_error(self):
+        """A non-ARIEL exception is wrapped with the mode and query that failed."""
+        from osprey.services.ariel_search.exceptions import SearchExecutionError
+
+        service = self._create_mock_service(
+            search_modules={
+                "keyword": {"enabled": True},
+                "semantic": {"enabled": True, "model": "test-model"},
+            }
+        )
+        # Fails inside the try block, before routing picks an arm.
+        service.repository.validate_search_model_table = AsyncMock(
+            side_effect=RuntimeError("pool exhausted")
+        )
+
+        with pytest.raises(SearchExecutionError) as exc_info:
+            await service.search("beam current", mode=SearchMode.KEYWORD)
+
+        error = exc_info.value
+        assert error.search_mode == "keyword"
+        assert error.query == "beam current"
+        assert "pool exhausted" in str(error)
+        assert isinstance(error.__cause__, RuntimeError)
+
+    @pytest.mark.asyncio
+    async def test_semantic_results_projected_to_entries_and_sources(self, fake_embedding_provider):
+        """Semantic hits become entries carrying _score, plus an entry_id source tuple."""
+        from unittest.mock import patch
+
+        service = self._create_mock_service(
+            search_modules={"semantic": {"enabled": True, "model": "test-model"}}
+        )
+        # Pre-set so _get_embedder() never reaches the provider registry.
+        service._embedder = fake_embedding_provider
+
+        seen_embedders = []
+
+        async def fake_semantic_search(query, repository, config, embedder, **kwargs):
+            seen_embedders.append(embedder)
+            return [
+                ({"entry_id": "entry-sem-001", "raw_text": "RF cavity trip"}, 0.91),
+                ({"entry_id": "entry-sem-002", "raw_text": "Beam dump at 08:12"}, 0.77),
+            ]
+
+        with patch(
+            "osprey.services.ariel_search.search.semantic.semantic_search",
+            side_effect=fake_semantic_search,
+        ):
+            result = await service.search("cavity", mode=SearchMode.SEMANTIC)
+
+        assert seen_embedders == [fake_embedding_provider]
+        assert result.search_modes_used == (SearchMode.SEMANTIC,)
+        assert result.reasoning == "Semantic search: 2 results"
+        assert result.sources == ("entry-sem-001", "entry-sem-002")
+        assert [entry["_score"] for entry in result.entries] == [0.91, 0.77]
+        assert result.entries[0]["raw_text"] == "RF cavity trip"
+
 
 class TestCreateArielService:
     """Tests for create_ariel_service factory function."""
@@ -505,6 +582,47 @@ class TestServiceValidateSearchModel:
         await service._validate_search_model()
         mock_repository.validate_search_model_table.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_validate_search_model_disables_semantic_when_table_missing(self, caplog):
+        """A missing embedding table disables semantic search instead of raising.
+
+        The config is built inside the test because this branch mutates
+        ``search_modules["semantic"].enabled`` -- a shared config would leak the
+        disabled flag into every test that ran afterwards.
+        """
+        from osprey.services.ariel_search.exceptions import ConfigurationError
+
+        config = ARIELConfig.from_dict(
+            {
+                "database": {"uri": "postgresql://localhost:5432/test"},
+                "search_modules": {"semantic": {"enabled": True, "model": "test-model"}},
+            }
+        )
+        mock_repository = MagicMock()
+        mock_repository.validate_search_model_table = AsyncMock(
+            side_effect=ConfigurationError(
+                "embedding table embeddings_test_model not found",
+                config_key="search_modules.semantic.model",
+            )
+        )
+
+        service = ARIELSearchService(
+            config=config,
+            pool=MagicMock(),
+            repository=mock_repository,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="ariel"):
+            await service._validate_search_model()
+
+        assert config.search_modules["semantic"].enabled is False
+        assert config.is_search_module_enabled("semantic") is False
+        assert "Semantic search disabled" in caplog.text
+        assert "embeddings_test_model" in caplog.text
+        assert "quickstart" in caplog.text
+        # Still marked validated, so the failure is not retried on every search.
+        assert service._validated_search_model is True
+
 
 class TestServiceGetStatus:
     """Tests for ARIELSearchService.get_status() method."""
@@ -587,6 +705,32 @@ class TestServiceGetStatus:
         assert result.enabled_search_modules == ["keyword", "semantic"]
         assert result.enabled_enhancement_modules == ["text_embedding"]
         assert isinstance(result.errors, list)
+
+    @pytest.mark.asyncio
+    async def test_get_status_reports_unreachable_database(self, minimal_config, fake_pool_factory):
+        """A pool that cannot hand out a connection becomes an error entry, not a raise."""
+        failing_pool = fake_pool_factory(error=RuntimeError("connection refused"))
+
+        mock_repository = MagicMock()
+        mock_repository.get_embedding_tables = AsyncMock(return_value=[])
+
+        service = ARIELSearchService(
+            config=minimal_config,
+            pool=failing_pool,
+            repository=mock_repository,
+        )
+
+        result = await service.get_status()
+
+        assert result.errors == ["Database error: connection refused"]
+        assert result.healthy is False
+        assert result.database_connected is False
+        assert result.entry_count is None
+        assert result.embedding_tables == []
+        assert result.last_ingestion is None
+        # Config-derived fields still populate despite the database being down.
+        assert "***" in result.database_uri
+        assert result.enabled_search_modules == ["keyword", "semantic"]
 
 
 class TestARIELSearchResultModel:

--- a/tests/services/ariel_search/test_service_create.py
+++ b/tests/services/ariel_search/test_service_create.py
@@ -1,5 +1,6 @@
 """Tests for ARIELSearchService.create_entry() orchestration."""
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -180,3 +181,40 @@ async def test_create_entry_sync_status_synced():
 
     # Repository was called twice: once for optimistic, once for synced
     assert mock_repository.upsert_entry.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_create_entry_reingestion_failure_is_warned_not_raised(caplog):
+    """A failing re-ingestion leaves the entry PENDING_SYNC and logs a warning.
+
+    The facility write already succeeded at this point, so a read-back failure
+    must not surface as an error -- the entry syncs on the next poll.
+    """
+    service, mock_adapter, mock_repository = _make_mock_service(
+        adapter_supports_write=True,
+        source_system="ALS eLog",
+    )
+
+    async def failing_fetch(**kwargs):
+        raise RuntimeError("logbook unreachable")
+        yield  # Unreachable; makes this an async generator
+
+    mock_adapter.fetch_entries = failing_fetch
+
+    request = FacilityEntryCreateRequest(subject="Test", details="Details")
+
+    with caplog.at_level(logging.WARNING, logger="ariel"):
+        with patch(
+            "osprey.services.ariel_search.ingestion.get_adapter",
+            return_value=mock_adapter,
+        ):
+            result = await service.create_entry(request)
+
+    assert result.sync_status == SyncStatus.PENDING_SYNC
+    assert result.entry_id == "test-entry-001"
+    assert "Re-ingestion after write failed for test-entry-001" in caplog.text
+    assert "logbook unreachable" in caplog.text
+    assert "sync on next poll" in caplog.text
+
+    # Only the optimistic upsert landed; the sync upsert never ran.
+    mock_repository.upsert_entry.assert_called_once()

--- a/tests/services/ariel_search/test_sql_query.py
+++ b/tests/services/ariel_search/test_sql_query.py
@@ -1,0 +1,346 @@
+"""Tests for the ARIEL read-only SQL query module.
+
+Covers three surfaces of ``search/sql_query.py``:
+
+- ``validate_sql_query`` — the allowlist/denylist gate that stands between an
+  agent-authored string and the database.
+- ``sql_query`` — the read-only transaction envelope, driven against the
+  shared ``_FakePool``.
+- ``format_sql_result`` — the agent-facing rendering of returned rows.
+
+The module-level ``ALLOWED_TABLES`` / ``FORBIDDEN_KEYWORDS`` sets are the
+security surface: tests read them and pin their contents, but never mutate
+them. Variant-set cases go through ``monkeypatch.setattr`` with a *copy*.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+
+import pytest
+from psycopg.rows import dict_row
+from pydantic import ValidationError
+
+from osprey.services.ariel_search.search.sql_query import (
+    ALLOWED_TABLES,
+    FORBIDDEN_KEYWORDS,
+    MAX_ROWS,
+    SqlQueryInput,
+    format_sql_result,
+    sql_query,
+    validate_sql_query,
+)
+
+# search/__init__.py re-exports the sql_query *function*, which shadows the
+# submodule of the same name on the package -- so the module handle that
+# monkeypatch needs has to come from sys.modules, not from an attribute lookup.
+sql_query_module = importlib.import_module("osprey.services.ariel_search.search.sql_query")
+
+# The statements sql_query wraps around every user query, in order.
+BEGIN_SQL = "BEGIN READ ONLY"
+TIMEOUT_SQL = "SET LOCAL statement_timeout = '10s'"
+ROLLBACK_SQL = "ROLLBACK"
+
+
+class TestSecuritySurface:
+    """The allowlist and denylist contents are themselves a contract."""
+
+    def test_allowed_tables_pinned(self):
+        """Widening the table allowlist must be a deliberate edit, not a drift."""
+        assert ALLOWED_TABLES == {"enhanced_entries", "text_embeddings"}
+
+    def test_forbidden_keywords_pinned(self):
+        """Every DML/DDL/DCL verb the validator rejects, enumerated."""
+        assert FORBIDDEN_KEYWORDS == {
+            "INSERT",
+            "UPDATE",
+            "DELETE",
+            "DROP",
+            "ALTER",
+            "CREATE",
+            "TRUNCATE",
+            "COPY",
+            "GRANT",
+            "REVOKE",
+            "VACUUM",
+            "SET",
+            "EXECUTE",
+        }
+
+    def test_max_rows_ceiling(self):
+        assert MAX_ROWS == 200
+
+
+class TestValidateSqlQueryAccepts:
+    """Queries that clear the gate."""
+
+    def test_plain_select(self):
+        validate_sql_query("SELECT * FROM enhanced_entries LIMIT 10")
+
+    def test_lowercase_select(self):
+        """The start check runs against the uppercased query."""
+        validate_sql_query("select entry_id from enhanced_entries")
+
+    def test_leading_whitespace_and_newlines(self):
+        validate_sql_query("\n   SELECT entry_id\n   FROM enhanced_entries\n")
+
+    def test_trailing_semicolon_is_stripped(self):
+        """One trailing semicolon is normalized away, not read as a second statement."""
+        validate_sql_query("SELECT * FROM enhanced_entries;")
+
+    def test_prefixed_embedding_table(self):
+        """``text_embeddings_*`` tables match the allowlist by prefix."""
+        validate_sql_query("SELECT * FROM text_embeddings_nomic_embed_text LIMIT 5")
+
+    def test_cte_name_is_not_a_table(self):
+        """A name bound by ``WITH x AS`` is skipped by the FROM/JOIN allowlist check."""
+        validate_sql_query(
+            "WITH stats AS (SELECT author FROM enhanced_entries) SELECT * FROM stats"
+        )
+
+    def test_join_between_allowed_tables(self):
+        validate_sql_query(
+            "SELECT e.entry_id FROM enhanced_entries e "
+            "JOIN text_embeddings_nomic t ON t.entry_id = e.entry_id"
+        )
+
+    def test_forbidden_keywords_match_on_word_boundaries(self):
+        """``UPDATED_AT`` / ``CREATED_AT`` contain UPDATE and CREATE but are columns."""
+        validate_sql_query("SELECT updated_at, created_at FROM enhanced_entries")
+
+
+class TestValidateSqlQueryRejects:
+    """Queries the gate turns away, and the message each one produces."""
+
+    @pytest.mark.parametrize("query", ["", "   ", "\n\t "])
+    def test_empty_query(self, query):
+        with pytest.raises(ValueError, match="cannot be empty"):
+            validate_sql_query(query)
+
+    def test_non_select_statement_reports_first_token(self):
+        with pytest.raises(ValueError, match="Only SELECT and WITH") as exc_info:
+            validate_sql_query("EXPLAIN SELECT * FROM enhanced_entries")
+        assert "'EXPLAIN'" in str(exc_info.value)
+
+    def test_multi_statement(self):
+        with pytest.raises(ValueError, match="Multi-statement queries are not allowed"):
+            validate_sql_query("SELECT 1 FROM enhanced_entries; SELECT 2 FROM enhanced_entries")
+
+    def test_semicolon_survives_trailing_strip(self):
+        """Stripping the trailing ``;`` still leaves the injected one in the body."""
+        with pytest.raises(ValueError, match="Multi-statement queries are not allowed"):
+            validate_sql_query("SELECT 1 FROM enhanced_entries; SELECT 2 FROM enhanced_entries;")
+
+    @pytest.mark.parametrize("keyword", sorted(FORBIDDEN_KEYWORDS))
+    def test_every_forbidden_keyword(self, keyword):
+        """Each denied verb is caught even mid-query, after a valid SELECT prefix."""
+        with pytest.raises(ValueError, match=f"Forbidden keyword '{keyword}'"):
+            validate_sql_query(f"SELECT entry_id FROM enhanced_entries {keyword} something")
+
+    def test_forbidden_keyword_lowercase(self):
+        """The keyword scan runs on the uppercased text, so case does not evade it."""
+        with pytest.raises(ValueError, match="Forbidden keyword 'DROP'"):
+            validate_sql_query("SELECT * FROM enhanced_entries where 1=1 drop table foo")
+
+    def test_table_outside_allowlist(self):
+        with pytest.raises(ValueError, match="Table 'users' is not in the allowlist"):
+            validate_sql_query("SELECT * FROM users")
+
+    def test_joined_table_outside_allowlist(self):
+        """JOIN targets are checked, not only the FROM table."""
+        with pytest.raises(ValueError, match="Table 'pg_authid' is not in the allowlist"):
+            validate_sql_query("SELECT * FROM enhanced_entries JOIN pg_authid ON pg_authid.oid = 1")
+
+    def test_lookalike_table_prefix_is_not_enough(self):
+        """Prefix matching requires the ``_`` separator, so ``enhanced_entriesx`` fails."""
+        with pytest.raises(ValueError, match="Table 'enhanced_entriesx'"):
+            validate_sql_query("SELECT * FROM enhanced_entriesx")
+
+    def test_cte_body_table_still_checked(self):
+        """Binding a CTE name does not launder the table it selects from."""
+        with pytest.raises(ValueError, match="Table 'pg_stat_activity'"):
+            validate_sql_query("WITH x AS (SELECT * FROM pg_stat_activity) SELECT * FROM x")
+
+
+class TestValidateSqlQueryVariantSets:
+    """The two constants are read at call time — swap in copies, never mutate."""
+
+    def test_widened_table_allowlist(self, monkeypatch):
+        widened = set(ALLOWED_TABLES) | {"ariel_runs"}
+        monkeypatch.setattr(sql_query_module, "ALLOWED_TABLES", widened)
+
+        validate_sql_query("SELECT * FROM ariel_runs")
+
+        assert ALLOWED_TABLES == {"enhanced_entries", "text_embeddings"}
+
+    def test_narrowed_table_allowlist(self, monkeypatch):
+        narrowed = {"text_embeddings"}
+        monkeypatch.setattr(sql_query_module, "ALLOWED_TABLES", narrowed)
+
+        with pytest.raises(ValueError, match="Table 'enhanced_entries'"):
+            validate_sql_query("SELECT * FROM enhanced_entries")
+
+        assert ALLOWED_TABLES == {"enhanced_entries", "text_embeddings"}
+
+    def test_extended_forbidden_keywords(self, monkeypatch):
+        extended = set(FORBIDDEN_KEYWORDS) | {"ANALYZE"}
+        monkeypatch.setattr(sql_query_module, "FORBIDDEN_KEYWORDS", extended)
+
+        with pytest.raises(ValueError, match="Forbidden keyword 'ANALYZE'"):
+            validate_sql_query("SELECT * FROM enhanced_entries ANALYZE")
+
+        assert "ANALYZE" not in FORBIDDEN_KEYWORDS
+
+
+class TestSqlQueryInput:
+    """The pydantic input schema exposed to the agent."""
+
+    def test_defaults(self):
+        model = SqlQueryInput(query="SELECT 1 FROM enhanced_entries")
+        assert model.max_rows == 100
+
+    def test_max_rows_upper_bound(self):
+        assert SqlQueryInput(query="SELECT 1", max_rows=MAX_ROWS).max_rows == MAX_ROWS
+        with pytest.raises(ValidationError):
+            SqlQueryInput(query="SELECT 1", max_rows=MAX_ROWS + 1)
+
+    def test_max_rows_lower_bound(self):
+        assert SqlQueryInput(query="SELECT 1", max_rows=1).max_rows == 1
+        with pytest.raises(ValidationError):
+            SqlQueryInput(query="SELECT 1", max_rows=0)
+
+    def test_query_is_required(self):
+        with pytest.raises(ValidationError):
+            SqlQueryInput()
+
+    def test_schema_is_not_the_validator(self):
+        """The model accepts any string; safety comes from validate_sql_query."""
+        assert SqlQueryInput(query="DROP TABLE enhanced_entries").query
+
+
+class TestSqlQueryExecution:
+    """``sql_query`` against the shared fake pool."""
+
+    QUERY = "SELECT entry_id FROM enhanced_entries LIMIT 5"
+
+    async def test_returns_scripted_rows(self, fake_pool_factory):
+        pool = fake_pool_factory(rows_for={"FROM enhanced_entries": [{"entry_id": "e-1"}]})
+
+        rows = await sql_query(pool, self.QUERY)
+
+        assert rows == [{"entry_id": "e-1"}]
+
+    async def test_read_only_transaction_envelope(self, fake_pool_factory):
+        """Every query is bracketed by BEGIN READ ONLY, a timeout, and ROLLBACK."""
+        pool = fake_pool_factory(rows_for={"FROM enhanced_entries": [{"entry_id": "e-1"}]})
+
+        await sql_query(pool, self.QUERY)
+
+        assert pool.sql == [BEGIN_SQL, TIMEOUT_SQL, self.QUERY, ROLLBACK_SQL]
+
+    async def test_cursor_requests_dict_row(self, fake_pool_factory):
+        pool = fake_pool_factory()
+
+        await sql_query(pool, self.QUERY)
+
+        assert [cur.row_factory for cur in pool.conn.cursors] == [dict_row]
+
+    async def test_empty_result_set(self, fake_pool):
+        assert await sql_query(fake_pool, self.QUERY) == []
+
+    async def test_rows_are_copied_into_plain_dicts(self, fake_pool_factory):
+        """``dict(row)`` detaches the result from whatever the driver handed back."""
+        scripted = {"entry_id": "e-1"}
+        pool = fake_pool_factory(rows_for={"FROM enhanced_entries": [scripted]})
+
+        rows = await sql_query(pool, self.QUERY)
+
+        assert rows[0] == scripted
+        assert rows[0] is not scripted
+
+    async def test_max_rows_limits_the_fetch(self, fake_pool_factory):
+        pool = fake_pool_factory(
+            rows_for={"FROM enhanced_entries": [{"entry_id": f"e-{i}"} for i in range(5)]}
+        )
+
+        rows = await sql_query(pool, self.QUERY, max_rows=2)
+
+        assert [row["entry_id"] for row in rows] == ["e-0", "e-1"]
+
+    async def test_max_rows_capped_at_module_ceiling(self, fake_pool_factory, monkeypatch):
+        """A caller asking for more than MAX_ROWS is silently clamped down to it."""
+        monkeypatch.setattr(sql_query_module, "MAX_ROWS", 2)
+        pool = fake_pool_factory(
+            rows_for={"FROM enhanced_entries": [{"entry_id": f"e-{i}"} for i in range(5)]}
+        )
+
+        rows = await sql_query(pool, self.QUERY, max_rows=100)
+
+        assert len(rows) == 2
+
+    async def test_validation_runs_before_any_sql(self, fake_pool):
+        """A rejected query never reaches the pool — not even the BEGIN."""
+        with pytest.raises(ValueError, match="Forbidden keyword 'DROP'"):
+            await sql_query(fake_pool, "SELECT * FROM enhanced_entries DROP TABLE foo")
+
+        assert fake_pool.calls == []
+
+    async def test_rollback_runs_when_the_query_raises(self, fake_pool_factory):
+        """The ``finally`` arm keeps the transaction from being left open."""
+        boom = RuntimeError("relation does not exist")
+        pool = fake_pool_factory(rows_for={"FROM enhanced_entries": boom})
+
+        with pytest.raises(RuntimeError, match="relation does not exist"):
+            await sql_query(pool, self.QUERY)
+
+        assert pool.sql == [BEGIN_SQL, TIMEOUT_SQL, self.QUERY, ROLLBACK_SQL]
+
+    async def test_logs_the_effective_max_rows(self, fake_pool, caplog):
+        with caplog.at_level(logging.INFO, logger="ariel"):
+            await sql_query(fake_pool, self.QUERY, max_rows=50)
+
+        assert "sql_query: executing query (max_rows=50)" in caplog.text
+
+    async def test_logged_max_rows_reflects_the_cap(self, fake_pool, caplog):
+        with caplog.at_level(logging.INFO, logger="ariel"):
+            await sql_query(fake_pool, self.QUERY, max_rows=1000)
+
+        assert f"max_rows={MAX_ROWS}" in caplog.text
+
+
+class TestFormatSqlResult:
+    """Agent-facing rendering of the row list."""
+
+    def test_no_rows(self):
+        assert format_sql_result([]) == "No results found."
+
+    def test_header_counts_rows(self):
+        out = format_sql_result([{"a": 1}, {"a": 2}])
+        assert out.splitlines()[0] == "Results: 2 row(s)"
+
+    def test_rows_are_numbered_from_one(self):
+        out = format_sql_result([{"a": 1}, {"a": 2}])
+        assert "--- Row 1 ---" in out
+        assert "--- Row 2 ---" in out
+
+    def test_columns_rendered_as_key_value_lines(self):
+        out = format_sql_result([{"entry_id": "e-1", "author": "jsmith"}])
+        assert "  entry_id: e-1" in out
+        assert "  author: jsmith" in out
+
+    def test_non_string_values_are_stringified(self):
+        out = format_sql_result([{"count": 42, "missing": None}])
+        assert "  count: 42" in out
+        assert "  missing: None" in out
+
+    def test_long_values_truncated_at_200_chars(self):
+        out = format_sql_result([{"raw_text": "x" * 500}])
+        rendered = next(line for line in out.splitlines() if line.startswith("  raw_text: "))
+        value = rendered.removeprefix("  raw_text: ")
+        assert value == "x" * 200 + "..."
+
+    def test_value_at_the_truncation_boundary_is_kept_whole(self):
+        out = format_sql_result([{"raw_text": "x" * 200}])
+        assert "  raw_text: " + "x" * 200 in out
+        assert "..." not in out


### PR DESCRIPTION
`src/osprey/services/ariel_search/` was the largest remaining pool of untested code: 3,186
statements with 674 uncovered (79%). ARIEL is the logbook interface operators query directly, so
untested ingest and search paths are where silent regressions in answers come from.

This phase adds fast, fake-backed unit tests over logic that previously only ran under containers.
The container-backed `integration/` suite is untouched and remains the two-party contract check —
the new tests assert emitted SQL and recorded call sequences, never database outcomes, so ordering
and ranking stay container-verified.

**Coverage: 79% → 99% (674 → 11 uncovered statements).**

## What changed

**Production code — one consistency edit.** `ingestion/adapters/__init__.py` now calls
`registry.initialize(silent=True)` unconditionally instead of first checking the registry's private
`_initialized` attribute. `RegistryManager.initialize` already self-guards, so the caller-side check
only duplicated private state across a module boundary. Net: 1 insertion, 2 deletions.

**Shared test infrastructure.** A fake pool/connection/cursor family covering the package's three
connection-acquisition shapes (`await conn.execute`, `dict_row` cursors, bare positional-tuple
cursors), with per-call SQL/params recording, substring-scripted results and exception injection;
a recording DDL connection for migration tests; and a fake embedding provider. The autouse service
-singleton fixture is hardened: it resets before each test and, at teardown, reports a still-live
instance with a `ResourceWarning` naming `close_ariel_service()` rather than silently resetting a
possibly-live service.

**Unit coverage across the package.** Repository error-wrapping (breadcrumb, message and cause
chain) and re-ingest upsert semantics; the CLI ingest and maintenance operations including daemon
signal handling and both purge branches; ingestion adapter retry, HTTP and XML fallback branches;
the `sql_query` allowlist/denylist security surface; migration rollback, status, dry-run and DDL
bodies; and the service and enhancement branches.

Historically bug-prone semantics are pinned with docstrings naming each hazard: the re-ingest
overwrite set, the attachments `'[]'::jsonb` preservation CASE, `enhancement_status` omission from
`DO UPDATE`, the missing-id `''` fallback and its upsert-collision consequence, the
malformed-timestamp fallback, and the `_check_tables_exist` first-outcome-permanent latch.

Two hygiene fixes found along the way: `test_database.py`'s topological-sort tests called a
copy-pasted reimplementation of the algorithm rather than the real `MigrationRunner._topological_sort`
(repointed, copy deleted, circular-dependency case added), and a stale `mock_search_service` fixture
that constructed `ARIELSearchResult` with nonexistent kwargs was removed.

## Verification

Coverage gate, byte-identical to the baseline receipt command:

```
TESTCONTAINERS_RYUK_DISABLED=1 .venv/bin/python -m pytest tests/services/ariel_search/ \
  --cov=src/osprey/services/ariel_search --cov-report=term-missing
TOTAL   3185   11   99%          (1107 passed, 2 skipped)
```

Full unit lane, both shapes, on the head commit:

```
TESTCONTAINERS_RYUK_DISABLED=1 .venv/bin/python -m pytest tests/ --ignore=tests/e2e -n 4 --dist loadgroup
==== 11839 passed, 39 skipped, 1 xfailed, 34 warnings in 272.78s (0:04:32) =====

TESTCONTAINERS_RYUK_DISABLED=1 .venv/bin/python -m pytest tests/ --ignore=tests/e2e
==== 11839 passed, 39 skipped, 1 xfailed, 31 warnings in 905.09s (0:15:05) =====
```

Identical counts across shapes; +408 tests against the 11,431 / 39 / 1 baseline.

```
.venv/bin/python -m pytest tests/infrastructure/test_import_time_audit.py -q
2 passed
```

Import-time audit passes with no WHITELIST additions. `git grep -l 'xdist_group'
tests/services/ariel_search/` returns exactly the 9 files that carried it before (8 in
`integration/` plus `test_apply_seed.py`) — no new test joins the docker group, and every new test
runs with no Postgres, Docker, Ollama or network on any xdist worker.

The remaining 11 uncovered statements sit in eight modules outside this phase's scope
(`database/connection.py`, `enhancement/base.py`, `ingestion/base.py`, `capabilities.py`,
`config.py`, `database/__init__.py`, `enhancement/factory.py`, `search/base.py`), 1–2 statements
each.

## Follow-ups, deliberately out of scope

- `src/osprey/cli/registry_cmd.py:25` still uses the private-attr guard replaced here; its tests
  drive both branches off `_initialized`.
- `cli_operations.run_sync` has an unreachable `else "unknown"` progress fallback — the ingestion
  block is always synthesized and `IngestionConfig` is always truthy, so an unset `source_url`
  prints `None`.
