### PR TITLE
test(e2e): add Nextcloud+Talk fixture image sources

### DIFF
--- a/tests/e2e/fixtures/Dockerfile.nextcloud_talk
+++ b/tests/e2e/fixtures/Dockerfile.nextcloud_talk
@@ -1,0 +1,121 @@
+# Pinned Nextcloud + Talk (spreed) server standing in for a real institutional
+# Nextcloud deployment, used ONLY by tests/e2e/test_nextcloud_talk_bridge_e2e.py
+# to exercise the engine<->dispatch contract against a REAL Talk OCS API rather
+# than a mocked client. Unlike the other e2e fixture here, this is not a stub:
+# it is a genuine, fully provisioned Nextcloud with Talk enabled, because the
+# whole point of the lane is that the adapter talks to the actual API surface
+# (room types, chat receive/send, mentions, file share/download).
+#
+# Published by .github/workflows/build-nextcloud-fixture.yml to
+#   ghcr.io/als-apg/nextcloud-talk-fixture:33.0.7-spreed23.0.9
+# so the e2e lane pulls a prebuilt image instead of paying provisioning cost
+# per run.
+#
+# ---------------------------------------------------------------------------
+# PINS (greppable — a wiring test asserts the e2e module's image constant
+# against these two tokens, so do not reformat them):
+#   NEXTCLOUD_PIN=33.0.7
+#   SPREED_PIN=23.0.9
+# ---------------------------------------------------------------------------
+#
+# Both pins move TOGETHER and are not independently selectable. Talk declares
+# an exact Nextcloud major in appinfo/info.xml — for 23.0.9 it is
+# <nextcloud min-version="33" max-version="33" />, i.e. min == max. Talk 23.x
+# runs on Nextcloud 33.x and nothing else, so bumping one pin without the other
+# produces an image whose app cannot be enabled at all. Nextcloud 33 also
+# satisfies the phase's Talk >= 21 floor with room to spare.
+#
+# When either pin changes, these must change with it:
+#   - the FROM tag below (nextcloud:<pin>-apache)
+#   - ARG SPREED_VERSION below
+#   - the ghcr tag above and in the fixture build workflow
+#   - NEXTCLOUD_FIXTURE_IMAGE in tests/e2e/test_nextcloud_talk_bridge_e2e.py
+#   - SPREED_SHA256 below (the release tarball checksum)
+#
+# The FROM tag and ARG SPREED_VERSION are not merely documentation: a wiring test
+# asserts both against the two greppable pin tokens above, so all four values must
+# move in lockstep or the test fails.
+FROM nextcloud:33.0.7-apache
+
+# Keep in lockstep with SPREED_PIN above. The checksum is verified at build
+# time, so an out-of-band --build-arg bump fails closed here rather than
+# silently baking an incompatible Talk.
+ARG SPREED_VERSION=23.0.9
+ARG SPREED_SHA256=e3096dbe40f1d439ede726ca8fce74f9daabe23aa407426ddc853be5da62ac20
+
+# Talk is baked in at BUILD time, never fetched at test time: the e2e lane must
+# not depend on reaching a release host while tests run.
+#
+# It lands in /usr/src/nextcloud/apps rather than custom_apps because the
+# entrypoint rsyncs /usr/src/nextcloud into /var/www/html with
+# --exclude-from=/upgrade.exclude, and that exclude list contains
+# /custom_apps/ — an app staged there would never reach the served tree.
+RUN set -eux; \
+    tarball="spreed-v${SPREED_VERSION}.tar.gz"; \
+    curl -fsSL -o "/tmp/${tarball}" \
+        "https://github.com/nextcloud-releases/spreed/releases/download/v${SPREED_VERSION}/${tarball}"; \
+    echo "${SPREED_SHA256}  /tmp/${tarball}" | sha256sum -c -; \
+    tar -xzf "/tmp/${tarball}" -C /usr/src/nextcloud/apps; \
+    rm -f "/tmp/${tarball}"; \
+    test -f "/usr/src/nextcloud/apps/spreed/appinfo/info.xml"
+
+# Readiness marker lives outside /var/www/html (a VOLUME) on purpose, so it is
+# per-container rather than per-volume: a fresh container is never born ready.
+RUN install -d -o www-data -g root /var/lib/talk-fixture
+
+# Throwaway fixture credentials. These exist so a bare `docker run` reaches a
+# provisioned state with no operator input — they are TEST-ONLY and must never
+# be reused for anything reachable. Presence of admin user + password + a
+# database selection is what makes the official entrypoint auto-install.
+#
+# The e2e module authenticates to the Talk OCS API as this admin to provision
+# its bot account and rooms, so both values are part of the fixture contract:
+# changing either requires the same change in
+# tests/e2e/test_nextcloud_talk_bridge_e2e.py.
+ENV NEXTCLOUD_ADMIN_USER=admin \
+    NEXTCLOUD_ADMIN_PASSWORD=talk-fixture-admin-9F3k \
+    SQLITE_DATABASE=nextcloud \
+    NEXTCLOUD_TRUSTED_DOMAINS="localhost 127.0.0.1 host.docker.internal nextcloud nextcloud-talk-fixture"
+
+# The entrypoint applies NEXTCLOUD_TRUSTED_DOMAINS only during install, so a
+# test reaching this container under some other hostname must override the env
+# var before first boot, not after.
+#
+# This failure is HEALTH-INVISIBLE, which is what makes it worth spelling out:
+# the HEALTHCHECK below probes 127.0.0.1, which is always trusted, so a container
+# addressed under an untrusted hostname reports perfectly healthy while every OCS
+# call comes back HTTP 400 "Trusted domain error". The e2e must therefore address
+# this container by one of the names baked in above — localhost, 127.0.0.1,
+# host.docker.internal, nextcloud, nextcloud-talk-fixture (a port is fine,
+# Nextcloud strips it before comparing) — and a mismatch will surface as HTTP 400
+# on the first OCS request, never as an unhealthy container.
+
+# Wired into two hook folders deliberately, but not in the way the folder names
+# suggest: in the upstream entrypoint `run_path before-starting` sits in the
+# apache branch OUTSIDE the version_greater gate, so it fires on EVERY boot,
+# including the first — immediately after post-installation. before-starting is
+# therefore the copy that actually guarantees the state; post-installation is
+# kept only so the install path provisions before that first before-starting
+# pass. First boot consequently provisions twice (post-installation enables Talk
+# and writes the marker; before-starting clears the marker and redoes the same
+# work), which is harmless because the script is idempotent — and it no-ops when
+# Nextcloud is not installed at all.
+#
+# chmod is a separate RUN rather than COPY --chmod so this builds on the classic
+# builder too: the entrypoint SKIPS hook scripts that lack the executable bit,
+# which would yield an image that boots fine and has no Talk.
+COPY nextcloud_talk_provision.sh /usr/local/bin/nextcloud_talk_provision.sh
+RUN set -eux; \
+    chmod 755 /usr/local/bin/nextcloud_talk_provision.sh; \
+    for hook in post-installation before-starting; do \
+        cp /usr/local/bin/nextcloud_talk_provision.sh \
+            "/docker-entrypoint-hooks.d/${hook}/nextcloud_talk_provision.sh"; \
+        test -x "/docker-entrypoint-hooks.d/${hook}/nextcloud_talk_provision.sh"; \
+    done
+
+# Readiness for the e2e lane: Talk provisioned AND apache serving. Both halves
+# matter — the marker alone is written before apache accepts connections.
+# start-period is generous because first boot runs a full sqlite install.
+HEALTHCHECK --interval=10s --timeout=10s --start-period=240s --retries=40 \
+    CMD test -f /var/lib/talk-fixture/ready \
+        && curl -fsS http://127.0.0.1/status.php | grep -q '"installed":true'

