### PR TITLE
fix(config): stop loading .env when an osprey module is imported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,14 @@ Compatibility is documented in release notes, not encoded in the version string.
 - The test suite no longer inherits a `TZ` supplied by a `.env` file, which made
   `tests/connectors/test_archiver_timezone.py` error on any machine whose system
   timezone differs from the one in `.env`. CI has no `.env`, so it never saw it.
+- Importing an `osprey` module no longer loads `.env` into the environment.
+  Previously any `import osprey.…` rewrote `os.environ` from whatever `.env`
+  sat in the working directory — or, through LiteLLM, in any parent directory —
+  overriding values the caller had set. `.env` now loads only where an
+  application asks for it: the `osprey` CLI, MCP server startup, and the Claude
+  Code launch paths. Every key is still passed through, unchanged, at those
+  points. Code that imports OSPREY as a library and relied on the side effect
+  must call `osprey.utils.config.load_project_dotenv()` itself.
 
 ## [2026.8.0]
 

--- a/src/osprey/cli/main.py
+++ b/src/osprey/cli/main.py
@@ -146,13 +146,20 @@ def cli(ctx):
       osprey health                   Check system health
       osprey channel-finder           Interactive channel search
     """
+    from osprey.utils.config import load_project_dotenv
     from osprey.utils.logger import configure_logging
 
     from .styles import initialize_theme_from_config
 
-    # The CLI is a process entry point: nothing else configures logging, and
-    # importing the framework deliberately does not. Records go to stderr, so
-    # `--json` subcommand output on stdout stays machine-readable.
+    # The CLI is a process entry point: nothing else populates the environment
+    # from `.env`, and importing the framework deliberately does not. Do this
+    # first — logging and theme config below resolve `${VAR}` placeholders, and
+    # subcommands may read os.environ before touching config at all.
+    load_project_dotenv()
+
+    # Likewise a process entry point for logging: nothing else configures it,
+    # and importing the framework deliberately does not. Records go to stderr,
+    # so `--json` subcommand output on stdout stays machine-readable.
     configure_logging()
 
     initialize_theme_from_config()

--- a/src/osprey/models/providers/litellm_adapter.py
+++ b/src/osprey/models/providers/litellm_adapter.py
@@ -22,13 +22,24 @@ Provider Integration:
 """
 
 import json
+import os
 import warnings
 from typing import TYPE_CHECKING, Any
 
-import litellm
-from pydantic import BaseModel
+# Must precede `import litellm`. LiteLLM calls a bare `dotenv.load_dotenv()` at
+# import when LITELLM_MODE is "DEV" (its default), which searches *upward* from
+# the process for a `.env` and publishes it into os.environ. A git worktree with
+# no `.env` of its own therefore inherits the parent checkout's — importing an
+# OSPREY provider module would absorb whatever `.env` sits above it on disk.
+# LITELLM_MODE gates nothing else in the package, so this disables that one side
+# effect and changes no other LiteLLM behaviour. setdefault, not assignment: an
+# operator who set LITELLM_MODE explicitly keeps their value.
+os.environ.setdefault("LITELLM_MODE", "PRODUCTION")
 
-from osprey.utils.logger import get_logger
+import litellm  # noqa: E402  (must follow the LITELLM_MODE setdefault above)
+from pydantic import BaseModel  # noqa: E402
+
+from osprey.utils.logger import get_logger  # noqa: E402
 
 if TYPE_CHECKING:
     from .base import BaseProvider

--- a/src/osprey/utils/config.py
+++ b/src/osprey/utils/config.py
@@ -2,13 +2,26 @@
 
 Loads a single YAML config file, resolves environment variables,
 and provides dot-path access to values.
