### PR TITLE
feat(connectors): register doocs connectors by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Added
 
+- DOOCS facilities can now select their connectors by name: `control_system.type:
+  doocs` and `archiver.type: doocs_archiver`, in `config.yml`, through `osprey
+  config set-control-system doocs`, or from the interactive config menu.
+  Previously the connectors shipped but were reachable only by spelling out their
+  dotted class paths. Both still require `doocs4py` from the DOOCS environment.
+
 - New `osprey.bridges.core` package: a channel-agnostic engine for connecting a
   chat or email channel to the OSPREY dispatcher/worker pair as its own process.
   It owns the parts that are the same for every channel — a crash-safe dedup

--- a/docs/source/how-to/add-connector.rst
+++ b/docs/source/how-to/add-connector.rst
@@ -23,9 +23,11 @@ The Control System Integration system provides a **two-layer abstraction** for w
   like ``epics`` but tracks setpoints through the simulated machine, so scans
   actually run (the mock connector can't do that); see :doc:`use-virtual-accelerator`
 - **mongodb_archiver**: MongoDB time-series archiver (optional, ``pip install "osprey-framework[archiver-mongodb]"``)
-
-A DOOCS connector and DOOCS archiver also ship in-tree; they are wired up via
-their dotted class paths rather than a registered name.
+- **doocs** / **doocs_archiver**: DOOCS properties and DOOCS local histories
+  (DESY, European XFEL). Both require ``doocs4py``, which is supplied by the
+  DOOCS environment rather than installed from PyPI — the import is deferred to
+  ``connect()``, so the names register everywhere and only fail where a DOOCS
+  environment is genuinely absent.
 
 
 Quick Start: Using Connectors
@@ -130,6 +132,35 @@ The connector requires the optional ``archiver-mongodb`` extra:
 .. code-block:: bash
 
    pip install "osprey-framework[archiver-mongodb]"
+
+Production Mode (DOOCS)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+DOOCS facilities select both connectors by name. Channel addresses are DOOCS
+properties (``FACILITY/DEVICE/LOCATION/PROPERTY``), and the control-system
+connector needs no options -- it reads its environment from the DOOCS
+installation:
+
+.. code-block:: yaml
+
+   control_system:
+     type: doocs
+
+   archiver:
+     type: doocs_archiver
+     doocs_archiver:
+       avg_window: 20    # optional moving average, in samples
+
+The archiver reads DOOCS *local histories*, so it only makes sense alongside
+``type: doocs``. Both connectors need ``doocs4py``, which the DOOCS environment
+provides rather than PyPI; without it, ``connect()`` fails with a clear
+``ImportError`` instead of silently degrading.
+
+.. note::
+
+   DOOCS supports the ``none`` and ``readback`` write-verification levels.
+   ``callback`` is accepted but has no DOOCS equivalent, so it performs a
+   readback and reports the level as ``readback``.
 
 
 Write Verification

--- a/src/osprey/cli/project_actions.py
+++ b/src/osprey/cli/project_actions.py
@@ -528,6 +528,7 @@ def handle_set_control_system(project_path: Path | None = None) -> None:
             value=types.VIRTUAL_ACCELERATOR,
         ),
         Choice("EPICS - Production mode (connects to real control system)", value=types.EPICS),
+        Choice("DOOCS - Production mode (DESY / European XFEL)", value=types.DOOCS),
         Choice("─" * 60, value=None, disabled=True),
         Choice("[←] Back - Return to config menu", value="back"),
     ]
@@ -551,6 +552,12 @@ def handle_set_control_system(project_path: Path | None = None) -> None:
             choices=build_archiver_choices(),
             style=custom_style,
         ).ask()
+    elif control_type == types.DOOCS:
+        # The DOOCS archiver reads DOOCS local histories, so it is the only
+        # archiver that pairs with a DOOCS control system. Offering the
+        # EPICS/MongoDB menu here would only let the wizard write a
+        # combination no facility runs.
+        archiver_type = types.DOOCS_ARCHIVER
     else:
         archiver_type = types.MOCK_ARCHIVER
 

