### PR TITLE
fix(export): install Chromium only when a launch reports it missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ Compatibility is documented in release notes, not encoded in the version string.
 - The theme picker now labels the DESY family `DESY` rather than `Desy`.
 - Newly scaffolded projects set `web.theme: osprey`, a family that no longer
   exists; the terminal warned and fell back on every start. Now `main`.
+- HTML-to-image export no longer runs `playwright install chromium` on every
+  conversion. The browser availability check used Playwright's sync API, which
+  fails inside a running event loop; the failure was misread as "browser
+  missing", so an async caller (e.g. the dispatch artifact byte route) paid a
+  subprocess and a network round-trip per conversion — and on hosts that cannot
+  reach the browser CDN, every conversion failed even with Chromium installed.
+  The browser launch is now itself the availability check: Chromium is installed
+  only when a launch reports the binary is absent, at most once per process, and
+  a launch that fails for any other reason surfaces unchanged instead of being
+  reported as a missing browser.
 - `osprey build` now fails with an actionable error when
   `claude_code.default_model` (e.g. `--set model=...`) names a model the
   selected provider does not serve. Previously the build only warned and the

--- a/src/osprey/mcp_server/export/converter.py
+++ b/src/osprey/mcp_server/export/converter.py
@@ -1,47 +1,115 @@
 """Convert HTML files to images using Playwright (headless Chromium).
 
-Auto-installs Chromium on first use. Raises ``PlaywrightNotInstalledError``
-instead of a raw ``ImportError`` when Playwright is missing.
+Chromium is installed on demand, but only ever in *reaction* to a launch that
+failed because the binary is genuinely absent — the launch itself is the
+availability check, so there is no second, weaker check that can disagree with
+it. The install is attempted at most once per process and its verdict is cached,
+so a host that cannot reach the browser CDN pays for one failed attempt rather
+than one per conversion.
+
+Raises ``PlaywrightNotInstalledError`` instead of a raw ``ImportError`` when
+Playwright itself is missing. A launch that fails for any other reason (missing
+system libraries, a sandbox denial) propagates unchanged rather than being
+reported as a missing browser.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import subprocess
+import sys
+import threading
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger("osprey.mcp_server.export.converter")
 
 SUPPORTED_FORMATS = {"png", "jpeg"}
+
+# The only launch-error text that means the browser binary is not there —
+# Playwright raises "browserType.launch: Executable doesn't exist at <path>".
+# Matching this and nothing else keeps a launch that failed for an unrelated
+# reason from being misread as a missing browser (and from triggering a pointless
+# network install).
+_MISSING_BROWSER_MARKER = "Executable doesn't exist"
+
+# Run through the *current* interpreter rather than a bare "playwright" console
+# script, which need not be on PATH in a container or in a venv the server was
+# not launched from.
+_INSTALL_CMD = [sys.executable, "-m", "playwright", "install", "chromium"]
+
+# At-most-once-per-process install, and its cached verdict. Guarded by a plain
+# threading lock (not asyncio) so the state stays correct across event loops and
+# across threads; it is only ever held inside a worker thread.
+_install_lock = threading.Lock()
+_install_attempted = False
+_install_error: str | None = None
 
 
 class PlaywrightNotInstalledError(Exception):
     """Raised when Playwright or its browsers are not available."""
 
 
-def _ensure_chromium_installed() -> None:
-    """Auto-install Chromium browser if not already present."""
-    try:
-        from playwright.sync_api import sync_playwright
+def _is_missing_browser(exc: BaseException) -> bool:
+    """Whether *exc* is Playwright reporting an absent browser binary."""
+    return _MISSING_BROWSER_MARKER in str(exc)
 
-        with sync_playwright() as p:
-            # Check if the executable exists
-            if not Path(p.chromium.executable_path).exists():
-                raise FileNotFoundError
-    except (FileNotFoundError, Exception):
-        logger.info("Chromium not found — installing via 'playwright install chromium'...")
+
+def _run_install() -> str | None:
+    """Run the Chromium install; return an error message, or ``None`` on success."""
+    logger.info("Chromium not found — installing via '%s'...", " ".join(_INSTALL_CMD))
+    try:
+        proc = subprocess.run(_INSTALL_CMD, capture_output=True, text=True)
+    except OSError as exc:
+        return f"Failed to run '{' '.join(_INSTALL_CMD)}': {exc}"
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()[-500:]
+        return (
+            f"Failed to auto-install Chromium (exit {proc.returncode}). "
+            f"Run manually: playwright install chromium\n{detail}"
+        )
+    logger.info("Chromium installed successfully.")
+    return None
+
+
+def _install_chromium() -> None:
+    """Install Chromium once per process; re-raise the cached failure thereafter.
+
+    Blocking — call it via :func:`asyncio.to_thread` so a conversion running on an
+    event loop does not stall it for the length of a browser download.
+
+    Raises:
+        PlaywrightNotInstalledError: The install failed, now or on the earlier
+            attempt whose verdict is cached.
+    """
+    global _install_attempted, _install_error
+    with _install_lock:
+        if not _install_attempted:
+            _install_attempted = True
+            _install_error = _run_install()
+        if _install_error is not None:
+            raise PlaywrightNotInstalledError(_install_error)
+
+
+async def _render(
+    async_playwright: Callable[[], Any],
+    source: Path,
+    dest: Path,
+    fmt: str,
+    width: int,
+    height: int,
+) -> None:
+    """Screenshot *source* into *dest* with one headless Chromium page."""
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
         try:
-            subprocess.run(
-                ["playwright", "install", "chromium"],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            logger.info("Chromium installed successfully.")
-        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
-            raise PlaywrightNotInstalledError(
-                "Failed to auto-install Chromium. Run manually: playwright install chromium"
-            ) from exc
+            page = await browser.new_page(viewport={"width": width, "height": height})
+            await page.goto(source.as_uri(), wait_until="networkidle")
+            await page.screenshot(path=str(dest), type=fmt, full_page=True)
+        finally:
+            await browser.close()
 
 
 async def convert_html_to_image(
@@ -53,8 +121,9 @@ async def convert_html_to_image(
 ) -> Path:
     """Render an HTML file to an image via headless Chromium.
 