+
+**Importing this module does not read ``.env`` and does not touch
+``os.environ``.** Building a :class:`ConfigBuilder` does (see its ``load_env``
+argument), and that is deliberate — but it must be an *application* that asks
+for a config, never the mere act of importing an ``osprey`` module. Loading
+``.env`` at import time made a library consumer's environment depend on which
+directory the process happened to start in, gave non-credential keys
+``override=True`` semantics they were never scoped for, and silently undid
+callers' own ``os.environ`` writes depending on import order.
+
+Applications load ``.env`` explicitly at startup: the CLI in
+``osprey.cli.main``, MCP servers via :func:`osprey.mcp_env.load_dotenv_from_project`,
+and the Claude Code launch paths via
+:func:`osprey.build.claude_code_resolver.inject_provider_env`.
 """
 
 import copy
 import logging
 import os
 import re
-import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, overload
 
@@ -219,6 +232,44 @@ def resolve_execution_method(
     )
 
 
+def load_project_dotenv() -> None:
+    """Load ``./.env`` into ``os.environ``, overriding existing values.
+
+    This is the ``.env`` → environ passthrough the framework depends on: it
+    feeds the ``${VAR}`` references Claude Code expands in ``.mcp.json`` at MCP
+    server launch time (``EPICS_CA_ADDR_LIST``, ``PHOEBUS_BRIDGE_URL``,
+    ``BLUESKY_*``), and it makes ``.env`` the source of truth for API keys over
+    a stale shell export. Every key in the file is passed through, not a
+    declared subset — narrowing it would drop Channel Access addressing with no
+    error.
+
+    ``override=True`` and the breadth of the copy are exactly why this must be
+    called deliberately. Call it from process entry points only; never at
+    import time, and never from library code that a host application merely
+    imports. Missing file, missing ``python-dotenv``, and an unreadable file
+    are all non-fatal.
+    """
+    try:
+        from dotenv import load_dotenv
+    except ImportError:
+        logger.warning("python-dotenv not available, skipping .env file loading")
+        return
+
+    dotenv_path = Path.cwd() / ".env"
+    try:
+        if not dotenv_path.exists():
+            logger.debug(f"No .env file found at {dotenv_path}")
+            return
+        load_dotenv(dotenv_path, override=True)
+        logger.debug(f"Loaded .env file from {dotenv_path}")
+    except OSError as e:
+        # e.g. a 0600 .env owned by another uid mounted into a non-root
+        # container (dispatch worker on a uid-mismatched host). Provider
+        # env should already be in os.environ by the time config is built,
+        # so degrade gracefully instead of crash-looping the process.
+        logger.warning(f"Could not read .env file at {dotenv_path}: {e}")
+
+
 class ConfigBuilder:
     """Loads a YAML config, resolves ``${VAR}`` env-var placeholders, and
     pre-computes a ``configurable`` dict for framework and standalone use.
