### PR TITLE
feat(cli): profile and persona ergonomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ Compatibility is documented in release notes, not encoded in the version string.
 - The emitted `profile.yml` header now opens with a lifecycle diagram:
   profile (edit) → build → project (regenerable) → deploy → running containers.
 
+### Changed
+
+- `osprey profile new` now writes persona profiles as small deltas
+  (`extends: ../profile.yml`) instead of full standalone copies: edit the host
+  profile once and every persona inherits the change, while each persona file
+  keeps its own capability posture (e.g. `control_system.writes_enabled:
+  false`) pinned explicitly. Model-selection choices baked at materialization
+  time — and `tier` — now reach personas through inheritance.
+- The shipped web-terminal rosters spell out `name`/`index`/`persona` on every
+  user entry instead of bare-string shorthand for the first user. Behavior is
+  unchanged; already-deployed projects will see a one-time profile-staleness
+  advisory from the preset content change.
+
 ### Fixed
 
 - Built projects' `config.yml` no longer misplaces section comments: entries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ## [Unreleased]
 
+### Added
+
+- `osprey profile new --force` replaces an existing profile directory, making
+  the materialize-and-build one-liner rerunnable. It only replaces a directory
+  that is a materialized profile (or empty), and deletes nothing until the new
+  profile has fully rendered — a failed run leaves the old directory intact.
+
 ### Fixed
 
 - Built projects' `config.yml` no longer misplaces section comments: entries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Compatibility is documented in release notes, not encoded in the version string.
   the materialize-and-build one-liner rerunnable. It only replaces a directory
   that is a materialized profile (or empty), and deletes nothing until the new
   profile has fully rendered — a failed run leaves the old directory intact.
+- The emitted `profile.yml` header now opens with a lifecycle diagram:
+  profile (edit) → build → project (regenerable) → deploy → running containers.
 
 ### Fixed
 

