### PR TITLE
feat(web-terminal): make the settings drawer explain itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,21 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Changed
 
+- The web terminal's System Settings drawer explains itself. Each tab opens
+  with a standing one-line subtitle, and the category help tooltips now
+  describe how each kind of file is *loaded* — when it enters the session,
+  what runs it, whether it advises or enforces — instead of summarizing what
+  the shipped files happen to say, which went stale as soon as an operator
+  edited one. Ownership prompts likewise state what taking or releasing
+  ownership actually does.
+- Each settings gallery now opens on artifacts rather than controls. Search and
+  the category chips moved behind a `Filter` disclosure on a single muted
+  summary line, and every category except the pinned ones starts collapsed.
+  An active filter stays named on that line, with a one-click clear, so a
+  narrowed list can never be mistaken for a short one.
+- The Behavior tab labels `CLAUDE.md` "project instructions" rather than
+  "system prompt": it is delivered as a message after the system prompt, while
+  the output style is what actually modifies it.
 - Bridge conversation history keeps more context. Replay is now bounded by the
   character budget (raised to 100k chars) rather than by turn count, which
   becomes a runaway backstop (100 turns), and a turn stays eligible for replay
@@ -112,6 +127,13 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- The settings drawer's `CLAUDE.md` section now has a help tooltip. Its help
+  text was filed under a category name no gallery ever displays, so the button
+  silently never rendered — on the one artifact that matters most.
+- The settings Config tab's form view no longer hides most of `config.yml`. It
+  listed a `python_execution` section that does not exist (the section is
+  `execution`), so execution settings were reachable only through Raw YAML;
+  `archiver`, `logbook`, and `facility_knowledge` are now editable there too.
 - Enum/status channels no longer render a state the channel was never in. A
   gap in an enum channel (a `null` sample) was being turned into the literal
   category rung `"<channel>: null"` on the chart's shared category axis, so a

--- a/src/osprey/interfaces/web_terminal/routes/config.py
+++ b/src/osprey/interfaces/web_terminal/routes/config.py
@@ -17,14 +17,22 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-# Config sections relevant to the agent (exclude internal/infra sections)
+# Config sections the Form view offers for editing. Deliberately narrower than
+# the file: infra/build sections (api, cli, deploy, modules, file_paths, ...)
+# are left to the Raw YAML view. Every name here must match a real top-level
+# key -- an entry that matches nothing renders nothing, silently, which is how
+# "python_execution" (the section is called "execution") kept the execution
+# settings out of the form.
 _AGENT_CONFIG_SECTIONS = [
     "control_system",
+    "archiver",
     "approval",
     "claude_code",
     "channel_finder",
     "ariel",
-    "python_execution",
+    "logbook",
+    "facility_knowledge",
+    "execution",
     "artifact_server",
     "screen_capture",
     "hooks",

--- a/src/osprey/interfaces/web_terminal/static/css/drawer.css
+++ b/src/osprey/interfaces/web_terminal/static/css/drawer.css
@@ -161,6 +161,23 @@
   display: flex;
 }
 
+/* ---- Tab Subtitle ----
+   A standing one-liner naming what the tab is. Muted and non-interactive on
+   purpose: always available to a first-time operator, never competing with the
+   content for attention. `flex-shrink: 0` keeps it from being squeezed out
+   when the gallery below it fills the panel. */
+
+.drawer-tab-subtitle {
+  margin: 0;
+  padding: 10px 12px;
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: var(--leading-relaxed);
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border-default);
+}
+
 /* ---- Drawer Close ---- */
 
 .drawer-close-btn {

--- a/src/osprey/interfaces/web_terminal/static/css/scaffold/10-prompt-gallery.css
+++ b/src/osprey/interfaces/web_terminal/static/css/scaffold/10-prompt-gallery.css
@@ -17,12 +17,77 @@
   color: var(--color-error);
 }
 
-/* ---- Search Bar ---- */
+/* ---- Meta Bar ----
+   The gallery's only permanent chrome: counts on the left, the Filter
+   disclosure on the right, deliberately quiet enough to read as a caption
+   rather than a toolbar. */
 
-.prompts-search-bar {
+.prompts-meta-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 6px 12px;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.prompts-meta-summary {
+  text-transform: uppercase;
+}
+
+.prompts-meta-spacer {
+  flex: 1;
+}
+
+.prompts-meta-clear {
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: var(--leading-none);
+  padding: 2px 4px;
+  cursor: pointer;
+  transition: color var(--wt-transition-fast);
+}
+
+.prompts-meta-clear:hover {
+  color: var(--color-accent-light);
+}
+
+.prompts-filter-toggle {
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 2px 0;
+  cursor: pointer;
+  transition: color var(--wt-transition-fast);
+}
+
+.prompts-filter-toggle:hover {
+  color: var(--color-accent-light);
+}
+
+/* ---- Filter Panel (collapsed by default) ---- */
+
+.prompts-filter-panel {
+  display: none;
   width: 100%;
   padding: 8px 12px;
   box-sizing: border-box;
+  background: var(--accent-tint-04);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.prompts-filter-panel.open {
+  display: block;
 }
 
 .prompts-search {
@@ -101,19 +166,6 @@
   margin: 0 4px;
 }
 
-/* ---- Summary Strip ---- */
-
-.prompts-summary {
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--text-muted);
-  padding: 6px 12px;
-  background: var(--accent-tint-04);
-  border-bottom: 1px solid var(--border-default);
-}
-
 /* ---- Category Sections ---- */
 
 .prompts-categories {
@@ -132,6 +184,23 @@
   display: flex;
   align-items: center;
   gap: 6px;
+  cursor: pointer;
+}
+
+.prompts-category-header:focus-visible {
+  outline: 1px solid var(--color-accent);
+  outline-offset: -1px;
+}
+
+.prompts-category-chevron {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+  width: 8px;
+  flex-shrink: 0;
+}
+
+.prompts-category-body.collapsed {
+  display: none;
 }
 
 .prompts-category-count {
@@ -923,6 +992,20 @@
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
+  min-height: 0;
+}
+
+/* ---- Gallery Section Hosts ----
+   The Behavior/Memory panels wrap their gallery in a section div so the tab's
+   static subtitle can sit above it (a gallery clears its own container on
+   build). These carry the flex sizing the panel used to give the gallery
+   directly, so `.scaffold-gallery-view { flex: 1 }` still resolves. */
+
+#behavior-gallery-section,
+#memory-gallery-section {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
   min-height: 0;
 }
 

--- a/src/osprey/interfaces/web_terminal/static/index.html
+++ b/src/osprey/interfaces/web_terminal/static/index.html
@@ -342,23 +342,38 @@
       <button class="drawer-close-btn">&times;</button>
     </div>
 
