### PR TITLE
fix(build): size the project-venv install cap to the download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,6 +334,12 @@ Compatibility is documented in release notes, not encoded in the version string.
   pointer. The timeline pane animated the same height the drag was setting, so it
   eased toward a target the cursor had already left and trailed by up to 85
   pixels for the whole gesture.
+- `osprey build` no longer aborts partway through creating a project's virtual
+  environment on a slow connection. Installing osprey's dependencies was capped
+  at five minutes, which a first-time download can exceed, and the build stopped
+  with an unexplained "Unexpected error". The limit is now generous enough for a
+  full download, and if it is ever reached the message names the install as the
+  step that ran long and suggests what to try.
 - Dispatched runs that delegate to a subagent now wait for the delegated work
   and return the full answer. Previously the reply could stop at "the agent is
   searching, I'll notify you when it completes" and nothing further arrived.

--- a/src/osprey/cli/build_environment.py
+++ b/src/osprey/cli/build_environment.py
@@ -733,6 +733,17 @@ def freeze_base_environment(python_path: Path, inherit_exclude: list[str]) -> li
     return pinned
 
 
+# Ceiling on the project-venv dependency install.
+#
+# This install pulls osprey's whole transitive tree into a fresh venv — around
+# 1.4 GB installed, from ~2.2 GB of wheels, on a cold cache. How long that takes
+# is a property of the network, not of the project, so the cap has to bound an
+# installer that is *stuck* rather than one that is merely slow. A tight cap
+# turns an ordinary cold-cache download into an abort that fires intermittently
+# and reads as flakiness rather than as a limit set too low.
+_VENV_INSTALL_TIMEOUT_S = 1800
+
+
 def _create_project_venv(project_path: Path, profile: Any) -> list[str]:
     """Create the project venv and install osprey + profile deps.
 
@@ -846,7 +857,24 @@ def _create_project_venv(project_path: Path, profile: Any) -> list[str]:
 
     spinner = Spinner("dots", text=f"  Installing osprey ({osprey_label}) + {dep_count} deps...")
     with Live(spinner, transient=True):
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=_VENV_INSTALL_TIMEOUT_S
+            )
+        except subprocess.TimeoutExpired as e:
+            # A bare TimeoutExpired escapes to build_cmd's catch-all and prints
+            # "Unexpected error", naming neither the step nor a way forward.
+            raise BuildProfileError(
+                f"installing osprey + {dep_count} deps into the project venv did not "
+                f"finish within {_VENV_INSTALL_TIMEOUT_S // 60} minutes.\n"
+                "        This install downloads osprey's full dependency tree (over a "
+                "gigabyte on a cold cache), so a slow or interrupted connection is the "
+                "usual cause.\n"
+                "        Re-running the build resumes from what already downloaded — "
+                "completed packages are served from the local cache.\n"
+                "        On a slow or restricted link, point the build at a closer "
+                "package mirror (UV_INDEX_URL, or PIP_INDEX_URL without uv)."
+            ) from e
 
     if result.returncode == 0:
         logger.info("  ✓ Installed osprey + %d profile deps into project venv", dep_count)

--- a/tests/cli/test_build_venv_install_timeout.py
+++ b/tests/cli/test_build_venv_install_timeout.py
@@ -1,0 +1,115 @@
+"""The project-venv install must tolerate a large, slow dependency download.
+
+``osprey build`` installs osprey and its whole transitive dependency tree into
+the freshly created project venv. That tree is well over a gigabyte of wheels
+(claude-agent-sdk, playwright, llvmlite, pyarrow, scipy, litellm ... measured at
+~1.4 GB installed from ~2.2 GB of downloads), so on a cold cache or a slow link
+the install is *legitimately* a multi-minute operation.
+
+The cap on that subprocess therefore has to bound a **hung** installer, not a
+slow one. A cap tight enough to fire on an ordinary cold-cache download turns a
+working build into an abort — and because the download time is a property of the
+network rather than of the project, it fires intermittently and looks like
+flakiness rather than a misconfigured limit.
+
+When the cap does fire it must also say so in terms the operator can act on:
+:func:`_create_project_venv` raising a bare ``subprocess.TimeoutExpired`` lands
+in ``build_cmd``'s catch-all and prints "Unexpected error", which names neither
+the step that timed out nor anything to do about it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from osprey.cli.build_environment import _create_project_venv
+from osprey.cli.build_profile import BuildProfile, EnvironmentConfig
+from osprey.errors import BuildProfileError
+
+# A full cold-cache install of osprey's dependency tree is a >1 GB download.
+# Fifteen minutes is the floor at which the cap is bounding a hung installer
+# rather than a slow network; the shipped value may be more generous still.
+MIN_INSTALL_TIMEOUT_S = 900
+
+
+def _profile() -> BuildProfile:
+    """A minimal profile that installs osprey from a pinned release spec."""
+    return BuildProfile(
+        name="test",
+        dependencies=[],
+        osprey_install="osprey-framework==1.2.3",
+        environment=EnvironmentConfig(python=None, packages=[]),
+    )
+
+
+def _is_install(cmd: list[str]) -> bool:
+    """True for the dependency-install call, not the venv-creation call."""
+    return "install" in cmd
+
+
+@pytest.fixture
+def with_uv(monkeypatch) -> str:
+    """Pin the uv branch so the install command shape is deterministic."""
+    uv = "/usr/bin/uv"
+    monkeypatch.setattr("osprey.cli.build_environment.shutil.which", lambda _: uv)
+    monkeypatch.delenv("UV", raising=False)
+    return uv
+
+
+def test_install_timeout_allows_a_full_dependency_download(with_uv, monkeypatch, tmp_path):
+    """The install subprocess gets a cap sized for a >1 GB download."""
+    seen: list[tuple[list[str], dict]] = []
+
+    def fake_run(cmd, **kwargs):
+        seen.append((cmd, kwargs))
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("osprey.cli.build_environment.subprocess.run", fake_run)
+
+    _create_project_venv(tmp_path, _profile())
+
+    install_calls = [(cmd, kw) for cmd, kw in seen if _is_install(cmd)]
+    assert install_calls, f"no install call recorded; saw {[c for c, _ in seen]}"
+    _, kwargs = install_calls[0]
+    assert kwargs["timeout"] >= MIN_INSTALL_TIMEOUT_S, (
+        f"the project-venv install is capped at {kwargs['timeout']}s, which a "
+        "cold-cache download of osprey's dependency tree can exceed on a slow "
+        "link — the cap must bound a hung installer, not a slow one"
+    )
+
+
+def test_install_timeout_is_reported_as_an_actionable_build_error(with_uv, monkeypatch, tmp_path):
+    """A timed-out install raises BuildProfileError naming the step and a remedy."""
+
+    def fake_run(cmd, **kwargs):
+        if _is_install(cmd):
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout", 0))
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("osprey.cli.build_environment.subprocess.run", fake_run)
+
+    with pytest.raises(BuildProfileError) as excinfo:
+        _create_project_venv(tmp_path, _profile())
+
+    message = str(excinfo.value)
+    assert "project venv" in message.lower(), message
+    # The operator needs to know it was the dependency install that ran long,
+    # not merely that "something" timed out.
+    assert "install" in message.lower(), message
+
+
+def test_venv_creation_failure_still_reports_its_own_error(with_uv, monkeypatch, tmp_path):
+    """Guard: the install-timeout handling does not swallow venv-creation errors."""
+
+    def fake_run(cmd, **kwargs):
+        if _is_install(cmd):
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+        return subprocess.CompletedProcess(args=cmd, returncode=1, stdout="", stderr="boom")
+
+    monkeypatch.setattr("osprey.cli.build_environment.subprocess.run", fake_run)
+
+    with pytest.raises(BuildProfileError, match="Failed to create project venv"):
+        _create_project_venv(Path(tmp_path), _profile())