--- a/src/osprey/connectors/factory.py
+++ b/src/osprey/connectors/factory.py
@@ -331,8 +331,8 @@ def isolated_connector_registries(*, clear: bool = False) -> Iterator[ConnectorR
         restore_connector_registries(snapshot)
 
 
-_BUILTIN_CONTROL_SYSTEMS = (types.MOCK, types.EPICS, types.VIRTUAL_ACCELERATOR)
-_BUILTIN_ARCHIVERS = (types.MOCK_ARCHIVER, types.EPICS_ARCHIVER)
+_BUILTIN_CONTROL_SYSTEMS = (types.MOCK, types.EPICS, types.VIRTUAL_ACCELERATOR, types.DOOCS)
+_BUILTIN_ARCHIVERS = (types.MOCK_ARCHIVER, types.EPICS_ARCHIVER, types.DOOCS_ARCHIVER)
 
 
 def register_builtin_connectors() -> None:
@@ -357,8 +357,14 @@ def register_builtin_connectors() -> None:
         # built-ins, so a missing pymongo isn't re-imported on every call.
         return
 
+    # The DOOCS connectors import doocs4py inside connect(), not at module
+    # scope, so they register unconditionally like any other built-in. A
+    # machine with no DOOCS environment only finds out when it tries to
+    # connect — which is the point at which it would have failed anyway.
+    from osprey.connectors.archiver.doocs_archiver_connector import DOOCSArchiverConnector
     from osprey.connectors.archiver.epics_archiver_connector import EPICSArchiverConnector
     from osprey.connectors.archiver.mock_archiver_connector import MockArchiverConnector
+    from osprey.connectors.control_system.doocs_connector import DOOCSConnector
     from osprey.connectors.control_system.epics_connector import EPICSConnector
     from osprey.connectors.control_system.mock_connector import MockConnector
     from osprey.connectors.control_system.va_connector import VirtualAcceleratorConnector
@@ -367,10 +373,12 @@ def register_builtin_connectors() -> None:
         (types.MOCK, MockConnector),
         (types.EPICS, EPICSConnector),
         (types.VIRTUAL_ACCELERATOR, VirtualAcceleratorConnector),
+        (types.DOOCS, DOOCSConnector),
     ]
     archivers: list[tuple[str, type[ArchiverConnector]]] = [
         (types.MOCK_ARCHIVER, MockArchiverConnector),
         (types.EPICS_ARCHIVER, EPICSArchiverConnector),
+        (types.DOOCS_ARCHIVER, DOOCSArchiverConnector),
     ]
 
     try:

--- a/src/osprey/connectors/types.py
+++ b/src/osprey/connectors/types.py
@@ -9,12 +9,14 @@ and don't need constants here.
 MOCK = "mock"
 EPICS = "epics"
 VIRTUAL_ACCELERATOR = "virtual_accelerator"
+DOOCS = "doocs"
 
 # -- Archiver connector types --
 MOCK_ARCHIVER = "mock_archiver"
 EPICS_ARCHIVER = "epics_archiver"
 MONGODB_ARCHIVER = "mongodb_archiver"
+DOOCS_ARCHIVER = "doocs_archiver"
 
 # -- CLI choice lists (only types with implementations) --
-CLI_CONTROL_SYSTEM_TYPES = [MOCK, EPICS, VIRTUAL_ACCELERATOR]
-CLI_ARCHIVER_TYPES = [MOCK_ARCHIVER, EPICS_ARCHIVER, MONGODB_ARCHIVER]
+CLI_CONTROL_SYSTEM_TYPES = [MOCK, EPICS, VIRTUAL_ACCELERATOR, DOOCS]
+CLI_ARCHIVER_TYPES = [MOCK_ARCHIVER, EPICS_ARCHIVER, MONGODB_ARCHIVER, DOOCS_ARCHIVER]