+    <!-- Each panel opens with a muted subtitle stating what the tab IS, in
+         mechanical terms (when its files load, what runs them) rather than in
+         terms of what the shipped files happen to say — the latter goes stale
+         the moment an operator edits one. Static markup, not JS-rendered, so
+         it survives each gallery clearing its own container on build. -->
+
     <!-- Behavior Tab (gallery, populated by JS) -->
-    <div class="drawer-tab-panel active" id="tab-behavior"></div>
+    <div class="drawer-tab-panel active" id="tab-behavior">
+      <p class="drawer-tab-subtitle">Files the agent reads at the start of every session:
+        what it knows, and who it delegates to. Guidance it follows, not a limit enforced.</p>
+      <div id="behavior-gallery-section"></div>
+    </div>
 
     <!-- Safety Tab (toggle bar + gallery + log viewer) -->
     <div class="drawer-tab-panel" id="tab-safety">
+      <p class="drawer-tab-subtitle">Programs the runtime runs itself around every tool call.
+        A hook can block a call before it executes, independent of the agent's decision.</p>
       <div id="hook-debug-bar"></div>
       <div id="safety-gallery-section"></div>
       <div id="hook-debug-log-section"></div>
     </div>
 
-    <!-- Memory Tab (Claude Code native memory gallery) -->
+    <!-- Memory Tab (native auto-memory gallery) -->
     <div class="drawer-tab-panel" id="tab-memory">
-      <!-- Populated by memory-gallery.js -->
+      <p class="drawer-tab-subtitle">Notes the agent writes for itself between sessions.</p>
+      <div id="memory-gallery-section"></div>
     </div>
 
     <!-- Config Tab (mini gallery + YAML form) -->
     <div class="drawer-tab-panel" id="tab-config">
+      <p class="drawer-tab-subtitle">This deployment's own config.yml — connectors, approval
+        policy, service wiring. Saving restarts the session.</p>
       <div id="config-gallery-section"></div>
       <div id="config-form-section">
         <div class="settings-mode-bar">

