### PR TITLE
fix(interfaces): remove two sources of nondeterminism in the interface test suites

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -335,6 +335,7 @@ markers = [
     "flaky: Rerun on failure to absorb nondeterminism outside the process — LLM sampling in e2e, OS event delivery in a couple of watcher tests (pytest-rerunfailures). Not for flaky unit tests; see tests/README.md",
     "e2e_services: E2E tests requiring local MCP service infrastructure (PostgreSQL, AccelPapers, etc.)",
     "dockerbuild: E2E tests that run a real docker build (skipped when docker is unavailable)",
+    "real_workspace_watcher: Web-terminal app test that needs a live filesystem observer — opts out of the conftest stub that keeps broadcaster assertions deterministic",
 ]
 
 # Ruff configuration for modern Python linting

--- a/src/osprey/interfaces/_serving.py
+++ b/src/osprey/interfaces/_serving.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import socket
 import threading
 import time
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from typing import TYPE_CHECKING
 
 import uvicorn
@@ -46,6 +46,35 @@ def wait_for_port(port: int, timeout: float = 10.0) -> None:
     raise RuntimeError(f"Server did not become ready on port {port} within {timeout}s")
 
 
+def _wait_until_serving(
+    server: uvicorn.Server,
+    thread: threading.Thread,
+    thread_error: list[BaseException],
+    port: int,
+    timeout: float = 10.0,
+) -> None:
+    """Block until *server* is serving, or explain why it never will be.
+
+    Waits on uvicorn's own ``started`` flag rather than probing the port, and
+    treats the serving thread exiting as a terminal answer. A server that dies
+    during startup — a lifespan that raises, a failed bind — otherwise looks
+    exactly like one that is merely slow, so the caller pays the whole timeout
+    and is then told the server "did not become ready", which points at the
+    timeout rather than at the error that actually occurred.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if server.started:
+            return
+        if not thread.is_alive():
+            raise RuntimeError(
+                f"Server exited during startup without listening on port {port}; "
+                "the application's startup failed (see the server log above)"
+            ) from (thread_error[0] if thread_error else None)
+        time.sleep(0.02)
+    raise RuntimeError(f"Server did not become ready on port {port} within {timeout}s")
+
+
 @contextmanager
 def run_app_server(app: FastAPI) -> Iterator[str]:
     """Run any FastAPI app on a free port in a background thread.
