### PR TITLE
feat(simulation): absolute noise and baseline texture for zero-baseline channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ Compatibility is documented in release notes, not encoded in the version string.
   DSN read the same value (previously both used the fixed `ariel` password).
   Existing Postgres volumes keep their original password — see the deploy
   how-to for the migration note.
+- Simulation machine files accept two optional per-channel keys: `noise_abs`, an
+  absolute Gaussian sigma in the channel's own units, and `texture`, slow
+  baseline motion declared as `{"kind": "wander", "amplitude": …, "period_s": …}`.
+  The existing `noise` key stays relative (a fraction of the value), so channels
+  that sit at zero can now be given movement. Machine files using neither key
+  parse and behave exactly as before.
 
 ### Changed
 
@@ -108,6 +114,22 @@ Compatibility is documented in release notes, not encoded in the version string.
   deploy/build semantics (`--force` preservation, `--dev` image builds, full
   subcommand list), telemetry now documented as on-by-default, MCP/executor error
   contracts, and the ARIEL web-interface module tables.
+- Simulated channels sitting at a `0.0` baseline no longer read back as dead-flat
+  constants. Relative `noise` is multiplicative, so it vanishes at zero and BPM
+  positions and corrector current readbacks declared noisy were perfectly still —
+  in live reads and in synthesized history alike. Mock and Virtual Accelerator
+  reads now put an absolute per-kind floor under the noise (a `noise_level` of
+  exactly `0.0` still means deterministic), machine files can declare `noise_abs`
+  and `texture`, and loading a machine file that declares relative noise on a zero
+  baseline now warns and names the affected channels.
+- Synthesized archiver history is pointwise deterministic: each sample's noise is
+  keyed to its channel and timestamp instead of drawn from a running stream, so
+  repeated, overlapping and time-shifted queries agree at shared timestamps.
+  Timestamps are keyed at millisecond resolution; windows whose timestamps are not
+  convertible to epoch seconds keep per-window determinism only.
+- The shipped control-assistant simulation data now produces organic BPM and
+  corrector-readback signals instead of flat lines, and corrector channels gained
+  the symmetric upper current limit their lower limit implied.
 
 ### Added
 

--- a/src/osprey/connectors/control_system/mock_connector.py
+++ b/src/osprey/connectors/control_system/mock_connector.py
@@ -135,9 +135,10 @@ class MockConnector(ControlSystemConnector):
         if channel_address not in self._state:
             self._state[channel_address] = self._generate_initial_value(channel_address)
 
-        # Add noise
+        # Add noise, floored per kind so a 0.0 baseline is not dead-flat.
         base_value = self._state[channel_address]
-        noise = np.random.normal(0, abs(base_value) * self._noise_level)
+        sigma = classify_pv(channel_address).noise_sigma(base_value, self._noise_level)
+        noise = np.random.normal(0, sigma)
         value = base_value + noise
 
         return ChannelValue(

--- a/src/osprey/connectors/pv_taxonomy.py
+++ b/src/osprey/connectors/pv_taxonomy.py
@@ -12,11 +12,29 @@ module is the single source of truth: :func:`classify_pv` returns a
 :class:`PVKind`, and each connector layers its own behaviour on top — the
 archiver shapes a time series per :attr:`PVKind.name`, the control connector
 seeds an initial value and reports units.
+
+The kind also carries :attr:`PVKind.noise_scale`, the absolute floor under the
+otherwise purely relative sigma, so a kind whose base value is legitimately
+``0.0`` is not silently dead-flat. :meth:`PVKind.noise_sigma` combines the two
+and is the single implementation both noise-applying fallbacks (the mock control
+connector and the Virtual Accelerator's engine source) call.
 """
 
 from dataclasses import dataclass
 
-__all__ = ["PVKind", "classify_pv"]
+__all__ = ["POSITION_NOISE_SCALE", "PVKind", "classify_pv"]
+
+POSITION_NOISE_SCALE = 0.005
+"""Absolute noise floor for the ``position`` kind, in mm.
+
+Roughly a BPM's single-shot resolution. Position is the one kind whose
+:attr:`PVKind.base_value` is legitimately ``0.0`` (a centred orbit), which makes
+the relative noise the fallback paths apply — ``abs(base) * noise_level`` —
+identically zero, so the channel reads back dead-flat however noisy it is
+declared to be. The floor is deliberately per-kind rather than global: base
+values span 1e-9 Torr to 5000 V, and any single absolute number would be
+overwhelming noise at one end of that range and invisible at the other.
+"""
 
 
 @dataclass(frozen=True)
@@ -27,11 +45,40 @@ class PVKind:
         name: Canonical kind, used by the archiver to pick a synthesis shape.
         base_value: Plausible steady-state value for the kind.
         units: Engineering units string (empty for the generic default).
+        noise_scale: Absolute lower bound on the kind's noise sigma, in the
+            kind's own units. Non-zero only for kinds whose ``base_value`` can
+            legitimately be ``0.0``; every other kind leaves it at ``0.0``, so
+            ``max(abs(base) * noise_level, noise_scale)`` is arithmetically
+            identical to the plain relative sigma there.
     """
 
     name: str
     base_value: float
     units: str
+    noise_scale: float = 0.0
+
+    def noise_sigma(self, base_value: float, noise_level: float) -> float:
+        """Sigma a noise-applying fallback should draw with for this kind.
+
+        The relative term ``abs(base_value) * noise_level`` is dead at a ``0.0``
+        base, so kinds whose base can legitimately be zero floor it with
+        :attr:`noise_scale`; every other kind's floor is ``0.0``, leaving the
+        sigma at the plain relative one. A ``noise_level`` of exactly ``0.0`` is
+        an explicit request for determinism, though, so it disables the floor
+        rather than being overridden by it.
+
+        Args:
+            base_value: The value the noise will be added to. Callers pass the
+                value they actually hold, which need not be :attr:`base_value`
+                (the mock control connector's may have been written to).
+            noise_level: Relative noise fraction.
+
+        Returns:
+            The sigma to draw with; ``0.0`` when ``noise_level`` is not positive.
+        """
+        if noise_level <= 0.0:
+            return 0.0
+        return max(abs(base_value) * noise_level, self.noise_scale)
 
 
 def classify_pv(pv_name: str) -> PVKind:
@@ -58,7 +105,7 @@ def classify_pv(pv_name: str) -> PVKind:
     if "lifetime" in lower:
         return PVKind("lifetime", 10.0, "hours")
     if "position" in lower or "pos" in lower:
-        return PVKind("position", 0.0, "mm")
+        return PVKind("position", 0.0, "mm", noise_scale=POSITION_NOISE_SCALE)
     if "energy" in lower:
         return PVKind("energy", 1900.0, "MeV")
     return PVKind("default", 100.0, "")

--- a/src/osprey/services/virtual_accelerator/ioc/engine_source.py
+++ b/src/osprey/services/virtual_accelerator/ioc/engine_source.py
@@ -36,7 +36,7 @@ from typing import Any
 
 import numpy as np
 
-from osprey.connectors.pv_taxonomy import classify_pv
+from osprey.connectors.pv_taxonomy import PVKind, classify_pv
 from osprey.services.virtual_accelerator.manifest import PARTITION_STATIC_NOISY, RECORD_TYPE_BINARY
 from osprey.simulation.engine import SimulationEngine, engine_serves
 
@@ -96,7 +96,8 @@ class EngineSource:
         self._records = dict(static_noisy_records)
         self._noise_level = noise_level
         self._rng = np.random.default_rng()
-        self._legacy_base: dict[str, float] = {}
+        # address -> PV taxonomy classification, memoised on first legacy read
+        self._legacy_kind: dict[str, PVKind] = {}
         self._setpoint_echo_records = {
             address: record
             for address, record in (setpoint_echo_records or {}).items()
@@ -223,14 +224,18 @@ class EngineSource:
 
     def _legacy_value(self, address: str) -> float | bool:
         record_type, noisy = self._channel_info.get(address, ("ai", False))
-        base = self._legacy_base.get(address)
-        if base is None:
-            base = classify_pv(address).base_value
-            self._legacy_base[address] = base
+        kind = self._legacy_kind.get(address)
+        if kind is None:
+            kind = classify_pv(address)
+            self._legacy_kind[address] = kind
+        base = kind.base_value
 
         if record_type == RECORD_TYPE_BINARY:
             return bool(base)
 
         if not noisy:
             return base
-        return base * (1.0 + float(self._rng.normal(0.0, self._noise_level)))
+
+        # Sigma is floored per kind so a legitimately-0.0 base is not dead-flat.
+        sigma = kind.noise_sigma(base, self._noise_level)
+        return base + float(self._rng.normal(0.0, sigma))

--- a/src/osprey/simulation/engine.py
+++ b/src/osprey/simulation/engine.py
@@ -38,14 +38,18 @@ from osprey.simulation.machine import (
     Scenario,
     ScenarioLogEntry,
     SimChannel,
+    TextureSpec,
     parse_machine,
 )
 from osprey.simulation.series import (
     apply_events,
     clamp,
     epoch_seconds_array,
+    keyed_normals,
+    pv_key_bytes,
     ref_value,
     string_series,
+    wander,
 )
 from osprey.utils.config import get_facility_timezone
 from osprey.utils.logger import get_logger
@@ -64,6 +68,79 @@ class SimReading:
     value: float | str
     units: str
     description: str
+
+
+def _texture_offset(
+    pv_key: bytes, texture: TextureSpec, t_abs_s: "np.ndarray | float"
+) -> "np.ndarray":
+    """Texture contribution at absolute epoch time(s) — shared by both engine paths.
+
+    Synthesis passes the window's epoch-seconds array; live reads pass a scalar
+    wall-clock now (``wander`` is scalar/array bit-exact, so the two paths
+    agree exactly at a shared timestamp). That agreement holds only because
+    both callers route through this one implementation with UNMODIFIED
+    absolute epoch seconds — do not normalize, quantize, or re-derive the time
+    input on either side. ``kind`` needs no dispatch: ``parse_machine``
+    validates the vocabulary and ``"wander"`` is the only kind defined today.
+
+    Args:
+        pv_key: Channel key from :func:`osprey.simulation.series.pv_key_bytes`.
+        texture: The channel's declared texture parameters.
+        t_abs_s: Absolute epoch seconds — array (synthesis) or scalar (live).
+
+    Returns:
+        Texture offsets with the shape of ``t_abs_s`` (0-d for a scalar).
+    """
+    # asarray is the same first step wander performs — a bit-exact dtype wrap
+    # (never a rounding or rebasing), here only to satisfy the array annotation.
+    times = np.asarray(t_abs_s, dtype=np.float64)
+    return wander(pv_key, times, texture.amplitude, texture.period_s)
+
+
+def _apply_signal_model(
+    pv: str, channel: SimChannel, series: "np.ndarray", t_abs: "np.ndarray | None"
+) -> "np.ndarray":
+    """Add a channel's declared signal model to its post-event baseline series.
+
+    Texture rides *post-event* levels: step/ramp events hard-overwrite the
+    series, so folding it in earlier would leave every stepped plateau dead
+    flat. It needs absolute time (that is what makes overlapping windows agree),
+    so non-epoch timestamps skip it — same precedent as anchored events in
+    :func:`osprey.simulation.series.apply_events`.
+
+    Both noise terms are keyed draws addressed by (channel, epoch millisecond),
+    never by an RNG stream position, so any two windows agree pointwise on
+    shared timestamps. The sample-index fallback keeps non-epoch windows
+    deterministic (still per-channel via the key).
+
+    Args:
+        pv: Channel name; keys the draws and names the channel in the
+            skipped-texture debug log.
+        channel: Parsed channel supplying ``texture``/``noise``/``noise_abs``.
+        series: Post-event baseline series, one entry per sample. Not mutated.
+        t_abs: Absolute epoch seconds per sample, or ``None`` when the requested
+            timestamps were not convertible.
+
+    Returns:
+        The series with texture and both noise terms applied.
+    """
+    pv_key = pv_key_bytes(pv)
+    if channel.texture is not None:
+        if t_abs is not None:
+            series = series + _texture_offset(pv_key, channel.texture, t_abs)
+        else:
+            logger.debug(
+                f"Skipping texture for {pv!r}: timestamps not convertible to epoch seconds"
+            )
+    if channel.noise > 0.0 or channel.noise_abs > 0.0:
+        counters = t_abs * 1000.0 if t_abs is not None else np.arange(len(series), dtype=np.int64)
+        if channel.noise > 0.0:
+            relative = keyed_normals(pv_key + b":noise", counters)
+            series = series * (1.0 + channel.noise * relative)
+        if channel.noise_abs > 0.0:
+            absolute = keyed_normals(pv_key + b":noise_abs", counters)
+            series = series + channel.noise_abs * absolute
+    return series
 
 
 class SimulationEngine:
@@ -277,7 +354,19 @@ class SimulationEngine:
         return pv in self._channels
 
     def read(self, pv: str) -> SimReading:
-        """Read a channel's effective value with noise applied.
+        """Read a channel's effective value with the live signal model applied.
+
+        Numeric pipeline: effective value -> + texture at wall-clock now ->
+        relative ``noise`` (multiplicative) -> + ``noise_abs`` (additive) ->
+        clamp. Texture is the shared deterministic term (:func:`_texture_offset`,
+        the same implementation synthesis uses), so for a NON-OVERRIDDEN,
+        noise-free channel a live read equals the synthesized sample at the
+        same timestamp exactly. That agreement is scoped: the effective value
+        resolves write > override > baseline, while synthesized history builds
+        on ``channel.value`` plus archiver events — an override shifts the live
+        read but not the history (scenarios declare matching archiver events to
+        keep the two consistent). Both noise draws stay stochastic on the
+        engine's RNG, deliberately: only synthesis draws are counter-based.
 
         Args:
             pv: Channel name.
@@ -292,9 +381,14 @@ class SimulationEngine:
         channel = self._require_channel(pv)
         value = self._effective(pv)
         if not isinstance(value, str):
+            value = float(value)
+            if channel.texture is not None:
+                value += float(_texture_offset(pv_key_bytes(pv), channel.texture, time.time()))
             if channel.noise > 0.0:
-                value = float(value) * (1.0 + float(self._rng.normal(0.0, channel.noise)))
-            value = clamp(float(value), channel.min_value, channel.max_value)
+                value *= 1.0 + float(self._rng.normal(0.0, channel.noise))
+            if channel.noise_abs > 0.0:
+                value += float(self._rng.normal(0.0, channel.noise_abs))
+            value = clamp(value, channel.min_value, channel.max_value)
         return SimReading(value=value, units=channel.units, description=channel.description)
 
     def write(self, pv: str, value: Any) -> None:
@@ -324,11 +418,20 @@ class SimulationEngine:
     def synthesize_series(self, pv: str, timestamps: Sequence[Any]) -> list[Any]:
         """Synthesize an archiver time-series for a channel.
 
-        Baseline-value channels yield a constant baseline plus per-channel
-        noise, with the active scenario's archiver events (step/ramp/spike)
-        applied. Expression channels are evaluated pointwise over the
-        synthesized series of their referenced channels, so derived channels
-        show correlated history.
+        Baseline-value channels yield their baseline with the active scenario's
+        archiver events (step/ramp/spike) applied, then the channel's declared
+        signal model: ``texture`` (slow baseline wander, riding post-event
+        levels), relative ``noise`` (multiplicative sigma) and ``noise_abs``
+        (additive sigma). All stochastic terms are deterministic keyed draws
+        addressed by (channel, absolute timestamp), so repeated or overlapping
+        queries agree pointwise on shared timestamps — with two caveats: noise
+        counters are quantized to the nearest millisecond, so sub-millisecond
+        timestamps share draws; and when timestamps are not convertible to
+        epoch seconds, texture is skipped and noise falls back to sample-index
+        counters (deterministic for a given window shape, but without
+        cross-window agreement). Expression channels are evaluated pointwise
+        over the synthesized series of their referenced channels, so derived
+        channels show correlated history.
 
         Event positioning has three flavors: ``at`` places an event at a fixed
         fraction of whatever window is requested, while ``at_offset`` (with
@@ -505,6 +608,16 @@ class SimulationEngine:
         return channel.value
 
     def _numeric_effective(self, pv: str) -> float:
+        """Numeric effective value of a referenced channel — texture-free.
+
+        Live expression evaluation resolves references through the effective
+        value only: texture, like noise, is a top-level measurement effect,
+        applied solely to the channel actually being read. Synthesized derived
+        series differ — they inherit referenced channels' texture and noise
+        through the cached per-window series (:meth:`_synthesize`). This
+        existing live/archive asymmetry for derived channels is documented and
+        pinned (``TestExprRefTextureSemantics``), not silently widened.
+        """
         value = self._effective(pv)
         if isinstance(value, str):
             raise ExpressionError(
@@ -535,7 +648,13 @@ class SimulationEngine:
         anchor: float,
         tz: ZoneInfo,
     ) -> "np.ndarray | list[str]":
-        """Build one channel's series, memoized per synthesis pass."""
+        """Build one channel's series, memoized per synthesis pass.
+
+        Expression channels evaluate pointwise over their references'
+        *synthesized* series, so a derived series inherits referenced
+        channels' texture and noise — unlike live derived reads, which
+        resolve references texture-free via :meth:`_numeric_effective`.
+        """
         cached = cache.get(pv)
         if cached is not None:
             return cached
@@ -564,8 +683,7 @@ class SimulationEngine:
             series = np.full(n, float(channel.value))
 
         series = apply_events(series, events, n, t_abs, anchor, tz)
-        if channel.noise > 0.0:
-            series = series * (1.0 + self._rng.normal(0.0, channel.noise, n))
+        series = _apply_signal_model(pv, channel, series, t_abs)
         if channel.min_value is not None or channel.max_value is not None:
             series = np.clip(series, channel.min_value, channel.max_value)
         cache[pv] = series

--- a/src/osprey/simulation/machine.py
+++ b/src/osprey/simulation/machine.py
@@ -24,7 +24,10 @@ from osprey.simulation.expressions import (
     compile_expression,
     extract_channel_refs,
 )
+from osprey.utils.logger import get_logger
 from osprey.utils.relative_time import RelativeTimestamp
+
+logger = get_logger("simulation_machine")
 
 DEFAULT_SCENARIO = "nominal"
 
@@ -39,10 +42,42 @@ _EVENT_VALUE_KEYS = {
     "spike": ("amplitude", "width"),
 }
 
+# Texture-object schema, validated with the same closed-key discipline as events:
+# every key is required and no others are accepted, so a typo is a load-time error
+# rather than a silently ignored parameter. 'kind' is a validated vocabulary so
+# further kinds can be added without a schema break.
+_TEXTURE_KEYS = ("kind", "amplitude", "period_s")
+_TEXTURE_KINDS = ("wander",)
+
+# Cap on channel names listed in the aggregated dead-noise warning.
+_DEAD_NOISE_EXAMPLES = 5
+
+
+@dataclass(frozen=True)
+class TextureSpec:
+    """Declared baseline-texture parameters for a channel.
+
+    Attributes:
+        kind: Texture vocabulary term; only ``"wander"`` is defined today.
+        amplitude: Envelope bound of the texture, in the channel's declared units.
+        period_s: The slowest period of the texture, in seconds.
+    """
+
+    kind: str
+    amplitude: float
+    period_s: float
+
 
 @dataclass(frozen=True)
 class SimChannel:
-    """Parsed channel definition from the machine file."""
+    """Parsed channel definition from the machine file.
+
+    ``noise`` is *relative* (multiplicative, ``value * (1 + N(0, noise))``) and is
+    therefore inert on a ``0.0`` baseline; ``noise_abs`` is the additive sigma in
+    the channel's declared ``units`` and composes with it. ``texture`` adds slow
+    baseline motion. Both signal fields default to the no-op, so machine files
+    written before they existed parse unchanged.
+    """
 
     name: str
     value: float | str | None
@@ -54,6 +89,8 @@ class SimChannel:
     expr_source: str = ""
     min_value: float | None = None
     max_value: float | None = None
+    noise_abs: float = 0.0
+    texture: TextureSpec | None = None
 
 
 @dataclass(frozen=True)
@@ -161,6 +198,7 @@ def parse_machine(machine: Any, machine_path: Path) -> ParsedMachine:
 
     channels = {pv: _parse_channel(pv, spec) for pv, spec in machine["channels"].items()}
     _check_references(channels)
+    _warn_dead_noise_channels(channels, machine_path)
     scenarios_dir = machine_path.parent / "scenarios"
     if scenarios_dir.is_dir():
         scenarios = load_scenario_bundles(scenarios_dir, channels)
@@ -212,6 +250,8 @@ def _parse_channel(pv: str, spec: Any) -> SimChannel:
         raise ValueError(
             f"Channel {pv!r}: 'min' ({min_value:g}) must be less than 'max' ({max_value:g})"
         )
+    noise_abs = _parse_noise_abs(pv, spec, is_string_channel)
+    texture = _parse_texture(pv, spec, is_string_channel)
 
     return SimChannel(
         name=pv,
@@ -224,6 +264,8 @@ def _parse_channel(pv: str, spec: Any) -> SimChannel:
         expr_source=spec["expr"] if has_expr else "",
         min_value=min_value,
         max_value=max_value,
+        noise_abs=noise_abs,
+        texture=texture,
     )
 
 
@@ -237,6 +279,120 @@ def _parse_bound(pv: str, spec: dict[str, Any], key: str, is_string_channel: boo
     if isinstance(raw, bool) or not isinstance(raw, (int, float)):
         raise ValueError(f"Channel {pv!r}: {key!r} must be a number, got {raw!r}")
     return float(raw)
+
+
+def _parse_noise_abs(pv: str, spec: dict[str, Any], is_string_channel: bool) -> float:
+    """Parse the optional ``noise_abs`` sigma (absolute, channel units).
+
+    Args:
+        pv: Channel name, for error messages.
+        spec: The raw channel spec.
+        is_string_channel: Whether the channel holds a string value (no signal model).
+
+    Returns:
+        The declared sigma, or ``0.0`` when the key is absent.
+
+    Raises:
+        ValueError: If the channel is string-valued, or the value is not a
+            non-negative number.
+    """
+    if "noise_abs" not in spec:
+        return 0.0
+    if is_string_channel:
+        raise ValueError(f"Channel {pv!r}: 'noise_abs' is not supported on string-valued channels")
+    raw = spec["noise_abs"]
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)) or raw < 0:
+        raise ValueError(f"Channel {pv!r}: 'noise_abs' must be a non-negative number, got {raw!r}")
+    return float(raw)
+
+
+def _parse_texture(pv: str, spec: dict[str, Any], is_string_channel: bool) -> TextureSpec | None:
+    """Parse the optional ``texture`` block into a :class:`TextureSpec`.
+
+    Every key in :data:`_TEXTURE_KEYS` is required and no others are accepted, so
+    a mistyped parameter fails at load time instead of being silently dropped.
+
+    Args:
+        pv: Channel name, for error messages.
+        spec: The raw channel spec.
+        is_string_channel: Whether the channel holds a string value (no signal model).
+
+    Returns:
+        The parsed texture, or ``None`` when the key is absent.
+
+    Raises:
+        ValueError: If the channel is string-valued, or the block is not a mapping
+            with exactly the required keys, a known ``kind``, and positive
+            ``amplitude``/``period_s``.
+    """
+    if "texture" not in spec:
+        return None
+    if is_string_channel:
+        raise ValueError(f"Channel {pv!r}: 'texture' is not supported on string-valued channels")
+    raw = spec["texture"]
+    if not isinstance(raw, dict):
+        raise ValueError(f"Channel {pv!r}: 'texture' must be a mapping, got {raw!r}")
+
+    unknown = sorted(set(raw) - set(_TEXTURE_KEYS))
+    if unknown:
+        raise ValueError(f"Channel {pv!r}: 'texture' has unknown keys {unknown}")
+    missing = [key for key in _TEXTURE_KEYS if key not in raw]
+    if missing:
+        raise ValueError(f"Channel {pv!r}: 'texture' missing keys {missing}")
+    if raw["kind"] not in _TEXTURE_KINDS:
+        raise ValueError(
+            f"Channel {pv!r}: 'texture' kind must be one of {list(_TEXTURE_KINDS)}, "
+            f"got {raw['kind']!r}"
+        )
+    return TextureSpec(
+        kind=str(raw["kind"]),
+        amplitude=_positive_texture_number(pv, raw, "amplitude"),
+        period_s=_positive_texture_number(pv, raw, "period_s"),
+    )
+
+
+def _positive_texture_number(pv: str, texture: dict[str, Any], key: str) -> float:
+    """Validate one strictly positive numeric ``texture`` parameter."""
+    raw = texture[key]
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)) or raw <= 0:
+        raise ValueError(f"Channel {pv!r}: 'texture' {key} must be a number > 0, got {raw!r}")
+    return float(raw)
+
+
+def _warn_dead_noise_channels(channels: dict[str, SimChannel], machine_path: Path) -> None:
+    """Warn once per file about channels whose noise declaration cannot express.
+
+    Relative ``noise`` is multiplicative (``value * (1 + N(0, noise))``), so a
+    channel with a ``0.0`` baseline and neither additive key synthesizes a
+    dead-flat constant — structurally valid, semantically wrong data. That is a
+    misconfiguration rather than a schema error, so it is reported and never
+    raised, and it is reported *once* with a bounded example list: a stale project
+    copy can hold hundreds of such channels, and one line each would bury the log
+    on every engine construction.
+
+    Args:
+        channels: The parsed channels of one machine file.
+        machine_path: Path the machine was loaded from, named in the warning.
+    """
+    dead = [
+        name
+        for name, channel in channels.items()
+        if channel.value == 0.0
+        and channel.noise > 0
+        and channel.noise_abs == 0.0
+        and channel.texture is None
+    ]
+    if not dead:
+        return
+
+    examples = ", ".join(dead[:_DEAD_NOISE_EXAMPLES])
+    if len(dead) > _DEAD_NOISE_EXAMPLES:
+        examples += f", ... (+{len(dead) - _DEAD_NOISE_EXAMPLES} more)"
+    logger.warning(
+        f"{machine_path}: {len(dead)} channel(s) declare relative 'noise' on a 0.0 baseline, "
+        f"which multiplies to a dead-flat constant: {examples}. Give them motion with "
+        f"'noise_abs' (absolute sigma in the channel's units) and/or a 'texture' block."
+    )
 
 
 def _check_references(channels: dict[str, SimChannel]) -> None:

