### PR TITLE
fix(config): keep section comments anchored when appending YAML entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Versions follow `YYYY.MM.MICRO`. Year and month identify the release window;
 the micro segment increments for hotfixes and same-month follow-up releases.
 Compatibility is documented in release notes, not encoded in the version string.
 
+## [Unreleased]
+
+### Fixed
+
+- Built projects' `config.yml` no longer misplaces section comments: entries
+  added at build time (service blocks, `deployed_services` names, web panels,
+  config overrides) rendered *after* the next section's comment banner —
+  splitting the `deployed_services` list around the `SAFETY CONTROLS` header.
+  Appended entries now render inside their own section, with the banner kept
+  at the section boundary.
+
 ## [2026.8.0]
 
 ### Removed

--- a/src/osprey/cli/build_injectors.py
+++ b/src/osprey/cli/build_injectors.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from osprey.errors import BuildProfileError
+from osprey.utils.config_writer import anchored_append, anchored_put
 from osprey.utils.logger import get_logger
 
 if TYPE_CHECKING:
@@ -245,12 +246,12 @@ def _inject_profile_services(
             config["services"] = {}
         svc_config = {"path": f"./services/{name}"}
         svc_config.update(svc_def.config)
-        config["services"][name] = svc_config
+        anchored_put(config["services"], name, svc_config)
 
         # Add to deployed_services
         deployed = config.get("deployed_services", [])
         if name not in [str(s) for s in deployed]:
-            deployed.append(name)
+            anchored_append(deployed, name)
             config["deployed_services"] = deployed
 
         count += 1
@@ -344,28 +345,36 @@ def _inject_dispatch(dispatch: DispatchConfig, profile_dir: Path, project_path: 
     # Override with OSPREY_DISPATCH_IMAGE/OSPREY_WORKER_IMAGE, or set
     # ``services.<name>.image`` here, to use a prebuilt/published image.
     config.setdefault("services", {})
-    config["services"]["event_dispatcher"] = {
-        "path": "./services/event_dispatcher",
-        "port": dispatch.dispatcher_port,
-        "facility_name": dispatch.facility_name,
-        "pv_strip_prefix": dispatch.pv_strip_prefix,
-        # Copy the project's triggers.yml into the service build context so the
-        # compose ``./triggers.yml`` bind-mount resolves to a file (otherwise the
-        # container runtime auto-creates an empty directory at the mount source).
-        "additional_dirs": [{"src": "triggers.yml", "dst": "triggers.yml"}],
-    }
-    config["services"]["dispatch_worker"] = {
-        "path": "./services/dispatch_worker",
-        "worker_count": dispatch.worker_count,
-        "worker_port_base": dispatch.worker_port_base,
-        "workspace_mode": dispatch.workspace_mode,
-        "timeout_sec": dispatch.timeout_sec,
-        "inactivity_sec": dispatch.inactivity_sec,
-    }
+    anchored_put(
+        config["services"],
+        "event_dispatcher",
+        {
+            "path": "./services/event_dispatcher",
+            "port": dispatch.dispatcher_port,
+            "facility_name": dispatch.facility_name,
+            "pv_strip_prefix": dispatch.pv_strip_prefix,
+            # Copy the project's triggers.yml into the service build context so the
+            # compose ``./triggers.yml`` bind-mount resolves to a file (otherwise the
+            # container runtime auto-creates an empty directory at the mount source).
+            "additional_dirs": [{"src": "triggers.yml", "dst": "triggers.yml"}],
+        },
+    )
+    anchored_put(
+        config["services"],
+        "dispatch_worker",
+        {
+            "path": "./services/dispatch_worker",
+            "worker_count": dispatch.worker_count,
+            "worker_port_base": dispatch.worker_port_base,
+            "workspace_mode": dispatch.workspace_mode,
+            "timeout_sec": dispatch.timeout_sec,
+            "inactivity_sec": dispatch.inactivity_sec,
+        },
+    )
     deployed = config.get("deployed_services", []) or []
     for name in ("event_dispatcher", "dispatch_worker"):
         if name not in [str(s) for s in deployed]:
-            deployed.append(name)
+            anchored_append(deployed, name)
     config["deployed_services"] = deployed
 
     # Derive web.panels.events.url from dispatcher_port so the port is a single
@@ -380,10 +389,21 @@ def _inject_dispatch(dispatch: DispatchConfig, profile_dir: Path, project_path: 
     # facility that pinned its own ``web.panels.events.path``.
     existing_events_url = config.get("web", {}).get("panels", {}).get("events", {}).get("url", "")
     if not existing_events_url:
-        config.setdefault("web", {}).setdefault("panels", {}).setdefault("events", {})
-        events_panel = config["web"]["panels"]["events"]
-        events_panel["url"] = f"http://localhost:{dispatch.dispatcher_port}"
-        events_panel.setdefault("path", "/dashboard")
+        panels = config.setdefault("web", {}).setdefault("panels", {})
+        events_panel = panels.get("events")
+        if events_panel is None:
+            # Put the complete panel in one shot: anchored_put re-anchors a
+            # section comment beneath the new entry, which needs the entry's
+            # full subtree to exist at insertion time.
+            anchored_put(
+                panels,
+                "events",
+                {"url": f"http://localhost:{dispatch.dispatcher_port}", "path": "/dashboard"},
+            )
+        else:
+            anchored_put(events_panel, "url", f"http://localhost:{dispatch.dispatcher_port}")
+            if "path" not in events_panel:
+                anchored_put(events_panel, "path", "/dashboard")
 
     with open(config_path, "w") as fh:
         yaml.dump(config, fh)
@@ -462,7 +482,7 @@ def _inject_bluesky(bluesky: BlueskyConfig, project_path: Path) -> None:
     # first ``osprey deploy up``. Override with OSPREY_BLUESKY_BRIDGE_IMAGE, or
     # set ``services.bluesky.image`` here, to use a prebuilt/published image.
     config.setdefault("services", {})
-    config["services"]["bluesky"] = {
+    svc_config: dict[str, Any] = {
         "path": "./services/bluesky",
         "port": bluesky.port,
         "tiled_enabled": bluesky.tiled_enabled,
@@ -475,17 +495,18 @@ def _inject_bluesky(bluesky: BlueskyConfig, project_path: Path) -> None:
         # as before: the compose template's {% if %} guard reads this same
         # key, so an unset plan_dir means no mount and no BLUESKY_PLAN_DIRS
         # env var at all (Task 1.4).
-        config["services"]["bluesky"]["plan_dir"] = bluesky.plan_dir
+        svc_config["plan_dir"] = bluesky.plan_dir
     if bluesky.excluded_plans:
         # Only written when non-empty — its absence keeps a deploy with no
         # exclusions rendering exactly as before: the compose template's
         # {% if %} guard reads this same key, so an empty list means no
         # BLUESKY_EXCLUDED_PLANS env var at all. The os.pathsep join is done
         # Python-side because the Jinja render context has no `os` module.
-        config["services"]["bluesky"]["excluded_plans"] = os.pathsep.join(bluesky.excluded_plans)
+        svc_config["excluded_plans"] = os.pathsep.join(bluesky.excluded_plans)
+    anchored_put(config["services"], "bluesky", svc_config)
     deployed = config.get("deployed_services", []) or []
     if "bluesky" not in [str(s) for s in deployed]:
-        deployed.append("bluesky")
+        anchored_append(deployed, "bluesky")
     config["deployed_services"] = deployed
 
     with open(config_path, "w") as fh:
@@ -567,13 +588,17 @@ def _inject_va(va: VAConfig, project_path: Path) -> None:
     # ``osprey deploy up``. Override with OSPREY_VA_IMAGE, or set
     # ``services.virtual_accelerator.image`` here, to use a prebuilt/published image.
     config.setdefault("services", {})
-    config["services"]["virtual_accelerator"] = {
-        "path": "./services/virtual_accelerator",
-        "port": va.port,
-    }
+    anchored_put(
+        config["services"],
+        "virtual_accelerator",
+        {
+            "path": "./services/virtual_accelerator",
+            "port": va.port,
+        },
+    )
     deployed = config.get("deployed_services", []) or []
     if "virtual_accelerator" not in [str(s) for s in deployed]:
-        deployed.append("virtual_accelerator")
+        anchored_append(deployed, "virtual_accelerator")
     config["deployed_services"] = deployed
 
     with open(config_path, "w") as fh:
@@ -648,13 +673,17 @@ def _inject_bluesky_panels(bluesky_panels: BlueskyPanelsConfig, project_path: Pa
     # first ``osprey deploy up``. Override with OSPREY_BLUESKY_PANELS_IMAGE, or
     # set ``services.bluesky_panels.image`` here, to use a prebuilt/published image.
     config.setdefault("services", {})
-    config["services"]["bluesky_panels"] = {
-        "path": "./services/bluesky_panels",
-        "port": bluesky_panels.port,
-    }
+    anchored_put(
+        config["services"],
+        "bluesky_panels",
+        {
+            "path": "./services/bluesky_panels",
+            "port": bluesky_panels.port,
+        },
+    )
     deployed = config.get("deployed_services", []) or []
     if "bluesky_panels" not in [str(s) for s in deployed]:
-        deployed.append("bluesky_panels")
+        anchored_append(deployed, "bluesky_panels")
     config["deployed_services"] = deployed
 
     # 3. Register the two web.panels.<id> entries. Derive each url from
@@ -674,11 +703,20 @@ def _inject_bluesky_panels(bluesky_panels: BlueskyPanelsConfig, project_path: Pa
         ("results", "/results/", "RESULTS"),
     )
     for panel_id, panel_path, label in panel_specs:
-        panel_cfg = config.setdefault("web", {}).setdefault("panels", {}).setdefault(panel_id, {})
+        panels = config.setdefault("web", {}).setdefault("panels", {})
+        panel_cfg = panels.get(panel_id)
+        if panel_cfg is None:
+            # Put the complete panel in one shot: anchored_put re-anchors a
+            # section comment beneath the new entry, which needs the entry's
+            # full subtree to exist at insertion time.
+            anchored_put(panels, panel_id, {"url": default_url, "path": panel_path, "label": label})
+            continue
         if not panel_cfg.get("url"):
-            panel_cfg["url"] = default_url
-        panel_cfg.setdefault("path", panel_path)
-        panel_cfg.setdefault("label", label)
+            anchored_put(panel_cfg, "url", default_url)
+        if "path" not in panel_cfg:
+            anchored_put(panel_cfg, "path", panel_path)
+        if "label" not in panel_cfg:
+            anchored_put(panel_cfg, "label", label)
 
     with open(config_path, "w") as fh:
         yaml.dump(config, fh)
@@ -759,13 +797,17 @@ def _inject_nextcloud_bridge(
     # OSPREY_NEXTCLOUD_BRIDGE_IMAGE, or set ``services.nextcloud_bridge.image``
     # here, to use a prebuilt/published image.
     config.setdefault("services", {})
-    config["services"]["nextcloud_bridge"] = {
-        "path": "./services/nextcloud_bridge",
-        "trigger": nextcloud_bridge.trigger,
-    }
+    anchored_put(
+        config["services"],
+        "nextcloud_bridge",
+        {
+            "path": "./services/nextcloud_bridge",
+            "trigger": nextcloud_bridge.trigger,
+        },
+    )
     deployed = config.get("deployed_services", []) or []
     if "nextcloud_bridge" not in [str(s) for s in deployed]:
-        deployed.append("nextcloud_bridge")
+        anchored_append(deployed, "nextcloud_bridge")
     config["deployed_services"] = deployed
 
     with open(config_path, "w") as fh:

--- a/src/osprey/cli/build_persistence.py
+++ b/src/osprey/cli/build_persistence.py
@@ -172,25 +172,18 @@ def _persist_mcp_servers(project_path: Path, mcp_servers: dict[str, Any]) -> Non
     ``.mcp.json`` and ``settings.json``.  Placeholders like ``{project_root}``
     are preserved as-is — resolution happens during regen.
     """
-    from osprey.utils.config_writer import _load, _save
+    from osprey.utils.config_writer import _load, _save, anchored_put
 
     from .build_profile import McpServerDef
 
     config_path = project_path / "config.yml"
     data = _load(config_path)
 
-    # Ensure claude_code.servers section exists
-    if "claude_code" not in data:
-        from ruamel.yaml import CommentedMap
-
-        data["claude_code"] = CommentedMap()
-    cc = data["claude_code"]
-    if "servers" not in cc:
-        from ruamel.yaml import CommentedMap
-
-        cc["servers"] = CommentedMap()
-    servers_section = cc["servers"]
-
+    # Collect the server specs first, then register them via anchored_put:
+    # writing an empty ``servers:`` map and filling it afterwards would leave
+    # any section comment trailing ``claude_code:`` anchored above the new
+    # entries (rendering them under the next section's banner).
+    specs: dict[str, dict[str, Any]] = {}
     for name, server in mcp_servers.items():
         if not isinstance(server, McpServerDef):
             continue
@@ -230,7 +223,19 @@ def _persist_mcp_servers(project_path: Path, mcp_servers: dict[str, Any]) -> Non
         if server.permissions:
             spec["permissions"] = dict(server.permissions)
 
-        servers_section[name] = spec
+        specs[name] = spec
+
+    if specs:
+        if "claude_code" not in data:
+            from ruamel.yaml import CommentedMap
+
+            data["claude_code"] = CommentedMap()
+        cc = data["claude_code"]
+        if "servers" in cc:
+            for name, spec in specs.items():
+                anchored_put(cc["servers"], name, spec)
+        else:
+            anchored_put(cc, "servers", specs)
 
     _save(config_path, data)
 
@@ -244,25 +249,30 @@ def _persist_artifact_server(project_path: Path, overrides: dict[str, Any]) -> N
     """
     from ruamel.yaml import CommentedMap
 
-    from osprey.utils.config_writer import _load, _save
+    from osprey.utils.config_writer import _load, _save, anchored_put
 
     config_path = project_path / "config.yml"
     data = _load(config_path)
 
     if "artifact_server" not in data:
+        # Root-level append: new top-level sections land at the file tail
+        # by design (the template documents appended sections there).
         data["artifact_server"] = CommentedMap()
     block = data["artifact_server"]
 
     for key, value in overrides.items():
         if key != "categories":
-            block[key] = value
-    for key, spec in overrides.get("categories", {}).items():
-        if "categories" not in block:
-            block["categories"] = CommentedMap()
-        entry = CommentedMap()
-        entry["label"] = spec["label"]
-        entry["color"] = spec["color"]
-        block["categories"][key] = entry
+            anchored_put(block, key, value)
+    categories = {
+        key: {"label": spec["label"], "color": spec["color"]}
+        for key, spec in overrides.get("categories", {}).items()
+    }
+    if categories:
+        if "categories" in block:
+            for key, entry in categories.items():
+                anchored_put(block["categories"], key, entry)
+        else:
+            anchored_put(block, "categories", categories)
 
     _save(config_path, data)
 

--- a/src/osprey/utils/config_writer.py
+++ b/src/osprey/utils/config_writer.py
@@ -28,7 +28,9 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from ruamel.yaml import YAML, CommentedMap
+from ruamel.yaml import YAML, CommentedMap, CommentedSeq
+from ruamel.yaml.error import CommentMark
+from ruamel.yaml.tokens import CommentToken
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +38,143 @@ logger = logging.getLogger(__name__)
 _yaml = YAML(typ="rt")
 _yaml.preserve_quotes = True
 _yaml.width = 4096  # prevent aggressive line-wrapping
+
+
+# =============================================================================
+# Section-Comment Anchoring
+# =============================================================================
+# ruamel attaches a comment block that sits between two YAML sections to the
+# deepest last node of the PRECEDING section — not to the key that follows it.
+# A plain append to that section's list/mapping therefore renders the new
+# entry *after* the comment block: a list split in two around a section
+# banner, or a new service block emitted below the next section's header.
+# The helpers below detach such a trailing block before appending and
+# re-attach it to the new last entry, so section banners stay at section
+# boundaries. Inline comments (same line as a value) are never moved.
+
+
+def _deepest_trailing_slot(container: Any) -> tuple[Any, Any, int] | None:
+    """Locate the comment slot trailing *container*'s last entry.
+
+    Descends through nested non-empty containers, because that is where ruamel
+    parks a section-trailing comment block. Returns ``(owner, key_or_index,
+    slot_index)`` addressing ``owner.ca.items[key_or_index][slot_index]``, or
+    None for empty/non-commented containers.
+    """
+    while True:
+        if isinstance(container, CommentedMap) and len(container):
+            last: Any = next(reversed(container))
+            slot = 2  # eol/post-value comment slot for mappings
+        elif isinstance(container, CommentedSeq) and len(container):
+            last = len(container) - 1
+            slot = 0  # post-item comment slot for sequences
+        else:
+            return None
+        value = container[last]
+        if isinstance(value, (CommentedMap, CommentedSeq)) and len(value):
+            container = value
+            continue
+        return container, last, slot
+
+
+def _steal_section_comment(container: Any) -> str | None:
+    """Detach and return the comment block trailing *container*'s last entry.
+
+    An inline comment on the entry's own line stays put; only the block that
+    follows on subsequent lines is removed and returned (with its leading
+    newline, ready for re-attachment). Returns None when there is nothing to
+    move.
+    """
+    found = _deepest_trailing_slot(container)
+    if found is None:
+        return None
+    owner, last, slot = found
+    entry = owner.ca.items.get(last)
+    token = entry[slot] if entry else None
+    if token is None:
+        return None
+    text = token.value
+    newline = text.find("\n")
+    if newline == -1 or not text[newline + 1 :].strip():
+        return None  # inline-only comment — nothing trails onto later lines
+    first_line, rest = text[: newline + 1], text[newline + 1 :]
+    if first_line.strip():
+        # Keep the inline part; the extra "\n" restores the line terminator
+        # the inline comment's token no longer provides at the new location.
+        token.value = first_line
+        return "\n" + rest
+    entry[slot] = None
+    if not any(entry):
+        del owner.ca.items[last]
+    return text
+
+
+def _attach_section_comment(container: Any, text: str) -> None:
+    """Attach *text* as the comment block trailing *container*'s last entry."""
+    found = _deepest_trailing_slot(container)
+    if found is None:
+        return
+    owner, last, slot = found
+    if not text.startswith("\n"):
+        text = "\n" + text
+    entry = owner.ca.items.setdefault(last, [None, None, None, None])
+    if entry[slot] is not None:
+        entry[slot].value += text
+    else:
+        entry[slot] = CommentToken(text, CommentMark(0), None)
+
+
+def _to_commented(obj: Any) -> Any:
+    """Deep-convert plain dicts/lists so comment slots exist along the spine."""
+    if isinstance(obj, dict) and not isinstance(obj, CommentedMap):
+        return CommentedMap((k, _to_commented(v)) for k, v in obj.items())
+    if isinstance(obj, list) and not isinstance(obj, CommentedSeq):
+        return CommentedSeq(_to_commented(item) for item in obj)
+    return obj
+
+
+def anchored_append(seq: Any, value: Any) -> None:
+    """Append *value* to *seq*, keeping a trailing section comment at the end.
+
+    Drop-in replacement for ``seq.append(value)`` on a round-trip-loaded
+    sequence whose tail may carry the comment block introducing the next
+    section. Plain lists are appended to unchanged.
+    """
+    if not isinstance(seq, CommentedSeq) or not len(seq):
+        seq.append(value)
+        return
+    moved = _steal_section_comment(seq)
+    seq.append(_to_commented(value))
+    if moved:
+        _attach_section_comment(seq, moved)
+
+
+def anchored_put(mapping: Any, key: Any, value: Any) -> None:
+    """Set ``mapping[key] = value``, keeping a trailing section comment at the end.
+
+    Drop-in replacement for item assignment on a round-trip-loaded mapping:
+    when *key* is new (ruamel appends it after the last entry — and after any
+    comment block trailing that entry), the block is re-anchored below the new
+    entry. Existing keys are updated in place with no layout change — except
+    the last key, whose replacement value would silently discard a comment
+    block parked inside the old value; that block is carried over. *value*
+    must be complete — an empty dict/list cannot carry the re-anchored
+    comment beneath it, so such values are assigned without relocation.
+    """
+    if not isinstance(mapping, CommentedMap) or not len(mapping):
+        mapping[key] = value
+        return
+    if key in mapping and next(reversed(mapping)) != key:
+        mapping[key] = value
+        return
+    value = _to_commented(value)
+    if isinstance(value, (CommentedMap, CommentedSeq)) and not len(value):
+        mapping[key] = value
+        return
+    moved = _steal_section_comment(mapping)
+    mapping[key] = value
+    if moved:
+        _attach_section_comment(mapping, moved)
 
 
 # =============================================================================
@@ -112,7 +251,7 @@ def config_add_to_list(
     if value in lst:
         return False
 
-    lst.append(value)
+    anchored_append(lst, value)
     _save(config_path, data)
     logger.debug("config_add_to_list: %s += %s in %s", ".".join(key_path), value, config_path)
     return True
@@ -225,16 +364,62 @@ def config_update_fields(
     data = _load(config_path)
 
     for dotted_key, value in updates.items():
-        parts = dotted_key.split(".")
-        node = data
-        for part in parts[:-1]:
-            if part not in node:
-                node[part] = {}
-            node = node[part]
-        node[parts[-1]] = value
+        _set_dotted_anchored(data, data, dotted_key, value, create_only=True)
 
     _save(config_path, data)
     logger.info("config_update_fields: updated %d field(s) in %s", len(updates), config_path)
+
+
+def _set_dotted_anchored(
+    root: Any, data: Any, dotted_key: str, value: Any, *, create_only: bool
+) -> None:
+    """Set a dotted key, re-anchoring a section comment displaced by new keys.
+
+    Walks ``dotted_key`` from *data*, creating missing intermediate maps. The
+    first key created inside an existing non-root mapping is where a trailing
+    section comment would be displaced — it is detached there, and re-attached
+    once the full subtree exists. New keys at the *root* mapping keep their
+    tail-append placement: the shipped templates document appended top-level
+    sections at the file tail, below banners written for exactly that purpose.
+
+    Args:
+        root: The document's top-level mapping (anchor exemption).
+        data: Mapping to walk from (the root itself, or a nested map).
+        dotted_key: ``"dot.separated.key"`` path.
+        value: Value to assign at the leaf.
+        create_only: If True, walk into whatever an existing intermediate key
+            holds (:func:`config_update_fields` semantics); if False, replace
+            non-mapping intermediates with empty maps
+            (:func:`_set_nested_value` semantics).
+    """
+    parts = dotted_key.split(".")
+    node = data
+    moved: str | None = None
+    anchor: Any = None
+
+    def _steal_here(current: Any) -> str | None:
+        if current is root or not isinstance(current, CommentedMap) or not len(current):
+            return None
+        return _steal_section_comment(current)
+
+    for part in parts[:-1]:
+        if part not in node:
+            if moved is None:
+                moved = _steal_here(node)
+                anchor = node if moved else None
+            node[part] = CommentedMap()
+        elif not create_only and not isinstance(node[part], dict):
+            node[part] = CommentedMap()
+        node = node[part]
+
+    leaf = parts[-1]
+    if leaf not in node and moved is None:
+        moved = _steal_here(node)
+        anchor = node if moved else None
+    node[leaf] = _to_commented(value)
+
+    if moved:
+        _attach_section_comment(anchor, moved)
 
 
 def config_read(config_path: Path) -> dict:
@@ -321,39 +506,39 @@ def update_yaml_file(
     return backup_path
 
 
-def _apply_nested_updates(data: dict, updates: dict) -> None:
+def _apply_nested_updates(data: dict, updates: dict, root: Any = None) -> None:
     """Apply nested updates to a dictionary, supporting dot notation keys.
 
     Args:
         data: Target dictionary to update (modified in place)
         updates: Updates to apply
+        root: The document's top-level mapping, threaded through recursion for
+            section-comment anchoring (defaults to *data*).
     """
+    if root is None:
+        root = data
     for key, value in updates.items():
         if "." in key:
-            _set_nested_value(data, key, value)
+            _set_nested_value(data, key, value, root=root)
         elif isinstance(value, dict) and key in data and isinstance(data[key], dict):
-            _apply_nested_updates(data[key], value)
-        else:
+            _apply_nested_updates(data[key], value, root=root)
+        elif data is root:
             data[key] = value
+        else:
+            anchored_put(data, key, value)
 
 
-def _set_nested_value(data: dict, path: str, value: Any) -> None:
+def _set_nested_value(data: dict, path: str, value: Any, root: Any = None) -> None:
     """Set a value at a nested path using dot notation.
 
     Args:
         data: Target dictionary
         path: Dot-separated path (e.g., "control_system.connector.epics.port")
         value: Value to set
+        root: The document's top-level mapping, for section-comment anchoring
+            (defaults to *data*).
     """
-    keys = path.split(".")
-    current = data
-
-    for key in keys[:-1]:
-        if key not in current or not isinstance(current[key], dict):
-            current[key] = {}
-        current = current[key]
-
-    current[keys[-1]] = value
+    _set_dotted_anchored(root if root is not None else data, data, path, value, create_only=False)
 
 
 # =============================================================================

--- a/tests/cli/test_build_injectors_comment_anchoring.py
+++ b/tests/cli/test_build_injectors_comment_anchoring.py
@@ -1,0 +1,66 @@
+"""Service injectors must not displace config.yml section comments.
+
+Regression tests for the rendered-config corruption where injector appends to
+``services:`` / ``deployed_services`` landed *after* the comment block that
+separates the SERVICE CONFIGURATION section from SAFETY CONTROLS — splitting
+the ``deployed_services`` list in two around the banner.
+"""
+
+from __future__ import annotations
+
+import yaml as pyyaml
+
+from osprey.cli.build_injectors import _inject_va
+from osprey.cli.build_profile_schema import VAConfig
+
+CONFIG_TEMPLATE = """\
+services:
+  postgresql:
+    path: ./services/postgresql
+  openobserve:
+    path: ./services/openobserve
+    port: 5080          # Host port
+
+# Services to deploy with `osprey deploy up`
+deployed_services:
+  - postgresql
+  - openobserve
+
+# ============================================================
+# SAFETY CONTROLS
+# ============================================================
+
+# Approval workflow for sensitive operations
+approval:
+  enabled: true
+"""
+
+
+def _line_no(text: str, needle: str) -> int:
+    for i, line in enumerate(text.splitlines()):
+        if needle in line:
+            return i
+    raise AssertionError(f"{needle!r} not found in:\n{text}")
+
+
+def test_inject_va_keeps_section_banner_after_deployed_services(tmp_path):
+    (tmp_path / "config.yml").write_text(CONFIG_TEMPLATE, encoding="utf-8")
+
+    _inject_va(VAConfig(port=5064), tmp_path)
+
+    text = (tmp_path / "config.yml").read_text(encoding="utf-8")
+
+    # The appended list item renders inside the list, before the banner.
+    assert _line_no(text, "- virtual_accelerator") < _line_no(text, "# SAFETY CONTROLS")
+    # The new service block renders inside services:, before the list comment.
+    assert _line_no(text, "  virtual_accelerator:") < _line_no(text, "# Services to deploy")
+    # The banner still directly precedes the approval section.
+    assert _line_no(text, "# SAFETY CONTROLS") < _line_no(text, "approval:")
+    assert _line_no(text, "# Approval workflow") < _line_no(text, "approval:")
+
+    config = pyyaml.safe_load(text)
+    assert config["deployed_services"] == ["postgresql", "openobserve", "virtual_accelerator"]
+    assert config["services"]["virtual_accelerator"] == {
+        "path": "./services/virtual_accelerator",
+        "port": 5064,
+    }

--- a/tests/utils/test_config_writer_comment_anchoring.py
+++ b/tests/utils/test_config_writer_comment_anchoring.py
@@ -1,0 +1,245 @@
+"""Section comments must stay anchored when config mutations append entries.
+
+ruamel.yaml attaches a comment block that sits between two sections to the
+deepest last node of the PRECEDING section. A plain append to that section's
+list or mapping therefore lands *after* the comment — splitting a list in two
+around a section banner, or emitting new service blocks below the header of
+the next section. These tests pin the corrected behavior: appended entries
+render inside their section and the trailing comment block stays at the
+section boundary.
+"""
+
+from __future__ import annotations
+
+from ruamel.yaml import YAML
+
+from osprey.utils.config_writer import (
+    anchored_append,
+    anchored_put,
+    config_add_to_list,
+    config_update_fields,
+    update_yaml_file,
+)
+
+SAMPLE = """\
+claude_code:
+  default_model: haiku
+  timeout: 300
+
+# ============================================================
+# WEB PANEL CONFIGURATION
+# ============================================================
+# Prose about panels.
+
+web:
+  panels:
+    ariel:
+      enabled: true
+    # trailing panel docs
+
+services:
+  postgresql:
+    path: ./services/postgresql
+  openobserve:
+    path: ./services/openobserve
+    port: 5080          # Host port
+
+# Services to deploy with `osprey deploy up`
+deployed_services:
+- postgresql
+- openobserve
+
+# ============================================================
+# SAFETY CONTROLS
+# ============================================================
+approval:
+  enabled: true
+"""
+# NOTE: list items sit at column 0 (ruamel's dump style) so that full-text
+# comparisons are stable across round-trips — re-indentation is round-trip
+# behavior, not something these helpers control.
+
+
+def _write_sample(tmp_path):
+    path = tmp_path / "config.yml"
+    path.write_text(SAMPLE, encoding="utf-8")
+    return path
+
+
+def _line_no(text: str, needle: str) -> int:
+    for i, line in enumerate(text.splitlines()):
+        if needle in line:
+            return i
+    raise AssertionError(f"{needle!r} not found in:\n{text}")
+
+
+def _load(path):
+    yaml = YAML(typ="safe")
+    with open(path, encoding="utf-8") as fh:
+        return yaml.load(fh)
+
+
+# ---------------------------------------------------------------------------
+# Node-level helpers
+# ---------------------------------------------------------------------------
+
+
+class TestAnchoredAppend:
+    def test_appended_items_render_before_section_banner(self, tmp_path):
+        path = _write_sample(tmp_path)
+        yaml = YAML()
+        config = yaml.load(path.read_text(encoding="utf-8"))
+
+        anchored_append(config["deployed_services"], "virtual_accelerator")
+        anchored_append(config["deployed_services"], "bluesky")
+
+        with open(path, "w", encoding="utf-8") as fh:
+            yaml.dump(config, fh)
+        text = path.read_text(encoding="utf-8")
+
+        assert _line_no(text, "- bluesky") < _line_no(text, "# SAFETY CONTROLS")
+        assert _line_no(text, "- virtual_accelerator") < _line_no(text, "- bluesky")
+        assert _load(path)["deployed_services"] == [
+            "postgresql",
+            "openobserve",
+            "virtual_accelerator",
+            "bluesky",
+        ]
+
+    def test_plain_list_still_appends(self, tmp_path):
+        lst = ["a"]
+        anchored_append(lst, "b")
+        assert lst == ["a", "b"]
+
+
+class TestAnchoredPut:
+    def test_new_service_block_renders_inside_section(self, tmp_path):
+        path = _write_sample(tmp_path)
+        yaml = YAML()
+        config = yaml.load(path.read_text(encoding="utf-8"))
+
+        anchored_put(
+            config["services"],
+            "virtual_accelerator",
+            {"path": "./services/virtual_accelerator", "port": 5064},
+        )
+
+        with open(path, "w", encoding="utf-8") as fh:
+            yaml.dump(config, fh)
+        text = path.read_text(encoding="utf-8")
+
+        # New block sits under services:, before the deployed_services comment.
+        assert _line_no(text, "virtual_accelerator:") < _line_no(text, "# Services to deploy")
+        # The inline comment on the previous last entry survives in place.
+        assert "port: 5080          # Host port" in text
+        assert _load(path)["services"]["virtual_accelerator"] == {
+            "path": "./services/virtual_accelerator",
+            "port": 5064,
+        }
+
+    def test_split_keeps_blank_line_before_moved_comment(self, tmp_path):
+        path = _write_sample(tmp_path)
+        yaml = YAML()
+        config = yaml.load(path.read_text(encoding="utf-8"))
+
+        anchored_put(config["services"], "va", {"port": 5064})
+
+        with open(path, "w", encoding="utf-8") as fh:
+            yaml.dump(config, fh)
+        lines = path.read_text(encoding="utf-8").splitlines()
+
+        comment_line = _line_no("\n".join(lines), "# Services to deploy")
+        assert lines[comment_line - 1].strip() == ""
+
+    def test_existing_key_update_leaves_layout_untouched(self, tmp_path):
+        path = _write_sample(tmp_path)
+        yaml = YAML()
+        config = yaml.load(path.read_text(encoding="utf-8"))
+
+        anchored_put(config["services"], "postgresql", {"path": "./services/postgresql"})
+
+        with open(path, "w", encoding="utf-8") as fh:
+            yaml.dump(config, fh)
+        text = path.read_text(encoding="utf-8")
+
+        assert _line_no(text, "# Services to deploy") < _line_no(text, "deployed_services:")
+        assert "virtual_accelerator" not in text
+
+    def test_nested_panel_addition_stays_inside_panels(self, tmp_path):
+        path = _write_sample(tmp_path)
+        yaml = YAML()
+        config = yaml.load(path.read_text(encoding="utf-8"))
+
+        anchored_put(
+            config["web"]["panels"],
+            "events",
+            {"url": "http://localhost:8020", "path": "/dashboard"},
+        )
+
+        with open(path, "w", encoding="utf-8") as fh:
+            yaml.dump(config, fh)
+        text = path.read_text(encoding="utf-8")
+
+        assert _line_no(text, "events:") < _line_no(text, "# trailing panel docs")
+        assert _line_no(text, "# trailing panel docs") < _line_no(text, "services:")
+
+
+# ---------------------------------------------------------------------------
+# File-level mutators
+# ---------------------------------------------------------------------------
+
+
+class TestConfigUpdateFields:
+    def test_new_nested_key_renders_before_next_banner(self, tmp_path):
+        path = _write_sample(tmp_path)
+
+        config_update_fields(path, {"claude_code.servers.bluesky.enabled": True})
+
+        text = path.read_text(encoding="utf-8")
+        assert _line_no(text, "servers:") < _line_no(text, "# WEB PANEL CONFIGURATION")
+        assert _load(path)["claude_code"]["servers"]["bluesky"]["enabled"] is True
+
+    def test_new_root_key_still_appends_at_tail(self, tmp_path):
+        # Top-level appends are intentional tail appends (the template
+        # documents appended sections at the file tail, below their banner).
+        path = _write_sample(tmp_path)
+
+        config_update_fields(path, {"facility.prefix": "ca"})
+
+        text = path.read_text(encoding="utf-8")
+        assert _line_no(text, "# SAFETY CONTROLS") < _line_no(text, "facility:")
+        assert text.rstrip().endswith("prefix: ca")
+
+    def test_existing_scalar_update_is_layout_neutral(self, tmp_path):
+        path = _write_sample(tmp_path)
+        before = path.read_text(encoding="utf-8")
+
+        config_update_fields(path, {"claude_code.default_model": "sonnet"})
+
+        after = path.read_text(encoding="utf-8")
+        assert after.replace("sonnet", "haiku") == before
+
+
+class TestUpdateYamlFile:
+    def test_nested_dict_form_new_key_stays_in_section(self, tmp_path):
+        path = _write_sample(tmp_path)
+
+        update_yaml_file(
+            path,
+            {"claude_code": {"servers": {"health": {"enabled": True}}}},
+            create_backup=False,
+        )
+
+        text = path.read_text(encoding="utf-8")
+        assert _line_no(text, "servers:") < _line_no(text, "# WEB PANEL CONFIGURATION")
+        assert _load(path)["claude_code"]["servers"]["health"]["enabled"] is True
+
+
+class TestConfigAddToList:
+    def test_appended_item_renders_before_section_banner(self, tmp_path):
+        path = _write_sample(tmp_path)
+
+        config_add_to_list(path, ["deployed_services"], "virtual_accelerator")
+
+        text = path.read_text(encoding="utf-8")
+        assert _line_no(text, "- virtual_accelerator") < _line_no(text, "# SAFETY CONTROLS")


### PR DESCRIPTION
Post-render config.yml mutations — service injectors, dotted config overrides, MCP-server and artifact-server persistence — appended entries **after** the comment block that trails a section. ruamel.yaml parks such a block on the deepest last node of the preceding section, so every append landed below the next section's banner: the `deployed_services` list rendered split in two around the `SAFETY CONTROLS` header, injected service blocks fell under the "Services to deploy" comment, and `claude_code.servers` / `web.panels` entries surfaced under unrelated banners.

New `anchored_append()` / `anchored_put()` primitives in `config_writer` detach the trailing comment block before the append and re-anchor it beneath the new last entry (inline comments stay put; blank-line spacing is preserved). All injectors and the config-override/persistence writers route through them. Root-level section appends keep their documented tail placement below their pre-written banners.

Parsed config data is unchanged — the fix is layout-only, pinned by helper-level tests plus an injector integration regression test.