### PR TITLE
Report found provider credentials at build; fail --dev when the local wheel can't be built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Changed
 
+- `osprey build` now prints a provider-credentials summary that reports the API
+  keys it *found*, not just the ones it didn't. It leads with the provider the
+  project was built for, names where that key came from (project `.env`, the
+  build directory's `.env`, or the shell), and warns if the selected provider's
+  key is missing. Previously the build logged one line per *unresolved*
+  placeholder — twice — so a successful key was silent, and a missing key for
+  the selected provider looked identical to the irrelevant misses for providers
+  the project never uses. The per-placeholder resolver line moved to `DEBUG`.
 - Scaffolded `.env` / `.env.example` files derive their provider API-key list
   from the provider registry instead of a hand-maintained list (which had
   drifted: `ALS_APG_API_KEY` was missing, a stale Langfuse block remained, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Changed
 
+- `osprey deploy --dev` now fails with a clear error when the local osprey wheel
+  cannot be built, instead of warning and deploying the pinned PyPI release.
+  Previously a missing `build` package (or a broken local checkout) produced one
+  warning among many info lines and an exit code of 0, so the containers came up
+  running released osprey and the deployment silently tested something other than
+  the local code. The preconditions — editable install, source checkout, `build`
+  package — are now checked before any deploy work begins, and `build` moved from
+  the `dev` extra to a base dependency so an editable install always has it.
 - `osprey build` now prints a provider-credentials summary that reports the API
   keys it *found*, not just the ones it didn't. It leads with the provider the
   project was built for, names where that key came from (project `.env`, the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,11 @@ dependencies = [
     "tenacity>=9.1.4",
     # Cross-version TypedDict/NotRequired — pydantic v2.12 rejects typing.TypedDict on py<3.12.
     "typing_extensions>=4.12.0",
+    # `osprey deploy up --dev` builds a wheel from the local checkout. A shipped
+    # CLI flag must not depend on an optional extra: an editable install without
+    # `--extra dev` would otherwise satisfy every other --dev precondition and
+    # fail only at wheel-build time.
+    "build",
 ]
 
 [project.optional-dependencies]
@@ -159,7 +164,6 @@ dev = [
     "mypy",
     "pre-commit",
     "ruff",
-    "build",  # Required for 'osprey deploy up --dev' to build local wheel
     "testcontainers[postgres]>=4.14.2",  # Real PostgreSQL for integration tests
     "testcontainers[mongodb]>=4.14.2",  # MongoDB for archiver-mongodb integration tests
     "docker>=7.2.0",  # Docker SDK for testcontainers availability check

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -36,6 +36,7 @@ from .build_environment import (
     _create_project_venv,
     _generate_env_template,
     _resolve_osprey_spec,
+    report_provider_credentials,
 )
 from .build_injectors import (
     _copy_service_templates,
@@ -87,6 +88,7 @@ __all__ = [
     "_resolve_osprey_spec",
     "_run_lifecycle_phase",
     "build",
+    "report_provider_credentials",
 ]
 
 
@@ -558,6 +560,10 @@ def build(
         # 14. Generate .env.template
         if build_profile.env.required or build_profile.env.defaults:
             _generate_env_template(project_path, build_profile.env)
+
+        # 15. Report provider credentials. Runs after every .env write above so
+        # the summary reflects what the project actually ships with.
+        report_provider_credentials(project_path, build_profile.provider)
 
         # 16. Generate manifest
         manifest_context = {

--- a/src/osprey/cli/build_environment.py
+++ b/src/osprey/cli/build_environment.py
@@ -14,6 +14,7 @@ import os
 import re
 import shutil
 import subprocess
+from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
 from typing import Any
@@ -23,6 +24,147 @@ from osprey.errors import BuildProfileError
 from osprey.utils.logger import get_logger
 
 logger = get_logger("build")
+
+
+@dataclass(frozen=True, slots=True)
+class CredentialStatus:
+    """Whether one provider's API-key env var is available to the built project.
+
+    ``source`` is a human-readable origin (``"project .env"``, ``"shell
+    environment"``, ``".env in <dir>"``) and is ``None`` when the key is not
+    set. The key's *value* is deliberately never carried — this record is built
+    to be logged.
+    """
+
+    provider: str
+    var: str
+    found: bool
+    source: str | None = None
+
+
+def _dotenv_keys(path: Path) -> dict[str, str]:
+    """Parse *path* into a dict, dropping empty values. Unreadable → ``{}``.
+
+    Empty values matter: ``.env.template`` ships bare ``VAR=`` lines, and a key
+    with no value authenticates nothing.
+    """
+    if not path.is_file():
+        return {}
+    from osprey.utils.dotenv import parse_dotenv_file
+
+    try:
+        return {key: value for key, value in parse_dotenv_file(path).items() if value}
+    except OSError as e:
+        # e.g. a 0600 .env owned by another uid — report as "not set" rather
+        # than failing a build that is otherwise complete.
+        logger.debug("Could not read %s while checking provider credentials: %s", path, e)
+        return {}
+
+
+def detect_provider_credentials(
+    project_path: Path, *, cwd: Path | None = None
+) -> list[CredentialStatus]:
+    """Resolve every keyed provider's API-key env var to a found/not-found status.
+
+    Sources are checked in the order that actually determines whether the built
+    project can authenticate:
+
+    1. the built project's ``.env`` — what ships with the project;
+    2. the build's working-directory ``.env`` — ``osprey.utils.config`` loads
+       this into ``os.environ`` as an import side effect, so it is a real
+       source even though nothing in the build reads it explicitly;
+    3. the shell environment.
+
+    Keyless providers (ollama, vllm, ds4, asksage) are excluded — they have no
+    API-key env var to report on.
+
+    Args:
+        project_path: Root of the built project.
+        cwd: Directory whose ``.env`` acts as source 2. Defaults to the process
+            working directory.
+
+    Returns:
+        One :class:`CredentialStatus` per keyed provider, in registry order.
+    """
+    from osprey.models.provider_registry import PROVIDER_API_KEYS
+
+    cwd = Path.cwd() if cwd is None else cwd
+    project_env = _dotenv_keys(project_path / ".env")
+    cwd_env_path = cwd / ".env"
+    # Skip when the build ran from inside the project: same file, already read.
+    cwd_env = (
+        {}
+        if cwd_env_path.resolve() == (project_path / ".env").resolve()
+        else _dotenv_keys(cwd_env_path)
+    )
+
+    statuses: list[CredentialStatus] = []
+    for provider, var in PROVIDER_API_KEYS.items():
+        if var is None:
+            continue
+        if var in project_env:
+            source: str | None = "project .env"
+        elif var in cwd_env:
+            source = f".env in {cwd}"
+        elif os.environ.get(var):
+            source = "shell environment"
+        else:
+            source = None
+        statuses.append(
+            CredentialStatus(provider=provider, var=var, found=source is not None, source=source)
+        )
+    return statuses
+
+
+def report_provider_credentials(
+    project_path: Path, provider: str, *, cwd: Path | None = None
+) -> list[CredentialStatus]:
+    """Log a provider-credentials summary, leading with the selected provider.
+
+    Reports keys that *were* found as well as those that were not. The generic
+    ``${VAR}`` resolver in :mod:`osprey.utils.config` can only report misses —
+    and knows nothing about which provider the build selected — so a missing key
+    for the selected provider would otherwise be indistinguishable from the
+    handful of irrelevant misses for providers the project will never use.
+
+    A missing key warns but never aborts: the project is still worth building,
+    and the key can be filled into ``.env`` afterwards.
+
+    Args:
+        project_path: Root of the built project.
+        provider: The provider this project was built for.
+        cwd: Passed through to :func:`detect_provider_credentials`.
+
+    Returns:
+        The statuses that were reported.
+    """
+    from osprey.models.provider_registry import PROVIDER_API_KEYS
+
+    statuses = detect_provider_credentials(project_path, cwd=cwd)
+    selected = next((s for s in statuses if s.provider == provider), None)
+
+    if selected is None:
+        # Keyless provider, or a name outside the registry (custom adapter).
+        if provider in PROVIDER_API_KEYS:
+            logger.info("  ✓ Provider: %s — no API key required", provider)
+        else:
+            logger.info("  ✓ Provider: %s — no known API key env var; skipping check", provider)
+    elif selected.found:
+        logger.info("  ✓ Provider: %s — %s found (%s)", provider, selected.var, selected.source)
+    else:
+        logger.warning("  ✗ Provider: %s — %s NOT SET", provider, selected.var)
+        logger.warning("      The build will complete, but the agent cannot reach the model.")
+        logger.warning("      Add %s to %s or export it.", selected.var, project_path / ".env")
+
+    others = [s for s in statuses if s is not selected]
+    found_others = [s.var for s in others if s.found]
+    missing_others = [s.var for s in others if not s.found]
+    if found_others:
+        logger.info("      Other keys detected: %s", ", ".join(found_others))
+    if missing_others:
+        logger.info("      Not set:             %s", ", ".join(missing_others))
+
+    return statuses
 
 
 def _copy_env_file(profile_dir: Path, project_path: Path, env_file: str) -> None:

--- a/src/osprey/cli/deploy_cmd.py
+++ b/src/osprey/cli/deploy_cmd.py
@@ -14,6 +14,7 @@ from osprey.deployment.container_manager import (
     rebuild_deployment,
     show_status,
 )
+from osprey.deployment.errors import DevModeUnavailableError
 
 from .project_utils import resolve_config_path, resolve_project_path
 
@@ -347,6 +348,16 @@ def deploy(
 
     except KeyboardInterrupt:
         console.print("\n!  Operation cancelled by user", style=Styles.WARNING)
+        raise click.Abort() from None
+    except DevModeUnavailableError as e:
+        # Rendered ahead of the generic handler: the reason alone is not
+        # actionable, and this failure is precisely the one that used to be a
+        # warning nobody saw. Print the remedy and say plainly that nothing was
+        # deployed, so it cannot be mistaken for a partial success.
+        console.print(f"\n✗ --dev cannot be honored: {e.reason}\n", style=Styles.ERROR)
+        for line in e.remedy.splitlines():
+            console.print(f"  {line}" if line else "")
+        console.print("\n  Nothing was deployed.\n", style=Styles.WARNING)
         raise click.Abort() from None
     except Exception as e:
         console.print(f"✗ Deployment failed: {e}", style=Styles.ERROR)

--- a/src/osprey/deployment/compose_generator.py
+++ b/src/osprey/deployment/compose_generator.py
@@ -22,6 +22,7 @@ from osprey.deployment.runtime_helper import get_runtime_command, runtime_env
 # and conftest keep patching / importing it from this module's namespace.
 from osprey.deployment.wheel_build import (
     _copy_local_framework_for_override,
+    preflight_dev_mode,
 )
 from osprey.deployment.wheel_build import (
     _reset_wheel_build_cache as _reset_wheel_build_cache,
@@ -338,20 +339,20 @@ def _stage_dev_wheel_for_context(out_dir, dev_mode):
         logger.info("Production mode: Containers will install osprey from PyPI")
         return False
     if not os.path.isfile(os.path.join(out_dir, "Dockerfile")):
-        logger.info(
+        # Routine and correct: pure-image services (postgresql, openobserve)
+        # never install osprey. DEBUG, not INFO — at INFO these lines outnumber
+        # the ones that carry a decision and bury them.
+        logger.debug(
             f"Development mode: build context {out_dir} has no Dockerfile, "
             "so no osprey wheel was staged for it"
         )
         return False
-    if _copy_local_framework_for_override(out_dir):
-        logger.key_info("Development mode: Osprey override prepared")
-        return True
-    logger.warning(
-        "Development mode requested but osprey wheel staging failed; "
-        "OSPREY_DEV will not be set for this build, so the pinned PyPI "
-        "install applies"
-    )
-    return False
+    # Raises DevModeUnavailableError rather than returning False when --dev
+    # cannot be honored; the deploy stops instead of silently deploying the
+    # pinned PyPI release under a flag that means "run my local code".
+    _copy_local_framework_for_override(out_dir)
+    logger.debug("Development mode: Osprey override prepared")
+    return True
 
 
 def render_kernel_templates(source_dir, config, out_dir):
@@ -934,6 +935,11 @@ def prepare_compose_files(config_path, dev_mode=False, expose_network=False):
     :rtype: tuple[dict, list[str]]
     :raises RuntimeError: If configuration loading fails
     """
+    # Fail before any work when --dev cannot be honored: every precondition is
+    # a path check away, so there is no reason to surface it seven services in.
+    if dev_mode:
+        preflight_dev_mode()
+
     try:
         with quiet_logger(["registry", "CONFIG"]):
             config = ConfigBuilder(config_path)

--- a/src/osprey/deployment/errors.py
+++ b/src/osprey/deployment/errors.py
@@ -1,0 +1,32 @@
+"""Deployment-subsystem errors.
+
+Recurring domain errors for container deployment. Framework-level, cross-cutting
+errors live in :mod:`osprey.errors`.
+"""
+
+from __future__ import annotations
+
+
+class DeploymentError(Exception):
+    """Base class for deployment failures."""
+
+
+class DevModeUnavailableError(DeploymentError):
+    """``--dev`` was requested but the local osprey wheel cannot be produced.
+
+    ``--dev`` is a statement about *which code runs in the containers*: build a
+    wheel from the local checkout so the containers run it instead of the pinned
+    PyPI release. When that cannot be done, continuing would deploy a different
+    codebase than the one asked for — the containers would come up healthy,
+    running released osprey, with no signal that the local checkout was never
+    involved. That is worse than not deploying: it silently invalidates whatever
+    the deployment was meant to test.
+
+    So this is an error rather than a warning. It carries a ``remedy`` describing
+    how to satisfy the precondition, which the CLI renders beneath the reason.
+    """
+
+    def __init__(self, reason: str, remedy: str) -> None:
+        self.reason = reason
+        self.remedy = remedy
+        super().__init__(f"--dev cannot be honored: {reason}")

--- a/src/osprey/deployment/wheel_build.py
+++ b/src/osprey/deployment/wheel_build.py
@@ -22,9 +22,65 @@ import os
 import shutil
 from pathlib import Path
 
+from osprey.deployment.errors import DevModeUnavailableError
 from osprey.utils.logger import get_logger
 
 logger = get_logger("deployment.compose")
+
+
+def preflight_dev_mode():
+    """Verify ``--dev`` can be honored, or raise before any deploy work begins.
+
+    Every precondition here is knowable in microseconds — an import-path check,
+    a ``stat``, and a module-spec lookup — so the check runs at the top of a
+    deploy rather than surfacing seven services in, after a subprocess launch.
+
+    This exists because the failure it guards is invisible by construction: a
+    ``--dev`` deploy that cannot stage a wheel still brings containers up
+    *successfully*, running the pinned PyPI release. Nothing downstream looks
+    wrong; the deployment simply is not testing the code the user meant to test.
+
+    :raises DevModeUnavailableError: If osprey is not installed editable, its
+        source root has no ``pyproject.toml``, or the ``build`` package is
+        missing.
+    """
+    import importlib.util
+
+    try:
+        import osprey
+    except ImportError as e:  # pragma: no cover — osprey is importing this module
+        raise DevModeUnavailableError(
+            "the osprey package could not be imported",
+            "Reinstall osprey: uv pip install -e <path-to-osprey-checkout>",
+        ) from e
+
+    module_path = Path(osprey.__file__).parent
+    path_str = str(module_path)
+    if "site-packages" in path_str or "dist-packages" in path_str:
+        raise DevModeUnavailableError(
+            f"osprey is installed from PyPI, not as an editable checkout ({path_str})",
+            "--dev builds a wheel from a local osprey source tree, which a "
+            "released install does not have.\n"
+            "Reinstall editable: uv pip install -e <path-to-osprey-checkout>",
+        )
+
+    source_root = module_path.parent.parent
+    if not (source_root / "pyproject.toml").exists():
+        raise DevModeUnavailableError(
+            f"no pyproject.toml found at the osprey source root ({source_root})",
+            "--dev needs a complete source checkout to build a wheel from.\n"
+            "Reinstall editable from a full checkout: uv pip install -e <path-to-osprey-checkout>",
+        )
+
+    if importlib.util.find_spec("build") is None:
+        raise DevModeUnavailableError(
+            "the 'build' package is not installed in the environment running osprey",
+            "--dev builds a wheel from your local osprey checkout so the "
+            "containers run your code instead of the pinned PyPI release.\n"
+            "Install it with:  uv sync --extra dev\n"
+            "        or with:  uv pip install build",
+        )
+
 
 # Staged next to every dev wheel (see ``_copy_local_framework_for_override``
 # below): the wheel's own base dependency list, which the Dockerfiles' deps
@@ -189,21 +245,31 @@ def _build_dev_wheel_cached(osprey_source_root):
         )
 
         if result.returncode != 0:
-            # Check for missing 'build' package
+            # A failed build is the most dangerous of the --dev failure modes:
+            # if the local checkout is broken, continuing would deploy the
+            # RELEASED code under a flag that says "run my local code", so the
+            # very changes being tested are invisible. Raise rather than warn,
+            # and do not memoize — the next call should retry a fixed checkout.
             if "No module named build" in result.stderr:
-                logger.warning(
-                    "The 'build' package is required for --dev mode. Install with: "
-                    r"uv pip install build or pip install build"
+                raise DevModeUnavailableError(
+                    "the 'build' package is not installed in the environment running osprey",
+                    "Install it with:  uv sync --extra dev\n        or with:  uv pip install build",
                 )
-            else:
-                logger.warning(f"Failed to build osprey wheel: {result.stderr}")
+            raise DevModeUnavailableError(
+                f"building a wheel from the local osprey checkout at {osprey_source_root} failed",
+                f"Fix the build error below, then re-run:\n\n{result.stderr.strip()}",
+            )
         else:
             # Find the built wheel and move it to the memo-owned cache dir
             # (tmpdir is deleted on exit; the cache must outlive it so later
             # staging calls can copy the same build instead of rebuilding).
             wheel_files = list(Path(tmpdir).glob("*.whl"))
             if not wheel_files:
-                logger.warning("No wheel file found after build")
+                raise DevModeUnavailableError(
+                    "the wheel build reported success but produced no .whl file",
+                    f"Check the build backend configured in "
+                    f"{osprey_source_root / 'pyproject.toml'}.",
+                )
             else:
                 if _wheel_cache_dir is None:
                     _wheel_cache_dir = tempfile.mkdtemp(prefix="osprey-dev-wheel-cache-")
@@ -259,12 +325,12 @@ def _copy_local_framework_for_override(out_dir):
         # If installed from site-packages, we can't build a wheel from the source
         osprey_path_str = str(osprey_module_path)
         if "site-packages" in osprey_path_str or "dist-packages" in osprey_path_str:
-            logger.warning(
-                "Osprey is installed from PyPI, not in editable mode. "
-                "The --dev flag requires an editable install to build a local wheel. "
-                "To use --dev, reinstall osprey with: uv pip install -e <path> or pip install -e <path>"
+            raise DevModeUnavailableError(
+                f"osprey is installed from PyPI, not as an editable checkout ({osprey_path_str})",
+                "--dev builds a wheel from a local osprey source tree, which a "
+                "released install does not have.\n"
+                "Reinstall editable: uv pip install -e <path-to-osprey-checkout>",
             )
-            return False
 
         # Get the osprey source root (go up from src/osprey to root)
         osprey_source_root = osprey_module_path.parent.parent
@@ -272,14 +338,14 @@ def _copy_local_framework_for_override(out_dir):
         # Verify this looks like a valid osprey source directory
         pyproject_path = osprey_source_root / "pyproject.toml"
         if not pyproject_path.exists():
-            logger.warning(
-                f"No pyproject.toml found at {osprey_source_root}, cannot build wheel from source"
+            raise DevModeUnavailableError(
+                f"no pyproject.toml found at the osprey source root ({osprey_source_root})",
+                "--dev needs a complete source checkout to build a wheel from.\n"
+                "Reinstall editable from a full checkout: "
+                "uv pip install -e <path-to-osprey-checkout>",
             )
-            return False
 
         cached_wheel = _build_dev_wheel_cached(osprey_source_root)
-        if cached_wheel is None:
-            return False
 
         # Copy the cached wheel to this call's output directory
         dest_wheel = os.path.join(out_dir, cached_wheel.name)
@@ -298,18 +364,32 @@ def _copy_local_framework_for_override(out_dir):
                 os.remove(dest_wheel)
             except OSError:
                 pass
-            logger.warning(
-                f"Failed to write {LOCAL_REQUIREMENTS_FILENAME} for dev override: {manifest_error}"
-            )
-            return False
+            raise DevModeUnavailableError(
+                f"could not write {LOCAL_REQUIREMENTS_FILENAME} beside the staged "
+                f"wheel ({manifest_error})",
+                "A context holding a wheel without its requirements manifest is "
+                "half-staged and would build against the released pin's "
+                "dependencies.\nCheck that the build context directory is writable.",
+            ) from manifest_error
 
         logger.success(f"Copied osprey wheel: {cached_wheel.name}")
 
         return True
 
-    except ImportError:
-        logger.warning("Osprey not found in local environment, containers will use PyPI version")
-        return False
+    except DevModeUnavailableError:
+        # The whole point of this error: --dev could not be honored, so the
+        # deploy must stop rather than quietly fall back to the PyPI release.
+        # Must be re-raised ahead of the broad handlers below.
+        raise
+    except ImportError as e:
+        raise DevModeUnavailableError(
+            "the osprey package could not be imported from the local environment",
+            "Reinstall osprey: uv pip install -e <path-to-osprey-checkout>",
+        ) from e
     except Exception as e:
-        logger.warning(f"Failed to build osprey wheel for dev override: {e}")
-        return False
+        # Any other staging failure is the same hazard wearing a different
+        # exception type: continuing would deploy released osprey under --dev.
+        raise DevModeUnavailableError(
+            f"staging the local osprey wheel failed: {e}",
+            "Re-run once the error above is resolved.",
+        ) from e

--- a/src/osprey/utils/config.py
+++ b/src/osprey/utils/config.py
@@ -80,9 +80,18 @@ def resolve_env_vars(data: Any, *, environ: "Mapping[str, str] | None" = None) -
                 if default_value is not None:
                     return default_value
                 else:
+                    # DEBUG, not INFO: this resolver is generic over the whole
+                    # config tree and knows nothing about which of the values it
+                    # walks actually matter to the caller. Reported at INFO it
+                    # rendered every build as a wall of misses for providers the
+                    # project never uses, while saying nothing about the keys
+                    # that *did* resolve. User-facing credential reporting lives
+                    # in osprey.cli.build_environment.report_provider_credentials,
+                    # which knows the selected provider.
                     if not os.environ.get("OSPREY_QUIET"):
-                        logger.info(
-                            f"Environment variable '{var_name}' not found, keeping original value"
+                        logger.debug(
+                            f"Environment variable '{var_name}' not found, "
+                            f"keeping placeholder verbatim"
                         )
                     return match.group(0)
             return env_value

--- a/tests/cli/test_build_provider_credentials.py
+++ b/tests/cli/test_build_provider_credentials.py
@@ -1,0 +1,223 @@
+"""Tests for the build-time provider credential summary.
+
+``osprey build`` used to report provider API keys only by their *absence*: the
+generic ``${VAR}`` resolver logged one INFO line per unresolved placeholder and
+said nothing at all about the keys it did resolve. That made the build output
+the complement of the useful signal — and never asserted the one fact that
+matters, namely whether the *selected* provider's key is available.
+
+These tests pin the replacement: an explicit summary that names the selected
+provider, states where its key came from, and groups the rest.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from osprey.cli.build_environment import (
+    CredentialStatus,
+    detect_provider_credentials,
+    report_provider_credentials,
+)
+
+
+@pytest.fixture
+def project(tmp_path):
+    """An empty built-project directory."""
+    p = tmp_path / "my-control-assistant"
+    p.mkdir()
+    return p
+
+
+@pytest.fixture(autouse=True)
+def _clear_provider_keys(monkeypatch):
+    """Drop every provider key from the process env.
+
+    ``osprey.utils.config`` eagerly loads a cwd ``.env`` into ``os.environ`` at
+    import time, so a developer's real keys would otherwise leak into these
+    assertions.
+    """
+    from osprey.models.provider_registry import PROVIDER_API_KEYS
+
+    for var in PROVIDER_API_KEYS.values():
+        if var is not None:
+            monkeypatch.delenv(var, raising=False)
+
+
+def _status_for(statuses: list[CredentialStatus], provider: str) -> CredentialStatus:
+    return next(s for s in statuses if s.provider == provider)
+
+
+class TestDetectProviderCredentials:
+    """Detection covers every source the built project can authenticate from."""
+
+    def test_key_in_project_env_is_found(self, project, tmp_path):
+        (project / ".env").write_text("CBORG_API_KEY=secret\n", encoding="utf-8")
+
+        statuses = detect_provider_credentials(project, cwd=tmp_path)
+
+        cborg = _status_for(statuses, "cborg")
+        assert cborg.found is True
+        assert cborg.var == "CBORG_API_KEY"
+        assert cborg.source == "project .env"
+
+    def test_key_in_shell_environment_is_found(self, project, tmp_path, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-xxx")
+
+        statuses = detect_provider_credentials(project, cwd=tmp_path)
+
+        anthropic = _status_for(statuses, "anthropic")
+        assert anthropic.found is True
+        assert anthropic.source == "shell environment"
+
+    def test_key_in_cwd_dotenv_is_found(self, project, tmp_path):
+        """The build's own cwd ``.env`` — the case that confused the user."""
+        (tmp_path / ".env").write_text("CBORG_API_KEY=secret\n", encoding="utf-8")
+
+        statuses = detect_provider_credentials(project, cwd=tmp_path)
+
+        cborg = _status_for(statuses, "cborg")
+        assert cborg.found is True
+        assert str(tmp_path) in cborg.source
+
+    def test_project_env_wins_over_cwd_dotenv(self, project, tmp_path):
+        (tmp_path / ".env").write_text("CBORG_API_KEY=from-cwd\n", encoding="utf-8")
+        (project / ".env").write_text("CBORG_API_KEY=from-project\n", encoding="utf-8")
+
+        statuses = detect_provider_credentials(project, cwd=tmp_path)
+
+        assert _status_for(statuses, "cborg").source == "project .env"
+
+    def test_missing_key_is_reported_not_found(self, project, tmp_path):
+        statuses = detect_provider_credentials(project, cwd=tmp_path)
+
+        openai = _status_for(statuses, "openai")
+        assert openai.found is False
+        assert openai.source is None
+
+    def test_empty_value_counts_as_missing(self, project, tmp_path):
+        """``.env.template`` ships ``VAR=`` lines; an empty key is not a key."""
+        (project / ".env").write_text("CBORG_API_KEY=\n", encoding="utf-8")
+
+        statuses = detect_provider_credentials(project, cwd=tmp_path)
+
+        assert _status_for(statuses, "cborg").found is False
+
+    def test_keyless_providers_are_excluded(self, project, tmp_path):
+        statuses = detect_provider_credentials(project, cwd=tmp_path)
+
+        names = {s.provider for s in statuses}
+        assert "ollama" not in names
+        assert "vllm" not in names
+        assert "ds4" not in names
+
+    def test_covers_every_keyed_provider_in_the_registry(self, project, tmp_path):
+        from osprey.models.provider_registry import PROVIDER_API_KEYS
+
+        statuses = detect_provider_credentials(project, cwd=tmp_path)
+
+        expected = {p for p, v in PROVIDER_API_KEYS.items() if v is not None}
+        assert {s.provider for s in statuses} == expected
+
+
+class TestReportProviderCredentials:
+    """The summary leads with the selected provider and prints found keys."""
+
+    def test_found_selected_provider_is_reported_with_source(self, project, tmp_path, caplog):
+        (project / ".env").write_text("CBORG_API_KEY=secret\n", encoding="utf-8")
+
+        with caplog.at_level(logging.INFO):
+            report_provider_credentials(project, "cborg", cwd=tmp_path)
+
+        text = caplog.text
+        assert "cborg" in text
+        assert "CBORG_API_KEY" in text
+        assert "project .env" in text
+
+    def test_secret_value_is_never_logged(self, project, tmp_path, caplog):
+        (project / ".env").write_text("CBORG_API_KEY=super-secret-value\n", encoding="utf-8")
+
+        with caplog.at_level(logging.DEBUG):
+            report_provider_credentials(project, "cborg", cwd=tmp_path)
+
+        assert "super-secret-value" not in caplog.text
+
+    def test_other_found_keys_are_listed(self, project, tmp_path, monkeypatch, caplog):
+        (project / ".env").write_text("CBORG_API_KEY=secret\n", encoding="utf-8")
+        monkeypatch.setenv("ALS_APG_API_KEY", "als-key")
+
+        with caplog.at_level(logging.INFO):
+            report_provider_credentials(project, "cborg", cwd=tmp_path)
+
+        assert "ALS_APG_API_KEY" in caplog.text
+
+    def test_unset_keys_are_still_listed(self, project, tmp_path, caplog):
+        (project / ".env").write_text("CBORG_API_KEY=secret\n", encoding="utf-8")
+
+        with caplog.at_level(logging.INFO):
+            report_provider_credentials(project, "cborg", cwd=tmp_path)
+
+        assert "OPENAI_API_KEY" in caplog.text
+        assert "ANTHROPIC_API_KEY" in caplog.text
+
+    def test_missing_selected_provider_key_warns(self, project, tmp_path, caplog):
+        with caplog.at_level(logging.INFO):
+            report_provider_credentials(project, "anthropic", cwd=tmp_path)
+
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warnings, "a missing selected-provider key must warn, not whisper"
+        assert "ANTHROPIC_API_KEY" in caplog.text
+
+    def test_missing_selected_provider_names_the_project_env_path(self, project, tmp_path, caplog):
+        """The hint must point at the built project, not the build cwd."""
+        with caplog.at_level(logging.INFO):
+            report_provider_credentials(project, "anthropic", cwd=tmp_path)
+
+        assert str(project / ".env") in caplog.text
+
+    def test_missing_selected_provider_key_does_not_abort(self, project, tmp_path):
+        """A missing key is a warning: the project is still worth building."""
+        statuses = report_provider_credentials(project, "anthropic", cwd=tmp_path)
+
+        assert _status_for(statuses, "anthropic").found is False
+
+    def test_keyless_selected_provider_reports_no_key_required(self, project, tmp_path, caplog):
+        with caplog.at_level(logging.INFO):
+            report_provider_credentials(project, "ollama", cwd=tmp_path)
+
+        assert "ollama" in caplog.text
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert not warnings, "a keyless provider must not warn about a missing key"
+
+    def test_unknown_provider_does_not_crash_the_build(self, project, tmp_path, caplog):
+        with caplog.at_level(logging.INFO):
+            report_provider_credentials(project, "not-a-real-provider", cwd=tmp_path)
+
+        assert "not-a-real-provider" in caplog.text
+
+
+class TestResolverNoLongerSpamsBuildOutput:
+    """The generic ``${VAR}`` resolver reports misses at DEBUG, not INFO."""
+
+    def test_unresolved_placeholder_is_not_logged_at_info(self, caplog, monkeypatch):
+        from osprey.utils.config import resolve_env_vars
+
+        monkeypatch.delenv("SOME_UNSET_VAR", raising=False)
+
+        with caplog.at_level(logging.INFO, logger="CONFIG"):
+            result = resolve_env_vars("${SOME_UNSET_VAR}")
+
+        assert result == "${SOME_UNSET_VAR}", "placeholder must still survive verbatim"
+        assert "SOME_UNSET_VAR" not in caplog.text
+
+    def test_unresolved_placeholder_is_still_available_at_debug(self, caplog, monkeypatch):
+        from osprey.utils.config import resolve_env_vars
+
+        monkeypatch.delenv("SOME_UNSET_VAR", raising=False)
+
+        with caplog.at_level(logging.DEBUG, logger="CONFIG"):
+            resolve_env_vars("${SOME_UNSET_VAR}")
+
+        assert "SOME_UNSET_VAR" in caplog.text

--- a/tests/deployment/test_compose_generator.py
+++ b/tests/deployment/test_compose_generator.py
@@ -418,6 +418,7 @@ def test_dev_wheel_build_uses_sys_executable(monkeypatch: pytest.MonkeyPatch) ->
     import sys
 
     from osprey.deployment import compose_generator
+    from osprey.deployment.errors import DevModeUnavailableError
 
     captured: dict = {}
 
@@ -427,7 +428,10 @@ def test_dev_wheel_build_uses_sys_executable(monkeypatch: pytest.MonkeyPatch) ->
         return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="stop here")
 
     monkeypatch.setattr(subprocess, "run", _fake_run)
-    compose_generator._copy_local_framework_for_override("/tmp/ignored")
+    # A failed build now aborts the deploy rather than falling back to the
+    # released package; the interpreter assertion below is what this test is for.
+    with pytest.raises(DevModeUnavailableError):
+        compose_generator._copy_local_framework_for_override("/tmp/ignored")
 
     assert captured.get("cmd"), "the wheel build subprocess was never invoked"
     assert captured["cmd"][0] == sys.executable, (
@@ -1956,22 +1960,39 @@ def test_rendered_compose_carries_osprey_dev_when_wheel_staged(
     assert args["OSPREY_DEV"] == "1"
 
 
-def test_rendered_compose_omits_osprey_dev_when_wheel_staging_fails(
+def test_failed_wheel_staging_aborts_the_deploy(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    args = _rendered_dispatcher_build_args(tmp_path, monkeypatch, staging_result=False)
-    assert "OSPREY_DEV" not in args, (
-        "a failed dev-wheel staging must not render the pin-relaxing "
-        f"OSPREY_DEV build arg (fail-closed); got {args}"
-    )
+    """A --dev deploy whose staging fails must stop, not render a fallback.
+
+    Rendering *without* OSPREY_DEV would keep the pinned install (fail-closed on
+    the build arg) but still deploy successfully — containers up on released
+    osprey under a flag that promises local code. The build-arg gate stays; the
+    deploy no longer reaches it.
+    """
+    from osprey.deployment import compose_generator
+    from osprey.deployment.errors import DevModeUnavailableError
+
+    def _staging_fails(out_dir):  # type: ignore[no-untyped-def]
+        raise DevModeUnavailableError("staging failed", "fix it")
+
+    monkeypatch.setattr(compose_generator, "_copy_local_framework_for_override", _staging_fails)
+    config_path = _write_dispatch_stack_config(tmp_path, deployed=["event_dispatcher"])
+    _copy_service_templates(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(DevModeUnavailableError):
+        prepare_compose_files(str(config_path), dev_mode=True)
 
 
-def test_rendered_compose_omits_osprey_dev_on_memoized_build_failure(
+def test_dev_deploy_aborts_on_build_failure_and_stages_nothing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Drive the REAL staging helper against a failing ``python -m build``:
-    the memoized failure must leave OSPREY_DEV out of the rendered compose."""
+    the deploy must abort, and no wheel may be left in the build context."""
     import subprocess as subprocess_module
+
+    from osprey.deployment.errors import DevModeUnavailableError
 
     real_run = subprocess_module.run
 
@@ -1987,11 +2008,10 @@ def test_rendered_compose_omits_osprey_dev_on_memoized_build_failure(
     config_path = _write_dispatch_stack_config(tmp_path, deployed=["event_dispatcher"])
     _copy_service_templates(tmp_path)
     monkeypatch.chdir(tmp_path)
-    prepare_compose_files(str(config_path), dev_mode=True)
 
-    compose_file = tmp_path / "build" / "services" / "event_dispatcher" / "docker-compose.yml"
-    args = yaml.safe_load(compose_file.read_text())["services"]["event-dispatcher"]["build"]["args"]
-    assert "OSPREY_DEV" not in args
+    with pytest.raises(DevModeUnavailableError):
+        prepare_compose_files(str(config_path), dev_mode=True)
+
     service_ctx = tmp_path / "build" / "services" / "event_dispatcher"
     assert not list(service_ctx.glob("*.whl")), "no wheel may be staged on a failed build"
 
@@ -2145,6 +2165,7 @@ def test_staging_fails_closed_when_manifest_cannot_be_derived(
     import subprocess as subprocess_module
 
     from osprey.deployment.compose_generator import _copy_local_framework_for_override
+    from osprey.deployment.errors import DevModeUnavailableError
 
     real_run = subprocess_module.run
 
@@ -2159,7 +2180,8 @@ def test_staging_fails_closed_when_manifest_cannot_be_derived(
 
     ctx = tmp_path / "ctx"
     ctx.mkdir()
-    assert _copy_local_framework_for_override(str(ctx)) is False
+    with pytest.raises(DevModeUnavailableError):
+        _copy_local_framework_for_override(str(ctx))
     assert not list(ctx.glob("*.whl")), "the half-staged wheel must be removed"
     assert not (ctx / "osprey-local-requirements.txt").exists()
 
@@ -2167,10 +2189,11 @@ def test_staging_fails_closed_when_manifest_cannot_be_derived(
 def test_staging_fails_closed_when_manifest_write_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, spy_wheel_build: list
 ) -> None:
-    """Even with a valid wheel, a failed manifest WRITE must fail staging
-    (return False) and remove the already-copied wheel."""
+    """Even with a valid wheel, a failed manifest WRITE must abort staging
+    and remove the already-copied wheel."""
     from osprey.deployment import wheel_build
     from osprey.deployment.compose_generator import _copy_local_framework_for_override
+    from osprey.deployment.errors import DevModeUnavailableError
 
     def _boom(cached_wheel, out_dir):  # type: ignore[no-untyped-def]
         raise OSError("disk full")
@@ -2179,6 +2202,7 @@ def test_staging_fails_closed_when_manifest_write_fails(
 
     ctx = tmp_path / "ctx"
     ctx.mkdir()
-    assert _copy_local_framework_for_override(str(ctx)) is False
+    with pytest.raises(DevModeUnavailableError):
+        _copy_local_framework_for_override(str(ctx))
     assert not list(ctx.glob("*.whl")), "the half-staged wheel must be removed"
     assert not (ctx / "osprey-local-requirements.txt").exists()

--- a/tests/deployment/test_dev_mode_preflight.py
+++ b/tests/deployment/test_dev_mode_preflight.py
@@ -1,0 +1,279 @@
+"""Tests for the ``--dev`` preflight and its hard-fail contract.
+
+``--dev`` is a statement about *which code runs in the containers*. When the
+local wheel could not be staged the deploy used to log a warning and continue,
+bringing containers up on the pinned PyPI release with exit code 0 — so a
+deployment meant to test local changes silently tested the released package
+instead. These tests pin the replacement: refuse, loudly, before any work.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from osprey.deployment.errors import DevModeUnavailableError
+from osprey.deployment.wheel_build import (
+    _build_dev_wheel_cached,
+    _copy_local_framework_for_override,
+    _reset_wheel_build_cache,
+    preflight_dev_mode,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_wheel_cache():
+    _reset_wheel_build_cache()
+    yield
+    _reset_wheel_build_cache()
+
+
+@pytest.fixture
+def editable_checkout(tmp_path, monkeypatch):
+    """Fake an editable osprey install rooted at a writable temp checkout."""
+    src = tmp_path / "checkout" / "src" / "osprey"
+    src.mkdir(parents=True)
+    (tmp_path / "checkout" / "pyproject.toml").write_text("[project]\nname='osprey'\n")
+
+    import osprey
+
+    monkeypatch.setattr(osprey, "__file__", str(src / "__init__.py"))
+    return tmp_path / "checkout"
+
+
+class TestPreflightDevMode:
+    """Every precondition fails fast, before any deploy work happens."""
+
+    def test_missing_build_package_raises(self, editable_checkout, monkeypatch):
+        import importlib.util
+
+        real_find_spec = importlib.util.find_spec
+        monkeypatch.setattr(
+            importlib.util,
+            "find_spec",
+            lambda name, *a, **k: None if name == "build" else real_find_spec(name, *a, **k),
+        )
+
+        with pytest.raises(DevModeUnavailableError) as exc:
+            preflight_dev_mode()
+
+        assert "build" in str(exc.value)
+
+    def test_missing_build_package_names_the_install_command(self, editable_checkout, monkeypatch):
+        """The error is only useful if it says how to fix it."""
+        import importlib.util
+
+        real_find_spec = importlib.util.find_spec
+        monkeypatch.setattr(
+            importlib.util,
+            "find_spec",
+            lambda name, *a, **k: None if name == "build" else real_find_spec(name, *a, **k),
+        )
+
+        with pytest.raises(DevModeUnavailableError) as exc:
+            preflight_dev_mode()
+
+        assert "uv sync --extra dev" in exc.value.remedy
+
+    def test_non_editable_install_raises(self, monkeypatch, tmp_path):
+        site = tmp_path / "site-packages" / "osprey"
+        site.mkdir(parents=True)
+
+        import osprey
+
+        monkeypatch.setattr(osprey, "__file__", str(site / "__init__.py"))
+
+        with pytest.raises(DevModeUnavailableError) as exc:
+            preflight_dev_mode()
+
+        assert "editable" in str(exc.value) or "editable" in exc.value.remedy
+
+    def test_missing_pyproject_raises(self, monkeypatch, tmp_path):
+        src = tmp_path / "checkout" / "src" / "osprey"
+        src.mkdir(parents=True)
+        # deliberately no pyproject.toml
+
+        import osprey
+
+        monkeypatch.setattr(osprey, "__file__", str(src / "__init__.py"))
+
+        with pytest.raises(DevModeUnavailableError) as exc:
+            preflight_dev_mode()
+
+        assert "pyproject.toml" in str(exc.value)
+
+    def test_healthy_environment_passes(self, editable_checkout):
+        """The repo's own dev environment must satisfy the preflight."""
+        preflight_dev_mode()  # must not raise
+
+    def test_preflight_is_cheap(self, editable_checkout, monkeypatch):
+        """No subprocess: the whole point is failing before any real work."""
+
+        def _explode(*args, **kwargs):
+            raise AssertionError("preflight must not spawn a subprocess")
+
+        monkeypatch.setattr(subprocess, "run", _explode)
+
+        preflight_dev_mode()
+
+
+class TestWheelBuildFailuresRaise:
+    """A failed wheel build must not degrade into a released-code deploy."""
+
+    def test_missing_build_module_raises(self, editable_checkout, monkeypatch):
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(
+                a[0] if a else [], 1, "", "No module named build"
+            ),
+        )
+
+        with pytest.raises(DevModeUnavailableError):
+            _build_dev_wheel_cached(editable_checkout)
+
+    def test_broken_local_source_raises_and_surfaces_stderr(self, editable_checkout, monkeypatch):
+        """The most dangerous case: local code is broken, so it must not be hidden."""
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(
+                a[0] if a else [], 1, "", "SyntaxError: invalid syntax in osprey/foo.py"
+            ),
+        )
+
+        with pytest.raises(DevModeUnavailableError) as exc:
+            _build_dev_wheel_cached(editable_checkout)
+
+        assert "SyntaxError" in exc.value.remedy
+
+    def test_failed_build_is_not_memoized(self, editable_checkout, monkeypatch):
+        """A fixed checkout must be retried, not served from a poisoned memo."""
+        calls = []
+
+        def _fail(*a, **k):
+            calls.append(1)
+            return subprocess.CompletedProcess(a[0] if a else [], 1, "", "boom")
+
+        monkeypatch.setattr(subprocess, "run", _fail)
+
+        for _ in range(2):
+            with pytest.raises(DevModeUnavailableError):
+                _build_dev_wheel_cached(editable_checkout)
+
+        assert len(calls) == 2, "failed builds must not be cached"
+
+    def test_build_producing_no_wheel_raises(self, editable_checkout, monkeypatch):
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(a[0] if a else [], 0, "", ""),
+        )
+
+        with pytest.raises(DevModeUnavailableError):
+            _build_dev_wheel_cached(editable_checkout)
+
+
+class TestStagingNeverSilentlyFallsBack:
+    """``_copy_local_framework_for_override`` returns True or raises — no False."""
+
+    def test_non_editable_install_raises_instead_of_returning_false(self, monkeypatch, tmp_path):
+        site = tmp_path / "site-packages" / "osprey"
+        site.mkdir(parents=True)
+
+        import osprey
+
+        monkeypatch.setattr(osprey, "__file__", str(site / "__init__.py"))
+
+        with pytest.raises(DevModeUnavailableError):
+            _copy_local_framework_for_override(str(tmp_path / "ctx"))
+
+    def test_unexpected_error_is_converted_not_swallowed(self, editable_checkout, monkeypatch):
+        """The old broad `except Exception` returned False, hiding the fallback."""
+        import osprey.deployment.wheel_build as wb
+
+        def _boom(*a, **k):
+            raise RuntimeError("disk on fire")
+
+        monkeypatch.setattr(wb, "_build_dev_wheel_cached", _boom)
+
+        with pytest.raises(DevModeUnavailableError) as exc:
+            _copy_local_framework_for_override(str(editable_checkout))
+
+        assert "disk on fire" in str(exc.value)
+
+
+class TestPrepareComposeFilesPreflight:
+    """The guard runs before config loading, so nothing is half-prepared."""
+
+    def test_dev_mode_preflights_before_touching_config(self, monkeypatch, tmp_path):
+        import osprey.deployment.compose_generator as cg
+
+        def _fail_preflight():
+            raise DevModeUnavailableError("nope", "do the thing")
+
+        def _config_must_not_load(*a, **k):
+            raise AssertionError("config was loaded before the --dev preflight ran")
+
+        monkeypatch.setattr(cg, "preflight_dev_mode", _fail_preflight)
+        monkeypatch.setattr(cg, "ConfigBuilder", _config_must_not_load)
+
+        with pytest.raises(DevModeUnavailableError):
+            cg.prepare_compose_files(str(tmp_path / "config.yml"), dev_mode=True)
+
+    def test_non_dev_mode_skips_the_preflight(self, monkeypatch, tmp_path):
+        """A production deploy must not require an editable checkout."""
+        import osprey.deployment.compose_generator as cg
+
+        def _must_not_run():
+            raise AssertionError("preflight ran without --dev")
+
+        monkeypatch.setattr(cg, "preflight_dev_mode", _must_not_run)
+
+        # Fails later on the missing config, which is fine — it proves the
+        # preflight was not reached.
+        with pytest.raises(Exception) as exc:
+            cg.prepare_compose_files(str(tmp_path / "missing.yml"), dev_mode=False)
+
+        assert not isinstance(exc.value, AssertionError)
+
+
+class TestPureImageContextsAreQuiet:
+    """Routine no-Dockerfile contexts must not drown the real signal."""
+
+    def test_no_dockerfile_context_logs_at_debug(self, tmp_path, caplog):
+        import logging
+
+        from osprey.deployment.compose_generator import _stage_dev_wheel_for_context
+
+        ctx = tmp_path / "postgresql"
+        ctx.mkdir()
+
+        with caplog.at_level(logging.INFO):
+            staged = _stage_dev_wheel_for_context(str(ctx), dev_mode=True)
+
+        assert staged is False
+        assert "no osprey wheel was staged" not in caplog.text
+
+        caplog.clear()
+        with caplog.at_level(logging.DEBUG):
+            _stage_dev_wheel_for_context(str(ctx), dev_mode=True)
+
+        assert "no osprey wheel was staged" in caplog.text
+
+
+def test_build_is_a_base_dependency():
+    """`--dev` is a shipped CLI flag; it must not need an optional extra."""
+    import tomllib
+
+    root = Path(__file__).resolve().parents[2]
+    data = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+
+    base = data["project"]["dependencies"]
+    assert any(dep == "build" or dep.startswith("build") for dep in base), (
+        "'build' must be a base dependency: an editable install without "
+        "--extra dev otherwise passes every other --dev precondition and "
+        "fails only at wheel-build time"
+    )


### PR DESCRIPTION
Two related fixes to build/deploy output, both cases where the logs narrated the mechanism while the outcome was the complement of what was printed.

## 1. `osprey build` reports provider credentials that were found

`resolve_env_vars()` logs one line per *unresolved* `${VAR}` placeholder and returns silently on success, so the build printed the complement of the useful signal: a key that resolved was invisible, and every provider the project will never use produced a line.

That resolver is generic over the whole config tree and has no notion of which provider the build selected, so a missing key for the selected provider looked identical to the irrelevant misses beside it. The block was also emitted twice, once per render pass.

Adds a summary in the build command, where the selected provider is known:

```
  ✓ Provider: cborg — CBORG_API_KEY found (project .env)
      Other keys detected: ALS_APG_API_KEY
      Not set:             ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLE_API_KEY, ...
```

and when the selected provider's key is missing:

```
  ✗ Provider: anthropic — ANTHROPIC_API_KEY NOT SET
      The build will complete, but the agent cannot reach the model.
      Add ANTHROPIC_API_KEY to <project>/.env or export it.
```

Sources are checked in the order that determines runtime auth — project `.env`, the build directory's `.env`, then the shell — so the reported origin is the one that will actually be used. Values are never logged. A missing key warns rather than aborts. The per-placeholder resolver line moves to `DEBUG`.

## 2. `osprey deploy --dev` fails instead of deploying released code

When the local wheel could not be staged, the deploy logged a warning among a dozen info lines, skipped the `OSPREY_DEV` build arg, and exited 0. Containers came up healthy on released osprey, so a deployment meant to exercise local changes silently exercised something else.

Two decisions were conflated. Withholding `OSPREY_DEV` on failed staging is correct and stays — relaxing the version pin while installing the released package is worse than either pure state. But that build-arg choice also decided the command's outcome, and there it was wrong.

- Preflight the three preconditions (editable install, source checkout with `pyproject.toml`, `build` importable) before any deploy work, so the failure surfaces immediately rather than seven services in.
- Staging failures raise `DevModeUnavailableError` instead of returning `False` — including a failed wheel build, the most dangerous case, since continuing hides the very changes under test.
- The CLI renders reason, remedy, and an explicit "Nothing was deployed", and exits non-zero.
- `build` moves from the `dev` extra to base dependencies. A shipped CLI flag must not depend on an optional extra: an editable install without `--extra dev` satisfied every other precondition and failed only at wheel-build time.
- Per-context "no Dockerfile, so no wheel was staged" lines drop to `DEBUG` — they describe correct behaviour for pure-image services and buried the line that carried a decision.

## Testing

- 35 new tests across `tests/cli/test_build_provider_credentials.py` and `tests/deployment/test_dev_mode_preflight.py`.
- Five existing tests in `test_compose_generator.py` updated: they pinned the old return-`False` fall-back contract. The invariants they protected (no half-staged artifacts, no wheel on a failed build, `OSPREY_DEV` never set without a staged wheel) are preserved.
- Both build paths verified end to end against real `osprey build` runs; the `--dev` error verified through the CLI (exit code 1).
- Full unit suite: 11177 passed.