### PR TITLE
feat(bridges): add channel-agnostic engine for dispatch bridges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Added
 
+- New `osprey.bridges.core` package: a channel-agnostic engine for connecting a
+  chat or email channel to the OSPREY dispatcher/worker pair as its own process.
+  It owns the parts that are the same for every channel — a crash-safe dedup
+  claim taken before dispatch, conversation history replayed with each question,
+  a retry queue drained in the background once the pair is healthy again, startup
+  recovery for messages that were in flight when the process stopped, and worker
+  artifact handling. A channel contributes only its wire format and platform I/O,
+  through the `ChannelOps` seam.
 - Every service image is now overridable through the same `env → config →
   default` chain: new `OSPREY_POSTGRES_IMAGE` env var plus
   `services.postgresql.image`, `services.openobserve.image`, and

--- a/src/osprey/bridges/__init__.py
+++ b/src/osprey/bridges/__init__.py
@@ -1,0 +1,10 @@
+"""OSPREY dispatch bridges.
+
+Bridges connect an external messaging channel (chat, email, ...) to the OSPREY
+dispatcher/worker pair. Each channel ships its own adapter package alongside the
+channel-agnostic engine in :mod:`osprey.bridges.core`; an adapter contributes only
+its own wire format and platform I/O.
+
+Subpackages:
+    core — channel-agnostic bridge engine (stores, dispatch client, pipeline, runtime)
+"""

--- a/src/osprey/bridges/core/__init__.py
+++ b/src/osprey/bridges/core/__init__.py
@@ -13,7 +13,7 @@ SDK imports**. Keep it that way: the isolation is what lets a bridge run as its 
 process against any deployment of the pair.
 
 Layers:
-    Primitives
+    Promoted primitives
         store — lock-guarded JSON file store (persistence substrate)
         config — ``CoreConfig`` and the terminal-status set
         dedup — at-least-once claim/CAS-transition store
@@ -25,11 +25,12 @@ Layers:
         dispatch_client — three-step dispatch handshake
         drain — supervised retry-queue drain thread
 
-    Message pipeline
+    Hoisted pipeline
         ports — the ``ChannelOps`` seam adapters implement
         pipeline — ``handle_event``, the per-message ordering specification
         retry_queue — park / give-up / supersede-at-enqueue
         reconcile — startup crash recovery for in-flight messages
+        runtime — collaborator wiring and drain supervision
 """
 
 from .artifacts import (
@@ -60,6 +61,7 @@ from .ports import (
 from .reconcile import ReconcileDeps, ReconcileReport, deliver_terminal, reconcile_inflight
 from .retry import coalesce_key, give_up_due, is_eligible, is_retryable, may_redispatch
 from .retry_queue import SUPERSEDED_STATUS, give_up, park, supersede_at_enqueue, supersede_note
+from .runtime import BridgeRuntime, build_deps, build_drain_deps, run_forever, start
 from .store import JsonFileStore
 
 __all__ = [
@@ -96,11 +98,14 @@ __all__ = [
     "ReplyContext",
     # engine entry points
     "SUPERSEDED_STATUS",
+    "BridgeRuntime",
     "DrainCallbacks",
     "DrainDeps",
     "PipelineDeps",
     "ReconcileDeps",
     "ReconcileReport",
+    "build_deps",
+    "build_drain_deps",
     "deliver_terminal",
     "drain_once",
     "ensure_alive",
@@ -109,6 +114,8 @@ __all__ = [
     "park",
     "reconcile_inflight",
     "run_drain_thread",
+    "run_forever",
+    "start",
     "supersede_at_enqueue",
     "supersede_note",
 ]

--- a/src/osprey/bridges/core/__init__.py
+++ b/src/osprey/bridges/core/__init__.py
@@ -1,29 +1,79 @@
 """Channel-agnostic core shared by OSPREY dispatch bridges.
 
-The crash-safe local stores and shared configuration every channel needs. A channel
-adapter composes this package and adds only its own wire format on top.
+A thin HTTP client of the OSPREY dispatcher/worker pair, plus the crash-safe local
+stores every channel needs. A channel adapter composes this package and adds only its
+own wire format on top.
 
-The engine has **no channel imports** (no chat/email specifics), **no imports of
-osprey dispatch internals**, and **no agent SDK imports**. Keep it that way: the
-isolation is what lets a bridge run as its own process against any deployment of the
-dispatcher/worker pair.
+The engine talks to the pair over HTTP only — ``POST {dispatcher}/webhook/{trigger}``,
+``GET {dispatcher}/dispatch/{dispatch_id}``, ``GET {worker}/dispatch/{run_id}``, the
+worker artifact byte route, and ``GET /health`` on both. It has **no channel imports**
+(no chat/email specifics), **no imports of osprey dispatch internals**, and **no agent
+SDK imports**. Keep it that way: the isolation is what lets a bridge run as its own
+process against any deployment of the pair.
 
 Modules:
     store — lock-guarded JSON file store (persistence substrate)
     config — ``CoreConfig`` and the terminal-status set
     dedup — at-least-once claim/CAS-transition store
     history — per-conversation transcript replayed on each dispatch
+    retry — pure, fail-closed retry policy
+    capabilities — fail-closed peer capability probe
+    health_gate — drain gate over dispatcher/worker health
+    artifacts — worker artifact fetch and normalization
+    dispatch_client — three-step dispatch handshake
+    drain — supervised retry-queue drain thread
 """
 
+from .artifacts import (
+    MAX_ARTIFACT_BYTES,
+    MAX_DOC_BYTES,
+    PNG_MAGIC,
+    artifact_ids,
+    ext_for_mime,
+    fetch_artifact,
+    safe_label,
+    split_artifacts,
+)
+from .capabilities import pair_supports
 from .config import TERMINAL_STATUSES, CoreConfig
 from .dedup import DedupStore
+from .dispatch_client import DispatchClient, DispatchError
+from .drain import DrainCallbacks, DrainDeps, drain_once, ensure_alive, run_drain_thread
+from .health_gate import gate_open
 from .history import HistoryStore
+from .retry import coalesce_key, give_up_due, is_eligible, is_retryable, may_redispatch
 from .store import JsonFileStore
 
 __all__ = [
+    # config + persistence substrate
     "TERMINAL_STATUSES",
     "CoreConfig",
     "DedupStore",
     "HistoryStore",
     "JsonFileStore",
+    # retry policy
+    "coalesce_key",
+    "give_up_due",
+    "is_eligible",
+    "is_retryable",
+    "may_redispatch",
+    # the pair over HTTP
+    "MAX_ARTIFACT_BYTES",
+    "MAX_DOC_BYTES",
+    "PNG_MAGIC",
+    "DispatchClient",
+    "DispatchError",
+    "artifact_ids",
+    "ext_for_mime",
+    "fetch_artifact",
+    "gate_open",
+    "pair_supports",
+    "safe_label",
+    "split_artifacts",
+    # retry-queue drain
+    "DrainCallbacks",
+    "DrainDeps",
+    "drain_once",
+    "ensure_alive",
+    "run_drain_thread",
 ]

--- a/src/osprey/bridges/core/__init__.py
+++ b/src/osprey/bridges/core/__init__.py
@@ -1,0 +1,29 @@
+"""Channel-agnostic core shared by OSPREY dispatch bridges.
+
+The crash-safe local stores and shared configuration every channel needs. A channel
+adapter composes this package and adds only its own wire format on top.
+
+The engine has **no channel imports** (no chat/email specifics), **no imports of
+osprey dispatch internals**, and **no agent SDK imports**. Keep it that way: the
+isolation is what lets a bridge run as its own process against any deployment of the
+dispatcher/worker pair.
+
+Modules:
+    store — lock-guarded JSON file store (persistence substrate)
+    config — ``CoreConfig`` and the terminal-status set
+    dedup — at-least-once claim/CAS-transition store
+    history — per-conversation transcript replayed on each dispatch
+"""
+
+from .config import TERMINAL_STATUSES, CoreConfig
+from .dedup import DedupStore
+from .history import HistoryStore
+from .store import JsonFileStore
+
+__all__ = [
+    "TERMINAL_STATUSES",
+    "CoreConfig",
+    "DedupStore",
+    "HistoryStore",
+    "JsonFileStore",
+]

--- a/src/osprey/bridges/core/__init__.py
+++ b/src/osprey/bridges/core/__init__.py
@@ -1,8 +1,9 @@
 """Channel-agnostic core shared by OSPREY dispatch bridges.
 
 A thin HTTP client of the OSPREY dispatcher/worker pair, plus the crash-safe local
-stores every channel needs. A channel adapter composes this package and adds only its
-own wire format on top.
+stores and the ordering-critical message pipeline every channel needs. A channel
+adapter composes this package with a :class:`ChannelOps` implementation and adds
+only its own wire format on top.
 
 The engine talks to the pair over HTTP only — ``POST {dispatcher}/webhook/{trigger}``,
 ``GET {dispatcher}/dispatch/{dispatch_id}``, ``GET {worker}/dispatch/{run_id}``, the
@@ -11,17 +12,24 @@ worker artifact byte route, and ``GET /health`` on both. It has **no channel imp
 SDK imports**. Keep it that way: the isolation is what lets a bridge run as its own
 process against any deployment of the pair.
 
-Modules:
-    store — lock-guarded JSON file store (persistence substrate)
-    config — ``CoreConfig`` and the terminal-status set
-    dedup — at-least-once claim/CAS-transition store
-    history — per-conversation transcript replayed on each dispatch
-    retry — pure, fail-closed retry policy
-    capabilities — fail-closed peer capability probe
-    health_gate — drain gate over dispatcher/worker health
-    artifacts — worker artifact fetch and normalization
-    dispatch_client — three-step dispatch handshake
-    drain — supervised retry-queue drain thread
+Layers:
+    Primitives
+        store — lock-guarded JSON file store (persistence substrate)
+        config — ``CoreConfig`` and the terminal-status set
+        dedup — at-least-once claim/CAS-transition store
+        history — per-conversation transcript replayed on each dispatch
+        retry — pure, fail-closed retry policy
+        capabilities — fail-closed peer capability probe
+        health_gate — drain gate over dispatcher/worker health
+        artifacts — worker artifact fetch and normalization
+        dispatch_client — three-step dispatch handshake
+        drain — supervised retry-queue drain thread
+
+    Message pipeline
+        ports — the ``ChannelOps`` seam adapters implement
+        pipeline — ``handle_event``, the per-message ordering specification
+        retry_queue — park / give-up / supersede-at-enqueue
+        reconcile — startup crash recovery for in-flight messages
 """
 
 from .artifacts import (
@@ -41,7 +49,17 @@ from .dispatch_client import DispatchClient, DispatchError
 from .drain import DrainCallbacks, DrainDeps, drain_once, ensure_alive, run_drain_thread
 from .health_gate import gate_open
 from .history import HistoryStore
+from .pipeline import PipelineDeps, handle_event
+from .ports import (
+    RESERVED_ENTRY_KEYS,
+    ChannelOps,
+    InboundEvent,
+    InputDownload,
+    ReplyContext,
+)
+from .reconcile import ReconcileDeps, ReconcileReport, deliver_terminal, reconcile_inflight
 from .retry import coalesce_key, give_up_due, is_eligible, is_retryable, may_redispatch
+from .retry_queue import SUPERSEDED_STATUS, give_up, park, supersede_at_enqueue, supersede_note
 from .store import JsonFileStore
 
 __all__ = [
@@ -70,10 +88,27 @@ __all__ = [
     "pair_supports",
     "safe_label",
     "split_artifacts",
-    # retry-queue drain
+    # the seam adapters implement
+    "RESERVED_ENTRY_KEYS",
+    "ChannelOps",
+    "InboundEvent",
+    "InputDownload",
+    "ReplyContext",
+    # engine entry points
+    "SUPERSEDED_STATUS",
     "DrainCallbacks",
     "DrainDeps",
+    "PipelineDeps",
+    "ReconcileDeps",
+    "ReconcileReport",
+    "deliver_terminal",
     "drain_once",
     "ensure_alive",
+    "give_up",
+    "handle_event",
+    "park",
+    "reconcile_inflight",
     "run_drain_thread",
+    "supersede_at_enqueue",
+    "supersede_note",
 ]

--- a/src/osprey/bridges/core/artifacts.py
+++ b/src/osprey/bridges/core/artifacts.py
@@ -1,0 +1,182 @@
+"""Fetch agent-generated plot artifacts from the dispatch worker.
+
+This is the channel-agnostic *fetch* half of artifact delivery: given a run and
+an artifact id, pull the bytes over the worker's authenticated byte route and
+apply the size / PNG-magic guards. What a channel then DOES with those bytes —
+republish them as a public object for an image widget, attach them as MIME
+parts, share them over WebDAV — stays in the channel package.
+
+``artifact_ids`` normalizes the run-status body's ``artifacts`` field (osprey
+#363 descriptor dicts, or bare id strings from an older worker) to a plain list
+of artifact-id strings.
+
+Nothing here raises to the caller: a fetch failure must degrade to fewer (or
+zero) images, never break the text answer. NO channel imports, NO osprey
+dispatch imports.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from .config import CoreConfig
+
+logger = logging.getLogger(__name__)
+
+# PNG magic bytes: any payload not starting with this is rejected.
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+# Oversize guard: a large image renders as a *broken* widget in most chat
+# surfaces, which is strictly worse than posting no image at all. This is a
+# rendering bound, not a memory bound — the body is already fully read by the
+# time it is checked.
+MAX_ARTIFACT_BYTES = 2 * 1024 * 1024
+
+# Same kind of bound as MAX_ARTIFACT_BYTES, but for non-image documents: a
+# rendering/sanity bound, not a memory bound — fetch_artifact reads the full
+# body before the size check runs.
+MAX_DOC_BYTES = 10 * 1024 * 1024
+
+
+def artifact_ids(artifacts: list[Any] | None) -> list[str]:
+    """Normalize a run's ``artifacts`` field to a list of artifact-id strings.
+
+    Accepts either osprey #363 descriptor dicts (``{"artifact_id": ...}``) or
+    bare id strings (an older worker still answering during the deploy window),
+    in any mix. Anything else — a dict without a usable ``artifact_id``, a
+    non-str/non-dict element — is skipped rather than raised on, so a malformed
+    entry costs at most one image, never the whole answer.
+    """
+    ids: list[str] = []
+    for a in artifacts or []:
+        if isinstance(a, str):
+            if a:
+                ids.append(a)
+        elif isinstance(a, dict):
+            aid = a.get("artifact_id")
+            if isinstance(aid, str) and aid:
+                ids.append(aid)
+        # else: unknown shape -> skip
+    return ids
+
+
+def split_artifacts(artifacts: list[Any] | None) -> tuple[list[str], list[dict]]:
+    """Split a run's ``artifacts`` field into ``(image_ids, doc_descriptors)``.
+
+    Mirrors ``artifact_ids``'s tolerance for the same input shapes (osprey #363
+    descriptor dicts, bare id strings from an older worker, or a mix), but
+    additionally routes each entry by ``delivered_mime``: PNG images go to
+    ``image_ids`` (id strings, matching the inline-image path); every other
+    artifact — including a descriptor with no ``delivered_mime`` key at all —
+    goes to ``doc_descriptors`` as the *full* dict, since a document delivery
+    path needs ``filename``/``delivered_mime`` that a bare id string can't
+    carry. A bare string is back-compat for an older worker with no mime at
+    all, so it is treated as the existing PNG image path. Anything else — a
+    dict without a usable ``artifact_id``, a non-str/non-dict element — is
+    skipped rather than raised on, same as ``artifact_ids``. Every id ends up
+    in exactly one bucket.
+    """
+    image_ids: list[str] = []
+    doc_descriptors: list[dict] = []
+    for a in artifacts or []:
+        if isinstance(a, str):
+            if a:
+                image_ids.append(a)
+        elif isinstance(a, dict):
+            aid = a.get("artifact_id")
+            if isinstance(aid, str) and aid:
+                if a.get("delivered_mime") == "image/png":
+                    image_ids.append(aid)
+                else:
+                    doc_descriptors.append(a)
+        # else: unknown shape -> skip
+    return image_ids, doc_descriptors
+
+
+# Fixed allowlist: an extension is derived ONLY from the mime, never a
+# worker-supplied filename, so no "/" or ".." can enter a storage object key.
+_EXT_BY_MIME = {
+    "text/html": ".html",
+    "text/markdown": ".md",
+    "text/plain": ".txt",
+    "application/pdf": ".pdf",
+    "text/csv": ".csv",
+    "application/json": ".json",
+    "image/jpeg": ".jpg",
+    "image/svg+xml": ".svg",
+}
+
+
+def ext_for_mime(mime: str | None) -> str:
+    """Map a ``delivered_mime`` to a file extension via a fixed allowlist.
+
+    Unknown or ``None`` mimes fall back to ``.bin`` rather than raising or
+    deriving anything from worker-supplied data.
+    """
+    if mime is None:
+        return ".bin"
+    return _EXT_BY_MIME.get(mime, ".bin")
+
+
+def safe_label(name: str | None, fallback: str) -> str:
+    """Strip CR/LF (a header-injection / serialization hazard) and bound the
+    length of a worker-supplied name.
+
+    Used for a user-visible label (never a storage object key) and for an
+    attachment filename.
+    """
+    cleaned = (name or "").replace("\r", "").replace("\n", "").strip()
+    return (cleaned or fallback)[:200]
+
+
+def fetch_artifact(
+    http: httpx.Client,
+    cfg: CoreConfig,
+    run_id: str,
+    artifact_id: str,
+    *,
+    max_bytes: int = MAX_ARTIFACT_BYTES,
+    require_png: bool = True,
+) -> bytes | None:
+    """Fetch one artifact's bytes from the worker; ``None`` on any failure or a
+    payload that fails the size guard (or the PNG-magic guard when required).
+
+    ``require_png`` defaults to ``True`` for image widgets that only render PNG.
+    A channel that delivers arbitrary MIME (attaching the worker's
+    ``delivered_mime`` bytes verbatim) passes ``require_png=False`` and a
+    suitable ``max_bytes``, keeping only the size guard.
+
+    The caller owns the ``httpx.Client``; build it with
+    ``httpx.Client(trust_env=cfg.trust_env)`` so proxy handling comes from
+    config rather than from whatever the ambient environment happens to set.
+    """
+    url = f"{cfg.worker_url}/dispatch/{run_id}/artifacts/{artifact_id}"
+    headers = {"Authorization": f"Bearer {cfg.dispatch_worker_token}"}
+    try:
+        resp = http.get(url, headers=headers)
+        resp.raise_for_status()
+        data = resp.content
+    except Exception as exc:
+        # Deliberately broad: ``httpx.InvalidURL`` does NOT subclass
+        # ``httpx.HTTPError`` and is raised at URL-construction time, before
+        # any transport error can occur. ``artifact_id`` is worker-supplied, so
+        # a control character in it would otherwise escape and cost the user
+        # the whole text answer. BaseException still propagates.
+        logger.warning("artifact fetch failed for %s/%s: %s", run_id, artifact_id, exc)
+        return None
+    if len(data) > max_bytes:
+        logger.warning(
+            "artifact %s/%s oversize (%d bytes > %d), skipping",
+            run_id,
+            artifact_id,
+            len(data),
+            max_bytes,
+        )
+        return None
+    if require_png and not data.startswith(PNG_MAGIC):
+        logger.warning("artifact %s/%s is not a PNG, skipping", run_id, artifact_id)
+        return None
+    return data

--- a/src/osprey/bridges/core/capabilities.py
+++ b/src/osprey/bridges/core/capabilities.py
@@ -1,0 +1,93 @@
+"""Per-dispatch capability probe for the OSPREY dispatch pair.
+
+Some dispatches carry a payload that only newer dispatcher/worker builds accept —
+the prime case is ``input_files`` (attachment bytes handed to the agent). Before
+a bridge fires such a dispatch it must confirm BOTH halves of the pair advertise
+the capability: a dispatch whose files reach an old worker would fail (or worse,
+silently drop them) *after* the user's message was already accepted.
+
+:func:`pair_supports` is that go/no-go check. It GETs ``/health`` on both the
+dispatcher and the worker and returns ``True`` only when the named capability
+appears in the ``"capabilities"`` list of BOTH bodies. It is **fail-closed**:
+any non-200, timeout, malformed body, missing/non-list ``capabilities`` key, or
+transport error on EITHER endpoint yields ``False``.
+
+There is deliberately **no caching** — capability is re-probed immediately before
+every capability-carrying dispatch, so a mid-session worker downgrade (or a
+just-completed upgrade) is observed on the very next dispatch rather than sticking
+to a stale answer.
+
+Consistent with :mod:`osprey.bridges.core.health_gate` (which GETs the same two
+``/health`` endpoints for the drain gate): a short per-request timeout, and the
+default client honors ``cfg.trust_env`` — ``False`` by default, so it ignores
+``HTTP(S)_PROXY`` and reaches the localhost endpoints directly. Tests inject their
+own :class:`httpx.MockTransport` client.
+
+Like every ``osprey.bridges.core`` module this carries ZERO osprey imports and
+ZERO channel (chat/email) imports — pure stdlib + httpx.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Short per-request timeout: a hung dispatcher/worker must fail the probe closed
+# quickly rather than stall the dispatch it gates. Matches health_gate._TIMEOUT.
+_TIMEOUT = 10.0
+
+
+def _health_capabilities(http: httpx.Client, base_url: str) -> frozenset[str] | None:
+    """The capability set advertised by ``{base_url}/health``, or ``None`` on any
+    failure.
+
+    Fail-closed: a non-200, non-JSON body, or a missing/non-list ``capabilities``
+    key -> ``None``. ``None`` is distinct from an empty ``frozenset`` (a healthy
+    endpoint that advertises no capabilities) — the caller treats both as "does
+    not support X", but only the empty set means the probe actually succeeded.
+    Non-string entries in the list are ignored.
+    """
+    try:
+        resp = http.get(f"{base_url}/health")
+        if resp.status_code != 200:
+            logger.warning("capability probe %s/health returned %d", base_url, resp.status_code)
+            return None
+        caps = resp.json().get("capabilities")
+        if not isinstance(caps, list):
+            logger.warning("capability probe %s/health missing capabilities list", base_url)
+            return None
+        return frozenset(c for c in caps if isinstance(c, str))
+    except Exception as exc:
+        logger.warning("capability probe %s/health failed: %s", base_url, exc)
+        return None
+
+
+def pair_supports(cfg, capability: str, http: httpx.Client | None = None) -> bool:
+    """Return ``True`` only if BOTH the dispatcher and the worker advertise
+    ``capability`` in their ``/health`` body.
+
+    Probes ``cfg.dispatcher_url`` then ``cfg.worker_url`` (the real
+    :class:`~osprey.bridges.core.config.CoreConfig` field names, shared with
+    :func:`osprey.bridges.core.health_gate.gate_open`). **Fail-closed**: if either
+    probe fails for any reason, or either side omits the capability, returns
+    ``False``. The worker is not probed when the dispatcher already lacks it
+    (short-circuit).
+
+    No caching — call this immediately before every dispatch that carries the
+    capability's payload. ``http`` is injectable for tests; otherwise a client is
+    built and closed here, honoring ``cfg.trust_env`` for proxy handling.
+    """
+    own_client = http is None
+    client = http or httpx.Client(timeout=_TIMEOUT, trust_env=cfg.trust_env)
+    try:
+        disp = _health_capabilities(client, cfg.dispatcher_url)
+        if disp is None or capability not in disp:
+            return False
+        work = _health_capabilities(client, cfg.worker_url)
+        return work is not None and capability in work
+    finally:
+        if own_client:
+            client.close()

--- a/src/osprey/bridges/core/config.py
+++ b/src/osprey/bridges/core/config.py
@@ -1,0 +1,188 @@
+"""Channel-neutral configuration shared by every dispatch bridge.
+
+:class:`CoreConfig` carries ONLY the fields a bridge needs to talk to the
+``osprey.dispatch`` pair and persist its local crash-safety stores — the
+dispatcher/worker URLs + tokens, the trigger name, the poll budget, and the
+dedup/history store paths. Nothing here is chat-, email-, or otherwise
+channel-specific, and (like every ``osprey.bridges.core`` module) it carries ZERO
+osprey dispatch imports.
+
+Each channel's own config *composes* a ``CoreConfig`` for these neutral fields
+and adds its channel-specific ones on top.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+# Statuses that mean an entry needs no further work. "completed"/"error" are
+# the worker's terminal run states; "post_failed" is bridge-local — the run
+# finished but delivering the reply failed permanently (do NOT retry on
+# restart). "superseded" is bridge-local too — a queued entry dropped because a
+# newer question in the same conversation coalesced over it; it MUST be
+# terminal, or DedupStore.reconcile() would re-surface it on restart and re-run
+# the deliberately dropped question. None of these is channel-specific, so they
+# live in the core.
+TERMINAL_STATUSES = frozenset({"completed", "error", "post_failed", "superseded"})
+
+# Spellings accepted as "on" for boolean env vars, matching the rest of the
+# repo (``osprey.interfaces.vendor``, ``osprey.services.bluesky_bridge``).
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+@dataclass
+class CoreConfig:
+    """Channel-neutral dispatch + local-store configuration.
+
+    Field names are the contract every ``osprey.bridges.core`` collaborator reads
+    (:class:`~osprey.bridges.core.dispatch_client.DispatchClient`,
+    :func:`~osprey.bridges.core.artifacts.fetch_artifact`, the stores). A channel
+    config that exposes these same attributes is a structural superset and works
+    anywhere a ``CoreConfig`` is expected.
+    """
+
+    # --- Dispatch pipeline endpoints ---------------------------------------
+    dispatcher_url: str = "http://localhost:8010"
+    worker_url: str = "http://localhost:9190"
+    event_dispatcher_token: str = ""
+    """Bearer token for the dispatcher webhook (inbound to :8010)."""
+
+    dispatch_worker_token: str = ""
+    """Bearer token for the worker run-status/artifact endpoints (:9190)."""
+
+    trigger: str = ""
+    """Dispatcher trigger to fire (``POST /webhook/{trigger}``). Channel-set —
+    the ONLY per-channel difference in the dispatched agent."""
+
+    # --- Polling controls ---------------------------------------------------
+    poll_interval: float = 2.0
+    """Seconds between worker status polls."""
+
+    poll_budget: float = 330.0
+    """Max seconds to poll before giving up. Must be at least ``worker_timeout``."""
+
+    worker_timeout: float = 300.0
+    """The worker's own per-run wall-clock cap, in seconds — the deployment's
+    ``DISPATCH_TIMEOUT_SEC``. Not used to time anything here; it is the floor
+    ``poll_budget`` is validated against, so a facility that raises the worker's
+    cap cannot leave the bridge abandoning runs that are still alive."""
+
+    # --- HTTP client behavior -----------------------------------------------
+    trust_env: bool = False
+    """Whether outbound HTTP clients honor ambient ``HTTP(S)_PROXY``/``NO_PROXY``.
+
+    Default ``False``: the dispatcher, the worker, and (where configured) the
+    alert host are reached directly, so a proxy inherited from a dev shell or CI
+    runner cannot silently mount itself in front of them. A site whose bridge
+    genuinely sits behind an egress proxy sets this true."""
+
+    # --- Retry queue / drain controls --------------------------------------
+    drain_interval: float = 60.0
+    """Seconds between drain-loop passes over the retry queue."""
+
+    retry_min_age: float = 1200.0
+    """Minimum age (s) a queued entry must reach before the drain retries it —
+    holds a failed dispatch back long enough for a transient outage to clear."""
+
+    retry_give_up: float = 172800.0
+    """Age (s) past which a queued entry that still cannot dispatch is abandoned
+    (an alert issue is filed instead of retrying forever). Default 48h."""
+
+    retry_lifetime_cap: float = 604800.0
+    """Hard ceiling (s) on how long any entry may live in the store before the
+    drain reaps it regardless of status. Default 7d."""
+
+    # --- GitLab alerts (give-up issue filing; opt-in) -----------------------
+    gitlab_url: str = ""
+    """Base URL of the GitLab instance used to file give-up issues. Empty means
+    the site has no alert host: no issues are filed and the health gate skips
+    its alert-issue check entirely."""
+
+    gitlab_project: str = ""
+    """Project path (namespace/name) that give-up issues are filed against."""
+
+    gitlab_issues_token: str = ""
+    """Token for the GitLab issues API. Unprefixed shared secret (like
+    ``event_dispatcher_token``) — read from ``GITLAB_ISSUES_TOKEN``."""
+
+    # --- Local state --------------------------------------------------------
+    dedup_path: str = "/data/dedup.json"
+    """Path to the persisted message_id -> run store (bridge-owned volume)."""
+
+    history_path: str = "/data/history.json"
+    """Path to the persisted per-conversation transcript store (same volume)."""
+
+    def __post_init__(self) -> None:
+        # The worker caps runs at `worker_timeout`; polling must outlast that to
+        # observe the terminal (timeout) result instead of racing it.
+        if self.poll_budget < self.worker_timeout:
+            raise ValueError(
+                f"poll_budget must be >= {self.worker_timeout}s (worker cap); "
+                f"got {self.poll_budget}"
+            )
+        # Drain/retry tunables are durations — a non-positive value would make the
+        # drain loop spin or reap everything immediately.
+        for name in (
+            "worker_timeout",
+            "drain_interval",
+            "retry_min_age",
+            "retry_give_up",
+            "retry_lifetime_cap",
+        ):
+            value = getattr(self, name)
+            if value <= 0:
+                raise ValueError(f"{name} must be > 0; got {value}")
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> CoreConfig:
+        """Build the neutral config from environment variables.
+
+        Reads channel-neutral names (no channel prefix); a channel config maps
+        its own prefixed vars onto these fields when it composes a
+        ``CoreConfig``.
+        """
+        e = os.environ if env is None else env
+
+        def _f(name: str, default: float) -> float:
+            raw = e.get(name)
+            if raw is None or raw == "":
+                return default
+            return float(raw)
+
+        def _b(name: str, default: bool) -> bool:
+            raw = e.get(name)
+            if raw is None or raw == "":
+                return default
+            return raw.strip().lower() in _TRUTHY
+
+        return cls(
+            dispatcher_url=e.get("DISPATCHER_URL", "http://localhost:8010").rstrip("/"),
+            worker_url=e.get("WORKER_URL", "http://localhost:9190").rstrip("/"),
+            event_dispatcher_token=e.get("EVENT_DISPATCHER_TOKEN", ""),
+            dispatch_worker_token=e.get("DISPATCH_WORKER_TOKEN", ""),
+            trigger=e.get("DISPATCH_TRIGGER", ""),
+            poll_interval=_f("POLL_INTERVAL", 2.0),
+            poll_budget=_f("POLL_BUDGET", 330.0),
+            # Same var the worker itself reads, so a deployment that raises the
+            # cap raises it for both halves from one setting.
+            worker_timeout=_f("DISPATCH_TIMEOUT_SEC", 300.0),
+            trust_env=_b("BRIDGE_TRUST_ENV", False),
+            drain_interval=_f("DRAIN_INTERVAL", 60.0),
+            retry_min_age=_f("RETRY_MIN_AGE", 1200.0),
+            retry_give_up=_f("RETRY_GIVE_UP", 172800.0),
+            retry_lifetime_cap=_f("RETRY_LIFETIME_CAP", 604800.0),
+            gitlab_url=e.get("GITLAB_URL", "").rstrip("/"),
+            gitlab_project=e.get("GITLAB_PROJECT", ""),
+            gitlab_issues_token=e.get("GITLAB_ISSUES_TOKEN", ""),
+            dedup_path=e.get("DEDUP_PATH", "/data/dedup.json"),
+            history_path=e.get("HISTORY_PATH", "/data/history.json"),
+        )
+
+    def require(self, *names: str) -> None:
+        """Raise if any of the named fields are unset. Used by an entrypoint to
+        fail fast before entering its poll loop."""
+        missing = [n for n in names if not getattr(self, n)]
+        if missing:
+            raise ValueError(f"missing required config: {', '.join(missing)}")

--- a/src/osprey/bridges/core/dedup.py
+++ b/src/osprey/bridges/core/dedup.py
@@ -1,0 +1,222 @@
+"""Crash-safe dedup / run store for a bridge.
+
+Guards against two failure modes:
+
+  * message *redelivery* — the same inbound message arriving more than once
+    (Pub/Sub redelivery, an IMAP re-poll). The message is marked processed only
+    after handling completes, so a crash mid-run redelivers it; the persisted
+    claim prevents re-dispatching.
+  * Bridge *restart* mid-run — on startup, :meth:`reconcile` reports the runs
+    that were still in flight so the caller can re-attach (poll the worker to
+    terminal + repost) instead of firing a brand-new dispatch.
+
+Backed by a small JSON file on a bridge-owned volume (persistence/locking in
+:class:`~osprey.bridges.core.store.JsonFileStore`). The store is a flat
+``message_id -> {"run_id": ..., "status": ..., <extra>}`` mapping. Extra metadata
+(space/thread/question, sender) is permitted so a restart can repost to the
+right destination; the core contract is only ``run_id`` + ``status``.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Any
+
+from .config import TERMINAL_STATUSES
+from .store import JsonFileStore
+
+# How long a terminal entry lingers before :meth:`DedupStore.claim` reaps it.
+# Chosen to exceed Pub/Sub's maximum redelivery window: as long as an entry can
+# still be redelivered, its dedup claim must survive to suppress a re-dispatch,
+# so pruning only after 7d preserves dedup correctness. A ``retry_now`` id that
+# outlives this window surfaces as "too old to retry" (its entry is gone).
+PRUNE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
+
+
+class DedupStore(JsonFileStore):
+    def __init__(self, path: str, *, now: Callable[[], float] = time.time) -> None:
+        # Injectable clock (epoch seconds) so tests drive prune ages with a fake
+        # clock, matching the ``now``-seam convention used across the core.
+        self._now = now
+        super().__init__(path)
+
+    # --- Internal helpers --------------------------------------------------
+    def _stamp_settled_if_terminal(self, entry: dict[str, Any], status: str) -> None:
+        """Record ``settled_at`` when an entry crosses into a terminal status,
+        marking the moment its 7d prune clock starts."""
+        if status in TERMINAL_STATUSES:
+            entry["settled_at"] = self._now()
+
+    def _prune_locked(self) -> None:
+        """Drop terminal entries older than :data:`PRUNE_MAX_AGE_SECONDS`.
+
+        Caller MUST hold ``self._lock``. Only terminal entries are considered —
+        ``pending`` / ``in_flight`` / ``queued`` are live work and never touched
+        (verified same-lock safe: this runs inside :meth:`claim`'s existing lock,
+        so it cannot race the drain or reconcile). An entry's age is measured
+        from ``settled_at`` (when it went terminal), falling back to
+        ``claimed_at`` (when it was first claimed).
+
+        A terminal entry carrying NEITHER timestamp is a pre-feature (ts-less)
+        entry: rather than delete it — which would drop a still-valid dedup claim
+        — it is grandfathered by stamping ``settled_at = now`` (persisted), so it
+        ages out one full window later instead of vanishing on first observation.
+        """
+        now = self._now()
+        changed = False
+        for message_id in list(self._data.keys()):
+            entry = self._data[message_id]
+            if entry.get("status") not in TERMINAL_STATUSES:
+                continue
+            ts = entry.get("settled_at")
+            if not isinstance(ts, (int, float)) or isinstance(ts, bool):
+                ts = entry.get("claimed_at")
+            if not isinstance(ts, (int, float)) or isinstance(ts, bool):
+                # Pre-feature ts-less terminal entry: grandfather to now.
+                entry["settled_at"] = now
+                changed = True
+                continue
+            if now - ts > PRUNE_MAX_AGE_SECONDS:
+                del self._data[message_id]
+                changed = True
+        if changed:
+            self._flush_locked()
+
+    # --- API ---------------------------------------------------------------
+    def seen(self, message_id: str) -> bool:
+        """True if we have already accepted this message id."""
+        with self._lock:
+            return message_id in self._data
+
+    def claim(self, message_id: str, **meta: Any) -> bool:
+        """Atomically claim a message id for processing.
+
+        Records a ``pending`` entry (``run_id=None``) and returns ``True`` iff
+        this call is the first to see ``message_id``. Concurrent redeliveries of
+        the same message therefore get exactly one ``True`` — the check and the
+        write happen under one lock, closing the seen()-then-record() race.
+
+        Prunes aged-out terminal entries first (see :meth:`_prune_locked`) under
+        this same lock: a redelivery of a long-since-pruned message finds its old
+        entry gone and re-claims cleanly.
+        """
+        with self._lock:
+            self._prune_locked()
+            if message_id in self._data:
+                return False
+            entry: dict[str, Any] = {
+                "run_id": None,
+                "status": "pending",
+                "claimed_at": self._now(),
+            }
+            if meta:
+                entry.update(meta)
+            self._data[message_id] = entry
+            self._flush_locked()
+            return True
+
+    def get(self, message_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            entry = self._data.get(message_id)
+            return dict(entry) if entry is not None else None
+
+    def record(
+        self,
+        message_id: str,
+        run_id: str | None,
+        status: str = "in_flight",
+        **meta: Any,
+    ) -> None:
+        """Upsert an entry. Sets ``run_id`` + ``status``; merges any ``meta``
+        (e.g. space/thread) while preserving previously stored fields.
+
+        A terminal entry is final: once a message has reached a terminal status
+        (see :data:`~osprey.bridges.core.config.TERMINAL_STATUSES`) this is a
+        no-op, so a late or duplicate callback cannot resurrect it into a
+        non-terminal (reconcilable) state and re-dispatch an already-answered
+        message on the next restart.
+        """
+        with self._lock:
+            entry = self._data.get(message_id)
+            if entry is not None and entry.get("status") in TERMINAL_STATUSES:
+                return
+            if entry is None:
+                entry = {}
+            entry["run_id"] = run_id
+            entry["status"] = status
+            if meta:
+                entry.update(meta)
+            self._stamp_settled_if_terminal(entry, status)
+            self._data[message_id] = entry
+            self._flush_locked()
+
+    def update_status(self, message_id: str, status: str) -> None:
+        """Set the status of an existing entry (no-op if unknown)."""
+        with self._lock:
+            entry = self._data.get(message_id)
+            if entry is None:
+                return
+            entry["status"] = status
+            self._stamp_settled_if_terminal(entry, status)
+            self._flush_locked()
+
+    def transition(
+        self,
+        message_id: str,
+        from_status: str,
+        to_status: str,
+        **meta: Any,
+    ) -> bool:
+        """Compare-and-set an entry's status under the single store lock.
+
+        Flips ``message_id`` from ``from_status`` to ``to_status`` iff the entry
+        exists AND is currently in ``from_status``, merging any ``meta`` on
+        success. Returns ``True`` when the flip was applied (and persisted),
+        ``False`` — with no write — when the entry is absent or its status does
+        not match ``from_status``.
+
+        This is the concurrency primitive of the retry queue: two threads racing
+        over the same entry (e.g. a drain flipping ``queued -> in_flight`` versus
+        a coalesce dropping ``queued -> superseded``) both read the same
+        ``from_status``, but only the first to run under the lock matches it and
+        wins; the loser sees the already-changed status and returns ``False``.
+        """
+        with self._lock:
+            entry = self._data.get(message_id)
+            if entry is None or entry.get("status") != from_status:
+                return False
+            entry["status"] = to_status
+            if meta:
+                entry.update(meta)
+            self._stamp_settled_if_terminal(entry, to_status)
+            self._data[message_id] = entry
+            self._flush_locked()
+            return True
+
+    def queued(self) -> dict[str, dict[str, Any]]:
+        """Return entries currently parked in the retry queue (``status ==
+        'queued'``). These are deliberately EXCLUDED from :meth:`reconcile` — the
+        drain loop owns them, not startup reconciliation."""
+        with self._lock:
+            return {
+                mid: dict(entry)
+                for mid, entry in self._data.items()
+                if entry.get("status") == "queued"
+            }
+
+    def reconcile(self) -> dict[str, dict[str, Any]]:
+        """Return entries that need re-attaching on startup: NOT terminal and
+        NOT ``queued``.
+
+        ``queued`` entries are retry-queue work owned by the drain loop, so they
+        are excluded here even though they are non-terminal — reconcile must not
+        re-dispatch them out from under the drain. ``queued`` is intentionally
+        kept OUT of :data:`~osprey.bridges.core.config.TERMINAL_STATUSES` (other
+        consumers key off that frozenset); the exclusion is explicit instead."""
+        with self._lock:
+            return {
+                mid: dict(entry)
+                for mid, entry in self._data.items()
+                if entry.get("status") not in TERMINAL_STATUSES and entry.get("status") != "queued"
+            }

--- a/src/osprey/bridges/core/dispatch_client.py
+++ b/src/osprey/bridges/core/dispatch_client.py
@@ -1,0 +1,318 @@
+"""HTTP client for the OSPREY dispatch pipeline.
+
+The full sequence:
+
+  1. ``POST {dispatcher}/webhook/{trigger}`` (Bearer EVENT_DISPATCHER_TOKEN,
+     question in the JSON body)  ->  202 ``{"dispatch_id": ...}``.
+  2. Poll ``GET {dispatcher}/dispatch/{dispatch_id}`` until the dispatcher reports
+     ``status == "completed"`` and hands back a ``run_id`` in ``result``. NOTE:
+     the dispatcher's "completed" is only the 202 handshake — it means the run was
+     *accepted* by the worker, NOT that the agent finished.
+  3. Poll ``GET {worker}/dispatch/{run_id}`` (Bearer DISPATCH_WORKER_TOKEN) until
+     the *worker* reports ``status in {completed, error}``. This is the real
+     terminal state, carrying ``text_output`` / ``error``.
+
+Returns
+``{"status", "text_output", "run_id", "error", "artifacts", "input_artifacts",
+"failure_class", "num_tool_calls", "error_code"}``.
+``error_code`` is the dispatcher's structured pool-error code, surfaced onto the
+result when the dispatcher rejected the request with one (e.g.
+``input_files_cap_exceeded`` / ``input_files_invalid``); ``None`` otherwise. The
+retry policy reads it to force such a rejection non-retryable.
+``artifacts`` is the run-status body's artifact field, passed through verbatim:
+a current worker returns a list of **descriptor dicts**
+(``{"artifact_id", "filename", "source_mime", "delivered_mime", "convertible"}``);
+an older worker (during the deploy window) returns bare id strings. Either shape
+is normalized to ids downstream by
+:func:`osprey.bridges.core.artifacts.artifact_ids`.
+``[]`` when there are no artifacts or the worker predates the field.
+``input_artifacts`` is the run-status body's list of inbound files the worker
+ingested for this run (``[{entry_id, filename, mime}]``), passed through
+verbatim; ``[]`` when there were none or the worker predates the field. The
+bridge records these as ``origin="input"`` history descriptors — they are never
+republished, so unlike output ``artifacts`` they never carry a public URL.
+
+``failure_class`` / ``num_tool_calls`` are the worker's run-classification
+fields, passed through from the run-status body. They drive the retry policy
+(is this run worth re-dispatching, and did the agent get far enough to matter).
+Both are ``None`` when **UNKNOWN** — an older worker that predates the fields
+omits them, and ``.get`` yields ``None``, never ``0``. Bridge-local error
+results (transport/handshake/poll-budget failures synthesized without ever
+reaching a worker terminal state) default ``failure_class="infrastructure"``
+and ``num_tool_calls=None``. Every consumer reads these with ``.get`` so an
+older worker skew (worker deployed before this field lands) degrades to
+UNKNOWN rather than breaking.
+
+Connection behavior is the deployment's to decide: the default client is built
+with ``trust_env=cfg.trust_env`` (default ``False``), so by default it ignores
+``HTTP(S)_PROXY`` and reaches the dispatcher and the worker directly — the same
+rule :mod:`osprey.bridges.core.health_gate` and
+:mod:`osprey.bridges.core.capabilities` follow. A site whose bridge sits behind
+an egress proxy sets ``trust_env`` true once, in config. Tests inject their own
+:class:`httpx.MockTransport` client.
+
+Like every ``osprey.bridges.core`` module this carries ZERO osprey dispatch
+imports.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+
+from .config import TERMINAL_STATUSES, CoreConfig
+
+
+class DispatchError(Exception):
+    """Raised for unexpected HTTP failures talking to the pipeline.
+
+    ``error_code`` carries the dispatcher's structured pool-error code when the
+    dispatcher reported ``status="error"`` with one (e.g.
+    ``input_files_cap_exceeded`` / ``input_files_invalid`` — a deterministic
+    rejection of the request). It is ``None`` for every other failure (transport
+    error, handshake glitch, poll-budget exhaustion). :meth:`DispatchClient.run`
+    lifts it onto the error result so
+    :func:`osprey.bridges.core.retry.is_retryable` can classify such a rejection
+    as non-retryable.
+    """
+
+    def __init__(self, message: str, *, error_code: str | None = None):
+        super().__init__(message)
+        self.error_code = error_code
+
+
+def _error_result(
+    run_id: str | None,
+    error: str,
+    *,
+    failure_class: str = "infrastructure",
+    num_tool_calls: int | None = None,
+    error_code: str | None = None,
+) -> dict[str, Any]:
+    """The module's uniform terminal-result shape, error branch.
+
+    Every path out of :meth:`DispatchClient.run`/:meth:`poll_worker` returns
+    ``{"status", "text_output", "run_id", "error", "artifacts", "input_artifacts",
+    "failure_class", "num_tool_calls", "error_code"}`` — build the error variant in
+    ONE place so no
+    branch can drift from the contract (the channel poster and the history
+    recording both key off these exact fields).
+
+    These are the *bridge-local* failures — a transport error, a failed
+    dispatcher/worker handshake, or poll-budget exhaustion — where no worker
+    terminal state was ever observed. They are ``failure_class="infrastructure"``
+    (the retry policy treats them as worth re-dispatching) with an UNKNOWN
+    (``None``) ``num_tool_calls`` since no agent progress is known. A caller may
+    override ``failure_class`` for a bridge-local failure it wants classified
+    differently, and ``error_code`` when the dispatcher surfaced a structured
+    rejection code (the retry policy uses it to force non-retryable regardless of
+    the defaulted ``failure_class``).
+    """
+    return {
+        "status": "error",
+        "text_output": "",
+        "run_id": run_id,
+        "error": error,
+        "artifacts": [],
+        "input_artifacts": [],
+        "failure_class": failure_class,
+        "num_tool_calls": num_tool_calls,
+        "error_code": error_code,
+    }
+
+
+class DispatchClient:
+    def __init__(
+        self,
+        cfg: CoreConfig,
+        client: httpx.Client | None = None,
+        *,
+        sleep: Callable[[float], None] = time.sleep,
+        monotonic: Callable[[], float] = time.monotonic,
+    ):
+        self.cfg = cfg
+        self._client = client or httpx.Client(timeout=30.0, trust_env=cfg.trust_env)
+        self._sleep = sleep
+        self._monotonic = monotonic
+
+    # --- step 1: fire the webhook -----------------------------------------
+    def fire(self, question: str, extra: dict[str, Any] | None = None) -> str:
+        """POST the question to the dispatcher webhook; return the dispatch_id."""
+        payload: dict[str, Any] = {"question": question}
+        if extra:
+            payload.update(extra)
+        url = f"{self.cfg.dispatcher_url}/webhook/{self.cfg.trigger}"
+        resp = self._client.post(
+            url,
+            json=payload,
+            headers={"Authorization": f"Bearer {self.cfg.event_dispatcher_token}"},
+        )
+        if resp.status_code not in (200, 202):
+            raise DispatchError(f"webhook {url} returned {resp.status_code}: {resp.text[:300]}")
+        dispatch_id: str | None = resp.json().get("dispatch_id")
+        if not dispatch_id:
+            raise DispatchError(f"webhook response missing dispatch_id: {resp.text[:300]}")
+        return dispatch_id
+
+    # --- step 2: dispatcher handshake -> run_id ---------------------------
+    def wait_for_run_id(self, dispatch_id: str, deadline: float) -> str:
+        """Poll the dispatcher until it hands back a run_id (or raise)."""
+        url = f"{self.cfg.dispatcher_url}/dispatch/{dispatch_id}"
+        headers = {"Authorization": f"Bearer {self.cfg.event_dispatcher_token}"}
+        while True:
+            resp = self._client.get(url, headers=headers)
+            if resp.status_code == 200:
+                body = resp.json()
+                status = body.get("status")
+                if status == "completed":
+                    run_id: str | None = (body.get("result") or {}).get("run_id")
+                    if not run_id:
+                        raise DispatchError(f"dispatcher completed but no run_id: {body}")
+                    return run_id
+                if status == "error":
+                    raise DispatchError(
+                        f"dispatcher reported error: {body.get('error')}",
+                        error_code=body.get("error_code"),
+                    )
+                # else pending -> keep polling
+            elif resp.status_code != 404:
+                raise DispatchError(
+                    f"dispatcher {url} returned {resp.status_code}: {resp.text[:300]}"
+                )
+            if self._monotonic() >= deadline:
+                raise DispatchError(f"timed out waiting for run_id (dispatch_id={dispatch_id})")
+            self._sleep(self.cfg.poll_interval)
+
+    # --- step 3: worker poll to terminal ----------------------------------
+    def poll_worker(self, run_id: str, deadline: float | None = None) -> dict[str, Any]:
+        """Poll the worker until the run reaches a terminal state.
+
+        Returns ``{"status", "text_output", "run_id", "error", "artifacts",
+        "input_artifacts", "failure_class", "num_tool_calls", "error_code"}``. On
+        budget exhaustion returns a
+        synthesized ``status="error"`` result rather than raising, so the caller
+        always has something to post.
+        """
+        if deadline is None:
+            deadline = self._monotonic() + self.cfg.poll_budget
+        url = f"{self.cfg.worker_url}/dispatch/{run_id}"
+        headers = {"Authorization": f"Bearer {self.cfg.dispatch_worker_token}"}
+        while True:
+            resp = self._client.get(url, headers=headers)
+            if resp.status_code == 200:
+                body = resp.json()
+                status = body.get("status")
+                if status in TERMINAL_STATUSES:
+                    return {
+                        "status": status,
+                        "text_output": body.get("text_output", "") or "",
+                        "run_id": run_id,
+                        "error": body.get("error"),
+                        # Missing key OR an explicit null -> [] so an older
+                        # worker image (deployed independently) degrades
+                        # gracefully instead of dropping the whole result. The
+                        # worker does serialize explicit nulls (see "error").
+                        # Whatever shape it carries (descriptor dicts on a
+                        # current worker, bare id strings on an older one) is
+                        # passed through verbatim and normalized downstream by
+                        # artifacts.artifact_ids.
+                        "artifacts": body.get("artifacts") or [],
+                        # Inbound files the worker ingested for this run, passed
+                        # through verbatim as ``[{entry_id, filename, mime}]``.
+                        # Missing key OR explicit null -> [] so a worker predating
+                        # the field (or a run with no inputs) degrades to "no
+                        # input artifacts" rather than dropping the result. The
+                        # bridge records these as ``origin="input"`` history
+                        # descriptors; they are never republished, so never carry
+                        # a public URL.
+                        "input_artifacts": body.get("input_artifacts") or [],
+                        # Worker run-classification, passed through as-is. An
+                        # older worker omits them -> None meaning UNKNOWN (never
+                        # coerce a missing count to 0). The retry policy reads
+                        # both to decide whether re-dispatching is worthwhile.
+                        "failure_class": body.get("failure_class"),
+                        "num_tool_calls": body.get("num_tool_calls"),
+                        # Structured pool-error code if the worker terminal body
+                        # carries one; None keeps the contract uniform otherwise.
+                        "error_code": body.get("error_code"),
+                    }
+                # pending / running -> keep polling
+            elif resp.status_code != 404:
+                # 404 can be a brief race (run just registered); anything else is fatal.
+                raise DispatchError(f"worker {url} returned {resp.status_code}: {resp.text[:300]}")
+            if self._monotonic() >= deadline:
+                return _error_result(
+                    run_id,
+                    f"bridge timed out after {self.cfg.poll_budget:.0f}s polling run {run_id}",
+                )
+            self._sleep(self.cfg.poll_interval)
+
+    # --- single non-polling status probe ----------------------------------
+    def status(self, run_id: str) -> dict[str, Any] | None:
+        """One-shot ``GET {worker}/dispatch/{run_id}`` — no polling, no deadline.
+
+        Returns the raw worker run-status body (which may be **non-terminal**,
+        e.g. ``{"status": "pending"}``) so a caller reconciling a persisted
+        ``run_id`` on restart can decide for itself whether the run is still in
+        flight or has reached a terminal state. Unlike :meth:`poll_worker` this
+        does not synthesize the uniform result contract — it hands back exactly
+        what the worker reported.
+
+        ``None`` on 404: the worker has no such run. That is a *signal* (the run
+        never registered, or its record has aged out), not an error — the caller
+        distinguishes "gone" from a live status body. Any other non-200 raises
+        :class:`DispatchError`, matching :meth:`poll_worker`.
+        """
+        url = f"{self.cfg.worker_url}/dispatch/{run_id}"
+        headers = {"Authorization": f"Bearer {self.cfg.dispatch_worker_token}"}
+        resp = self._client.get(url, headers=headers)
+        if resp.status_code == 200:
+            body: dict[str, Any] = resp.json()
+            return body
+        if resp.status_code == 404:
+            return None
+        raise DispatchError(f"worker {url} returned {resp.status_code}: {resp.text[:300]}")
+
+    # --- full sequence -----------------------------------------------------
+    def run(
+        self,
+        question: str,
+        extra: dict[str, Any] | None = None,
+        *,
+        on_run_id: Callable[[str], None] | None = None,
+    ) -> dict[str, Any]:
+        """Fire the webhook and poll all the way to a terminal worker result.
+
+        Always returns ``{"status", "text_output", "run_id", "error", "artifacts",
+        "input_artifacts", "failure_class", "num_tool_calls", "error_code"}``.
+        Any failure in the sequence — a dispatcher/worker non-2xx (``DispatchError``)
+        or a transient network error (``httpx.HTTPError``: ConnectError,
+        ReadTimeout, ...) — is converted to an ``error`` result so the caller can
+        always post *something* back to the user rather than escaping unhandled.
+
+        ``on_run_id`` (if given) is invoked with the run_id the moment the
+        dispatcher handshake yields one, BEFORE the long worker poll. This lets
+        the caller persist a non-terminal ``run_id`` so a crash mid-poll can be
+        reconciled on restart instead of silently dropping the question.
+        """
+        try:
+            # The handshake gets its own budget; the worker poll below starts a
+            # fresh budget so a slow handshake can never eat into the worker's
+            # full poll window (which must outlast the worker's own run cap).
+            handshake_deadline = self._monotonic() + self.cfg.poll_budget
+            dispatch_id = self.fire(question, extra)
+            run_id = self.wait_for_run_id(dispatch_id, handshake_deadline)
+        except (DispatchError, httpx.HTTPError) as exc:
+            # A dispatcher pool-error may carry a structured error_code (an
+            # input_files rejection); lift it onto the result so the retry policy
+            # can classify it. Ordinary transport/handshake failures have none.
+            return _error_result(None, str(exc), error_code=getattr(exc, "error_code", None))
+        if on_run_id is not None:
+            on_run_id(run_id)
+        try:
+            return self.poll_worker(run_id)  # fresh budget (deadline=None)
+        except (DispatchError, httpx.HTTPError) as exc:
+            return _error_result(run_id, str(exc))

--- a/src/osprey/bridges/core/drain.py
+++ b/src/osprey/bridges/core/drain.py
@@ -1,0 +1,455 @@
+"""Retry-queue drain loop: channel-neutral scheduling over parked entries.
+
+When a bridge cannot dispatch an inbound message (the pipeline is down, the gate
+is closed), it parks the claim as ``status == "queued"`` instead of dropping it.
+This module owns replaying those parked entries once the pipeline recovers.
+
+:func:`drain_once` is one pass:
+
+  1. Consult the health gate. If it is closed, do nothing — replaying into a
+     still-broken pipeline would just re-fail (and possibly re-file alerts).
+  2. Coalesce redundant fresh entries: among run_id-less entries sharing a
+     channel-supplied :func:`osprey.bridges.core.retry.coalesce_key`, keep only
+     the newest and supersede the rest (``queued -> superseded`` via the store's
+     CAS :meth:`~osprey.bridges.core.dedup.DedupStore.transition`), announcing
+     each drop via the optional ``supersede`` callback. This runs on the FULL
+     queue snapshot, BEFORE the age filter, so a newest-but-too-young message
+     still supersedes an older eligible sibling (otherwise both would eventually
+     be answered).
+  3. Keep the survivors aged past ``retry_min_age``
+     (:func:`osprey.bridges.core.retry.is_eligible`).
+  4. For each surviving entry:
+       * give-up check (:func:`osprey.bridges.core.retry.give_up_due`): abandon
+         via the give-up callback, then mark the entry terminal (a failed notice
+         leaves it queued to retry; the reason lands in ``give_up_reason`` meta);
+       * **re-attach** when it already has a ``run_id`` — probe the worker once
+         (:meth:`~osprey.bridges.core.dispatch_client.DispatchClient.status`): a
+         ``completed`` run is delivered (callback) and marked terminal (a
+         failed delivery leaves it queued so the next cycle re-delivers); a
+         non-terminal run is left for the next cycle; a terminal FAILURE body is
+         the run's definitive outcome, so the retry decision is applied — one
+         redispatch iff :func:`~osprey.bridges.core.retry.is_retryable` AND
+         :func:`~osprey.bridges.core.retry.may_redispatch` both pass, else give
+         up; two *consecutive* 404s across cycles (tracked in entry meta) mean
+         the run is gone with its outcome UNKNOWN, so give up — an unknown
+         outcome is never re-dispatched;
+       * otherwise **redispatch** — but only when a KNOWN ``num_tool_calls == 0``
+         in the entry meta proves the failed attempt took no side-effecting
+         action (:func:`~osprey.bridges.core.retry.may_redispatch`, fail-closed):
+         unknown or nonzero means give up (the honest "couldn't safely re-run"
+         path), NEVER re-execute. When provably safe: flip ``queued ->
+         in_flight`` (CAS, stamping ``retried``) then hand off to the channel's
+         dispatch callback, which re-fires and delivers (the existing
+         ``_run_id_persister`` pattern).
+
+Every channel-specific side effect (posting a reply, delivering a re-attached
+result, filing a give-up notice) is injected through :class:`DrainCallbacks`, so
+``osprey.bridges.core`` carries ZERO channel imports and ZERO osprey dispatch
+imports. The store lifecycle (CAS transitions, terminal marking, 404
+bookkeeping) stays here.
+
+:func:`run_drain_thread` and :func:`ensure_alive` are the supervision helpers a
+channel entrypoint uses to run the loop as a daemon thread and restart it if it
+ever dies. One drain is shared by the whole bridge process — never one per
+conversation — because the queue it walks is the process-wide dedup store.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from .config import TERMINAL_STATUSES
+from .dedup import DedupStore
+from .dispatch_client import DispatchClient
+from .health_gate import gate_open
+from .retry import (
+    ceiling_age,
+    coalesce_key,
+    give_up_due,
+    is_eligible,
+    is_retryable,
+    may_redispatch,
+)
+
+logger = logging.getLogger(__name__)
+
+# Two consecutive 404s from the worker (across drain cycles) mean the run record
+# is gone for good — the worker never registered it, or it aged out — so the
+# entry can never be re-attached and is abandoned. One 404 alone can be a brief
+# registration race, so a single miss only defers to the next cycle.
+NOTFOUND_GIVE_UP = 2
+
+# Terminal status stamped on an abandoned entry: it is done, must leave both the
+# queued() set and the reconcile() set so it is never reprocessed. "error" is an
+# existing terminal status (see config.TERMINAL_STATUSES) — no new status needed.
+_GIVE_UP_STATUS = "error"
+
+
+@dataclass
+class DrainCallbacks:
+    """Channel-specific I/O the drain invokes. Everything here is pure channel
+    behavior — the drain owns all dedup-store state, so a callback never needs to
+    write status/run_id (except the ``_run_id_persister`` the channel wires into
+    its own dispatch, for crash-safety).
+
+    All callbacks run on the drain thread and may block (the dispatch callback
+    runs a full worker poll). A raising callback is logged and never kills the
+    loop; per-callback retry semantics are documented on each field.
+
+    This is the drain's slice of the :class:`~osprey.bridges.core.ports.ChannelOps`
+    seam, expressed as plain callables so the loop stays testable with three
+    lambdas. The failure contracts below are the same ones ``ports.py``
+    documents for ``post_answer`` / ``post_giveup`` / ``post_superseded``; a
+    ``ChannelOps`` implementation satisfies them through the thin binding the
+    runtime wiring builds (the callbacks also own store-independent channel
+    steps — history append, file delivery — that no single protocol member
+    covers).
+    """
+
+    dispatch: Callable[[str, dict[str, Any]], Any]
+    """Redispatch a run-id-less queued entry from its persisted question.
+    ``(message_id, entry)``. The channel re-fires the dispatch (with its
+    ``_run_id_persister`` for crash-safety), delivers the reply, and records the
+    terminal status itself — the drain has already flipped the entry to
+    ``in_flight`` and does not touch it afterward."""
+
+    deliver: Callable[[str, dict[str, Any], dict[str, Any]], Any]
+    """Deliver a re-attached run's COMPLETED result. ``(message_id, entry,
+    result_body)`` where ``result_body`` is the raw worker status body — only
+    ``status == "completed"`` bodies reach this callback (terminal failures are
+    routed through the retry decision instead). Raise on a failed send: the
+    entry then STAYS QUEUED and the next cycle re-attaches and re-delivers
+    (at-least-once, bounded by the give-up ceilings). Channels should mirror
+    the same crash-safety ordering internally: send the reply first, then
+    settle the store status."""
+
+    give_up: Callable[[str, dict[str, Any]], Any]
+    """Abandon an entry: notify the user / file a give-up issue. ``(message_id,
+    entry)``. The drain marks the entry terminal only AFTER this returns — a
+    notice that fails to send leaves the entry queued for the next cycle (a
+    lost give-up notice is silence, worse than the rare duplicate a race could
+    produce). The drain stamps its machine-side reason into the terminal
+    transition meta (``give_up_reason``) for the audit trail."""
+
+    supersede: Callable[[str, dict[str, Any]], Any] | None = None
+    """Optional: note that an entry was coalesced away in favor of a newer
+    sibling. ``(message_id, entry)``, called only after the drain WON the
+    ``queued -> superseded`` CAS (at most once per entry). A channel that
+    already posts its own supersede note at enqueue time (so the queue rarely
+    holds duplicates) may leave this ``None``; the drain then coalesces
+    silently."""
+
+
+@dataclass
+class DrainDeps:
+    """Collaborators for :func:`drain_once`, injected for testability.
+
+    ``cfg`` supplies the retry tunables (``retry_min_age`` / ``retry_give_up`` /
+    ``retry_lifetime_cap`` / ``drain_interval``) and, for the default gate, the
+    dispatcher/worker coordinates and ``trust_env`` that
+    :func:`osprey.bridges.core.health_gate.gate_open` reads. ``gate`` / ``now`` /
+    ``sleep`` are overridable so tests drive the clock and health signal
+    directly.
+    """
+
+    cfg: Any
+    dedup: DedupStore
+    dispatcher: DispatchClient
+    callbacks: DrainCallbacks
+    gate: Callable[[], bool] | None = None
+    now: Callable[[], float] = time.time
+    sleep: Callable[[float], None] = time.sleep
+
+    def gate_is_open(self) -> bool:
+        """Health gate for this pass — the injected ``gate`` or, by default,
+        :func:`osprey.bridges.core.health_gate.gate_open` against ``cfg`` (which
+        builds its client honoring ``cfg.trust_env``)."""
+        if self.gate is not None:
+            return self.gate()
+        return gate_open(self.cfg)
+
+
+def _newest_first(entries: list[tuple[str, dict[str, Any]]]) -> list[tuple[str, dict[str, Any]]]:
+    """Sort ``(message_id, entry)`` pairs newest-request first.
+
+    "Newest" follows the request's FIRST park time (``first_queued_at``,
+    falling back to ``queued_at``) — a re-park refreshes ``queued_at``, and
+    sorting on that would let an old question in a retry loop out-rank a
+    genuinely newer one during coalescing."""
+    return sorted(
+        entries,
+        key=lambda item: item[1].get("first_queued_at") or item[1].get("queued_at", 0),
+        reverse=True,
+    )
+
+
+def _ceiling_reason(entry: dict[str, Any], now: float, cfg: Any) -> str:
+    """Human-readable reason for an age-ceiling give-up (same
+    :func:`~osprey.bridges.core.retry.ceiling_age` anchor the ceilings
+    measure)."""
+    age = ceiling_age(entry, now)
+    if age >= cfg.retry_lifetime_cap:
+        return f"queued for {age:.0f}s, past the retry lifetime cap ({cfg.retry_lifetime_cap:.0f}s)"
+    return (
+        f"queued for {age:.0f}s without a successful retry, past the give-up age "
+        f"({cfg.retry_give_up:.0f}s)"
+    )
+
+
+def _select(deps: DrainDeps, now: float) -> list[tuple[str, dict[str, Any]]]:
+    """Queued entries to process this pass: coalesced first, THEN age-filtered.
+
+    Coalescing runs on the FULL queue snapshot before the ``retry_min_age``
+    filter so a newest-but-too-young message still supersedes an older eligible
+    sibling — filtering first would answer the old one this pass and the new
+    one a few passes later (both). Run-id-less entries sharing a coalesce key
+    collapse to the newest — the older duplicates are superseded in the store —
+    and the survivors are then age-filtered (re-attach entries, which have a
+    run_id, are never coalesced and always pass through individually).
+    """
+    survivors: list[tuple[str, dict[str, Any]]] = []
+    groups: dict[tuple, list[tuple[str, dict[str, Any]]]] = {}
+    for mid, entry in deps.dedup.queued().items():
+        # A dispatched entry (has a run_id) is re-attached on its own; only fresh
+        # entries coalesce. An empty coalesce key is the no-group sentinel.
+        key = coalesce_key(entry)
+        if entry.get("run_id") or key == ():
+            survivors.append((mid, entry))
+        else:
+            groups.setdefault(key, []).append((mid, entry))
+
+    for members in groups.values():
+        newest, *older = _newest_first(members)
+        survivors.append(newest)
+        for mid, entry in older:
+            # CAS: only supersede if still queued (a racing pass may have taken it).
+            if deps.dedup.transition(mid, "queued", "superseded"):
+                logger.info("coalesced %s into %s", mid, newest[0])
+                if deps.callbacks.supersede is not None:
+                    try:
+                        deps.callbacks.supersede(mid, entry)
+                    except Exception:
+                        logger.exception("supersede callback failed for %s", mid)
+    return [(mid, entry) for mid, entry in survivors if is_eligible(entry, now, deps.cfg)]
+
+
+def _reattach(deps: DrainDeps, message_id: str, entry: dict[str, Any], run_id: str) -> None:
+    """Probe a persisted run once and act on its state (see module docstring)."""
+    body = deps.dispatcher.status(run_id)
+
+    if body is None:  # 404 — run not (yet) known to the worker
+        misses = entry.get("notfound_count", 0)
+        misses = (misses if isinstance(misses, int) and not isinstance(misses, bool) else 0) + 1
+        if misses >= NOTFOUND_GIVE_UP:
+            logger.info(
+                "run %s gone (%d consecutive 404s); giving up %s", run_id, misses, message_id
+            )
+            _abandon(
+                deps,
+                message_id,
+                entry,
+                f"run {run_id} is unknown to the worker ({misses} consecutive 404s); "
+                "its outcome is unknown, so it is never re-dispatched",
+            )
+        else:
+            # Persist the miss and wait a cycle. CAS keeps it write-safe: the
+            # meta lands only while the entry is still queued (a plain record()
+            # could stomp a concurrent queued -> in_flight flip back to queued).
+            deps.dedup.transition(message_id, "queued", "queued", notfound_count=misses)
+        return
+
+    status = body.get("status")
+    if status not in TERMINAL_STATUSES:
+        # Still running — clear any stale miss streak and try again next cycle.
+        if entry.get("notfound_count"):
+            deps.dedup.transition(message_id, "queued", "queued", notfound_count=0)
+        return
+
+    if status == "completed":
+        # Deliver FIRST, then mark. A raising callback leaves the entry queued
+        # (run_id intact) so the NEXT cycle re-attaches and re-delivers: a
+        # transient post failure retries (at-least-once), bounded by the
+        # give_up_due ceilings — never a first-failure terminal post_failed.
+        # Channels mirror this crash-safety ordering internally (email: send
+        # the reply, then settle the status) so a crash between the two
+        # re-delivers rather than drops.
+        try:
+            deps.callbacks.deliver(message_id, entry, body)
+        except Exception:
+            logger.exception("deliver failed for %s; left queued to retry next cycle", message_id)
+            return
+        deps.dedup.transition(message_id, "queued", status)
+        return
+
+    # A terminal FAILURE body — the persisted run's definitive outcome. Not an
+    # answer to deliver: apply the retry decision instead. One redispatch iff the
+    # failure class is retryable AND a known-zero tool-call count (entry meta or
+    # this body) proves the run took no action; anything else is abandoned.
+    if is_retryable(body) and may_redispatch(entry, body):
+        logger.info(
+            "run %s terminal %r is safely retryable; redispatching %s", run_id, status, message_id
+        )
+        _redispatch(deps, message_id, entry, result=body)
+    else:
+        logger.info(
+            "run %s terminal %r not safely retryable; giving up %s", run_id, status, message_id
+        )
+        _abandon(
+            deps,
+            message_id,
+            entry,
+            f"run {run_id} failed terminally "
+            f"(failure_class={body.get('failure_class')!r}) and cannot be safely re-run",
+        )
+
+
+def _redispatch(
+    deps: DrainDeps,
+    message_id: str,
+    entry: dict[str, Any],
+    result: dict[str, Any] | None = None,
+) -> None:
+    """Safety-gate a queued entry, claim it (CAS), and hand it to dispatch.
+
+    Re-dispatching re-executes the agent from scratch, so it must be PROVEN
+    side-effect free: a KNOWN tool-call count of exactly 0 across the entry's
+    persisted meta and (on the re-attach path) the observed terminal ``result``.
+    Unknown or nonzero fails closed — the entry takes the give-up path (the
+    channel's honest "couldn't safely re-run" notice), NEVER a re-execution.
+    """
+    if not may_redispatch(entry, result or {}):
+        logger.info(
+            "cannot prove %s side-effect free (num_tool_calls unknown/nonzero); giving up",
+            message_id,
+        )
+        _abandon(
+            deps,
+            message_id,
+            entry,
+            "the failed attempt cannot be proven side-effect free "
+            "(num_tool_calls unknown or nonzero), so re-running it is not safe",
+        )
+        return
+    # Flip queued -> in_flight atomically so a concurrent pass can't double-fire;
+    # only the winner runs the callback. `retried` and the incremented `attempts`
+    # both feed give_up_due later (it honors either signal).
+    attempts = entry.get("attempts")
+    if not isinstance(attempts, int) or isinstance(attempts, bool) or attempts < 0:
+        attempts = 0
+    won = deps.dedup.transition(
+        message_id, "queued", "in_flight", retried=True, run_id=None, attempts=attempts + 1
+    )
+    if not won:
+        return
+    deps.callbacks.dispatch(message_id, entry)
+
+
+def _abandon(deps: DrainDeps, message_id: str, entry: dict[str, Any], reason: str) -> None:
+    """Fire the give-up callback, then mark the entry terminal (CAS-guarded).
+
+    Callback FIRST: a give-up notice that fails to send leaves the entry queued
+    for the next cycle rather than silently terminal — a lost notice is
+    silence, worse than the rare duplicate a race could produce. ``reason`` is
+    the drain's machine-side explanation; it never reaches the callback (the
+    surface stays ``(message_id, entry)``) but is stamped into the terminal
+    transition meta as ``give_up_reason`` for the audit trail.
+    """
+    try:
+        deps.callbacks.give_up(message_id, entry)
+    except Exception:
+        logger.exception("give_up callback failed for %s; leaving queued", message_id)
+        return
+    deps.dedup.transition(message_id, "queued", _GIVE_UP_STATUS, give_up_reason=reason)
+
+
+def drain_once(deps: DrainDeps) -> None:
+    """Run one drain pass. No-op (returns early) when the health gate is closed.
+
+    Each entry is processed inside its own try/except so a single failure — a
+    worker error, a callback raising — is logged and skipped, never aborting the
+    rest of the pass.
+    """
+    if not deps.gate_is_open():
+        logger.debug("drain skipped: health gate closed")
+        return
+
+    now = deps.now()
+    for message_id, entry in _select(deps, now):
+        try:
+            # Give-up takes precedence: an entry past its ceilings is abandoned
+            # before we spend a redispatch/probe on it. The gate is open now, so
+            # this outage-clearing counts as "gate observed open since enqueue".
+            gate_seen = bool(entry.get("gate_seen_open"))
+            if give_up_due(entry, now, gate_seen, deps.cfg):
+                _abandon(deps, message_id, entry, _ceiling_reason(entry, now, deps.cfg))
+                continue
+
+            run_id = entry.get("run_id")
+            if run_id:
+                _reattach(deps, message_id, entry, run_id)
+            else:
+                _redispatch(deps, message_id, entry)
+
+            # Record that the gate was open while this entry was still queued, so
+            # a FUTURE pass can give up at the give-up age even with no retry.
+            # Stamped after give_up_due so an entry gets one fair pass first. The
+            # CAS applies it only if the entry is STILL queued (redispatch/deliver
+            # may have moved it on) — atomically, unlike a get-then-record.
+            if not gate_seen:
+                deps.dedup.transition(message_id, "queued", "queued", gate_seen_open=True)
+        except Exception as exc:  # isolate per-entry: one failure never aborts the pass
+            logger.warning("drain: entry %s failed this pass: %s", message_id, exc)
+
+
+# --- thread supervision ----------------------------------------------------
+
+
+def run_drain_thread(deps: DrainDeps, stop: threading.Event | None = None) -> threading.Thread:
+    """Start and return a daemon thread that calls :func:`drain_once` every
+    ``cfg.drain_interval`` seconds until ``stop`` is set.
+
+    ONE thread per bridge process, shared across every conversation: the pass it
+    runs walks the whole dedup queue, so a per-room thread would multiply the
+    same work and race on the same CAS transitions.
+
+    The loop body is fully guarded: any exception escaping ``drain_once`` is
+    logged and the loop continues, so the drain thread does not die on a
+    transient fault. Daemon so it never blocks process exit; named for logs.
+    """
+    stop = stop or threading.Event()
+
+    def _loop() -> None:
+        logger.info("drain loop started (interval=%.0fs)", deps.cfg.drain_interval)
+        while not stop.is_set():
+            try:
+                drain_once(deps)
+            except Exception:
+                logger.exception("drain_once raised; continuing")
+            # Interruptible sleep: stop.set() wakes it immediately for shutdown.
+            stop.wait(deps.cfg.drain_interval)
+
+    thread = threading.Thread(target=_loop, name="bridge-drain", daemon=True)
+    thread.start()
+    return thread
+
+
+def ensure_alive(
+    thread: threading.Thread | None,
+    factory: Callable[[], threading.Thread],
+) -> threading.Thread:
+    """Return a live drain thread: ``thread`` if it is still alive, else a fresh
+    one from ``factory``.
+
+    A channel's supervision path calls this periodically so a drain thread that
+    somehow died (an unforeseen crash in the loop harness) is transparently
+    replaced without restarting the whole bridge.
+    """
+    if thread is not None and thread.is_alive():
+        return thread
+    logger.warning("drain thread not alive; restarting")
+    return factory()

--- a/src/osprey/bridges/core/health_gate.py
+++ b/src/osprey/bridges/core/health_gate.py
@@ -1,0 +1,137 @@
+"""Drain-gate health check: is it safe to drain queued work back into dispatch?
+
+A bridge that has queued messages while the dispatch pipeline was unhealthy must
+not replay them until the pipeline is demonstrably back. :func:`gate_open` is
+that go/no-go check — it returns ``True`` only when all of the following hold
+*right now*:
+
+  (a) the dispatcher's ``GET /health`` is ``200`` with ``status == "ok"``;
+  (b) the worker's ``GET /health`` likewise;
+  (c) **only where an alert host is configured** — the GitLab instance reports
+      **no** open ``osprey-alert`` issue for the project (an open issue with that
+      label means the watchdog currently considers the deployment broken).
+
+Check (c) is **opt-in**: it runs only when both ``cfg.gitlab_url`` and
+``cfg.gitlab_issues_token`` are non-empty. A site that files no alert issues has
+no alert host to ask, and asking a host that is not there would fail-close the
+gate forever — parked messages would never replay and every outage would end in
+give-up notices. Unconfigured, the gate is (a) AND (b) alone.
+
+Where the checks *do* run they are **fail-closed**: any non-200, timeout,
+malformed body, or exception on ANY of them yields ``False``. A GitLab *API*
+failure (unreachable, non-200, bad JSON) is therefore treated identically to a
+still-open alert — both close the gate — but they are distinct causes: (c) is
+only satisfied by a positive ``200`` + empty-list answer, never by an inability
+to ask.
+
+Connection behavior is the deployment's to decide: the client is built with
+``trust_env=cfg.trust_env`` (default ``False``), so by default it ignores
+``HTTP(S)_PROXY`` entirely and reaches the dispatcher, the worker, and the alert
+host directly. A site whose bridge sits behind an egress proxy sets
+``trust_env`` true once, in config. Tests inject their own
+:class:`httpx.MockTransport` client.
+
+Like every ``osprey.bridges.core`` module this carries ZERO osprey dispatch
+imports and ZERO channel (chat/email) imports — the gate is pure stdlib + httpx.
+"""
+
+from __future__ import annotations
+
+import logging
+import urllib.parse
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# The watchdog's alert label. An open issue carrying this label means the
+# deployment is currently flagged broken, so the gate must stay closed until it
+# is resolved.
+ALERT_LABEL = "osprey-alert"
+
+# Short per-request timeout: a hung dispatcher/worker/GitLab must fail the gate
+# closed quickly rather than stall the drain loop that calls it.
+_TIMEOUT = 10.0
+
+
+def _health_ok(http: httpx.Client, base_url: str) -> bool:
+    """``True`` iff ``{base_url}/health`` returns 200 with ``status == "ok"``.
+
+    Fail-closed: any non-200, non-JSON body, or transport error -> ``False``.
+    """
+    try:
+        resp = http.get(f"{base_url}/health")
+        if resp.status_code != 200:
+            logger.warning("health check %s/health returned %d", base_url, resp.status_code)
+            return False
+        return bool(resp.json().get("status") == "ok")
+    except Exception as exc:
+        logger.warning("health check %s/health failed: %s", base_url, exc)
+        return False
+
+
+def alert_check_configured(cfg) -> bool:
+    """``True`` iff this deployment has an alert host the gate can ask.
+
+    Both the host and the token are required: a URL with no token cannot query
+    the issues API, and a token with no URL has nothing to query. Either one
+    missing means the site simply does not run the alert-issue check.
+    """
+    return bool(cfg.gitlab_url) and bool(cfg.gitlab_issues_token)
+
+
+def _no_open_alert(http: httpx.Client, cfg) -> bool:
+    """``True`` iff GitLab returns 200 with an EMPTY open-``osprey-alert`` list.
+
+    A non-200, non-list body, or any exception (unreachable, timeout, bad JSON)
+    is an API *failure* and returns ``False`` — deliberately indistinguishable
+    at the gate from a genuinely open alert, but arrived at only by failing to
+    get a clean empty answer, never by observing one.
+    """
+    project = urllib.parse.quote(cfg.gitlab_project, safe="")
+    url = f"{cfg.gitlab_url}/api/v4/projects/{project}/issues"
+    try:
+        resp = http.get(
+            url,
+            params={"labels": ALERT_LABEL, "state": "opened"},
+            headers={"PRIVATE-TOKEN": cfg.gitlab_issues_token},
+        )
+        if resp.status_code != 200:
+            logger.warning("gitlab alert query returned %d", resp.status_code)
+            return False
+        issues = resp.json()
+        if not isinstance(issues, list):
+            logger.warning("gitlab alert query returned non-list body")
+            return False
+        if issues:
+            logger.info("gate closed: %d open %s issue(s)", len(issues), ALERT_LABEL)
+            return False
+        return True
+    except Exception as exc:
+        logger.warning("gitlab alert query failed: %s", exc)
+        return False
+
+
+def gate_open(cfg, client: httpx.Client | None = None) -> bool:
+    """Return ``True`` only if it is safe to drain queued work into dispatch.
+
+    Runs the fail-closed dispatcher-health and worker-health checks against
+    ``cfg``'s ``dispatcher_url`` / ``worker_url``, then — only where
+    :func:`alert_check_configured` — the no-open-``osprey-alert`` check against
+    ``gitlab_url`` / ``gitlab_project`` / ``gitlab_issues_token`` (the real
+    :class:`~osprey.bridges.core.config.CoreConfig` field names). Any single
+    check that runs and fails closes the gate. ``client`` is injectable for
+    tests; otherwise one honoring ``cfg.trust_env`` is built and closed here.
+    """
+    own_client = client is None
+    http = client or httpx.Client(timeout=_TIMEOUT, trust_env=cfg.trust_env)
+    try:
+        if not (_health_ok(http, cfg.dispatcher_url) and _health_ok(http, cfg.worker_url)):
+            return False
+        if not alert_check_configured(cfg):
+            logger.debug("gate: no alert host configured; dispatcher+worker health only")
+            return True
+        return _no_open_alert(http, cfg)
+    finally:
+        if own_client:
+            http.close()

--- a/src/osprey/bridges/core/history.py
+++ b/src/osprey/bridges/core/history.py
@@ -1,0 +1,228 @@
+"""Per-conversation history so follow-up questions carry their context.
+
+Each dispatch run is stateless — without this, "now plot it over 24h" arrives
+at the agent with no idea what "it" is. The bridge is the only component that
+sees the whole conversation (it handles every question and posts every answer),
+so it owns the transcript and ships the recent turns along with each new
+question in the webhook payload. The agent itself is unchanged: it simply
+receives the conversation so far, the same context it would naturally have in
+an interactive session.
+
+Keying is channel-defined (a Chat thread/space, an email sender). Persistence
+lives in :class:`~osprey.bridges.core.store.JsonFileStore` (same volume and
+durability guarantees as the dedup store) so a bridge restart keeps
+conversations.
+
+A turn is ``{question, answer, ts, run_id, artifacts}``: the ``ts`` (epoch
+seconds, matching the retry queue's ``queued_at`` clock) anchors the 90-day
+age-prune; ``run_id`` ties the turn back to the run that produced it; and
+``artifacts`` carries up to :data:`MAX_ARTIFACTS_PER_TURN` opaque descriptor
+dicts (produced elsewhere — this store round-trips them without inspecting
+their shape) so a follow-up can refer to a plot/file the agent already made.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable
+from typing import Any
+
+from .store import JsonFileStore
+
+# Bounds on what we replay into the payload. Turn count is the primary knob;
+# the char budget guards against a few huge answers bloating every follow-up
+# (the worker's prompt is finite and channel answers can be long).
+#
+# Why bound this at all — the window is replayed as fresh input tokens on EVERY
+# follow-up (each dispatch run is stateless, so there is no cross-run prompt
+# cache to amortize it), and a DM's history key is its space, which never
+# rotates: a DM is one unbounded, ever-growing conversation. Without a cap an
+# old DM would eventually replay months of stale, unrelated turns into every
+# new question. The caps below are sized generously (~10k tokens of history)
+# so normal working sessions carry full context, while still fencing the
+# eternal-DM case.
+MAX_TURNS = 30
+MAX_CHARS = 40000
+
+# Hard age ceiling: a turn older than this is dropped on the next append, so a
+# long-lived DM never replays months-stale exchanges even if it stays under the
+# turn/char caps. Pre-feature turns (no ``ts``) are grandfathered to the load
+# time (see :meth:`HistoryStore._coerce`), so this prune can never mistake them
+# for ancient and wipe a conversation's whole history on first append.
+MAX_AGE_SECONDS = 90 * 24 * 60 * 60
+
+# Per-turn cap on carried artifact descriptors. One run can emit many plots; we
+# keep the most recent handful so the payload (and the char budget) stays
+# bounded. We retain the TAIL — descriptors arrive oldest-first, so the last N
+# are the run's most recent outputs, the ones a "show me that again" follow-up
+# most likely means.
+MAX_ARTIFACTS_PER_TURN = 10
+
+# Placeholder recorded in the "answer" slot when a run did not produce one (it
+# timed out, errored, or returned no text). We keep the QUESTION in history so a
+# follow-up ("do that but take 30 min", "try again") can resolve its referent —
+# without a marker turn the failed request leaves no trace at all and the agent
+# is honestly told the thread is empty. The marker is a NON-answer: it must never
+# read as a fabricated result the agent could cite.
+FAILED_TURN_ANSWER = "[This request did not produce an answer — it timed out or errored.]"
+
+
+class HistoryStore(JsonFileStore):
+    def __init__(
+        self,
+        path: str,
+        *,
+        max_turns: int = MAX_TURNS,
+        max_chars: int = MAX_CHARS,
+        max_age_seconds: float = MAX_AGE_SECONDS,
+        now: Callable[[], float] = time.time,
+    ):
+        self.max_turns = max_turns
+        self.max_chars = max_chars
+        self.max_age_seconds = max_age_seconds
+        # Clock seam: tests inject a fake ``now`` to exercise grandfathering and
+        # the age-prune without real sleeps. Read once at load (grandfathering)
+        # and once per append (timestamp + prune cutoff).
+        self._now = now
+        # Set by _coerce (which runs inside super().__init__ -> _load) when it
+        # had to fill in any missing field; drives the persist-on-load below so
+        # a grandfathered ``ts`` survives a restart.
+        self._coerce_dirty = False
+        super().__init__(path)
+        # Persist the grandfathered turns exactly once, so the assigned ts is
+        # durable and the age-prune reads a stable load-time anchor rather than
+        # re-grandfathering (to an ever-later "now") on every restart.
+        if self._coerce_dirty:
+            with self._lock:
+                self._flush_locked()
+
+    def _coerce(self, loaded: dict) -> dict:
+        """Normalize the loaded mapping into the current turn shape.
+
+        Every conversation must be a list of turns; each turn is upgraded to
+        ``{question, answer, ts, run_id, artifacts}``. Pre-feature turns lack
+        ``ts``/``run_id``/``artifacts`` — a missing ``ts`` is stamped with the
+        load time (so the age-prune can't treat it as ancient), a missing
+        ``run_id`` becomes ``None``, and missing/oversized ``artifacts`` become
+        a capped list. Any fill-in marks the store dirty so __init__ persists it.
+        """
+        now = self._now()
+        result: dict[str, list[dict[str, Any]]] = {}
+        for key, turns in loaded.items():
+            if not isinstance(turns, list):
+                continue  # drop malformed conversations
+            coerced: list[dict[str, Any]] = []
+            for turn in turns:
+                if not isinstance(turn, dict):
+                    self._coerce_dirty = True
+                    continue  # drop malformed turns
+                normalized = self._coerce_turn(turn, now)
+                if normalized != turn:
+                    self._coerce_dirty = True
+                coerced.append(normalized)
+            result[key] = coerced
+        return result
+
+    def _coerce_turn(self, turn: dict, now: float) -> dict[str, Any]:
+        """Upgrade one loaded turn to the canonical shape (see :meth:`_coerce`)."""
+        question = turn.get("question")
+        answer = turn.get("answer")
+        ts = turn.get("ts")
+        # bool is an int subclass — reject it so a stray True/False ts is
+        # re-stamped rather than read as 1.0/0.0 (epoch 1970 → instantly pruned).
+        if not isinstance(ts, (int, float)) or isinstance(ts, bool):
+            ts = now
+        run_id = turn.get("run_id")
+        if not isinstance(run_id, str):
+            run_id = None
+        artifacts = turn.get("artifacts")
+        if not isinstance(artifacts, list):
+            artifacts = []
+        return {
+            "question": question if isinstance(question, str) else "",
+            "answer": answer if isinstance(answer, str) else "",
+            "ts": ts,
+            "run_id": run_id,
+            "artifacts": _cap_artifacts(artifacts),
+        }
+
+    # --- API ---------------------------------------------------------------
+    def recent(self, key: str) -> list[dict[str, Any]]:
+        """Return the replayable turns for a conversation, oldest first.
+
+        Applies the turn cap and then the char budget (dropping oldest first),
+        so the newest exchanges always survive. The char budget counts the FULL
+        serialized turn — descriptors included — because the whole turn is what
+        rides the payload, so an answer with many/large artifact descriptors
+        must be charged for them, not just its question+answer text.
+        """
+        with self._lock:
+            turns = [dict(t) for t in self._data.get(key, [])]
+        turns = turns[-self.max_turns :]
+        # Enforce the char budget from the tail (newest) backwards.
+        kept: list[dict[str, Any]] = []
+        used = 0
+        for turn in reversed(turns):
+            size = len(json.dumps(turn, ensure_ascii=False, default=str))
+            if kept and used + size > self.max_chars:
+                break
+            kept.append(turn)
+            used += size
+        kept.reverse()
+        return kept
+
+    def append(
+        self,
+        key: str,
+        question: str,
+        answer: str,
+        run_id: str | None = None,
+        artifacts: list[dict[str, Any]] | None = None,
+    ) -> None:
+        """Record one completed exchange for a conversation.
+
+        ``run_id`` and ``artifacts`` are optional so pre-existing 3-arg callers
+        keep working unchanged. ``artifacts`` is capped to
+        :data:`MAX_ARTIFACTS_PER_TURN` (tail kept). Appending also age-prunes the
+        conversation, dropping turns whose ``ts`` is older than
+        ``max_age_seconds`` relative to now.
+        """
+        if not key:
+            return
+        now = self._now()
+        turn = {
+            "question": question,
+            "answer": answer,
+            "ts": now,
+            "run_id": run_id,
+            "artifacts": _cap_artifacts(list(artifacts) if artifacts else []),
+        }
+        cutoff = now - self.max_age_seconds
+        with self._lock:
+            turns = self._data.setdefault(key, [])
+            turns.append(turn)
+            # Age-prune: drop turns older than the ceiling. A turn missing ts is
+            # treated as "now" (kept) — coercion always stamps one, so this only
+            # guards a turn appended in the current process.
+            turns[:] = [t for t in turns if t.get("ts", now) >= cutoff]
+            # Persist a bounded window; recent() re-applies the cap on read.
+            if len(turns) > self.max_turns:
+                del turns[: len(turns) - self.max_turns]
+            self._flush_locked()
+
+    def append_failed(self, key: str, question: str) -> None:
+        """Record a failed turn: the question with the :data:`FAILED_TURN_ANSWER`
+        marker, so the next question in this conversation can still resolve its
+        referent. An empty question carries no referent, so it is not recorded."""
+        if not question:
+            return
+        self.append(key, question, FAILED_TURN_ANSWER)
+
+
+def _cap_artifacts(artifacts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Keep at most :data:`MAX_ARTIFACTS_PER_TURN` descriptors, retaining the
+    tail (most recent). Descriptors are round-tripped opaquely."""
+    if len(artifacts) > MAX_ARTIFACTS_PER_TURN:
+        return list(artifacts[-MAX_ARTIFACTS_PER_TURN:])
+    return list(artifacts)

--- a/src/osprey/bridges/core/pipeline.py
+++ b/src/osprey/bridges/core/pipeline.py
@@ -1,0 +1,769 @@
+"""The per-message pipeline: ``handle_event``, the ordering specification itself.
+
+Every dispatch bridge runs the same safety-critical sequence for one inbound message;
+this module owns that sequence once, parameterized by the
+:class:`~osprey.bridges.core.ports.ChannelOps` seam so no adapter ever re-authors it:
+
+1.  ``ops.parse_event`` — ``None`` means the event is not for us: return ``"ignored"``.
+2.  ``dedup.claim`` — atomically claim the message BEFORE anything fires. The claim
+    persists the question ``text``, sender provenance, ``history_key`` and the
+    adapter's ``claim_meta`` (destination/threading/attachment refs), so a crash or a
+    redelivery can never re-dispatch, and every later step — including the retry drain
+    and startup reconcile, long after the wire event is gone — works off the persisted
+    entry alone. A lost claim returns ``"duplicate"`` without firing anything.
+3.  ``ops.post_ack`` — the user's "on it" signal, BEFORE the long dispatch.
+4.  ``ops.resolve_reply_context`` — after the claim, so duplicates never pay for it;
+    the resolved ``reply_to`` (plus its meta, e.g. quoted attachment refs) is persisted
+    so every re-dispatch path replays the same context without re-resolving.
+5.  ``history.recent`` — the conversation-so-far rides the payload so follow-ups
+    resolve their referents.
+6.  ONE memoized ``input_files`` capability probe for the whole dispatch, shared by
+    the attachment fold (the own and quoted buckets of ``ops.download_inputs``,
+    budgeted own-first, with own provenance top-level and quoted provenance folded
+    into ``reply_to``) and the prior-image re-injection. The probe itself
+    (:func:`~osprey.bridges.core.capabilities.pair_supports`) is deliberately
+    uncached, so the memoization here is strictly per-dispatch: a mid-session
+    downgrade is observed on the next dispatch.
+7.  ``dispatcher.run`` — with an ``on_run_id`` callback that persists the run id
+    (non-terminal ``in_flight``) BEFORE the long worker poll, so reconcile can
+    re-attach after a crash mid-poll.
+8.  Settle the terminal result off the persisted entry: a retryable failure is parked
+    in the retry queue (:func:`osprey.bridges.core.retry_queue.park` — the drain
+    replays it later; no history is written for an unfinished exchange); anything else
+    is final — ``ops.post_answer`` (which raises on a failed send: the entry is then
+    re-queued, run id intact, for the drain to re-attach and re-deliver — never marked
+    terminal, never appended to history), then the terminal status mark, then
+    best-effort ``ops.deliver_files``, then the history append.
+
+Returns ``"ignored"`` | ``"duplicate"`` | ``"handled"``.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from . import retry, retry_queue
+from .artifacts import fetch_artifact
+from .capabilities import pair_supports
+from .config import CoreConfig
+from .dedup import DedupStore
+from .dispatch_client import DispatchClient
+from .history import HistoryStore
+from .ports import RESERVED_ENTRY_KEYS, ChannelOps, InputDownload
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "EXPIRED_NOTE",
+    "IMAGE_MIMES",
+    "MAX_FILES",
+    "MAX_TOTAL_BYTES",
+    "OVER_BUDGET_REASON",
+    "REINJECT_MAX_IMAGES",
+    "REINJECT_MAX_TOTAL_BYTES",
+    "SERVER_TOO_OLD_REASON",
+    "TOO_MANY_FILES_REASON",
+    "PipelineDeps",
+    "build_extra",
+    "handle_event",
+]
+
+# --- Fresh-file budget --------------------------------------------------------------
+# The worker validates all ``ingest=True`` files of one dispatch against a single count
+# cap and the fresh half of its total decoded ceiling; a violation is a fatal,
+# non-retryable 400. ``ops.download_inputs`` returns two provenance buckets (own /
+# quoted), and the ENGINE enforces the shared budget across ``files`` then
+# ``quoted_files``, in that order, so the two sources can never sum past the caps —
+# routing each trim's skip note into the matching bucket.
+MAX_FILES = 5
+MAX_TOTAL_BYTES = 10 * 1024 * 1024
+
+# --- Prior-image re-injection budget ------------------------------------------------
+# Shares the worker's total input ceiling with the fresh budget above: 10MiB fresh +
+# 8MiB replayed priors. Only images are re-injected.
+IMAGE_MIMES = frozenset({"image/png", "image/jpeg", "image/gif", "image/webp"})
+REINJECT_MAX_IMAGES = 3
+REINJECT_MAX_TOTAL_BYTES = 8 * 1024 * 1024
+
+# Skip reason for a downloaded file the pair cannot ingest (capability probe said no).
+# The bytes are never shipped to a worker that would drop them; the reason rides the
+# payload so the agent can relay why.
+SERVER_TOO_OLD_REASON = "couldn't ingest (server too old)"
+
+# Skip reasons for files the engine's shared fresh budget declined.
+TOO_MANY_FILES_REASON = f"too many attachments (limit {MAX_FILES}); this file was not processed"
+OVER_BUDGET_REASON = "attachments exceed the total size budget; this file was not processed"
+
+# The note flagged onto a prior-artifact descriptor whose bytes could not be brought
+# back (404 / swept / over budget / network). It rides in the outgoing
+# ``conversation_so_far``; trigger prompts key on this EXACT phrase to tell the user
+# the file is no longer available rather than silently retrying. Never fatal — a
+# flagged descriptor is skipped, not dropped.
+EXPIRED_NOTE = "may have expired"
+
+# Belt-and-suspenders mirror of ``HistoryStore.MAX_ARTIFACTS_PER_TURN``: the store
+# already caps (keeping the tail), but we assemble OLDEST-first so its tail-keep
+# retains the NEWEST, and we never hand it an unbounded list.
+MAX_TURN_DESCRIPTORS = 10
+
+# Timeout for the default prior-artifact byte fetch against the worker.
+_PRIOR_FETCH_TIMEOUT = 30.0
+
+
+def _default_fetch_prior_artifact(
+    cfg: CoreConfig, run_id: str | None, descriptor: Mapping[str, Any], max_bytes: int
+) -> bytes | None:
+    """Fetch one prior artifact's bytes via the worker byte route; ``None`` on any
+    failure. An adapter whose channel republishes artifacts at a stable URL (and
+    stamps ``public_url`` on the descriptor via ``deliver_files``) injects its own
+    fetcher with a fallback for artifacts the worker has since swept."""
+    entry_id = descriptor.get("entry_id")
+    if not run_id or not isinstance(entry_id, str) or not entry_id or max_bytes <= 0:
+        return None
+    with httpx.Client(timeout=_PRIOR_FETCH_TIMEOUT, trust_env=cfg.trust_env) as http:
+        return fetch_artifact(
+            http, cfg, run_id=run_id, artifact_id=entry_id, max_bytes=max_bytes, require_png=False
+        )
+
+
+@dataclass
+class PipelineDeps:
+    """Injected collaborators — makes the per-message handler unit-testable.
+
+    ``park`` is the retry-queue seam, defaulting to the real
+    :func:`osprey.bridges.core.retry_queue.park`; it is called
+    ``(ops, dedup, message_id, entry, result)`` on a retryable terminal failure.
+    ``probe_capability`` is the per-dispatch ``input_files`` probe, called
+    ``(cfg, "input_files")``; ``fetch_prior_artifact`` recovers one prior IMAGE
+    artifact's bytes, called ``(cfg, run_id, descriptor, max_bytes)``. All three are
+    injectable so tests run no network I/O.
+    """
+
+    cfg: CoreConfig
+    ops: ChannelOps
+    dedup: DedupStore
+    dispatcher: DispatchClient
+    history: HistoryStore | None = None
+    park: Callable[..., Any] = retry_queue.park
+    probe_capability: Callable[..., bool] = pair_supports
+    fetch_prior_artifact: Callable[..., bytes | None] = _default_fetch_prior_artifact
+
+
+def _run_id_persister(dedup: DedupStore, message_id: str) -> Callable[[str], None]:
+    """Build a ``DispatchClient.run(on_run_id=...)`` callback.
+
+    Records the run_id with a NON-terminal status BEFORE the long worker poll, so
+    startup reconcile can re-attach if we crash mid-poll. Only ``run_id``/``status``
+    are written — the claim persisted the message meta, and
+    :meth:`~osprey.bridges.core.dedup.DedupStore.record` preserves it.
+    """
+
+    def persist(run_id: str) -> None:
+        dedup.record(message_id, run_id=run_id, status="in_flight")
+
+    return persist
+
+
+def _dispatch(
+    dispatcher: DispatchClient,
+    dedup: DedupStore,
+    message_id: str,
+    text: str,
+    extra: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Fire one dispatch for ``message_id``, persisting its run id mid-handshake.
+
+    The single dispatch call for every path that fires a question — the live pipeline,
+    the drain's retry, and startup reconcile's re-dispatch — so all three get the
+    crash-safety persister (:func:`_run_id_persister`) and none can drift. An empty (or
+    absent) ``extra`` is sent as no ``extra`` at all, keeping a text-only dispatch's
+    payload identical whether or not the engine looked for context to attach.
+    """
+    persist = _run_id_persister(dedup, message_id)
+    if extra:
+        return dispatcher.run(text, extra=dict(extra), on_run_id=persist)
+    return dispatcher.run(text, on_run_id=persist)
+
+
+def _capability_probe(deps: PipelineDeps) -> Callable[[], bool]:
+    """A memoized ``input_files`` capability probe for ONE dispatch.
+
+    Returns a zero-arg callable that runs :attr:`PipelineDeps.probe_capability` at
+    most once and caches the verdict, so the attachment fold and the prior-image
+    re-injection — every feature that gates on the pair advertising ``input_files`` —
+    share a SINGLE probe per dispatch. The probe fires lazily on first call, so a
+    dispatch that ships no bytes never probes at all; and the memo lives only for
+    this dispatch, so a mid-session downgrade is observed on the next one.
+    """
+    verdict: dict[str, bool] = {}
+
+    def probe() -> bool:
+        if "v" not in verdict:
+            verdict["v"] = bool(deps.probe_capability(deps.cfg, "input_files"))
+        return verdict["v"]
+
+    return probe
+
+
+def build_extra(
+    deps: PipelineDeps,
+    entry: Mapping[str, Any],
+    *,
+    history_key: str,
+    reply_to: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Assemble the dispatch ``extra`` for one message off its persisted ``entry``.
+
+    The single payload assembler: :func:`handle_event` calls it on the live path (with
+    the just-resolved ``reply_to``) and :func:`osprey.bridges.core.runtime.rebuild_extra`
+    calls it for every RE-dispatch (with the persisted one), so a replayed question can
+    never quietly ship less than the live one did. In order: the conversation-so-far, so
+    follow-ups ("now plot it over 24h") resolve their referents; the reply context, which
+    the quoted-attachment fold then folds provenance into; this message's attachments;
+    and the newest prior image artifacts — the last two off ONE memoized capability
+    probe, so a dispatch shipping no bytes never probes at all.
+
+    ``history_key`` is passed rather than read off ``entry`` because the live path knows
+    it from the parsed event; empty means "no conversation history for this message".
+    Returns ``{}`` for a text-only entry with no history, leaving the payload
+    byte-identical to the no-attachment path.
+    """
+    extra: dict[str, Any] = {}
+
+    turns: list[dict[str, Any]] = []
+    if deps.history is not None and history_key:
+        turns = deps.history.recent(history_key)
+        if turns:
+            extra["conversation_so_far"] = turns
+
+    # A COPY: the quoted-attachment fold mutates ``reply_to``, and handing out either
+    # the store's own nested dict or the adapter's mapping would let per-dispatch keys
+    # leak. Set BEFORE the fold, which folds quoted provenance inside it.
+    if reply_to:
+        extra["reply_to"] = dict(reply_to)
+
+    probe = _capability_probe(deps)
+    _fold_inputs(deps.ops.download_inputs(entry), extra, probe)
+    _reinject_prior_images(deps, extra, turns, probe)
+    return extra
+
+
+def handle_event(event: Any, deps: PipelineDeps) -> str:
+    """Process one raw wire event. Returns a short status string for logging.
+
+    Return values: ``"ignored"`` (not addressed to us), ``"duplicate"``
+    (redelivery), or ``"handled"``. See the module docstring for the ordering
+    specification this function IS.
+    """
+    parsed = deps.ops.parse_event(event)
+    if parsed is None:
+        return "ignored"
+
+    # An adapter claim_meta key colliding with an engine-owned entry field would be a
+    # silent overwrite in one direction or the other (a stamped ``reply_to`` clobbered
+    # by the persisted reply context; a stamped ``attempts`` corrupting the drain's
+    # give-up ceilings). Reject it HERE, before anything is claimed or fired, so the
+    # bug fails in the adapter's first test instead of corrupting entries in
+    # production.
+    collisions = RESERVED_ENTRY_KEYS.intersection(parsed.claim_meta)
+    if collisions:
+        raise ValueError(
+            f"claim_meta for {parsed.message_id} collides with engine-owned entry "
+            f"fields {sorted(collisions)}; see osprey.bridges.core.ports.RESERVED_ENTRY_KEYS"
+        )
+
+    # Atomically claim the message BEFORE dispatch: a crash/redelivery can't re-fire
+    # it, and two concurrent redeliveries can't both pass. The claim persists the
+    # question text (so a restart that crashed before a run_id existed can
+    # re-dispatch), sender provenance (the one field no other store ever sees),
+    # history_key (adapter channel policy, not reconstructible from the meta), and
+    # the adapter's claim_meta verbatim (destination/threading/attachment refs).
+    if not deps.dedup.claim(
+        parsed.message_id,
+        text=parsed.text,
+        sender_id=parsed.sender_id,
+        sender_display=parsed.sender_display,
+        history_key=parsed.history_key,
+        **dict(parsed.claim_meta),
+    ):
+        logger.info("duplicate delivery for %s — skipping", parsed.message_id)
+        return "duplicate"
+
+    entry = deps.dedup.get(parsed.message_id) or {}
+    deps.ops.post_ack(entry)
+
+    reply_to: dict[str, str] | None = None
+
+    # Resolve the channel's native reply/quote mechanic AFTER the claim (duplicates
+    # never pay for it). Persist reply_to + its meta (e.g. quoted attachment refs)
+    # before dispatch so every re-dispatch path replays the same context without
+    # re-resolving; ``extra`` gets its own copy to mutate.
+    reply = deps.ops.resolve_reply_context(parsed)
+    if reply is not None:
+        reply_to = dict(reply.reply_to)
+        # ReplyContext.meta lands in the same flat entry namespace as the engine's
+        # bookkeeping. The claim already committed, so a collision here cannot fail
+        # the message — strip the offending keys LOUDLY instead of letting them
+        # corrupt the entry (or clobber the reply_to persisted right below).
+        meta = dict(reply.meta)
+        meta_collisions = RESERVED_ENTRY_KEYS.intersection(meta)
+        if meta_collisions:
+            logger.error(
+                "ReplyContext.meta for %s collides with engine-owned entry fields %s; "
+                "dropping those keys (see osprey.bridges.core.ports.RESERVED_ENTRY_KEYS)",
+                parsed.message_id,
+                sorted(meta_collisions),
+            )
+            for key in meta_collisions:
+                del meta[key]
+        deps.dedup.record(
+            parsed.message_id, run_id=None, status="pending", reply_to=reply_to, **meta
+        )
+
+    # Assemble the dispatch payload off the persisted entry (refreshed: it now
+    # carries the reply meta too). The freshly resolved reply context is passed in
+    # rather than re-read, so the live path never depends on the store's round-trip.
+    entry = deps.dedup.get(parsed.message_id) or entry
+    extra = build_extra(deps, entry, history_key=parsed.history_key, reply_to=reply_to)
+
+    result = _dispatch(deps.dispatcher, deps.dedup, parsed.message_id, parsed.text, extra)
+
+    # Settle the terminal result off the persisted entry — independent of the
+    # inbound event, exactly like the drain and reconcile paths.
+    entry = deps.dedup.get(parsed.message_id) or {}
+    _settle_terminal(deps, parsed.message_id, entry, result)
+    return "handled"
+
+
+# --- input fold ---------------------------------------------------------------------
+
+
+def _decoded_size(content_b64: Any) -> int:
+    """Decoded byte size of one file's ``content_b64``; undecodable counts as zero
+    (defensive; never raises)."""
+    if not isinstance(content_b64, str) or not content_b64:
+        return 0
+    try:
+        return len(base64.b64decode(content_b64))
+    except Exception:
+        return 0
+
+
+def _apply_fresh_budget(
+    buckets: list[tuple[list[dict[str, Any]], list[dict[str, Any]]]],
+) -> list[list[dict[str, Any]]]:
+    """Enforce the SINGLE shared fresh-file budget across ``buckets`` in order.
+
+    Each bucket is ``(files, skipped)``; the count and byte caps are shared across
+    all buckets (own-message files first, quoted after — so own attachments win a
+    tight budget), and each over-budget file degrades to a skip note in ITS OWN
+    bucket's ``skipped`` list, never a sibling's. Returns the kept files per bucket.
+    """
+    kept_per_bucket: list[list[dict[str, Any]]] = []
+    count = 0
+    total = 0
+    for files, skipped in buckets:
+        kept: list[dict[str, Any]] = []
+        for item in files:
+            if count >= MAX_FILES:
+                skipped.append({"filename": item.get("filename"), "reason": TOO_MANY_FILES_REASON})
+                continue
+            size = _decoded_size(item.get("content_b64"))
+            if total + size > MAX_TOTAL_BYTES:
+                skipped.append({"filename": item.get("filename"), "reason": OVER_BUDGET_REASON})
+                continue
+            kept.append(item)
+            count += 1
+            total += size
+        kept_per_bucket.append(kept)
+    return kept_per_bucket
+
+
+def _fold_inputs(inputs: InputDownload, extra: dict[str, Any], probe: Callable[[], bool]) -> None:
+    """Budget the downloaded files and capability-gate their delivery into ``extra``,
+    keeping the two provenance buckets of :class:`~osprey.bridges.core.ports.InputDownload`
+    separate end to end.
+
+    Three outcomes, applied per bucket off ONE shared budget and ONE shared probe:
+
+      * no deliverable file  -> ship only the skip notes (if any); the capability
+        probe never runs (nothing to send).
+      * capable pair         -> ``input_files`` (adapter-shaped, ``ingest=True``,
+        own files before quoted) plus the skip notes.
+      * non-capable pair     -> NO ``input_files`` (bytes an old worker would drop
+        are never shipped); each undeliverable file gains a
+        :data:`SERVER_TOO_OLD_REASON` skip so the agent can relay why.
+
+    Own-message provenance rides top-level: ``extra["input_files"]`` /
+    ``extra["skipped_attachments"]``. Quoted provenance rides INSIDE
+    ``extra["reply_to"]``: delivered filenames as ``reply_to["attachments"]``, skips
+    as ``reply_to["skipped_attachments"]`` — so the agent knows those files came from
+    the quoted message, not the current one. Quoted files without a resolved
+    ``reply_to`` are an adapter contract violation and are dropped with a warning
+    (there is no quoted bucket to report them in).
+
+    An empty :class:`~osprey.bridges.core.ports.InputDownload` is a strict no-op:
+    ``extra`` stays byte-identical to the text-only path.
+    """
+    skipped = [dict(s) for s in inputs.skipped]
+    quoted_skipped = [dict(s) for s in inputs.quoted_skipped]
+    quoted_files = [dict(f) for f in inputs.quoted_files]
+
+    reply_to = extra.get("reply_to")
+    if (quoted_files or quoted_skipped) and not isinstance(reply_to, dict):
+        logger.warning(
+            "download_inputs returned quoted files/skips but no reply context resolved; "
+            "dropping the quoted bucket"
+        )
+        quoted_files, quoted_skipped = [], []
+
+    files, quoted = _apply_fresh_budget(
+        [([dict(f) for f in inputs.files], skipped), (quoted_files, quoted_skipped)]
+    )
+    # ONE probe for both buckets (memoized by the caller); no deliverable file
+    # anywhere means the probe never runs — there is nothing to send.
+    capable = probe() if (files or quoted) else False
+
+    # Own bucket -> top-level provenance.
+    if files:
+        if capable:
+            extra["input_files"] = files
+            extra["skipped_attachments"] = skipped
+        else:
+            extra["skipped_attachments"] = skipped + [
+                {"filename": f.get("filename"), "reason": SERVER_TOO_OLD_REASON} for f in files
+            ]
+    elif skipped:
+        # Every own file was declined: the skip reasons still ride the payload so
+        # the agent can relay them.
+        extra["skipped_attachments"] = skipped
+
+    # Quoted bucket -> provenance INSIDE reply_to. Delivered bytes still ride
+    # input_files (after the own files), but the filenames/skips land on reply_to
+    # so the agent knows they came from the quoted message.
+    if quoted and isinstance(reply_to, dict):
+        if capable:
+            extra.setdefault("input_files", []).extend(quoted)
+            reply_to["attachments"] = [f.get("filename") for f in quoted]
+        else:
+            quoted_skipped = quoted_skipped + [
+                {"filename": f.get("filename"), "reason": SERVER_TOO_OLD_REASON} for f in quoted
+            ]
+    if quoted_skipped and isinstance(reply_to, dict):
+        reply_to["skipped_attachments"] = quoted_skipped
+
+
+# --- prior-image re-injection -------------------------------------------------------
+
+
+def _content_hashes(input_files: Any) -> set[bytes]:
+    """SHA-256 digests of the bytes already in ``input_files`` (this message's own
+    and quoted attachments), for dedup against re-injected priors. Tolerates a
+    missing key or an item without decodable bytes."""
+    hashes: set[bytes] = set()
+    for item in input_files or []:
+        b64 = item.get("content_b64") if isinstance(item, dict) else None
+        if not isinstance(b64, str) or not b64:
+            continue
+        try:
+            hashes.add(hashlib.sha256(base64.b64decode(b64)).digest())
+        except Exception:
+            continue
+    return hashes
+
+
+def _flag_expired(turns: list[dict[str, Any]], ti: int, ai: int) -> None:
+    """Flag one prior-artifact descriptor with :data:`EXPIRED_NOTE` WITHOUT mutating
+    the :class:`~osprey.bridges.core.history.HistoryStore`'s copy.
+
+    ``HistoryStore.recent`` shallow-copies each turn but SHARES the nested artifact
+    list and descriptor dicts with the persisted store, so we replace the turn's
+    artifact list (and the one descriptor) with fresh objects the store never sees.
+    Idempotent and safe to call repeatedly for the same turn."""
+    turn = turns[ti]
+    arts = list(turn.get("artifacts") or [])
+    if not (0 <= ai < len(arts)) or not isinstance(arts[ai], dict):
+        return
+    arts[ai] = {**arts[ai], "note": EXPIRED_NOTE}
+    turn["artifacts"] = arts
+
+
+def _reinject_prior_images(
+    deps: PipelineDeps,
+    extra: dict[str, Any],
+    turns: list[dict[str, Any]],
+    probe: Callable[[], bool],
+) -> None:
+    """Re-inject the newest prior IMAGE artifacts (bytes) as ``ingest=False`` files.
+
+    A follow-up dispatch already carries the prior turns in ``conversation_so_far``
+    (descriptors and all); this additionally ships the BYTES of the newest
+    :data:`REINJECT_MAX_IMAGES` prior images (across all turns, within
+    :data:`REINJECT_MAX_TOTAL_BYTES`) so the agent can look at them again, not just
+    read a descriptor. Runs AFTER the current message's own files are folded.
+
+    Gated on the SAME ``input_files`` capability probe as the current-message fold:
+    a non-capable pair gets no bytes anywhere (the descriptors still ride
+    ``conversation_so_far`` untouched). Each selected image is pulled via
+    :attr:`PipelineDeps.fetch_prior_artifact` against the shared budget; a fetch
+    that fails or would bust the budget flags its descriptor with
+    :data:`EXPIRED_NOTE` and is skipped — never fatal, never blocks dispatch. Bytes
+    are deduped by SHA-256 against the files the current message already attached
+    (and against each other), so a user who re-attaches the very plot they are
+    asking about does not ship it twice.
+    """
+    if not turns:
+        return
+
+    # Collect image descriptors chronologically (turns oldest-first; within a turn,
+    # descriptors are already oldest-first), remembering each one's turn+index so a
+    # failed fetch can flag exactly that descriptor.
+    candidates: list[tuple[int, int, str | None, dict[str, Any]]] = []
+    for ti, turn in enumerate(turns):
+        run_id = turn.get("run_id")
+        for ai, desc in enumerate(turn.get("artifacts") or []):
+            if isinstance(desc, dict) and desc.get("delivered_mime") in IMAGE_MIMES:
+                candidates.append((ti, ai, run_id, desc))
+    if not candidates:
+        return
+
+    # Probe only now — never for a dispatch with no prior images to re-inject.
+    if not probe():
+        return
+
+    # Newest wins the budget: keep the newest N, process them newest-first so a
+    # tight budget starves the OLDER images, then re-inject in chronological order.
+    selected = candidates[-REINJECT_MAX_IMAGES:]
+    seen = _content_hashes(extra.get("input_files"))
+    injected: list[dict[str, Any]] = []
+    remaining = REINJECT_MAX_TOTAL_BYTES
+    for ti, ai, run_id, desc in reversed(selected):
+        data = deps.fetch_prior_artifact(deps.cfg, run_id, desc, remaining)
+        if data is None:
+            _flag_expired(turns, ti, ai)
+            continue
+        digest = hashlib.sha256(data).digest()
+        if digest in seen:
+            continue  # already attached to this message (or an earlier prior)
+        seen.add(digest)
+        injected.append(
+            {
+                "filename": desc.get("filename"),
+                "mime": desc.get("delivered_mime"),
+                "content_b64": base64.b64encode(data).decode("ascii"),
+                "ingest": False,
+            }
+        )
+        remaining -= len(data)
+
+    if injected:
+        injected.reverse()  # restore chronological order among the re-injected
+        extra.setdefault("input_files", []).extend(injected)
+
+
+# --- terminal settle ----------------------------------------------------------------
+
+
+def _settle_terminal(
+    deps: PipelineDeps, message_id: str, entry: dict[str, Any], result: dict[str, Any]
+) -> None:
+    """Settle a terminal dispatch result off the persisted ``entry``.
+
+    A retryable failure (provider/infrastructure) is parked in the retry queue via
+    :attr:`PipelineDeps.park` — the user gets the queued notice from ``park`` itself,
+    and the history append is SKIPPED (the exchange is unfinished; the drain records
+    it when the queued run completes). ``post_queued`` raising AFTER the park CAS
+    committed is swallowed here: a lost notice never loses the request.
+
+    Every other result is final, in crash-safe order: send the answer FIRST
+    (``post_answer`` raises on a failed delivery — the entry is then re-queued with
+    its run id intact so the drain re-attaches and re-delivers next cycle, and no
+    terminal mark or history append happens), THEN record the terminal status, then
+    best-effort ``deliver_files`` (never raises), then the history append with the
+    returned ``{artifact_id: public_url}`` stamped onto this turn's descriptors.
+    """
+    if retry.is_retryable(result):
+        try:
+            deps.park(deps.ops, deps.dedup, message_id, entry, result)
+        except Exception:
+            logger.exception("queued notice failed for %s; entry stays parked", message_id)
+        return
+
+    try:
+        deps.ops.post_answer(entry, result)
+    except Exception:
+        logger.exception(
+            "answer delivery failed for %s; re-queueing for the drain to re-deliver", message_id
+        )
+        _requeue_for_redelivery(deps, message_id, entry, result)
+        return
+
+    # Answer landed: only run_id/status change here; the claim persisted the rest.
+    deps.dedup.record(message_id, run_id=result.get("run_id"), status=result.get("status", "error"))
+    urls = _deliver_files(deps, message_id, entry, result)
+    _append_history(deps, entry, result, urls)
+
+
+def _deliver_files(
+    deps: PipelineDeps, message_id: str, entry: Mapping[str, Any], result: Mapping[str, Any]
+) -> dict[str, str]:
+    """Deliver the run's OUTPUT artifacts, returning the ``{artifact_id: public_url}``
+    map of whatever the channel republished (empty when it republished nothing).
+
+    The one file-delivery step for every path that has already posted an answer — the
+    live settle and the drain's re-attached delivery. ``deliver_files`` degrades to
+    text-only rather than raising, by contract; a misbehaving adapter that raises anyway
+    must not un-deliver the text that already landed, so the raise is logged and treated
+    as "nothing republished" — the terminal mark and the history append still happen.
+    """
+    try:
+        return dict(deps.ops.deliver_files(entry, result) or {})
+    except Exception:
+        logger.exception("file delivery raised for %s; text already sent", message_id)
+        return {}
+
+
+def _requeue_for_redelivery(
+    deps: PipelineDeps, message_id: str, entry: dict[str, Any], result: dict[str, Any]
+) -> None:
+    """Keep an entry whose answer could not be delivered QUEUED (run id intact).
+
+    The drain's re-attach path then probes the persisted run and re-delivers next
+    cycle (at-least-once, bounded by the give-up ceilings) — a transient post failure
+    must never terminal-mark an undelivered answer or silently drop it. Stamps the
+    queue bookkeeping the drain's pacing/ceiling policy reads; ``attempts`` is left
+    to the drain (this was a delivery failure, not a dispatch attempt)."""
+    now = time.time()
+    deps.dedup.transition(
+        message_id,
+        str(entry.get("status") or "pending"),
+        "queued",
+        run_id=result.get("run_id") or entry.get("run_id"),
+        queued_at=now,
+        first_queued_at=entry.get("first_queued_at") or entry.get("queued_at") or now,
+    )
+
+
+# --- history ------------------------------------------------------------------------
+
+
+def _append_history(
+    deps: PipelineDeps,
+    entry: dict[str, Any],
+    result: dict[str, Any],
+    artifact_urls: dict[str, str] | None = None,
+) -> None:
+    """Record this exchange under the entry's persisted ``history_key`` so the NEXT
+    question in the conversation carries it. A completed run with text keeps the
+    real answer, the producing ``run_id``, and this turn's artifact descriptors (so
+    a follow-up can refer back to a plot the agent already made); anything else
+    (timeout, error, or a completed run with no text) keeps the QUESTION with a
+    marker so a follow-up still resolves its referent — the raw error text is never
+    replayed, and a failed turn carries no descriptors. Best-effort: a history write
+    must never fail a delivery that already landed.
+    """
+    if deps.history is None:
+        return
+    key = entry.get("history_key")
+    if not key:
+        return
+    question = entry.get("text", "")
+    answer = result.get("text_output") or ""
+    try:
+        if result.get("status") == "completed" and answer:
+            deps.history.append(
+                key,
+                question,
+                answer,
+                run_id=result.get("run_id"),
+                artifacts=_turn_descriptors(result, artifact_urls),
+            )
+        else:
+            deps.history.append_failed(key, question)
+    except Exception:
+        logger.exception("history append failed for %s; continuing", key)
+
+
+def _turn_descriptors(
+    result: dict[str, Any], artifact_urls: dict[str, str] | None = None
+) -> list[dict[str, Any]]:
+    """Assemble this turn's artifact descriptors, OLDEST-first.
+
+    Order is inputs (what the user sent, older) then outputs (what the run produced,
+    newer), each in delivery order, so the history store's tail-keeping cap retains
+    the NEWEST when it trims. Each descriptor is
+    ``{entry_id, filename, delivered_mime, public_url?, origin}`` with ``origin`` in
+    ``{"input", "output"}``. Only OUTPUT descriptors ever carry ``public_url``
+    (stamped from the ``deliver_files`` return); INPUT files are never republished,
+    so never get one — a hard invariant."""
+    url_map = artifact_urls if isinstance(artifact_urls, dict) else {}
+    descriptors = _input_descriptors(result) + _output_descriptors(result, url_map)
+    return descriptors[-MAX_TURN_DESCRIPTORS:]
+
+
+def _output_descriptors(
+    result: dict[str, Any], artifact_urls: dict[str, str]
+) -> list[dict[str, Any]]:
+    """OUTPUT descriptors from the run-status ``artifacts`` field (descriptor dicts,
+    or bare id strings from an older worker treated as PNG images). A ``public_url``
+    is stamped only when the artifact was republished by ``deliver_files`` (its id is
+    in ``artifact_urls``)."""
+    descriptors: list[dict[str, Any]] = []
+    for a in result.get("artifacts") or []:
+        entry_id: str
+        filename: Any = None
+        mime: Any = "image/png"
+        if isinstance(a, str):
+            if not a:
+                continue
+            entry_id = a
+        elif isinstance(a, dict):
+            raw_id = a.get("artifact_id")
+            if not (isinstance(raw_id, str) and raw_id):
+                continue
+            entry_id = raw_id
+            filename = a.get("filename")
+            mime = a.get("delivered_mime")
+        else:
+            continue
+        descriptor: dict[str, Any] = {
+            "entry_id": entry_id,
+            "filename": filename,
+            "delivered_mime": mime,
+            "origin": "output",
+        }
+        url = artifact_urls.get(entry_id)
+        if url:
+            descriptor["public_url"] = url
+        descriptors.append(descriptor)
+    return descriptors
+
+
+def _input_descriptors(result: dict[str, Any]) -> list[dict[str, Any]]:
+    """INPUT descriptors from the run-status ``input_artifacts`` field
+    (``[{entry_id, filename, mime}]`` from the worker). Inputs are never
+    republished, so a descriptor NEVER carries a ``public_url``."""
+    descriptors: list[dict[str, Any]] = []
+    for a in result.get("input_artifacts") or []:
+        if not isinstance(a, dict):
+            continue
+        entry_id = a.get("entry_id")
+        if not (isinstance(entry_id, str) and entry_id):
+            continue
+        descriptors.append(
+            {
+                "entry_id": entry_id,
+                "filename": a.get("filename"),
+                "delivered_mime": a.get("mime"),
+                "origin": "input",
+            }
+        )
+    return descriptors

--- a/src/osprey/bridges/core/ports.py
+++ b/src/osprey/bridges/core/ports.py
@@ -1,0 +1,330 @@
+"""The ``ChannelOps`` seam: every platform side effect the bridge engine invokes.
+
+The engine (pipeline / retry_queue / reconcile / drain wiring) owns the safety-critical
+*ordering* — **claim -> ack -> reply context -> dispatch** (the ack is the FIRST thing after
+a won claim, so no channel I/O ever delays the user's "on it" signal), send before terminal
+mark, history only after a successful post — while every platform I/O behind those steps is
+injected through :class:`ChannelOps`. The design generalizes the two proven channels (Google Chat and email):
+everything the two share verbatim lives in the engine; everywhere they diverge is a protocol
+member.
+
+Destination addressing is deliberately NOT modeled here. Chat posts into ``(space, thread)``,
+email replies to ``(sender, in_reply_to, references)``, Nextcloud Talk posts into a room
+token — so the engine never sees an address. The adapter stamps whatever it needs into
+:attr:`InboundEvent.claim_meta`, the engine persists that meta verbatim on the dedup claim,
+and every outbound member receives the persisted ``entry`` back and reads its own fields out
+of it. That round-trip is also what makes the retry drain and startup reconcile work: both
+operate *only* on persisted entries, long after the wire event is gone.
+
+Failure contracts are part of the seam (the engine's crash-safety ordering depends on them):
+
+============================  =========================================================
+member                        contract on failure
+============================  =========================================================
+``parse_event``               return ``None`` (drop/ignore); never raise on bad input
+``resolve_reply_context``     return ``None``; reply context is enrichment, never fatal
+``post_ack``                  best-effort: swallow internally, never raise
+``download_inputs``           per-file failures become ``skipped`` notes; never raise
+``post_answer``               MUST raise — the engine turns the raise into "stay queued
+                              and re-deliver next cycle" (drain) or ``post_failed``
+                              (reconcile); a swallowed failure would silently drop the
+                              answer
+``deliver_files``             best-effort: degrade to text-only, never raise — the
+                              answer text has already landed via ``post_answer`` and
+                              must not be un-delivered by a failed file upload
+``post_queued``               may raise — the engine parks the entry BEFORE posting the
+                              notice, so a lost notice never loses the request
+``post_giveup``               MUST raise — the engine marks the entry terminal only
+                              after the notice lands; a lost give-up notice is silence,
+                              worse than the rare duplicate a retry could produce
+``post_superseded``           best-effort: the coalesce CAS is already committed, so a
+                              failed note must never disturb the pass
+``coalesce_key``              pure function of the entry; never raise
+============================  =========================================================
+
+This module is import-isolated on purpose: no channel imports, no osprey dispatch
+internals, no agent SDK, not even sibling ``osprey.bridges.core`` modules — an adapter can
+type-check against the seam without dragging in the engine.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+__all__ = [
+    "RESERVED_ENTRY_KEYS",
+    "ChannelOps",
+    "InboundEvent",
+    "InputDownload",
+    "ReplyContext",
+]
+
+# Entry keys the ENGINE writes on the persisted dedup entry. The adapter-owned
+# namespaces — :attr:`InboundEvent.claim_meta` and :attr:`ReplyContext.meta` — land in
+# the SAME flat entry dict, so an adapter key colliding with any of these is a silent
+# overwrite in one direction or the other (e.g. a stamped ``reply_to`` clobbered by the
+# engine's persisted reply context; a stamped ``attempts`` corrupting the drain's
+# give-up ceilings). The pipeline rejects ``claim_meta`` collisions at claim time and
+# strips ``ReplyContext.meta`` collisions (loudly) before persisting.
+#
+# Writers, for the record: the pipeline claims ``text`` / ``sender_id`` /
+# ``sender_display`` / ``history_key`` and persists ``reply_to``; the dedup store
+# stamps ``run_id`` / ``status`` / ``claimed_at`` / ``settled_at``; the retry queue's
+# park stamps ``failure_class`` / ``num_tool_calls`` / ``queued_at`` /
+# ``first_queued_at`` / ``coalesce_key`` / ``attempts``; the pipeline's re-queue path
+# stamps ``queued_at`` / ``first_queued_at``; the drain stamps ``retried`` /
+# ``attempts`` / ``notfound_count`` / ``gate_seen_open`` / ``give_up_reason``.
+RESERVED_ENTRY_KEYS: frozenset[str] = frozenset(
+    {
+        "text",
+        "sender_id",
+        "sender_display",
+        "history_key",
+        "run_id",
+        "status",
+        "claimed_at",
+        "settled_at",
+        "reply_to",
+        "queued_at",
+        "first_queued_at",
+        "attempts",
+        "retried",
+        "failure_class",
+        "num_tool_calls",
+        "coalesce_key",
+        "notfound_count",
+        "gate_seen_open",
+        "give_up_reason",
+    }
+)
+
+
+@dataclass(frozen=True)
+class InboundEvent:
+    """A parsed, channel-neutral inbound message — what :meth:`ChannelOps.parse_event`
+    distills out of a raw wire event for the engine to claim and dispatch.
+
+    Only the fields the engine itself consumes are first-class; everything
+    channel-specific rides in :attr:`claim_meta`. Adapters may subclass (as a dataclass)
+    to carry extra parse state privately, or stash the wire event in :attr:`raw`.
+    """
+
+    message_id: str
+    """Channel-supplied opaque dedup key, unique per deliverable message. The engine
+    treats it as a black box (claim key, log token) — it is the ADAPTER's job to scope
+    it when the platform does not guarantee globally unique message ids (e.g. a
+    Nextcloud Talk adapter keys ``f"{room_token}:{message_id}"``; email synthesizes a
+    hash when ``Message-ID`` is absent)."""
+
+    text: str
+    """The question: mention-stripped, quote-stripped message text. The engine claims
+    it, ships it to the dispatcher, and re-dispatches from the persisted copy after a
+    crash — so it must be complete on its own, without the wire event."""
+
+    sender_id: str
+    """Stable machine identity of the sender (``users/123``, an email address, a Talk
+    actor id). Persisted for provenance and used in channel coalesce keys."""
+
+    sender_display: str
+    """Human display name of the sender, for logs and reply context."""
+
+    history_key: str
+    """The adapter-computed per-conversation key the transcript store is scoped by.
+    First-class because it is NOT reconstructible from the other fields: it encodes
+    channel policy (a Chat DM keys on space while a room keys on thread; email keys on
+    sender; Talk keys on room token), and the retry drain needs it to append history
+    when a queued run finally completes — long after ``is_dm``-style wire context is
+    gone. Empty string means "no conversation history for this message"."""
+
+    claim_meta: Mapping[str, Any] = field(default_factory=dict)
+    """Channel-specific fields the engine persists VERBATIM on the dedup claim and
+    hands back (inside ``entry``) to every outbound member: destination/threading
+    (``space``/``thread``, ``in_reply_to``/``references``, a room token) and inbound
+    attachment refs for :meth:`ChannelOps.download_inputs` to re-fetch on a
+    re-dispatch. Must be JSON-plain (it round-trips through the on-disk store).
+
+    This meta and :attr:`ReplyContext.meta` land in the SAME flat entry dict as the
+    engine's own bookkeeping: keys MUST NOT collide with
+    :data:`RESERVED_ENTRY_KEYS` (the pipeline raises at claim time on a
+    collision), and the two adapter namespaces must not collide with each other."""
+
+    raw: Any = None
+    """The original wire event, for adapter-internal use only (e.g.
+    :meth:`ChannelOps.resolve_reply_context` re-reading an inline quote snapshot).
+    NEVER persisted or otherwise touched by the engine."""
+
+
+@dataclass(frozen=True)
+class ReplyContext:
+    """Resolved reply-to context for a message that quotes/replies to another.
+
+    Returned by :meth:`ChannelOps.resolve_reply_context`; the engine ships
+    :attr:`reply_to` to the worker and persists both fields so every re-dispatch path
+    replays the same context without re-resolving.
+    """
+
+    reply_to: Mapping[str, str]
+    """``{"sender": <display name>, "text": <quoted text>}`` — the payload contract the
+    worker already consumes. The adapter truncates ``text`` to its own limit."""
+
+    meta: Mapping[str, Any] = field(default_factory=dict)
+    """Extra JSON-plain fields persisted into the entry beside ``reply_to`` — e.g. the
+    quoted message's attachment refs, so :meth:`ChannelOps.download_inputs` can fetch
+    the quoted files on both the live and the re-dispatch path.
+
+    Lands in the SAME flat entry dict as :attr:`InboundEvent.claim_meta` and the
+    engine's own bookkeeping: keys MUST NOT collide with
+    :data:`RESERVED_ENTRY_KEYS` (the pipeline strips such keys, loudly, rather than
+    let them corrupt the entry), and must not collide with the adapter's own
+    ``claim_meta`` keys."""
+
+
+@dataclass(frozen=True)
+class InputDownload:
+    """Inbound files fetched (or declined) for one dispatch, in two provenance buckets.
+
+    File entries are worker-payload-shaped dicts (``filename`` / ``content_b64`` /
+    ``mime`` ...); skip entries are ``{"filename": ..., "reason": ...}`` notes for
+    anything the adapter could not or would not fetch, shipped to the agent so it can
+    relay why. The OWN bucket (``files`` / ``skipped``) holds the message's own
+    attachments; the QUOTED bucket (``quoted_files`` / ``quoted_skipped``) holds
+    attachments of the quoted/replied-to message a resolved
+    :class:`ReplyContext` pointed at. A channel with no quote mechanic (email, Talk
+    without ``parent``) simply leaves the quoted bucket empty.
+
+    The ENGINE owns the shared fresh-file budget and applies it across ``files`` then
+    ``quoted_files``, in that order (own attachments win a tight budget), routing each
+    capability/trim skip into the MATCHING bucket. Own-message provenance is folded to
+    top-level payload keys (``input_files`` / ``skipped_attachments``); quoted
+    provenance is folded INSIDE ``reply_to`` (``reply_to["attachments"]`` = delivered
+    quoted filenames, ``reply_to["skipped_attachments"]`` = quoted skips), so the agent
+    knows those files came from the quoted message, not the current one. Quoted files
+    are meaningful only when a reply context resolved (there is a ``reply_to`` to fold
+    into).
+
+    ``InputDownload()`` (all four empty) is the no-op: a text-only message must leave
+    the dispatch payload byte-identical to the no-attachment path.
+    """
+
+    files: Sequence[Mapping[str, Any]] = ()
+    skipped: Sequence[Mapping[str, Any]] = ()
+    quoted_files: Sequence[Mapping[str, Any]] = ()
+    quoted_skipped: Sequence[Mapping[str, Any]] = ()
+
+
+@runtime_checkable
+class ChannelOps(Protocol):
+    """Platform I/O a channel adapter implements; the engine owns all ordering and
+    store state around these calls (see the module docstring for the per-member
+    failure contracts — they are load-bearing).
+
+    Every post-claim member takes the persisted ``entry`` dict (the claim's
+    ``claim_meta`` plus the engine's own bookkeeping) rather than the wire event, so
+    the same implementation serves the live path, the retry drain, and startup
+    reconcile identically.
+
+    **Concurrency.** The engine may invoke any member concurrently: the retry drain
+    runs as its own daemon thread alongside live ingestion, and a channel may ingest
+    from more than one path (e.g. one thread per room). Implementations must be
+    thread-safe and must not assume per-dispatch instance affinity — the same
+    ``ChannelOps`` object serves every thread. The engine's own per-dispatch state
+    (the memoized ``input_files`` capability probe) is scoped to a single dispatch
+    and never shared across threads. Members may block (``download_inputs`` and the
+    posts do real I/O); the engine never requires them to return promptly.
+    """
+
+    def parse_event(self, event: Any) -> InboundEvent | None:
+        """Parse one raw wire event into an :class:`InboundEvent`, or ``None`` to
+        ignore it (not addressed to the bot, untrusted sender, empty question,
+        non-message event). Must be cheap and I/O-free: it runs BEFORE the dedup
+        claim, so redeliveries pay this cost repeatedly."""
+        ...
+
+    def resolve_reply_context(self, event: InboundEvent) -> ReplyContext | None:
+        """Resolve the platform's native reply/quote mechanic for ``event``, or
+        ``None`` when it is not a reply (or resolution failed — never fatal). Runs
+        once, AFTER the claim, so duplicates never pay for it; adapters whose wire
+        events carry the reply inline (Talk's ``parent``) just read ``event.raw``,
+        while adapters needing a lookup (Chat's ``messages.get`` fallback) do their
+        I/O here."""
+        ...
+
+    def post_ack(self, entry: Mapping[str, Any]) -> None:
+        """Give the user an immediate "on it" signal in the conversation (an emoji
+        reaction, a short message). Best-effort; a channel with no ack idiom (email)
+        implements this as a no-op."""
+        ...
+
+    def download_inputs(self, entry: Mapping[str, Any]) -> InputDownload:
+        """Fetch the inbound files referenced by the persisted ``entry``: its own
+        attachment refs into the OWN bucket (``files`` / ``skipped``), any
+        quoted-message refs from ``ReplyContext.meta`` into the QUOTED bucket
+        (``quoted_files`` / ``quoted_skipped``) — see :class:`InputDownload` for how
+        the engine budgets and folds the two. Called at most once per dispatch;
+        whether the fetched bytes are actually shipped is decided by the ENGINE's
+        single memoized ``input_files`` capability probe — the adapter never probes
+        worker capabilities itself. Also the re-dispatch path: refs come from the
+        entry, never from a live wire event."""
+        ...
+
+    def post_answer(self, entry: Mapping[str, Any], result: Mapping[str, Any]) -> None:
+        """Deliver the terminal answer TEXT into the conversation: the completed
+        answer, or the channel's error wording for a non-completed status (raw
+        internal error strings must never leak). Raise on delivery failure — the
+        engine relies on the raise for its at-least-once redelivery."""
+        ...
+
+    def deliver_files(
+        self, entry: Mapping[str, Any], result: Mapping[str, Any]
+    ) -> Mapping[str, str]:
+        """Deliver the run's OUTPUT artifacts into the conversation (fetch from the
+        worker, upload/republish platform-side). Called after :meth:`post_answer`
+        succeeded; degrades to text-only on failure, never raises. Returns
+        ``{artifact_id: public_url}`` for artifacts republished at a stable URL (may
+        be empty) — the engine stamps these onto the history turn's descriptors.
+
+        A returned URL MUST be retrievable by an unauthenticated GET from the
+        engine: it is re-fetched later for prior-artifact re-injection, and the
+        engine holds no channel credentials. A channel that cannot publish such a
+        URL (e.g. a WebDAV store that would 401, short of minting world-readable
+        share links) returns ``{}`` for that artifact — re-injection then degrades
+        to the worker byte route only.
+
+        A channel whose answer and artifacts ride ONE payload (email: a single MIME
+        message carries the text and the attachments) folds the artifacts into
+        :meth:`post_answer` and implements this member as a no-op returning ``{}``.
+        Such a channel MUST keep the artifact fetch/attach best-effort INSIDE
+        ``post_answer``, so ``post_answer`` still raises only on transport failure —
+        a lost artifact must never un-deliver the answer (see the failure table)."""
+        ...
+
+    def post_queued(self, entry: Mapping[str, Any], result: Mapping[str, Any]) -> None:
+        """Tell the user their request is parked and will run once service is
+        restored. Posted on the FIRST park only (a re-park is silent); ``result`` is
+        the retryable-failure result that triggered the park, for channels that
+        surface any of it."""
+        ...
+
+    def post_giveup(self, entry: Mapping[str, Any]) -> None:
+        """Post the honest "couldn't run this automatically" notice for an abandoned
+        entry. Raise on failure — the engine leaves the entry queued and retries the
+        notice next cycle. The machine-side reason stays in store meta
+        (``give_up_reason``), never in the user-facing wording."""
+        ...
+
+    def post_superseded(self, entry: Mapping[str, Any]) -> None:
+        """Post the one-line note that a newer question in the same conversation
+        superseded this queued one (into the OLD message's own thread). Best-effort;
+        never raises."""
+        ...
+
+    def coalesce_key(self, entry: Mapping[str, Any]) -> str | Sequence[str]:
+        """The channel's grouping key for collapsing redundant queued entries: entries
+        sharing a key keep only the newest (Chat groups on
+        ``[history_key, sender_id]``; email on the References-thread root). Return
+        ``""`` (or ``()``) for "stands alone — never coalesce". Pure function of the
+        persisted entry; the engine normalizes and persists it via
+        :func:`osprey.bridges.core.retry.coalesce_key` at park time."""
+        ...

--- a/src/osprey/bridges/core/reconcile.py
+++ b/src/osprey/bridges/core/reconcile.py
@@ -1,0 +1,232 @@
+"""Startup crash recovery: drive to terminal whatever was in flight when we stopped.
+
+A bridge claims a message BEFORE it dispatches, and marks the entry terminal only
+AFTER the answer has been posted. That ordering is what makes delivery at-least-once
+— but it also means a crash anywhere in between leaves a non-terminal entry that
+nothing else will ever pick up: the channel's own redelivery is defeated by the dedup
+claim, and the retry drain deliberately owns only ``queued`` entries. This module is
+the other half of that contract. It runs once at startup, over
+:meth:`~osprey.bridges.core.dedup.DedupStore.reconcile` (non-terminal and not
+``queued``), and finishes each entry.
+
+Three cases, distinguished by what the entry already carries:
+
+``retried`` and no ``run_id``
+    A drain redispatch that crashed after CAS-flipping ``queued -> in_flight`` but
+    before a run existed. The drain owns retried entries, so hand it straight back to
+    the queue — startup must never dispatch one, so the health gate and the retry
+    min-age always mediate the next attempt.
+
+a ``run_id``
+    Crashed mid-poll: a run WAS started and may already have reached hardware.
+    **Re-attach** — poll the worker to terminal and deliver. Never re-dispatch: a
+    second run of the same question is a second set of side effects.
+
+no ``run_id`` but a persisted ``text``
+    Crashed after the claim, before the dispatcher handshake yielded a run id. No run
+    was ever started, so a **re-dispatch** is safe — which is precisely why the claim
+    persists ``text`` before anything is fired.
+
+Anything else (no run id, no text) is left alone rather than guessed at.
+
+Delivery goes through :class:`~osprey.bridges.core.ports.ChannelOps`, whose failure
+contracts carry the crash-safety here: ``post_answer`` MUST raise, and a raise during
+reconcile marks the entry ``post_failed``. That is deliberately harsher than the drain's
+"stay queued and re-deliver next cycle": startup runs once per process, so an entry
+whose destination is permanently gone (a deleted thread, a bounced address) would
+otherwise be retried on every restart forever, and a raise out of here would crashloop
+the bridge before it ever subscribed.
+
+Two seams are injectable so the module stays independent of the rest of the engine:
+``build_extra`` (re-assemble a re-dispatch's context — conversation replay, reply
+context, re-downloaded attachments) and ``settle`` (what to do with a terminal result).
+Both default to a self-contained implementation; the runtime overrides them with the
+pipeline's versions so a reconciled result settles exactly like a live one.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from .config import TERMINAL_STATUSES
+from .dedup import DedupStore
+from .dispatch_client import DispatchClient
+from .pipeline import _dispatch
+from .ports import ChannelOps
+
+__all__ = [
+    "ReconcileDeps",
+    "ReconcileReport",
+    "deliver_terminal",
+    "reconcile_inflight",
+]
+
+logger = logging.getLogger(__name__)
+
+
+class ReconcileDeps(Protocol):
+    """The collaborators reconcile needs, as a structural type.
+
+    A Protocol rather than a concrete dataclass so the runtime's own (larger)
+    dependency bundle can be passed straight in — reconcile reads exactly these three
+    attributes and nothing else.
+    """
+
+    dedup: DedupStore
+    dispatcher: DispatchClient
+    ops: ChannelOps
+
+
+@dataclass
+class ReconcileReport:
+    """What one startup pass did, for the runtime's startup log and for tests.
+
+    ``failed`` counts entries whose dispatch/poll raised and were left for the next
+    startup; ``post_failed`` counts entries abandoned because the answer could not be
+    delivered. Both are non-fatal — a reconcile pass never raises.
+    """
+
+    reattached: int = 0
+    redispatched: int = 0
+    requeued: int = 0
+    skipped: int = 0
+    failed: int = 0
+    post_failed: int = 0
+
+    @property
+    def total(self) -> int:
+        """Every non-terminal entry this pass looked at."""
+        return (
+            self.reattached
+            + self.redispatched
+            + self.requeued
+            + self.skipped
+            + self.failed
+            + self.post_failed
+        )
+
+
+def deliver_terminal(
+    deps: ReconcileDeps,
+    message_id: str,
+    entry: Mapping[str, Any],
+    result: Mapping[str, Any],
+) -> bool:
+    """Deliver a reconciled terminal result and settle the entry. Returns whether the
+    answer landed.
+
+    Send BEFORE the terminal mark, always: the entry stays reconcilable until the user
+    actually has the answer. A ``post_answer`` raise (its contract — see
+    :mod:`~osprey.bridges.core.ports`) means the answer did NOT land, and the entry is
+    marked ``post_failed`` rather than retried on every future restart. File delivery
+    is best-effort by contract and never un-delivers the text that already landed.
+
+    This is the DEFAULT settlement, deliberately the conservative common denominator of
+    the two proven channels: no retry-queue park and no history append. The runtime
+    injects the pipeline's settlement instead, so a retryable failure discovered at
+    startup is parked for the drain and a delivered answer is recorded in history.
+    """
+    try:
+        deps.ops.post_answer(entry, result)
+    except Exception:
+        logger.exception("reconcile post failed for %s; marking post_failed", message_id)
+        deps.dedup.update_status(message_id, "post_failed")
+        return False
+    try:
+        deps.ops.deliver_files(entry, result)
+    except Exception:
+        # Contractually unreachable (deliver_files degrades to text-only rather than
+        # raising), but the answer text has already landed — a misbehaving adapter must
+        # not cost us the terminal mark and leave the entry to be re-delivered forever.
+        logger.exception("reconcile file delivery raised for %s; text already sent", message_id)
+    status = result.get("status", "error")
+    deps.dedup.update_status(message_id, status if status in TERMINAL_STATUSES else "error")
+    return True
+
+
+def reconcile_inflight(
+    deps: ReconcileDeps,
+    *,
+    build_extra: Callable[[Mapping[str, Any]], Mapping[str, Any] | None] | None = None,
+    settle: Callable[[str, Mapping[str, Any], Mapping[str, Any]], Any] | None = None,
+) -> ReconcileReport:
+    """Finish every in-flight message left over from the previous process.
+
+    Call once at startup, before the inbound loop starts: the entries handled here are
+    invisible to every other mechanism, and a message the user is still waiting on
+    should be answered before new ones compete for the worker.
+
+    ``build_extra`` re-assembles the dispatch context for a re-dispatch off the
+    persisted entry (fresh conversation history, the persisted reply context,
+    attachments re-downloaded from the persisted refs). Default ``None`` means "replay
+    the question alone" — correct but thinner than a live dispatch, so the runtime
+    passes the pipeline's builder. ``settle`` handles a terminal result and defaults to
+    :func:`deliver_terminal`.
+
+    Never raises: a per-entry dispatch failure leaves that entry for the next startup
+    and the pass continues. Returns a :class:`ReconcileReport` of what it did.
+    """
+
+    def default_settle(mid: str, current: Mapping[str, Any], body: Mapping[str, Any]) -> Any:
+        return deliver_terminal(deps, mid, current, body)
+
+    settle_result = settle if settle is not None else default_settle
+    report = ReconcileReport()
+
+    for message_id, entry in deps.dedup.reconcile().items():
+        run_id = entry.get("run_id")
+
+        # A drain redispatch that crashed before a run_id existed. The drain owns it;
+        # dispatching from startup would bypass the health gate and the retry min-age
+        # that exist to keep a failing service from being hammered on every restart.
+        if entry.get("retried") and not run_id:
+            logger.info("returning retried in-flight %s to the queue", message_id)
+            deps.dedup.transition(message_id, entry.get("status", "in_flight"), "queued")
+            report.requeued += 1
+            continue
+
+        text = entry.get("text")
+        reattached = bool(run_id)
+        try:
+            if run_id:
+                # RE-ATTACH. The run exists and may already have touched hardware, so
+                # this path must never fire a second dispatch. A fresh poll budget:
+                # the run has been going since before the crash, and the worker's own
+                # cap — not our previous, now-lost deadline — bounds it.
+                logger.info("reconciling in-flight run %s (%s)", run_id, message_id)
+                result = deps.dispatcher.poll_worker(run_id)
+            elif text:
+                # RE-DISPATCH. No run was ever started (that is what "no run_id" means
+                # for a non-retried entry), so replaying the persisted question is the
+                # only way this message is ever answered.
+                logger.info("re-dispatching %s (crashed before a run_id existed)", message_id)
+                extra = build_extra(entry) if build_extra is not None else None
+                result = _dispatch(deps.dispatcher, deps.dedup, message_id, text, extra)
+            else:
+                # Neither a run to re-attach nor a question to replay: there is nothing
+                # correct to do, and guessing would either drop the entry's dedup claim
+                # or invent a dispatch. Leave it for a human.
+                logger.info("in-flight %s has no run_id and no text; leaving", message_id)
+                report.skipped += 1
+                continue
+        except Exception:
+            logger.exception("reconcile failed for %s; leaving for next startup", message_id)
+            report.failed += 1
+            continue
+
+        # Re-read: the re-dispatch persister has just written the new run_id, and the
+        # settlement (and the channel post it drives) must see the entry as stored.
+        current = deps.dedup.get(message_id) or dict(entry)
+        if settle_result(message_id, current, result) is False:
+            # Only the default settlement reports delivery failure; an injected one
+            # returning None counts as delivered (it owns its own outcome handling).
+            report.post_failed += 1
+        elif reattached:
+            report.reattached += 1
+        else:
+            report.redispatched += 1
+
+    return report

--- a/src/osprey/bridges/core/retry.py
+++ b/src/osprey/bridges/core/retry.py
@@ -1,0 +1,191 @@
+"""Pure retry-policy decisions for the drain loop.
+
+The drain loop periodically re-examines entries the bridge parked in its retry
+queue (``status == "queued"`` in the :class:`~osprey.bridges.core.dedup.DedupStore`)
+and, for each, must decide: is this failure the kind worth retrying at all? is it
+*safe* to fire a fresh dispatch? has it aged enough to try again? should we give
+up and file a GitLab issue instead? which queued entries collapse into one?
+
+Every function here is a **pure** decision — no I/O, no clock, no config lookup
+of its own: the caller passes ``now`` (epoch seconds, ``time.time()``) and the
+``cfg`` tunables. That keeps them exhaustively table-testable and free of channel
+and dispatch-internal imports (stdlib only).
+
+Contracts consumed:
+
+  * ``result`` — a dispatch result dict
+    (:func:`osprey.bridges.core.dispatch_client` shape) carrying ``failure_class``
+    (one of ``provider`` / ``infrastructure`` / an agent-or-user class / ``None``),
+    ``num_tool_calls`` (``int`` or ``None`` when the worker never reported one),
+    and ``error_code`` (a dispatcher pool-error code, e.g. an input_files
+    rejection, or ``None``) which can force a non-retryable verdict.
+  * ``entry`` — a :class:`~osprey.bridges.core.dedup.DedupStore` value dict. Beyond
+    the core ``run_id`` / ``status`` it may carry retry bookkeeping the drain stamps
+    into claim meta: ``queued_at`` (epoch seconds the entry entered the queue),
+    ``attempts`` (count of redispatch attempts so far), ``num_tool_calls`` (the
+    worst tool-call count observed across prior attempts), and ``coalesce_key``
+    (a channel-supplied grouping key).
+  * ``cfg`` — anything exposing ``retry_min_age`` / ``retry_give_up`` /
+    ``retry_lifetime_cap`` (a :class:`~osprey.bridges.core.config.CoreConfig`),
+    duck-typed so tests can pass a stub.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# A failed run is worth retrying only when the failure is external to the agent's
+# reasoning — a provider outage or infrastructure fault that a later attempt may
+# clear. An agent/user-level failure (bad question, tool refusal) would fail
+# identically on redispatch, so it is NOT retryable.
+RETRYABLE_FAILURE_CLASSES = frozenset({"provider", "infrastructure"})
+
+# A dispatcher pool result may reject a capability-carrying dispatch outright with
+# a structured error_code. Such a rejection is deterministic — an identical
+# redispatch would be rejected identically — so it is NON-retryable regardless of
+# the failure_class the (bridge-local, infrastructure-defaulted) error result
+# otherwise carries. Today these are the input_files rejections.
+NON_RETRYABLE_ERROR_CODES = frozenset({"input_files_cap_exceeded", "input_files_invalid"})
+
+
+def _is_int(value: Any) -> bool:
+    """True for a real integer count (``bool`` is excluded — ``True``/``False``
+    are ints in Python but never a valid tool-call count)."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _age(entry: dict[str, Any], now: float) -> float:
+    """Seconds since the entry entered the retry queue, clamped to ``>= 0``.
+
+    A missing/invalid ``queued_at`` is treated as *just now* (age 0) so a
+    malformed entry is neither retried early nor abandoned early. A ``queued_at``
+    in the future (clock skew) also clamps to 0.
+    """
+    q = entry.get("queued_at")
+    if not isinstance(q, (int, float)) or isinstance(q, bool):
+        q = now
+    return max(0.0, now - q)
+
+
+def ceiling_age(entry: dict[str, Any], now: float) -> float:
+    """Seconds since the entry FIRST entered the retry queue, for the give-up
+    ceilings.
+
+    A re-park refreshes ``queued_at`` (the per-attempt pacing clock read by
+    :func:`is_eligible`) but preserves ``first_queued_at`` — anchoring the
+    ceilings there is what stops a cycling entry (park -> retry -> fail ->
+    re-park) from re-aging forever and never giving up. Entries persisted
+    before ``first_queued_at`` existed fall back to ``queued_at``.
+    """
+    q = entry.get("first_queued_at")
+    if not isinstance(q, (int, float)) or isinstance(q, bool):
+        return _age(entry, now)
+    return max(0.0, now - q)
+
+
+def _retried(entry: dict[str, Any]) -> bool:
+    """Whether the drain has already made a redispatch attempt for this entry.
+
+    Honors either signal the drain may stamp: a boolean ``retried`` flag (set by
+    the ``queued -> in_flight`` transition) or a positive ``attempts`` count.
+    """
+    if entry.get("retried"):
+        return True
+    a = entry.get("attempts", 0)
+    return _is_int(a) and a > 0
+
+
+def is_retryable(result: dict[str, Any]) -> bool:
+    """Whether ``result``'s failure class warrants any retry at all.
+
+    A structured ``error_code`` in :data:`NON_RETRYABLE_ERROR_CODES` (an
+    input_files rejection) forces ``False`` first — such a rejection is
+    deterministic even though the bridge-local error result defaults
+    ``failure_class`` to the retryable ``"infrastructure"``. Otherwise ``True``
+    iff ``failure_class`` is one of :data:`RETRYABLE_FAILURE_CLASSES`; a missing
+    or ``None`` class (and a missing/unrelated ``error_code``) -> ``False``
+    (unknown is not retried).
+    """
+    if result.get("error_code") in NON_RETRYABLE_ERROR_CODES:
+        return False
+    return result.get("failure_class") in RETRYABLE_FAILURE_CLASSES
+
+
+def may_redispatch(entry: dict[str, Any], result: dict[str, Any]) -> bool:
+    """Whether it is *safe* to fire a brand-new dispatch for this entry.
+
+    A redispatch re-runs the agent from scratch, so it is only safe when the
+    failed run took **no** side-effecting action — i.e. a *known* tool-call count
+    of exactly 0. The count is read from the freshly-observed ``result`` and from
+    any worst-case count the drain persisted on the ``entry`` across earlier
+    attempts; redispatch is permitted only when at least one of those is known
+    AND every known count is 0. If a tool count is unknown everywhere, we cannot
+    prove safety, so we refuse (fail-closed).
+
+    Orthogonal to :func:`is_retryable` — the caller checks both: retryable *and*
+    safe to redispatch.
+    """
+    counts = [result.get("num_tool_calls"), entry.get("num_tool_calls")]
+    known = [c for c in counts if _is_int(c)]
+    return bool(known) and all(c == 0 for c in known)
+
+
+def is_eligible(entry: dict[str, Any], now: float, cfg: Any) -> bool:
+    """Whether a queued entry has aged past ``retry_min_age`` and may be retried
+    on this drain pass.
+
+    Holds a just-failed dispatch back long enough for a transient outage to
+    clear. ``True`` iff ``age > cfg.retry_min_age`` (strict; a clamped-to-0 age
+    can never exceed a positive threshold).
+    """
+    return bool(_age(entry, now) > cfg.retry_min_age)
+
+
+def give_up_due(entry: dict[str, Any], now: float, gate_ever_open: bool, cfg: Any) -> bool:
+    """Whether a queued entry should be abandoned (a GitLab give-up issue filed)
+    instead of retried further.
+
+    Two independent ceilings:
+
+      * the hard **lifetime cap** (``retry_lifetime_cap``, ~7d): once reached the
+        entry is reaped no matter what — an unconditional backstop against an
+        entry living forever.
+      * the softer **give-up age** (``retry_give_up``, ~48h): applied ONLY if the
+        entry has actually been retried (a ``retried`` flag or ``attempts > 0``)
+        or the health gate was observed open at some point since it was enqueued
+        (``gate_ever_open``).
+        If neither holds, the outage has been continuous and the entry never got
+        a fair attempt, so the give-up age is *extended* rather than triggered —
+        we keep it queued until the lifetime cap.
+
+    Both ceilings measure :func:`ceiling_age` — anchored at the entry's FIRST
+    park, not its latest re-park — so a cycling entry still ages out.
+    """
+    age = ceiling_age(entry, now)
+    if age >= cfg.retry_lifetime_cap:
+        return True
+    if age >= cfg.retry_give_up and (_retried(entry) or gate_ever_open):
+        return True
+    return False
+
+
+def coalesce_key(entry: dict[str, Any]) -> tuple:
+    """Grouping key for collapsing redundant queued entries into one.
+
+    When several messages for the same conversation pile up while dispatch is
+    down, the drain redispatches only the newest per key and supersedes the rest.
+    The key is channel-supplied and persisted in claim meta as ``coalesce_key``
+    (e.g. Chat ``space``/``thread`` or an email thread id); it is normalized to a
+    hashable tuple: a list/tuple becomes ``tuple(key)``, any scalar becomes a
+    1-tuple, and a missing/empty key becomes the empty tuple ``()``.
+
+    ``()`` is the *no-group* sentinel: an entry without a coalesce key must NOT
+    be collapsed with other keyless entries, so the drain treats an empty tuple
+    as "stands alone" rather than as a shared group.
+    """
+    key = entry.get("coalesce_key")
+    if key is None or key == "" or key == [] or key == ():
+        return ()
+    if isinstance(key, (list, tuple)):
+        return tuple(key)
+    return (key,)

--- a/src/osprey/bridges/core/retry_queue.py
+++ b/src/osprey/bridges/core/retry_queue.py
@@ -1,0 +1,230 @@
+"""The retry queue's write side: park, supersede-at-enqueue, give-up notice.
+
+The drain loop (:mod:`osprey.bridges.core.drain`) owns *reading* the queue — which
+parked entry is eligible, which has aged out, which gets redispatched. This module owns
+the three places something is *put into* or *taken out of* the queue by a decision the
+drain does not make:
+
+  * :func:`park` — a retryable failure becomes a ``queued`` entry plus an honest notice.
+  * :func:`supersede_at_enqueue` — parking a newer message drops the older queued
+    siblings it makes redundant (called by :func:`park`; exposed for tests/diagnostics).
+  * :func:`give_up` / :func:`supersede_note` — the two channel-side notices the drain
+    invokes through its callbacks, bound to :class:`~osprey.bridges.core.ports.ChannelOps`.
+
+Every store mutation goes through :meth:`~osprey.bridges.core.dedup.DedupStore.transition`,
+the compare-and-set primitive: it is what keeps this module from racing the drain thread.
+A CAS that loses (the entry already moved out of the status we expected) is never an
+error here — it means another actor legitimately owns that entry now, and we do nothing.
+
+Ordering is the safety property, and it differs per notice because the failure contracts
+in :mod:`osprey.bridges.core.ports` differ:
+
+  * ``post_queued`` **may raise**: the entry is parked and its siblings superseded
+    *before* the notice is posted, so a lost notice costs the user a message, never
+    their request.
+  * ``post_giveup`` **must raise**: :func:`give_up` posts and does NOT mark the entry
+    terminal — the drain does that only after this returns, so a failed notice leaves
+    the entry queued for the next cycle rather than silently dropped.
+  * ``post_superseded`` **never raises**: the coalesce CAS is already committed, so a
+    failed note is swallowed and must not disturb the rest of the pass.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from . import retry
+from .dedup import DedupStore
+from .history import HistoryStore
+from .ports import ChannelOps
+
+logger = logging.getLogger(__name__)
+
+# Status a queued entry is flipped to when a newer question in the same conversation
+# coalesces over it. This is a TERMINAL drop — the earlier request is intentionally
+# abandoned in favor of the newer one and must never be re-dispatched. For
+# restart-safety the string MUST be a member of
+# :data:`~osprey.bridges.core.config.TERMINAL_STATUSES`; otherwise
+# :meth:`~osprey.bridges.core.dedup.DedupStore.reconcile` re-surfaces a superseded
+# entry on the next start and re-runs the dropped question.
+SUPERSEDED_STATUS = "superseded"
+
+__all__ = [
+    "SUPERSEDED_STATUS",
+    "give_up",
+    "park",
+    "supersede_at_enqueue",
+    "supersede_note",
+]
+
+
+def park(
+    ops: ChannelOps,
+    dedup: DedupStore,
+    message_id: str,
+    entry: Mapping[str, Any],
+    result: Mapping[str, Any],
+    *,
+    now: Callable[[], float] = time.time,
+) -> bool:
+    """Park a retryable-failure request in the retry queue for the drain loop.
+
+    Returns ``True`` iff this call actually parked the entry. Steps, in order:
+
+      1. Flip the entry to ``queued`` — a CAS off its current (non-terminal) status,
+         stamping the retry bookkeeping the drain reads. ``failure_class`` and
+         ``num_tool_calls`` are copied verbatim from ``result``: ``None`` (unknown) is
+         preserved as ``None``, never coerced to ``0``, because
+         :func:`osprey.bridges.core.retry.may_redispatch` is fail-closed on unknown.
+         ``queued_at`` is the per-attempt pacing clock and refreshes on every park;
+         ``first_queued_at`` is the give-up-ceiling anchor and is stamped only once, so
+         a cycling entry cannot re-age forever. ``attempts`` starts at ``0`` on the
+         first park and is otherwise left to the drain, which increments it per
+         redispatch — a re-park never resets it.
+      2. Only if that CAS won, supersede the older queued siblings sharing this entry's
+         coalesce key (see :func:`supersede_at_enqueue`).
+      3. On the FIRST park only, post the "your request is queued" notice. A re-park is
+         silent: the user was already told once, and the next message in that
+         conversation is either the answer or the give-up notice.
+
+    The CAS losing (``False``) means someone else already moved this entry — a racing
+    drain, a late terminal callback — so nothing is parked, nothing is superseded and
+    no notice is posted.
+
+    **The park CAS runs before supersession on purpose.** Supersession is only ever
+    justified by the newer message actually taking the older one's place: cancelling an
+    older queued question on behalf of a newer one that did not itself park would leave
+    the user with no answer to either and no explanation for the first. Callers must
+    honor the same precondition — :func:`park` is called on a retryable failure, never
+    on a dispatch that is still in flight or that succeeded.
+
+    History is deliberately NOT appended: the exchange is unfinished. The drain appends
+    under the persisted ``history_key`` once the queued run finally completes.
+
+    Reads destination/threading/sender only from the persisted ``entry``, so it serves
+    the live pipeline and the drain's re-park identically. ``post_queued`` may raise
+    (see :mod:`osprey.bridges.core.ports`); the raise propagates to the caller *after*
+    the queue state is committed, so a lost notice never loses the request.
+    """
+    key = retry.coalesce_key({"coalesce_key": ops.coalesce_key(entry)})
+
+    parked_at = now()
+    first_park = not entry.get("first_queued_at") and not entry.get("queued_at")
+    meta: dict[str, Any] = {
+        "failure_class": result.get("failure_class"),
+        "num_tool_calls": result.get("num_tool_calls"),
+        "queued_at": parked_at,
+        "first_queued_at": entry.get("first_queued_at") or entry.get("queued_at") or parked_at,
+        # Persisted JSON-plain (a list) and normalized back through
+        # retry.coalesce_key on every read, so the on-disk shape round-trips.
+        "coalesce_key": list(key),
+    }
+    if first_park:
+        meta["attempts"] = 0
+
+    from_status = str(entry.get("status") or "pending")
+    if not dedup.transition(message_id, from_status, "queued", **meta):
+        logger.info(
+            "park of %s lost the CAS off %r; leaving it to whoever owns it now",
+            message_id,
+            from_status,
+        )
+        return False
+
+    supersede_at_enqueue(ops, dedup, message_id, key)
+
+    if first_park:
+        ops.post_queued(dedup.get(message_id) or {**dict(entry), **meta}, result)
+    return True
+
+
+def supersede_at_enqueue(
+    ops: ChannelOps,
+    dedup: DedupStore,
+    message_id: str,
+    key: tuple,
+) -> list[str]:
+    """Drop every OLDER queued entry sharing ``key``, returning the ids dropped.
+
+    Called by :func:`park` right after ``message_id`` itself became ``queued``, so every
+    other entry in the queue predates it: a newer question in the same conversation
+    makes the older queued one redundant. Each match is CAS-flipped ``queued ->
+    superseded`` (a terminal drop) and gets its own one-line note in its OWN thread —
+    the user is never left wondering why an earlier question went unanswered.
+
+    ``key`` is the normalized tuple from :func:`osprey.bridges.core.retry.coalesce_key`.
+    The empty tuple is the *no-group* sentinel: a keyless entry stands alone and is
+    never coalesced (keyless entries must not collapse into each other).
+
+    The CAS is the race guard: a drain that already claimed an entry (``queued ->
+    in_flight``) wins, and we then neither drop nor note it. Notes go through
+    :func:`supersede_note`, so they are best-effort here exactly as they are on the
+    drain side — the flip is already committed, and a failing ``post_superseded`` is
+    logged while the pass continues with the remaining siblings.
+    """
+    if not key:
+        return []
+    dropped: list[str] = []
+    for mid, sibling in dedup.queued().items():
+        if mid == message_id or retry.coalesce_key(sibling) != key:
+            continue
+        if not dedup.transition(mid, "queued", SUPERSEDED_STATUS):
+            continue
+        dropped.append(mid)
+        logger.info("coalesced %s into %s", mid, message_id)
+        supersede_note(ops, dedup, mid, sibling)
+    return dropped
+
+
+def give_up(
+    ops: ChannelOps,
+    dedup: DedupStore,
+    message_id: str,
+    entry: Mapping[str, Any],
+    *,
+    history: HistoryStore | None = None,
+) -> None:
+    """Post the honest "couldn't run this automatically" notice for an abandoned entry.
+
+    Binds :meth:`~osprey.bridges.core.ports.ChannelOps.post_giveup` for the drain's
+    ``give_up`` callback. It deliberately does NOT mark the entry terminal: the drain
+    does that only after this returns, so a notice that fails to send leaves the entry
+    queued for the next cycle. A lost give-up notice is silence, which is worse than
+    the rare duplicate a retry could produce — hence the raise propagates.
+
+    The failed turn is recorded in conversation history (so the transcript shows the
+    question was asked and not answered) only AFTER the notice landed, and best-effort:
+    a history write must never turn a delivered notice into a retried one.
+    """
+    current = dict(dedup.get(message_id) or entry)
+    ops.post_giveup(current)
+
+    key = current.get("history_key")
+    if history is not None and key:
+        try:
+            history.append_failed(key, current.get("text", ""))
+        except Exception:
+            logger.exception("give-up history append failed for %s; continuing", message_id)
+
+
+def supersede_note(
+    ops: ChannelOps,
+    dedup: DedupStore,
+    message_id: str,
+    entry: Mapping[str, Any],
+) -> None:
+    """Note that a queued entry was coalesced away by a newer sibling.
+
+    Binds :meth:`~osprey.bridges.core.ports.ChannelOps.post_superseded` for the drain's
+    optional ``supersede`` callback, covering DRAIN-side collapses (:func:`park`'s
+    enqueue path already notes its own drops). No history is written for a dropped
+    turn. Best-effort: the coalesce CAS is already committed, so a failed note must
+    never disturb the drain pass.
+    """
+    try:
+        ops.post_superseded(dict(dedup.get(message_id) or entry))
+    except Exception:
+        logger.exception("supersede note post failed for %s; continuing", message_id)

--- a/src/osprey/bridges/core/runtime.py
+++ b/src/osprey/bridges/core/runtime.py
@@ -1,0 +1,350 @@
+"""The process shell: build the engine's collaborators, recover, and supervise the drain.
+
+This is what an adapter's ``__main__`` calls. It owns everything about running a bridge
+EXCEPT ingestion:
+
+* :func:`build_deps` — construct the collaborator set (stores, dispatch client, pipeline
+  bundle) from a :class:`~osprey.bridges.core.config.CoreConfig` plus the adapter's
+  :class:`~osprey.bridges.core.ports.ChannelOps` implementation.
+* :func:`start` — run :func:`~osprey.bridges.core.reconcile.reconcile_inflight` FIRST
+  (crash recovery completes before a single new message is accepted), then start the one
+  supervised drain thread.
+* :class:`BridgeRuntime` — the handle the adapter drives: ``handle_event`` per inbound
+  message, ``supervise`` on its periodic wake, ``shutdown`` on exit.
+* :func:`run_forever` — the whole of the above around the adapter's own blocking loop.
+
+**The adapter owns ingestion.** How messages arrive is the one thing that does not
+generalize (a Pub/Sub streaming pull, an IMAP poll, a thread per Talk room), so the
+adapter runs its own inbound loop and calls :meth:`BridgeRuntime.handle_event` per
+message. Core deliberately has no ingestion loop: putting one here would force every
+channel through one arrival model, and the ordering guarantees that actually matter all
+live downstream of ``handle_event``.
+
+**One drain thread per process**, shared across every conversation: a drain pass walks
+the whole dedup queue, so a per-room thread would multiply the same work and race on the
+same CAS transitions. It is a daemon (never blocks process exit) and supervised — a
+thread that somehow died is replaced without restarting the bridge.
+
+The re-dispatch paths (the drain's ``dispatch`` callback and reconcile's re-dispatch of
+an entry that crashed before a run id existed) must send the SAME payload the live path
+would and settle its result the SAME way, or a replayed question silently loses its
+conversation history, its reply context, and its retry-parking. So this module binds the
+pipeline's own helpers for both rather than re-deriving them; they are module-private to
+say "not adapter API", not "not engine API", and the one-implementation rule is the
+whole point of the wiring living here.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from . import retry_queue
+from .config import CoreConfig
+from .dedup import DedupStore
+from .dispatch_client import DispatchClient
+from .drain import DrainCallbacks, DrainDeps, ensure_alive, run_drain_thread
+from .health_gate import gate_open
+from .history import HistoryStore
+from .pipeline import (
+    PipelineDeps,
+    _append_history,
+    _deliver_files,
+    _dispatch,
+    _settle_terminal,
+    build_extra,
+    handle_event,
+)
+from .ports import ChannelOps
+from .reconcile import ReconcileReport, reconcile_inflight
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "BridgeRuntime",
+    "build_deps",
+    "build_drain_callbacks",
+    "build_drain_deps",
+    "rebuild_extra",
+    "run_forever",
+    "start",
+]
+
+
+# --- collaborator construction ------------------------------------------------------
+
+
+def build_deps(
+    cfg: CoreConfig,
+    ops: ChannelOps,
+    *,
+    dedup: DedupStore | None = None,
+    history: HistoryStore | None = None,
+    dispatcher: DispatchClient | None = None,
+) -> PipelineDeps:
+    """Build the engine's collaborator set from ``cfg`` and the adapter's ``ops``.
+
+    Returns the :class:`~osprey.bridges.core.pipeline.PipelineDeps` bundle every engine
+    entry point takes — it also satisfies
+    :class:`~osprey.bridges.core.reconcile.ReconcileDeps` structurally, so one bundle
+    serves the live pipeline, startup reconcile and the drain wiring, and there is no
+    second place a collaborator could be constructed differently.
+
+    The stores are file-backed at the configured paths and the dispatch client honors
+    ``cfg.trust_env``; each is injectable for tests and for an adapter that needs a
+    pre-configured instance. The remaining :class:`PipelineDeps` seams (``park``,
+    ``probe_capability``, ``fetch_prior_artifact``) keep their real defaults — override
+    them with :func:`dataclasses.replace` on the returned bundle, which is also how an
+    adapter opts out of conversation history entirely (``history=None``).
+    """
+    return PipelineDeps(
+        cfg=cfg,
+        ops=ops,
+        dedup=dedup if dedup is not None else DedupStore(cfg.dedup_path),
+        dispatcher=dispatcher if dispatcher is not None else DispatchClient(cfg),
+        history=history if history is not None else HistoryStore(cfg.history_path),
+    )
+
+
+# --- re-dispatch context ------------------------------------------------------------
+
+
+def rebuild_extra(deps: PipelineDeps, entry: Mapping[str, Any]) -> dict[str, Any]:
+    """Rebuild the dispatch ``extra`` for a RE-DISPATCH off a persisted entry.
+
+    Every re-dispatch call site (the drain's retry, startup reconcile of an entry that
+    crashed before a run id existed) goes through here, so a replayed question carries
+    what the live path assembled: a FRESH ``conversation_so_far`` (its follow-up referent
+    may have landed since the first attempt), the reply context persisted at claim time
+    (replayed, never re-resolved — the quoted message may be gone), this message's
+    attachments re-downloaded from the persisted refs, and the newest prior image
+    artifacts re-injected — all off the SAME single memoized capability probe the live
+    path uses. No bytes are ever persisted, so re-downloading is the only way to recover
+    them.
+
+    Returns ``{}`` for a plain text-only entry with no history, leaving the re-dispatch
+    payload byte-identical to a live text-only dispatch.
+    """
+    return build_extra(
+        deps,
+        entry,
+        history_key=str(entry.get("history_key") or ""),
+        reply_to=entry.get("reply_to"),
+    )
+
+
+# --- drain wiring -------------------------------------------------------------------
+
+
+def _drain_dispatch(deps: PipelineDeps, message_id: str, entry: dict[str, Any]) -> None:
+    """Drain callback: redispatch a run-id-less queued entry from its persisted question.
+
+    The drain has already CAS-flipped the entry ``queued -> in_flight`` (stamping
+    ``retried`` and incrementing ``attempts``) and does not touch it afterward, so this
+    binding owns the outcome: rebuild the live payload, re-fire with the crash-safety
+    persister, and settle exactly as the live path does — which re-parks a fresh
+    retryable failure for the next pass, unchanged.
+    """
+    text = entry.get("text")
+    if not text:
+        # Nothing to replay and nothing to re-attach: leaving it queued would retry
+        # forever. Terminal, so it leaves both the queued and the reconcile sets.
+        logger.error("queued %s has no text to redispatch; abandoning", message_id)
+        deps.dedup.update_status(message_id, "error")
+        return
+
+    result = _dispatch(deps.dispatcher, deps.dedup, message_id, text, rebuild_extra(deps, entry))
+
+    # Re-read: the persister has just written the new run id, and the settlement (and
+    # the channel post it drives) must see the entry as stored.
+    current = deps.dedup.get(message_id) or dict(entry)
+    _settle_terminal(deps, message_id, current, result)
+
+
+def _drain_deliver(
+    deps: PipelineDeps, message_id: str, entry: dict[str, Any], result_body: dict[str, Any]
+) -> None:
+    """Drain callback: deliver a re-attached run's COMPLETED result.
+
+    Only ``completed`` bodies reach here (terminal failures are policy-routed inside the
+    drain), so this is always the final answer. ``post_answer`` raising is NOT swallowed:
+    the raise is what leaves the entry queued for the next cycle to re-attach and
+    re-deliver, instead of dropping the answer. The drain marks the entry terminal only
+    after this returns, so nothing here writes status.
+    """
+    current = deps.dedup.get(message_id) or dict(entry)
+    # The raw worker status body omits the run id; graft the persisted one on so
+    # artifact delivery and the history turn can address the run.
+    result = {**result_body, "run_id": current.get("run_id")}
+
+    deps.ops.post_answer(current, result)
+    urls = _deliver_files(deps, message_id, current, result)
+    _append_history(deps, current, result, urls)
+
+
+def build_drain_callbacks(deps: PipelineDeps) -> DrainCallbacks:
+    """Bind the drain's four callbacks over the ``ChannelOps`` implementation in ``deps``.
+
+    :class:`~osprey.bridges.core.drain.DrainCallbacks` is deliberately a NARROWER surface
+    than :class:`~osprey.bridges.core.ports.ChannelOps` — it is the drain's slice of the
+    seam plus the store-independent channel steps (history append, file delivery) no
+    single protocol member covers. Adapters implement ``ChannelOps`` only; this binding
+    is the one place the two surfaces meet, so the failure contracts (``post_answer`` and
+    ``post_giveup`` propagate; ``post_superseded`` is best-effort) hold identically for
+    every channel.
+    """
+    return DrainCallbacks(
+        dispatch=lambda mid, entry: _drain_dispatch(deps, mid, entry),
+        deliver=lambda mid, entry, body: _drain_deliver(deps, mid, entry, body),
+        give_up=lambda mid, entry: retry_queue.give_up(
+            deps.ops, deps.dedup, mid, entry, history=deps.history
+        ),
+        supersede=lambda mid, entry: retry_queue.supersede_note(deps.ops, deps.dedup, mid, entry),
+    )
+
+
+def build_drain_deps(
+    deps: PipelineDeps,
+    *,
+    gate: Callable[[], bool] | None = None,
+    now: Callable[[], float] = time.time,
+    sleep: Callable[[float], None] = time.sleep,
+) -> DrainDeps:
+    """Assemble the :class:`~osprey.bridges.core.drain.DrainDeps` the drain loop runs on.
+
+    The health gate defaults to :func:`~osprey.bridges.core.health_gate.gate_open` over
+    the same ``cfg`` — dispatcher ``/health`` AND worker ``/health``, plus the alert-issue
+    check only when it is configured. A facility with its own readiness signal injects
+    ``gate`` instead; tests inject it (with ``now``/``sleep``) to drive the loop without
+    network or real time.
+    """
+    return DrainDeps(
+        cfg=deps.cfg,
+        dedup=deps.dedup,
+        dispatcher=deps.dispatcher,
+        callbacks=build_drain_callbacks(deps),
+        gate=gate if gate is not None else (lambda: gate_open(deps.cfg)),
+        now=now,
+        sleep=sleep,
+    )
+
+
+# --- the running bridge -------------------------------------------------------------
+
+
+@dataclass
+class BridgeRuntime:
+    """A started engine: the collaborator bundle plus the live drain thread.
+
+    Handed to the adapter's inbound loop, which calls :meth:`handle_event` per message,
+    :meth:`supervise` whenever it wakes, and :meth:`shutdown` on exit.
+    """
+
+    deps: PipelineDeps
+    drain: DrainDeps
+    stop: threading.Event
+    thread: threading.Thread
+
+    def handle_event(self, event: Any) -> str:
+        """Run one raw wire event through the pipeline. Returns ``"ignored"``,
+        ``"duplicate"`` or ``"handled"`` for the adapter's logs."""
+        return handle_event(event, self.deps)
+
+    def supervise(self) -> threading.Thread:
+        """Replace the drain thread if it died; otherwise a no-op returning the live one.
+
+        Call it from the adapter's periodic wake — queued work must never stall silently
+        because an unforeseen fault killed the loop harness. The replacement shares this
+        runtime's stop event, so :meth:`shutdown` still stops it.
+        """
+        self.thread = ensure_alive(self.thread, lambda: run_drain_thread(self.drain, self.stop))
+        return self.thread
+
+    def shutdown(self) -> None:
+        """Signal the drain thread to stop. It is a daemon, so this is about stopping
+        work promptly, not about being allowed to exit; an in-progress pass finishes."""
+        self.stop.set()
+
+
+def start(
+    cfg: CoreConfig,
+    ops: ChannelOps,
+    *,
+    deps: PipelineDeps | None = None,
+    gate: Callable[[], bool] | None = None,
+    stop: threading.Event | None = None,
+) -> BridgeRuntime:
+    """Recover, start the drain, and return the runtime handle — in that order.
+
+    Startup crash recovery runs FIRST and to completion: the entries it finishes are
+    invisible to every other mechanism (the channel's own redelivery is defeated by the
+    dedup claim, and the drain owns only ``queued`` entries), and a user still waiting on
+    an answer should get it before new messages compete for the worker. Reconcile is
+    given the pipeline's own context builder and settlement, so a result recovered at
+    startup ships the same payload and settles the same way a live one does — a retryable
+    failure discovered here is parked for the drain rather than reported as an error, and
+    a delivered answer is recorded in conversation history.
+
+    Then the single drain daemon thread starts. Only after both does the caller get a
+    handle it could feed messages through.
+    """
+    bundle = deps if deps is not None else build_deps(cfg, ops)
+    drain_deps = build_drain_deps(bundle, gate=gate)
+
+    report = _recover(bundle)
+    if report.total:
+        logger.info(
+            "startup reconcile: %d in-flight (reattached=%d redispatched=%d requeued=%d "
+            "skipped=%d failed=%d post_failed=%d)",
+            report.total,
+            report.reattached,
+            report.redispatched,
+            report.requeued,
+            report.skipped,
+            report.failed,
+            report.post_failed,
+        )
+
+    stop_event = stop if stop is not None else threading.Event()
+    return BridgeRuntime(
+        deps=bundle,
+        drain=drain_deps,
+        stop=stop_event,
+        thread=run_drain_thread(drain_deps, stop_event),
+    )
+
+
+def _recover(deps: PipelineDeps) -> ReconcileReport:
+    """Startup crash recovery with the pipeline's context builder and settlement."""
+    return reconcile_inflight(
+        deps,
+        build_extra=lambda entry: rebuild_extra(deps, entry),
+        settle=lambda mid, entry, result: _settle_terminal(deps, mid, dict(entry), dict(result)),
+    )
+
+
+def run_forever(
+    cfg: CoreConfig,
+    ops: ChannelOps,
+    serve: Callable[[BridgeRuntime], None],
+    *,
+    deps: PipelineDeps | None = None,
+    gate: Callable[[], bool] | None = None,
+    stop: threading.Event | None = None,
+) -> None:
+    """The adapter entry point: start the engine, run the adapter's inbound loop, stop.
+
+    ``serve`` is the adapter's own blocking ingestion loop. It receives the
+    :class:`BridgeRuntime` and is expected to call :meth:`~BridgeRuntime.handle_event`
+    per inbound message and :meth:`~BridgeRuntime.supervise` whenever it wakes. When it
+    returns (or raises), the drain is signalled to stop.
+    """
+    runtime = start(cfg, ops, deps=deps, gate=gate, stop=stop)
+    try:
+        serve(runtime)
+    finally:
+        runtime.shutdown()

--- a/src/osprey/bridges/core/store.py
+++ b/src/osprey/bridges/core/store.py
@@ -1,0 +1,71 @@
+"""Lock-guarded, crash-safe JSON file store shared by the bridges' state stores.
+
+Both :class:`~osprey.bridges.core.dedup.DedupStore` and
+:class:`~osprey.bridges.core.history.HistoryStore` persist a small dict to a JSON file
+on the bridge-owned volume. The durability pattern is identical and subtle
+enough to keep in ONE place:
+
+  * a bridge dispatches callbacks on a thread pool (e.g. google-cloud-pubsub),
+    so a single shared store is mutated by many threads. Every read/modify/write
+    (and the JSON dump, which iterates the dict) happens under one lock.
+  * Writes are atomic: dump to a tmp file created in the SAME directory as the
+    target (``os.replace`` is only atomic within one filesystem), then rename.
+    A failed dump unlinks the tmp file and re-raises.
+  * A missing or corrupt file loads as empty — the store must never crash the
+    bridge at startup.
+
+Subclasses override :meth:`_coerce` to validate/normalize the loaded mapping.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import threading
+from typing import Any
+
+
+class JsonFileStore:
+    def __init__(self, path: str):
+        self.path = path
+        self._data: dict[str, Any] = {}
+        self._lock = threading.Lock()
+        self._load()
+
+    def _coerce(self, loaded: dict) -> dict:
+        """Hook: filter/normalize the freshly loaded mapping. Default: as-is."""
+        return loaded
+
+    def _load(self) -> None:
+        try:
+            with open(self.path, encoding="utf-8") as f:
+                loaded = json.load(f)
+            if isinstance(loaded, dict):
+                self._data = self._coerce(loaded)
+        except (FileNotFoundError, ValueError):
+            # ValueError covers BOTH JSONDecodeError and UnicodeDecodeError —
+            # any unparseable file loads as empty. Deliberately NOT OSError:
+            # an unreadable volume must fail loudly, because silently starting
+            # with an empty dedup store would re-dispatch answered questions.
+            self._data = {}
+
+    def _flush_locked(self) -> None:
+        """Persist the store. Caller MUST hold ``self._lock`` — the lock is
+        what keeps concurrent mutation from racing the JSON dump."""
+        directory = os.path.dirname(self.path) or "."
+        os.makedirs(directory, exist_ok=True)
+        snapshot = dict(self._data)
+        fd, tmp = tempfile.mkstemp(
+            dir=directory, prefix=f".{os.path.basename(self.path)}.", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(snapshot, f, indent=2)
+            os.replace(tmp, self.path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise

--- a/tests/bridges/__init__.py
+++ b/tests/bridges/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the channel-agnostic bridge engine (osprey.bridges.core)."""

--- a/tests/bridges/conftest.py
+++ b/tests/bridges/conftest.py
@@ -1,0 +1,187 @@
+"""Shared fixtures for the bridge-engine suite: the ``ChannelOps`` recording double.
+
+:class:`RecordingChannelOps` implements the full :class:`~osprey.bridges.core.ports.ChannelOps`
+protocol and records every call — plus any engine-side event a test :meth:`~RecordingChannelOps.mark`\\ s
+into the same timeline (a dedup claim, a dispatcher run) — so ordering invariants read as one
+assertion::
+
+    ops = RecordingChannelOps()
+    ...
+    ops.assert_order("claim", "post_ack", "dispatch", "post_answer", "history_append")
+
+Import it directly (``from tests.bridges.conftest import RecordingChannelOps``) when a test
+needs custom construction, or use the ``channel_ops`` fixture for a fresh default instance.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from osprey.bridges.core.ports import InboundEvent, InputDownload, ReplyContext
+
+
+@dataclass(frozen=True)
+class RecordedCall:
+    """One timeline entry: the op (protocol member or ``mark``\\ ed engine event) and a
+    plain dict of whatever arguments/details the call carried."""
+
+    op: str
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+
+class RecordingChannelOps:
+    """A ``ChannelOps`` test double that records call order and returns canned values.
+
+    Construction knobs (all optional):
+
+    ``parse_result``
+        What :meth:`parse_event` returns (default ``None`` = ignore the event).
+    ``reply_context``
+        What :meth:`resolve_reply_context` returns (default ``None`` = not a reply).
+    ``inputs``
+        What :meth:`download_inputs` returns (default empty :class:`InputDownload`).
+    ``file_urls``
+        What :meth:`deliver_files` returns (default ``{}``).
+    ``coalesce``
+        What :meth:`coalesce_key` returns (default ``""`` = never coalesce).
+
+    Failure injection: :meth:`fail_next` queues an exception for a member's NEXT call —
+    the call is recorded first, then raises — so drain tests can express "the first
+    ``post_answer`` fails, the retry succeeds" without a custom double.
+    """
+
+    def __init__(
+        self,
+        *,
+        parse_result: InboundEvent | None = None,
+        reply_context: ReplyContext | None = None,
+        inputs: InputDownload | None = None,
+        file_urls: Mapping[str, str] | None = None,
+        coalesce: str | Sequence[str] = "",
+    ) -> None:
+        self.calls: list[RecordedCall] = []
+        self.parse_result = parse_result
+        self.reply_context = reply_context
+        self.inputs = inputs if inputs is not None else InputDownload()
+        self.file_urls = dict(file_urls or {})
+        self.coalesce = coalesce
+        self._failures: dict[str, deque[BaseException]] = {}
+
+    # -- recording machinery -------------------------------------------------
+
+    def mark(self, op: str, **details: Any) -> None:
+        """Record an ENGINE-side event (``claim``, ``dispatch``, ``history_append``, ...)
+        into the same timeline as the protocol calls, so cross-boundary ordering
+        ("claim precedes dispatch") is assertable alongside channel I/O. Wire it into
+        store/dispatcher stubs: ``dispatcher.run = lambda *a, **k: ops.mark("dispatch")``."""
+        self._record(op, details)
+
+    def fail_next(self, op: str, exc: BaseException) -> None:
+        """Queue ``exc`` to be raised by the next call to ``op`` (after recording it).
+        Multiple queued failures pop FIFO; once drained, calls succeed again."""
+        self._failures.setdefault(op, deque()).append(exc)
+
+    def _record(self, op: str, details: Mapping[str, Any]) -> None:
+        self.calls.append(RecordedCall(op, dict(details)))
+        queued = self._failures.get(op)
+        if queued:
+            raise queued.popleft()
+
+    # -- timeline inspection -------------------------------------------------
+
+    @property
+    def names(self) -> list[str]:
+        """Every recorded op name, in call order."""
+        return [call.op for call in self.calls]
+
+    def of(self, op: str) -> list[Mapping[str, Any]]:
+        """The recorded details of every call to ``op``, in order."""
+        return [call.details for call in self.calls if call.op == op]
+
+    def count(self, op: str) -> int:
+        """How many times ``op`` was called."""
+        return len(self.of(op))
+
+    def assert_order(self, *ops: str) -> None:
+        """Assert ``ops`` occur as a subsequence of the recorded timeline (greedy
+        left-to-right match, so repeated ops are handled naturally). Raises
+        ``AssertionError`` naming the first op that could not be matched, with the
+        full timeline for diagnosis.
+
+        Because the match is a greedy subsequence, this CANNOT express "X only ever
+        after Y": ``['history_append', 'post_answer', 'history_append']`` passes
+        ``assert_order('post_answer', 'history_append')`` despite an append preceding
+        the post. Use :meth:`assert_never_before` for those invariants."""
+        position = 0
+        names = self.names
+        for op in ops:
+            try:
+                position = names.index(op, position) + 1
+            except ValueError:
+                raise AssertionError(
+                    f"expected {op!r} (in order {list(ops)!r}) but it does not occur "
+                    f"after position {position} in recorded timeline {names!r}"
+                ) from None
+
+    def assert_never_before(self, op: str, other: str) -> None:
+        """Assert NO occurrence of ``op`` precedes the FIRST occurrence of ``other``
+        (which must occur). The strict form of "op only ever after other": unlike
+        :meth:`assert_order`'s greedy subsequence matching, a stray earlier ``op`` —
+        exactly the shape an engine bug that appended history on a failed attempt
+        would produce — fails here, with the full timeline for diagnosis."""
+        names = self.names
+        assert other in names, f"expected {other!r} in recorded timeline {names!r}"
+        first_other = names.index(other)
+        assert op not in names[:first_other], (
+            f"{op!r} occurred before the first {other!r} in recorded timeline {names!r}"
+        )
+
+    # -- ChannelOps protocol members ------------------------------------------
+
+    def parse_event(self, event: Any) -> InboundEvent | None:
+        self._record("parse_event", {"event": event})
+        return self.parse_result
+
+    def resolve_reply_context(self, event: InboundEvent) -> ReplyContext | None:
+        self._record("resolve_reply_context", {"event": event})
+        return self.reply_context
+
+    def post_ack(self, entry: Mapping[str, Any]) -> None:
+        self._record("post_ack", {"entry": entry})
+
+    def download_inputs(self, entry: Mapping[str, Any]) -> InputDownload:
+        self._record("download_inputs", {"entry": entry})
+        return self.inputs
+
+    def post_answer(self, entry: Mapping[str, Any], result: Mapping[str, Any]) -> None:
+        self._record("post_answer", {"entry": entry, "result": result})
+
+    def deliver_files(
+        self, entry: Mapping[str, Any], result: Mapping[str, Any]
+    ) -> Mapping[str, str]:
+        self._record("deliver_files", {"entry": entry, "result": result})
+        return dict(self.file_urls)
+
+    def post_queued(self, entry: Mapping[str, Any], result: Mapping[str, Any]) -> None:
+        self._record("post_queued", {"entry": entry, "result": result})
+
+    def post_giveup(self, entry: Mapping[str, Any]) -> None:
+        self._record("post_giveup", {"entry": entry})
+
+    def post_superseded(self, entry: Mapping[str, Any]) -> None:
+        self._record("post_superseded", {"entry": entry})
+
+    def coalesce_key(self, entry: Mapping[str, Any]) -> str | Sequence[str]:
+        self._record("coalesce_key", {"entry": entry})
+        return self.coalesce
+
+
+@pytest.fixture
+def channel_ops() -> RecordingChannelOps:
+    """A fresh default recording double (parse ignores, no reply, no files)."""
+    return RecordingChannelOps()

--- a/tests/bridges/test_artifacts.py
+++ b/tests/bridges/test_artifacts.py
@@ -1,0 +1,335 @@
+"""Conformance suite for ``osprey.bridges.core.artifacts``.
+
+This file consolidates five bridge-core test modules, one per public function.
+Each origin is kept as its own class so the test names stay verbatim (several
+names — ``test_empty_and_none_are_safe`` most notably — appear in more than one
+origin and would otherwise shadow each other in a single module namespace).
+
+Sections:
+
+* ``TestFetchArtifact``  — worker byte fetch + size/PNG guards
+* ``TestArtifactIds``    — run-status ``artifacts`` field -> id strings
+* ``TestSplitArtifacts`` — mime-routed split into image ids / doc descriptors
+* ``TestExtForMime``     — mime -> extension allowlist
+* ``TestSafeLabel``      — CR/LF stripping + length bound
+* ``TestNeverRaiseContract`` — new here: pins the "a fetch failure never
+  escapes" guarantee the module's docstring promises
+"""
+
+import httpx
+import pytest
+
+from osprey.bridges.core.artifacts import (
+    PNG_MAGIC,
+    artifact_ids,
+    ext_for_mime,
+    fetch_artifact,
+    safe_label,
+    split_artifacts,
+)
+from osprey.bridges.core.config import CoreConfig
+
+# ---------------------------------------------------------------------------
+# fetch_artifact: worker byte fetch + size/PNG guards, incl. the non-PNG path
+# a document-delivering channel relies on (require_png=False) and a custom
+# max_bytes.
+# ---------------------------------------------------------------------------
+
+PNG = PNG_MAGIC + b"body"
+PDF = b"%PDF-1.7\n...."
+
+CFG = CoreConfig(worker_url="http://work:9190", dispatch_worker_token="work-token")
+
+
+def _http(payloads):
+    """payloads: artifact_id -> bytes (200) or None (404)."""
+
+    def handler(request):
+        aid = str(request.url).rsplit("/", 1)[-1]
+        data = payloads.get(aid)
+        if data is None:
+            return httpx.Response(404)
+        assert request.headers["Authorization"] == "Bearer work-token"
+        return httpx.Response(200, content=data)
+
+    return httpx.Client(transport=httpx.MockTransport(handler), trust_env=CFG.trust_env)
+
+
+class TestFetchArtifact:
+    def test_png_default_accepts_png(self):
+        assert fetch_artifact(_http({"a": PNG}), CFG, "R1", "a") == PNG
+
+    def test_png_default_rejects_non_png(self):
+        assert fetch_artifact(_http({"a": PDF}), CFG, "R1", "a") is None
+
+    def test_require_png_false_accepts_non_png(self):
+        # document path: attach delivered_mime bytes verbatim, no PNG requirement.
+        assert fetch_artifact(_http({"a": PDF}), CFG, "R1", "a", require_png=False) == PDF
+
+    def test_custom_max_bytes_enforced(self):
+        big = PNG_MAGIC + b"x" * 100
+        assert fetch_artifact(_http({"a": big}), CFG, "R1", "a", max_bytes=10) is None
+        assert fetch_artifact(_http({"a": big}), CFG, "R1", "a", max_bytes=1000) == big
+
+    def test_404_returns_none(self):
+        assert fetch_artifact(_http({}), CFG, "R1", "missing") is None
+
+    def test_size_guard_applies_even_when_png_not_required(self):
+        assert (
+            fetch_artifact(_http({"a": PDF}), CFG, "R1", "a", require_png=False, max_bytes=2)
+            is None
+        )
+
+
+# ---------------------------------------------------------------------------
+# artifact_ids: normalize the run-status ``artifacts`` field to id strings.
+#
+# Covers the three inputs the deploy window can produce — osprey #363 descriptor
+# dicts, bare id strings from an older worker, and a mix — plus the malformed
+# shapes that must be skipped rather than raised on.
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactIds:
+    @staticmethod
+    def _descriptor(aid):
+        """A realistic #363 descriptor dict."""
+        return {
+            "artifact_id": aid,
+            "filename": f"{aid}.png",
+            "source_mime": "image/png",
+            "delivered_mime": "image/png",
+            "convertible": True,
+        }
+
+    def test_descriptor_dicts_yield_ids(self):
+        artifacts = [self._descriptor("art-1"), self._descriptor("art-2")]
+        assert artifact_ids(artifacts) == ["art-1", "art-2"]
+
+    def test_bare_strings_pass_through_unchanged(self):
+        # Back-compat: an older worker still answering with id strings mid-deploy.
+        assert artifact_ids(["art-1", "art-2"]) == ["art-1", "art-2"]
+
+    def test_mixed_dicts_and_strings(self):
+        assert artifact_ids([self._descriptor("art-1"), "art-2"]) == ["art-1", "art-2"]
+
+    def test_empty_and_none_are_safe(self):
+        assert artifact_ids([]) == []
+        assert artifact_ids(None) == []
+
+    def test_malformed_entries_are_skipped_not_raised(self):
+        artifacts = [
+            self._descriptor("keep-1"),
+            {"filename": "no-id.png"},  # dict without artifact_id
+            {"artifact_id": None},  # null id
+            {"artifact_id": ""},  # empty id
+            {"artifact_id": 123},  # non-str id (must not leak an int into a URL)
+            "",  # empty string
+            123,  # wrong type entirely
+            None,  # bare None element
+            self._descriptor("keep-2"),
+        ]
+        assert artifact_ids(artifacts) == ["keep-1", "keep-2"]
+
+
+# ---------------------------------------------------------------------------
+# split_artifacts: route the run-status ``artifacts`` field into an image-id
+# bucket (PNG, inline-image path) and a doc-descriptor bucket (everything else).
+#
+# Covers the same input shapes as ``artifact_ids`` (osprey #363 descriptor
+# dicts, bare id strings from an older worker, a mix, malformed shapes to skip)
+# plus the mime-based routing split_artifacts adds on top.
+# ---------------------------------------------------------------------------
+
+
+class TestSplitArtifacts:
+    @staticmethod
+    def _descriptor(aid, mime="image/png", **overrides):
+        """A realistic #363 descriptor dict."""
+        d = {
+            "artifact_id": aid,
+            "filename": f"{aid}.bin",
+            "source_mime": mime,
+            "delivered_mime": mime,
+            "convertible": True,
+        }
+        d.update(overrides)
+        return d
+
+    def test_png_descriptor_goes_to_image_bucket_by_id(self):
+        image_ids, doc_descriptors = split_artifacts([self._descriptor("art-1", "image/png")])
+        assert image_ids == ["art-1"]
+        assert doc_descriptors == []
+
+    def test_bare_string_goes_to_image_bucket(self):
+        # Back-compat: an older worker with no mime at all -> existing PNG path.
+        image_ids, doc_descriptors = split_artifacts(["art-1"])
+        assert image_ids == ["art-1"]
+        assert doc_descriptors == []
+
+    def test_image_jpeg_goes_to_doc_bucket_as_whole_dict(self):
+        desc = self._descriptor("art-2", "image/jpeg")
+        image_ids, doc_descriptors = split_artifacts([desc])
+        assert image_ids == []
+        assert doc_descriptors == [desc]
+
+    def test_image_svg_goes_to_doc_bucket(self):
+        desc = self._descriptor("art-3", "image/svg+xml")
+        image_ids, doc_descriptors = split_artifacts([desc])
+        assert image_ids == []
+        assert doc_descriptors == [desc]
+
+    def test_document_mime_goes_to_doc_bucket(self):
+        desc = self._descriptor("art-4", "text/markdown")
+        image_ids, doc_descriptors = split_artifacts([desc])
+        assert image_ids == []
+        assert doc_descriptors == [desc]
+
+    def test_missing_delivered_mime_key_goes_to_doc_bucket(self):
+        desc = {"artifact_id": "art-5", "filename": "art-5.bin"}
+        assert "delivered_mime" not in desc
+        image_ids, doc_descriptors = split_artifacts([desc])
+        assert image_ids == []
+        assert doc_descriptors == [desc]
+
+    def test_malformed_entries_are_skipped_from_both_buckets(self):
+        artifacts = [
+            {"filename": "no-id.png"},  # dict without artifact_id
+            {"artifact_id": None},  # null id
+            {"artifact_id": ""},  # empty id
+            {"artifact_id": 123},  # non-str id
+            "",  # empty string
+            123,  # wrong type entirely
+            None,  # bare None element
+        ]
+        image_ids, doc_descriptors = split_artifacts(artifacts)
+        assert image_ids == []
+        assert doc_descriptors == []
+
+    def test_mixed_input_keeps_each_id_in_exactly_one_bucket(self):
+        png = self._descriptor("keep-png", "image/png")
+        jpeg = self._descriptor("keep-jpeg", "image/jpeg")
+        md = self._descriptor("keep-md", "text/markdown")
+        no_mime = {"artifact_id": "keep-no-mime", "filename": "x.bin"}
+        bare = "keep-bare"
+        artifacts = [
+            png,
+            {"filename": "no-id.png"},
+            jpeg,
+            "",
+            md,
+            None,
+            no_mime,
+            bare,
+            {"artifact_id": None},
+        ]
+        image_ids, doc_descriptors = split_artifacts(artifacts)
+
+        all_doc_ids = {d["artifact_id"] for d in doc_descriptors}
+        assert set(image_ids) & all_doc_ids == set()
+
+        assert image_ids == ["keep-png", "keep-bare"]
+        assert doc_descriptors == [jpeg, md, no_mime]
+
+    def test_empty_and_none_are_safe(self):
+        assert split_artifacts([]) == ([], [])
+        assert split_artifacts(None) == ([], [])
+
+
+# ---------------------------------------------------------------------------
+# ext_for_mime: map a ``delivered_mime`` to a file extension via a fixed
+# allowlist, falling back to ``.bin`` for anything not in it.
+# ---------------------------------------------------------------------------
+
+MAPPED = [
+    ("text/html", ".html"),
+    ("text/markdown", ".md"),
+    ("text/plain", ".txt"),
+    ("application/pdf", ".pdf"),
+    ("text/csv", ".csv"),
+    ("application/json", ".json"),
+    ("image/jpeg", ".jpg"),
+    ("image/svg+xml", ".svg"),
+]
+
+
+class TestExtForMime:
+    @pytest.mark.parametrize("mime,ext", MAPPED)
+    def test_mapped_mimes(self, mime, ext):
+        assert ext_for_mime(mime) == ext
+
+    def test_unknown_mime_falls_back_to_bin(self):
+        assert ext_for_mime("application/x-tar") == ".bin"
+
+    def test_none_falls_back_to_bin(self):
+        assert ext_for_mime(None) == ".bin"
+
+    def test_empty_string_falls_back_to_bin(self):
+        assert ext_for_mime("") == ".bin"
+
+
+# ---------------------------------------------------------------------------
+# safe_label: strip CR/LF and bound the length of a worker-supplied name.
+#
+# Shared by a channel's user-visible label and an attachment filename.
+# ---------------------------------------------------------------------------
+
+
+class TestSafeLabel:
+    def test_plain_name_passes_through(self):
+        assert safe_label("plot.png", "fallback") == "plot.png"
+
+    def test_embedded_crlf_is_stripped(self):
+        assert safe_label("plot\r\n.png", "fallback") == "plot.png"
+
+    def test_surrounding_whitespace_is_trimmed(self):
+        assert safe_label("  plot.png  ", "fallback") == "plot.png"
+
+    def test_empty_name_falls_back(self):
+        assert safe_label("", "fallback") == "fallback"
+
+    def test_whitespace_only_name_falls_back(self):
+        assert safe_label("   ", "fallback") == "fallback"
+
+    def test_none_name_falls_back(self):
+        assert safe_label(None, "fallback") == "fallback"
+
+    def test_long_name_is_bounded_to_200_chars(self):
+        long_name = "a" * 300
+        result = safe_label(long_name, "fallback")
+        assert len(result) == 200
+        assert result == "a" * 200
+
+    def test_name_that_becomes_empty_after_stripping_falls_back(self):
+        # All CR/LF, nothing left after cleaning -> fallback, then bounded.
+        result = safe_label("\r\n\r\n", "fallback")
+        assert result == "fallback"
+
+    def test_fallback_itself_is_bounded(self):
+        long_fallback = "b" * 300
+        result = safe_label("", long_fallback)
+        assert len(result) == 200
+        assert result == "b" * 200
+
+
+# ---------------------------------------------------------------------------
+# NEW (not in the ported suite): the never-raise contract.
+#
+# The module promises that a failed fetch degrades delivery to text-only rather
+# than losing the answer, so no exception may escape fetch_artifact — including
+# the URL-construction failures that do NOT subclass httpx.HTTPError.
+# ---------------------------------------------------------------------------
+
+
+class TestNeverRaiseContract:
+    def test_control_char_in_artifact_id_returns_none(self):
+        # httpx.InvalidURL is raised at URL-construction time and is not an
+        # httpx.HTTPError, so only a broad except keeps it from escaping.
+        assert fetch_artifact(_http({}), CFG, "R1", "bad\nid") is None
+
+    def test_transport_exception_returns_none(self):
+        def boom(request):
+            raise httpx.ConnectError("worker unreachable", request=request)
+
+        http = httpx.Client(transport=httpx.MockTransport(boom), trust_env=CFG.trust_env)
+        assert fetch_artifact(http, CFG, "R1", "a") is None

--- a/tests/bridges/test_capabilities.py
+++ b/tests/bridges/test_capabilities.py
@@ -1,0 +1,202 @@
+"""pair_supports: the per-dispatch capability probe. BOTH the dispatcher and the
+worker /health bodies must advertise the named capability in their "capabilities"
+list; any failure on either side is fail-closed to False.
+
+Table-driven over the two bodies via httpx.MockTransport: capable / one-side-
+missing / both-missing / non-200 / timeout / garbage-json / missing key, plus
+request-shape, short-circuit, and direct-connection checks."""
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from osprey.bridges.core import capabilities
+from osprey.bridges.core.capabilities import pair_supports
+
+CAP = "input_files"
+
+
+def _cfg():
+    # Structural stub of the CoreConfig fields pair_supports reads; guarded
+    # against drift by test_pair_supports_reads_real_coreconfig_fields below.
+    return SimpleNamespace(
+        dispatcher_url="http://disp:8010",
+        worker_url="http://work:9190",
+        trust_env=False,
+    )
+
+
+def _health(caps, code=200):
+    """A /health responder. ``caps`` as a list becomes the ``capabilities`` field;
+    ``None`` omits the key (older endpoint); a dict is returned as the whole body
+    (malformed-shape cases)."""
+
+    def f(_req):
+        if isinstance(caps, dict):
+            return httpx.Response(code, json=caps)
+        body = {"status": "ok"}
+        if caps is not None:
+            body["capabilities"] = caps
+        return httpx.Response(code, json=body)
+
+    return f
+
+
+def _raise(exc):
+    def f(_req):
+        raise exc
+
+    return f
+
+
+def _client(disp=None, work=None, record=None):
+    disp = disp if disp is not None else _health([CAP])
+    work = work if work is not None else _health([CAP])
+
+    def handler(request):
+        if record is not None:
+            record.append(request)
+        host = request.url.host
+        if host == "disp":
+            return disp(request)
+        if host == "work":
+            return work(request)
+        raise AssertionError(f"unexpected host {host}")
+
+    # trust_env=False so ambient HTTP(S)_PROXY (dev shells, CI) can't mount an
+    # env-proxy transport that bypasses the MockTransport and hits the network.
+    return httpx.Client(transport=httpx.MockTransport(handler), trust_env=False)
+
+
+# --- truth table over the two /health bodies -------------------------------
+
+
+@pytest.mark.parametrize(
+    "disp_caps, work_caps, expected",
+    [
+        ([CAP], [CAP], True),  # both advertise -> supported
+        ([CAP, "x"], ["y", CAP], True),  # present among others on both sides
+        ([CAP], [], False),  # worker missing
+        ([], [CAP], False),  # dispatcher missing
+        ([], [], False),  # both missing
+        (["other"], ["other"], False),  # neither names it
+    ],
+)
+def test_pair_supports_truth_table(disp_caps, work_caps, expected):
+    client = _client(_health(disp_caps), _health(work_caps))
+    assert pair_supports(_cfg(), CAP, client) is expected
+
+
+# --- fail-closed on any probe failure --------------------------------------
+
+
+def test_dispatcher_non_200_is_false():
+    assert pair_supports(_cfg(), CAP, _client(disp=_health([CAP], code=503))) is False
+
+
+def test_worker_non_200_is_false():
+    assert pair_supports(_cfg(), CAP, _client(work=_health([CAP], code=500))) is False
+
+
+def test_dispatcher_timeout_is_false():
+    assert pair_supports(_cfg(), CAP, _client(disp=_raise(httpx.TimeoutException("t")))) is False
+
+
+def test_worker_transport_error_is_false():
+    assert pair_supports(_cfg(), CAP, _client(work=_raise(httpx.ConnectError("boom")))) is False
+
+
+def test_capabilities_not_a_list_is_false():
+    # A malformed body whose capabilities field is not a list -> fail-closed.
+    bad = _health({"status": "ok", "capabilities": {"input_files": True}})
+    assert pair_supports(_cfg(), CAP, _client(disp=bad)) is False
+
+
+def test_capabilities_key_missing_is_false():
+    # An older /health with no capabilities field at all.
+    assert pair_supports(_cfg(), CAP, _client(disp=_health(None))) is False
+
+
+def test_garbage_json_body_is_false():
+    def not_json(_req):
+        return httpx.Response(200, text="<html>not json</html>")
+
+    assert pair_supports(_cfg(), CAP, _client(disp=not_json)) is False
+
+
+def test_non_string_entries_ignored():
+    # Junk non-string entries don't crash the frozenset build; the real cap counts.
+    client = _client(_health([CAP, 5, None]), _health([CAP]))
+    assert pair_supports(_cfg(), CAP, client) is True
+
+
+# --- request shape / short-circuit / direct connection ---------------------
+
+
+def test_probes_both_health_endpoints():
+    record = []
+    pair_supports(_cfg(), CAP, _client(record=record))
+    seen = [(r.url.host, r.url.path) for r in record]
+    assert ("disp", "/health") in seen
+    assert ("work", "/health") in seen
+    assert all(r.method == "GET" for r in record)
+
+
+def test_dispatcher_failure_short_circuits_worker():
+    # If the dispatcher probe already fails, the worker must not be queried.
+    record = []
+    assert pair_supports(_cfg(), CAP, _client(disp=_health([], code=503), record=record)) is False
+    assert [r.url.host for r in record] == ["disp"]
+
+
+def test_dispatcher_lacking_capability_short_circuits_worker():
+    # A healthy dispatcher that simply doesn't advertise the cap also short-circuits.
+    record = []
+    assert pair_supports(_cfg(), CAP, _client(disp=_health(["other"]), record=record)) is False
+    assert [r.url.host for r in record] == ["disp"]
+
+
+def test_default_client_is_direct(monkeypatch):
+    # With no injected client, pair_supports must build a proxy-ignoring
+    # (trust_env=False) client. Scrub ambient proxy env so test order can't leak.
+    for var in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY"):
+        monkeypatch.delenv(var, raising=False)
+        monkeypatch.delenv(var.lower(), raising=False)
+    captured = {}
+    mock = _client(disp=_health([], code=503))  # any answer; we only inspect kwargs
+
+    def fake_client(*args, **kwargs):
+        captured.update(kwargs)
+        return mock
+
+    monkeypatch.setattr(capabilities.httpx, "Client", fake_client)
+    pair_supports(_cfg(), CAP)
+    assert captured.get("trust_env") is False
+
+
+def test_default_client_honors_configured_trust_env(monkeypatch):
+    # trust_env is config, not a module constant: a site behind an egress proxy
+    # sets it once on CoreConfig and the probe's own client picks it up.
+    captured = {}
+    mock = _client(disp=_health([], code=503))
+
+    def fake_client(*args, **kwargs):
+        captured.update(kwargs)
+        return mock
+
+    monkeypatch.setattr(capabilities.httpx, "Client", fake_client)
+    cfg = _cfg()
+    cfg.trust_env = True
+    pair_supports(cfg, CAP)
+    assert captured.get("trust_env") is True
+
+
+def test_pair_supports_reads_real_coreconfig_fields():
+    """Drive pair_supports with a REAL CoreConfig, not the stub: an attribute-name
+    drift between this module and CoreConfig would raise inside the fail-closed
+    except and silently answer False forever — only a real instance catches it."""
+    from osprey.bridges.core.config import CoreConfig
+
+    cfg = CoreConfig(dispatcher_url="http://disp:8010", worker_url="http://work:9190")
+    assert pair_supports(cfg, CAP, _client()) is True

--- a/tests/bridges/test_config.py
+++ b/tests/bridges/test_config.py
@@ -1,0 +1,211 @@
+"""CoreConfig: env mapping, poll-budget guard, and require()."""
+
+import pytest
+
+from osprey.bridges.core.config import CoreConfig
+
+
+def test_from_env_maps_all_neutral_fields():
+    env = {
+        "DISPATCHER_URL": "http://disp:8010/",  # trailing slash must be stripped
+        "WORKER_URL": "http://work:9190/",
+        "EVENT_DISPATCHER_TOKEN": "disp-token",
+        "DISPATCH_WORKER_TOKEN": "work-token",
+        "DISPATCH_TRIGGER": "email-question",
+        "POLL_INTERVAL": "0.5",
+        "POLL_BUDGET": "360",
+        "DRAIN_INTERVAL": "30",
+        "RETRY_MIN_AGE": "600",
+        "RETRY_GIVE_UP": "86400",
+        "RETRY_LIFETIME_CAP": "259200",
+        "GITLAB_URL": "https://gl.example.com/",  # trailing slash must be stripped
+        "GITLAB_PROJECT": "team/proj",
+        "GITLAB_ISSUES_TOKEN": "gl-token",
+        "DEDUP_PATH": "/data/email_dedup.json",
+        "HISTORY_PATH": "/data/email_history.json",
+    }
+    cfg = CoreConfig.from_env(env)
+    assert cfg.dispatcher_url == "http://disp:8010"
+    assert cfg.worker_url == "http://work:9190"
+    assert cfg.event_dispatcher_token == "disp-token"
+    assert cfg.dispatch_worker_token == "work-token"
+    assert cfg.trigger == "email-question"
+    assert cfg.poll_interval == 0.5
+    assert cfg.poll_budget == 360.0
+    assert cfg.drain_interval == 30.0
+    assert cfg.retry_min_age == 600.0
+    assert cfg.retry_give_up == 86400.0
+    assert cfg.retry_lifetime_cap == 259200.0
+    assert cfg.gitlab_url == "https://gl.example.com"
+    assert cfg.gitlab_project == "team/proj"
+    assert cfg.gitlab_issues_token == "gl-token"
+    assert cfg.dedup_path == "/data/email_dedup.json"
+    assert cfg.history_path == "/data/email_history.json"
+
+
+def test_from_env_defaults_when_unset():
+    cfg = CoreConfig.from_env({})
+    assert cfg.dispatcher_url == "http://localhost:8010"
+    assert cfg.worker_url == "http://localhost:9190"
+    assert cfg.trigger == ""
+    assert cfg.poll_interval == 2.0
+    assert cfg.poll_budget == 330.0
+    assert cfg.drain_interval == 60.0
+    assert cfg.retry_min_age == 1200.0
+    assert cfg.retry_give_up == 172800.0
+    assert cfg.retry_lifetime_cap == 604800.0
+    # No alert host is assumed: an unconfigured deployment files no give-up
+    # issues and its health gate skips the alert-issue check entirely.
+    assert cfg.gitlab_url == ""
+    assert cfg.gitlab_project == ""
+    assert cfg.gitlab_issues_token == ""
+
+
+def test_gitlab_issues_token_is_unprefixed_shared_secret():
+    # Read from the neutral GITLAB_ISSUES_TOKEN, same pattern as the dispatch
+    # tokens — channel configs do NOT prefix it.
+    cfg = CoreConfig.from_env({"GITLAB_ISSUES_TOKEN": "shared"})
+    assert cfg.gitlab_issues_token == "shared"
+
+
+def test_drain_retry_empty_string_falls_back_to_default():
+    cfg = CoreConfig.from_env(
+        {
+            "DRAIN_INTERVAL": "",
+            "RETRY_MIN_AGE": "",
+            "RETRY_GIVE_UP": "",
+            "RETRY_LIFETIME_CAP": "",
+        }
+    )
+    assert cfg.drain_interval == 60.0
+    assert cfg.retry_min_age == 1200.0
+    assert cfg.retry_give_up == 172800.0
+    assert cfg.retry_lifetime_cap == 604800.0
+
+
+@pytest.mark.parametrize(
+    "field", ["drain_interval", "retry_min_age", "retry_give_up", "retry_lifetime_cap"]
+)
+def test_non_positive_duration_is_rejected(field):
+    with pytest.raises(ValueError, match=field):
+        CoreConfig(**{field: 0})
+    with pytest.raises(ValueError, match=field):
+        CoreConfig(**{field: -1.0})
+
+
+def test_empty_string_numeric_falls_back_to_default():
+    # An explicitly-empty env var must not crash float() — it means "unset".
+    cfg = CoreConfig.from_env({"POLL_INTERVAL": "", "POLL_BUDGET": ""})
+    assert cfg.poll_interval == 2.0
+    assert cfg.poll_budget == 330.0
+
+
+def test_poll_budget_below_worker_cap_is_rejected():
+    with pytest.raises(ValueError, match="poll_budget"):
+        CoreConfig(poll_budget=299)
+
+
+def test_require_raises_on_missing_field():
+    cfg = CoreConfig(dispatcher_url="http://disp:8010", event_dispatcher_token="")
+    with pytest.raises(ValueError, match="event_dispatcher_token"):
+        cfg.require("event_dispatcher_token")
+
+
+def test_require_passes_when_all_present():
+    cfg = CoreConfig(event_dispatcher_token="t", dispatch_worker_token="w")
+    cfg.require("event_dispatcher_token", "dispatch_worker_token")  # no raise
+
+
+# --- Alert host is opt-in -------------------------------------------------
+
+
+def test_alert_host_configured_only_when_env_sets_it():
+    # Both halves of the alert config come from the environment; nothing about a
+    # particular facility is baked in as a default.
+    cfg = CoreConfig.from_env({"GITLAB_URL": "https://gl.example.com/", "GITLAB_PROJECT": "a/b"})
+    assert cfg.gitlab_url == "https://gl.example.com"
+    assert cfg.gitlab_project == "a/b"
+
+
+def test_alert_host_default_is_empty_on_the_dataclass_too():
+    # Not just from_env(): a directly-constructed config is unconfigured too, so
+    # a channel that composes CoreConfig cannot inherit an alert host by accident.
+    cfg = CoreConfig()
+    assert cfg.gitlab_url == ""
+    assert cfg.gitlab_project == ""
+
+
+# --- poll_budget is validated against the configured worker timeout -------
+
+
+def test_worker_timeout_defaults_to_worker_cap():
+    assert CoreConfig().worker_timeout == 300.0
+    assert CoreConfig.from_env({}).worker_timeout == 300.0
+
+
+def test_worker_timeout_read_from_dispatch_timeout_sec():
+    # Same var the worker itself reads, so one setting raises the cap on both
+    # halves of the pair.
+    cfg = CoreConfig.from_env({"DISPATCH_TIMEOUT_SEC": "600", "POLL_BUDGET": "660"})
+    assert cfg.worker_timeout == 600.0
+    assert cfg.poll_budget == 660.0
+
+
+def test_worker_timeout_empty_string_falls_back_to_default():
+    cfg = CoreConfig.from_env({"DISPATCH_TIMEOUT_SEC": ""})
+    assert cfg.worker_timeout == 300.0
+
+
+def test_poll_budget_below_raised_worker_timeout_is_rejected():
+    # A facility that raises the worker's cap but leaves the default poll budget
+    # would abandon runs that are still alive — reject that at config load.
+    with pytest.raises(ValueError, match="poll_budget"):
+        CoreConfig(poll_budget=330, worker_timeout=600)
+
+
+def test_poll_budget_below_raised_worker_timeout_is_rejected_from_env():
+    with pytest.raises(ValueError, match="poll_budget"):
+        CoreConfig.from_env({"DISPATCH_TIMEOUT_SEC": "600"})
+
+
+def test_poll_budget_at_or_above_worker_timeout_is_accepted():
+    assert CoreConfig(poll_budget=600, worker_timeout=600).poll_budget == 600.0
+    assert CoreConfig(poll_budget=700, worker_timeout=600).poll_budget == 700.0
+
+
+def test_poll_budget_below_lowered_worker_timeout_is_still_the_floor():
+    # A site that lowers the worker cap lowers the floor with it: 200s of budget
+    # is fine against a 120s worker, and still rejected against a 240s one.
+    assert CoreConfig(poll_budget=200, worker_timeout=120).poll_budget == 200.0
+    with pytest.raises(ValueError, match="poll_budget"):
+        CoreConfig(poll_budget=200, worker_timeout=240)
+
+
+@pytest.mark.parametrize("bad", [0, -1.0])
+def test_non_positive_worker_timeout_is_rejected(bad):
+    with pytest.raises(ValueError, match="worker_timeout"):
+        CoreConfig(worker_timeout=bad)
+
+
+# --- trust_env is explicit config ----------------------------------------
+
+
+def test_trust_env_defaults_to_false():
+    # Direct connections to the pair: an ambient HTTP(S)_PROXY from a dev shell
+    # or CI runner must not mount itself in front of the dispatcher/worker.
+    assert CoreConfig().trust_env is False
+    assert CoreConfig.from_env({}).trust_env is False
+
+
+@pytest.mark.parametrize("raw", ["1", "true", "TRUE", "yes", "on", " True "])
+def test_trust_env_enabled_by_truthy_env(raw):
+    assert CoreConfig.from_env({"BRIDGE_TRUST_ENV": raw}).trust_env is True
+
+
+@pytest.mark.parametrize("raw", ["", "0", "false", "no", "off", "maybe"])
+def test_trust_env_stays_false_for_anything_else(raw):
+    assert CoreConfig.from_env({"BRIDGE_TRUST_ENV": raw}).trust_env is False
+
+
+def test_trust_env_settable_directly():
+    assert CoreConfig(trust_env=True).trust_env is True

--- a/tests/bridges/test_dedup.py
+++ b/tests/bridges/test_dedup.py
@@ -1,0 +1,388 @@
+"""DedupStore conformance suite.
+
+Two concerns, kept in their original sections:
+
+  * **prune / timestamp stamping** — ``claim()`` stamps ``claimed_at`` and,
+    before claiming, reaps terminal entries whose settle time is more than
+    :data:`~osprey.bridges.core.dedup.PRUNE_MAX_AGE_SECONDS` old; terminal
+    transitions stamp ``settled_at``.
+  * **CAS transition / retry-queue selection** — the concurrency primitive the
+    whole retry queue is built on.
+
+Both drive a REAL store on ``tmp_path`` (no mocks) and the actual lock; the
+prune section injects a fake clock through the ``now`` seam.
+"""
+
+import json
+import threading
+
+from osprey.bridges.core.dedup import PRUNE_MAX_AGE_SECONDS, DedupStore
+
+
+class FakeClock:
+    """Injectable monotone clock (epoch seconds) advanced explicitly by tests."""
+
+    def __init__(self, t: float = 1_000_000.0) -> None:
+        self.t = t
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+def _clocked_store(tmp_path, clock):
+    return DedupStore(str(tmp_path / "dedup.json"), now=clock)
+
+
+def _store(tmp_path):
+    return DedupStore(str(tmp_path / "dedup.json"))
+
+
+def _write_raw(tmp_path, data):
+    """Seed the store file directly, simulating a pre-feature persisted store."""
+    with open(str(tmp_path / "dedup.json"), "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+# ===========================================================================
+# Section 1 — prune + timestamp stamping
+# ===========================================================================
+
+
+# --- timestamp stamping ----------------------------------------------------
+def test_claim_stamps_claimed_at(tmp_path):
+    clock = FakeClock()
+    d = _clocked_store(tmp_path, clock)
+    d.claim("m1")
+    assert d.get("m1")["claimed_at"] == clock.t
+
+
+def test_terminal_transition_stamps_settled_at(tmp_path):
+    clock = FakeClock()
+    d = _clocked_store(tmp_path, clock)
+    d.claim("m1")
+    d.record("m1", run_id="r1", status="in_flight")
+    # Non-terminal transition does NOT stamp settled_at.
+    assert "settled_at" not in d.get("m1")
+
+    clock.advance(5.0)
+    assert d.transition("m1", "in_flight", "completed") is True
+    assert d.get("m1")["settled_at"] == clock.t
+
+
+def test_record_terminal_stamps_settled_at(tmp_path):
+    clock = FakeClock()
+    d = _clocked_store(tmp_path, clock)
+    d.claim("m1")
+    d.record("m1", run_id="r1", status="completed")
+    assert d.get("m1")["settled_at"] == clock.t
+
+
+# --- prune: age boundary ---------------------------------------------------
+def test_prune_keeps_terminal_entry_at_exact_age_boundary(tmp_path):
+    clock = FakeClock()
+    d = _clocked_store(tmp_path, clock)
+    d.claim("old")
+    d.transition("old", "pending", "completed")  # settled_at = t0
+
+    # Exactly PRUNE_MAX_AGE_SECONDS old: age is NOT > the threshold, so it stays.
+    clock.advance(PRUNE_MAX_AGE_SECONDS)
+    d.claim("trigger")  # prune runs at the start of claim()
+    assert d.seen("old") is True
+
+
+def test_prune_drops_terminal_entry_past_age_boundary(tmp_path):
+    clock = FakeClock()
+    d = _clocked_store(tmp_path, clock)
+    d.claim("old")
+    d.transition("old", "pending", "completed")  # settled_at = t0
+
+    clock.advance(PRUNE_MAX_AGE_SECONDS + 1)
+    d.claim("trigger")
+    assert d.seen("old") is False
+    assert d.seen("trigger") is True
+
+
+def test_prune_uses_claimed_at_when_settled_at_absent(tmp_path):
+    """A terminal entry with claimed_at but no settled_at ages from claimed_at."""
+    clock = FakeClock()
+    _write_raw(tmp_path, {"old": {"run_id": "r", "status": "error", "claimed_at": clock.t}})
+    d = _clocked_store(tmp_path, clock)
+
+    clock.advance(PRUNE_MAX_AGE_SECONDS + 1)
+    d.claim("trigger")
+    assert d.seen("old") is False
+
+
+# --- prune: only terminal entries ------------------------------------------
+def test_prune_leaves_non_terminal_entries(tmp_path):
+    clock = FakeClock()
+    d = _clocked_store(tmp_path, clock)
+    d.claim("pending1")
+    d.claim("inflight1")
+    d.record("inflight1", run_id="r1", status="in_flight")
+    d.claim("queued1")
+    d.transition("queued1", "pending", "queued")
+
+    # Far past any prune horizon — non-terminal work is never reaped.
+    clock.advance(PRUNE_MAX_AGE_SECONDS * 10)
+    d.claim("trigger")
+    assert d.seen("pending1") is True
+    assert d.seen("inflight1") is True
+    assert d.seen("queued1") is True
+
+
+def test_prune_reaps_each_terminal_status(tmp_path):
+    clock = FakeClock()
+    d = _clocked_store(tmp_path, clock)
+    for i, status in enumerate(("completed", "error", "post_failed", "superseded")):
+        mid = f"m{i}"
+        d.claim(mid)
+        d.transition(mid, "pending", status)
+
+    clock.advance(PRUNE_MAX_AGE_SECONDS + 1)
+    d.claim("trigger")
+    assert [d.seen(f"m{i}") for i in range(4)] == [False, False, False, False]
+
+
+# --- prune: grandfathering ts-less terminal entries ------------------------
+def test_prune_grandfathers_tsless_terminal_entry_on_first_observation(tmp_path):
+    """A pre-feature terminal entry (no settled_at, no claimed_at) survives the
+    first prune and gets settled_at = now stamped and persisted."""
+    clock = FakeClock()
+    _write_raw(tmp_path, {"legacy": {"run_id": "r", "status": "completed"}})
+    d = _clocked_store(tmp_path, clock)
+
+    d.claim("trigger")  # first prune observation
+    assert d.seen("legacy") is True
+    assert d.get("legacy")["settled_at"] == clock.t
+
+    # The stamp is persisted: a fresh store reading the file sees it.
+    d2 = _clocked_store(tmp_path, clock)
+    assert d2.get("legacy")["settled_at"] == clock.t
+
+
+def test_prune_grandfathered_entry_ages_out_one_window_later(tmp_path):
+    clock = FakeClock()
+    _write_raw(tmp_path, {"legacy": {"run_id": "r", "status": "completed"}})
+    d = _clocked_store(tmp_path, clock)
+
+    d.claim("trigger1")  # grandfathers: settled_at = t0
+    grandfather_t = clock.t
+
+    # Not yet a full window past the grandfather stamp: still present.
+    clock.advance(PRUNE_MAX_AGE_SECONDS)
+    d.claim("trigger2")
+    assert d.seen("legacy") is True
+    assert d.get("legacy")["settled_at"] == grandfather_t  # not re-stamped
+
+    # One tick past the window from the grandfather stamp: reaped.
+    clock.advance(1)
+    d.claim("trigger3")
+    assert d.seen("legacy") is False
+
+
+# --- prune: redelivery re-claims cleanly -----------------------------------
+def test_prune_redelivery_of_pruned_message_reclaims_cleanly(tmp_path):
+    clock = FakeClock()
+    d = _clocked_store(tmp_path, clock)
+    d.claim("m1", space="s1")
+    d.transition("m1", "pending", "completed")
+
+    clock.advance(PRUNE_MAX_AGE_SECONDS + 1)
+    # A redelivery of the long-since-pruned m1: its stale entry is reaped by the
+    # prune at the start of claim(), so this call re-claims it as brand new.
+    assert d.claim("m1", space="s2") is True
+    entry = d.get("m1")
+    assert entry["status"] == "pending"
+    assert entry["run_id"] is None
+    assert entry["space"] == "s2"  # fresh claim, not the stale s1
+    assert entry["claimed_at"] == clock.t
+
+
+# ===========================================================================
+# Section 2 — CAS transition + retry-queue selection
+# ===========================================================================
+
+
+def test_transition_matches_from_status(tmp_path):
+    d = _store(tmp_path)
+    d.claim("m1")  # status == "pending"
+
+    assert d.transition("m1", "pending", "queued") is True
+    assert d.get("m1")["status"] == "queued"
+
+
+def test_transition_returns_false_on_status_mismatch(tmp_path):
+    d = _store(tmp_path)
+    d.claim("m1")  # status == "pending"
+
+    assert d.transition("m1", "queued", "in_flight") is False
+    # No write: the entry keeps its real status.
+    assert d.get("m1")["status"] == "pending"
+
+
+def test_transition_returns_false_when_absent(tmp_path):
+    d = _store(tmp_path)
+    assert d.transition("nope", "queued", "in_flight") is False
+    assert d.get("nope") is None
+
+
+def test_transition_merges_meta_on_success(tmp_path):
+    d = _store(tmp_path)
+    d.claim("m1", space="s1")
+
+    assert d.transition("m1", "pending", "queued", attempts=1) is True
+    entry = d.get("m1")
+    assert entry["status"] == "queued"
+    assert entry["attempts"] == 1
+    assert entry["space"] == "s1"  # pre-existing meta preserved
+
+
+def test_transition_does_not_merge_meta_on_failure(tmp_path):
+    d = _store(tmp_path)
+    d.claim("m1")
+
+    assert d.transition("m1", "queued", "in_flight", attempts=9) is False
+    assert "attempts" not in d.get("m1")
+
+
+def test_transition_persists_across_reload(tmp_path):
+    path = str(tmp_path / "dedup.json")
+    d = DedupStore(path)
+    d.claim("m1")
+    assert d.transition("m1", "pending", "queued") is True
+
+    # A fresh store reading the same file must see the flipped status.
+    d2 = DedupStore(path)
+    assert d2.get("m1")["status"] == "queued"
+
+
+def test_cas_race_leaves_exactly_one_winner(tmp_path):
+    """Concurrent flip (drain: queued -> in_flight) vs coalesce-drop
+    (queued -> superseded) over the same entry: exactly one transition wins."""
+    d = _store(tmp_path)
+    d.claim("m1")
+    assert d.transition("m1", "pending", "queued") is True
+
+    start = threading.Barrier(2)
+    results: dict[str, bool] = {}
+
+    def flip():
+        start.wait()
+        results["drain"] = d.transition("m1", "queued", "in_flight")
+
+    def drop():
+        start.wait()
+        results["coalesce"] = d.transition("m1", "queued", "superseded")
+
+    threads = [threading.Thread(target=flip), threading.Thread(target=drop)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Exactly one CAS observed the "queued" status and won.
+    assert sum(results.values()) == 1
+    final = d.get("m1")["status"]
+    if results["drain"]:
+        assert final == "in_flight"
+    else:
+        assert final == "superseded"
+
+
+def test_many_threads_flip_one_winner(tmp_path):
+    """N threads all racing the same queued -> in_flight flip: exactly one True."""
+    d = _store(tmp_path)
+    d.claim("m1")
+    d.transition("m1", "pending", "queued")
+
+    n = 32
+    start = threading.Barrier(n)
+    wins: list[bool] = []
+    wins_lock = threading.Lock()
+
+    def worker():
+        start.wait()
+        won = d.transition("m1", "queued", "in_flight")
+        with wins_lock:
+            wins.append(won)
+
+    threads = [threading.Thread(target=worker) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert sum(wins) == 1
+    assert d.get("m1")["status"] == "in_flight"
+
+
+def test_no_ghost_resurrection_via_record_after_terminal(tmp_path):
+    """A terminal entry is final: a late/duplicate record() must not resurrect
+    it into a non-terminal state (which reconcile would re-dispatch)."""
+    d = _store(tmp_path)
+    d.claim("m1", space="s1")
+    d.record("m1", run_id="r1", status="in_flight")
+    assert d.transition("m1", "in_flight", "completed") is True
+
+    # A stale worker callback fires record() again — default status is
+    # non-terminal ("in_flight"). It must be ignored.
+    d.record("m1", run_id="r1", status="in_flight")
+
+    entry = d.get("m1")
+    assert entry["status"] == "completed"  # still terminal
+    assert entry["run_id"] == "r1"
+    assert len(d.reconcile()) == 0  # no ghost re-surfaces for re-dispatch
+    # And no phantom second entry was created.
+    with d._lock:
+        assert list(d._data.keys()) == ["m1"]
+
+
+def test_record_still_upserts_non_terminal_entry(tmp_path):
+    """The terminal guard must not break the normal in-flight upsert path."""
+    d = _store(tmp_path)
+    d.claim("m1")  # pending
+    d.record("m1", run_id="r1", status="in_flight")
+    assert d.get("m1")["status"] == "in_flight"
+    assert d.get("m1")["run_id"] == "r1"
+
+
+def test_queued_returns_only_queued_entries(tmp_path):
+    d = _store(tmp_path)
+    d.claim("q1")
+    d.claim("q2")
+    d.claim("p1")
+    d.claim("done")
+    d.transition("q1", "pending", "queued")
+    d.transition("q2", "pending", "queued")
+    d.record("done", run_id="r", status="completed")
+
+    q = d.queued()
+    assert set(q) == {"q1", "q2"}
+    assert all(e["status"] == "queued" for e in q.values())
+
+
+def test_reconcile_excludes_queued(tmp_path):
+    d = _store(tmp_path)
+    d.claim("inflight")
+    d.claim("queued1")
+    d.claim("done")
+    d.record("inflight", run_id="r1", status="in_flight")
+    d.transition("queued1", "pending", "queued")
+    d.record("done", run_id="r2", status="completed")
+
+    rec = d.reconcile()
+    # in_flight (non-terminal, non-queued) reconciles; queued is owned by the
+    # drain loop; completed is terminal.
+    assert set(rec) == {"inflight"}
+
+
+def test_queued_not_in_terminal_statuses():
+    """Guard: 'queued' must NOT be a terminal status — other consumers key off
+    the frozenset, and a queued entry is live work, not done."""
+    from osprey.bridges.core.config import TERMINAL_STATUSES
+
+    assert "queued" not in TERMINAL_STATUSES

--- a/tests/bridges/test_dispatch_client.py
+++ b/tests/bridges/test_dispatch_client.py
@@ -1,0 +1,576 @@
+"""DispatchClient: the fire -> handshake -> worker-poll sequence and the uniform
+terminal result contract
+``{status, text_output, run_id, error, artifacts, input_artifacts, failure_class,
+num_tool_calls, error_code}``.
+
+Every path is driven through the DI seams (``client=`` MockTransport,
+``monotonic=``, ``sleep=``) so nothing sleeps or hits the network. The
+``failure_class`` / ``num_tool_calls`` fields are the retry-policy inputs: a
+worker terminal body passes them through verbatim (absent -> ``None`` meaning
+UNKNOWN, never ``0``), and every bridge-local error result defaults them to
+``"infrastructure"`` / ``None``.
+
+Sections below correspond to the three concerns this suite covers: the sequence
+and result contract, the structured ``error_code`` surface, and the one-shot
+:meth:`DispatchClient.status` probe. A final section covers the ``trust_env``
+wiring, which is configuration-driven rather than hardcoded.
+"""
+
+import httpx
+import pytest
+
+from osprey.bridges.core.config import CoreConfig
+from osprey.bridges.core.dispatch_client import DispatchClient, DispatchError, _error_result
+
+CFG = CoreConfig(
+    dispatcher_url="http://disp:8010",
+    worker_url="http://work:9190",
+    event_dispatcher_token="disp-token",
+    dispatch_worker_token="work-token",
+    trigger="unit-question",
+    poll_interval=1.0,
+    poll_budget=300.0,
+)
+
+CONTRACT_KEYS = {
+    "status",
+    "text_output",
+    "run_id",
+    "error",
+    "artifacts",
+    "input_artifacts",
+    "failure_class",
+    "num_tool_calls",
+    "error_code",
+}
+
+
+def _client(handler, *, monotonic=None, sleep=None):
+    """A DispatchClient wired to a MockTransport handler with frozen time.
+
+    ``monotonic`` defaults to a constant clock (deadlines never trip); pass a
+    callable (e.g. an iterator's ``next``) to force budget exhaustion. ``sleep``
+    is a no-op recorder by default.
+    """
+    transport = httpx.MockTransport(handler)
+    return DispatchClient(
+        CFG,
+        client=httpx.Client(transport=transport),
+        monotonic=(monotonic or (lambda: 0.0)),
+        sleep=(sleep or (lambda _s: None)),
+    )
+
+
+def _seq_monotonic(values):
+    """A monotonic() that yields successive values then sticks on the last."""
+    it = iter(values)
+    last = [0.0]
+
+    def _m():
+        try:
+            last[0] = next(it)
+        except StopIteration:
+            pass
+        return last[0]
+
+    return _m
+
+
+# ==========================================================================
+# Sequence + uniform terminal result contract
+# ==========================================================================
+
+
+# --------------------------------------------------------------------------
+# _error_result: the single-source error branch of the contract
+# --------------------------------------------------------------------------
+def test_error_result_has_full_contract_shape():
+    r = _error_result("R1", "boom")
+    assert set(r) == CONTRACT_KEYS
+
+
+def test_error_result_defaults_infrastructure_and_unknown_count():
+    r = _error_result("R1", "boom")
+    assert r["status"] == "error"
+    assert r["text_output"] == ""
+    assert r["run_id"] == "R1"
+    assert r["error"] == "boom"
+    assert r["artifacts"] == []
+    assert r["failure_class"] == "infrastructure"
+    assert r["num_tool_calls"] is None
+
+
+def test_error_result_run_id_may_be_none():
+    assert _error_result(None, "no run")["run_id"] is None
+
+
+def test_error_result_failure_class_overridable():
+    r = _error_result("R1", "boom", failure_class="policy")
+    assert r["failure_class"] == "policy"
+    assert r["num_tool_calls"] is None
+
+
+# --------------------------------------------------------------------------
+# poll_worker: terminal-body passthrough of the classification fields
+# --------------------------------------------------------------------------
+def _worker_handler(body, *, status_code=200):
+    def handler(request):
+        assert request.headers["Authorization"] == "Bearer work-token"
+        return httpx.Response(status_code, json=body)
+
+    return handler
+
+
+def test_poll_worker_completed_passes_classification_through():
+    body = {
+        "status": "completed",
+        "text_output": "done",
+        "error": None,
+        "artifacts": ["a1"],
+        "failure_class": None,
+        "num_tool_calls": 7,
+    }
+    r = _client(_worker_handler(body)).poll_worker("R1")
+    assert set(r) == CONTRACT_KEYS
+    assert r["status"] == "completed"
+    assert r["text_output"] == "done"
+    assert r["run_id"] == "R1"
+    assert r["artifacts"] == ["a1"]
+    assert r["failure_class"] is None
+    assert r["num_tool_calls"] == 7
+
+
+def test_poll_worker_error_status_carries_failure_class():
+    body = {
+        "status": "error",
+        "text_output": "",
+        "error": "agent blew up",
+        "failure_class": "agent",
+        "num_tool_calls": 3,
+    }
+    r = _client(_worker_handler(body)).poll_worker("R2")
+    assert r["status"] == "error"
+    assert r["error"] == "agent blew up"
+    assert r["failure_class"] == "agent"
+    assert r["num_tool_calls"] == 3
+
+
+def test_poll_worker_absent_fields_are_none_not_zero():
+    # Older worker predating the fields: keys omitted entirely.
+    body = {"status": "completed", "text_output": "hi"}
+    r = _client(_worker_handler(body)).poll_worker("R3")
+    assert r["failure_class"] is None
+    assert r["num_tool_calls"] is None
+
+
+def test_poll_worker_explicit_zero_tool_calls_preserved():
+    # A present 0 is a real count (agent ran no tools), NOT unknown.
+    body = {"status": "completed", "text_output": "hi", "num_tool_calls": 0}
+    r = _client(_worker_handler(body)).poll_worker("R4")
+    assert r["num_tool_calls"] == 0
+
+
+def test_poll_worker_null_artifacts_degrade_to_empty_list():
+    body = {"status": "completed", "text_output": "hi", "artifacts": None}
+    r = _client(_worker_handler(body)).poll_worker("R5")
+    assert r["artifacts"] == []
+
+
+@pytest.mark.parametrize(
+    "body_extra, expected",
+    [
+        # present list -> passed through verbatim
+        (
+            {"input_artifacts": [{"entry_id": "in1", "filename": "data.csv", "mime": "text/csv"}]},
+            [{"entry_id": "in1", "filename": "data.csv", "mime": "text/csv"}],
+        ),
+        ({"input_artifacts": []}, []),  # explicit empty
+        ({"input_artifacts": None}, []),  # explicit null -> []
+        ({}, []),  # older worker: key absent -> []
+    ],
+)
+def test_poll_worker_input_artifacts_passthrough(body_extra, expected):
+    body = {"status": "completed", "text_output": "hi", **body_extra}
+    r = _client(_worker_handler(body)).poll_worker("R9")
+    assert r["input_artifacts"] == expected
+
+
+def test_error_result_carries_empty_input_artifacts():
+    assert _error_result("R1", "boom")["input_artifacts"] == []
+
+
+# --------------------------------------------------------------------------
+# poll_worker: non-terminal polling, budget exhaustion, HTTP errors
+# --------------------------------------------------------------------------
+def test_poll_worker_polls_past_pending_until_terminal():
+    responses = iter(
+        [
+            httpx.Response(200, json={"status": "running"}),
+            httpx.Response(404),  # brief post-register race, tolerated
+            httpx.Response(200, json={"status": "completed", "text_output": "ok"}),
+        ]
+    )
+
+    def handler(request):
+        return next(responses)
+
+    r = _client(handler).poll_worker("R6")
+    assert r["status"] == "completed"
+    assert r["text_output"] == "ok"
+
+
+def test_poll_worker_budget_exhaustion_returns_infrastructure_error():
+    # Worker never terminal; monotonic crosses the deadline (0 + 300).
+    body = {"status": "running"}
+    client = _client(
+        _worker_handler(body),
+        monotonic=_seq_monotonic([0.0, 301.0]),
+    )
+    r = client.poll_worker("R7")
+    assert set(r) == CONTRACT_KEYS
+    assert r["status"] == "error"
+    assert r["run_id"] == "R7"
+    assert r["failure_class"] == "infrastructure"
+    assert r["num_tool_calls"] is None
+    assert "timed out" in r["error"]
+
+
+def test_poll_worker_non_404_http_error_raises():
+    with pytest.raises(DispatchError):
+        _client(_worker_handler({}, status_code=500)).poll_worker("R8")
+
+
+# --------------------------------------------------------------------------
+# fire + wait_for_run_id: the handshake steps
+# --------------------------------------------------------------------------
+def test_fire_returns_dispatch_id():
+    def handler(request):
+        assert request.method == "POST"
+        assert str(request.url) == "http://disp:8010/webhook/unit-question"
+        assert request.headers["Authorization"] == "Bearer disp-token"
+        return httpx.Response(202, json={"dispatch_id": "D1"})
+
+    assert _client(handler).fire("hello") == "D1"
+
+
+def test_fire_missing_dispatch_id_raises():
+    def handler(request):
+        return httpx.Response(202, json={})
+
+    with pytest.raises(DispatchError):
+        _client(handler).fire("hello")
+
+
+def test_fire_non_2xx_raises():
+    def handler(request):
+        return httpx.Response(500, text="nope")
+
+    with pytest.raises(DispatchError):
+        _client(handler).fire("hello")
+
+
+def test_wait_for_run_id_returns_run_id_on_completed():
+    def handler(request):
+        return httpx.Response(200, json={"status": "completed", "result": {"run_id": "R9"}})
+
+    assert _client(handler).wait_for_run_id("D1", deadline=100.0) == "R9"
+
+
+def test_wait_for_run_id_dispatcher_error_raises():
+    def handler(request):
+        return httpx.Response(200, json={"status": "error", "error": "dispatch failed"})
+
+    with pytest.raises(DispatchError):
+        _client(handler).wait_for_run_id("D1", deadline=100.0)
+
+
+# --------------------------------------------------------------------------
+# run(): full sequence, on_run_id hook, error conversion
+# --------------------------------------------------------------------------
+def _full_handler(*, worker_body):
+    def handler(request):
+        path = request.url.path
+        if path == "/webhook/unit-question":
+            return httpx.Response(202, json={"dispatch_id": "D1"})
+        if path == "/dispatch/D1":
+            return httpx.Response(200, json={"status": "completed", "result": {"run_id": "R1"}})
+        if path == "/dispatch/R1":
+            return httpx.Response(200, json=worker_body)
+        return httpx.Response(404)
+
+    return handler
+
+
+def test_run_full_sequence_returns_terminal_contract():
+    body = {"status": "completed", "text_output": "final", "num_tool_calls": 5}
+    seen = []
+    r = _client(_full_handler(worker_body=body)).run("q", on_run_id=seen.append)
+    assert set(r) == CONTRACT_KEYS
+    assert r["status"] == "completed"
+    assert r["text_output"] == "final"
+    assert r["num_tool_calls"] == 5
+    assert r["failure_class"] is None
+    # on_run_id fires with the handshake run_id before the worker poll.
+    assert seen == ["R1"]
+
+
+def test_run_handshake_dispatch_error_returns_infrastructure_result():
+    def handler(request):
+        if request.url.path == "/webhook/unit-question":
+            return httpx.Response(500, text="down")
+        return httpx.Response(404)
+
+    r = _client(handler).run("q")
+    assert set(r) == CONTRACT_KEYS
+    assert r["status"] == "error"
+    assert r["run_id"] is None  # never got a run_id
+    assert r["failure_class"] == "infrastructure"
+    assert r["num_tool_calls"] is None
+
+
+def test_run_network_error_during_handshake_converted_to_result():
+    def handler(request):
+        raise httpx.ConnectError("no route")
+
+    r = _client(handler).run("q")
+    assert r["status"] == "error"
+    assert r["run_id"] is None
+    assert r["failure_class"] == "infrastructure"
+
+
+def test_run_worker_error_after_run_id_keeps_run_id():
+    def handler(request):
+        path = request.url.path
+        if path == "/webhook/unit-question":
+            return httpx.Response(202, json={"dispatch_id": "D1"})
+        if path == "/dispatch/D1":
+            return httpx.Response(200, json={"status": "completed", "result": {"run_id": "R1"}})
+        # worker poll fails hard (non-404)
+        return httpx.Response(500, text="worker down")
+
+    seen = []
+    r = _client(handler).run("q", on_run_id=seen.append)
+    assert r["status"] == "error"
+    assert r["run_id"] == "R1"  # preserved so a restart can reconcile
+    assert r["failure_class"] == "infrastructure"
+    assert seen == ["R1"]
+
+
+# ==========================================================================
+# error_code surface on the dispatch result contract
+#
+# When the dispatcher pool result is status="error" with a structured error_code
+# (e.g. an input_files rejection), DispatchClient lifts that code onto the uniform
+# error result so osprey.bridges.core.retry.is_retryable can classify it. Every
+# result dict carries an error_code key (None when there is none).
+# ==========================================================================
+
+# --- _error_result / DispatchError carry the field -------------------------
+
+
+def test_error_result_error_code_default_none():
+    assert _error_result("R1", "boom")["error_code"] is None
+
+
+def test_error_result_error_code_settable():
+    r = _error_result(None, "rejected", error_code="input_files_cap_exceeded")
+    assert r["error_code"] == "input_files_cap_exceeded"
+
+
+def test_dispatch_error_carries_error_code_attribute():
+    assert (
+        DispatchError("nope", error_code="input_files_invalid").error_code == "input_files_invalid"
+    )
+
+
+def test_dispatch_error_default_error_code_none():
+    assert DispatchError("plain").error_code is None
+
+
+# --- wait_for_run_id propagates the dispatcher's code onto the exception ----
+
+
+def test_wait_for_run_id_error_code_propagates_to_exception():
+    def handler(request):
+        return httpx.Response(
+            200, json={"status": "error", "error": "bad", "error_code": "input_files_invalid"}
+        )
+
+    with pytest.raises(DispatchError) as exc_info:
+        _client(handler).wait_for_run_id("D1", deadline=100.0)
+    assert exc_info.value.error_code == "input_files_invalid"
+
+
+def test_wait_for_run_id_error_without_code_has_none():
+    def handler(request):
+        return httpx.Response(200, json={"status": "error", "error": "generic"})
+
+    with pytest.raises(DispatchError) as exc_info:
+        _client(handler).wait_for_run_id("D1", deadline=100.0)
+    assert exc_info.value.error_code is None
+
+
+# --- run() lifts the dispatcher error_code onto the result -----------------
+
+
+def test_run_surfaces_dispatcher_error_code_on_result():
+    # Dispatcher pool result is status="error" carrying an input_files error_code;
+    # run() must lift it onto the returned error result (not swallow it).
+    def handler(request):
+        path = request.url.path
+        if path == "/webhook/unit-question":
+            return httpx.Response(202, json={"dispatch_id": "D1"})
+        if path == "/dispatch/D1":
+            return httpx.Response(
+                200,
+                json={
+                    "status": "error",
+                    "error": "too many files",
+                    "error_code": "input_files_cap_exceeded",
+                },
+            )
+        return httpx.Response(404)
+
+    r = _client(handler).run("q")
+    assert r["status"] == "error"
+    assert r["run_id"] is None  # rejected at the handshake, never got a run_id
+    assert r["error_code"] == "input_files_cap_exceeded"
+
+
+def test_run_ordinary_failure_has_none_error_code():
+    # A plain transport/handshake failure carries no structured error_code.
+    def handler(request):
+        if request.url.path == "/webhook/unit-question":
+            return httpx.Response(500, text="down")
+        return httpx.Response(404)
+
+    assert _client(handler).run("q")["error_code"] is None
+
+
+# --- poll_worker keeps the contract uniform --------------------------------
+
+
+def test_poll_worker_terminal_body_error_code_passed_through():
+    body = {"status": "error", "error": "x", "error_code": "input_files_invalid"}
+
+    def handler(request):
+        return httpx.Response(200, json=body)
+
+    assert _client(handler).poll_worker("R1")["error_code"] == "input_files_invalid"
+
+
+def test_poll_worker_terminal_body_without_error_code_is_none():
+    def handler(request):
+        return httpx.Response(200, json={"status": "completed", "text_output": "ok"})
+
+    assert _client(handler).poll_worker("R1")["error_code"] is None
+
+
+# ==========================================================================
+# DispatchClient.status: a single non-polling GET /dispatch/{run_id} used to
+# reconcile a persisted run_id on restart.
+#
+# Unlike poll_worker it never sleeps, never loops, and returns the worker's raw
+# body verbatim (possibly non-terminal). 404 is a signal -> None; any other
+# non-200 raises DispatchError.
+# ==========================================================================
+
+STATUS_CFG = CoreConfig(
+    worker_url="http://work:9190",
+    dispatch_worker_token="work-token",
+    poll_budget=300.0,
+)
+
+
+def _status_client(handler):
+    return DispatchClient(STATUS_CFG, client=httpx.Client(transport=httpx.MockTransport(handler)))
+
+
+def _status_handler(response):
+    """Return a handler that asserts the GET shape and yields ``response``."""
+
+    def handler(request):
+        assert request.method == "GET"
+        assert str(request.url) == "http://work:9190/dispatch/R1"
+        assert request.headers["Authorization"] == "Bearer work-token"
+        return response
+
+    return handler
+
+
+def test_status_returns_terminal_body_verbatim():
+    body = {
+        "status": "completed",
+        "text_output": "done",
+        "artifacts": ["a1"],
+        "failure_class": None,
+        "num_tool_calls": 4,
+    }
+    r = _status_client(_status_handler(httpx.Response(200, json=body))).status("R1")
+    assert r == body
+
+
+def test_status_returns_non_terminal_body():
+    # The whole point: a live run reports pending and status() hands it back
+    # rather than blocking or synthesizing a result.
+    body = {"status": "pending"}
+    assert _status_client(_status_handler(httpx.Response(200, json=body))).status("R1") == body
+
+
+def test_status_404_returns_none():
+    assert _status_client(_status_handler(httpx.Response(404))).status("R1") is None
+
+
+def test_status_500_raises_dispatch_error():
+    with pytest.raises(DispatchError):
+        _status_client(_status_handler(httpx.Response(500, text="worker down"))).status("R1")
+
+
+def test_status_does_not_sleep_or_poll():
+    # A single request is issued: the handler that raises on a 2nd call proves
+    # there is no polling loop.
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        if calls["n"] > 1:
+            raise AssertionError("status() must issue exactly one request")
+        return httpx.Response(200, json={"status": "running"})
+
+    def boom(_s):
+        raise AssertionError("status() must not sleep")
+
+    client = DispatchClient(
+        STATUS_CFG,
+        client=httpx.Client(transport=httpx.MockTransport(handler)),
+        sleep=boom,
+    )
+    assert client.status("R1") == {"status": "running"}
+    assert calls["n"] == 1
+
+
+# ==========================================================================
+# trust_env is configuration, not a per-module constant
+#
+# The default client honors ``cfg.trust_env`` (default False) rather than
+# hardcoding httpx's proxy-trusting default, so a bridge's proxy behavior is one
+# setting shared by every core module instead of differing silently per module.
+# ==========================================================================
+
+
+@pytest.mark.parametrize("trust_env", [False, True])
+def test_default_client_honors_cfg_trust_env(trust_env):
+    cfg = CoreConfig(poll_budget=300.0, trust_env=trust_env)
+    client = DispatchClient(cfg)
+    try:
+        assert client._client.trust_env is trust_env
+    finally:
+        client._client.close()
+
+
+def test_injected_client_is_used_as_given():
+    # An injected client is never rebuilt, so cfg.trust_env does not apply to it.
+    injected = httpx.Client(transport=httpx.MockTransport(lambda r: httpx.Response(404)))
+    client = DispatchClient(CoreConfig(poll_budget=300.0, trust_env=True), client=injected)
+    assert client._client is injected
+    injected.close()

--- a/tests/bridges/test_drain.py
+++ b/tests/bridges/test_drain.py
@@ -1,0 +1,578 @@
+"""drain_once + supervision helpers, driven with fake callbacks, a fake
+DispatchClient.status, and a REAL DedupStore on a temp file.
+
+Covers: gate-closed no-op, min-age eligibility, coalescing (before the age
+filter; supersede notes; terminal superseded), the redispatch safety gate
+(KNOWN num_tool_calls == 0 or give up — never re-execute unproven work), fresh
+redispatch (CAS; CAS-loser takes no action), re-attach (completed deliver /
+non-terminal skip / terminal-failure retry decision / consecutive-404 give up),
+the give-up ceilings, deliver-failure -> post_failed, per-entry isolation, and
+the thread supervision helpers."""
+
+import threading
+import time
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+import pytest
+
+from osprey.bridges.core.dedup import DedupStore
+from osprey.bridges.core.drain import (
+    DrainCallbacks,
+    DrainDeps,
+    drain_once,
+    ensure_alive,
+    run_drain_thread,
+)
+
+NOW = 1_000_000.0
+PAST_MIN = 2000.0  # > retry_min_age (1200)
+
+
+def _cfg(**over):
+    base = {
+        "retry_min_age": 1200.0,
+        "retry_give_up": 172800.0,
+        "retry_lifetime_cap": 604800.0,
+        "drain_interval": 0.01,
+    }
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+@dataclass
+class FakeCalls:
+    """Records callback invocations; deliver/give_up can be told to raise."""
+
+    dispatched: list = field(default_factory=list)
+    delivered: list = field(default_factory=list)
+    gave_up: list = field(default_factory=list)
+    deliver_raises: bool = False
+    give_up_raises: bool = False
+
+    def as_callbacks(self):
+        def dispatch(mid, entry):
+            self.dispatched.append(mid)
+
+        def deliver(mid, entry, body):
+            self.delivered.append((mid, body.get("status")))
+            if self.deliver_raises:
+                raise RuntimeError("send failed")
+
+        def give_up(mid, entry):
+            self.gave_up.append(mid)
+            if self.give_up_raises:
+                raise RuntimeError("notice failed")
+
+        return DrainCallbacks(dispatch=dispatch, deliver=deliver, give_up=give_up)
+
+
+class FakeDispatcher:
+    """Stands in for DispatchClient.status: returns queued bodies by run_id."""
+
+    def __init__(self, bodies=None):
+        # run_id -> body dict (None means 404)
+        self.bodies = bodies or {}
+
+    def status(self, run_id):
+        return self.bodies.get(run_id)
+
+
+def _deps(store, calls, dispatcher=None, gate=True, now=NOW):
+    return DrainDeps(
+        cfg=_cfg(),
+        dedup=store,
+        dispatcher=dispatcher or FakeDispatcher(),
+        callbacks=calls.as_callbacks(),
+        gate=(lambda: gate),
+        now=(lambda: now),
+    )
+
+
+def _store(tmp_path):
+    return DedupStore(str(tmp_path / "dedup.json"))
+
+
+def _enqueue(store, mid, age=PAST_MIN, **meta):
+    """Create a queued entry aged `age` seconds before NOW."""
+    store.claim(mid, **meta)
+    store.transition(mid, "pending", "queued", queued_at=NOW - age, **meta)
+
+
+# --- gate ------------------------------------------------------------------
+
+
+def test_gate_closed_is_noop(tmp_path):
+    store = _store(tmp_path)
+    _enqueue(store, "m1")
+    calls = FakeCalls()
+    drain_once(_deps(store, calls, gate=False))
+    assert calls.dispatched == [] and store.get("m1")["status"] == "queued"
+
+
+# --- eligibility -----------------------------------------------------------
+
+
+def test_too_young_entry_skipped(tmp_path):
+    store = _store(tmp_path)
+    _enqueue(store, "young", age=100.0)  # < retry_min_age
+    calls = FakeCalls()
+    drain_once(_deps(store, calls))
+    assert calls.dispatched == []
+    assert store.get("young")["status"] == "queued"
+
+
+# --- fresh redispatch (CAS) ------------------------------------------------
+
+
+def test_fresh_entry_redispatched_and_flipped(tmp_path):
+    store = _store(tmp_path)
+    _enqueue(store, "m1", text="hi", num_tool_calls=0)  # known side-effect free
+    calls = FakeCalls()
+    drain_once(_deps(store, calls))
+    assert calls.dispatched == ["m1"]
+    entry = store.get("m1")
+    assert entry["status"] == "in_flight"
+    assert entry["retried"] is True
+
+
+def test_unknown_tool_calls_never_redispatched(tmp_path):
+    """No num_tool_calls in the entry meta -> the failed attempt cannot be
+    PROVEN side-effect free -> honest give-up, never a re-execution."""
+    store = _store(tmp_path)
+    _enqueue(store, "m1", text="hi")  # num_tool_calls unknown
+    calls = FakeCalls()
+    drain_once(_deps(store, calls))
+    assert calls.dispatched == []
+    assert calls.gave_up == ["m1"]
+    assert store.get("m1")["status"] == "error"
+
+
+def test_nonzero_tool_calls_never_redispatched(tmp_path):
+    """A failed attempt that made tool calls may have acted on the machine —
+    re-running it is forbidden regardless of failure class."""
+    store = _store(tmp_path)
+    _enqueue(store, "m1", text="hi", num_tool_calls=3)
+    calls = FakeCalls()
+    drain_once(_deps(store, calls))
+    assert calls.dispatched == []
+    assert calls.gave_up == ["m1"]
+    assert store.get("m1")["status"] == "error"
+
+
+def test_cas_loser_takes_no_action(tmp_path):
+    """An entry flipped away between the queue snapshot and the drain's CAS is
+    skipped entirely — the loser must not double-dispatch."""
+    store = _store(tmp_path)
+    _enqueue(store, "m1", num_tool_calls=0)
+    _enqueue(store, "m2", num_tool_calls=0)
+    dispatched = []
+
+    def dispatch(mid, entry):
+        dispatched.append(mid)
+        if mid == "m1":  # simulate a racing actor claiming m2 mid-pass
+            assert store.transition("m2", "queued", "superseded")
+
+    cbs = DrainCallbacks(dispatch=dispatch, deliver=lambda m, e, b: None, give_up=lambda m, e: None)
+    deps = DrainDeps(
+        cfg=_cfg(),
+        dedup=store,
+        dispatcher=FakeDispatcher(),
+        callbacks=cbs,
+        gate=(lambda: True),
+        now=(lambda: NOW),
+    )
+    drain_once(deps)
+    assert dispatched == ["m1"]  # m2's CAS lost -> no dispatch for it
+    assert store.get("m2")["status"] == "superseded"
+
+
+# --- coalescing ------------------------------------------------------------
+
+
+def test_coalesce_keeps_newest_supersedes_rest(tmp_path):
+    store = _store(tmp_path)
+    # Two fresh entries, same coalesce key; m_new is newer (smaller age).
+    _enqueue(store, "m_old", age=3000.0, coalesce_key=["space", "thread"], num_tool_calls=0)
+    _enqueue(store, "m_new", age=2000.0, coalesce_key=["space", "thread"], num_tool_calls=0)
+    calls = FakeCalls()
+    drain_once(_deps(store, calls))
+    assert calls.dispatched == ["m_new"]
+    assert store.get("m_old")["status"] == "superseded"
+    assert store.get("m_new")["status"] == "in_flight"
+
+
+def test_coalesce_fires_supersede_callback(tmp_path):
+    store = _store(tmp_path)
+    _enqueue(store, "m_old", age=3000.0, coalesce_key=["s", "t"], num_tool_calls=0)
+    _enqueue(store, "m_new", age=2000.0, coalesce_key=["s", "t"], num_tool_calls=0)
+    superseded = []
+    calls = FakeCalls()
+    cbs = calls.as_callbacks()
+    cbs.supersede = lambda mid, entry: superseded.append(mid)
+    deps = DrainDeps(
+        cfg=_cfg(),
+        dedup=store,
+        dispatcher=FakeDispatcher(),
+        callbacks=cbs,
+        gate=(lambda: True),
+        now=(lambda: NOW),
+    )
+    drain_once(deps)
+    assert superseded == ["m_old"]
+
+
+def test_coalesce_runs_before_age_filter(tmp_path):
+    """A newest-but-too-young sibling still supersedes an older ELIGIBLE one —
+    otherwise the old question is answered this pass and the new one later."""
+    store = _store(tmp_path)
+    _enqueue(store, "m_old", age=3000.0, coalesce_key=["k"], num_tool_calls=0)
+    _enqueue(store, "m_new", age=100.0, coalesce_key=["k"], num_tool_calls=0)  # < min age
+    calls = FakeCalls()
+    drain_once(_deps(store, calls))
+    assert store.get("m_old")["status"] == "superseded"
+    assert calls.dispatched == []  # the newest waits out retry_min_age
+    assert store.get("m_new")["status"] == "queued"
+
+
+def test_coalesce_newest_by_first_queued_at(tmp_path):
+    # A re-parked older request carries a FRESHER queued_at than a newer request
+    # parked once; "newest" must follow the request's first park time, not the
+    # latest re-park, or a retry loop shields an old question from coalescing.
+    store = _store(tmp_path)
+    _enqueue(
+        store,
+        "m_old",
+        age=100.0,
+        coalesce_key=["k"],
+        num_tool_calls=0,
+        first_queued_at=NOW - 5000.0,
+    )
+    _enqueue(
+        store,
+        "m_new",
+        age=3000.0,
+        coalesce_key=["k"],
+        num_tool_calls=0,
+        first_queued_at=NOW - 3000.0,
+    )
+    calls = FakeCalls()
+    drain_once(_deps(store, calls))
+    assert store.get("m_old")["status"] == "superseded"
+    assert store.get("m_new")["status"] == "in_flight"
+
+
+def test_give_up_ceiling_survives_repark(tmp_path):
+    # A cycling entry (fresh queued_at from its latest re-park) must still trip
+    # the give-up ceiling through its first_queued_at anchor.
+    store = _store(tmp_path)
+    _enqueue(
+        store,
+        "m1",
+        age=PAST_MIN,
+        first_queued_at=NOW - 172801.0,
+        retried=True,
+        num_tool_calls=0,
+    )
+    calls = FakeCalls()
+    drain_once(_deps(store, calls))
+    assert calls.gave_up == ["m1"]
+    assert store.get("m1")["status"] == "error"
+
+
+def test_superseded_is_terminal_and_never_reconciled(tmp_path):
+    """'superseded' must be a terminal drop: reconcile() re-running a
+    deliberately dropped question on restart is forbidden."""
+    from osprey.bridges.core.config import TERMINAL_STATUSES
+
+    assert "superseded" in TERMINAL_STATUSES
+    store = _store(tmp_path)
+    _enqueue(store, "m_old", age=3000.0, coalesce_key=["k"], num_tool_calls=0)
+    _enqueue(store, "m_new", age=2000.0, coalesce_key=["k"], num_tool_calls=0)
+    drain_once(_deps(store, FakeCalls()))
+    assert store.get("m_old")["status"] == "superseded"
+    assert "m_old" not in store.reconcile()
+    assert "m_old" not in store.queued()
+
+
+def test_empty_coalesce_key_never_coalesces(tmp_path):
+    store = _store(tmp_path)
+    # No coalesce_key -> each stands alone, both redispatched.
+    _enqueue(store, "a", age=3000.0, num_tool_calls=0)
+    _enqueue(store, "b", age=2000.0, num_tool_calls=0)
+    calls = FakeCalls()
+    drain_once(_deps(store, calls))
+    assert sorted(calls.dispatched) == ["a", "b"]
+
+
+# --- re-attach -------------------------------------------------------------
+
+
+def test_reattach_terminal_delivers_and_marks(tmp_path):
+    store = _store(tmp_path)
+    _enqueue(store, "m1")
+    store.record("m1", run_id="R1", status="queued")  # has a run_id
+    dispatcher = FakeDispatcher({"R1": {"status": "completed", "text_output": "done"}})
+    calls = FakeCalls()
+    drain_once(_deps(store, calls, dispatcher=dispatcher))
+    assert calls.delivered == [("m1", "completed")]
+    assert calls.dispatched == []  # re-attach, not redispatch
+    assert store.get("m1")["status"] == "completed"
+
+
+def test_reattach_nonterminal_skips(tmp_path):
+    store = _store(tmp_path)
+    _enqueue(store, "m1")
+    store.record("m1", run_id="R1", status="queued")
+    dispatcher = FakeDispatcher({"R1": {"status": "running"}})
+    calls = FakeCalls()
+    drain_once(_deps(store, calls, dispatcher=dispatcher))
+    assert calls.delivered == [] and calls.gave_up == []
+    assert store.get("m1")["status"] == "queued"
+
+
+def test_reattach_single_404_defers(tmp_path):
+    store = _store(tmp_path)
+    _enqueue(store, "m1")
+    store.record("m1", run_id="R1", status="queued")
+    dispatcher = FakeDispatcher({})  # 404 for R1
+    calls = FakeCalls()
+    drain_once(_deps(store, calls, dispatcher=dispatcher))
+    assert calls.gave_up == []
+    entry = store.get("m1")
+    assert entry["status"] == "queued"
+    assert entry["notfound_count"] == 1
+
+
+def test_reattach_two_consecutive_404s_give_up(tmp_path):
+    store = _store(tmp_path)
+    _enqueue(store, "m1")
+    store.record("m1", run_id="R1", status="queued")
+    dispatcher = FakeDispatcher({})  # always 404
+    calls = FakeCalls()
+    deps = _deps(store, calls, dispatcher=dispatcher)
+    drain_once(deps)  # miss 1
+    assert store.get("m1")["notfound_count"] == 1
+    drain_once(deps)  # miss 2 -> give up
+    assert calls.gave_up == ["m1"]
+    assert store.get("m1")["status"] == "error"
+
+
+def test_reattach_failure_retryable_and_safe_redispatches(tmp_path):
+    """A terminal FAILURE body is the run's definitive outcome: retryable class
+    + known-zero tool calls -> one fresh dispatch, not a delivery."""
+    store = _store(tmp_path)
+    _enqueue(store, "m1", text="hi")
+    store.record("m1", run_id="R1", status="queued")
+    body = {"status": "error", "failure_class": "provider", "num_tool_calls": 0}
+    calls = FakeCalls()
+    drain_once(_deps(store, calls, dispatcher=FakeDispatcher({"R1": body})))
+    assert calls.dispatched == ["m1"]
+    assert calls.delivered == []  # an error body is never "delivered"
+    entry = store.get("m1")
+    assert entry["status"] == "in_flight"
+    assert entry["retried"] is True
+    assert entry["run_id"] is None  # cleared; the channel's persister stamps the new one
+
+
+def test_reattach_failure_with_tool_calls_gives_up(tmp_path):
+    """Retryable class but the failed run made tool calls -> it may have acted
+    on the machine, so it is abandoned, never re-executed."""
+    store = _store(tmp_path)
+    _enqueue(store, "m1", text="hi")
+    store.record("m1", run_id="R1", status="queued")
+    body = {"status": "error", "failure_class": "infrastructure", "num_tool_calls": 2}
+    calls = FakeCalls()
+    drain_once(_deps(store, calls, dispatcher=FakeDispatcher({"R1": body})))
+    assert calls.dispatched == [] and calls.delivered == []
+    assert calls.gave_up == ["m1"]
+    assert store.get("m1")["status"] == "error"
+
+
+def test_reattach_failure_not_retryable_gives_up(tmp_path):
+    """An agent/user-level failure would fail identically on redispatch."""
+    store = _store(tmp_path)
+    _enqueue(store, "m1", text="hi")
+    store.record("m1", run_id="R1", status="queued")
+    body = {"status": "error", "failure_class": "agent", "num_tool_calls": 0}
+    calls = FakeCalls()
+    drain_once(_deps(store, calls, dispatcher=FakeDispatcher({"R1": body})))
+    assert calls.dispatched == []
+    assert calls.gave_up == ["m1"]
+    assert store.get("m1")["status"] == "error"
+
+
+def test_reattach_404_streak_resets_on_hit(tmp_path):
+    store = _store(tmp_path)
+    _enqueue(store, "m1")
+    store.record("m1", run_id="R1", status="queued")
+    dispatcher = FakeDispatcher({})
+    calls = FakeCalls()
+    deps = _deps(store, calls, dispatcher=dispatcher)
+    drain_once(deps)  # miss 1
+    dispatcher.bodies["R1"] = {"status": "running"}  # now the run appears
+    drain_once(deps)  # non-terminal -> streak cleared
+    assert store.get("m1")["notfound_count"] == 0
+
+
+# --- give-up ceilings ------------------------------------------------------
+
+
+def test_give_up_lifetime_cap(tmp_path):
+    store = _store(tmp_path)
+    _enqueue(store, "old", age=604800.0)  # >= lifetime cap
+    calls = FakeCalls()
+    drain_once(_deps(store, calls))
+    assert calls.gave_up == ["old"]
+    assert calls.dispatched == []
+    assert store.get("old")["status"] == "error"
+
+
+def test_give_up_age_extends_on_first_pass_then_fires(tmp_path):
+    store = _store(tmp_path)
+    _enqueue(store, "m1", age=200000.0, text="hi", num_tool_calls=0)  # > give_up age, attempts 0
+    calls = FakeCalls()
+    deps = _deps(store, calls)
+    # First pass: gate seen open now but not yet persisted from a PRIOR pass, and
+    # never retried -> extend (redispatch), and stamp gate_seen_open.
+    drain_once(deps)
+    assert calls.gave_up == []
+    assert store.get("m1")["status"] == "in_flight"  # got its fair attempt
+
+
+def test_give_up_age_fires_when_gate_seen_open_prior(tmp_path):
+    store = _store(tmp_path)
+    _enqueue(store, "m1", age=200000.0)
+    store.record("m1", run_id=None, status="queued", gate_seen_open=True)
+    calls = FakeCalls()
+    drain_once(_deps(store, calls))
+    assert calls.gave_up == ["m1"]
+
+
+# --- deliver failure -> stays queued, retried -------------------------------
+
+
+def test_deliver_failure_leaves_queued_and_retries_next_cycle(tmp_path):
+    """A raising deliver must NOT terminally drop the answer: the entry stays
+    queued (run_id intact) and the next cycle re-attaches and re-delivers."""
+    store = _store(tmp_path)
+    _enqueue(store, "m1")
+    store.record("m1", run_id="R1", status="queued")
+    dispatcher = FakeDispatcher({"R1": {"status": "completed", "text_output": "hi"}})
+    calls = FakeCalls(deliver_raises=True)
+    deps = _deps(store, calls, dispatcher=dispatcher)
+    drain_once(deps)  # send fails
+    entry = store.get("m1")
+    assert entry["status"] == "queued"
+    assert entry["run_id"] == "R1"
+    calls.deliver_raises = False
+    drain_once(deps)  # transient failure cleared -> re-delivered
+    assert calls.delivered == [("m1", "completed"), ("m1", "completed")]
+    assert store.get("m1")["status"] == "completed"
+
+
+# --- give-up mechanics -------------------------------------------------------
+
+
+def test_dispatch_increments_attempts(tmp_path):
+    store = _store(tmp_path)
+    _enqueue(store, "m1", num_tool_calls=0, attempts=0)
+    _enqueue(store, "m2", num_tool_calls=0, attempts=2)
+    calls = FakeCalls()
+    drain_once(_deps(store, calls))
+    assert store.get("m1")["attempts"] == 1
+    assert store.get("m2")["attempts"] == 3
+
+
+def test_give_up_reason_stamped_in_store_meta(tmp_path):
+    """The drain's machine-side reason lands in the terminal transition meta
+    (audit trail) — the callback surface stays (message_id, entry)."""
+    store = _store(tmp_path)
+    _enqueue(store, "m_age", age=604800.0)  # lifetime cap
+    _enqueue(store, "m_run", text="hi")
+    store.record("m_run", run_id="R1", status="queued")
+    body = {"status": "error", "failure_class": "agent", "num_tool_calls": 0}
+    calls = FakeCalls()
+    drain_once(_deps(store, calls, dispatcher=FakeDispatcher({"R1": body})))
+    assert sorted(calls.gave_up) == ["m_age", "m_run"]
+    assert "lifetime cap" in store.get("m_age")["give_up_reason"]
+    assert "cannot be safely re-run" in store.get("m_run")["give_up_reason"]
+
+
+def test_give_up_notice_failure_leaves_queued(tmp_path):
+    """Callback first, CAS second: a give-up notice that fails to send leaves
+    the entry queued so the next cycle retries the notice — never a silent
+    terminal drop."""
+    store = _store(tmp_path)
+    _enqueue(store, "m1", age=604800.0)
+    calls = FakeCalls(give_up_raises=True)
+    deps = _deps(store, calls)
+    drain_once(deps)
+    assert calls.gave_up == ["m1"]  # attempted
+    assert store.get("m1")["status"] == "queued"  # not dropped
+    calls.give_up_raises = False
+    drain_once(deps)  # notice now sends -> terminal
+    assert store.get("m1")["status"] == "error"
+
+
+# --- per-entry isolation ---------------------------------------------------
+
+
+def test_one_entry_failure_does_not_abort_pass(tmp_path):
+    store = _store(tmp_path)
+    _enqueue(store, "bad")
+    store.record("bad", run_id="RB", status="queued")
+    _enqueue(store, "good", text="hi", num_tool_calls=0)
+
+    class Boom(FakeDispatcher):
+        def status(self, run_id):
+            raise RuntimeError("worker exploded")
+
+    calls = FakeCalls()
+    drain_once(_deps(store, calls, dispatcher=Boom()))
+    # The good fresh entry is still redispatched despite the bad one raising.
+    assert calls.dispatched == ["good"]
+    assert store.get("bad")["status"] == "queued"
+
+
+# --- supervision helpers ---------------------------------------------------
+
+
+def test_run_drain_thread_runs_and_stops(tmp_path):
+    store = _store(tmp_path)
+    _enqueue(store, "m1", text="hi", num_tool_calls=0)
+    calls = FakeCalls()
+    deps = _deps(store, calls)
+    stop = threading.Event()
+    thread = run_drain_thread(deps, stop=stop)
+    # Poll until the fresh entry gets dispatched, then stop.
+    for _ in range(200):
+        if calls.dispatched:
+            break
+        time.sleep(0.01)
+    stop.set()
+    thread.join(timeout=2.0)
+    assert calls.dispatched == ["m1"]
+    assert not thread.is_alive()
+    assert thread.daemon and thread.name == "bridge-drain"
+
+
+def test_ensure_alive_returns_live_thread():
+    alive = threading.Thread(target=lambda: time.sleep(1.0))
+    alive.start()
+    try:
+        assert ensure_alive(alive, factory=lambda: pytest.fail("should not rebuild")) is alive
+    finally:
+        alive.join()
+
+
+def test_ensure_alive_rebuilds_dead_thread():
+    made = []
+
+    def factory():
+        t = threading.Thread(target=lambda: None)
+        made.append(t)
+        return t
+
+    result = ensure_alive(None, factory)
+    assert result is made[0]

--- a/tests/bridges/test_health_gate.py
+++ b/tests/bridges/test_health_gate.py
@@ -1,0 +1,283 @@
+"""gate_open: fail-closed checks (dispatcher health, worker health, and — only
+where an alert host is configured — no open osprey-alert issue), with the GitLab
+*API failure* case unit-tested separately from the *open alert* case (both close
+the gate, distinct causes).
+
+The alert-issue check is opt-in: it runs only when both ``gitlab_url`` and
+``gitlab_issues_token`` are set. The final section pins that behavior from both
+sides — unconfigured the gate ignores GitLab entirely, configured it keeps every
+fail-closed guarantee.
+"""
+
+from types import SimpleNamespace
+
+import httpx
+
+from osprey.bridges.core import health_gate
+from osprey.bridges.core.health_gate import gate_open
+
+
+def _cfg(**overrides):
+    # A structural stub of the CoreConfig fields gate_open reads. Field names
+    # MUST track CoreConfig's — test_gate_open_reads_real_coreconfig_fields
+    # below guards against the stub and the real config drifting apart.
+    fields = {
+        "dispatcher_url": "http://disp:8010",
+        "worker_url": "http://work:9190",
+        "gitlab_url": "https://git.als.lbl.gov",
+        "gitlab_project": "physics/production/als-profiles",
+        "gitlab_issues_token": "gltok",
+        "trust_env": False,
+    }
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+def _health(status="ok", code=200):
+    def f(_req):
+        return httpx.Response(code, json={"status": status})
+
+    return f
+
+
+def _gitlab(code=200, body=None):
+    def f(_req):
+        return httpx.Response(code, json=[] if body is None else body)
+
+    return f
+
+
+def _raise(exc):
+    def f(_req):
+        raise exc
+
+    return f
+
+
+def _client(disp=None, work=None, gitlab=None, record=None):
+    disp = disp or _health()
+    work = work or _health()
+    gitlab = gitlab or _gitlab()
+
+    def handler(request):
+        host = request.url.host
+        if host == "git.als.lbl.gov":
+            if record is not None:
+                record.append(request)
+            return gitlab(request)
+        if host == "disp":
+            return disp(request)
+        if host == "work":
+            return work(request)
+        raise AssertionError(f"unexpected host {host}")
+
+    # trust_env=False: with ambient HTTP(S)_PROXY set (dev shells, CI), httpx
+    # would otherwise mount env-proxy transports that bypass the MockTransport
+    # and hit the network — the suite must be immune to environment/test-order.
+    return httpx.Client(transport=httpx.MockTransport(handler), trust_env=False)
+
+
+# --- happy path ------------------------------------------------------------
+
+
+def test_all_healthy_no_alert_opens_gate():
+    assert gate_open(_cfg(), _client()) is True
+
+
+def test_gitlab_empty_list_opens_gate():
+    # Isolated positive case for check (c): a clean 200 + empty list.
+    assert gate_open(_cfg(), _client(gitlab=_gitlab(200, []))) is True
+
+
+# --- dispatcher / worker health --------------------------------------------
+
+
+def test_dispatcher_status_not_ok_closes_gate():
+    assert gate_open(_cfg(), _client(disp=_health(status="degraded"))) is False
+
+
+def test_dispatcher_non_200_closes_gate():
+    assert gate_open(_cfg(), _client(disp=_health(code=503))) is False
+
+
+def test_worker_status_not_ok_closes_gate():
+    assert gate_open(_cfg(), _client(work=_health(status="degraded"))) is False
+
+
+def test_worker_non_200_closes_gate():
+    assert gate_open(_cfg(), _client(work=_health(code=500))) is False
+
+
+def test_health_transport_error_closes_gate():
+    assert gate_open(_cfg(), _client(disp=_raise(httpx.ConnectError("boom")))) is False
+
+
+# --- GitLab: open alert vs API failure are DISTINCT causes -----------------
+
+
+def test_open_alert_closes_gate():
+    # (c) fails because an alert IS open — a positive observation of breakage.
+    # Also the phase's second success criterion: with gitlab_url and the issues
+    # token both set, an open alert issue closes the gate.
+    body = [{"iid": 7, "labels": ["osprey-alert"], "state": "opened"}]
+    assert gate_open(_cfg(), _client(gitlab=_gitlab(200, body))) is False
+
+
+def test_gitlab_api_failure_non_200_closes_gate():
+    # (c) fails because we could not ASK — a 500 from GitLab, NOT an open alert.
+    assert gate_open(_cfg(), _client(gitlab=_gitlab(500, {"message": "boom"}))) is False
+
+
+def test_gitlab_api_failure_exception_closes_gate():
+    # (c) fails on a transport error (unreachable/timeout) — again an API
+    # failure distinct from observing an open alert.
+    assert gate_open(_cfg(), _client(gitlab=_raise(httpx.TimeoutException("t")))) is False
+
+
+def test_gitlab_non_list_body_closes_gate():
+    assert gate_open(_cfg(), _client(gitlab=_gitlab(200, {"unexpected": "shape"}))) is False
+
+
+# --- request shape / short-circuit / direct connection ---------------------
+
+
+def test_gitlab_request_shape():
+    record = []
+    gate_open(_cfg(), _client(record=record))
+    assert len(record) == 1
+    req = record[0]
+    assert req.headers["PRIVATE-TOKEN"] == "gltok"
+    # project path is URL-encoded into the API path (no bare slashes).
+    assert "physics%2Fproduction%2Fals-profiles" in str(req.url)
+    assert req.url.path.endswith("/issues")
+    assert req.url.params.get("labels") == "osprey-alert"
+    assert req.url.params.get("state") == "opened"
+
+
+def test_dispatcher_failure_short_circuits_gitlab():
+    # A closed earlier check must not even query GitLab.
+    record = []
+    assert gate_open(_cfg(), _client(disp=_health(code=503), record=record)) is False
+    assert record == []
+
+
+def test_default_client_is_direct(monkeypatch):
+    # With no injected client, gate_open must build a client honoring the
+    # config's trust_env, which defaults False so the alert host is reached
+    # directly. Ambient proxy env must not leak in regardless of test order, so
+    # scrub it first.
+    for var in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY"):
+        monkeypatch.delenv(var, raising=False)
+        monkeypatch.delenv(var.lower(), raising=False)
+    captured = {}
+    mock = _client(disp=_health(status="down"))  # built before patching; any close
+
+    def fake_client(*args, **kwargs):
+        captured.update(kwargs)
+        return mock
+
+    monkeypatch.setattr(health_gate.httpx, "Client", fake_client)
+    gate_open(_cfg())
+    assert captured.get("trust_env") is False
+
+
+def test_gate_open_reads_real_coreconfig_fields():
+    """Drive gate_open with a REAL CoreConfig, not the stub: an attribute-name
+    drift between this module and CoreConfig (e.g. gitlab_token vs
+    gitlab_issues_token) raises inside the fail-closed except and silently
+    closes the gate forever — only a real instance can catch that."""
+    from osprey.bridges.core.config import CoreConfig
+
+    cfg = CoreConfig(
+        dispatcher_url="http://disp:8010",
+        worker_url="http://work:9190",
+        gitlab_url="https://git.als.lbl.gov",
+        gitlab_project="physics/production/als-profiles",
+        gitlab_issues_token="real-cfg-token",
+    )
+    record = []
+    assert gate_open(cfg, _client(record=record)) is True
+    assert len(record) == 1
+    assert record[0].headers["PRIVATE-TOKEN"] == "real-cfg-token"
+
+
+# --- the alert-issue check is opt-in ---------------------------------------
+
+
+def test_unconfigured_alert_check_opens_gate_on_healthy_pair():
+    """The phase's first success criterion: with no alert host configured, two
+    healthy /health responses are enough to open the gate. Were this check still
+    mandatory, an unconfigured site would fail it forever, the drain would never
+    run, and parked messages would age out into give-up notices."""
+    record = []
+    cfg = _cfg(gitlab_url="", gitlab_project="", gitlab_issues_token="")
+    assert gate_open(cfg, _client(record=record)) is True
+    # ...and nothing was asked of GitLab at all.
+    assert record == []
+
+
+def test_unconfigured_alert_check_skipped_with_real_coreconfig_defaults():
+    """CoreConfig's shipped defaults leave gitlab_url/project/token empty, so an
+    out-of-the-box config must take the skip path — not merely the stub."""
+    from osprey.bridges.core.config import CoreConfig
+
+    cfg = CoreConfig(dispatcher_url="http://disp:8010", worker_url="http://work:9190")
+    assert cfg.gitlab_url == ""
+    assert cfg.gitlab_issues_token == ""
+    record = []
+    assert gate_open(cfg, _client(record=record)) is True
+    assert record == []
+
+
+def test_url_without_token_skips_alert_check():
+    # A host with no token cannot query the issues API; half-configured is
+    # unconfigured, not fail-closed-forever.
+    record = []
+    cfg = _cfg(gitlab_issues_token="")
+    assert gate_open(cfg, _client(record=record)) is True
+    assert record == []
+
+
+def test_token_without_url_skips_alert_check():
+    record = []
+    cfg = _cfg(gitlab_url="")
+    assert gate_open(cfg, _client(record=record)) is True
+    assert record == []
+
+
+def test_unconfigured_alert_check_still_requires_dispatcher_health():
+    # Skipping (c) must not weaken (a): the gate is skipping one check, not
+    # opening unconditionally.
+    cfg = _cfg(gitlab_url="", gitlab_issues_token="")
+    assert gate_open(cfg, _client(disp=_health(code=503))) is False
+
+
+def test_unconfigured_alert_check_still_requires_worker_health():
+    # ...nor (b).
+    cfg = _cfg(gitlab_url="", gitlab_issues_token="")
+    assert gate_open(cfg, _client(work=_health(status="degraded"))) is False
+
+
+def test_alert_check_configured_predicate():
+    assert health_gate.alert_check_configured(_cfg()) is True
+    assert health_gate.alert_check_configured(_cfg(gitlab_url="")) is False
+    assert health_gate.alert_check_configured(_cfg(gitlab_issues_token="")) is False
+    assert health_gate.alert_check_configured(_cfg(gitlab_url="", gitlab_issues_token="")) is False
+
+
+# --- trust_env comes from config, not a module constant --------------------
+
+
+def test_default_client_honors_configured_trust_env(monkeypatch):
+    # A site behind an egress proxy sets trust_env once, in config, and the
+    # gate's own client picks it up.
+    captured = {}
+    mock = _client(disp=_health(status="down"))
+
+    def fake_client(*args, **kwargs):
+        captured.update(kwargs)
+        return mock
+
+    monkeypatch.setattr(health_gate.httpx, "Client", fake_client)
+    gate_open(_cfg(trust_env=True))
+    assert captured.get("trust_env") is True

--- a/tests/bridges/test_history.py
+++ b/tests/bridges/test_history.py
@@ -1,0 +1,372 @@
+"""Tests for :class:`osprey.bridges.core.history.HistoryStore`.
+
+Covers the current turn shape ({question, answer, ts, run_id, artifacts}), the
+grandfathering of pre-feature turns (PROPOSAL criterion 8: mixed old/new files
+load and replay correctly), the char budget counting the full serialized turn,
+the per-turn artifact cap, and the 90-day age-prune — all driven by an injected
+clock so there are no real sleeps.
+"""
+
+from __future__ import annotations
+
+import json
+
+from osprey.bridges.core.history import (
+    FAILED_TURN_ANSWER,
+    MAX_AGE_SECONDS,
+    MAX_ARTIFACTS_PER_TURN,
+    HistoryStore,
+)
+
+DAY = 24 * 60 * 60
+
+
+class FakeClock:
+    """Monotone-ish injectable clock: reads return ``t``; tests set ``t``."""
+
+    def __init__(self, t: float = 1_000_000.0):
+        self.t = t
+
+    def __call__(self) -> float:
+        return self.t
+
+
+def _write(path, data: dict) -> None:
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _read(path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# --- basic round-trip -------------------------------------------------------
+
+
+def test_append_and_recent_basic(tmp_path):
+    h = HistoryStore(str(tmp_path / "h.json"))
+    h.append("k", "q1", "a1")
+    h.append("k", "q2", "a2")
+    turns = h.recent("k")
+    assert [t["question"] for t in turns] == ["q1", "q2"]
+    assert [t["answer"] for t in turns] == ["a1", "a2"]
+    # New turns carry the full shape.
+    for t in turns:
+        assert set(t) == {"question", "answer", "ts", "run_id", "artifacts"}
+        assert t["run_id"] is None
+        assert t["artifacts"] == []
+
+
+def test_empty_key_is_noop(tmp_path):
+    h = HistoryStore(str(tmp_path / "h.json"))
+    h.append("", "q", "a")
+    assert h.recent("") == []
+
+
+def test_recent_unknown_key(tmp_path):
+    h = HistoryStore(str(tmp_path / "h.json"))
+    assert h.recent("nope") == []
+
+
+# --- append signature: back-compat + new params -----------------------------
+
+
+def test_append_three_arg_still_works(tmp_path):
+    """Pre-existing 3-arg callers must keep working."""
+    h = HistoryStore(str(tmp_path / "h.json"))
+    h.append("k", "q", "a")  # no run_id / artifacts
+    (turn,) = h.recent("k")
+    assert turn["run_id"] is None
+    assert turn["artifacts"] == []
+
+
+def test_append_with_run_id_and_artifacts(tmp_path):
+    h = HistoryStore(str(tmp_path / "h.json"))
+    arts = [
+        {"entry_id": "e1", "filename": "plot.png", "delivered_mime": "image/png", "origin": "run"}
+    ]
+    h.append("k", "q", "a", run_id="run-123", artifacts=arts)
+    (turn,) = h.recent("k")
+    assert turn["run_id"] == "run-123"
+    assert turn["artifacts"] == arts
+
+
+def test_artifacts_capped_tail_kept(tmp_path):
+    h = HistoryStore(str(tmp_path / "h.json"))
+    arts = [{"entry_id": f"e{i}"} for i in range(MAX_ARTIFACTS_PER_TURN + 5)]
+    h.append("k", "q", "a", artifacts=arts)
+    (turn,) = h.recent("k")
+    assert len(turn["artifacts"]) == MAX_ARTIFACTS_PER_TURN
+    # Tail retained (most recent).
+    assert turn["artifacts"][0]["entry_id"] == "e5"
+    assert turn["artifacts"][-1]["entry_id"] == f"e{MAX_ARTIFACTS_PER_TURN + 4}"
+
+
+def test_descriptors_round_trip_opaquely(tmp_path):
+    """The store must not inspect descriptor shape — arbitrary dicts survive."""
+    h = HistoryStore(str(tmp_path / "h.json"))
+    weird = [{"anything": {"nested": [1, 2, 3]}, "x": None}]
+    h.append("k", "q", "a", artifacts=weird)
+    (turn,) = h.recent("k")
+    assert turn["artifacts"] == weird
+
+
+# --- append_failed ----------------------------------------------------------
+
+
+def test_append_failed_records_marker(tmp_path):
+    h = HistoryStore(str(tmp_path / "h.json"))
+    h.append_failed("k", "q")
+    (turn,) = h.recent("k")
+    assert turn["question"] == "q"
+    assert turn["answer"] == FAILED_TURN_ANSWER
+    assert turn["run_id"] is None
+    assert turn["artifacts"] == []
+
+
+def test_append_failed_empty_question_noop(tmp_path):
+    h = HistoryStore(str(tmp_path / "h.json"))
+    h.append_failed("k", "")
+    assert h.recent("k") == []
+
+
+# --- caps: turn count and char budget ---------------------------------------
+
+
+def test_turn_count_cap(tmp_path):
+    h = HistoryStore(str(tmp_path / "h.json"), max_turns=3)
+    for i in range(6):
+        h.append("k", f"q{i}", f"a{i}")
+    turns = h.recent("k")
+    assert [t["question"] for t in turns] == ["q3", "q4", "q5"]
+    # Persisted window is also bounded.
+    assert len(_read(tmp_path / "h.json")["k"]) == 3
+
+
+def test_char_budget_drops_oldest(tmp_path):
+    h = HistoryStore(str(tmp_path / "h.json"), max_chars=200)
+    h.append("k", "x" * 100, "y" * 100)  # oldest, large
+    h.append("k", "q2", "a2")
+    h.append("k", "q3", "a3")
+    turns = h.recent("k")
+    # The big first turn is dropped by the char budget; newest survive.
+    assert [t["question"] for t in turns] == ["q2", "q3"]
+
+
+def test_char_budget_counts_full_serialized_turn(tmp_path):
+    """The budget must charge for the whole serialized turn (descriptors
+    included), not just question+answer — a turn heavy with artifact
+    descriptors must be able to blow the budget on its own."""
+    # Tiny q/a but a big artifact payload.
+    big_art = [{"blob": "z" * 500}]
+    small = HistoryStore(str(tmp_path / "s.json"))
+    small.append("k", "q1", "a1")
+    small.append("k", "q2", "a2", artifacts=big_art)
+    # Budget large enough for two text-only turns but not once the 500-char
+    # descriptor is counted: the oldest text turn is evicted.
+    h = HistoryStore(str(tmp_path / "h.json"), max_chars=300)
+    h.append("k", "q1", "a1")
+    h.append("k", "q2", "a2", artifacts=big_art)
+    turns = h.recent("k")
+    # Only the newest (artifact-heavy) turn fits; it always survives as newest.
+    assert [t["question"] for t in turns] == ["q2"]
+    assert turns[0]["artifacts"] == big_art
+
+
+def test_recent_always_keeps_newest_even_if_over_budget(tmp_path):
+    h = HistoryStore(str(tmp_path / "h.json"), max_chars=1)
+    h.append("k", "q1", "a1")
+    h.append("k", "q2", "a2")
+    turns = h.recent("k")
+    assert [t["question"] for t in turns] == ["q2"]
+
+
+# --- 90-day age prune -------------------------------------------------------
+
+
+def test_age_prune_on_append(tmp_path):
+    clock = FakeClock(1_000_000.0)
+    h = HistoryStore(str(tmp_path / "h.json"), now=clock)
+    h.append("k", "old", "a")
+    # Advance past the age ceiling, then append — old turn is pruned.
+    clock.t += MAX_AGE_SECONDS + DAY
+    h.append("k", "new", "a")
+    turns = h.recent("k")
+    assert [t["question"] for t in turns] == ["new"]
+
+
+def test_age_prune_keeps_within_window(tmp_path):
+    clock = FakeClock(1_000_000.0)
+    h = HistoryStore(str(tmp_path / "h.json"), now=clock)
+    h.append("k", "t0", "a")
+    clock.t += MAX_AGE_SECONDS - DAY  # still inside the window
+    h.append("k", "t1", "a")
+    turns = h.recent("k")
+    assert [t["question"] for t in turns] == ["t0", "t1"]
+
+
+# --- grandfathering (PROPOSAL criterion 8) ----------------------------------
+
+
+def test_grandfather_old_turns_stamps_load_time(tmp_path):
+    path = tmp_path / "h.json"
+    _write(path, {"k": [{"question": "old_q", "answer": "old_a"}]})
+    clock = FakeClock(555.0)
+    h = HistoryStore(str(path), now=clock)
+    (turn,) = h.recent("k")
+    assert turn["question"] == "old_q"
+    assert turn["answer"] == "old_a"
+    assert turn["ts"] == 555.0  # stamped at load time
+    assert turn["run_id"] is None
+    assert turn["artifacts"] == []
+
+
+def test_grandfathered_ts_is_persisted(tmp_path):
+    """The load-time ts must be written back, so a restart doesn't re-stamp to
+    an ever-later 'now' and the age-prune reads a stable anchor."""
+    path = tmp_path / "h.json"
+    _write(path, {"k": [{"question": "old_q", "answer": "old_a"}]})
+    clock = FakeClock(555.0)
+    HistoryStore(str(path), now=clock)  # construction persists coercion
+    on_disk = _read(path)
+    assert on_disk["k"][0]["ts"] == 555.0
+    assert on_disk["k"][0]["run_id"] is None
+    assert on_disk["k"][0]["artifacts"] == []
+
+
+def test_grandfathered_history_survives_first_append(tmp_path):
+    """Regression for criterion 8: a pre-feature conversation must NOT be wiped
+    as 'ancient' the first time a new turn is appended."""
+    path = tmp_path / "h.json"
+    _write(path, {"k": [{"question": "old_q", "answer": "old_a"}]})
+    clock = FakeClock(1_000_000.0)
+    h = HistoryStore(str(path), now=clock)
+    # Small advance (well within 90d), then append.
+    clock.t += DAY
+    h.append("k", "new_q", "new_a")
+    turns = h.recent("k")
+    assert [t["question"] for t in turns] == ["old_q", "new_q"]
+
+
+def test_grandfathered_ancient_pruned_only_after_window(tmp_path):
+    """Once the load-time anchor itself ages past the window, the old turn is
+    pruned on append (it is not immortal)."""
+    path = tmp_path / "h.json"
+    _write(path, {"k": [{"question": "old_q", "answer": "old_a"}]})
+    clock = FakeClock(1_000_000.0)
+    h = HistoryStore(str(path), now=clock)  # old_q anchored at 1_000_000
+    clock.t += MAX_AGE_SECONDS + DAY
+    h.append("k", "new_q", "new_a")
+    turns = h.recent("k")
+    assert [t["question"] for t in turns] == ["new_q"]
+
+
+def test_mixed_old_and_new_turns_load(tmp_path):
+    """A file with both legacy (2-field) and current (5-field) turns loads and
+    replays correctly, preserving order."""
+    path = tmp_path / "h.json"
+    _write(
+        path,
+        {
+            "k": [
+                {"question": "legacy_q", "answer": "legacy_a"},  # old shape
+                {
+                    "question": "new_q",
+                    "answer": "new_a",
+                    "ts": 2_000_000.0,
+                    "run_id": "run-9",
+                    "artifacts": [{"entry_id": "e1"}],
+                },
+            ]
+        },
+    )
+    clock = FakeClock(1_500_000.0)
+    h = HistoryStore(str(path), now=clock)
+    turns = h.recent("k")
+    assert [t["question"] for t in turns] == ["legacy_q", "new_q"]
+    # Legacy grandfathered.
+    assert turns[0]["ts"] == 1_500_000.0
+    assert turns[0]["run_id"] is None
+    assert turns[0]["artifacts"] == []
+    # Current turn preserved verbatim.
+    assert turns[1]["ts"] == 2_000_000.0
+    assert turns[1]["run_id"] == "run-9"
+    assert turns[1]["artifacts"] == [{"entry_id": "e1"}]
+
+
+def test_current_format_file_not_marked_dirty(tmp_path):
+    """A file already in the current shape must not be rewritten on load (no
+    needless churn / no ts drift)."""
+    path = tmp_path / "h.json"
+    turn = {
+        "question": "q",
+        "answer": "a",
+        "ts": 2_000_000.0,
+        "run_id": "run-1",
+        "artifacts": [{"entry_id": "e1"}],
+    }
+    _write(path, {"k": [turn]})
+    before = path.read_text(encoding="utf-8")
+    clock = FakeClock(9_999_999.0)
+    HistoryStore(str(path), now=clock)
+    # ts must NOT have been re-stamped to 9_999_999.
+    assert _read(path)["k"][0]["ts"] == 2_000_000.0
+    # File unchanged (not flushed).
+    assert path.read_text(encoding="utf-8") == before
+
+
+def test_oversized_artifacts_capped_on_load(tmp_path):
+    path = tmp_path / "h.json"
+    arts = [{"entry_id": f"e{i}"} for i in range(MAX_ARTIFACTS_PER_TURN + 3)]
+    _write(
+        path,
+        {"k": [{"question": "q", "answer": "a", "ts": 5.0, "run_id": None, "artifacts": arts}]},
+    )
+    h = HistoryStore(str(path))
+    (turn,) = h.recent("k")
+    assert len(turn["artifacts"]) == MAX_ARTIFACTS_PER_TURN
+    # And the cap is persisted.
+    assert len(_read(path)["k"][0]["artifacts"]) == MAX_ARTIFACTS_PER_TURN
+
+
+# --- malformed inputs -------------------------------------------------------
+
+
+def test_malformed_conversation_dropped(tmp_path):
+    path = tmp_path / "h.json"
+    _write(path, {"good": [{"question": "q", "answer": "a"}], "bad": "not-a-list"})
+    h = HistoryStore(str(path))
+    assert [t["question"] for t in h.recent("good")] == ["q"]
+    assert h.recent("bad") == []
+
+
+def test_malformed_turn_dropped(tmp_path):
+    path = tmp_path / "h.json"
+    _write(path, {"k": ["not-a-dict", {"question": "q", "answer": "a"}]})
+    h = HistoryStore(str(path))
+    turns = h.recent("k")
+    assert [t["question"] for t in turns] == ["q"]
+
+
+def test_bool_ts_is_restamped(tmp_path):
+    """A stray boolean ts (int subclass) must be re-stamped, not read as
+    1.0/0.0 epoch (which would prune the turn instantly)."""
+    path = tmp_path / "h.json"
+    _write(path, {"k": [{"question": "q", "answer": "a", "ts": True}]})
+    clock = FakeClock(777.0)
+    h = HistoryStore(str(path), now=clock)
+    (turn,) = h.recent("k")
+    assert turn["ts"] == 777.0
+
+
+# --- persistence across "restart" -------------------------------------------
+
+
+def test_reload_preserves_turns(tmp_path):
+    path = tmp_path / "h.json"
+    h1 = HistoryStore(str(path))
+    h1.append("k", "q", "a", run_id="r1", artifacts=[{"entry_id": "e1"}])
+    h2 = HistoryStore(str(path))  # fresh instance = restart
+    (turn,) = h2.recent("k")
+    assert turn["question"] == "q"
+    assert turn["run_id"] == "r1"
+    assert turn["artifacts"] == [{"entry_id": "e1"}]

--- a/tests/bridges/test_pipeline.py
+++ b/tests/bridges/test_pipeline.py
@@ -1,0 +1,804 @@
+"""Tests for the channel-agnostic per-message pipeline (``handle_event``).
+
+This suite DEFINES the pipeline's ordering contract — it is not a port. The stores are
+the real ``DedupStore``/``HistoryStore`` (tmp-file backed, subclassed only to ``mark``
+their calls into the ``RecordingChannelOps`` timeline); the dispatcher is a stub that
+records its payload and returns a canned terminal result; the retry-queue park defaults
+to the REAL :func:`osprey.bridges.core.retry_queue.park` unless a test injects a seam.
+
+The load-bearing invariants, each with a named test:
+
+* claim precedes dispatch            — ``test_claim_precedes_dispatch``
+* ack precedes dispatch              — ``test_ack_precedes_dispatch``
+* history only after successful post — ``test_failed_post_answer_keeps_entry_queued_and_skips_history``
+* ONE memoized probe per dispatch    — ``test_capability_probe_runs_once_for_all_three_consumers``
+* downgrade seen on NEXT dispatch    — ``test_probe_downgrade_observed_on_next_dispatch``
+* no-op InputDownload is invisible   — ``test_noop_input_download_leaves_payload_byte_identical``
+* duplicate fires nothing            — ``test_duplicate_delivery_returns_duplicate_and_fires_nothing``
+* unparseable event never claims     — ``test_unparseable_event_is_ignored_and_never_claims``
+"""
+
+from __future__ import annotations
+
+import base64
+import copy
+import logging
+from typing import Any
+
+import pytest
+
+from osprey.bridges.core import pipeline
+from osprey.bridges.core.config import CoreConfig
+from osprey.bridges.core.dedup import DedupStore
+from osprey.bridges.core.history import HistoryStore
+from osprey.bridges.core.pipeline import (
+    EXPIRED_NOTE,
+    OVER_BUDGET_REASON,
+    SERVER_TOO_OLD_REASON,
+    TOO_MANY_FILES_REASON,
+    PipelineDeps,
+    handle_event,
+)
+from osprey.bridges.core.ports import InboundEvent, InputDownload, ReplyContext
+from tests.bridges.conftest import RecordingChannelOps
+
+MSG = "spaces/AAA/messages/1"
+MSG2 = "spaces/AAA/messages/2"
+QUESTION = "what is the orbit doing?"
+HISTORY_KEY = "spaces/AAA"
+
+COMPLETED = {
+    "status": "completed",
+    "text_output": "The orbit is stable.",
+    "run_id": "run-1",
+    "num_tool_calls": 3,
+}
+
+
+def b64(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+def make_event(**over: Any) -> InboundEvent:
+    fields: dict[str, Any] = {
+        "message_id": MSG,
+        "text": QUESTION,
+        "sender_id": "users/7",
+        "sender_display": "Pat",
+        "history_key": HISTORY_KEY,
+        "claim_meta": {"space": "spaces/AAA", "thread": "spaces/AAA/threads/T"},
+    }
+    fields.update(over)
+    return InboundEvent(**fields)
+
+
+def make_file(filename: str, data: bytes, mime: str = "image/png") -> dict[str, Any]:
+    return {"filename": filename, "mime": mime, "content_b64": b64(data), "ingest": True}
+
+
+class MarkingDedup(DedupStore):
+    """Real dedup store that marks ``claim`` into the shared timeline."""
+
+    def __init__(self, path: str, ops: RecordingChannelOps) -> None:
+        super().__init__(path)
+        self._ops = ops
+
+    def claim(self, message_id: str, **meta: Any) -> bool:
+        claimed = super().claim(message_id, **meta)
+        self._ops.mark("claim", message_id=message_id, claimed=claimed)
+        return claimed
+
+
+class MarkingHistory(HistoryStore):
+    """Real history store that marks reads/writes into the shared timeline.
+
+    Note ``append_failed`` delegates to ``append`` internally, so a failed turn
+    marks BOTH ``history_append_failed`` and ``history_append``.
+    """
+
+    def __init__(self, path: str, ops: RecordingChannelOps) -> None:
+        super().__init__(path)
+        self._ops = ops
+
+    def recent(self, key: str) -> list[dict[str, Any]]:
+        turns = super().recent(key)
+        self._ops.mark("history_recent", key=key, turns=len(turns))
+        return turns
+
+    def append(
+        self,
+        key: str,
+        question: str,
+        answer: str,
+        run_id: str | None = None,
+        artifacts: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self._ops.mark("history_append", key=key, question=question, answer=answer)
+        super().append(key, question, answer, run_id=run_id, artifacts=artifacts)
+
+    def append_failed(self, key: str, question: str) -> None:
+        self._ops.mark("history_append_failed", key=key, question=question)
+        super().append_failed(key, question)
+
+
+class StubDispatcher:
+    """Records each dispatch payload (deep-copied at call time) and marks the shared
+    timeline; fires ``on_run_id`` before returning the canned terminal result, the
+    way the real client persists the run id mid-handshake."""
+
+    def __init__(self, ops: RecordingChannelOps, result: dict[str, Any] | None = None) -> None:
+        self._ops = ops
+        self.result = dict(COMPLETED if result is None else result)
+        self.calls: list[dict[str, Any]] = []
+
+    def run(self, question: str, extra: dict | None = None, *, on_run_id=None) -> dict[str, Any]:
+        self.calls.append({"question": question, "extra": copy.deepcopy(extra)})
+        self._ops.mark("dispatch", question=question)
+        if on_run_id is not None and self.result.get("run_id"):
+            on_run_id(self.result["run_id"])
+        return dict(self.result)
+
+
+class CountingProbe:
+    """A ``probe_capability`` double: counts calls, returns scripted verdicts."""
+
+    def __init__(self, *verdicts: bool) -> None:
+        self.verdicts = list(verdicts) or [True]
+        self.calls = 0
+
+    def __call__(self, cfg: Any, capability: str) -> bool:
+        assert capability == "input_files"
+        self.calls += 1
+        return self.verdicts[min(self.calls - 1, len(self.verdicts) - 1)]
+
+
+def make_deps(
+    tmp_path,
+    ops: RecordingChannelOps,
+    *,
+    result: dict[str, Any] | None = None,
+    history: bool = True,
+    probe=None,
+    fetch_prior=None,
+    park=None,
+) -> PipelineDeps:
+    kwargs: dict[str, Any] = {
+        "cfg": CoreConfig(),
+        "ops": ops,
+        "dedup": MarkingDedup(str(tmp_path / "dedup.json"), ops),
+        "dispatcher": StubDispatcher(ops, result=result),
+        "history": MarkingHistory(str(tmp_path / "history.json"), ops) if history else None,
+        "probe_capability": probe if probe is not None else CountingProbe(True),
+        "fetch_prior_artifact": (
+            fetch_prior if fetch_prior is not None else lambda cfg, rid, desc, mb: None
+        ),
+    }
+    if park is not None:
+        kwargs["park"] = park
+    return PipelineDeps(**kwargs)
+
+
+# --- ignore / duplicate -------------------------------------------------------------
+
+
+def test_unparseable_event_is_ignored_and_never_claims(tmp_path):
+    ops = RecordingChannelOps()  # parse_result=None -> ignore
+    deps = make_deps(tmp_path, ops)
+
+    assert handle_event({"type": "MEMBERSHIP"}, deps) == "ignored"
+
+    assert ops.names == ["parse_event"]  # no claim, no ack, no dispatch, nothing
+    assert deps.dedup.get(MSG) is None
+
+
+def test_duplicate_delivery_returns_duplicate_and_fires_nothing(tmp_path):
+    ops = RecordingChannelOps(parse_result=make_event())
+    deps = make_deps(tmp_path, ops)
+    assert handle_event({}, deps) == "handled"
+    entry_before = deps.dedup.get(MSG)
+    first_pass = len(ops.names)
+
+    assert handle_event({}, deps) == "duplicate"
+
+    # The redelivery paid for the parse and the losing claim, nothing else.
+    assert ops.names[first_pass:] == ["parse_event", "claim"]
+    assert len(deps.dispatcher.calls) == 1
+    assert ops.count("post_ack") == 1
+    assert ops.count("resolve_reply_context") == 1
+    assert deps.dedup.get(MSG) == entry_before
+
+
+# --- claim / ack / dispatch ordering ------------------------------------------------
+
+
+def test_claim_precedes_dispatch(tmp_path):
+    ops = RecordingChannelOps(parse_result=make_event())
+    deps = make_deps(tmp_path, ops)
+
+    handle_event({}, deps)
+
+    ops.assert_never_before("dispatch", "claim")
+
+
+def test_ack_precedes_dispatch(tmp_path):
+    ops = RecordingChannelOps(parse_result=make_event())
+    deps = make_deps(tmp_path, ops)
+
+    handle_event({}, deps)
+
+    ops.assert_never_before("post_ack", "claim")
+    ops.assert_never_before("dispatch", "post_ack")
+
+
+def test_ack_precedes_reply_context(tmp_path):
+    # The ack exists to eliminate latency: resolve_reply_context may cost the
+    # adapter network round-trips, so the user's "on it" signal must never wait
+    # on it. Strict check — no resolve may occur before the first ack.
+    reply = ReplyContext(reply_to={"sender": "Sam", "text": "the original question"})
+    ops = RecordingChannelOps(parse_result=make_event(), reply_context=reply)
+    deps = make_deps(tmp_path, ops)
+
+    handle_event({}, deps)
+
+    ops.assert_never_before("resolve_reply_context", "post_ack")
+    assert ops.count("post_ack") == 1
+    assert ops.count("resolve_reply_context") == 1
+
+
+def test_claim_persists_full_meta_before_anything_fires(tmp_path):
+    ops = RecordingChannelOps(parse_result=make_event())
+    deps = make_deps(tmp_path, ops)
+
+    handle_event({}, deps)
+
+    # The ack — the very first thing fired — already sees the fully persisted claim:
+    # first-class fields AND the adapter's claim_meta, so a crash at any later point
+    # can re-dispatch and re-address from the store alone.
+    ack_entry = ops.of("post_ack")[0]["entry"]
+    assert ack_entry["text"] == QUESTION
+    assert ack_entry["sender_id"] == "users/7"
+    assert ack_entry["sender_display"] == "Pat"
+    assert ack_entry["history_key"] == HISTORY_KEY
+    assert ack_entry["space"] == "spaces/AAA"
+    assert ack_entry["thread"] == "spaces/AAA/threads/T"
+    assert ack_entry["status"] == "pending"
+
+
+# --- reply context ------------------------------------------------------------------
+
+
+def test_reply_context_resolved_after_claim_and_persisted(tmp_path):
+    reply = ReplyContext(
+        reply_to={"sender": "Sam", "text": "the original question"},
+        meta={"quoted_attachments": [{"resource_name": "r1", "content_name": "q.png"}]},
+    )
+    ops = RecordingChannelOps(parse_result=make_event(), reply_context=reply)
+    deps = make_deps(tmp_path, ops)
+
+    handle_event({}, deps)
+
+    # After the claim (duplicates never pay for it), before the dispatch.
+    ops.assert_order("claim", "post_ack", "resolve_reply_context", "dispatch")
+    # Persisted for every re-dispatch path: base reply_to plus the reply meta.
+    entry = deps.dedup.get(MSG)
+    assert entry["reply_to"] == {"sender": "Sam", "text": "the original question"}
+    assert entry["quoted_attachments"] == [{"resource_name": "r1", "content_name": "q.png"}]
+    # Shipped with the dispatch.
+    extra = deps.dispatcher.calls[0]["extra"]
+    assert extra["reply_to"] == {"sender": "Sam", "text": "the original question"}
+    # download_inputs ran off the REFRESHED entry, so it can fetch the quoted refs.
+    assert ops.of("download_inputs")[0]["entry"]["quoted_attachments"] == [
+        {"resource_name": "r1", "content_name": "q.png"}
+    ]
+
+
+# --- history in the payload ---------------------------------------------------------
+
+
+def test_history_rides_the_payload(tmp_path):
+    ops = RecordingChannelOps(parse_result=make_event())
+    deps = make_deps(tmp_path, ops)
+    deps.history.append(HISTORY_KEY, "prior question", "prior answer", run_id="run-0")
+
+    handle_event({}, deps)
+
+    turns = deps.dispatcher.calls[0]["extra"]["conversation_so_far"]
+    assert [t["question"] for t in turns] == ["prior question"]
+    # And the settled exchange became the next turn.
+    assert [t["answer"] for t in deps.history.recent(HISTORY_KEY)] == [
+        "prior answer",
+        "The orbit is stable.",
+    ]
+
+
+def test_empty_history_key_skips_history_entirely(tmp_path):
+    ops = RecordingChannelOps(parse_result=make_event(history_key=""))
+    deps = make_deps(tmp_path, ops)
+
+    assert handle_event({}, deps) == "handled"
+
+    assert ops.count("history_recent") == 0
+    assert ops.count("history_append") == 0
+    assert deps.dispatcher.calls[0]["extra"] is None
+
+
+# --- terminal settle ----------------------------------------------------------------
+
+
+def test_settle_order_answer_then_files_then_history(tmp_path):
+    result = dict(
+        COMPLETED,
+        artifacts=[{"artifact_id": "art-1", "filename": "plot.png", "delivered_mime": "image/png"}],
+    )
+    ops = RecordingChannelOps(
+        parse_result=make_event(), file_urls={"art-1": "https://pub/art-1.png"}
+    )
+    deps = make_deps(tmp_path, ops, result=result)
+
+    assert handle_event({}, deps) == "handled"
+
+    # Strict "only ever after" checks: nothing history- or file-shaped may occur
+    # before the first successful post (greedy subsequence matching would miss a
+    # stray earlier occurrence).
+    ops.assert_never_before("history_append", "post_answer")
+    ops.assert_never_before("history_append", "deliver_files")
+    ops.assert_never_before("deliver_files", "post_answer")
+    entry = deps.dedup.get(MSG)
+    assert entry["status"] == "completed"
+    assert entry["run_id"] == "run-1"
+    # The deliver_files return was stamped onto this turn's OUTPUT descriptor.
+    (turn,) = deps.history.recent(HISTORY_KEY)
+    assert turn["artifacts"] == [
+        {
+            "entry_id": "art-1",
+            "filename": "plot.png",
+            "delivered_mime": "image/png",
+            "origin": "output",
+            "public_url": "https://pub/art-1.png",
+        }
+    ]
+
+
+def test_settle_survives_a_raising_file_delivery(tmp_path):
+    """``deliver_files`` never raises by contract, but the answer has already landed: a
+    misbehaving adapter must not cost the terminal mark or the history turn — the same
+    guarantee the drain and reconcile delivery paths give."""
+    ops = RecordingChannelOps(parse_result=make_event())
+    ops.fail_next("deliver_files", RuntimeError("upload exploded"))
+    deps = make_deps(tmp_path, ops)
+
+    assert handle_event({}, deps) == "handled"
+
+    assert deps.dedup.get(MSG)["status"] == "completed"
+    assert [turn["answer"] for turn in deps.history.recent(HISTORY_KEY)] == [
+        COMPLETED["text_output"]
+    ]
+
+
+def test_failed_post_answer_keeps_entry_queued_and_skips_history(tmp_path):
+    ops = RecordingChannelOps(parse_result=make_event())
+    ops.fail_next("post_answer", RuntimeError("channel 500"))
+    deps = make_deps(tmp_path, ops)
+
+    assert handle_event({}, deps) == "handled"
+
+    # No terminal mark, no file delivery, no history of any kind.
+    assert ops.count("deliver_files") == 0
+    assert ops.count("history_append") == 0
+    assert ops.count("history_append_failed") == 0
+    assert deps.history.recent(HISTORY_KEY) == []
+    # The entry stays QUEUED with its run id intact, so the drain's re-attach path
+    # re-delivers the already-computed answer next cycle instead of dropping it.
+    entry = deps.dedup.get(MSG)
+    assert entry["status"] == "queued"
+    assert entry["run_id"] == "run-1"
+    assert entry["queued_at"] > 0
+    assert entry["first_queued_at"] > 0
+
+
+def test_error_result_posts_wording_and_appends_failed_marker(tmp_path):
+    result = {"status": "error", "failure_class": "fatal", "run_id": "run-1"}
+    ops = RecordingChannelOps(parse_result=make_event())
+    deps = make_deps(tmp_path, ops, result=result)
+
+    assert handle_event({}, deps) == "handled"
+
+    # Non-retryable: the channel posts its error wording (post_answer), the entry is
+    # terminal, and the QUESTION is kept with the failed-turn marker — the raw error
+    # text is never replayed into history.
+    assert ops.count("post_answer") == 1
+    assert ops.count("post_queued") == 0
+    assert deps.dedup.get(MSG)["status"] == "error"
+    assert ops.of("history_append_failed") == [{"key": HISTORY_KEY, "question": QUESTION}]
+
+
+# --- retryable failures park --------------------------------------------------------
+
+RETRYABLE = {
+    "status": "error",
+    "failure_class": "infrastructure",
+    "num_tool_calls": 0,
+    "run_id": "run-1",
+}
+
+
+def test_retryable_failure_parks_via_real_retry_queue(tmp_path):
+    ops = RecordingChannelOps(parse_result=make_event())
+    deps = make_deps(tmp_path, ops, result=RETRYABLE)  # default park = retry_queue.park
+
+    assert handle_event({}, deps) == "handled"
+
+    # Parked, not settled: queued notice instead of an answer, no history.
+    assert ops.count("post_answer") == 0
+    assert ops.count("post_queued") == 1
+    assert ops.count("history_append") == 0
+    assert deps.history.recent(HISTORY_KEY) == []
+    entry = deps.dedup.get(MSG)
+    assert entry["status"] == "queued"
+    assert entry["attempts"] == 0
+    assert entry["failure_class"] == "infrastructure"
+    assert entry["queued_at"] > 0
+
+
+def test_injected_park_seam_receives_persisted_entry_and_result(tmp_path):
+    parked: list[tuple[str, str, str]] = []
+
+    def park(ops_, dedup_, message_id, entry, result):
+        parked.append((message_id, entry["text"], result["failure_class"]))
+
+    ops = RecordingChannelOps(parse_result=make_event())
+    deps = make_deps(tmp_path, ops, result=RETRYABLE, park=park)
+
+    assert handle_event({}, deps) == "handled"
+
+    assert parked == [(MSG, QUESTION, "infrastructure")]
+    assert ops.count("post_answer") == 0
+
+
+# --- the single memoized capability probe -------------------------------------------
+
+
+def test_capability_probe_runs_once_for_all_three_consumers(tmp_path):
+    # All three probe consumers in one dispatch: the message's own attachment, a
+    # quoted-message attachment (both via download_inputs), and a prior-image
+    # re-injection from history.
+    inputs = InputDownload(files=(make_file("own.png", b"OWN"), make_file("quoted.png", b"QUOTED")))
+    ops = RecordingChannelOps(parse_result=make_event(), inputs=inputs)
+    probe = CountingProbe(True)
+    deps = make_deps(tmp_path, ops, probe=probe, fetch_prior=lambda cfg, rid, d, mb: b"PRIOR")
+    deps.history.append(
+        HISTORY_KEY,
+        "plot it",
+        "done",
+        run_id="run-0",
+        artifacts=[
+            {
+                "entry_id": "art-0",
+                "filename": "prior.png",
+                "delivered_mime": "image/png",
+                "origin": "output",
+            }
+        ],
+    )
+
+    handle_event({}, deps)
+
+    assert probe.calls == 1
+    files = deps.dispatcher.calls[0]["extra"]["input_files"]
+    # Own file first, quoted after (list order from download_inputs), re-injected
+    # prior last — fresh files ingest=True, replayed prior ingest=False.
+    assert [f["filename"] for f in files] == ["own.png", "quoted.png", "prior.png"]
+    assert [f["ingest"] for f in files] == [True, True, False]
+    assert files[2]["content_b64"] == b64(b"PRIOR")
+
+
+def test_probe_downgrade_observed_on_next_dispatch(tmp_path):
+    inputs = InputDownload(files=(make_file("own.png", b"OWN"),))
+    ops = RecordingChannelOps(parse_result=make_event(), inputs=inputs)
+    probe = CountingProbe(True, False)
+    deps = make_deps(tmp_path, ops, probe=probe, history=False)
+
+    handle_event({}, deps)
+    ops.parse_result = make_event(message_id=MSG2)
+    handle_event({}, deps)
+
+    # The memo is per-dispatch, never global: the second dispatch re-probed and
+    # observed the downgrade — no bytes shipped, an honest skip note instead.
+    assert probe.calls == 2
+    first, second = (call["extra"] for call in deps.dispatcher.calls)
+    assert [f["filename"] for f in first["input_files"]] == ["own.png"]
+    assert "input_files" not in second
+    assert second["skipped_attachments"] == [
+        {"filename": "own.png", "reason": SERVER_TOO_OLD_REASON}
+    ]
+
+
+def test_probe_is_lazy_when_nothing_would_ship(tmp_path):
+    # Skip notes alone ship without ever probing: there are no bytes to gate.
+    inputs = InputDownload(skipped=({"filename": "big.bin", "reason": "too large"},))
+    ops = RecordingChannelOps(parse_result=make_event(), inputs=inputs)
+    probe = CountingProbe(True)
+    deps = make_deps(tmp_path, ops, probe=probe, history=False)
+
+    handle_event({}, deps)
+
+    assert probe.calls == 0
+    assert deps.dispatcher.calls[0]["extra"] == {
+        "skipped_attachments": [{"filename": "big.bin", "reason": "too large"}]
+    }
+
+
+# --- the no-op InputDownload invariant ----------------------------------------------
+
+
+def test_noop_input_download_leaves_payload_byte_identical(tmp_path):
+    # A text-only message: the adapter returns the empty InputDownload(). The
+    # dispatch payload must be byte-identical to the no-attachment path — the
+    # dispatcher is called with NO extra at all, and the probe never fires.
+    ops = RecordingChannelOps(parse_result=make_event())  # inputs = InputDownload()
+    probe = CountingProbe(True)
+    deps = make_deps(tmp_path, ops, probe=probe, history=False)
+
+    assert handle_event({}, deps) == "handled"
+
+    assert ops.count("download_inputs") == 1
+    assert deps.dispatcher.calls[0] == {"question": QUESTION, "extra": None}
+    assert probe.calls == 0
+
+
+# --- the engine-owned fresh-file budget ---------------------------------------------
+
+
+def test_fresh_budget_count_cap_in_list_order(tmp_path, monkeypatch):
+    monkeypatch.setattr(pipeline, "MAX_FILES", 2)
+    inputs = InputDownload(
+        files=(make_file("f1", b"aa"), make_file("f2", b"b"), make_file("f3", b"cc"))
+    )
+    ops = RecordingChannelOps(parse_result=make_event(), inputs=inputs)
+    deps = make_deps(tmp_path, ops, history=False)
+
+    handle_event({}, deps)
+
+    extra = deps.dispatcher.calls[0]["extra"]
+    assert [f["filename"] for f in extra["input_files"]] == ["f1", "f2"]
+    assert extra["skipped_attachments"] == [{"filename": "f3", "reason": TOO_MANY_FILES_REASON}]
+
+
+def test_fresh_budget_bytes_cap_can_decline_everything(tmp_path, monkeypatch):
+    monkeypatch.setattr(pipeline, "MAX_TOTAL_BYTES", 1)
+    inputs = InputDownload(files=(make_file("f1", b"too-big"),))
+    ops = RecordingChannelOps(parse_result=make_event(), inputs=inputs)
+    probe = CountingProbe(True)
+    deps = make_deps(tmp_path, ops, probe=probe, history=False)
+
+    handle_event({}, deps)
+
+    # Everything declined -> skips-only payload, and no probe (nothing to send).
+    assert probe.calls == 0
+    assert deps.dispatcher.calls[0]["extra"] == {
+        "skipped_attachments": [{"filename": "f1", "reason": OVER_BUDGET_REASON}]
+    }
+
+
+# --- quoted-bucket provenance routing -----------------------------------------------
+
+
+def make_reply(**meta: Any) -> ReplyContext:
+    return ReplyContext(reply_to={"sender": "Sam", "text": "the original question"}, **meta)
+
+
+def test_quoted_files_deliver_into_reply_to_provenance(tmp_path):
+    inputs = InputDownload(
+        files=(make_file("own.png", b"OWN"),),
+        quoted_files=(make_file("quoted.png", b"QUOTED"),),
+    )
+    ops = RecordingChannelOps(parse_result=make_event(), reply_context=make_reply(), inputs=inputs)
+    deps = make_deps(tmp_path, ops, history=False)
+
+    handle_event({}, deps)
+
+    extra = deps.dispatcher.calls[0]["extra"]
+    # Bytes ride input_files own-first; provenance splits: own top-level, quoted
+    # inside reply_to (delivered filenames), exactly the worker payload contract.
+    assert [f["filename"] for f in extra["input_files"]] == ["own.png", "quoted.png"]
+    assert extra["skipped_attachments"] == []
+    assert extra["reply_to"]["attachments"] == ["quoted.png"]
+    assert "skipped_attachments" not in extra["reply_to"]
+
+
+def test_quoted_file_trimmed_by_budget_skips_into_reply_to_bucket(tmp_path, monkeypatch):
+    # The shared budget runs across files THEN quoted_files: with room for one file,
+    # the own attachment wins and the quoted one is trimmed — and its skip note lands
+    # in reply_to["skipped_attachments"], NOT the top-level own bucket.
+    monkeypatch.setattr(pipeline, "MAX_FILES", 1)
+    inputs = InputDownload(
+        files=(make_file("own.png", b"OWN"),),
+        quoted_files=(make_file("quoted.png", b"QUOTED"),),
+    )
+    ops = RecordingChannelOps(parse_result=make_event(), reply_context=make_reply(), inputs=inputs)
+    deps = make_deps(tmp_path, ops, history=False)
+
+    handle_event({}, deps)
+
+    extra = deps.dispatcher.calls[0]["extra"]
+    assert [f["filename"] for f in extra["input_files"]] == ["own.png"]
+    assert extra["skipped_attachments"] == []
+    assert extra["reply_to"]["skipped_attachments"] == [
+        {"filename": "quoted.png", "reason": TOO_MANY_FILES_REASON}
+    ]
+    assert "attachments" not in extra["reply_to"]
+    # The persisted reply_to is untouched — provenance notes ride the payload only.
+    assert deps.dedup.get(MSG)["reply_to"] == {"sender": "Sam", "text": "the original question"}
+
+
+def test_budget_bytes_shared_across_own_then_quoted(tmp_path, monkeypatch):
+    # The byte cap is one budget over both buckets, consumed in own-then-quoted
+    # order: own fits, the quoted file would bust the remainder and is trimmed into
+    # its own bucket with the over-budget reason.
+    monkeypatch.setattr(pipeline, "MAX_TOTAL_BYTES", 4)
+    inputs = InputDownload(
+        files=(make_file("own.png", b"abc"),),
+        quoted_files=(make_file("quoted.png", b"de"),),
+    )
+    ops = RecordingChannelOps(parse_result=make_event(), reply_context=make_reply(), inputs=inputs)
+    deps = make_deps(tmp_path, ops, history=False)
+
+    handle_event({}, deps)
+
+    extra = deps.dispatcher.calls[0]["extra"]
+    assert [f["filename"] for f in extra["input_files"]] == ["own.png"]
+    assert extra["reply_to"]["skipped_attachments"] == [
+        {"filename": "quoted.png", "reason": OVER_BUDGET_REASON}
+    ]
+
+
+def test_non_capable_pair_routes_skips_to_matching_buckets(tmp_path):
+    # Non-capable pair: no bytes ship anywhere, and each undeliverable file's
+    # SERVER_TOO_OLD note joins the adapter's own skips in the MATCHING bucket.
+    inputs = InputDownload(
+        files=(make_file("own.png", b"OWN"),),
+        skipped=({"filename": "own-huge.bin", "reason": "too large"},),
+        quoted_files=(make_file("quoted.png", b"QUOTED"),),
+        quoted_skipped=({"filename": "quoted-drive.doc", "reason": "drive file"},),
+    )
+    ops = RecordingChannelOps(parse_result=make_event(), reply_context=make_reply(), inputs=inputs)
+    deps = make_deps(tmp_path, ops, probe=CountingProbe(False), history=False)
+
+    handle_event({}, deps)
+
+    extra = deps.dispatcher.calls[0]["extra"]
+    assert "input_files" not in extra
+    assert extra["skipped_attachments"] == [
+        {"filename": "own-huge.bin", "reason": "too large"},
+        {"filename": "own.png", "reason": SERVER_TOO_OLD_REASON},
+    ]
+    assert extra["reply_to"]["skipped_attachments"] == [
+        {"filename": "quoted-drive.doc", "reason": "drive file"},
+        {"filename": "quoted.png", "reason": SERVER_TOO_OLD_REASON},
+    ]
+    assert "attachments" not in extra["reply_to"]
+
+
+def test_quoted_skips_alone_ride_reply_to_without_probing(tmp_path):
+    # Skip notes alone (both buckets) ship without probing: nothing to send.
+    inputs = InputDownload(
+        skipped=({"filename": "own.bin", "reason": "too large"},),
+        quoted_skipped=({"filename": "quoted.bin", "reason": "too large"},),
+    )
+    ops = RecordingChannelOps(parse_result=make_event(), reply_context=make_reply(), inputs=inputs)
+    probe = CountingProbe(True)
+    deps = make_deps(tmp_path, ops, probe=probe, history=False)
+
+    handle_event({}, deps)
+
+    assert probe.calls == 0
+    extra = deps.dispatcher.calls[0]["extra"]
+    assert extra["skipped_attachments"] == [{"filename": "own.bin", "reason": "too large"}]
+    assert extra["reply_to"]["skipped_attachments"] == [
+        {"filename": "quoted.bin", "reason": "too large"}
+    ]
+
+
+def test_quoted_bucket_without_reply_context_is_dropped_with_warning(tmp_path, caplog):
+    # Quoted files with no resolved reply are an adapter contract violation: there is
+    # no reply_to to fold their provenance into, so the bucket is dropped loudly and
+    # the dispatch proceeds.
+    inputs = InputDownload(quoted_files=(make_file("quoted.png", b"QUOTED"),))
+    ops = RecordingChannelOps(parse_result=make_event(), inputs=inputs)  # no reply_context
+    deps = make_deps(tmp_path, ops, history=False)
+
+    with caplog.at_level(logging.WARNING, logger="osprey.bridges.core.pipeline"):
+        assert handle_event({}, deps) == "handled"
+
+    assert deps.dispatcher.calls[0]["extra"] is None
+    assert any("quoted" in rec.message for rec in caplog.records)
+
+
+# --- reserved-key collision detection -----------------------------------------------
+
+
+def test_claim_meta_reserved_key_collision_fails_before_anything_fires(tmp_path):
+    # A Talk adapter stamping claim_meta["reply_to"] would have it clobbered by the
+    # engine's persisted reply context — the collision must fail fast, before the
+    # claim, so nothing is half-processed.
+    event = make_event(claim_meta={"space": "spaces/AAA", "reply_to": {"sender": "x"}})
+    ops = RecordingChannelOps(parse_result=event)
+    deps = make_deps(tmp_path, ops)
+
+    with pytest.raises(ValueError, match="reply_to"):
+        handle_event({}, deps)
+
+    assert ops.names == ["parse_event"]  # no claim, no ack, no dispatch
+    assert deps.dedup.get(MSG) is None
+
+
+def test_reply_meta_reserved_key_collision_is_stripped_loudly(tmp_path, caplog):
+    # The claim has already committed when reply meta arrives, so a colliding key
+    # cannot fail the message — it is stripped (the drain's bookkeeping stays
+    # uncorrupted) and logged as an error, while legitimate meta persists.
+    reply = ReplyContext(
+        reply_to={"sender": "Sam", "text": "the original question"},
+        meta={"attempts": 99, "quoted_attachments": [{"resource_name": "r1"}]},
+    )
+    ops = RecordingChannelOps(parse_result=make_event(), reply_context=reply)
+    deps = make_deps(tmp_path, ops)
+
+    with caplog.at_level(logging.ERROR, logger="osprey.bridges.core.pipeline"):
+        assert handle_event({}, deps) == "handled"
+
+    entry = deps.dedup.get(MSG)
+    assert "attempts" not in entry  # the drain give-up ceiling field survived intact
+    assert entry["quoted_attachments"] == [{"resource_name": "r1"}]
+    assert any("attempts" in rec.getMessage() for rec in caplog.records)
+
+
+# --- prior-image re-injection edge cases --------------------------------------------
+
+
+def _seed_prior_image(deps: PipelineDeps) -> None:
+    deps.history.append(
+        HISTORY_KEY,
+        "plot it",
+        "done",
+        run_id="run-0",
+        artifacts=[
+            {
+                "entry_id": "art-0",
+                "filename": "prior.png",
+                "delivered_mime": "image/png",
+                "origin": "output",
+            }
+        ],
+    )
+
+
+def test_unfetchable_prior_flagged_expired_without_store_pollution(tmp_path):
+    ops = RecordingChannelOps(parse_result=make_event())
+    deps = make_deps(tmp_path, ops, fetch_prior=lambda cfg, rid, d, mb: None)
+    _seed_prior_image(deps)
+
+    assert handle_event({}, deps) == "handled"
+
+    extra = deps.dispatcher.calls[0]["extra"]
+    assert "input_files" not in extra
+    # The outgoing payload's descriptor carries the note...
+    (turn,) = extra["conversation_so_far"]
+    assert turn["artifacts"][0]["note"] == EXPIRED_NOTE
+    # ...but the persisted history copy was never mutated (the settled exchange
+    # appended a second turn behind it; the seeded turn is the first).
+    stored = HistoryStore(str(tmp_path / "history.json")).recent(HISTORY_KEY)[0]
+    assert "note" not in stored["artifacts"][0]
+
+
+def test_reinjected_prior_dedupes_against_own_attachment(tmp_path):
+    # The user re-attached the very plot they are asking about: the prior fetch
+    # returns identical bytes, which must not ship twice.
+    inputs = InputDownload(files=(make_file("own-copy.png", b"SAME-BYTES"),))
+    ops = RecordingChannelOps(parse_result=make_event(), inputs=inputs)
+    deps = make_deps(tmp_path, ops, fetch_prior=lambda cfg, rid, d, mb: b"SAME-BYTES")
+    _seed_prior_image(deps)
+
+    handle_event({}, deps)
+
+    files = deps.dispatcher.calls[0]["extra"]["input_files"]
+    assert [f["filename"] for f in files] == ["own-copy.png"]

--- a/tests/bridges/test_ports.py
+++ b/tests/bridges/test_ports.py
@@ -1,0 +1,291 @@
+"""The ``ChannelOps`` seam: protocol conformance of the recording double, and the
+recording/ordering ergonomics downstream suites (drain, pipeline, retry_queue,
+reconcile) assert against."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import pytest
+
+from osprey.bridges.core.ports import ChannelOps, InboundEvent, InputDownload, ReplyContext
+from tests.bridges.conftest import RecordedCall, RecordingChannelOps
+
+# Every protocol member, in the canonical live-path call order (where one exists):
+# claim -> ack -> reply context -> dispatch. The ack is the FIRST thing after a won
+# claim — resolve_reply_context may cost the adapter network round-trips and must
+# never delay the user's "on it" signal.
+PROTOCOL_MEMBERS = [
+    "parse_event",
+    "post_ack",
+    "resolve_reply_context",
+    "download_inputs",
+    "post_answer",
+    "deliver_files",
+    "post_queued",
+    "post_giveup",
+    "post_superseded",
+    "coalesce_key",
+]
+
+
+def _event(**overrides: Any) -> InboundEvent:
+    fields: dict[str, Any] = {
+        "message_id": "room1:42",
+        "text": "what is the orbit doing?",
+        "sender_id": "users/7",
+        "sender_display": "Alice",
+        "history_key": "spaces/AAA",
+    }
+    fields.update(overrides)
+    return InboundEvent(**fields)
+
+
+# --- protocol conformance -----------------------------------------------------
+
+
+def test_double_satisfies_channel_ops_protocol():
+    assert isinstance(RecordingChannelOps(), ChannelOps)
+
+
+def test_every_protocol_member_is_callable_on_the_double():
+    ops = RecordingChannelOps()
+    for name in PROTOCOL_MEMBERS:
+        assert callable(getattr(ops, name)), name
+
+
+def test_protocol_is_structural_not_inheritance():
+    """A from-scratch class with the right members conforms — adapters never need to
+    subclass anything from the core package."""
+
+    class MinimalOps:
+        def parse_event(self, event: Any) -> InboundEvent | None:
+            return None
+
+        def resolve_reply_context(self, event: InboundEvent) -> ReplyContext | None:
+            return None
+
+        def post_ack(self, entry: Mapping[str, Any]) -> None:
+            pass
+
+        def download_inputs(self, entry: Mapping[str, Any]) -> InputDownload:
+            return InputDownload()
+
+        def post_answer(self, entry: Mapping[str, Any], result: Mapping[str, Any]) -> None:
+            pass
+
+        def deliver_files(
+            self, entry: Mapping[str, Any], result: Mapping[str, Any]
+        ) -> Mapping[str, str]:
+            return {}
+
+        def post_queued(self, entry: Mapping[str, Any], result: Mapping[str, Any]) -> None:
+            pass
+
+        def post_giveup(self, entry: Mapping[str, Any]) -> None:
+            pass
+
+        def post_superseded(self, entry: Mapping[str, Any]) -> None:
+            pass
+
+        def coalesce_key(self, entry: Mapping[str, Any]) -> str | Sequence[str]:
+            return ""
+
+    assert isinstance(MinimalOps(), ChannelOps)
+
+
+def test_incomplete_class_does_not_satisfy_protocol():
+    class NotOps:
+        def parse_event(self, event: Any) -> None:
+            return None
+
+    assert not isinstance(NotOps(), ChannelOps)
+
+
+# --- parsed-event / payload types ---------------------------------------------
+
+
+def test_inbound_event_is_frozen_with_neutral_defaults():
+    event = _event()
+    assert event.claim_meta == {}
+    assert event.raw is None
+    with pytest.raises(AttributeError):
+        event.text = "mutated"  # type: ignore[misc]
+
+
+def test_inbound_event_carries_claim_meta_and_raw_opaquely():
+    wire = {"chat": {"messagePayload": {}}}
+    event = _event(claim_meta={"space": "spaces/AAA", "thread": "threads/T"}, raw=wire)
+    assert event.claim_meta["thread"] == "threads/T"
+    assert event.raw is wire
+
+
+def test_input_download_default_is_the_no_op():
+    empty = InputDownload()
+    assert empty.files == () and empty.skipped == ()
+    # The quoted bucket defaults empty too, so a channel with no quote mechanic
+    # (email, Talk without ``parent``) never touches the new fields.
+    assert empty.quoted_files == () and empty.quoted_skipped == ()
+
+
+def test_reply_context_defaults_to_empty_meta():
+    ctx = ReplyContext(reply_to={"sender": "Osprey", "text": "the orbit is stable"})
+    assert ctx.meta == {}
+
+
+# --- recording ----------------------------------------------------------------
+
+
+def test_records_protocol_calls_in_order_with_arguments():
+    ops = RecordingChannelOps()
+    entry = {"space": "spaces/AAA", "text": "q"}
+    result = {"status": "completed", "text_output": "a"}
+
+    ops.post_ack(entry)
+    ops.post_answer(entry, result)
+    ops.deliver_files(entry, result)
+
+    assert ops.names == ["post_ack", "post_answer", "deliver_files"]
+    assert ops.of("post_answer") == [{"entry": entry, "result": result}]
+    assert ops.calls[0] == RecordedCall("post_ack", {"entry": entry})
+
+
+def test_mark_interleaves_engine_events_into_the_timeline():
+    """Engine-side steps (claim, dispatch, history) marked by store/dispatcher stubs
+    land in the same timeline, so cross-boundary ordering is one assertion."""
+    ops = RecordingChannelOps()
+    entry = {"text": "q"}
+
+    ops.mark("claim", message_id="m1")
+    ops.post_ack(entry)
+    ops.mark("dispatch", message_id="m1")
+    ops.post_answer(entry, {"status": "completed"})
+    ops.mark("history_append", key="spaces/AAA")
+
+    ops.assert_order("claim", "post_ack", "dispatch")
+    ops.assert_order("post_answer", "history_append")
+    assert ops.of("claim") == [{"message_id": "m1"}]
+
+
+def test_assert_order_fails_on_violation_and_on_missing_op():
+    ops = RecordingChannelOps()
+    ops.post_answer({}, {})
+    ops.post_ack({})
+
+    with pytest.raises(AssertionError, match="post_answer"):
+        ops.assert_order("post_ack", "post_answer")
+    with pytest.raises(AssertionError, match="post_giveup"):
+        ops.assert_order("post_giveup")
+
+
+def test_assert_order_matches_repeated_ops_as_a_subsequence():
+    """A failed first attempt does not shadow the retry: greedy matching walks past
+    it, so 'answer posted, then history' holds across at-least-once redelivery."""
+    ops = RecordingChannelOps()
+    ops.post_answer({}, {})  # attempt 1 (failed at the transport, say)
+    ops.post_answer({}, {})  # retry succeeds
+    ops.mark("history_append")
+
+    ops.assert_order("post_answer", "post_answer", "history_append")
+    with pytest.raises(AssertionError):
+        ops.assert_order("post_answer", "post_answer", "post_answer")
+
+
+def test_assert_never_before_catches_what_greedy_subsequence_misses():
+    """The timeline ['history_append', 'post_answer', 'history_append'] — an engine
+    bug appending history BEFORE any successful post — passes assert_order (greedy
+    subsequence matching walks past the stray first append) but must fail the strict
+    never-before check. This is the invariant the settle phase exists to protect."""
+    ops = RecordingChannelOps()
+    ops.mark("history_append")
+    ops.post_answer({}, {})
+    ops.mark("history_append")
+
+    ops.assert_order("post_answer", "history_append")  # the false pass, demonstrated
+    with pytest.raises(AssertionError, match="before the first"):
+        ops.assert_never_before("history_append", "post_answer")
+
+
+def test_assert_never_before_passes_clean_timelines_and_requires_the_anchor():
+    ops = RecordingChannelOps()
+    ops.post_answer({}, {})
+    ops.mark("history_append")
+
+    ops.assert_never_before("history_append", "post_answer")
+    # An op that never occurs at all trivially satisfies "never before".
+    ops.assert_never_before("post_giveup", "post_answer")
+    # But the anchor MUST occur — an invariant about an event that never happened
+    # would silently assert nothing.
+    with pytest.raises(AssertionError, match="deliver_files"):
+        ops.assert_never_before("history_append", "deliver_files")
+
+
+def test_count_and_of_track_repeat_calls():
+    ops = RecordingChannelOps()
+    ops.post_superseded({"space": "s1"})
+    ops.post_superseded({"space": "s2"})
+    assert ops.count("post_superseded") == 2
+    assert [d["entry"]["space"] for d in ops.of("post_superseded")] == ["s1", "s2"]
+
+
+# --- canned returns & failure injection ---------------------------------------
+
+
+def test_configured_returns_flow_through():
+    event = _event()
+    ctx = ReplyContext(reply_to={"sender": "Bob", "text": "earlier"})
+    inputs = InputDownload(files=({"filename": "a.png", "content_b64": "aGk="},))
+    ops = RecordingChannelOps(
+        parse_result=event,
+        reply_context=ctx,
+        inputs=inputs,
+        file_urls={"art-1": "https://files.example/a.png"},
+        coalesce=["spaces/AAA", "users/7"],
+    )
+
+    assert ops.parse_event({"raw": True}) is event
+    assert ops.resolve_reply_context(event) is ctx
+    assert ops.download_inputs({"attachments": []}) is inputs
+    assert ops.deliver_files({}, {}) == {"art-1": "https://files.example/a.png"}
+    assert ops.coalesce_key({}) == ["spaces/AAA", "users/7"]
+
+
+def test_default_double_ignores_events_and_never_coalesces():
+    ops = RecordingChannelOps()
+    assert ops.parse_event({"anything": 1}) is None
+    assert ops.resolve_reply_context(_event()) is None
+    assert ops.download_inputs({}) == InputDownload()
+    assert ops.deliver_files({}, {}) == {}
+    assert ops.coalesce_key({}) == ""
+
+
+def test_fail_next_records_the_call_then_raises_then_recovers():
+    """Drain semantics in miniature: the failed post is visible in the timeline, and
+    the NEXT call succeeds — 'first deliver fails, second cycle re-delivers'."""
+    ops = RecordingChannelOps()
+    ops.fail_next("post_answer", RuntimeError("chat 502"))
+
+    with pytest.raises(RuntimeError, match="chat 502"):
+        ops.post_answer({"space": "s"}, {"status": "completed"})
+    ops.post_answer({"space": "s"}, {"status": "completed"})  # recovered
+
+    assert ops.count("post_answer") == 2
+
+
+def test_fail_next_queues_fifo_per_op():
+    ops = RecordingChannelOps()
+    ops.fail_next("post_giveup", RuntimeError("first"))
+    ops.fail_next("post_giveup", RuntimeError("second"))
+
+    with pytest.raises(RuntimeError, match="first"):
+        ops.post_giveup({})
+    with pytest.raises(RuntimeError, match="second"):
+        ops.post_giveup({})
+    ops.post_giveup({})
+    assert ops.count("post_giveup") == 3
+
+
+def test_channel_ops_fixture_provides_a_fresh_default_double(channel_ops):
+    assert isinstance(channel_ops, RecordingChannelOps)
+    assert channel_ops.calls == []

--- a/tests/bridges/test_reconcile.py
+++ b/tests/bridges/test_reconcile.py
@@ -1,0 +1,477 @@
+"""Startup crash-recovery suite.
+
+The scenarios are written as *crashes*: a real :class:`DedupStore` on ``tmp_path`` is
+left in exactly the state a process death would leave it in, then
+:func:`reconcile_inflight` runs against it and the store's own contents are the
+assertion. The dispatcher is a recording fake — the point of most of these tests is
+which dispatcher calls did NOT happen.
+
+The load-bearing one is
+:func:`test_reattach_polls_existing_run_and_never_dispatches`: an entry that already
+carries a run_id must be POLLED, never re-fired, because that run may already have
+reached hardware.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from osprey.bridges.core.dedup import DedupStore
+from osprey.bridges.core.reconcile import ReconcileReport, deliver_terminal, reconcile_inflight
+
+from .conftest import RecordingChannelOps
+
+
+class FakeDispatcher:
+    """A ``DispatchClient`` stand-in recording every call it receives.
+
+    ``poll_result`` / ``run_result`` are the terminal bodies handed back; ``fire`` is
+    present (and counted) purely so a test can prove it was never reached.
+    """
+
+    def __init__(
+        self,
+        *,
+        poll_result: dict[str, Any] | None = None,
+        run_result: dict[str, Any] | None = None,
+        run_id: str = "run-new",
+    ) -> None:
+        self.poll_result = poll_result or {"status": "completed", "text_output": "polled"}
+        self.run_result = run_result or {"status": "completed", "text_output": "ran"}
+        self.run_id = run_id
+        self.polled: list[str] = []
+        self.ran: list[tuple[str, dict[str, Any] | None]] = []
+        self.fired: list[str] = []
+        self.raise_on_poll: BaseException | None = None
+        self.raise_on_run: BaseException | None = None
+
+    # -- DispatchClient surface ----------------------------------------------
+
+    def poll_worker(self, run_id: str, deadline: float | None = None) -> dict[str, Any]:
+        self.polled.append(run_id)
+        if self.raise_on_poll is not None:
+            raise self.raise_on_poll
+        return dict(self.poll_result, run_id=run_id)
+
+    def run(self, question, extra=None, *, on_run_id=None) -> dict[str, Any]:
+        self.ran.append((question, extra))
+        if self.raise_on_run is not None:
+            raise self.raise_on_run
+        if on_run_id is not None:
+            on_run_id(self.run_id)
+        return dict(self.run_result, run_id=self.run_id)
+
+    def fire(self, question: str, extra: dict[str, Any] | None = None) -> str:
+        self.fired.append(question)
+        return "dispatch-1"
+
+    @property
+    def dispatch_calls(self) -> int:
+        """Every call that would START a new run — the number that must stay 0 on the
+        re-attach path."""
+        return len(self.ran) + len(self.fired)
+
+
+@dataclass
+class Deps:
+    """A ``ReconcileDeps``-shaped bundle (structural, not a subclass)."""
+
+    dedup: DedupStore
+    dispatcher: FakeDispatcher
+    ops: RecordingChannelOps = field(default_factory=RecordingChannelOps)
+
+
+@pytest.fixture
+def store(tmp_path) -> DedupStore:
+    return DedupStore(str(tmp_path / "dedup.json"))
+
+
+def _crashed_mid_poll(store: DedupStore, message_id: str = "m1", run_id: str = "run-42") -> None:
+    """Leave the store as a crash between the dispatcher handshake and the answer:
+    claimed with its question, a run_id recorded, status still non-terminal."""
+    store.claim(message_id, text="how is the beam?", history_key="room-1")
+    store.record(message_id, run_id=run_id, status="in_flight")
+
+
+def _crashed_before_run_id(store: DedupStore, message_id: str = "m1") -> None:
+    """Leave the store as a crash after the claim but before any run existed."""
+    store.claim(message_id, text="how is the beam?", history_key="room-1")
+
+
+# --- re-attach: the case that must never re-dispatch --------------------------
+
+
+def test_reattach_polls_existing_run_and_never_dispatches(store):
+    """An entry carrying a run_id is polled to terminal and delivered with ZERO
+    additional dispatch calls.
+
+    This is the phase's crash-mid-run criterion. A run_id means a run was started and
+    may already have moved hardware; re-dispatching would duplicate those side effects.
+    Asserting only "the answer arrived" would pass even for a re-dispatch, so the
+    assertion that matters is the dispatch count.
+    """
+    _crashed_mid_poll(store, run_id="run-42")
+    deps = Deps(dedup=store, dispatcher=FakeDispatcher())
+
+    report = reconcile_inflight(deps)
+
+    assert deps.dispatcher.dispatch_calls == 0, "re-attach must not start a second run"
+    assert deps.dispatcher.ran == []
+    assert deps.dispatcher.fired == []
+    assert deps.dispatcher.polled == ["run-42"]
+    assert report == ReconcileReport(reattached=1)
+    assert deps.ops.count("post_answer") == 1
+    assert deps.ops.of("post_answer")[0]["result"]["text_output"] == "polled"
+    assert store.get("m1")["status"] == "completed"
+
+
+def test_reattach_delivers_files_after_the_answer(store):
+    _crashed_mid_poll(store)
+    deps = Deps(dedup=store, dispatcher=FakeDispatcher())
+
+    reconcile_inflight(deps)
+
+    deps.ops.assert_order("post_answer", "deliver_files")
+
+
+def test_reattach_marks_the_result_status_terminal(store):
+    _crashed_mid_poll(store)
+    deps = Deps(
+        dedup=store,
+        dispatcher=FakeDispatcher(poll_result={"status": "error", "error": "worker blew up"}),
+    )
+
+    reconcile_inflight(deps)
+
+    assert store.get("m1")["status"] == "error"
+
+
+def test_reattach_coerces_an_unknown_status_to_error(store):
+    """A worker body with a status outside the terminal set must still settle: leaving
+    it non-terminal would make the entry reconcilable forever."""
+    _crashed_mid_poll(store)
+    deps = Deps(dedup=store, dispatcher=FakeDispatcher(poll_result={"status": "weird"}))
+
+    reconcile_inflight(deps)
+
+    assert store.get("m1")["status"] == "error"
+
+
+# --- re-dispatch: no run was ever started -------------------------------------
+
+
+def test_redispatch_when_claimed_before_a_run_id_existed(store):
+    _crashed_before_run_id(store)
+    deps = Deps(dedup=store, dispatcher=FakeDispatcher())
+
+    report = reconcile_inflight(deps)
+
+    assert [q for q, _ in deps.dispatcher.ran] == ["how is the beam?"]
+    assert deps.dispatcher.polled == []
+    assert report == ReconcileReport(redispatched=1)
+    assert store.get("m1")["status"] == "completed"
+
+
+def test_redispatch_persists_the_new_run_id_before_the_poll(store):
+    """The re-dispatch installs the same crash-safety persister the live path uses, so
+    a crash during reconcile's own dispatch is re-attachable next startup rather than
+    dispatched a second time."""
+    seen: list[str | None] = []
+    _crashed_before_run_id(store)
+    dispatcher = FakeDispatcher(run_id="run-99")
+
+    def run(question, extra=None, *, on_run_id=None):
+        dispatcher.ran.append((question, extra))
+        on_run_id("run-99")
+        seen.append(store.get("m1")["run_id"])  # visible BEFORE the terminal result
+        return {"status": "completed", "text_output": "ran", "run_id": "run-99"}
+
+    dispatcher.run = run  # type: ignore[method-assign]
+    deps = Deps(dedup=store, dispatcher=dispatcher)
+
+    reconcile_inflight(deps)
+
+    assert seen == ["run-99"]
+    assert store.get("m1")["run_id"] == "run-99"
+
+
+def test_redispatch_without_a_builder_ships_the_question_alone(store):
+    _crashed_before_run_id(store)
+    deps = Deps(dedup=store, dispatcher=FakeDispatcher())
+
+    reconcile_inflight(deps)
+
+    assert deps.dispatcher.ran == [("how is the beam?", None)]
+
+
+def test_build_extra_seam_supplies_the_redispatch_context(store):
+    """The runtime injects the pipeline's context builder so a replayed question
+    carries the same conversation/attachment context a live dispatch would."""
+    _crashed_before_run_id(store)
+    deps = Deps(dedup=store, dispatcher=FakeDispatcher())
+    entries: list[str] = []
+
+    def build_extra(entry):
+        entries.append(entry["history_key"])
+        return {"conversation_so_far": [{"q": "earlier"}]}
+
+    reconcile_inflight(deps, build_extra=build_extra)
+
+    assert entries == ["room-1"]
+    assert deps.dispatcher.ran == [
+        ("how is the beam?", {"conversation_so_far": [{"q": "earlier"}]})
+    ]
+
+
+def test_empty_build_extra_result_is_omitted_from_the_dispatch(store):
+    """An empty context must leave the payload byte-identical to the no-context path,
+    not ship ``extra={}``."""
+    _crashed_before_run_id(store)
+    deps = Deps(dedup=store, dispatcher=FakeDispatcher())
+
+    reconcile_inflight(deps, build_extra=lambda entry: {})
+
+    assert deps.dispatcher.ran == [("how is the beam?", None)]
+
+
+# --- retried entries belong to the drain --------------------------------------
+
+
+def test_retried_entry_without_a_run_id_goes_back_to_the_queue(store):
+    """A drain redispatch that crashed before a run existed is handed back to the
+    queue, never dispatched from startup — the health gate and retry min-age must keep
+    mediating it."""
+    store.claim("m1", text="how is the beam?")
+    store.transition("m1", "pending", "queued")
+    store.transition("m1", "queued", "in_flight", retried=True, attempts=1)
+    deps = Deps(dedup=store, dispatcher=FakeDispatcher())
+
+    report = reconcile_inflight(deps)
+
+    assert store.get("m1")["status"] == "queued"
+    assert deps.dispatcher.dispatch_calls == 0
+    assert deps.dispatcher.polled == []
+    assert deps.ops.calls == []
+    assert report == ReconcileReport(requeued=1)
+
+
+def test_retried_entry_with_a_run_id_is_still_re_attached(store):
+    """``retried`` only diverts entries with nothing to attach to. A retried entry that
+    DID reach a run is a crash mid-poll like any other."""
+    store.claim("m1", text="how is the beam?")
+    store.transition("m1", "pending", "queued")
+    store.transition("m1", "queued", "in_flight", retried=True)
+    store.record("m1", run_id="run-7", status="in_flight")
+    deps = Deps(dedup=store, dispatcher=FakeDispatcher())
+
+    report = reconcile_inflight(deps)
+
+    assert deps.dispatcher.polled == ["run-7"]
+    assert deps.dispatcher.dispatch_calls == 0
+    assert report == ReconcileReport(reattached=1)
+
+
+def test_queued_entries_are_left_to_the_drain(store):
+    store.claim("m1", text="how is the beam?")
+    store.transition("m1", "pending", "queued")
+    deps = Deps(dedup=store, dispatcher=FakeDispatcher())
+
+    report = reconcile_inflight(deps)
+
+    assert report == ReconcileReport()
+    assert store.get("m1")["status"] == "queued"
+    assert deps.dispatcher.dispatch_calls == 0
+
+
+def test_terminal_entries_are_untouched(store):
+    store.claim("m1", text="how is the beam?")
+    store.update_status("m1", "completed")
+    deps = Deps(dedup=store, dispatcher=FakeDispatcher())
+
+    assert reconcile_inflight(deps) == ReconcileReport()
+    assert deps.ops.calls == []
+
+
+# --- nothing to do / failure handling -----------------------------------------
+
+
+def test_entry_with_neither_run_id_nor_text_is_left_alone(store):
+    """Guessing would either invent a dispatch or drop a live dedup claim."""
+    store.claim("m1", history_key="room-1")
+    deps = Deps(dedup=store, dispatcher=FakeDispatcher())
+
+    report = reconcile_inflight(deps)
+
+    assert report == ReconcileReport(skipped=1)
+    assert store.get("m1")["status"] == "pending"
+    assert deps.dispatcher.dispatch_calls == 0
+    assert deps.ops.calls == []
+
+
+def test_a_raising_poll_leaves_the_entry_for_the_next_startup(store):
+    _crashed_mid_poll(store)
+    dispatcher = FakeDispatcher()
+    dispatcher.raise_on_poll = RuntimeError("worker unreachable")
+    deps = Deps(dedup=store, dispatcher=dispatcher)
+
+    report = reconcile_inflight(deps)
+
+    assert report == ReconcileReport(failed=1)
+    assert store.get("m1")["status"] == "in_flight"  # still reconcilable
+    assert deps.ops.count("post_answer") == 0
+
+
+def test_a_raising_dispatch_leaves_the_entry_for_the_next_startup(store):
+    _crashed_before_run_id(store)
+    dispatcher = FakeDispatcher()
+    dispatcher.raise_on_run = RuntimeError("dispatcher down")
+    deps = Deps(dedup=store, dispatcher=dispatcher)
+
+    report = reconcile_inflight(deps)
+
+    assert report == ReconcileReport(failed=1)
+    assert store.get("m1")["status"] == "pending"
+
+
+def test_one_failing_entry_does_not_abort_the_pass(store):
+    """Reconcile runs before the bridge subscribes; one bad entry must not stop the
+    others (or crashloop the process)."""
+    _crashed_mid_poll(store, message_id="bad", run_id="run-bad")
+    _crashed_mid_poll(store, message_id="good", run_id="run-good")
+    dispatcher = FakeDispatcher()
+    original = dispatcher.poll_worker
+
+    def poll(run_id, deadline=None):
+        if run_id == "run-bad":
+            dispatcher.polled.append(run_id)
+            raise RuntimeError("boom")
+        return original(run_id, deadline)
+
+    dispatcher.poll_worker = poll  # type: ignore[method-assign]
+    deps = Deps(dedup=store, dispatcher=dispatcher)
+
+    report = reconcile_inflight(deps)
+
+    assert report == ReconcileReport(reattached=1, failed=1)
+    assert store.get("bad")["status"] == "in_flight"
+    assert store.get("good")["status"] == "completed"
+
+
+def test_a_failed_post_marks_the_entry_post_failed(store):
+    """``post_answer`` raises by contract when the answer did not land. At startup that
+    is terminal: a permanently unpostable destination must not be retried on every
+    restart, and the raise must not escape into the process's boot path."""
+    _crashed_mid_poll(store)
+    ops = RecordingChannelOps()
+    ops.fail_next("post_answer", RuntimeError("thread deleted"))
+    deps = Deps(dedup=store, dispatcher=FakeDispatcher(), ops=ops)
+
+    report = reconcile_inflight(deps)
+
+    assert report == ReconcileReport(post_failed=1)
+    assert store.get("m1")["status"] == "post_failed"
+    assert ops.count("deliver_files") == 0
+
+
+def test_a_raising_file_delivery_does_not_un_deliver_the_answer(store):
+    """``deliver_files`` must never raise, but if an adapter does, the text has already
+    landed — the entry still settles terminal."""
+    _crashed_mid_poll(store)
+    ops = RecordingChannelOps()
+    ops.fail_next("deliver_files", RuntimeError("upload failed"))
+    deps = Deps(dedup=store, dispatcher=FakeDispatcher(), ops=ops)
+
+    report = reconcile_inflight(deps)
+
+    assert report == ReconcileReport(reattached=1)
+    assert store.get("m1")["status"] == "completed"
+
+
+# --- settlement seam ----------------------------------------------------------
+
+
+def test_settle_seam_replaces_the_default_settlement(store):
+    """The runtime injects the pipeline's settlement so a retryable failure found at
+    startup is parked for the drain instead of being marked terminal."""
+    _crashed_mid_poll(store)
+    deps = Deps(dedup=store, dispatcher=FakeDispatcher(poll_result={"status": "error"}))
+    settled: list[tuple[str, str]] = []
+
+    def settle(message_id, entry, result):
+        settled.append((message_id, entry["text"]))
+        store.update_status(message_id, "queued")
+
+    report = reconcile_inflight(deps, settle=settle)
+
+    assert settled == [("m1", "how is the beam?")]
+    assert store.get("m1")["status"] == "queued"
+    assert deps.ops.calls == []  # the seam owns all channel I/O
+    assert report == ReconcileReport(reattached=1)
+
+
+def test_settle_sees_the_entry_as_stored_after_the_redispatch(store):
+    """The entry handed to settlement is re-read, so it carries the run_id the
+    re-dispatch just persisted rather than the stale pre-crash copy."""
+    _crashed_before_run_id(store)
+    deps = Deps(dedup=store, dispatcher=FakeDispatcher(run_id="run-99"))
+    seen: list[Any] = []
+
+    reconcile_inflight(deps, settle=lambda mid, entry, result: seen.append(entry["run_id"]))
+
+    assert seen == ["run-99"]
+
+
+def test_deliver_terminal_is_reusable_on_its_own(store):
+    """The default settlement is a public function so the runtime can compose it."""
+    _crashed_mid_poll(store)
+    deps = Deps(dedup=store, dispatcher=FakeDispatcher())
+    entry = store.get("m1")
+
+    assert deliver_terminal(deps, "m1", entry, {"status": "completed"}) is True
+    assert store.get("m1")["status"] == "completed"
+
+
+# --- pass-level behavior ------------------------------------------------------
+
+
+def test_a_mixed_store_settles_every_entry_in_one_pass(store):
+    _crashed_mid_poll(store, message_id="attach", run_id="run-1")
+    _crashed_before_run_id(store, message_id="redispatch")
+    store.claim("retried", text="q")
+    store.transition("retried", "pending", "queued")
+    store.transition("retried", "queued", "in_flight", retried=True)
+    store.claim("bare")
+    store.claim("done", text="q")
+    store.update_status("done", "completed")
+    deps = Deps(dedup=store, dispatcher=FakeDispatcher())
+
+    report = reconcile_inflight(deps)
+
+    assert report == ReconcileReport(reattached=1, redispatched=1, requeued=1, skipped=1)
+    assert report.total == 4
+    assert deps.dispatcher.polled == ["run-1"]
+    assert len(deps.dispatcher.ran) == 1
+
+
+def test_an_empty_store_is_a_no_op(store):
+    deps = Deps(dedup=store, dispatcher=FakeDispatcher())
+
+    assert reconcile_inflight(deps) == ReconcileReport()
+    assert deps.dispatcher.dispatch_calls == 0
+
+
+def test_a_second_pass_finds_nothing_left(store):
+    """Idempotence across restarts: a settled entry is terminal, so a bridge that
+    restarts twice never re-answers the same message."""
+    _crashed_mid_poll(store)
+    deps = Deps(dedup=store, dispatcher=FakeDispatcher())
+
+    reconcile_inflight(deps)
+    second = reconcile_inflight(deps)
+
+    assert second == ReconcileReport()
+    assert deps.dispatcher.polled == ["run-42"]
+    assert deps.ops.count("post_answer") == 1

--- a/tests/bridges/test_retry.py
+++ b/tests/bridges/test_retry.py
@@ -1,0 +1,238 @@
+"""Table-driven coverage of the pure retry-policy decisions in osprey.bridges.core.retry.
+
+Each branch of every function gets an explicit row: retryable failure classes,
+the redispatch safety gate (known tool-call counts), age eligibility, the
+two-ceiling give-up rule, and coalesce-key normalization."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from osprey.bridges.core.retry import (
+    coalesce_key,
+    give_up_due,
+    is_eligible,
+    is_retryable,
+    may_redispatch,
+)
+
+NOW = 1_000_000.0
+
+
+def _cfg(retry_min_age=1200.0, retry_give_up=172800.0, retry_lifetime_cap=604800.0):
+    return SimpleNamespace(
+        retry_min_age=retry_min_age,
+        retry_give_up=retry_give_up,
+        retry_lifetime_cap=retry_lifetime_cap,
+    )
+
+
+def _queued(age, **extra):
+    """An entry that entered the queue ``age`` seconds before NOW."""
+    return {"queued_at": NOW - age, **extra}
+
+
+# --- is_retryable ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "failure_class, expected",
+    [
+        ("provider", True),
+        ("infrastructure", True),
+        ("agent", False),
+        ("user", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_is_retryable_by_class(failure_class, expected):
+    assert is_retryable({"failure_class": failure_class}) is expected
+
+
+def test_is_retryable_missing_key():
+    assert is_retryable({}) is False
+
+
+# --- is_retryable: error_code override -------------------------------------
+
+
+@pytest.mark.parametrize(
+    "error_code, failure_class, expected",
+    [
+        # The two input_files rejections are non-retryable even though the
+        # bridge-local error result defaults failure_class to the (retryable)
+        # "infrastructure" class -> the error_code must win.
+        ("input_files_cap_exceeded", "infrastructure", False),
+        ("input_files_invalid", "infrastructure", False),
+        ("input_files_cap_exceeded", "provider", False),
+        # An absent / unrelated error_code leaves the failure_class verdict intact.
+        (None, "infrastructure", True),
+        ("some_other_code", "provider", True),
+        (None, "agent", False),
+    ],
+)
+def test_is_retryable_error_code_override(error_code, failure_class, expected):
+    assert is_retryable({"failure_class": failure_class, "error_code": error_code}) is expected
+
+
+def test_is_retryable_error_code_absent_key_uses_failure_class():
+    # No error_code key at all -> fall through to the failure_class rule.
+    assert is_retryable({"failure_class": "provider"}) is True
+    assert is_retryable({"failure_class": "agent"}) is False
+
+
+# --- may_redispatch --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "result_n, entry_n, expected",
+    [
+        (0, None, True),  # result knows 0, entry silent
+        (0, 0, True),  # both known 0
+        (None, 0, True),  # entry remembers 0 from a prior attempt
+        (0, 2, False),  # a prior attempt DID make tool calls -> unsafe
+        (3, None, False),  # this run made tool calls
+        (None, None, False),  # unknown everywhere -> fail-closed
+        (True, None, False),  # bool is not a valid count -> unknown
+    ],
+)
+def test_may_redispatch(result_n, entry_n, expected):
+    entry = {} if entry_n is None else {"num_tool_calls": entry_n}
+    result = {} if result_n is None else {"num_tool_calls": result_n}
+    assert may_redispatch(entry, result) is expected
+
+
+@pytest.mark.parametrize("n", [1, 2, 3, 7, 42, 1000])
+def test_may_redispatch_refuses_whenever_tool_calls_were_made(n):
+    """A run that made ANY tool call may never be replayed.
+
+    A dispatched run can reach hardware, so a redispatch of a run with side
+    effects repeats a machine action. The refusal must hold no matter which
+    side reports the positive count, and no matter what the other side says.
+    """
+    # Positive count observed on the fresh result.
+    assert may_redispatch({}, {"num_tool_calls": n}) is False
+    # Positive count remembered on the entry from a prior attempt.
+    assert may_redispatch({"num_tool_calls": n}, {}) is False
+    # A known-0 on the other side does NOT rescue it — every known count must be 0.
+    assert may_redispatch({"num_tool_calls": 0}, {"num_tool_calls": n}) is False
+    assert may_redispatch({"num_tool_calls": n}, {"num_tool_calls": 0}) is False
+
+
+# --- is_eligible -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "age, expected",
+    [
+        (1201.0, True),  # just past min
+        (1200.0, False),  # exactly min -> strict > fails
+        (600.0, False),  # too young
+        (-50.0, False),  # future queued_at (clock skew) -> age clamps to 0
+    ],
+)
+def test_is_eligible_by_age(age, expected):
+    assert is_eligible(_queued(age), NOW, _cfg()) is expected
+
+
+def test_is_eligible_missing_queued_at():
+    # No queued_at -> treated as just-now (age 0) -> not yet eligible.
+    assert is_eligible({}, NOW, _cfg()) is False
+
+
+# --- give_up_due -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "age, attempts, gate_ever_open, expected",
+    [
+        # Hard lifetime cap: unconditional, even with no attempt and gate never open.
+        (604800.0, 0, False, True),
+        (700000.0, 0, False, True),
+        # Give-up age reached AND the entry was actually retried.
+        (172800.0, 1, False, True),
+        # Give-up age reached AND the gate was seen open since enqueue.
+        (172800.0, 0, True, True),
+        # Give-up age reached but never retried and gate never opened -> extend.
+        (172800.0, 0, False, False),
+        (500000.0, 0, False, False),
+        # Below the give-up age -> not due regardless of attempts/gate.
+        (100000.0, 5, True, False),
+    ],
+)
+def test_give_up_due(age, attempts, gate_ever_open, expected):
+    entry = _queued(age, attempts=attempts)
+    assert give_up_due(entry, NOW, gate_ever_open, _cfg()) is expected
+
+
+def test_give_up_due_retried_flag_triggers():
+    # The drain stamps a boolean `retried` flag (not a count) on redispatch;
+    # give_up_due honors it the same as attempts > 0.
+    entry = _queued(172800.0, retried=True)
+    assert give_up_due(entry, NOW, False, _cfg()) is True
+
+
+def test_give_up_due_retried_flag_false_extends():
+    entry = _queued(172800.0, retried=False)
+    assert give_up_due(entry, NOW, False, _cfg()) is False
+
+
+def test_give_up_due_missing_queued_at_never_gives_up():
+    # Age 0 -> below both ceilings.
+    assert give_up_due({"attempts": 3}, NOW, True, _cfg()) is False
+
+
+# --- ceiling anchor: first_queued_at ---------------------------------------
+
+
+def test_give_up_due_anchors_on_first_queued_at():
+    # A re-parked entry has a FRESH queued_at (per-attempt pacing) but its
+    # first_queued_at remembers when the request originally entered the queue.
+    # The give-up ceiling must read the original time, else a cycling entry
+    # (park -> retry -> fail -> re-park) re-ages forever and never gives up.
+    entry = {"queued_at": NOW - 100.0, "first_queued_at": NOW - 172800.0, "retried": True}
+    assert give_up_due(entry, NOW, False, _cfg()) is True
+
+
+def test_lifetime_cap_anchors_on_first_queued_at():
+    entry = {"queued_at": NOW - 100.0, "first_queued_at": NOW - 604800.0}
+    assert give_up_due(entry, NOW, False, _cfg()) is True
+
+
+def test_give_up_due_falls_back_to_queued_at():
+    # Entries persisted before first_queued_at existed keep working: the
+    # ceilings fall back to queued_at.
+    entry = {"queued_at": NOW - 604800.0}
+    assert give_up_due(entry, NOW, False, _cfg()) is True
+
+
+def test_is_eligible_ignores_first_queued_at():
+    # Pacing stays per-park: a just-re-parked entry (fresh queued_at) is NOT
+    # eligible again immediately, however old the request itself is.
+    entry = {"queued_at": NOW - 100.0, "first_queued_at": NOW - 604800.0}
+    assert is_eligible(entry, NOW, _cfg()) is False
+
+
+# --- coalesce_key ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "key, expected",
+    [
+        ("space/AAA", ("space/AAA",)),
+        (["space", "thread"], ("space", "thread")),
+        (("space", "thread"), ("space", "thread")),
+        (None, ()),
+        ("", ()),
+        ([], ()),
+        ((), ()),
+    ],
+)
+def test_coalesce_key(key, expected):
+    entry = {} if key is None else {"coalesce_key": key}
+    assert coalesce_key(entry) == expected
+
+
+def test_coalesce_key_missing():
+    assert coalesce_key({}) == ()

--- a/tests/bridges/test_retry_queue.py
+++ b/tests/bridges/test_retry_queue.py
@@ -1,0 +1,617 @@
+"""Retry-queue write-side specification: park, supersede-at-enqueue, give-up notice.
+
+Every test drives a REAL :class:`~osprey.bridges.core.dedup.DedupStore` (and, where
+history is involved, a real :class:`~osprey.bridges.core.history.HistoryStore`) on
+``tmp_path`` — the CAS being tested IS the store's, so mocking it would test nothing —
+against the shared ``RecordingChannelOps`` double for the channel side.
+
+The section that matters most is "supersession preconditions". Supersession is the only
+place the engine cancels work a user asked for, and it is justified *solely* by a newer
+message taking the older one's place. The three named tests there pin each side of that:
+a newer message that parks supersedes; a newer message that succeeds or is still in
+flight supersedes nothing. Getting it wrong silently drops a user's first question while
+answering their second, with no notice for either — invisible in production.
+"""
+
+import time
+
+import pytest
+
+from osprey.bridges.core.config import TERMINAL_STATUSES
+from osprey.bridges.core.dedup import DedupStore
+from osprey.bridges.core.history import HistoryStore
+from osprey.bridges.core.retry import is_retryable
+from osprey.bridges.core.retry_queue import (
+    SUPERSEDED_STATUS,
+    give_up,
+    park,
+    supersede_at_enqueue,
+    supersede_note,
+)
+from tests.bridges.conftest import RecordingChannelOps
+
+CHAT_KEY = ["space/1", "users/alice"]
+
+RETRYABLE = {"failure_class": "provider", "num_tool_calls": 0, "status": "error"}
+
+
+class FakeClock:
+    """Injectable monotone clock (epoch seconds) advanced explicitly by tests."""
+
+    def __init__(self, t: float = 1_000_000.0) -> None:
+        self.t = t
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+@pytest.fixture
+def dedup(tmp_path):
+    return DedupStore(str(tmp_path / "dedup.json"))
+
+
+def _ops(**kwargs) -> RecordingChannelOps:
+    """A recording double whose channel coalesce key defaults to the Chat-style
+    ``[history_key, sender_id]`` grouping."""
+    kwargs.setdefault("coalesce", CHAT_KEY)
+    return RecordingChannelOps(**kwargs)
+
+
+def _claim(dedup: DedupStore, message_id: str, **meta):
+    """Claim a message the way the pipeline does, and return the persisted entry."""
+    dedup.claim(message_id, text="why is the beam down?", history_key="space/1", **meta)
+    return dedup.get(message_id)
+
+
+def _seed_queued(dedup: DedupStore, message_id: str, *, key=CHAT_KEY, **meta):
+    """Seed an already-parked entry (an older sibling waiting in the queue)."""
+    entry = _claim(dedup, message_id, **meta)
+    dedup.transition(
+        message_id,
+        entry["status"],
+        "queued",
+        coalesce_key=key,
+        queued_at=1_000.0,
+        first_queued_at=1_000.0,
+        attempts=0,
+    )
+    return dedup.get(message_id)
+
+
+# ===========================================================================
+# Section 1 — park: what lands in the store
+# ===========================================================================
+
+
+def test_park_flips_pending_to_queued(dedup):
+    entry = _claim(dedup, "m1")
+
+    assert park(_ops(), dedup, "m1", entry, RETRYABLE) is True
+
+    assert dedup.get("m1")["status"] == "queued"
+    assert "m1" in dedup.queued()
+
+
+def test_park_stamps_retry_bookkeeping(dedup):
+    clock = FakeClock()
+    entry = _claim(dedup, "m1")
+
+    park(_ops(), dedup, "m1", entry, RETRYABLE, now=clock)
+
+    parked = dedup.get("m1")
+    assert parked["failure_class"] == "provider"
+    assert parked["num_tool_calls"] == 0
+    assert parked["queued_at"] == clock.t
+    assert parked["first_queued_at"] == clock.t
+    assert parked["attempts"] == 0
+
+
+def test_park_preserves_unknown_tool_count_as_none(dedup):
+    """``None`` means *unknown*, and ``may_redispatch`` is fail-closed on unknown.
+    Coercing it to 0 would let the drain re-run a side-effecting agent."""
+    entry = _claim(dedup, "m1")
+
+    park(_ops(), dedup, "m1", entry, {"failure_class": "infrastructure"})
+
+    parked = dedup.get("m1")
+    assert parked["num_tool_calls"] is None
+    assert parked["failure_class"] == "infrastructure"
+
+
+def test_park_persists_normalized_channel_coalesce_key(dedup):
+    """The channel supplies the grouping input; the engine normalizes it through
+    ``retry.coalesce_key`` and persists it JSON-plain so it round-trips on disk."""
+    ops = _ops(coalesce="thread-root-42")
+    entry = _claim(dedup, "m1")
+
+    park(ops, dedup, "m1", entry, RETRYABLE)
+
+    assert dedup.get("m1")["coalesce_key"] == ["thread-root-42"]
+    assert ops.of("coalesce_key")[0]["entry"] == entry
+
+
+def test_park_defaults_to_time_time(dedup):
+    """The clock is injectable but must default to wall time — the drain's ageing
+    compares ``queued_at`` against ``time.time()``."""
+    entry = _claim(dedup, "m1")
+    before = time.time()
+
+    park(_ops(), dedup, "m1", entry, RETRYABLE)
+
+    assert before <= dedup.get("m1")["queued_at"] <= time.time()
+
+
+def test_repark_refreshes_pacing_clock_but_not_the_giveup_anchor(dedup):
+    """``queued_at`` paces the next attempt and refreshes; ``first_queued_at`` anchors
+    the give-up ceilings and must NOT, or a cycling entry re-ages forever."""
+    clock = FakeClock()
+    entry = _claim(dedup, "m1")
+    park(_ops(), dedup, "m1", entry, RETRYABLE, now=clock)
+
+    clock.advance(3600.0)
+    # The drain redispatched and failed again: queued -> in_flight -> re-park.
+    dedup.transition("m1", "queued", "in_flight", retried=True, attempts=1)
+    park(_ops(), dedup, "m1", dedup.get("m1"), RETRYABLE, now=clock)
+
+    reparked = dedup.get("m1")
+    assert reparked["queued_at"] == 1_003_600.0
+    assert reparked["first_queued_at"] == 1_000_000.0
+
+
+def test_repark_never_resets_the_attempt_count(dedup):
+    """``attempts`` is the drain's; only the FIRST park seeds it at 0."""
+    entry = _claim(dedup, "m1")
+    park(_ops(), dedup, "m1", entry, RETRYABLE)
+    dedup.transition("m1", "queued", "in_flight", retried=True, attempts=3)
+
+    park(_ops(), dedup, "m1", dedup.get("m1"), RETRYABLE)
+
+    assert dedup.get("m1")["attempts"] == 3
+
+
+def test_park_of_a_pre_first_queued_at_entry_anchors_on_queued_at(dedup):
+    """An entry persisted before ``first_queued_at`` existed still gets a stable
+    anchor, taken from its older ``queued_at`` rather than reset to now."""
+    _claim(dedup, "m1")
+    dedup.transition("m1", "pending", "in_flight", queued_at=500.0)
+
+    park(_ops(), dedup, "m1", dedup.get("m1"), RETRYABLE, now=FakeClock())
+
+    assert dedup.get("m1")["first_queued_at"] == 500.0
+
+
+def test_park_writes_no_history(dedup, tmp_path):
+    """The exchange is unfinished — history is appended by the drain when the queued
+    run finally completes, never at park time."""
+    history = HistoryStore(str(tmp_path / "history.json"))
+    entry = _claim(dedup, "m1")
+
+    park(_ops(), dedup, "m1", entry, RETRYABLE)
+
+    assert history.recent("space/1") == []
+
+
+# ===========================================================================
+# Section 2 — park: the queued notice, and its ordering
+# ===========================================================================
+
+
+def test_first_park_posts_the_queued_notice(dedup):
+    ops = _ops()
+    entry = _claim(dedup, "m1")
+
+    park(ops, dedup, "m1", entry, RETRYABLE)
+
+    assert ops.count("post_queued") == 1
+    assert ops.of("post_queued")[0]["result"] == RETRYABLE
+
+
+def test_repark_is_silent(dedup):
+    """The user was told once; the next message in the thread is the answer or the
+    give-up notice, not another "still queued"."""
+    ops = _ops()
+    entry = _claim(dedup, "m1")
+    park(ops, dedup, "m1", entry, RETRYABLE)
+    dedup.transition("m1", "queued", "in_flight", retried=True, attempts=1)
+
+    park(ops, dedup, "m1", dedup.get("m1"), RETRYABLE)
+
+    assert ops.count("post_queued") == 1
+
+
+def test_entry_is_already_queued_when_the_notice_is_posted(dedup):
+    """``post_queued`` MAY raise, so the engine parks FIRST: the entry handed to the
+    notice is the persisted one, already in ``queued``."""
+    ops = _ops()
+    entry = _claim(dedup, "m1")
+
+    park(ops, dedup, "m1", entry, RETRYABLE)
+
+    posted = ops.of("post_queued")[0]["entry"]
+    assert posted["status"] == "queued"
+    assert posted["queued_at"] == dedup.get("m1")["queued_at"]
+
+
+def test_failed_queued_notice_leaves_the_request_parked(dedup):
+    """A lost notice costs the user a message; it must never cost them the request."""
+    ops = _ops()
+    ops.fail_next("post_queued", RuntimeError("chat 503"))
+    entry = _claim(dedup, "m1")
+
+    with pytest.raises(RuntimeError):
+        park(ops, dedup, "m1", entry, RETRYABLE)
+
+    assert dedup.get("m1")["status"] == "queued"
+    assert "m1" in dedup.queued()
+
+
+def test_failed_queued_notice_still_superseded_the_older_sibling(dedup):
+    """Queue state is committed before the notice, so a raise cannot leave the queue
+    half-collapsed."""
+    ops = _ops()
+    ops.fail_next("post_queued", RuntimeError("chat 503"))
+    _seed_queued(dedup, "old")
+    entry = _claim(dedup, "new")
+
+    with pytest.raises(RuntimeError):
+        park(ops, dedup, "new", entry, RETRYABLE)
+
+    assert dedup.get("old")["status"] == SUPERSEDED_STATUS
+
+
+# ===========================================================================
+# Section 3 — park: the CAS
+# ===========================================================================
+
+
+def test_park_loses_the_cas_when_the_entry_already_moved(dedup):
+    """A racing drain (or a late terminal callback) owns the entry now — parking on
+    top of it would resurrect work someone else settled."""
+    ops = _ops()
+    entry = _claim(dedup, "m1")
+    dedup.update_status("m1", "completed")
+
+    assert park(ops, dedup, "m1", entry, RETRYABLE) is False
+
+    assert dedup.get("m1")["status"] == "completed"
+    assert ops.count("post_queued") == 0
+
+
+def test_a_park_that_lost_the_cas_supersedes_nothing(dedup):
+    """The precondition again, at CAS granularity: no park, no supersession."""
+    ops = _ops()
+    _seed_queued(dedup, "old")
+    entry = _claim(dedup, "new")
+    dedup.update_status("new", "completed")
+
+    assert park(ops, dedup, "new", entry, RETRYABLE) is False
+
+    assert dedup.get("old")["status"] == "queued"
+    assert ops.count("post_superseded") == 0
+
+
+def test_park_of_an_unknown_message_is_a_no_op(dedup):
+    ops = _ops()
+
+    assert park(ops, dedup, "ghost", {"status": "pending"}, RETRYABLE) is False
+
+    assert dedup.get("ghost") is None
+    assert ops.count("post_queued") == 0
+
+
+# ===========================================================================
+# Section 4 — supersession preconditions (the invariant that is easy to lose)
+# ===========================================================================
+
+
+def _newer_message_finishes(ops, dedup, message_id, entry, result):
+    """The caller contract park depends on, spelled out: the pipeline parks a message
+    ONLY when its failure is retryable, and otherwise settles it terminally. These
+    three tests drive that rule rather than calling ``park`` directly, so they fail if
+    supersession ever migrates onto a non-park path."""
+    if is_retryable(result):
+        return park(ops, dedup, message_id, entry, result)
+    dedup.record(message_id, entry.get("run_id"), result.get("status", "completed"))
+    return False
+
+
+def test_older_sibling_superseded_when_newer_message_parks(dedup):
+    ops = _ops()
+    _seed_queued(dedup, "old")
+    entry = _claim(dedup, "new")
+
+    _newer_message_finishes(ops, dedup, "new", entry, RETRYABLE)
+
+    assert dedup.get("old")["status"] == SUPERSEDED_STATUS
+    assert ops.count("post_superseded") == 1
+    assert ops.of("post_superseded")[0]["entry"]["status"] == SUPERSEDED_STATUS
+    assert dedup.get("new")["status"] == "queued"
+
+
+def test_older_sibling_untouched_when_newer_message_dispatches_successfully(dedup):
+    """The failure mode this guards: the user's older queued question is cancelled by
+    a newer one that then succeeds — they never get the first answer and are never
+    told why."""
+    ops = _ops()
+    _seed_queued(dedup, "old")
+    entry = _claim(dedup, "new")
+
+    _newer_message_finishes(
+        ops, dedup, "new", entry, {"status": "completed", "answer": "beam is up"}
+    )
+
+    assert dedup.get("old")["status"] == "queued"
+    assert "old" in dedup.queued()
+    assert ops.count("post_superseded") == 0
+
+
+def test_older_sibling_untouched_while_newer_message_is_in_flight(dedup):
+    """An in-flight newer message has not taken the older one's place — it may yet
+    succeed, fail non-retryably, or crash. Only its park may supersede."""
+    ops = _ops()
+    _seed_queued(dedup, "old")
+    _claim(dedup, "new")
+
+    dedup.record("new", "run-7", "in_flight")
+
+    assert dedup.get("old")["status"] == "queued"
+    assert "old" in dedup.queued()
+    assert ops.count("post_superseded") == 0
+
+
+def test_non_retryable_failure_of_the_newer_message_supersedes_nothing(dedup):
+    """A failed-but-unretryable newer message ends with its own error reply; the older
+    queued question is still owed an answer."""
+    ops = _ops()
+    _seed_queued(dedup, "old")
+    entry = _claim(dedup, "new")
+
+    _newer_message_finishes(ops, dedup, "new", entry, {"status": "error", "failure_class": "agent"})
+
+    assert dedup.get("old")["status"] == "queued"
+    assert ops.count("post_superseded") == 0
+
+
+# ===========================================================================
+# Section 5 — supersede-at-enqueue: matching, the CAS, and best-effort notes
+# ===========================================================================
+
+
+def test_supersession_skips_the_parking_entry_itself(dedup):
+    """The entry is already ``queued`` by the time siblings are scanned, so the
+    self-exclusion is load-bearing: without it a park cancels itself."""
+    ops = _ops()
+    entry = _claim(dedup, "m1")
+
+    park(ops, dedup, "m1", entry, RETRYABLE)
+
+    assert dedup.get("m1")["status"] == "queued"
+    assert ops.count("post_superseded") == 0
+
+
+def test_sibling_with_a_different_key_is_untouched(dedup):
+    ops = _ops()
+    _seed_queued(dedup, "other", key=["space/2", "users/bob"])
+    entry = _claim(dedup, "new")
+
+    park(ops, dedup, "new", entry, RETRYABLE)
+
+    assert dedup.get("other")["status"] == "queued"
+    assert ops.count("post_superseded") == 0
+
+
+def test_keyless_entries_stand_alone(dedup):
+    """``""``/``()`` is the no-group sentinel, not a group of its own — two keyless
+    entries must never collapse into each other."""
+    ops = _ops(coalesce="")
+    _seed_queued(dedup, "old", key=[])
+    entry = _claim(dedup, "new")
+
+    park(ops, dedup, "new", entry, RETRYABLE)
+
+    assert dedup.get("old")["status"] == "queued"
+    assert ops.count("post_superseded") == 0
+
+
+def test_scalar_and_sequence_keys_normalize_to_the_same_group(dedup):
+    """A sibling persisted from a scalar channel key still matches a scalar park."""
+    ops = _ops(coalesce="thread-root")
+    _seed_queued(dedup, "old", key="thread-root")
+    entry = _claim(dedup, "new")
+
+    park(ops, dedup, "new", entry, RETRYABLE)
+
+    assert dedup.get("old")["status"] == SUPERSEDED_STATUS
+
+
+def test_all_older_siblings_in_the_group_are_dropped(dedup):
+    ops = _ops()
+    _seed_queued(dedup, "old1")
+    _seed_queued(dedup, "old2")
+    entry = _claim(dedup, "new")
+
+    park(ops, dedup, "new", entry, RETRYABLE)
+
+    assert dedup.get("old1")["status"] == SUPERSEDED_STATUS
+    assert dedup.get("old2")["status"] == SUPERSEDED_STATUS
+    assert ops.count("post_superseded") == 2
+
+
+def test_cas_is_respected_for_an_entry_that_left_the_queue(dedup):
+    """A drain that already claimed the sibling (``queued -> in_flight``) wins the
+    race: we neither drop it nor post a note it would contradict."""
+    ops = _ops()
+    _seed_queued(dedup, "old")
+    dedup.transition("old", "queued", "in_flight", retried=True)
+    entry = _claim(dedup, "new")
+
+    park(ops, dedup, "new", entry, RETRYABLE)
+
+    assert dedup.get("old")["status"] == "in_flight"
+    assert ops.count("post_superseded") == 0
+
+
+def test_failed_supersede_note_does_not_disturb_the_pass(dedup):
+    """The coalesce CAS is already committed — a failing note must not abort the
+    remaining siblings, nor the park's own queued notice."""
+    ops = _ops()
+    ops.fail_next("post_superseded", RuntimeError("chat 503"))
+    _seed_queued(dedup, "old1")
+    _seed_queued(dedup, "old2")
+    entry = _claim(dedup, "new")
+
+    assert park(ops, dedup, "new", entry, RETRYABLE) is True
+
+    assert dedup.get("old1")["status"] == SUPERSEDED_STATUS
+    assert dedup.get("old2")["status"] == SUPERSEDED_STATUS
+    assert ops.count("post_superseded") == 2
+    assert ops.count("post_queued") == 1
+
+
+def test_supersede_at_enqueue_returns_the_dropped_ids(dedup):
+    ops = _ops()
+    _seed_queued(dedup, "old")
+    _seed_queued(dedup, "other", key=["space/2", "users/bob"])
+
+    dropped = supersede_at_enqueue(ops, dedup, "new", ("space/1", "users/alice"))
+
+    assert dropped == ["old"]
+
+
+def test_supersede_at_enqueue_ignores_the_empty_key(dedup):
+    ops = _ops()
+    _seed_queued(dedup, "old", key=[])
+
+    assert supersede_at_enqueue(ops, dedup, "new", ()) == []
+
+    assert dedup.get("old")["status"] == "queued"
+    assert ops.count("post_superseded") == 0
+
+
+def test_superseded_status_is_terminal(dedup):
+    """If it were not terminal, ``reconcile()`` would re-surface a dropped question on
+    the next restart and re-run it."""
+    assert SUPERSEDED_STATUS in TERMINAL_STATUSES
+
+    _seed_queued(dedup, "old")
+    park(_ops(), dedup, "new", _claim(dedup, "new"), RETRYABLE)
+
+    assert "old" not in dedup.queued()
+    assert "old" not in dedup.reconcile()
+
+
+# ===========================================================================
+# Section 6 — give-up and the drain-side supersede note
+# ===========================================================================
+
+
+def test_give_up_posts_the_persisted_entry(dedup):
+    ops = _ops()
+    entry = _claim(dedup, "m1")
+    park(ops, dedup, "m1", entry, RETRYABLE)
+
+    give_up(ops, dedup, "m1", entry)
+
+    assert ops.count("post_giveup") == 1
+    assert ops.of("post_giveup")[0]["entry"]["status"] == "queued"
+
+
+def test_give_up_leaves_the_terminal_mark_to_the_drain(dedup):
+    """The drain marks terminal only AFTER this returns — so a notice that fails to
+    send leaves the entry queued for the next cycle instead of silently dropped."""
+    ops = _ops()
+    entry = _claim(dedup, "m1")
+    park(ops, dedup, "m1", entry, RETRYABLE)
+
+    give_up(ops, dedup, "m1", entry)
+
+    assert dedup.get("m1")["status"] == "queued"
+
+
+def test_give_up_raises_when_the_notice_fails(dedup):
+    """``post_giveup`` MUST raise and the engine MUST let it through: a lost give-up
+    notice is silence, worse than a rare duplicate."""
+    ops = _ops()
+    ops.fail_next("post_giveup", RuntimeError("chat 503"))
+    entry = _claim(dedup, "m1")
+
+    with pytest.raises(RuntimeError):
+        give_up(ops, dedup, "m1", entry)
+
+    assert dedup.get("m1")["status"] == "pending"
+
+
+def test_give_up_records_the_failed_turn_in_history(dedup, tmp_path):
+    history = HistoryStore(str(tmp_path / "history.json"))
+    ops = _ops()
+    entry = _claim(dedup, "m1")
+
+    give_up(ops, dedup, "m1", entry, history=history)
+
+    turns = history.recent("space/1")
+    assert len(turns) == 1
+    assert turns[0]["question"] == "why is the beam down?"
+
+
+def test_give_up_skips_history_when_the_notice_failed(dedup, tmp_path):
+    """No notice landed, so the drain will retry the whole give-up next cycle — a
+    history turn written now would be duplicated."""
+    history = HistoryStore(str(tmp_path / "history.json"))
+    ops = _ops()
+    ops.fail_next("post_giveup", RuntimeError("chat 503"))
+    entry = _claim(dedup, "m1")
+
+    with pytest.raises(RuntimeError):
+        give_up(ops, dedup, "m1", entry, history=history)
+
+    assert history.recent("space/1") == []
+
+
+def test_give_up_survives_a_failing_history_write(dedup):
+    """The notice already landed; a history failure must not turn a delivered notice
+    into a retried one."""
+
+    class BrokenHistory:
+        def append_failed(self, key, question):
+            raise RuntimeError("disk full")
+
+    ops = _ops()
+    entry = _claim(dedup, "m1")
+
+    give_up(ops, dedup, "m1", entry, history=BrokenHistory())
+
+    assert ops.count("post_giveup") == 1
+
+
+def test_give_up_without_a_history_key_posts_only(dedup, tmp_path):
+    history = HistoryStore(str(tmp_path / "history.json"))
+    ops = _ops()
+    dedup.claim("m1", text="hi", history_key="")
+
+    give_up(ops, dedup, "m1", dedup.get("m1"), history=history)
+
+    assert ops.count("post_giveup") == 1
+    assert history.recent("") == []
+
+
+def test_supersede_note_posts_the_persisted_entry(dedup):
+    ops = _ops()
+    entry = _seed_queued(dedup, "old")
+
+    supersede_note(ops, dedup, "old", entry)
+
+    assert ops.count("post_superseded") == 1
+    assert ops.of("post_superseded")[0]["entry"]["text"] == "why is the beam down?"
+
+
+def test_supersede_note_never_raises(dedup):
+    ops = _ops()
+    ops.fail_next("post_superseded", RuntimeError("chat 503"))
+    entry = _seed_queued(dedup, "old")
+
+    supersede_note(ops, dedup, "old", entry)
+
+    assert ops.count("post_superseded") == 1

--- a/tests/bridges/test_runtime.py
+++ b/tests/bridges/test_runtime.py
@@ -1,0 +1,552 @@
+"""Tests for the runtime shell: collaborator wiring, startup recovery, drain supervision.
+
+Stores are the real ``DedupStore``/``HistoryStore`` on temp files; the dispatcher is a
+stub that records its payload, marks itself into the ``RecordingChannelOps`` timeline and
+returns a canned terminal result. ``run_drain_thread`` is monkeypatched wherever a test
+cares about *whether* a drain started rather than what it does — the drain loop itself is
+covered by ``test_drain.py``, and no test here sleeps or waits on real time.
+
+The load-bearing invariants, each with a named test:
+
+* collaborators come from cfg + ops        — ``test_build_deps_constructs_collaborators_from_cfg_and_ops``
+* recovery completes BEFORE the drain runs — ``test_reconcile_runs_before_the_drain_starts``
+* exactly ONE drain thread                 — ``test_start_starts_exactly_one_drain_thread``
+* a dead drain is replaced                 — ``test_supervise_restarts_a_dead_drain``
+* the gate is the health gate              — ``test_gate_defaults_to_health_gate_gate_open``
+* callbacks hit the right ChannelOps member— ``test_deliver_callback_posts_answer_then_files_then_history`` and friends
+* a re-dispatch replays the live payload   — ``test_rebuild_extra_replays_history_reply_and_inputs``
+"""
+
+from __future__ import annotations
+
+import base64
+import dataclasses
+import threading
+from typing import Any
+
+import pytest
+
+from osprey.bridges.core import runtime
+from osprey.bridges.core.config import CoreConfig
+from osprey.bridges.core.dedup import DedupStore
+from osprey.bridges.core.dispatch_client import DispatchClient
+from osprey.bridges.core.history import HistoryStore
+from osprey.bridges.core.pipeline import PipelineDeps
+from osprey.bridges.core.ports import InputDownload
+from osprey.bridges.core.reconcile import ReconcileDeps
+from tests.bridges.conftest import RecordingChannelOps
+
+QUESTION = "what is the orbit doing?"
+HISTORY_KEY = "room/AAA"
+
+COMPLETED = {
+    "status": "completed",
+    "text_output": "The orbit is stable.",
+    "run_id": "run-1",
+    "num_tool_calls": 3,
+}
+
+# A bridge-local infrastructure failure: retryable, so the pipeline settlement parks it.
+RETRYABLE = {
+    "status": "error",
+    "text_output": "",
+    "run_id": "run-1",
+    "error": "dispatcher unreachable",
+    "failure_class": "infrastructure",
+    "num_tool_calls": None,
+}
+
+
+class FakeDispatcher:
+    """Stands in for ``DispatchClient``: records dispatches, marks the timeline."""
+
+    def __init__(self, ops: RecordingChannelOps, result: dict[str, Any] | None = None) -> None:
+        self.ops = ops
+        self.result = result if result is not None else COMPLETED
+        self.runs: list[tuple[str, dict[str, Any] | None]] = []
+        self.polled: list[str] = []
+        self.bodies: dict[str, dict[str, Any] | None] = {}
+
+    def run(self, question, extra=None, *, on_run_id=None):
+        self.runs.append((question, extra))
+        self.ops.mark("dispatch", question=question, extra=extra)
+        if on_run_id is not None:
+            on_run_id("run-new")
+        return dict(self.result)
+
+    def poll_worker(self, run_id, deadline=None):
+        self.polled.append(run_id)
+        self.ops.mark("poll_worker", run_id=run_id)
+        return dict(self.result)
+
+    def status(self, run_id):
+        return self.bodies.get(run_id)
+
+
+def _cfg(tmp_path, **over: Any) -> CoreConfig:
+    fields: dict[str, Any] = {
+        "dedup_path": str(tmp_path / "dedup.json"),
+        "history_path": str(tmp_path / "history.json"),
+        "drain_interval": 0.01,
+    }
+    fields.update(over)
+    return CoreConfig(**fields)
+
+
+def _deps(tmp_path, ops: RecordingChannelOps, **over: Any) -> PipelineDeps:
+    """A deps bundle on real stores with a stub dispatcher and a capable pair."""
+    cfg = over.pop("cfg", None) or _cfg(tmp_path)
+    deps = PipelineDeps(
+        cfg=cfg,
+        ops=ops,
+        dedup=DedupStore(cfg.dedup_path),
+        dispatcher=over.pop("dispatcher", None) or FakeDispatcher(ops),
+        history=HistoryStore(cfg.history_path),
+        probe_capability=lambda cfg, capability: True,
+    )
+    return dataclasses.replace(deps, **over) if over else deps
+
+
+@pytest.fixture
+def spawn():
+    """Make real ``Thread`` objects in a known liveness state, with no drain loop and no
+    sleeping: each blocks on its own event, which the fixture releases at teardown."""
+    releases: list[threading.Event] = []
+
+    def make(alive: bool = True) -> threading.Thread:
+        release = threading.Event()
+        releases.append(release)
+        thread = threading.Thread(target=release.wait, daemon=True)
+        thread.start()
+        if not alive:
+            release.set()
+            thread.join(timeout=5.0)
+        return thread
+
+    yield make
+    for release in releases:
+        release.set()
+
+
+@pytest.fixture
+def no_drain(monkeypatch, spawn):
+    """Replace ``run_drain_thread`` with a recorder; returns the list of DrainDeps it was
+    started with (so ``len(started)`` is the thread count)."""
+    started: list[Any] = []
+
+    def fake_run_drain_thread(deps, stop=None):
+        started.append(deps)
+        return spawn()
+
+    monkeypatch.setattr(runtime, "run_drain_thread", fake_run_drain_thread)
+    return started
+
+
+def _claim(store: DedupStore, message_id: str, **meta: Any) -> dict[str, Any]:
+    store.claim(message_id, **meta)
+    return store.get(message_id) or {}
+
+
+def _b64(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+# --- collaborator construction -----------------------------------------------
+
+
+def test_build_deps_constructs_collaborators_from_cfg_and_ops(tmp_path):
+    cfg = _cfg(tmp_path)
+    ops = RecordingChannelOps()
+
+    deps = runtime.build_deps(cfg, ops)
+
+    assert deps.cfg is cfg
+    assert deps.ops is ops
+    assert isinstance(deps.dedup, DedupStore) and deps.dedup.path == cfg.dedup_path
+    assert isinstance(deps.history, HistoryStore) and deps.history.path == cfg.history_path
+    assert isinstance(deps.dispatcher, DispatchClient)
+
+
+def test_build_deps_bundle_also_satisfies_the_reconcile_surface(tmp_path):
+    """One bundle serves pipeline, reconcile and the drain wiring — reconcile reads
+    exactly ``dedup`` / ``dispatcher`` / ``ops`` off it, so there is no second place a
+    collaborator could be constructed differently."""
+    ops = RecordingChannelOps()
+    deps = runtime.build_deps(_cfg(tmp_path), ops)
+    surface: ReconcileDeps = deps
+
+    assert surface.ops is ops
+    assert surface.dedup is deps.dedup
+    assert surface.dispatcher is deps.dispatcher
+
+
+def test_build_deps_uses_injected_stores_verbatim(tmp_path):
+    ops = RecordingChannelOps()
+    dedup = DedupStore(str(tmp_path / "other-dedup.json"))
+    history = HistoryStore(str(tmp_path / "other-history.json"))
+    dispatcher = FakeDispatcher(ops)
+
+    deps = runtime.build_deps(
+        _cfg(tmp_path), ops, dedup=dedup, history=history, dispatcher=dispatcher
+    )
+
+    assert deps.dedup is dedup and deps.history is history and deps.dispatcher is dispatcher
+
+
+# --- startup ordering ---------------------------------------------------------
+
+
+def test_reconcile_runs_before_the_drain_starts(tmp_path, monkeypatch, spawn):
+    """Crash recovery must complete before anything new can be accepted: a message the
+    user is already waiting on is answered before the drain competes for the worker."""
+    ops = RecordingChannelOps()
+    deps = _deps(tmp_path, ops)
+    _claim(deps.dedup, "m1", text=QUESTION, history_key=HISTORY_KEY)
+    deps.dedup.record("m1", run_id="run-1", status="in_flight")
+
+    def marking_run_drain_thread(drain_deps, stop=None):
+        ops.mark("drain_started")
+        return spawn()
+
+    monkeypatch.setattr(runtime, "run_drain_thread", marking_run_drain_thread)
+    runtime.start(deps.cfg, ops, deps=deps)
+
+    ops.assert_order("poll_worker", "post_answer", "drain_started")
+    ops.assert_never_before("drain_started", "poll_worker")
+    assert deps.dedup.get("m1")["status"] == "completed"
+
+
+def test_startup_recovery_settles_through_the_pipeline(tmp_path, no_drain):
+    """The injected settlement is the pipeline's: a retryable failure found at startup is
+    PARKED for the drain (queued + queued notice), not reported as a delivered error."""
+    ops = RecordingChannelOps()
+    deps = _deps(tmp_path, ops, dispatcher=None)
+    deps = dataclasses.replace(deps, dispatcher=FakeDispatcher(ops, RETRYABLE))
+    _claim(deps.dedup, "m1", text=QUESTION, history_key=HISTORY_KEY)
+    deps.dedup.record("m1", run_id="run-1", status="in_flight")
+
+    runtime.start(deps.cfg, ops, deps=deps)
+
+    assert deps.dedup.get("m1")["status"] == "queued"
+    assert ops.count("post_queued") == 1
+    assert ops.count("post_answer") == 0
+
+
+def test_startup_recovery_replays_the_live_payload(tmp_path, no_drain):
+    """A re-dispatch (crashed before a run id existed) carries the same context a live
+    dispatch would — proof the pipeline's context builder is the injected one."""
+    ops = RecordingChannelOps()
+    deps = _deps(tmp_path, ops)
+    deps.history.append(HISTORY_KEY, "earlier?", "earlier answer")
+    _claim(deps.dedup, "m1", text=QUESTION, history_key=HISTORY_KEY)
+
+    runtime.start(deps.cfg, ops, deps=deps)
+
+    (question, extra) = deps.dispatcher.runs[0]
+    assert question == QUESTION
+    assert [turn["answer"] for turn in extra["conversation_so_far"]] == ["earlier answer"]
+
+
+# --- drain supervision --------------------------------------------------------
+
+
+def test_start_starts_exactly_one_drain_thread(tmp_path, no_drain):
+    ops = RecordingChannelOps()
+    deps = _deps(tmp_path, ops)
+
+    bridge = runtime.start(deps.cfg, ops, deps=deps)
+
+    assert len(no_drain) == 1
+    assert no_drain[0] is bridge.drain
+    assert bridge.thread.is_alive()
+
+
+def test_supervise_is_a_noop_while_the_drain_lives(tmp_path, no_drain):
+    ops = RecordingChannelOps()
+    bridge = runtime.start(_cfg(tmp_path), ops, deps=_deps(tmp_path, ops))
+    live = bridge.thread
+
+    assert bridge.supervise() is live
+    assert len(no_drain) == 1
+
+
+def test_supervise_restarts_a_dead_drain(tmp_path, no_drain, spawn):
+    ops = RecordingChannelOps()
+    bridge = runtime.start(_cfg(tmp_path), ops, deps=_deps(tmp_path, ops))
+    dead = spawn(alive=False)
+    bridge.thread = dead
+
+    replacement = bridge.supervise()
+
+    assert replacement is not dead and replacement.is_alive()
+    assert bridge.thread is replacement
+    assert len(no_drain) == 2
+
+
+def test_shutdown_signals_the_drain_to_stop(tmp_path, no_drain):
+    ops = RecordingChannelOps()
+    bridge = runtime.start(_cfg(tmp_path), ops, deps=_deps(tmp_path, ops))
+
+    assert not bridge.stop.is_set()
+    bridge.shutdown()
+    assert bridge.stop.is_set()
+
+
+def test_the_real_drain_thread_is_a_named_daemon(tmp_path):
+    """No monkeypatch here: the ONE thread the runtime really starts must be a daemon so
+    it never blocks process exit. The gate is injected, so the loop does no I/O."""
+    ops = RecordingChannelOps()
+    deps = _deps(tmp_path, ops)
+
+    bridge = runtime.start(deps.cfg, ops, deps=deps, gate=lambda: False)
+    try:
+        assert bridge.thread.daemon and bridge.thread.name == "bridge-drain"
+        drains = [t for t in threading.enumerate() if t.name == "bridge-drain"]
+        assert drains == [bridge.thread]
+    finally:
+        bridge.shutdown()
+        bridge.thread.join(timeout=5.0)
+    assert not bridge.thread.is_alive()
+
+
+# --- the health gate ----------------------------------------------------------
+
+
+def test_gate_defaults_to_health_gate_gate_open(tmp_path, monkeypatch):
+    ops = RecordingChannelOps()
+    deps = _deps(tmp_path, ops)
+    seen: list[Any] = []
+    monkeypatch.setattr(runtime, "gate_open", lambda cfg: seen.append(cfg) or False)
+
+    assert runtime.build_drain_deps(deps).gate_is_open() is False
+    assert seen == [deps.cfg]
+
+
+def test_injected_gate_replaces_the_health_gate(tmp_path, monkeypatch):
+    ops = RecordingChannelOps()
+    deps = _deps(tmp_path, ops)
+    monkeypatch.setattr(
+        runtime, "gate_open", lambda cfg: pytest.fail("health gate must not be consulted")
+    )
+
+    assert runtime.build_drain_deps(deps, gate=lambda: True).gate_is_open() is True
+
+
+# --- drain callbacks over ChannelOps ------------------------------------------
+
+
+def test_dispatch_callback_redispatches_and_settles(tmp_path):
+    ops = RecordingChannelOps()
+    deps = _deps(tmp_path, ops)
+    entry = _claim(deps.dedup, "m1", text=QUESTION, history_key=HISTORY_KEY)
+
+    runtime.build_drain_callbacks(deps).dispatch("m1", entry)
+
+    assert deps.dispatcher.runs[0][0] == QUESTION
+    ops.assert_order("dispatch", "post_answer")
+    assert deps.dedup.get("m1")["status"] == "completed"
+
+
+def test_dispatch_callback_abandons_an_entry_with_no_text(tmp_path):
+    """Nothing to replay and nothing to re-attach: terminal, or the drain retries it
+    forever."""
+    ops = RecordingChannelOps()
+    deps = _deps(tmp_path, ops)
+    entry = _claim(deps.dedup, "m1", history_key=HISTORY_KEY)
+
+    runtime.build_drain_callbacks(deps).dispatch("m1", entry)
+
+    assert deps.dispatcher.runs == []
+    assert deps.dedup.get("m1")["status"] == "error"
+
+
+def test_deliver_callback_posts_answer_then_files_then_history(tmp_path):
+    ops = RecordingChannelOps(file_urls={"a1": "https://files/a1.png"})
+    deps = _deps(tmp_path, ops)
+    entry = _claim(deps.dedup, "m1", text=QUESTION, history_key=HISTORY_KEY)
+    deps.dedup.record("m1", run_id="run-1", status="queued")
+
+    runtime.build_drain_callbacks(deps).deliver(
+        "m1", entry, {"status": "completed", "text_output": "The orbit is stable."}
+    )
+
+    ops.assert_order("post_answer", "deliver_files")
+    # The raw worker body omits the run id; the binding grafts the persisted one on.
+    assert ops.of("post_answer")[0]["result"]["run_id"] == "run-1"
+    assert [turn["answer"] for turn in deps.history.recent(HISTORY_KEY)] == ["The orbit is stable."]
+    # The drain owns the terminal mark; the callback must not write status.
+    assert deps.dedup.get("m1")["status"] == "queued"
+
+
+def test_deliver_callback_propagates_a_failed_post(tmp_path):
+    """The raise is the drain's at-least-once signal — swallowing it would drop the
+    answer, and nothing after the failed post may run."""
+    ops = RecordingChannelOps()
+    deps = _deps(tmp_path, ops)
+    entry = _claim(deps.dedup, "m1", text=QUESTION, history_key=HISTORY_KEY)
+    ops.fail_next("post_answer", RuntimeError("send failed"))
+
+    with pytest.raises(RuntimeError, match="send failed"):
+        runtime.build_drain_callbacks(deps).deliver("m1", entry, dict(COMPLETED))
+
+    assert ops.count("deliver_files") == 0
+    assert deps.history.recent(HISTORY_KEY) == []
+
+
+def test_deliver_callback_survives_a_raising_file_delivery(tmp_path):
+    """``deliver_files`` must never raise by contract, but the answer has already landed:
+    a misbehaving adapter must not cost the history turn or force a re-delivery."""
+    ops = RecordingChannelOps()
+    deps = _deps(tmp_path, ops)
+    entry = _claim(deps.dedup, "m1", text=QUESTION, history_key=HISTORY_KEY)
+    ops.fail_next("deliver_files", RuntimeError("upload exploded"))
+
+    runtime.build_drain_callbacks(deps).deliver("m1", entry, dict(COMPLETED))
+
+    assert [turn["answer"] for turn in deps.history.recent(HISTORY_KEY)] == [
+        COMPLETED["text_output"]
+    ]
+
+
+def test_give_up_callback_posts_the_notice_and_records_the_failed_turn(tmp_path):
+    ops = RecordingChannelOps()
+    deps = _deps(tmp_path, ops)
+    entry = _claim(deps.dedup, "m1", text=QUESTION, history_key=HISTORY_KEY)
+
+    runtime.build_drain_callbacks(deps).give_up("m1", entry)
+
+    assert ops.count("post_giveup") == 1
+    assert deps.history.recent(HISTORY_KEY) != []
+
+
+def test_give_up_callback_propagates_a_failed_notice(tmp_path):
+    """A lost give-up notice is silence: the raise leaves the entry queued for the next
+    cycle rather than marking it terminal."""
+    ops = RecordingChannelOps()
+    deps = _deps(tmp_path, ops)
+    entry = _claim(deps.dedup, "m1", text=QUESTION, history_key=HISTORY_KEY)
+    ops.fail_next("post_giveup", RuntimeError("notice failed"))
+
+    with pytest.raises(RuntimeError, match="notice failed"):
+        runtime.build_drain_callbacks(deps).give_up("m1", entry)
+
+
+def test_supersede_callback_is_best_effort(tmp_path):
+    ops = RecordingChannelOps()
+    deps = _deps(tmp_path, ops)
+    entry = _claim(deps.dedup, "m1", text=QUESTION, history_key=HISTORY_KEY)
+    ops.fail_next("post_superseded", RuntimeError("note failed"))
+
+    runtime.build_drain_callbacks(deps).supersede("m1", entry)  # must not raise
+
+    assert ops.count("post_superseded") == 1
+    assert deps.history.recent(HISTORY_KEY) == []  # a dropped turn writes no history
+
+
+def test_adapters_implement_channel_ops_only(tmp_path):
+    """The recording double implements ``ChannelOps`` and nothing else; every drain
+    callback is bound from it, so no adapter ever implements both surfaces."""
+    ops = RecordingChannelOps()
+    deps = _deps(tmp_path, ops)
+
+    callbacks = runtime.build_drain_callbacks(deps)
+
+    assert not hasattr(ops, "dispatch") and not hasattr(ops, "deliver")
+    assert callbacks.supersede is not None
+    assert all(callable(cb) for cb in (callbacks.dispatch, callbacks.deliver, callbacks.give_up))
+
+
+# --- re-dispatch payload ------------------------------------------------------
+
+
+def test_rebuild_extra_replays_history_reply_and_inputs(tmp_path):
+    ops = RecordingChannelOps(
+        inputs=InputDownload(
+            files=[
+                {
+                    "filename": "orbit.png",
+                    "mime": "image/png",
+                    "content_b64": _b64(b"bytes"),
+                    "ingest": True,
+                }
+            ]
+        )
+    )
+    deps = _deps(tmp_path, ops)
+    deps.history.append(HISTORY_KEY, "earlier?", "earlier answer")
+    _claim(deps.dedup, "m1", text=QUESTION, history_key=HISTORY_KEY)
+    deps.dedup.record(
+        "m1", run_id=None, status="pending", reply_to={"sender": "Pat", "text": "the plot"}
+    )
+
+    extra = runtime.rebuild_extra(deps, deps.dedup.get("m1"))
+
+    assert [turn["answer"] for turn in extra["conversation_so_far"]] == ["earlier answer"]
+    assert extra["reply_to"]["sender"] == "Pat"
+    assert [f["filename"] for f in extra["input_files"]] == ["orbit.png"]
+    # A COPY of the persisted reply context: per-dispatch keys must not leak into the store.
+    assert extra["reply_to"] is not deps.dedup.get("m1")["reply_to"]
+
+
+def test_rebuild_extra_is_empty_for_a_text_only_entry(tmp_path):
+    """A text-only re-dispatch must stay byte-identical to a live text-only dispatch."""
+    ops = RecordingChannelOps()
+    deps = _deps(tmp_path, ops)
+    _claim(deps.dedup, "m1", text=QUESTION, history_key="")
+
+    assert runtime.rebuild_extra(deps, deps.dedup.get("m1")) == {}
+
+
+# --- the adapter entry point --------------------------------------------------
+
+
+def test_run_forever_serves_the_adapter_loop_then_stops(tmp_path, no_drain):
+    ops = RecordingChannelOps()
+    deps = _deps(tmp_path, ops)
+    seen: dict[str, Any] = {}
+
+    def serve(bridge: runtime.BridgeRuntime) -> None:
+        seen["bridge"] = bridge
+        seen["running"] = not bridge.stop.is_set()
+        # The adapter owns ingestion and feeds the engine one event at a time.
+        seen["outcome"] = bridge.handle_event({"raw": "wire event"})
+        seen["supervised"] = bridge.supervise()
+
+    runtime.run_forever(deps.cfg, ops, serve, deps=deps)
+
+    assert seen["running"] is True
+    assert seen["outcome"] == "ignored"  # the default double parses nothing
+    assert seen["supervised"] is seen["bridge"].thread
+    assert seen["bridge"].stop.is_set()
+    assert len(no_drain) == 1
+
+
+def test_run_forever_stops_the_drain_when_the_loop_raises(tmp_path, no_drain):
+    ops = RecordingChannelOps()
+    deps = _deps(tmp_path, ops)
+    captured: dict[str, Any] = {}
+
+    def serve(bridge: runtime.BridgeRuntime) -> None:
+        captured["bridge"] = bridge
+        raise RuntimeError("subscription died")
+
+    with pytest.raises(RuntimeError, match="subscription died"):
+        runtime.run_forever(deps.cfg, ops, serve, deps=deps)
+
+    assert captured["bridge"].stop.is_set()
+
+
+# --- the package export surface -----------------------------------------------
+
+
+def test_package_exports_the_documented_engine_surface():
+    import osprey.bridges.core as core
+    from osprey.bridges.core import pipeline, ports
+
+    assert len(core.__all__) == len(set(core.__all__))
+    missing = [name for name in core.__all__ if not hasattr(core, name)]
+    assert missing == []
+    assert core.ChannelOps is ports.ChannelOps
+    assert core.RESERVED_ENTRY_KEYS is ports.RESERVED_ENTRY_KEYS
+    assert core.handle_event is pipeline.handle_event
+    assert core.run_forever is runtime.run_forever

--- a/tests/bridges/test_store.py
+++ b/tests/bridges/test_store.py
@@ -1,0 +1,378 @@
+"""Unit tests for the lock-guarded JSON file store in ``osprey.bridges.core.store``.
+
+:class:`JsonFileStore` is the persistence substrate under the dedup, history and
+retry-queue stores, and it has no direct test suite of its own upstream — it is
+covered there only transitively. These tests pin its contract directly:
+
+  * the load path's *asymmetric* error handling (missing/corrupt loads empty, an
+    unreadable volume fails loudly),
+  * the ``_coerce`` normalization hook,
+  * the atomic tmp-then-``os.replace`` write, including tmp cleanup on failure,
+  * the ``threading.Lock`` guard that makes a shared store safe under the
+    bridges' thread-per-callback dispatch model,
+  * and the **on-disk JSON shape**, asserted byte-for-byte. A live deployment's
+    state files must stay readable across upgrades, so a format drift here is a
+    compatibility break and must fail loudly rather than quietly re-serialize.
+
+The store is exercised through a minimal concrete subclass, mirroring how the
+real stores use it: mutate ``_data`` under ``_lock``, then ``_flush_locked``.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from osprey.bridges.core.store import JsonFileStore
+
+
+class _Counter(JsonFileStore):
+    """Smallest realistic subclass: read/modify/write under the inherited lock."""
+
+    def put(self, key: str, value: Any) -> None:
+        with self._lock:
+            self._data[key] = value
+            self._flush_locked()
+
+    def get(self, key: str) -> Any:
+        with self._lock:
+            return self._data.get(key)
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            return dict(self._data)
+
+
+class _Coercing(JsonFileStore):
+    """Subclass that records and rewrites what ``_load`` hands to ``_coerce``."""
+
+    def __init__(self, path: str):
+        self.seen: list[dict] = []
+        super().__init__(path)
+
+    def _coerce(self, loaded: dict) -> dict:
+        self.seen.append(dict(loaded))
+        return {k: v for k, v in loaded.items() if not k.startswith("_")}
+
+
+# --------------------------------------------------------------------------- load
+
+
+def test_missing_file_loads_empty_and_creates_nothing(tmp_path):
+    """A store pointed at a nonexistent path starts empty without touching disk."""
+    path = tmp_path / "state.json"
+
+    store = JsonFileStore(str(path))
+
+    assert store._data == {}
+    assert not path.exists()
+    assert store.path == str(path)
+
+
+def test_corrupt_json_loads_empty(tmp_path):
+    """Unparseable content must load empty rather than crash the bridge at startup."""
+    path = tmp_path / "state.json"
+    path.write_text("{not json at all", encoding="utf-8")
+
+    assert JsonFileStore(str(path))._data == {}
+
+
+def test_non_utf8_bytes_load_empty(tmp_path):
+    """UnicodeDecodeError is a ValueError — a mojibake file also loads empty."""
+    path = tmp_path / "state.json"
+    path.write_bytes(b'{"k": "\xff\xfe"}')
+
+    assert JsonFileStore(str(path))._data == {}
+
+
+@pytest.mark.parametrize("payload", ["[1, 2, 3]", "null", '"a string"', "42"])
+def test_valid_json_that_is_not_an_object_leaves_data_untouched(tmp_path, payload):
+    """Only a JSON *object* is adopted; anything else leaves ``_data`` as it was.
+
+    On a fresh instance that means empty. Note this is NOT the same as the
+    corrupt path: ``_load`` does not reset ``_data`` here, it simply declines to
+    replace it — see :func:`test_reload_over_a_non_object_file_keeps_prior_data`.
+    """
+    path = tmp_path / "state.json"
+    path.write_text(payload, encoding="utf-8")
+
+    assert JsonFileStore(str(path))._data == {}
+
+
+def test_reload_over_a_non_object_file_keeps_prior_data(tmp_path):
+    """Pins the asymmetry: a non-object reload keeps state, a corrupt one clears it."""
+    path = tmp_path / "state.json"
+    store = _Counter(str(path))
+    store.put("a", 1)
+
+    path.write_text("[]", encoding="utf-8")
+    store._load()
+    assert store._data == {"a": 1}  # declined, not cleared
+
+    path.write_text("<<<", encoding="utf-8")
+    store._load()
+    assert store._data == {}  # corrupt clears
+
+
+def test_unreadable_path_raises_rather_than_loading_empty(tmp_path):
+    """OSError is deliberately NOT swallowed: a broken volume must fail loudly.
+
+    Silently starting with an empty dedup store would re-dispatch already
+    answered messages, so only FileNotFoundError/ValueError load as empty.
+    """
+    directory = tmp_path / "state.json"
+    directory.mkdir()
+
+    with pytest.raises(OSError):
+        JsonFileStore(str(directory))
+
+
+def test_coerce_hook_normalizes_the_loaded_mapping(tmp_path):
+    """``_coerce`` sees the raw mapping and its return value becomes the state."""
+    path = tmp_path / "state.json"
+    path.write_text(json.dumps({"keep": 1, "_drop": 2}), encoding="utf-8")
+
+    store = _Coercing(str(path))
+
+    assert store.seen == [{"keep": 1, "_drop": 2}]
+    assert store._data == {"keep": 1}
+
+
+def test_coerce_hook_is_not_called_when_the_file_is_absent(tmp_path):
+    """No file, no mapping to normalize — subclasses may rely on this."""
+    store = _Coercing(str(tmp_path / "missing.json"))
+
+    assert store.seen == []
+    assert store._data == {}
+
+
+# ------------------------------------------------------------------------ write
+
+
+def test_write_then_read_round_trip_preserves_structure_and_types(tmp_path):
+    """A fresh instance reading the same path recovers the exact nested value."""
+    path = tmp_path / "state.json"
+    payload = {
+        "msg-1": {
+            "status": "completed",
+            "attempts": 3,
+            "score": 1.5,
+            "done": True,
+            "run_id": None,
+            "artifacts": ["a.png", "b.txt"],
+            "nested": {"turns": [{"question": "q", "answer": "a"}]},
+        }
+    }
+
+    store = _Counter(str(path))
+    store.put("msg-1", payload["msg-1"])
+
+    reloaded = _Counter(str(path))
+    assert reloaded.snapshot() == payload
+    entry = reloaded.get("msg-1")
+    assert isinstance(entry["attempts"], int)
+    assert isinstance(entry["score"], float)
+    assert entry["done"] is True
+    assert entry["run_id"] is None
+
+
+def test_on_disk_artifact_is_plain_json_with_the_documented_shape(tmp_path):
+    """Format guard: 2-space-indented, ASCII-escaped JSON object, no trailing newline.
+
+    A deployment upgrading onto this engine must be able to read its existing
+    state files, so any change to this serialization is a compatibility break.
+    """
+    path = tmp_path / "state.json"
+    store = _Counter(str(path))
+    store.put("msg-1", {"status": "completed", "note": "café"})
+
+    raw = path.read_text(encoding="utf-8")
+
+    assert json.loads(raw) == {"msg-1": {"status": "completed", "note": "café"}}
+    assert raw.startswith("{\n")
+    assert '\n  "msg-1": {\n' in raw  # indent=2, default separators
+    assert "caf\\u00e9" in raw  # ensure_ascii default
+    assert not raw.endswith("\n")
+
+
+def test_empty_store_writes_an_empty_json_object(tmp_path):
+    """The empty state is ``{}`` on disk, and reloads as empty."""
+    path = tmp_path / "state.json"
+    store = _Counter(str(path))
+
+    with store._lock:
+        store._flush_locked()
+
+    assert path.read_text(encoding="utf-8") == "{}"
+    assert _Counter(str(path))._data == {}
+
+
+def test_flush_creates_missing_parent_directories(tmp_path):
+    """First write on a fresh volume must not require the directory to exist."""
+    path = tmp_path / "deep" / "nested" / "state.json"
+    store = _Counter(str(path))
+
+    store.put("k", "v")
+
+    assert json.loads(path.read_text(encoding="utf-8")) == {"k": "v"}
+
+
+def test_flush_handles_a_bare_filename_relative_to_cwd(tmp_path, monkeypatch):
+    """``os.path.dirname`` is empty for a bare filename; the store falls back to "."."""
+    monkeypatch.chdir(tmp_path)
+    store = _Counter("state.json")
+
+    store.put("k", "v")
+
+    assert json.loads((tmp_path / "state.json").read_text(encoding="utf-8")) == {"k": "v"}
+
+
+def test_successful_write_leaves_no_temporary_files(tmp_path):
+    """The tmp file is renamed into place, never left behind."""
+    path = tmp_path / "state.json"
+    store = _Counter(str(path))
+
+    for i in range(5):
+        store.put(f"k{i}", i)
+
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["state.json"]
+
+
+def test_failed_dump_unlinks_the_tmp_file_and_reraises(tmp_path):
+    """A non-serializable value must not leave debris or a truncated state file."""
+    path = tmp_path / "state.json"
+    store = _Counter(str(path))
+    store.put("good", 1)
+    before = path.read_text(encoding="utf-8")
+
+    with pytest.raises(TypeError):
+        store.put("bad", object())
+
+    assert path.read_text(encoding="utf-8") == before  # previous state intact
+    assert [p.name for p in tmp_path.iterdir()] == ["state.json"]
+
+
+def test_tmp_file_is_created_in_the_target_directory(tmp_path, monkeypatch):
+    """``os.replace`` is only atomic within one filesystem, so the tmp file must
+    be a sibling of the target — not in the system temp dir."""
+    path = tmp_path / "deep" / "state.json"
+    store = _Counter(str(path))
+    seen: list[str] = []
+
+    real_mkstemp = tempfile.mkstemp
+
+    def spy(*args, **kwargs):
+        seen.append(kwargs.get("dir", ""))
+        return real_mkstemp(*args, **kwargs)
+
+    monkeypatch.setattr("osprey.bridges.core.store.tempfile.mkstemp", spy)
+    store.put("k", "v")
+
+    assert seen == [str(tmp_path / "deep")]
+
+
+# ------------------------------------------------------------------ concurrency
+
+
+def test_lock_serializes_concurrent_read_modify_write(tmp_path):
+    """The ``threading.Lock`` guard must prevent lost updates.
+
+    This is the property the adapters' thread-per-room concurrency model depends
+    on: many threads mutate one shared store. Each worker does a genuine
+    read/modify/write with a yield in the middle of the critical section, so an
+    unguarded implementation would interleave and lose increments. The store is
+    also instrumented to assert mutual exclusion directly.
+    """
+    path = tmp_path / "state.json"
+    store = _Counter(str(path))
+    store.put("n", 0)
+
+    workers, per_worker = 8, 40
+    barrier = threading.Barrier(workers)
+    inside = 0
+    overlaps: list[int] = []
+    probe = threading.Lock()
+    errors: list[BaseException] = []
+
+    def bump() -> None:
+        nonlocal inside
+        try:
+            barrier.wait(timeout=10)
+            for _ in range(per_worker):
+                with store._lock:
+                    with probe:
+                        inside += 1
+                        if inside > 1:
+                            overlaps.append(inside)
+                    current = store._data["n"]
+                    time.sleep(0)  # yield the GIL mid-critical-section
+                    store._data["n"] = current + 1
+                    store._flush_locked()
+                    with probe:
+                        inside -= 1
+        except BaseException as exc:  # surface in the main thread
+            errors.append(exc)
+
+    threads = [threading.Thread(target=bump) for _ in range(workers)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert errors == []
+    assert not any(t.is_alive() for t in threads)
+    assert overlaps == [], "two threads were inside the guarded region at once"
+    assert store.get("n") == workers * per_worker
+    assert json.loads(path.read_text(encoding="utf-8")) == {"n": workers * per_worker}
+
+
+def test_concurrent_writers_never_expose_a_partial_file(tmp_path):
+    """A reader racing the writers always sees a complete, parseable JSON object.
+
+    This is what the tmp-then-``os.replace`` write buys: readers never observe a
+    half-written state file.
+    """
+    path = tmp_path / "state.json"
+    store = _Counter(str(path))
+    store.put("seed", 0)
+
+    stop = threading.Event()
+    reads = 0
+    errors: list[BaseException] = []
+
+    def write() -> None:
+        try:
+            for i in range(150):
+                store.put(f"k{i}", {"i": i, "blob": "x" * 200})
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            stop.set()
+
+    def read() -> None:
+        nonlocal reads
+        try:
+            while not stop.is_set():
+                try:
+                    parsed = json.loads(path.read_text(encoding="utf-8"))
+                except FileNotFoundError:
+                    continue
+                assert isinstance(parsed, dict) and "seed" in parsed
+                reads += 1
+        except BaseException as exc:
+            errors.append(exc)
+
+    writer, reader = threading.Thread(target=write), threading.Thread(target=read)
+    writer.start()
+    reader.start()
+    writer.join(timeout=30)
+    reader.join(timeout=30)
+
+    assert errors == []
+    assert reads, "reader never observed the file"
+    assert len(store.snapshot()) == 151


### PR DESCRIPTION
Adds `osprey.bridges.core`: a channel-agnostic engine for connecting a messaging
channel (chat, email, …) to the OSPREY dispatcher/worker pair as its own process.

A bridge has to survive things a request/response service does not — the platform
redelivers messages, the pair goes down mid-answer, the process restarts with runs
still in flight, and a user asks three questions during an outage. The rules that
make those cases safe are the same for every channel, and they are ordering rules:
claim before dispatching, acknowledge before the long wait, record history only
once the answer has actually landed. This puts them in one place.

**`ChannelOps` is the seam.** A channel implements parse/ack/download/post/deliver
and the queued, give-up and superseded notices; the engine owns everything around
them. Destination addressing is deliberately not modelled — a chat room, an email
thread and a room token have nothing useful in common — so an adapter stamps
whatever it needs onto the dedup claim, and every outbound call reads it back off
the persisted entry rather than off the wire event. That round-trip is what lets a
single adapter implementation serve the live path, the retry drain and startup
recovery identically, since the latter two run long after the event is gone.

Each protocol member also carries an explicit failure contract, because crash-safety
depends on which calls may raise: a failed answer must leave the entry queued for
redelivery, while a failed artifact upload must *not* un-deliver an answer that has
already landed.

**What's included:** the lock-guarded state stores, the three-step dispatch handshake,
a fail-closed capability probe and health gate, worker artifact fetching, the pure
retry policy, the supervised retry drain, and the message pipeline, reconcile and
runtime built on the seam. 466 hermetic tests; nothing touches the network.

**What's not:** any channel adapter. The engine ships with no platform SDK
dependency and needs nothing beyond `httpx`, which is already a core dependency.

Two safety properties worth calling out for review:

- `may_redispatch` is fail-closed. A failed run is replayed only when a *known*
  tool-call count of zero proves it had no side effects; an unknown count refuses.
  Where a dispatched run can reach hardware, an unproven retry is a repeated
  machine action.
- Startup recovery re-attaches to any run that already has an id and re-dispatches
  only those claimed before one existed — which is safe precisely because no run
  was ever started for them.

## How it hangs together

```text
  channel adapter  (implements ChannelOps; owns its own inbound loop)
         │
         │  handle_event(event, deps)
         ▼
  ┌─ pipeline ──────────────────────────────────────────────────┐
  │  parse ─► claim ─► ack ─► reply ctx ─► history ─► probe×1   │
  │            │        │                                       │
  │            │        └── first thing after a won claim       │
  │            └── persists metadata BEFORE anything fires      │
  └────────────────────────────┬────────────────────────────────┘
                               ▼
                       dispatch_client
                  webhook ─► dispatcher ─► worker
                               │
                    ┌──────────┴───────────┐
              terminal                 retryable
                    │                      │
                    ▼                      ▼
        post_answer ─► deliver_files   retry_queue.park
                    │                      │  supersede older
                    ▼                      │  siblings, notice
             history.append                ▼
          (only after a good post)      [ queued ]
                                           │
                                           ▼
                            drain  (one daemon thread, all rooms)
                            gate_open? ─► health_gate ─► both /health
                                           │
                            replay newest · give up · supersede

  process start ─► reconcile
                     has run_id ? ─► re-attach + poll   (never re-dispatches)
                     no  run_id ? ─► re-dispatch        (safe: none was started)

  ── state ──────────────────────────────────────────────────────
  dedup · history  ──►  JsonFileStore   lock-guarded, atomic replace
```
