### PR TITLE
feat(web): unified tile headers, open-beside, per-tile close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,13 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Added
 
+- Web terminal workspace: every panel tile now has the same header bar — six-dot
+  drag grip, panel name, and a close button that closes just that tile (the
+  panel stays on the rail; one click reopens it). Panels can be opened side by
+  side as first-class gestures: drag a rail icon into the workspace to split
+  exactly where you drop it, or use the ⊞ "open in a new tile" corner on a rail
+  entry's hover. Opening an already-open panel beside moves its tile instead of
+  duplicating it.
 - Each user in a multi-user deployment can have their own default theme: set
   `theme:` on a roster entry in `modules.web_terminals.users` (a family such as
   `desy`, or a concrete id such as `desy-light` to also pin light/dark). It

--- a/src/osprey/interfaces/web_terminal/static/css/dockview-overrides.css
+++ b/src/osprey/interfaces/web_terminal/static/css/dockview-overrides.css
@@ -142,19 +142,15 @@
 /* ---- Tile header bar: the single tab IS the host chrome ----
  * One panel per tile is a workspace invariant (both modes), so a tile's "tab"
  * can never have siblings; dock-tab.js renders it as the tile's header bar.
- * The two tile kinds get very different amounts of it:
+ * EVERY tile carries the same 36px bar with the same grammar — six-dot drag
+ * grip on the left, the tile's identity beside it, close on the right — so
+ * grabbing, naming and closing a tile is one gesture learned once:
  *
- *   SERVICE tiles get an 8px grip strip and nothing more. The panel's name is
- *     already on its rail entry and its lifecycle controls (close, popout)
- *     live on that entry's hover corners, so a 36px bar per tile was chrome
- *     charged against every panel for affordances reached rarely. What is left
- *     is the one thing that must be ON the tile: something to grab it by.
- *   The TERMINAL tile keeps a real 36px bar, because its content earns the
- *     height — session LED, session id, selector and "+ New" are frequent,
- *     stateful controls, and its close is the terminal's only pointer close
- *     path (its rail entry deliberately has no "×").
+ *   SERVICE tiles show grip + the panel's name (.tile-tab-title) + close.
+ *   The TERMINAL tile shows grip + the adopted .terminal-header (session LED,
+ *     session id, selector, "+ New") + close.
  *
- * Fixed heights, no hover reveal: a strip never changes size, so tile content
+ * Fixed height, no hover reveal: the bar never changes size, so tile content
  * never reflows on pointer movement.
  *
  * Height is set on the container DIRECTLY rather than through dockview's
@@ -164,17 +160,8 @@
  * ties with the stock `.dockview-theme-*` blocks and loses the order
  * tiebreak — the same trap the selector note at the top of this file
  * describes. Compounding onto the container is (0,2,0) and wins on
- * specificity, deterministically, in either theme.
- *
- * The terminal is selected with `:has()` rather than a JS-stamped class
- * deliberately: a tile's group element changes when it is dragged elsewhere,
- * so a class would need re-stamping on every move, while this re-evaluates
- * itself. */
+ * specificity, deterministically, in either theme. */
 .dock-root .dv-tabs-and-actions-container {
-  height: 8px;
-}
-
-.dock-root .dv-tabs-and-actions-container:has(.tile-tab-terminal) {
   height: 36px;
 }
 
@@ -189,53 +176,49 @@
 .dock-root .tile-tab {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
+  gap: 8px;
+  padding: 0 6px 0 10px;
   width: 100%;
   height: 100%;
   min-width: 0;
   cursor: grab;
 }
 
