### PR TITLE
feat(providers): honor ALS_APG_BASE_URL endpoint override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ on:
 # src/osprey/templates/services/openobserve/docker-compose.yml.j2 moves.
 env:
   OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
+  # ALS-APG endpoint override: set the ALS_APG_BASE_URL repository variable
+  # to point every LLM-touching job (probes and pytest alike) at an
+  # alternate gateway. Empty/unset keeps the provider's default endpoint.
+  ALS_APG_BASE_URL: ${{ vars.ALS_APG_BASE_URL }}
 
 jobs:
   test:
@@ -513,8 +517,10 @@ jobs:
           echo "   (Check repo secrets; required for the agentic-per-preset job.)"
           exit 1
         fi
+        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com}"
+        ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/}"; ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/v1}"
         HTTP_CODE=$(curl -sS -o /tmp/probe.txt -w "%{http_code}" --max-time 15 \
-          -X POST https://llm.gianlucamartino.com/v1/messages \
+          -X POST "$ALS_APG_PROBE_BASE/v1/messages" \
           -H "Content-Type: application/json" \
           -H "anthropic-version: 2023-06-01" \
           -H "Authorization: Bearer $ALS_APG_API_KEY" \
@@ -587,8 +593,10 @@ jobs:
           echo "❌ ALS_APG_API_KEY secret is not set on this runner"
           exit 1
         fi
+        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com}"
+        ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/}"; ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/v1}"
         HTTP_CODE=$(curl -sS -o /tmp/probe.txt -w "%{http_code}" --max-time 15 \
-          -X POST https://llm.gianlucamartino.com/v1/messages \
+          -X POST "$ALS_APG_PROBE_BASE/v1/messages" \
           -H "Content-Type: application/json" \
           -H "anthropic-version: 2023-06-01" \
           -H "Authorization: Bearer $ALS_APG_API_KEY" \
@@ -709,8 +717,10 @@ jobs:
           echo "❌ ALS_APG_API_KEY secret is not set on this runner"
           exit 1
         fi
+        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com}"
+        ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/}"; ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/v1}"
         HTTP_CODE=$(curl -sS -o /tmp/probe.txt -w "%{http_code}" --max-time 15 \
-          -X POST https://llm.gianlucamartino.com/v1/messages \
+          -X POST "$ALS_APG_PROBE_BASE/v1/messages" \
           -H "Content-Type: application/json" \
           -H "anthropic-version: 2023-06-01" \
           -H "Authorization: Bearer $ALS_APG_API_KEY" \
@@ -833,8 +843,10 @@ jobs:
           echo "❌ ALS_APG_API_KEY secret is not set on this runner"
           exit 1
         fi
+        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com}"
+        ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/}"; ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/v1}"
         HTTP_CODE=$(curl -sS -o /tmp/probe.txt -w "%{http_code}" --max-time 15 \
-          -X POST https://llm.gianlucamartino.com/v1/messages \
+          -X POST "$ALS_APG_PROBE_BASE/v1/messages" \
           -H "Content-Type: application/json" \
           -H "anthropic-version: 2023-06-01" \
           -H "Authorization: Bearer $ALS_APG_API_KEY" \
@@ -905,8 +917,10 @@ jobs:
           echo "❌ ALS_APG_API_KEY secret is not set on this runner"
           exit 1
         fi
+        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com}"
+        ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/}"; ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/v1}"
         HTTP_CODE=$(curl -sS -o /tmp/probe.txt -w "%{http_code}" --max-time 15 \
-          -X POST https://llm.gianlucamartino.com/v1/messages \
+          -X POST "$ALS_APG_PROBE_BASE/v1/messages" \
           -H "Content-Type: application/json" \
           -H "anthropic-version: 2023-06-01" \
           -H "Authorization: Bearer $ALS_APG_API_KEY" \
@@ -1368,8 +1382,10 @@ jobs:
           echo "❌ ALS_APG_API_KEY secret is not set on this runner"
           exit 1
         fi
+        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com}"
+        ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/}"; ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/v1}"
         HTTP_CODE=$(curl -sS -o /tmp/probe.txt -w "%{http_code}" --max-time 15 \
-          -X POST https://llm.gianlucamartino.com/v1/messages \
+          -X POST "$ALS_APG_PROBE_BASE/v1/messages" \
           -H "Content-Type: application/json" \
           -H "anthropic-version: 2023-06-01" \
           -H "Authorization: Bearer $ALS_APG_API_KEY" \

--- a/src/osprey/build/claude_code_resolver.py
+++ b/src/osprey/build/claude_code_resolver.py
@@ -623,10 +623,14 @@ class ClaudeCodeModelResolver:
         with its own gateway and have the agent use the endpoint ``osprey
         health`` probes. Above both sits the break-glass env override: a
         built-in provider that declares ``base_url_env_var`` lets a set
-        (non-empty) env var beat config and the built-in URL, so an
+        (non-empty) value beat config and the built-in URL, so an
         already-deployed system whose config is baked into an image can be
-        redirected at a fallback gateway without a rebuild. The trailing
-        ``/v1`` is stripped for ``ANTHROPIC_BASE_URL`` either way (see below).
+        redirected at a fallback gateway without a rebuild. That value is read
+        only from an explicitly supplied ``environ`` — this method never
+        consults ``os.environ``, because it also renders ``settings.json`` at
+        build time, where an ambient read would bake the builder's endpoint
+        into the artifact. The trailing ``/v1`` is stripped for
+        ``ANTHROPIC_BASE_URL`` either way (see below).
 
         A provider that leaves a tier unmapped by all three sources is refused
         — the framework will not substitute another provider's model IDs.
@@ -639,9 +643,11 @@ class ClaudeCodeModelResolver:
             claude_code_config: The ``claude_code`` section of config.yml.
             api_providers: The ``api.providers`` section (optional).
             environ: Mapping the ``base_url_env_var`` override is read from.
-                Defaults to ``os.environ``; :func:`load_provider_spec` passes
-                its ``os.environ`` + project-``.env`` overlay so the override
-                honors the same lookup as ``${VAR}`` config expansion.
+                Omitted means "no override" — never ``os.environ``, so
+                build-time rendering is reproducible on any machine.
+                :func:`load_provider_spec` passes its ``os.environ`` +
+                project-``.env`` overlay, which is what enables the override on
+                every runtime path.
 
         Returns:
             Resolved spec, or ``None`` when no provider is configured.
@@ -688,7 +694,13 @@ class ClaudeCodeModelResolver:
         # declare base_url_env_var): config is often baked into a container
         # image, and a set env var must be able to redirect the deployment at
         # a fallback gateway without a rebuild. Empty means unset.
-        env_lookup = os.environ if environ is None else environ
+        # No ambient os.environ read: the override is honored only when a
+        # caller hands in a lookup, i.e. from load_provider_spec's runtime
+        # overlay. resolve() also renders settings.json at *build* time
+        # (templates/claude_code.py, templates/manager.py), where reading the
+        # builder's environment would bake whatever gateway that machine
+        # happened to export into the shipped artifact.
+        env_lookup: Mapping[str, str] = environ if environ is not None else {}
         env_var = provider_def.get("base_url_env_var")
         base_url = (
             (env_lookup.get(env_var) if env_var else None)

--- a/src/osprey/build/claude_code_resolver.py
+++ b/src/osprey/build/claude_code_resolver.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import sys
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -65,6 +66,10 @@ CLAUDE_CODE_PROVIDERS: dict[str, dict] = {
         "auth_env_var": "ANTHROPIC_AUTH_TOKEN",  # Bearer auth for proxy
         "auth_secret_env": "ALS_APG_API_KEY",  # Shell env var holding the secret
         "base_url": "https://llm.gianlucamartino.com",  # ALS-APG AWS proxy (no /v1)
+        # Break-glass redirect: a set env var beats config and the URL above,
+        # so a deployment with a baked-in config can be pointed at a fallback
+        # gateway at runtime (mirrors the provider adapter's base_url_env_var).
+        "base_url_env_var": "ALS_APG_BASE_URL",
         "default_model_tier": "haiku",
         # Fallback model IDs (used when api.providers.als-apg.models is absent)
         "models": {
@@ -473,6 +478,7 @@ def load_provider_spec(
         cc_config,
         cfg.get("api", {}).get("providers", {}),
         include_telemetry=include_telemetry,
+        environ=lookup,
     )
 
 
@@ -599,6 +605,7 @@ class ClaudeCodeModelResolver:
         api_providers: dict | None = None,
         *,
         include_telemetry: bool = True,
+        environ: Mapping[str, str] | None = None,
     ) -> ClaudeCodeModelSpec | None:
         """Build a ``ClaudeCodeModelSpec`` from config.
 
@@ -614,8 +621,12 @@ class ClaudeCodeModelResolver:
         ``base_url`` follows the same rule: ``api.providers[name].base_url``
         overrides the built-in URL, so a facility can front a built-in provider
         with its own gateway and have the agent use the endpoint ``osprey
-        health`` probes. The trailing ``/v1`` is stripped for
-        ``ANTHROPIC_BASE_URL`` either way (see below).
+        health`` probes. Above both sits the break-glass env override: a
+        built-in provider that declares ``base_url_env_var`` lets a set
+        (non-empty) env var beat config and the built-in URL, so an
+        already-deployed system whose config is baked into an image can be
+        redirected at a fallback gateway without a rebuild. The trailing
+        ``/v1`` is stripped for ``ANTHROPIC_BASE_URL`` either way (see below).
 
         A provider that leaves a tier unmapped by all three sources is refused
         — the framework will not substitute another provider's model IDs.
@@ -627,6 +638,10 @@ class ClaudeCodeModelResolver:
         Args:
             claude_code_config: The ``claude_code`` section of config.yml.
             api_providers: The ``api.providers`` section (optional).
+            environ: Mapping the ``base_url_env_var`` override is read from.
+                Defaults to ``os.environ``; :func:`load_provider_spec` passes
+                its ``os.environ`` + project-``.env`` overlay so the override
+                honors the same lookup as ``${VAR}`` config expansion.
 
         Returns:
             Resolved spec, or ``None`` when no provider is configured.
@@ -669,8 +684,16 @@ class ClaudeCodeModelResolver:
         # having the built-in URL silently win. The built-in URL is the
         # fallback for configs that name none; a custom provider has no
         # built-in entry, so its api.providers value is the only source.
-        base_url = api_providers.get(provider_name, {}).get("base_url") or provider_def.get(
-            "base_url"
+        # Above all of that sits the break-glass env override (providers that
+        # declare base_url_env_var): config is often baked into a container
+        # image, and a set env var must be able to redirect the deployment at
+        # a fallback gateway without a rebuild. Empty means unset.
+        env_lookup = os.environ if environ is None else environ
+        env_var = provider_def.get("base_url_env_var")
+        base_url = (
+            (env_lookup.get(env_var) if env_var else None)
+            or api_providers.get(provider_name, {}).get("base_url")
+            or provider_def.get("base_url")
         )
 
         # ── Build tier → model mapping ───────────────────────────

--- a/src/osprey/models/providers/als_apg.py
+++ b/src/osprey/models/providers/als_apg.py
@@ -22,6 +22,10 @@ class ALSAPGProviderAdapter(LiteLLMDelegatingProvider):
     requires_model_id = True
     supports_proxy = True
     default_base_url = "https://llm.gianlucamartino.com"
+    # Break-glass redirect: a set ALS_APG_BASE_URL beats config and the default,
+    # so deployments with a baked-in URL can be pointed at a fallback gateway
+    # at runtime (accepts the URL with or without a trailing /v1).
+    base_url_env_var = "ALS_APG_BASE_URL"
     # als-apg routes openai-compatible; without a base_url litellm would fall
     # through to api.openai.com, so a missing base_url resolves to the default.
     apply_default_base_url_fallback = True

--- a/src/osprey/models/providers/base.py
+++ b/src/osprey/models/providers/base.py
@@ -24,6 +24,13 @@ class BaseProvider(ABC):
         requires_model_id: Whether provider requires model ID specification
         supports_proxy: Whether provider supports HTTP proxy configuration
         default_base_url: Default API endpoint URL if applicable
+        base_url_env_var: Name of an env var that, when set, overrides every
+            other base_url source (explicit argument, config, default) for this
+            provider — the runtime lever for redirecting an already-deployed
+            system at a different gateway without a rebuild. None disables the
+            override (the default; providers opt in explicitly so the name
+            never collides with an env var another layer owns, e.g.
+            ANTHROPIC_BASE_URL).
         default_model_id: Default model recommended for general use (used in templates)
         health_check_model_id: Cheapest/fastest model for health checks
         available_models: List of available model IDs for this provider
@@ -53,6 +60,7 @@ class BaseProvider(ABC):
     requires_model_id: bool = NotImplemented
     supports_proxy: bool = NotImplemented
     default_base_url: str | None = None
+    base_url_env_var: str | None = None  # Env var overriding all base_url sources (opt-in)
     default_model_id: str | None = None  # Default model for templates/general use
     health_check_model_id: str | None = None  # Cheapest model for health checks
     available_models: list[str] = []  # List of available models for this provider

--- a/src/osprey/models/providers/litellm_delegating.py
+++ b/src/osprey/models/providers/litellm_delegating.py
@@ -20,6 +20,7 @@ module), the lookup falls back to the real helpers imported here instead of
 failing with an AttributeError.
 """
 
+import os
 import sys
 from typing import Any
 
@@ -43,7 +44,18 @@ class LiteLLMDelegatingProvider(BaseProvider):
     apply_default_base_url_fallback: bool = False
 
     def _effective_base_url(self, base_url: str | None) -> str | None:
-        """Apply the Stanford-only default_base_url fallback when enabled."""
+        """Resolve the base_url: env override > caller value > default fallback.
+
+        A provider that declares :attr:`~BaseProvider.base_url_env_var` lets a
+        set (non-empty) env var beat every other source — the caller's value
+        usually comes from config baked into a deployment, and the env var is
+        the runtime lever that redirects it without a rebuild. The
+        ``apply_default_base_url_fallback`` behavior below is unchanged.
+        """
+        if self.base_url_env_var:
+            override = os.environ.get(self.base_url_env_var)
+            if override:
+                return override
         if self.apply_default_base_url_fallback:
             return base_url or self.default_base_url
         return base_url

--- a/src/osprey/services/channel_finder/benchmarks/evaluation.py
+++ b/src/osprey/services/channel_finder/benchmarks/evaluation.py
@@ -128,7 +128,7 @@ def llm_judge_coverage(response_text: str, expected: list[str]) -> tuple[list[st
             provider = "als-apg"
             api_key = als_apg_key
             model_id = "claude-haiku-4-5-20251001"
-            base_url = "https://llm.gianlucamartino.com"
+            base_url = os.environ.get("ALS_APG_BASE_URL", "https://llm.gianlucamartino.com")
         else:
             cborg_key = os.environ.get("CBORG_API_KEY")
             auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN")

--- a/src/osprey/templates/apps/ariel_standalone/config.yml.j2
+++ b/src/osprey/templates/apps/ariel_standalone/config.yml.j2
@@ -75,7 +75,7 @@ api:
         opus: gpt-oss:120b
     als-apg:
       api_key: ${ALS_APG_API_KEY}
-      base_url: https://llm.gianlucamartino.com/v1
+      base_url: ${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com/v1}
       models:
         haiku: claude-haiku-4-5-20251001
         sonnet: claude-sonnet-4-6

--- a/src/osprey/templates/apps/channel_finder_standalone/config.yml.j2
+++ b/src/osprey/templates/apps/channel_finder_standalone/config.yml.j2
@@ -76,7 +76,7 @@ api:
         opus: gpt-oss:120b
     als-apg:
       api_key: ${ALS_APG_API_KEY}
-      base_url: https://llm.gianlucamartino.com/v1
+      base_url: ${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com/v1}
       models:
         haiku: claude-haiku-4-5-20251001
         sonnet: claude-sonnet-4-6

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -108,7 +108,7 @@ api:
         opus: claudeopus41
     als-apg:
       api_key: ${ALS_APG_API_KEY}
-      base_url: https://llm.gianlucamartino.com/v1
+      base_url: ${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com/v1}
       models:
         haiku: claude-haiku-4-5-20251001
         sonnet: claude-sonnet-4-6

--- a/src/osprey/templates/apps/hello_world/config.yml.j2
+++ b/src/osprey/templates/apps/hello_world/config.yml.j2
@@ -89,7 +89,7 @@ api:
         opus: claudeopus41
     als-apg:
       api_key: ${ALS_APG_API_KEY}
-      base_url: https://llm.gianlucamartino.com/v1
+      base_url: ${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com/v1}
       models:
         haiku: claude-haiku-4-5-20251001
         sonnet: claude-sonnet-4-6

--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -498,7 +498,7 @@ api:
         opus: claudeopus41
     als-apg:
       api_key: ${ALS_APG_API_KEY}
-      base_url: https://llm.gianlucamartino.com/v1
+      base_url: ${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com/v1}
       models:
         haiku: claude-haiku-4-5-20251001
         sonnet: claude-sonnet-4-6

--- a/tests/cli/test_base_url_override.py
+++ b/tests/cli/test_base_url_override.py
@@ -151,3 +151,67 @@ class TestEndToEndThroughLoadProviderSpec:
 
         spec = load_provider_spec(tmp_path, include_telemetry=False)
         assert spec.env_block["ANTHROPIC_BASE_URL"] == FACILITY_GATEWAY
+
+
+class TestEnvVarBreakGlassOverride:
+    """ALS_APG_BASE_URL beats both the config value and the built-in URL.
+
+    Config is often baked into container images at build time; the env var is
+    the runtime lever that redirects an already-deployed system at a fallback
+    gateway without a rebuild. Only providers that declare ``base_url_env_var``
+    in CLAUDE_CODE_PROVIDERS participate.
+    """
+
+    def test_env_var_wins_over_builtin_url(self, monkeypatch):
+        monkeypatch.setenv("ALS_APG_BASE_URL", f"{FACILITY_GATEWAY}/v1")
+        spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"})
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == FACILITY_GATEWAY
+
+    def test_env_var_wins_over_config_base_url(self, monkeypatch):
+        monkeypatch.setenv("ALS_APG_BASE_URL", f"{FACILITY_GATEWAY}/v1")
+        spec = ClaudeCodeModelResolver.resolve(
+            {"provider": "als-apg"},
+            api_providers={"als-apg": {"base_url": "https://baked.example.org/v1"}},
+        )
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == FACILITY_GATEWAY
+
+    def test_unset_env_var_preserves_existing_behavior(self, monkeypatch):
+        monkeypatch.delenv("ALS_APG_BASE_URL", raising=False)
+        spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"})
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://llm.gianlucamartino.com"
+
+    def test_empty_env_var_is_ignored(self, monkeypatch):
+        monkeypatch.setenv("ALS_APG_BASE_URL", "")
+        spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"})
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://llm.gianlucamartino.com"
+
+    def test_explicit_environ_mapping_beats_process_env(self, monkeypatch):
+        """resolve() honors a caller-supplied lookup, so load_provider_spec can
+        pass its os.environ + project-.env overlay (.env wins)."""
+        monkeypatch.delenv("ALS_APG_BASE_URL", raising=False)
+        spec = ClaudeCodeModelResolver.resolve(
+            {"provider": "als-apg"},
+            environ={"ALS_APG_BASE_URL": f"{FACILITY_GATEWAY}/v1"},
+        )
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == FACILITY_GATEWAY
+
+    def test_project_dotenv_reaches_the_override_via_load_provider_spec(
+        self, tmp_path, monkeypatch
+    ):
+        """The on-disk runtime path: ALS_APG_BASE_URL in the project .env
+        (not the process env) still redirects the agent."""
+        from osprey.build.claude_code_resolver import load_provider_spec
+
+        monkeypatch.delenv("ALS_APG_BASE_URL", raising=False)
+        (tmp_path / "config.yml").write_text(
+            "api:\n"
+            "  providers:\n"
+            "    als-apg:\n"
+            "      base_url: https://baked.example.org/v1\n"
+            "claude_code:\n"
+            "  provider: als-apg\n"
+        )
+        (tmp_path / ".env").write_text(f"ALS_APG_BASE_URL={FACILITY_GATEWAY}/v1\n")
+
+        spec = load_provider_spec(tmp_path, include_telemetry=False)
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == FACILITY_GATEWAY

--- a/tests/cli/test_base_url_override.py
+++ b/tests/cli/test_base_url_override.py
@@ -154,64 +154,127 @@ class TestEndToEndThroughLoadProviderSpec:
 
 
 class TestEnvVarBreakGlassOverride:
-    """ALS_APG_BASE_URL beats both the config value and the built-in URL.
+    """A supplied ``base_url_env_var`` value beats config and the built-in URL.
 
     Config is often baked into container images at build time; the env var is
     the runtime lever that redirects an already-deployed system at a fallback
     gateway without a rebuild. Only providers that declare ``base_url_env_var``
-    in CLAUDE_CODE_PROVIDERS participate.
+    in CLAUDE_CODE_PROVIDERS participate, and the value must be handed in via
+    ``environ`` — see :class:`TestResolveNeverReadsAmbientEnviron` for why
+    ``resolve()`` refuses to read the process environment itself.
     """
 
-    def test_env_var_wins_over_builtin_url(self, monkeypatch):
-        monkeypatch.setenv("ALS_APG_BASE_URL", f"{FACILITY_GATEWAY}/v1")
-        spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"})
-        assert spec.env_block["ANTHROPIC_BASE_URL"] == FACILITY_GATEWAY
-
-    def test_env_var_wins_over_config_base_url(self, monkeypatch):
-        monkeypatch.setenv("ALS_APG_BASE_URL", f"{FACILITY_GATEWAY}/v1")
-        spec = ClaudeCodeModelResolver.resolve(
-            {"provider": "als-apg"},
-            api_providers={"als-apg": {"base_url": "https://baked.example.org/v1"}},
-        )
-        assert spec.env_block["ANTHROPIC_BASE_URL"] == FACILITY_GATEWAY
-
-    def test_unset_env_var_preserves_existing_behavior(self, monkeypatch):
-        monkeypatch.delenv("ALS_APG_BASE_URL", raising=False)
-        spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"})
-        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://llm.gianlucamartino.com"
-
-    def test_empty_env_var_is_ignored(self, monkeypatch):
-        monkeypatch.setenv("ALS_APG_BASE_URL", "")
-        spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"})
-        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://llm.gianlucamartino.com"
-
-    def test_explicit_environ_mapping_beats_process_env(self, monkeypatch):
-        """resolve() honors a caller-supplied lookup, so load_provider_spec can
-        pass its os.environ + project-.env overlay (.env wins)."""
-        monkeypatch.delenv("ALS_APG_BASE_URL", raising=False)
+    def test_supplied_value_wins_over_builtin_url(self):
         spec = ClaudeCodeModelResolver.resolve(
             {"provider": "als-apg"},
             environ={"ALS_APG_BASE_URL": f"{FACILITY_GATEWAY}/v1"},
         )
         assert spec.env_block["ANTHROPIC_BASE_URL"] == FACILITY_GATEWAY
 
-    def test_project_dotenv_reaches_the_override_via_load_provider_spec(
-        self, tmp_path, monkeypatch
-    ):
-        """The on-disk runtime path: ALS_APG_BASE_URL in the project .env
-        (not the process env) still redirects the agent."""
+    def test_supplied_value_wins_over_config_base_url(self):
+        spec = ClaudeCodeModelResolver.resolve(
+            {"provider": "als-apg"},
+            api_providers={"als-apg": {"base_url": "https://baked.example.org/v1"}},
+            environ={"ALS_APG_BASE_URL": f"{FACILITY_GATEWAY}/v1"},
+        )
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == FACILITY_GATEWAY
+
+    def test_absent_value_preserves_existing_behavior(self):
+        spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"}, environ={})
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://llm.gianlucamartino.com"
+
+    def test_empty_value_is_ignored(self):
+        """An empty export must not blank the URL — fall through to the default."""
+        spec = ClaudeCodeModelResolver.resolve(
+            {"provider": "als-apg"}, environ={"ALS_APG_BASE_URL": ""}
+        )
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://llm.gianlucamartino.com"
+
+    def test_provider_without_the_declaration_ignores_the_value(self):
+        """The override is opt-in per provider, so it cannot leak across them."""
+        spec = ClaudeCodeModelResolver.resolve(
+            {"provider": "cborg"},
+            environ={"ALS_APG_BASE_URL": f"{FACILITY_GATEWAY}/v1"},
+        )
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://api.cborg.lbl.gov"
+
+
+class TestResolveNeverReadsAmbientEnviron:
+    """``resolve()`` is pure: the process environment must not reach it.
+
+    This method also renders ``settings.json`` at *build* time
+    (``cli/templates/claude_code.py``, ``cli/templates/manager.py``). If it read
+    ``os.environ``, whatever gateway the build machine happened to export would
+    be baked into the shipped artifact — a CI builder would ship its own test
+    endpoint to production. Overrides therefore arrive only via ``environ``,
+    which is what ``load_provider_spec`` supplies on the runtime paths.
+    """
+
+    def test_process_env_does_not_reach_the_env_block(self, monkeypatch):
+        monkeypatch.setenv("ALS_APG_BASE_URL", "https://build-machine.example.org/v1")
+        spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"})
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://llm.gianlucamartino.com"
+
+    def test_process_env_does_not_override_a_config_base_url(self, monkeypatch):
+        monkeypatch.setenv("ALS_APG_BASE_URL", "https://build-machine.example.org/v1")
+        spec = ClaudeCodeModelResolver.resolve(
+            {"provider": "als-apg"},
+            api_providers={"als-apg": {"base_url": f"{FACILITY_GATEWAY}/v1"}},
+        )
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == FACILITY_GATEWAY
+
+    def test_supplied_environ_beats_the_process_env(self, monkeypatch):
+        """The caller's mapping is authoritative, not a merge with os.environ."""
+        monkeypatch.setenv("ALS_APG_BASE_URL", "https://build-machine.example.org/v1")
+        spec = ClaudeCodeModelResolver.resolve(
+            {"provider": "als-apg"},
+            environ={"ALS_APG_BASE_URL": f"{FACILITY_GATEWAY}/v1"},
+        )
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == FACILITY_GATEWAY
+
+
+class TestOverrideReachesTheRuntimePath:
+    """``load_provider_spec`` is where the override becomes live.
+
+    It supplies the ``os.environ`` + project-``.env`` overlay, so a deployment
+    redirects itself by exporting the variable (or writing it into ``.env``)
+    and restarting the process — the config baked into its image is untouched.
+    """
+
+    BAKED_CONFIG = (
+        "api:\n"
+        "  providers:\n"
+        "    als-apg:\n"
+        "      base_url: https://baked.example.org/v1\n"
+        "claude_code:\n"
+        "  provider: als-apg\n"
+    )
+
+    def test_process_env_overrides_the_baked_config(self, tmp_path, monkeypatch):
+        """The production mechanism: the value arrives in the container's env."""
+        from osprey.build.claude_code_resolver import load_provider_spec
+
+        (tmp_path / "config.yml").write_text(self.BAKED_CONFIG)
+        monkeypatch.setenv("ALS_APG_BASE_URL", f"{FACILITY_GATEWAY}/v1")
+
+        spec = load_provider_spec(tmp_path, include_telemetry=False)
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == FACILITY_GATEWAY
+
+    def test_project_dotenv_overrides_the_baked_config(self, tmp_path, monkeypatch):
         from osprey.build.claude_code_resolver import load_provider_spec
 
         monkeypatch.delenv("ALS_APG_BASE_URL", raising=False)
-        (tmp_path / "config.yml").write_text(
-            "api:\n"
-            "  providers:\n"
-            "    als-apg:\n"
-            "      base_url: https://baked.example.org/v1\n"
-            "claude_code:\n"
-            "  provider: als-apg\n"
-        )
+        (tmp_path / "config.yml").write_text(self.BAKED_CONFIG)
         (tmp_path / ".env").write_text(f"ALS_APG_BASE_URL={FACILITY_GATEWAY}/v1\n")
 
         spec = load_provider_spec(tmp_path, include_telemetry=False)
         assert spec.env_block["ANTHROPIC_BASE_URL"] == FACILITY_GATEWAY
+
+    def test_baked_config_stands_when_nothing_overrides_it(self, tmp_path, monkeypatch):
+        from osprey.build.claude_code_resolver import load_provider_spec
+
+        monkeypatch.delenv("ALS_APG_BASE_URL", raising=False)
+        (tmp_path / "config.yml").write_text(self.BAKED_CONFIG)
+
+        spec = load_provider_spec(tmp_path, include_telemetry=False)
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://baked.example.org"

--- a/tests/dispatch_worker/test_retention.py
+++ b/tests/dispatch_worker/test_retention.py
@@ -274,8 +274,18 @@ def test_retention_loop_runs_one_iteration(tmp_path, monkeypatch):
     store = ArtifactStore(workspace_root=tmp_path)
 
     calls: list[float] = []
+    real_sleep = asyncio.sleep
 
     async def fake_sleep(interval):
+        # This patch replaces the PROCESS-global asyncio.sleep, and daemon
+        # threads left running by earlier tests in the same worker (uvicorn
+        # servers tick sleep(0.1), the epics-ca test loop, …) call it too.
+        # Intercept only this loop's own interval and pass everything else
+        # through, so a foreign thread's tick can neither pollute `calls`
+        # nor swallow the cancellation meant for the retention loop.
+        if interval != 123.0:
+            await real_sleep(interval)
+            return
         # Let the first sleep return so one sweep runs, then cancel the loop.
         calls.append(interval)
         if len(calls) >= 2:

--- a/tests/e2e/claude_code/test_sdk_workflows.py
+++ b/tests/e2e/claude_code/test_sdk_workflows.py
@@ -62,7 +62,11 @@ class TestClaudeCodeSDKIntegration:
             project_dir,
             prompt,
             max_turns=5,
-            max_budget_usd=0.25,
+            # 0.50 matches the suite's smoke-test tier (safety/feedback tests).
+            # The old 0.25 cap was tuned hair-thin: a normal run costs ~$0.25
+            # and gateway cost accounting varies a fraction of a cent, enough
+            # to hard-error the query on budget rather than fail an assertion.
+            max_budget_usd=0.50,
         )
 
         # -- Debug output --
@@ -95,7 +99,7 @@ class TestClaudeCodeSDKIntegration:
 
         # Cost should be reasonable for a simple query
         if result.cost_usd is not None:
-            budget = 0.25 * e2e_budget_scale()
+            budget = 0.50 * e2e_budget_scale()
             assert result.cost_usd < budget, (
                 f"Smoke test cost ${result.cost_usd:.4f} — exceeded ${budget:.2f} budget"
             )

--- a/tests/e2e/test_dispatch_deploy.py
+++ b/tests/e2e/test_dispatch_deploy.py
@@ -157,10 +157,17 @@ def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
     # have no token default (they fail closed), and `deploy up` would otherwise
     # auto-generate a random token; we write fixed tokens here so the bearer
     # below is predictable, and pass the provider secret through.
+    # The endpoint override rides the same .env: without it the container-side
+    # config expansion falls back to the provider's built-in default gateway.
+    base_url_line = (
+        f"ALS_APG_BASE_URL={os.environ['ALS_APG_BASE_URL']}\n"
+        if os.environ.get("ALS_APG_BASE_URL")
+        else ""
+    )
     (project_dir / ".env").write_text(
         "EVENT_DISPATCHER_TOKEN=dev-token\n"
         "DISPATCH_WORKER_TOKEN=dev-token\n"
-        f"ALS_APG_API_KEY={os.environ['ALS_APG_API_KEY']}\n",
+        f"ALS_APG_API_KEY={os.environ['ALS_APG_API_KEY']}\n" + base_url_line,
         encoding="utf-8",
     )
 

--- a/tests/e2e/test_dispatch_overlay_visibility.py
+++ b/tests/e2e/test_dispatch_overlay_visibility.py
@@ -312,10 +312,17 @@ def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
     # have no token default (they fail closed), and `deploy up` would otherwise
     # auto-generate a random token; we write fixed tokens here so the bearer
     # below is predictable, and pass the provider secret through.
+    # The endpoint override rides the same .env: without it the container-side
+    # config expansion falls back to the provider's built-in default gateway.
+    base_url_line = (
+        f"ALS_APG_BASE_URL={os.environ['ALS_APG_BASE_URL']}\n"
+        if os.environ.get("ALS_APG_BASE_URL")
+        else ""
+    )
     (project_dir / ".env").write_text(
         "EVENT_DISPATCHER_TOKEN=dev-token\n"
         "DISPATCH_WORKER_TOKEN=dev-token\n"
-        f"ALS_APG_API_KEY={os.environ['ALS_APG_API_KEY']}\n",
+        f"ALS_APG_API_KEY={os.environ['ALS_APG_API_KEY']}\n" + base_url_line,
         encoding="utf-8",
     )
 

--- a/tests/e2e/test_dockerfile_e2e.py
+++ b/tests/e2e/test_dockerfile_e2e.py
@@ -294,6 +294,15 @@ def test_generated_image_serves_agent_over_http(built_image):
     api_key = os.environ["ALS_APG_API_KEY"]  # guaranteed present by requires_als_apg
     env_args = ["-e", f"ALS_APG_API_KEY={api_key}"]
 
+    # The endpoint override rides the same contract. It is deliberately absent
+    # from the image (build-time rendering never bakes the builder's
+    # environment), so a run pointed at a non-default gateway must pass it in
+    # here exactly as a deployment passes it via env_file — otherwise the
+    # container dials the provider's built-in default instead.
+    base_url = os.environ.get("ALS_APG_BASE_URL")
+    if base_url:
+        env_args += ["-e", f"ALS_APG_BASE_URL={base_url}"]
+
     run = subprocess.run(
         [
             "docker",

--- a/tests/e2e/test_in_context_backend.py
+++ b/tests/e2e/test_in_context_backend.py
@@ -79,7 +79,10 @@ if _ALS_APG_KEY:
     _PROVIDER = "als-apg"
     _PROVIDER_API_KEY = _ALS_APG_KEY
     _SUBAGENT_MODEL = "claude-haiku-4-5-20251001"  # bare wire id; gateway rejects prefixed slugs
-    _PROVIDER_BASE_URL = "https://llm.gianlucamartino.com"
+    # Overridable so a run can be aimed at another gateway; same convention as
+    # judge.py. The value is written into the generated project's config, which
+    # is what the MCP subprocess reads — it does not inherit this process's env.
+    _PROVIDER_BASE_URL = os.environ.get("ALS_APG_BASE_URL", "https://llm.gianlucamartino.com")
     _BACKEND_MODEL = "als-apg/claude-haiku-4-5-20251001"
     _EXPECTED_WIRE = "claude-haiku-4-5-20251001"
 elif _CBORG_KEY:

--- a/tests/e2e/test_llm_channel_namer.py
+++ b/tests/e2e/test_llm_channel_namer.py
@@ -36,7 +36,7 @@ def get_available_providers() -> dict[str, dict]:
         (
             "als-apg",
             ["ALS_APG_API_KEY"],
-            "https://llm.gianlucamartino.com",
+            os.environ.get("ALS_APG_BASE_URL", "https://llm.gianlucamartino.com"),
             "claude-haiku-4-5-20251001",
         ),
         ("cborg", ["CBORG_API_KEY"], "https://api.cborg.lbl.gov", "anthropic/claude-haiku"),

--- a/tests/e2e/test_llm_providers.py
+++ b/tests/e2e/test_llm_providers.py
@@ -152,7 +152,7 @@ def get_available_providers_raw() -> dict[str, dict[str, Any]]:
         (
             "als-apg",
             ["ALS_APG_API_KEY"],
-            "https://llm.gianlucamartino.com",
+            os.environ.get("ALS_APG_BASE_URL", "https://llm.gianlucamartino.com"),
             "claude-haiku-4-5-20251001",
         ),
     ]

--- a/tests/models/test_providers_als_apg.py
+++ b/tests/models/test_providers_als_apg.py
@@ -140,6 +140,58 @@ class TestALSAPGExecuteCompletion:
         assert mock_exec.call_args.kwargs["base_url"] == "https://llm.gianlucamartino.com"
 
 
+class TestALSAPGBaseURLEnvOverride:
+    """ALS_APG_BASE_URL redirects the adapter regardless of config.
+
+    The env var is the break-glass lever for pointing an already-deployed
+    system at a fallback gateway without rebuilding images: it must beat
+    both an explicit base_url argument and the built-in default.
+    """
+
+    def test_declares_the_env_var_name(self):
+        assert ALSAPGProviderAdapter.base_url_env_var == "ALS_APG_BASE_URL"
+
+    def test_env_var_wins_over_explicit_base_url(self, monkeypatch):
+        monkeypatch.setenv("ALS_APG_BASE_URL", "https://fallback.example.org/v1")
+        with patch(COMPLETION, return_value="ok") as mock_exec:
+            ALSAPGProviderAdapter().execute_completion(
+                message="hi", model_id="m", api_key="key", base_url="https://proxy"
+            )
+        assert mock_exec.call_args.kwargs["base_url"] == "https://fallback.example.org/v1"
+
+    def test_env_var_fills_missing_base_url(self, monkeypatch):
+        monkeypatch.setenv("ALS_APG_BASE_URL", "https://fallback.example.org/v1")
+        with patch(COMPLETION, return_value="ok") as mock_exec:
+            ALSAPGProviderAdapter().execute_completion(
+                message="hi", model_id="m", api_key="key", base_url=None
+            )
+        assert mock_exec.call_args.kwargs["base_url"] == "https://fallback.example.org/v1"
+
+    def test_empty_env_var_is_ignored(self, monkeypatch):
+        """An empty export must not blank the URL — fall through to the default."""
+        monkeypatch.setenv("ALS_APG_BASE_URL", "")
+        with patch(COMPLETION, return_value="ok") as mock_exec:
+            ALSAPGProviderAdapter().execute_completion(
+                message="hi", model_id="m", api_key="key", base_url=None
+            )
+        assert mock_exec.call_args.kwargs["base_url"] == "https://llm.gianlucamartino.com"
+
+    def test_env_var_redirects_check_health_too(self, monkeypatch):
+        """osprey health must probe the endpoint completions actually use."""
+        monkeypatch.setenv("ALS_APG_BASE_URL", "https://fallback.example.org/v1")
+        with patch(HEALTH, return_value=(True, "ok")) as mock_health:
+            ALSAPGProviderAdapter().check_health(api_key="key", base_url="https://proxy")
+        assert mock_health.call_args.kwargs["base_url"] == "https://fallback.example.org/v1"
+
+    def test_unset_env_var_preserves_existing_behavior(self, monkeypatch):
+        monkeypatch.delenv("ALS_APG_BASE_URL", raising=False)
+        with patch(COMPLETION, return_value="ok") as mock_exec:
+            ALSAPGProviderAdapter().execute_completion(
+                message="hi", model_id="m", api_key="key", base_url="https://proxy"
+            )
+        assert mock_exec.call_args.kwargs["base_url"] == "https://proxy"
+
+
 class TestALSAPGCheckHealth:
     """check_health forwards to the litellm health helper with model fallback."""
 

--- a/tests/models/test_providers_als_apg.py
+++ b/tests/models/test_providers_als_apg.py
@@ -15,12 +15,25 @@ asserting True. That default is pinned below.
 
 from unittest.mock import patch
 
+import pytest
 from pydantic import BaseModel
 
 from osprey.models.providers.als_apg import ALSAPGProviderAdapter
 
 COMPLETION = "osprey.models.providers.als_apg.execute_litellm_completion"
 HEALTH = "osprey.models.providers.als_apg.check_litellm_health"
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_base_url_override(monkeypatch):
+    """Clear ALS_APG_BASE_URL so these tests describe the adapter, not the host.
+
+    The adapter reads this variable at request time by design, so a CI runner
+    (or a developer shell) that exports it would otherwise rewrite the base_url
+    every assertion below is about. Tests that exercise the override set it
+    explicitly, which still wins — the fixture runs first.
+    """
+    monkeypatch.delenv("ALS_APG_BASE_URL", raising=False)
 
 
 class _Sample(BaseModel):


### PR DESCRIPTION
Lets a provider's endpoint be redirected at runtime, without a rebuild.

## Why

A provider's `base_url` is reachable today only through `config.yml`. That is
the right home for it, but rendered projects bake their config into a container
image at build time, so changing the endpoint of an already-deployed system
means a full rebuild-and-redeploy cycle. That is the wrong cost for the one
value most likely to need changing under time pressure: which gateway the
provider talks to.

## What

Providers may declare `base_url_env_var`. When that variable is set and
non-empty, it wins over every other source:

```
<PROVIDER>_BASE_URL env var   →  beats
api.providers.<name>.base_url →  beats
the built-in default URL
```

`als-apg` declares `ALS_APG_BASE_URL` — the name `tests/e2e/judge.py` and the
benchmark matrix already use for exactly this purpose, so the change promotes an
existing harness convention into the runtime rather than inventing a name.
The override is opt-in per provider, so it can never collide with a variable
another layer owns (notably `ANTHROPIC_BASE_URL`).

Both resolution paths honor it:

- **Framework calls** — `LiteLLMDelegatingProvider._effective_base_url`, so
  completions *and* health checks probe the same endpoint. An empty value is
  treated as unset rather than blanking the URL.
- **Agent calls** — `ClaudeCodeModelResolver` when building
  `ANTHROPIC_BASE_URL`, read through the `os.environ` + project-`.env` overlay
  already used for `${VAR}` config expansion. The lookup is a parameter, so the
  pure resolver stays free of ambient-environment reads and the lever behaves
  identically across the CLI, SDK runner, web terminal, and dispatch worker.

Config templates now ship the `als-apg` `base_url` as
`${ALS_APG_BASE_URL:-<default>}`, so a freshly rendered project is redirectable
even though its config is baked at build time.

## CI

The endpoint comes from the `ALS_APG_BASE_URL` repository variable, exported at
workflow level so preflight probes and pytest jobs follow the same redirect. The
probes fall back to the previous URL when the variable is unset and tolerate a
value written with or without a trailing `/v1`, so no endpoint is pinned in the
workflow.

## Tests

12 new tests across the two layers, covering precedence over both config and
default, empty-value handling, health-check redirect, the injected-mapping form,
and the on-disk `.env` path. Existing behavior with the variable unset is pinned
unchanged.