--- a/src/osprey/interfaces/web_terminal/static/js/memory-gallery.js
+++ b/src/osprey/interfaces/web_terminal/static/js/memory-gallery.js
@@ -546,7 +546,12 @@ export function initMemoryGallery() {
   const memoryPanel = document.getElementById('tab-memory');
   if (!memoryPanel) return;
 
-  const memoryGallery = new MemoryGallery({ container: memoryPanel });
+  // Section container, so the panel can also hold the static subtitle
+  // index.html renders above it (the gallery clears its own container on
+  // build). Falls back to the panel itself for fixtures mounting a bare
+  // `#tab-memory`, matching the scaffold galleries.
+  const memoryContainer = document.getElementById('memory-gallery-section') || memoryPanel;
+  const memoryGallery = new MemoryGallery({ container: memoryContainer });
 
   // Load when tab becomes active
   memoryPanel.addEventListener('drawer:tab-activate', () => {

--- a/src/osprey/interfaces/web_terminal/static/js/scaffold-gallery.js
+++ b/src/osprey/interfaces/web_terminal/static/js/scaffold-gallery.js
@@ -22,6 +22,9 @@ import { el as _el } from '/design-system/js/dom.js';
 import {
   BEHAVIOR_CATEGORIES,
   BEHAVIOR_NAMES,
+  BEHAVIOR_CATEGORY_OVERRIDES,
+  BEHAVIOR_CATEGORY_REMAPS,
+  BEHAVIOR_PINNED_CATEGORIES,
   SAFETY_CATEGORIES,
   CONFIG_NAMES,
   configureMarked,
@@ -102,6 +105,17 @@ class ArtifactGallery {
     this.loaded = false;
     this.summary = { total: 0, framework: 0, userOwned: 0 };
 
+    // Filter panel (search box + category chips) starts collapsed: the default
+    // gallery is artifacts plus one muted summary line, nothing else.
+    this.filterOpen = false;
+    // Categories the operator has collapsed, plus the ones seeded collapsed on
+    // first sight (everything outside `pinnedCategories`). Both live for as
+    // long as the drawer stays open -- reset() clears them on close.
+    /** @type {Set<string>} */
+    this.collapsedCategories = new Set();
+    /** @type {Set<string>} */
+    this.seenCategories = new Set();
+
     // DOM references (populated by _buildDOM)
     this.loadingEl = null;
     this.errorEl = null;
@@ -109,8 +123,11 @@ class ArtifactGallery {
     this.detailView = null;
     this.searchInput = null;
     this.filterChipsEl = null;
+    this.filterPanelEl = null;
+    this.filterToggleEl = null;
     this.untrackedBannerEl = null;
     this.summaryEl = null;
+    this.clearFilterEl = null;
     this.categoriesEl = null;
     this.detailHeaderEl = null;
     this.detailModesEl = null;
@@ -181,32 +198,67 @@ class ArtifactGallery {
     // Gallery view
     this.galleryView = _el('div', 'scaffold-gallery-view');
 
-    if (this.showSearch) {
-      const searchBar = _el('div', 'prompts-search-bar');
+    // Meta bar: one muted line carrying the counts, the active-filter readout,
+    // and the only always-visible control -- the Filter disclosure. Rendered
+    // whenever there is anything to put in it; the Config tab turns all three
+    // options off and gets no bar at all.
+    const hasFilterPanel = this.showSearch || this.showFilterChips;
+    if (this.showSummary || hasFilterPanel) {
+      const metaBar = _el('div', 'prompts-meta-bar');
 
-      this.searchInput = document.createElement('input');
-      this.searchInput.type = 'text';
-      this.searchInput.className = 'prompts-search';
-      this.searchInput.placeholder = 'Search artifacts...';
-      this.searchInput.spellcheck = false;
-      searchBar.appendChild(this.searchInput);
+      this.summaryEl = _el('span', 'prompts-meta-summary');
+      metaBar.appendChild(this.summaryEl);
+
+      // Clear-all for an active filter/search. Shown by renderSummary() only
+      // while something is actually filtering, so collapsing the panel can
+      // never hide the fact that the list is narrowed.
+      const clearBtn = document.createElement('button');
+      clearBtn.className = 'prompts-meta-clear';
+      clearBtn.type = 'button';
+      clearBtn.textContent = '✕';
+      clearBtn.title = 'Clear filters';
+      clearBtn.style.display = 'none';
+      metaBar.appendChild(clearBtn);
+      this.clearFilterEl = clearBtn;
+
+      const spacer = _el('span', 'prompts-meta-spacer');
+      metaBar.appendChild(spacer);
+
+      if (hasFilterPanel) {
+        const toggle = document.createElement('button');
+        toggle.className = 'prompts-filter-toggle';
+        toggle.type = 'button';
+        toggle.setAttribute('aria-expanded', 'false');
+        metaBar.appendChild(toggle);
+        this.filterToggleEl = toggle;
+      }
+
+      this.galleryView.appendChild(metaBar);
+    }
+
+    if (hasFilterPanel) {
+      this.filterPanelEl = _el('div', 'prompts-filter-panel');
+
+      if (this.showSearch) {
+        this.searchInput = document.createElement('input');
+        this.searchInput.type = 'text';
+        this.searchInput.className = 'prompts-search';
+        this.searchInput.placeholder = 'Search artifacts...';
+        this.searchInput.spellcheck = false;
+        this.filterPanelEl.appendChild(this.searchInput);
+      }
 
       if (this.showFilterChips) {
         this.filterChipsEl = _el('div', 'prompts-filter-chips');
-        searchBar.appendChild(this.filterChipsEl);
+        this.filterPanelEl.appendChild(this.filterChipsEl);
       }
 
-      this.galleryView.appendChild(searchBar);
+      this.galleryView.appendChild(this.filterPanelEl);
     }
 
     this.untrackedBannerEl = _el('div', 'prompts-untracked-banner');
     this.untrackedBannerEl.style.display = 'none';
     this.galleryView.appendChild(this.untrackedBannerEl);
-
-    if (this.showSummary) {
-      this.summaryEl = _el('div', 'prompts-summary');
-      this.galleryView.appendChild(this.summaryEl);
-    }
 
     this.categoriesEl = _el('div', 'prompts-categories');
     this.galleryView.appendChild(this.categoriesEl);
@@ -355,6 +407,9 @@ class ArtifactGallery {
     this.searchQuery = '';
     this.filterCategory = null;
     this.filterProjectOwned = false;
+    this.filterOpen = false;
+    this.collapsedCategories = new Set();
+    this.seenCategories = new Set();
     this.editDirty = false;
     this.loaded = false;
     this.summary = { total: 0, framework: 0, userOwned: 0 };
@@ -382,13 +437,19 @@ export function initScaffoldGallery() {
 
   if (!behaviorPanel || !safetyPanel || !configGallerySection) return;
 
+  // Section container, so the tab panel can also hold the static subtitle that
+  // index.html renders above it (the gallery clears its own container on
+  // build). Falls back to the panel itself, matching the Safety tab below and
+  // keeping fixtures that mount a bare `#tab-behavior` working.
+  const behaviorGalleryContainer =
+    document.getElementById('behavior-gallery-section') || behaviorPanel;
   const behaviorGallery = new ArtifactGallery({
-    container: behaviorPanel,
+    container: behaviorGalleryContainer,
     categoryFilter: (a) => BEHAVIOR_CATEGORIES.has(a.category) || BEHAVIOR_NAMES.has(a.name),
     options: {
-      categoryOverrides: { 'claude-md': 'system prompt' },
-      categoryRemaps: { rules: 'instructions' },
-      pinnedCategories: ['system prompt', 'instructions'],
+      categoryOverrides: BEHAVIOR_CATEGORY_OVERRIDES,
+      categoryRemaps: BEHAVIOR_CATEGORY_REMAPS,
+      pinnedCategories: BEHAVIOR_PINNED_CATEGORIES,
     },
   });
 

--- a/src/osprey/interfaces/web_terminal/static/js/scaffold/edit.js
+++ b/src/osprey/interfaces/web_terminal/static/js/scaffold/edit.js
@@ -67,7 +67,11 @@ export function createScaffoldGalleryEdit(gallery) {
   /** @returns {Promise<void>} */
   async function takeOwnership() {
     if (!gallery.selectedArtifact) return;
-    if (!confirm('By doing this you take responsibility for this file.')) return;
+    if (!confirm(
+      'Take ownership of this file? A project copy is written into .claude/, and '
+      + 'OSPREY stops overwriting it when artifacts are regenerated — later framework '
+      + 'updates to it will not reach your project. You can release ownership again.'
+    )) return;
 
     try {
       await apiRequest(`/api/scaffold/${encodeURIComponent(gallery.selectedArtifact.name)}/claim`, {
@@ -88,7 +92,10 @@ export function createScaffoldGalleryEdit(gallery) {
   /** @returns {Promise<void>} */
   async function releaseToFramework() {
     if (!gallery.selectedArtifact) return;
-    if (!confirm('Your customizations will be removed.')) return;
+    if (!confirm(
+      'Release this file back to the framework? Your project copy is deleted from '
+      + 'disk and the framework version takes over again.'
+    )) return;
 
     await unoverrideArtifact(true);
   }
@@ -96,7 +103,10 @@ export function createScaffoldGalleryEdit(gallery) {
   /** @returns {Promise<void>} */
   async function handleEditFramework() {
     if (!gallery.selectedArtifact) return;
-    if (!confirm('This will create a project copy for editing.')) return;
+    if (!confirm(
+      'Editing this file takes ownership of it: a project copy is written into '
+      + '.claude/, and OSPREY stops overwriting it when artifacts are regenerated.'
+    )) return;
 
     try {
       await apiRequest(`/api/scaffold/${encodeURIComponent(gallery.selectedArtifact.name)}/claim`, {
@@ -282,7 +292,7 @@ export function createScaffoldGalleryEdit(gallery) {
     if (!gallery.selectedArtifact) return;
 
     if (!skipConfirm) {
-      if (!confirm('Reset to framework default? This will remove your customizations.')) {
+      if (!confirm('Reset to the framework default? Your project copy is deleted from disk.')) {
         return;
       }
     }

--- a/src/osprey/interfaces/web_terminal/static/js/scaffold/utils.js
+++ b/src/osprey/interfaces/web_terminal/static/js/scaffold/utils.js
@@ -23,17 +23,31 @@ import { escapeHtml } from '/design-system/js/dom.js';
 export const AGENT_MODEL_OPTIONS = ['haiku', 'sonnet', 'opus'];
 
 /**
- * Brief descriptions for each artifact category, shown in the help tooltip.
+ * Help text for each artifact category, shown in the header tooltip.
+ *
+ * These describe the LOADING MECHANICS of each category, deliberately not what
+ * the shipped files happen to say. The content is the operator's to change --
+ * a blurb about "safety boundaries and error-handling protocols" goes stale the
+ * moment someone edits a rule, while "loads at the start of every session"
+ * stays true whatever they write.
+ *
+ * Keyed by DISPLAY category, so the keys must line up with the values in
+ * {@link BEHAVIOR_CATEGORY_OVERRIDES}/{@link BEHAVIOR_CATEGORY_REMAPS} below
+ * rather than with the raw `category` field on an artifact. Both tables live
+ * in this module so that alignment is checkable in one place (a key that
+ * matches no reachable display category renders no help button at all, silently
+ * -- which is exactly how the CLAUDE.md section went without one).
+ *
  * @type {Record<string, string>}
  */
 export const CATEGORY_HELP = {
-  'system instructions': 'The main CLAUDE.md file that defines the AI assistant\'s identity, capabilities, and behavioral guidelines.',
-  agents: 'Sub-agents that Claude delegates specialized tasks to (search, analysis, visualization). Each agent has its own model, tools, and instructions.',
-  config: 'Top-level configuration files: MCP server definitions (.mcp.json) and permissions (settings.json).',
-  hooks: 'Python scripts that run before or after Claude uses a tool. They enforce safety rules, validate inputs, and inject error guidance.',
-  instructions: 'Markdown files loaded as persistent directives. They define safety boundaries, error handling protocols, and artifact conventions.',
-  skills: 'Multi-file bundles that Claude can invoke as structured workflows. Skills support companion files (CSS/JS references, templates).',
-  'output-styles': 'Markdown style guides that shape how Claude writes responses — tone, format, and epistemic discipline for control system communication.',
+  'project instructions': "The project's CLAUDE.md. Read at the start of every session and injected as a message after the system prompt, so it is context the agent reads rather than a rule the system enforces. It stays for the whole session and is re-read after a context compaction.",
+  instructions: 'Markdown files in .claude/rules/. Each one loads at the start of every session, at the same priority as CLAUDE.md, and stays in context throughout. A file with a paths: header loads only when the agent opens a matching file. Like CLAUDE.md, these are read as context, not enforced.',
+  agents: "Subagent definitions in .claude/agents/. Each runs in its own context window with its own instructions, model, and tool list. The agent delegates when a task matches a subagent's description and gets back only that subagent's final answer — the subagent's own work never enters this session.",
+  skills: 'Folders under .claude/skills/, each with a SKILL.md. Only the name and description load at session start; the body loads when the skill runs — invoked by you with /name, or by the agent when the description matches the task. Companion files in the folder are read on demand.',
+  'output-styles': 'Markdown files in .claude/output-styles/. An output style is appended to the system prompt itself. Exactly one is active at a time, selected by the outputStyle setting, and a change takes effect in the next session. Unless the file sets keep-coding-instructions: true, it replaces the built-in software-engineering instructions. Output styles do not reach subagents.',
+  hooks: "Programs wired to session lifecycle events in settings.json. The runtime runs them itself, not the agent, so a PreToolUse hook can block a tool call before it executes, independent of the agent's decision. This is the only layer in this drawer that enforces rather than advises.",
+  config: ".mcp.json declares which MCP servers start with the session; their tools become the agent's tools. settings.json holds the permission lists, the hook wiring, and the model and output-style selection. Both are read at session start; edits apply on the next session.",
 };
 
 // ---- Category Routing ---- //
@@ -42,6 +56,25 @@ export const BEHAVIOR_CATEGORIES = new Set(['agents', 'skills', 'rules', 'output
 export const BEHAVIOR_NAMES = new Set(['claude-md']);        // config category, behavior tab
 export const SAFETY_CATEGORIES = new Set(['hooks']);
 export const CONFIG_NAMES = new Set(['mcp-json', 'settings-json']); // config category, config tab
+
+/**
+ * Behavior-tab display-category tables, consumed by initScaffoldGallery.
+ *
+ * `claude-md` has no "/" in its canonical name, so the service reports it in
+ * the catch-all `config` category; the override gives it a section of its own.
+ * It is deliberately NOT called "system prompt": CLAUDE.md is delivered as a
+ * message after the system prompt, and the one artifact here that really does
+ * modify the system prompt is the output style.
+ *
+ * @type {Record<string, string>}
+ */
+export const BEHAVIOR_CATEGORY_OVERRIDES = { 'claude-md': 'project instructions' };
+
+/** @type {Record<string, string>} */
+export const BEHAVIOR_CATEGORY_REMAPS = { rules: 'instructions' };
+
+/** @type {string[]} */
+export const BEHAVIOR_PINNED_CATEGORIES = ['project instructions', 'instructions'];
 
 // ---- Marked.js Configuration (one-time) ---- //
 
@@ -111,14 +144,14 @@ export function configureMarked() {
  */
 export function iconForCategory(cat) {
   switch ((cat || '').toLowerCase()) {
-    case 'system prompt':   return '📜'; // scroll
-    case 'instructions': return '📋'; // clipboard
-    case 'agents':   return '🤖';  // robot
-    case 'hooks':    return '⚡';         // lightning
-    case 'commands': return '⌘';         // command key
-    case 'config':   return '⚙';         // gear
-    case 'skills':   return '📦';  // package
-    default:         return '📄';   // document
+    case 'project instructions': return '📜'; // scroll
+    case 'instructions':   return '📋';  // clipboard
+    case 'agents':         return '🤖';  // robot
+    case 'hooks':          return '⚡';  // lightning
+    case 'output-styles':  return '🎨';  // palette
+    case 'config':         return '⚙';   // gear
+    case 'skills':         return '📦';  // package
+    default:               return '📄';  // document
   }
 }
 

--- a/src/osprey/interfaces/web_terminal/static/js/scaffold/view.js
+++ b/src/osprey/interfaces/web_terminal/static/js/scaffold/view.js
@@ -2,9 +2,16 @@
 /**
  * OSPREY Web Terminal — Scaffold Gallery: view layer
  *
- * Gallery-view rendering (search bar, filter chips, untracked-file banner,
- * summary line, and the category/card grid) plus the pure artifact-list
- * filter behind it.
+ * Gallery-view rendering (the muted meta line, the collapsible filter panel
+ * holding search + chips, the untracked-file banner, and the collapsible
+ * category/card grid) plus the pure artifact-list filter behind it.
+ *
+ * Chrome budget: the gallery's only permanent row is the meta line. Search and
+ * the category chips live behind its Filter disclosure, and every category but
+ * the pinned ones starts collapsed, so opening a tab shows artifacts rather
+ * than controls. The cost of hiding controls is that an active filter must
+ * stay legible with the panel shut -- hence the "N of M · <what>" readout and
+ * the clear-all ✕ on the meta line itself.
  *
  * Mirrors the factory/injection pattern scaffold/data.js and
  * lattice_dashboard/render.js already use: {@link createScaffoldGalleryView}
@@ -34,12 +41,19 @@ import { createScaffoldGalleryCards } from './cards.js';
  * @property {string|null} filterCategory
  * @property {boolean} filterProjectOwned
  * @property {string} searchQuery
+ * @property {boolean} [filterOpen]
+ * @property {Set<string>} [collapsedCategories]
+ * @property {Set<string>} [seenCategories]
+ * @property {boolean} [_lastFiltering]
  * @property {string[]} pinnedCategories
  * @property {{total: number, framework: number, userOwned: number}} summary
  * @property {HTMLElement|null} galleryView
  * @property {HTMLElement|null} detailView
  * @property {HTMLElement|null} untrackedBannerEl
  * @property {HTMLElement|null} filterChipsEl
+ * @property {HTMLElement|null} [filterPanelEl]
+ * @property {HTMLElement|null} [filterToggleEl]
+ * @property {HTMLElement|null} [clearFilterEl]
  * @property {HTMLElement|null} summaryEl
  * @property {HTMLInputElement|null} searchInput
  * @property {HTMLElement|null} categoriesEl
@@ -141,6 +155,17 @@ export function createScaffoldGalleryView(gallery) {
     setTimeout(() => document.addEventListener('click', handler), 0);
   }
 
+  /**
+   * True while the artifact list is narrowed by anything -- a category chip,
+   * the project-owned toggle, or a search query. Drives both the meta line's
+   * "N of M" readout and the category seeding below, so a narrowed list can
+   * never be mistaken for a short one.
+   * @returns {boolean}
+   */
+  function isFiltering() {
+    return Boolean(gallery.filterCategory || gallery.filterProjectOwned || gallery.searchQuery);
+  }
+
   /** @returns {void} */
   function renderGallery() {
     if (gallery.galleryView) gallery.galleryView.style.display = '';
@@ -150,8 +175,46 @@ export function createScaffoldGalleryView(gallery) {
 
     renderUntrackedBanner();
     renderFilterChips();
-    renderSummary();
     bindSearch();
+    renderFilterToggle();
+    renderCategories();  // ends with renderSummary()
+  }
+
+  /**
+   * Paint the Filter disclosure and its panel to match `gallery.filterOpen`,
+   * and (re)bind the toggle. Assignment to `onclick` rather than
+   * addEventListener keeps this idempotent across re-renders -- the same
+   * reason bindSearch() clones its input.
+   * @returns {void}
+   */
+  function renderFilterToggle() {
+    const btn = gallery.filterToggleEl;
+    const panel = gallery.filterPanelEl;
+    if (!btn || !panel) return;
+
+    const open = Boolean(gallery.filterOpen);
+    btn.textContent = open ? 'Filter ⌃' : 'Filter ⌄';
+    btn.setAttribute('aria-expanded', String(open));
+    panel.classList.toggle('open', open);
+
+    btn.onclick = () => {
+      gallery.filterOpen = !gallery.filterOpen;
+      renderFilterToggle();
+      if (gallery.filterOpen && gallery.searchInput) gallery.searchInput.focus();
+    };
+  }
+
+  /**
+   * Drop every active filter and re-render. Wired to the meta line's ✕, which
+   * is the escape hatch for a filter left active behind a collapsed panel.
+   * @returns {void}
+   */
+  function clearFilters() {
+    gallery.filterCategory = null;
+    gallery.filterProjectOwned = false;
+    gallery.searchQuery = '';
+    if (gallery.searchInput) gallery.searchInput.value = '';
+    renderFilterChips();
     renderCategories();
   }
 
@@ -175,14 +238,14 @@ export function createScaffoldGalleryView(gallery) {
 
     const title = _el('span', 'prompts-untracked-title');
     const n = gallery.untrackedFiles.length;
-    title.textContent = `${n} file${n > 1 ? 's' : ''} active in Claude Code but not managed by OSPREY`;
+    title.textContent = `${n} file${n > 1 ? 's' : ''} active in the agent's setup but not managed by OSPREY`;
     header.appendChild(title);
 
     banner.appendChild(header);
 
     const desc = _el('div', 'prompts-untracked-desc');
     desc.textContent =
-      'These files are in .claude/ and will be loaded by Claude Code, but they are not tracked in your project config. Register them to manage through this UI, or delete them.';
+      'These files are in .claude/ and take effect in the next session, but they are not tracked in your project config — a rebuild will not reproduce them. Register them to manage through this UI, or delete them.';
     banner.appendChild(desc);
 
     const list = _el('div', 'prompts-untracked-list');
@@ -213,7 +276,7 @@ export function createScaffoldGalleryView(gallery) {
       const deleteBtn = document.createElement('button');
       deleteBtn.className = 'prompts-untracked-btn prompts-untracked-delete';
       deleteBtn.textContent = 'Delete';
-      deleteBtn.title = 'Remove this file from disk — it will no longer affect Claude Code';
+      deleteBtn.title = 'Remove this file from disk — it will no longer reach the agent';
       deleteBtn.addEventListener('click', () => gallery.deleteUntracked(file.canonical_name));
       actions.appendChild(deleteBtn);
 
@@ -275,11 +338,40 @@ export function createScaffoldGalleryView(gallery) {
     }
   }
 
-  /** @returns {void} */
+  /**
+   * Paint the muted meta line. Unfiltered it is a plain inventory; filtered it
+   * names every active narrowing and reveals the clear-all ✕. The framework
+   * count is deliberately gone -- it is just total minus project-owned, and
+   * this line is the gallery's only permanent chrome.
+   * @returns {void}
+   */
   function renderSummary() {
     if (!gallery.summaryEl) return;
+
+    const total = gallery.summary.total;
+    const owned = gallery.summary.userOwned;
+
+    if (!isFiltering()) {
+      gallery.summaryEl.textContent =
+        `${total} artifact${total === 1 ? '' : 's'}` +
+        (owned > 0 ? ` · ${owned} project-owned` : '');
+      if (gallery.clearFilterEl) gallery.clearFilterEl.style.display = 'none';
+      return;
+    }
+
+    /** @type {string[]} */
+    const active = [];
+    if (gallery.filterCategory) active.push(gallery.filterCategory);
+    if (gallery.filterProjectOwned) active.push('project-owned');
+    if (gallery.searchQuery) active.push(`"${gallery.searchQuery}"`);
+
     gallery.summaryEl.textContent =
-      `${gallery.summary.total} artifacts · ${gallery.summary.framework} framework · ${gallery.summary.userOwned} project-owned`;
+      `${boundGetFilteredArtifacts().length} of ${total} · ${active.join(' · ')}`;
+
+    if (gallery.clearFilterEl) {
+      gallery.clearFilterEl.style.display = '';
+      gallery.clearFilterEl.onclick = clearFilters;
+    }
   }
 
   /** @returns {void} */
@@ -332,17 +424,68 @@ export function createScaffoldGalleryView(gallery) {
       if (bPin >= 0) return 1;
       return a.localeCompare(b);
     });
+
+    // Collapse bookkeeping. A category is seeded collapsed the first time it
+    // is seen unless it is pinned; after that the operator's own toggles win.
+    // Crossing the filtered/unfiltered boundary resets both sets, so starting
+    // a search always opens everything (matches can never hide behind a
+    // collapsed header) and clearing it restores the pinned-only default.
+    //
+    // Collapsing only earns its keep when there is more than one section to
+    // choose between: the single-category galleries (Safety's hooks, Config's
+    // two files) would otherwise open on a lone header over an empty panel.
+    // Their operator can still collapse it by hand.
+    const collapsed = gallery.collapsedCategories || (gallery.collapsedCategories = new Set());
+    const seen = gallery.seenCategories || (gallery.seenCategories = new Set());
+    const filtering = isFiltering();
+    const seedCollapsed = !filtering && sortedCategories.length > 1;
+    if (filtering !== gallery._lastFiltering) {
+      gallery._lastFiltering = filtering;
+      collapsed.clear();
+      seen.clear();
+    }
+
     for (const cat of sortedCategories) {
+      if (!seen.has(cat)) {
+        seen.add(cat);
+        if (seedCollapsed && !pinned.includes(cat)) collapsed.add(cat);
+      }
+      const isCollapsed = collapsed.has(cat);
+
       const section = document.createElement('div');
       section.className = 'prompts-category-section';
 
-      // Category header.
+      // Category header — the disclosure control for its own section.
       const header = document.createElement('div');
       header.className = 'prompts-category-header';
+      header.setAttribute('role', 'button');
+      header.tabIndex = 0;
+      header.setAttribute('aria-expanded', String(!isCollapsed));
+
+      const chevron = document.createElement('span');
+      chevron.className = 'prompts-category-chevron';
+      chevron.setAttribute('aria-hidden', 'true');
+      chevron.textContent = isCollapsed ? '▸' : '▾';
+      header.appendChild(chevron);
 
       const label = document.createElement('span');
+      label.className = 'prompts-category-label';
       label.textContent = cat.toUpperCase();
       header.appendChild(label);
+
+      const toggleSection = () => {
+        if (collapsed.has(cat)) collapsed.delete(cat);
+        else collapsed.add(cat);
+        renderCategories();
+      };
+      header.addEventListener('click', toggleSection);
+      header.addEventListener('keydown', (e) => {
+        const key = /** @type {KeyboardEvent} */ (e).key;
+        if (key === 'Enter' || key === ' ') {
+          e.preventDefault();
+          toggleSection();
+        }
+      });
 
       const count = document.createElement('span');
       count.className = 'prompts-category-count';
@@ -363,8 +506,10 @@ export function createScaffoldGalleryView(gallery) {
       }
 
       // "+" create button — use original category (not display-remapped).
+      // No 'commands': no gallery's categoryFilter admits that category, so a
+      // commands section can never render and the branch was unreachable.
       const creatableCategories = new Set([
-        'agents', 'rules', 'hooks', 'skills', 'commands', 'output-styles'
+        'agents', 'rules', 'hooks', 'skills', 'output-styles'
       ]);
       const originalCat = groups[cat][0]?.category || cat;
       if (creatableCategories.has(originalCat.toLowerCase())) {
@@ -381,6 +526,14 @@ export function createScaffoldGalleryView(gallery) {
 
       section.appendChild(header);
 
+      // Cards live in their own wrapper so collapsing is a class flip on one
+      // element. They are always BUILT -- collapsing hides them in CSS rather
+      // than skipping the render, so a collapsed section still answers to the
+      // search index and to card queries.
+      const body = document.createElement('div');
+      body.className = 'prompts-category-body';
+      if (isCollapsed) body.classList.add('collapsed');
+
       // Skills get special grouping.
       if (cat.toLowerCase() === 'skills') {
         /** @type {Record<string, any[]>} */
@@ -392,20 +545,23 @@ export function createScaffoldGalleryView(gallery) {
           skillGroups[skillName].push(art);
         }
         for (const [skillName, groupArts] of Object.entries(skillGroups).sort()) {
-          renderSkillGroup(section, skillName, groupArts);
+          renderSkillGroup(body, skillName, groupArts);
         }
       } else {
         for (const artifact of groups[cat]) {
-          renderArtifactCard(section, artifact, cat);
+          renderArtifactCard(body, artifact, cat);
         }
       }
 
+      section.appendChild(body);
       categoriesEl.appendChild(section);
     }
 
     if (filtered.length === 0) {
       categoriesEl.innerHTML = '<div class="prompts-empty">No matching artifacts found.</div>';
     }
+
+    renderSummary();
   }
 
   /** @returns {any[]} */
@@ -421,6 +577,8 @@ export function createScaffoldGalleryView(gallery) {
     renderGallery,
     renderUntrackedBanner,
     renderFilterChips,
+    renderFilterToggle,
+    clearFilters,
     renderSummary,
     bindSearch,
     renderCategories,

--- a/src/osprey/interfaces/web_terminal/static/js/settings.js
+++ b/src/osprey/interfaces/web_terminal/static/js/settings.js
@@ -58,12 +58,13 @@ const ENUM_FIELDS = {
   'approval.tools.entry_create': ['always', 'selective', 'skip'],
 };
 
-// Fields that should render as toggles (boolean)
+// Fields that should render as toggles even when the current value is null or
+// absent. A field whose value is already a boolean gets a toggle regardless
+// (see createInputForValue), so this set only matters for unset keys.
 const BOOLEAN_FIELDS = new Set([
   'approval.enabled',
   'control_system.writes_enabled',
   'control_system.read_only',
-  'python_execution.enabled',
   'ariel.enabled',
   'artifact_server.auto_launch',
   'screen_capture.enabled',

--- a/src/osprey/services/build_artifacts/catalog.py
+++ b/src/osprey/services/build_artifacts/catalog.py
@@ -51,19 +51,19 @@ def _get_default_artifacts() -> list[BuildArtifact]:
             canonical_name="claude-md",
             template_path="CLAUDE.md.j2",
             output_path="CLAUDE.md",
-            description="CLAUDE.md system prompt (control-system persona)",
+            description="CLAUDE.md project instructions (control-system persona)",
         ),
         BuildArtifact(
             canonical_name="claude-md-ariel",
             template_path="CLAUDE.ariel.md.j2",
             output_path="CLAUDE.md",
-            description="CLAUDE.md system prompt (ARIEL logbook research persona)",
+            description="CLAUDE.md project instructions (ARIEL logbook research persona)",
         ),
         BuildArtifact(
             canonical_name="claude-md-channel-finder",
             template_path="CLAUDE.channel-finder.md.j2",
             output_path="CLAUDE.md",
-            description="CLAUDE.md system prompt (channel-finder assistant persona)",
+            description="CLAUDE.md project instructions (channel-finder assistant persona)",
         ),
         BuildArtifact(
             canonical_name="mcp-json",

--- a/tests/interfaces/web_terminal/scaffold-utils.test.mjs
+++ b/tests/interfaces/web_terminal/scaffold-utils.test.mjs
@@ -22,6 +22,9 @@ import {
   CATEGORY_HELP,
   BEHAVIOR_CATEGORIES,
   BEHAVIOR_NAMES,
+  BEHAVIOR_CATEGORY_OVERRIDES,
+  BEHAVIOR_CATEGORY_REMAPS,
+  BEHAVIOR_PINNED_CATEGORIES,
   SAFETY_CATEGORIES,
   CONFIG_NAMES,
   configureMarked,
@@ -155,8 +158,48 @@ describe('category-routing set membership', () => {
 
   test('CATEGORY_HELP and AGENT_MODEL_OPTIONS are populated, non-empty', () => {
     expect(Object.keys(CATEGORY_HELP).length).toBeGreaterThan(0);
-    expect(CATEGORY_HELP.hooks).toMatch(/before or after Claude uses a tool/i);
+    expect(CATEGORY_HELP.hooks).toMatch(/PreToolUse hook can block a tool call/i);
     expect(AGENT_MODEL_OPTIONS).toContain('sonnet');
+  });
+
+  test('every display category a gallery can render has help text', () => {
+    // The regression guard for a whole bug class: CATEGORY_HELP is keyed by
+    // DISPLAY category, so a key that matches no reachable display category
+    // renders no help button at all and fails silently. That is exactly how
+    // the CLAUDE.md section lost its `?` -- the table said "system
+    // instructions" while the gallery displayed "system prompt".
+    const displayed = new Set();
+    for (const raw of [...BEHAVIOR_CATEGORIES, ...SAFETY_CATEGORIES]) {
+      displayed.add(BEHAVIOR_CATEGORY_REMAPS[raw] || raw);
+    }
+    for (const override of Object.values(BEHAVIOR_CATEGORY_OVERRIDES)) {
+      displayed.add(override);
+    }
+    // mcp-json / settings-json carry no "/" in their canonical name, so the
+    // service reports them under the catch-all `config` category.
+    displayed.add('config');
+
+    const missing = [...displayed].filter((cat) => !CATEGORY_HELP[cat]);
+    expect(missing).toEqual([]);
+  });
+
+  test('no CATEGORY_HELP key is unreachable', () => {
+    const displayed = new Set(['config']);
+    for (const raw of [...BEHAVIOR_CATEGORIES, ...SAFETY_CATEGORIES]) {
+      displayed.add(BEHAVIOR_CATEGORY_REMAPS[raw] || raw);
+    }
+    for (const override of Object.values(BEHAVIOR_CATEGORY_OVERRIDES)) {
+      displayed.add(override);
+    }
+
+    const orphaned = Object.keys(CATEGORY_HELP).filter((key) => !displayed.has(key));
+    expect(orphaned).toEqual([]);
+  });
+
+  test('pinned behavior categories are real display categories', () => {
+    for (const pinned of BEHAVIOR_PINNED_CATEGORIES) {
+      expect(CATEGORY_HELP[pinned]).toBeDefined();
+    }
   });
 });
 

--- a/tests/interfaces/web_terminal/scaffold-view.test.mjs
+++ b/tests/interfaces/web_terminal/scaffold-view.test.mjs
@@ -41,6 +41,10 @@ import {
  *   detailView: HTMLElement,
  *   untrackedBannerEl: HTMLElement,
  *   filterChipsEl: HTMLElement,
+ *   filterPanelEl: HTMLElement,
+ *   filterToggleEl: HTMLElement,
+ *   clearFilterEl: HTMLElement,
+ *   collapsedCategories: Set<string>,
  *   summaryEl: HTMLElement,
  *   searchInput: HTMLInputElement,
  *   categoriesEl: HTMLElement,
@@ -59,12 +63,18 @@ function makeGallery(overrides = {}) {
     filterCategory: null,
     filterProjectOwned: false,
     searchQuery: '',
+    filterOpen: false,
+    collapsedCategories: new Set(),
+    seenCategories: new Set(),
     pinnedCategories: [],
     summary: { total: 0, framework: 0, userOwned: 0 },
     galleryView: document.createElement('div'),
     detailView: document.createElement('div'),
     untrackedBannerEl: document.createElement('div'),
     filterChipsEl: document.createElement('div'),
+    filterPanelEl: document.createElement('div'),
+    filterToggleEl: document.createElement('button'),
+    clearFilterEl: document.createElement('button'),
     summaryEl: document.createElement('div'),
     searchInput: (() => {
       const wrapper = document.createElement('div');
@@ -236,10 +246,94 @@ describe('createScaffoldGalleryView', () => {
 
     view.renderCategories();
 
-    const headers = [...gallery.categoriesEl.querySelectorAll('.prompts-category-header span:first-child')]
+    const headers = [...gallery.categoriesEl.querySelectorAll('.prompts-category-label')]
       .map((el) => el.textContent);
     expect(headers[0]).toBe('HOOKS');
     expect(gallery.categoriesEl.querySelectorAll('.prompts-card').length).toBe(3);
+  });
+
+  test('unpinned categories start collapsed; pinned ones start open', () => {
+    const gallery = makeGallery({ artifacts: ARTIFACTS, pinnedCategories: ['hooks'] });
+    const view = createScaffoldGalleryView(gallery);
+
+    view.renderCategories();
+
+    const sections = [...gallery.categoriesEl.querySelectorAll('.prompts-category-section')];
+    const state = sections.map((s) => [
+      qs(s, '.prompts-category-label').textContent,
+      qs(s, '.prompts-category-body').classList.contains('collapsed'),
+    ]);
+    expect(state).toEqual([['HOOKS', false], ['AGENTS', true], ['SYSTEM PROMPT', true]]);
+  });
+
+  test('a single-category gallery never seeds its only section collapsed', () => {
+    // Safety (hooks only) and Config (mcp-json + settings-json, both `config`)
+    // would otherwise open on a lone header above an empty panel.
+    const gallery = makeGallery({
+      artifacts: [{ name: 'a', displayCategory: 'hooks', status: 'framework' }],
+      pinnedCategories: [],
+    });
+    const view = createScaffoldGalleryView(gallery);
+
+    view.renderCategories();
+
+    expect(qs(gallery.categoriesEl, '.prompts-category-body').classList.contains('collapsed'))
+      .toBe(false);
+  });
+
+  test('collapsed sections still render their cards (hidden, not skipped)', () => {
+    const gallery = makeGallery({ artifacts: ARTIFACTS, pinnedCategories: [] });
+    const view = createScaffoldGalleryView(gallery);
+
+    view.renderCategories();
+
+    // Every section collapsed, yet all three cards exist in the DOM.
+    expect(gallery.categoriesEl.querySelectorAll('.prompts-category-body.collapsed').length).toBe(3);
+    expect(gallery.categoriesEl.querySelectorAll('.prompts-card').length).toBe(3);
+  });
+
+  test('clicking a category header toggles that section only', () => {
+    const gallery = makeGallery({ artifacts: ARTIFACTS, pinnedCategories: ['hooks'] });
+    const view = createScaffoldGalleryView(gallery);
+
+    view.renderCategories();
+    qs(gallery.categoriesEl, '.prompts-category-header').dispatchEvent(new Event('click'));
+
+    const sections = [...gallery.categoriesEl.querySelectorAll('.prompts-category-section')];
+    // HOOKS was open and is now collapsed; the others are untouched.
+    expect(qs(sections[0], '.prompts-category-body').classList.contains('collapsed')).toBe(true);
+    expect(qs(sections[1], '.prompts-category-body').classList.contains('collapsed')).toBe(true);
+    expect(gallery.collapsedCategories.has('hooks')).toBe(true);
+  });
+
+  test('starting a search opens every section so matches cannot hide', () => {
+    const gallery = makeGallery({ artifacts: ARTIFACTS, pinnedCategories: [] });
+    const view = createScaffoldGalleryView(gallery);
+
+    view.renderCategories();  // unfiltered: everything seeded collapsed
+    expect(gallery.categoriesEl.querySelectorAll('.prompts-category-body.collapsed').length).toBe(3);
+
+    gallery.searchQuery = 'a';
+    view.renderCategories();
+
+    expect(gallery.categoriesEl.querySelectorAll('.prompts-category-body.collapsed').length).toBe(0);
+  });
+
+  test('the Filter disclosure opens and closes the panel holding search + chips', () => {
+    const gallery = makeGallery({ artifacts: ARTIFACTS });
+    const view = createScaffoldGalleryView(gallery);
+
+    view.renderFilterToggle();
+    expect(gallery.filterPanelEl.classList.contains('open')).toBe(false);
+    expect(gallery.filterToggleEl.getAttribute('aria-expanded')).toBe('false');
+
+    gallery.filterToggleEl.dispatchEvent(new Event('click'));
+    expect(gallery.filterOpen).toBe(true);
+    expect(gallery.filterPanelEl.classList.contains('open')).toBe(true);
+    expect(gallery.filterToggleEl.getAttribute('aria-expanded')).toBe('true');
+
+    gallery.filterToggleEl.dispatchEvent(new Event('click'));
+    expect(gallery.filterPanelEl.classList.contains('open')).toBe(false);
   });
 
   test('renderCategories shows the empty state when nothing matches', () => {
@@ -289,15 +383,51 @@ describe('createScaffoldGalleryView', () => {
     expect(gallery.filterProjectOwned).toBe(true);
   });
 
-  test('renderSummary renders the totals line', () => {
+  test('renderSummary renders the inventory line and hides the clear button', () => {
     const gallery = makeGallery({ summary: { total: 5, framework: 3, userOwned: 2 } });
     const view = createScaffoldGalleryView(gallery);
 
     view.renderSummary();
 
     expect(gallery.summaryEl.textContent).toContain('5 artifacts');
-    expect(gallery.summaryEl.textContent).toContain('3 framework');
     expect(gallery.summaryEl.textContent).toContain('2 project-owned');
+    expect(gallery.clearFilterEl.style.display).toBe('none');
+  });
+
+  test('an active filter is legible on the meta line even with the panel shut', () => {
+    // The whole point of collapsing the controls: a narrowed list must never
+    // read as a short one.
+    const gallery = makeGallery({
+      artifacts: ARTIFACTS,
+      summary: { total: 3, framework: 2, userOwned: 1 },
+      filterCategory: 'agents',
+      searchQuery: 'one',
+    });
+    const view = createScaffoldGalleryView(gallery);
+
+    view.renderSummary();
+
+    expect(gallery.summaryEl.textContent).toBe('1 of 3 · agents · "one"');
+    expect(gallery.clearFilterEl.style.display).not.toBe('none');
+  });
+
+  test('the meta line\'s clear button drops every filter and re-renders', () => {
+    const gallery = makeGallery({
+      artifacts: ARTIFACTS,
+      summary: { total: 3, framework: 2, userOwned: 1 },
+      filterCategory: 'agents',
+      filterProjectOwned: true,
+      searchQuery: 'one',
+    });
+    const view = createScaffoldGalleryView(gallery);
+
+    view.renderSummary();
+    gallery.clearFilterEl.dispatchEvent(new Event('click'));
+
+    expect(gallery.filterCategory).toBeNull();
+    expect(gallery.filterProjectOwned).toBe(false);
+    expect(gallery.searchQuery).toBe('');
+    expect(gallery.summaryEl.textContent).toContain('3 artifacts');
   });
 
   test('renderUntrackedBanner hides itself when there are no untracked files', () => {


### PR DESCRIPTION
The web terminal's System Settings drawer showed operators a wall of files
without saying what any of them were for. This makes it explain itself.

**Each tab states its purpose.** All four tabs open with a standing one-line
subtitle. The category help tooltips were rewritten to describe how a kind of
file is *loaded* — when it enters the session, what runs it, whether it advises
or enforces — instead of summarizing what the shipped files happen to say,
which went stale the moment an operator edited one. Ownership prompts now state
what taking or releasing ownership actually does.

**Galleries open on artifacts, not controls.** Search and the category chips
moved behind a `Filter ⌄` disclosure on a single muted summary line, and
categories beyond the pinned ones start collapsed. An active filter stays named
on that line (`1 OF 6 · "SAFETY" ✕`) with a one-click clear, so a narrowed list
can never be mistaken for a short one. Sections only seed collapsed when there
is more than one to choose between — a single-category gallery would otherwise
open as a lone header over nothing.

**Two fixes fall out of the same pass.** The `CLAUDE.md` section's help was
filed under a category name no gallery displays, so its `?` button silently
never rendered — on the one artifact that matters most. The Config tab's form
view listed a `python_execution` section that does not exist (the section is
`execution`), hiding execution settings behind Raw YAML; the allowlist now
names the real sections, and `archiver`, `logbook`, and `facility_knowledge`
are editable there too.

**Relabel.** `CLAUDE.md` is "project instructions" rather than "system prompt"
throughout, including the three build-artifact descriptions — it is delivered
as a message after the system prompt, while the output style is what actually
modifies it.

Not included, deliberately: surfacing `config.yml`'s own comments as per-field
help in the Form view, and the `settings.json` `outputStyle` path-vs-name
question — the latter may be a live bug where the control-operator style never
applies, and wants its own verification rather than being folded into a copy
change.
