### PR TITLE
feat: add osprey theme-lab for proposing accent themes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,7 @@ jobs:
       if: steps.changes.outputs.theming == 'true'
       run: |
         uv run pytest tests/interfaces/design_system/test_behavioral.py \
+          tests/interfaces/design_system/test_theme_lab.py \
           tests/interfaces/web_terminal/test_panels_browser.py \
           tests/interfaces/web_terminal/test_contract_params.py \
           tests/interfaces/web_terminal/test_logout_resume_browser.py \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ Compatibility is documented in release notes, not encoded in the version string.
   and a key that was retired cannot come back in a template, a preset override,
   or the loader's defaults. Contributors can run it from a checkout with
   `uv run python scripts/check_config_keys.py`.
+- `osprey theme-lab` opens a browser workbench for designing a theme: pick an
+  accent color, see it previewed live in dark and light with contrast badges,
+  then copy an export block describing the theme to request it.
 
 ### Changed
 

--- a/docs/source/cli-reference/index.rst
+++ b/docs/source/cli-reference/index.rst
@@ -26,6 +26,7 @@ without arguments launches an interactive TUI menu.
    osprey ariel              # ARIEL logbook search service
    osprey artifacts          # Artifact gallery
    osprey web                # Launch web terminal
+   osprey theme-lab          # Design and preview a theme in the browser
    osprey scaffold           # Build artifact overrides
    osprey audit              # Audit project or profile safety
    osprey skills             # Manage bundled Osprey skills
@@ -363,6 +364,31 @@ Launch the Web Terminal interface. See :doc:`/how-to/web-terminal/operate`.
    osprey web --port 9000 --host 0.0.0.0
    osprey web --detach
    osprey web stop
+
+osprey theme-lab
+================
+
+Design a theme in the browser. Starts a local server for OSPREY's design
+system and opens the Theme Lab, where you pick an accent color and see it
+previewed live on dark and light mock-ups of the web terminal, with contrast
+badges that update as you go. Copying the export block gives you a
+ready-to-paste description of the theme to request; the lab itself does not
+write theme files. See :doc:`/how-to/web-terminal/theming`.
+
+``osprey theme-lab [OPTIONS]``
+   Serve the Theme Lab and open it. The URL is printed as well, so the page can
+   be opened by hand if no browser appears.
+
+   ``-p, --port INTEGER`` — Port to serve on (default: an unused port chosen
+   automatically).
+
+   ``--no-browser`` — Do not open a browser window; print the URL only.
+
+.. code-block:: bash
+
+   osprey theme-lab
+   osprey theme-lab --port 9000
+   osprey theme-lab --no-browser
 
 osprey audit
 ============

--- a/docs/source/how-to/web-terminal/theming.rst
+++ b/docs/source/how-to/web-terminal/theming.rst
@@ -69,6 +69,22 @@ across reloads.
    ``web.theme`` (the browser interfaces) is separate from ``cli.theme`` (the
    colors of OSPREY's plain terminal output). They never affect each other.
 
+Propose a theme
+---------------
+
+Have a color of your own in mind? Run:
+
+.. code-block:: bash
+
+   osprey theme-lab
+
+That opens the Theme Lab in your browser. Pick an accent color and the dark and
+light mock-ups of the terminal re-skin as you go, while the contrast badges tell
+you at a glance whether text stays readable against it — the same check every
+shipped theme has to pass. When you are happy, give the theme a name, copy the
+export block, and paste it into a GitHub issue. The lab doesn't create the theme
+itself; the export spells out exactly what needs to change to make it real.
+
 .. dropdown:: Going deeper — the design system
    :icon: paintbrush
 

--- a/src/osprey/cli/main.py
+++ b/src/osprey/cli/main.py
@@ -53,6 +53,7 @@ class LazyGroup(click.Group):
             "sim": "osprey.cli.sim",  # Simulation scenarios
             "artifacts": "osprey.cli.artifacts_cmd",  # Artifact Gallery
             "web": "osprey.cli.web_cmd",  # Web Terminal
+            "theme-lab": "osprey.cli.theme_lab_cmd",  # Design-system theme workbench
             "scaffold": "osprey.cli.scaffold_cmd",  # Build artifact overrides
             "audit": "osprey.cli.audit_cmd",  # Safety auditor
             "skills": "osprey.cli.skills_cmd",  # Bundled skill management
@@ -80,6 +81,8 @@ class LazyGroup(click.Group):
             cmd_func = mod.artifacts
         elif cmd_name == "web":
             cmd_func = mod.web
+        elif cmd_name == "theme-lab":
+            cmd_func = mod.theme_lab
         elif cmd_name == "scaffold":
             cmd_func = mod.scaffold
         else:
@@ -101,6 +104,7 @@ class LazyGroup(click.Group):
             "sim",
             "artifacts",
             "web",
+            "theme-lab",
             "scaffold",
             "audit",
             "skills",
@@ -131,6 +135,7 @@ def cli(ctx):
       osprey deploy up                Start services
       osprey claude regen             Regenerate Claude Code artifacts
       osprey web                      Launch web terminal
+      osprey theme-lab                Build and preview themes in the browser
       osprey health                   Check system health
       osprey channel-finder           Interactive channel search
     """

--- a/src/osprey/cli/theme_lab_cmd.py
+++ b/src/osprey/cli/theme_lab_cmd.py
@@ -1,0 +1,126 @@
+"""CLI command for the OSPREY Theme Lab.
+
+Provides ``osprey theme-lab``: serves the design-system static directory on a
+local port and opens the Theme Lab page, an interactive workbench for building
+and previewing OSPREY themes against the live design tokens.
+
+The command is intentionally project-independent — the Theme Lab reads only the
+design system that ships inside the wheel, so it runs from any directory without
+a ``config.yml``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+#: Page the browser is pointed at, relative to the server root. Served by the
+#: ``/design-system`` mount that ``configure_interface_app`` always registers.
+THEME_LAB_PATH = "/design-system/theme-lab.html"
+
+
+def _design_system_static_dir() -> Path:
+    """Return the packaged design-system static directory.
+
+    Resolved from the ``osprey.interfaces.design_system`` package itself rather
+    than from the source tree layout, so an installed wheel and an editable
+    checkout both find the same assets.
+    """
+    from osprey.interfaces import design_system
+
+    return Path(design_system.__file__).parent / "static"
+
+
+def create_app() -> FastAPI:
+    """Build the FastAPI app that serves the Theme Lab.
+
+    The design-system directory is passed as the interface's own ``static_dir``
+    so its assets are reachable under ``/static`` as well as under the
+    ``/design-system`` mount that :func:`configure_interface_app` registers
+    automatically for every interface.
+
+    Importable and callable with no server running — the Playwright suite and
+    the CLI both build the app through this one factory.
+    """
+    from fastapi import FastAPI
+    from fastapi.responses import RedirectResponse
+
+    from osprey.interfaces._app_setup import configure_interface_app
+
+    static_dir = _design_system_static_dir()
+    if not static_dir.is_dir():
+        raise FileNotFoundError(
+            f"design-system static directory not found: {static_dir} "
+            "(the OSPREY installation is incomplete)"
+        )
+
+    app = FastAPI(title="OSPREY Theme Lab")
+
+    @app.get("/", include_in_schema=False)
+    async def root() -> RedirectResponse:
+        return RedirectResponse(THEME_LAB_PATH)
+
+    configure_interface_app(app, static_dir=static_dir)
+
+    return app
+
+
+@click.command("theme-lab")
+@click.option(
+    "--port",
+    "-p",
+    type=int,
+    default=None,
+    help="Port to serve on (default: an unused port chosen automatically).",
+)
+@click.option("--no-browser", is_flag=True, help="Do not open a browser window.")
+def theme_lab(port: int | None, no_browser: bool) -> None:
+    """Serve the OSPREY Theme Lab in a browser.
+
+    Starts a local server for the design system and opens the Theme Lab, where
+    themes can be built and previewed against the live design tokens. The URL is
+    printed so it can be opened by hand if the browser does not appear.
+
+    Example:
+
+    \b
+        osprey theme-lab                   # Serve on a free port, open a browser
+        osprey theme-lab --port 9000       # Serve on a specific port
+        osprey theme-lab --no-browser      # Print the URL only
+    """
+    import uvicorn
+
+    from osprey.interfaces._serving import free_port
+
+    try:
+        app = create_app()
+    except FileNotFoundError as exc:
+        click.echo(f"ERROR: {exc}", err=True)
+        sys.exit(1)
+
+    serve_port = port if port is not None else free_port()
+    url = f"http://127.0.0.1:{serve_port}{THEME_LAB_PATH}"
+
+    if not no_browser:
+        # A browser that refuses to open (headless host, no DISPLAY) must not
+        # take the server down with it — the printed URL below is still usable.
+        try:
+            from osprey.interfaces.web_terminal.app import _open_browser_when_ready
+
+            _open_browser_when_ready(url)
+        except Exception as exc:
+            click.echo(f"WARNING: could not open a browser ({exc}).", err=True)
+
+    click.echo(f"Theme Lab: {url}")
+    click.echo("Press Ctrl+C to stop\n")
+
+    try:
+        uvicorn.run(app, host="127.0.0.1", port=serve_port, log_level="warning")
+    except KeyboardInterrupt:
+        click.echo("\nShutting down...")

--- a/src/osprey/interfaces/design_system/static/css/theme-lab.css
+++ b/src/osprey/interfaces/design_system/static/css/theme-lab.css
@@ -1,0 +1,754 @@
+/* OSPREY Design System — Theme Lab
+   Hand-maintained. Page styles for static/theme-lab.html: the accent-picker
+   controls column, the two scoped [data-theme] preview panels, and the
+   schematic "mini shell" mock instantiated into both of them.
+
+   Two rules govern everything below:
+
+   1. Zero color literals. Every color is a custom-property reference into
+      tokens.css, so the rules below resolve against whichever theme scope they
+      happen to render inside — the entire mechanism the preview relies on.
+   2. The mini-shell (.ms-*) rules must never depend on an ancestor's theme:
+      they are plain class selectors only, so one rule set serves both panels. */
+
+/* base.css clips html/body to a single viewport for app shells that manage
+   their own internal scroll regions. The lab is ordinary scrolling content. */
+html, body {
+  height: auto;
+  overflow: auto;
+}
+
+body {
+  padding: var(--space-5);
+  font-family: var(--font-display);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+.lab-page {
+  max-width: 1500px;
+  margin: 0 auto;
+}
+
+/* --- Masthead ------------------------------------------------------------ */
+
+.lab-masthead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding-bottom: var(--space-3);
+  margin-bottom: var(--space-5);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.lab-masthead-title {
+  margin: 0;
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-bold);
+}
+
+.lab-masthead-kicker {
+  margin: var(--space-1) 0 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.lab-masthead-link {
+  font-size: var(--text-sm);
+  color: var(--color-accent-light);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.lab-masthead-link:hover {
+  color: var(--color-accent);
+  text-decoration: underline;
+}
+
+/* --- Page grid ----------------------------------------------------------- */
+
+.lab {
+  display: grid;
+  grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
+  align-items: start;
+  gap: var(--space-5);
+}
+
+@media (max-width: 1100px) {
+  .lab { grid-template-columns: minmax(0, 1fr); }
+}
+
+/* --- Controls column ----------------------------------------------------- */
+
+.lab-controls {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  min-width: 0;
+}
+
+.lab-section {
+  padding: var(--space-4);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+}
+
+.lab-section-title {
+  margin: 0 0 var(--space-3);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-none);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.lab-field { margin-top: var(--space-4); }
+.lab-field:first-of-type { margin-top: 0; }
+
+.lab-field-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
+}
+
+.lab-field-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.lab-range-value {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+}
+
+/* --- Hue / saturation wheel ---------------------------------------------- */
+
+.lab-wheel {
+  display: block;
+  width: 100%;
+  max-width: 240px;
+  height: auto;
+  margin: 0 auto;
+  border-radius: var(--radius-full);
+  background: var(--bg-elevated);
+  cursor: crosshair;
+  touch-action: none;
+}
+
+/* --- Text inputs / ranges ------------------------------------------------ */
+
+.lab-text-input {
+  flex: 1;
+  min-width: 0;
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--text-md);
+  color: var(--text-primary);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  transition: border-color var(--duration-fast) ease, box-shadow var(--duration-fast) ease;
+}
+
+.lab-text-input::placeholder { color: var(--text-muted); }
+
+.lab-text-input.is-invalid { border-color: var(--color-error); }
+
+.lab-hex-swatch {
+  flex: none;
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+}
+
+.lab-range {
+  display: block;
+  width: 100%;
+  accent-color: var(--color-accent);
+  cursor: pointer;
+}
+
+.lab-text-input:focus-visible,
+.lab-range:focus-visible,
+.lab-wheel:focus-visible,
+.lab-btn:focus-visible,
+.lab-preset:focus-visible,
+.lab-export-text:focus-visible {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--accent-tint-30);
+}
+
+/* --- Preset row ---------------------------------------------------------- */
+
+.lab-preset-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.lab-preset {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  font-family: var(--font-display);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  transition: color var(--duration-fast) ease, border-color var(--duration-fast) ease;
+}
+
+.lab-preset:hover {
+  color: var(--text-primary);
+  border-color: var(--border-accent);
+}
+
+.lab-preset.is-active {
+  color: var(--color-accent-light);
+  background: var(--accent-tint-10);
+  border-color: var(--color-accent);
+}
+
+.lab-preset-swatch {
+  width: 12px;
+  height: 12px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-full);
+  background: var(--bg-panel);
+}
+
+/* --- Slug / validation message ------------------------------------------- */
+
+.lab-warning {
+  margin: var(--space-2) 0 0;
+  font-size: var(--text-sm);
+  line-height: var(--leading-snug);
+  color: var(--color-warning);
+}
+
+.lab-warning:empty { display: none; }
+.lab-warning.is-ok { color: var(--color-success); }
+.lab-warning.is-error { color: var(--color-error); }
+
+/* --- Buttons ------------------------------------------------------------- */
+
+.lab-btn {
+  padding: var(--space-1) var(--space-3);
+  font-family: var(--font-display);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--color-on-accent);
+  background: var(--color-accent);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background-color var(--duration-fast) ease, border-color var(--duration-fast) ease;
+}
+
+.lab-btn:hover {
+  background: var(--color-accent-light);
+  border-color: var(--color-accent-light);
+}
+
+.lab-btn.is-done {
+  color: var(--color-success);
+  background: var(--success-tint-08);
+  border-color: var(--color-success);
+}
+
+/* --- Export -------------------------------------------------------------- */
+
+.lab-export-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.lab-export-title { margin: 0; }
+
+.lab-export-text {
+  margin: 0;
+  max-height: 320px;
+  padding: var(--space-3);
+  overflow: auto;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: var(--leading-relaxed);
+  color: var(--text-secondary);
+  background: var(--bg-terminal);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  white-space: pre;
+  user-select: text;
+}
+
+/* --- Preview panels ------------------------------------------------------ */
+
+.lab-previews {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  gap: var(--space-4);
+  min-width: 0;
+}
+
+/* Each panel carries its own data-theme, so these token references resolve to
+   that panel's mode — the panel chrome is itself part of the preview. */
+.lab-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  min-width: 0;
+  padding: var(--space-4);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-xl);
+}
+
+.lab-panel-label {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-none);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.lab-panel-hint {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-regular);
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--text-muted);
+}
+
+.lab-mount { min-width: 0; }
+
+.lab-readout {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.lab-readout-title {
+  margin: var(--space-2) 0 0;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+/* --- WCAG gate badges ---------------------------------------------------- */
+
+.lab-gates {
+  display: flex;
+  flex-direction: column;
+}
+
+.lab-gate {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-1) 0;
+  border-bottom: 1px solid var(--border-default);
+}
+
+.lab-gate-label {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.lab-gate-badge {
+  flex: none;
+  padding: var(--space-1) var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-none);
+  color: var(--text-muted);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-full);
+}
+
+.lab-gate-badge.is-pass {
+  color: var(--color-success);
+  background: var(--success-tint-08);
+  border-color: var(--color-success);
+}
+
+.lab-gate-badge.is-warn {
+  color: var(--color-warning);
+  background: var(--amber-tint-08);
+  border-color: var(--color-warning);
+}
+
+.lab-gate-badge.is-fail {
+  color: var(--color-error);
+  background: var(--error-tint-08);
+  border-color: var(--color-error);
+}
+
+/* --- Derived-token table ------------------------------------------------- */
+
+.lab-tokens { overflow-x: auto; }
+
+.lab-token-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+}
+
+.lab-token-table th {
+  padding: var(--space-1) var(--space-2);
+  text-align: left;
+  font-weight: var(--weight-semibold);
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border-default);
+  white-space: nowrap;
+}
+
+.lab-token-table td {
+  padding: var(--space-1) var(--space-2);
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-default);
+  white-space: nowrap;
+}
+
+.lab-token-name { color: var(--text-primary); }
+
+.lab-token-swatch {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  vertical-align: middle;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-xs);
+  background: var(--bg-elevated);
+}
+
+/* ========================================================================= */
+/* Mini shell — the schematic web-terminal mock (template#mini-shell).        */
+/* Rendered once per theme scope; every rule below is theme-agnostic.         */
+/* ========================================================================= */
+
+.ms-shell {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  font-family: var(--font-display);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+}
+
+.ms-spacer { flex: 1; }
+
+/* Header bar */
+
+.ms-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-panel);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.ms-logo {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.14em;
+  color: var(--color-accent);
+}
+
+.ms-title {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+}
+
+.ms-icon-btn {
+  padding: var(--space-1);
+  font-size: var(--text-md);
+  line-height: var(--leading-none);
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: color var(--duration-fast) ease, background-color var(--duration-fast) ease;
+}
+
+.ms-icon-btn:hover {
+  color: var(--color-accent-light);
+  background: var(--accent-tint-08);
+}
+
+/* Tab strip */
+
+.ms-tabs {
+  display: flex;
+  gap: var(--space-1);
+  padding: 0 var(--space-3);
+  background: var(--bg-panel);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.ms-tab {
+  padding: var(--space-2) var(--space-3);
+  font-family: inherit;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: color var(--duration-fast) ease, border-color var(--duration-fast) ease;
+}
+
+.ms-tab:hover { color: var(--text-secondary); }
+
+.ms-tab.is-active {
+  color: var(--color-accent-light);
+  border-bottom-color: var(--color-accent);
+}
+
+/* Body: icon rail + main column */
+
+.ms-body {
+  display: flex;
+  min-height: 0;
+}
+
+.ms-rail {
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-2);
+  background: var(--bg-panel);
+  border-right: 1px solid var(--border-default);
+}
+
+.ms-rail-item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  font-size: var(--text-sm);
+  line-height: var(--leading-none);
+  color: var(--text-muted);
+  border-radius: var(--radius-md);
+}
+
+.ms-rail-item.is-active {
+  color: var(--color-accent-light);
+  background: var(--accent-tint-12);
+  box-shadow: inset 2px 0 0 var(--color-accent);
+}
+
+.ms-main {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 0;
+  padding: var(--space-3);
+}
+
+/* Terminal snippet */
+
+.ms-terminal {
+  padding: var(--space-2) var(--space-3);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  line-height: var(--leading-relaxed);
+  color: var(--terminal-text);
+  background: var(--bg-terminal);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+}
+
+.ms-term-line {
+  margin: 0;
+  white-space: pre;
+}
+
+.ms-term-prompt { color: var(--color-accent); }
+
+.ms-term-out { color: var(--text-secondary); }
+
+.ms-term-cursor {
+  display: inline-block;
+  width: 5px;
+  height: 9px;
+  vertical-align: text-bottom;
+  background: var(--terminal-cursor);
+}
+
+.ms-selection {
+  padding: 0 2px;
+  color: var(--text-primary);
+  background: var(--terminal-selection);
+  border-radius: var(--radius-xs);
+}
+
+/* System-tint row */
+
+.ms-system-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-2xs);
+  color: var(--text-secondary);
+  background: var(--wt-accent-system-tint-04);
+  border-left: 2px solid var(--color-accent);
+  border-radius: var(--radius-sm);
+}
+
+.ms-system-tag {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-accent-light);
+}
+
+.ms-link {
+  color: var(--color-accent-light);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.ms-link:hover { color: var(--color-accent); }
+
+/* Chat entry box */
+
+.ms-entry {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.ms-entry-field {
+  flex: 1;
+  min-width: 0;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+}
+
+/* Static stand-in for :focus-visible — the preview must show the ring without
+   the mock ever actually taking focus. */
+.ms-focus-ring {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--accent-tint-30);
+}
+
+.ms-btn {
+  flex: none;
+  padding: var(--space-2) var(--space-3);
+  font-family: inherit;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-none);
+  white-space: nowrap;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: color var(--duration-fast) ease, background-color var(--duration-fast) ease, border-color var(--duration-fast) ease;
+}
+
+.ms-btn-primary {
+  color: var(--color-on-accent);
+  background: var(--color-accent);
+  border: 1px solid var(--color-accent);
+}
+
+.ms-btn-primary:hover {
+  background: var(--color-accent-light);
+  border-color: var(--color-accent-light);
+}
+
+.ms-btn-ghost {
+  color: var(--color-accent-light);
+  background: var(--accent-tint-06);
+  border: 1px solid var(--border-accent);
+}
+
+.ms-btn-ghost:hover {
+  background: var(--accent-tint-12);
+  border-color: var(--color-accent);
+}
+
+/* Status bar */
+
+.ms-status {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-1) var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+  background: var(--bg-panel);
+  border-top: 1px solid var(--border-default);
+}
+
+.ms-status-item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.ms-status-item.is-accent { color: var(--color-accent-light); }
+
+.ms-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-full);
+  background: var(--color-accent);
+}