--- a/src/osprey/registry/builtins.py
+++ b/src/osprey/registry/builtins.py
@@ -7,6 +7,8 @@ that all Osprey applications build upon.
 """
 
 from osprey.connectors.types import (
+    DOOCS,
+    DOOCS_ARCHIVER,
     EPICS,
     EPICS_ARCHIVER,
     MOCK,
@@ -77,6 +79,13 @@ class FrameworkRegistryProvider(RegistryConfigProvider):
                     class_name="VirtualAcceleratorConnector",
                     description="Virtual Accelerator connector for PyAT-backed soft-IOC simulations",
                 ),
+                ConnectorRegistration(
+                    name=DOOCS,
+                    connector_type="control_system",
+                    module_path="osprey.connectors.control_system.doocs_connector",
+                    class_name="DOOCSConnector",
+                    description="DOOCS control system connector (requires doocs4py)",
+                ),
                 # Archiver connectors
                 ConnectorRegistration(
                     name=MOCK_ARCHIVER,
@@ -98,6 +107,13 @@ class FrameworkRegistryProvider(RegistryConfigProvider):
                     module_path="osprey.connectors.archiver.mongodb_archiver_connector",
                     class_name="MongoDBArchiverConnector",
                     description="MongoDB archiver connector for time-series PV data",
+                ),
+                ConnectorRegistration(
+                    name=DOOCS_ARCHIVER,
+                    connector_type="archiver",
+                    module_path="osprey.connectors.archiver.doocs_archiver_connector",
+                    class_name="DOOCSArchiverConnector",
+                    description="DOOCS local history connector (requires doocs4py)",
                 ),
             ],
             # ARIEL search modules

--- a/src/osprey/templates/skills/osprey-build-deploy/references/facility-config-schema.md
+++ b/src/osprey/templates/skills/osprey-build-deploy/references/facility-config-schema.md
@@ -56,7 +56,7 @@ control_system:
 
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
-| `type` | enum | yes | OSPREY ships connectors for `epics` and `mock` today. `doocs`, `tango`, and `custom` are **roadmap values only** — selecting one writes the value into config but NO connector is built, so the resulting assistant has no live control-system access. Use `mock` for development on non-EPICS facilities until a real connector lands. Any value other than `epics` disables the EPICS test IOC module. |
+| `type` | enum | yes | OSPREY ships connectors for `epics`, `doocs`, and `mock` today. `doocs` additionally needs `doocs4py`, which comes from the DOOCS environment rather than PyPI. `tango` and `custom` are **roadmap values only** — selecting one writes the value into config but NO connector is built, so the resulting assistant has no live control-system access. Use `mock` for development on facilities with no connector yet. Any value other than `epics` disables the EPICS test IOC module. |
 | `ca_addr_list` | string | EPICS only | Used in compose files that need EPICS broadcast |
 | `archiver_url` | URL | no | Used by integration tests and analytics agents |
 

--- a/src/osprey/templates/skills/osprey-build-deploy/references/setup-interview.md
+++ b/src/osprey/templates/skills/osprey-build-deploy/references/setup-interview.md
@@ -57,11 +57,11 @@ Validate: lowercase, alphanumeric + hyphens only, 2–6 chars. If invalid, expla
 **Q1.3 Control system type:**
 - EPICS (most US/Asian accelerators — APS, ALS, SLAC, NSLS-II, J-PARC, KEK, etc.)
 - Mock / simulated (for development without real hardware) (Recommended for first deploy)
-- DOOCS (DESY, European XFEL) — ROADMAP, no connector yet
+- DOOCS (DESY, European XFEL) — requires `doocs4py` from the DOOCS environment
 - TANGO (ESRF, MAX IV, Soleil, Elettra) — ROADMAP, no connector yet
 - Custom (you write your own connector) — no built-in support
 
-> "Which control system do you connect to? OSPREY ships built-in support for **EPICS** and **Mock** today. DOOCS and TANGO are roadmap values — picking one writes the config but there is no working connector yet, so live control-system access won't work. If your site runs DOOCS/TANGO/Custom, pick `mock` for now so you can exercise the rest of the deploy pipeline; switch to the real value once a connector lands."
+> "Which control system do you connect to? OSPREY ships built-in support for **EPICS**, **DOOCS**, and **Mock** today. DOOCS also needs the `doocs4py` library, which your DOOCS environment provides — it is not installed from PyPI. TANGO is a roadmap value: picking it writes the config but there is no working connector yet, so live control-system access won't work. If your site runs TANGO or a custom stack, pick `mock` for now so you can exercise the rest of the deploy pipeline; switch to the real value once a connector lands."
 
 **Q1.4 Timezone** (in a follow-up question or the same group if room):
 > "What timezone is your facility in? Drives container clocks and the assistant's time handling (how it reads operator times and stamps output). Default: `UTC`. ALS uses `America/Los_Angeles`."

--- a/tests/connectors/test_doocs_registration.py
+++ b/tests/connectors/test_doocs_registration.py
@@ -1,0 +1,172 @@
+"""Tests for the ``doocs`` / ``doocs_archiver`` connector type surface.
+
+The DOOCS connectors shipped in-tree but were reachable only through a dotted
+class path, because no name was ever minted for them. These tests pin the name
+across every layer that has to agree on it: the type constants, the factory's
+built-in registration, the framework registry, and the two CLI entry points.
+
+``doocs4py`` is never imported here — both connectors defer that import to
+``connect()``, which is exactly what makes registering them unconditionally
+safe on machines with no DOOCS environment.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from osprey.connectors import types
+from osprey.connectors.factory import (
+    ConnectorFactory,
+    isolated_connector_registries,
+    register_builtin_connectors,
+)
+
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+class TestTypeConstants:
+    """``types.py`` is the single source of truth for the name strings."""
+
+    def test_control_system_constant(self):
+        assert types.DOOCS == "doocs"
+
+    def test_archiver_constant(self):
+        assert types.DOOCS_ARCHIVER == "doocs_archiver"
+
+    def test_constants_appear_in_cli_choice_lists(self):
+        assert types.DOOCS in types.CLI_CONTROL_SYSTEM_TYPES
+        assert types.DOOCS_ARCHIVER in types.CLI_ARCHIVER_TYPES
+
+
+class TestBuiltinRegistration:
+    """``register_builtin_connectors()`` mints both names."""
+
+    def test_doocs_registers_as_builtin_control_system(self):
+        with isolated_connector_registries(clear=True):
+            register_builtin_connectors()
+
+            assert types.DOOCS in ConnectorFactory.list_control_systems()
+            registered = ConnectorFactory._control_system_connectors[types.DOOCS]
+            assert registered.__name__ == "DOOCSConnector"
+
+    def test_doocs_archiver_registers_as_builtin_archiver(self):
+        with isolated_connector_registries(clear=True):
+            register_builtin_connectors()
+
+            assert types.DOOCS_ARCHIVER in ConnectorFactory.list_archivers()
+            registered = ConnectorFactory._archiver_connectors[types.DOOCS_ARCHIVER]
+            assert registered.__name__ == "DOOCSArchiverConnector"
+
+    def test_registration_needs_no_doocs4py(self):
+        """Registration must not import doocs4py.
+
+        Both connectors import it inside ``connect()``. If that ever moved to
+        module scope, registering the built-ins would raise ImportError on
+        every non-DESY machine and take the whole framework down with it.
+        """
+        import sys
+
+        with (
+            patch.dict(sys.modules, {"doocs4py": None}),
+            isolated_connector_registries(clear=True),
+        ):
+            register_builtin_connectors()
+
+            assert types.DOOCS in ConnectorFactory.list_control_systems()
+
+
+class TestFrameworkRegistryEntries:
+    """The registry provider carries matching entries for discovery/export."""
+
+    def test_registry_lists_both_doocs_connectors(self):
+        from osprey.registry.builtins import FrameworkRegistryProvider
+
+        connectors = FrameworkRegistryProvider().get_registry_config().connectors
+        by_name = {c.name: c for c in connectors}
+
+        assert by_name[types.DOOCS].connector_type == "control_system"
+        assert by_name[types.DOOCS].class_name == "DOOCSConnector"
+        assert by_name[types.DOOCS_ARCHIVER].connector_type == "archiver"
+        assert by_name[types.DOOCS_ARCHIVER].class_name == "DOOCSArchiverConnector"
+
+
+class TestCliSurface:
+    """Both CLI entry points offer the type, so they cannot disagree."""
+
+    def test_set_control_system_choice_includes_doocs(self):
+        from osprey.cli.config_cmd import set_control_system
+
+        param = next(p for p in set_control_system.params if p.name == "system_type")
+        assert types.DOOCS in param.type.choices
+
+    def test_set_control_system_accepts_doocs(self, cli_runner, tmp_path):
+        from osprey.cli.config_cmd import set_control_system
+
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("control_system:\n  type: mock\n")
+
+        with (
+            patch("osprey.cli.project_utils.resolve_config_path") as mock_resolve,
+            patch("osprey.utils.config_writer.set_control_system_type") as mock_update,
+        ):
+            mock_resolve.return_value = str(config_file)
+            mock_update.return_value = ("new content", "preview")
+
+            result = cli_runner.invoke(set_control_system, [types.DOOCS])
+
+            assert result.exit_code == 0
+            assert mock_update.call_args.args[1] == types.DOOCS
+
+    def test_interactive_menu_offers_doocs(self, tmp_path):
+        """The wizard's control-system menu lists DOOCS alongside EPICS."""
+        from osprey.cli import project_actions
+
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("control_system:\n  type: mock\n")
+
+        with (
+            patch.object(project_actions.questionary, "select") as mock_select,
+            patch.object(project_actions, "console"),
+        ):
+            # Backing out of the menu ends the flow before any prompt or write.
+            mock_select.return_value.ask.return_value = "back"
+
+            project_actions.handle_set_control_system(tmp_path)
+
+        choices = mock_select.call_args.kwargs["choices"]
+        assert types.DOOCS in [c.value for c in choices]
+
+    def test_doocs_control_system_pairs_with_doocs_archiver(self, tmp_path):
+        """Picking DOOCS must not offer EPICS Archiver Appliance or MongoDB.
+
+        The DOOCS archiver reads DOOCS *local histories*, so it is the only
+        archiver that pairs with a DOOCS control system. The wizard therefore
+        selects it directly instead of prompting.
+        """
+        from osprey.cli import project_actions
+
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("control_system:\n  type: mock\n")
+
+        with (
+            patch.object(project_actions.questionary, "select") as mock_select,
+            patch.object(project_actions.questionary, "confirm") as mock_confirm,
+            patch.object(project_actions, "console"),
+            patch("builtins.input", return_value=""),
+            patch(
+                "osprey.utils.config_writer.set_control_system_type",
+                return_value=("new content", "preview"),
+            ) as mock_set,
+        ):
+            mock_select.return_value.ask.return_value = types.DOOCS
+            mock_confirm.return_value.ask.return_value = False
+
+            project_actions.handle_set_control_system(tmp_path)
+
+            # Exactly one prompt: the control-system menu. No archiver prompt.
+            assert mock_select.call_count == 1
+            assert mock_set.call_args.args[2] == types.DOOCS_ARCHIVER


