### PR TITLE
fix(build): reject unservable model selections at build and deploy time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ## [Unreleased]
 
+### Fixed
+
+- `osprey build` now fails with an actionable error when
+  `claude_code.default_model` (e.g. `--set model=...`) names a model the
+  selected provider does not serve. Previously the build only warned and the
+  deployed web terminals crash-looped behind the reverse proxy (502).
+
 ### Added
 
 - New `osprey.bridges.core` package: a channel-agnostic engine for connecting a

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -665,6 +665,18 @@ def build(
                 "Agent tool/permission drift detected:\n  " + "\n  ".join(validation_errors)
             )
 
+        # 16d. Validate the model selection against the rendered provider map.
+        # The web terminal runs the same resolver strict at startup, so a value
+        # that only warns here would deploy per-user terminals that crash-loop
+        # behind the reverse proxy. Failing the build stops the
+        # `build && deploy` chain at the checkpoint the operator watches.
+        from osprey.build.claude_code_resolver import load_provider_spec
+
+        try:
+            load_provider_spec(project_path)
+        except ValueError as e:
+            raise BuildProfileError(str(e)) from e
+
         # 17. Git init + commit
         _git_init_and_commit(project_path)
 

--- a/src/osprey/deployment/web_terminals/persona_images.py
+++ b/src/osprey/deployment/web_terminals/persona_images.py
@@ -14,6 +14,7 @@ import sys
 from pathlib import Path
 from typing import cast
 
