### PR TITLE
feat(web-terminals): add per-user login to the multi-user stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -765,6 +765,7 @@ jobs:
             --ignore=tests/e2e/test_nextcloud_talk_bridge_e2e.py \
             --ignore=tests/e2e/test_gchat_bridge_e2e.py \
             --ignore=tests/e2e/fixtures/test_gchat_fixture_smoke.py \
+            --ignore=tests/e2e/web_terminals/test_auth_perimeter.py \
             --ignore=tests/e2e/claude_code/test_channel_finder_mcp_benchmarks.py
         fi
 
@@ -1792,6 +1793,68 @@ jobs:
         docker rm -f e2e-nginx || true
         docker rm -f osprey-e2e-mus-p3-registry || true
         docker compose -p osprey-e2e-mus-p3 down || true
+
+  auth-perimeter-e2e:
+    name: Auth Perimeter E2E (real sidecar image + nginx auth_request)
+    runs-on: ubuntu-latest
+    # Same PR scoping as the lifecycle lanes above: same-repo PRs into main
+    # only, since this drives real container lifecycle against the runtime.
+    #
+    # DELIBERATELY ITS OWN LANE. This is the only job in the repo that builds
+    # the deployed auth-sidecar Dockerfile, which is a real
+    # `pip install osprey-framework` with a C toolchain — minutes, cold, every
+    # run. The multi-user lifecycle lanes are all-stub and fast; folding this
+    # into them would have made every lifecycle run pay that build. Keeping it
+    # separate also means the cost shows up on its own line rather than as an
+    # unexplained slowdown in a neighbouring job.
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+
+    - name: Set up Python
+      run: uv python install 3.11
+
+    - name: Set up Docker Compose
+      uses: docker/setup-compose-action@v2
+
+    - name: Install osprey
+      run: uv sync --extra dev
+
+    # `deploy up --dev` builds the sidecar image and stages a locally-built
+    # wheel into its context, so the whole run exercises THIS branch's code
+    # rather than a published release.
+    - name: Run auth perimeter E2E
+      run: |
+        uv run pytest tests/e2e/web_terminals/test_auth_perimeter.py -v --tb=short
+
+    # Belt-and-suspenders on top of the test's own try/finally teardown. Every
+    # resource named here is exact — never a prune, an -a/--all sweep, or a
+    # wildcard — matching the test module's container-ops safety guardrail.
+    - name: Clean up any stranded auth-perimeter resources
+      if: always()
+      run: |
+        for user in alice bob; do
+          docker rm -f "authe2e-web-${user}" || true
+          docker volume rm "osprey-e2e-auth-perimeter_${user}-claude-config" || true
+          docker volume rm "osprey-e2e-auth-perimeter_${user}-agent-data" || true
+        done
+        docker rm -f authe2e-auth || true
+        docker rm -f authe2e-nginx || true
+        docker compose -p osprey-e2e-auth-perimeter down || true
+        docker rmi -f authe2e-assistant-auth:local || true
+        docker rmi -f authe2e-operator:local || true
 
   multi-user-deploy-lifecycle-e2e-podman:
     name: Multi-User Deploy Lifecycle E2E (PRs into main, podman runtime)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,6 +399,15 @@ jobs:
             - 'tests/interfaces/conftest.py'
             - 'tests/interfaces/_browser.py'
             - 'tests/interfaces/test_load_smokes.py'
+            # The multi-user login-flow browser test drives the composed
+            # perimeter — nginx's rendered config plus the auth sidecar — none
+            # of which lives under interfaces/. Without these four a change to
+            # the login page, the nginx template or the shared container
+            # fixture would leave this lane green by skipping it entirely.
+            - 'src/osprey/services/auth_sidecar/**'
+            - 'src/osprey/deployment/web_terminals/**'
+            - 'src/osprey/templates/modules/web_terminals/**'
+            - 'tests/deployment/web_terminals/test_auth_serving.py'
 
     - name: Install uv
       if: steps.changes.outputs.theming == 'true'
@@ -427,6 +436,7 @@ jobs:
           tests/interfaces/web_terminal/test_agent_activity_browser.py \
           tests/interfaces/web_terminal/test_contract_params.py \
           tests/interfaces/web_terminal/test_logout_resume_browser.py \
+          tests/interfaces/web_terminal/test_auth_login_browser.py \
           tests/interfaces/test_load_smokes.py -v --tb=short
 
     - name: Run visual regression suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -478,6 +478,21 @@ Compatibility is documented in release notes, not encoded in the version string.
   exactly where you drop it, or use the ⊞ "open in a new tile" corner on a rail
   entry's hover. Opening an already-open panel beside moves its tile instead of
   duplicating it.
+- A multi-user web-terminal deployment can now require a real login. Set
+  `modules.web_terminals.auth.method` to `password` (passwords OSPREY manages
+  and hashes for you) or `oidc` (your facility's single sign-on, mapped onto
+  roster entries by an `oidc_subject` field), and every request to a user's
+  terminal — pages, APIs and the live connection — is refused unless the
+  browser holds a valid session for that user. `osprey deploy up` provisions
+  each user's password hash into a `0600`, gitignored `.env.auth` that only the
+  login service can read, printing any password it has to generate exactly once;
+  `osprey deploy passwd <user>` rotates one later and ends that user's sessions.
+  It fails closed throughout: without `tls.enabled` the deployment refuses to
+  render rather than send session cookies in the clear (override with
+  `auth.allow_insecure_http` only behind a TLS-terminating proxy), and a deploy
+  aborts before starting anything if a password hash cannot be established. The
+  default stays `auth.method: none`, and no preset turns it on — see the
+  multi-user how-to for the full setup and how to roll it back.
 - Each user in a multi-user deployment can have their own default theme: set
   `theme:` on a roster entry in `modules.web_terminals.users` (a family such as
   `desy`, or a concrete id such as `desy-light` to also pin light/dark). It

--- a/docs/source/cli-reference/index.rst
+++ b/docs/source/cli-reference/index.rst
@@ -184,7 +184,7 @@ Manage Docker/Podman services for Osprey projects.
    osprey deploy ACTION [OPTIONS]
 
 **Actions:** ``up``, ``down``, ``restart``, ``status``, ``build``, ``clean``, ``rebuild``,
-``decommission``, ``prune``, ``nuke``, ``seed``.
+``decommission``, ``prune``, ``nuke``, ``seed``, ``passwd``.
 
 - ``up`` -- Start all configured services.
 - ``down`` -- Stop all services.
@@ -198,6 +198,8 @@ Manage Docker/Podman services for Osprey projects.
 - ``nuke`` -- Tear down the entire multi-user web-terminal stack (destructive).
 - ``seed [USER]`` -- (Re)seed web-terminal workspaces from the user index;
   ``USER`` targets one user, omit to reseed all.
+- ``passwd USER`` -- Change one web-terminal user's login password (password
+  authentication only). Prompts without echoing, and ends that user's sessions.
 
 **Options (apply to all actions):**
 

--- a/docs/source/how-to/multi-user.rst
+++ b/docs/source/how-to/multi-user.rst
@@ -21,6 +21,8 @@ host, brought up with a single ``osprey deploy up``.
    - Standing the two-persona stack up from the ``control-assistant`` preset,
      and watching the write boundary refuse — and approve — a real write
    - Day-to-day operations: adding, reseeding, and removing users
+   - How to require a login — passwords OSPREY manages, or your facility's
+     single sign-on
 
    **Prerequisites:** The concepts need none. To stand the stack up you'll
    want Docker (or Podman) and your model-provider credentials — the
@@ -83,9 +85,10 @@ and builds its container image locally, so no registry or CI is involved.
 
 **One front door.** An nginx reverse proxy serves the landing page and proxies
 ``/u/<name>/`` to that user's container. The per-user containers are pinned to
-the loopback interface, so nginx is the only network path in. The landing
-page's user cards are a convenience for choosing an identity on a trusted
-machine — not authentication (see :ref:`multi-user-require-a-login`).
+the loopback interface, so nginx is the only network path in. The landing page
+lists the roster, and its cards are how someone picks an identity; whether
+clicking a card *lets them in* depends on whether you have turned login on —
+see :ref:`multi-user-require-a-login`.
 
 The config block
 ================
@@ -360,22 +363,219 @@ warm, and returning to the same user reconnects to it.
 Require a login
 ===============
 
-Today the stack ships with **no authentication and no TLS**: anyone who can
-reach the nginx port can open any user's terminal, over plain HTTP. The user
-cards are a convenience for choosing an identity on a shared trusted machine,
-not an access-control boundary — and the persona split is a *capability*
-boundary enforced per project, not an identity one. That posture is right for
-a **single trusted host** — a workstation or control-room machine you already
-trust — and wrong for an untrusted network.
+Out of the box the stack asks for no credentials and speaks plain HTTP:
+clicking a card on the landing page opens that terminal, and anyone who can
+reach the nginx port can click any card. That posture suits a **single trusted
+host** — a workstation or control-room machine you already trust — and nothing
+beyond it. It is the walkthrough's choice, not a limit of the stack: it keeps
+one ``osprey deploy up`` on a laptop free of certificates and identity
+providers. No preset ships with login enabled, so this is something you turn on
+deliberately.
+
+Set ``auth.method`` and every request under ``/u/<name>/`` — pages, APIs and
+the terminal's live connection alike — is refused unless the browser holds a
+valid session for *that* user. The check happens at the front door: a small
+authentication service joins the stack in its own container, and nginx asks it
+about each request before proxying anything. Nothing depends on the per-user
+containers policing themselves.
+
+Note that the persona split is a *capability* boundary, enforced per project —
+it decides what a session may do, never who may open it. Those are separate
+questions, and login answers only the second.
+
+Choose a method
+---------------
+
+**Passwords**, managed by OSPREY. Nothing extra to run or operate:
+
+.. code-block:: yaml
+
+   modules:
+     web_terminals:
+       tls:
+         enabled: true
+         cert: /etc/osprey/tls/facility.crt
+         key: /etc/osprey/tls/facility.key
+       auth:
+         method: password
+
+**OIDC**, against the single sign-on your facility already runs. Each roster
+entry names the identity that maps to it, so a valid login as somebody else
+cannot open this user's terminal:
+
+.. code-block:: yaml
+
+   modules:
+     web_terminals:
+       tls:
+         enabled: true
+         cert: /etc/osprey/tls/facility.crt
+         key: /etc/osprey/tls/facility.key
+       auth:
+         method: oidc
+         oidc:
+           issuer: https://sso.example.org/realms/accelerator
+           client_id_env: OSPREY_AUTH_OIDC_CLIENT_ID
+           client_secret_env: OSPREY_AUTH_OIDC_CLIENT_SECRET
+           claim: sub                       # ID-token claim to match on
+       users:
+         - name: alice
+           index: 0
+           oidc_subject: "8f4c1e02-..."     # alice's value of that claim
+         - name: bob
+           index: 1
+           oidc_subject: "b7d9a340-..."
+
+The ``*_env`` keys hold environment-variable **names**, not credentials: put the
+client id and secret in the project's ``.env`` under those names. The names
+shown are the ones OSPREY reads when you omit the keys, and ``claim`` falls back
+to ``sub`` in the authentication service itself. ``oidc_subject`` is not a
+secret — it is the identifier your provider already publishes for that person.
+
+Three more keys are optional. ``auth.port`` is the port the authentication
+service listens on (default ``9070``); ``auth.session_lifetime`` is how long a
+session stays valid, in **whole seconds** (default ``43200``, twelve hours); and
+``auth.image`` names the service's image, which is **required** when
+``image_source: registry`` — your CI publishes that image the same way it
+publishes the terminal images. In ``image_source: local`` mode
+``osprey deploy up`` builds it for you and ``auth.image`` is not needed.
+
+.. warning::
+
+   ``auth.port`` and ``auth.session_lifetime`` must be plain positive integers.
+   A duration string like ``"12h"``, a decimal, zero or a negative number is
+   **silently replaced by the default** — nothing warns you — so a deployment
+   that meant eight-hour sessions would quietly keep twelve-hour ones.
+
+The service listens on ``127.0.0.1`` on the deploy host itself (the web stack
+uses host networking), so nginx reaches it and nothing off-host does. It is not
+published as a container port, and anyone with a shell on the deploy host can
+reach it — the same as every per-user terminal.
+
+Serve it over HTTPS
+-------------------
+
+A session cookie sent over plain HTTP is readable by anything on the path, so a
+deployment with ``auth.method`` other than ``none`` and ``tls.enabled: false``
+**refuses to render at all** rather than hand out cookies in the clear. You
+therefore have to pick one of two ways to get the connection encrypted.
+
+**Let this nginx terminate TLS.** Set ``tls.enabled: true`` with a certificate
+and key, and nginx serves HTTPS on 443, redirects the plain port to it, and
+marks session cookies so browsers only ever send them over HTTPS. Bringing the
+certificate itself is your job, and it takes one step OSPREY does not do for
+you:
+
+.. important::
+
+   ``tls.cert`` and ``tls.key`` are paths **inside the nginx container**, not on
+   the deploy host, and the generated compose overlay mounts nothing but nginx's
+   own config files. Setting the two keys alone leaves nginx pointing at files
+   that do not exist there, and it will not start. Bind-mount the directory
+   holding your certificate and key into the ``nginx`` service — from a small
+   compose file of your own, listed after the web overlay in
+   ``runtime.compose_files`` — and give ``tls.cert`` / ``tls.key`` the paths as
+   seen *inside* the container.
+
+**Or terminate TLS in front of this nginx.** If a facility load balancer or
+ingress proxy already presents the certificate and forwards to this host, set
+``auth.allow_insecure_http: true`` and leave ``tls.enabled`` off. This is a
+normal deployment, not a workaround: the browser's connection is encrypted by
+the thing in front, and the hop it forwards over is yours to keep private.
+
+What ``allow_insecure_http`` is *not* is a way to postpone certificates on a
+reachable host. With it set and nothing terminating TLS, anyone who can watch
+the traffic can copy a session cookie and become that user. An isolated network
+where you accept that risk is the only other case for it.
+
+Passwords, and where they live
+------------------------------
+
+In password mode ``osprey deploy up`` makes sure every user on the roster has a
+password hash before it starts anything, and aborts before a single container
+starts if it cannot — an unwritable file is caught here rather than becoming a
+stack nobody can log in to. The same check covers the keys used to sign session
+cookies, so an OIDC deployment can abort the same way even though it provisions
+no passwords at all. The usual cause either way is permissions on ``.env.auth``
+or on the project directory.
+
+The hashes and signing keys live in ``.env.auth`` in the project root — mode
+``0600``, listed in the generated ``.gitignore`` next to ``.env.production``,
+and handed to the authentication service alone. No terminal container ever sees
+it.
+
+For each user, in order:
+
+#. An existing hash in ``.env.auth`` is kept. Deploying again never resets
+   anyone's password.
+#. Otherwise, a plaintext ``OSPREY_AUTH_PW_<USER>`` in the project's ``.env`` is
+   hashed into ``.env.auth`` — the way to set a password you already chose. The
+   plaintext stays on the deploy host; only the hash reaches a container.
+#. Otherwise a password is generated, hashed, and **printed once**, on that
+   deploy's output. Nothing can recover it afterwards, so capture it and hand it
+   to the person.
+
+``<USER>`` is the username uppercased with ``-`` turned into ``_``. Because that
+mapping is what keeps one user's password out of another user's terminal, an
+authenticated deployment refuses to render when two roster names collide under
+it (``alice-b`` and ``alice_b``), or when a name falls outside
+``[a-z0-9][a-z0-9_-]*``.
+
+To change a password later:
+
+.. code-block:: bash
+
+   osprey deploy passwd alice
+
+It prompts (never echoing), rewrites that one hash, and restarts the
+authentication service. Alice's existing sessions stop working immediately, and
+nobody else's are touched.
+
+Sessions, logging out, and rolling back
+---------------------------------------
+
+The landing page stays public — it lists the roster so people can find their own
+card, and a card is a prompt, not a door. One browser may hold several unlocked
+users at once, which is what a shared control-room machine needs; logging out
+ends that one user's session and leaves the others alone.
 
 .. note::
 
-   Per-user login (passwords OSPREY manages for you, or your facility's
-   single sign-on) and TLS are being added and will document themselves in
-   this section. Until then, do not set
-   ``modules.web_terminals.auth.method``: the seam is fail-closed by design,
-   so enabling it locks *every* user out rather than silently authorizing
-   them.
+   The list of logged-out sessions is held in the authentication service's
+   memory, so restarting that container forgets it. A cookie captured before a
+   logout could be replayed until it expires on its own — within
+   ``auth.session_lifetime``.
+
+Removing someone needs care, because a credential can outlive the person's
+account in three different ways:
+
+**Use** ``osprey deploy decommission alice`` **, not a hand-edit.** Deleting a
+roster entry and running ``osprey deploy up`` removes alice's container, and the
+authentication service stops answering for a name that is no longer on the
+roster — but her hash stays in ``.env.auth``. Add the name back months later and
+her old password works again. ``decommission`` (or ``prune``, for names already
+edited out) is what actually retires the credential.
+
+**A plaintext password in** ``.env`` **survives decommission.** If you seeded
+alice's password by putting ``OSPREY_AUTH_PW_ALICE`` in the project's ``.env``,
+decommissioning her clears the hash but leaves that line — and the next
+``osprey deploy up`` for a new alice hashes it straight back in, handing the new
+person the departed one's password. The decommission warns you, but the warning
+scrolls past in a deploy log weeks before anyone reuses the name. **Delete the**
+``.env`` **line by hand when the person leaves.**
+
+**In OIDC mode,** ``decommission`` **is the verb that ends a session.**
+``prune`` cleans up users already off the roster, but it only restarts the
+authentication service when it actually removed a password entry — and an OIDC
+user has none. Their container is gone either way, so the stale route just
+fails; but if what you need is that person's *session* closed now, run
+``decommission``.
+
+To turn login back off, set ``auth.method: none`` and run ``osprey deploy up``.
+That re-renders nginx and the compose file, drops the authentication service,
+and returns the stack to the open posture described at the top of this section.
+``.env.auth`` is left in place, so turning login on again keeps everyone's
+existing password.
 
 Related pages
 =============

--- a/docs/source/how-to/multi-user.rst
+++ b/docs/source/how-to/multi-user.rst
@@ -394,7 +394,8 @@ Choose a method
      web_terminals:
        tls:
          enabled: true
-         cert: /etc/osprey/tls/facility.crt
+         host_cert_dir: /etc/ssl/facility     # host side; mounted for you
+         cert: /etc/osprey/tls/facility.crt   # container side
          key: /etc/osprey/tls/facility.key
        auth:
          method: password
@@ -409,7 +410,8 @@ cannot open this user's terminal:
      web_terminals:
        tls:
          enabled: true
-         cert: /etc/osprey/tls/facility.crt
+         host_cert_dir: /etc/ssl/facility     # host side; mounted for you
+         cert: /etc/osprey/tls/facility.crt   # container side
          key: /etc/osprey/tls/facility.key
        auth:
          method: oidc
@@ -463,19 +465,37 @@ therefore have to pick one of two ways to get the connection encrypted.
 **Let this nginx terminate TLS.** Set ``tls.enabled: true`` with a certificate
 and key, and nginx serves HTTPS on 443, redirects the plain port to it, and
 marks session cookies so browsers only ever send them over HTTPS. Bringing the
-certificate itself is your job, and it takes one step OSPREY does not do for
-you:
+certificate is still your job, but getting it *into* the container is not:
 
-.. important::
+.. code-block:: yaml
 
-   ``tls.cert`` and ``tls.key`` are paths **inside the nginx container**, not on
-   the deploy host, and the generated compose overlay mounts nothing but nginx's
-   own config files. Setting the two keys alone leaves nginx pointing at files
-   that do not exist there, and it will not start. Bind-mount the directory
-   holding your certificate and key into the ``nginx`` service — from a small
-   compose file of your own, listed after the web overlay in
-   ``runtime.compose_files`` — and give ``tls.cert`` / ``tls.key`` the paths as
-   seen *inside* the container.
+   tls:
+     enabled: true
+     host_cert_dir: /etc/ssl/facility          # on the deploy host
+     cert: /etc/osprey/tls/facility.crt        # inside the container
+     key: /etc/osprey/tls/facility.key
+
+``host_cert_dir`` is the only key here that names a path on the **deploy host**;
+``cert`` and ``key`` are paths **inside the nginx container**. Setting
+``host_cert_dir`` bind-mounts that directory, read-only, at the directory
+``cert`` sits in — so the certificate is where nginx looks without you writing
+any compose of your own. Renewals need nothing extra: the mount is a directory,
+so a replaced file is picked up on the next nginx reload.
+
+Because one mount has to deliver both files, ``cert`` and ``key`` must sit in
+the same directory, and ``host_cert_dir`` must be absolute. A deployment that
+breaks either rule is refused at render time, naming the reason — rather than
+starting an nginx that immediately dies looking for a file nobody mounted.
+
+.. note::
+
+   ``host_cert_dir`` is optional. Leave it out and nothing is mounted: the
+   compose overlay renders exactly as it does without TLS, and supplying the
+   certificate is yours to arrange — a bind mount from a small compose file of
+   your own, listed after the web overlay in ``runtime.compose_files``, or
+   whatever your facility's certificate management already does. That is the
+   route to take when a plain directory bind cannot express how certificates
+   reach this host.
 
 **Or terminate TLS in front of this nginx.** If a facility load balancer or
 ingress proxy already presents the certificate and forwards to this host, set

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,19 @@ dependencies = [
     # ARIEL Web Interface (FastAPI server)
     "fastapi>=0.140.0",
     "uvicorn[standard]>=0.51.0",
+    # OIDC client + JOSE (token verification) for the multi-user web-terminal
+    # auth sidecar. Declared explicitly rather than relied on as fastmcp's
+    # transitive dependency — the sidecar imports it directly.
+    "authlib>=1.6.5",
+    # Signed session cookies for the auth sidecar (login session id + unlocked-user set).
+    "itsdangerous>=2.2.0",
+    # Form parsing for the auth sidecar's login POST. Starlette requires this for
+    # EVERY form body, urlencoded included — not only multipart — so without it a
+    # login POST fails at request time rather than at import. Declared explicitly
+    # for the same reason as authlib above: it reaches us today only as `mcp`'s
+    # transitive dependency, and a sidecar image built from a narrower set would
+    # serve a login page whose form can never be submitted.
+    "python-multipart>=0.0.18",
     # Utilities
     "unique-namer>=0.1.0",
     # EPICS Channel Access client (used by control_system connector,

--- a/scripts/benchmark/matrix_e2e_config.json
+++ b/scripts/benchmark/matrix_e2e_config.json
@@ -127,6 +127,10 @@
       "reason": "Boot smoke for the Google Chat bridge's own test fixtures (loopback HTTP fakes and the Pub/Sub emulator container) — it asserts that the fixtures answer, never runs an agent, and contacts no model."
     },
     {
+      "path": "tests/e2e/web_terminals/test_auth_perimeter.py",
+      "reason": "Builds the real auth-sidecar image and drives one `osprey deploy up`, then asserts over plain HTTP that the login perimeter refuses and admits; no LLM anywhere, and the image build would cost every matrix cell minutes for no model signal."
+    },
+    {
       "path": "tests/e2e/web_terminals/test_loopback_chokepoint.py",
       "reason": "No LLM anywhere: launches `osprey web` with --shell true (PTY runs /usr/bin/true, never spawns an agent) and asserts TCP bind behavior via raw socket connects."
     },

--- a/src/osprey/cli/deploy_cmd.py
+++ b/src/osprey/cli/deploy_cmd.py
@@ -35,6 +35,7 @@ from .project_utils import resolve_config_path, resolve_project_path
             "prune",
             "nuke",
             "seed",
+            "passwd",
         ]
     ),
 )
@@ -123,6 +124,8 @@ def deploy(
       nuke          - Tear down the entire multi-user web-terminal stack (WARNING: destructive)
       seed          - (Re)seed web-terminal workspaces from the user index; optional
                       USER targets one user, omit to reseed all
+      passwd        - Change one web-terminal user's login password (requires USER);
+                      prompts for the new password and ends that user's sessions
 
     The services to deploy are defined in your config.yml under
     the 'deployed_services' key.
@@ -191,11 +194,14 @@ def deploy(
 
       # Reseed every user's workspace from the user index
       $ osprey deploy seed
+
+      # Change alice's web-terminal login password (prompts, never echoes)
+      $ osprey deploy passwd alice
     """
     # Argument validation happens BEFORE any project/config resolution or
     # lazy import so it is exercised even when the lifecycle modules (or a
     # project directory) don't exist yet.
-    if action == "decommission" and not user:
+    if action in ("decommission", "passwd") and not user:
         raise click.UsageError(
             f"'{action}' requires a USER argument, e.g. osprey deploy {action} alice"
         )
@@ -213,9 +219,9 @@ def deploy(
         raise click.UsageError(f"--dry-run is only valid for 'prune', not '{action}'.")
 
     # A stray USER on an action that doesn't consume it is a typo, not a no-op:
-    # only decommission/seed take a target user (the require-USER guard above
-    # covers the missing-user case for those two).
-    if user and action not in ("decommission", "seed"):
+    # only decommission/seed/passwd take a target user (the require-USER guard
+    # above covers the missing-user case for decommission and passwd).
+    if user and action not in ("decommission", "seed", "passwd"):
         raise click.UsageError(f"'{action}' does not take a USER argument (got {user!r}).")
 
     if action != "status":
@@ -345,6 +351,32 @@ def deploy(
             from osprey.deployment.web_terminals.seeding import seed_web_terminals
 
             seed_web_terminals(config_path, user)
+
+        elif action == "passwd":
+            from osprey.deployment.web_terminals.lifecycle import rotate_user_password
+
+            assert user is not None  # narrows for type-checkers; guarded above
+
+            # hide_input: the password is never echoed to the terminal, never
+            # placed on the argv (where it would land in shell history and in
+            # every `ps` listing on the host), and never logged.
+            # confirmation_prompt: a mistyped password would otherwise lock the
+            # user out of a terminal that was working a moment ago.
+            password = click.prompt(
+                f"New web-terminal password for {user}",
+                hide_input=True,
+                confirmation_prompt=True,
+            )
+            rotate_user_password(config_path, user, password)
+            # Deliberately does not claim the old sessions are already dead:
+            # when nothing has been deployed from this root yet, the recreate
+            # is skipped (with its own warning) and the change takes effect at
+            # the next `deploy up`. Stating the consequence without asserting
+            # the timing keeps this true on both paths.
+            console.print(
+                f"\n✓ Password changed for [accent]{user}[/accent]. Any session they "
+                "still hold stops working as soon as the sidecar is running this change."
+            )
 
     except KeyboardInterrupt:
         console.print("\n!  Operation cancelled by user", style=Styles.WARNING)

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -958,8 +958,16 @@ def deploy_up(config_path, detached=False, dev_mode=False, expose_network=False)
     # abort on a missing provider secret must say so in seconds, not after
     # the whole project image has been built. deploy_up_web_terminals re-runs
     # the same (idempotent) steps later, unchanged.
+    #
+    # Its result is CAPTURED and threaded into deploy_up_web_terminals below,
+    # not discarded: preflight is the only step that can tell whether THIS
+    # deploy changed `.env.auth`, and compose bakes an `env_file`'s content into
+    # a container at creation time, so the deploy that changed the file is the
+    # one that has to recreate the auth sidecar. Recomputing it later is not an
+    # option — provisioning is idempotent, so a second run reports no change.
+    web_preflight = None
     if web_terminals_enabled:
-        preflight_web_terminals(config, env)
+        web_preflight = preflight_web_terminals(config, env)
 
     # Build the <project>:local image the dispatch worker references. The worker
     # has no compose build block (that would race the event-dispatcher on the
@@ -969,7 +977,9 @@ def deploy_up(config_path, detached=False, dev_mode=False, expose_network=False)
     _build_project_image(config, dev_mode, env)
 
     if web_terminals_enabled:
-        deploy_up_web_terminals(config, compose_files, dev_mode, env, _env_file_args())
+        deploy_up_web_terminals(
+            config, compose_files, dev_mode, env, _env_file_args(), web_preflight
+        )
         log_endpoint_summary(config, compose_files)
         return
 

--- a/src/osprey/deployment/web_terminals/auth_credentials.py
+++ b/src/osprey/deployment/web_terminals/auth_credentials.py
@@ -1,0 +1,689 @@
+"""Deploy-time provisioning of per-user web-terminal auth credentials.
+
+Owns ``.env.auth``: the 0600 project-root file holding one
+``OSPREY_AUTH_PW_HASH_<USER>`` entry per roster user, referenced ONLY by the
+auth sidecar's compose ``env_file`` so an auth secret never reaches a per-user
+agent container. :func:`ensure_auth_credentials` establishes a hash for every
+roster user; :func:`purge_auth_credentials` removes a departed user's entries so
+a re-added same-name user gets a fresh credential rather than inheriting the
+previous holder's password.
+
+Provisioning follows the "existing value wins, append what's missing"
+convention of the service-token writer
+(``osprey.deployment.container_lifecycle._ensure_service_tokens``): re-running a
+deploy never rewrites a hash that is already there, so the operation is
+idempotent and pre-existing sessions survive a routine deploy.
+
+Two namespaces live under the ``OSPREY_AUTH_PW_`` stem and are deliberately
+kept in different files: plaintext ``OSPREY_AUTH_PW_<USER>`` is read from the
+project ``.env`` as a convenience input and is hashed on the way in, while
+``OSPREY_AUTH_PW_HASH_<USER>`` is written to (and read from) ``.env.auth``.
+Only the latter is ever handed to a container, so a plaintext password set for
+convenience never ships.
+
+Username validity is enforced *here* as a hard raise rather than left to lint:
+``osprey deploy`` never runs lint, and two usernames that normalize onto one
+env-var suffix (``alice-b`` and ``alice_b``) would silently share a single hash
+— one operator's password opening the other's terminal, the exact isolation
+failure this feature exists to prevent.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+# The service-token recipes are imported rather than restated so the signing
+# secrets below are minted and validated exactly like every other deploy-time
+# secret, and pick up any constraint registered for them later.
+from osprey.deployment.service_tokens import (
+    _generate_token,
+    _raise_invalid_var,
+    _validate_var,
+)
+
+# `USERNAME_CHARSET_RE` is the single definition of the roster-username charset,
+# shared with the lint rule that reports the same violation at scaffold time and
+# with render's fail-closed gate. Restating the pattern here would let the
+# deploy-time gate and the other two drift apart.
+from osprey.deployment.web_terminals.personas import (
+    USERNAME_CHARSET_RE,
+    env_var_suffix,
+    env_var_suffix_collisions,
+)
+from osprey.services.auth_sidecar.passwords import hash_password
+from osprey.utils.dotenv import dotenv_line_var, parse_dotenv_file
+from osprey.utils.logger import get_logger
+
+logger = get_logger("deployment.lifecycle")
+
+#: Project-root file holding the per-user password hashes. Separate from the
+#: project ``.env`` so the sidecar can be the only service that mounts it.
+AUTH_ENV_FILENAME = ".env.auth"
+
+#: Env-var stem for a stored hash, completed by :func:`env_var_suffix`.
+PW_HASH_VAR_PREFIX = "OSPREY_AUTH_PW_HASH_"
+
+#: Env-var stem for an operator-supplied plaintext password in the project
+#: ``.env``. Consumed and hashed at preflight; never forwarded to a container.
+PW_PLAINTEXT_VAR_PREFIX = "OSPREY_AUTH_PW_"
+
+#: The sidecar's cookie-signing secret, required in EVERY auth method — an
+#: empty one takes the whole sidecar to 503.
+SESSION_SECRET_VAR = "OSPREY_AUTH_SESSION_SECRET"
+
+#: Secret for the short-lived OIDC state cookie. Required by the sidecar only
+#: in ``oidc`` mode, but minted alongside the session secret regardless.
+STATE_SECRET_VAR = "OSPREY_AUTH_STATE_SECRET"
+
+#: Both signing secrets, in a fixed order so an appended block is byte-stable.
+SESSION_SECRET_VARS = (SESSION_SECRET_VAR, STATE_SECRET_VAR)
+
+_HASH_HEADER = "# Auto-generated web-terminal auth password hashes (osprey deploy)"
+_SECRET_HEADER = "# Auto-generated web-terminal auth signing secrets (osprey deploy)"
+
+# Minted-password alphabet: alphanumerics minus the transcription lookalikes
+# (0/O, 1/l/I). A minted password is read off a terminal and retyped by a
+# person, so ambiguity costs support calls; staying alphanumeric also keeps the
+# value free of any character a dotenv parser treats specially.
+_MINT_ALPHABET = "abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+
+# Length of a minted password in characters. 16 characters from this 57-symbol
+# alphabet is ~93 bits of entropy — far above what the sidecar's per-user
+# attempt throttle leaves reachable, and short enough to retype. This is a
+# human-facing password, not a machine token, so it deliberately does not carry
+# the 256-bit bar the service-token recipes hold themselves to.
+_MINT_LENGTH = 16
+
+
+@dataclass(frozen=True)
+class AuthCredentialsResult:
+    """Outcome of one :func:`ensure_auth_credentials` run.
+
+    ``changed`` is the field the deploy path keys off: whenever ``.env.auth``
+    gains content, the sidecar must be force-recreated rather than restarted,
+    because compose bakes ``env_file`` content into the container at *creation*
+    time — a restarted sidecar would keep serving the previous file's hashes.
+
+    ``missing`` names users for whom no hash could be established (the file
+    could not be written). It is the post-mint invariant the fail-closed deploy
+    gate checks: a ``method: password`` deploy with a non-empty ``missing`` must
+    abort before any compose invocation rather than come up with a user who can
+    never log in.
+    """
+
+    env_auth_path: Path
+    changed: bool
+    minted: tuple[str, ...]
+    hashed_from_plaintext: tuple[str, ...]
+    preexisting: tuple[str, ...]
+    missing: tuple[str, ...]
+
+
+def _validate_usernames(usernames: list[str]) -> None:
+    """Reject a roster this module cannot key credentials for, with a hard raise.
+
+    Raises:
+        RuntimeError: If any username falls outside the roster charset, or if
+            two distinct usernames normalize onto the same env-var suffix.
+    """
+    invalid = [name for name in usernames if not USERNAME_CHARSET_RE.fullmatch(name)]
+    if invalid:
+        raise RuntimeError(
+            "Cannot provision web-terminal auth credentials: "
+            f"{', '.join(repr(name) for name in sorted(invalid))} does not match "
+            f"{USERNAME_CHARSET_RE.pattern!r} (usernames become nginx location keys "
+            "and URL path segments). Refusing to deploy."
+        )
+
+    collisions = env_var_suffix_collisions(usernames)
+    if collisions:
+        detail = "; ".join(
+            f"{', '.join(repr(n) for n in names)} -> {PW_HASH_VAR_PREFIX}{suffix}"
+            for suffix, names in collisions.items()
+        )
+        raise RuntimeError(
+            "Cannot provision web-terminal auth credentials: distinct usernames map "
+            f"onto one credential variable ({detail}). They would share a single "
+            "password, so one user's credentials would open another's terminal. "
+            "Rename one of them. Refusing to deploy."
+        )
+
+
+def _mint_password() -> str:
+    """Generate one human-typeable password from a CSPRNG."""
+    return "".join(secrets.choice(_MINT_ALPHABET) for _ in range(_MINT_LENGTH))
+
+
+def _append_entries(env_auth_path: Path, entries: dict[str, str], header: str) -> None:
+    """Append ``entries`` to ``.env.auth`` under ``header``, creating it 0600.
+
+    The file is opened with an explicit 0600 creation mode rather than being
+    created and then chmod'ed, so a hash is never briefly world-readable.
+
+    The append is not atomic: a crash mid-write can leave the final line
+    truncated. That degrades fail-closed in every case — a truncated hash value
+    no longer verifies any password, and a truncated variable name leaves its
+    user with no hash at all (the next deploy re-mints one). Neither outcome
+    grants access, and an operator recovers either with ``osprey deploy passwd
+    <user>``. Entries written before the torn line are complete and unaffected,
+    since each occupies its own line.
+
+    Raises:
+        OSError: If the file or its directory cannot be written.
+    """
+    prefix = ""
+    if env_auth_path.is_file():
+        text = env_auth_path.read_text(encoding="utf-8")
+        if text and not text.endswith("\n"):
+            prefix = "\n"
+    block = "".join(f"{key}={value}\n" for key, value in entries.items())
+    fd = os.open(env_auth_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    with os.fdopen(fd, "a", encoding="utf-8") as fh:
+        fh.write(f"{prefix}{header}\n{block}")
+
+
+def _normalize_mode(env_auth_path: Path) -> None:
+    """Tighten an existing ``.env.auth`` to 0600, never raising.
+
+    Guarded on its own because the callers' write paths deliberately *report*
+    an OSError rather than raise it: on a read-only filesystem this chmod
+    raises the same error, and letting it escape would break that contract from
+    the last statement of the caller. A mode change is not a content change, so
+    this never affects a caller's ``changed`` report.
+    """
+    if not env_auth_path.is_file():
+        return
+    try:
+        os.chmod(env_auth_path, 0o600)
+    except OSError as exc:
+        logger.warning(
+            "Could not set 0600 permissions on %s (%s); check them by hand — "
+            "it holds web-terminal auth secrets.",
+            env_auth_path,
+            exc,
+        )
+
+
+def ensure_auth_credentials(
+    usernames: Iterable[str],
+    project_root: str | Path,
+    *,
+    echo: Callable[[str], None] = print,
+) -> AuthCredentialsResult:
+    """Establish a password hash in ``.env.auth`` for every roster user.
+
+    Per user, in precedence order:
+
+    1. An ``OSPREY_AUTH_PW_HASH_<USER>`` entry already in ``.env.auth`` is kept
+       untouched — re-deploying is idempotent and does not invalidate sessions.
+       An entry present but *empty* (``OSPREY_AUTH_PW_HASH_ALICE=``) does not
+       count as established: that user falls through to the steps below and the
+       freshly written entry, appended after the empty one, is the one the
+       parser returns (last assignment wins). An empty value would otherwise
+       leave a roster user permanently unable to log in.
+    2. Otherwise a plaintext ``OSPREY_AUTH_PW_<USER>`` in the project ``.env``
+       is hashed in. Leading and trailing whitespace is trimmed before hashing,
+       so a value padded by an editor or a copy-paste hashes to what the
+       operator will actually type at the login prompt; a password whose real
+       content is only whitespace is treated as absent. The plaintext stays in
+       ``.env`` (which no container receives on the auth path) and is never
+       echoed: the operator already knows it.
+    3. Otherwise a random password is minted, hashed, and printed **once**.
+       That print is the only moment the password exists in cleartext output;
+       it is never logged, and only its hash is persisted, so it cannot be
+       recovered afterwards.
+
+    Neither the process environment nor ``.env`` is consulted for a *hash*: the
+    sidecar reads its credentials solely from ``.env.auth`` via compose
+    ``env_file``, so a hash visible only to this process would suppress the mint
+    and leave the user unable to log in. Likewise a plaintext password is read
+    only from the project ``.env`` file, never from the process environment — a
+    stray exported variable must not silently become a deployed credential.
+
+    A write failure (read-only ``.env.auth``, unwritable project root) is
+    reported through ``missing`` rather than raised, so the deploy path's
+    fail-closed gate produces the abort with its own context. Nothing is printed
+    for a password that could not be persisted.
+
+    Args:
+        usernames: Roster usernames, typically ``entry["name"]`` for each
+            ``normalize_users`` entry. Order is preserved; a name repeated
+            verbatim is one user listed twice and is processed once.
+        project_root: Directory holding ``.env`` and ``.env.auth``.
+        echo: Sink for the one-time minted-password notice. Defaults to
+            :func:`print` — deliberately not the logger, which ships elsewhere.
+
+    Returns:
+        An :class:`AuthCredentialsResult` describing what happened, including
+        whether ``.env.auth`` changed.
+
+    Raises:
+        RuntimeError: If a username is outside the roster charset, or two
+            distinct usernames collide onto one credential variable.
+    """
+    ordered: list[str] = []
+    for name in usernames:
+        if name not in ordered:
+            ordered.append(name)
+    _validate_usernames(ordered)
+
+    root = Path(project_root)
+    env_auth_path = root / AUTH_ENV_FILENAME
+    dotenv_path = root / ".env"
+
+    stored = parse_dotenv_file(env_auth_path) if env_auth_path.is_file() else {}
+    project_env = parse_dotenv_file(dotenv_path) if dotenv_path.is_file() else {}
+
+    preexisting: list[str] = []
+    hashed_from_plaintext: list[str] = []
+    minted: list[str] = []
+    pending: dict[str, str] = {}
+    minted_passwords: dict[str, str] = {}
+
+    for name in ordered:
+        suffix = env_var_suffix(name)
+        hash_var = f"{PW_HASH_VAR_PREFIX}{suffix}"
+        if stored.get(hash_var, "").strip():
+            preexisting.append(name)
+            continue
+        plaintext = project_env.get(f"{PW_PLAINTEXT_VAR_PREFIX}{suffix}", "").strip()
+        if plaintext:
+            pending[hash_var] = hash_password(plaintext)
+            hashed_from_plaintext.append(name)
+            continue
+        password = _mint_password()
+        pending[hash_var] = hash_password(password)
+        minted_passwords[name] = password
+        minted.append(name)
+
+    changed = False
+    missing: list[str] = []
+    if pending:
+        try:
+            _append_entries(env_auth_path, pending, _HASH_HEADER)
+        except OSError as exc:
+            # Fail-closed, but not from here: the deploy gate owns the abort so
+            # it can name the deploy context. Say so loudly meanwhile — never
+            # naming a password, minted or supplied.
+            missing = hashed_from_plaintext + minted
+            logger.error(
+                "Could not write web-terminal auth credentials to %s (%s). "
+                "No password hash could be established for: %s",
+                env_auth_path,
+                exc,
+                ", ".join(sorted(missing)),
+            )
+            hashed_from_plaintext = []
+            minted = []
+        else:
+            changed = True
+            # Log the variable names only — a hash identifies a credential
+            # generation and must not travel to a log sink.
+            logger.key_info(
+                "Provisioned web-terminal auth credential(s) %s in %s (gitignored, 0600)",
+                ", ".join(pending),
+                env_auth_path,
+            )
+            for name in minted:
+                echo(
+                    f"Minted a login password for web-terminal user '{name}': "
+                    f"{minted_passwords[name]}"
+                )
+            if minted:
+                echo(
+                    "Record these now — they are shown this once and cannot be "
+                    "recovered; only their hashes are stored."
+                )
+
+    _normalize_mode(env_auth_path)
+
+    return AuthCredentialsResult(
+        env_auth_path=env_auth_path,
+        changed=changed,
+        minted=tuple(minted),
+        hashed_from_plaintext=tuple(hashed_from_plaintext),
+        preexisting=tuple(preexisting),
+        missing=tuple(missing),
+    )
+
+
+@dataclass(frozen=True)
+class AuthSecretsResult:
+    """Outcome of one :func:`ensure_auth_session_secrets` run.
+
+    Fields carry env-var NAMES, never values. ``changed`` and ``missing`` mean
+    what they do on :class:`AuthCredentialsResult`: a changed ``.env.auth``
+    obliges the deploy to force-recreate the sidecar, and a non-empty
+    ``missing`` is the fail-closed gate's signal that a secret could not be
+    established.
+    """
+
+    env_auth_path: Path
+    changed: bool
+    minted: tuple[str, ...]
+    preexisting: tuple[str, ...]
+    missing: tuple[str, ...]
+
+
+def ensure_auth_session_secrets(project_root: str | Path) -> AuthSecretsResult:
+    """Mint the sidecar's cookie-signing secrets into ``.env.auth``.
+
+    Call on the deploy preflight path whenever ``auth.method != "none"``; the
+    method itself is the caller's to read, exactly as it decides whether to
+    call :func:`ensure_auth_credentials`.
+
+    Both secrets are minted through the shared service-token recipe
+    (``token_urlsafe(32)``, 256 bits) rather than a private generator here, and
+    the effective value is checked against the same registered-constraint
+    validator, so a constraint added for these vars later takes effect on this
+    path without further work. They are deliberately NOT registered in
+    ``_SERVICE_TOKEN_VARS``: that map only mints for members of
+    ``deployed_services``, which no web-terminal-stack service ever is, so an
+    entry there would silently mint nothing.
+
+    ``OSPREY_AUTH_STATE_SECRET`` is minted unconditionally even though the
+    sidecar only requires it in ``oidc`` mode, so that switching a deployment's
+    method to ``oidc`` cannot 503 on a secret nobody remembered to add.
+
+    Existing values always win, making this idempotent — re-minting would
+    invalidate every live session. The one exception is a present-but-empty (or
+    whitespace-only) value, which is re-minted: the sidecar strips and rejects
+    such a value as missing configuration and answers every request with 503,
+    so preserving it would keep the whole deployment locked out. This is the
+    deliberate opposite of ``_ensure_service_tokens``' "an explicitly empty
+    token is a decision, leave it" rule, which holds there because an empty
+    service token fails only its own service closed.
+
+    A write failure is reported through ``missing`` rather than raised, matching
+    :func:`ensure_auth_credentials` so the deploy gate owns the abort.
+
+    Args:
+        project_root: Directory holding ``.env.auth``.
+
+    Returns:
+        An :class:`AuthSecretsResult` naming which variables were minted, which
+        were already present, and which could not be established.
+
+    Raises:
+        RuntimeError: If an effective value fails a constraint registered for
+            it in ``service_tokens``. The message names the variable and its
+            constraint, never the value.
+    """
+    env_auth_path = Path(project_root) / AUTH_ENV_FILENAME
+    stored = parse_dotenv_file(env_auth_path) if env_auth_path.is_file() else {}
+
+    minted: list[str] = []
+    preexisting: list[str] = []
+    pending: dict[str, str] = {}
+    for var in SESSION_SECRET_VARS:
+        if stored.get(var, "").strip():
+            preexisting.append(var)
+            continue
+        pending[var] = _generate_token(var)
+        minted.append(var)
+
+    changed = False
+    missing: list[str] = []
+    if pending:
+        try:
+            _append_entries(env_auth_path, pending, _SECRET_HEADER)
+        except OSError as exc:
+            missing = minted
+            minted = []
+            logger.error(
+                "Could not write web-terminal auth secrets to %s (%s). "
+                "No value could be established for: %s",
+                env_auth_path,
+                exc,
+                ", ".join(sorted(missing)),
+            )
+        else:
+            changed = True
+            # Names only — a signing secret must never reach a log sink.
+            logger.key_info(
+                "Provisioned web-terminal auth secret(s) %s in %s (gitignored, 0600)",
+                ", ".join(pending),
+                env_auth_path,
+            )
+
+    _normalize_mode(env_auth_path)
+
+    # Validate whatever the sidecar will actually read, whether just minted or
+    # carried over from a previous deploy. Resolved from the file alone: the
+    # sidecar receives .env.auth through compose env_file, so a value visible
+    # only to this process is not the one that will be in force.
+    post = parse_dotenv_file(env_auth_path) if env_auth_path.is_file() else {}
+    for var in SESSION_SECRET_VARS:
+        if var in missing:
+            continue
+        effective = post.get(var, "")
+        if effective and not _validate_var(var, effective):
+            _raise_invalid_var(var)
+
+    return AuthSecretsResult(
+        env_auth_path=env_auth_path,
+        changed=changed,
+        minted=tuple(minted),
+        preexisting=tuple(preexisting),
+        missing=tuple(missing),
+    )
+
+
+def purge_auth_credentials(username: str, project_root: str | Path) -> bool:
+    """Remove ``username``'s ``OSPREY_AUTH_PW_*`` entries from ``.env.auth``.
+
+    Called when a user is decommissioned or pruned: a re-added same-name user
+    must be minted a fresh credential instead of silently inheriting the
+    departed user's password. Both the hash entry and any plaintext entry that
+    was placed in ``.env.auth`` by hand are removed; every other line —
+    comments, blank lines, other users' entries — is preserved line-for-line.
+    Line *content* is untouched, but the file is rewritten with LF endings and
+    a trailing newline, so CRLF input is normalized on the way out.
+
+    The rewrite is atomic (temporary file plus rename) so an interrupted purge
+    cannot leave a truncated credential file, and the replacement is 0600 like
+    the original.
+
+    Unlike :func:`ensure_auth_credentials` this does not validate ``username``:
+    removing entries for a name the roster should never have accepted is always
+    safe, and a lifecycle teardown must not be blocked by the departing user's
+    spelling.
+
+    Args:
+        username: The roster username whose entries should be removed.
+        project_root: Directory holding ``.env.auth``.
+
+    Returns:
+        ``True`` if the file changed, ``False`` if it was absent or held no
+        entry for that user. The deploy path force-recreates the sidecar on
+        ``True`` for the same reason :attr:`AuthCredentialsResult.changed`
+        exists.
+    """
+    env_auth_path = Path(project_root) / AUTH_ENV_FILENAME
+    if not env_auth_path.is_file():
+        return False
+
+    suffix = env_var_suffix(username)
+    targets = {
+        f"{PW_HASH_VAR_PREFIX}{suffix}",
+        f"{PW_PLAINTEXT_VAR_PREFIX}{suffix}",
+    }
+    lines = env_auth_path.read_text(encoding="utf-8").splitlines()
+    kept = [line for line in lines if dotenv_line_var(line) not in targets]
+    if len(kept) == len(lines):
+        return False
+
+    _atomic_rewrite(env_auth_path, kept)
+    logger.key_info(
+        "Removed web-terminal auth credential(s) for %r from %s", username, env_auth_path
+    )
+    return True
+
+
+def _atomic_rewrite(env_auth_path: Path, lines: list[str]) -> None:
+    """Replace ``.env.auth``'s whole content with ``lines``, atomically and 0600.
+
+    Write-to-temporary-then-rename, so an interrupted write cannot leave a
+    truncated credential file: a reader sees either the previous content or the
+    new content, never a half-written line. The temporary is created 0600 rather
+    than chmod'ed afterwards, so a hash is never briefly world-readable, and
+    ``os.replace`` carries that mode onto the destination — which is why callers
+    need no separate mode fix-up.
+
+    Shared by :func:`purge_auth_credentials` and :func:`set_auth_password` so
+    there is one definition of how this file is rewritten.
+
+    Raises:
+        OSError: If the temporary or the destination cannot be written.
+    """
+    tmp_path = env_auth_path.with_name(f"{env_auth_path.name}.tmp")
+    fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.write("".join(f"{line}\n" for line in lines))
+    os.replace(tmp_path, env_auth_path)
+
+
+def set_auth_password(username: str, password: str, project_root: str | Path) -> Path:
+    """Replace ``username``'s stored hash with one derived from ``password``.
+
+    The rotation entry point behind ``osprey deploy passwd <user>``, and the only
+    operation in this module that deliberately overwrites an established
+    credential — :func:`ensure_auth_credentials` exists precisely never to do
+    that.
+
+    **Replaces in place; never appends.** The user's existing entry is
+    substituted where it already sits — every other line, including other users'
+    entries, the signing secrets and the headers, is preserved byte for byte —
+    and the file is rewritten exactly once. Appending a second entry would also
+    "work", since the parser takes the last assignment, but every rotation would
+    leave the superseded credential sitting in the file: correctness would rest
+    on parse order rather than on content, a hash an operator believed retired
+    would still be readable, and a facility rotating on a schedule would grow
+    this file without bound.
+
+    Whitespace is stripped before hashing, matching the plaintext path in
+    :func:`ensure_auth_credentials`, so a password set through ``.env`` and one
+    set here behave identically at the login prompt.
+
+    Every live session of that user dies as a consequence, with no revocation
+    bookkeeping: a session cookie carries the credential-generation tag of the
+    hash it was issued against (see
+    :func:`osprey.services.auth_sidecar.passwords.generation_tag`), and a new
+    hash necessarily produces a different tag.
+
+    **This function RAISES on a write failure, and that is a deliberate
+    divergence from the rest of this module — do not "harmonize" it.**
+    :func:`ensure_auth_credentials` and :func:`ensure_auth_session_secrets`
+    report through a ``missing`` tuple because they run on the deploy path,
+    where a fail-closed gate downstream owns the abort and can name the whole
+    deployment's context. Nothing downstream owns this one: it is reached from
+    an interactive command, and an operator who was just prompted for a
+    password must never be told it took effect when the file could not be
+    written. Because the replacement is a single atomic rewrite, a failure
+    leaves the file exactly as it was — the old password keeps working, which
+    is the state the raised error describes.
+
+    The password is never logged, and never appears in a return value or an
+    exception message.
+
+    Args:
+        username: Roster username whose password is being replaced.
+        password: The new cleartext password; hashed here and never stored.
+        project_root: Directory holding ``.env.auth``.
+
+    Returns:
+        The path of the ``.env.auth`` that now holds the new hash. Returning at
+        all means the credential is in force once the sidecar is recreated,
+        which is the caller's next obligation.
+
+    Raises:
+        RuntimeError: If ``username`` is outside the roster charset, or if
+            ``.env.auth`` could not be written — the message says plainly that
+            the password did not change.
+        ValueError: If ``password`` is empty or only whitespace.
+    """
+    _validate_usernames([username])
+
+    secret = password.strip()
+    if not secret:
+        raise ValueError(f"Refusing to set an empty password for web-terminal user {username!r}.")
+
+    root = Path(project_root)
+    env_auth_path = root / AUTH_ENV_FILENAME
+    suffix = env_var_suffix(username)
+    hash_var = f"{PW_HASH_VAR_PREFIX}{suffix}"
+    plaintext_var = f"{PW_PLAINTEXT_VAR_PREFIX}{suffix}"
+    entry = f"{hash_var}={hash_password(secret)}"
+
+    existing = (
+        env_auth_path.read_text(encoding="utf-8").splitlines() if env_auth_path.is_file() else []
+    )
+    lines = _lines_with_entry_replaced(existing, entry, hash_var, plaintext_var)
+
+    try:
+        _atomic_rewrite(env_auth_path, lines)
+    except OSError as exc:
+        raise RuntimeError(
+            f"Could not write {env_auth_path} ({exc}); the password for {username!r} "
+            "was NOT changed. Check that file's permissions and retry."
+        ) from exc
+
+    # The variable name only — a hash identifies a credential generation and
+    # must not travel to a log sink, and the password never does at all.
+    logger.key_info("Replaced web-terminal auth credential %s in %s", hash_var, env_auth_path)
+    return env_auth_path
+
+
+def _lines_with_entry_replaced(
+    existing: list[str], entry: str, hash_var: str, plaintext_var: str
+) -> list[str]:
+    """``existing`` with ``entry`` substituted in place for ``hash_var``.
+
+    The user's current assignment is overwritten where it already sits, so the
+    file's shape does not change: no line moves, no header is duplicated, and a
+    repeated rotation is a no-growth operation. Any *further* assignments of the
+    same variable are dropped, which cleans up a file that an earlier
+    append-style write had already doubled up. A plaintext entry for the same
+    user is dropped too, since it is superseded by the hash being written and
+    would otherwise sit in the credential file as cleartext.
+
+    A user with no entry yet is appended under the existing
+    :data:`_HASH_HEADER` when the file already has one — placed after the last
+    hash line so it joins that block — and under a newly added header when it
+    does not.
+    """
+    lines: list[str] = []
+    replaced = False
+    for line in existing:
+        var = dotenv_line_var(line)
+        if var == hash_var:
+            if not replaced:
+                lines.append(entry)
+                replaced = True
+            continue
+        if var == plaintext_var:
+            continue
+        lines.append(line)
+    if replaced:
+        return lines
+
+    if _HASH_HEADER in lines:
+        last_hash = max(
+            (
+                index
+                for index, line in enumerate(lines)
+                if (dotenv_line_var(line) or "").startswith(PW_HASH_VAR_PREFIX)
+            ),
+            default=lines.index(_HASH_HEADER),
+        )
+        lines.insert(last_hash + 1, entry)
+        return lines
+
+    if lines and lines[-1].strip():
+        lines.append("")
+    lines.extend((_HASH_HEADER, entry))
+    return lines

--- a/src/osprey/deployment/web_terminals/lifecycle.py
+++ b/src/osprey/deployment/web_terminals/lifecycle.py
@@ -1,4 +1,4 @@
-"""Per-user web-terminal lifecycle verbs: decommission, prune, nuke.
+"""Per-user web-terminal lifecycle verbs: decommission, prune, nuke, passwd.
 
 This module owns the destructive side of multi-user web-terminal deployments —
 removing a user's container/volumes and the roster entry, artifacts, and routing
@@ -15,7 +15,10 @@ read-only and never itself a removal argv; :func:`nuke_stack`'s pre-removal
 ``image inspect`` calls are the same kind of read-only check.
 
 :func:`decommission_user`, :func:`prune_users`, and :func:`nuke_stack` are the
-three verbs this module implements.
+three destructive verbs this module implements. :func:`rotate_user_password` is
+the one non-destructive verb here: it changes a credential rather than removing
+a resource, but it belongs with the others because it is reached the same way
+(``osprey deploy <verb> <user>``) and needs the same roster/runtime gating.
 
 Volume-scoping boundary (applies to :func:`prune_users`'s discovery and to
 :func:`nuke_stack`'s per-user volume teardown alike): orphan discovery
@@ -30,6 +33,16 @@ never cross-match each other's containers or volumes. The printed plan + typed
 confirmation every destructive verb here requires remains the operator's
 backstop regardless: nothing is removed without the operator seeing the exact
 resource names first.
+
+CWD CONTRACT: every verb here resolves project-root-relative paths — the
+``.env``/``.env.auth`` credential files, the rendered ``docker-compose.web.yml``
+the sidecar recreate addresses, and the ``--archive`` tarball directory —
+against the CURRENT WORKING DIRECTORY, because ``osprey deploy`` chdirs to the
+project root before dispatching any of them. A programmatic caller that invokes
+these functions from elsewhere, passing only ``config_path``, would have those
+paths disagree with the config it passed, and the failure would be silent
+(credentials purged from the wrong file, a recreate skipped as "not deployed").
+Call them from the project root.
 
 Image-scoping boundary (applies only to :func:`nuke_stack`'s persona-image
 teardown): unlike containers and volumes, image tags are host-global — two
@@ -50,7 +63,7 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 
 from osprey.deployment.compose_generator import resolve_project_name, resolve_user_volume_names
 from osprey.deployment.facility_config import normalize_facility_config
@@ -60,10 +73,28 @@ from osprey.deployment.runtime_helper import (
     verify_runtime_is_running,
 )
 from osprey.deployment.web_terminals.artifacts import write_web_terminal_artifacts
+from osprey.deployment.web_terminals.auth_credentials import (
+    AUTH_ENV_FILENAME,
+    PW_PLAINTEXT_VAR_PREFIX,
+    purge_auth_credentials,
+    set_auth_password,
+)
 from osprey.deployment.web_terminals.naming import web_container_name, web_container_prefix
-from osprey.deployment.web_terminals.personas import as_dict, normalize_users, resolve_personas
+from osprey.deployment.web_terminals.personas import (
+    as_dict,
+    effective_image_source,
+    env_var_suffix,
+    normalize_users,
+    resolve_personas,
+)
+from osprey.deployment.web_terminals.postup_hooks import reload_nginx_config
+from osprey.deployment.web_terminals.render import _auth_tls_context
 from osprey.utils.config import ConfigBuilder
 from osprey.utils.config_writer import config_replace_list
+from osprey.utils.dotenv import parse_dotenv_file
+from osprey.utils.logger import get_logger
+
+logger = get_logger("deployment.lifecycle")
 
 _USERS_KEY_PATH = ["modules", "web_terminals", "users"]
 
@@ -171,7 +202,21 @@ def decommission_user(
     facility_prefix = as_dict(config.get("facility")).get("prefix") or ""
     remove_container(runtime, web_container_name(facility_prefix, user), env=env)
 
-    _apply_volume_policy(runtime, volumes, archive=archive, purge=purge, env=env)
+    # Authentication (no-op when off): purge the departed user's credentials,
+    # reload the freshly rendered nginx routes, and recreate the sidecar so its
+    # roster and hashes are re-read and the user's session dies now.
+    try:
+        _reconcile_auth_after_user_removal(updated_config, [user], rerendered=True)
+    finally:
+        # Deliberately in `finally`, not sequentially after: what fails above is
+        # a REMOTE effect (the running sidecar still holds the old roster) while
+        # every LOCAL change — roster edit, re-render, container removal,
+        # credential purge — has already succeeded. Abandoning the volume policy
+        # would leave the deployment in a state MORE inconsistent than the error
+        # reports, and it is cleanup the operator cannot easily finish by hand.
+        # The reconcile's error still surfaces afterwards, so a failure to close
+        # access stays fatal. Do NOT "simplify" this back to a plain call.
+        _apply_volume_policy(runtime, volumes, archive=archive, purge=purge, env=env)
 
 
 # =============================================================================
@@ -276,6 +321,13 @@ def prune_users(
         _apply_volume_policy(
             runtime, orphan_volumes.get(user, []), archive=archive, purge=purge, env=env
         )
+
+    # Authentication (no-op when off): an orphan is already off the roster, so
+    # nothing was re-rendered and the sidecar's compose definition is unchanged
+    # — but their hashes can still be sitting in .env.auth, and a re-added
+    # same-name user must not inherit them. Recreates only if a purge actually
+    # changed the file, so a prune with nothing to purge bounces nothing.
+    _reconcile_auth_after_user_removal(config, orphan_users, rerendered=False)
 
 
 # =============================================================================
@@ -398,6 +450,23 @@ def nuke_stack(config_path: str | Path, *, assume_yes: bool = False) -> None:
         if image.endswith(":local") and image not in candidate_images:
             candidate_images.append(image)
 
+    # The auth sidecar's own locally-built tag, on exactly the terms that
+    # produced it: authentication on AND local mode AND no auth.image pinning an
+    # external image (see provision.build_auth_sidecar_image). It is a candidate
+    # like any persona tag — the same com.osprey.project label verification
+    # below decides whether it is really ours, since image tags are host-global.
+    auth_ctx = _auth_tls_context(web_terminals)
+    if (
+        auth_ctx["auth_method"] != "none"
+        and effective_image_source(web_terminals) == "local"
+        and not auth_ctx["auth_image"]
+    ):
+        from osprey.deployment.web_terminals.provision import auth_sidecar_local_tag
+
+        auth_image = auth_sidecar_local_tag(config)
+        if auth_image not in candidate_images:
+            candidate_images.append(auth_image)
+
     # Each candidate is individually label-verified against THIS deployment's
     # project name before it is ever considered for removal — image tags are
     # host-global, so a sibling deployment's identically-named tag must survive
@@ -418,7 +487,7 @@ def nuke_stack(config_path: str | Path, *, assume_yes: bool = False) -> None:
         f"service stack — every container (project-scoped), {len(volumes)} "
         f"volume(s) ({len(roster_names)} roster user(s), "
         f"{len(orphan_volumes)} off-roster user(s)), and {len(images_to_remove)} "
-        "persona image(s):"
+        "image(s):"
     )
     print(f"  - containers: {' '.join(runtime_cmd)} -p {project} down")
     for volume in volumes:
@@ -434,7 +503,7 @@ def nuke_stack(config_path: str | Path, *, assume_yes: bool = False) -> None:
     prompt = (
         f"This will PERMANENTLY tear down the entire web-terminal stack for "
         f"project {project!r}, including {len(volumes)} volume(s) and "
-        f"{len(images_to_remove)} persona image(s). Type 'nuke' to confirm: "
+        f"{len(images_to_remove)} image(s). Type 'nuke' to confirm: "
     )
     if not confirm_destroy(prompt, assume_yes, expected="nuke"):
         raise RuntimeError("Nuke aborted: confirmation did not match.")
@@ -452,6 +521,334 @@ def nuke_stack(config_path: str | Path, *, assume_yes: bool = False) -> None:
 
     for image in images_to_remove:
         remove_image(runtime, image, env=env)
+
+
+# =============================================================================
+# passwd: rotate one user's login password
+# =============================================================================
+
+
+def _reconcile_auth_after_user_removal(
+    config: dict[str, Any], removed: list[str], *, rerendered: bool
+) -> None:
+    """Put a roster removal into force on the running auth sidecar.
+
+    Removing a user's container and roster entry is not enough when
+    authentication is on. Three things outlive it, and each is closed here:
+
+    1. **The departed user's credentials** stay in ``.env.auth``, so a re-added
+       same-name user would silently inherit the previous holder's password.
+       :func:`~osprey.deployment.web_terminals.auth_credentials.purge_auth_credentials`
+       removes them.
+    2. **The rendered nginx routes** for that user are already gone from
+       ``nginx.conf`` on disk, but nginx is still serving the previous config —
+       hence the reload, which only applies when the caller actually re-rendered.
+    3. **The sidecar's own view**: its roster arrives as a compose ``environment``
+       entry and its hashes through ``env_file``, BOTH of which compose baked
+       into the container at creation time. Only a recreate re-reads them, which
+       is also what kills the removed user's live session immediately rather
+       than at its natural expiry.
+
+    A no-op when ``auth.method`` is ``none``: there is no sidecar, no
+    ``.env.auth``, and nothing about an unauthenticated deployment changes.
+
+    Args:
+        config: The deploy config (post-edit for a re-rendered caller).
+        removed: Usernames whose credentials should be purged.
+        rerendered: Whether the caller re-rendered the web-terminal artifacts.
+            ``True`` (decommission) always reloads nginx — the re-rendered
+            routes are on disk whatever else happens — and recreates the
+            sidecar unless the purge failed having removed nothing: an
+            unchanged ``.env.auth`` leaves the recreate nothing to put into
+            force (see Raises). The roster in the sidecar's compose definition
+            changed, so the recreate is required even if the user had no
+            credentials to purge.
+            ``False`` (prune, which removes only already-off-roster resources
+            and re-renders nothing) recreates only when a purge actually changed
+            ``.env.auth``, so a prune that found nothing to purge leaves every
+            live terminal and session untouched.
+
+    Raises:
+        RuntimeError: If a credential purge or the sidecar recreate failed. A
+            purge that failed *after* clearing someone else's credentials still
+            recreates the sidecar first, so the part that did succeed is in
+            force before the error is raised; the message then names only the
+            users whose credentials survive.
+    """
+    web_terminals = as_dict(as_dict(config.get("modules")).get("web_terminals"))
+    if _auth_tls_context(web_terminals)["auth_method"] == "none":
+        return
+
+    # Deferred import for the same reason rotate_user_password defers it: a
+    # module-level import would pull the whole deploy stack into every
+    # lifecycle verb.
+    from osprey.deployment.web_terminals.provision import (
+        force_recreate_auth_sidecar,
+        web_stack_compose_cmd,
+    )
+
+    project_root = Path.cwd()
+
+    purged: list[str] = []
+    # Everyone still to be cleared. A name is struck off once its purge
+    # RETURNED, so whatever is left here after the loop is exactly the set whose
+    # credentials are still in the file — the user whose purge raised, plus
+    # everyone the loop never reached.
+    unpurged = list(removed)
+    purge_error: OSError | None = None
+    # The purge loop gets its OWN guard, deliberately not merged with the
+    # recreate's below. With several users (prune), a failure partway through
+    # has ALREADY removed the hashes of everyone purged before it, and a removal
+    # that is never put into force is worse than no removal at all: the hash is
+    # gone from the file an operator would read, while the running sidecar still
+    # holds it and still lets that user log in — silently, until the next
+    # deploy. So a partial purge still reaches the recreate below, and the
+    # failure is raised afterwards, naming only the users whose credentials
+    # really did survive. `.env.auth` is rewritten whole, so the first OSError
+    # condemns every remaining user too; there is nothing to gain by carrying on
+    # down the list.
+    try:
+        for user in removed:
+            if purge_auth_credentials(user, project_root):
+                purged.append(user)
+            unpurged.remove(user)
+    except OSError as exc:
+        purge_error = exc
+
+    # Purely advisory, and outside the recreate guard below deliberately: it only
+    # READS the project `.env`, so an unreadable one says nothing about whether
+    # the sidecar can be recreated. Inside that guard it would be reported as a
+    # recreate failure AND skip the recreate it never attempted.
+    try:
+        _warn_if_plaintext_password_survives(removed, project_root)
+    except OSError as exc:
+        logger.warning(
+            "Could not check whether a removed web-terminal user's plaintext password "
+            "survives in %s (%s). If that file sets %s<USER> for any of %s, remove the "
+            "line by hand — the next `osprey deploy up` would otherwise hash it back in.",
+            project_root / ".env",
+            exc,
+            PW_PLAINTEXT_VAR_PREFIX,
+            ", ".join(repr(name) for name in removed),
+        )
+
+    # Outside the recreate guard below, and deliberately not gated on the purge
+    # outcome: the re-rendered nginx.conf is already on disk and nothing else
+    # applies it — compose never restarts a running container whose
+    # bind-mounted config CONTENT changed — so skipping the reload would leave
+    # nginx serving the removed user's route until the next deploy. Advisory
+    # and never raises (it warns).
+    if rerendered:
+        reload_nginx_config(web_stack_compose_cmd(config), runtime_env(config))
+
+    recreate_error: OSError | subprocess.CalledProcessError | None = None
+    # The recreate runs on a PARTIAL purge (see above) but not on one that
+    # removed nothing: with no change to `.env.auth` there is nothing to put
+    # into force — a recreate would re-read the file with the surviving hash
+    # still in it — and bouncing every live session would be gratuitous.
+    try:
+        if purged or (rerendered and purge_error is None):
+            force_recreate_auth_sidecar(config)
+    except (OSError, subprocess.CalledProcessError) as exc:
+        recreate_error = exc
+
+    # A surviving credential outranks an unreconciled sidecar: one is an open
+    # door, the other is a stale container. So the purge failure is what the
+    # operator is told about, and the recreate failure (if there was one too)
+    # rides along inside its message rather than replacing it.
+    if purge_error is not None:
+        names = ", ".join(repr(name) for name in unpurged)
+        detail = (
+            f"their auth credentials could not be removed from {AUTH_ENV_FILENAME} "
+            f"({purge_error}), so a stored password still opens a terminal under that "
+            "name. Fix that file's permissions and re-run this command."
+        )
+        if purged:
+            others = ", ".join(repr(name) for name in purged)
+            if recreate_error is None:
+                detail += (
+                    f" The credentials of {others} WERE removed, and the sidecar was "
+                    "recreated, so that much is already in force."
+                )
+            else:
+                detail += (
+                    f" The credentials of {others} WERE removed, but the sidecar could "
+                    f"not be recreated either ({recreate_error}), so it still holds "
+                    "them. Run `osprey deploy up`."
+                )
+        _fail_reconcile(names, detail, purge_error)
+
+    if recreate_error is not None:
+        # Deliberately narrow: `auth_request` is emitted only inside the
+        # per-user `location /u/<user>/` blocks, and the nginx reload above
+        # already dropped the removed user's block (it warns rather than
+        # raising, so it ran). Nothing consults the stale sidecar on their
+        # behalf — what survives is an unreconciled sidecar still holding
+        # their roster entry and password hash. Do not widen this to "their
+        # session may still be live": an overstated error an operator later
+        # finds untrue costs the next one its credibility.
+        detail = (
+            f"their auth credentials were purged from {AUTH_ENV_FILENAME}, but the auth "
+            f"sidecar could not be recreated ({recreate_error}), so it was not reconciled "
+            "and still holds their roster entry and password hash. Run `osprey deploy up` "
+            "to recreate it."
+        )
+        _fail_reconcile(", ".join(repr(name) for name in removed), detail, recreate_error)
+
+
+def _fail_reconcile(names: str, detail: str, cause: BaseException) -> NoReturn:
+    """Log and raise one auth-reconcile failure, in that order.
+
+    Logged as well as raised: if the caller's remaining cleanup then fails, its
+    exception supersedes this one and this record is all that is left.
+    """
+    message = f"Web-terminal user(s) {names} were removed and {detail}"
+    logger.error(message)
+    raise RuntimeError(message) from cause
+
+
+def _warn_if_plaintext_password_survives(removed: list[str], project_root: Path) -> None:
+    """Warn when a removed user's PLAINTEXT password is still in the project ``.env``.
+
+    Purging ``.env.auth`` is only half the story. ``ensure_auth_credentials``
+    has a second provisioning source: with no stored hash for a user it hashes
+    ``OSPREY_AUTH_PW_<SUFFIX>`` out of the project ``.env``. So the purge that
+    closes the departed user's access also re-opens that fallback — the next
+    ``osprey deploy up`` re-establishes the very password the purge derived its
+    hash from, and a re-added same-name user inherits it.
+
+    Warn rather than edit: ``.env`` is operator-owned and full of unrelated
+    configuration, and silently deleting lines from it is a worse failure mode
+    than the one being closed. The variable name is derived through
+    :func:`~osprey.deployment.web_terminals.personas.env_var_suffix`, the same
+    mapping that keyed the credential in the first place, so the warning can
+    never name a variable the provisioner would not read.
+    """
+    dotenv_path = project_root / ".env"
+    if not dotenv_path.is_file():
+        return
+    values = parse_dotenv_file(dotenv_path)
+    for user in removed:
+        variable = f"{PW_PLAINTEXT_VAR_PREFIX}{env_var_suffix(user)}"
+        if values.get(variable, "").strip():
+            logger.warning(
+                "%s still sets %s for the removed web-terminal user %r. Their password "
+                "was purged from %s, but the next `osprey deploy up` would hash that "
+                "plaintext back in — so re-adding this username would re-establish the "
+                "DEPARTED holder's password. Remove that line from %s.",
+                dotenv_path,
+                variable,
+                user,
+                AUTH_ENV_FILENAME,
+                dotenv_path,
+            )
+
+
+def rotate_user_password(config_path: str | Path, user: str, password: str) -> None:
+    """Replace one web-terminal user's login password and put it into force.
+
+    The verb behind ``osprey deploy passwd <user>``. Order of operations, each a
+    prerequisite for the next:
+
+    1. Gate on this deployment having an OSPREY-managed password to change at
+       all. ``auth.method: none`` has no credentials, and under ``oidc`` the
+       facility's identity provider holds them — writing a hash in either case
+       would produce a credential nothing ever checks, while telling the
+       operator their password had changed.
+    2. Gate on the roster. An off-roster name keys a variable no rendered
+       sidecar reads, so its "new password" could never be used.
+    3. Gate on the container runtime, *before* anything is written, so a
+       rotation cannot leave an operator holding a password that the deployment
+       was never told about.
+    4. Replace the stored hash (:func:`~osprey.deployment.web_terminals.auth_credentials.set_auth_password`).
+    5. Force-recreate the sidecar through the shared
+       :func:`~osprey.deployment.web_terminals.provision.force_recreate_auth_sidecar`,
+       so the new password works the moment this returns rather than at the next
+       deploy. That primitive is a warning-and-no-op when nothing has been
+       rendered at this project root, so rotating a password before the stack
+       has ever been deployed still stores the hash rather than failing.
+
+    Every one of that user's live sessions dies as a side effect — the session
+    cookie carries the generation tag of the hash it was issued against — which
+    is what makes this usable as a revocation: rotating a password ends the
+    access it granted. No other user's session is affected.
+
+    The password is never logged, printed, or echoed on this path.
+
+    Args:
+        config_path: Path to the facility ``config.yml``; its directory is the
+            project root holding ``.env.auth``.
+        user: Web-terminal username whose password is being replaced.
+        password: The new cleartext password. Hashed by the callee; never stored.
+
+    Raises:
+        ValueError: If authentication is off or IdP-held, or ``user`` is not on
+            the roster. Nothing is written in either case.
+        RuntimeError: If the container runtime is unreachable, or (from
+            :func:`~osprey.deployment.web_terminals.auth_credentials.set_auth_password`)
+            if ``.env.auth`` could not be written — the message says plainly
+            that the password did not change.
+            If the sidecar recreate fails, the error says the password WAS
+            changed and names the command that puts it in force — the new hash
+            is stored by then, so reporting a plain failure would tell the
+            operator their old password still works when it does not.
+    """
+    config_path = Path(config_path)
+    config = normalize_facility_config(ConfigBuilder(str(config_path)).raw_config)
+    web_terminals = as_dict(as_dict(config.get("modules")).get("web_terminals"))
+
+    # Read through the same parser the render and the deploy preflight use, so
+    # the three can never disagree about what this deployment's `auth` means.
+    auth_method = _auth_tls_context(web_terminals)["auth_method"]
+    if auth_method == "none":
+        raise ValueError(
+            "modules.web_terminals.auth.method is 'none', so this deployment has no "
+            "login passwords to change. Enable authentication first; nothing was modified."
+        )
+    if auth_method != "password":
+        raise ValueError(
+            f"modules.web_terminals.auth.method is {auth_method!r}, so credentials are "
+            "held by the identity provider rather than by OSPREY. Change the password "
+            "there; nothing was modified."
+        )
+
+    if not any(entry["name"] == user for entry in normalize_users(web_terminals.get("users"))):
+        raise ValueError(
+            f"User {user!r} is not present in modules.web_terminals.users; no password was changed."
+        )
+
+    _require_running_runtime(config)
+
+    # Raises (rather than reporting) if `.env.auth` cannot be written, which is
+    # what keeps the recreate below from running against an unchanged file and
+    # reporting success over a password that did not change. CWD, not
+    # `config_path.parent`: the recreate below resolves its compose file
+    # against CWD (see the module's CWD CONTRACT), and the two must agree or a
+    # caller off the project root would store the hash in one place and
+    # recreate against another.
+    set_auth_password(user, password, Path.cwd())
+
+    # The shared primitive, imported rather than re-implemented: provision.py
+    # owns the web stack's compose argv, and a second copy assembled here would
+    # be free to drift from the one `up`/`down` use. Imported at call time
+    # because provision.py is the deploy path's own module — a module-scope
+    # import would pull the whole deploy stack in for every lifecycle verb.
+    from osprey.deployment.web_terminals.provision import force_recreate_auth_sidecar
+
+    try:
+        force_recreate_auth_sidecar(config)
+    except subprocess.CalledProcessError as exc:
+        # The hash is ALREADY stored, so this is not "the rotation failed" — it
+        # is the mirror image of the write-failure case above. Left to
+        # propagate, the CLI's generic handler prints "Deployment failed" over a
+        # password that DID change, and the operator concludes their old one
+        # still works. It does not: the sidecar serves the old hash only until
+        # it is recreated, and the new password is the one that will be in force.
+        raise RuntimeError(
+            f"The password for {user!r} WAS changed, but the auth sidecar could not be "
+            f"recreated ({exc}), so it is still serving the previous password. Run "
+            "`osprey deploy up` to put the new password in force."
+        ) from exc
 
 
 def _compose_down_project(

--- a/src/osprey/deployment/web_terminals/lint.py
+++ b/src/osprey/deployment/web_terminals/lint.py
@@ -10,7 +10,6 @@ set via :func:`allocate_ports`.
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -20,8 +19,10 @@ import yaml
 from osprey.deployment.web_terminals.persona_images import persona_build_profile_shape_problem
 from osprey.deployment.web_terminals.personas import (
     SUPPORTED_MCP_TOPOLOGY,
+    USERNAME_CHARSET_RE,
     as_dict,
     effective_image_source,
+    env_var_suffix_collisions,
     resolve_image_tag,
     resolve_personas,
 )
@@ -29,6 +30,11 @@ from osprey.deployment.web_terminals.ports import (
     FAMILY_BASE_FIELDS,
     allocate_ports,
     base_ports_from_config,
+)
+from osprey.deployment.web_terminals.render import (
+    SUPPORTED_AUTH_METHODS,
+    _auth_tls_context,
+    _external_origin,
 )
 
 # Rule 12's closed set of reserved compose service keys. "dispatch-sidecar-*" is a
@@ -51,14 +57,19 @@ def _is_reserved_service_name(name: str) -> bool:
     return name in _RESERVED_SERVICE_NAMES or name.startswith(_RESERVED_SERVICE_PREFIX)
 
 
-# Usernames become nginx `location` keys and URL path segments (`/<user>/...`), so
-# they're held to a stricter charset than a bare "no reserved collision" check.
-_USERNAME_CHARSET_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
-
-# The TLS seam's listener port (`listen 443 ssl` in the gated nginx block, see
-# Task 1.3). `auth.method` has no other value than "none" in this schema revision
-# (Task 1.4), so there's no dedicated auth-service port to reserve yet.
+# The TLS seam's listener port (`listen 443 ssl` in the gated nginx block). The
+# auth sidecar's listener has no constant here: it is config-driven
+# (`auth.port`), and its effective value is read from render's parsed auth
+# context rather than restated.
 _TLS_LISTEN_PORT = 443
+
+# The credential env-var stem a roster username is keyed into
+# (`OSPREY_AUTH_PW_HASH_<SUFFIX>`), quoted only inside this module's collision
+# message. It is deliberately NOT imported from `auth_credentials`, which owns
+# the constant: this module is pure static validation of a config file, and
+# importing the credential provisioner to quote one string in a message would
+# pull the whole deploy-time secret-minting path in behind it.
+_PW_HASH_VAR_PREFIX = "OSPREY_AUTH_PW_HASH_"
 
 
 @dataclass(frozen=True)
@@ -124,6 +135,10 @@ def lint_web_terminals(config: Any) -> list[Finding]:
     findings.extend(_check_persona_extra_mounts(web_terminals))
     findings.extend(_check_unknown_mcp_topology(web_terminals))
     findings.extend(_check_nginx_image(web_terminals))
+    findings.extend(_check_auth_method(web_terminals))
+    findings.extend(_check_auth_transport(web_terminals))
+    findings.extend(_check_auth_oidc(root, web_terminals))
+    findings.extend(_check_auth_credential_collisions(web_terminals, users))
     return findings
 
 
@@ -228,14 +243,14 @@ def _check_username_charset(users: list[Any]) -> list[Finding]:
     findings: list[Finding] = []
     for user in users:
         name = _user_name(user)
-        if name is not None and not _USERNAME_CHARSET_RE.match(name):
+        if name is not None and not USERNAME_CHARSET_RE.fullmatch(name):
             findings.append(
                 Finding(
                     severity="error",
                     code="web_terminals.invalid_username_charset",
                     message=(
                         f"modules.web_terminals.users entry {name!r} does not match "
-                        f"{_USERNAME_CHARSET_RE.pattern!r} (usernames become nginx "
+                        f"{USERNAME_CHARSET_RE.pattern!r} (usernames become nginx "
                         "location keys and URL path segments)"
                     ),
                 )
@@ -471,14 +486,19 @@ def _check_port_overlap(
             if isinstance(value, int):
                 entries.append((value, f"test_ioc.{field}"))
 
-    # S5: the gated auth/TLS seam's port(s) (Task 1.3/1.4) — only join the
-    # collision set when the seam is actually enabled by config; the default
-    # (tls disabled, auth "none") must not reserve 443 against ordinary configs.
+    # S5: the gated auth/TLS seam's port(s) — only join the collision set when
+    # the seam is actually enabled by config; the default (tls disabled, auth
+    # "none") must not reserve 443 or the sidecar port against ordinary configs.
     tls = as_dict(web_terminals.get("tls"))
     if bool(tls.get("enabled", False)):
         entries.append((_TLS_LISTEN_PORT, "web_terminals.tls (listen 443 ssl)"))
-    # `auth.method` has no value other than "none" in this schema revision, so
-    # there's no dedicated auth-service port to add yet (see Task 1.4's schema).
+    auth_context = _auth_context(web_terminals)
+    if auth_context is not None and auth_context["auth_method"] != "none":
+        # The sidecar's own listener, published on the host beside every other
+        # service in the stack. Unlike `nginx_port` it has no `ports.*` mirror
+        # to be covered by S3 — `auth.port` is where it is declared — so it is
+        # added here directly, exactly like the TLS listener above.
+        entries.append((auth_context["auth_port"], "web_terminals.auth.port"))
 
     by_port: dict[int, list[str]] = {}
     for port, source in entries:
@@ -526,14 +546,14 @@ def _check_persona_charset(web_terminals: dict[str, Any]) -> list[Finding]:
     ``^[a-z0-9][a-z0-9_-]*$`` (see :func:`_check_username_charset`)."""
     findings: list[Finding] = []
     for persona_name in _persona_catalog(web_terminals):
-        if isinstance(persona_name, str) and not _USERNAME_CHARSET_RE.match(persona_name):
+        if isinstance(persona_name, str) and not USERNAME_CHARSET_RE.fullmatch(persona_name):
             findings.append(
                 Finding(
                     severity="error",
                     code="web_terminals.invalid_persona_charset",
                     message=(
                         f"modules.web_terminals.personas key {persona_name!r} does not "
-                        f"match {_USERNAME_CHARSET_RE.pattern!r} (persona names become "
+                        f"match {USERNAME_CHARSET_RE.pattern!r} (persona names become "
                         "image-tag suffixes and path components)"
                     ),
                 )
@@ -1166,3 +1186,270 @@ def _check_nginx_image(web_terminals: dict[str, Any]) -> list[Finding]:
             )
         ]
     return []
+
+
+# --- auth seam checks --------------------------------------------------------
+#
+# These are scaffold-time feedback only. The authoritative deploy-path gates
+# live elsewhere and fail closed on their own: render.py raises on an unknown
+# `auth.method` and on auth-without-TLS, and `auth_credentials.py` raises on a
+# roster it cannot key credentials for. `osprey deploy` never runs this module,
+# so nothing here may be the only thing standing between a bad config and a
+# deployment — every check below mirrors a gate that also exists downstream,
+# except where the downstream path *cannot* see the mistake (see
+# :func:`_check_auth_method`).
+
+
+def _auth_context(web_terminals: dict[str, Any]) -> dict[str, Any] | None:
+    """render.py's parsed view of the ``auth``/``tls`` stanzas, or ``None``.
+
+    Every check below reads the derived values the nginx template and the
+    compose overlay consume rather than re-reading ``auth.*`` itself, so lint
+    and render can't disagree about what a stanza means (see
+    :func:`~osprey.deployment.web_terminals.render._auth_tls_context`, which is
+    the single definition).
+
+    That function raises on exactly one input — an ``auth.method`` string
+    naming a method that does not exist — which :func:`_check_auth_method`
+    reports on its own. Every check keyed on a parsed method is meaningless for
+    such a config, so this degrades to ``None`` and they skip themselves rather
+    than reporting confused follow-on findings.
+    """
+    try:
+        return _auth_tls_context(web_terminals)
+    except ValueError:
+        return None
+
+
+def _check_auth_method(web_terminals: dict[str, Any]) -> list[Finding]:
+    """``modules.web_terminals.auth.method`` must name a supported method.
+
+    Two distinct mistakes, both ERRORs:
+
+    * An **unknown method string** (``"basic"``). render raises on this too —
+      this check is the scaffold-time mirror, with the same message.
+    * A **wrong-typed** ``auth`` stanza or ``method`` value (a mapping, an int,
+      a bare ``auth: password`` string where a mapping belongs). render reads
+      every value defensively, so a wrong-typed one falls back to its default
+      and the deployment renders with authentication silently *off* — nothing
+      downstream can catch it. This module is the only surface that sees it.
+
+    An absent key, and an ``auth:``/``method:`` written with no value at all
+    (both ``None`` after YAML load), are the documented defaults and are not
+    flagged.
+    """
+    auth_raw = web_terminals.get("auth")
+    if auth_raw is not None and not isinstance(auth_raw, dict):
+        return [
+            Finding(
+                severity="error",
+                code="web_terminals.invalid_auth_stanza",
+                message=(
+                    f"modules.web_terminals.auth {auth_raw!r} is not a mapping; it must "
+                    "be a block with a 'method' key (e.g. 'auth:\\n  method: password'). "
+                    "A non-mapping stanza is read as no auth stanza at all, which would "
+                    "render the deployment with authentication silently disabled"
+                ),
+            )
+        ]
+
+    auth = as_dict(auth_raw)
+    if "method" not in auth:
+        return []
+    method = auth.get("method")
+    if method is None:
+        return []
+    if not isinstance(method, str):
+        return [
+            Finding(
+                severity="error",
+                code="web_terminals.invalid_auth_method_type",
+                message=(
+                    f"modules.web_terminals.auth.method {method!r} is not a string; "
+                    f"expected one of {', '.join(SUPPORTED_AUTH_METHODS)}. A non-string "
+                    "value falls back to 'none' at render time, which would render the "
+                    "deployment with authentication silently disabled"
+                ),
+            )
+        ]
+    if method in SUPPORTED_AUTH_METHODS:
+        return []
+    return [
+        Finding(
+            severity="error",
+            code="web_terminals.unknown_auth_method",
+            message=(
+                f"modules.web_terminals.auth.method {method!r} is not a supported "
+                f"authentication method; expected one of {', '.join(SUPPORTED_AUTH_METHODS)}"
+            ),
+        )
+    ]
+
+
+def _check_auth_transport(web_terminals: dict[str, Any]) -> list[Finding]:
+    """Authentication over cleartext HTTP: an ERROR, or a WARN once accepted.
+
+    A session cookie is a bearer credential. Served over plain HTTP it is
+    readable — and replayable — by anything on the path, so ``auth.method`` set
+    without ``tls.enabled`` is refused at render time unless the deployment
+    explicitly accepts that risk with ``auth.allow_insecure_http: true``. This
+    is the scaffold-time mirror of that gate: the ERROR for the refusal, and a
+    WARN when the escape hatch is what's keeping the config renderable, so the
+    risk is restated at every lint rather than only in the commit that took it.
+
+    With TLS on, ``allow_insecure_http`` is inert and nothing is reported.
+    """
+    context = _auth_context(web_terminals)
+    if context is None or context["auth_method"] == "none":
+        return []
+    if context["tls_enabled"]:
+        return []
+    if context["auth_allow_insecure_http"]:
+        return [
+            Finding(
+                severity="warn",
+                code="web_terminals.auth_insecure_http",
+                message=(
+                    f"modules.web_terminals.auth.method is {context['auth_method']!r} "
+                    "with tls.enabled false and allow_insecure_http true; session "
+                    "cookies will travel over cleartext HTTP, where anything on the "
+                    "network path can read and replay them. Enable tls for any "
+                    "deployment reachable beyond a trusted host"
+                ),
+            )
+        ]
+    return [
+        Finding(
+            severity="error",
+            code="web_terminals.auth_requires_tls",
+            message=(
+                f"modules.web_terminals.auth.method is {context['auth_method']!r} but "
+                "tls.enabled is false; session cookies would travel over cleartext "
+                "HTTP. Enable modules.web_terminals.tls, or set "
+                "auth.allow_insecure_http: true to accept that risk (only sensible on "
+                "a trusted network)"
+            ),
+        )
+    ]
+
+
+def _check_auth_oidc(root: dict[str, Any], web_terminals: dict[str, Any]) -> list[Finding]:
+    """``method: oidc`` needs an issuer, usable client env-var names, and an origin.
+
+    Three ERRORs, all config-visible and all fatal at *request* time rather
+    than deploy time if they slip through — a sidecar that cannot complete a
+    login flow locks the whole roster out:
+
+    * **Issuer.** ``auth.oidc.issuer`` has no default: without it there is no
+      discovery document to fetch and no IdP to redirect to.
+    * **Client env-var names.** ``client_id_env``/``client_secret_env`` name the
+      variables the sidecar reads its client credentials from (never the
+      credentials themselves), and both default to a documented
+      ``OSPREY_AUTH_OIDC_*`` name. Omitting them is therefore fine; setting one
+      to something unusable (empty, wrong type) is not — render silently
+      restores the default, so the sidecar would read a variable the operator
+      never set.
+    * **External origin.** The OIDC ``redirect_uri`` is built from the
+      deployment's one external origin, which needs ``deploy.fqdn``. An IdP
+      rejects a callback whose ``redirect_uri`` isn't character-for-character
+      the registered one, so an underivable origin means no login can complete.
+    """
+    context = _auth_context(web_terminals)
+    if context is None or context["auth_method"] != "oidc":
+        return []
+
+    findings: list[Finding] = []
+    oidc = as_dict(as_dict(web_terminals.get("auth")).get("oidc"))
+
+    if not context["auth_oidc_issuer"]:
+        findings.append(
+            Finding(
+                severity="error",
+                code="web_terminals.auth_oidc_missing_issuer",
+                message=(
+                    "modules.web_terminals.auth.method is 'oidc' but "
+                    "auth.oidc.issuer is not set; the sidecar needs the issuer URL to "
+                    "discover the IdP's endpoints"
+                ),
+            )
+        )
+
+    for field in ("client_id_env", "client_secret_env"):
+        if field not in oidc:
+            continue  # unset is fine — the documented OSPREY_AUTH_OIDC_* default applies
+        value = oidc.get(field)
+        if isinstance(value, str) and value.strip():
+            continue
+        findings.append(
+            Finding(
+                severity="error",
+                code="web_terminals.auth_oidc_invalid_client_env",
+                message=(
+                    f"modules.web_terminals.auth.oidc.{field} {value!r} is not a "
+                    "non-empty string; it must name the environment variable holding "
+                    "that OIDC client credential (the name, never the credential). An "
+                    "unusable value silently restores the default variable name, which "
+                    "the deployment has not set"
+                ),
+            )
+        )
+
+    # Only `deploy.fqdn` can make the origin underivable; the published port
+    # merely fills the ':port' suffix when TLS is off. A malformed `nginx_port`
+    # is render's own error, reported there — substituting one here keeps this
+    # check to the one thing it is about.
+    nginx_port = web_terminals.get("nginx_port")
+    try:
+        _external_origin(
+            root,
+            nginx_port if isinstance(nginx_port, int) else 0,
+            tls_enabled=bool(context["tls_enabled"]),
+        )
+    except ValueError as exc:
+        findings.append(
+            Finding(
+                severity="error",
+                code="web_terminals.auth_oidc_unresolvable_origin",
+                message=(
+                    "modules.web_terminals.auth.method is 'oidc' but this deployment's "
+                    f"external origin cannot be derived ({exc}); the OIDC redirect_uri "
+                    "is built from it and must match the URI registered with the IdP"
+                ),
+            )
+        )
+    return findings
+
+
+def _check_auth_credential_collisions(
+    web_terminals: dict[str, Any], users: list[Any]
+) -> list[Finding]:
+    """Password mode: two roster users may not key the same credential variable.
+
+    A username is normalized (uppercased, ``-`` to ``_``) into the env-var
+    suffix its stored password hash lives under, so ``alice-b`` and ``alice_b``
+    would share one ``OSPREY_AUTH_PW_HASH_ALICE_B`` entry — one operator's
+    password opening the other's terminal, the exact isolation failure this
+    feature exists to establish. ``auth_credentials`` refuses to provision such
+    a roster with a hard raise on the deploy path; this is the same rejection
+    at scaffold time, where renaming a user is still cheap.
+
+    Scoped to ``method: password``: the per-user credential variable is what
+    collides, and OIDC deployments have none (identity comes from the IdP).
+    """
+    context = _auth_context(web_terminals)
+    if context is None or context["auth_method"] != "password":
+        return []
+    names = [name for name in (_user_name(user) for user in users) if name is not None]
+    return [
+        Finding(
+            severity="error",
+            code="web_terminals.auth_credential_collision",
+            message=(
+                f"modules.web_terminals.users entries {colliding} all map onto the "
+                f"credential variable {_PW_HASH_VAR_PREFIX}{suffix}; they would share a "
+                "single password, so one user's credentials would open another's "
+                "terminal. Rename one of them"
+            ),
+        )
+        for suffix, colliding in env_var_suffix_collisions(names).items()
+    ]

--- a/src/osprey/deployment/web_terminals/personas.py
+++ b/src/osprey/deployment/web_terminals/personas.py
@@ -3,12 +3,16 @@
 Turns the raw ``modules.web_terminals`` roster into explicit per-user identity:
 normalized ``{"name", "index"}`` entries (:func:`normalize_users`) and fully
 resolved image/project/container-dir identity per user
-(:func:`resolve_personas`). Port arithmetic lives separately in
-:mod:`osprey.deployment.web_terminals.ports`.
+(:func:`resolve_personas`). Also home to the username→env-var-suffix mapping
+(:func:`env_var_suffix`) and its collision detector
+(:func:`env_var_suffix_collisions`), which credential provisioning, the auth
+sidecar and lint share so a user's credentials are keyed identically everywhere.
+Port arithmetic lives separately in :mod:`osprey.deployment.web_terminals.ports`.
 """
 
 import os
 import re
+from collections.abc import Iterable
 from typing import Any
 
 # Matches ${VAR} and $VAR env references inside modules.web_terminals.image_tag.
@@ -23,6 +27,18 @@ _ENV_REF_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9
 # `claude_code.servers` custom entries (those render through the unrelated
 # per-project `.mcp.json` pipeline, untouched by this module).
 SUPPORTED_MCP_TOPOLOGY = "per_container_stdio"
+
+# Usernames become nginx `location` keys and URL path segments (`/<user>/...`), so
+# they're held to a stricter charset than a bare "no reserved collision" check.
+# Public and defined here, alongside `env_var_suffix`, because this module owns
+# what a roster username *is*: lint's scaffold-time rule, render's fail-closed
+# gate and `auth_credentials`' deploy-time gate all import it from here, so the
+# three cannot drift apart.
+#
+# Apply it with `.fullmatch()`, never `.match()`: Python's `$` also matches
+# *before* a trailing newline, so `.match()` accepts "alice\n" — a name that
+# goes on to render into an nginx location key mid-directive.
+USERNAME_CHARSET_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 
 
 def as_dict(value: Any) -> dict[str, Any]:
@@ -65,6 +81,17 @@ def normalize_users(users_raw: Any) -> list[dict[str, Any]]:
     web terminal resolves it at startup and warns+falls back on an unknown one,
     and lint reports a non-string separately.
 
+    An object entry's optional ``oidc_subject`` (the value of the configured OIDC
+    claim -- ``sub`` by default -- that identifies this roster user at the IdP) is
+    carried through on the same terms, with one deliberate difference: an *empty*
+    string is dropped along with every non-string, where ``display_name`` and
+    ``theme`` would keep it. This field is an authorization mapping, not a
+    cosmetic one -- carrying ``""`` through would let an identity whose claim is
+    missing or empty match a roster user. Dropping it instead leaves that user
+    with no mapping at all, which the callback answers with 403. Only the
+    *non-secret* side of the mapping ever lives in config.yml; password hashes
+    never do (they live in ``.env.auth``, keyed by :func:`env_var_suffix`).
+
     Malformed entries — anything that isn't a string, and any dict missing a
     string ``name`` or an int ``index`` — are dropped rather than raising
     (well-formedness is lint.py's job). ``bool`` is a subclass of ``int`` in
@@ -80,10 +107,10 @@ def normalize_users(users_raw: Any) -> list[dict[str, Any]]:
             than a list (including ``None``) is treated as an empty roster.
 
     Returns:
-        New ``{"name": str, "index": int}`` dicts (plus an optional
-        ``"display_name": str`` key when the entry carried a string one) in
-        config-declaration order. Input dicts are never mutated or returned by
-        reference.
+        New ``{"name": str, "index": int}`` dicts (plus optional
+        ``"display_name"``, ``"theme"`` and ``"oidc_subject"`` string keys when
+        the entry carried them) in config-declaration order. Input dicts are
+        never mutated or returned by reference.
     """
     if not isinstance(users_raw, list):
         return []
@@ -102,8 +129,60 @@ def normalize_users(users_raw: Any) -> list[dict[str, Any]]:
                 theme = entry.get("theme")
                 if isinstance(theme, str):
                     normalized_entry["theme"] = theme
+                oidc_subject = entry.get("oidc_subject")
+                if isinstance(oidc_subject, str) and oidc_subject:
+                    normalized_entry["oidc_subject"] = oidc_subject
                 normalized.append(normalized_entry)
     return normalized
+
+
+def env_var_suffix(username: str) -> str:
+    """Map a roster username to the suffix its per-user env vars are keyed by.
+
+    Uppercase, with ``-`` replaced by ``_`` — so ``alice-b`` keys
+    ``OSPREY_AUTH_PW_HASH_ALICE_B``. This is the single definition of that
+    mapping; credential provisioning, the sidecar's env lookup, and lint all
+    route through it so a username can never be keyed one way at mint time and
+    another at verify time.
+
+    The mapping is intentionally total and lossy: it neither validates the
+    username charset nor rejects anything. Two distinct usernames can therefore
+    collide onto one suffix (``alice-b`` and ``alice_b``), which is exactly what
+    :func:`env_var_suffix_collisions` exists to detect — enforcement is the
+    caller's (a hard raise on the deploy preflight path, an ERROR in lint), not
+    this function's.
+    """
+    return username.upper().replace("-", "_")
+
+
+def env_var_suffix_collisions(usernames: Iterable[str]) -> dict[str, list[str]]:
+    """Find roster usernames that :func:`env_var_suffix` maps onto one suffix.
+
+    Without this check ``alice-b`` and ``alice_b`` would silently share a single
+    ``OSPREY_AUTH_PW_HASH_ALICE_B`` entry — one user's password would open the
+    other's terminal, which is precisely the isolation the auth feature exists to
+    establish.
+
+    A username repeated verbatim in the roster is *not* a collision here: it is
+    one user listed twice (a duplicate-name config error reported separately),
+    not two users sharing a credential. Only distinct names count.
+
+    Args:
+        usernames: Roster usernames — typically ``entry["name"]`` for each
+            :func:`normalize_users` entry. Non-string items are ignored, matching
+            this module's drop-don't-raise convention.
+
+    Returns:
+        ``{suffix: [colliding usernames]}`` for suffixes claimed by two or more
+        distinct usernames; empty when the roster is unambiguous. Suffix keys and
+        the names under each are sorted, so a lint or preflight message built
+        from this is byte-stable across runs.
+    """
+    by_suffix: dict[str, set[str]] = {}
+    for username in usernames:
+        if isinstance(username, str):
+            by_suffix.setdefault(env_var_suffix(username), set()).add(username)
+    return {suffix: sorted(names) for suffix, names in sorted(by_suffix.items()) if len(names) > 1}
 
 
 def effective_image_source(web_terminals: dict[str, Any]) -> str:
@@ -240,7 +319,10 @@ def resolve_personas(
         one (render emits them as ``OSPREY_WEB_APP_NAME`` and
         ``OSPREY_WEB_THEME``); each is omitted entirely otherwise, so a roster
         declaring neither resolves byte-identically to before these fields
-        existed.
+        existed. An optional ``"oidc_subject"`` key rides through on the same
+        terms, so the auth sidecar's roster→identity mapping is read off the same
+        resolved entry as everything else rather than re-derived from the raw
+        roster.
 
     Raises:
         ValueError: See ``strict`` above.
@@ -285,7 +367,7 @@ def resolve_personas(
         render.py's conditional-``sublabel`` convention: a key is present only
         for a non-empty string, so a roster declaring none leaves the entry
         byte-identical to a resolution from before these fields existed."""
-        for field in ("display_name", "theme"):
+        for field in ("display_name", "theme", "oidc_subject"):
             value = source.get(field)
             if isinstance(value, str) and value:
                 entry[field] = value

--- a/src/osprey/deployment/web_terminals/provision.py
+++ b/src/osprey/deployment/web_terminals/provision.py
@@ -3,21 +3,30 @@
 Extracts the web-terminal-only provisioning logic ``osprey deploy up`` runs
 before and around the compose invocation for a ``modules.web_terminals``
 deploy: per-persona local image builds (rendering any missing persona project
-on demand), ``.env.production`` generation for local-mode deploys, rootless-
-podman ``loginctl`` linger, the advisory post-up ``verify.sh`` smoke check, and
-the dual-compose (backend-services + web stack) orchestration itself.
+on demand), ``.env.production`` generation for local-mode deploys, ``.env.auth``
+credential provisioning and its fail-closed gate when authentication is on,
+rootless-podman ``loginctl`` linger, the advisory post-up ``verify.sh`` smoke
+check, and the dual-compose (backend-services + web stack) orchestration itself.
 
 ``osprey.deployment.container_lifecycle.deploy_up`` delegates the whole
 web-terminal branch to :func:`deploy_up_web_terminals` here; everything generic
 or shared with the plain (non-web) deploy path stays in ``container_lifecycle``.
 """
 
+import fnmatch
 import os
+import shutil
 import subprocess
+from dataclasses import dataclass
+from importlib.resources import as_file, files
 from pathlib import Path
 
 import yaml
 
+from osprey.deployment.compose_generator import (
+    _stage_dev_wheel_for_context,
+    resolve_project_name,
+)
 from osprey.deployment.runtime_helper import (
     get_container_image_id,
     get_image_id,
@@ -25,42 +34,106 @@ from osprey.deployment.runtime_helper import (
     runtime_env,
 )
 from osprey.deployment.web_terminals.artifacts import write_web_terminal_artifacts
+from osprey.deployment.web_terminals.auth_credentials import (
+    AUTH_ENV_FILENAME,
+    AuthCredentialsResult,
+    AuthSecretsResult,
+    ensure_auth_credentials,
+    ensure_auth_session_secrets,
+)
 from osprey.deployment.web_terminals.env_production import ensure_env_production
 from osprey.deployment.web_terminals.persona_images import (
     auto_render_missing_personas,
     build_persona_images,
 )
-from osprey.deployment.web_terminals.personas import effective_image_source, resolve_personas
+from osprey.deployment.web_terminals.personas import (
+    effective_image_source,
+    normalize_users,
+    resolve_personas,
+)
 from osprey.deployment.web_terminals.postup_hooks import (
     enable_linger,
     reload_nginx_config,
     run_verify_script,
     warn_if_web_stack_unreachable,
 )
+from osprey.deployment.web_terminals.render import _auth_tls_context
 from osprey.deployment.web_terminals.seeding import seed_user_containers
 from osprey.utils.logger import get_logger
 
 logger = get_logger("deployment.lifecycle")
 
 
-def preflight_web_terminals(config: dict, env: dict[str, str]) -> None:
+@dataclass(frozen=True)
+class WebTerminalPreflightResult:
+    """What :func:`preflight_web_terminals` established that the rest of the
+    deploy still has to act on.
+
+    A state object rather than a bare bool so a later preflight step can report
+    its own decision without changing every caller's signature — the same reason
+    ``auth_credentials`` returns result dataclasses instead of tuples.
+
+    ``auth_env_changed`` is the deterministic sidecar force-recreate signal: it
+    is ``True`` exactly when this preflight added content to ``.env.auth``
+    (a freshly minted hash, a hash derived from a plaintext password, or a
+    signing secret). Compose bakes ``env_file`` content into a container at
+    CREATION time and podman-compose never recreates a container on a
+    content-only change, so a sidecar that is merely left running — or even
+    restarted — would keep serving the *previous* file's credentials. The deploy
+    that changed the file is therefore the deploy that must recreate the
+    sidecar; deferring it to "the next deploy" would leave a user unable to log
+    in with the password this very deploy just printed.
+
+    CONTRACT FOR THE CONSUMER (``deploy_up``'s web-terminal branch in
+    ``osprey.deployment.container_lifecycle``): pass this object straight into
+    :func:`deploy_up_web_terminals`'s ``preflight`` parameter — that function
+    already unions the sidecar into its single post-``up`` recreate when the
+    flag is set, so the consumer needs no compose invocation of its own. The
+    ``lifecycle`` re-render verbs reach the same conclusion by a different route
+    (``purge_auth_credentials`` returning ``True``) and call
+    :func:`force_recreate_auth_sidecar` directly, since they issue no ``up``.
+
+    ``False`` must leave the deploy exactly as it is today — a no-op redeploy
+    still recreates zero containers, which is what keeps live terminals from
+    being bounced on every deploy.
+    """
+
+    auth_env_changed: bool = False
+
+
+def preflight_web_terminals(config: dict, env: dict[str, str]) -> WebTerminalPreflightResult:
     """Fail-fast web-terminal preflight, run BEFORE any image build.
 
     ``deploy_up`` invokes this ahead of its (minutes-long) project-image
-    build so the two deploy aborts that need no image at all — an
-    unresolvable persona catalog and a missing provider auth secret
-    (:func:`ensure_env_production`'s fail-closed gate) — surface in seconds.
-    Local mode first renders any missing persona project (the credential
-    sweep reads each rendered persona's ``config.yml``), from the persona
-    deltas in this deployment's own profile — exactly as the main provisioning
-    path does, which is why ``project_root`` is passed to both: it is where the
-    manifest naming that profile lives.
+    build so the deploy aborts that need no image at all — an
+    unresolvable persona catalog, a missing provider auth secret
+    (:func:`ensure_env_production`'s fail-closed gate), a registry-mode
+    deployment with no ``auth.image`` (:func:`_require_auth_sidecar_image`) and
+    an auth credential that could not be established
+    (:func:`_provision_auth_secrets`) — surface in seconds. Local mode first
+    renders any missing persona project (the credential sweep reads each
+    rendered persona's ``config.yml``), from the persona deltas in this
+    deployment's own profile — exactly as the main provisioning path does,
+    which is why ``project_root`` is passed to both: it is where the manifest
+    naming that profile lives.
+
+    Auth provisioning runs LAST, and in both image-source modes: the sidecar's
+    credentials are needed whatever the images come from, but minting them for
+    a deploy that :func:`ensure_env_production` is about to abort would write
+    (and print) passwords for a stack that never comes up.
 
     Every step is idempotent, so :func:`deploy_up_web_terminals` re-running
     the same sequence later is a cheap no-op: rendered personas are
     user-owned and skipped, and an existing ``.env.production`` is returned
-    as-is. Assumes the project-root cwd every other step of ``osprey deploy
-    up`` already relies on.
+    as-is. Auth provisioning is idempotent in the same sense — an established
+    hash or secret is never rewritten — which is also why it lives here and
+    NOT in :func:`deploy_up_web_terminals`: a second run would report nothing
+    changed and the force-recreate signal would be lost. Assumes the
+    project-root cwd every other step of ``osprey deploy up`` already relies on.
+
+    :returns: A :class:`WebTerminalPreflightResult` whose ``auth_env_changed``
+        tells the caller whether this deploy must force-recreate the auth
+        sidecar — see that class for the full contract.
     """
     project_root = os.getcwd()
     web_terminals = (config.get("modules") or {}).get("web_terminals") or {}
@@ -70,6 +143,457 @@ def preflight_web_terminals(config: dict, env: dict[str, str]) -> None:
         resolved_users = resolve_personas(web_terminals, registry_cfg, facility_prefix, strict=True)
         auto_render_missing_personas(config, resolved_users, env, project_root=Path(project_root))
     ensure_env_production(config, project_root)
+    # BEFORE the mint, deliberately: a registry-mode deploy that forgot
+    # auth.image is already doomed, and minting here first would write (and
+    # print, once) a password for a stack that never comes up. Moving this call
+    # below _provision_auth_secrets silently loses that property.
+    _require_auth_sidecar_image(web_terminals)
+    return WebTerminalPreflightResult(
+        auth_env_changed=_provision_auth_secrets(web_terminals, project_root)
+    )
+
+
+def _provision_auth_secrets(web_terminals: dict, project_root: str) -> bool:
+    """Establish every auth credential this deployment needs, then gate on it.
+
+    A no-op when ``modules.web_terminals.auth.method`` is ``none`` (the
+    default): nothing is read, written or warned about, so an unauthenticated
+    deployment behaves byte-for-byte as it did before authentication existed.
+
+    Otherwise, in this order:
+
+    1. **Mint** — :func:`~osprey.deployment.web_terminals.auth_credentials.ensure_auth_credentials`
+       for the roster (``password`` mode only: it is the sole method that
+       consults a stored hash, and an ``oidc`` deployment must not accumulate
+       passwords nobody will ever type), then
+       :func:`~osprey.deployment.web_terminals.auth_credentials.ensure_auth_session_secrets`,
+       which runs in EVERY method. The latter is not optional in ``oidc`` mode
+       for two independent reasons: the sidecar 503s without a cookie-signing
+       secret, and the sidecar's compose service declares ``env_file:
+       .env.auth`` — ``compose up`` hard-fails when that file does not exist,
+       so this call is also what brings the file into being on a fresh root.
+    2. **Gate** — :func:`_raise_if_auth_provisioning_incomplete`, as a
+       post-mint invariant. Deliberately after the mint, never instead of it:
+       the question is not "was a credential configured?" but "does one exist
+       now?", and only the mint can answer that.
+
+    Nothing wraps the mint in ``try``/``except``: ``ensure_auth_credentials``
+    raises (writing nothing) on a roster it cannot key — a charset violation,
+    or two usernames colliding onto one credential variable — and that raise IS
+    the deploy abort. ``osprey deploy`` never runs lint, so swallowing it would
+    silently deploy a stack where one operator's password opens another's
+    terminal.
+
+    The method is read through
+    :func:`~osprey.deployment.web_terminals.render._auth_tls_context` rather
+    than off the raw stanza, so the deploy path and the rendered artifacts can
+    never disagree about what ``auth`` means — and an unsupported method raises
+    here as well, ahead of the render that would otherwise be the first to
+    notice.
+
+    :param web_terminals: The already-unwrapped ``modules.web_terminals`` dict.
+    :param project_root: Directory holding ``.env``, ``.env.auth`` and
+        ``.gitignore``.
+    :returns: Whether ``.env.auth`` gained content — the caller's
+        ``auth_env_changed``.
+    :raises RuntimeError: If a credential could not be established (see the
+        gate), or if the roster cannot be keyed (charset violation or two
+        usernames colliding onto one credential variable, both raised by
+        ``ensure_auth_credentials``).
+    """
+    auth_method = _auth_tls_context(web_terminals)["auth_method"]
+    if auth_method == "none":
+        return False
+
+    _warn_if_env_auth_not_gitignored(Path(project_root))
+
+    credentials = None
+    if auth_method == "password":
+        usernames = [entry["name"] for entry in normalize_users(web_terminals.get("users"))]
+        credentials = ensure_auth_credentials(usernames, project_root)
+    session_secrets = ensure_auth_session_secrets(project_root)
+    _raise_if_auth_provisioning_incomplete(auth_method, credentials, session_secrets)
+    return bool(credentials and credentials.changed) or session_secrets.changed
+
+
+def _raise_if_auth_provisioning_incomplete(
+    auth_method: str,
+    credentials: AuthCredentialsResult | None,
+    secrets: AuthSecretsResult,
+) -> None:
+    """Fail-closed deploy gate: abort before compose when a credential is missing.
+
+    Both provisioning functions *report* a write failure through their
+    ``missing`` tuple rather than raising, so this is the single place the
+    deploy actually stops — early enough that no container has been created and
+    the operator is left with the stack they already had, rather than one whose
+    login nobody can pass. BOTH tuples are checked: skipping either would let an
+    unwritable ``.env.auth`` log a complaint and proceed to compose anyway.
+
+    A missing password hash can only arise in ``password`` mode, the only mode
+    that provisions one at all — hence the ``None`` credentials result
+    elsewhere. A missing signing secret counts in every method: without it the
+    sidecar answers every request with 503 and the whole deployment is locked
+    out.
+
+    :param auth_method: The parsed ``auth.method`` (never ``"none"`` here).
+    :param credentials: The :func:`ensure_auth_credentials` result, or ``None``
+        when the method provisions no password hashes.
+    :param secrets: The :func:`ensure_auth_session_secrets` result.
+    :raises RuntimeError: If either ``missing`` tuple is non-empty. The message
+        names each affected user and variable — never a password or a hash.
+    """
+    problems: list[str] = []
+    if credentials is not None and credentials.missing:
+        problems.append(
+            "no login password could be established for web-terminal user(s) "
+            f"{', '.join(sorted(credentials.missing))}"
+        )
+    if secrets.missing:
+        problems.append(f"no value could be established for {', '.join(sorted(secrets.missing))}")
+    if not problems:
+        return
+    raise RuntimeError(
+        f"Cannot deploy with modules.web_terminals.auth.method: {auth_method} — "
+        f"{'; '.join(problems)}. {secrets.env_auth_path} could not be written "
+        "(check the file's permissions and the project root's, then re-run). "
+        "Aborting before any container is started: bringing the stack up would "
+        "leave the affected user(s) unable to log in at all."
+    )
+
+
+def _warn_if_env_auth_not_gitignored(project_root: Path) -> None:
+    """Warn — never block — when ``.gitignore`` does not cover ``.env.auth``.
+
+    Projects scaffolded before authentication existed have a ``.gitignore``
+    that lists ``.env`` and ``.env.production`` but not ``.env.auth``, and
+    gitignore matches literal names rather than prefixes, so ``.env`` does not
+    cover it. The file this preflight is about to write holds password hashes
+    and the sidecar's signing secrets; committing it would publish them.
+
+    Coverage is decided by the LAST matching pattern, the way git decides it: a
+    later ``!.env.auth`` un-ignores what an earlier ``.env*`` covered, and that
+    file IS tracked, so it must still warn.
+
+    Warn-only by design: the file is written with mode 0600 either way, the
+    credentials are only *at risk* if someone stages them, and refusing to
+    deploy over the contents of a file the operator may not even track would
+    make the auth feature unusable outside a git checkout for no security gain.
+
+    A project root with no ``.gitignore`` at all is left alone: that is
+    ordinarily a directory nobody commits from, and a deploy is not the place
+    to press an operator into starting a gitignore they never had.
+    """
+    gitignore_path = project_root / ".gitignore"
+    if not gitignore_path.is_file():
+        return
+    try:
+        lines = gitignore_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        # Unreadable .gitignore — nothing to say that would be trustworthy.
+        return
+    # git resolves a path against the LAST pattern that matches it, not the
+    # first — so `.env*` followed by `!.env.auth` leaves the file TRACKED. Scan
+    # every line and keep the polarity of the last match rather than returning
+    # on the first: returning early would go quiet on exactly the arrangement
+    # that re-exposes the credentials.
+    ignored = False
+    for line in lines:
+        pattern = line.strip()
+        if not pattern or pattern.startswith("#"):
+            continue
+        negated = pattern.startswith("!")
+        if negated:
+            pattern = pattern[1:]
+        # Match the way git does for a root-anchored plain file: leading and
+        # trailing "/" are structural, and a pattern may be a glob, so `.env*`
+        # counts as covering the file just as `.env.auth` does.
+        if fnmatch.fnmatch(AUTH_ENV_FILENAME, pattern.strip("/")):
+            ignored = not negated
+    if ignored:
+        return
+    logger.warning(
+        "%s does not ignore %s. That file holds this deployment's web-terminal "
+        "password hashes and session-signing secrets — add a %s line to %s so it "
+        "cannot be committed.",
+        gitignore_path,
+        AUTH_ENV_FILENAME,
+        AUTH_ENV_FILENAME,
+        gitignore_path.name,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auth sidecar: image production and the shared force-recreate primitive
+# ---------------------------------------------------------------------------
+
+#: The auth sidecar's compose service key, as rendered by
+#: ``docker-compose.web.yml.j2``. Every invocation that addresses the sidecar by
+#: name reads it from here rather than restating the literal, so the deploy path
+#: and the rendered artifact cannot drift apart.
+AUTH_SERVICE_NAME = "auth"
+
+#: Build-context directory (relative to the project root) the bundled sidecar
+#: Dockerfile is materialized into. Under ``build/`` with every other service's
+#: context, so it is regenerable and already gitignored.
+AUTH_BUILD_CONTEXT = Path("build") / "services" / "auth_sidecar"
+
+#: Files copied out of the bundled template package to form that context. The
+#: ``.dockerignore`` is not optional: the Dockerfile COPYs it as the guaranteed
+#: sibling that keeps its optional ``*.wh[l]`` glob matching.
+_AUTH_CONTEXT_FILES = ("Dockerfile", ".dockerignore")
+
+#: Package-relative location of those bundled files. Resolved through
+#: importlib.resources rather than ``Path(__file__)`` so it works from an
+#: installed wheel too, matching render.py's convention for the .j2 sources.
+#:
+#: They live beside the module's other templates rather than under
+#: ``templates/services/``: that tree is catalog-bound (every directory there
+#: must be a registered, project-copied build artifact — see
+#: ``BuildArtifactCatalog``), and the sidecar is a web-terminals stack member,
+#: not a service a project declares under ``services:``.
+_AUTH_TEMPLATE_PACKAGE_PATH = "templates/modules/web_terminals/auth_sidecar"
+
+
+def auth_sidecar_local_tag(config: dict) -> str:
+    """The image tag a local-mode deploy builds for the sidecar.
+
+    Must equal what ``docker-compose.web.yml.j2`` renders when ``auth.image``
+    is unset (``{{ auth_image | default(facility_prefix ~ "-assistant-auth:local",
+    true) }}``) — a mismatch would leave compose referencing a tag nothing
+    built, failing at ``up`` with an opaque "no such image".
+    """
+    facility_prefix = (config.get("facility") or {}).get("prefix") or ""
+    return f"{facility_prefix}-assistant-auth:local"
+
+
+def _require_auth_sidecar_image(web_terminals: dict) -> None:
+    """Registry-mode gate: ``auth.image`` must name a published sidecar image.
+
+    Registry mode builds nothing locally, and the compose overlay falls back to
+    the ``:local`` tag when ``auth.image`` is unset — a tag that mode never
+    produces. Without this the deploy would reach ``compose pull``/``up`` and
+    die on a tag no registry has, with nothing to say which key was missing.
+    Publishing the image is the facility CI's contract, exactly like
+    ``.env.production``; OSPREY only checks that the deployment names one.
+
+    A no-op when authentication is off (no sidecar is rendered at all) and in
+    local mode (:func:`build_auth_sidecar_image` produces the tag there).
+
+    :raises RuntimeError: Registry mode, authentication on, ``auth.image`` unset.
+    """
+    if _auth_tls_context(web_terminals)["auth_method"] == "none":
+        return
+    if effective_image_source(web_terminals) == "local":
+        return
+    if _auth_tls_context(web_terminals)["auth_image"]:
+        return
+    raise RuntimeError(
+        "modules.web_terminals.auth.image is not set. A registry-mode deploy "
+        "(modules.web_terminals.image_source: registry, the default) never builds "
+        "the auth sidecar's image locally, so it must name a published one — "
+        "building it and pushing it is the facility CI's job, like .env.production. "
+        "Either set modules.web_terminals.auth.image, or set "
+        "modules.web_terminals.image_source: local to have `osprey deploy up` build "
+        "the sidecar image on this host."
+    )
+
+
+def _materialize_auth_build_context(project_root: Path, dev_mode: bool) -> Path:
+    """Write the bundled sidecar Dockerfile into this project's build tree.
+
+    The sidecar has no rendered project of its own (unlike a persona) and no
+    compose ``build:`` block (unlike a backend service), so its build context is
+    materialized here from the template package. Overwritten on every deploy: it
+    holds no operator-owned content, only the bundled files plus whatever
+    ``--dev`` stages beside them.
+
+    :returns: The build-context directory.
+    """
+    context_dir = project_root / AUTH_BUILD_CONTEXT
+    context_dir.mkdir(parents=True, exist_ok=True)
+    template_dir = files("osprey").joinpath(_AUTH_TEMPLATE_PACKAGE_PATH)
+    for name in _AUTH_CONTEXT_FILES:
+        with as_file(template_dir.joinpath(name)) as source:
+            shutil.copyfile(source, context_dir / name)
+    # Same wheel-drop convention every service build context uses: under --dev
+    # the locally-built wheel lands beside the Dockerfile and its optional COPY
+    # glob picks it up. Fail-loud rather than silently deploying the pinned PyPI
+    # release under a flag that means "run my local code".
+    _stage_dev_wheel_for_context(str(context_dir), dev_mode)
+    return context_dir
+
+
+def build_auth_sidecar_image(config: dict, dev_mode: bool, env: dict[str, str]) -> None:
+    """Build the sidecar's ``<facility_prefix>-assistant-auth:local`` image.
+
+    The local-mode counterpart of :func:`_require_auth_sidecar_image`, and the
+    only producer of that tag: the web compose overlay declares the sidecar with
+    an ``image:`` and no ``build:`` block, so nothing else would ever create it.
+    Called from :func:`deploy_up_web_terminals`'s local branch, beside
+    :func:`build_persona_images` and before any compose invocation.
+
+    The tag is deliberately local-only, which is exactly why the web stack's
+    ``pull`` runs in registry mode ONLY (see :func:`deploy_up_web_terminals`'s
+    MODE BRANCH): ``compose pull`` hard-fails on a tag no registry can serve, so
+    a local-mode pull would abort the deploy on this image alone.
+
+    Three no-op cases, each deliberate:
+
+    * authentication off — no sidecar service is rendered, so nothing to build;
+    * registry mode — the image comes from ``auth.image`` (preflight already
+      required it);
+    * ``auth.image`` set in local mode — the deployment pinned an external
+      image, and building over that pin would produce a tag nothing references.
+
+    :param config: Raw deploy config.
+    :param dev_mode: Whether ``--dev`` was passed — stages a locally-built wheel
+        into the build context, exactly like every other service image.
+    :param env: Environment for the build subprocess.
+    """
+    web_terminals = (config.get("modules") or {}).get("web_terminals") or {}
+    auth_ctx = _auth_tls_context(web_terminals)
+    if auth_ctx["auth_method"] == "none":
+        return
+    if effective_image_source(web_terminals) != "local":
+        return
+    if auth_ctx["auth_image"]:
+        logger.info(
+            "Skipping the local auth-sidecar build: modules.web_terminals.auth.image "
+            "pins %s, so the deployment supplies the image.",
+            auth_ctx["auth_image"],
+        )
+        return
+
+    project_root = Path(os.getcwd())
+    context_dir = _materialize_auth_build_context(project_root, dev_mode)
+
+    from osprey import __version__ as osprey_version
+
+    tag = auth_sidecar_local_tag(config)
+    project_label = resolve_project_name(config)
+    cmd = [
+        get_runtime_command(config)[0],
+        "build",
+        "-t",
+        tag,
+        "-f",
+        str(context_dir / "Dockerfile"),
+        # OSPREY_PROJECT_NAME is what stamps `com.osprey.project` on the image
+        # (the Dockerfile's final metadata-only layer), the same ownership label
+        # persona images carry — `nuke` verifies it before removing a tag, so an
+        # unlabeled image here would be left behind by a full teardown.
+        "--build-arg",
+        f"OSPREY_PROJECT_NAME={project_label}",
+        "--build-arg",
+        f"OSPREY_VERSION={osprey_version}",
+    ]
+    if dev_mode:
+        cmd.extend(["--build-arg", "OSPREY_DEV=1"])
+    cmd.append(str(context_dir))
+
+    logger.key_info("Building auth sidecar image %s:", tag)
+    logger.info("Running command:\n    %s", " ".join(cmd))
+    subprocess.run(cmd, env=env, check=True)
+
+
+def web_stack_compose_cmd(config: dict, env_file_args: list[str] | None = None) -> list[str]:
+    """The web stack's ``<runtime> compose -f docker-compose.web.yml [...]`` base argv.
+
+    One builder for every invocation against the web compose project — the
+    deploy path's ``pull``/``up``/recreate, ``deploy_down_web_terminals``, and
+    the lifecycle verbs' nginx reload and sidecar recreate — so no caller can
+    fork the argv and drift from it (the project directory the web file's
+    relative paths resolve against is decided by this ``-f`` list; see
+    :func:`deploy_up_web_terminals`'s WHY TWO INVOCATIONS note).
+
+    :param env_file_args: The ``["--env-file", ".env"]`` (or ``[]``) fragment
+        the caller already resolved. ``None`` resolves it here through
+        ``container_lifecycle._env_file_args``, for the lifecycle verbs that are
+        entered straight from the CLI and never had one to thread down — so the
+        rule (and its "no .env" warning) keeps a single definition.
+    """
+    if env_file_args is None:
+        # Function-local import: container_lifecycle imports this module at its
+        # top level, so importing it back at module scope would be a cycle
+        # (same reason persona_images imports _resolve_pip_spec locally).
+        from osprey.deployment.container_lifecycle import _env_file_args
+
+        env_file_args = _env_file_args()
+    cmd = get_runtime_command(config)
+    cmd.extend(("-f", "docker-compose.web.yml"))
+    cmd.extend(env_file_args)
+    return cmd
+
+
+def force_recreate_auth_sidecar(
+    config: dict,
+    env_file_args: list[str] | None = None,
+    *,
+    env: dict[str, str] | None = None,
+) -> None:
+    """Recreate the auth sidecar container so it re-reads ``.env.auth``.
+
+    Compose bakes ``env_file`` CONTENT into a container at creation time, and
+    podman-compose never recreates a container whose service definition is
+    unchanged — so after ``.env.auth`` changes, neither a plain ``up -d`` nor a
+    restart puts the new credentials in force. Only a recreate does.
+
+    One function because there are three callers that must all do it identically:
+
+    1. the deploy path, whenever preflight reports
+       :attr:`WebTerminalPreflightResult.auth_env_changed`;
+    2. the lifecycle verbs (``decommission_user``/``prune_users``), which purge
+       a departed user's entries and must kill that user's sessions at once;
+    3. ``osprey deploy passwd <user>``, so a rotated password takes effect
+       immediately rather than at the next full deploy.
+
+    Scoped to the single ``auth`` service: recreating the whole stack would
+    bounce every live terminal for a change none of them can see.
+
+    A no-op (with a warning) when no ``docker-compose.web.yml`` has been
+    rendered at the project root — there is no stack to recreate, and failing
+    here would turn "nothing was deployed yet" into a deploy error.
+
+    :param config: Raw deploy config (selects the runtime and the pinned
+        compose project).
+    :param env_file_args: The ``["--env-file", ".env"]`` (or ``[]``) argv
+        fragment the caller resolved, exactly as the ``up``/``down`` paths take
+        it; ``None`` lets :func:`web_stack_compose_cmd` resolve it, which is what
+        the lifecycle verbs (``passwd``, ``decommission``, ``prune``) pass since
+        they are entered straight from the CLI.
+    :param env: Base environment for the subprocess; defaults to this process's
+        own. Pinned with ``COMPOSE_PROJECT_NAME`` here either way, so the
+        recreate addresses the same compose project the stack was brought up in.
+    """
+    if not Path("docker-compose.web.yml").exists():
+        logger.warning(
+            "No docker-compose.web.yml at the project root — skipping the auth "
+            "sidecar recreate. Any %s change takes effect at the next "
+            "`osprey deploy up`.",
+            AUTH_ENV_FILENAME,
+        )
+        return
+    _force_recreate_services(
+        web_stack_compose_cmd(config, env_file_args),
+        runtime_env(config, env if env is not None else dict(os.environ)),
+        [AUTH_SERVICE_NAME],
+    )
+
+
+def _force_recreate_services(
+    web_cmd: list[str], run_env: dict[str, str], services: list[str]
+) -> None:
+    """Run one service-scoped ``up -d --force-recreate`` for ``services``.
+
+    The single place that argv is built. Always service-scoped: a bare
+    ``up -d --force-recreate`` would bounce every live terminal in the stack,
+    which is exactly what both callers (the post-``up`` reconcile and
+    :func:`force_recreate_auth_sidecar`) exist to avoid.
+    """
+    cmd = web_cmd + ["up", "-d", "--force-recreate", *services]
+    logger.info(f"Running command:\n    {' '.join(cmd)}")
+    subprocess.run(cmd, env=run_env, check=True)
 
 
 def deploy_up_web_terminals(
@@ -78,6 +602,7 @@ def deploy_up_web_terminals(
     dev_mode: bool,
     env: dict[str, str],
     env_file_args: list[str],
+    preflight: WebTerminalPreflightResult | None = None,
 ) -> None:
     """Reconcile the web-terminal stack (plus any co-deployed backend services).
 
@@ -209,6 +734,12 @@ def deploy_up_web_terminals(
         rather than recomputed here so the "no .env" warning stays defined in
         one place and this module needs no import back into
         ``container_lifecycle``.
+    :param preflight: What :func:`preflight_web_terminals` returned for THIS
+        deploy. Its ``auth_env_changed`` adds the auth sidecar to the post-``up``
+        recreate set — the deploy that changed ``.env.auth`` is the deploy that
+        must put those credentials in force. ``None`` (the default) keeps the
+        pre-authentication behavior exactly: nothing is force-recreated beyond
+        podman's own image drift.
     """
     write_web_terminal_artifacts(config)
 
@@ -243,6 +774,10 @@ def deploy_up_web_terminals(
         # only once `up` runs.
         ensure_env_production(config, project_root)
         build_persona_images(config, resolved_users, dev_mode, env)
+        # The sidecar's own local-only tag, produced by the same rule and at the
+        # same point as the persona images: nothing else builds it, and the web
+        # stack's `up` below would otherwise die on a tag that does not exist.
+        build_auth_sidecar_image(config, dev_mode, env)
     else:
         # Registry mode has no auto-render; the same before-compose rule holds.
         ensure_env_production(config, project_root)
@@ -286,9 +821,7 @@ def deploy_up_web_terminals(
         subprocess.run(services_cmd, env=run_env, check=True)
 
     # ---- web-terminal stack (own compose project directory: project root) --
-    web_cmd = get_runtime_command(config)
-    web_cmd.extend(("-f", "docker-compose.web.yml"))
-    web_cmd.extend(env_file_args)
+    web_cmd = web_stack_compose_cmd(config, env_file_args)
 
     # Same stale-container preflight as the services stack above (and same
     # no-`--remove-orphans` constraint — see that comment).
@@ -309,14 +842,17 @@ def deploy_up_web_terminals(
     logger.info(f"Running command:\n    {' '.join(up_cmd)}")
     subprocess.run(up_cmd, env=run_env, check=True)
 
-    # podman-compose 1.0.6 never recreates a container on a same-tag digest
-    # change, so a re-pulled `:latest` (or any moving tag) leaves the previous
-    # image's container running after the `up` above. Reconcile that drift by
-    # force-recreating only the services whose running image ID no longer
-    # matches their tag's freshly resolved image ID. No-op on docker (its
-    # compose already recreates after a pull — double-recreating would bounce
-    # live terminals).
-    _reconcile_web_stack_image_drift(config, web_cmd, run_env)
+    # One post-`up` recreate covering both reasons a container can still be
+    # stale: podman's same-tag image drift, and — when preflight changed
+    # `.env.auth` — the auth sidecar, whose env_file content compose baked in at
+    # creation time. Unioned rather than issued separately so a sidecar that
+    # qualifies both ways is recreated once, not twice.
+    _reconcile_web_stack_recreates(
+        config,
+        web_cmd,
+        run_env,
+        force_recreate=(AUTH_SERVICE_NAME,) if preflight and preflight.auth_env_changed else (),
+    )
 
     # Hot-reload nginx: `up -d` never restarts a running nginx whose
     # bind-mounted nginx.conf/landing.html CONTENT changed — the container
@@ -344,27 +880,37 @@ def deploy_up_web_terminals(
     warn_if_web_stack_unreachable(config)
 
 
-def _reconcile_web_stack_image_drift(
-    config: dict, web_cmd: list[str], run_env: dict[str, str]
+def _reconcile_web_stack_recreates(
+    config: dict,
+    web_cmd: list[str],
+    run_env: dict[str, str],
+    force_recreate: tuple[str, ...] = (),
 ) -> None:
-    """Force-recreate web-stack containers whose running image ID drifted from
-    their tag.
+    """Issue the one post-``up`` force-recreate this deploy needs.
 
-    ``podman-compose`` 1.0.6 treats a container as up-to-date whenever its
-    service definition is unchanged, so a same-tag digest change (a re-pulled
-    ``:latest``, or any moving tag) never triggers a recreate — ``up -d`` leaves
-    the container running the previous image. This inspects, for each service
-    the rendered ``docker-compose.web.yml`` declares, the image ID its ``image:``
-    reference now resolves to versus the image ID its running container was
-    created from, and runs ``up -d --force-recreate`` for exactly the services
-    that differ.
+    Two independent reasons a container can be stale after ``up -d``, resolved
+    into a SINGLE service-scoped recreate so no container is bounced twice:
 
-    Gated to podman: ``docker compose`` already recreates a service after its
-    image is re-pulled, so a second forced recreate here would needlessly bounce
-    a live terminal. Every inspection is advisory — a service whose image or
-    container can't be inspected (missing image, container not yet created) is
-    skipped, never aborting the deploy — and an all-match run issues no compose
-    command at all.
+    1. **Image drift** (podman only). ``podman-compose`` 1.0.6 treats a
+       container as up-to-date whenever its service definition is unchanged, so
+       a same-tag digest change (a re-pulled ``:latest``, or any moving tag)
+       never triggers a recreate — ``up -d`` leaves the container running the
+       previous image. This inspects, for each service the rendered
+       ``docker-compose.web.yml`` declares, the image ID its ``image:``
+       reference now resolves to versus the image ID its running container was
+       created from. Gated to podman: ``docker compose`` already recreates a
+       service after its image is re-pulled, so a second forced recreate would
+       needlessly bounce a live terminal. Every inspection is advisory — a
+       service whose image or container can't be inspected (missing image,
+       container not yet created) is skipped, never aborting the deploy.
+    2. **``force_recreate``, from the caller** — today the auth sidecar when
+       preflight changed ``.env.auth``, whose content compose baked into the
+       running container at creation time. This reason is runtime-independent:
+       unlike drift, no compose implementation recreates on an ``env_file``
+       content change, so these services are recreated on docker too and the
+       podman gate above deliberately does not cover them.
+
+    An all-match run with no ``force_recreate`` issues no compose command at all.
 
     :param config: Raw deploy config (selects the runtime).
     :param web_cmd: The web stack's ``<runtime> compose -f docker-compose.web.yml
@@ -372,46 +918,47 @@ def _reconcile_web_stack_image_drift(
         against the same compose project as the preceding ``up``.
     :param run_env: The ``COMPOSE_PROJECT_NAME``-pinned environment shared by
         every web-stack invocation.
+    :param force_recreate: Service keys to recreate regardless of image drift
+        and regardless of runtime. Unioned with the drifted set (order
+        preserved, no duplicates) so a service that qualifies both ways is
+        recreated exactly once.
     """
+    changed: list[str] = list(force_recreate)
+
     runtime = get_runtime_command(config)[0]
-    if runtime != "podman":
-        return
+    if runtime == "podman":
+        # The rendered compose file (written at the top of
+        # deploy_up_web_terminals) is the single source of truth for which
+        # services exist and what image / container name each carries -- reading
+        # it here keeps this reconcile free of any per-service name
+        # reconstruction and covers nginx and every per-user terminal uniformly.
+        try:
+            compose_doc = yaml.safe_load(Path("docker-compose.web.yml").read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError) as exc:
+            logger.warning(
+                "image-drift reconcile skipped: could not read docker-compose.web.yml: %s", exc
+            )
+            compose_doc = None
 
-    # The rendered compose file (written at the top of deploy_up_web_terminals)
-    # is the single source of truth for which services exist and what image /
-    # container name each carries -- reading it here keeps this reconcile free
-    # of any per-service name reconstruction and covers nginx and every
-    # per-user terminal uniformly.
-    try:
-        compose_doc = yaml.safe_load(Path("docker-compose.web.yml").read_text(encoding="utf-8"))
-    except (OSError, yaml.YAMLError) as exc:
-        logger.warning(
-            "image-drift reconcile skipped: could not read docker-compose.web.yml: %s", exc
-        )
-        return
-
-    services = (compose_doc or {}).get("services") or {}
-    changed: list[str] = []
-    for service_name, service in services.items():
-        service = service or {}
-        image = service.get("image")
-        container = service.get("container_name")
-        if not image or not container:
-            continue
-        tag_id = get_image_id(runtime, image, env=run_env)
-        running_id = get_container_image_id(runtime, container, env=run_env)
-        if tag_id is None or running_id is None:
-            # Missing image or not-yet-created container -- advisory skip.
-            continue
-        if tag_id != running_id:
-            changed.append(service_name)
+        services = (compose_doc or {}).get("services") or {}
+        for service_name, service in services.items():
+            service = service or {}
+            image = service.get("image")
+            container = service.get("container_name")
+            if not image or not container or service_name in changed:
+                continue
+            tag_id = get_image_id(runtime, image, env=run_env)
+            running_id = get_container_image_id(runtime, container, env=run_env)
+            if tag_id is None or running_id is None:
+                # Missing image or not-yet-created container -- advisory skip.
+                continue
+            if tag_id != running_id:
+                changed.append(service_name)
 
     if not changed:
         return
 
-    recreate_cmd = web_cmd + ["up", "-d", "--force-recreate", *changed]
-    logger.info(f"Running command:\n    {' '.join(recreate_cmd)}")
-    subprocess.run(recreate_cmd, env=run_env, check=True)
+    _force_recreate_services(web_cmd, run_env, changed)
 
 
 def deploy_down_web_terminals(
@@ -452,9 +999,7 @@ def deploy_down_web_terminals(
     """
     if not Path("docker-compose.web.yml").exists():
         return
-    down_cmd = get_runtime_command(config)
-    down_cmd.extend(("-f", "docker-compose.web.yml"))
-    down_cmd.extend(env_file_args)
+    down_cmd = web_stack_compose_cmd(config, env_file_args)
     down_cmd.append("down")
     logger.info(f"Running command:\n    {' '.join(down_cmd)}")
     result = subprocess.run(

--- a/src/osprey/deployment/web_terminals/render.py
+++ b/src/osprey/deployment/web_terminals/render.py
@@ -17,8 +17,11 @@ from jinja2 import Environment, FileSystemLoader
 
 from osprey.deployment.web_terminals.personas import (
     SUPPORTED_MCP_TOPOLOGY,
+    USERNAME_CHARSET_RE,
     as_dict,
     effective_image_source,
+    env_var_suffix,
+    env_var_suffix_collisions,
     resolve_personas,
 )
 from osprey.deployment.web_terminals.ports import (
@@ -58,6 +61,30 @@ _LOOPBACK_BIND_HOST = "127.0.0.1"
 # an absent config value renders exactly as before this seam existed.
 _DEFAULT_NGINX_IMAGE = "nginx:1.27-alpine"
 
+#: The authentication methods this deployment can actually serve: ``none`` (no
+#: auth at all), ``password`` (OSPREY-managed scrypt hashes) and ``oidc``
+#: (Authlib client against a facility IdP). Anything else is a hard config
+#: error rather than a forward-compatible passthrough — nginx would emit the
+#: ``auth_request`` seam against a sidecar that cannot answer for that method,
+#: which does fail closed but only as an unactionable 403 on every request.
+SUPPORTED_AUTH_METHODS = ("none", "password", "oidc")
+
+#: Port the auth sidecar listens on when ``auth.port`` is unset. Deliberately
+#: outside the per-user port families (which start at ``*_base_port`` and grow
+#: with the roster) so a default-port sidecar can't collide with user N's
+#: terminal; lint joins the effective value into its port-collision check.
+_DEFAULT_AUTH_PORT = 9070
+
+#: How long an unlocked-user entry stays valid when ``auth.session_lifetime``
+#: is unset, in seconds (12 hours — one operator shift plus slack).
+_DEFAULT_SESSION_LIFETIME = 12 * 60 * 60
+
+#: Env-var *names* (never values) the sidecar reads its OIDC client credentials
+#: from when the config doesn't name its own. The credentials themselves live
+#: in ``.env.auth`` and never enter config.yml.
+_DEFAULT_OIDC_CLIENT_ID_ENV = "OSPREY_AUTH_OIDC_CLIENT_ID"
+_DEFAULT_OIDC_CLIENT_SECRET_ENV = "OSPREY_AUTH_OIDC_CLIENT_SECRET"
+
 
 def render_web_terminals(config: Any) -> dict[str, str]:
     """Render the compose overlay, nginx fragment, and landing page for one facility config.
@@ -77,8 +104,13 @@ def render_web_terminals(config: Any) -> dict[str, str]:
     Raises:
         ValueError: If ``modules.web_terminals.nginx_port`` is missing/not an int,
             if a configured user can't resolve a full port-family set, if
-            ``deploy.fqdn`` is missing while at least one user is configured (the
-            landing-origin host baked into ``OSPREY_TERMINAL_LANDING_URL``), if
+            ``deploy.fqdn`` is missing while the deployment needs an external
+            origin — at least one user configured (the host baked into
+            ``OSPREY_TERMINAL_LANDING_URL``) or authentication enabled (see
+            :func:`_external_origin`), if the ``auth``/``tls`` stanzas are
+            incoherent (unknown ``auth.method``, ``tls.enabled`` without a
+            cert/key pair, or authentication over cleartext HTTP without
+            ``auth.allow_insecure_http``), if
             a roster entry's persona reference can't be resolved (see
             :func:`osprey.deployment.web_terminals.personas.resolve_personas`'s
             ``strict`` contract — render always resolves strictly), or if
@@ -117,6 +149,21 @@ def render_web_terminals(config: Any) -> dict[str, str]:
                 # the template's `{% if svc.theme %}` guard false, so no env
                 # line is emitted and the app falls back to config web.theme.
                 "theme": entry.get("theme"),
+                # Optional per-user OIDC identity -> the auth sidecar's
+                # OSPREY_AUTH_OIDC_SUBJECT_<SUFFIX>. Same shape again: absent
+                # leaves the compose template's `{% if svc.oidc_subject %}`
+                # guard false. Without this passthrough an `oidc` deployment
+                # would render no subject mapping at all and every IdP identity
+                # would be unmappable.
+                "oidc_subject": entry.get("oidc_subject"),
+                # The env-var name that subject is emitted under, resolved HERE
+                # through env_var_suffix() — the single definition of the
+                # username->env-var mapping, shared with credential
+                # provisioning, the sidecar's own lookup and lint. The template
+                # emits this verbatim rather than re-deriving `upper|replace`,
+                # which would be a second copy of the mapping free to drift from
+                # the one that keys the password hashes.
+                "oidc_subject_env": f"OSPREY_AUTH_OIDC_SUBJECT_{env_var_suffix(entry['name'])}",
                 **user_ports,
                 # One env line per companion family, derived from the web-server
                 # registry (PANEL_ENV_VARS) so a newly registered companion is
@@ -134,9 +181,41 @@ def render_web_terminals(config: Any) -> dict[str, str]:
     if not isinstance(nginx_port, int):
         raise ValueError("modules.web_terminals.nginx_port is required and must be an int")
 
-    landing_url = _landing_url(root, nginx_port) if services else ""
-
     image_source = effective_image_source(web_terminals)
+
+    auth_tls_ctx = _auth_tls_context(web_terminals)
+    if auth_tls_ctx["tls_enabled"] and not (auth_tls_ctx["tls_cert"] and auth_tls_ctx["tls_key"]):
+        raise ValueError(
+            "modules.web_terminals.tls.enabled is true but tls.cert/tls.key are not both "
+            "set — the gated `listen 443 ssl` seam needs both paths to emit a "
+            "coherent ssl_certificate/ssl_certificate_key pair"
+        )
+    if (
+        auth_tls_ctx["auth_method"] != "none"
+        and not auth_tls_ctx["tls_enabled"]
+        and not auth_tls_ctx["auth_allow_insecure_http"]
+    ):
+        raise ValueError(
+            f"modules.web_terminals.auth.method is {auth_tls_ctx['auth_method']!r} but "
+            "tls.enabled is false — session cookies would cross the network in "
+            "cleartext, so login is refused rather than rendered insecurely. Enable "
+            "tls, or set auth.allow_insecure_http: true to accept that risk (only "
+            "sensible behind a TLS-terminating proxy or on an isolated network)"
+        )
+    _check_roster_charset(services, auth_tls_ctx["auth_method"])
+    _check_roster_env_var_collisions(services, auth_tls_ctx["auth_method"])
+
+    tls_enabled = auth_tls_ctx["tls_enabled"]
+    # The one origin every absolute URL in this deployment is built from (see
+    # _external_origin). Derived only when something actually needs it: a
+    # roster-less config with no auth has no absolute URL to build, and must
+    # keep rendering without a deploy.fqdn.
+    external_origin = (
+        _external_origin(root, nginx_port, tls_enabled=tls_enabled)
+        if services or auth_tls_ctx["auth_method"] != "none"
+        else ""
+    )
+    landing_url = _landing_url(root, nginx_port, tls_enabled=tls_enabled) if services else ""
 
     compose_ctx = {
         "facility_prefix": facility_prefix,
@@ -152,19 +231,19 @@ def render_web_terminals(config: Any) -> dict[str, str]:
         # public tag. Facilities whose images all come from a private registry
         # override this so the nginx image is pullable too.
         "nginx_image": web_terminals.get("nginx_image") or _DEFAULT_NGINX_IMAGE,
+        # The auth sidecar's service (image, listen port, session lifetime, the
+        # env-var names its OIDC credentials arrive under) is rendered from the
+        # same parsed stanza the nginx seam reads, so the two ends of the
+        # auth_request contract can't drift apart.
+        "external_origin": external_origin,
+        **auth_tls_ctx,
     }
-    auth_tls_ctx = _auth_tls_context(web_terminals)
-    if auth_tls_ctx["tls_enabled"] and not (auth_tls_ctx["tls_cert"] and auth_tls_ctx["tls_key"]):
-        raise ValueError(
-            "modules.web_terminals.tls.enabled is true but tls.cert/tls.key are not both "
-            "set — the gated `listen 443 ssl` seam (Task 1.3) needs both paths to emit a "
-            "coherent ssl_certificate/ssl_certificate_key pair"
-        )
 
     nginx_ctx = {
         "nginx_port": nginx_port,
         "services": services,
         "bind_host": _LOOPBACK_BIND_HOST,
+        "external_origin": external_origin,
         **auth_tls_ctx,
     }
     landing_ctx = {
@@ -297,25 +376,56 @@ def _landing_theme_blocks(root: dict[str, Any]) -> list[dict[str, Any]]:
     return blocks
 
 
-def _landing_url(root: dict[str, Any], nginx_port: int) -> str:
-    """Build the absolute origin baked into every service's ``OSPREY_TERMINAL_LANDING_URL``.
+def _external_origin(root: dict[str, Any], nginx_port: int, *, tls_enabled: bool) -> str:
+    """Build the one origin every absolute URL this deployment emits is derived from.
 
-    Per-user containers only get this value once, at container start (env vars, not
-    request time) — unlike nginx.conf.j2's per-request ``$host`` redirect target,
-    resolving it can't be deferred to the browser. It comes from ``deploy.fqdn``:
-    the schema documents that field as reachable from developers' laptops (used in
-    client-mode profiles), whereas ``deploy.host`` is only guaranteed
-    SSH-resolvable (may be a bare `~/.ssh/config` alias, not a browser-reachable
-    hostname).
+    Two consumers need an absolute URL that a browser will actually resolve: the
+    landing link baked into each container (:func:`_landing_url`) and the auth
+    sidecar's OIDC ``redirect_uri``. Those two must agree exactly — an IdP
+    rejects a ``redirect_uri`` that isn't character-for-character the registered
+    one, and a landing link on a different origin would drop the session cookie
+    — so both come from here rather than being assembled twice.
+
+    Scheme and port follow ``tls.enabled``: with TLS on, the 443 server is the
+    sole content server (the plain listener only redirects to it), and 443 is
+    left implicit, which is both the canonical origin serialization and the form
+    an IdP client registration is normally written in. With TLS off the origin
+    is plain HTTP on the published ``nginx_port``.
+
+    The host comes from ``deploy.fqdn``: the schema documents that field as
+    reachable from developers' laptops (used in client-mode profiles), whereas
+    ``deploy.host`` is only guaranteed SSH-resolvable (may be a bare
+    `~/.ssh/config` alias, not a browser-reachable hostname).
+
+    Args:
+        root: The parsed facility config (only ``deploy.fqdn`` is read).
+        nginx_port: The published plain-HTTP port, used only when TLS is off.
+        tls_enabled: The parsed ``tls.enabled`` (see :func:`_auth_tls_context`).
+
+    Raises:
+        ValueError: If ``deploy.fqdn`` is missing or blank.
     """
     deploy = as_dict(root.get("deploy"))
     host = str(deploy.get("fqdn") or "").strip()
     if not host:
         raise ValueError(
             "deploy.fqdn is required to render modules.web_terminals landing_url "
-            "(OSPREY_TERMINAL_LANDING_URL) when at least one user is configured"
+            "(OSPREY_TERMINAL_LANDING_URL) when at least one user is configured "
+            "or authentication is enabled"
         )
-    return f"http://{host}:{nginx_port}"
+    return f"https://{host}" if tls_enabled else f"http://{host}:{nginx_port}"
+
+
+def _landing_url(root: dict[str, Any], nginx_port: int, *, tls_enabled: bool = False) -> str:
+    """The absolute origin baked into every service's ``OSPREY_TERMINAL_LANDING_URL``.
+
+    Per-user containers only get this value once, at container start (env vars, not
+    request time) — unlike nginx.conf.j2's per-request ``$host`` redirect target,
+    resolving it can't be deferred to the browser. It is the deployment's external
+    origin verbatim (:func:`_external_origin`), which is what keeps a "back to
+    landing" link and an OIDC ``redirect_uri`` on the same origin by construction.
+    """
+    return _external_origin(root, nginx_port, tls_enabled=tls_enabled)
 
 
 def _user_card(resolved_user: dict[str, Any]) -> dict[str, Any]:
@@ -390,36 +500,187 @@ def _build_groups(
 
 
 def _auth_tls_context(web_terminals: dict[str, Any]) -> dict[str, Any]:
-    """Read the optional, forward-looking ``web_terminals.auth``/``web_terminals.tls``
-    stanzas (Task 1.4's config contract) into the context keys the gated nginx seam
-    render (Task 1.3) consumes.
+    """Read the ``web_terminals.auth``/``web_terminals.tls`` stanzas into the context
+    keys the nginx seam and the auth sidecar's compose service consume.
 
-    Both stanzas are entirely optional and default to the inert v1 posture: no
-    authentication, no TLS — identical trust model to Phase 1, only the access
-    boundary moves from host-port to URL-path. **This function does not render any
-    nginx seam block itself** — it only derives the defensively-read values; Task
-    1.3 is responsible for turning ``tls_enabled``/``auth_method`` into actual
-    `listen 443 ssl` / `auth_request` directives.
+    This is the single place ``modules.web_terminals.auth`` is parsed: the nginx
+    template, the compose overlay and the lint rules all read the keys returned
+    here rather than the raw config, so there is one definition of what an
+    ``auth`` stanza means. **This function renders nothing** — it derives values;
+    the templates turn ``tls_enabled``/``auth_method`` into actual `listen 443
+    ssl` / `auth_request` directives.
+
+    Both stanzas remain entirely optional and default to the inert posture: no
+    authentication, no TLS. Every value is read defensively (wrong-typed entries
+    fall back to their default, as everywhere else in this module — lint is the
+    authoritative gate on schema well-formedness) with one exception: an
+    ``auth.method`` string naming a method that does not exist raises, because
+    the resulting deployment would emit an auth seam nothing can answer.
 
     Args:
         web_terminals: The already-unwrapped ``modules.web_terminals`` dict (as
             passed to :func:`render_web_terminals`'s Jinja contexts).
 
     Returns:
-        A dict with exactly four keys: ``auth_method`` (str, defaults to
-        ``"none"``), ``tls_enabled`` (bool, defaults to ``False``), and
-        ``tls_cert``/``tls_key`` (str path or ``None``, present only to be read
-        when ``tls_enabled`` is true).
+        A dict with the auth keys ``auth_method`` (one of
+        :data:`SUPPORTED_AUTH_METHODS`, defaults to ``"none"``), ``auth_port``
+        (int, the sidecar's listen port), ``auth_session_lifetime`` (int
+        seconds), ``auth_allow_insecure_http`` (bool), ``auth_image`` (str or
+        ``None`` — required only in registry image-source mode),
+        ``auth_oidc_issuer`` (str or ``None``),
+        ``auth_oidc_client_id_env``/``auth_oidc_client_secret_env`` (the env-var
+        *names* the sidecar reads its OIDC client credentials from — never the
+        credentials themselves) and ``auth_oidc_claim`` (str or ``None``, the
+        ID-token claim carrying the identity to map onto a roster user); plus
+        the TLS keys ``tls_enabled`` (bool) and
+        ``tls_cert``/``tls_key`` (str path or ``None``, read only when
+        ``tls_enabled``).
+
+    Raises:
+        ValueError: If ``auth.method`` is a non-empty string outside
+            :data:`SUPPORTED_AUTH_METHODS`.
     """
     auth = as_dict(web_terminals.get("auth"))
     tls = as_dict(web_terminals.get("tls"))
-    auth_method = auth.get("method")
+    oidc = as_dict(auth.get("oidc"))
+
+    method = auth.get("method")
+    auth_method = method if isinstance(method, str) and method else "none"
+    if auth_method not in SUPPORTED_AUTH_METHODS:
+        raise ValueError(
+            f"modules.web_terminals.auth.method {auth_method!r} is not a supported "
+            f"authentication method; expected one of {', '.join(SUPPORTED_AUTH_METHODS)}"
+        )
+
     return {
-        "auth_method": auth_method if isinstance(auth_method, str) and auth_method else "none",
+        "auth_method": auth_method,
+        "auth_port": _positive_int(auth.get("port"), _DEFAULT_AUTH_PORT),
+        "auth_session_lifetime": _positive_int(
+            auth.get("session_lifetime"), _DEFAULT_SESSION_LIFETIME
+        ),
+        "auth_allow_insecure_http": bool(auth.get("allow_insecure_http", False)),
+        "auth_image": auth.get("image") or None,
+        "auth_oidc_issuer": oidc.get("issuer") or None,
+        "auth_oidc_client_id_env": _non_empty_str(
+            oidc.get("client_id_env"), _DEFAULT_OIDC_CLIENT_ID_ENV
+        ),
+        "auth_oidc_client_secret_env": _non_empty_str(
+            oidc.get("client_secret_env"), _DEFAULT_OIDC_CLIENT_SECRET_ENV
+        ),
+        # Which ID-token claim carries the identity that maps onto a roster
+        # user. Left as None when unset (rather than defaulted here) so the
+        # compose service emits no OSPREY_AUTH_OIDC_CLAIM at all and the
+        # sidecar's own documented default applies — one default, in one place.
+        "auth_oidc_claim": _non_empty_str(oidc.get("claim"), "") or None,
         "tls_enabled": bool(tls.get("enabled", False)),
         "tls_cert": tls.get("cert"),
         "tls_key": tls.get("key"),
     }
+
+
+def _positive_int(value: Any, default: int) -> int:
+    """A config value read as a positive int, falling back to ``default``.
+
+    ``bool`` is excluded explicitly: it passes ``isinstance(..., int)``, and
+    ``auth.port: true`` becoming port 1 would be a baffling deployment.
+    """
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return value
+    return default
+
+
+def _non_empty_str(value: Any, default: str) -> str:
+    """A config value read as a non-empty string, falling back to ``default``."""
+    return value if isinstance(value, str) and value.strip() else default
+
+
+def _check_roster_charset(services: list[dict[str, Any]], auth_method: str) -> None:
+    """Fail-closed render gate: with authentication on, every roster name must
+    match the username charset.
+
+    The charset is enforced in two other places, and a deployment can miss both:
+    lint is skippable (``--no-lint``), and ``auth_credentials`` only runs on the
+    password-mode deploy path. Nothing on the render path itself checked, so a
+    name carrying ``&`` or ``?`` rendered an nginx auth location whose verify
+    query held *two* user parameters
+    (``/_osprey_auth/bob&user=alice`` -> ``...verify?user=bob&user=alice``) —
+    the exact ambiguity per-user internal locations exist to prevent. Since the
+    username is the authorization identity, an unusable one must stop the render
+    rather than produce a seam whose meaning depends on how the sidecar's query
+    parser breaks a tie.
+
+    Scoped to authentication being on, deliberately: with ``auth.method: none``
+    the username is a routing label, not an identity, and raising here would
+    break renders that work today. Lint still reports it in that case.
+
+    Args:
+        services: The resolved per-user service entries (each with a ``user``).
+        auth_method: The parsed ``auth.method`` (see :func:`_auth_tls_context`).
+
+    Raises:
+        ValueError: If authentication is on and any roster name is outside the
+            charset. The message names every offender.
+    """
+    if auth_method == "none":
+        return
+    # fullmatch, not match: `$` also matches *before* a trailing newline, so
+    # `match` would accept "alice\n" — a name that then renders into an nginx
+    # location key mid-directive.
+    offenders = [
+        service["user"]
+        for service in services
+        if not USERNAME_CHARSET_RE.fullmatch(service["user"])
+    ]
+    if offenders:
+        raise ValueError(
+            f"modules.web_terminals.users {', '.join(repr(name) for name in offenders)} "
+            f"must match {USERNAME_CHARSET_RE.pattern!r} because "
+            f"modules.web_terminals.auth.method is {auth_method!r}: an authenticated "
+            "deployment makes the username the authorization identity, and it is "
+            "rendered literally into an nginx location key and into the auth "
+            "subrequest's ?user= value, where a name containing '&' or '?' would "
+            "silently authorize a different user"
+        )
+
+
+def _check_roster_env_var_collisions(services: list[dict[str, Any]], auth_method: str) -> None:
+    """Fail-closed render gate: with authentication on, no two roster names may
+    share one per-user env-var suffix.
+
+    :func:`~osprey.deployment.web_terminals.personas.env_var_suffix` is total and
+    lossy — ``alice-b`` and ``alice_b`` both key ``..._ALICE_B`` — so a colliding
+    pair would share a single ``OSPREY_AUTH_PW_HASH_ALICE_B``: one user's
+    password would open the other's terminal, which is the precise isolation
+    this feature exists to establish.
+
+    Caught here rather than only downstream because the downstream signals are
+    both poor. Credential provisioning raises on the password-mode deploy path
+    only, and in ``oidc`` mode the collision surfaces (if at all) as a
+    whole-deployment 503 from the sidecar — an outage whose message says nothing
+    about which two roster names caused it. Render time knows both names.
+
+    Args:
+        services: The resolved per-user service entries (each with a ``user``).
+        auth_method: The parsed ``auth.method`` (see :func:`_auth_tls_context`).
+
+    Raises:
+        ValueError: If authentication is on and two or more names collide. The
+            message names each colliding group and the suffix they share.
+    """
+    if auth_method == "none":
+        return
+    collisions = env_var_suffix_collisions([service["user"] for service in services])
+    if collisions:
+        detail = "; ".join(
+            f"{', '.join(repr(name) for name in names)} all key {suffix!r}"
+            for suffix, names in collisions.items()
+        )
+        raise ValueError(
+            f"modules.web_terminals.users collide on their per-user env-var suffix "
+            f"({detail}) and modules.web_terminals.auth.method is {auth_method!r}: "
+            "colliding names would share one OSPREY_AUTH_PW_HASH_* entry, so one "
+            "user's password would open the other's terminal. Rename one of them"
+        )
 
 
 def _check_mcp_topology(web_terminals: dict[str, Any]) -> None:

--- a/src/osprey/deployment/web_terminals/render.py
+++ b/src/osprey/deployment/web_terminals/render.py
@@ -9,6 +9,7 @@ All port arithmetic is delegated to :func:`osprey.deployment.web_terminals.ports
 
 from __future__ import annotations
 
+import posixpath
 import re
 from importlib.resources import as_file, files
 from typing import Any
@@ -190,6 +191,7 @@ def render_web_terminals(config: Any) -> dict[str, str]:
             "set — the gated `listen 443 ssl` seam needs both paths to emit a "
             "coherent ssl_certificate/ssl_certificate_key pair"
         )
+    _check_tls_host_cert_dir(auth_tls_ctx)
     if (
         auth_tls_ctx["auth_method"] != "none"
         and not auth_tls_ctx["tls_enabled"]
@@ -575,7 +577,78 @@ def _auth_tls_context(web_terminals: dict[str, Any]) -> dict[str, Any]:
         "tls_enabled": bool(tls.get("enabled", False)),
         "tls_cert": tls.get("cert"),
         "tls_key": tls.get("key"),
+        # The HOST directory holding the certificate and key. Optional, and the
+        # only key in this stanza that names a path on the deploy host rather
+        # than one inside the nginx container: setting it makes the overlay
+        # bind-mount that directory read-only at the container-side directory
+        # `tls.cert` sits in, which is the step that otherwise has to be done by
+        # hand. Left unset, nothing is mounted and the operator supplies the
+        # mount themselves — the escape hatch for a facility whose certificates
+        # arrive by some route a directory bind cannot express.
+        "tls_host_cert_dir": _non_empty_str(tls.get("host_cert_dir"), "") or None,
+        # Where that directory lands inside the container: the parent of
+        # `tls.cert`. Derived rather than configured so the mount and the
+        # `ssl_certificate` directive cannot name different places.
+        "tls_mount_target": _tls_mount_target(tls),
     }
+
+
+def _check_tls_host_cert_dir(ctx: dict[str, Any]) -> None:
+    """Refuse a ``tls.host_cert_dir`` that cannot deliver both files.
+
+    One read-only bind mount covers the certificate *and* the key only when the
+    two sit in the same directory inside the container, because the mount lands
+    at the parent of ``tls.cert``. A key elsewhere would leave nginx reading a
+    path nothing supplies — the exact silent failure this key exists to remove —
+    so it is refused at render time rather than at nginx start.
+
+    A relative ``host_cert_dir`` is refused for the same reason: compose
+    resolves it against the project directory, so a deployment moved to another
+    machine would mount a different (or missing) directory without saying so.
+
+    Nothing is checked when the key is unset: that is the supported posture in
+    which the operator supplies the mount themselves.
+    """
+    host_dir = ctx["tls_host_cert_dir"]
+    if not host_dir:
+        return
+    if not ctx["tls_enabled"]:
+        raise ValueError(
+            "modules.web_terminals.tls.host_cert_dir is set but tls.enabled is false — "
+            "the certificate directory would be mounted into an nginx that serves no "
+            "HTTPS. Enable tls, or drop host_cert_dir"
+        )
+    if not posixpath.isabs(host_dir):
+        raise ValueError(
+            f"modules.web_terminals.tls.host_cert_dir {host_dir!r} must be an absolute "
+            "path on the deploy host: compose resolves a relative bind source against "
+            "the project directory, so the same config would mount a different "
+            "directory elsewhere"
+        )
+    cert_dir = ctx["tls_mount_target"]
+    key_dir = posixpath.dirname(_non_empty_str(ctx["tls_key"], "")) or None
+    if cert_dir != key_dir:
+        raise ValueError(
+            "modules.web_terminals.tls.cert and tls.key must sit in the same directory "
+            f"when host_cert_dir is set (cert is in {cert_dir!r}, key in {key_dir!r}): "
+            "host_cert_dir is mounted at the certificate's directory, so a key outside "
+            "it would not be present in the container"
+        )
+
+
+def _tls_mount_target(tls: dict[str, Any]) -> str | None:
+    """The in-container directory ``tls.host_cert_dir`` is mounted at.
+
+    The parent of ``tls.cert``, so a mounted directory always lands exactly
+    where nginx's ``ssl_certificate`` looks. Returns ``None`` when there is
+    nothing to mount or no certificate path to derive it from; the caller
+    validates that ``tls.key`` shares the directory, which is what makes a
+    single mount sufficient for both files.
+    """
+    cert = _non_empty_str(tls.get("cert"), "")
+    if not cert:
+        return None
+    return posixpath.dirname(cert) or None
 
 
 def _positive_int(value: Any, default: int) -> int:

--- a/src/osprey/interfaces/web_terminal/static/js/api.js
+++ b/src/osprey/interfaces/web_terminal/static/js/api.js
@@ -60,6 +60,75 @@ export function withPrefix(path) {
 }
 
 /**
+ * Set once a probe has seen a 401, i.e. the session behind this page is gone.
+ * A reload is already on its way, so every reconnect loop stops here.
+ */
+let sessionExpired = false;
+
+/** In-flight health probe, shared by all channels so closes don't fan out. */
+/** @type {Promise<boolean>|null} */
+let healthProbe = null;
+
+/**
+ * Ask the app's own health route whether this page still has a session,
+ * resolving true only on a definite 401.
+ *
+ * The browser WebSocket API hides handshake status codes from JavaScript, so
+ * a connection the perimeter refused with 401 reaches `onclose` looking
+ * exactly like a dropped network — without this probe an expired session
+ * leaves the terminal reconnecting forever. Three details are load-bearing:
+ *
+ * - The URL goes through {@link withPrefix}, so it is the per-user app's own
+ *   `/u/<user>/health`. That route sits behind its user's auth gate, which is
+ *   what makes the 401 visible; the auth sidecar's `/health` is unauthenticated
+ *   and would always answer 200, and a root-absolute `/health` is not proxied.
+ * - `Accept: application/json`. The perimeter content-negotiates its 401: an
+ *   Accept mentioning text/html gets a 302 to the login page, anything else
+ *   gets a bare 401. We want the status, not the page.
+ * - The app decides nothing about authorization and holds no secret. It reads
+ *   one status code and reacts.
+ *
+ * Anything that is not a 401 — a network error, a 5xx, a healthy 200 — resolves
+ * false and leaves the caller's reconnect/backoff behavior untouched. Where no
+ * auth fronts the deployment (single-origin/dev), the probe simply always sees
+ * the app's own 200.
+ * @returns {Promise<boolean>}
+ */
+function probeSessionExpired() {
+  if (sessionExpired) return Promise.resolve(true);
+  if (!healthProbe) {
+    healthProbe = fetch(withPrefix('/health'), {
+      cache: 'no-store',
+      headers: { Accept: 'application/json' },
+    })
+      .then((res) => res.status === 401)
+      .catch(() => false)
+      .finally(() => {
+        healthProbe = null;
+      });
+  }
+  return healthProbe;
+}
+
+/**
+ * Probe after a channel closed and, on an expired session, reload so the HTML
+ * navigation path triggers the perimeter's login redirect. Fire-and-forget:
+ * callers schedule their ordinary reconnect first, so a probe that fails for
+ * any other reason costs nothing but one request.
+ * @param {() => void} [onExpired] tear down the caller's own handle first
+ *   (an EventSource would otherwise keep retrying until the reload lands)
+ */
+function reloadIfSessionExpired(onExpired) {
+  probeSessionExpired().then((expired) => {
+    if (!expired) return;
+    if (onExpired) onExpired();
+    if (sessionExpired) return; // another channel already triggered the reload
+    sessionExpired = true;
+    location.reload();
+  });
+}
+
+/**
  * Build a same-origin WebSocket URL with the scheme that matches the current
  * page: wss:// when served over HTTPS, ws:// otherwise. Pass a root-absolute
  * path such as '/ws/terminal'. Avoids mixed-content failures under TLS.
@@ -84,7 +153,7 @@ export function createWebSocket(url, { onOpen, onMessage, onClose, onError } = {
   let wsUrl = url;
 
   function connect() {
-    if (stopped) return;
+    if (stopped || sessionExpired) return;
     wsState = 'connecting';
     notifyStateChange();
 
@@ -107,6 +176,7 @@ export function createWebSocket(url, { onOpen, onMessage, onClose, onError } = {
       notifyStateChange();
       if (onClose) onClose(e);
       scheduleReconnect();
+      reloadIfSessionExpired();
     };
 
     ws.onerror = (e) => {
@@ -115,7 +185,7 @@ export function createWebSocket(url, { onOpen, onMessage, onClose, onError } = {
   }
 
   function scheduleReconnect() {
-    if (stopped) return;
+    if (stopped || sessionExpired) return;
     const delay = Math.min(1000 * Math.pow(2, attempt), 30000);
     attempt++;
     setTimeout(connect, delay);
@@ -153,7 +223,7 @@ export function createEventSource(url, { onMessage, onError } = {}) {
   let stopped = false;
 
   function connect() {
-    if (stopped) return;
+    if (stopped || sessionExpired) return;
     sseState = 'connecting';
     notifyStateChange();
 
@@ -180,6 +250,9 @@ export function createEventSource(url, { onMessage, onError } = {}) {
       notifyStateChange();
       if (onError) onError();
       // EventSource auto-reconnects, but update state
+      reloadIfSessionExpired(() => {
+        if (es) es.close();
+      });
     };
   }
 

--- a/src/osprey/interfaces/web_terminal/static/js/app.js
+++ b/src/osprey/interfaces/web_terminal/static/js/app.js
@@ -86,9 +86,10 @@ function initNewSessionButton() {
  * Real logout, in order: (1) POST the server logout route — prefix-aware via
  * `window.__OSPREY_PREFIX__` so it reaches this container under `/u/<user>/`
  * — which empties the PTY + operator registries (routes/websocket.py's
- * `logout_terminal`); (2) clear the client's own stored PTY session id
+ * `logout_terminal`); (2) end the auth session too, if the deployment has one
+ * (`endAuthSession`); (3) clear the client's own stored PTY session id
  * (`clearStoredSessionId`, terminal.js) so a fresh page load's
- * `initTerminal()` finds nothing to auto-resume; (3) only then navigate to
+ * `initTerminal()` finds nothing to auto-resume; (4) only then navigate to
  * the landing page. A failed logout request still clears the local pointer
  * and navigates — the client's own record of "my session" is what matters
  * for this browser, and getting stuck on the page helps no one.
@@ -122,9 +123,65 @@ export function initLogoutButton() {
     } catch (err) {
       console.error('Logout request failed:', err);
     }
+    await endAuthSession();
     clearStoredSessionId();
     window.location.assign(landingUrl);
   });
+}
+
+/**
+ * The roster username this container serves, from the server-rendered URL
+ * prefix (`window.__OSPREY_PREFIX__`, which `compute_url_prefix()` sets to
+ * exactly `/u/<user>` for a multi-user container and to `""` otherwise).
+ *
+ * Read from the prefix rather than from the identity chip's text because the
+ * prefix is the copy the app already routes every one of its own requests
+ * through — the chip is display markup, and taking a name from rendered text
+ * to put it back in a URL is how a display change becomes a wiring bug.
+ * Returns `""` for a plain `osprey web`, which has no per-user prefix.
+ */
+function terminalUserFromPrefix() {
+  const prefix = (window.__OSPREY_PREFIX__ || '').replace(/\/+$/, '');
+  return prefix.startsWith('/u/') ? prefix.slice('/u/'.length) : '';
+}
+
+/**
+ * End the auth sidecar's session for this container's user — best effort, and
+ * cosmetic. The app holds no signing secret and decides nothing: the sidecar
+ * revokes the session id and reissues the cookie without this user, and nginx
+ * enforces the result. Skipping this step (or failing it) costs the operator a
+ * session that outlives their terminal by up to `auth.session_lifetime`; it can
+ * never grant access.
+ *
+ * `/auth/logout` is deliberately NOT run through `withPrefix()`, unlike every
+ * other request this file makes: the sidecar's public surface is mounted at the
+ * origin root (nginx's `location /auth/`), so a prefixed URL would land on this
+ * container instead and 404. One `user` parameter, encoded — the route refuses
+ * a repeated one rather than picking a side.
+ *
+ * A `fetch` rather than a navigation, which is what makes this safe to run
+ * unconditionally. `location /auth/` exists only when `auth.method != "none"`,
+ * so navigating there would strand every existing no-auth multi-user
+ * deployment on a 404 instead of the landing page; the app cannot tell the two
+ * postures apart, because keeping `OSPREY_AUTH_*` out of these containers is
+ * the isolation the feature is built on. As a fetch, the sidecar's `Set-Cookie`
+ * still reaches the jar when auth is on, and a 404/502 is simply ignored when
+ * it is not — the caller navigates to the landing page either way.
+ */
+async function endAuthSession() {
+  const user = terminalUserFromPrefix();
+  if (!user) return;
+  try {
+    // The response is deliberately not inspected: a 404 is the *expected*
+    // answer in a deployment with authentication off, so treating a non-ok
+    // status as an error would log one on every logout that is working fine.
+    await fetch(`/auth/logout?user=${encodeURIComponent(user)}`, {
+      credentials: 'same-origin',
+      cache: 'no-store',
+    });
+  } catch (err) {
+    console.error('Auth logout request failed:', err);
+  }
 }
 
 /* ---- UI Mode Toggle (Expert / Simple) ---- */

--- a/src/osprey/services/auth_sidecar/__init__.py
+++ b/src/osprey/services/auth_sidecar/__init__.py
@@ -1,0 +1,6 @@
+"""Auth sidecar: a FastAPI service that authenticates multi-user web-terminal access.
+
+The sidecar answers nginx ``auth_request`` subrequests for each ``/u/<user>/``
+location and serves the login flow. Enforcement lives entirely at this
+perimeter; the per-user OSPREY containers hold no auth logic.
+"""

--- a/src/osprey/services/auth_sidecar/app.py
+++ b/src/osprey/services/auth_sidecar/app.py
@@ -1,0 +1,751 @@
+"""Auth sidecar FastAPI application factory.
+
+One process per multi-user deployment, sitting beside nginx: it answers the
+``auth_request`` subrequest for every ``/u/<user>/`` location and serves the
+login flow at ``/auth/*``. Served as ``uvicorn
+osprey.services.auth_sidecar.app:create_app --factory``.
+
+**Everything it needs arrives as environment.** The compose service reads the
+non-secret settings from the rendered ``modules.web_terminals.auth`` stanza and
+the secrets from ``.env.auth`` (0600, sidecar-only ``env_file``); nothing is
+read from ``config.yml`` here and no credential ever enters a rendered
+artifact. :class:`AuthSettings` is the single parser for that surface — routes
+read ``request.app.state.settings`` (or depend on :func:`get_settings`) rather
+than reaching into :data:`os.environ` themselves. The shared per-process
+objects are built here for the same reason — the session codec
+(:func:`get_session_codec`), the revocation store
+(:func:`get_revocation_store`) and the login-attempt throttle
+(:func:`get_attempt_throttle`). Each only means anything if every route touches
+the same instance: four differently-parameterised codecs (or four clocks) let
+expiries disagree, a second revocation store is a logout nothing checks, and a
+second throttle counts every attempt as the first. Anything else shared across
+routes belongs here too, on the same pattern — built once in the factory,
+reached through an accessor.
+
+Per-user values are keyed by
+:func:`~osprey.deployment.web_terminals.personas.env_var_suffix` — the one
+definition of the username→env-var mapping, shared with credential
+provisioning and lint so a password can never be keyed one way at mint time and
+another at verify time.
+
+**Fail closed, but still answer the healthcheck.** A misconfigured sidecar must
+lock people out rather than let them in, so :func:`create_app` never raises:
+the app starts, ``/health`` reports ``configured: false``, and every other path
+— routes that do not exist yet included, over HTTP and websockets alike — is
+refused by :class:`ConfigurationGuard` before it runs. That ordering is
+deliberate: a route author cannot forget to declare the check, because the
+check does not live in the routes.
+
+**Session middleware is pinned here, not defaulted.** Authlib's Starlette
+client keeps its OIDC ``state``/``nonce`` in a Starlette session, whose defaults
+(14-day lifetime, ``path=/``, no ``Secure``) are all wrong for a
+short-lived cross-site handshake artifact. The pins live next to the settings
+that feed them; see :data:`STATE_COOKIE_NAME` and friends. It is installed only
+when a real state secret was minted — never under a stand-in key, so a missing
+secret surfaces as a loud error at the first line that touches a session rather
+than as cookies signed by a key that dies with the process.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from importlib import import_module
+from typing import Any, Literal
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from starlette.middleware.sessions import SessionMiddleware
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from osprey.deployment.web_terminals.personas import env_var_suffix, env_var_suffix_collisions
+
+from .revocation import RevocationStore
+from .sessions import SessionCodec
+from .throttle import AttemptThrottle
+
+logger = logging.getLogger(__name__)
+
+SERVICE_NAME = "auth-sidecar"
+"""Reported by ``/health``; matches the compose service's name suffix."""
+
+HEALTH_PATH = "/health"
+"""The one path :class:`ConfigurationGuard` lets through unconfigured.
+
+nginx never proxies it — it exists for the container healthcheck and for
+``osprey deploy``'s post-up smoke check, both of which talk to the sidecar's own
+port directly.
+"""
+
+SUPPORTED_METHODS = ("password", "oidc")
+"""Methods this process can actually serve.
+
+``none`` is a supported *deployment* posture (see ``render.py``'s
+``SUPPORTED_AUTH_METHODS``) but not a supported sidecar mode: with auth off
+there is no sidecar in the compose file at all, so a sidecar that finds
+``OSPREY_AUTH_METHOD=none`` has been mis-wired and refuses everything.
+"""
+
+# --- OIDC state cookie (Starlette SessionMiddleware) -------------------------
+# Pinned, never configurable: this cookie carries only the in-flight OIDC
+# handshake state, and every attribute below is a security property of that
+# handshake rather than a facility preference.
+
+STATE_COOKIE_NAME = "osprey_auth_state"
+"""Distinct from the auth session cookie, so logout/rotation never disturb it."""
+
+STATE_COOKIE_PATH = "/auth"
+"""The only prefix the handshake runs under — the cookie is never sent to
+``/u/<user>/`` or to the verify subrequest."""
+
+STATE_COOKIE_MAX_AGE = 300
+"""Seconds. An abandoned handshake expires in minutes, not Starlette's 14 days."""
+
+STATE_COOKIE_SAME_SITE: Literal["lax", "strict", "none"] = "lax"
+"""``lax`` (not ``strict``): the IdP redirects back with a top-level GET, which
+``strict`` would strip the cookie from."""
+
+# --- Environment variable names ---------------------------------------------
+
+ENV_METHOD = "OSPREY_AUTH_METHOD"
+ENV_SESSION_SECRET = "OSPREY_AUTH_SESSION_SECRET"
+ENV_STATE_SECRET = "OSPREY_AUTH_STATE_SECRET"
+ENV_SESSION_LIFETIME = "OSPREY_AUTH_SESSION_LIFETIME"
+ENV_TLS_ENABLED = "OSPREY_AUTH_TLS_ENABLED"
+ENV_EXTERNAL_ORIGIN = "OSPREY_AUTH_EXTERNAL_ORIGIN"
+ENV_USERS = "OSPREY_AUTH_USERS"
+
+ENV_PW_HASH_PREFIX = "OSPREY_AUTH_PW_HASH_"
+"""Per-user stored hash: ``OSPREY_AUTH_PW_HASH_<SUFFIX>``."""
+
+ENV_OIDC_ISSUER = "OSPREY_AUTH_OIDC_ISSUER"
+ENV_OIDC_CLIENT_ID_ENV = "OSPREY_AUTH_OIDC_CLIENT_ID_ENV"
+ENV_OIDC_CLIENT_SECRET_ENV = "OSPREY_AUTH_OIDC_CLIENT_SECRET_ENV"
+ENV_OIDC_CLAIM = "OSPREY_AUTH_OIDC_CLAIM"
+ENV_OIDC_SUBJECT_PREFIX = "OSPREY_AUTH_OIDC_SUBJECT_"
+"""Per-user expected IdP identity: ``OSPREY_AUTH_OIDC_SUBJECT_<SUFFIX>``."""
+
+DEFAULT_OIDC_CLIENT_ID_ENV = "OSPREY_AUTH_OIDC_CLIENT_ID"
+DEFAULT_OIDC_CLIENT_SECRET_ENV = "OSPREY_AUTH_OIDC_CLIENT_SECRET"
+DEFAULT_OIDC_CLAIM = "sub"
+DEFAULT_SESSION_LIFETIME = 12 * 60 * 60
+
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+_FALSE_VALUES = frozenset({"0", "false", "no", "off"})
+
+# Route modules included when they exist, in this order. Each is expected to
+# expose a module-level ``router``. A name that has not landed yet is skipped —
+# and *only* that case is skipped: an ImportError raised from inside a module
+# that does exist propagates, so a broken route can never degrade into a
+# silently missing one.
+_ROUTE_MODULES = ("verify", "login", "logout", "oidc")
+_ROUTES_PACKAGE = f"{__package__}.routes"
+
+
+def _flag(raw: str | None, default: bool = False) -> bool:
+    """Read an env flag; anything unrecognised falls back to ``default``."""
+    if raw is None or not raw.strip():
+        return default
+    return raw.strip().lower() in _TRUE_VALUES
+
+
+def _is_unrecognized_flag(raw: str | None) -> bool:
+    """Whether ``raw`` is a non-empty value :func:`_flag` does not understand.
+
+    ``OSPREY_AUTH_TLS_ENABLED=maybe`` reads as false, which silently downgrades
+    the ``Secure`` attribute on both cookies — the deployment believes it is
+    serving TLS and the cookies say otherwise. The value is still treated as
+    false (guessing "they probably meant yes" would be worse), but the caller
+    warns loudly rather than letting the typo pass unremarked.
+    """
+    if raw is None or not raw.strip():
+        return False
+    return raw.strip().lower() not in (_TRUE_VALUES | _FALSE_VALUES)
+
+
+def _positive_int(raw: str | None, default: int) -> int:
+    """Read a positive int from the environment, falling back to ``default``."""
+    try:
+        value = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+def _roster(raw: str | None) -> tuple[str, ...]:
+    """Parse the comma-separated roster, dropping blanks and repeats.
+
+    Order is preserved: it is the roster's declaration order, which the login
+    page reuses.
+    """
+    seen: list[str] = []
+    for chunk in (raw or "").split(","):
+        name = chunk.strip()
+        if name and name not in seen:
+            seen.append(name)
+    return tuple(seen)
+
+
+@dataclass(frozen=True)
+class AuthSettings:
+    """The sidecar's whole configuration surface, parsed once at startup.
+
+    Built by :meth:`from_env` and cached on ``app.state.settings``. Frozen: the
+    values are read at process start and a change to any of them (a rotated
+    password above all) reaches the sidecar only through a container
+    force-recreate, because compose bakes ``env_file`` content at container
+    *creation*. Reading the environment lazily per request would suggest a
+    liveness this deployment does not have.
+
+    **Every secret-bearing field is excluded from the generated ``repr``.** A
+    dataclass repr is one ``logger.debug("settings=%s", settings)``, one
+    unhandled traceback frame, or one debugger session away from printing the
+    session signing key into a log aggregator. The values are still readable as
+    attributes by code that needs them; they simply never render by accident.
+    The variable *names* (``oidc_client_id_var``) and the OIDC subject map stay
+    visible — those are configuration, not credentials, and are exactly what an
+    operator needs to see when diagnosing a lockout.
+
+    Attributes:
+        method: ``password`` or ``oidc``. Any other value — including the
+            ``none`` posture, which means no sidecar should be running at all —
+            leaves the app unconfigured and refusing.
+        session_secret: Signing key for the auth session cookie. Empty when
+            unset, which is a refusal condition.
+        state_secret: Signing key for the OIDC state cookie, kept separate from
+            ``session_secret`` so the short-lived handshake artifact and the
+            long-lived session never share a key.
+        session_lifetime: How long an unlocked-user entry stays valid, seconds.
+        tls_enabled: Whether the public origin is HTTPS. Drives the ``Secure``
+            attribute on both cookies.
+        external_origin: Scheme://host[:port] the browser reaches nginx on,
+            derived once at render time and shared with the landing page. The
+            OIDC ``redirect_uri`` is built from it.
+        users: Roster usernames, in declaration order.
+        password_hashes: ``{username: stored hash}`` for the roster users that
+            have one. A roster user with no entry is absent, never empty-string
+            keyed — :meth:`password_hash` returns ``None`` and the caller denies.
+        oidc_issuer: Discovery issuer URL, or ``None``.
+        oidc_client_id: The OIDC client id itself, resolved through the
+            indirection described in :meth:`from_env`.
+        oidc_client_secret: Likewise the client secret.
+        oidc_client_id_var: The env-var name the client id was read from — the
+            resolved name, not the default, so a refusal message points at the
+            variable this deployment actually uses.
+        oidc_client_secret_var: Likewise for the client secret.
+        oidc_claim: Which ID-token claim carries the identity to map onto a
+            roster user.
+        oidc_subjects: ``{username: expected claim value}`` from the roster.
+    """
+
+    method: str = "none"
+    session_secret: str = field(default="", repr=False)
+    state_secret: str = field(default="", repr=False)
+    session_lifetime: int = DEFAULT_SESSION_LIFETIME
+    tls_enabled: bool = False
+    external_origin: str = ""
+    users: tuple[str, ...] = ()
+    password_hashes: Mapping[str, str] = field(default_factory=dict, repr=False)
+    oidc_issuer: str | None = None
+    oidc_client_id: str = ""
+    oidc_client_secret: str = field(default="", repr=False)
+    oidc_client_id_var: str = DEFAULT_OIDC_CLIENT_ID_ENV
+    oidc_client_secret_var: str = DEFAULT_OIDC_CLIENT_SECRET_ENV
+    oidc_claim: str = DEFAULT_OIDC_CLAIM
+    oidc_subjects: Mapping[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> AuthSettings:
+        """Parse settings out of ``env`` (default :data:`os.environ`).
+
+        Never raises: a malformed value falls back to its default and shows up
+        as a refusal in :meth:`missing_requirements`, because a sidecar that
+        dies on import is a sidecar whose healthcheck cannot explain why
+        everyone is locked out.
+
+        The OIDC client credentials are read through one level of indirection:
+        the config names the *variable* holding each credential
+        (``OSPREY_AUTH_OIDC_CLIENT_ID_ENV``, defaulting to
+        :data:`DEFAULT_OIDC_CLIENT_ID_ENV`), and the credential itself lives in
+        ``.env.auth`` under that name. A facility that already ships its IdP
+        client id under its own variable name therefore does not have to
+        duplicate it.
+
+        Args:
+            env: Environment mapping to read. Defaults to the process
+                environment.
+
+        Returns:
+            The parsed settings.
+        """
+        source: Mapping[str, str] = os.environ if env is None else env
+
+        users = _roster(source.get(ENV_USERS))
+        password_hashes: dict[str, str] = {}
+        oidc_subjects: dict[str, str] = {}
+        for user in users:
+            suffix = env_var_suffix(user)
+            stored = (source.get(f"{ENV_PW_HASH_PREFIX}{suffix}") or "").strip()
+            if stored:
+                password_hashes[user] = stored
+            subject = (source.get(f"{ENV_OIDC_SUBJECT_PREFIX}{suffix}") or "").strip()
+            if subject:
+                oidc_subjects[user] = subject
+
+        client_id_var = (
+            source.get(ENV_OIDC_CLIENT_ID_ENV) or ""
+        ).strip() or DEFAULT_OIDC_CLIENT_ID_ENV
+        client_secret_var = (
+            source.get(ENV_OIDC_CLIENT_SECRET_ENV) or ""
+        ).strip() or DEFAULT_OIDC_CLIENT_SECRET_ENV
+
+        return cls(
+            method=(source.get(ENV_METHOD) or "none").strip().lower() or "none",
+            session_secret=(source.get(ENV_SESSION_SECRET) or "").strip(),
+            state_secret=(source.get(ENV_STATE_SECRET) or "").strip(),
+            session_lifetime=_positive_int(
+                source.get(ENV_SESSION_LIFETIME), DEFAULT_SESSION_LIFETIME
+            ),
+            tls_enabled=_flag(source.get(ENV_TLS_ENABLED)),
+            external_origin=(source.get(ENV_EXTERNAL_ORIGIN) or "").strip().rstrip("/"),
+            users=users,
+            password_hashes=password_hashes,
+            oidc_issuer=(source.get(ENV_OIDC_ISSUER) or "").strip() or None,
+            oidc_client_id=(source.get(client_id_var) or "").strip(),
+            oidc_client_secret=(source.get(client_secret_var) or "").strip(),
+            oidc_client_id_var=client_id_var,
+            oidc_client_secret_var=client_secret_var,
+            oidc_claim=(source.get(ENV_OIDC_CLAIM) or "").strip() or DEFAULT_OIDC_CLAIM,
+            oidc_subjects=oidc_subjects,
+        )
+
+    def missing_requirements(self) -> tuple[str, ...]:
+        """Names of the settings that must be present before auth can be served.
+
+        Deliberately *not* a per-user check: a roster user with no password
+        hash, or with no mapped OIDC subject, is denied individually by the
+        verify/callback routes. Only deployment-wide gaps — the ones that would
+        make every answer meaningless — belong here, since anything named here
+        takes the whole sidecar down to 503.
+
+        The two OIDC client credentials are reported under their *resolved*
+        variable names (:attr:`oidc_client_id_var`), not the defaults: a
+        deployment that pointed the config at ``FACILITY_IDP_CLIENT`` must be
+        told to set ``FACILITY_IDP_CLIENT``, or the message sends an operator to
+        set a variable nothing reads.
+
+        The two session-codec preconditions — a non-blank signing secret and a
+        positive lifetime — are checked here rather than trusted from
+        :meth:`from_env`'s normalization. ``configured`` is what
+        :func:`create_app` consults before building the
+        :class:`~osprey.services.auth_sidecar.sessions.SessionCodec`, and that
+        codec raises on either. Checking the values themselves makes
+        "servable implies constructible" true of any :class:`AuthSettings`,
+        however it was built, instead of true only of ones that came through
+        the parser — otherwise a directly-constructed
+        ``AuthSettings(method="password", session_secret="   ")`` reports
+        servable and then kills the factory, taking the healthcheck that would
+        have explained it down too.
+
+        Returns:
+            Env-var names (never values), sorted for a stable log line. Empty
+            when the sidecar can serve.
+        """
+        missing: set[str] = set()
+        if self.method not in SUPPORTED_METHODS:
+            missing.add(ENV_METHOD)
+        if not self.session_secret.strip():
+            missing.add(ENV_SESSION_SECRET)
+        if self.session_lifetime <= 0:
+            missing.add(ENV_SESSION_LIFETIME)
+        if self.method == "oidc":
+            if not self.state_secret.strip():
+                missing.add(ENV_STATE_SECRET)
+            if not self.oidc_issuer:
+                missing.add(ENV_OIDC_ISSUER)
+            if not self.external_origin:
+                missing.add(ENV_EXTERNAL_ORIGIN)
+            if not self.oidc_client_id:
+                missing.add(self.oidc_client_id_var)
+            if not self.oidc_client_secret:
+                missing.add(self.oidc_client_secret_var)
+        return tuple(sorted(missing))
+
+    def roster_collisions(self) -> dict[str, list[str]]:
+        """Roster usernames that key the same per-user env vars.
+
+        ``alice-b`` and ``alice_b`` both map to the suffix ``ALICE_B``, so they
+        would share one ``OSPREY_AUTH_PW_HASH_ALICE_B`` entry — one operator's
+        password opening another's terminal, which is precisely the isolation
+        this service exists to establish. There is no safe way to serve such a
+        roster, so a collision refuses the whole sidecar rather than guessing
+        which user the credential belongs to.
+
+        Returns:
+            ``{suffix: [colliding usernames]}``, empty when the roster is
+            unambiguous. Detection is
+            :func:`~osprey.deployment.web_terminals.personas.env_var_suffix_collisions`,
+            shared with lint and credential provisioning.
+        """
+        return env_var_suffix_collisions(self.users)
+
+    @property
+    def configured(self) -> bool:
+        """Whether the sidecar can serve anything beyond ``/health``."""
+        return not self.missing_requirements() and not self.roster_collisions()
+
+    def password_hash(self, user: str) -> str | None:
+        """The stored hash for ``user``, or ``None`` if the roster has none."""
+        return self.password_hashes.get(user)
+
+    def oidc_subject(self, user: str) -> str | None:
+        """The IdP identity mapped to ``user``, or ``None`` if unmapped."""
+        return self.oidc_subjects.get(user)
+
+    def knows_user(self, user: str) -> bool:
+        """Whether ``user`` is on this deployment's roster."""
+        return user in self.users
+
+
+def get_settings(request: Request) -> AuthSettings:
+    """The running app's settings — usable directly or as a FastAPI dependency."""
+    settings: AuthSettings = request.app.state.settings
+    return settings
+
+
+def _require_wired(request: Request, attribute: str, description: str) -> Any:
+    """Fetch a shared object built by :func:`create_app`, or fail loudly.
+
+    The single implementation behind every shared-object accessor below, so the
+    three cannot drift into three different behaviors for the same condition.
+
+    Raises:
+        RuntimeError: If the object was never built, which happens only when the
+            settings are unservable. Route code never sees this — the
+            configuration guard has already refused the request with 503 — so it
+            is an assertion about wiring, not a case for callers to handle.
+    """
+    value = getattr(request.app.state, attribute, None)
+    if value is None:
+        raise RuntimeError(
+            f"auth sidecar has no {description}; the configuration guard should have "
+            "refused this request"
+        )
+    return value
+
+
+def get_session_codec(request: Request) -> SessionCodec:
+    """The app's one session codec — usable directly or as a FastAPI dependency.
+
+    Every route that touches a session cookie goes through this rather than
+    constructing its own: one signing secret, one maximum age, and above all one
+    clock, so an expiry stamped by the login route is checked against the same
+    time source by verify.
+
+    Raises:
+        RuntimeError: See :func:`_require_wired`.
+    """
+    codec: SessionCodec = _require_wired(request, "session_codec", "session codec")
+    return codec
+
+
+def get_revocation_store(request: Request) -> RevocationStore:
+    """The app's one revocation store — usable directly or as a dependency.
+
+    Logout writes to it and verify reads it, so they must be the same object:
+    two stores would mean a logout that revokes a session nothing checks. The
+    store keeps its own ``time.time`` clock, matching the absolute epoch
+    expiries carried in session cookies — deliberately not the codec's clock,
+    which tests may have moved.
+
+    Raises:
+        RuntimeError: See :func:`_require_wired`.
+    """
+    store: RevocationStore = _require_wired(request, "revocation_store", "revocation store")
+    return store
+
+
+def get_attempt_throttle(request: Request) -> AttemptThrottle:
+    """The app's one login-attempt throttle — usable directly or as a dependency.
+
+    A throttle is only a throttle if every attempt lands in the same one; a
+    per-route or per-request instance would count each attempt as the first and
+    never close a window. It runs on ``time.monotonic`` by design (see
+    :mod:`~osprey.services.auth_sidecar.throttle`), so a wall-clock step cannot
+    open a window early — another reason it does not share the codec's clock.
+
+    Raises:
+        RuntimeError: See :func:`_require_wired`.
+    """
+    throttle: AttemptThrottle = _require_wired(request, "attempt_throttle", "attempt throttle")
+    return throttle
+
+
+WEBSOCKET_REFUSAL_CODE = 1011
+"""Close code for a websocket refused by the guard (RFC 6455 "internal error").
+
+The honest code for "this gate cannot decide right now" — the same thing the
+503 says on the HTTP side. 1008 (policy violation) would claim the request was
+evaluated and rejected, which is not what happened.
+
+What a real client sees is not this number: a close sent before the handshake
+is accepted is turned by uvicorn into an HTTP 403 rejection of the upgrade, so
+the socket never opens at all. The code is what the ASGI test client observes,
+and the reason it is pinned in tests — treat it as the refusal's identity
+in-process, not as a promise about the wire.
+"""
+
+
+class ConfigurationGuard:
+    """Pure-ASGI middleware refusing every path but ``/health`` when unconfigured.
+
+    Placed outside the routes on purpose. The alternative — a dependency each
+    route declares — fails open the first time someone adds a route and forgets
+    it, and "someone forgets" is not an acceptable failure mode for the only
+    thing standing between a browser and another operator's terminal.
+
+    **Pure ASGI, not** :class:`~starlette.middleware.base.BaseHTTPMiddleware`.
+    That base class only dispatches ``http`` scopes and passes everything else
+    straight through, so a websocket route on an unconfigured sidecar would
+    complete its handshake and start exchanging frames past a gate that believes
+    it is refusing all traffic. The sidecar serves no websocket route today,
+    which is exactly why this must be structural: the failure would arrive with
+    whoever adds the first one, long after this reasoning is out of view.
+
+    Refusals are shaped per protocol:
+
+    * ``http`` → 503 with a JSON body. nginx turns any non-2xx subrequest answer
+      into a denial, and 503 says "this gate is not operational" rather than
+      implying credentials were evaluated and rejected.
+    * ``websocket`` → closed with :data:`WEBSOCKET_REFUSAL_CODE`, without ever
+      accepting the handshake.
+    * anything else (``lifespan``) → passed through untouched. Startup and
+      shutdown must run whatever the configuration, or an unconfigured app
+      could not even boot to serve its healthcheck.
+    """
+
+    def __init__(self, app: ASGIApp, settings: AuthSettings) -> None:
+        """Wrap ``app``, refusing traffic while ``settings`` are unservable.
+
+        Args:
+            app: The next ASGI application in the stack.
+            settings: The app's settings. Servability is evaluated once, here:
+                the settings are frozen and read at process start, and this
+                check sits in front of every request, so re-deriving it per
+                request would re-scan the roster for collisions on the hot path
+                to reach an answer that cannot have changed.
+        """
+        self.app = app
+        self.settings = settings
+        self._servable = settings.configured
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Refuse, or hand the scope on."""
+        if (
+            self._servable
+            or scope["type"] not in ("http", "websocket")
+            or scope.get("path") == HEALTH_PATH
+        ):
+            await self.app(scope, receive, send)
+            return
+
+        if scope["type"] == "websocket":
+            await send({"type": "websocket.close", "code": WEBSOCKET_REFUSAL_CODE})
+            return
+
+        response = JSONResponse(
+            status_code=503,
+            content={
+                "detail": (
+                    "auth sidecar is not configured; refusing all authentication "
+                    "(see the service log for the missing settings)"
+                )
+            },
+        )
+        await response(scope, receive, send)
+
+
+def _include_available_routers(app: FastAPI) -> None:
+    """Include each route module in :data:`_ROUTE_MODULES` that exists.
+
+    The extension point for the verify/login/logout/oidc tasks: land
+    ``routes/<name>.py`` exposing a ``router``, and this factory picks it up
+    with no edit here. A module that has not landed is skipped; an ImportError
+    from *within* a module that has landed propagates, so a route broken by a
+    bad import fails loudly at startup instead of quietly not existing.
+    """
+    for name in _ROUTE_MODULES:
+        module_path = f"{_ROUTES_PACKAGE}.{name}"
+        try:
+            module = import_module(module_path)
+        except ModuleNotFoundError as exc:
+            if exc.name not in (module_path, _ROUTES_PACKAGE):
+                raise
+            continue
+        app.include_router(module.router)
+
+
+def create_app(env: Mapping[str, str] | None = None) -> FastAPI:
+    """Create the auth sidecar's FastAPI application.
+
+    Args:
+        env: Environment mapping to configure from. Defaults to the process
+            environment; tests pass an explicit mapping.
+
+    Returns:
+        A configured app, constructible whatever the environment holds. When a
+        required setting is missing it still starts and still answers
+        ``/health`` — every other path is refused with 503.
+    """
+    settings = AuthSettings.from_env(env)
+
+    app = FastAPI(
+        title="OSPREY Auth Sidecar",
+        description="Authenticates multi-user web-terminal access at the nginx perimeter",
+        version="1.0.0",
+        # Deliberately unlike the sibling interface factories: a security
+        # perimeter publishes no schema of its own routes. `app.openapi()` still
+        # builds one in-process for tests; only the served endpoints are gone.
+        docs_url=None,
+        redoc_url=None,
+        openapi_url=None,
+    )
+    app.state.settings = settings
+    # Evaluated once: the settings are frozen, so the answer cannot change, and
+    # the healthcheck is polled continuously — no reason to re-scan the roster
+    # for collisions on every poll.
+    servable = settings.configured
+    # Built once, here, and shared by every route through `get_session_codec`.
+    # Only when the settings are servable: `SessionCodec` refuses an empty
+    # secret (correctly — an unsigned cookie is a forgeable one), and the app
+    # has to start regardless so the healthcheck can report why it will not
+    # serve. `configured` implies a non-empty session secret, so this
+    # construction cannot raise.
+    app.state.session_codec = (
+        SessionCodec(settings.session_secret, max_age=settings.session_lifetime)
+        if servable
+        else None
+    )
+    # The other two shared stores, same pattern and same reason. Each is
+    # per-process state that only means anything if every route touches the one
+    # instance: a second revocation store is a logout nothing checks, a second
+    # throttle counts every attempt as the first. Both keep their own clocks
+    # (`time.time` for the store, to match the absolute expiries in session
+    # cookies; `time.monotonic` for the throttle, so a clock step cannot open a
+    # window early) — deliberately not the codec's.
+    app.state.revocation_store = RevocationStore() if servable else None
+    app.state.attempt_throttle = AttemptThrottle() if servable else None
+
+    @app.get(HEALTH_PATH)
+    async def health() -> dict[str, Any]:
+        """Liveness probe. Answers 200 even unconfigured, and names no secret."""
+        return {
+            "status": "ok",
+            "service": SERVICE_NAME,
+            "method": settings.method,
+            "configured": servable,
+        }
+
+    _include_available_routers(app)
+
+    # Installed only against a real minted secret. There is no ephemeral
+    # fallback key: one would let a session-touching route quietly issue state
+    # cookies signed by a secret that dies with the process and that no other
+    # replica or restart can verify — the failure would surface as unexplainable
+    # intermittent OIDC handshake errors. Without the secret the middleware is
+    # simply absent, so touching `request.session` raises at the call site and
+    # names the real problem.
+    if settings.state_secret:
+        app.add_middleware(
+            SessionMiddleware,
+            secret_key=settings.state_secret,
+            session_cookie=STATE_COOKIE_NAME,
+            path=STATE_COOKIE_PATH,
+            max_age=STATE_COOKIE_MAX_AGE,
+            same_site=STATE_COOKIE_SAME_SITE,
+            https_only=settings.tls_enabled,
+        )
+    # Added last, so it is the outermost layer: a refused request reaches
+    # neither the session middleware nor any route.
+    app.add_middleware(ConfigurationGuard, settings=settings)
+
+    _log_configuration(settings, env)
+
+    return app
+
+
+def _log_configuration(settings: AuthSettings, env: Mapping[str, str] | None) -> None:
+    """Emit the startup breadcrumbs an operator needs to diagnose a lockout.
+
+    Every message names variables, never values. Called once from
+    :func:`create_app`, after the app is assembled.
+    """
+    missing = settings.missing_requirements()
+    collisions = settings.roster_collisions()
+
+    if missing:
+        logger.error(
+            "auth sidecar is not configured and will refuse every request except %s: "
+            "unset or invalid %s",
+            HEALTH_PATH,
+            ", ".join(missing),
+        )
+    if collisions:
+        # Named in full: the operator has to rename one of the users, and the
+        # suffix alone would not tell them which two names collided.
+        logger.error(
+            "auth sidecar refuses to serve an ambiguous roster: %s. Two usernames that "
+            "map to one env-var suffix would share a single credential; rename one.",
+            "; ".join(
+                f"{', '.join(names)} all key {ENV_PW_HASH_PREFIX}{suffix}"
+                for suffix, names in sorted(collisions.items())
+            ),
+        )
+    if settings.configured and not settings.users:
+        logger.warning(
+            "auth sidecar started with an empty roster (%s is unset or blank): no user "
+            "can be authenticated, so every terminal stays locked",
+            ENV_USERS,
+        )
+
+    source: Mapping[str, str] = os.environ if env is None else env
+    if _is_unrecognized_flag(source.get(ENV_TLS_ENABLED)):
+        logger.warning(
+            "%s is set to a value that is neither true nor false; reading it as false, "
+            "so cookies will be issued without the Secure attribute",
+            ENV_TLS_ENABLED,
+        )
+
+    origin_is_https = settings.external_origin.startswith("https://")
+    if settings.external_origin and origin_is_https != settings.tls_enabled:
+        # Both directions are real failures, and they fail differently enough
+        # that one shared message would misdiagnose whichever one it did not
+        # describe.
+        if origin_is_https:
+            # The browser reaches this deployment over HTTPS, but every cookie
+            # the sidecar issues will lack Secure, so any incidental plain-HTTP
+            # request to the same host leaks them.
+            logger.warning(
+                "%s is an https origin but %s is false: cookies will be issued without "
+                "the Secure attribute on a TLS deployment — one of the two settings is wrong",
+                ENV_EXTERNAL_ORIGIN,
+                ENV_TLS_ENABLED,
+            )
+        else:
+            # Worse than a leak: a browser silently discards a Secure cookie
+            # sent over http, so every login appears to succeed and nothing is
+            # ever unlocked. Nothing in the response says why.
+            logger.warning(
+                "%s is a cleartext origin but %s is true: browsers discard Secure cookies "
+                "on http, so logins will appear to succeed and unlock nothing — one of the "
+                "two settings is wrong",
+                ENV_EXTERNAL_ORIGIN,
+                ENV_TLS_ENABLED,
+            )
+    elif not settings.tls_enabled:
+        logger.warning(
+            "auth sidecar is serving on a cleartext origin: session cookies will be "
+            "issued without the Secure attribute"
+        )

--- a/src/osprey/services/auth_sidecar/exceptions.py
+++ b/src/osprey/services/auth_sidecar/exceptions.py
@@ -1,0 +1,15 @@
+"""Domain errors shared across the auth sidecar's modules."""
+
+from __future__ import annotations
+
+__all__ = ["InvalidSessionError"]
+
+
+class InvalidSessionError(Exception):
+    """A session cookie could not be trusted and must be treated as absent.
+
+    Raised for tampering, a malformed or unknown-version payload, and cookies
+    older than the permitted age. Callers do not need to distinguish the causes:
+    every one of them means "no session", and the message says which it was for
+    logs.
+    """

--- a/src/osprey/services/auth_sidecar/passwords.py
+++ b/src/osprey/services/auth_sidecar/passwords.py
@@ -3,12 +3,29 @@
 Passwords are hashed with :func:`hashlib.scrypt` and stored as self-describing
 strings::
 
-    scrypt$<n>$<r>$<p>$<salt>$<hash>
+    scrypt.<n>.<r>.<p>.<salt>.<hash>
 
 Salt and hash are unpadded URL-safe base64. Carrying the cost parameters in the
 stored string means they can be raised later without invalidating credentials
 minted under the old cost: :func:`verify_password` always reads the parameters
 back out of the stored string rather than assuming the current pins.
+
+WHY ``.`` AND NOT THE CONVENTIONAL ``$``
+----------------------------------------
+The PHC-style ``$`` separator cannot survive the trip to the container. A stored
+hash travels to the sidecar as a value in ``.env.auth``, which the rendered
+compose overlay hands over as an ``env_file`` — and Docker Compose performs
+``${VAR}`` interpolation on those values. Every ``$`` followed by a valid
+identifier character is read as a variable reference and replaced with the empty
+string, so ``scrypt$16384$8$1$<salt>$<key>`` arrives as ``scrypt$16384$8$1``:
+the numeric fields survive (a digit cannot begin a variable name) and the salt
+and key — random base64, usually starting with a letter — are silently eaten.
+The credential then verifies against nothing and every login is refused.
+
+``.`` is outside the base64url alphabet (``A-Za-z0-9-_``), so it cannot collide
+with a salt or key, and no shell or compose layer ascribes meaning to it. The
+separator is :data:`FIELD_SEP` rather than a literal so the writer and
+:func:`_parse_stored` cannot drift apart.
 
 The module also mints *credential-generation tags* — truncated one-way digests
 of a stored-hash string. Session cookies are signed but not encrypted, so the
@@ -26,6 +43,15 @@ import secrets
 
 SCHEME = "scrypt"
 """Identifier written as the first field of every stored hash."""
+
+FIELD_SEP = "."
+"""Separator between stored-hash fields.
+
+Deliberately NOT ``$``: these strings travel to the sidecar through a compose
+``env_file``, where ``$`` starts a variable reference and would take the salt
+and key with it (see the module docstring). Must stay outside the base64url
+alphabet so it cannot occur inside a salt or key.
+"""
 
 SCRYPT_N = 2**14
 """CPU/memory cost factor for newly minted hashes."""
@@ -87,7 +113,7 @@ def hash_password(
         p: Parallelisation factor. Defaults to the module pin.
 
     Returns:
-        A string of the form ``scrypt$n$r$p$salt$hash``.
+        A string of the form ``scrypt.n.r.p.salt.hash``.
 
     Raises:
         ValueError: If ``password`` is empty.
@@ -105,7 +131,7 @@ def hash_password(
         maxmem=SCRYPT_MAXMEM,
         dklen=KEY_BYTES,
     )
-    return f"{SCHEME}${n}${r}${p}${_b64encode(salt)}${_b64encode(derived)}"
+    return FIELD_SEP.join((SCHEME, str(n), str(r), str(p), _b64encode(salt), _b64encode(derived)))
 
 
 def _parse_stored(stored: str) -> tuple[int, int, int, bytes, bytes]:
@@ -120,7 +146,7 @@ def _parse_stored(stored: str) -> tuple[int, int, int, bytes, bytes]:
     Raises:
         ValueError: If ``stored`` is not a well-formed scrypt hash string.
     """
-    fields = stored.split("$")
+    fields = stored.split(FIELD_SEP)
     if len(fields) != _FIELD_COUNT:
         raise ValueError(f"stored hash must have {_FIELD_COUNT} fields")
 

--- a/src/osprey/services/auth_sidecar/passwords.py
+++ b/src/osprey/services/auth_sidecar/passwords.py
@@ -1,0 +1,213 @@
+"""Password hashing and credential-generation tags for the auth sidecar.
+
+Passwords are hashed with :func:`hashlib.scrypt` and stored as self-describing
+strings::
+
+    scrypt$<n>$<r>$<p>$<salt>$<hash>
+
+Salt and hash are unpadded URL-safe base64. Carrying the cost parameters in the
+stored string means they can be raised later without invalidating credentials
+minted under the old cost: :func:`verify_password` always reads the parameters
+back out of the stored string rather than assuming the current pins.
+
+The module also mints *credential-generation tags* — truncated one-way digests
+of a stored-hash string. Session cookies are signed but not encrypted, so the
+stored hash must never enter one; a tag lets the sidecar detect that a user's
+password has been rotated (the tag no longer matches the digest of the current
+stored hash) without keeping server-side session state.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import secrets
+
+SCHEME = "scrypt"
+"""Identifier written as the first field of every stored hash."""
+
+SCRYPT_N = 2**14
+"""CPU/memory cost factor for newly minted hashes."""
+
+SCRYPT_R = 8
+"""Block size for newly minted hashes."""
+
+SCRYPT_P = 1
+"""Parallelisation factor for newly minted hashes."""
+
+SCRYPT_MAXMEM = 64 * 1024 * 1024
+"""Memory ceiling handed to OpenSSL, in bytes.
+
+``hashlib.scrypt``'s default of ``maxmem=0`` leaves OpenSSL's own 32 MB cap in
+place, which ``n=2**14, r=8`` already exceeds; without an explicit ceiling the
+pinned cost factors raise instead of hashing.
+"""
+
+SALT_BYTES = 16
+"""Length of the random salt drawn per hash."""
+
+KEY_BYTES = 32
+"""Length of the derived key."""
+
+GENERATION_TAG_CHARS = 16
+"""Number of hex characters kept from the generation-tag digest."""
+
+_FIELD_COUNT = 6
+
+
+def _b64encode(raw: bytes) -> str:
+    """Encode bytes as unpadded URL-safe base64."""
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64decode(text: str) -> bytes:
+    """Decode unpadded URL-safe base64.
+
+    Raises:
+        ValueError: If ``text`` is not valid base64.
+    """
+    padding = "=" * (-len(text) % 4)
+    return base64.urlsafe_b64decode(text + padding)
+
+
+def hash_password(
+    password: str,
+    *,
+    n: int = SCRYPT_N,
+    r: int = SCRYPT_R,
+    p: int = SCRYPT_P,
+) -> str:
+    """Hash a password into a self-describing stored-hash string.
+
+    Args:
+        password: The plaintext password. Must be non-empty.
+        n: CPU/memory cost factor. Defaults to the module pin.
+        r: Block size. Defaults to the module pin.
+        p: Parallelisation factor. Defaults to the module pin.
+
+    Returns:
+        A string of the form ``scrypt$n$r$p$salt$hash``.
+
+    Raises:
+        ValueError: If ``password`` is empty.
+    """
+    if not password:
+        raise ValueError("password must not be empty")
+
+    salt = secrets.token_bytes(SALT_BYTES)
+    derived = hashlib.scrypt(
+        password.encode("utf-8"),
+        salt=salt,
+        n=n,
+        r=r,
+        p=p,
+        maxmem=SCRYPT_MAXMEM,
+        dklen=KEY_BYTES,
+    )
+    return f"{SCHEME}${n}${r}${p}${_b64encode(salt)}${_b64encode(derived)}"
+
+
+def _parse_stored(stored: str) -> tuple[int, int, int, bytes, bytes]:
+    """Split a stored-hash string into its cost parameters, salt and key.
+
+    Args:
+        stored: A string previously produced by :func:`hash_password`.
+
+    Returns:
+        A tuple of ``(n, r, p, salt, key)``.
+
+    Raises:
+        ValueError: If ``stored`` is not a well-formed scrypt hash string.
+    """
+    fields = stored.split("$")
+    if len(fields) != _FIELD_COUNT:
+        raise ValueError(f"stored hash must have {_FIELD_COUNT} fields")
+
+    scheme, n_text, r_text, p_text, salt_text, key_text = fields
+    if scheme != SCHEME:
+        raise ValueError(f"unsupported hash scheme: {scheme!r}")
+
+    try:
+        n, r, p = int(n_text), int(r_text), int(p_text)
+    except ValueError as exc:
+        raise ValueError("scrypt parameters must be integers") from exc
+    if n < 2 or r < 1 or p < 1:
+        raise ValueError("scrypt parameters out of range")
+
+    salt, key = _b64decode(salt_text), _b64decode(key_text)
+    if not salt or not key:
+        raise ValueError("stored hash carries an empty salt or key")
+    return n, r, p, salt, key
+
+
+def verify_password(password: str, stored: str) -> bool:
+    """Check a plaintext password against a stored-hash string.
+
+    The cost parameters come from ``stored``, so hashes minted under an older
+    cost keep verifying. Comparison is constant-time. A malformed or unusable
+    ``stored`` value verifies as ``False`` rather than raising — the sidecar
+    treats an unreadable credential as a failed login, not a crash.
+
+    Args:
+        password: The plaintext password to check.
+        stored: A string previously produced by :func:`hash_password`.
+
+    Returns:
+        ``True`` if the password matches, ``False`` otherwise.
+    """
+    if not password:
+        return False
+    try:
+        n, r, p, salt, key = _parse_stored(stored)
+        candidate = hashlib.scrypt(
+            password.encode("utf-8"),
+            salt=salt,
+            n=n,
+            r=r,
+            p=p,
+            maxmem=SCRYPT_MAXMEM,
+            dklen=len(key),
+        )
+    except (ValueError, MemoryError):
+        return False
+    return hmac.compare_digest(candidate, key)
+
+
+def generation_tag(stored: str) -> str:
+    """Derive the credential-generation tag for a stored-hash string.
+
+    The tag is a truncated SHA-256 digest: one-way, so a cookie carrying it
+    discloses nothing about the hash, and specific to one credential, so a
+    rotated password yields a different tag.
+
+    Args:
+        stored: A stored-hash string as produced by :func:`hash_password`.
+
+    Returns:
+        A lowercase hex string of :data:`GENERATION_TAG_CHARS` characters.
+
+    Raises:
+        ValueError: If ``stored`` is empty.
+    """
+    if not stored:
+        raise ValueError("stored hash must not be empty")
+    digest = hashlib.sha256(stored.encode("utf-8")).hexdigest()
+    return digest[:GENERATION_TAG_CHARS]
+
+
+def verify_generation_tag(tag: str, stored: str) -> bool:
+    """Check a session's generation tag against the current stored hash.
+
+    Args:
+        tag: The tag carried by the session, or an empty value.
+        stored: The user's current stored-hash string.
+
+    Returns:
+        ``True`` if ``tag`` was derived from ``stored``, ``False`` otherwise —
+        including when either argument is empty, so a password-mode session
+        without a tag never authorises.
+    """
+    if not tag or not stored:
+        return False
+    return hmac.compare_digest(tag, generation_tag(stored))

--- a/src/osprey/services/auth_sidecar/return_to.py
+++ b/src/osprey/services/auth_sidecar/return_to.py
@@ -1,0 +1,101 @@
+"""The one rule for where a login may send the browser afterwards.
+
+Both login flows accept a return-to from the client — the password route reads
+it off the link nginx emits and again out of a hidden form field, the OIDC route
+off the same link and then back out of a decoded state cookie — and both must
+hold it to the same rule. That is why the rule lives here rather than in either
+route: a return-to that one flow rejects and the other honours is an open
+redirect with a second front door.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+MAX_RETURN_TO_LENGTH = 2048
+"""Longest return-to a login will honour, in characters.
+
+nginx's allowlist bounds what a return-to may *contain*, not how much of it there
+may be: a path is limited only by the request line, which is kilobytes. A
+return-to that long is nobody's terminal — it is a ``Location`` header wide
+enough to exceed the proxy's own buffer, which reaches the operator as a 502
+instead of a login, and the OIDC hand-off percent-encodes it into something
+several times larger again. Generous for the real thing (``/u/<user>/panel/…``)
+and far below where any of that starts.
+"""
+
+_ENCODED_SEPARATOR_RE = re.compile(r"%(?:2f|5c)", re.IGNORECASE)
+"""Percent-encoded ``/`` and ``\\`` in a return-to.
+
+A path carrying them means different things to this service, to nginx's location
+matching, and to the browser that finally resolves it. Nothing legitimate needs
+an encoded separator in a terminal's path, so a return-to carrying one is
+discarded rather than decoded.
+"""
+
+
+def safe_return_to(raw: object, user: str, *, flow: str = "login") -> str:
+    """Validate a return-to target, falling back to ``user``'s terminal.
+
+    The value is client input on every leg it arrives on, and is validated on
+    each of them. Anything that could send the browser to another origin — an
+    absolute URL, a protocol-relative ``//host``, a backslash form browsers
+    normalise into one — is discarded rather than repaired, as is a path
+    carrying a percent-encoded separator, which this service, nginx and the
+    browser would each read differently. A rejected target is not an error to
+    the person logging in; they came here to reach their terminal, so that is
+    where they go.
+
+    An empty value is normal and frequent, not an error: nginx collapses
+    ``next`` to nothing for any path carrying a space, ``+``, ``@``, ``:``,
+    ``,``, ``%`` or a non-ASCII character, so a deep link to an artifact whose
+    filename has a space in it simply lands the operator on their terminal root.
+
+    Length is one of the rejection rules, not a separate concern: the allowlist
+    at the perimeter bounds what a return-to may contain, never how much of it
+    there is.
+
+    Args:
+        raw: The requested return-to. Typed as ``object`` because the OIDC
+            callback reads it back out of a decoded cookie payload, where its
+            shape is whatever was stored rather than whatever was declared.
+        user: The roster user being logged in, for the default target.
+        flow: Which login the request came in on, for the rejection log line.
+
+    Returns:
+        A same-origin absolute path, safe to put in a ``Location`` header and in
+        a hidden field.
+    """
+    default = f"/u/{user}/"
+    if not isinstance(raw, str) or not raw:
+        return default
+
+    candidate = raw.strip()
+    rejected = (
+        # Longer than any terminal path, and long enough to make a Location
+        # header the proxy in front of this service will not carry.
+        len(candidate) > MAX_RETURN_TO_LENGTH
+        # Relative and absolute-URL forms both let the browser leave this origin.
+        or not candidate.startswith("/")
+        # "//host" and "/\host" are read by browsers as another origin.
+        or candidate.startswith(("//", "/\\"))
+        # A backslash anywhere is normalised to "/" by browsers, so it can
+        # reconstruct one of the forms above after this check.
+        or "\\" in candidate
+        # Control characters (CR/LF above all) have no place in a path and are
+        # how a Location header gets split.
+        or any(character < " " or character == "\x7f" for character in candidate)
+        or bool(_ENCODED_SEPARATOR_RE.search(candidate))
+    )
+    if rejected:
+        logger.warning(
+            "%s for %r requested an off-origin return-to; sending them to their own "
+            "terminal instead",
+            flow,
+            user,
+        )
+        return default
+    return candidate

--- a/src/osprey/services/auth_sidecar/revocation.py
+++ b/src/osprey/services/auth_sidecar/revocation.py
@@ -1,0 +1,111 @@
+"""In-memory revocation list for logged-out session ids.
+
+A session cookie is signed, not stateful: once issued it stays cryptographically
+valid until its recorded expiry. Logout therefore needs somewhere to record "this
+session id is dead", and the verify endpoint consults that record on every
+``auth_request`` subrequest.
+
+**Process-local by design.** The sidecar runs single-process (uvicorn default), so
+one dict in that process is the whole store — there is no shared cache to keep
+coherent. Two consequences the deployment docs state plainly:
+
+* Anything that recreates the container clears the list. A force-recreate on
+  ``osprey deploy passwd``, a decommission re-render, or a podman image-drift
+  reconcile all drop it. A cookie captured before a logout would work again after
+  such a restart, bounded by ``auth.session_lifetime``.
+* Password rotation does **not** rely on this store. Invalidation there rests on
+  the credential-generation tag carried in each unlocked-user entry, which is
+  recomputed from the current stored hash on every verify and so survives
+  restarts. Revocation covers logout only.
+
+Memory is bounded by logouts-per-session-lifetime, not by container uptime: an
+entry is dropped once the clock passes the expiry that was recorded with it,
+since a session that has expired is rejected on its own expiry check and no
+longer needs a revocation record.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+
+__all__ = ["RevocationStore"]
+
+
+class RevocationStore:
+    """Tracks revoked session ids until the moment they would have expired.
+
+    Expiry timestamps are absolute epoch seconds, matching the per-user expiry
+    carried in the session cookie, so callers can pass the cookie's value
+    straight through.
+
+    Not thread-safe on its own; the sidecar's async request handlers touch it
+    from a single event loop, and every method completes without awaiting.
+    """
+
+    def __init__(self, clock: Callable[[], float] = time.time) -> None:
+        """Create an empty store.
+
+        Args:
+            clock: Returns the current time as absolute epoch seconds. Injectable
+                so tests can advance time without sleeping.
+        """
+        self._clock = clock
+        self._revoked: dict[str, float] = {}
+
+    def revoke(self, session_id: str, expires_at: float) -> None:
+        """Record a session id as revoked until ``expires_at``.
+
+        Re-revoking a known id keeps the later of the two expiries, so a
+        refreshed cookie cannot shorten an existing record.
+
+        Args:
+            session_id: The session id from the cookie being logged out.
+            expires_at: Absolute epoch seconds at which that session expires on
+                its own. Passing an already-past value is harmless: the session
+                is expired, :meth:`is_revoked` reports ``False`` for it, and the
+                entry is dropped on the next sweep.
+        """
+        self.purge_expired()
+        existing = self._revoked.get(session_id)
+        if existing is None or expires_at > existing:
+            self._revoked[session_id] = expires_at
+
+    def is_revoked(self, session_id: str) -> bool:
+        """Whether ``session_id`` was revoked and has not yet reached its expiry.
+
+        Reports ``False`` once the recorded expiry has passed, whether or not the
+        entry has been swept yet — the answer never depends on sweep timing. A
+        caller reaching that point has an expired session anyway and rejects it on
+        the expiry check.
+        """
+        expires_at = self._revoked.get(session_id)
+        if expires_at is None:
+            return False
+        if self._clock() >= expires_at:
+            del self._revoked[session_id]
+            return False
+        return True
+
+    def purge_expired(self) -> int:
+        """Drop every entry whose recorded expiry has passed.
+
+        Called on each :meth:`revoke`, which is what keeps the store bounded by
+        logouts-per-lifetime. Exposed so a caller can sweep on its own schedule.
+
+        Returns:
+            How many entries were dropped.
+        """
+        now = self._clock()
+        stale = [sid for sid, expires_at in self._revoked.items() if now >= expires_at]
+        for session_id in stale:
+            del self._revoked[session_id]
+        return len(stale)
+
+    def clear(self) -> None:
+        """Forget every revocation — equivalent to what a container restart does."""
+        self._revoked.clear()
+
+    def __len__(self) -> int:
+        """How many entries are held, including any not yet swept."""
+        return len(self._revoked)

--- a/src/osprey/services/auth_sidecar/routes/__init__.py
+++ b/src/osprey/services/auth_sidecar/routes/__init__.py
@@ -1,0 +1,7 @@
+"""Route modules for the auth sidecar.
+
+Each module here exposes a module-level ``router``; the application factory
+includes the ones that exist (see
+:func:`~osprey.services.auth_sidecar.app._include_available_routers`), so a new
+route lands by adding a file, not by editing the factory.
+"""

--- a/src/osprey/services/auth_sidecar/routes/login.py
+++ b/src/osprey/services/auth_sidecar/routes/login.py
@@ -1,0 +1,721 @@
+"""Password-mode login page and credential POST for the auth sidecar.
+
+One public path, :data:`LOGIN_PATH`, under the ``/auth/`` prefix nginx proxies
+here: ``GET`` renders the prompt and ``POST`` evaluates the credential. It is
+where every denied browser navigation lands — nginx's ``error_page 401`` sends
+``/auth/login?user=<name>&next=<path>`` — and it is the only place a
+password-mode session comes from.
+
+**The clicked card is the username.** The landing page offers one card per roster
+user, so this page is addressed per user and asks for a password and nothing
+else. There is no username field: a name typed here could only disagree with the
+one the link named, and the page would then either lie about who is being
+unlocked or refuse an operator who typed their own name correctly.
+
+**Every method's unauthenticated browser arrives here.** nginx's 401 handler
+knows nothing about how this deployment authenticates, so it emits the same
+``/auth/login`` redirect under OIDC. A password form is unanswerable there —
+there are no passwords to enter — so ``GET`` in OIDC mode redirects onward to
+:data:`~osprey.services.auth_sidecar.routes.oidc.LOGIN_PATH`, carrying the same
+user and the same return-to. That path is this module's alone (the OIDC routes
+live under ``/auth/oidc/``), so the dispatch has to happen here or nowhere.
+
+**The throttle runs before the credential, never after.** A refused attempt
+costs a dict lookup; an evaluated one costs an scrypt derivation. Consulting
+:meth:`~osprey.services.auth_sidecar.throttle.AttemptThrottle.retry_after` first
+is what makes parallel guessing throughput-bounded rather than merely delayed,
+and it is why a 429 never calls ``record_failure``: counting attempts the
+sidecar declined to evaluate would let a flood ratchet the window against the
+operator it is supposed to protect.
+
+**Every refusal is the same refusal.** A user with no provisioned credential, a
+user who is not on the roster at all, and a wrong password produce one status,
+one page, one message, and one identical call into the throttle. What the deny
+path deliberately does *not* do is spend an scrypt derivation on a username that
+has no stored hash: the roster is public (the landing page lists it), so
+equalising that work would buy no secrecy, while turning every POST naming an
+invented user into a key derivation an attacker can request without ever meeting
+a throttle window. The residual is a timing difference, and it is real —
+measured at roughly 32.3 ms for a credentialed roster user against 2.9 ms for an
+uncredentialed one and 2.3 ms for a name that is not on the roster. It
+distinguishes "this user has a password provisioned" from "this user does not",
+which the landing page already discloses, and it is accepted rather than
+overlooked.
+
+``GET`` does answer 404 for a user who is not on the roster — the same answer the
+OIDC login route gives, and the honest one, since no credential is evaluated
+there and nginx only ever generates links for users that exist. Roster
+membership is public by design; what must not vary is the answer to *"was that
+the right password"*, which is what the POST path holds identical.
+
+**Nothing a client sends is assumed to be small.** nginx will pass through a
+return-to as long as a request line allows, and a form field has no bound at
+all. Both are capped —
+:data:`~osprey.services.auth_sidecar.return_to.MAX_RETURN_TO_LENGTH` for the
+return-to, :data:`MAX_USERNAME_LENGTH` for the name — before either can reach a
+``Location`` header, where an over-long value becomes a 502 from the proxy
+rather than a login, or the rendered page, where an unauthenticated,
+pre-throttle request would otherwise choose the response's size.
+
+**A cross-site POST is not a login.** ``SameSite=Lax`` keeps the session cookie
+off cross-site *sub*requests, but it does not stop a browser from storing the
+``Set-Cookie`` a top-level cross-site form POST comes back with. Unchecked, a
+page anywhere could log an operator into an attacker's roster user — and since a
+login *adds* to the unlocked set rather than replacing it, the operator would
+keep their own terminals and have no reason to notice which one they are typing
+into. So before anything else happens on ``POST``, the submitting origin
+(``Origin``, or ``Referer`` where an older browser omits it on a same-origin
+form) is compared against this deployment's own, and anything else — including a
+request that declares no origin at all — is refused. The refusal is the *same*
+400 a malformed form already produces: a distinct status would tell an attacker
+exactly which control fired, and same-shaped refusals are this route's whole
+deny-path discipline.
+
+**One consequence worth stating for anyone driving this endpoint from a
+script**: a POST with neither header is refused, so a test or health probe must
+send an ``Origin`` naming the deployment. Real browsers do it unprompted, and a
+scripted client has no victim's cookie jar for a minted session to act on, so
+nothing legitimate is lost by requiring it.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Annotated, Any
+from urllib.parse import quote, urlsplit
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from fastapi.responses import RedirectResponse
+from fastapi.templating import Jinja2Templates
+from starlette.datastructures import FormData
+
+from ..app import (
+    AuthSettings,
+    get_attempt_throttle,
+    get_revocation_store,
+    get_session_codec,
+    get_settings,
+)
+from ..exceptions import InvalidSessionError
+from ..passwords import generation_tag, verify_password
+from ..return_to import safe_return_to
+from ..revocation import RevocationStore
+from ..sessions import SESSION_COOKIE_NAME, SessionCodec, SessionState
+from ..throttle import AttemptThrottle
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+LOGIN_PATH = "/auth/login"
+"""Public path nginx's ``error_page 401`` redirects browsers to, verbatim."""
+
+OIDC_LOGIN_PATH = "/auth/oidc/login"
+"""Where an OIDC deployment's ``GET`` is sent instead of a password form.
+
+Spelled out rather than imported from
+:mod:`~osprey.services.auth_sidecar.routes.oidc`: reading one string from that
+module would pull Authlib and its HTTP stack into this one's import, on a
+deployment that may have no OIDC in it at all. The two constants are checked
+against each other by the tests instead.
+"""
+
+TEMPLATE_NAME = "login.html"
+"""Rendered from the package's ``templates/`` directory."""
+
+FIELD_USER = "user"
+FIELD_NEXT = "next"
+FIELD_PASSWORD = "password"
+"""Form field names, matching the hidden inputs and the password input in
+``login.html``. The browser test and the composed-stack test drive these."""
+
+DENIAL_MESSAGE = "That password was not accepted. Please try again."
+"""The one refusal message. Names no user, no roster and no reason: an unknown
+user and a wrong password must read identically."""
+
+THROTTLE_MESSAGE = "Too many attempts. Wait a moment and try again."
+"""Shown with the 429. Carries no count and no window length beyond the
+``Retry-After`` header, which is the machine-readable half."""
+
+MAX_LOCATION_LENGTH = 2048
+"""Longest ``Location`` header this route will emit, in characters.
+
+The return-to cap alone does not bound this one. The OIDC hand-off
+percent-encodes the return-to into a query parameter, and encoding a path made
+of separators triples its length — so a value comfortably inside
+:data:`~osprey.services.auth_sidecar.return_to.MAX_RETURN_TO_LENGTH` can still
+leave here as a header wider than the proxy buffer nginx reads a response's
+headers into, which the operator meets as a 502. The check is therefore made on
+the string that actually goes out.
+"""
+
+MAX_USERNAME_LENGTH = 128
+"""Longest username this route will echo or key a throttle window on.
+
+A roster username is a directory segment in ``/u/<user>/`` and an environment
+variable suffix; nothing near this length can be one. The bound exists because
+the submitted value reaches a rendered page and a throttle key on a path that is
+unauthenticated and — for the page — reached before any credential is evaluated,
+so without it an anonymous request would choose how large a response the sidecar
+builds.
+"""
+
+_TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
+
+_templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
+"""Autoescaping Jinja2 environment over the package's templates."""
+
+_NO_STORE_HEADERS = {"Cache-Control": "no-store"}
+"""On every rendered page.
+
+A login prompt in a shared control room must not come back out of a browser's
+back-forward cache with a previous operator's username on it, and a 401 page
+must never be served from cache in place of the terminal it was standing in for.
+"""
+
+_THEME_VARIABLES = (
+    "--bg-primary",
+    "--bg-panel",
+    "--bg-elevated",
+    "--text-primary",
+    "--text-secondary",
+    "--text-muted",
+    "--color-accent",
+    "--color-error",
+    "--border-default",
+    "--border-accent",
+    "--shadow-dropdown",
+)
+"""The design-system custom properties ``login.html`` uses, read by name.
+
+Read by name rather than copied as a block for the reason the landing page does
+the same: the page is standalone and wants only what it uses, and a renamed
+token must surface as a fallback-with-a-warning rather than as a deployment
+quietly off-palette.
+"""
+
+_DEFAULT_THEME_FAMILY = "main"
+"""Which family's dark/light pair to bake in.
+
+The sidecar has no theme setting of its own — it authenticates, it does not
+render terminals — so the login page wears the framework default rather than
+inventing a configuration surface for one page.
+"""
+
+_SAFE_CSS_VALUE_RE = re.compile(r"[#A-Za-z0-9 ,.()%/_-]+")
+"""What a baked custom-property value may look like.
+
+Values come from the framework's own token tree, so this is belt and braces on a
+string that lands inside a ``<style>`` element — where HTML escaping is no
+defence against a ``</style>`` sequence, and would corrupt legitimate values.
+
+Applied with :meth:`~re.Pattern.fullmatch` rather than ``^…$`` and
+:meth:`~re.Pattern.match`: ``$`` also matches *before* a trailing newline, so an
+anchored ``match`` would accept a value carrying one — and a newline is exactly
+what would let a value break out of the declaration it was baked into.
+"""
+
+
+@lru_cache(maxsize=1)
+def _theme_blocks() -> tuple[dict[str, Any], ...]:
+    """The design-system token values to bake into the page, resolved once.
+
+    Two blocks, in the shape ``login.html`` and the landing page share: the
+    default family's dark values unconditionally, and its light values behind a
+    ``prefers-color-scheme`` query, so the login page follows the viewer's OS the
+    way the terminals behind it do.
+
+    Returns:
+        Block dicts, or an empty tuple when the token tree cannot be read or
+        carries a value this module will not put in a stylesheet. Empty is not a
+        failure the operator has to act on: every ``var()`` in the template
+        carries a literal fallback, so the page still renders in the default
+        dark palette.
+    """
+    try:
+        from osprey.interfaces.design_system.theme_config import (
+            load_theme_registry,
+            theme_css_variables,
+        )
+
+        _, defaults = load_theme_registry()
+        family = defaults[_DEFAULT_THEME_FAMILY]
+        wanted = (
+            (None, "dark", family["dark"]),
+            ("(prefers-color-scheme: light)", "light", family["light"]),
+        )
+        blocks = []
+        for media, color_scheme, theme_id in wanted:
+            values = theme_css_variables(theme_id, _THEME_VARIABLES)
+            for name, value in values.items():
+                if not _SAFE_CSS_VALUE_RE.fullmatch(value):
+                    raise ValueError(f"{name} in theme {theme_id!r} is not a safe CSS value")
+            blocks.append(
+                {
+                    "media": media,
+                    "color_scheme": color_scheme,
+                    "variables": tuple(values.items()),
+                }
+            )
+    except (ImportError, OSError, KeyError, ValueError) as exc:
+        # KeyError also covers MissingThemeVariableError, which is one — a
+        # renamed or dangling token. None of these stop a login: the page falls
+        # back to the palette baked into its own stylesheet.
+        logger.warning(
+            "login page is using its built-in palette: the design-system tokens could not "
+            "be resolved (%s)",
+            type(exc).__name__,
+        )
+        return ()
+    return tuple(blocks)
+
+
+def _only(values: list[str] | None) -> str | None:
+    """The single non-empty string in ``values``, or ``None``.
+
+    Several values are refused rather than resolved, for the reason
+    :func:`~osprey.services.auth_sidecar.routes.verify.verify` refuses them: a
+    login that took the first of ``?user=bob&user=alice`` would let the answer
+    depend on which end a parser happens to pick.
+    """
+    if not values or len(values) != 1:
+        return None
+    return values[0] or None
+
+
+def _page(
+    request: Request,
+    *,
+    user: str,
+    target: str,
+    status_code: int = 200,
+    error: str | None = None,
+    headers: dict[str, str] | None = None,
+) -> Response:
+    """Render the password prompt.
+
+    The same template for the first prompt, a refusal and a throttled attempt —
+    only ``status_code`` and ``error`` differ, so no refusal can be told from
+    another by its shape.
+
+    Args:
+        request: The inbound request, which Starlette's template response needs.
+        user: The roster user named by the link or the form, echoed into the
+            prompt. Escaped by the template, never trusted as markup.
+        target: The already-validated return-to, carried in a hidden field.
+        status_code: 200 for the prompt, 401 for a refusal, 429 when throttled.
+        error: The message to show, or ``None`` for a first prompt.
+        headers: Extra response headers, merged over the no-store default.
+
+    Returns:
+        The rendered page.
+    """
+    return _templates.TemplateResponse(
+        request,
+        TEMPLATE_NAME,
+        {
+            "user": user,
+            "next": target,
+            "error": error,
+            "login_path": LOGIN_PATH,
+            "theme_blocks": _theme_blocks(),
+        },
+        status_code=status_code,
+        headers={**_NO_STORE_HEADERS, **(headers or {})},
+    )
+
+
+def _current_session(
+    request: Request, codec: SessionCodec, revocations: RevocationStore
+) -> SessionState:
+    """The browser's auth session, or a fresh one.
+
+    An unreadable cookie — tampered, stale-keyed, or from a retired payload
+    version — is not an error here: it carries no authorisation, so the login it
+    is about to be replaced by starts from an empty session. A *readable* one is
+    kept so that unlocking a second user leaves the first one unlocked, which is
+    the whole point of a set-valued session.
+
+    **A revoked session id is not inherited.** Logout revokes by id, and verify
+    refuses every cookie carrying a revoked one — so a login that kept the id
+    would hand back a freshly signed cookie that verify then rejects, and the
+    next login would inherit it again. The browser would be locked out of a
+    terminal it just authenticated for, until the entry expired, with nothing in
+    the response saying why. It is reachable as an ordinary logout/login race,
+    so the id is retired here rather than carried.
+    """
+    raw = request.cookies.get(SESSION_COOKIE_NAME)
+    if not raw:
+        return codec.new_state()
+    try:
+        state = codec.decode(raw)
+    except InvalidSessionError:
+        logger.info("discarding an unreadable auth session cookie during login")
+        return codec.new_state()
+
+    if revocations.is_revoked(state.session_id):
+        logger.info("starting a new session: the cookie presented at login had been revoked")
+        return codec.new_state()
+    return state
+
+
+def _oidc_destination(user: str, target: str) -> str:
+    """The OIDC login URL this route hands a browser off to."""
+    return (
+        f"{OIDC_LOGIN_PATH}?{FIELD_USER}={quote(user, safe='')}"
+        f"&{FIELD_NEXT}={quote(target, safe='')}"
+    )
+
+
+def _expected_origin(request: Request, settings: AuthSettings) -> str | None:
+    """The one origin a login form may legitimately have been submitted from.
+
+    The deployment's declared
+    :attr:`~osprey.services.auth_sidecar.app.AuthSettings.external_origin` is the
+    authority wherever it exists. It is derived at render time from the
+    deployment's own configuration — the same value the OIDC ``redirect_uri`` is
+    built from — so it is the deployment's own word about where it lives, not a
+    client's.
+
+    It is optional in password mode, though, and a deployment without one still
+    has to be able to log people in. There the origin the request was *addressed
+    to* stands in (``Host``, with ``X-Forwarded-Proto`` for the scheme nginx
+    received). That is weaker — ``Host`` is client-supplied — but not weak
+    against the attack this check exists for: a cross-site form makes the
+    victim's browser set ``Host`` from the URL it is posting *to* while
+    ``Origin`` names the page it is posting *from*, and an attacker can choose
+    neither. A client that forges both is not a browser and has no victim's
+    cookie jar to act on.
+
+    Args:
+        request: The inbound request, as nginx forwarded it.
+        settings: The deployment's frozen settings.
+
+    Returns:
+        A lowercased ``scheme://host``, or ``None`` when neither source yields
+        one — in which case the caller refuses, because a check with nothing to
+        compare against is not a check.
+    """
+    if settings.external_origin:
+        return settings.external_origin.rstrip("/").lower()
+
+    forwarded = request.headers.get("x-forwarded-proto") or ""
+    # A proxy chain appends rather than replaces; the first entry is the scheme
+    # the browser used.
+    scheme = (forwarded.split(",")[0].strip() or request.url.scheme).lower()
+    host = (request.headers.get("host") or request.url.netloc).strip().lower()
+    return f"{scheme}://{host}" if host else None
+
+
+def _submission_origin(request: Request) -> str | None:
+    """Where this POST says it was submitted from, or ``None`` if it will not say.
+
+    ``Origin`` first: browsers send it on every cross-origin POST and, for over a
+    decade, on same-origin ones too, and it cannot be set by page script.
+    ``Referer`` is the fallback for the older same-origin behaviour, read for its
+    origin alone — the path is neither needed nor trusted.
+
+    A literal ``null`` origin (a sandboxed iframe, some redirect chains) counts as
+    "will not say" rather than as an origin: it matches no deployment, and
+    treating it as a value would only obscure why the refusal happened.
+    """
+    origin = (request.headers.get("origin") or "").strip()
+    if origin and origin.lower() != "null":
+        return origin.rstrip("/").lower()
+
+    referer = (request.headers.get("referer") or "").strip()
+    if referer:
+        parts = urlsplit(referer)
+        if parts.scheme and parts.netloc:
+            return f"{parts.scheme}://{parts.netloc}".lower()
+    return None
+
+
+def _cross_site_post(request: Request, settings: AuthSettings) -> bool:
+    """Whether this POST may not be treated as a submission of *this* login form.
+
+    Fail closed on both halves. A POST that declares no origin at all is refused
+    rather than admitted: every browser this login page can be used from sends
+    one, so the only callers a permissive branch would serve are scripted clients
+    — which have no victim's cookie jar and therefore nothing legitimate to gain
+    from the sidecar minting a session. A deployment that can name no origin of
+    its own is refused for the same reason: a comparison with nothing on one side
+    is not a comparison.
+    """
+    submitted = _submission_origin(request)
+    expected = _expected_origin(request, settings)
+    return submitted is None or expected is None or submitted != expected
+
+
+def _form_values(form: FormData, field: str) -> list[str]:
+    """Every string value submitted under ``field``.
+
+    Non-string parts (an upload posted under a field this form has no file
+    input for) are dropped, so a multipart body cannot make a value look like a
+    username.
+    """
+    return [value for value in form.getlist(field) if isinstance(value, str)]
+
+
+@router.get(LOGIN_PATH)
+async def login_page(
+    request: Request,
+    settings: Annotated[AuthSettings, Depends(get_settings)],
+    user: Annotated[list[str] | None, Query()] = None,
+    return_to: Annotated[list[str] | None, Query(alias=FIELD_NEXT)] = None,
+) -> Response:
+    """Show the password prompt for one roster user.
+
+    Both parameters are optional and list-typed on purpose: required ones would
+    make a malformed link draw FastAPI's 422 validation body — a different
+    status, a different shape, and a description of this endpoint's parameters
+    that nothing needs — and a scalar ``user`` would silently resolve a repeated
+    parameter instead of refusing it.
+
+    ``next`` may legitimately arrive empty: nginx sanitises the original path
+    through an allowlist and emits nothing when it does not survive, in which
+    case the login returns the browser to ``/u/<user>/``.
+
+    An over-long ``user`` is refused here rather than carried: no roster name
+    approaches :data:`MAX_USERNAME_LENGTH`, and both onward paths from this
+    handler — the rendered page and the OIDC hand-off's percent-encoded
+    ``Location`` — would otherwise let an anonymous link decide how much this
+    service emits.
+
+    Args:
+        request: The inbound request.
+        settings: The deployment's frozen settings.
+        user: The roster user whose card was clicked. Exactly one value.
+        return_to: Where to send the browser afterwards, if the link carried a
+            usable one.
+
+    Returns:
+        The rendered prompt in password mode, or a redirect to the OIDC login
+        route on a deployment that authenticates that way — nginx's 401 handler
+        sends every method's browsers here, and a password form is unanswerable
+        under OIDC.
+
+    Raises:
+        HTTPException: 400 when the link does not name exactly one user; 404
+            when this deployment serves no password login, or when ``user`` is
+            not on the roster.
+    """
+    username = _only(user)
+    if username is None:
+        # Counts and lengths, never values: this is the one part of the request a
+        # client chose freely.
+        logger.warning(
+            "login page requested without exactly one user parameter (got %d)", len(user or [])
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="the login link must name exactly one user",
+            headers=_NO_STORE_HEADERS,
+        )
+
+    if len(username) > MAX_USERNAME_LENGTH:
+        logger.warning(
+            "login page requested for an impossible username of %d characters", len(username)
+        )
+        raise HTTPException(
+            status_code=400, detail="that is not a username", headers=_NO_STORE_HEADERS
+        )
+
+    target = safe_return_to(_only(return_to), username)
+
+    if settings.method == "oidc":
+        # The cross-method hand-off. Roster membership and identity mapping are
+        # the OIDC route's decisions, so this redirects without pre-judging
+        # either — it only ensures the browser reaches a login it can complete.
+        destination = _oidc_destination(username, target)
+        if len(destination) > MAX_LOCATION_LENGTH:
+            # Percent-encoding a path of separators triples it, so a return-to
+            # inside its own cap can still leave here as a header the proxy will
+            # not carry. Measured on the value that actually goes out, and the
+            # answer is the same as for any unusable return-to: the user's own
+            # terminal.
+            destination = _oidc_destination(username, f"/u/{username}/")
+        return RedirectResponse(destination, status_code=302, headers=_NO_STORE_HEADERS)
+
+    if settings.method != "password":
+        # Unreachable behind the configuration guard, which admits only the two
+        # supported methods. Written as the stricter default anyway: an
+        # unexpected method must not fall through into a password prompt.
+        raise HTTPException(
+            status_code=404,
+            detail="this deployment does not use password login",
+            headers=_NO_STORE_HEADERS,
+        )
+
+    if not settings.knows_user(username):
+        # No credential is evaluated on this path and the roster is public — the
+        # landing page lists it — so the honest answer is that there is no such
+        # login page, matching what the OIDC login route says. The POST path,
+        # where a credential *is* evaluated, deliberately does not distinguish.
+        raise HTTPException(status_code=404, detail="no such user", headers=_NO_STORE_HEADERS)
+
+    return _page(request, user=username, target=target)
+
+
+@router.post(LOGIN_PATH)
+async def login_submit(
+    request: Request,
+    settings: Annotated[AuthSettings, Depends(get_settings)],
+    codec: Annotated[SessionCodec, Depends(get_session_codec)],
+    throttle: Annotated[AttemptThrottle, Depends(get_attempt_throttle)],
+    revocations: Annotated[RevocationStore, Depends(get_revocation_store)],
+) -> Response:
+    """Evaluate one password attempt and, on success, unlock that user.
+
+    The form is read off the request rather than declared as FastAPI ``Form``
+    parameters, for the reason the query parameters above are optional: a
+    missing or repeated field must produce this route's own refusal, never a 422
+    validation body. It also makes the "exactly one value" rule explicit for the
+    username, which is the field whose ambiguity would matter.
+
+    Order is load-bearing, twice over. The ``Origin`` check comes before
+    everything — a cross-site form must not be able to burn an operator's
+    throttle window, let alone reach a credential — and the throttle is consulted
+    before the credential is looked at, so a refused attempt costs a dict lookup
+    instead of a key derivation and never grows the window. Only an attempt this
+    route actually evaluated records a failure.
+
+    On success the user joins — rather than replaces — the browser's unlocked
+    set, carrying an expiry stamped from the codec's clock and the
+    credential-generation tag of the hash it was checked against. The tag is
+    what makes a later ``osprey deploy passwd`` retire this session: verify
+    recomputes it from the *current* stored hash and refuses when they differ.
+    The username goes into the entry exactly as submitted, because verify
+    exact-matches it against the roster — normalising it here would open the
+    chain rather than close it.
+
+    Args:
+        request: The inbound request, carrying the submitted form.
+        settings: The deployment's frozen settings.
+        codec: The app's one session codec, and the one clock every expiry in
+            the session path is stamped from.
+        throttle: The app's one login-attempt throttle.
+        revocations: The app's one revocation store, so a session id logout has
+            retired is not carried into the cookie this login issues.
+
+    Returns:
+        A 303 to the validated return-to carrying the re-issued session cookie;
+        the prompt again with 401 and one fixed message when the credential is
+        refused; the prompt with 429 and ``Retry-After`` when the attempt
+        arrived inside an open window.
+
+    Raises:
+        HTTPException: 400 when the form arrives from another origin or does not
+            name exactly one user; 404 when this deployment serves no password
+            login.
+    """
+    if settings.method != "password":
+        raise HTTPException(
+            status_code=404,
+            detail="this deployment does not use password login",
+            headers=_NO_STORE_HEADERS,
+        )
+
+    if _cross_site_post(request, settings):
+        # Before the form is even read: this request is not a login attempt at
+        # all, so it may not touch the throttle, and the refusal is the shape a
+        # malformed form already produces rather than a new one to probe with.
+        logger.warning(
+            "login POST refused: submitted from %r, which is not this deployment (%r)",
+            _submission_origin(request),
+            _expected_origin(request, settings),
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="this form was not submitted from this deployment",
+            headers=_NO_STORE_HEADERS,
+        )
+
+    form = await request.form()
+    submitted_users = _form_values(form, FIELD_USER)
+    username = _only(submitted_users)
+    if username is None:
+        logger.warning(
+            "login submitted without exactly one user field (got %d)", len(submitted_users)
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="the login form must name exactly one user",
+            headers=_NO_STORE_HEADERS,
+        )
+
+    # An over-long name cannot be a roster user, and it must not be *looked up*
+    # as one either: a prefix of it could collide with a real roster name and
+    # unlock that user's credential under a name the browser never sent. So it is
+    # refused on the ordinary deny path below (`stored` forced to None), while
+    # the bounded form is what gets echoed and what keys the throttle window —
+    # neither the page nor the throttle's memory is the caller's to size.
+    oversize = len(username) > MAX_USERNAME_LENGTH
+    shown = username[:MAX_USERNAME_LENGTH] if oversize else username
+    if oversize:
+        logger.warning("login submitted an impossible username of %d characters", len(username))
+
+    target = safe_return_to(_only(_form_values(form, FIELD_NEXT)), shown)
+    # A missing, repeated or non-string password is simply not a password: it
+    # takes the ordinary refusal path rather than a distinguishable one, and
+    # `verify_password` answers False for an empty string without deriving a key.
+    password = _only(_form_values(form, FIELD_PASSWORD)) or ""
+
+    delay = throttle.retry_after(shown)
+    if delay > 0:
+        # Before evaluation, and without recording a failure: counting attempts
+        # that were never evaluated is how a flood of parallel guesses would
+        # ratchet the window against the operator it protects.
+        logger.info(
+            "login attempt for %r refused unevaluated: the attempt window is still open", username
+        )
+        return _page(
+            request,
+            user=shown,
+            target=target,
+            status_code=429,
+            error=THROTTLE_MESSAGE,
+            headers={"Retry-After": str(math.ceil(delay))},
+        )
+
+    stored = None if oversize else settings.password_hash(username)
+    # `stored is None` covers a roster user with no provisioned credential, a
+    # username that is not on the roster at all, and one too long to be either.
+    # None derives a key — see the module docstring — and all three leave through
+    # the identical refusal below, including the same call into the throttle.
+    if stored is None or not verify_password(password, stored):
+        throttle.record_failure(shown)
+        logger.warning("login refused for %r: the submitted credential did not verify", shown)
+        return _page(request, user=shown, target=target, status_code=401, error=DENIAL_MESSAGE)
+
+    # `shown` here too, not `username`: on this path they are the same string —
+    # an over-long name never gets a stored hash — and keying both throttle calls
+    # the same way is what makes "the window this attempt was checked against" and
+    # "the window it clears" provably the same entry.
+    throttle.record_success(shown)
+    now = codec.now()
+    session = _current_session(request, codec, revocations).with_user(
+        username,
+        expires_at=now + settings.session_lifetime,
+        generation_tag=generation_tag(stored),
+    )
+
+    response = RedirectResponse(target, status_code=303, headers=_NO_STORE_HEADERS)
+    response.set_cookie(
+        SESSION_COOKIE_NAME,
+        codec.encode(session),
+        httponly=True,
+        samesite="lax",
+        secure=settings.tls_enabled,
+        # Not the state cookie's "/auth": this one has to reach the terminals it
+        # authorises, whose verify subrequest nginx issues from "/u/<user>/".
+        # No Max-Age either — a browser-session cookie whose real lifetime is the
+        # signed expiry inside it, which is the only one the sidecar can enforce.
+        path="/",
+    )
+    logger.info("password login succeeded for %r", username)
+    return response

--- a/src/osprey/services/auth_sidecar/routes/logout.py
+++ b/src/osprey/services/auth_sidecar/routes/logout.py
@@ -1,0 +1,184 @@
+"""Logout: surrender one unlocked user without disturbing the others.
+
+``GET /auth/logout?user=<name>`` under the public ``/auth/`` prefix, reached
+either from the in-app logout control (which navigates here after its own PTY
+teardown POST) or directly. It composes with that teardown rather than replacing
+it: the app tears down the terminal, this retires the session's claim on it.
+
+**One user, not the browser.** A control-room machine may have several roster
+users unlocked in one browser at once, so logging out of alice must leave bob
+exactly as he was. That shapes everything below.
+
+**Why the session id is rotated.** Revocation is recorded per session *id* and
+:func:`~osprey.services.auth_sidecar.routes.verify.verify` refuses any cookie
+whose id appears in the store — for every user it carries, not just the one that
+logged out. Reissuing the surrendered cookie's id would therefore log bob out as
+a side effect of alice leaving. So the response carries the surviving users under
+a **fresh** id while the old id goes into the revocation store: the cookie the
+browser handed in is dead, and the one it gets back is not. The issued-at stamp
+is preserved, so this cannot be used to extend a session's overall age by
+logging out repeatedly.
+
+**Revoked until the entry would have lapsed anyway.** The store is given the
+logged-out user's own ``expires_at``. That is exactly long enough: the only
+thing a captured pre-logout cookie could do is authorize *that* user, and the
+entry inside it stops authorizing at that same moment on its own expiry check.
+
+**Every logout looks the same from outside.** Logging out a user who was never
+unlocked, or one who is not on the roster at all, produces the same 303 to the
+landing page and the same reissued cookie as a real logout — no error, no detail,
+nothing that reveals whether that user was unlocked in this browser. The
+distinction is recorded in the log, for the operator, at debug level.
+
+Reached by a top-level ``GET`` navigation on purpose (the in-app control is a
+link, and ``SameSite=Lax`` sends the cookie on exactly that). The cost is that
+another site can force a logout; the benefit is that logout works from a plain
+link with no script. A forced logout ends a session early — a nuisance, never an
+escalation — so the trade is taken deliberately.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import replace
+from typing import Annotated
+
+from fastapi import APIRouter, Cookie, Depends, Query, Response
+from fastapi.responses import RedirectResponse
+
+from ..app import AuthSettings, get_revocation_store, get_session_codec, get_settings
+from ..exceptions import InvalidSessionError
+from ..revocation import RevocationStore
+from ..sessions import (
+    SESSION_COOKIE_NAME,
+    SessionCodec,
+    SessionState,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+LOGOUT_PATH = "/auth/logout"
+"""Public path nginx proxies here verbatim (``location /auth/``)."""
+
+LANDING_PATH = "/"
+"""Where a logged-out browser is sent.
+
+A same-origin absolute path, not
+:attr:`~osprey.services.auth_sidecar.app.AuthSettings.external_origin` + "/":
+the origin is only required in OIDC mode (it builds the ``redirect_uri``), and a
+password-mode deployment that leaves it unset must still redirect somewhere real.
+nginx serves the landing page at exactly this path.
+"""
+
+
+def _redirect() -> RedirectResponse:
+    """The one response every logout produces, successful or not.
+
+    303 rather than 302: the browser must follow it with a ``GET`` regardless of
+    how it arrived, and the landing page is a different resource rather than a
+    relocation of this one. ``no-store`` for the same reason every login
+    response carries it: nothing in the auth flow may ever be replayed from a
+    cache, and a replayed logout would skip the revocation while looking like
+    it worked.
+    """
+    return RedirectResponse(LANDING_PATH, status_code=303, headers={"Cache-Control": "no-store"})
+
+
+def _set_session_cookie(
+    response: Response, codec: SessionCodec, state: SessionState, settings: AuthSettings
+) -> None:
+    """Attach the reissued session cookie.
+
+    Attributes are the same set the login and OIDC callback routes issue — a
+    cookie that differed in any of them would be a *second* cookie to the
+    browser, leaving the original in place and logged out of nothing.
+
+    ``Path=/`` because this cookie has to reach the terminals it authorises,
+    whose verify subrequest nginx issues from ``/u/<user>/``; no ``Max-Age``,
+    so it is a session cookie whose real lifetime is the signed expiry inside it.
+    """
+    response.set_cookie(
+        SESSION_COOKIE_NAME,
+        codec.encode(state),
+        httponly=True,
+        samesite="lax",
+        secure=settings.tls_enabled,
+        path="/",
+    )
+
+
+@router.get(LOGOUT_PATH)
+async def logout(
+    settings: Annotated[AuthSettings, Depends(get_settings)],
+    codec: Annotated[SessionCodec, Depends(get_session_codec)],
+    revocations: Annotated[RevocationStore, Depends(get_revocation_store)],
+    user: Annotated[list[str] | None, Query()] = None,
+    session_cookie: Annotated[str | None, Cookie(alias=SESSION_COOKIE_NAME)] = None,
+) -> Response:
+    """Lock ``user`` again in this browser's session.
+
+    Both parameters are optional so that a malformed request redirects like every
+    other logout instead of drawing FastAPI's 422 validation body — a different
+    status, a different shape, and a description of this endpoint's parameters
+    that nothing needs. ``user`` is read as a list for the same reason
+    :func:`~osprey.services.auth_sidecar.routes.verify.verify` does: a repeated
+    parameter is refused outright rather than resolved to whichever value a
+    parser happens to pick first.
+
+    Args:
+        settings: The deployment's frozen settings.
+        codec: The app's one session codec, and the one clock in the session path.
+        revocations: The app's one revocation store — the same object verify
+            reads, or this would revoke something nothing checks.
+        user: The roster user to log out. Exactly one value acts; none and
+            several are no-ops.
+        session_cookie: The browser's session cookie, if it sent one.
+
+    Returns:
+        A 303 to the landing page, carrying a reissued cookie whenever there was
+        a readable session to reissue.
+    """
+    response = _redirect()
+
+    requested = user or []
+    if len(requested) != 1 or not requested[0]:
+        # The count, never the values: they are caller-supplied. A request that
+        # names no user (or several) has not asked for anything specific, so
+        # nothing is revoked and no cookie is disturbed.
+        logger.debug("logout ignored: expected exactly one user parameter, got %d", len(requested))
+        return response
+
+    username = requested[0]
+
+    if not session_cookie:
+        logger.debug("logout for %r: no session cookie to act on", username)
+        return response
+
+    try:
+        state = codec.decode(session_cookie)
+    except InvalidSessionError:
+        # Tampered, stale-keyed or over-age. It carries no authorisation, so
+        # there is nothing to revoke and nothing worth reissuing; the browser
+        # keeps a cookie that every verify already refuses, and the next login
+        # replaces it. The exception message stays out of the log — it is
+        # derived from the value the caller sent.
+        logger.debug("logout for %r: session cookie is unreadable", username)
+        return response
+
+    entry = state.entry(username)
+    if entry is not None:
+        # Only now is there something to retire. `decode` has already dropped
+        # expired entries, so reaching here means the user really was unlocked.
+        revocations.revoke(state.session_id, entry.expires_at)
+        logger.info("logout: %r surrendered an unlocked session", username)
+    else:
+        logger.debug("logout for %r: that user was not unlocked in this session", username)
+
+    # Rotated id, preserved issued-at, and the same cookie whether or not
+    # anything was revoked — so a logout for a user who was never unlocked is
+    # indistinguishable from one that ended a real session.
+    rotated = replace(state.without_user(username), session_id=codec.new_state().session_id)
+    _set_session_cookie(response, codec, rotated, settings)
+    return response

--- a/src/osprey/services/auth_sidecar/routes/oidc.py
+++ b/src/osprey/services/auth_sidecar/routes/oidc.py
@@ -1,0 +1,422 @@
+"""OIDC login and callback for the auth sidecar.
+
+Two routes under the public ``/auth/`` prefix nginx proxies here:
+:data:`LOGIN_PATH` starts the handshake for one roster user and
+:data:`CALLBACK_PATH` finishes it. Both exist only when the deployment runs
+``auth.method: oidc``; in password mode they answer 404, because the factory
+includes every route module regardless of method and "this endpoint is not part
+of this deployment" is the honest answer.
+
+**The clicked card is the username.** The landing page offers one card per
+roster user, so the login route is addressed per user and the callback's job is
+not "who is this person" but "is this person the user whose card was clicked".
+The identity the IdP asserts is compared against
+:meth:`~osprey.services.auth_sidecar.app.AuthSettings.oidc_subject` for *that*
+user and nothing else: an identity that maps to no roster user, or to a
+different one, is refused with 403. Searching the roster for whichever user the
+subject happens to match would turn a mis-click into someone else's terminal,
+which is exactly the isolation this sidecar exists to establish.
+
+**Which user was clicked is server-side state.** It travels in the pinned
+Starlette session cookie (:data:`PENDING_FLOW_SESSION_KEY`) alongside Authlib's
+own ``state``/``nonce``, keyed by the same ``state`` value — never as a query
+parameter on the ``redirect_uri``, which the browser could edit between the two
+legs of the handshake and thereby pick which roster user a successful IdP login
+unlocks. The session cookie is signed with the state secret, so its contents are
+the sidecar's own word.
+
+**The identity comes from the verified ID token.** Authlib validates the token's
+signature, issuer, audience and nonce before
+:meth:`authorize_access_token` returns it as ``token["userinfo"]``; this module
+reads the configured claim from there and never calls the userinfo endpoint. The
+audience is on that list only because :func:`_claims_options` asks for it —
+Authlib checks ``aud`` when the caller names it and not otherwise, so removing
+that argument would silently reduce the audience check to the OIDC ``azp`` rule.
+A deployment whose IdP carries the mapped claim only at that endpoint therefore
+locks out with a log line naming the claim, rather than authorising on a second,
+weaker trust path.
+
+**Nothing about a failure reaches the browser but its category.** Tokens, claim
+values and client secrets never enter a response or a log line; refusals name
+the user and the reason class only.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from typing import Any
+
+import httpx
+from authlib.integrations.starlette_client import OAuth, OAuthError
+from fastapi import APIRouter, HTTPException, Query, Request, Response
+from fastapi.responses import RedirectResponse
+
+from ..app import AuthSettings, get_revocation_store, get_session_codec, get_settings
+from ..exceptions import InvalidSessionError
+from ..return_to import safe_return_to
+from ..sessions import SESSION_COOKIE_NAME, SessionState
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+LOGIN_PATH = "/auth/oidc/login"
+"""Starts the handshake for one roster user: ``?user=<name>&next=<return-to>``."""
+
+CALLBACK_PATH = "/auth/oidc/callback"
+"""Where the IdP sends the browser back. Registered with the IdP as
+:attr:`~osprey.services.auth_sidecar.app.AuthSettings.external_origin` + this
+path — both legs must agree on it byte for byte, and the token exchange repeats
+it, so it is derived from the deployment's own origin rather than from the
+inbound request (which arrives from nginx over loopback and names the wrong
+host)."""
+
+CLIENT_NAME = "osprey_oidc"
+"""Authlib client name. It namespaces Authlib's own session entries
+(``_state_osprey_oidc_<state>``), so it is part of the state cookie's shape."""
+
+PENDING_FLOW_SESSION_KEY = "osprey_oidc_pending"
+"""State-cookie key holding the in-flight handshake: ``{"state", "user", "next"}``.
+
+One entry, not a map: Authlib's Starlette integration drops every previous
+``_state_*`` entry each time it stores a new one, so a browser can only ever
+have one handshake it could complete. A second entry here would outlive the
+Authlib data it is paired with and could only ever fail the state check."""
+
+DEFAULT_SCOPE = "openid profile email"
+"""Requested scopes.
+
+``openid`` is what makes this OIDC rather than bare OAuth2 (it is also what
+makes Authlib generate and check a nonce). ``profile`` and ``email`` are asked
+for because the claim a facility maps onto a roster user is commonly
+``preferred_username`` or ``email``, and a claim that was never requested is
+simply absent from the token — which this module reads as "deny"."""
+
+
+def _discovery_url(issuer: str) -> str:
+    """The OIDC discovery document for ``issuer``."""
+    return f"{issuer.rstrip('/')}/.well-known/openid-configuration"
+
+
+def _require_oidc_mode(settings: AuthSettings) -> None:
+    """Refuse with 404 unless this deployment authenticates with OIDC.
+
+    Raises:
+        HTTPException: 404 in password mode. Not 403: the endpoint is not part
+            of this deployment's surface at all, and saying "forbidden" would
+            imply an identity was evaluated.
+    """
+    if settings.method != "oidc":
+        raise HTTPException(status_code=404, detail="this deployment does not use OIDC login")
+
+
+def _oauth_client(request: Request) -> Any:
+    """The app's one Authlib client, built on first use and cached.
+
+    Cached on ``app.state`` rather than at module scope: two apps in one process
+    (every test that builds a second one) would otherwise share a client
+    configured for the first app's issuer and credentials. Building it lazily
+    also keeps the discovery fetch off the factory's path — the sidecar starts
+    and answers its healthcheck whether or not the IdP is reachable — and the
+    cached client holds the fetched metadata, so discovery happens once rather
+    than per login.
+
+    Tests replace it by assigning ``app.state.oidc_client`` before the first
+    request.
+    """
+    client = getattr(request.app.state, "oidc_client", None)
+    if client is not None:
+        return client
+
+    settings = get_settings(request)
+    registry = OAuth()
+    registry.register(
+        name=CLIENT_NAME,
+        server_metadata_url=_discovery_url(settings.oidc_issuer or ""),
+        client_id=settings.oidc_client_id,
+        client_secret=settings.oidc_client_secret,
+        client_kwargs={"scope": DEFAULT_SCOPE},
+    )
+    client = registry.create_client(CLIENT_NAME)
+    request.app.state.oidc_client = client
+    return client
+
+
+def _same_value(left: str, right: str) -> bool:
+    """Whether two text values are equal, compared in constant time.
+
+    As UTF-8 bytes, never as ``str``: :func:`secrets.compare_digest` raises
+    ``TypeError`` the moment either side carries a non-ASCII character, and both
+    things compared here can. A ``state`` parameter is unauthenticated input, so
+    one accented character in it would be an unhandled 500 rather than a
+    refusal; a mapped identity like ``jörg@example.org`` would raise on the
+    comparison that was about to *succeed*, locking that operator out for good.
+    """
+    return secrets.compare_digest(left.encode("utf-8"), right.encode("utf-8"))
+
+
+def _claims_options(settings: AuthSettings) -> dict[str, dict[str, list[str]]]:
+    """Which ID-token claims Authlib must check, and against what.
+
+    **``aud`` is only checked when it is named here.** Authlib's own default
+    supplies ``iss`` and nothing else, so without this an ID token minted for a
+    *different* relying party validates as long as it carries an ``azp`` naming
+    this client — the OIDC ``azp`` rule is then the only thing standing in the
+    way, and an IdP emits ``azp`` at its discretion. Naming ``aud`` makes the
+    audience check this deployment's own rather than a side effect of a claim
+    that may never arrive.
+
+    **``iss`` is repeated here because this mapping replaces Authlib's default
+    rather than extending it.** Omitting it would trade the audience hole for an
+    issuer one.
+
+    Both spellings of the issuer are accepted. OIDC Discovery requires the
+    published ``issuer`` to equal the prefix its document was fetched from, and
+    :func:`_discovery_url` strips one trailing slash off that prefix — so a
+    deployment whose configured issuer differs from the IdP's published one by
+    exactly that character is correctly configured, and locking it out would be
+    this function inventing a requirement neither party has.
+
+    Args:
+        settings: The deployment's settings. Both values it reads are
+            deployment-wide requirements in OIDC mode, so the configuration
+            guard has already refused every request that could reach here
+            without them.
+
+    Returns:
+        A ``claims_options`` mapping for
+        :meth:`authorize_access_token`.
+    """
+    issuer = (settings.oidc_issuer or "").strip()
+    trimmed = issuer.rstrip("/")
+    return {
+        "iss": {"values": [issuer] if issuer == trimmed else [issuer, trimmed]},
+        "aud": {"values": [settings.oidc_client_id]},
+    }
+
+
+def _current_session(request: Request) -> SessionState:
+    """The browser's auth session, or a fresh one.
+
+    An unreadable cookie — tampered, stale-keyed, or from a retired payload
+    version — is not an error here: it carries no authorisation, so the login
+    it is about to be replaced by starts from an empty session.
+
+    **A revoked session id is not inherited.** Logout revokes by id and verify
+    refuses every cookie carrying a revoked one, so a callback that kept the id
+    would re-sign a cookie verify then rejects — and the next handshake would
+    inherit it again, locking the browser out of the terminal it just
+    authenticated for until the entry expired. Retiring the id here is what makes
+    a logout followed by a fresh login mean what it says.
+    """
+    codec = get_session_codec(request)
+    raw = request.cookies.get(SESSION_COOKIE_NAME)
+    if not raw:
+        return codec.new_state()
+    try:
+        state = codec.decode(raw)
+    except InvalidSessionError:
+        logger.info("discarding an unreadable auth session cookie during oidc login")
+        return codec.new_state()
+
+    if get_revocation_store(request).is_revoked(state.session_id):
+        logger.info("starting a new session: the cookie presented at oidc login had been revoked")
+        return codec.new_state()
+    return state
+
+
+@router.get(LOGIN_PATH)
+async def oidc_login(
+    request: Request,
+    user: str = Query(..., description="Roster user whose card was clicked"),
+    return_to: str | None = Query(None, alias="next", description="Same-origin path to return to"),
+) -> Response:
+    """Redirect to the IdP to authenticate as ``user``.
+
+    Args:
+        request: The inbound request.
+        user: The roster user being logged in.
+        return_to: Where to send the browser after a successful callback.
+
+    Returns:
+        A redirect to the IdP's authorization endpoint.
+
+    Raises:
+        HTTPException: 404 when this deployment is not in OIDC mode or ``user``
+            is not on the roster; 403 when ``user`` has no mapped IdP identity
+            (the handshake could only end in a refusal, so it does not start);
+            502 when the issuer's discovery document cannot be fetched or read.
+    """
+    settings = get_settings(request)
+    _require_oidc_mode(settings)
+
+    if not settings.knows_user(user):
+        raise HTTPException(status_code=404, detail="no such user")
+    if settings.oidc_subject(user) is None:
+        logger.warning("oidc login refused for %r: no IdP identity is mapped to that user", user)
+        raise HTTPException(status_code=403, detail="this user has no mapped identity provider")
+
+    target = safe_return_to(return_to, user, flow="oidc login")
+    client = _oauth_client(request)
+    redirect_uri = f"{settings.external_origin}{CALLBACK_PATH}"
+
+    # Deliberately not `authorize_redirect`, which is these three steps with the
+    # state value kept inside it. The state is what binds this handshake to the
+    # user whose card was clicked, so this route needs it in hand.
+    try:
+        authorization = await client.create_authorization_url(redirect_uri)
+    except httpx.HTTPError:
+        logger.warning("oidc login failed: the issuer's discovery document is unreachable")
+        raise HTTPException(
+            status_code=502, detail="the identity provider could not be reached"
+        ) from None
+    except Exception as exc:
+        # Reached, not defensive: a discovery document that is served but wrong
+        # — HTML from a captive portal, JSON with no authorization_endpoint —
+        # raises out of Authlib rather than out of httpx, and a mistyped issuer
+        # is where that shows up first. Same reasoning as the callback's broad
+        # arm, and the same discipline: class name only, never the response.
+        logger.warning(
+            "oidc login failed: the issuer's discovery document is unusable (%s)",
+            type(exc).__name__,
+        )
+        raise HTTPException(
+            status_code=502, detail="the identity provider's configuration could not be read"
+        ) from None
+
+    await client.save_authorize_data(request, redirect_uri=redirect_uri, **authorization)
+    request.session[PENDING_FLOW_SESSION_KEY] = {
+        "state": authorization["state"],
+        "user": user,
+        "next": target,
+    }
+    return RedirectResponse(authorization["url"], status_code=302)
+
+
+@router.get(CALLBACK_PATH)
+async def oidc_callback(request: Request) -> Response:
+    """Finish the handshake and unlock the user whose card was clicked.
+
+    Args:
+        request: The inbound request, carrying the IdP's ``code`` and ``state``.
+
+    Returns:
+        A redirect to the validated return-to, carrying the re-issued auth
+        session cookie.
+
+    Raises:
+        HTTPException: 404 outside OIDC mode; 400 when no handshake is in flight
+            for this browser, when the returned ``state`` does not match the one
+            that started it, or when the IdP reports an error; 403 when the
+            asserted identity is not the one mapped to the clicked user; 502
+            when the IdP is unreachable or its response does not validate.
+    """
+    settings = get_settings(request)
+    _require_oidc_mode(settings)
+
+    # Popped before anything is validated, so a callback that fails any check
+    # below still consumes the pending flow. The trade is deliberate: it costs a
+    # cancelled login (any page that can reach this URL can make the operator
+    # click their card again), and it buys a handshake that cannot be replayed,
+    # probed repeatedly, or left half-open in the cookie. A login is cheap to
+    # restart; a reusable one is not cheap to hold.
+    pending = request.session.pop(PENDING_FLOW_SESSION_KEY, None)
+    if not isinstance(pending, dict) or not pending.get("state") or not pending.get("user"):
+        logger.warning("oidc callback rejected: no login is in flight for this browser")
+        raise HTTPException(status_code=400, detail="no login is in progress")
+
+    # Checked here as well as inside Authlib, and against our own record of the
+    # state: Authlib proves the callback belongs to a handshake this browser
+    # started, while this proves it belongs to the handshake that carried this
+    # user. Without it a browser holding two half-finished flows could complete
+    # one of them under the other's username.
+    returned_state = request.query_params.get("state") or ""
+    if not _same_value(str(pending["state"]), returned_state):
+        logger.warning("oidc callback rejected: returned state does not match the login in flight")
+        raise HTTPException(status_code=400, detail="login state mismatch")
+
+    user = str(pending["user"])
+    expected_subject = settings.oidc_subject(user)
+    if expected_subject is None:
+        # Unreachable through the login route, which refuses first; re-checked
+        # because this is the decision that must never fall through to "some
+        # other user's subject matched".
+        logger.warning("oidc callback refused for %r: no IdP identity is mapped to that user", user)
+        raise HTTPException(status_code=403, detail="this user has no mapped identity provider")
+
+    client = _oauth_client(request)
+    try:
+        token = await client.authorize_access_token(
+            request, claims_options=_claims_options(settings)
+        )
+    except OAuthError as exc:
+        # The IdP reported an error, or Authlib's own state check failed.
+        logger.warning("oidc callback rejected by the authorization step: %s", type(exc).__name__)
+        raise HTTPException(
+            status_code=400, detail="the identity provider rejected the login"
+        ) from None
+    except httpx.HTTPError:
+        logger.warning(
+            "oidc callback failed: the identity provider's token endpoint is unreachable"
+        )
+        raise HTTPException(
+            status_code=502, detail="the identity provider could not be reached"
+        ) from None
+    except Exception as exc:  # ID-token validation: signature, issuer, audience, nonce, claims.
+        # Deliberately broad. The concrete types come from whichever JWT library
+        # the installed Authlib delegates to, and pinning them here would turn a
+        # dependency bump into a 500 on a token that should simply be refused.
+        # Only the class name is logged: an exception from claim validation can
+        # carry claim material, and none of it belongs in the service log.
+        logger.warning(
+            "oidc callback rejected: the ID token did not validate (%s)", type(exc).__name__
+        )
+        raise HTTPException(
+            status_code=502, detail="the identity provider's response could not be validated"
+        ) from None
+
+    claims = token.get("userinfo") or {}
+    asserted = claims.get(settings.oidc_claim)
+    if not isinstance(asserted, str) or not asserted:
+        logger.warning(
+            "oidc callback refused for %r: the ID token carries no usable %r claim",
+            user,
+            settings.oidc_claim,
+        )
+        raise HTTPException(status_code=403, detail="the identity provider asserted no identity")
+
+    if not _same_value(asserted, expected_subject):
+        # No search of the roster for a user this identity *would* match: the
+        # card that was clicked is the only user this login can unlock.
+        logger.warning(
+            "oidc callback refused for %r: the asserted identity is mapped to a different user "
+            "or to none",
+            user,
+        )
+        raise HTTPException(status_code=403, detail="this identity is not permitted for this user")
+
+    codec = get_session_codec(request)
+    now = codec.now()
+    # No generation tag: that is the password mode's rotation signal, computed
+    # from a stored hash which OIDC has none of. An OIDC entry is bounded by its
+    # expiry and by logout alone.
+    session = _current_session(request).with_user(
+        user, expires_at=now + settings.session_lifetime, generation_tag=""
+    )
+
+    response = RedirectResponse(
+        safe_return_to(pending.get("next"), user, flow="oidc login"), status_code=303
+    )
+    response.set_cookie(
+        SESSION_COOKIE_NAME,
+        codec.encode(session),
+        httponly=True,
+        samesite="lax",
+        secure=settings.tls_enabled,
+        # Not the state cookie's "/auth": this one has to reach the terminals it
+        # authorises, whose verify subrequest nginx issues from "/u/<user>/".
+        path="/",
+    )
+    logger.info("oidc login succeeded for %r", user)
+    return response

--- a/src/osprey/services/auth_sidecar/routes/verify.py
+++ b/src/osprey/services/auth_sidecar/routes/verify.py
@@ -1,0 +1,188 @@
+"""The ``auth_request`` target: one bare 200 or 401 per protected request.
+
+nginx calls this once for every request under ``/u/<user>/`` — page loads, API
+calls, websocket handshakes alike — and turns any non-2xx answer into a denial.
+It is therefore on the hot path of the whole deployment and says as little as
+possible: an empty 200 or a bare 401, with no body, no redirect and no
+``WWW-Authenticate``. Where an unauthenticated browser should be *sent* is
+nginx's decision (``error_page 401``, content-negotiated), not this route's; a
+redirect issued here would be followed by the subrequest instead of the user.
+
+**The username is a render-time literal.** Each roster user has its own internal
+``location = /_osprey_auth/<user>`` whose ``proxy_pass`` carries
+``?user=<user>`` baked in at render time, so nothing about the client's request
+— path, headers, cookies — selects which identity is being authorized. That is
+why this route reads a query parameter and never reconstructs the user from
+``$request_uri`` or ``X-Original-URI``: those are attacker-influenceable, and a
+path-confusion trick against them would authorize the wrong terminal. A query
+carrying the parameter more than once is refused outright rather than resolved,
+so the answer can never depend on which of two values a parser happens to pick.
+
+**Every denial looks the same.** An unknown user, an unmapped one, a missing
+cookie, a forged cookie and a rotated password all produce the identical bare
+401. The reason is recorded at debug level, by category, for the operator
+reading the sidecar's log — never the cookie, the generation tag, or the stored
+hash. Cookies are signed, not encrypted, so their contents are the caller's
+session; nothing about it belongs in a log line.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Cookie, Depends, Query, Response
+
+from ..app import AuthSettings, get_revocation_store, get_session_codec, get_settings
+from ..exceptions import InvalidSessionError
+from ..passwords import verify_generation_tag
+from ..revocation import RevocationStore
+from ..sessions import SESSION_COOKIE_NAME, SessionCodec
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+VERIFY_PATH = "/verify"
+"""Rendered into every per-user internal location's ``proxy_pass``.
+
+Deliberately *not* under the public ``/auth/`` prefix: everything below that
+prefix is reachable without a session (it is where sessions come from), and this
+endpoint must stay reachable only through nginx's ``internal`` auth locations.
+"""
+
+
+def _deny(user: str, reason: str) -> Response:
+    """Refuse, recording why for the log and nothing for the client.
+
+    Args:
+        user: The username the subrequest asked about, logged with ``%r`` so a
+            value carrying newlines cannot forge a log line.
+        reason: A fixed category string. Never interpolate a cookie, a tag or a
+            hash into it.
+
+    Returns:
+        A bare 401 — the same response for every reason, so the client cannot
+        tell an unknown user from a bad cookie.
+    """
+    logger.debug("verify denied for user %r: %s", user, reason)
+    return Response(status_code=401)
+
+
+@router.get(VERIFY_PATH)
+async def verify(
+    settings: Annotated[AuthSettings, Depends(get_settings)],
+    codec: Annotated[SessionCodec, Depends(get_session_codec)],
+    revocations: Annotated[RevocationStore, Depends(get_revocation_store)],
+    user: Annotated[list[str] | None, Query()] = None,
+    session_cookie: Annotated[str | None, Cookie(alias=SESSION_COOKIE_NAME)] = None,
+) -> Response:
+    """Authorize one ``auth_request`` subrequest for ``user``.
+
+    All four conditions must hold, and any one of them failing gives the same
+    answer:
+
+    1. the request names exactly one roster user;
+    2. the session cookie verifies, is not over-age, and is well-formed;
+    3. that user is in the cookie's unlocked set and has not passed its expiry;
+    4. the session id has not been revoked by a logout;
+
+    plus, in password mode, that the entry's credential-generation tag still
+    matches the digest of the user's *current* stored hash. That last check is
+    what makes ``osprey deploy passwd`` take effect immediately: rotating the
+    password changes the stored hash, so every session minted against the old
+    one stops verifying — without server-side session state, and surviving the
+    container recreate that rotation performs (which is also what clears the
+    revocation store).
+
+    The parameters are missing-tolerant on purpose. ``user`` defaults to absent
+    and the cookie to ``None`` rather than being required, because FastAPI would
+    otherwise answer a malformed subrequest with a 422 carrying a validation
+    body — a different status and a different shape from every other refusal,
+    which is both an information leak and something nginx would surface
+    differently.
+
+    ``user`` is read as a *list* so that a repeated parameter is refused rather
+    than resolved. A single-valued ``str`` would silently take the first value
+    and authorize against it, making the answer depend on which end of
+    ``?user=bob&user=alice`` the parser picks. nginx's exact-match ``internal``
+    locations cannot produce that query today — the username is a render-time
+    literal and the render gate rejects a roster name carrying ``&`` or ``?`` —
+    but this endpoint is the deployment's single authorization decision, and it
+    should not rest its safety on another layer's invariant holding forever.
+
+    Args:
+        settings: The deployment's frozen settings.
+        codec: The app's one session codec, which also holds the one clock every
+            expiry in the session path is stamped from and checked against.
+        revocations: The app's one revocation store, written by logout.
+        user: The roster username, supplied by nginx as a render-time literal.
+            Exactly one value authorizes; none and several are both refused.
+        session_cookie: The signed session cookie, if the browser sent one.
+
+    Returns:
+        An empty 200 when the request is authorized, a bare 401 otherwise.
+    """
+    requested = user or []
+    if len(requested) != 1:
+        # Zero values means something other than a rendered nginx location
+        # called this; several means the query was assembled by something that
+        # is not this deployment's nginx at all. The count goes in the log, the
+        # values never do — they are the one part of this request a client could
+        # have chosen.
+        return _deny("", f"expected exactly one user parameter, got {len(requested)}")
+
+    username = requested[0]
+    if not username:
+        return _deny(username, "empty user parameter")
+
+    if not settings.knows_user(username):
+        return _deny(username, "user is not on the roster")
+
+    if not session_cookie:
+        return _deny(username, "no session cookie")
+
+    try:
+        state = codec.decode(session_cookie)
+    except InvalidSessionError:
+        # Tampering, a malformed or unknown-version payload, and an over-age
+        # cookie are one case here: the cookie cannot be trusted, so there is no
+        # session. The exception's message stays out of the log — it is derived
+        # from the cookie the caller sent.
+        return _deny(username, "session cookie rejected")
+
+    now = codec.now()
+    if not state.is_unlocked(username, now):
+        # Covers both "this browser never unlocked that user" and "the entry
+        # lapsed": `decode` has already dropped expired entries.
+        return _deny(username, "user is not unlocked in this session")
+
+    if revocations.is_revoked(state.session_id):
+        return _deny(username, "session was revoked by a logout")
+
+    if settings.method != "oidc":
+        # Password mode. Written as "not OIDC" rather than "is password" so the
+        # stricter branch is the default one: the guard admits only the two
+        # supported methods, and anything else reaching here must get the tag
+        # check, not skip it.
+        #
+        # In OIDC mode the entry's tag is not consulted at all, whatever it
+        # holds. There is no stored hash to compare it against, and only a
+        # holder of the signing secret could have put a tag there in the first
+        # place — a session that survives that check has already proved more
+        # than the tag could.
+        stored = settings.password_hash(username)
+        if stored is None:
+            # A roster user with no provisioned credential. An individual
+            # denial, not a deployment-wide fault: the other users still
+            # authenticate, so this is a 401 rather than the guard's 503.
+            return _deny(username, "user has no stored credential")
+
+        entry = state.entry(username)
+        if entry is None or not verify_generation_tag(entry.generation_tag, stored):
+            # `is_unlocked` above means the entry exists; the check is here so
+            # the tag comparison cannot be reached with `None`. A tag that no
+            # longer matches means the password was rotated under this session.
+            return _deny(username, "credential generation tag does not match")
+
+    return Response(status_code=200)

--- a/src/osprey/services/auth_sidecar/sessions.py
+++ b/src/osprey/services/auth_sidecar/sessions.py
@@ -1,0 +1,376 @@
+"""Signed session cookies for the auth sidecar.
+
+One browser may hold several unlocked users at once, so a session is not "who am
+I" but "which roster users has this browser unlocked, and until when". That set
+lives in a single :mod:`itsdangerous`-signed cookie::
+
+    {"v": 1, "sid": "<session id>", "iat": <epoch>, "users": {
+        "alice": {"exp": <epoch>, "tag": "0123456789abcdef"}
+    }}
+
+**Signed, not encrypted.** Anyone holding the cookie can read the payload; they
+just cannot change it. Nothing secret may go in — in particular the stored
+password hash never does. Each password-mode entry carries only the
+credential-generation tag from :mod:`~osprey.services.auth_sidecar.passwords`, a
+one-way digest the verify endpoint recomputes from the current stored hash so a
+rotated password invalidates that user's sessions without server-side state.
+OIDC entries carry no tag (there is no stored hash), which is why
+:func:`~osprey.services.auth_sidecar.passwords.verify_generation_tag` refuses an
+empty tag: a password-mode session must never authorise without one.
+
+**The codec only signs and verifies.** Cookie attributes — ``SameSite=Lax``,
+``HttpOnly`` always, ``Secure`` under TLS — are the caller's to set on the
+response; this module never touches a request or response object.
+
+**Fail closed.** Constructing a codec without a signing secret raises rather than
+falling back to an unsigned or default-keyed cookie, so a misconfigured sidecar
+cannot start and hand out forgeable sessions. Decoding raises
+:class:`~osprey.services.auth_sidecar.exceptions.InvalidSessionError` for a
+bad signature, a malformed payload, an
+unknown payload version, or a cookie older than the permitted age, and silently
+drops entries that have passed their expiry — an expired user is never returned
+as unlocked even if a caller forgets to re-check the clock.
+
+Expiries are absolute epoch seconds, matching
+:class:`~osprey.services.auth_sidecar.revocation.RevocationStore`, so a session's
+expiry can be passed straight from one to the other.
+"""
+
+from __future__ import annotations
+
+import secrets
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+from itsdangerous import BadSignature, URLSafeSerializer
+
+from .exceptions import InvalidSessionError
+
+__all__ = [
+    "PAYLOAD_VERSION",
+    "SESSION_COOKIE_NAME",
+    "SIGNATURE_SALT",
+    "SessionCodec",
+    "SessionState",
+    "UnlockedUser",
+]
+
+PAYLOAD_VERSION = 1
+"""Version stamped into every payload; decoding rejects any other value.
+
+A deployment that keeps its signing secret across an upgrade would otherwise
+have old cookies deserialise into a new payload shape. Bumping this retires
+every outstanding session instead.
+"""
+
+SESSION_COOKIE_NAME = "osprey_auth_session"
+"""Cookie name the sidecar's routes use for the session.
+
+Defined here so the login, logout, verify and OIDC routes agree on one name.
+The codec itself never reads or writes a cookie.
+"""
+
+SIGNATURE_SALT = "osprey-auth-session"
+"""Namespacing salt for the signature.
+
+Keeps session signatures distinct from any other value signed with the same
+secret, so a token minted for one purpose cannot be replayed as another.
+"""
+
+SESSION_ID_BYTES = 16
+"""Entropy drawn for a new session id."""
+
+
+@dataclass(frozen=True, slots=True)
+class UnlockedUser:
+    """One roster user this browser has unlocked.
+
+    Attributes:
+        username: The roster username, exactly as it appears in ``/u/<user>/``.
+        expires_at: Absolute epoch seconds after which this entry no longer
+            authorises, whatever the rest of the session's state.
+        generation_tag: The credential-generation tag from
+            :func:`~osprey.services.auth_sidecar.passwords.generation_tag`, or
+            ``""`` for an OIDC entry, which has no stored hash behind it.
+    """
+
+    username: str
+    expires_at: float
+    generation_tag: str = ""
+
+    def is_expired(self, now: float) -> bool:
+        """Whether this entry has reached its expiry at ``now``."""
+        return now >= self.expires_at
+
+
+@dataclass(frozen=True, slots=True)
+class SessionState:
+    """The decoded contents of one session cookie.
+
+    Immutable: :meth:`with_user` and :meth:`without_user` return a new state
+    rather than mutating this one, so a route that re-issues a cookie cannot
+    accidentally leave the old state half-updated on an error path.
+
+    Attributes:
+        session_id: Stable across logins and logouts within one browser session;
+            this is the id the revocation store records at logout.
+        issued_at: Absolute epoch seconds when the session id was minted. Bounds
+            the whole session's life independently of any single user's expiry.
+        users: The unlocked-user entries, in the order they were added.
+    """
+
+    session_id: str
+    issued_at: float
+    users: tuple[UnlockedUser, ...] = field(default=())
+
+    @classmethod
+    def new(cls, now: float) -> SessionState:
+        """Start an empty session with a freshly minted id.
+
+        Args:
+            now: Current time as absolute epoch seconds.
+        """
+        return cls(session_id=secrets.token_urlsafe(SESSION_ID_BYTES), issued_at=now, users=())
+
+    def entry(self, username: str) -> UnlockedUser | None:
+        """The entry for ``username``, or ``None`` if this session has none.
+
+        Returns the entry whether or not it has expired; the caller that needs
+        the generation tag also needs to know an expired entry exists. Use
+        :meth:`is_unlocked` for the authorisation question.
+        """
+        for user in self.users:
+            if user.username == username:
+                return user
+        return None
+
+    def is_unlocked(self, username: str, now: float) -> bool:
+        """Whether ``username`` is unlocked and unexpired at ``now``.
+
+        This is the session's half of the verify decision. The generation tag
+        and the revocation list are checked separately by the verify route,
+        which has the stored hash and the store.
+
+        Args:
+            username: The roster user the request is for.
+            now: Current time as absolute epoch seconds.
+        """
+        entry = self.entry(username)
+        return entry is not None and not entry.is_expired(now)
+
+    def unlocked_usernames(self, now: float) -> tuple[str, ...]:
+        """Every username unlocked and unexpired at ``now``, in insertion order."""
+        return tuple(user.username for user in self.users if not user.is_expired(now))
+
+    def with_user(
+        self, username: str, *, expires_at: float, generation_tag: str = ""
+    ) -> SessionState:
+        """Return this state with ``username`` unlocked until ``expires_at``.
+
+        Re-adding a user replaces that entry in place — a fresh login refreshes
+        the expiry and the tag without disturbing the order of the others.
+
+        Args:
+            username: The roster user being unlocked.
+            expires_at: Absolute epoch seconds at which the entry lapses.
+            generation_tag: The credential-generation tag in password mode;
+                omitted for OIDC.
+
+        Raises:
+            ValueError: If ``username`` is empty.
+        """
+        if not username:
+            raise ValueError("username must not be empty")
+
+        entry = UnlockedUser(
+            username=username, expires_at=float(expires_at), generation_tag=generation_tag
+        )
+        if self.entry(username) is None:
+            return replace(self, users=(*self.users, entry))
+        return replace(
+            self,
+            users=tuple(entry if user.username == username else user for user in self.users),
+        )
+
+    def without_user(self, username: str) -> SessionState:
+        """Return this state with ``username`` locked again.
+
+        This is logout: the other unlocked users survive, and the session id is
+        unchanged so the revocation store can retire the old cookie by id.
+        """
+        return replace(self, users=tuple(user for user in self.users if user.username != username))
+
+    def prune_expired(self, now: float) -> SessionState:
+        """Return this state with every entry that has passed its expiry dropped."""
+        return replace(self, users=tuple(user for user in self.users if not user.is_expired(now)))
+
+
+def _as_epoch(value: Any, field_name: str) -> float:
+    """Read a payload field as absolute epoch seconds.
+
+    Raises:
+        InvalidSessionError: If the value is not a real number.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise InvalidSessionError(f"session payload field {field_name!r} is not a timestamp")
+    return float(value)
+
+
+class SessionCodec:
+    """Signs and verifies :class:`SessionState` payloads.
+
+    The codec holds the only clock in the session path: the issued-at stamp is
+    written from it and the maximum-age check reads it back, so tests advance
+    time instead of sleeping. ``itsdangerous``' own timed serializer is
+    deliberately not used — its timestamp comes from the real wall clock and
+    could not be injected.
+    """
+
+    def __init__(
+        self,
+        secret: str,
+        *,
+        max_age: float | None = None,
+        clock: Callable[[], float] = time.time,
+        salt: str = SIGNATURE_SALT,
+    ) -> None:
+        """Create a codec.
+
+        Args:
+            secret: The signing secret, typically ``OSPREY_AUTH_SESSION_SECRET``.
+            max_age: Maximum age in seconds for a cookie, measured from its
+                issued-at stamp. ``None`` bounds the session only by its
+                per-user expiries; deployments pass ``auth.session_lifetime``.
+            clock: Returns the current time as absolute epoch seconds.
+            salt: Signature namespacing salt.
+
+        Raises:
+            ValueError: If ``secret`` is unset, empty or only whitespace. The
+                sidecar fails to start rather than issuing forgeable cookies.
+        """
+        if not secret or not secret.strip():
+            raise ValueError("session signing secret is unset; refusing to issue session cookies")
+        if max_age is not None and max_age <= 0:
+            raise ValueError("max_age must be positive when set")
+
+        self._clock = clock
+        self._max_age = max_age
+        self._serializer = URLSafeSerializer(secret, salt=salt)
+
+    def now(self) -> float:
+        """Current time as absolute epoch seconds, from the injected clock.
+
+        Exposed so routes stamp expiries from the same clock the codec checks
+        them against.
+        """
+        return self._clock()
+
+    def new_state(self) -> SessionState:
+        """Start an empty session, stamped with this codec's clock."""
+        return SessionState.new(self._clock())
+
+    def encode(self, state: SessionState) -> str:
+        """Sign ``state`` into the cookie value.
+
+        Args:
+            state: The session to serialise. Its ``issued_at`` is preserved, so
+                re-issuing a cookie after a login or logout does not extend the
+                session's overall age.
+
+        Returns:
+            A URL-safe signed string for the caller to set as a cookie value.
+        """
+        payload = {
+            "v": PAYLOAD_VERSION,
+            "sid": state.session_id,
+            "iat": state.issued_at,
+            "users": {
+                user.username: {"exp": user.expires_at, "tag": user.generation_tag}
+                for user in state.users
+            },
+        }
+        return self._serializer.dumps(payload)
+
+    def decode(self, raw: str, *, max_age: float | None = None) -> SessionState:
+        """Verify a cookie value and return the session it carries.
+
+        Entries that have passed their expiry are dropped from the result, so an
+        expired user cannot be authorised even by a caller that skips the clock
+        check. An empty result is normal and not an error: it is what a session
+        looks like after its last user logs out.
+
+        Args:
+            raw: The cookie value as received.
+            max_age: Overrides the codec's maximum age for this call.
+
+        Returns:
+            The decoded state, with expired entries removed.
+
+        Raises:
+            InvalidSessionError: If the signature does not verify, the payload
+                is malformed or of an unknown version, or the cookie is older
+                than the permitted age.
+        """
+        if not raw:
+            raise InvalidSessionError("session cookie is empty")
+
+        try:
+            payload = self._serializer.loads(raw)
+        except BadSignature as exc:
+            raise InvalidSessionError("session cookie failed signature verification") from exc
+
+        if not isinstance(payload, dict):
+            raise InvalidSessionError("session payload is not an object")
+
+        version = payload.get("v")
+        if version != PAYLOAD_VERSION:
+            raise InvalidSessionError(f"unsupported session payload version: {version!r}")
+
+        session_id = payload.get("sid")
+        if not isinstance(session_id, str) or not session_id:
+            raise InvalidSessionError("session payload carries no session id")
+
+        issued_at = _as_epoch(payload.get("iat"), "iat")
+        effective_max_age = self._max_age if max_age is None else max_age
+        now = self._clock()
+        if effective_max_age is not None and now - issued_at > effective_max_age:
+            raise InvalidSessionError("session cookie is older than the maximum session age")
+
+        state = SessionState(
+            session_id=session_id,
+            issued_at=issued_at,
+            users=self._decode_users(payload.get("users")),
+        )
+        return state.prune_expired(now)
+
+    @staticmethod
+    def _decode_users(raw_users: Any) -> tuple[UnlockedUser, ...]:
+        """Read the unlocked-user map out of a verified payload.
+
+        Raises:
+            InvalidSessionError: If the map or any entry is malformed.
+        """
+        if raw_users is None:
+            return ()
+        if not isinstance(raw_users, dict):
+            raise InvalidSessionError("session payload 'users' is not an object")
+
+        users = []
+        for username, entry in raw_users.items():
+            if not isinstance(username, str) or not username:
+                raise InvalidSessionError("session payload carries an empty username")
+            if not isinstance(entry, dict):
+                raise InvalidSessionError(f"session entry for {username!r} is not an object")
+            tag = entry.get("tag", "")
+            if not isinstance(tag, str):
+                raise InvalidSessionError(f"session entry for {username!r} has a non-string tag")
+            users.append(
+                UnlockedUser(
+                    username=username,
+                    expires_at=_as_epoch(entry.get("exp"), f"users[{username}].exp"),
+                    generation_tag=tag,
+                )
+            )
+        return tuple(users)

--- a/src/osprey/services/auth_sidecar/templates/login.html
+++ b/src/osprey/services/auth_sidecar/templates/login.html
@@ -1,0 +1,186 @@
+{#
+  login.html — password prompt for one roster user.
+
+  Rendered by routes/login.py (Jinja2, autoescape ON) and served through nginx's
+  public `/auth/` location. Self-contained by necessity: the sidecar is its own
+  container with no static-asset mount and no stylesheet to link, and this page
+  must render on a deployment whose every other URL is behind the session it
+  exists to create. So the CSS is inline and the palette is baked in.
+
+  Template variables (contract with routes/login.py):
+
+    user: str, required
+      The roster user whose card was clicked. Shown in the prompt and carried in
+      a hidden field — there is NO username input on this page, because the page
+      is addressed per user and typing a different name here would only produce
+      a login the server refuses.
+
+    next: str, required
+      The validated same-origin return-to. Already checked by
+      `_safe_return_to()`; re-checked on POST, since a hidden field is client
+      input like any other.
+
+    error: str | None
+      A message to show above the form. One fixed string for every refusal — an
+      unknown user and a wrong password produce the identical page.
+
+    login_path: str, required
+      Where the form posts. Comes from the route module's own constant so the
+      path is defined once.
+
+    theme_blocks: list[dict], possibly empty
+      Design-system token values to bake into the stylesheet, in the same shape
+      the landing page uses: {"media": str | None, "color_scheme": str,
+      "variables": [(name, value), ...]}. NOT `|e`-escaped — these are CSS, not
+      HTML, and escaping would corrupt values (`rgba(0, 0, 0, .4)`) while doing
+      nothing about the only real hazard in a <style>, which the route guards
+      against by pattern-checking every value instead.
+
+      The list may be empty when the token tree cannot be read. Every `var()`
+      below therefore carries a literal fallback, so a page with no token block
+      still renders in the framework's default dark palette rather than
+      unstyled.
+#}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex, nofollow">
+  <title>Sign in &mdash; {{ user|e }}</title>
+  <style>
+    {%- for block in theme_blocks %}
+    {%- set pad = "  " if block["media"] else "" %}
+    {%- if block["media"] %}
+    @media {{ block["media"] }} {
+    {%- endif %}
+    {{ pad }}:root {
+    {{ pad }}  color-scheme: {{ block["color_scheme"] }};
+    {%- for name, value in block["variables"] %}
+    {{ pad }}  {{ name }}: {{ value }};
+    {%- endfor %}
+    {{ pad }}}
+    {%- if block["media"] %}
+    }
+    {%- endif %}
+    {%- endfor %}
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1.5rem;
+      background: var(--bg-primary, #111217);
+      color: var(--text-primary, #ccccdc);
+      font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    }
+    .login-card {
+      width: 100%;
+      max-width: 26rem;
+      padding: 2rem;
+      border: 1px solid var(--border-default, #2c3235);
+      border-radius: 10px;
+      background: var(--bg-panel, #181b1f);
+      box-shadow: var(--shadow-dropdown, 0 8px 24px rgba(0, 0, 0, 0.4));
+    }
+    .login-mark {
+      margin: 0 0 1.5rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--text-muted, #6e6e77);
+    }
+    .login-prompt {
+      margin: 0 0 0.35rem;
+      font-size: 1.25rem;
+      font-weight: 500;
+      line-height: 1.35;
+    }
+    .login-user {
+      color: var(--color-accent, #6e9fff);
+      overflow-wrap: anywhere;
+    }
+    .login-hint {
+      margin: 0 0 1.5rem;
+      font-size: 0.875rem;
+      color: var(--text-secondary, #8e8e9a);
+    }
+    .login-error {
+      margin: 0 0 1.25rem;
+      padding: 0.7rem 0.85rem;
+      border: 1px solid var(--color-error, #e05454);
+      border-radius: 6px;
+      font-size: 0.875rem;
+      color: var(--color-error, #e05454);
+      background: var(--bg-elevated, #22252b);
+    }
+    .login-label {
+      display: block;
+      margin-bottom: 0.4rem;
+      font-size: 0.8125rem;
+      color: var(--text-secondary, #8e8e9a);
+    }
+    .login-input {
+      width: 100%;
+      padding: 0.65rem 0.75rem;
+      border: 1px solid var(--border-default, #2c3235);
+      border-radius: 6px;
+      background: var(--bg-elevated, #22252b);
+      color: var(--text-primary, #ccccdc);
+      font-family: inherit;
+      font-size: 1rem;
+    }
+    .login-input:focus {
+      outline: none;
+      border-color: var(--color-accent, #6e9fff);
+      box-shadow: 0 0 0 3px var(--border-accent, rgba(110, 159, 255, 0.15));
+    }
+    .login-submit {
+      width: 100%;
+      margin-top: 1.25rem;
+      padding: 0.7rem 1rem;
+      border: 1px solid var(--color-accent, #6e9fff);
+      border-radius: 6px;
+      background: var(--color-accent, #6e9fff);
+      color: var(--bg-primary, #111217);
+      font-family: inherit;
+      font-size: 0.9375rem;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    .login-submit:hover { filter: brightness(1.08); }
+    .login-back {
+      display: block;
+      margin-top: 1.5rem;
+      font-size: 0.8125rem;
+      color: var(--text-muted, #6e6e77);
+    }
+    .login-back:hover { color: var(--color-accent, #6e9fff); }
+  </style>
+</head>
+<body>
+  <main class="login-card">
+    <p class="login-mark">OSPREY</p>
+    {#- The acceptance gate: the username is stated, never asked for. #}
+    <h1 class="login-prompt">Enter password for <span class="login-user">{{ user|e }}</span></h1>
+    <p class="login-hint">You are signing in to this terminal only.</p>
+    {%- if error %}
+    <p class="login-error" role="alert">{{ error|e }}</p>
+    {%- endif %}
+    <form method="post" action="{{ login_path|e }}">
+      {#- Hidden, not editable: the page is addressed per user, and the server
+          re-validates both values on arrival. #}
+      <input type="hidden" name="user" value="{{ user|e }}">
+      <input type="hidden" name="next" value="{{ next|e }}">
+      <label class="login-label" for="password">Password</label>
+      <input class="login-input" id="password" name="password" type="password"
+             autocomplete="current-password" autofocus required>
+      <button class="login-submit" type="submit">Unlock terminal</button>
+    </form>
+    <a class="login-back" href="/">&larr; Choose a different user</a>
+  </main>
+</body>
+</html>

--- a/src/osprey/services/auth_sidecar/throttle.py
+++ b/src/osprey/services/auth_sidecar/throttle.py
@@ -1,0 +1,189 @@
+"""Per-user brute-force throttle for the login route.
+
+Each roster user carries one "next allowed attempt" timestamp. An attempt that
+arrives before it is refused outright — the caller returns 429 and never touches
+the stored credential. That ordering is the whole point: rejecting *before*
+evaluation makes parallel guessing throughput-bounded rather than merely
+latency-delayed, because a hundred concurrent requests cost the sidecar a dict
+lookup each instead of a hundred scrypt derivations.
+
+The window grows on each failed attempt (1s, 2s, 4s, … capped at 30s) and is
+dropped entirely on success, so an operator who mistypes once pays a second and
+an operator who types correctly pays nothing.
+
+**No lockout, ever.** A control-room operator must never be shut out of the
+terminals, so there is no failure count that latches. The window only ever
+delays the next attempt, and it decays: a user quiet for ``forget_after`` seconds
+is forgotten and starts again at ``initial_delay``. That also bounds memory,
+since the login route keys on a requested username.
+
+Framework-free on purpose — the login route maps :meth:`AttemptThrottle.retry_after`
+onto the 429 and its ``Retry-After`` header. Time is injectable so tests need not
+sleep.
+
+Typical wiring::
+
+    delay = throttle.retry_after(user)
+    if delay > 0:
+        return plain_429(retry_after=math.ceil(delay))   # no credential check
+    if verify_password(user, submitted):
+        throttle.record_success(user)
+        ...
+    else:
+        throttle.record_failure(user)
+        ...
+
+A refused attempt must not call :meth:`record_failure`; only attempts that were
+actually evaluated grow the window. Otherwise a flood of parallel requests would
+ratchet the window against a legitimate operator, which is the lockout this
+module exists to avoid.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+__all__ = ["AttemptThrottle"]
+
+_DEFAULT_INITIAL_DELAY = 1.0
+_DEFAULT_MULTIPLIER = 2.0
+_DEFAULT_MAX_DELAY = 30.0
+_DEFAULT_FORGET_AFTER = 300.0
+
+
+@dataclass(slots=True)
+class _UserState:
+    """One user's current window: how long it is, and when it lifts."""
+
+    delay: float
+    next_allowed_at: float
+
+
+class AttemptThrottle:
+    """Tracks the next allowed login attempt per user.
+
+    Times are durations from an arbitrary origin (``time.monotonic`` by default),
+    never wall-clock instants, so a clock step cannot open or extend a window.
+
+    Not thread-safe on its own; the sidecar's async request handlers touch it from
+    a single event loop, and every method completes without awaiting.
+    """
+
+    def __init__(
+        self,
+        *,
+        initial_delay: float = _DEFAULT_INITIAL_DELAY,
+        multiplier: float = _DEFAULT_MULTIPLIER,
+        max_delay: float = _DEFAULT_MAX_DELAY,
+        forget_after: float = _DEFAULT_FORGET_AFTER,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        """Create an empty throttle.
+
+        Args:
+            initial_delay: Window after the first failed attempt, in seconds.
+            multiplier: Factor the window grows by on each further failure.
+            max_delay: Ceiling on the window, in seconds. The cap is what bounds
+                guessing throughput; it is deliberately low enough that a locked-out
+                operator is never more than this many seconds from retrying.
+            forget_after: Seconds of quiet, measured past the moment the window
+                lifted, after which the user's escalation is discarded.
+            clock: Returns a monotonically increasing seconds value. Injectable so
+                tests can advance time without sleeping.
+
+        Raises:
+            ValueError: If the parameters could not produce a growing, capped
+                window (non-positive delays, a multiplier below 1, or a cap below
+                the initial delay).
+        """
+        if initial_delay <= 0:
+            raise ValueError(f"initial_delay must be positive, got {initial_delay}")
+        if multiplier < 1:
+            raise ValueError(f"multiplier must be at least 1, got {multiplier}")
+        if max_delay < initial_delay:
+            raise ValueError(
+                f"max_delay ({max_delay}) must be at least initial_delay ({initial_delay})"
+            )
+        if forget_after < 0:
+            raise ValueError(f"forget_after must not be negative, got {forget_after}")
+
+        self._initial_delay = initial_delay
+        self._multiplier = multiplier
+        self._max_delay = max_delay
+        self._forget_after = forget_after
+        self._clock = clock
+        self._states: dict[str, _UserState] = {}
+
+    @property
+    def max_delay(self) -> float:
+        """The window ceiling, in seconds — what bounds guessing throughput."""
+        return self._max_delay
+
+    def retry_after(self, user: str) -> float:
+        """Seconds the caller must refuse ``user`` for; ``0.0`` when an attempt is allowed.
+
+        A pure query: it never grows the window, so parallel requests arriving
+        inside one window cannot ratchet it. Call it before evaluating any
+        credential, and return 429 with this value (rounded up) as ``Retry-After``
+        when it is positive.
+        """
+        state = self._states.get(user)
+        if state is None:
+            return 0.0
+        remaining = state.next_allowed_at - self._clock()
+        return remaining if remaining > 0 else 0.0
+
+    def record_failure(self, user: str) -> float:
+        """Record an evaluated attempt that failed and open the next window.
+
+        The window is ``initial_delay`` on the first failure and grows by
+        ``multiplier`` on each subsequent one, capped at ``max_delay``.
+
+        Args:
+            user: The roster user whose attempt failed.
+
+        Returns:
+            The length of the window just opened, in seconds.
+        """
+        self.purge_stale()
+        now = self._clock()
+        state = self._states.get(user)
+        if state is None:
+            delay = self._initial_delay
+        else:
+            delay = min(state.delay * self._multiplier, self._max_delay)
+        self._states[user] = _UserState(delay=delay, next_allowed_at=now + delay)
+        return delay
+
+    def record_success(self, user: str) -> None:
+        """Clear ``user``'s window after a successful login.
+
+        A no-op for a user with no recorded failures.
+        """
+        self._states.pop(user, None)
+
+    def purge_stale(self) -> int:
+        """Forget users whose window lifted more than ``forget_after`` seconds ago.
+
+        Called on each :meth:`record_failure`, which is what keeps the throttle
+        bounded by recently-active users rather than by every username ever asked
+        for. Exposed so a caller can sweep on its own schedule.
+
+        Returns:
+            How many users were forgotten.
+        """
+        cutoff = self._clock() - self._forget_after
+        stale = [user for user, state in self._states.items() if state.next_allowed_at <= cutoff]
+        for user in stale:
+            del self._states[user]
+        return len(stale)
+
+    def clear(self) -> None:
+        """Forget every user's window — equivalent to what a container restart does."""
+        self._states.clear()
+
+    def __len__(self) -> int:
+        """How many users are being tracked, including any not yet swept."""
+        return len(self._states)

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -1110,4 +1110,4 @@ web:
 #       family; families left unset fall back to the registry defaults.
 #
 # See the deploy skill's facility-config reference and
-# docs/how-to/web-terminal/multi-user.rst for the full schema.
+# docs/how-to/multi-user.rst for the full schema.

--- a/src/osprey/templates/modules/web_terminals/auth_sidecar/.dockerignore
+++ b/src/osprey/templates/modules/web_terminals/auth_sidecar/.dockerignore
@@ -1,0 +1,22 @@
+# Build-context hygiene for the auth-sidecar image.
+#
+# The Dockerfile needs only the locally-built osprey wheel (*.whl) and, on dev
+# builds, the staged osprey-local-requirements.txt. It is also COPYed itself as
+# the guaranteed sibling that keeps those optional globs matching.
+#
+# Nothing else belongs in this context, and one exclusion is load-bearing rather
+# than cosmetic: the sidecar's credentials live in `.env.auth` at the project
+# root and are delivered at RUNTIME through compose `env_file`. A secret baked
+# into an image layer would survive every rotation and travel with the tag.
+**/__pycache__/
+*.pyc
+.git/
+.env
+.env.auth
+.env.production
+# Compose files + templates are runtime/deploy artifacts, not image inputs.
+docker-compose.yml
+docker-compose.web.yml
+*.j2
+# Bind-mounted or read at runtime; must not be baked into the image.
+config.yml

--- a/src/osprey/templates/modules/web_terminals/auth_sidecar/Dockerfile
+++ b/src/osprey/templates/modules/web_terminals/auth_sidecar/Dockerfile
@@ -1,0 +1,97 @@
+# Image for the web-terminal auth sidecar (osprey.services.auth_sidecar): the
+# FastAPI process that answers nginx `auth_request` subrequests for every
+# `/u/<user>/` location and serves the login flow.
+#
+# NO ENTRYPOINT, deliberately: the rendered docker-compose.web.yml supplies the
+# FULL uvicorn argv via `command:`, so anything prepended here would either
+# swallow those arguments or duplicate them. The healthcheck in that same file
+# is the in-image python-urllib probe every other OSPREY service uses, so both
+# `python` and `uvicorn` must stay on PATH — the base image provides the first
+# and the framework install below provides the second.
+#
+# osprey install strategy (two cache-friendly layers):
+#   * deps layer  — primes the pinned framework release (+ its dependencies)
+#     from PyPI in one RUN. The framework's core FastAPI/uvicorn/authlib/
+#     itsdangerous deps cover everything this sidecar needs, so a plain prime
+#     suffices — plus any local dependency delta staged as
+#     osprey-local-requirements.txt on dev builds. Its build cache is shared
+#     across projects and only rebuilds when the staged manifest changes.
+#   * wheel layer — when `osprey deploy up --dev` stages a locally-built wheel
+#     into the build context, this later layer overlays it (so unreleased code
+#     is included). With no wheel staged it is a no-op.
+# This image is built locally by `osprey deploy up` in `image_source: local`
+# mode; a registry-mode deployment sets modules.web_terminals.auth.image to a
+# published image instead, and publishing that image is the facility CI's job.
+#
+# WHY THIS LIVES UNDER templates/modules/ AND NOT templates/services/: that tree
+# is catalog-bound — every directory in it must be a registered BuildArtifactCatalog
+# entry copied into rendered projects, and `_copy_service_templates` only copies
+# services a project names in `deployed_services` or declares under `services:`.
+# The sidecar is a member of the web-terminals stack, not a service a project
+# declares, so an entry there would never be acted on. Do not "tidy" this back.
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Debian apt mirrors over HTTPS (plain-HTTP bulk fetches are throttled or
+# broken by middleboxes on some networks; deb.debian.org supports HTTPS), and
+# bounded apt retries with backoff so a transient network blip mid-build does
+# not fail the whole image.
+RUN find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
+    -exec sed -i 's|http://deb.debian.org|https://deb.debian.org|g' {} + \
+ && printf 'Acquire::Retries "5";\n' > /etc/apt/apt.conf.d/80-osprey-retries
+
+# ── deps layer ───────────────────────────────────────────────────────────────
+# Prime the image with the pinned framework release and its dependencies. A C
+# toolchain is needed at install time to compile any native deps; it is purged
+# in this same RUN so it does not bloat the final image. Under `--dev` an
+# unreleased pin may not exist on PyPI: OSPREY_DEV=1 relaxes the failure to an
+# unpinned prime (the wheel layer below then overlays the real code); without it
+# a pin miss stays fatal. Any local dependency delta staged as
+# osprey-local-requirements.txt (dev builds only) is installed after the primer,
+# while the toolchain is still available; the `.dockerignore` COPY sibling keeps
+# the glob matching when no manifest is staged, so this cache only busts when
+# the manifest content changes.
+ARG OSPREY_VERSION=""
+ARG OSPREY_DEV=""
+COPY .dockerignore osprey-local-requirements.tx[t] /tmp/deps-ctx/
+RUN [ -n "$OSPREY_VERSION" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; } \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends build-essential python3-dev \
+    && { pip install --no-cache-dir "osprey-framework==$OSPREY_VERSION" \
+         || if [ "$OSPREY_DEV" = "1" ]; then \
+                echo "WARNING: pin unreleased, priming with latest" \
+                && pip install --no-cache-dir "osprey-framework" ; \
+            else \
+                exit 1 ; \
+            fi ; } \
+    && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then \
+           pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ; \
+       fi \
+    && apt-get purge -y build-essential python3-dev \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+
+# ── wheel layer ──────────────────────────────────────────────────────────────
+# Overlay a locally-built wheel when `osprey deploy up --dev` stages one into
+# the build context. `.dockerignore` is a guaranteed sibling of the COPY, so
+# the glob always matches at least one file; `*.wh[l]` optionally pulls in the
+# wheel. The wheel is installed plain (no extra — the deps layer already primed
+# every extra), then force-reinstalled --no-deps to guarantee its own modules
+# win, and `pip check` guards against residual mismatches. No wheel staged →
+# no-op, image already complete after the deps layer.
+COPY .dockerignore *.wh[l] /tmp/ctx/
+RUN if ls /tmp/ctx/*.whl >/dev/null 2>&1; then \
+        echo "Overlaying locally-built osprey wheel (dev build)" \
+        && pip install --no-cache-dir /tmp/ctx/*.whl \
+        && pip install --no-cache-dir --no-deps --force-reinstall /tmp/ctx/*.whl \
+        && pip check ; \
+    fi \
+    && rm -rf /tmp/ctx
+
+# Project metadata, kept as the final metadata-only layer so the shared deps
+# cache chain above stays identical across projects (a per-project value here
+# never invalidates the framework install below it).
+ARG OSPREY_PROJECT_NAME=""
+LABEL com.osprey.project=$OSPREY_PROJECT_NAME

--- a/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
+++ b/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
@@ -83,11 +83,83 @@
     nginx_image: str, optional, default "nginx:1.27-alpine"
     facility_timezone: str, optional, default "UTC" -> TZ
 
+    AUTH SIDECAR (all from render.py's `_auth_tls_context()`, the single parser
+    of `modules.web_terminals.auth`/`tls` — this template re-parses nothing):
+
+    auth_method: str, required ("none" | "password" | "oidc")
+      "none" (the default posture) renders NO `auth:` service at all — the
+      whole block below is suppressed, byte for byte, so every deployment that
+      has not opted into authentication keeps the compose overlay it has today.
+    auth_port: int, required
+      Host port the sidecar's uvicorn binds — on `bind_host` only, exactly like
+      the per-user apps. nginx (same host netns) is the only thing that reaches
+      it; `auth_request` subrequests and the `/auth/*` login flow both proxy
+      there. Joined into lint's port-collision check against the per-user
+      families, so this port is guaranteed not to be some user's panel port.
+    auth_session_lifetime: int, required (seconds) -> OSPREY_AUTH_SESSION_LIFETIME
+    auth_image: str | None
+      Registry-mode image for the sidecar. When unset, the local-build tag
+      `<facility_prefix>-assistant-auth:local` is referenced instead — the
+      persona-image pattern (`<project>-<persona>:local`, personas.py) applied
+      to the sidecar, whose `<project>` is resolve_personas()'s default
+      `<facility_prefix>-assistant`. Producing that image is the runtime build's
+      job; this template only names the tag.
+    auth_oidc_issuer: str | None, auth_oidc_client_id_env / auth_oidc_client_secret_env: str
+      Emitted only in `oidc` mode. The two `*_env` values are env-var NAMES, not
+      credentials: the sidecar reads the named variable out of its `.env.auth`
+      environment (one level of indirection, so a facility keeps its own
+      variable names). No credential is ever rendered here.
+    auth_oidc_claim: str | None
+      Which ID-token claim carries the identity to map onto a roster user.
+      `None` (the common case) emits NO env line, leaving the sidecar's own
+      documented default — so the default is defined once, in the sidecar,
+      rather than restated here.
+    services[].oidc_subject: str, optional — this user's expected IdP identity
+      (the non-secret half of the roster->identity mapping; the credential half
+      lives in `.env.auth`, keyed by the same suffix). Resolved from the roster
+      by resolve_personas() and carried through render.py's per-service dicts
+      like `display_name`/`theme`.
+    services[].oidc_subject_env: str — the env-var name the above is emitted
+      under, pre-resolved by render.py through personas.env_var_suffix(). Always
+      present; read only when `oidc_subject` is set. Pre-resolved on purpose:
+      the username->env-var mapping has exactly one definition, and a template
+      that re-derived it could key a subject differently from the password hash
+      keyed by the same user.
+    external_origin: str -> OSPREY_AUTH_EXTERNAL_ORIGIN
+      The one origin browsers reach nginx on; the OIDC `redirect_uri` is built
+      from it. Same derivation the landing link uses (render.py::_external_origin).
+    tls_enabled: bool -> OSPREY_AUTH_TLS_ENABLED
+      Whether that origin is HTTPS. The sidecar terminates no TLS itself (nginx
+      does) — this only decides the `Secure` attribute on the cookies it issues,
+      which is why no cert/key is mounted into this service.
+
     bind_host: str, required (Task 1.1)
       Loopback address (always "127.0.0.1") baked into every per-user
-      service's OSPREY_TERMINAL_BIND_HOST. Not sourced from facility-config
-      — see render.py's `_LOOPBACK_BIND_HOST` for why this is a constant,
-      not a knob.
+      service's OSPREY_TERMINAL_BIND_HOST — and into the auth sidecar's own
+      uvicorn bind. Not sourced from facility-config — see render.py's
+      `_LOOPBACK_BIND_HOST` for why this is a constant, not a knob.
+
+  ----------------------------------------------------------------------------
+  SECRETS ISOLATION (the reason for the auth service's env_file/environment split)
+
+  The sidecar's `env_file` is `.env.auth` (0600, project root, written by
+  auth_credentials.ensure_auth_credentials) and NOTHING ELSE. Two rules, both
+  load-bearing:
+
+  1. `.env.auth` is never given to a `web-*` service. Those containers run the
+     agent; the session signing key in `.env.auth` would let any user's agent
+     mint a valid cookie for every other user, which is precisely the isolation
+     this feature exists to establish. The inverse also holds: the sidecar never
+     reads `.env.production` — the per-user containers' shared env file — so no
+     provider key or facility credential is in reach of the login surface.
+  2. Secrets travel ONLY as `env_file` entries, never as `environment:` values.
+     Compose passes a service-level `env_file` value through literally, while
+     an `environment:` value goes through `${...}` interpolation — and a stored
+     scrypt hash (`scrypt$16384$8$1$salt$key`) is full of `$`, which
+     interpolation would eat. Non-secret settings (method, lifetime, roster,
+     origin, OIDC issuer and per-user subject mapping) come from the template
+     variables above and are safe in `environment:`; anything secret stays in
+     the file.
 
   ----------------------------------------------------------------------------
   NETWORKING
@@ -137,6 +209,86 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
+{#- The auth sidecar. Whitespace control on this `if` (and its `endif`) is what
+   keeps the `auth.method: none` render byte-identical to the pre-auth overlay:
+   with the block suppressed, the `{%- if %}` swallows the newline it would
+   otherwise leave behind and the `endif` line's own newline restores the one
+   that ended `start_period: 10s`. Service key "auth" cannot collide with a
+   roster user — users render as `web-<user>` — nor with nginx or any base
+   docker-compose.yml service. #}
+{%- if auth_method != "none" %}
+
+  auth:
+    {#- Registry mode pins `auth.image`; local mode leaves it unset and the
+       runtime build produces this tag (see AUTH SIDECAR contract above). A
+       registry-mode deployment that forgot `auth.image` is caught by the
+       deploy preflight, not by silently building here. #}
+    image: {{ auth_image | default(facility_prefix ~ "-assistant-auth:local", true) }}
+    container_name: {{ facility_prefix }}-auth
+    restart: unless-stopped
+    network_mode: host
+    {#- Single process, deliberately: the revocation list and the brute-force
+       throttle are in-memory, so a second worker would answer with a different
+       view of both. Bound to `bind_host` for the same reason the per-user apps
+       are — nginx shares this host netns and is the only intended caller, and
+       the login surface must not be reachable off-host on its own port. `curl`
+       is not in an OSPREY service image, so the probe is the in-image python
+       one every other OSPREY service uses; /health answers 200 even when the
+       sidecar is unconfigured and refusing everything, so the container stays
+       up to explain itself rather than crash-looping. #}
+    command: ["uvicorn", "osprey.services.auth_sidecar.app:create_app", "--factory", "--host", "{{ bind_host }}", "--port", "{{ auth_port }}"]
+    env_file: .env.auth
+    environment:
+      - TZ={{ facility_timezone | default("UTC") }}
+      - OSPREY_AUTH_METHOD={{ auth_method }}
+      - OSPREY_AUTH_SESSION_LIFETIME={{ auth_session_lifetime }}
+      - OSPREY_AUTH_TLS_ENABLED={{ "true" if tls_enabled else "false" }}
+      - OSPREY_AUTH_EXTERNAL_ORIGIN={{ external_origin }}
+      {#- The roster the sidecar will answer for, in declaration order (the
+         login page reuses that order). Rendered from the same `services` list
+         the per-user containers and nginx locations come from, so a user can
+         never exist in one and be missing from the other. #}
+      - OSPREY_AUTH_USERS={{ services | map(attribute="user") | join(",") }}
+{#- Everything OIDC — issuer, credential-variable names, claim, and the per-user
+   subject mapping — is gated on the mode, so a `password` deployment carries no
+   OIDC settings at all even if a roster entry still declares an `oidc_subject`
+   from an earlier posture. #}
+{%- if auth_method == "oidc" %}
+{%- if auth_oidc_issuer %}
+      - OSPREY_AUTH_OIDC_ISSUER={{ auth_oidc_issuer }}
+{%- endif %}
+      {#- NAMES of the variables holding the client credentials, not the
+         credentials: the values themselves arrive from `.env.auth` under
+         whatever names a facility already keeps them under. #}
+      - OSPREY_AUTH_OIDC_CLIENT_ID_ENV={{ auth_oidc_client_id_env }}
+      - OSPREY_AUTH_OIDC_CLIENT_SECRET_ENV={{ auth_oidc_client_secret_env }}
+{%- if auth_oidc_claim %}
+      {#- Only when the facility names one: with no line here the sidecar
+         applies its own documented default (`sub`), so the default lives in
+         one place instead of being restated by the renderer. #}
+      - OSPREY_AUTH_OIDC_CLAIM={{ auth_oidc_claim }}
+{%- endif %}
+{%- for svc in services %}
+{%- if svc.oidc_subject %}
+      {#- This user's expected IdP identity — the non-secret half of the
+         roster→identity mapping. The variable NAME arrives pre-resolved as
+         `svc.oidc_subject_env` (render.py, via personas.env_var_suffix()) and
+         is emitted verbatim: deriving `upper|replace` here would be a second
+         copy of the username→env-var mapping, free to drift from the one that
+         keys this user's password hash in `.env.auth`. tojson quotes the WHOLE
+         `KEY=value` (see OSPREY_WEB_APP_NAME below) because a subject can be an
+         email or a DN containing `": "`, which would derail the YAML parse. #}
+      - {{ (svc.oidc_subject_env ~ "=" ~ svc.oidc_subject) | tojson }}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://{{ bind_host }}:{{ auth_port }}/health').status==200 else 1)\""]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+{%- endif %}
 {% for svc in services %}
 {% if svc.user == "nginx" %}
   {# HARD FAIL: a user literally named "nginx" would silently clobber the

--- a/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
+++ b/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
@@ -83,6 +83,16 @@
     nginx_image: str, optional, default "nginx:1.27-alpine"
     facility_timezone: str, optional, default "UTC" -> TZ
 
+    tls_host_cert_dir: str | None, tls_mount_target: str | None
+      Together they render nginx's one optional volume: the operator's
+      certificate directory on the DEPLOY HOST, mounted read-only at the
+      in-container directory `tls.cert` names. Both come from
+      `_auth_tls_context()`; `tls_mount_target` is derived from `tls.cert`
+      rather than configured, so the mount cannot land somewhere other than
+      where the `ssl_certificate` directive looks. When `tls_host_cert_dir` is
+      None the volume list renders byte-identically to a no-TLS deployment and
+      the operator supplies the mount from their own compose file.
+
     AUTH SIDECAR (all from render.py's `_auth_tls_context()`, the single parser
     of `modules.web_terminals.auth`/`tls` — this template re-parses nothing):
 
@@ -203,6 +213,16 @@ services:
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
       - ./nginx/landing.html:/usr/share/nginx/html/landing.html:ro
+{%- if tls_host_cert_dir and tls_mount_target %}
+      {#- The operator's certificate directory, read-only, landing at the
+         directory `tls.cert` names so nginx's ssl_certificate finds it. Emitted
+         only when `tls.host_cert_dir` is set: without it this list is byte-for-
+         byte what a no-TLS deployment renders, and the operator is expected to
+         supply the mount from a compose file of their own. render.py has
+         already refused a relative source, and a key living outside this
+         directory, so one mount is known to deliver both files. #}
+      - {{ tls_host_cert_dir }}:{{ tls_mount_target }}:ro
+{%- endif %}
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:{{ nginx_port }}/ || exit 1"]
       interval: 15s

--- a/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
+++ b/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
@@ -162,14 +162,26 @@
      this feature exists to establish. The inverse also holds: the sidecar never
      reads `.env.production` — the per-user containers' shared env file — so no
      provider key or facility credential is in reach of the login surface.
-  2. Secrets travel ONLY as `env_file` entries, never as `environment:` values.
-     Compose passes a service-level `env_file` value through literally, while
-     an `environment:` value goes through `${...}` interpolation — and a stored
-     scrypt hash (`scrypt$16384$8$1$salt$key`) is full of `$`, which
-     interpolation would eat. Non-secret settings (method, lifetime, roster,
-     origin, OIDC issuer and per-user subject mapping) come from the template
-     variables above and are safe in `environment:`; anything secret stays in
-     the file.
+  2. Secrets travel ONLY as `env_file` entries, never as `environment:` values,
+     and every secret VALUE must be free of `$`. Both halves are load-bearing.
+
+     Keeping secrets out of `environment:` keeps them out of the rendered
+     compose file (and out of `docker inspect` output for the per-user
+     services). But do NOT read that as "an env_file value is passed through
+     literally" — it is not. Compose interpolates `${...}` in env_file values
+     too, and every `$` followed by an identifier character is replaced with
+     the empty string. That is why the stored hash is separated by `.` rather
+     than the conventional `$` (osprey.services.auth_sidecar.passwords
+     `FIELD_SEP`): a `$`-separated hash arrives here with its salt and key
+     eaten, verifies against nothing, and refuses every login — silently, and
+     only for the values whose random base64 happens to start with a letter.
+
+     Anything new added to `.env.auth` must therefore encode `$`-free.
+     `tests/deployment/web_terminals/test_auth_credentials.py` pins that as a
+     property of the whole file, not of the hash alone. Non-secret settings
+     (method, lifetime, roster, origin, OIDC issuer and per-user subject
+     mapping) come from the template variables above and stay in
+     `environment:`.
 
   ----------------------------------------------------------------------------
   NETWORKING

--- a/src/osprey/templates/modules/web_terminals/nginx.conf.j2
+++ b/src/osprey/templates/modules/web_terminals/nginx.conf.j2
@@ -22,18 +22,29 @@
       their own: once a browser is on a user's own `/u/<user>/` origin, the
       per-user app reverse-proxies its own panels (routes/proxy.py) to those
       three families internally, so nginx never needs to know about them.
-    tls_enabled: bool, required (Task 1.3/1.4's gated seam; defaults to False)
-      When true, emit a `listen 443 ssl` listener inside `server{}` plus
+    tls_enabled: bool, required (defaults to False)
+      When true, emit TWO server blocks: a redirect-only one on nginx_port
+      whose entire content is `return 301 https://$host$request_uri;`, and the
+      real content server on `listen 443 ssl` with
       `ssl_certificate`/`ssl_certificate_key` pointing at tls_cert/tls_key.
-      When false, nothing TLS-related is emitted — v1's plain-http posture.
+      When false, nothing TLS-related is emitted and the single server listens
+      on nginx_port — the plain-http posture.
     tls_cert, tls_key: str | None
       Absolute paths inside the nginx container. Only read when tls_enabled
       is true; render.py already refuses to render (ValueError) if
       tls_enabled is true but either path is missing.
-    auth_method: str, required (Task 1.3/1.4's gated seam; defaults to "none")
+    auth_method: str, required (defaults to "none")
       When anything other than "none", emit an `auth_request` directive in
-      every proxied `/u/<user>/` location plus the single internal target
-      location it subrequests. When "none", nothing auth-related is emitted.
+      every proxied `/u/<user>/` location, the per-user internal target
+      location each of them subrequests, and the public `/auth/` surface the
+      sidecar serves the login flow from. When "none", nothing auth-related is
+      emitted and this template renders exactly what it rendered before
+      authentication existed.
+    auth_port: int, required when auth_method != "none" (defaults to 9070)
+      The loopback port the auth sidecar listens on. Reached at bind_host, the
+      same way every per-user app is: the sidecar shares the host network
+      namespace with nginx (see docker-compose.web.yml.j2) and publishes
+      nothing routable of its own.
 
   Render output: this file is expected at `nginx/nginx.conf` (relative to the
   rendered docker-compose.web.yml.j2), matching the
@@ -104,53 +115,143 @@
   proxied locations, and avoids a second render path for the 0-user case).
 
   ----------------------------------------------------------------------------
-  GATED AUTH/TLS SEAM (forward-looking, inert by default)
+  AUTH/TLS, OFF BY DEFAULT
 
-  v1 ships with no authentication and no TLS — this is an intentional, tracked
-  scope cut (see PROPOSAL.md's OC-1/M1), not an oversight. Rather than leave
-  the config schema silent about it, `web_terminals.tls`/`web_terminals.auth`
-  (Task 1.4) are read now and this template renders the matching nginx
-  directives GATED OFF by default, so a facility can opt in later without a
-  template rewrite:
+  A deployment that sets neither `web_terminals.auth` nor `web_terminals.tls`
+  renders exactly what this template rendered before either existed: plain
+  http, no `auth_request`, every `/u/<user>/` open to anyone who can reach the
+  port. Both features are opt-in, and each is gated independently:
 
-  - `tls_enabled` (default False) emits nothing. When true, it adds a
-    `listen 443 ssl` listener plus `ssl_certificate`/`ssl_certificate_key`
-    referencing the configured cert/key paths — render.py refuses to render
-    at all if either path is missing, so this template never has to guard
-    against an incoherent pair.
-  - `auth_method` (default "none") emits nothing. When set to anything else,
-    every proxied `/u/<user>/` location gets an `auth_request` subrequest to
-    a single internal `/_osprey_auth` location. That target is a FAIL-CLOSED
-    placeholder (`return 403;` — there is no auth-service port in the schema
-    yet, see lint.py's `_TLS_LISTEN_PORT` comment): setting `auth.method`
-    without wiring a real backend must lock every user out, never silently
-    authorize them. A real deployment replaces this stub with a `proxy_pass`
-    to its chosen auth backend (e.g. oauth2-proxy) when this seam graduates
-    past the inert placeholder.
+  - `tls_enabled` (default False) emits nothing. When true, the plain port
+    becomes a redirect-only server and a second `listen 443 ssl` server —
+    carrying `ssl_certificate`/`ssl_certificate_key` from the configured
+    paths — becomes the sole content server. render.py refuses to render at
+    all if either path is missing, so this template never has to guard against
+    an incoherent pair.
+  - `auth_method` (default "none") emits nothing. When set to a real method,
+    every proxied `/u/<user>/` location gets an `auth_request` naming that
+    user's own internal `/_osprey_auth/<user>` location, which asks the
+    sidecar `GET /verify?user=<user>` over loopback. The username in that
+    subrequest is fixed at render time from the roster, so the identity being
+    authorized is structural — a request cannot influence which user it is
+    checked against. The public `/auth/` prefix (login page, credential POST,
+    OIDC callback, logout) stays outside `auth_request`, as does the landing
+    page at `= /`; everything else under a user prefix is gated.
+
+  Fail-closed is the invariant that survives every partial state: a sidecar
+  that is down, unconfigured, or answering 503 denies the subrequest, and
+  nginx turns a denied subrequest into a refusal rather than a pass-through.
+  Misconfiguration locks operators out; it never quietly lets strangers in.
 
   Both the default (off) render and an enabled render (tls on with a
-  self-signed cert fixture + a stub auth method) MUST pass `nginx -t` — the
-  enabled path is validated by actually running nginx, not by string-matching
-  the template output.
+  self-signed cert fixture + auth on) MUST pass `nginx -t` — the enabled path
+  is validated by actually running nginx, not by string-matching the template
+  output.
 #}
 map $http_upgrade $connection_upgrade {
     default upgrade;
     '' close;
 }
+{% if auth_method != "none" %}
+# Is this request a browser NAVIGATION, or something a program issued?
+#
+# It decides what a denied `auth_request` looks like. A person typing a URL or
+# clicking a link should land on the login page; a `fetch()`, an EventSource,
+# or a WebSocket handshake should get a bare 401 it can act on. Redirecting
+# those instead would hand a JSON caller a page of login HTML (a parse error
+# somewhere far from the cause) and put an EventSource into a silent reconnect
+# loop against a login page that never becomes the stream it wanted.
+#
+# The source is the Upgrade and Accept headers concatenated, which is a
+# deliberate trick: browsers send `Accept: text/html,…` first on a navigation,
+# so anchoring at the start matches exactly those — while any WebSocket
+# handshake prefixes the upgrade token, pushing `text/html` off the anchor and
+# scoring 0 no matter what its Accept header claims. `fetch()` defaults to
+# `*/*`, XHR to `*/*`, and EventSource to `text/event-stream`; none match.
+map $http_upgrade$http_accept $osprey_auth_wants_login_page {
+    default 0;
+    "~*^text/html" 1;
+    "~*^application/xhtml\+xml" 1;
+}
 
+# The return-to path, or nothing. An allowlist, and it has to be one.
+#
+# `$uri` is nginx's DECODED path, which is the safe form for matching (it is
+# what routed the request) and the DANGEROUS form for emitting: `%0d%0a` in a
+# request path has already become a real CR LF by the time this is read, and
+# `return 302` copies a variable into the Location header verbatim. Emitting
+# `$uri` directly let one crafted link append arbitrary response headers —
+# a Set-Cookie planting an attacker's session on this very origin, reachable
+# by anyone, and most effective on a logged-out victim, which is exactly who
+# follows a login link. A `%26` likewise arrived as a real `&` and appended a
+# second `user=` parameter, which a query parser reading the last value would
+# have taken over the one this deployment rendered.
+#
+# So nothing decoded is emitted unless it matches the shape of a legitimate
+# terminal path. The character class admits no CR, no LF, no `&`, no `?`, no
+# space — deep links keep working, and everything else collapses to the empty
+# default, which the login page treats as "no return-to". `\z` rather than
+# `$`: PCRE's `$` also matches immediately BEFORE a trailing newline, so a
+# path ending in `%0a` would otherwise still be emitted, newline and all.
+map $uri $osprey_auth_next {
+    default "";
+    "~^/u/[A-Za-z0-9._-]+/[A-Za-z0-9._~/-]*\z" $uri;
+}
+{% endif -%}
+{% if tls_enabled %}
+# TLS is on, so the plain port serves NOTHING but the way to the secure one.
+# A single server listening on both ports would answer the same content over
+# cleartext — and any session cookie it set there would cross the network in
+# the clear, which is the whole thing TLS was turned on to prevent. Splitting
+# the listeners means there is no plain-http code path left to issue one.
+#
+# The redirect target is `$host` — the name the client actually asked for —
+# and NOT the render-time external origin, deliberately. A deployment is
+# reachable under more names than the one config knows about (an alias, an
+# internal DNS name, a bare IP), and rewriting the host on the way to https
+# would bounce those clients to a name they may not resolve or whose
+# certificate they cannot match. `external_origin` is for values that must be
+# fixed at render time (env-baked links, an IdP-registered redirect_uri); a
+# per-request redirect is not one of them.
 server {
     listen {{ nginx_port }};
     listen [::]:{{ nginx_port }};
-{% if tls_enabled %}
-    # Gated TLS seam (Task 1.3): web_terminals.tls.enabled is true.
+    server_name _;
+
+    return 301 https://$host$request_uri;
+}
+{% endif %}
+server {
+{%- if tls_enabled %}
+    # The sole content server: with TLS on, everything below is reachable only
+    # over the encrypted listener.
     listen 443 ssl;
     listen [::]:443 ssl;
     ssl_certificate {{ tls_cert }};
     ssl_certificate_key {{ tls_key }};
+{% else %}
+    listen {{ nginx_port }};
+    listen [::]:{{ nginx_port }};
 {% endif %}
     server_name _;
 
     root /usr/share/nginx/html;
+{%- if auth_method != "none" %}
+
+    # Server level on purpose, so it covers EVERY redirect this server can
+    # emit — the login redirect, the `/u/<user>` bookmark 301s, and whatever
+    # is added later — not just the one location that first needed it.
+    #
+    # Left at its default, nginx turns a relative redirect target into an
+    # absolute URL built from `$host` plus ITS OWN listening port. That is
+    # wrong for precisely the topology `auth.allow_insecure_http` exists to
+    # support: with a facility TLS terminator in front, a browser on
+    # `https://facility/u/alice` gets walked to `http://facility:9080/u/alice/`
+    # — cleartext, where a Secure cookie will not follow and a non-Secure one
+    # would be exposed — while advertising the internal port on the way. A
+    # relative Location keeps whatever origin the client already had.
+    absolute_redirect off;
+{%- endif %}
 
     # Exact match: ONLY the root serves the landing page. Any other path
     # outside a /u/<user>/ mount is a hard 404 — a prefix-catch-all here would
@@ -172,8 +273,32 @@ server {
     # the request reaches the upstream.
     location /u/{{ svc.user }}/ {
 {% if auth_method != "none" %}
-        # Gated auth seam (Task 1.3): web_terminals.auth.method is "{{ auth_method }}".
-        auth_request /_osprey_auth;
+        # Authentication is on (web_terminals.auth.method is "{{ auth_method }}"):
+        # every request that reaches this location — page load, panel API call,
+        # WebSocket handshake, SSE stream — is authorized first by the internal
+        # subrequest below, which asks the sidecar about {{ svc.user }} and nobody
+        # else. A denied subrequest means nginx never opens the upstream
+        # connection at all, so an unauthenticated request never touches this
+        # user's container.
+        auth_request /_osprey_auth/{{ svc.user }};
+
+        # Who a denied subrequest should prompt for. Carried in a variable
+        # because the handler below is shared by every user; the value is
+        # still a render-time literal, so it names this location's user and
+        # cannot be steered by the request. Variables survive the internal
+        # redirect into the named location.
+        set $osprey_auth_user {{ svc.user }};
+        # `=` matters: without it the named location's body would be served
+        # under the original 401 status, and a browser does not follow the
+        # Location header of a 401. With it, the handler's own status (302 or
+        # 401) becomes the response's.
+        #
+        # This intercepts only nginx's OWN 401 from the auth_request above.
+        # A 401 from the upstream app passes through untouched, because
+        # proxy_intercept_errors is off by default and this deployment leaves
+        # it off — the app's own API errors are its business, not the
+        # perimeter's.
+        error_page 401 = @osprey_auth_401;
 {% endif %}
         proxy_pass http://{{ bind_host }}:{{ svc.web }}/;
         proxy_http_version 1.1;
@@ -183,6 +308,17 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+{%- if auth_method != "none" %}
+        # The browser's cookies stop here. One cookie jar serves this whole
+        # origin, so an operator with several users unlocked would otherwise
+        # hand {{ svc.user }}'s container a session cookie naming all of them —
+        # and these containers run agent-generated code, which makes anything
+        # readable inside one a credential that has effectively left the
+        # perimeter. Nothing is lost by cutting it: the web-terminal app sets
+        # and reads no cookies at all, and the only thing that needs this one
+        # is the sidecar, which is reached by a different route.
+        proxy_set_header Cookie "";
+{%- endif %}
         proxy_buffering off;
         proxy_read_timeout 3600s;
     }
@@ -191,18 +327,102 @@ server {
     location = /u/{{ svc.user }} {
         return 301 /u/{{ svc.user }}/;
     }
+{% if auth_method != "none" %}
+
+    # {{ svc.user }}'s own auth target — the only thing the `auth_request` above
+    # can reach. There is one of these per roster user, and the `?user=` it asks
+    # the sidecar about is a RENDER-TIME LITERAL: no part of the client's
+    # request (path, header, cookie) selects which user is being authorized, so
+    # the sidecar never has to reconstruct the identity from $request_uri or
+    # X-Original-URI — the two places a crafted URL could otherwise smuggle a
+    # different username in. `internal` keeps the path unreachable from outside.
+    location = /_osprey_auth/{{ svc.user }} {
+        internal;
+        proxy_pass http://{{ bind_host }}:{{ auth_port }}/verify?user={{ svc.user }};
+        # Load-bearing, not an optimization. An auth subrequest inherits the
+        # parent request's headers, so without these two directives a POST's
+        # Content-Length is announced to the sidecar, which reads no body and
+        # replies immediately — leaving the announced bytes unsent and the
+        # subrequest hanging until it times out. Every authenticated POST (chat
+        # message, file write, approval) would stall. `proxy_pass_request_body
+        # off` suppresses the body; clearing Content-Length stops nginx
+        # advertising a body it will not send.
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        # This subrequest sits in front of EVERY gated request, so its worst
+        # case is the deployment's worst case. Answering it is a signature
+        # check against process-local state over loopback — microseconds — so
+        # nginx's 60s defaults describe nothing this can legitimately do, and
+        # would let one wedged sidecar hold every open terminal's next request
+        # for a minute before failing it. Failing in seconds turns that into a
+        # visible error instead of a hang.
+        proxy_connect_timeout 2s;
+        proxy_read_timeout 5s;
+    }
+{% endif -%}
 {% endfor %}
 {% if auth_method != "none" %}
-    # Gated auth seam (Task 1.3): the single internal target every proxied
-    # `/u/<user>/` location's auth_request subrequests. Placeholder only —
-    # there is no auth-service port in the schema yet (lint.py) — and
-    # FAIL-CLOSED (`return 403;`) by design: setting `auth.method` without
-    # wiring a real backend must lock every user out, never silently
-    # authorize them. A real deployment replaces this stub with a
-    # `proxy_pass` to its chosen auth backend (e.g. oauth2-proxy).
-    location = /_osprey_auth {
-        internal;
-        return 403;
+
+    # The public login surface — the ONE place under this origin that answers
+    # without a session, because it is where a session comes from. Everything
+    # the sidecar serves publicly lives under this prefix: the login page and
+    # its assets, the credential POST, the OIDC callback, and logout. No
+    # `auth_request` here, by necessity: gating the login page behind a session
+    # is a locked door whose key is inside the room.
+    #
+    # `/verify` is NOT reachable through this prefix — it is not under /auth/,
+    # and the per-user targets that call it are `internal`. The landing page at
+    # `= /` likewise stays public and ungated (it is the identity chooser, and
+    # it is what the nginx container's own healthcheck probes); the per-user
+    # apps' `/health` routes sit behind their user's gate on purpose, so an
+    # expired session makes an open terminal's probe 401 and reload.
+    # What a denied `auth_request` turns into, for every user. Reached only by
+    # the `error_page 401` above — it is a named location, so nothing routes
+    # here from outside.
+    #
+    # `if` is safe here in a way it famously is not elsewhere in nginx: a
+    # location-level `if` containing nothing but `return` is one of the two
+    # constructs documented as fully defined behaviour. There is no
+    # proxy_pass, no rewrite, and no second directive inside it.
+    location @osprey_auth_401 {
+        # The return-to is `$osprey_auth_next` — the ALLOWLISTED form of the
+        # path (see the map above) — and never `$uri` itself. Neither is
+        # `$request_uri` the answer: it is injection-safe, being still
+        # percent-encoded, but it carries whatever the client typed, including
+        # a leading `//` that a browser reads as an absolute URL and follows
+        # off-site. One variable is unsafe to emit, the other is unsafe to
+        # trust; the map is what makes a value both.
+        #
+        # The query string is dropped with all of this — a deliberate trade,
+        # since the terminal's own state does not live in one. The sidecar
+        # still treats `next` as untrusted input.
+        if ($osprey_auth_wants_login_page) {
+            return 302 /auth/login?user=$osprey_auth_user&next=$osprey_auth_next;
+        }
+        # Programs get the status, not a page: a bare 401 is what the app's
+        # WebSocket/SSE close handlers probe for to decide the session died.
+        return 401;
+    }
+
+    location /auth/ {
+        proxy_pass http://{{ bind_host }}:{{ auth_port }}/auth/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        # Stated outright rather than left to defaults or to whatever the
+        # terminal locations above need. The login flow is a handful of short
+        # request/response round trips against a loopback service — it has no
+        # long-poll, no stream, and nothing to keep open — so a sidecar that
+        # is wedged should surface as a prompt error in seconds, not as a
+        # browser tab that hangs for a minute on a dead upstream.
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 15s;
+        proxy_read_timeout 15s;
     }
 {% endif %}
 }

--- a/src/osprey/templates/skills/osprey-build-deploy/references/facility-config-schema.md
+++ b/src/osprey/templates/skills/osprey-build-deploy/references/facility-config-schema.md
@@ -310,12 +310,21 @@ modules:
               url: "https://elog.example.org"
             - label: "Status Page"
               url: "https://status.example.org"
-    auth:                                 # OPTIONAL — forward-looking, config-gated seam; INERT (see note below)
-      method: "none"                      # none (default); no other value is exercised in this schema revision
-    tls:                                  # OPTIONAL — forward-looking, config-gated seam; INERT (see note below)
-      enabled: false                      # default; v1 ships plain HTTP only
-      cert: "/etc/osprey/tls/facility.crt"  # only read when enabled: true
-      key: "/etc/osprey/tls/facility.key"   # only read when enabled: true
+    auth:                                 # OPTIONAL — off by default (see "Authentication" below)
+      method: "none"                      # none (default) | password | oidc
+      port: 9070                          # auth sidecar's listen port (default 9070)
+      session_lifetime: 43200             # seconds a session stays valid (default 43200 = 12h)
+      allow_insecure_http: false          # default; true renders auth without TLS — see below
+      image: "registry.example.com/osprey/web-terminal-auth:latest"  # REQUIRED in registry mode
+      oidc:                               # only read when method: oidc
+        issuer: "https://sso.example.org/realms/accelerator"
+        client_id_env: "OSPREY_AUTH_OIDC_CLIENT_ID"        # env var NAME (default shown)
+        client_secret_env: "OSPREY_AUTH_OIDC_CLIENT_SECRET"  # env var NAME (default shown)
+        claim: "sub"                      # ID-token claim matched against users[].oidc_subject
+    tls:                                  # OPTIONAL — required whenever auth.method != none
+      enabled: false                      # default; plain HTTP
+      cert: "/etc/osprey/tls/facility.crt"  # path INSIDE the nginx container; only read when enabled
+      key: "/etc/osprey/tls/facility.key"   # path INSIDE the nginx container; only read when enabled
 ```
 
 | Field | Type | Required | Notes |
@@ -336,10 +345,18 @@ modules:
 | `personas.<name>` | map of objects | no | Catalog of heterogeneous personas — own project, own image, own permissions. Omit entirely (no `personas:` block, no `persona:` keys anywhere) for exactly today's behavior. See "Personas" below |
 | `mcp.topology` | enum | no | `per_container_stdio` (default — today's behavior) is the only accepted value. `shared_http` is a recognized but rejected value — lint ERROR and render `ValueError`. See "MCP topology" below and `references/modules/web-terminals.md` for the deferral rationale |
 | `landing.groups` | list of group objects | no | Defaults to a single `type: "users"` group if omitted. `type: "users"` groups take no other fields and auto-populate from `users[]`; `type: "links"` groups require `label` and a `links` list of `{label, url}` objects |
-| `auth.method` | string | no | Defaults to `"none"` (no authentication). Forward-looking seam only — see note below |
-| `tls.enabled` | bool | no | Defaults to `false` (plain HTTP). Forward-looking seam only — see note below |
-| `tls.cert` | string | required if `tls.enabled: true` | Path to the TLS certificate file, mounted into the nginx container |
-| `tls.key` | string | required if `tls.enabled: true` | Path to the TLS private key file, mounted into the nginx container |
+| `auth.method` | enum | no | `"none"` (default — no login), `"password"` (OSPREY-managed scrypt hashes) or `"oidc"`. Any other value raises at render time. Anything but `none` brings up the auth sidecar and puts an `auth_request` in front of every `/u/<user>/` location. See "Authentication" below |
+| `auth.port` | int | no (default 9070) | The auth sidecar's listen port. The sidecar runs `network_mode: host` and binds `127.0.0.1:<port>` on the deploy host — it is NOT published through a compose `ports:` mapping and is NOT on an internal bridge network, so nginx (same netns) reaches it and nothing off-host does. Joined into the same port-collision check as the per-user families. **Must be a plain positive int**: any other value (string, float, bool, ≤ 0) is silently replaced by 9070 — there is no lint rule for it |
+| `auth.session_lifetime` | int **seconds** | no (default 43200 = 12h) | How long a session stays valid, in whole seconds. Also the bound on how long a captured cookie could be replayed after a sidecar restart (see "Authentication" below). **Must be a plain positive int**: a duration string (`"12h"`), a float, `0` or a negative value is silently replaced by 43200 — there is no lint rule for it, so a facility that meant 8h keeps 12h with no warning |
+| `auth.allow_insecure_http` | bool | no (default false) | Permits `auth.method != none` with `tls.enabled: false`, which otherwise refuses to render. Only defensible behind a TLS-terminating proxy or on an isolated network; lint warns |
+| `auth.image` | string | required if `image_source: registry` and `auth.method != none` | The sidecar's image reference. Publishing it is the facility CI's job, like the per-user images; deploy preflight fails when it is unset in registry mode. Ignored in `local` mode, where `deploy up` builds `<facility.prefix>-assistant-auth:local` itself |
+| `auth.oidc.issuer` | string | required if `auth.method: oidc` | OIDC issuer URL; the sidecar discovers endpoints from it |
+| `auth.oidc.client_id_env` | string | no (default `OSPREY_AUTH_OIDC_CLIENT_ID`) | Name of the env var holding the client id. A **variable name**, never the value — OIDC credentials live in `.env`, never in config |
+| `auth.oidc.client_secret_env` | string | no (default `OSPREY_AUTH_OIDC_CLIENT_SECRET`) | Name of the env var holding the client secret, same rule |
+| `auth.oidc.claim` | string | no (**sidecar** default `sub`) | Which ID-token claim carries the identity matched against a roster entry's `oidc_subject`. An identity that maps to no roster user is refused. Unset emits no env var at all and the sidecar's own `sub` default applies — the default lives there, not in the render, so don't document it as a config-layer default |
+| `tls.enabled` | bool | no | Defaults to `false` (plain HTTP). `true` makes the plain port a `301` redirect and serves all content on `listen 443 ssl` |
+| `tls.cert` | string | required if `tls.enabled: true` | Path to the TLS certificate **as seen inside the nginx container**. The rendered overlay mounts only nginx's own config files, so the certificate directory must be mounted into the `nginx` service by a facility-supplied compose file later in `runtime.compose_files` |
+| `tls.key` | string | required if `tls.enabled: true` | Path to the TLS private key, same rule. `tls.enabled: true` with either path unset refuses to render |
 
 Every port-valued field in the table above must be free of collisions with every
 other port allocation in the config: `nginx_port` against `ports.*` (its mirror is
@@ -373,6 +390,7 @@ users:
     persona: "analysis"                  # optional — key into personas.<name>
     display_name: "Operations"           # optional — window/tab title → OSPREY_WEB_APP_NAME
     theme: "desy-light"                  # optional — default web UI theme → OSPREY_WEB_THEME
+    oidc_subject: "8f4c1e02-..."         # optional — this user's identity at the IdP (auth.method: oidc)
 ```
 
 | Field | Type | Required | Notes |
@@ -381,6 +399,7 @@ users:
 | `index` | int (non-negative, non-bool) | yes, for an object-form entry | Explicit port-offset. A bare-string entry has no `index` field at all (its offset is inferred from list position); the moment an entry is written in object form, `index` must be present and a valid non-negative, non-bool int, or lint rejects it — there is no "infer it anyway" fallback for object-form entries. `osprey deploy decommission` freezes every *surviving* entry to this object form (assigning each its current positional index) before deleting the target user, so removing an earlier user from the list can never shift a later survivor's allocated ports; this is a tooling-managed migration, not something to hand-author in the interview |
 | `persona` | string | no | Key into `modules.web_terminals.personas`. Falls back to `default_persona` when absent; falls back further to "no persona in effect" (today's single-image, single-project behavior) when neither is set |
 | `display_name` | string | no | Human-facing window/tab title for this user's terminal. Emitted into the container as `OSPREY_WEB_APP_NAME`, which `osprey web` treats as authoritative over the per-image `web.app_name` in `config.yml` — the only way to vary the title per user, since every per-user container on a shared image otherwise reads the same baked `web.app_name`. Omit it (the default) to emit no env line at all and inherit `web.app_name`. Must be a string when present (a non-string is a lint ERROR); bare-string roster entries can't carry one |
+| `oidc_subject` | string | no | This user's identity at the identity provider — the value the `auth.oidc.claim` claim carries for them. Read only when `auth.method: oidc`; a login whose claim matches no roster entry is refused. Not a secret (it is an identifier the IdP already publishes), so it belongs in config rather than `.env`. Bare-string roster entries can't carry one |
 | `theme` | string | no | This user's default web UI theme. Emitted into the container as `OSPREY_WEB_THEME`, which `osprey web` treats as authoritative over the per-image `web.theme` in `config.yml` — the only way to vary the theme per user on a shared image. Either a theme **family** (`"main"`, `"desy"`, `"high-contrast"`, `"retro"`), which sets the palette and leaves light/dark to that user's OS preference, or a concrete theme **id** (`"desy-light"`), which also pins the mode. It is a *default*: the user's own pick in the display menu outranks it thereafter. Omit it (the default) to emit no env line at all and inherit `web.theme`. Must be a string when present (a non-string is a lint ERROR); the *value* is not validated here — the theme registry ships with the image, and an unknown value warns at container start and falls back to `main`. Bare-string roster entries can't carry one |
 
 ### Personas
@@ -439,18 +458,51 @@ e.g. a `claude_code.servers` custom `url` entry, is unaffected). See
 `references/modules/web-terminals.md` for why a shared HTTP tier is schema-only in this
 revision.
 
-> **`auth`/`tls` are forward-looking, config-gated seams — not an implemented
-> security feature.** With the defaults shown (`auth.method: none`,
-> `tls.enabled: false`), the rendered stack is functionally equivalent to Phase 1
-> (minus the port→path relocation): perimeter-trust, plain HTTP, open to anyone who
-> reaches the deploy host. OSPREY does not ship an auth backend or provision
-> certificates for you — these stanzas only exist so that a future phase can wire
-> a real `auth_request` backend and TLS termination as a config flip instead of a
-> template rewrite. The multi-user-support epic's two CRITICAL findings, **C1 (no
-> authentication)** and **C2 (all traffic is cleartext HTTP)**, remain **OPEN and
-> explicitly deferred** — defining this schema does not close them, and no
-> deployment should be treated as authenticated or encrypted on the strength of
-> these fields existing.
+### Authentication
+
+`auth.method: password` or `oidc` adds an **auth sidecar** to the stack — a small
+service in its own container that answers nginx's `auth_request` subrequest for every
+`/u/<user>/` request and serves the login flow at `/auth/*`. A request reaches a user's
+container only when the browser holds a valid, unrevoked session for **that** user;
+the username in each subrequest is a render-time literal, so nothing a client sends can
+redirect the check at another user's terminal. The landing page stays public (it is the
+identity chooser), and one browser may hold several unlocked users at once — the shared
+control-room case. This closes the multi-user-support epic's finding **C1 (no
+authentication)** for deployments that enable it; **C2 (cleartext HTTP)** closes with
+`tls.enabled: true`. Both remain open for a deployment left at the defaults, which is
+still the shipped posture of every preset.
+
+Everything about this configuration fails **closed**:
+
+- `auth.method != none` with `tls.enabled: false` **refuses to render** unless
+  `auth.allow_insecure_http: true` — session cookies never cross a cleartext network by
+  accident.
+- With auth on — **any** method, not just `password` — a roster name outside
+  `[a-z0-9][a-z0-9_-]*`, or two names colliding on one env-var suffix (`alice-b` and
+  `alice_b` both key `..._ALICE_B`), refuses to render. A collision would let one user's
+  password open the other's terminal. (The credential provisioner enforces the same rule
+  again, but only on the password-mode deploy path; lint reports the charset unscoped to
+  auth and never raises. Three checks, three different scopes — don't conflate them.)
+- `osprey deploy up` aborts **before any compose invocation** when a password-mode user's
+  hash cannot be established, **or** when a cookie-signing secret cannot be — so an OIDC
+  deployment, which provisions no hashes at all, can abort on the same gate.
+- Registry mode without `auth.image` fails the same preflight.
+
+**Credentials never live in this file.** Password hashes live in `.env.auth` (project
+root, `0600`, gitignored alongside `.env.production`), which only the sidecar's `env_file`
+references — no terminal container receives it. Per user, `osprey deploy up` keeps an
+existing hash, else hashes a plaintext `OSPREY_AUTH_PW_<USER>` from the project `.env`
+(the plaintext never reaches a container), else mints a password and prints it **once**.
+`osprey deploy passwd <user>` rotates one user's password and ends that user's sessions.
+`decommission`/`prune` purge the departing user's credential, so a later same-named user
+starts fresh — but a plain `deploy up` after a hand-edited roster does **not**, and a
+plaintext `OSPREY_AUTH_PW_<USER>` left in `.env` is re-hashed on the next deploy and
+survives both verbs. Operational detail lives in the multi-user how-to, not here.
+
+One honest limitation: the revoked-session list is held in the sidecar's memory, so
+restarting that container (including podman's image-drift reconcile) forgets it. A cookie
+captured before a logout could be replayed until it expires on its own — bounded by
+`auth.session_lifetime`.
 
 ### `modules.olog` — electronic logbook integration
 

--- a/src/osprey/templates/skills/osprey-build-deploy/references/facility-config-schema.md
+++ b/src/osprey/templates/skills/osprey-build-deploy/references/facility-config-schema.md
@@ -323,6 +323,7 @@ modules:
         claim: "sub"                      # ID-token claim matched against users[].oidc_subject
     tls:                                  # OPTIONAL — required whenever auth.method != none
       enabled: false                      # default; plain HTTP
+      host_cert_dir: "/etc/ssl/facility"    # dir ON THE DEPLOY HOST; mounted read-only for you
       cert: "/etc/osprey/tls/facility.crt"  # path INSIDE the nginx container; only read when enabled
       key: "/etc/osprey/tls/facility.key"   # path INSIDE the nginx container; only read when enabled
 ```
@@ -355,8 +356,9 @@ modules:
 | `auth.oidc.client_secret_env` | string | no (default `OSPREY_AUTH_OIDC_CLIENT_SECRET`) | Name of the env var holding the client secret, same rule |
 | `auth.oidc.claim` | string | no (**sidecar** default `sub`) | Which ID-token claim carries the identity matched against a roster entry's `oidc_subject`. An identity that maps to no roster user is refused. Unset emits no env var at all and the sidecar's own `sub` default applies — the default lives there, not in the render, so don't document it as a config-layer default |
 | `tls.enabled` | bool | no | Defaults to `false` (plain HTTP). `true` makes the plain port a `301` redirect and serves all content on `listen 443 ssl` |
-| `tls.cert` | string | required if `tls.enabled: true` | Path to the TLS certificate **as seen inside the nginx container**. The rendered overlay mounts only nginx's own config files, so the certificate directory must be mounted into the `nginx` service by a facility-supplied compose file later in `runtime.compose_files` |
+| `tls.cert` | string | required if `tls.enabled: true` | Path to the TLS certificate **as seen inside the nginx container** |
 | `tls.key` | string | required if `tls.enabled: true` | Path to the TLS private key, same rule. `tls.enabled: true` with either path unset refuses to render |
+| `tls.host_cert_dir` | string | no | Absolute directory **on the deploy host** holding the certificate and key. Set it and the overlay bind-mounts that directory read-only at the container-side directory `tls.cert` names, so nginx finds the certificate with no facility-supplied compose file. Because one mount serves both files, `tls.cert` and `tls.key` must share a directory; a relative path, a key outside that directory, or `host_cert_dir` without `tls.enabled` each refuse to render. Omit it to mount nothing and supply the certificate yourself (a compose file later in `runtime.compose_files`, or whatever your certificate management already does) |
 
 Every port-valued field in the table above must be free of collisions with every
 other port allocation in the config: `nginx_port` against `ports.*` (its mirror is

--- a/src/osprey/templates/skills/osprey-build-deploy/references/modules/web-terminals.md
+++ b/src/osprey/templates/skills/osprey-build-deploy/references/modules/web-terminals.md
@@ -4,7 +4,7 @@ A multi-user web terminal stack lets named operators reach the built assistant f
 
 **Enabled when**: `modules.web_terminals.enabled: true` in `facility-config.yml`.
 
-> **Loopback-bound apps behind a single chokepoint — still perimeter-trust only.** Every per-user service (the web family plus every companion-panel family) binds `127.0.0.1` inside its container, so nginx is the **only** process that can reach them from outside — hitting a per-user host port directly no longer reaches anything. That does **not** mean the stack is authenticated or encrypted: `modules.web_terminals.auth` and `.tls` exist as config-gated seams, but with their defaults (`auth.method: none`, `tls.enabled: false`) traffic reaching nginx is still unauthenticated, cleartext HTTP, open to anyone who reaches the deploy host. Enabling `auth.method` to anything other than `none` fails **closed** — every request gets `403` — rather than allow-all, since no real auth backend exists behind the seam yet. Only deploy this module on a network you already trust (VPN-only segment, firewalled lab subnet, etc.) until a real auth backend and real TLS certificates are configured.
+> **Loopback-bound apps behind a single chokepoint; authentication is opt-in.** Every per-user service (the web family plus every companion-panel family) binds `127.0.0.1` inside its container, so nginx is the **only** process that can reach them from outside — hitting a per-user host port directly no longer reaches anything. What that chokepoint *asks* of a request is a configuration choice. At the shipped defaults (`auth.method: none`, `tls.enabled: false` — every preset) traffic reaching nginx is unauthenticated cleartext HTTP, open to anyone who reaches the deploy host, so deploy it that way only on a network you already trust (VPN-only segment, firewalled lab subnet). Setting `modules.web_terminals.auth.method` to `password` or `oidc` brings up the auth sidecar and requires a real per-user login for every `/u/<user>/` request; `modules.web_terminals.tls.enabled: true` adds HTTPS, and auth without it refuses to render unless `auth.allow_insecure_http: true`. Full field reference and the fail-closed rules: `references/facility-config-schema.md` § "Authentication".
 
 ---
 
@@ -309,6 +309,7 @@ A compose overlay (`docker-compose.web.yml` by default; added to `${config.runti
 
 - One `nginx` service (container name `${config.facility.prefix}-nginx`) listening on `0.0.0.0:${config.modules.web_terminals.nginx_port}`, from image `${config.modules.web_terminals.nginx_image}` (default `nginx:1.27-alpine`). This is the one image in the stack pulled from a public registry rather than built from the facility's own project, so on hosts locked to a private mirror set `nginx_image` to the mirrored reference or the service is unpullable. Mounts `./nginx/nginx.conf` and `./nginx/landing.html` read-only.
 - An anchor `&web-terminal` block holding image, restart policy, env_file, network — extended by every per-user service.
+- One `auth` service (container name `${config.facility.prefix}-auth`), **only** when `auth.method != none` — the sidecar nginx's `auth_request` calls. Like every other service here it runs `network_mode: host`, binding `127.0.0.1:${config.modules.web_terminals.auth.port}` on the deploy host rather than publishing a compose port. Single uvicorn process by design (the revocation list and login throttle are in-memory). Its `env_file` is `.env.auth` and nothing else carries those variables. At `auth.method: none` the block is suppressed entirely and the overlay is byte-identical to a pre-authentication render.
 - One service per user, each publishing all four `*_base_port + index` host ports (per the Architecture table above) with `OSPREY_TERMINAL_USER=<user>` and the other three `OSPREY_*_PORT` env vars set alongside it — plus a paired `<user>-claude-config` / `<user>-agent-data` named volume per user, living on the container engine's local graphroot, **not** on any NFS mount. (Deliberate: rootless container UIDs don't survive NFS write paths reliably, but Claude Code writes to its config dir continuously during a session.)
 
 **These artifacts are generated deterministically, not hand-rendered by the scaffolding skill.** Run:
@@ -345,6 +346,8 @@ Neither `osprey deploy up` nor `osprey deploy seed` HTTP-probes the per-user ser
 ### .env.template
 
 No new entries are required by this module on its own — web terminals reuse the LLM provider key and any other secrets the assistant already needs. If `modules.event_dispatcher` is also enabled, the sidecar token env var is propagated into each terminal so it can call sidecar endpoints.
+
+With authentication on, two optional `.env` entries apply: an `OSPREY_AUTH_PW_<USER>` plaintext to seed a chosen password for that user (hashed into `.env.auth` at deploy time, never shipped to a container), and — in `oidc` mode — the client id/secret under the names `auth.oidc.client_id_env` / `client_secret_env` point at. The generated password hashes and session secrets live in `.env.auth`, which the deploy writes. Three ignore templates keep it out of images and history: the project `.gitignore` and `.dockerignore` (both of which also list `.env.production`), plus the auth sidecar's own build-context `.dockerignore`. Never commit `.env.auth` or `.env.production`.
 
 ### Other files
 
@@ -439,6 +442,14 @@ The equivalent by hand, if you're editing `facility-config.yml` directly instead
    ```
 
 To clean up users that were removed from the roster this second way (bypassing `decommission`) and left as orphans, run `osprey deploy prune [--dry-run] [--archive|--purge]` — it discovers containers/volumes not on the current roster and removes them the same way `decommission` would.
+
+With authentication on, both verbs also purge that user's `OSPREY_AUTH_PW_*` entries from `.env.auth`, so a later user of the same name is minted a fresh credential rather than inheriting the departed one. `decommission` additionally reloads nginx and force-recreates the sidecar unconditionally (its roster arrives as a compose `environment` entry baked in at container creation), which is what kills the removed user's live session immediately. `prune` re-renders nothing and recreates **only** when a purge actually changed `.env.auth` — so in `oidc` mode, where an orphan has no password entry to purge, prune ends no session. Reach for `decommission` when closing access is the point.
+
+Neither happens on a plain `deploy up` after a hand-edited roster: the user's container and routes go away, but their hash stays in `.env.auth` and re-establishes the old password if the name is ever re-added. A plaintext `OSPREY_AUTH_PW_<USER>` in the project `.env` survives even `decommission` — the next deploy re-hashes it — so remove that line by hand when someone leaves (the decommission warns when one is still present).
+
+### Change a user's password
+
+`osprey deploy passwd <user>` (password mode only): prompts for the new password without echoing it, rewrites that one `OSPREY_AUTH_PW_HASH_<USER>` entry in `.env.auth`, and force-recreates the sidecar so the change takes effect. That user's existing sessions stop working immediately; no other user is affected. There is no self-service password change from the browser.
 
 ### Inspect a user's session state
 

--- a/src/osprey/templates/skills/osprey-build-deploy/templates/facility-config.example.yml
+++ b/src/osprey/templates/skills/osprey-build-deploy/templates/facility-config.example.yml
@@ -222,18 +222,21 @@ modules:
               url: "https://elog.dls.example.org"
             - label: "Status Page"
               url: "https://status.dls.example.org"
-    # auth/tls below are OPTIONAL, forward-looking, config-gated seams — INERT with
-    # these (default) values. No auth backend or TLS is implemented in this phase;
-    # the stack is perimeter-trust plain HTTP, identical to Phase 1. C1
-    # (authentication) and C2 (cleartext HTTP) remain OPEN/deferred — see
-    # facility-config-schema.md for the full note. Uncomment/edit only once a
-    # later phase actually wires an auth_request backend + cert provisioning.
+    # auth/tls below are OPTIONAL and OFF by default: with no `auth:` stanza the
+    # stack is perimeter-trust plain HTTP, so deploy it that way only on a network
+    # you already trust. Uncomment to require a real per-user login — `password`
+    # (hashes OSPREY provisions into .env.auth) or `oidc` (your own IdP). Auth
+    # without TLS refuses to render unless auth.allow_insecure_http is set, and
+    # tls.cert/tls.key are paths INSIDE the nginx container, which the facility
+    # mounts there itself. Full reference: facility-config-schema.md §
+    # "Authentication".
     # auth:
-    #   method: "none"                   # none (default) — no other value is exercised yet
+    #   method: "none"                   # none (default) | password | oidc
+    #   session_lifetime: 43200          # INTEGER seconds (default 43200 = 12h)
     # tls:
-    #   enabled: false                   # default; v1 ships plain HTTP only
-    #   cert: "/etc/osprey/tls/dls.crt"  # only read when enabled: true
-    #   key: "/etc/osprey/tls/dls.key"   # only read when enabled: true
+    #   enabled: false                   # default; plain HTTP
+    #   cert: "/etc/osprey/tls/dls.crt"  # container-side path; only read when enabled
+    #   key: "/etc/osprey/tls/dls.key"   # container-side path; only read when enabled
 
   # ---------------------------------------------------------------------------
   # Electronic logbook integration.

--- a/src/osprey/templates/skills/osprey-build-deploy/templates/facility-config.example.yml
+++ b/src/osprey/templates/skills/osprey-build-deploy/templates/facility-config.example.yml
@@ -226,15 +226,18 @@ modules:
     # stack is perimeter-trust plain HTTP, so deploy it that way only on a network
     # you already trust. Uncomment to require a real per-user login — `password`
     # (hashes OSPREY provisions into .env.auth) or `oidc` (your own IdP). Auth
-    # without TLS refuses to render unless auth.allow_insecure_http is set, and
-    # tls.cert/tls.key are paths INSIDE the nginx container, which the facility
-    # mounts there itself. Full reference: facility-config-schema.md §
+    # without TLS refuses to render unless auth.allow_insecure_http is set.
+    # tls.cert/tls.key are paths INSIDE the nginx container; host_cert_dir is the
+    # directory ON THE DEPLOY HOST holding them, which the overlay bind-mounts
+    # read-only where cert sits (omit it to mount nothing and supply the
+    # certificate yourself). Full reference: facility-config-schema.md §
     # "Authentication".
     # auth:
     #   method: "none"                   # none (default) | password | oidc
     #   session_lifetime: 43200          # INTEGER seconds (default 43200 = 12h)
     # tls:
     #   enabled: false                   # default; plain HTTP
+    #   host_cert_dir: "/etc/ssl/dls"    # host-side dir; mounted read-only at cert's dir
     #   cert: "/etc/osprey/tls/dls.crt"  # container-side path; only read when enabled
     #   key: "/etc/osprey/tls/dls.key"   # container-side path; only read when enabled
 

--- a/src/osprey/utils/dotenv.py
+++ b/src/osprey/utils/dotenv.py
@@ -54,11 +54,27 @@ def parse_dotenv_text(text: str) -> dict[str, str]:
     return env
 
 
+def dotenv_line_var(line: str) -> str | None:
+    """The variable a raw ``.env`` line assigns, or ``None`` for a non-assignment.
+
+    Comments, blank lines, and anything without an ``=`` yield ``None``; an
+    optional ``export`` prefix is stripped, matching :func:`parse_dotenv_file`.
+    Callers that need to rewrite a ``.env`` line-by-line (rather than parse it
+    into a dict) use this so they classify lines exactly the way the parser
+    does — a divergence would let a rewrite keep a line the parser still reads.
+    """
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in stripped:
+        return None
+    candidate = stripped[7:] if stripped.startswith("export ") else stripped
+    return candidate.partition("=")[0].strip() or None
+
+
 def _dotenv_raw_lines(text: str) -> dict[str, str]:
     """Map ``KEY`` -> its raw ``KEY=VALUE`` line (quoting intact) from ``text``."""
     raw: dict[str, str] = {}
     for line in text.splitlines():
-        key = _line_key(line)
+        key = dotenv_line_var(line)
         if key:
             raw[key] = line.strip()
     return raw
@@ -208,7 +224,7 @@ def derive_project_env(
     consumed: set[str] = set()
     out_lines: list[str] = []
     for line in rendered_text.splitlines():
-        key = _line_key(line)
+        key = dotenv_line_var(line)
         if key is None:
             out_lines.append(line)
             continue
@@ -307,7 +323,7 @@ def _overlay_project_env(
     seen: set[str] = set()
     out_lines: list[str] = []
     for line in existing_text.splitlines():
-        key = _line_key(line)
+        key = dotenv_line_var(line)
         if key is None:
             out_lines.append(line)
             continue
@@ -479,16 +495,6 @@ def _format_env_line(key: str, value: str) -> str:
     )
 
 
-def _line_key(line: str) -> str | None:
-    """The ``KEY`` a raw ``.env`` line assigns, or ``None`` for comments/blanks."""
-    stripped = line.strip()
-    if not stripped or stripped.startswith("#") or "=" not in stripped:
-        return None
-    candidate = stripped[7:] if stripped.startswith("export ") else stripped
-    key = candidate.partition("=")[0].strip()
-    return key or None
-
-
 def merge_env_preserving_existing(
     rendered_text: str,
     existing_text: str,
@@ -516,7 +522,7 @@ def merge_env_preserving_existing(
     consumed: set[str] = set()
     out_lines: list[str] = []
     for line in rendered_text.splitlines():
-        key = _line_key(line)
+        key = dotenv_line_var(line)
         if key is not None and key in existing:
             out_lines.append(existing[key])
             consumed.add(key)

--- a/tests/cli/test_deploy_cmd.py
+++ b/tests/cli/test_deploy_cmd.py
@@ -461,3 +461,154 @@ class TestDeployCommandOutput:
                 assert (
                     "Building" in result.output or "built" in result.output or "✅" in result.output
                 )
+
+
+def _flat(output: str) -> str:
+    """`output` with every run of whitespace collapsed to one space.
+
+    Console output here is rich-rendered and click's help is width-wrapped, so a
+    phrase can be split across lines at any column. Collapsing whitespace lets a
+    test assert on the phrase rather than on where the renderer chose to break
+    it — a single word is never split, so `passwd` and `auth.method` survive.
+    """
+    return " ".join(output.split())
+
+
+class TestPasswdAction:
+    """`osprey deploy passwd <user>` — rotate one web-terminal login password.
+
+    The dispatch is deliberately thin (guards, a hidden prompt, one call), so
+    these tests pin the CLI's own contract: that the guards admit exactly the
+    right argv, that the typed password reaches the rotation verbatim, and that
+    it never reaches the terminal, the argv, or a refusal message. The rotation
+    itself is covered where it lives, in the lifecycle tests.
+    """
+
+    _ROTATE = "osprey.deployment.web_terminals.lifecycle.rotate_user_password"
+
+    def _config(self, tmp_path):
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("# test")
+        return config_file
+
+    def test_passwd_is_offered_in_the_command_help(self, cli_runner):
+        """The action is discoverable, and documented as requiring a USER."""
+        result = cli_runner.invoke(deploy, ["--help"])
+
+        assert result.exit_code == 0
+        assert "passwd" in _flat(result.output)
+
+    def test_passwd_requires_a_user_argument(self, cli_runner, tmp_path):
+        """`deploy passwd` with no USER is a usage error, and rotates nothing.
+
+        Silently doing nothing (or worse, prompting for a password with no
+        target) would be the failure mode of leaving `passwd` out of the
+        require-USER guard.
+        """
+        config_file = self._config(tmp_path)
+
+        with patch(self._ROTATE) as mock_rotate:
+            result = cli_runner.invoke(deploy, ["passwd", "--config", str(config_file)])
+
+        assert result.exit_code != 0
+        assert "requires a USER" in _flat(result.output)
+        assert not mock_rotate.called
+
+    def test_passwd_accepts_a_user_argument(self, cli_runner, tmp_path):
+        """`deploy passwd alice` is not rejected by the stray-USER guard.
+
+        That guard rejects a USER on any action not on its allowlist, so
+        omitting `passwd` from it would make the action unusable in its only
+        valid form.
+        """
+        config_file = self._config(tmp_path)
+
+        with patch(self._ROTATE) as mock_rotate:
+            with patch("osprey.cli.deploy_cmd.resolve_config_path") as mock_resolve:
+                mock_resolve.return_value = config_file
+                result = cli_runner.invoke(
+                    deploy,
+                    ["passwd", "alice", "--config", str(config_file)],
+                    input="s3cr3t-pw\ns3cr3t-pw\n",
+                )
+
+        assert "does not take a USER argument" not in _flat(result.output)
+        assert mock_rotate.called
+        assert mock_rotate.call_args[0][1] == "alice"
+
+    def test_passwd_passes_the_prompted_password_through_verbatim(self, cli_runner, tmp_path):
+        """What the operator types is what gets hashed — no trimming, no
+        re-prompt loop, and the config path and user travel with it."""
+        config_file = self._config(tmp_path)
+
+        with patch(self._ROTATE) as mock_rotate:
+            with patch("osprey.cli.deploy_cmd.resolve_config_path") as mock_resolve:
+                mock_resolve.return_value = config_file
+                cli_runner.invoke(
+                    deploy,
+                    ["passwd", "alice", "--config", str(config_file)],
+                    input="c0rrect horse\nc0rrect horse\n",
+                )
+
+        assert mock_rotate.call_args[0] == (config_file, "alice", "c0rrect horse")
+
+    def test_passwd_never_echoes_the_password(self, cli_runner, tmp_path):
+        """The typed password appears nowhere in the terminal output.
+
+        It is prompted with `hide_input`, never taken from the argv (where it
+        would land in shell history and in every `ps` listing on the host), and
+        never printed back in the success message.
+        """
+        config_file = self._config(tmp_path)
+        secret = "unmistakable-secret-42"  # gitleaks:allow -- fake, asserted NOT to leak
+
+        with patch(self._ROTATE):
+            with patch("osprey.cli.deploy_cmd.resolve_config_path") as mock_resolve:
+                mock_resolve.return_value = config_file
+                result = cli_runner.invoke(
+                    deploy,
+                    ["passwd", "alice", "--config", str(config_file)],
+                    input=f"{secret}\n{secret}\n",
+                )
+
+        assert result.exit_code == 0
+        assert secret not in result.output
+
+    def test_passwd_requires_the_password_to_be_confirmed(self, cli_runner, tmp_path):
+        """A mistyped password must not be accepted on the strength of one
+        entry: it would lock the user out of a terminal that worked a moment
+        ago, and the operator would have no way to know what they typed."""
+        config_file = self._config(tmp_path)
+
+        with patch(self._ROTATE) as mock_rotate:
+            with patch("osprey.cli.deploy_cmd.resolve_config_path") as mock_resolve:
+                mock_resolve.return_value = config_file
+                result = cli_runner.invoke(
+                    deploy,
+                    ["passwd", "alice", "--config", str(config_file)],
+                    input="typed-one-way\ntyped-another-way\n",
+                )
+
+        assert result.exit_code != 0
+        assert not mock_rotate.called
+
+    def test_passwd_refusal_exits_non_zero_with_the_reason(self, cli_runner, tmp_path):
+        """A refusal from the rotation verb (auth off, IdP-held credentials, or
+        an off-roster user) surfaces as a non-zero exit carrying its reason —
+        never as a success message over a password that did not change."""
+        config_file = self._config(tmp_path)
+        refusal = "modules.web_terminals.auth.method is 'none'"
+
+        with patch(self._ROTATE, side_effect=ValueError(refusal)):
+            with patch("osprey.cli.deploy_cmd.resolve_config_path") as mock_resolve:
+                mock_resolve.return_value = config_file
+                result = cli_runner.invoke(
+                    deploy,
+                    ["passwd", "alice", "--config", str(config_file)],
+                    input="s3cr3t-pw\ns3cr3t-pw\n",
+                )
+
+        assert result.exit_code != 0
+        flat = _flat(result.output)
+        assert "auth.method" in flat
+        assert "Password changed" not in flat

--- a/tests/cli/test_dockerfile_template.py
+++ b/tests/cli/test_dockerfile_template.py
@@ -14,6 +14,7 @@
   shipping a broken recipe.
 """
 
+import fnmatch
 import json
 import os
 import re
@@ -375,6 +376,50 @@ class TestDockerignore:
             assert required in entries, f"{required} missing from .dockerignore"
         # .env.example is safe and useful inside the image — must be re-included
         assert "!.env.example" in entries
+
+    def test_auth_and_production_env_are_excluded(self, hello_project):
+        """Named regression guard for the two files that carry live credentials.
+
+        ``.env.auth`` holds the web-terminal password hashes and the sidecar's
+        session-signing secrets; ``.env.production`` holds the provider secrets
+        a multi-user deploy generates at the project root — the same root the
+        persona images are then built from, so an unexcluded one is baked into
+        every agent image.
+
+        Asserted by **matching** rather than by literal line, and separately
+        from :meth:`test_secrets_and_host_state_excluded`, which pins the
+        template's own spelling. Today one ``.env*`` glob covers both; a future
+        rewrite to explicit entries, or to a narrower pattern, keeps this test
+        meaningful either way, and the names stay written down where the reason
+        for excluding them is.
+
+        Last-match-wins with negation, the way both git and Docker resolve it —
+        a later ``!.env.auth`` would re-expose the file, so polarity is carried
+        through the whole scan rather than returning on the first hit. That
+        makes ORDER load-bearing, which is why this reads the file's lines
+        directly instead of reusing :meth:`_entries`: that helper returns a
+        *set*, and resolving a last-match rule over an unordered collection
+        would decide ``.env.example``'s fate at random.
+        """
+        lines = [
+            line.strip()
+            for line in (hello_project / ".dockerignore").read_text().splitlines()
+            if line.strip() and not line.startswith("#")
+        ]
+
+        def _ignored(name: str) -> bool:
+            ignored = False
+            for entry in lines:
+                pattern = entry[1:] if entry.startswith("!") else entry
+                if fnmatch.fnmatch(name, pattern.strip("/")):
+                    ignored = not entry.startswith("!")
+            return ignored
+
+        for secret in (".env.auth", ".env.production"):
+            assert _ignored(secret), f"{secret} would be baked into the image"
+        # Positive control: the negation that keeps the documented variable
+        # list in the image must still win over the glob that covers it.
+        assert not _ignored(".env.example"), ".env.example should stay in the image"
 
     def test_dockerfile_excluded_but_not_dockerignore(self, hello_project):
         """The wheel layer's ``COPY .dockerignore *.wh[l]`` needs .dockerignore to

--- a/tests/cli/test_templates.py
+++ b/tests/cli/test_templates.py
@@ -228,6 +228,23 @@ class TestGitIsolation:
         assert ".claude/settings.local.json" in gitignore_content
         assert "CLAUDE.local.md" in gitignore_content
 
+    def test_gitignore_ignores_secret_env_files(self, tmp_path):
+        """Every secret env file is ignored by name.
+
+        ``.env.auth`` (the web-terminal password hashes) and ``.env.production``
+        (the provider secrets) each need their own entry: gitignore matches the
+        literal name, so the ``.env`` pattern does not cover them and their
+        contents would otherwise be committable.
+        """
+        runner = CliRunner()
+        result = runner.invoke(build, _build_args("secret-env-test", str(tmp_path)))
+
+        assert result.exit_code == 0, result.output
+        project_dir = tmp_path / "secret-env-test"
+        lines = [line.strip() for line in (project_dir / ".gitignore").read_text().splitlines()]
+        assert ".env" in lines
+        assert ".env.auth" in lines
+
     def test_claude_dir_in_initial_commit(self, tmp_path):
         """.claude/ artifacts are included in the initial commit."""
         import subprocess

--- a/tests/cli/test_templates.py
+++ b/tests/cli/test_templates.py
@@ -229,21 +229,41 @@ class TestGitIsolation:
         assert "CLAUDE.local.md" in gitignore_content
 
     def test_gitignore_ignores_secret_env_files(self, tmp_path):
-        """Every secret env file is ignored by name.
+        """Every secret env file is genuinely ignored, and ``.env.example`` is not.
 
         ``.env.auth`` (the web-terminal password hashes) and ``.env.production``
-        (the provider secrets) each need their own entry: gitignore matches the
-        literal name, so the ``.env`` pattern does not cover them and their
-        contents would otherwise be committable.
+        (the provider secrets) hold credentials that must never become
+        committable. Asked of **git itself** rather than by looking for literal
+        lines: the template covers them with a ``.env*`` glob, so a line-by-line
+        check would pass or fail on how the ignore file happens to be spelled
+        rather than on whether these files are actually covered. ``.env.example``
+        is the documented variable list and carries no secrets, so the
+        negation that keeps it tracked is asserted as the positive control —
+        without it, a bare ``.env*`` would swallow it too.
         """
+        import subprocess
+
         runner = CliRunner()
         result = runner.invoke(build, _build_args("secret-env-test", str(tmp_path)))
 
         assert result.exit_code == 0, result.output
         project_dir = tmp_path / "secret-env-test"
-        lines = [line.strip() for line in (project_dir / ".gitignore").read_text().splitlines()]
-        assert ".env" in lines
-        assert ".env.auth" in lines
+
+        def _ignored(name: str) -> bool:
+            # check-ignore resolves pattern matching over path NAMES, so the
+            # files need not exist; exit 0 means "some pattern ignores this".
+            return (
+                subprocess.run(
+                    ["git", "check-ignore", "-q", name],
+                    cwd=project_dir,
+                    capture_output=True,
+                ).returncode
+                == 0
+            )
+
+        for secret in (".env", ".env.auth", ".env.production"):
+            assert _ignored(secret), f"{secret} carries secrets but git would let it be committed"
+        assert not _ignored(".env.example"), ".env.example must stay tracked"
 
     def test_claude_dir_in_initial_commit(self, tmp_path):
         """.claude/ artifacts are included in the initial commit."""

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -1341,3 +1341,87 @@ def test_workflow_on_key_parses_to_bool_true_not_string(workflow: dict[str, Any]
     only ever indexes workflow['jobs']."""
     assert True in workflow
     assert "on" not in workflow
+
+
+# ---------------------------------------------------------------------------
+# (h) multi-user login-flow browser test: registered in the lane, and the lane
+# is actually triggered by the code it covers
+# ---------------------------------------------------------------------------
+
+BROWSER_JOB = "visual-theming"
+BROWSER_RUN_STEP = "Run behavioral theming suite"
+BROWSER_FILTER_STEP = "Detect design-system / dispatch dashboard changes"
+AUTH_BROWSER_TEST_FILE = "tests/interfaces/web_terminal/test_auth_login_browser.py"
+AUTH_SERVING_TEST_FILE = "tests/deployment/web_terminals/test_auth_serving.py"
+AUTH_PERIMETER_PATHS = (
+    "src/osprey/services/auth_sidecar/**",
+    "src/osprey/deployment/web_terminals/**",
+    "src/osprey/templates/modules/web_terminals/**",
+    AUTH_SERVING_TEST_FILE,
+)
+
+
+def _browser_lane_files(wf: dict[str, Any]) -> str:
+    return _find_named_step(wf, BROWSER_JOB, BROWSER_RUN_STEP)["run"]
+
+
+def _browser_lane_filter_paths(wf: dict[str, Any]) -> list[str]:
+    """The `theming` filter's path list, parsed out of the step's `filters` blob.
+
+    dorny/paths-filter takes its filters as a YAML *string*, so the outer
+    safe_load leaves this as text and it has to be parsed a second time —
+    still structurally, never by substring matching.
+    """
+    step = _find_named_step(wf, BROWSER_JOB, BROWSER_FILTER_STEP)
+    return yaml.safe_load(step["with"]["filters"])["theming"]
+
+
+def test_login_flow_browser_test_runs_in_the_browser_lane(workflow: dict[str, Any]) -> None:
+    """The suite has to be NAMED in the lane's pytest invocation.
+
+    The lane runs an explicit file list, not a directory glob, so a new
+    browser-marked file that nobody adds here is never collected anywhere: the
+    unit lane skips it (no chromium), and this lane never hears of it. It
+    reports green by running nothing at all."""
+    assert AUTH_BROWSER_TEST_FILE in _browser_lane_files(workflow)
+
+
+def test_login_flow_browser_test_runs_in_the_browser_lane__mutation_drops_the_file() -> None:
+    """Removing the file from the invocation must fail the guard — the exact
+    vacuous-green shape above."""
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, BROWSER_JOB, BROWSER_RUN_STEP)
+    step["run"] = step["run"].replace(f"{AUTH_BROWSER_TEST_FILE} \\\n", "")
+    assert AUTH_BROWSER_TEST_FILE not in _browser_lane_files(mutated)
+
+
+def test_browser_lane_is_triggered_by_the_perimeter_it_covers(workflow: dict[str, Any]) -> None:
+    """Every path the login-flow test actually exercises must arm the lane.
+
+    The filter was written for `interfaces/` and `dispatch/`, but this suite
+    drives the auth sidecar, the rendered nginx config and the shared container
+    fixture — none of which live there. Left unlisted, a PR that changes the
+    login page or the perimeter template skips every gated step in this job,
+    which GitHub reports as a job SUCCESS. The proof would be silently gone at
+    exactly the moment it mattered."""
+    paths = _browser_lane_filter_paths(workflow)
+    missing = [path for path in AUTH_PERIMETER_PATHS if path not in paths]
+    assert missing == [], (
+        f"the '{BROWSER_JOB}' lane is not triggered by {missing}, so a change there would "
+        f"green-skip {AUTH_BROWSER_TEST_FILE} instead of running it"
+    )
+
+
+def test_browser_lane_is_triggered_by_the_perimeter__mutation_drops_the_sidecar_path() -> None:
+    """Dropping the sidecar source from the filter must be reported missing."""
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, BROWSER_JOB, BROWSER_FILTER_STEP)
+    filters = yaml.safe_load(step["with"]["filters"])
+    filters["theming"] = [
+        path for path in filters["theming"] if path != "src/osprey/services/auth_sidecar/**"
+    ]
+    step["with"]["filters"] = yaml.safe_dump(filters)
+    paths = _browser_lane_filter_paths(mutated)
+    assert [p for p in AUTH_PERIMETER_PATHS if p not in paths] == [
+        "src/osprey/services/auth_sidecar/**"
+    ]

--- a/tests/deployment/test_container_lifecycle.py
+++ b/tests/deployment/test_container_lifecycle.py
@@ -1811,6 +1811,45 @@ def test_deploy_up_runs_web_terminal_preflight_before_image_build(monkeypatch, t
     assert order == ["preflight", "build_image", "web_up"]
 
 
+def test_deploy_up_threads_the_preflight_result_into_the_web_stack(monkeypatch, tmp_path):
+    """The preflight result must reach deploy_up_web_terminals, not be dropped:
+    it is the only thing that knows whether THIS deploy changed .env.auth, and
+    compose baked the old file into the running sidecar at creation time.
+    Provisioning is idempotent, so re-deriving it later would report no change
+    and the sidecar would keep serving the previous credentials."""
+    from osprey.deployment.web_terminals.provision import WebTerminalPreflightResult
+
+    captured: list = []
+    result = WebTerminalPreflightResult(auth_env_changed=True)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        container_lifecycle,
+        "prepare_compose_files",
+        lambda *a, **k: (
+            {"deployed_services": [], "modules": {"web_terminals": {"enabled": True}}},
+            ["docker-compose.yml"],
+        ),
+    )
+    monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
+    monkeypatch.setattr(container_lifecycle, "_preflight_host_ports", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "_ensure_service_tokens", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "_build_project_image", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "log_endpoint_summary", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "preflight_web_terminals", lambda *a, **k: result)
+    monkeypatch.setattr(
+        container_lifecycle,
+        "deploy_up_web_terminals",
+        lambda *args, **kwargs: captured.append((args, kwargs)),
+    )
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    assert len(captured) == 1
+    args, kwargs = captured[0]
+    assert result in args or kwargs.get("preflight") is result
+
+
 def test_deploy_up_no_web_terminals_skips_preflight(monkeypatch, tmp_path):
     order: list[str] = []
 

--- a/tests/deployment/web_terminals/test_auth_credentials.py
+++ b/tests/deployment/web_terminals/test_auth_credentials.py
@@ -1,0 +1,817 @@
+"""Tests for deploy-time web-terminal auth credential provisioning."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from osprey.deployment.web_terminals.auth_credentials import (
+    _HASH_HEADER,
+    AUTH_ENV_FILENAME,
+    PW_HASH_VAR_PREFIX,
+    PW_PLAINTEXT_VAR_PREFIX,
+    SESSION_SECRET_VAR,
+    STATE_SECRET_VAR,
+    ensure_auth_credentials,
+    ensure_auth_session_secrets,
+    purge_auth_credentials,
+    set_auth_password,
+)
+from osprey.services.auth_sidecar.passwords import generation_tag, verify_password
+from osprey.utils.dotenv import parse_dotenv_file
+
+pytestmark = pytest.mark.unit
+
+# The unwritable-file cases below rely on the OS honoring a read-only mode.
+# root ignores it, so those assertions would be vacuous there.
+running_as_root = hasattr(os, "geteuid") and os.geteuid() == 0
+
+
+class Echo:
+    """Collects the one-time minted-password notices."""
+
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+
+    def __call__(self, message: str) -> None:
+        self.lines.append(message)
+
+    @property
+    def text(self) -> str:
+        return "\n".join(self.lines)
+
+
+def read_auth_env(project_root: Path) -> dict[str, str]:
+    return parse_dotenv_file(project_root / AUTH_ENV_FILENAME)
+
+
+def file_mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def test_mints_hash_for_a_user_with_no_credential(tmp_path: Path) -> None:
+    echo = Echo()
+
+    result = ensure_auth_credentials(["alice"], tmp_path, echo=echo)
+
+    assert result.minted == ("alice",)
+    assert result.hashed_from_plaintext == ()
+    assert result.preexisting == ()
+    assert result.missing == ()
+    assert result.changed is True
+    assert result.env_auth_path == tmp_path / AUTH_ENV_FILENAME
+
+    stored = read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"]
+    assert stored.startswith("scrypt$")
+
+
+def test_env_auth_is_created_0600(tmp_path: Path) -> None:
+    ensure_auth_credentials(["alice"], tmp_path, echo=Echo())
+
+    assert file_mode(tmp_path / AUTH_ENV_FILENAME) == 0o600
+
+
+def test_existing_env_auth_with_loose_mode_is_tightened(tmp_path: Path) -> None:
+    env_auth = tmp_path / AUTH_ENV_FILENAME
+    env_auth.write_text(f"{PW_HASH_VAR_PREFIX}ALICE=scrypt$16384$8$1$c2FsdA$a2V5\n")
+    env_auth.chmod(0o644)
+
+    result = ensure_auth_credentials(["alice"], tmp_path, echo=Echo())
+
+    assert result.changed is False  # a permission fix is not a content change
+    assert file_mode(env_auth) == 0o600
+
+
+def test_minted_password_is_printed_exactly_once_and_verifies(tmp_path: Path) -> None:
+    echo = Echo()
+
+    ensure_auth_credentials(["alice"], tmp_path, echo=echo)
+
+    # Recover the printed password from the notice, then prove it is the one
+    # the stored hash accepts.
+    notice = next(line for line in echo.lines if "'alice'" in line)
+    password = notice.rsplit(": ", 1)[1]
+    assert password.isalnum()  # dotenv-safe, no transcription lookalikes
+    assert echo.text.count(password) == 1
+
+    stored = read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"]
+    assert verify_password(password, stored)
+    assert not verify_password("wrong-password", stored)
+
+
+def test_minted_password_never_reaches_the_log(tmp_path: Path, caplog) -> None:
+    echo = Echo()
+
+    with caplog.at_level("DEBUG"):
+        ensure_auth_credentials(["alice"], tmp_path, echo=echo)
+
+    # Prove the instrument works before asserting on what it did NOT capture.
+    assert f"{PW_HASH_VAR_PREFIX}ALICE" in caplog.text
+
+    password = next(line for line in echo.lines if "'alice'" in line).rsplit(": ", 1)[1]
+    assert password not in caplog.text
+    stored = read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"]
+    assert stored not in caplog.text
+
+
+def test_plaintext_from_project_dotenv_is_hashed_in(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text(f"{PW_PLAINTEXT_VAR_PREFIX}ALICE=operator-choice\n")
+    echo = Echo()
+
+    result = ensure_auth_credentials(["alice"], tmp_path, echo=echo)
+
+    assert result.hashed_from_plaintext == ("alice",)
+    assert result.minted == ()
+    assert result.changed is True
+
+    stored = read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"]
+    assert verify_password("operator-choice", stored)
+    # The plaintext is neither echoed nor copied into the sidecar's env file.
+    assert "operator-choice" not in echo.text
+    assert "operator-choice" not in (tmp_path / AUTH_ENV_FILENAME).read_text()
+
+
+def test_existing_hash_wins_over_plaintext(tmp_path: Path) -> None:
+    existing = f"{PW_HASH_VAR_PREFIX}ALICE=scrypt$16384$8$1$c2FsdA$a2V5"
+    (tmp_path / AUTH_ENV_FILENAME).write_text(f"{existing}\n")
+    (tmp_path / ".env").write_text(f"{PW_PLAINTEXT_VAR_PREFIX}ALICE=operator-choice\n")
+
+    result = ensure_auth_credentials(["alice"], tmp_path, echo=Echo())
+
+    assert result.preexisting == ("alice",)
+    assert result.changed is False
+    assert read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"] == existing.split("=", 1)[1]
+
+
+def test_plaintext_wins_over_minting(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text(f"{PW_PLAINTEXT_VAR_PREFIX}BOB=bobs-password\n")
+    echo = Echo()
+
+    result = ensure_auth_credentials(["alice", "bob"], tmp_path, echo=echo)
+
+    assert result.minted == ("alice",)
+    assert result.hashed_from_plaintext == ("bob",)
+    assert "'bob'" not in echo.text
+
+
+def test_rerun_is_idempotent_and_reports_no_change(tmp_path: Path) -> None:
+    ensure_auth_credentials(["alice", "bob"], tmp_path, echo=Echo())
+    before = (tmp_path / AUTH_ENV_FILENAME).read_text()
+
+    echo = Echo()
+    result = ensure_auth_credentials(["alice", "bob"], tmp_path, echo=echo)
+
+    assert result.changed is False
+    assert result.preexisting == ("alice", "bob")
+    assert result.minted == ()
+    assert echo.lines == []
+    assert (tmp_path / AUTH_ENV_FILENAME).read_text() == before
+
+
+def test_only_the_missing_user_is_appended(tmp_path: Path) -> None:
+    ensure_auth_credentials(["alice"], tmp_path, echo=Echo())
+    alice_hash = read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"]
+
+    result = ensure_auth_credentials(["alice", "bob"], tmp_path, echo=Echo())
+
+    assert result.preexisting == ("alice",)
+    assert result.minted == ("bob",)
+    stored = read_auth_env(tmp_path)
+    assert stored[f"{PW_HASH_VAR_PREFIX}ALICE"] == alice_hash
+    assert stored[f"{PW_HASH_VAR_PREFIX}BOB"].startswith("scrypt$")
+
+
+def test_append_to_a_file_without_a_trailing_newline(tmp_path: Path) -> None:
+    (tmp_path / AUTH_ENV_FILENAME).write_text("# hand-written, no trailing newline")
+
+    ensure_auth_credentials(["alice"], tmp_path, echo=Echo())
+
+    assert f"{PW_HASH_VAR_PREFIX}ALICE" in read_auth_env(tmp_path)
+    text = (tmp_path / AUTH_ENV_FILENAME).read_text()
+    assert "newline#" not in text  # the appended block starts on its own line
+
+
+def test_a_hash_in_the_process_env_does_not_suppress_minting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The sidecar reads .env.auth only, so a hash visible just to this process
+    # must not stand in for a persisted one.
+    monkeypatch.setenv(f"{PW_HASH_VAR_PREFIX}ALICE", "scrypt$16384$8$1$c2FsdA$a2V5")
+
+    result = ensure_auth_credentials(["alice"], tmp_path, echo=Echo())
+
+    assert result.minted == ("alice",)
+    assert read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"] != "scrypt$16384$8$1$c2FsdA$a2V5"
+
+
+def test_plaintext_is_not_read_from_the_process_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A stray exported variable must not silently become a deployed credential.
+    monkeypatch.setenv(f"{PW_PLAINTEXT_VAR_PREFIX}ALICE", "exported-password")
+
+    result = ensure_auth_credentials(["alice"], tmp_path, echo=Echo())
+
+    assert result.minted == ("alice",)
+    stored = read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"]
+    assert not verify_password("exported-password", stored)
+
+
+def test_a_user_listed_twice_is_provisioned_once(tmp_path: Path) -> None:
+    result = ensure_auth_credentials(["alice", "alice"], tmp_path, echo=Echo())
+
+    assert result.minted == ("alice",)
+    text = (tmp_path / AUTH_ENV_FILENAME).read_text()
+    assert text.count(f"{PW_HASH_VAR_PREFIX}ALICE=") == 1
+
+
+def test_empty_roster_writes_nothing(tmp_path: Path) -> None:
+    result = ensure_auth_credentials([], tmp_path, echo=Echo())
+
+    assert result.changed is False
+    assert not (tmp_path / AUTH_ENV_FILENAME).exists()
+
+
+@pytest.mark.parametrize("username", ["Alice", "al ice", "-alice", "alice.b", "_alice"])
+def test_invalid_username_charset_raises(tmp_path: Path, username: str) -> None:
+    with pytest.raises(RuntimeError, match="Refusing to deploy"):
+        ensure_auth_credentials([username], tmp_path, echo=Echo())
+
+    assert not (tmp_path / AUTH_ENV_FILENAME).exists()
+
+
+def test_username_with_a_trailing_newline_is_rejected(tmp_path: Path) -> None:
+    """The charset gate is a `fullmatch`, not a `match`.
+
+    Python's `$` also matches *before* a trailing newline, so a `match` would let
+    "alice\\n" through this deploy-path gate and on into an nginx location key.
+    """
+    with pytest.raises(RuntimeError, match="Refusing to deploy"):
+        ensure_auth_credentials(["alice\n"], tmp_path, echo=Echo())
+
+    assert not (tmp_path / AUTH_ENV_FILENAME).exists()
+
+
+def test_env_var_suffix_collision_raises_naming_both_users(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError) as excinfo:
+        ensure_auth_credentials(["alice-b", "alice_b"], tmp_path, echo=Echo())
+
+    message = str(excinfo.value)
+    assert "'alice-b'" in message
+    assert "'alice_b'" in message
+    assert f"{PW_HASH_VAR_PREFIX}ALICE_B" in message
+    # Nothing is written when the roster is ambiguous.
+    assert not (tmp_path / AUTH_ENV_FILENAME).exists()
+
+
+@pytest.mark.skipif(running_as_root, reason="root ignores the read-only mode this test relies on")
+def test_unwritable_env_auth_reports_missing_without_raising(tmp_path: Path) -> None:
+    env_auth = tmp_path / AUTH_ENV_FILENAME
+    env_auth.write_text("# pre-existing\n")
+    env_auth.chmod(0o400)
+    echo = Echo()
+    try:
+        result = ensure_auth_credentials(["alice", "bob"], tmp_path, echo=echo)
+    finally:
+        env_auth.chmod(0o600)
+
+    assert result.missing == ("alice", "bob")
+    assert result.changed is False
+    assert result.minted == ()
+    # A password that could not be persisted is never shown to the operator.
+    assert echo.lines == []
+
+
+def test_empty_hash_value_is_re_minted_and_the_new_entry_wins(tmp_path: Path) -> None:
+    # An empty value is not an established credential — left alone it would
+    # lock the user out permanently. The re-minted entry is appended after the
+    # empty one, and last assignment wins for the parser the sidecar shares.
+    (tmp_path / AUTH_ENV_FILENAME).write_text(f"{PW_HASH_VAR_PREFIX}ALICE=\n")
+    echo = Echo()
+
+    result = ensure_auth_credentials(["alice"], tmp_path, echo=echo)
+
+    assert result.minted == ("alice",)
+    assert result.preexisting == ()
+    assert result.changed is True
+
+    password = next(line for line in echo.lines if "'alice'" in line).rsplit(": ", 1)[1]
+    assert verify_password(password, read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"])
+
+
+def test_whitespace_padded_plaintext_is_trimmed_before_hashing(tmp_path: Path) -> None:
+    # The trim makes the stored hash match what the operator types at the
+    # prompt, rather than a value only a copy-paste could reproduce.
+    (tmp_path / ".env").write_text(f"{PW_PLAINTEXT_VAR_PREFIX}ALICE=  padded-password  \n")
+
+    result = ensure_auth_credentials(["alice"], tmp_path, echo=Echo())
+
+    assert result.hashed_from_plaintext == ("alice",)
+    stored = read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"]
+    assert verify_password("padded-password", stored)
+    assert not verify_password("  padded-password  ", stored)
+
+
+def test_whitespace_only_plaintext_falls_through_to_minting(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text(f'{PW_PLAINTEXT_VAR_PREFIX}ALICE="   "\n')
+
+    result = ensure_auth_credentials(["alice"], tmp_path, echo=Echo())
+
+    assert result.minted == ("alice",)
+    assert result.hashed_from_plaintext == ()
+
+
+@pytest.mark.skipif(running_as_root, reason="root ignores the read-only mode this test relies on")
+def test_a_failing_chmod_does_not_break_the_reported_not_raised_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # On a read-only filesystem the append AND the trailing permission fix both
+    # fail. The write failure must still surface through `missing` rather than
+    # as an escaping OSError from the last statement in the function.
+    env_auth = tmp_path / AUTH_ENV_FILENAME
+    env_auth.write_text("# pre-existing\n")
+    env_auth.chmod(0o400)
+
+    real_chmod = os.chmod
+
+    def failing_chmod(path, mode, *args, **kwargs):
+        if str(path) == str(env_auth):
+            raise OSError(30, "Read-only file system")
+        return real_chmod(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(os, "chmod", failing_chmod)
+    try:
+        result = ensure_auth_credentials(["alice"], tmp_path, echo=Echo())
+    finally:
+        monkeypatch.undo()
+        env_auth.chmod(0o600)
+
+    assert result.missing == ("alice",)
+    assert result.changed is False
+
+
+def test_a_failing_chmod_still_returns_a_successful_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    real_chmod = os.chmod
+
+    def failing_chmod(path, mode, *args, **kwargs):
+        if str(path).endswith(AUTH_ENV_FILENAME):
+            raise OSError(1, "Operation not permitted")
+        return real_chmod(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(os, "chmod", failing_chmod)
+    result = ensure_auth_credentials(["alice"], tmp_path, echo=Echo())
+
+    assert result.changed is True
+    assert result.minted == ("alice",)
+    assert result.missing == ()
+    assert f"{PW_HASH_VAR_PREFIX}ALICE" in read_auth_env(tmp_path)
+
+
+def test_purge_normalizes_crlf_input_but_keeps_line_content(tmp_path: Path) -> None:
+    (tmp_path / AUTH_ENV_FILENAME).write_bytes(
+        b"# header\r\n"
+        b"OSPREY_AUTH_PW_HASH_ALICE=scrypt$16384$8$1$c2FsdA$a2V5\r\n"
+        b"OSPREY_AUTH_PW_HASH_BOB=scrypt$16384$8$1$c2FsdA$Ym9i\r\n"
+    )
+
+    assert purge_auth_credentials("alice", tmp_path) is True
+
+    text = (tmp_path / AUTH_ENV_FILENAME).read_text()
+    assert "ALICE" not in text
+    assert "\r" not in text  # CRLF is normalized to LF on rewrite
+    assert text == "# header\nOSPREY_AUTH_PW_HASH_BOB=scrypt$16384$8$1$c2FsdA$Ym9i\n"
+
+
+def test_purge_removes_only_the_named_users_entries(tmp_path: Path) -> None:
+    ensure_auth_credentials(["alice", "bob"], tmp_path, echo=Echo())
+    bob_hash = read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}BOB"]
+
+    changed = purge_auth_credentials("alice", tmp_path)
+
+    assert changed is True
+    stored = read_auth_env(tmp_path)
+    assert f"{PW_HASH_VAR_PREFIX}ALICE" not in stored
+    assert stored[f"{PW_HASH_VAR_PREFIX}BOB"] == bob_hash
+
+
+def test_purge_removes_a_hand_placed_plaintext_entry(tmp_path: Path) -> None:
+    (tmp_path / AUTH_ENV_FILENAME).write_text(
+        f"{PW_PLAINTEXT_VAR_PREFIX}ALICE=hand-placed\n"
+        f"export {PW_HASH_VAR_PREFIX}ALICE=scrypt$16384$8$1$c2FsdA$a2V5\n"
+        "# keep me\n"
+    )
+
+    assert purge_auth_credentials("alice", tmp_path) is True
+
+    text = (tmp_path / AUTH_ENV_FILENAME).read_text()
+    assert "ALICE" not in text
+    assert "# keep me" in text
+
+
+def test_purge_preserves_mode_and_leaves_no_temporary_file(tmp_path: Path) -> None:
+    ensure_auth_credentials(["alice", "bob"], tmp_path, echo=Echo())
+
+    purge_auth_credentials("alice", tmp_path)
+
+    assert file_mode(tmp_path / AUTH_ENV_FILENAME) == 0o600
+    assert [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")] == []
+
+
+def test_purge_is_a_no_op_for_an_unknown_user(tmp_path: Path) -> None:
+    ensure_auth_credentials(["alice"], tmp_path, echo=Echo())
+    before = (tmp_path / AUTH_ENV_FILENAME).read_text()
+
+    assert purge_auth_credentials("carol", tmp_path) is False
+    assert (tmp_path / AUTH_ENV_FILENAME).read_text() == before
+
+
+def test_purge_is_a_no_op_when_env_auth_is_absent(tmp_path: Path) -> None:
+    assert purge_auth_credentials("alice", tmp_path) is False
+    assert not (tmp_path / AUTH_ENV_FILENAME).exists()
+
+
+def test_purge_uses_the_same_suffix_mapping_as_provisioning(tmp_path: Path) -> None:
+    ensure_auth_credentials(["alice-b"], tmp_path, echo=Echo())
+    assert f"{PW_HASH_VAR_PREFIX}ALICE_B" in read_auth_env(tmp_path)
+
+    assert purge_auth_credentials("alice-b", tmp_path) is True
+    assert read_auth_env(tmp_path) == {}
+
+
+def test_readded_user_gets_a_fresh_credential_after_purge(tmp_path: Path) -> None:
+    echo = Echo()
+    ensure_auth_credentials(["alice"], tmp_path, echo=echo)
+    old_password = next(line for line in echo.lines if "'alice'" in line).rsplit(": ", 1)[1]
+
+    purge_auth_credentials("alice", tmp_path)
+    ensure_auth_credentials(["alice"], tmp_path, echo=Echo())
+
+    stored = read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"]
+    assert not verify_password(old_password, stored)
+
+
+# --- Session/state signing secrets (task 4.2) --------------------------------
+
+
+def test_secrets_are_minted_into_env_auth(tmp_path: Path) -> None:
+    result = ensure_auth_session_secrets(tmp_path)
+
+    assert result.minted == (SESSION_SECRET_VAR, STATE_SECRET_VAR)
+    assert result.preexisting == ()
+    assert result.missing == ()
+    assert result.changed is True
+
+    stored = read_auth_env(tmp_path)
+    # token_urlsafe(32) — 256 bits, the shared service-token recipe.
+    assert len(stored[SESSION_SECRET_VAR]) >= 40
+    assert stored[SESSION_SECRET_VAR] != stored[STATE_SECRET_VAR]
+
+
+def test_secret_minting_creates_env_auth_0600(tmp_path: Path) -> None:
+    ensure_auth_session_secrets(tmp_path)
+
+    assert file_mode(tmp_path / AUTH_ENV_FILENAME) == 0o600
+
+
+def test_secrets_are_idempotent_and_report_no_change(tmp_path: Path) -> None:
+    ensure_auth_session_secrets(tmp_path)
+    before = (tmp_path / AUTH_ENV_FILENAME).read_text()
+
+    result = ensure_auth_session_secrets(tmp_path)
+
+    # Re-minting would invalidate every live session.
+    assert result.changed is False
+    assert result.minted == ()
+    assert result.preexisting == (SESSION_SECRET_VAR, STATE_SECRET_VAR)
+    assert (tmp_path / AUTH_ENV_FILENAME).read_text() == before
+
+
+def test_an_existing_secret_is_never_overwritten(tmp_path: Path) -> None:
+    (tmp_path / AUTH_ENV_FILENAME).write_text(f"{SESSION_SECRET_VAR}=operator-chosen-secret\n")
+
+    result = ensure_auth_session_secrets(tmp_path)
+
+    assert result.preexisting == (SESSION_SECRET_VAR,)
+    assert result.minted == (STATE_SECRET_VAR,)
+    assert read_auth_env(tmp_path)[SESSION_SECRET_VAR] == "operator-chosen-secret"
+
+
+@pytest.mark.parametrize("empty_value", ["", "   "])
+def test_an_empty_secret_is_re_minted(tmp_path: Path, empty_value: str) -> None:
+    # The sidecar strips and rejects an empty value as missing configuration
+    # and answers every request with 503, so preserving it would keep the whole
+    # deployment locked out.
+    (tmp_path / AUTH_ENV_FILENAME).write_text(f'{SESSION_SECRET_VAR}="{empty_value}"\n')
+
+    result = ensure_auth_session_secrets(tmp_path)
+
+    assert SESSION_SECRET_VAR in result.minted
+    assert read_auth_env(tmp_path)[SESSION_SECRET_VAR].strip()
+
+
+def test_secrets_never_reach_the_log(tmp_path: Path, caplog) -> None:
+    with caplog.at_level("DEBUG"):
+        ensure_auth_session_secrets(tmp_path)
+
+    # The instrument works: variable names ARE logged.
+    assert SESSION_SECRET_VAR in caplog.text
+    stored = read_auth_env(tmp_path)
+    assert stored[SESSION_SECRET_VAR] not in caplog.text
+    assert stored[STATE_SECRET_VAR] not in caplog.text
+
+
+def test_secrets_coexist_with_password_hashes_in_one_file(tmp_path: Path) -> None:
+    ensure_auth_credentials(["alice"], tmp_path, echo=Echo())
+    secrets_result = ensure_auth_session_secrets(tmp_path)
+
+    assert secrets_result.changed is True
+    stored = read_auth_env(tmp_path)
+    assert stored[f"{PW_HASH_VAR_PREFIX}ALICE"].startswith("scrypt$")
+    assert stored[SESSION_SECRET_VAR]
+    # Order-independent: minting secrets first must not disturb the hashes.
+    assert ensure_auth_credentials(["alice"], tmp_path, echo=Echo()).changed is False
+
+
+def test_secret_minting_is_not_wired_through_service_token_vars() -> None:
+    # _SERVICE_TOKEN_VARS only mints for members of `deployed_services`, which
+    # no web-terminal-stack service ever is — an entry there would silently
+    # mint nothing.
+    from osprey.deployment.container_lifecycle import _SERVICE_TOKEN_VARS
+
+    declared = {var for vars_ in _SERVICE_TOKEN_VARS.values() for var in vars_}
+    assert SESSION_SECRET_VAR not in declared
+    assert STATE_SECRET_VAR not in declared
+
+
+@pytest.mark.skipif(running_as_root, reason="root ignores the read-only mode this test relies on")
+def test_unwritable_env_auth_reports_missing_secrets_without_raising(tmp_path: Path) -> None:
+    env_auth = tmp_path / AUTH_ENV_FILENAME
+    env_auth.write_text("# pre-existing\n")
+    env_auth.chmod(0o400)
+    try:
+        result = ensure_auth_session_secrets(tmp_path)
+    finally:
+        env_auth.chmod(0o600)
+
+    assert result.missing == (SESSION_SECRET_VAR, STATE_SECRET_VAR)
+    assert result.minted == ()
+    assert result.changed is False
+
+
+def test_an_invalid_existing_secret_raises_without_echoing_the_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The validator is imported from service_tokens, so a constraint registered
+    # for these vars later takes effect on this path with no further work.
+    from osprey.deployment import service_tokens
+
+    monkeypatch.setitem(service_tokens._VAR_VALIDATORS, SESSION_SECRET_VAR, str.isalnum)
+    monkeypatch.setitem(
+        service_tokens._VAR_VALIDATOR_DESCRIPTIONS, SESSION_SECRET_VAR, "must be alphanumeric"
+    )
+    (tmp_path / AUTH_ENV_FILENAME).write_text(f"{SESSION_SECRET_VAR}=not+alphanumeric/value\n")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        ensure_auth_session_secrets(tmp_path)
+
+    message = str(excinfo.value)
+    assert SESSION_SECRET_VAR in message
+    assert "must be alphanumeric" in message
+    assert "not+alphanumeric/value" not in message
+
+
+# =============================================================================
+# set_auth_password: rotation (osprey deploy passwd)
+# =============================================================================
+
+
+def _hash_lines(project_root: Path, user_suffix: str) -> list[str]:
+    """Every raw line in .env.auth assigning that user's hash variable."""
+    text = (project_root / AUTH_ENV_FILENAME).read_text(encoding="utf-8")
+    var = f"{PW_HASH_VAR_PREFIX}{user_suffix}="
+    return [line for line in text.splitlines() if line.startswith(var)]
+
+
+def test_set_auth_password_stores_a_hash_that_verifies(tmp_path: Path) -> None:
+    assert set_auth_password("alice", "new-password", tmp_path) == tmp_path / AUTH_ENV_FILENAME
+
+    stored = read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"]
+    assert verify_password("new-password", stored)
+
+
+def test_set_auth_password_replaces_rather_than_appends(tmp_path: Path) -> None:
+    """The rotated file holds ONE entry for the user, not a new one after the old.
+
+    Appending would also "work" — the parser takes the last assignment — but the
+    superseded hash would stay readable in the file, and the file's correctness
+    would rest on parse order rather than on its content.
+    """
+    set_auth_password("alice", "first-password", tmp_path)
+    first = read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"]
+
+    set_auth_password("alice", "second-password", tmp_path)
+
+    assert len(_hash_lines(tmp_path, "ALICE")) == 1
+    stored = read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"]
+    assert stored != first
+    assert first not in (tmp_path / AUTH_ENV_FILENAME).read_text(encoding="utf-8")
+
+
+def test_set_auth_password_does_not_accumulate_across_repeated_rotations(tmp_path: Path) -> None:
+    for password in ("one", "two", "three", "four"):
+        set_auth_password("alice", password, tmp_path)
+
+    assert len(_hash_lines(tmp_path, "ALICE")) == 1
+    assert verify_password("four", read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"])
+
+
+def test_set_auth_password_does_not_accumulate_headers(tmp_path: Path) -> None:
+    """The file does not grow at all across rotations — not by entries, and not
+    by orphaned header comments either.
+
+    An append-style write emitted a fresh `# Auto-generated ...` header on every
+    rotation, so a facility rotating on a schedule accumulated one comment line
+    per rotation, each above nothing. The hash count stayed correct, which is
+    why this needs its own pin.
+    """
+    set_auth_password("alice", "first", tmp_path)
+    after_first = (tmp_path / AUTH_ENV_FILENAME).read_text(encoding="utf-8")
+
+    for password in ("second", "third", "fourth", "fifth"):
+        set_auth_password("alice", password, tmp_path)
+
+    text = (tmp_path / AUTH_ENV_FILENAME).read_text(encoding="utf-8")
+    assert text.count(_HASH_HEADER) == 1
+    # Same shape, same line count — only the hash value differs.
+    assert len(text.splitlines()) == len(after_first.splitlines())
+
+
+def test_set_auth_password_rotation_moves_no_other_line(tmp_path: Path) -> None:
+    """Substituted IN PLACE: every line except the user's own is byte-identical
+    and in the same position, so a rotation cannot reorder or drop a neighbour's
+    credential."""
+    ensure_auth_credentials(["alice", "bob"], tmp_path, echo=Echo())
+    ensure_auth_session_secrets(tmp_path)
+    before = (tmp_path / AUTH_ENV_FILENAME).read_text(encoding="utf-8").splitlines()
+
+    set_auth_password("alice", "alices-new-password", tmp_path)
+
+    after = (tmp_path / AUTH_ENV_FILENAME).read_text(encoding="utf-8").splitlines()
+    assert len(after) == len(before)
+    differing = [i for i, (a, b) in enumerate(zip(before, after, strict=True)) if a != b]
+    assert len(differing) == 1
+    assert after[differing[0]].startswith(f"{PW_HASH_VAR_PREFIX}ALICE=")
+
+
+def test_set_auth_password_only_the_old_password_stops_working(tmp_path: Path) -> None:
+    set_auth_password("alice", "old-password", tmp_path)
+    set_auth_password("alice", "new-password", tmp_path)
+
+    stored = read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"]
+    assert verify_password("new-password", stored)
+    assert not verify_password("old-password", stored)
+
+
+def test_set_auth_password_changes_the_generation_tag(tmp_path: Path) -> None:
+    """The tag is what ends the user's live sessions.
+
+    A session cookie carries the generation tag of the hash it was issued
+    against, so a rotation that left the tag unchanged would leave every
+    pre-rotation session valid — the opposite of what rotating a password means.
+    """
+    set_auth_password("alice", "old-password", tmp_path)
+    before = generation_tag(read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"])
+
+    set_auth_password("alice", "new-password", tmp_path)
+    after = generation_tag(read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"])
+
+    assert before != after
+
+
+def test_set_auth_password_leaves_other_users_untouched(tmp_path: Path) -> None:
+    ensure_auth_credentials(["alice", "bob"], tmp_path, echo=Echo())
+    bobs_hash = read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}BOB"]
+
+    set_auth_password("alice", "alices-new-password", tmp_path)
+
+    assert read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}BOB"] == bobs_hash
+    assert len(_hash_lines(tmp_path, "BOB")) == 1
+
+
+def test_set_auth_password_preserves_the_signing_secrets(tmp_path: Path) -> None:
+    """Rotating one password must not invalidate every OTHER user's session,
+    which is what dropping the session secret would do."""
+    ensure_auth_session_secrets(tmp_path)
+    before = read_auth_env(tmp_path)[SESSION_SECRET_VAR]
+
+    set_auth_password("alice", "alices-password", tmp_path)
+
+    assert read_auth_env(tmp_path)[SESSION_SECRET_VAR] == before
+
+
+def test_set_auth_password_creates_the_file_0600_when_absent(tmp_path: Path) -> None:
+    assert not (tmp_path / AUTH_ENV_FILENAME).exists()
+
+    set_auth_password("alice", "alices-password", tmp_path)
+
+    assert file_mode(tmp_path / AUTH_ENV_FILENAME) == 0o600
+
+
+def test_set_auth_password_tightens_a_loose_mode(tmp_path: Path) -> None:
+    env_auth = tmp_path / AUTH_ENV_FILENAME
+    env_auth.write_text(f"{PW_HASH_VAR_PREFIX}ALICE=stale\n")
+    env_auth.chmod(0o644)
+
+    set_auth_password("alice", "alices-password", tmp_path)
+
+    assert file_mode(env_auth) == 0o600
+
+
+def test_set_auth_password_never_writes_the_cleartext(tmp_path: Path) -> None:
+    set_auth_password("alice", "unmistakable-cleartext", tmp_path)
+
+    assert "unmistakable-cleartext" not in (tmp_path / AUTH_ENV_FILENAME).read_text(
+        encoding="utf-8"
+    )
+
+
+def test_set_auth_password_never_logs_the_cleartext(tmp_path: Path, caplog) -> None:
+    with caplog.at_level("DEBUG"):
+        set_auth_password("alice", "unmistakable-cleartext", tmp_path)
+
+    assert "unmistakable-cleartext" not in caplog.text
+    # Nor the hash it produced — a hash identifies a credential generation.
+    assert read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"] not in caplog.text
+
+
+def test_set_auth_password_strips_surrounding_whitespace(tmp_path: Path) -> None:
+    """Same treatment the `.env` plaintext path gives, so a password set either
+    way behaves identically at the login prompt."""
+    set_auth_password("alice", "  padded-password\n", tmp_path)
+
+    stored = read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"]
+    assert verify_password("padded-password", stored)
+
+
+@pytest.mark.parametrize("password", ["", "   ", "\n\t "])
+def test_set_auth_password_rejects_an_empty_password(tmp_path: Path, password: str) -> None:
+    with pytest.raises(ValueError, match="empty password"):
+        set_auth_password("alice", password, tmp_path)
+
+    assert not (tmp_path / AUTH_ENV_FILENAME).exists()
+
+
+def test_set_auth_password_rejects_a_username_outside_the_charset(tmp_path: Path) -> None:
+    """The same hard gate `ensure_auth_credentials` applies — a name that is not
+    a legal nginx location key/URL segment can never be authorized."""
+    with pytest.raises(RuntimeError, match="does not match"):
+        set_auth_password("alice&bob", "some-password", tmp_path)
+
+    assert not (tmp_path / AUTH_ENV_FILENAME).exists()
+
+
+@pytest.mark.skipif(running_as_root, reason="root ignores the read-only mode this test relies on")
+def test_set_auth_password_raises_on_a_write_failure(tmp_path: Path) -> None:
+    """A DELIBERATE divergence from this module's reported-not-raised contract.
+
+    `ensure_*` reports through `missing` because a fail-closed deploy gate
+    downstream owns the abort. Nothing owns this one — it is reached from an
+    interactive command — so an operator who was just prompted for a password
+    must never be told it took effect when the file could not be written.
+    """
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    (project_root / AUTH_ENV_FILENAME).write_text(f"{PW_HASH_VAR_PREFIX}ALICE=established\n")
+    project_root.chmod(0o500)
+    try:
+        with pytest.raises(RuntimeError, match="NOT changed"):
+            set_auth_password("alice", "new-password", project_root)
+    finally:
+        project_root.chmod(0o700)
+
+    # Fail-closed: whatever survives, it is not the credential the operator was
+    # told is now in force.
+    stored = read_auth_env(project_root).get(f"{PW_HASH_VAR_PREFIX}ALICE", "")
+    assert not verify_password("new-password", stored) or stored == ""
+
+
+@pytest.mark.skipif(running_as_root, reason="root ignores the read-only mode this test relies on")
+def test_set_auth_password_write_failure_never_names_the_password(tmp_path: Path) -> None:
+    """The raise carries the path and the username — never the cleartext, which
+    would otherwise reach a traceback, a log, or a bug report."""
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    (project_root / AUTH_ENV_FILENAME).write_text(f"{PW_HASH_VAR_PREFIX}ALICE=established\n")
+    project_root.chmod(0o500)
+    try:
+        with pytest.raises(RuntimeError) as exc_info:
+            set_auth_password("alice", "unmistakable-cleartext", project_root)
+    finally:
+        project_root.chmod(0o700)
+
+    assert "unmistakable-cleartext" not in str(exc_info.value)

--- a/tests/deployment/web_terminals/test_auth_credentials.py
+++ b/tests/deployment/web_terminals/test_auth_credentials.py
@@ -20,7 +20,12 @@ from osprey.deployment.web_terminals.auth_credentials import (
     purge_auth_credentials,
     set_auth_password,
 )
-from osprey.services.auth_sidecar.passwords import generation_tag, verify_password
+from osprey.services.auth_sidecar.passwords import (
+    FIELD_SEP,
+    SCHEME,
+    generation_tag,
+    verify_password,
+)
 from osprey.utils.dotenv import parse_dotenv_file
 
 pytestmark = pytest.mark.unit
@@ -65,7 +70,32 @@ def test_mints_hash_for_a_user_with_no_credential(tmp_path: Path) -> None:
     assert result.env_auth_path == tmp_path / AUTH_ENV_FILENAME
 
     stored = read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"]
-    assert stored.startswith("scrypt$")
+    assert stored.startswith(f"{SCHEME}{FIELD_SEP}")
+
+
+def test_no_env_auth_value_contains_a_dollar_sign(tmp_path: Path) -> None:
+    """Every value in ``.env.auth`` must encode without ``$`` — a whole-file rule.
+
+    The rendered compose overlay hands this file to the sidecar as an
+    ``env_file``, and Docker Compose interpolates ``${...}`` in env_file values:
+    each ``$`` followed by an identifier character is replaced with the empty
+    string. A ``$``-bearing secret therefore arrives at the container truncated,
+    and the failure is invisible from the host — the file on disk is correct,
+    every unit test that reads it passes, and only the login refuses.
+
+    Asserted over the FILE rather than over the hash alone because the hash was
+    merely the first value to hit it: the signing secrets share this file, and
+    so will anything added later. Base64url (``A-Za-z0-9-_``) and the ``.``
+    separator are both safe; a future encoding that reaches for ``$`` is not.
+    """
+    ensure_auth_credentials(["alice", "bob"], tmp_path, echo=Echo())
+    ensure_auth_session_secrets(tmp_path)
+
+    offenders = {name: value for name, value in read_auth_env(tmp_path).items() if "$" in value}
+    assert offenders == {}, (
+        f"{AUTH_ENV_FILENAME} values containing '$' would be truncated by compose "
+        f"env_file interpolation before the sidecar ever reads them: {sorted(offenders)}"
+    )
 
 
 def test_env_auth_is_created_0600(tmp_path: Path) -> None:
@@ -76,7 +106,7 @@ def test_env_auth_is_created_0600(tmp_path: Path) -> None:
 
 def test_existing_env_auth_with_loose_mode_is_tightened(tmp_path: Path) -> None:
     env_auth = tmp_path / AUTH_ENV_FILENAME
-    env_auth.write_text(f"{PW_HASH_VAR_PREFIX}ALICE=scrypt$16384$8$1$c2FsdA$a2V5\n")
+    env_auth.write_text(f"{PW_HASH_VAR_PREFIX}ALICE=scrypt.16384.8.1.AAAA.AAAB\n")
     env_auth.chmod(0o644)
 
     result = ensure_auth_credentials(["alice"], tmp_path, echo=Echo())
@@ -135,7 +165,7 @@ def test_plaintext_from_project_dotenv_is_hashed_in(tmp_path: Path) -> None:
 
 
 def test_existing_hash_wins_over_plaintext(tmp_path: Path) -> None:
-    existing = f"{PW_HASH_VAR_PREFIX}ALICE=scrypt$16384$8$1$c2FsdA$a2V5"
+    existing = f"{PW_HASH_VAR_PREFIX}ALICE=scrypt.16384.8.1.AAAA.AAAB"
     (tmp_path / AUTH_ENV_FILENAME).write_text(f"{existing}\n")
     (tmp_path / ".env").write_text(f"{PW_PLAINTEXT_VAR_PREFIX}ALICE=operator-choice\n")
 
@@ -181,7 +211,7 @@ def test_only_the_missing_user_is_appended(tmp_path: Path) -> None:
     assert result.minted == ("bob",)
     stored = read_auth_env(tmp_path)
     assert stored[f"{PW_HASH_VAR_PREFIX}ALICE"] == alice_hash
-    assert stored[f"{PW_HASH_VAR_PREFIX}BOB"].startswith("scrypt$")
+    assert stored[f"{PW_HASH_VAR_PREFIX}BOB"].startswith(f"{SCHEME}{FIELD_SEP}")
 
 
 def test_append_to_a_file_without_a_trailing_newline(tmp_path: Path) -> None:
@@ -199,12 +229,12 @@ def test_a_hash_in_the_process_env_does_not_suppress_minting(
 ) -> None:
     # The sidecar reads .env.auth only, so a hash visible just to this process
     # must not stand in for a persisted one.
-    monkeypatch.setenv(f"{PW_HASH_VAR_PREFIX}ALICE", "scrypt$16384$8$1$c2FsdA$a2V5")
+    monkeypatch.setenv(f"{PW_HASH_VAR_PREFIX}ALICE", "scrypt.16384.8.1.AAAA.AAAB")
 
     result = ensure_auth_credentials(["alice"], tmp_path, echo=Echo())
 
     assert result.minted == ("alice",)
-    assert read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"] != "scrypt$16384$8$1$c2FsdA$a2V5"
+    assert read_auth_env(tmp_path)[f"{PW_HASH_VAR_PREFIX}ALICE"] != "scrypt.16384.8.1.AAAA.AAAB"
 
 
 def test_plaintext_is_not_read_from_the_process_env(
@@ -375,8 +405,8 @@ def test_a_failing_chmod_still_returns_a_successful_write(
 def test_purge_normalizes_crlf_input_but_keeps_line_content(tmp_path: Path) -> None:
     (tmp_path / AUTH_ENV_FILENAME).write_bytes(
         b"# header\r\n"
-        b"OSPREY_AUTH_PW_HASH_ALICE=scrypt$16384$8$1$c2FsdA$a2V5\r\n"
-        b"OSPREY_AUTH_PW_HASH_BOB=scrypt$16384$8$1$c2FsdA$Ym9i\r\n"
+        b"OSPREY_AUTH_PW_HASH_ALICE=scrypt.16384.8.1.AAAA.AAAB\r\n"
+        b"OSPREY_AUTH_PW_HASH_BOB=scrypt.16384.8.1.AAAA.AAAC\r\n"
     )
 
     assert purge_auth_credentials("alice", tmp_path) is True
@@ -384,7 +414,7 @@ def test_purge_normalizes_crlf_input_but_keeps_line_content(tmp_path: Path) -> N
     text = (tmp_path / AUTH_ENV_FILENAME).read_text()
     assert "ALICE" not in text
     assert "\r" not in text  # CRLF is normalized to LF on rewrite
-    assert text == "# header\nOSPREY_AUTH_PW_HASH_BOB=scrypt$16384$8$1$c2FsdA$Ym9i\n"
+    assert text == "# header\nOSPREY_AUTH_PW_HASH_BOB=scrypt.16384.8.1.AAAA.AAAC\n"
 
 
 def test_purge_removes_only_the_named_users_entries(tmp_path: Path) -> None:
@@ -402,7 +432,7 @@ def test_purge_removes_only_the_named_users_entries(tmp_path: Path) -> None:
 def test_purge_removes_a_hand_placed_plaintext_entry(tmp_path: Path) -> None:
     (tmp_path / AUTH_ENV_FILENAME).write_text(
         f"{PW_PLAINTEXT_VAR_PREFIX}ALICE=hand-placed\n"
-        f"export {PW_HASH_VAR_PREFIX}ALICE=scrypt$16384$8$1$c2FsdA$a2V5\n"
+        f"export {PW_HASH_VAR_PREFIX}ALICE=scrypt.16384.8.1.AAAA.AAAB\n"
         "# keep me\n"
     )
 
@@ -531,7 +561,7 @@ def test_secrets_coexist_with_password_hashes_in_one_file(tmp_path: Path) -> Non
 
     assert secrets_result.changed is True
     stored = read_auth_env(tmp_path)
-    assert stored[f"{PW_HASH_VAR_PREFIX}ALICE"].startswith("scrypt$")
+    assert stored[f"{PW_HASH_VAR_PREFIX}ALICE"].startswith(f"{SCHEME}{FIELD_SEP}")
     assert stored[SESSION_SECRET_VAR]
     # Order-independent: minting secrets first must not disturb the hashes.
     assert ensure_auth_credentials(["alice"], tmp_path, echo=Echo()).changed is False

--- a/tests/deployment/web_terminals/test_auth_serving.py
+++ b/tests/deployment/web_terminals/test_auth_serving.py
@@ -59,8 +59,9 @@ osprey-framework`` resolves for the real image, and fails loudly if one is not
 declared. Drop ``python-multipart`` from ``pyproject.toml`` and this harness
 loses it exactly as the deployed image would, and
 :func:`test_login_post_parses_its_form_body_in_the_container` goes red. What
-remains unproven here is the *built image* itself; the full-stack
-``tests/e2e/test_multi_user_demo.py`` job is where that belongs.
+remains unproven here is the *built image* itself: no job builds
+``templates/modules/web_terminals/auth_sidecar/Dockerfile``, so a break confined
+to that Dockerfile would reach a deployment without a test noticing.
 """
 
 from __future__ import annotations

--- a/tests/deployment/web_terminals/test_auth_serving.py
+++ b/tests/deployment/web_terminals/test_auth_serving.py
@@ -1,0 +1,1176 @@
+"""The authenticated perimeter, served for real: nginx + the auth sidecar.
+
+Every other test of this feature looks at one side of the perimeter. The render
+tests string-match Jinja output; ``test_nginx_validate.py`` proves the fragment
+is a config nginx *accepts*; the sidecar's own unit tests drive its routes in
+process. None of them can see what the two halves do to a request *together*,
+and that is where this feature's sharpest properties live — a header nginx
+emits from a decoded variable, an identity fixed by which location a normalised
+path lands in, a cookie nginx must strip before the upstream sees it. Those are
+observable only by putting a real request through a real nginx into a real
+sidecar and looking at what came out the other end.
+
+So this module composes the stack from the *rendered* artifacts and serves it:
+
+* the **stub upstream** container stands in for the per-user terminal apps. It
+  is a stdlib echo server that answers on each user's rendered loopback port
+  with a JSON transcript of what it received, which is how assertions about
+  what reached the app (the stripped ``Cookie``, the POST body, the stripped
+  ``/u/<user>`` prefix) are made against the *upstream's* view rather than the
+  client's guess. It also owns the network namespace and publishes the port.
+* **nginx** and the **sidecar** join that namespace with
+  ``--network container:<stub>``. This is what makes the rendered config work
+  unmodified: it dials ``127.0.0.1:<port>`` for every upstream (the per-user
+  apps and ``/verify`` alike), which is only true if all three processes share
+  one loopback. Publishing from the namespace owner keeps the entry point
+  reachable from the host on macOS too, where ``--network host`` shares the
+  Docker VM's namespace and not the Mac's.
+
+Nothing here is hand-written that the deployment produces for itself. The nginx
+config, its mount paths, the sidecar's argv, its non-secret environment and the
+external origin are all read out of ``render_web_terminals()``'s output;
+``.env.auth`` is written by the production credential functions
+(``ensure_auth_session_secrets`` and ``set_auth_password``, what the deploy
+preflight and ``osprey deploy passwd`` call) and handed to the container through
+``--env-file``, matching the rendered ``env_file:``. Only the passwords
+themselves are chosen here, because minting deliberately never returns one.
+
+PASSWORD MODE ONLY, deliberately. The OIDC handshake is proven in process
+against a real signing provider in ``tests/services/auth_sidecar/test_oidc_flow.py``;
+an IdP container would have to live inside this shared namespace to be
+reachable at all, and would re-prove nothing.
+
+WHAT THE SIDECAR IMAGE HERE IS, AND IS NOT
+------------------------------------------
+The deployed sidecar image (``templates/modules/web_terminals/auth_sidecar/Dockerfile``)
+installs the whole ``osprey-framework`` distribution — scipy, playwright,
+accelerator-toolbox and the rest — which is a multi-minute, multi-hundred-MB
+build this file cannot afford: it runs in the ordinary unit lane. The harness
+image below installs only the part of that dependency set the sidecar's import
+closure actually needs, plus the repository's own ``src/`` bind-mounted.
+
+The one property that distinction endangers is ``python-multipart``: Starlette
+requires it for EVERY form body, urlencoded included, so a sidecar image
+missing it serves a login page whose form can never be submitted, and no unit
+test would notice. The harness therefore installs nothing of its own choosing —
+:func:`_declared_specs` takes each package's requirement *specifier from the
+distribution's own metadata*, the same declaration ``pip install
+osprey-framework`` resolves for the real image, and fails loudly if one is not
+declared. Drop ``python-multipart`` from ``pyproject.toml`` and this harness
+loses it exactly as the deployed image would, and
+:func:`test_login_post_parses_its_form_body_in_the_container` goes red. What
+remains unproven here is the *built image* itself; the full-stack
+``tests/e2e/test_multi_user_demo.py`` job is where that belongs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import shutil
+import socket
+import subprocess
+import textwrap
+import time
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from importlib.metadata import requires as distribution_requires
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import yaml
+from packaging.requirements import Requirement
+
+from osprey.deployment.web_terminals.auth_credentials import (
+    AUTH_ENV_FILENAME,
+    ensure_auth_session_secrets,
+    purge_auth_credentials,
+    set_auth_password,
+)
+from osprey.deployment.web_terminals.personas import env_var_suffix
+from osprey.deployment.web_terminals.render import render_web_terminals
+from osprey.interfaces._serving import free_port
+from osprey.services.auth_sidecar.passwords import generation_tag, hash_password
+from osprey.services.auth_sidecar.sessions import SESSION_COOKIE_NAME, SessionCodec
+from osprey.utils.dotenv import parse_dotenv_file
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SRC_DIR = _REPO_ROOT / "src"
+
+_USERS = ("alice", "bob", "carol")
+"""The roster. ``carol`` exists so the throttle test can burn a user's attempt
+window without locking out the user every other test logs in as — the throttle
+is per-user and process-local, and the stack is shared across this module."""
+
+_PASSWORDS = {"alice": "alice-pw-correct", "bob": "bob-pw-correct", "carol": "carol-pw-correct"}
+
+_PACKAGES = (
+    "fastapi",
+    "uvicorn",
+    "authlib",
+    "itsdangerous",
+    "python-multipart",
+    "httpx",
+    "jinja2",
+    "ruamel.yaml",
+    "pyyaml",
+    "click",
+    "rich",
+)
+"""The sidecar's import closure, by distribution name.
+
+Found by running ``import osprey.services.auth_sidecar.app`` in a bare
+``python:3.11-slim`` and adding what it asked for: the app itself needs the
+first five, and ``osprey.deployment.web_terminals.personas`` drags the render
+and registry packages behind it. The *versions* are never named here — see
+:func:`_declared_specs`.
+"""
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        return subprocess.run(["docker", "info"], capture_output=True, timeout=10).returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+pytestmark = [
+    pytest.mark.dockerbuild,
+    pytest.mark.skipif(not _docker_available(), reason="docker not available"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Harness image
+# ---------------------------------------------------------------------------
+
+
+def _canonical(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _declared_specs() -> tuple[str, ...]:
+    """The requirement specifiers ``osprey-framework`` declares for :data:`_PACKAGES`.
+
+    Read from the *installed distribution's* metadata rather than written out
+    here, so the harness image can only contain what a deployment's
+    ``pip install osprey-framework`` would also install. That is what keeps
+    :func:`test_login_post_parses_its_form_body_in_the_container` honest about
+    ``python-multipart``: the harness has it because the distribution declares
+    it, not because this file asked for it.
+
+    Raises:
+        AssertionError: If the distribution does not declare one of them. That
+            is a real defect rather than a harness problem — the sidecar imports
+            the package, so the deployed image would be missing it too.
+    """
+    declared: dict[str, str] = {}
+    for raw in distribution_requires("osprey-framework") or ():
+        requirement = Requirement(raw)
+        # Extras (``; extra == "dev"``) are not in a default install, so they
+        # are not in the deployed image either.
+        if requirement.marker is not None and not requirement.marker.evaluate({"extra": ""}):
+            continue
+        declared[_canonical(requirement.name)] = str(requirement)
+
+    missing = [name for name in _PACKAGES if _canonical(name) not in declared]
+    assert not missing, (
+        f"osprey-framework does not declare {missing}, which the auth sidecar imports. "
+        "The deployed sidecar image installs the distribution's declared dependencies "
+        "and would be missing them too."
+    )
+    return tuple(declared[_canonical(name)] for name in _PACKAGES)
+
+
+def _harness_dockerfile() -> str:
+    specs = " ".join(f'"{spec}"' for spec in _declared_specs())
+    return textwrap.dedent(
+        f"""\
+        FROM python:3.11-slim
+        RUN pip install --no-cache-dir {specs}
+        ENV PYTHONPATH=/src PYTHONDONTWRITEBYTECODE=1
+        """
+    )
+
+
+def _build_harness_image(tmp_path: Path) -> str:
+    """Build (or reuse) the image the sidecar and the stub upstream run from.
+
+    The tag carries a digest of the Dockerfile, so a dependency-declaration
+    change produces a new tag instead of silently reusing a stale layer — and
+    two sessions running concurrently share a tag only when they would have
+    built identical content.
+    """
+    dockerfile = _harness_dockerfile()
+    tag = f"osprey-auth-serving-harness:{hashlib.sha256(dockerfile.encode()).hexdigest()[:12]}"
+
+    if subprocess.run(["docker", "image", "inspect", tag], capture_output=True).returncode == 0:
+        return tag
+
+    context = tmp_path / "harness"
+    context.mkdir()
+    (context / "Dockerfile").write_text(dockerfile)
+    result = subprocess.run(
+        ["docker", "build", "-t", tag, str(context)],
+        capture_output=True,
+        text=True,
+        timeout=900,
+    )
+    assert result.returncode == 0, f"harness image build failed:\n{result.stdout}\n{result.stderr}"
+    return tag
+
+
+TERMINAL_STAND_IN_MARKER = "osprey-terminal-stand-in"
+"""Element id the stub serves at the app root, for a browser to look for.
+
+The real per-user terminal app cannot run here — it needs the ``claude``
+binary and a provider — so the browser suite's "you arrived at the terminal"
+assertion is against this marker. What that proves is the perimeter half (the
+navigation reached the user's own upstream through nginx with a session); the
+terminal UI's own rendering is covered by the in-process suites under
+``tests/interfaces/web_terminal/``.
+"""
+
+_STUB_UPSTREAM = f'''\
+"""Stand-in for the per-user terminal apps.
+
+Serves an HTML page at the app root, the way the terminal would to a
+navigating browser, and echoes a JSON transcript of the request everywhere
+else, which is how the serving tests assert on what actually reached the app.
+"""
+import json
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+PAGE = (
+    "<!doctype html><title>Terminal</title>"
+    \'<div id="{TERMINAL_STAND_IN_MARKER}">terminal for port %d</div>\'
+)
+
+
+class Echo(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def _respond(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(length) if length else b""
+        port = self.server.server_address[1]
+        if self.command == "GET" and self.path == "/":
+            payload = (PAGE % port).encode()
+            content_type = "text/html; charset=utf-8"
+        else:
+            payload = json.dumps(
+                {{
+                    "port": port,
+                    "method": self.command,
+                    "path": self.path,
+                    "headers": {{key.lower(): value for key, value in self.headers.items()}},
+                    "body": body.decode("utf-8", "replace"),
+                }}
+            ).encode()
+            content_type = "application/json"
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    do_GET = _respond
+    do_POST = _respond
+
+    def log_message(self, *args):
+        pass
+
+
+servers = [ThreadingHTTPServer(("127.0.0.1", int(port)), Echo) for port in sys.argv[1:]]
+for server in servers[1:]:
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+servers[0].serve_forever()
+'''
+
+
+# ---------------------------------------------------------------------------
+# The composed stack
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Stack:
+    """Everything a test needs to talk to the running perimeter."""
+
+    port: int
+    origin: str
+    session_secret: str
+    stored_hashes: dict[str, str]
+    upstream_ports: dict[str, int]
+    deployment_root: Path
+    auth_container: str
+    auth_run_argv: list[str]
+
+    @property
+    def env_auth_path(self) -> Path:
+        return self.deployment_root / AUTH_ENV_FILENAME
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def recreate_auth(self) -> None:
+        """Replace the sidecar container, the way a credential change obliges.
+
+        compose bakes ``env_file`` content into a container at *creation* time,
+        so a deployment that rewrites ``.env.auth`` must force-recreate the
+        sidecar rather than restart it. This reproduces that half: the container
+        is removed and started again from the same argv, which re-reads the file
+        as it now stands on disk. The signing secrets live in that same file and
+        are untouched, so cookies minted before the recreate still verify — which
+        is what makes "this session is refused *now*" mean something.
+        """
+        subprocess.run(["docker", "rm", "-f", self.auth_container], capture_output=True, timeout=60)
+        started = subprocess.run(self.auth_run_argv, capture_output=True, text=True, timeout=180)
+        assert started.returncode == 0, started.stderr
+        _wait_for(
+            f"{self.base_url}/auth/login?user=alice",
+            names=[self.auth_container],
+            what="the recreated auth sidecar",
+        )
+
+    def codec(self) -> SessionCodec:
+        """A codec on the sidecar's own signing secret.
+
+        Forging a *validly signed* cookie is the only way to reach the expiry
+        and credential-generation checks from outside: both are properties of a
+        cookie the sidecar already trusts the signature of, and neither can be
+        produced by waiting (the rendered lifetime is twelve hours) or by
+        rotating a password (which needs a container recreate).
+        """
+        return SessionCodec(self.session_secret)
+
+    def client(self, **kwargs: Any) -> httpx.Client:
+        """A client with a cookie jar, which is the only correct way to drive this.
+
+        The sidecar sets two cookies on different paths (the OIDC state cookie
+        on ``/auth``, the session cookie on ``/``); a hand-assembled ``Cookie``
+        header sends the wrong one and reports a confident false green.
+        """
+        return httpx.Client(base_url=self.base_url, follow_redirects=False, timeout=15, **kwargs)
+
+
+def _config(nginx_port: int) -> dict[str, Any]:
+    """The deployment this module serves.
+
+    ``deploy.fqdn`` is the loopback address on purpose: the rendered
+    ``OSPREY_AUTH_EXTERNAL_ORIGIN`` is derived from it and the nginx port, and
+    it is the origin the sidecar's login POST requires a submission to declare.
+    Pointing it at where the test actually reaches the stack means that check
+    is exercised against a *rendered* value rather than an overridden one.
+
+    ``allow_insecure_http`` is the shape a facility behind its own TLS
+    terminator deploys — one server block, no certificate fixture, and the same
+    gated surface.
+    """
+    return {
+        "facility": {"name": "Demo Light Source", "prefix": "dls", "timezone": "UTC"},
+        "registry": {"url": "git.dls.example.org:5050/physics/production/dls-profiles"},
+        "deploy": {"host": "dls-deploy", "fqdn": "127.0.0.1"},
+        "modules": {
+            "web_terminals": {
+                "enabled": True,
+                "nginx_port": nginx_port,
+                "web_base_port": 9091,
+                "artifact_base_port": 9291,
+                "ariel_base_port": 9391,
+                "lattice_base_port": 9491,
+                "users": list(_USERS),
+                "auth": {"method": "password", "allow_insecure_http": True},
+            }
+        },
+    }
+
+
+_UPSTREAM_RE = re.compile(
+    r"location /u/(?P<user>[^/ ]+)/ \{.*?proxy_pass http://127\.0\.0\.1:(?P<port>\d+)/;",
+    re.DOTALL,
+)
+
+
+def _rendered_upstream_ports(nginx_conf: str) -> dict[str, int]:
+    """The loopback port nginx will really dial for each user.
+
+    Read back out of the config rather than recomputed from the port bases, so
+    the stub upstream listens where nginx looks even if allocation changes.
+    """
+    return {m.group("user"): int(m.group("port")) for m in _UPSTREAM_RE.finditer(nginx_conf)}
+
+
+def _docker_logs(name: str) -> str:
+    result = subprocess.run(
+        ["docker", "logs", "--tail", "40", name], capture_output=True, text=True
+    )
+    return f"--- {name} ---\n{result.stdout}\n{result.stderr}"
+
+
+def _wait_for(url: str, *, names: list[str], what: str, timeout: float = 60.0) -> None:
+    deadline = time.monotonic() + timeout
+    last = "no attempt made"
+    while time.monotonic() < deadline:
+        try:
+            response = httpx.get(url, timeout=5)
+        except httpx.HTTPError as exc:  # not up yet
+            last = repr(exc)
+        else:
+            if response.status_code == 200:
+                return
+            last = f"HTTP {response.status_code}"
+        time.sleep(0.5)
+    logs = "\n".join(_docker_logs(name) for name in names)
+    raise AssertionError(f"{what} never became ready ({last})\n{logs}")
+
+
+@contextmanager
+def serving_stack(tmp_path: Path) -> Iterator[Stack]:
+    """Bring the rendered perimeter up, and take it down again.
+
+    A context manager rather than a fixture so the browser suite in
+    ``tests/interfaces/web_terminal/test_auth_login_browser.py`` can drive the
+    same stack: it needs exactly this perimeter (real nginx, real sidecar, real
+    rendered config) with a Chromium page pointed at it instead of httpx, and a
+    second implementation of it would be a second thing to keep true.
+    """
+    image = _build_harness_image(tmp_path)
+
+    # `.env.auth` is written by the production credential functions, not
+    # hand-rolled: `ensure_auth_session_secrets` is what a deploy preflight
+    # calls, and `set_auth_password` is what `osprey deploy passwd` calls. The
+    # sidecar then reads the real file through `--env-file`, matching the
+    # rendered `env_file: .env.auth`. Known passwords rather than the minted
+    # ones because `ensure_auth_credentials` deliberately never returns them.
+    #
+    # It lives outside the per-attempt render directory so a port retry cannot
+    # re-mint the secrets underneath a container that already read them.
+    deployment_root = tmp_path / "deployment"
+    deployment_root.mkdir()
+    ensure_auth_session_secrets(deployment_root)
+    for user in _USERS:
+        set_auth_password(user, _PASSWORDS[user], deployment_root)
+
+    env_auth = parse_dotenv_file(deployment_root / AUTH_ENV_FILENAME)
+    session_secret = env_auth["OSPREY_AUTH_SESSION_SECRET"]
+    stored_hashes = {
+        user: env_auth[f"OSPREY_AUTH_PW_HASH_{env_var_suffix(user)}"] for user in _USERS
+    }
+
+    token = uuid.uuid4().hex[:8]
+    names = [
+        f"osprey-authserving-nginx-{token}",
+        f"osprey-authserving-auth-{token}",
+        f"osprey-authserving-stub-{token}",
+    ]
+    nginx_name, auth_name, stub_name = names
+
+    try:
+        # A port free a moment ago can be taken before docker binds it (the
+        # window is real: rendering and three container starts sit inside it),
+        # and the daemon reports that as an opaque failure. Re-render on a
+        # fresh port rather than turning a lost race into a red test.
+        for attempt in range(3):
+            nginx_port = free_port()
+            artifacts = render_web_terminals(_config(nginx_port))
+            # Lay the rendered artifacts out at the paths their own compose
+            # mounts expect, so the `./nginx/...` host sides resolve unchanged.
+            project = tmp_path / f"project-{attempt}"
+            for relative_path, content in artifacts.items():
+                target = project / relative_path
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(content)
+            (project / "stub_upstream.py").write_text(_STUB_UPSTREAM)
+
+            upstream_ports = _rendered_upstream_ports(artifacts["nginx/nginx.conf"])
+            assert set(upstream_ports) == set(_USERS), upstream_ports
+
+            # The stub owns the namespace and the published port; nginx and the
+            # sidecar join it, which is what makes the rendered loopback
+            # `proxy_pass` targets resolve.
+            started = subprocess.run(
+                [
+                    "docker",
+                    "run",
+                    "-d",
+                    "--name",
+                    stub_name,
+                    "-p",
+                    f"127.0.0.1:{nginx_port}:{nginx_port}",
+                    "-v",
+                    f"{project / 'stub_upstream.py'}:/stub_upstream.py:ro",
+                    image,
+                    "python",
+                    "/stub_upstream.py",
+                    *[str(upstream_ports[user]) for user in _USERS],
+                ],
+                capture_output=True,
+                text=True,
+                timeout=180,
+            )
+            if started.returncode == 0:
+                break
+            subprocess.run(["docker", "rm", "-f", stub_name], capture_output=True, timeout=60)
+        else:
+            raise AssertionError(f"the stub upstream never started:\n{started.stderr}")
+
+        compose = yaml.safe_load(artifacts["docker-compose.web.yml"])
+        nginx_service = compose["services"]["nginx"]
+        auth_service = compose["services"]["auth"]
+
+        external_origin = next(
+            value.split("=", 1)[1]
+            for value in auth_service["environment"]
+            if value.startswith("OSPREY_AUTH_EXTERNAL_ORIGIN=")
+        )
+        assert external_origin == f"http://127.0.0.1:{nginx_port}", external_origin
+
+        auth_env: list[str] = []
+        for value in auth_service["environment"]:
+            auth_env += ["-e", value]
+        # Kept as an argv the Stack can replay: a credential change obliges a
+        # force-recreate, and the recreated container has to be the same one.
+        auth_run_argv = [
+            "docker",
+            "run",
+            "-d",
+            "--name",
+            auth_name,
+            "--network",
+            f"container:{stub_name}",
+            "-v",
+            f"{_SRC_DIR}:/src:ro",
+            "--env-file",
+            str(deployment_root / AUTH_ENV_FILENAME),
+            *auth_env,
+            image,
+            *auth_service["command"],
+        ]
+        auth_started = subprocess.run(auth_run_argv, capture_output=True, text=True, timeout=180)
+        assert auth_started.returncode == 0, auth_started.stderr
+
+        nginx_mounts: list[str] = []
+        for volume in nginx_service["volumes"]:
+            host_side, container_side = volume.split(":", 1)
+            nginx_mounts += ["-v", f"{(project / host_side).resolve()}:{container_side}"]
+        nginx_started = subprocess.run(
+            [
+                "docker",
+                "run",
+                "-d",
+                "--name",
+                nginx_name,
+                "--network",
+                f"container:{stub_name}",
+                *nginx_mounts,
+                nginx_service["image"],
+            ],
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        assert nginx_started.returncode == 0, nginx_started.stderr
+
+        base_url = f"http://127.0.0.1:{nginx_port}"
+        # The landing page is nginx's own healthcheck target and needs no
+        # session; the login page is the first thing that requires the sidecar.
+        _wait_for(f"{base_url}/", names=names, what="nginx")
+        _wait_for(f"{base_url}/auth/login?user=alice", names=names, what="the auth sidecar")
+
+        yield Stack(
+            port=nginx_port,
+            origin=external_origin,
+            session_secret=session_secret,
+            stored_hashes=stored_hashes,
+            upstream_ports=upstream_ports,
+            deployment_root=deployment_root,
+            auth_container=auth_name,
+            auth_run_argv=auth_run_argv,
+        )
+    finally:
+        # Unconditionally, and by name: a `docker run` that fails to set up
+        # networking still leaves the container behind, and the next attempt
+        # would collide with its name.
+        for name in names:
+            subprocess.run(["docker", "rm", "-f", name], capture_output=True, timeout=60)
+
+
+@pytest.fixture(scope="module")
+def stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Stack]:
+    """The rendered perimeter, running.
+
+    Module-scoped: three containers and an image build are far too expensive
+    per test, and every test below either logs in with its own client (so the
+    cookie jars do not interact) or acts on a user nothing else touches.
+    """
+    with serving_stack(tmp_path_factory.mktemp("auth-serving")) as running:
+        yield running
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _raw_request(port: int, target: str, headers: dict[str, str]) -> tuple[bytes, bytes]:
+    """Send a request line verbatim over a socket and return (head, body).
+
+    curl and httpx both normalise a request target before it leaves the client,
+    which silently rewrites away the very inputs the injection probes below are
+    about. Nothing between this and nginx touches the bytes.
+    """
+    lines = [f"GET {target} HTTP/1.1", *(f"{key}: {value}" for key, value in headers.items())]
+    payload = ("\r\n".join([*lines, "", ""])).encode()
+
+    chunks: list[bytes] = []
+    with socket.create_connection(("127.0.0.1", port), timeout=15) as sock:
+        sock.sendall(payload)
+        while True:
+            chunk = sock.recv(65536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+    head, _, body = b"".join(chunks).partition(b"\r\n\r\n")
+    return head, body
+
+
+def _header_lines(head: bytes, name: str) -> list[bytes]:
+    """Every header line in ``head`` with the given field name.
+
+    Split on CRLF only, so a bare LF smuggled into a header *value* stays
+    inside the line it corrupted instead of being read as a line break — which
+    is exactly the difference the probes below assert on.
+    """
+    prefix = f"{name.lower()}:".encode()
+    return [line for line in head.split(b"\r\n") if line.lower().startswith(prefix)]
+
+
+def _login(
+    stack: Stack, client: httpx.Client, user: str, password: str | None = None
+) -> httpx.Response:
+    """Submit the login form the way the login page's own form would."""
+    return client.post(
+        "/auth/login",
+        data={"user": user, "password": _PASSWORDS[user] if password is None else password},
+        # Browsers send this on every POST and page script cannot set it; the
+        # sidecar refuses a submission that declares no origin at all.
+        headers={"Origin": stack.origin, "Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+
+def _navigation() -> dict[str, str]:
+    """The ``Accept`` a browser sends when a person navigates to a URL."""
+    return {"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}
+
+
+# ---------------------------------------------------------------------------
+# 1-2. What the login redirect may carry
+# ---------------------------------------------------------------------------
+
+
+def test_trailing_newline_in_path_cannot_reach_the_location_header(stack: Stack) -> None:
+    """A path ending in ``%0a`` must not put a newline in ``Location``.
+
+    nginx percent-*decodes* ``$uri``, so by the time the allowlist map reads it
+    the escape is a real LF and ``return 302`` would copy it into the header
+    verbatim. PCRE's ``$`` also matches immediately before a trailing newline,
+    so an allowlist anchored with ``$`` instead of ``\\z`` matches this path,
+    emits it, and appends whatever follows the newline as response headers of
+    the attacker's choosing. This exact request is the one case that tells the
+    two anchors apart, and it only survives the trip over a raw socket.
+    """
+    # Act
+    head, _ = _raw_request(
+        stack.port,
+        "/u/alice/x%0a",
+        {"Host": f"127.0.0.1:{stack.port}", "Connection": "close", **_navigation()},
+    )
+
+    # Assert
+    assert head.startswith(b"HTTP/1.1 302"), head
+    locations = _header_lines(head, "Location")
+    assert len(locations) == 1, head
+    location = locations[0]
+    assert b"\n" not in location, location
+    assert location.endswith(b"next="), location
+
+
+def test_crlf_in_path_cannot_inject_a_response_header(stack: Stack) -> None:
+    """``%0d%0a`` in the path must not become a ``Set-Cookie`` on this origin.
+
+    A cookie planted here would be planted on the very origin the terminals
+    live on, by a link most effective against a logged-out victim — which is
+    precisely who follows a login link.
+    """
+    # Act
+    head, _ = _raw_request(
+        stack.port,
+        "/u/alice/x%0d%0aSet-Cookie:%20evil=1",
+        {"Host": f"127.0.0.1:{stack.port}", "Connection": "close", **_navigation()},
+    )
+
+    # Assert
+    assert b"set-cookie" not in head.lower(), head
+    assert b"evil=1" not in head, head
+
+
+# ---------------------------------------------------------------------------
+# 3. Redirects stay relative
+# ---------------------------------------------------------------------------
+
+
+def test_bookmark_redirect_is_relative_and_drops_no_port(stack: Stack) -> None:
+    """``/u/alice`` must redirect to exactly ``/u/alice/``.
+
+    Left at nginx's default, ``absolute_redirect`` rebuilds a relative target
+    as ``$host`` plus nginx's *own* listening port — which walks a browser that
+    arrived through a facility TLS terminator onto cleartext on an internal
+    port. The ``Host`` here carries a port precisely because that is the input
+    the default reads.
+    """
+    # Act
+    with stack.client() as client:
+        response = client.get("/u/alice", headers={"Host": f"127.0.0.1:{stack.port}"})
+
+    # Assert
+    assert response.status_code == 301
+    assert response.headers["location"] == "/u/alice/"
+
+
+# ---------------------------------------------------------------------------
+# 4. What a denied request looks like
+# ---------------------------------------------------------------------------
+
+
+def test_navigation_without_a_session_is_sent_to_the_login_page(stack: Stack) -> None:
+    """A person typing a URL should land on the prompt, naming their own user."""
+    # Act
+    with stack.client() as client:
+        response = client.get("/u/bob/", headers=_navigation())
+
+    # Assert
+    assert response.status_code == 302
+    assert response.headers["location"] == "/auth/login?user=bob&next=/u/bob/"
+
+
+@pytest.mark.parametrize(
+    ("label", "headers"),
+    [
+        ("fetch/json", {"Accept": "application/json"}),
+        ("eventsource", {"Accept": "text/event-stream"}),
+        (
+            # A WebSocket handshake carries `Accept: text/html` from the page
+            # that opened it; the Upgrade token in front of it is what has to
+            # push the match off the anchor.
+            "websocket",
+            {
+                "Accept": "text/html,application/xhtml+xml",
+                "Upgrade": "websocket",
+                "Connection": "Upgrade",
+                "Sec-WebSocket-Version": "13",
+                # RFC 6455's own example nonce, not a secret.
+                "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",  # gitleaks:allow
+            },
+        ),
+    ],
+)
+def test_programs_get_a_bare_401_not_a_login_page(
+    stack: Stack, label: str, headers: dict[str, str]
+) -> None:
+    """Anything a program issued must get the status, never a page of HTML.
+
+    A JSON caller handed login HTML fails as a parse error far from the cause,
+    and an EventSource reconnects forever against a page that will never become
+    the stream it asked for.
+
+    What is asserted is that this is a refusal and not a hand-off: no
+    ``Location``, and nothing of the login form in the body. nginx's own 401
+    body is a stock HTML page, which is fine — the caller reads the status, and
+    a program that followed a redirect into a login page would not.
+    """
+    # Act
+    with stack.client() as client:
+        response = client.get("/u/alice/", headers=headers)
+
+    # Assert
+    assert response.status_code == 401, label
+    assert "location" not in response.headers, label
+    assert "<form" not in response.text.lower(), label
+    assert "/auth/login" not in response.text, label
+
+
+# ---------------------------------------------------------------------------
+# 5. One user's session unlocks one user
+# ---------------------------------------------------------------------------
+
+
+def test_a_session_unlocks_its_own_user_and_nobody_else(stack: Stack) -> None:
+    """alice's cookie opens alice's terminal and is refused at bob's."""
+    # Arrange
+    with stack.client() as client:
+        landed = _login(stack, client, "alice")
+        assert landed.status_code == 303, landed.text
+        assert landed.headers["location"] == "/u/alice/"
+
+        # Act
+        allowed = client.get("/u/alice/", headers=_navigation())
+        refused = client.get("/u/bob/", headers=_navigation())
+
+    # Assert
+    assert allowed.status_code == 200
+    assert refused.status_code == 302
+    assert refused.headers["location"].startswith("/auth/login?user=bob")
+
+
+def test_login_post_from_a_foreign_origin_is_refused_before_anything_else(stack: Stack) -> None:
+    """A form posted from somewhere else is not a login attempt at all.
+
+    Without this, an attacker's page could post its own credentials into a
+    victim's browser and log that browser into the *attacker's* roster user —
+    every later action in that tab then belongs to the attacker's terminal.
+
+    The refusal has to land before the form is read and before the throttle, so
+    two things are asserted beyond the 400: no cookie was set, and the window
+    was not consumed — the immediately following correct login still succeeds
+    rather than coming back 429. ``bob`` is used because nothing else in this
+    module ever fails his password, so a 429 here could only have come from
+    this test.
+    """
+    # Act
+    with stack.client() as client:
+        foreign = client.post(
+            "/auth/login",
+            data={"user": "bob", "password": _PASSWORDS["bob"]},
+            headers={
+                "Origin": "https://operator-portal.evil.example.org",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+        )
+        legitimate = _login(stack, client, "bob")
+
+    # Assert
+    assert foreign.status_code == 400
+    assert "set-cookie" not in foreign.headers
+    assert legitimate.status_code == 303, legitimate.text
+
+
+def test_two_browsers_on_one_user_get_independent_sessions(stack: Stack) -> None:
+    """Two clients logging in as the same user both work, and do not collide.
+
+    The perimeter keys authorization off the cookie a request carries, not off
+    any per-user server-side slot — so a second browser must neither be refused
+    nor take the first one's session over. An operator with a desk machine and a
+    laptop is the ordinary case, not an edge one.
+    """
+    # Act
+    with stack.client() as first, stack.client() as second:
+        _login(stack, first, "alice")
+        _login(stack, second, "alice")
+
+        first_view = first.get("/u/alice/", headers=_navigation())
+        second_view = second.get("/u/alice/", headers=_navigation())
+
+        # Assert
+        assert first.cookies[SESSION_COOKIE_NAME] != second.cookies[SESSION_COOKIE_NAME]
+        assert first_view.status_code == 200
+        assert second_view.status_code == 200
+
+
+def test_login_cookie_is_httponly_lax_and_root_scoped(stack: Stack) -> None:
+    """Asserted on the raw header: ``response.cookies`` normalises the
+    attributes away, and each of them is load-bearing.
+
+    ``Secure`` must be absent under ``allow_insecure_http`` — a Secure cookie
+    would never be sent back over the cleartext hop this posture exists for.
+    """
+    # Act
+    with stack.client() as client:
+        response = _login(stack, client, "alice")
+
+    # Assert
+    raw = response.headers["set-cookie"]
+    assert raw.startswith(f"{SESSION_COOKIE_NAME}=")
+    assert "HttpOnly" in raw
+    assert "SameSite=lax" in raw
+    assert "Path=/" in raw
+    assert "Secure" not in raw
+
+
+def test_dot_segment_path_confusion_is_authorized_as_the_user_it_reaches(stack: Stack) -> None:
+    """``/u/alice/%2e%2e/bob/`` must be decided as *bob*, and refused.
+
+    nginx decodes and collapses the dot segments before it picks a location, so
+    this request routes into bob's block and takes bob's ``auth_request``. The
+    failure this rules out is the opposite: a stack that matched alice's
+    location (and so alice's authorization) while proxying to bob's upstream.
+    Sent raw because httpx would resolve the dot segments client-side and never
+    put this target on the wire.
+    """
+    # Arrange
+    with stack.client() as client:
+        _login(stack, client, "alice")
+        cookie = client.cookies[SESSION_COOKIE_NAME]
+
+    # Act — one hand-built Cookie header, deliberately: this probe cannot go
+    # through the jar, and the session cookie is the only one scoped to "/".
+    head, _ = _raw_request(
+        stack.port,
+        "/u/alice/%2e%2e/bob/",
+        {
+            "Host": f"127.0.0.1:{stack.port}",
+            "Cookie": f"{SESSION_COOKIE_NAME}={cookie}",
+            "Connection": "close",
+            **_navigation(),
+        },
+    )
+
+    # Assert
+    assert head.startswith(b"HTTP/1.1 302"), head
+    locations = _header_lines(head, "Location")
+    assert locations == [b"Location: /auth/login?user=bob&next=/u/bob/"], head
+
+
+# ---------------------------------------------------------------------------
+# 6-7. What reaches the upstream
+# ---------------------------------------------------------------------------
+
+
+def test_authenticated_post_carries_its_body_to_the_upstream(stack: Stack) -> None:
+    """An authenticated POST completes, and its body arrives unaltered.
+
+    A POST is the one request shape that has to survive *two* trips through
+    nginx — the ``auth_request`` subrequest and then the proxied request
+    itself — and half a megabyte is well past the socket buffers either could
+    hide a stall behind. If the subrequest and the proxied request ever
+    disagreed about the body, this is where it would show as a hang.
+
+    HONEST LIMIT: this does not discriminate ``proxy_pass_request_body off``.
+    That directive protects against an auth backend that waits for the body it
+    was told to expect; uvicorn answers the subrequest without reading one, so
+    removing the directive leaves this test green. It is defence for the
+    upstreams that do wait, and this harness cannot stand in for them.
+    """
+    # Arrange
+    payload = '{"content": "' + "x" * (512 * 1024) + '"}'
+    with stack.client() as client:
+        _login(stack, client, "alice")
+
+        # Act
+        response = client.post(
+            "/u/alice/api/chat",
+            content=payload.encode(),
+            headers={"Content-Type": "application/json"},
+        )
+
+    # Assert
+    assert response.status_code == 200, response.text
+    echoed = response.json()
+    assert echoed["method"] == "POST"
+    assert echoed["body"] == payload
+    assert echoed["port"] == stack.upstream_ports["alice"]
+    # The trailing slashes on the location and the proxy_pass target strip the
+    # prefix, so the app never sees /u/alice.
+    assert echoed["path"] == "/api/chat"
+
+
+def test_upstream_receives_no_cookie_header(stack: Stack) -> None:
+    """The browser's cookie jar stops at nginx.
+
+    One jar serves this whole origin, so an operator with several users
+    unlocked would otherwise hand alice's container a cookie naming all of
+    them — inside a container that runs agent-generated code, which makes
+    anything readable there a credential that has left the perimeter. Asserted
+    on what the upstream *received*, which is the only place the difference
+    exists.
+    """
+    # Arrange
+    with stack.client() as client:
+        _login(stack, client, "alice")
+        _login(stack, client, "bob")
+        assert SESSION_COOKIE_NAME in client.cookies
+
+        # Act
+        response = client.get("/u/alice/panel", headers={"X-Probe": "cookie-stripping"})
+
+    # Assert
+    assert response.status_code == 200
+    received = response.json()["headers"]
+    assert "cookie" not in received, received
+    # A guard against a vacuous green: the request really did carry headers
+    # through, so the missing Cookie is a strip rather than a lost request.
+    assert received["x-probe"] == "cookie-stripping"
+
+
+# ---------------------------------------------------------------------------
+# 8. Sessions end
+# ---------------------------------------------------------------------------
+
+
+def test_expired_entry_no_longer_authorizes(stack: Stack) -> None:
+    """A signed cookie whose entry has lapsed is refused.
+
+    Forged rather than waited for: the rendered lifetime is twelve hours, and
+    the property under test is what ``verify`` does with a cookie whose
+    signature it *accepts*.
+    """
+    # Arrange
+    codec = stack.codec()
+    now = codec.now()
+    state = codec.new_state().with_user(
+        "alice",
+        expires_at=now - 1,
+        generation_tag=generation_tag(stack.stored_hashes["alice"]),
+    )
+
+    # Act
+    with stack.client(cookies={SESSION_COOKIE_NAME: codec.encode(state)}) as client:
+        response = client.get("/u/alice/", headers={"Accept": "application/json"})
+
+    # Assert
+    assert response.status_code == 401
+
+
+def test_rotated_password_retires_sessions_minted_against_the_old_one(stack: Stack) -> None:
+    """The credential-generation tag is what makes ``osprey deploy passwd`` bite.
+
+    Rotation changes the stored hash, so every session carrying the old hash's
+    tag stops verifying — with no server-side session state, and surviving the
+    container recreate that rotation performs. The control case in the same
+    test is what proves the refusal is the tag and not the forgery.
+    """
+    # Arrange
+    codec = stack.codec()
+    fresh = codec.now() + 3600
+    stale = codec.new_state().with_user(
+        "alice", expires_at=fresh, generation_tag=generation_tag(hash_password("a-rotated-secret"))
+    )
+    current = codec.new_state().with_user(
+        "alice", expires_at=fresh, generation_tag=generation_tag(stack.stored_hashes["alice"])
+    )
+
+    # Act
+    with stack.client(cookies={SESSION_COOKIE_NAME: codec.encode(stale)}) as client:
+        rotated_out = client.get("/u/alice/", headers={"Accept": "application/json"})
+    with stack.client(cookies={SESSION_COOKIE_NAME: codec.encode(current)}) as client:
+        control = client.get("/u/alice/", headers={"Accept": "application/json"})
+
+    # Assert
+    assert rotated_out.status_code == 401
+    assert control.status_code == 200
+
+
+def test_logout_locks_one_user_and_leaves_the_others_unlocked(stack: Stack) -> None:
+    """Logging alice out of a browser that also has bob unlocked keeps bob in."""
+    # Arrange
+    with stack.client() as client:
+        _login(stack, client, "alice")
+        _login(stack, client, "bob")
+
+        # Act
+        logout = client.get("/auth/logout?user=alice")
+        alice_after = client.get("/u/alice/", headers={"Accept": "application/json"})
+        bob_after = client.get("/u/bob/", headers={"Accept": "application/json"})
+
+    # Assert
+    assert logout.status_code == 303
+    assert alice_after.status_code == 401
+    assert bob_after.status_code == 200
+
+
+def test_decommissioning_a_user_kills_their_live_session(stack: Stack) -> None:
+    """Removing a user's credential must refuse the session they already hold.
+
+    This is the claim behind decommissioning, and it is only observable in
+    containers: the mocked lifecycle tests can assert the argv of a
+    force-recreate, but not that the sidecar comes back having re-read
+    ``.env.auth`` and now denies a cookie it accepted a moment ago. The purge is
+    done by the production function, so a change that stopped removing the hash
+    would surface here rather than being re-implemented by the test.
+
+    The signing secrets survive in the same file, so the cookie is still
+    *validly signed* across the recreate — the refusal is the missing
+    credential, not a broken signature. bob is checked alongside to show the
+    recreate did not simply lock everyone out.
+    """
+    # Arrange — the exact bytes, restored verbatim afterwards: re-running
+    # `set_auth_password` would mint a NEW hash, and every other test's view of
+    # alice's credential generation would silently go stale.
+    original = stack.env_auth_path.read_bytes()
+    with stack.client() as alice, stack.client() as bob:
+        _login(stack, alice, "alice")
+        _login(stack, bob, "bob")
+        assert alice.get("/u/alice/", headers=_navigation()).status_code == 200
+
+        try:
+            # Act
+            assert purge_auth_credentials("alice", stack.deployment_root) is True
+            stack.recreate_auth()
+
+            # Assert
+            after = alice.get("/u/alice/", headers={"Accept": "application/json"})
+            survivor = bob.get("/u/bob/", headers={"Accept": "application/json"})
+            assert after.status_code == 401
+            assert survivor.status_code == 200
+        finally:
+            stack.env_auth_path.write_bytes(original)
+            stack.recreate_auth()
+
+
+def test_repeated_failures_are_throttled_before_the_credential_is_evaluated(
+    stack: Stack,
+) -> None:
+    """A second attempt inside the window is refused 429 — even a correct one.
+
+    That last part is the property: the throttle is consulted *before* the
+    credential is looked at, so a flood of guesses costs a dict lookup rather
+    than a key derivation. ``carol`` exists only for this test, because the
+    window it opens is per-user and outlives the request.
+    """
+    # Arrange / Act
+    with stack.client() as client:
+        first = _login(stack, client, "carol", password="wrong-1")
+        second = _login(stack, client, "carol", password="wrong-2")
+        # The right password, inside the window the wrong ones opened.
+        third = _login(stack, client, "carol")
+
+    # Assert
+    assert first.status_code == 401
+    assert second.status_code == 429
+    assert int(second.headers["retry-after"]) >= 1
+    assert third.status_code == 429
+    assert "set-cookie" not in third.headers
+
+
+# ---------------------------------------------------------------------------
+# 9. The image can actually parse the form it serves
+# ---------------------------------------------------------------------------
+
+
+def test_login_post_parses_its_form_body_in_the_container(stack: Stack) -> None:
+    """A real urlencoded login POST, parsed by the sidecar's own container.
+
+    Starlette asserts on ``python-multipart`` for *every* form body, urlencoded
+    included, so an image built from a narrower dependency set than the dev venv
+    serves a login page whose form 500s on submission with a fully green unit
+    suite behind it. The harness image installs only what the distribution
+    declares (see :func:`_declared_specs`), so this passes because the
+    declaration is there — not because the test asked for the package.
+    """
+    # Act
+    with stack.client() as client:
+        response = _login(stack, client, "alice")
+
+        # Assert
+        assert response.status_code == 303, response.text
+        assert response.headers["location"] == "/u/alice/"
+        assert client.get("/u/alice/", headers=_navigation()).status_code == 200

--- a/tests/deployment/web_terminals/test_auth_tls_seams.py
+++ b/tests/deployment/web_terminals/test_auth_tls_seams.py
@@ -1,38 +1,51 @@
-"""Regression guard for the phase-4 auth/TLS seams in web-terminal nginx rendering.
+"""Regression guard for the auth/TLS seams in web-terminal nginx rendering.
 
-Phase 3 changes the deploy *lifecycle* (up/down/reconcile/status, etc.) around
-:func:`osprey.deployment.web_terminals.render.render_web_terminals`, but must not
-touch the two security seams that Phase 4 (real auth backend, real TLS
-provisioning) is scoped to fill in. Those seams are deliberately gated OFF by
-default and, when opted into via config, fail closed/fast rather than silently
-degrade:
+Deploy-lifecycle work (up/down/reconcile/status, etc.) around
+:func:`osprey.deployment.web_terminals.render.render_web_terminals` must not move
+the two security seams this deployment's safety rests on. Both remain entirely
+opt-in — a config that sets neither stanza renders the pre-auth plain-http
+posture byte for byte — and both fail closed rather than silently degrade:
 
-1. AUTH FAIL-CLOSED: setting ``modules.web_terminals.auth.method`` to anything
-   other than ``"none"`` must still emit the ``auth_request`` -> ``return 403``
-   stub per proxied ``/u/<user>/`` location (no real auth backend exists yet —
-   the placeholder must deny, never silently authorize). Leaving ``auth.method``
-   absent/``"none"`` must emit no ``auth_request`` at all, even with TLS on.
+1. AUTH FAIL-CLOSED: setting ``modules.web_terminals.auth.method`` to a real
+   method (``password``/``oidc``) must gate EVERY proxied ``/u/<user>/``
+   location behind an ``auth_request`` naming that user's own ``internal``
+   ``/_osprey_auth/<user>`` target, which asks the sidecar
+   ``GET /verify?user=<user>`` with the username fixed at render time. No
+   location may be left ungated, no target may be reachable from outside, and
+   nothing anywhere may authorize by returning success. Leaving ``auth.method``
+   absent/``"none"`` must emit no auth surface at all, even with TLS on.
 2. TLS FAIL-FAST: ``modules.web_terminals.tls.enabled: true`` without both
    ``tls.cert`` and ``tls.key`` set must raise ``ValueError`` at render time
-   rather than emit an incoherent nginx config. With both paths set, it must
-   render the ``listen 443 ssl`` listener and the configured cert/key paths.
+   rather than emit an incoherent nginx config. With both paths set, the plain
+   port becomes a redirect-only server and the ``listen 443 ssl`` server becomes
+   the sole content server — so with auth also on, there is no cleartext path to
+   a login form and therefore no cleartext origin a session cookie can be issued
+   on.
 
 This file is the authority to point at if a future lifecycle change is
 suspected of moving either seam — it duplicates a handful of assertions
 already present in test_render.py by design (a single, explicit,
 narrowly-scoped file that stays correct even if test_render.py's broader
-coverage shifts).
+coverage shifts), and it deliberately keeps its own helpers rather than
+importing test_render.py's.
 """
 
 from __future__ import annotations
 
 import copy
+import re
 
 import pytest
 
 from osprey.deployment.web_terminals.render import render_web_terminals
 
 _BASE_PORTS = {"web": 9091, "artifact": 9291, "ariel": 9391, "lattice": 9491}
+
+_TLS_STANZA = {
+    "enabled": True,
+    "cert": "/etc/nginx/certs/dls.crt",
+    "key": "/etc/nginx/certs/dls.key",
+}
 
 
 def _config(users: list[str]) -> dict:
@@ -62,59 +75,217 @@ def _config(users: list[str]) -> dict:
 _MULTI_USER_CONFIG = _config(["alice", "bob", "carol"])
 
 
-def test_seam_auth_method_set_emits_fail_closed_auth_request_stub() -> None:
-    """SEAM 1 (auth fail-closed): a configured `auth.method` (not "none") must emit
-    `auth_request` in every proxied `/u/<user>/` location plus a `return 403;`
-    internal stub target — never `return 200;`. This is the fail-closed placeholder
-    Phase 4 is scoped to replace with a real backend; a lifecycle change must not
-    turn it into a silent allow."""
+def _auth_config(users: list[str] | None = None, *, tls: bool = False) -> dict:
+    """A rendering config with authentication on, over cleartext unless `tls`.
+
+    Without TLS the render refuses `auth.method` outright unless the facility
+    accepts the risk, so `allow_insecure_http` is set in that case — the seam
+    under test here is the auth surface itself, not that separate gate.
+    """
+    config = _config(users if users is not None else ["alice", "bob", "carol"])
+    web_terminals = config["modules"]["web_terminals"]
+    web_terminals["auth"] = {"method": "password"}
+    if tls:
+        web_terminals["tls"] = copy.deepcopy(_TLS_STANZA)
+    else:
+        web_terminals["auth"]["allow_insecure_http"] = True
+    return config
+
+
+def _render_nginx(config: dict) -> str:
+    return render_web_terminals(config)["nginx/nginx.conf"]
+
+
+def _directives(conf: str) -> str:
+    """`conf` with its comment lines dropped.
+
+    Counting and absence assertions have to ignore comment prose, which in this
+    template frequently names the very construct being counted or ruled out (the
+    comments explain `auth_request`, `$request_uri` and `/verify` at length).
+    """
+    return "\n".join(line for line in conf.splitlines() if not line.lstrip().startswith("#"))
+
+
+def _server_blocks(conf: str) -> list[str]:
+    """The top-level `server { … }` bodies, in render order.
+
+    Under TLS there are TWO: the redirect-only plain-port server first, then the
+    443 content server. Split on the closing brace in column 0, which only a
+    top-level block has.
+    """
+    blocks = re.findall(r"^server \{\n(.*?)^\}$", conf, flags=re.DOTALL | re.MULTILINE)
+    assert blocks, "no top-level server block in the rendered fragment"
+    return blocks
+
+
+def _location_body(conf: str, header: str) -> str:
+    match = re.search(rf"{re.escape(header)} \{{(.*?)\n    \}}", conf, flags=re.DOTALL)
+    assert match is not None, f"no {header!r} block in the rendered fragment"
+    return match.group(1)
+
+
+def test_seam_auth_method_set_gates_every_user_behind_its_own_internal_target() -> None:
+    """SEAM 1 (auth fail-closed): a configured `auth.method` must gate every
+    proxied `/u/<user>/` location behind an `auth_request` naming that user's own
+    `internal` target — and must emit no construct that authorizes by returning
+    success.
+
+    The pin is a coverage invariant, not a substring: one `auth_request` per
+    proxied user location, so a roster entry rendered ungated fails here rather
+    than passing because some other user's directive is present.
+    """
     # Arrange
-    config = copy.deepcopy(_MULTI_USER_CONFIG)
+    config = _auth_config()
     users = config["modules"]["web_terminals"]["users"]
-    config["modules"]["web_terminals"]["auth"] = {"method": "oauth2_proxy"}
 
     # Act
-    artifacts = render_web_terminals(config)
-    nginx_conf = artifacts["nginx/nginx.conf"]
+    nginx_conf = _render_nginx(config)
+    directives = _directives(nginx_conf)
+
+    # Assert — every proxied user location is gated, and by its OWN target
+    gated_locations = directives.count("location /u/")
+    assert gated_locations == len(users)
+    assert directives.count("auth_request ") == gated_locations
+    for user in users:
+        assert f"auth_request /_osprey_auth/{user};" in _location_body(
+            nginx_conf, f"location /u/{user}/"
+        )
+        assert f"location = /_osprey_auth/{user} {{" in nginx_conf
+
+    # Assert — the auth targets are unreachable from outside, one per user
+    assert directives.count("internal;") == len(users)
+
+    # Assert — nothing authorizes, and the pre-sidecar shared stub is gone
+    # rather than merely supplemented: neither a permissive `return 200;` nor
+    # the single blanket `return 403;` target it used to deny with survives.
+    assert "return 200;" not in nginx_conf
+    assert "return 403;" not in directives
+    assert "location = /_osprey_auth {" not in nginx_conf
+
+
+def test_seam_auth_target_asks_the_sidecar_about_a_render_time_username() -> None:
+    """SEAM 1 (identity is structural): each internal target's `?user=` is a
+    render-time literal from the roster, so no part of a client's request
+    selects which user it is authorized as.
+
+    The subrequest must also carry no body (an inherited Content-Length the
+    sidecar never reads hangs every authenticated POST) and must fail in seconds
+    rather than hold a gated request on nginx's 60s defaults.
+    """
+    # Arrange
+    config = _auth_config(["alice", "bob"])
+    users = config["modules"]["web_terminals"]["users"]
+
+    # Act
+    nginx_conf = _render_nginx(config)
+    directives = _directives(nginx_conf)
 
     # Assert
-    assert nginx_conf.count("auth_request /_osprey_auth;") == len(users)
-    assert nginx_conf.count("internal;") == 1
-    assert "return 403;" in nginx_conf
-    assert "return 200;" not in nginx_conf
+    for user in users:
+        body = _location_body(nginx_conf, f"location = /_osprey_auth/{user}")
+        assert f"proxy_pass http://127.0.0.1:9070/verify?user={user};" in body
+        assert "proxy_pass_request_body off;" in body
+        assert 'proxy_set_header Content-Length "";' in body
+        assert "proxy_connect_timeout 2s;" in body
+        assert "proxy_read_timeout 5s;" in body
+
+    # The identity is never reconstructed from client-controlled input — the two
+    # places a crafted URL could otherwise smuggle a different username in.
+    assert "$request_uri" not in directives
+    assert "X-Original-URI" not in directives
+    # `/verify` is reachable only through the internal targets: it is not a
+    # location of its own and is not exposed under the public `/auth/` prefix.
+    assert "location /verify" not in directives
+    assert "location = /verify" not in directives
+    assert len([line for line in directives.splitlines() if "/verify" in line]) == len(users)
 
 
-def test_seam_auth_none_or_absent_emits_no_auth_request_even_with_tls_on() -> None:
+def test_seam_auth_denied_subrequest_redirects_only_an_allowlisted_return_path() -> None:
+    """SEAM 1 (a refusal never emits an attacker-chosen header value): the shared
+    401 handler's login redirect carries `$osprey_auth_next` — the allowlisted
+    form of the path — and neither raw path variable.
+
+    `$uri` is nginx's DECODED path, so a `%0d%0a` in the request path is a real
+    CR LF by the time `return 302` copies it into the Location header; emitting
+    it verbatim let a crafted link append arbitrary response headers.
+    `$request_uri` is injection-safe but carries whatever the client typed,
+    including a leading `//` a browser follows off-site. Everything that is not
+    a plain terminal path must collapse to the empty default.
+    """
+    # Act
+    nginx_conf = _render_nginx(_auth_config())
+    handler = _location_body(nginx_conf, "location @osprey_auth_401")
+    handler_directives = _directives(handler)
+
+    # Assert — the sanitized variable is what the redirect emits
+    assert "return 302 /auth/login?user=$osprey_auth_user&next=$osprey_auth_next;" in handler
+    assert "next=$uri" not in handler_directives
+    assert "$request_uri" not in handler_directives
+    # Programs get a bare status they can act on, not a page of login HTML.
+    assert "return 401;" in handler_directives
+
+    # Assert — the allowlist is an allowlist: a default of "" and an anchored
+    # pattern. `\z`, not `$`: PCRE's `$` also matches before a trailing newline,
+    # so a path ending in `%0a` would otherwise be emitted, newline and all.
+    allowlist = _directives(nginx_conf)
+    assert "map $uri $osprey_auth_next {" in allowlist
+    assert '\n    default "";' in allowlist
+    assert re.search(r'\n    "~\^/u/\[[^"]+\\z" \$uri;', allowlist) is not None
+    assert "map $http_upgrade$http_accept $osprey_auth_wants_login_page {" in allowlist
+
+
+def test_seam_auth_redirects_stay_on_the_clients_own_origin() -> None:
+    """SEAM 1 (no redirect walks a browser off TLS): `absolute_redirect off` sits
+    at SERVER scope — before the first location, exactly once — so it covers
+    every redirect this server can emit, not just the one that first needed it.
+
+    Left at nginx's default, a relative Location becomes an absolute URL built
+    from `$host` plus nginx's OWN listening port: a browser on
+    `https://facility/u/alice` behind a facility TLS terminator would be walked
+    to `http://facility:9080/u/alice/`. It is gated on auth being on, so the
+    `method: none` render must not carry it at all.
+    """
+    # Act
+    content = _server_blocks(_render_nginx(_auth_config(["alice"])))[0]
+
+    # Assert — server scope, before any location, and only there
+    preamble = _directives(content).split("location", 1)[0]
+    assert "absolute_redirect off;" in preamble
+    assert content.count("absolute_redirect off;") == 1
+
+    # Assert — gated on auth: the unauthenticated render is unchanged by it
+    assert "absolute_redirect" not in _render_nginx(copy.deepcopy(_MULTI_USER_CONFIG))
+
+
+def test_seam_auth_none_or_absent_emits_no_auth_surface_even_with_tls_on() -> None:
     """SEAM 1 (auth gated off by default): with `auth.method` absent/"none", no
-    `auth_request` directive is emitted at all — including when TLS is separately
+    part of the auth surface is emitted — no `auth_request`, no internal target,
+    no public `/auth/` prefix, no 401 handler — including when TLS is separately
     enabled. The two seams are independently gated; TLS opting in must not
     accidentally opt in auth too."""
     # Arrange — absent auth stanza, TLS enabled
     config = copy.deepcopy(_MULTI_USER_CONFIG)
     assert "auth" not in config["modules"]["web_terminals"]
-    config["modules"]["web_terminals"]["tls"] = {
-        "enabled": True,
-        "cert": "/etc/nginx/certs/dls.crt",
-        "key": "/etc/nginx/certs/dls.key",
-    }
+    config["modules"]["web_terminals"]["tls"] = copy.deepcopy(_TLS_STANZA)
 
     # Act
-    artifacts = render_web_terminals(config)
-    nginx_conf = artifacts["nginx/nginx.conf"]
+    nginx_conf = _render_nginx(config)
 
     # Assert
     assert "listen 443 ssl;" in nginx_conf
-    assert "auth_request" not in nginx_conf
+    for absent in ("auth_request", "_osprey_auth", "location /auth/", "error_page"):
+        assert absent not in nginx_conf
 
     # Arrange — explicit auth.method: "none" (not merely absent)
     config_explicit_none = copy.deepcopy(_MULTI_USER_CONFIG)
     config_explicit_none["modules"]["web_terminals"]["auth"] = {"method": "none"}
 
     # Act
-    nginx_conf_explicit_none = render_web_terminals(config_explicit_none)["nginx/nginx.conf"]
+    nginx_conf_explicit_none = _render_nginx(config_explicit_none)
 
     # Assert
-    assert "auth_request" not in nginx_conf_explicit_none
+    for absent in ("auth_request", "_osprey_auth", "location /auth/", "error_page"):
+        assert absent not in nginx_conf_explicit_none
 
 
 def test_seam_tls_enabled_without_both_cert_and_key_raises_value_error() -> None:
@@ -152,25 +323,66 @@ def test_seam_tls_enabled_without_both_cert_and_key_raises_value_error() -> None
         render_web_terminals(config_key_only)
 
 
+def test_seam_auth_over_cleartext_is_refused_unless_explicitly_accepted() -> None:
+    """SEAM 2 (no session cookie over cleartext by accident): `auth.method` set
+    with `tls.enabled` false must raise rather than render a login flow whose
+    cookies cross the network in the clear. A facility fronted by its own TLS
+    terminator opts in explicitly via `auth.allow_insecure_http`."""
+    # Arrange — auth on, no TLS, no explicit acceptance
+    config = copy.deepcopy(_MULTI_USER_CONFIG)
+    config["modules"]["web_terminals"]["auth"] = {"method": "password"}
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="allow_insecure_http"):
+        render_web_terminals(config)
+
+    # Act / Assert — the explicit opt-in renders the auth surface
+    assert "auth_request " in _directives(_render_nginx(_auth_config()))
+
+
 def test_seam_tls_enabled_with_both_cert_and_key_emits_ssl_listen_and_paths() -> None:
     """SEAM 2 (TLS renders when fully configured): with both `tls.cert` and
-    `tls.key` set, render emits `listen 443 ssl` plus the configured
-    `ssl_certificate`/`ssl_certificate_key` paths inside the `server{}` block."""
+    `tls.key` set, the fragment splits into a redirect-only server on the plain
+    port and a `listen 443 ssl` content server carrying the configured
+    `ssl_certificate`/`ssl_certificate_key` paths."""
     # Arrange
     config = copy.deepcopy(_MULTI_USER_CONFIG)
-    config["modules"]["web_terminals"]["tls"] = {
-        "enabled": True,
-        "cert": "/etc/nginx/certs/dls.crt",
-        "key": "/etc/nginx/certs/dls.key",
-    }
+    config["modules"]["web_terminals"]["tls"] = copy.deepcopy(_TLS_STANZA)
 
     # Act
-    nginx_conf = render_web_terminals(config)["nginx/nginx.conf"]
+    blocks = _server_blocks(_render_nginx(config))
 
-    # Assert
-    assert "listen 443 ssl;" in nginx_conf
-    assert "ssl_certificate /etc/nginx/certs/dls.crt;" in nginx_conf
-    assert "ssl_certificate_key /etc/nginx/certs/dls.key;" in nginx_conf
-    server_index = nginx_conf.index("server {")
-    ssl_index = nginx_conf.index("listen 443 ssl;")
-    assert server_index < ssl_index, "the ssl listener must sit inside server{}, not above it"
+    # Assert — two servers: the plain port redirects, 443 serves
+    assert len(blocks) == 2
+    redirect, content = blocks
+    assert "return 301 https://$host$request_uri;" in redirect
+    assert "location" not in redirect
+    assert "listen 443 ssl;" in content
+    assert "ssl_certificate /etc/nginx/certs/dls.crt;" in content
+    assert "ssl_certificate_key /etc/nginx/certs/dls.key;" in content
+    assert "location = / {" in content
+
+
+def test_seam_auth_surface_exists_only_on_the_tls_content_server() -> None:
+    """SEAMS 1+2 together: with both on, every gated location and every auth
+    target lives in the 443 server and nowhere else. A duplicate left on the
+    cleartext listener would be a plain-http path to a login form, and any
+    session cookie issued there would cross the network in the clear."""
+    # Arrange
+    config = _auth_config(tls=True)
+    users = config["modules"]["web_terminals"]["users"]
+
+    # Act
+    redirect, content = _server_blocks(_render_nginx(config))
+
+    # Assert — the cleartext listener carries nothing but the 301
+    assert redirect.count("location") == 0
+    assert "_osprey_auth" not in redirect
+    assert _directives(redirect).count("auth_request ") == 0
+
+    # Assert — the secure listener carries the whole gated surface, in full
+    assert _directives(content).count("location /u/") == len(users)
+    assert _directives(content).count("auth_request ") == len(users)
+    assert content.count("location = /_osprey_auth/") == len(users)
+    assert "location /auth/ {" in content
+    assert "return 200;" not in content

--- a/tests/deployment/web_terminals/test_auth_tls_seams.py
+++ b/tests/deployment/web_terminals/test_auth_tls_seams.py
@@ -36,6 +36,7 @@ import copy
 import re
 
 import pytest
+import yaml
 
 from osprey.deployment.web_terminals.render import render_web_terminals
 
@@ -361,6 +362,92 @@ def test_seam_tls_enabled_with_both_cert_and_key_emits_ssl_listen_and_paths() ->
     assert "ssl_certificate /etc/nginx/certs/dls.crt;" in content
     assert "ssl_certificate_key /etc/nginx/certs/dls.key;" in content
     assert "location = / {" in content
+
+
+def _nginx_volumes(config: dict) -> list[str]:
+    """The rendered nginx service's ``volumes`` list, parsed from the overlay."""
+    overlay = yaml.safe_load(render_web_terminals(config)["docker-compose.web.yml"])
+    return list(overlay["services"]["nginx"]["volumes"])
+
+
+def test_tls_host_cert_dir_mounts_the_certificate_where_nginx_looks_for_it() -> None:
+    """SEAM 2 (the certificate actually reaches the container): `tls.host_cert_dir`
+    renders a read-only bind of that HOST directory at the in-container directory
+    `tls.cert` names. Without it nginx starts, finds no certificate, and dies —
+    the one configuration a facility must get right had no guard behind it."""
+    # Arrange
+    config = copy.deepcopy(_MULTI_USER_CONFIG)
+    config["modules"]["web_terminals"]["tls"] = {
+        **copy.deepcopy(_TLS_STANZA),
+        "host_cert_dir": "/etc/ssl/dls",
+    }
+
+    # Act
+    volumes = _nginx_volumes(config)
+
+    # Assert — the mount target is DERIVED from tls.cert, so it cannot name a
+    # directory other than the one ssl_certificate reads.
+    assert "/etc/ssl/dls:/etc/nginx/certs:ro" in volumes
+    content = _server_blocks(_render_nginx(config))[1]
+    assert "ssl_certificate /etc/nginx/certs/dls.crt;" in content
+
+
+def test_tls_without_host_cert_dir_mounts_nothing_extra() -> None:
+    """The key is optional, and omitting it is a supported posture: a facility
+    whose certificates arrive by a route a directory bind cannot express supplies
+    the mount itself. The nginx volume list must then be exactly what a no-TLS
+    deployment renders, so opting out costs nothing."""
+    # Arrange
+    with_tls = copy.deepcopy(_MULTI_USER_CONFIG)
+    with_tls["modules"]["web_terminals"]["tls"] = copy.deepcopy(_TLS_STANZA)
+
+    # Act / Assert
+    assert _nginx_volumes(with_tls) == _nginx_volumes(_MULTI_USER_CONFIG)
+
+
+@pytest.mark.parametrize(
+    ("stanza", "expected"),
+    [
+        pytest.param(
+            {"enabled": False, "host_cert_dir": "/etc/ssl/dls"},
+            "tls.enabled is false",
+            id="mount-without-tls",
+        ),
+        pytest.param(
+            {**_TLS_STANZA, "host_cert_dir": "certs/dls"},
+            "must be an absolute path",
+            id="relative-source",
+        ),
+        pytest.param(
+            {
+                "enabled": True,
+                "cert": "/etc/nginx/certs/dls.crt",
+                "key": "/etc/nginx/private/dls.key",
+                "host_cert_dir": "/etc/ssl/dls",
+            },
+            "same directory",
+            id="key-outside-the-mount",
+        ),
+    ],
+)
+def test_tls_host_cert_dir_refuses_a_mount_that_cannot_deliver_both_files(
+    stanza: dict, expected: str
+) -> None:
+    """Each rejected shape would otherwise render happily and fail at nginx start.
+
+    A relative source silently follows the project directory; a key outside the
+    mounted directory is simply absent in the container; and mounting a
+    certificate into an nginx serving no HTTPS is a config the operator did not
+    mean. All three are refused at render time, where the message can name the
+    cause.
+    """
+    # Arrange
+    config = copy.deepcopy(_MULTI_USER_CONFIG)
+    config["modules"]["web_terminals"]["tls"] = stanza
+
+    # Act / Assert
+    with pytest.raises(ValueError, match=expected):
+        render_web_terminals(config)
 
 
 def test_seam_auth_surface_exists_only_on_the_tls_content_server() -> None:

--- a/tests/deployment/web_terminals/test_lifecycle.py
+++ b/tests/deployment/web_terminals/test_lifecycle.py
@@ -1505,14 +1505,14 @@ def test_decommission_purges_the_departed_users_auth_credentials(
     the departed user's. Leaving the hash behind would silently hand the next
     holder of that name the previous holder's credential."""
     monkeypatch.chdir(tmp_path)
-    _seed_env_auth(tmp_path, ALICE="scrypt$alice", BOB="scrypt$bob")
+    _seed_env_auth(tmp_path, ALICE="scrypt.alice", BOB="scrypt.bob")
     config_path = _write_config(tmp_path, _renderable_auth_config(["alice", "bob"]))
 
     lifecycle.decommission_user(str(config_path), "alice", assume_yes=True)
 
     stored = parse_dotenv_file(tmp_path / AUTH_ENV_FILENAME)
     assert f"{PW_HASH_VAR_PREFIX}ALICE" not in stored
-    assert stored[f"{PW_HASH_VAR_PREFIX}BOB"] == "scrypt$bob"  # untouched
+    assert stored[f"{PW_HASH_VAR_PREFIX}BOB"] == "scrypt.bob"  # untouched
 
 
 def test_decommission_reloads_nginx_and_recreates_the_auth_sidecar(
@@ -1523,7 +1523,7 @@ def test_decommission_reloads_nginx_and_recreates_the_auth_sidecar(
     creation. The reload drops the user's routes; the recreate re-reads both and
     ends their live session now rather than at its natural expiry."""
     monkeypatch.chdir(tmp_path)
-    _seed_env_auth(tmp_path, ALICE="scrypt$alice")
+    _seed_env_auth(tmp_path, ALICE="scrypt.alice")
     config_path = _write_config(tmp_path, _renderable_auth_config(["alice", "bob"]))
 
     lifecycle.decommission_user(str(config_path), "alice", assume_yes=True)
@@ -1561,7 +1561,7 @@ def test_prune_purges_off_roster_auth_credentials_and_recreates(
     # prune re-renders nothing, so the deployed compose file is the one a
     # previous `deploy up` left at the project root.
     (tmp_path / "docker-compose.web.yml").write_text("services: {}\n", encoding="utf-8")
-    _seed_env_auth(tmp_path, ALICE="scrypt$alice", CAROL="scrypt$carol")
+    _seed_env_auth(tmp_path, ALICE="scrypt.alice", CAROL="scrypt$carol")
     listing["containers"] = ["dls-web-carol"]
     config_path = _write_config(tmp_path, _renderable_auth_config(["alice"]))
 
@@ -1569,7 +1569,7 @@ def test_prune_purges_off_roster_auth_credentials_and_recreates(
 
     stored = parse_dotenv_file(tmp_path / AUTH_ENV_FILENAME)
     assert f"{PW_HASH_VAR_PREFIX}CAROL" not in stored
-    assert stored[f"{PW_HASH_VAR_PREFIX}ALICE"] == "scrypt$alice"  # on-roster, untouched
+    assert stored[f"{PW_HASH_VAR_PREFIX}ALICE"] == "scrypt.alice"  # on-roster, untouched
     assert [cmd for cmd in _web_stack_cmds(calls) if "--force-recreate" in cmd]
 
 
@@ -1585,7 +1585,7 @@ def test_prune_with_no_auth_entries_to_purge_recreates_nothing(
     # suppresses the argv on its own and this test would pass even with the
     # nothing-to-put-into-force guard deleted.
     (tmp_path / "docker-compose.web.yml").write_text("services: {}\n", encoding="utf-8")
-    _seed_env_auth(tmp_path, ALICE="scrypt$alice")
+    _seed_env_auth(tmp_path, ALICE="scrypt.alice")
     listing["containers"] = ["dls-web-carol"]  # orphan that never had a credential
     config_path = _write_config(tmp_path, _renderable_auth_config(["alice"]))
 
@@ -1604,7 +1604,7 @@ def test_decommission_warns_when_a_departed_users_plaintext_auth_password_surviv
     is operator-owned, so this warns (naming the exact variable) rather than
     silently editing it."""
     monkeypatch.chdir(tmp_path)
-    _seed_env_auth(tmp_path, ALICE="scrypt$alice")
+    _seed_env_auth(tmp_path, ALICE="scrypt.alice")
     (tmp_path / ".env").write_text("SOMETHING=1\nOSPREY_AUTH_PW_ALICE=hunter2\n", encoding="utf-8")
     config_path = _write_config(tmp_path, _renderable_auth_config(["alice", "bob"]))
 
@@ -1624,7 +1624,7 @@ def test_an_unreadable_env_does_not_become_a_recreate_failure(
     recreate failure, and above all it must not skip the recreate — the step that
     actually puts the purge into force."""
     monkeypatch.chdir(tmp_path)
-    _seed_env_auth(tmp_path, ALICE="scrypt$alice")
+    _seed_env_auth(tmp_path, ALICE="scrypt.alice")
     (tmp_path / ".env").write_text("SOMETHING=1\n", encoding="utf-8")
     config_path = _write_config(tmp_path, _renderable_auth_config(["alice", "bob"]))
 
@@ -1652,7 +1652,7 @@ def test_decommission_auth_recreate_failure_is_fatal_after_the_volume_policy_run
     from osprey.deployment.web_terminals import provision
 
     monkeypatch.chdir(tmp_path)
-    _seed_env_auth(tmp_path, ALICE="scrypt$alice")
+    _seed_env_auth(tmp_path, ALICE="scrypt.alice")
     config_path = _write_config(tmp_path, _renderable_auth_config(["alice", "bob"]))
 
     def _failed_recreate(*args, **kwargs):
@@ -1710,7 +1710,7 @@ def test_decommission_purge_failure_names_the_user_whose_credential_survives(
     container was already removed, with nothing saying the credential survived
     and that the perimeter was never reconciled."""
     monkeypatch.chdir(tmp_path)
-    _seed_env_auth(tmp_path, ALICE="scrypt$alice")
+    _seed_env_auth(tmp_path, ALICE="scrypt.alice")
     config_path = _write_config(tmp_path, _renderable_auth_config(["alice", "bob"]))
 
     def _unwritable(*args, **kwargs):

--- a/tests/deployment/web_terminals/test_lifecycle.py
+++ b/tests/deployment/web_terminals/test_lifecycle.py
@@ -18,7 +18,10 @@ from ruamel.yaml import YAML
 
 from osprey.deployment.compose_generator import resolve_user_volume_names
 from osprey.deployment.web_terminals import lifecycle
+from osprey.deployment.web_terminals.auth_credentials import AUTH_ENV_FILENAME, PW_HASH_VAR_PREFIX
+from osprey.services.auth_sidecar.passwords import verify_password
 from osprey.utils import config_writer
+from osprey.utils.dotenv import parse_dotenv_file
 
 _FORBIDDEN_ARGV_TOKENS = {"prune", "-a", "--all", "system", "network"}
 _GLOB_METACHARACTERS = set("*?[")
@@ -1059,10 +1062,12 @@ def test_nuke_prints_image_plan_before_confirmation(
 
     out = capsys.readouterr().out
     assert "acc-control-control-room:local" in out
-    assert "persona image" in out
+    # "image(s)", not "persona image(s)": the set now also carries the auth
+    # sidecar's own local tag when authentication is on in local mode.
+    assert "image(s)" in out
     # The plan (containing the image line) was printed strictly before input() was read.
     assert prompts, "expected the confirmation prompt to have been read"
-    assert "1 persona image" in prompts[0] or "persona image" in prompts[0]
+    assert "1 image(s)" in prompts[0]
 
 
 def test_nuke_without_confirmation_never_removes_or_inspects_images_when_declined(
@@ -1179,3 +1184,659 @@ other_section:
         {"name": "alice", "index": 0},
         {"name": "carol", "index": 2},
     ]
+
+
+# =============================================================================
+# passwd: rotate one user's login password
+# =============================================================================
+
+
+def _auth_config(users, method="password"):
+    """`_config` plus an `auth` stanza, the only thing the passwd verb adds."""
+    config = _config(users)
+    config["modules"]["web_terminals"]["auth"] = {"method": method}
+    return config
+
+
+def _read_hash(project_root, user_suffix):
+    return parse_dotenv_file(project_root / AUTH_ENV_FILENAME).get(
+        f"{PW_HASH_VAR_PREFIX}{user_suffix}", ""
+    )
+
+
+@pytest.fixture
+def recreate_calls(monkeypatch):
+    """Record calls to the SHARED sidecar-recreate primitive.
+
+    That primitive lives in provision.py, which owns the web stack's compose
+    argv; the argv it emits is pinned by provision's own tests. What belongs
+    here is that this verb delegates to it — and with which arguments — rather
+    than assembling a second copy of the invocation.
+    """
+    from osprey.deployment.web_terminals import provision
+
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        provision,
+        "force_recreate_auth_sidecar",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+    return calls
+
+
+def test_passwd_stores_the_new_hash_and_recreates_the_sidecar(
+    tmp_path, monkeypatch, fake_runtime, recreate_calls
+):
+    """The hash is replaced AND the sidecar is recreated — a stored hash the
+    running sidecar never re-reads would leave the operator with a password
+    that does not work."""
+    monkeypatch.chdir(tmp_path)
+    config_path = _write_config(tmp_path, _auth_config(["alice", "bob"]))
+
+    lifecycle.rotate_user_password(str(config_path), "alice", "alices-new-password")
+
+    assert verify_password("alices-new-password", _read_hash(tmp_path, "ALICE"))
+    # Delegation contract: the shared primitive is called exactly once, with
+    # this deploy's config and nothing else — resolving the --env-file fragment
+    # is the primitive's job, not this verb's (one definition, shared with
+    # `up`/`down`).
+    assert len(recreate_calls) == 1
+    (config_arg, *rest), kwargs = recreate_calls[0]
+    assert config_arg["modules"]["web_terminals"]["users"] == ["alice", "bob"]
+    assert rest == [] and kwargs == {}
+
+
+def test_passwd_emits_no_runtime_argv_of_its_own(
+    tmp_path, monkeypatch, fake_runtime, recreate_calls
+):
+    """Changing a password touches no container directly: no per-user terminal
+    is bounced, nothing is removed, and the only runtime action is the delegated
+    single-service recreate."""
+    monkeypatch.chdir(tmp_path)
+    config_path = _write_config(tmp_path, _auth_config(["alice", "bob"]))
+
+    lifecycle.rotate_user_password(str(config_path), "alice", "alices-new-password")
+
+    assert fake_runtime == []
+
+
+def _capture_recreate_argv(monkeypatch) -> list[list[str]]:
+    """Record the argv the REAL recreate primitive emits.
+
+    The fragment used to be resolved at this call site and handed to the
+    primitive, so it could be asserted on the delegated call's arguments. It is
+    now resolved inside the primitive's own argv builder (one definition shared
+    with `up`/`down`), so the honest assertion is on the argv that reaches the
+    runtime — a stricter check than the old one, and one that cannot pass while
+    the fragment is dropped on the floor.
+
+    CAUTION for anyone extending a test that uses this: `lifecycle`, `provision`
+    and `postup_hooks` all do a plain `import subprocess`, so they share ONE
+    module object. Patching `provision.subprocess.run` here REPLACES the patch
+    `fake_runtime` installed, which means `fake_runtime`'s own list stays EMPTY
+    in these tests. Assert on the list this returns; an assertion against
+    `fake_runtime` here would be vacuously true.
+    """
+    from osprey.deployment.web_terminals import provision
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(provision, "get_runtime_command", lambda config=None: ["docker", "compose"])
+    monkeypatch.setattr(provision.subprocess, "run", lambda cmd, **kwargs: calls.append(list(cmd)))
+    return calls
+
+
+def test_passwd_carries_the_env_file_fragment_into_the_recreate(
+    tmp_path, monkeypatch, fake_runtime
+):
+    """The recreate resolves the same variables as every other web-stack
+    invocation — omitting the fragment would make this a differently-configured
+    `up`."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text("SOMETHING=1\n")
+    (tmp_path / "docker-compose.web.yml").write_text("services: {}\n")
+    config_path = _write_config(tmp_path, _auth_config(["alice"]))
+    argv = _capture_recreate_argv(monkeypatch)
+
+    lifecycle.rotate_user_password(str(config_path), "alice", "alices-new-password")
+
+    assert argv[0][:6] == [
+        "docker",
+        "compose",
+        "-f",
+        "docker-compose.web.yml",
+        "--env-file",
+        ".env",
+    ]
+
+
+def test_passwd_before_the_stack_is_deployed_warns_and_does_not_raise(
+    tmp_path, monkeypatch, fake_runtime, caplog
+):
+    """A password can be set before the stack has ever been brought up: with no
+    rendered docker-compose.web.yml there is no container to recreate, and
+    failing here would turn "not deployed yet" into a rotation error. The hash
+    is still stored, and the next `osprey deploy up` puts it in force."""
+    monkeypatch.chdir(tmp_path)
+    config_path = _write_config(tmp_path, _auth_config(["alice"]))
+    argv = _capture_recreate_argv(monkeypatch)  # no compose file written
+
+    with caplog.at_level("WARNING"):
+        lifecycle.rotate_user_password(str(config_path), "alice", "alices-new-password")
+
+    assert argv == []
+    assert "docker-compose.web.yml" in caplog.text
+    assert verify_password("alices-new-password", _read_hash(tmp_path, "ALICE"))
+
+
+def test_passwd_recreate_carries_no_env_file_argument_without_a_dotenv(
+    tmp_path, monkeypatch, fake_runtime
+):
+    """No `.env` at the project root means no `--env-file` argument at all —
+    compose rejects one pointing at a file that does not exist."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "docker-compose.web.yml").write_text("services: {}\n")
+    config_path = _write_config(tmp_path, _auth_config(["alice"]))
+    argv = _capture_recreate_argv(monkeypatch)
+
+    lifecycle.rotate_user_password(str(config_path), "alice", "alices-new-password")
+
+    assert "--env-file" not in argv[0]
+
+
+def test_passwd_refuses_when_authentication_is_off(tmp_path, monkeypatch, fake_runtime):
+    """`auth.method: none` has no password to change — writing a hash would
+    produce a credential nothing ever checks, over a success message."""
+    monkeypatch.chdir(tmp_path)
+    config_path = _write_config(tmp_path, _auth_config(["alice"], method="none"))
+
+    with pytest.raises(ValueError, match="none"):
+        lifecycle.rotate_user_password(str(config_path), "alice", "alices-new-password")
+
+    assert not (tmp_path / AUTH_ENV_FILENAME).exists()
+    assert fake_runtime == []
+
+
+def test_passwd_refuses_when_credentials_are_held_by_the_idp(tmp_path, monkeypatch, fake_runtime):
+    monkeypatch.chdir(tmp_path)
+    config_path = _write_config(tmp_path, _auth_config(["alice"], method="oidc"))
+
+    with pytest.raises(ValueError, match="identity provider"):
+        lifecycle.rotate_user_password(str(config_path), "alice", "alices-new-password")
+
+    assert not (tmp_path / AUTH_ENV_FILENAME).exists()
+    assert fake_runtime == []
+
+
+def test_passwd_refuses_an_off_roster_user(tmp_path, monkeypatch, fake_runtime):
+    """An off-roster name keys a variable no rendered sidecar reads, so its
+    "new password" could never be used to log in anywhere."""
+    monkeypatch.chdir(tmp_path)
+    config_path = _write_config(tmp_path, _auth_config(["alice"]))
+
+    with pytest.raises(ValueError, match="not present in modules.web_terminals.users"):
+        lifecycle.rotate_user_password(str(config_path), "mallory", "some-password")
+
+    assert not (tmp_path / AUTH_ENV_FILENAME).exists()
+    assert fake_runtime == []
+
+
+def test_passwd_refuses_before_writing_when_the_runtime_is_down(tmp_path, monkeypatch):
+    """Gate on the runtime BEFORE the write: otherwise the operator is handed a
+    password the deployment was never told about."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(lifecycle, "verify_runtime_is_running", lambda config=None: (False, "down"))
+    config_path = _write_config(tmp_path, _auth_config(["alice"]))
+
+    with pytest.raises(RuntimeError, match="down"):
+        lifecycle.rotate_user_password(str(config_path), "alice", "alices-new-password")
+
+    assert not (tmp_path / AUTH_ENV_FILENAME).exists()
+
+
+def test_passwd_does_not_recreate_when_the_credential_write_failed(
+    tmp_path, monkeypatch, fake_runtime, recreate_calls
+):
+    """A failed write must abort loudly, not recreate a sidecar around an
+    unchanged file and report success."""
+    monkeypatch.chdir(tmp_path)
+
+    def _unwritable(*args, **kwargs):
+        raise RuntimeError("Could not write .env.auth; the password was NOT changed.")
+
+    monkeypatch.setattr(lifecycle, "set_auth_password", _unwritable)
+    config_path = _write_config(tmp_path, _auth_config(["alice"]))
+
+    with pytest.raises(RuntimeError, match="NOT changed"):
+        lifecycle.rotate_user_password(str(config_path), "alice", "alices-new-password")
+
+    assert recreate_calls == []
+
+
+def test_passwd_reports_a_failed_recreate_as_a_password_that_DID_change(
+    tmp_path, monkeypatch, fake_runtime
+):
+    """The mirror of the write-failure case, and the harder half to get right.
+
+    By the time the recreate runs the hash is already stored, so a bare failure
+    would reach the CLI's generic handler as "Deployment failed" — and the
+    operator would conclude their old password still works. It does not. The
+    error has to say the password changed and name what puts it in force.
+    """
+    monkeypatch.chdir(tmp_path)
+    config_path = _write_config(tmp_path, _auth_config(["alice"]))
+
+    from osprey.deployment.web_terminals import provision
+
+    def _failed_recreate(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, ["docker", "compose", "up"])
+
+    monkeypatch.setattr(provision, "force_recreate_auth_sidecar", _failed_recreate)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        lifecycle.rotate_user_password(str(config_path), "alice", "alices-new-password")
+
+    message = str(exc_info.value)
+    assert "WAS changed" in message
+    assert "osprey deploy up" in message
+    # The stored hash really is the new one — the message is not a consolation.
+    assert verify_password("alices-new-password", _read_hash(tmp_path, "ALICE"))
+
+
+def test_passwd_never_logs_or_prints_the_password(
+    tmp_path, monkeypatch, fake_runtime, capsys, caplog
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = _write_config(tmp_path, _auth_config(["alice"]))
+
+    with caplog.at_level("DEBUG"):
+        lifecycle.rotate_user_password(str(config_path), "alice", "unmistakable-secret")
+
+    assert "unmistakable-secret" not in capsys.readouterr().out
+    assert "unmistakable-secret" not in caplog.text
+
+
+# =============================================================================
+# Roster removal with authentication on: credential purge + perimeter reconcile
+# =============================================================================
+
+
+@pytest.fixture
+def auth_reconcile_runtime(monkeypatch):
+    """Make the delegated web-stack calls (nginx reload, sidecar recreate) safe
+    to run, and let the existing runtime fixtures record them.
+
+    Deliberately patches NO subprocess: ``lifecycle``, ``provision`` and
+    ``postup_hooks`` all do a plain ``import subprocess``, so they share one
+    module object — ``fake_runtime``/``fake_runtime_prune`` already intercept
+    every one of these calls, and a second patch here would silently replace
+    theirs (including the ``ps -a`` discovery output prune depends on). What
+    does need patching is ``provision``'s own ``get_runtime_command`` binding,
+    which those fixtures do not reach.
+    """
+    from osprey.deployment.web_terminals import provision
+
+    monkeypatch.setattr(provision, "get_runtime_command", lambda config=None: ["docker", "compose"])
+
+
+def _web_stack_cmds(calls) -> list[list[str]]:
+    """The recorded argv that address the web compose project."""
+    return [cmd for cmd in calls if "docker-compose.web.yml" in cmd]
+
+
+def _renderable_auth_config(users, method="password"):
+    """`_auth_config` that also passes the render gate: authentication over
+    cleartext HTTP is refused at render time unless explicitly allowed, and
+    decommission re-renders the artifacts as part of the verb."""
+    config = _auth_config(users, method=method)
+    config["modules"]["web_terminals"]["auth"]["allow_insecure_http"] = True
+    return config
+
+
+def _seed_env_auth(tmp_path, **hashes) -> None:
+    """Write a .env.auth holding one stored hash per named user suffix."""
+    lines = [f"{PW_HASH_VAR_PREFIX}{suffix}={value}\n" for suffix, value in hashes.items()]
+    (tmp_path / AUTH_ENV_FILENAME).write_text("".join(lines), encoding="utf-8")
+
+
+def test_decommission_purges_the_departed_users_auth_credentials(
+    tmp_path, monkeypatch, fake_runtime, auth_reconcile_runtime
+):
+    """A re-added same-name user must be minted a FRESH password, never inherit
+    the departed user's. Leaving the hash behind would silently hand the next
+    holder of that name the previous holder's credential."""
+    monkeypatch.chdir(tmp_path)
+    _seed_env_auth(tmp_path, ALICE="scrypt$alice", BOB="scrypt$bob")
+    config_path = _write_config(tmp_path, _renderable_auth_config(["alice", "bob"]))
+
+    lifecycle.decommission_user(str(config_path), "alice", assume_yes=True)
+
+    stored = parse_dotenv_file(tmp_path / AUTH_ENV_FILENAME)
+    assert f"{PW_HASH_VAR_PREFIX}ALICE" not in stored
+    assert stored[f"{PW_HASH_VAR_PREFIX}BOB"] == "scrypt$bob"  # untouched
+
+
+def test_decommission_reloads_nginx_and_recreates_the_auth_sidecar(
+    tmp_path, monkeypatch, fake_runtime, auth_reconcile_runtime
+):
+    """Re-rendering the artifacts is not enough: nginx still serves the previous
+    config, and the sidecar holds the old roster and hashes baked in at its
+    creation. The reload drops the user's routes; the recreate re-reads both and
+    ends their live session now rather than at its natural expiry."""
+    monkeypatch.chdir(tmp_path)
+    _seed_env_auth(tmp_path, ALICE="scrypt$alice")
+    config_path = _write_config(tmp_path, _renderable_auth_config(["alice", "bob"]))
+
+    lifecycle.decommission_user(str(config_path), "alice", assume_yes=True)
+
+    web_cmds = _web_stack_cmds(fake_runtime)
+    assert any(cmd[-4:] == ["nginx", "nginx", "-s", "reload"] for cmd in web_cmds)
+    recreates = [cmd for cmd in web_cmds if "--force-recreate" in cmd]
+    assert len(recreates) == 1
+    # Service-scoped: a bare --force-recreate would bounce every live terminal.
+    assert recreates[0][-3:] == ["-d", "--force-recreate", "auth"]
+
+
+def test_decommission_with_auth_off_touches_no_auth_state(
+    tmp_path, monkeypatch, fake_runtime, auth_reconcile_runtime
+):
+    """`auth.method: none` has no sidecar, no .env.auth and no perimeter to
+    reconcile — the verb must behave exactly as it did before auth existed."""
+    monkeypatch.chdir(tmp_path)
+    config_path = _write_config(tmp_path, _renderable_auth_config(["alice", "bob"], method="none"))
+
+    lifecycle.decommission_user(str(config_path), "alice", assume_yes=True)
+
+    assert _web_stack_cmds(fake_runtime) == []
+    assert not (tmp_path / AUTH_ENV_FILENAME).exists()
+
+
+def test_prune_purges_off_roster_auth_credentials_and_recreates(
+    tmp_path, monkeypatch, fake_runtime_prune, auth_reconcile_runtime
+):
+    """An orphan was hand-edited off the roster, so nothing re-renders — but
+    their hash is still in .env.auth and would be inherited by the next user of
+    that name. Purge it, then recreate so the sidecar stops honoring it."""
+    calls, listing = fake_runtime_prune
+    monkeypatch.chdir(tmp_path)
+    # prune re-renders nothing, so the deployed compose file is the one a
+    # previous `deploy up` left at the project root.
+    (tmp_path / "docker-compose.web.yml").write_text("services: {}\n", encoding="utf-8")
+    _seed_env_auth(tmp_path, ALICE="scrypt$alice", CAROL="scrypt$carol")
+    listing["containers"] = ["dls-web-carol"]
+    config_path = _write_config(tmp_path, _renderable_auth_config(["alice"]))
+
+    lifecycle.prune_users(str(config_path), assume_yes=True)
+
+    stored = parse_dotenv_file(tmp_path / AUTH_ENV_FILENAME)
+    assert f"{PW_HASH_VAR_PREFIX}CAROL" not in stored
+    assert stored[f"{PW_HASH_VAR_PREFIX}ALICE"] == "scrypt$alice"  # on-roster, untouched
+    assert [cmd for cmd in _web_stack_cmds(calls) if "--force-recreate" in cmd]
+
+
+def test_prune_with_no_auth_entries_to_purge_recreates_nothing(
+    tmp_path, monkeypatch, fake_runtime_prune, auth_reconcile_runtime
+):
+    """Nothing changed in .env.auth and nothing was re-rendered, so there is
+    nothing to put into force — bouncing the sidecar would drop every live
+    session for no reason."""
+    calls, listing = fake_runtime_prune
+    monkeypatch.chdir(tmp_path)
+    # The deployed compose file MUST be present: without it warn-and-no-op
+    # suppresses the argv on its own and this test would pass even with the
+    # nothing-to-put-into-force guard deleted.
+    (tmp_path / "docker-compose.web.yml").write_text("services: {}\n", encoding="utf-8")
+    _seed_env_auth(tmp_path, ALICE="scrypt$alice")
+    listing["containers"] = ["dls-web-carol"]  # orphan that never had a credential
+    config_path = _write_config(tmp_path, _renderable_auth_config(["alice"]))
+
+    lifecycle.prune_users(str(config_path), assume_yes=True)
+
+    assert _web_stack_cmds(calls) == []
+
+
+def test_decommission_warns_when_a_departed_users_plaintext_auth_password_survives(
+    tmp_path, monkeypatch, fake_runtime, auth_reconcile_runtime, caplog
+):
+    """Purging .env.auth is only half the story: `ensure_auth_credentials` also
+    hashes `OSPREY_AUTH_PW_<SUFFIX>` out of the project .env whenever no hash is
+    established, so the purge re-opens that fallback and the next `deploy up`
+    would re-establish the DEPARTED holder's password for a re-added name. .env
+    is operator-owned, so this warns (naming the exact variable) rather than
+    silently editing it."""
+    monkeypatch.chdir(tmp_path)
+    _seed_env_auth(tmp_path, ALICE="scrypt$alice")
+    (tmp_path / ".env").write_text("SOMETHING=1\nOSPREY_AUTH_PW_ALICE=hunter2\n", encoding="utf-8")
+    config_path = _write_config(tmp_path, _renderable_auth_config(["alice", "bob"]))
+
+    with caplog.at_level("WARNING"):
+        lifecycle.decommission_user(str(config_path), "alice", assume_yes=True)
+
+    assert "OSPREY_AUTH_PW_ALICE" in caplog.text
+    assert ".env" in caplog.text
+    assert "hunter2" not in caplog.text  # names the variable, never its value
+
+
+def test_an_unreadable_env_does_not_become_a_recreate_failure(
+    tmp_path, monkeypatch, fake_runtime, auth_reconcile_runtime, caplog
+):
+    """The plaintext-survival check only READS the project `.env`, so a failure
+    to read it says nothing about the sidecar. It must not be reported as a
+    recreate failure, and above all it must not skip the recreate — the step that
+    actually puts the purge into force."""
+    monkeypatch.chdir(tmp_path)
+    _seed_env_auth(tmp_path, ALICE="scrypt$alice")
+    (tmp_path / ".env").write_text("SOMETHING=1\n", encoding="utf-8")
+    config_path = _write_config(tmp_path, _renderable_auth_config(["alice", "bob"]))
+
+    def _unreadable(*args, **kwargs):
+        raise OSError("Permission denied")
+
+    monkeypatch.setattr(lifecycle, "parse_dotenv_file", _unreadable)
+
+    with caplog.at_level("WARNING"):
+        lifecycle.decommission_user(str(config_path), "alice", assume_yes=True)
+
+    assert [cmd for cmd in _web_stack_cmds(fake_runtime) if "--force-recreate" in cmd]
+    assert "Permission denied" in caplog.text
+    assert "could not be recreated" not in caplog.text
+
+
+def test_decommission_auth_recreate_failure_is_fatal_after_the_volume_policy_runs(
+    tmp_path, monkeypatch, fake_runtime, auth_reconcile_runtime
+):
+    """A failed recreate is fatal — the removed user's session may still be live,
+    which is the whole point of the verb — but it is raised only AFTER the
+    remaining local cleanup completes: every local change already succeeded, and
+    abandoning the volume policy would leave a state more inconsistent than the
+    error reports."""
+    from osprey.deployment.web_terminals import provision
+
+    monkeypatch.chdir(tmp_path)
+    _seed_env_auth(tmp_path, ALICE="scrypt$alice")
+    config_path = _write_config(tmp_path, _renderable_auth_config(["alice", "bob"]))
+
+    def _failed_recreate(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, ["docker", "compose", "up"])
+
+    monkeypatch.setattr(provision, "force_recreate_auth_sidecar", _failed_recreate)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        lifecycle.decommission_user(str(config_path), "alice", purge=True, assume_yes=True)
+
+    message = str(exc_info.value)
+    assert "purged" in message
+    # Narrow and true: auth_request lives only in the per-user location blocks
+    # and the (advisory, non-raising) reload already dropped alice's. What
+    # survives is an unreconciled sidecar, NOT a live session — an overstated
+    # error an operator later finds untrue costs the next one its credibility.
+    assert "still holds their roster entry and password hash" in message
+    assert "may still be live" not in message
+    assert "osprey deploy up" in message
+    # The claim in that message is a verified fact, not a consolation.
+    assert f"{PW_HASH_VAR_PREFIX}ALICE" not in parse_dotenv_file(tmp_path / AUTH_ENV_FILENAME)
+    # ...and the deferred raise let the volume policy finish first.
+    assert [cmd for cmd in fake_runtime if cmd[1:3] == ["volume", "rm"]]
+
+
+def test_prune_auth_recreate_failure_is_fatal_too(
+    tmp_path, monkeypatch, fake_runtime_prune, auth_reconcile_runtime
+):
+    """The prune path reaches the same guard — a decommission-only test would
+    miss half of it."""
+    from osprey.deployment.web_terminals import provision
+
+    calls, listing = fake_runtime_prune
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "docker-compose.web.yml").write_text("services: {}\n", encoding="utf-8")
+    _seed_env_auth(tmp_path, CAROL="scrypt$carol")
+    listing["containers"] = ["dls-web-carol"]
+    config_path = _write_config(tmp_path, _renderable_auth_config(["alice"]))
+
+    def _failed_recreate(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, ["docker", "compose", "up"])
+
+    monkeypatch.setattr(provision, "force_recreate_auth_sidecar", _failed_recreate)
+
+    with pytest.raises(RuntimeError, match="still holds their roster entry"):
+        lifecycle.prune_users(str(config_path), assume_yes=True)
+
+    assert f"{PW_HASH_VAR_PREFIX}CAROL" not in parse_dotenv_file(tmp_path / AUTH_ENV_FILENAME)
+
+
+def test_decommission_purge_failure_names_the_user_whose_credential_survives(
+    tmp_path, monkeypatch, fake_runtime, auth_reconcile_runtime
+):
+    """An unwritable .env.auth surfaced as a bare PermissionError after the
+    container was already removed, with nothing saying the credential survived
+    and that the perimeter was never reconciled."""
+    monkeypatch.chdir(tmp_path)
+    _seed_env_auth(tmp_path, ALICE="scrypt$alice")
+    config_path = _write_config(tmp_path, _renderable_auth_config(["alice", "bob"]))
+
+    def _unwritable(*args, **kwargs):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(lifecycle, "purge_auth_credentials", _unwritable)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        lifecycle.decommission_user(str(config_path), "alice", assume_yes=True)
+
+    message = str(exc_info.value)
+    assert "alice" in message
+    assert AUTH_ENV_FILENAME in message
+    assert "still opens a terminal" in message
+    # Decommission targets ONE user, so this purge cleared nobody before it
+    # failed: there is no partial change to put into force, and bouncing every
+    # live session would be gratuitous. The hash is STILL THERE and no recreate
+    # ran. Contrast the multi-user case below, where the recreate MUST run.
+    assert f"{PW_HASH_VAR_PREFIX}ALICE" in parse_dotenv_file(tmp_path / AUTH_ENV_FILENAME)
+    assert not [cmd for cmd in fake_runtime if "--force-recreate" in cmd]
+    # The nginx reload is NOT skipped with it: the re-rendered config — already
+    # missing alice's route to her removed container — is on disk either way,
+    # and only the reload applies it.
+    assert any(cmd[-4:] == ["nginx", "nginx", "-s", "reload"] for cmd in fake_runtime)
+
+
+def test_prune_partial_purge_failure_still_forces_the_earlier_removals_into_effect(
+    tmp_path, monkeypatch, fake_runtime_prune, auth_reconcile_runtime
+):
+    """The failure this guard exists to prevent, and the reason the purge loop
+    has a guard of its own.
+
+    With several orphans, a purge that succeeds for carol and then raises for
+    dave has ALREADY taken carol's hash out of `.env.auth`. Skipping the
+    recreate there would leave the deployment lying in the operator's favour:
+    the file they would read no longer lists carol, while the running sidecar
+    still holds her hash and still lets her log in — until the next deploy, with
+    nothing saying so. So the recreate runs anyway, and only then is the error
+    raised, naming dave (whose credential really did survive) and NOT carol.
+    """
+    calls, listing = fake_runtime_prune
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "docker-compose.web.yml").write_text("services: {}\n", encoding="utf-8")
+    _seed_env_auth(tmp_path, CAROL="scrypt$carol", DAVE="scrypt$dave")
+    listing["containers"] = ["dls-web-carol", "dls-web-dave"]
+    config_path = _write_config(tmp_path, _renderable_auth_config(["alice"]))
+
+    real_purge = lifecycle.purge_auth_credentials
+
+    def _fails_for_dave(user, project_root):
+        if user == "dave":
+            raise PermissionError(13, "Permission denied")
+        return real_purge(user, project_root)
+
+    monkeypatch.setattr(lifecycle, "purge_auth_credentials", _fails_for_dave)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        lifecycle.prune_users(str(config_path), assume_yes=True)
+
+    message = str(exc_info.value)
+    # Named as removed-and-still-credentialed: only dave.
+    assert "'dave'" in message
+    assert "still opens a terminal" in message
+    assert "were removed and their auth credentials could not be removed" in message
+    # carol appears only as the reassurance that her removal IS in force — never
+    # as one of the users whose credential survived.
+    assert "'carol' WERE removed" in message
+    # The disk state the message describes is the real one.
+    stored = parse_dotenv_file(tmp_path / AUTH_ENV_FILENAME)
+    assert f"{PW_HASH_VAR_PREFIX}CAROL" not in stored
+    assert f"{PW_HASH_VAR_PREFIX}DAVE" in stored
+    # ...and the partial removal was put into force before the raise.
+    assert [cmd for cmd in calls if "--force-recreate" in cmd]
+
+
+def _auth_persona_config(users, *, method="password", auth_image=None, image_source="local"):
+    """A local-mode persona config with authentication on — the shape that makes
+    the sidecar's own :local tag a nuke candidate."""
+    config = _persona_config(users, project_name="demo-project")
+    config["modules"]["web_terminals"]["image_source"] = image_source
+    auth: dict = {"method": method}
+    if auth_image is not None:
+        auth["image"] = auth_image
+    config["modules"]["web_terminals"]["auth"] = auth
+    return config
+
+
+def test_nuke_auth_sidecar_image_is_removed_when_label_verified(
+    tmp_path, monkeypatch, fake_runtime_nuke
+):
+    """The sidecar's local tag is this deployment's to tear down, on the same
+    label-verified terms as a persona tag — nothing else ever removes it."""
+    calls, _listing, _down_result, image_labels = fake_runtime_nuke
+    monkeypatch.chdir(tmp_path)
+    config_path = _write_config(tmp_path, _auth_persona_config(["alice"]))
+    image_labels["dls-assistant-auth:local"] = "demo-project"
+    image_labels["acc-control-control-room:local"] = "demo-project"
+    _assert_no_input_prompt(monkeypatch)
+
+    lifecycle.nuke_stack(str(config_path), assume_yes=True)
+
+    removed = [c[3] for c in calls if c[1:3] == ["image", "rm"]]
+    assert "dls-assistant-auth:local" in removed
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "why"),
+    [
+        ({"method": "none"}, "auth off renders no sidecar at all"),
+        ({"image_source": "registry"}, "registry mode never built a local tag"),
+        ({"auth_image": "reg/auth:1"}, "auth.image pins an externally owned image"),
+    ],
+)
+def test_nuke_auth_sidecar_image_is_not_a_candidate(
+    tmp_path, monkeypatch, fake_runtime_nuke, kwargs, why
+):
+    """Only the exact conditions that PRODUCE the local tag make it a teardown
+    candidate; removing an image this deployment never built is not ours to do."""
+    calls, _listing, _down_result, image_labels = fake_runtime_nuke
+    monkeypatch.chdir(tmp_path)
+    config_path = _write_config(tmp_path, _auth_persona_config(["alice"], **kwargs))
+    image_labels["dls-assistant-auth:local"] = "demo-project"  # exists and is ours
+    image_labels["acc-control-control-room:local"] = "demo-project"
+    _assert_no_input_prompt(monkeypatch)
+
+    lifecycle.nuke_stack(str(config_path), assume_yes=True)
+
+    inspected = [c[3] for c in calls if c[1:3] == ["image", "inspect"]]
+    assert "dls-assistant-auth:local" not in inspected, why

--- a/tests/deployment/web_terminals/test_lint.py
+++ b/tests/deployment/web_terminals/test_lint.py
@@ -6,6 +6,7 @@ import copy
 
 import pytest
 
+from osprey.deployment.web_terminals import lint
 from osprey.deployment.web_terminals.lint import Finding, lint_web_terminals
 
 _CLEAN_CONFIG = {
@@ -212,6 +213,25 @@ def test_lint_username_charset_rejects_leading_dash_underscore_space_and_upperca
         assert any(f.code == "web_terminals.invalid_username_charset" for f in errors), (
             f"expected {bad_name!r} to be rejected"
         )
+
+
+def test_lint_username_charset_rejects_a_trailing_newline() -> None:
+    """The charset check is a `fullmatch`, not a `match`.
+
+    Python's `$` also matches *before* a trailing newline, so a `match` would
+    report "alice\\n" as clean — a name that renders into an nginx location key
+    mid-directive.
+    """
+    # Arrange
+    config = copy.deepcopy(_CLEAN_CONFIG)
+    config["modules"]["web_terminals"]["users"] = ["alice\n"]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    errors = _errors(findings)
+    assert any(f.code == "web_terminals.invalid_username_charset" for f in errors)
 
 
 def test_lint_username_charset_accepts_leading_digit() -> None:
@@ -693,6 +713,22 @@ def test_lint_persona_catalog_bad_charset_is_an_error() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["personas"] = {"Bad Persona": {"project": "als-x"}}
+    config["modules"]["web_terminals"]["users"] = [{"name": "thellert", "index": 0}]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    errors = _errors(findings)
+    assert any(f.code == "web_terminals.invalid_persona_charset" for f in errors)
+
+
+def test_lint_persona_charset_rejects_a_trailing_newline() -> None:
+    """Same `fullmatch`-not-`match` rule as the username charset check: a persona
+    key with a trailing newline is not clean."""
+    # Arrange
+    config = copy.deepcopy(_CLEAN_CONFIG)
+    config["modules"]["web_terminals"]["personas"] = {"ops\n": {"project": "als-x"}}
     config["modules"]["web_terminals"]["users"] = [{"name": "thellert", "index": 0}]
 
     # Act
@@ -1782,3 +1818,480 @@ def test_lint_empty_nginx_image_is_a_warning() -> None:
     warnings = _warnings(findings)
     assert any(f.code == "web_terminals.empty_nginx_image" for f in warnings)
     assert not any(f.code == "web_terminals.invalid_nginx_image" for f in _errors(findings))
+
+
+# --- auth seam checks ---------------------------------------------------------
+
+
+def test_username_charset_re_is_public_for_auth_credentials() -> None:
+    """`auth_credentials` imports this regex so the deploy-time charset gate and
+    the lint-time check cannot drift; it is part of this module's public surface."""
+    # Act / Assert
+    assert lint.USERNAME_CHARSET_RE.pattern == r"^[a-z0-9][a-z0-9_-]*$"
+
+
+_AUTH_CODES = frozenset(
+    {
+        "web_terminals.invalid_auth_stanza",
+        "web_terminals.invalid_auth_method_type",
+        "web_terminals.unknown_auth_method",
+        "web_terminals.auth_requires_tls",
+        "web_terminals.auth_insecure_http",
+        "web_terminals.auth_oidc_missing_issuer",
+        "web_terminals.auth_oidc_invalid_client_env",
+        "web_terminals.auth_oidc_unresolvable_origin",
+        "web_terminals.auth_credential_collision",
+    }
+)
+
+
+def _auth_config(auth: object, *, tls: bool = True, fqdn: str | None = "web.example.org") -> dict:
+    """A clean config with an `auth` stanza, TLS on and an origin derivable.
+
+    Those two defaults keep each test to the one thing it is about: with TLS
+    off every auth-on config also reports the transport ERROR, and without
+    `deploy.fqdn` every `oidc` config also reports the origin ERROR.
+    """
+    config = copy.deepcopy(_CLEAN_CONFIG)
+    if fqdn is not None:
+        config["deploy"] = {"fqdn": fqdn}
+    web_terminals = config["modules"]["web_terminals"]
+    web_terminals["auth"] = auth
+    if tls:
+        web_terminals["tls"] = {
+            "enabled": True,
+            "cert": "/etc/osprey/tls/facility.crt",
+            "key": "/etc/osprey/tls/facility.key",
+        }
+    return config
+
+
+def _auth_findings(findings: list[Finding]) -> list[Finding]:
+    return [f for f in findings if f.code in _AUTH_CODES]
+
+
+def test_lint_clean_password_auth_config_reports_no_auth_findings() -> None:
+    """Password auth over TLS with an unambiguous roster is a valid deployment."""
+    # Arrange
+    config = _auth_config({"method": "password"})
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert _auth_findings(findings) == []
+    assert _errors(findings) == []
+
+
+def test_lint_absent_auth_stanza_reports_no_auth_findings() -> None:
+    """The inert default (no `auth` stanza at all) must stay silent."""
+    # Arrange
+    config = copy.deepcopy(_CLEAN_CONFIG)
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert _auth_findings(findings) == []
+
+
+def test_lint_auth_method_none_reports_no_auth_findings() -> None:
+    """`method: none` is the explicit spelling of the default, over plain HTTP."""
+    # Arrange
+    config = _auth_config({"method": "none"}, tls=False, fqdn=None)
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert _auth_findings(findings) == []
+
+
+def test_lint_auth_method_written_with_no_value_reports_no_auth_findings() -> None:
+    """`method:` with nothing after it parses to None — an omitted value, which
+    is the documented default, not a typo to reject."""
+    # Arrange
+    config = _auth_config({"method": None}, tls=False, fqdn=None)
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert _auth_findings(findings) == []
+
+
+def test_lint_unknown_auth_method_is_an_error() -> None:
+    """A method the sidecar cannot serve would emit an auth seam nothing answers."""
+    # Arrange
+    config = _auth_config({"method": "basic"})
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    errors = _errors(findings)
+    assert any(f.code == "web_terminals.unknown_auth_method" for f in errors)
+    assert any("'basic'" in f.message for f in errors)
+
+
+def test_lint_empty_auth_method_string_is_an_error() -> None:
+    """An empty `method` silently falls back to 'none' at render time (auth off),
+    so lint is where an operator learns the stanza is inert."""
+    # Arrange
+    config = _auth_config({"method": ""})
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert any(f.code == "web_terminals.unknown_auth_method" for f in _errors(findings))
+
+
+def test_lint_non_string_auth_method_is_an_error() -> None:
+    """render reads `method` defensively, so a wrong-typed one renders auth
+    silently OFF — lint is the only surface that catches the type mistake."""
+    # Arrange
+    config = _auth_config({"method": {"password": True}})
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    errors = _errors(findings)
+    assert any(f.code == "web_terminals.invalid_auth_method_type" for f in errors)
+    assert not any(f.code == "web_terminals.unknown_auth_method" for f in errors)
+
+
+def test_lint_non_mapping_auth_stanza_is_an_error() -> None:
+    """`auth: password` (a scalar where the mapping belongs) is read as no auth
+    stanza at all — the same silent-off failure, one level up."""
+    # Arrange
+    config = _auth_config("password")
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert any(f.code == "web_terminals.invalid_auth_stanza" for f in _errors(findings))
+
+
+def test_lint_unknown_auth_method_suppresses_downstream_auth_findings() -> None:
+    """A method render cannot parse makes every method-keyed check meaningless;
+    only the unknown-method ERROR is reported, not confused follow-ons."""
+    # Arrange — no TLS and no fqdn, which would otherwise add two more findings
+    config = _auth_config({"method": "basic"}, tls=False, fqdn=None)
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert [f.code for f in _auth_findings(findings)] == ["web_terminals.unknown_auth_method"]
+
+
+def test_lint_auth_port_joins_the_port_overlap_set() -> None:
+    """With auth enabled, the sidecar's listener is a real published port and
+    collides with any other source claiming it."""
+    # Arrange — put the sidecar on nginx's own published port
+    config = _auth_config({"method": "password", "port": 9080})
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    overlap_findings = [f for f in _errors(findings) if f.code == "web_terminals.port_overlap"]
+    assert any("web_terminals.auth.port" in f.message for f in overlap_findings)
+    assert any("9080" in f.message for f in overlap_findings)
+
+
+def test_lint_default_auth_port_joins_the_port_overlap_set() -> None:
+    """The default sidecar port (9070) is claimed just as an explicit one is."""
+    # Arrange
+    config = _auth_config({"method": "password"})
+    config["ports"]["conflicting"] = 9070
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    overlap_findings = [f for f in _errors(findings) if f.code == "web_terminals.port_overlap"]
+    assert any("web_terminals.auth.port" in f.message for f in overlap_findings)
+
+
+def test_lint_auth_port_absent_from_overlap_set_when_method_is_none() -> None:
+    """No sidecar is rendered for `method: none`, so its port must not be
+    reserved against an ordinary config that happens to use 9070."""
+    # Arrange
+    config = _auth_config({"method": "none", "port": 9070}, tls=False, fqdn=None)
+    config["ports"]["conflicting"] = 9070
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    overlap_findings = [f for f in _errors(findings) if f.code == "web_terminals.port_overlap"]
+    assert not any("web_terminals.auth.port" in f.message for f in overlap_findings)
+
+
+def test_lint_auth_without_tls_is_an_error() -> None:
+    """Session cookies over cleartext HTTP is refused at render time; lint says
+    so at scaffold time."""
+    # Arrange
+    config = _auth_config({"method": "password"}, tls=False)
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    errors = _errors(findings)
+    assert any(f.code == "web_terminals.auth_requires_tls" for f in errors)
+    assert not any(f.code == "web_terminals.auth_insecure_http" for f in _warnings(findings))
+
+
+def test_lint_auth_without_tls_and_allow_insecure_http_is_a_warning() -> None:
+    """The escape hatch makes the config renderable — the risk is restated as a
+    warning at every lint, not silently accepted once."""
+    # Arrange
+    config = _auth_config({"method": "password", "allow_insecure_http": True}, tls=False)
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert any(f.code == "web_terminals.auth_insecure_http" for f in _warnings(findings))
+    assert not any(f.code == "web_terminals.auth_requires_tls" for f in _errors(findings))
+
+
+def test_lint_auth_with_tls_reports_no_transport_finding() -> None:
+    """With TLS on, `allow_insecure_http` is inert and nothing is reported."""
+    # Arrange
+    config = _auth_config({"method": "password", "allow_insecure_http": True})
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.auth_insecure_http" for f in _warnings(findings))
+    assert not any(f.code == "web_terminals.auth_requires_tls" for f in _errors(findings))
+
+
+def test_lint_auth_method_none_without_tls_reports_no_transport_finding() -> None:
+    """Plain HTTP is only a finding once there is a session cookie to protect."""
+    # Arrange
+    config = _auth_config({"method": "none"}, tls=False, fqdn=None)
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.auth_requires_tls" for f in _errors(findings))
+
+
+def test_lint_clean_oidc_auth_config_reports_no_auth_findings() -> None:
+    """A complete OIDC stanza over TLS with a derivable origin is valid."""
+    # Arrange
+    config = _auth_config(
+        {
+            "method": "oidc",
+            "oidc": {
+                "issuer": "https://idp.example.org/realms/osprey",
+                "client_id_env": "FACILITY_OIDC_CLIENT_ID",
+                "client_secret_env": "FACILITY_OIDC_CLIENT_SECRET",
+            },
+        }
+    )
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert _auth_findings(findings) == []
+
+
+def test_lint_auth_oidc_without_issuer_is_an_error() -> None:
+    """The issuer has no default: without it there is no IdP to redirect to."""
+    # Arrange
+    config = _auth_config({"method": "oidc"})
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert any(f.code == "web_terminals.auth_oidc_missing_issuer" for f in _errors(findings))
+
+
+def test_lint_auth_oidc_with_empty_issuer_is_an_error() -> None:
+    """An empty issuer is as unusable as an absent one."""
+    # Arrange
+    config = _auth_config({"method": "oidc", "oidc": {"issuer": ""}})
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert any(f.code == "web_terminals.auth_oidc_missing_issuer" for f in _errors(findings))
+
+
+def test_lint_auth_oidc_omitted_client_env_names_report_no_error() -> None:
+    """Both env-var names carry a documented OSPREY_AUTH_OIDC_* default, so
+    omitting them is a valid config, not a missing field."""
+    # Arrange
+    config = _auth_config({"method": "oidc", "oidc": {"issuer": "https://idp.example.org"}})
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(
+        f.code == "web_terminals.auth_oidc_invalid_client_env" for f in _errors(findings)
+    )
+
+
+def test_lint_auth_oidc_empty_client_id_env_is_an_error() -> None:
+    """An unusable name silently restores the default variable, which this
+    deployment has not set — the sidecar would read an unset credential."""
+    # Arrange
+    config = _auth_config(
+        {"method": "oidc", "oidc": {"issuer": "https://idp.example.org", "client_id_env": "  "}}
+    )
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    errors = _errors(findings)
+    assert any(f.code == "web_terminals.auth_oidc_invalid_client_env" for f in errors)
+    assert any("client_id_env" in f.message for f in errors)
+
+
+def test_lint_auth_oidc_non_string_client_secret_env_is_an_error() -> None:
+    """The field names an environment variable; a non-string is the same silent
+    fallback as an empty one."""
+    # Arrange
+    config = _auth_config(
+        {
+            "method": "oidc",
+            "oidc": {"issuer": "https://idp.example.org", "client_secret_env": ["A", "B"]},
+        }
+    )
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    errors = _errors(findings)
+    assert any(f.code == "web_terminals.auth_oidc_invalid_client_env" for f in errors)
+    assert any("client_secret_env" in f.message for f in errors)
+
+
+def test_lint_auth_oidc_without_deploy_fqdn_is_an_error() -> None:
+    """The redirect_uri is built from the deployment's external origin; without
+    `deploy.fqdn` there is no origin, so no login can complete."""
+    # Arrange
+    config = _auth_config(
+        {"method": "oidc", "oidc": {"issuer": "https://idp.example.org"}}, fqdn=None
+    )
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert any(f.code == "web_terminals.auth_oidc_unresolvable_origin" for f in _errors(findings))
+
+
+def test_lint_auth_password_mode_without_deploy_fqdn_reports_no_origin_error() -> None:
+    """Only the OIDC callback needs an absolute origin; password mode's flow is
+    same-origin and relative throughout."""
+    # Arrange
+    config = _auth_config({"method": "password"}, fqdn=None)
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(
+        f.code == "web_terminals.auth_oidc_unresolvable_origin" for f in _errors(findings)
+    )
+
+
+def test_lint_auth_password_mode_reports_no_oidc_findings() -> None:
+    """The whole OIDC block is unread in password mode."""
+    # Arrange
+    config = _auth_config({"method": "password"})
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(f.code.startswith("web_terminals.auth_oidc") for f in findings)
+
+
+def test_lint_auth_credential_collision_is_an_error() -> None:
+    """`alice-b` and `alice_b` normalize onto one OSPREY_AUTH_PW_HASH_ALICE_B
+    entry — one operator's password would open the other's terminal."""
+    # Arrange
+    config = _auth_config({"method": "password"})
+    config["modules"]["web_terminals"]["users"] = ["alice-b", "alice_b"]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    errors = _errors(findings)
+    collisions = [f for f in errors if f.code == "web_terminals.auth_credential_collision"]
+    assert collisions
+    assert "OSPREY_AUTH_PW_HASH_ALICE_B" in collisions[0].message
+    assert "'alice-b'" in collisions[0].message and "'alice_b'" in collisions[0].message
+
+
+def test_lint_auth_credential_collision_covers_object_form_users() -> None:
+    """The roster's object form keys credentials exactly as the bare form does."""
+    # Arrange
+    config = _auth_config({"method": "password"})
+    config["modules"]["web_terminals"]["users"] = [
+        {"name": "alice-b", "index": 0},
+        {"name": "alice_b", "index": 1},
+    ]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert any(f.code == "web_terminals.auth_credential_collision" for f in _errors(findings))
+
+
+def test_lint_distinct_usernames_report_no_auth_credential_collision() -> None:
+    """A roster whose names map onto distinct suffixes is unambiguous."""
+    # Arrange
+    config = _auth_config({"method": "password"})
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.auth_credential_collision" for f in _errors(findings))
+
+
+def test_lint_auth_credential_collision_not_reported_in_oidc_mode() -> None:
+    """OIDC deployments hold no per-user credential variable to collide on."""
+    # Arrange
+    config = _auth_config({"method": "oidc", "oidc": {"issuer": "https://idp.example.org"}})
+    config["modules"]["web_terminals"]["users"] = ["alice-b", "alice_b"]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.auth_credential_collision" for f in _errors(findings))
+
+
+def test_lint_auth_credential_collision_not_reported_when_auth_is_off() -> None:
+    """No auth means no credential file; the roster keys nothing."""
+    # Arrange
+    config = _auth_config({"method": "none"}, tls=False, fqdn=None)
+    config["modules"]["web_terminals"]["users"] = ["alice-b", "alice_b"]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.auth_credential_collision" for f in _errors(findings))

--- a/tests/deployment/web_terminals/test_nginx_validate.py
+++ b/tests/deployment/web_terminals/test_nginx_validate.py
@@ -1,20 +1,26 @@
-"""Durable `nginx -t` validation of the rendered nginx fragment (Task 1.3).
+"""Durable `nginx -t` validation of the rendered nginx fragment.
 
-`test_render.py`'s seam tests are string-match assertions on the Jinja output —
-cheap and fast, but they can't catch an nginx syntax error the strings happen to
-satisfy. This module closes that gap for real by actually invoking `nginx -t`
-inside `nginx:1.27-alpine` (the base image the deployed stack uses) against both
-renders relevant to the gated auth/TLS seam (Task 1.3):
+`test_render.py`'s and `test_auth_tls_seams.py`'s assertions are string matches
+on the Jinja output — cheap and fast, but they can't catch an nginx syntax error
+the strings happen to satisfy. This module closes that gap for real by actually
+invoking `nginx -t` inside `nginx:1.27-alpine` (the base image the deployed stack
+uses) against each render shape the auth/TLS seams can produce:
 
 - the default render (`auth.method` unset -> "none", `tls.enabled` unset -> False):
-  the seam is fully inert, matching Phase 1's plain-http/no-auth posture.
-- an enabled render (`tls.enabled: true` with a real self-signed cert/key pair
-  generated fresh per test run, `auth.method` set to a stub value): the seam this
-  task actually renders (`listen 443 ssl` + `ssl_certificate*` + `auth_request` +
-  the fail-closed internal target).
+  the seam is fully inert, matching the pre-auth plain-http posture.
+- the fully enabled render (`tls.enabled: true` with a real self-signed cert/key
+  pair generated fresh per test run, plus `auth.method: password`): two server
+  blocks, the plain port's `return 301 https://…`, `listen 443 ssl` +
+  `ssl_certificate*`, the two `map`s, a per-user `auth_request` and `internal`
+  verify target, the shared named 401 handler, and the public `/auth/` prefix.
+- the cleartext-auth render (`auth.method: password` with
+  `allow_insecure_http`, the shape a facility behind its own TLS terminator
+  deploys): the same auth surface inside a *single* server block.
 
-This is the OC-1/M1 gap closer: "validated by running nginx, not string-matched"
-needs to be true in CI, not just as a one-off manual check.
+Every one of these tests asserts the constructs it means to validate are
+actually present in the rendered fragment before handing it to nginx — a
+template that stopped emitting the auth surface would otherwise still "pass"
+`nginx -t` and report a vacuous green.
 
 Skipped entirely when docker (or openssl) is unavailable, mirroring
 `tests/e2e/test_dockerfile_e2e.py`'s `_docker_available()` pattern.
@@ -53,7 +59,9 @@ pytestmark = [
 ]
 
 
-def _config(tls: dict | None = None, auth: dict | None = None) -> dict:
+def _config(
+    tls: dict | None = None, auth: dict | None = None, users: list[str] | None = None
+) -> dict:
     web_terminals: dict = {
         "enabled": True,
         "nginx_port": 9080,
@@ -61,7 +69,7 @@ def _config(tls: dict | None = None, auth: dict | None = None) -> dict:
         "artifact_base_port": _BASE_PORTS["artifact"],
         "ariel_base_port": _BASE_PORTS["ariel"],
         "lattice_base_port": _BASE_PORTS["lattice"],
-        "users": ["alice", "bob"],
+        "users": ["alice", "bob"] if users is None else users,
     }
     if tls is not None:
         web_terminals["tls"] = tls
@@ -103,6 +111,37 @@ def _generate_self_signed_cert(certs_dir: Path) -> tuple[Path, Path]:
     return cert_path, key_path
 
 
+def _directives(conf: str) -> str:
+    """`conf` with its comment lines dropped.
+
+    The template's prose names `auth_request`, `/verify` and `$request_uri` at
+    length, so counting or absence assertions have to ignore it.
+    """
+    return "\n".join(line for line in conf.splitlines() if not line.lstrip().startswith("#"))
+
+
+def _assert_auth_surface_present(nginx_conf: str, users: list[str]) -> None:
+    """Every construct the enabled renders exist to hand nginx is really there.
+
+    Without this, a template that stopped emitting the auth surface would still
+    produce a fragment `nginx -t` accepts, and these tests would report a green
+    that validated nothing about authentication.
+    """
+    directives = _directives(nginx_conf)
+    assert directives.count("auth_request ") == len(users)
+    for user in users:
+        assert f"auth_request /_osprey_auth/{user};" in directives
+        assert f"location = /_osprey_auth/{user} {{" in directives
+        assert f"/verify?user={user};" in directives
+    assert directives.count("internal;") == len(users)
+    assert "map $uri $osprey_auth_next {" in directives
+    assert "map $http_upgrade$http_accept $osprey_auth_wants_login_page {" in directives
+    assert "error_page 401 = @osprey_auth_401;" in directives
+    assert "location @osprey_auth_401 {" in directives
+    assert "location /auth/ {" in directives
+    assert "return 200;" not in nginx_conf
+
+
 def _run_nginx_t(conf_dir: Path, certs_dir: Path | None) -> subprocess.CompletedProcess:
     mounts = [
         "-v",
@@ -136,10 +175,19 @@ def test_default_gated_off_render_passes_nginx_t() -> None:
 
 
 def test_enabled_tls_and_auth_render_passes_nginx_t() -> None:
-    """C2: the enabled render (tls.enabled + a real self-signed cert/key,
-    auth.method set to a stub) — the seam this task actually renders
-    (`listen 443 ssl` + `ssl_certificate*` + `auth_request` + the fail-closed
-    internal target) — is validated by running nginx, not string-matched."""
+    """C2: the fully enabled render (tls.enabled + a real self-signed cert/key,
+    auth.method: password) — two server blocks, the plain port's 301, the ssl
+    listener and cert pair, the two maps, a per-user `auth_request` and
+    `internal` verify target, the shared named 401 handler and the public
+    `/auth/` prefix — is validated by running nginx, not string-matched.
+
+    Several of those constructs are ones a fragment can get syntactically wrong
+    in ways no string match notices: a named location referenced by `error_page`
+    but never defined, a `map` at the wrong context, or an `if` block nginx
+    rejects where it stands.
+    """
+    users = ["alice", "bob"]
+
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         conf_dir = tmp_path / "conf"
@@ -153,18 +201,55 @@ def test_enabled_tls_and_auth_render_passes_nginx_t() -> None:
         # the container (/etc/nginx/certs/...), not the host tmp path.
         artifacts = render_web_terminals(
             _config(
+                users=users,
                 tls={
                     "enabled": True,
                     "cert": f"/etc/nginx/certs/{cert_path.name}",
                     "key": f"/etc/nginx/certs/{key_path.name}",
                 },
-                auth={"method": "oauth2_proxy"},
+                auth={"method": "password"},
             )
         )
-        (conf_dir / "default.conf").write_text(artifacts["nginx/nginx.conf"])
+        nginx_conf = artifacts["nginx/nginx.conf"]
+        # Guard against a vacuous green: nginx would happily accept a fragment
+        # that had quietly stopped emitting the whole gated surface.
+        _assert_auth_surface_present(nginx_conf, users)
+        assert "listen 443 ssl;" in nginx_conf
+        assert f"ssl_certificate /etc/nginx/certs/{cert_path.name};" in nginx_conf
+        assert f"ssl_certificate_key /etc/nginx/certs/{key_path.name};" in nginx_conf
+        assert "return 301 https://$host$request_uri;" in nginx_conf
+
+        (conf_dir / "default.conf").write_text(nginx_conf)
 
         # Act
         result = _run_nginx_t(conf_dir, certs_dir=certs_dir)
+
+    # Assert
+    assert result.returncode == 0, result.stderr
+
+
+def test_cleartext_auth_render_passes_nginx_t() -> None:
+    """C3: the auth-without-TLS render (`allow_insecure_http`, the shape a
+    facility behind its own TLS terminator deploys) puts the same gated surface
+    inside a SINGLE server block — a different nesting of the same directives,
+    and one nothing else runs nginx against."""
+    users = ["alice", "bob"]
+
+    # Arrange
+    artifacts = render_web_terminals(
+        _config(users=users, auth={"method": "password", "allow_insecure_http": True})
+    )
+    nginx_conf = artifacts["nginx/nginx.conf"]
+    _assert_auth_surface_present(nginx_conf, users)
+    assert "absolute_redirect off;" in nginx_conf
+    assert "listen 443 ssl;" not in nginx_conf
+
+    with tempfile.TemporaryDirectory() as tmp:
+        conf_dir = Path(tmp)
+        (conf_dir / "default.conf").write_text(nginx_conf)
+
+        # Act
+        result = _run_nginx_t(conf_dir, certs_dir=None)
 
     # Assert
     assert result.returncode == 0, result.stderr

--- a/tests/deployment/web_terminals/test_personas.py
+++ b/tests/deployment/web_terminals/test_personas.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 
 import pytest
 
-from osprey.deployment.web_terminals.personas import normalize_users, resolve_personas
+from osprey.deployment.web_terminals.personas import (
+    env_var_suffix,
+    env_var_suffix_collisions,
+    normalize_users,
+    resolve_personas,
+)
 
 
 def test_normalize_users_bare_strings_indexed_by_position() -> None:
@@ -863,3 +868,218 @@ def test_resolve_personas_no_persona_entry_is_seed_base_true() -> None:
 
     # Assert
     assert result[0]["seed_base"] is True
+
+
+# ---------------------------------------------------------------------------
+# Roster OIDC identity mapping (normalize_users / resolve_personas passthrough)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_users_carries_string_oidc_subject_through() -> None:
+    """An object entry's `oidc_subject` — the non-secret IdP claim value that
+    identifies this roster user — is carried onto the normalized entry."""
+    # Arrange
+    users_raw = [{"name": "alice", "index": 0, "oidc_subject": "alice@example.org"}]
+
+    # Act
+    result = normalize_users(users_raw)
+
+    # Assert
+    assert result == [{"name": "alice", "index": 0, "oidc_subject": "alice@example.org"}]
+
+
+def test_normalize_users_omits_oidc_subject_key_when_absent() -> None:
+    """A roster declaring no OIDC mapping keeps the plain two-key shape, so a
+    password-mode (or pre-auth) config normalizes exactly as it did before."""
+    # Act / Assert
+    assert normalize_users(["alice"]) == [{"name": "alice", "index": 0}]
+    assert normalize_users([{"name": "bob", "index": 1}]) == [{"name": "bob", "index": 1}]
+
+
+def test_normalize_users_drops_non_string_oidc_subject() -> None:
+    """A non-string `oidc_subject` is dropped defensively; the rest of a
+    well-formed entry still normalizes."""
+    # Arrange
+    users_raw = [{"name": "alice", "index": 0, "oidc_subject": ["alice@example.org"]}]
+
+    # Act
+    result = normalize_users(users_raw)
+
+    # Assert — entry survives (name/index valid), oidc_subject omitted
+    assert result == [{"name": "alice", "index": 0}]
+
+
+def test_normalize_users_drops_empty_oidc_subject() -> None:
+    """An empty `oidc_subject` must never become a mapping: an identity whose
+    claim is missing or empty would otherwise match this roster user. Dropping
+    it leaves the user unmapped, which the OIDC callback answers with 403."""
+    # Arrange
+    users_raw = [{"name": "alice", "index": 0, "oidc_subject": ""}]
+
+    # Act
+    result = normalize_users(users_raw)
+
+    # Assert
+    assert result == [{"name": "alice", "index": 0}]
+
+
+def test_normalize_users_oidc_subject_is_independent_of_the_cosmetic_fields() -> None:
+    """The identity mapping and the cosmetic per-user fields don't interfere —
+    declaring all three keeps all three."""
+    # Arrange
+    users_raw = [
+        {
+            "name": "alice",
+            "index": 0,
+            "display_name": "Operations",
+            "theme": "desy",
+            "oidc_subject": "alice@example.org",
+        }
+    ]
+
+    # Act
+    result = normalize_users(users_raw)
+
+    # Assert
+    assert result == [
+        {
+            "name": "alice",
+            "index": 0,
+            "display_name": "Operations",
+            "theme": "desy",
+            "oidc_subject": "alice@example.org",
+        }
+    ]
+
+
+def test_resolve_personas_exposes_oidc_subject_when_set() -> None:
+    """The mapping rides through to the resolved entry, so the sidecar's roster
+    context reads it off the same object as every other per-user field."""
+    # Arrange
+    web_terminals = {"users": [{"name": "alice", "index": 0, "oidc_subject": "alice@example.org"}]}
+
+    # Act
+    result = resolve_personas(web_terminals, _REGISTRY, "als")
+
+    # Assert
+    assert result[0]["oidc_subject"] == "alice@example.org"
+
+
+def test_resolve_personas_oidc_subject_threads_through_persona_branch() -> None:
+    """The passthrough is not confined to the zero-migration path — a user
+    resolved through a catalog persona keeps its mapping too."""
+    # Arrange
+    web_terminals = {
+        "users": [
+            {"name": "alice", "index": 0, "persona": "gui", "oidc_subject": "alice@example.org"}
+        ],
+        "personas": {"gui": {"project": "als-gui"}},
+    }
+
+    # Act
+    result = resolve_personas(web_terminals, _REGISTRY, "als")
+
+    # Assert
+    assert result[0]["persona"] == "gui"
+    assert result[0]["oidc_subject"] == "alice@example.org"
+
+
+def test_resolve_personas_omits_oidc_subject_key_when_unset() -> None:
+    """A roster with no OIDC mapping resolves byte-identically to before the
+    field existed — no `oidc_subject: None` key appears."""
+    # Act
+    result = resolve_personas({"users": ["alice"]}, _REGISTRY, "als")
+
+    # Assert
+    assert "oidc_subject" not in result[0]
+
+
+# ---------------------------------------------------------------------------
+# env_var_suffix() / env_var_suffix_collisions()
+# ---------------------------------------------------------------------------
+
+
+def test_env_var_suffix_uppercases_and_maps_dashes_to_underscores() -> None:
+    """The one definition of how a username keys its per-user env vars."""
+    # Act / Assert
+    assert env_var_suffix("alice") == "ALICE"
+    assert env_var_suffix("alice-b") == "ALICE_B"
+    assert env_var_suffix("Alice-B-C") == "ALICE_B_C"
+
+
+def test_env_var_suffix_leaves_already_conforming_names_untouched() -> None:
+    """Idempotent on its own output — an already-uppercase, underscored name is
+    returned unchanged, so re-keying an existing entry can't drift."""
+    # Arrange
+    once = env_var_suffix("alice-b")
+
+    # Act / Assert
+    assert env_var_suffix(once) == once
+
+
+def test_env_var_suffix_is_total_and_does_not_validate_charset() -> None:
+    """Charset enforcement belongs to the preflight raise and lint, not here —
+    this helper maps whatever it is given rather than raising."""
+    # Act / Assert
+    assert env_var_suffix("") == ""
+    assert env_var_suffix("alice.b") == "ALICE.B"
+
+
+def test_env_var_suffix_collisions_reports_names_sharing_one_suffix() -> None:
+    """`alice-b` and `alice_b` both key OSPREY_AUTH_PW_HASH_ALICE_B — without
+    this check one user's password would open the other's terminal."""
+    # Act
+    result = env_var_suffix_collisions(["alice-b", "alice_b", "carol"])
+
+    # Assert
+    assert result == {"ALICE_B": ["alice-b", "alice_b"]}
+
+
+def test_env_var_suffix_collisions_empty_for_an_unambiguous_roster() -> None:
+    """A roster whose usernames map one-to-one reports nothing."""
+    # Act / Assert
+    assert env_var_suffix_collisions(["alice", "bob", "carol"]) == {}
+    assert env_var_suffix_collisions([]) == {}
+
+
+def test_env_var_suffix_collisions_ignores_case_only_and_repeated_names() -> None:
+    """A verbatim-repeated name is one user listed twice (a duplicate-name error
+    reported separately), not two users sharing a credential — while names
+    differing only in case really do collide onto one suffix."""
+    # Act / Assert
+    assert env_var_suffix_collisions(["alice", "alice"]) == {}
+    assert env_var_suffix_collisions(["alice", "Alice"]) == {"ALICE": ["Alice", "alice"]}
+
+
+def test_env_var_suffix_collisions_output_is_sorted_for_stable_messages() -> None:
+    """Suffix keys and the names under each are sorted, so a lint or preflight
+    message built from this reads the same across runs."""
+    # Act
+    result = env_var_suffix_collisions(["zed_x", "b-1", "zed-x", "b_1"])
+
+    # Assert
+    assert list(result) == ["B_1", "ZED_X"]
+    assert result == {"B_1": ["b-1", "b_1"], "ZED_X": ["zed-x", "zed_x"]}
+
+
+def test_env_var_suffix_collisions_ignores_non_string_entries() -> None:
+    """Drop-don't-raise, like the rest of this module: a malformed roster entry
+    that slipped through can't crash the collision check."""
+    # Act
+    result = env_var_suffix_collisions(["alice-b", None, 7, "alice_b"])  # type: ignore[list-item]
+
+    # Assert
+    assert result == {"ALICE_B": ["alice-b", "alice_b"]}
+
+
+def test_env_var_suffix_collisions_consumes_normalize_users_names() -> None:
+    """The intended call shape: the names off a normalized roster, so callers
+    holding entry dicts (lint, credential provisioning) share one check."""
+    # Arrange
+    users = normalize_users(["alice-b", {"name": "alice_b", "index": 4}, "bob"])
+
+    # Act
+    result = env_var_suffix_collisions(entry["name"] for entry in users)
+
+    # Assert
+    assert result == {"ALICE_B": ["alice-b", "alice_b"]}

--- a/tests/deployment/web_terminals/test_provision.py
+++ b/tests/deployment/web_terminals/test_provision.py
@@ -1,19 +1,39 @@
 """Unit tests for the web-terminal deploy orchestration entrypoints.
 
 Covers ``osprey.deployment.web_terminals.provision`` in isolation: the web
-stack's own ``compose down`` and the post-``up`` image-drift reconcile. The
+stack's own ``compose down``, the single post-``up`` force-recreate (image
+drift plus caller-requested services), the
+``preflight_web_terminals`` auth-credential provisioning (mint order, the
+fail-closed gate, and the force-recreate signal it returns), and the auth
+sidecar's image production (registry-mode ``auth.image`` requirement,
+local-mode build, pull scoping) plus the shared force-recreate primitive. The
 deploy_up-entry orchestration that wires the provisioning modules together
 lives in ``tests/deployment/test_container_lifecycle.py``; the split-out
 provisioning steps have their own modules and test files
 (``test_persona_images.py``, ``test_env_production.py``,
-``test_postup_hooks.py``).
+``test_auth_credentials.py``, ``test_postup_hooks.py``).
 """
 
 from __future__ import annotations
 
 import os
+from pathlib import Path
+
+import pytest
 
 from osprey.deployment.web_terminals import provision
+from osprey.deployment.web_terminals.auth_credentials import (
+    AUTH_ENV_FILENAME,
+    PW_HASH_VAR_PREFIX,
+    SESSION_SECRET_VARS,
+    AuthCredentialsResult,
+    AuthSecretsResult,
+)
+from osprey.utils.dotenv import parse_dotenv_file
+
+# The unwritable-path cases below rely on the OS honoring a read-only mode.
+# root ignores it, so those assertions would be vacuous there.
+running_as_root = hasattr(os, "geteuid") and os.geteuid() == 0
 
 
 class _FakeCompletedProcess:
@@ -80,7 +100,7 @@ def test_deploy_down_web_terminals_noop_without_web_file(monkeypatch, tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# _reconcile_web_stack_image_drift -- post-`up` force-recreate on digest change
+# _reconcile_web_stack_recreates -- the single post-`up` force-recreate
 # ---------------------------------------------------------------------------
 
 _WEB_COMPOSE = (
@@ -143,7 +163,7 @@ def test_reconcile_force_recreates_only_drifted_services(monkeypatch, tmp_path):
 
     monkeypatch.setattr(provision.subprocess, "run", _fake_run)
 
-    provision._reconcile_web_stack_image_drift({}, _WEB_CMD, _RUN_ENV)
+    provision._reconcile_web_stack_recreates({}, _WEB_CMD, _RUN_ENV)
 
     assert len(recorded) == 1
     cmd, env = recorded[0]
@@ -181,7 +201,7 @@ def test_reconcile_noop_when_all_images_match(monkeypatch, tmp_path):
 
     monkeypatch.setattr(provision.subprocess, "run", _unexpected_run)
 
-    provision._reconcile_web_stack_image_drift({}, _WEB_CMD, _RUN_ENV)
+    provision._reconcile_web_stack_recreates({}, _WEB_CMD, _RUN_ENV)
 
 
 def test_reconcile_skipped_entirely_on_docker(monkeypatch, tmp_path):
@@ -198,7 +218,7 @@ def test_reconcile_skipped_entirely_on_docker(monkeypatch, tmp_path):
     monkeypatch.setattr(provision, "get_container_image_id", _boom)
     monkeypatch.setattr(provision.subprocess, "run", _boom)
 
-    provision._reconcile_web_stack_image_drift({}, _WEB_CMD, _RUN_ENV)
+    provision._reconcile_web_stack_recreates({}, _WEB_CMD, _RUN_ENV)
 
 
 def test_reconcile_skips_service_on_inspect_error_without_raising(monkeypatch, tmp_path):
@@ -227,7 +247,7 @@ def test_reconcile_skips_service_on_inspect_error_without_raising(monkeypatch, t
     monkeypatch.setattr(provision.subprocess, "run", _unexpected_run)
 
     # No raise, no compose invocation.
-    provision._reconcile_web_stack_image_drift({}, _WEB_CMD, _RUN_ENV)
+    provision._reconcile_web_stack_recreates({}, _WEB_CMD, _RUN_ENV)
 
 
 def test_reconcile_skipped_when_compose_file_unreadable(monkeypatch, tmp_path):
@@ -242,4 +262,660 @@ def test_reconcile_skipped_when_compose_file_unreadable(monkeypatch, tmp_path):
     monkeypatch.setattr(provision, "get_image_id", _boom)
     monkeypatch.setattr(provision.subprocess, "run", _boom)
 
-    provision._reconcile_web_stack_image_drift({}, _WEB_CMD, _RUN_ENV)
+    provision._reconcile_web_stack_recreates({}, _WEB_CMD, _RUN_ENV)
+
+
+# ---------------------------------------------------------------------------
+# preflight_web_terminals -- auth credential provisioning, gate, and signal
+# ---------------------------------------------------------------------------
+
+
+def _auth_config(method: str, users=("alice", "bob"), auth_image="reg/osprey-auth:1") -> dict:
+    """A registry-mode web-terminals config with `method` authentication.
+
+    Carries an `auth.image` by default because registry mode requires one (see
+    the sidecar-image section below); pass None to exercise that requirement.
+    """
+    auth: dict = {"method": method}
+    if auth_image is not None:
+        auth["image"] = auth_image
+    return {
+        "facility": {"prefix": "als"},
+        "modules": {
+            "web_terminals": {
+                "users": list(users),
+                "auth": auth,
+            }
+        },
+    }
+
+
+def _run_preflight(monkeypatch, project_root: Path, config: dict):
+    """Run the preflight from `project_root` with the non-auth steps neutered.
+
+    ``ensure_env_production`` has its own fail-closed gate (and would raise on
+    a registry-mode root with no .env.production); it is covered by
+    test_env_production.py, so stub it out to keep these assertions about auth.
+    """
+    monkeypatch.chdir(project_root)
+    monkeypatch.setattr(provision, "ensure_env_production", lambda config, root: None)
+    return provision.preflight_web_terminals(config, {})
+
+
+def _credentials_result(
+    path: Path, *, changed=False, missing=(), users=()
+) -> AuthCredentialsResult:
+    return AuthCredentialsResult(
+        env_auth_path=path,
+        changed=changed,
+        minted=(),
+        hashed_from_plaintext=(),
+        preexisting=tuple(users),
+        missing=tuple(missing),
+    )
+
+
+def _secrets_result(path: Path, *, changed=False, missing=()) -> AuthSecretsResult:
+    return AuthSecretsResult(
+        env_auth_path=path,
+        changed=changed,
+        minted=(),
+        preexisting=SESSION_SECRET_VARS,
+        missing=tuple(missing),
+    )
+
+
+def _stub_clean_provisioning(monkeypatch, tmp_path):
+    """Both provisioning calls succeed, change nothing, and leave nothing missing."""
+    env_auth = tmp_path / AUTH_ENV_FILENAME
+    monkeypatch.setattr(
+        provision,
+        "ensure_auth_credentials",
+        lambda usernames, root, **kwargs: _credentials_result(env_auth),
+    )
+    monkeypatch.setattr(
+        provision, "ensure_auth_session_secrets", lambda root: _secrets_result(env_auth)
+    )
+
+
+@pytest.mark.parametrize("image_source", ["local", "registry"])
+def test_preflight_mints_credentials_then_secrets_for_the_roster(
+    monkeypatch, tmp_path, image_source
+):
+    """Order is load-bearing and explicit: the roster's password hashes first,
+    then the signing secrets, both keyed off the project root and both handed
+    the plain roster names (never the normalized env-var suffixes).
+
+    Run in BOTH image-source modes: the sidecar needs its credentials whatever
+    the images come from, and only registry mode was exercised until the
+    parametrize was added."""
+    calls: list[tuple] = []
+    env_auth = tmp_path / AUTH_ENV_FILENAME
+
+    def _fake_credentials(usernames, project_root, **kwargs):
+        calls.append(("credentials", list(usernames), str(project_root)))
+        return _credentials_result(env_auth, users=usernames)
+
+    def _fake_secrets(project_root):
+        calls.append(("secrets", str(project_root)))
+        return _secrets_result(env_auth)
+
+    monkeypatch.setattr(provision, "ensure_auth_credentials", _fake_credentials)
+    monkeypatch.setattr(provision, "ensure_auth_session_secrets", _fake_secrets)
+    # Local mode resolves personas and may auto-render; neither is this test's
+    # subject, and local mode needs no auth.image.
+    monkeypatch.setattr(provision, "resolve_personas", lambda *a, **kw: [])
+    monkeypatch.setattr(provision, "auto_render_missing_personas", lambda *a, **kw: None)
+
+    config = _auth_config("password", users=["alice", {"name": "bob-2", "index": 4}])
+    config["modules"]["web_terminals"]["image_source"] = image_source
+    result = _run_preflight(monkeypatch, tmp_path, config)
+
+    assert [call[0] for call in calls] == ["credentials", "secrets"]
+    assert calls[0][1] == ["alice", "bob-2"]
+    assert calls[0][2] == str(tmp_path)
+    assert calls[1][1] == str(tmp_path)
+    assert result.auth_env_changed is False
+
+
+def test_preflight_with_auth_none_touches_no_credential_state(monkeypatch, tmp_path, caplog):
+    """`auth.method: none` (the default) must behave exactly as it did before
+    authentication existed: nothing minted, no .env.auth, no gitignore warning
+    — even from a project root whose .gitignore does not cover the file."""
+
+    def _unexpected(*args, **kwargs):
+        raise AssertionError("auth provisioning must not run with auth.method: none")
+
+    monkeypatch.setattr(provision, "ensure_auth_credentials", _unexpected)
+    monkeypatch.setattr(provision, "ensure_auth_session_secrets", _unexpected)
+    (tmp_path / ".gitignore").write_text(".env\n", encoding="utf-8")
+
+    with caplog.at_level("WARNING"):
+        result = _run_preflight(monkeypatch, tmp_path, _auth_config("none"))
+
+    assert result.auth_env_changed is False
+    assert not (tmp_path / AUTH_ENV_FILENAME).exists()
+    assert AUTH_ENV_FILENAME not in caplog.text
+
+
+def test_preflight_provisions_and_reports_changed_then_is_idempotent(monkeypatch, tmp_path):
+    """End to end on a real project root: the first deploy establishes every
+    hash and both signing secrets and reports the force-recreate signal; the
+    second changes nothing, so it must NOT recreate the sidecar again."""
+    config = _auth_config("password", users=("alice", "bob-2"))
+
+    first = _run_preflight(monkeypatch, tmp_path, config)
+
+    env_auth = tmp_path / AUTH_ENV_FILENAME
+    stored = parse_dotenv_file(env_auth)
+    assert stored[f"{PW_HASH_VAR_PREFIX}ALICE"]
+    assert stored[f"{PW_HASH_VAR_PREFIX}BOB_2"]
+    assert all(stored[var] for var in SESSION_SECRET_VARS)
+    assert first.auth_env_changed is True
+
+    before = env_auth.read_text(encoding="utf-8")
+    second = _run_preflight(monkeypatch, tmp_path, config)
+
+    assert second.auth_env_changed is False
+    assert env_auth.read_text(encoding="utf-8") == before
+
+
+def test_preflight_in_oidc_mode_creates_env_auth_with_secrets_and_no_hashes(monkeypatch, tmp_path):
+    """oidc mode still has to WRITE .env.auth: the sidecar's compose service
+    declares `env_file: .env.auth`, so `compose up` hard-fails outright when the
+    file is absent — an oidc stack could not start at all. What it must not
+    contain is password hashes: oidc authenticates at the IdP, and minting
+    passwords nobody will ever type would put credentials on disk for nothing."""
+    result = _run_preflight(monkeypatch, tmp_path, _auth_config("oidc", users=("alice", "bob")))
+
+    env_auth = tmp_path / AUTH_ENV_FILENAME
+    assert env_auth.is_file()
+    stored = parse_dotenv_file(env_auth)
+    assert all(stored[var] for var in SESSION_SECRET_VARS)
+    assert not [var for var in stored if var.startswith(PW_HASH_VAR_PREFIX)]
+    assert result.auth_env_changed is True
+
+
+def test_preflight_does_not_swallow_a_roster_that_cannot_be_keyed(monkeypatch, tmp_path):
+    """`ensure_auth_credentials` raises (writing nothing) when two usernames
+    normalize onto one credential variable — they would share a password, so one
+    operator's credentials would open the other's terminal. Deploy never runs
+    lint, so that raise IS the abort: the preflight must let it propagate."""
+    config = _auth_config("password", users=("alice-b", "alice_b"))
+
+    with pytest.raises(RuntimeError, match="one credential variable"):
+        _run_preflight(monkeypatch, tmp_path, config)
+
+    assert not (tmp_path / AUTH_ENV_FILENAME).exists()
+
+
+@pytest.mark.skipif(running_as_root, reason="root ignores the read-only mode this test relies on")
+def test_preflight_gate_raises_naming_every_user_left_without_a_hash(monkeypatch, tmp_path):
+    """The post-mint invariant: with .env.auth unwritable no password hash can
+    be established, so the deploy aborts HERE — before any compose invocation —
+    naming each password-mode roster user, rather than bringing up terminals
+    nobody can log into."""
+    env_auth = tmp_path / AUTH_ENV_FILENAME
+    env_auth.write_text("# pre-existing\n", encoding="utf-8")
+    os.chmod(env_auth, 0o400)
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            _run_preflight(monkeypatch, tmp_path, _auth_config("password", users=("alice", "bob")))
+    finally:
+        os.chmod(env_auth, 0o600)
+
+    message = str(excinfo.value)
+    assert "alice" in message
+    assert "bob" in message
+    assert AUTH_ENV_FILENAME in message
+    assert "auth.method: password" in message
+
+
+@pytest.mark.skipif(running_as_root, reason="root ignores the read-only mode this test relies on")
+def test_preflight_gate_raises_naming_missing_secret_vars_in_oidc_mode(monkeypatch, tmp_path):
+    """A signing secret is required in EVERY method, so an unwritable .env.auth
+    aborts an oidc deploy too, naming the variables. No user is named: oidc
+    provisions no password hash in the first place, and refusing over one would
+    block a deployment that would have worked."""
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    os.chmod(project_root, 0o500)  # nothing can be created inside it
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            _run_preflight(monkeypatch, project_root, _auth_config("oidc", users=("alice",)))
+    finally:
+        os.chmod(project_root, 0o700)
+
+    message = str(excinfo.value)
+    for var in SESSION_SECRET_VARS:
+        assert var in message
+    assert "alice" not in message
+
+
+@pytest.mark.parametrize(
+    ("credentials_changed", "secrets_changed", "expected"),
+    [(False, False, False), (True, False, True), (False, True, True), (True, True, True)],
+)
+def test_preflight_force_recreate_signal_ors_both_results(
+    monkeypatch, tmp_path, credentials_changed, secrets_changed, expected
+):
+    """Either write obliges the same action — compose bakes env_file content in
+    at container CREATION, so a sidecar left running would serve the previous
+    file's contents whichever of the two functions appended to it."""
+    env_auth = tmp_path / AUTH_ENV_FILENAME
+    monkeypatch.setattr(
+        provision,
+        "ensure_auth_credentials",
+        lambda usernames, root, **kwargs: _credentials_result(
+            env_auth, changed=credentials_changed
+        ),
+    )
+    monkeypatch.setattr(
+        provision,
+        "ensure_auth_session_secrets",
+        lambda root: _secrets_result(env_auth, changed=secrets_changed),
+    )
+
+    result = _run_preflight(monkeypatch, tmp_path, _auth_config("password"))
+
+    assert result.auth_env_changed is expected
+
+
+@pytest.mark.parametrize(
+    "gitignore",
+    [
+        "# nothing\n",
+        ".env\n.env.production\n",
+        "!.env.auth\n",
+        # git resolves a path against the LAST matching pattern, so this file
+        # is TRACKED despite the earlier glob — the warning must still fire.
+        ".env*\n!.env.auth\n",
+    ],
+)
+def test_preflight_warns_when_gitignore_does_not_cover_env_auth(
+    monkeypatch, tmp_path, caplog, gitignore
+):
+    """Projects scaffolded before auth existed ignore .env but not .env.auth —
+    and gitignore matches literal names, so .env does not cover it. Warn (never
+    block) that a file about to hold hashes and signing secrets is committable."""
+    _stub_clean_provisioning(monkeypatch, tmp_path)
+    (tmp_path / ".gitignore").write_text(gitignore, encoding="utf-8")
+
+    with caplog.at_level("WARNING"):
+        result = _run_preflight(monkeypatch, tmp_path, _auth_config("password"))
+
+    assert AUTH_ENV_FILENAME in caplog.text
+    assert ".gitignore" in caplog.text
+    assert result.auth_env_changed is False  # warn-only: the deploy continues
+
+
+@pytest.mark.parametrize(
+    "gitignore",
+    [".env.auth\n", "/.env.auth\n", ".env*\n", "!.env.auth\n.env.auth\n"],
+)
+def test_preflight_does_not_warn_when_gitignore_covers_env_auth(
+    monkeypatch, tmp_path, caplog, gitignore
+):
+    """A literal entry, a root-anchored one, or a glob that matches it all count
+    as covered — the warning must not become background noise."""
+    _stub_clean_provisioning(monkeypatch, tmp_path)
+    (tmp_path / ".gitignore").write_text(gitignore, encoding="utf-8")
+
+    with caplog.at_level("WARNING"):
+        _run_preflight(monkeypatch, tmp_path, _auth_config("password"))
+
+    assert AUTH_ENV_FILENAME not in caplog.text
+
+
+def test_preflight_does_not_warn_without_a_gitignore_at_all(monkeypatch, tmp_path, caplog):
+    """No .gitignore is ordinarily a root nobody commits from; warning there
+    would fire on every deploy about a risk that does not exist."""
+    _stub_clean_provisioning(monkeypatch, tmp_path)
+
+    with caplog.at_level("WARNING"):
+        _run_preflight(monkeypatch, tmp_path, _auth_config("password"))
+
+    assert AUTH_ENV_FILENAME not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Auth sidecar image: the registry-mode requirement and the local-mode build
+# ---------------------------------------------------------------------------
+
+
+def _sidecar_config(image_source: str, *, auth_image=None, method="password") -> dict:
+    """A config in `image_source` mode, with auth.image only when given."""
+    config = _auth_config(method, users=("alice",), auth_image=auth_image)
+    config["modules"]["web_terminals"]["image_source"] = image_source
+    return config
+
+
+def test_registry_mode_without_auth_image_fails_preflight(monkeypatch, tmp_path):
+    """Registry mode builds nothing locally, and the compose overlay falls back
+    to a `:local` tag that mode never produces — so a deployment that forgot
+    auth.image must abort here, naming the key, instead of dying at `pull` on a
+    tag no registry has."""
+    _stub_clean_provisioning(monkeypatch, tmp_path)
+
+    with pytest.raises(RuntimeError, match="auth.image"):
+        _run_preflight(monkeypatch, tmp_path, _sidecar_config("registry"))
+
+
+def test_registry_mode_with_auth_image_passes_preflight(monkeypatch, tmp_path):
+    _stub_clean_provisioning(monkeypatch, tmp_path)
+
+    result = _run_preflight(
+        monkeypatch, tmp_path, _sidecar_config("registry", auth_image="reg/osprey-auth:1.2.3")
+    )
+
+    assert result.auth_env_changed is False
+
+
+def test_local_mode_needs_no_auth_image_at_preflight(monkeypatch, tmp_path):
+    """Local mode produces the tag itself, so the key is optional there."""
+    _stub_clean_provisioning(monkeypatch, tmp_path)
+    monkeypatch.setattr(provision, "auto_render_missing_personas", lambda *a, **kw: None)
+    monkeypatch.setattr(provision, "resolve_personas", lambda *a, **kw: [])
+
+    result = _run_preflight(monkeypatch, tmp_path, _sidecar_config("local"))
+
+    assert result.auth_env_changed is False
+
+
+def test_auth_method_none_needs_no_auth_image(monkeypatch, tmp_path):
+    """With authentication off no sidecar service is rendered at all, so a
+    registry deploy that never opted in must not be asked for an image."""
+    _stub_clean_provisioning(monkeypatch, tmp_path)
+
+    result = _run_preflight(monkeypatch, tmp_path, _sidecar_config("registry", method="none"))
+
+    assert result.auth_env_changed is False
+
+
+def _capture_build(monkeypatch):
+    recorded: list[list[str]] = []
+
+    def _fake_run(cmd, **kwargs):
+        recorded.append(list(cmd))
+        return _FakeCompletedProcess()
+
+    monkeypatch.setattr(provision.subprocess, "run", _fake_run)
+    monkeypatch.setattr(provision, "get_runtime_command", lambda config=None: ["podman", "compose"])
+    return recorded
+
+
+def test_local_mode_builds_the_auth_image_the_compose_overlay_references(monkeypatch, tmp_path):
+    """The tag, the context and the ownership label in one place: compose
+    declares the sidecar with an `image:` and no `build:` block, so this is its
+    only producer — and the tag must be exactly what the overlay renders."""
+    monkeypatch.chdir(tmp_path)
+    recorded = _capture_build(monkeypatch)
+
+    provision.build_auth_sidecar_image(_sidecar_config("local"), False, {})
+
+    assert len(recorded) == 1
+    cmd = recorded[0]
+    context_dir = tmp_path / provision.AUTH_BUILD_CONTEXT
+    assert cmd[:4] == ["podman", "build", "-t", "als-assistant-auth:local"]
+    assert cmd[-1] == str(context_dir)
+    assert "-f" in cmd and cmd[cmd.index("-f") + 1] == str(context_dir / "Dockerfile")
+    # OSPREY_PROJECT_NAME is what stamps com.osprey.project on the image, the
+    # ownership label `nuke` verifies before removing a tag.
+    assert any(arg.startswith("OSPREY_PROJECT_NAME=") and arg.split("=", 1)[1] for arg in cmd)
+    assert any(arg.startswith("OSPREY_VERSION=") and arg.split("=", 1)[1] for arg in cmd)
+    assert "OSPREY_DEV=1" not in cmd
+    # The context is materialized from the bundled template package, including
+    # the .dockerignore the Dockerfile COPYs as its guaranteed glob sibling.
+    assert (context_dir / "Dockerfile").is_file()
+    assert (context_dir / ".dockerignore").is_file()
+
+
+def test_local_mode_dev_build_of_the_auth_image_passes_the_dev_build_arg(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    recorded = _capture_build(monkeypatch)
+    monkeypatch.setattr(provision, "_stage_dev_wheel_for_context", lambda out_dir, dev: True)
+
+    provision.build_auth_sidecar_image(_sidecar_config("local"), True, {})
+
+    assert "OSPREY_DEV=1" in recorded[0]
+
+
+def test_local_mode_with_auth_image_builds_nothing(monkeypatch, tmp_path):
+    """auth.image pins an externally supplied image; building over that pin
+    would produce a tag nothing references."""
+    monkeypatch.chdir(tmp_path)
+    recorded = _capture_build(monkeypatch)
+
+    provision.build_auth_sidecar_image(_sidecar_config("local", auth_image="reg/auth:1"), False, {})
+
+    assert recorded == []
+
+
+def test_registry_mode_builds_no_auth_image_locally(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    recorded = _capture_build(monkeypatch)
+
+    provision.build_auth_sidecar_image(
+        _sidecar_config("registry", auth_image="reg/auth:1"), False, {}
+    )
+
+    assert recorded == []
+
+
+def test_auth_method_none_builds_no_auth_image_locally(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    recorded = _capture_build(monkeypatch)
+
+    provision.build_auth_sidecar_image(_sidecar_config("local", method="none"), False, {})
+
+    assert recorded == []
+
+
+# ---------------------------------------------------------------------------
+# Web-stack invocations: pull scoping and the force-recreate primitive
+# ---------------------------------------------------------------------------
+
+
+def _stub_web_stack(monkeypatch, tmp_path):
+    """Neuter every collaborator of deploy_up_web_terminals and capture argv."""
+    monkeypatch.chdir(tmp_path)
+    recorded: list[list[str]] = []
+
+    def _fake_run(cmd, **kwargs):
+        recorded.append(list(cmd))
+        return _FakeCompletedProcess()
+
+    monkeypatch.setattr(provision.subprocess, "run", _fake_run)
+    monkeypatch.setattr(provision, "get_runtime_command", lambda config=None: ["docker", "compose"])
+    monkeypatch.setattr(provision, "runtime_env", lambda config, env: dict(env))
+    monkeypatch.setattr(provision, "write_web_terminal_artifacts", lambda config, dest_dir=".": [])
+    monkeypatch.setattr(provision, "ensure_env_production", lambda config, root: None)
+    monkeypatch.setattr(provision, "resolve_personas", lambda *a, **kw: [])
+    monkeypatch.setattr(provision, "auto_render_missing_personas", lambda *a, **kw: None)
+    monkeypatch.setattr(provision, "build_persona_images", lambda *a, **kw: None)
+    monkeypatch.setattr(provision, "build_auth_sidecar_image", lambda *a, **kw: None)
+    monkeypatch.setattr(provision, "_reconcile_web_stack_recreates", lambda *a, **kw: None)
+    monkeypatch.setattr(provision, "reload_nginx_config", lambda *a, **kw: None)
+    monkeypatch.setattr(provision, "enable_linger", lambda *a, **kw: None)
+    monkeypatch.setattr(provision, "seed_user_containers", lambda *a, **kw: None)
+    monkeypatch.setattr(provision, "run_verify_script", lambda *a, **kw: None)
+    monkeypatch.setattr(provision, "warn_if_web_stack_unreachable", lambda *a, **kw: None)
+    return recorded
+
+
+def test_local_mode_web_stack_never_pulls_the_local_auth_image(monkeypatch, tmp_path):
+    """`compose pull` hard-fails on a tag no registry can serve, and the
+    sidecar's local tag is exactly that — so local mode's web stack must issue
+    no pull at all, which is what keeps the locally built image out of it."""
+    recorded = _stub_web_stack(monkeypatch, tmp_path)
+
+    provision.deploy_up_web_terminals(_sidecar_config("local"), [], False, {}, [])
+
+    assert not any("pull" in cmd for cmd in recorded)
+    assert any(cmd[-2:] == ["up", "-d"] for cmd in recorded)
+
+
+def test_registry_mode_web_stack_still_pulls(monkeypatch, tmp_path):
+    """Registry mode's sidecar image is a published one (preflight required
+    auth.image), so it belongs in the pull like every other web-stack image."""
+    recorded = _stub_web_stack(monkeypatch, tmp_path)
+
+    provision.deploy_up_web_terminals(
+        _sidecar_config("registry", auth_image="reg/auth:1"), [], False, {}, []
+    )
+
+    assert any("pull" in cmd for cmd in recorded)
+
+
+def test_local_mode_builds_the_auth_image_before_any_compose_invocation(monkeypatch, tmp_path):
+    """Ordering is the point: compose `up` on an unbuilt local tag fails with an
+    opaque 'no such image'."""
+    order: list[str] = []
+    recorded = _stub_web_stack(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        provision, "build_auth_sidecar_image", lambda *a, **kw: order.append("build")
+    )
+
+    def _fake_run(cmd, **kwargs):
+        recorded.append(list(cmd))
+        order.append("compose")
+        return _FakeCompletedProcess()
+
+    monkeypatch.setattr(provision.subprocess, "run", _fake_run)
+
+    provision.deploy_up_web_terminals(_sidecar_config("local"), [], False, {}, [])
+
+    assert order[0] == "build"
+
+
+def test_force_recreate_auth_sidecar_targets_only_the_sidecar_service(monkeypatch, tmp_path):
+    """env_file content is baked in at container creation, so only a recreate
+    puts a changed .env.auth in force — scoped to the `auth` service, because
+    recreating the whole stack would bounce every live terminal."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "docker-compose.web.yml").write_text("services: {}\n", encoding="utf-8")
+    recorded: list[dict] = []
+
+    def _fake_run(cmd, **kwargs):
+        recorded.append({"cmd": list(cmd), "env": kwargs.get("env")})
+        return _FakeCompletedProcess()
+
+    monkeypatch.setattr(provision.subprocess, "run", _fake_run)
+    monkeypatch.setattr(provision, "get_runtime_command", lambda config=None: ["podman", "compose"])
+
+    provision.force_recreate_auth_sidecar(
+        {"project_name": "myproj"}, ["--env-file", ".env"], env={"X": "1"}
+    )
+
+    assert len(recorded) == 1
+    assert recorded[0]["cmd"] == [
+        "podman",
+        "compose",
+        "-f",
+        "docker-compose.web.yml",
+        "--env-file",
+        ".env",
+        "up",
+        "-d",
+        "--force-recreate",
+        "auth",
+    ]
+    # Same COMPOSE_PROJECT_NAME pin as the `up` that created the stack —
+    # without it compose would address a different project entirely.
+    assert recorded[0]["env"]["COMPOSE_PROJECT_NAME"] == "myproj"
+
+
+def test_changed_env_auth_recreates_the_sidecar_once_even_when_its_image_drifted(
+    monkeypatch, tmp_path
+):
+    """Both reasons resolve into ONE service-scoped recreate: the sidecar's
+    env_file changed AND (podman) its image drifted. Issuing them separately
+    would bounce the same container twice in one deploy."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "docker-compose.web.yml").write_text(
+        "services:\n  auth:\n    image: als-assistant-auth:local\n    container_name: als-auth\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(provision, "get_runtime_command", lambda config=None: ["podman", "compose"])
+    _patch_ids(
+        monkeypatch,
+        image_ids={"als-assistant-auth:local": "idNEW"},
+        container_ids={"als-auth": "idOLD"},  # drifted as well
+    )
+    recorded = []
+
+    def _fake_run(cmd, **kwargs):
+        recorded.append(list(cmd))
+        return _FakeCompletedProcess()
+
+    monkeypatch.setattr(provision.subprocess, "run", _fake_run)
+
+    provision._reconcile_web_stack_recreates({}, _WEB_CMD, _RUN_ENV, force_recreate=("auth",))
+
+    assert len(recorded) == 1
+    assert recorded[0][-3:] == ["-d", "--force-recreate", "auth"]
+    assert recorded[0].count("auth") == 1
+
+
+def test_changed_env_auth_recreates_the_sidecar_on_docker_too(monkeypatch, tmp_path):
+    """The podman gate covers IMAGE DRIFT only. No compose implementation
+    recreates a container when its env_file's CONTENT changed, so a
+    caller-requested recreate must fire on docker as well — otherwise every
+    docker deployment would keep serving the previous credentials."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(provision, "get_runtime_command", lambda config=None: ["docker", "compose"])
+    recorded = []
+
+    def _fake_run(cmd, **kwargs):
+        recorded.append(list(cmd))
+        return _FakeCompletedProcess()
+
+    monkeypatch.setattr(provision.subprocess, "run", _fake_run)
+
+    provision._reconcile_web_stack_recreates({}, _WEB_CMD, _RUN_ENV, force_recreate=("auth",))
+
+    assert len(recorded) == 1
+    assert recorded[0][-1] == "auth"
+
+
+def test_deploy_up_recreates_the_sidecar_when_preflight_changed_env_auth(monkeypatch, tmp_path):
+    """The seam the deploy flow uses: hand deploy_up_web_terminals the preflight
+    result and the sidecar joins the post-`up` recreate. Without the result
+    (or with the flag clear) the deploy recreates nothing."""
+    recorded = _stub_web_stack(monkeypatch, tmp_path)
+    captured: list[tuple] = []
+    monkeypatch.setattr(
+        provision,
+        "_reconcile_web_stack_recreates",
+        lambda config, web_cmd, run_env, force_recreate=(): captured.append(force_recreate),
+    )
+    config = _sidecar_config("registry", auth_image="reg/auth:1")
+
+    provision.deploy_up_web_terminals(
+        config, [], False, {}, [], provision.WebTerminalPreflightResult(auth_env_changed=True)
+    )
+    provision.deploy_up_web_terminals(
+        config, [], False, {}, [], provision.WebTerminalPreflightResult(auth_env_changed=False)
+    )
+    provision.deploy_up_web_terminals(config, [], False, {}, [])
+
+    assert captured == [("auth",), (), ()]
+    assert recorded  # the stack was still brought up in every case
+
+
+def test_force_recreate_auth_sidecar_is_a_warning_not_a_failure_without_a_stack(
+    monkeypatch, tmp_path, caplog
+):
+    """Nothing was ever deployed from this root: there is no container to
+    recreate, and raising would turn that into a deploy error."""
+    monkeypatch.chdir(tmp_path)
+
+    def _unexpected_run(cmd, **kwargs):
+        raise AssertionError(f"unexpected subprocess.run: {cmd}")
+
+    monkeypatch.setattr(provision.subprocess, "run", _unexpected_run)
+
+    with caplog.at_level("WARNING"):
+        provision.force_recreate_auth_sidecar({"project_name": "myproj"}, [])
+
+    assert "docker-compose.web.yml" in caplog.text

--- a/tests/deployment/web_terminals/test_render.py
+++ b/tests/deployment/web_terminals/test_render.py
@@ -1356,7 +1356,7 @@ def test_auth_context_never_reads_a_credential_out_of_config() -> None:
             "issuer": "https://sso.dls.example.org/realms/facility",
             "client_secret": "s3cr3t-should-never-render",
         },
-        "password_hash": "scrypt$16384$8$1$salt$hash",
+        "password_hash": "scrypt.16384.8.1.salt.hash",
     }
 
     # Act
@@ -1365,7 +1365,7 @@ def test_auth_context_never_reads_a_credential_out_of_config() -> None:
     # Assert
     rendered_values = " ".join(str(value) for value in context.values())
     assert "s3cr3t-should-never-render" not in rendered_values
-    assert "scrypt$" not in rendered_values
+    assert "scrypt." not in rendered_values
 
 
 def test_render_auth_context_gate_method_without_tls_raises() -> None:

--- a/tests/deployment/web_terminals/test_render.py
+++ b/tests/deployment/web_terminals/test_render.py
@@ -8,13 +8,34 @@ from unittest.mock import patch
 
 import pytest
 import yaml
+from jinja2 import Template
 
+from osprey.deployment.web_terminals.auth_credentials import AUTH_ENV_FILENAME
+from osprey.deployment.web_terminals.personas import env_var_suffix
 from osprey.deployment.web_terminals.ports import (
     PANEL_ENV_VARS,
     allocate_ports,
     base_ports_from_config,
 )
 from osprey.deployment.web_terminals.render import _auth_tls_context, render_web_terminals
+
+# The sidecar's own env-var names, imported rather than spelled out: the compose
+# service and the app factory are the two ends of one contract, and a rename on
+# either side must fail here instead of silently rendering a variable nothing reads.
+from osprey.services.auth_sidecar.app import (
+    ENV_EXTERNAL_ORIGIN,
+    ENV_METHOD,
+    ENV_OIDC_CLIENT_ID_ENV,
+    ENV_OIDC_CLIENT_SECRET_ENV,
+    ENV_OIDC_ISSUER,
+    ENV_OIDC_SUBJECT_PREFIX,
+    ENV_PW_HASH_PREFIX,
+    ENV_SESSION_LIFETIME,
+    ENV_SESSION_SECRET,
+    ENV_STATE_SECRET,
+    ENV_TLS_ENABLED,
+    ENV_USERS,
+)
 
 # The four classic config-set families; the effective per-family base set the
 # render actually allocates from also carries every registry default
@@ -431,6 +452,144 @@ def test_render_missing_deploy_fqdn_is_fine_with_zero_users() -> None:
 
     # Assert
     assert "docker-compose.web.yml" in artifacts
+
+
+# ---------------------------------------------------------------------------
+# Task 1.3: one external-origin derivation behind landing_url and OIDC
+# ---------------------------------------------------------------------------
+
+
+def _tls_config(users: list[str] | None = None) -> dict:
+    """A config with TLS terminated at nginx (cert/key set, as the render demands)."""
+    config = copy.deepcopy(_config(users) if users is not None else _MULTI_USER_CONFIG)
+    config["modules"]["web_terminals"]["tls"] = {
+        "enabled": True,
+        "cert": "/etc/nginx/certs/dls.crt",
+        "key": "/etc/nginx/certs/dls.key",
+    }
+    return config
+
+
+def _capture_render_contexts(config: dict) -> dict[str, dict]:
+    """Render `config`, capturing the Jinja context each template was given.
+
+    `external_origin` is exported for templates that don't consume it yet (the
+    nginx TLS-redirect block and the compose sidecar service land later), so the
+    context itself is the only place its export can be pinned today.
+    """
+    captured: dict[str, dict] = {}
+
+    def _record(self, **context):  # type: ignore[no-untyped-def]
+        captured[self.name] = context
+        return ""
+
+    with patch.object(Template, "render", _record):
+        render_web_terminals(config)
+    return captured
+
+
+def test_external_origin_without_tls_is_plain_http_on_the_published_nginx_port() -> None:
+    """No TLS: nginx publishes one plain port, and that port is part of the origin."""
+    # Arrange
+    config = copy.deepcopy(_MULTI_USER_CONFIG)
+
+    # Act
+    contexts = _capture_render_contexts(config)
+
+    # Assert
+    assert contexts["nginx.conf.j2"]["external_origin"] == "http://dls-deploy.dls.example.org:9080"
+
+
+def test_external_origin_with_tls_is_https_with_443_left_implicit() -> None:
+    """TLS on: the 443 server is the sole content server, and 443 is left implicit —
+    the canonical origin serialization, and the form an OIDC client registration is
+    normally written in (an IdP compares `redirect_uri` character for character)."""
+    # Arrange
+    config = _tls_config()
+
+    # Act
+    contexts = _capture_render_contexts(config)
+
+    # Assert — the nginx_port never appears in a TLS origin
+    assert contexts["nginx.conf.j2"]["external_origin"] == "https://dls-deploy.dls.example.org"
+
+
+def test_external_origin_is_exported_to_both_the_nginx_and_compose_contexts() -> None:
+    """One derivation, exported to every consumer: the nginx server blocks and the
+    compose overlay (whose auth sidecar builds its OIDC redirect_uri from it)."""
+    # Arrange
+    config = _tls_config()
+
+    # Act
+    contexts = _capture_render_contexts(config)
+
+    # Assert
+    origin = "https://dls-deploy.dls.example.org"
+    assert contexts["nginx.conf.j2"]["external_origin"] == origin
+    assert contexts["docker-compose.web.yml.j2"]["external_origin"] == origin
+
+
+def test_landing_url_is_the_external_origin_verbatim_under_tls() -> None:
+    """The divergence guard this task exists for: `landing_url` is not assembled
+    separately, so it cannot drift from the origin the OIDC redirect_uri uses."""
+    # Arrange
+    config = _tls_config()
+
+    # Act
+    contexts = _capture_render_contexts(config)
+    compose_ctx = contexts["docker-compose.web.yml.j2"]
+
+    # Assert
+    assert compose_ctx["landing_url"] == compose_ctx["external_origin"]
+
+
+def test_landing_url_baked_into_containers_follows_tls_into_https() -> None:
+    """Regression: OSPREY_TERMINAL_LANDING_URL used to be hardcoded to
+    `http://<fqdn>:<nginx_port>` regardless of TLS, so a TLS deployment shipped every
+    container a "back to landing" link on the plain origin — which under the TLS
+    posture only ever redirects, and would never carry a Secure session cookie."""
+    # Arrange
+    config = _tls_config()
+
+    # Act
+    compose = yaml.safe_load(render_web_terminals(config)["docker-compose.web.yml"])
+
+    # Assert
+    landing_env = [
+        env
+        for env in compose["services"]["web-alice"]["environment"]
+        if env.startswith("OSPREY_TERMINAL_LANDING_URL=")
+    ]
+    assert landing_env == ["OSPREY_TERMINAL_LANDING_URL=https://dls-deploy.dls.example.org"]
+
+
+def test_landing_url_without_tls_is_unchanged_from_today() -> None:
+    """The plain-HTTP deployment (every current facility) renders byte-identically."""
+    # Arrange
+    config = copy.deepcopy(_MULTI_USER_CONFIG)
+
+    # Act
+    compose = yaml.safe_load(render_web_terminals(config)["docker-compose.web.yml"])
+
+    # Assert
+    assert (
+        "OSPREY_TERMINAL_LANDING_URL=http://dls-deploy.dls.example.org:9080"
+        in compose["services"]["web-alice"]["environment"]
+    )
+
+
+def test_external_origin_is_required_by_auth_even_with_an_empty_roster() -> None:
+    """`deploy.fqdn` stops being users-only once auth is on: the sidecar needs an
+    origin to build its redirect_uri from, so a roster-less auth deployment must fail
+    loudly here rather than at the IdP with a redirect_uri mismatch."""
+    # Arrange
+    config = _tls_config(users=[])
+    del config["deploy"]["fqdn"]
+    config["modules"]["web_terminals"]["auth"] = {"method": "oidc"}
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="deploy.fqdn"):
+        render_web_terminals(config)
 
 
 def test_render_missing_web_base_port_raises_value_error() -> None:
@@ -992,13 +1151,13 @@ def test_auth_default_none_reads_configured_method() -> None:
     """A configured `web_terminals.auth.method` is read through, not clobbered by the default."""
     # Arrange
     web_terminals = copy.deepcopy(_MULTI_USER_CONFIG)["modules"]["web_terminals"]
-    web_terminals["auth"] = {"method": "oauth2_proxy"}
+    web_terminals["auth"] = {"method": "password"}
 
     # Act
     context = _auth_tls_context(web_terminals)
 
     # Assert
-    assert context["auth_method"] == "oauth2_proxy"
+    assert context["auth_method"] == "password"
 
 
 def test_auth_method_non_string_falls_back_to_none() -> None:
@@ -1047,6 +1206,229 @@ def test_tls_default_off_reads_configured_stanza() -> None:
     assert context["tls_enabled"] is True
     assert context["tls_cert"] == "/etc/nginx/certs/dls.crt"
     assert context["tls_key"] == "/etc/nginx/certs/dls.key"
+
+
+# ---------------------------------------------------------------------------
+# Task 1.2: the full auth stanza — `_auth_tls_context` is the single parser
+# ---------------------------------------------------------------------------
+
+
+def test_auth_context_defaults_are_inert_without_an_auth_stanza() -> None:
+    """No `auth` stanza -> every auth key resolves to a default that renders nothing:
+    no method, no image pin, no OIDC issuer. The two knobs that must still hold a
+    usable value (the sidecar's port and the session lifetime) carry the documented
+    defaults so a facility enabling auth needs only `method`."""
+    # Arrange
+    web_terminals = copy.deepcopy(_MULTI_USER_CONFIG)["modules"]["web_terminals"]
+
+    # Act
+    context = _auth_tls_context(web_terminals)
+
+    # Assert
+    assert context["auth_method"] == "none"
+    assert context["auth_allow_insecure_http"] is False
+    assert context["auth_image"] is None
+    assert context["auth_oidc_issuer"] is None
+    assert context["auth_port"] == 9070
+    assert context["auth_session_lifetime"] == 12 * 60 * 60
+
+
+def test_auth_context_reads_every_configured_scalar() -> None:
+    """A fully specified `auth` stanza is read through field for field."""
+    # Arrange
+    web_terminals = copy.deepcopy(_MULTI_USER_CONFIG)["modules"]["web_terminals"]
+    web_terminals["auth"] = {
+        "method": "password",
+        "port": 9401,
+        "session_lifetime": 3600,
+        "allow_insecure_http": True,
+        "image": "git.dls.example.org:5050/physics/production/dls-auth:2026.8.1",
+    }
+
+    # Act
+    context = _auth_tls_context(web_terminals)
+
+    # Assert
+    assert context["auth_method"] == "password"
+    assert context["auth_port"] == 9401
+    assert context["auth_session_lifetime"] == 3600
+    assert context["auth_allow_insecure_http"] is True
+    assert context["auth_image"].endswith("dls-auth:2026.8.1")
+
+
+def test_auth_context_reads_oidc_issuer_and_credential_env_var_names() -> None:
+    """`oidc` mode names its issuer inline and its client credentials only by env-var
+    name — the credentials themselves live in `.env.auth`, never in config.yml."""
+    # Arrange
+    web_terminals = copy.deepcopy(_MULTI_USER_CONFIG)["modules"]["web_terminals"]
+    web_terminals["auth"] = {
+        "method": "oidc",
+        "allow_insecure_http": True,
+        "oidc": {
+            "issuer": "https://sso.dls.example.org/realms/facility",
+            "client_id_env": "DLS_SSO_CLIENT_ID",
+            "client_secret_env": "DLS_SSO_CLIENT_SECRET",
+        },
+    }
+
+    # Act
+    context = _auth_tls_context(web_terminals)
+
+    # Assert
+    assert context["auth_method"] == "oidc"
+    assert context["auth_oidc_issuer"] == "https://sso.dls.example.org/realms/facility"
+    assert context["auth_oidc_client_id_env"] == "DLS_SSO_CLIENT_ID"
+    assert context["auth_oidc_client_secret_env"] == "DLS_SSO_CLIENT_SECRET"
+
+
+def test_auth_context_oidc_credential_env_var_names_have_defaults() -> None:
+    """A facility that doesn't rename them gets the framework's own env-var names, so
+    an `oidc` stanza only has to carry the issuer."""
+    # Arrange
+    web_terminals = copy.deepcopy(_MULTI_USER_CONFIG)["modules"]["web_terminals"]
+    web_terminals["auth"] = {
+        "method": "oidc",
+        "allow_insecure_http": True,
+        "oidc": {"issuer": "https://sso.dls.example.org/realms/facility"},
+    }
+
+    # Act
+    context = _auth_tls_context(web_terminals)
+
+    # Assert
+    assert context["auth_oidc_client_id_env"] == "OSPREY_AUTH_OIDC_CLIENT_ID"
+    assert context["auth_oidc_client_secret_env"] == "OSPREY_AUTH_OIDC_CLIENT_SECRET"
+
+
+def test_auth_context_unknown_method_raises_value_error() -> None:
+    """An `auth.method` naming a method no sidecar implements is a hard error, not a
+    forward-compatible passthrough: rendering it would emit an `auth_request` seam
+    that nothing can answer, locking the deployment out with an unactionable 403."""
+    # Arrange
+    web_terminals = copy.deepcopy(_MULTI_USER_CONFIG)["modules"]["web_terminals"]
+    web_terminals["auth"] = {"method": "oauth2_proxy"}
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="auth.method") as exc_info:
+        _auth_tls_context(web_terminals)
+    message = str(exc_info.value)
+    assert "oauth2_proxy" in message
+    # The message names the alternatives, so the fix is obvious from the error alone.
+    assert "password" in message
+    assert "oidc" in message
+
+
+def test_auth_context_malformed_scalars_fall_back_to_defaults() -> None:
+    """Wrong-typed values follow this module's defensive-read convention (lint is the
+    authoritative gate on well-formedness) rather than crashing the render. `bool` is
+    called out explicitly: it satisfies `isinstance(x, int)`, so an unguarded read
+    would turn `port: true` into port 1."""
+    # Arrange
+    web_terminals = copy.deepcopy(_MULTI_USER_CONFIG)["modules"]["web_terminals"]
+    web_terminals["auth"] = {
+        "port": True,
+        "session_lifetime": -1,
+        "image": "",
+        "oidc": "not-a-dict",
+    }
+
+    # Act
+    context = _auth_tls_context(web_terminals)
+
+    # Assert
+    assert context["auth_port"] == 9070
+    assert context["auth_session_lifetime"] == 12 * 60 * 60
+    assert context["auth_image"] is None
+    assert context["auth_oidc_issuer"] is None
+    assert context["auth_oidc_client_id_env"] == "OSPREY_AUTH_OIDC_CLIENT_ID"
+
+
+def test_auth_context_never_reads_a_credential_out_of_config() -> None:
+    """Secrets belong in `.env.auth`; the parser reads env-var *names* only. A config
+    that pastes a literal client secret (or password hash) in must not carry it into
+    any render context, where it would land in a committed compose/nginx artifact."""
+    # Arrange
+    web_terminals = copy.deepcopy(_MULTI_USER_CONFIG)["modules"]["web_terminals"]
+    web_terminals["auth"] = {
+        "method": "oidc",
+        "allow_insecure_http": True,
+        "oidc": {
+            "issuer": "https://sso.dls.example.org/realms/facility",
+            "client_secret": "s3cr3t-should-never-render",
+        },
+        "password_hash": "scrypt$16384$8$1$salt$hash",
+    }
+
+    # Act
+    context = _auth_tls_context(web_terminals)
+
+    # Assert
+    rendered_values = " ".join(str(value) for value in context.values())
+    assert "s3cr3t-should-never-render" not in rendered_values
+    assert "scrypt$" not in rendered_values
+
+
+def test_render_auth_context_gate_method_without_tls_raises() -> None:
+    """Fail-closed render gate: authentication over cleartext HTTP would ship session
+    cookies in the open, so the render refuses rather than emitting it — the same
+    posture as the tls cert/key fail-fast right beside it."""
+    # Arrange
+    config = copy.deepcopy(_MULTI_USER_CONFIG)
+    config["modules"]["web_terminals"]["auth"] = {"method": "password"}
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="allow_insecure_http") as exc_info:
+        render_web_terminals(config)
+    assert "tls.enabled" in str(exc_info.value)
+
+
+def test_render_auth_context_gate_allow_insecure_http_permits_the_render() -> None:
+    """The escape hatch is explicit and per-deployment: a facility terminating TLS at
+    an upstream proxy opts in by name."""
+    # Arrange
+    config = copy.deepcopy(_MULTI_USER_CONFIG)
+    config["modules"]["web_terminals"]["auth"] = {
+        "method": "password",
+        "allow_insecure_http": True,
+    }
+
+    # Act
+    artifacts = render_web_terminals(config)
+
+    # Assert
+    assert "auth_request" in artifacts["nginx/nginx.conf"]
+
+
+def test_render_auth_context_gate_is_satisfied_by_tls_enabled() -> None:
+    """The ordinary way to pass the gate is to actually enable TLS."""
+    # Arrange
+    config = copy.deepcopy(_MULTI_USER_CONFIG)
+    config["modules"]["web_terminals"]["auth"] = {"method": "oidc"}
+    config["modules"]["web_terminals"]["tls"] = {
+        "enabled": True,
+        "cert": "/etc/nginx/certs/dls.crt",
+        "key": "/etc/nginx/certs/dls.key",
+    }
+
+    # Act
+    artifacts = render_web_terminals(config)
+
+    # Assert
+    assert "auth_request" in artifacts["nginx/nginx.conf"]
+
+
+def test_render_auth_context_gate_does_not_fire_for_method_none() -> None:
+    """The gate is about protecting session cookies; with no authentication there are
+    none, so plain-HTTP deployments keep rendering exactly as they do today."""
+    # Arrange
+    config = copy.deepcopy(_MULTI_USER_CONFIG)
+    config["modules"]["web_terminals"]["auth"] = {"method": "none"}
+
+    # Act
+    artifacts = render_web_terminals(config)
+
+    # Assert
+    assert "auth_request" not in artifacts["nginx/nginx.conf"]
 
 
 def test_render_succeeds_with_auth_default_none_and_tls_default_off() -> None:
@@ -1145,26 +1527,35 @@ def test_nginx_seam_tls_enabled_without_cert_or_key_raises_value_error() -> None
         render_web_terminals(config)
 
 
-def test_nginx_seam_auth_method_set_emits_auth_request_per_user_location() -> None:
+def test_nginx_seam_auth_method_set_gates_every_proxied_user_location() -> None:
     """C2 (render half): a configured `auth.method` (anything but the "none" default)
-    emits an `auth_request` directive inside every proxied `/u/<user>/` location, plus
-    the single internal target location it subrequests."""
+    leaves NO proxied `/u/<user>/` location ungated.
+
+    The per-user target shape each `auth_request` names is pinned by the
+    `auth_location` tests below; this one guards the coverage property they
+    can't — that the count of gated locations equals the count of proxied ones,
+    so a user added through a code path that forgets the gate fails here.
+    Fail-closed is asserted alongside it: nothing in the render authorizes on
+    its own, so a sidecar that is down or unconfigured denies rather than
+    admits.
+    """
     # Arrange
     config = copy.deepcopy(_MULTI_USER_CONFIG)
     users = config["modules"]["web_terminals"]["users"]
-    config["modules"]["web_terminals"]["auth"] = {"method": "oauth2_proxy"}
+    config["modules"]["web_terminals"]["auth"] = {
+        "method": "password",
+        "allow_insecure_http": True,
+    }
 
     # Act
     artifacts = render_web_terminals(config)
     nginx_conf = artifacts["nginx/nginx.conf"]
 
     # Assert
-    assert nginx_conf.count("auth_request /_osprey_auth;") == len(users)
-    assert nginx_conf.count("internal;") == 1
-    # Fail-closed: the stub target denies (403), never silently authorizes (200) —
-    # setting auth.method without wiring a real backend must lock users out.
-    assert "return 403;" in nginx_conf
-    assert "return 200;" not in nginx_conf
+    directives = _directives(nginx_conf)
+    assert directives.count("auth_request ") == len(users)
+    assert directives.count("    location /u/") == len(users)
+    assert "return 200;" not in directives
 
 
 def test_nginx_seam_auth_none_omits_auth_request_even_with_tls_enabled() -> None:
@@ -1307,6 +1698,677 @@ def test_mcp_topology_custom_url_server_config_is_a_separate_namespace() -> None
     }
 
 
+# ---------------------------------------------------------------------------
+# Task 3.1: per-user internal auth locations
+# ---------------------------------------------------------------------------
+
+
+def _auth_config(users: list[str] | None = None, **auth: object) -> dict:
+    """A rendering config with authentication on.
+
+    `allow_insecure_http` is set unless the caller enables TLS, because the
+    render refuses `auth.method` over cleartext otherwise — a gate these tests
+    are not about (it has its own coverage above).
+    """
+    config = _config(users if users is not None else ["alice", "bob", "carol"])
+    stanza: dict = {"method": "password", "allow_insecure_http": True}
+    stanza.update(auth)
+    config["modules"]["web_terminals"]["auth"] = stanza
+    return config
+
+
+def _render_nginx(config: dict) -> str:
+    return render_web_terminals(config)["nginx/nginx.conf"]
+
+
+def _directives(conf: str) -> str:
+    """`conf` with its comment lines dropped.
+
+    Counting and absence assertions have to ignore comment prose, which in this
+    template frequently names the very construct being counted or ruled out —
+    the comment above `error_page` explains what the `auth_request` above it
+    does, and would otherwise be counted as a second `auth_request`.
+    """
+    return "\n".join(line for line in conf.splitlines() if not line.lstrip().startswith("#"))
+
+
+def test_auth_location_is_rendered_once_per_roster_user() -> None:
+    """Each user gets their OWN internal auth target, not a shared one.
+
+    A single shared target could only learn which user is being authorized from
+    the request itself (`$request_uri`/`X-Original-URI`) — client-controlled
+    input on the authorization path. Per-user locations make the identity a
+    property of which location matched, which the client cannot influence.
+    """
+    # Arrange
+    users = ["alice", "bob", "carol"]
+
+    # Act
+    nginx_conf = _render_nginx(_auth_config(users))
+
+    # Assert
+    for user in users:
+        assert f"location = /_osprey_auth/{user} {{" in nginx_conf
+    assert nginx_conf.count("location = /_osprey_auth/") == len(users)
+    # The pre-sidecar shared stub is gone, not merely supplemented.
+    assert "location = /_osprey_auth {" not in nginx_conf
+
+
+def test_auth_location_is_named_by_each_users_own_auth_request() -> None:
+    """`/u/<user>/` subrequests `<user>`'s target — never another user's.
+
+    Pinning the pairing (not just the presence of both directives) is what
+    catches a loop that renders every `auth_request` against the first user.
+    """
+    # Arrange
+    users = ["alice", "bob", "carol"]
+
+    # Act
+    nginx_conf = _render_nginx(_auth_config(users))
+
+    # Assert
+    for user in users:
+        location = re.search(rf"location /u/{user}/ \{{(.*?)\n    \}}", nginx_conf, flags=re.DOTALL)
+        assert location is not None, f"no proxied location rendered for {user}"
+        assert f"auth_request /_osprey_auth/{user};" in location.group(1)
+    assert _directives(nginx_conf).count("auth_request ") == len(users)
+
+
+def test_auth_location_verifies_against_the_sidecar_with_a_render_time_username() -> None:
+    """The target proxies to the sidecar's `/verify`, with `?user=` baked in.
+
+    The username is a literal from the roster, so the sidecar is asked about
+    exactly the user whose prefix was requested — there is no code path where a
+    crafted URL, header, or cookie chooses a different one.
+    """
+    # Act
+    nginx_conf = _render_nginx(_auth_config(["alice", "bob"]))
+
+    # Assert
+    assert "proxy_pass http://127.0.0.1:9070/verify?user=alice;" in nginx_conf
+    assert "proxy_pass http://127.0.0.1:9070/verify?user=bob;" in nginx_conf
+
+
+def test_auth_location_follows_the_configured_auth_port() -> None:
+    """A facility that moves the sidecar off 9070 is routed to the new port —
+    the template reads `auth_port`, it never hardcodes the default."""
+    # Act
+    nginx_conf = _render_nginx(_auth_config(["alice"], port=9471))
+
+    # Assert
+    assert "proxy_pass http://127.0.0.1:9471/verify?user=alice;" in nginx_conf
+    assert ":9070/verify" not in nginx_conf
+
+
+def test_auth_location_is_internal_only() -> None:
+    """Every auth target carries `internal;`, so a browser cannot request one
+    directly — the subrequest is the only way in."""
+    # Arrange
+    users = ["alice", "bob", "carol"]
+
+    # Act
+    nginx_conf = _render_nginx(_auth_config(users))
+
+    # Assert
+    for user in users:
+        target = re.search(
+            rf"location = /_osprey_auth/{user} \{{(.*?)\n    \}}", nginx_conf, flags=re.DOTALL
+        )
+        assert target is not None, f"no auth target rendered for {user}"
+        assert "internal;" in target.group(1)
+    assert nginx_conf.count("internal;") == len(users)
+
+
+def test_auth_location_suppresses_the_subrequest_body() -> None:
+    """`proxy_pass_request_body off` + a cleared `Content-Length` on every auth
+    target.
+
+    Without both, nginx announces the parent POST's body to a sidecar that
+    never reads it, and the subrequest hangs until it times out — every
+    authenticated POST in the deployment stalls. This assertion is the only
+    cheap guard for that; the failure mode is invisible to a syntax check.
+    """
+    # Arrange
+    users = ["alice", "bob"]
+
+    # Act
+    nginx_conf = _render_nginx(_auth_config(users))
+
+    # Assert
+    assert nginx_conf.count("proxy_pass_request_body off;") == len(users)
+    assert nginx_conf.count('proxy_set_header Content-Length "";') == len(users)
+
+
+def test_auth_location_verify_subrequest_fails_fast() -> None:
+    """Every verify target states short timeouts instead of inheriting 60s.
+
+    This subrequest sits in front of every gated request, so its worst case is
+    the deployment's worst case: on nginx's defaults, one wedged sidecar holds
+    each open terminal's next request for a minute before failing it. A
+    loopback signature check has no legitimate reason to take that long.
+    """
+    # Arrange
+    users = ["alice", "bob", "carol"]
+
+    # Act
+    nginx_conf = _render_nginx(_auth_config(users))
+
+    # Assert
+    for user in users:
+        body = _location_body(nginx_conf, f"location = /_osprey_auth/{user}")
+        assert "proxy_connect_timeout 2s;" in body
+        assert "proxy_read_timeout 5s;" in body
+    # The gated terminal locations keep the long SSE/WebSocket read timeout —
+    # the short one belongs to the subrequest only.
+    assert "proxy_read_timeout 3600s;" in _location_body(nginx_conf, "location /u/alice/")
+
+
+def test_auth_location_absent_when_method_is_none() -> None:
+    """`auth.method: none` renders no auth target, no `auth_request`, and no
+    reference to the sidecar's port — byte-for-byte the pre-auth output.
+
+    (The wider byte-equality guarantee is pinned by the golden fixtures in
+    test_golden_render.py; this asserts the property directly for the explicit
+    `method: none` spelling as well as the absent-stanza default.)
+    """
+    # Arrange
+    default_config = copy.deepcopy(_MULTI_USER_CONFIG)
+    explicit_none = copy.deepcopy(_MULTI_USER_CONFIG)
+    explicit_none["modules"]["web_terminals"]["auth"] = {"method": "none"}
+
+    # Act
+    default_conf = _render_nginx(default_config)
+    explicit_conf = _render_nginx(explicit_none)
+
+    # Assert
+    assert explicit_conf == default_conf
+    assert "_osprey_auth" not in default_conf
+    assert "auth_request" not in default_conf
+    assert "9070" not in default_conf
+
+
+def test_auth_location_zero_users_renders_no_auth_targets() -> None:
+    """An empty roster with auth on has nobody to authorize: no targets, and —
+    critically — no location that answers 200 in their absence."""
+    # Act
+    nginx_conf = _render_nginx(_auth_config([]))
+
+    # Assert
+    assert "_osprey_auth" not in nginx_conf
+    assert "return 200;" not in nginx_conf
+
+
+# ---------------------------------------------------------------------------
+# Task 3.2: public /auth locations
+# ---------------------------------------------------------------------------
+
+
+def _location_body(nginx_conf: str, header: str) -> str:
+    """The directives inside a top-level `location …` block, by its header line."""
+    match = re.search(rf"{re.escape(header)} \{{(.*?)\n    \}}", nginx_conf, flags=re.DOTALL)
+    assert match is not None, f"no `{header}` block in the rendered fragment"
+    return match.group(1)
+
+
+def test_auth_public_location_proxies_the_login_surface_to_the_sidecar() -> None:
+    """`/auth/` reaches the sidecar's own `/auth/` prefix — the login page, the
+    credential POST, the OIDC callback, logout, and the page's assets all ride
+    this one prefix location rather than an enumeration that drifts from the
+    sidecar's router."""
+    # Act
+    nginx_conf = _render_nginx(_auth_config())
+
+    # Assert
+    assert "    location /auth/ {" in nginx_conf
+    assert "proxy_pass http://127.0.0.1:9070/auth/;" in _location_body(
+        nginx_conf, "location /auth/"
+    )
+
+
+def test_auth_public_location_follows_the_configured_auth_port() -> None:
+    """The public surface and the internal verify targets are pointed at the same
+    configured sidecar port — neither hardcodes the 9070 default."""
+    # Act
+    nginx_conf = _render_nginx(_auth_config(port=9471))
+
+    # Assert
+    assert "proxy_pass http://127.0.0.1:9471/auth/;" in nginx_conf
+    assert ":9070" not in nginx_conf
+
+
+def test_auth_public_location_is_not_behind_auth_request() -> None:
+    """The login flow must answer without a session — gating it behind one is a
+    locked door whose key is inside the room. Same for the landing page at `= /`,
+    which is both the identity chooser and what the nginx healthcheck probes."""
+    # Act
+    nginx_conf = _render_nginx(_auth_config())
+
+    # Assert
+    assert "auth_request" not in _location_body(nginx_conf, "location /auth/")
+    assert "auth_request" not in _location_body(nginx_conf, "location = /")
+
+
+def test_auth_public_location_is_not_internal() -> None:
+    """`/auth/` is browser-reachable: an `internal` marker here would 404 every
+    login attempt (the exact failure a copy-paste from the verify targets makes,
+    and one no syntax check catches)."""
+    # Act
+    nginx_conf = _render_nginx(_auth_config())
+
+    # Assert
+    assert "internal;" not in _location_body(nginx_conf, "location /auth/")
+
+
+def test_auth_public_location_sets_explicit_short_proxy_timeouts() -> None:
+    """The login surface states its own timeouts instead of taking whatever the
+    terminal locations need.
+
+    The `/u/<user>/` locations run `proxy_read_timeout 3600s` to keep SSE and
+    WebSocket streams alive; the login flow is a few short round trips to a
+    loopback service, so a wedged sidecar should surface in seconds rather than
+    hang a browser tab.
+    """
+    # Act
+    body = _location_body(_render_nginx(_auth_config()), "location /auth/")
+
+    # Assert
+    assert "proxy_connect_timeout 5s;" in body
+    assert "proxy_send_timeout 15s;" in body
+    assert "proxy_read_timeout 15s;" in body
+    assert "3600s" not in body
+
+
+def test_auth_public_location_does_not_expose_the_verify_endpoint() -> None:
+    """`/verify` is reachable only through the `internal` per-user targets. It
+    must not be proxied under the public prefix, where a browser could ask the
+    sidecar about any username it liked."""
+    # Act
+    nginx_conf = _render_nginx(_auth_config())
+
+    # Assert
+    assert "location /verify" not in nginx_conf
+    assert "location = /verify" not in nginx_conf
+    # Every directive (as opposed to comment prose) naming `/verify` is the
+    # proxy_pass target of an internal per-user location.
+    verify_lines = [line for line in _directives(nginx_conf).splitlines() if "/verify" in line]
+    assert verify_lines, "the verify targets themselves should still be rendered"
+    assert all("/verify?user=" in line for line in verify_lines)
+
+
+def test_auth_public_location_absent_when_method_is_none() -> None:
+    """No sidecar, no public login surface — a `none` deployment renders no
+    `/auth/` location at all."""
+    # Act
+    nginx_conf = _render_nginx(copy.deepcopy(_MULTI_USER_CONFIG))
+
+    # Assert
+    assert "location /auth/" not in nginx_conf
+
+
+def test_auth_public_location_renders_for_an_empty_roster() -> None:
+    """The login surface is a property of the sidecar, not of the roster: it is
+    rendered even with zero users, so a roster added later needs no second
+    render path (and an empty deployment still serves a coherent origin)."""
+    # Act
+    nginx_conf = _render_nginx(_auth_config([]))
+
+    # Assert
+    assert "    location /auth/ {" in nginx_conf
+
+
+# ---------------------------------------------------------------------------
+# Task 3.5: upstream cookie stripping
+# ---------------------------------------------------------------------------
+
+
+def test_cookie_strip_on_every_proxied_user_location() -> None:
+    """No browser cookie reaches a per-user container.
+
+    One cookie jar serves the whole origin, so an operator with several users
+    unlocked would otherwise hand each container a session cookie naming all of
+    them — and these containers run agent-generated code, so anything readable
+    inside one has effectively left the perimeter.
+    """
+    # Arrange
+    users = ["alice", "bob", "carol"]
+
+    # Act
+    nginx_conf = _render_nginx(_auth_config(users))
+
+    # Assert
+    for user in users:
+        assert 'proxy_set_header Cookie "";' in _location_body(nginx_conf, f"location /u/{user}/")
+
+
+def test_cookie_strip_spares_the_sidecar_locations() -> None:
+    """The sidecar is the one upstream that MUST see the cookie — it is the
+    thing that reads the session. Stripping it there would deny every request
+    and lock the deployment out."""
+    # Act
+    nginx_conf = _render_nginx(_auth_config(["alice"]))
+
+    # Assert
+    assert "Cookie" not in _location_body(nginx_conf, "location /auth/")
+    assert "Cookie" not in _directives(_location_body(nginx_conf, "location = /_osprey_auth/alice"))
+
+
+def test_cookie_strip_absent_when_method_is_none() -> None:
+    """Without authentication there is no auth cookie to keep out of a
+    container, and the render stays byte-identical to its pre-auth self."""
+    # Act
+    nginx_conf = _render_nginx(copy.deepcopy(_MULTI_USER_CONFIG))
+
+    # Assert
+    assert "Cookie" not in nginx_conf
+
+
+# ---------------------------------------------------------------------------
+# Task 3.3: content-negotiated 401
+# ---------------------------------------------------------------------------
+
+
+def test_negotiated_401_classifies_requests_by_accept_and_upgrade() -> None:
+    """A `map` decides navigation-vs-program from the Accept header, with the
+    Upgrade header concatenated in front of it.
+
+    The concatenation is what excludes WebSocket handshakes: an upgrade token
+    in front pushes `text/html` off the `^` anchor, so a handshake scores 0
+    whatever its Accept header claims.
+    """
+    # Act
+    nginx_conf = _render_nginx(_auth_config())
+
+    # Assert
+    assert "map $http_upgrade$http_accept $osprey_auth_wants_login_page {" in nginx_conf
+    map_body = re.search(
+        r"map \$http_upgrade\$http_accept \$osprey_auth_wants_login_page \{(.*?)\n\}",
+        nginx_conf,
+        flags=re.DOTALL,
+    )
+    assert map_body is not None
+    assert "default 0;" in map_body.group(1)
+    assert '"~*^text/html" 1;' in map_body.group(1)
+
+
+def test_negotiated_401_every_user_location_intercepts_with_the_shared_handler() -> None:
+    """Each `/u/<user>/` sends its 401 to the named handler and states, as a
+    render-time literal, which user the handler should prompt for.
+
+    `error_page 401 = @…` (with the `=`) is what lets the handler's own status
+    replace the 401 — without it a browser would receive a 401 carrying a
+    Location header, which it does not follow.
+    """
+    # Arrange
+    users = ["alice", "bob", "carol"]
+
+    # Act
+    nginx_conf = _render_nginx(_auth_config(users))
+
+    # Assert
+    for user in users:
+        body = _location_body(nginx_conf, f"location /u/{user}/")
+        assert f"set $osprey_auth_user {user};" in body
+        assert "error_page 401 = @osprey_auth_401;" in body
+
+
+def test_negotiated_401_handler_redirects_navigations_and_bares_everything_else() -> None:
+    """The handler redirects only when the map said "navigation", and answers a
+    bare 401 otherwise.
+
+    A blanket redirect would hand a JSON caller a page of login HTML and leave
+    an EventSource reconnecting forever against a login page that never becomes
+    the stream it asked for.
+    """
+    # Act
+    body = _location_body(_render_nginx(_auth_config()), "location @osprey_auth_401")
+
+    # Assert
+    assert "if ($osprey_auth_wants_login_page) {" in body
+    assert "return 302 /auth/login?user=$osprey_auth_user&next=$osprey_auth_next;" in body
+    # The unconditional fallthrough, outside the `if`.
+    assert re.search(r"\n        return 401;", body)
+
+
+def test_negotiated_401_return_to_is_allowlisted_never_a_raw_path_variable() -> None:
+    """The return-to emits `$osprey_auth_next` — and neither raw path variable.
+
+    `$uri` is decoded by the time it is read, so emitting it copies a decoded
+    CR LF straight into the Location header (response-header injection).
+    `$request_uri` is injection-safe but still client-controlled, and a leading
+    `//` in it reads as an absolute URL that walks the browser off-site. Only
+    the allowlist map produces a value that is safe to emit AND safe to trust.
+    """
+    # Act
+    nginx_conf = _render_nginx(_auth_config())
+    body = _location_body(nginx_conf, "location @osprey_auth_401")
+
+    # Assert
+    assert "next=$osprey_auth_next;" in body
+    directives = _directives(body)
+    assert "next=$uri" not in directives
+    assert "$request_uri" not in directives
+
+
+def test_negotiated_401_return_to_allowlist_rejects_injection_and_keeps_deep_links() -> None:
+    """The allowlist regex itself, exercised against what an attacker sends.
+
+    This runs the pattern the template actually emits rather than restating it,
+    so a widened character class fails here. nginx decodes percent-escapes
+    before this map is consulted, hence the decoded forms below: `%0d%0a`
+    arrives as a real CR LF, `%26` as a real `&`.
+    """
+    # Arrange
+    nginx_conf = _render_nginx(_auth_config())
+    pattern = re.search(r'\n    "~(\S+)" \$uri;', nginx_conf)
+    assert pattern is not None, "no allowlist entry in the $osprey_auth_next map"
+    # PCRE's `\z` is spelled `\Z` in Python; the anchor semantics are the same
+    # (end of subject, NOT "before a trailing newline" the way `$` behaves).
+    allowlist = re.compile(pattern.group(1).replace(r"\z", r"\Z"))
+
+    # Act / Assert — legitimate deep links survive
+    for path in (
+        "/u/alice/",
+        "/u/alice/files/notes_v2.1-final.txt",
+        "/u/alice-b/panel/~cache/x",
+    ):
+        assert allowlist.match(path), f"deep link {path!r} should round-trip"
+
+    # Act / Assert — every hostile decoded form collapses to the empty default
+    for path in (
+        "/u/alice/x\r\nX-Injected: yes",  # header injection
+        "/u/alice/x\nSet-Cookie: evil=1",  # session fixation on our own origin
+        "/u/alice/x\n",  # trailing bare LF: why the anchor is \z, not $
+        "/u/alice/x&user=bob",  # second `user` param wins in most parsers
+        "/u/alice/x?next=/u/bob/",  # smuggled query
+        "//evil.example.org/",  # protocol-relative open redirect
+        "/auth/login",  # outside every user prefix
+        "/u/alice/x y",  # raw space splits the header value
+    ):
+        assert not allowlist.match(path), f"{path!r} must not be reflected"
+
+
+def test_negotiated_401_every_redirect_is_relative_to_the_clients_own_origin() -> None:
+    """`absolute_redirect off` sits at SERVER level, not in one location.
+
+    Left on, nginx rebuilds a relative redirect target into an absolute URL
+    from `$host` plus its OWN listening port — wrong for the very topology
+    `auth.allow_insecure_http` exists to serve: behind a facility TLS
+    terminator, `https://facility/u/alice` becomes `http://facility:9080/u/alice/`,
+    downgrading the scheme and advertising the internal port. Scoping it to the
+    login handler alone would leave the `/u/<user>` bookmark 301s — a link an
+    operator is far more likely to have saved — still absolute.
+    """
+    # Act
+    nginx_conf = _render_nginx(_auth_config(["alice"]))
+    content = _server_blocks(nginx_conf)[0]
+
+    # Assert — declared before the first location, so every one inherits it
+    server_preamble = _directives(content).split("location", 1)[0]
+    assert "absolute_redirect off;" in server_preamble
+    assert content.count("absolute_redirect off;") == 1
+    assert "return 302 http" not in content
+    # The bookmark redirect is the one this placement exists to cover.
+    assert "return 301 /u/alice/;" in _location_body(nginx_conf, "location = /u/alice")
+
+
+def test_negotiated_401_login_target_is_the_public_auth_prefix() -> None:
+    """The place denied users are sent must itself be reachable without a
+    session — the redirect target lives under the ungated `/auth/` prefix."""
+    # Act
+    nginx_conf = _render_nginx(_auth_config())
+    body = _location_body(nginx_conf, "location @osprey_auth_401")
+
+    # Assert
+    assert "/auth/login" in body
+    assert "    location /auth/ {" in nginx_conf
+    assert "auth_request" not in _location_body(nginx_conf, "location /auth/")
+
+
+def test_negotiated_401_absent_when_method_is_none() -> None:
+    """Nothing to negotiate without authentication: no map, no `error_page`,
+    no handler."""
+    # Act
+    nginx_conf = _render_nginx(copy.deepcopy(_MULTI_USER_CONFIG))
+
+    # Assert
+    assert "$osprey_auth_wants_login_page" not in nginx_conf
+    assert "error_page" not in nginx_conf
+    assert "@osprey_auth_401" not in nginx_conf
+
+
+# ---------------------------------------------------------------------------
+# Task 3.4: TLS redirect server block
+# ---------------------------------------------------------------------------
+
+
+def _server_blocks(nginx_conf: str) -> list[str]:
+    """The top-level `server { … }` blocks, in render order.
+
+    Split on the closing brace in column 0, which only a top-level block has
+    (every nested `location` closes at an indent).
+    """
+    blocks = re.findall(r"^server \{\n(.*?)^\}$", nginx_conf, flags=re.DOTALL | re.MULTILINE)
+    assert blocks, "no top-level server block in the rendered fragment"
+    return blocks
+
+
+def test_tls_redirect_off_renders_exactly_one_server_block() -> None:
+    """Without TLS there is nothing to redirect to: one server, on the plain
+    port, serving everything — unchanged from before TLS was renderable."""
+    # Act
+    nginx_conf = _render_nginx(copy.deepcopy(_MULTI_USER_CONFIG))
+
+    # Assert
+    assert len(_server_blocks(nginx_conf)) == 1
+    assert "return 301 https://" not in nginx_conf
+    assert "listen 9080;" in nginx_conf
+
+
+def test_tls_redirect_splits_into_a_redirect_server_and_a_content_server() -> None:
+    """With TLS on, the plain port and 443 become two separate servers.
+
+    One server listening on both ports would answer the same content over
+    cleartext, and any session cookie it set would cross the network in the
+    clear — the exact risk TLS was enabled to remove.
+    """
+    # Act
+    blocks = _server_blocks(_render_nginx(_tls_config()))
+
+    # Assert
+    assert len(blocks) == 2
+    redirect, content = blocks
+    assert "listen 9080;" in redirect
+    assert "listen [::]:9080;" in redirect
+    assert "listen 443 ssl;" in content
+    assert "listen [::]:443 ssl;" in content
+    # Neither listener answers on the other's port.
+    assert "443" not in redirect
+    assert "listen 9080;" not in content
+
+
+def test_tls_redirect_server_serves_nothing_but_the_redirect() -> None:
+    """The plain-port server has no locations, no root, and no proxying — its
+    only content is the 301. Anything else served there would be served over
+    cleartext."""
+    # Act
+    redirect = _server_blocks(_render_nginx(_tls_config()))[0]
+
+    # Assert
+    assert "return 301 https://$host$request_uri;" in redirect
+    assert "location" not in redirect
+    assert "root " not in redirect
+    assert "proxy_pass" not in redirect
+    assert "auth_request" not in redirect
+
+
+def test_tls_redirect_target_is_the_requested_host_not_the_render_time_origin() -> None:
+    """The 301 goes to `$host` — the name the client actually used.
+
+    A deployment answers to more names than config knows (aliases, internal DNS
+    names, a bare IP); rewriting the host at render time would bounce those
+    clients to a name they may not resolve. `external_origin` is for values
+    that must be fixed at render time, like an IdP-registered redirect_uri.
+    """
+    # Arrange
+    config = _tls_config()
+    fqdn = config["deploy"]["fqdn"]
+
+    # Act
+    redirect = _server_blocks(_render_nginx(config))[0]
+
+    # Assert
+    assert "https://$host$request_uri" in redirect
+    assert fqdn not in redirect
+
+
+def test_tls_redirect_content_server_holds_the_cert_and_every_user_route() -> None:
+    """The 443 server is the sole content server: cert pair, landing page, and
+    every per-user route live there, not in the redirect server."""
+    # Arrange
+    config = _tls_config(["alice", "bob"])
+
+    # Act
+    content = _server_blocks(_render_nginx(config))[1]
+
+    # Assert
+    assert "ssl_certificate /etc/nginx/certs/dls.crt;" in content
+    assert "ssl_certificate_key /etc/nginx/certs/dls.key;" in content
+    assert "location = / {" in content
+    assert "location /u/alice/ {" in content
+    assert "location /u/bob/ {" in content
+
+
+def test_tls_redirect_leaves_the_auth_surface_only_on_the_secure_server() -> None:
+    """With auth and TLS both on, the login flow and the per-user gates exist
+    only behind TLS — there is no plain-http path to a login form, so no cookie
+    can be issued on the cleartext origin."""
+    # Arrange
+    config = _auth_config()
+    config["modules"]["web_terminals"]["auth"].pop("allow_insecure_http")
+    config["modules"]["web_terminals"]["tls"] = {
+        "enabled": True,
+        "cert": "/etc/nginx/certs/dls.crt",
+        "key": "/etc/nginx/certs/dls.key",
+    }
+
+    # Act
+    redirect, content = _server_blocks(_render_nginx(config))
+
+    # Assert
+    assert "location /auth/" not in redirect
+    assert "_osprey_auth" not in redirect
+    assert "location /auth/ {" in content
+    assert "auth_request /_osprey_auth/alice;" in content
+    # Count-equality across the two-server matrix: every gated location and
+    # every auth target lives in the 443 server and nowhere else, so the split
+    # cannot silently leave a duplicate of one on the cleartext listener.
+    users = config["modules"]["web_terminals"]["users"]
+    assert _directives(content).count("auth_request ") == len(users)
+    assert _directives(redirect).count("auth_request ") == 0
+    assert content.count("location = /_osprey_auth/") == len(users)
+    assert redirect.count("location") == 0
+
+
 def test_nginx_landing_location_is_exact_match_only() -> None:
     """The landing page is served for `/` ONLY — every other unmatched path 404s.
 
@@ -1321,3 +2383,427 @@ def test_nginx_landing_location_is_exact_match_only() -> None:
     # Assert
     assert "location = / {" in nginx_conf
     assert not re.search(r"location / \{", nginx_conf)
+
+
+# ---------------------------------------------------------------------------
+# Task 4.4: the auth sidecar's compose service, and the secrets isolation
+# between it and the per-user containers
+# ---------------------------------------------------------------------------
+
+
+def _compose(config: dict) -> dict:
+    """The rendered compose overlay, parsed."""
+    return yaml.safe_load(render_web_terminals(config)["docker-compose.web.yml"])
+
+
+def _env_names(service: dict) -> list[str]:
+    """The env-var names a compose service declares inline, in rendered order."""
+    return [line.split("=", 1)[0] for line in service.get("environment", [])]
+
+
+def test_auth_sidecar_service_is_absent_for_method_none() -> None:
+    """The default posture renders the overlay it renders today: no sidecar service,
+    no auth environment, no reference to the credential file. Every deployment that
+    has not opted into authentication must be untouched by this feature."""
+    # Arrange
+    config = copy.deepcopy(_MULTI_USER_CONFIG)
+
+    # Act
+    rendered = render_web_terminals(config)["docker-compose.web.yml"]
+
+    # Assert
+    assert set(yaml.safe_load(rendered)["services"]) == {
+        "nginx",
+        "web-alice",
+        "web-bob",
+        "web-carol",
+    }
+    assert "OSPREY_AUTH" not in rendered
+    assert AUTH_ENV_FILENAME not in rendered
+
+
+def test_auth_sidecar_service_is_the_only_service_authentication_adds() -> None:
+    """Turning auth on adds exactly one service — `auth` — and changes nothing about
+    the per-user set. The name is deliberately not `web-auth`: usernames render as
+    `web-<user>`, so a roster user named "auth" would collide with that spelling but
+    cannot collide with this one."""
+    # Act
+    services = set(_compose(_auth_config())["services"])
+
+    # Assert
+    assert services == {"auth", "nginx", "web-alice", "web-bob", "web-carol"}
+
+
+def test_auth_sidecar_service_serves_a_single_uvicorn_bound_to_loopback() -> None:
+    """The sidecar binds the loopback address on `auth.port` under host networking,
+    exactly like the per-user apps: nginx shares the netns and is the only intended
+    caller, so the login surface is unreachable off-host on its own port.
+
+    Single process, not a worker pool — the revocation list and the brute-force
+    throttle are in-memory, so a second worker would answer from a different view of
+    both (a logged-out session still valid on whichever worker missed the logout).
+    """
+    # Act
+    auth = _compose(_auth_config(port=9411))["services"]["auth"]
+
+    # Assert
+    assert auth["command"] == [
+        "uvicorn",
+        "osprey.services.auth_sidecar.app:create_app",
+        "--factory",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "9411",
+    ]
+    assert "--workers" not in auth["command"]
+    assert auth["network_mode"] == "host"
+
+
+def test_auth_sidecar_service_image_defaults_to_the_local_build_tag() -> None:
+    """Local mode: no `auth.image`, so the service names the tag the runtime build
+    produces — the persona-image pattern (`<project>-<name>:local`) applied to the
+    sidecar, whose project is resolve_personas()'s default `<prefix>-assistant`."""
+    # Act
+    auth = _compose(_auth_config())["services"]["auth"]
+
+    # Assert
+    assert auth["image"] == "dls-assistant-auth:local"
+
+
+def test_auth_sidecar_service_image_pins_a_configured_registry_image() -> None:
+    """Registry mode: `auth.image` is used verbatim — publishing it is the facility
+    CI's job, and nothing is built on the deploy host."""
+    # Arrange
+    image = "git.dls.example.org:5050/physics/production/dls-auth:2026.8.1"
+
+    # Act
+    auth = _compose(_auth_config(image=image))["services"]["auth"]
+
+    # Assert
+    assert auth["image"] == image
+
+
+def test_auth_sidecar_service_carries_the_roster_in_declaration_order() -> None:
+    """The sidecar answers for exactly the users nginx routes to, from the same
+    resolved `services` list — a user cannot exist in one and be missing from the
+    other. Order is the roster's declaration order, which the login page reuses."""
+    # Act
+    auth = _compose(_auth_config(["carol", "alice"]))["services"]["auth"]
+
+    # Assert
+    assert f"{ENV_USERS}=carol,alice" in auth["environment"]
+
+
+def test_auth_sidecar_service_environment_is_exactly_the_non_secret_settings() -> None:
+    """The inline `environment:` block is pinned key for key, and every key in it is
+    non-secret. This is the assertion that fails if a later task reaches for a secret
+    here instead of `.env.auth`: compose interpolates `environment:` values (a stored
+    `scrypt$...` hash would be eaten by `$` expansion) and, unlike an env_file, the
+    values land in the committed compose artifact."""
+    # Act
+    auth = _compose(_auth_config())["services"]["auth"]
+
+    # Assert
+    assert _env_names(auth) == [
+        "TZ",
+        ENV_METHOD,
+        ENV_SESSION_LIFETIME,
+        ENV_TLS_ENABLED,
+        ENV_EXTERNAL_ORIGIN,
+        ENV_USERS,
+    ]
+
+
+def test_auth_sidecar_service_tls_flag_and_origin_follow_the_deployment() -> None:
+    """`OSPREY_AUTH_TLS_ENABLED` is not about the sidecar's own listener (nginx
+    terminates TLS; nothing is mounted here) — it decides the `Secure` attribute on
+    the cookies it issues, so it must track the public origin, not the local bind."""
+    # Arrange
+    plain = _auth_config()
+    secured = _auth_config()
+    secured["modules"]["web_terminals"]["tls"] = {
+        "enabled": True,
+        "cert": "/etc/nginx/certs/dls.crt",
+        "key": "/etc/nginx/certs/dls.key",
+    }
+
+    # Act
+    plain_env = _compose(plain)["services"]["auth"]["environment"]
+    secured_env = _compose(secured)["services"]["auth"]["environment"]
+
+    # Assert
+    assert f"{ENV_TLS_ENABLED}=false" in plain_env
+    assert f"{ENV_EXTERNAL_ORIGIN}=http://dls-deploy.dls.example.org:9080" in plain_env
+    assert f"{ENV_TLS_ENABLED}=true" in secured_env
+    assert f"{ENV_EXTERNAL_ORIGIN}=https://dls-deploy.dls.example.org" in secured_env
+
+
+def test_auth_sidecar_service_names_oidc_credential_variables_only_in_oidc_mode() -> None:
+    """`oidc` mode adds the issuer plus the NAMES of the two variables holding the
+    client credentials — one level of indirection, so the credentials themselves stay
+    in `.env.auth` under whatever names the facility already uses.
+
+    Password mode emits none of it rather than an inert empty issuer, and the whole
+    OIDC group is gated on the mode: the password roster here still declares an
+    `oidc_subject` left over from an earlier posture, and none of it renders.
+    """
+    # Arrange
+    issuer = "https://sso.dls.example.org/realms/facility"
+    password_roster = [{"name": "alice", "index": 0, "oidc_subject": "alice@dls.example.org"}]
+
+    # Act
+    password_env = _compose(_auth_config(password_roster))["services"]["auth"]["environment"]
+    oidc_env = _compose(
+        _auth_config(
+            method="oidc",
+            oidc={
+                "issuer": issuer,
+                "client_id_env": "DLS_SSO_CLIENT_ID",
+                "client_secret_env": "DLS_SSO_CLIENT_SECRET",
+            },
+        )
+    )["services"]["auth"]["environment"]
+
+    # Assert
+    assert not [line for line in password_env if "OIDC" in line]
+    assert f"{ENV_OIDC_ISSUER}={issuer}" in oidc_env
+    assert f"{ENV_OIDC_CLIENT_ID_ENV}=DLS_SSO_CLIENT_ID" in oidc_env
+    assert f"{ENV_OIDC_CLIENT_SECRET_ENV}=DLS_SSO_CLIENT_SECRET" in oidc_env
+    # The variable names are named; the credentials behind them never appear.
+    assert not [line for line in oidc_env if line.startswith("DLS_SSO_CLIENT")]
+
+
+def test_auth_sidecar_service_maps_each_users_oidc_subject_from_the_roster() -> None:
+    """The non-secret half of the roster->identity mapping travels from the roster
+    entry to the sidecar's environment under the name `env_var_suffix()` gives it —
+    asserted against that function rather than a hardcoded literal, so this test
+    cannot quietly disagree with the mapping that keys the password hashes.
+
+    The value is quoted as a whole `KEY=value` scalar because a subject is typically
+    an email or a DN, and a DN's `": "` would otherwise derail the YAML parse. A
+    roster user who declares no subject gets no line at all, rather than an empty one
+    that would map every unidentified caller onto them.
+    """
+    # Arrange
+    config = _auth_config(
+        [
+            {"name": "alice", "index": 0, "oidc_subject": "cn=Alice Smith, ou=Users"},
+            {"name": "dana-b", "index": 1, "oidc_subject": "dana@dls.example.org"},
+            "bob",
+        ],
+        method="oidc",
+        oidc={"issuer": "https://sso.dls.example.org"},
+    )
+
+    # Act
+    auth_env = _compose(config)["services"]["auth"]["environment"]
+
+    # Assert — the suffix is whatever env_var_suffix() says it is, including for
+    # the hyphenated name, which is where a hand-rolled second mapping would drift.
+    assert (
+        f"{ENV_OIDC_SUBJECT_PREFIX}{env_var_suffix('alice')}=cn=Alice Smith, ou=Users" in auth_env
+    )
+    assert f"{ENV_OIDC_SUBJECT_PREFIX}{env_var_suffix('dana-b')}=dana@dls.example.org" in auth_env
+    assert not [
+        line
+        for line in auth_env
+        if line.startswith(f"{ENV_OIDC_SUBJECT_PREFIX}{env_var_suffix('bob')}")
+    ]
+
+
+def test_auth_sidecar_service_omits_the_oidc_claim_unless_the_facility_names_one() -> None:
+    """No configured claim means no env line, so the sidecar applies its own
+    documented default. Restating that default in the renderer would give the
+    deployment two places to change it and one of them would eventually be wrong."""
+    # Act
+    auth_env = _compose(
+        _auth_config(method="oidc", oidc={"issuer": "https://sso.dls.example.org"})
+    )["services"]["auth"]["environment"]
+
+    # Assert
+    assert not [line for line in auth_env if line.startswith("OSPREY_AUTH_OIDC_CLAIM")]
+
+
+def test_auth_sidecar_service_names_a_configured_non_default_oidc_claim() -> None:
+    """An IdP that carries the mappable identity somewhere other than `sub` (a
+    facility SSO keyed on `email` or `preferred_username`) is configured by name, and
+    that name reaches the sidecar."""
+    # Act
+    auth_env = _compose(
+        _auth_config(
+            method="oidc",
+            oidc={"issuer": "https://sso.dls.example.org", "claim": "preferred_username"},
+        )
+    )["services"]["auth"]["environment"]
+
+    # Assert
+    assert "OSPREY_AUTH_OIDC_CLAIM=preferred_username" in auth_env
+
+
+def test_auth_context_reads_the_oidc_claim_and_leaves_it_none_when_unusable() -> None:
+    """The parse side of the claim: configured strings come through, and anything
+    unusable (absent, blank, wrong-typed) resolves to None — this module's defensive
+    -read convention, and the value that makes the sidecar's default apply."""
+    # Arrange
+    configured = copy.deepcopy(_MULTI_USER_CONFIG)["modules"]["web_terminals"]
+    configured["auth"] = {"method": "oidc", "oidc": {"claim": "email"}}
+    malformed = copy.deepcopy(_MULTI_USER_CONFIG)["modules"]["web_terminals"]
+    malformed["auth"] = {"method": "oidc", "oidc": {"claim": ["not", "a", "string"]}}
+    blank = copy.deepcopy(_MULTI_USER_CONFIG)["modules"]["web_terminals"]
+    blank["auth"] = {"method": "oidc", "oidc": {"claim": "   "}}
+
+    # Act / Assert
+    assert _auth_tls_context(configured)["auth_oidc_claim"] == "email"
+    assert _auth_tls_context(malformed)["auth_oidc_claim"] is None
+    assert _auth_tls_context(blank)["auth_oidc_claim"] is None
+    assert (
+        _auth_tls_context(copy.deepcopy(_MULTI_USER_CONFIG)["modules"]["web_terminals"])[
+            "auth_oidc_claim"
+        ]
+        is None
+    )
+
+
+def test_auth_sidecar_service_healthcheck_probes_its_own_health_route() -> None:
+    """`/health` answers 200 even when the sidecar is unconfigured and refusing
+    everything, so the container stays up to explain the lockout instead of
+    crash-looping. Probed in-image with python: `curl` is not in an OSPREY service
+    image (the nginx service's curl probe runs in the nginx image)."""
+    # Act
+    auth = _compose(_auth_config(port=9411))["services"]["auth"]
+
+    # Assert
+    probe = auth["healthcheck"]["test"]
+    assert probe[0] == "CMD-SHELL"
+    assert "http://127.0.0.1:9411/health" in probe[1]
+    assert "curl" not in probe[1]
+
+
+def test_auth_env_isolation_secrets_reach_the_sidecar_only_through_env_file() -> None:
+    """`.env.auth` (0600, sidecar-only) is the sidecar's whole secret surface, and it
+    arrives as a service-level `env_file`. That is the only path that survives the
+    values intact: compose interpolates `environment:` entries, and a stored scrypt
+    hash (`scrypt$16384$8$1$salt$key`) is full of `$`."""
+    # Act
+    rendered = render_web_terminals(_auth_config())["docker-compose.web.yml"]
+    auth = yaml.safe_load(rendered)["services"]["auth"]
+
+    # Assert
+    assert auth["env_file"] == AUTH_ENV_FILENAME
+    for secret_var in (ENV_SESSION_SECRET, ENV_STATE_SECRET, ENV_PW_HASH_PREFIX):
+        assert secret_var not in rendered
+
+
+def test_auth_env_isolation_sidecar_never_reads_env_production() -> None:
+    """The inverse of the isolation rule: `.env.production` is the per-user
+    containers' shared env file (provider keys, facility credentials). The login
+    surface has no business reading it, and pulling it in would also drag the agent
+    tier's variables into the process that mints sessions."""
+    # Act
+    auth = _compose(_auth_config())["services"]["auth"]
+
+    # Assert
+    assert ".env.production" not in str(auth.get("env_file"))
+    assert not [name for name in _env_names(auth) if name.startswith("ANTHROPIC")]
+
+
+def test_auth_env_isolation_no_web_service_carries_an_auth_variable() -> None:
+    """The proposal's central isolation assertion. Every per-user container runs the
+    agent; the session signing key would let any user's agent mint a valid cookie for
+    every other user, which is exactly the isolation this feature establishes. So no
+    `web-*` service may carry an `OSPREY_AUTH_*` variable inline or reach `.env.auth`
+    through an env_file — while keeping the `.env.production` it has today."""
+    # Act
+    compose = _compose(_auth_config())
+
+    # Assert
+    for name, service in compose["services"].items():
+        if not name.startswith("web-"):
+            continue
+        assert service["env_file"] == ".env.production"
+        assert AUTH_ENV_FILENAME not in str(service["env_file"])
+        assert not [env for env in _env_names(service) if env.startswith("OSPREY_AUTH")]
+
+
+def test_render_auth_on_refuses_a_roster_name_outside_the_username_charset() -> None:
+    """Defense in depth on the render path itself. The charset is enforced by lint
+    (skippable with `--no-lint`) and by credential provisioning (password mode only),
+    so a malformed name could reach the renderer with neither having run — and the
+    name is written literally into an nginx location key and the verify subrequest's
+    `?user=` value. `bob&user=alice` would render a query carrying two user
+    parameters, making the authorized identity a function of how the sidecar's query
+    parser breaks the tie. With auth on, that is a refusal, not a render."""
+    # Arrange
+    injected = _auth_config(["alice", "bob&user=alice"])
+    uppercase = _auth_config(["Alice"])
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="modules.web_terminals.users") as exc_info:
+        render_web_terminals(injected)
+    message = str(exc_info.value)
+    # The offender is named, and only the offender — a message that just says
+    # "a username is invalid" leaves the operator grepping a 40-user roster.
+    assert "bob&user=alice" in message
+    assert "'alice'" not in message
+    assert "auth.method" in message
+    with pytest.raises(ValueError, match="Alice"):
+        render_web_terminals(uppercase)
+
+
+def test_render_auth_off_still_renders_a_roster_name_outside_the_charset() -> None:
+    """The gate is scoped to authentication being on. With `auth.method: none` the
+    username is a routing label rather than an authorization identity, and every
+    deployment rendering such a name today must keep rendering — lint still reports
+    it. Tightening this would be a silent breaking change for no security gain."""
+    # Arrange
+    config = _config(["alice", "bob.jones"])
+
+    # Act
+    compose = yaml.safe_load(render_web_terminals(config)["docker-compose.web.yml"])
+
+    # Assert
+    assert "web-bob.jones" in compose["services"]
+
+
+def test_render_auth_on_charset_gate_rejects_a_trailing_newline_in_a_roster_name() -> None:
+    """`$` in the charset pattern also matches *before* a trailing newline, so a
+    `.match()` gate would accept `"alice\\n"` — a name that renders into an nginx
+    location key mid-directive. The gate uses `.fullmatch()`; this pins that, because
+    the difference is invisible in every other test's inputs."""
+    # Act / Assert
+    with pytest.raises(ValueError, match="modules.web_terminals.users"):
+        render_web_terminals(_auth_config(["alice\n"]))
+
+
+def test_render_auth_on_refuses_roster_names_that_collide_on_their_env_var_suffix() -> None:
+    """`env_var_suffix()` is lossy: `alice-b` and `alice_b` both key `..._ALICE_B`, so
+    the pair would share ONE `OSPREY_AUTH_PW_HASH_ALICE_B` — one user's password
+    opening the other's terminal, the exact isolation failure this feature exists to
+    prevent.
+
+    Both names pass the charset check, so this needs its own gate. Downstream it is
+    caught only on the password-mode deploy path; in `oidc` mode it surfaces as a
+    whole-deployment 503 that names neither user. Render time knows both names, so it
+    says both.
+    """
+    # Act / Assert
+    with pytest.raises(ValueError, match="env-var suffix") as exc_info:
+        render_web_terminals(_auth_config(["alice-b", "alice_b"], method="oidc"))
+    message = str(exc_info.value)
+    assert "alice-b" in message
+    assert "alice_b" in message
+    assert env_var_suffix("alice-b") in message
+
+
+def test_render_auth_off_still_renders_roster_names_that_collide_on_their_suffix() -> None:
+    """Scoped like the charset gate: with no authentication there are no per-user
+    credential variables to collide over, so a roster that renders today keeps
+    rendering. Lint still reports the collision."""
+    # Act
+    compose = yaml.safe_load(
+        render_web_terminals(_config(["alice-b", "alice_b"]))["docker-compose.web.yml"]
+    )
+
+    # Assert
+    assert {"web-alice-b", "web-alice_b"} <= set(compose["services"])

--- a/tests/e2e/web_terminals/test_auth_perimeter.py
+++ b/tests/e2e/web_terminals/test_auth_perimeter.py
@@ -1,0 +1,495 @@
+"""Acceptance proof that ``osprey deploy up`` stands up a WORKING login perimeter
+from the **real** auth-sidecar image.
+
+WHAT THIS FILE IS FOR, AND WHAT IT DELIBERATELY DOES NOT DUPLICATE
+-----------------------------------------------------------------
+``tests/deployment/web_terminals/test_auth_serving.py`` already covers the
+perimeter's *semantics* exhaustively — header injection, cookie scope, cross-user
+isolation, expiry, rotation, logout — against a composed nginx + sidecar stack.
+It builds a deliberately NARROW harness image, though: only the sidecar's import
+closure, with each package's specifier read from the distribution's own metadata.
+That design is what makes a missing *declaration* fail loudly (drop
+``python-multipart`` from ``pyproject.toml`` and its login-POST test goes red),
+and it is the right trade for a test that runs in the ordinary unit lane.
+
+What it cannot catch is a break confined to the DEPLOYED Dockerfile
+(``templates/modules/web_terminals/auth_sidecar/Dockerfile``): a bad base image,
+a wrong ``COPY``, a system library that stopped being installed. Nothing else in
+the suite builds that file, so such a break would reach a facility untested.
+
+This file is the one job that builds it. It is therefore deliberately NARROW in
+the other direction — it asks only the questions that need the real image and a
+real deploy, and leaves every semantic question to the unit lane:
+
+  T1  ``deploy up`` BUILDS the real sidecar image, labeled with this
+      deployment's project (what ``nuke`` verifies before removing a tag).
+  T2  The sidecar container comes up and its ``/health`` reports ``configured``
+      — i.e. the image can actually import and run the app, and it found the
+      credentials the same deploy provisioned.
+  T3  An unauthenticated request for a user's terminal is REFUSED at nginx.
+  T4  A real login unlocks that user, and the authorized request reaches THAT
+      USER'S upstream container — proving the whole chain (login → cookie →
+      ``auth_request`` → prefix-stripped proxy) works on the deployed artifacts,
+      not just on a harness.
+
+WHY THE PERSONA STUB SERVES HTTP HERE
+-------------------------------------
+The other lifecycle fixtures use an alpine stub that only idles (``tail -f
+/dev/null``), which is enough to inspect and exec into. That is NOT enough here:
+with a dead upstream, an authorized request returns 502 and a REFUSED one
+returns 401, so the test would be asserting on the difference between two
+failures. The stub below serves one byte-identifiable page over busybox
+``httpd``, so T4 can assert it received the response ALICE'S OWN container
+produced — the positive control that distinguishes "auth let it through" from
+"auth let it through and the proxy pointed somewhere else".
+
+COST, AND WHY THIS IS ITS OWN LANE
+----------------------------------
+Building the real sidecar means ``pip install osprey-framework`` with a C
+toolchain — minutes, cold, on every run. The multi-user lifecycle lane is
+all-stub and fast, and folding this into it would have made every lifecycle run
+pay that. It lives in its own CI lane so the cost is visible on its own line.
+
+``--dev`` is REQUIRED, not incidental: the Dockerfile pins
+``osprey-framework==$OSPREY_VERSION``, and a source checkout's version is not on
+PyPI. ``--dev`` sets ``OSPREY_DEV=1`` (relaxing the pin miss to an unpinned
+prime) and stages the locally-built wheel the image then overlays, so what runs
+here is this branch's code rather than a release.
+
+CONTAINER-OPS SAFETY: every runtime-mutating call below names an EXACT resource
+this test created — the ``<prefix>-nginx`` / ``<prefix>-auth`` / ``<prefix>-web-
+<user>`` containers, this project's volumes, and the ``:local`` image tags — or
+is the project-scoped ``compose down`` the deploy lifecycle itself uses. Nothing
+here ever runs a prune, an ``-a``/``--all`` sweep, or a wildcard removal.
+"""
+
+from __future__ import annotations
+
+import http.cookiejar
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+# ``dockerbuild`` is load-bearing, not descriptive: a guard in
+# tests/deployment/test_ci_workflow_wiring.py requires every file carrying it to
+# be --ignore'd in the shared e2e-tests lane AND given its own job. Without the
+# marker this file would be swept into that lane's glob over tests/e2e/ and the
+# expensive sidecar build would run twice per PR.
+pytestmark = [pytest.mark.e2e, pytest.mark.dockerbuild]
+
+_SUPPORTED_RUNTIMES = ("docker", "podman")
+RUNTIME = os.environ.get("OSPREY_E2E_RUNTIME", "docker")
+if RUNTIME not in _SUPPORTED_RUNTIMES:
+    raise RuntimeError(
+        f"OSPREY_E2E_RUNTIME={RUNTIME!r} is not supported; expected one of {_SUPPORTED_RUNTIMES}"
+    )
+
+PROJECT_NAME = "osprey-e2e-auth-perimeter"
+PREFIX = "authe2e"
+PERSONA = "operator"
+PERSONA_PROJECT = f"{PREFIX}-operator"
+USERS = ("alice", "bob")
+
+# Ports well clear of every other stack a developer may have up (the tutorial
+# stacks hold 5064/5080/5432, and the lifecycle fixtures the 9000s/19081).
+NGINX_PORT = 19180
+AUTH_PORT = 19170
+BASE_PORTS = {
+    "web": 19191,
+    "artifact": 19291,
+    "ariel": 19391,
+    "lattice": 19491,
+    "channel_finder": 19591,
+}
+
+#: Served by each user's stub upstream, so an authorized response can be traced
+#: back to the container that produced it.
+UPSTREAM_MARKER = "osprey-e2e-auth-perimeter upstream"
+
+AUTH_IMAGE_TAG = f"{PREFIX}-assistant-auth:local"
+PERSONA_IMAGE_TAG = f"{PERSONA_PROJECT}:local"
+
+NGINX_C = f"{PREFIX}-nginx"
+AUTH_C = f"{PREFIX}-auth"
+
+# The sidecar build is a real framework install; everything else here is alpine.
+DEPLOY_UP_TIMEOUT_SEC = 1800
+VERB_TIMEOUT_SEC = 120
+READY_TIMEOUT_SEC = 120.0
+
+#: Seeded per user in the project ``.env`` as ``OSPREY_AUTH_PW_<USER>``, the
+#: documented way to set a password you already chose (provisioning step 2).
+#: Deterministic on purpose: the alternative — scraping the password ``deploy
+#: up`` prints for a generated credential — reads a rich-rendered line that may
+#: wrap, which would split the secret at an arbitrary column. What that print
+#: does is covered where it belongs, in the credential unit tests.
+_PASSWORDS = {"alice": "alice-e2e-pw-correct", "bob": "bob-e2e-pw-correct"}
+
+_ENV_CONTENT = "ANTHROPIC_API_KEY=fake-llm-key-value\n" + "".join(
+    f"OSPREY_AUTH_PW_{user.upper()}={password}\n" for user, password in _PASSWORDS.items()
+)
+
+
+def _web_container(user: str) -> str:
+    return f"{PREFIX}-web-{user}"
+
+
+def _runtime_cli(*args: str, timeout: int = 30) -> subprocess.CompletedProcess:
+    return subprocess.run([RUNTIME, *args], capture_output=True, text=True, timeout=timeout)
+
+
+def _fmt(label: str, result: subprocess.CompletedProcess) -> str:
+    return (
+        f"{label} failed (rc={result.returncode}):\n"
+        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )
+
+
+def _find_osprey_console_script() -> Path:
+    candidate = Path(sys.executable).parent / "osprey"
+    if candidate.exists():
+        return candidate
+    found = shutil.which("osprey")
+    if found:
+        return Path(found)
+    raise RuntimeError("Could not locate the 'osprey' console script.")
+
+
+def _run_osprey(
+    osprey_bin: Path, args: list[str], cwd: Path, timeout: int = VERB_TIMEOUT_SEC
+) -> subprocess.CompletedProcess:
+    """Run an ``osprey`` verb with the deploy-side runtime pinned to RUNTIME.
+
+    Deliberately does NOT set ``OSPREY_PIP_SPEC``: the lifecycle fixtures poison
+    it so a stub Dockerfile that ever started consuming it would fail loudly, but
+    the sidecar image here is a REAL framework install and must resolve normally.
+    """
+    return subprocess.run(
+        [str(osprey_bin), *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env={**os.environ, "CLAUDECODE": "", "CONTAINER_RUNTIME": RUNTIME},
+    )
+
+
+def _container_id(name: str) -> str | None:
+    result = _runtime_cli("inspect", "--type", "container", "-f", "{{.Id}}", name, timeout=15)
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def _image_exists(tag: str) -> bool:
+    return _runtime_cli("inspect", "--type", "image", tag, timeout=15).returncode == 0
+
+
+def _image_label(tag: str, key: str) -> str | None:
+    result = _runtime_cli(
+        "inspect",
+        "--type",
+        "image",
+        "-f",
+        f'{{{{ index .Config.Labels "{key}" }}}}',
+        tag,
+        timeout=15,
+    )
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def _logs(name: str) -> str:
+    result = _runtime_cli("logs", "--tail", "80", name, timeout=20)
+    return f"--- {name} stdout ---\n{result.stdout}\n--- {name} stderr ---\n{result.stderr}"
+
+
+def _write_persona_project(root: Path) -> Path:
+    """A minimal local-mode persona project whose stub actually SERVES.
+
+    Beyond what the idling lifecycle stub provides (a ``dispatch`` user and the
+    two mount-point directories the per-user compose service declares volumes
+    onto), this one runs busybox ``httpd`` on the port compose hands it, so an
+    authorized request through nginx has something real to reach. Binding
+    ``127.0.0.1`` mirrors the production app: nginx shares the host network
+    namespace and is the only thing meant to reach a per-user port.
+
+    ``busybox-extras`` is REQUIRED and easy to lose: alpine's default busybox
+    does NOT include the ``httpd`` applet, so without this package the CMD dies
+    with "httpd: not found", the container crashloops, and the failure surfaces
+    far from its cause — as ``deploy up`` aborting because it could not seed a
+    container that never stayed up.
+    """
+    root.mkdir(parents=True)
+    (root / "config.yml").write_text(f"project_name: {PERSONA_PROJECT}\n", encoding="utf-8")
+    container_dir = f"/app/{PERSONA_PROJECT}"
+    (root / "Dockerfile").write_text(
+        "FROM alpine:3.20\n"
+        # busybox-extras carries the httpd applet; the base busybox does not.
+        "RUN apk add --no-cache busybox-extras \\\n"
+        "    && adduser -D dispatch \\\n"
+        "    && mkdir -p /data/claude-config \\\n"
+        f"    && mkdir -p {container_dir}/_agent_data \\\n"
+        f"    && mkdir -p {container_dir}/.claude/skills \\\n"
+        f"    && chown -R dispatch:dispatch /data/claude-config {container_dir} \\\n"
+        # /srv belongs to dispatch too: the CMD writes index.html at start-up,
+        # and a root-owned directory would make that write the next crashloop.
+        "    && mkdir -p /srv \\\n"
+        "    && chown -R dispatch:dispatch /srv\n"
+        # Written at START-UP, not build time: OSPREY_TERMINAL_USER and
+        # OSPREY_TERMINAL_WEB_PORT are per-user values compose supplies to the
+        # container, so one image serves every user and each page names the
+        # container that produced it. That marker is what makes T4 a proof of
+        # ROUTING rather than merely of authorization.
+        'CMD ["sh", "-c", "echo '
+        f"'{UPSTREAM_MARKER} for '"
+        '\\"$OSPREY_TERMINAL_USER\\" > /srv/index.html; '
+        'exec httpd -f -p 127.0.0.1:\\"$OSPREY_TERMINAL_WEB_PORT\\" -h /srv"]\n',
+        encoding="utf-8",
+    )
+    return root
+
+
+def _config_dict(persona_path: Path) -> dict[str, Any]:
+    """Local-mode facility config with password auth over cleartext.
+
+    ``allow_insecure_http`` is what lets auth render without TLS. That is the
+    documented posture for a deployment behind a TLS terminator, and here it
+    keeps the test off certificate management — the TLS mount has its own
+    render-level coverage in ``tests/deployment/web_terminals/test_auth_tls_seams.py``.
+    """
+    return {
+        "project_name": PROJECT_NAME,
+        "container_runtime": RUNTIME,
+        "facility": {"name": "E2E Auth Perimeter Fixture", "prefix": PREFIX, "timezone": "UTC"},
+        "llm": {"api_key_env_var": "ANTHROPIC_API_KEY"},
+        "deploy": {"fqdn": "127.0.0.1"},
+        "deployed_services": [],
+        "modules": {
+            "web_terminals": {
+                "enabled": True,
+                "image_source": "local",
+                "default_persona": PERSONA,
+                "personas": {
+                    PERSONA: {"project": PERSONA_PROJECT, "project_path": str(persona_path)}
+                },
+                "nginx_port": NGINX_PORT,
+                "web_base_port": BASE_PORTS["web"],
+                "artifact_base_port": BASE_PORTS["artifact"],
+                "ariel_base_port": BASE_PORTS["ariel"],
+                "lattice_base_port": BASE_PORTS["lattice"],
+                "channel_finder_base_port": BASE_PORTS["channel_finder"],
+                "users": list(USERS),
+                "auth": {
+                    "method": "password",
+                    "port": AUTH_PORT,
+                    "allow_insecure_http": True,
+                },
+            }
+        },
+    }
+
+
+def _make_project_dir(tmp_path: Path) -> Path:
+    persona_path = _write_persona_project(tmp_path / "persona")
+    dest = tmp_path / "project"
+    dest.mkdir()
+    (dest / "config.yml").write_text(
+        yaml.safe_dump(_config_dict(persona_path), sort_keys=False), encoding="utf-8"
+    )
+    (dest / ".env").write_text(_ENV_CONTENT, encoding="utf-8")
+    context_dir = dest / "docker" / "web-terminal-context"
+    context_dir.mkdir(parents=True)
+    (context_dir / "base.md").write_text("# auth perimeter e2e\n", encoding="utf-8")
+    return dest
+
+
+def _teardown() -> None:
+    """Exact-named sweep; failures swallowed (a safety net, never an assertion)."""
+    for user in USERS:
+        _runtime_cli("rm", "-f", _web_container(user))
+    _runtime_cli("rm", "-f", AUTH_C)
+    _runtime_cli("rm", "-f", NGINX_C)
+    _runtime_cli("compose", "-p", PROJECT_NAME, "down", timeout=60)
+    for tag in (AUTH_IMAGE_TAG, PERSONA_IMAGE_TAG):
+        _runtime_cli("rmi", "-f", tag, timeout=60)
+
+
+def _browser() -> tuple[urllib.request.OpenerDirector, http.cookiejar.CookieJar]:
+    """A client that keeps cookies the way a browser does.
+
+    Login answers ``303 See Other`` and sets the session cookie on THAT response,
+    so a plain ``urlopen`` — which follows the redirect itself — returns the
+    followed response's headers and the cookie is gone by the time the caller
+    sees anything. A cookie jar captures it mid-redirect and replays it on every
+    later request through the same opener, which is both what a browser does and
+    what makes the assertions here about the session rather than about headers.
+    """
+    jar = http.cookiejar.CookieJar()
+    return urllib.request.build_opener(urllib.request.HTTPCookieProcessor(jar)), jar
+
+
+def _request(
+    target: str,
+    *,
+    method: str = "GET",
+    headers: dict[str, str] | None = None,
+    data: bytes | None = None,
+    port: int = NGINX_PORT,
+    opener: urllib.request.OpenerDirector | None = None,
+) -> tuple[int, dict[str, str], str]:
+    """One HTTP request, returning (status, headers, body) and never raising on 4xx/5xx.
+
+    Pass ``opener`` (from :func:`_browser`) to carry a session across requests;
+    omit it for the unauthenticated probes, which must carry nothing.
+    """
+    req = urllib.request.Request(  # noqa: S310 - loopback only
+        f"http://127.0.0.1:{port}{target}", method=method, data=data
+    )
+    for key, value in (headers or {}).items():
+        req.add_header(key, value)
+    open_it = opener.open if opener is not None else urllib.request.urlopen
+    try:
+        with open_it(req, timeout=15) as resp:  # noqa: S310 - loopback only
+            return resp.status, dict(resp.headers), resp.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as exc:
+        return exc.code, dict(exc.headers), exc.read().decode("utf-8", "replace")
+
+
+def _wait_for_health(timeout: float) -> dict[str, Any]:
+    """Poll the sidecar's own /health until it answers, or fail with its logs.
+
+    A dead sidecar is the failure this lane exists to catch, so the message on
+    timeout carries the container's logs — an image that cannot import the app
+    says so there and nowhere else.
+    """
+    deadline = time.monotonic() + timeout
+    last = "(no attempt yet)"
+    while time.monotonic() < deadline:
+        try:
+            status, _, body = _request("/health", port=AUTH_PORT)
+            if status == 200:
+                return json.loads(body)
+            last = f"HTTP {status}: {body[:200]}"
+        except (urllib.error.URLError, ConnectionError, OSError) as exc:
+            last = str(exc)
+        time.sleep(2.0)
+    raise AssertionError(
+        f"auth sidecar /health not ready after {timeout:.0f}s (last: {last})\n{_logs(AUTH_C)}"
+    )
+
+
+def _navigation() -> dict[str, str]:
+    """The ``Accept`` a browser sends when a person navigates to a URL."""
+    return {"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}
+
+
+@pytest.fixture(scope="module")
+def deployment(tmp_path_factory: pytest.TempPathFactory) -> Iterator[dict[str, Any]]:
+    """One ``deploy up --dev`` for the whole module — the expensive part runs once."""
+    if shutil.which(RUNTIME) is None:
+        pytest.skip(f"{RUNTIME} not available")
+    if _runtime_cli("ps", timeout=10).returncode != 0:
+        pytest.skip(f"{RUNTIME} daemon not responding")
+
+    tmp_path = tmp_path_factory.mktemp("auth-perimeter")
+    project_dir = _make_project_dir(tmp_path)
+    osprey_bin = _find_osprey_console_script()
+
+    _teardown()  # clear anything a previous crashed run stranded under these names
+    try:
+        up = _run_osprey(
+            osprey_bin, ["deploy", "up", "--dev"], project_dir, timeout=DEPLOY_UP_TIMEOUT_SEC
+        )
+        assert up.returncode == 0, _fmt("deploy up --dev (auth perimeter)", up)
+        health = _wait_for_health(READY_TIMEOUT_SEC)
+        yield {"project_dir": project_dir, "health": health, "up": up}
+    finally:
+        _teardown()
+
+
+def test_deploy_up_builds_the_real_sidecar_image(deployment: dict[str, Any]) -> None:
+    """T1: the DEPLOYED Dockerfile builds, and the tag carries this project's label.
+
+    The image is what every other assertion in this file runs against, and it is
+    the artifact no other job in the suite produces. The ownership label matters
+    on its own: ``nuke`` verifies it before removing a tag, so an unlabeled image
+    would survive a full teardown.
+    """
+    assert _image_exists(AUTH_IMAGE_TAG), f"{AUTH_IMAGE_TAG} was not built by 'deploy up'"
+    assert _image_label(AUTH_IMAGE_TAG, "com.osprey.project") == PROJECT_NAME
+
+
+def test_the_sidecar_runs_and_reports_itself_configured(deployment: dict[str, Any]) -> None:
+    """T2: the container starts, the app imports, and it found this deploy's credentials.
+
+    ``configured: false`` is the sidecar's fail-closed posture when it has no
+    credentials — it still answers ``/health`` and refuses every other path. A
+    ``true`` here therefore proves two separate things landed: the image can run
+    the app at all, and the ``.env.auth`` the SAME deploy provisioned reached it.
+    """
+    assert _container_id(AUTH_C) is not None, f"{AUTH_C} was not created"
+    assert deployment["health"].get("configured") is True, (
+        f"sidecar came up unconfigured: {deployment['health']}\n{_logs(AUTH_C)}"
+    )
+
+
+def test_a_terminal_is_refused_without_a_session(deployment: dict[str, Any]) -> None:
+    """T3: nginx refuses an unauthenticated request for a user's terminal.
+
+    Asked with a *program's* ``Accept`` so the answer is a bare 401 rather than
+    the login-page redirect a browser navigation receives — the redirect variant
+    is covered in the unit lane; what matters here is that the deployed
+    perimeter refuses at all.
+    """
+    status, _, _ = _request("/u/alice/", headers={"Accept": "application/json"})
+    assert status == 401, f"unauthenticated request was not refused (got {status})"
+
+
+def test_a_real_login_reaches_that_users_own_upstream(deployment: dict[str, Any]) -> None:
+    """T4: login → cookie → auth_request → prefix-stripped proxy, end to end.
+
+    The response body must be the one ALICE'S container serves. A 200 alone
+    would only prove the request got past authentication; the per-user marker is
+    what proves nginx then routed it to the right upstream with the ``/u/alice``
+    prefix stripped — the two halves of the contract that can fail
+    independently.
+    """
+    client, jar = _browser()
+    body = urllib.parse.urlencode({"user": "alice", "password": _PASSWORDS["alice"]}).encode()
+    status, _, _ = _request(
+        "/auth/login",
+        method="POST",
+        data=body,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            # The sidecar refuses a submission declaring no origin at all.
+            "Origin": f"http://127.0.0.1:{NGINX_PORT}",
+            **_navigation(),
+        },
+        opener=client,
+    )
+    assert status == 200, f"login was not accepted (got {status})\n{_logs(AUTH_C)}"
+    assert [c.name for c in jar], f"login issued no session cookie\n{_logs(AUTH_C)}"
+
+    status, _, page = _request(
+        "/u/alice/",
+        headers=_navigation(),
+        opener=client,
+    )
+    assert status == 200, (
+        f"authorized request did not reach the upstream (got {status})\n"
+        f"{_logs(NGINX_C)}\n{_logs(_web_container('alice'))}"
+    )
+    assert f"{UPSTREAM_MARKER} for alice" in page, (
+        f"authorized request reached the wrong upstream:\n{page[:400]}"
+    )

--- a/tests/interfaces/web_terminal/api.test.mjs
+++ b/tests/interfaces/web_terminal/api.test.mjs
@@ -14,6 +14,9 @@
  *     `window.__OSPREY_PREFIX__` (the multi-user prefix contract) and
  *     prepend it to root-absolute paths only, are a no-op when the prefix is
  *     empty/absent, and never double-prefix or touch already-absolute URLs
+ *   - reload-on-401 probe: a closed WS/SSE channel asks the app's own
+ *     prefixed health route whether the session survived, and only a definite
+ *     401 stops the reconnect loop and reloads
  *
  * Module isolation: api.js keeps `wsState`/`sseState`/`stateListeners` as
  * module-private state that no init() resets. `vi.resetModules()` plus a fresh
@@ -277,6 +280,245 @@ describe('URL prefix: window.__OSPREY_PREFIX__ (multi-user prefix contract)', ()
     } finally {
       source.stop();
     }
+  });
+});
+
+describe('reconnect: session-expiry probe (reload-on-401)', () => {
+  /**
+   * Drain the probe's promise chain (fetch -> then -> catch -> finally -> the
+   * reload decision). A fixed number of microtask ticks, so this stays
+   * deterministic under fake timers, which only fake the macrotask queue.
+   */
+  async function flushProbe() {
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+  }
+
+  /**
+   * Stub `WebSocket` with a constructor that records every instance, so a test
+   * can drive `onclose` by hand and count reconnect attempts.
+   * @returns {any[]} the constructed instances, in order
+   */
+  function stubWebSocket() {
+    /** @type {any[]} */
+    const instances = [];
+    vi.stubGlobal(
+      'WebSocket',
+      class {
+        constructor() {
+          instances.push(this);
+        }
+        close() {}
+      }
+    );
+    return instances;
+  }
+
+  /**
+   * Stub `EventSource` the same way, recording instances and `close()` calls.
+   * @returns {any[]}
+   */
+  function stubEventSource() {
+    /** @type {any[]} */
+    const instances = [];
+    vi.stubGlobal(
+      'EventSource',
+      class {
+        constructor() {
+          this.closed = false;
+          instances.push(this);
+        }
+        close() {
+          this.closed = true;
+        }
+      }
+    );
+    return instances;
+  }
+
+  /**
+   * Stub `location` with a reload spy (and the fields wsUrl reads).
+   * @returns {any}
+   */
+  function stubLocation() {
+    const loc = { protocol: 'http:', host: 'localhost:5000', reload: vi.fn() };
+    vi.stubGlobal('location', loc);
+    return loc;
+  }
+
+  /** @param {number} status */
+  function stubFetchStatus(status) {
+    const fetchMock = vi.fn(async () => ({ ok: status < 400, status }));
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+  }
+
+  beforeEach(() => {
+    window.__OSPREY_PREFIX__ = '/u/alice';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('a closed WebSocket probes the app\'s own prefixed health route with a JSON Accept header', async () => {
+    stubLocation();
+    const sockets = stubWebSocket();
+    const fetchMock = stubFetchStatus(401);
+
+    api.createWebSocket('ws://localhost:5000/u/alice/ws/terminal');
+    sockets[0].onclose({ code: 1006 });
+    await flushProbe();
+
+    // Never the sidecar's unauthenticated /health, never a root-absolute
+    // /health: only /u/<user>/health sits behind the user's auth gate.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith('/u/alice/health', {
+      cache: 'no-store',
+      headers: { Accept: 'application/json' },
+    });
+  });
+
+  test('a 401 probe stops the reconnect loop and reloads', async () => {
+    vi.useFakeTimers();
+    const loc = stubLocation();
+    const sockets = stubWebSocket();
+    stubFetchStatus(401);
+
+    api.createWebSocket('ws://localhost:5000/u/alice/ws/terminal');
+    sockets[0].onclose({ code: 1006 });
+    await flushProbe();
+
+    expect(loc.reload).toHaveBeenCalledTimes(1);
+    // Past the whole backoff ceiling: no further connection is attempted.
+    vi.advanceTimersByTime(60000);
+    expect(sockets).toHaveLength(1);
+  });
+
+  test('a probe that fails with a network error keeps the existing reconnect/backoff and never reloads', async () => {
+    vi.useFakeTimers();
+    const loc = stubLocation();
+    const sockets = stubWebSocket();
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new TypeError('Failed to fetch'); }));
+
+    api.createWebSocket('ws://localhost:5000/u/alice/ws/terminal');
+    sockets[0].onclose({ code: 1006 });
+    await flushProbe();
+
+    expect(loc.reload).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1000);
+    expect(sockets).toHaveLength(2);
+  });
+
+  test('a healthy 200 probe keeps the existing reconnect/backoff and never reloads', async () => {
+    vi.useFakeTimers();
+    const loc = stubLocation();
+    const sockets = stubWebSocket();
+    stubFetchStatus(200);
+
+    api.createWebSocket('ws://localhost:5000/u/alice/ws/terminal');
+    sockets[0].onclose({ code: 1006 });
+    await flushProbe();
+
+    expect(loc.reload).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1000);
+    expect(sockets).toHaveLength(2);
+  });
+
+  test('a 503 probe (server restarting, session intact) keeps reconnecting', async () => {
+    vi.useFakeTimers();
+    const loc = stubLocation();
+    const sockets = stubWebSocket();
+    stubFetchStatus(503);
+
+    api.createWebSocket('ws://localhost:5000/u/alice/ws/terminal');
+    sockets[0].onclose({ code: 1006 });
+    await flushProbe();
+
+    expect(loc.reload).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1000);
+    expect(sockets).toHaveLength(2);
+  });
+
+  test('concurrent closes share a single in-flight probe', async () => {
+    stubLocation();
+    const sockets = stubWebSocket();
+    const fetchMock = stubFetchStatus(200);
+
+    api.createWebSocket('ws://localhost:5000/u/alice/ws/terminal');
+    api.createWebSocket('ws://localhost:5000/u/alice/ws/other');
+    sockets[0].onclose({ code: 1006 });
+    sockets[1].onclose({ code: 1006 });
+    await flushProbe();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('reloads at most once no matter how many channels close afterwards', async () => {
+    const loc = stubLocation();
+    const sockets = stubWebSocket();
+    const fetchMock = stubFetchStatus(401);
+
+    api.createWebSocket('ws://localhost:5000/u/alice/ws/terminal');
+    const second = api.createWebSocket('ws://localhost:5000/u/alice/ws/other');
+    sockets[0].onclose({ code: 1006 });
+    await flushProbe();
+    expect(loc.reload).toHaveBeenCalledTimes(1);
+
+    sockets[1].onclose({ code: 1006 });
+    await flushProbe();
+
+    expect(loc.reload).toHaveBeenCalledTimes(1);
+    // The expiry is already known, so no second request goes out.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    second.stop();
+  });
+
+  test('an EventSource error on a 401 closes the source and reloads', async () => {
+    const loc = stubLocation();
+    const sources = stubEventSource();
+    const fetchMock = stubFetchStatus(401);
+
+    api.createEventSource('/api/files/events');
+    sources[0].onerror();
+    await flushProbe();
+
+    expect(fetchMock).toHaveBeenCalledWith('/u/alice/health', {
+      cache: 'no-store',
+      headers: { Accept: 'application/json' },
+    });
+    expect(sources[0].closed).toBe(true);
+    expect(loc.reload).toHaveBeenCalledTimes(1);
+  });
+
+  test('an EventSource error with the session intact neither closes the source nor reloads', async () => {
+    const loc = stubLocation();
+    const sources = stubEventSource();
+    stubFetchStatus(200);
+
+    const source = api.createEventSource('/api/files/events');
+    sources[0].onerror();
+    await flushProbe();
+
+    expect(sources[0].closed).toBe(false);
+    expect(loc.reload).not.toHaveBeenCalled();
+    source.stop();
+  });
+
+  test('probes the unprefixed /health when no per-user prefix is set (single-origin/dev)', async () => {
+    delete window.__OSPREY_PREFIX__;
+    const loc = stubLocation();
+    const sockets = stubWebSocket();
+    const fetchMock = stubFetchStatus(200);
+
+    api.createWebSocket('ws://localhost:5000/ws/terminal');
+    sockets[0].onclose({ code: 1006 });
+    await flushProbe();
+
+    expect(fetchMock).toHaveBeenCalledWith('/health', {
+      cache: 'no-store',
+      headers: { Accept: 'application/json' },
+    });
+    expect(loc.reload).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/interfaces/web_terminal/app-logout.test.mjs
+++ b/tests/interfaces/web_terminal/app-logout.test.mjs
@@ -183,6 +183,168 @@ describe('initLogoutButton: click flow', () => {
   });
 });
 
+describe('initLogoutButton: auth-session chaining', () => {
+  /** Every fetch the click made, in order. */
+  function captureFetches() {
+    /** @type {string[]} */
+    const urls = [];
+    const fetchMock = vi.fn(async (/** @type {string} */ url) => {
+      urls.push(url);
+      return { ok: true, status: 200, statusText: 'OK', json: async () => ({ status: 'ok' }) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    return { urls, fetchMock };
+  }
+
+  test('ends the auth session after the PTY teardown, before navigating', async () => {
+    window.__OSPREY_PREFIX__ = '/u/alice';
+    const btn = renderLogoutButton('/landing');
+    const { urls } = captureFetches();
+    const assign = vi.fn();
+    vi.stubGlobal('location', { origin: 'http://localhost:5000', assign });
+
+    initLogoutButton();
+    btn.click();
+
+    await vi.waitFor(() => expect(assign).toHaveBeenCalledTimes(1));
+    // Order matters: the terminal is torn down first, so a session that
+    // outlives the request cannot still be driving a live PTY.
+    expect(urls).toEqual(['/u/alice/api/terminal/logout', '/auth/logout?user=alice']);
+  });
+
+  test('addresses the sidecar at the origin root, never under the user prefix', async () => {
+    window.__OSPREY_PREFIX__ = '/u/alice';
+    const btn = renderLogoutButton('/landing');
+    const { urls } = captureFetches();
+    vi.stubGlobal('location', { origin: 'http://localhost:5000', assign: vi.fn() });
+
+    initLogoutButton();
+    btn.click();
+
+    // `/u/alice/auth/logout` would be proxied to this container and 404 —
+    // nginx serves the sidecar's public surface at the origin root.
+    await vi.waitFor(() => expect(urls).toHaveLength(2));
+    expect(urls[1]).toBe('/auth/logout?user=alice');
+    expect(urls[1].startsWith('/auth/')).toBe(true);
+  });
+
+  test('sends exactly one user parameter, percent-encoded', async () => {
+    window.__OSPREY_PREFIX__ = '/u/alice-b';
+    const btn = renderLogoutButton('/landing');
+    const { urls } = captureFetches();
+    vi.stubGlobal('location', { origin: 'http://localhost:5000', assign: vi.fn() });
+
+    initLogoutButton();
+    btn.click();
+
+    await vi.waitFor(() => expect(urls).toHaveLength(2));
+    const query = new URL(urls[1], 'http://localhost:5000').searchParams;
+    // The route refuses a repeated `user` outright rather than picking one.
+    expect(query.getAll('user')).toEqual(['alice-b']);
+  });
+
+  test('carries same-origin credentials, or the session cookie never arrives', async () => {
+    window.__OSPREY_PREFIX__ = '/u/alice';
+    const btn = renderLogoutButton('/landing');
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ status: 'ok' }),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('location', { origin: 'http://localhost:5000', assign: vi.fn() });
+
+    initLogoutButton();
+    btn.click();
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(fetchMock).toHaveBeenLastCalledWith('/auth/logout?user=alice', {
+      credentials: 'same-origin',
+      cache: 'no-store',
+    });
+  });
+
+  test('skips the sidecar entirely without a per-user prefix (plain `osprey web`)', async () => {
+    const btn = renderLogoutButton('/landing');
+    const { urls } = captureFetches();
+    const assign = vi.fn();
+    vi.stubGlobal('location', { origin: 'http://localhost:5000', assign });
+
+    initLogoutButton();
+    btn.click();
+
+    await vi.waitFor(() => expect(assign).toHaveBeenCalledTimes(1));
+    expect(urls).toEqual(['/api/terminal/logout']);
+  });
+
+  test('still navigates when the sidecar answers 404 (authentication is off)', async () => {
+    // The regression this shape exists to prevent: `location /auth/` is only
+    // rendered when `auth.method != "none"`, and the app cannot tell the two
+    // postures apart, so a *navigation* would strand a no-auth deployment on a
+    // 404 instead of the landing page.
+    window.__OSPREY_PREFIX__ = '/u/alice';
+    const btn = renderLogoutButton('/landing');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (/** @type {string} */ url) =>
+        url.startsWith('/auth/')
+          ? { ok: false, status: 404, statusText: 'Not Found' }
+          : { ok: true, status: 200, statusText: 'OK', json: async () => ({ status: 'ok' }) }
+      )
+    );
+    const assign = vi.fn();
+    vi.stubGlobal('location', { origin: 'http://localhost:5000', assign });
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    initLogoutButton();
+    btn.click();
+
+    await vi.waitFor(() => expect(assign).toHaveBeenCalledTimes(1));
+    expect(assign).toHaveBeenCalledWith('/landing');
+    // A 404 here is the expected answer, not a fault to shout about.
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  test('still clears storage and navigates when the sidecar is unreachable', async () => {
+    window.__OSPREY_PREFIX__ = '/u/alice';
+    localStorage.setItem(STORAGE_KEY, 'warm-session-id');
+    const btn = renderLogoutButton('/landing');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (/** @type {string} */ url) => {
+        if (url.startsWith('/auth/')) throw new Error('sidecar down');
+        return { ok: true, status: 200, statusText: 'OK', json: async () => ({ status: 'ok' }) };
+      })
+    );
+    const assign = vi.fn();
+    vi.stubGlobal('location', { origin: 'http://localhost:5000', assign });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    initLogoutButton();
+    btn.click();
+
+    await vi.waitFor(() => expect(assign).toHaveBeenCalledTimes(1));
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(assign).toHaveBeenCalledWith('/landing');
+  });
+
+  test('an unsafe landing_url still stops everything, sidecar included', async () => {
+    window.__OSPREY_PREFIX__ = '/u/alice';
+    const btn = renderLogoutButton('javascript:alert(1)');
+    const { fetchMock } = captureFetches();
+    const assign = vi.fn();
+    vi.stubGlobal('location', { origin: 'http://localhost:5000', assign });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    initLogoutButton();
+    btn.click();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(assign).not.toHaveBeenCalled();
+  });
+});
+
 describe('post-logout: a fresh load does not auto-resume', () => {
   /** Minimal fake xterm.js Terminal -- just enough surface for initTerminal(). */
   class FakeTerminal {

--- a/tests/interfaces/web_terminal/test_auth_login_browser.py
+++ b/tests/interfaces/web_terminal/test_auth_login_browser.py
@@ -1,0 +1,287 @@
+"""Browser test: landing card -> password prompt -> the user's own terminal.
+
+The composed-stack serving test
+(``tests/deployment/web_terminals/test_auth_serving.py``) drives this same
+perimeter with httpx, which is the right instrument for headers, cookies and
+status codes. It cannot see the part a person actually performs: that the
+landing page's cards are real links a click follows, that the redirect a denied
+``auth_request`` emits lands a *browser* on the prompt, that the prompt asks for
+a password and never for a name, and that submitting the form — with the
+``Origin`` a browser sets unprompted and nothing else — walks back to the
+terminal the click was aimed at.
+
+That round trip is the deployment's front door, and every hop in it is a
+different component: nginx's ``error_page``/``map`` pair chooses the redirect,
+the sidecar renders the prompt and evaluates the credential, and the browser's
+own cookie jar carries the result back through nginx's ``auth_request``. The
+in-process web-terminal browser suites in this directory cannot reach it —
+they run the app behind an ASGI prefix-stripping stand-in, with no nginx and no
+sidecar in the picture at all.
+
+So this suite drives the REAL containerised stack, reusing
+:func:`~tests.deployment.web_terminals.test_auth_serving.serving_stack` rather
+than standing up a second copy of it. It is marked both ``browser`` and
+``dockerbuild`` and skips cleanly when either chromium or docker is missing.
+
+WHAT THE DESTINATION IS. The per-user terminal app cannot run in this harness —
+it needs the ``claude`` binary and a provider — so the upstream behind
+``/u/<user>/`` is the serving test's stub, which answers the app root with a
+page carrying
+:data:`~tests.deployment.web_terminals.test_auth_serving.TERMINAL_STAND_IN_MARKER`.
+Arriving there proves the perimeter delivered the browser to *that user's own
+upstream* with a session; it does not prove anything about the terminal UI,
+which the in-process suites in this directory cover.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from osprey.services.auth_sidecar.passwords import generation_tag
+from osprey.services.auth_sidecar.sessions import SESSION_COOKIE_NAME
+from tests.deployment.web_terminals.test_auth_serving import (
+    _PASSWORDS,
+    TERMINAL_STAND_IN_MARKER,
+    serving_stack,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from playwright.sync_api import Browser, Page
+
+    from tests.deployment.web_terminals.test_auth_serving import Stack
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        return subprocess.run(["docker", "info"], capture_output=True, timeout=10).returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+pytestmark = [
+    pytest.mark.browser,
+    pytest.mark.dockerbuild,
+    pytest.mark.slow,
+    pytest.mark.skipif(not _docker_available(), reason="docker not available"),
+]
+
+
+def _require_chromium() -> None:
+    """Skip the module unless a chromium binary is really launchable.
+
+    Checked *here*, in the fixture that starts the containers, rather than left
+    to ``chromium_browser``: pytest builds module-scoped fixtures before
+    function-scoped ones, so without this the ordinary unit lane — which has
+    docker but no chromium — would compose the whole stack and tear it down
+    again for a module in which every test then skips.
+    """
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:  # pragma: no cover
+        pytest.skip("playwright package not installed")
+
+    playwright = sync_playwright().start()
+    try:
+        playwright.chromium.launch(headless=True).close()
+    except Exception as exc:  # pragma: no cover - the usual CI unit-lane path
+        pytest.skip(f"Chromium binary not available: {exc}")
+    finally:
+        # Always stopped: a leaked playwright loop makes every later
+        # asyncio.run()/pytest-asyncio test in the worker raise.
+        playwright.stop()
+
+
+@pytest.fixture(scope="module")
+def stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Stack]:
+    """The composed perimeter, shared by every test in this module.
+
+    Module-scoped for the same reason the serving test's is: three containers
+    per test would dominate the runtime. Each test opens its own browser
+    context, so no cookie jar is shared between them.
+    """
+    _require_chromium()
+    with serving_stack(tmp_path_factory.mktemp("auth-login-browser")) as running:
+        yield running
+
+
+@pytest.fixture
+def page(chromium_browser: Browser) -> Iterator[Page]:
+    """A page in a fresh, empty context — a browser that has never logged in."""
+    context = chromium_browser.new_context()
+    try:
+        yield context.new_page()
+    finally:
+        context.close()
+
+
+def _unlock(page: Page, user: str) -> None:
+    """Type the password and submit, the way the prompt asks to be used.
+
+    Deliberately a real form submission rather than a scripted POST: the
+    ``Origin`` header the sidecar requires is set by the browser and cannot be
+    set by page script, so this is the only way to exercise that check as a
+    person meets it.
+    """
+    page.fill("#password", _PASSWORDS[user])
+    page.click("button.login-submit")
+
+
+def test_landing_card_leads_to_a_password_prompt_for_that_user(stack: Stack, page: Page) -> None:
+    """Clicking alice's card sends this browser to alice's prompt.
+
+    Three separate things have to hold for this to work, and no unit test sees
+    any of them together: the landing card is a link to ``/u/alice/``, nginx's
+    denied ``auth_request`` turns a *navigation* into a 302 rather than a bare
+    401, and the return-to it carries survives into the prompt.
+    """
+    # Act
+    page.goto(f"{stack.base_url}/")
+    page.click('a.landing-card[href="/u/alice/"]')
+
+    # Assert
+    page.wait_for_selector(".login-card")
+    assert "/auth/login" in page.url
+    assert page.locator("span.login-user").inner_text().strip() == "alice"
+    # The return-to came through the whole chain: card href -> nginx's
+    # allowlist map -> the sidecar's own validation -> the form's hidden field.
+    assert page.locator('input[name="next"]').input_value() == "/u/alice/"
+
+
+def test_the_prompt_asks_for_a_password_and_never_for_a_name(stack: Stack, page: Page) -> None:
+    """No username field: identity comes from the card, not from typing.
+
+    A name the operator types is a name an attacker can suggest, and it would
+    also make the prompt a place to enumerate the roster. The user is fixed by
+    the link that got here and travels in a hidden field; the only thing a
+    person supplies is the secret.
+    """
+    # Act
+    page.goto(f"{stack.base_url}/u/alice/")
+    page.wait_for_selector(".login-card")
+
+    # Assert — a hidden field is fine; a typeable one is the failure.
+    assert page.locator('input[name="user"]').get_attribute("type") == "hidden"
+    assert page.locator('input[name="user"]').input_value() == "alice"
+    assert page.locator('input[type="text"]').count() == 0
+    assert page.locator("input:visible").count() == 1
+    assert page.locator("#password").get_attribute("type") == "password"
+
+
+def test_password_unlocks_and_returns_to_the_users_own_terminal(stack: Stack, page: Page) -> None:
+    """The whole front door, end to end, as a person walks through it.
+
+    Card -> prompt -> password -> back at ``/u/alice/`` with the terminal
+    behind it. The session cookie is set by the sidecar on the deployment
+    origin and spent by nginx's ``auth_request`` on the very next request,
+    which is the handoff this feature exists to make work.
+    """
+    # Arrange
+    page.goto(f"{stack.base_url}/")
+    page.click('a.landing-card[href="/u/alice/"]')
+    page.wait_for_selector(".login-card")
+
+    # Act
+    _unlock(page, "alice")
+
+    # Assert
+    page.wait_for_selector(f"#{TERMINAL_STAND_IN_MARKER}")
+    assert page.url == f"{stack.base_url}/u/alice/"
+    cookies = {cookie["name"]: cookie for cookie in page.context.cookies()}
+    assert SESSION_COOKIE_NAME in cookies
+    assert cookies[SESSION_COOKIE_NAME]["httpOnly"] is True
+
+
+def test_an_unlocked_browser_is_still_refused_at_another_users_terminal(
+    stack: Stack, page: Page
+) -> None:
+    """Unlocking alice does not open bob, and the prompt says whose it is.
+
+    The perimeter's whole point, seen the way an operator would meet it: the
+    same browser, one hop later, is asked for a *different* user's password
+    rather than let through.
+    """
+    # Arrange
+    page.goto(f"{stack.base_url}/u/alice/")
+    page.wait_for_selector(".login-card")
+    _unlock(page, "alice")
+    page.wait_for_selector(f"#{TERMINAL_STAND_IN_MARKER}")
+
+    # Act
+    page.goto(f"{stack.base_url}/u/bob/")
+
+    # Assert
+    page.wait_for_selector(".login-card")
+    assert page.locator("span.login-user").inner_text().strip() == "bob"
+
+
+def test_a_wrong_password_re_prompts_without_naming_the_reason(stack: Stack, page: Page) -> None:
+    """A refusal returns the prompt with one fixed message and no session.
+
+    One message for every reason — unknown user, no credential, wrong secret —
+    is what stops the prompt from being an oracle. ``carol`` is used because
+    her attempt window is nothing else's business.
+    """
+    # Arrange
+    page.goto(f"{stack.base_url}/u/carol/")
+    page.wait_for_selector(".login-card")
+
+    # Act
+    page.fill("#password", "not-carols-password")
+    page.click("button.login-submit")
+
+    # Assert
+    page.wait_for_selector("p.login-error")
+    assert page.locator("p.login-error").get_attribute("role") == "alert"
+    assert "carol" not in page.locator("p.login-error").inner_text()
+    assert SESSION_COOKIE_NAME not in {cookie["name"] for cookie in page.context.cookies()}
+
+
+def test_an_expired_session_sends_a_reload_back_to_the_prompt(stack: Stack, page: Page) -> None:
+    """A tab left open overnight reloads into the login page, not an error.
+
+    Forged rather than waited for — the rendered lifetime is twelve hours — and
+    forged with the sidecar's own signing secret, so what the perimeter refuses
+    is a cookie whose signature it accepts. That is the case a browser actually
+    meets: the cookie is still there and still valid-looking, and the entry
+    inside it has lapsed.
+    """
+    # Arrange — a real unlock first, so the reload is a genuine "this tab was
+    # working a moment ago" and not a browser that never had a session.
+    page.goto(f"{stack.base_url}/u/alice/")
+    page.wait_for_selector(".login-card")
+    _unlock(page, "alice")
+    page.wait_for_selector(f"#{TERMINAL_STAND_IN_MARKER}")
+
+    codec = stack.codec()
+    lapsed = codec.new_state().with_user(
+        "alice",
+        expires_at=codec.now() - 1,
+        generation_tag=generation_tag(stack.stored_hashes["alice"]),
+    )
+    page.context.clear_cookies()
+    page.context.add_cookies(
+        [
+            {
+                "name": SESSION_COOKIE_NAME,
+                "value": codec.encode(lapsed),
+                "domain": "127.0.0.1",
+                "path": "/",
+            }
+        ]
+    )
+
+    # Act
+    page.reload()
+
+    # Assert
+    page.wait_for_selector(".login-card")
+    assert page.locator("span.login-user").inner_text().strip() == "alice"
+    assert page.locator(f"#{TERMINAL_STAND_IN_MARKER}").count() == 0

--- a/tests/interfaces/web_terminal/test_logout_resume_browser.py
+++ b/tests/interfaces/web_terminal/test_logout_resume_browser.py
@@ -40,6 +40,7 @@ import sys
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 
@@ -216,6 +217,20 @@ def test_logout_and_return_starts_fresh_session(tmp_path, monkeypatch, chromium_
             "() => { const o = document.getElementById('welcome-overlay'); if (o) o.remove(); }"
         )
 
+        # Record the auth-sidecar chaining request. This deployment has NO
+        # sidecar (no auth stanza, so nginx renders no `location /auth/` and
+        # nothing is listening), which makes this the live proof of the
+        # authentication-off case: the request is made, it fails, and the
+        # logout still completes. A *navigation* to the sidecar here would
+        # strand the browser on a 404 instead of the landing page.
+        auth_requests: list[str] = []
+
+        def _record(request) -> None:
+            if "/auth/logout" in request.url:
+                auth_requests.append(request.url)
+
+        page.on("request", _record)
+
         # --- Logout: clears the stored pointer, THEN navigates to landing ---
         # Logout lives in the identity chip's popover; open it first.
         page.click("#identity-menu-btn")
@@ -224,6 +239,15 @@ def test_logout_and_return_starts_fresh_session(tmp_path, monkeypatch, chromium_
         page.wait_for_url(lambda u: u.startswith(landing_url))
         assert page.url.startswith(landing_url)
         expect(page.locator("#landing-marker")).to_be_visible()
+
+        # The auth session was asked to end, addressed at the ORIGIN ROOT — not
+        # under `/u/<user>/` (which `base_url` is, and which would reach this
+        # container rather than the sidecar) — and naming exactly this user once.
+        assert auth_requests, "logout did not attempt to end the auth session"
+        assert len(auth_requests) == 1
+        requested = urlsplit(auth_requests[0])
+        assert requested.path == "/auth/logout"
+        assert parse_qs(requested.query) == {"user": [user]}
 
         # NOTE: we can't read the terminal origin's localStorage from here —
         # the page has navigated to the landing origin (a different

--- a/tests/services/auth_sidecar/mock_idp.py
+++ b/tests/services/auth_sidecar/mock_idp.py
@@ -1,0 +1,271 @@
+"""A stub OpenID provider, complete enough for a real Authlib handshake.
+
+``test_oidc.py`` substitutes Authlib at the route boundary, which pins what
+:mod:`osprey.services.auth_sidecar.routes.oidc` decides but proves nothing about
+the library underneath it: discovery, the nonce, the ID token's signature and
+its ``iss``/``aud``/``exp`` claims are all validated inside Authlib, and a fake
+client short-circuits every one of them. This module is the other half — a real
+IdP, served over a real socket, whose tokens are really signed, so
+``test_oidc_flow.py`` can drive the handshake the deployment will actually run.
+
+**It is a provider, not a mock.** The four endpoints an OIDC code flow touches
+are all here (:data:`DISCOVERY_PATH`, :data:`AUTHORIZE_PATH`,
+:data:`TOKEN_PATH`, :data:`JWKS_PATH`), it checks the client credentials it is
+sent, and it binds each authorization code to the ``nonce`` and ``redirect_uri``
+of the leg that created it. A token this provider issues verifies against the
+JWKS it publishes — which is what makes a *deliberately* broken token
+(:attr:`MockIdP.sign_with_intruder_key` and friends) evidence of a rejection
+path rather than of a fixture that never worked.
+
+**Every way it can lie is one attribute.** The knobs on :class:`MockIdP` change
+one property of the response and nothing else, so a test that flips
+:attr:`MockIdP.nonce_claim` differs from the passing case in exactly the value
+under test. :meth:`MockIdP.reset` restores all of them, which is what lets one
+served instance back a whole module of tests.
+
+There is a :data:`USERINFO_PATH` too, and it answers with an identity mapped to
+a *different* roster user on purpose: the sidecar reads identity only from the
+verified ID token, and a test can prove that by watching this endpoint go
+untouched (:attr:`MockIdP.userinfo_requests`).
+"""
+
+from __future__ import annotations
+
+import base64
+import secrets
+import time
+from typing import Any
+from urllib.parse import urlencode
+
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from joserfc import jwt
+from joserfc.jwk import KeySet, RSAKey
+
+DISCOVERY_PATH = "/.well-known/openid-configuration"
+AUTHORIZE_PATH = "/authorize"
+TOKEN_PATH = "/token"
+JWKS_PATH = "/jwks.json"
+USERINFO_PATH = "/userinfo"
+
+SIGNING_KEY_ID = "mock-idp-signing-key"
+"""``kid`` of the published key.
+
+The intruder key carries the same one deliberately: a different ``kid`` would be
+refused as an unknown key (Authlib even re-fetches the JWKS for that case),
+which is a different failure from the one a signature test means to provoke.
+"""
+
+DISCOVERY_OK = "ok"
+DISCOVERY_WITHOUT_AUTHORIZATION_ENDPOINT = "no-authorization-endpoint"
+DISCOVERY_AS_HTML = "html"
+"""Discovery-document postures. The last two are what a mistyped issuer or a
+captive portal actually serves: a reachable document that is not usable."""
+
+DEFAULT_CLIENT_ID = "osprey-terminals"
+DEFAULT_CLIENT_SECRET = "client-secret-value"
+
+
+def _client_credentials(request: Request, form: dict[str, str]) -> tuple[str, str]:
+    """The client id and secret presented on a token request.
+
+    Both RFC 6749 forms are read — Authlib defaults to ``client_secret_basic``,
+    but a provider that only understood one of them would silently pass a client
+    configured for the other.
+    """
+    header = request.headers.get("authorization", "")
+    if header.lower().startswith("basic "):
+        decoded = base64.b64decode(header.split(" ", 1)[1]).decode("latin1")
+        client_id, _, client_secret = decoded.partition(":")
+        return client_id, client_secret
+    return form.get("client_id", ""), form.get("client_secret", "")
+
+
+class MockIdP:
+    """A stub OpenID provider whose responses a test can bend one at a time.
+
+    Attributes:
+        issuer: The provider's own origin, assigned once it is being served —
+            every URL it publishes and the ``iss`` it stamps into tokens are
+            built from it, so discovery and the token agree by construction
+            until a test says otherwise.
+        subject: The identity asserted in the ``sub`` claim.
+        extra_claims: Additional ID-token claims, e.g. ``preferred_username``.
+        discovery: One of the ``DISCOVERY_*`` postures.
+        sign_with_intruder_key: Sign with a key the JWKS does not publish.
+        issuer_claim: Override the token's ``iss``.
+        audience_claim: Override the token's ``aud``.
+        nonce_claim: Override the token's ``nonce`` — otherwise it echoes the
+            nonce the authorize leg was given, which is what a correct provider
+            does.
+        token_lifetime: Seconds between the token's ``iat`` and its ``exp``.
+        issued_at_offset: Seconds to shift ``iat`` by; negative values age a
+            token past Authlib's 120-second leeway.
+        omit_id_token: Answer the token endpoint with an access token only —
+            an OAuth2 provider where an OIDC one was configured.
+        authorize_error: Send the browser back with ``error=<this>`` instead of
+            a code, the shape of a denied consent screen.
+        authorize_requests: Query parameters of each authorize call, in order.
+        token_requests: Form fields of each token call, in order.
+        userinfo_requests: How many times the userinfo endpoint was called.
+    """
+
+    def __init__(
+        self,
+        *,
+        client_id: str = DEFAULT_CLIENT_ID,
+        client_secret: str = DEFAULT_CLIENT_SECRET,
+    ) -> None:
+        """Build the provider and its FastAPI app.
+
+        Args:
+            client_id: The one client this provider will issue tokens to.
+            client_secret: That client's secret.
+        """
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.issuer = ""
+        self._key = RSAKey.generate_key(
+            2048, parameters={"kid": SIGNING_KEY_ID, "use": "sig", "alg": "RS256"}
+        )
+        self._intruder_key = RSAKey.generate_key(
+            2048, parameters={"kid": SIGNING_KEY_ID, "use": "sig", "alg": "RS256"}
+        )
+        self._flows: dict[str, dict[str, str]] = {}
+        self.reset()
+        self.app = self._build_app()
+
+    # --- knobs ---------------------------------------------------------------
+
+    def reset(self) -> None:
+        """Restore every knob and forget every recorded request.
+
+        Called between tests so one served provider can back a whole module: a
+        leftover ``nonce_claim`` from an earlier test would otherwise fail the
+        next one somewhere far from its cause.
+        """
+        self.subject = "idp|alice"
+        self.extra_claims: dict[str, Any] = {}
+        self.discovery = DISCOVERY_OK
+        self.sign_with_intruder_key = False
+        self.issuer_claim: str | None = None
+        self.audience_claim: str | None = None
+        self.nonce_claim: str | None = None
+        self.token_lifetime = 300
+        self.issued_at_offset = 0
+        self.omit_id_token = False
+        self.authorize_error: str | None = None
+        self._flows.clear()
+        self.authorize_requests: list[dict[str, str]] = []
+        self.token_requests: list[dict[str, str]] = []
+        self.userinfo_requests = 0
+
+    @property
+    def discovery_url(self) -> str:
+        """Where the sidecar will look for the discovery document."""
+        return f"{self.issuer}{DISCOVERY_PATH}"
+
+    # --- endpoints -----------------------------------------------------------
+
+    def _discovery_document(self) -> dict[str, Any]:
+        return {
+            "issuer": self.issuer,
+            "authorization_endpoint": f"{self.issuer}{AUTHORIZE_PATH}",
+            "token_endpoint": f"{self.issuer}{TOKEN_PATH}",
+            "jwks_uri": f"{self.issuer}{JWKS_PATH}",
+            "userinfo_endpoint": f"{self.issuer}{USERINFO_PATH}",
+            "response_types_supported": ["code"],
+            "grant_types_supported": ["authorization_code"],
+            "subject_types_supported": ["public"],
+            "id_token_signing_alg_values_supported": ["RS256"],
+            "scopes_supported": ["openid", "profile", "email"],
+            "token_endpoint_auth_methods_supported": [
+                "client_secret_basic",
+                "client_secret_post",
+            ],
+        }
+
+    def _id_token(self, flow: dict[str, str]) -> str:
+        """Sign an ID token for a completed authorization ``flow``."""
+        issued_at = int(time.time()) + self.issued_at_offset
+        claims: dict[str, Any] = {
+            "iss": self.issuer_claim if self.issuer_claim is not None else self.issuer,
+            "sub": self.subject,
+            "aud": self.audience_claim if self.audience_claim is not None else self.client_id,
+            "iat": issued_at,
+            "exp": issued_at + self.token_lifetime,
+            "nonce": self.nonce_claim if self.nonce_claim is not None else flow.get("nonce", ""),
+            **self.extra_claims,
+        }
+        key = self._intruder_key if self.sign_with_intruder_key else self._key
+        return jwt.encode({"alg": "RS256", "kid": SIGNING_KEY_ID}, claims, key)
+
+    def _build_app(self) -> FastAPI:
+        app = FastAPI(title="Mock OpenID Provider", docs_url=None, redoc_url=None, openapi_url=None)
+
+        @app.get(DISCOVERY_PATH)
+        async def discovery() -> Any:
+            if self.discovery == DISCOVERY_AS_HTML:
+                # A captive portal or a plain 200 from a web server: reachable,
+                # served, and not JSON.
+                return HTMLResponse("<html><body>sign in to the guest network</body></html>")
+            document = self._discovery_document()
+            if self.discovery == DISCOVERY_WITHOUT_AUTHORIZATION_ENDPOINT:
+                document.pop("authorization_endpoint")
+            return JSONResponse(document)
+
+        @app.get(JWKS_PATH)
+        async def jwks() -> Any:
+            return JSONResponse(KeySet([self._key]).as_dict(private=False))
+
+        @app.get(AUTHORIZE_PATH)
+        async def authorize(request: Request) -> Any:
+            params = dict(request.query_params)
+            self.authorize_requests.append(params)
+            target = params.get("redirect_uri", "")
+            state = params.get("state", "")
+
+            if self.authorize_error is not None:
+                returned = {"error": self.authorize_error, "state": state}
+            else:
+                code = f"authorization-code-{secrets.token_hex(8)}"
+                self._flows[code] = {
+                    "nonce": params.get("nonce", ""),
+                    "redirect_uri": target,
+                }
+                returned = {"code": code, "state": state}
+
+            separator = "&" if "?" in target else "?"
+            return RedirectResponse(f"{target}{separator}{urlencode(returned)}", status_code=302)
+
+        @app.post(TOKEN_PATH)
+        async def token(request: Request) -> Any:
+            async with request.form() as submitted:
+                form = {key: str(value) for key, value in submitted.items()}
+            self.token_requests.append(form)
+
+            if _client_credentials(request, form) != (self.client_id, self.client_secret):
+                return JSONResponse({"error": "invalid_client"}, status_code=401)
+
+            flow = self._flows.pop(form.get("code", ""), None)
+            if flow is None:
+                return JSONResponse({"error": "invalid_grant"}, status_code=400)
+
+            body: dict[str, Any] = {
+                "access_token": f"access-token-{secrets.token_hex(8)}",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "scope": "openid profile email",
+            }
+            if not self.omit_id_token:
+                body["id_token"] = self._id_token(flow)
+            return JSONResponse(body)
+
+        @app.get(USERINFO_PATH)
+        async def userinfo() -> Any:
+            # Deliberately not `self.subject`: the sidecar must never reach here,
+            # and an identical answer would hide it if it did.
+            self.userinfo_requests += 1
+            return JSONResponse({"sub": "idp|carol"})
+
+        return app

--- a/tests/services/auth_sidecar/test_app.py
+++ b/tests/services/auth_sidecar/test_app.py
@@ -1,0 +1,795 @@
+"""Tests for the auth sidecar's FastAPI application factory.
+
+Three things are pinned here, in rough order of how much damage getting them
+wrong would do: the app refuses everything but ``/health`` when a required
+setting is missing (fail closed), the OIDC state cookie carries the pinned
+attributes rather than Starlette's defaults, and :class:`AuthSettings` reads the
+documented env-var names — including the per-user suffix mapping the credential
+provisioner writes with.
+
+Settings are always passed to ``create_app`` as an explicit mapping, so a
+variable left over in the real process environment can never make a test pass.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import APIRouter, FastAPI, Request, WebSocket
+from fastapi.testclient import TestClient
+from starlette.middleware.sessions import SessionMiddleware
+from starlette.websockets import WebSocketDisconnect
+
+from osprey.services.auth_sidecar import app as app_mod
+from osprey.services.auth_sidecar.app import (
+    DEFAULT_OIDC_CLIENT_ID_ENV,
+    DEFAULT_OIDC_CLIENT_SECRET_ENV,
+    DEFAULT_SESSION_LIFETIME,
+    HEALTH_PATH,
+    STATE_COOKIE_MAX_AGE,
+    STATE_COOKIE_NAME,
+    WEBSOCKET_REFUSAL_CODE,
+    AuthSettings,
+    create_app,
+    get_attempt_throttle,
+    get_revocation_store,
+    get_session_codec,
+    get_settings,
+)
+from osprey.services.auth_sidecar.exceptions import InvalidSessionError
+from osprey.services.auth_sidecar.revocation import RevocationStore
+from osprey.services.auth_sidecar.sessions import (
+    SessionCodec,
+    SessionState,
+)
+from osprey.services.auth_sidecar.throttle import AttemptThrottle
+
+SESSION_SECRET = "session-secret-value"
+STATE_SECRET = "state-secret-value"
+
+PASSWORD_ENV = {
+    "OSPREY_AUTH_METHOD": "password",
+    "OSPREY_AUTH_SESSION_SECRET": SESSION_SECRET,
+    "OSPREY_AUTH_USERS": "alice,bob",
+    "OSPREY_AUTH_PW_HASH_ALICE": "scrypt$16384$8$1$c2FsdA$aGFzaA",
+    "OSPREY_AUTH_EXTERNAL_ORIGIN": "https://terminals.example.org",
+    "OSPREY_AUTH_TLS_ENABLED": "true",
+}
+
+OIDC_ENV = {
+    "OSPREY_AUTH_METHOD": "oidc",
+    "OSPREY_AUTH_SESSION_SECRET": SESSION_SECRET,
+    "OSPREY_AUTH_STATE_SECRET": STATE_SECRET,
+    "OSPREY_AUTH_USERS": "alice",
+    "OSPREY_AUTH_OIDC_ISSUER": "https://idp.example.org",
+    "OSPREY_AUTH_OIDC_CLIENT_ID": "client-id",
+    "OSPREY_AUTH_OIDC_CLIENT_SECRET": "client-secret",
+    "OSPREY_AUTH_EXTERNAL_ORIGIN": "https://terminals.example.org",
+    "OSPREY_AUTH_TLS_ENABLED": "true",
+}
+
+
+def _probe_app(env: dict[str, str]) -> FastAPI:
+    """An app plus one throwaway ``/auth`` route that touches the session.
+
+    The state cookie only reaches the wire once something writes to the session,
+    and this factory deliberately ships no such route yet — the OIDC task's
+    login route will be the first. The probe stands in for it so the pinned
+    cookie attributes are asserted on a real ``Set-Cookie`` header rather than
+    on the middleware's constructor arguments.
+    """
+    app = create_app(env)
+
+    @app.get("/auth/_probe")
+    async def probe(request: Request) -> dict[str, str]:
+        request.session["handshake"] = "in-flight"
+        return {"status": "ok"}
+
+    return app
+
+
+class TestHealth:
+    """``/health`` answers in every configuration state."""
+
+    def test_configured_app_reports_ok(self) -> None:
+        with TestClient(create_app(PASSWORD_ENV)) as client:
+            response = client.get(HEALTH_PATH)
+        assert response.status_code == 200
+        assert response.json() == {
+            "status": "ok",
+            "service": "auth-sidecar",
+            "method": "password",
+            "configured": True,
+        }
+
+    def test_unconfigured_app_still_answers(self) -> None:
+        with TestClient(create_app({})) as client:
+            response = client.get(HEALTH_PATH)
+        assert response.status_code == 200
+        assert response.json()["configured"] is False
+
+    def test_body_carries_no_secret(self) -> None:
+        with TestClient(create_app(OIDC_ENV)) as client:
+            body = client.get(HEALTH_PATH).text
+        for secret in (SESSION_SECRET, STATE_SECRET, "client-secret"):
+            assert secret not in body
+
+
+class TestFailClosed:
+    """A missing required setting refuses everything but the healthcheck."""
+
+    @pytest.mark.parametrize("path", ["/auth/login", "/verify", "/openapi.json", "/does-not-exist"])
+    def test_unconfigured_refuses_every_other_path(self, path: str) -> None:
+        with TestClient(create_app({})) as client:
+            response = client.get(path)
+        assert response.status_code == 503
+        assert "not configured" in response.json()["detail"]
+
+    def test_refusal_sets_no_cookie(self) -> None:
+        """A refused request must not hand the browser any state to carry.
+
+        Built from the one configuration where this could actually fail: a
+        state secret IS set, so SessionMiddleware is installed and able to mint
+        cookies, while the OIDC settings around it are incomplete, so the app
+        is unservable. The probe route writes to the session, which is what
+        would emit a ``Set-Cookie`` — the guard sitting outside the session
+        middleware is what stops the request from ever reaching it.
+        """
+        env = dict(OIDC_ENV)
+        del env["OSPREY_AUTH_OIDC_ISSUER"]
+        del env["OSPREY_AUTH_OIDC_CLIENT_ID"]
+        app = _probe_app(env)
+        assert any(middleware.cls is SessionMiddleware for middleware in app.user_middleware)
+
+        with TestClient(app) as client:
+            response = client.get("/auth/_probe")
+        assert response.status_code == 503
+        assert "set-cookie" not in {name.lower() for name in response.headers}
+
+    def test_refusal_names_no_secret(self) -> None:
+        env = dict(OIDC_ENV)
+        del env["OSPREY_AUTH_STATE_SECRET"]
+        with TestClient(create_app(env)) as client:
+            body = client.get("/auth/login").text
+        assert SESSION_SECRET not in body
+        assert "client-secret" not in body
+
+    def test_configured_app_lets_requests_through_to_routing(self) -> None:
+        with TestClient(create_app(PASSWORD_ENV)) as client:
+            response = client.get("/does-not-exist")
+        assert response.status_code == 404
+
+    def test_method_none_is_not_a_servable_sidecar_mode(self) -> None:
+        env = dict(PASSWORD_ENV, OSPREY_AUTH_METHOD="none")
+        with TestClient(create_app(env)) as client:
+            assert client.get(HEALTH_PATH).json()["configured"] is False
+            assert client.get("/auth/login").status_code == 503
+
+    def test_unknown_method_refuses_rather_than_crashing_the_factory(self) -> None:
+        env = dict(PASSWORD_ENV, OSPREY_AUTH_METHOD="kerberos")
+        app = create_app(env)
+        with TestClient(app) as client:
+            assert client.get("/auth/login").status_code == 503
+
+    def test_missing_settings_are_logged_by_name_only(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        env = dict(OIDC_ENV)
+        del env["OSPREY_AUTH_OIDC_CLIENT_SECRET"]
+        with caplog.at_level(logging.ERROR, logger=app_mod.__name__):
+            create_app(env)
+        assert DEFAULT_OIDC_CLIENT_SECRET_ENV in caplog.text
+        assert "client-secret" not in caplog.text
+
+    def test_cleartext_origin_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        env = dict(
+            PASSWORD_ENV,
+            OSPREY_AUTH_TLS_ENABLED="false",
+            OSPREY_AUTH_EXTERNAL_ORIGIN="http://terminals.example.org",
+        )
+        with caplog.at_level(logging.WARNING, logger=app_mod.__name__):
+            create_app(env)
+        assert "cleartext" in caplog.text
+
+    def test_https_origin_without_the_tls_flag_is_a_loud_mismatch(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An https origin with TLS off issues Secure-less cookies on a TLS site.
+
+        The generic cleartext warning must not stand in for this: it reads as
+        "you meant to deploy without TLS", which is the opposite diagnosis.
+        """
+        env = dict(
+            PASSWORD_ENV,
+            OSPREY_AUTH_TLS_ENABLED="false",
+            OSPREY_AUTH_EXTERNAL_ORIGIN="https://terminals.example.org",
+        )
+        with caplog.at_level(logging.WARNING, logger=app_mod.__name__):
+            create_app(env)
+        assert "one of the two settings is wrong" in caplog.text
+        assert "cleartext" not in caplog.text
+
+    def test_cleartext_origin_with_the_tls_flag_on_is_a_loud_mismatch(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The other direction, and the more confusing failure of the two.
+
+        Secure cookies over http are discarded by the browser without comment,
+        so every login appears to succeed and unlocks nothing. Silence here
+        leaves an operator debugging a login loop with no signal at all.
+        """
+        env = dict(
+            PASSWORD_ENV,
+            OSPREY_AUTH_TLS_ENABLED="true",
+            OSPREY_AUTH_EXTERNAL_ORIGIN="http://terminals.example.org",
+        )
+        with caplog.at_level(logging.WARNING, logger=app_mod.__name__):
+            create_app(env)
+        assert "one of the two settings is wrong" in caplog.text
+        assert "discard Secure cookies" in caplog.text
+
+    def test_no_cookie_warning_when_tls_is_on(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger=app_mod.__name__):
+            create_app(PASSWORD_ENV)
+        assert "Secure attribute" not in caplog.text
+
+    def test_unrecognized_tls_flag_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        env = dict(PASSWORD_ENV, OSPREY_AUTH_TLS_ENABLED="maybe")
+        with caplog.at_level(logging.WARNING, logger=app_mod.__name__):
+            app = create_app(env)
+        assert "neither true nor false" in caplog.text
+        assert app.state.settings.tls_enabled is False
+
+    def test_empty_roster_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        env = dict(PASSWORD_ENV, OSPREY_AUTH_USERS="")
+        with caplog.at_level(logging.WARNING, logger=app_mod.__name__):
+            create_app(env)
+        assert "empty roster" in caplog.text
+
+
+class TestRosterCollisions:
+    """Two usernames keying one credential refuse the whole sidecar.
+
+    There is no per-user answer available here: the sidecar cannot tell which of
+    ``alice-b`` and ``alice_b`` the single ``OSPREY_AUTH_PW_HASH_ALICE_B`` entry
+    belongs to, so serving either one would be a guess about whose terminal a
+    password opens.
+    """
+
+    COLLIDING = "alice-b,alice_b"
+
+    def test_a_collision_makes_the_app_unservable(self) -> None:
+        env = dict(PASSWORD_ENV, OSPREY_AUTH_USERS=self.COLLIDING)
+        settings = AuthSettings.from_env(env)
+        assert settings.missing_requirements() == ()
+        assert settings.roster_collisions() == {"ALICE_B": ["alice-b", "alice_b"]}
+        assert settings.configured is False
+
+    def test_a_collision_refuses_traffic(self) -> None:
+        env = dict(PASSWORD_ENV, OSPREY_AUTH_USERS=self.COLLIDING)
+        with TestClient(create_app(env)) as client:
+            assert client.get("/auth/login").status_code == 503
+            assert client.get(HEALTH_PATH).json()["configured"] is False
+
+    def test_the_colliding_usernames_are_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        env = dict(PASSWORD_ENV, OSPREY_AUTH_USERS=self.COLLIDING)
+        with caplog.at_level(logging.ERROR, logger=app_mod.__name__):
+            create_app(env)
+        assert "alice-b" in caplog.text
+        assert "alice_b" in caplog.text
+        assert "OSPREY_AUTH_PW_HASH_ALICE_B" in caplog.text
+
+    def test_a_distinct_roster_is_unaffected(self) -> None:
+        assert AuthSettings.from_env(PASSWORD_ENV).roster_collisions() == {}
+
+
+class TestSecretsNeverRender:
+    """No secret-bearing field appears in the dataclass repr.
+
+    One ``logger.debug("settings=%s", settings)`` or one traceback frame is all
+    it takes for a default repr to write the session signing key into a log
+    aggregator, so the exclusion is pinned rather than left to reviewer
+    vigilance.
+    """
+
+    def test_secrets_are_absent_from_repr(self) -> None:
+        env = dict(
+            OIDC_ENV,
+            OSPREY_AUTH_USERS="alice",
+            OSPREY_AUTH_PW_HASH_ALICE="scrypt$16384$8$1$c2FsdA$aGFzaA",
+        )
+        rendered = repr(AuthSettings.from_env(env))
+        for secret in (SESSION_SECRET, STATE_SECRET, "client-secret", "aGFzaA"):
+            assert secret not in rendered
+
+    def test_configuration_stays_visible(self) -> None:
+        env = dict(OIDC_ENV, OSPREY_AUTH_OIDC_SUBJECT_ALICE="alice@example.org")
+        rendered = repr(AuthSettings.from_env(env))
+        assert "alice@example.org" in rendered
+        assert "https://idp.example.org" in rendered
+        assert DEFAULT_OIDC_CLIENT_ID_ENV in rendered
+
+    def test_password_hashes_are_still_readable_by_code(self) -> None:
+        settings = AuthSettings.from_env(PASSWORD_ENV)
+        assert settings.password_hash("alice") == PASSWORD_ENV["OSPREY_AUTH_PW_HASH_ALICE"]
+
+
+class TestWebsocketRefusal:
+    """The guard covers websocket scopes, not just HTTP.
+
+    ``BaseHTTPMiddleware`` dispatches ``http`` scopes only and passes everything
+    else through, so an unconfigured sidecar would complete a websocket
+    handshake past a gate that believes it is refusing all traffic. The sidecar
+    ships no websocket route today — which is why this is pinned now, since the
+    failure would otherwise arrive with whoever adds the first one.
+    """
+
+    @staticmethod
+    def _app_with_socket(env: dict[str, str]) -> FastAPI:
+        app = create_app(env)
+
+        @app.websocket("/ws")
+        async def socket(websocket: WebSocket) -> None:
+            await websocket.accept()
+            await websocket.send_text("reached the route")
+
+        return app
+
+    def test_unconfigured_websocket_never_completes_its_handshake(self) -> None:
+        with TestClient(self._app_with_socket({})) as client:
+            with pytest.raises(WebSocketDisconnect) as caught:
+                with client.websocket_connect("/ws"):
+                    pass
+        assert caught.value.code == WEBSOCKET_REFUSAL_CODE
+
+    def test_configured_websocket_connects(self) -> None:
+        with TestClient(self._app_with_socket(PASSWORD_ENV)) as client:
+            with client.websocket_connect("/ws") as socket:
+                assert socket.receive_text() == "reached the route"
+
+    def test_lifespan_still_runs_unconfigured(self) -> None:
+        """Startup/shutdown are not http/websocket scopes and must pass through.
+
+        Refusing them would leave an unconfigured app unable to boot far enough
+        to answer the healthcheck that explains why it is refusing.
+        """
+        with TestClient(create_app({})) as client:
+            assert client.get(HEALTH_PATH).status_code == 200
+
+
+class TestRequirements:
+    """Which gaps take the whole sidecar down, and which are per-user."""
+
+    def test_password_mode_needs_only_a_session_secret(self) -> None:
+        env = dict(PASSWORD_ENV)
+        del env["OSPREY_AUTH_SESSION_SECRET"]
+        assert AuthSettings.from_env(env).missing_requirements() == ("OSPREY_AUTH_SESSION_SECRET",)
+
+    def test_password_mode_does_not_require_the_state_secret(self) -> None:
+        env = dict(PASSWORD_ENV)
+        env.pop("OSPREY_AUTH_STATE_SECRET", None)
+        assert AuthSettings.from_env(env).configured is True
+
+    def test_oidc_mode_requires_the_full_handshake_surface(self) -> None:
+        assert set(
+            AuthSettings.from_env({"OSPREY_AUTH_METHOD": "oidc"}).missing_requirements()
+        ) == {
+            DEFAULT_OIDC_CLIENT_ID_ENV,
+            DEFAULT_OIDC_CLIENT_SECRET_ENV,
+            "OSPREY_AUTH_EXTERNAL_ORIGIN",
+            "OSPREY_AUTH_OIDC_ISSUER",
+            "OSPREY_AUTH_SESSION_SECRET",
+            "OSPREY_AUTH_STATE_SECRET",
+        }
+
+    def test_missing_requirements_are_reported_in_a_stable_order(self) -> None:
+        missing = AuthSettings.from_env({"OSPREY_AUTH_METHOD": "oidc"}).missing_requirements()
+        assert list(missing) == sorted(missing)
+
+    def test_indirected_credentials_are_reported_under_their_resolved_names(self) -> None:
+        """Naming the default would send an operator to set a variable nothing reads."""
+        env = dict(OIDC_ENV)
+        del env["OSPREY_AUTH_OIDC_CLIENT_ID"]
+        env["OSPREY_AUTH_OIDC_CLIENT_ID_ENV"] = "FACILITY_IDP_CLIENT"
+
+        settings = AuthSettings.from_env(env)
+        assert settings.missing_requirements() == ("FACILITY_IDP_CLIENT",)
+        assert settings.oidc_client_id_var == "FACILITY_IDP_CLIENT"
+        assert settings.oidc_client_secret_var == DEFAULT_OIDC_CLIENT_SECRET_ENV
+
+    def test_resolved_names_reach_the_startup_log(self, caplog: pytest.LogCaptureFixture) -> None:
+        env = dict(OIDC_ENV)
+        del env["OSPREY_AUTH_OIDC_CLIENT_ID"]
+        env["OSPREY_AUTH_OIDC_CLIENT_ID_ENV"] = "FACILITY_IDP_CLIENT"
+        with caplog.at_level(logging.ERROR, logger=app_mod.__name__):
+            create_app(env)
+        assert "FACILITY_IDP_CLIENT" in caplog.text
+        assert DEFAULT_OIDC_CLIENT_ID_ENV not in caplog.text
+
+    @pytest.mark.parametrize(
+        ("overrides", "expected"),
+        [
+            ({"session_secret": "   "}, "OSPREY_AUTH_SESSION_SECRET"),
+            ({"session_lifetime": 0}, "OSPREY_AUTH_SESSION_LIFETIME"),
+            ({"session_lifetime": -1}, "OSPREY_AUTH_SESSION_LIFETIME"),
+            ({"method": "oidc", "state_secret": "   "}, "OSPREY_AUTH_STATE_SECRET"),
+        ],
+        ids=["blank-secret", "zero-lifetime", "negative-lifetime", "blank-state-secret"],
+    )
+    def test_codec_preconditions_are_requirements_not_parser_luck(
+        self, overrides: dict[str, Any], expected: str
+    ) -> None:
+        """Settings the codec cannot be built from must report as unservable.
+
+        Constructed directly rather than through ``from_env``: the parser
+        normalizes both of these away, so routing through it would only prove
+        the parser works, not that ``configured`` implies a constructible
+        codec.
+        """
+        kwargs: dict[str, Any] = {"method": "password", "session_secret": SESSION_SECRET}
+        kwargs.update(overrides)
+        settings = AuthSettings(**kwargs)
+        assert expected in settings.missing_requirements()
+        assert settings.configured is False
+
+    @pytest.mark.parametrize(
+        "env_value", ["   ", "0", "-30", "abc"], ids=["blank", "zero", "negative", "nonsense"]
+    )
+    def test_the_factory_survives_unusable_session_settings(self, env_value: str) -> None:
+        """Whatever the value, the app starts and the healthcheck still answers.
+
+        A secret or lifetime the codec would reject must degrade to a 503
+        refusal with a working ``/health``, never to a factory that raises and
+        leaves nothing running to report why.
+        """
+        for name in ("OSPREY_AUTH_SESSION_SECRET", "OSPREY_AUTH_SESSION_LIFETIME"):
+            env = dict(PASSWORD_ENV)
+            env[name] = env_value
+            with TestClient(create_app(env)) as client:
+                assert client.get(HEALTH_PATH).status_code == 200
+
+    def test_a_user_without_a_hash_is_denied_individually_not_globally(self) -> None:
+        settings = AuthSettings.from_env(PASSWORD_ENV)
+        assert settings.configured is True
+        assert settings.password_hash("bob") is None
+        assert settings.knows_user("bob") is True
+
+
+class TestSettingsParsing:
+    """The documented env-var names, read exactly as documented."""
+
+    def test_explicit_mapping_ignores_the_process_environment(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OSPREY_AUTH_METHOD", "password")
+        monkeypatch.setenv("OSPREY_AUTH_SESSION_SECRET", "leaked-from-the-process")
+        settings = AuthSettings.from_env({})
+        assert settings.method == "none"
+        assert settings.session_secret == ""
+
+    def test_process_environment_is_the_default_source(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for name, value in PASSWORD_ENV.items():
+            monkeypatch.setenv(name, value)
+        assert AuthSettings.from_env().configured is True
+
+    def test_roster_is_ordered_and_deduplicated(self) -> None:
+        env = dict(PASSWORD_ENV, OSPREY_AUTH_USERS=" bob , alice ,, bob ")
+        assert AuthSettings.from_env(env).users == ("bob", "alice")
+
+    def test_per_user_hash_uses_the_shared_suffix_mapping(self) -> None:
+        env = dict(
+            PASSWORD_ENV,
+            OSPREY_AUTH_USERS="alice-b",
+            OSPREY_AUTH_PW_HASH_ALICE_B="stored-hash",
+        )
+        assert AuthSettings.from_env(env).password_hash("alice-b") == "stored-hash"
+
+    def test_hashes_outside_the_roster_are_not_loaded(self) -> None:
+        env = dict(PASSWORD_ENV, OSPREY_AUTH_PW_HASH_MALLORY="stored-hash")
+        settings = AuthSettings.from_env(env)
+        assert settings.password_hash("mallory") is None
+        assert set(settings.password_hashes) == {"alice"}
+
+    def test_per_user_oidc_subject_is_read(self) -> None:
+        env = dict(OIDC_ENV, OSPREY_AUTH_OIDC_SUBJECT_ALICE="alice@example.org")
+        settings = AuthSettings.from_env(env)
+        assert settings.oidc_subject("alice") == "alice@example.org"
+        assert settings.oidc_subject("bob") is None
+
+    def test_oidc_credentials_are_read_through_the_named_variables(self) -> None:
+        env = dict(OIDC_ENV)
+        del env["OSPREY_AUTH_OIDC_CLIENT_ID"]
+        env["OSPREY_AUTH_OIDC_CLIENT_ID_ENV"] = "FACILITY_IDP_CLIENT"
+        env["FACILITY_IDP_CLIENT"] = "facility-client-id"
+        settings = AuthSettings.from_env(env)
+        assert settings.oidc_client_id == "facility-client-id"
+        assert settings.oidc_client_secret == "client-secret"
+
+    def test_session_lifetime_defaults_and_rejects_nonsense(self) -> None:
+        assert AuthSettings.from_env(PASSWORD_ENV).session_lifetime == DEFAULT_SESSION_LIFETIME
+        for value in ("0", "-5", "half an hour", ""):
+            env = dict(PASSWORD_ENV, OSPREY_AUTH_SESSION_LIFETIME=value)
+            assert AuthSettings.from_env(env).session_lifetime == DEFAULT_SESSION_LIFETIME
+        env = dict(PASSWORD_ENV, OSPREY_AUTH_SESSION_LIFETIME="3600")
+        assert AuthSettings.from_env(env).session_lifetime == 3600
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [("true", True), ("1", True), ("YES", True), ("false", False), ("", False)],
+    )
+    def test_tls_flag_reading(self, value: str, expected: bool) -> None:
+        env = dict(PASSWORD_ENV, OSPREY_AUTH_TLS_ENABLED=value)
+        assert AuthSettings.from_env(env).tls_enabled is expected
+
+    def test_external_origin_drops_a_trailing_slash(self) -> None:
+        env = dict(PASSWORD_ENV, OSPREY_AUTH_EXTERNAL_ORIGIN="https://example.org/")
+        assert AuthSettings.from_env(env).external_origin == "https://example.org"
+
+    def test_settings_are_reachable_from_a_request(self) -> None:
+        app = create_app(PASSWORD_ENV)
+
+        @app.get("/auth/_settings")
+        async def read(request: Request) -> dict[str, Any]:
+            return {"users": list(get_settings(request).users)}
+
+        with TestClient(app) as client:
+            assert client.get("/auth/_settings").json() == {"users": ["alice", "bob"]}
+
+    def test_settings_are_cached_on_app_state(self) -> None:
+        app = create_app(PASSWORD_ENV)
+        assert isinstance(app.state.settings, AuthSettings)
+        assert app.state.settings.method == "password"
+
+
+class TestSharedStores:
+    """The revocation store and attempt throttle follow the codec's pattern.
+
+    Both are per-process state that only means anything if every route touches
+    the one instance: a second revocation store is a logout nothing checks, and
+    a second throttle counts every attempt as the first, so neither ever closes
+    a window.
+    """
+
+    STORES = [
+        ("revocation_store", get_revocation_store, RevocationStore, "revocation store"),
+        ("attempt_throttle", get_attempt_throttle, AttemptThrottle, "attempt throttle"),
+    ]
+    IDS = ["revocation-store", "attempt-throttle"]
+
+    @pytest.mark.parametrize(("attribute", "accessor", "kind", "label"), STORES, ids=IDS)
+    def test_configured_app_builds_the_store(
+        self, attribute: str, accessor: Any, kind: type, label: str
+    ) -> None:
+        assert isinstance(getattr(create_app(PASSWORD_ENV).state, attribute), kind)
+
+    @pytest.mark.parametrize(("attribute", "accessor", "kind", "label"), STORES, ids=IDS)
+    def test_every_route_gets_the_same_instance(
+        self, attribute: str, accessor: Any, kind: type, label: str
+    ) -> None:
+        app = create_app(PASSWORD_ENV)
+        seen: list[Any] = []
+
+        @app.get("/auth/_store")
+        async def read(request: Request) -> dict[str, bool]:
+            seen.append(accessor(request))
+            return {"ok": True}
+
+        with TestClient(app) as client:
+            client.get("/auth/_store")
+            client.get("/auth/_store")
+
+        assert len(seen) == 2
+        assert seen[0] is seen[1] is getattr(app.state, attribute)
+
+    @pytest.mark.parametrize(("attribute", "accessor", "kind", "label"), STORES, ids=IDS)
+    def test_unconfigured_app_has_no_store(
+        self, attribute: str, accessor: Any, kind: type, label: str
+    ) -> None:
+        assert getattr(create_app({}).state, attribute) is None
+
+    @pytest.mark.parametrize(("attribute", "accessor", "kind", "label"), STORES, ids=IDS)
+    def test_accessor_refuses_when_there_is_no_store(
+        self, attribute: str, accessor: Any, kind: type, label: str
+    ) -> None:
+        request = SimpleNamespace(app=SimpleNamespace(state=create_app({}).state))
+        with pytest.raises(RuntimeError, match="configuration guard"):
+            accessor(request)
+        with pytest.raises(RuntimeError, match=label):
+            accessor(request)
+
+    def test_the_three_shared_objects_are_distinct(self) -> None:
+        """A copy-paste in the factory would otherwise alias two of them."""
+        state = create_app(PASSWORD_ENV).state
+        assert state.session_codec is not state.revocation_store
+        assert state.revocation_store is not state.attempt_throttle
+
+    def test_stores_keep_their_own_clocks(self) -> None:
+        """Neither store is wired to the codec's clock.
+
+        The revocation store records absolute epoch expiries taken straight
+        from session cookies, and the throttle runs on a monotonic clock so a
+        wall-clock step cannot open a window early. Sharing the codec's
+        injectable clock would break both properties.
+        """
+        state = create_app(PASSWORD_ENV).state
+        assert state.revocation_store._clock is time.time
+        assert state.attempt_throttle._clock is time.monotonic
+
+
+class TestSessionCodec:
+    """One codec per app, shared by every route that touches a session cookie.
+
+    Four route modules each constructing their own would be four chances to
+    drift on the signing secret, the maximum age, or — least visibly — the
+    clock, so the identity of the shared instance is the thing worth pinning.
+    """
+
+    def test_configured_app_builds_a_codec(self) -> None:
+        app = create_app(PASSWORD_ENV)
+        assert isinstance(app.state.session_codec, SessionCodec)
+
+    def test_every_route_gets_the_same_instance(self) -> None:
+        app = create_app(PASSWORD_ENV)
+        seen: list[SessionCodec] = []
+
+        @app.get("/auth/_codec")
+        async def read(request: Request) -> dict[str, bool]:
+            seen.append(get_session_codec(request))
+            return {"ok": True}
+
+        with TestClient(app) as client:
+            client.get("/auth/_codec")
+            client.get("/auth/_codec")
+
+        assert len(seen) == 2
+        assert seen[0] is seen[1] is app.state.session_codec
+
+    def test_unconfigured_app_has_no_codec(self) -> None:
+        assert create_app({}).state.session_codec is None
+
+    def test_accessor_refuses_when_there_is_no_codec(self) -> None:
+        app = create_app({})
+        request = SimpleNamespace(app=SimpleNamespace(state=app.state))
+        with pytest.raises(RuntimeError, match="configuration guard"):
+            get_session_codec(request)  # type: ignore[arg-type]
+
+    def test_codec_signs_with_the_configured_session_secret(self) -> None:
+        app = create_app(PASSWORD_ENV)
+        codec: SessionCodec = app.state.session_codec
+        cookie = codec.encode(codec.new_state())
+
+        assert SessionCodec(SESSION_SECRET).decode(cookie).session_id
+        with pytest.raises(InvalidSessionError):
+            SessionCodec("a-different-secret").decode(cookie)
+
+    def test_codec_max_age_is_the_configured_session_lifetime(self) -> None:
+        env = dict(PASSWORD_ENV, OSPREY_AUTH_SESSION_LIFETIME="60")
+        codec: SessionCodec = create_app(env).state.session_codec
+
+        fresh = SessionState(session_id="s", issued_at=time.time())
+        assert codec.decode(codec.encode(fresh)).session_id == "s"
+
+        stale = SessionState(session_id="s", issued_at=time.time() - 120)
+        with pytest.raises(InvalidSessionError, match="maximum session age"):
+            codec.decode(codec.encode(stale))
+
+
+class TestStateCookie:
+    """Authlib's session cookie carries our pins, not Starlette's defaults."""
+
+    def _set_cookie(self, env: dict[str, str]) -> str:
+        """The ``Set-Cookie`` header, lowercased.
+
+        Starlette writes the attribute names in lowercase (``path=``,
+        ``httponly``); browsers treat them case-insensitively, so the
+        assertions do too rather than pinning today's casing.
+        """
+        with TestClient(_probe_app(env)) as client:
+            response = client.get("/auth/_probe")
+        assert response.status_code == 200
+        return response.headers["set-cookie"].lower()
+
+    def test_name_path_and_lifetime_are_pinned(self) -> None:
+        header = self._set_cookie(OIDC_ENV)
+        assert header.startswith(f"{STATE_COOKIE_NAME}=")
+        assert f"max-age={STATE_COOKIE_MAX_AGE}" in header
+        assert "path=/auth" in header
+        assert "samesite=lax" in header
+        assert "httponly" in header
+
+    def test_lifetime_is_not_starlettes_fortnight(self) -> None:
+        assert STATE_COOKIE_MAX_AGE == 300
+        assert "max-age=1209600" not in self._set_cookie(OIDC_ENV)
+
+    def test_secure_follows_the_tls_flag(self) -> None:
+        assert "secure" in self._set_cookie(OIDC_ENV)
+        assert "secure" not in self._set_cookie(
+            dict(OIDC_ENV, OSPREY_AUTH_TLS_ENABLED="false", OSPREY_AUTH_EXTERNAL_ORIGIN="http://x")
+        )
+
+    def test_state_secret_never_reaches_the_client(self) -> None:
+        header = self._set_cookie(OIDC_ENV)
+        assert STATE_SECRET not in header
+        assert SESSION_SECRET not in header
+
+    def test_app_without_a_state_secret_still_constructs(self) -> None:
+        env = dict(PASSWORD_ENV)
+        env.pop("OSPREY_AUTH_STATE_SECRET", None)
+        with TestClient(create_app(env)) as client:
+            assert client.get(HEALTH_PATH).status_code == 200
+
+    def test_no_state_secret_means_no_session_middleware(self) -> None:
+        """Without a minted secret the middleware is absent, not stand-in keyed.
+
+        A per-process fallback key would let a route issue state cookies signed
+        by a secret that dies with the process — surfacing later as
+        unexplainable intermittent handshake failures. Absent middleware instead
+        fails at the first line that touches a session, naming the real problem.
+        """
+        env = dict(PASSWORD_ENV)
+        env.pop("OSPREY_AUTH_STATE_SECRET", None)
+        app = _probe_app(env)
+
+        assert not any(middleware.cls is SessionMiddleware for middleware in app.user_middleware)
+        with TestClient(app) as client, pytest.raises(AssertionError, match="SessionMiddleware"):
+            client.get("/auth/_probe")
+
+    def test_a_state_secret_installs_the_middleware(self) -> None:
+        app = create_app(OIDC_ENV)
+        assert any(middleware.cls is SessionMiddleware for middleware in app.user_middleware)
+
+
+class TestRouteExtensionPoint:
+    """Route modules are picked up when they land, and never faked when they don't."""
+
+    def test_absent_route_modules_are_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A name with no module behind it leaves the app with only ``/health``.
+
+        The list is replaced rather than left alone: asserting on the real route
+        surface would make this test fail every time a route module lands, which
+        says nothing about the skip behaviour it exists to pin.
+        """
+        monkeypatch.setattr(app_mod, "_ROUTE_MODULES", ("never_landing",))
+        paths = create_app(PASSWORD_ENV).openapi()["paths"]
+        assert set(paths) == {HEALTH_PATH}
+
+    def test_schema_endpoints_are_not_served(self) -> None:
+        """A security perimeter publishes no schema of its own routes.
+
+        ``app.openapi()`` still builds one in-process (the assertions above rely
+        on it); only the served endpoints are gone.
+        """
+        with TestClient(create_app(PASSWORD_ENV)) as client:
+            for path in ("/openapi.json", "/docs", "/redoc"):
+                assert client.get(path).status_code == 404
+
+    def test_a_landed_route_module_is_included(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        router = APIRouter()
+
+        @router.get("/verify")
+        async def verify() -> dict[str, str]:
+            return {"status": "ok"}
+
+        module = ModuleType("osprey.services.auth_sidecar.routes.verify")
+        module.router = router  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module.__name__, module)
+
+        app = create_app(PASSWORD_ENV)
+        assert "/verify" in app.openapi()["paths"]
+        with TestClient(app) as client:
+            assert client.get("/verify").json() == {"status": "ok"}
+
+    def test_a_broken_route_module_fails_loudly(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _raise(name: str) -> ModuleType:
+            raise ModuleNotFoundError("No module named 'joserfc'", name="joserfc")
+
+        monkeypatch.setattr(app_mod, "import_module", _raise)
+        with pytest.raises(ModuleNotFoundError, match="joserfc"):
+            create_app(PASSWORD_ENV)

--- a/tests/services/auth_sidecar/test_login.py
+++ b/tests/services/auth_sidecar/test_login.py
@@ -1,0 +1,852 @@
+"""Tests for the auth sidecar's password login page and credential POST.
+
+Three properties carry most of the weight here, and each is pinned from several
+directions:
+
+* **The page is addressed per user.** It states the username and never asks for
+  one, and the username it unlocks travels into the session cookie byte for byte
+  — verify exact-matches it against the roster, so any normalisation here would
+  break the chain open rather than closed.
+* **Every refusal is the same refusal.** A wrong password, a roster user with no
+  provisioned credential and a username that is not on the roster at all produce
+  the same status, the same page and the same call into the throttle. The
+  identity of those three responses is asserted byte for byte.
+* **The throttle runs before the credential.** An attempt arriving inside an open
+  window is refused with the *correct* password in hand, and it does not grow
+  the window it was refused by.
+
+Apps are always built from an explicit env mapping, so a variable left in the
+real process environment cannot make one of these pass.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from osprey.services.auth_sidecar.app import create_app
+from osprey.services.auth_sidecar.passwords import generation_tag, hash_password
+from osprey.services.auth_sidecar.return_to import MAX_RETURN_TO_LENGTH
+from osprey.services.auth_sidecar.routes.login import (
+    DENIAL_MESSAGE,
+    LOGIN_PATH,
+    MAX_LOCATION_LENGTH,
+    MAX_USERNAME_LENGTH,
+    OIDC_LOGIN_PATH,
+    THROTTLE_MESSAGE,
+)
+from osprey.services.auth_sidecar.sessions import SESSION_COOKIE_NAME, SessionCodec, SessionState
+from osprey.services.auth_sidecar.throttle import AttemptThrottle
+
+SESSION_SECRET = "session-secret-value"
+STATE_SECRET = "state-secret-value"
+SESSION_LIFETIME = 3600
+EXTERNAL_ORIGIN = "https://terminals.example.org"
+
+ALICE_PASSWORD = "alice-password"
+ALICE_HASH = hash_password(ALICE_PASSWORD)
+
+# Three five-character usernames, so the three refusal bodies can be compared
+# byte for byte after substituting the name each one echoes back:
+#   alice — on the roster, with a provisioned credential
+#   carol — on the roster, with none
+#   mally — not on the roster at all
+PASSWORD_ENV = {
+    "OSPREY_AUTH_METHOD": "password",
+    "OSPREY_AUTH_SESSION_SECRET": SESSION_SECRET,
+    "OSPREY_AUTH_SESSION_LIFETIME": str(SESSION_LIFETIME),
+    "OSPREY_AUTH_USERS": "alice,bob,carol",
+    "OSPREY_AUTH_PW_HASH_ALICE": ALICE_HASH,
+    "OSPREY_AUTH_PW_HASH_BOB": hash_password("bob-password"),
+    "OSPREY_AUTH_EXTERNAL_ORIGIN": EXTERNAL_ORIGIN,
+    "OSPREY_AUTH_TLS_ENABLED": "true",
+}
+
+OIDC_ENV = {
+    "OSPREY_AUTH_METHOD": "oidc",
+    "OSPREY_AUTH_SESSION_SECRET": SESSION_SECRET,
+    "OSPREY_AUTH_STATE_SECRET": STATE_SECRET,
+    "OSPREY_AUTH_SESSION_LIFETIME": str(SESSION_LIFETIME),
+    "OSPREY_AUTH_USERS": "alice,bob",
+    "OSPREY_AUTH_OIDC_ISSUER": "https://idp.example.org",
+    "OSPREY_AUTH_OIDC_CLIENT_ID": "client-id",
+    "OSPREY_AUTH_OIDC_CLIENT_SECRET": "client-secret-value",
+    "OSPREY_AUTH_EXTERNAL_ORIGIN": EXTERNAL_ORIGIN,
+    "OSPREY_AUTH_TLS_ENABLED": "true",
+}
+
+
+def _client(env: dict[str, str] | None = None) -> TestClient:
+    """A test client over a sidecar built from ``env`` (password mode by default).
+
+    Addressed over ``https``, matching the TLS deployment the default env
+    describes: the cookie this route issues carries ``Secure`` there, and a
+    client talking http would silently drop it — the same failure an operator
+    sees when ``tls_enabled`` disagrees with the real origin.
+    """
+    app = create_app(env if env is not None else PASSWORD_ENV)
+    return TestClient(app, base_url="https://testserver")
+
+
+def _issued_cookie(response: httpx.Response) -> str:
+    """The session cookie value a response set.
+
+    Read off the header rather than out of the client's jar: a test that seeds a
+    cookie of its own would otherwise leave two entries under one name, and the
+    assertion would depend on which the jar hands back.
+    """
+    header = response.headers["set-cookie"]
+    return header.split(";", 1)[0].split("=", 1)[1]
+
+
+def _codec(secret: str = SESSION_SECRET) -> SessionCodec:
+    """A client-side codec for reading (or forging) the cookie the route issues."""
+    return SessionCodec(secret, max_age=SESSION_LIFETIME)
+
+
+def _post(client: TestClient, data: dict[str, object], **kwargs: object) -> httpx.Response:
+    """POST to the login route the way a browser on this deployment would.
+
+    Every POST carries an ``Origin``, because the route refuses one that does not
+    — a form that will not say where it came from cannot be told from a
+    cross-site submission. Tests about that check override the header.
+    """
+    headers = {"Origin": EXTERNAL_ORIGIN, **dict(kwargs.pop("headers", {}) or {})}
+    return client.post(LOGIN_PATH, data=data, headers=headers, follow_redirects=False, **kwargs)
+
+
+def _login(
+    client: TestClient,
+    *,
+    user: str = "alice",
+    password: str = ALICE_PASSWORD,
+    next_value: str = "",
+) -> httpx.Response:
+    """POST one credential attempt, without following the success redirect."""
+    return _post(client, {"user": user, "next": next_value, "password": password})
+
+
+def _cookie_attributes(header: str) -> dict[str, str]:
+    """The Set-Cookie attributes, lowercased, as ``{name: value}`` (flags map to "")."""
+    attributes: dict[str, str] = {}
+    for chunk in header.split(";")[1:]:
+        name, _, value = chunk.strip().partition("=")
+        attributes[name.lower()] = value
+    return attributes
+
+
+def _inputs(body: str) -> list[str]:
+    """Every ``<input>`` tag in the page, as raw markup."""
+    return re.findall(r"<input[^>]*>", body, flags=re.IGNORECASE | re.DOTALL)
+
+
+class FakeClock:
+    """A monotonic clock the test moves by hand.
+
+    The throttle's windows are seconds long, so tests that let them lapse in real
+    time would be pinning the machine's speed rather than the route's behaviour —
+    and tests that stay inside one would be assuming two requests land within a
+    second of each other.
+    """
+
+    def __init__(self) -> None:
+        self.time = 1000.0
+
+    def advance(self, seconds: float) -> None:
+        self.time += seconds
+
+    def __call__(self) -> float:
+        return self.time
+
+
+def _throttled_client(
+    env: dict[str, str] | None = None,
+) -> tuple[TestClient, AttemptThrottle, FakeClock]:
+    """A client whose sidecar throttles on a clock the test controls.
+
+    The throttle is replaced on ``app.state`` — the one place every route reaches
+    it through — so the route under test is unmodified.
+    """
+    app = create_app(env if env is not None else PASSWORD_ENV)
+    clock = FakeClock()
+    throttle = AttemptThrottle(clock=clock)
+    app.state.attempt_throttle = throttle
+    return TestClient(app, base_url="https://testserver"), throttle, clock
+
+
+# --- The page ---------------------------------------------------------------
+
+
+def test_page_states_the_user_and_asks_only_for_a_password() -> None:
+    """The acceptance gate: "Enter password for <user>" and no username field."""
+    response = _client().get(LOGIN_PATH, params={"user": "alice", "next": "/u/alice/"})
+
+    assert response.status_code == 200
+    assert "Enter password for" in response.text
+    assert "alice" in response.text
+
+    fields = _inputs(response.text)
+    # One password input, and every other field hidden: nothing on this page
+    # invites typing a username.
+    assert sum('type="password"' in field for field in fields) == 1
+    editable = [field for field in fields if 'type="hidden"' not in field]
+    assert len(editable) == 1
+    assert 'type="password"' in editable[0]
+    assert 'name="user"' not in editable[0]
+    # The username still travels with the form, as a value the browser cannot edit.
+    assert any('type="hidden"' in field and 'name="user"' in field for field in fields)
+
+
+def test_page_is_never_cached() -> None:
+    """A shared control-room browser must not re-serve a previous prompt."""
+    response = _client().get(LOGIN_PATH, params={"user": "alice", "next": ""})
+
+    assert response.headers["cache-control"] == "no-store"
+
+
+def test_page_escapes_the_username_it_echoes() -> None:
+    """A roster name carrying markup renders as text, not as markup."""
+    env = {**PASSWORD_ENV, "OSPREY_AUTH_USERS": "alice,<script>x</script>"}
+    response = _client(env).get(LOGIN_PATH, params={"user": "<script>x</script>"})
+
+    assert response.status_code == 200
+    assert "<script>x</script>" not in response.text
+    assert "&lt;script&gt;" in response.text
+
+
+def test_empty_next_falls_back_to_the_users_own_terminal() -> None:
+    """nginx emits an empty ``next`` when the original path fails its allowlist."""
+    response = _client().get(LOGIN_PATH, params={"user": "alice", "next": ""})
+
+    assert response.status_code == 200
+    assert 'name="next" value="/u/alice/"' in response.text
+
+
+def test_a_same_origin_next_is_carried_into_the_form() -> None:
+    response = _client().get(LOGIN_PATH, params={"user": "alice", "next": "/u/alice/files/log"})
+
+    assert 'name="next" value="/u/alice/files/log"' in response.text
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        "https://evil.example/",
+        "//evil.example/",
+        "/\\evil.example/",
+        "/u/alice/\\..\\evil",
+        "/u/alice/%2f%2fevil.example",
+        "/u/alice/%5Cevil",
+        "u/alice/",
+        "/u/alice/\r\nSet-Cookie: x=y",
+    ],
+)
+def test_an_off_origin_next_is_discarded(hostile: str) -> None:
+    """Anything that could leave this origin is replaced, never repaired."""
+    response = _client().get(LOGIN_PATH, params={"user": "alice", "next": hostile})
+
+    assert response.status_code == 200
+    assert 'name="next" value="/u/alice/"' in response.text
+
+
+@pytest.mark.parametrize("params", [{}, {"user": ""}, {"user": ["alice", "bob"]}])
+def test_a_link_without_exactly_one_user_is_refused(params: dict[str, object]) -> None:
+    """Never a 422: a malformed link gets this route's own refusal."""
+    response = _client().get(LOGIN_PATH, params=params)
+
+    assert response.status_code == 400
+
+
+def test_a_user_who_is_not_on_the_roster_has_no_login_page() -> None:
+    """No credential is evaluated here, and the roster is public."""
+    response = _client().get(LOGIN_PATH, params={"user": "mally"})
+
+    assert response.status_code == 404
+
+
+def test_the_refusals_that_are_not_pages_are_uncacheable_too() -> None:
+    """The page carries no-store; so must the answers that replace it."""
+    client = _client()
+
+    for response in (
+        client.get(LOGIN_PATH),
+        client.get(LOGIN_PATH, params={"user": "mally"}),
+        _post(client, {"password": "x"}),
+        client.post(LOGIN_PATH, data={"password": "x"}, follow_redirects=False),
+    ):
+        assert response.status_code in (400, 404)
+        assert response.headers["cache-control"] == "no-store"
+
+
+# --- Nothing a client sends is assumed to be small --------------------------
+
+
+def test_an_over_long_next_never_reaches_a_location_header() -> None:
+    """nginx bounds what a return-to may contain, not how much of it there is.
+
+    A return-to of request-line size becomes a ``Location`` wider than the
+    proxy's buffer, which the operator meets as a 502 rather than a login.
+    """
+    enormous = "/u/alice/" + "a" * 8000
+
+    page = _client().get(LOGIN_PATH, params={"user": "alice", "next": enormous})
+    redirect = _login(_client(), next_value=enormous)
+
+    assert 'name="next" value="/u/alice/"' in page.text
+    assert redirect.status_code == 303
+    assert redirect.headers["location"] == "/u/alice/"
+
+
+def test_a_next_at_the_cap_is_still_honoured() -> None:
+    """The bound is generous, not a second allowlist: a real deep link survives."""
+    deep = "/u/alice/" + "a" * (MAX_RETURN_TO_LENGTH - len("/u/alice/"))
+
+    response = _client().get(LOGIN_PATH, params={"user": "alice", "next": deep})
+
+    assert f'name="next" value="{deep}"' in response.text
+
+
+def test_an_over_long_user_does_not_enlarge_the_refusal_page() -> None:
+    """The response's size is not an anonymous, pre-credential caller's to choose."""
+    client = _client()
+    ordinary = _login(client, user="mally", password="x")
+
+    huge = _login(client, user="m" * 50_000, password="x")
+
+    assert huge.status_code == ordinary.status_code == 401
+    assert DENIAL_MESSAGE in huge.text
+    # The name is echoed in a few places (title, prompt, hidden field, default
+    # return-to), so the page grows by a small multiple of the cap — never by the
+    # 50 KB the caller sent.
+    assert "m" * (MAX_USERNAME_LENGTH + 1) not in huge.text
+    assert len(huge.text) < len(ordinary.text) + 8 * MAX_USERNAME_LENGTH
+
+
+def test_an_over_long_user_is_never_looked_up_as_a_roster_user() -> None:
+    """Truncating for display must not turn into truncating for authorisation.
+
+    A roster name is at most the cap, so a *prefix* of an over-long submission
+    could match one exactly — and the browser would have unlocked a user it never
+    named.
+    """
+    env = {
+        **PASSWORD_ENV,
+        "OSPREY_AUTH_USERS": "a" * MAX_USERNAME_LENGTH,
+        f"OSPREY_AUTH_PW_HASH_{'A' * MAX_USERNAME_LENGTH}": ALICE_HASH,
+    }
+    client = _client(env)
+
+    response = _login(client, user="a" * (MAX_USERNAME_LENGTH + 1), password=ALICE_PASSWORD)
+
+    assert response.status_code == 401
+    assert "set-cookie" not in response.headers
+
+
+def test_an_over_long_user_has_no_login_page() -> None:
+    response = _client().get(LOGIN_PATH, params={"user": "m" * 50_000})
+
+    assert response.status_code == 400
+    assert len(response.text) < 1000
+
+
+# --- OIDC dispatch ----------------------------------------------------------
+
+
+def test_the_oidc_hand_off_names_the_route_that_exists() -> None:
+    """The login module spells the OIDC path out rather than importing it, so
+    that a deployment with no OIDC in it does not import Authlib. This is the
+    check that keeps the two copies honest."""
+    from osprey.services.auth_sidecar.routes import oidc
+
+    assert OIDC_LOGIN_PATH == oidc.LOGIN_PATH
+
+
+def test_oidc_deployments_are_sent_to_the_oidc_login_route() -> None:
+    """nginx's 401 handler sends every method's browsers here; only one can answer.
+
+    Without this hand-off an OIDC deployment would show a password form that no
+    password could ever satisfy.
+    """
+    response = _client(OIDC_ENV).get(
+        LOGIN_PATH, params={"user": "alice", "next": "/u/alice/files"}, follow_redirects=False
+    )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == f"{OIDC_LOGIN_PATH}?user=alice&next=%2Fu%2Falice%2Ffiles"
+    assert "Enter password for" not in response.text
+
+
+def test_oidc_dispatch_validates_the_return_to_before_forwarding_it() -> None:
+    response = _client(OIDC_ENV).get(
+        LOGIN_PATH,
+        params={"user": "alice", "next": "https://evil.example/"},
+        follow_redirects=False,
+    )
+
+    assert response.headers["location"] == f"{OIDC_LOGIN_PATH}?user=alice&next=%2Fu%2Falice%2F"
+
+
+def test_the_oidc_hand_off_bounds_the_location_it_emits() -> None:
+    """Percent-encoding triples a path of separators, so a return-to inside its
+    own cap can still become a header nginx will not carry."""
+    separators = "/" * (MAX_RETURN_TO_LENGTH - 1)
+
+    response = _client(OIDC_ENV).get(
+        LOGIN_PATH, params={"user": "alice", "next": f"/{separators}"}, follow_redirects=False
+    )
+
+    assert response.status_code == 302
+    assert len(response.headers["location"]) <= MAX_LOCATION_LENGTH
+    assert response.headers["location"].endswith("next=%2Fu%2Falice%2F")
+
+
+def test_oidc_deployments_serve_no_password_form() -> None:
+    """A POST under OIDC is not a refusal of a credential — there is no form."""
+    response = _login(_client(OIDC_ENV))
+
+    assert response.status_code == 404
+
+
+# --- Successful login -------------------------------------------------------
+
+
+def test_login_unlocks_the_user_and_redirects_to_the_validated_target() -> None:
+    client = _client()
+    before = time.time()
+
+    response = _login(client, next_value="/u/alice/files")
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/u/alice/files"
+
+    state = _codec().decode(_issued_cookie(response))
+    entry = state.entry("alice")
+    assert entry is not None
+    assert entry.generation_tag == generation_tag(ALICE_HASH)
+    assert before + SESSION_LIFETIME <= entry.expires_at <= time.time() + SESSION_LIFETIME
+
+
+def test_login_carries_the_username_verbatim_and_verify_accepts_it() -> None:
+    """No normalisation anywhere in the chain: verify exact-matches the roster."""
+    env = {
+        **PASSWORD_ENV,
+        "OSPREY_AUTH_USERS": "Ann",
+        "OSPREY_AUTH_PW_HASH_ANN": ALICE_HASH,
+    }
+    client = _client(env)
+
+    response = _login(client, user="Ann")
+    assert response.status_code == 303
+
+    state = _codec().decode(_issued_cookie(response))
+    assert [user.username for user in state.users] == ["Ann"]
+    # The cookie the login issued authorises exactly the user it named — and the
+    # differently-cased name is a different user, which is why the entry may not
+    # be folded.
+    assert client.get("/verify", params={"user": "Ann"}).status_code == 200
+    assert client.get("/verify", params={"user": "ann"}).status_code == 401
+
+
+def test_an_off_origin_target_in_the_form_is_discarded_too() -> None:
+    """The hidden field is client input like any other, so it is re-validated."""
+    response = _login(_client(), next_value="https://evil.example/")
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/u/alice/"
+
+
+def test_login_leaves_other_unlocked_users_alone() -> None:
+    """One browser may hold several terminals; a second login is not a reset."""
+    codec = _codec()
+    existing = SessionState.new(codec.now()).with_user(
+        "bob", expires_at=codec.now() + SESSION_LIFETIME, generation_tag="bobs-tag"
+    )
+    client = _client()
+    client.cookies.set(SESSION_COOKIE_NAME, codec.encode(existing))
+
+    response = _login(client)
+
+    state = codec.decode(_issued_cookie(response))
+    assert sorted(user.username for user in state.users) == ["alice", "bob"]
+    assert state.session_id == existing.session_id
+
+
+def test_an_unreadable_cookie_is_replaced_by_a_fresh_session() -> None:
+    """A cookie that carries no authorisation is not an error on the way in."""
+    client = _client()
+    client.cookies.set(SESSION_COOKIE_NAME, "not-a-signed-payload")
+
+    response = _login(client)
+
+    assert response.status_code == 303
+    state = _codec().decode(_issued_cookie(response))
+    assert state.unlocked_usernames(state.issued_at) == ("alice",)
+
+
+def test_the_session_cookie_matches_the_oidc_routes_attributes() -> None:
+    """A divergence here would mean login behaved differently per method.
+
+    ``Path=/`` because the cookie must reach the verify subrequest nginx issues
+    from ``/u/<user>/``; no ``Max-Age``, so the browser holds it for the session
+    and the signed expiry inside it stays the only authority on its lifetime.
+    """
+    response = _login(_client())
+
+    header = response.headers["set-cookie"]
+    assert header.startswith(f"{SESSION_COOKIE_NAME}=")
+    attributes = _cookie_attributes(header)
+    assert attributes["path"] == "/"
+    assert attributes["samesite"] == "lax"
+    assert "httponly" in attributes
+    assert "secure" in attributes
+    assert "max-age" not in attributes
+    assert "expires" not in attributes
+
+
+def test_the_session_cookie_drops_secure_on_a_cleartext_deployment() -> None:
+    """A Secure cookie over http is silently discarded — every login would
+    appear to succeed and unlock nothing."""
+    env = {**PASSWORD_ENV, "OSPREY_AUTH_TLS_ENABLED": "false"}
+
+    response = _login(_client(env))
+
+    assert "secure" not in _cookie_attributes(response.headers["set-cookie"])
+
+
+def test_a_multipart_form_is_parsed_like_any_other() -> None:
+    """The regression guard for the form-parsing dependency.
+
+    Starlette needs ``python-multipart`` for every form body, so a build that
+    lost it would serve a login page whose form can never be submitted — with a
+    green unit suite behind it if nothing exercised a real POST.
+    """
+    response = _post(
+        _client(),
+        {"user": "alice", "next": "/u/alice/", "password": ALICE_PASSWORD},
+        files={"unused": ("empty.txt", b"")},
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/u/alice/"
+
+
+def test_a_revoked_session_id_is_not_carried_into_the_new_cookie() -> None:
+    """Otherwise a logout/login race locks the browser out of what it just unlocked.
+
+    Logout revokes by session id and verify refuses every cookie carrying a
+    revoked one, so a login that inherited the id would hand back a freshly
+    signed cookie that verify rejects — and the next login would inherit it
+    again, with nothing in either response saying why.
+    """
+    app = create_app(PASSWORD_ENV)
+    client = TestClient(app, base_url="https://testserver")
+    codec = _codec()
+    retired = SessionState.new(codec.now())
+    app.state.revocation_store.revoke(retired.session_id, codec.now() + SESSION_LIFETIME)
+    client.cookies.set(SESSION_COOKIE_NAME, codec.encode(retired))
+
+    response = _login(client)
+
+    assert response.status_code == 303
+    assert codec.decode(_issued_cookie(response)).session_id != retired.session_id
+    # The proof that matters: the terminal this login was for actually opens.
+    assert client.get("/verify", params={"user": "alice"}).status_code == 200
+
+
+# --- Cross-site submissions --------------------------------------------------
+
+
+def test_a_form_submitted_from_another_origin_is_not_a_login() -> None:
+    """``SameSite=Lax`` does not stop a browser storing the cookie a top-level
+    cross-site POST comes back with, so an attacker page could otherwise log an
+    operator into the attacker's roster user — and because a login adds rather
+    than replaces, the operator would keep their own terminals and have little
+    reason to notice which one they are typing into."""
+    client, throttle, _ = _throttled_client()
+
+    response = _post(
+        client,
+        {"user": "alice", "next": "", "password": ALICE_PASSWORD},
+        headers={"Origin": "https://evil.example"},
+    )
+
+    assert response.status_code == 400
+    assert "set-cookie" not in response.headers
+    assert SESSION_COOKIE_NAME not in client.cookies
+    # Refused before the throttle: a cross-site page must not be able to burn an
+    # operator's window either.
+    assert throttle.retry_after("alice") == 0.0
+
+
+@pytest.mark.parametrize("origin", [EXTERNAL_ORIGIN, EXTERNAL_ORIGIN.upper() + "/"])
+def test_the_deployments_declared_origin_is_accepted(origin: str) -> None:
+    """Case and a trailing slash do not make it a different site."""
+    response = _post(
+        _client(),
+        {"user": "alice", "next": "", "password": ALICE_PASSWORD},
+        headers={"Origin": origin},
+    )
+
+    assert response.status_code == 303
+
+
+def test_the_declared_origin_outranks_the_host_the_request_arrived_on() -> None:
+    """``external_origin`` is the deployment's own word about where it lives;
+    ``Host`` is the client's. Where the two disagree, the client does not win."""
+    response = _post(
+        _client(),
+        {"user": "alice", "next": "", "password": ALICE_PASSWORD},
+        headers={"Origin": "https://testserver"},
+    )
+
+    assert response.status_code == 400
+
+
+def test_a_deployment_with_no_declared_origin_falls_back_to_the_host() -> None:
+    """Password mode is not required to declare one, and must still log people in.
+
+    The fallback is weaker — ``Host`` is client-supplied — but not weak against
+    this attack: a cross-site form makes the browser derive ``Host`` from the URL
+    it posts *to* while ``Origin`` names the page it posts *from*, and an
+    attacker chooses neither.
+    """
+    env = {key: value for key, value in PASSWORD_ENV.items() if "EXTERNAL_ORIGIN" not in key}
+    client = _client(env)
+
+    accepted = _post(
+        client,
+        {"user": "alice", "next": "", "password": ALICE_PASSWORD},
+        headers={"Origin": "https://testserver"},
+    )
+    refused = _post(
+        client,
+        {"user": "alice", "next": "", "password": ALICE_PASSWORD},
+        headers={"Origin": "https://evil.example"},
+    )
+
+    assert accepted.status_code == 303
+    assert refused.status_code == 400
+
+
+def test_the_scheme_comes_from_the_proxys_forwarded_header() -> None:
+    """nginx terminates TLS, so the sidecar's own scheme is not the browser's."""
+    env = {key: value for key, value in PASSWORD_ENV.items() if "EXTERNAL_ORIGIN" not in key}
+    client = TestClient(create_app(env), base_url="http://terminals.example.org")
+
+    response = _post(
+        client,
+        {"user": "alice", "next": "", "password": ALICE_PASSWORD},
+        headers={"Origin": "https://terminals.example.org", "X-Forwarded-Proto": "https"},
+    )
+
+    assert response.status_code == 303
+
+
+def test_a_post_that_declares_no_origin_at_all_is_refused() -> None:
+    """Fail closed. Every browser this page can be used from sends one, so the
+    only callers a permissive branch would serve are scripted clients — which
+    have no victim's cookie jar for a minted session to act on."""
+    client = _client()
+
+    response = client.post(
+        LOGIN_PATH,
+        data={"user": "alice", "next": "", "password": ALICE_PASSWORD},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 400
+    assert "set-cookie" not in response.headers
+
+
+def test_a_null_origin_is_not_an_origin() -> None:
+    """Sandboxed iframes and some redirect chains send the literal string."""
+    response = _post(
+        _client(),
+        {"user": "alice", "next": "", "password": ALICE_PASSWORD},
+        headers={"Origin": "null"},
+    )
+
+    assert response.status_code == 400
+
+
+@pytest.mark.parametrize(
+    ("referer", "expected"),
+    [
+        (f"{EXTERNAL_ORIGIN}/auth/login?user=alice", 303),
+        ("https://evil.example/attack.html", 400),
+        ("not-a-url", 400),
+    ],
+)
+def test_referer_stands_in_where_a_browser_omits_the_origin(referer: str, expected: int) -> None:
+    """Older browsers omitted ``Origin`` on same-origin form posts. Only the
+    referrer's origin is read; its path is neither needed nor trusted."""
+    client = _client()
+
+    response = client.post(
+        LOGIN_PATH,
+        data={"user": "alice", "next": "", "password": ALICE_PASSWORD},
+        headers={"Referer": referer},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == expected
+
+
+# --- Refusals ---------------------------------------------------------------
+
+
+def test_a_wrong_password_is_refused_without_a_session() -> None:
+    client = _client()
+
+    response = _login(client, password="not-the-password")
+
+    assert response.status_code == 401
+    assert DENIAL_MESSAGE in response.text
+    assert "set-cookie" not in response.headers
+    assert SESSION_COOKIE_NAME not in client.cookies
+
+
+def test_an_empty_password_is_refused_like_any_other() -> None:
+    response = _login(_client(), password="")
+
+    assert response.status_code == 401
+    assert DENIAL_MESSAGE in response.text
+
+
+def test_every_refusal_is_the_same_refusal() -> None:
+    """Wrong password, no provisioned credential and no roster entry are one answer.
+
+    The three responses are compared byte for byte once each one's echoed
+    username is substituted — the only thing that may differ between them is the
+    caller's own input coming back.
+    """
+    client = _client()
+    wrong = _login(client, user="alice", password="not-the-password")
+    uncredentialed = _login(client, user="carol", password="anything")
+    unknown = _login(client, user="mally", password="anything")
+
+    assert wrong.status_code == uncredentialed.status_code == unknown.status_code == 401
+    for other, name in ((uncredentialed, "carol"), (unknown, "mally")):
+        assert other.text.replace(name, "alice") == wrong.text
+        assert other.headers["content-type"] == wrong.headers["content-type"]
+        assert other.headers["cache-control"] == wrong.headers["cache-control"]
+        assert "set-cookie" not in other.headers
+
+
+def test_the_throttle_fires_for_a_user_who_is_not_on_the_roster() -> None:
+    """A non-roster username must not be the cheap way past the throttle."""
+    client, _, _ = _throttled_client()
+
+    first = _login(client, user="mally", password="anything")
+    second = _login(client, user="mally", password="anything")
+
+    assert first.status_code == 401
+    assert second.status_code == 429
+    assert int(second.headers["retry-after"]) >= 1
+
+
+def test_a_throttled_attempt_is_refused_before_the_credential_is_evaluated() -> None:
+    """The correct password inside an open window is still a 429, not a login."""
+    client, _, _ = _throttled_client()
+    assert _login(client, password="not-the-password").status_code == 401
+
+    response = _login(client, password=ALICE_PASSWORD)
+
+    assert response.status_code == 429
+    assert THROTTLE_MESSAGE in response.text
+    assert int(response.headers["retry-after"]) >= 1
+    assert "set-cookie" not in response.headers
+    assert SESSION_COOKIE_NAME not in client.cookies
+
+
+def test_a_throttled_attempt_does_not_grow_the_window() -> None:
+    """Otherwise a flood of parallel guesses would ratchet the window against
+    the operator the throttle exists to protect."""
+    client, throttle, _ = _throttled_client()
+
+    _login(client, password="not-the-password")
+    opened = throttle.retry_after("alice")
+    assert _login(client, password="not-the-password").status_code == 429
+
+    assert throttle.retry_after("alice") <= opened
+
+
+def test_the_window_lifts_and_the_credential_is_evaluated_again() -> None:
+    """The refusal delays an operator; it never latches into a lockout."""
+    client, throttle, clock = _throttled_client()
+    _login(client, password="not-the-password")
+    assert _login(client, password=ALICE_PASSWORD).status_code == 429
+
+    clock.advance(throttle.max_delay + 1)
+
+    assert _login(client, password=ALICE_PASSWORD).status_code == 303
+
+
+def test_a_successful_login_clears_the_window() -> None:
+    """An operator who mistypes once pays a second, not a minute."""
+    client, throttle, clock = _throttled_client()
+
+    _login(client, password="not-the-password")
+    clock.advance(throttle.max_delay + 1)
+    assert _login(client, password=ALICE_PASSWORD).status_code == 303
+
+    assert throttle.retry_after("alice") == 0.0
+
+
+@pytest.mark.parametrize(
+    "form",
+    [
+        {"password": ALICE_PASSWORD},
+        {"user": "", "password": ALICE_PASSWORD},
+        {"user": ["alice", "bob"], "password": ALICE_PASSWORD},
+    ],
+)
+def test_a_form_without_exactly_one_user_is_refused(form: dict[str, object]) -> None:
+    """Never a 422, and never resolved to whichever value a parser picks first."""
+    response = _post(_client(), form)
+
+    assert response.status_code == 400
+    assert "set-cookie" not in response.headers
+
+
+# --- Logging ----------------------------------------------------------------
+
+
+def test_a_successful_login_is_logged_and_the_password_is_not(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The positive assertion comes first, so this cannot pass vacuously."""
+    caplog.set_level(logging.DEBUG)
+
+    assert _login(_client()).status_code == 303
+
+    assert "password login succeeded for 'alice'" in caplog.text
+    assert ALICE_PASSWORD not in caplog.text
+
+
+def test_a_refusal_names_the_user_but_never_the_credential(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG)
+
+    assert _login(_client(), password="hunter2-and-a-secret").status_code == 401
+
+    assert "login refused for 'alice'" in caplog.text
+    assert "hunter2-and-a-secret" not in caplog.text
+
+
+def test_a_username_carrying_newlines_cannot_forge_a_log_line(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Every caller-supplied value reaching a log line is ``%r``-formatted."""
+    caplog.set_level(logging.DEBUG)
+
+    assert _login(_client(), user="mally\nWARNING forged", password="x").status_code == 401
+
+    assert "'mally\\nWARNING forged'" in caplog.text
+    assert "\nWARNING forged" not in caplog.text

--- a/tests/services/auth_sidecar/test_logout.py
+++ b/tests/services/auth_sidecar/test_logout.py
@@ -1,0 +1,387 @@
+"""Tests for the auth sidecar's logout route.
+
+The acceptance case is the one a shared control-room machine depends on: alice
+logs out, bob — unlocked in the same browser, in the same cookie — is still
+unlocked afterwards. Everything else here is either the other half of that
+(the surrendered cookie really is dead) or the discipline that keeps a logout
+from reporting on a session it was not given.
+
+Cookies are minted with a client-side
+:class:`~osprey.services.auth_sidecar.sessions.SessionCodec` rather than by
+driving the login route, so these tests exercise logout alone. Sessions are
+verified through the real ``/verify`` endpoint, because "revoked" means nothing
+except as verify sees it. The app is always built from an explicit env mapping,
+so a variable left in the real process environment cannot make one pass.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from osprey.services.auth_sidecar.app import create_app
+from osprey.services.auth_sidecar.passwords import generation_tag, hash_password
+from osprey.services.auth_sidecar.routes.logout import LANDING_PATH, LOGOUT_PATH
+from osprey.services.auth_sidecar.sessions import (
+    SESSION_COOKIE_NAME,
+    SessionCodec,
+    SessionState,
+    UnlockedUser,
+)
+
+SESSION_SECRET = "session-secret-value"
+SESSION_LIFETIME = 3600
+
+ALICE_HASH = hash_password("alice-password")
+BOB_HASH = hash_password("bob-password")
+
+PASSWORD_ENV = {
+    "OSPREY_AUTH_METHOD": "password",
+    "OSPREY_AUTH_SESSION_SECRET": SESSION_SECRET,
+    "OSPREY_AUTH_SESSION_LIFETIME": str(SESSION_LIFETIME),
+    "OSPREY_AUTH_USERS": "alice,bob",
+    "OSPREY_AUTH_PW_HASH_ALICE": ALICE_HASH,
+    "OSPREY_AUTH_PW_HASH_BOB": BOB_HASH,
+    "OSPREY_AUTH_EXTERNAL_ORIGIN": "https://terminals.example.org",
+    "OSPREY_AUTH_TLS_ENABLED": "true",
+}
+
+SESSION_ID = "test-session-id"
+
+_STORED = {"alice": ALICE_HASH, "bob": BOB_HASH}
+
+
+def _unlocked(username: str, *, ttl: float = 600.0) -> UnlockedUser:
+    """An unlocked-user entry expiring ``ttl`` seconds from now."""
+    return UnlockedUser(
+        username=username,
+        expires_at=SessionCodec(SESSION_SECRET).now() + ttl,
+        generation_tag=generation_tag(_STORED[username]),
+    )
+
+
+def _mint(*entries: UnlockedUser, session_id: str = SESSION_ID) -> str:
+    """Sign a session cookie carrying ``entries``."""
+    codec = SessionCodec(SESSION_SECRET)
+    return codec.encode(SessionState(session_id=session_id, issued_at=codec.now(), users=entries))
+
+
+def _app(env: dict[str, str] | None = None) -> FastAPI:
+    """A sidecar app built from an explicit environment."""
+    return create_app(PASSWORD_ENV if env is None else env)
+
+
+def _logout(
+    client: TestClient, user: str | list[str] | None, cookie: str | None = None
+) -> httpx.Response:
+    """Call logout the way the in-app control's navigation does.
+
+    The cookie goes in as a raw header rather than through the client's jar, so
+    each request carries exactly the cookie the test named. Redirects are not
+    followed: the landing page is nginx's to serve, not this app's.
+    """
+    headers = {} if cookie is None else {"Cookie": f"{SESSION_COOKIE_NAME}={cookie}"}
+    params = {} if user is None else {"user": user}
+    return client.get(LOGOUT_PATH, params=params, headers=headers, follow_redirects=False)
+
+
+def _verify(client: TestClient, user: str, cookie: str) -> int:
+    """Ask the real verify endpoint whether ``cookie`` still authorizes ``user``."""
+    return client.get(
+        "/verify",
+        params={"user": user},
+        headers={"Cookie": f"{SESSION_COOKIE_NAME}={cookie}"},
+    ).status_code
+
+
+def _reissued(response: httpx.Response) -> str:
+    """The session cookie value the logout response set."""
+    jar = httpx.Cookies()
+    jar.extract_cookies(response)
+    value = jar.get(SESSION_COOKIE_NAME)
+    assert value is not None, "logout did not reissue a session cookie"
+    return value
+
+
+class TestRegistration:
+    """The factory picks the route up with no edit of its own."""
+
+    def test_logout_is_registered_by_the_factory(self) -> None:
+        assert LOGOUT_PATH in _app().openapi()["paths"]
+
+
+class TestAcceptance:
+    """One user leaves; the others stay exactly as they were."""
+
+    def test_alice_logs_out_and_bob_stays_unlocked(self) -> None:
+        cookie = _mint(_unlocked("alice"), _unlocked("bob"))
+        with TestClient(_app()) as client:
+            assert _verify(client, "alice", cookie) == 200
+            assert _verify(client, "bob", cookie) == 200
+
+            reissued = _reissued(_logout(client, "alice", cookie))
+
+            assert _verify(client, "bob", reissued) == 200
+            assert _verify(client, "alice", reissued) == 401
+
+    def test_the_surrendered_cookie_stops_authorizing_everything(self) -> None:
+        """The other half of the acceptance case: bob survives on the cookie he
+        was *given*, never on the one that was handed in — that one is revoked by
+        session id, which retires it for every user it carried."""
+        cookie = _mint(_unlocked("alice"), _unlocked("bob"))
+        with TestClient(_app()) as client:
+            _logout(client, "alice", cookie)
+
+            assert _verify(client, "alice", cookie) == 401
+            assert _verify(client, "bob", cookie) == 401
+
+    def test_logout_redirects_to_the_landing_page(self) -> None:
+        cookie = _mint(_unlocked("alice"))
+        with TestClient(_app()) as client:
+            response = _logout(client, "alice", cookie)
+
+        assert response.status_code == 303
+        assert response.headers["location"] == LANDING_PATH
+        # Like every login response: a cached logout would replay the redirect
+        # without the revocation behind it.
+        assert response.headers["cache-control"] == "no-store"
+
+    def test_the_reissued_session_carries_a_fresh_session_id(self) -> None:
+        """Why bob survives at all: revocation is recorded per session id, and
+        verify refuses every user on a revoked one, so reissuing the same id
+        would log bob out as a side effect of alice leaving."""
+        cookie = _mint(_unlocked("alice"), _unlocked("bob"))
+        with TestClient(_app()) as client:
+            reissued = _reissued(_logout(client, "alice", cookie))
+
+        codec = SessionCodec(SESSION_SECRET)
+        assert codec.decode(reissued).session_id != SESSION_ID
+
+    def test_the_reissued_session_does_not_extend_its_own_age(self) -> None:
+        """Rotating the id must not reset the issued-at stamp, or logging out
+        repeatedly would extend a session past `session_lifetime` indefinitely."""
+        codec = SessionCodec(SESSION_SECRET)
+        issued_at = codec.now() - 120
+        cookie = codec.encode(
+            SessionState(session_id=SESSION_ID, issued_at=issued_at, users=(_unlocked("bob"),))
+        )
+        with TestClient(_app()) as client:
+            reissued = _reissued(_logout(client, "alice", cookie))
+
+        assert codec.decode(reissued).issued_at == pytest.approx(issued_at)
+
+
+class TestLoginAgainAfterLogout:
+    """The self-inflicted-lockout regression the id rotation exists to prevent."""
+
+    def _log_back_in(self, cookie: str, username: str) -> str:
+        """Mint the cookie a login route would issue on top of ``cookie``.
+
+        This is what every login path in this service does with the browser's
+        current session: decode it, add the entry, keep the session id (see
+        ``routes/oidc.py``'s ``_current_session`` followed by ``with_user``).
+        The real routes are not driven here — the password login route has not
+        landed, and the OIDC callback needs an IdP — but the session handling
+        under test is theirs, character for character, and it is precisely the
+        step that inherits whatever session id logout left behind.
+        """
+        codec = SessionCodec(SESSION_SECRET)
+        session = codec.decode(cookie).with_user(
+            username,
+            expires_at=codec.now() + 600,
+            generation_tag=generation_tag(_STORED[username]),
+        )
+        return codec.encode(session)
+
+    def test_logging_in_again_in_the_same_browser_works(self) -> None:
+        """Had logout reissued the revoked session id, this login would mint a
+        fresh entry under an id the store already refuses: the user would get a
+        303 and a cookie, then every verify would deny for up to
+        `session_lifetime` — a silent lockout that looks like a broken password.
+        """
+        cookie = _mint(_unlocked("alice"))
+        with TestClient(_app()) as client:
+            reissued = _reissued(_logout(client, "alice", cookie))
+
+            back_in = self._log_back_in(reissued, "alice")
+
+            assert _verify(client, "alice", back_in) == 200
+
+    def test_logging_in_again_does_not_revive_the_surrendered_cookie(self) -> None:
+        """The other direction: a new login must not un-revoke the cookie that
+        was handed in, which an attacker may have captured before the logout."""
+        cookie = _mint(_unlocked("alice"))
+        with TestClient(_app()) as client:
+            reissued = _reissued(_logout(client, "alice", cookie))
+            self._log_back_in(reissued, "alice")
+
+            assert _verify(client, "alice", cookie) == 401
+
+    def test_a_second_logout_after_logging_back_in_still_revokes(self) -> None:
+        """Rotation must hold across cycles, not just the first one: the second
+        logout revokes the id the second session actually carried."""
+        cookie = _mint(_unlocked("alice"))
+        app = _app()
+        with TestClient(app) as client:
+            reissued = _reissued(_logout(client, "alice", cookie))
+            back_in = self._log_back_in(reissued, "alice")
+            assert _verify(client, "alice", back_in) == 200
+
+            second = _reissued(_logout(client, "alice", back_in))
+
+            assert _verify(client, "alice", back_in) == 401
+            assert _verify(client, "alice", self._log_back_in(second, "alice")) == 200
+
+
+class TestRevocation:
+    """Logout writes to the store verify reads."""
+
+    def test_the_old_session_id_is_revoked_in_the_shared_store(self) -> None:
+        """Revoking into a store nothing checks would look identical from the
+        route's own return value, so this asserts on the app's store itself."""
+        cookie = _mint(_unlocked("alice"))
+        app = _app()
+        with TestClient(app) as client:
+            assert len(app.state.revocation_store) == 0
+            _logout(client, "alice", cookie)
+
+        assert app.state.revocation_store.is_revoked(SESSION_ID)
+
+    def test_a_logout_for_a_user_who_was_not_unlocked_revokes_nothing(self) -> None:
+        """Bob is on the roster but not in this cookie: there is no session of
+        his to retire, and alice's must not be collateral."""
+        cookie = _mint(_unlocked("alice"))
+        app = _app()
+        with TestClient(app) as client:
+            _logout(client, "bob", cookie)
+
+            assert len(app.state.revocation_store) == 0
+            assert _verify(client, "alice", cookie) == 200
+
+
+class TestBenignPaths:
+    """Nothing about a logout reveals whether that user was unlocked."""
+
+    def test_a_logout_with_no_cookie_redirects_without_error(self) -> None:
+        with TestClient(_app()) as client:
+            response = _logout(client, "alice")
+
+        assert response.status_code == 303
+        assert response.headers["location"] == LANDING_PATH
+
+    def test_a_logout_with_no_user_parameter_redirects_without_error(self) -> None:
+        """Never a 422: FastAPI's validation body is a different status, a
+        different shape, and a description of this endpoint nothing needs."""
+        cookie = _mint(_unlocked("alice"))
+        with TestClient(_app()) as client:
+            response = _logout(client, None, cookie)
+
+        assert response.status_code == 303
+
+    def test_a_repeated_user_parameter_acts_on_neither(self) -> None:
+        """As in verify: refused outright rather than resolved to whichever value
+        a parser picks first."""
+        cookie = _mint(_unlocked("alice"), _unlocked("bob"))
+        app = _app()
+        with TestClient(app) as client:
+            assert _logout(client, ["alice", "bob"], cookie).status_code == 303
+
+            assert len(app.state.revocation_store) == 0
+            assert _verify(client, "alice", cookie) == 200
+            assert _verify(client, "bob", cookie) == 200
+
+    def test_a_logout_for_an_unknown_user_redirects_without_error(self) -> None:
+        """Not on the roster at all — still a plain redirect, with no hint that
+        the name was unrecognised rather than merely locked."""
+        cookie = _mint(_unlocked("alice"))
+        with TestClient(_app()) as client:
+            response = _logout(client, "mallory", cookie)
+
+        assert response.status_code == 303
+
+    def test_an_unlocked_and_a_locked_logout_are_shaped_identically(self) -> None:
+        """The information-leak assertion: status, location and the presence of a
+        reissued cookie are the same whether or not that user was unlocked."""
+        cookie = _mint(_unlocked("alice"))
+        with TestClient(_app()) as client:
+            real = _logout(client, "alice", cookie)
+            noop = _logout(client, "bob", cookie)
+
+        assert (real.status_code, real.headers["location"]) == (
+            noop.status_code,
+            noop.headers["location"],
+        )
+        assert _reissued(real) and _reissued(noop)
+
+    def test_an_unreadable_cookie_redirects_without_error(self) -> None:
+        cookie = _mint(_unlocked("alice"))
+        with TestClient(_app()) as client:
+            assert _logout(client, "alice", cookie[:-4]).status_code == 303
+
+    def test_logging_out_the_last_user_leaves_an_empty_session(self) -> None:
+        cookie = _mint(_unlocked("alice"))
+        with TestClient(_app()) as client:
+            reissued = _reissued(_logout(client, "alice", cookie))
+
+        assert SessionCodec(SESSION_SECRET).decode(reissued).users == ()
+
+
+class TestCookieAttributes:
+    """Parity with the cookie the login and OIDC callback routes issue.
+
+    A cookie differing in any attribute below is a *second* cookie to the
+    browser: the original stays in place and the logout logs out of nothing.
+    """
+
+    def _set_cookie_header(self, tls: str) -> str:
+        env = {**PASSWORD_ENV, "OSPREY_AUTH_TLS_ENABLED": tls}
+        cookie = _mint(_unlocked("alice"))
+        with TestClient(_app(env)) as client:
+            response = _logout(client, "alice", cookie)
+        header = response.headers.get("set-cookie")
+        assert header is not None
+        return header
+
+    def test_the_reissued_cookie_is_httponly_lax_and_root_pathed(self) -> None:
+        header = self._set_cookie_header("true")
+
+        assert header.startswith(f"{SESSION_COOKIE_NAME}=")
+        assert "HttpOnly" in header
+        assert "SameSite=lax" in header
+        assert "Path=/" in header
+
+    def test_the_reissued_cookie_is_secure_under_tls(self) -> None:
+        assert "Secure" in self._set_cookie_header("true")
+
+    def test_the_reissued_cookie_drops_secure_without_tls(self) -> None:
+        """`allow_insecure_http` deployments would otherwise have the browser
+        discard a cookie it was told to send only over HTTPS."""
+        assert "Secure" not in self._set_cookie_header("false")
+
+    def test_the_reissued_cookie_carries_no_max_age(self) -> None:
+        """A session cookie: its real lifetime is the signed expiry inside it,
+        and a Max-Age would be a second, unsigned answer to the same question."""
+        header = self._set_cookie_header("true")
+
+        assert "Max-Age" not in header
+        assert "Expires" not in header
+
+
+class TestLogging:
+    """Caller-supplied values reach the log only through `%r`."""
+
+    def test_a_username_carrying_a_newline_cannot_forge_a_log_line(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cookie = _mint(_unlocked("alice"))
+        with caplog.at_level(logging.DEBUG, logger="osprey.services.auth_sidecar.routes.logout"):
+            with TestClient(_app()) as client:
+                _logout(client, "mallory\nINFO forged", cookie)
+
+        assert caplog.records
+        assert "\\nINFO forged" in caplog.text
+        assert "\nINFO forged" not in caplog.text

--- a/tests/services/auth_sidecar/test_oidc.py
+++ b/tests/services/auth_sidecar/test_oidc.py
@@ -1,0 +1,749 @@
+"""Tests for the auth sidecar's OIDC login and callback routes.
+
+Authlib is replaced at the route boundary — ``app.state.oidc_client`` — so these
+tests pin *this* module's decisions rather than the library's: which roster user
+a callback can unlock, what happens when the asserted identity maps to nobody or
+to somebody else, and what the re-issued session cookie carries. The handshake
+against a real (mock) IdP is a separate test.
+
+The load-bearing assertion, repeated in several shapes: a callback never unlocks
+a user other than the one whose card was clicked, whatever identity the IdP
+asserts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from base64 import b64encode
+from typing import Any
+
+import httpx
+import itsdangerous
+import pytest
+from authlib.integrations.starlette_client import OAuthError
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from osprey.services.auth_sidecar.app import STATE_COOKIE_NAME, create_app
+from osprey.services.auth_sidecar.return_to import MAX_RETURN_TO_LENGTH
+from osprey.services.auth_sidecar.routes.oidc import (
+    CALLBACK_PATH,
+    LOGIN_PATH,
+    PENDING_FLOW_SESSION_KEY,
+)
+from osprey.services.auth_sidecar.sessions import SESSION_COOKIE_NAME, SessionCodec, SessionState
+
+SESSION_SECRET = "session-secret-value"
+STATE_SECRET = "state-secret-value"
+EXTERNAL_ORIGIN = "https://terminals.example.org"
+SESSION_LIFETIME = 3600
+
+ALICE_SUBJECT = "idp|alice"
+CAROL_SUBJECT = "idp|carol"
+FLOW_STATE = "handshake-state-value"
+IDP_AUTHORIZE_URL = "https://idp.example.org/authorize?client_id=client-id&state=" + FLOW_STATE
+
+# alice and carol are mapped; bob is on the roster with no mapped identity, so
+# he is the "unmapped" case every refusal test needs.
+OIDC_ENV = {
+    "OSPREY_AUTH_METHOD": "oidc",
+    "OSPREY_AUTH_SESSION_SECRET": SESSION_SECRET,
+    "OSPREY_AUTH_STATE_SECRET": STATE_SECRET,
+    "OSPREY_AUTH_SESSION_LIFETIME": str(SESSION_LIFETIME),
+    "OSPREY_AUTH_USERS": "alice,bob,carol",
+    "OSPREY_AUTH_OIDC_ISSUER": "https://idp.example.org",
+    "OSPREY_AUTH_OIDC_CLIENT_ID": "client-id",
+    "OSPREY_AUTH_OIDC_CLIENT_SECRET": "client-secret-value",
+    "OSPREY_AUTH_OIDC_SUBJECT_ALICE": ALICE_SUBJECT,
+    "OSPREY_AUTH_OIDC_SUBJECT_CAROL": CAROL_SUBJECT,
+    "OSPREY_AUTH_EXTERNAL_ORIGIN": EXTERNAL_ORIGIN,
+    "OSPREY_AUTH_TLS_ENABLED": "true",
+}
+
+PASSWORD_ENV = {
+    "OSPREY_AUTH_METHOD": "password",
+    "OSPREY_AUTH_SESSION_SECRET": SESSION_SECRET,
+    "OSPREY_AUTH_USERS": "alice",
+    "OSPREY_AUTH_EXTERNAL_ORIGIN": EXTERNAL_ORIGIN,
+}
+
+
+class FakeOIDCClient:
+    """Stands in for Authlib's Starlette client at the route boundary.
+
+    Records what the login route hands it (the ``redirect_uri`` above all, which
+    the IdP registration has to match) and returns whatever the test wants the
+    callback to see.
+    """
+
+    def __init__(
+        self,
+        *,
+        userinfo: dict[str, Any] | None = None,
+        token: dict[str, Any] | None = None,
+        authorize_error: BaseException | None = None,
+        callback_error: BaseException | None = None,
+        state: str = FLOW_STATE,
+    ) -> None:
+        self.state = state
+        self.token = token if token is not None else {"userinfo": userinfo or {}}
+        self.authorize_error = authorize_error
+        self.callback_error = callback_error
+        self.redirect_uri: str | None = None
+        self.saved: dict[str, Any] | None = None
+
+    async def create_authorization_url(self, redirect_uri: str | None = None) -> dict[str, Any]:
+        if self.authorize_error is not None:
+            raise self.authorize_error
+        self.redirect_uri = redirect_uri
+        return {"url": IDP_AUTHORIZE_URL, "state": self.state, "nonce": "nonce-value"}
+
+    async def save_authorize_data(self, request: Any, **kwargs: Any) -> None:
+        self.saved = kwargs
+
+    async def authorize_access_token(self, request: Any, **kwargs: Any) -> dict[str, Any]:
+        # Authlib's own signature takes keyword arguments the callback supplies
+        # (claims_options above all, which is what makes it check the audience).
+        # Accepting and recording them keeps this stand-in callable wherever the
+        # real client is; refusing them would fail every callback with a
+        # TypeError the broad except arm reports as an unvalidatable token.
+        self.token_kwargs = kwargs
+        if self.callback_error is not None:
+            raise self.callback_error
+        return self.token
+
+
+def _app(env: dict[str, str] | None = None, client: FakeOIDCClient | None = None) -> FastAPI:
+    """An app in OIDC mode with Authlib replaced."""
+    app = create_app(env if env is not None else OIDC_ENV)
+    app.state.oidc_client = client if client is not None else FakeOIDCClient()
+    return app
+
+
+def _client(app: FastAPI, *, tls: bool = True) -> TestClient:
+    """A test client whose origin matches the deployment's.
+
+    Not cosmetic: the state cookie the factory pins carries ``Secure`` whenever
+    the deployment is on TLS, and a client on an ``http://`` origin drops it
+    silently — every handshake would then fail as "no login in flight", for a
+    reason that has nothing to do with this module.
+    """
+    return TestClient(app, base_url="https://testserver" if tls else "http://testserver")
+
+
+def _osprey_log(caplog: pytest.LogCaptureFixture) -> str:
+    """Only this service's log records.
+
+    The test client's own HTTP logger echoes full request URLs, so asserting
+    against the whole capture would test httpx rather than what this module
+    writes.
+    """
+    return "\n".join(
+        record.getMessage() for record in caplog.records if record.name.startswith("osprey.")
+    )
+
+
+def _state_cookie(data: dict[str, Any]) -> str:
+    """Forge a Starlette session cookie the way ``SessionMiddleware`` signs one.
+
+    Lets a callback be exercised without first driving the login route, which is
+    the only way to test a pending flow the login route would never create (an
+    unmapped user, a stale state).
+    """
+    signer = itsdangerous.TimestampSigner(STATE_SECRET)
+    return signer.sign(b64encode(json.dumps(data).encode("utf-8"))).decode("utf-8")
+
+
+def _pending(user: str, *, state: str = FLOW_STATE, next_target: str | None = None) -> str:
+    """A state cookie carrying one in-flight handshake for ``user``.
+
+    One caveat for anything built on this helper: a cookie planted here lands in
+    the test jar at path ``/``, while the response's own ``Set-Cookie`` carries
+    the pinned ``path=/auth``, so the jar keeps the planted value instead of
+    replacing it. The route still consumes the flow — the *server* pops it — but
+    a second request from the same client presents the forged cookie again.
+    Assert on consumption only through the real login route (see
+    ``test_callback_does_not_reuse_a_completed_flow``), never through this one.
+    """
+    return _state_cookie(
+        {
+            PENDING_FLOW_SESSION_KEY: {
+                "state": state,
+                "user": user,
+                "next": next_target or f"/u/{user}/",
+            }
+        }
+    )
+
+
+def _session_from(response: httpx.Response) -> SessionState:
+    """Decode the auth session cookie the response set."""
+    codec = SessionCodec(SESSION_SECRET, max_age=SESSION_LIFETIME)
+    return codec.decode(response.cookies[SESSION_COOKIE_NAME])
+
+
+def _set_cookie_header(response: httpx.Response, name: str) -> str:
+    """The raw ``Set-Cookie`` header for ``name``; attributes are asserted on it."""
+    for header in response.headers.get_list("set-cookie"):
+        if header.startswith(f"{name}="):
+            return header
+    raise AssertionError(f"no Set-Cookie for {name!r} in {response.headers.get_list('set-cookie')}")
+
+
+# --- the routes exist and belong to this mode --------------------------------
+
+
+def test_factory_includes_the_oidc_routes() -> None:
+    """The factory picks the module up with no edit of its own."""
+    paths = create_app(OIDC_ENV).openapi()["paths"]
+    assert LOGIN_PATH in paths
+    assert CALLBACK_PATH in paths
+
+
+@pytest.mark.parametrize("path", [LOGIN_PATH, CALLBACK_PATH])
+def test_oidc_routes_are_absent_in_password_mode(path: str) -> None:
+    """A password deployment has no OIDC surface, even though the module loads."""
+    with _client(_app(PASSWORD_ENV)) as client:
+        response = client.get(path, params={"user": "alice"}, follow_redirects=False)
+    assert response.status_code == 404
+
+
+# --- login -------------------------------------------------------------------
+
+
+def test_login_redirects_to_the_identity_provider() -> None:
+    """The clicked card starts a handshake whose redirect_uri is the deployment's."""
+    fake = FakeOIDCClient()
+    with _client(_app(client=fake)) as client:
+        response = client.get(LOGIN_PATH, params={"user": "alice"}, follow_redirects=False)
+
+    assert response.status_code == 302
+    assert response.headers["location"] == IDP_AUTHORIZE_URL
+    assert fake.redirect_uri == f"{EXTERNAL_ORIGIN}{CALLBACK_PATH}"
+    assert fake.saved is not None
+    assert fake.saved["redirect_uri"] == f"{EXTERNAL_ORIGIN}{CALLBACK_PATH}"
+    # The clicked user rides in the signed state cookie, never on the wire.
+    assert STATE_COOKIE_NAME in response.cookies
+    assert "alice" not in response.headers["location"]
+
+
+def test_login_refuses_a_user_with_no_mapped_identity(caplog: pytest.LogCaptureFixture) -> None:
+    """A handshake that could only end in a refusal never starts."""
+    with caplog.at_level(logging.WARNING), _client(_app()) as client:
+        response = client.get(LOGIN_PATH, params={"user": "bob"}, follow_redirects=False)
+
+    assert response.status_code == 403
+    assert "bob" in caplog.text
+
+
+def test_login_refuses_a_user_who_is_not_on_the_roster() -> None:
+    with _client(_app()) as client:
+        response = client.get(LOGIN_PATH, params={"user": "mallory"}, follow_redirects=False)
+    assert response.status_code == 404
+
+
+def test_login_reports_an_unreachable_issuer_as_502() -> None:
+    """Discovery failure is the IdP's fault, not a crash in the sidecar."""
+    fake = FakeOIDCClient(authorize_error=httpx.ConnectError("no route to issuer"))
+    with _client(_app(client=fake)) as client:
+        response = client.get(LOGIN_PATH, params={"user": "alice"}, follow_redirects=False)
+    assert response.status_code == 502
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        RuntimeError('Missing "authorize_url" value'),
+        ValueError("Expecting value: line 1 column 1 (char 0)"),
+    ],
+    ids=["no-authorization-endpoint", "not-json"],
+)
+def test_login_reports_an_unusable_discovery_document_as_502(failure: Exception) -> None:
+    """A wrong issuer or a captive portal serves a document that parses badly
+    rather than failing to arrive; that is still the IdP's problem, not a 500."""
+    with _client(_app(client=FakeOIDCClient(authorize_error=failure))) as client:
+        response = client.get(LOGIN_PATH, params={"user": "alice"}, follow_redirects=False)
+    assert response.status_code == 502
+
+
+# --- return-to validation ----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "https://evil.example.org/",
+        "//evil.example.org/",
+        "/\\evil.example.org/",
+        "/u/alice/\\..\\..",
+        "u/alice/",
+        "/u/alice/\r\nSet-Cookie: x=y",
+    ],
+    ids=["absolute", "protocol-relative", "backslash-authority", "backslash", "relative", "crlf"],
+)
+def test_login_discards_an_off_origin_return_to(target: str) -> None:
+    """A tampered return-to sends the operator to their own terminal instead."""
+    with _client(_app(client=FakeOIDCClient(userinfo={"sub": ALICE_SUBJECT}))) as client:
+        client.get(LOGIN_PATH, params={"user": "alice", "next": target}, follow_redirects=False)
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/u/alice/"
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "/u/alice/artifacts%2f..%2f..%2fu%2fbob%2f",
+        "/u/alice/" + "a" * MAX_RETURN_TO_LENGTH,
+    ],
+    ids=["encoded-separator", "over-length"],
+)
+def test_login_discards_a_return_to_only_the_shared_rule_rejects(target: str) -> None:
+    """Both flows hold a return-to to one rule.
+
+    An encoded separator (which this service, nginx and the browser each resolve
+    differently) and a value past the cap (which becomes a ``Location`` header
+    the proxy answers with a 502) are rejected on the OIDC leg exactly as they
+    are on the password one.
+    """
+    with _client(_app(client=FakeOIDCClient(userinfo={"sub": ALICE_SUBJECT}))) as client:
+        client.get(LOGIN_PATH, params={"user": "alice", "next": target}, follow_redirects=False)
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/u/alice/"
+
+
+def test_login_keeps_a_same_origin_return_to() -> None:
+    with _client(_app(client=FakeOIDCClient(userinfo={"sub": ALICE_SUBJECT}))) as client:
+        client.get(
+            LOGIN_PATH,
+            params={"user": "alice", "next": "/u/alice/tuning?panel=orbit"},
+            follow_redirects=False,
+        )
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/u/alice/tuning?panel=orbit"
+
+
+def test_callback_survives_a_return_to_that_is_not_a_string() -> None:
+    """The stored return-to is read back out of a cookie payload, so its shape
+    is whatever was written, not whatever was declared."""
+    app = _app(client=FakeOIDCClient(userinfo={"sub": ALICE_SUBJECT}))
+    with _client(app) as client:
+        client.cookies.set(
+            STATE_COOKIE_NAME,
+            _state_cookie(
+                {PENDING_FLOW_SESSION_KEY: {"state": FLOW_STATE, "user": "alice", "next": 17}}
+            ),
+        )
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/u/alice/"
+
+
+# --- callback: the identity must be the clicked user's -----------------------
+
+
+def test_callback_unlocks_the_clicked_user() -> None:
+    """The whole point: a mapped identity unlocks that user and nobody else."""
+    with _client(_app(client=FakeOIDCClient(userinfo={"sub": ALICE_SUBJECT}))) as client:
+        client.get(LOGIN_PATH, params={"user": "alice"}, follow_redirects=False)
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/u/alice/"
+    session = _session_from(response)
+    assert session.unlocked_usernames(now=0.0) == ("alice",)
+    entry = session.entry("alice")
+    assert entry is not None
+    # No generation tag: that is the password mode's rotation signal, and an
+    # empty one is what verify refuses to authorise a password session on.
+    assert entry.generation_tag == ""
+
+
+def test_callback_expiry_comes_from_the_configured_lifetime() -> None:
+    codec = SessionCodec(SESSION_SECRET, max_age=SESSION_LIFETIME)
+    with _client(_app(client=FakeOIDCClient(userinfo={"sub": ALICE_SUBJECT}))) as client:
+        client.get(LOGIN_PATH, params={"user": "alice"}, follow_redirects=False)
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    entry = _session_from(response).entry("alice")
+    assert entry is not None
+    assert entry.expires_at == pytest.approx(codec.now() + SESSION_LIFETIME, abs=5)
+
+
+def test_callback_cookie_carries_the_pinned_attributes() -> None:
+    """HttpOnly always, SameSite=Lax, Secure under TLS, and path ``/`` so the
+    cookie reaches the ``/u/<user>/`` locations it authorises."""
+    with _client(_app(client=FakeOIDCClient(userinfo={"sub": ALICE_SUBJECT}))) as client:
+        client.get(LOGIN_PATH, params={"user": "alice"}, follow_redirects=False)
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    header = _set_cookie_header(response, SESSION_COOKIE_NAME).lower()
+    assert "httponly" in header
+    assert "samesite=lax" in header
+    assert "secure" in header
+    assert "path=/;" in header or header.rstrip().endswith("path=/")
+
+
+def test_callback_does_not_inherit_a_revoked_session_id() -> None:
+    """A logout/login race must not lock the browser out of what it just unlocked.
+
+    Logout revokes by session id and verify refuses every cookie carrying a
+    revoked one, so a callback that kept the id would re-sign a cookie verify
+    then rejects — and the next handshake would inherit it again.
+    """
+    app = _app(client=FakeOIDCClient(userinfo={"sub": ALICE_SUBJECT}))
+    codec = SessionCodec(SESSION_SECRET, max_age=SESSION_LIFETIME)
+    retired = SessionState.new(codec.now())
+    app.state.revocation_store.revoke(retired.session_id, codec.now() + SESSION_LIFETIME)
+
+    with _client(app) as client:
+        client.cookies.set(SESSION_COOKIE_NAME, codec.encode(retired))
+        client.get(LOGIN_PATH, params={"user": "alice"}, follow_redirects=False)
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+        assert response.status_code == 303
+        assert _session_from(response).session_id != retired.session_id
+        # The proof that matters: the terminal this handshake was for opens.
+        assert client.get("/verify", params={"user": "alice"}).status_code == 200
+
+
+def test_callback_without_tls_issues_no_secure_cookie() -> None:
+    env = {
+        **OIDC_ENV,
+        "OSPREY_AUTH_TLS_ENABLED": "false",
+        "OSPREY_AUTH_EXTERNAL_ORIGIN": "http://x",
+    }
+    app = _app(env, FakeOIDCClient(userinfo={"sub": ALICE_SUBJECT}))
+    with _client(app, tls=False) as client:
+        client.get(LOGIN_PATH, params={"user": "alice"}, follow_redirects=False)
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    assert "secure" not in _set_cookie_header(response, SESSION_COOKIE_NAME).lower()
+
+
+def test_callback_honours_the_configured_claim() -> None:
+    """``oidc_claim`` selects which claim carries the identity."""
+    env = {**OIDC_ENV, "OSPREY_AUTH_OIDC_CLAIM": "email"}
+    userinfo = {"sub": "some-opaque-id", "email": ALICE_SUBJECT}
+    with _client(_app(env, FakeOIDCClient(userinfo=userinfo))) as client:
+        client.get(LOGIN_PATH, params={"user": "alice"}, follow_redirects=False)
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    assert response.status_code == 303
+    assert _session_from(response).unlocked_usernames(now=0.0) == ("alice",)
+
+
+def test_callback_refuses_an_identity_mapped_to_another_user(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """carol's identity does not open alice's terminal — and does not open
+    carol's either. The clicked card is the only user a login can unlock."""
+    with (
+        caplog.at_level(logging.WARNING),
+        _client(_app(client=FakeOIDCClient(userinfo={"sub": CAROL_SUBJECT}))) as client,
+    ):
+        client.get(LOGIN_PATH, params={"user": "alice"}, follow_redirects=False)
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    assert response.status_code == 403
+    assert SESSION_COOKIE_NAME not in response.cookies
+    assert "carol" not in caplog.text
+
+
+def test_callback_refuses_an_unmapped_identity(caplog: pytest.LogCaptureFixture) -> None:
+    """The acceptance gate: an IdP identity mapped to no roster user is refused.
+
+    Driven through a forged pending flow for bob, who the login route would
+    never have sent to the IdP — the callback must refuse on its own, not
+    because something upstream did.
+    """
+    app = _app(client=FakeOIDCClient(userinfo={"sub": "idp|stranger"}))
+    with caplog.at_level(logging.WARNING), _client(app) as client:
+        client.cookies.set(STATE_COOKIE_NAME, _pending("bob"))
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    assert response.status_code == 403
+    assert SESSION_COOKIE_NAME not in response.cookies
+    assert "bob" in caplog.text
+
+
+def test_callback_ignores_a_user_query_parameter() -> None:
+    """The clicked card is the username, and the callback's URL is not a vote.
+
+    The pending flow says alice; the query string says carol, whose identity the
+    IdP is asserting. If the query parameter were read, this would succeed as
+    carol — so the refusal is the whole binding, stated in one request.
+    """
+    app = _app(client=FakeOIDCClient(userinfo={"sub": CAROL_SUBJECT}))
+    with _client(app) as client:
+        client.cookies.set(STATE_COOKIE_NAME, _pending("alice"))
+        response = client.get(
+            CALLBACK_PATH,
+            params={"code": "auth-code", "state": FLOW_STATE, "user": "carol"},
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 403
+    assert SESSION_COOKIE_NAME not in response.cookies
+
+
+def test_callback_compares_a_non_ascii_identity_without_raising() -> None:
+    """A mapped identity carrying a diacritic must be able to log in.
+
+    Compared as ``str``, ``secrets.compare_digest`` raises on exactly this
+    input, which would turn a login that should succeed into a 500 and lock the
+    operator out permanently.
+    """
+    env = {**OIDC_ENV, "OSPREY_AUTH_OIDC_SUBJECT_ALICE": "jörg@example.org"}
+    app = _app(env, FakeOIDCClient(userinfo={"sub": "jörg@example.org"}))
+    with _client(app) as client:
+        client.cookies.set(STATE_COOKIE_NAME, _pending("alice"))
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    assert response.status_code == 303
+    assert _session_from(response).unlocked_usernames(now=0.0) == ("alice",)
+
+
+def test_callback_refuses_a_differing_non_ascii_identity() -> None:
+    """The same comparison still denies when the values differ."""
+    env = {**OIDC_ENV, "OSPREY_AUTH_OIDC_SUBJECT_ALICE": "jörg@example.org"}
+    app = _app(env, FakeOIDCClient(userinfo={"sub": "jorg@example.org"}))
+    with _client(app) as client:
+        client.cookies.set(STATE_COOKIE_NAME, _pending("alice"))
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    assert response.status_code == 403
+    assert SESSION_COOKIE_NAME not in response.cookies
+
+
+def test_callback_refuses_a_non_ascii_state_without_raising() -> None:
+    """``state`` is unauthenticated input; an accent in it is a denial, not a 500."""
+    app = _app(client=FakeOIDCClient(userinfo={"sub": ALICE_SUBJECT}))
+    with _client(app) as client:
+        client.cookies.set(STATE_COOKIE_NAME, _pending("alice"))
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": "ü"}, follow_redirects=False
+        )
+
+    assert response.status_code == 400
+    assert SESSION_COOKIE_NAME not in response.cookies
+
+
+def test_callback_refuses_when_the_claim_is_absent() -> None:
+    """A token carrying no usable claim asserts no identity, so it authorises none."""
+    app = _app(client=FakeOIDCClient(userinfo={"email": ALICE_SUBJECT}))
+    with _client(app) as client:
+        client.cookies.set(STATE_COOKIE_NAME, _pending("alice"))
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    assert response.status_code == 403
+    assert SESSION_COOKIE_NAME not in response.cookies
+
+
+def test_callback_refuses_a_non_string_claim() -> None:
+    """A claim of the wrong shape is not compared against, it is refused."""
+    app = _app(client=FakeOIDCClient(userinfo={"sub": ["idp|alice"]}))
+    with _client(app) as client:
+        client.cookies.set(STATE_COOKIE_NAME, _pending("alice"))
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    assert response.status_code == 403
+
+
+def test_callback_refuses_a_token_with_no_userinfo() -> None:
+    app = _app(client=FakeOIDCClient(token={"access_token": "opaque"}))
+    with _client(app) as client:
+        client.cookies.set(STATE_COOKIE_NAME, _pending("alice"))
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    assert response.status_code == 403
+
+
+# --- callback: handshake integrity -------------------------------------------
+
+
+def test_callback_without_a_pending_flow_is_refused() -> None:
+    """A callback nobody started is not a login."""
+    with _client(_app()) as client:
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    assert response.status_code == 400
+    assert SESSION_COOKIE_NAME not in response.cookies
+
+
+def test_callback_refuses_a_state_the_browser_did_not_start() -> None:
+    """The returned state must be the one this browser's pending flow carries."""
+    app = _app(client=FakeOIDCClient(userinfo={"sub": ALICE_SUBJECT}))
+    with _client(app) as client:
+        client.cookies.set(STATE_COOKIE_NAME, _pending("alice", state="a-different-state"))
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    assert response.status_code == 400
+    assert SESSION_COOKIE_NAME not in response.cookies
+
+
+def test_callback_does_not_reuse_a_completed_flow() -> None:
+    """The pending flow is consumed, so a replayed callback finds nothing."""
+    with _client(_app(client=FakeOIDCClient(userinfo={"sub": ALICE_SUBJECT}))) as client:
+        client.get(LOGIN_PATH, params={"user": "alice"}, follow_redirects=False)
+        first = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+        replay = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    assert first.status_code == 303
+    assert replay.status_code == 400
+
+
+def test_authorization_failure_is_a_4xx_not_a_crash() -> None:
+    """Authlib's own state/IdP error path surfaces as a refusal."""
+    app = _app(client=FakeOIDCClient(callback_error=OAuthError(error="access_denied")))
+    with _client(app) as client:
+        client.cookies.set(STATE_COOKIE_NAME, _pending("alice"))
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    assert response.status_code == 400
+    assert SESSION_COOKIE_NAME not in response.cookies
+
+
+def test_token_validation_failure_is_reported_as_a_bad_gateway() -> None:
+    """An ID token that does not validate is the IdP's problem, not a 500."""
+    app = _app(client=FakeOIDCClient(callback_error=ValueError("bad signature")))
+    with _client(app) as client:
+        client.cookies.set(STATE_COOKIE_NAME, _pending("alice"))
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    assert response.status_code == 502
+    assert SESSION_COOKIE_NAME not in response.cookies
+
+
+def test_unreachable_token_endpoint_is_reported_as_a_bad_gateway() -> None:
+    app = _app(client=FakeOIDCClient(callback_error=httpx.ConnectError("token endpoint down")))
+    with _client(app) as client:
+        client.cookies.set(STATE_COOKIE_NAME, _pending("alice"))
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    assert response.status_code == 502
+
+
+# --- the session the callback re-issues --------------------------------------
+
+
+def test_callback_keeps_other_unlocked_users() -> None:
+    """A shared control-room browser: alice logging in leaves bob unlocked."""
+    codec = SessionCodec(SESSION_SECRET, max_age=SESSION_LIFETIME)
+    existing = codec.new_state().with_user(
+        "bob", expires_at=codec.now() + SESSION_LIFETIME, generation_tag="bobtag"
+    )
+    app = _app(client=FakeOIDCClient(userinfo={"sub": ALICE_SUBJECT}))
+    with _client(app) as client:
+        client.cookies.set(SESSION_COOKIE_NAME, codec.encode(existing))
+        client.get(LOGIN_PATH, params={"user": "alice"}, follow_redirects=False)
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    session = _session_from(response)
+    assert set(session.unlocked_usernames(now=0.0)) == {"alice", "bob"}
+    bob = session.entry("bob")
+    assert bob is not None
+    assert bob.generation_tag == "bobtag"
+    assert session.session_id == existing.session_id
+
+
+def test_callback_treats_an_unreadable_cookie_as_a_fresh_session() -> None:
+    """A tampered session cookie carries no authorisation, so it is replaced."""
+    app = _app(client=FakeOIDCClient(userinfo={"sub": ALICE_SUBJECT}))
+    with _client(app) as client:
+        client.cookies.set(SESSION_COOKIE_NAME, "not-a-signed-cookie")
+        client.get(LOGIN_PATH, params={"user": "alice"}, follow_redirects=False)
+        response = client.get(
+            CALLBACK_PATH, params={"code": "auth-code", "state": FLOW_STATE}, follow_redirects=False
+        )
+
+    assert response.status_code == 303
+    assert _session_from(response).unlocked_usernames(now=0.0) == ("alice",)
+
+
+# --- nothing secret leaves the process ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_factory",
+    [
+        lambda: FakeOIDCClient(userinfo={"sub": CAROL_SUBJECT}),
+        lambda: FakeOIDCClient(callback_error=OAuthError(error="access_denied")),
+    ],
+    ids=["mismatch", "authorization-error"],
+)
+def test_failures_never_echo_credentials_or_tokens(
+    client_factory: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Refusals name a category; they never carry the client secret, the code,
+    the token, or the asserted identity."""
+    app = _app(client=client_factory())
+    with caplog.at_level(logging.DEBUG), _client(app) as client:
+        client.cookies.set(STATE_COOKIE_NAME, _pending("alice"))
+        response = client.get(
+            CALLBACK_PATH,
+            params={"code": "secret-auth-code", "state": FLOW_STATE},
+            follow_redirects=False,
+        )
+
+    leaked = ("client-secret-value", "secret-auth-code", CAROL_SUBJECT, ALICE_SUBJECT)
+    for value in leaked:
+        assert value not in response.text
+        assert value not in _osprey_log(caplog)

--- a/tests/services/auth_sidecar/test_oidc_flow.py
+++ b/tests/services/auth_sidecar/test_oidc_flow.py
@@ -1,0 +1,633 @@
+"""The auth sidecar's OIDC handshake, driven against a real signing IdP.
+
+``test_oidc.py`` replaces Authlib at ``app.state.oidc_client``; these tests
+replace nothing. The sidecar builds its own client from
+``OSPREY_AUTH_OIDC_ISSUER``, fetches a discovery document over a socket, and
+hands Authlib tokens signed by :mod:`tests.services.auth_sidecar.mock_idp` — so
+what is under test here is the half the fake stands in for: discovery, the
+nonce, the ID token's signature, and its ``iss``/``aud``/``exp`` claims. Every
+refusal below is Authlib's, arriving at the callback's deliberately broad
+``except`` arm; every acceptance is a token that genuinely verified.
+
+**The flow is walked, never assembled.** Each test starts at the login route,
+follows the 302 to the provider with a second client (a real request to the
+listening stub — the sidecar's ASGI app cannot serve it), and hands the
+provider's redirect back to the sidecar as a top-level cross-site GET, cookie
+jar and all. Nothing here forges a state cookie: a planted cookie lands at path
+``/`` while the server's own carries ``path=/auth``, so the jar would keep
+answering with the forgery and any claim about a consumed flow would be
+vacuous. Walking the flow is also the only way SameSite=Lax is genuinely
+exercised — the callback is a cross-site navigation, and a ``strict`` cookie
+would simply not arrive.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from base64 import b64decode
+from collections.abc import Iterator
+from typing import Any
+
+import httpx
+import itsdangerous
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from osprey.interfaces._serving import run_app_server
+from osprey.services.auth_sidecar.app import STATE_COOKIE_NAME, create_app
+from osprey.services.auth_sidecar.routes.oidc import (
+    CALLBACK_PATH,
+    CLIENT_NAME,
+    DEFAULT_SCOPE,
+    LOGIN_PATH,
+    PENDING_FLOW_SESSION_KEY,
+)
+from osprey.services.auth_sidecar.sessions import SESSION_COOKIE_NAME, SessionCodec, SessionState
+from tests.services.auth_sidecar.mock_idp import (
+    DISCOVERY_AS_HTML,
+    DISCOVERY_WITHOUT_AUTHORIZATION_ENDPOINT,
+    MockIdP,
+)
+
+SESSION_SECRET = "session-secret-value"
+STATE_SECRET = "state-secret-value"
+EXTERNAL_ORIGIN = "https://testserver"
+"""The deployment's public origin. It matches the test client's base URL so the
+callback the provider redirects to is one this client can actually be asked
+for, exactly as a browser would be."""
+
+SESSION_LIFETIME = 3600
+
+ALICE_SUBJECT = "idp|alice"
+CAROL_SUBJECT = "idp|carol"
+
+TOP_LEVEL_NAVIGATION = {
+    "Sec-Fetch-Site": "cross-site",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Dest": "document",
+}
+"""What a browser sends when the IdP redirects it back: a cross-site top-level
+GET, which is precisely the request shape SameSite=Lax admits and SameSite=Strict
+would strip the state cookie from."""
+
+
+# --- the provider ------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def idp() -> Iterator[MockIdP]:
+    """One stub provider, listening on a real port for the whole module.
+
+    Served once rather than per test: the sidecar reaches it over TCP, so it
+    cannot be an ASGI object handed to a client, and standing a server up for
+    each of thirty tests costs more than resetting one.
+    """
+    provider = MockIdP()
+    with run_app_server(provider.app) as base_url:
+        provider.issuer = base_url
+        yield provider
+
+
+@pytest.fixture(autouse=True)
+def _reset_idp(idp: MockIdP) -> Iterator[None]:
+    """Give every test an unmodified provider with no recorded requests."""
+    idp.reset()
+    yield
+
+
+# --- the sidecar -------------------------------------------------------------
+
+
+def _env(idp: MockIdP, **overrides: str) -> dict[str, str]:
+    """The sidecar's environment, pointed at the running provider.
+
+    alice and carol are mapped; bob is on the roster with no mapped identity.
+    """
+    env = {
+        "OSPREY_AUTH_METHOD": "oidc",
+        "OSPREY_AUTH_SESSION_SECRET": SESSION_SECRET,
+        "OSPREY_AUTH_STATE_SECRET": STATE_SECRET,
+        "OSPREY_AUTH_SESSION_LIFETIME": str(SESSION_LIFETIME),
+        "OSPREY_AUTH_USERS": "alice,bob,carol",
+        "OSPREY_AUTH_OIDC_ISSUER": idp.issuer,
+        "OSPREY_AUTH_OIDC_CLIENT_ID": idp.client_id,
+        "OSPREY_AUTH_OIDC_CLIENT_SECRET": idp.client_secret,
+        "OSPREY_AUTH_OIDC_SUBJECT_ALICE": ALICE_SUBJECT,
+        "OSPREY_AUTH_OIDC_SUBJECT_CAROL": CAROL_SUBJECT,
+        "OSPREY_AUTH_EXTERNAL_ORIGIN": EXTERNAL_ORIGIN,
+        "OSPREY_AUTH_TLS_ENABLED": "true",
+    }
+    env.update(overrides)
+    return env
+
+
+def _sidecar(idp: MockIdP, **overrides: str) -> FastAPI:
+    """A sidecar app with no test double anywhere in it."""
+    return create_app(_env(idp, **overrides))
+
+
+def _browser(app: FastAPI) -> TestClient:
+    """A client on the deployment's own origin, keeping its cookies.
+
+    The origin matters: both cookies carry ``Secure`` under TLS, and a client on
+    ``http://`` would drop them and turn every handshake into "no login in
+    flight" for a reason unrelated to what is being tested.
+    """
+    return TestClient(app, base_url=EXTERNAL_ORIGIN)
+
+
+# --- walking the handshake ---------------------------------------------------
+
+
+def _start_login(
+    client: TestClient, user: str, *, next_target: str | None = None
+) -> httpx.Response:
+    """Click ``user``'s card. Returns the sidecar's redirect to the provider."""
+    params = {"user": user}
+    if next_target is not None:
+        params["next"] = next_target
+    return client.get(LOGIN_PATH, params=params, follow_redirects=False)
+
+
+def _visit_identity_provider(location: str) -> httpx.Response:
+    """Follow the redirect to the provider with a real HTTP request.
+
+    A separate client on purpose: the provider is a listening server, not the
+    ASGI app the sidecar's test client is bound to, and routing this hop through
+    that client would send the authorize request to the sidecar instead.
+    """
+    with httpx.Client(follow_redirects=False, timeout=10.0) as browser:
+        return browser.get(location)
+
+
+def _return_to_sidecar(client: TestClient, location: str) -> httpx.Response:
+    """Hand the provider's redirect back to the sidecar as a browser would."""
+    return client.get(location, follow_redirects=False, headers=TOP_LEVEL_NAVIGATION)
+
+
+def _log_in(client: TestClient, user: str, *, next_target: str | None = None) -> httpx.Response:
+    """Walk a whole handshake for ``user``; returns the callback's response."""
+    login = _start_login(client, user, next_target=next_target)
+    assert login.status_code == 302, login.text
+    handoff = _visit_identity_provider(login.headers["location"])
+    assert handoff.status_code == 302, handoff.text
+    return _return_to_sidecar(client, handoff.headers["location"])
+
+
+# --- reading what the cookies carry ------------------------------------------
+
+
+def _state_payload(client: TestClient) -> dict[str, Any]:
+    """The decoded Starlette session the state cookie currently holds.
+
+    Read out of the client's jar, so it reflects what the browser would send
+    next — the only honest place to assert that a handshake was consumed.
+    """
+    raw = client.cookies.get(STATE_COOKIE_NAME)
+    if not raw:
+        return {}
+    unsigned = itsdangerous.TimestampSigner(STATE_SECRET).unsign(raw)
+    payload: dict[str, Any] = json.loads(b64decode(unsigned))
+    return payload
+
+
+def _session_from(response: httpx.Response) -> SessionState:
+    """Decode the auth session cookie the response set."""
+    codec = SessionCodec(SESSION_SECRET, max_age=SESSION_LIFETIME)
+    return codec.decode(response.cookies[SESSION_COOKIE_NAME])
+
+
+def _set_cookie_header(response: httpx.Response, name: str) -> str:
+    """The raw ``Set-Cookie`` header for ``name``; attributes are asserted on it."""
+    for header in response.headers.get_list("set-cookie"):
+        if header.startswith(f"{name}="):
+            return header
+    raise AssertionError(f"no Set-Cookie for {name!r} in {response.headers.get_list('set-cookie')}")
+
+
+def _osprey_log(caplog: pytest.LogCaptureFixture) -> str:
+    """Only this service's log records, never the test clients' request logs."""
+    return "\n".join(
+        record.getMessage() for record in caplog.records if record.name.startswith("osprey.")
+    )
+
+
+# --- the round trip ----------------------------------------------------------
+
+
+def test_a_real_handshake_unlocks_the_clicked_user(idp: MockIdP) -> None:
+    """The whole flow against a real IdP: discovery, redirect, signed token, session.
+
+    Everything Authlib validates is validated here for real — this is the case
+    every refusal below is a single-value deviation from.
+    """
+    with _browser(_sidecar(idp)) as client:
+        response = _log_in(client, "alice", next_target="/u/alice/tuning?panel=orbit")
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/u/alice/tuning?panel=orbit"
+
+    session = _session_from(response)
+    assert session.unlocked_usernames(now=0.0) == ("alice",)
+    entry = session.entry("alice")
+    assert entry is not None
+    # OIDC sessions carry no credential-generation tag; there is no stored hash
+    # to compute one from.
+    assert entry.generation_tag == ""
+
+    authorize = idp.authorize_requests[-1]
+    assert authorize["client_id"] == idp.client_id
+    assert authorize["response_type"] == "code"
+    assert authorize["scope"] == DEFAULT_SCOPE
+    # `openid` in the scope is what makes Authlib generate and later check a nonce.
+    assert authorize["nonce"]
+
+
+def test_the_redirect_uri_is_identical_on_both_legs(idp: MockIdP) -> None:
+    """Authorization and token exchange must present the same ``redirect_uri``.
+
+    An IdP compares the two byte for byte and refuses the exchange when they
+    differ, so this is the assertion that the deployment's registered callback
+    is what actually travels — the value the sidecar derives from its own
+    origin, never from the inbound request.
+    """
+    expected = f"{EXTERNAL_ORIGIN}{CALLBACK_PATH}"
+    with _browser(_sidecar(idp)) as client:
+        response = _log_in(client, "alice")
+
+    assert response.status_code == 303
+    assert idp.authorize_requests[-1]["redirect_uri"] == expected
+    assert idp.token_requests[-1]["redirect_uri"] == expected
+    assert idp.token_requests[-1]["grant_type"] == "authorization_code"
+
+
+def test_authlibs_state_entry_is_written_and_then_cleared(idp: MockIdP) -> None:
+    """The state cookie holds Authlib's own entry beside the sidecar's, briefly.
+
+    ``_state_osprey_oidc_<state>`` is the shape the pinned cookie is sized and
+    scoped for, and both entries have to be gone once the handshake completes or
+    the next login inherits a half-finished one.
+    """
+    with _browser(_sidecar(idp)) as client:
+        login = _start_login(client, "alice")
+        assert login.status_code == 302
+
+        # Read out of the redirect the browser is about to follow, not out of
+        # the provider's records: the state cookie has to be readable at exactly
+        # this point, before the IdP has seen anything.
+        outbound = httpx.URL(login.headers["location"]).params
+        started = _state_payload(client)
+        authlib_key = f"_state_{CLIENT_NAME}_{outbound['state']}"
+        assert authlib_key in started
+        assert started[authlib_key]["data"]["nonce"] == outbound["nonce"]
+        assert started[authlib_key]["data"]["redirect_uri"] == f"{EXTERNAL_ORIGIN}{CALLBACK_PATH}"
+        assert started[PENDING_FLOW_SESSION_KEY]["user"] == "alice"
+        assert started[PENDING_FLOW_SESSION_KEY]["state"] == outbound["state"]
+
+        handoff = _visit_identity_provider(login.headers["location"])
+        response = _return_to_sidecar(client, handoff.headers["location"])
+
+    assert response.status_code == 303
+    finished = _state_payload(client)
+    assert authlib_key not in finished
+    assert PENDING_FLOW_SESSION_KEY not in finished
+
+
+def test_the_callback_arrives_as_a_lax_cross_site_navigation(idp: MockIdP) -> None:
+    """The state cookie is scoped for the redirect that actually comes back.
+
+    ``SameSite=Lax`` and ``path=/auth`` are what let a top-level GET from the
+    IdP carry the handshake; ``Strict`` would drop it and the login would fail
+    as "no login is in progress".
+    """
+    with _browser(_sidecar(idp)) as client:
+        login = _start_login(client, "alice")
+        header = _set_cookie_header(login, STATE_COOKIE_NAME).lower()
+        assert "samesite=lax" in header
+        assert "path=/auth" in header
+        assert "max-age=300" in header
+        assert "httponly" in header
+
+        handoff = _visit_identity_provider(login.headers["location"])
+        response = _return_to_sidecar(client, handoff.headers["location"])
+
+    assert response.status_code == 303
+
+
+def test_a_completed_handshake_cannot_be_replayed(idp: MockIdP) -> None:
+    """The consumed flow is gone from the browser's own cookie, not just the server's."""
+    with _browser(_sidecar(idp)) as client:
+        login = _start_login(client, "alice")
+        handoff = _visit_identity_provider(login.headers["location"])
+        callback_url = handoff.headers["location"]
+
+        first = _return_to_sidecar(client, callback_url)
+        replay = _return_to_sidecar(client, callback_url)
+
+    assert first.status_code == 303
+    assert replay.status_code == 400
+    assert SESSION_COOKIE_NAME not in replay.cookies
+
+
+def test_identity_comes_from_the_id_token_not_the_userinfo_endpoint(idp: MockIdP) -> None:
+    """The userinfo endpoint asserts carol; the token asserts alice; alice wins.
+
+    A sidecar that fell back to the userinfo endpoint would either unlock the
+    wrong user or refuse the right one, and either way this counter would move.
+    """
+    with _browser(_sidecar(idp)) as client:
+        response = _log_in(client, "alice")
+
+    assert response.status_code == 303
+    assert idp.userinfo_requests == 0
+
+
+# --- the ID token has to validate --------------------------------------------
+
+
+def test_a_replayed_nonce_is_refused(idp: MockIdP, caplog: pytest.LogCaptureFixture) -> None:
+    """A token whose nonce is not the one this browser's handshake carries.
+
+    The nonce is the binding between the authorization request and the token;
+    without this check a token minted for one login could be planted into
+    another.
+    """
+    idp.nonce_claim = "a-nonce-from-another-handshake"
+    with caplog.at_level(logging.WARNING), _browser(_sidecar(idp)) as client:
+        response = _log_in(client, "alice")
+
+    assert response.status_code == 502
+    assert SESSION_COOKIE_NAME not in response.cookies
+    assert "did not validate" in _osprey_log(caplog)
+
+
+def test_a_token_signed_by_an_unpublished_key_is_refused(
+    idp: MockIdP, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Signed with the provider's ``kid`` but not its key: the signature fails.
+
+    The matching ``kid`` is what makes this a signature test — an unknown one
+    would be refused as a missing key, which is a different path.
+    """
+    idp.sign_with_intruder_key = True
+    with caplog.at_level(logging.WARNING), _browser(_sidecar(idp)) as client:
+        response = _log_in(client, "alice")
+
+    assert response.status_code == 502
+    assert SESSION_COOKIE_NAME not in response.cookies
+    assert "did not validate" in _osprey_log(caplog)
+
+
+def test_a_token_from_another_issuer_is_refused(
+    idp: MockIdP, caplog: pytest.LogCaptureFixture
+) -> None:
+    """``iss`` must be the issuer the discovery document named."""
+    idp.issuer_claim = "https://idp.evil.example.org"
+    with caplog.at_level(logging.WARNING), _browser(_sidecar(idp)) as client:
+        response = _log_in(client, "alice")
+
+    assert response.status_code == 502
+    assert SESSION_COOKIE_NAME not in response.cookies
+    assert "did not validate" in _osprey_log(caplog)
+
+
+def test_a_token_for_another_audience_is_refused(
+    idp: MockIdP, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A token naming another relying party as its audience does not log anyone in.
+
+    The refusal has to be the audience check itself. Before the callback named
+    ``aud`` in its ``claims_options`` this same token was still refused, but by
+    the OIDC ``azp`` rule — an ``aud`` that is not this client makes ``azp``
+    required, and it was absent — which is why the logged class name is asserted
+    here: ``InvalidClaimError`` is the audience comparison, ``MissingClaimError``
+    would mean the audience was never compared and a claim the IdP chooses
+    whether to send did the work.
+    """
+    idp.audience_claim = "some-other-relying-party"
+    with caplog.at_level(logging.WARNING), _browser(_sidecar(idp)) as client:
+        response = _log_in(client, "alice")
+
+    assert response.status_code == 502
+    assert SESSION_COOKIE_NAME not in response.cookies
+    log = _osprey_log(caplog)
+    assert "did not validate" in log
+    assert "InvalidClaimError" in log
+    assert "MissingClaimError" not in log
+
+
+def test_a_token_for_another_audience_is_refused_even_when_azp_names_this_client(
+    idp: MockIdP,
+) -> None:
+    """The case the ``azp`` rule cannot catch, and the reason ``aud`` is checked.
+
+    ``azp`` naming this client satisfies every OIDC rule Authlib applies on its
+    own, so this token — minted for a *different* relying party — was accepted
+    outright until the audience was named in ``claims_options``: 303, with a
+    session cookie. Nothing but the audience comparison refuses it, which makes
+    this the one test that fails the moment that argument is dropped.
+    """
+    idp.audience_claim = "some-other-relying-party"
+    idp.extra_claims = {"azp": idp.client_id}
+    with _browser(_sidecar(idp)) as client:
+        response = _log_in(client, "alice")
+
+    assert response.status_code == 502
+    assert SESSION_COOKIE_NAME not in response.cookies
+
+
+@pytest.mark.parametrize("slash_in_token", [False, True], ids=["bare-iss", "slashed-iss"])
+def test_a_trailing_slash_on_the_configured_issuer_locks_nobody_out(
+    idp: MockIdP, slash_in_token: bool
+) -> None:
+    """Naming the claims to check must not invent an issuer requirement.
+
+    Supplying ``claims_options`` replaces Authlib's default ``iss`` entry rather
+    than extending it, so the callback rebuilds that entry — and an issuer
+    configured with a trailing slash is the same issuer, because the discovery
+    URL is built by stripping exactly that character. Which spelling reaches the
+    token is the IdP's choice (Auth0 publishes the slashed form, Keycloak the
+    bare one), so an operator who configured it with the slash has to be able to
+    log in against either. Both cases are here because each one is what fails
+    when the other spelling is dropped from the list.
+    """
+    if slash_in_token:
+        idp.issuer_claim = f"{idp.issuer}/"
+    app = _sidecar(idp, OSPREY_AUTH_OIDC_ISSUER=f"{idp.issuer}/")
+    with _browser(app) as client:
+        response = _log_in(client, "alice")
+
+    assert response.status_code == 303
+    assert _session_from(response).unlocked_usernames(now=0.0) == ("alice",)
+
+
+def test_an_expired_token_is_refused(idp: MockIdP, caplog: pytest.LogCaptureFixture) -> None:
+    """Well past Authlib's 120-second leeway, so this is expiry and not clock skew."""
+    idp.issued_at_offset = -3600
+    idp.token_lifetime = 300
+    with caplog.at_level(logging.WARNING), _browser(_sidecar(idp)) as client:
+        response = _log_in(client, "alice")
+
+    assert response.status_code == 502
+    assert SESSION_COOKIE_NAME not in response.cookies
+    assert "did not validate" in _osprey_log(caplog)
+
+
+def test_a_token_response_without_an_id_token_asserts_no_identity(idp: MockIdP) -> None:
+    """An OAuth2 provider where an OIDC one was configured.
+
+    Authlib parses no ID token, so the token carries no ``userinfo`` and there is
+    no identity to compare — a refusal, never a login on the access token alone.
+    """
+    idp.omit_id_token = True
+    with _browser(_sidecar(idp)) as client:
+        response = _log_in(client, "alice")
+
+    assert response.status_code == 403
+    assert SESSION_COOKIE_NAME not in response.cookies
+
+
+# --- the provider misbehaves -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "posture",
+    [DISCOVERY_WITHOUT_AUTHORIZATION_ENDPOINT, DISCOVERY_AS_HTML],
+    ids=["no-authorization-endpoint", "not-json"],
+)
+def test_an_unusable_discovery_document_is_a_bad_gateway(idp: MockIdP, posture: str) -> None:
+    """Reachable but wrong is still the IdP's problem, not a 500.
+
+    A mistyped issuer lands on something that answers 200 — a captive portal, a
+    plain web server — and the failure surfaces inside Authlib rather than as an
+    httpx error.
+    """
+    idp.discovery = posture
+    with _browser(_sidecar(idp)) as client:
+        response = _start_login(client, "alice")
+
+    assert response.status_code == 502
+    assert idp.authorize_requests == []
+
+
+def test_a_rejected_consent_screen_is_a_refusal(idp: MockIdP) -> None:
+    """The IdP sends the browser back with ``error=`` instead of a code."""
+    idp.authorize_error = "access_denied"
+    with _browser(_sidecar(idp)) as client:
+        response = _log_in(client, "alice")
+
+    assert response.status_code == 400
+    assert SESSION_COOKIE_NAME not in response.cookies
+
+
+def test_a_wrong_client_secret_is_a_refusal_not_a_crash(idp: MockIdP) -> None:
+    """The token endpoint really checks the credentials the sidecar presents."""
+    app = _sidecar(idp, OSPREY_AUTH_OIDC_CLIENT_SECRET="not-the-registered-secret")
+    with _browser(app) as client:
+        response = _log_in(client, "alice")
+
+    assert response.status_code == 400
+    assert SESSION_COOKIE_NAME not in response.cookies
+
+
+# --- the identity has to be the clicked user's -------------------------------
+
+
+def test_an_identity_mapped_to_nobody_is_refused(
+    idp: MockIdP, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A verified token is not an authorisation: the subject must be alice's."""
+    idp.subject = "idp|stranger"
+    with caplog.at_level(logging.WARNING), _browser(_sidecar(idp)) as client:
+        response = _log_in(client, "alice")
+
+    assert response.status_code == 403
+    assert SESSION_COOKIE_NAME not in response.cookies
+    assert "alice" in _osprey_log(caplog)
+
+
+def test_an_identity_mapped_to_another_user_is_refused(idp: MockIdP) -> None:
+    """carol's real, verified identity does not open alice's terminal.
+
+    Nor carol's: the clicked card is the only user a handshake can unlock, so no
+    session cookie is issued at all.
+    """
+    idp.subject = CAROL_SUBJECT
+    with _browser(_sidecar(idp)) as client:
+        response = _log_in(client, "alice")
+
+    assert response.status_code == 403
+    assert SESSION_COOKIE_NAME not in response.cookies
+
+
+def test_a_user_with_no_mapped_identity_never_reaches_the_provider(idp: MockIdP) -> None:
+    """bob's handshake could only end in a refusal, so it does not start."""
+    with _browser(_sidecar(idp)) as client:
+        response = _start_login(client, "bob")
+
+    assert response.status_code == 403
+    assert idp.authorize_requests == []
+
+
+def test_a_non_ascii_identity_can_log_in(idp: MockIdP) -> None:
+    """An operator whose mapped identity carries a diacritic is not locked out.
+
+    Compared as ``str``, ``secrets.compare_digest`` raises ``TypeError`` on
+    exactly this input — turning the comparison that was about to succeed into a
+    500, permanently, for that one operator. This is the regression test.
+    """
+    idp.subject = "jörg@example.org"
+    app = _sidecar(idp, OSPREY_AUTH_OIDC_SUBJECT_ALICE="jörg@example.org")
+    with _browser(app) as client:
+        response = _log_in(client, "alice")
+
+    assert response.status_code == 303
+    assert _session_from(response).unlocked_usernames(now=0.0) == ("alice",)
+
+
+def test_a_configured_claim_other_than_sub_is_honoured(idp: MockIdP) -> None:
+    """Facilities commonly map on ``preferred_username`` rather than ``sub``."""
+    idp.subject = "an-opaque-provider-id"
+    idp.extra_claims = {"preferred_username": "alice@example.org"}
+    app = _sidecar(
+        idp,
+        OSPREY_AUTH_OIDC_CLAIM="preferred_username",
+        OSPREY_AUTH_OIDC_SUBJECT_ALICE="alice@example.org",
+    )
+    with _browser(app) as client:
+        response = _log_in(client, "alice")
+
+    assert response.status_code == 303
+    assert _session_from(response).unlocked_usernames(now=0.0) == ("alice",)
+
+
+def test_the_session_cookie_carries_the_pinned_attributes(idp: MockIdP) -> None:
+    """HttpOnly, SameSite=Lax, Secure under TLS, and path ``/`` so it reaches
+    the ``/u/<user>/`` locations it authorises."""
+    with _browser(_sidecar(idp)) as client:
+        response = _log_in(client, "alice")
+
+    header = _set_cookie_header(response, SESSION_COOKIE_NAME).lower()
+    assert "httponly" in header
+    assert "samesite=lax" in header
+    assert "secure" in header
+    assert "path=/;" in header or header.rstrip().endswith("path=/")
+
+
+def test_a_refusal_never_echoes_the_token_or_the_client_secret(
+    idp: MockIdP, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A real signed token is in flight here, so this is the case that matters:
+    neither it, nor the identity it asserts, nor the client secret may appear in
+    a response or a log line."""
+    idp.subject = CAROL_SUBJECT
+    with caplog.at_level(logging.DEBUG), _browser(_sidecar(idp)) as client:
+        response = _log_in(client, "alice")
+
+    assert response.status_code == 403
+    issued = idp.token_requests[-1]["code"]
+    for value in (idp.client_secret, issued, CAROL_SUBJECT):
+        assert value not in response.text
+        assert value not in _osprey_log(caplog)

--- a/tests/services/auth_sidecar/test_passwords.py
+++ b/tests/services/auth_sidecar/test_passwords.py
@@ -7,6 +7,7 @@ import hashlib
 import pytest
 
 from osprey.services.auth_sidecar.passwords import (
+    FIELD_SEP,
     GENERATION_TAG_CHARS,
     SCHEME,
     SCRYPT_N,
@@ -31,7 +32,7 @@ class TestHashFormat:
     """The stored string carries its own scheme and cost parameters."""
 
     def test_fields_are_scheme_then_pinned_parameters(self, stored: str) -> None:
-        fields = stored.split("$")
+        fields = stored.split(FIELD_SEP)
         assert len(fields) == 6
         scheme, n, r, p = fields[:4]
         assert scheme == SCHEME
@@ -41,7 +42,7 @@ class TestHashFormat:
         assert (SCRYPT_N, SCRYPT_R, SCRYPT_P) == (2**14, 8, 1)
 
     def test_salt_and_hash_are_non_empty(self, stored: str) -> None:
-        salt, digest = stored.split("$")[4:]
+        salt, digest = stored.split(FIELD_SEP)[4:]
         assert salt and digest
 
     def test_plaintext_never_appears_in_the_stored_string(self, stored: str) -> None:
@@ -50,7 +51,7 @@ class TestHashFormat:
     def test_each_hash_draws_a_fresh_salt(self) -> None:
         first, second = hash_password("same"), hash_password("same")
         assert first != second
-        assert first.split("$")[4] != second.split("$")[4]
+        assert first.split(FIELD_SEP)[4] != second.split(FIELD_SEP)[4]
 
     def test_empty_password_is_refused(self) -> None:
         with pytest.raises(ValueError, match="must not be empty"):
@@ -76,7 +77,7 @@ class TestVerify:
     def test_parameters_are_read_from_the_stored_string(self) -> None:
         """A hash minted at a different cost still verifies."""
         legacy = hash_password(PASSWORD, n=2**4, r=1, p=1)
-        assert legacy.split("$")[1:4] == ["16", "1", "1"]
+        assert legacy.split(FIELD_SEP)[1:4] == ["16", "1", "1"]
         assert verify_password(PASSWORD, legacy) is True
         assert verify_password("nope", legacy) is False
 
@@ -85,14 +86,14 @@ class TestVerify:
         [
             "",
             "not-a-hash",
-            "scrypt$16384$8$1$c2FsdA",  # too few fields
-            "scrypt$16384$8$1$c2FsdA$aGFzaA$extra",  # too many fields
-            "bcrypt$16384$8$1$c2FsdA$aGFzaA",  # unknown scheme
-            "scrypt$many$8$1$c2FsdA$aGFzaA",  # non-integer cost
-            "scrypt$0$8$1$c2FsdA$aGFzaA",  # out-of-range cost
-            "scrypt$16384$8$1$!!!$aGFzaA",  # undecodable salt
-            "scrypt$16384$8$1$$aGFzaA",  # empty salt
-            "scrypt$16384$8$1$c2FsdA$",  # empty hash
+            "scrypt.16384.8.1.c2FsdA",  # too few fields
+            "scrypt.16384.8.1.c2FsdA.aGFzaA.extra",  # too many fields
+            "bcrypt.16384.8.1.c2FsdA.aGFzaA",  # unknown scheme
+            "scrypt.many.8.1.c2FsdA.aGFzaA",  # non-integer cost
+            "scrypt.0.8.1.c2FsdA.aGFzaA",  # out-of-range cost
+            "scrypt.16384.8.1.!!!.aGFzaA",  # undecodable salt
+            "scrypt.16384.8.1..aGFzaA",  # empty salt
+            "scrypt.16384.8.1.c2FsdA.",  # empty hash
         ],
     )
     def test_malformed_stored_hash_fails_closed(self, bad: str) -> None:
@@ -116,7 +117,7 @@ class TestGenerationTag:
 
     def test_tag_discloses_neither_the_hash_nor_the_password(self, stored: str) -> None:
         tag = generation_tag(stored)
-        salt, digest = stored.split("$")[4:]
+        salt, digest = stored.split(FIELD_SEP)[4:]
         assert tag not in stored
         assert salt not in tag
         assert digest not in tag

--- a/tests/services/auth_sidecar/test_passwords.py
+++ b/tests/services/auth_sidecar/test_passwords.py
@@ -1,0 +1,147 @@
+"""Tests for auth-sidecar password hashing and credential-generation tags."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from osprey.services.auth_sidecar.passwords import (
+    GENERATION_TAG_CHARS,
+    SCHEME,
+    SCRYPT_N,
+    SCRYPT_P,
+    SCRYPT_R,
+    generation_tag,
+    hash_password,
+    verify_generation_tag,
+    verify_password,
+)
+
+PASSWORD = "correct horse battery staple"
+
+
+@pytest.fixture(scope="module")
+def stored() -> str:
+    """A stored-hash string for :data:`PASSWORD`, minted once for the module."""
+    return hash_password(PASSWORD)
+
+
+class TestHashFormat:
+    """The stored string carries its own scheme and cost parameters."""
+
+    def test_fields_are_scheme_then_pinned_parameters(self, stored: str) -> None:
+        fields = stored.split("$")
+        assert len(fields) == 6
+        scheme, n, r, p = fields[:4]
+        assert scheme == SCHEME
+        assert (int(n), int(r), int(p)) == (SCRYPT_N, SCRYPT_R, SCRYPT_P)
+
+    def test_pinned_cost_is_the_documented_one(self) -> None:
+        assert (SCRYPT_N, SCRYPT_R, SCRYPT_P) == (2**14, 8, 1)
+
+    def test_salt_and_hash_are_non_empty(self, stored: str) -> None:
+        salt, digest = stored.split("$")[4:]
+        assert salt and digest
+
+    def test_plaintext_never_appears_in_the_stored_string(self, stored: str) -> None:
+        assert PASSWORD not in stored
+
+    def test_each_hash_draws_a_fresh_salt(self) -> None:
+        first, second = hash_password("same"), hash_password("same")
+        assert first != second
+        assert first.split("$")[4] != second.split("$")[4]
+
+    def test_empty_password_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="must not be empty"):
+            hash_password("")
+
+
+class TestVerify:
+    """Verification round-trips and fails closed."""
+
+    def test_correct_password_verifies(self, stored: str) -> None:
+        assert verify_password(PASSWORD, stored) is True
+
+    def test_wrong_password_is_rejected(self, stored: str) -> None:
+        assert verify_password("wrong horse battery staple", stored) is False
+
+    def test_empty_password_is_rejected(self, stored: str) -> None:
+        assert verify_password("", stored) is False
+
+    def test_non_ascii_password_round_trips(self) -> None:
+        secret = "pässwörd-Ω-日本語"
+        assert verify_password(secret, hash_password(secret)) is True
+
+    def test_parameters_are_read_from_the_stored_string(self) -> None:
+        """A hash minted at a different cost still verifies."""
+        legacy = hash_password(PASSWORD, n=2**4, r=1, p=1)
+        assert legacy.split("$")[1:4] == ["16", "1", "1"]
+        assert verify_password(PASSWORD, legacy) is True
+        assert verify_password("nope", legacy) is False
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            "not-a-hash",
+            "scrypt$16384$8$1$c2FsdA",  # too few fields
+            "scrypt$16384$8$1$c2FsdA$aGFzaA$extra",  # too many fields
+            "bcrypt$16384$8$1$c2FsdA$aGFzaA",  # unknown scheme
+            "scrypt$many$8$1$c2FsdA$aGFzaA",  # non-integer cost
+            "scrypt$0$8$1$c2FsdA$aGFzaA",  # out-of-range cost
+            "scrypt$16384$8$1$!!!$aGFzaA",  # undecodable salt
+            "scrypt$16384$8$1$$aGFzaA",  # empty salt
+            "scrypt$16384$8$1$c2FsdA$",  # empty hash
+        ],
+    )
+    def test_malformed_stored_hash_fails_closed(self, bad: str) -> None:
+        assert verify_password(PASSWORD, bad) is False
+
+
+class TestGenerationTag:
+    """The tag is a truncated one-way digest of the stored-hash string."""
+
+    def test_tag_is_truncated_sha256_of_the_stored_string(self, stored: str) -> None:
+        expected = hashlib.sha256(stored.encode("utf-8")).hexdigest()[:GENERATION_TAG_CHARS]
+        assert generation_tag(stored) == expected
+
+    def test_tag_shape_is_short_lowercase_hex(self, stored: str) -> None:
+        tag = generation_tag(stored)
+        assert len(tag) == GENERATION_TAG_CHARS == 16
+        assert all(char in "0123456789abcdef" for char in tag)
+
+    def test_tag_is_deterministic(self, stored: str) -> None:
+        assert generation_tag(stored) == generation_tag(stored)
+
+    def test_tag_discloses_neither_the_hash_nor_the_password(self, stored: str) -> None:
+        tag = generation_tag(stored)
+        salt, digest = stored.split("$")[4:]
+        assert tag not in stored
+        assert salt not in tag
+        assert digest not in tag
+        assert PASSWORD not in tag
+
+    def test_empty_stored_hash_has_no_tag(self) -> None:
+        with pytest.raises(ValueError, match="must not be empty"):
+            generation_tag("")
+
+    def test_tag_verifies_against_its_own_stored_hash(self, stored: str) -> None:
+        assert verify_generation_tag(generation_tag(stored), stored) is True
+
+    def test_rotated_password_invalidates_the_tag(self, stored: str) -> None:
+        rotated = hash_password("a brand new password")
+        assert verify_generation_tag(generation_tag(stored), rotated) is False
+
+    def test_rehashing_the_same_password_invalidates_the_tag(self, stored: str) -> None:
+        """A fresh salt means a fresh generation, even for an unchanged password."""
+        rehashed = hash_password(PASSWORD)
+        assert rehashed != stored
+        assert verify_generation_tag(generation_tag(stored), rehashed) is False
+
+    @pytest.mark.parametrize("tag", ["", "0" * GENERATION_TAG_CHARS, "short"])
+    def test_missing_or_foreign_tag_is_rejected(self, tag: str, stored: str) -> None:
+        assert verify_generation_tag(tag, stored) is False
+
+    def test_tag_check_fails_closed_without_a_stored_hash(self, stored: str) -> None:
+        assert verify_generation_tag(generation_tag(stored), "") is False

--- a/tests/services/auth_sidecar/test_revocation.py
+++ b/tests/services/auth_sidecar/test_revocation.py
@@ -1,0 +1,178 @@
+"""Tests for the auth sidecar's in-memory revocation store."""
+
+from __future__ import annotations
+
+import pytest
+
+from osprey.services.auth_sidecar.revocation import RevocationStore
+
+
+class FakeClock:
+    """A hand-advanced stand-in for ``time.time`` (absolute epoch seconds)."""
+
+    def __init__(self, now: float = 1_000_000.0) -> None:
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.fixture
+def clock() -> FakeClock:
+    return FakeClock()
+
+
+@pytest.fixture
+def store(clock: FakeClock) -> RevocationStore:
+    return RevocationStore(clock=clock)
+
+
+def test_unknown_session_is_not_revoked(store: RevocationStore) -> None:
+    assert store.is_revoked("never-seen") is False
+
+
+def test_revoked_session_is_reported_revoked(store: RevocationStore, clock: FakeClock) -> None:
+    store.revoke("sess-a", expires_at=clock.now + 3600)
+
+    assert store.is_revoked("sess-a") is True
+
+
+def test_revocation_is_scoped_to_the_revoked_id(store: RevocationStore, clock: FakeClock) -> None:
+    store.revoke("sess-a", expires_at=clock.now + 3600)
+
+    assert store.is_revoked("sess-b") is False
+
+
+def test_revocation_holds_right_up_to_the_expiry(store: RevocationStore, clock: FakeClock) -> None:
+    store.revoke("sess-a", expires_at=clock.now + 3600)
+
+    clock.advance(3599)
+
+    assert store.is_revoked("sess-a") is True
+
+
+def test_revocation_lapses_at_the_expiry(store: RevocationStore, clock: FakeClock) -> None:
+    store.revoke("sess-a", expires_at=clock.now + 3600)
+
+    clock.advance(3600)
+
+    assert store.is_revoked("sess-a") is False
+
+
+def test_entry_is_dropped_when_its_expiry_is_observed(
+    store: RevocationStore, clock: FakeClock
+) -> None:
+    """Reading a lapsed entry evicts it, so lookups alone bound memory."""
+    store.revoke("sess-a", expires_at=clock.now + 60)
+    clock.advance(60)
+
+    store.is_revoked("sess-a")
+
+    assert len(store) == 0
+
+
+def test_revoking_sweeps_entries_that_have_expired(
+    store: RevocationStore, clock: FakeClock
+) -> None:
+    """Memory is bounded by logouts-per-lifetime: old entries go on each logout."""
+    store.revoke("old-1", expires_at=clock.now + 60)
+    store.revoke("old-2", expires_at=clock.now + 60)
+    clock.advance(120)
+
+    store.revoke("fresh", expires_at=clock.now + 3600)
+
+    assert len(store) == 1
+    assert store.is_revoked("fresh") is True
+
+
+def test_live_entries_survive_a_sweep(store: RevocationStore, clock: FakeClock) -> None:
+    store.revoke("short", expires_at=clock.now + 60)
+    store.revoke("long", expires_at=clock.now + 3600)
+    clock.advance(120)
+
+    assert store.purge_expired() == 1
+    assert store.is_revoked("long") is True
+    assert len(store) == 1
+
+
+def test_purge_expired_reports_zero_when_nothing_is_stale(
+    store: RevocationStore, clock: FakeClock
+) -> None:
+    store.revoke("sess-a", expires_at=clock.now + 3600)
+
+    assert store.purge_expired() == 0
+    assert len(store) == 1
+
+
+def test_revoking_an_already_expired_session_is_inert(
+    store: RevocationStore, clock: FakeClock
+) -> None:
+    """The session is already dead on its own expiry check; nothing accumulates."""
+    store.revoke("stale", expires_at=clock.now - 1)
+
+    assert store.is_revoked("stale") is False
+    assert store.purge_expired() == 0
+    assert len(store) == 0
+
+
+def test_re_revoking_keeps_the_later_expiry(store: RevocationStore, clock: FakeClock) -> None:
+    """A shorter-lived cookie for the same id must not cut the record short."""
+    store.revoke("sess-a", expires_at=clock.now + 3600)
+    store.revoke("sess-a", expires_at=clock.now + 60)
+
+    clock.advance(120)
+
+    assert store.is_revoked("sess-a") is True
+
+
+def test_re_revoking_extends_to_a_later_expiry(store: RevocationStore, clock: FakeClock) -> None:
+    store.revoke("sess-a", expires_at=clock.now + 60)
+    store.revoke("sess-a", expires_at=clock.now + 3600)
+
+    clock.advance(120)
+
+    assert store.is_revoked("sess-a") is True
+    assert len(store) == 1
+
+
+def test_clear_forgets_every_revocation(store: RevocationStore, clock: FakeClock) -> None:
+    """Stands in for what a container force-recreate does to the store."""
+    store.revoke("sess-a", expires_at=clock.now + 3600)
+    store.revoke("sess-b", expires_at=clock.now + 3600)
+
+    store.clear()
+
+    assert len(store) == 0
+    assert store.is_revoked("sess-a") is False
+
+
+def test_many_logouts_within_one_lifetime_stay_bounded(
+    store: RevocationStore, clock: FakeClock
+) -> None:
+    """Sessions revoked in earlier lifetimes do not accumulate across uptime."""
+    lifetime = 12 * 3600
+    for round_index in range(5):
+        for user_index in range(20):
+            store.revoke(f"sess-{round_index}-{user_index}", expires_at=clock.now + lifetime)
+        clock.advance(lifetime + 1)
+
+    store.revoke("final", expires_at=clock.now + lifetime)
+
+    assert len(store) == 1
+
+
+def test_defaults_to_wall_clock_time() -> None:
+    """Expiries are absolute epoch seconds, matching the cookie's own values."""
+    import time
+
+    store = RevocationStore()
+    store.revoke("sess-a", expires_at=time.time() + 3600)
+
+    assert store.is_revoked("sess-a") is True
+
+    store.revoke("sess-b", expires_at=time.time() - 1)
+
+    assert store.is_revoked("sess-b") is False

--- a/tests/services/auth_sidecar/test_sessions.py
+++ b/tests/services/auth_sidecar/test_sessions.py
@@ -1,0 +1,525 @@
+"""Tests for the auth sidecar's signed session cookies."""
+
+from __future__ import annotations
+
+import pytest
+from itsdangerous import URLSafeSerializer
+
+from osprey.services.auth_sidecar.exceptions import InvalidSessionError
+from osprey.services.auth_sidecar.passwords import (
+    generation_tag,
+    hash_password,
+    verify_generation_tag,
+)
+from osprey.services.auth_sidecar.sessions import (
+    PAYLOAD_VERSION,
+    SIGNATURE_SALT,
+    SessionCodec,
+    SessionState,
+    UnlockedUser,
+)
+
+SECRET = "test-session-secret"
+HOUR = 3600.0
+
+
+class FakeClock:
+    """A hand-advanced stand-in for ``time.time`` (absolute epoch seconds)."""
+
+    def __init__(self, now: float = 1_000_000.0) -> None:
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.fixture
+def clock() -> FakeClock:
+    return FakeClock()
+
+
+@pytest.fixture
+def codec(clock: FakeClock) -> SessionCodec:
+    return SessionCodec(SECRET, max_age=12 * HOUR, clock=clock)
+
+
+def sign_payload(payload: object, *, secret: str = SECRET) -> str:
+    """Sign an arbitrary payload the way the codec does.
+
+    Lets a test present a well-signed but wrong-shaped cookie — the case a
+    signature check alone cannot catch.
+    """
+    return URLSafeSerializer(secret, salt=SIGNATURE_SALT).dumps(payload)
+
+
+# --- construction -----------------------------------------------------------
+
+
+@pytest.mark.parametrize("secret", ["", "   ", "\t\n"])
+def test_missing_secret_refuses_to_build_a_codec(secret: str) -> None:
+    """Fail closed: no secret means no sidecar, never unsigned cookies."""
+    with pytest.raises(ValueError, match="secret is unset"):
+        SessionCodec(secret)
+
+
+def test_non_positive_max_age_is_rejected() -> None:
+    with pytest.raises(ValueError, match="max_age must be positive"):
+        SessionCodec(SECRET, max_age=0)
+
+
+def test_new_state_stamps_the_injected_clock(codec: SessionCodec, clock: FakeClock) -> None:
+    state = codec.new_state()
+
+    assert state.issued_at == clock.now
+    assert state.users == ()
+    assert state.session_id
+
+
+def test_session_ids_are_unique(codec: SessionCodec) -> None:
+    ids = {codec.new_state().session_id for _ in range(50)}
+
+    assert len(ids) == 50
+
+
+# --- round trips ------------------------------------------------------------
+
+
+def test_round_trip_preserves_session_id_and_issue_time(codec: SessionCodec) -> None:
+    state = codec.new_state()
+
+    decoded = codec.decode(codec.encode(state))
+
+    assert decoded.session_id == state.session_id
+    assert decoded.issued_at == state.issued_at
+
+
+def test_round_trip_preserves_a_user_entry(codec: SessionCodec, clock: FakeClock) -> None:
+    state = codec.new_state().with_user(
+        "alice", expires_at=clock.now + HOUR, generation_tag="0123456789abcdef"
+    )
+
+    decoded = codec.decode(codec.encode(state))
+
+    assert decoded.users == (
+        UnlockedUser(
+            username="alice", expires_at=clock.now + HOUR, generation_tag="0123456789abcdef"
+        ),
+    )
+
+
+def test_oidc_entry_round_trips_without_a_tag(codec: SessionCodec, clock: FakeClock) -> None:
+    """OIDC has no stored hash behind it, so its entry carries no tag."""
+    state = codec.new_state().with_user("alice", expires_at=clock.now + HOUR)
+
+    decoded = codec.decode(codec.encode(state))
+
+    entry = decoded.entry("alice")
+    assert entry is not None
+    assert entry.generation_tag == ""
+
+
+def test_an_empty_session_round_trips(codec: SessionCodec) -> None:
+    """What a session looks like after its last user logs out — not an error."""
+    state = codec.new_state()
+
+    decoded = codec.decode(codec.encode(state))
+
+    assert decoded.users == ()
+    assert decoded.unlocked_usernames(codec.now()) == ()
+
+
+def test_re_issuing_does_not_extend_the_overall_session_age(
+    codec: SessionCodec, clock: FakeClock
+) -> None:
+    """A login later in the session keeps the original issued-at stamp."""
+    state = codec.new_state()
+    clock.advance(HOUR)
+
+    reissued = codec.decode(codec.encode(state.with_user("alice", expires_at=clock.now + HOUR)))
+
+    assert reissued.issued_at == state.issued_at
+
+
+# --- multi-user add and remove ----------------------------------------------
+
+
+def test_several_users_are_unlocked_at_once(codec: SessionCodec, clock: FakeClock) -> None:
+    state = (
+        codec.new_state()
+        .with_user("alice", expires_at=clock.now + HOUR)
+        .with_user("bob", expires_at=clock.now + HOUR)
+    )
+
+    decoded = codec.decode(codec.encode(state))
+
+    assert decoded.unlocked_usernames(clock.now) == ("alice", "bob")
+
+
+def test_logging_out_one_user_keeps_the_others(codec: SessionCodec, clock: FakeClock) -> None:
+    state = (
+        codec.new_state()
+        .with_user("alice", expires_at=clock.now + HOUR)
+        .with_user("bob", expires_at=clock.now + HOUR)
+    )
+
+    decoded = codec.decode(codec.encode(state.without_user("alice")))
+
+    assert decoded.is_unlocked("alice", clock.now) is False
+    assert decoded.is_unlocked("bob", clock.now) is True
+
+
+def test_logout_keeps_the_session_id(codec: SessionCodec, clock: FakeClock) -> None:
+    """The revocation store retires the old cookie by id, so it must not change."""
+    state = codec.new_state().with_user("alice", expires_at=clock.now + HOUR)
+
+    assert state.without_user("alice").session_id == state.session_id
+
+
+def test_removing_an_absent_user_is_inert(codec: SessionCodec, clock: FakeClock) -> None:
+    state = codec.new_state().with_user("alice", expires_at=clock.now + HOUR)
+
+    assert state.without_user("bob") == state
+
+
+def test_re_adding_a_user_refreshes_that_entry_in_place(
+    codec: SessionCodec, clock: FakeClock
+) -> None:
+    state = (
+        codec.new_state()
+        .with_user("alice", expires_at=clock.now + 60, generation_tag="aaaaaaaaaaaaaaaa")
+        .with_user("bob", expires_at=clock.now + HOUR)
+        .with_user("alice", expires_at=clock.now + HOUR, generation_tag="bbbbbbbbbbbbbbbb")
+    )
+
+    assert state.unlocked_usernames(clock.now) == ("alice", "bob")
+    alice = state.entry("alice")
+    assert alice is not None
+    assert alice.expires_at == clock.now + HOUR
+    assert alice.generation_tag == "bbbbbbbbbbbbbbbb"
+
+
+def test_states_are_immutable(codec: SessionCodec, clock: FakeClock) -> None:
+    """Routes build new states; an error path can never leave a half-update."""
+    state = codec.new_state()
+
+    state.with_user("alice", expires_at=clock.now + HOUR)
+
+    assert state.users == ()
+
+
+def test_empty_username_is_rejected(codec: SessionCodec, clock: FakeClock) -> None:
+    with pytest.raises(ValueError, match="username must not be empty"):
+        codec.new_state().with_user("", expires_at=clock.now + HOUR)
+
+
+def test_unknown_user_has_no_entry(codec: SessionCodec, clock: FakeClock) -> None:
+    state = codec.new_state().with_user("alice", expires_at=clock.now + HOUR)
+
+    assert state.entry("bob") is None
+    assert state.is_unlocked("bob", clock.now) is False
+
+
+# --- per-user expiry --------------------------------------------------------
+
+
+def test_entry_authorises_right_up_to_its_expiry(codec: SessionCodec, clock: FakeClock) -> None:
+    state = codec.new_state().with_user("alice", expires_at=clock.now + HOUR)
+
+    clock.advance(HOUR - 1)
+
+    assert codec.decode(codec.encode(state)).is_unlocked("alice", clock.now) is True
+
+
+def test_entry_stops_authorising_at_its_expiry(codec: SessionCodec, clock: FakeClock) -> None:
+    state = codec.new_state().with_user("alice", expires_at=clock.now + HOUR)
+
+    clock.advance(HOUR)
+
+    assert codec.decode(codec.encode(state)).is_unlocked("alice", clock.now) is False
+
+
+def test_decode_drops_expired_entries(codec: SessionCodec, clock: FakeClock) -> None:
+    """Fail closed: an expired entry never comes back, clock check or not."""
+    state = codec.new_state().with_user("alice", expires_at=clock.now + 60)
+    encoded = codec.encode(state)
+
+    clock.advance(120)
+
+    assert codec.decode(encoded).entry("alice") is None
+
+
+def test_one_user_expiring_leaves_the_others_unlocked(
+    codec: SessionCodec, clock: FakeClock
+) -> None:
+    state = (
+        codec.new_state()
+        .with_user("alice", expires_at=clock.now + 60)
+        .with_user("bob", expires_at=clock.now + HOUR)
+    )
+    encoded = codec.encode(state)
+
+    clock.advance(120)
+
+    assert codec.decode(encoded).unlocked_usernames(clock.now) == ("bob",)
+
+
+def test_prune_expired_keeps_live_entries(codec: SessionCodec, clock: FakeClock) -> None:
+    state = (
+        codec.new_state()
+        .with_user("alice", expires_at=clock.now + 60)
+        .with_user("bob", expires_at=clock.now + HOUR)
+    )
+
+    pruned = state.prune_expired(clock.now + 120)
+
+    assert pruned.unlocked_usernames(clock.now + 120) == ("bob",)
+    assert pruned.session_id == state.session_id
+
+
+# --- maximum session age ----------------------------------------------------
+
+
+def test_cookie_within_the_maximum_age_decodes(codec: SessionCodec, clock: FakeClock) -> None:
+    encoded = codec.encode(codec.new_state())
+
+    clock.advance(12 * HOUR)
+
+    assert codec.decode(encoded).users == ()
+
+
+def test_cookie_past_the_maximum_age_is_rejected(codec: SessionCodec, clock: FakeClock) -> None:
+    encoded = codec.encode(codec.new_state())
+
+    clock.advance(12 * HOUR + 1)
+
+    with pytest.raises(InvalidSessionError, match="older than the maximum session age"):
+        codec.decode(encoded)
+
+
+def test_maximum_age_can_be_overridden_per_call(codec: SessionCodec, clock: FakeClock) -> None:
+    encoded = codec.encode(codec.new_state())
+
+    clock.advance(120)
+
+    with pytest.raises(InvalidSessionError, match="older than the maximum session age"):
+        codec.decode(encoded, max_age=60)
+
+
+def test_without_a_maximum_age_only_per_user_expiry_bounds_the_session(
+    clock: FakeClock,
+) -> None:
+    codec = SessionCodec(SECRET, clock=clock)
+    encoded = codec.encode(codec.new_state().with_user("alice", expires_at=clock.now + HOUR))
+
+    clock.advance(365 * 24 * HOUR)
+
+    decoded = codec.decode(encoded)
+
+    assert decoded.users == ()
+
+
+# --- tampering and malformed payloads ---------------------------------------
+
+
+def test_a_swapped_payload_is_rejected(codec: SessionCodec, clock: FakeClock) -> None:
+    """A signature only covers the body it was made for."""
+    encoded = codec.encode(codec.new_state().with_user("alice", expires_at=clock.now + HOUR))
+    signature = encoded.rpartition(".")[2]
+    forged_body = sign_payload({"nope": True}).rpartition(".")[0]
+
+    with pytest.raises(InvalidSessionError, match="signature verification"):
+        codec.decode(f"{forged_body}.{signature}")
+
+
+def test_a_tampered_signature_is_rejected(codec: SessionCodec, clock: FakeClock) -> None:
+    """A changed signature must not verify.
+
+    The FIRST character is changed, never the last. A base64url character
+    carries six bits, but the final one of a 32-byte digest carries only four
+    that mean anything — so for roughly one signature in fourteen, changing it
+    decodes to the very same bytes, the codec correctly accepts a signature that
+    was never actually altered, and this test fails for being wrong rather than
+    for the codec being wrong. Every earlier character is fully significant, so
+    changing one always changes the digest.
+    """
+    encoded = codec.encode(codec.new_state().with_user("alice", expires_at=clock.now + HOUR))
+    body, _, signature = encoded.rpartition(".")
+    flipped = ("a" if signature[0] != "a" else "b") + signature[1:]
+
+    with pytest.raises(InvalidSessionError, match="signature verification"):
+        codec.decode(f"{body}.{flipped}")
+
+
+def test_a_cookie_signed_with_another_secret_is_rejected(codec: SessionCodec) -> None:
+    """A cookie from a differently-keyed sidecar must not authorise here."""
+    foreign = sign_payload(
+        {"v": PAYLOAD_VERSION, "sid": "s", "iat": 0.0, "users": {}}, secret="other-secret"
+    )
+
+    with pytest.raises(InvalidSessionError, match="signature verification"):
+        codec.decode(foreign)
+
+
+def test_a_cookie_signed_with_another_salt_is_rejected(clock: FakeClock) -> None:
+    other = SessionCodec(SECRET, clock=clock, salt="some-other-purpose")
+    encoded = other.encode(other.new_state())
+
+    with pytest.raises(InvalidSessionError, match="signature verification"):
+        SessionCodec(SECRET, clock=clock).decode(encoded)
+
+
+def test_an_empty_cookie_is_rejected(codec: SessionCodec) -> None:
+    with pytest.raises(InvalidSessionError, match="empty"):
+        codec.decode("")
+
+
+def test_garbage_is_rejected(codec: SessionCodec) -> None:
+    with pytest.raises(InvalidSessionError, match="signature verification"):
+        codec.decode("not-a-cookie")
+
+
+@pytest.mark.parametrize("version", [0, 2, "1", None])
+def test_an_unknown_payload_version_is_rejected(codec: SessionCodec, version: object) -> None:
+    """A retained secret across an upgrade must not resurrect old-shaped cookies."""
+    encoded = sign_payload({"v": version, "sid": "s", "iat": 0.0, "users": {}})
+
+    with pytest.raises(InvalidSessionError, match="unsupported session payload version"):
+        codec.decode(encoded)
+
+
+def test_the_current_version_is_stamped_into_the_payload(codec: SessionCodec) -> None:
+    encoded = codec.encode(codec.new_state())
+
+    payload = URLSafeSerializer(SECRET, salt=SIGNATURE_SALT).loads(encoded)
+
+    assert payload["v"] == PAYLOAD_VERSION
+
+
+@pytest.mark.parametrize(
+    ("payload", "match"),
+    [
+        (["not", "an", "object"], "not an object"),
+        ({"v": PAYLOAD_VERSION, "iat": 0.0, "users": {}}, "no session id"),
+        ({"v": PAYLOAD_VERSION, "sid": "", "iat": 0.0, "users": {}}, "no session id"),
+        ({"v": PAYLOAD_VERSION, "sid": 7, "iat": 0.0, "users": {}}, "no session id"),
+        ({"v": PAYLOAD_VERSION, "sid": "s", "users": {}}, "'iat' is not a timestamp"),
+        ({"v": PAYLOAD_VERSION, "sid": "s", "iat": "soon", "users": {}}, "not a timestamp"),
+        ({"v": PAYLOAD_VERSION, "sid": "s", "iat": 0.0, "users": []}, "'users' is not an object"),
+        (
+            {"v": PAYLOAD_VERSION, "sid": "s", "iat": 0.0, "users": {"alice": "yes"}},
+            "not an object",
+        ),
+        (
+            {"v": PAYLOAD_VERSION, "sid": "s", "iat": 0.0, "users": {"alice": {"tag": "a"}}},
+            "exp.* is not a timestamp",
+        ),
+        (
+            {
+                "v": PAYLOAD_VERSION,
+                "sid": "s",
+                "iat": 0.0,
+                "users": {"alice": {"exp": 1, "tag": 9}},
+            },
+            "non-string tag",
+        ),
+        (
+            {"v": PAYLOAD_VERSION, "sid": "s", "iat": 0.0, "users": {"": {"exp": 1}}},
+            "empty username",
+        ),
+    ],
+)
+def test_a_malformed_payload_is_rejected(payload: object, match: str) -> None:
+    """Signed but wrong-shaped: what a version skew or a bug upstream looks like.
+
+    Age-unbounded on purpose — these payloads are about shape, and the
+    fixed ``iat`` in them would otherwise trip the maximum-age check first.
+    """
+    with pytest.raises(InvalidSessionError, match=match):
+        SessionCodec(SECRET).decode(sign_payload(payload))
+
+
+def test_a_payload_without_users_decodes_as_empty(codec: SessionCodec) -> None:
+    encoded = sign_payload({"v": PAYLOAD_VERSION, "sid": "s", "iat": 0.0})
+
+    assert SessionCodec(SECRET).decode(encoded).users == ()
+
+
+# --- what the cookie may carry ----------------------------------------------
+
+
+def test_the_stored_hash_never_enters_the_cookie(codec: SessionCodec, clock: FakeClock) -> None:
+    """Cookies are signed, not encrypted: only the one-way tag may travel."""
+    stored = hash_password("correct horse battery staple")
+    encoded = codec.encode(
+        codec.new_state().with_user(
+            "alice", expires_at=clock.now + HOUR, generation_tag=generation_tag(stored)
+        )
+    )
+
+    assert stored not in encoded
+    assert stored.split("$")[-1] not in encoded
+
+
+def test_the_carried_tag_verifies_against_the_stored_hash(
+    codec: SessionCodec, clock: FakeClock
+) -> None:
+    stored = hash_password("correct horse battery staple")
+    state = codec.new_state().with_user(
+        "alice", expires_at=clock.now + HOUR, generation_tag=generation_tag(stored)
+    )
+
+    entry = codec.decode(codec.encode(state)).entry("alice")
+
+    assert entry is not None
+    assert verify_generation_tag(entry.generation_tag, stored) is True
+
+
+def test_a_rotated_password_invalidates_the_carried_tag(
+    codec: SessionCodec, clock: FakeClock
+) -> None:
+    """Rotation kills sessions statelessly — this survives a sidecar restart."""
+    old_stored = hash_password("old-password")
+    state = codec.new_state().with_user(
+        "alice", expires_at=clock.now + HOUR, generation_tag=generation_tag(old_stored)
+    )
+    rotated = hash_password("new-password")
+
+    entry = codec.decode(codec.encode(state)).entry("alice")
+
+    assert entry is not None
+    assert verify_generation_tag(entry.generation_tag, rotated) is False
+
+
+def test_an_oidc_entry_never_satisfies_the_password_mode_tag_check(
+    codec: SessionCodec, clock: FakeClock
+) -> None:
+    """An untagged entry must not authorise where a stored hash exists."""
+    state = codec.new_state().with_user("alice", expires_at=clock.now + HOUR)
+    stored = hash_password("alice-password")
+
+    entry = codec.decode(codec.encode(state)).entry("alice")
+
+    assert entry is not None
+    assert verify_generation_tag(entry.generation_tag, stored) is False
+
+
+def test_state_defaults_to_wall_clock_time() -> None:
+    """Expiries are absolute epoch seconds, matching the revocation store."""
+    import time
+
+    codec = SessionCodec(SECRET, max_age=12 * HOUR)
+    state = codec.new_state().with_user("alice", expires_at=time.time() + HOUR)
+
+    decoded = codec.decode(codec.encode(state))
+
+    assert decoded.is_unlocked("alice", time.time()) is True
+
+
+def test_state_is_hashable() -> None:
+    """Frozen all the way down, so a state can key a cache or land in a set."""
+    state = SessionState(session_id="s", issued_at=0.0).with_user("alice", expires_at=1.0)
+
+    assert len({state, state}) == 1

--- a/tests/services/auth_sidecar/test_throttle.py
+++ b/tests/services/auth_sidecar/test_throttle.py
@@ -1,0 +1,258 @@
+"""Tests for the auth sidecar's per-user login attempt throttle."""
+
+from __future__ import annotations
+
+import pytest
+
+from osprey.services.auth_sidecar.throttle import AttemptThrottle
+
+
+class FakeClock:
+    """A hand-advanced stand-in for ``time.monotonic``."""
+
+    def __init__(self, now: float = 1000.0) -> None:
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.fixture
+def clock() -> FakeClock:
+    return FakeClock()
+
+
+@pytest.fixture
+def throttle(clock: FakeClock) -> AttemptThrottle:
+    return AttemptThrottle(clock=clock)
+
+
+def test_first_attempt_is_allowed(throttle: AttemptThrottle) -> None:
+    assert throttle.retry_after("alice") == 0.0
+
+
+def test_failure_opens_the_initial_window(throttle: AttemptThrottle) -> None:
+    assert throttle.record_failure("alice") == 1.0
+    assert throttle.retry_after("alice") == pytest.approx(1.0)
+
+
+def test_window_lifts_once_it_elapses(throttle: AttemptThrottle, clock: FakeClock) -> None:
+    throttle.record_failure("alice")
+
+    clock.advance(1.0)
+
+    assert throttle.retry_after("alice") == 0.0
+
+
+def test_window_still_holds_just_before_it_lifts(
+    throttle: AttemptThrottle, clock: FakeClock
+) -> None:
+    throttle.record_failure("alice")
+
+    clock.advance(0.75)
+
+    assert throttle.retry_after("alice") == pytest.approx(0.25)
+
+
+def test_window_doubles_on_each_further_failure(
+    throttle: AttemptThrottle, clock: FakeClock
+) -> None:
+    windows = []
+    for _ in range(4):
+        windows.append(throttle.record_failure("alice"))
+        clock.advance(windows[-1])
+
+    assert windows == [1.0, 2.0, 4.0, 8.0]
+
+
+def test_window_is_capped_at_thirty_seconds(throttle: AttemptThrottle, clock: FakeClock) -> None:
+    """The cap is what bounds guessing throughput without ever locking anyone out."""
+    for _ in range(20):
+        delay = throttle.record_failure("alice")
+        clock.advance(delay)
+
+    assert delay == 30.0
+    assert throttle.max_delay == 30.0
+
+
+def test_window_never_exceeds_the_cap_however_many_failures(
+    throttle: AttemptThrottle, clock: FakeClock
+) -> None:
+    for _ in range(50):
+        clock.advance(throttle.record_failure("alice"))
+
+    assert throttle.retry_after("alice") == 0.0
+    assert throttle.record_failure("alice") == 30.0
+    assert throttle.retry_after("alice") <= 30.0
+
+
+def test_success_resets_the_window(throttle: AttemptThrottle, clock: FakeClock) -> None:
+    throttle.record_failure("alice")
+    throttle.record_failure("alice")
+    clock.advance(60)
+
+    throttle.record_success("alice")
+
+    assert throttle.retry_after("alice") == 0.0
+    assert throttle.record_failure("alice") == 1.0
+
+
+def test_success_for_an_untracked_user_is_a_no_op(throttle: AttemptThrottle) -> None:
+    throttle.record_success("never-failed")
+
+    assert throttle.retry_after("never-failed") == 0.0
+    assert len(throttle) == 0
+
+
+def test_throttling_is_per_user(throttle: AttemptThrottle) -> None:
+    """One operator's fat-fingering must not delay anybody else's login."""
+    throttle.record_failure("alice")
+
+    assert throttle.retry_after("alice") > 0
+    assert throttle.retry_after("bob") == 0.0
+
+
+def test_retry_after_does_not_extend_the_window(
+    throttle: AttemptThrottle, clock: FakeClock
+) -> None:
+    """Refused attempts are a pure query — a parallel flood cannot ratchet the window."""
+    throttle.record_failure("alice")
+    clock.advance(0.5)
+
+    for _ in range(100):
+        assert throttle.retry_after("alice") == pytest.approx(0.5)
+
+    clock.advance(0.5)
+    assert throttle.retry_after("alice") == 0.0
+
+
+def test_parallel_attempts_are_all_refused_within_one_window(
+    throttle: AttemptThrottle,
+) -> None:
+    """Throughput-bounded, not latency-delayed: every concurrent guess is refused."""
+    throttle.record_failure("alice")
+
+    assert all(throttle.retry_after("alice") > 0 for _ in range(100))
+
+
+def test_a_quiet_user_is_forgotten_and_starts_over(
+    throttle: AttemptThrottle, clock: FakeClock
+) -> None:
+    throttle.record_failure("alice")
+    throttle.record_failure("alice")
+
+    clock.advance(1000)
+
+    assert throttle.record_failure("alice") == 1.0
+
+
+def test_stale_users_are_swept_so_memory_stays_bounded(
+    throttle: AttemptThrottle, clock: FakeClock
+) -> None:
+    for index in range(50):
+        throttle.record_failure(f"probe-{index}")
+    assert len(throttle) == 50
+
+    clock.advance(1000)
+    throttle.record_failure("alice")
+
+    assert len(throttle) == 1
+
+
+def test_purge_stale_leaves_recently_active_users(
+    throttle: AttemptThrottle, clock: FakeClock
+) -> None:
+    throttle.record_failure("old")
+    clock.advance(1000)
+    throttle.record_failure("recent")
+
+    assert throttle.purge_stale() == 0
+    assert throttle.retry_after("recent") > 0
+
+
+def test_purge_stale_keeps_a_user_still_inside_the_forget_horizon(
+    throttle: AttemptThrottle, clock: FakeClock
+) -> None:
+    throttle.record_failure("alice")
+    clock.advance(200)
+
+    assert throttle.purge_stale() == 0
+    assert len(throttle) == 1
+
+
+def test_clear_forgets_every_user(throttle: AttemptThrottle) -> None:
+    throttle.record_failure("alice")
+    throttle.record_failure("bob")
+
+    throttle.clear()
+
+    assert len(throttle) == 0
+    assert throttle.retry_after("alice") == 0.0
+
+
+def test_sustained_guessing_is_bounded_by_the_cap(
+    throttle: AttemptThrottle, clock: FakeClock
+) -> None:
+    """An attacker who keeps guessing gets at most one evaluated attempt per cap."""
+    evaluated = 0
+    for _ in range(600):  # 600 one-second ticks = 10 minutes of hammering
+        if throttle.retry_after("alice") == 0.0:
+            evaluated += 1
+            throttle.record_failure("alice")
+        clock.advance(1.0)
+
+    assert evaluated <= 600 / throttle.max_delay + 5
+
+
+def test_no_lockout_however_long_the_attack_runs(
+    throttle: AttemptThrottle, clock: FakeClock
+) -> None:
+    """The operator is never more than the cap away from their next try."""
+    for _ in range(200):
+        throttle.record_failure("alice")
+        clock.advance(0.1)
+
+    assert throttle.retry_after("alice") <= 30.0
+
+    clock.advance(30.0)
+    assert throttle.retry_after("alice") == 0.0
+
+    throttle.record_success("alice")
+    assert throttle.retry_after("alice") == 0.0
+
+
+def test_custom_growth_parameters_are_honoured(clock: FakeClock) -> None:
+    throttle = AttemptThrottle(initial_delay=2.0, multiplier=3.0, max_delay=10.0, clock=clock)
+
+    assert throttle.record_failure("alice") == 2.0
+    assert throttle.record_failure("alice") == 6.0
+    assert throttle.record_failure("alice") == 10.0
+    assert throttle.record_failure("alice") == 10.0
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"initial_delay": 0},
+        {"initial_delay": -1.0},
+        {"multiplier": 0.5},
+        {"max_delay": 0.5},
+        {"forget_after": -1.0},
+    ],
+)
+def test_nonsensical_parameters_are_rejected(kwargs: dict[str, float]) -> None:
+    with pytest.raises(ValueError):
+        AttemptThrottle(**kwargs)
+
+
+def test_defaults_to_a_monotonic_clock() -> None:
+    """Durations must not follow wall-clock steps."""
+    throttle = AttemptThrottle()
+
+    assert throttle.record_failure("alice") == 1.0
+    assert 0.0 < throttle.retry_after("alice") <= 1.0
+    throttle.record_success("alice")
+    assert throttle.retry_after("alice") == 0.0

--- a/tests/services/auth_sidecar/test_verify.py
+++ b/tests/services/auth_sidecar/test_verify.py
@@ -1,0 +1,365 @@
+"""Tests for the auth sidecar's ``auth_request`` target.
+
+The endpoint answers one question — may this browser reach ``/u/<user>/`` right
+now — and everything pinned here is about it answering "no" often enough. The
+acceptance case is the isolation the whole feature exists for: one browser's
+valid cookie for alice authorizes alice and *only* alice, on the same request
+otherwise unchanged.
+
+Cookies are minted here with a client-side
+:class:`~osprey.services.auth_sidecar.sessions.SessionCodec` rather than by
+driving the (not yet landed) login route, so these tests exercise the verify
+path alone. The app is always built from an explicit env mapping, so a variable
+left in the real process environment cannot make one pass.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from osprey.services.auth_sidecar.app import create_app
+from osprey.services.auth_sidecar.passwords import generation_tag, hash_password
+from osprey.services.auth_sidecar.sessions import (
+    SESSION_COOKIE_NAME,
+    SessionCodec,
+    SessionState,
+    UnlockedUser,
+)
+
+SESSION_SECRET = "session-secret-value"
+STATE_SECRET = "state-secret-value"
+SESSION_LIFETIME = 3600
+
+ALICE_HASH = hash_password("alice-password")
+ROTATED_ALICE_HASH = hash_password("alice-new-password")
+
+PASSWORD_ENV = {
+    "OSPREY_AUTH_METHOD": "password",
+    "OSPREY_AUTH_SESSION_SECRET": SESSION_SECRET,
+    "OSPREY_AUTH_SESSION_LIFETIME": str(SESSION_LIFETIME),
+    "OSPREY_AUTH_USERS": "alice,bob",
+    "OSPREY_AUTH_PW_HASH_ALICE": ALICE_HASH,
+    "OSPREY_AUTH_EXTERNAL_ORIGIN": "https://terminals.example.org",
+    "OSPREY_AUTH_TLS_ENABLED": "true",
+}
+
+OIDC_ENV = {
+    "OSPREY_AUTH_METHOD": "oidc",
+    "OSPREY_AUTH_SESSION_SECRET": SESSION_SECRET,
+    "OSPREY_AUTH_STATE_SECRET": STATE_SECRET,
+    "OSPREY_AUTH_SESSION_LIFETIME": str(SESSION_LIFETIME),
+    "OSPREY_AUTH_USERS": "alice,bob",
+    "OSPREY_AUTH_OIDC_ISSUER": "https://idp.example.org",
+    "OSPREY_AUTH_OIDC_CLIENT_ID": "client-id",
+    "OSPREY_AUTH_OIDC_CLIENT_SECRET": "client-secret",
+    "OSPREY_AUTH_EXTERNAL_ORIGIN": "https://terminals.example.org",
+    "OSPREY_AUTH_TLS_ENABLED": "true",
+}
+
+SESSION_ID = "test-session-id"
+
+
+def _mint(
+    *entries: UnlockedUser,
+    secret: str = SESSION_SECRET,
+    session_id: str = SESSION_ID,
+    issued_at: float | None = None,
+) -> str:
+    """Sign a session cookie the way the login route will.
+
+    Args:
+        entries: The unlocked-user entries the cookie carries.
+        secret: Signing secret. A different one stands in for a forged cookie.
+        session_id: The session id, which logout revokes by.
+        issued_at: Stamp for the age check; defaults to now.
+    """
+    codec = SessionCodec(secret)
+    now = codec.now()
+    state = SessionState(
+        session_id=session_id,
+        issued_at=now if issued_at is None else issued_at,
+        users=entries,
+    )
+    return codec.encode(state)
+
+
+def _unlocked(
+    username: str, *, stored: str | None = ALICE_HASH, ttl: float = 600.0
+) -> UnlockedUser:
+    """An unlocked-user entry expiring ``ttl`` seconds from now.
+
+    Args:
+        username: The roster user the entry unlocks.
+        stored: The stored hash the generation tag is derived from, or ``None``
+            for an OIDC entry, which carries no tag.
+        ttl: Seconds until the entry lapses; negative for an expired one.
+    """
+    return UnlockedUser(
+        username=username,
+        expires_at=SessionCodec(SESSION_SECRET).now() + ttl,
+        generation_tag="" if stored is None else generation_tag(stored),
+    )
+
+
+def _app(env: dict[str, str] | None = None) -> FastAPI:
+    """A sidecar app built from an explicit environment."""
+    return create_app(PASSWORD_ENV if env is None else env)
+
+
+def _verify(
+    client: TestClient,
+    user: str | list[str] | None,
+    cookie: str | None = None,
+    *,
+    method: str = "GET",
+) -> httpx.Response:
+    """Issue one subrequest the way nginx's internal auth location does.
+
+    The cookie goes in as a raw header rather than through the client's jar, so
+    each request carries exactly the cookie the test named and nothing carries
+    over between them.
+
+    Args:
+        client: The test client.
+        user: The ``user`` query parameter — a list repeats it, ``None`` omits
+            it entirely.
+        cookie: The session cookie value, if the request carries one.
+        method: HTTP method, so the non-GET refusals can be exercised.
+    """
+    headers = {} if cookie is None else {"Cookie": f"{SESSION_COOKIE_NAME}={cookie}"}
+    params = {} if user is None else {"user": user}
+    return client.request(method, "/verify", params=params, headers=headers)
+
+
+class TestRegistration:
+    """The factory picks the route up with no edit of its own."""
+
+    def test_verify_is_registered_by_the_factory(self) -> None:
+        assert "/verify" in _app().openapi()["paths"]
+
+
+class TestAcceptance:
+    """The isolation guarantee, on one cookie."""
+
+    def test_alice_cookie_authorizes_alice_and_not_bob(self) -> None:
+        cookie = _mint(_unlocked("alice"))
+        with TestClient(_app()) as client:
+            assert _verify(client, "alice", cookie).status_code == 200
+            assert _verify(client, "bob", cookie).status_code == 401
+
+    def test_authorization_carries_no_body(self) -> None:
+        """nginx reads only the status; anything else is surface for nothing."""
+        cookie = _mint(_unlocked("alice"))
+        with TestClient(_app()) as client:
+            assert _verify(client, "alice", cookie).content == b""
+
+
+class TestDenials:
+    """Every way in must be closed, and closed identically."""
+
+    def test_missing_cookie_is_denied(self) -> None:
+        with TestClient(_app()) as client:
+            assert _verify(client, "alice").status_code == 401
+
+    def test_tampered_cookie_is_denied(self) -> None:
+        """A cookie signed with another secret is a forgery, not a session."""
+        forged = _mint(_unlocked("alice"), secret="not-the-session-secret")
+        with TestClient(_app()) as client:
+            assert _verify(client, "alice", forged).status_code == 401
+
+    def test_truncated_cookie_is_denied(self) -> None:
+        cookie = _mint(_unlocked("alice"))
+        with TestClient(_app()) as client:
+            assert _verify(client, "alice", cookie[:-4]).status_code == 401
+
+    def test_expired_entry_is_denied(self) -> None:
+        cookie = _mint(_unlocked("alice", ttl=-1.0))
+        with TestClient(_app()) as client:
+            assert _verify(client, "alice", cookie).status_code == 401
+
+    def test_over_age_cookie_is_denied(self) -> None:
+        """Past ``session_lifetime`` the whole cookie lapses, entries or not."""
+        codec = SessionCodec(SESSION_SECRET)
+        cookie = _mint(_unlocked("alice"), issued_at=codec.now() - SESSION_LIFETIME - 60)
+        with TestClient(_app()) as client:
+            assert _verify(client, "alice", cookie).status_code == 401
+
+    def test_revoked_session_is_denied(self) -> None:
+        """Logout kills a cookie that is otherwise entirely valid."""
+        entry = _unlocked("alice")
+        cookie = _mint(entry)
+        app = _app()
+        with TestClient(app) as client:
+            assert _verify(client, "alice", cookie).status_code == 200
+            app.state.revocation_store.revoke(SESSION_ID, entry.expires_at)
+            assert _verify(client, "alice", cookie).status_code == 401
+
+    def test_rotated_password_is_denied(self) -> None:
+        """The generation tag is what makes ``deploy passwd`` take effect."""
+        cookie = _mint(_unlocked("alice"))
+        rotated = {**PASSWORD_ENV, "OSPREY_AUTH_PW_HASH_ALICE": ROTATED_ALICE_HASH}
+        with TestClient(_app(rotated)) as client:
+            assert _verify(client, "alice", cookie).status_code == 401
+
+    def test_password_mode_entry_without_a_tag_is_denied(self) -> None:
+        """An OIDC-shaped entry must not authorize a password deployment."""
+        cookie = _mint(_unlocked("alice", stored=None))
+        with TestClient(_app()) as client:
+            assert _verify(client, "alice", cookie).status_code == 401
+
+    def test_roster_user_without_a_credential_is_denied(self) -> None:
+        """An individual 401 — the deployment still serves everyone else."""
+        cookie = _mint(_unlocked("bob"))
+        with TestClient(_app()) as client:
+            assert _verify(client, "bob", cookie).status_code == 401
+            assert _verify(client, "alice", _mint(_unlocked("alice"))).status_code == 200
+
+    def test_non_roster_user_is_denied(self) -> None:
+        """Even holding a cookie that claims to unlock them."""
+        cookie = _mint(_unlocked("carol"))
+        with TestClient(_app()) as client:
+            assert _verify(client, "carol", cookie).status_code == 401
+
+    def test_missing_user_parameter_is_denied(self) -> None:
+        """Never a 200, and never FastAPI's 422 validation body either."""
+        cookie = _mint(_unlocked("alice"))
+        with TestClient(_app()) as client:
+            response = _verify(client, None, cookie)
+        assert response.status_code == 401
+        assert response.content == b""
+
+    def test_empty_user_parameter_is_denied(self) -> None:
+        cookie = _mint(_unlocked("alice"))
+        with TestClient(_app()) as client:
+            assert _verify(client, "", cookie).status_code == 401
+
+    @pytest.mark.parametrize("users", [["bob", "alice"], ["alice", "bob"]])
+    def test_a_repeated_user_parameter_is_denied(self, users: list[str]) -> None:
+        """Both orderings, so nothing rides on which value a parser picks.
+
+        nginx's exact-match internal locations cannot produce this query today.
+        The point is that if some future seam ever does, the endpoint refuses
+        instead of resolving the ambiguity in whichever direction is convenient
+        — including the direction that would authorize alice's valid cookie
+        against a request naming bob.
+        """
+        cookie = _mint(_unlocked("alice"))
+        with TestClient(_app()) as client:
+            # The single-parameter request proves the cookie is good, so the
+            # refusal below is the repetition and not some unrelated denial.
+            assert _verify(client, "alice", cookie).status_code == 200
+            assert _verify(client, users, cookie).status_code == 401
+
+    @pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"])
+    def test_only_get_is_served(self, method: str) -> None:
+        """nginx's auth subrequest is a GET; nothing else may authorize.
+
+        FastAPI does not add HEAD to a GET route the way bare Starlette does,
+        so even the body-less twin of the served method is refused here.
+        """
+        cookie = _mint(_unlocked("alice"))
+        with TestClient(_app()) as client:
+            response = _verify(client, "alice", cookie, method=method)
+        assert response.status_code >= 400
+
+    @pytest.mark.parametrize(
+        ("user", "cookie"),
+        [
+            ("carol", None),
+            ("alice", None),
+            ("alice", "forged"),
+        ],
+    )
+    def test_denials_are_indistinguishable(self, user: str, cookie: str | None) -> None:
+        """An unknown user and a bad cookie must look the same to the client.
+
+        Same status, same empty body, and no ``WWW-Authenticate`` to hint that
+        a credential would help here — the login flow lives at nginx's
+        ``error_page``, not behind a challenge header on the subrequest.
+        """
+        value = None if cookie is None else _mint(_unlocked("alice"), secret=cookie)
+        with TestClient(_app()) as client:
+            response = _verify(client, user, value)
+        assert response.status_code == 401
+        assert response.content == b""
+        assert "www-authenticate" not in response.headers
+
+
+class TestOidcMode:
+    """OIDC sessions carry no generation tag, and must not be asked for one."""
+
+    def test_entry_without_a_tag_authorizes(self) -> None:
+        cookie = _mint(_unlocked("alice", stored=None))
+        with TestClient(_app(OIDC_ENV)) as client:
+            assert _verify(client, "alice", cookie).status_code == 200
+
+    def test_a_non_empty_tag_is_ignored(self) -> None:
+        """Informational, and deliberate: OIDC never consults the tag.
+
+        There is no stored hash in this mode to compare a tag against, and a
+        cookie carrying one at all could only have been minted by a holder of
+        the signing secret — which is strictly more than the tag would prove.
+        Pinned so a later reader does not mistake this for an oversight.
+        """
+        cookie = _mint(_unlocked("alice", stored=ROTATED_ALICE_HASH))
+        with TestClient(_app(OIDC_ENV)) as client:
+            assert _verify(client, "alice", cookie).status_code == 200
+
+    def test_unmapped_roster_user_still_authorizes(self) -> None:
+        """No stored hash exists in this mode, so its absence denies nothing."""
+        cookie = _mint(_unlocked("bob", stored=None))
+        with TestClient(_app(OIDC_ENV)) as client:
+            assert _verify(client, "bob", cookie).status_code == 200
+
+    def test_revocation_and_expiry_still_apply(self) -> None:
+        expired = _mint(_unlocked("alice", stored=None, ttl=-1.0))
+        entry = _unlocked("alice", stored=None)
+        app = _app(OIDC_ENV)
+        with TestClient(app) as client:
+            assert _verify(client, "alice", expired).status_code == 401
+            app.state.revocation_store.revoke(SESSION_ID, entry.expires_at)
+            assert _verify(client, "alice", _mint(entry)).status_code == 401
+
+
+class TestLogging:
+    """Denials are diagnosable without disclosing anything."""
+
+    def test_denial_logs_a_reason_but_no_secret_material(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        entry = _unlocked("alice")
+        cookie = _mint(entry)
+        rotated = {**PASSWORD_ENV, "OSPREY_AUTH_PW_HASH_ALICE": ROTATED_ALICE_HASH}
+        caplog.set_level(logging.DEBUG)
+
+        with TestClient(_app(rotated)) as client:
+            assert _verify(client, "alice", cookie).status_code == 401
+
+        assert "generation tag" in caplog.text
+        for secret in (cookie, entry.generation_tag, ALICE_HASH, ROTATED_ALICE_HASH):
+            assert secret not in caplog.text
+
+    def test_a_forged_cookie_is_never_echoed(self, caplog: pytest.LogCaptureFixture) -> None:
+        forged = _mint(_unlocked("alice"), secret="not-the-session-secret")
+        caplog.set_level(logging.DEBUG)
+
+        with TestClient(_app()) as client:
+            assert _verify(client, "alice", forged).status_code == 401
+
+        assert "session cookie rejected" in caplog.text
+        assert forged not in caplog.text
+
+    def test_authorization_logs_nothing(self, caplog: pytest.LogCaptureFixture) -> None:
+        """One line per allowed request would be one line per keystroke."""
+        cookie = _mint(_unlocked("alice"))
+        caplog.set_level(logging.DEBUG, logger="osprey.services.auth_sidecar.routes.verify")
+
+        with TestClient(_app()) as client:
+            assert _verify(client, "alice", cookie).status_code == 200
+
+        assert caplog.text == ""

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-31T07:40:24.517242Z"
+exclude-newer = "2026-07-31T12:22:19.29822Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -2299,6 +2299,15 @@ wheels = [
 ]
 
 [[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
 name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3903,6 +3912,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "aiohttp-socks" },
     { name = "anthropic" },
+    { name = "authlib" },
     { name = "bluesky" },
     { name = "bokeh" },
     { name = "build" },
@@ -3917,6 +3927,7 @@ dependencies = [
     { name = "httpx" },
     { name = "idna" },
     { name = "ipywidgets" },
+    { name = "itsdangerous" },
     { name = "jinja2" },
     { name = "litellm" },
     { name = "markdown" },
@@ -3938,6 +3949,7 @@ dependencies = [
     { name = "pyepics" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "questionary" },
     { name = "requests" },
@@ -4061,6 +4073,7 @@ requires-dist = [
     { name = "aiohttp-socks", specifier = ">=0.8.0" },
     { name = "aiohttp-socks", marker = "extra == 'ariel-proxy'", specifier = ">=0.8.0" },
     { name = "anthropic" },
+    { name = "authlib", specifier = ">=1.6.5" },
     { name = "bluesky", specifier = ">=1.15.1" },
     { name = "bokeh", specifier = ">=3.9.1" },
     { name = "build" },
@@ -4089,6 +4102,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "idna", specifier = ">=3.18" },
     { name = "ipywidgets" },
+    { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "litellm", specifier = ">=1.56.0" },
     { name = "markdown", specifier = ">=3.5" },
@@ -4147,6 +4161,7 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'" },
     { name = "python-dateutil", specifier = ">=2.9.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
+    { name = "python-multipart", specifier = ">=0.0.18" },
     { name = "python-xlib", marker = "extra == 'all'", specifier = ">=0.33" },
     { name = "python-xlib", marker = "extra == 'screen-capture-linux'", specifier = ">=0.33" },
     { name = "pyyaml", specifier = ">=6.0.2" },


### PR DESCRIPTION
A multi-user web-terminal deployment can now require a real per-user login.
Enforcement lives entirely at the perimeter: an auth sidecar joins the stack in
its own container, and nginx consults it via `auth_request` before proxying any
page, API call or WebSocket under `/u/<user>/`. The per-user terminal containers
carry no auth logic at all.

## Configuring it

`modules.web_terminals.auth.method` takes `none` (default), `password` or `oidc`.

- **password** — OSPREY manages scrypt hashes itself; nothing else to stand up.
- **oidc** — the facility's single sign-on. The callback checks the verified ID
  token (issuer, audience, nonce) against that user's `oidc_subject` mapping, so
  a valid login as somebody else cannot open this user's terminal.

The default renders byte-identically to a no-auth deployment, pinned by golden
fixtures, and no preset enables login.

## Failing closed

- Auth over cleartext HTTP refuses to render unless `auth.allow_insecure_http`
  is set, for deployments behind a TLS-terminating proxy.
- A deploy aborts before starting any container if a password hash or session
  signing key cannot be established.
- Roster names that collide under the `OSPREY_AUTH_PW_<USER>` mapping, or that
  fall outside `[a-z0-9][a-z0-9_-]*`, are refused at render time.

## Credential lifecycle

`osprey deploy up` hashes each user's password into `.env.auth` (mode 0600,
gitignored, readable only by the sidecar), prints any generated password exactly
once, and scrubs plaintext from `.env`. `osprey deploy passwd <user>` rotates one
credential and recreates the sidecar so the old password and live sessions die
immediately. `decommission` / `prune` purge the hash, reload the re-rendered
nginx routes and end the session — failing loudly and naming any credential that
survived.

One browser can hold several unlocked users at once, which is what a shared
control-room machine needs; logging one user out leaves the others untouched. An
expired session reloads the page into the login redirect rather than leaving a
dead reconnect loop.

## Known gaps

- **TLS certificates are not mounted.** `tls.cert` / `tls.key` are paths inside
  the nginx container, and the generated overlay mounts only nginx's own config.
  Operators bind-mount the certificate directory from their own compose file;
  the how-to documents this explicitly. Folding it into the generated overlay is
  a deployment-contract decision left open.
- **The sidecar image is not built by any job.** The container tests build a
  narrower harness image that takes each dependency specifier from the
  distribution metadata, so a missing declaration (notably `python-multipart`,
  which Starlette needs for every form body) fails loudly. A break confined to
  the sidecar Dockerfile itself would not be caught.
- The logged-out session list is in-process, so restarting the sidecar forgets
  it; a cookie captured before a logout is replayable until it expires.
- Rate-limiting the login POST at the perimeter is not included.

## Testing

Unit and integration coverage for the sidecar (sessions, passwords, throttle,
revocation, OIDC flow against a mock IdP), the rendered nginx perimeter, and the
credential lifecycle; browser tests drive login and the expired-session reload
against the composed stack. Full suite green locally (16306 passed).
