### PR TITLE
fix(bridges): route artifact delivery on the served bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ Compatibility is documented in release notes, not encoded in the version string.
   `claude_code.default_model` (e.g. `--set model=...`) names a model the
   selected provider does not serve. Previously the build only warned and the
   deployed web terminals crash-looped behind the reverse proxy (502).
+- Chat bridges no longer drop an artifact whose conversion failed. A run's
+  artifact descriptors predict `image/png` for everything the worker intends to
+  render, but a conversion that fails at fetch time makes the byte route serve
+  the original file instead — and a delivery path routing on the prediction
+  rejected those bytes as "not a PNG" and discarded them with no error anywhere.
+  Delivery now routes on what actually arrived (the bytes and the served
+  Content-Type), so a failed render is delivered as a document rather than lost,
+  and its filename takes the extension of what was served. The same prediction
+  drove prior-image re-injection, which could hand the agent a text file
+  labelled as an image on a follow-up question; a prior artifact is now
+  re-injected under the type it was really served as, or not at all.
 
 ### Added
 

--- a/src/osprey/bridges/core/__init__.py
+++ b/src/osprey/bridges/core/__init__.py
@@ -37,11 +37,12 @@ from .artifacts import (
     MAX_ARTIFACT_BYTES,
     MAX_DOC_BYTES,
     PNG_MAGIC,
+    FetchedArtifact,
+    artifact_descriptors,
     artifact_ids,
     ext_for_mime,
     fetch_artifact,
     safe_label,
-    split_artifacts,
 )
 from .capabilities import pair_supports
 from .config import TERMINAL_STATUSES, CoreConfig