--- a/tests/integration/test_build_boot.py
+++ b/tests/integration/test_build_boot.py
@@ -111,7 +111,14 @@ def build_outputs(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Path]:
             cmd,
             capture_output=True,
             text=True,
-            timeout=600,
+            # The build's own dependency install is the long pole: it downloads
+            # osprey's whole tree into the project venv, which on a hosted
+            # runner's cold cache is a multi-minute transfer that macOS runners
+            # have been observed to stretch past five minutes. This budget sits
+            # above the build's internal install cap's realistic range so a slow
+            # download surfaces as the build's own diagnostic rather than as an
+            # opaque timeout here, and fails only on a genuinely stuck build.
+            timeout=1200,
             env={**os.environ, "CLAUDECODE": ""},
         )
         if proc.returncode != 0:


### PR DESCRIPTION
## What

`osprey build` creates the project virtual environment and installs osprey plus the profile's dependencies into it. That install was capped at 300 seconds.

The install pulls osprey's whole transitive dependency tree into a fresh venv — measured at ~1.4 GB installed, from ~2.2 GB of wheels, on a cold cache. Five minutes is inside the range an ordinary first-time download takes, so the build aborted partway through whenever the transfer ran long.

Two consequences:

- **It failed intermittently.** How long the download takes is a property of the network, not of the project, so the same build succeeded or failed depending on conditions at the time. Hosted macOS runners straddle the old limit and crossed it in roughly a quarter of runs.
- **The failure was unreadable.** `subprocess.TimeoutExpired` propagated to the catch-all in `build_cmd`, which printed `✗ Unexpected error: ... timed out after 300 seconds` — naming neither the step that ran long nor anything to do about it.

## Change

- The install cap now bounds an installer that is *stuck* rather than one that is merely slow, with the reasoning recorded next to the constant.
- A timeout raises `BuildProfileError` identifying the dependency install as the step that ran long, and pointing at a retry (completed packages are served from the local cache) or a closer package index.
- The `test_build_boot` fixture's own budget moves above the range the install can legitimately need, so a slow download surfaces as the build's own diagnostic instead of an opaque timeout in the harness.

## Tests

`tests/cli/test_build_venv_install_timeout.py` covers the cap being sized for a large download, the timeout being reported as an actionable build error, and a guard that venv-creation failures still report their own error.

Verified locally: new tests fail before the change and pass after; `tests/cli/` and the CI-wiring guard pass (2012 tests); `tests/integration/test_build_boot.py` passes against real builds; mypy, `ruff check`, and `ruff format --check` clean.

## Not addressed here

A `hello-world` project venv installs ~1.4 GB, including playwright, llvmlite, pyarrow, googleapiclient, scikit-learn and plotly. Whether the minimal preset should carry that footprint is a dependency-architecture question, deliberately left out of scope.