@@ -267,25 +318,7 @@ class ConfigBuilder:
             FileNotFoundError: If config.yml is not found and no path is provided.
         """
         if load_env:
-            try:
-                from dotenv import load_dotenv
-
-                dotenv_path = Path.cwd() / ".env"
-                if dotenv_path.exists():
-                    load_dotenv(
-                        dotenv_path, override=True
-                    )  # .env file is source of truth for API keys
-                    logger.debug(f"Loaded .env file from {dotenv_path}")
-                else:
-                    logger.debug(f"No .env file found at {dotenv_path}")
-            except ImportError:
-                logger.warning("python-dotenv not available, skipping .env file loading")
-            except OSError as e:
-                # e.g. a 0600 .env owned by another uid mounted into a non-root
-                # container (dispatch worker on a uid-mismatched host). Provider
-                # env should already be in os.environ by the time config is built,
-                # so degrade gracefully instead of crash-looping the process.
-                logger.warning(f"Could not read .env file at {dotenv_path}: {e}")
+            load_project_dotenv()
 
         if config_path is None:
             cwd_config = Path.cwd() / "config.yml"
@@ -917,9 +950,9 @@ def get_full_configuration(config_path: str | None = None) -> dict[str, Any]:
     return _get_configurable(config_path, set_as_default=set_as_default)
 
 
-# Eager-init config on import; deferred init is OK if config.yml is absent.
-try:
-    if "sphinx" not in sys.modules and not os.environ.get("SPHINX_BUILD"):
-        _get_config()
-except FileNotFoundError:
-    pass
+# No eager _get_config() here, deliberately. Building the default config at
+# import time loaded `.env` into os.environ as a side effect of importing any
+# osprey module (osprey/utils/__init__.py imports this one), which is the
+# behaviour the module docstring rules out. The first real get_config_value()
+# call builds it instead; entry points that need `.env` in the environment
+# load it themselves.

--- a/src/osprey/utils/logger.py
+++ b/src/osprey/utils/logger.py
@@ -283,21 +283,12 @@ def get_logger(
 
     base_logger = logging.getLogger(component_name)
 
-    try:
-        config_path = f"logging.logging_colors.{component_name}"
-        color = get_config_value(config_path)
-
-        if not color:
-            color = "white"
-
-    except Exception as e:
-        color = "white"
-        # Only show warning in debug mode to reduce noise
-        import os
-
-        if os.getenv("DEBUG_LOGGING"):
-            print(
-                f"WARNING: Failed to load color config for {component_name}: {e}. Using white as fallback."
-            )
-
-    return ComponentLogger(base_logger, component_name, color, state=state)
+    # No config lookup here, deliberately. This used to resolve
+    # ``logging.logging_colors.<component>``, but nothing ever consumed the
+    # result — ComponentLogger.color is write-only and _log() delegates
+    # straight to the stdlib logger. Building a Config to answer it dragged
+    # the whole config machinery — and its ``.env`` load — into all ~70
+    # module-level ``logger = get_logger(...)`` sites, making a bare
+    # ``import osprey.<anything>`` rewrite os.environ. See the module
+    # docstring in osprey.utils.config on where .env loading belongs.
+    return ComponentLogger(base_logger, component_name, "white", state=state)

--- a/tests/utils/test_import_env_hygiene.py
+++ b/tests/utils/test_import_env_hygiene.py
@@ -1,0 +1,242 @@
+"""Importing an ``osprey`` module must not rewrite ``os.environ`` from ``.env``.
+
+The environment counterpart to ``test_logging_guard.py``: importing the
+framework leaves the host application's logging alone, and it leaves the host
+application's *environment* alone too. Loading ``.env`` is something a process
+entry point does deliberately — the CLI, an MCP server's ``main()``, a Claude
+Code launch path — never something an import does on the way past.
+
+Two independent writers used to break that, and each has its own case below:
+
+* OSPREY's own config loader, reached because ``osprey/utils/__init__.py``
+  imports ``config``, which built the default ``Config`` at module scope.
+  It reads ``./.env`` — so which file wins depended on the working directory.
+* LiteLLM, which calls a bare ``dotenv.load_dotenv()`` at import when
+  ``LITELLM_MODE`` is unset. That form searches *upward*, so it needs no
+  ``.env`` in the working directory at all — a worktree inherited the parent
+  checkout's. ``osprey.models.providers.litellm_adapter`` pins the mode to
+  disable it.
+
+Every case runs in a subprocess. Import side effects fire once per interpreter,
+so they cannot be re-observed in-process, and a leaked ``os.environ`` write
+would outlive ``monkeypatch`` and contaminate the rest of the session.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# Deliberately not a name anything reads. A real key (TZ, an API key) would let
+# a passing test mean "nothing consumed it yet" rather than "nothing loaded it".
+SENTINEL = "OSPREY_IMPORT_HYGIENE_SENTINEL"
+
+
+def _write_dotenv(directory: Path) -> Path:
+    """Write a ``.env`` carrying the sentinel, plus filler that looks routine."""
+    directory.mkdir(parents=True, exist_ok=True)
+    env_file = directory / ".env"
+    env_file.write_text(
+        f"{SENTINEL}=leaked\nTZ=Antarctica/Troll\nOSPREY_FAKE_API_KEY=sk-not-a-real-key\n"
+    )
+    return env_file
+
+
+def _probe(snippet: str, *, cwd: Path) -> str | None:
+    """Run ``snippet`` in a fresh interpreter under ``cwd``; return the sentinel it saw.
+
+    The child must not inherit the sentinel, or every assertion below passes
+    for the wrong reason.
+    """
+    env = {k: v for k, v in os.environ.items() if k != SENTINEL}
+    code = textwrap.dedent(snippet) + textwrap.dedent(
+        f"""
+        import json as _json, os as _os
+        print("SENTINEL_RESULT " + _json.dumps(_os.environ.get({SENTINEL!r})))
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert result.returncode == 0, (
+        f"probe failed (exit {result.returncode})\n--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )
+    for line in result.stdout.splitlines():
+        if line.startswith("SENTINEL_RESULT "):
+            return json.loads(line.removeprefix("SENTINEL_RESULT "))
+    raise AssertionError(f"probe printed no result\n--- stdout ---\n{result.stdout}")
+
+
+# ===================================================================
+# Non-vacuity: the fixture .env is real, readable, and loadable
+# ===================================================================
+
+
+def test_explicit_load_does_publish_the_sentinel(tmp_path):
+    """The control. Without this, every assertion below could pass on a typo.
+
+    Also pins the other half of the contract: entry points that *do* call
+    ``load_project_dotenv()`` still get the full ``.env`` passthrough, which
+    feeds the ``${VAR}`` references Claude Code expands in ``.mcp.json``.
+    """
+    _write_dotenv(tmp_path)
+
+    seen = _probe(
+        """
+        from osprey.utils.config import load_project_dotenv
+        load_project_dotenv()
+        """,
+        cwd=tmp_path,
+    )
+
+    assert seen == "leaked"
+
+
+def test_explicit_load_overrides_an_existing_value(tmp_path):
+    """``override=True`` is load-bearing for API keys: ``.env`` beats a stale export."""
+    _write_dotenv(tmp_path)
+
+    seen = _probe(
+        """
+        import os
+        os.environ["OSPREY_IMPORT_HYGIENE_SENTINEL"] = "from-the-shell"
+        from osprey.utils.config import load_project_dotenv
+        load_project_dotenv()
+        """,
+        cwd=tmp_path,
+    )
+
+    assert seen == "leaked"
+
+
+# ===================================================================
+# Importing publishes nothing
+# ===================================================================
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        # The config machinery itself, and the package __init__ that pulls it in.
+        "osprey.utils.config",
+        "osprey.utils",
+        # A module-level `logger = get_logger(...)` site. ~70 of these exist;
+        # each one used to build a Config to resolve a colour nothing read.
+        "osprey.connectors.archiver.mock_archiver_connector",
+        # A connector an application imports without asking for any config.
+        "osprey.connectors.control_system.mock_connector",
+    ],
+)
+def test_import_does_not_publish_dotenv(tmp_path, module):
+    _write_dotenv(tmp_path)
+
+    seen = _probe(f"import {module}", cwd=tmp_path)
+
+    assert seen is None, f"importing {module} published .env into os.environ"
+
+
+def test_import_does_not_clobber_a_caller_value(tmp_path):
+    """The monkeypatch failure mode: a later import must not undo a caller's write."""
+    _write_dotenv(tmp_path)
+
+    seen = _probe(
+        """
+        import os
+        os.environ["OSPREY_IMPORT_HYGIENE_SENTINEL"] = "set-by-the-caller"
+        import osprey.utils.config  # noqa: F401
+        """,
+        cwd=tmp_path,
+    )
+
+    assert seen == "set-by-the-caller"
+
+
+# ===================================================================
+# The upward walk: a .env the process never chose
+# ===================================================================
+
+
+def test_provider_import_does_not_walk_up_to_a_parent_dotenv(tmp_path):
+    """LiteLLM's bare ``load_dotenv()`` searches parent directories.
+
+    This is the worktree case: ``.claude/worktrees/<name>/`` has no ``.env``,
+    the walk reaches the parent checkout's, and importing a provider module
+    absorbs it. The child's cwd deliberately has no ``.env`` of its own, so
+    only an upward search can find one.
+    """
+    _write_dotenv(tmp_path)
+    child = tmp_path / "nested" / "workdir"
+    child.mkdir(parents=True)
+    assert not (child / ".env").exists()
+
+    seen = _probe("import osprey.models.providers.litellm_adapter", cwd=child)
+
+    assert seen is None, "a parent directory's .env reached os.environ via the provider import"
+
+
+def test_litellm_mode_is_pinned_but_respects_an_explicit_setting():
+    """The mechanism, and its escape hatch. Pinning gates nothing else in LiteLLM."""
+    env = {k: v for k, v in os.environ.items() if k != "LITELLM_MODE"}
+    probe = (
+        "import os; import osprey.models.providers.litellm_adapter; "
+        "print('MODE ' + os.environ['LITELLM_MODE'])"
+    )
+
+    default = subprocess.run(
+        [sys.executable, "-c", probe], env=env, capture_output=True, text=True, timeout=180
+    )
+    assert default.returncode == 0, default.stderr
+    assert "MODE PRODUCTION" in default.stdout
+
+    explicit = subprocess.run(
+        [sys.executable, "-c", probe],
+        env={**env, "LITELLM_MODE": "DEV"},
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert explicit.returncode == 0, explicit.stderr
+    assert "MODE DEV" in explicit.stdout
+
+
+# ===================================================================
+# The CLI is an entry point, so it does load .env
+# ===================================================================
+
+
+def test_cli_entry_point_loads_dotenv(tmp_path):
+    """`osprey <command>` must still see `.env` from its first line.
+
+    Nothing else populates the environment for a CLI process now that import
+    doesn't, so a subcommand reading ``os.environ`` directly — before anything
+    builds a config — depends on this. The invocation runs inside the probe's
+    subprocess because the CLI writes straight to ``os.environ``, which would
+    otherwise outlive the test.
+    """
+    _write_dotenv(tmp_path)
+
+    seen = _probe(
+        """
+        from click.testing import CliRunner
+        from osprey.cli.main import cli
+        # The group callback runs before the subcommand is dispatched. It may
+        # then fail on the missing config.yml — irrelevant, .env loads first,
+        # and that ordering is the point.
+        CliRunner().invoke(cli, ["config", "--help"])
+        """,
+        cwd=tmp_path,
+    )
+
+    assert seen == "leaked"


### PR DESCRIPTION
Importing almost any `osprey` module rewrote `os.environ` from a `.env` file. No configuration was requested and no config object was constructed by the caller — the import alone was enough:

```python
import os
print(os.environ.get("TZ"))   # None
import osprey.connectors.archiver.mock_archiver_connector
print(os.environ.get("TZ"))   # America/Los_Angeles
```

The write used `override=True`, so it also replaced values the caller had already set — which is what let it undo `monkeypatch` in tests and made the outcome depend on import order and working directory.

## Two writers

**OSPREY's config loader.** `osprey/utils/__init__.py` imports `utils.config`, and `config.py` built the default `Config` at module scope. That reads `./.env`, so *which* file won depended on where the process started.

**LiteLLM.** It calls a bare `dotenv.load_dotenv()` at import unless `LITELLM_MODE` is set. That form searches *upward* through parent directories, so it needs no `.env` in the working directory at all — a checkout nested under another one absorbs the outer `.env`. `LITELLM_MODE` gates nothing else in the package, so pinning it to `PRODUCTION` before `import litellm` disables that one side effect and changes no other behaviour. It uses `setdefault`, so an operator who sets the variable explicitly keeps their value.

## What changed

Loading `.env` is now something a process entry point does deliberately, never something an import does on the way past.

- The eager `_get_config()` at import is gone. The first real `get_config_value()` call builds the config instead.
- The CLI group callback calls the new `load_project_dotenv()` explicitly, before logging and theme config resolve any `${VAR}`. MCP servers (`mcp_env.load_dotenv_from_project`) and the Claude Code launch paths (`inject_provider_env`) already loaded it themselves.
- `get_logger()` no longer resolves `logging.logging_colors.<component>`. That lookup was the second-order trigger, dragging the config machinery into ~70 module-level `logger = get_logger(...)` sites — and nothing consumed its result: `ComponentLogger.color` is never read and `_log()` delegates straight to the stdlib logger.

**Semantics at the load points are unchanged.** Every key in `.env` is still passed through with `override=True`. That breadth is load-bearing — the `${VAR}` references Claude Code expands in `.mcp.json` at MCP server launch time (`EPICS_CA_ADDR_LIST`, `PHOEBUS_BRIDGE_URL`, `BLUESKY_*`) resolve against the environment those calls populate, and narrowing the copy would drop Channel Access addressing with no error.

## Compatibility

Code that imports OSPREY as a library and relied on the side effect must now call `osprey.utils.config.load_project_dotenv()` itself. Applications launched through the CLI, an MCP server, or a Claude Code launch path are unaffected.

The chat bridges read config purely from environment variables set by compose and never depended on `.env`; they abort naming any missing variable rather than failing silently.

## Tests

`tests/utils/test_import_env_hygiene.py` — the environment counterpart to the existing `test_logging_guard.py`. It asserts that importing publishes nothing, that a caller's own `os.environ` write survives a later import, that a parent directory's `.env` is not reached through the provider adapter, and that the CLI entry point still loads `.env`. Two control cases pin that the fixture `.env` really is loadable, so the negative assertions cannot pass vacuously.

Every case runs in a subprocess: import side effects fire once per interpreter and cannot be re-observed in-process, and a leaked `os.environ` write would outlive `monkeypatch` and contaminate the rest of the session.

Verified against the pre-fix code: 9 of the 10 fail without this change. The one that passes is `test_cli_entry_point_loads_dotenv`, which asserts preserved behaviour rather than the defect.