### PR TITLE
fix(build): defer unresolved telemetry credentials at build time

### DIFF
--- a/src/osprey/build/claude_code_resolver.py
+++ b/src/osprey/build/claude_code_resolver.py
@@ -428,6 +428,7 @@ def load_provider_spec(
     *,
     provider: str | None = None,
     include_telemetry: bool = True,
+    defer_unresolved_telemetry_creds: bool = False,
 ) -> ClaudeCodeModelSpec | None:
     """Read ``config.yml``, expand ``${VAR}`` placeholders, and resolve the spec.
 
@@ -478,6 +479,7 @@ def load_provider_spec(
         cc_config,
         cfg.get("api", {}).get("providers", {}),
         include_telemetry=include_telemetry,
+        defer_unresolved_telemetry_creds=defer_unresolved_telemetry_creds,
         environ=lookup,
     )
 
@@ -605,6 +607,7 @@ class ClaudeCodeModelResolver:
         api_providers: dict | None = None,
         *,
         include_telemetry: bool = True,
+        defer_unresolved_telemetry_creds: bool = False,
         environ: Mapping[str, str] | None = None,
     ) -> ClaudeCodeModelSpec | None:
         """Build a ``ClaudeCodeModelSpec`` from config.
@@ -831,6 +834,7 @@ class ClaudeCodeModelResolver:
                     telemetry_cfg,
                     in_container=_running_in_container(),
                     openobserve_host=_openobserve_host_override(),
+                    defer_unresolved_creds=defer_unresolved_telemetry_creds,
                 )
             )
 

