### PR TITLE
test(channel-finder): cover the hierarchical database concerns individually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .coverage
-.coverage.*
+.coverage*
 .cache
 nosetests.xml
 coverage.xml

--- a/src/osprey/services/channel_finder/databases/_hierarchical_naming.py
+++ b/src/osprey/services/channel_finder/databases/_hierarchical_naming.py
@@ -189,42 +189,6 @@ class _HierarchicalNamingMixin(_HierarchicalBase):
 
         return channel
 
-    def _find_separator_between_levels(
-        self, start_idx: int, end_idx: int, pattern_levels: list[str]
-    ) -> str:
-        """
-        Find the appropriate separator between two non-consecutive pattern levels.
-
-        When optional levels are skipped, we need to find which separator to use.
-        We use the first separator encountered when walking from start to end.
-
-        Args:
-            start_idx: Index of the starting level (last non-empty)
-            end_idx: Index of the ending level (current non-empty)
-            pattern_levels: List of all pattern levels in order
-
-        Returns:
-            Separator string to use
-
-        Example:
-            Levels: [system, device, subdevice, signal]
-            Pattern: {system}-{device}:{subdevice}:{signal}
-            If subdevice is empty and we're connecting device (idx=1) to signal (idx=3):
-            - Check device→subdevice separator: ":"
-            - Return ":"
-        """
-        # Walk through levels from start to end and find first separator
-        for i in range(start_idx, end_idx):
-            current_level = pattern_levels[i]
-            next_level = pattern_levels[i + 1]
-            sep_key = (current_level, next_level)
-
-            if sep_key in self.default_separators:
-                return self.default_separators[sep_key]
-
-        # Fallback to colon if no separator found
-        return ":"
-
     def _build_channel_with_separators(
         self, path: dict[str, str], separator_overrides: dict[tuple[str, str], str]
     ) -> str:
@@ -262,7 +226,6 @@ class _HierarchicalNamingMixin(_HierarchicalBase):
         import re
 
         pattern = self.naming_pattern
-        self._get_pattern_levels()
 
         # Parse the naming pattern to extract literal text and placeholders
         # Pattern: "S{sector}:{building}:F{floor}"
@@ -396,12 +359,9 @@ class _HierarchicalNamingMixin(_HierarchicalBase):
             path: dict[str, str],
             node: dict,
             level_idx: int,
-            separator_overrides: dict[tuple[str, str], str] | None = None,
+            separator_overrides: dict[tuple[str, str], str],
         ):
             """Recursively expand tree with flexible level handling and custom separators."""
-            if separator_overrides is None:
-                separator_overrides = {}
-
             # Check if this node specifies a custom separator for its children
             # Create a NEW dict for this subtree to avoid polluting siblings
             local_overrides = separator_overrides.copy()

--- a/tests/README.md
+++ b/tests/README.md
@@ -423,6 +423,15 @@ Read past the 409s. They are a symptom of the first failure, not a second bug.
 
 Checklist for a new test area:
 
+- [ ] **New test filenames are unique across all of `tests/`.** Most test
+      directories have no `__init__.py`, so a file's module name is just its
+      basename, and two files anywhere in `tests/` sharing one collide — pytest
+      refuses to collect the second. Check with `find tests -name "<basename>.py"`;
+      prefer a name qualified by the module under test. The two gates disagree
+      about this failure, which is what makes it easy to ship: serially it aborts
+      the whole run (`Interrupted: 1 error during collection`), but under `-n 4`
+      it degrades — exit 1, and the colliding file's tests simply never run,
+      which later reads as a coverage shortfall rather than a collection failure.
 - [ ] **Reuse the shared fixtures and helpers.** `free_port()` / `wait_for_port()`
       for ports, the existing reset seams for global state, `patch_subprocess()`
       for subprocess fakes, `isolated_home` for anything touching `$HOME`.

--- a/tests/services/channel_finder/conftest.py
+++ b/tests/services/channel_finder/conftest.py
@@ -1,0 +1,682 @@
+"""Shared hierarchical-database fixtures for the channel-finder tests.
+
+Every database here is written to disk as real JSON under ``tmp_path`` and then
+loaded. There is no in-memory constructor: ``BaseDatabase.__init__`` calls
+``load_database()`` eagerly, so a :class:`HierarchicalChannelDatabase` only
+exists once its document exists as a file.
+
+The family is organised in two layers:
+
+* ``*_doc()`` -- module-level builders returning the raw JSON document as a
+  plain dict. Each call builds a fresh dict, so a test may mutate the result to
+  produce a near-miss variant (a broken ``_expansion``, a container removed, an
+  extra level) without leaking into any other test.
+* ``*_db`` -- fixtures that write the matching document and return the loaded
+  database.
+
+Every builder docstring states the shape it produces *and* the production branch
+it exists to reach, so a consumer can pick a fixture without re-reading
+``osprey.services.channel_finder.databases``. Module references below are
+relative to that package.
+
+Nothing here touches the network, a container, or the repository tree; the only
+filesystem writes go to the per-test ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from osprey.services.channel_finder.databases.hierarchical import (
+    HierarchicalChannelDatabase,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Document builders
+#
+# A hierarchical document is ``{"hierarchy": {"levels": [...],
+# "naming_pattern": "..."}, "tree": {...}}``. ``levels`` entries carry
+# ``name``/``type`` (``"tree"`` or ``"instances"``) and an optional
+# ``optional: true``. Optional levels MUST appear in ``naming_pattern`` --
+# ``_hierarchical_loading._validate_naming_pattern`` rejects the document
+# otherwise.
+# ---------------------------------------------------------------------------
+
+
+def _document(levels: list[dict[str, Any]], naming_pattern: str, tree: dict) -> dict:
+    """Assemble a hierarchical document from its three parts."""
+    return {
+        "hierarchy": {"levels": levels, "naming_pattern": naming_pattern},
+        "tree": tree,
+    }
+
+
+def tree_only_doc() -> dict:
+    """Three tree levels, no instance expansion anywhere.
+
+    ``system:device:signal`` over ``SR``/``BR``. The baseline shape: exercises
+    plain tree recursion in ``_hierarchical_naming._build_channel_map`` and the
+    tree branch of ``_hierarchical_query._navigate_to_node`` /
+    ``_extract_tree_options`` with nothing else in play. ``BR`` has no children,
+    so it is an automatic leaf (no ``_is_leaf`` marker needed) -- use it to
+    reach the "node has no children" early return in ``_is_leaf_node``.
+
+    Channels: ``SR:BPM:X``, ``SR:BPM:Y``, ``SR:QUAD:Setpoint``, ``BR``.
+    """
+    return _document(
+        levels=[
+            {"name": "system", "type": "tree"},
+            {"name": "device", "type": "tree"},
+            {"name": "signal", "type": "tree"},
+        ],
+        naming_pattern="{system}:{device}:{signal}",
+        tree={
+            "SR": {
+                "_description": "Storage Ring",
+                "BPM": {
+                    "_description": "Beam Position Monitor",
+                    "X": {"_description": "Horizontal position"},
+                    "Y": {"_description": "Vertical position"},
+                },
+                "QUAD": {"_description": "Quadrupole", "Setpoint": {}},
+            },
+            "BR": {"_description": "Booster Ring"},
+        },
+    )
+
+
+def range_instances_doc() -> dict:
+    """An ``instances`` level expanded by ``_type: "range"``.
+
+    ``system(tree) -> device(instances) -> signal(tree)``, with the required
+    ``DEVICE`` container carrying ``{"_type": "range", "_pattern": "B{:02d}",
+    "_range": [1, 3]}`` under ``BPM`` and a second, differently-patterned range
+    under ``QUAD``. Reaches the range arm of ``_hierarchical_base
+    ._get_instance_names`` and ``_hierarchical_query._expand_instances``, the
+    instances arm of ``_build_channel_map``, and the full happy path of
+    ``_hierarchical_loading._validate_expansion_definition`` for ranges
+    (``_pattern`` and ``_range`` both present and well formed).
+
+    Channels: ``SR:BPM:B01:X`` ... ``SR:BPM:B03:Y``, ``SR:QUAD:Q1:Setpoint`` ...
+    """
+    return _document(
+        levels=[
+            {"name": "system", "type": "tree"},
+            {"name": "family", "type": "tree"},
+            {"name": "device", "type": "instances"},
+            {"name": "signal", "type": "tree"},
+        ],
+        naming_pattern="{system}:{family}:{device}:{signal}",
+        tree={
+            "SR": {
+                "_description": "Storage Ring",
+                "BPM": {
+                    "_description": "Beam Position Monitors",
+                    "DEVICE": {
+                        "_expansion": {
+                            "_type": "range",
+                            "_pattern": "B{:02d}",
+                            "_range": [1, 3],
+                        },
+                        "X": {"_description": "Horizontal position"},
+                        "Y": {"_description": "Vertical position"},
+                    },
+                },
+                "QUAD": {
+                    "_description": "Quadrupoles",
+                    "DEVICE": {
+                        "_expansion": {
+                            "_type": "range",
+                            "_pattern": "Q{}",
+                            "_range": [1, 2],
+                        },
+                        "Setpoint": {},
+                        "Readback": {},
+                    },
+                },
+            },
+        },
+    )
+
+
+def list_instances_doc() -> dict:
+    """An ``instances`` level expanded by ``_type: "list"``.
+
+    ``system(tree) -> unit(instances) -> signal(tree)``, with the required
+    ``UNIT`` container carrying ``{"_type": "list", "_instances": ["MAIN",
+    "BACKUP", "TEST"]}``. The list arm is the counterpart of
+    :func:`range_instances_doc`: it reaches the ``list`` branches of
+    ``_get_instance_names``, ``_expand_instances`` and
+    ``_validate_expansion_definition`` (which checks ``_instances`` is present,
+    is a list, and is non-empty).
+
+    Channels: ``RF:MAIN:Power``, ``RF:MAIN:Phase``, ``RF:BACKUP:Power``, ...
+    """
+    return _document(
+        levels=[
+            {"name": "system", "type": "tree"},
+            {"name": "unit", "type": "instances"},
+            {"name": "signal", "type": "tree"},
+        ],
+        naming_pattern="{system}:{unit}:{signal}",
+        tree={
+            "RF": {
+                "_description": "RF system",
+                "UNIT": {
+                    "_expansion": {
+                        "_type": "list",
+                        "_instances": ["MAIN", "BACKUP", "TEST"],
+                    },
+                    "Power": {"_description": "Forward power"},
+                    "Phase": {"_description": "Cavity phase"},
+                },
+            },
+        },
+    )
+
+
+def optional_tree_level_doc() -> dict:
+    """A tree level declared ``optional: true`` that some branches skip.
+
+    ``system -> device -> subdevice(tree, optional) -> signal``. Under ``PS``,
+    ``PSU`` is a real subdevice container while ``Heartbeat`` carries
+    ``_is_leaf: true`` and no children, so ``_build_channel_map`` takes the
+    "OPTIONAL LEVEL SKIP" branch and re-assigns it to ``signal``. The resulting
+    empty ``subdevice`` component leaves a ``::`` artifact that
+    ``_hierarchical_naming._clean_optional_separators`` collapses.
+
+    Channels: ``SR:PS:PSU:Voltage``, ``SR:PS:PSU:Current``, ``SR:PS:Heartbeat``.
+    """
+    return _document(
+        levels=[
+            {"name": "system", "type": "tree"},
+            {"name": "device", "type": "tree"},
+            {"name": "subdevice", "type": "tree", "optional": True},
+            {"name": "signal", "type": "tree"},
+        ],
+        naming_pattern="{system}:{device}:{subdevice}:{signal}",
+        tree={
+            "SR": {
+                "_description": "Storage Ring",
+                "PS": {
+                    "_description": "Power supplies",
+                    "PSU": {
+                        "_description": "Supply unit",
+                        "Voltage": {},
+                        "Current": {},
+                    },
+                    "Heartbeat": {"_is_leaf": True, "_description": "Liveness"},
+                },
+            },
+        },
+    )
+
+
+def optional_instance_level_doc() -> dict:
+    """An ``optional`` instance level whose *first* branch has no container.
+
+    ``system(tree) -> device(instances, optional) -> signal(tree)``. Validation
+    walks only the first tree branch it finds, so listing ``BR`` (no ``DEVICE``
+    container) before ``SR`` (which has one) is what reaches the
+    "optional instance level has no container in some branches" early return in
+    ``_hierarchical_loading._validate_instance_level``. A *required* instance
+    level in the same position raises instead -- that error path needs a
+    mutated copy of this document with ``optional`` dropped.
+
+    ``BR`` also reaches the ``expansion_def is None`` fall-through in the
+    instances arm of ``_build_channel_map``: the branch simply yields no
+    channels.
+
+    Channels: ``SR:D1:X``, ``SR:D2:X`` (nothing from ``BR``).
+    """
+    return _document(
+        levels=[
+            {"name": "system", "type": "tree"},
+            {"name": "device", "type": "instances", "optional": True},
+            {"name": "signal", "type": "tree"},
+        ],
+        naming_pattern="{system}:{device}:{signal}",
+        tree={
+            "BR": {"_description": "Booster - no DEVICE container", "Status": {}},
+            "SR": {
+                "_description": "Storage Ring",
+                "DEVICE": {
+                    "_expansion": {"_type": "range", "_pattern": "D{}", "_range": [1, 2]},
+                    "X": {"_description": "Horizontal position"},
+                },
+            },
+        },
+    )
+
+
+def hybrid_expansion_doc() -> dict:
+    """``_expansion`` on a *tree* child rather than on an instance container.
+
+    All three levels are ``tree``-typed, but the ``CH`` node under ``SR`` owns
+    an ``_expansion``. That is the hybrid pattern: ``_build_channel_map``
+    expands ``CH`` into ``CH-1``..``CH-3`` and assigns each instance to the
+    surrounding *tree* level, and ``_hierarchical_query._extract_tree_options``
+    returns the expanded instances instead of the container name ``CH``.
+    ``_navigate_to_node`` and ``_collect_separator_overrides`` reach their
+    "selection is an expanded instance, find the container that generates it"
+    fallbacks with a selection such as ``device="CH-2"``.
+
+    No level is ``instances``-typed, so ``_validate_instance_level`` never runs
+    against this document.
+
+    Channels: ``SR:CH-1:Voltage`` ... ``SR:CH-3:Current``, ``SR:PS:Status``.
+    """
+    return _document(
+        levels=[
+            {"name": "system", "type": "tree"},
+            {"name": "device", "type": "tree"},
+            {"name": "signal", "type": "tree"},
+        ],
+        naming_pattern="{system}:{device}:{signal}",
+        tree={
+            "SR": {
+                "_description": "Storage Ring",
+                "CH": {
+                    "_description": "Corrector channels",
+                    "_expansion": {"_type": "range", "_pattern": "CH-{}", "_range": [1, 3]},
+                    "Voltage": {},
+                    "Current": {},
+                },
+                "PS": {"_description": "Power supply", "Status": {}},
+            },
+        },
+    )
+
+
+def scalar_leaves_doc() -> dict:
+    """Nodes whose children are scalars rather than dicts.
+
+    ``BPM`` has only scalar children (``X``/``Y`` are ints) and ``QUAD`` mixes a
+    scalar (``units``) into a dict child. Scalars are invisible to every
+    ``isinstance(value, dict)`` guard, so a node with only scalar children is an
+    automatic leaf in ``_hierarchical_naming._is_leaf_node`` and contributes no
+    recursion in ``_build_channel_map`` -- but
+    ``_hierarchical_base._count_channels`` *does* count them (its ``else``
+    branch), which is the arithmetic the tree preview reports.
+
+    Channels: ``SR:BPM``, ``SR:QUAD:Setpoint``.
+    """
+    return _document(
+        levels=[
+            {"name": "system", "type": "tree"},
+            {"name": "device", "type": "tree"},
+            {"name": "signal", "type": "tree"},
+        ],
+        naming_pattern="{system}:{device}:{signal}",
+        tree={
+            "SR": {
+                "_description": "Storage Ring",
+                "BPM": {"X": 1, "Y": 2},
+                "QUAD": {"Setpoint": {"units": "A"}},
+            },
+        },
+    )
+
+
+def separator_override_doc() -> dict:
+    """``_separator`` overrides at the root child *and* at depth > 0.
+
+    ``SR`` carries ``"_separator": "-"``, which ``_build_channel_map`` binds to
+    the ``(system, device)`` pair; ``BPM``, one level deeper, carries
+    ``"_separator": "_"``, bound to ``(device, signal)``. Both are collected
+    again -- by a different code path -- in
+    ``_hierarchical_naming._collect_separator_overrides`` when
+    ``build_channels_from_selections`` is called with matching selections.
+    ``QUAD`` deliberately carries no override, which is what proves the
+    per-subtree copy of the override dict does not leak into siblings.
+
+    Channels: ``SR-BPM_X:RB``, ``SR-BPM_X:SP``, ``SR-QUAD:Setpoint:RB``.
+    """
+    return _document(
+        levels=[
+            {"name": "system", "type": "tree"},
+            {"name": "device", "type": "tree"},
+            {"name": "signal", "type": "tree"},
+            {"name": "suffix", "type": "tree"},
+        ],
+        naming_pattern="{system}:{device}:{signal}:{suffix}",
+        tree={
+            "SR": {
+                "_description": "Storage Ring",
+                "_separator": "-",
+                "BPM": {
+                    "_description": "Beam Position Monitor",
+                    "_separator": "_",
+                    "X": {"RB": {}, "SP": {}},
+                },
+                "QUAD": {"_description": "Quadrupole", "Setpoint": {"RB": {}}},
+            },
+        },
+    )
+
+
+def channel_part_doc() -> dict:
+    """``_channel_part`` overrides, including the navigation-only empty string.
+
+    ``Magnets`` renames itself to ``MAG`` and its child ``Power Supplies`` to
+    ``PS``; ``Building-1`` sets ``"_channel_part": ""``, which
+    ``_hierarchical_naming._get_channel_part`` returns verbatim so the level
+    contributes nothing to the name. The resulting empty first component leaves
+    a leading ``:`` that ``_clean_optional_separators`` strips, and the
+    "value is falsy, skip it" arm of ``_build_channel_with_separators`` is what
+    drops the component in the first place.
+
+    Note the tree keys stay human-readable: navigation still uses ``Magnets``
+    and ``Building-1``, only the emitted names change. One consequence to expect
+    before asserting on it: ``_hierarchical_query.get_statistics`` buckets
+    channels by comparing the stored path against the raw *tree key*, so both
+    systems report ``channel_count: 0`` here even though two channels exist.
+
+    Channels: ``MAG:PS:Current``, ``RACK:Temp``.
+    """
+    return _document(
+        levels=[
+            {"name": "system", "type": "tree"},
+            {"name": "device", "type": "tree"},
+            {"name": "signal", "type": "tree"},
+        ],
+        naming_pattern="{system}:{device}:{signal}",
+        tree={
+            "Magnets": {
+                "_channel_part": "MAG",
+                "_description": "Magnet systems",
+                "Power Supplies": {"_channel_part": "PS", "Current": {}},
+            },
+            "Building-1": {
+                "_channel_part": "",
+                "_description": "Navigation-only grouping",
+                "RACK": {"Temp": {}},
+            },
+        },
+    )
+
+
+def leaf_with_children_doc() -> dict:
+    """``_is_leaf: true`` on a node that *also* has dict children (required level).
+
+    ``SIGNAL-Y`` sits at the required ``signal`` level and is both a complete
+    channel and the parent of the ``RB``/``SP`` suffix variants. This is the
+    only shape that reaches the "process children of leaf nodes" block in
+    ``_build_channel_map``: the node emits its own channel, then re-enters
+    recursion with its children assigned to the next *tree* level.
+
+    Contrast with :func:`optional_leaf_with_children_doc`, where the identical
+    node under an optional level takes a different branch and its children are
+    dropped.
+
+    Channels: ``SR:PS:SIGNAL-Y``, ``SR:PS:SIGNAL-Y:RB``, ``SR:PS:SIGNAL-Y:SP``.
+    """
+    return _document(
+        levels=[
+            {"name": "system", "type": "tree"},
+            {"name": "device", "type": "tree"},
+            {"name": "signal", "type": "tree"},
+            {"name": "suffix", "type": "tree"},
+        ],
+        naming_pattern="{system}:{device}:{signal}:{suffix}",
+        tree={
+            "SR": {
+                "_description": "Storage Ring",
+                "PS": {
+                    "_description": "Power supply",
+                    "SIGNAL-Y": {
+                        "_is_leaf": True,
+                        "_description": "Complete channel with suffix variants",
+                        "RB": {"_description": "Readback"},
+                        "SP": {"_description": "Setpoint"},
+                    },
+                },
+            },
+        },
+    )
+
+
+def optional_leaf_with_children_doc() -> dict:
+    """``_is_leaf: true`` plus dict children, this time under an *optional* level.
+
+    Same ``SIGNAL-Y`` node as :func:`leaf_with_children_doc`, but the level it
+    sits at (``subdevice``) is declared ``optional: true``. The optional-level
+    check in ``_build_channel_map`` fires *first*, so the node skips its level
+    and is assigned to ``suffix`` instead -- by which point every level has been
+    consumed and its ``RB``/``SP`` children are never visited. Use this pair to
+    characterise that asymmetry rather than assuming it.
+
+    ``PSU`` is the ordinary sibling that does occupy the optional level.
+
+    Channels: ``SR:PS:SIGNAL-Y``, ``SR:PS:PSU:Voltage`` (no ``RB``/``SP``).
+    """
+    return _document(
+        levels=[
+            {"name": "system", "type": "tree"},
+            {"name": "device", "type": "tree"},
+            {"name": "subdevice", "type": "tree", "optional": True},
+            {"name": "suffix", "type": "tree"},
+        ],
+        naming_pattern="{system}:{device}:{subdevice}:{suffix}",
+        tree={
+            "SR": {
+                "_description": "Storage Ring",
+                "PS": {
+                    "_description": "Power supply",
+                    "SIGNAL-Y": {
+                        "_is_leaf": True,
+                        "_description": "Complete channel with suffix variants",
+                        "RB": {"_description": "Readback"},
+                        "SP": {"_description": "Setpoint"},
+                    },
+                    "PSU": {"_description": "Supply unit", "Voltage": {}},
+                },
+            },
+        },
+    )
+
+
+def all_optional_next_instances_doc() -> dict:
+    """Every remaining level optional, with the next level ``instances``-typed.
+
+    ``system(tree) -> device(instances, optional) -> signal(tree, optional)``.
+    At the ``SR`` node both remaining levels are optional, so ``_is_leaf_node``
+    evaluates ``all_remaining_optional`` as True -- the only shape in this file
+    that does -- and then takes its ``instances`` arm: ``SR`` has no ``DEVICE``
+    container, so it *is* a leaf. ``BR`` has one, so the same arm returns False
+    and the branch expands normally.
+
+    ``SR`` is listed first for the same reason as in
+    :func:`optional_instance_level_doc`: validation walks only the first branch.
+
+    Channels: ``SR``, ``SR:X``, ``SR:Y``, ``BR:D1:Z``, ``BR:D2:Z``.
+    """
+    return _document(
+        levels=[
+            {"name": "system", "type": "tree"},
+            {"name": "device", "type": "instances", "optional": True},
+            {"name": "signal", "type": "tree", "optional": True},
+        ],
+        naming_pattern="{system}:{device}:{signal}",
+        tree={
+            "SR": {
+                "_description": "No DEVICE container - all remaining levels optional",
+                "X": {"_description": "Horizontal position"},
+                "Y": {"_description": "Vertical position"},
+            },
+            "BR": {
+                "_description": "Has a DEVICE container",
+                "DEVICE": {
+                    "_expansion": {"_type": "range", "_pattern": "D{}", "_range": [1, 2]},
+                    "Z": {},
+                },
+            },
+        },
+    )
+
+
+def all_optional_next_tree_doc() -> dict:
+    """Every remaining level optional, with the next level ``tree``-typed.
+
+    ``system(tree) -> subdevice(tree, optional) -> signal(tree, optional)``.
+    The counterpart of :func:`all_optional_next_instances_doc` for the ``tree``
+    arm of the ``all_remaining_optional`` block in ``_is_leaf_node``.
+
+    Worth knowing before writing assertions: that arm can only ever return
+    False. It re-tests ``has_tree_children`` with the same predicate the
+    ``has_children`` guard above it already applied, and a node that failed that
+    guard returned True several lines earlier. The branch is reachable -- this
+    document reaches it -- but no document can make it return True.
+
+    Channels: ``SR:PSU:Voltage``, ``SR:PSU:Current``.
+    """
+    return _document(
+        levels=[
+            {"name": "system", "type": "tree"},
+            {"name": "subdevice", "type": "tree", "optional": True},
+            {"name": "signal", "type": "tree", "optional": True},
+        ],
+        naming_pattern="{system}:{subdevice}:{signal}",
+        tree={
+            "SR": {
+                "_description": "Storage Ring",
+                "PSU": {"_description": "Supply unit", "Voltage": {}, "Current": {}},
+            },
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Writer and loader
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def write_hier_json(tmp_path: Path) -> Callable[..., Path]:
+    """Factory writing a hierarchical document to ``tmp_path`` as JSON.
+
+    Returns:
+        Callable ``(doc, name="hier.json") -> Path``. Pass distinct names when
+        one test needs several databases side by side; the document is written
+        verbatim and never validated, so this is also the seam for producing
+        deliberately malformed documents that ``load_database`` must reject.
+    """
+
+    def _write(doc: dict, name: str = "hier.json") -> Path:
+        path = tmp_path / name
+        path.write_text(json.dumps(doc, indent=2))
+        return path
+
+    return _write
+
+
+@pytest.fixture
+def hier_db_factory(
+    write_hier_json: Callable[..., Path],
+) -> Callable[..., HierarchicalChannelDatabase]:
+    """Factory writing a document and returning the loaded database.
+
+    Returns:
+        Callable ``(doc, name="hier.json") -> HierarchicalChannelDatabase``.
+        Loading happens inside :class:`BaseDatabase`'s constructor, so a
+        document that fails validation raises from this call.
+    """
+
+    def _load(doc: dict, name: str = "hier.json") -> HierarchicalChannelDatabase:
+        return HierarchicalChannelDatabase(str(write_hier_json(doc, name)))
+
+    return _load
+
+
+# ---------------------------------------------------------------------------
+# Loaded databases, one per shape
+#
+# Each fixture is the loaded counterpart of the like-named ``*_doc()`` builder;
+# see that builder's docstring for the shape and the branch it reaches.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tree_only_db(hier_db_factory) -> HierarchicalChannelDatabase:
+    """Loaded :func:`tree_only_doc` -- three tree levels, no expansion."""
+    return hier_db_factory(tree_only_doc(), "tree_only.json")
+
+
+@pytest.fixture
+def range_instances_db(hier_db_factory) -> HierarchicalChannelDatabase:
+    """Loaded :func:`range_instances_doc` -- ``_type: "range"`` instance level."""
+    return hier_db_factory(range_instances_doc(), "range_instances.json")
+
+
+@pytest.fixture
+def list_instances_db(hier_db_factory) -> HierarchicalChannelDatabase:
+    """Loaded :func:`list_instances_doc` -- ``_type: "list"`` instance level."""
+    return hier_db_factory(list_instances_doc(), "list_instances.json")
+
+
+@pytest.fixture
+def optional_tree_level_db(hier_db_factory) -> HierarchicalChannelDatabase:
+    """Loaded :func:`optional_tree_level_doc` -- optional tree level, skipped by a leaf."""
+    return hier_db_factory(optional_tree_level_doc(), "optional_tree_level.json")
+
+
+@pytest.fixture
+def optional_instance_level_db(hier_db_factory) -> HierarchicalChannelDatabase:
+    """Loaded :func:`optional_instance_level_doc` -- optional instance level, no container."""
+    return hier_db_factory(optional_instance_level_doc(), "optional_instance_level.json")
+
+
+@pytest.fixture
+def hybrid_expansion_db(hier_db_factory) -> HierarchicalChannelDatabase:
+    """Loaded :func:`hybrid_expansion_doc` -- ``_expansion`` on a tree child."""
+    return hier_db_factory(hybrid_expansion_doc(), "hybrid_expansion.json")
+
+
+@pytest.fixture
+def scalar_leaves_db(hier_db_factory) -> HierarchicalChannelDatabase:
+    """Loaded :func:`scalar_leaves_doc` -- non-dict leaf values."""
+    return hier_db_factory(scalar_leaves_doc(), "scalar_leaves.json")
+
+
+@pytest.fixture
+def separator_override_db(hier_db_factory) -> HierarchicalChannelDatabase:
+    """Loaded :func:`separator_override_doc` -- ``_separator`` at two depths."""
+    return hier_db_factory(separator_override_doc(), "separator_override.json")
+
+
+@pytest.fixture
+def channel_part_db(hier_db_factory) -> HierarchicalChannelDatabase:
+    """Loaded :func:`channel_part_doc` -- ``_channel_part`` overrides, one empty."""
+    return hier_db_factory(channel_part_doc(), "channel_part.json")
+
+
+@pytest.fixture
+def leaf_with_children_db(hier_db_factory) -> HierarchicalChannelDatabase:
+    """Loaded :func:`leaf_with_children_doc` -- ``_is_leaf`` node with children."""
+    return hier_db_factory(leaf_with_children_doc(), "leaf_with_children.json")
+
+
+@pytest.fixture
+def optional_leaf_with_children_db(hier_db_factory) -> HierarchicalChannelDatabase:
+    """Loaded :func:`optional_leaf_with_children_doc` -- same node, optional level."""
+    return hier_db_factory(optional_leaf_with_children_doc(), "optional_leaf_with_children.json")
+
+
+@pytest.fixture
+def all_optional_next_instances_db(hier_db_factory) -> HierarchicalChannelDatabase:
+    """Loaded :func:`all_optional_next_instances_doc` -- all-optional tail, instances next."""
+    return hier_db_factory(all_optional_next_instances_doc(), "all_optional_instances.json")
+
+
+@pytest.fixture
+def all_optional_next_tree_db(hier_db_factory) -> HierarchicalChannelDatabase:
+    """Loaded :func:`all_optional_next_tree_doc` -- all-optional tail, tree next."""
+    return hier_db_factory(all_optional_next_tree_doc(), "all_optional_tree.json")

--- a/tests/services/channel_finder/databases/test_hierarchical_base_helpers.py
+++ b/tests/services/channel_finder/databases/test_hierarchical_base_helpers.py
@@ -1,0 +1,232 @@
+"""Direct-call tests for the pure helpers on ``_HierarchicalBase``.
+
+The helpers exercised here are the cross-cutting utilities the hierarchical
+mixins share: instance-name expansion, value coercion, and node/expansion
+counting. Every one of them is pure -- it reads only its arguments -- so the
+tests call them straight, with literal nodes for the ``staticmethod`` /
+``classmethod`` helpers and a loaded database only where the helper is bound to
+an instance. Each case pins the *emitted value*, including the fallback arms
+that a schema-valid document never reaches through the loader.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from osprey.services.channel_finder.databases._hierarchical_base import _HierarchicalBase
+
+if TYPE_CHECKING:
+    from osprey.services.channel_finder.databases.hierarchical import (
+        HierarchicalChannelDatabase,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _get_instance_names
+# ---------------------------------------------------------------------------
+
+
+def test_get_instance_names_range(tree_only_db: HierarchicalChannelDatabase) -> None:
+    """``_type: range`` formats ``_pattern`` over the inclusive ``_range``."""
+    names = tree_only_db._get_instance_names(
+        {"_type": "range", "_pattern": "{:02d}", "_range": [1, 3]}
+    )
+    assert names == ["01", "02", "03"]
+
+
+def test_get_instance_names_list(tree_only_db: HierarchicalChannelDatabase) -> None:
+    """``_type: list`` returns ``_instances`` verbatim."""
+    assert tree_only_db._get_instance_names({"_type": "list", "_instances": ["A", "B"]}) == [
+        "A",
+        "B",
+    ]
+
+
+@pytest.mark.parametrize(
+    "expansion_def",
+    [
+        pytest.param({}, id="no-type"),
+        pytest.param({"_type": "sequence"}, id="unknown-type"),
+        pytest.param({"_type": None, "_instances": ["A"]}, id="null-type-with-instances"),
+    ],
+)
+def test_get_instance_names_unknown_type_is_empty(
+    tree_only_db: HierarchicalChannelDatabase, expansion_def: dict
+) -> None:
+    """An expansion whose ``_type`` matches neither arm expands to nothing.
+
+    The final ``return []`` is the fallback: an unrecognised ``_type`` yields no
+    instances rather than raising, and any sibling keys (``_instances`` here)
+    are ignored because the dispatch never reaches their arm.
+    """
+    assert tree_only_db._get_instance_names(expansion_def) == []
+
+
+# ---------------------------------------------------------------------------
+# _ensure_list / _get_single_value
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_list_passes_a_list_through_unchanged(
+    tree_only_db: HierarchicalChannelDatabase,
+) -> None:
+    """A list is returned as the *same object*, not a copy."""
+    original = ["X", "Y"]
+    result = tree_only_db._ensure_list(original)
+    assert result is original
+
+
+def test_ensure_list_maps_none_to_empty(tree_only_db: HierarchicalChannelDatabase) -> None:
+    """``None`` becomes ``[]`` -- an absent selection contributes no values."""
+    assert tree_only_db._ensure_list(None) == []
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("BPM", ["BPM"], id="str"),
+        pytest.param(0, [0], id="falsy-int"),
+        pytest.param(False, [False], id="false"),
+    ],
+)
+def test_ensure_list_wraps_a_scalar(
+    tree_only_db: HierarchicalChannelDatabase, value: object, expected: list
+) -> None:
+    """Any non-list, non-``None`` value is wrapped -- including falsy scalars."""
+    assert tree_only_db._ensure_list(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(["A", "B"], "A", id="list-takes-first"),
+        pytest.param([], None, id="empty-list-is-none"),
+        pytest.param("A", "A", id="scalar-passthrough"),
+        pytest.param(None, None, id="none-passthrough"),
+    ],
+)
+def test_get_single_value(
+    tree_only_db: HierarchicalChannelDatabase, value: object, expected: object
+) -> None:
+    """The list arm collapses to the first element, or ``None`` when empty."""
+    assert tree_only_db._get_single_value(value) == expected
+
+
+# ---------------------------------------------------------------------------
+# _child_keys
+# ---------------------------------------------------------------------------
+
+
+def test_child_keys_drops_metadata_and_underscored_keys() -> None:
+    """Known metadata keys and any other ``_``-prefixed key are not children."""
+    node = {
+        "_description": "Storage Ring",
+        "_expansion": {"_type": "range"},
+        "_channel_part": "SR",
+        "_is_leaf": True,
+        "_separator": "-",
+        "_future_metadata": "ignored",
+        "BPM": {},
+        "QUAD": {},
+    }
+    assert _HierarchicalBase._child_keys(node) == ["BPM", "QUAD"]
+
+
+def test_child_keys_of_a_childless_node_is_empty() -> None:
+    """A node carrying only metadata has no children at all."""
+    assert _HierarchicalBase._child_keys({"_description": "leaf"}) == []
+
+
+# ---------------------------------------------------------------------------
+# _expansion_instance_count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("expansion", "expected"),
+    [
+        pytest.param({"_range": [1, 8]}, 8, id="inclusive-range"),
+        pytest.param({"_range": [3, 3]}, 1, id="single-element-range"),
+        pytest.param({"_range": [5, 1]}, 0, id="inverted-range-floors-at-zero"),
+        pytest.param({}, 1, id="empty-descriptor-defaults-to-one"),
+    ],
+)
+def test_expansion_instance_count(expansion: dict, expected: int) -> None:
+    """The count is the inclusive width of ``_range``, floored at zero.
+
+    An empty descriptor falls back to the built-in ``[1, 1]`` default, so a node
+    that declares ``_expansion`` without a range still multiplies by one rather
+    than collapsing its subtree to zero channels.
+    """
+    assert _HierarchicalBase._expansion_instance_count(expansion) == expected
+
+
+# ---------------------------------------------------------------------------
+# _count_channels
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "node",
+    [
+        pytest.param("SR:BPM:X", id="str"),
+        pytest.param(42, id="int"),
+        pytest.param(None, id="none"),
+        pytest.param(["SR"], id="list"),
+    ],
+)
+def test_count_channels_of_a_non_dict_is_zero(node: object) -> None:
+    """A non-dict argument counts as nothing rather than raising.
+
+    ``_count_channels`` recurses only into dict values, but it is also called
+    directly on caller-supplied nodes; the guard keeps a scalar or a list from
+    reaching the ``.items()`` call below it.
+    """
+    assert _HierarchicalBase._count_channels(node) == 0
+
+
+def test_count_channels_counts_scalar_leaf_values() -> None:
+    """Children whose value is a scalar each count as one channel.
+
+    ``{"X": 1, "Y": 2}`` has no dict children, so the recursion never fires --
+    the two scalars are counted by the ``else`` arm instead, and the node is not
+    additionally counted as a childless leaf because ``_child_keys`` still sees
+    ``X`` and ``Y``.
+    """
+    assert _HierarchicalBase._count_channels({"X": 1, "Y": 2}) == 2
+
+
+def test_count_channels_mixes_scalar_and_dict_children() -> None:
+    """A scalar sibling adds one on top of the recursion into a dict child."""
+    node = {"_description": "Quadrupole", "units": "A", "Setpoint": {"_description": "sp"}}
+    # "units" -> 1 (scalar arm); "Setpoint" -> 1 (childless dict).
+    assert _HierarchicalBase._count_channels(node) == 2
+
+
+def test_count_channels_of_a_metadata_only_node_is_one() -> None:
+    """A node with no children is itself the channel."""
+    assert _HierarchicalBase._count_channels({"_description": "Beam current"}) == 1
+
+
+def test_count_channels_multiplies_dict_children_by_their_expansion() -> None:
+    """A dict child carrying ``_expansion`` multiplies its own subtree count."""
+    node = {
+        "BPM": {
+            "_expansion": {"_type": "range", "_range": [1, 4]},
+            "X": {},
+            "Y": {},
+        },
+    }
+    assert _HierarchicalBase._count_channels(node) == 8
+
+
+def test_count_channels_on_a_loaded_tree(scalar_leaves_db: HierarchicalChannelDatabase) -> None:
+    """The scalar arm is reached through a real loaded document, not just literals.
+
+    ``scalar_leaves`` holds ``SR.BPM = {"X": 1, "Y": 2}`` (two scalars) and
+    ``SR.QUAD.Setpoint = {"units": "A"}`` (one scalar), which is the arithmetic
+    the tree preview reports for that shape.
+    """
+    assert _HierarchicalBase._count_channels(scalar_leaves_db.tree) == 3

