### PR TITLE
fix: harden container fixtures and clear three deferred defects

### DIFF
--- a/src/osprey/cli/registry_cmd.py
+++ b/src/osprey/cli/registry_cmd.py
@@ -22,9 +22,10 @@ def display_registry_contents(verbose: bool = False):
         # Get registry (initialize if needed) - suppress initialization logs
         with quiet_logger(["registry", "CONFIG"]):
             registry = get_registry()
-            if not registry._initialized:
+            if not registry.get_stats()["initialized"]:
                 console.print("\n[dim]Initializing registry...[/dim]")
-                registry.initialize()
+            # Idempotent -- self-guards when already initialized.
+            registry.initialize()
 
         # Get registry stats
         stats = registry.get_stats()

--- a/src/osprey/services/ariel_search/cli_operations.py
+++ b/src/osprey/services/ariel_search/cli_operations.py
@@ -222,7 +222,7 @@ async def run_sync(
     async with service:
         scheduler = IngestionScheduler(config=sync_config, repository=service.repository)
         if progress:
-            source = sync_config.ingestion.source_url if sync_config.ingestion else "unknown"
+            source = sync_config.ingestion.source_url or "unknown"
             progress(f"Polling for new entries (source: {source})...")
 
         poll_result = await scheduler.poll_once(limit=limit)

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_hook_log.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_hook_log.py
@@ -36,9 +36,10 @@ def load_hook_config():
 def get_hook_input():
     """Read and return hook input JSON from stdin. Returns {} on failure."""
     try:
-        return json.load(sys.stdin)
+        parsed = json.load(sys.stdin)
     except (json.JSONDecodeError, ValueError):
         return {}
+    return parsed if isinstance(parsed, dict) else {}
 
 
 def get_project_dir(hook_input):

--- a/tests/_container_support.py
+++ b/tests/_container_support.py
@@ -1,0 +1,135 @@
+"""Shared helpers for testcontainers-backed tests.
+
+Several test packages (``tests/connectors/``, ``tests/services/ariel_search/``,
+``tests/e2e/``) spin up real containers and must degrade to a skip rather than
+an error when the host has no Docker engine. This module is the single home for
+the environment probes and start helpers they share.
+
+The leading underscore keeps the module out of pytest collection: ``python_files``
+matches ``test_*.py``/``*_test.py`` only, and a helper module that got collected
+would report its imports as test failures.
+
+Note on imports: ``docker`` is a ``dev``-extra dependency, so it is imported
+lazily inside the functions that need it. A module-scope import would turn a
+missing extra into a collection error for every test package that imports from
+here. ``requests`` is a base dependency and is safe at module scope.
+"""
+
+import logging
+import time
+from collections.abc import Callable
+from contextlib import suppress
+from typing import TypeVar
+
+import pytest
+import requests
+
+logger = logging.getLogger(__name__)
+
+ContainerT = TypeVar("ContainerT")
+
+
+def is_docker_available() -> bool:
+    """Return True if the Docker daemon is reachable.
+
+    Used to gate testcontainers-backed fixtures so that contributors
+    without a running Docker engine see a skip rather than an error.
+    """
+    try:
+        import docker
+
+        client = docker.from_env()
+        client.ping()
+        return True
+    except Exception as e:
+        logger.warning(f"Docker not available: {e}")
+        return False
+
+
+def stop_quietly(container: object) -> None:
+    """Stop a container, swallowing teardown errors.
+
+    ``stop()`` calls ``remove(force=True)``, which raises ``NotFound`` when the
+    container is already gone — the same case testcontainers' own reaper
+    suppresses. Letting that escape turns a clean run into an ERROR at teardown.
+
+    Used both to discard a container built by a failed start attempt and as the
+    teardown for fixtures that own one.
+    """
+    with suppress(Exception):
+        container.stop()  # type: ignore[attr-defined]
+
+
+def start_or_skip(
+    factory: Callable[[], ContainerT],
+    label: str,
+    *,
+    backoff: float = 3.0,
+) -> ContainerT:
+    """Start a container built by ``factory``, skipping the test on failure.
+
+    ``factory`` must *build and return a new container object* on every call.
+    A retry always builds a fresh one: ``DockerContainer.start()`` assigns
+    ``self._container`` before the readiness wait, so reusing the object after a
+    timeout would orphan the container started by the first attempt.
+
+    The ``except`` chain is ordered, not a tuple, and the order is load-bearing
+    because ``ImageNotFound ⊂ NotFound ⊂ APIError ⊂ RequestException``:
+
+    * ``docker.errors.NotFound`` — a missing image or resource. Not transient,
+      so skip immediately; a second 120s readiness wait cannot help.
+    * ``requests.exceptions.RequestException`` — a flaky daemon or registry
+      call. Retried once after ``backoff`` seconds.
+    * ``Exception`` — anything else, notably ``TimeoutError``. Skip immediately.
+
+    ``backoff`` is keyword-only so tests can pass ``backoff=0`` instead of
+    paying real wall clock for the retry sleep.
+
+    Args:
+        factory: Zero-argument callable returning a fresh, unstarted container.
+        label: Human-readable name for the container, used in skip messages.
+        backoff: Seconds to wait before the single retry.
+
+    Returns:
+        The started container.
+
+    Raises:
+        Skipped: Via ``pytest.skip`` when the container cannot be started.
+    """
+    import docker.errors
+
+    max_attempts = 2
+    for attempt in range(1, max_attempts + 1):
+        container = factory()
+        try:
+            container.start()  # type: ignore[attr-defined]
+            return container
+        except docker.errors.NotFound as exc:
+            stop_quietly(container)
+            pytest.skip(_skip_message(label, exc, attempt))
+        except requests.exceptions.RequestException as exc:
+            stop_quietly(container)
+            if attempt == max_attempts:
+                pytest.skip(_skip_message(label, exc, attempt))
+            logger.warning(
+                f"{label}: start attempt {attempt} failed "
+                f"({type(exc).__name__}: {exc}); retrying in {backoff}s"
+            )
+            time.sleep(backoff)
+        except Exception as exc:
+            stop_quietly(container)
+            pytest.skip(_skip_message(label, exc, attempt))
+
+    raise AssertionError("unreachable: retry loop always skips or returns")
+
+
+def _skip_message(label: str, exc: BaseException, attempt: int) -> str:
+    """Build a skip message naming the container, attempt count, and cause.
+
+    The exception type *is* the diagnosis, so it is reported verbatim rather
+    than mapped onto a bucket taxonomy.
+    """
+    return (
+        f"{label}: container failed to start after {attempt} attempt(s) — "
+        f"{type(exc).__name__}: {exc}"
+    )

--- a/tests/cli/test_registry_cmd.py
+++ b/tests/cli/test_registry_cmd.py
@@ -16,6 +16,11 @@ from osprey.cli.registry_cmd import (
 )
 
 
+def _printed_text(mock_console) -> str:
+    """Join every positional argument passed to a patched ``console.print``."""
+    return " ".join(str(call.args[0]) for call in mock_console.print.call_args_list if call.args)
+
+
 @pytest.fixture
 def mock_registry():
     """Create a mock registry with test data."""
@@ -23,6 +28,7 @@ def mock_registry():
 
     # Mock stats
     registry.get_stats.return_value = {
+        "initialized": True,
         "services": 1,
         "service_names": ["test_service"],
     }
@@ -34,8 +40,6 @@ def mock_registry():
     registry.list_providers.return_value = ["test_provider"]
     registry.get_provider.return_value = MagicMock(description="Test AI provider")
 
-    registry._initialized = True
-
     return registry
 
 
@@ -46,28 +50,34 @@ class TestDisplayRegistryContents:
         """Test displaying registry contents when registry is already initialized."""
         with patch("osprey.cli.registry_cmd.get_registry") as mock_get_registry:
             with patch("osprey.utils.log_filter.quiet_logger"):
-                mock_get_registry.return_value = mock_registry
+                with patch("osprey.cli.registry_cmd.console") as mock_console:
+                    mock_get_registry.return_value = mock_registry
 
-                result = display_registry_contents(verbose=False)
+                    result = display_registry_contents(verbose=False)
 
-                # Should succeed
-                assert result is True
-                # Should get stats
-                assert mock_registry.get_stats.called
+                    # Should succeed
+                    assert result is True
+                    # Should get stats
+                    assert mock_registry.get_stats.called
+                    # Already initialized -- no progress notice
+                    assert "Initializing registry" not in _printed_text(mock_console)
 
     def test_initializes_registry_if_not_initialized(self, mock_registry):
         """Test that uninitialized registry gets initialized."""
-        mock_registry._initialized = False
+        mock_registry.get_stats.return_value["initialized"] = False
 
         with patch("osprey.cli.registry_cmd.get_registry") as mock_get_registry:
             with patch("osprey.utils.log_filter.quiet_logger"):
-                mock_get_registry.return_value = mock_registry
+                with patch("osprey.cli.registry_cmd.console") as mock_console:
+                    mock_get_registry.return_value = mock_registry
 
-                result = display_registry_contents(verbose=False)
+                    result = display_registry_contents(verbose=False)
 
-                # Should initialize registry
-                assert mock_registry.initialize.called
-                assert result is True
+                    # Should initialize registry
+                    assert mock_registry.initialize.called
+                    assert result is True
+                    # Cold run announces the load, which is otherwise silent
+                    assert "Initializing registry" in _printed_text(mock_console)
 
     def test_handles_exceptions_gracefully(self):
         """Test that exceptions are handled gracefully."""

--- a/tests/connectors/conftest.py
+++ b/tests/connectors/conftest.py
@@ -8,29 +8,11 @@ skip cleanly when Docker is unavailable, matching the pattern used by
 ``tests/services/ariel_search/conftest.py``.
 """
 
-import logging
 from datetime import datetime, timedelta
 
 import pytest
 
-logger = logging.getLogger(__name__)
-
-
-def is_docker_available() -> bool:
-    """Return True if the Docker daemon is reachable.
-
-    Used to gate testcontainers-backed fixtures so that contributors
-    without a running Docker engine see a skip rather than an error.
-    """
-    try:
-        import docker
-
-        client = docker.from_env()
-        client.ping()
-        return True
-    except Exception as e:
-        logger.warning(f"Docker not available: {e}")
-        return False
+from tests._container_support import is_docker_available, start_or_skip, stop_quietly
 
 
 @pytest.fixture(scope="session")
@@ -58,25 +40,26 @@ def mongodb_container():
     collection_name = "test_archiver_collection"
     auth_db = "admin"
 
-    container = MongoDbContainer("mongo:7", username=username, password=password)
-    container.start()
-
-    import atexit
-
-    atexit.register(container.stop)
+    container = start_or_skip(
+        lambda: MongoDbContainer("mongo:7", username=username, password=password),
+        label="mongodb",
+    )
 
     host = container.get_container_host_ip()
     port = int(container.get_exposed_port(27017))
 
-    yield {
-        "host": host,
-        "port": port,
-        "username": username,
-        "password": password,
-        "auth_db": auth_db,
-        "db_name": db_name,
-        "collection_name": collection_name,
-    }
+    try:
+        yield {
+            "host": host,
+            "port": port,
+            "username": username,
+            "password": password,
+            "auth_db": auth_db,
+            "db_name": db_name,
+            "collection_name": collection_name,
+        }
+    finally:
+        stop_quietly(container)
 
 
 @pytest.fixture(scope="function")

--- a/tests/e2e/test_ariel_search.py
+++ b/tests/e2e/test_ariel_search.py
@@ -9,13 +9,14 @@ Run with:
 
 from __future__ import annotations
 
-import atexit
 import logging
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
+
+from tests._container_support import is_docker_available, start_or_skip, stop_quietly
 
 if TYPE_CHECKING:
     from osprey.services.ariel_search.config import ARIELConfig
@@ -74,31 +75,24 @@ def is_dev_database_available() -> tuple[bool, str]:
     return False, ""
 
 
-def is_docker_available() -> bool:
-    """Check if Docker is available for testcontainers."""
-    try:
-        import docker
-
-        client = docker.from_env()
-        client.ping()
-        return True
-    except Exception:
-        return False
-
-
 # =============================================================================
 # Module-scoped fixtures for E2E tests
 # =============================================================================
 
 
 @pytest.fixture(scope="module")
-def e2e_database_url() -> str:
+def e2e_database_url(request: pytest.FixtureRequest) -> str:
     """Get database connection URL for e2e tests.
 
     Tries:
     1. ARIEL_TEST_DATABASE_URL environment variable
     2. Existing docker-compose dev database
     3. Testcontainers
+
+    Only the testcontainers branch owns a container, so teardown is registered
+    with ``request.addfinalizer`` on that branch alone. A ``yield`` would turn
+    all three exits into generator paths and make the two that return an
+    externally managed URL fail with "did not yield a value".
     """
     # Check env var
     env_url = os.environ.get("ARIEL_TEST_DATABASE_URL")
@@ -119,14 +113,17 @@ def e2e_database_url() -> str:
     logger.info("Starting testcontainers PostgreSQL for e2e tests")
     from testcontainers.postgres import PostgresContainer
 
-    container = PostgresContainer(
-        image="ankane/pgvector:latest",
-        username="ariel",
-        password="ariel",
-        dbname="ariel_e2e_test",
+    container = start_or_skip(
+        lambda: PostgresContainer(
+            image="ankane/pgvector:latest",
+            username="ariel",
+            password="ariel",
+            dbname="ariel_e2e_test",
+        ),
+        label="ariel-e2e-postgres",
     )
-    container.start()
-    atexit.register(container.stop)
+
+    request.addfinalizer(lambda: stop_quietly(container))
 
     url = container.get_connection_url()
     if url.startswith("postgresql+psycopg2://"):

--- a/tests/hooks/test_approval_hook.py
+++ b/tests/hooks/test_approval_hook.py
@@ -975,13 +975,19 @@ def test_fallback_pattern_parity_with_framework(hook_module):
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("stdin", ["", "{nope", "[]"], ids=["empty", "invalid-json", "wrong-shape"])
+@pytest.mark.parametrize(
+    "stdin",
+    ["", "{nope", "[]", "[1,2,3]"],
+    ids=["empty", "invalid-json", "wrong-shape", "wrong-shape-truthy"],
+)
 def test_malformed_stdin_fails_open(tmp_path, hook_runner_raw, stdin):
     """Unusable stdin passes the tool through without asking for approval.
 
-    A closed pipe, a truncated write and a non-object payload each leave the
-    hook with no tool to gate, so it exits 0 and emits no decision. Emitting an
-    "ask" here would stall every tool call behind a prompt nobody can answer.
+    A closed pipe, a truncated write and a non-object payload — falsy (``[]``)
+    or truthy (``[1,2,3]``) — each leave the hook with no tool to gate, so it
+    exits 0 and emits no decision. Emitting an "ask" here would stall every
+    tool call behind a prompt nobody can answer. The truthy payload is the one
+    an emptiness check lets through, so it has to be rejected on shape.
     """
     returncode, stdout, stderr = hook_runner_raw(
         "osprey_approval.py",

--- a/tests/hooks/test_error_guidance_hook.py
+++ b/tests/hooks/test_error_guidance_hook.py
@@ -563,13 +563,19 @@ def test_custom_server_prefix_triggers_guidance(hook_runner, make_config):
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("stdin", ["", "{nope", "[]"], ids=["empty", "invalid-json", "wrong-shape"])
+@pytest.mark.parametrize(
+    "stdin",
+    ["", "{nope", "[]", "[1,2,3]"],
+    ids=["empty", "invalid-json", "wrong-shape", "wrong-shape-truthy"],
+)
 def test_malformed_stdin_fails_open(tmp_path, hook_runner_raw, stdin):
     """Unusable stdin injects nothing instead of crashing the tool call.
 
-    A closed pipe, a truncated write and a non-object payload carry no tool
-    response to inspect. A PostToolUse hook that exited non-zero here would
-    surface as a failure on a tool call that already succeeded.
+    A closed pipe, a truncated write and a non-object payload — falsy (``[]``)
+    or truthy (``[1,2,3]``) — carry no tool response to inspect. A PostToolUse
+    hook that exited non-zero here would surface as a failure on a tool call
+    that already succeeded. The truthy payload is the one an emptiness check
+    lets through, so it has to be rejected on shape.
     """
     returncode, stdout, stderr = hook_runner_raw(
         "osprey_error_guidance.py",

--- a/tests/hooks/test_feedback_capture_hook.py
+++ b/tests/hooks/test_feedback_capture_hook.py
@@ -285,13 +285,19 @@ class TestFeedbackCaptureNoTotal:
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("stdin", ["", "{nope", "[]"], ids=["empty", "invalid-json", "wrong-shape"])
+@pytest.mark.parametrize(
+    "stdin",
+    ["", "{nope", "[]", "[1,2,3]"],
+    ids=["empty", "invalid-json", "wrong-shape", "wrong-shape-truthy"],
+)
 def test_malformed_stdin_fails_open(tmp_path, hook_runner_raw, stdin):
     """Unusable stdin captures nothing and leaves the tool call untouched.
 
-    A closed pipe, a truncated write and a non-object payload give the hook no
-    channel finder result to store, so it exits 0 without writing a pending
-    review or a decision envelope.
+    A closed pipe, a truncated write and a non-object payload — falsy (``[]``)
+    or truthy (``[1,2,3]``) — give the hook no channel finder result to store,
+    so it exits 0 without writing a pending review or a decision envelope. The
+    truthy payload is the one an emptiness check lets through, so it has to be
+    rejected on shape.
     """
     returncode, stdout, stderr = hook_runner_raw(
         "osprey_cf_feedback_capture.py",

--- a/tests/hooks/test_limits_hook.py
+++ b/tests/hooks/test_limits_hook.py
@@ -307,13 +307,19 @@ def test_step_size_blocks_when_current_value_unreadable(tmp_path, hook_runner):
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("stdin", ["", "{nope", "[]"], ids=["empty", "invalid-json", "wrong-shape"])
+@pytest.mark.parametrize(
+    "stdin",
+    ["", "{nope", "[]", "[1,2,3]"],
+    ids=["empty", "invalid-json", "wrong-shape", "wrong-shape-truthy"],
+)
 def test_malformed_stdin_fails_open(tmp_path, hook_runner_raw, stdin):
     """Unusable stdin allows the write through rather than denying it.
 
     Limits validation is fail-closed once it has a channel and a value, but it
     never gets that far here: a closed pipe, a truncated write or a non-object
-    payload leaves nothing to validate, so the hook exits 0 with no decision.
+    payload — falsy (``[]``) or truthy (``[1,2,3]``) — leaves nothing to
+    validate, so the hook exits 0 with no decision. The truthy payload is the
+    one an emptiness check lets through, so it has to be rejected on shape.
     """
     returncode, stdout, stderr = hook_runner_raw(
         "osprey_limits.py",

--- a/tests/hooks/test_memory_guard_hook.py
+++ b/tests/hooks/test_memory_guard_hook.py
@@ -326,14 +326,20 @@ def test_uses_claude_project_dir_env(tmp_path, hook_runner, memory_dir_for, monk
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("stdin", ["", "{nope", "[]"], ids=["empty", "invalid-json", "wrong-shape"])
+@pytest.mark.parametrize(
+    "stdin",
+    ["", "{nope", "[]", "[1,2,3]"],
+    ids=["empty", "invalid-json", "wrong-shape", "wrong-shape-truthy"],
+)
 def test_malformed_stdin_fails_open(tmp_path, hook_runner_raw, stdin):
     """Unusable stdin yields no opinion — not a deny.
 
     The guard denies writes it can see and does not recognise, but a closed
-    pipe, a truncated write or a non-object payload names no tool at all. With
-    no ``tool_name`` to match, the hook exits 0 silently and Write is left to
-    the rest of the permission chain.
+    pipe, a truncated write, or a non-object payload — falsy (``[]``) or
+    truthy (``[1,2,3]``) — names no tool at all. With no ``tool_name`` to
+    match, the hook exits 0 silently and Write is left to the rest of the
+    permission chain. The truthy payload is the one that slips past an
+    emptiness check, so it has to be rejected on shape.
     """
     returncode, stdout, stderr = hook_runner_raw(
         "osprey_memory_guard.py",

--- a/tests/hooks/test_notebook_update_hook.py
+++ b/tests/hooks/test_notebook_update_hook.py
@@ -171,13 +171,19 @@ def test_notebook_update_swallows_unlink_failure(tmp_path, run_notebook_update_h
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("stdin", ["", "{nope", "[]"], ids=["empty", "invalid-json", "wrong-shape"])
+@pytest.mark.parametrize(
+    "stdin",
+    ["", "{nope", "[]", "[1,2,3]"],
+    ids=["empty", "invalid-json", "wrong-shape", "wrong-shape-truthy"],
+)
 def test_malformed_stdin_fails_open(tmp_path, hook_runner_raw, stdin):
     """Unusable stdin leaves the tree alone and the tool call intact.
 
-    A closed pipe, a truncated write and a non-object payload name no
-    notebook, so there is no cache entry to invalidate: exit 0, nothing on
-    stdout, and not a byte changed under the project directory.
+    A closed pipe, a truncated write and a non-object payload — falsy (``[]``)
+    or truthy (``[1,2,3]``) — name no notebook, so there is no cache entry to
+    invalidate: exit 0, nothing on stdout, and not a byte changed under the
+    project directory. The truthy payload is the one an emptiness check lets
+    through, so it has to be rejected on shape.
     """
     before = snapshot(tmp_path)
 

--- a/tests/hooks/test_osprey_hook_log.py
+++ b/tests/hooks/test_osprey_hook_log.py
@@ -88,6 +88,25 @@ def test_get_hook_input_malformed_stdin_returns_empty(monkeypatch):
     assert hook_log.get_hook_input() == {}
 
 
+@pytest.mark.parametrize("payload", ["[1, 2, 3]", '"str"', "42", "true"])
+def test_get_hook_input_truthy_non_dict_returns_empty(payload, monkeypatch):
+    """Valid JSON that parses to a truthy non-dict must still yield {}.
+
+    Consumers gate on ``if not hook_input`` and then call ``.get()``. A truthy
+    non-dict clears that gate and would raise ``AttributeError``, exiting
+    non-zero — which makes fail-open PreToolUse hooks block the tool call.
+    """
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    assert hook_log.get_hook_input() == {}
+
+
+@pytest.mark.parametrize("payload", ["[]", "0"])
+def test_get_hook_input_falsy_non_dict_returns_empty(payload, monkeypatch):
+    """Falsy non-dicts already short-circuit in consumers; pin them anyway."""
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    assert hook_log.get_hook_input() == {}
+
+
 # ---------------------------------------------------------------------------
 # get_project_dir
 # ---------------------------------------------------------------------------

--- a/tests/hooks/test_writes_check_hook.py
+++ b/tests/hooks/test_writes_check_hook.py
@@ -254,14 +254,20 @@ def test_fallback_defaults_when_no_hook_config(tmp_path, hook_runner, make_confi
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("stdin", ["", "{nope", "[]"], ids=["empty", "invalid-json", "wrong-shape"])
+@pytest.mark.parametrize(
+    "stdin",
+    ["", "{nope", "[]", "[1,2,3]"],
+    ids=["empty", "invalid-json", "wrong-shape", "wrong-shape-truthy"],
+)
 def test_malformed_stdin_fails_open(tmp_path, hook_runner_raw, stdin):
     """Stdin the hook cannot use lets the tool through instead of blocking it.
 
-    The three shapes are a closed pipe, a truncated write, and a payload whose
-    JSON is valid but is not the expected object. A PreToolUse hook fails open
-    by exiting 0 and printing no decision — anything else would turn a bad
-    payload into a denied tool call.
+    The four shapes are a closed pipe, a truncated write, and two payloads
+    whose JSON is valid but is not the expected object — one falsy (``[]``)
+    and one truthy (``[1,2,3]``). The truthy one is the sharper case: it
+    survives an emptiness check, so only a shape check keeps it out. A
+    PreToolUse hook fails open by exiting 0 and printing no decision —
+    anything else would turn a bad payload into a denied tool call.
     """
     returncode, stdout, stderr = hook_runner_raw(
         "osprey_writes_check.py",

--- a/tests/services/ariel_search/conftest.py
+++ b/tests/services/ariel_search/conftest.py
@@ -25,6 +25,7 @@ from osprey.services.ariel_search.enhancement.semantic_processor.processor impor
 from osprey.services.ariel_search.enhancement.text_embedding.embedder import (
     TextEmbeddingModule,
 )
+from tests._container_support import is_docker_available, start_or_skip, stop_quietly
 
 if TYPE_CHECKING:
     from osprey.services.ariel_search.config import ARIELConfig
@@ -206,37 +207,29 @@ def is_dev_database_available() -> tuple[bool, str]:
     return False, ""
 
 
-def is_docker_available() -> bool:
-    """Check if Docker is available for testcontainers.
-
-    Returns:
-        True if Docker daemon is running and accessible, False otherwise.
-    """
-    try:
-        import docker
-
-        client = docker.from_env()
-        client.ping()
-        logger.info("Docker is available for integration tests")
-        return True
-    except Exception as e:
-        logger.warning(f"Docker not available: {e}")
-        return False
-
-
 # ============================================================================
 # Integration test fixtures (require Docker)
 # ============================================================================
 
 
 @pytest.fixture(scope="session")
-def database_url() -> str:
+def database_url(request: pytest.FixtureRequest) -> str:
     """Get database connection URL for tests.
 
     Tries in order:
     1. ARIEL_TEST_DATABASE_URL environment variable
     2. Existing docker-compose dev database (ariel-dev-db on port 5433)
     3. Testcontainers (spins up fresh container)
+
+    Deliberately a plain (non-generator) fixture: only the third exit owns a
+    container, while the first two return a URL to a database this fixture did
+    not create. A ``yield`` would make *all three* paths generator paths, so the
+    two resource-free exits would raise "did not yield a value". Container
+    teardown is registered with ``request.addfinalizer`` instead, which runs at
+    session teardown exactly as a ``finally`` would.
+
+    Args:
+        request: Fixture request, used to register container teardown.
 
     Returns:
         PostgreSQL connection URL
@@ -264,21 +257,23 @@ def database_url() -> str:
         )
 
     logger.info("Starting testcontainers PostgreSQL (dev database not running)")
