### PR TITLE
feat(version): derive the framework version from the git tag

### DIFF
--- a/.github/workflows/build-nextcloud-fixture.yml
+++ b/.github/workflows/build-nextcloud-fixture.yml
@@ -60,6 +60,9 @@ jobs:
     steps:
     - name: Check out the fixture sources
       uses: actions/checkout@v7
+      # Full history + tags: the package version is derived from the git tag.
+      with:
+        fetch-depth: 0
 
     - name: Verify the dispatched tag matches the Dockerfile pins
       # Publishing a tag that disagrees with what the image actually contains is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
+      # Full history + tags: the package version is derived from the git tag.
+      with:
+        fetch-depth: 0
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
@@ -212,6 +215,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
+      # Full history + tags: the package version is derived from the git tag.
+      with:
+        fetch-depth: 0
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
@@ -241,6 +247,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
+      # Full history + tags: the package version is derived from the git tag.
+      with:
+        fetch-depth: 0
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
@@ -406,6 +415,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
+      # Full history + tags: the package version is derived from the git tag.
+      with:
+        fetch-depth: 0
 
     - name: Set up Node
       uses: actions/setup-node@v7
@@ -444,6 +456,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
+      # Full history + tags: the package version is derived from the git tag.
+      with:
+        fetch-depth: 0
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
@@ -485,6 +500,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
+      # Full history + tags: the package version is derived from the git tag.
+      with:
+        fetch-depth: 0
 
     - name: Log in to ghcr (openobserve mirror)
       uses: docker/login-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,21 +26,28 @@ jobs:
     - name: Set up Python
       run: uv python install 3.11
 
-    - name: Verify version matches tag
-      run: |
-        TAG_VERSION="${GITHUB_REF#refs/tags/v}"
-        # Extract version from __init__.py without importing
-        PACKAGE_VERSION=$(grep '__version__ = ' src/osprey/__init__.py | cut -d'"' -f2)
-        echo "Tag version: $TAG_VERSION"
-        echo "Package version: $PACKAGE_VERSION"
-        if [ "$TAG_VERSION" != "$PACKAGE_VERSION" ]; then
-          echo "❌ Version mismatch! Tag: $TAG_VERSION, Package: $PACKAGE_VERSION"
-          exit 1
-        fi
-        echo "✅ Version matches: $TAG_VERSION"
-
     - name: Build package
       run: uv build