--- a/src/osprey/build/claude_code_telemetry.py
+++ b/src/osprey/build/claude_code_telemetry.py
@@ -198,7 +198,9 @@ def _resolve_telemetry_endpoint(
     return endpoint
 
 
-def _openobserve_auth_header(telemetry_cfg: dict) -> tuple[str, str]:
+def _openobserve_auth_header(
+    telemetry_cfg: dict, *, defer_unresolved: bool = False
+) -> tuple[str, str] | None:
     """Compute the HTTP Basic auth header for an OpenObserve backend.
 
     Both credentials arrive already ``${VAR}``-expanded in the config (the
@@ -206,15 +208,25 @@ def _openobserve_auth_header(telemetry_cfg: dict) -> tuple[str, str]:
     so this reads them straight from the config — never ``os.environ``. The
     base64 header value cannot be expressed as ``${VAR}``; it is computed here.
 
+    Args:
+        telemetry_cfg: The ``claude_code.telemetry`` config section.
+        defer_unresolved: When True, an unresolved ``${VAR}`` credential returns
+            ``None`` (with a warning) instead of raising. Build-time callers set
+            this: they render a scaffold whose credentials belong to the
+            *deployment*, and the runtime re-resolves them at agent-spawn. A
+            missing or blank credential still raises — no later step can fill
+            that in.
+
     Returns:
-        ``("Authorization", "Basic <base64(user:password)>")``.
+        ``("Authorization", "Basic <base64(user:password)>")``, or ``None`` when
+        a credential is deferred.
 
     Raises:
         ValueError: If either credential is missing or blank — an
             unauthenticated exporter to an auth-gated store would silently drop
             every span, so refuse to emit one — or if either credential still
             carries a literal ``${VAR}`` (an unresolved placeholder whose env
-            var is unset).
+            var is unset) and ``defer_unresolved`` is False.
     """
     oo = telemetry_cfg.get("openobserve") or {}
     user = oo.get("user")
@@ -232,6 +244,14 @@ def _openobserve_auth_header(telemetry_cfg: dict) -> tuple[str, str]:
     # instead of failing clearly here at resolve() time.
     for field_name, cred in (("openobserve.user", user), ("openobserve.password", password)):
         if "${" in str(cred):
+            if defer_unresolved:
+                warnings.warn(
+                    f"{field_name} still contains an unresolved '${{VAR}}': {cred!r}. "
+                    "Omitting the OpenObserve auth header from the rendered "
+                    "scaffold; the runtime must resolve it at agent-spawn.",
+                    stacklevel=2,
+                )
+                return None
             raise TelemetryConfigError(
                 f"{field_name} still contains an unresolved '${{VAR}}': {cred!r}. "
                 "The referenced environment variable is unset — refusing to "
@@ -246,6 +266,7 @@ def _build_telemetry_env(
     *,
     in_container: bool = False,
     openobserve_host: str | None = None,
+    defer_unresolved_creds: bool = False,
 ) -> dict[str, str]:
     """Build the OTEL/telemetry env block from the ``claude_code.telemetry`` config.
 
@@ -293,8 +314,9 @@ def _build_telemetry_env(
     if configured:
         headers.update(_parse_header_map(configured))
     if telemetry_cfg.get("backend") == "openobserve":
-        key, value = _openobserve_auth_header(telemetry_cfg)
-        headers[key] = value
+        auth = _openobserve_auth_header(telemetry_cfg, defer_unresolved=defer_unresolved_creds)
+        if auth is not None:
+            headers[auth[0]] = auth[1]
     if headers:
         env["OTEL_EXPORTER_OTLP_HEADERS"] = _render_kv_map(headers)
 

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -670,8 +670,13 @@ def build(
         # `build && deploy` chain at the checkpoint the operator watches.
         from osprey.build.claude_code_resolver import load_provider_spec
 
+        # Telemetry credentials are exempt from this strictness: a profile may
+        # legitimately leave them as ${VAR} for the *deployment* to supply, and
+        # the runtime re-resolves them at agent-spawn (degrading telemetry, not
+        # the agent, if they are still unset). Aborting here would force every
+        # such build to hand the builder production observability secrets.
         try:
-            load_provider_spec(project_path)
+            load_provider_spec(project_path, defer_unresolved_telemetry_creds=True)
         except ValueError as e:
             raise BuildProfileError(str(e)) from e
 

--- a/src/osprey/cli/templates/claude_code.py
+++ b/src/osprey/cli/templates/claude_code.py
@@ -246,7 +246,12 @@ def build_claude_code_context(
 
     api_providers = config.get("api", {}).get("providers", {})
     try:
-        model_spec = ClaudeCodeModelResolver.resolve(claude_code_config, api_providers)
+        # Build time: telemetry credentials may legitimately be the
+        # deployment's to supply (the runtime re-resolves them at agent-spawn),
+        # so an unresolved ${VAR} omits the auth header instead of aborting.
+        model_spec = ClaudeCodeModelResolver.resolve(
+            claude_code_config, api_providers, defer_unresolved_telemetry_creds=True
+        )
     except ValueError as exc:
         warnings.warn(str(exc), stacklevel=2)
         model_spec = None

--- a/tests/cli/test_telemetry_env.py
+++ b/tests/cli/test_telemetry_env.py
@@ -287,6 +287,63 @@ def test_creds_failloud_on_unresolved_var(creds):
         _build_telemetry_env({"enabled": True, "backend": "openobserve", "openobserve": creds})
 
 
+@pytest.mark.parametrize(
+    "creds",
+    [
+        {"user": "${ZO_ROOT_USER_EMAIL}", "password": "p"},
+        {"user": "u", "password": "${ZO_ROOT_USER_PASSWORD}"},
+    ],
+)
+def test_creds_deferred_at_build_time_omit_header(creds, recwarn):
+    """``defer_unresolved_creds`` downgrades the hard failure to a warning.
+
+    A build renders a project whose telemetry credentials are supplied by the
+    *deployment* (the worker re-resolves them against its own .env at
+    agent-spawn — see dispatch_api). Aborting the build there would force every
+    such project to hand the builder production secrets. The header is omitted
+    rather than encoded from a placeholder, so nothing bogus is baked.
+    """
+    env = _build_telemetry_env(
+        {"enabled": True, "backend": "openobserve", "openobserve": creds},
+        defer_unresolved_creds=True,
+    )
+
+    assert "OTEL_EXPORTER_OTLP_HEADERS" not in env
+    # Telemetry itself stays configured — only the auth header is deferred.
+    assert env["CLAUDE_CODE_ENABLE_TELEMETRY"] == "1"
+    assert any("unresolved" in str(w.message) for w in recwarn)
+
+
+def test_creds_deferred_flag_does_not_excuse_missing_creds():
+    """Deferral covers an unresolved ${VAR}, not an absent credential.
+
+    A blank/missing credential is a config error at every stage — there is no
+    later resolution step that could fill it in.
+    """
+    with pytest.raises(ValueError):
+        _build_telemetry_env(
+            {"enabled": True, "backend": "openobserve", "openobserve": {"user": "u"}},
+            defer_unresolved_creds=True,
+        )
+
+
+def test_creds_default_still_fails_loud_for_runtime():
+    """The default is unchanged: spawn-time callers must still fail loud.
+
+    The dispatch worker re-resolves at agent-spawn with the deployment's own
+    .env; there is no later stage, so an unresolved cred there is terminal for
+    telemetry and must not be papered over.
+    """
+    with pytest.raises(ValueError):
+        _build_telemetry_env(
+            {
+                "enabled": True,
+                "backend": "openobserve",
+                "openobserve": {"user": "${ZO_ROOT_USER_EMAIL}", "password": "p"},
+            }
+        )
+
+
 def test_config_headers_merge_auth_wins():
     """Config headers are merged; computed auth wins on key collision."""
     env = _build_telemetry_env(


### PR DESCRIPTION
`osprey build` aborted when a profile left telemetry credentials as `${VAR}`.

That is a legitimate configuration: the credentials belong to the **deployment**, and the runtime re-resolves them at agent-spawn (`dispatch_api` catches `TelemetryConfigError` and degrades telemetry without taking the agent down). Failing the build forced every such project to hand its builder production observability secrets.

## Change

Build-time callers (`build_cmd`'s strict validation and the Claude Code context render) pass `defer_unresolved_telemetry_creds=True`. An unresolved credential then warns and **omits** the auth header instead of raising — so no placeholder is ever base64-encoded into a rendered scaffold.

## What is deliberately unchanged

- **Default stays strict.** Spawn-time resolution still fails loud; there is no later stage that could fill the value in.
- **Missing/blank credentials still raise everywhere.** Deferral covers an unresolved placeholder, not an absent secret.
- **Nothing bogus is baked.** The header is dropped, not encoded from a literal — the failure mode the original guard exists to prevent.

## Tests

Four new cases in `tests/cli/test_telemetry_env.py`: deferral omits the header for either credential, deferral does not excuse a missing credential, and the default path still fails loud. Full `tests/cli` + `tests/models`: 2537 passed.