### PR TITLE
feat(build): explicit MCP transport key for URL servers

### DIFF
--- a/docs/source/how-to/build-profiles.rst
+++ b/docs/source/how-to/build-profiles.rst
@@ -434,6 +434,26 @@ configuration) and ``.claude/settings.json`` (tool permissions) — so a later
          allow: ["safe_tool"]
          ask: ["write_tool"]
 
+Remote servers declare a ``url`` instead of a ``command``, plus an optional
+``transport`` — ``http`` (streamable-HTTP, the default) or ``sse`` (legacy
+Server-Sent Events):
+
+.. code-block:: yaml
+
+   mcp_servers:
+     matlab:
+       transport: http
+       url: "http://localhost:8008/mcp"
+       permissions:
+         allow: ["mml_search"]
+     legacy_api:
+       transport: sse
+       url: "http://appsdev2:8001/sse"
+
+``command`` and ``url`` are mutually exclusive, and stdio servers must not set
+``transport`` (launching via ``command`` *is* the transport) — the profile
+loader rejects both combinations at load time.
+
 **Placeholder resolution:**
 
 - ``{project_root}`` — resolved at **build time** to the absolute project path

--- a/src/osprey/cli/build_persistence.py
+++ b/src/osprey/cli/build_persistence.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from osprey.utils.logger import get_logger
 
@@ -175,10 +176,14 @@ def _persist_mcp_servers(project_path: Path, mcp_servers: dict[str, Any]) -> Non
 
         spec: dict[str, Any] = {}
         if server.url:
-            spec["transport"] = "http"
+            # Written explicitly (even for the default) so the rendered
+            # config.yml states its wire transport instead of implying it —
+            # _custom_server_from_spec() reads this key back during regen.
+            spec["transport"] = server.transport
             spec["url"] = server.url
         else:
-            spec["transport"] = "stdio"
+            # Stdio servers get no transport key: launching via 'command' IS
+            # the transport, and load_profile rejects a declared one.
             if server.command:
                 spec["command"] = server.command
             if server.args:
@@ -188,16 +193,18 @@ def _persist_mcp_servers(project_path: Path, mcp_servers: dict[str, Any]) -> Non
         if server.port is not None and server.url:
             # Emit a derived network block so non-Claude consumers
             # (compose-port checkers, integration-tests probes) can read
-            # host/docker URLs without re-deriving them.
+            # host/docker URLs without re-deriving them. The endpoint path
+            # follows the declared url (an SSE server's stream is not /mcp).
             # NOTE: docker_url uses the MCP server's YAML key (`name`) as the
             # container hostname. This assumes the operator names the
             # docker-compose service identically to the mcp_servers entry
             # (e.g. mcp_servers.matlab → service: matlab). If they diverge,
             # docker_url will point at a non-existent host.
+            path = urlparse(server.url).path or "/mcp"
             spec["network"] = {
                 "port": int(server.port),
-                "host_url": f"http://localhost:{server.port}/mcp",
-                "docker_url": f"http://{name}:{server.port}/mcp",
+                "host_url": f"http://localhost:{server.port}{path}",
+                "docker_url": f"http://{name}:{server.port}{path}",
             }
         if server.permissions:
             spec["permissions"] = dict(server.permissions)

--- a/src/osprey/cli/build_profile_load.py
+++ b/src/osprey/cli/build_profile_load.py
@@ -208,6 +208,22 @@ def _parse_profile(raw: dict[str, Any]) -> BuildProfile:
             raise BuildProfileError(
                 f"MCP server '{name}' has both 'command' and 'url' — use one or the other"
             )
+        transport = sdef.get("transport", "http")
+        if transport not in ("http", "sse"):
+            raise BuildProfileError(
+                f"MCP server '{name}' transport must be 'http' or 'sse' (got {transport!r})"
+            )
+        if "transport" in sdef and command:
+            raise BuildProfileError(
+                f"MCP server '{name}' declares 'transport' with 'command' — stdio "
+                "servers have no transport choice"
+            )
+        if transport == "sse" and not url:
+            # The port-derived URL below is a streamable-HTTP /mcp endpoint;
+            # an SSE server must spell out where its event stream lives.
+            raise BuildProfileError(
+                f"MCP server '{name}' transport 'sse' requires an explicit 'url'"
+            )
         if port is not None and command:
             raise BuildProfileError(
                 f"MCP server '{name}' has both 'command' and 'port' — stdio servers cannot declare a port"
@@ -227,6 +243,7 @@ def _parse_profile(raw: dict[str, Any]) -> BuildProfile:
                 "ask": perms.get("ask", []),
             },
             url=url,