-    On first use, automatically installs Chromium if the browser
-    binary is missing.
+    If the browser binary is missing it is installed (once per process) and the
+    render retried. A browser that launches is never re-checked and never
+    re-installed.
 
     Args:
         html_path: Path to the source HTML file.
@@ -67,7 +136,8 @@ async def convert_html_to_image(
         Resolved ``Path`` of the written image file.
 
     Raises:
-        PlaywrightNotInstalledError: Playwright or Chromium not available.
+        PlaywrightNotInstalledError: Playwright is not importable, or Chromium is
+            absent and could not be installed.
         FileNotFoundError: *html_path* does not exist.
         ValueError: Unsupported *fmt*.
     """
@@ -87,22 +157,22 @@ async def convert_html_to_image(
             "Playwright is not installed. Run: pip install playwright && playwright install chromium"
         ) from exc
 
-    # Auto-install Chromium on first use
-    _ensure_chromium_installed()
-
     try:
-        async with async_playwright() as p:
-            browser = await p.chromium.launch()
-            page = await browser.new_page(viewport={"width": width, "height": height})
-            await page.goto(source.as_uri(), wait_until="networkidle")
-            await page.screenshot(path=str(dest), type=fmt, full_page=True)
-            await browser.close()
+        await _render(async_playwright, source, dest, fmt, width, height)
     except Exception as exc:
-        if "Executable doesn't exist" in str(exc) or "browserType.launch" in str(exc):
-            raise PlaywrightNotInstalledError(
-                "Chromium browser not installed. Run: playwright install chromium"
-            ) from exc
-        raise
+        if not _is_missing_browser(exc):
+            raise
+        # The launch is the availability check, so only a genuinely absent binary
+        # reaches here: install it and retry exactly once.
+        await asyncio.to_thread(_install_chromium)
+        try:
+            await _render(async_playwright, source, dest, fmt, width, height)
+        except Exception as retry_exc:
+            if _is_missing_browser(retry_exc):
+                raise PlaywrightNotInstalledError(
+                    "Chromium browser not installed. Run: playwright install chromium"
+                ) from retry_exc
+            raise
 
     logger.info("Converted %s → %s (%s)", source.name, dest.name, fmt)
     return dest.resolve()

--- a/tests/mcp_server/test_html_converter.py
+++ b/tests/mcp_server/test_html_converter.py
@@ -1,25 +1,43 @@
 """Tests for the HTML-to-image converter module."""
 
+import subprocess
 import sys
 from types import ModuleType
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from osprey.mcp_server.export import converter as converter_mod
 from osprey.mcp_server.export.converter import (
     PlaywrightNotInstalledError,
     convert_html_to_image,
 )
 
+# The launch error Playwright raises when the browser binary is absent — the ONLY
+# condition that may trigger an auto-install.
+MISSING_BROWSER_ERROR = (
+    "browserType.launch: Executable doesn't exist at "
+    "/root/.cache/ms-playwright/chromium-1091/chrome-linux/chrome"
+)
 
-def _make_playwright_mock():
-    """Build a mock playwright module with async_playwright context manager."""
+
+def _make_playwright_mock(launch_side_effect=None):
+    """Build a mock playwright module with async_playwright context manager.
+
+    Args:
+        launch_side_effect: Optional ``side_effect`` for ``chromium.launch`` — a
+            list whose exception entries are raised and whose other entries are
+            returned, used to simulate a failed-then-successful launch.
+    """
     mock_page = AsyncMock()
     mock_browser = AsyncMock()
     mock_browser.new_page.return_value = mock_page
 
     mock_pw = AsyncMock()
-    mock_pw.chromium.launch.return_value = mock_browser
+    if launch_side_effect is None:
+        mock_pw.chromium.launch.return_value = mock_browser
+    else:
+        mock_pw.chromium.launch.side_effect = launch_side_effect
 
     mock_ctx = AsyncMock()
     mock_ctx.__aenter__.return_value = mock_pw
@@ -44,10 +62,7 @@ async def test_convert_html_to_png(tmp_path):
 
     mock_mod, mock_page, mock_browser = _make_playwright_mock()
 
-    with (
-        patch.dict(sys.modules, {"playwright.async_api": mock_mod, "playwright": MagicMock()}),
-        patch("osprey.mcp_server.export.converter._ensure_chromium_installed"),
-    ):
+    with patch.dict(sys.modules, {"playwright.async_api": mock_mod, "playwright": MagicMock()}):
         result = await convert_html_to_image(html_file, output_file)
 
     assert result == output_file.resolve()
@@ -98,10 +113,123 @@ async def test_custom_viewport(tmp_path):
 
     mock_mod, mock_page, mock_browser = _make_playwright_mock()
 
-    with (
-        patch.dict(sys.modules, {"playwright.async_api": mock_mod, "playwright": MagicMock()}),
-        patch("osprey.mcp_server.export.converter._ensure_chromium_installed"),
-    ):
+    with patch.dict(sys.modules, {"playwright.async_api": mock_mod, "playwright": MagicMock()}):
         await convert_html_to_image(html_file, output_file, width=800, height=600)
 
     mock_browser.new_page.assert_called_once_with(viewport={"width": 800, "height": 600})
+
+
+# ---------------------------------------------------------------------------
+# Chromium auto-install
+#
+# The browser is only ever installed in reaction to a launch that actually
+# failed for a missing binary. Any other outcome — a successful launch, or a
+# launch that failed for another reason — must not shell out to the network.
+# ---------------------------------------------------------------------------
+
+
+class TestChromiumAutoInstall:
+    """Auto-install is reactive, at-most-once, and never masks other errors."""
+
+    @pytest.fixture(autouse=True)
+    def _install_calls(self, monkeypatch, tmp_path):
+        """Record install subprocesses instead of running them; reset the cache."""
+        calls: list[list[str]] = []
+
+        def _fake_run(cmd, **kwargs):
+            calls.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(converter_mod.subprocess, "run", _fake_run)
+        monkeypatch.setattr(converter_mod, "_install_attempted", False)
+        monkeypatch.setattr(converter_mod, "_install_error", None)
+        return calls
+
+    @staticmethod
+    def _html(tmp_path):
+        html_file = tmp_path / "plot.html"
+        html_file.write_text("<html></html>")
+        (tmp_path / "plot.png").write_bytes(b"fake")
+        return html_file, tmp_path / "plot.png"
+
+    @pytest.mark.unit
+    async def test_successful_launch_never_installs(self, tmp_path, _install_calls):
+        """A browser that launches is a browser that is installed — no subprocess.
+
+        Regression test for the sync-in-async availability probe: it raised inside
+        a running event loop, was misread as "browser missing", and installed
+        Chromium over the network on every single conversion.
+        """
+        html_file, output_file = self._html(tmp_path)
+        mock_mod, _, _ = _make_playwright_mock()
+
+        with patch.dict(sys.modules, {"playwright.async_api": mock_mod}):
+            await convert_html_to_image(html_file, output_file)
+
+        assert _install_calls == []
+
+    @pytest.mark.unit
+    async def test_missing_browser_installs_then_retries(self, tmp_path, _install_calls):
+        """A launch that fails for a missing binary installs once and retries."""
+        html_file, output_file = self._html(tmp_path)
+        _, _, mock_browser = _make_playwright_mock()
+        mock_mod, _, _ = _make_playwright_mock(
+            launch_side_effect=[Exception(MISSING_BROWSER_ERROR), mock_browser]
+        )
+
+        with patch.dict(sys.modules, {"playwright.async_api": mock_mod}):
+            result = await convert_html_to_image(html_file, output_file)
+
+        assert result == output_file.resolve()
+        assert _install_calls == [[sys.executable, "-m", "playwright", "install", "chromium"]]
+
+    @pytest.mark.unit
+    async def test_install_attempted_at_most_once_per_process(self, tmp_path, _install_calls):
+        """A second conversion with a missing browser does not re-install."""
+        html_file, output_file = self._html(tmp_path)
+        mock_mod, _, _ = _make_playwright_mock(
+            launch_side_effect=[Exception(MISSING_BROWSER_ERROR)] * 4
+        )
+
+        with patch.dict(sys.modules, {"playwright.async_api": mock_mod}):
+            for _ in range(2):
+                with pytest.raises(PlaywrightNotInstalledError):
+                    await convert_html_to_image(html_file, output_file)
+
+        assert len(_install_calls) == 1
+
+    @pytest.mark.unit
+    async def test_failed_install_reports_stderr(self, tmp_path, monkeypatch):
+        """A nonzero install surfaces as PlaywrightNotInstalledError with its stderr."""
+        html_file, output_file = self._html(tmp_path)
+
+        def _failing_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="proxy blocked the CDN")
+
+        monkeypatch.setattr(converter_mod.subprocess, "run", _failing_run)
+        monkeypatch.setattr(converter_mod, "_install_attempted", False)
+        monkeypatch.setattr(converter_mod, "_install_error", None)
+
+        mock_mod, _, _ = _make_playwright_mock(
+            launch_side_effect=[Exception(MISSING_BROWSER_ERROR)] * 2
+        )
+        with patch.dict(sys.modules, {"playwright.async_api": mock_mod}):
+            with pytest.raises(PlaywrightNotInstalledError, match="proxy blocked the CDN"):
+                await convert_html_to_image(html_file, output_file)
+
+    @pytest.mark.unit
+    async def test_unrelated_launch_failure_propagates(self, tmp_path, _install_calls):
+        """A launch failure that is not a missing binary surfaces as itself."""
+        html_file, output_file = self._html(tmp_path)
+        mock_mod, _, _ = _make_playwright_mock(
+            launch_side_effect=[
+                Exception("browserType.launch: Host system is missing dependencies")
+            ]
+        )
+
+        with patch.dict(sys.modules, {"playwright.async_api": mock_mod}):
+            with pytest.raises(Exception, match="missing dependencies") as excinfo:
+                await convert_html_to_image(html_file, output_file)
+
+        assert not isinstance(excinfo.value, PlaywrightNotInstalledError)
+        assert _install_calls == []


### PR DESCRIPTION
Closes #502.

## The problem

`_ensure_chromium_installed` verified the browser with Playwright's **sync** API. `sync_playwright()` raises when called inside a running asyncio loop, so every conversion driven from an async server — the dispatch worker's artifact byte route, for instance — hit that error. The check caught it under a blanket `except (FileNotFoundError, Exception)` and read a structural error as "browser missing", then shelled out to `playwright install chromium`.

- Hosts with open egress: a wasted subprocess and network round-trip on **every** conversion (the install no-ops).
- Hosts where the browser CDN is blocked: the install exits nonzero, `PlaywrightNotInstalledError` is raised, and **every text-artifact conversion fails** even though Chromium is present and launchable.

Reproduced before touching the code: with a mocked async Playwright whose launch succeeds, the current implementation still spawned `["playwright", "install", "chromium"]`.

## The fix

Delete the pre-check. Checking a capability through a different mechanism than the one that uses it is what allowed the check to be wrong; the launch itself is the ground truth, and it was already being performed a few lines later.

- A launch that fails with `Executable doesn't exist` — the one message that means the binary is absent — installs Chromium and retries the render exactly once.
- The install runs at most once per process and its verdict is cached, so an egress-blocked host pays for one failed attempt rather than one per conversion. The cache guards only the remediation, never the truth: the launch is still attempted every time, so an operator who installs the browser by hand afterwards is picked up immediately.
- It runs off the event loop (`asyncio.to_thread`) under a plain threading lock, so concurrent conversions cannot stampede into parallel installs and a browser download cannot stall the loop. A threading lock rather than an asyncio one keeps the state correct across event loops.
- It invokes `sys.executable -m playwright` rather than a bare `playwright` console script, which need not be on `PATH` in a container or in a venv the server was not launched from, and it reports the install's stderr on failure.
- A launch that fails for any other reason (missing system libraries, a sandbox denial) now propagates unchanged. Previously any `browserType.launch` error was reported as `dependency_missing: Chromium browser not installed`, which sent operators after the wrong problem; such failures now reach `artifact_export`'s generic handler as `conversion_error` with the real message.

Also closes a browser-process leak on the error path: the page work is now wrapped so `browser.close()` runs even when the screenshot raises.

## Tests

Five new tests pin the contract: a successful launch never installs (the regression this fixes), a missing binary installs once and retries, a second missing-browser conversion does not re-install, a failed install surfaces its stderr, and an unrelated launch failure propagates without triggering an install. The suite also runs ~12x faster now that it no longer shells out to a real `playwright install` on every case.

Full unit suite green (14205 passed); ruff, ruff format, and mypy clean.