### PR TITLE
fix(dispatch-worker): keep subagent delegation in the foreground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,6 +280,9 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- Dispatched runs that delegate to a subagent now wait for the delegated work
+  and return the full answer. Previously the reply could stop at "the agent is
+  searching, I'll notify you when it completes" and nothing further arrived.
 - `osprey web --project <dir>` launched from outside the project now behaves the
   same as running `osprey web` inside it. Previously the flag only set the
   terminal's working directory, so the project's `.env` was never loaded

--- a/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
+++ b/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
@@ -381,6 +381,20 @@ async def run_dispatch(
 
     sdk_env = build_clean_env(project_cwd=project_dir)
 
+    # Keep subagent delegation in the foreground. Since CLI 2.1.x the Agent tool
+    # auto-backgrounds delegated subagents: it returns immediately, the turn
+    # ends, and the results arrive on a *later* turn as a task notification.
+    # ``_drain_response`` stops at the first ResultMessage, so the worker would
+    # answer "the agent is searching, I'll notify you when it completes" and
+    # silently drop the delegated work. Set explicitly rather than inherited —
+    # ``build_clean_env()`` strips every ``CLAUDE_CODE_*`` key by design.
+    #
+    # Deliberately NOT set in ``build_clean_env()`` itself: the interactive
+    # web-terminal sessions share that helper, and they converge on a later
+    # turn, so backgrounding is correct there. Only this single-drain path
+    # needs the guard. The cost is that parallel delegations run sequentially.
+    sdk_env["CLAUDE_CODE_DISABLE_BACKGROUND_TASKS"] = "1"
+
     # Point OSPREY config resolution at the project explicitly. The worker
     # process CWD is the image WORKDIR (``/app`` in the container), not the
     # project dir, and ``osprey.utils.config`` falls back to ``CWD/config.yml``

--- a/tests/unit/dispatch_worker/test_sdk_runner.py
+++ b/tests/unit/dispatch_worker/test_sdk_runner.py
@@ -227,6 +227,33 @@ async def test_config_file_env_points_at_project(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_subagent_delegation_runs_in_the_foreground(monkeypatch):
+    """The dispatched agent's env disables background tasks.
+
+    Since Claude Code CLI 2.1.x the Agent tool auto-backgrounds delegated
+    subagents: the turn ends immediately and the subagent's results arrive on a
+    *later* turn as a task notification. ``_drain_response`` stops at the first
+    ResultMessage, so the worker would answer "the agent is searching, I'll
+    notify you when it completes" and never deliver the delegated work.
+
+    ``build_clean_env()`` strips every ``CLAUDE_CODE_*`` key, so this guard
+    cannot be inherited — the worker has to set it explicitly. Regression guard
+    for that silent under-run.
+    """
+    captured: dict = {}
+
+    async def fake_query(options, project_dir, prompt):
+        captured["options"] = options
+        yield AssistantMessage(content=[TextBlock(text="ok")], model="m")
+        yield _result_message(cost_usd=0.1, num_turns=1)
+
+    monkeypatch.setattr(sdk_runner, "_stream_with_ready_mcp", fake_query)
+    await sdk_runner.run_dispatch("do it", ["Read"], event_queue=asyncio.Queue())
+
+    assert captured["options"].env["CLAUDE_CODE_DISABLE_BACKGROUND_TASKS"] == "1"
+
+
+@pytest.mark.asyncio
 async def test_sdk_missing(monkeypatch):
     monkeypatch.setattr(sdk_runner, "HAS_SDK", False)
 


### PR DESCRIPTION
Dispatched runs that delegate to a subagent can return a truncated answer — "the agent is searching, I'll notify you when it completes" — with the delegated work never arriving.

## Cause

The Agent tool auto-backgrounds delegated subagents on current CLI releases: it returns immediately, the turn ends, and results arrive on a *later* turn as a task notification. `_drain_response` stops at the first `ResultMessage`, so the worker never sees the continuation.

`CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` exists to suppress exactly this (documented at `agent_runner/primitives.py:379`), but the worker cannot inherit it: it builds its SDK environment with `build_clean_env()`, which strips every `CLAUDE_CODE_*` key by design.

## Fix

Set the guard explicitly on the worker's SDK env, alongside the other path-specific keys it already layers on.

It is deliberately **not** set inside `build_clean_env()`. That helper is shared with the interactive web-terminal sessions (`routes/chat.py`, `routes/websocket.py`), which do converge on a later turn — backgrounding is correct there, and forcing them sequential would slow the UI for no benefit. Only the single-drain worker path needs the guard.

## Scope

Fix only. `claude-agent-sdk` stays pinned at 0.2.110.

The 0.2.128 bump surfaced this bug, but adopting it is a separate question: across three E2E runs on that version the lane failed three times with four different non-repeating tests, two of them delegation-related, versus a first-try pass on 0.2.110. That warrants its own evaluation rather than riding along with a fix.

This change is worth landing on 0.2.110 regardless — it hardens the worker against backgrounding whenever the bundled CLI starts doing it.

## Verification

A unit test asserts the worker's SDK env carries the guard; it fails with `KeyError` before the fix.