--- a/docs/source/cli-reference/index.rst
+++ b/docs/source/cli-reference/index.rst
@@ -84,13 +84,20 @@ durable, facility-owned input to ``osprey build`` — see
    ``TARGET_DIR`` is created and populated with a standalone ``profile.yml``
    (the preset's full configuration written out explicitly, no ``extends:``),
    the preset's ``data/`` tree copied verbatim, an ``overlays/`` seed, and a
-   ``README.md``. Refuses to overwrite an existing directory.
+   ``README.md``. Refuses to overwrite an existing directory unless ``--force``
+   is given.
 
    ``-O, --override PATH`` — Layer a YAML file on top of the preset before
    writing (repeatable, in order).
 
    ``--set KEY.PATH=VALUE`` — Inline override baked into the written profile
    (repeatable). RHS is parsed as YAML. Wins over ``-O`` at the same key.
+
+   ``--force`` — Replace an existing profile directory, deleting its current
+   contents including any edits you made there. Only a directory that is a
+   materialized profile (contains ``profile.yml``) or is empty is replaced;
+   anything else is refused. Nothing is deleted until the replacement profile
+   has fully rendered, so a failed run leaves the old directory untouched.
 
 ``osprey profile validate TARGET``
    Check a profile without building anything. ``TARGET`` is a profile

--- a/docs/source/how-to/build-profiles.rst
+++ b/docs/source/how-to/build-profiles.rst
@@ -132,14 +132,20 @@ directory alongside ``profile.yml``:
        readonly.yml       # a read-only terminal
        readwrite.yml      # a write-capable terminal
 
-Each persona profile carries ``data: ../data``, so the whole stack reads the
-single data tree above it — edit ``data/`` once and every persona picks the
-change up on its next build, with no per-persona copy to keep in sync. The
-host ``profile.yml`` points at these files by path, so keep the names in step
-if you rename one.
+Each persona profile is a small *delta* over the host: it begins with
+``extends: ../profile.yml``, so every setting in the host profile — including
+any edit you make there later — applies to the persona too, and the persona
+file lists only what makes it different (for the read-only persona, chiefly
+``control_system.writes_enabled: false``). It also carries ``data: ../data``,
+so the whole stack reads the single data tree above it — edit ``data/`` once
+and every persona picks the change up on its next build. The host
+``profile.yml`` points at these files by path, so keep the names in step if
+you rename one, and note that renaming or moving ``profile.yml`` itself breaks
+the personas' ``extends`` reference.
 
 They are ordinary profiles: edit one to change what that persona's terminal
-can do, validate it on its own, or build it directly.
+can do, validate it on its own to see the fully resolved result, or build it
+directly.
 
 .. code-block:: bash
 

--- a/src/osprey/cli/build_profile_emit.py
+++ b/src/osprey/cli/build_profile_emit.py
@@ -781,6 +781,96 @@ def _replace_header(text: str, header: str) -> str:
     return header.rstrip("\n") + "\n\n" + "\n".join(lines[body_start:]).rstrip("\n") + "\n"
 
 
+def emit_persona_delta_yaml(
+    preset_name: str,
+    profile_name: str,
+    profile_filename: str,
+    host_filename: str = "profile.yml",
+) -> str:
+    """Render a persona sibling as a DELTA over the materialized host profile.
+
+    The bundled persona presets are already deltas — a handful of keys over
+    their base preset, each carrying its own explanatory comment. This
+    emission keeps that shape and rebases it: the preset's raw text is reused
+    comments-and-all, with ``extends`` repointed from the bundled base preset
+    at the host ``profile.yml`` one directory up, the display ``name``
+    retitled, and ``data`` re-anchored on the host's tree (relative paths
+    resolve against the file that names them, so the inherited ``data: data``
+    would otherwise look inside ``personas/``).
+
+    Callers must only pass a ``preset_name`` whose ``extends`` chain reaches
+    the host profile's source preset
+    (:func:`~.build_profile_presets._preset_extends_chain_reaches`); rebasing
+    any other preset onto the host would change what it resolves to. Presets
+    off that chain keep the flattened :func:`emit_standalone_profile_yaml`
+    path.
+
+    Args:
+        preset_name: Bundled persona preset whose raw text is the delta body.
+        profile_name: Display name for the emitted persona profile.
+        profile_filename: Display path (``my-profile/personas/readonly.yml``)
+            for the header's validate hint.
+        host_filename: The host profile's file name one directory up.
+
+    Returns:
+        Complete persona profile text: ``extends: ../<host_filename>``, the
+        preset's own commented overrides, and the shared-tree ``data`` anchor.
+
+    Raises:
+        BuildProfileError: If the preset is unknown or declares no ``extends``
+            line to rebase.
+    """
+    raw, preset_path = _load_preset_raw(preset_name)
+    if not isinstance(raw.get("extends"), str) or not raw["extends"]:
+        raise BuildProfileError(
+            f"Preset {preset_name!r} declares no extends chain — it cannot be "
+            f"emitted as a delta over a host profile."
+        )
+    host_ref = f"../{host_filename}"
+
+    body: list[str] = []
+    titled = False
+    for line in preset_path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("extends:"):
+            body.append(f"extends: {host_ref}")
+        elif line.startswith("name:"):
+            body.append(f"name: {profile_name}")
+            titled = True
+        elif line.startswith("data:"):
+            # The shared-tree anchor is appended below with its own comment; a
+            # second top-level ``data`` key would be invalid YAML.
+            continue
+        else:
+            body.append(line)
+    text = "\n".join(body).rstrip("\n") + "\n"
+
+    preset_hash = compute_preset_hash(preset_name) or "(unavailable)"
+    header = (
+        f"# {profile_name} — persona profile, a delta over {host_ref}\n"
+        f"#\n"
+        f"# `extends: {host_ref}` inherits every setting from the host profile —\n"
+        f"# including any edit you make there — and the keys below are this\n"
+        f"# persona's only differences. See the resolved whole with:\n"
+        f"#   osprey profile validate {profile_filename}\n"
+        f"#\n"
+        f"# Provenance — what this persona was materialized from:\n"
+        f"#   source preset: {preset_name}\n"
+        f"#   preset content hash: {preset_hash}"
+    )
+    text = _replace_header(text, header)
+
+    tail = [
+        "",
+        "# One facility data tree for the whole stack: the host profile's data/",
+        "# directory. Relative paths resolve against THIS file, so without this",
+        "# override the inherited `data: data` would look inside personas/.",
+        "data: ../data",
+    ]
+    if not titled:
+        tail = ["", f"name: {profile_name}", *tail]
+    return text.rstrip("\n") + "\n" + "\n".join(tail) + "\n"
+
+
 # The lifecycle picture at the top of a materialized profile: what the user
 # owns, what the build regenerates from it, and what deploy turns that into.
 # Plain ASCII (no box-drawing glyphs) and <= 80 columns, so it survives any

--- a/src/osprey/cli/build_profile_emit.py
+++ b/src/osprey/cli/build_profile_emit.py
@@ -855,7 +855,8 @@ def emit_persona_delta_yaml(
         f"#\n"
         f"# Provenance — what this persona was materialized from:\n"
         f"#   source preset: {preset_name}\n"
-        f"#   preset content hash: {preset_hash}"
+        f"#   preset content hash: {preset_hash}\n"
+        f"#   emitted by OSPREY {__version__}"
     )
     text = _replace_header(text, header)
 

--- a/src/osprey/cli/build_profile_emit.py
+++ b/src/osprey/cli/build_profile_emit.py
@@ -781,6 +781,31 @@ def _replace_header(text: str, header: str) -> str:
     return header.rstrip("\n") + "\n\n" + "\n".join(lines[body_start:]).rstrip("\n") + "\n"
 
 
+# The lifecycle picture at the top of a materialized profile: what the user
+# owns, what the build regenerates from it, and what deploy turns that into.
+# Plain ASCII (no box-drawing glyphs) and <= 80 columns, so it survives any
+# editor a facility opens config files in. Emitted only into the main
+# profile.yml — persona siblings share the mental model and repeating the
+# picture three times per profile directory would just be noise.
+_FLOW_DIAGRAM = """\
+#  YOU EDIT THIS                IS RENDERED INTO             WHICH RUNS AS
+#
+#  +----------------+  osprey   +----------------+  osprey   +-----------------+
+#  |    PROFILE     |  build    |    PROJECT     |  deploy   |   DEPLOYMENT    |
+#  |                |           |                |           |                 |
+#  |  profile.yml   +---------->|  config.yml    +---------->|  agent CLI/web  |
+#  |  data/         |           |  services/     |  up -d    |  + service      |
+#  |  overlays/     |           |  .mcp.json     |           |    containers   |
+#  |  personas/     |           |  .env  ...     |           | (docker/podman) |
+#  +----------------+           +----------------+           +-----------------+
+#   durable source of            regenerable — a              osprey deploy down
+#   truth; keep + edit           --force rebuild              stops it; deploy
+#                                overwrites it                up recreates it
+#
+#        ^                                                          |
+#        +--- the loop: edit profile -> rebuild -> redeploy --------+"""
+
+
 def emit_standalone_profile_yaml(
     preset_name: str,
     overrides: tuple[Path, ...],
@@ -788,6 +813,7 @@ def emit_standalone_profile_yaml(
     profile_name: str,
     profile_filename: str,
     extra_layers: tuple[Mapping[str, Any], ...] = (),
+    include_flow_diagram: bool = False,
 ) -> str:
     """Render the standalone ``profile.yml`` text for ``osprey profile new``.
 
@@ -805,6 +831,9 @@ def emit_standalone_profile_yaml(
             this to repoint the emitted persona catalog at the sibling profiles
             it is about to write: those values are derived from the resolved
             catalog, so they cannot come from a file the caller passes.
+        include_flow_diagram: Embed the profile → build → deploy lifecycle
+            diagram in the generated header. Set for the main ``profile.yml``
+            only; persona siblings keep the compact header.
 
     Returns:
         Complete ``profile.yml`` content: fully explicit (no ``extends:``),
@@ -879,6 +908,7 @@ def emit_standalone_profile_yaml(
 
     normalized = base_anchor.stem
     preset_hash = compute_preset_hash(preset_name) or "(unavailable)"
+    flow_block = f"{_FLOW_DIAGRAM}\n#\n" if include_flow_diagram else ""
     header = (
         f"# {profile_name} — OSPREY build profile\n"
         f"#\n"
@@ -886,6 +916,7 @@ def emit_standalone_profile_yaml(
         f"# standalone profile: everything the preset configures is written out\n"
         f"# below and is yours to edit. Nothing is inherited at build time.\n"
         f"#\n"
+        f"{flow_block}"
         f"# Provenance — what this profile was materialized from:\n"
         f"#   source preset: {normalized}\n"
         f"#   preset content hash: {preset_hash}\n"
@@ -896,8 +927,9 @@ def emit_standalone_profile_yaml(
         f"# source preset set it:\n"
         f"#   {', '.join(sorted(_BUILD_MECHANICS_KEYS))}\n"
         f"#\n"
-        f"# Build a project from this profile with:\n"
-        f"#   osprey build <PROJECT_NAME> {profile_filename}"
+        f"# Build a project from this profile, then deploy it:\n"
+        f"#   osprey build <PROJECT_NAME> {profile_filename}\n"
+        f"#   cd <PROJECT_NAME> && osprey deploy up -d"
     )
     text = _replace_header(text, header)
 

--- a/src/osprey/cli/build_profile_presets.py
+++ b/src/osprey/cli/build_profile_presets.py
@@ -83,3 +83,33 @@ def _load_preset_raw(name: str) -> tuple[dict[str, Any], Path]:
     if not isinstance(raw, dict):
         raise BuildProfileError(f"Preset {name!r} must be a YAML mapping")
     return raw, target
+
+
+def _preset_extends_chain_reaches(child: str, ancestor: str) -> bool:
+    """Whether preset ``child``'s ``extends`` chain passes through ``ancestor``.
+
+    Walks bundled-preset names only: a chain hop that is missing, empty,
+    path-shaped, or otherwise not a bundled preset ends the walk with False —
+    such a chain cannot be rebased onto a profile materialized from
+    ``ancestor`` without changing what it resolves to. ``child == ancestor``
+    is also False: reaching requires at least one ``extends`` hop, because the
+    caller's delta emission rewrites an ``extends`` line that must exist.
+    A cycle returns False here and is rejected with a proper error by
+    :func:`~.build_profile_merge._resolve_extends` when the preset is used.
+    """
+    target = _normalize_preset_name(ancestor)
+    current = _normalize_preset_name(child)
+    seen: set[str] = set()
+    while current not in seen:
+        seen.add(current)
+        if _preset_exists(current) is None:
+            return False
+        raw, _path = _load_preset_raw(current)
+        parent = raw.get("extends")
+        if not isinstance(parent, str) or not parent or _preset_exists(parent) is None:
+            return False
+        parent = _normalize_preset_name(parent)
+        if parent == target:
+            return True
+        current = parent
+    return False

--- a/src/osprey/cli/profile_cmd.py
+++ b/src/osprey/cli/profile_cmd.py
@@ -134,11 +134,19 @@ def validate(target: Path) -> None:
     help="Inline scalar/list override baked into the emitted profile (repeatable). "
     "RHS parsed as YAML.",
 )
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Replace an existing profile directory, deleting its current contents "
+    "(including any edits). Refuses a target that is not a materialized "
+    "profile (no profile.yml) and not empty.",
+)
 def new(
     target_dir: Path,
     preset: str,
     overrides: tuple[Path, ...],
     set_pairs: tuple[str, ...],
+    force: bool,
 ) -> None:
     """Materialize an editable profile directory from a bundled preset.
 
@@ -154,7 +162,9 @@ def new(
       $ osprey profile new my-profile --preset hello-world --set model=sonnet
     """
     try:
-        target = _materialize_profile_directory(target_dir, preset, overrides, set_pairs)
+        target = _materialize_profile_directory(
+            target_dir, preset, overrides, set_pairs, force=force
+        )
     except BuildProfileError as e:
         # Reaching here means a packaging problem, not a user mistake — the
         # helper raises UsageError for everything the caller could have got
@@ -201,7 +211,16 @@ _PERSONA_DATA_REF = f"../{_PROFILE_DATA_DIRNAME}"
 # elsewhere in the tree is untouched.
 _EXCLUDED_DATA_SUBTREES: tuple[tuple[str, ...], ...] = (("benchmarks", "results"),)
 
-_ALREADY_EXISTS = "Target directory already exists: {target}. Remove it or choose a different path."
+_ALREADY_EXISTS = (
+    "Target directory already exists: {target}. Remove it, choose a different "
+    "path, or re-run with --force to replace it."
+)
+
+_NOT_REPLACEABLE = (
+    "Refusing --force: {target} is not a materialized profile directory (no "
+    "profile.yml) and not empty. Remove it yourself if you really mean to "
+    "replace it."
+)
 
 # Build-time staging directories a bundle may ship inside its data tree, paired
 # with what the README should say about each. Data-driven rather than
@@ -451,6 +470,8 @@ def _materialize_profile_directory(
     preset_name: str,
     overrides: tuple[Path, ...] = (),
     set_pairs: tuple[str, ...] = (),
+    *,
+    force: bool = False,
 ) -> Path:
     """Materialize an editable, standalone profile directory from ``preset_name``.
 
@@ -464,6 +485,10 @@ def _materialize_profile_directory(
     Fail-before-mutating: the preset, its layers, and the rendered profile text
     are all produced before the first ``mkdir``, and anything that fails after
     it removes the target rather than leaving a half-materialized directory.
+    With ``force``, an existing target is deleted at that same point — never
+    earlier — and only when it is a materialized profile (has ``profile.yml``)
+    or an empty directory, so a failed run or a mistyped target never costs an
+    unrelated directory.
 
     Returns:
         The resolved target directory.
@@ -503,8 +528,19 @@ def _materialize_profile_directory(
     name_override = baked.get("name")
 
     target = target_dir.resolve()
+    replacing = False
     if target.exists():
-        raise click.UsageError(_ALREADY_EXISTS.format(target=target))
+        if not force:
+            raise click.UsageError(_ALREADY_EXISTS.format(target=target))
+        # --force only replaces what this command itself produces: a
+        # materialized profile (profile.yml present) or an empty directory.
+        # Anything else could be an arbitrary directory named by mistake —
+        # refuse rather than delete it.
+        if not (
+            target.is_dir() and ((target / "profile.yml").is_file() or not any(target.iterdir()))
+        ):
+            raise click.UsageError(_NOT_REPLACEABLE.format(target=target))
+        replacing = True
 
     normalized_preset = _normalize_preset_name(preset_name)
     # `target.name` is the user-chosen directory name (e.g. "my-profile") —
@@ -536,6 +572,12 @@ def _materialize_profile_directory(
         profile_filename=profile_filename,
         extra_layers=(_persona_catalog_layer(persona_texts),) if persona_texts else (),
     )
+
+    # The replacement happens here, after every input has resolved and the new
+    # profile text is fully rendered — a failure above (bad preset, invalid
+    # override) leaves the existing directory exactly as it was.
+    if replacing:
+        shutil.rmtree(target)
 
     try:
         target.mkdir(parents=True)

--- a/src/osprey/cli/profile_cmd.py
+++ b/src/osprey/cli/profile_cmd.py
@@ -571,6 +571,7 @@ def _materialize_profile_directory(
         profile_name=profile_name_default,
         profile_filename=profile_filename,
         extra_layers=(_persona_catalog_layer(persona_texts),) if persona_texts else (),
+        include_flow_diagram=True,
     )
 
     # The replacement happens here, after every input has resolved and the new

--- a/src/osprey/cli/profile_cmd.py
+++ b/src/osprey/cli/profile_cmd.py
@@ -297,6 +297,10 @@ def _persona_catalog_layer(persona_names: Iterable[str]) -> dict[str, Any]:
 def _replayed_model_selection(baked: dict[str, Any]) -> tuple[str, ...]:
     """``--set`` pairs re-applying the caller's baked model selection to a persona.
 
+    Only the flattened fallback emission needs this: a delta persona inherits
+    the host profile wholesale, baked model selection included, through its
+    ``extends: ../profile.yml``.
+
     Mirrors :func:`osprey.deployment.web_terminals.persona_images._parent_set_override_args`
     exactly — the same key set (:data:`MODEL_SELECTION_OVERRIDE_KEYS`) and the
     same ``str | int`` value filter — because the two are the SAME guarantee at
@@ -324,38 +328,38 @@ def _persona_profile_texts(
     profile_name: str,
     profile_dirname: str,
     baked: dict[str, Any],
+    host_preset: str,
 ) -> dict[str, str]:
-    """Emit one standalone profile text per persona the profile deploys.
+    """Emit one sibling profile text per persona the profile deploys.
 
     Empty unless the profile stands up a persona stack of its own (see
     :func:`~osprey.cli.build_profile_emit.emits_persona_profiles`) — a persona
     preset inherits the catalog but disables the module, and emitting from one
     of those would produce personas-of-a-persona.
 
-    Each persona profile is materialized from its catalog entry's own
-    ``build_profile`` preset with ``data: ../data`` injected through the same
-    ``--set`` layering the host profile's ``data: data`` uses, so no second path
-    into the emitted content exists.
-
-    The caller's ``-O``/``--set`` layers are NOT replayed wholesale: they are
-    authored against the host preset and may not even be valid against a
-    persona one. The model-selection subset IS replayed
-    (:func:`_replayed_model_selection`), because those keys carry whole-stack
-    intent — without it, ``profile new --set provider=X`` would emit a host
-    profile on provider X and persona profiles still on the preset's provider,
-    and every persona terminal would run against credentials the facility may
-    not even hold. The deploy-time counterpart
-    (:func:`osprey.deployment.web_terminals.persona_images._parent_set_override_args`)
-    covers only a choice made at ``osprey build`` time, so it cannot stand in
-    for this one: a profile baked here and then built with no flags records no
-    explicit override in the project manifest and forwards nothing.
+    A persona whose preset ``extends``-chains through ``host_preset`` (the
+    bundled shape: ``control-assistant-readonly`` over ``control-assistant``)
+    is emitted as a DELTA — ``extends: ../profile.yml`` plus the preset's own
+    few overrides (:func:`~.build_profile_emit.emit_persona_delta_yaml`) — so
+    the host profile stays the single source of truth: edits there, and the
+    caller's baked ``-O``/``--set`` layers with them, reach every persona
+    through resolution instead of being copied around. A catalog entry whose
+    preset sits outside that chain cannot be rebased without changing what it
+    resolves to; it falls back to the flattened standalone emission, with the
+    model-selection subset of the caller's overrides replayed into it
+    (:func:`_replayed_model_selection`) so a whole-stack provider choice still
+    reaches it.
 
     Raises:
         click.UsageError: With every unusable catalog entry named at once.
     """
     from .build_profile import resolve_build_profile
-    from .build_profile_emit import emit_standalone_profile_yaml, persona_catalog
-    from .build_profile_presets import _normalize_preset_name
+    from .build_profile_emit import (
+        emit_persona_delta_yaml,
+        emit_standalone_profile_yaml,
+        persona_catalog,
+    )
+    from .build_profile_presets import _normalize_preset_name, _preset_extends_chain_reaches
 
     catalog = persona_catalog(resolved.config)
     model_selection = _replayed_model_selection(baked)
@@ -399,13 +403,22 @@ def _persona_profile_texts(
                 f"{resolved.data_bundle!r} — one shared data tree cannot serve both"
             )
             continue
-        texts[persona_name] = emit_standalone_profile_yaml(
-            preset_name=_normalize_preset_name(preset_ref),
-            overrides=(),
-            set_pairs=(f"data={_PERSONA_DATA_REF}", *model_selection),
-            profile_name=f"{profile_name} ({persona_name})",
-            profile_filename=f"{profile_dirname}/{_PERSONA_PROFILE_DIRNAME}/{persona_name}.yml",
-        )
+        persona_preset = _normalize_preset_name(preset_ref)
+        persona_filename = f"{profile_dirname}/{_PERSONA_PROFILE_DIRNAME}/{persona_name}.yml"
+        if _preset_extends_chain_reaches(persona_preset, host_preset):
+            texts[persona_name] = emit_persona_delta_yaml(
+                preset_name=persona_preset,
+                profile_name=f"{profile_name} ({persona_name})",
+                profile_filename=persona_filename,
+            )
+        else:
+            texts[persona_name] = emit_standalone_profile_yaml(
+                preset_name=persona_preset,
+                overrides=(),
+                set_pairs=(f"data={_PERSONA_DATA_REF}", *model_selection),
+                profile_name=f"{profile_name} ({persona_name})",
+                profile_filename=persona_filename,
+            )
     if problems:
         raise click.UsageError(
             "Cannot materialize the persona profiles this profile's web-terminal "
@@ -559,7 +572,9 @@ def _materialize_profile_directory(
     # repointed at them, so the whole stack reads this profile's data tree
     # rather than the bundled preset's (D7a). Emitted before the first mkdir,
     # like everything else here, so a bad catalog entry fails before mutating.
-    persona_texts = _persona_profile_texts(resolved, profile_name_default, target.name, baked)
+    persona_texts = _persona_profile_texts(
+        resolved, profile_name_default, target.name, baked, normalized_preset
+    )
 
     # The materialized tree is what the build must read, so `data:` is emitted
     # as an active key — injected through the same --set layering a user would

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -200,7 +200,14 @@ config:
     channel_finder_base_port: 9591  # first per-user channel-finder panel port
     default_persona: readonly   # roster entries with no persona resolve here
     users:
-      - alice                   # bare string → default_persona (readonly)
+      # One web terminal per entry. `index` pins the user's port offsets
+      # (each `*_base_port` above + index), so removing an entry never shifts
+      # another user's ports; `persona` names a catalog entry below. A bare
+      # string (`- alice`) is also accepted: it takes its list position as
+      # index and falls back to `default_persona`.
+      - name: alice
+        index: 0
+        persona: readonly
       - name: bob
         index: 1
         persona: readwrite

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -7,9 +7,11 @@
 
 name: Control Assistant
 
-# The data bundle provides the project skeleton (config.yml, registry, data
-# files, benchmark datasets, etc.).  "control_assistant" is the standard full
-# bundle that includes channel databases, benchmarks, and a logbook seed.
+# Which packaged project skeleton `osprey build` renders (config.yml,
+# README, Dockerfile). "control_assistant" is the full skeleton. Its data
+# files (channel databases, benchmarks, facility knowledge, logbook seeds)
+# are copied into a materialized profile's data/ directory, and that copy
+# — not the packaged one — is what the build uses from then on.
 app_template: control_assistant
 
 # Default LLM provider and model. Override here or via `osprey build`'s

--- a/src/osprey/profiles/presets/multi-user-demo.yml
+++ b/src/osprey/profiles/presets/multi-user-demo.yml
@@ -21,9 +21,11 @@
 
 name: Multi-User Demo
 
-# The standard full bundle (channel databases, simulation data, logbook seed) —
-# the demo needs real channels to read, and a channel_limits.json for the
-# write-capable tier's limits checking to bite on.
+# Which packaged project skeleton `osprey build` renders (config.yml, README,
+# Dockerfile). The full "control_assistant" skeleton — the demo needs real
+# channels to read, and a channel_limits.json for the write-capable tier's
+# limits checking to bite on. Its data files are copied into a materialized
+# profile's data/ directory; that copy is what the build uses from then on.
 app_template: control_assistant
 
 provider: anthropic

--- a/src/osprey/profiles/presets/multi-user-demo.yml
+++ b/src/osprey/profiles/presets/multi-user-demo.yml
@@ -126,7 +126,14 @@ config:
     channel_finder_base_port: 9591  # first per-user channel-finder panel port
     default_persona: readonly   # roster entries with no persona resolve here
     users:
-      - alice                   # bare string → default_persona (readonly)
+      # One web terminal per entry. `index` pins the user's port offsets
+      # (each `*_base_port` above + index), so removing an entry never shifts
+      # another user's ports; `persona` names a catalog entry below. A bare
+      # string (`- alice`) is also accepted: it takes its list position as
+      # index and falls back to `default_persona`.
+      - name: alice
+        index: 0
+        persona: readonly
       - name: bob
         index: 1
         persona: readwrite

--- a/tests/cli/test_persona_presets.py
+++ b/tests/cli/test_persona_presets.py
@@ -291,7 +291,7 @@ class TestBaseWebTerminals:
         """The rendered ``modules.web_terminals`` subtree matches the two-persona
         demo shape: local image source, readonly default, a readonly/readwrite
         catalog whose ``project`` equals its ``project_path`` basename, and a
-        roster mapping alice→readonly (via default) and bob→readwrite."""
+        roster mapping alice→readonly and bob→readwrite, both explicit."""
         rendered = _render_config_overrides(tmp_path, {"system": {}})
         wt = rendered["modules"]["web_terminals"]
 
@@ -305,9 +305,9 @@ class TestBaseWebTerminals:
         assert wt["lattice_base_port"] == 9491
         assert wt["channel_finder_base_port"] == 9591
 
-        # Roster: alice is a bare string (inherits default_persona: readonly);
-        # bob is object-form with an explicit index and the readwrite persona.
-        assert wt["users"][0] == "alice"
+        # Roster: both entries ship fully explicit — name, index, persona —
+        # so the config states outright what normalization would derive.
+        assert wt["users"][0] == {"name": "alice", "index": 0, "persona": "readonly"}
         assert wt["users"][1] == {"name": "bob", "index": 1, "persona": "readwrite"}
 
         personas = wt["personas"]
@@ -579,7 +579,7 @@ class TestControlAssistantWebTier:
         assert wt["default_persona"] == "readonly"
         assert wt["nginx_port"] == 9080
 
-        assert wt["users"][0] == "alice"
+        assert wt["users"][0] == {"name": "alice", "index": 0, "persona": "readonly"}
         assert wt["users"][1] == {"name": "bob", "index": 1, "persona": "readwrite"}
 
         personas = wt["personas"]

--- a/tests/cli/test_persona_profile_emission.py
+++ b/tests/cli/test_persona_profile_emission.py
@@ -206,22 +206,44 @@ def test_catalog_is_rewritten_to_point_at_the_sibling_profiles(
 
 
 @pytest.mark.parametrize("preset", TRIGGER_PRESETS)
-def test_persona_profiles_are_standalone_and_keep_their_posture(
+def test_persona_profiles_are_deltas_and_keep_their_posture(
     runner: CliRunner, tmp_path: Path, preset: str
 ):
-    """Emitted flat (no ``extends:``) and still carrying the one axis the
-    persona presets exist to differ on."""
+    """Emitted as a DELTA over the host profile (``extends: ../profile.yml``):
+    the host stays the single source of truth, and each persona file carries
+    only what makes it that persona — with the write posture pinned explicitly
+    in the delta, where no host edit can silently override it."""
     target = tmp_path / "my-profile"
 
     assert _new(runner, target, preset).exit_code == 0
 
     postures = {}
     for persona_file in sorted((target / "personas").iterdir()):
-        text = persona_file.read_text()
-        assert not any(line.startswith("extends:") for line in text.splitlines()), persona_file
-        parsed = yaml.safe_load(text)
+        parsed = yaml.safe_load(persona_file.read_text())
+        assert parsed["extends"] == "../profile.yml", persona_file.name
+        # The big sections are inherited, not restated.
+        for inherited_key in ("app_template", "provider", "model", "requires_osprey_version"):
+            assert inherited_key not in parsed, (persona_file.name, inherited_key)
         postures[persona_file.stem] = parsed["config"]["control_system.writes_enabled"]
     assert postures == {"readonly": False, "readwrite": True}
+
+
+@pytest.mark.parametrize("preset", TRIGGER_PRESETS)
+def test_host_profile_edits_propagate_to_personas(runner: CliRunner, tmp_path: Path, preset: str):
+    """The point of the delta shape: edit the host profile once and every
+    persona follows at its next resolution — no re-materialization, no
+    hand-mirroring into the persona files."""
+    target = tmp_path / "my-profile"
+    assert _new(runner, target, preset).exit_code == 0
+
+    host_file = target / "profile.yml"
+    text = host_file.read_text(encoding="utf-8")
+    assert "provider: anthropic" in text
+    host_file.write_text(text.replace("provider: anthropic", "provider: cborg"), encoding="utf-8")
+
+    for persona_file in sorted((target / "personas").iterdir()):
+        resolved, _dir = resolve_build_profile(persona_file.resolve(), None)
+        assert resolved.provider == "cborg", persona_file.name
 
 
 @pytest.mark.parametrize("preset", ("hello-world", "ariel-standalone", *CHILD_PRESETS))
@@ -280,18 +302,17 @@ def test_emitted_stack_builds_end_to_end(runner: CliRunner, tmp_path: Path) -> N
 
 
 @pytest.mark.parametrize("preset", TRIGGER_PRESETS)
-def test_baked_model_selection_is_replayed_into_every_persona(
+def test_baked_model_selection_reaches_every_persona_by_inheritance(
     runner: CliRunner, tmp_path: Path, preset: str
 ) -> None:
-    """A provider/model chosen at ``profile new`` time must retint the WHOLE
-    stack, not just the host.
+    """A provider/model chosen at ``profile new`` time retints the WHOLE stack:
+    baked once into the host profile and inherited by every persona through
+    ``extends: ../profile.yml``. Nothing is copied into the persona files —
+    the host is the single place the choice lives.
 
-    The canonical flow bakes the choice here and then builds with no flags, so
-    nothing is recorded as an explicit override in the project manifest and the
-    deploy-time forwarding path has nothing to forward. Without replay, persona
-    terminals would run against a provider the facility may hold no credentials
-    for while the host works — a failure that only shows up in a deployed
-    container.
+    ``tier`` travels too, unlike under the old replay allowlist: the stack
+    shares one data tree, so a persona materializing a different
+    channel-database tier than its host was an inconsistency, not a feature.
     """
     target = tmp_path / "my-profile"
 
@@ -312,24 +333,25 @@ def test_baked_model_selection_is_replayed_into_every_persona(
     assert result.exit_code == 0, result.output
     host = yaml.safe_load((target / "profile.yml").read_text())
     assert (host["provider"], host["model"]) == ("cborg", "opus")
+    assert host["tier"] == 1
     persona_files = sorted((target / "personas").iterdir())
     assert persona_files  # the assertions below must not pass vacuously
     for persona_file in persona_files:
         parsed = yaml.safe_load(persona_file.read_text())
-        assert parsed["provider"] == "cborg", persona_file.name
-        assert parsed["model"] == "opus", persona_file.name
-        assert parsed["channel_finder_mode"] == "in_context", persona_file.name
-        # Exactly the model-selection keys travel. `tier` is baked into the
-        # host but is not whole-stack intent, so it stays behind.
-        assert host["tier"] == 1
-        assert "tier" not in parsed, persona_file.name
+        for key in ("provider", "model", "channel_finder_mode", "tier"):
+            assert key not in parsed, (persona_file.name, key)
+        resolved, _dir = resolve_build_profile(persona_file.resolve(), None)
+        assert resolved.provider == "cborg", persona_file.name
+        assert resolved.model == "opus", persona_file.name
+        assert resolved.channel_finder_mode == "in_context", persona_file.name
+        assert resolved.tier == 1, persona_file.name
 
 
-def test_baked_override_file_model_selection_is_replayed_too(
+def test_baked_override_file_model_selection_is_inherited_too(
     runner: CliRunner, tmp_path: Path
 ) -> None:
-    """The replay reads the merged ``-O`` + ``--set`` result, so a choice made
-    in an override file carries exactly as far as one made inline."""
+    """A choice made in an ``-O`` override file bakes into the host profile and
+    carries into every persona resolution exactly as far as an inline one."""
     override = tmp_path / "o.yml"
     override.write_text("provider: cborg\nmodel: opus\n", encoding="utf-8")
     target = tmp_path / "my-profile"
@@ -337,8 +359,40 @@ def test_baked_override_file_model_selection_is_replayed_too(
     assert _new(runner, target, "multi-user-demo", "-O", str(override)).exit_code == 0
 
     for persona_file in sorted((target / "personas").iterdir()):
-        parsed = yaml.safe_load(persona_file.read_text())
-        assert (parsed["provider"], parsed["model"]) == ("cborg", "opus"), persona_file.name
+        resolved, _dir = resolve_build_profile(persona_file.resolve(), None)
+        assert (resolved.provider, resolved.model) == ("cborg", "opus"), persona_file.name
+
+
+def test_persona_preset_outside_the_host_chain_falls_back_to_flat(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """A catalog entry whose preset does not ``extends``-chain through the
+    host's preset cannot be expressed as a delta over the host profile —
+    resolving it through ``../profile.yml`` would change its meaning. It
+    materializes flattened, exactly as every persona did before deltas."""
+    override = _persona_override(
+        tmp_path,
+        {
+            "outsider": {
+                "project": "outsider",
+                "project_path": "../outsider",
+                # Same app template as control-assistant (passes the shared-
+                # data-tree check) but extends multi-user-demo, not the host.
+                "build_profile": "multi-user-demo-readonly",
+            }
+        },
+    )
+    target = tmp_path / "my-profile"
+
+    assert _new(runner, target, "control-assistant", "-O", str(override)).exit_code == 0
+
+    parsed = yaml.safe_load((target / "personas" / "outsider.yml").read_text())
+    assert "extends" not in parsed
+    assert parsed["data"] == "../data"
+    # The in-chain personas still emit as deltas alongside it.
+    for name in ("readonly", "readwrite"):
+        sibling = yaml.safe_load((target / "personas" / f"{name}.yml").read_text())
+        assert sibling["extends"] == "../profile.yml", name
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_preset_hash_pin.py
+++ b/tests/cli/test_preset_hash_pin.py
@@ -25,20 +25,24 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     "channel-finder-standalone": (
         "sha256:03c3d35070730762db3d46ef88beabe3b0e0bf98abd5fff72d81a95d2b6fc918"
     ),
-    "control-assistant": "sha256:663c0bf96468bbb27fc6d654e450b55b7793e1a169b57c453080241c14882ab6",
+    # The six web-terminal presets were re-pinned when the shipped roster went
+    # from a bare-string first user to fully explicit name/index/persona
+    # entries — a resolved-content change (deploy-visible as staleness), made
+    # knowingly per the module docstring. The resolved *behavior* is identical.
+    "control-assistant": "sha256:807a488a6d709eb2caec040fcbee659dbf7521bd3033e43c8fb50b35c8f3af27",
     "control-assistant-readonly": (
-        "sha256:f37efc17138c93e526c82fa28f090c6b2e40c3fdfad37914a19e2e85d07124e7"
+        "sha256:40c52b45831c289a7c63702a58ac89112081649ab6d7d9d7c07dd7eb3c042a02"
     ),
     "control-assistant-readwrite": (
-        "sha256:dfdc843f4286c67e71292bbfe8f6eb7b7567823ad51ebf12dba12564c75b57f9"
+        "sha256:b281e2e1f0d294a3264424b50096663c51f041d17c0f7b20ae56ac4acc6413f6"
     ),
     "hello-world": "sha256:e1666b0b1a1d1232bc3aa9c32ccf11e3555a217162fda292f4240396ef19ec8a",
-    "multi-user-demo": "sha256:4176b9dbe5695042a380e5c505251bb1b5afce934717eb7b53aefc7ba13a7e90",
+    "multi-user-demo": "sha256:83fd981e71a1101faf7af8405eb05a9f9a60d26e7a78c34bc9d8157ac4395fbd",
     "multi-user-demo-readonly": (
-        "sha256:1cc708c17581447ad4295672bffb43545f08d56d8679c274713e53b037ebf537"
+        "sha256:0bb68c5f24a409b26575c43c40f6c9debbca4b3cccb51c36fe16082cb0a91d01"
     ),
     "multi-user-demo-readwrite": (
-        "sha256:e9b656144ac1e4419ccfbc931d669bc0f223f4e0397452a82af753a8e8c52615"
+        "sha256:81f6006d1b2f636be7fe4dc94eb747fb619d70944379c8e0d522591b1b5166d5"
     ),
 }
 

--- a/tests/cli/test_profile_new.py
+++ b/tests/cli/test_profile_new.py
@@ -342,6 +342,35 @@ def test_existing_target_is_rejected(runner: CliRunner, tmp_path: Path) -> None:
     assert not (target / "profile.yml").exists()
 
 
+def test_header_carries_the_flow_diagram(runner: CliRunner, tmp_path: Path) -> None:
+    """The top comment block shows profile -> build -> project -> deploy."""
+    target = tmp_path / "p"
+    assert _new(runner, target, "hello-world").exit_code == 0
+
+    text = (target / "profile.yml").read_text(encoding="utf-8")
+    head = "\n".join(text.splitlines()[:45])
+
+    assert "PROFILE" in head
+    assert "PROJECT" in head
+    assert "DEPLOYMENT" in head
+    assert "edit profile -> rebuild -> redeploy" in head
+    # Every diagram line is a YAML comment and fits a standard terminal.
+    for line in head.splitlines():
+        if "PROFILE" in line or "-->" in line:
+            assert line.startswith("#")
+            assert len(line) <= 80
+
+
+def test_persona_profiles_do_not_repeat_the_flow_diagram(runner: CliRunner, tmp_path: Path) -> None:
+    target = tmp_path / "p"
+    assert _new(runner, target, "control-assistant").exit_code == 0
+
+    persona_files = sorted((target / "personas").glob("*.yml"))
+    assert persona_files, "control-assistant should emit persona siblings"
+    for persona_file in persona_files:
+        assert "edit profile -> rebuild -> redeploy" not in persona_file.read_text(encoding="utf-8")
+
+
 def test_existing_target_error_suggests_force(runner: CliRunner, tmp_path: Path) -> None:
     target = tmp_path / "p"
     target.mkdir()

--- a/tests/cli/test_profile_new.py
+++ b/tests/cli/test_profile_new.py
@@ -342,6 +342,85 @@ def test_existing_target_is_rejected(runner: CliRunner, tmp_path: Path) -> None:
     assert not (target / "profile.yml").exists()
 
 
+def test_existing_target_error_suggests_force(runner: CliRunner, tmp_path: Path) -> None:
+    target = tmp_path / "p"
+    target.mkdir()
+    (target / "profile.yml").write_text("name: Old\n", encoding="utf-8")
+
+    result = _new(runner, target, "hello-world")
+
+    assert result.exit_code == 2
+    assert "--force" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --force: replace an existing materialized profile
+# ---------------------------------------------------------------------------
+
+
+def test_force_replaces_existing_profile_directory(runner: CliRunner, tmp_path: Path) -> None:
+    target = tmp_path / "p"
+    assert _new(runner, target, "hello-world").exit_code == 0
+    # User edits + stray files that a re-materialization must not keep.
+    (target / "profile.yml").write_text("name: Edited Away\n", encoding="utf-8")
+    (target / "data" / "stray.txt").write_text("stale\n", encoding="utf-8")
+
+    result = _new(runner, target, "hello-world", "--force")
+
+    assert result.exit_code == 0, result.output
+    profile_text = (target / "profile.yml").read_text(encoding="utf-8")
+    assert "Edited Away" not in profile_text
+    assert not (target / "data" / "stray.txt").exists(), "stale file survived --force"
+
+
+def test_force_bakes_new_set_pairs(runner: CliRunner, tmp_path: Path) -> None:
+    target = tmp_path / "p"
+    assert _new(runner, target, "hello-world").exit_code == 0
+
+    result = _new(runner, target, "hello-world", "--force", "--set", "model=sonnet")
+
+    assert result.exit_code == 0, result.output
+    resolved, _ = resolve_build_profile(target / "profile.yml", None, (), ())
+    assert resolved.model == "sonnet"
+
+
+def test_force_refuses_directory_that_is_not_a_profile(runner: CliRunner, tmp_path: Path) -> None:
+    target = tmp_path / "p"
+    target.mkdir()
+    (target / "keepme.txt").write_text("mine\n", encoding="utf-8")
+
+    result = _new(runner, target, "hello-world", "--force")
+
+    assert result.exit_code == 2
+    assert "profile.yml" in result.output
+    # Refused means untouched.
+    assert (target / "keepme.txt").read_text(encoding="utf-8") == "mine\n"
+
+
+def test_force_allows_replacing_an_empty_directory(runner: CliRunner, tmp_path: Path) -> None:
+    target = tmp_path / "p"
+    target.mkdir()
+
+    result = _new(runner, target, "hello-world", "--force")
+
+    assert result.exit_code == 0, result.output
+    assert (target / "profile.yml").is_file()
+
+
+def test_force_with_bad_preset_leaves_existing_profile_untouched(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """--force must not delete anything before the new profile is fully rendered."""
+    target = tmp_path / "p"
+    assert _new(runner, target, "hello-world").exit_code == 0
+    original = (target / "profile.yml").read_text(encoding="utf-8")
+
+    result = _new(runner, target, "no-such-preset", "--force")
+
+    assert result.exit_code == 2
+    assert (target / "profile.yml").read_text(encoding="utf-8") == original
+
+
 def test_extends_override_is_rejected(runner: CliRunner, tmp_path: Path) -> None:
     override = tmp_path / "o.yml"
     override.write_text("extends: control-assistant\n", encoding="utf-8")

--- a/tests/cli/test_profile_source_flow_parity.py
+++ b/tests/cli/test_profile_source_flow_parity.py
@@ -439,8 +439,10 @@ def test_no_config_key_in_the_materialized_profile_prefixes_another(pair: Pair) 
 
 @pytest.mark.parametrize("preset", PERSONA_PRESETS)
 def test_emitted_persona_profiles_carry_the_guards_too(preset: str, tmp_path: Path) -> None:
-    """The siblings are profiles a facility builds from as well, so they owe the
-    same partition, prefix and provenance guarantees as the host profile."""
+    """The siblings are profiles a facility builds from as well — but they are
+    DELTAS, so the standalone guarantees hold at the resolved layer, not in the
+    raw text: every EXPLICIT field arrives through ``extends: ../profile.yml``,
+    while the file itself owes only prefix cleanliness and provenance."""
     runner = CliRunner()
     target = tmp_path / "profile"
     _materialize(runner, target, preset)
@@ -449,9 +451,11 @@ def test_emitted_persona_profiles_carry_the_guards_too(preset: str, tmp_path: Pa
     assert siblings, f"{preset}: no persona profiles were emitted"
     for sibling in siblings:
         text = sibling.read_text()
-        active, commented = _active_and_commented(text)
-        missing = {_FIELD_TO_YAML.get(field, field) for field in _EXPLICIT_KEYS} - active
-        assert not missing, f"{sibling.name}: EXPLICIT keys missing: {sorted(missing)}"
-        assert not active & commented, f"{sibling.name}: both active and templated"
+        resolved, _dir = resolve_build_profile(sibling.resolve(), None)
+        for field in _EXPLICIT_KEYS:
+            key = _FIELD_TO_YAML.get(field, field)
+            assert getattr(resolved, field, None) is not None, (
+                f"{sibling.name}: EXPLICIT key {key!r} does not survive resolution"
+            )
         assert _prefix_pairs(yaml.safe_load(text).get("config") or {}) == []
         assert "emitted by OSPREY" in text.split("\nname:")[0]


### PR DESCRIPTION
Improvements to what `osprey profile new` materializes and how the profile directory behaves as the durable source of truth.

## `--force` re-materialization
- `osprey profile new --force` replaces an existing profile directory, making the materialize-and-build one-liner rerunnable. It only replaces a directory that is provably a materialized profile (or empty), and deletes nothing until the new profile has fully rendered — a failed run leaves the old directory intact.
- The plain-run "already exists" error now points at `--force`.

## Emitted profile legibility
- The `profile.yml` header opens with a lifecycle diagram: profile (edit) → build → project (regenerable) → deploy → running containers.
- The `app_template` comments in the shipped presets now say what the key actually selects (the packaged project skeleton) and that a materialized profile's own `data/` copy takes precedence.
- Shipped web-terminal rosters spell out `name`/`index`/`persona` on every user entry instead of bare-string shorthand. Behavior identical; preset hash pins updated knowingly.

## Personas as extends deltas
- Persona siblings are now emitted as small deltas (`extends: ../profile.yml`) instead of full standalone copies: the host profile is the single source of truth, edits there reach every persona through resolution, and each persona file pins only its own posture (e.g. `control_system.writes_enabled: false`) — which no host edit can silently override.
- Baked `--set` model selection (and now `tier`) reaches personas by inheritance; the replay path remains only for catalog entries whose preset does not extends-chain through the host's preset, which keep the flattened emission.
- Docs updated (`how-to/build-profiles`), and the persona parity guards now assert at the resolved layer.