@@ -53,14 +82,46 @@ def run_app_server(app: FastAPI) -> Iterator[str]:
     Yields:
         The server's base URL, e.g. ``"http://127.0.0.1:54321"``.
     """
-    port = free_port()
+    # Bind the listening socket here and hand uvicorn the live socket, rather
+    # than passing it a port number chosen earlier. ``free_port`` must close its
+    # socket before returning the number, which leaves a window where anything
+    # else on the machine can claim that port — and a readiness check that only
+    # opens a TCP connection is satisfied by whoever won it. Owning the socket
+    # for the server's whole lifetime removes the window and makes the yielded
+    # URL provably this app's.
+    sock = socket.socket()
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(128)
+    port = int(sock.getsockname()[1])
+
     config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
     server = uvicorn.Server(config)
-    t = threading.Thread(target=server.run, daemon=True)
+    thread_error: list[BaseException] = []
+
+    def _serve() -> None:
+        try:
+            server.run(sockets=[sock])
+        except BaseException as exc:  # noqa: BLE001 - surfaced to the caller as the cause
+            # Includes the SystemExit uvicorn raises when startup fails.
+            thread_error.append(exc)
+
+    t = threading.Thread(target=_serve, daemon=True)
     t.start()
-    wait_for_port(port)
+
+    def _shutdown() -> None:
+        server.should_exit = True
+        t.join(timeout=5)
+        with suppress(OSError):
+            sock.close()
+
+    try:
+        _wait_until_serving(server, t, thread_error, port)
+    except BaseException:
+        _shutdown()
+        raise
+
     try:
         yield f"http://127.0.0.1:{port}"
     finally:
-        server.should_exit = True
-        t.join(timeout=5)
+        _shutdown()

--- a/tests/interfaces/test_app_server_helper.py
+++ b/tests/interfaces/test_app_server_helper.py
@@ -1,0 +1,84 @@
+"""Tests for ``run_app_server`` — the shared helper behind the browser suites.
+
+The helper runs an interface's ``create_app()`` on a throwaway port in a
+background thread. Its failure reporting matters as much as its happy path: it
+is the entry point for every real-browser test, so when a server does not come
+up, the message it raises is the only evidence anyone gets.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import time
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from osprey.interfaces._serving import run_app_server
+
+# The helper's own readiness budget. A startup *failure* must be reported well
+# inside it rather than consuming the whole budget first.
+READINESS_BUDGET = 10.0
+
+
+def _app_with_failing_lifespan() -> FastAPI:
+    """An app that cannot start: its lifespan raises before yielding."""
+
+    @contextlib.asynccontextmanager
+    async def lifespan(_app: FastAPI):
+        raise RuntimeError("lifespan exploded")
+        yield  # pragma: no cover - unreachable, documents the shape
+
+    return FastAPI(lifespan=lifespan)
+
+
+class TestStartupFailureReporting:
+    """A server that dies must be reported as dead, not as slow."""
+
+    def test_startup_failure_is_reported_without_burning_the_whole_budget(self):
+        """A dead server is detected promptly instead of after the full timeout.
+
+        Measured readiness for real interface apps is ~0.1 s (p90 0.11 s), so a
+        run that consumes the entire 10 s budget always means the server never
+        listened at all. Polling the port blindly cannot tell those apart and
+        pays the full timeout for a failure that was knowable immediately.
+        """
+        # Arrange
+        app = _app_with_failing_lifespan()
+
+        # Act
+        started = time.monotonic()
+        with pytest.raises(RuntimeError) as excinfo:
+            with run_app_server(app):
+                pass  # pragma: no cover - the context must not be entered
+        elapsed = time.monotonic() - started
+
+        # Assert
+        assert elapsed < READINESS_BUDGET / 2, (
+            f"took {elapsed:.1f}s to report a server that never started; "
+            "the helper polled the port blindly instead of noticing the thread exited"
+        )
+        assert "exited during startup" in str(excinfo.value), (
+            f"error must say the server died, not that it was slow; got: {excinfo.value}"
+        )
+
+
+class TestHappyPath:
+    def test_yields_a_url_served_by_the_supplied_app(self):
+        """The yielded URL reaches the app that was passed in."""
+        # Arrange
+        app = FastAPI()
+
+        @app.get("/ping")
+        def ping() -> dict[str, str]:
+            return {"pong": "from-this-app"}
+
+        # Act
+        with run_app_server(app) as base_url:
+            resp = httpx.get(f"{base_url}/ping", timeout=5.0)
+
+        # Assert — proves the port belongs to *our* server, not a coincidental
+        # listener that a bare TCP connect check would have accepted.
+        assert resp.status_code == 200
+        assert resp.json() == {"pong": "from-this-app"}