+            transport=transport,
             port=port,
         )
 

--- a/src/osprey/cli/build_profile_schema.py
+++ b/src/osprey/cli/build_profile_schema.py
@@ -28,7 +28,11 @@ class McpServerDef:
     env: dict[str, str] = field(default_factory=dict)
     permissions: dict[str, list[str]] = field(default_factory=dict)
     # permissions: {"allow": ["tool1"], "ask": ["tool2"]}
-    url: str | None = None  # HTTP/SSE transport URL (mutually exclusive with command)
+    url: str | None = None  # Remote transport URL (mutually exclusive with command)
+    # Wire transport for URL servers: "http" (streamable-HTTP, the default) or
+    # "sse" (legacy Server-Sent Events). Stdio servers (command) must not set
+    # it — load_profile rejects that.
+    transport: str = "http"
     # Single port the HTTP MCP service binds AND publishes. Compose maps
     # host:port → container:port 1:1, so consumers can derive every URL
     # variant from this single value. Mutually exclusive with command;

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -60,7 +60,10 @@ class ServerDefinition:
     is_external: bool = False
     external_command: str | None = None
     external_args: list[str] = field(default_factory=list)
-    url: str | None = None  # HTTP/SSE transport URL (mutually exclusive with command)
+    url: str | None = None  # Remote transport URL (mutually exclusive with command)
+    # Wire transport for URL servers: "http" (streamable-HTTP) or "sse"
+    # (legacy Server-Sent Events). Meaningless for stdio servers.
+    transport: str = "http"
     port: int | None = (
         None  # Host/container port for HTTP servers; informational for non-Claude consumers
     )
@@ -506,8 +509,9 @@ def resolve_servers(claude_code_config: dict, ctx: dict) -> list[dict]:
 
     Returns:
         List of plain dicts, each representing one server with keys:
-        name, enabled, command, args, env, permissions_allow, permissions_ask,
-        fixed_allow, hooks_pre, hooks_post, is_custom.
+        name, enabled, url, transport (``"http"``/``"sse"`` for URL servers,
+        ``None`` for stdio), command, args, env, permissions_allow,
+        permissions_ask, fixed_allow, hooks_pre, hooks_post, is_custom.
     """
     servers: dict[str, ServerDefinition] = {
         k: copy.deepcopy(v) for k, v in FRAMEWORK_SERVERS.items()
@@ -569,7 +573,9 @@ def resolve_servers(claude_code_config: dict, ctx: dict) -> list[dict]:
                     name,
                 )
                 continue
-            servers[name] = _custom_server_from_spec(name, spec)
+            custom = _custom_server_from_spec(name, spec)
+            if custom is not None:
+                servers[name] = custom
 
     # ── Build output dicts ────────────────────────────────────
     result = []
@@ -727,9 +733,38 @@ def build_extended_server(name: str, spec: dict) -> ServerDefinition | None:
     return clone
 
 
-def _custom_server_from_spec(name: str, spec: dict) -> ServerDefinition:
-    """Build a ServerDefinition from a new-format config spec."""
+#: Valid ``transport`` values for URL-based custom servers.
+VALID_TRANSPORTS = ("http", "sse")
+
+
+def _custom_server_from_spec(name: str, spec: dict) -> ServerDefinition | None:
+    """Build a ServerDefinition from a new-format config spec.
+
+    Returns ``None`` (after a logged warning) for an invalid ``transport``
+    value — silently defaulting a typo like ``trasnport: ssse`` to HTTP would
+    ship a server that can never connect, so the spec is rejected loudly
+    instead (matches the missing-command/url handling in resolve_servers).
+    """
     perms = spec.get("permissions", {})
+
+    transport = spec.get("transport", "http")
+    if spec.get("url"):
+        if transport not in VALID_TRANSPORTS:
+            logger.warning(
+                "Server %r has invalid transport %r — must be one of %s; skipping",
+                name,
+                transport,
+                "/".join(VALID_TRANSPORTS),
+            )
+            return None
+    elif "transport" in spec:
+        # A command server is structurally stdio — there is no transport choice.
+        logger.warning(
+            "Server %r declares 'transport' but launches via 'command' — stdio "
+            "servers have no transport choice; ignoring the key",
+            name,
+        )
+        transport = "http"
 
     # Resolve pre-tool-use hook presets
     hooks_pre: list[HookRule] = []
@@ -753,6 +788,7 @@ def _custom_server_from_spec(name: str, spec: dict) -> ServerDefinition:
         external_command=spec.get("command", ""),
         external_args=spec.get("args", []),
         url=spec.get("url"),
+        transport=transport,
         port=spec.get("port"),
         permissions_allow=perms.get("allow", []),
         permissions_ask=perms.get("ask", []),
@@ -794,6 +830,9 @@ def _server_to_dict(sdef: ServerDefinition, ctx: dict) -> dict:
         "name": sdef.name,
         "enabled": sdef.default_enabled,
         "url": url,
+        # Transport only means something for URL servers; None for stdio so a
+        # consumer can never mistake a command server for an HTTP one.
+        "transport": sdef.transport if url else None,
         "command": command,
         "args": args,
         "env": env,

--- a/src/osprey/templates/apps/control_assistant/README.md.j2
+++ b/src/osprey/templates/apps/control_assistant/README.md.j2
@@ -585,14 +585,14 @@ deployed_services:
 uv run osprey deploy up
 ```
 
-3. Configure Claude Desktop (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+3. Point your MCP client at the server (e.g. a Claude Code project's `.mcp.json`):
 
 ```json
 {
   "mcpServers": {
     "channel-finder": {
-      "transport": "sse",
-      "url": "http://localhost:8051/sse"
+      "type": "http",
+      "url": "http://localhost:8051/mcp"
     }
   }
 }

--- a/src/osprey/templates/claude_code/mcp.json.j2
+++ b/src/osprey/templates/claude_code/mcp.json.j2
@@ -1,7 +1,7 @@
 {%- set server_blocks = [] -%}
 {%- for s in servers if s.enabled -%}
 {%- if s.url -%}
-{%- set block = {"type": "http", "url": s.url} -%}
+{%- set block = {"type": s.transport, "url": s.url} -%}
 {%- else -%}
 {%- set block = {"command": s.command, "args": s.args} -%}
 {%- if s.env -%}{%- set _ = block.update({"env": s.env}) -%}{%- endif -%}

--- a/tests/cli/test_build_cmd.py
+++ b/tests/cli/test_build_cmd.py
@@ -688,7 +688,7 @@ class TestBuildHelpers:
             load_profile(p)
 
     def test_persist_mcp_servers_port_emits_network_block(self, tmp_path: Path):
-        """_persist_mcp_servers emits transport=http + network block when port is set."""
+        """_persist_mcp_servers emits transport + url + network block when port is set."""
         from osprey.cli.build_cmd import _persist_mcp_servers
 
         project_path = tmp_path / "project"
@@ -706,14 +706,16 @@ class TestBuildHelpers:
 
         config = yaml.safe_load((project_path / "config.yml").read_text())
         entry = config["claude_code"]["servers"]["matlab"]
+        # The default is written explicitly — the rendered config states its
+        # wire transport instead of implying it from the url's presence.
         assert entry["transport"] == "http"
         assert entry["url"] == "http://localhost:8008/mcp"
         assert entry["network"]["port"] == 8008
         assert entry["network"]["host_url"] == "http://localhost:8008/mcp"
         assert entry["network"]["docker_url"] == "http://matlab:8008/mcp"
 
-    def test_persist_mcp_servers_stdio_emits_transport_stdio(self, tmp_path: Path):
-        """Stdio servers get transport=stdio and no network block."""
+    def test_persist_mcp_servers_stdio_emits_command_only(self, tmp_path: Path):
+        """Stdio servers get command/args and no network block."""
         from osprey.cli.build_cmd import _persist_mcp_servers
 
         project_path = tmp_path / "project"
@@ -730,12 +732,13 @@ class TestBuildHelpers:
 
         config = yaml.safe_load((project_path / "config.yml").read_text())
         entry = config["claude_code"]["servers"]["confluence"]
-        assert entry["transport"] == "stdio"
+        # Stdio has no transport choice — the key must not appear.
+        assert "transport" not in entry
         assert entry["command"] == "uvx"
         assert "network" not in entry
 
     def test_persist_mcp_servers_url_without_port_no_network_block(self, tmp_path: Path):
-        """A url-only server (no port hint) gets transport=http but no network block."""
+        """A url-only server (no port hint) gets no network block."""
         from osprey.cli.build_cmd import _persist_mcp_servers
 
         project_path = tmp_path / "project"
@@ -752,6 +755,30 @@ class TestBuildHelpers:
         assert entry["transport"] == "http"
         assert entry["url"] == "http://appsdev2:8008/mcp"
         assert "network" not in entry
+
+    def test_persist_mcp_servers_sse_transport_and_network_path(self, tmp_path: Path):
+        """An SSE server persists transport=sse; network URLs follow the url's path."""
+        from osprey.cli.build_cmd import _persist_mcp_servers
+
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        (project_path / "config.yml").write_text("facility_name: test\n")
+
+        servers = {
+            "legacy": McpServerDef(
+                url="http://localhost:9000/sse",
+                transport="sse",
+                port=9000,
+            ),
+        }
+        _persist_mcp_servers(project_path, servers)
+
+        config = yaml.safe_load((project_path / "config.yml").read_text())
+        entry = config["claude_code"]["servers"]["legacy"]
+        assert entry["transport"] == "sse"
+        assert entry["url"] == "http://localhost:9000/sse"
+        assert entry["network"]["host_url"] == "http://localhost:9000/sse"
+        assert entry["network"]["docker_url"] == "http://legacy:9000/sse"
 
     def test_apply_config_overrides(self, tmp_path: Path):
         """_apply_config_overrides should update config.yml fields."""