--- a/src/osprey/simulation/series.py
+++ b/src/osprey/simulation/series.py
@@ -10,6 +10,7 @@ in isolation (see ``tests/simulation/test_series_primitives.py``; the
 engine-driven behavior is covered in ``tests/simulation/test_series.py``).
 """
 
+import hashlib
 from collections.abc import Sequence
 from datetime import datetime, timedelta
 from datetime import time as dtime
@@ -22,6 +23,208 @@ from osprey.simulation.expressions import ExpressionError
 from osprey.utils.logger import get_logger
 
 logger = get_logger("simulation_series")
+
+# splitmix64 mixing constants: an odd increment (the golden-ratio word) and the
+# two finalizer multipliers. The finalizer is a bijection on uint64, so distinct
+# counters can never collide onto the same word for a given key.
+_GAMMA = np.uint64(0x9E3779B97F4A7C15)
+_MIX_A = np.uint64(0xBF58476D1CE4E5B9)
+_MIX_B = np.uint64(0x94D049BB133111EB)
+_SHIFT_30 = np.uint64(30)
+_SHIFT_27 = np.uint64(27)
+_SHIFT_31 = np.uint64(31)
+_SHIFT_11 = np.uint64(11)
+_ONE = np.uint64(1)
+# 53 significand bits scaled into the unit interval.
+_TWO_POW_M53 = 2.0**-53
+_TWO_PI = 2.0 * np.pi
+
+# Texture: a stack of sinusoids log-spaced downward from the declared slowest
+# period. The per-channel weight jitter is applied in log space and is narrower
+# than half the decay step, so the slowest component dominates for every
+# channel rather than only on average.
+_WANDER_SUBKEY = b":wander"
+_WANDER_COMPONENTS = 5
+_WANDER_OCTAVE_SPAN = 3.5
+_WANDER_DECAY_PER_OCTAVE = 0.5
+_WANDER_JITTER_OCTAVES = 0.15
+
+
+def pv_key_bytes(pv_name: str) -> bytes:
+    """Per-channel key for the counter-based draw primitives.
+
+    The key is the SHA-256 digest of the UTF-8 channel name. The builtin
+    ``hash()`` is deliberately not used: it is salted per process, so draws
+    keyed on it would differ between runs of the same scenario.
+
+    Callers derive independent streams for the same channel by appending a
+    subkey (e.g. ``pv_key_bytes(pv) + b":noise_abs"``).
+
+    Args:
+        pv_name: Channel name.
+
+    Returns:
+        A 32-byte digest suitable as the ``pv_key`` argument of
+        :func:`keyed_normals`.
+    """
+    return hashlib.sha256(pv_name.encode("utf-8")).digest()
+
+
+def _key_words(pv_key: bytes) -> tuple[np.uint64, np.uint64]:
+    """Two uint64 lane keys derived from an arbitrary-length key."""
+    digest = hashlib.sha256(pv_key).digest()
+    return (
+        np.uint64(int.from_bytes(digest[0:8], "big")),
+        np.uint64(int.from_bytes(digest[8:16], "big")),
+    )
+
+
+def _mix64(z: "np.ndarray") -> "np.ndarray":
+    """splitmix64 avalanche finalizer over a uint64 array (wrapping arithmetic)."""
+    z = (z ^ (z >> _SHIFT_30)) * _MIX_A
+    z = (z ^ (z >> _SHIFT_27)) * _MIX_B
+    return np.asarray(z ^ (z >> _SHIFT_31))
+
+
+def _as_counter_array(counters: "np.ndarray") -> "np.ndarray":
+    """Normalize counters to uint64, rounding floats to the nearest integer.
+
+    Epoch-millisecond counters usually arrive as float64 (``epoch_s * 1000``);
+    signed integers (sample-index fallback, pre-epoch timestamps) wrap into
+    uint64 modularly, which keys deterministically like any other value.
+    """
+    array = np.asarray(counters)
+    if array.dtype.kind == "f":
+        array = np.rint(array).astype(np.int64)
+    if array.dtype != np.uint64:
+        array = array.astype(np.uint64)
+    return array
+
+
+def _keyed_words(pv_key: bytes, counters_ms: "np.ndarray") -> "tuple[np.ndarray, np.ndarray]":
+    """The two uint64 words each sample consumes, as a pair of arrays.
+
+    Exactly two words per sample, addressed by that sample's own counter — no
+    stream position is involved, which is what makes the draws pointwise
+    reproducible across differently-shaped windows.
+    """
+    counters = _as_counter_array(counters_ms)
+    k0, k1 = _key_words(pv_key)
+    base = counters * _GAMMA
+    return _mix64(base ^ k0), _mix64(base ^ k1)
+
+
+def keyed_normals(pv_key: bytes, counters_ms: "np.ndarray") -> "np.ndarray":
+    """Standard normal draws addressed by ``(channel key, counter)``.
+
+    Each sample's draw is a pure function of its own counter, so two windows
+    that share a timestamp get the same value, in any order, in any batch size,
+    from any process. This is the pinned construction for all synthesis noise:
+
+    1. a uint64 avalanche mix of the counter against two key-derived lane words
+       (exactly two words per sample, fixed consumption by construction);
+    2. an **open**-interval mapping of the log argument,
+       ``u1 = ((w >> 11) | 1) * 2**-53``, so ``u1 > 0`` always and ``log(u1)``
+       can never be ``-inf`` — a frozen calendar timestamp that produced ``-inf``
+       would fail permanently rather than transiently;
+    3. the Box-Muller cosine branch.
+
+    The ziggurat rejection sampler behind numpy's batch normal draws consumes a
+    *variable* number of words per sample, so a batch drawn from a window-start
+    counter does not equal the corresponding per-sample draws — it is forbidden
+    on this path, and ``tests/simulation/test_series_primitives.py`` pins the
+    equivalence against a per-sample reference implementation.
+
+    Args:
+        pv_key: Channel key, typically :func:`pv_key_bytes` output optionally
+            suffixed with a subkey to get an independent stream.
+        counters_ms: Per-sample counters, conventionally epoch milliseconds.
+            Floats are rounded to the nearest integer; any shape is accepted.
+
+    Returns:
+        A float64 array of standard normal draws with the shape of
+        ``counters_ms``.
+    """
+    w0, w1 = _keyed_words(pv_key, counters_ms)
+    u1 = ((w0 >> _SHIFT_11) | _ONE).astype(np.float64) * _TWO_POW_M53
+    u2 = (w1 >> _SHIFT_11).astype(np.float64) * _TWO_POW_M53
+    return np.sqrt(-2.0 * np.log(u1)) * np.cos(_TWO_PI * u2)
+
+
+def _unit_interval(words: "np.ndarray") -> "np.ndarray":
+    """Map uint64 words onto float64 in the half-open interval ``[0, 1)``."""
+    return np.asarray((words >> _SHIFT_11).astype(np.float64) * _TWO_POW_M53)
+
+
+def _wander_components(
+    pv_key: bytes, period_s: float
+) -> "tuple[np.ndarray, np.ndarray, np.ndarray]":
+    """Periods, phases and normalized weights of one channel's texture stack.
+
+    Periods are log-spaced downward from ``period_s`` (the slowest) across
+    :data:`_WANDER_OCTAVE_SPAN` octaves. Phases and weight jitter come from the
+    channel key, so the declared parameters can stay family-uniform while every
+    channel still gets its own apparent offset and motion.
+
+    Args:
+        pv_key: Channel key, as for :func:`keyed_normals`.
+        period_s: Slowest period in seconds.
+
+    Returns:
+        ``(periods, phases, weights)``, each of length
+        :data:`_WANDER_COMPONENTS`, with ``weights`` summing to 1.
+    """
+    index = np.arange(_WANDER_COMPONENTS, dtype=np.uint64)
+    phase_words, weight_words = _keyed_words(pv_key + _WANDER_SUBKEY, index)
+    octaves = np.arange(_WANDER_COMPONENTS, dtype=np.float64) * (
+        _WANDER_OCTAVE_SPAN / (_WANDER_COMPONENTS - 1)
+    )
+    periods = period_s * 2.0**-octaves
+    phases = _unit_interval(phase_words) * _TWO_PI
+    jitter = (2.0 * _unit_interval(weight_words) - 1.0) * _WANDER_JITTER_OCTAVES
+    weights = 2.0 ** (-_WANDER_DECAY_PER_OCTAVE * octaves + jitter)
+    return periods, phases, np.asarray(weights / weights.sum())
+
+
+def wander(pv_key: bytes, t_abs_s: "np.ndarray", amplitude: float, period_s: float) -> "np.ndarray":
+    """Band-limited quasi-random baseline texture, evaluated on absolute time.
+
+    A seeded sum of :data:`_WANDER_COMPONENTS` sinusoids whose periods are
+    log-spaced downward from ``period_s``. One declaration therefore covers two
+    timescales: with ``period_s`` of many hours the slowest terms read as a
+    distinct quasi-static offset inside any short query window, while the faster
+    octaves supply visible motion — which is what lets a whole channel family
+    share one set of declared parameters and still look individual.
+
+    The envelope is bounded structurally rather than by clipping: the weights
+    are positive and sum to 1, so ``|wander| <= amplitude`` follows from the
+    triangle inequality and the output stays linear in ``amplitude``.
+
+    Being a pure function of absolute epoch seconds is what makes overlapping
+    archiver windows agree exactly on their shared timestamps.
+
+    Args:
+        pv_key: Channel key, as for :func:`keyed_normals`.
+        t_abs_s: Absolute epoch seconds; any shape.
+        amplitude: Envelope bound, in the channel's declared units.
+        period_s: Slowest period in seconds; must be positive.
+
+    Returns:
+        A float64 array of texture offsets with the shape of ``t_abs_s``.
+
+    Raises:
+        ValueError: If ``period_s`` is not positive. Machine-file parsing
+            already rejects this; the guard keeps a direct caller from turning
+            a division by zero into silent ``NaN`` in the series.
+    """
+    if period_s <= 0.0:
+        raise ValueError(f"wander period_s must be > 0, got {period_s!r}")
+    times = np.asarray(t_abs_s, dtype=np.float64)
+    periods, phases, weights = _wander_components(pv_key, period_s)
+    total = np.zeros(times.shape, dtype=np.float64)
+    for period, phase, weight in zip(periods, phases, weights, strict=True):
+        total += weight * np.sin(_TWO_PI * times / period + phase)
+    return amplitude * total
 
 
 def clamp(value: float, min_value: float | None, max_value: float | None) -> float:

--- a/src/osprey/templates/apps/control_assistant/data/simulation/machine.json
+++ b/src/osprey/templates/apps/control_assistant/data/simulation/machine.json
@@ -2302,2019 +2302,3027 @@
     },
     "SR:MAG:HCM:01:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 01 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:01:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 01 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:02:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 02 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:02:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 02 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:03:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 03 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:03:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 03 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:04:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 04 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:04:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 04 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:05:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 05 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:05:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 05 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:06:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 06 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:06:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 06 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:07:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 07 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:07:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 07 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:08:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 08 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:08:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 08 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:09:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 09 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:09:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 09 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:10:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 10 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:10:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 10 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:11:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 11 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:11:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 11 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:12:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 12 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:12:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 12 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:13:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 13 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:13:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 13 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:14:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 14 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:14:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 14 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:15:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 15 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:15:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 15 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:16:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 16 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:16:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 16 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:17:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 17 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:17:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 17 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:18:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 18 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:18:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 18 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:19:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 19 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:19:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 19 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:20:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 20 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:20:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 20 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:21:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 21 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:21:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 21 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:22:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 22 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:22:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 22 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:23:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 23 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:23:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 23 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:24:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 24 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:24:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 24 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:25:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 25 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:25:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 25 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:26:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 26 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:26:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 26 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:27:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 27 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:27:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 27 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:28:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 28 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:28:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 28 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:29:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 29 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:29:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 29 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:30:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 30 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:30:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 30 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:31:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 31 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:31:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 31 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:32:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 32 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:32:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 32 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:33:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 33 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:33:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 33 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:34:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 34 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:34:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 34 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:35:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 35 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:35:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 35 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:36:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 36 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:36:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 36 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:37:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 37 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:37:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 37 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:38:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 38 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:38:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 38 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:39:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 39 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:39:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 39 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:40:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 40 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:40:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 40 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:41:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 41 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:41:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 41 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:42:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 42 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:42:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 42 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:43:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 43 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:43:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 43 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:44:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 44 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:44:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 44 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:45:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 45 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:45:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 45 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:46:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 46 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:46:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 46 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:47:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 47 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:47:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 47 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:48:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 48 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:48:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 48 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:49:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 49 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:49:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 49 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:50:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 50 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:50:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 50 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:51:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 51 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:51:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 51 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:52:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 52 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:52:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 52 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:53:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 53 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:53:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 53 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:54:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 54 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:54:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 54 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:55:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 55 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:55:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 55 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:56:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 56 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:56:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 56 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:57:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 57 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:57:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 57 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:58:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 58 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:58:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 58 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:59:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 59 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:59:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 59 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:60:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 60 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:60:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 60 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:61:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 61 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:61:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 61 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:62:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 62 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:62:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 62 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:63:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 63 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:63:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 63 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:64:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 64 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:64:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 64 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:65:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 65 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:65:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 65 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:66:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 66 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:66:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 66 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:67:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 67 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:67:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 67 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:68:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 68 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:68:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 68 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:69:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 69 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:69:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 69 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:70:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 70 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:70:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 70 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:71:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 71 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:71:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 71 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:72:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring horizontal corrector 72 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:HCM:72:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring horizontal corrector 72 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:01:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 01 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:01:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 01 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:02:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 02 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:02:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 02 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:03:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 03 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:03:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 03 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:04:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 04 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:04:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 04 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:05:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 05 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:05:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 05 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:06:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 06 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:06:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 06 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:07:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 07 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:07:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 07 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:08:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 08 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:08:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 08 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:09:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 09 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:09:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 09 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:10:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 10 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:10:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 10 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:11:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 11 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:11:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 11 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:12:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 12 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:12:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 12 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:13:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 13 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:13:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 13 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:14:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 14 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:14:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 14 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:15:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 15 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:15:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 15 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:16:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 16 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:16:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 16 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:17:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 17 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:17:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 17 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:18:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 18 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:18:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 18 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:19:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 19 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:19:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 19 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:20:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 20 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:20:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 20 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:21:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 21 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:21:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 21 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:22:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 22 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:22:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 22 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:23:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 23 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:23:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 23 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:24:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 24 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:24:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 24 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:25:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 25 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:25:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 25 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:26:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 26 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:26:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 26 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:27:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 27 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:27:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 27 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:28:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 28 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:28:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 28 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:29:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 29 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:29:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 29 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:30:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 30 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:30:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 30 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:31:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 31 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:31:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 31 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:32:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 32 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:32:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 32 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:33:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 33 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:33:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 33 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:34:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 34 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:34:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 34 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:35:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 35 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:35:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 35 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:36:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 36 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:36:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 36 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:37:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 37 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:37:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 37 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:38:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 38 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:38:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 38 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:39:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 39 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:39:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 39 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:40:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 40 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:40:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 40 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:41:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 41 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:41:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 41 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:42:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 42 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:42:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 42 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:43:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 43 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:43:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 43 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:44:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 44 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:44:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 44 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:45:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 45 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:45:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 45 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:46:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 46 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:46:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 46 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:47:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 47 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:47:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 47 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:48:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 48 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:48:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 48 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:49:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 49 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:49:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 49 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:50:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 50 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:50:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 50 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:51:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 51 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:51:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 51 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:52:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 52 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:52:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 52 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:53:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 53 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:53:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 53 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:54:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 54 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:54:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 54 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:55:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 55 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:55:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 55 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:56:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 56 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:56:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 56 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:57:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 57 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:57:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 57 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:58:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 58 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:58:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 58 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:59:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 59 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:59:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 59 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:60:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 60 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:60:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 60 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:61:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 61 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:61:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 61 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:62:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 62 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:62:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 62 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:63:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 63 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:63:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 63 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:64:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 64 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:64:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 64 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:65:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 65 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:65:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 65 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:66:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 66 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:66:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 66 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:67:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 67 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:67:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 67 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:68:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 68 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:68:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 68 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:69:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 69 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:69:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 69 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:70:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 70 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:70:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 70 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:71:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 71 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:71:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 71 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:72:CURRENT:RB": {
       "value": 0.0,
-      "noise": 0.01,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.005,
+        "period_s": 21600.0
+      },
       "units": "A",
       "description": "Storage-ring vertical corrector 72 current readback (nominal ~0.0 A; pyat-coupled -- backed by the AT lattice model)",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:VCM:72:CURRENT:SP": {
       "value": 0.0,
       "noise": 0,
       "units": "A",
       "description": "Storage-ring vertical corrector 72 current setpoint",
-      "min": -12.0
+      "min": -12.0,
+      "max": 12.0
     },
     "SR:MAG:QFA:01:CURRENT:RB": {
       "value": 356.101,
@@ -5326,865 +6334,1585 @@
     },
     "SR:DIAG:BPM:01:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 01 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:01:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 01 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:02:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 02 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:02:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 02 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:03:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 03 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:03:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 03 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:04:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 04 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:04:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 04 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:05:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 05 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:05:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 05 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:06:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 06 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:06:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 06 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:07:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 07 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:07:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 07 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:08:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 08 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:08:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 08 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:09:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 09 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:09:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 09 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:10:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 10 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:10:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 10 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:11:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 11 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:11:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 11 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:12:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 12 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:12:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 12 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:13:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 13 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:13:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 13 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:14:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 14 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:14:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 14 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:15:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 15 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:15:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 15 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:16:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 16 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:16:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 16 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:17:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 17 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:17:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 17 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:18:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 18 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:18:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 18 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:19:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 19 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:19:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 19 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:20:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 20 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:20:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 20 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:21:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 21 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:21:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 21 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:22:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 22 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:22:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 22 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:23:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 23 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:23:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 23 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:24:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 24 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:24:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 24 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:25:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 25 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:25:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 25 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:26:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 26 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:26:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 26 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:27:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 27 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:27:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 27 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:28:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 28 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:28:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 28 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:29:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 29 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:29:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 29 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:30:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 30 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:30:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 30 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:31:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 31 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:31:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 31 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:32:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 32 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:32:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 32 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:33:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 33 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:33:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 33 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:34:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 34 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:34:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 34 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:35:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 35 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:35:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 35 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:36:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 36 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:36:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 36 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:37:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 37 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:37:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 37 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:38:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 38 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:38:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 38 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:39:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 39 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:39:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 39 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:40:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 40 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:40:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 40 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:41:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 41 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:41:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 41 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:42:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 42 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:42:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 42 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:43:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 43 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:43:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 43 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:44:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 44 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:44:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 44 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:45:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 45 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:45:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 45 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:46:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 46 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:46:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 46 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:47:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 47 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:47:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 47 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:48:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 48 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:48:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 48 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:49:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 49 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:49:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 49 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:50:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 50 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:50:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 50 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:51:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 51 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:51:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 51 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:52:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 52 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:52:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 52 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:53:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 53 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:53:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 53 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:54:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 54 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:54:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 54 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:55:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 55 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:55:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 55 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:56:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 56 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:56:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 56 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:57:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 57 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:57:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 57 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:58:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 58 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:58:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 58 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:59:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 59 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:59:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 59 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:60:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 60 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:60:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 60 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:61:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 61 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:61:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 61 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:62:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 62 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:62:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 62 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:63:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 63 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:63:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 63 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:64:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 64 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:64:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 64 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:65:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 65 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:65:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 65 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:66:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 66 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:66:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 66 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:67:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 67 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:67:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 67 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:68:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 68 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:68:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 68 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:69:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 69 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:69:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 69 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:70:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 70 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:70:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 70 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:71:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 71 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:71:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 71 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:72:POSITION:X": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 72 horizontal position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
     "SR:DIAG:BPM:72:POSITION:Y": {
       "value": 0.0,
-      "noise": 0.2,
+      "noise_abs": 0.001,
+      "texture": {
+        "kind": "wander",
+        "amplitude": 0.03,
+        "period_s": 43200.0
+      },
       "units": "mm",
       "description": "Storage-ring BPM 72 vertical position readback (pyat-coupled -- recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
     },
@@ -6584,7 +8312,8 @@
       "noise": 0,
       "units": "A",
       "description": "Booster-to-storage transport-line horizontal corrector 01 current setpoint",
-      "min": 0.0
+      "min": 0.0,
+      "max": 5.0
     },
     "BTS:MAG:HCM:01:STATUS:READY": {
       "value": 1,
@@ -6603,7 +8332,8 @@
       "noise": 0,
       "units": "A",
       "description": "Booster-to-storage transport-line horizontal corrector 02 current setpoint",
-      "min": 0.0
+      "min": 0.0,
+      "max": 5.0
     },
     "BTS:MAG:HCM:02:STATUS:READY": {
       "value": 1,
@@ -6622,7 +8352,8 @@
       "noise": 0,
       "units": "A",
       "description": "Booster-to-storage transport-line horizontal corrector 03 current setpoint",
-      "min": 0.0
+      "min": 0.0,
+      "max": 5.0
     },
     "BTS:MAG:HCM:03:STATUS:READY": {
       "value": 1,
@@ -6641,7 +8372,8 @@
       "noise": 0,
       "units": "A",
       "description": "Booster-to-storage transport-line horizontal corrector 04 current setpoint",
-      "min": 0.0
+      "min": 0.0,
+      "max": 5.0
     },
     "BTS:MAG:HCM:04:STATUS:READY": {
       "value": 1,
@@ -6660,7 +8392,8 @@
       "noise": 0,
       "units": "A",
       "description": "Booster-to-storage transport-line horizontal corrector 05 current setpoint",
-      "min": 0.0
+      "min": 0.0,
+      "max": 5.0
     },
     "BTS:MAG:HCM:05:STATUS:READY": {
       "value": 1,
@@ -6679,7 +8412,8 @@
       "noise": 0,
       "units": "A",
       "description": "Booster-to-storage transport-line horizontal corrector 06 current setpoint",
-      "min": 0.0
+      "min": 0.0,
+      "max": 5.0
     },
     "BTS:MAG:HCM:06:STATUS:READY": {
       "value": 1,
@@ -6812,7 +8546,8 @@
       "noise": 0,
       "units": "A",
       "description": "Booster-to-storage transport-line vertical corrector 01 current setpoint",
-      "min": 0.0
+      "min": 0.0,
+      "max": 5.0
     },
     "BTS:MAG:VCM:01:STATUS:READY": {
       "value": 1,
@@ -6831,7 +8566,8 @@
       "noise": 0,
       "units": "A",
       "description": "Booster-to-storage transport-line vertical corrector 02 current setpoint",
-      "min": 0.0
+      "min": 0.0,
+      "max": 5.0
     },
     "BTS:MAG:VCM:02:STATUS:READY": {
       "value": 1,
@@ -6850,7 +8586,8 @@
       "noise": 0,
       "units": "A",
       "description": "Booster-to-storage transport-line vertical corrector 03 current setpoint",
-      "min": 0.0
+      "min": 0.0,
+      "max": 5.0
     },
     "BTS:MAG:VCM:03:STATUS:READY": {
       "value": 1,
@@ -6869,7 +8606,8 @@
       "noise": 0,
       "units": "A",
       "description": "Booster-to-storage transport-line vertical corrector 04 current setpoint",
-      "min": 0.0
+      "min": 0.0,
+      "max": 5.0
     },
     "BTS:MAG:VCM:04:STATUS:READY": {
       "value": 1,
@@ -6888,7 +8626,8 @@
       "noise": 0,
       "units": "A",
       "description": "Booster-to-storage transport-line vertical corrector 05 current setpoint",
-      "min": 0.0
+      "min": 0.0,
+      "max": 5.0
     },
     "BTS:MAG:VCM:05:STATUS:READY": {
       "value": 1,
@@ -6907,7 +8646,8 @@
       "noise": 0,
       "units": "A",
       "description": "Booster-to-storage transport-line vertical corrector 06 current setpoint",
-      "min": 0.0
+      "min": 0.0,
+      "max": 5.0
     },
     "BTS:MAG:VCM:06:STATUS:READY": {
       "value": 1,

--- a/tests/connectors/test_mock_connector.py
+++ b/tests/connectors/test_mock_connector.py
@@ -1,8 +1,10 @@
 """Tests for mock connector."""
 
+from contextlib import contextmanager
 from datetime import datetime
 from unittest.mock import patch
 
+import numpy as np
 import pytest
 
 from osprey.connectors.archiver.mock_archiver_connector import MockArchiverConnector
@@ -293,3 +295,127 @@ class TestMockArchiverConnector:
         assert values.std() > 0
 
         await connector.disconnect()
+
+
+@contextmanager
+def _captured_sigmas():
+    """Record the sigma of every Gaussian draw the mock connector makes.
+
+    Yields:
+        The list the recorder appends each draw's ``scale`` argument to, so a
+        test can assert on the exact sigma rather than on a sampled value.
+    """
+    sigmas: list[float] = []
+    real_normal = np.random.normal
+
+    def recorder(loc, scale, *args, **kwargs):
+        sigmas.append(scale)
+        return real_normal(loc, scale, *args, **kwargs)
+
+    with patch("osprey.connectors.control_system.mock_connector.np.random.normal", recorder):
+        yield sigmas
+
+
+class TestKindAwareNoiseFloor:
+    """The procedural fallback applies noise multiplicatively, so a channel
+    whose baseline is exactly ``0.0`` is immune to its own noise declaration.
+    Kinds whose base can legitimately be zero therefore carry an absolute sigma
+    floor (``PVKind.noise_scale``); every other kind's sigma is untouched.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("pv_name", "base_value"),
+        [
+            ("SR:BEAM:CURRENT", 500.0),
+            ("PS:CURRENT", 150.0),
+            ("RF:VOLTAGE", 5000.0),
+            ("RF:POWER", 50.0),
+            ("VAC:PRESSURE", 1e-9),
+            ("CRYO:TEMP", 25.0),
+            ("SR:LIFETIME", 10.0),
+            ("SR:ENERGY", 1900.0),
+            ("SOME:RANDOM:PV", 100.0),
+        ],
+    )
+    async def test_non_position_kind_sigma_is_exactly_unchanged(self, pv_name, base_value):
+        """Regression guard: the floor must not perturb any kind with a non-zero base."""
+        with patch("osprey.utils.config.get_config_value", return_value=True):
+            connector = MockConnector()
+            await connector.connect({"response_delay_ms": 0, "noise_level": 0.01})
+            with _captured_sigmas() as sigmas:
+                await connector.read_channel(pv_name)
+            await connector.disconnect()
+
+        assert sigmas == [abs(base_value) * 0.01]
+
+    @pytest.mark.asyncio
+    async def test_position_channel_sigma_at_zero_baseline_is_the_kind_floor(self):
+        with patch("osprey.utils.config.get_config_value", return_value=True):
+            connector = MockConnector()
+            await connector.connect({"response_delay_ms": 0, "noise_level": 0.01})
+            with _captured_sigmas() as sigmas:
+                await connector.read_channel("BPM:POSITION:X")
+            await connector.disconnect()
+
+        assert sigmas == [0.005]
+
+    @pytest.mark.asyncio
+    async def test_position_channel_at_zero_baseline_varies_across_reads(self):
+        with patch("osprey.utils.config.get_config_value", return_value=True):
+            connector = MockConnector()
+            await connector.connect({"response_delay_ms": 0, "noise_level": 0.01})
+
+            values = {(await connector.read_channel("BPM:POSITION:X")).value for _ in range(20)}
+
+            await connector.disconnect()
+
+        assert len(values) > 1, "a 0.0-baseline position channel must still carry noise"
+
+    @pytest.mark.asyncio
+    async def test_floor_stops_binding_once_the_channel_moves_off_zero(self):
+        """Above the floor the sigma is purely relative again -- the floor is a
+        minimum, not an added noise source."""
+        with patch(
+            "osprey.utils.config.get_config_value",
+            side_effect=_config_with_writes_enabled,
+        ):
+            connector = MockConnector()
+            await connector.connect({"response_delay_ms": 0, "noise_level": 0.01})
+            await connector.write_channel("BPM:POSITION:X", 5.0)
+
+            with _captured_sigmas() as sigmas:
+                await connector.read_channel("BPM:POSITION:X")
+
+            await connector.disconnect()
+
+        assert sigmas == [5.0 * 0.01]
+
+    @pytest.mark.asyncio
+    async def test_zero_noise_level_disables_the_floor(self):
+        """``noise_level: 0`` is an explicit request for determinism; the kind
+        floor exists to fix the zero-base degeneracy, not to override that
+        request, so it does not apply when the relative level is zero."""
+        with patch("osprey.utils.config.get_config_value", return_value=True):
+            connector = MockConnector()
+            await connector.connect({"response_delay_ms": 0, "noise_level": 0.0})
+            with _captured_sigmas() as sigmas:
+                await connector.read_channel("BPM:POSITION:X")
+                await connector.read_channel("SR:BEAM:CURRENT")
+            await connector.disconnect()
+
+        assert sigmas == [0.0, 0.0]
+
+    @pytest.mark.asyncio
+    async def test_position_channel_at_zero_noise_level_is_deterministic(self):
+        """True determinism, not merely small variance: repeated reads of a
+        0.0-baseline position channel must return the exact same value."""
+        with patch("osprey.utils.config.get_config_value", return_value=True):
+            connector = MockConnector()
+            await connector.connect({"response_delay_ms": 0, "noise_level": 0.0})
+
+            values = {(await connector.read_channel("BPM:POSITION:X")).value for _ in range(20)}
+
+            await connector.disconnect()
+
+        assert len(values) == 1, "noise_level 0.0 must produce identical reads, not just tight ones"