--- a/tests/interfaces/web_terminal/conftest.py
+++ b/tests/interfaces/web_terminal/conftest.py
@@ -1,0 +1,75 @@
+"""Shared fixtures for the web-terminal app tests.
+
+Every test in this directory that drives ``create_app`` through the
+``TestClient`` lifespan gets a real :class:`WorkspaceWatcher` — an OS-level
+filesystem observer on ``watch_dir``, running on its own thread. That observer
+calls ``app.state.broadcaster.broadcast`` for any event it sees, on the very
+object tests replace with a mock to capture route broadcasts. A background
+thread and the assertion therefore share one counter.
+
+On macOS this is not merely theoretical. watchdog's FSEvents backend defaults
+to ``suppress_history=False``, and its own documentation notes the API "may
+emit historic events up to 30 sec before the watch was started" — so the
+observer replays the ``tmp_path`` creation the fixture itself performed moments
+earlier. Delivery is asynchronous, so whether that replay lands inside a test's
+assertion window is decided by FSEvents daemon coalescing, not by the test.
+That is what made ``test_valid_panel_broadcasts_panel_visibility_event``
+intermittently report "Called 2 times" against ``assert_called_once``, and CI
+covers ``macos-latest``.
+
+No app test here exercises file watching — the watcher's own tests build it
+directly from ``file_watcher``, and the SSE route tests build their own app —
+so the observer is stubbed out by default. It is incidental machinery for these
+tests, and starting it buys nothing but a 30-second window of foreign events.
+
+Opt back in with ``@pytest.mark.real_workspace_watcher`` when a test genuinely
+needs live file watching through the app factory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from osprey.interfaces.web_terminal.file_watcher import FileEventBroadcaster
+
+
+class StubWorkspaceWatcher:
+    """Drop-in for :class:`WorkspaceWatcher` that starts no observer thread.
+
+    Mirrors the real constructor signature and records what the lifespan wired
+    up, so tests can still assert the watcher was pointed at the right
+    directory without an OS-level observer being involved.
+    """
+
+    def __init__(self, workspace_dir: Path, broadcaster: FileEventBroadcaster) -> None:
+        self.workspace_dir = workspace_dir
+        self.broadcaster = broadcaster
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.started = False
+
+
+@pytest.fixture(autouse=True)
+def stub_workspace_watcher(request):
+    """Stop ``create_app`` starting a real filesystem observer.
+
+    Patches the name bound in ``web_terminal.app`` rather than the class in
+    ``file_watcher``, so tests importing ``WorkspaceWatcher`` from its own
+    module keep the real implementation.
+    """
+    if request.node.get_closest_marker("real_workspace_watcher"):
+        yield None
+        return
+
+    with patch(
+        "osprey.interfaces.web_terminal.app.WorkspaceWatcher",
+        StubWorkspaceWatcher,
+    ) as stub:
+        yield stub

--- a/tests/interfaces/web_terminal/test_web_custom_panels.py
+++ b/tests/interfaces/web_terminal/test_web_custom_panels.py
@@ -16,6 +16,8 @@ from osprey.interfaces.web_terminal.app import (
 )
 from osprey.profiles.web_panels import BUILTIN_PANEL_LABELS
 
+from .conftest import StubWorkspaceWatcher
+
 
 @pytest.fixture
 def workspace_dir(tmp_path):
@@ -619,6 +621,36 @@ class TestHiddenPanels:
 
 
 # ---- POST /api/panel-visibility ----
+
+
+class TestBroadcastAssertionsAreDeterministic:
+    """The broadcast assertions below must not share a counter with a live thread.
+
+    ``create_app``'s lifespan wires a ``WorkspaceWatcher`` to the same
+    broadcaster object these tests mock, so a filesystem event delivered on the
+    observer thread lands on the mock the route assertions count. On macOS
+    watchdog replays events from up to 30 s before the watch started — including
+    this fixture's own ``tmp_path`` creation — so the extra call arrives on a
+    timing that no test controls.
+
+    The directory conftest stubs the observer out. This guard fails if that stub
+    is removed, rather than leaving the broadcast assertions below to misfire
+    intermittently on a slow runner.
+    """
+
+    def test_lifespan_wires_a_watcher_that_starts_no_observer(self, client_all_panels):
+        # Arrange — fixture has run the full lifespan
+
+        # Act
+        watcher = client_all_panels.app.state.watcher
+
+        # Assert — stubbed, but still wired exactly as production wires it
+        assert isinstance(watcher, StubWorkspaceWatcher), (
+            "app tests must not start a real filesystem observer; "
+            "it broadcasts onto the mock these tests assert on"
+        )
+        assert watcher.started is True, "lifespan must still start the watcher it wires"
+        assert watcher.broadcaster is client_all_panels.app.state.broadcaster
 
 
 class TestPanelVisibilityAPI:


### PR DESCRIPTION
Two independent flakes in the interface suites, both root-caused and reproduced deterministically before fixing.

---

## 1. Panels test raced a live filesystem observer

`test_web_custom_panels.py::test_valid_panel_broadcasts_panel_visibility_event` failed intermittently with `Expected 'mock' to be called once. Called 2 times.`

The app tests drive `create_app` through the `TestClient` lifespan, which starts a `WorkspaceWatcher` — an OS-level filesystem observer on `watch_dir`, on its own thread. `_WorkspaceHandler` holds a reference to the broadcaster *object* and calls `self._broadcaster.broadcast(...)`, so when a test replaces the `broadcast` *attribute* with a `MagicMock`, watcher-thread events land on the very counter `assert_called_once()` reads. A background thread and the assertion shared one counter.

On macOS this is more than theoretical: watchdog's FSEvents backend defaults to `suppress_history=False`. macOS keeps a persistent on-disk journal of filesystem changes (for Spotlight/Time Machine), and FSEvents coalesces everything that happened to one item into a single event with OR'd flags. An item created just before the stream started and touched just after arrives as one event still carrying `is_created`, with no timestamp to separate them — so the observer reports a creation that already happened, including the fixture's own `tmp_path` creation. CI covers `macos-latest`.

Forcing one write into `watch_dir` during the assertion window reproduces it deterministically: `Expected 'mock' to be called once. Called 3 times.`

**Change.** A new directory `conftest.py` stubs the observer by default. The patch targets `osprey.interfaces.web_terminal.app.WorkspaceWatcher` — the name bound in *app's* namespace — so `test_file_watcher.py`, which imports the class from `file_watcher`, keeps the real implementation. Scoped directory-wide rather than to one file: all 19 `create_app` test files were each starting an observer, and none of them test file watching. Adds a registered `real_workspace_watcher` opt-out marker and a deterministic guard test that fails if the stub is removed.

---

## 2. A dead app server was reported as a slow one

`test_contract_params.py::test_query_params_configure_embedded_and_theme[ariel]` failed with `Server did not become ready on port 50775 within 10.0s`, then passed on an identical re-run.

`run_app_server` waited for readiness by opening TCP connections to a port number. That cannot distinguish a server still starting from one that already died, so a lifespan that raises — or a failed bind — consumed the whole 10s budget and surfaced as a message about the *timeout*, while the actual startup error had already been logged and discarded.

Instrumenting the helper across a full directory run gave 65 readiness samples: **median 0.10s, p90 0.11s, max 1.96s**. Against a 10s budget, exhausting it always meant the server never listened — never that it was slow. Raising the timeout would only have delayed the same misleading report.

A second defect fell out of the same probe: with a squatter holding the port, `wait_for_port` returned *successfully*, having connected to the squatter rather than to our app. A bare TCP connect proves something is listening, not that it is ours.

**Change.** Wait on uvicorn's own `started` flag and treat the serving thread exiting as terminal, chaining whatever escaped it (including the `SystemExit` uvicorn raises on startup failure) as the cause. Bind the listening socket in the helper and hand uvicorn the live socket: `free_port` must close its socket before returning the number, leaving a window for anything else to claim that port. Owning the socket for the server's lifetime closes the window and makes the yielded URL provably this app's.

`free_port` and `wait_for_port` keep their signatures — both are used directly elsewhere, for EPICS ports and the documentation screenshot runner.

Regression test: an app whose lifespan raises must be reported inside half the readiness budget, with an error saying the server died. Before: 10.61s and "did not become ready". After: 0.47s and "exited during startup".

---

## Verification

- `tests/interfaces/` — **1639 passed**, 1 skipped (pre-existing, documented)
- `tests/interfaces/web_terminal/` — 630/630, plus 5/5 stress runs under CI's `-n 4 --dist loadgroup`
- `tests/docs/` — 50 passed (the other consumer of the serving helper)
- `ruff check` and `ruff format --check` clean
- Confirmed the `real_workspace_watcher` opt-out genuinely restores the real watcher, so it is not dead code