### PR DESCRIPTION
The DOOCS control-system and archiver connectors ship in-tree but no name was
ever minted for them, so `control_system.type: doocs` failed with `Unknown
control system type: 'doocs'` and DOOCS facilities had to spell out dotted class
paths (`osprey.connectors.control_system.doocs_connector.DOOCSConnector`) to
reach them.

This mints `doocs` and `doocs_archiver` across every layer that has to agree on
a connector name:

- `connectors/types.py` — constants, plus both CLI choice lists
- `connectors/factory.py` — `_BUILTIN_CONTROL_SYSTEMS` / `_BUILTIN_ARCHIVERS`
- `registry/builtins.py` — matching `ConnectorRegistration` entries
- `cli/project_actions.py` — the interactive config wizard

The wizard pairs a DOOCS control system with the DOOCS archiver directly rather
than prompting: that archiver reads DOOCS *local histories*, so it is the only
archiver that pairs with `type: doocs`.

Registration is unconditional. Both connectors defer their `doocs4py` import to
`connect()`, so importing them costs nothing on machines with no DOOCS
environment, and a missing `doocs4py` still surfaces as a clear `ImportError` at
connect time rather than at startup. A regression test pins that property — if
the import is ever hoisted to module scope, registering the built-ins would
raise on every non-DESY machine, and this turns that into a red build.

Docs updated to match: the connector how-to gains a DOOCS configuration section,
and the build-interview references no longer describe DOOCS as a roadmap value
with no connector.