--- a/src/osprey/interfaces/design_system/static/js/theme-lab-ui.js
+++ b/src/osprey/interfaces/design_system/static/js/theme-lab-ui.js
@@ -1,0 +1,638 @@
+/**
+ * Theme lab -- DOM layer.
+ *
+ * The page's entry point. Everything here is impure by design: it reads the
+ * lab's markup, owns the mutable accent state, and writes custom properties
+ * onto the two scoped preview containers. All the math, the WCAG scoring, the
+ * slug rules and the export markdown live in `theme-lab.js`, which stays
+ * import-safe so the unit tests can exercise it without a document.
+ *
+ * The load-bearing property of this file: after boot, a color change never
+ * creates or replaces a node. The mini-shell is cloned once per scope, the
+ * badge and token rows are built once, and every subsequent update is a
+ * `setProperty` write or a `textContent` assignment. That is what makes the
+ * two previews re-skin live instead of flickering through a rebuild.
+ */
+
+import {
+  buildExportMarkdown,
+  checkCollision,
+  clamp,
+  deriveAccentVars,
+  evaluateGates,
+  hslCss,
+  hslToRgb,
+  parseColor,
+  rgbToHex,
+  rgbToHsl,
+  rgbaCss,
+  slugifyThemeName,
+} from './theme-lab.js';
+
+/** @typedef {import('./theme-lab.js').Rgb} Rgb */
+/** @typedef {import('./theme-lab.js').Hsl} Hsl */
+/** @typedef {import('./theme-lab.js').ThemeMode} ThemeMode */
+/** @typedef {import('./theme-lab.js').LabState} LabState */
+/** @typedef {import('./theme-lab.js').ScopeColors} ScopeColors */
+/** @typedef {import('./theme-lab.js').GateResult} GateResult */
+/** @typedef {import('./theme-lab.js').ThemeManifest} ThemeManifest */
+/** @typedef {import('./theme-lab.js').ModeExport} ModeExport */
+/** @typedef {import('./theme-lab.js').CollisionResult} CollisionResult */
+
+/* The shipped theme registry, read from the generated module rather than
+   transcribed: a hand-written id list here would drift the day a theme is
+   added. Declared with the layer that consumes it -- ES module imports hoist,
+   so the position is presentational, and the pure half above stays free of
+   dependencies. */
+import { THEMES, DEFAULTS, DEFAULT_FAMILY } from './tokens.js';
+
+/** The two scopes the page renders, in DOM order. */
+const MODES = /** @type {ReadonlyArray<ThemeMode>} */ (['dark', 'light']);
+
+/**
+ * Every shipped theme id and family name, for {@link checkCollision}.
+ *
+ * @type {ThemeManifest}
+ */
+const MANIFEST = {
+  ids: THEMES.map((theme) => theme.id),
+  families: [...new Set([DEFAULT_FAMILY, ...Object.keys(DEFAULTS), ...THEMES.map((t) => t.family)])],
+};
+
+/**
+ * How far the emphasis variant (`--color-accent-light`) sits from its mode's
+ * base lightness. Positive in dark mode, negative in light: "light" is the
+ * token's name for *emphasis*, and emphasis reads as brighter on a dark
+ * surface and deeper on a pale one. The lab has no emphasis control of its
+ * own, so this pair is the whole rule.
+ *
+ * @type {Record<ThemeMode, number>}
+ */
+const EMPHASIS_DELTA = { dark: 16, light: -8 };
+
+/**
+ * How far light mode's base accent starts below dark mode's when a single
+ * color is chosen for both (a preset, or a typed hex). A pale background
+ * needs a deeper accent to clear the same contrast gate. It is only a
+ * starting point: each mode's slider moves independently afterwards.
+ */
+const LIGHT_MODE_DELTA = -10;
+
+/** Lightness the hue/saturation disc is painted at -- a fixed reference. */
+const WHEEL_LIGHTNESS = 50;
+
+/** Radius, in canvas pixels, of the disc's current-selection marker. */
+const MARKER_RADIUS = 6;
+
+/** Margin above a gate's threshold within which a pass is still flagged. */
+const WARN_MARGIN = 0.5;
+
+/** @typedef {{label: string, hsl: [number, number, number]}} Preset */
+
+/**
+ * Accent starting points, as numeric `[hue, saturation, lightness]` triples --
+ * never color strings, so this file needs no second hygiene allowance. The
+ * lightness is dark mode's; light mode starts {@link LIGHT_MODE_DELTA} below
+ * it. All five clear both gates in both modes as shipped.
+ *
+ * @type {ReadonlyArray<Preset>}
+ */
+const PRESETS = [
+  { label: 'Teal', hsl: [178, 60, 41] },
+  { label: 'Amber', hsl: [45, 70, 50] },
+  { label: 'Indigo', hsl: [232, 60, 55] },
+  { label: 'Rose', hsl: [345, 60, 46] },
+  { label: 'Slate', hsl: [210, 20, 55] },
+];
+
+/**
+ * The lab's single mutable store. Every control writes here through
+ * {@link setHueSaturation}/{@link setAccent}/{@link setModeLightness}, and
+ * every readout is recomputed from it -- there is no second source of truth.
+ *
+ * @type {LabState}
+ */
+const state = {
+  dark: { hue: 0, saturation: 0, lightness: 0, emphasisLightness: 0 },
+  light: { hue: 0, saturation: 0, lightness: 0, emphasisLightness: 0 },
+};
+
+/**
+ * Set one mode's base lightness, re-deriving its emphasis variant.
+ *
+ * @param {ThemeMode} mode
+ * @param {number} lightness
+ */
+function setModeLightness(mode, lightness) {
+  const base = clamp(lightness, 0, 100);
+  state[mode] = {
+    ...state[mode],
+    lightness: base,
+    emphasisLightness: clamp(base + EMPHASIS_DELTA[mode], 0, 100),
+  };
+}
+
+/**
+ * Set the hue and saturation both modes share, leaving each mode's lightness
+ * alone -- dragging the wheel must not undo a slider the author has tuned.
+ *
+ * @param {number} hue
+ * @param {number} saturation
+ */
+function setHueSaturation(hue, saturation) {
+  for (const mode of MODES) {
+    state[mode] = { ...state[mode], hue: (hue + 360) % 360, saturation: clamp(saturation, 0, 100) };
+  }
+}
+
+/**
+ * Set the whole accent from one color choice: shared hue/saturation, dark
+ * mode at `lightness`, light mode {@link LIGHT_MODE_DELTA} below it.
+ *
+ * @param {number} hue
+ * @param {number} saturation
+ * @param {number} lightness dark mode's base lightness.
+ */
+function setAccent(hue, saturation, lightness) {
+  setHueSaturation(hue, saturation);
+  setModeLightness('dark', lightness);
+  setModeLightness('light', lightness + LIGHT_MODE_DELTA);
+}
+
+/** The current accent as a hex color -- dark mode's, the mode this page runs in. */
+function accentHex() {
+  return rgbToHex(hslToRgb({ h: state.dark.hue, s: state.dark.saturation, l: state.dark.lightness }));
+}
+
+/* --- DOM helpers --------------------------------------------------------- */
+
+/**
+ * Look up a required element by id, narrowed to a concrete element type.
+ *
+ * @template {Element} T
+ * @param {string} id
+ * @param {new () => T} ctor
+ * @returns {T}
+ */
+function requireElement(id, ctor) {
+  const node = document.getElementById(id);
+  if (!(node instanceof ctor)) {
+    throw new Error(`theme lab: element "${id}" is missing or not a ${ctor.name}`);
+  }
+  return node;
+}
+
+/**
+ * Create an element with a class and, optionally, text content.
+ *
+ * @param {string} tag
+ * @param {string} className
+ * @param {string} [text]
+ * @returns {HTMLElement}
+ */
+function make(tag, className, text) {
+  const node = document.createElement(tag);
+  if (className !== '') node.className = className;
+  if (text !== undefined) node.textContent = text;
+  return node;
+}
+
+/**
+ * Read a scope's own background and primary text, which `tokens.css` gives it
+ * through its `data-theme` attribute. Read once at init and cached: they are
+ * inputs to the derivation, never outputs of it.
+ *
+ * @param {HTMLElement} element
+ * @returns {ScopeColors}
+ */
+function readScopeColors(element) {
+  const styles = getComputedStyle(element);
+  return {
+    bgPrimary: styles.getPropertyValue('--bg-primary').trim(),
+    textPrimary: styles.getPropertyValue('--text-primary').trim(),
+  };
+}
+
+/* --- Hue / saturation disc ----------------------------------------------- */
+
+/**
+ * Paint the hue/saturation disc into a reusable buffer: angle is hue, radius
+ * is saturation, lightness fixed at {@link WHEEL_LIGHTNESS}. Pixels outside
+ * the disc stay transparent, so the canvas's own background shows through.
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {number} size canvas width and height, in pixels.
+ * @returns {ImageData}
+ */
+function paintWheel(ctx, size) {
+  const image = ctx.createImageData(size, size);
+  const centre = size / 2;
+  for (let y = 0; y < size; y += 1) {
+    for (let x = 0; x < size; x += 1) {
+      const dx = x - centre + 0.5;
+      const dy = y - centre + 0.5;
+      const distance = Math.sqrt(dx * dx + dy * dy) / centre;
+      if (distance > 1) continue;
+      const rgb = hslToRgb({
+        h: (Math.atan2(dy, dx) * 180) / Math.PI,
+        s: distance * 100,
+        l: WHEEL_LIGHTNESS,
+      });
+      const offset = (y * size + x) * 4;
+      image.data[offset] = rgb.r;
+      image.data[offset + 1] = rgb.g;
+      image.data[offset + 2] = rgb.b;
+      image.data[offset + 3] = 255;
+    }
+  }
+  return image;
+}
+
+/**
+ * Blit the disc and ring the current selection. The marker is drawn as a pale
+ * circle inside a dark one so it stays visible over every hue.
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {ImageData} image
+ * @param {number} hue
+ * @param {number} saturation
+ */
+function drawWheel(ctx, image, hue, saturation) {
+  ctx.putImageData(image, 0, 0);
+  const centre = image.width / 2;
+  const angle = (hue * Math.PI) / 180;
+  const distance = (clamp(saturation, 0, 100) / 100) * centre;
+  const x = centre + Math.cos(angle) * distance;
+  const y = centre + Math.sin(angle) * distance;
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = rgbaCss({ r: 0, g: 0, b: 0 }, 0.6);
+  ctx.beginPath();
+  ctx.arc(x, y, MARKER_RADIUS + 1, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.strokeStyle = hslCss({ h: 0, s: 0, l: 100 });
+  ctx.beginPath();
+  ctx.arc(x, y, MARKER_RADIUS, 0, Math.PI * 2);
+  ctx.stroke();
+}
+
+/**
+ * Convert a pointer position over the disc into a hue/saturation pair,
+ * clamping to the rim so a drag that leaves the canvas still tracks.
+ *
+ * @param {HTMLCanvasElement} canvas
+ * @param {PointerEvent} event
+ * @returns {{hue: number, saturation: number}}
+ */
+function pointerToHueSaturation(canvas, event) {
+  const rect = canvas.getBoundingClientRect();
+  const radius = rect.width / 2;
+  const dx = event.clientX - rect.left - radius;
+  const dy = event.clientY - rect.top - rect.height / 2;
+  return {
+    hue: (Math.atan2(dy, dx) * 180) / Math.PI,
+    saturation: (Math.sqrt(dx * dx + dy * dy) / radius) * 100,
+  };
+}
+
+/* --- Readouts ------------------------------------------------------------ */
+
+/**
+ * Build one scope's gate rows once. Only the badges change afterwards, so
+ * only they are returned.
+ *
+ * @param {HTMLElement} container
+ * @param {GateResult[]} results
+ * @returns {HTMLElement[]} badge nodes, in gate order.
+ */
+function buildGates(container, results) {
+  return results.map((gate) => {
+    const row = make('div', 'lab-gate');
+    const badge = make('span', 'lab-gate-badge');
+    row.append(make('span', 'lab-gate-label', gate.name), badge);
+    container.append(row);
+    return badge;
+  });
+}
+
+/**
+ * Restate each gate as `PASS`/`FAIL` plus its ratio. A pass within
+ * {@link WARN_MARGIN} of its threshold is styled as a warning: it clears the
+ * build-time gate, but only just.
+ *
+ * @param {HTMLElement[]} badges
+ * @param {GateResult[]} results
+ */
+function updateGates(badges, results) {
+  results.forEach((gate, index) => {
+    const badge = badges[index];
+    const tight = gate.pass && gate.ratio < gate.threshold + WARN_MARGIN;
+    badge.textContent = `${gate.pass ? 'PASS' : 'FAIL'} ${gate.ratio.toFixed(2)}`;
+    badge.title = `needs ${gate.threshold.toFixed(1)}:1`;
+    badge.classList.toggle('is-pass', gate.pass && !tight);
+    badge.classList.toggle('is-warn', tight);
+    badge.classList.toggle('is-fail', !gate.pass);
+  });
+}
+
+/** @typedef {{swatch: HTMLElement, value: HTMLElement}} TokenRow */
+
+/**
+ * Build one scope's derived-token table once, one row per property name.
+ *
+ * @param {HTMLElement} container
+ * @param {Record<string, string>} vars
+ * @returns {Map<string, TokenRow>} the cells each name writes into.
+ */
+function buildTokens(container, vars) {
+  const table = make('table', 'lab-token-table');
+  const body = make('tbody', '');
+  const header = make('tr', '');
+  for (const title of ['', 'Token', 'Value']) header.append(make('th', '', title));
+  body.append(header);
+
+  /** @type {Map<string, TokenRow>} */
+  const rows = new Map();
+  for (const name of Object.keys(vars)) {
+    const row = make('tr', '');
+    const swatchCell = make('td', '');
+    const swatch = make('span', 'lab-token-swatch');
+    const value = make('td', '');
+    swatchCell.append(swatch);
+    row.append(swatchCell, make('td', 'lab-token-name', name), value);
+    body.append(row);
+    rows.set(name, { swatch, value });
+  }
+  table.append(body);
+  container.append(table);
+  return rows;
+}
+
+/**
+ * Restate every derived value. Cells are written in place -- the table is
+ * built once and never rebuilt, so a color change costs text and style
+ * writes only.
+ *
+ * @param {Map<string, TokenRow>} rows
+ * @param {Record<string, string>} vars
+ */
+function updateTokens(rows, vars) {
+  for (const [name, cells] of rows) {
+    const value = vars[name] ?? '';
+    cells.swatch.style.background = value;
+    cells.value.textContent = value;
+  }
+}
+
+/* --- Page wiring --------------------------------------------------------- */
+
+/**
+ * One preview scope: its themed container, the colors that container supplies,
+ * its lightness control, and the readout nodes it writes into.
+ *
+ * @typedef {{
+ *   mode: ThemeMode,
+ *   panel: HTMLElement,
+ *   colors: ScopeColors,
+ *   slider: HTMLInputElement,
+ *   sliderValue: HTMLElement,
+ *   badges: HTMLElement[],
+ *   tokens: Map<string, TokenRow>,
+ * }} Scope
+ */
+
+/**
+ * Wire the lab page. Everything the DOM needs is created here, once; every
+ * later interaction only writes custom properties and text.
+ *
+ * The drawing context is a parameter rather than something acquired here: it
+ * is captured by the nested `render`, and a locally narrowed `const` does not
+ * carry its non-nullness into a hoisted closure.
+ *
+ * @param {HTMLCanvasElement} wheel the hue/saturation canvas.
+ * @param {CanvasRenderingContext2D} context that canvas's 2d context.
+ */
+function initLab(wheel, context) {
+  const template = requireElement('mini-shell', HTMLTemplateElement);
+  const hexInput = requireElement('hex-input', HTMLInputElement);
+  const hexSwatch = requireElement('hex-swatch', HTMLElement);
+  const presetRow = requireElement('preset-row', HTMLElement);
+  const nameInput = requireElement('theme-name', HTMLInputElement);
+  const slugWarning = requireElement('slug-warning', HTMLElement);
+  const exportText = requireElement('export-text', HTMLElement);
+  const copyButton = requireElement('copy-export', HTMLButtonElement);
+
+  const first = PRESETS[0];
+  setAccent(first.hsl[0], first.hsl[1], first.hsl[2]);
+
+  /** @type {Scope[]} */
+  const scopes = MODES.map((mode) => {
+    const mount = requireElement(`preview-${mode}`, HTMLElement);
+    const panel = mount.closest('[data-theme]');
+    if (!(panel instanceof HTMLElement)) {
+      throw new Error(`theme lab: preview "${mode}" is not inside a themed scope`);
+    }
+    mount.append(template.content.cloneNode(true));
+    const colors = readScopeColors(mount);
+    const vars = deriveAccentVars(state, mode, colors);
+    return {
+      mode,
+      panel,
+      colors,
+      slider: requireElement(`lightness-${mode}`, HTMLInputElement),
+      sliderValue: requireElement(`lightness-${mode}-value`, HTMLElement),
+      badges: buildGates(requireElement(`gates-${mode}`, HTMLElement), evaluateGates(vars, colors)),
+      tokens: buildTokens(requireElement(`tokens-${mode}`, HTMLElement), vars),
+    };
+  });
+
+  /* Presets are static, so each button -- and its swatch -- is built once.
+     The click handler is delegated off the row and finds its payload through
+     this map, keyed by the node the `data-preset` hook matched. */
+  /** @type {Map<Element, Preset>} */
+  const presetByNode = new Map();
+  PRESETS.forEach((preset, index) => {
+    const button = make('button', 'lab-preset');
+    button.setAttribute('type', 'button');
+    button.dataset.preset = String(index);
+    const swatch = make('span', 'lab-preset-swatch');
+    swatch.style.background = hslCss({ h: preset.hsl[0], s: preset.hsl[1], l: preset.hsl[2] });
+    button.append(swatch, document.createTextNode(preset.label));
+    presetRow.append(button);
+    presetByNode.set(button, preset);
+  });
+
+  /**
+   * Recompute every derived value from {@link state} and write it out.
+   *
+   * No node is created or replaced here: each scope gets custom-property
+   * writes, and the readouts get text. That is what makes the two previews
+   * re-skin live rather than flicker through a rebuild.
+   */
+  function render() {
+    /** @type {Partial<Record<ThemeMode, ModeExport>>} */
+    const perMode = {};
+
+    for (const scope of scopes) {
+      const vars = deriveAccentVars(state, scope.mode, scope.colors);
+      for (const [name, value] of Object.entries(vars)) {
+        scope.panel.style.setProperty(name, value);
+        // Dark is also the document's own theme, so the lab's chrome (buttons,
+        // focus rings, preset pills) follows the accent being designed.
+        if (scope.mode === 'dark') document.documentElement.style.setProperty(name, value);
+      }
+      const gates = evaluateGates(vars, scope.colors);
+      perMode[scope.mode] = { derived: vars, gates };
+      updateGates(scope.badges, gates);
+      updateTokens(scope.tokens, vars);
+      const lightness = Math.round(state[scope.mode].lightness);
+      scope.slider.value = String(lightness);
+      scope.sliderValue.textContent = `${lightness}%`;
+    }
+
+    const hex = accentHex();
+    hexSwatch.style.background = hex;
+    if (document.activeElement !== hexInput) {
+      hexInput.value = hex;
+      hexInput.classList.remove('is-invalid');
+    }
+    for (const [node, preset] of presetByNode) {
+      const matches =
+        Math.round(state.dark.hue) === preset.hsl[0] &&
+        Math.round(state.dark.saturation) === preset.hsl[1] &&
+        Math.round(state.dark.lightness) === preset.hsl[2];
+      node.classList.toggle('is-active', matches);
+    }
+    drawWheel(context, wheelImage, state.dark.hue, state.dark.saturation);
+
+    // The name field feeds two readouts -- the inline warning and the export
+    // heading -- so it is resolved here rather than in its own listener, and
+    // both stay consistent with whatever was last typed.
+    const typed = nameInput.value.trim();
+    const slug = slugifyThemeName(typed);
+    const collision = checkCollision(slug, MANIFEST);
+    if (typed === '') {
+      slugWarning.textContent = '';
+      slugWarning.className = 'lab-warning';
+    } else {
+      // textContent, never markup: the reason quotes what the author typed.
+      slugWarning.textContent = collision.collides ? collision.reason : `${slug} — available`;
+      slugWarning.className = `lab-warning ${collision.collides ? 'is-error' : 'is-ok'}`;
+    }
+
+    const dark = perMode.dark;
+    const light = perMode.light;
+    if (dark !== undefined && light !== undefined) {
+      exportText.textContent = buildExportMarkdown({
+        label: typed,
+        // An unnamed proposal still exports something implementable; the
+        // placeholder is obvious enough that nobody ships it by accident.
+        slug: slug === '' ? 'my-theme' : slug,
+        collision,
+        dark,
+        light,
+      });
+    }
+  }
+
+  const wheelImage = paintWheel(context, wheel.width);
+
+  // The disc is a control, so it takes focus and answers the arrow keys; the
+  // markup declares only its label, the interaction model belongs here.
+  wheel.tabIndex = 0;
+
+  /** @param {PointerEvent} event */
+  const trackPointer = (event) => {
+    const picked = pointerToHueSaturation(wheel, event);
+    setHueSaturation(picked.hue, picked.saturation);
+    render();
+  };
+  wheel.addEventListener('pointerdown', (event) => {
+    wheel.setPointerCapture(event.pointerId);
+    trackPointer(event);
+  });
+  wheel.addEventListener('pointermove', (event) => {
+    if (wheel.hasPointerCapture(event.pointerId)) trackPointer(event);
+  });
+  wheel.addEventListener('pointerup', (event) => wheel.releasePointerCapture(event.pointerId));
+  wheel.addEventListener('keydown', (event) => {
+    const step = event.shiftKey ? 10 : 2;
+    /** @type {Record<string, [number, number] | undefined>} */
+    const moves = {
+      ArrowLeft: [-step, 0],
+      ArrowRight: [step, 0],
+      ArrowUp: [0, step],
+      ArrowDown: [0, -step],
+    };
+    const move = moves[event.key];
+    if (move === undefined) return;
+    event.preventDefault();
+    setHueSaturation(state.dark.hue + move[0], state.dark.saturation + move[1]);
+    render();
+  });
+
+  for (const scope of scopes) {
+    scope.slider.addEventListener('input', () => {
+      setModeLightness(scope.mode, Number(scope.slider.value));
+      render();
+    });
+  }
+
+  hexInput.addEventListener('input', () => {
+    const rgb = parseColor(hexInput.value);
+    // Half-typed input is flagged, not acted on; the field reverts on commit.
+    hexInput.classList.toggle('is-invalid', rgb === null);
+    if (rgb === null) return;
+    const hsl = rgbToHsl(rgb);
+    setAccent(hsl.h, hsl.s, hsl.l);
+    render();
+  });
+  const revertHex = () => {
+    hexInput.classList.remove('is-invalid');
+    hexInput.value = accentHex();
+  };
+  hexInput.addEventListener('change', revertHex);
+  hexInput.addEventListener('blur', revertHex);
+
+  presetRow.addEventListener('click', (event) => {
+    const node = event.target instanceof Element ? event.target.closest('[data-preset]') : null;
+    const preset = node === null ? undefined : presetByNode.get(node);
+    if (preset === undefined) return;
+    setAccent(preset.hsl[0], preset.hsl[1], preset.hsl[2]);
+    render();
+  });
+
+  nameInput.addEventListener('input', () => render());
+
+  copyButton.addEventListener('click', () => {
+    // The <pre> is populated and selectable at all times, so a clipboard
+    // denial (insecure origin, refused permission) costs the author a manual
+    // select rather than the export itself.
+    const clipboard = navigator.clipboard;
+    if (clipboard === undefined) {
+      copyButton.textContent = 'Select and copy';
+      return;
+    }
+    clipboard.writeText(exportText.textContent ?? '').then(
+      () => {
+        copyButton.textContent = 'Copied';
+        window.setTimeout(() => {
+          copyButton.textContent = 'Copy';
+        }, 1200);
+      },
+      () => {
+        copyButton.textContent = 'Select and copy';
+      }
+    );
+  });
+
+  render();
+}
+
+/* The page's only side effect. This module is loaded from <head> with `type=
+   "module"`, so the document is parsed by the time it runs; the guard keeps
+   the module importable (a canvas-less environment simply gets no lab). */
+const wheelCanvas = document.getElementById('hue-wheel');
+if (wheelCanvas instanceof HTMLCanvasElement) {
+  const wheelContext = wheelCanvas.getContext('2d');
+  if (wheelContext !== null) initLab(wheelCanvas, wheelContext);
+}

--- a/src/osprey/interfaces/design_system/static/js/theme-lab.js
+++ b/src/osprey/interfaces/design_system/static/js/theme-lab.js
@@ -24,15 +24,33 @@
  *                              above the base lightness, in light mode below
  *                              it. The direction is never assumed -- it comes
  *                              from that mode's own emphasis-lightness input.
+ *                              NOTE this is a deliberate simplification: the
+ *                              lab moves lightness only, so it cannot
+ *                              reproduce a hand-authored emphasis color that
+ *                              also shifts hue or saturation. The shipped
+ *                              osprey dark pair does exactly that -- its base
+ *                              sits near hue 179 at 51% saturation while its
+ *                              emphasis sits near hue 175 at 59% -- so the lab
+ *                              cannot round-trip it. A lab proposal is
+ *                              internally consistent, not a re-derivation of
+ *                              an existing theme; the export carries the
+ *                              explicit values either way.
  *   --border-accent            emphasis variant at alpha 0.15 (dark) / 0.25 (light)
  *   --accent-tint-NN           emphasis variant at alpha NN/100, for the eight
  *                              levels 04 06 08 10 12 20 25 30
  *   --wt-accent-system-tint-04 accent BASE at alpha 0.04 (not the emphasis
  *                              variant -- the one member of the family that
  *                              tints from the base)
- *   --color-on-accent          whichever of the target scope's own bg.primary /
- *                              text.primary has the higher WCAG contrast
- *                              against the chosen accent
+ *   --color-on-accent          the LAB'S OWN rule, not one read off tokens.css:
+ *                              whichever of the scope's bg.primary /
+ *                              text.primary / black / white has the highest
+ *                              WCAG contrast against the chosen accent. Every
+ *                              shipped theme hand-picks this value (only `dark`
+ *                              happens to use its own bg.primary), so there is
+ *                              no convention to mirror -- what the lab
+ *                              guarantees is that it clears the gate whenever
+ *                              any candidate can, and that the value it scores
+ *                              is the value it exports.
  *
  * `--ansi-cursor-accent` is deliberately NOT derived here: despite the name it
  * is a near-background color, not a member of the accent family.
@@ -75,14 +93,20 @@
 /** @typedef {{name: string, ratio: number, threshold: number, pass: boolean}} GateResult */
 /** @typedef {{collides: boolean, reason: string | null}} CollisionResult */
 
-/** Alpha levels, as hundredths, of the `--accent-tint-NN` scale. */
-const TINT_LEVELS = [4, 6, 8, 10, 12, 20, 25, 30];
+/**
+ * Alpha levels, as hundredths, of the `--accent-tint-NN` scale.
+ *
+ * Exported so the coverage spec can hold these constants against the committed
+ * `tokens.css` rather than re-deriving them with the same helpers (which would
+ * make the assertion tautological).
+ */
+export const TINT_LEVELS = [4, 6, 8, 10, 12, 20, 25, 30];
 
 /** `--border-accent` alpha, per mode. */
-const BORDER_ALPHA = { dark: 0.15, light: 0.25 };
+export const BORDER_ALPHA = { dark: 0.15, light: 0.25 };
 
 /** `--wt-accent-system-tint-04` alpha. */
-const SYSTEM_TINT_ALPHA = 0.04;
+export const SYSTEM_TINT_ALPHA = 0.04;
 
 const HEX_PATTERN = /^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
 const LEGACY_RGB_PATTERN =
@@ -287,24 +311,63 @@ export function rgbaCss(rgb, alpha) {
 /* hygiene-allow-color-end */
 
 /**
- * Pick `--color-on-accent`: whichever of the target scope's own background or
- * primary text reads best on the accent fill.
+ * Pure black and white, always available as `--color-on-accent` candidates.
  *
- * Returns the scope's string verbatim rather than a re-serialization, so a
- * value read off a live computed style survives untouched.
+ * Nothing in the design system requires `accent.on` to be one of the scope's
+ * own colors, and the shipped themes prove it: of the six, only `dark` uses
+ * its own `bg.primary`. `light` and both `apex` themes reuse dark's near-black
+ * ink, `high-contrast-dark` ships pure black and `high-contrast-light` pure
+ * white -- none of which is that scope's own background or primary text.
+ * Offering only the two scope colors would make the lab reject accents that
+ * ship fine: a mid grey reaches 4.22:1 against both of dark's primaries (a
+ * FAIL) but 4.62:1 against black (a PASS).
+ *
+ * Built from numeric channels rather than written as hex literals, so this
+ * file keeps its single hygiene exemption (the two serializers above).
+ *
+ * @type {ReadonlyArray<string>}
+ */
+const NEUTRAL_ON_ACCENT_CANDIDATES = [
+  rgbToHex({ r: 0, g: 0, b: 0 }),
+  rgbToHex({ r: 255, g: 255, b: 255 }),
+];
+
+/**
+ * Pick `--color-on-accent`: whichever candidate reads best on the accent fill.
+ *
+ * This is the LAB'S OWN selection rule, not a rule read off `tokens.css` --
+ * every shipped theme hand-picks this value. What the lab guarantees is only
+ * that its choice clears the gate whenever any of its candidates can, and that
+ * the value it scores is the value it exports.
+ *
+ * Scope colors are returned verbatim rather than re-serialized, so a value read
+ * off a live computed style survives untouched.
  *
  * @param {Rgb} accent
  * @param {ScopeColors} scopeColors
  * @returns {string}
  */
 function pickOnAccent(accent, scopeColors) {
-  const background = parseColor(scopeColors.bgPrimary);
-  const text = parseColor(scopeColors.textPrimary);
-  if (background === null) return scopeColors.textPrimary;
-  if (text === null) return scopeColors.bgPrimary;
-  return contrastRatio(accent, background) >= contrastRatio(accent, text)
-    ? scopeColors.bgPrimary
-    : scopeColors.textPrimary;
+  /** @type {string[]} */
+  const candidates = [scopeColors.bgPrimary, scopeColors.textPrimary].filter(
+    (value) => parseColor(value) !== null
+  );
+  candidates.push(...NEUTRAL_ON_ACCENT_CANDIDATES);
+
+  let best = candidates[0];
+  let bestRatio = -1;
+  for (const candidate of candidates) {
+    const rgb = parseColor(candidate);
+    if (rgb === null) continue;
+    const ratio = contrastRatio(accent, rgb);
+    // Strictly greater, so an earlier candidate wins a tie -- the scope's own
+    // colors are listed first and are the more idiomatic choice.
+    if (ratio > bestRatio) {
+      bestRatio = ratio;
+      best = candidate;
+    }
+  }
+  return best;
 }
 
 /**
@@ -613,9 +676,17 @@ export function buildExportMarkdown(input) {
   lines.push(
     `2. **\`tokens/themes/${slug}-dark.json\`** and **\`tokens/themes/${slug}-light.json\`** —`
   );
-  lines.push('   copy the same-mode sibling (`themes/dark.json` / `themes/light.json`) and');
-  lines.push('   replace `accent.base`, `accent.light`, `accent.on`, `border.accent` and');
-  lines.push('   the eight `tint.accent.*` entries with the values tabled above. Set');
+  lines.push('   copy the same-mode sibling (`themes/dark.json` / `themes/light.json`), then');
+  lines.push('   mind the two different authoring styles it uses:');
+  lines.push('');
+  lines.push('   - `accent.base`, `accent.light` and `accent.on` are **references** into');
+  lines.push('     `core.json` (`{color.teal.300}`), not literals. Point them at the ramp');
+  lines.push('     steps added in step 1 — do not paste the hex from the table here, or the');
+  lines.push('     step-1 additions are left dead and the one-hop convention is broken.');
+  lines.push('   - `border.accent` and the eight `tint.accent.*` entries are **literal**');
+  lines.push('     alpha-composite colors. Paste those from the table exactly as tabled.');
+  lines.push('');
+  lines.push('   Then set');
   lines.push(
     `   \`$extensions\` to \`{"mode": "dark"|"light", "id": "${slug}-dark"|"${slug}-light",`
   );
@@ -632,7 +703,8 @@ export function buildExportMarkdown(input) {
   lines.push(`   "${slug}-light": "light"`);
   lines.push('   ```');
   lines.push('');
-  lines.push('   This is what `apex` and `high-contrast` already do. Note the');
+  lines.push('   This is what `apex` already does in all five, and `high-contrast` in');
+  lines.push('   four of them (`ariel.json` authors its own high-contrast groups). Note the');
   lines.push('   consequence: `wt-accent-system-tint-04` is authored in');
   lines.push('   `web_terminal.json`, so inheriting keeps the default value rather than');
   lines.push('   the accent-matched one below. Author a full `web_terminal.json` group');

--- a/src/osprey/interfaces/design_system/static/js/theme-lab.js
+++ b/src/osprey/interfaces/design_system/static/js/theme-lab.js
@@ -1,0 +1,659 @@
+/**
+ * Theme lab -- pure color math, accent-token derivation, and export spec.
+ *
+ * The DOM half lives in `theme-lab-ui.js`, which is what the page loads;
+ * this module is import-safe and is what the unit tests exercise directly.
+ *
+ * This half of the module is deliberately side-effect free: no `window`, no
+ * `document`, no module-level mutable state. It answers three questions the
+ * lab's UI asks continuously:
+ *
+ *   1. What are the accent-family custom properties for a given accent choice?
+ *      (`deriveAccentVars`)
+ *   2. Do those choices clear the design system's WCAG gates?
+ *      (`relativeLuminance`, `contrastRatio`, `evaluateGates`)
+ *   3. Is the name the author typed usable, or does it collide with a shipped
+ *      theme? (`slugifyThemeName`, `checkCollision`)
+ *
+ * DERIVATION RULES (read off the generated `static/css/tokens.css`, which is
+ * the authority -- the default `osprey` family is the shape proposers riff on):
+ *
+ *   --color-accent             the chosen accent for that mode
+ *   --color-accent-light       the mode's *emphasis* variant. "light" means
+ *                              emphasis, not luminance: in dark mode it sits
+ *                              above the base lightness, in light mode below
+ *                              it. The direction is never assumed -- it comes
+ *                              from that mode's own emphasis-lightness input.
+ *   --border-accent            emphasis variant at alpha 0.15 (dark) / 0.25 (light)
+ *   --accent-tint-NN           emphasis variant at alpha NN/100, for the eight
+ *                              levels 04 06 08 10 12 20 25 30
+ *   --wt-accent-system-tint-04 accent BASE at alpha 0.04 (not the emphasis
+ *                              variant -- the one member of the family that
+ *                              tints from the base)
+ *   --color-on-accent          whichever of the target scope's own bg.primary /
+ *                              text.primary has the higher WCAG contrast
+ *                              against the chosen accent
+ *
+ * `--ansi-cursor-accent` is deliberately NOT derived here: despite the name it
+ * is a near-background color, not a member of the accent family.
+ *
+ * The WCAG luminance and contrast math mirrors
+ * `generator/validate.py`'s `relative_luminance`/`contrast_ratio` bit for bit,
+ * and `GATES` mirrors the two accent entries of its `WCAG_GATES` (the AA tuple
+ * applied to the default family), so the lab's badges and the build-time
+ * validator can never disagree.
+ */
+
+
+/** @typedef {{r: number, g: number, b: number}} Rgb */
+/** @typedef {{h: number, s: number, l: number}} Hsl  hue in degrees, s/l in percent */
+/** @typedef {'dark' | 'light'} ThemeMode */
+
+/**
+ * One mode's accent controls. `lightness` drives the base accent;
+ * `emphasisLightness` drives the emphasis variant (`--color-accent-light`).
+ * Both share the mode's hue and saturation.
+ *
+ * @typedef {{
+ *   hue: number,
+ *   saturation: number,
+ *   lightness: number,
+ *   emphasisLightness: number,
+ * }} ModeAccent
+ */
+
+/** @typedef {Record<ThemeMode, ModeAccent>} LabState */
+
+/**
+ * The two colors a derivation target scope supplies about itself. Values may
+ * be hex or legacy comma rgb/rgba (what `getComputedStyle` hands back).
+ *
+ * @typedef {{bgPrimary: string, textPrimary: string}} ScopeColors
+ */
+
+/** @typedef {{ids: string[], families: string[]}} ThemeManifest */
+/** @typedef {{name: string, ratio: number, threshold: number, pass: boolean}} GateResult */
+/** @typedef {{collides: boolean, reason: string | null}} CollisionResult */
+
+/** Alpha levels, as hundredths, of the `--accent-tint-NN` scale. */
+const TINT_LEVELS = [4, 6, 8, 10, 12, 20, 25, 30];
+
+/** `--border-accent` alpha, per mode. */
+const BORDER_ALPHA = { dark: 0.15, light: 0.25 };
+
+/** `--wt-accent-system-tint-04` alpha. */
+const SYSTEM_TINT_ALPHA = 0.04;
+
+const HEX_PATTERN = /^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+const LEGACY_RGB_PATTERN =
+  /^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*(?:,\s*[\d.]+\s*)?\)$/i;
+
+/**
+ * Clamp `value` into `[low, high]`.
+ *
+ * Exported for the UI layer, which clamps slider and pointer input to the
+ * same bounds this module's conversions assume.
+ *
+ * @param {number} value
+ * @param {number} low
+ * @param {number} high
+ * @returns {number}
+ */
+export function clamp(value, low, high) {
+  return Math.min(high, Math.max(low, value));
+}
+
+/**
+ * Parse a hex color into 8-bit channels. Accepts 3-, 4-, 6- and 8-digit forms;
+ * any alpha digits are parsed and discarded (every consumer here pairs opaque
+ * colors, exactly as the validator does).
+ *
+ * @param {string} value
+ * @returns {Rgb | null} `null` if `value` is not a hex color.
+ */
+export function hexToRgb(value) {
+  const match = HEX_PATTERN.exec(String(value).trim());
+  if (match === null) return null;
+  const digits = match[1];
+  const pairs =
+    digits.length <= 4 ? Array.from(digits, (digit) => digit + digit) : (digits.match(/../g) ?? []);
+  return {
+    r: parseInt(pairs[0], 16),
+    g: parseInt(pairs[1], 16),
+    b: parseInt(pairs[2], 16),
+  };
+}
+
+/**
+ * Parse any color spelling this design system permits -- hex, or legacy comma
+ * rgb/rgba -- into 8-bit channels. The legacy form is what
+ * `getComputedStyle` returns, so scope colors read off a live element land
+ * here rather than in {@link hexToRgb}.
+ *
+ * @param {string} value
+ * @returns {Rgb | null} `null` if `value` is neither spelling.
+ */
+export function parseColor(value) {
+  const text = String(value).trim();
+  const hex = hexToRgb(text);
+  if (hex !== null) return hex;
+  const match = LEGACY_RGB_PATTERN.exec(text);
+  if (match === null) return null;
+  const channels = [match[1], match[2], match[3]].map((part) => Number(part));
+  if (channels.some((channel) => channel > 255)) return null;
+  return { r: channels[0], g: channels[1], b: channels[2] };
+}
+
+/**
+ * Serialize 8-bit channels as a 6-digit lowercase hex color.
+ *
+ * @param {Rgb} rgb
+ * @returns {string}
+ */
+export function rgbToHex(rgb) {
+  /** @param {number} value @returns {string} */
+  const channel = (value) =>
+    Math.round(clamp(value, 0, 255))
+      .toString(16)
+      .padStart(2, '0');
+  return `#${channel(rgb.r)}${channel(rgb.g)}${channel(rgb.b)}`;
+}
+
+/**
+ * Convert 8-bit channels to hue/saturation/lightness.
+ *
+ * @param {Rgb} rgb
+ * @returns {Hsl} hue in `[0, 360)`, saturation and lightness in `[0, 100]`.
+ */
+export function rgbToHsl(rgb) {
+  const r = clamp(rgb.r, 0, 255) / 255;
+  const g = clamp(rgb.g, 0, 255) / 255;
+  const b = clamp(rgb.b, 0, 255) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const delta = max - min;
+  const l = (max + min) / 2;
+
+  if (delta === 0) return { h: 0, s: 0, l: l * 100 };
+
+  const s = delta / (1 - Math.abs(2 * l - 1));
+  let h;
+  if (max === r) {
+    h = 60 * (((g - b) / delta) % 6);
+  } else if (max === g) {
+    h = 60 * ((b - r) / delta + 2);
+  } else {
+    h = 60 * ((r - g) / delta + 4);
+  }
+  return { h: (h + 360) % 360, s: s * 100, l: l * 100 };
+}
+
+/**
+ * Convert hue/saturation/lightness to 8-bit channels.
+ *
+ * @param {Hsl} hsl hue in degrees (wrapped), saturation and lightness in percent.
+ * @returns {Rgb}
+ */
+export function hslToRgb(hsl) {
+  const h = (((hsl.h % 360) + 360) % 360) / 60;
+  const s = clamp(hsl.s, 0, 100) / 100;
+  const l = clamp(hsl.l, 0, 100) / 100;
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs((h % 2) - 1));
+  const m = l - c / 2;
+
+  /** @type {[number, number, number]} */
+  let triple;
+  if (h < 1) triple = [c, x, 0];
+  else if (h < 2) triple = [x, c, 0];
+  else if (h < 3) triple = [0, c, x];
+  else if (h < 4) triple = [0, x, c];
+  else if (h < 5) triple = [x, 0, c];
+  else triple = [c, 0, x];
+
+  return {
+    r: Math.round((triple[0] + m) * 255),
+    g: Math.round((triple[1] + m) * 255),
+    b: Math.round((triple[2] + m) * 255),
+  };
+}
+
+/**
+ * WCAG 2.x relative luminance of an opaque sRGB color.
+ *
+ * Mirrors `generator/validate.py::relative_luminance` exactly, including its
+ * `0.03928` linear-segment cutoff, so a badge shown here and a build-time gate
+ * failure can never disagree.
+ *
+ * @param {Rgb} rgb
+ * @returns {number} luminance in `[0, 1]`.
+ */
+export function relativeLuminance(rgb) {
+  /** @param {number} value @returns {number} */
+  const channel = (value) => {
+    const c = clamp(value, 0, 255) / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * channel(rgb.r) + 0.7152 * channel(rgb.g) + 0.0722 * channel(rgb.b);
+}
+
+/**
+ * WCAG contrast ratio between two opaque sRGB colors. Argument order does not
+ * matter -- the lighter color is always the numerator.
+ *
+ * @param {Rgb} a
+ * @param {Rgb} b
+ * @returns {number} ratio in `[1, 21]`.
+ */
+export function contrastRatio(a, b) {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+/* hygiene-allow-color-start: color-string serializers. The two helpers below
+   FORMAT a CSS color from numeric channel state -- the function-call text is
+   an output template, not a hardcoded theme color. This is the single
+   allowlisted span in the theme lab; every other color value in this feature
+   stays numeric (h/s/l or r/g/b) until it reaches one of these two. */
+/**
+ * Serialize hue/saturation/lightness as a CSS `hsl` color.
+ *
+ * @param {Hsl} hsl
+ * @returns {string}
+ */
+export function hslCss(hsl) {
+  const h = Math.round((((hsl.h % 360) + 360) % 360) * 10) / 10;
+  const s = Math.round(clamp(hsl.s, 0, 100) * 10) / 10;
+  const l = Math.round(clamp(hsl.l, 0, 100) * 10) / 10;
+  return `hsl(${h}, ${s}%, ${l}%)`;
+}
+
+/**
+ * Serialize 8-bit channels plus an alpha as a legacy comma `rgba` color --
+ * the spelling the token generator emits and the only one xterm.js accepts
+ * alongside full-length hex.
+ *
+ * @param {Rgb} rgb
+ * @param {number} alpha alpha in `[0, 1]`; emitted with two decimals.
+ * @returns {string}
+ */
+export function rgbaCss(rgb, alpha) {
+  /** @param {number} value @returns {number} */
+  const channel = (value) => Math.round(clamp(value, 0, 255));
+  const a = clamp(alpha, 0, 1).toFixed(2);
+  return `rgba(${channel(rgb.r)}, ${channel(rgb.g)}, ${channel(rgb.b)}, ${a})`;
+}
+/* hygiene-allow-color-end */
+
+/**
+ * Pick `--color-on-accent`: whichever of the target scope's own background or
+ * primary text reads best on the accent fill.
+ *
+ * Returns the scope's string verbatim rather than a re-serialization, so a
+ * value read off a live computed style survives untouched.
+ *
+ * @param {Rgb} accent
+ * @param {ScopeColors} scopeColors
+ * @returns {string}
+ */
+function pickOnAccent(accent, scopeColors) {
+  const background = parseColor(scopeColors.bgPrimary);
+  const text = parseColor(scopeColors.textPrimary);
+  if (background === null) return scopeColors.textPrimary;
+  if (text === null) return scopeColors.bgPrimary;
+  return contrastRatio(accent, background) >= contrastRatio(accent, text)
+    ? scopeColors.bgPrimary
+    : scopeColors.textPrimary;
+}
+
+/**
+ * Derive every accent-family custom property for one mode.
+ *
+ * See the module docstring for the rules and for why `--ansi-cursor-accent` is
+ * not among the returned names.
+ *
+ * @param {LabState} state per-mode accent controls.
+ * @param {ThemeMode} mode which mode to derive.
+ * @param {ScopeColors} scopeColors the target scope's own bg/text primaries,
+ *   used only by the `--color-on-accent` rule.
+ * @returns {Record<string, string>} CSS custom-property name to value.
+ */
+export function deriveAccentVars(state, mode, scopeColors) {
+  const accent = state[mode];
+  const base = hslToRgb({ h: accent.hue, s: accent.saturation, l: accent.lightness });
+  const emphasis = hslToRgb({ h: accent.hue, s: accent.saturation, l: accent.emphasisLightness });
+
+  /** @type {Record<string, string>} */
+  const vars = {
+    '--color-accent': rgbToHex(base),
+    '--color-accent-light': rgbToHex(emphasis),
+    '--color-on-accent': pickOnAccent(base, scopeColors),
+    '--border-accent': rgbaCss(emphasis, BORDER_ALPHA[mode]),
+  };
+  for (const level of TINT_LEVELS) {
+    vars[`--accent-tint-${String(level).padStart(2, '0')}`] = rgbaCss(emphasis, level / 100);
+  }
+  vars['--wt-accent-system-tint-04'] = rgbaCss(base, SYSTEM_TINT_ALPHA);
+  return vars;
+}
+
+/**
+ * The accent contrast gates, mirroring the two accent entries of
+ * `generator/validate.py::WCAG_GATES` (the AA tuple the default family is held
+ * to). `accent.on` is gated against `accent.base` rather than the background,
+ * because it is text on an accent fill.
+ *
+ * @type {ReadonlyArray<{name: string, threshold: number}>}
+ */
+const GATES = [
+  { name: 'accent.base vs bg.primary', threshold: 3.0 },
+  { name: 'accent.on vs accent.base', threshold: 4.5 },
+];
+
+/**
+ * Score a derived accent family against the WCAG gates.
+ *
+ * Fails closed: if a color cannot be parsed, the gate reports the worst
+ * possible ratio (1) and does not pass, rather than being skipped.
+ *
+ * @param {Record<string, string>} derived output of {@link deriveAccentVars}.
+ * @param {ScopeColors} scopeColors the same scope colors used to derive it.
+ * @returns {GateResult[]} one entry per gate, in {@link GATES} order.
+ */
+export function evaluateGates(derived, scopeColors) {
+  const accent = parseColor(derived['--color-accent']);
+  const onAccent = parseColor(derived['--color-on-accent']);
+  const background = parseColor(scopeColors.bgPrimary);
+  /** @type {Array<[Rgb | null, Rgb | null]>} */
+  const pairs = [
+    [accent, background],
+    [onAccent, accent],
+  ];
+  return GATES.map((gate, index) => {
+    const [foreground, against] = pairs[index];
+    const ratio =
+      foreground === null || against === null ? 1 : contrastRatio(foreground, against);
+    return { name: gate.name, ratio, threshold: gate.threshold, pass: ratio >= gate.threshold };
+  });
+}
+
+/**
+ * Reduce a human-typed theme name to a CSS/id-safe slug.
+ *
+ * Diacritics are folded to their base letters; every other non-alphanumeric
+ * run becomes a single dash; leading and trailing dashes are trimmed. A name
+ * with no representable characters at all slugifies to the empty string, which
+ * {@link checkCollision} then rejects.
+ *
+ * @param {string} text
+ * @returns {string} a slug matching `/^[a-z0-9]+(-[a-z0-9]+)*$/`, or `''`.
+ */
+export function slugifyThemeName(text) {
+  return String(text)
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/gu, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Check a slug against the shipped theme registry.
+ *
+ * A lab theme ships as a *family* with one theme per mode, so three things can
+ * collide: the slug against an existing theme id, the slug against an existing
+ * family name, and either derived id (`<slug>-dark` / `<slug>-light`) against
+ * an existing theme id.
+ *
+ * The manifest is injected rather than imported so this stays pure and so
+ * there is exactly one copy of the id list in the product -- callers pass
+ * `THEMES`/`DEFAULTS` from the generated `tokens.js`.
+ *
+ * @param {string} slug output of {@link slugifyThemeName}.
+ * @param {ThemeManifest} manifest known theme ids and family names.
+ * @returns {CollisionResult} `reason` is `null` when there is no collision.
+ */
+export function checkCollision(slug, manifest) {
+  if (slug === '') {
+    return { collides: true, reason: 'name must contain at least one letter or digit' };
+  }
+  if (manifest.ids.includes(slug)) {
+    return { collides: true, reason: `"${slug}" is already a theme id` };
+  }
+  if (manifest.families.includes(slug)) {
+    return { collides: true, reason: `"${slug}" is already a theme family` };
+  }
+  for (const mode of ['dark', 'light']) {
+    const derivedId = `${slug}-${mode}`;
+    if (manifest.ids.includes(derivedId)) {
+      return { collides: true, reason: `"${slug}" would produce the existing theme "${derivedId}"` };
+    }
+  }
+  return { collides: false, reason: null };
+}
+
+/**
+ * Order the derived custom properties are presented in -- the two opaque
+ * colors first, then the alpha family from most to least opaque, so the table
+ * reads as "the colors, then the washes".
+ *
+ * @type {ReadonlyArray<string>}
+ */
+const TOKEN_DISPLAY_ORDER = [
+  '--color-accent',
+  '--color-accent-light',
+  '--color-on-accent',
+  '--border-accent',
+  '--accent-tint-30',
+  '--accent-tint-25',
+  '--accent-tint-20',
+  '--accent-tint-12',
+  '--accent-tint-10',
+  '--accent-tint-08',
+  '--accent-tint-06',
+  '--accent-tint-04',
+  '--wt-accent-system-tint-04',
+];
+
+/**
+ * The design-system token dot-path each derived custom property is authored
+ * as, for the export's "what to change" tables.
+ *
+ * `--wt-accent-system-tint-04` is deliberately absent: it lives in the
+ * `web_terminal` interface document, not in a theme document, and shipped
+ * families inherit it rather than authoring it (see {@link buildExportMarkdown}).
+ *
+ * @type {Readonly<Record<string, string>>}
+ */
+const TOKEN_PATHS = {
+  '--color-accent': 'accent.base',
+  '--color-accent-light': 'accent.light',
+  '--color-on-accent': 'accent.on',
+  '--border-accent': 'border.accent',
+  '--accent-tint-04': 'tint.accent.04',
+  '--accent-tint-06': 'tint.accent.06',
+  '--accent-tint-08': 'tint.accent.08',
+  '--accent-tint-10': 'tint.accent.10',
+  '--accent-tint-12': 'tint.accent.12',
+  '--accent-tint-20': 'tint.accent.20',
+  '--accent-tint-25': 'tint.accent.25',
+  '--accent-tint-30': 'tint.accent.30',
+};
+
+/**
+ * One mode's contribution to an export: what was derived and how it scored.
+ *
+ * @typedef {{
+ *   derived: Record<string, string>,
+ *   gates: GateResult[],
+ * }} ModeExport
+ */
+
+/**
+ * Everything {@link buildExportMarkdown} needs, gathered by the UI layer.
+ *
+ * @typedef {{
+ *   label: string,
+ *   slug: string,
+ *   collision: CollisionResult,
+ *   dark: ModeExport,
+ *   light: ModeExport,
+ * }} ExportInput
+ */
+
+/** @param {number} ratio @returns {string} */
+function formatRatio(ratio) {
+  return `${ratio.toFixed(2)}:1`;
+}
+
+/**
+ * Render the per-mode token table rows of the export.
+ *
+ * @param {ModeExport} modeExport
+ * @returns {string[]} markdown lines.
+ */
+function exportTokenTable(modeExport) {
+  const lines = ['| Token | Value |', '| --- | --- |'];
+  for (const name of TOKEN_DISPLAY_ORDER) {
+    const path = TOKEN_PATHS[name];
+    if (path === undefined) continue;
+    lines.push(`| \`${path}\` | \`${modeExport.derived[name]}\` |`);
+  }
+  return lines;
+}
+
+/**
+ * Build the paste-into-an-issue markdown spec for a proposed theme.
+ *
+ * The output is deliberately self-contained: someone reading it in a GitHub
+ * issue must be able to implement the theme without opening the lab. That
+ * means it carries both the *values* and the complete *change set* -- every
+ * file that has to move, in the shape this repository actually uses.
+ *
+ * Two details of that change set are easy to get wrong, so they are stated
+ * explicitly in the output rather than left implied:
+ *
+ *   * `accent.base` / `accent.light` / `accent.on` are authored as *references*
+ *     into `core.json`'s ramps (`{color.teal.300}`), not as literal hex, so a
+ *     new accent needs ramp steps adding there first.
+ *   * every shipped non-default family (`apex`, `high-contrast`) *inherits* the
+ *     interface groups rather than authoring them, so the change set asks for
+ *     `$extensions.inherits` entries -- and notes that
+ *     `wt-accent-system-tint-04` therefore keeps the default value unless the
+ *     author opts out of inheriting.
+ *
+ * @param {ExportInput} input
+ * @returns {string} markdown.
+ */
+export function buildExportMarkdown(input) {
+  const { label, slug, collision, dark, light } = input;
+  const failed = [
+    ...dark.gates.filter((gate) => !gate.pass).map((gate) => ['dark', gate]),
+    ...light.gates.filter((gate) => !gate.pass).map((gate) => ['light', gate]),
+  ];
+
+  /** @type {string[]} */
+  const lines = [];
+  lines.push(`# Theme proposal: ${label || slug}`);
+  lines.push('');
+  lines.push(`- **Family name:** \`${slug}\``);
+  lines.push(`- **Theme ids:** \`${slug}-dark\`, \`${slug}-light\``);
+  lines.push(`- **Display label:** ${label || slug}`);
+  lines.push('');
+
+  if (failed.length > 0 || collision.collides) {
+    lines.push('## ⚠ Warnings');
+    lines.push('');
+    if (collision.collides && collision.reason !== null) {
+      lines.push(`- **Name collision:** ${collision.reason}. Pick a different name.`);
+    }
+    for (const entry of failed) {
+      const mode = /** @type {string} */ (entry[0]);
+      const gate = /** @type {GateResult} */ (entry[1]);
+      lines.push(
+        `- **Contrast (${mode}):** ${gate.name} is ${formatRatio(gate.ratio)}, ` +
+          `below the required ${gate.threshold.toFixed(1)}:1.`
+      );
+    }
+    lines.push('');
+    lines.push('These do not block a proposal, but the design system enforces the');
+    lines.push('contrast gates at build time -- a theme that fails them cannot ship');
+    lines.push('as-is.');
+    lines.push('');
+  }
+
+  for (const [mode, modeExport] of /** @type {Array<[string, ModeExport]>} */ ([
+    ['Dark', dark],
+    ['Light', light],
+  ])) {
+    lines.push(`## ${mode} mode`);
+    lines.push('');
+    lines.push(...exportTokenTable(modeExport));
+    lines.push('');
+    for (const gate of modeExport.gates) {
+      const verdict = gate.pass ? 'PASS' : 'FAIL';
+      lines.push(
+        `- ${verdict} — ${gate.name}: ${formatRatio(gate.ratio)} ` +
+          `(needs ${gate.threshold.toFixed(1)}:1)`
+      );
+    }
+    lines.push('');
+  }
+
+  lines.push('## Implementation change set');
+  lines.push('');
+  lines.push('All paths are relative to `src/osprey/interfaces/design_system/`.');
+  lines.push('');
+  lines.push(`1. **\`tokens/core.json\`** — add ramp steps for the new hexes. The theme`);
+  lines.push('   documents reference core ramps (`{color.teal.300}`) rather than');
+  lines.push('   inlining hex, so add the accent base and emphasis colors above as new');
+  lines.push('   steps in an existing ramp or a new one, then reference them in step 2.');
+  lines.push('');
+  lines.push(
+    `2. **\`tokens/themes/${slug}-dark.json\`** and **\`tokens/themes/${slug}-light.json\`** —`
+  );
+  lines.push('   copy the same-mode sibling (`themes/dark.json` / `themes/light.json`) and');
+  lines.push('   replace `accent.base`, `accent.light`, `accent.on`, `border.accent` and');
+  lines.push('   the eight `tint.accent.*` entries with the values tabled above. Set');
+  lines.push(
+    `   \`$extensions\` to \`{"mode": "dark"|"light", "id": "${slug}-dark"|"${slug}-light",`
+  );
+  lines.push(`   "label": "${label || slug}", "family": "${slug}"}\` (no \`"default": true\` —`);
+  lines.push('   that belongs to the shipped default theme).');
+  lines.push('');
+  lines.push('3. **`tokens/interfaces/*.json`** — add the new ids to each');
+  lines.push('   `$extensions.inherits` map so the five interface documents');
+  lines.push('   (`ariel.json`, `artifacts.json`, `channel_finder.json`,');
+  lines.push('   `lattice_dashboard.json`, `web_terminal.json`) reuse the base groups:');
+  lines.push('');
+  lines.push('   ```json');
+  lines.push(`   "${slug}-dark": "dark",`);
+  lines.push(`   "${slug}-light": "light"`);
+  lines.push('   ```');
+  lines.push('');
+  lines.push('   This is what `apex` and `high-contrast` already do. Note the');
+  lines.push('   consequence: `wt-accent-system-tint-04` is authored in');
+  lines.push('   `web_terminal.json`, so inheriting keeps the default value rather than');
+  lines.push('   the accent-matched one below. Author a full `web_terminal.json` group');
+  lines.push('   for the new ids only if that tint must match the accent:');
+  lines.push('');
+  lines.push(`   - dark: \`${dark.derived['--wt-accent-system-tint-04']}\``);
+  lines.push(`   - light: \`${light.derived['--wt-accent-system-tint-04']}\``);
+  lines.push('');
+  lines.push('4. **Regenerate the artifacts** — run the generator and commit what it');
+  lines.push('   writes (`static/css/tokens.css`, `static/js/tokens.js`,');
+  lines.push('   `static/js/theme-boot.js`):');
+  lines.push('');
+  lines.push('   ```console');
+  lines.push('   $ python -m osprey.interfaces.design_system.generator.build');
+  lines.push('   ```');
+  lines.push('');
+  lines.push('5. **Check the gates** — the generator validates WCAG contrast per family.');
+  lines.push('   An unrecognized family is held to the AA gates, which are the ones');
+  lines.push('   scored above.');
+  lines.push('');
+  lines.push('_Generated by `osprey theme-lab`._');
+
+  return lines.join('\n');
+}

--- a/src/osprey/interfaces/design_system/static/theme-lab.html
+++ b/src/osprey/interfaces/design_system/static/theme-lab.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>OSPREY Theme Lab</title>
+
+<!-- No theme-boot.js / theme-manager.js here, deliberately. The page renders
+     BOTH modes side by side in scoped [data-theme] containers, so the document
+     theme is pinned to "dark" on <html> above and a visitor's persisted theme
+     preference must never leak in and re-skin the chrome under them. -->
+
+<!-- Design system tokens + reset. Relative so the page resolves correctly at
+     /design-system/theme-lab.html and under any panel proxy prefix; the shared
+     web fonts are mounted separately at the server root, hence absolute. -->
+<link rel="stylesheet" href="css/tokens.css">
+<link rel="stylesheet" href="css/base.css">
+<link rel="stylesheet" href="/static/fonts/fonts.css">
+<link rel="stylesheet" href="css/theme-lab.css">
+
+<!-- The DOM layer. It imports the pure half (js/theme-lab.js) and the
+     generated theme registry (js/tokens.js) as ES modules. -->
+<script type="module" src="js/theme-lab-ui.js"></script>
+</head>
+<body>
+
+<div class="lab-page">
+
+  <header class="lab-masthead">
+    <div>
+      <h1 class="lab-masthead-title">Theme lab</h1>
+      <p class="lab-masthead-kicker">Pick an accent — both modes re-skin live</p>
+    </div>
+    <a class="lab-masthead-link" href="reference.html">Token reference &rsaquo;</a>
+  </header>
+
+  <div class="lab">
+
+    <!-- ============================ CONTROLS ============================ -->
+    <aside class="lab-controls">
+
+      <section class="lab-section">
+        <h2 class="lab-section-title">Accent</h2>
+
+        <canvas class="lab-wheel" id="hue-wheel" width="240" height="240"
+                aria-label="Hue and saturation picker"></canvas>
+
+        <div class="lab-field">
+          <label class="lab-field-label" for="hex-input">Hex</label>
+          <div class="lab-field-row">
+            <span class="lab-hex-swatch" id="hex-swatch" aria-hidden="true"></span>
+            <input class="lab-text-input" id="hex-input" type="text" spellcheck="false"
+                   autocomplete="off" autocapitalize="off" placeholder="six-digit hex">
+          </div>
+        </div>
+
+        <div class="lab-field">
+          <span class="lab-field-label">Presets</span>
+          <!-- Populated by theme-lab.js: one .lab-preset button per preset. -->
+          <div class="lab-preset-row" id="preset-row"></div>
+        </div>
+      </section>
+
+      <section class="lab-section">
+        <h2 class="lab-section-title">Lightness</h2>
+
+        <div class="lab-field">
+          <label class="lab-field-label" for="lightness-dark">
+            Dark mode <output class="lab-range-value" id="lightness-dark-value"></output>
+          </label>
+          <input class="lab-range" id="lightness-dark" type="range"
+                 min="0" max="100" step="1" value="50">
+        </div>
+
+        <div class="lab-field">
+          <label class="lab-field-label" for="lightness-light">
+            Light mode <output class="lab-range-value" id="lightness-light-value"></output>
+          </label>
+          <input class="lab-range" id="lightness-light" type="range"
+                 min="0" max="100" step="1" value="50">
+        </div>
+      </section>
+
+      <section class="lab-section">
+        <h2 class="lab-section-title">Name</h2>
+
+        <div class="lab-field">
+          <label class="lab-field-label" for="theme-name">Theme name</label>
+          <input class="lab-text-input" id="theme-name" type="text" spellcheck="false"
+                 autocomplete="off" placeholder="Harbour dusk">
+          <!-- Slug preview / collision warning. Empty = collapsed (CSS :empty). -->
+          <p class="lab-warning" id="slug-warning" role="status" aria-live="polite"></p>
+        </div>
+      </section>
+
+      <section class="lab-section lab-export">
+        <div class="lab-export-head">
+          <h2 class="lab-section-title lab-export-title">Export</h2>
+          <button class="lab-btn" id="copy-export" type="button">Copy</button>
+        </div>
+        <pre class="lab-export-text" id="export-text" tabindex="0"></pre>
+      </section>
+
+    </aside>
+
+    <!-- ============================ PREVIEWS ============================ -->
+    <main class="lab-previews">
+
+      <!-- Scoped theme containers. tokens.css declares its theme blocks as bare
+           attribute selectors (`:root, [data-theme="dark"]` / `[data-theme="light"]`),
+           so each container below inherits that mode's FULL token set with no
+           JavaScript at all. This is the load-bearing trick of the page. -->
+      <section class="lab-panel" data-theme="dark">
+        <div class="lab-panel-label">Dark<span class="lab-panel-hint">data-theme="dark"</span></div>
+        <div class="lab-mount" id="preview-dark"></div>
+        <div class="lab-readout">
+          <h3 class="lab-readout-title">Contrast</h3>
+          <div class="lab-gates" id="gates-dark"></div>
+          <h3 class="lab-readout-title">Derived tokens</h3>
+          <div class="lab-tokens" id="tokens-dark"></div>
+        </div>
+      </section>
+
+      <section class="lab-panel" data-theme="light">
+        <div class="lab-panel-label">Light<span class="lab-panel-hint">data-theme="light"</span></div>
+        <div class="lab-mount" id="preview-light"></div>
+        <div class="lab-readout">
+          <h3 class="lab-readout-title">Contrast</h3>
+          <div class="lab-gates" id="gates-light"></div>
+          <h3 class="lab-readout-title">Derived tokens</h3>
+          <div class="lab-tokens" id="tokens-light"></div>
+        </div>
+      </section>
+
+    </main>
+
+  </div>
+</div>
+
+<!-- ======================= MINI SHELL TEMPLATE =========================
+     One schematic mock of the web terminal, instantiated by theme-lab.js into
+     BOTH #preview-dark and #preview-light. Deliberately NOT a copy of
+     web_terminal/static/index.html — it is a caricature whose only job is to
+     put every accent-consuming pattern on screen at once: primary button,
+     ghost button, inline link, active/inactive tab, accent-tinted rail item,
+     focus ring, selected text, system-tint row, accent status item. Drift
+     against the real shell is cosmetic and expected.
+     ==================================================================== -->
+<template id="mini-shell">
+  <div class="ms-shell">
+
+    <div class="ms-header">
+      <span class="ms-logo">OSPREY</span>
+      <span class="ms-title">Web Terminal</span>
+      <span class="ms-spacer"></span>
+      <button class="ms-icon-btn" type="button" tabindex="-1" aria-hidden="true">&#9881;</button>
+      <button class="ms-icon-btn" type="button" tabindex="-1" aria-hidden="true">&#9776;</button>
+    </div>
+
+    <div class="ms-tabs">
+      <button class="ms-tab is-active" type="button" tabindex="-1">Session</button>
+      <button class="ms-tab" type="button" tabindex="-1">Files</button>
+      <button class="ms-tab" type="button" tabindex="-1">Orbit</button>
+    </div>
+
+    <div class="ms-body">
+
+      <nav class="ms-rail" aria-hidden="true">
+        <span class="ms-rail-item is-active">&#9724;</span>
+        <span class="ms-rail-item">&#9723;</span>
+        <span class="ms-rail-item">&#9679;</span>
+        <span class="ms-rail-item">&#9650;</span>
+      </nav>
+
+      <div class="ms-main">
+
+        <div class="ms-terminal">
+          <p class="ms-term-line"><span class="ms-term-prompt">osprey &rsaquo;</span> read_channel SR:BPM:14:X</p>
+          <p class="ms-term-line ms-term-out">SR:BPM:14:X = <span class="ms-selection">-0.184 mm</span></p>
+          <p class="ms-term-line ms-term-out">4 correctors armed, 172 BPMs nominal</p>
+          <p class="ms-term-line"><span class="ms-term-prompt">osprey &rsaquo;</span> <span class="ms-term-cursor"></span></p>
+        </div>
+
+        <div class="ms-system-row">
+          <span class="ms-system-tag">system</span>
+          <span>Connector armed &mdash; see <a class="ms-link" href="#" tabindex="-1">write policy</a></span>
+        </div>
+
+        <div class="ms-entry">
+          <div class="ms-entry-field ms-focus-ring">Ask the operator agent&hellip;</div>
+          <button class="ms-btn ms-btn-ghost" type="button" tabindex="-1">Attach</button>
+          <button class="ms-btn ms-btn-primary" type="button" tabindex="-1">Send</button>
+        </div>
+
+      </div>
+    </div>
+
+    <div class="ms-status">
+      <span class="ms-status-item is-accent"><span class="ms-status-dot"></span>connected</span>
+      <span class="ms-status-item">80&times;24</span>
+      <span class="ms-spacer"></span>
+      <span class="ms-status-item">12:04:31</span>
+    </div>
+
+  </div>
+</template>
+
+</body>
+</html>

--- a/tests/cli/test_theme_lab_cmd.py
+++ b/tests/cli/test_theme_lab_cmd.py
@@ -1,0 +1,139 @@
+"""Tests for the ``osprey theme-lab`` CLI command.
+
+Hermetic: no browser is ever opened and no server is ever bound — ``uvicorn.run``
+and the browser-opening helper are patched out.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+
+from osprey.cli.main import LazyGroup, cli
+from osprey.cli.theme_lab_cmd import THEME_LAB_PATH, create_app, theme_lab
+
+BROWSER_HELPER = "osprey.interfaces.web_terminal.app._open_browser_when_ready"
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+# -- registration ----------------------------------------------------------
+
+
+class TestRegistration:
+    """The command must be listed AND resolvable through LazyGroup."""
+
+    def test_root_help_lists_theme_lab(self, runner):
+        result = runner.invoke(cli, ["--help"])
+
+        assert result.exit_code == 0
+        assert "theme-lab" in result.output
+
+    def test_lazy_group_resolves_hyphenated_name(self):
+        """``theme-lab`` is not a Python identifier, so the default
+        ``getattr(mod, cmd_name)`` path in LazyGroup.get_command cannot find it.
+
+        Regression guard: without the explicit ``theme-lab`` branch this raises
+        AttributeError the moment anyone actually runs the command, which a
+        help-listing test alone does not catch.
+        """
+        group = LazyGroup(name="osprey")
+
+        command = group.get_command(mock.Mock(), "theme-lab")
+
+        assert command is not None
+        assert command.name == "theme-lab"
+
+    def test_command_help_through_group(self, runner):
+        result = runner.invoke(cli, ["theme-lab", "--help"])
+
+        assert result.exit_code == 0
+        assert "--no-browser" in result.output
+
+
+# -- serving ---------------------------------------------------------------
+
+
+class TestServing:
+    """Flag handling around the uvicorn call."""
+
+    def test_no_browser_serves_without_opening_one(self, runner):
+        with (
+            mock.patch("uvicorn.run") as mock_run,
+            mock.patch(BROWSER_HELPER) as mock_browser,
+        ):
+            result = runner.invoke(theme_lab, ["--no-browser"])
+
+        assert result.exit_code == 0
+        assert not mock_browser.called
+        _, kwargs = mock_run.call_args
+        assert kwargs["host"] == "127.0.0.1"
+        assert isinstance(kwargs["port"], int)
+        assert f":{kwargs['port']}{THEME_LAB_PATH}" in result.output
+
+    def test_port_flag_is_honoured(self, runner):
+        with (
+            mock.patch("uvicorn.run") as mock_run,
+            mock.patch(BROWSER_HELPER),
+        ):
+            result = runner.invoke(theme_lab, ["--port", "9123", "--no-browser"])
+
+        assert result.exit_code == 0
+        assert mock_run.call_args.kwargs["port"] == 9123
+        assert f"http://127.0.0.1:9123{THEME_LAB_PATH}" in result.output
+
+    def test_browser_opened_at_theme_lab_page_by_default(self, runner):
+        with (
+            mock.patch("uvicorn.run"),
+            mock.patch(BROWSER_HELPER) as mock_browser,
+        ):
+            result = runner.invoke(theme_lab, ["--port", "9124"])
+
+        assert result.exit_code == 0
+        mock_browser.assert_called_once_with(f"http://127.0.0.1:9124{THEME_LAB_PATH}")
+
+    def test_browser_failure_still_serves_and_prints_url(self, runner):
+        """A headless host must get a usable URL, not a dead command."""
+        with (
+            mock.patch("uvicorn.run") as mock_run,
+            mock.patch(BROWSER_HELPER, side_effect=RuntimeError("no display")),
+        ):
+            result = runner.invoke(theme_lab, ["--port", "9125"])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+        assert f"http://127.0.0.1:9125{THEME_LAB_PATH}" in result.output
+
+
+# -- app factory -----------------------------------------------------------
+
+
+class TestCreateApp:
+    """create_app() is shared with the browser suite, so it must stand alone."""
+
+    def test_mounts_design_system(self):
+        app = create_app()
+
+        mounts = {route.path: route for route in app.routes if hasattr(route, "app")}
+        assert "/design-system" in mounts
+
+    def test_design_system_mount_serves_packaged_static_dir(self):
+        from osprey.interfaces import design_system
+
+        app = create_app()
+
+        mount = next(r for r in app.routes if getattr(r, "path", None) == "/design-system")
+        served = Path(mount.app.directory).resolve()
+        assert served == (Path(design_system.__file__).parent / "static").resolve()
+
+    def test_root_redirects_to_theme_lab_page(self):
+        app = create_app()
+
+        paths = [getattr(route, "path", None) for route in app.routes]
+        assert "/" in paths

--- a/tests/interfaces/design_system/js/theme-lab-coverage.test.mjs
+++ b/tests/interfaces/design_system/js/theme-lab-coverage.test.mjs
@@ -23,7 +23,14 @@ import path from 'node:path';
 
 import { test, expect } from 'vitest';
 
-import { deriveAccentVars } from '/design-system/js/theme-lab.js';
+import {
+  BORDER_ALPHA,
+  SYSTEM_TINT_ALPHA,
+  TINT_LEVELS,
+  deriveAccentVars,
+  hexToRgb,
+  rgbaCss,
+} from '/design-system/js/theme-lab.js';
 
 /**
  * Names that match the accent regex below but are deliberately NOT part of
@@ -86,4 +93,116 @@ test('every token deriveAccentVars produces exists in tokens.css', () => {
     orphaned,
     `deriveAccentVars produces propert(y/ies) not found in tokens.css: ${orphaned.join(', ')}`
   ).toEqual([]);
+});
+
+// ---------------------------------------------------------------------------
+// Value-level guard: the derivation RULES, not just the names
+// ---------------------------------------------------------------------------
+//
+// The three tests above compare NAMES. They stay green if someone changes what
+// a name is worth -- re-basing `tint.accent.*` on accent.base instead of
+// accent.light, or moving `border.accent` off 0.15/0.25. The math spec doesn't
+// close that either: it builds its expectations with the same helpers it is
+// checking, so it is tautological with respect to the alphas.
+//
+// This test closes it from the other side. It takes each shipped theme's own
+// declared `--color-accent` / `--color-accent-light` straight out of the
+// committed CSS, and requires the rest of that block to be exactly what the
+// lab's constants say it should be. Nothing here is re-derived from the lab's
+// state, so it fails if EITHER side moves: change `BORDER_ALPHA` in the lab and
+// it breaks; re-base the tints in `dark.json` and regenerate, and it breaks.
+//
+// It deliberately does NOT assert `--color-accent-light` itself. The lab moves
+// lightness only, while the shipped emphasis colors also shift hue/saturation
+// (#319795 h179/s51 -> #4fd1c5 h175/s59), so the lab cannot reproduce them --
+// a documented simplification, not a drift. `--color-on-accent` is likewise
+// excluded: it is the lab's own selection rule, hand-picked in every theme.
+
+/**
+ * Extract one theme block's declarations from tokens.css.
+ *
+ * @param {string} selector the exact selector text, e.g. `[data-theme="light"]`.
+ * @returns {Record<string, string>} custom-property name to declared value.
+ */
+function themeBlock(selector) {
+  const start = css.indexOf(selector);
+  expect(start, `tokens.css has no ${selector} block`).toBeGreaterThan(-1);
+  const body = css.slice(css.indexOf('{', start) + 1, css.indexOf('}', start));
+  /** @type {Record<string, string>} */
+  const declarations = {};
+  for (const [, name, value] of body.matchAll(/(--[a-z0-9-]+)\s*:\s*([^;]+);/g)) {
+    declarations[name] = value.trim();
+  }
+  return declarations;
+}
+
+/** @type {ReadonlyArray<['dark' | 'light', string]>} */
+const THEME_BLOCKS = [
+  ['dark', ':root, [data-theme="dark"]'],
+  ['light', '[data-theme="light"]'],
+];
+
+for (const [mode, selector] of THEME_BLOCKS) {
+  test(`the shipped ${mode} theme follows the alpha rules the lab derives by`, () => {
+    const block = themeBlock(selector);
+    const base = hexToRgb(block['--color-accent']);
+    const emphasis = hexToRgb(block['--color-accent-light']);
+    expect(base, `${mode}: --color-accent is not a hex color`).not.toBeNull();
+    expect(emphasis, `${mode}: --color-accent-light is not a hex color`).not.toBeNull();
+
+    /** @type {string[]} */
+    const mismatches = [];
+    /** @param {string} name @param {string} expected */
+    const check = (name, expected) => {
+      if (block[name] !== expected) {
+        mismatches.push(`${name}: tokens.css ${block[name]} but the lab derives ${expected}`);
+      }
+    };
+
+    // Tints and the accent border come from the EMPHASIS color.
+    for (const level of TINT_LEVELS) {
+      const key = `--accent-tint-${String(level).padStart(2, '0')}`;
+      check(key, rgbaCss(/** @type {{r:number,g:number,b:number}} */ (emphasis), level / 100));
+    }
+    check(
+      '--border-accent',
+      rgbaCss(/** @type {{r:number,g:number,b:number}} */ (emphasis), BORDER_ALPHA[mode])
+    );
+    // The one member of the family that tints from the BASE instead.
+    check(
+      '--wt-accent-system-tint-04',
+      rgbaCss(/** @type {{r:number,g:number,b:number}} */ (base), SYSTEM_TINT_ALPHA)
+    );
+
+    expect(
+      mismatches,
+      `the lab's derivation rules no longer describe how this design system authors the ` +
+        `${mode} accent family, so the values it exports would be wrong:\n  ` +
+        mismatches.join('\n  ')
+    ).toEqual([]);
+  });
+}
+
+test('deriveAccentVars applies those same rules to a fresh accent', () => {
+  // Guards the direction the test above cannot: that deriveAccentVars actually
+  // USES the constants it is checked against, for an accent that ships nowhere.
+  const state = {
+    dark: { hue: 262, saturation: 89, lightness: 66, emphasisLightness: 82 },
+    light: { hue: 262, saturation: 89, lightness: 56, emphasisLightness: 48 },
+  };
+  const derived = deriveAccentVars(state, 'dark', SCOPE_COLORS);
+  const emphasis = hexToRgb(derived['--color-accent-light']);
+  const base = hexToRgb(derived['--color-accent']);
+
+  for (const level of TINT_LEVELS) {
+    expect(derived[`--accent-tint-${String(level).padStart(2, '0')}`]).toBe(
+      rgbaCss(/** @type {{r:number,g:number,b:number}} */ (emphasis), level / 100)
+    );
+  }
+  expect(derived['--border-accent']).toBe(
+    rgbaCss(/** @type {{r:number,g:number,b:number}} */ (emphasis), BORDER_ALPHA.dark)
+  );
+  expect(derived['--wt-accent-system-tint-04']).toBe(
+    rgbaCss(/** @type {{r:number,g:number,b:number}} */ (base), SYSTEM_TINT_ALPHA)
+  );
 });

--- a/tests/interfaces/design_system/js/theme-lab-coverage.test.mjs
+++ b/tests/interfaces/design_system/js/theme-lab-coverage.test.mjs
@@ -1,0 +1,89 @@
+/**
+ * Drift alarm for the accent-token family: keeps `theme-lab.js`'s
+ * `deriveAccentVars` and the design system's committed `tokens.css` from
+ * silently diverging.
+ *
+ * This is a tripwire, not a formality. If someone adds a new accent-named
+ * custom property to `tokens.css` -- or renames/removes one -- this test must
+ * fail until the theme lab is taught about it (or the name is added to
+ * `EXCLUSIONS` below with a reason). It asserts two-sided set equality:
+ *
+ *   (a) every `--*accent*` property in tokens.css is either produced by
+ *       `deriveAccentVars` or explicitly excluded, and
+ *   (b) every property `deriveAccentVars` produces actually exists in
+ *       tokens.css.
+ *
+ *   npx vitest run tests/interfaces/design_system/js/theme-lab-coverage.test.mjs
+ */
+
+/* global process */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { test, expect } from 'vitest';
+
+import { deriveAccentVars } from '/design-system/js/theme-lab.js';
+
+/**
+ * Names that match the accent regex below but are deliberately NOT part of
+ * the derived accent family, each with the reason it is excluded. Keep this
+ * list as short as possible -- an exclusion is a claim that a name only
+ * *looks* like an accent token, and each one needs a real justification.
+ */
+const EXCLUSIONS = {
+  // Despite the name, this is a near-background terminal cursor color (e.g.
+  // #050a10 in dark, #fafbfd in light) -- not derived from the accent.
+  '--ansi-cursor-accent': 'near-background terminal cursor color, not derived from the accent',
+};
+
+// `import.meta.url` is not a `file:` URL under this repo's vitest setup
+// (environment: happy-dom), so `fileURLToPath(new URL(...))` throws. Vitest
+// runs from the repo root, so resolve off `process.cwd()` instead.
+const cssPath = path.join(
+  process.cwd(),
+  'src/osprey/interfaces/design_system/static/css/tokens.css'
+);
+const css = readFileSync(cssPath, 'utf8');
+
+/** Every distinct accent-named custom property declared in tokens.css. */
+const tokensAccentNames = new Set(css.match(/--[a-z0-9-]*accent[a-z0-9-]*/g));
+
+/** A plausible lab state/scope, exercised only for the KEY SET it derives. */
+const STATE = {
+  dark: { hue: 178, saturation: 51, lightness: 39, emphasisLightness: 60 },
+  light: { hue: 178, saturation: 51, lightness: 39, emphasisLightness: 29 },
+};
+const SCOPE_COLORS = { bgPrimary: '#0a0f1a', textPrimary: '#f1f5f9' };
+
+const derivedNames = new Set(Object.keys(deriveAccentVars(STATE, 'dark', SCOPE_COLORS)));
+
+test('every exclusion actually matches a token in tokens.css', () => {
+  // Self-check: an exclusion for a name that no longer exists would let this
+  // guard pass vacuously instead of catching real drift.
+  const staleExclusions = Object.keys(EXCLUSIONS).filter((name) => !tokensAccentNames.has(name));
+  expect(
+    staleExclusions,
+    `EXCLUSIONS names no accent token that exists in tokens.css: ${staleExclusions.join(', ')}`
+  ).toEqual([]);
+});
+
+test('every accent-named token in tokens.css is derived or explicitly excluded', () => {
+  const undocumented = [...tokensAccentNames].filter(
+    (name) => !derivedNames.has(name) && !(name in EXCLUSIONS)
+  );
+  expect(
+    undocumented,
+    `tokens.css has accent token(s) deriveAccentVars does not produce and that are not in ` +
+      `EXCLUSIONS: ${undocumented.join(', ')}. Teach deriveAccentVars about them, or add an ` +
+      `exclusion with a reason.`
+  ).toEqual([]);
+});
+
+test('every token deriveAccentVars produces exists in tokens.css', () => {
+  const orphaned = [...derivedNames].filter((name) => !tokensAccentNames.has(name));
+  expect(
+    orphaned,
+    `deriveAccentVars produces propert(y/ies) not found in tokens.css: ${orphaned.join(', ')}`
+  ).toEqual([]);
+});

--- a/tests/interfaces/design_system/js/theme-lab-export.test.mjs
+++ b/tests/interfaces/design_system/js/theme-lab-export.test.mjs
@@ -1,0 +1,290 @@
+/**
+ * Unit tests for `buildExportMarkdown` -- the paste-into-an-issue spec the
+ * theme lab hands an author when they are happy with a proposal.
+ *
+ * The export is the lab's only durable output, so what this spec protects is
+ * that it stays *self-contained*: someone reading it in a GitHub issue must be
+ * able to implement the theme without opening the lab again. Concretely that
+ * means three things, and they are what the tests below assert:
+ *
+ *   - the identity of the proposal (family slug, both derived theme ids, and
+ *     the label to author) survives into the markdown, including when the
+ *     author never typed a label;
+ *   - both modes carry their derived values *paired with the token dot-path
+ *     they are authored as*, plus the gate verdicts that judged them -- the
+ *     table rows are checked path-and-value together, so a table that lost its
+ *     values could not pass on the prose that also mentions the paths;
+ *   - the change set names every real file that has to move, and the command
+ *     that regenerates the artifacts.
+ *
+ * The warning block is checked in all three states -- failing gate, name
+ * collision, and clean -- because the clean case is what stops the other two
+ * from passing vacuously.
+ *
+ * Inputs are derived by calling the real `deriveAccentVars`/`evaluateGates`
+ * rather than by hand-writing fixtures, so this spec keeps telling the truth if
+ * the derivation rules change.
+ *
+ *   npx vitest run tests/interfaces/design_system/js/theme-lab-export.test.mjs
+ */
+
+import { test, expect, describe } from 'vitest';
+
+import {
+  buildExportMarkdown,
+  deriveAccentVars,
+  evaluateGates,
+} from '/design-system/js/theme-lab.js';
+
+/** @typedef {import('/design-system/js/theme-lab.js').LabState} LabState */
+/** @typedef {import('/design-system/js/theme-lab.js').ThemeMode} ThemeMode */
+/** @typedef {import('/design-system/js/theme-lab.js').ScopeColors} ScopeColors */
+/** @typedef {import('/design-system/js/theme-lab.js').ModeExport} ModeExport */
+/** @typedef {import('/design-system/js/theme-lab.js').CollisionResult} CollisionResult */
+
+/** The osprey family's two scopes, verbatim from the generated tokens.css. */
+const DARK_SCOPE = { bgPrimary: '#0a0f1a', textPrimary: '#f1f5f9' };
+const LIGHT_SCOPE = { bgPrimary: '#f7f9fc', textPrimary: '#0c1322' };
+
+/** A teal accent that clears both gates in both modes. */
+/** @type {LabState} */
+const PASSING_STATE = {
+  dark: { hue: 190, saturation: 70, lightness: 60, emphasisLightness: 72 },
+  light: { hue: 190, saturation: 65, lightness: 34, emphasisLightness: 26 },
+};
+
+/** Same accent in light mode, but a near-background navy in dark mode. */
+/** @type {LabState} */
+const DARK_ON_DARK_STATE = {
+  dark: { hue: 220, saturation: 40, lightness: 12, emphasisLightness: 20 },
+  light: { hue: 190, saturation: 65, lightness: 34, emphasisLightness: 26 },
+};
+
+/** No collision -- what `checkCollision` returns for an unused name. */
+/** @type {CollisionResult} */
+const NO_COLLISION = { collides: false, reason: null };
+
+/** The token dot-paths every mode table must carry, in the module's own order. */
+const TOKEN_PATHS = [
+  'accent.base',
+  'accent.light',
+  'accent.on',
+  'border.accent',
+  'tint.accent.04',
+  'tint.accent.06',
+  'tint.accent.08',
+  'tint.accent.10',
+  'tint.accent.12',
+  'tint.accent.20',
+  'tint.accent.25',
+  'tint.accent.30',
+];
+
+/**
+ * Derive one mode the way the UI layer does, and score it.
+ *
+ * @param {LabState} state
+ * @param {ThemeMode} mode
+ * @param {ScopeColors} scope
+ * @returns {ModeExport}
+ */
+function modeExport(state, mode, scope) {
+  const derived = deriveAccentVars(state, mode, scope);
+  return { derived, gates: evaluateGates(derived, scope) };
+}
+
+/**
+ * Assemble the full export input for a state, exactly as the UI layer would.
+ *
+ * @param {{state?: LabState, label?: string, slug?: string, collision?: CollisionResult}} [overrides]
+ * @returns {import('/design-system/js/theme-lab.js').ExportInput}
+ */
+function exportInput(overrides = {}) {
+  const state = overrides.state ?? PASSING_STATE;
+  return {
+    label: overrides.label ?? 'Harbor Teal',
+    slug: overrides.slug ?? 'harbor-teal',
+    collision: overrides.collision ?? NO_COLLISION,
+    dark: modeExport(state, 'dark', DARK_SCOPE),
+    light: modeExport(state, 'light', LIGHT_SCOPE),
+  };
+}
+
+/**
+ * The body of the `##` section whose heading mentions `heading`, up to the next
+ * `##` heading. Lets a mode's rows and verdicts be asserted without the other
+ * mode's identical-looking rows satisfying them.
+ *
+ * @param {string} markdown
+ * @param {string} heading
+ * @returns {string}
+ */
+function sectionOf(markdown, heading) {
+  const lines = markdown.split('\n');
+  const start = lines.findIndex((line) => line.startsWith('##') && line.includes(heading));
+  expect(start, `export has no "${heading}" section`).toBeGreaterThanOrEqual(0);
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((line) => line.startsWith('## '));
+  return (end === -1 ? rest : rest.slice(0, end)).join('\n');
+}
+
+/**
+ * The one line of `section` that carries the token dot-path `path`.
+ *
+ * @param {string} section
+ * @param {string} path
+ * @returns {string}
+ */
+function rowFor(section, path) {
+  const rows = section.split('\n').filter((line) => line.includes(`\`${path}\``));
+  expect(rows, `expected exactly one row for ${path}`).toHaveLength(1);
+  return rows[0];
+}
+
+describe('proposal identity', () => {
+  test('names the family slug and both derived theme ids', () => {
+    const markdown = buildExportMarkdown(exportInput());
+
+    expect(markdown).toContain('harbor-teal');
+    expect(markdown).toContain('harbor-teal-dark');
+    expect(markdown).toContain('harbor-teal-light');
+  });
+
+  test('carries the human label into the title and the label to author', () => {
+    const markdown = buildExportMarkdown(exportInput({ label: 'Harbor Teal' }));
+
+    expect(markdown.split('\n')[0]).toContain('Harbor Teal');
+    expect(markdown).toContain('"label": "Harbor Teal"');
+  });
+
+  test('falls back to the slug when no label was typed', () => {
+    const markdown = buildExportMarkdown(exportInput({ label: '' }));
+
+    expect(markdown.split('\n')[0]).toContain('harbor-teal');
+    expect(markdown).toContain('"label": "harbor-teal"');
+    expect(markdown).not.toContain('undefined');
+  });
+});
+
+describe('per-mode values', () => {
+  test('each mode tables every token dot-path against its own derived value', () => {
+    const input = exportInput();
+    const markdown = buildExportMarkdown(input);
+
+    for (const [heading, modeInput] of /** @type {Array<[string, ModeExport]>} */ ([
+      ['Dark mode', input.dark],
+      ['Light mode', input.light],
+    ])) {
+      const section = sectionOf(markdown, heading);
+      for (const path of TOKEN_PATHS) {
+        expect(rowFor(section, path)).not.toBe('');
+      }
+      expect(rowFor(section, 'accent.base')).toContain(modeInput.derived['--color-accent']);
+      expect(rowFor(section, 'accent.light')).toContain(modeInput.derived['--color-accent-light']);
+      expect(rowFor(section, 'accent.on')).toContain(modeInput.derived['--color-on-accent']);
+      expect(rowFor(section, 'border.accent')).toContain(modeInput.derived['--border-accent']);
+      expect(rowFor(section, 'tint.accent.04')).toContain(modeInput.derived['--accent-tint-04']);
+      expect(rowFor(section, 'tint.accent.30')).toContain(modeInput.derived['--accent-tint-30']);
+    }
+  });
+
+  test('the two modes contribute distinct accent hexes, both present', () => {
+    const input = exportInput();
+    const markdown = buildExportMarkdown(input);
+
+    const darkAccent = input.dark.derived['--color-accent'];
+    const lightAccent = input.light.derived['--color-accent'];
+    expect(darkAccent).not.toBe(lightAccent);
+    expect(markdown).toContain(darkAccent);
+    expect(markdown).toContain(lightAccent);
+  });
+});
+
+describe('gate verdicts', () => {
+  test('every gate of every mode is reported with a verdict and a ratio', () => {
+    const input = exportInput();
+    const markdown = buildExportMarkdown(input);
+
+    for (const [heading, modeInput] of /** @type {Array<[string, ModeExport]>} */ ([
+      ['Dark mode', input.dark],
+      ['Light mode', input.light],
+    ])) {
+      const section = sectionOf(markdown, heading);
+      expect(modeInput.gates.length).toBeGreaterThan(0);
+      for (const gate of modeInput.gates) {
+        const verdicts = section
+          .split('\n')
+          .filter((line) => line.includes(gate.name) && line.includes(gate.ratio.toFixed(2)));
+        expect(verdicts, `no verdict line for ${heading} / ${gate.name}`).toHaveLength(1);
+        expect(verdicts[0]).toContain(gate.pass ? 'PASS' : 'FAIL');
+      }
+    }
+  });
+
+  test('a failing gate is reported as FAIL in its own mode section', () => {
+    const input = exportInput({ state: DARK_ON_DARK_STATE });
+    const markdown = buildExportMarkdown(input);
+
+    const failing = input.dark.gates.filter((gate) => !gate.pass);
+    expect(failing.length).toBeGreaterThan(0);
+    expect(sectionOf(markdown, 'Dark mode')).toContain('FAIL');
+    expect(sectionOf(markdown, 'Light mode')).not.toContain('FAIL');
+  });
+});
+
+describe('implementation change set', () => {
+  test('names every file that has to move and the generator command', () => {
+    const markdown = buildExportMarkdown(exportInput({ slug: 'harbor-teal' }));
+
+    for (const file of [
+      'core.json',
+      'harbor-teal-dark.json',
+      'harbor-teal-light.json',
+      'ariel.json',
+      'artifacts.json',
+      'channel_finder.json',
+      'lattice_dashboard.json',
+      'web_terminal.json',
+    ]) {
+      expect(markdown, `change set never mentions ${file}`).toContain(file);
+    }
+    expect(markdown).toContain('python -m osprey.interfaces.design_system.generator.build');
+  });
+});
+
+describe('warnings', () => {
+  test('a failing gate raises a warning that names the gate, mode and ratio', () => {
+    const input = exportInput({ state: DARK_ON_DARK_STATE });
+    const markdown = buildExportMarkdown(input);
+
+    const failing = input.dark.gates.filter((gate) => !gate.pass);
+    expect(failing.length).toBeGreaterThan(0);
+
+    const warnings = sectionOf(markdown, 'Warnings');
+    for (const gate of failing) {
+      expect(warnings).toContain(gate.name);
+      expect(warnings).toContain(gate.ratio.toFixed(2));
+    }
+    expect(warnings.toLowerCase()).toContain('dark');
+  });
+
+  test('a name collision raises a warning carrying the collision reason', () => {
+    const markdown = buildExportMarkdown(
+      exportInput({
+        slug: 'apex',
+        collision: { collides: true, reason: '"apex" is already a theme family' },
+      })
+    );
+
+    expect(sectionOf(markdown, 'Warnings')).toContain('"apex" is already a theme family');
+  });
+
+  test('no warning section at all when the gates pass and the name is free', () => {
+    const input = exportInput();
+    const markdown = buildExportMarkdown(input);
+
+    expect([...input.dark.gates, ...input.light.gates].every((gate) => gate.pass)).toBe(true);
+    expect(markdown).not.toMatch(/^#+.*Warning/mu);
+    expect(markdown).not.toContain('FAIL');
+  });
+});

--- a/tests/interfaces/design_system/js/theme-lab-math.test.mjs
+++ b/tests/interfaces/design_system/js/theme-lab-math.test.mjs
@@ -1,0 +1,415 @@
+/**
+ * Unit tests for theme-lab.js's pure layer -- the color math, the accent
+ * derivation rules, and the name/collision helpers. Nothing here touches the
+ * DOM: these functions are side-effect free by contract, and this spec is what
+ * keeps them that way as the UI layer lands in the same module.
+ *
+ * The three things worth stating explicitly, because they are the rules the
+ * lab's output is judged against:
+ *
+ *   - `contrastRatio`/`relativeLuminance` must agree with
+ *     `generator/validate.py` bit for bit, so a badge that says "pass" and a
+ *     build-time gate that says "fail" can never coexist. Checked against the
+ *     WCAG reference pair (pure black vs pure white = 21:1) and against
+ *     #767676-on-white, the canonical AA boundary gray.
+ *   - the derived name set is exactly the accent family in the generated
+ *     tokens.css MINUS `--ansi-cursor-accent`, which is a near-background
+ *     color rather than an accent member despite its name.
+ *   - `--color-on-accent` follows the target scope, not the accent: the same
+ *     accent picks the background in a dark scope and the text color in a
+ *     light one.
+ *
+ *   npx vitest run tests/interfaces/design_system/js/theme-lab-math.test.mjs
+ */
+
+import { test, expect, describe } from 'vitest';
+
+import {
+  hexToRgb,
+  parseColor,
+  rgbToHex,
+  rgbToHsl,
+  hslToRgb,
+  relativeLuminance,
+  contrastRatio,
+  hslCss,
+  rgbaCss,
+  deriveAccentVars,
+  evaluateGates,
+  slugifyThemeName,
+  checkCollision,
+} from '/design-system/js/theme-lab.js';
+
+/** The osprey family's two scopes, verbatim from the generated tokens.css. */
+const DARK_SCOPE = { bgPrimary: '#0a0f1a', textPrimary: '#f1f5f9' };
+const LIGHT_SCOPE = { bgPrimary: '#f7f9fc', textPrimary: '#0c1322' };
+
+/** The shipped registry, as the DOM layer will pass it in from tokens.js. */
+const MANIFEST = {
+  ids: ['apex-dark', 'apex-light', 'dark', 'high-contrast-dark', 'high-contrast-light', 'light'],
+  families: ['osprey', 'apex', 'high-contrast'],
+};
+
+/**
+ * Build a lab state whose two modes carry the given base/emphasis hex pairs.
+ *
+ * @param {[string, string]} dark base and emphasis hex for dark mode.
+ * @param {[string, string]} light base and emphasis hex for light mode.
+ */
+function stateFrom(dark, light) {
+  /** @param {[string, string]} pair */
+  const mode = ([base, emphasis]) => {
+    const b = rgbToHsl(/** @type {{r:number,g:number,b:number}} */ (hexToRgb(base)));
+    const e = rgbToHsl(/** @type {{r:number,g:number,b:number}} */ (hexToRgb(emphasis)));
+    return { hue: b.h, saturation: b.s, lightness: b.l, emphasisLightness: e.l };
+  };
+  return { dark: mode(dark), light: mode(light) };
+}
+
+/** The osprey family's own accents, as a lab state. */
+const OSPREY_STATE = stateFrom(['#319795', '#4fd1c5'], ['#0a8f8c', '#0d7377']);
+
+describe('hex/rgb conversion', () => {
+  test('parses the six-digit form', () => {
+    expect(hexToRgb('#319795')).toEqual({ r: 49, g: 151, b: 149 });
+  });
+
+  test('expands the three-digit shorthand', () => {
+    expect(hexToRgb('#abc')).toEqual({ r: 170, g: 187, b: 204 });
+  });
+
+  test('parses the alpha-bearing forms, discarding alpha', () => {
+    expect(hexToRgb('#31979580')).toEqual({ r: 49, g: 151, b: 149 });
+    expect(hexToRgb('#abcd')).toEqual({ r: 170, g: 187, b: 204 });
+  });
+
+  test('rejects anything that is not a hex color', () => {
+    expect(hexToRgb('319795')).toBeNull();
+    expect(hexToRgb('#12345')).toBeNull();
+    expect(hexToRgb('rgb(49, 151, 149)')).toBeNull();
+    expect(hexToRgb('')).toBeNull();
+  });
+
+  test('round-trips hex -> rgb -> hex', () => {
+    for (const hex of ['#000000', '#ffffff', '#319795', '#4fd1c5', '#0a0f1a', '#f7f9fc']) {
+      expect(rgbToHex(/** @type {any} */ (hexToRgb(hex)))).toBe(hex);
+    }
+  });
+
+  test('clamps out-of-range channels when serializing', () => {
+    expect(rgbToHex({ r: -20, g: 300, b: 128 })).toBe('#00ff80');
+  });
+});
+
+describe('parseColor', () => {
+  test('accepts the legacy comma form getComputedStyle returns', () => {
+    expect(parseColor('rgb(49, 151, 149)')).toEqual({ r: 49, g: 151, b: 149 });
+    expect(parseColor('rgba(49, 151, 149, 0.15)')).toEqual({ r: 49, g: 151, b: 149 });
+  });
+
+  test('accepts hex too, and rejects out-of-range channels', () => {
+    expect(parseColor('#319795')).toEqual({ r: 49, g: 151, b: 149 });
+    expect(parseColor('rgb(300, 0, 0)')).toBeNull();
+    expect(parseColor('hsl(180, 50%, 40%)')).toBeNull();
+  });
+});
+
+describe('hsl conversion', () => {
+  test('round-trips rgb -> hsl -> rgb exactly', () => {
+    for (const hex of ['#319795', '#4fd1c5', '#0a8f8c', '#0d7377', '#0a0f1a', '#c07a00']) {
+      const rgb = /** @type {any} */ (hexToRgb(hex));
+      expect(hslToRgb(rgbToHsl(rgb))).toEqual(rgb);
+    }
+  });
+
+  test('handles achromatic colors (zero saturation, undefined hue)', () => {
+    expect(rgbToHsl({ r: 128, g: 128, b: 128 })).toEqual({ h: 0, s: 0, l: (128 / 255) * 100 });
+    expect(hslToRgb({ h: 0, s: 0, l: 100 })).toEqual({ r: 255, g: 255, b: 255 });
+    expect(hslToRgb({ h: 0, s: 0, l: 0 })).toEqual({ r: 0, g: 0, b: 0 });
+  });
+
+  test('reports hue per sector', () => {
+    expect(rgbToHsl({ r: 255, g: 0, b: 0 }).h).toBeCloseTo(0, 6);
+    expect(rgbToHsl({ r: 0, g: 255, b: 0 }).h).toBeCloseTo(120, 6);
+    expect(rgbToHsl({ r: 0, g: 0, b: 255 }).h).toBeCloseTo(240, 6);
+  });
+
+  test('wraps out-of-range hue instead of clipping it', () => {
+    expect(hslToRgb({ h: 480, s: 100, l: 50 })).toEqual(hslToRgb({ h: 120, s: 100, l: 50 }));
+    expect(hslToRgb({ h: -120, s: 100, l: 50 })).toEqual(hslToRgb({ h: 240, s: 100, l: 50 }));
+  });
+});
+
+describe('WCAG luminance and contrast', () => {
+  test('luminance spans the full range at the extremes', () => {
+    expect(relativeLuminance({ r: 0, g: 0, b: 0 })).toBe(0);
+    expect(relativeLuminance({ r: 255, g: 255, b: 255 })).toBeCloseTo(1, 10);
+  });
+
+  test('black on white is the reference 21:1', () => {
+    expect(contrastRatio({ r: 0, g: 0, b: 0 }, { r: 255, g: 255, b: 255 })).toBeCloseTo(21, 10);
+  });
+
+  test('#767676 on white is the canonical AA boundary gray', () => {
+    // 0.2126+0.7152+0.0722 == 1, so a gray's luminance is just the channel
+    // transfer of 118/255 -> ((0.46275+0.055)/1.055)^2.4 == 0.181164...,
+    // giving 1.05/0.231164 == 4.5422:1 -- the value the WCAG reference
+    // implementations report for this gray, and just over the 4.5 body-text
+    // threshold that made it the canonical "darkest passing gray".
+    const gray = /** @type {any} */ (hexToRgb('#767676'));
+    expect(relativeLuminance(gray)).toBeCloseTo(0.181164, 6);
+    expect(contrastRatio(gray, { r: 255, g: 255, b: 255 })).toBeCloseTo(4.5422, 4);
+  });
+
+  test('is symmetric in its arguments', () => {
+    const a = /** @type {any} */ (hexToRgb('#319795'));
+    const b = /** @type {any} */ (hexToRgb('#0a0f1a'));
+    expect(contrastRatio(a, b)).toBe(contrastRatio(b, a));
+  });
+
+  test('a color against itself is 1:1', () => {
+    const a = /** @type {any} */ (hexToRgb('#319795'));
+    expect(contrastRatio(a, a)).toBe(1);
+  });
+});
+
+describe('color serializers', () => {
+  test('rgbaCss emits the legacy comma form with two-decimal alpha', () => {
+    expect(rgbaCss({ r: 49, g: 151, b: 149 }, 0.04)).toBe('rgba(49, 151, 149, 0.04)');
+    expect(rgbaCss({ r: 79, g: 209, b: 197 }, 0.1)).toBe('rgba(79, 209, 197, 0.10)');
+    expect(rgbaCss({ r: 13, g: 115, b: 119 }, 0.25)).toBe('rgba(13, 115, 119, 0.25)');
+  });
+
+  test('hslCss emits degrees and percentages', () => {
+    expect(hslCss({ h: 178.8, s: 51, l: 39.2 })).toBe('hsl(178.8, 51%, 39.2%)');
+    expect(hslCss({ h: 480, s: 100, l: 50 })).toBe('hsl(120, 100%, 50%)');
+  });
+});
+
+describe('deriveAccentVars', () => {
+  const derived = deriveAccentVars(OSPREY_STATE, 'dark', DARK_SCOPE);
+
+  test('emits exactly the accent family, minus --ansi-cursor-accent', () => {
+    expect(Object.keys(derived).sort()).toEqual(
+      [
+        '--accent-tint-04',
+        '--accent-tint-06',
+        '--accent-tint-08',
+        '--accent-tint-10',
+        '--accent-tint-12',
+        '--accent-tint-20',
+        '--accent-tint-25',
+        '--accent-tint-30',
+        '--border-accent',
+        '--color-accent',
+        '--color-accent-light',
+        '--color-on-accent',
+        '--wt-accent-system-tint-04',
+      ].sort()
+    );
+    // Named explicitly: --ansi-cursor-accent is a near-background color, not
+    // an accent member, and must never be derived from the accent.
+    expect(derived).not.toHaveProperty('--ansi-cursor-accent');
+  });
+
+  test('reproduces the accent it was built from', () => {
+    expect(derived['--color-accent']).toBe('#319795');
+  });
+
+  test('tints derive from the emphasis variant, not the base', () => {
+    const emphasis = /** @type {any} */ (hexToRgb(derived['--color-accent-light']));
+    expect(derived['--accent-tint-04']).toBe(rgbaCss(emphasis, 0.04));
+    expect(derived['--accent-tint-12']).toBe(rgbaCss(emphasis, 0.12));
+    expect(derived['--accent-tint-30']).toBe(rgbaCss(emphasis, 0.3));
+    expect(derived['--border-accent']).toBe(rgbaCss(emphasis, 0.15));
+  });
+
+  test('--wt-accent-system-tint-04 alone derives from the accent base', () => {
+    expect(derived['--wt-accent-system-tint-04']).toBe('rgba(49, 151, 149, 0.04)');
+    expect(derived['--wt-accent-system-tint-04']).not.toBe(derived['--accent-tint-04']);
+  });
+
+  test('--border-accent alpha is per-mode: 0.15 dark, 0.25 light', () => {
+    const light = deriveAccentVars(OSPREY_STATE, 'light', LIGHT_SCOPE);
+    expect(derived['--border-accent']).toContain('0.15');
+    expect(light['--border-accent']).toContain('0.25');
+  });
+
+  test('emphasis is lighter than base in dark mode and darker in light mode', () => {
+    const light = deriveAccentVars(OSPREY_STATE, 'light', LIGHT_SCOPE);
+    /** @param {string} hex */
+    const lightnessOf = (hex) => rgbToHsl(/** @type {any} */ (hexToRgb(hex))).l;
+    expect(lightnessOf(derived['--color-accent-light'])).toBeGreaterThan(
+      lightnessOf(derived['--color-accent'])
+    );
+    expect(lightnessOf(light['--color-accent-light'])).toBeLessThan(
+      lightnessOf(light['--color-accent'])
+    );
+  });
+
+  test('reads the mode it is asked for, not the other one', () => {
+    expect(deriveAccentVars(OSPREY_STATE, 'light', LIGHT_SCOPE)['--color-accent']).toBe('#0a8f8c');
+  });
+});
+
+describe('--color-on-accent follows the scope, not the accent', () => {
+  /** One accent, evaluated against both scopes. */
+  const state = stateFrom(['#319795', '#4fd1c5'], ['#319795', '#4fd1c5']);
+
+  test('picks the background in a dark scope', () => {
+    const derived = deriveAccentVars(state, 'dark', DARK_SCOPE);
+    expect(derived['--color-on-accent']).toBe(DARK_SCOPE.bgPrimary);
+  });
+
+  test('picks the text color in a light scope', () => {
+    const derived = deriveAccentVars(state, 'light', LIGHT_SCOPE);
+    expect(derived['--color-on-accent']).toBe(LIGHT_SCOPE.textPrimary);
+  });
+
+  test('the pick flips when the scope background flips', () => {
+    const flipped = { bgPrimary: LIGHT_SCOPE.bgPrimary, textPrimary: DARK_SCOPE.textPrimary };
+    // Both candidates are now near-white, so the near-white background wins on
+    // its own merits only if it genuinely reads better -- assert the winner is
+    // whichever candidate actually has the higher ratio, computed here.
+    const accent = /** @type {any} */ (hexToRgb('#319795'));
+    const better =
+      contrastRatio(accent, /** @type {any} */ (hexToRgb(flipped.bgPrimary))) >=
+      contrastRatio(accent, /** @type {any} */ (hexToRgb(flipped.textPrimary)))
+        ? flipped.bgPrimary
+        : flipped.textPrimary;
+    expect(deriveAccentVars(state, 'dark', flipped)['--color-on-accent']).toBe(better);
+  });
+
+  test('always yields the better of the two candidates', () => {
+    const derived = deriveAccentVars(state, 'dark', DARK_SCOPE);
+    const accent = /** @type {any} */ (hexToRgb(derived['--color-accent']));
+    const chosen = contrastRatio(accent, /** @type {any} */ (hexToRgb(derived['--color-on-accent'])));
+    const rejected = contrastRatio(accent, /** @type {any} */ (hexToRgb(DARK_SCOPE.textPrimary)));
+    expect(chosen).toBeGreaterThanOrEqual(rejected);
+  });
+});
+
+describe('evaluateGates', () => {
+  test('mirrors validate.py: accent.base vs bg.primary >= 3, accent.on vs accent.base >= 4.5', () => {
+    const gates = evaluateGates(deriveAccentVars(OSPREY_STATE, 'dark', DARK_SCOPE), DARK_SCOPE);
+    expect(gates.map((gate) => [gate.name, gate.threshold])).toEqual([
+      ['accent.base vs bg.primary', 3.0],
+      ['accent.on vs accent.base', 4.5],
+    ]);
+  });
+
+  test('the shipped osprey dark accent clears both gates', () => {
+    const gates = evaluateGates(deriveAccentVars(OSPREY_STATE, 'dark', DARK_SCOPE), DARK_SCOPE);
+    expect(gates.every((gate) => gate.pass)).toBe(true);
+  });
+
+  test('the 3.0 gate is decided at the boundary, not near it', () => {
+    // Against white, #949494 is 3.033:1 and #959595 is 2.995:1 -- one step of
+    // gray on either side of the non-text-UI threshold.
+    const white = { bgPrimary: '#ffffff', textPrimary: '#000000' };
+    const passing = evaluateGates({ '--color-accent': '#949494', '--color-on-accent': '#000000' }, white);
+    const failing = evaluateGates({ '--color-accent': '#959595', '--color-on-accent': '#000000' }, white);
+    expect(passing[0].ratio).toBeCloseTo(3.033, 3);
+    expect(passing[0].pass).toBe(true);
+    expect(failing[0].ratio).toBeCloseTo(2.995, 3);
+    expect(failing[0].pass).toBe(false);
+  });
+
+  test('the 4.5 gate is decided at the boundary, not near it', () => {
+    // On-accent against the accent fill: #767676 under white is 4.542:1,
+    // #777777 is 4.478:1 -- either side of the body-text threshold.
+    const scope = { bgPrimary: '#000000', textPrimary: '#ffffff' };
+    const passing = evaluateGates({ '--color-accent': '#767676', '--color-on-accent': '#ffffff' }, scope);
+    const failing = evaluateGates({ '--color-accent': '#777777', '--color-on-accent': '#ffffff' }, scope);
+    expect(passing[1].ratio).toBeCloseTo(4.542, 3);
+    expect(passing[1].pass).toBe(true);
+    expect(failing[1].ratio).toBeCloseTo(4.478, 3);
+    expect(failing[1].pass).toBe(false);
+  });
+
+  test('fails closed on an unparseable color rather than skipping the gate', () => {
+    const gates = evaluateGates(
+      { '--color-accent': 'not-a-color', '--color-on-accent': '#ffffff' },
+      DARK_SCOPE
+    );
+    expect(gates.every((gate) => gate.ratio === 1 && gate.pass === false)).toBe(true);
+  });
+});
+
+describe('slugifyThemeName', () => {
+  test('lowercases and hyphenates whitespace', () => {
+    expect(slugifyThemeName('Midnight Teal')).toBe('midnight-teal');
+    expect(slugifyThemeName('  Midnight   Teal  ')).toBe('midnight-teal');
+  });
+
+  test('collapses punctuation into single dashes', () => {
+    expect(slugifyThemeName('Ocean/Sky (v2)')).toBe('ocean-sky-v2');
+    expect(slugifyThemeName('a___b...c')).toBe('a-b-c');
+  });
+
+  test('folds diacritics to their base letters', () => {
+    expect(slugifyThemeName('Café Naïve')).toBe('cafe-naive');
+  });
+
+  test('trims leading and trailing dashes', () => {
+    expect(slugifyThemeName('---Dawn---')).toBe('dawn');
+    expect(slugifyThemeName('!Dawn!')).toBe('dawn');
+  });
+
+  test('keeps digits', () => {
+    expect(slugifyThemeName('Theme 2026')).toBe('theme-2026');
+  });
+
+  test('yields the empty string when nothing is representable', () => {
+    expect(slugifyThemeName('')).toBe('');
+    expect(slugifyThemeName('   ')).toBe('');
+    expect(slugifyThemeName('!!!')).toBe('');
+    expect(slugifyThemeName('日本語')).toBe('');
+  });
+
+  test('is idempotent', () => {
+    const once = slugifyThemeName('Ocean/Sky (v2)');
+    expect(slugifyThemeName(once)).toBe(once);
+  });
+});
+
+describe('checkCollision', () => {
+  test('accepts a clean name', () => {
+    expect(checkCollision('midnight-teal', MANIFEST)).toEqual({ collides: false, reason: null });
+  });
+
+  test('rejects an exact theme-id hit', () => {
+    const result = checkCollision('dark', MANIFEST);
+    expect(result.collides).toBe(true);
+    expect(result.reason).toContain('theme id');
+  });
+
+  test('rejects a family-stem hit', () => {
+    const result = checkCollision('high-contrast', MANIFEST);
+    expect(result.collides).toBe(true);
+    expect(result.reason).toContain('family');
+  });
+
+  test('rejects a name whose derived per-mode ids would collide', () => {
+    // A lab theme ships as a family with one id per mode, so a slug is unusable
+    // if `<slug>-dark`/`<slug>-light` already exist even when the slug itself
+    // is free. Uses a manifest with the family list deliberately empty so the
+    // derived-id rule is what does the rejecting.
+    const result = checkCollision('apex', { ids: MANIFEST.ids, families: [] });
+    expect(result.collides).toBe(true);
+    expect(result.reason).toContain('apex-dark');
+  });
+
+  test('rejects the empty slug', () => {
+    const result = checkCollision('', MANIFEST);
+    expect(result.collides).toBe(true);
+    expect(result.reason).toContain('letter or digit');
+  });
+
+  test('reads the injected manifest rather than a baked-in list', () => {
+    expect(checkCollision('dark', { ids: [], families: [] }).collides).toBe(false);
+    expect(checkCollision('midnight-teal', { ids: ['midnight-teal'], families: [] }).collides).toBe(
+      true
+    );
+  });
+});

--- a/tests/interfaces/design_system/js/theme-lab-math.test.mjs
+++ b/tests/interfaces/design_system/js/theme-lab-math.test.mjs
@@ -252,40 +252,68 @@ describe('deriveAccentVars', () => {
   });
 });
 
-describe('--color-on-accent follows the scope, not the accent', () => {
+describe('--color-on-accent picks the most readable candidate', () => {
   /** One accent, evaluated against both scopes. */
   const state = stateFrom(['#319795', '#4fd1c5'], ['#319795', '#4fd1c5']);
 
-  test('picks the background in a dark scope', () => {
+  /** @param {string} accentHex @param {{bgPrimary: string, textPrimary: string}} scope */
+  const bestOf = (accentHex, scope) => {
+    const accent = /** @type {any} */ (hexToRgb(accentHex));
+    const candidates = [scope.bgPrimary, scope.textPrimary, '#000000', '#ffffff'];
+    let best = candidates[0];
+    let bestRatio = -1;
+    for (const candidate of candidates) {
+      const ratio = contrastRatio(accent, /** @type {any} */ (hexToRgb(candidate)));
+      if (ratio > bestRatio) {
+        bestRatio = ratio;
+        best = candidate;
+      }
+    }
+    return { best, bestRatio };
+  };
+
+  test('yields the highest-contrast candidate in a dark scope', () => {
     const derived = deriveAccentVars(state, 'dark', DARK_SCOPE);
-    expect(derived['--color-on-accent']).toBe(DARK_SCOPE.bgPrimary);
+    expect(derived['--color-on-accent']).toBe(bestOf(derived['--color-accent'], DARK_SCOPE).best);
   });
 
-  test('picks the text color in a light scope', () => {
+  test('yields the highest-contrast candidate in a light scope', () => {
     const derived = deriveAccentVars(state, 'light', LIGHT_SCOPE);
-    expect(derived['--color-on-accent']).toBe(LIGHT_SCOPE.textPrimary);
+    expect(derived['--color-on-accent']).toBe(bestOf(derived['--color-accent'], LIGHT_SCOPE).best);
   });
 
   test('the pick flips when the scope background flips', () => {
     const flipped = { bgPrimary: LIGHT_SCOPE.bgPrimary, textPrimary: DARK_SCOPE.textPrimary };
-    // Both candidates are now near-white, so the near-white background wins on
-    // its own merits only if it genuinely reads better -- assert the winner is
-    // whichever candidate actually has the higher ratio, computed here.
-    const accent = /** @type {any} */ (hexToRgb('#319795'));
-    const better =
-      contrastRatio(accent, /** @type {any} */ (hexToRgb(flipped.bgPrimary))) >=
-      contrastRatio(accent, /** @type {any} */ (hexToRgb(flipped.textPrimary)))
-        ? flipped.bgPrimary
-        : flipped.textPrimary;
-    expect(deriveAccentVars(state, 'dark', flipped)['--color-on-accent']).toBe(better);
+    const derived = deriveAccentVars(state, 'dark', flipped);
+    expect(derived['--color-on-accent']).toBe(bestOf(derived['--color-accent'], flipped).best);
   });
 
-  test('always yields the better of the two candidates', () => {
+  test('never returns a candidate a rival beats', () => {
     const derived = deriveAccentVars(state, 'dark', DARK_SCOPE);
     const accent = /** @type {any} */ (hexToRgb(derived['--color-accent']));
     const chosen = contrastRatio(accent, /** @type {any} */ (hexToRgb(derived['--color-on-accent'])));
-    const rejected = contrastRatio(accent, /** @type {any} */ (hexToRgb(DARK_SCOPE.textPrimary)));
-    expect(chosen).toBeGreaterThanOrEqual(rejected);
+    for (const rival of [DARK_SCOPE.bgPrimary, DARK_SCOPE.textPrimary, '#000000', '#ffffff']) {
+      expect(chosen).toBeGreaterThanOrEqual(
+        contrastRatio(accent, /** @type {any} */ (hexToRgb(rival)))
+      );
+    }
+  });
+
+  test('considers black and white, not only the scope primaries', () => {
+    // Regression: restricting the candidates to the scope's own two colors made
+    // the lab reject accents that ship fine. A mid grey reaches only 4.22:1
+    // against dark's background and 4.15:1 against its text -- both under the
+    // 4.5 gate -- but 4.62:1 against black, which is exactly what
+    // high-contrast-dark ships. Without black in the set the lab tells a
+    // colleague this accent cannot ship, and it can.
+    const grey = stateFrom(['#767676', '#767676'], ['#767676', '#767676']);
+    const derived = deriveAccentVars(grey, 'dark', DARK_SCOPE);
+
+    expect(derived['--color-on-accent']).toBe('#000000');
+    const onAccentGate = evaluateGates(derived, DARK_SCOPE)[1];
+    expect(onAccentGate.name).toBe('accent.on vs accent.base');
+    expect(onAccentGate.pass).toBe(true);
+    expect(onAccentGate.ratio).toBeGreaterThan(4.5);
   });
 });
 

--- a/tests/interfaces/design_system/test_theme_lab.py
+++ b/tests/interfaces/design_system/test_theme_lab.py
@@ -1,0 +1,293 @@
+"""Browser smoke test for the Theme Lab page.
+
+Proves the one thing no unit test can reach: that the lab's DOM layer actually
+boots in a real browser and re-skins both scoped previews live. The math, the
+gate scoring and the export markdown are unit-tested in
+``tests/interfaces/design_system/js/theme-lab-*.test.mjs``; what is checked here
+is the wiring between them and the page.
+
+Specifically:
+
+* the page boots with no console errors (a throwing ``initLab`` would otherwise
+  fail silently, leaving a page that merely *looks* right),
+* the two ``[data-theme]`` preview scopes really do resolve different token
+  sets from ``tokens.css`` — the scoped-theme trick the whole page rests on,
+* typing an accent updates each scope's computed ``--color-accent`` *without*
+  rebuilding the mock,
+* the export block carries the accent, the slug and the full change set, and
+* a deliberately low-contrast accent raises a FAIL badge and a warning section.
+
+Follows the harness pattern of ``test_behavioral.py``: a real uvicorn server on
+a free port in a background thread, a real chromium browser, and a clean skip
+when the chromium binary is not installed.
+
+Run:
+    .venv/bin/pytest tests/interfaces/design_system/test_theme_lab.py -v
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.interfaces.conftest import _run_app_server
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from playwright.sync_api import Browser, Page
+
+pytestmark = pytest.mark.slow
+
+LAB_PATH = "/design-system/theme-lab.html"
+
+#: A vivid violet, far from the shipped teal so a re-skin is unambiguous.
+ACCENT_HEX = "#8b5cf6"
+
+#: Near-black: on the dark preview's near-black background this cannot clear
+#: the 3:1 accent-vs-background gate, so it must raise a FAIL badge.
+LOW_CONTRAST_HEX = "#0b1220"
+
+#: Every file the exported change set has to name for it to be actionable.
+CHANGE_SET_FILES = (
+    "core.json",
+    "ariel.json",
+    "artifacts.json",
+    "channel_finder.json",
+    "lattice_dashboard.json",
+    "web_terminal.json",
+)
+
+
+def _hex_channels(value: str) -> tuple[int, int, int]:
+    """Parse ``#rrggbb`` into 8-bit channels."""
+    match = re.fullmatch(r"#([0-9a-fA-F]{6})", value.strip())
+    assert match is not None, f"expected a 6-digit hex color, got {value!r}"
+    digits = match.group(1)
+    return tuple(int(digits[i : i + 2], 16) for i in (0, 2, 4))  # type: ignore[return-value]
+
+
+def _scope_var(page: Page, mode: str, name: str) -> str:
+    """Read a custom property off one preview scope's themed container."""
+    return page.evaluate(
+        """([mode, name]) => {
+            const mount = document.getElementById(`preview-${mode}`);
+            const panel = mount.closest('[data-theme]');
+            return getComputedStyle(panel).getPropertyValue(name).trim();
+        }""",
+        [mode, name],
+    )
+
+
+def _set_accent(page: Page, value: str) -> None:
+    """Type an accent into the hex field and let the lab settle."""
+    page.fill("#hex-input", value)
+    page.wait_for_timeout(100)
+
+
+@pytest.fixture
+def lab_page(chromium_browser: Browser) -> Iterator[Page]:
+    """Serve the lab through its real CLI app factory and open it."""
+    from osprey.cli.theme_lab_cmd import create_app
+
+    errors: list[str] = []
+    with _run_app_server(create_app()) as base_url:
+        page = chromium_browser.new_page()
+        page.on(
+            "console",
+            lambda message: errors.append(message.text) if message.type == "error" else None,
+        )
+        page.on("pageerror", lambda exc: errors.append(str(exc)))
+        page.goto(f"{base_url}{LAB_PATH}")
+        page.wait_for_selector("#preview-dark .ms-shell")
+        # Surfaced before any assertion below, so a boot failure is reported as
+        # itself rather than as a confusing downstream selector timeout.
+        assert errors == [], f"console errors on load: {errors}"
+        yield page
+        page.close()
+
+
+def test_both_scopes_resolve_distinct_theme_tokens(lab_page: Page) -> None:
+    """Each scoped container picks up its own mode's tokens, with no JS."""
+    dark_bg = _scope_var(lab_page, "dark", "--bg-primary")
+    light_bg = _scope_var(lab_page, "light", "--bg-primary")
+
+    assert dark_bg != ""
+    assert light_bg != ""
+    assert dark_bg != light_bg, (
+        "both preview scopes resolved the same --bg-primary; the scoped "
+        "[data-theme] containers are not receiving separate token sets"
+    )
+    # The dark scope must genuinely be the darker one -- a swap would mean the
+    # previews are mislabelled.
+    assert sum(_hex_channels(dark_bg)) < sum(_hex_channels(light_bg))
+
+
+def test_mini_shell_is_instantiated_into_both_scopes(lab_page: Page) -> None:
+    """The template is cloned once per scope, so every accent surface exists."""
+    for mode in ("dark", "light"):
+        shell = lab_page.locator(f"#preview-{mode} .ms-shell")
+        assert shell.count() == 1, f"expected exactly one mini-shell in {mode}"
+        for selector in (".ms-btn-primary", ".ms-tab.is-active", ".ms-rail-item.is-active"):
+            assert lab_page.locator(f"#preview-{mode} {selector}").count() >= 1, (
+                f"{mode} preview is missing an accent-consuming surface: {selector}"
+            )
+
+
+def test_accent_change_reskins_both_scopes_without_rebuilding(lab_page: Page) -> None:
+    """A color change is a custom-property write, not a DOM rebuild."""
+    before_dark = _scope_var(lab_page, "dark", "--color-accent")
+
+    # Tag the existing node; if the mock were re-created the tag would vanish.
+    lab_page.evaluate("document.querySelector('#preview-dark .ms-shell').dataset.sentinel = 'kept'")
+
+    _set_accent(lab_page, ACCENT_HEX)
+
+    after_dark = _scope_var(lab_page, "dark", "--color-accent")
+    after_light = _scope_var(lab_page, "light", "--color-accent")
+
+    assert after_dark != before_dark, "the dark preview did not re-skin"
+    assert after_light != "", "the light preview has no accent"
+    assert after_dark != after_light, (
+        "both modes derived the same accent; the per-mode lightness offset is not being applied"
+    )
+
+    # The dark scope is the mode the hex field speaks for, so it should land on
+    # (very close to) exactly what was typed -- allowing only hex->HSL->hex
+    # rounding.
+    typed = _hex_channels(ACCENT_HEX)
+    landed = _hex_channels(after_dark)
+    assert all(abs(a - b) <= 2 for a, b in zip(typed, landed, strict=True)), (
+        f"dark accent {after_dark} is not the accent that was typed ({ACCENT_HEX})"
+    )
+
+    sentinel = lab_page.evaluate(
+        "document.querySelector('#preview-dark .ms-shell').dataset.sentinel"
+    )
+    assert sentinel == "kept", "the mini-shell was rebuilt instead of re-skinned"
+
+
+def test_export_carries_values_slug_and_change_set(lab_page: Page) -> None:
+    """The export is implementable on its own, without the lab."""
+    _set_accent(lab_page, ACCENT_HEX)
+    lab_page.fill("#theme-name", "Harbour Dusk")
+    lab_page.wait_for_timeout(100)
+
+    export = lab_page.locator("#export-text").inner_text()
+    dark_accent = _scope_var(lab_page, "dark", "--color-accent")
+
+    assert "harbour-dusk" in export, "the slug is missing from the export"
+    assert "harbour-dusk-dark" in export
+    assert "harbour-dusk-light" in export
+    assert dark_accent in export, "the chosen accent value is missing from the export"
+
+    for filename in CHANGE_SET_FILES:
+        assert filename in export, f"the change set does not name {filename}"
+    assert "python -m osprey.interfaces.design_system.generator.build" in export, (
+        "the change set does not say how to regenerate the artifacts"
+    )
+    # Token dot-paths, not just CSS variable names -- the developer edits JSON.
+    for path in ("accent.base", "accent.light", "accent.on", "border.accent", "tint.accent.04"):
+        assert path in export, f"the export does not map to the token path {path}"
+
+
+def test_low_contrast_accent_fails_a_gate_and_warns_in_the_export(lab_page: Page) -> None:
+    """Gates warn, never block -- but they must actually fire."""
+    _set_accent(lab_page, ACCENT_HEX)
+    assert "FAIL" not in lab_page.locator("#gates-dark").inner_text(), (
+        "the control accent should clear the dark-mode gates"
+    )
+
+    _set_accent(lab_page, LOW_CONTRAST_HEX)
+
+    badges = lab_page.locator("#gates-dark").inner_text()
+    assert "FAIL" in badges, f"a near-background accent did not fail a gate: {badges!r}"
+
+    export = lab_page.locator("#export-text").inner_text()
+    assert "Warnings" in export, "a failing gate produced no warning section in the export"
+    assert "below the required" in export
+
+
+def test_colliding_theme_name_is_flagged(lab_page: Page) -> None:
+    """A name that would shadow a shipped family is called out."""
+    lab_page.fill("#theme-name", "apex")
+    lab_page.wait_for_timeout(100)
+
+    warning = lab_page.locator("#slug-warning").inner_text()
+    assert "apex" in warning
+    assert "already" in warning.lower(), f"collision not reported: {warning!r}"
+
+    export = lab_page.locator("#export-text").inner_text()
+    assert "Warnings" in export
+
+
+# ---------------------------------------------------------------------------
+# Validator parity — no browser required, so this runs in every lane
+# ---------------------------------------------------------------------------
+#
+# The lab tells a colleague whether their accent passes. The generator decides
+# whether it actually ships. If those two ever disagree, the lab lies -- someone
+# is told their theme is fine and then CI rejects it, or worse, the reverse. The
+# two implementations are in different languages and cannot share code, so what
+# is asserted here is that they still agree on the numbers.
+
+
+def _theme_lab_source() -> str:
+    from pathlib import Path
+
+    import osprey.interfaces.design_system as design_system_pkg
+
+    return (Path(design_system_pkg.__file__).parent / "static" / "js" / "theme-lab.js").read_text()
+
+
+def test_lab_wcag_constants_match_the_generator() -> None:
+    """Both luminance implementations use the same WCAG 2.x constants."""
+    import inspect
+
+    from osprey.interfaces.design_system.generator import validate
+
+    python_source = inspect.getsource(validate.relative_luminance) + inspect.getsource(
+        validate.contrast_ratio
+    )
+    js_source = _theme_lab_source()
+
+    # Every constant WCAG 2.x fixes. A typo in any one of them changes a ratio
+    # without changing anything a name-based guard would notice.
+    for constant in ("0.2126", "0.7152", "0.0722", "0.03928", "12.92", "0.055", "1.055", "2.4"):
+        assert constant in python_source, f"{constant} vanished from the generator's luminance"
+        assert constant in js_source, (
+            f"the theme lab's luminance no longer uses {constant}; it has drifted from "
+            "generator/validate.py and its contrast badges can no longer be trusted"
+        )
+    assert "0.05" in python_source and "0.05" in js_source, (
+        "the contrast-ratio offset differs between the lab and the generator"
+    )
+
+
+def test_lab_gates_match_the_generators_accent_gates() -> None:
+    """The lab scores exactly the accent gates the generator enforces."""
+    from osprey.interfaces.design_system.generator.validate import WCAG_GATES
+
+    expected = {
+        f"{gate.foreground} vs {gate.background}": gate.minimum
+        for gate in WCAG_GATES
+        if gate.foreground.startswith("accent")
+    }
+    assert expected, "the generator no longer defines any accent gates"
+
+    found = {
+        name: float(threshold)
+        for name, threshold in re.findall(
+            r"\{\s*name:\s*'([^']+)',\s*threshold:\s*([0-9.]+)\s*\}", _theme_lab_source()
+        )
+    }
+
+    assert found == expected, (
+        "the theme lab's gates have drifted from generator/validate.py's WCAG_GATES.\n"
+        f"  generator: {expected}\n"
+        f"  theme lab: {found}\n"
+        "A colleague would be told their theme passes a check the build does not run, "
+        "or fails one it does not enforce."
+    )

--- a/tests/interfaces/design_system/test_theme_lab.py
+++ b/tests/interfaces/design_system/test_theme_lab.py
@@ -139,6 +139,11 @@ def test_mini_shell_is_instantiated_into_both_scopes(lab_page: Page) -> None:
 def test_accent_change_reskins_both_scopes_without_rebuilding(lab_page: Page) -> None:
     """A color change is a custom-property write, not a DOM rebuild."""
     before_dark = _scope_var(lab_page, "dark", "--color-accent")
+    # Captured too, and asserted below. Checking only "light is non-empty and
+    # differs from dark" would NOT catch a light scope that never gets written
+    # at all: it would still read the theme's own shipped accent out of
+    # tokens.css, which is non-empty and differs from whatever was typed.
+    before_light = _scope_var(lab_page, "light", "--color-accent")
 
     # Tag the existing node; if the mock were re-created the tag would vanish.
     lab_page.evaluate("document.querySelector('#preview-dark .ms-shell').dataset.sentinel = 'kept'")
@@ -149,7 +154,7 @@ def test_accent_change_reskins_both_scopes_without_rebuilding(lab_page: Page) ->
     after_light = _scope_var(lab_page, "light", "--color-accent")
 
     assert after_dark != before_dark, "the dark preview did not re-skin"
-    assert after_light != "", "the light preview has no accent"
+    assert after_light != before_light, "the light preview did not re-skin"
     assert after_dark != after_light, (
         "both modes derived the same accent; the per-mode lightness offset is not being applied"
     )


### PR DESCRIPTION
## What this adds

`osprey theme-lab` starts a small local server and opens a page where someone can pick an accent colour and see it applied live to schematic dark **and** light mock-ups of the web terminal. WCAG contrast badges score the choice as they go, and an **Export** button copies paste-ready markdown describing the theme and everything a developer must change to implement it.

The point is to let a colleague go from "I'd like a theme in this colour" to a concrete, implementable issue without knowing anything about the repository. The lab never writes theme files itself.

## How it works

- **Scoped previews.** `tokens.css` declares its theme blocks as bare `[data-theme="…"]` attribute selectors, so a `<div data-theme="light">` inside a dark page resolves the entire light token set with no JavaScript. Both previews are scoped containers; there is deliberately no theme-boot/theme-manager on the page, so a visitor's stored theme preference can't leak in.
- **Pure/impure split.** `js/theme-lab.js` holds the colour maths, accent derivation, WCAG scoring, slug rules and export text, and is import-safe with no dependencies — that is what the unit tests exercise. `js/theme-lab-ui.js` owns the DOM and is what the page loads.
- **No rebuilds.** The mock is cloned once per scope and the badge/token rows are built once; every subsequent update is a `setProperty` write or a `textContent` assignment, so the previews re-skin rather than flicker.
- **Derivation** follows the shipped `osprey` family as read off the generated `tokens.css`: tints and `border.accent` from the emphasis variant, `wt-accent-system-tint-04` from the base. `accent.on` is the lab's own rule — the highest-contrast of the scope's two primaries plus black and white.

## Correctness

The risk that matters is the lab telling someone their theme passes a check the build would reject, or the reverse.

- The lab's luminance and contrast functions were verified to agree with `generator/validate.py` **bit-for-bit** (identical to 10 decimal places across a range of pairs, including 21:1 and near-threshold cases). Two tests assert the WCAG constants and the accent gate thresholds stay in sync with `WCAG_GATES`; they need no browser, so they run in every lane.
- A **name-level** guard reads the committed `tokens.css` and fails if the design system grows an accent-named token the lab doesn't account for, or if the lab derives one that no longer exists. It carries exactly one exclusion (`--ansi-cursor-accent`, a near-background colour despite its name) and self-checks that its exclusions still match real tokens.
- A **value-level** guard takes each shipped theme's own declared accent colours out of the CSS and requires the rest of that block to match the lab's exported alpha constants — so re-basing the tints or moving a border alpha fails on either side. This closes a gap the name guard could not see and the maths spec could not either (it built its expectations with the same helpers it was checking).

## Review round

An adversarial review found five real defects; all are fixed in the last two commits:

- **`accent.on` was chosen from only the scope's own two primaries.** Five of the six shipped themes use neither, and the narrow set produced *false FAILs* — a mid grey clears 4.22:1 against both of dark's primaries but 4.62:1 against black, which the high-contrast family already ships. Direction was safe (it under-reported), but it told colleagues a usable colour was unusable.
- **The export's change set contradicted itself.** `accent.base`/`light`/`on` are `{color.ramp.step}` references, not literals; the old step 2 said to paste hex into all of them, which would orphan the step-1 ramp additions.
- **The export mis-attributed the inherits pattern** to both `apex` and `high-contrast`; `ariel.json` authors its own high-contrast groups.
- **The coverage guard compared names only** (fixed by the value-level guard above).
- **The browser test never asserted the *light* scope re-skinned** — it fell back to its own shipped accent, so the assertions held even if the light panel was never written.

Two nits were declined as not defects: no `try/catch` around `initLab` (a missing id is an editing mistake, and the console-error assertion catches it), and `parseColor` accepting alpha > 1 in legacy rgb (unreachable, since `rgbaCss` clamps).

## Notes for review

- Three planning assumptions didn't match the repository and were corrected rather than followed. The plan named `docs/screenshots/contact_sheet.py` as the source of truth for the accent maths — that file doesn't exist here, so the generated `tokens.css` was used. The plan described the shipped families as `main`/`retro`/`desy` and asked the theming docs to be "corrected" to say so; the real families are `osprey`, `apex` and `high-contrast`, the existing docs were already right, and they were left alone. The plan's export text described authoring per-theme `web_terminal.json` blocks; no shipped family does that, so the export teaches the inheritance pattern and states the `wt-accent-system-tint-04` consequence explicitly.
- **Known limitation, documented in the module:** the lab models the emphasis variant as a lightness shift only, so it cannot round-trip a hand-authored `accent.light` that also moves hue or saturation — the shipped osprey pair does exactly that. A lab proposal is internally consistent rather than a re-derivation of an existing theme, and the export carries explicit values either way.
- The Playwright suite is registered in the browser lane, which names its suites explicitly. Without that entry it would only ever meet a runner with no chromium and skip.
- `theme-lab.js` and `theme-lab-ui.js` are separate modules because eslint caps interface JS at 450 lines; keeping them separate also keeps the pure half dependency-free.

## Verification

- `pytest tests/interfaces/design_system/ tests/cli/` — 2316 passed, 1 skipped (pre-existing)
- `vitest run` — 899 passed; `tsc --noEmit`, `eslint .`, `ruff check`, `ruff format --check` all clean; docs build clean
- The browser tests were run against real chromium and mutation-tested (breaking the per-scope property write, and separately a gate threshold, fails them with clear messages); run five times for flakiness
- A wheel was built and inspected to confirm the page, its CSS/JS, the tokens and all shared fonts are packaged