### PR TITLE
build(deps): bump GitHub Actions to current majors

### DIFF
--- a/.github/workflows/build-nextcloud-fixture.yml
+++ b/.github/workflows/build-nextcloud-fixture.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
     - name: Check out the fixture sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Verify the dispatched tag matches the Dockerfile pins
       # Publishing a tag that disagrees with what the image actually contains is
@@ -112,14 +112,14 @@ jobs:
         echo "Tag matches the pinned versions."
 
     - name: Log in to ghcr
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Build and push the fixture
       # --platform is stated explicitly rather than inherited from the runner:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,7 +402,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Set up Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: '22'
 
@@ -481,7 +481,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Log in to ghcr (openobserve mirror)
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -559,7 +559,7 @@ jobs:
         fetch-depth: 0
 
     - name: Log in to ghcr (openobserve mirror)
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -739,7 +739,7 @@ jobs:
         fetch-depth: 0
 
     - name: Log in to ghcr (openobserve mirror)
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -801,7 +801,7 @@ jobs:
         fetch-depth: 0
 
     - name: Log in to ghcr (openobserve mirror)
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -873,7 +873,7 @@ jobs:
         fetch-depth: 0
 
     - name: Log in to ghcr (openobserve mirror)
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -940,7 +940,7 @@ jobs:
         fetch-depth: 0
 
     - name: Log in to ghcr (openobserve mirror)
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -985,7 +985,7 @@ jobs:
         fetch-depth: 0
 
     - name: Log in to ghcr (openobserve mirror)
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -1035,7 +1035,7 @@ jobs:
         fetch-depth: 0
 
     - name: Log in to ghcr (openobserve mirror)
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -1081,7 +1081,7 @@ jobs:
         fetch-depth: 0
 
     - name: Log in to ghcr (openobserve mirror)
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -1128,7 +1128,7 @@ jobs:
         fetch-depth: 0
 
     - name: Log in to ghcr (openobserve mirror)
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -1172,7 +1172,7 @@ jobs:
         fetch-depth: 0
 
     - name: Log in to ghcr (openobserve mirror)
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -1217,7 +1217,7 @@ jobs:
         fetch-depth: 0
 
     - name: Log in to ghcr (openobserve mirror)
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -1265,7 +1265,7 @@ jobs:
         fetch-depth: 0
 
     - name: Log in to ghcr (openobserve mirror)
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -1320,7 +1320,7 @@ jobs:
         fetch-depth: 0
 
     - name: Log in to ghcr (openobserve mirror + Nextcloud Talk fixture)
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}

--- a/.github/workflows/mirror-openobserve.yml
+++ b/.github/workflows/mirror-openobserve.yml
@@ -36,14 +36,14 @@ jobs:
 
     steps:
     - name: Log in to ghcr
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Copy image registry-to-registry
       # imagetools copies the manifest LIST server-side. Do not replace this


### PR DESCRIPTION
Consolidates four outstanding GitHub Actions version bumps into a single change so they run with real credentials and can produce a genuinely green board.

| action | was | now | notes |
|---|---|---|---|
| `actions/checkout` | v4 | v7 | only `build-nextcloud-fixture.yml` was still on v4; every other workflow was already v7 |
| `actions/setup-node` | v6 | v7 | single call site, exercised by the `frontend-js` job |
| `docker/login-action` | v3 | v4 | 16 call sites |
| `docker/setup-buildx-action` | v3 | v4 | 2 call sites, both in manually-dispatched workflows |

Version references only — no workflow logic, expressions, or inputs changed. All three files re-validated as parseable YAML.

`login-action` is pinned to the bare major `v4` rather than an exact patch, matching how every other action in this repo is referenced.

Note that `setup-buildx-action` appears only in `mirror-openobserve.yml` and `build-nextcloud-fixture.yml`, both `workflow_dispatch`-only. No PR run can exercise those two call sites; they need a manual dispatch to confirm.