--- a/tests/e2e/fixtures/nextcloud_talk_provision.sh
+++ b/tests/e2e/fixtures/nextcloud_talk_provision.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+# First-boot provisioning for the Nextcloud + Talk e2e fixture image
+# (Dockerfile.nextcloud_talk). Copied into BOTH the "post-installation" and
+# "before-starting" entrypoint hook folders, so a fresh container provisions
+# itself and a restarted one re-asserts the same state.
+#
+# The official entrypoint executes hook scripts through its own run_as()
+# helper, which means this already runs as www-data — `php occ` is invoked
+# directly, with no su dance.
+set -eu
+
+OCC="php /var/www/html/occ"
+READY_MARKER=/var/lib/talk-fixture/ready
+
+# Never advertise readiness while re-provisioning.
+rm -f "$READY_MARKER"
+
+# "before-starting" also fires on containers that were never installed (someone
+# cleared the admin env vars), and there a no-op is correct: occ would fail and
+# take the whole entrypoint down with it.
+#
+# But occ exits nonzero for plenty of other reasons — a stale/half-populated
+# volume, an unreadable config.php, maintenance mode, a PHP fatal — and those
+# must NOT be read as "not installed". Booting apache Talk-less and marker-less
+# turns a real breakage into an opaque health-wait timeout, with a log line that
+# actively misdirects whoever debugs it: the same wasted e2e session the
+# assertion further down exists to prevent. So the exit status and the payload
+# are judged separately, and only "exited 0 AND reported installed:false" is a
+# silent no-op.
+#
+# Matching stays substring/grep-based on purpose: on a genuinely uninstalled
+# instance occ prepends a "Nextcloud is not installed - only a limited number of
+# commands are available" banner BEFORE the JSON, so decoding the whole stream
+# would choke on the one case this branch exists to handle.
+status_rc=0
+status_output=$($OCC status --output=json 2>&1) || status_rc=$?
+
+if [ "$status_rc" -ne 0 ]; then
+    echo "[talk-fixture] FATAL: 'occ status' exited ${status_rc}. This instance is broken," >&2
+    echo "[talk-fixture] not merely uninstalled - refusing to boot without Talk." >&2
+    printf '%s\n' "$status_output" >&2
+    exit "$status_rc"
+fi
+
+status_json=$(printf '%s' "$status_output" | tr -d ' ')
+
+if printf '%s' "$status_json" | grep -q '"installed":false'; then
+    echo "[talk-fixture] Nextcloud is not installed; skipping Talk provisioning."
+    exit 0
+fi
+
+if ! printf '%s' "$status_json" | grep -q '"installed":true'; then
+    echo "[talk-fixture] FATAL: 'occ status' reported no install state at all." >&2
+    printf '%s\n' "$status_output" >&2
+    exit 1
+fi
+
+echo "[talk-fixture] Enabling Talk (spreed)..."
+$OCC app:enable spreed
+
+# Onboarding overlay is pure noise for an API-driven fixture, and is not
+# guaranteed to be shipped in every Nextcloud build.
+$OCC app:disable firstrunwizard || true
+
+# app:enable already fails loudly, but assert the end state too: reporting ready
+# with Talk half-provisioned is the one failure mode that would waste an entire
+# e2e debugging session.
+if ! $OCC app:list --output=json \
+    | php -r 'exit(isset(json_decode(stream_get_contents(STDIN), true)["enabled"]["spreed"]) ? 0 : 1);'; then
+    echo "[talk-fixture] FATAL: spreed is not in the enabled app list after app:enable." >&2
+    exit 1
+fi
+
+# Marker content is the provisioned Talk version, so a failing e2e run can tell
+# "wrong Talk" apart from "Talk missing" straight from the container.
+#
+# The version is captured and checked BEFORE anything is written, because a plain
+# redirect creates the marker before the command produces output: a
+# config:app:get that printed nothing (or only a newline) but exited 0 would
+# leave a present-but-blank marker, so the container would be genuinely ready
+# while the marker's whole diagnostic purpose had silently evaporated.
+#
+# The capture is deliberately NOT piped into tr: a pipeline reports the LAST
+# command's status, so `occ ... | tr` would mask an occ failure that set -eu
+# should be killing the boot over. Strip in a second step instead, and test the
+# stripped value rather than the file size — whitespace-only output is a blank
+# marker too, just not a zero-byte one.
+talk_version=$($OCC config:app:get spreed installed_version)
+talk_version=$(printf '%s' "$talk_version" | tr -d '[:space:]')
+if [ -z "$talk_version" ]; then
+    echo "[talk-fixture] FATAL: could not read Talk's installed_version; refusing to write a blank marker." >&2
+    exit 1
+fi
+
+# tmp+mv so the marker is never observable in a half-written state: the
+# HEALTHCHECK tests only for its existence, so a partial file would read as ready.
+printf '%s\n' "$talk_version" > "$READY_MARKER.tmp"
+mv "$READY_MARKER.tmp" "$READY_MARKER"
+
+echo "[talk-fixture] Talk provisioned: $(cat "$READY_MARKER")"


### PR DESCRIPTION
Adds the Dockerfile and provisioning script that the fixture build workflow
builds from.

The image pins an exact Nextcloud release and an exact Talk release and bakes
Talk in at build time, so the end-to-end lane starts a ready server instead of
installing and provisioning one per run.

Each pinned version is recorded twice — in the authoritative `FROM`/`ARG` and in
greppable comment tokens — so a bump that moves one and not the other is caught
before an image is published under a tag that would misdescribe its contents.

The health check deliberately requires both a provisioning marker and
`status.php` reporting the server installed. The marker alone survives a
container restart in the writable layer, so it would report ready against a
server that is not.

These sources sit on the default branch because the workflow that builds them is
dispatch-only from there, and it reads them out of the checkout.