### PR TITLE
chore: ignore local-only agent and scratch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Scratch notes (local idea capture)
+scratch/
+
 # NFS temporary files
 .nfs*
 
@@ -123,6 +126,10 @@ valves.json
 
 # Agent data directories
 _agent_data/*
+.agents/
+
+# Local coding-agent guidance (CLAUDE.md is the tracked source of guidance)
+AGENTS.md
 
 # Sample logbook data (large JSONL files)
 logbook_*.jsonl
@@ -180,6 +187,9 @@ src/osprey/templates/apps/control_assistant/data/benchmarks/results/
 # Node.js (dev-only JS toolchain; not part of the Python wheel)
 node_modules/
 
-# feature-scaffolding logs
+# feature-scaffolding logs (not committed)
 .claude/.logs/.state/
 .claude/.logs/*.jsonl
+
+# Process scaffolding — never committed (specs/plans live here uncommitted)
+docs/superpowers/


### PR DESCRIPTION
Adds ignore rules for per-developer files that currently show up as untracked noise in every working checkout, and that should never be tracked:

| Rule | Covers |
|---|---|
| `scratch/` | Local idea capture |
| `docs/superpowers/` | Planning documents that stay uncommitted by policy |
| `.agents/` | Per-developer coding-agent data, alongside the existing `_agent_data/*` |
| `AGENTS.md` | Local coding-agent guidance file |

`CLAUDE.md` remains the repo's tracked coding-agent guidance — this only stops the untracked local equivalents from being offered for commit.

No source, test, or packaging change. No changelog entry: the `Unreleased` section carries user-facing Added/Changed/Fixed/Removed items only, and this has no user-visible effect.