### PR TITLE
refactor(agent-runner): make the MCP readiness helpers public

### DIFF
--- a/src/osprey/agent_runner/__init__.py
+++ b/src/osprey/agent_runner/__init__.py
@@ -12,8 +12,8 @@ Public surface::
         combined_text,
         resolve_default_model,
         sdk_env,
-        _expected_mcp_servers,
-        _await_mcp_ready,
+        expected_mcp_servers,
+        await_mcp_ready,
         run_query,
         agent_session,
         run_turns,
@@ -26,10 +26,10 @@ Public surface::
 from osprey.agent_runner.primitives import (
     SDKWorkflowResult,
     ToolTrace,
-    _await_mcp_ready,
-    _expected_mcp_servers,
+    await_mcp_ready,
     build_agent_options,
     combined_text,
+    expected_mcp_servers,
     resolve_default_model,
     sdk_env,
 )
@@ -57,8 +57,8 @@ __all__ = [
     "combined_text",
     "resolve_default_model",
     "sdk_env",
-    "_expected_mcp_servers",
-    "_await_mcp_ready",
+    "expected_mcp_servers",
+    "await_mcp_ready",
     # runner (single-turn)
     "run_query",
     # session (multi-turn)

--- a/src/osprey/agent_runner/primitives.py
+++ b/src/osprey/agent_runner/primitives.py
@@ -224,7 +224,7 @@ class SDKWorkflowResult:
     system_messages: list[SystemMessage] = field(default_factory=list)
     result: ResultMessage | None = None
     # Authoritative MCP server snapshot from ``ClaudeSDKClient.get_mcp_status()``
-    # captured just before the prompt is sent (see ``_await_mcp_ready``). Each entry
+    # captured just before the prompt is sent (see ``await_mcp_ready``). Each entry
     # is an ``McpServerStatus`` object (SDK) or raw dict: {name, status, tools, ...}.
     # Empty when the runner used the one-shot ``query()`` path with no client to poll.
     # This is the ground-truth infra-vs-model discriminator: a failure where the
@@ -613,7 +613,7 @@ _MCP_READY_TIMEOUT_S = float(os.environ.get("OSPREY_E2E_MCP_READY_TIMEOUT", "20"
 _MCP_READY_POLL_S = 0.3
 
 
-def _expected_mcp_servers(project_dir: Path) -> set[str]:
+def expected_mcp_servers(project_dir: Path) -> set[str]:
     """The MCP server names a project declares in ``.mcp.json`` — the set the
     readiness barrier waits for. Returns an empty set if the file is unreadable."""
     try:
@@ -623,7 +623,7 @@ def _expected_mcp_servers(project_dir: Path) -> set[str]:
     return set(cfg.get("mcpServers", {}).keys())
 
 
-async def _await_mcp_ready(
+async def await_mcp_ready(
     client: ClaudeSDKClient,
     expected: set[str],
     *,

--- a/src/osprey/agent_runner/runner.py
+++ b/src/osprey/agent_runner/runner.py
@@ -31,10 +31,10 @@ except ImportError:
 
 from osprey.agent_runner.primitives import (
     SDKWorkflowResult,
-    _await_mcp_ready,
     _drain_response,
-    _expected_mcp_servers,
+    await_mcp_ready,
     build_agent_options,
+    expected_mcp_servers,
 )
 
 # ---------------------------------------------------------------------------
@@ -58,9 +58,9 @@ async def run_query(
     the SDK forwards to the Claude Code CLI as ``--disallowedTools``, blocking
     writes even under ``permission_mode=bypassPermissions``.
 
-    The function polls ``_await_mcp_ready`` before sending the prompt so the
+    The function polls ``await_mcp_ready`` before sending the prompt so the
     agent always starts with a fully registered toolset — eliminating the
-    controls cold-start race described in ``primitives._await_mcp_ready``.
+    controls cold-start race described in ``primitives.await_mcp_ready``.
 
     Args:
         project_dir: Path to an initialized OSPREY project.
@@ -104,9 +104,7 @@ async def run_query(
         # we can poll ``get_mcp_status()`` and wait out async MCP registration
         # before the first turn — eliminating the controls cold-start race.
         async with ClaudeSDKClient(options=options) as client:
-            workflow.mcp_servers = await _await_mcp_ready(
-                client, _expected_mcp_servers(project_dir)
-            )
+            workflow.mcp_servers = await await_mcp_ready(client, expected_mcp_servers(project_dir))
             await client.query(prompt)
             await _drain_response(client, workflow)
     except Exception as exc:

--- a/src/osprey/agent_runner/session.py
+++ b/src/osprey/agent_runner/session.py
@@ -44,10 +44,10 @@ except ImportError:
 from osprey.agent_runner.primitives import (
     SDKWorkflowResult,
     ToolTrace,
-    _await_mcp_ready,
     _drain_response,
-    _expected_mcp_servers,
+    await_mcp_ready,
     build_agent_options,
+    expected_mcp_servers,
 )
 
 
@@ -236,7 +236,7 @@ async def agent_session(
     )
 
     async with ClaudeSDKClient(options=options) as client:
-        mcp_servers = await _await_mcp_ready(client, _expected_mcp_servers(project_dir))
+        mcp_servers = await await_mcp_ready(client, expected_mcp_servers(project_dir))
         yield AgentSession(client, max_budget_usd=max_budget_usd, mcp_servers=mcp_servers)
 
 

--- a/src/osprey/cli/query_cmd.py
+++ b/src/osprey/cli/query_cmd.py
@@ -33,8 +33,8 @@ import yaml  # type: ignore[import-untyped]
 from osprey.agent_runner import (
     EXIT_USAGE,
     SDKWorkflowResult,
-    _expected_mcp_servers,
     evaluate_verdict,
+    expected_mcp_servers,
     read_only_disallowed_tools,
     run_query,
 )
@@ -129,7 +129,7 @@ def query(ctx: click.Context, prompt: str, as_json: bool, project: str | None) -
         return
 
     disallowed_tools = read_only_disallowed_tools(project_dir)
-    expected = _expected_mcp_servers(project_dir)
+    expected = expected_mcp_servers(project_dir)
 
     try:
         result = asyncio.run(run_query(project_dir, prompt, disallowed_tools=disallowed_tools))

--- a/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
+++ b/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
@@ -18,7 +18,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from osprey.agent_runner.primitives import _await_mcp_ready, _expected_mcp_servers
+from osprey.agent_runner.primitives import await_mcp_ready, expected_mcp_servers
 from osprey.mcp_server.dispatch_worker import failure_class, run_stats
 
 logger = logging.getLogger("osprey.mcp_server.dispatch_worker.sdk_runner")
@@ -259,7 +259,7 @@ async def _stream_with_ready_mcp(
     connected gives every dispatch a ready toolset, matching what
     ``osprey.agent_runner.runner`` already does for interactive runs.
 
-    The barrier is bounded (see ``_await_mcp_ready``) and returns the last
+    The barrier is bounded (see ``await_mcp_ready``) and returns the last
     snapshot on timeout rather than raising, so a server that genuinely never
     registers still runs — and is logged as such — instead of failing the
     dispatch outright.
@@ -270,12 +270,12 @@ async def _stream_with_ready_mcp(
     """
     async with ClaudeSDKClient(options=options) as client:
         # No declared servers — nothing to wait for. Skipped explicitly because
-        # ``_await_mcp_ready`` polls an empty expectation to its full deadline,
+        # ``await_mcp_ready`` polls an empty expectation to its full deadline,
         # which would add that delay to every run of a project whose .mcp.json
         # declares nothing (or could not be read).
-        expected = _expected_mcp_servers(Path(project_dir))
+        expected = expected_mcp_servers(Path(project_dir))
         if expected:
-            servers = await _await_mcp_ready(client, expected)
+            servers = await await_mcp_ready(client, expected)
             connected = {s.get("name") for s in servers if s.get("status") == "connected"}
             missing = sorted(expected - connected)
             if missing:

--- a/tests/agent_runner/test_runner.py
+++ b/tests/agent_runner/test_runner.py
@@ -1,6 +1,6 @@
 """Unit tests for osprey.agent_runner.runner.run_query.
 
-All tests mock ClaudeSDKClient and _await_mcp_ready so no live model or API
+All tests mock ClaudeSDKClient and await_mcp_ready so no live model or API
 keys are required.  The fake message stream exercises the full collection
 logic: tool call → tool result (via UserMessage) → text block → ResultMessage.
 """
@@ -76,7 +76,7 @@ async def _scripted_stream() -> AsyncIterator:
 @pytest.fixture()
 def project_dir(tmp_path: Path) -> Path:
     """Minimal OSPREY project skeleton sufficient for run_query."""
-    # .mcp.json declares the "controls" server so _expected_mcp_servers parses it.
+    # .mcp.json declares the "controls" server so expected_mcp_servers parses it.
     (tmp_path / ".mcp.json").write_text(
         '{"mcpServers": {"controls": {"command": "osprey-controls-mcp"}}}'
     )
@@ -117,7 +117,7 @@ async def test_run_query_collects_tool_traces_and_text(project_dir: Path) -> Non
     with (
         patch("osprey.agent_runner.runner.ClaudeSDKClient", return_value=async_cm),
         patch(
-            "osprey.agent_runner.runner._await_mcp_ready",
+            "osprey.agent_runner.runner.await_mcp_ready",
             new=AsyncMock(return_value=FAKE_MCP_SERVERS),
         ),
         patch("osprey.agent_runner.primitives.sdk_env", return_value={"CLAUDECODE": ""}),
@@ -126,7 +126,7 @@ async def test_run_query_collects_tool_traces_and_text(project_dir: Path) -> Non
             return_value="claude-haiku-4-5-20251001",
         ),
         patch(
-            "osprey.agent_runner.runner._expected_mcp_servers",
+            "osprey.agent_runner.runner.expected_mcp_servers",
             return_value={"controls"},
         ),
     ):
@@ -170,7 +170,7 @@ async def test_run_query_passes_disallowed_tools_to_options(project_dir: Path) -
     with (
         patch("osprey.agent_runner.runner.ClaudeSDKClient", side_effect=_capture_client),
         patch(
-            "osprey.agent_runner.runner._await_mcp_ready",
+            "osprey.agent_runner.runner.await_mcp_ready",
             new=AsyncMock(return_value=[]),
         ),
         patch("osprey.agent_runner.primitives.sdk_env", return_value={"CLAUDECODE": ""}),
@@ -179,7 +179,7 @@ async def test_run_query_passes_disallowed_tools_to_options(project_dir: Path) -
             return_value="claude-haiku-4-5-20251001",
         ),
         patch(
-            "osprey.agent_runner.runner._expected_mcp_servers",
+            "osprey.agent_runner.runner.expected_mcp_servers",
             return_value=set(),
         ),
     ):
@@ -207,7 +207,7 @@ async def test_run_query_uses_resolved_model_when_none(project_dir: Path) -> Non
     with (
         patch("osprey.agent_runner.runner.ClaudeSDKClient", side_effect=_capture_client),
         patch(
-            "osprey.agent_runner.runner._await_mcp_ready",
+            "osprey.agent_runner.runner.await_mcp_ready",
             new=AsyncMock(return_value=[]),
         ),
         patch("osprey.agent_runner.primitives.sdk_env", return_value={"CLAUDECODE": ""}),
@@ -216,7 +216,7 @@ async def test_run_query_uses_resolved_model_when_none(project_dir: Path) -> Non
             return_value="claude-haiku-4-5-20251001",
         ),
         patch(
-            "osprey.agent_runner.runner._expected_mcp_servers",
+            "osprey.agent_runner.runner.expected_mcp_servers",
             return_value=set(),
         ),
     ):
@@ -238,7 +238,7 @@ async def test_run_query_uses_explicit_model_when_supplied(project_dir: Path) ->
     with (
         patch("osprey.agent_runner.runner.ClaudeSDKClient", side_effect=_capture_client),
         patch(
-            "osprey.agent_runner.runner._await_mcp_ready",
+            "osprey.agent_runner.runner.await_mcp_ready",
             new=AsyncMock(return_value=[]),
         ),
         patch("osprey.agent_runner.primitives.sdk_env", return_value={"CLAUDECODE": ""}),
@@ -247,7 +247,7 @@ async def test_run_query_uses_explicit_model_when_supplied(project_dir: Path) ->
             return_value="claude-haiku-4-5-20251001",
         ),
         patch(
-            "osprey.agent_runner.runner._expected_mcp_servers",
+            "osprey.agent_runner.runner.expected_mcp_servers",
             return_value=set(),
         ),
     ):
@@ -258,7 +258,7 @@ async def test_run_query_uses_explicit_model_when_supplied(project_dir: Path) ->
 
 @pytest.mark.asyncio
 async def test_run_query_mcp_servers_populated(project_dir: Path) -> None:
-    """MCP server snapshot from _await_mcp_ready is stored in the result."""
+    """MCP server snapshot from await_mcp_ready is stored in the result."""
     async_cm, _ = _make_mock_client()
     fake_servers = [
         {"name": "controls", "status": "connected", "tools": []},
@@ -268,7 +268,7 @@ async def test_run_query_mcp_servers_populated(project_dir: Path) -> None:
     with (
         patch("osprey.agent_runner.runner.ClaudeSDKClient", return_value=async_cm),
         patch(
-            "osprey.agent_runner.runner._await_mcp_ready",
+            "osprey.agent_runner.runner.await_mcp_ready",
             new=AsyncMock(return_value=fake_servers),
         ),
         patch("osprey.agent_runner.primitives.sdk_env", return_value={"CLAUDECODE": ""}),
@@ -277,7 +277,7 @@ async def test_run_query_mcp_servers_populated(project_dir: Path) -> None:
             return_value="claude-haiku-4-5-20251001",
         ),
         patch(
-            "osprey.agent_runner.runner._expected_mcp_servers",
+            "osprey.agent_runner.runner.expected_mcp_servers",
             return_value={"controls", "python"},
         ),
     ):
@@ -302,7 +302,7 @@ async def test_run_query_wraps_sdk_exception(project_dir: Path) -> None:
             return_value="claude-haiku-4-5-20251001",
         ),
         patch(
-            "osprey.agent_runner.runner._expected_mcp_servers",
+            "osprey.agent_runner.runner.expected_mcp_servers",
             return_value=set(),
         ),
     ):
@@ -360,7 +360,7 @@ async def test_run_query_parses_list_content_and_is_error(project_dir: Path) -> 
     with (
         patch("osprey.agent_runner.runner.ClaudeSDKClient", return_value=async_cm),
         patch(
-            "osprey.agent_runner.runner._await_mcp_ready",
+            "osprey.agent_runner.runner.await_mcp_ready",
             new=AsyncMock(return_value=[]),
         ),
         patch("osprey.agent_runner.primitives.sdk_env", return_value={"CLAUDECODE": ""}),
@@ -368,7 +368,7 @@ async def test_run_query_parses_list_content_and_is_error(project_dir: Path) -> 
             "osprey.agent_runner.primitives.resolve_default_model",
             return_value="claude-haiku-4-5-20251001",
         ),
-        patch("osprey.agent_runner.runner._expected_mcp_servers", return_value=set()),
+        patch("osprey.agent_runner.runner.expected_mcp_servers", return_value=set()),
     ):
         result = await run_query(project_dir, "q", disallowed_tools=[])
 
@@ -436,7 +436,7 @@ async def test_run_query_starts_proxy_for_non_native_provider(project_dir: Path)
         patch(
             "osprey.agent_runner.runner.ClaudeSDKClient", side_effect=_capture(captured, async_cm)
         ),
-        patch("osprey.agent_runner.runner._await_mcp_ready", new=AsyncMock(return_value=[])),
+        patch("osprey.agent_runner.runner.await_mcp_ready", new=AsyncMock(return_value=[])),
         patch("osprey.agent_runner.primitives.sdk_env", return_value=proxy_env),
         patch("osprey.agent_runner.primitives.resolve_default_model", return_value="m"),
         patch(
@@ -444,7 +444,7 @@ async def test_run_query_starts_proxy_for_non_native_provider(project_dir: Path)
             return_value=_FakeSpec(needs_proxy=True, upstream_base_url="https://argo.example/v1"),
         ),
         patch("osprey.agent_runner.primitives.start_proxy", proxy),
-        patch("osprey.agent_runner.runner._expected_mcp_servers", return_value=set()),
+        patch("osprey.agent_runner.runner.expected_mcp_servers", return_value=set()),
     ):
         await run_query(project_dir, "q", disallowed_tools=[])
 
@@ -466,7 +466,7 @@ async def test_run_query_warns_when_proxy_auth_token_missing(project_dir: Path, 
 
     with (
         patch("osprey.agent_runner.runner.ClaudeSDKClient", return_value=async_cm),
-        patch("osprey.agent_runner.runner._await_mcp_ready", new=AsyncMock(return_value=[])),
+        patch("osprey.agent_runner.runner.await_mcp_ready", new=AsyncMock(return_value=[])),
         patch("osprey.agent_runner.primitives.sdk_env", return_value=proxy_env),
         patch("osprey.agent_runner.primitives.resolve_default_model", return_value="m"),
         patch(
@@ -474,7 +474,7 @@ async def test_run_query_warns_when_proxy_auth_token_missing(project_dir: Path, 
             return_value=_FakeSpec(needs_proxy=True, provider="argo"),
         ),
         patch("osprey.agent_runner.primitives.start_proxy", proxy),
-        patch("osprey.agent_runner.runner._expected_mcp_servers", return_value=set()),
+        patch("osprey.agent_runner.runner.expected_mcp_servers", return_value=set()),
         caplog.at_level(logging.WARNING, logger="osprey.agent_runner.primitives"),
     ):
         await run_query(project_dir, "q", disallowed_tools=[])
@@ -500,7 +500,7 @@ async def test_run_query_no_proxy_for_native_provider(project_dir: Path) -> None
         patch(
             "osprey.agent_runner.runner.ClaudeSDKClient", side_effect=_capture(captured, async_cm)
         ),
-        patch("osprey.agent_runner.runner._await_mcp_ready", new=AsyncMock(return_value=[])),
+        patch("osprey.agent_runner.runner.await_mcp_ready", new=AsyncMock(return_value=[])),
         patch("osprey.agent_runner.primitives.sdk_env", return_value=native_env),
         patch("osprey.agent_runner.primitives.resolve_default_model", return_value="m"),
         patch(
@@ -508,7 +508,7 @@ async def test_run_query_no_proxy_for_native_provider(project_dir: Path) -> None
             return_value=_FakeSpec(needs_proxy=False),
         ),
         patch("osprey.agent_runner.primitives.start_proxy", proxy),
-        patch("osprey.agent_runner.runner._expected_mcp_servers", return_value=set()),
+        patch("osprey.agent_runner.runner.expected_mcp_servers", return_value=set()),
     ):
         await run_query(project_dir, "q", disallowed_tools=[])
 
@@ -527,7 +527,7 @@ async def test_run_query_no_proxy_when_upstream_absent(project_dir: Path) -> Non
         patch(
             "osprey.agent_runner.runner.ClaudeSDKClient", side_effect=_capture(captured, async_cm)
         ),
-        patch("osprey.agent_runner.runner._await_mcp_ready", new=AsyncMock(return_value=[])),
+        patch("osprey.agent_runner.runner.await_mcp_ready", new=AsyncMock(return_value=[])),
         patch("osprey.agent_runner.primitives.sdk_env", return_value={"CLAUDECODE": ""}),
         patch("osprey.agent_runner.primitives.resolve_default_model", return_value="m"),
         patch(
@@ -535,7 +535,7 @@ async def test_run_query_no_proxy_when_upstream_absent(project_dir: Path) -> Non
             return_value=_FakeSpec(needs_proxy=True, upstream_base_url=None),
         ),
         patch("osprey.agent_runner.primitives.start_proxy", proxy),
-        patch("osprey.agent_runner.runner._expected_mcp_servers", return_value=set()),
+        patch("osprey.agent_runner.runner.expected_mcp_servers", return_value=set()),
     ):
         await run_query(project_dir, "q", disallowed_tools=[])
 

--- a/tests/agent_runner/test_session.py
+++ b/tests/agent_runner/test_session.py
@@ -209,8 +209,8 @@ async def test_run_turns_stops_early_when_budget_exhausted(tmp_path: Path) -> No
     with (
         patch("osprey.agent_runner.session.build_agent_options", return_value=MagicMock()),
         patch("osprey.agent_runner.session.ClaudeSDKClient", return_value=async_cm),
-        patch("osprey.agent_runner.session._await_mcp_ready", new=AsyncMock(return_value=[])),
-        patch("osprey.agent_runner.session._expected_mcp_servers", return_value=set()),
+        patch("osprey.agent_runner.session.await_mcp_ready", new=AsyncMock(return_value=[])),
+        patch("osprey.agent_runner.session.expected_mcp_servers", return_value=set()),
     ):
         results = await run_turns(
             tmp_path, ["p0", "p1", "p2"], disallowed_tools=[], max_budget_usd=0.004
@@ -232,8 +232,8 @@ async def test_run_turns_runs_fixed_script(tmp_path: Path) -> None:
     with (
         patch("osprey.agent_runner.session.build_agent_options", return_value=MagicMock()),
         patch("osprey.agent_runner.session.ClaudeSDKClient", return_value=async_cm),
-        patch("osprey.agent_runner.session._await_mcp_ready", new=AsyncMock(return_value=[])),
-        patch("osprey.agent_runner.session._expected_mcp_servers", return_value=set()),
+        patch("osprey.agent_runner.session.await_mcp_ready", new=AsyncMock(return_value=[])),
+        patch("osprey.agent_runner.session.expected_mcp_servers", return_value=set()),
     ):
         results = await run_turns(tmp_path, ["p0", "p1"], disallowed_tools=[])
 

--- a/tests/cli/test_query_cmd.py
+++ b/tests/cli/test_query_cmd.py
@@ -126,7 +126,7 @@ class TestHappyPath:
                 "osprey.cli.query_cmd.read_only_disallowed_tools",
                 return_value=["mcp__controls__channel_write"],
             ),
-            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value={"controls"}),
+            patch("osprey.cli.query_cmd.expected_mcp_servers", return_value={"controls"}),
         ):
             result = runner.invoke(query, ["--project", str(project_with_mcp), "What is 6*7?"])
         assert result.exit_code == EXIT_PASS
@@ -142,7 +142,7 @@ class TestHappyPath:
                 "osprey.cli.query_cmd.read_only_disallowed_tools",
                 return_value=["mcp__controls__channel_write"],
             ),
-            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value={"controls"}),
+            patch("osprey.cli.query_cmd.expected_mcp_servers", return_value={"controls"}),
         ):
             result = runner.invoke(query, ["--project", str(project_with_mcp), "What is 6*7?"])
         assert "The answer is 42." in result.output
@@ -166,7 +166,7 @@ class TestVerdictFailure:
                 "osprey.cli.query_cmd.read_only_disallowed_tools",
                 return_value=["mcp__controls__channel_write"],
             ),
-            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value={"controls"}),
+            patch("osprey.cli.query_cmd.expected_mcp_servers", return_value={"controls"}),
         ):
             result = runner.invoke(query, ["--project", str(project_with_mcp), "ping"])
         assert result.exit_code == EXIT_VERDICT_FAIL
@@ -198,7 +198,7 @@ class TestWriteToolSafety:
 
         with (
             patch("osprey.cli.query_cmd.run_query", side_effect=capturing_run_query),
-            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value={"controls"}),
+            patch("osprey.cli.query_cmd.expected_mcp_servers", return_value={"controls"}),
         ):
             runner.invoke(query, ["--project", str(project_with_mcp), "safe query"])
 
@@ -236,7 +236,7 @@ class TestJsonOutput:
                 "osprey.cli.query_cmd.read_only_disallowed_tools",
                 return_value=["mcp__controls__channel_write"],
             ),
-            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value={"controls"}),
+            patch("osprey.cli.query_cmd.expected_mcp_servers", return_value={"controls"}),
         ):
             result = runner.invoke(
                 query, ["--project", str(project_with_mcp), "--json", "beam current"]
@@ -260,7 +260,7 @@ class TestJsonOutput:
                 "osprey.cli.query_cmd.read_only_disallowed_tools",
                 return_value=["mcp__controls__channel_write"],
             ),
-            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value={"controls"}),
+            patch("osprey.cli.query_cmd.expected_mcp_servers", return_value={"controls"}),
         ):
             result = runner.invoke(
                 query, ["--project", str(project_with_mcp), "--json", "beam current"]
@@ -283,7 +283,7 @@ class TestJsonOutput:
                 "osprey.cli.query_cmd.read_only_disallowed_tools",
                 return_value=["mcp__controls__channel_write"],
             ),
-            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value={"controls"}),
+            patch("osprey.cli.query_cmd.expected_mcp_servers", return_value={"controls"}),
         ):
             result = runner.invoke(query, ["--project", str(project_with_mcp), "--json", "q"])
 
@@ -307,7 +307,7 @@ class TestJsonOutput:
                 "osprey.cli.query_cmd.read_only_disallowed_tools",
                 return_value=["mcp__controls__channel_write"],
             ),
-            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value={"controls"}),
+            patch("osprey.cli.query_cmd.expected_mcp_servers", return_value={"controls"}),
         ):
             result = runner.invoke(query, ["--project", str(project_with_mcp), "--json", "ping"])
 
@@ -350,7 +350,7 @@ class TestJsonStdoutPurity:
                 "osprey.cli.query_cmd.read_only_disallowed_tools",
                 return_value=["mcp__controls__channel_write"],
             ),
-            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value={"controls"}),
+            patch("osprey.cli.query_cmd.expected_mcp_servers", return_value={"controls"}),
         ):
             result = runner.invoke(
                 query, ["--project", str(project_with_mcp), "--json", "beam current"]
@@ -381,7 +381,7 @@ class TestInfraErrors:
                 "osprey.cli.query_cmd.read_only_disallowed_tools",
                 return_value=["mcp__controls__channel_write"],
             ),
-            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value=set()),
+            patch("osprey.cli.query_cmd.expected_mcp_servers", return_value=set()),
         ):
             result = runner.invoke(query, ["--project", str(project_with_mcp), "hello"])
         assert result.exit_code == EXIT_USAGE
@@ -396,7 +396,7 @@ class TestInfraErrors:
                 "osprey.cli.query_cmd.read_only_disallowed_tools",
                 return_value=["mcp__controls__channel_write"],
             ),
-            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value=set()),
+            patch("osprey.cli.query_cmd.expected_mcp_servers", return_value=set()),
         ):
             result = runner.invoke(query, ["--project", str(project_with_mcp), "hello"])
         assert result.exit_code == EXIT_USAGE
@@ -413,7 +413,7 @@ class TestInfraErrors:
                 "osprey.cli.query_cmd.read_only_disallowed_tools",
                 return_value=["mcp__controls__channel_write"],
             ),
-            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value=set()),
+            patch("osprey.cli.query_cmd.expected_mcp_servers", return_value=set()),
         ):
             result = runner.invoke(query, ["--project", str(project_with_mcp), "hello"])
         assert result.exit_code == EXIT_USAGE
@@ -432,7 +432,7 @@ class TestInfraErrors:
                 "osprey.cli.query_cmd.read_only_disallowed_tools",
                 return_value=["mcp__controls__channel_write"],
             ),
-            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value=set()),
+            patch("osprey.cli.query_cmd.expected_mcp_servers", return_value=set()),
         ):
             result = runner.invoke(query, ["--project", str(project_with_mcp), "hello"])
         assert result.exit_code == EXIT_USAGE
@@ -453,7 +453,7 @@ class TestInfraErrors:
                 "osprey.cli.query_cmd.read_only_disallowed_tools",
                 return_value=["mcp__controls__channel_write"],
             ),
-            patch("osprey.cli.query_cmd._expected_mcp_servers", return_value=set()),
+            patch("osprey.cli.query_cmd.expected_mcp_servers", return_value=set()),
         ):
             result = runner.invoke(query, ["--project", str(project_with_mcp), "hello"])
         assert result.exit_code == EXIT_USAGE

--- a/tests/e2e/sdk_helpers.py
+++ b/tests/e2e/sdk_helpers.py
@@ -59,8 +59,8 @@ except ImportError:
 from osprey.agent_runner import (
     SDKWorkflowResult,
     ToolTrace,
-    _await_mcp_ready,
-    _expected_mcp_servers,
+    await_mcp_ready,
+    expected_mcp_servers,
     resolve_default_model,
     sdk_env,
 )
@@ -562,12 +562,10 @@ async def run_sdk_query(
     try:
         # ClaudeSDKClient (streaming) rather than the one-shot ``query()`` so we can
         # poll ``get_mcp_status()`` and wait out async MCP registration before the
-        # first turn — eliminating the controls cold-start race (see _await_mcp_ready).
+        # first turn — eliminating the controls cold-start race (see await_mcp_ready).
         # Message handling is identical to the query() iterator.
         async with ClaudeSDKClient(options=options) as client:
-            workflow.mcp_servers = await _await_mcp_ready(
-                client, _expected_mcp_servers(project_dir)
-            )
+            workflow.mcp_servers = await await_mcp_ready(client, expected_mcp_servers(project_dir))
             await client.query(prompt)
             async for message in client.receive_response():
                 if isinstance(message, AssistantMessage):
@@ -725,9 +723,7 @@ async def run_sdk_query_with_hooks(
             # Wait out async MCP registration (controls cold-starts ~1.5s) so the
             # agent never races a half-built toolset. Snapshot is the authoritative
             # infra-vs-model record.
-            workflow.mcp_servers = await _await_mcp_ready(
-                client, _expected_mcp_servers(project_dir)
-            )
+            workflow.mcp_servers = await await_mcp_ready(client, expected_mcp_servers(project_dir))
             await client.query(prompt)
             async for message in client.receive_response():
                 if isinstance(message, AssistantMessage):

--- a/tests/e2e/test_mcp_readiness.py
+++ b/tests/e2e/test_mcp_readiness.py
@@ -1,7 +1,7 @@
 """Unit tests for the MCP readiness barrier + instrumentation in sdk_helpers.
 
 These exercise the cold-start-race fix without any API calls or a real CLI:
-``_await_mcp_ready`` is driven by a fake client, and the ``SDKWorkflowResult``
+``await_mcp_ready`` is driven by a fake client, and the ``SDKWorkflowResult``
 accessors are pure data transforms. The integration behaviour (the barrier
 actually eliminating the controls cold-start flake) is covered by the e2e suite.
 
@@ -19,8 +19,8 @@ import pytest
 from tests.e2e.sdk_helpers import (
     SDKWorkflowResult,
     ToolTrace,
-    _await_mcp_ready,
-    _expected_mcp_servers,
+    await_mcp_ready,
+    expected_mcp_servers,
 )
 
 pytestmark = pytest.mark.unit
@@ -63,7 +63,7 @@ def test_await_returns_once_all_expected_connected() -> None:
             ],
         ]
     )
-    servers = asyncio.run(_await_mcp_ready(client, {"controls", "python"}, timeout_s=5, poll_s=0))
+    servers = asyncio.run(await_mcp_ready(client, {"controls", "python"}, timeout_s=5, poll_s=0))
     status = {s["name"]: s["status"] for s in servers}
     assert status == {"controls": "connected", "python": "connected"}
     assert client.calls == 3  # did not over-poll once ready
@@ -75,7 +75,7 @@ def test_await_tolerates_early_get_status_errors() -> None:
         [[_srv("controls", "connected", ["channel_write"])]],
         raise_first=2,
     )
-    servers = asyncio.run(_await_mcp_ready(client, {"controls"}, timeout_s=5, poll_s=0))
+    servers = asyncio.run(await_mcp_ready(client, {"controls"}, timeout_s=5, poll_s=0))
     assert {s["name"]: s["status"] for s in servers} == {"controls": "connected"}
 
 
@@ -83,7 +83,7 @@ def test_await_returns_last_snapshot_on_timeout_without_raising() -> None:
     """If a server never connects, return the last snapshot (don't raise) so the
     caller records a genuine registration failure rather than masking it."""
     client = _FakeClient([[_srv("controls", "pending"), _srv("python", "connected")]])
-    servers = asyncio.run(_await_mcp_ready(client, {"controls"}, timeout_s=0.05, poll_s=0.01))
+    servers = asyncio.run(await_mcp_ready(client, {"controls"}, timeout_s=0.05, poll_s=0.01))
     assert {s["name"]: s["status"] for s in servers} == {
         "controls": "pending",
         "python": "connected",
@@ -113,11 +113,11 @@ def test_expected_mcp_servers_reads_mcp_json(tmp_path) -> None:
         '{"mcpServers": {"controls": {}, "python": {}, "osprey_workspace": {}}}',
         encoding="utf-8",
     )
-    assert _expected_mcp_servers(tmp_path) == {"controls", "python", "osprey_workspace"}
+    assert expected_mcp_servers(tmp_path) == {"controls", "python", "osprey_workspace"}
 
 
 def test_expected_mcp_servers_empty_when_missing(tmp_path) -> None:
-    assert _expected_mcp_servers(tmp_path) == set()
+    assert expected_mcp_servers(tmp_path) == set()
 
 
 def test_redelegation_loop_detected_on_repeated_identical_agent_spawns() -> None:

--- a/tests/unit/dispatch_worker/test_sdk_runner_mcp_barrier.py
+++ b/tests/unit/dispatch_worker/test_sdk_runner_mcp_barrier.py
@@ -62,7 +62,7 @@ async def test_mcp_is_polled_to_connected_before_the_prompt_is_sent(monkeypatch)
     """The barrier is only worth anything if it precedes the first turn."""
     events: list[str] = []
     monkeypatch.setattr(sdk_runner, "ClaudeSDKClient", lambda options: _FakeClient(events))
-    monkeypatch.setattr(sdk_runner, "_expected_mcp_servers", lambda _p: {"controls"})
+    monkeypatch.setattr(sdk_runner, "expected_mcp_servers", lambda _p: {"controls"})
 
     messages = await _drain(sdk_runner._stream_with_ready_mcp(object(), "/proj", object()))
 
@@ -79,11 +79,11 @@ async def test_run_proceeds_and_warns_when_a_server_never_connects(monkeypatch, 
     is logged so a missing tool is diagnosable as infra, not model behaviour."""
     events: list[str] = []
     monkeypatch.setattr(sdk_runner, "ClaudeSDKClient", lambda options: _FakeClient(events))
-    monkeypatch.setattr(sdk_runner, "_expected_mcp_servers", lambda _p: {"controls", "archiver"})
+    monkeypatch.setattr(sdk_runner, "expected_mcp_servers", lambda _p: {"controls", "archiver"})
     # Barrier timed out: only one of the two expected servers came up.
     monkeypatch.setattr(
         sdk_runner,
-        "_await_mcp_ready",
+        "await_mcp_ready",
         lambda _c, _e: _ready([{"name": "controls", "status": "connected"}]),
     )
 
@@ -103,7 +103,7 @@ async def test_no_declared_servers_is_skipped_rather_than_polled_to_the_deadline
     run — the barrier is skipped outright, not merely waited out."""
     events: list[str] = []
     monkeypatch.setattr(sdk_runner, "ClaudeSDKClient", lambda options: _FakeClient(events))
-    monkeypatch.setattr(sdk_runner, "_expected_mcp_servers", lambda _p: set())
+    monkeypatch.setattr(sdk_runner, "expected_mcp_servers", lambda _p: set())
 
     started = time.monotonic()
     messages = await _drain(sdk_runner._stream_with_ready_mcp(object(), "/proj", object()))


### PR DESCRIPTION
`expected_mcp_servers` and `await_mcp_ready` were declared private by their leading underscore, while every other signal said they are public:

- re-exported from `osprey.agent_runner`
- listed in `__all__` — with the underscores
- documented in the module docstring under a heading called `Public surface`
- imported across package boundaries by four consumers: `cli/query_cmd.py`, `agent_runner/runner.py`, `agent_runner/session.py`, and `mcp_server/dispatch_worker/sdk_runner.py`

This drops the prefix so the names match the role they already have. Pure rename — 88 references across 12 files, no behavior change, no signature change.

### Verification

| Gate | Result |
|---|---|
| `pytest tests/ --ignore=tests/e2e` | 13619 passed, 39 skipped, 1 xfailed |
| `ruff check` / `ruff format --check` | clean (4 import-order autofixes applied) |
| `mypy src/ --no-incremental` | 341 errors in 151 files — **identical** to the `main` baseline at `3bf3be2ab`, so 0 new |
| e2e collection | `tests/e2e/test_mcp_readiness.py` collects 10 tests |

No changelog entry: `osprey.agent_runner` is not in the documented API surface (`docs/source` has no reference to it) and this has no user-visible effect.