--- a/tests/connectors/test_pv_taxonomy.py
+++ b/tests/connectors/test_pv_taxonomy.py
@@ -6,30 +6,57 @@ from osprey.connectors.pv_taxonomy import classify_pv
 
 
 @pytest.mark.parametrize(
-    ("pv_name", "kind", "base_value", "units"),
+    ("pv_name", "kind", "base_value", "units", "noise_scale"),
     [
-        ("SR:BEAM:CURRENT", "beam_current", 500.0, "mA"),
-        ("SR:DCCT", "beam_current", 500.0, "mA"),  # DCCT is a beam-current monitor
-        ("PS:CURRENT", "current", 150.0, "A"),
-        ("RF:VOLTAGE", "voltage", 5000.0, "V"),
-        ("RF:POWER", "power", 50.0, "kW"),
-        ("VAC:PRESSURE", "pressure", 1e-9, "Torr"),
-        ("CRYO:TEMP", "temperature", 25.0, "°C"),
-        ("SR:LIFETIME", "lifetime", 10.0, "hours"),
-        ("BPM:POSITION:X", "position", 0.0, "mm"),
-        ("BPM:POS:Y", "position", 0.0, "mm"),
-        ("SR:ENERGY", "energy", 1900.0, "MeV"),
-        ("SOME:RANDOM:PV", "default", 100.0, ""),
+        ("SR:BEAM:CURRENT", "beam_current", 500.0, "mA", 0.0),
+        ("SR:DCCT", "beam_current", 500.0, "mA", 0.0),  # DCCT is a beam-current monitor
+        ("PS:CURRENT", "current", 150.0, "A", 0.0),
+        ("RF:VOLTAGE", "voltage", 5000.0, "V", 0.0),
+        ("RF:POWER", "power", 50.0, "kW", 0.0),
+        ("VAC:PRESSURE", "pressure", 1e-9, "Torr", 0.0),
+        ("CRYO:TEMP", "temperature", 25.0, "°C", 0.0),
+        ("SR:LIFETIME", "lifetime", 10.0, "hours", 0.0),
+        ("BPM:POSITION:X", "position", 0.0, "mm", 0.005),
+        ("BPM:POS:Y", "position", 0.0, "mm", 0.005),
+        ("SR:ENERGY", "energy", 1900.0, "MeV", 0.0),
+        ("SOME:RANDOM:PV", "default", 100.0, "", 0.0),
     ],
 )
