### PR TITLE
fix(web): resolve the project once, refuse configless launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,13 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Changed
 
+- `osprey web` now resolves the project it serves once, up front (`--project`,
+  then `OSPREY_CONFIG`, then the current directory) and refuses to launch when
+  no `config.yml` is resolvable, instead of silently serving a terminal with
+  only the universal panels. The launch banner names the resolved project, the
+  resolved config is published to child processes (including the `--reload`
+  worker), and a detached server's command line always carries `--project` so
+  a copied restart cannot lose the project identity.
 - `osprey deploy --dev` now fails with a clear error when the local osprey wheel
   cannot be built, instead of warning and deploying the pinned PyPI release.
   Previously a missing `build` package (or a broken local checkout) produced one

--- a/src/osprey/cli/web_cmd.py
+++ b/src/osprey/cli/web_cmd.py
@@ -17,6 +17,7 @@ import sys
 import time
 from collections.abc import Mapping
 from pathlib import Path
+from typing import NoReturn
 
 import click
 
@@ -118,43 +119,89 @@ def _write_pid(project_dir: Path, pid: int) -> None:
     (project_dir / PID_FILE).write_text(str(pid))
 
 
-def _enter_project(project: str | None) -> None:
-    """Make ``--project`` authoritative, so it behaves like ``cd <project>``.
+def _resolve_project_config(project: str | None) -> tuple[Path, Path]:
+    """Resolve THE project this server serves, and make it authoritative.
 
-    Nearly everything the web terminal touches is resolved relative to the
-    process working directory — ``config.yml`` (:func:`resolve_config_path`),
-    the project ``.env``, ``.claude/``, and ``watch_dir``/``_agent_data``. The
-    ``--project`` flag previously only reached ``app.state.project_cwd``, so
-    launching from anywhere else left every one of those pointing at the
-    operator's shell directory: the project ``.env`` was never loaded, config
-    ``${VAR}`` placeholders (e.g. a provider ``api_key``) stayed unexpanded,
-    the project's ``web_terminal``/``claude_code`` settings were silently
-    replaced by built-in defaults, and ``_agent_data/`` was created in the
-    wrong place. Changing directory here fixes all of them at one point
-    instead of threading a project path through each resolver.
+    Single source of truth for the project identity of ``osprey web``.
+    Everything the server and its children resolve — config.yml (panels,
+    companion servers, providers), the project ``.env``, ``.claude/``, and
+    ``watch_dir``/``_agent_data`` — must derive from one decision made once,
+    up front. Resolution order:
 