--- a/tests/cli/test_build_profile_parse.py
+++ b/tests/cli/test_build_profile_parse.py
@@ -64,6 +64,57 @@ def test_mcp_server_with_empty_command_and_url_raises() -> None:
         _parse_profile({"name": "x", "mcp_servers": {"empty": {"command": "", "url": ""}}})
 
 
+def test_mcp_server_transport_defaults_to_http() -> None:
+    """A URL server without a transport key parses as streamable-HTTP."""
+    profile = _parse_profile({"name": "x", "mcp_servers": {"api": {"url": "http://host:9000/mcp"}}})
+    assert profile.mcp_servers["api"].transport == "http"
+
+
+def test_mcp_server_transport_sse_parses() -> None:
+    """An explicit transport: sse with a url is accepted and carried through."""
+    profile = _parse_profile(
+        {
+            "name": "x",
+            "mcp_servers": {"legacy": {"transport": "sse", "url": "http://host:9000/sse"}},
+        }
+    )
+    assert profile.mcp_servers["legacy"].transport == "sse"
+
+
+def test_mcp_server_invalid_transport_raises() -> None:
+    """A transport outside http/sse raises, naming the bad value."""
+    with pytest.raises(
+        BuildProfileError, match="MCP server 'typo' transport must be 'http' or 'sse'"
+    ):
+        _parse_profile(
+            {
+                "name": "x",
+                "mcp_servers": {"typo": {"transport": "ssse", "url": "http://host:9000/mcp"}},
+            }
+        )
+
+
+def test_mcp_server_transport_with_command_raises() -> None:
+    """Stdio servers have no transport choice — declaring one is rejected."""
+    with pytest.raises(
+        BuildProfileError, match="MCP server 'local' declares 'transport' with 'command'"
+    ):
+        _parse_profile(
+            {
+                "name": "x",
+                "mcp_servers": {"local": {"transport": "http", "command": "uvx"}},
+            }
+        )
+
+
+def test_mcp_server_sse_requires_explicit_url() -> None:
+    """transport: sse with only a port raises — the derived URL is an /mcp endpoint."""
+    with pytest.raises(
+        BuildProfileError, match="MCP server 'legacy' transport 'sse' requires an explicit 'url'"
+    ):
+        _parse_profile({"name": "x", "mcp_servers": {"legacy": {"transport": "sse", "port": 9000}}})
+
+
 # ── services: ────────────────────────────────────────────────────────────────
 
 