+
+    - name: Verify built version matches tag
+      # The version is derived from the tag rather than a literal, so this checks
+      # the artifact that is actually about to be published. A shallow checkout or
+      # a missing tag does not fail the build — it silently yields 0.1.devN — so
+      # this gate is what catches that before it reaches PyPI.
+      run: |
+        TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+        WHEEL=$(ls dist/*.whl)
+        # Wheel filenames are <name>-<version>-<python tag>-...; field 2 is the version.
+        BUILT_VERSION=$(basename "$WHEEL" | cut -d'-' -f2)
+        echo "Tag version:   $TAG_VERSION"
+        echo "Built version: $BUILT_VERSION"
+        if [ "$TAG_VERSION" != "$BUILT_VERSION" ]; then
+          echo "❌ Version mismatch! Tag: $TAG_VERSION, Built: $BUILT_VERSION"
+          echo "   A clean checkout of tag v$TAG_VERSION must build exactly $TAG_VERSION."
+          echo "   A local segment or .postN means the tag is not what was built."
+          exit 1
+        fi
+        echo "✅ Built version matches tag: $TAG_VERSION"
 
     - name: Check package
       run: uvx twine check dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,11 @@ src/osprey/templates/apps/control_assistant/data/benchmarks/results/
 # Node.js (dev-only JS toolchain; not part of the Python wheel)
 node_modules/
 
+# Version stamp written by the hatch-vcs build hook. Committing it would recreate
+# the stale-literal problem the git-derived version exists to remove. It is still
+# packaged into the wheel and sdist — the hook registers it as a build artifact.
+src/osprey/_version.py
+
 # feature-scaffolding logs (not committed)
 .claude/.logs/.state/
 .claude/.logs/*.jsonl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,21 @@ Compatibility is documented in release notes, not encoded in the version string.
   directory and rebuild; the project stays a regenerable artifact.
   `osprey profile validate DIR` checks a profile without building, and
   `osprey profile presets` lists the bundled presets.
+
+- The framework version is now derived from the git tag instead of a literal in
+  `src/osprey/__init__.py`. A build between releases reports its distance from
+  the last one (`2026.8.0.post12+g83fda5e60`) rather than claiming to be that
+  release, in `osprey --version`, the status line, the web terminal health
+  payload, and generated project READMEs. Cutting a release is now just tagging
+  — there is no version to bump.
+
+- `osprey deploy up` and `osprey build` now refuse to pin
+  `osprey-framework==<version>` when running from a development checkout, since
+  no published release corresponds to that code. Use `--dev` to build and stage
+  a local wheel, or set `OSPREY_PIP_SPEC` to pin explicitly. Previously this
+  emitted a pin for a version that was never published and failed later, inside
+  the image build, with an opaque pip error.
+
 - Web terminal header: the username badge and the logout button are now one
   identity chip on the right, whose menu holds the deployment name and Log out.
   The deployment name (`web.app_name`) moved to the left, beside "Web Terminal".

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -239,8 +239,18 @@ cron = "osprey.dispatch.sources.cron:CronSource"
 epics_ca = "osprey.dispatch.sources.epics_ca:EpicsCaSource"
 
 # Hatchling build configuration
+# The version comes from the git tag, not a literal — a release is cut by tagging.
+# `post-release` keeps the base version on the *last* tag (2026.6.2.post783+g83fda5e60),
+# where the default `guess-next-dev` would invent an unreleased 2026.6.3. CalVer cannot
+# predict its own next number, so guessing is worse than not guessing.
 [tool.hatch.version]
-path = "src/osprey/__init__.py"
+source = "vcs"
+raw-options = { version_scheme = "post-release" }
+
+# Stamps the resolved version into the built artifact, which is the only way a wheel
+# (and any container built from one) can report its version without git present.
+[tool.hatch.build.hooks.vcs]
+version-file = "src/osprey/_version.py"
 
 [tool.hatch.build]
 # Never package benchmark results produced by running the channel-finder
@@ -343,6 +353,9 @@ markers = [
 line-length = 100
 target-version = "py311"
 src = ["src", "interfaces", "deployment"]
+# Written by the hatch-vcs build hook, not by hand — formatting it is not ours to
+# enforce, and it is present in any built or editable-installed tree.
+extend-exclude = ["src/osprey/_version.py"]
 
 [tool.ruff.lint]
 select = [

--- a/src/osprey/__init__.py
+++ b/src/osprey/__init__.py
@@ -14,11 +14,16 @@ importing the package configures nothing.
 
 from typing import TYPE_CHECKING, Any
 
+from osprey.version import get_running_version
+
 if TYPE_CHECKING:
     from osprey.utils.logger import configure_logging
 
-# Version information
-__version__ = "2026.8.0"
+# Version information. Derived from the git tag at build time and resolved at import
+# by osprey.version — see that module for the resolution chain. Bound eagerly rather
+# than through __getattr__ below so that `from osprey import __version__` and
+# `patch("osprey.__version__", ...)` keep behaving like the plain attribute it was.
+__version__ = get_running_version()
 
 __all__ = ["__version__", "configure_logging"]
 

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -304,21 +304,26 @@ def build(
             from packaging.specifiers import SpecifierSet
             from packaging.version import Version
 
-            from osprey import __version__
+            from osprey.version import get_release_version
 
-            spec = SpecifierSet(build_profile.requires_osprey_version)
-            current = Version(__version__)
+            # Compare the release lineage, not the running version: a development
+            # build carries a post/local segment that no release specifier is
+            # written against. `prereleases=True` keeps a pre-release lineage from
+            # being excluded by PEP 440's default filtering.
+            release_version = get_release_version()
+            spec = SpecifierSet(build_profile.requires_osprey_version, prereleases=True)
+            current = Version(release_version)
             if current not in spec:
                 logger.error(
                     "  ✗ OSPREY %s does not satisfy requires_osprey_version: %s",
-                    __version__,
+                    release_version,
                     build_profile.requires_osprey_version,
                 )
                 logger.info("     Upgrade OSPREY or run: osprey --version")
                 raise click.Abort()
             logger.info(
                 "  ✓ OSPREY %s satisfies %s",
-                __version__,
+                release_version,
                 build_profile.requires_osprey_version,
             )
 

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -306,24 +306,32 @@ def build(
 
             from osprey.version import get_release_version
 
+            from .build_profile_load import _PROFILE_SCHEMA_MIN_OSPREY
+
             # Compare the release lineage, not the running version: a development
             # build carries a post/local segment that no release specifier is
-            # written against. `prereleases=True` keeps a pre-release lineage from
-            # being excluded by PEP 440's default filtering.
+            # written against. But the lineage alone is not the whole capability:
+            # between releases a checkout ships the *next* release's profile
+            # schema (it stamps `_PROFILE_SCHEMA_MIN_OSPREY` into every profile
+            # it writes) while its tag still names the previous release, so
+            # judging it by tag alone would make it refuse profiles it just
+            # wrote. The schema floor this code carries is therefore also a
+            # floor on what it satisfies. `prereleases=True` keeps a pre-release
+            # lineage from being excluded by PEP 440's default filtering.
             release_version = get_release_version()
             spec = SpecifierSet(build_profile.requires_osprey_version, prereleases=True)
-            current = Version(release_version)
+            current = max(Version(release_version), Version(_PROFILE_SCHEMA_MIN_OSPREY))
             if current not in spec:
                 logger.error(
                     "  ✗ OSPREY %s does not satisfy requires_osprey_version: %s",
-                    release_version,
+                    current,
                     build_profile.requires_osprey_version,
                 )
                 logger.info("     Upgrade OSPREY or run: osprey --version")
                 raise click.Abort()
             logger.info(
                 "  ✓ OSPREY %s satisfies %s",
-                release_version,
+                current,
                 build_profile.requires_osprey_version,
             )
 

--- a/src/osprey/cli/build_environment.py
+++ b/src/osprey/cli/build_environment.py
@@ -244,7 +244,15 @@ def _resolve_osprey_spec(osprey_install: str) -> tuple[str, str]:
             return src_path, f"editable: {src_path}"
 
         if dist is not None:
-            spec = f"osprey-framework=={dist.version}"
+            from osprey.version import get_release_version, is_release, unreleased_pin_reason
+
+            if not is_release():
+                raise BuildProfileError(
+                    f"Cannot pin osprey-framework: {unreleased_pin_reason()} "
+                    "Set `osprey_install` in your profile to a source path or an "
+                    "explicit PEP 508 spec, or build from a released osprey."
+                )
+            spec = f"osprey-framework=={get_release_version()}"
             return spec, spec
 
         # Metadata unavailable (rare: e.g. running osprey directly from a

--- a/src/osprey/cli/templates/manifest.py
+++ b/src/osprey/cli/templates/manifest.py
@@ -252,17 +252,44 @@ def get_tracked_files(
 
 
 def get_framework_version() -> str:
-    """Get current osprey version.
+    """Get the running osprey version, for display in generated projects.
+
+    This is the version a human reads — it carries distance past the last release
+    (``2026.6.2.post783+g83fda5e60``) so a project rendered from a development
+    checkout says so. Anything comparing versions wants
+    :func:`osprey.version.get_release_version` instead; see
+    :func:`get_framework_release_version`.
 
     Returns:
-        Version string (e.g., "0.7.0") or ``"unknown"`` if the version
-        symbol cannot be imported (broken environment / partial install).
-        Manifest readers can branch on the sentinel.
+        Version string, or ``"unknown"`` if the version module cannot be imported
+        (broken environment / partial install). Manifest readers branch on the
+        sentinel.
     """
     try:
-        from osprey import __version__
+        from osprey.version import get_running_version
 
-        return __version__
+        return get_running_version()
+    except (ImportError, AttributeError):
+        return "unknown"
+
+
+def get_framework_release_version() -> str:
+    """Get the release this osprey descends from, for version *comparisons*.
+
+    Stamped into the manifest's ``creation.osprey_version`` and read back by
+    :mod:`osprey.deployment.staleness`, which compares it by string equality. Using
+    the running version on either side would make every commit in a development
+    checkout register as drift — inverting the advisory's rule that "can't compare"
+    must never read as drift into "always reads as drift".
+
+    Returns:
+        Release version string (e.g. ``"2026.6.2"``), or ``"unknown"`` if the
+        version module cannot be imported.
+    """
+    try:
+        from osprey.version import get_release_version
+
+        return get_release_version()
     except (ImportError, AttributeError):
         return "unknown"
 
@@ -542,7 +569,9 @@ def generate_manifest(
     )
     reproducible_command = build_reproducible_command(build_args)
     file_checksums = calculate_file_checksums(project_dir)
-    framework_version = get_framework_version()
+    # The release lineage, not the running version — staleness compares this field
+    # by string equality, so a development build must not read as drift.
+    framework_version = get_framework_release_version()
     user_owned_manifest = build_user_owned_manifest(template_root, jinja_env, project_dir, context)
 
     # The 'template' field carries the original preset name (hyphenated) when

--- a/src/osprey/deployment/compose_generator.py
+++ b/src/osprey/deployment/compose_generator.py
@@ -196,10 +196,17 @@ def _inject_project_metadata(config):
     # Resolve the running framework version so service Dockerfiles can pin the
     # PyPI install (`pip install osprey-framework==<version>`) for production
     # builds. Dev builds install a locally-built wheel instead (see --dev).
-    try:
-        from osprey import __version__ as osprey_version
-    except Exception:
-        osprey_version = ""
+    #
+    # This is deliberately the *running* version rather than the release lineage,
+    # and deliberately ungated. The service Dockerfiles hard-fail on an empty
+    # OSPREY_VERSION but tolerate an unreleased one under OSPREY_DEV=1, priming
+    # the layer with the latest release and warning that the pin was unreleased.
+    # Substituting the base release here would silently prime with released code
+    # and suppress that warning. A production build from a development checkout is
+    # refused earlier and more clearly by `_resolve_pip_spec`.
+    from osprey.version import get_running_version
+
+    osprey_version = get_running_version()
 
     # Create enhanced config with label metadata
     config_with_labels = config.copy()

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -360,25 +360,46 @@ def _resolve_claude_cli_version(config: dict) -> str:
     return _DEFAULT_CLAUDE_CLI_VERSION
 
 
-def _resolve_pip_spec() -> str:
+def _resolve_pip_spec(dev_mode: bool = False) -> str:
     """The ``OSPREY_PIP_SPEC`` build arg for the project image.
 
     An operator ``OSPREY_PIP_SPEC`` export wins (e.g. a ``git+https`` URL that
-    pins an unreleased build). Otherwise pin the running framework version
+    pins an unreleased build). Otherwise pin the released framework version
     (``osprey-framework==<version>``), matching the dispatch image's production
     install, so a project image built without ``--dev`` ships a deterministic
     release rather than tracking whatever ``osprey-framework`` resolves to at
-    build time. Under ``--dev`` a locally-built wheel is staged into the build
-    context and the Dockerfile installs that instead, ignoring this spec.
+    build time.
+
+    Under ``dev_mode`` a locally-built wheel has been staged into the build
+    context and the Dockerfile installs that instead, ignoring this spec — so the
+    release check is skipped. It has to be: a development checkout is exactly
+    where ``--dev`` is used, and refusing there would block the workflow this
+    error recommends. The caller passes the *effective* dev mode, so a ``--dev``
+    run whose wheel staging failed still gets the check and refuses rather than
+    quietly installing released code.
+
+    :param dev_mode: Whether a local wheel was staged for this build.
+    :raises UnreleasedVersionPinError: if a PyPI install would be pinned to a
+        version that was never published.
     """
     spec = os.environ.get("OSPREY_PIP_SPEC")
     if spec:
         return spec
-    try:
-        from osprey import __version__ as osprey_version
-    except Exception:
-        osprey_version = ""
-    return f"osprey-framework=={osprey_version}" if osprey_version else "osprey-framework"
+
+    from osprey.deployment.errors import UnreleasedVersionPinError
+    from osprey.version import get_release_version, is_release, unreleased_pin_reason
+
+    if dev_mode:
+        # The staged wheel is what gets installed; this value is inert.
+        return f"osprey-framework=={get_release_version()}"
+
+    if not is_release():
+        raise UnreleasedVersionPinError(
+            unreleased_pin_reason(),
+            "Use `osprey deploy up --dev` to build and stage a wheel from this "
+            "checkout, or set OSPREY_PIP_SPEC to pin explicitly.",
+        )
+    return f"osprey-framework=={get_release_version()}"
 
 
 def _worker_image_target(config: dict, env: dict) -> str:
@@ -433,7 +454,7 @@ def _project_image_build_cmd(
         "--build-arg",
         f"CLAUDE_CLI_VERSION={_resolve_claude_cli_version(config)}",
         "--build-arg",
-        f"OSPREY_PIP_SPEC={_resolve_pip_spec()}",
+        f"OSPREY_PIP_SPEC={_resolve_pip_spec(dev_mode=dev_mode)}",
     ]
     if dev_mode:
         cmd.extend(["--build-arg", "OSPREY_DEV=1"])

--- a/src/osprey/deployment/errors.py
+++ b/src/osprey/deployment/errors.py
@@ -30,3 +30,22 @@ class DevModeUnavailableError(DeploymentError):
         self.reason = reason
         self.remedy = remedy
         super().__init__(f"--dev cannot be honored: {reason}")
+
+
+class UnreleasedVersionPinError(DeploymentError):
+    """An ``osprey-framework==`` pin was needed, but this build is not a release.
+
+    The same reasoning as :class:`DevModeUnavailableError`, from the other
+    direction. A development checkout sits some number of commits past the last
+    tag, and no distribution on PyPI corresponds to it. Pinning to the nearest
+    release would produce containers running code the operator never wrote, with
+    nothing in the logs saying the two differ; emitting no pin at all would leave
+    the image tracking whatever PyPI resolves to that day.
+
+    So this refuses, and carries a ``remedy`` the CLI renders beneath the reason.
+    """
+
+    def __init__(self, reason: str, remedy: str) -> None:
+        self.reason = reason
+        self.remedy = remedy
+        super().__init__(f"Cannot pin osprey-framework: {reason}")

--- a/src/osprey/deployment/staleness.py
+++ b/src/osprey/deployment/staleness.py
@@ -33,9 +33,11 @@ _MANIFEST_FILENAME = ".osprey-manifest.json"
 
 
 def _installed_version() -> str:
-    from osprey.cli.templates.manifest import get_framework_version
+    # The release lineage, matching what the manifest stores. Comparing running
+    # versions would flag every commit in a development checkout as drift.
+    from osprey.cli.templates.manifest import get_framework_release_version
 
-    return get_framework_version()
+    return get_framework_release_version()
 
 
 def _load_manifest(project_dir: Path) -> dict[str, Any] | None:

--- a/src/osprey/deployment/web_terminals/persona_images.py
+++ b/src/osprey/deployment/web_terminals/persona_images.py
@@ -116,7 +116,7 @@ def _persona_image_build_cmd(
     cli_version = _resolve_persona_claude_cli_version(project_path)
     if cli_version:
         cmd.extend(["--build-arg", f"CLAUDE_CLI_VERSION={cli_version}"])
-    cmd.extend(["--build-arg", f"OSPREY_PIP_SPEC={_resolve_pip_spec()}"])
+    cmd.extend(["--build-arg", f"OSPREY_PIP_SPEC={_resolve_pip_spec(dev_mode=dev_mode)}"])
     if dev_mode:
         cmd.extend(["--build-arg", "OSPREY_DEV=1"])
     cmd.append(project_path)

--- a/src/osprey/templates/skills/osprey-release/SKILL.md
+++ b/src/osprey/templates/skills/osprey-release/SKILL.md
@@ -2,13 +2,13 @@
 name: osprey-release
 description: >
   Guides a maintainer through cutting an OSPREY release on the GitHub Flow
-  workflow: open a version-bump PR, merge it to main, tag the merge commit,
-  push the tag, verify the automated PyPI publish. Use when someone says
-  "create a release", "bump the version", "cut v2026.X.Y", "publish to PyPI",
-  "tag a release", or asks about the release process. Composes with
-  `osprey-contribute` for the bump PR. Versions follow CalVer (vYYYY.M.P) and
-  the source of truth is `src/osprey/__init__.py` — Hatch derives the
-  pyproject.toml version dynamically.
+  workflow: land the release-notes PR, tag the merge commit, push the tag,
+  verify the automated PyPI publish. Use when someone says "create a release",
+  "bump the version", "cut v2026.X.Y", "publish to PyPI", "tag a release", or
+  asks about the release process. Composes with `osprey-contribute` for the
+  notes PR. Versions follow CalVer (vYYYY.M.P) and the source of truth is the
+  git tag — Hatch derives the version from it, so there is no version literal
+  to bump.
 allowed-tools: Read, Glob, Grep, Bash, Edit
 ---
 
@@ -21,10 +21,10 @@ pushed.
 The shape is:
 
 1. Verify the working state and decide on the version number.
-2. Open a **version-bump PR** (no direct push to `main` — branch protection
-   rejects it).
+2. Open a **release-notes PR** carrying the CHANGELOG, RELEASE_NOTES and README
+   updates (no direct push to `main` — branch protection rejects it).
 3. Merge the PR to `main`.
-4. Tag the merge commit and push the tag.
+4. Tag the merge commit and push the tag. **This is what sets the version.**
 5. Verify the automated GitHub Actions workflow publishes successfully.
 
 For the PR mechanics in step 2, defer to the `osprey-contribute` skill.
@@ -42,21 +42,27 @@ month). When the year or month rolls over, `P` resets to `0`.
 
 ## The Source of Truth
 
-`src/osprey/__init__.py` holds `__version__`. Everything else either reads
-from there (Hatch, the GitHub Actions verify step) or is a doc string that
-also needs updating.
+**The git tag is the version.** There is no version literal anywhere in the
+tree to edit — `hatch-vcs` derives the package version from `git describe` at
+build time, and `osprey.version` resolves it at runtime. Tagging `v2026.7.0`
+*is* the act of setting the version to `2026.7.0`.
+
+Between releases the version reports its distance from the last tag
+(`2026.6.2.post783+g83fda5e60`), which is how a development build is
+distinguishable from the release it descends from.
 
 | File | Purpose | Updated by |
 | --- | --- | --- |
-| `src/osprey/__init__.py` | Source of truth — Hatch reads this for the package version | This skill |
-| `src/osprey/cli/main.py` | Fallback version printed by `osprey --version` when not installed | This skill |
 | `RELEASE_NOTES.md` | First-line title with the release version | This skill |
 | `CHANGELOG.md` | Add `## [vYYYY.M.P] - YYYY-MM-DD` heading; rotate `## [Unreleased]` content | This skill |
 | `README.md` | "Latest Release" line with version + theme | This skill |
-| `pyproject.toml` | Uses `dynamic = ["version"]`; Hatch reads from `__init__.py` | **Do not edit** |
+| `pyproject.toml` | `[tool.hatch.version] source = "vcs"` | **Do not edit** |
+| `src/osprey/_version.py` | Build-time stamp, gitignored | **Never commit** |
 
-The release.yml verify step greps `__version__ =` out of `src/osprey/__init__.py`
-and compares it to the pushed tag — if these disagree, the publish fails.
+The release.yml verify step builds the package and compares the *built wheel's*
+version to the pushed tag — if these disagree, the publish fails. They disagree
+when the tag is not on the commit being built, or when the checkout is shallow
+(which yields `0.1.devN` rather than failing outright).
 
 ---
 
@@ -98,23 +104,22 @@ deactivate && rm -rf .venv-release-test
 
 Any failures stop the release. Fix forward, then re-run.
 
-## Step 2: Version-bump PR
+## Step 2: Release-notes PR
 
-The version-bump commit cannot be pushed directly to `main` — branch
-protection rejects it. Open a PR instead.
+Release-notes commits cannot be pushed directly to `main` — branch protection
+rejects it. Open a PR instead.
 
 ```bash
 git checkout main && git pull --ff-only origin main
 git checkout -b release/vYYYY.M.P
 ```
 
-Update each file with the new version. Show the maintainer each diff before
-applying:
+There is **no version literal to edit** — the tag in Step 4 sets the version.
+This PR carries only the human-facing notes. Show the maintainer each diff
+before applying:
 
 | File | Change |
 | --- | --- |
-| `src/osprey/__init__.py` | `__version__ = "YYYY.M.P"` |
-| `src/osprey/cli/main.py` | The fallback `__version__ = "YYYY.M.P"` line |
 | `RELEASE_NOTES.md` | First line: `# Osprey Framework - Latest Release (vYYYY.M.P)` followed by the theme tagline |
 | `CHANGELOG.md` | Convert `## [Unreleased]` to `## [YYYY.M.P] - YYYY-MM-DD`; insert a fresh empty `## [Unreleased]` above it |
 | `README.md` | Update the "Latest Release" line with version + theme |
@@ -123,15 +128,13 @@ Then run a consistency check — every line should mention the same version:
 
 ```bash
 echo "=== VERSION CONSISTENCY CHECK ==="
-echo "__init__.py:    $(grep '__version__ = ' src/osprey/__init__.py)"
-echo "cli/main.py:    $(grep '__version__ = ' src/osprey/cli/main.py)"
 echo "RELEASE_NOTES:  $(head -1 RELEASE_NOTES.md)"
 echo "README.md:      $(grep 'Latest Release:' README.md)"
 echo "CHANGELOG.md:   $(grep -m1 '^## \[' CHANGELOG.md)"
 ```
 
 Now hand off to `osprey-contribute` for the rest of the PR mechanics:
-`quick_check.sh` → commit (`release: bump version to YYYY.M.P`) →
+`quick_check.sh` → commit (`release: notes for vYYYY.M.P`) →
 `ci_check.sh` → push → `premerge_check.sh main` → `gh pr create`.
 
 The PR title should be `release: vYYYY.M.P — <theme>`. The PR body should

--- a/src/osprey/version.py
+++ b/src/osprey/version.py
@@ -1,0 +1,261 @@
+"""Resolve the version of the running OSPREY framework.
+
+This module is the single source every consumer reads from. It distinguishes two
+values that are easy to conflate but have different jobs:
+
+- :func:`get_running_version` — what this process actually *is*, including how far
+  past the last release it sits (``2026.6.2.post783+g83fda5e60``). Everything shown
+  to a human or stamped as informational metadata wants this.
+- :func:`get_release_version` — the last shipped release (``2026.6.2``). PEP 440
+  comparisons and PyPI pins want this, because a version with a local segment has no
+  distribution behind it.
+
+The version is derived from the git tag at build time (``hatch-vcs``), so a release
+is cut by tagging rather than by editing a literal. At runtime it is resolved by the
+first of these that answers:
+
+1. ``git describe``, anchored to OSPREY's *own* source root. An editable install's
+   stamp is written once when the wheel is rebuilt and is not refreshed by
+   ``uv sync``, so a source checkout must ask git directly or it reports a stale
+   version commit-to-commit.
+2. ``osprey/_version.py``, stamped into the artifact at build time. This is what
+   makes a wheel — and any container built from one — honest, where no git exists.
+3. Installed distribution metadata.
+4. A sentinel carrying a local segment, so a broken environment can never be
+   mistaken for a release.
+
+Step 1 is anchored rather than cwd-relative on purpose. ``osprey build`` runs
+``git init`` inside the project it generates, and the Claude Code status line
+imports osprey from a process whose working directory is the operator's own repo —
+a cwd-relative probe would report someone else's tag as OSPREY's version.
+"""
+
+from __future__ import annotations
+
+import functools
+import subprocess
+from pathlib import Path
+
+__all__ = [
+    "get_release_version",
+    "get_running_version",
+    "is_release",
+    "unreleased_pin_reason",
+]
+
+#: Distribution name on PyPI. Note this is *not* the import name ``osprey``.
+_DIST_NAME = "osprey-framework"
+
+#: OSPREY's own source root: ``<root>/src/osprey/version.py`` -> ``<root>``. For an
+#: installed copy this points into ``site-packages``' parent, which has no ``.git``,
+#: so the git probe short-circuits without forking a subprocess.
+_SOURCE_ROOT = Path(__file__).resolve().parents[2]
+
+#: Emitted when nothing else answers. The local segment is deliberate: it keeps
+#: :func:`is_release` false, so a broken environment fails closed instead of
+#: claiming to be a release and pinning against a version that does not exist.
+_UNKNOWN_VERSION = "0.0.0+unknown"
+
+_GIT_TIMEOUT_SECONDS = 2
+
+
+def _anchored_at_osprey_source() -> bool:
+    """Report whether :data:`_SOURCE_ROOT` really is OSPREY's own git checkout.
+
+    Two independent checks, both cheap. The ``.git`` test is a plain filesystem
+    probe — it is what keeps installed copies from paying for a subprocess — and
+    uses ``exists()`` rather than ``is_dir()`` because a git worktree's ``.git`` is
+    a file pointing at the real git directory.
+
+    Returns:
+        True when the source root carries a git checkout that declares itself to be
+        the ``osprey-framework`` distribution.
+    """
+    if not (_SOURCE_ROOT / ".git").exists():
+        return False
+
+    pyproject = _SOURCE_ROOT / "pyproject.toml"
+    try:
+        import tomllib
+
+        with pyproject.open("rb") as handle:
+            declared = tomllib.load(handle).get("project", {}).get("name")
+    except (OSError, ValueError, ImportError):
+        return False
+    return bool(declared == _DIST_NAME)
+
+
+def _pep440_from_describe(described: str) -> str | None:
+    """Convert ``git describe`` output into the same string the build stamp holds.
+
+    Mirrors ``setuptools-scm``'s ``post-release`` version scheme with the default
+    ``node-and-date`` local scheme, so a given commit reports one version whether it
+    is run from the source tree or from a wheel built out of it.
+
+    Args:
+        described: Output of ``git describe --tags --long --dirty``, e.g.
+            ``v2026.6.2-783-g83fda5e60`` or ``v2026.6.2-0-g1234567-dirty``.
+
+    Returns:
+        A PEP 440 version string, or None when the output cannot be parsed.
+    """
+    dirty = described.endswith("-dirty")
+    if dirty:
+        described = described[: -len("-dirty")]
+
+    tag, _, remainder = described.rpartition("-g")
+    tag, _, distance = tag.rpartition("-")
+    if not tag or not distance.isdigit() or not remainder:
+        return None
+
+    base = tag.removeprefix("v")
+    if distance == "0" and not dirty:
+        return base
+
+    local = f"g{remainder}"
+    if dirty:
+        from datetime import date
+
+        local = f"{local}.d{date.today():%Y%m%d}"
+    return f"{base}.post{distance}+{local}"
+
+
+def _version_from_git() -> str | None:
+    """Derive the version from OSPREY's own checkout, or None if unavailable."""
+    if not _anchored_at_osprey_source():
+        return None
+
+    try:
+        completed = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(_SOURCE_ROOT),
+                "describe",
+                "--tags",
+                "--long",
+                "--dirty",
+                "--match",
+                "v[0-9]*",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        # No git binary on this host, or the call timed out. Fall through.
+        return None
+
+    if completed.returncode != 0:
+        # A shallow clone or a repo with no matching tag reaches here.
+        return None
+    return _pep440_from_describe(completed.stdout.strip())
+
+
+def _version_from_stamp() -> str | None:
+    """Read the version stamped into the artifact by the build hook."""
+    try:
+        from osprey._version import __version__
+
+        return str(__version__)
+    except (ImportError, AttributeError):
+        return None
+
+
+def _version_from_metadata() -> str | None:
+    """Read the version from installed distribution metadata."""
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as metadata_version
+
+    try:
+        return metadata_version(_DIST_NAME)
+    except PackageNotFoundError:
+        return None
+
+
+@functools.cache
+def get_running_version() -> str:
+    """Return the version of the OSPREY currently executing.
+
+    Includes distance past the last release and the commit, so a build from a
+    development checkout is distinguishable from the release it descends from. This
+    is the value to show a human or stamp as informational metadata.
+
+    Returns:
+        A PEP 440 version string, e.g. ``"2026.6.2"`` at a tag or
+        ``"2026.6.2.post783+g83fda5e60"`` 783 commits past one. Never raises.
+    """
+    return (
+        _version_from_git() or _version_from_stamp() or _version_from_metadata() or _UNKNOWN_VERSION
+    )
+
+
+@functools.cache
+def get_release_version() -> str:
+    """Return the last shipped release this build descends from.
+
+    Strips the distance and commit that :func:`get_running_version` carries, leaving
+    a version that exists on PyPI and compares cleanly under PEP 440. Use this for
+    specifier checks and install pins — but pair it with :func:`is_release` before
+    pinning, since from a development checkout it names a release whose code is
+    *not* what is running.
+
+    Returns:
+        A release version string, e.g. ``"2026.6.2"``. Never raises.
+    """
+    from packaging.version import InvalidVersion, Version
+
+    running = get_running_version()
+    try:
+        return Version(running).base_version
+    except InvalidVersion:
+        return running
+
+
+def unreleased_pin_reason() -> str:
+    """Explain why the running build cannot be pinned to a published release.
+
+    Shared by every producer of an ``osprey-framework==`` requirement so they all
+    refuse for the same stated reason. Callers supply their own remedy, since the
+    way out differs by command.
+
+    Returns:
+        A one-sentence reason naming the running version and its distance from the
+        last release.
+    """
+    from packaging.version import InvalidVersion, Version
+
+    running = get_running_version()
+    release = get_release_version()
+    try:
+        distance = Version(running).post
+    except InvalidVersion:
+        distance = None
+
+    past = f", {distance} commits past v{release}" if distance else ""
+    return (
+        f"running {running} is not a released version{past}. A container built from "
+        "PyPI would run different code than this checkout."
+    )
+
+
+def is_release() -> bool:
+    """Report whether this build is exactly a tagged, clean release.
+
+    False for anything carrying distance, a pre/post/dev segment, a local segment,
+    or uncommitted changes — and for an environment where the version could not be
+    resolved at all.
+
+    Returns:
+        True only when the running version is a published release.
+    """
+    from packaging.version import InvalidVersion, Version
+
+    try:
+        parsed = Version(get_running_version())
+    except InvalidVersion:
+        return False
+    return not (
+        parsed.is_devrelease or parsed.is_postrelease or parsed.is_prerelease or parsed.local
+    )

--- a/tests/cli/test_build_cmd.py
+++ b/tests/cli/test_build_cmd.py
@@ -1197,6 +1197,11 @@ class TestResolveOspreySpec:
         assert spec == "/abs/path/to/osprey"
         assert "editable" in label
 
+    def _pretend_release(self, monkeypatch, version="2026.5.0", released=True):
+        """Drive the version API, which is what the resolver now pins from."""
+        monkeypatch.setattr("osprey.version.get_release_version", lambda: version)
+        monkeypatch.setattr("osprey.version.is_release", lambda: released)
+
     def test_wheel_install_pins_to_version(self, monkeypatch):
         """uv tool / pip wheel install → pinned to ``osprey-framework==<version>``."""
         from osprey.cli.build_cmd import _resolve_osprey_spec
@@ -1206,6 +1211,7 @@ class TestResolveOspreySpec:
             direct_url={"url": "https://pypi/...", "archive_info": {"hash": "sha256=abc"}},
         )
         monkeypatch.setattr("osprey.cli.build_environment.distribution", lambda _name: fake)
+        self._pretend_release(monkeypatch)
 
         spec, label = _resolve_osprey_spec("local")
         assert spec == "osprey-framework==2026.5.0"
@@ -1217,9 +1223,32 @@ class TestResolveOspreySpec:
 
         fake = self._fake_dist(version="2026.5.0", direct_url=None)
         monkeypatch.setattr("osprey.cli.build_environment.distribution", lambda _name: fake)
+        self._pretend_release(monkeypatch)
 
         spec, _label = _resolve_osprey_spec("local")
         assert spec == "osprey-framework==2026.5.0"
+
+    def test_unreleased_build_refuses_to_pin(self, monkeypatch):
+        """A development build has no PyPI distribution — refuse rather than mislead.
+
+        Pinning to the nearest release would install code the operator never
+        wrote, with nothing saying the two differ.
+        """
+        from osprey.cli.build_cmd import _resolve_osprey_spec
+        from osprey.errors import BuildProfileError
+
+        fake = self._fake_dist(
+            version="2026.5.0.post783+g83fda5e60",
+            direct_url={"url": "https://pypi/...", "archive_info": {"hash": "sha256=abc"}},
+        )
+        monkeypatch.setattr("osprey.cli.build_environment.distribution", lambda _name: fake)
+        monkeypatch.setattr(
+            "osprey.version.get_running_version", lambda: "2026.5.0.post783+g83fda5e60"
+        )
+        self._pretend_release(monkeypatch, released=False)
+
+        with pytest.raises(BuildProfileError, match="not a released version"):
+            _resolve_osprey_spec("local")
 
     def test_pip_keyword_uses_unpinned_pypi(self, monkeypatch):
         """Explicit ``osprey_install: pip`` → unpinned ``osprey-framework``."""

--- a/tests/cli/test_profile_unknown_keys.py
+++ b/tests/cli/test_profile_unknown_keys.py
@@ -15,7 +15,6 @@ import yaml
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
-from osprey import __version__
 from osprey.cli import build_profile_presets
 from osprey.cli.build_profile_load import (
     _KNOWN_PROFILE_KEYS,
@@ -141,14 +140,22 @@ def test_schema_min_osprey_is_pinned() -> None:
 
 
 def test_running_osprey_satisfies_the_schema_floor() -> None:
-    """The release shipping these keys must be able to build what it emits.
+    """The code shipping these keys must be able to build what it emits.
 
-    ``osprey build`` aborts when ``__version__`` does not satisfy a profile's
-    ``requires_osprey_version``, and emitted profiles stamp ``>=`` this floor —
-    so a floor ahead of the shipped version would make every materialized
-    profile unbuildable.
+    ``osprey build`` compares ``max(release lineage, _PROFILE_SCHEMA_MIN_OSPREY)``
+    against a profile's ``requires_osprey_version``, and emitted profiles stamp
+    ``>=`` this floor. Between releases the tag lineage sits *behind* the floor
+    (the floor names the next release, which does not exist yet), so it is the
+    schema arm of the max() that keeps every materialized profile buildable.
+    Assert the effective capability exactly as the check computes it — the
+    profile round-trip itself is proven functionally by
+    ``test_profile_source_flow_parity``, which builds from emitted profiles on
+    whatever checkout runs the suite.
     """
-    assert Version(__version__) in SpecifierSet(f">={_PROFILE_SCHEMA_MIN_OSPREY}")
+    from osprey.version import get_release_version
+
+    effective = max(Version(get_release_version()), Version(_PROFILE_SCHEMA_MIN_OSPREY))
+    assert effective in SpecifierSet(f">={_PROFILE_SCHEMA_MIN_OSPREY}")
 
 
 def test_schema_min_osprey_is_a_usable_version_floor() -> None:

--- a/tests/cli/test_templates.py
+++ b/tests/cli/test_templates.py
@@ -653,12 +653,13 @@ def test_get_framework_version_unknown_on_import_failure(monkeypatch):
     real_import = builtins.__import__
 
     def fake_import(name, *args, **kwargs):
-        if name == "osprey":
+        if name in ("osprey", "osprey.version"):
             raise ImportError("simulated failure")
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
     assert manifest_mod.get_framework_version() == "unknown"
+    assert manifest_mod.get_framework_release_version() == "unknown"
 
 
 def test_registry_style_parameter_is_gone():

--- a/tests/deployment/conftest.py
+++ b/tests/deployment/conftest.py
@@ -23,6 +23,24 @@ def reset_runtime_cache():
 
 
 @pytest.fixture(autouse=True)
+def running_a_released_osprey(monkeypatch):
+    """Build image argv as though a released osprey were running.
+
+    Production image builds pin ``osprey-framework==<release>`` and refuse when
+    the running framework is a development build, since no published
+    distribution matches it. The test suite itself runs from a development
+    checkout, so without this every argv-shape test here would trip that refusal
+    instead of asserting on the argv it cares about.
+
+    Tests that are *about* the refusal re-patch these inside the test body, which
+    takes precedence — see ``TestResolvePipSpec`` in
+    ``test_container_lifecycle.py``.
+    """
+    monkeypatch.setattr("osprey.version.is_release", lambda: True)
+    monkeypatch.setattr("osprey.version.get_release_version", lambda: "2026.6.2")
+
+
+@pytest.fixture(autouse=True)
 def reset_wheel_build_cache():
     """Isolate every test from the process-wide dev-wheel build memo.
 

--- a/tests/deployment/test_container_lifecycle.py
+++ b/tests/deployment/test_container_lifecycle.py
@@ -1843,3 +1843,78 @@ def test_deploy_up_no_web_terminals_skips_preflight(monkeypatch, tmp_path):
 
     assert "preflight" not in order
     assert "build_image" in order
+
+
+class TestResolvePipSpec:
+    """The ``OSPREY_PIP_SPEC`` build arg must never name a nonexistent release.
+
+    A hand-maintained version literal used to let this emit
+    ``osprey-framework==<unreleased>``, which fails at pip resolve inside the
+    image build with no indication of why.
+    """
+
+    def test_operator_override_wins(self, monkeypatch):
+        monkeypatch.setenv("OSPREY_PIP_SPEC", "git+https://example.invalid/osprey@abc123")
+        assert (
+            container_lifecycle._resolve_pip_spec() == "git+https://example.invalid/osprey@abc123"
+        )
+
+    def test_release_pins_to_the_release(self, monkeypatch):
+        monkeypatch.delenv("OSPREY_PIP_SPEC", raising=False)
+        monkeypatch.setattr("osprey.version.is_release", lambda: True)
+        monkeypatch.setattr("osprey.version.get_release_version", lambda: "2026.6.2")
+
+        assert container_lifecycle._resolve_pip_spec() == "osprey-framework==2026.6.2"
+
+    def test_development_build_refuses_and_names_the_way_out(self, monkeypatch):
+        from osprey.deployment.errors import UnreleasedVersionPinError
+
+        monkeypatch.delenv("OSPREY_PIP_SPEC", raising=False)
+        monkeypatch.setattr("osprey.version.is_release", lambda: False)
+        monkeypatch.setattr("osprey.version.get_release_version", lambda: "2026.6.2")
+        monkeypatch.setattr(
+            "osprey.version.get_running_version", lambda: "2026.6.2.post783+g83fda5e60"
+        )
+
+        with pytest.raises(UnreleasedVersionPinError) as excinfo:
+            container_lifecycle._resolve_pip_spec()
+
+        assert "783 commits past v2026.6.2" in excinfo.value.reason
+        assert "--dev" in excinfo.value.remedy
+
+    def test_override_still_wins_from_a_development_build(self, monkeypatch):
+        """The escape hatch must not be gated behind being a release."""
+        monkeypatch.setenv("OSPREY_PIP_SPEC", "osprey-framework==2026.6.2")
+        monkeypatch.setattr("osprey.version.is_release", lambda: False)
+
+        assert container_lifecycle._resolve_pip_spec() == "osprey-framework==2026.6.2"
+
+    def test_dev_mode_does_not_refuse(self, monkeypatch):
+        """``--dev`` is used *from* a development checkout — it must not refuse.
+
+        The staged wheel is what the Dockerfile installs, so this spec is inert.
+        Gating it here would block the workflow the refusal message recommends.
+        """
+        monkeypatch.delenv("OSPREY_PIP_SPEC", raising=False)
+        monkeypatch.setattr("osprey.version.is_release", lambda: False)
+        monkeypatch.setattr("osprey.version.get_release_version", lambda: "2026.6.2")
+
+        assert container_lifecycle._resolve_pip_spec(dev_mode=True) == "osprey-framework==2026.6.2"
+
+    def test_dev_run_whose_wheel_staging_failed_still_refuses(self, monkeypatch):
+        """Callers pass the *effective* dev mode, which is False when staging failed.
+
+        That build installs from PyPI after all, so it must not quietly ship
+        released code in place of the checkout `--dev` was asked to test.
+        """
+        from osprey.deployment.errors import UnreleasedVersionPinError
+
+        monkeypatch.delenv("OSPREY_PIP_SPEC", raising=False)
+        monkeypatch.setattr("osprey.version.is_release", lambda: False)
+        monkeypatch.setattr("osprey.version.get_release_version", lambda: "2026.6.2")
+        monkeypatch.setattr(
+            "osprey.version.get_running_version", lambda: "2026.6.2.post783+g83fda5e60"
+        )
+
+        with pytest.raises(UnreleasedVersionPinError):
+            container_lifecycle._resolve_pip_spec(dev_mode=False)

--- a/tests/deployment/test_project_staleness.py
+++ b/tests/deployment/test_project_staleness.py
@@ -67,6 +67,32 @@ def test_fresh_project_yields_no_reasons(tmp_path, presets_dir, monkeypatch):
     assert staleness.staleness_reasons(tmp_path) == []
 
 
+def test_development_commits_do_not_read_as_drift(tmp_path, presets_dir, monkeypatch):
+    """Two dev builds of the same release must not register as staleness.
+
+    Both sides of this comparison carry the release lineage, not the running
+    version. If either carried the running version, every commit in a development
+    checkout would report the project as stale and the advisory would become noise.
+    """
+    _write_preset(presets_dir, "demo", "name: Demo\n")
+    from osprey.cli.templates import manifest as manifest_mod
+
+    # Rendered at one dev commit...
+    monkeypatch.setattr(manifest_mod, "get_release_version", lambda: "2026.7.0", raising=False)
+    _write_manifest(
+        tmp_path,
+        creation={
+            "osprey_version": "2026.7.0",
+            "preset_hash": build_profile.compute_preset_hash("demo"),
+        },
+    )
+
+    # ...deployed from another, 40 commits later on the same release.
+    monkeypatch.setattr(staleness, "_installed_version", lambda: "2026.7.0")
+
+    assert staleness.staleness_reasons(tmp_path) == []
+
+
 def test_version_drift_is_reported(tmp_path, monkeypatch):
     monkeypatch.setattr(staleness, "_installed_version", lambda: "2026.8.1")
     _write_manifest(tmp_path)

--- a/tests/e2e/test_deploy_lifecycle.py
+++ b/tests/e2e/test_deploy_lifecycle.py
@@ -159,13 +159,25 @@ def _run_osprey(
     # forcing it to RUNTIME here structurally couples the deploy-side runtime
     # to the assert-side _runtime_cli runtime, regardless of what the ambient
     # environment (or CI job) does or doesn't set.
+    #
+    # OSPREY_PIP_SPEC is the documented operator escape from the unreleased-
+    # version pin refusal (deploy up from a dev checkout cannot honestly pin a
+    # PyPI release). Every image these tests build is a stub Dockerfile that
+    # never declares the build arg, so the spec is inert — but its VALUE must
+    # stay a loud failure: if a future fixture ever consumes it, pip must
+    # refuse rather than silently install a real release.
     return subprocess.run(
         [str(osprey_bin), *args],
         cwd=str(cwd),
         capture_output=True,
         text=True,
         timeout=timeout,
-        env={**os.environ, "CLAUDECODE": "", "CONTAINER_RUNTIME": RUNTIME},
+        env={
+            **os.environ,
+            "CLAUDECODE": "",
+            "CONTAINER_RUNTIME": RUNTIME,
+            "OSPREY_PIP_SPEC": "osprey-framework==0.0.0+e2e-stub",
+        },
     )
 
 

--- a/tests/e2e/test_dockerfile_e2e.py
+++ b/tests/e2e/test_dockerfile_e2e.py
@@ -406,9 +406,15 @@ def _build_sentinel_wheel(version: str, work_dir: Path) -> Path:
     """Build a local osprey wheel pinned to ``version`` containing a sentinel module.
 
     Copies the minimal build inputs (``pyproject.toml``, ``README.md``,
-    ``src/osprey``) to a scratch tree, stamps ``__version__`` to ``version``,
-    injects ``osprey/_e2e_sentinel.py``, and runs ``python -m build --wheel``.
-    Returns the built wheel path (inside ``work_dir``).
+    ``src/osprey``) to a scratch tree, injects ``osprey/_e2e_sentinel.py``, and
+    runs ``python -m build --wheel``. Returns the built wheel path (inside
+    ``work_dir``).
+
+    The scratch tree has no ``.git``, and the version is derived from git rather
+    than from a literal, so the build is pinned with
+    ``SETUPTOOLS_SCM_PRETEND_VERSION``. The per-package
+    ``SETUPTOOLS_SCM_PRETEND_VERSION_FOR_*`` form does not take here — do not
+    substitute it without re-verifying against the ``osprey-framework`` dist name.
     """
     import osprey as _osprey
 
@@ -423,14 +429,6 @@ def _build_sentinel_wheel(version: str, work_dir: Path) -> Path:
     for name in ("pyproject.toml", "README.md"):
         shutil.copy2(source_root / name, wheel_src / name)
 
-    # Stamp the version hatchling reads ([tool.hatch.version] -> __init__.py).
-    init_path = wheel_src / "src" / "osprey" / "__init__.py"
-    stamped, n = re.subn(
-        r'__version__ = "[^"]+"', f'__version__ = "{version}"', init_path.read_text(), count=1
-    )
-    assert n == 1, "could not stamp __version__ in the wheel source copy"
-    init_path.write_text(stamped)
-
     (wheel_src / "src" / "osprey" / "_e2e_sentinel.py").write_text(
         f'SENTINEL = "{SENTINEL_MARKER}"\n'
     )
@@ -441,6 +439,7 @@ def _build_sentinel_wheel(version: str, work_dir: Path) -> Path:
         capture_output=True,
         text=True,
         timeout=600,
+        env={**os.environ, "SETUPTOOLS_SCM_PRETEND_VERSION": version},
     )
     assert build.returncode == 0, (
         f"sentinel wheel build failed:\n--- stdout ---\n{build.stdout[-3000:]}"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,192 @@
+"""Unit tests for the version resolution chain in osprey.version."""
+
+import subprocess
+
+import pytest
+
+from osprey import version as version_module
+from osprey.version import get_release_version, get_running_version, is_release
+
+
+@pytest.fixture(autouse=True)
+def _clear_version_cache():
+    """Drop the memoised version between tests so each one resolves fresh."""
+    get_running_version.cache_clear()
+    get_release_version.cache_clear()
+    yield
+    get_running_version.cache_clear()
+    get_release_version.cache_clear()
+
+
+def _git(*args, cwd):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+def _make_repo(path, tag, extra_commits=0):
+    """Build a throwaway git repo carrying ``tag`` and ``extra_commits`` past it."""
+    path.mkdir(parents=True, exist_ok=True)
+    _git("init", "-q", cwd=path)
+    _git("config", "user.email", "test@example.com", cwd=path)
+    _git("config", "user.name", "Test", cwd=path)
+    (path / "pyproject.toml").write_text('[project]\nname = "osprey-framework"\n')
+    _git("add", "-A", cwd=path)
+    _git("commit", "-qm", "initial", cwd=path)
+    _git("tag", tag, cwd=path)
+    for index in range(extra_commits):
+        (path / f"file{index}.txt").write_text(str(index))
+        _git("add", "-A", cwd=path)
+        _git("commit", "-qm", f"commit {index}", cwd=path)
+    return path
+
+
+class TestDescribeParsing:
+    def test_exact_tag_is_the_bare_release(self):
+        assert version_module._pep440_from_describe("v2026.6.2-0-g1234567") == "2026.6.2"
+
+    def test_distance_becomes_a_post_release_with_the_commit(self):
+        assert (
+            version_module._pep440_from_describe("v2026.6.2-783-g83fda5e60")
+            == "2026.6.2.post783+g83fda5e60"
+        )
+
+    def test_dirty_tree_is_marked_and_never_reads_as_a_release(self):
+        parsed = version_module._pep440_from_describe("v2026.6.2-0-g1234567-dirty")
+        assert parsed is not None
+        assert parsed.startswith("2026.6.2.post0+g1234567.d")
+
+    def test_unparseable_output_returns_none(self):
+        assert version_module._pep440_from_describe("not-a-describe") is None
+        assert version_module._pep440_from_describe("") is None
+
+
+class TestResolutionChain:
+    def test_source_checkout_reports_distance_past_the_tag(self, tmp_path, monkeypatch):
+        repo = _make_repo(tmp_path / "osprey", "v2026.6.2", extra_commits=3)
+        monkeypatch.setattr(version_module, "_SOURCE_ROOT", repo)
+
+        running = get_running_version()
+        assert running.startswith("2026.6.2.post3+g")
+        assert get_release_version() == "2026.6.2"
+        assert is_release() is False
+
+    def test_clean_tag_is_a_release(self, tmp_path, monkeypatch):
+        repo = _make_repo(tmp_path / "osprey", "v2026.6.2")
+        monkeypatch.setattr(version_module, "_SOURCE_ROOT", repo)
+
+        assert get_running_version() == "2026.6.2"
+        assert get_release_version() == "2026.6.2"
+        assert is_release() is True
+
+    def test_does_not_pick_up_an_unrelated_repos_tags(self, tmp_path, monkeypatch):
+        """The anchor must beat cwd.
+
+        ``osprey build`` runs ``git init`` in the project it generates, and the
+        status line imports osprey from the operator's own repo. A cwd-relative
+        probe would report that repo's tag as OSPREY's version.
+        """
+        unrelated = _make_repo(tmp_path / "someone-elses-repo", "v9.9.9", extra_commits=2)
+        (unrelated / "pyproject.toml").write_text('[project]\nname = "not-osprey"\n')
+        _git("add", "-A", cwd=unrelated)
+        _git("commit", "-qm", "rename", cwd=unrelated)
+
+        installed = tmp_path / "site-packages-parent"
+        installed.mkdir()
+        monkeypatch.setattr(version_module, "_SOURCE_ROOT", installed)
+        monkeypatch.setattr(version_module, "_version_from_stamp", lambda: "2026.6.2")
+        monkeypatch.chdir(unrelated)
+
+        assert get_running_version() == "2026.6.2"
+
+    def test_pyproject_declaring_another_project_is_rejected(self, tmp_path, monkeypatch):
+        repo = _make_repo(tmp_path / "osprey", "v2026.6.2", extra_commits=1)
+        (repo / "pyproject.toml").write_text('[project]\nname = "something-else"\n')
+        monkeypatch.setattr(version_module, "_SOURCE_ROOT", repo)
+        monkeypatch.setattr(version_module, "_version_from_stamp", lambda: "1.2.3")
+
+        assert get_running_version() == "1.2.3"
+
+    def test_stamp_is_used_when_there_is_no_git(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(version_module, "_SOURCE_ROOT", tmp_path)
+        monkeypatch.setattr(version_module, "_version_from_stamp", lambda: "2026.6.2.post5+gabc123")
+
+        assert get_running_version() == "2026.6.2.post5+gabc123"
+        assert get_release_version() == "2026.6.2"
+        assert is_release() is False
+
+    def test_metadata_is_used_when_there_is_no_stamp(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(version_module, "_SOURCE_ROOT", tmp_path)
+        monkeypatch.setattr(version_module, "_version_from_stamp", lambda: None)
+        monkeypatch.setattr(version_module, "_version_from_metadata", lambda: "2026.6.2")
+
+        assert get_running_version() == "2026.6.2"
+
+    def test_missing_git_binary_falls_through_without_raising(self, tmp_path, monkeypatch):
+        repo = _make_repo(tmp_path / "osprey", "v2026.6.2", extra_commits=1)
+        monkeypatch.setattr(version_module, "_SOURCE_ROOT", repo)
+        monkeypatch.setattr(version_module, "_version_from_stamp", lambda: "2026.6.2")
+
+        def _no_git(*args, **kwargs):
+            raise FileNotFoundError("git")
+
+        monkeypatch.setattr(version_module.subprocess, "run", _no_git)
+
+        assert get_running_version() == "2026.6.2"
+
+    def test_git_timeout_falls_through_without_raising(self, tmp_path, monkeypatch):
+        repo = _make_repo(tmp_path / "osprey", "v2026.6.2", extra_commits=1)
+        monkeypatch.setattr(version_module, "_SOURCE_ROOT", repo)
+        monkeypatch.setattr(version_module, "_version_from_stamp", lambda: "2026.6.2")
+
+        def _slow(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd="git", timeout=2)
+
+        monkeypatch.setattr(version_module.subprocess, "run", _slow)
+
+        assert get_running_version() == "2026.6.2"
+
+    def test_shallow_clone_without_tags_falls_through(self, tmp_path, monkeypatch):
+        repo = tmp_path / "osprey"
+        repo.mkdir()
+        _git("init", "-q", cwd=repo)
+        _git("config", "user.email", "test@example.com", cwd=repo)
+        _git("config", "user.name", "Test", cwd=repo)
+        (repo / "pyproject.toml").write_text('[project]\nname = "osprey-framework"\n')
+        _git("add", "-A", cwd=repo)
+        _git("commit", "-qm", "initial", cwd=repo)
+        monkeypatch.setattr(version_module, "_SOURCE_ROOT", repo)
+        monkeypatch.setattr(version_module, "_version_from_stamp", lambda: "2026.6.2")
+
+        assert get_running_version() == "2026.6.2"
+
+
+class TestUnresolvableEnvironment:
+    def test_falls_back_without_crashing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(version_module, "_SOURCE_ROOT", tmp_path)
+        monkeypatch.setattr(version_module, "_version_from_stamp", lambda: None)
+        monkeypatch.setattr(version_module, "_version_from_metadata", lambda: None)
+
+        assert get_running_version() == "0.0.0+unknown"
+
+    def test_fails_closed_rather_than_claiming_to_be_a_release(self, tmp_path, monkeypatch):
+        """A broken environment must never pin — hence the local segment."""
+        monkeypatch.setattr(version_module, "_SOURCE_ROOT", tmp_path)
+        monkeypatch.setattr(version_module, "_version_from_stamp", lambda: None)
+        monkeypatch.setattr(version_module, "_version_from_metadata", lambda: None)
+
+        assert is_release() is False
+
+
+class TestLiveCheckout:
+    def test_release_version_matches_the_newest_tag(self):
+        """The running checkout's release lineage is the newest v* tag reachable."""
+        described = subprocess.run(
+            ["git", "describe", "--tags", "--abbrev=0", "--match", "v[0-9]*"],
+            cwd=version_module._SOURCE_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if described.returncode != 0:
+            pytest.skip("no reachable v* tag in this checkout")
+
+        assert get_release_version() == described.stdout.strip().removeprefix("v")


### PR DESCRIPTION
## The problem

The framework version was a hand-maintained literal in `src/osprey/__init__.py`, scraped at build time by `[tool.hatch.version] path=`. It changed only at release, so a build from `main` reported the last released version no matter how far past it the code had moved — and nothing forced it to agree with the tags, so it drifted in **both** directions:

| | |
|---|---|
| `src/osprey/__init__.py` | `2026.8.0` |
| Newest git tag | `v2026.6.2` |
| Latest on PyPI | `2026.6.2` |

`2026.8.0` exists only as a string. That is not cosmetic — `deployment/container_lifecycle.py` builds the production pin as `osprey-framework=={__version__}`, so a non-`--dev` container build off `main` emitted a requirement for a distribution that has never been published and failed at pip resolve with an opaque error. `cli/build_environment.py` was a second, independent pin producer with the same defect, reading `importlib.metadata` rather than `__version__`.

## The change

The git tag becomes the source of truth. `hatch-vcs` derives the version, a build hook stamps it into the artifact, and one module resolves it at runtime.

```
get_running_version()  ->  2026.6.2.post796+g6b2d8ca7e   what this process is
get_release_version()  ->  2026.6.2                      last real release
is_release()           ->  False                         gates the pins
```

`osprey.__version__` stays a plain eager attribute fed by `get_running_version()`. That is what keeps the change small: the ~15 display consumers — `osprey --version`, the menu banner, the status line, the web-terminal health payload, generated project READMEs — need no edit and become honest for free. Only the six lineage and pin sites were repointed.

**Resolution order** is anchored git describe → build stamp → installed metadata → sentinel. Git comes first because with `hatch-vcs` the version is computed once when the editable wheel is rebuilt and **`uv sync` does not refresh it**, so a stamp-only scheme would leave a development checkout reporting a stale version — the original complaint. The probe is anchored to osprey's own source root, never the working directory, so the repo `osprey build` creates in a generated project cannot be mistaken for the framework's own.

`post-release` is the deliberate scheme choice: `Version(...).base_version` lands on the real last tag. The default `guess-next-dev` would report a base of `2026.6.3` — a release that does not exist — and CalVer cannot predict its own next number anyway.

**Pins fail closed.** Both producers now refuse rather than name a version with no distribution behind it, and say how to proceed. Pinning the nearest release instead would be worse than failing: containers would come up healthy running code the operator never wrote, with nothing saying the two differ. The check is skipped under `--dev`, where a staged local wheel makes the pin inert — a development checkout is exactly where `--dev` is used. Callers pass the *effective* dev mode, so a `--dev` run whose wheel staging failed still refuses.

**`creation.osprey_version` is lineage, not display.** `staleness.py` reads that field back by string equality, so recording the running version there would report every commit in a development checkout as drift — inverting the advisory's own rule that an inability to compare must never read as drift.

## CI and release

Two changes here are load-bearing rather than tidy-up:

- **`fetch-depth: 0`** on every checkout that runs `uv build` or `uv sync`. A depth-1 clone carries no tags, and setuptools-scm does not fail there — it warns and emits `0.1.devN`, while `twine check` validates metadata rather than the version. Without this the package lane goes **green** while publishing a bogus artifact.
- **The release gate** compared the pushed tag to the literal. It now builds first and compares the tag to the wheel actually about to be published.

`src/osprey/_version.py` is gitignored — committing the stamp would recreate the stale-literal problem in a less visible form. It still ships in the wheel and sdist; the hook registers it as a build artifact.

## Note for the next release

Because the tag is now the version, **`main` will report `2026.6.2.post<N>` until `v2026.8.0` is pushed.** The `2026.8.0` bump commit landed without its tag, so that release is currently a string and nothing else. Tagging it makes it real, and the new release gate verifies the built wheel matches.

## Verification

- `tests/test_version.py` — 16 cases, including one asserting the resolver ignores an unrelated repo's tags when run from inside it
- Full unit suite green; existing suites pass unchanged, which is the evidence the `__version__` hinge holds
- A wheel built from this branch, installed into a clean venv with no git present, reports the same version as the source checkout