-    Without ``--project`` only the ``.env`` load applies — a bare ``osprey web``
-    already runs in the project directory. That load happens here, rather than
-    just before the server starts as it used to, so the ``get_config_value``
-    reads below expand ``${VAR}`` against it and both entry paths stay
-    identical.
+      1. ``--project`` (explicit flag): behaves exactly like ``cd <project> &&
+         osprey web`` — the process chdirs into it so every cwd-relative
+         resolver agrees, and the flag outranks an ambient ``OSPREY_CONFIG``
+         export, which may still point at whichever project the operator last
+         worked in.
+      2. ``OSPREY_CONFIG`` env var: honored where it points, with NO chdir —
+         an explicit export is the operator's own pin on the config alone, so
+         cwd-relative state (``.claude/``, ``_agent_data``) deliberately stays
+         in the invoking directory. A dangling path is a launch error, not a
+         silent fallback.
+      3. ``<cwd>/config.yml``: the plain ``osprey web`` inside a project.
+
+    A launch with NO resolvable config is an error, not a degraded mode: the
+    panel set, companion servers, and provider wiring all come from
+    config.yml, so a configless launch comes up as a mystery terminal with
+    most of its rail missing ("my panels vanished") instead of pointing at
+    the actual problem (wrong directory).
+
+    On success, publishes the resolved path to ``OSPREY_CONFIG`` so this
+    process, every child (PTY shells and their MCP servers), and the
+    ``--reload`` worker (which re-imports ``create_app()`` with no arguments)
+    all resolve the SAME config, then loads the project ``.env``
+    (:func:`osprey.mcp_env.load_dotenv_from_project` keys off that same
+    publication) so the ``get_config_value`` reads that follow expand
+    ``${VAR}`` placeholders against it.
+
+    Returns:
+        ``(project_dir, config_path)``, both absolute.
     """
     if project:
         # Resolve against the invoking shell's cwd — before the chdir, or a
         # relative --project would be resolved against itself.
         project_dir = Path(project).resolve()
+        config_path = project_dir / "config.yml"
+        if not config_path.is_file():
+            _abort_no_project_config(project_dir)
         os.chdir(project_dir)
+    elif os.environ.get("OSPREY_CONFIG"):
+        # Same expansion as osprey.utils.workspace.resolve_config_path().
+        config_path = Path(os.path.expandvars(os.environ["OSPREY_CONFIG"])).expanduser()
+        if not config_path.is_file():
+            click.echo(
+                f"ERROR: OSPREY_CONFIG points to a missing config file: {config_path}",
+                err=True,
+            )
+            raise SystemExit(1)
+        config_path = config_path.resolve()
+        project_dir = config_path.parent
+    else:
+        project_dir = Path.cwd().resolve()
+        config_path = project_dir / "config.yml"
+        if not config_path.is_file():
+            _abort_no_project_config(project_dir)
 
-        # An explicit flag outranks an ambient OSPREY_CONFIG export, which may
-        # still point at whichever project the operator last worked in. Child
-        # PTY shells and their MCP servers inherit this to find the project.
-        project_config = project_dir / "config.yml"
-        if project_config.is_file():
-            os.environ["OSPREY_CONFIG"] = str(project_config)
+    os.environ["OSPREY_CONFIG"] = str(config_path)
 
     from osprey.mcp_env import load_dotenv_from_project
 
     load_dotenv_from_project()
+    return project_dir, config_path
+
+
+def _abort_no_project_config(project_dir: Path) -> NoReturn:
+    """Refuse the launch, naming the three ways to point at a project."""
+    click.echo(
+        f"ERROR: No OSPREY project found — config.yml missing in {project_dir}\n\n"
+        "The web terminal needs a project config to know which panels,\n"
+        "companion servers, and providers to serve. Either:\n"
+        "  - run from a project directory containing config.yml, or\n"
+        "  - pass --project /path/to/project, or\n"
+        "  - set OSPREY_CONFIG=/path/to/config.yml",
+        err=True,
+    )
+    raise SystemExit(1)
 
 
 def _preflight_vendor_check() -> None:
@@ -240,20 +287,7 @@ def _probe_companion_ports() -> list[str]:
     return failures
 
 
-def _resolve_project_config_path(project_dir: Path) -> Path:
-    """Resolve config.yml the same way ``resolve_config_path()`` does, for *project_dir*.
-
-    Mirrors ``osprey.utils.workspace.resolve_config_path()`` (``OSPREY_CONFIG``
-    env var first, else ``<dir>/config.yml``) but keyed off the pre-flight's
-    already-resolved ``project_dir`` instead of ``Path.cwd()`` — the two agree
-    whenever ``--project`` isn't passed, since ``project_dir`` defaults to cwd.
-    """
-    return Path(
-        os.path.expandvars(os.environ.get("OSPREY_CONFIG", str(project_dir / "config.yml")))
-    )
-
-
-def _probe_auth_secret(project_dir: Path | None) -> tuple[list[str], list[str]]:
+def _probe_auth_secret(project_dir: Path) -> tuple[list[str], list[str]]:
     """Probe 2: the resolved provider's auth secret must be resolvable before launch.
 
     A proxy provider (als-apg, cborg, a custom ``api.providers`` entry, ...)
@@ -263,20 +297,18 @@ def _probe_auth_secret(project_dir: Path | None) -> tuple[list[str], list[str]]:
     a warning, not an abort.
 
     Checks both ``os.environ`` and the project's ``.env`` (via
-    ``dotenv_values``, which reads without mutating ``os.environ``): the real
-    launch's ``load_dotenv_from_project()`` only runs after pre-flight on the
-    foreground path (see ``web()``), so a secret that lives only in ``.env``
-    must still count as present here — otherwise a healthy proxy launch would
-    false-fail.
+    ``dotenv_values``, which reads without mutating ``os.environ``).
+    ``_resolve_project_config()`` does load ``.env`` before pre-flight runs,
+    but this probe must not DEPEND on that side effect: reading ``.env``
+    directly keeps it correct on its own, so a secret that lives only in
+    ``.env`` counts as present regardless of load ordering — otherwise a
+    healthy proxy launch could false-fail.
 
     Zero network: ``load_provider_spec`` is a pure config read. A missing or
     malformed config.yml, or an unknown provider name, is left for Probe 3 (or
     the launch itself) to report — this probe just skips quietly rather than
     duplicating that diagnosis.
     """
-    if project_dir is None:
-        return [], []
-
     from osprey.build.claude_code_resolver import load_provider_spec
 
     try:
@@ -305,7 +337,7 @@ def _probe_auth_secret(project_dir: Path | None) -> tuple[list[str], list[str]]:
     )
 
 
-def _probe_config_validity(project_dir: Path | None) -> list[str]:
+def _probe_config_validity(project_dir: Path, config_path: Path) -> list[str]:
     """Probe 3: config.yml and .claude/settings.json must at least parse.
 
     ``load_osprey_config()`` swallows every exception and returns ``{}`` on
@@ -317,12 +349,12 @@ def _probe_config_validity(project_dir: Path | None) -> list[str]:
     does not call ``validate_agent_tools_against_permissions()`` — agent-tool
     / permission drift is a build-time concern, not a launch gate.
 