@@ -83,13 +84,14 @@ __all__ = [
     "PNG_MAGIC",
     "DispatchClient",
     "DispatchError",
+    "FetchedArtifact",
+    "artifact_descriptors",
     "artifact_ids",
     "ext_for_mime",
     "fetch_artifact",
     "gate_open",
     "pair_supports",
     "safe_label",
-    "split_artifacts",
     # the seam adapters implement
     "RESERVED_ENTRY_KEYS",
     "ChannelOps",

--- a/src/osprey/bridges/core/artifacts.py
+++ b/src/osprey/bridges/core/artifacts.py
@@ -1,23 +1,34 @@
-"""Fetch agent-generated plot artifacts from the dispatch worker.
+"""Fetch agent-generated artifacts from the dispatch worker.
 
 This is the channel-agnostic *fetch* half of artifact delivery: given a run and
 an artifact id, pull the bytes over the worker's authenticated byte route and
-apply the size / PNG-magic guards. What a channel then DOES with those bytes —
-republish them as a public object for an image widget, attach them as MIME
-parts, share them over WebDAV — stays in the channel package.
+apply the size guard. What a channel then DOES with those bytes — republish them
+as a public object for an image widget, attach them as MIME parts, share them
+over WebDAV — stays in the channel package.
 
-``artifact_ids`` normalizes the run-status body's ``artifacts`` field (osprey
-#363 descriptor dicts, or bare id strings from an older worker) to a plain list
-of artifact-id strings.
+A run's ``artifacts`` descriptors are a *prediction*, written when the run
+completes: they promise ``delivered_mime: image/png`` for everything the worker
+intends to render, but whether the render happens is only known at fetch time
+(a converter dependency can be missing, a renderer can crash), and the byte
+route then serves the original bytes under their real Content-Type. So a
+descriptor may name and label an artifact, and must never decide what it *is*:
+:class:`FetchedArtifact` carries the two facts that cannot lie — the bytes
+(``is_png``) and the Content-Type the worker served them under. Routing on the
+prediction instead loses artifacts silently (osprey #503).
+
+``artifact_ids`` and ``artifact_descriptors`` normalize the run-status body's
+``artifacts`` field (osprey #363 descriptor dicts, or bare id strings from an
+older worker) to ids and to descriptor dicts respectively.
 
 Nothing here raises to the caller: a fetch failure must degrade to fewer (or
-zero) images, never break the text answer. NO channel imports, NO osprey
+zero) attachments, never break the text answer. NO channel imports, NO osprey
 dispatch imports.
 """
 
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Any
 
 import httpx
@@ -39,6 +50,34 @@ MAX_ARTIFACT_BYTES = 2 * 1024 * 1024
 # rendering/sanity bound, not a memory bound — fetch_artifact reads the full
 # body before the size check runs.
 MAX_DOC_BYTES = 10 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class FetchedArtifact:
+    """One artifact as the worker actually served it.
+
+    Attributes:
+        data: The bytes, already past the size guard.
+        content_type: The served Content-Type with any parameters stripped
+            (``text/csv; charset=utf-8`` -> ``text/csv``), or ``None`` when the
+            worker sent none. Authoritative over the run descriptor's
+            ``delivered_mime``, which only predicted what a fetch would produce.
+    """
+
+    data: bytes
+    content_type: str | None
+
+    @property
+    def is_png(self) -> bool:
+        """Whether the bytes really are a PNG — magic bytes, not a header claim."""
+        return self.data.startswith(PNG_MAGIC)
+
+
+def _bare_mime(content_type: str | None) -> str | None:
+    """Strip parameters and case from a Content-Type; ``None`` stays ``None``."""
+    if not content_type:
+        return None
+    return content_type.split(";", 1)[0].strip().lower() or None
 
 
 def artifact_ids(artifacts: list[Any] | None) -> list[str]:
@@ -63,37 +102,34 @@ def artifact_ids(artifacts: list[Any] | None) -> list[str]:
     return ids
 
 
-def split_artifacts(artifacts: list[Any] | None) -> tuple[list[str], list[dict]]:
-    """Split a run's ``artifacts`` field into ``(image_ids, doc_descriptors)``.
+def artifact_descriptors(artifacts: list[Any] | None) -> list[dict]:
+    """Normalize a run's ``artifacts`` field to descriptor dicts, in order.
 
     Mirrors ``artifact_ids``'s tolerance for the same input shapes (osprey #363
-    descriptor dicts, bare id strings from an older worker, or a mix), but
-    additionally routes each entry by ``delivered_mime``: PNG images go to
-    ``image_ids`` (id strings, matching the inline-image path); every other
-    artifact — including a descriptor with no ``delivered_mime`` key at all —
-    goes to ``doc_descriptors`` as the *full* dict, since a document delivery
-    path needs ``filename``/``delivered_mime`` that a bare id string can't
-    carry. A bare string is back-compat for an older worker with no mime at
-    all, so it is treated as the existing PNG image path. Anything else — a
-    dict without a usable ``artifact_id``, a non-str/non-dict element — is
-    skipped rather than raised on, same as ``artifact_ids``. Every id ends up
-    in exactly one bucket.
+    descriptor dicts, bare id strings from an older worker, or a mix), but keeps
+    the *whole* dict so a delivery path also gets the ``filename`` /
+    ``delivered_mime`` naming hints an id string cannot carry; a bare string
+    becomes ``{"artifact_id": <id>}``, a descriptor with no hints at all.
+    Anything else — a dict without a usable ``artifact_id``, a non-str/non-dict
+    element — is skipped rather than raised on, so a malformed entry costs at
+    most one artifact, never the whole answer.
+
+    It deliberately does NOT route by ``delivered_mime``: that field is a
+    prediction made before anything was rendered, and an artifact whose
+    conversion failed at fetch time arrives as its original bytes. Route on what
+    :func:`fetch_artifact` actually returns instead (osprey #503).
     """
-    image_ids: list[str] = []
-    doc_descriptors: list[dict] = []
+    out: list[dict] = []
     for a in artifacts or []:
         if isinstance(a, str):
             if a:
-                image_ids.append(a)
+                out.append({"artifact_id": a})
         elif isinstance(a, dict):
             aid = a.get("artifact_id")
             if isinstance(aid, str) and aid:
-                if a.get("delivered_mime") == "image/png":
-                    image_ids.append(aid)
-                else:
-                    doc_descriptors.append(a)
+                out.append(a)
         # else: unknown shape -> skip
-    return image_ids, doc_descriptors
+    return out
 
 
 # Fixed allowlist: an extension is derived ONLY from the mime, never a
@@ -138,16 +174,20 @@ def fetch_artifact(
     run_id: str,
     artifact_id: str,
     *,
-    max_bytes: int = MAX_ARTIFACT_BYTES,
-    require_png: bool = True,
-) -> bytes | None:
-    """Fetch one artifact's bytes from the worker; ``None`` on any failure or a
-    payload that fails the size guard (or the PNG-magic guard when required).
+    max_bytes: int = MAX_DOC_BYTES,
+) -> FetchedArtifact | None:
+    """Fetch one artifact from the worker; ``None`` on any failure or a payload
+    that fails the size guard.
 
-    ``require_png`` defaults to ``True`` for image widgets that only render PNG.
-    A channel that delivers arbitrary MIME (attaching the worker's
-    ``delivered_mime`` bytes verbatim) passes ``require_png=False`` and a
-    suitable ``max_bytes``, keeping only the size guard.
+    The only content the fetch rejects is content it could not get or could not
+    fit: what the bytes turn out to BE is the caller's decision, taken from the
+    returned :class:`FetchedArtifact`. A fetcher that dropped a payload for
+    contradicting the run's ``delivered_mime`` prediction would make an artifact
+    vanish with no error anywhere (osprey #503).
+
+    ``max_bytes`` defaults to the document ceiling; a caller that will only
+    accept an image applies :data:`MAX_ARTIFACT_BYTES` to the returned bytes,
+    which are read in full either way.
 
     The caller owns the ``httpx.Client``; build it with
     ``httpx.Client(trust_env=cfg.trust_env)`` so proxy handling comes from
@@ -159,6 +199,7 @@ def fetch_artifact(
         resp = http.get(url, headers=headers)
         resp.raise_for_status()
         data = resp.content
+        content_type = resp.headers.get("content-type")
     except Exception as exc:
         # Deliberately broad: ``httpx.InvalidURL`` does NOT subclass
         # ``httpx.HTTPError`` and is raised at URL-construction time, before
@@ -176,7 +217,4 @@ def fetch_artifact(
             max_bytes,
         )
         return None
-    if require_png and not data.startswith(PNG_MAGIC):
-        logger.warning("artifact %s/%s is not a PNG, skipping", run_id, artifact_id)
-        return None
-    return data
+    return FetchedArtifact(data=data, content_type=_bare_mime(content_type))

--- a/src/osprey/bridges/core/dispatch_client.py
+++ b/src/osprey/bridges/core/dispatch_client.py
@@ -23,8 +23,11 @@ retry policy reads it to force such a rejection non-retryable.
 a current worker returns a list of **descriptor dicts**
 (``{"artifact_id", "filename", "source_mime", "delivered_mime", "convertible"}``);
 an older worker (during the deploy window) returns bare id strings. Either shape
-is normalized to ids downstream by
-:func:`osprey.bridges.core.artifacts.artifact_ids`.
+is normalized downstream by :func:`osprey.bridges.core.artifacts.artifact_ids`
+(to ids) or :func:`osprey.bridges.core.artifacts.artifact_descriptors` (to whole
+descriptors). ``delivered_mime`` is what the worker *predicted* it would serve,
+not what a fetch returns — see that module on why delivery routes on the served
+Content-Type instead.
 ``[]`` when there are no artifacts or the worker predates the field.
 ``input_artifacts`` is the run-status body's list of inbound files the worker
 ingested for this run (``[{entry_id, filename, mime}]``), passed through

--- a/src/osprey/bridges/core/pipeline.py
+++ b/src/osprey/bridges/core/pipeline.py
@@ -51,7 +51,7 @@ from typing import Any
 import httpx
 
 from . import retry, retry_queue
-from .artifacts import fetch_artifact
+from .artifacts import FetchedArtifact, fetch_artifact
 from .capabilities import pair_supports
 from .config import CoreConfig
 from .dedup import DedupStore
@@ -120,18 +120,19 @@ _PRIOR_FETCH_TIMEOUT = 30.0
 
 def _default_fetch_prior_artifact(
     cfg: CoreConfig, run_id: str | None, descriptor: Mapping[str, Any], max_bytes: int
-) -> bytes | None:
-    """Fetch one prior artifact's bytes via the worker byte route; ``None`` on any
-    failure. An adapter whose channel republishes artifacts at a stable URL (and
-    stamps ``public_url`` on the descriptor via ``deliver_files``) injects its own
+) -> FetchedArtifact | None:
+    """Fetch one prior artifact via the worker byte route; ``None`` on any failure.
+
+    Returns the served Content-Type alongside the bytes, because the descriptor's
+    ``delivered_mime`` is only a prediction of what a fetch would produce. An
+    adapter whose channel republishes artifacts at a stable URL (and stamps
+    ``public_url`` on the descriptor via ``deliver_files``) injects its own
     fetcher with a fallback for artifacts the worker has since swept."""
     entry_id = descriptor.get("entry_id")
     if not run_id or not isinstance(entry_id, str) or not entry_id or max_bytes <= 0:
         return None
     with httpx.Client(timeout=_PRIOR_FETCH_TIMEOUT, trust_env=cfg.trust_env) as http:
-        return fetch_artifact(
-            http, cfg, run_id=run_id, artifact_id=entry_id, max_bytes=max_bytes, require_png=False
-        )
+        return fetch_artifact(http, cfg, run_id=run_id, artifact_id=entry_id, max_bytes=max_bytes)
 
 
 @dataclass
@@ -143,8 +144,10 @@ class PipelineDeps:
     ``(ops, dedup, message_id, entry, result)`` on a retryable terminal failure.
     ``probe_capability`` is the per-dispatch ``input_files`` probe, called
     ``(cfg, "input_files")``; ``fetch_prior_artifact`` recovers one prior IMAGE
-    artifact's bytes, called ``(cfg, run_id, descriptor, max_bytes)``. All three are
-    injectable so tests run no network I/O.
+    artifact, called ``(cfg, run_id, descriptor, max_bytes)`` and returning a
+    :class:`~osprey.bridges.core.artifacts.FetchedArtifact` (bytes plus the type they
+    were served under) or ``None``. All three are injectable so tests run no network
+    I/O.
     """
 
     cfg: CoreConfig
@@ -154,7 +157,7 @@ class PipelineDeps:
     history: HistoryStore | None = None
     park: Callable[..., Any] = retry_queue.park
     probe_capability: Callable[..., bool] = pair_supports
-    fetch_prior_artifact: Callable[..., bytes | None] = _default_fetch_prior_artifact
+    fetch_prior_artifact: Callable[..., FetchedArtifact | None] = _default_fetch_prior_artifact
 
 
 def _run_id_persister(dedup: DedupStore, message_id: str) -> Callable[[str], None]:
@@ -546,10 +549,25 @@ def _reinject_prior_images(
     injected: list[dict[str, Any]] = []
     remaining = REINJECT_MAX_TOTAL_BYTES
     for ti, ai, run_id, desc in reversed(selected):
-        data = deps.fetch_prior_artifact(deps.cfg, run_id, desc, remaining)
-        if data is None:
+        fetched = deps.fetch_prior_artifact(deps.cfg, run_id, desc, remaining)
+        if fetched is None:
             _flag_expired(turns, ti, ai)
             continue
+        # ``delivered_mime`` only PREDICTED an image (it is stamped at run
+        # completion, before any conversion runs); the byte route's Content-Type
+        # is what was actually served. An artifact whose conversion failed comes
+        # back as its original, non-image bytes — re-injecting those as the image
+        # the agent is told to look at is worse than not re-injecting them, and
+        # the descriptor rides ``conversation_so_far`` either way.
+        mime = fetched.content_type or desc.get("delivered_mime")
+        if mime not in IMAGE_MIMES:
+            logger.warning(
+                "prior artifact served as %s, not the predicted %s; not re-injected",
+                mime,
+                desc.get("delivered_mime"),
+            )
+            continue
+        data = fetched.data
         digest = hashlib.sha256(data).digest()
         if digest in seen:
             continue  # already attached to this message (or an earlier prior)
@@ -557,7 +575,7 @@ def _reinject_prior_images(
         injected.append(
             {
                 "filename": desc.get("filename"),
-                "mime": desc.get("delivered_mime"),
+                "mime": mime,
                 "content_b64": base64.b64encode(data).decode("ascii"),
                 "ingest": False,
             }

--- a/src/osprey/bridges/nextcloud_talk/ops.py
+++ b/src/osprey/bridges/nextcloud_talk/ops.py
@@ -72,10 +72,10 @@ from osprey.bridges.core import (
     InboundEvent,
     InputDownload,
     ReplyContext,
+    artifact_descriptors,
     ext_for_mime,
     fetch_artifact,
     safe_label,
-    split_artifacts,
 )
 
 from .client import MAX_DOWNLOAD_BYTES, REQUEST_TIMEOUT, DavTooLargeError, TalkClient, upload_dir
@@ -310,6 +310,13 @@ def _upload_name(label: Any, extension: str, fallback: Any) -> str:
     stem = _segment(label) or _segment(fallback) or "artifact"
     if extension and stem.lower().endswith(extension.lower()):
         return stem
+    # The worker's filename is predicted alongside delivered_mime, so a name carrying a
+    # DIFFERENT extension is a prediction the delivery contradicted ("data.png" for a
+    # render that never happened). Replace it rather than stack it — the extension still
+    # comes only from the mime.
+    root, dot, suffix = stem.rpartition(".")
+    if dot and root and len(suffix) <= 5 and suffix.isalnum():
+        stem = root
     return f"{stem}{extension}"
 
 
@@ -678,8 +685,8 @@ class NextcloudTalkOps:
             logger.debug("no room or run id to deliver artifacts for; text only")
             return {}
         artifacts = result.get("artifacts")
-        image_ids, docs = split_artifacts(artifacts if isinstance(artifacts, list) else None)
-        if not image_ids and not docs:
+        descriptors = artifact_descriptors(artifacts if isinstance(artifacts, list) else None)
+        if not descriptors:
             return {}
         try:
             directory = upload_dir(room, run_id)
@@ -691,36 +698,8 @@ class NextcloudTalkOps:
             )
             return {}
 
-        for artifact_id in image_ids:
-            # The image bucket is PNG by construction (that is what routes an artifact
-            # into it), so the magic-byte guard stays on and the extension is fixed.
-            self._deliver_one(
-                room,
-                directory,
-                run_id,
-                artifact_id,
-                name=_upload_name(artifact_id, ".png", artifact_id),
-                max_bytes=MAX_ARTIFACT_BYTES,
-                require_png=True,
-            )
-        for descriptor in docs:
-            doc_id = descriptor.get("artifact_id")
-            if not isinstance(doc_id, str) or not doc_id:
-                continue  # split_artifacts already drops these; belt for a future shape
-            mime = descriptor.get("delivered_mime")
-            self._deliver_one(
-                room,
-                directory,
-                run_id,
-                doc_id,
-                name=_upload_name(
-                    descriptor.get("filename"),
-                    ext_for_mime(mime if isinstance(mime, str) else None),
-                    doc_id,
-                ),
-                max_bytes=MAX_DOC_BYTES,
-                require_png=False,
-            )
+        for descriptor in descriptors:
+            self._deliver_one(room, directory, run_id, descriptor)
         return {}
 
     def _deliver_one(
@@ -728,36 +707,55 @@ class NextcloudTalkOps:
         room: str,
         directory: str,
         run_id: str,
-        artifact_id: str,
-        *,
-        name: str,
-        max_bytes: int,
-        require_png: bool,
+        descriptor: Mapping[str, Any],
     ) -> None:
         """Fetch, upload, and share one artifact. Never raises.
+
+        The descriptor only *names* the artifact: its ``delivered_mime`` is a
+        prediction made before anything was rendered, so an artifact whose
+        conversion failed arrives as its original bytes under a different
+        Content-Type. Routing on the prediction would drop exactly those
+        artifacts, silently (osprey #503) — so the delivered bytes decide the
+        path, and the descriptor only supplies a preferred name.
 
         Args:
             room: Destination room token.
             directory: DAV directory this run's artifacts go into.
             run_id: Run the artifact belongs to.
-            artifact_id: Worker artifact id to fetch.
-            name: Filename to write inside ``directory``.
-            max_bytes: Size ceiling for the fetch.
-            require_png: Whether the payload must carry PNG magic bytes.
+            descriptor: Normalized artifact descriptor — ``artifact_id`` plus any
+                ``filename`` / ``delivered_mime`` hints the worker sent.
         """
-        data = fetch_artifact(
+        artifact_id = descriptor["artifact_id"]
+        fetched = fetch_artifact(
             self._http,
             self._cfg.core,
             run_id,
             artifact_id,
-            max_bytes=max_bytes,
-            require_png=require_png,
+            max_bytes=MAX_DOC_BYTES,
         )
-        if data is None:
-            # fetch_artifact logged why (transport, oversize, or not a PNG).
+        if fetched is None:
+            # fetch_artifact logged why (transport or oversize).
             return
+        if fetched.is_png:
+            # Talk renders a PNG inline, and an oversize one renders broken —
+            # worse than not posting it. Documents get the larger budget.
+            if len(fetched.data) > MAX_ARTIFACT_BYTES:
+                logger.warning(
+                    "image artifact %s oversize (%d bytes), not delivered to room %s",
+                    artifact_id,
+                    len(fetched.data),
+                    room,
+                )
+                return
+            extension = ".png"
+        else:
+            predicted = descriptor.get("delivered_mime")
+            extension = ext_for_mime(
+                fetched.content_type or (predicted if isinstance(predicted, str) else None)
+            )
+        name = _upload_name(descriptor.get("filename"), extension, artifact_id)
         try:
-            path = self._client.dav_mkcol_put(directory, name, data)
+            path = self._client.dav_mkcol_put(directory, name, fetched.data)
             self._client.share_to_room(path, room)
         except Exception:
             # A file that uploaded but failed to share is left where it is on purpose:

--- a/tests/bridges/nextcloud/test_deliver_files.py
+++ b/tests/bridges/nextcloud/test_deliver_files.py
@@ -61,7 +61,12 @@ def png_descriptor(artifact_id, **extra):
 
 
 class FakeWorker:
-    """The worker's artifact byte route: serves per-id payloads, records every request."""
+    """The worker's artifact byte route: serves per-id payloads, records every request.
+
+    A payload is either raw bytes or ``(bytes, content_type)`` — the byte route's
+    Content-Type is what a consumer names a fallback delivery from, so it is part
+    of what this fake has to reproduce.
+    """
 
     def __init__(self, payloads=None, *, fail_ids=(), status=500):
         self.payloads = dict(payloads or {})
@@ -79,7 +84,10 @@ class FakeWorker:
         artifact_id = request.url.path.rsplit("/", 1)[-1]
         if artifact_id in self.fail_ids:
             return httpx.Response(self.status, text="worker down")
-        return httpx.Response(200, content=self.payloads.get(artifact_id, PNG))
+        payload = self.payloads.get(artifact_id, PNG)
+        data, content_type = payload if isinstance(payload, tuple) else (payload, None)
+        headers = {"Content-Type": content_type} if content_type else {}
+        return httpx.Response(200, content=data, headers=headers)
 
 
 class FakeNextcloud:
@@ -243,16 +251,54 @@ def test_an_oversize_image_is_dropped_without_uploading():
     assert nc.of("PUT") == []
 
 
-def test_a_non_png_payload_in_the_image_bucket_is_dropped():
-    # The magic-byte guard stays on for the image path: Talk would render a
-    # mislabelled file as a broken image.
-    ops, _, nc = _ops(FakeWorker({"plot": b"not-a-png"}))
+# ==========================================================================
+# The bytes decide, not the descriptor
+#
+# A descriptor is written when a run completes and promises "image/png" for
+# everything the worker intends to render. Whether the render actually happens
+# is only known at fetch time — a converter dependency can be missing, a
+# renderer can crash — and the byte route then serves the ORIGINAL bytes under
+# their real Content-Type. Routing on the promise loses those artifacts
+# silently (osprey #503), so delivery routes on what arrived.
+# ==========================================================================
+
+
+def test_a_predicted_image_that_arrives_as_text_is_delivered_as_a_document():
+    # osprey #503: descriptor says image/png, the conversion failed, the byte
+    # route served the original CSV. The file must reach the room, not vanish.
+    csv = b"x,sin_x\n0,0\n"
+    ops, _, nc = _ops(FakeWorker({"plot": (csv, "text/csv")}))
     assert ops.deliver_files(ENTRY, result(png_descriptor("plot"))) == {}
-    assert nc.of("PUT") == []
+    assert nc.of("PUT")[0].content == csv
+    assert nc.of("PUT")[0].url.path.endswith("/roomA/R1/plot.csv")
+
+
+def test_a_fallback_replaces_the_predicted_extension_rather_than_stacking_it():
+    # The descriptor's filename is predicted too ("data.png" for a render that
+    # never happened); the extension still comes from the mime that was served.
+    csv = b"x,sin_x\n"
+    ops, _, nc = _ops(FakeWorker({"plot": (csv, "text/csv")}))
+    ops.deliver_files(ENTRY, result(png_descriptor("plot", filename="data.png")))
+    assert nc.of("PUT")[0].url.path.endswith("/roomA/R1/data.csv")
+
+
+def test_a_fallback_without_a_content_type_falls_back_to_the_predicted_mime():
+    # An older worker that serves no Content-Type leaves only the prediction to
+    # name the file — still better than dropping it.
+    ops, _, nc = _ops(FakeWorker({"doc1": PDF}))
+    ops.deliver_files(ENTRY, result({"artifact_id": "doc1", "delivered_mime": "application/pdf"}))
+    assert nc.of("PUT")[0].url.path.endswith("/roomA/R1/doc1.pdf")
+
+
+def test_png_bytes_are_delivered_as_an_image_whatever_the_descriptor_predicted():
+    # The mirror case: a descriptor with no mime at all, PNG bytes on the wire.
+    ops, _, nc = _ops(FakeWorker({"doc1": (PNG, "image/png")}))
+    ops.deliver_files(ENTRY, result({"artifact_id": "doc1"}))
+    assert nc.of("PUT")[0].url.path.endswith("/roomA/R1/doc1.png")
 
 
 # ==========================================================================
-# Artifact-id normalisation (core's split_artifacts tolerance)
+# Artifact-entry normalisation (core's artifact_descriptors tolerance)
 # ==========================================================================
 
 
@@ -407,6 +453,10 @@ def test_delivery_touches_only_the_artifact_byte_route_and_the_dav_share_surface
         ("plot", ".png", "plot.png"),
         ("plot.png", ".png", "plot.png"),  # not doubled
         ("PLOT.PNG", ".png", "PLOT.PNG"),  # case-insensitive match
+        # A predicted name whose extension the delivery contradicted: the mime
+        # wins and the stale extension is replaced, never stacked.
+        ("data.png", ".csv", "data.csv"),
+        ("run_2026.04.01_orbit", ".csv", "run_2026.04.01_orbit.csv"),  # not an extension
         ("orbit report", ".pdf", "orbit_report.pdf"),
         # Separators become "_" and the leading dot/underscore run is stripped, so a
         # traversal attempt collapses into one ordinary filename.

--- a/tests/bridges/test_artifacts.py
+++ b/tests/bridges/test_artifacts.py
@@ -7,9 +7,10 @@ origin and would otherwise shadow each other in a single module namespace).
 
 Sections:
 
-* ``TestFetchArtifact``  — worker byte fetch + size/PNG guards
+* ``TestFetchArtifact``  — worker byte fetch, size guard, and the served
+  Content-Type that is authoritative over any prediction
 * ``TestArtifactIds``    — run-status ``artifacts`` field -> id strings
-* ``TestSplitArtifacts`` — mime-routed split into image ids / doc descriptors
+* ``TestArtifactDescriptors`` — run-status ``artifacts`` field -> descriptors
 * ``TestExtForMime``     — mime -> extension allowlist
 * ``TestSafeLabel``      — CR/LF stripping + length bound
 * ``TestNeverRaiseContract`` — new here: pins the "a fetch failure never
@@ -21,64 +22,79 @@ import pytest
 
 from osprey.bridges.core.artifacts import (
     PNG_MAGIC,
+    artifact_descriptors,
     artifact_ids,
     ext_for_mime,
     fetch_artifact,
     safe_label,
-    split_artifacts,
 )
 from osprey.bridges.core.config import CoreConfig
 
 # ---------------------------------------------------------------------------
-# fetch_artifact: worker byte fetch + size/PNG guards, incl. the non-PNG path
-# a document-delivering channel relies on (require_png=False) and a custom
-# max_bytes.
+# fetch_artifact: worker byte fetch + size guard, and the two facts a consumer
+# routes on — the bytes themselves (is_png) and the Content-Type the worker
+# served them under. Neither is a prediction, so neither can disagree with what
+# was actually delivered.
 # ---------------------------------------------------------------------------
 
 PNG = PNG_MAGIC + b"body"
 PDF = b"%PDF-1.7\n...."
+CSV = b"x,sin_x\n0,0\n"
 
 CFG = CoreConfig(worker_url="http://work:9190", dispatch_worker_token="work-token")
 
 
 def _http(payloads):
-    """payloads: artifact_id -> bytes (200) or None (404)."""
+    """payloads: artifact_id -> bytes, or (bytes, content_type), or None (404)."""
 
     def handler(request):
         aid = str(request.url).rsplit("/", 1)[-1]
-        data = payloads.get(aid)
-        if data is None:
+        payload = payloads.get(aid)
+        if payload is None:
             return httpx.Response(404)
         assert request.headers["Authorization"] == "Bearer work-token"
-        return httpx.Response(200, content=data)
+        data, content_type = payload if isinstance(payload, tuple) else (payload, None)
+        headers = {"Content-Type": content_type} if content_type else {}
+        return httpx.Response(200, content=data, headers=headers)
 
     return httpx.Client(transport=httpx.MockTransport(handler), trust_env=CFG.trust_env)
 
 
 class TestFetchArtifact:
-    def test_png_default_accepts_png(self):
-        assert fetch_artifact(_http({"a": PNG}), CFG, "R1", "a") == PNG
+    def test_returns_the_bytes_and_the_served_content_type(self):
+        fetched = fetch_artifact(_http({"a": (PNG, "image/png")}), CFG, "R1", "a")
+        assert fetched.data == PNG
+        assert fetched.content_type == "image/png"
 
-    def test_png_default_rejects_non_png(self):
-        assert fetch_artifact(_http({"a": PDF}), CFG, "R1", "a") is None
+    def test_a_non_image_payload_is_returned_not_dropped(self):
+        # osprey #503: the byte route serving CSV where the descriptor predicted a
+        # PNG must not make the artifact vanish — the caller re-routes it.
+        fetched = fetch_artifact(_http({"a": (CSV, "text/csv")}), CFG, "R1", "a")
+        assert fetched.data == CSV
+        assert fetched.content_type == "text/csv"
+        assert fetched.is_png is False
 
-    def test_require_png_false_accepts_non_png(self):
-        # document path: attach delivered_mime bytes verbatim, no PNG requirement.
-        assert fetch_artifact(_http({"a": PDF}), CFG, "R1", "a", require_png=False) == PDF
+    def test_is_png_reads_the_magic_bytes_not_the_header(self):
+        # A header claiming PNG over text bytes is exactly the #503 failure; the
+        # magic bytes are the unforgeable half.
+        assert fetch_artifact(_http({"a": (CSV, "image/png")}), CFG, "R1", "a").is_png is False
+        assert fetch_artifact(_http({"a": (PNG, "text/csv")}), CFG, "R1", "a").is_png is True
+
+    def test_content_type_parameters_are_stripped(self):
+        # Starlette appends "; charset=utf-8" to any text/* media type.
+        fetched = fetch_artifact(_http({"a": (CSV, "text/csv; charset=utf-8")}), CFG, "R1", "a")
+        assert fetched.content_type == "text/csv"
+
+    def test_a_missing_content_type_is_none_not_a_guess(self):
+        assert fetch_artifact(_http({"a": PDF}), CFG, "R1", "a").content_type is None
 
     def test_custom_max_bytes_enforced(self):
         big = PNG_MAGIC + b"x" * 100
         assert fetch_artifact(_http({"a": big}), CFG, "R1", "a", max_bytes=10) is None
-        assert fetch_artifact(_http({"a": big}), CFG, "R1", "a", max_bytes=1000) == big
+        assert fetch_artifact(_http({"a": big}), CFG, "R1", "a", max_bytes=1000).data == big
 
     def test_404_returns_none(self):
         assert fetch_artifact(_http({}), CFG, "R1", "missing") is None
-
-    def test_size_guard_applies_even_when_png_not_required(self):
-        assert (
-            fetch_artifact(_http({"a": PDF}), CFG, "R1", "a", require_png=False, max_bytes=2)
-            is None
-        )
 
 
 # ---------------------------------------------------------------------------
@@ -133,16 +149,17 @@ class TestArtifactIds:
 
 
 # ---------------------------------------------------------------------------
-# split_artifacts: route the run-status ``artifacts`` field into an image-id
-# bucket (PNG, inline-image path) and a doc-descriptor bucket (everything else).
+# artifact_descriptors: normalize the run-status ``artifacts`` field to
+# descriptor dicts, keeping every hint (filename, delivered_mime) a delivery
+# path can use to NAME an artifact. It deliberately does not route: what an
+# artifact turns out to be is only knowable once its bytes have been served.
 #
-# Covers the same input shapes as ``artifact_ids`` (osprey #363 descriptor
-# dicts, bare id strings from an older worker, a mix, malformed shapes to skip)
-# plus the mime-based routing split_artifacts adds on top.
+# Covers the same input shapes as ``artifact_ids`` — osprey #363 descriptor
+# dicts, bare id strings from an older worker, a mix, malformed shapes to skip.
 # ---------------------------------------------------------------------------
 
 
-class TestSplitArtifacts:
+class TestArtifactDescriptors:
     @staticmethod
     def _descriptor(aid, mime="image/png", **overrides):
         """A realistic #363 descriptor dict."""
@@ -156,84 +173,47 @@ class TestSplitArtifacts:
         d.update(overrides)
         return d
 
-    def test_png_descriptor_goes_to_image_bucket_by_id(self):
-        image_ids, doc_descriptors = split_artifacts([self._descriptor("art-1", "image/png")])
-        assert image_ids == ["art-1"]
-        assert doc_descriptors == []
+    def test_descriptor_dicts_pass_through_whole(self):
+        desc = self._descriptor("art-1")
+        assert artifact_descriptors([desc]) == [desc]
 
-    def test_bare_string_goes_to_image_bucket(self):
-        # Back-compat: an older worker with no mime at all -> existing PNG path.
-        image_ids, doc_descriptors = split_artifacts(["art-1"])
-        assert image_ids == ["art-1"]
-        assert doc_descriptors == []
+    def test_a_bare_string_becomes_a_descriptor_with_no_hints(self):
+        # Back-compat: an older worker still answering with id strings mid-deploy.
+        assert artifact_descriptors(["art-1"]) == [{"artifact_id": "art-1"}]
 
-    def test_image_jpeg_goes_to_doc_bucket_as_whole_dict(self):
-        desc = self._descriptor("art-2", "image/jpeg")
-        image_ids, doc_descriptors = split_artifacts([desc])
-        assert image_ids == []
-        assert doc_descriptors == [desc]
+    def test_every_mime_is_kept_in_one_list(self):
+        # No mime-based routing here: a PNG prediction and a markdown prediction
+        # are the same kind of hint, and either can be wrong.
+        png = self._descriptor("keep-png", "image/png")
+        md = self._descriptor("keep-md", "text/markdown")
+        assert artifact_descriptors([png, md]) == [png, md]
 
-    def test_image_svg_goes_to_doc_bucket(self):
-        desc = self._descriptor("art-3", "image/svg+xml")
-        image_ids, doc_descriptors = split_artifacts([desc])
-        assert image_ids == []
-        assert doc_descriptors == [desc]
-
-    def test_document_mime_goes_to_doc_bucket(self):
-        desc = self._descriptor("art-4", "text/markdown")
-        image_ids, doc_descriptors = split_artifacts([desc])
-        assert image_ids == []
-        assert doc_descriptors == [desc]
-
-    def test_missing_delivered_mime_key_goes_to_doc_bucket(self):
+    def test_a_descriptor_without_a_mime_is_kept(self):
         desc = {"artifact_id": "art-5", "filename": "art-5.bin"}
-        assert "delivered_mime" not in desc
-        image_ids, doc_descriptors = split_artifacts([desc])
-        assert image_ids == []
-        assert doc_descriptors == [desc]
+        assert artifact_descriptors([desc]) == [desc]
 
-    def test_malformed_entries_are_skipped_from_both_buckets(self):
+    def test_malformed_entries_are_skipped_not_raised_on(self):
         artifacts = [
             {"filename": "no-id.png"},  # dict without artifact_id
             {"artifact_id": None},  # null id
             {"artifact_id": ""},  # empty id
-            {"artifact_id": 123},  # non-str id
+            {"artifact_id": 123},  # non-str id (must not leak an int into a URL)
             "",  # empty string
             123,  # wrong type entirely
             None,  # bare None element
         ]
-        image_ids, doc_descriptors = split_artifacts(artifacts)
-        assert image_ids == []
-        assert doc_descriptors == []
+        assert artifact_descriptors(artifacts) == []
 
-    def test_mixed_input_keeps_each_id_in_exactly_one_bucket(self):
-        png = self._descriptor("keep-png", "image/png")
-        jpeg = self._descriptor("keep-jpeg", "image/jpeg")
-        md = self._descriptor("keep-md", "text/markdown")
-        no_mime = {"artifact_id": "keep-no-mime", "filename": "x.bin"}
-        bare = "keep-bare"
-        artifacts = [
-            png,
-            {"filename": "no-id.png"},
-            jpeg,
-            "",
-            md,
-            None,
-            no_mime,
-            bare,
-            {"artifact_id": None},
+    def test_a_malformed_entry_does_not_cost_its_valid_siblings(self):
+        keep = self._descriptor("keep")
+        assert artifact_descriptors([{"filename": "no-id.png"}, keep, None, "bare"]) == [
+            keep,
+            {"artifact_id": "bare"},
         ]
-        image_ids, doc_descriptors = split_artifacts(artifacts)
-
-        all_doc_ids = {d["artifact_id"] for d in doc_descriptors}
-        assert set(image_ids) & all_doc_ids == set()
-
-        assert image_ids == ["keep-png", "keep-bare"]
-        assert doc_descriptors == [jpeg, md, no_mime]
 
     def test_empty_and_none_are_safe(self):
-        assert split_artifacts([]) == ([], [])
-        assert split_artifacts(None) == ([], [])
+        assert artifact_descriptors([]) == []
+        assert artifact_descriptors(None) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/bridges/test_pipeline.py
+++ b/tests/bridges/test_pipeline.py
@@ -28,6 +28,7 @@ from typing import Any
 import pytest
 
 from osprey.bridges.core import pipeline
+from osprey.bridges.core.artifacts import FetchedArtifact
 from osprey.bridges.core.config import CoreConfig
 from osprey.bridges.core.dedup import DedupStore
 from osprey.bridges.core.history import HistoryStore
@@ -150,6 +151,11 @@ class CountingProbe:
         assert capability == "input_files"
         self.calls += 1
         return self.verdicts[min(self.calls - 1, len(self.verdicts) - 1)]
+
+
+def _prior(data: bytes, content_type: str | None = None):
+    """A ``fetch_prior_artifact`` seam serving *data* under *content_type*."""
+    return lambda cfg, rid, desc, mb: FetchedArtifact(data=data, content_type=content_type)
 
 
 def make_deps(
@@ -465,7 +471,7 @@ def test_capability_probe_runs_once_for_all_three_consumers(tmp_path):
     inputs = InputDownload(files=(make_file("own.png", b"OWN"), make_file("quoted.png", b"QUOTED")))
     ops = RecordingChannelOps(parse_result=make_event(), inputs=inputs)
     probe = CountingProbe(True)
-    deps = make_deps(tmp_path, ops, probe=probe, fetch_prior=lambda cfg, rid, d, mb: b"PRIOR")
+    deps = make_deps(tmp_path, ops, probe=probe, fetch_prior=_prior(b"PRIOR"))
     deps.history.append(
         HISTORY_KEY,
         "plot it",
@@ -795,10 +801,52 @@ def test_reinjected_prior_dedupes_against_own_attachment(tmp_path):
     # returns identical bytes, which must not ship twice.
     inputs = InputDownload(files=(make_file("own-copy.png", b"SAME-BYTES"),))
     ops = RecordingChannelOps(parse_result=make_event(), inputs=inputs)
-    deps = make_deps(tmp_path, ops, fetch_prior=lambda cfg, rid, d, mb: b"SAME-BYTES")
+    deps = make_deps(tmp_path, ops, fetch_prior=_prior(b"SAME-BYTES"))
     _seed_prior_image(deps)
 
     handle_event({}, deps)
 
     files = deps.dispatcher.calls[0]["extra"]["input_files"]
     assert [f["filename"] for f in files] == ["own-copy.png"]
+
+
+def test_a_prior_whose_bytes_are_not_an_image_is_not_reinjected(tmp_path):
+    # osprey #503: the descriptor predicted image/png, but the render failed and
+    # the byte route served the original CSV. Shipping those bytes labelled
+    # image/png would hand the model a file that is not the image it is told to
+    # look at; the descriptor still rides conversation_so_far either way.
+    ops = RecordingChannelOps(parse_result=make_event())
+    deps = make_deps(tmp_path, ops, fetch_prior=_prior(b"x,sin_x\n0,0\n", "text/csv"))
+    _seed_prior_image(deps)
+
+    assert handle_event({}, deps) == "handled"
+
+    extra = deps.dispatcher.calls[0]["extra"]
+    assert "input_files" not in extra
+    (turn,) = extra["conversation_so_far"]
+    assert turn["artifacts"][0]["delivered_mime"] == "image/png"
+
+
+def test_a_reinjected_prior_is_labelled_with_the_served_type(tmp_path):
+    # The prediction said PNG, the byte route served JPEG: the model is told what
+    # it actually got.
+    ops = RecordingChannelOps(parse_result=make_event())
+    deps = make_deps(tmp_path, ops, fetch_prior=_prior(b"JPEG-BYTES", "image/jpeg"))
+    _seed_prior_image(deps)
+
+    handle_event({}, deps)
+
+    (file,) = deps.dispatcher.calls[0]["extra"]["input_files"]
+    assert file["mime"] == "image/jpeg"
+
+
+def test_a_prior_served_without_a_content_type_keeps_the_predicted_mime(tmp_path):
+    # An older worker sends no Content-Type; the prediction is all there is.
+    ops = RecordingChannelOps(parse_result=make_event())
+    deps = make_deps(tmp_path, ops, fetch_prior=_prior(b"PRIOR"))
+    _seed_prior_image(deps)
+
+    handle_event({}, deps)
+
+    (file,) = deps.dispatcher.calls[0]["extra"]["input_files"]
+    assert file["mime"] == "image/png"


### PR DESCRIPTION
Closes #503.

## The problem

A run's artifact descriptors are stamped at run completion and promise `delivered_mime: image/png` for every artifact the worker intends to render. Whether the render actually happens is only knowable at fetch time — a converter dependency can be missing, a renderer can crash — and the byte route then serves the **original** bytes under their real Content-Type.

Delivery routed on the promise: `split_artifacts` sent the entry down the image path, `fetch_artifact` rejected the payload for failing the PNG-magic guard, and the artifact was discarded. The descriptor said PNG, the bytes said text, the consumer dropped the file, and no error surfaced anywhere — the user simply got nothing.

## The fix

Route on what actually arrived, which is the only thing that cannot contradict itself:

- `fetch_artifact` returns a `FetchedArtifact` — the bytes plus the served Content-Type (parameters stripped) — and rejects only what it could not fetch or could not fit. The `require_png` drop is gone: a fetcher that discards a payload for disagreeing with a prediction is what made the artifact vanish.
- `artifact_descriptors` replaces `split_artifacts`. It normalizes the same input shapes but does not route, because the field it would route on is a prediction; the descriptor survives as a naming hint only.
- The Talk adapter runs one delivery loop. PNG magic bytes select the image path (and the image size ceiling); anything else takes the document path, with the extension derived from the Content-Type that was served, falling back to the prediction only when the worker sent no type. A predicted filename whose extension the delivery contradicted (`data.png` for a render that never happened) has it replaced rather than stacked.

The worker side needed no change: `test_converter_failure_falls_back_to_original` already pins that the byte route serves the original bytes under their truthful Content-Type. That is precisely what the consumer now trusts.

## Second consumer of the same root cause

Prior-image re-injection in `pipeline.py` selected candidates by predicted mime and stamped that same prediction onto the replayed bytes. A follow-up question could therefore hand the agent a CSV labelled `image/png`. It now labels a replayed artifact with the type it was really served under, and skips anything that did not arrive as an image; the descriptor still rides `conversation_so_far` either way. `PipelineDeps.fetch_prior_artifact` — an injectable seam with no in-repo implementations besides the default — returns `FetchedArtifact | None` accordingly.

## Not done, deliberately

The issue also suggested probing converter availability when the descriptor is built. A fetch-time failure (dependency regression, OOM, renderer crash) is unpredictable by construction, so a probe would narrow the window without closing it, and it would cost a probe per listing on a path documented as render-free. The prediction stays a prediction; the consumer no longer treats it as a fact.

## Tests

The existing suite *pinned* the silent loss (`test_a_non_png_payload_in_the_image_bucket_is_dropped`); that expectation is replaced. New coverage: a predicted image arriving as CSV is delivered as `.csv` rather than dropped, a stale predicted extension is replaced not stacked, a missing Content-Type falls back to the prediction, PNG bytes are delivered as an image whatever the descriptor said, and the re-injection cases above.

Full unit suite green (14180 passed); ruff, ruff format, and mypy clean.