--- a/tests/services/channel_finder/databases/test_loading_container_path.py
+++ b/tests/services/channel_finder/databases/test_loading_container_path.py
@@ -1,0 +1,169 @@
+"""The container path ``_hierarchical_loading`` reports for a missing ``_expansion``.
+
+An instance level whose container exists but carries no ``_expansion`` is the
+only caller of ``_get_container_path``: ``_validate_instance_level`` builds the
+path purely to name the offending node in its error message. The path is
+assembled from the *declared* hierarchy rather than from the tree walk, so each
+preceding level contributes a different token -- ``[CATEGORY]`` for a ``tree``
+level, ``['NAME']`` for an ``instances`` level -- and a level at index 0
+contributes nothing at all. Those arms are mutually exclusive, so one document
+cannot reach them all; the three below split them.
+
+Which container gets validated is not free choice: ``_find_level_container``
+walks only the *first* non-underscore dict child at each tree level. For
+:func:`range_instances_doc` that makes ``tree['SR']['BPM']['DEVICE']`` the
+validated node -- the ``QUAD`` branch's ``DEVICE`` is never reached, so mutating
+it would leave the document loading cleanly and prove nothing.
+
+Every case asserts the exact path string, both where the message reports the
+container and where it reports the missing key. A test that only asserted "some
+ValueError was raised" would pass against a path builder that emitted the wrong
+tokens, which is the failure this file exists to catch.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from tests.services.channel_finder.conftest import _document, range_instances_doc
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_RANGE_EXPANSION = {"_type": "range", "_pattern": "D{}", "_range": [1, 2]}
+
+
+def tree_preceded_doc(*, with_expansion: bool) -> dict:
+    """Instance level at index 2, preceded by two ``tree`` levels.
+
+    The shared range document already has that shape; only the ``_expansion`` on
+    the validated container is at issue, so it is dropped rather than rebuilt.
+    Two preceding tree levels mean two ``[CATEGORY]`` tokens.
+    """
+    doc = range_instances_doc()
+    if not with_expansion:
+        del doc["tree"]["SR"]["BPM"]["DEVICE"]["_expansion"]
+    return doc
+
+
+def instances_preceded_doc(*, with_expansion: bool) -> dict:
+    """Instance level at index 2, preceded by a ``tree`` then an ``instances`` level.
+
+    Consecutive instance levels must be nested, so ``DEVICE`` lives inside
+    ``UNIT``; the outer ``UNIT`` keeps its expansion so validation reaches the
+    inner container instead of failing earlier. The preceding instances level
+    contributes its own name, not ``[CATEGORY]``.
+    """
+    device: dict[str, Any] = {"Power": {"_description": "Forward power"}}
+    if with_expansion:
+        device["_expansion"] = dict(_RANGE_EXPANSION)
+    return _document(
+        levels=[
+            {"name": "system", "type": "tree"},
+            {"name": "unit", "type": "instances"},
+            {"name": "device", "type": "instances"},
+            {"name": "signal", "type": "tree"},
+        ],
+        naming_pattern="{system}:{unit}:{device}:{signal}",
+        tree={
+            "RF": {
+                "_description": "RF system",
+                "UNIT": {
+                    "_expansion": {"_type": "list", "_instances": ["MAIN", "BACKUP"]},
+                    "DEVICE": device,
+                },
+            },
+        },
+    )
+
+
+def root_instances_doc(*, with_expansion: bool) -> dict:
+    """Instance level at index 0, with nothing in front of it.
+
+    No preceding level means the loop body never runs, so the path is the root
+    token and the container name alone.
+    """
+    device: dict[str, Any] = {"X": {"_description": "Horizontal position"}}
+    if with_expansion:
+        device["_expansion"] = dict(_RANGE_EXPANSION)
+    return _document(
+        levels=[
+            {"name": "device", "type": "instances"},
+            {"name": "signal", "type": "tree"},
+        ],
+        naming_pattern="{device}:{signal}",
+        tree={"DEVICE": device},
+    )
+
+
+# Each case: (document builder, level named in the message, expected path).
+CONTAINER_PATHS = [
+    pytest.param(
+        tree_preceded_doc,
+        "device",
+        "tree[CATEGORY][CATEGORY]['DEVICE']",
+        id="preceded-by-tree-levels",
+    ),
+    pytest.param(
+        instances_preceded_doc,
+        "device",
+        "tree[CATEGORY]['UNIT']['DEVICE']",
+        id="preceded-by-instances-level",
+    ),
+    pytest.param(
+        root_instances_doc,
+        "device",
+        "tree['DEVICE']",
+        id="first-level",
+    ),
+]
+
+
+@pytest.mark.parametrize(("make_doc", "level_name", "expected_path"), CONTAINER_PATHS)
+def test_missing_expansion_reports_container_path(
+    hier_db_factory: Callable[..., Any],
+    make_doc: Callable[..., dict],
+    level_name: str,
+    expected_path: str,
+) -> None:
+    """A container without ``_expansion`` is rejected, named by its declared path."""
+    with pytest.raises(ValueError, match="missing '_expansion' definition") as excinfo:
+        hier_db_factory(make_doc(with_expansion=False))
+
+    message = str(excinfo.value)
+    assert f"Instance level '{level_name}'" in message
+    assert f"Found container at: {expected_path}\n" in message
+    assert f"Missing: {expected_path}['_expansion']\n" in message
+
+
+@pytest.mark.parametrize(
+    ("make_doc", "expected_channels"),
+    [
+        pytest.param(
+            tree_preceded_doc,
+            {"SR:BPM:B01:X", "SR:QUAD:Q1:Setpoint"},
+            id="preceded-by-tree-levels",
+        ),
+        pytest.param(
+            instances_preceded_doc,
+            {"RF:MAIN:D1:Power", "RF:BACKUP:D2:Power"},
+            id="preceded-by-instances-level",
+        ),
+        pytest.param(root_instances_doc, {"D1:X", "D2:X"}, id="first-level"),
+    ],
+)
+def test_same_document_loads_once_expansion_is_present(
+    hier_db_factory: Callable[..., Any],
+    make_doc: Callable[..., dict],
+    expected_channels: set[str],
+) -> None:
+    """Control case: the dropped ``_expansion`` is the only thing wrong.
+
+    Without this, a case whose document tripped some *earlier* guard -- a
+    misdeclared level, an unreachable container -- would still raise and still
+    look green while never touching the path builder.
+    """
+    db = hier_db_factory(make_doc(with_expansion=True))
+
+    assert expected_channels <= set(db.channel_map)

--- a/tests/services/channel_finder/databases/test_loading_database_validation.py
+++ b/tests/services/channel_finder/databases/test_loading_database_validation.py
@@ -1,0 +1,239 @@
+"""Document-level rejection arms of ``_hierarchical_loading.load_database``.
+
+These are the malformed-*document* failures -- a missing ``hierarchy`` section, a
+naming pattern out of sync with the declared levels, a bad level ``type``, an
+instance level whose container is missing or misplaced. The malformed
+``_expansion`` arms live next door in ``test_loading_expansion_validation.py``.
+
+Each case starts from a shared ``*_doc()`` builder in
+``tests/services/channel_finder/conftest.py`` (or, where no shared shape fits, a
+minimal document built here) and breaks exactly one rule, so the failure is
+attributable to the mutation and to nothing that came before it. Validation runs
+in a fixed order -- ``_validate_naming_pattern`` before
+``_validate_hierarchy_config`` before ``_validate_tree_structure`` -- and every
+document below is valid up to the arm it is meant to reach.
+
+One ordering trap is worth stating outright: ``load_database`` reads ``tree``
+*before* it checks for ``hierarchy``, so a document missing both raises
+``KeyError`` from the ``tree`` lookup and never reaches the ``hierarchy`` guard.
+The missing-``hierarchy`` case below therefore keeps its ``tree``.
+
+The messages are long and multi-line; each assertion matches a short
+distinguishing substring rather than the whole text.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from tests.services.channel_finder.conftest import (
+    optional_instance_level_doc,
+    optional_tree_level_doc,
+    tree_only_doc,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+LOADING_LOGGER = "osprey.services.channel_finder.databases._hierarchical_loading"
+
+
+def _consecutive_instances_doc(nested: bool) -> dict:
+    """Two adjacent ``instances`` levels, declared nested or as tree siblings.
+
+    ``system(tree) -> cell(instances) -> device(instances)``. With ``nested``
+    the ``DEVICE`` container sits inside ``CELL``, which is the layout
+    ``_validate_instance_level`` demands; without it the two containers are
+    siblings under ``SR``, which is the rejected layout. No shared builder has
+    two consecutive instance levels, so this shape is built here.
+    """
+    device = {"_expansion": {"_type": "list", "_instances": ["A", "B"]}, "Value": {}}
+    cell = {"_expansion": {"_type": "range", "_pattern": "C{:02d}", "_range": [1, 2]}}
+
+    if nested:
+        cell["DEVICE"] = device
+        system: dict[str, Any] = {"CELL": cell}
+    else:
+        system = {"CELL": cell, "DEVICE": device}
+
+    return {
+        "hierarchy": {
+            "levels": [
+                {"name": "system", "type": "tree"},
+                {"name": "cell", "type": "instances"},
+                {"name": "device", "type": "instances"},
+            ],
+            "naming_pattern": "{system}:{cell}:{device}",
+        },
+        "tree": {"SR": {"_description": "Storage Ring", **system}},
+    }
+
+
+def _no_hierarchy_doc() -> dict:
+    """A document with a valid ``tree`` and no ``hierarchy`` section at all."""
+    return {"tree": tree_only_doc()["tree"]}
+
+
+def _undefined_pattern_level_doc() -> dict:
+    """Valid levels, but the pattern names a level that was never declared."""
+    doc = tree_only_doc()
+    doc["hierarchy"]["naming_pattern"] = "{system}:{device}:{signal}:{bogus}"
+    return doc
+
+
+def _optional_level_missing_placeholder_doc() -> dict:
+    """An ``optional: true`` level dropped from the naming pattern."""
+    doc = optional_tree_level_doc()
+    doc["hierarchy"]["naming_pattern"] = "{system}:{device}:{signal}"
+    return doc
+
+
+def _invalid_level_type_doc() -> dict:
+    """A level whose ``type`` is neither ``"tree"`` nor ``"instances"``."""
+    doc = tree_only_doc()
+    doc["hierarchy"]["levels"][2]["type"] = "category"
+    return doc
+
+
+def _required_instance_without_container_doc() -> dict:
+    """A *required* instance level whose first tree branch has no container.
+
+    ``optional_instance_level_doc`` lists ``BR`` -- which has no ``DEVICE``
+    container -- before ``SR``, and ``_find_level_container`` only ever walks
+    the first branch it finds. As shipped the level is optional, so the missing
+    container is tolerated; dropping ``optional`` turns the same document into
+    the required-level rejection.
+    """
+    doc = optional_instance_level_doc()
+    del doc["hierarchy"]["levels"][1]["optional"]
+    return doc
+
+
+# Each case: (document builder, message substring). One case per rejection arm,
+# in the order load_database evaluates them.
+DOCUMENT_REJECTIONS = [
+    pytest.param(
+        _no_hierarchy_doc,
+        "must contain 'hierarchy' section",
+        id="missing-hierarchy-section",
+    ),
+    pytest.param(
+        _undefined_pattern_level_doc,
+        "references undefined hierarchy levels",
+        id="pattern-references-undefined-level",
+    ),
+    pytest.param(
+        _optional_level_missing_placeholder_doc,
+        "must appear in naming_pattern",
+        id="optional-level-missing-placeholder",
+    ),
+    pytest.param(
+        _invalid_level_type_doc,
+        "has invalid type",
+        id="invalid-level-type",
+    ),
+    pytest.param(
+        _required_instance_without_container_doc,
+        "requires container named",
+        id="required-instance-level-without-container",
+    ),
+    pytest.param(
+        lambda: _consecutive_instances_doc(nested=False),
+        "Consecutive instance levels",
+        id="consecutive-instance-levels-as-siblings",
+    ),
+]
+
+
+@pytest.mark.parametrize(("make_doc", "match"), DOCUMENT_REJECTIONS)
+def test_malformed_document_is_rejected(
+    hier_db_factory: Callable[..., Any],
+    make_doc: Callable[[], dict],
+    match: str,
+) -> None:
+    """Each malformed document raises ValueError from the constructor."""
+    with pytest.raises(ValueError, match=match):
+        hier_db_factory(make_doc())
+
+
+def test_missing_hierarchy_raises_value_error_not_key_error(
+    hier_db_factory: Callable[..., Any],
+) -> None:
+    """The missing-``hierarchy`` guard fires, rather than a ``tree`` KeyError.
+
+    ``load_database`` reads ``data["tree"]`` first, so a document missing both
+    keys dies with ``KeyError('tree')`` before the guard runs -- that failure
+    would still look like a rejection to a bare ``pytest.raises(Exception)``
+    while leaving the guard uncovered. Pinning the type here is what keeps the
+    case honest.
+    """
+    doc = _no_hierarchy_doc()
+    assert "tree" in doc
+    assert "hierarchy" not in doc
+
+    with pytest.raises(ValueError) as excinfo:
+        hier_db_factory(doc)
+
+    assert not isinstance(excinfo.value, KeyError)
+    assert "hierarchy" in str(excinfo.value)
+
+
+def test_level_absent_from_pattern_is_navigation_only(
+    hier_db_factory: Callable[..., Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A non-optional level left out of the pattern loads and logs a note.
+
+    Pattern placeholders must be a *subset* of the declared levels, not equal to
+    them: a level with no placeholder is usable for navigation and simply
+    contributes nothing to channel names. This is the accepting counterpart of
+    the ``pattern-references-undefined-level`` rejection above.
+    """
+    doc = tree_only_doc()
+    doc["hierarchy"]["naming_pattern"] = "{system}:{device}"
+
+    with caplog.at_level(logging.INFO, logger=LOADING_LOGGER):
+        db = hier_db_factory(doc)
+
+    assert "navigation only" in caplog.text
+    assert "'signal'" in caplog.text
+    assert "signal" in db.hierarchy_levels
+    assert db.channel_map
+
+
+def test_optional_instance_level_without_container_loads(
+    hier_db_factory: Callable[..., Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The accepting counterpart of the required-instance-level rejection.
+
+    ``optional_instance_level_doc`` is the *same* document as
+    :func:`_required_instance_without_container_doc` with ``optional`` still in
+    place: ``_find_level_container`` returns None for the first branch either
+    way, and only the ``optional`` flag decides whether that is tolerated with a
+    log line or raised on. Loading it unmutated is what shows the rejection
+    above is attributable to dropping the flag and not to the missing container
+    on its own.
+    """
+    with caplog.at_level(logging.INFO, logger=LOADING_LOGGER):
+        db = hier_db_factory(optional_instance_level_doc())
+
+    assert "no container in some branches" in caplog.text
+    assert "'device'" in caplog.text
+    assert db.channel_map
+
+
+def test_nested_consecutive_instance_levels_load(
+    hier_db_factory: Callable[..., Any],
+) -> None:
+    """Control case for the consecutive-instances rejection.
+
+    The same two instance levels load once ``DEVICE`` is nested inside ``CELL``,
+    which is what shows the rejection above comes from the sibling layout and
+    not from anything else in that document.
+    """
+    db = hier_db_factory(_consecutive_instances_doc(nested=True))
+
+    assert db.channel_map

--- a/tests/services/channel_finder/databases/test_loading_expansion_validation.py
+++ b/tests/services/channel_finder/databases/test_loading_expansion_validation.py
@@ -1,0 +1,140 @@
+"""Rejection arms of ``_hierarchical_loading._validate_expansion_definition``.
+
+Every case here writes a document whose ``_expansion`` block breaks exactly one
+rule and asserts that loading it raises. The base documents come from the shared
+``*_doc()`` builders in ``tests/services/channel_finder/conftest.py`` -- each
+call returns a fresh dict, so replacing one ``_expansion`` cannot leak into
+another case, and the surrounding document stays valid so the failure is
+attributable to the mutation and nothing else.
+
+Which container gets validated is not free choice: ``_find_level_container``
+walks the *first* tree branch it finds at each tree level, so for
+:func:`range_instances_doc` the validated container is ``tree['SR']['BPM']
+['DEVICE']`` and for :func:`list_instances_doc` it is ``tree['RF']['UNIT']``.
+Those are the two nodes the helpers below mutate.
+
+The validator's messages are long and multi-line; each assertion matches a short
+distinguishing substring rather than the whole text.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from tests.services.channel_finder.conftest import (
+    list_instances_doc,
+    range_instances_doc,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _range_doc_with(expansion: dict[str, Any]) -> dict:
+    """A valid range document with the validated ``_expansion`` replaced."""
+    doc = range_instances_doc()
+    doc["tree"]["SR"]["BPM"]["DEVICE"]["_expansion"] = expansion
+    return doc
+
+
+def _list_doc_with(expansion: dict[str, Any]) -> dict:
+    """A valid list document with the validated ``_expansion`` replaced."""
+    doc = list_instances_doc()
+    doc["tree"]["RF"]["UNIT"]["_expansion"] = expansion
+    return doc
+
+
+# Each case: (document builder, level named in the message, message substring).
+# One case per rejection arm, in source order.
+EXPANSION_REJECTIONS = [
+    pytest.param(
+        lambda: _range_doc_with({"_pattern": "B{:02d}", "_range": [1, 3]}),
+        "device",
+        "missing '_type' field",
+        id="missing-type",
+    ),
+    pytest.param(
+        lambda: _range_doc_with({"_type": "range", "_range": [1, 3]}),
+        "device",
+        "requires '_pattern' field",
+        id="range-missing-pattern",
+    ),
+    pytest.param(
+        lambda: _range_doc_with({"_type": "range", "_pattern": "B{:02d}"}),
+        "device",
+        "requires '_range' field",
+        id="range-missing-range",
+    ),
+    pytest.param(
+        lambda: _range_doc_with({"_type": "range", "_pattern": "B{:02d}", "_range": [1, 2, 3]}),
+        "device",
+        "'_range' must be",
+        id="range-not-two-elements",
+    ),
+    pytest.param(
+        lambda: _range_doc_with({"_type": "range", "_pattern": "B{:02d}", "_range": ["1", 3]}),
+        "device",
+        "start and end must be integers",
+        id="range-non-integer-bounds",
+    ),
+    pytest.param(
+        lambda: _range_doc_with({"_type": "range", "_pattern": "B{:02d}", "_range": [5, 1]}),
+        "device",
+        "start must be <= end",
+        id="range-start-after-end",
+    ),
+    pytest.param(
+        lambda: _list_doc_with({"_type": "list"}),
+        "unit",
+        "requires '_instances' field",
+        id="list-missing-instances",
+    ),
+    pytest.param(
+        lambda: _list_doc_with({"_type": "list", "_instances": "MAIN"}),
+        "unit",
+        "'_instances' must be a list",
+        id="list-instances-not-a-list",
+    ),
+    pytest.param(
+        lambda: _list_doc_with({"_type": "list", "_instances": []}),
+        "unit",
+        "'_instances' cannot be empty",
+        id="list-instances-empty",
+    ),
+    pytest.param(
+        lambda: _range_doc_with({"_type": "sequence", "_range": [1, 3]}),
+        "device",
+        "invalid '_type'",
+        id="unknown-type",
+    ),
+]
+
+
+@pytest.mark.parametrize(("make_doc", "level_name", "match"), EXPANSION_REJECTIONS)
+def test_invalid_expansion_is_rejected(
+    hier_db_factory: Callable[..., Any],
+    make_doc: Callable[[], dict],
+    level_name: str,
+    match: str,
+) -> None:
+    """Each malformed ``_expansion`` raises ValueError naming its level."""
+    with pytest.raises(ValueError, match=match) as excinfo:
+        hier_db_factory(make_doc())
+
+    assert f"'{level_name}'" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("make_doc", [range_instances_doc, list_instances_doc])
+def test_base_document_loads_unmutated(
+    hier_db_factory: Callable[..., Any],
+    make_doc: Callable[[], dict],
+) -> None:
+    """Control case: the documents the rejections mutate are themselves valid.
+
+    Without this, a suite whose cases all tripped some earlier guard would still
+    look green.
+    """
+    db = hier_db_factory(make_doc())
+
+    assert db.channel_map

--- a/tests/services/channel_finder/databases/test_naming_channel_map.py
+++ b/tests/services/channel_finder/databases/test_naming_channel_map.py
@@ -1,0 +1,306 @@
+"""Recursion contracts of ``_hierarchical_naming._build_channel_map``.
+
+This file is deliberately narrow. ``test_naming_characterization`` already pins
+the emitted channel list and ``channel_map`` payload for every shape in the
+shared fixture family, the ``_is_leaf: true``-with-children asymmetry, the
+all-remaining-optional tail, and ``_separator`` collection at both depths. None
+of that is repeated here.
+
+What is added are three contracts of the recursion itself that no inventory
+assertion reaches:
+
+1. **Recursion depth is bounded by the level count.** ``expand_tree`` is never
+   entered below ``len(hierarchy_levels)``, and a node handed to it at exactly
+   that depth is always treated as a leaf -- whatever children it has. This is
+   why the second ``if level_idx >= len(self.hierarchy_levels): return`` guard,
+   the one *after* the leaf block, can never fire: reaching it requires a
+   non-leaf node at a depth where every node is a leaf.
+2. **The ``instances`` container lookup** matches by case-insensitive key, skips
+   non-dict values, skips name matches that carry no ``_expansion``, and
+   navigates *into* the container -- so siblings of the container are dropped.
+3. **A leaf with dict children and no ``tree`` level left** does not stop after
+   emitting its own channel; it falls through and is processed again as an
+   ``instances`` level at the same position.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from tests.services.channel_finder.conftest import _document, leaf_with_children_doc
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from osprey.services.channel_finder.databases.hierarchical import (
+        HierarchicalChannelDatabase,
+    )
+
+
+#: A two-instance range, reused by every ``instances``-level document below.
+RANGE_EXPANSION = {"_type": "range", "_pattern": "D{}", "_range": [1, 2]}
+
+#: ``system(tree) -> device(instances) -> signal(tree)``.
+INSTANCE_LEVELS = [
+    {"name": "system", "type": "tree"},
+    {"name": "device", "type": "instances"},
+    {"name": "signal", "type": "tree"},
+]
+
+#: The same three levels with ``device`` optional, which is what makes
+#: ``_hierarchical_loading._validate_instance_level`` return early on a first
+#: branch that has no container and leave later branches unvalidated.
+OPTIONAL_INSTANCE_LEVELS = [
+    {"name": "system", "type": "tree"},
+    {"name": "device", "type": "instances", "optional": True},
+    {"name": "signal", "type": "tree"},
+]
+
+INSTANCE_PATTERN = "{system}:{device}:{signal}"
+
+
+def _record_leaf_calls(db: HierarchicalChannelDatabase) -> list[tuple[int, bool]]:
+    """Wrap ``db._is_leaf_node`` so every call records ``(level_idx, verdict)``.
+
+    The wrapper is installed on the instance only, and the returned list fills
+    in during the next ``_build_channel_map()`` call. ``_build_channel_map``
+    consults ``_is_leaf_node`` exactly once per ``expand_tree`` entry, so the
+    recorded indices are the recursion depths the traversal visited.
+    """
+    calls: list[tuple[int, bool]] = []
+    unbound = type(db)._is_leaf_node
+
+    def spy(node: dict, level_idx: int) -> bool:
+        verdict = unbound(db, node, level_idx)
+        calls.append((level_idx, verdict))
+        return verdict
+
+    db._is_leaf_node = spy
+    return calls
+
+
+class TestRecursionDepthIsBounded:
+    """No node is ever expanded past the last hierarchy level.
+
+    ``_build_channel_map`` carries two identical ``level_idx >=
+    len(hierarchy_levels)`` returns, one inside the leaf block and one after it.
+    The tests here pin the invariant that makes the second one dead code: at that
+    depth ``_is_leaf_node`` answers True unconditionally, so the leaf block runs
+    and returns, and control never reaches the trailing guard.
+    """
+
+    def test_traversal_never_recurses_below_the_last_level(self, leaf_with_children_db) -> None:
+        """The deepest ``expand_tree`` entry sits at exactly ``len(levels)``.
+
+        ``leaf_with_children_db`` is the shape that goes deepest: ``SIGNAL-Y``
+        emits at the ``signal`` level and then re-enters recursion with
+        ``RB``/``SP`` bound to ``suffix``, the last level, so those calls arrive
+        with ``level_idx == 4``.
+        """
+        calls = _record_leaf_calls(leaf_with_children_db)
+        leaf_with_children_db._build_channel_map()
+
+        n_levels = len(leaf_with_children_db.hierarchy_levels)
+        assert calls, "the traversal never ran"
+        assert max(idx for idx, _ in calls) == n_levels
+        assert not [idx for idx, _ in calls if idx > n_levels]
+
+    def test_every_node_at_the_last_level_is_treated_as_a_leaf(self, leaf_with_children_db) -> None:
+        """At full depth the verdict is True for every node the traversal sees."""
+        calls = _record_leaf_calls(leaf_with_children_db)
+        leaf_with_children_db._build_channel_map()
+
+        n_levels = len(leaf_with_children_db.hierarchy_levels)
+        at_full_depth = [verdict for idx, verdict in calls if idx >= n_levels]
+        assert at_full_depth, "no node reached the last level"
+        assert all(at_full_depth)
+
+    def test_children_below_the_last_level_are_dropped(self, hier_db_factory) -> None:
+        """A node at full depth stops even when it has dict children.
+
+        ``RB`` here owns a ``DEEP`` child, but ``suffix`` was the last level, so
+        the traversal emits ``...:RB`` and returns without visiting it.
+
+        Characterized as-is, not endorsed: the drop is silent.
+        """
+        doc = leaf_with_children_doc()
+        doc["tree"]["SR"]["PS"]["SIGNAL-Y"]["RB"]["DEEP"] = {"_description": "one too far"}
+        db = hier_db_factory(doc, "below_last_level.json")
+
+        assert list(db._build_channel_map()) == [
+            "SR:PS:SIGNAL-Y",
+            "SR:PS:SIGNAL-Y:RB",
+            "SR:PS:SIGNAL-Y:SP",
+        ]
+
+    def test_a_node_with_children_is_a_leaf_once_the_levels_run_out(
+        self, leaf_with_children_db
+    ) -> None:
+        """The direct statement of the invariant, on the only shape that could break it.
+
+        A node with dict children and no ``_is_leaf`` marker is the one input
+        that fails the first two leaf criteria. Asked about it at full depth,
+        ``_is_leaf_node`` still answers True -- which is what leaves the trailing
+        ``level_idx >= len(levels)`` guard unreachable.
+        """
+        n_levels = len(leaf_with_children_db.hierarchy_levels)
+        node = leaf_with_children_db.tree["SR"]
+
+        assert "_is_leaf" not in node
+        assert any(isinstance(v, dict) for k, v in node.items() if not k.startswith("_"))
+        assert leaf_with_children_db._is_leaf_node(node, n_levels) is True
+        assert leaf_with_children_db._is_leaf_node(node, 0) is False
+
+
+class TestInstanceContainerLookup:
+    """How the ``instances`` arm finds the container that carries ``_expansion``."""
+
+    @pytest.mark.parametrize("container_key", ["DEVICE", "device", "DeViCe"])
+    def test_the_container_key_is_matched_case_insensitively(
+        self, hier_db_factory: Callable[..., HierarchicalChannelDatabase], container_key: str
+    ) -> None:
+        """Any casing of the level name names the container."""
+        db = hier_db_factory(
+            _document(
+                levels=INSTANCE_LEVELS,
+                naming_pattern=INSTANCE_PATTERN,
+                tree={"SR": {container_key: {"_expansion": RANGE_EXPANSION, "X": {}}}},
+            ),
+            f"container_{container_key}.json",
+        )
+        assert list(db._build_channel_map()) == ["SR:D1:X", "SR:D2:X"]
+
+    def test_a_non_dict_value_with_the_container_name_is_skipped(self, hier_db_factory) -> None:
+        """The scalar ``DEVICE`` does not shadow the real container."""
+        db = hier_db_factory(
+            _document(
+                levels=INSTANCE_LEVELS,
+                naming_pattern=INSTANCE_PATTERN,
+                tree={
+                    "SR": {
+                        "DEVICE": 7,
+                        "device": {"_expansion": RANGE_EXPANSION, "X": {}},
+                    }
+                },
+            ),
+            "scalar_shadow.json",
+        )
+        assert list(db._build_channel_map()) == ["SR:D1:X", "SR:D2:X"]
+
+    def test_siblings_of_the_container_are_never_visited(self, hier_db_factory) -> None:
+        """Expansion navigates *into* the container, abandoning everything beside it.
+
+        Characterized as-is, not endorsed: ``Status`` sits next to the container
+        and produces no channel, with no document-level signal that it will not.
+        """
+        db = hier_db_factory(
+            _document(
+                levels=INSTANCE_LEVELS,
+                naming_pattern=INSTANCE_PATTERN,
+                tree={
+                    "SR": {
+                        "Status": {},
+                        "DEVICE": {"_expansion": RANGE_EXPANSION, "X": {}},
+                    }
+                },
+            ),
+            "sibling_outside_container.json",
+        )
+        channels = list(db._build_channel_map())
+        assert channels == ["SR:D1:X", "SR:D2:X"]
+        assert "SR:Status" not in channels
+
+    def test_a_container_without_an_expansion_yields_nothing(self, hier_db_factory) -> None:
+        """A name match with no ``_expansion`` leaves the branch empty.
+
+        A *required* instance level cannot reach this: the loader rejects the
+        document. The level is optional here so validation stops at ``AA`` --
+        the first branch, which has no container at all -- and never inspects
+        ``BB``. ``CC`` is the control: the empty branch does not disturb it.
+        """
+        db = hier_db_factory(
+            _document(
+                levels=OPTIONAL_INSTANCE_LEVELS,
+                naming_pattern=INSTANCE_PATTERN,
+                tree={
+                    "AA": {"_description": "no container at all", "Status": {}},
+                    "BB": {"DEVICE": {"X": {}}},
+                    "CC": {"DEVICE": {"_expansion": RANGE_EXPANSION, "X": {}}},
+                },
+            ),
+            "container_without_expansion.json",
+        )
+        assert list(db._build_channel_map()) == ["CC:D1:X", "CC:D2:X"]
+
+    def test_the_scan_continues_past_a_name_match_that_has_no_expansion(
+        self, hier_db_factory
+    ) -> None:
+        """The lookup stops at the first name match *carrying* ``_expansion``.
+
+        ``BB`` holds two keys that both match ``device`` case-insensitively.
+        ``DEVICE`` comes first and has no ``_expansion``, so the scan keeps
+        going and expands from ``device`` instead.
+        """
+        db = hier_db_factory(
+            _document(
+                levels=OPTIONAL_INSTANCE_LEVELS,
+                naming_pattern=INSTANCE_PATTERN,
+                tree={
+                    "AA": {"_description": "no container at all", "Status": {}},
+                    "BB": {
+                        "DEVICE": {"Y": {}},
+                        "device": {"_expansion": RANGE_EXPANSION, "X": {}},
+                    },
+                },
+            ),
+            "scan_past_name_match.json",
+        )
+        channels = list(db._build_channel_map())
+        assert channels == ["BB:D1:X", "BB:D2:X"]
+        # ``Y`` lived in the container that was scanned past, so it is gone.
+        assert not [c for c in channels if c.endswith(":Y")]
+
+
+class TestLeafWithChildrenAndNoTreeLevelLeft:
+    """The third exit from the leaf-with-children block: no ``tree`` level remains.
+
+    ``test_naming_characterization`` pins the two exits that return -- children
+    re-assigned to a later tree level, and the optional-level skip. When no
+    ``tree`` level is left at or after the current position, the block instead
+    falls *through*, and the node is processed a second time by the level
+    handling below it.
+    """
+
+    def test_the_node_emits_its_channel_and_is_expanded_again_as_instances(
+        self, hier_db_factory
+    ) -> None:
+        """``PS`` is both a channel and the parent of the ``num`` instances.
+
+        ``num`` is the only level after ``device`` and it is ``instances``-typed,
+        so the leaf block finds no next tree level and does not return. Control
+        reaches the ``instances`` arm at the same ``level_idx``, which finds
+        ``NUM`` and expands it.
+        """
+        db = hier_db_factory(
+            _document(
+                levels=[
+                    {"name": "system", "type": "tree"},
+                    {"name": "device", "type": "tree"},
+                    {"name": "num", "type": "instances"},
+                ],
+                naming_pattern="{system}:{device}:{num}",
+                tree={"SR": {"PS": {"_is_leaf": True, "NUM": {"_expansion": RANGE_EXPANSION}}}},
+            ),
+            "leaf_no_tree_level_left.json",
+        )
+        channel_map = db._build_channel_map()
+
+        assert list(channel_map) == ["SR:PS", "SR:PS:D1", "SR:PS:D2"]
+        # The node's own channel stops at ``device``; the instances carry ``num``.
+        assert channel_map["SR:PS"]["path"] == {"system": "SR", "device": "PS"}
+        assert channel_map["SR:PS:D1"]["path"] == {
+            "system": "SR",
+            "device": "PS",
+            "num": "D1",
+        }

--- a/tests/services/channel_finder/databases/test_naming_characterization.py
+++ b/tests/services/channel_finder/databases/test_naming_characterization.py
@@ -1,0 +1,779 @@
+"""Characterization of ``_hierarchical_naming`` -- what it does today, not what it should do.
+
+This module is a safety net, not a specification. Every assertion below was
+derived by running the current implementation and writing down its answer; none
+of it was derived from the docstrings in
+``osprey.services.channel_finder.databases._hierarchical_naming``. Several of the
+behaviours pinned here are, in the judgement of the author, wrong. They are
+pinned anyway, with a comment saying so, because the point of the file is to make
+a *behaviour-preserving* change to that module detectable -- and a test that
+asserts the intended behaviour cannot tell a preserved bug from a fixed one.
+
+Three surprises are characterized explicitly, each in its own section below:
+
+1. ``_is_leaf: true`` combined with dict children means different things under a
+   required level and under an optional level; under the optional one the
+   children are silently dropped.
+2. An all-remaining-optional tail whose next level is ``tree``-typed never
+   produces the bare parent channel, while the ``instances``-typed counterpart
+   does.
+3. ``get_statistics`` buckets by raw tree key, so a tree using ``_channel_part``
+   reports ``channel_count: 0`` for systems that do have channels.
+
+Nothing here asserts on coverage, on private call counts, or on anything else
+that a pure deletion of unreachable code inside the module would perturb. The
+observable surface is the emitted channel names, the ``channel_map`` payloads,
+and the return value of ``build_channels_from_selections``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from tests.services.channel_finder.conftest import (
+    _document,
+    hybrid_expansion_doc,
+    range_instances_doc,
+    separator_override_doc,
+    tree_only_doc,
+)
+
+if TYPE_CHECKING:
+    from osprey.services.channel_finder.databases.hierarchical import (
+        HierarchicalChannelDatabase,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The full channel inventory, one entry per shape in the shared fixture family.
+#
+# Lists are ordered, because the emission order is itself current behaviour:
+# it follows the document's key order through the recursion, and a change to it
+# would mean the traversal changed.
+# ---------------------------------------------------------------------------
+
+EXPECTED_CHANNELS: dict[str, list[str]] = {
+    "tree_only_db": [
+        "SR:BPM:X",
+        "SR:BPM:Y",
+        "SR:QUAD:Setpoint",
+        "BR",
+    ],
+    "range_instances_db": [
+        "SR:BPM:B01:X",
+        "SR:BPM:B01:Y",
+        "SR:BPM:B02:X",
+        "SR:BPM:B02:Y",
+        "SR:BPM:B03:X",
+        "SR:BPM:B03:Y",
+        "SR:QUAD:Q1:Setpoint",
+        "SR:QUAD:Q1:Readback",
+        "SR:QUAD:Q2:Setpoint",
+        "SR:QUAD:Q2:Readback",
+    ],
+    "list_instances_db": [
+        "RF:MAIN:Power",
+        "RF:MAIN:Phase",
+        "RF:BACKUP:Power",
+        "RF:BACKUP:Phase",
+        "RF:TEST:Power",
+        "RF:TEST:Phase",
+    ],
+    "optional_tree_level_db": [
+        "SR:PS:PSU:Voltage",
+        "SR:PS:PSU:Current",
+        "SR:PS:Heartbeat",
+    ],
+    # BR has no DEVICE container and contributes nothing at all -- not even its
+    # own ``Status`` child, which never becomes a channel.
+    "optional_instance_level_db": [
+        "SR:D1:X",
+        "SR:D2:X",
+    ],
+    "hybrid_expansion_db": [
+        "SR:CH-1:Voltage",
+        "SR:CH-1:Current",
+        "SR:CH-2:Voltage",
+        "SR:CH-2:Current",
+        "SR:CH-3:Voltage",
+        "SR:CH-3:Current",
+        "SR:PS:Status",
+    ],
+    # BPM's scalar X/Y children are invisible to the dict guards, so BPM itself
+    # is the channel and the scalars produce nothing.
+    "scalar_leaves_db": [
+        "SR:BPM",
+        "SR:QUAD:Setpoint",
+    ],
+    "separator_override_db": [
+        "SR-BPM_X:RB",
+        "SR-BPM_X:SP",
+        "SR-QUAD:Setpoint:RB",
+    ],
+    "channel_part_db": [
+        "MAG:PS:Current",
+        "RACK:Temp",
+    ],
+    "leaf_with_children_db": [
+        "SR:PS:SIGNAL-Y",
+        "SR:PS:SIGNAL-Y:RB",
+        "SR:PS:SIGNAL-Y:SP",
+    ],
+    # Same SIGNAL-Y node as above, one level made optional: RB/SP are gone.
+    # See the asymmetry section for the full statement of this.
+    "optional_leaf_with_children_db": [
+        "SR:PS:SIGNAL-Y",
+        "SR:PS:PSU:Voltage",
+    ],
+    "all_optional_next_instances_db": [
+        "SR",
+        "SR:X",
+        "SR:Y",
+        "BR:D1:Z",
+        "BR:D2:Z",
+    ],
+    # No bare "SR" here, unlike the instances counterpart above.
+    "all_optional_next_tree_db": [
+        "SR:PSU:Voltage",
+        "SR:PSU:Current",
+    ],
+}
+
+
+#: Channels that ``_build_channel_map`` emits but ``build_channels_from_selections``
+#: cannot reproduce from their own stored path, because the path stops before a
+#: *required* pattern level. Empty for every other shape -- see
+#: ``TestBuildChannelsFromSelections`` for the full statement.
+NON_REPLAYABLE_CHANNELS: dict[str, set[str]] = {name: set() for name in EXPECTED_CHANNELS} | {
+    # BR has no children at all, so it terminates at ``system``.
+    "tree_only_db": {"BR"},
+    # BPM's children are scalars, invisible to the dict guards.
+    "scalar_leaves_db": {"SR:BPM"},
+    # SIGNAL-Y is a channel in its own right at the ``signal`` level, with
+    # ``suffix`` left unfilled.
+    "leaf_with_children_db": {"SR:PS:SIGNAL-Y"},
+}
+
+
+@pytest.fixture(params=sorted(EXPECTED_CHANNELS))
+def any_shape(request) -> tuple[str, HierarchicalChannelDatabase]:
+    """Every shape in the shared fixture family, one at a time."""
+    return request.param, request.getfixturevalue(request.param)
+
+
+class TestChannelInventory:
+    """The complete set of channel names each shape expands to."""
+
+    @pytest.mark.parametrize(("fixture_name", "expected"), sorted(EXPECTED_CHANNELS.items()))
+    def test_build_channel_map_emits_exactly_these_channels(
+        self, request, fixture_name: str, expected: list[str]
+    ) -> None:
+        db = request.getfixturevalue(fixture_name)
+        assert list(db._build_channel_map()) == expected
+
+    def test_loaded_channel_map_matches_a_fresh_expansion(self, any_shape) -> None:
+        """``load_database`` stores the same map a fresh call builds."""
+        _, db = any_shape
+        assert db.channel_map == db._build_channel_map()
+
+    def test_expansion_is_repeatable(self, any_shape) -> None:
+        """Expanding twice yields an equal map -- no accumulated state."""
+        _, db = any_shape
+        assert db._build_channel_map() == db._build_channel_map()
+
+    def test_every_entry_is_keyed_by_its_own_channel_name(self, any_shape) -> None:
+        """Each value carries ``channel`` (equal to the key) and a ``path`` dict."""
+        _, db = any_shape
+        for name, info in db._build_channel_map().items():
+            assert info["channel"] == name
+            assert isinstance(info["path"], dict)
+            assert set(info) == {"channel", "path"}
+
+
+class TestChannelPaths:
+    """The ``path`` payload stored alongside each channel name."""
+
+    def test_tree_only_paths(self, tree_only_db) -> None:
+        paths = {k: v["path"] for k, v in tree_only_db._build_channel_map().items()}
+        assert paths == {
+            "SR:BPM:X": {"system": "SR", "device": "BPM", "signal": "X"},
+            "SR:BPM:Y": {"system": "SR", "device": "BPM", "signal": "Y"},
+            "SR:QUAD:Setpoint": {"system": "SR", "device": "QUAD", "signal": "Setpoint"},
+            # BR terminates early; the levels it never reached are simply absent
+            # from the path rather than present as empty strings.
+            "BR": {"system": "BR"},
+        }
+
+    def test_optional_tree_level_paths_omit_the_skipped_level(self, optional_tree_level_db) -> None:
+        paths = {k: v["path"] for k, v in optional_tree_level_db._build_channel_map().items()}
+        assert paths["SR:PS:PSU:Voltage"] == {
+            "system": "SR",
+            "device": "PS",
+            "subdevice": "PSU",
+            "signal": "Voltage",
+        }
+        # Heartbeat skipped ``subdevice`` and was re-assigned to ``signal``.
+        assert paths["SR:PS:Heartbeat"] == {
+            "system": "SR",
+            "device": "PS",
+            "signal": "Heartbeat",
+        }
+
+    def test_channel_part_paths_record_the_emitted_part_not_the_tree_key(
+        self, channel_part_db
+    ) -> None:
+        """The path stores ``_channel_part`` values, so the tree key is unrecoverable.
+
+        Characterized as-is, not endorsed: ``Magnets`` and ``Building-1`` are the
+        keys a caller would navigate with, but neither appears in any path. The
+        empty ``_channel_part`` is stored as an empty string, which is what makes
+        ``get_statistics`` mis-bucket (see the section on that below).
+        """
+        paths = {k: v["path"] for k, v in channel_part_db._build_channel_map().items()}
+        assert paths == {
+            "MAG:PS:Current": {"system": "MAG", "device": "PS", "signal": "Current"},
+            "RACK:Temp": {"system": "", "device": "RACK", "signal": "Temp"},
+        }
+
+    def test_all_optional_next_instances_paths(self, all_optional_next_instances_db) -> None:
+        paths = {
+            k: v["path"] for k, v in all_optional_next_instances_db._build_channel_map().items()
+        }
+        assert paths == {
+            "SR": {"system": "SR"},
+            "SR:X": {"system": "SR", "signal": "X"},
+            "SR:Y": {"system": "SR", "signal": "Y"},
+            "BR:D1:Z": {"system": "BR", "device": "D1", "signal": "Z"},
+            "BR:D2:Z": {"system": "BR", "device": "D2", "signal": "Z"},
+        }
+
+    def test_colliding_channel_names_collapse_to_the_last_writer(self, hier_db_factory) -> None:
+        """Two tree positions naming the same channel leave only the later path.
+
+        Characterized as-is, not endorsed: ``channel_map`` is a plain dict keyed
+        by the emitted name, so a document whose naming pattern omits a
+        distinguishing level silently loses channels. Nothing warns.
+        """
+        db = hier_db_factory(
+            _document(
+                levels=[
+                    {"name": "system", "type": "tree"},
+                    {"name": "device", "type": "tree"},
+                    {"name": "signal", "type": "tree"},
+                ],
+                naming_pattern="{system}:{signal}",
+                tree={"SR": {"A": {"Temp": {}}, "B": {"Temp": {}}}},
+            ),
+            "collision.json",
+        )
+        channel_map = db._build_channel_map()
+        assert list(channel_map) == ["SR:Temp"]
+        assert channel_map["SR:Temp"]["path"] == {
+            "system": "SR",
+            "device": "B",
+            "signal": "Temp",
+        }
+
+
+class TestLeafWithChildrenAsymmetry:
+    """Finding 1: ``_is_leaf: true`` + dict children behaves differently by level kind.
+
+    The same node -- ``_is_leaf: true`` with ``RB``/``SP`` dict children -- emits
+    three channels under a required level and one under an optional level. Under
+    the optional level the optional-skip branch fires before the leaf branch, the
+    node is re-assigned to the *next* level, every level is thereby consumed, and
+    the children are never visited.
+
+    Characterized as-is, not endorsed: the drop is silent and there is no
+    document-level signal that ``RB``/``SP`` will not appear.
+    """
+
+    def test_required_level_emits_the_node_and_recurses_into_its_children(
+        self, leaf_with_children_db
+    ) -> None:
+        channel_map = leaf_with_children_db._build_channel_map()
+        assert list(channel_map) == [
+            "SR:PS:SIGNAL-Y",
+            "SR:PS:SIGNAL-Y:RB",
+            "SR:PS:SIGNAL-Y:SP",
+        ]
+        # The node occupies ``signal``; its children occupy the next tree level.
+        assert channel_map["SR:PS:SIGNAL-Y"]["path"] == {
+            "system": "SR",
+            "device": "PS",
+            "signal": "SIGNAL-Y",
+        }
+        assert channel_map["SR:PS:SIGNAL-Y:RB"]["path"] == {
+            "system": "SR",
+            "device": "PS",
+            "signal": "SIGNAL-Y",
+            "suffix": "RB",
+        }
+
+    def test_optional_level_drops_the_children_and_shifts_the_node_one_level_down(
+        self, optional_leaf_with_children_db
+    ) -> None:
+        channel_map = optional_leaf_with_children_db._build_channel_map()
+        assert list(channel_map) == ["SR:PS:SIGNAL-Y", "SR:PS:PSU:Voltage"]
+        # SIGNAL-Y landed on ``suffix``, not on the ``subdevice`` level it was
+        # written under -- that is the level skip, and it is why nothing is left
+        # for RB/SP to occupy.
+        assert optional_leaf_with_children_db._build_channel_map()["SR:PS:SIGNAL-Y"]["path"] == {
+            "system": "SR",
+            "device": "PS",
+            "suffix": "SIGNAL-Y",
+        }
+
+    def test_the_two_shapes_disagree_about_the_same_node(
+        self, leaf_with_children_db, optional_leaf_with_children_db
+    ) -> None:
+        """Stated directly: RB/SP survive under the required level and not the optional one."""
+        required = set(leaf_with_children_db._build_channel_map())
+        optional = set(optional_leaf_with_children_db._build_channel_map())
+
+        assert {"SR:PS:SIGNAL-Y:RB", "SR:PS:SIGNAL-Y:SP"} <= required
+        assert not {c for c in optional if c.endswith((":RB", ":SP"))}
+        # The node's own channel is emitted either way.
+        assert "SR:PS:SIGNAL-Y" in required & optional
+
+    def test_optional_skip_at_the_final_level_emits_only_the_parent(self, hier_db_factory) -> None:
+        """With no next level to skip into, the child expands in place and vanishes.
+
+        Characterized as-is, not endorsed: ``Beat`` contributes nothing; the only
+        channel is its parent ``SR``.
+        """
+        db = hier_db_factory(
+            _document(
+                levels=[
+                    {"name": "system", "type": "tree"},
+                    {"name": "sub", "type": "tree", "optional": True},
+                ],
+                naming_pattern="{system}:{sub}",
+                tree={"SR": {"Beat": {"_is_leaf": True}}},
+            ),
+            "optional_skip_last.json",
+        )
+        channel_map = db._build_channel_map()
+        assert list(channel_map) == ["SR"]
+        assert channel_map["SR"]["path"] == {"system": "SR"}
+
+
+class TestAllRemainingOptionalTail:
+    """Finding 2: the ``tree`` arm of the all-remaining-optional check never yields a leaf.
+
+    When every level from the current position on is optional, a node with an
+    ``instances``-typed next level is treated as a leaf if it has no matching
+    container -- so ``SR`` emits a bare ``SR`` channel. The ``tree``-typed
+    counterpart re-tests the same "has dict children" predicate that a node must
+    already have passed to reach that point, so it can only answer "not a leaf".
+
+    Characterized as-is, not endorsed. The assertions below pin the *consequence*
+    -- no bare parent channel on the tree side -- rather than the arm's return
+    value, and hold whether or not the unreachable-True branch still exists.
+    """
+
+    def test_instances_tail_emits_the_bare_parent_channel(
+        self, all_optional_next_instances_db
+    ) -> None:
+        channels = list(all_optional_next_instances_db._build_channel_map())
+        assert "SR" in channels
+        assert channels == ["SR", "SR:X", "SR:Y", "BR:D1:Z", "BR:D2:Z"]
+
+    def test_tree_tail_never_emits_the_bare_parent_channel(self, all_optional_next_tree_db) -> None:
+        channels = list(all_optional_next_tree_db._build_channel_map())
+        assert "SR" not in channels
+        assert channels == ["SR:PSU:Voltage", "SR:PSU:Current"]
+
+    def test_leaf_detection_answers_for_each_tail_kind(
+        self, all_optional_next_instances_db, all_optional_next_tree_db
+    ) -> None:
+        """The leaf verdicts behind the two inventories above.
+
+        ``SR`` in the instances document has no ``DEVICE`` container, so it is a
+        leaf; ``BR`` has one, so it is not. In the tree document ``SR`` is never
+        a leaf, and neither is ``PSU`` -- only childless nodes are.
+        """
+        instances_tree = all_optional_next_instances_db.tree
+        assert all_optional_next_instances_db._is_leaf_node(instances_tree["SR"], 1) is True
+        assert all_optional_next_instances_db._is_leaf_node(instances_tree["BR"], 1) is False
+
+        tree_tree = all_optional_next_tree_db.tree
+        assert all_optional_next_tree_db._is_leaf_node(tree_tree["SR"], 1) is False
+        assert all_optional_next_tree_db._is_leaf_node(tree_tree["SR"]["PSU"], 2) is False
+        assert all_optional_next_tree_db._is_leaf_node(tree_tree["SR"]["PSU"]["Voltage"], 2) is True
+
+    def test_nodes_with_only_scalar_children_are_leaves(self, scalar_leaves_db) -> None:
+        """Scalars are invisible to the dict guards, so ``BPM`` is childless here."""
+        assert scalar_leaves_db._is_leaf_node(scalar_leaves_db.tree["SR"]["BPM"], 1) is True
+        assert list(scalar_leaves_db._build_channel_map()) == ["SR:BPM", "SR:QUAD:Setpoint"]
+
+
+class TestStatisticsBucketing:
+    """Finding 3: ``get_statistics`` buckets by raw tree key, not by emitted name."""
+
+    def test_channel_part_systems_report_zero_channels(self, channel_part_db) -> None:
+        """Characterized as-is, not endorsed: both counts are wrong.
+
+        ``total_channels`` is 2 and both channels belong to one of the two listed
+        systems, yet each system reports ``channel_count: 0``. The bucketing
+        compares the stored path value (``MAG``, ``""``) against the tree key
+        (``Magnets``, ``Building-1``) and never matches.
+        """
+        stats = channel_part_db.get_statistics()
+        assert stats["total_channels"] == 2
+        assert stats["systems"] == [
+            {"name": "Magnets", "channel_count": 0},
+            {"name": "Building-1", "channel_count": 0},
+        ]
+
+    def test_bucketing_is_correct_when_no_channel_part_is_used(self, tree_only_db) -> None:
+        """The contrast case: without ``_channel_part`` the counts do add up."""
+        stats = tree_only_db.get_statistics()
+        assert stats["total_channels"] == 4
+        assert stats["systems"] == [
+            {"name": "SR", "channel_count": 3},
+            {"name": "BR", "channel_count": 1},
+        ]
+
+
+class TestChannelPartRendering:
+    """``_channel_part`` overrides and the separator cleanup they trigger."""
+
+    def test_explicit_part_replaces_the_tree_key_in_the_name(self, channel_part_db) -> None:
+        assert list(channel_part_db._build_channel_map()) == ["MAG:PS:Current", "RACK:Temp"]
+
+    def test_empty_part_drops_the_component_and_the_leading_separator(
+        self, channel_part_db
+    ) -> None:
+        """``Building-1`` contributes nothing, and the resulting ``:RACK:Temp`` is cleaned."""
+        assert "RACK:Temp" in channel_part_db._build_channel_map()
+
+    def test_empty_part_at_a_middle_level_collapses_the_doubled_separator(
+        self, hier_db_factory
+    ) -> None:
+        doc = tree_only_doc()
+        doc["tree"]["SR"]["BPM"]["_channel_part"] = ""
+        db = hier_db_factory(doc, "mid_empty_part.json")
+        # ``SR`` + empty + ``X`` would read ``SR::X``; the cleanup collapses it.
+        assert list(db._build_channel_map()) == ["SR:X", "SR:Y", "SR:QUAD:Setpoint", "BR"]
+
+    def test_two_empty_parts_leave_the_name_starting_at_the_first_real_component(
+        self, hier_db_factory
+    ) -> None:
+        doc = tree_only_doc()
+        doc["tree"]["SR"]["_channel_part"] = ""
+        doc["tree"]["SR"]["BPM"]["_channel_part"] = ""
+        db = hier_db_factory(doc, "two_empty_parts.json")
+        assert list(db._build_channel_map()) == ["X", "Y", "QUAD:Setpoint", "BR"]
+
+    def test_literal_pattern_text_is_kept_and_disappears_with_a_skipped_level(
+        self, hier_db_factory
+    ) -> None:
+        """A literal prefix belongs to its placeholder: skip the level, lose the literal."""
+        db = hier_db_factory(
+            _document(
+                levels=[
+                    {"name": "system", "type": "tree"},
+                    {"name": "sub", "type": "tree", "optional": True},
+                    {"name": "signal", "type": "tree"},
+                ],
+                naming_pattern="{system}:S{sub}:{signal}",
+                tree={"SR": {"Beat": {"_is_leaf": True}, "PSU": {"V": {}}}},
+            ),
+            "literal_prefix.json",
+        )
+        assert list(db._build_channel_map()) == ["SR:Beat", "SR:SPSU:V"]
+
+
+class TestSeparatorOverrides:
+    """``_separator`` metadata, in the tree expansion and in the selections path."""
+
+    def test_overrides_apply_per_subtree_and_do_not_leak_to_siblings(
+        self, separator_override_db
+    ) -> None:
+        """``SR`` sets ``-`` and ``BPM`` sets ``_``; ``QUAD`` keeps the pattern's ``:``."""
+        assert list(separator_override_db._build_channel_map()) == [
+            "SR-BPM_X:RB",
+            "SR-BPM_X:SP",
+            "SR-QUAD:Setpoint:RB",
+        ]
+
+    def test_selections_reproduce_the_expansion_names(self, separator_override_db) -> None:
+        """The two collection paths agree for this document."""
+        assert separator_override_db.build_channels_from_selections(
+            {"system": "SR", "device": "BPM", "signal": "X", "suffix": ["RB", "SP"]}
+        ) == ["SR-BPM_X:RB", "SR-BPM_X:SP"]
+        assert separator_override_db.build_channels_from_selections(
+            {"system": "SR", "device": "QUAD", "signal": "Setpoint", "suffix": "RB"}
+        ) == ["SR-QUAD:Setpoint:RB"]
+
+    def test_separator_on_the_tree_root_itself_is_ignored(self, hier_db_factory) -> None:
+        """Only nodes below the root can carry an override.
+
+        Characterized as-is, not endorsed: the root's ``_separator`` is dropped
+        without complaint because the guard requires a non-zero level index.
+        """
+        doc = separator_override_doc()
+        doc["tree"]["_separator"] = "@"
+        db = hier_db_factory(doc, "root_separator.json")
+        assert list(db._build_channel_map()) == [
+            "SR-BPM_X:RB",
+            "SR-BPM_X:SP",
+            "SR-QUAD:Setpoint:RB",
+        ]
+
+    def test_separator_with_no_later_tree_level_is_ignored(self, hier_db_factory) -> None:
+        """An override binds to the next ``tree`` level; with none, it is dropped."""
+        db = hier_db_factory(
+            _document(
+                levels=[
+                    {"name": "system", "type": "tree"},
+                    {"name": "device", "type": "instances"},
+                ],
+                naming_pattern="{system}:{device}",
+                tree={
+                    "SR": {
+                        "_separator": "~",
+                        "DEVICE": {
+                            "_expansion": {
+                                "_type": "range",
+                                "_pattern": "D{}",
+                                "_range": [1, 2],
+                            }
+                        },
+                    }
+                },
+            ),
+            "separator_no_tree_level.json",
+        )
+        assert list(db._build_channel_map()) == ["SR:D1", "SR:D2"]
+
+    def test_separator_on_an_instance_container_binds_to_the_following_tree_level(
+        self, hier_db_factory
+    ) -> None:
+        doc = range_instances_doc()
+        doc["tree"]["SR"]["BPM"]["DEVICE"]["_separator"] = "#"
+        db = hier_db_factory(doc, "instances_separator.json")
+        channels = list(db._build_channel_map())
+        assert channels[:2] == ["SR:BPM:B01#X", "SR:BPM:B01#Y"]
+        # QUAD, which sets no override, is untouched.
+        assert "SR:QUAD:Q1:Setpoint" in channels
+        assert db.build_channels_from_selections(
+            {"system": "SR", "family": "BPM", "device": "B01", "signal": "X"}
+        ) == ["SR:BPM:B01#X"]
+
+    def test_separator_on_a_hybrid_expansion_node_applies_to_every_instance(
+        self, hier_db_factory
+    ) -> None:
+        doc = hybrid_expansion_doc()
+        doc["tree"]["SR"]["CH"]["_separator"] = "%"
+        db = hier_db_factory(doc, "hybrid_separator.json")
+        assert list(db._build_channel_map()) == [
+            "SR:CH-1%Voltage",
+            "SR:CH-1%Current",
+            "SR:CH-2%Voltage",
+            "SR:CH-2%Current",
+            "SR:CH-3%Voltage",
+            "SR:CH-3%Current",
+            "SR:PS:Status",
+        ]
+        assert db.build_channels_from_selections(
+            {"system": "SR", "device": "CH-2", "signal": "Voltage"}
+        ) == ["SR:CH-2%Voltage"]
+
+
+class TestBuildChannelsFromSelections:
+    """The selections API, which has two production callers and so is load-bearing."""
+
+    def test_single_values_and_lists_form_a_cartesian_product(self, tree_only_db) -> None:
+        assert tree_only_db.build_channels_from_selections(
+            {"system": "SR", "device": "BPM", "signal": ["X", "Y"]}
+        ) == ["SR:BPM:X", "SR:BPM:Y"]
+        assert tree_only_db.build_channels_from_selections(
+            {"system": ["SR", "BR"], "device": ["BPM", "QUAD"], "signal": "X"}
+        ) == ["SR:BPM:X", "SR:QUAD:X", "BR:BPM:X", "BR:QUAD:X"]
+
+    def test_a_missing_required_level_raises_and_names_the_level(self, tree_only_db) -> None:
+        with pytest.raises(ValueError, match="Required level 'signal' is missing"):
+            tree_only_db.build_channels_from_selections({"system": "SR", "device": "BPM"})
+
+    def test_an_omitted_optional_level_becomes_an_empty_component(
+        self, optional_tree_level_db
+    ) -> None:
+        assert optional_tree_level_db.build_channels_from_selections(
+            {"system": "SR", "device": "PS", "signal": "Heartbeat"}
+        ) == ["SR:PS:Heartbeat"]
+        assert optional_tree_level_db.build_channels_from_selections(
+            {"system": "SR", "device": "PS", "subdevice": "", "signal": "Heartbeat"}
+        ) == ["SR:PS:Heartbeat"]
+        assert optional_tree_level_db.build_channels_from_selections(
+            {"system": "SR", "device": "PS", "subdevice": "PSU", "signal": "Voltage"}
+        ) == ["SR:PS:PSU:Voltage"]
+
+    def test_an_empty_list_anywhere_collapses_the_whole_product(self, tree_only_db) -> None:
+        """Characterized as-is, not endorsed: an empty selection returns ``[]`` silently.
+
+        A required level given ``[]`` or ``None`` is not the same as omitting it
+        -- omitting raises, supplying an empty container returns no channels and
+        no explanation.
+        """
+        assert (
+            tree_only_db.build_channels_from_selections(
+                {"system": "SR", "device": "BPM", "signal": []}
+            )
+            == []
+        )
+        assert (
+            tree_only_db.build_channels_from_selections(
+                {"system": "SR", "device": "BPM", "signal": None}
+            )
+            == []
+        )
+
+    def test_an_empty_string_for_a_required_level_drops_the_component(self, tree_only_db) -> None:
+        """Characterized as-is, not endorsed: a required level accepts ``""`` and vanishes."""
+        assert tree_only_db.build_channels_from_selections(
+            {"system": "SR", "device": "BPM", "signal": ""}
+        ) == ["SR:BPM"]
+
+    def test_an_empty_list_for_an_optional_level_still_collapses_the_product(
+        self, optional_tree_level_db
+    ) -> None:
+        """Unlike ``""`` and omission, ``[]`` on an optional level yields nothing."""
+        assert (
+            optional_tree_level_db.build_channels_from_selections(
+                {"system": "SR", "device": "PS", "subdevice": [], "signal": "Heartbeat"}
+            )
+            == []
+        )
+
+    def test_levels_absent_from_the_naming_pattern_are_ignored(self, hier_db_factory) -> None:
+        db = hier_db_factory(
+            _document(
+                levels=[
+                    {"name": "system", "type": "tree"},
+                    {"name": "device", "type": "tree"},
+                    {"name": "signal", "type": "tree"},
+                ],
+                naming_pattern="{system}:{signal}",
+                tree={"SR": {"BPM": {"X": {}}}},
+            ),
+            "subset_pattern.json",
+        )
+        # ``device`` is required by the hierarchy but not by the pattern, so
+        # omitting it does not raise.
+        assert db.build_channels_from_selections({"system": "SR", "signal": "X"}) == ["SR:X"]
+
+    def test_unknown_selection_keys_are_ignored(self, tree_only_db) -> None:
+        assert tree_only_db.build_channels_from_selections(
+            {"system": "SR", "device": "BPM", "signal": "X", "not_a_level": "Z"}
+        ) == ["SR:BPM:X"]
+
+    def test_values_absent_from_the_tree_are_rendered_anyway(self, tree_only_db) -> None:
+        """Characterized as-is, not endorsed: selections are never validated.
+
+        The method is a name formatter, not a lookup. It happily returns a
+        channel name that corresponds to nothing in the tree and is not a key of
+        ``channel_map``.
+        """
+        built = tree_only_db.build_channels_from_selections(
+            {"system": "NOPE", "device": "NOPE", "signal": "NOPE"}
+        )
+        assert built == ["NOPE:NOPE:NOPE"]
+        assert built[0] not in tree_only_db.channel_map
+
+    def test_channel_part_trees_require_the_emitted_part_not_the_tree_key(
+        self, channel_part_db
+    ) -> None:
+        """Characterized as-is, not endorsed: navigating by tree key produces a bad name.
+
+        ``_build_channel_map`` maps ``Magnets`` to ``MAG``, but this method does
+        no such translation -- passing the key a caller would have browsed with
+        yields a channel that does not exist.
+        """
+        assert channel_part_db.build_channels_from_selections(
+            {"system": "MAG", "device": "PS", "signal": "Current"}
+        ) == ["MAG:PS:Current"]
+
+        bogus = channel_part_db.build_channels_from_selections(
+            {"system": "Magnets", "device": "Power Supplies", "signal": "Current"}
+        )
+        assert bogus == ["Magnets:Power Supplies:Current"]
+        assert bogus[0] not in channel_part_db.channel_map
+
+    def test_expanded_instances_are_selectable_by_their_generated_names(
+        self, hybrid_expansion_db, range_instances_db
+    ) -> None:
+        assert hybrid_expansion_db.build_channels_from_selections(
+            {"system": "SR", "device": "CH-2", "signal": "Voltage"}
+        ) == ["SR:CH-2:Voltage"]
+        assert range_instances_db.build_channels_from_selections(
+            {"system": "SR", "family": "BPM", "device": "B02", "signal": ["X", "Y"]}
+        ) == ["SR:BPM:B02:X", "SR:BPM:B02:Y"]
+
+    def test_literal_pattern_text_is_applied_to_selections(self, hier_db_factory) -> None:
+        db = hier_db_factory(
+            _document(
+                levels=[
+                    {"name": "sector", "type": "tree"},
+                    {"name": "device", "type": "tree"},
+                ],
+                naming_pattern="S{sector}:F{device}",
+                tree={"01": {"A": {}}, "02": {"B": {}}},
+            ),
+            "literal_selections.json",
+        )
+        assert list(db._build_channel_map()) == ["S01:FA", "S02:FB"]
+        assert db.build_channels_from_selections({"sector": ["01", "02"], "device": "A"}) == [
+            "S01:FA",
+            "S02:FA",
+        ]
+
+    @pytest.mark.parametrize("fixture_name", sorted(EXPECTED_CHANNELS))
+    def test_replaying_each_stored_path_reproduces_its_channel_name(
+        self, request, fixture_name: str
+    ) -> None:
+        """Feeding a channel's own ``path`` back in returns that channel name.
+
+        This is the round-trip that ties the two entry points together. It holds
+        for every channel whose path covers all required pattern levels --
+        including the ones carrying empty strings or omitting *optional* levels
+        -- and never returns a different name. The exceptions are listed in
+        :data:`NON_REPLAYABLE_CHANNELS` and covered by the test below.
+        """
+        db = request.getfixturevalue(fixture_name)
+        truncated = NON_REPLAYABLE_CHANNELS[fixture_name]
+        replayed = {
+            name: db.build_channels_from_selections(info["path"])
+            for name, info in db._build_channel_map().items()
+            if name not in truncated
+        }
+        assert replayed == {name: [name] for name in replayed}
+
+    @pytest.mark.parametrize("fixture_name", sorted(EXPECTED_CHANNELS))
+    def test_paths_that_stop_before_a_required_level_cannot_be_replayed(
+        self, request, fixture_name: str
+    ) -> None:
+        """Characterized as-is, not endorsed: some emitted channels are unreproducible.
+
+        A node that terminates early -- because it has no children, or because
+        ``_is_leaf`` made it a channel mid-hierarchy -- gets a path that omits a
+        *required* level. ``_build_channel_map`` is happy to emit such a channel,
+        but replaying its own path through ``build_channels_from_selections``
+        raises, because that method insists every required pattern level be
+        supplied. The two entry points therefore disagree about which channels
+        exist, and :data:`NON_REPLAYABLE_CHANNELS` is that disagreement in full.
+        """
+        db = request.getfixturevalue(fixture_name)
+        channel_map = db._build_channel_map()
+        expected = NON_REPLAYABLE_CHANNELS[fixture_name]
+
+        raised = set()
+        for name, info in channel_map.items():
+            try:
+                db.build_channels_from_selections(info["path"])
+            except ValueError:
+                raised.add(name)
+
+        assert raised == expected

--- a/tests/services/channel_finder/databases/test_naming_leaf_detection.py
+++ b/tests/services/channel_finder/databases/test_naming_leaf_detection.py
@@ -1,0 +1,165 @@
+"""Unit contracts for the naming mixin's per-node decisions.
+
+``test_naming_characterization`` pins what ``_hierarchical_naming`` *emits*: the
+channel inventory of every fixture shape, the stored paths, and the return value
+of ``build_channels_from_selections``. This module works one level down, on the
+three decisions those inventories are assembled from:
+
+* ``_build_channel_with_separators``' pattern-completeness guard, which raises
+  ``KeyError`` for a placeholder with no value in the path;
+* ``_is_leaf_node``'s explicit ``_is_leaf`` marker and its "all levels consumed"
+  arm, asserted as verdicts rather than through their emitted consequences;
+* ``_get_channel_part``'s three-way lookup.
+
+It closes with the one ``build_channels_from_selections`` behaviour the
+characterization suite does not reach: a list-valued selection collects its
+separator overrides from the first value only and then applies them to all of
+them.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from tests.services.channel_finder.conftest import leaf_with_children_doc
+
+
+class TestPatternCompletenessGuard:
+    """``_build_channel_with_separators`` raises when a placeholder has no value.
+
+    The guard is documented on the method (``Raises: KeyError``) but no *document*
+    can reach it. ``_hierarchical_loading._validate_naming_pattern`` rejects any
+    placeholder that is not a hierarchy level, and after that check both callers
+    supply a value for every remaining placeholder: ``build_channels_from_selections``
+    zips one selection list per pattern level, and ``_build_channel_map`` fills the
+    missing ones with ``""``. What the guard actually catches is a naming pattern
+    that drifts *after* load, away from the levels it was validated against.
+    """
+
+    def test_a_pattern_level_absent_from_the_path_raises_naming_the_level(
+        self, tree_only_db
+    ) -> None:
+        with pytest.raises(KeyError) as excinfo:
+            tree_only_db._build_channel_with_separators({"system": "SR", "device": "BPM"}, {})
+
+        assert excinfo.value.args[0] == "signal"
+
+    def test_an_empty_string_is_a_value_and_does_not_raise(self, tree_only_db) -> None:
+        """The guard tests membership, not truthiness -- that is what lets optional
+        levels reach the method as ``""`` and be dropped from the name instead."""
+        assert (
+            tree_only_db._build_channel_with_separators(
+                {"system": "SR", "device": "BPM", "signal": ""}, {}
+            )
+            == "SR:BPM"
+        )
+
+    def test_pattern_and_levels_agree_on_a_loaded_database(self, tree_only_db) -> None:
+        """Why neither caller can reach the guard: the two sets coincide after load."""
+        placeholders = set(re.findall(r"\{(\w+)\}", tree_only_db.naming_pattern))
+        assert placeholders == set(tree_only_db._get_pattern_levels())
+
+    def test_a_pattern_drifting_past_load_raises_from_the_selections_api(
+        self, tree_only_db
+    ) -> None:
+        """A placeholder added after validation is dropped by ``_get_pattern_levels``
+        -- so no selection list is built for it and the path reaches the guard short."""
+        tree_only_db.naming_pattern = "{system}:{device}:{signal}:{revision}"
+
+        with pytest.raises(KeyError) as excinfo:
+            tree_only_db.build_channels_from_selections(
+                {"system": "SR", "device": "BPM", "signal": "X"}
+            )
+
+        assert excinfo.value.args[0] == "revision"
+
+    def test_the_same_drift_raises_from_the_tree_expansion(self, tree_only_db) -> None:
+        """``_build_channel_map`` fills only pattern levels, so it too falls short."""
+        tree_only_db.naming_pattern = "{system}:{device}:{signal}:{revision}"
+
+        with pytest.raises(KeyError) as excinfo:
+            tree_only_db._build_channel_map()
+
+        assert excinfo.value.args[0] == "revision"
+
+
+class TestExplicitLeafMarker:
+    """``_is_leaf: true`` and the "all levels consumed" arm, as leaf verdicts.
+
+    The characterization suite asserts what a marked node *emits*; these assert
+    that the marker is what decides it. ``SIGNAL-Y`` sits at a required, non-final
+    level and has dict children, so every other arm of ``_is_leaf_node`` answers
+    "not a leaf" -- removing the marker flips both the verdict and the inventory.
+    """
+
+    def test_the_marker_makes_a_node_with_children_a_leaf_mid_hierarchy(
+        self, leaf_with_children_db
+    ) -> None:
+        node = leaf_with_children_db.tree["SR"]["PS"]["SIGNAL-Y"]
+        assert leaf_with_children_db._is_leaf_node(node, 2) is True
+
+    def test_without_the_marker_the_node_is_not_a_leaf_and_loses_its_own_channel(
+        self, hier_db_factory
+    ) -> None:
+        doc = leaf_with_children_doc()
+        del doc["tree"]["SR"]["PS"]["SIGNAL-Y"]["_is_leaf"]
+        db = hier_db_factory(doc, "leaf_marker_removed.json")
+
+        assert db._is_leaf_node(db.tree["SR"]["PS"]["SIGNAL-Y"], 2) is False
+        # The suffix variants survive; only the bare ``SR:PS:SIGNAL-Y`` is gone.
+        assert list(db.channel_map) == ["SR:PS:SIGNAL-Y:RB", "SR:PS:SIGNAL-Y:SP"]
+
+    def test_a_false_marker_leaves_the_childless_rule_in_charge(
+        self, leaf_with_children_db
+    ) -> None:
+        """The marker can only force ``True``; ``_is_leaf: false`` is not a veto."""
+        childless = {"_is_leaf": False, "_description": "Marked not-a-leaf, but has no children"}
+        assert leaf_with_children_db._is_leaf_node(childless, 0) is True
+
+    def test_a_consumed_hierarchy_makes_even_a_parent_node_a_leaf(self, tree_only_db) -> None:
+        """``BPM`` has dict children either way; only the level index differs."""
+        node = tree_only_db.tree["SR"]["BPM"]
+        assert tree_only_db._is_leaf_node(node, len(tree_only_db.hierarchy_levels)) is True
+        assert tree_only_db._is_leaf_node(node, 1) is False
+
+
+class TestChannelPartLookup:
+    """``_get_channel_part``'s three-way lookup, read off the node directly."""
+
+    def test_an_explicit_part_replaces_the_tree_key(self, channel_part_db) -> None:
+        assert channel_part_db._get_channel_part({"_channel_part": "MAG"}, "Magnets") == "MAG"
+
+    def test_an_empty_part_is_honoured_rather_than_falling_back(self, channel_part_db) -> None:
+        """The key is read by presence, not truthiness -- an empty override means
+        "contribute nothing to the name", which is not the same as "not set"."""
+        assert channel_part_db._get_channel_part({"_channel_part": ""}, "Building-1") == ""
+
+    def test_a_node_without_the_key_uses_the_tree_key(self, channel_part_db) -> None:
+        assert channel_part_db._get_channel_part({"_description": "Rack"}, "RACK") == "RACK"
+
+
+class TestSelectionsWithListValues:
+    """One ``build_channels_from_selections`` behaviour the inventories cannot show."""
+
+    def test_a_separator_override_from_the_first_value_is_applied_to_all_of_them(
+        self, separator_override_db
+    ) -> None:
+        """Characterized as-is, not endorsed: overrides leak across a list selection.
+
+        ``_collect_separator_overrides`` navigates with a single value per level, so
+        a list-valued ``device`` is resolved to its first entry -- ``BPM``, which
+        carries ``"_separator": "_"``. The whole Cartesian product is then rendered
+        with that separator, including ``QUAD``, which carries none. The same
+        selection made on its own gets the pattern's ``:``, and the tree expansion
+        agrees with the single-value answer.
+        """
+        assert separator_override_db.build_channels_from_selections(
+            {"system": "SR", "device": ["BPM", "QUAD"], "signal": "X", "suffix": "RB"}
+        ) == ["SR-BPM_X:RB", "SR-QUAD_X:RB"]
+
+        # QUAD alone keeps the pattern separator between ``device`` and ``signal``.
+        assert separator_override_db.build_channels_from_selections(
+            {"system": "SR", "device": "QUAD", "signal": "Setpoint", "suffix": "RB"}
+        ) == ["SR-QUAD:Setpoint:RB"]
+        assert "SR-QUAD:Setpoint:RB" in separator_override_db.channel_map

--- a/tests/services/channel_finder/databases/test_naming_separator_overrides.py
+++ b/tests/services/channel_finder/databases/test_naming_separator_overrides.py
@@ -1,0 +1,443 @@
+"""The tree walk behind ``_collect_separator_overrides``.
+
+``build_channels_from_selections`` formats a name from selections alone -- it
+never looks a selection up in the tree. The one thing it *does* read from the
+tree is the ``_separator`` metadata, collected by walking down the selections in
+``_hierarchical_naming._collect_separator_overrides``. That walk has its own
+navigation rules, separate from the recursion in ``_build_channel_map``, and
+they decide how far down the tree the collection gets before it gives up.
+
+``test_naming_characterization`` pins the outcome of that walk for selections
+that match the tree cleanly. This module pins the rest of it: which selections
+make the walk skip a level, which make it stop early, and what the two
+instance-container fallbacks accept -- a selection that no ``_expansion``
+generates still resolves through a container whose *key* matches the level name
+case-insensitively, while a branch with no container at all ends the walk and
+silently drops every override below it.
+
+Every assertion is on an emitted channel name or on the returned override
+mapping. ``_collect_separator_overrides`` is called directly because its return
+value is the thing under test, and most cases pair it with the
+``build_channels_from_selections`` name that consumes that mapping -- so the
+walk is pinned through the public API as well as through its own return value.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from tests.services.channel_finder.conftest import _document, range_instances_doc
+
+if TYPE_CHECKING:
+    from osprey.services.channel_finder.databases.hierarchical import (
+        HierarchicalChannelDatabase,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Documents for shapes the shared fixture family does not cover: an instance
+# level whose container is present in one branch and absent in the sibling, a
+# container whose key is not upper-case, and an optional tree level with a
+# ``_separator`` sitting *below* it.
+# ---------------------------------------------------------------------------
+
+
+def _paired_container_doc() -> dict[str, Any]:
+    """One branch with a ``DEVICE`` container, one without, both carrying ``X``.
+
+    ``system(tree) -> device(instances, optional) -> signal(tree) ->
+    suffix(tree)``. ``X`` sets ``"_separator": "_"`` in *both* branches, so the
+    only difference between them is whether the walk survives the ``device``
+    level long enough to reach it.
+    """
+    return _document(
+        levels=[
+            {"name": "system", "type": "tree"},
+            {"name": "device", "type": "instances", "optional": True},
+            {"name": "signal", "type": "tree"},
+            {"name": "suffix", "type": "tree"},
+        ],
+        naming_pattern="{system}:{device}:{signal}:{suffix}",
+        tree={
+            "SR": {
+                "DEVICE": {
+                    "_expansion": {"_type": "range", "_pattern": "D{}", "_range": [1, 2]},
+                    "X": {"_separator": "_", "RB": {}},
+                }
+            },
+            "BR": {"X": {"_separator": "_", "RB": {}}},
+        },
+    )
+
+
+def _mixed_case_container_doc() -> dict[str, Any]:
+    """An instance container keyed ``Device`` rather than ``DEVICE``."""
+    return _document(
+        levels=[
+            {"name": "system", "type": "tree"},
+            {"name": "device", "type": "instances"},
+            {"name": "signal", "type": "tree"},
+        ],
+        naming_pattern="{system}:{device}:{signal}",
+        tree={
+            "SR": {
+                "Device": {
+                    "_separator": "@",
+                    "_expansion": {"_type": "range", "_pattern": "D{}", "_range": [1, 2]},
+                    "X": {},
+                }
+            }
+        },
+    )
+
+
+def _optional_skip_doc() -> dict[str, Any]:
+    """An optional tree level with an override on the node *after* it.
+
+    ``system(tree) -> subdevice(tree, optional) -> signal(tree) ->
+    suffix(tree)``. ``Heartbeat`` sits at ``signal`` and carries the override,
+    so it is only reached when the walk skips the omitted ``subdevice`` level
+    instead of stopping at it. ``PSU`` is the sibling that does occupy the
+    optional level and sets nothing.
+    """
+    return _document(
+        levels=[
+            {"name": "system", "type": "tree"},
+            {"name": "subdevice", "type": "tree", "optional": True},
+            {"name": "signal", "type": "tree"},
+            {"name": "suffix", "type": "tree"},
+        ],
+        naming_pattern="{system}:{subdevice}:{signal}:{suffix}",
+        tree={
+            "SR": {
+                "Heartbeat": {"_separator": "_", "RB": {}},
+                "PSU": {"Voltage": {"RB": {}}},
+            }
+        },
+    )
+
+
+def _crossing_instances_doc() -> dict[str, Any]:
+    """An override on a node whose next level is ``instances``, not ``tree``."""
+    return _document(
+        levels=[
+            {"name": "system", "type": "tree"},
+            {"name": "device", "type": "instances"},
+            {"name": "signal", "type": "tree"},
+        ],
+        naming_pattern="{system}:{device}:{signal}",
+        tree={
+            "SR": {
+                "_separator": "~",
+                "DEVICE": {
+                    "_expansion": {"_type": "range", "_pattern": "D{}", "_range": [1, 2]},
+                    "X": {},
+                },
+            }
+        },
+    )
+
+
+@pytest.fixture
+def paired_container_db(
+    hier_db_factory: Callable[..., HierarchicalChannelDatabase],
+) -> HierarchicalChannelDatabase:
+    return hier_db_factory(_paired_container_doc(), "paired_container.json")
+
+
+@pytest.fixture
+def mixed_case_container_db(
+    hier_db_factory: Callable[..., HierarchicalChannelDatabase],
+) -> HierarchicalChannelDatabase:
+    return hier_db_factory(_mixed_case_container_doc(), "mixed_case_container.json")
+
+
+@pytest.fixture
+def optional_skip_db(
+    hier_db_factory: Callable[..., HierarchicalChannelDatabase],
+) -> HierarchicalChannelDatabase:
+    return hier_db_factory(_optional_skip_doc(), "optional_skip.json")
+
+
+@pytest.fixture
+def crossing_instances_db(
+    hier_db_factory: Callable[..., HierarchicalChannelDatabase],
+) -> HierarchicalChannelDatabase:
+    return hier_db_factory(_crossing_instances_doc(), "crossing_instances.json")
+
+
+@pytest.fixture
+def instance_separator_db(
+    hier_db_factory: Callable[..., HierarchicalChannelDatabase],
+) -> HierarchicalChannelDatabase:
+    """``range_instances`` with an override on the ``BPM`` container only.
+
+    ``QUAD`` has a container of its own and no override, which is what tells a
+    collected separator apart from a leaked one.
+    """
+    doc = range_instances_doc()
+    doc["tree"]["SR"]["BPM"]["DEVICE"]["_separator"] = "#"
+    return hier_db_factory(doc, "instance_separator.json")
+
+
+class TestInstanceContainerFallback:
+    """Resolving an ``instances`` selection when no ``_expansion`` generates it."""
+
+    def test_a_selection_no_expansion_generates_still_finds_the_container(
+        self, instance_separator_db
+    ) -> None:
+        """The container key is matched directly once the expansion search fails.
+
+        ``B01`` is generated by ``DEVICE``'s range and resolves through the
+        expansion search; ``BOGUS`` is generated by nothing, and resolves
+        through the container key instead. Both reach the same node, so both
+        pick up its ``#``.
+        """
+        assert instance_separator_db._collect_separator_overrides(
+            {"system": "SR", "family": "BPM", "device": "B01", "signal": "X"}
+        ) == {("device", "signal"): "#"}
+        assert instance_separator_db._collect_separator_overrides(
+            {"system": "SR", "family": "BPM", "device": "BOGUS", "signal": "X"}
+        ) == {("device", "signal"): "#"}
+
+        assert instance_separator_db.build_channels_from_selections(
+            {"system": "SR", "family": "BPM", "device": "BOGUS", "signal": "X"}
+        ) == ["SR:BPM:BOGUS#X"]
+
+    def test_the_container_key_is_matched_case_insensitively(self, mixed_case_container_db) -> None:
+        """``Device`` matches the ``device`` level; the comparison upper-cases both."""
+        assert mixed_case_container_db._collect_separator_overrides(
+            {"system": "SR", "device": "NOPE", "signal": "X"}
+        ) == {("device", "signal"): "@"}
+        assert mixed_case_container_db.build_channels_from_selections(
+            {"system": "SR", "device": "NOPE", "signal": "X"}
+        ) == ["SR:NOPE@X"]
+
+    def test_a_container_that_sets_no_override_contributes_nothing(
+        self, instance_separator_db
+    ) -> None:
+        """``QUAD``'s container is found by the same fallback and yields ``{}``.
+
+        Reaching a node is not the same as collecting from it: the fallback
+        resolves ``BOGUS`` under ``QUAD`` too, and ``QUAD`` simply has no
+        ``_separator`` for it to pick up.
+        """
+        assert (
+            instance_separator_db._collect_separator_overrides(
+                {"system": "SR", "family": "QUAD", "device": "BOGUS", "signal": "Setpoint"}
+            )
+            == {}
+        )
+        assert instance_separator_db.build_channels_from_selections(
+            {"system": "SR", "family": "QUAD", "device": "BOGUS", "signal": "Setpoint"}
+        ) == ["SR:QUAD:BOGUS:Setpoint"]
+
+
+class TestNavigationStopsAtAMissingContainer:
+    """A branch with no container for the ``instances`` level ends the walk."""
+
+    def test_a_branch_without_a_container_loses_every_override_below_it(
+        self, paired_container_db
+    ) -> None:
+        """The same ``X`` node, reached in one branch and not in the other.
+
+        ``SR`` has a ``DEVICE`` container, so the walk passes through it and
+        reaches ``X``'s ``_``. ``BR`` has none -- neither an expansion that
+        generates ``D1`` nor a child keyed ``DEVICE`` -- so the walk stops at
+        the ``device`` level and ``X`` is never visited, even though ``BR``'s
+        own ``X`` carries an identical override.
+        """
+        assert paired_container_db._collect_separator_overrides(
+            {"system": "SR", "device": "D1", "signal": "X", "suffix": "RB"}
+        ) == {("signal", "suffix"): "_"}
+        assert paired_container_db.build_channels_from_selections(
+            {"system": "SR", "device": "D1", "signal": "X", "suffix": "RB"}
+        ) == ["SR:D1:X_RB"]
+
+        assert (
+            paired_container_db._collect_separator_overrides(
+                {"system": "BR", "device": "D1", "signal": "X", "suffix": "RB"}
+            )
+            == {}
+        )
+        assert paired_container_db.build_channels_from_selections(
+            {"system": "BR", "device": "D1", "signal": "X", "suffix": "RB"}
+        ) == ["BR:D1:X:RB"]
+
+    def test_overrides_collected_before_the_stop_are_kept(self, hier_db_factory) -> None:
+        """Stopping discards what is below, not what is already collected."""
+        doc = _paired_container_doc()
+        doc["tree"]["BR"]["_separator"] = "-"
+        db = hier_db_factory(doc, "paired_container_root_sep.json")
+        assert db._collect_separator_overrides(
+            {"system": "BR", "device": "D1", "signal": "X", "suffix": "RB"}
+        ) == {("system", "signal"): "-"}
+
+    def test_omitting_the_optional_instance_level_walks_past_the_gap(
+        self, paired_container_db
+    ) -> None:
+        """The same ``BR`` branch reaches ``X`` once ``device`` is left out.
+
+        ``device`` is optional, so omitting it skips the level rather than
+        stopping at it -- which is what makes the stop above attributable to the
+        missing container and not to the branch shape.
+        """
+        assert paired_container_db._collect_separator_overrides(
+            {"system": "BR", "signal": "X", "suffix": "RB"}
+        ) == {("signal", "suffix"): "_"}
+        assert paired_container_db.build_channels_from_selections(
+            {"system": "BR", "signal": "X", "suffix": "RB"}
+        ) == ["BR:X_RB"]
+
+
+class TestSkippedOptionalLevels:
+    """An optional level with no usable selection is skipped, and the walk goes on."""
+
+    def test_an_omitted_optional_level_is_skipped(self, optional_skip_db) -> None:
+        assert optional_skip_db._collect_separator_overrides(
+            {"system": "SR", "signal": "Heartbeat", "suffix": "RB"}
+        ) == {("signal", "suffix"): "_"}
+        assert optional_skip_db.build_channels_from_selections(
+            {"system": "SR", "signal": "Heartbeat", "suffix": "RB"}
+        ) == ["SR:Heartbeat_RB"]
+
+    def test_an_empty_optional_selection_is_skipped_the_same_way(self, optional_skip_db) -> None:
+        """``""`` and ``[]`` both reduce to "no selection here" for the walk.
+
+        The two diverge afterwards, in the Cartesian product rather than in the
+        walk: an empty string leaves an empty component, while an empty list
+        collapses the product to no channels at all -- with the override
+        collected either way.
+        """
+        for empty in ("", []):
+            assert optional_skip_db._collect_separator_overrides(
+                {"system": "SR", "subdevice": empty, "signal": "Heartbeat", "suffix": "RB"}
+            ) == {("signal", "suffix"): "_"}
+
+        assert optional_skip_db.build_channels_from_selections(
+            {"system": "SR", "subdevice": "", "signal": "Heartbeat", "suffix": "RB"}
+        ) == ["SR:Heartbeat_RB"]
+        assert (
+            optional_skip_db.build_channels_from_selections(
+                {"system": "SR", "subdevice": [], "signal": "Heartbeat", "suffix": "RB"}
+            )
+            == []
+        )
+
+    def test_occupying_the_optional_level_reaches_a_different_subtree(
+        self, optional_skip_db
+    ) -> None:
+        """``PSU`` sets no override, so the sibling's ``_`` does not follow it."""
+        assert (
+            optional_skip_db._collect_separator_overrides(
+                {"system": "SR", "subdevice": "PSU", "signal": "Voltage", "suffix": "RB"}
+            )
+            == {}
+        )
+        assert optional_skip_db.build_channels_from_selections(
+            {"system": "SR", "subdevice": "PSU", "signal": "Voltage", "suffix": "RB"}
+        ) == ["SR:PSU:Voltage:RB"]
+
+
+class TestStoppedWalks:
+    """A required level the walk cannot resolve ends it, keeping what came before."""
+
+    def test_a_missing_required_level_stops_the_walk(self, separator_override_db) -> None:
+        """``SR``'s override survives; ``BPM``'s, one level further down, does not.
+
+        ``build_channels_from_selections`` refuses a document-level selection
+        this incomplete, so the collection is observed directly -- the walk is
+        reachable in this state through any caller that collects overrides
+        before validating the selections.
+        """
+        assert separator_override_db._collect_separator_overrides({"system": "SR"}) == {
+            ("system", "device"): "-"
+        }
+        assert separator_override_db._collect_separator_overrides(
+            {"system": "SR", "device": "BPM"}
+        ) == {("system", "device"): "-", ("device", "signal"): "_"}
+
+    def test_an_empty_required_selection_stops_the_walk(self, separator_override_db) -> None:
+        for empty in ("", []):
+            assert separator_override_db._collect_separator_overrides(
+                {"system": "SR", "device": empty, "signal": "X", "suffix": "RB"}
+            ) == {("system", "device"): "-"}
+
+        # ``device`` contributes no component, so the surviving (system, device)
+        # override never applies and the pattern's own separators are used.
+        assert separator_override_db.build_channels_from_selections(
+            {"system": "SR", "device": "", "signal": "X", "suffix": "RB"}
+        ) == ["SR:X:RB"]
+
+    def test_a_tree_selection_absent_from_the_node_stops_the_walk(
+        self, separator_override_db
+    ) -> None:
+        """An unknown value is not an error -- it is the end of the walk.
+
+        The name is still built, so the override collected above the unknown
+        level is applied to it: ``SR-NOPE`` keeps ``SR``'s dash while ``BPM``'s
+        underscore, which the walk never reached, is absent.
+        """
+        assert separator_override_db._collect_separator_overrides(
+            {"system": "SR", "device": "NOPE", "signal": "X", "suffix": "RB"}
+        ) == {("system", "device"): "-"}
+        assert separator_override_db.build_channels_from_selections(
+            {"system": "SR", "device": "NOPE", "signal": "X", "suffix": "RB"}
+        ) == ["SR-NOPE:X:RB"]
+
+    def test_an_unknown_first_level_collects_nothing_at_all(self, separator_override_db) -> None:
+        assert (
+            separator_override_db._collect_separator_overrides(
+                {"system": "NOPE", "device": "BPM", "signal": "X", "suffix": "RB"}
+            )
+            == {}
+        )
+        assert separator_override_db.build_channels_from_selections(
+            {"system": "NOPE", "device": "BPM", "signal": "X", "suffix": "RB"}
+        ) == ["NOPE:BPM:X:RB"]
+
+
+class TestWhereAnOverrideBinds:
+    """Which level pair an override lands on, and which selection it is read from."""
+
+    def test_an_override_binds_past_an_intervening_instances_level(
+        self, crossing_instances_db
+    ) -> None:
+        """The next *tree* level is the target, so ``device`` is stepped over.
+
+        Characterized as-is, not endorsed: the resulting ``(system, signal)``
+        pair can only apply when ``device`` contributes no component, so for
+        every channel this document actually emits the override is inert -- the
+        expansion agrees, emitting ``SR:D1:X`` with the pattern's colon.
+        """
+        assert crossing_instances_db._collect_separator_overrides(
+            {"system": "SR", "device": "D1", "signal": "X"}
+        ) == {("system", "signal"): "~"}
+        assert crossing_instances_db.build_channels_from_selections(
+            {"system": "SR", "device": "D1", "signal": "X"}
+        ) == ["SR:D1:X"]
+        assert list(crossing_instances_db._build_channel_map()) == ["SR:D1:X", "SR:D2:X"]
+
+    def test_a_multi_value_selection_is_walked_by_its_first_value_only(
+        self, separator_override_db
+    ) -> None:
+        """Characterized as-is, not endorsed: one branch decides the whole product.
+
+        The walk reduces ``["BPM", "QUAD"]`` to ``"BPM"`` and collects ``BPM``'s
+        underscore, then the product applies it to every combination -- so the
+        ``QUAD`` channel is emitted with a separator ``QUAD`` does not set, and
+        does not match the name the expansion gives it.
+        """
+        built = separator_override_db.build_channels_from_selections(
+            {"system": "SR", "device": ["BPM", "QUAD"], "signal": "X", "suffix": "RB"}
+        )
+        assert built == ["SR-BPM_X:RB", "SR-QUAD_X:RB"]
+        assert built[1] not in separator_override_db.channel_map
+
+        # Reversing the order moves the underscore, and the same two selections
+        # then render with the pattern's colon instead.
+        assert separator_override_db.build_channels_from_selections(
+            {"system": "SR", "device": ["QUAD", "BPM"], "signal": "X", "suffix": "RB"}
+        ) == ["SR-QUAD:X:RB", "SR-BPM:X:RB"]

--- a/tests/services/channel_finder/databases/test_query_expansion.py
+++ b/tests/services/channel_finder/databases/test_query_expansion.py
@@ -1,0 +1,252 @@
+"""Expansion-side behaviour of ``_hierarchical_query``.
+
+Covers the level-name accessor and the instance-expansion half of the query
+mixin: how an ``instances`` level turns into a list of options, what each
+expansion ``_type`` contributes to the option descriptions, and what happens at
+a branch where the level's container is absent or carries no ``_expansion``.
+
+Tree navigation itself (``_navigate_to_node`` / ``_extract_tree_options``) is
+characterised elsewhere; here ``get_options_at_level`` is only the public seam
+that reaches ``_get_expansion_options`` and ``_expand_instances``.
+
+Loaded databases and the ``hier_db_factory`` come from the package ``conftest``
+as fixtures. The two documents built locally exist for shapes no shared fixture
+provides -- a *required* instance level whose container is missing (or
+expansion-less) in a sibling branch that validation never walks.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tests.services.channel_finder.conftest import _document
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from osprey.services.channel_finder.databases.hierarchical import (
+        HierarchicalChannelDatabase,
+    )
+
+
+def _sibling_branch_missing_container_doc() -> dict:
+    """A *required* instance level whose container exists in only one branch.
+
+    ``_validate_instance_level`` refuses to load a document whose required
+    instance level has no container -- but ``_find_level_container`` walks only
+    the *first* tree child it finds. Listing ``SR`` (which owns ``DEVICE``)
+    before ``BR`` (which does not) therefore loads cleanly, while navigating to
+    ``BR`` reaches the "no key matches the level name" fall-through in
+    ``_get_expansion_options`` without the level being optional.
+
+    ``BR`` contributes no channels: the instances arm of ``_build_channel_map``
+    finds no expansion definition there either.
+
+    Channels: ``SR:D1:X``, ``SR:D2:X``.
+    """
+    return _document(
+        levels=[
+            {"name": "system", "type": "tree"},
+            {"name": "device", "type": "instances"},
+            {"name": "signal", "type": "tree"},
+        ],
+        naming_pattern="{system}:{device}:{signal}",
+        tree={
+            "SR": {
+                "_description": "Storage Ring",
+                "DEVICE": {
+                    "_expansion": {"_type": "range", "_pattern": "D{}", "_range": [1, 2]},
+                    "X": {"_description": "Horizontal position"},
+                },
+            },
+            "BR": {"_description": "Booster - no DEVICE container", "Status": {}},
+        },
+    )
+
+
+def _sibling_branch_container_without_expansion_doc() -> dict:
+    """A sibling branch whose container matches the level name but has no expansion.
+
+    Same first-branch-only validation loophole as
+    :func:`_sibling_branch_missing_container_doc`, one step further along: ``BR``
+    *does* own a ``DEVICE`` key, so ``_get_expansion_options`` matches it on
+    name and then fails the ``"_expansion" in value`` guard -- the loop keeps
+    scanning and still falls through to the empty result. A document where the
+    *first* branch looked like this would be rejected outright with
+    "container missing '_expansion' definition".
+
+    Channels: ``SR:D1:X``, ``SR:D2:X``.
+    """
+    doc = _sibling_branch_missing_container_doc()
+    doc["tree"]["BR"] = {
+        "_description": "Booster - DEVICE container, no expansion",
+        "DEVICE": {"X": {"_description": "Horizontal position"}},
+    }
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# get_hierarchy_definition
+# ---------------------------------------------------------------------------
+
+
+def test_get_hierarchy_definition_returns_level_names_in_order(
+    tree_only_db: HierarchicalChannelDatabase,
+) -> None:
+    """The accessor reports the declared level names, in declaration order."""
+    assert tree_only_db.get_hierarchy_definition() == ["system", "device", "signal"]
+
+
+def test_get_hierarchy_definition_includes_instance_levels(
+    range_instances_db: HierarchicalChannelDatabase,
+) -> None:
+    """Instance-typed levels are reported alongside tree levels, undistinguished."""
+    assert range_instances_db.get_hierarchy_definition() == [
+        "system",
+        "family",
+        "device",
+        "signal",
+    ]
+
+
+def test_get_hierarchy_definition_returns_a_defensive_copy(
+    tree_only_db: HierarchicalChannelDatabase,
+) -> None:
+    """Callers get a fresh list; mutating it leaves the database untouched."""
+    first = tree_only_db.get_hierarchy_definition()
+    assert first is not tree_only_db.hierarchy_levels
+
+    first.append("intruder")
+
+    assert tree_only_db.hierarchy_levels == ["system", "device", "signal"]
+    assert tree_only_db.get_hierarchy_definition() == ["system", "device", "signal"]
+
+
+# ---------------------------------------------------------------------------
+# _expand_instances: the two expansion types
+# ---------------------------------------------------------------------------
+
+
+def test_list_expansion_returns_instances_in_declaration_order(
+    list_instances_db: HierarchicalChannelDatabase,
+) -> None:
+    """``_type: "list"`` yields ``_instances`` verbatim, order preserved.
+
+    Descriptions are empty: unlike the range arm, the list arm has no index to
+    describe an instance by.
+    """
+    options = list_instances_db.get_options_at_level("unit", {"system": "RF"})
+
+    assert options == [
+        {"name": "MAIN", "description": ""},
+        {"name": "BACKUP", "description": ""},
+        {"name": "TEST", "description": ""},
+    ]
+
+
+def test_list_expansion_options_match_the_expanded_channel_names(
+    list_instances_db: HierarchicalChannelDatabase,
+) -> None:
+    """Every offered list instance really does appear in the flat channel map."""
+    options = list_instances_db.get_options_at_level("unit", {"system": "RF"})
+
+    for option in options:
+        assert f"RF:{option['name']}:Power" in list_instances_db.channel_map
+
+
+def test_range_expansion_numbers_its_descriptions(
+    range_instances_db: HierarchicalChannelDatabase,
+) -> None:
+    """``_type: "range"`` formats ``_pattern`` per index and describes each by index."""
+    options = range_instances_db.get_options_at_level("device", {"system": "SR", "family": "BPM"})
+
+    assert options == [
+        {"name": "B01", "description": "Instance 1"},
+        {"name": "B02", "description": "Instance 2"},
+        {"name": "B03", "description": "Instance 3"},
+    ]
+
+
+def test_range_expansion_is_read_per_container_not_per_level(
+    range_instances_db: HierarchicalChannelDatabase,
+) -> None:
+    """A second branch at the same level expands under its own pattern and range."""
+    options = range_instances_db.get_options_at_level("device", {"system": "SR", "family": "QUAD"})
+
+    assert [option["name"] for option in options] == ["Q1", "Q2"]
+
+
+# ---------------------------------------------------------------------------
+# _get_expansion_options: branches with no usable container
+# ---------------------------------------------------------------------------
+
+
+def test_optional_instance_level_without_container_yields_no_options(
+    optional_instance_level_db: HierarchicalChannelDatabase,
+) -> None:
+    """An optional instance level offers nothing in a branch that omits its container."""
+    assert optional_instance_level_db.get_options_at_level("device", {"system": "BR"}) == []
+
+
+def test_optional_instance_level_still_expands_where_the_container_exists(
+    optional_instance_level_db: HierarchicalChannelDatabase,
+) -> None:
+    """The empty result is branch-local: the sibling branch expands normally."""
+    options = optional_instance_level_db.get_options_at_level("device", {"system": "SR"})
+
+    assert options == [
+        {"name": "D1", "description": "Instance 1"},
+        {"name": "D2", "description": "Instance 2"},
+    ]
+
+
+def test_required_instance_level_yields_no_options_in_an_unvalidated_branch(
+    hier_db_factory: Callable[..., HierarchicalChannelDatabase],
+) -> None:
+    """A required level offers nothing where the container is missing.
+
+    Validation only walks the first tree branch, so this shape loads even though
+    ``BR`` has no ``DEVICE`` container -- the level being required is no
+    guarantee that every branch can expand it.
+    """
+    db = hier_db_factory(_sibling_branch_missing_container_doc(), "sibling_missing.json")
+
+    assert db.get_options_at_level("device", {"system": "BR"}) == []
+    assert [option["name"] for option in db.get_options_at_level("device", {"system": "SR"})] == [
+        "D1",
+        "D2",
+    ]
+
+
+def test_instance_container_without_expansion_yields_no_options(
+    hier_db_factory: Callable[..., HierarchicalChannelDatabase],
+) -> None:
+    """A name-matched container with no ``_expansion`` is skipped, not raised on."""
+    db = hier_db_factory(
+        _sibling_branch_container_without_expansion_doc(), "sibling_no_expansion.json"
+    )
+
+    assert db.get_options_at_level("device", {"system": "BR"}) == []
+
+
+def test_branches_without_expansion_contribute_no_channels(
+    hier_db_factory: Callable[..., HierarchicalChannelDatabase],
+) -> None:
+    """The empty option list is consistent with the map: such branches yield nothing."""
+    db = hier_db_factory(_sibling_branch_missing_container_doc(), "sibling_missing_map.json")
+
+    assert sorted(db.channel_map) == ["SR:D1:X", "SR:D2:X"]
+
+
+def test_local_documents_are_rebuilt_per_call() -> None:
+    """Mutating a built document does not leak into the next build.
+
+    :func:`_sibling_branch_container_without_expansion_doc` derives itself by
+    overwriting part of its sibling's result, so freshness is load-bearing here
+    rather than incidental.
+    """
+    mutated = _sibling_branch_missing_container_doc()
+    mutated["tree"]["BR"]["Status"] = {"_description": "touched"}
+
+    assert _sibling_branch_missing_container_doc()["tree"]["BR"]["Status"] == {}
+    assert "DEVICE" not in _sibling_branch_missing_container_doc()["tree"]["BR"]

--- a/tests/services/channel_finder/databases/test_query_navigation.py
+++ b/tests/services/channel_finder/databases/test_query_navigation.py
@@ -1,0 +1,289 @@
+"""Tree navigation behaviour of the hierarchical query mixin.
+
+Drives a real :class:`HierarchicalChannelDatabase` -- never a mock -- through
+``get_options_at_level`` and the ``_navigate_to_node`` /
+``_extract_tree_options`` helpers it delegates to, all in
+``osprey.services.channel_finder.databases._hierarchical_query``.
+
+Four navigation behaviours are characterised here:
+
+* a selection that names nothing in the tree aborts navigation, and the public
+  entry point turns that into an empty option list rather than an error;
+* an ``instances`` level does not consume a selection -- navigation descends
+  into the container whose key matches the *level name*, compared
+  case-insensitively -- and simply stays put when no such container exists;
+* a tree selection that is an *expanded* instance (``CH-1`` against a tree
+  holding ``CH`` with an ``_expansion``) resolves to the container that
+  generates it;
+* a tree child carrying an ``_expansion`` is expanded inline, so the option
+  list offers the generated instances instead of the container name.
+
+Every database is built from JSON under ``tmp_path`` via the shared fixtures in
+``tests/services/channel_finder/conftest.py``; the one shape not in that family
+is built locally below. Nothing here touches the network, a container, or the
+repository tree.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from osprey.services.channel_finder.databases.hierarchical import (
+        HierarchicalChannelDatabase,
+    )
+
+
+def _names(options: list[dict[str, str]]) -> list[str]:
+    """Return just the ``name`` field of each option, in order."""
+    return [option["name"] for option in options]
+
+
+def _mixed_case_container_doc() -> dict:
+    """An ``instances`` level whose container is spelled ``Device``, not ``DEVICE``.
+
+    The conftest family always spells instance containers in upper case, which
+    leaves the ``key.upper() == prev_level.upper()`` comparison in
+    ``_navigate_to_node`` indistinguishable from a plain ``key == level.upper()``
+    check. This shape separates the two: the level is named ``device`` and the
+    container ``Device``, so navigation only reaches ``X`` if both sides are
+    folded. ``_hierarchical_loading._find_level_container`` folds the same way,
+    so the document loads.
+    """
+    return {
+        "hierarchy": {
+            "levels": [
+                {"name": "system", "type": "tree"},
+                {"name": "device", "type": "instances"},
+                {"name": "signal", "type": "tree"},
+            ],
+            "naming_pattern": "{system}:{device}:{signal}",
+        },
+        "tree": {
+            "SR": {
+                "_description": "Storage Ring",
+                "Device": {
+                    "_expansion": {"_type": "range", "_pattern": "D{}", "_range": [1, 2]},
+                    "X": {"_description": "Horizontal position"},
+                },
+            },
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tree descent by selection
+# ---------------------------------------------------------------------------
+
+
+class TestTreeDescent:
+    """``_navigate_to_node`` following ordinary ``tree``-level selections."""
+
+    def test_first_level_needs_no_selections(self, tree_only_db: HierarchicalChannelDatabase):
+        """At the first level the loop breaks immediately and the root is used."""
+        options = tree_only_db.get_options_at_level("system", {})
+
+        assert _names(options) == ["SR", "BR"]
+        assert options[0]["description"] == "Storage Ring"
+
+    def test_selection_descends_one_level(self, tree_only_db: HierarchicalChannelDatabase):
+        """A matching selection moves the cursor into that child node."""
+        options = tree_only_db.get_options_at_level("device", {"system": "SR"})
+
+        assert _names(options) == ["BPM", "QUAD"]
+        assert options[0]["description"] == "Beam Position Monitor"
+
+    def test_missing_description_becomes_empty_string(
+        self, tree_only_db: HierarchicalChannelDatabase
+    ):
+        """A child without ``_description`` still yields an option, with ``""``."""
+        options = tree_only_db.get_options_at_level("signal", {"system": "SR", "device": "QUAD"})
+
+        assert options == [{"name": "Setpoint", "description": ""}]
+
+    def test_list_valued_selection_uses_its_first_entry(
+        self, tree_only_db: HierarchicalChannelDatabase
+    ):
+        """Selections may arrive as lists; navigation follows the first element."""
+        options = tree_only_db.get_options_at_level("device", {"system": ["SR", "BR"]})
+
+        assert _names(options) == ["BPM", "QUAD"]
+
+
+# ---------------------------------------------------------------------------
+# Navigation failure -> empty option list
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidPath:
+    """A selection matching neither a child nor an expansion aborts the walk."""
+
+    def test_unknown_selection_navigates_to_none(self, tree_only_db: HierarchicalChannelDatabase):
+        """No child ``NOPE`` and no ``_expansion`` to fall back on -> ``None``."""
+        assert tree_only_db._navigate_to_node("device", {"system": "NOPE"}) is None
+
+    def test_unknown_selection_yields_no_options(self, tree_only_db: HierarchicalChannelDatabase):
+        """The public entry point reports the dead end as an empty list."""
+        assert tree_only_db.get_options_at_level("device", {"system": "NOPE"}) == []
+        # ... and the same call with a real system does return options, so the
+        # empty list above is the navigation failure and not an empty fixture.
+        assert tree_only_db.get_options_at_level("device", {"system": "SR"}) != []
+
+    def test_empty_selection_list_yields_no_options(
+        self, tree_only_db: HierarchicalChannelDatabase
+    ):
+        """An empty list collapses to ``None``, which matches no child."""
+        assert tree_only_db.get_options_at_level("device", {"system": []}) == []
+
+
+# ---------------------------------------------------------------------------
+# Instance levels: descend into the container, ignore the selection
+# ---------------------------------------------------------------------------
+
+
+class TestInstanceLevelDescent:
+    """``instances`` levels move the cursor into their container, not past it."""
+
+    def test_descends_into_container_named_after_the_level(
+        self, range_instances_db: HierarchicalChannelDatabase
+    ):
+        """``device`` (instances) enters ``DEVICE`` so ``signal`` sees its children."""
+        options = range_instances_db.get_options_at_level(
+            "signal", {"system": "SR", "family": "BPM"}
+        )
+
+        assert _names(options) == ["X", "Y"]
+        assert options[0]["description"] == "Horizontal position"
+
+    def test_instance_selection_does_not_move_the_cursor(
+        self, range_instances_db: HierarchicalChannelDatabase
+    ):
+        """Passing the selected instance changes nothing: the container is entered."""
+        without_selection = range_instances_db.get_options_at_level(
+            "signal", {"system": "SR", "family": "QUAD"}
+        )
+        with_selection = range_instances_db.get_options_at_level(
+            "signal", {"system": "SR", "family": "QUAD", "device": "Q2"}
+        )
+
+        assert _names(without_selection) == ["Setpoint", "Readback"]
+        assert with_selection == without_selection
+
+    def test_container_lookup_is_case_insensitive(self, hier_db_factory):
+        """A ``Device`` container is found for a ``device`` level."""
+        db = hier_db_factory(_mixed_case_container_doc(), "mixed_case_container.json")
+
+        options = db.get_options_at_level("signal", {"system": "SR"})
+
+        assert options == [{"name": "X", "description": "Horizontal position"}]
+
+    def test_absent_container_leaves_the_cursor_in_place(
+        self, optional_instance_level_db: HierarchicalChannelDatabase
+    ):
+        """``BR`` has no ``DEVICE`` container, so ``signal`` sees ``BR``'s own children."""
+        options = optional_instance_level_db.get_options_at_level("signal", {"system": "BR"})
+
+        assert options == [{"name": "Status", "description": ""}]
+
+    def test_sibling_branch_with_a_container_still_descends(
+        self, optional_instance_level_db: HierarchicalChannelDatabase
+    ):
+        """The same optional level does descend under ``SR``, which has the container."""
+        options = optional_instance_level_db.get_options_at_level("signal", {"system": "SR"})
+
+        assert options == [{"name": "X", "description": "Horizontal position"}]
+
+
+# ---------------------------------------------------------------------------
+# Tree selection that is an expanded instance
+# ---------------------------------------------------------------------------
+
+
+class TestExpandedInstanceSelection:
+    """A ``tree``-level selection may name an instance generated by ``_expansion``."""
+
+    def test_expanded_instance_resolves_to_its_container(
+        self, hybrid_expansion_db: HierarchicalChannelDatabase
+    ):
+        """``device="CH-1"`` is not a tree key; the ``CH`` container generates it."""
+        options = hybrid_expansion_db.get_options_at_level(
+            "signal", {"system": "SR", "device": "CH-1"}
+        )
+
+        assert _names(options) == ["Voltage", "Current"]
+
+    def test_every_generated_instance_resolves_alike(
+        self, hybrid_expansion_db: HierarchicalChannelDatabase
+    ):
+        """The fallback is not anchored to the first instance of the range."""
+        for instance in ("CH-1", "CH-2", "CH-3"):
+            node = hybrid_expansion_db._navigate_to_node(
+                "signal", {"system": "SR", "device": instance}
+            )
+
+            assert node is not None
+            assert node["_description"] == "Corrector channels"
+
+    def test_direct_child_selection_skips_the_fallback(
+        self, hybrid_expansion_db: HierarchicalChannelDatabase
+    ):
+        """A sibling that *is* a tree key is matched directly, expansions untouched."""
+        options = hybrid_expansion_db.get_options_at_level(
+            "signal", {"system": "SR", "device": "PS"}
+        )
+
+        assert options == [{"name": "Status", "description": ""}]
+
+    def test_instance_outside_the_range_is_still_invalid(
+        self, hybrid_expansion_db: HierarchicalChannelDatabase
+    ):
+        """``CH-9`` looks like an instance but the expansion never generates it."""
+        assert (
+            hybrid_expansion_db._navigate_to_node("signal", {"system": "SR", "device": "CH-9"})
+            is None
+        )
+        assert (
+            hybrid_expansion_db.get_options_at_level("signal", {"system": "SR", "device": "CH-9"})
+            == []
+        )
+
+
+# ---------------------------------------------------------------------------
+# Inline expansion of tree children
+# ---------------------------------------------------------------------------
+
+
+class TestInlineExpansionOptions:
+    """``_extract_tree_options`` expands children that carry an ``_expansion``."""
+
+    def test_expanding_child_is_offered_as_its_instances(
+        self, hybrid_expansion_db: HierarchicalChannelDatabase
+    ):
+        """``CH`` is replaced by ``CH-1``..``CH-3``; the plain sibling stays as-is."""
+        options = hybrid_expansion_db.get_options_at_level("device", {"system": "SR"})
+
+        assert _names(options) == ["CH-1", "CH-2", "CH-3", "PS"]
+        assert "CH" not in _names(options)
+
+    def test_expanded_options_are_described_by_index(
+        self, hybrid_expansion_db: HierarchicalChannelDatabase
+    ):
+        """Generated instances carry a positional description, not the container's."""
+        options = hybrid_expansion_db.get_options_at_level("device", {"system": "SR"})
+
+        assert options[0] == {"name": "CH-1", "description": "Instance 1"}
+        assert options[-1] == {"name": "PS", "description": "Power supply"}
+
+    def test_metadata_and_scalar_keys_are_never_offered(
+        self, scalar_leaves_db: HierarchicalChannelDatabase
+    ):
+        """Underscore keys and non-dict children are both skipped."""
+        options = scalar_leaves_db.get_options_at_level("device", {"system": "SR"})
+
+        assert _names(options) == ["BPM", "QUAD"]
+
+        scalar_children = scalar_leaves_db.get_options_at_level(
+            "signal", {"system": "SR", "device": "BPM"}
+        )
+
+        assert scalar_children == []

--- a/tests/services/channel_finder/tools/test_build_database_helpers.py
+++ b/tests/services/channel_finder/tools/test_build_database_helpers.py
@@ -1,0 +1,266 @@
+"""Direct-call tests for the pure helpers of the channel database builder.
+
+These exercise ``load_csv``, ``group_by_family``, ``find_common_description``
+and ``create_template`` against ``tmp_path`` CSV files and in-memory row dicts.
+The full ``build_database`` pipeline is covered elsewhere; nothing here touches
+the filesystem outside ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from osprey.services.channel_finder.tools.build_database import (
+    create_template,
+    find_common_description,
+    group_by_family,
+    load_csv,
+)
+
+# ---------------------------------------------------------------------------
+# load_csv
+# ---------------------------------------------------------------------------
+
+
+def _write_csv(tmp_path: Path, body: str, name: str = "channels.csv") -> Path:
+    csv_path = tmp_path / name
+    csv_path.write_text(body, encoding="utf-8")
+    return csv_path
+
+
+def test_load_csv_skips_comment_and_empty_address_rows(tmp_path: Path) -> None:
+    csv_path = _write_csv(
+        tmp_path,
+        "address,description,family_name,instances,sub_channel\n"
+        "# this is a comment row,ignored,,,\n"
+        ",orphan row with no address,,,\n"
+        "SR:BPM1:X,Beam position horizontal,,,\n"
+        "   ,whitespace-only address,,,\n"
+        "SR:SCH1:SP,Corrector setpoint,SCH,12,:SP\n",
+    )
+
+    rows = load_csv(csv_path)
+
+    assert [r["address"] for r in rows] == ["SR:BPM1:X", "SR:SCH1:SP"]
+    assert rows[0]["description"] == "Beam position horizontal"
+    assert rows[1]["family_name"] == "SCH"
+
+
+def test_load_csv_normalizes_blank_fields_to_none_and_strips(tmp_path: Path) -> None:
+    csv_path = _write_csv(
+        tmp_path,
+        "address,description,family_name,instances,sub_channel\n"
+        "  SR:BPM1:X  ,  Beam position horizontal  ,,,   \n",
+    )
+
+    (row,) = load_csv(csv_path)
+
+    assert row["address"] == "SR:BPM1:X"
+    assert row["description"] == "Beam position horizontal"
+    assert row["family_name"] is None
+    assert row["instances"] is None
+    assert row["sub_channel"] is None
+
+
+def test_load_csv_honors_custom_delimiter(tmp_path: Path) -> None:
+    csv_path = _write_csv(
+        tmp_path,
+        "address\tdescription\tfamily_name\n"
+        "#comment\tignored\t\n"
+        "SR:BPM1:X\tBeam position horizontal\t\n",
+        name="channels.tsv",
+    )
+
+    rows = load_csv(csv_path, delimiter="\t")
+
+    assert [r["address"] for r in rows] == ["SR:BPM1:X"]
+    assert rows[0]["description"] == "Beam position horizontal"
+
+
+# ---------------------------------------------------------------------------
+# group_by_family
+# ---------------------------------------------------------------------------
+
+
+def test_group_by_family_splits_families_from_standalone() -> None:
+    channels = [
+        {"address": "SR:SCH1:SP", "family_name": "SCH"},
+        {"address": "SR:SCH1:AM", "family_name": "SCH"},
+        {"address": "SR:BPM1:X", "family_name": None},
+        {"address": "SR:QF1:SP", "family_name": "QF"},
+    ]
+
+    families, standalone = group_by_family(channels)
+
+    assert set(families) == {"SCH", "QF"}
+    assert [c["address"] for c in families["SCH"]] == ["SR:SCH1:SP", "SR:SCH1:AM"]
+    assert [c["address"] for c in standalone] == ["SR:BPM1:X"]
+
+
+# ---------------------------------------------------------------------------
+# find_common_description
+# ---------------------------------------------------------------------------
+
+
+def test_find_common_description_empty_list_returns_empty() -> None:
+    assert find_common_description([]) == ""
+
+
+def test_find_common_description_single_entry_returns_it_verbatim() -> None:
+    # The single-description short circuit bypasses the >=3-word guard.
+    assert find_common_description(["Beam"]) == "Beam"
+    assert (
+        find_common_description(["Horizontal corrector magnet current setpoint"])
+        == "Horizontal corrector magnet current setpoint"
+    )
+
+
+def test_find_common_description_no_shared_first_word_returns_empty() -> None:
+    descriptions = [
+        "Horizontal corrector magnet current setpoint",
+        "Quadrupole focusing magnet current readback",
+    ]
+
+    assert find_common_description(descriptions) == ""
+
+
+def test_find_common_description_short_shared_prefix_returns_empty() -> None:
+    # Common prefix is only "Beam" -- fewer than three words, so it is rejected.
+    descriptions = ["Beam current monitor", "Beam voltage monitor"]
+
+    assert find_common_description(descriptions) == ""
+
+
+def test_find_common_description_returns_shared_prefix_preserving_case() -> None:
+    descriptions = [
+        "Horizontal Corrector Magnet current setpoint",
+        "horizontal corrector magnet current readback",
+        "HORIZONTAL CORRECTOR MAGNET CURRENT status",
+    ]
+
+    # Case-insensitive matching, but capitalization comes from the first entry.
+    assert find_common_description(descriptions) == "Horizontal Corrector Magnet current"
+
+
+def test_find_common_description_strips_trailing_punctuation() -> None:
+    descriptions = [
+        "Corrector magnet current - horizontal",
+        "Corrector magnet current - vertical",
+    ]
+
+    assert find_common_description(descriptions) == "Corrector magnet current"
+
+
+# ---------------------------------------------------------------------------
+# create_template
+# ---------------------------------------------------------------------------
+
+
+def _family_row(sub_channel: str, description: str, instances: str = "12") -> dict:
+    return {
+        "address": f"SR:SCH01{sub_channel}",
+        "description": description,
+        "family_name": "SCH",
+        "instances": instances,
+        "sub_channel": sub_channel,
+    }
+
+
+def test_create_template_strips_common_prefix_from_sub_channel_descriptions() -> None:
+    channels = [
+        _family_row(":SP", "Horizontal corrector magnet current setpoint"),
+        _family_row(":AM", "Horizontal corrector magnet current readback"),
+        _family_row(":ON", "Horizontal corrector magnet current"),
+        _family_row(":ST", "HORIZONTAL CORRECTOR MAGNET CURRENT status"),
+    ]
+
+    template = create_template("SCH", channels)
+
+    assert template["template"] is True
+    assert template["base_name"] == "SCH"
+    assert template["instances"] == [1, 12]
+    assert template["sub_channels"] == [":SP", ":AM", ":ON", ":ST"]
+    assert template["description"] == "Horizontal corrector magnet current"
+    assert template["address_pattern"] == "SCH{instance:02d}{suffix}"
+    assert template["channel_descriptions"] == {
+        # Prefix stripped and the remainder lower-cased at its first character.
+        ":SP": "setpoint",
+        ":AM": "readback",
+        # Description equal to the prefix leaves nothing unique behind.
+        ":ON": "",
+        # Different capitalization does not match the prefix, so it is kept whole.
+        ":ST": "HORIZONTAL CORRECTOR MAGNET CURRENT status",
+    }
+
+
+def test_create_template_lowercases_only_the_first_character_of_the_remainder() -> None:
+    channels = [
+        _family_row(":SP", "Storage ring corrector magnet Setpoint Value"),
+        _family_row(":AM", "Storage ring corrector magnet Readback Value"),
+    ]
+
+    template = create_template("SCH", channels)
+
+    assert template["description"] == "Storage ring corrector magnet"
+    assert template["channel_descriptions"] == {
+        ":SP": "setpoint Value",
+        ":AM": "readback Value",
+    }
+
+
+def test_create_template_falls_back_to_generic_description_and_keeps_originals() -> None:
+    channels = [
+        _family_row(":SP", "Horizontal corrector setpoint", instances="4"),
+        _family_row(":AM", "Quadrupole focusing readback", instances="4"),
+    ]
+
+    template = create_template("SCH", channels)
+
+    assert template["description"] == "SCH device family"
+    # With the generic fallback, sub-channel descriptions are left untouched.
+    assert template["channel_descriptions"] == {
+        ":SP": "Horizontal corrector setpoint",
+        ":AM": "Quadrupole focusing readback",
+    }
+
+
+def test_create_template_deduplicates_repeated_sub_channels() -> None:
+    channels = [
+        _family_row(":SP", "Horizontal corrector magnet current setpoint"),
+        _family_row(":SP", "A later duplicate that must be ignored"),
+        _family_row(":AM", "Horizontal corrector magnet current readback"),
+    ]
+
+    template = create_template("SCH", channels)
+
+    assert template["sub_channels"] == [":SP", ":AM"]
+    assert set(template["channel_descriptions"]) == {":SP", ":AM"}
+
+
+def test_create_template_ignores_rows_without_a_sub_channel() -> None:
+    channels = [
+        {
+            "address": "SR:SCH01",
+            "description": "Horizontal corrector magnet family root",
+            "family_name": "SCH",
+            "instances": "8",
+            "sub_channel": None,
+        },
+        _family_row(":SP", "Horizontal corrector magnet current setpoint", instances="8"),
+        _family_row(":AM", "Horizontal corrector magnet current readback", instances="8"),
+    ]
+
+    template = create_template("SCH", channels)
+
+    assert template["instances"] == [1, 8]
+    assert template["sub_channels"] == [":SP", ":AM"]
+    assert template["description"] == "Horizontal corrector magnet current"
+
+
+def test_create_template_rejects_non_numeric_instance_count() -> None:
+    channels = [_family_row(":SP", "Horizontal corrector setpoint", instances="many")]
+
+    with pytest.raises(ValueError):
+        create_template("SCH", channels)

--- a/tests/services/channel_finder/tools/test_build_database_llm.py
+++ b/tests/services/channel_finder/tools/test_build_database_llm.py
@@ -1,0 +1,223 @@
+"""Tests for the LLM-naming and error-recovery branches of ``build_database``.
+
+Covers the three arms that the plain (no-LLM) path never reaches: successful
+LLM naming, degradation to addresses when the namer cannot be constructed, and
+the per-family fallthrough that turns a template-creation failure into
+standalone entries instead of aborting the whole build.
+
+``build_database`` imports ``create_namer_from_config`` *inside* the function
+body, so the name is never bound on ``build_database``'s module globals.
+Patching must therefore target the owning module,
+``osprey.services.channel_finder.tools.llm_channel_namer``. Each fake records
+that it was called so an inert patch fails the test rather than passing
+silently.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from osprey.services.channel_finder.tools.build_database import build_database
+
+NAMER_FACTORY = "osprey.services.channel_finder.tools.llm_channel_namer.create_namer_from_config"
+
+
+class _FakeNamer:
+    """Stand-in for ``LLMChannelNamer`` — no network, no API key."""
+
+    def __init__(self, names: list[str]) -> None:
+        self.model_id = "fake/model-1"
+        self.batch_size = 7
+        self._names = names
+        self.received: list[dict] = []
+
+    def generate_names(self, channels: list[dict]) -> list[str]:
+        self.received = list(channels)
+        return list(self._names)
+
+
+class _RecordingFactory:
+    """Callable that records its invocation so an inert patch is detectable."""
+
+    def __init__(self, result=None, error: Exception | None = None) -> None:
+        self._result = result
+        self._error = error
+        self.calls: list[object] = []
+
+    def __call__(self, config_path=None):
+        self.calls.append(config_path)
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+def _write_csv(tmp_path: Path, rows: list[str]) -> Path:
+    csv_path = tmp_path / "channels.csv"
+    header = "address,description,family_name,instances,sub_channel"
+    csv_path.write_text("\n".join([header, *rows]) + "\n", encoding="utf-8")
+    return csv_path
+
+
+def _standalone(db: dict) -> list[dict]:
+    return [entry for entry in db["channels"] if not entry["template"]]
+
+
+def _templates(db: dict) -> list[dict]:
+    return [entry for entry in db["channels"] if entry["template"]]
+
+
+def test_llm_naming_success_applies_generated_names(tmp_path, monkeypatch):
+    """Generated names land on the standalone entries and in the metadata."""
+    csv_path = _write_csv(
+        tmp_path,
+        [
+            "SR:BEND:1:CURRENT,Main bend magnet current,,,",
+            "SR:RF:CAVITY:VOLTAGE,RF cavity gap voltage,,,",
+        ],
+    )
+    output_path = tmp_path / "out" / "db.json"
+    namer = _FakeNamer(["BendMagnetCurrent", "RfCavityVoltage"])
+    factory = _RecordingFactory(result=namer)
+    monkeypatch.setattr(NAMER_FACTORY, factory)
+
+    config_path = tmp_path / "config.yml"
+    db = build_database(csv_path, output_path, use_llm=True, config_path=config_path)
+
+    # The patch was genuinely exercised, with the caller's config path.
+    assert factory.calls == [config_path]
+
+    entries = _standalone(db)
+    assert [e["channel"] for e in entries] == ["BendMagnetCurrent", "RfCavityVoltage"]
+    assert [e["address"] for e in entries] == [
+        "SR:BEND:1:CURRENT",
+        "SR:RF:CAVITY:VOLTAGE",
+    ]
+
+    # The namer saw the address/description pairs, not raw CSV rows.
+    assert namer.received == [
+        {"short_name": "SR:BEND:1:CURRENT", "description": "Main bend magnet current"},
+        {
+            "short_name": "SR:RF:CAVITY:VOLTAGE",
+            "description": "RF cavity gap voltage",
+        },
+    ]
+
+    llm_meta = db["_metadata"]["llm_naming"]
+    assert llm_meta["enabled"] is True
+    assert llm_meta["model"] == "fake/model-1"
+    assert "2 standalone channels" in llm_meta["purpose"]
+
+    # The same content reaches disk.
+    on_disk = json.loads(output_path.read_text(encoding="utf-8"))
+    assert on_disk == db
+
+
+def test_llm_naming_failure_degrades_to_addresses(tmp_path, monkeypatch):
+    """A namer that cannot be constructed degrades instead of propagating."""
+    csv_path = _write_csv(
+        tmp_path,
+        [
+            "SR:BEND:1:CURRENT,Main bend magnet current,,,",
+            "SR:RF:CAVITY:VOLTAGE,RF cavity gap voltage,,,",
+        ],
+    )
+    output_path = tmp_path / "db.json"
+    factory = _RecordingFactory(error=RuntimeError("no provider configured"))
+    monkeypatch.setattr(NAMER_FACTORY, factory)
+
+    db = build_database(csv_path, output_path, use_llm=True)
+
+    assert factory.calls == [None]
+
+    entries = _standalone(db)
+    assert [e["channel"] for e in entries] == [
+        "SR:BEND:1:CURRENT",
+        "SR:RF:CAVITY:VOLTAGE",
+    ]
+    assert [e["channel"] for e in entries] == [e["address"] for e in entries]
+
+    # Degraded run still reports that LLM naming was requested, but no model.
+    llm_meta = db["_metadata"]["llm_naming"]
+    assert llm_meta["enabled"] is True
+    assert llm_meta["model"] is None
+    assert llm_meta["purpose"] is None
+
+    on_disk = json.loads(output_path.read_text(encoding="utf-8"))
+    assert on_disk == db
+
+
+def test_template_failure_falls_through_to_standalone(tmp_path):
+    """A family whose template cannot be built becomes standalone entries."""
+    csv_path = _write_csv(
+        tmp_path,
+        [
+            # instances="abc" makes create_template's int() raise ValueError.
+            "BPM01:X,BPM horizontal position,BPM,abc,:X",
+            "BPM01:Y,BPM vertical position,BPM,abc,:Y",
+            # A well-formed family must still make it into the database.
+            "COR01:SP,Corrector setpoint,COR,4,:SP",
+            "COR01:RB,Corrector readback,COR,4,:RB",
+            "SR:TEMP,Ring temperature,,,",
+        ],
+    )
+    output_path = tmp_path / "db.json"
+
+    db = build_database(csv_path, output_path)
+
+    templates = _templates(db)
+    assert [t["base_name"] for t in templates] == ["COR"]
+
+    # The two BPM rows fell through to standalone, appended after the genuine
+    # standalone row, and are named by address.
+    entries = _standalone(db)
+    assert [e["address"] for e in entries] == ["SR:TEMP", "BPM01:X", "BPM01:Y"]
+    assert [e["channel"] for e in entries] == ["SR:TEMP", "BPM01:X", "BPM01:Y"]
+    assert [e["description"] for e in entries] == [
+        "Ring temperature",
+        "BPM horizontal position",
+        "BPM vertical position",
+    ]
+
+    stats = db["_metadata"]["stats"]
+    assert stats == {
+        "template_entries": 1,
+        "standalone_entries": 3,
+        "total_entries": 4,
+    }
+
+    on_disk = json.loads(output_path.read_text(encoding="utf-8"))
+    assert on_disk == db
+
+
+def test_patch_target_is_the_owning_module():
+    """Guard: the factory is not bound on build_database's module globals.
+
+    If it ever becomes a module-level import there, this test fails and the
+    patch target above must be revisited.
+    """
+    from osprey.services.channel_finder.tools import build_database as mod
+
+    assert not hasattr(mod, "create_namer_from_config")
+
+
+@pytest.mark.parametrize("use_llm", [True, False])
+def test_no_standalone_channels_skips_naming_entirely(tmp_path, monkeypatch, use_llm):
+    """With no standalone rows the namer is never constructed."""
+    csv_path = _write_csv(
+        tmp_path,
+        [
+            "COR01:SP,Corrector setpoint,COR,2,:SP",
+            "COR01:RB,Corrector readback,COR,2,:RB",
+        ],
+    )
+    factory = _RecordingFactory(error=AssertionError("must not be called"))
+    monkeypatch.setattr(NAMER_FACTORY, factory)
+
+    db = build_database(csv_path, tmp_path / "db.json", use_llm=use_llm)
+
+    assert factory.calls == []
+    assert _standalone(db) == []
+    assert [t["base_name"] for t in _templates(db)] == ["COR"]


### PR DESCRIPTION
## Summary

The `_hierarchical_*` concern modules in `src/osprey/services/channel_finder/databases/` were
covered only *through the facade*: exercised incidentally by tests aimed at something else, with
no dedicated tests of their own. `_hierarchical_query.py` had no dedicated test file at all. This
PR closes that tail for all six concern modules and for `tools/build_database.py`.

The deliverable is **test machinery, not production restructuring**. The only production change is
a deletion of dead code (below). Channel lookup sits on the critical path of nearly every agent
action, so untested branches there are disproportionately expensive.

All counts in this description are coverage **statements**, not source lines and not percentages.
A multi-line `raise ValueError(...)` is one statement, reported at its first line. Percentages are
avoided in the tables on purpose: a displayed "90%" can round-mask 89.99%.

## The split decision, and why it was rejected

The starting hypothesis for this work was that `_hierarchical_naming.py` should be split, on the
grounds that separator handling "reads largely stateless" and that extracting pure functions would
pay for itself in testability. Measurement refutes that:

- `_clean_optional_separators` was already at **100%** covered.
- `_build_channel_with_separators` had **3** uncovered statements.

The extractable code was already tested. Of the 87 uncovered statements in the module, roughly
**65** sat in just two functions — `_build_channel_map` (~40) and `_collect_separator_overrides`
(~25). Both are recursive tree-walkers. Neither decomposes without threading an accumulator and a
recursive callable through every frame, which trades a testability problem for a signature problem
and moves no coverage.

A split was mechanically **feasible** — the mixin never writes to `self` — but it was rejected **on
value**, not on difficulty. This PR is therefore a test-machinery change. The way to cover those
two walkers was to drive them with real database documents, which is what the new fixtures do.

## Production change

One deletion in `_hierarchical_naming.py` (11 statements, 8 of them uncovered; the module's
denominator drops from 232 to 221):

- `_find_separator_between_levels` — a repo-wide grep for the name now returns zero occurrences;
  before the deletion it returned exactly one, its own `def`.
- A discarded `self._get_pattern_levels()` call whose return value was thrown away. The method is a
  pure `re.findall` and keeps its two live callers.
- `expand_tree`'s `separator_overrides is None` guard, together with the `| None = None` default.
  All seven call sites pass a dict explicitly.

This is denominator reduction by removing code, which is the legitimate opposite of inflating a
percentage with `pragma: no cover` or a coverage `omit`. No behaviour changes.

## Per-module uncovered statements

| Module | Statements | Uncovered before | Uncovered now | Target |
|---|---|---|---|---|
| `databases/_hierarchical_naming.py` | 221 | 87 | **1** | ≤ 20 |
| `databases/_hierarchical_loading.py` | 149 | 42 | **3** | ≤ 12 |
| `databases/_hierarchical_query.py` | 96 | 20 | **1** | ≤ 6 |
| `databases/_hierarchical_base.py` | 58 | 7 | **1** | ≤ 3 |
| `databases/_hierarchical_preview.py` | 75 | 4 | **4** | ≤ 4 (no regression) |
| `databases/_hierarchical_write.py` | 168 | 14 | **14** | ≤ 14 (no regression) |
| `tools/build_database.py` | 130 | 32 | **0** | ≤ 8 |

`_hierarchical_naming.py`'s "before" figure of 87 is against its pre-deletion denominator of 232.

`_hierarchical_preview.py` and `_hierarchical_write.py` were already above the bar and were held
there. Their no-regression status was checked as an identical **line list**, not as an unchanged
count, across every measurement in this work — 4 uncovered at lines 138, 180, 188, 189 and 14
uncovered at lines 52, 63, 149, 263, 328-330, 332-334, 337, 362, 366, 367, with no drift.

`tools/build_database.py` reached zero. Its starting figure was also a correction: it was reported
as untested, but it was already exercised through the Click CLI by
`tests/cli/test_channel_finder_cmd.py`, which put it at 32 uncovered rather than 130.

## Package-level outcome

The package now stands at **470 uncovered statements out of 4112** — 88.6% covered, which coverage
displays as "89%". This is stated as a count first for the reason given above.

Package-level ≥ 90% was **not** bought by this work and was never in scope. The projection going in
was ~87%; the actual result is a little better than that. The gap to 90% lives almost entirely in
the modules excluded below.

Excluding those, the rest of the package sits at **86 uncovered statements out of 2605**.

## Modules excluded by scope

These five areas hold **384 of the package's 470** uncovered statements. Their exclusion is a
**scope decision, not an oversight**:

| Excluded | Uncovered | Statements |
|---|---|---|
| `benchmarks/*` (12 modules) | 252 | 971 |
| `databases/middle_layer.py` | 76 | 257 |
| `utils/mml_converter.py` | 26 | 87 |
| `databases/flat.py` | 17 | 91 |
| `databases/duckdb_import.py` | 13 | 101 |

`benchmarks/*` is the single largest block. Worth recording plainly: the assumption that these
modules need real LLM providers to test is **wrong** — the ReAct loop is fakeable, and the
mechanism to fake it exists. They are excluded because this change is scoped to the hierarchical
database concerns, not because they are untestable. That makes them a well-defined follow-up rather
than a dead end.

## Conceded uncovered statements

Four statements are left uncovered deliberately. They are **not all the same kind** of
unreachability, and the distinction matters to anyone auditing them later.

**Structurally unreachable** — no input reaches them:

- `_hierarchical_query.py:62` — the trailing `return []` after the `tree` and `instances` arms.
  Validation rejects any other level type, so the fallthrough cannot be entered.
- `_hierarchical_base.py:88` — the `return 1` fallback in `_expansion_instance_count`. Reachable
  only through the un-underscored `range` alias, which is dead against any schema-valid database.
- `_hierarchical_naming.py:449` — the `return` of a **duplicated** guard. Lines 444-445 and 448-449
  are the byte-identical `if level_idx >= len(self.hierarchy_levels): return`. The second cannot
  fire: `_is_leaf_node` returns `True` whenever `level_idx >= len(self.hierarchy_levels)`, so the
  only path that satisfies line 448's condition has already returned at line 445.

**Pre-empted by validation ordering** — reachable in principle, unreachable in practice because an
earlier validator raises first:

- `_hierarchical_loading.py:131, 136, 146` — three `raise ValueError` validation statements.
  `_validate_naming_pattern()` runs at `:52`, before `_validate_hierarchy_config()` at `:55`, and it
  already indexes `self.hierarchy_config["levels"][level]` at `:105`. Any document malformed enough
  to trip these three guards raises `KeyError` from that earlier lookup instead. This ordering is
  documented in the test tree at
  `tests/services/channel_finder/databases/test_loading_database_validation.py` lines 11-19,
  including the related trap that `load_database` reads `tree` before it checks for `hierarchy`.

These four are the entirety of the uncovered set across naming, loading, query and base.

## Gate evidence

The suite was run in **two shapes**, and the identical counts across them are what establishes that
the new tests carry no ordering or parallelism dependence:

| Shape | Command | Result |
|---|---|---|
| Parallel, with coverage | `pytest tests/ --ignore=tests/e2e -n 4 --dist loadgroup --cov=src/osprey/services/channel_finder --cov-report=term-missing` | exit 0 — 12106 passed, 39 skipped, 1 xfailed, 0 failed |
| Fully serial, no coverage | `pytest tests/ --ignore=tests/e2e -q` | exit 0 — 12106 passed, 39 skipped, 1 xfailed, 0 failed |

Identical in every column: no xdist dependence, no `loadgroup` ordering effect, no cross-test
leakage. Skipped and xfailed are unchanged from the pre-change baseline of 39 / 1. Passed moves from
11,839 to 12,106 — **267 net new tests**, across a new shared `conftest.py` and 12 new test modules.

`tests/infrastructure/test_import_time_audit.py` passes (2 passed) with **no `WHITELIST` change** —
`tests/infrastructure/` is untouched, and that audit asserts exact `WHITELIST` equality in both
directions, so an addition would itself have been a failure.

One measurement note for anyone re-deriving these numbers: `[tool.coverage.run]` sets
`parallel = true`, so a run leaves `.coverage.<host>.<pid>.*` data files behind and an unqualified
`coverage report` will silently read whichever it finds, including data from before a change. The
figures above come from an explicitly named report file written by a run whose stale data files were
cleared first, and were sanity-checked against the post-deletion statement count of 221 for
`_hierarchical_naming.py`.

## What the new tests are

- A shared hierarchical-database fixture family in a new `tests/services/channel_finder/conftest.py`,
  with shapes derived mechanically from the uncovered statement set: tree-only; `range`- and
  `list`-typed instance levels; optional levels; optional instance levels with no container; hybrid
  `_expansion`; scalar (non-dict) leaves; separator overrides; `_channel_part` both populated and
  empty; `_is_leaf: true` nodes that also carry dict children; and databases where all remaining
  levels are optional, for both `instances`- and `tree`-typed next levels.
- A characterization module for `_hierarchical_naming.py` that pins **what the code does today**,
  derived by running it rather than by reading its docstrings, so that a later behaviour-preserving
  refactor of those two tree-walkers is detectable. Where the pinned behaviour looks wrong it is
  pinned anyway and labelled "characterized, not endorsed" — a test that asserts the *intended*
  behaviour cannot tell a preserved bug from a fixed one.
- Dedicated modules for query navigation and expansion, loading validation (document arms,
  `_expansion` arms, and container-path resolution), naming channel-map construction, separator
  overrides, leaf detection, `_hierarchical_base` helpers, and `build_database`'s pure helpers and
  LLM-namer paths.

The new `conftest.py` is **strictly additive**. The three pre-existing hierarchical test files
(`test_hierarchical_writes.py`, `test_tree_preview.py`, `test_preview_database.py`) are unmodified;
migrating them onto the shared fixtures, and de-duplicating the SR/BR JSON they each carry, is left
for a later cleanup.

New tests use `tmp_path` JSON and in-memory dicts only: no Postgres, no Docker, no network, no
`sleep`.

## Hygiene

- No `pragma: no cover` added — `git diff` contains zero added lines matching it.
- No coverage `omit` entry added; `pyproject.toml` is unmodified.
- Nothing under `src/osprey/templates/` modified.
- No new `xdist_group`, no new `@flaky`.
- No import-time side effects; the import-time audit's `WHITELIST` is unchanged.
- The three pre-existing hierarchical test files are unmodified (additive-only).

**One honest caveat, so it does not read as a contradiction later:** grepping the channel-finder
test tree for `pragma: no cover` returns exactly one hit —
`tests/services/channel_finder/test_rate_limiter.py:91`, on a `fake_sleep` helper that is asserted
never to run. That line is present unchanged at the same line number before this change, in a file
this PR never touches. The count is 1 before and 1 after. No pragma was added here.

## Follow-ups

Named rather than silently carried:

1. **Remove the duplicated `level_idx >= len(...)` guard** at `_hierarchical_naming.py:447-449`.
   That single removal takes the module to **zero** uncovered statements. It was left in place here
   because a separate piece of this work was chartered to cover that same region, and removing code
   under it mid-flight would have made the two changes hard to attribute.
2. **Simplify the `all_remaining_optional` tree arm of `_is_leaf_node`** (`_hierarchical_naming.py`
   lines 135-142). It is live and reachable, but its predicate can never be true at that point: it
   re-tests `has_tree_children` with the same predicate the surrounding logic has already applied,
   so it always returns `False`. The consequence is pinned by the characterization tests — an
   all-remaining-optional tail whose next level is `tree`-typed never produces the bare parent
   channel, while the `instances`-typed counterpart does.
3. **Cover `benchmarks/*`** (252 uncovered statements). See the scope note above: the ReAct loop is
   fakeable, so this does not require real LLM providers.

### Two genuine defects the characterization pass exposed

Both are **pinned as-is and neither is fixed** — fixing them is a behaviour change and out of scope
here. They are named because the tests now make them visible, and because a future reader will
otherwise mistake the pinned assertions for endorsement.

1. **`_build_channel_map` and `build_channels_from_selections` disagree about which channels
   exist.** Three emitted channels cannot be replayed from their own stored `path`: feeding a
   channel's `path` back through `build_channels_from_selections` raises `ValueError` on a missing
   required level. The three are `"BR"` (tree-only shape, no children at all), `"SR:BPM"` (scalar
   children, invisible to the dict guards) and `"SR:PS:SIGNAL-Y"` (a channel in its own right at the
   `signal` level, with `suffix` unfilled). `build_channels_from_selections` has two production
   callers — `src/osprey/mcp_server/channel_finder_hierarchical/tools/build_channels.py:39` and
   `src/osprey/interfaces/channel_finder/database_api.py:304` — so this is a live round-trip hole,
   not a private-method curiosity.

2. **A list-valued selection collects separator overrides from its first entry only**, then applies
   them across the whole Cartesian product. `{"system": "SR", "device": ["BPM", "QUAD"], ...}` walks
   `"BPM"`, picks up `BPM`'s `_` override, and emits `SR-QUAD_X:RB` — `QUAD` inheriting a separator
   it does not set, and a name that is not a key of `channel_map`. Reversing the list to
   `["QUAD", "BPM"]` moves the underscore, so the same two selections render differently depending
   on order. The list path disagrees with the rest of the system, which renders that combination
   with the pattern's own separator.

Two smaller behaviours worth naming while they are fresh:

- **Selections are never validated.** `build_channels_from_selections({"system": "NOPE",
  "device": "NOPE", "signal": "NOPE"})` returns `["NOPE:NOPE:NOPE"]` — a name that corresponds to
  nothing in the tree and is not a key of `channel_map`. The method is a name formatter, not a
  lookup. Relatedly, an empty list or `None` for any level silently collapses the entire product to
  `[]` with no explanation, while `""` for a required level drops that component and succeeds.
- **`get_statistics` mis-buckets under `_channel_part`.** It buckets by raw tree key, so a tree
  using `_channel_part` reports `channel_count: 0` for systems that do hold channels.

### Coverage-instrument foot-guns worth carrying forward

Each of these produced a wrong number at least once during this work:

- `[tool.coverage.run] parallel = true` leaves `.coverage.<host>.<pid>.*` files behind, and an
  unqualified `coverage report` will silently read them — including data recorded before a change.
  Clear or move them before measuring, and name the report file explicitly.
- A file-path `--cov=.../some_module.py` collects **nothing** and reports 0%. Use the directory
  form.
- Coverage's statement count is **not** a raw `ast.stmt` walk: `_hierarchical_naming.py` is 221
  statements to coverage and 232 to `ast`. Anyone verifying this PR's deletion with `ast` would
  wrongly conclude it removed nothing. Use `coverage.parser.PythonParser` for any statement-count
  comparison.