-    Both files are optional — a project without one is not a failure, just
-    nothing to validate.
+    ``config_path`` is the path ``_resolve_project_config()`` already settled
+    on — threaded through rather than re-derived, so pre-flight can never
+    parse a different file than the one the server will actually load.
+    ``settings.json`` is optional; a project without one is not a failure,
+    just nothing to validate.
     """
-    if project_dir is None:
-        return []
-
     failures: list[str] = []
 
     settings_path = project_dir / ".claude" / "settings.json"
@@ -334,7 +366,6 @@ def _probe_config_validity(project_dir: Path | None) -> list[str]:
         except json.JSONDecodeError as e:
             failures.append(f"{settings_path}: invalid JSON ({e})")
 
-    config_path = _resolve_project_config_path(project_dir)
     if config_path.exists():
         import yaml
 
@@ -347,7 +378,7 @@ def _probe_config_validity(project_dir: Path | None) -> list[str]:
 
 
 def _preflight(
-    config: dict, project_dir: Path | None, host: str, port: int
+    config: dict, project_dir: Path, config_path: Path, host: str, port: int
 ) -> tuple[list[str], list[str]]:
     """Run fast, synchronous, zero-network pre-flight probes before the server binds.
 
@@ -358,9 +389,11 @@ def _preflight(
     ``ANTHROPIC_API_KEY`` in env — subscription/OAuth login is still
     launchable).
 
+    ``project_dir``/``config_path`` are the pair ``_resolve_project_config()``
+    settled on — every probe sees the SAME project the server will serve.
     ``config``/``host``/``port`` are threaded through for probes that need
     them; none currently do. Probe 1 (companion port collisions) reads its own
-    panel/port config directly; Probes 2-3 use ``project_dir``.
+    panel/port config directly; Probes 2-3 use ``project_dir``/``config_path``.
     """
     failures: list[str] = []
     warnings: list[str] = []
@@ -368,7 +401,7 @@ def _preflight(
     auth_failures, auth_warnings = _probe_auth_secret(project_dir)
     failures.extend(auth_failures)
     warnings.extend(auth_warnings)
-    failures.extend(_probe_config_validity(project_dir))
+    failures.extend(_probe_config_validity(project_dir, config_path))
     return failures, warnings
 
 
@@ -480,6 +513,10 @@ def web(
     Starts a FastAPI server with a split-pane UI: a real terminal (PTY) on the
     left and a live workspace file viewer on the right.
 
+    The project is resolved once, up front: --project if given, else the
+    OSPREY_CONFIG environment variable, else ./config.yml. A launch without
+    a resolvable project config is refused.
+
     Example:
 
     \b
@@ -494,7 +531,14 @@ def web(
     if ctx.invoked_subcommand is not None:
         return
 
-    _enter_project(project)
+    # Resolve the project identity FIRST and fail loudly if there is none.
+    # Everything below — the vendor check's offline flag, host/port/shell
+    # resolution, pre-flight's probes, and the server itself — reads the
+    # project's config, so an unresolvable config must abort here rather than
+    # degrade into a mystery terminal serving another directory's defaults.
+    project_dir, project_config = _resolve_project_config(project)
+    project = str(project_dir)
+    click.echo(f"Project: {project_dir}")
 
     _preflight_vendor_check()
 
@@ -520,8 +564,9 @@ def web(
     if not skip_preflight:
         from osprey.utils.workspace import load_osprey_config
 
-        project_dir = Path(project).resolve() if project else Path.cwd()
-        failures, warnings = _preflight(load_osprey_config(), project_dir, host, port)
+        failures, warnings = _preflight(
+            load_osprey_config(), project_dir, project_config, host, port
+        )
         for warning in warnings:
             click.echo(f"WARNING: {warning}", err=True)
         if failures:
@@ -584,6 +629,9 @@ def web(
 
             _open_browser_when_ready(f"http://{host}:{port}")
 
+            # The reload worker re-imports create_app() with no arguments; it
+            # finds the project via the OSPREY_CONFIG publication made in
+            # _resolve_project_config().
             uvicorn.run(
                 "osprey.interfaces.web_terminal.app:create_app",
                 factory=True,
@@ -595,12 +643,18 @@ def web(
         else:
             from osprey.interfaces.web_terminal import run_web
 
-            run_web(host=host, port=port, shell_command=shell_command, project_dir=project)
+            run_web(
+                host=host,
+                port=port,
+                shell_command=shell_command,
+                config_path=str(project_config),
+                project_dir=project,
+            )
     except KeyboardInterrupt:
         click.echo("\nShutting down...")
 
 
-def _start_detached(host: str, port: int, shell: str | None, project: str | None) -> None:
+def _start_detached(host: str, port: int, shell: str | None, project: str) -> None:
     """Spawn the web server as a background process.
 
     ``shell`` is the raw user ``--shell`` flag (or None), NOT the resolved argv.