--- a/tests/cli/test_claude_regen.py
+++ b/tests/cli/test_claude_regen.py
@@ -727,21 +727,28 @@ class TestDisableServers:
         assert "mcp__my-server__do_stuff" in ask
 
     def test_regen_preserves_url_servers(self, tmp_path):
-        """URL/SSE servers in config.yml survive regen and appear in .mcp.json."""
+        """URL servers in config.yml survive regen; transport drives .mcp.json's type."""
         project_dir, _ = self._create_and_regen(
             tmp_path,
             custom_servers={
                 "remote-api": {
-                    "url": "http://remote:8001/sse",
+                    "url": "http://remote:8001/mcp",
                     "permissions": {"allow": ["search"]},
-                }
+                },
+                "legacy-api": {
+                    "transport": "sse",
+                    "url": "http://remote:8002/sse",
+                },
             },
         )
 
         mcp_data = json.loads((project_dir / ".mcp.json").read_text())
-        assert "remote-api" in mcp_data["mcpServers"]
+        # No transport key → streamable-HTTP default.
         entry = mcp_data["mcpServers"]["remote-api"]
-        assert entry == {"type": "http", "url": "http://remote:8001/sse"}
+        assert entry == {"type": "http", "url": "http://remote:8001/mcp"}
+        # Explicit transport: sse → rendered as an SSE server.
+        entry = mcp_data["mcpServers"]["legacy-api"]
+        assert entry == {"type": "sse", "url": "http://remote:8002/sse"}
 
         # Permissions should be in settings.json
         settings = json.loads((project_dir / ".claude" / "settings.json").read_text())