-def test_classify_pv(pv_name, kind, base_value, units):
+def test_classify_pv(pv_name, kind, base_value, units, noise_scale):
     result = classify_pv(pv_name)
     assert result.name == kind
     assert result.base_value == base_value
     assert result.units == units
+    assert result.noise_scale == noise_scale
 
 
 def test_beam_current_takes_priority_over_generic_current():
     """A PV matching both 'beam' and 'current' classifies as beam_current."""
     assert classify_pv("BEAM:CURRENT:MONITOR").name == "beam_current"
     assert classify_pv("CORRECTOR:CURRENT").name == "current"
+
+
+def test_position_is_the_only_kind_carrying_an_absolute_noise_floor():
+    """``noise_scale`` exists only for kinds whose base can legitimately be 0.
+
+    A single global absolute floor would be wrong-scale across bases spanning
+    1e-9 Torr to 5000 V, so every kind with a non-zero base keeps ``0.0`` and
+    its fallback sigma stays purely relative.
+    """
+    probes = {
+        "SR:BEAM:CURRENT": 0.0,
+        "PS:CURRENT": 0.0,
+        "RF:VOLTAGE": 0.0,
+        "RF:POWER": 0.0,
+        "VAC:PRESSURE": 0.0,
+        "CRYO:TEMP": 0.0,
+        "SR:LIFETIME": 0.0,
+        "SR:ENERGY": 0.0,
+        "SOME:RANDOM:PV": 0.0,
+        "BPM:POSITION:X": 0.005,
+    }
+    for pv_name, expected in probes.items():
+        kind = classify_pv(pv_name)
+        assert kind.noise_scale == expected, pv_name
+        # The floor is only ever needed where the relative sigma is dead.
+        assert (kind.noise_scale > 0.0) == (kind.base_value == 0.0), pv_name