+from osprey.build.claude_code_resolver import load_provider_spec
 from osprey.deployment.compose_generator import (
     _copy_local_framework_for_override,
     resolve_project_name,
@@ -298,7 +299,22 @@ def auto_render_missing_personas(
                     "directory and re-run `osprey deploy up` to re-render it, or "
                     "rebuild it with `osprey build`."
                 )
-            # Complete render is user-owned -- never overwrite it.
+            # Complete render is user-owned -- never overwrite it. But do
+            # validate that its model selection still resolves: the web
+            # terminal runs the same resolver strict at startup, so a stale
+            # model baked in by an earlier parent build (existing renders
+            # never inherit new `--set` overrides) would otherwise ship a
+            # container that crash-loops behind the reverse proxy (502).
+            try:
+                load_provider_spec(project_path)
+            except ValueError as e:
+                raise ValueError(
+                    f"Persona {persona_name!r} render at {project_path} has a "
+                    f"model configuration its provider cannot serve:\n  {e}\n"
+                    f"Fix {project_path / 'config.yml'}, or remove that "
+                    "directory and re-run `osprey deploy up` to re-render it "
+                    "from the parent build's settings."
+                ) from e
             continue
 
         build_profile = unit["build_profile"]

--- a/tests/cli/test_build_preset.py
+++ b/tests/cli/test_build_preset.py
@@ -1282,6 +1282,37 @@ class TestDeployServicesKnob:
         assert not (tmp_path / "op" / "services").exists()
 
 
+def test_set_unservable_model_fails_build(
+    runner: CliRunner, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A model the selected provider cannot serve must fail the build itself.
+
+    The web-terminal container runs the same resolver strict at startup, so a
+    build that merely warns here ships a deploy whose per-user terminals
+    crash-loop behind the reverse proxy (502). The build is the checkpoint the
+    operator actually watches — it must stop the `build && deploy` chain.
+    """
+    with caplog.at_level(logging.ERROR):
+        result = runner.invoke(
+            build,
+            [
+                "smoke",
+                "--preset",
+                "hello-world",
+                "--set",
+                "provider=als-apg",
+                "--set",
+                "model=anthropic/claude-opus",
+                "--skip-deps",
+                "--skip-lifecycle",
+                "--output-dir",
+                str(tmp_path),
+            ],
+        )
+    assert result.exit_code != 0, result.output
+    _assert_build_error_logged(caplog, "neither a model tier nor a model id")
+
+
 def test_set_value_invalid_yaml_raises() -> None:
     """A --set value that isn't valid YAML raises BuildProfileError, not a YAMLError."""
     with pytest.raises(BuildProfileError, match="is not valid YAML"):

--- a/tests/cli/test_inject_nextcloud_bridge.py
+++ b/tests/cli/test_inject_nextcloud_bridge.py
@@ -45,7 +45,7 @@ _PROFILE_YAML = """\
 name: NcBridgeTest
 data_bundle: hello_world
 provider: anthropic
-model: claude-haiku-4-5
+model: haiku
 dispatch:
   triggers: triggers.yml
 {nextcloud_bridge}
@@ -402,7 +402,7 @@ def test_full_build_bridge_without_dispatch_block_aborts(
     profile_dir.mkdir()
     (profile_dir / "profile.yml").write_text(
         "name: NcNoDispatch\ndata_bundle: hello_world\nprovider: anthropic\n"
-        "model: claude-haiku-4-5\nnextcloud_bridge: {}\n",
+        "model: haiku\nnextcloud_bridge: {}\n",
         encoding="utf-8",
     )
     with caplog.at_level(logging.ERROR):

--- a/tests/deployment/web_terminals/test_persona_images.py
+++ b/tests/deployment/web_terminals/test_persona_images.py
@@ -518,6 +518,34 @@ def test_auto_render_complete_render_is_noop(monkeypatch, tmp_path):
     assert calls == []
 
 
+def test_auto_render_existing_render_with_unservable_model_raises(monkeypatch, tmp_path):
+    """A complete persona render whose config names a model its provider cannot
+    serve must fail the deploy here, with the path and a remedy — not boot a
+    web-terminal container that crash-loops behind the reverse proxy (502).
+    An existing render is user-owned and never re-rendered, so a stale model
+    baked in by an earlier parent build would otherwise persist forever."""
+    project_path = tmp_path / "ops-app"
+    project_path.mkdir()
+    (project_path / "config.yml").write_text(
+        "project_name: ops-app\n"
+        "claude_code:\n"
+        "  provider: anthropic\n"
+        "  default_model: anthropic/claude-opus\n",
+        encoding="utf-8",
+    )
+    (project_path / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    config = _auto_render_config(tmp_path)
+    calls = []
+    monkeypatch.setattr(persona_images.subprocess, "run", lambda cmd, **k: calls.append(cmd))
+
+    with pytest.raises(ValueError, match="neither a model tier nor a model ID") as excinfo:
+        persona_images.auto_render_missing_personas(config, _AUTO_RENDER_USERS, {})
+
+    assert str(project_path) in str(excinfo.value)
+    assert "remove" in str(excinfo.value).lower()  # remedy: fix or remove the render
+    assert calls == []  # never rendered over the user-owned tree
+
+
 def test_auto_render_missing_build_profile_raises(monkeypatch, tmp_path):
     """project_path absent (a render IS needed) but the catalog entry has no
     build_profile -> raise, since there's nothing to render from."""


### PR DESCRIPTION
An unservable `claude_code.default_model` (e.g. `--set model=anthropic/claude-opus` with a provider that serves `haiku|sonnet|opus`) used to produce only a build-time warning; the strict check first ran inside the deployed web-terminal containers, which then crash-looped behind the reverse proxy and answered 502 on every per-user page while the deploy reported green.

Two fail-loud gates, both delegating to `load_provider_spec` — the exact resolver the web terminal runs at startup, so what build/deploy accept and what containers can boot can never drift:

- `osprey build` aborts with the resolver's actionable message when the model selection cannot resolve against the rendered provider map, stopping a `build && deploy` chain at the build.
- `osprey deploy up` validates existing persona renders the same way. An existing render is user-owned and never re-rendered, so a stale model baked in by an earlier parent build would otherwise persist indefinitely; the error names the config file and the remedy (fix it, or remove the directory to re-render from the parent's settings).

Also fixes test fixtures that carried an unservable model ID (`claude-haiku-4-5`) — the same latent bug class the gate now catches.