-    from testcontainers.postgres import PostgresContainer
+    try:
+        from testcontainers.postgres import PostgresContainer
+    except ImportError:
+        pytest.skip("testcontainers[postgres] not installed")
 
     # Use pgvector image for vector search support
-    container = PostgresContainer(
-        image="ankane/pgvector:latest",
-        username="ariel",
-        password="ariel",
-        dbname="ariel_test",
+    container = start_or_skip(
+        lambda: PostgresContainer(
+            image="ankane/pgvector:latest",
+            username="ariel",
+            password="ariel",
+            dbname="ariel_test",
+        ),
+        label="postgres",
     )
-    container.start()
 
-    # Register cleanup
-    import atexit
-
-    atexit.register(container.stop)
+    request.addfinalizer(lambda: stop_quietly(container))
 
     url = container.get_connection_url()
     # Convert psycopg2 format to psycopg (v3) format

--- a/tests/services/ariel_search/test_cli_operations_pipeline.py
+++ b/tests/services/ariel_search/test_cli_operations_pipeline.py
@@ -253,9 +253,7 @@ class TestRunSync:
         # Step 3 short-circuits when nothing is enabled.
         assert "No enhancement modules enabled or selected" in messages
 
-    async def test_unset_source_url_is_reported_verbatim(
-        self, monkeypatch, mock_repository, fake_pool
-    ):
+    async def test_unset_source_url_reports_unknown(self, monkeypatch, mock_repository, fake_pool):
         _patch_pool(monkeypatch, fake_pool)
         _patch_migrations(monkeypatch, applied=[])
         _patch_scheduler(monkeypatch, _poll_result())
@@ -265,11 +263,7 @@ class TestRunSync:
         messages: list[str] = []
         await ops.run_sync(_config(adapter="generic_json"), progress=messages.append)
 
-        # The "unknown" fallback in the progress line is unreachable: the
-        # deep-copied dict always gains an ``ingestion`` block, so
-        # ``sync_config.ingestion`` is an always-truthy dataclass and an unset
-        # ``source_url`` prints as None.
-        assert "Polling for new entries (source: None)..." in messages
+        assert "Polling for new entries (source: unknown)..." in messages
 
     async def test_runs_silently_without_a_progress_callback(
         self, monkeypatch, mock_repository, fake_pool

--- a/tests/test_container_support.py
+++ b/tests/test_container_support.py
@@ -1,0 +1,135 @@
+"""Unit tests for the shared testcontainers helpers.
+
+These drive ``start_or_skip`` with fake factories — no Docker engine, no
+containers, no network — so they run in the plain unit lane.
+
+Every skip case is asserted inside ``pytest.raises(pytest.skip.Exception)``.
+A test that merely *calls* code raising ``Skipped`` reports SKIPPED with exit 0
+and executes none of its assertions: it looks green while proving nothing.
+"""
+
+import pytest
+import requests
+
+from tests._container_support import start_or_skip
+
+# ``docker`` is a ``dev``-extra dependency. Importing it at module scope would
+# make this file ERROR at collection wherever the extra is absent — the very
+# outcome ``_container_support`` keeps its own ``docker`` import lazy to avoid.
+# ``importorskip`` degrades to a clean skip instead. The real exception class is
+# used deliberately rather than a stand-in: the ordered ``except`` chain is only
+# meaningful against the genuine ``ImageNotFound ⊂ NotFound ⊂ APIError ⊂
+# RequestException`` hierarchy, which a fake could not reproduce.
+docker_errors = pytest.importorskip("docker.errors")
+
+
+class FakeContainer:
+    """Minimal stand-in for a testcontainers container object.
+
+    ``start`` raises the next error queued for it, or succeeds. ``stop`` records
+    the call so tests can assert that failed attempts are cleaned up.
+    """
+
+    def __init__(self, error: BaseException | None):
+        self.error = error
+        self.started = False
+        self.stop_calls = 0
+
+    def start(self):
+        self.started = True
+        if self.error is not None:
+            raise self.error
+        return self
+
+    def stop(self):
+        self.stop_calls += 1
+
+
+class RecordingFactory:
+    """Zero-arg factory yielding a fresh ``FakeContainer`` per call.
+
+    Mirrors the contract ``start_or_skip`` relies on: a retry must build a new
+    container rather than restart the previous object.
+    """
+
+    def __init__(self, *errors: BaseException | None):
+        self.errors = list(errors)
+        self.containers: list[FakeContainer] = []
+
+    def __call__(self) -> FakeContainer:
+        error = self.errors[len(self.containers)]
+        container = FakeContainer(error)
+        self.containers.append(container)
+        return container
+
+    @property
+    def call_count(self) -> int:
+        return len(self.containers)
+
+    @property
+    def stop_calls(self) -> int:
+        return sum(c.stop_calls for c in self.containers)
+
+
+def test_retryable_failure_twice_skips_after_two_attempts():
+    """Two consecutive transport errors exhaust the single retry and skip."""
+    exc = requests.exceptions.RequestException("connection reset by peer")
+    factory = RecordingFactory(exc, requests.exceptions.RequestException("still down"))
+
+    with pytest.raises(pytest.skip.Exception) as ei:
+        start_or_skip(factory, label="flaky-db", backoff=0)
+
+    assert "flaky-db" in ei.value.msg
+    assert "RequestException" in ei.value.msg
+    assert "still down" in ei.value.msg
+    assert factory.call_count == 2
+    assert factory.stop_calls == 2
+    # A retry must not restart the first object — each attempt gets its own.
+    assert factory.containers[0] is not factory.containers[1]
+
+
+def test_retryable_failure_then_success_returns_second_container():
+    """The retry returns the freshly built container, not the failed one."""
+    factory = RecordingFactory(requests.exceptions.ConnectionError("daemon busy"), None)
+
+    container = start_or_skip(factory, label="flaky-db", backoff=0)
+
+    assert container is factory.containers[1]
+    assert factory.call_count == 2
+    # Only the failed first attempt is torn down.
+    assert factory.containers[0].stop_calls == 1
+    assert factory.containers[1].stop_calls == 0
+    assert factory.stop_calls == 1
+
+
+def test_timeout_skips_without_retry():
+    """A readiness timeout is not transient — no second 120s wait."""
+    factory = RecordingFactory(TimeoutError("container did not become ready"))
+
+    with pytest.raises(pytest.skip.Exception) as ei:
+        start_or_skip(factory, label="slow-db", backoff=0)
+
+    assert "slow-db" in ei.value.msg
+    assert "TimeoutError" in ei.value.msg
+    assert "container did not become ready" in ei.value.msg
+    assert factory.call_count == 1
+    assert factory.stop_calls == 1
+
+
+def test_image_not_found_skips_without_retry():
+    """``ImageNotFound`` is a ``RequestException`` subclass and must not retry.
+
+    This is the case that proves the ordered ``except`` chain: a tuple-based
+    implementation would pull a missing image into the retry arm and pay a
+    second full readiness wait for an error that can never clear.
+    """
+    factory = RecordingFactory(docker_errors.ImageNotFound("no such image: nope:1"))
+
+    with pytest.raises(pytest.skip.Exception) as ei:
+        start_or_skip(factory, label="missing-image-db", backoff=0)
+
+    assert "missing-image-db" in ei.value.msg
+    assert "ImageNotFound" in ei.value.msg
+    assert "no such image: nope:1" in ei.value.msg
+    assert factory.call_count == 1
+    assert factory.stop_calls == 1

--- a/tests/va/conftest.py
+++ b/tests/va/conftest.py
@@ -30,10 +30,11 @@ import sys
 # imports ``softioc.builder`` too, so it needs the same treatment -- but it must
 # exit with pytest's *real* status so genuine failures still fail CI.
 #
-# This runs from an ``atexit`` hook registered at import time.  atexit fires
-# last-registered-first, so cleanup hooks other suites register during the run
-# (e.g. ``atexit.register(container.stop)``) still run first; we then ``os._exit``
-# before the crashing C++ static destructors, skipping only them.
+# This runs from an ``atexit`` hook registered at import time.  pytest's own
+# fixture teardown has already completed by then, and atexit fires
+# last-registered-first, so any interpreter-exit handlers other suites register
+# during the run still get to run; we then ``os._exit`` before the crashing C++
+# static destructors, skipping only them.
 
 _PYTEST_EXIT_CODE: int | None = None
 


### PR DESCRIPTION
## Summary

The closing phase of the `refactor-follow-ups` epic. It does two things: hardens the three
testcontainer fixtures so they can never ERROR, and clears the three deferred defects from earlier
phases that had an obvious correct answer.

The framing constraint is that `ci.yml` triggers on `pull_request: branches: [main]` only, so the
`epic/refactor-follow-ups` → `main` PR is the **first** time the tests, docker, and e2e lanes run on
any of this epic's work. Everything here is small and individually test-covered, and nothing touches
the channel-lookup critical path. Three of the five items are deliberate behaviour changes, not
mechanical edits — describing them otherwise would misstate what is shipping.

## Container fixtures

Three fixtures started containers: `mongodb_container` (`tests/connectors/conftest.py`),
the `PostgresContainer` fallback in `database_url` (`tests/services/ariel_search/conftest.py`), and
`e2e_database_url` (`tests/e2e/test_ariel_search.py`). All three carried their own copy of
`is_docker_available()` — four copies in total, counting `tests/va/conftest.py` — and all three
registered cleanup through `atexit` rather than owning it.

Both properties are now fixed by a new `tests/_container_support.py` exporting
`is_docker_available()` and `start_or_skip(factory, label, *, backoff=3.0)`:

- **A fresh container per attempt.** `DockerContainer.start()` assigns `self._container` *before* the
  readiness wait, so retrying on the same object orphans the first container. `start_or_skip` takes a
  factory and builds a new one each attempt, stopping each failed attempt under
  `contextlib.suppress`.
- **An ordered `except` chain, not a tuple.** `ImageNotFound` ⊂ `NotFound` ⊂ `APIError` ⊂
  `RequestException`, so a tuple would retry precisely the case that must skip. The order is
  `docker.errors.NotFound` → skip, `requests.exceptions.RequestException` → retry once after
  `backoff`, `Exception` → skip. That last arm is where `TimeoutError` lands, and a second 120s
  readiness wait cannot help it. The skip message carries `type(exc).__name__` and `str(exc)`; there
  is no bucket taxonomy.
- **`docker.errors` is imported lazily inside the function.** A module-scope import would turn a
  missing dev extra into a collection ERROR across two directories. `requests` is a base dependency
  and is imported at module scope.

Teardown is now fixture-owned and non-raising. `stop()` calls `remove(force=True)`, which raises
`NotFound` when the container is already gone — testcontainers' own reaper suppresses exactly this,
and an unsuppressed raise is an `ERROR at teardown`, the outcome this phase exists to eliminate.
Under `atexit` that failure was merely invisible, not absent.

Each fixture keeps its existing control flow rather than being converted:

| Fixture | Shape | Teardown |
|---|---|---|
| `mongodb_container` | single-exit generator | `try: yield … finally:` suppressed `stop()` |
| `database_url` | plain `return`, three exits | `request.addfinalizer()` on the container branch |
| `e2e_database_url` | plain `return`, three exits | `request.addfinalizer()` on the container branch |

Using finalizers on the two plain-`return` fixtures is what keeps the `did not yield a value`
failure mode — which would error nine dependent files — structurally impossible. `database_url` also
gains the `ImportError` guard for the `[postgres]` extra that it was missing, so both hardened
fixtures now carry two distinct skips: one for the daemon, one for the optional extra.

`tests/va/conftest.py` cited `atexit.register(container.stop)` as a live example of a hook its
`os._exit` runs before. That parenthetical is now stale, and is updated.

## Hook stdin guard

`get_hook_input()` in `osprey_hook_log.py` guarded the JSON *parse*, not the resulting *shape*. Falsy
non-dict payloads were already safe — every consumer runs `if not hook_input: <fail open>` before
`.get()`, so `[]` and `0` short-circuit. **Truthy** non-dict payloads did not: `[1,2,3]`, `"str"`,
`42` and `true` passed that check and then raised `AttributeError` on `.get()`, exiting non-zero.

In the four PreToolUse hooks — `osprey_writes_check`, `osprey_memory_guard`, `osprey_approval`,
`osprey_limits` — a non-zero exit **blocks the tool call**. So a malformed-but-valid stdin payload
could block an agent's tool call through hooks that are meant to fail open. The guard returns `{}`
for any non-dict parse, which makes the docstring's existing "Returns {} on failure" true.

Coverage is direct unit tests in `tests/hooks/test_osprey_hook_log.py`, plus a parametrize case and a
matching docstring correction in each of the seven test files whose hook imports `get_hook_input`.
`tests/hooks/test_osprey_panels_context.py` and `test_config_drift_hook.py` carry a byte-identical
`test_malformed_stdin_fails_open` but neither hook imports `get_hook_input`, so they are deliberately
untouched — adding them would touch two more files for two cases that cannot fail.

## Two defect fixes

**`registry_cmd.py` no longer reaches through `RegistryManager._initialized`.** The message is now
gated on `registry.get_stats()["initialized"]` and `initialize()` is called unconditionally, since it
self-guards. `get_stats()` is already called a few lines below, so this adds no API surface. The
"Initializing registry..." message is kept deliberately: it fires exactly when work is about to
happen, and `initialize()`'s own `logger.info` is suppressed by the enclosing
`quiet_logger(["registry", "CONFIG"])`, making it the only user feedback on a cold run.

**`run_sync` reports an unset `source_url` as `unknown`.** The old guard tested
`sync_config.ingestion`, which cannot be falsy — line 218's `setdefault` creates the `ingestion` key
one line before line 225 reads it — so an unset `source_url` printed `(source: None)`. The guard now
tests the value. The `None` check on `ingestion` is omitted on purpose rather than kept as
belt-and-braces, for the reason just given.

The test that pinned this bug asserted `(source: None)` under a four-line comment explaining that the
fallback was unreachable. It is renamed, the comment is deleted, and the assertion is flipped in the
same commit as the fix.

## Gate evidence

Full unit lane, run against the final post-polish tree:

```
uv run pytest tests/ --ignore=tests/e2e -n 4 --dist loadgroup
→ exit 0 — 12096 passed, 66 skipped, 1 xfailed
```

Helper unit tests are gated on `4 passed, 0 skipped`, not on a green exit code: each asserts inside
`pytest.raises(pytest.skip.Exception)`, because a test that merely *calls* a function raising
`Skipped` reports SKIPPED with exit 0 and executes no assertions.

**One honest caveat about the numbers.** The baseline at `bdb6462b` was not re-derived, so the
pass-count delta against phase 5's recorded 12,106 / 39 / 1 is **not** verified and should not be
quoted — the skip count in particular moves with Docker availability on the running host. What *is*
verified is the collection reconciliation: 12,145 → 12,162 collected, `+17`, decomposing exactly as
4 (helper) + 6 (hook unit) + 7 (consumer parametrize).

Also verified directly: `grep -rn "atexit"` returns nothing across the three rewired files;
`grep -rl "def is_docker_available" tests/` returns exactly one file; and
`grep -rn '\._initialized' src/ --include='*.py' | grep -v 'self\._initialized'` returns nothing,
against exactly one line at base.

## Deliberately out of scope

The four channel-finder issues surfaced by phase 5 are **not** here. Each is a small diff sitting
behind a real behaviour decision on the channel-lookup critical path, and one of them would require
rewriting the characterization tests phase 5 wrote to pin current behaviour. Editing
`src/osprey/services/channel_finder/` means this phase's scope has been left.
