### PR TITLE
fix(tests): clear a .env-supplied TZ once per session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,10 @@ Compatibility is documented in release notes, not encoded in the version string.
   Appended entries now render inside their own section, with the banner kept
   at the section boundary.
 
+- The test suite no longer inherits a `TZ` supplied by a `.env` file, which made
+  `tests/connectors/test_archiver_timezone.py` error on any machine whose system
+  timezone differs from the one in `.env`. CI has no `.env`, so it never saw it.
+
 ## [2026.8.0]
 
 ### Removed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ This module provides shared fixtures and utilities for all Osprey tests.
 
 import logging
 import os
+import time
 from pathlib import Path
 
 import pytest
@@ -29,10 +30,12 @@ _PRISTINE_LOGGING = {
 # Environment guard
 # ===================================================================
 #
-# Declared first in this module on purpose: autouse fixtures at the same scope
-# are set up in declaration order, so this one is set up before every other
-# fixture and torn down after all of them — including `monkeypatch`, whose undo
-# therefore lands *inside* the snapshot window instead of after it.
+# Ordering note: autouse fixtures of equal scope are set up in *alphabetical*
+# order, not declaration order — `pytest --setup-plan <test>` prints the real
+# sequence. So `_no_host_timezone_leak` is the outermost function-scoped fixture
+# here (leading underscore), not this one, and anything that must sit outside
+# that guard's snapshot window has to be session-scoped rather than merely
+# declared earlier.
 
 
 @pytest.fixture(autouse=True, scope="function")
@@ -48,6 +51,7 @@ def restore_environ():
 
     ``OSPREY_CONFIG`` and ``CONFIG_FILE`` are additionally cleared on the way in,
     so a developer who exports either in their shell still gets a pristine run.
+    ``TZ`` is handled once per session instead -- see ``_clear_dotenv_timezone``.
     """
     saved = dict(os.environ)
 
@@ -93,6 +97,31 @@ def reset_state_between_tests():
 # ===================================================================
 # Host-timezone leak guard
 # ===================================================================
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _clear_dotenv_timezone():
+    """Drop a ``.env``-injected ``TZ`` once, before any test runs.
+
+    litellm calls a bare ``load_dotenv()`` at import, and the bare form searches
+    *parent* directories -- so a worktree with no ``.env`` of its own still
+    inherits the checkout's. That publishes ``TZ`` into ``os.environ`` during
+    collection without a matching ``time.tzset()``, leaving the variable and the
+    C library's cached zone disagreeing. The first test to call ``tzset()`` then
+    reconciles them mid-test, and ``_no_host_timezone_leak`` reports the change
+    against whichever test happened to make the call. It only bites where the
+    host zone differs from the ``.env`` one, which is why CI -- which has no
+    ``.env`` at all -- never sees it.
+
+    Session scope is load-bearing: the clear has to land outside every
+    function-scoped fixture's window, including the guard's own. Autouse
+    fixtures of equal scope are ordered alphabetically, so ``_no_host_timezone``
+    sets up first and tears down last; doing this per test would fall inside
+    that window and read as a leak.
+    """
+    if os.environ.pop("TZ", None) is not None:
+        time.tzset()
+    yield
 
 
 @pytest.fixture(autouse=True, scope="function")

--- a/tests/test_env_isolation.py
+++ b/tests/test_env_isolation.py
@@ -1,0 +1,41 @@
+"""The test session is hermetic against the developer's own shell and ``.env``.
+
+CI runs with no ``.env``; a developer's checkout normally has one, and the config
+loader reads it into ``os.environ`` with override semantics from a module-level
+logger call -- so importing almost any ``osprey`` module is enough to publish
+every key in that file. ``restore_environ`` in ``tests/conftest.py`` clears the
+keys that would otherwise make a local run diverge from CI.
+"""
+
+import os
+import time
+
+import pytest
+
+#: Keys ``restore_environ`` clears on the way in to every test.
+PRISTINE_KEYS = ("OSPREY_CONFIG", "CONFIG_FILE", "TZ")
+
+
+@pytest.mark.parametrize("key", PRISTINE_KEYS)
+def test_developer_environment_does_not_reach_tests(key):
+    """A key from the developer's shell or ``.env`` never reaches a test body."""
+    assert key not in os.environ, (
+        f"{key} reached a test from the developer's shell or .env. CI has "
+        "neither, so this run does not reproduce what CI does."
+    )
+
+
+def test_process_timezone_agrees_with_environ():
+    """``TZ`` and the C library's cached zone are in step.
+
+    Clearing ``TZ`` without ``time.tzset()`` would leave the process running on
+    the zone ``.env`` selected while ``os.environ`` claimed otherwise -- the next
+    test to call ``tzset()`` would then shift zones mid-test and trip the
+    host-timezone leak guard for a reason that has nothing to do with that test.
+    """
+    before = time.tzname
+    time.tzset()
+    assert time.tzname == before, (
+        f"process timezone {before} does not match a tzset() of the current "
+        f"environment ({time.tzname}); TZ was cleared without a tzset()."
+    )


### PR DESCRIPTION
`tests/connectors/test_archiver_timezone.py::test_archiver_spike_is_box_tz_independent` errors on the full unit suite on any machine whose system timezone differs from the `TZ` in its `.env`. CI has no `.env`, so it never sees this.

## Cause

`litellm` calls a bare `load_dotenv()` at import time. The bare form searches *parent* directories, so even a worktree with no `.env` of its own inherits the checkout's. That publishes `TZ` into `os.environ` during collection, and nothing calls `time.tzset()` afterwards — so the variable and the C library's cached zone disagree:

```
AT PLUGIN IMPORT:  TZ=None                    tzname=('CET', 'CEST')
AFTER COLLECTION:  TZ='America/Los_Angeles'   tzname=('CET', 'CEST')
```

The first test to call `tzset()` reconciles that split mid-test. `_no_host_timezone_leak` compares `(TZ, tzname)` across each test and reports the change against whichever test made the call:

```
before = ('America/Los_Angeles', ('CET', 'CEST'))
after  = ('America/Los_Angeles', ('PST', 'PDT'))
```

The reported test is the detector, not the defect — it is one of only three that call `tzset()`, and it does so correctly.

## Fix

Clear `TZ` once per session and re-sync the C library.

Session scope is load-bearing rather than stylistic. `pytest --setup-plan` shows autouse fixtures of equal scope are set up in **alphabetical** order, not declaration order, so `_no_host_timezone_leak` is the outermost function-scoped fixture. A per-test clear lands *inside* its snapshot window and reads as a leak — which is what a first attempt inside `restore_environ` did. The neighbouring comment asserting declaration-order setup is corrected for the same reason.

Also adds `tests/test_env_isolation.py`, pinning both that the developer environment does not reach tests and that `TZ` agrees with the C library's zone.

## Verification

Full unit suite (`pytest tests/ --ignore=tests/e2e`) on this machine, host zone `Europe/Berlin`, `.env` `TZ=America/Los_Angeles`:

| | before | after |
|---|---|---|
| passed | 15864 | 15868 |
| errors | 1 | 0 |