--- a/tests/deployment/web_terminals/test_persona_images.py
+++ b/tests/deployment/web_terminals/test_persona_images.py
@@ -610,7 +610,7 @@ def test_auto_render_forwards_explicit_overrides_from_parent_manifest(monkeypatc
     assert len(calls) == 1
     cmd = calls[0]
     assert cmd[-4:] == ["--set", "provider=als-apg", "--set", "model=anthropic/claude-opus"]
-    assert "channel_finder_mode=hierarchical" not in " ".join(cmd)
+    assert not any(arg.startswith("channel_finder_mode=") for arg in cmd)
 
 
 def test_auto_render_without_project_root_forwards_nothing(monkeypatch, tmp_path):
@@ -678,4 +678,4 @@ def test_auto_render_forwards_only_keys_with_recorded_values(monkeypatch, tmp_pa
 
     cmd = calls[0]
     assert cmd[-2:] == ["--set", "provider=als-apg"]
-    assert "model" not in " ".join(cmd)
+    assert not any(arg.startswith("model=") for arg in cmd)

--- a/tests/simulation/conftest.py
+++ b/tests/simulation/conftest.py
@@ -42,6 +42,22 @@ TEST_MACHINE = {
         "T:MODE": {"value": "CW", "description": "Operating mode"},
         "T:NOISY": {"value": 100.0, "noise": 0.05, "description": "Noisy diagnostic"},
         "T:VAC": {"value": 8.0e-9, "units": "Torr", "noise": 0.0, "description": "Vacuum"},
+        # Zero-baseline channels: the regime where relative 'noise' multiplies to a
+        # dead-flat constant. They carry the additive keys instead, so they exercise
+        # absolute noise and baseline texture at the 0.0 baseline that broke.
+        "T:ZERO:NOISY": {
+            "value": 0.0,
+            "units": "mm",
+            "noise_abs": 0.02,
+            "description": "Zero-baseline position with absolute noise only",
+        },
+        "T:ZERO:TEXTURED": {
+            "value": 0.0,
+            "units": "mm",
+            "noise_abs": 0.005,
+            "texture": {"kind": "wander", "amplitude": 0.05, "period_s": 3600.0},
+            "description": "Zero-baseline position with absolute noise and wander texture",
+        },
     },
     "scenarios": {
         "nominal": {"description": "All systems nominal."},

--- a/tests/simulation/test_engine.py
+++ b/tests/simulation/test_engine.py
@@ -1,7 +1,9 @@
 """Tests for the SimulationEngine: schema, precedence, scenarios, noise."""
 
 import os
+from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 from osprey.simulation import SimulationEngine, engine_serves
@@ -218,7 +220,12 @@ class TestReadsAndPrecedence:
 
 
 class TestNoise:
-    """Noise semantics: value * (1 + N(0, noise)); strings and noise=0 untouched."""
+    """Live-read noise semantics: ``value * (1 + N(0, noise))`` per ``read()``.
+
+    Strings and ``noise=0`` channels are untouched. This covers the live-read
+    path only; series synthesis uses deterministic keyed draws (relative and
+    absolute) plus texture, pinned in ``test_series.py``.
+    """
 
     def test_noise_zero_is_exact(self, machine_file):
         engine = SimulationEngine.from_file(machine_file)
@@ -236,6 +243,151 @@ class TestNoise:
         machine_dict["channels"]["T:MODE"]["noise"] = 0.5
         engine = SimulationEngine.from_file(make_machine_file(machine_dict))
         assert engine.read("T:MODE").value == "CW"
+
+
+class TestLiveReadSignalModel:
+    """Live-read pipeline: effective -> + texture(now) -> noise -> noise_abs -> clamp.
+
+    Texture is the shared deterministic term (same implementation as synthesis,
+    evaluated at wall-clock now), so a live read and a synthesized sample agree
+    exactly at a shared timestamp for non-overridden channels. Both live noise
+    draws stay stochastic on the engine's RNG — that asymmetry with synthesis
+    is deliberate.
+    """
+
+    TEX_CHANNEL = {
+        "value": 5.0,
+        "noise": 0.0,
+        "texture": {"kind": "wander", "amplitude": 1.0, "period_s": 3600.0},
+        "description": "Noise-free textured channel",
+    }
+    # Spread across the 3600 s period so the instants cannot all sit near
+    # zero crossings of the texture stack.
+    FROZEN_INSTANTS = (1_764_000_000.0, 1_764_000_700.0, 1_764_001_500.0, 1_764_002_600.0)
+
+    @staticmethod
+    def _freeze_now(monkeypatch, epoch):
+        """Freeze the engine module's wall clock without touching stdlib time."""
+        monkeypatch.setattr("osprey.simulation.engine.time", SimpleNamespace(time=lambda: epoch))
+
+    def test_live_read_matches_synthesis_at_frozen_now(
+        self, machine_dict, make_machine_file, monkeypatch
+    ):
+        """FR4: textured live read equals the synthesis sample at the same t, exactly."""
+        machine_dict["channels"]["T:TEX"] = dict(self.TEX_CHANNEL)
+        engine = SimulationEngine.from_file(make_machine_file(machine_dict))
+        contributions = []
+        for frozen in self.FROZEN_INSTANTS:
+            self._freeze_now(monkeypatch, frozen)
+            live = engine.read("T:TEX").value
+            (synthesized,) = engine.synthesize_series("T:TEX", [frozen])
+            assert live == synthesized  # bit-exact, not approx
+            assert live != 5.0  # anti-degenerate: texture actually contributed
+            contributions.append(abs(live - 5.0))
+        # Anti-degenerate: the agreement is about a non-trivial quantity.
+        assert max(contributions) > 0.05
+
+    def test_zero_baseline_live_reads_vary(self, machine_file):
+        """The original bug: zero-baseline channels must not read as hard zeros."""
+        engine = SimulationEngine.from_file(machine_file)
+        sigma = 0.02  # T:ZERO:NOISY noise_abs in conftest
+        values = np.array([engine.read("T:ZERO:NOISY").value for _ in range(300)])
+        assert len(set(values.tolist())) > 1
+        assert 0.5 * sigma < values.std() < 1.5 * sigma
+        assert abs(values.mean()) < 0.5 * sigma
+
+    def test_composed_noise_distribution(self, machine_dict, make_machine_file):
+        """Relative and absolute live noise compose in quadrature around the baseline."""
+        machine_dict["channels"]["T:BOTH"] = {
+            "value": 10.0,
+            "noise": 0.1,
+            "noise_abs": 1.0,
+            "description": "Composed relative + absolute noise",
+        }
+        engine = SimulationEngine.from_file(make_machine_file(machine_dict))
+        values = np.array([engine.read("T:BOTH").value for _ in range(400)])
+        assert values.mean() == pytest.approx(10.0, abs=0.3)
+        assert values.std() == pytest.approx(np.sqrt(2.0), rel=0.2)
+
+    def test_string_channels_untouched(self, machine_file):
+        """String channels pass through the live-read pipeline verbatim."""
+        engine = SimulationEngine.from_file(machine_file)
+        assert {engine.read("T:MODE").value for _ in range(10)} == {"CW"}
+
+    def test_override_shifts_live_read_not_history(self, machine_dict, make_machine_file):
+        """Pin the pre-existing `_effective()` seam — deliberately not fixed here.
+
+        Live reads resolve through ``_effective`` (write > override > baseline),
+        while ``_synthesize`` builds history from ``channel.value`` plus archiver
+        events. An override therefore shifts the live read but not the
+        synthesized history; scenarios that want consistent history declare
+        matching archiver events (the shipped scenarios all do).
+        """
+        machine_dict["channels"]["T:PLAIN"] = {
+            "value": 10.0,
+            "noise": 0.0,
+            "description": "Override-seam probe",
+        }
+        machine_dict["scenarios"]["override-only"] = {
+            "description": "Override without archiver events.",
+            "overrides": {"T:PLAIN": 99.0},
+        }
+        engine = SimulationEngine.from_file(make_machine_file(machine_dict))
+        engine.set_active_scenario("override-only")
+        assert engine.read("T:PLAIN").value == 99.0
+        series = engine.synthesize_series("T:PLAIN", [1_764_000_000.0 + i for i in range(20)])
+        assert series == [10.0] * 20
+
+
+class TestExprRefTextureSemantics:
+    """Derived (expression) channels: the accepted live/archive texture asymmetry.
+
+    Texture is a top-level measurement effect, like noise: a synthesized
+    derived series inherits its referenced channels' texture through the
+    cached per-window series, while a live derived read resolves its
+    references texture-free via ``_numeric_effective``. The asymmetry is
+    documented and pinned here, not silently widened.
+    """
+
+    @staticmethod
+    def _machine(machine_dict):
+        machine_dict["channels"]["T:TEX"] = {
+            "value": 5.0,
+            "noise": 0.0,
+            "texture": {"kind": "wander", "amplitude": 1.0, "period_s": 3600.0},
+            "description": "Noise-free textured channel",
+        }
+        machine_dict["channels"]["T:DERIVED"] = {
+            "expr": "2 * ch('T:TEX')",
+            "noise": 0.0,
+            "description": "Derived from the textured channel",
+        }
+        return machine_dict
+
+    def test_synthesized_derived_series_inherits_texture(self, machine_dict, make_machine_file):
+        """Archive path: the derived series tracks the referenced TEXTURED series exactly."""
+        engine = SimulationEngine.from_file(make_machine_file(self._machine(machine_dict)))
+        ts = [1_764_000_000.0 + i for i in range(300)]
+        tex = np.array(engine.synthesize_series("T:TEX", ts))
+        derived = np.array(engine.synthesize_series("T:DERIVED", ts))
+        np.testing.assert_array_equal(derived, 2.0 * tex)
+        # Anti-degenerate: the inherited texture actually moves — two flat
+        # series would satisfy the relation above trivially.
+        assert np.ptp(derived) > 0.05
+
+    def test_live_derived_read_resolves_texture_free(
+        self, machine_dict, make_machine_file, monkeypatch
+    ):
+        """Live path: references resolve texture-free; only the read channel's own
+        texture would apply (T:DERIVED declares none, so the read is exact)."""
+        engine = SimulationEngine.from_file(make_machine_file(self._machine(machine_dict)))
+        monkeypatch.setattr(
+            "osprey.simulation.engine.time", SimpleNamespace(time=lambda: 1_764_000_000.0)
+        )
+        # Texture is alive on the referenced channel at this frozen instant...
+        assert engine.read("T:TEX").value != 5.0
+        # ...but does not propagate into the derived read.
+        assert engine.read("T:DERIVED").value == 10.0
 
 
 class TestActiveScenarioStateFile:

--- a/tests/simulation/test_machine.py
+++ b/tests/simulation/test_machine.py
@@ -17,6 +17,7 @@ from osprey.simulation.machine import (
     ParsedMachine,
     Scenario,
     SimChannel,
+    TextureSpec,
     _require_event_number,
     _validate_at_time,
     _validate_position_keys,
@@ -107,6 +108,296 @@ class TestParseMachineValidation:
         )
         with pytest.raises(ValueError, match="event shape must be one of"):
             parse_machine(machine, _PATH)
+
+
+def _channels(specs):
+    """A minimal machine wrapping the given ``pv -> spec`` channel mapping."""
+    return {"channels": specs}
+
+
+def _one(spec):
+    """Parse a single-channel machine and return the parsed ``PV:A``."""
+    return parse_machine(_channels({"PV:A": spec}), _PATH).channels["PV:A"]
+
+
+class TestParseNoiseAbs:
+    """``noise_abs``: additive sigma in the channel's declared units."""
+
+    def test_defaults_to_zero_when_absent(self):
+        assert _one({"value": 0.0}).noise_abs == 0.0
+
+    def test_round_trips(self):
+        assert _one({"value": 0.0, "noise_abs": 0.02}).noise_abs == 0.02
+
+    def test_zero_is_allowed(self):
+        assert _one({"value": 0.0, "noise_abs": 0}).noise_abs == 0.0
+
+    def test_int_is_coerced_to_float(self):
+        parsed = _one({"value": 0.0, "noise_abs": 3})
+        assert parsed.noise_abs == 3.0
+        assert isinstance(parsed.noise_abs, float)
+
+    def test_allowed_on_expression_channel(self):
+        machine = _channels(
+            {"PV:A": {"value": 1.0}, "PV:B": {"expr": "ch('PV:A')", "noise_abs": 1}}
+        )
+        assert parse_machine(machine, _PATH).channels["PV:B"].noise_abs == 1.0
+
+    def test_rejects_negative(self):
+        with pytest.raises(ValueError, match="'noise_abs' must be a non-negative number"):
+            _one({"value": 0.0, "noise_abs": -1e-6})
+
+    def test_rejects_non_number(self):
+        with pytest.raises(ValueError, match="'noise_abs' must be a non-negative number"):
+            _one({"value": 0.0, "noise_abs": "0.02"})
+
+    def test_rejects_bool(self):
+        with pytest.raises(ValueError, match="'noise_abs' must be a non-negative number"):
+            _one({"value": 0.0, "noise_abs": True})
+
+    def test_composes_with_relative_noise(self):
+        parsed = _one({"value": 5.0, "noise": 0.01, "noise_abs": 0.2})
+        assert (parsed.noise, parsed.noise_abs) == (0.01, 0.2)
+
+
+class TestParseTexture:
+    """``texture``: the declarative baseline-motion primitive."""
+
+    def test_defaults_to_none_when_absent(self):
+        assert _one({"value": 0.0}).texture is None
+
+    def test_round_trips_into_texture_spec(self):
+        texture = _one(
+            {"value": 0.0, "texture": {"kind": "wander", "amplitude": 0.05, "period_s": 3600}}
+        ).texture
+        assert texture == TextureSpec(kind="wander", amplitude=0.05, period_s=3600.0)
+        assert isinstance(texture.amplitude, float)
+        assert isinstance(texture.period_s, float)
+
+    def test_texture_spec_is_frozen(self):
+        texture = _one(
+            {"value": 0.0, "texture": {"kind": "wander", "amplitude": 1.0, "period_s": 60.0}}
+        ).texture
+        with pytest.raises(Exception):  # noqa: B017 - FrozenInstanceError
+            texture.amplitude = 2.0
+
+    def test_rejects_non_mapping(self):
+        with pytest.raises(ValueError, match="'texture' must be a mapping"):
+            _one({"value": 0.0, "texture": [1, 2]})
+
+    def test_rejects_missing_kind(self):
+        with pytest.raises(ValueError, match=r"'texture' missing keys \['kind'\]"):
+            _one({"value": 0.0, "texture": {"amplitude": 1.0, "period_s": 60.0}})
+
+    def test_rejects_missing_amplitude_and_period(self):
+        with pytest.raises(ValueError, match=r"'texture' missing keys \['amplitude', 'period_s'\]"):
+            _one({"value": 0.0, "texture": {"kind": "wander"}})
+
+    def test_rejects_unknown_kind(self):
+        with pytest.raises(ValueError, match=r"'texture' kind must be one of \['wander'\]"):
+            _one({"value": 0.0, "texture": {"kind": "drift", "amplitude": 1.0, "period_s": 60.0}})
+
+    def test_rejects_unknown_key_inside_texture(self):
+        with pytest.raises(ValueError, match=r"'texture' has unknown keys \['octaves'\]"):
+            _one(
+                {
+                    "value": 0.0,
+                    "texture": {
+                        "kind": "wander",
+                        "amplitude": 1.0,
+                        "period_s": 60.0,
+                        "octaves": 4,
+                    },
+                }
+            )
+
+    def test_rejects_non_positive_amplitude(self):
+        with pytest.raises(ValueError, match="'texture' amplitude must be a number > 0"):
+            _one({"value": 0.0, "texture": {"kind": "wander", "amplitude": 0.0, "period_s": 60.0}})
+
+    def test_rejects_non_positive_period(self):
+        with pytest.raises(ValueError, match="'texture' period_s must be a number > 0"):
+            _one({"value": 0.0, "texture": {"kind": "wander", "amplitude": 1.0, "period_s": -1}})
+
+    def test_rejects_bool_amplitude(self):
+        with pytest.raises(ValueError, match="'texture' amplitude must be a number > 0"):
+            _one({"value": 0.0, "texture": {"kind": "wander", "amplitude": True, "period_s": 60.0}})
+
+    def test_rejects_non_string_kind(self):
+        with pytest.raises(ValueError, match=r"'texture' kind must be one of \['wander'\]"):
+            _one({"value": 0.0, "texture": {"kind": 1, "amplitude": 1.0, "period_s": 60.0}})
+
+    def test_allowed_on_expression_channel(self):
+        machine = _channels(
+            {
+                "PV:A": {"value": 1.0},
+                "PV:B": {
+                    "expr": "ch('PV:A')",
+                    "texture": {"kind": "wander", "amplitude": 0.1, "period_s": 120.0},
+                },
+            }
+        )
+        assert parse_machine(machine, _PATH).channels["PV:B"].texture is not None
+
+
+class TestStringChannelRejectsSignalKeys:
+    """String channels have no numeric signal model (mirrors min/max rejection)."""
+
+    def test_rejects_noise_abs(self):
+        with pytest.raises(
+            ValueError, match="'noise_abs' is not supported on string-valued channels"
+        ):
+            _one({"value": "CW", "noise_abs": 0.1})
+
+    def test_rejects_texture(self):
+        with pytest.raises(
+            ValueError, match="'texture' is not supported on string-valued channels"
+        ):
+            _one({"value": "CW", "texture": {"kind": "wander", "amplitude": 1.0, "period_s": 60.0}})
+
+    def test_string_channel_without_signal_keys_parses(self):
+        assert _one({"value": "CW"}).value == "CW"
+
+
+class TestUnknownTopLevelKeyLeniency:
+    """FR8: adding the two keys does not tighten top-level unknown-key handling."""
+
+    def test_unknown_top_level_key_is_ignored(self):
+        assert _one({"value": 1.0, "wibble": "whatever"}).value == 1.0
+
+
+class TestSimChannelDefaults:
+    """FR: existing fixtures must construct unchanged (both new fields default)."""
+
+    def test_constructs_without_new_fields(self):
+        channel = SimChannel(
+            name="PV:A",
+            value=1.0,
+            expr=None,
+            refs=(),
+            units="A",
+            noise=0.01,
+            description="d",
+        )
+        assert channel.noise_abs == 0.0
+        assert channel.texture is None
+
+    def test_still_frozen(self):
+        channel = SimChannel("PV:A", 1.0, None, (), "A", 0.0, "d")
+        with pytest.raises(Exception):  # noqa: B017 - FrozenInstanceError
+            channel.noise_abs = 1.0
+
+
+def _warnings(caplog):
+    """WARNING-level records captured during a parse."""
+    return [r for r in caplog.records if r.levelno >= 30]
+
+
+class TestDeadConfigParseGuard:
+    """FR7: one aggregated warning per parsed file for the dead configuration.
+
+    Dead configuration = ``value == 0.0`` with relative ``noise > 0`` and neither
+    additive key, which multiplies to a constant 0.0.
+    """
+
+    DEAD = {"value": 0.0, "noise": 0.05}
+
+    def test_warns_exactly_once_for_many_dead_channels(self, caplog):
+        machine = _channels({f"PV:{i}": dict(self.DEAD) for i in range(20)})
+        with caplog.at_level("WARNING"):
+            parse_machine(machine, _PATH)
+        assert len(_warnings(caplog)) == 1
+
+    def test_warning_names_the_count(self, caplog):
+        machine = _channels({f"PV:{i}": dict(self.DEAD) for i in range(20)})
+        with caplog.at_level("WARNING"):
+            parse_machine(machine, _PATH)
+        assert "20 channel(s)" in caplog.text
+
+    def test_warning_lists_up_to_five_examples_then_elides(self, caplog):
+        machine = _channels({f"PV:{i}": dict(self.DEAD) for i in range(20)})
+        with caplog.at_level("WARNING"):
+            parse_machine(machine, _PATH)
+        for i in range(5):
+            assert f"PV:{i}" in caplog.text
+        assert "PV:5" not in caplog.text
+        assert "(+15 more)" in caplog.text
+
+    def test_no_elision_when_five_or_fewer(self, caplog):
+        machine = _channels({f"PV:{i}": dict(self.DEAD) for i in range(3)})
+        with caplog.at_level("WARNING"):
+            parse_machine(machine, _PATH)
+        assert "more)" not in caplog.text
+        assert "3 channel(s)" in caplog.text
+
+    def test_warning_states_the_remedy_and_the_file(self, caplog):
+        with caplog.at_level("WARNING"):
+            parse_machine(_channels({"PV:A": dict(self.DEAD)}), _PATH)
+        assert "noise_abs" in caplog.text
+        assert "texture" in caplog.text
+        assert "machine.json" in caplog.text
+
+    def test_never_raises(self):
+        parse_machine(_channels({"PV:A": dict(self.DEAD)}), _PATH)  # no raise
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            pytest.param({"value": 0.0, "noise": 0.05, "noise_abs": 0.01}, id="has-noise-abs"),
+            pytest.param(
+                {
+                    "value": 0.0,
+                    "noise": 0.05,
+                    "texture": {"kind": "wander", "amplitude": 1.0, "period_s": 60.0},
+                },
+                id="has-texture",
+            ),
+            pytest.param({"value": 0.0, "noise": 0.0}, id="no-relative-noise"),
+            pytest.param({"value": 0.0}, id="noise-absent"),
+            pytest.param({"value": 100.0, "noise": 0.05}, id="non-zero-baseline"),
+            pytest.param({"value": "CW"}, id="string-channel"),
+            pytest.param({"value": -0.0, "noise": 0.0}, id="negative-zero-no-noise"),
+        ],
+    )
+    def test_no_warning_for_healthy_configurations(self, spec, caplog):
+        with caplog.at_level("WARNING"):
+            parse_machine(_channels({"PV:A": spec}), _PATH)
+        assert _warnings(caplog) == []
+
+    def test_expression_channel_is_never_flagged(self, caplog):
+        machine = _channels(
+            {"PV:A": {"value": 1.0}, "PV:B": {"expr": "ch('PV:A') * 0", "noise": 0.05}}
+        )
+        with caplog.at_level("WARNING"):
+            parse_machine(machine, _PATH)
+        assert _warnings(caplog) == []
+
+    def test_only_dead_channels_are_counted(self, caplog):
+        machine = _channels(
+            {
+                "PV:DEAD": dict(self.DEAD),
+                "PV:OK": {"value": 0.0, "noise": 0.05, "noise_abs": 0.01},
+                "PV:LIVE": {"value": 100.0, "noise": 0.05},
+            }
+        )
+        with caplog.at_level("WARNING"):
+            parse_machine(machine, _PATH)
+        assert "1 channel(s)" in caplog.text
+        assert "PV:DEAD" in caplog.text
+        assert "PV:OK" not in caplog.text
+
+
+class TestZeroBaselineFixtures:
+    """The shared conftest zero-baseline channels are healthy by construction."""
+
+    def test_fixture_channels_parse_with_signal_keys(self, machine_dict, caplog):
+        with caplog.at_level("WARNING"):
+            channels = parse_machine(machine_dict, _PATH).channels
+        assert channels["T:ZERO:NOISY"].value == 0.0
+        assert channels["T:ZERO:NOISY"].noise_abs == 0.02
+        assert channels["T:ZERO:NOISY"].texture is None
+        assert channels["T:ZERO:TEXTURED"].texture == TextureSpec("wander", 0.05, 3600.0)
+        assert _warnings(caplog) == []
 
 
 _PREFIX = "Scenario 'x', channel 'PV:A'"

--- a/tests/simulation/test_series.py
+++ b/tests/simulation/test_series.py
@@ -1,5 +1,6 @@
 """Tests for synthesize_series(): archiver event shapes and pointwise exprs."""
 
+import copy
 from datetime import UTC, datetime, timedelta
 
 import numpy as np
@@ -16,7 +17,13 @@ def _timestamps(n=200):
 
 
 class TestBaselineSeries:
-    """Baseline-value channels: constant baseline plus per-channel noise."""
+    """Baseline-value channels: constant baseline plus the channel's declared signal model.
+
+    Relative ``noise`` scales the series multiplicatively, ``noise_abs`` adds an
+    absolute-sigma term, and both are deterministic keyed draws addressed by
+    (channel, absolute timestamp) — not stateful RNG streams — so a channel with
+    neither declared stays exactly constant.
+    """
 
     def test_constant_baseline_no_noise(self, machine_file):
         engine = SimulationEngine.from_file(machine_file)
@@ -43,6 +50,192 @@ class TestBaselineSeries:
         engine = SimulationEngine.from_file(machine_file)
         with pytest.raises(KeyError):
             engine.synthesize_series("NO:SUCH:PV", _timestamps())
+
+
+def _abs_window(offset_s=0, n=600, step_s=1):
+    """UTC-aware 1 Hz (by default) timestamps, absolutely positioned."""
+    start = datetime(2024, 3, 11, 12, 0, 0, tzinfo=UTC) + timedelta(seconds=offset_s)
+    return [start + timedelta(seconds=i * step_s) for i in range(n)]
+
+
+class TestSignalModelSynthesis:
+    """Deterministic keyed noise (relative + absolute) and wander texture.
+
+    Synthesis draws are pure functions of (channel name, absolute timestamp):
+    identical or overlapping archiver windows agree pointwise on shared
+    timestamps, zero-baseline channels carry additive ``noise_abs``, and
+    ``texture`` adds slow baseline motion that rides post-event levels.
+    """
+
+    def test_absolute_noise_on_zero_baseline(self, machine_file):
+        """FR1: sigma>0 on a 0.0 baseline produces N(0, sigma) samples, never a constant."""
+        engine = SimulationEngine.from_file(machine_file)
+        series = np.array(engine.synthesize_series("T:ZERO:NOISY", _abs_window(n=500)))
+        sigma = 0.02  # T:ZERO:NOISY noise_abs in conftest
+        assert len(set(series.tolist())) > 1
+        assert 0.5 * sigma < series.std() < 1.5 * sigma
+        assert abs(series.mean()) < 0.5 * sigma
+
+    def test_identical_windows_agree_across_engine_instances(self, machine_dict, make_machine_file):
+        """FR2: two independently-built engines synthesize identical series."""
+        engine_a = SimulationEngine.from_file(make_machine_file(machine_dict, "machine_a.json"))
+        engine_b = SimulationEngine.from_file(make_machine_file(machine_dict, "machine_b.json"))
+        ts = _abs_window(n=300)
+        for pv in ("T:NOISY", "T:ZERO:NOISY", "T:ZERO:TEXTURED"):
+            assert engine_a.synthesize_series(pv, ts) == engine_b.synthesize_series(pv, ts)
+
+    def test_overlapping_windows_agree_pointwise(self, machine_file):
+        """FR2: overlapping windows agree exactly on shared timestamps.
+
+        Covers texture and both noise kinds; fails if any draw or the texture is
+        evaluated on window-relative rather than absolute time.
+        """
+        engine = SimulationEngine.from_file(machine_file)
+        window_a = _abs_window(offset_s=0, n=600)
+        window_b = _abs_window(offset_s=300, n=600)
+        for pv in ("T:NOISY", "T:ZERO:NOISY", "T:ZERO:TEXTURED"):
+            series_a = engine.synthesize_series(pv, window_a)
+            series_b = engine.synthesize_series(pv, window_b)
+            assert series_a[300:600] == series_b[0:300]
+
+    def test_jittered_windows_agree_on_shared_timestamps(self, machine_file):
+        """FR2: window start, length, and sampling stride don't perturb shared samples."""
+        engine = SimulationEngine.from_file(machine_file)
+        full = engine.synthesize_series("T:ZERO:TEXTURED", _abs_window(n=600))
+        shifted = engine.synthesize_series("T:ZERO:TEXTURED", _abs_window(offset_s=37, n=100))
+        assert shifted == full[37:137]
+        strided = engine.synthesize_series("T:ZERO:TEXTURED", _abs_window(n=100, step_s=5))
+        assert strided == full[0:500:5]
+
+    def test_relative_and_absolute_noise_are_independent_streams(
+        self, machine_dict, make_machine_file
+    ):
+        """The two noise draws compose in quadrature, proving distinct subkeys.
+
+        With value=10, noise=0.1, noise_abs=1.0 the independent-stream std is
+        sqrt((10*0.1)^2 + 1^2) ~= 1.414; a shared stream would add the sigmas
+        coherently and read ~2.0, well outside the asserted band.
+        """
+        machine_dict["channels"]["T:BOTH"] = {
+            "value": 10.0,
+            "noise": 0.1,
+            "noise_abs": 1.0,
+            "description": "Composed relative + absolute noise",
+        }
+        engine = SimulationEngine.from_file(make_machine_file(machine_dict))
+        series = np.array(engine.synthesize_series("T:BOTH", _abs_window(n=2000)))
+        assert series.mean() == pytest.approx(10.0, abs=0.15)
+        assert series.std() == pytest.approx(np.sqrt(2.0), rel=0.12)
+
+    def test_texture_moves_the_baseline(self, machine_dict, make_machine_file):
+        """Anti-degenerate: texture measurably changes and varies the series, bounded."""
+        machine_dict["channels"]["T:TEX"] = {
+            "value": 5.0,
+            "noise": 0.0,
+            "texture": {"kind": "wander", "amplitude": 1.0, "period_s": 3600.0},
+            "description": "Pure texture channel",
+        }
+        engine = SimulationEngine.from_file(make_machine_file(machine_dict))
+        series = np.array(engine.synthesize_series("T:TEX", _abs_window(n=600)))
+        offsets = series - 5.0
+        assert np.max(np.abs(offsets)) > 0.01  # differs from the texture-free constant
+        assert np.ptp(offsets) > 0.05  # and actually moves within the window
+        assert np.max(np.abs(offsets)) <= 1.0 + 1e-9  # |wander| <= amplitude
+
+    def test_step_plateau_carries_texture_and_noise(self, machine_dict, make_machine_file):
+        """FR6: texture and noise ride the post-step plateau (events applied first).
+
+        The textured/texture-free twin comparison isolates the texture
+        contribution (same channel name, hence identical noise draws): applying
+        texture before the step would let the overwrite erase it and collapse
+        the plateau difference to zero.
+        """
+        machine_dict["channels"]["T:STEPPED"] = {
+            "value": 42.0,
+            "noise": 0.0,
+            "noise_abs": 0.05,
+            "texture": {"kind": "wander", "amplitude": 1.0, "period_s": 3600.0},
+            "description": "Stepped channel with texture and absolute noise",
+        }
+        machine_dict["scenarios"]["stepped"] = {
+            "description": "Step down mid-window.",
+            "archiver": [
+                {
+                    "channel": "T:STEPPED",
+                    "events": [{"shape": "step", "at": 0.35, "to": 28.4}],
+                }
+            ],
+        }
+        textured_file = make_machine_file(machine_dict, "textured.json")
+        plain_dict = copy.deepcopy(machine_dict)
+        del plain_dict["channels"]["T:STEPPED"]["texture"]
+        plain_file = make_machine_file(plain_dict, "plain.json")
+
+        ts = _abs_window(n=600)
+        t = np.linspace(0, 1, 600)
+        engine = SimulationEngine.from_file(textured_file)
+        engine.set_active_scenario("stepped")
+        textured = np.array(engine.synthesize_series("T:STEPPED", ts))
+        plain_engine = SimulationEngine.from_file(plain_file)
+        plain_engine.set_active_scenario("stepped")
+        plain = np.array(plain_engine.synthesize_series("T:STEPPED", ts))
+
+        # Noise rides the plateau: the texture-free twin shows the declared
+        # noise_abs sigma there — and nothing more (texture-scale motion would
+        # blow the upper band).
+        plateau_noise = (plain - 28.4)[t >= 0.4]
+        assert 0.5 * 0.05 < plateau_noise.std() < 1.5 * 0.05
+        # Texture rides the plateau: the twin diff isolates it from the noise.
+        texture_contribution = (textured - plain)[t >= 0.4]
+        assert np.ptp(texture_contribution) > 0.05  # survives the step overwrite
+        assert np.max(np.abs(texture_contribution)) <= 1.0 + 1e-9
+
+    def test_at_time_recurrence_unaffected_by_texture(self, machine_dict, make_machine_file):
+        """FR6: daily ``at_time`` events still fire every date on a textured channel."""
+        machine_dict["channels"]["T:VAC"]["texture"] = {
+            "kind": "wander",
+            "amplitude": 1.0e-9,
+            "period_s": 3600.0,
+        }
+        machine_dict["scenarios"]["burst"] = {
+            "description": "Daily vacuum burst.",
+            "archiver": [
+                {
+                    "channel": "T:VAC",
+                    "events": [
+                        {"shape": "spike", "at_time": "14:32:08", "amplitude": 1.5e-7, "width": 600}
+                    ],
+                }
+            ],
+        }
+        engine = SimulationEngine.from_file(make_machine_file(machine_dict))
+        engine.set_active_scenario("burst")
+        start = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+        ts = [start + timedelta(minutes=10 * i) for i in range(288)]  # 2 days @ 10 min
+        series = engine.synthesize_series("T:VAC", ts)
+        peaks = [i for i in range(1, 287) if series[i] > 1.0e-7]
+        assert {ts[i].date() for i in peaks} == {ts[0].date(), ts[-1].date()}
+
+    def test_non_epoch_timestamps_fall_back_deterministically(
+        self, machine_dict, make_machine_file
+    ):
+        """t_abs=None: noise falls back to sample-index counters; texture is skipped."""
+        opaque = ["not-a-timestamp"] * 200
+        textured_file = make_machine_file(machine_dict, "textured.json")
+        plain_dict = copy.deepcopy(machine_dict)
+        del plain_dict["channels"]["T:ZERO:TEXTURED"]["texture"]
+        plain_file = make_machine_file(plain_dict, "plain.json")
+
+        engine = SimulationEngine.from_file(textured_file)
+        noisy = np.array(engine.synthesize_series("T:ZERO:NOISY", opaque))
+        assert noisy.std() > 0  # the fallback still draws real noise
+        assert engine.synthesize_series("T:ZERO:NOISY", opaque) == noisy.tolist()
+
+        # Texture needs absolute time; without it the textured channel matches
+        # its texture-free twin exactly (identical fallback noise draws).
+        textured = engine.synthesize_series("T:ZERO:TEXTURED", opaque)
+        plain_engine = SimulationEngine.from_file(plain_file)
+        assert textured == plain_engine.synthesize_series("T:ZERO:TEXTURED", opaque)
 
 
 class TestSeriesBounds:

--- a/tests/simulation/test_series_primitives.py
+++ b/tests/simulation/test_series_primitives.py
@@ -6,14 +6,18 @@ module's standalone contract so the extracted primitives can be refactored
 without going through the full engine each time.
 """
 
+import hashlib
+import math
 import os
 import time
 from datetime import datetime
+from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import numpy as np
 import pytest
 
+from osprey.simulation import series as series_module
 from osprey.simulation.expressions import ExpressionError
 from osprey.simulation.series import (
     apply_events,
@@ -21,9 +25,76 @@ from osprey.simulation.series import (
     daily_occurrences,
     epoch_seconds_array,
     event_positions,
+    keyed_normals,
+    pv_key_bytes,
     ref_value,
     string_series,
+    wander,
 )
+
+# --------------------------------------------------------------------------
+# Deliberately-slow per-sample reference implementation of the pinned draw
+# construction. It lives here (not in src/) on purpose: it is the independent
+# witness that the vectorized batch path consumes exactly two words per sample
+# and therefore stays pointwise-deterministic. Pure Python ints, one sample at
+# a time, no numpy — the opposite implementation strategy from the real one.
+# --------------------------------------------------------------------------
+
+_MASK64 = (1 << 64) - 1
+_GAMMA = 0x9E3779B97F4A7C15
+_MIX_A = 0xBF58476D1CE4E5B9
+_MIX_B = 0x94D049BB133111EB
+_TWO_POW_M53 = 2.0**-53
+
+
+def _reference_mix64(z: int) -> int:
+    """splitmix64 finalizer over Python ints."""
+    z = ((z ^ (z >> 30)) * _MIX_A) & _MASK64
+    z = ((z ^ (z >> 27)) * _MIX_B) & _MASK64
+    return (z ^ (z >> 31)) & _MASK64
+
+
+def _reference_key_words(pv_key: bytes) -> tuple[int, int]:
+    digest = hashlib.sha256(pv_key).digest()
+    return int.from_bytes(digest[0:8], "big"), int.from_bytes(digest[8:16], "big")
+
+
+def _reference_words(pv_key: bytes, counter: int) -> tuple[int, int]:
+    """The two words consumed by a single sample."""
+    k0, k1 = _reference_key_words(pv_key)
+    base = (counter * _GAMMA) & _MASK64
+    return _reference_mix64(base ^ k0), _reference_mix64(base ^ k1)
+
+
+def _reference_normal(pv_key: bytes, counter: int) -> float:
+    w0, w1 = _reference_words(pv_key, counter)
+    u1 = ((w0 >> 11) | 1) * _TWO_POW_M53
+    u2 = (w1 >> 11) * _TWO_POW_M53
+    return math.sqrt(-2.0 * math.log(u1)) * math.cos(2.0 * math.pi * u2)
+
+
+def _unxor_shift(y: int, shift: int) -> int:
+    """Invert ``x -> x ^ (x >> shift)`` by fixed-point iteration."""
+    x = y
+    for _ in range(64 // shift + 1):
+        x = y ^ (x >> shift)
+    return x
+
+
+def _reference_unmix64(z: int) -> int:
+    """Inverse of :func:`_reference_mix64` (the finalizer is a bijection)."""
+    z = _unxor_shift(z, 31)
+    z = (z * pow(_MIX_B, -1, 1 << 64)) & _MASK64
+    z = _unxor_shift(z, 27)
+    z = (z * pow(_MIX_A, -1, 1 << 64)) & _MASK64
+    return _unxor_shift(z, 30)
+
+
+def _counter_producing_zero_word(pv_key: bytes, lane: int) -> int:
+    """The unique counter whose ``lane`` word mixes to exactly zero."""
+    key_word = _reference_key_words(pv_key)[lane]
+    base = _reference_unmix64(0) ^ key_word
+    return (base * pow(_GAMMA, -1, 1 << 64)) & _MASK64
 
 
 class TestClamp:
@@ -204,3 +275,460 @@ class TestApplyEvents:
         assert out[5] == pytest.approx(2.0, rel=1e-6)
         # Input is not mutated (apply_events copies).
         np.testing.assert_array_equal(series, np.zeros(11))
+
+
+class TestPvKeyBytes:
+    def test_is_sha256_of_the_utf8_name(self):
+        assert pv_key_bytes("SR:BPM1:X") == hashlib.sha256(b"SR:BPM1:X").digest()
+
+    def test_stable_and_distinct_per_name(self):
+        assert pv_key_bytes("A") == pv_key_bytes("A")
+        assert pv_key_bytes("A") != pv_key_bytes("B")
+
+    def test_builtin_hash_is_not_used(self):
+        """``hash()`` is PYTHONHASHSEED-randomized per process, so a key derived
+        from it would silently change between runs. Same-name keys must be
+        reproducible against a literal digest computed outside this process."""
+        expected = bytes.fromhex("07b788d9e5c120d3471cb7245b835ab1bfd5ac347f77e92488b177f617ecaf2f")
+        assert pv_key_bytes("SR:HCM:1:SP") == expected
+
+
+class TestKeyedNormals:
+    """The pinned fixed-consumption draw construction (FR12).
+
+    ``Generator.normal(size=n)`` is forbidden on this path: it uses ziggurat
+    rejection sampling with *variable* stream consumption, so a batch draw from
+    a window-start counter does not equal the per-sample draws — pointwise
+    determinism breaks invisibly. These tests pin the alternative.
+    """
+
+    def test_matches_per_sample_reference_exactly(self):
+        key = pv_key_bytes("SR:BPM:07:X")
+        counters = np.arange(1_764_500_000_000, 1_764_500_000_000 + 500, 100, dtype=np.uint64)
+
+        out = keyed_normals(key, counters)
+
+        expected = np.array([_reference_normal(key, int(c)) for c in counters])
+        np.testing.assert_array_equal(out, expected)
+
+    def test_word_stage_matches_reference_exactly(self):
+        """Exactness anchor below the transcendentals: if the normals ever
+        disagree while the words and uniforms still match bit-for-bit, the cause
+        is a 1-ULP libm/SIMD difference, not a broken construction."""
+        key = pv_key_bytes("SR:BPM:07:Y")
+        counters = np.arange(1_764_500_000_000, 1_764_500_000_000 + 200, dtype=np.uint64)
+
+        w0, w1 = series_module._keyed_words(key, counters)
+
+        expected = [_reference_words(key, int(c)) for c in counters]
+        np.testing.assert_array_equal(w0, np.array([w[0] for w in expected], dtype=np.uint64))
+        np.testing.assert_array_equal(w1, np.array([w[1] for w in expected], dtype=np.uint64))
+
+    def test_consumes_exactly_two_words_per_sample(self):
+        """A batch of n samples uses the n-th sample's own counter, never a
+        running stream position: drawing one sample in isolation reproduces its
+        value inside any batch."""
+        key = pv_key_bytes("SR:HCM:12:SP")
+        counters = np.arange(9_000_000, 9_000_000 + 64, dtype=np.uint64)
+
+        batch = keyed_normals(key, counters)
+
+        for i in (0, 1, 17, 63):
+            single = keyed_normals(key, np.array([counters[i]], dtype=np.uint64))
+            assert single[0] == batch[i]
+
+    def test_pointwise_stable_across_separate_calls(self):
+        key = pv_key_bytes("SR:VCM:03:SP")
+        counters = np.array([1, 2, 3, 1_700_000_000_000], dtype=np.uint64)
+
+        np.testing.assert_array_equal(keyed_normals(key, counters), keyed_normals(key, counters))
+
+    def test_pointwise_stable_under_slicing_and_reordering(self):
+        key = pv_key_bytes("SR:VCM:04:SP")
+        counters = np.arange(2_000_000, 2_000_100, dtype=np.uint64)
+
+        full = keyed_normals(key, counters)
+
+        np.testing.assert_array_equal(keyed_normals(key, counters[10:40]), full[10:40])
+        np.testing.assert_array_equal(keyed_normals(key, counters[::-1]), full[::-1])
+        order = np.array([73, 5, 5, 99, 0], dtype=np.intp)
+        np.testing.assert_array_equal(keyed_normals(key, counters[order]), full[order])
+
+    def test_overlapping_windows_agree_on_shared_counters(self):
+        """Two windows that share timestamps must agree exactly on the overlap —
+        the property that window-start-seeded batch draws cannot provide."""
+        key = pv_key_bytes("SR:DCCT:CURRENT")
+        window_a = np.arange(1_764_000_000_000, 1_764_000_060_000, 1000, dtype=np.uint64)
+        window_b = np.arange(1_764_000_030_000, 1_764_000_090_000, 1000, dtype=np.uint64)
+
+        draws_a = keyed_normals(key, window_a)
+        draws_b = keyed_normals(key, window_b)
+
+        np.testing.assert_array_equal(draws_a[30:], draws_b[:30])
+
+    def test_distinct_keys_give_distinct_draws(self):
+        counters = np.arange(500, dtype=np.uint64)
+
+        a = keyed_normals(pv_key_bytes("SR:BPM:01:X"), counters)
+        b = keyed_normals(pv_key_bytes("SR:BPM:01:Y"), counters)
+
+        assert not np.any(a == b)
+        assert abs(float(np.corrcoef(a, b)[0, 1])) < 0.15
+
+    def test_zero_mixed_word_stays_finite(self):
+        """Open-interval mapping: ``u1 = ((w >> 11) | 1) * 2**-53`` keeps
+        ``u1 > 0`` even for the one counter whose word mixes to exactly zero, so
+        ``log(u1)`` can never be ``-inf``. A shared-mapping defect here would be
+        invisible to the equivalence test, hence a dedicated test."""
+        key = pv_key_bytes("SR:BPM:99:X")
+
+        for lane in (0, 1):
+            counter = _counter_producing_zero_word(key, lane)
+            assert _reference_words(key, counter)[lane] == 0  # the setup is real
+
+            counters = np.array([counter], dtype=np.uint64)
+            w0, w1 = series_module._keyed_words(key, counters)
+            assert int((w0 if lane == 0 else w1)[0]) == 0
+
+            out = keyed_normals(key, counters)
+            assert np.isfinite(out).all()
+            assert out[0] == _reference_normal(key, counter)
+            # sqrt(-2 * log(2**-53)) is the largest magnitude the mapping admits.
+            assert abs(float(out[0])) <= math.sqrt(2.0 * 53.0 * math.log(2.0))
+
+    def test_no_inf_or_nan_over_a_large_sweep(self):
+        key = pv_key_bytes("SR:BPM:42:X")
+        counters = np.arange(200_000, dtype=np.uint64)
+
+        assert np.isfinite(keyed_normals(key, counters)).all()
+
+    def test_distribution_sanity(self):
+        key = pv_key_bytes("SR:BPM:11:X")
+        counters = np.arange(100_000, dtype=np.uint64)
+
+        out = keyed_normals(key, counters)
+
+        assert abs(float(out.mean())) < 0.02
+        assert float(out.std()) == pytest.approx(1.0, abs=0.02)
+        # Box-Muller cosine branch is symmetric; tails should be populated.
+        assert float(np.abs(out).max()) > 3.5
+
+    def test_accepts_float_counters_by_rounding(self):
+        """Callers derive counters as ``epoch_seconds * 1000``, which arrives as
+        float64; the draw must key on the rounded integer millisecond."""
+        key = pv_key_bytes("SR:BPM:05:X")
+
+        out = keyed_normals(key, np.array([1_764_000_000_123.4, 1_764_000_000_122.5]))
+
+        assert out[0] == _reference_normal(key, 1_764_000_000_123)
+        assert out[1] == _reference_normal(key, 1_764_000_000_122)  # rint: half to even
+
+    def test_accepts_signed_and_negative_counters(self):
+        """Sample-index fallback counters are plain int64; pre-epoch timestamps
+        make them negative. Both must key deterministically rather than raise."""
+        key = pv_key_bytes("SR:BPM:06:X")
+        counters = np.array([-2, -1, 0, 1], dtype=np.int64)
+
+        out = keyed_normals(key, counters)
+
+        assert np.isfinite(out).all()
+        np.testing.assert_array_equal(out, keyed_normals(key, counters))
+        assert out[2] == _reference_normal(key, 0)
+        assert out[0] == _reference_normal(key, (-2) & _MASK64)
+
+    def test_shape_dtype_and_empty_input(self):
+        key = pv_key_bytes("SR:BPM:08:X")
+
+        out = keyed_normals(key, np.arange(6, dtype=np.uint64).reshape(2, 3))
+        assert out.shape == (2, 3)
+        assert out.dtype == np.float64
+
+        empty = keyed_normals(key, np.array([], dtype=np.uint64))
+        assert empty.shape == (0,)
+        assert empty.dtype == np.float64
+
+    def test_subkeys_are_independent_streams(self):
+        """Relative and absolute noise draw from the same counters; a distinct
+        subkey keeps the two streams from being the same number twice."""
+        counters = np.arange(1000, dtype=np.uint64)
+        base = pv_key_bytes("SR:BPM:09:X")
+
+        rel = keyed_normals(base + b":noise", counters)
+        absolute = keyed_normals(base + b":noise_abs", counters)
+
+        assert not np.any(rel == absolute)
+
+    def test_perf_144_channels_by_10000_samples(self):
+        """FR12 perf sanity: the pointwise-correct per-generator loop this
+        construction replaces cost ~11.6 s for the same workload."""
+        counters = np.arange(1_764_000_000_000, 1_764_000_000_000 + 10_000, dtype=np.uint64)
+
+        start = time.perf_counter()
+        for channel in range(144):
+            keyed_normals(pv_key_bytes(f"SR:SIM:{channel}:X"), counters)
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < 1.0, f"144 x 10,000 draws took {elapsed:.3f}s (budget 1.0s)"
+
+    def test_construction_uses_no_numpy_generator(self):
+        """``series`` is the deterministic core: a stateful numpy generator in it
+        would reintroduce stream-position-dependent draws. The guard matches
+        call-shaped tokens so prose may still explain the trap it prevents."""
+        source = Path(series_module.__file__).read_text(encoding="utf-8")
+
+        assert "np.random" not in source
+        assert "default_rng(" not in source
+        assert ".normal(" not in source
+
+
+class TestWanderComponents:
+    """Structural pins on the component stack behind :func:`wander`."""
+
+    def test_component_count_is_in_the_declared_range(self):
+        periods, phases, weights = series_module._wander_components(pv_key_bytes("PV:A"), 3600.0)
+
+        assert 4 <= len(periods) <= 6
+        assert len(phases) == len(periods)
+        assert len(weights) == len(periods)
+
+    def test_period_s_is_the_slowest_period(self):
+        """``period_s`` names the slowest component, not the only one."""
+        periods, _, _ = series_module._wander_components(pv_key_bytes("PV:A"), 3600.0)
+
+        assert periods[0] == 3600.0
+        assert np.all(np.diff(periods) < 0.0)  # strictly decreasing
+
+    def test_periods_span_three_to_four_octaves_log_spaced(self):
+        periods, _, _ = series_module._wander_components(pv_key_bytes("PV:A"), 3600.0)
+
+        octaves = np.log2(periods[0] / periods[-1])
+        assert 3.0 <= octaves <= 4.0
+        # Log-spaced => equal octave steps between neighbours.
+        steps = np.diff(np.log2(periods))
+        np.testing.assert_allclose(steps, steps[0], rtol=1e-12)
+
+    def test_period_ratios_are_not_simple_rationals(self):
+        """Incommensurate in the practical sense: no pair of components shares a
+        short common period, so the stack does not visibly repeat."""
+        periods, _, _ = series_module._wander_components(pv_key_bytes("PV:A"), 3600.0)
+
+        for i in range(len(periods)):
+            for j in range(i + 1, len(periods)):
+                ratio = periods[i] / periods[j]
+                for q in range(1, 5):
+                    for p in range(1, 4 * q + 1):
+                        assert abs(ratio - p / q) > 0.02, f"{ratio} ~= {p}/{q}"
+
+    def test_weights_are_normalized_and_slowest_dominates(self):
+        """Envelope bound comes from ``sum(weights) == 1`` with positive weights,
+        and the log-space jitter is narrower than the decay step, so the slowest
+        component dominates for EVERY channel rather than only on average."""
+        for name in [f"PV:{i}" for i in range(50)]:
+            _, _, weights = series_module._wander_components(pv_key_bytes(name), 3600.0)
+
+            assert float(weights.sum()) == pytest.approx(1.0, abs=1e-12)
+            assert np.all(weights > 0.0)
+            assert np.all(np.diff(weights) < 0.0)
+
+    def test_phases_cover_the_circle_and_differ_per_channel(self):
+        phases = np.concatenate(
+            [
+                series_module._wander_components(pv_key_bytes(f"PV:{i}"), 3600.0)[1]
+                for i in range(60)
+            ]
+        )
+
+        assert np.all(phases >= 0.0)
+        assert np.all(phases < 2.0 * np.pi)
+        assert phases.min() < 0.5 and phases.max() > 2.0 * np.pi - 0.5
+        assert len(np.unique(phases)) == len(phases)
+
+
+class TestWander:
+    """The declarative baseline-texture primitive.
+
+    One component covers both timescales: with ``period_s`` of many hours the
+    slowest terms read as a distinct quasi-static per-channel offset inside any
+    short query window, while the faster octaves supply visible motion.
+    """
+
+    def test_envelope_is_bounded_by_amplitude(self):
+        amplitude = 25.0
+        t = np.linspace(1.7e9, 1.7e9 + 200_000.0, 20_001)
+
+        for name in [f"SR:BPM:{i}:X" for i in range(20)]:
+            out = wander(pv_key_bytes(name), t, amplitude, 3600.0)
+
+            assert np.all(np.abs(out) <= amplitude)
+            assert np.isfinite(out).all()
+
+    def test_bound_is_structural_not_clipping(self):
+        """Doubling the amplitude doubles every sample exactly. A clipped
+        implementation is nonlinear at the bound and fails this."""
+        key = pv_key_bytes("SR:BPM:3:X")
+        t = np.linspace(1.7e9, 1.7e9 + 50_000.0, 5_001)
+
+        single = wander(key, t, 1.0, 3600.0)
+        double = wander(key, t, 2.0, 3600.0)
+
+        np.testing.assert_array_equal(double, 2.0 * single)
+        # Nothing piles up at the bound the way a clip would.
+        assert np.abs(single).max() < 1.0
+
+    def test_deterministic_per_channel_and_time(self):
+        key = pv_key_bytes("SR:BPM:4:X")
+        t = np.linspace(1.7e9, 1.7e9 + 10_000.0, 1_001)
+
+        np.testing.assert_array_equal(wander(key, t, 10.0, 3600.0), wander(key, t, 10.0, 3600.0))
+        # Order-independent: a reordered request returns reordered values.
+        order = np.array([500, 3, 999, 0, 3], dtype=np.intp)
+        np.testing.assert_array_equal(
+            wander(key, t[order], 10.0, 3600.0), wander(key, t, 10.0, 3600.0)[order]
+        )
+
+    def test_overlapping_windows_agree_exactly_on_shared_timestamps(self):
+        """The two windows are built independently (not sliced from a common
+        array) so the shared timestamps are equal by value, and the texture must
+        agree bit-for-bit there — this is what makes overlapping archiver
+        queries consistent."""
+        key = pv_key_bytes("SR:BPM:5:X")
+        window_a = np.arange(1_764_000_000.0, 1_764_000_600.0, 5.0)
+        window_b = np.arange(1_764_000_300.0, 1_764_000_900.0, 5.0)
+
+        draws_a = wander(key, window_a, 10.0, 3600.0)
+        draws_b = wander(key, window_b, 10.0, 3600.0)
+
+        shared = 60  # 300 s of overlap at 5 s spacing
+        np.testing.assert_array_equal(window_a[shared:], window_b[:shared])
+        np.testing.assert_array_equal(draws_a[shared:], draws_b[:shared])
+
+    def test_long_window_mean_is_about_zero(self):
+        """Texture is ambient motion, not a fake static baseline: over many
+        slow periods it averages out, so the declared ``value: 0.0`` still reads
+        as zero on a daily mean."""
+        amplitude = 40.0
+        period_s = 3600.0
+        t = np.linspace(1.7e9, 1.7e9 + 400 * period_s, 200_001)
+
+        for name in ["SR:BPM:1:X", "SR:BPM:2:Y", "SR:HCM:9:CURRENT:RB"]:
+            out = wander(pv_key_bytes(name), t, amplitude, period_s)
+
+            assert abs(float(out.mean())) < 0.02 * amplitude
+
+    def test_distinct_channels_get_distinct_offsets_in_a_short_window(self):
+        """Family-uniform declared parameters, per-channel apparent offset — the
+        offsets come from the seeded phases, not from per-entry amplitudes."""
+        amplitude = 30.0
+        t = np.linspace(1.7e9, 1.7e9 + 60.0, 61)
+
+        offsets = np.array(
+            [
+                float(wander(pv_key_bytes(f"SR:BPM:{i}:X"), t, amplitude, 86400.0).mean())
+                for i in range(144)
+            ]
+        )
+
+        assert len(np.unique(offsets)) == len(offsets)
+        # The spread is a visible fraction of the envelope, not a hairline.
+        assert float(offsets.std()) > 0.1 * amplitude
+
+    def test_short_window_drift_is_small_when_period_dominates_the_window(self):
+        amplitude = 50.0
+        t = np.linspace(1.7e9, 1.7e9 + 60.0, 61)  # 60 s window vs a 24 h period
+
+        for name in [f"SR:BPM:{i}:X" for i in range(20)]:
+            out = wander(pv_key_bytes(name), t, amplitude, 86400.0)
+
+            assert float(out.max() - out.min()) < 0.1 * amplitude
+
+    def test_motion_is_visible_over_a_window_spanning_the_period(self):
+        """Guards the degenerate pass: a constant (or all-zero) texture would
+        satisfy the envelope, determinism and drift tests above."""
+        amplitude = 30.0
+        period_s = 3600.0
+        t = np.linspace(1.7e9, 1.7e9 + 2 * period_s, 4_001)
+
+        for name in [f"SR:BPM:{i}:X" for i in range(20)]:
+            out = wander(pv_key_bytes(name), t, amplitude, period_s)
+
+            assert float(out.max() - out.min()) > 0.3 * amplitude
+
+    def test_does_not_repeat_at_the_slowest_period(self):
+        """Incommensurate components mean the stack is not periodic in
+        ``period_s`` — a harmonic stack would repeat exactly one period later."""
+        key = pv_key_bytes("SR:BPM:6:X")
+        period_s = 3600.0
+        t = np.linspace(1.7e9, 1.7e9 + period_s, 2_001)
+
+        now = wander(key, t, 20.0, period_s)
+        one_period_later = wander(key, t + period_s, 20.0, period_s)
+
+        assert float(np.abs(now - one_period_later).max()) > 0.1 * 20.0
+
+    def test_faster_octaves_move_within_a_window_far_shorter_than_period_s(self):
+        """The quasi-static term is not the whole story: inside a window that is
+        a small fraction of ``period_s`` there is still real motion, which is
+        what puts wander back on the BPM plots."""
+        amplitude = 30.0
+        t = np.linspace(1.7e9, 1.7e9 + 1800.0, 1_801)  # 30 min of a 24 h period
+
+        spans = [
+            float(np.ptp(wander(pv_key_bytes(f"SR:BPM:{i}:X"), t, amplitude, 86400.0)))
+            for i in range(20)
+        ]
+
+        assert min(spans) > 0.001 * amplitude
+        assert float(np.median(spans)) > 0.01 * amplitude
+
+    def test_is_pure_and_does_not_mutate_input(self):
+        key = pv_key_bytes("SR:BPM:7:X")
+        t = np.linspace(1.7e9, 1.7e9 + 1000.0, 101)
+        original = t.copy()
+
+        first = wander(key, t, 10.0, 3600.0)
+        wander(pv_key_bytes("SR:BPM:8:X"), t, 99.0, 60.0)  # interleaved other call
+        second = wander(key, t, 10.0, 3600.0)
+
+        np.testing.assert_array_equal(t, original)
+        np.testing.assert_array_equal(first, second)
+
+    def test_zero_amplitude_is_flat(self):
+        out = wander(pv_key_bytes("SR:BPM:9:X"), np.linspace(1.7e9, 1.7e9 + 100.0, 11), 0.0, 60.0)
+
+        np.testing.assert_array_equal(out, np.zeros(11))
+
+    def test_shape_dtype_and_empty_input(self):
+        key = pv_key_bytes("SR:BPM:10:X")
+
+        out = wander(key, np.full((2, 3), 1.7e9), 5.0, 3600.0)
+        assert out.shape == (2, 3)
+        assert out.dtype == np.float64
+
+        empty = wander(key, np.array([]), 5.0, 3600.0)
+        assert empty.shape == (0,)
+        assert empty.dtype == np.float64
+
+    def test_scalar_live_read_matches_the_synthesized_sample_exactly(self):
+        """The live-read path samples texture at a single wall-clock instant while
+        synthesis passes a whole window. Both go through this one function, so a
+        live read at time ``t`` and the synthesized sample at ``t`` must be the
+        same number — bit-for-bit, not merely close."""
+        key = pv_key_bytes("SR:BPM:12:X")
+        now = 1_764_000_000.5
+
+        live = wander(key, now, 30.0, 86400.0)
+        window = np.array([now - 1.0, now, now + 1.0])
+        synthesized = wander(key, window, 30.0, 86400.0)
+
+        assert float(live) == float(synthesized[1])
+        assert np.asarray(live).shape == ()
+
+    def test_non_positive_period_is_rejected(self):
+        """A zero/negative period would divide to inf and put NaN in the series —
+        the exact class of silent corruption this feature exists to remove."""
+        key = pv_key_bytes("SR:BPM:11:X")
+        t = np.linspace(1.7e9, 1.7e9 + 100.0, 11)
+
+        for bad in (0.0, -1.0):
+            with pytest.raises(ValueError, match="period_s"):
+                wander(key, t, 10.0, bad)

--- a/tests/templates/test_machine_json_lattice.py
+++ b/tests/templates/test_machine_json_lattice.py
@@ -23,7 +23,9 @@ from __future__ import annotations
 
 import json
 from collections import Counter
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -208,6 +210,212 @@ class TestQfaShfShdCarryGenuineAnchors:
         for c in setpoints:
             entry = machine_channels[c["address"]]
             assert entry["value"] != 0.0, c["address"]
+
+
+@dataclass(frozen=True)
+class _Subfamily:
+    """One calibrated subfamily of machine.json entries.
+
+    Attributes:
+        prefix: Address prefix every member shares.
+        suffix: Address suffix every member shares.
+        count: Exact number of member addresses expected.
+        entry: The full expected entry. ``description`` is a template whose
+            ``{index}`` placeholder is filled with the member's device index --
+            that index is the *only* thing allowed to vary across members.
+    """
+
+    prefix: str
+    suffix: str
+    count: int
+    entry: dict[str, Any]
+
+
+# The 288 SR channels below used to synthesize dead-flat zeros: their noise was
+# relative and their baseline is 0.0, so `value * noise` was identically 0. They
+# now carry absolute noise plus a wander texture. These dicts are the calibrated
+# contract, pinned verbatim so a later hand-edit of machine.json cannot quietly
+# desynchronize one device from its subfamily or drift the whole subfamily back
+# towards flatness.
+#
+# The two texture periods differ ON PURPOSE and must not be "harmonised":
+#   * BPM (43200 s) needs per-channel DISTINCTNESS -- adjacent BPMs must sit in
+#     visibly separate lanes across a 3-hour window, which needs the slow
+#     component to dominate within-window motion.
+#   * Corrector RB (21600 s) needs visible mA-scale ripple tracking a setpoint of
+#     ~0, where distinctness is meaningless and a longer period would only
+#     flatten the ripple.
+# One shared value would serve one job and break the other.
+_SUBFAMILIES: dict[str, _Subfamily] = {
+    "SR BPM POSITION:X": _Subfamily(
+        prefix="SR:DIAG:BPM:",
+        suffix=":POSITION:X",
+        count=72,
+        entry={
+            "value": 0.0,
+            "noise_abs": 0.001,
+            "texture": {"kind": "wander", "amplitude": 0.03, "period_s": 43200.0},
+            "units": "mm",
+            "description": (
+                "Storage-ring BPM {index} horizontal position readback (pyat-coupled -- "
+                "recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
+            ),
+        },
+    ),
+    "SR BPM POSITION:Y": _Subfamily(
+        prefix="SR:DIAG:BPM:",
+        suffix=":POSITION:Y",
+        count=72,
+        entry={
+            "value": 0.0,
+            "noise_abs": 0.001,
+            "texture": {"kind": "wander", "amplitude": 0.03, "period_s": 43200.0},
+            "units": "mm",
+            "description": (
+                "Storage-ring BPM {index} vertical position readback (pyat-coupled -- "
+                "recomputed from the AT lattice model; ideal closed orbit, 0.0 mm baseline)"
+            ),
+        },
+    ),
+    "SR HCM CURRENT:RB": _Subfamily(
+        prefix="SR:MAG:HCM:",
+        suffix=":CURRENT:RB",
+        count=72,
+        entry={
+            "value": 0.0,
+            "noise_abs": 0.001,
+            "texture": {"kind": "wander", "amplitude": 0.005, "period_s": 21600.0},
+            "units": "A",
+            "description": (
+                "Storage-ring horizontal corrector {index} current readback (nominal ~0.0 A; "
+                "pyat-coupled -- backed by the AT lattice model)"
+            ),
+            "min": -12.0,
+            "max": 12.0,
+        },
+    ),
+    "SR VCM CURRENT:RB": _Subfamily(
+        prefix="SR:MAG:VCM:",
+        suffix=":CURRENT:RB",
+        count=72,
+        entry={
+            "value": 0.0,
+            "noise_abs": 0.001,
+            "texture": {"kind": "wander", "amplitude": 0.005, "period_s": 21600.0},
+            "units": "A",
+            "description": (
+                "Storage-ring vertical corrector {index} current readback (nominal ~0.0 A; "
+                "pyat-coupled -- backed by the AT lattice model)"
+            ),
+            "min": -12.0,
+            "max": 12.0,
+        },
+    ),
+    "SR HCM CURRENT:SP": _Subfamily(
+        prefix="SR:MAG:HCM:",
+        suffix=":CURRENT:SP",
+        count=72,
+        entry={
+            "value": 0.0,
+            "noise": 0,
+            "units": "A",
+            "description": "Storage-ring horizontal corrector {index} current setpoint",
+            "min": -12.0,
+            "max": 12.0,
+        },
+    ),
+    "SR VCM CURRENT:SP": _Subfamily(
+        prefix="SR:MAG:VCM:",
+        suffix=":CURRENT:SP",
+        count=72,
+        entry={
+            "value": 0.0,
+            "noise": 0,
+            "units": "A",
+            "description": "Storage-ring vertical corrector {index} current setpoint",
+            "min": -12.0,
+            "max": 12.0,
+        },
+    ),
+}
+
+# BTS corrector setpoints are deliberately NOT part of the uniform-entry sweep
+# above: they were excluded from the zero-baseline calibration because each one
+# carries a genuine per-device baseline (0.984 .. 1.235 A). Only their bounds,
+# noise and units are subfamily-uniform, so only those are pinned.
+_BTS_CORRECTOR_SP_PREFIXES = ("BTS:MAG:HCM:", "BTS:MAG:VCM:")
+_BTS_CORRECTOR_SP_COUNT = 12
+_BTS_CORRECTOR_SP_BOUNDS: dict[str, Any] = {"min": 0.0, "max": 5.0, "noise": 0, "units": "A"}
+_BTS_CORRECTOR_SP_KEYS = {"value", "noise", "units", "description", "min", "max"}
+
+
+def _members(machine_channels: dict, sub: _Subfamily) -> list[str]:
+    """Return the sorted addresses belonging to ``sub``."""
+    return sorted(
+        addr
+        for addr in machine_channels
+        if addr.startswith(sub.prefix) and addr.endswith(sub.suffix)
+    )
+
+
+def _device_index(address: str) -> str:
+    """Return the device-index field of a ``RING:GROUP:FAMILY:NN:...`` address."""
+    return address.split(":")[3]
+
+
+class TestCalibratedSubfamiliesAreUniform:
+    """Every member of a calibrated subfamily must be byte-identical to its
+    subfamily spec once the device index is substituted in.
+
+    This is a drift guard over the 288 SR channels that were calibrated out of
+    dead-flat zeros (absolute noise + wander texture) plus the corrector current
+    band. Equality is over the WHOLE entry, so it also catches a stray extra key
+    or a silently dropped one."""
+
+    @pytest.mark.parametrize("subfamily_name", sorted(_SUBFAMILIES))
+    def test_subfamily_member_count(self, subfamily_name, machine_channels):
+        sub = _SUBFAMILIES[subfamily_name]
+        assert len(_members(machine_channels, sub)) == sub.count
+
+    @pytest.mark.parametrize("subfamily_name", sorted(_SUBFAMILIES))
+    def test_every_member_matches_the_subfamily_spec(self, subfamily_name, machine_channels):
+        sub = _SUBFAMILIES[subfamily_name]
+        members = _members(machine_channels, sub)
+        assert members, subfamily_name
+        for address in members:
+            expected = dict(sub.entry)
+            expected["description"] = expected["description"].format(index=_device_index(address))
+            assert machine_channels[address] == expected, address
+
+    def test_bpm_and_corrector_rb_periods_stay_distinct(self):
+        """The two wander periods are a deliberate asymmetry, not an oversight."""
+        bpm_period = _SUBFAMILIES["SR BPM POSITION:X"].entry["texture"]["period_s"]
+        rb_period = _SUBFAMILIES["SR HCM CURRENT:RB"].entry["texture"]["period_s"]
+        assert bpm_period == 43200.0
+        assert rb_period == 21600.0
+        assert bpm_period != rb_period
+
+
+class TestBtsCorrectorSetpointBoundsAreUniform:
+    """BTS corrector setpoints share bounds, noise and units -- but NOT ``value``.
+
+    Each of the 12 carries its own non-zero operational baseline, which is why
+    they were excluded from the zero-baseline calibration; pinning ``value``
+    here would be wrong."""
+
+    def test_bts_corrector_setpoints_share_bounds_but_not_values(self, machine_channels):
+        addresses = sorted(
+            addr
+            for addr in machine_channels
+            if addr.startswith(_BTS_CORRECTOR_SP_PREFIXES) and addr.endswith(":CURRENT:SP")
+        )
+        assert len(addresses) == _BTS_CORRECTOR_SP_COUNT
+        for address in addresses:
+            entry = machine_channels[address]
+            assert set(entry) == _BTS_CORRECTOR_SP_KEYS, address
+            for field, value in _BTS_CORRECTOR_SP_BOUNDS.items():
+                assert entry[field] == value, f"{address}.{field}"
+            assert entry["value"] != 0.0, address
 
 
 class TestMachineJsonParsesAsValidMachineDescription:

--- a/tests/va/test_engine_source.py
+++ b/tests/va/test_engine_source.py
@@ -11,6 +11,7 @@ import json
 import os
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from osprey.services.virtual_accelerator.ioc.engine_source import EngineSource
@@ -24,6 +25,7 @@ from osprey.simulation.engine import SimulationEngine
 VAC_RB = "ZZTEST:VAC:PRESSURE:01:RB"
 FAULT_BI = "ZZTEST:STATUS:01:FAULT"
 NOT_IN_MACHINE = "ZZTEST:UNKNOWN:01:LEVEL:RB"
+POSITION_UNMODELED = "ZZTEST:BPM:01:POSITION:X:RB"
 
 TEST_MACHINE = {
     "name": "EngineSourceTestRig",
@@ -230,3 +232,137 @@ class TestLegacyFallbackForUnmodeledChannels:
         src = EngineSource(engine, channels, recs, data_dir)
         src.poll_once()
         assert isinstance(recs[bi_addr].value, bool)
+
+
+class _RecordingRng:
+    """Stand-in for a numpy Generator that records each draw's sigma.
+
+    Lets a test assert on the exact noise sigma the fallback asked for rather
+    than on a sampled value.
+
+    Args:
+        draw: The standard-normal deviate every ``normal()`` call returns.
+    """
+
+    def __init__(self, draw: float = 1.0) -> None:
+        self.sigmas: list[float] = []
+        self._draw = draw
+
+    def normal(self, loc: float, scale: float) -> float:
+        self.sigmas.append(scale)
+        return loc + self._draw * scale
+
+
+class TestKindAwareNoiseFloor:
+    """The legacy fallback applies noise relative to the taxonomy base value,
+    so an unmodeled channel whose kind has a ``0.0`` base is immune to its own
+    ``noise`` flag. Kinds whose base can legitimately be zero carry an absolute
+    sigma floor; every other kind's sigma stays exactly what it is today.
+    """
+
+    NOISE_LEVEL = 0.05
+
+    def _driven(self, engine, data_dir, address: str, *, rng=None):
+        """Build a source driving one noisy unmodeled address of any kind."""
+        channels = [*CHANNELS, _channel(address, record_type=RECORD_TYPE_ANALOG, noise=True)]
+        recs = {addr: FakeRecord() for addr in [VAC_RB, FAULT_BI, NOT_IN_MACHINE, address]}
+        src = EngineSource(engine, channels, recs, data_dir, noise_level=self.NOISE_LEVEL)
+        if rng is not None:
+            src._rng = rng
+        return src, recs
+
+    @pytest.mark.parametrize(
+        ("address", "base_value"),
+        [
+            ("ZZTEST:DCCT:01:BEAM:CURRENT:RB", 500.0),
+            ("ZZTEST:PS:01:CURRENT:RB", 150.0),
+            ("ZZTEST:RF:01:VOLTAGE:RB", 5000.0),
+            ("ZZTEST:RF:01:POWER:RB", 50.0),
+            ("ZZTEST:VAC:02:PRESSURE:RB", 1e-9),
+            ("ZZTEST:CRYO:01:TEMP:RB", 25.0),
+            ("ZZTEST:SR:01:LIFETIME:RB", 10.0),
+            ("ZZTEST:SR:01:ENERGY:RB", 1900.0),
+            ("ZZTEST:UNKNOWN:03:LEVEL:RB", 100.0),
+        ],
+    )
+    def test_non_position_kind_sigma_is_exactly_unchanged(
+        self, engine, data_dir, address, base_value
+    ):
+        """Regression guard: the floor must not perturb any kind with a non-zero base."""
+        rng = _RecordingRng()
+        src, _recs = self._driven(engine, data_dir, address, rng=rng)
+        src.poll_once()
+
+        assert rng.sigmas == [abs(base_value) * self.NOISE_LEVEL]
+
+    def test_non_position_kind_spread_is_statistically_unchanged(self, engine, data_dir):
+        """Formulation-independent companion to the sigma assertion above: the
+        realised spread of a non-zero-base kind still matches ``base * level``."""
+        address = "ZZTEST:UNKNOWN:04:LEVEL:RB"
+        src, recs = self._driven(engine, data_dir, address)
+        src._rng = np.random.default_rng(20260730)
+
+        samples = []
+        for _ in range(300):
+            src.poll_once()
+            samples.append(recs[address].value)
+
+        expected_sigma = 100.0 * self.NOISE_LEVEL  # default kind base
+        assert np.std(samples) == pytest.approx(expected_sigma, rel=0.2)
+        assert np.mean(samples) == pytest.approx(100.0, abs=expected_sigma)
+
+    def test_position_kind_sigma_at_zero_base_is_the_kind_floor(self, engine, data_dir):
+        rng = _RecordingRng()
+        src, _recs = self._driven(engine, data_dir, POSITION_UNMODELED, rng=rng)
+        src.poll_once()
+
+        assert rng.sigmas == [0.005]
+
+    def test_position_kind_at_zero_base_varies_across_polls(self, engine, data_dir):
+        src, recs = self._driven(engine, data_dir, POSITION_UNMODELED)
+
+        values = set()
+        for _ in range(20):
+            src.poll_once()
+            values.add(recs[POSITION_UNMODELED].value)
+
+        assert len(values) > 1, "a 0.0-base position channel must still carry noise"
+
+    def test_zero_noise_level_disables_the_floor_and_is_deterministic(self, engine, data_dir):
+        """``noise_level: 0`` is an explicit request for determinism; the kind
+        floor exists to fix the zero-base degeneracy, not to override that
+        request, so a position channel polled repeatedly at level 0.0 returns
+        the exact same value every time (true determinism, not just small
+        variance)."""
+        channels = [
+            *CHANNELS,
+            _channel(POSITION_UNMODELED, record_type=RECORD_TYPE_ANALOG, noise=True),
+        ]
+        recs = {
+            addr: FakeRecord() for addr in [VAC_RB, FAULT_BI, NOT_IN_MACHINE, POSITION_UNMODELED]
+        }
+        src = EngineSource(engine, channels, recs, data_dir, noise_level=0.0)
+
+        values = set()
+        for _ in range(20):
+            src.poll_once()
+            values.add(recs[POSITION_UNMODELED].value)
+
+        assert values == {0.0}
+
+    def test_non_noisy_position_channel_stays_exactly_zero(self, engine, data_dir):
+        """The floor is a sigma floor, not a value source: a channel whose
+        manifest entry says ``noise: false`` is still perfectly static."""
+        channels = [
+            *CHANNELS,
+            _channel(POSITION_UNMODELED, record_type=RECORD_TYPE_ANALOG, noise=False),
+        ]
+        recs = {
+            addr: FakeRecord() for addr in [VAC_RB, FAULT_BI, NOT_IN_MACHINE, POSITION_UNMODELED]
+        }
+        src = EngineSource(engine, channels, recs, data_dir, noise_level=self.NOISE_LEVEL)
+
+        src.poll_once()
+        src.poll_once()
+
+        assert recs[POSITION_UNMODELED].value == 0.0


### PR DESCRIPTION
Simulated channels that sit at a `0.0` baseline used to read back as dead-flat
constants. Channel `noise` is multiplicative, so a channel declaring noise on a
zero baseline got exactly zero noise — BPM positions and corrector current
readbacks were perfectly still, in live reads and in synthesized archiver history
alike.

Machine files gain two optional per-channel keys: `noise_abs`, an absolute
Gaussian sigma in the channel's own units, and `texture`, a declarative slow
wander block. Both apply on the live-read and synthesis paths in the order
baseline → events → texture → relative noise → absolute noise → clamp; texture
rides post-event levels because step and ramp events overwrite the series.
Relative `noise` keeps its existing semantics, and files using neither key parse
and behave exactly as before. Loading a machine file that declares relative noise
on a zero baseline now emits one aggregated warning naming the affected channels.

Synthesis draws move to a counter-based keyed construction, making history a
pointwise function of channel and timestamp — so identical, overlapping and
jittered queries agree at shared timestamps. Live reads keep the engine's
stateful generator.

Channels served without a machine file get the same treatment through a second
path: `PVKind` gains an optional `noise_scale`, non-zero only for kinds whose
base can legitimately be zero, and both the mock connector and the virtual
accelerator's legacy source take `sigma = max(abs(base) * noise_level,
kind.noise_scale)` through one shared implementation. A `noise_level` of exactly
`0.0` disables the floor, so an explicit request for determinism is honoured. A
single global floor would be wrong-scale across bases spanning 1e-9 Torr to
5000 V.

Finally, the shipped control-assistant simulation data is calibrated against the
new keys, so archiver plots show organic motion with a distinct per-channel
offset instead of flat lines, and every storage-ring corrector current entry
gains the symmetric upper bound its lower bound implied.

## How it hangs together

```text
  machine.json                     per-channel: noise, noise_abs, texture
       │
       │  load + validate ─── machine.py
       │                      warns once, naming channels that declare
       ▼                      relative noise on a 0.0 baseline
  ┌──────────────────────────── SimulationEngine (engine.py) ───────────────────────────┐
  │                                                                                     │
  │   read(pv)                                   synthesize_series(pv, timestamps)      │
  │   live · stateful RNG                        history · pointwise in (pv, t)         │
  │        │                                                    │                       │
  │        └──────────────────┬─────────────────────────────────┘                       │
  │                           ▼                                                         │
  │                  _apply_signal_model()                                              │
  │                                                                                     │
  │   baseline ─► events ─► texture ─► rel. noise ─► abs. noise ─► clamp                │
  │                            │           │             │                              │
  └────────────────────────────┼───────────┼─────────────┼──────────────────────────────┘
                               ▼           └──────┬──────┘
                        series.wander             ▼
                                          series.keyed_normals
                                          counter-keyed on pv_key + timestamp_ms

  channels with no machine file ── fallback floor ──────────────────────────────

       mock_connector.py  ─────┐
                               ├──►  sigma = max(|base| · noise_level, kind.noise_scale)
       va/ioc/engine_source.py ┘                              PVKind (pv_taxonomy.py)
```