-/* Service tile grip: the grip-pill idiom shared with the resize sashes above
- * and the design system's `.osprey-splitter` — same 28×3 geometry and muted →
- * accent treatment as a horizontal divider's grip, so "grab the pill to move
- * this" is one gesture learned once and true everywhere in the product. */
+/* The drag grip: an upright 2×3 dot grid on every tile — the one mark that
+ * means "grab here to move this tile", muted at rest and accent under the
+ * pointer, matching the sash/splitter grip treatment above. */
 .dock-root .tile-tab-grip {
   flex: 0 0 auto;
-  width: 28px;
-  height: 3px;
-  border-radius: var(--radius-full);
-  background: var(--text-muted);
-  opacity: 0.55;
-  transition: background var(--duration-fast) ease, opacity var(--duration-fast) ease;
-}
-
-.dock-root .dv-tab:hover .tile-tab-grip,
-.dock-root .dv-tab:active .tile-tab-grip {
-  background: var(--color-accent);
-  opacity: 1;
-}
-
-/* Terminal tile: the adopted .terminal-header supplies the bar's content, so
- * the layout goes back to a left-anchored row and the grip reverts to the
- * upright 2×3 dot grid that reads as a handle beside populated content (a
- * centred pill would collide with the header it sits next to). */
-.dock-root .tile-tab-terminal {
-  justify-content: flex-start;
-  gap: 8px;
-  padding: 0 6px 0 10px;
-}
-
-.dock-root .tile-tab-terminal .tile-tab-grip {
   width: 10px;
   height: 14px;
-  border-radius: 0;
-  background: none;
   background-image:
     radial-gradient(circle, var(--text-muted) 1.5px, transparent 1.6px);
   background-size: 5px 5px;
   background-position: 0 0;
   opacity: 0.6;
+  transition: opacity var(--duration-fast) ease;
+}
+
+.dock-root .dv-tab:hover .tile-tab-grip,
+.dock-root .dv-tab:active .tile-tab-grip {
+  background-image:
+    radial-gradient(circle, var(--color-accent) 1.5px, transparent 1.6px);
+  opacity: 1;
+}
+
+/* Service tile name: display type at rail-label weight, ellipsized so a long
+ * runtime-panel label can never push the close control off the bar. */
+.dock-root .tile-tab-title {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-family: var(--font-display);
+  font-size: var(--text-sm);
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
 }
 
 .dock-root .tile-tab-actions {
@@ -264,10 +247,11 @@
 
 /* Simple mode is a locked layout. dock-workspace.js disables drag/float
  * (disableDnd) and sash resize (api.locked) at runtime, so a service tile's
- * grip strip is dead chrome there — it collapses away entirely and the panel
- * gets those pixels back. The terminal's strip is exempt by the :has() rule
- * above (it is content, not a handle), but its close is suppressed: closing
- * the session tile is not a simple-mode gesture.
+ * header bar is dead chrome there — it collapses away entirely and the panel
+ * gets those pixels back. The terminal's bar stays (`:not(:has(...))` — it
+ * carries live session controls, content rather than chrome), but its grip
+ * and close are suppressed: moving or closing tiles is not a simple-mode
+ * gesture.
  * display:none overrides dockview's own visibility toggle on the active tab.
  *
  * A zero-height flex container does not clip its children on its own, and

--- a/src/osprey/interfaces/web_terminal/static/css/terminal.css
+++ b/src/osprey/interfaces/web_terminal/static/css/terminal.css
@@ -750,13 +750,14 @@ html[data-ui-mode="simple"] .session-selector {
 }
 
 /* Per-entry corner affordances — decorative, revealed on hover. The rail owns
-   a panel's whole lifecycle, so both the close "×" and the popout "↗" live
-   here; the tile's own header bar is a bare drag grip with no controls on it.
-   They take mirrored top corners, clear of the centred icon + label stack. */
+   a panel's MEMBERSHIP lifecycle: close "×" (remove from rail, top-left),
+   popout "↗" (top-right), and open-beside "⊞" (open as a new tile,
+   bottom-right); closing an OPEN tile is the tile header's own "×". The
+   corners sit clear of the centred icon + label stack. */
 .panel-rail-close,
-.panel-rail-popout {
+.panel-rail-popout,
+.panel-rail-beside {
   position: absolute;
-  top: 4px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -772,6 +773,7 @@ html[data-ui-mode="simple"] .session-selector {
 }
 
 .panel-rail-close {
+  top: 4px;
   left: 4px;
   font-size: var(--text-lg);
 }
@@ -779,6 +781,16 @@ html[data-ui-mode="simple"] .session-selector {
 /* The arrow is a smaller glyph than the "×" at the same nominal size, so it
    rides one step up the scale to read as the "×"'s equal weight. */
 .panel-rail-popout {
+  top: 4px;
+  right: 4px;
+  font-size: var(--text-base);
+}
+
+/* Open-beside takes the bottom-right corner, below the popout: both "take
+   this panel somewhere" verbs share the right edge, membership removal keeps
+   the left. Same step-up sizing rationale as the popout glyph. */
+.panel-rail-beside {
+  bottom: 4px;
   right: 4px;
   font-size: var(--text-base);
 }
@@ -786,7 +798,8 @@ html[data-ui-mode="simple"] .session-selector {
 /* Revealed on hover only — the active cell stays clean (close via hover or the
    keyboard Delete/Backspace shortcut). */
 .panel-rail-button:hover .panel-rail-close,
-.panel-rail-button:hover .panel-rail-popout { opacity: 0.7; }
+.panel-rail-button:hover .panel-rail-popout,
+.panel-rail-button:hover .panel-rail-beside { opacity: 0.7; }
 
 .panel-rail-close:hover {
   opacity: 1;
@@ -794,12 +807,27 @@ html[data-ui-mode="simple"] .session-selector {
   background: var(--accent-tint-08);
 }
 
-/* Popout is non-destructive, so it lights accent rather than the close's error
-   red — the colour is the only cue distinguishing the two corners on hover. */
-.panel-rail-popout:hover {
+/* Popout and open-beside are non-destructive, so they light accent rather
+   than the close's error red — the colour is the cue distinguishing the
+   corners on hover. */
+.panel-rail-popout:hover,
+.panel-rail-beside:hover {
   opacity: 1;
   color: var(--color-accent-light);
   background: var(--accent-tint-08);
+}
+
+/* The drag source dims while its ghost travels, so "this entry is being
+   dragged" reads at a glance. */
+.panel-rail-button.dragging {
+  opacity: 0.4;
+}
+
+/* Simple mode is a locked layout: growing it is not a simple-mode gesture, so
+   the open-beside corner disappears entirely (rail-drag.js cancels the drag
+   half in JS — CSS cannot suppress draggable). */
+html[data-ui-mode="simple"] .panel-rail-beside {
+  display: none;
 }
 
 /* The design system's `.agent-attention` badge is pinned to the same top-right
@@ -819,19 +847,22 @@ html[data-ui-mode="simple"] .session-selector {
   opacity: 0.6;
 }
 
-/* Popout is the opposite case: a panel whose backend has not come up has no
-   resolved standalone URL yet, so the affordance is hidden rather than offered
-   as a dead click (panel-manager's handler no-ops on a null URL regardless). */
-.panel-rail-button.disabled .panel-rail-popout {
+/* Popout and open-beside are the opposite case: a panel whose backend has not
+   come up has nothing useful to open, so the affordances are hidden rather
+   than offered as a dead click (the JS handlers guard regardless). */
+.panel-rail-button.disabled .panel-rail-popout,
+.panel-rail-button.disabled .panel-rail-beside {
   display: none;
 }
 
 /* The SESSION (terminal) entry is the rail's permanent anchor: it never has a
    membership "×" — its tile is closed/reopened through its own header bar and
    the Delete-key shortcut instead (dock-workspace.js guards the JS paths too).
-   It has no standalone page either, so no "↗". */
+   It has no standalone page either, so no "↗"; its tile reopens via a plain
+   click, so no "⊞" (and panel-manager cancels its drag). */
 .panel-rail-button[data-panel-id="terminal"] .panel-rail-close,
-.panel-rail-button[data-panel-id="terminal"] .panel-rail-popout {
+.panel-rail-button[data-panel-id="terminal"] .panel-rail-popout,
+.panel-rail-button[data-panel-id="terminal"] .panel-rail-beside {
   display: none;
 }
 
@@ -1043,6 +1074,11 @@ html[data-rail-position="top"] .panel-rail-popout {
 
 html[data-rail-position="top"] .panel-rail-close {
   left: 2px;
+}
+
+html[data-rail-position="top"] .panel-rail-beside {
+  bottom: 2px;
+  right: 2px;
 }
 
 html[data-rail-position="top"] .panel-rail-popout {

--- a/src/osprey/interfaces/web_terminal/static/js/dock-iframe.js
+++ b/src/osprey/interfaces/web_terminal/static/js/dock-iframe.js
@@ -27,8 +27,7 @@
  * resize — and, between settles, via a ResizeObserver on each managed
  * placeholder's group content container. dockview emits no per-frame layout
  * event during a live sash drag, but the drag resizes those containers every
- * frame, so the observer follows the sash continuously (same for the
- * single-tab strip's hover expand — see dockview-overrides.css) instead of the
+ * frame, so the observer follows the sash continuously instead of the
  * iframe freezing and snapping at mouseup. Settle events additionally REWIRE
  * the observed set (groups are created/destroyed as panels move); the observer
  * callback only re-applies geometry, never rewires, so it cannot recurse.
@@ -161,16 +160,26 @@ function ensureOverlay() {
 }
 
 /**
- * Re-apply dock-workspace.js's pointer shield to the overlay iframes. The shared
- * `.main-container.dock-dragging iframe { pointer-events:none }` rule can't win
- * against the inline `pointer-events:auto` these iframes carry, so we toggle it
- * inline across the whole drag gesture (start → any natural terminator).
+ * Toggle the inline pointer shield over every managed overlay iframe. The
+ * shared `.main-container.dock-dragging iframe { pointer-events:none }` rule
+ * can't win against the inline `pointer-events:auto` these iframes carry, so
+ * the toggle must be inline. Exported for rail-drag.js, whose HTML5 drags
+ * start outside dockview and therefore outside onDragGesture's coverage.
+ * @param {boolean} on
+ */
+export function setIframePointerShield(on) {
+  for (const e of managed.values()) e.iframe.style.pointerEvents = on ? 'none' : 'auto';
+}
+
+/**
+ * Re-apply dock-workspace.js's pointer shield to the overlay iframes across
+ * every dockview-initiated drag gesture (start → any natural terminator).
  * @param {any} api
  */
 function wireDragShield(api) {
   disposers.push(...onDragGesture(api, {
-    onStart: () => { for (const e of managed.values()) e.iframe.style.pointerEvents = 'none'; },
-    onEnd: () => { for (const e of managed.values()) e.iframe.style.pointerEvents = 'auto'; },
+    onStart: () => setIframePointerShield(true),
+    onEnd: () => setIframePointerShield(false),
   }));
 }
 
@@ -462,7 +471,7 @@ function dispatchResize(iframe) {
 /**
  * Live follower for the stretch between dockview settle events: observes each
  * managed placeholder's group content container, whose per-frame resize during
- * a sash drag (or the single-tab strip's hover expand) has no dockview event.
+ * a sash drag has no dockview event.
  * Rewired by syncGeometry() on every settle — groups come and go as panels
  * move. The callback re-applies geometry only; it never rewires, so the
  * initial fire observe() triggers cannot recurse into another rewire.

--- a/src/osprey/interfaces/web_terminal/static/js/dock-sync.js
+++ b/src/osprey/interfaces/web_terminal/static/js/dock-sync.js
@@ -147,61 +147,83 @@ function onDockClickCapture(e) {
 }
 
 /**
- * Resolve the dockview panel id for a `.dv-tab` element. dockview does not stamp
- * the id on the tab DOM, so map by position: the tab's index among its `.dv-tab`
- * siblings indexes into its group's ordered `panels`. Returns null if anything
- * along the chain is missing (resolves to a no-op close).
+ * Resolve the dockview panel id for a `.dv-tab` element. dock-tab.js stamps the
+ * id on every tile bar it renders (`data-panel-id` on the `.tile-tab` root), so
+ * the resolution is an exact read — no positional mapping. Returns null when
+ * the stamp is absent (resolves to a no-op close).
  * @param {Element} tab
  * @returns {string | null}
  */
 function panelIdForTab(tab) {
+  const tile = tab.querySelector('.tile-tab');
+  return (tile instanceof HTMLElement ? tile.dataset.panelId : null) ?? null;
+}
+
+/**
+ * Dock a service panel's placeholder at an explicit position as its own tile —
+ * the shared placement verb behind "open beside" (rail ⊞ / "+" add-menu) and
+ * the rail drag-and-drop drop routing. Creates the placeholder by the
+ * adapter's own id + component so the adapter adopts it in place (its
+ * ensurePlaceholder no-ops when the id already exists), keeping this position.
+ *
+ * An ALREADY-DOCKED placeholder is MOVED to the position (remove + re-add —
+ * safe because placeholders are empty; the overlay iframe simply re-follows
+ * its new rectangle), never duplicated. Two guarded no-op cases: the target
+ * group is the placeholder's own group (removing a tile's sole panel destroys
+ * the group the re-add would reference), and an already-docked panel with no
+ * position at all (nothing meaningful to do).
+ *
+ * No-op in fallback mode and in SIMPLE mode — the locked simple layout has
+ * exactly one service tile, so callers there fall through to the plain show
+ * path and take the tile over like a rail click. Wrapped in the echo guard so
+ * neither the removal's auto-activation nor the add's active-panel change is
+ * read as a human focus — the caller's show path owns the focus POST.
+ * @param {string} serviceId  panel-manager rail id
+ * @param {string} [title]    dock tab title (defaults to the id)
+ * @param {{referenceGroup?: any, direction: string} | null} [position]
+ *   referenceGroup omitted = split against the grid edge in `direction`
+ */
+export function dockPanelAt(serviceId, title = serviceId, position = null) {
   const api = getDockApi();
-  if (!api) return null;
-  const groupEl = tab.closest('.dv-groupview');
-  const container = tab.parentElement;
-  if (!groupEl || !container) return null;
-  const group = api.groups.find(
-    (/** @type {any} */ g) => g.element === groupEl || g.element?.contains?.(tab),
-  );
-  if (!group) return null;
-  const tabs = Array.from(container.children).filter((c) => c.classList.contains('dv-tab'));
-  const index = tabs.indexOf(tab);
-  if (index < 0) return null;
-  return group.panels?.[index]?.id ?? null;
+  if (!api) return;
+  if (document.documentElement.getAttribute('data-ui-mode') === 'simple') return;
+  const placeholderId = PLACEHOLDER_PREFIX + serviceId;
+  const existing = api.getPanel(placeholderId);
+  if (existing) {
+    if (!position) return;
+    if (existing.group && existing.group === position.referenceGroup) return;
+  }
+  /** @type {any} */
+  const opts = { id: placeholderId, component: PLACEHOLDER_COMPONENT, title };
+  if (position) opts.position = position;
+  withEchoSuppressed(() => {
+    try {
+      if (existing) api.removePanel(existing);
+      api.addPanel(opts);
+    } catch (err) {
+      console.error('dock-sync: dockPanelAt failed for', placeholderId, err);
+    }
+  });
 }
 
 /**
  * Dock a service panel's placeholder BESIDE the currently-active group as a
- * NEW tile, so a panel opened from the "+" add-menu splits where the operator
- * is working — the one rail verb that grows the layout (a rail click on the
- * entry itself REPLACES the focused tile's panel instead; see the adapter's
- * ensurePlaceholder). Creates the placeholder by the adapter's own id +
- * component so the adapter adopts it in place (its ensurePlaceholder no-ops
- * when the id already exists), keeping this position. No-op in fallback mode,
- * when the panel is already docked, and in SIMPLE mode — the locked simple
- * layout has exactly one service tile, so an add-menu pick there falls through
- * to the plain show path and takes the tile over like a rail click. Wrapped in
- * the echo guard so the add's active-panel change is not read as a human
- * focus — the add-menu's own show path POSTs the focus.
+ * NEW tile, so a panel opened from the rail's ⊞ corner or the "+" add-menu
+ * splits where the operator is working — the discoverable half of the
+ * open-beside verb (rail drag-and-drop is the precise half; both land in
+ * {@link dockPanelAt}, so an already-open panel is moved, not duplicated). A
+ * rail click on the entry itself still REPLACES the focused tile's panel
+ * instead (the adapter's ensurePlaceholder).
  * @param {string} serviceId  panel-manager rail id
  * @param {string} [title]    dock tab title (defaults to the id)
  */
 export function dockPanelBesideActive(serviceId, title = serviceId) {
   const api = getDockApi();
   if (!api) return;
-  if (document.documentElement.getAttribute('data-ui-mode') === 'simple') return;
-  const placeholderId = PLACEHOLDER_PREFIX + serviceId;
-  if (api.getPanel(placeholderId)) return;
-  /** @type {any} */
-  const opts = { id: placeholderId, component: PLACEHOLDER_COMPONENT, title };
-  if (api.activeGroup) opts.position = { referenceGroup: api.activeGroup, direction: 'right' };
-  withEchoSuppressed(() => {
-    try {
-      api.addPanel(opts);
-    } catch (err) {
-      console.error('dock-sync: dockPanelBesideActive addPanel failed for', placeholderId, err);
-    }
-  });
+  const position = api.activeGroup
+    ? { referenceGroup: api.activeGroup, direction: 'right' }
+    : null;
+  dockPanelAt(serviceId, title, position);
 }
 
 /**

--- a/src/osprey/interfaces/web_terminal/static/js/dock-tab.js
+++ b/src/osprey/interfaces/web_terminal/static/js/dock-tab.js
@@ -2,25 +2,23 @@
 /* OSPREY Web Terminal — Tile Header Bar (custom dockview tab renderer)
  *
  * Under the one-panel-per-tile invariant a tile's "tab" can never have
- * siblings, so instead of a tab it renders the tile's HOST HEADER BAR. The
- * two tile kinds get very different bars, because they carry very different
- * amounts of state:
+ * siblings, so instead of a tab it renders the tile's HOST HEADER BAR. Every
+ * tile gets the same bar grammar — drag grip on the left, the tile's
+ * identity in the middle, close on the right — so grabbing, naming and
+ * closing a tile is one gesture learned once:
  *
- *   service tiles — a bare drag GRIP, nothing else. Their title is already on
- *     the rail entry, and their lifecycle controls (close, popout) live on
- *     that entry's hover corners, so a full-height bar per tile was chrome
- *     charged against every panel for affordances used rarely. The strip is
- *     styled down to a grip pill in dockview-overrides.css.
+ *   service tiles — grip + a visible `.tile-tab-title` + close. The close is
+ *     a LOCAL tile close (the panel keeps its rail entry; dock-sync routes
+ *     the click to a vacate handler); membership removal stays the rail
+ *     entry's "×". Popout remains rail-only.
  *   the terminal tile — grip + the adopted live `.terminal-header` + close.
- *     Its bar earns its height: session LED, session id, the session selector
- *     and "+ New" are frequently-used, stateful controls with nowhere better
- *     to live, and this close is the terminal's only pointer close path (its
- *     rail entry deliberately has no "×").
+ *     The header supplies the identity and more: session LED, session id,
+ *     the session selector and "+ New" are frequently-used, stateful
+ *     controls with nowhere better to live.
  *
  * Registered via dockview's createTabComponent/defaultTabComponent
  * (dock-workspace.js), which keeps dockview's native tab DnD, drop
- * hit-testing and close plumbing intact — the bar IS the drag handle, at
- * either height.
+ * hit-testing and close plumbing intact — the bar IS the drag handle.
  */
 
 import { TERMINAL_RAIL_ID } from './panel-catalog.js';
@@ -106,8 +104,9 @@ class TileTab {
     grip.setAttribute('aria-hidden', 'true');
     root.appendChild(grip);
 
-    // Service tiles stop here: grip only. Everything else about a service
-    // panel is reachable from its rail entry.
+    /** @type {HTMLElement | null} visible name element (service tiles only) */
+    this._titleEl = null;
+
     if (id === TERMINAL_RAIL_ID) {
       root.classList.add('tile-tab-terminal');
       const header = terminalHeader();
@@ -118,29 +117,34 @@ class TileTab {
         // function's docstring for why attaching per-construction would
         // accumulate listeners).
       }
-
-      const actions = document.createElement('div');
-      actions.className = 'tile-tab-actions';
-      // The DefaultTab idiom: preventDefault on pointerdown keeps an action
-      // press from starting a drag/focus dance; the click still fires.
-      actions.addEventListener('pointerdown', (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-      });
-      const close = document.createElement('button');
-      close.type = 'button';
-      close.className = 'tile-tab-close';
-      close.textContent = '×';
-      close.title = 'Close tile';
-      close.setAttribute('aria-label', 'Close tile');
-      close.addEventListener('click', (e) => {
-        if (e.defaultPrevented) return;
-        e.preventDefault();
-        this._api?.close?.();
-      });
-      actions.appendChild(close);
-      root.appendChild(actions);
+    } else {
+      const title = document.createElement('span');
+      title.className = 'tile-tab-title';
+      root.appendChild(title);
+      this._titleEl = title;
     }
+
+    const actions = document.createElement('div');
+    actions.className = 'tile-tab-actions';
+    // The DefaultTab idiom: preventDefault on pointerdown keeps an action
+    // press from starting a drag/focus dance; the click still fires.
+    actions.addEventListener('pointerdown', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+    });
+    const close = document.createElement('button');
+    close.type = 'button';
+    close.className = 'tile-tab-close';
+    close.textContent = '×';
+    close.title = 'Close tile';
+    close.setAttribute('aria-label', 'Close tile');
+    close.addEventListener('click', (e) => {
+      if (e.defaultPrevented) return;
+      e.preventDefault();
+      this._api?.close?.();
+    });
+    actions.appendChild(close);
+    root.appendChild(actions);
 
     this._element = root;
   }
@@ -152,14 +156,15 @@ class TileTab {
   /** @param {any} params  dockview TabPartInitParameters (title, params, api, …) */
   init(params) {
     this._api = params.api;
-    // A service strip is a drag handle carrying no text, which would leave
-    // assistive tech with an unnamed control. The panel title becomes its
-    // accessible name instead of a visible label — kept current, since a
-    // renamed panel would otherwise announce a stale one. The terminal bar is
-    // exempt: the header it adopted names it already.
+    // The panel title is a service bar's visible label AND its accessible
+    // name, kept current so a renamed panel never shows or announces a stale
+    // one. The terminal bar is exempt: the header it adopted names it already.
     if (this._panelId === TERMINAL_RAIL_ID) return;
     /** @param {string} title */
-    const applyName = (title) => this._element.setAttribute('aria-label', title);
+    const applyName = (title) => {
+      if (this._titleEl) this._titleEl.textContent = title;
+      this._element.setAttribute('aria-label', title);
+    };
     applyName(params.title ?? '');
     const sub = params.api?.onDidTitleChange?.((/** @type {any} */ e) => applyName(e?.title ?? ''));
     if (sub?.dispose) this._disposables.push(sub);

--- a/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
@@ -32,7 +32,11 @@ import { createPanelIframe } from './panel-iframe-factory.js';
 import {
   PANELS, TERMINAL_RAIL_ID, TERMINAL_RAIL_LABEL, DEFAULT_PANEL_FALLBACK,
 } from './panel-catalog.js';
-import { initDockSync, withEchoSuppressed, setTileCloseHandler } from './dock-sync.js';
+import {
+  initDockSync, withEchoSuppressed, setTileCloseHandler,
+  dockPanelBesideActive, dockPanelAt,
+} from './dock-sync.js';
+import { initRailDrag, railDragStart, railDragEnd } from './rail-drag.js';
 import { startHealthPolling as startPolling } from './panel-health.js';
 import { openTerminalPanel, closeTerminalPanel } from './dock-workspace.js';
 import { initRailThemeCoupling } from './rail-position.js';
@@ -172,6 +176,17 @@ export async function initPanelManager(panelId) {
   // tab focus / close POSTs the same setPanelFocus / setPanelVisibility the rail
   // and agent use. Wires lazily once the dockview shell is up; no-ops without it.
   initDockSync();
+
+  // Rail drag-and-drop: a rail entry dropped on a tile edge opens (or moves)
+  // that panel as a new tile at the drop position, then reveals it through the
+  // same activate/show tail every other open path uses. Wires lazily like
+  // initDockSync; no-ops without a dock shell.
+  initRailDrag({
+    onDropPanel: (id, position) => {
+      dockPanelAt(id, labelOf(id), position);
+      revealOpenedPanel(id);
+    },
+  });
 
   // Fetch panel config and filter PANELS before rendering
   let panelConfig = null;
@@ -465,12 +480,11 @@ function railOptions() {
   return {
     onActivate: (/** @type {string} */ id) => {
       if (id === TERMINAL_RAIL_ID) { openTerminalPanel(); return; }
-      // Clicking the entry whose tile is ALREADY surfaced retires that tile.
-      // This is the local vacate that used to sit on the tile's own "×" — a
-      // service tile's strip is now a bare drag grip, so the gesture moved to
-      // the rail rather than disappearing. It stays a LOCAL layout change:
-      // rail membership survives, so a second click brings the tile back.
-      // Membership removal remains the separate "×" corner.
+      // Clicking the entry whose tile is ALREADY surfaced retires that tile —
+      // a toggle shortcut equivalent to the tile header's own "×". It stays a
+      // LOCAL layout change: rail membership survives, so a second click
+      // brings the tile back. Membership removal remains the separate "×"
+      // corner.
       if (visiblePanels.has(id)) {
         if (activeTabId === id) { retireTile(id); return; }
         activateTab(id, { userInitiated: true });
@@ -480,16 +494,59 @@ function railOptions() {
       if (id === TERMINAL_RAIL_ID) { closeTerminalPanel(); return; }
       setPanelVisibility(id, false);
     },
-    // The rail owns the whole panel lifecycle, popout included — a tile's
-    // header bar is a bare drag grip. No-ops before the panel's config fetch
-    // has resolved a URL; the rail also hides the affordance while the entry
-    // is `.disabled`, so this guard is the backstop, not the only gate.
+    // Popout stays rail-only (a tile has no standalone-URL affordance).
+    // No-ops before the panel's config fetch has resolved a URL; the rail
+    // also hides the affordance while the entry is `.disabled`, so this
+    // guard is the backstop, not the only gate.
     onPopout: (/** @type {string} */ id) => {
       if (id === TERMINAL_RAIL_ID) return;
       const url = getPanelStandaloneUrl(id);
       if (url) window.open(url, '_blank', 'noopener');
     },
+    // "⊞" — open this panel as a NEW tile beside the active one, the
+    // discoverable half of the open-beside verb (rail drag is the precise
+    // half). The terminal entry routes to its own reopen path; CSS hides its
+    // corner regardless.
+    onOpenBeside: (/** @type {string} */ id) => openPanelBeside(id),
+    // Rail drag source: the terminal entry never drags (its tile moves by its
+    // own header bar); everything else defers to rail-drag's policy (simple
+    // mode and fallback mode cancel there).
+    onDragStart: (/** @type {string} */ id, /** @type {DataTransfer | null} */ dt) =>
+      id === TERMINAL_RAIL_ID ? false : railDragStart(id, dt),
+    onDragEnd: () => railDragEnd(),
   };
+}
+
+/** The catalog label for a panel id (falls back to the id itself).
+ *  @param {string} id @returns {string} */
+function labelOf(id) {
+  return PANELS.find((p) => p.id === id)?.label ?? id;
+}
+
+/**
+ * Shared reveal tail for every "open as a new tile" path (rail ⊞, rail drop):
+ * a member panel is focused locally + reported (activateTab no-ops while the
+ * panel is unhealthy — the placeholder tile still appears and fills on the
+ * next health settle); a non-member is revealed through the same
+ * visibility-POST path the "+" menu uses.
+ * @param {string} panelId
+ */
+function revealOpenedPanel(panelId) {
+  if (visiblePanels.has(panelId)) activateTab(panelId, { userInitiated: true });
+  else showPanel(panelId);
+}
+
+/**
+ * Open a panel as a NEW tile beside the active group — the rail ⊞ corner's
+ * action. An already-open panel is MOVED beside the active tile (dockPanelAt's
+ * move semantics), never duplicated. In simple mode the placement no-ops in
+ * dock-sync and the reveal tail takes the single tile over like a rail click.
+ * @param {string} panelId
+ */
+function openPanelBeside(panelId) {
+  if (panelId === TERMINAL_RAIL_ID) { openTerminalPanel(); return; }
+  dockPanelBesideActive(panelId, labelOf(panelId));
+  revealOpenedPanel(panelId);
 }
 
 /**

--- a/src/osprey/interfaces/web_terminal/static/js/panel-rail.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-rail.js
@@ -3,10 +3,11 @@
  *
  * A pure DOM-rendering module for the 74px left icon rail that replaces the
  * horizontal header tab strip. It builds one entry per rail MEMBER (icon,
- * label, active accent) plus a trailing `＋` add affordance, and exposes small
+ * label, active accent, hover corners, drag source) and exposes small
  * imperative mutators — set active, enable, attention, append, remove — so
  * `panel-manager.js`'s state machine can drive the rail without owning any DOM
- * specifics.
+ * specifics. (The `＋` add control is NOT the rail's: the template supplies it
+ * as the sibling `#panel-add-btn`.)
  *
  * The rail deliberately carries NO per-panel health readout. Backend liveness
  * is reported in one place — the SYSTEM panel's `web_panels` health category —
@@ -32,14 +33,14 @@
  *
  *   <nav class="panel-rail" role="tablist">
  *     <button class="panel-rail-button disabled" data-panel-id="artifacts"
- *             type="button" role="tab" aria-selected="false" title="WORKSPACE">
+ *             type="button" role="tab" aria-selected="false" title="WORKSPACE"
+ *             draggable="true">                                       (only when onDragStart given)
  *       <span class="panel-rail-icon" data-icon="artifacts" aria-hidden="true"></span>
  *       <span class="panel-rail-label">WORKSPACE</span>
  *       <span class="panel-rail-close" aria-hidden="true">×</span>    (only when onClose given)
  *       <span class="panel-rail-popout" aria-hidden="true">↗</span>   (only when onPopout given)
+ *       <span class="panel-rail-beside" aria-hidden="true">⊞</span>   (only when onOpenBeside given)
  *     </button>
- *     ...
- *     <button class="panel-rail-add" type="button" aria-label="Add panel">＋</button>  (only when onAdd given)
  *   </nav>
  *
  * State classes on an entry: `.active` (surfaced panel), `.disabled` (backend
@@ -62,17 +63,22 @@ import { flashElement } from '/design-system/js/highlight.js';
 
 /**
  * Interaction closures injected by the caller so the rail stays a dumb view.
- * Every callback is optional: omit `onClose` / `onPopout` to render no such
- * per-entry corner affordance, omit `onAdd` to render no `＋` button.
+ * Every callback is optional: omit `onClose` / `onPopout` / `onOpenBeside` to
+ * render no such per-entry corner affordance, omit `onDragStart` to render
+ * non-draggable entries. `onDragStart` may return false to cancel the drag for
+ * that entry (the caller's policy — e.g. the terminal entry, simple mode);
+ * this module stays policy-free.
  * @typedef {object} RailOptions
- * @property {(id: string) => void} [onActivate] - an entry was clicked
- * @property {(id: string) => void} [onClose]    - the entry's close "×" was clicked
- * @property {(id: string) => void} [onPopout]   - the entry's popout "↗" was clicked
- * @property {() => void} [onAdd]                 - the trailing `＋` was clicked
+ * @property {(id: string) => void} [onActivate]   - an entry was clicked
+ * @property {(id: string) => void} [onClose]      - the entry's close "×" was clicked
+ * @property {(id: string) => void} [onPopout]     - the entry's popout "↗" was clicked
+ * @property {(id: string) => void} [onOpenBeside] - the entry's "⊞" (open in a new tile) was clicked
+ * @property {(id: string, dataTransfer: DataTransfer | null) => boolean} [onDragStart]
+ *   - a drag left an entry; return false to cancel it
+ * @property {(id: string) => void} [onDragEnd]    - the entry's drag gesture ended (any outcome)
  */
 
 const BUTTON_SELECTOR = '.panel-rail-button';
-const ADD_SELECTOR = '.panel-rail-add';
 
 // ---- Rendering ----
 
@@ -114,10 +120,11 @@ function buildRailButton(panel, options = {}) {
     btn.addEventListener('click', () => onActivate(panel.id));
   }
 
-  // Per-entry corner affordances — the rail owns a panel's whole lifecycle
-  // (open, close, pop out), so both live here rather than on the tile itself,
-  // whose header bar is a bare drag grip. Rendered only when the caller wants
-  // them; close takes the top-left corner, popout the mirrored top-right.
+  // Per-entry corner affordances — the rail owns a panel's MEMBERSHIP
+  // lifecycle (remove from rail, pop out, open as a new tile). Rendered only
+  // when the caller wants them; close takes the top-left corner, popout the
+  // mirrored top-right, open-beside the bottom-right. (Closing an OPEN tile
+  // is the tile header's own "×" — a layout gesture, not a membership one.)
   if (options.onClose) {
     btn.appendChild(
       buildCornerAffordance('panel-rail-close', '×', `Close ${panel.label}`, panel.id, options.onClose)
@@ -129,6 +136,34 @@ function buildRailButton(panel, options = {}) {
         'panel-rail-popout', '↗', `Open ${panel.label} in a new window`, panel.id, options.onPopout
       )
     );
+  }
+  if (options.onOpenBeside) {
+    btn.appendChild(
+      buildCornerAffordance(
+        'panel-rail-beside', '⊞', `Open ${panel.label} in a new tile`, panel.id, options.onOpenBeside
+      )
+    );
+  }
+
+  // Drag source: dragging an entry into the workspace opens the panel as a
+  // NEW tile at the drop position (the precise half of the open-beside verb).
+  // The caller's onDragStart stamps the dataTransfer payload and may cancel
+  // (return false) — e.g. for the terminal entry or a locked simple layout.
+  if (options.onDragStart) {
+    const onDragStart = options.onDragStart;
+    btn.setAttribute('draggable', 'true');
+    btn.addEventListener('dragstart', (e) => {
+      if (!onDragStart(panel.id, e.dataTransfer)) {
+        e.preventDefault();
+        return;
+      }
+      btn.classList.add('dragging');
+    });
+    const onDragEnd = options.onDragEnd;
+    btn.addEventListener('dragend', () => {
+      btn.classList.remove('dragging');
+      onDragEnd?.(panel.id);
+    });
   }
 
   return btn;
@@ -161,24 +196,10 @@ function buildCornerAffordance(className, glyph, title, panelId, handler) {
 }
 
 /**
- * Build the `＋` add affordance that sits after the panel entries.
- * @param {() => void} onAdd
- * @returns {HTMLButtonElement}
- */
-function buildAddButton(onAdd) {
-  const add = document.createElement('button');
-  add.type = 'button';
-  add.className = 'panel-rail-add';
-  add.setAttribute('aria-label', 'Add panel');
-  add.textContent = '＋';
-  add.addEventListener('click', () => onAdd());
-  return add;
-}
-
-/**
  * Render the full rail into `railEl`, replacing any existing content. Entries
- * are appended in `panels` order, followed by the `＋` button when `onAdd` is
- * supplied. Marks `railEl` as `role="tablist"` for assistive tech.
+ * are appended in `panels` order. Marks `railEl` as `role="tablist"` for
+ * assistive tech. (The `＋` add control is the template's sibling
+ * `#panel-add-btn`, outside this nav — never rendered here.)
  *
  * This is the destructive full render — the twin of the tab strip's
  * `renderTabs()`. Use {@link addEntry} / {@link removeEntry} for
@@ -195,22 +216,18 @@ export function createRail(railEl, panels, options = {}) {
   for (const panel of panels) {
     railEl.appendChild(buildRailButton(panel, options));
   }
-  if (options.onAdd) {
-    railEl.appendChild(buildAddButton(options.onAdd));
-  }
 }
 
 /**
  * Append a single entry without disturbing existing ones — the non-destructive
  * path for membership additions (agent show_panel, "+" menu pick, runtime
- * registration). Inserts before the `＋` button when one is present so the add
- * affordance stays last; otherwise appends at the end.
+ * registration).
  *
  * Idempotent by id: if an entry for `panel.id` already exists it is returned
  * unchanged (no duplicate node), mirroring the tab strip's re-register guard.
  * @param {HTMLElement} railEl
  * @param {RailPanel} panel
- * @param {RailOptions} [options] - `onAdd` is ignored here (the rail already owns its `＋`)
+ * @param {RailOptions} [options]
  * @returns {HTMLButtonElement}
  */
 export function addEntry(railEl, panel, options = {}) {
@@ -218,12 +235,7 @@ export function addEntry(railEl, panel, options = {}) {
   if (existing) return existing;
 
   const btn = buildRailButton(panel, options);
-  const addBtn = railEl.querySelector(ADD_SELECTOR);
-  if (addBtn) {
-    railEl.insertBefore(btn, addBtn);
-  } else {
-    railEl.appendChild(btn);
-  }
+  railEl.appendChild(btn);
   return btn;
 }
 

--- a/src/osprey/interfaces/web_terminal/static/js/rail-drag.js
+++ b/src/osprey/interfaces/web_terminal/static/js/rail-drag.js
@@ -1,0 +1,150 @@
+// @ts-check
+/* OSPREY Web Terminal — Rail Drag (drag a rail entry into the workspace)
+ *
+ * The precise half of the open-beside verb: dragging a rail entry into the
+ * workspace opens (or moves) that panel as a NEW tile exactly where it is
+ * dropped. The rail entry is a plain HTML5 drag source (panel-rail.js sets
+ * `draggable` and forwards dragstart/dragend here via panel-manager's
+ * closures); this module bridges that FOREIGN drag into dockview's own
+ * external-drag hooks, verified against the vendored dockview-core build:
+ *
+ *   - api.onUnhandledDragOver fires for any non-dockview drag over a dockview
+ *     drop target, carrying { nativeEvent, target, position, group } plus
+ *     accept(). Accepting paints dockview's native drop overlay — the same
+ *     highlight a tile drag shows, so the two gestures read identically.
+ *     During dragover the HTML5 payload is unreadable (dataTransfer protected
+ *     mode), so acceptance keys off dataTransfer.types alone.
+ *   - api.onDidDrop fires on the real drop with { nativeEvent, position,
+ *     group }; there the payload IS readable and resolves the panel id.
+ *
+ * One panel per tile stays an invariant: only split geometries are accepted —
+ * tab, header-space and center targets are refused, mirroring
+ * dock-workspace's wireStackingVeto for dockview's own drags (group-model
+ * vetoes do not see foreign drags, so the refusal lives here).
+ *
+ * Placement itself is NOT this module's job: the accepted drop is handed to
+ * the caller's onDropPanel(id, position) (panel-manager routes it into
+ * dock-sync's dockPanelAt + the activation tail), keeping this module free of
+ * panel state.
+ *
+ * Iframe shields: a drag crossing an overlay iframe would have its dragover
+ * events swallowed by that separate browsing context, killing dockview's drop
+ * detection. dockview's own drags shield via dock-workspace's onDragGesture;
+ * a rail drag starts OUTSIDE dockview, so the same two shields are raised
+ * here across the gesture — the `.dock-dragging` class on .main-container
+ * (terminal.css) and the adapter's inline pointer-events toggle
+ * (setIframePointerShield), which the class rule cannot reach.
+ */
+
+import { getDockApi } from './dock-workspace.js';
+import { setIframePointerShield } from './dock-iframe.js';
+
+/** DataTransfer type carrying the dragged panel's rail id. */
+export const RAIL_DRAG_MIME = 'application/x-osprey-panel';
+
+/** True once the dockview listeners are attached (idempotent guard). */
+let wired = false;
+/** Bounded retry so late DockviewApi arrival still wires (mirrors dock-sync). */
+let wireAttempts = 0;
+/** @type {((id: string, position: {referenceGroup?: any, direction: string} | null) => void) | null} */
+let dropHandler = null;
+
+/** @param {any} nativeEvent @returns {boolean} whether the drag carries our MIME */
+function isRailDrag(nativeEvent) {
+  const types = nativeEvent?.dataTransfer?.types;
+  return !!types && Array.from(types).includes(RAIL_DRAG_MIME);
+}
+
+/**
+ * Drop-overlay position → addPanel direction. The two vocabularies differ on
+ * the vertical axis ('top'/'bottom' vs 'above'/'below'); addPanel throws
+ * "invalid direction" on the untranslated values. 'center' is deliberately
+ * absent — a center drop would stack, which the accept veto already refuses.
+ * @type {Record<string, string>}
+ */
+const DIRECTION_BY_POSITION = {
+  left: 'left',
+  right: 'right',
+  top: 'above',
+  bottom: 'below',
+};
+
+/**
+ * A drag-over geometry that would stack panels as tabs in one tile — the
+ * foreign-drag twin of dock-workspace's isStackingDrop (that one reads
+ * `kind`; the unhandled-drag-over event calls the same field `target`).
+ * @param {any} e  an UnhandledDragOverEvent
+ * @returns {boolean}
+ */
+function isStackingTarget(e) {
+  return e.target === 'tab' || e.target === 'header_space'
+    || (e.target === 'content' && e.position === 'center');
+}
+
+/**
+ * Wire the dockview external-drag hooks and register the drop handler. Safe
+ * to call repeatedly (idempotent); polls a bounded number of times while the
+ * DockviewApi has not arrived yet, exactly like initDockSync.
+ * @param {{ onDropPanel: (id: string, position: {referenceGroup?: any, direction: string} | null) => void }} options
+ */
+export function initRailDrag({ onDropPanel }) {
+  dropHandler = onDropPanel;
+  wire();
+}
+
+function wire() {
+  if (wired) return;
+  if (typeof document === 'undefined') return;
+  const api = getDockApi();
+  if (api) {
+    api.onUnhandledDragOver((/** @type {any} */ e) => {
+      if (!isRailDrag(e.nativeEvent)) return; // not ours (file drag, text, …)
+      if (isStackingTarget(e)) return;        // one panel per tile — never stack
+      e.accept();
+    });
+    api.onDidDrop((/** @type {any} */ e) => {
+      const id = e?.nativeEvent?.dataTransfer?.getData?.(RAIL_DRAG_MIME);
+      if (!id) return;                 // a dockview-internal or foreign drop
+      const direction = DIRECTION_BY_POSITION[e.position];
+      if (!direction) return;          // 'center' (stacking backstop) or unknown
+      const position = e.group ? { referenceGroup: e.group, direction } : { direction };
+      dropHandler?.(id, position);
+    });
+    wired = true;
+    return;
+  }
+  if (wireAttempts++ > 30) return; // ~4.5s at 150ms — the shell is genuinely absent
+  setTimeout(wire, 150);
+}
+
+/**
+ * Begin a rail drag: stamp the payload and raise the iframe shields. Returns
+ * false — cancelling the drag (panel-rail preventDefaults) — in simple mode
+ * (locked layout) and in fallback mode (no dock to drop into).
+ * @param {string} id  panel-manager rail id
+ * @param {DataTransfer | null} dataTransfer
+ * @returns {boolean} whether the drag may proceed
+ */
+export function railDragStart(id, dataTransfer) {
+  if (document.documentElement.getAttribute('data-ui-mode') === 'simple') return false;
+  if (!getDockApi()) return false;
+  if (dataTransfer) {
+    dataTransfer.setData(RAIL_DRAG_MIME, id);
+    // text/plain fallback so a stray drop outside the app degrades harmlessly.
+    dataTransfer.setData('text/plain', id);
+    dataTransfer.effectAllowed = 'move';
+  }
+  shield(true);
+  return true;
+}
+
+/** End a rail drag (drop, cancel, or escape): lower the iframe shields. */
+export function railDragEnd() {
+  shield(false);
+}
+
+/** @param {boolean} on */
+function shield(on) {
+  document.querySelector('.main-container')?.classList.toggle('dock-dragging', on);
+  setIframePointerShield(on);
+}

--- a/tests/interfaces/web_terminal/dock-sync.test.mjs
+++ b/tests/interfaces/web_terminal/dock-sync.test.mjs
@@ -131,9 +131,9 @@ async function wire(api) {
 
 /**
  * Build a dockview-shaped group DOM (one `.dv-groupview` holding a tab strip of
- * `.dv-tab` elements, each with the `.tile-tab-close` close control) under
- * `root`, and register a matching fake group on `api` whose ordered `panels` line
- * up by index with the rendered tabs — the mapping panelIdForTab relies on.
+ * `.dv-tab` elements, each wrapping a `.tile-tab` root that carries the
+ * `data-panel-id` stamp dock-tab.js writes, with the `.tile-tab-close` close
+ * control inside) under `root` — the stamp is what panelIdForTab resolves.
  * @param {HTMLElement} root
  * @param {any} api
  * @param {string[]} panelIds
@@ -143,16 +143,20 @@ function buildGroup(root, api, panelIds) {
   groupview.className = 'dv-groupview';
   const strip = document.createElement('div');
   strip.className = 'dv-tabs-container';
-  /** @type {{tab: HTMLElement, action: HTMLElement}[]} */
+  /** @type {{tab: HTMLElement, tile: HTMLElement, action: HTMLElement}[]} */
   const tabs = [];
-  for (let i = 0; i < panelIds.length; i++) {
+  for (const id of panelIds) {
     const tab = document.createElement('div');
     tab.className = 'dv-tab';
-    const action = document.createElement('div');
+    const tile = document.createElement('div');
+    tile.className = 'tile-tab';
+    tile.dataset.panelId = id;
+    const action = document.createElement('button');
     action.className = 'tile-tab-close';
-    tab.appendChild(action);
+    tile.appendChild(action);
+    tab.appendChild(tile);
     strip.appendChild(tab);
-    tabs.push({ tab, action });
+    tabs.push({ tab, tile, action });
   }
   groupview.appendChild(strip);
   root.appendChild(groupview);
@@ -346,7 +350,7 @@ describe('human tab close → local vacate handler (never a POST)', () => {
     expect(mod).toBeTruthy();
   });
 
-  test('the close click maps by tab position — the second tab resolves the second panel', async () => {
+  test('the close click resolves by the data-panel-id stamp — the second tab resolves the second panel', async () => {
     const api = makeApi();
     const { root } = await wire(api);
     const { tabs } = buildGroup(root, api, ['iframe:ariel', 'iframe:bluesky']);
@@ -379,11 +383,11 @@ describe('human tab close → local vacate handler (never a POST)', () => {
     expect(tileClose).not.toHaveBeenCalled();
   });
 
-  test('a close click on an unresolvable tab (no matching group) is a silent no-op', async () => {
+  test('a close click on an unstamped tab (no data-panel-id) is a silent no-op', async () => {
     const api = makeApi();
     const { root } = await wire(api);
     const { tabs } = buildGroup(root, api, ['iframe:ariel']);
-    api.groups = []; // group vanished between render and click
+    tabs[0].tile.removeAttribute('data-panel-id'); // stamp lost — nothing to resolve
 
     expect(() =>
       tabs[0].action.dispatchEvent(new MouseEvent('click', { bubbles: true })),
@@ -459,13 +463,59 @@ describe('dockPanelBesideActive — placeholder append (register/open path)', ()
     }
   });
 
-  test('is a no-op when the panel is already docked', async () => {
+  test('MOVES an already-docked placeholder beside the active group (remove + re-add)', async () => {
     const api = makeApi();
-    api._panels['iframe:ariel'] = { id: 'iframe:ariel' };
+    const activeGroup = { id: 'group-1' };
+    api.activeGroup = activeGroup;
+    const existing = { id: 'iframe:ariel', group: { id: 'group-0' } };
+    api._panels['iframe:ariel'] = existing;
+    const { mod } = await wire(api);
+
+    mod.dockPanelBesideActive('ariel', 'ARIEL');
+
+    expect(api.removePanel).toHaveBeenCalledExactlyOnceWith(existing);
+    expect(api._added[0]).toEqual({
+      id: 'iframe:ariel',
+      component: 'dock-iframe-placeholder',
+      title: 'ARIEL',
+      position: { referenceGroup: activeGroup, direction: 'right' },
+    });
+  });
+
+  test('a move is echo-guarded — the removal\'s auto-activation does not POST a focus', async () => {
+    const api = makeApi();
+    api.activeGroup = { id: 'group-1' };
+    api._panels['iframe:ariel'] = { id: 'iframe:ariel', group: { id: 'group-0' } };
+    api._activateOnRemove = { id: 'iframe:bluesky' };
     const { mod } = await wire(api);
 
     mod.dockPanelBesideActive('ariel');
 
+    expect(setPanelFocus).not.toHaveBeenCalled();
+  });
+
+  test('already docked IN the active group: a no-op (never remove a tile to re-create it in place)', async () => {
+    const api = makeApi();
+    const activeGroup = { id: 'group-1' };
+    api.activeGroup = activeGroup;
+    api._panels['iframe:ariel'] = { id: 'iframe:ariel', group: activeGroup };
+    const { mod } = await wire(api);
+
+    mod.dockPanelBesideActive('ariel');
+
+    expect(api.removePanel).not.toHaveBeenCalled();
+    expect(api.addPanel).not.toHaveBeenCalled();
+  });
+
+  test('already docked with NO active group: a no-op (no meaningful target)', async () => {
+    const api = makeApi();
+    api.activeGroup = null;
+    api._panels['iframe:ariel'] = { id: 'iframe:ariel', group: { id: 'group-0' } };
+    const { mod } = await wire(api);
+
+    mod.dockPanelBesideActive('ariel');
+
+    expect(api.removePanel).not.toHaveBeenCalled();
     expect(api.addPanel).not.toHaveBeenCalled();
   });
 
@@ -505,6 +555,60 @@ describe('dockPanelBesideActive — placeholder append (register/open path)', ()
 
     expect(() => mod.dockPanelBesideActive('ariel')).not.toThrow();
     expect(setPanelFocus).not.toHaveBeenCalled();
+  });
+});
+
+describe('dockPanelAt — placement at an explicit dock position (rail drag / drop routing)', () => {
+  test('adds a fresh placeholder at the given group + direction', async () => {
+    const api = makeApi();
+    const target = { id: 'group-2' };
+    const { mod } = await wire(api);
+
+    mod.dockPanelAt('okf', 'KNOWLEDGE', { referenceGroup: target, direction: 'bottom' });
+
+    expect(api._added[0]).toEqual({
+      id: 'iframe:okf',
+      component: 'dock-iframe-placeholder',
+      title: 'KNOWLEDGE',
+      position: { referenceGroup: target, direction: 'bottom' },
+    });
+  });
+
+  test('moves an existing placeholder to the given position', async () => {
+    const api = makeApi();
+    const target = { id: 'group-2' };
+    const existing = { id: 'iframe:okf', group: { id: 'group-0' } };
+    api._panels['iframe:okf'] = existing;
+    const { mod } = await wire(api);
+
+    mod.dockPanelAt('okf', 'KNOWLEDGE', { referenceGroup: target, direction: 'left' });
+
+    expect(api.removePanel).toHaveBeenCalledExactlyOnceWith(existing);
+    expect(api._added[0].position).toEqual({ referenceGroup: target, direction: 'left' });
+  });
+
+  test('dropping a panel onto its OWN group is a no-op (would destroy the tile mid-move)', async () => {
+    const api = makeApi();
+    const home = { id: 'group-0' };
+    api._panels['iframe:okf'] = { id: 'iframe:okf', group: home };
+    const { mod } = await wire(api);
+
+    mod.dockPanelAt('okf', 'KNOWLEDGE', { referenceGroup: home, direction: 'right' });
+
+    expect(api.removePanel).not.toHaveBeenCalled();
+    expect(api.addPanel).not.toHaveBeenCalled();
+  });
+
+  test('is a no-op in simple mode (locked layout)', async () => {
+    document.documentElement.setAttribute('data-ui-mode', 'simple');
+    try {
+      const api = makeApi();
+      const { mod } = await wire(api);
+      mod.dockPanelAt('okf', 'KNOWLEDGE', { referenceGroup: { id: 'g' }, direction: 'right' });
+      expect(api.addPanel).not.toHaveBeenCalled();
+    } finally {
+      document.documentElement.removeAttribute('data-ui-mode');
+    }
   });
 });
 
@@ -577,7 +681,7 @@ describe('initDockSync — wiring, idempotency, late arrival', () => {
 describe('module isolation (vi.resetModules per test)', () => {
   test('exposes exactly its public surface as functions', async () => {
     const mod = await import(SYNC);
-    for (const name of ['withEchoSuppressed', 'dockPanelBesideActive', 'serviceIdOf', 'initDockSync', 'setTileCloseHandler']) {
+    for (const name of ['withEchoSuppressed', 'dockPanelBesideActive', 'dockPanelAt', 'serviceIdOf', 'initDockSync', 'setTileCloseHandler']) {
       expect(typeof mod[name]).toBe('function');
     }
   });

--- a/tests/interfaces/web_terminal/panel-rail.test.mjs
+++ b/tests/interfaces/web_terminal/panel-rail.test.mjs
@@ -113,27 +113,9 @@ describe('createRail', () => {
     expect(entryIds(rail)).toEqual(['okf']);
   });
 
-  test('renders the ＋ add button only when onAdd is given', () => {
+  test('never renders a ＋ inside the rail — the add control is the template\'s sibling #panel-add-btn', () => {
     createRail(rail, PANELS);
     expect(rail.querySelector('.panel-rail-add')).toBeNull();
-
-    createRail(rail, PANELS, { onAdd: () => {} });
-    const add = rail.querySelector('.panel-rail-add');
-    expect(add?.textContent).toBe('＋');
-    expect(add?.getAttribute('aria-label')).toBe('Add panel');
-  });
-
-  test('onAdd fires when the ＋ button is clicked', () => {
-    let clicked = 0;
-    createRail(rail, PANELS, { onAdd: () => { clicked += 1; } });
-    /** @type {HTMLButtonElement} */ (rail.querySelector('.panel-rail-add')).click();
-    expect(clicked).toBe(1);
-  });
-
-  test('the add button stays last, after every entry', () => {
-    createRail(rail, PANELS, { onAdd: () => {} });
-    const last = rail.children[rail.children.length - 1];
-    expect(last.classList.contains('panel-rail-add')).toBe(true);
   });
 });
 
@@ -209,6 +191,101 @@ describe('entry interactions', () => {
     expect(entry.querySelector('.panel-rail-popout')).toBeTruthy();
   });
 
+  test('open-beside affordance renders only when onOpenBeside is provided', () => {
+    createRail(rail, PANELS);
+    expect(getEntry(rail, 'artifacts')?.querySelector('.panel-rail-beside')).toBeNull();
+
+    rail = freshRail();
+    createRail(rail, PANELS, { onOpenBeside: () => {} });
+    expect(getEntry(rail, 'artifacts')?.querySelector('.panel-rail-beside')?.textContent).toBe('⊞');
+  });
+
+  test('clicking open-beside invokes onOpenBeside without activating the entry', () => {
+    /** @type {string[]} */
+    const activated = [];
+    /** @type {string[]} */
+    const beside = [];
+    createRail(rail, PANELS, {
+      onActivate: (id) => activated.push(id),
+      onOpenBeside: (id) => beside.push(id),
+    });
+    /** @type {HTMLElement} */ (
+      /** @type {HTMLElement} */ (getEntry(rail, 'ariel')).querySelector('.panel-rail-beside')
+    ).click();
+    expect(beside).toEqual(['ariel']);
+    expect(activated).toEqual([]);
+  });
+
+});
+
+describe('drag from the rail (onDragStart / onDragEnd)', () => {
+  /** @type {HTMLElement} */
+  let rail;
+  beforeEach(() => {
+    rail = freshRail();
+  });
+
+  /** Build a dragstart-shaped event happy-dom can dispatch (no DragEvent there).
+   *  @param {string} type */
+  function dragEvent(type) {
+    const ev = new Event(type, { bubbles: true, cancelable: true });
+    /** @type {any} */ (ev).dataTransfer = {
+      data: /** @type {Record<string, string>} */ ({}),
+      effectAllowed: '',
+      setData(/** @type {string} */ k, /** @type {string} */ v) { this.data[k] = v; },
+    };
+    return ev;
+  }
+
+  test('entries are draggable only when onDragStart is provided', () => {
+    createRail(rail, PANELS);
+    expect(getEntry(rail, 'ariel')?.getAttribute('draggable')).toBeNull();
+
+    rail = freshRail();
+    createRail(rail, PANELS, { onDragStart: () => true });
+    expect(getEntry(rail, 'ariel')?.getAttribute('draggable')).toBe('true');
+  });
+
+  test('dragstart hands (id, dataTransfer) to onDragStart and marks the source entry', () => {
+    /** @type {any[]} */
+    const calls = [];
+    createRail(rail, PANELS, {
+      onDragStart: (id, dt) => { calls.push([id, dt]); return true; },
+    });
+    const entry = /** @type {HTMLElement} */ (getEntry(rail, 'ariel'));
+    const ev = dragEvent('dragstart');
+    entry.dispatchEvent(ev);
+
+    expect(calls).toEqual([['ariel', /** @type {any} */ (ev).dataTransfer]]);
+    expect(entry.classList.contains('dragging')).toBe(true);
+    expect(ev.defaultPrevented).toBe(false);
+  });
+
+  test('onDragStart returning false cancels the drag (no dragging state, default prevented)', () => {
+    createRail(rail, PANELS, { onDragStart: () => false });
+    const entry = /** @type {HTMLElement} */ (getEntry(rail, 'ariel'));
+    const ev = dragEvent('dragstart');
+    entry.dispatchEvent(ev);
+
+    expect(entry.classList.contains('dragging')).toBe(false);
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  test('dragend clears the dragging state and calls onDragEnd', () => {
+    /** @type {string[]} */
+    const ended = [];
+    createRail(rail, PANELS, {
+      onDragStart: () => true,
+      onDragEnd: (id) => ended.push(id),
+    });
+    const entry = /** @type {HTMLElement} */ (getEntry(rail, 'ariel'));
+    entry.dispatchEvent(dragEvent('dragstart'));
+    expect(entry.classList.contains('dragging')).toBe(true);
+
+    entry.dispatchEvent(dragEvent('dragend'));
+    expect(entry.classList.contains('dragging')).toBe(false);
+    expect(ended).toEqual(['ariel']);
+  });
 });
 
 describe('addEntry (non-destructive)', () => {
@@ -236,11 +313,11 @@ describe('addEntry (non-destructive)', () => {
     expect(artifacts?.classList.contains('disabled')).toBe(false);
   });
 
-  test('inserts before the ＋ button so add stays last', () => {
-    createRail(rail, PANELS, { onAdd: () => {} });
+  test('appends at the end of the rail', () => {
+    createRail(rail, PANELS);
     addEntry(rail, { id: 'lattice', label: 'LATTICE' });
     const last = rail.children[rail.children.length - 1];
-    expect(last.classList.contains('panel-rail-add')).toBe(true);
+    expect(last.getAttribute('data-panel-id')).toBe('lattice');
     expect(entryIds(rail)).toEqual(['artifacts', 'ariel', 'channel-finder', 'lattice']);
   });
 
@@ -266,15 +343,13 @@ describe('removeEntry', () => {
   let rail;
   beforeEach(() => {
     rail = freshRail();
-    createRail(rail, PANELS, { onAdd: () => {} });
+    createRail(rail, PANELS);
   });
 
-  test('removes the entry node, preserving the others and the ＋ button', () => {
+  test('removes the entry node, preserving the others', () => {
     removeEntry(rail, 'ariel');
     expect(entryIds(rail)).toEqual(['artifacts', 'channel-finder']);
     expect(getEntry(rail, 'ariel')).toBeNull();
-    const last = rail.children[rail.children.length - 1];
-    expect(last.classList.contains('panel-rail-add')).toBe(true);
   });
 
   test('a removed entry can be re-added (remove ≠ forget)', () => {

--- a/tests/interfaces/web_terminal/rail-drag.test.mjs
+++ b/tests/interfaces/web_terminal/rail-drag.test.mjs
@@ -1,0 +1,268 @@
+/**
+ * Contract tests for the rail→workspace drag bridge (rail-drag.js):
+ *   npx vitest run tests/interfaces/web_terminal/rail-drag.test.mjs
+ *
+ * rail-drag.js wires HTML5 drags that START on a rail entry into dockview's
+ * external-drag hooks: onUnhandledDragOver accepts our MIME on split targets
+ * only (one panel per tile — tab/header/center geometries never accept), and
+ * onDidDrop resolves the payload + drop position into the caller's
+ * onDropPanel(id, position). It also owns the drag-time iframe shields
+ * (`.dock-dragging` on .main-container + the adapter's inline pointer shield),
+ * raised in railDragStart and lowered in railDragEnd.
+ *
+ * dockview and the collaborators are stubbed at the module boundary, exactly
+ * as in dock-sync.test.mjs.
+ */
+
+import { test, expect, describe, beforeEach, vi } from 'vitest';
+
+const MOD = '../../../src/osprey/interfaces/web_terminal/static/js/rail-drag.js';
+
+const { getDockApi, setIframePointerShield, state } = vi.hoisted(() => ({
+  state: { api: /** @type {any} */ (null) },
+  getDockApi: vi.fn(() => /** @type {any} */ (null)),
+  setIframePointerShield: vi.fn(),
+}));
+getDockApi.mockImplementation(() => state.api);
+
+vi.mock('../../../src/osprey/interfaces/web_terminal/static/js/dock-workspace.js', () => ({
+  getDockApi,
+  defaultServiceWidth: () => 600,
+  setServiceRedock: () => {},
+  onDragGesture: () => [],
+}));
+vi.mock('../../../src/osprey/interfaces/web_terminal/static/js/dock-iframe.js', () => ({
+  setIframePointerShield,
+  PLACEHOLDER_PREFIX: 'iframe:',
+  PLACEHOLDER_COMPONENT: 'dock-iframe-placeholder',
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  getDockApi.mockImplementation(() => state.api);
+  state.api = null;
+  document.body.innerHTML = '';
+  document.documentElement.removeAttribute('data-ui-mode');
+});
+
+/** Fake DockviewApi exposing only the external-dnd hooks rail-drag wires. */
+function makeApi() {
+  /** @type {any} */
+  const api = {
+    /** @type {null | ((e: any) => void)} */ _overCb: null,
+    /** @type {null | ((e: any) => void)} */ _dropCb: null,
+  };
+  api.onUnhandledDragOver = vi.fn((/** @type {any} */ cb) => {
+    api._overCb = cb;
+    return { dispose() {} };
+  });
+  api.onDidDrop = vi.fn((/** @type {any} */ cb) => {
+    api._dropCb = cb;
+    return { dispose() {} };
+  });
+  return api;
+}
+
+/** An UnhandledDragOverEvent-shaped stub carrying our MIME (or not). */
+function overEvent({ target = 'content', position = 'right', withMime = true } = {}) {
+  return {
+    nativeEvent: { dataTransfer: { types: withMime ? ['application/x-osprey-panel'] : ['text/plain'] } },
+    target,
+    position,
+    accepted: false,
+    accept() { this.accepted = true; },
+  };
+}
+
+/** A DidDrop-shaped stub whose dataTransfer serves the payload on getData.
+ *  @param {{id?: string, position?: string, group?: any, withMime?: boolean}} [opts] */
+function dropEvent({ id = 'ariel', position = 'right', group = { id: 'g1' }, withMime = true } = {}) {
+  return {
+    nativeEvent: {
+      dataTransfer: {
+        getData: (/** @type {string} */ k) =>
+          withMime && k === 'application/x-osprey-panel' ? id : '',
+      },
+    },
+    position,
+    group,
+  };
+}
+
+/** @param {any} api */
+async function wire(api, onDropPanel = vi.fn()) {
+  state.api = api;
+  const container = document.createElement('div');
+  container.className = 'main-container';
+  document.body.appendChild(container);
+  const mod = await import(MOD);
+  mod.initRailDrag({ onDropPanel });
+  return { mod, container, onDropPanel };
+}
+
+describe('drag-over acceptance (paints dockview\'s drop overlay)', () => {
+  test('accepts a rail drag on a split geometry', async () => {
+    const api = makeApi();
+    await wire(api);
+    const e = overEvent({ target: 'content', position: 'right' });
+    api._overCb(e);
+    expect(e.accepted).toBe(true);
+  });
+
+  test('accepts edge-of-grid targets', async () => {
+    const api = makeApi();
+    await wire(api);
+    const e = overEvent({ target: 'edge', position: 'left' });
+    api._overCb(e);
+    expect(e.accepted).toBe(true);
+  });
+
+  test('never accepts stacking geometries (tab, header space, center)', async () => {
+    const api = makeApi();
+    await wire(api);
+    for (const e of [
+      overEvent({ target: 'tab' }),
+      overEvent({ target: 'header_space' }),
+      overEvent({ target: 'content', position: 'center' }),
+    ]) {
+      api._overCb(e);
+      expect(e.accepted).toBe(false);
+    }
+  });
+
+  test('ignores foreign drags without the rail MIME (e.g. a file drag)', async () => {
+    const api = makeApi();
+    await wire(api);
+    const e = overEvent({ withMime: false });
+    api._overCb(e);
+    expect(e.accepted).toBe(false);
+  });
+});
+
+describe('drop routing', () => {
+  test('resolves the payload and hands (id, {referenceGroup, direction}) to onDropPanel', async () => {
+    const api = makeApi();
+    const group = { id: 'g1' };
+    const { onDropPanel } = await wire(api);
+
+    api._dropCb(dropEvent({ id: 'okf', position: 'bottom', group }));
+
+    // Overlay 'bottom' translates to addPanel's 'below' — the two vocabularies
+    // differ on the vertical axis and the untranslated value throws.
+    expect(onDropPanel).toHaveBeenCalledExactlyOnceWith('okf', {
+      referenceGroup: group,
+      direction: 'below',
+    });
+  });
+
+  test('overlay "top" translates to direction "above"', async () => {
+    const api = makeApi();
+    const group = { id: 'g1' };
+    const { onDropPanel } = await wire(api);
+
+    api._dropCb(dropEvent({ id: 'okf', position: 'top', group }));
+
+    expect(onDropPanel).toHaveBeenCalledExactlyOnceWith('okf', {
+      referenceGroup: group,
+      direction: 'above',
+    });
+  });
+
+  test('a groupless (grid-edge) drop passes a direction-only position', async () => {
+    const api = makeApi();
+    const { onDropPanel } = await wire(api);
+
+    api._dropCb(dropEvent({ id: 'okf', position: 'left', group: null }));
+
+    expect(onDropPanel).toHaveBeenCalledExactlyOnceWith('okf', { direction: 'left' });
+  });
+
+  test('ignores drops without the rail MIME payload', async () => {
+    const api = makeApi();
+    const { onDropPanel } = await wire(api);
+    api._dropCb(dropEvent({ withMime: false }));
+    expect(onDropPanel).not.toHaveBeenCalled();
+  });
+
+  test('a center drop never places (stacking backstop)', async () => {
+    const api = makeApi();
+    const { onDropPanel } = await wire(api);
+    api._dropCb(dropEvent({ position: 'center' }));
+    expect(onDropPanel).not.toHaveBeenCalled();
+  });
+});
+
+describe('railDragStart / railDragEnd — payload + shields', () => {
+  /** @returns {any} minimal DataTransfer stand-in */
+  function fakeDT() {
+    return {
+      data: /** @type {Record<string, string>} */ ({}),
+      effectAllowed: '',
+      setData(/** @type {string} */ k, /** @type {string} */ v) { this.data[k] = v; },
+    };
+  }
+
+  test('stamps the MIME payload, raises both shields, and reports accepted', async () => {
+    const api = makeApi();
+    const { mod, container } = await wire(api);
+    const dt = fakeDT();
+
+    expect(mod.railDragStart('ariel', dt)).toBe(true);
+    expect(dt.data['application/x-osprey-panel']).toBe('ariel');
+    expect(dt.data['text/plain']).toBe('ariel');
+    expect(container.classList.contains('dock-dragging')).toBe(true);
+    expect(setIframePointerShield).toHaveBeenCalledExactlyOnceWith(true);
+  });
+
+  test('railDragEnd lowers both shields', async () => {
+    const api = makeApi();
+    const { mod, container } = await wire(api);
+    mod.railDragStart('ariel', fakeDT());
+
+    mod.railDragEnd();
+
+    expect(container.classList.contains('dock-dragging')).toBe(false);
+    expect(setIframePointerShield).toHaveBeenLastCalledWith(false);
+  });
+
+  test('cancels in simple mode (locked layout)', async () => {
+    const api = makeApi();
+    const { mod, container } = await wire(api);
+    document.documentElement.setAttribute('data-ui-mode', 'simple');
+
+    expect(mod.railDragStart('ariel', fakeDT())).toBe(false);
+    expect(container.classList.contains('dock-dragging')).toBe(false);
+    expect(setIframePointerShield).not.toHaveBeenCalled();
+  });
+
+  test('cancels in fallback mode (no dock to drop into)', async () => {
+    const { mod } = await wire(null);
+    expect(mod.railDragStart('ariel', fakeDT())).toBe(false);
+  });
+});
+
+describe('initRailDrag — wiring, idempotency, late arrival', () => {
+  test('is idempotent — a second init does not double-wire', async () => {
+    const api = makeApi();
+    const { mod } = await wire(api);
+    mod.initRailDrag({ onDropPanel: vi.fn() });
+    expect(api.onUnhandledDragOver).toHaveBeenCalledTimes(1);
+    expect(api.onDidDrop).toHaveBeenCalledTimes(1);
+  });
+
+  test('retries and wires once a late DockviewApi arrives', async () => {
+    vi.useFakeTimers();
+    try {
+      const mod = await import(MOD);
+      mod.initRailDrag({ onDropPanel: vi.fn() });
+      const api = makeApi();
+      state.api = api;
+      expect(api.onDidDrop).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(150);
+      expect(api.onDidDrop).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/interfaces/web_terminal/test_panels_browser.py
+++ b/tests/interfaces/web_terminal/test_panels_browser.py
@@ -252,11 +252,10 @@ def _open_page(browser, base_url: str) -> Page:
 # Dock DOM helpers
 # ---------------------------------------------------------------------------
 #
-# A service tile's strip renders NO text — it is a bare drag grip, since the
-# panel's name is on its rail entry and its close/popout controls are that
-# entry's hover corners (dock-tab.js). Tabs are therefore addressed by the
-# accessible name the strip carries instead, which dock-tab.js sets from the
-# dockview panel title and keeps current through onDidTitleChange.
+# Every tile renders the same header bar (dock-tab.js): drag grip, identity,
+# close. A service tile's identity is its visible .tile-tab-title, mirrored
+# into the bar's aria-label and kept current through onDidTitleChange — the
+# aria-label is the stable handle these tests address tabs by.
 # The terminal tab is the one exception: it renders no aria-label — it adopts
 # the live .terminal-header, which names it — so it is identified by that
 # adoption and given the synthetic "SESSION" label below, the stable handle for
@@ -333,9 +332,9 @@ _STRIP_HEIGHT_JS = r"""(terminal) => {
 def _strip_height(page: Page, *, terminal: bool) -> int:
     """Rendered height of a tile's header strip, in px.
 
-    The two tile kinds are sized differently on purpose: a service tile gets a
-    bare grip strip, the terminal a full bar whose content earns the height
-    (dockview-overrides.css). Returns -1 when no such tile is docked.
+    Every tile carries the same fixed-height bar in expert mode
+    (dockview-overrides.css); simple mode collapses the service bars to zero.
+    Returns -1 when no such tile is docked.
     """
     return page.evaluate(_STRIP_HEIGHT_JS, terminal)
 
@@ -363,24 +362,17 @@ def _track_panel_posts(page: Page) -> list[str]:
 
 
 def _open_second_tile(page: Page, base_url: str, panel_id: str, label: str) -> None:
-    """Open ``panel_id`` as a SECOND tile beside the current one via the "+" menu.
+    """Open ``panel_id`` as a SECOND tile beside the current one via the rail's ⊞.
 
     A rail click would REPLACE the focused tile's panel (one panel per tile), so
-    tests that need two service tiles side by side go through the add menu:
-    remove the panel from the rail server-side (its entry disappears — the rail
-    is the membership list), then re-add it from the "+" popover, whose
-    expert-mode path docks it beside the active group.
+    tests that need two service tiles side by side use the entry's hover ⊞
+    ("open in a new tile") corner — the open-beside verb. ``base_url`` is
+    unused (kept so call sites read uniformly with the old add-menu dance).
     """
-    r = requests.post(
-        f"{base_url}/api/panel-visibility",
-        json={"panel": panel_id, "visible": False},
-    )
-    assert r.status_code == 200
-    expect(page.locator(f'button.panel-rail-button[data-panel-id="{panel_id}"]')).to_have_count(
-        0, timeout=5_000
-    )
-    page.locator("#panel-add-btn").click()
-    page.locator(f'.panel-add-item[data-panel-id="{panel_id}"]').click()
+    del base_url  # the ⊞ path is purely client-side
+    entry = page.locator(f'button.panel-rail-button[data-panel-id="{panel_id}"]')
+    entry.hover()
+    entry.locator(".panel-rail-beside").click()
     expect(_service_tab(page, label)).to_have_count(1, timeout=5_000)
 
 
@@ -389,13 +381,11 @@ def _drag_with_dock_shield(page: Page, source, target, **kwargs) -> None:
 
     During a genuine pointer drag, dockview's onWillDragPanel raises the drag
     state (dock-workspace.js + dock-iframe.js): the ``.dock-dragging`` class on
-    .main-container — which force-reveals collapsed single-tab strips so their
-    tabs are drop targets — and the iframe pointer shield, so overlay iframes
-    can't swallow the drag events over a covered group. Playwright's synthetic
+    .main-container and the iframe pointer shield, so overlay iframes can't
+    swallow the drag events over a covered group. Playwright's synthetic
     drag_to hit-tests the drop point WITHOUT any dragstart having raised that
-    state, so a drop onto a collapsed tab strip resolves to the wrong zone and
-    a drop over an overlay iframe is judged "intercepted" and times out.
-    Pre-raise both halves for the gesture, then restore them.
+    state, so a drop over an overlay iframe is judged "intercepted" and times
+    out. Pre-raise both halves for the gesture, then restore them.
     """
     shield = (
         "(v) => { document.querySelectorAll('.dock-iframe-overlay iframe')"
@@ -711,9 +701,8 @@ def test_dock_tab_close_is_local_vacate_no_posts(tmp_path, chromium_browser):
     retiring the data-viz tile clears the local active state, but the panel
     keeps its rail membership — its entry stays in the rail at full brightness
     and NO panel POST fires (neither visibility nor a bounced focus). The
-    gesture lives on the rail because a service tile's strip is a bare drag
-    grip with no controls of its own; the entry's "×" corner is the separate,
-    membership-removing action.
+    re-click is the toggle shortcut equivalent of the tile header's own "×";
+    the entry's "×" corner is the separate, membership-removing action.
     """
     workspace = tmp_path / "_agent_data"
     workspace.mkdir()
@@ -725,8 +714,6 @@ def test_dock_tab_close_is_local_vacate_no_posts(tmp_path, chromium_browser):
     ) as (base_url, _app):
         page = _open_page(chromium_browser, base_url)
         _focus_service_panel(page, "data-viz", "DATA VIZ")
-        # A service tile carries no controls at all — only the drag grip.
-        expect(_service_tab(page, "DATA VIZ").locator(".tile-tab-close")).to_have_count(0)
         page.wait_for_timeout(600)
 
         posts = _track_panel_posts(page)
@@ -741,6 +728,163 @@ def test_dock_tab_close_is_local_vacate_no_posts(tmp_path, chromium_browser):
         expect(rail_entry).not_to_have_class(re.compile(r"\bactive\b"), timeout=5_000)
         page.wait_for_timeout(600)
         assert posts == [], f"a local tile close must not POST, got {posts}"
+
+        page.close()
+
+
+def test_service_tile_close_button_is_local_vacate(tmp_path, chromium_browser):
+    """The service tile header's own "×" closes JUST the tile — never membership.
+
+    Every tile now carries a close control (dock-tab.js). Clicking a service
+    tile's "×" retires the tile locally: the rail entry survives at full
+    brightness with no POST of any kind, and a plain rail click brings the
+    panel straight back.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _live_server(
+        workspace,
+        enabled_panels={"artifacts"},
+        custom_panels=[_CUSTOM_DATA_VIZ],
+    ) as (base_url, _app):
+        page = _open_page(chromium_browser, base_url)
+        _focus_service_panel(page, "data-viz", "DATA VIZ")
+        # The unified bar: grip + visible title + close (popout stays rail-only).
+        tab = _service_tab(page, "DATA VIZ")
+        expect(tab.locator(".tile-tab-grip")).to_have_count(1)
+        expect(tab.locator(".tile-tab-title")).to_have_text("DATA VIZ")
+        expect(tab.locator(".tile-tab-close")).to_have_count(1)
+        expect(tab.locator(".tile-tab-popout")).to_have_count(0)
+        page.wait_for_timeout(600)
+
+        posts = _track_panel_posts(page)
+        tab.locator(".tile-tab-close").click()
+
+        # The tile is gone; the rail entry survives, inactive; zero POSTs.
+        expect(_service_tab(page, "DATA VIZ")).to_have_count(0, timeout=5_000)
+        rail_entry = page.locator('button.panel-rail-button[data-panel-id="data-viz"]')
+        expect(rail_entry).to_be_attached(timeout=5_000)
+        expect(rail_entry).not_to_have_class(re.compile(r"\bactive\b"), timeout=5_000)
+        page.wait_for_timeout(600)
+        assert posts == [], f"a tile close must not POST, got {posts}"
+
+        # One rail click reopens the panel — close is never a removal.
+        rail_entry.click()
+        expect(_service_tab(page, "DATA VIZ")).to_have_count(1, timeout=5_000)
+        expect(_overlay_iframe(page, "data-viz")).to_be_visible(timeout=5_000)
+
+        page.close()
+
+
+def test_open_beside_moves_docked_panel_instead_of_duplicating(tmp_path, chromium_browser):
+    """⊞ on an ALREADY-OPEN panel moves its tile beside the active one.
+
+    The old dance (remove from rail, re-add via "+") is gone: dockPanelAt's
+    move semantics relocate the existing placeholder, so the panel never
+    duplicates and never loses its rail membership.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _live_server(
+        workspace,
+        enabled_panels={"artifacts"},
+        custom_panels=[_CUSTOM_DATA_VIZ],
+    ) as (base_url, _app):
+        page = _open_page(chromium_browser, base_url)
+        expect(_service_tab(page, "WORKSPACE")).to_have_count(1, timeout=10_000)
+        _open_second_tile(page, base_url, "data-viz", "DATA VIZ")
+        # Focus the artifacts tile so data-viz's own tile is NOT the active one.
+        _service_tab(page, "WORKSPACE").click()
+        expect(
+            page.locator('button.panel-rail-button[data-panel-id="artifacts"].active')
+        ).to_have_count(1, timeout=5_000)
+        groups_before = len(_dock_groups(page))
+
+        # Act — ⊞ on the already-open data-viz entry.
+        entry = page.locator('button.panel-rail-button[data-panel-id="data-viz"]')
+        entry.hover()
+        entry.locator(".panel-rail-beside").click()
+
+        # Still exactly one data-viz tab, and the tile count is unchanged —
+        # the tile MOVED (beside artifacts), it was not duplicated.
+        expect(_service_tab(page, "DATA VIZ")).to_have_count(1, timeout=5_000)
+        assert len(_dock_groups(page)) == groups_before, _dock_groups(page)
+        expect(_overlay_iframe(page, "data-viz")).to_be_visible(timeout=5_000)
+
+        page.close()
+
+
+# Synthesize the HTML5 drag a rail entry emits, dropped in the bottom quadrant
+# of the terminal group's content — Playwright's mouse-based drag_to cannot
+# produce HTML5 dnd events, so the sequence is dispatched in-page with a real
+# DataTransfer. dragstart runs panel-rail's real handler (payload + shields);
+# dragover/drop land on dockview's group drop target, which fires
+# onUnhandledDragOver (accepted by rail-drag.js) and then onDidDrop. The drop
+# only registers once a dragover has been PROCESSED (dockview settles its
+# overlay state asynchronously), hence the repeated dragover with settles
+# between — a single dragover followed immediately by drop is silently ignored.
+_RAIL_DRAG_DROP_JS = """async (panelId) => {
+    const entry = document.querySelector(
+        `button.panel-rail-button[data-panel-id="${panelId}"]`);
+    const dt = new DataTransfer();
+    entry.dispatchEvent(new DragEvent('dragstart',
+        { bubbles: true, cancelable: true, dataTransfer: dt }));
+    const term = [...document.querySelectorAll('.dv-groupview')].find(g =>
+        g.querySelector('.terminal-header'));
+    const content = term.querySelector('.dv-content-container');
+    const r = content.getBoundingClientRect();
+    // Just inside the grid's bottom edge band → dockview resolves
+    // { target: 'edge', position: 'bottom' } — a split against the grid edge
+    // (the group-targeted variant is covered by the ⊞ tests + unit suite;
+    // points deeper inside the content resolve 'center', which is refused).
+    const x = r.left + r.width / 2;
+    const y = r.bottom - 5;
+    const opts = { bubbles: true, cancelable: true, dataTransfer: dt,
+                   clientX: x, clientY: y };
+    const target = document.elementFromPoint(x, y) ?? content;
+    const settle = () => new Promise((res) => setTimeout(res, 100));
+    target.dispatchEvent(new DragEvent('dragenter', opts));
+    target.dispatchEvent(new DragEvent('dragover', opts));
+    await settle();
+    target.dispatchEvent(new DragEvent('dragover', opts));
+    await settle();
+    target.dispatchEvent(new DragEvent('drop', opts));
+    entry.dispatchEvent(new DragEvent('dragend', { bubbles: true, dataTransfer: dt }));
+}"""
+
+
+def test_drag_rail_entry_to_tile_edge_opens_split(tmp_path, chromium_browser):
+    """Dragging a rail entry onto a tile edge opens the panel as a new tile there.
+
+    The precise half of the open-beside verb (rail-drag.js): the entry's HTML5
+    drag carries the panel id; dropping it near the bottom edge of the terminal
+    tile splits that tile and the panel fills the new half, then the normal
+    reveal tail focuses it.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _live_server(
+        workspace,
+        enabled_panels={"artifacts"},
+        custom_panels=[_CUSTOM_DATA_VIZ],
+    ) as (base_url, _app):
+        page = _open_page(chromium_browser, base_url)
+        expect(_service_tab(page, "WORKSPACE")).to_have_count(1, timeout=10_000)
+        groups_before = len(_dock_groups(page))
+
+        page.evaluate(_RAIL_DRAG_DROP_JS, "data-viz")
+
+        # A new tile exists holding data-viz, below the terminal group.
+        expect(_service_tab(page, "DATA VIZ")).to_have_count(1, timeout=5_000)
+        assert len(_dock_groups(page)) == groups_before + 1, _dock_groups(page)
+        expect(_overlay_iframe(page, "data-viz")).to_be_visible(timeout=5_000)
+        groups = _dock_groups(page)
+        term = next(g for g in groups if g["tabs"] == ["SESSION"])
+        dv = next(g for g in groups if g["tabs"] == ["DATA VIZ"])
+        assert dv["y"] > term["y"], (term, dv)
 
         page.close()
 
@@ -1813,12 +1957,11 @@ _TERMINAL_STRIP_H_JS = """() => {
 
 
 def test_tile_bar_fixed_height_no_hover_reflow(tmp_path, chromium_browser):
-    """Tile header strips never change height — hover must not reflow content.
+    """Tile header bars never change height — hover must not reflow content.
 
-    Replaces the retired collapse/reveal behavior. Both strips are fixed
-    height, at two different sizes: the terminal's bar holds real content,
-    while a service tile keeps only a drag grip. Hovering either (the old
-    expand trigger) must leave the height and the content's top edge unmoved.
+    Replaces the retired collapse/reveal behavior. Every tile carries the same
+    fixed-height bar (grip + identity + close); hovering one (the old expand
+    trigger) must leave the height and the content's top edge unmoved.
     """
     workspace = tmp_path / "_agent_data"
     workspace.mkdir()
@@ -1853,26 +1996,22 @@ def test_tile_bar_fixed_height_no_hover_reflow(tmp_path, chromium_browser):
             == content_top
         ), "tile content shifted on hover"
 
-        # A service tile carries the grip and nothing else — its name is on
-        # the rail entry and its close/popout are that entry's hover corners.
+        # A service tile carries the unified bar: grip + visible title + close
+        # (popout stays a rail-entry affordance).
         ws = _service_tab(page, "WORKSPACE")
         expect(ws.locator(".tile-tab-grip")).to_have_count(1)
-        expect(ws.locator(".tile-tab-close")).to_have_count(0)
+        expect(ws.locator(".tile-tab-title")).to_have_text("WORKSPACE")
+        expect(ws.locator(".tile-tab-close")).to_have_count(1)
         expect(ws.locator(".tile-tab-popout")).to_have_count(0)
-        expect(ws.locator(".tile-tab-title")).to_have_count(0)
 
-        # It is also FAR shorter than the terminal's — the point of the split.
-        # Asserted against an absolute ceiling, not merely "< the terminal's":
-        # dockview's stock strip is 35px and the terminal's is 36px, so a
-        # relative check passes even when our height rule never applies at all.
+        # Same bar height as the terminal's — one header system, one size.
         svc_h = _strip_height(page, terminal=False)
-        assert 0 < svc_h <= 12, f"service strip should be a grip, got {svc_h}px"
-        assert svc_h < h_rest, f"service strip {svc_h}px vs terminal {h_rest}px"
+        assert svc_h == h_rest, f"service bar {svc_h}px vs terminal {h_rest}px"
 
         # And it does not reflow on hover either.
         ws.hover()
         page.wait_for_timeout(300)
-        assert _strip_height(page, terminal=False) == svc_h, "service strip grew on hover"
+        assert _strip_height(page, terminal=False) == svc_h, "service bar grew on hover"
 
         page.close()
 

--- a/tests/interfaces/web_terminal/tile-tab.test.mjs
+++ b/tests/interfaces/web_terminal/tile-tab.test.mjs
@@ -1,9 +1,8 @@
 /**
  * Contract tests for the tile-tab renderer (dock-tab.js): the custom dockview
- * tab that IS each tile's header bar. Service tiles render a bare drag grip —
- * their name is on the rail entry and their close/popout controls are that
- * entry's hover corners. The terminal tile keeps a populated bar: grip +
- * adopted .terminal-header + close. Run:
+ * tab that IS each tile's header bar. Every tile gets the same bar — drag
+ * grip, identity, close. Service tiles carry a visible `.tile-tab-title`;
+ * the terminal tile adopts the live .terminal-header instead. Run:
  *   npx vitest run tests/interfaces/web_terminal/tile-tab.test.mjs
  */
 import { test, expect, describe, beforeEach, vi } from 'vitest';
@@ -25,19 +24,39 @@ describe('tile-tab renderer', () => {
     vi.restoreAllMocks();
   });
 
-  test('service tab renders the grip and nothing else', async () => {
+  test('service tab renders grip, visible title, and close', async () => {
     const { createTileTab } = await import(MOD);
     const tab = createTileTab('iframe:ariel');
     tab.init({ title: 'ARIEL', params: {}, api: fakeApi() });
 
     expect(tab.element.classList.contains('tile-tab')).toBe(true);
     expect(tab.element.querySelector('.tile-tab-grip')).toBeTruthy();
-    // The affordances that used to live here now belong to the rail entry.
-    expect(tab.element.querySelector('.tile-tab-title')).toBeNull();
+    // One header grammar for every tile: name on the bar, close on the bar.
+    expect(tab.element.querySelector('.tile-tab-title')?.textContent).toBe('ARIEL');
+    expect(tab.element.querySelector('.tile-tab-close')).toBeTruthy();
+    expect(tab.element.querySelector('.tile-tab-actions')).toBeTruthy();
+    // Popout stays a rail-entry affordance — never on the tile.
     expect(tab.element.querySelector('.tile-tab-popout')).toBeNull();
-    expect(tab.element.querySelector('.tile-tab-close')).toBeNull();
-    expect(tab.element.querySelector('.tile-tab-actions')).toBeNull();
-    expect(tab.element.textContent).toBe(''); // no visible text at all
+  });
+
+  test('service close click calls api.close()', async () => {
+    const { createTileTab } = await import(MOD);
+    const api = fakeApi();
+    const tab = createTileTab('iframe:ariel');
+    tab.init({ title: 'ARIEL', params: {}, api });
+    /** @type {HTMLElement} */ (tab.element.querySelector('.tile-tab-close'))
+      .dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    expect(api.close).toHaveBeenCalledTimes(1);
+  });
+
+  test('service close pointerdown is prevented so it cannot start a tile drag', async () => {
+    const { createTileTab } = await import(MOD);
+    const tab = createTileTab('iframe:ariel');
+    tab.init({ title: 'ARIEL', params: {}, api: fakeApi() });
+    const ev = new MouseEvent('pointerdown', { bubbles: true, cancelable: true });
+    /** @type {HTMLElement} */ (tab.element.querySelector('.tile-tab-close'))
+      .dispatchEvent(ev);
+    expect(ev.defaultPrevented).toBe(true);
   });
 
   test('the strip carries the dockview panel id as a stable handle', async () => {
@@ -47,7 +66,7 @@ describe('tile-tab renderer', () => {
     expect(tab.element.dataset.panelId).toBe('iframe:ariel');
   });
 
-  test('the title becomes the strip\'s accessible name, not visible text', async () => {
+  test('the title is visible text AND the accessible name, kept live on rename', async () => {
     const { createTileTab } = await import(MOD);
     const api = fakeApi();
     /** @type {(e: {title: string}) => void} */ let onTitle = () => {};
@@ -56,9 +75,10 @@ describe('tile-tab renderer', () => {
     tab.init({ title: 'KNOWLEDGE', params: {}, api });
 
     expect(tab.element.getAttribute('aria-label')).toBe('KNOWLEDGE');
-    expect(tab.element.textContent).toBe('');
+    expect(tab.element.querySelector('.tile-tab-title')?.textContent).toBe('KNOWLEDGE');
     onTitle({ title: 'RENAMED' });
     expect(tab.element.getAttribute('aria-label')).toBe('RENAMED');
+    expect(tab.element.querySelector('.tile-tab-title')?.textContent).toBe('RENAMED');
   });
 
   test('the terminal bar takes no aria-label — its adopted header names it', async () => {


### PR DESCRIPTION
Every workspace tile now renders the same header bar — six-dot drag grip, panel name, and a close button that retires just that tile (the panel keeps its rail entry; one click reopens it). Panels open side by side as first-class gestures: drag a rail icon onto a tile edge to split exactly there, or use the entry's hover ⊞ "open in a new tile" corner. Opening an already-open panel beside moves its tile instead of duplicating it.

Placement is one shared verb (`dockPanelAt`) behind the add-menu, the rail corner, and the new rail drag-and-drop; tab→panel resolution now reads the id stamped on the tile bar instead of mapping by DOM index. One panel per tile stays an invariant — stacking drop geometries are refused for external drags exactly as for dockview-native ones — and simple mode keeps its locked layout (no drag, no open-beside, service headers collapsed).

## How it hangs together

```text
              RAIL ENTRY (panel-rail.js)
     click           ⊞ corner            drag (HTML5)
       │                │                    │  dragstart: MIME payload
       ▼                ▼                    ▼  + iframe pointer shields
  activateTab    openPanelBeside        rail-drag.js
  (replace in    (panel-manager.js)       │ onUnhandledDragOver →
   active tile)         │                 │   accept split targets only
       │                ▼                 │ onDidDrop → group + position
       │        dockPanelBesideActive     │   (top/bottom → above/below)
       │                └───────┬─────────┘
       │                        ▼
       │              dockPanelAt (dock-sync.js)
       │              move placeholder if docked, add if new
       ▼                        ▼
     dockview grid ◀── empty placeholder tiles
       │               (dock-iframe.js overlay iframes follow their rects)
       ▼
  TileTab header bar (dock-tab.js):  ⠿ grip · panel name · ×
       × click → capture handler (dock-sync.js) → local vacate, no POST
       (rail entry survives; rail "×" alone removes membership)
```