@@ -608,8 +662,11 @@ def _start_detached(host: str, port: int, shell: str | None, project: str | None
     pin remains honored from config; if we forwarded a resolved/pinned argv here,
     it would re-enter ``resolve_shell_command()`` in the child and fail for
     multi-word forms like ``npx -y @anthropic-ai/claude-code@<v>``.
+
+    ``project`` is the directory ``_resolve_project_config()`` settled on —
+    always present, never re-derived from cwd here.
     """
-    project_dir = Path(project).resolve() if project else Path.cwd()
+    project_dir = Path(project).resolve()
 
     # Idempotent: if already running, just report
     existing = _read_pid(project_dir)
@@ -635,8 +692,10 @@ def _start_detached(host: str, port: int, shell: str | None, project: str | None
     ]
     if shell:
         cmd += ["--shell", shell]
-    if project:
-        cmd += ["--project", str(Path(project).resolve())]
+    # Always name the project in the child argv: it's what `ps` shows and what
+    # humans and agents copy to restart the server. A restart from another
+    # directory must not silently lose the project identity.
+    cmd += ["--project", str(project_dir)]
 
     log_path = project_dir / LOG_FILE
     log_fh = open(log_path, "w")  # noqa: SIM115

--- a/tests/cli/test_web_bind.py
+++ b/tests/cli/test_web_bind.py
@@ -50,6 +50,20 @@ def _isolate_bind_and_port_env(monkeypatch):
         monkeypatch.delenv(_key)
 
 
+@pytest.fixture(autouse=True)
+def _project_config(tmp_path, monkeypatch):
+    """Satisfy `web()`'s project resolution for every launch-path test here.
+
+    `osprey web` refuses to start without a resolvable config.yml (a configless
+    launch silently serves a panel-less terminal). These tests exercise bind
+    and port resolution, not project resolution, so point OSPREY_CONFIG at a
+    minimal config to get past the launch gate.
+    """
+    cfg = tmp_path / "config.yml"
+    cfg.write_text("web: {}\n")
+    monkeypatch.setenv("OSPREY_CONFIG", str(cfg))
+
+
 def _free_port() -> int:
     """Reserve then release an OS-assigned port so nothing is listening on it."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:

--- a/tests/cli/test_web_cmd.py
+++ b/tests/cli/test_web_cmd.py
@@ -147,6 +147,196 @@ def test_wait_for_server_early_crash():
     assert _wait_for_server("127.0.0.1", 8087, proc, timeout=5.0) is False
 
 
+# -- project/config resolution ---------------------------------------------
+#
+# `osprey web` resolves THE project it serves exactly once, up front, in
+# _resolve_project_config(): --project > OSPREY_CONFIG > cwd. These tests pin
+# that single mechanism — the loud failure without a config, the banner, the
+# OSPREY_CONFIG publication for children, and the always-explicit --project in
+# the detached child's argv. (TestProjectFlagIsAuthoritative below pins the
+# other half of the contract: what --project must override.)
+
+
+class TestProjectResolution:
+    """`osprey web` must resolve a real project config or refuse to start.
+
+    The web terminal's panel set, companion servers, and provider wiring all
+    come from config.yml. A launch from a directory without one used to
+    silently degrade to universal panels only — these tests pin the loud
+    failure and the explicit project forwarding that prevent that.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch):
+        # web() writes OSPREY_WEB_PORT and OSPREY_CONFIG directly into
+        # os.environ for its child processes. setenv-then-delenv forces
+        # monkeypatch to record an undo entry even when the key started
+        # absent, so those in-test writes are always rolled back instead of
+        # leaking into later tests (same trick as test_web_bind.py's
+        # _isolate_bind_and_port_env).
+        for key in ("OSPREY_CONFIG", "OSPREY_WEB_PORT"):
+            monkeypatch.setenv(key, "__unset_by_test_fixture__")
+            monkeypatch.delenv(key)
+
+    def test_no_config_anywhere_refuses_to_start(self, runner, tmp_path):
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(web, [])
+
+        assert result.exit_code == 1
+        assert "config.yml" in result.output
+        assert "--project" in result.output
+
+    def test_project_flag_without_config_refuses(self, runner, tmp_path):
+        """--project at a directory without config.yml is a launch error
+        naming that directory — not a silent fallback to cwd or env."""
+        empty = tmp_path / "empty"
+        empty.mkdir()
+
+        result = runner.invoke(web, ["--project", str(empty)])
+
+        assert result.exit_code == 1
+        assert "config.yml" in result.output
+        assert str(empty.resolve()) in result.output
+
+    def test_osprey_config_pointing_at_missing_file_refuses(self, runner, tmp_path, monkeypatch):
+        monkeypatch.setenv("OSPREY_CONFIG", str(tmp_path / "nope" / "config.yml"))
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(web, [])
+
+        assert result.exit_code == 1
+        assert "OSPREY_CONFIG" in result.output
+
+    @patch("osprey.utils.shell_resolver.resolve_shell_command", return_value="/bin/fake-claude")
+    @patch("osprey.cli.web_cmd._preflight", return_value=([], []))
+    @patch("osprey.cli.web_cmd._wait_for_server", return_value=True)
+    @patch("osprey.cli.web_cmd.subprocess.Popen")
+    @patch("osprey.cli.web_cmd.get_config_value", return_value={})
+    def test_project_flag_resolves_config_from_elsewhere(
+        self, mock_config, mock_popen, mock_wait, mock_preflight, mock_resolve, tmp_path, runner
+    ):
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        mock_popen.return_value = mock_proc
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / "config.yml").write_text("web: {}\n")
+
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(web, ["--detach", "--project", str(project)])
+
+        assert result.exit_code == 0
+        child_argv = mock_popen.call_args.args[0]
+        assert "--project" in child_argv
+        assert str(project.resolve()) in child_argv
+
+    @patch("osprey.utils.shell_resolver.resolve_shell_command", return_value="/bin/fake-claude")
+    @patch("osprey.cli.web_cmd._preflight", return_value=([], []))
+    @patch("osprey.cli.web_cmd._wait_for_server", return_value=True)
+    @patch("osprey.cli.web_cmd.subprocess.Popen")
+    @patch("osprey.cli.web_cmd.get_config_value", return_value={})
+    def test_detach_child_argv_always_carries_project(
+        self, mock_config, mock_popen, mock_wait, mock_preflight, mock_resolve, tmp_path, runner
+    ):
+        """Even without --project, the child command must name the project dir.
+
+        The detached child's argv is what `ps` shows — and what humans and
+        agents copy to restart the server. Without --project the project
+        identity rides only in the inherited cwd and a restart from another
+        directory silently loses every domain panel.
+        """
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        mock_popen.return_value = mock_proc
+
+        with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+            Path("config.yml").write_text("web: {}\n")
+            result = runner.invoke(web, ["--detach"])
+            cwd = Path(td).resolve()
+
+        assert result.exit_code == 0
+        child_argv = mock_popen.call_args.args[0]
+        assert "--project" in child_argv
+        assert str(cwd) in child_argv
+
+    @patch("osprey.utils.shell_resolver.resolve_shell_command", return_value="/bin/fake-claude")
+    @patch("osprey.cli.web_cmd._preflight", return_value=([], []))
+    @patch("osprey.cli.web_cmd._wait_for_server", return_value=True)
+    @patch("osprey.cli.web_cmd.subprocess.Popen")
+    @patch("osprey.cli.web_cmd.get_config_value", return_value={})
+    def test_banner_names_the_project(
+        self, mock_config, mock_popen, mock_wait, mock_preflight, mock_resolve, tmp_path, runner
+    ):
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        mock_popen.return_value = mock_proc
+
+        with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+            Path("config.yml").write_text("web: {}\n")
+            result = runner.invoke(web, ["--detach"])
+            cwd = Path(td).resolve()
+
+        assert result.exit_code == 0
+        assert f"Project: {cwd}" in result.output
+
+    def test_osprey_config_env_resolved_without_chdir(self, runner, tmp_path, monkeypatch):
+        """An OSPREY_CONFIG export is honored where it points, with NO chdir.
+
+        The export pins the config alone — unlike --project, which means
+        `cd <project> && osprey web` — so cwd-relative state stays in the
+        invoking directory while config resolution follows the export.
+        """
+        config_file = tmp_path / "elsewhere" / "config.yml"
+        config_file.parent.mkdir()
+        config_file.write_text("web: {}\n")
+        monkeypatch.setenv("OSPREY_CONFIG", str(config_file))
+
+        captured = {}
+
+        def _capture_run_web(**kw):
+            captured["kwargs"] = kw
+            captured["cwd"] = os.getcwd()
+
+        monkeypatch.setattr("osprey.interfaces.web_terminal.run_web", _capture_run_web)
+        monkeypatch.setattr("osprey.mcp_env.load_dotenv_from_project", lambda: None)
+
+        with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+            result = runner.invoke(
+                web, ["--shell", "true", "--skip-preflight"], catch_exceptions=False
+            )
+            launch_dir = Path(td).resolve()
+
+        assert result.exit_code == 0
+        assert Path(captured["kwargs"]["config_path"]).resolve() == config_file.resolve()
+        assert Path(captured["cwd"]).resolve() == launch_dir
+
+    def test_bare_launch_publishes_osprey_config_for_children(self, runner, tmp_path, monkeypatch):
+        """Even a plain `osprey web` inside a project must publish OSPREY_CONFIG.
+
+        The --reload worker re-imports create_app() with no arguments, and
+        child PTY shells / MCP servers resolve the project through the
+        environment — without the publication they all fall back to their own
+        cwd, which the operator may have changed by then.
+        """
+        observed = {}
+
+        def _capture_run_web(**_kw):
+            observed["osprey_config"] = os.environ.get("OSPREY_CONFIG")
+
+        monkeypatch.setattr("osprey.interfaces.web_terminal.run_web", _capture_run_web)
+        monkeypatch.setattr("osprey.mcp_env.load_dotenv_from_project", lambda: None)
+
+        with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+            Path("config.yml").write_text("web: {}\n")
+            result = runner.invoke(
+                web, ["--shell", "true", "--skip-preflight"], catch_exceptions=False
+            )
+            proj = Path(td).resolve()
+
+        assert result.exit_code == 0
+        assert Path(observed["osprey_config"]).resolve() == proj / "config.yml"
+
+
 # -- detach -----------------------------------------------------------------
 
 
@@ -163,6 +353,7 @@ def test_detach_spawns_subprocess(
     mock_popen.return_value = mock_proc
 
     with runner.isolated_filesystem(temp_dir=tmp_path):
+        Path("config.yml").write_text("web: {}\n")
         result = runner.invoke(web, ["--detach"])
 
     assert result.exit_code == 0
@@ -184,6 +375,7 @@ def test_detach_writes_pid_file(
     mock_popen.return_value = mock_proc
 
     with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        Path("config.yml").write_text("web: {}\n")
         result = runner.invoke(web, ["--detach"])
         pid_content = (Path(td) / PID_FILE).read_text()
 
@@ -199,6 +391,7 @@ def test_detach_idempotent_when_running(
     mock_config, mock_read_pid, mock_preflight, mock_resolve, runner, tmp_path
 ):
     with runner.isolated_filesystem(temp_dir=tmp_path):
+        Path("config.yml").write_text("web: {}\n")
         result = runner.invoke(web, ["--detach"])
 
     assert result.exit_code == 0
@@ -218,6 +411,7 @@ def test_detach_cleans_stale_pid(
     mock_popen.return_value = mock_proc
 
     with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        Path("config.yml").write_text("web: {}\n")
         # Write a stale PID file
         (Path(td) / PID_FILE).write_text("999999999")
 
@@ -243,6 +437,7 @@ def test_detach_shows_url_and_pid(
     mock_popen.return_value = mock_proc
 
     with runner.isolated_filesystem(temp_dir=tmp_path):
+        Path("config.yml").write_text("web: {}\n")
         result = runner.invoke(web, ["--detach"])
 
     assert "PID 12345" in result.output
@@ -355,14 +550,16 @@ def _spy_config_readers(monkeypatch) -> list[str]:
 class TestPreflightCompanionPortCollision:
     """Probe 1: held companion ports are reported; free/excluded ports are not."""
 
-    def test_held_artifact_port_reported(self, monkeypatch):
+    def test_held_artifact_port_reported(self, monkeypatch, tmp_path):
         """A companion port the lifespan WILL launch, already held, is a finding."""
         port = _free_port()
         _patch_config(monkeypatch, {"artifact_server": {"port": port}})
 
         held = _hold_port(port)
         try:
-            failures, warnings = _preflight({}, None, "127.0.0.1", 8087)
+            failures, warnings = _preflight(
+                {}, tmp_path, tmp_path / "config.yml", "127.0.0.1", 8087
+            )
         finally:
             held.close()
 
@@ -372,14 +569,14 @@ class TestPreflightCompanionPortCollision:
         assert f"lsof -i :{port}" in failures[0]
         assert warnings == []
 
-    def test_free_ports_clean_pass(self, monkeypatch):
+    def test_free_ports_clean_pass(self, monkeypatch, tmp_path):
         """With no companion ports held, _preflight returns no findings."""
         port = _free_port()
         _patch_config(monkeypatch, {"artifact_server": {"port": port}})
 
-        assert _preflight({}, None, "127.0.0.1", 8087) == ([], [])
+        assert _preflight({}, tmp_path, tmp_path / "config.yml", "127.0.0.1", 8087) == ([], [])
 
-    def test_require_section_unmet_panel_excluded(self, monkeypatch):
+    def test_require_section_unmet_panel_excluded(self, monkeypatch, tmp_path):
         """Enabled-but-not-launched panel (require_section unmet) is not probed."""
         # "channel-finder" is enabled in web.panels, but the channel_finder
         # top-level section (which gates auto_launch/require_section) is
@@ -395,13 +592,13 @@ class TestPreflightCompanionPortCollision:
         )
         probed_keys = _spy_config_readers(monkeypatch)
 
-        failures, warnings = _preflight({}, None, "127.0.0.1", 8087)
+        failures, warnings = _preflight({}, tmp_path, tmp_path / "config.yml", "127.0.0.1", 8087)
 
         assert failures == []
         assert warnings == []
         assert "channel_finder" not in probed_keys
 
-    def test_disabled_panel_excluded(self, monkeypatch):
+    def test_disabled_panel_excluded(self, monkeypatch, tmp_path):
         """A panel absent from web.panels is not probed even if its port is held."""
         artifact_port = _free_port()
         _patch_config(
@@ -409,13 +606,13 @@ class TestPreflightCompanionPortCollision:
         )  # ariel not enabled
         probed_keys = _spy_config_readers(monkeypatch)
 
-        failures, warnings = _preflight({}, None, "127.0.0.1", 8087)
+        failures, warnings = _preflight({}, tmp_path, tmp_path / "config.yml", "127.0.0.1", 8087)
 
         assert failures == []
         assert warnings == []
         assert "ariel" not in probed_keys
 
-    def test_no_network_or_registry_calls(self, monkeypatch):
+    def test_no_network_or_registry_calls(self, monkeypatch, tmp_path):
         """Probe 1 never starts a companion server or hits its /health endpoint."""
         port = _free_port()
         _patch_config(monkeypatch, {"artifact_server": {"port": port}})
@@ -429,7 +626,7 @@ class TestPreflightCompanionPortCollision:
         monkeypatch.setattr(ServerLauncher, "_is_running", _boom)
         monkeypatch.setattr("urllib.request.urlopen", _boom)
 
-        assert _preflight({}, None, "127.0.0.1", 8087) == ([], [])
+        assert _preflight({}, tmp_path, tmp_path / "config.yml", "127.0.0.1", 8087) == ([], [])
 
     def test_panel_id_mapping_covers_every_registry_server(self):
         """Every FRAMEWORK_WEB_SERVERS entry except `artifact` (always launched,
@@ -459,9 +656,11 @@ class TestWebCommandPreflightWiring:
 
         held = _hold_port(artifact_port)
         try:
-            result = runner.invoke(
-                web, ["--port", str(own_port), "--shell", "true"], catch_exceptions=False
-            )
+            with runner.isolated_filesystem():
+                Path("config.yml").write_text("web: {}\n")
+                result = runner.invoke(
+                    web, ["--port", str(own_port), "--shell", "true"], catch_exceptions=False
+                )
         finally:
             held.close()
 
@@ -476,9 +675,11 @@ class TestWebCommandPreflightWiring:
         self._stub_launch(monkeypatch)
         own_port = _free_port()
 
-        result = runner.invoke(
-            web, ["--port", str(own_port), "--shell", "true"], catch_exceptions=False
-        )
+        with runner.isolated_filesystem():
+            Path("config.yml").write_text("web: {}\n")
+            result = runner.invoke(
+                web, ["--port", str(own_port), "--shell", "true"], catch_exceptions=False
+            )
 
         assert result.exit_code == 0
 
@@ -490,11 +691,13 @@ class TestWebCommandPreflightWiring:
 
         held = _hold_port(artifact_port)
         try:
-            result = runner.invoke(
-                web,
-                ["--port", str(own_port), "--shell", "true", "--skip-preflight"],
-                catch_exceptions=False,
-            )
+            with runner.isolated_filesystem():
+                Path("config.yml").write_text("web: {}\n")
+                result = runner.invoke(
+                    web,
+                    ["--port", str(own_port), "--shell", "true", "--skip-preflight"],
+                    catch_exceptions=False,
+                )
         finally:
             held.close()
 
@@ -547,6 +750,7 @@ class TestPreflightAuthSecret:
         own_port = _free_port()
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("config.yml").write_text("web: {}\n")
             result = runner.invoke(
                 web, ["--port", str(own_port), "--shell", "true"], catch_exceptions=False
             )
@@ -571,6 +775,7 @@ class TestPreflightAuthSecret:
         own_port = _free_port()
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("config.yml").write_text("web: {}\n")
             result = runner.invoke(
                 web, ["--port", str(own_port), "--shell", "true"], catch_exceptions=False
             )
@@ -594,6 +799,7 @@ class TestPreflightAuthSecret:
         own_port = _free_port()
 
         with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+            Path("config.yml").write_text("web: {}\n")
             (Path(td) / ".env").write_text("ALS_APG_API_KEY=secret-from-dotenv\n")
             result = runner.invoke(
                 web, ["--port", str(own_port), "--shell", "true"], catch_exceptions=False
@@ -618,6 +824,7 @@ class TestPreflightAuthSecret:
         own_port = _free_port()
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("config.yml").write_text("web: {}\n")
             result = runner.invoke(
                 web, ["--port", str(own_port), "--shell", "true"], catch_exceptions=False
             )
@@ -635,6 +842,7 @@ class TestPreflightAuthSecret:
         own_port = _free_port()
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("config.yml").write_text("web: {}\n")
             result = runner.invoke(
                 web, ["--port", str(own_port), "--shell", "true"], catch_exceptions=False
             )
@@ -658,6 +866,7 @@ class TestPreflightAuthSecret:
         own_port = _free_port()
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("config.yml").write_text("web: {}\n")
             result = runner.invoke(
                 web, ["--port", str(own_port), "--shell", "true"], catch_exceptions=False
             )
@@ -686,6 +895,7 @@ class TestPreflightConfigValidity:
         own_port = _free_port()
 
         with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+            Path("config.yml").write_text("web: {}\n")
             settings_path = Path(td) / ".claude" / "settings.json"
             settings_path.parent.mkdir(parents=True)
             settings_path.write_text("{not valid json")
@@ -703,6 +913,7 @@ class TestPreflightConfigValidity:
         own_port = _free_port()
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("config.yml").write_text("web: {}\n")
             result = runner.invoke(
                 web, ["--port", str(own_port), "--shell", "true"], catch_exceptions=False
             )
@@ -737,11 +948,15 @@ class TestDetachSkipsPreflightInChild:
         mock_popen.return_value = mock_proc
 
         monkeypatch.chdir(tmp_path)
-        _start_detached("127.0.0.1", 8087, None, None)
+        _start_detached("127.0.0.1", 8087, None, str(tmp_path))
 
         cmd = mock_popen.call_args.args[0]
         assert "--skip-preflight" in cmd
         assert "--detach" not in cmd
+        # The resolved project always rides in the child argv (see
+        # TestProjectResolution.test_detach_child_argv_always_carries_project
+        # for the CLI-level pin).
+        assert "--project" in cmd
 
 
 # -- --project makes the project directory authoritative --------------------

--- a/tests/e2e/web_terminals/test_loopback_chokepoint.py
+++ b/tests/e2e/web_terminals/test_loopback_chokepoint.py
@@ -153,6 +153,11 @@ def test_declared_loopback_survives_hostile_host_flag_over_real_socket(tmp_path:
     free_port = _free_port()
     project_dir = tmp_path / "project"
     project_dir.mkdir()
+    # `osprey web` refuses to launch without a resolvable project config, so
+    # the directory it runs in has to be a real (if minimal) project — same as
+    # the deployment this test mirrors. Without it the server exits before
+    # binding and the bind assertions below never get to run.
+    (project_dir / "config.yml").write_text("system:\n  name: loopback-chokepoint\n")
     log_path = tmp_path / "server.log"
 
     # sys.executable, NEVER bare "python": in this shared worktree, bare
@@ -173,6 +178,11 @@ def test_declared_loopback_survives_hostile_host_flag_over_real_socket(tmp_path:
 
     env = dict(os.environ)
     env[DECLARED_BIND_ENV] = "127.0.0.1"
+    # An OSPREY_CONFIG exported in the developer's shell outranks the cwd when
+    # the child resolves its project, which would silently point this launch at
+    # some other project's config. Drop it so `cwd=project_dir` is what decides.
+    env.pop("OSPREY_CONFIG", None)
+    env.pop("CONFIG_FILE", None)
     # Neutralize the browser-open side effect (run_web -> _open_browser_when_ready
     # -> webbrowser.open()). The BROWSER env var is read by the webbrowser
     # module's standard-browser registration and, when set, is registered


### PR DESCRIPTION
## Problem

`osprey web` derived "the project" independently in several places: the `.env` load, the `web_terminal`/`claude_code` config reads, pre-flight's config parse, the reload worker's re-import, and the detached child's argv each resolved it from cwd, `OSPREY_CONFIG`, or `--project` on their own. The pieces could disagree:

- with a stale `OSPREY_CONFIG` export, the server read one project's config while cwd-relative state came from another;
- a launch without any resolvable config silently served a terminal with only the universal panels — "my panels vanished" instead of "wrong directory".

## Fix

Resolve the project **exactly once**, before anything reads config, in a single resolver with one documented precedence: `--project` > `OSPREY_CONFIG` > `./config.yml`.

- `--project` behaves exactly like `cd <project> && osprey web` and overrides a stale `OSPREY_CONFIG` export (preserving the contract from #490, whose six regression tests pass unchanged).
- A launch without a resolvable `config.yml` aborts with the three ways to point at a project, instead of degrading to a panel-less terminal.
- The resolved config path is published to `OSPREY_CONFIG` on every entry path (PTY children, MCP servers, the `--reload` worker) and threaded explicitly into `run_web` and the pre-flight probes — no consumer re-derives it, so pre-flight can never parse a different file than the one the server loads.
- The launch banner names the resolved project, and a detached child's argv always carries `--project` so a copied restart cannot lose the project identity.

## Behavior changes

- `osprey web` in a directory without `config.yml` (and no `--project`/`OSPREY_CONFIG`) now exits 1 with guidance instead of launching a degraded terminal.
- `OSPREY_CONFIG` pointing at a missing file is now a launch error instead of a silent fallback.
- `osprey web stop` and `--help` are unaffected.

## Tests

- New `TestProjectResolution` class: fail-loud cases (no config, dangling `OSPREY_CONFIG`, `--project` without config), launch banner, `OSPREY_CONFIG` publication on bare launches, env-export resolution without chdir, and the always-`--project` detached child argv.
- All six `TestProjectFlagIsAuthoritative` tests pass unchanged.
- Full `tests/cli/` suite: 1719 passed. Full unit suite (`pytest tests/ --ignore=tests/e2e`), docs build, package build, and twine check green via `ci_check.sh`.