--- a/tests/health/test_derive.py
+++ b/tests/health/test_derive.py
@@ -74,7 +74,7 @@ def _server(
         network["host_url"] = host_url
     if docker_url is not None:
         network["docker_url"] = docker_url
-    entry: dict[str, Any] = {"transport": "http", "url": url, "network": network}
+    entry: dict[str, Any] = {"url": url, "network": network}
     if permissions is not None:
         entry["permissions"] = permissions
     return entry
@@ -226,12 +226,12 @@ def test_permissions_non_mapping_treated_as_absent_but_check_emitted():
         pytest.param({"bad": "not-a-mapping"}, id="non_mapping_entry"),
         pytest.param({"bad": _server(url="")}, id="empty_url"),
         pytest.param(
-            {"bad": {"transport": "http", "network": {"host_url": "http://x/mcp"}}},
+            {"bad": {"network": {"host_url": "http://x/mcp"}}},
             id="missing_url",
         ),
-        pytest.param({"bad": {"transport": "http", "url": "http://x/mcp"}}, id="missing_network"),
+        pytest.param({"bad": {"url": "http://x/mcp"}}, id="missing_network"),
         pytest.param(
-            {"bad": {"transport": "http", "url": "http://x/mcp", "network": "nope"}},
+            {"bad": {"url": "http://x/mcp", "network": "nope"}},
             id="non_mapping_network",
         ),
         pytest.param({"bad": _server(host_url=None)}, id="missing_network_url_key"),

--- a/tests/registry/test_mcp.py
+++ b/tests/registry/test_mcp.py
@@ -77,13 +77,13 @@ class TestResolveServers:
         assert s["permissions_ask"] == ["write_data"]
         assert s["is_custom"] is True
 
-    def test_resolve_custom_server_url_transport(self):
-        """Custom URL/SSE server resolves with url field, empty command."""
+    def test_resolve_custom_server_url_defaults_to_http_transport(self):
+        """A URL server without a transport key resolves as streamable-HTTP."""
         ctx = _base_ctx()
         cfg = {
             "servers": {
                 "remote-api": {
-                    "url": "http://remote:8001/sse",
+                    "url": "http://remote:8001/mcp",
                     "permissions": {"allow": ["search"], "ask": []},
                 }
             }
@@ -92,11 +92,70 @@ class TestResolveServers:
         remote = [s for s in servers if s["name"] == "remote-api"]
         assert len(remote) == 1
         s = remote[0]
-        assert s["url"] == "http://remote:8001/sse"
+        assert s["url"] == "http://remote:8001/mcp"
+        assert s["transport"] == "http"
         assert s["command"] == ""
         assert s["args"] == []
         assert s["permissions_allow"] == ["search"]
         assert s["is_custom"] is True
+
+    def test_resolve_custom_server_sse_transport(self):
+        """transport: sse on a URL server carries through to the resolved dict."""
+        ctx = _base_ctx()
+        cfg = {
+            "servers": {
+                "legacy-api": {
+                    "transport": "sse",
+                    "url": "http://remote:8001/sse",
+                }
+            }
+        }
+        servers = resolve_servers(cfg, ctx)
+        (s,) = [s for s in servers if s["name"] == "legacy-api"]
+        assert s["transport"] == "sse"
+        assert s["url"] == "http://remote:8001/sse"
+
+    def test_resolve_custom_server_invalid_transport_skipped(self, caplog):
+        """An invalid transport value rejects the server loudly (no silent http)."""
+        ctx = _base_ctx()
+        cfg = {
+            "servers": {
+                "typo-api": {
+                    "transport": "ssse",
+                    "url": "http://remote:8001/mcp",
+                }
+            }
+        }
+        with caplog.at_level("WARNING"):
+            servers = resolve_servers(cfg, ctx)
+        assert not [s for s in servers if s["name"] == "typo-api"]
+        assert "invalid transport" in caplog.text
+
+    def test_resolve_custom_server_transport_on_stdio_ignored(self, caplog):
+        """A command server declaring transport keeps working; the key is ignored loudly."""
+        ctx = _base_ctx()
+        cfg = {
+            "servers": {
+                "my-server": {
+                    "transport": "sse",
+                    "command": "node",
+                    "args": ["server.js"],
+                }
+            }
+        }
+        with caplog.at_level("WARNING"):
+            servers = resolve_servers(cfg, ctx)
+        (s,) = [s for s in servers if s["name"] == "my-server"]
+        assert s["command"] == "node"
+        assert s["transport"] is None
+        assert "no transport choice" in caplog.text
+
+    def test_resolve_stdio_servers_have_no_transport(self):
+        """Framework (stdio) servers resolve with transport None, never 'http'."""
+        servers = resolve_servers({}, _base_ctx())
+        for s in servers:
+            if not s["url"]:
+                assert s["transport"] is None
 
     def test_resolve_conditional_server_enabled(self):
         """channel_finder_pipeline in ctx → channel-finder server enabled."""


### PR DESCRIPTION
## Summary

Custom MCP servers declared with a `url` now carry an explicit `transport` key — `http` (streamable-HTTP, the default) or `sse` (legacy Server-Sent Events) — that flows from the build profile through the persisted `config.yml` into the rendered `.mcp.json`, whose server `type` was previously hardcoded to `http`.

Previously the persisted `transport` key was write-only: the build wrote `transport: http|stdio` into `config.yml`, but nothing ever read it back, so editing it had silently zero effect. It is now the round-trip contract for URL servers, and stdio servers get no transport key at all (launching via `command` *is* the transport).

## Validation (fail-fast)

- Profile loader rejects: unknown transport values, `transport` declared on a stdio (`command`) server, and `transport: sse` without an explicit `url` (the port-derived URL is a streamable-HTTP `/mcp` endpoint).
- At regen time the config resolver skips a server with an invalid transport loudly instead of silently defaulting a typo to `http`.

## Also

- The derived `network` block's host/docker URLs follow the declared url's endpoint path instead of hardcoding `/mcp` — an SSE server's network block no longer points at a nonexistent endpoint.
- Stdio servers resolve with `transport: None` so a consumer can never mistake a command server for an HTTP one.
- Documented next to the other `mcp_servers` keys in the build-profiles how-to; the last stale `"transport": "sse"` snippet in the control-assistant template README replaced with the real `.mcp.json` form.

## Tests

Loader validation (5 new), resolver transport handling (5 new/updated), SSE persistence round-trip, and the regen end-to-end test now asserts `"type": "sse"` lands in `.mcp.json` — it previously asserted the hardcoded-http behavior.