### PR TITLE
test: raise the archiver stack to full line and branch coverage

### DIFF
--- a/src/osprey/utils/timeseries.py
+++ b/src/osprey/utils/timeseries.py
@@ -40,8 +40,6 @@ def _lttb_select_indices(values: list, max_points: int) -> list[int]:
         c_end = min(c_end, n)
         if c_start >= n:
             c_start = n - 1
-        if c_end > n:
-            c_end = n
         c_len = max(c_end - c_start, 1)
         # x[i] == i, so the bucket's mean x is the mean of its index range.
         avg_x = sum(range(c_start, c_end)) / c_len

--- a/tests/connectors/test_doocs_archiver_connector.py
+++ b/tests/connectors/test_doocs_archiver_connector.py
@@ -187,6 +187,14 @@ class TestGetDataSinglePV:
         df = await conn.get_data(["FAC/DEV/LOC/PROP"], _START, _END)
         assert len(df) > 0
 
+    async def test_unreadable_history_raises_runtime_error(self, archiver):
+        """A channel whose history cannot be read fails loudly, not as an empty frame."""
+        conn, mock_d4py = archiver
+        mock_d4py.get.side_effect = RuntimeError("DOOCS error")
+
+        with pytest.raises(RuntimeError, match="Cannot read history for FAC/DEV/LOC/PROP"):
+            await conn.get_data(["FAC/DEV/LOC/PROP"], _START, _END)
+
 
 class TestGetDataTimeout:
     """``timeout`` reaches ``asyncio.wait_for``, with the configured default applied."""
@@ -416,6 +424,29 @@ class TestReadHistory:
         assert len(out["data"]) == len(out["time"]) == n
         # min_periods=1 shrinks the window at the edges rather than zero-padding.
         assert np.all(np.isfinite(out["data"]))
+
+    def test_pagination_breaks_when_oldest_timestamp_stops_advancing(self):
+        """The failsafe: a chunk whose oldest timestamp equals the current stop
+        must end pagination instead of re-requesting the same window forever."""
+        mid_ts = (_START_TS + _END_TS) / 2
+        mock_d4py = MagicMock()
+        # The first chunk covers only the newer half of the window, so pagination
+        # continues with current_stop = mid_ts; the archive then keeps answering
+        # with that same oldest sample. No third result: without the failsafe the
+        # loop would spin into StopIteration and report no data at all.
+        mock_d4py.get.side_effect = [
+            MagicMock(value=_make_raw_chunk(n=10, t_start=mid_ts, t_end=_END_TS)),
+            MagicMock(value=[(mid_ts, 0, 0, 99.0)]),
+        ]
+
+        conn = self._make_connector_with_d4py(mock_d4py)
+        out = conn._read_history("FAC/DEV/LOC/PROP", _START_TS, _END_TS)
+
+        assert out is not None
+        assert mock_d4py.get.call_count == 2
+        # The duplicated mid-window sample is deduplicated, not double-counted.
+        assert len(out["time"]) == 10
+        assert np.all(np.diff(out["time"]) > 0)
 
     def test_hist_suffix_appended(self):
         chunk = _make_raw_chunk(n=5)

--- a/tests/connectors/test_mock_archiver_simfile_fallback.py
+++ b/tests/connectors/test_mock_archiver_simfile_fallback.py
@@ -28,7 +28,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from osprey.connectors.archiver.mock_archiver_connector import MockArchiverConnector
+from osprey.connectors.archiver.mock_archiver_connector import MockArchiverConnector, _anchor
 
 ARCHIVER_LOGGER = "mock_archiver_connector"
 
@@ -110,6 +110,29 @@ async def _series(connector: MockArchiverConnector) -> list[float]:
 def _warnings(caplog) -> list[str]:
     """Warning-or-worse messages only — the loaders chat at INFO on every load."""
     return [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+class TestAnchor:
+    """``_anchor`` only rewrites a path that is both relative and has a root to hang on."""
+
+    @pytest.mark.parametrize(
+        ("path", "root", "expected"),
+        [
+            (
+                Path("/elsewhere/machine.json"),
+                Path("/project/root"),
+                Path("/elsewhere/machine.json"),
+            ),
+            (Path("data/machine.json"), None, Path("data/machine.json")),
+            (
+                Path("data/machine.json"),
+                Path("/project/root"),
+                Path("/project/root/data/machine.json"),
+            ),
+        ],
+    )
+    def test_only_a_relative_path_with_a_root_is_rewritten(self, path, root, expected):
+        assert _anchor(path, root) == expected
 
 
 class TestDerivedFromControlSystem:

--- a/tests/connectors/test_mock_connector.py
+++ b/tests/connectors/test_mock_connector.py
@@ -214,6 +214,15 @@ class TestMockArchiverConnector:
         assert connector._connected is False
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("sample_rate_hz", [0, -1.0])
+    async def test_connect_rejects_non_positive_sample_rate(self, sample_rate_hz):
+        """A zero or negative rate would divide by zero later; connect refuses it."""
+        connector = MockArchiverConnector()
+
+        with pytest.raises(ValueError, match="sample_rate_hz must be > 0"):
+            await connector.connect({"sample_rate_hz": sample_rate_hz})
+
+    @pytest.mark.asyncio
     async def test_get_data_accepts_any_pvs(self):
         """Test that mock archiver accepts any PV names."""
         connector = MockArchiverConnector()
@@ -395,6 +404,32 @@ class TestMockArchiverProcessing:
         assert not df["value"].isna().any()
 
         await connector.disconnect()
+
+
+class TestMockArchiverProceduralKinds:
+    """Every PV-kind branch of the procedural generator shapes a plausible series:
+    finite, varying, with a mean near the kind's base value — no exact values."""
+
+    @pytest.mark.parametrize(
+        ("pv_name", "base_value"),
+        [
+            ("PS:CURRENT", 150.0),
+            ("RF:POWER", 50.0),
+            ("CRYO:TEMP", 25.0),
+            ("SR:LIFETIME", 10.0),
+            ("SOME:RANDOM:PV", 100.0),
+        ],
+    )
+    def test_each_kind_generates_a_plausible_series(self, pv_name, base_value):
+        connector = MockArchiverConnector()
+        connector._noise_level = 0.01
+
+        values = connector._generate_time_series(pv_name, 200)
+
+        assert len(values) == 200
+        assert np.all(np.isfinite(values))
+        assert values.std() > 0, "the series must vary, not sit at the base value"
+        assert values.mean() == pytest.approx(base_value, rel=0.5)
 
 
 class TestMockArchiverReproducibility:

--- a/tests/connectors/test_mongodb_archiver_connector.py
+++ b/tests/connectors/test_mongodb_archiver_connector.py
@@ -2,7 +2,7 @@
 
 import sys
 from datetime import UTC, datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -779,6 +779,24 @@ class TestQueryShapeWithoutDocker:
         assert set(df["channel"]) == {"BEAM:CURRENT"}
 
     @pytest.mark.asyncio
+    async def test_document_missing_date_is_skipped(self):
+        """A document without a 'date' field is skipped; its values contribute no rows."""
+        documents = [
+            {"BEAM:CURRENT": 99.0},  # no 'date' field: must not become a row
+            {"date": datetime(2024, 1, 1, 0, 0, 1, tzinfo=UTC), "BEAM:CURRENT": 1.0},
+        ]
+        connector, _ = self._stub_connector(documents)
+
+        df = await connector.get_data(
+            pv_list=["BEAM:CURRENT"],
+            start_date=datetime(2024, 1, 1, tzinfo=UTC),
+            end_date=datetime(2024, 1, 2, tzinfo=UTC),
+            precision_ms=0,
+        )
+
+        assert df["value"].tolist() == [1.0]
+
+    @pytest.mark.asyncio
     async def test_mixed_cadence_channels_aggregate_independently(self):
         """A 10 Hz and a much sparser channel queried together must each be
         aggregated over only their own samples.
@@ -816,3 +834,106 @@ class TestQueryShapeWithoutDocker:
         # SLOW: its own 50 real samples, each its own bin.
         assert len(slow_values) == 50
         assert slow_values == pytest.approx([500.0 + i for i in range(50)])
+
+
+class TestErrorHandlingWithoutDocker:
+    """Exception mapping and degradation paths, with the pymongo client mocked."""
+
+    @staticmethod
+    def _erroring_connector(**side_effects):
+        """Return a connected connector whose named collection methods raise."""
+        connector = MongoDBArchiverConnector()
+        connector._connected = True
+        connector._collection = MagicMock()
+        connector._timeout = 10
+        for method, exception in side_effects.items():
+            getattr(connector._collection, method).side_effect = exception
+        return connector
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("raised", "match"),
+        [
+            ("ConnectionFailure", "Cannot connect to MongoDB"),
+            ("ConfigurationError", "MongoDB configuration error"),
+            (TimeoutError("unreachable"), "MongoDB connection failed"),
+            (OSError("unreachable"), "MongoDB connection failed"),
+            (RuntimeError("driver bug"), "MongoDB connection failed"),
+        ],
+    )
+    async def test_connect_failures_map_to_connection_error(self, raised, match, monkeypatch):
+        """Every connect()-time failure surfaces as ConnectionError, message per cause."""
+        if isinstance(raised, str):  # pymongo exception class, imported lazily
+            pymongo_errors = pytest.importorskip("pymongo.errors")
+            raised = getattr(pymongo_errors, raised)("refused")
+        monkeypatch.setenv("MONGODB_MOCK_PASSWORD", "secret")
+        connector = MongoDBArchiverConnector()
+        config = {
+            "host": "mongodb.example.invalid",
+            "name": "testdb",
+            "collection": "testcoll",
+            "auth": "admin",
+            "username": "user",
+            "password_env": "MONGODB_MOCK_PASSWORD",
+        }
+
+        with patch("pymongo.MongoClient") as mock_client_cls:
+            mock_client_cls.return_value.admin.command.side_effect = raised
+            with pytest.raises(ConnectionError, match=match) as exc_info:
+                await connector.connect(config)
+
+        assert isinstance(exc_info.value.__cause__, type(raised))
+
+    @pytest.mark.asyncio
+    async def test_disconnect_swallows_close_error_and_clears_state(self):
+        """A failing client.close() is logged, not raised, and state is still cleared."""
+        connector = self._erroring_connector()
+        connector._client = MagicMock()
+        connector._client.close.side_effect = RuntimeError("socket already closed")
+
+        await connector.disconnect()
+
+        assert connector._client is None
+        assert connector._collection is None
+        assert connector._connected is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("raised", "expected", "match"),
+        [
+            (TimeoutError("slow server"), TimeoutError, "MongoDB query timed out after 10s"),
+            (
+                ConnectionError("connection reset"),
+                ConnectionError,
+                "Network connectivity issue with MongoDB",
+            ),
+            (ValueError("bad document"), ValueError, "Error retrieving data from MongoDB"),
+            (TypeError("bad document"), ValueError, "Error retrieving data from MongoDB"),
+            (RuntimeError("cursor lost"), ValueError, "Error retrieving data from MongoDB"),
+        ],
+    )
+    async def test_get_data_failures_map_per_exception_type(self, raised, expected, match):
+        """Each get_data()-time failure re-raises as the documented type and message."""
+        connector = self._erroring_connector(find=raised)
+
+        with pytest.raises(expected, match=match) as exc_info:
+            await connector.get_data(
+                pv_list=["BEAM:CURRENT"],
+                start_date=datetime(2024, 1, 1, tzinfo=UTC),
+                end_date=datetime(2024, 1, 2, tzinfo=UTC),
+            )
+
+        assert isinstance(exc_info.value.__cause__, type(raised))
+
+    @pytest.mark.asyncio
+    async def test_availability_query_errors_degrade_to_not_archived(self):
+        """get_metadata()/check_availability() report not-archived instead of raising."""
+        connector = self._erroring_connector(count_documents=RuntimeError("cursor lost"))
+
+        metadata = await connector.get_metadata("BEAM:CURRENT")
+        assert isinstance(metadata, ArchiverMetadata)
+        assert metadata.pv_name == "BEAM:CURRENT"
+        assert metadata.is_archived is False
+
+        availability = await connector.check_availability(["BEAM:CURRENT", "BEAM:LIFETIME"])
+        assert availability == {"BEAM:CURRENT": False, "BEAM:LIFETIME": False}

--- a/tests/health/probes/test_archiver_freshness.py
+++ b/tests/health/probes/test_archiver_freshness.py
@@ -276,6 +276,64 @@ async def test_timeout_passed_to_get_data() -> None:
     assert timeout == 7  # float seconds coerced to the connector's int timeout
 
 
+# --- Global-config fallback (ctx.config is None) -----------------------------
+
+
+async def test_none_config_falls_back_to_global_archiver_block(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CLI/standalone: with no per-run config the block comes from the global
+    singleton via ``get_config_value("archiver", ...)`` and the run proceeds."""
+    import osprey.utils.config as config_module
+
+    block = {"type": "mock_archiver"}
+    keys_asked: list[str] = []
+
+    def fake_get_config_value(key: str, default: Any = None) -> Any:
+        keys_asked.append(key)
+        return block
+
+    monkeypatch.setattr(config_module, "get_config_value", fake_get_config_value)
+    archiver = _SpyArchiver(_frame(newest_age_s=10))
+    runtime = _SpyRuntime(archiver)
+    ctx = ProbeContext(runtime=runtime, config=None)  # type: ignore[arg-type]
+
+    result = await run({"channel": "BEAM:CURRENT"}, ctx)
+
+    assert result.status is Status.OK
+    assert keys_asked == ["archiver"]
+    assert runtime.get_archiver_calls == [block]  # the global block reached the runtime
+
+
+def _raising_get_config_value(key: str, default: Any = None) -> Any:
+    raise RuntimeError("config file not found")
+
+
+@pytest.mark.parametrize(
+    "get_config_value",
+    [
+        pytest.param(_raising_get_config_value, id="config-load-raises"),
+        pytest.param(lambda key, default=None: "epics", id="scalar-archiver-value"),
+    ],
+)
+async def test_none_config_with_unusable_global_config_is_error(
+    monkeypatch: pytest.MonkeyPatch, get_config_value: Any
+) -> None:
+    """Config unavailability -- a raising loader or a scalar ``archiver:`` value
+    -- degrades to the misconfiguration error, not a crash."""
+    import osprey.utils.config as config_module
+
+    monkeypatch.setattr(config_module, "get_config_value", get_config_value)
+    runtime = _SpyRuntime(_SpyArchiver())
+    ctx = ProbeContext(runtime=runtime, config=None)  # type: ignore[arg-type]
+
+    result = await run({"channel": "BEAM:CURRENT"}, ctx)
+
+    assert result.status is Status.ERROR
+    assert "no archiver configured" in result.message
+    assert runtime.get_archiver_calls == []
+
+
 # --- Real in-tree MockArchiverConnector end to end --------------------------
 
 

--- a/tests/interfaces/artifacts/test_app_endpoints.py
+++ b/tests/interfaces/artifacts/test_app_endpoints.py
@@ -1,0 +1,297 @@
+"""Tests for artifact gallery app endpoints and helpers not covered elsewhere.
+
+Covers:
+  - GET/DELETE /api/artifacts/{id} (single-entry fetch and deletion)
+  - GET/POST /api/focus (focus state, stale-focus fallback, fullscreen flag)
+  - the focus_state.txt file the CLI hook reads (pin/unpin/focus lifecycle)
+  - GET /files/{id}/{filename} for HTML artifacts (Plotly injection, offline
+    CDN rewriting, missing-file 404s)
+  - the _SSEBroadcaster queue bookkeeping
+  - config.yml priming in create_app and run_server's uvicorn handoff
+"""
+
+import asyncio
+
+import pytest
+from fastapi.testclient import TestClient
+
+from osprey.interfaces.artifacts.app import (
+    _inject_html_snippet,
+    _SSEBroadcaster,
+    create_app,
+    run_server,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _save_text_artifact(store, title="Plain text"):
+    return store.save_file(
+        file_content=b"hello",
+        filename="note.txt",
+        artifact_type="text",
+        title=title,
+        description="",
+        mime_type="text/plain",
+        tool_source="test",
+    )
+
+
+def _save_html_artifact(store, content: str):
+    return store.save_file(
+        file_content=content.encode(),
+        filename="plot.html",
+        artifact_type="plot_html",
+        title="Plot",
+        description="",
+        mime_type="text/html",
+        tool_source="test",
+    )
+
+
+@pytest.fixture
+def app_client(tmp_path):
+    return TestClient(create_app(workspace_root=tmp_path)), tmp_path
+
+
+class TestArtifactEntryAPI:
+    """GET and DELETE /api/artifacts/{artifact_id}."""
+
+    def test_get_artifact_returns_entry(self, app_client):
+        client, _ = app_client
+        entry = _save_text_artifact(client.app.state.artifact_store, title="Fetch Me")
+
+        resp = client.get(f"/api/artifacts/{entry.id}")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == entry.id
+        assert resp.json()["title"] == "Fetch Me"
+
+    def test_delete_artifact_removes_entry(self, app_client):
+        client, _ = app_client
+        entry = _save_text_artifact(client.app.state.artifact_store)
+
+        resp = client.delete(f"/api/artifacts/{entry.id}")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok", "artifact_id": entry.id}
+        assert client.get(f"/api/artifacts/{entry.id}").status_code == 404
+        assert client.delete(f"/api/artifacts/{entry.id}").status_code == 404
+
+
+class TestFocus:
+    """GET/POST /api/focus and the focus_state.txt file the CLI hook reads."""
+
+    def test_focus_lifecycle(self, app_client):
+        client, _ = app_client
+        store = client.app.state.artifact_store
+        assert client.get("/api/focus").json() == {"focused": False, "artifact": None}
+
+        first = _save_text_artifact(store, title="First")
+        _save_text_artifact(store, title="Second")
+        assert client.post("/api/focus", json={"artifact_id": "nonexistent"}).status_code == 404
+
+        resp = client.post("/api/focus", json={"artifact_id": first.id})
+        assert resp.json() == {"status": "ok", "artifact_id": first.id}
+        focus = client.get("/api/focus").json()
+        assert focus["focused"] is True
+        assert focus["artifact"]["id"] == first.id  # not the latest artifact
+
+        resp = client.post("/api/focus", json={"artifact_id": first.id, "fullscreen": True})
+        assert resp.status_code == 200
+        assert resp.json()["artifact_id"] == first.id
+
+    def test_stale_focus_cleared_and_falls_back_to_latest(self, app_client):
+        """A focused artifact deleted out from under the app contributes no
+        line to focus_state.txt; GET /api/focus clears the stale id and falls
+        back to the newest remaining entry."""
+        client, workspace = app_client
+        store = client.app.state.artifact_store
+        doomed = _save_text_artifact(store, title="Doomed")
+        client.post("/api/focus", json={"artifact_id": doomed.id})
+        store.delete_entry(doomed.id)
+        survivor = _save_text_artifact(store, title="Survivor")
+
+        # Rewriting the file while the stale id is still set omits the artifact line.
+        client.post(f"/api/artifacts/{survivor.id}/pin", json={"pinned": True})
+        text = (workspace / "focus_state.txt").read_text()
+        assert "artifact:" not in text
+        assert 'pinned:   "Survivor"' in text
+
+        focus = client.get("/api/focus").json()
+        assert focus["focused"] is False
+        assert focus["artifact"]["id"] == survivor.id
+        assert client.app.state.focused_artifact_id is None  # stale id was cleared
+
+    def test_focus_file_pin_unpin_and_dedupe(self, app_client):
+        """Pinning writes a pinned line; unpinning empties (not deletes) the
+        file; an artifact both focused and pinned appears only as the focused
+        line, not duplicated as a pinned line."""
+        client, workspace = app_client
+        entry = _save_text_artifact(client.app.state.artifact_store, title="Both")
+        focus_file = workspace / "focus_state.txt"
+
+        client.post(f"/api/artifacts/{entry.id}/pin", json={"pinned": True})
+        assert 'pinned:   "Both"' in focus_file.read_text()
+
+        client.post(f"/api/artifacts/{entry.id}/pin", json={"pinned": False})
+        # The file is emptied, not deleted -- the hook treats both as "no focus".
+        assert focus_file.read_text() == ""
+
+        client.post(f"/api/artifacts/{entry.id}/pin", json={"pinned": True})
+        client.post("/api/focus", json={"artifact_id": entry.id})
+        text = focus_file.read_text()
+        assert f'artifact: "Both" (id={entry.id})' in text
+        assert "pinned:" not in text
+
+    def test_delete_clears_focus_only_for_the_focused_artifact(self, tmp_path):
+        """With the lifespan listeners registered, deleting another artifact
+        must not disturb the focus; deleting the focused one clears the focus
+        state and empties the file."""
+        with TestClient(create_app(workspace_root=tmp_path)) as client:
+            store = client.app.state.artifact_store
+            focused = _save_text_artifact(store, title="Focused")
+            other = _save_text_artifact(store, title="Other")
+            client.post("/api/focus", json={"artifact_id": focused.id})
+
+            assert client.delete(f"/api/artifacts/{other.id}").status_code == 200
+            assert client.app.state.focused_artifact_id == focused.id
+            focus = client.get("/api/focus").json()
+            assert focus["focused"] is True
+            assert focus["artifact"]["id"] == focused.id
+
+            assert client.delete(f"/api/artifacts/{focused.id}").status_code == 200
+            assert client.app.state.focused_artifact_id is None
+            assert client.get("/api/focus").json() == {"focused": False, "artifact": None}
+            assert (tmp_path / "focus_state.txt").read_text() == ""
+
+
+class TestServeFileEndpoint:
+    """GET /files/{artifact_id}/{filename}."""
+
+    def test_missing_artifact_or_file_returns_404(self, app_client):
+        client, _ = app_client
+        assert client.get("/files/nonexistent/whatever.html").status_code == 404
+
+        store = client.app.state.artifact_store
+        entry = _save_text_artifact(store)
+        store.get_file_path(entry.id).unlink()
+        resp = client.get(f"/files/{entry.id}/{entry.filename}")
+        assert resp.status_code == 404
+        assert "not found on disk" in resp.json()["detail"]
+
+    def test_plotly_bundle_injected_only_when_absent(self, app_client, monkeypatch):
+        """A plot_html artifact saved with include_plotlyjs=False gets the
+        local Plotly bundle plus the responsive snippet injected (offline mode
+        pins the injected src to the local vendor path); one already carrying
+        the bundle must not get a second 4.8MB script tag."""
+        client, _ = app_client
+        store = client.app.state.artifact_store
+
+        monkeypatch.setenv("OSPREY_OFFLINE", "1")
+        bare = _save_html_artifact(
+            store, '<html><head></head><body><div class="plotly-graph-div"></div></body></html>'
+        )
+        resp = client.get(f"/files/{bare.id}/{bare.filename}")
+        assert resp.status_code == 200
+        assert resp.headers["content-disposition"].startswith("inline")
+        assert 'src="/static/js/vendor/plotly-3.3.1.min.js"' in resp.text
+        assert ".js-plotly-plot" in resp.text  # responsive/theming snippet
+
+        monkeypatch.setenv("OSPREY_OFFLINE", "0")
+        bundled = _save_html_artifact(
+            store,
+            "<html><head>"
+            '<script src="/static/js/vendor/plotly-3.3.1.min.js"></script>'
+            "</head><body></body></html>",
+        )
+        resp = client.get(f"/files/{bundled.id}/{bundled.filename}")
+        assert resp.status_code == 200
+        assert resp.text.count("plotly-3.3.1.min.js") == 1
+        assert ".js-plotly-plot" in resp.text  # snippet still injected
+
+    def test_offline_rewrites_cdn_plotly_to_local(self, app_client, monkeypatch):
+        """In offline mode a CDN Plotly reference is rewritten to the bundled
+        copy and its SRI attributes are stripped (the local file may differ
+        from the CDN version, and SRI would block it)."""
+        monkeypatch.setenv("OSPREY_OFFLINE", "1")
+        client, _ = app_client
+        entry = _save_html_artifact(
+            client.app.state.artifact_store,
+            "<html><head>"
+            '<script src="https://cdn.plot.ly/plotly-2.35.2.min.js"'
+            ' integrity="sha384-abc123" crossorigin="anonymous"></script>'
+            "</head><body></body></html>",
+        )
+
+        resp = client.get(f"/files/{entry.id}/{entry.filename}")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "cdn.plot.ly" not in body
+        assert "integrity=" not in body
+        assert "crossorigin" not in body
+        # The rewritten reference also satisfies the dedup check -- no second copy.
+        assert body.count("plotly-3.3.1.min.js") == 1
+
+
+def test_inject_snippet_without_head_or_body_prepends():
+    result = _inject_html_snippet(b"<div>fragment</div>", "<style>s</style>")
+    assert result == b"<style>s</style><div>fragment</div>"
+
+
+def test_sse_broadcaster_queue_bookkeeping():
+    """Full queues drop events rather than raise; unsubscribing unknown or
+    already-removed queues is a no-op."""
+    b = _SSEBroadcaster()
+    slow_client = b.subscribe()
+    while not slow_client.full():
+        slow_client.put_nowait({"filler": True})
+    capacity = slow_client.qsize()
+
+    b.broadcast({"type": "artifact"})  # must not raise
+    assert slow_client.qsize() == capacity  # dropped, not queued
+
+    b.unsubscribe(asyncio.Queue())  # never subscribed: no-op
+    b.unsubscribe(slow_client)
+    b.unsubscribe(slow_client)  # double-unsubscribe must not raise either
+
+
+class TestAppLifecycle:
+    """create_app config priming and run_server's uvicorn handoff."""
+
+    def test_config_yml_priming_is_best_effort(self, tmp_path, monkeypatch):
+        """A config.yml in the workspace root is loaded at app construction
+        (custom artifact categories come from it), while one the loader
+        rejects must not take the gallery down with it."""
+        import osprey.utils.config as config_module
+
+        # Snapshot the config singletons; monkeypatch restores them at teardown
+        # so priming the default config cannot leak into other tests.
+        monkeypatch.setattr(config_module, "_default_config", config_module._default_config)
+        monkeypatch.setattr(
+            config_module, "_default_configurable", config_module._default_configurable
+        )
+
+        good = tmp_path / "good"
+        good.mkdir()
+        (good / "config.yml").write_text("project_name: artifacts-coverage-test\n")
+        assert TestClient(create_app(workspace_root=good)).get("/health").status_code == 200
+
+        bad = tmp_path / "bad"
+        bad.mkdir()
+        (bad / "config.yml").write_text(":\n  - not valid yaml: [unclosed\n")
+        assert TestClient(create_app(workspace_root=bad)).get("/health").status_code == 200
+
+    def test_run_server_builds_app_and_hands_it_to_uvicorn(self, tmp_path, monkeypatch):
+        import uvicorn
+
+        calls = {}
+
+        def fake_run(app, **kwargs):
+            calls["app"] = app
+            calls.update(kwargs)
+
+        monkeypatch.setattr(uvicorn, "run", fake_run)
+        run_server(host="127.0.0.1", port=59999, workspace_root=tmp_path)
+
+        assert calls["host"] == "127.0.0.1"
+        assert calls["port"] == 59999
+        assert calls["app"].title == "OSPREY Artifact Gallery"

--- a/tests/interfaces/artifacts/test_markdown_rendered.py
+++ b/tests/interfaces/artifacts/test_markdown_rendered.py
@@ -106,3 +106,23 @@ class TestMarkdownRenderedAPI:
         json_block_end = html.index("</script>", json_block_start)
         json_content = html[json_block_start:json_block_end]
         assert "</script>" not in json_content
+
+    @pytest.mark.unit
+    def test_markdown_file_missing_on_disk_returns_404(self, app_client):
+        """A registered entry whose file vanished from disk returns 404, not 500."""
+        client, _ = app_client
+        store = client.app.state.artifact_store
+        entry = store.save_file(
+            file_content=b"# Gone",
+            filename="gone.md",
+            artifact_type="markdown",
+            title="Gone Markdown",
+            description="",
+            mime_type="text/markdown",
+            tool_source="test",
+        )
+        store.get_file_path(entry.id).unlink()
+
+        resp = client.get(f"/api/markdown/{entry.id}/rendered")
+        assert resp.status_code == 404
+        assert "not found on disk" in resp.json()["detail"]

--- a/tests/interfaces/artifacts/test_notebook_rendered.py
+++ b/tests/interfaces/artifacts/test_notebook_rendered.py
@@ -37,10 +37,10 @@ class TestNotebookRenderedAPI:
         app = create_app(workspace_root=tmp_path)
         return TestClient(app), tmp_path
 
-    def _save_notebook(self, client):
+    def _save_notebook(self, client, content: bytes | None = None):
         store = client.app.state.artifact_store
         return store.save_file(
-            file_content=_make_notebook_bytes(),
+            file_content=content or _make_notebook_bytes(),
             filename="demo.ipynb",
             artifact_type="notebook",
             title="Demo Notebook",
@@ -104,3 +104,25 @@ class TestNotebookRenderedAPI:
         client, _ = app_client
         resp = client.get("/api/notebooks/nonexistent-id/rendered")
         assert resp.status_code == 404
+
+    @pytest.mark.unit
+    def test_notebook_file_missing_on_disk_returns_404(self, app_client):
+        """A registered entry whose .ipynb vanished from disk returns 404, not 500."""
+        client, _ = app_client
+        entry = self._save_notebook(client)
+        client.app.state.artifact_store.get_file_path(entry.id).unlink()
+
+        resp = client.get(f"/api/notebooks/{entry.id}/rendered")
+        assert resp.status_code == 404
+        assert "not found on disk" in resp.json()["detail"]
+
+    @pytest.mark.unit
+    def test_unparseable_notebook_returns_500_with_detail(self, app_client):
+        """A file that nbformat cannot parse surfaces as a 500 with the render
+        error in the detail, rather than an unhandled exception."""
+        client, _ = app_client
+        entry = self._save_notebook(client, content=b"this is not JSON at all {")
+
+        resp = client.get(f"/api/notebooks/{entry.id}/rendered")
+        assert resp.status_code == 500
+        assert "Notebook rendering failed" in resp.json()["detail"]

--- a/tests/interfaces/artifacts/test_timeseries_api.py
+++ b/tests/interfaces/artifacts/test_timeseries_api.py
@@ -451,6 +451,96 @@ class TestArtifactDataAPI:
         assert resp.status_code == 404
 
 
+class TestDataFileResolution:
+    """How ``/api/artifacts/{id}/data`` locates the entry's ``data_file`` on
+    disk: absolute paths are used as-is; relative paths are tried against the
+    workspace parent, the artifact store dir, and the workspace root in turn.
+    """
+
+    _PAYLOAD = {
+        "query": {"channels": ["PV:A"]},
+        "series": {"PV:A": {"timestamps": ["t0", "t1"], "values": [1.0, 2.0]}},
+    }
+
+    @pytest.fixture
+    def app_client(self, tmp_path):
+        from fastapi.testclient import TestClient
+
+        from osprey.interfaces.artifacts.app import create_app
+
+        app = create_app(workspace_root=tmp_path)
+        return TestClient(app), tmp_path
+
+    @staticmethod
+    def _save_with_data_file(store, data_file: str):
+        """Register a timeseries artifact whose ``data_file`` is the given string."""
+        return store.save_file(
+            file_content=b"timeseries placeholder",
+            filename="ts.txt",
+            artifact_type="text",
+            title="Relative data file",
+            description="data_file resolution test",
+            mime_type="text/plain",
+            tool_source="archiver_read",
+            metadata={"data_type": "timeseries", "data_file": data_file},
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "data_file",
+        ["data/rel_series.json", "bare_series.json"],
+        ids=["workspace-relative", "bare-filename"],
+    )
+    def test_relative_data_file_resolves(self, app_client, data_file):
+        """A workspace-relative path (the last candidate tried) and a bare
+        filename (tried against the store dir) both still resolve — legacy
+        entries wrote such paths."""
+        client, workspace = app_client
+        store = client.app.state.artifact_store
+        entry = self._save_with_data_file(store, data_file)
+        # save_file created the store dir; a bare name lands beside the index.
+        base = store.artifact_dir if data_file == "bare_series.json" else workspace
+        target = base / data_file
+        target.parent.mkdir(exist_ok=True)
+        target.write_text(json.dumps(self._PAYLOAD))
+
+        resp = client.get(f"/api/artifacts/{entry.id}/data?format=chart")
+        assert resp.status_code == 200
+        assert resp.json()["channels"][0]["channel"] == "PV:A"
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("absolute", [False, True], ids=["relative", "absolute"])
+    def test_missing_data_file_returns_404(self, app_client, absolute):
+        """A data_file that resolves nowhere — absolute, or relative and
+        matching no candidate location — is a 404, not a 500."""
+        client, workspace = app_client
+        store = client.app.state.artifact_store
+        data_file = str(workspace / "vanished.json") if absolute else "data/ghost_series.json"
+        entry = self._save_with_data_file(store, data_file)
+
+        resp = client.get(f"/api/artifacts/{entry.id}/data?format=chart")
+        assert resp.status_code == 404
+        assert "not found on disk" in resp.json()["detail"]
+
+    @pytest.mark.unit
+    def test_oversized_data_file_returns_413(self, app_client, monkeypatch):
+        """A data file over the size cap is refused with 413 rather than
+        parsed; the cap protects the gallery process, not the client."""
+        monkeypatch.setattr("osprey.interfaces.artifacts.app.MAX_TIMESERIES_FILE_BYTES", 64)
+        client, workspace = app_client
+        store = client.app.state.artifact_store
+        entry, _ = _make_timeseries_artifact(store, workspace, n_rows=50)
+
+        resp = client.get(f"/api/artifacts/{entry.id}/data?format=chart")
+        assert resp.status_code == 413
+        assert "too large" in resp.json()["detail"].lower()
+
+        # The cap applies only to the parsed formats: the raw passthrough
+        # (no format param) still streams the file bytes.
+        raw = client.get(f"/api/artifacts/{entry.id}/data")
+        assert raw.status_code == 200
+
+
 class TestArtifactTablePivotRobustness:
     """Edge cases in ``_pivot_channel_series_to_table``, the union-and-fill
     pivot behind ``format=table``.

--- a/tests/mcp_server/test_archiver_read_tool.py
+++ b/tests/mcp_server/test_archiver_read_tool.py
@@ -251,6 +251,25 @@ def test_parse_time_unrecognized_relative_falls_through_to_dateutil(expression, 
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    ("field", "kwargs"),
+    [
+        ("start_time", {"start_time": "not-a-timestamp"}),
+        # A bad end_time is caught after a good start_time.
+        ("end_time", {"start_time": "2024-01-15T10:00:00", "end_time": "not-a-timestamp"}),
+    ],
+)
+async def test_archiver_read_unparseable_time(archiver_project, field, kwargs):
+    """A time even dateutil cannot parse errors cleanly, naming the failing field."""
+    fn = _get_archiver_read()
+    with assert_raises_error(error_type="validation_error") as ctx:
+        await fn(channels=["SR:CURRENT:RB"], **kwargs)
+
+    assert field in ctx["envelope"]["error_message"]
+    assert "not-a-timestamp" in ctx["envelope"]["error_message"]
+
+
+@pytest.mark.unit
 async def test_archiver_read_file_persistence(tmp_path, archiver_read_tool):
     """Archiver read saves data to _agent_data/artifacts/ via ArtifactStore."""
     fn, connector = archiver_read_tool

--- a/tests/mcp_server/test_data_context_list_delete.py
+++ b/tests/mcp_server/test_data_context_list_delete.py
@@ -1,0 +1,132 @@
+"""Tests for the data_list and data_delete MCP tools.
+
+Covers:
+  - Listing entries with and without filters, echoing the filters applied
+  - ToolError passthrough vs internal_error wrapping on store failures
+  - Deleting an entry (index + file), missing-entry not_found
+"""
+
+import json
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from osprey.stores.artifact_store import initialize_artifact_store
+from tests.mcp_server.conftest import assert_raises_error, get_tool_fn
+
+
+def _save_entry(store, tool="channel_read", category="channel_values"):
+    """Helper to save a data entry with minimal boilerplate."""
+    return store.save_data(
+        tool=tool,
+        data={"value": 42, "units": "mA"},
+        title="test entry",
+        description="test entry",
+        summary={"count": 1},
+        access_details={"format": "json"},
+        category=category,
+    )
+
+
+@pytest.fixture
+def store(tmp_path):
+    """Initialize an ArtifactStore in a temporary workspace."""
+    return initialize_artifact_store(workspace_root=tmp_path)
+
+
+@pytest.fixture
+def list_tool():
+    """Get the raw async function for data_list."""
+    from osprey.mcp_server.workspace.tools.data_context_tools import data_list
+
+    return get_tool_fn(data_list)
+
+
+@pytest.fixture
+def delete_tool():
+    """Get the raw async function for data_delete."""
+    from osprey.mcp_server.workspace.tools.data_context_tools import data_delete
+
+    return get_tool_fn(data_delete)
+
+
+@pytest.mark.asyncio
+async def test_list_returns_entries_and_echoes_filters(store, list_tool):
+    """No filters: every entry, null filters echoed. Filtered: only the match."""
+    e1 = _save_entry(store)
+    e2 = _save_entry(store, tool="archiver_read", category="archiver_data")
+
+    unfiltered = json.loads(await list_tool())
+    assert unfiltered["total_entries"] == 2
+    assert {e["id"] for e in unfiltered["entries"]} == {e1.id, e2.id}
+    assert unfiltered["filters_applied"] == {
+        "tool": None,
+        "category": None,
+        "last_n": None,
+        "source_agent": None,
+    }
+
+    filtered = json.loads(await list_tool(tool_filter="archiver_read", last_n=5))
+    assert filtered["total_entries"] == 1
+    assert filtered["entries"][0]["id"] == e2.id
+    assert filtered["filters_applied"]["tool"] == "archiver_read"
+    assert filtered["filters_applied"]["last_n"] == 5
+
+
+@pytest.mark.asyncio
+async def test_list_reraises_tool_error_unwrapped(store, list_tool, monkeypatch):
+    """A ToolError from inside the store passes through, never re-wrapped as internal_error."""
+    envelope = json.dumps(
+        {"error": True, "error_type": "custom_error", "error_message": "x", "suggestions": []}
+    )
+
+    def _boom(**kwargs):
+        raise ToolError(envelope)
+
+    monkeypatch.setattr(store, "list_entries", _boom)
+
+    with assert_raises_error(error_type="custom_error"):
+        await list_tool()
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_entry_and_file(store, delete_tool):
+    entry = _save_entry(store)
+    file_path = store.get_file_path(entry.id)
+
+    result = json.loads(await delete_tool(entry_id=entry.id))
+
+    assert result["status"] == "success"
+    assert result["entry_id"] == entry.id
+    assert store.get_entry(entry.id) is None
+    assert not file_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_missing_entry_is_not_found(store, delete_tool):
+    with assert_raises_error(error_type="not_found") as ctx:
+        await delete_tool(entry_id="nonexistent_id")
+    assert "nonexistent_id" in ctx["envelope"]["error_message"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool_fixture", "store_method", "kwargs"),
+    [
+        ("list_tool", "list_entries", {}),
+        ("delete_tool", "delete_entry", {"entry_id": "e1"}),
+    ],
+)
+async def test_unexpected_store_failure_is_internal_error(
+    store, request, monkeypatch, tool_fixture, store_method, kwargs
+):
+    """An unexpected store exception surfaces as internal_error, not a raw traceback."""
+
+    def _boom(*args, **kw):
+        raise RuntimeError("index unreadable")
+
+    monkeypatch.setattr(store, store_method, _boom)
+
+    with assert_raises_error(error_type="internal_error") as ctx:
+        await request.getfixturevalue(tool_fixture)(**kwargs)
+    assert "index unreadable" in ctx["envelope"]["error_message"]

--- a/tests/mcp_server/test_data_context_read.py
+++ b/tests/mcp_server/test_data_context_read.py
@@ -226,6 +226,76 @@ class TestDataRead:
         assert set(preview["top_level_keys"]) == expected_keys
 
     @pytest.mark.asyncio
+    async def test_oversize_series_preview_without_query_block(self, store, read_tool):
+        """A series payload with no query dict still previews — just without `query`."""
+        entry = _save_entry(store)
+        stamps = [f"2026-05-11T00:{i // 60:02d}:{i % 60:02d}+00:00" for i in range(200)]
+        payload = {
+            "series": {"CH_A": {"timestamps": stamps, "values": [float(i) for i in range(200)]}},
+            "padding": "z" * (110 * 1024),
+        }
+        store.get_file_path(entry.id).write_text(json.dumps(payload))
+
+        with assert_raises_error(error_type="file_too_large") as ctx:
+            await read_tool(entry_id=entry.id)
+        preview = ctx["envelope"]["details"]["preview"]
+        assert preview["shape"] == "timeseries_series"
+        assert preview["channels"] == ["CH_A"]
+        assert "query" not in preview
+
+    @pytest.mark.parametrize(
+        ("content", "expected"),
+        [
+            # A top-level JSON array previews its length and first items.
+            pytest.param(
+                json.dumps(list(range(40000))).encode(),
+                {"shape": "json_array", "length": 40000, "first_items": [0, 1, 2, 3, 4]},
+                id="json_array",
+            ),
+            # A bare JSON scalar previews at most 200 characters of its value.
+            pytest.param(
+                json.dumps("z" * (150 * 1024)).encode(),
+                {"shape": "json_scalar", "value_preview": "z" * 200},
+                id="json_scalar",
+            ),
+            # An undecodable (non-UTF-8) file is reported as binary.
+            pytest.param(b"\xff\xfe" * (60 * 1024), {"shape": "binary"}, id="binary"),
+            # Above the 16 MB parse ceiling, no preview parsing is attempted at all.
+            pytest.param(
+                b"x" * (17 * 1024 * 1024),
+                {"shape": "skipped_too_large_for_preview"},
+                id="beyond_parse_limit",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_oversize_preview_shapes(self, store, read_tool, content, expected):
+        """Non-object payloads preview their shape (and peek), never a text head/tail."""
+        entry = _save_entry(store)
+        store.get_file_path(entry.id).write_bytes(content)
+
+        with assert_raises_error(error_type="file_too_large") as ctx:
+            await read_tool(entry_id=entry.id)
+        preview = ctx["envelope"]["details"]["preview"]
+        assert {k: preview.get(k) for k in expected} == expected
+        assert "head" not in preview
+
+    @pytest.mark.asyncio
+    async def test_read_wraps_unexpected_store_failure_as_internal_error(
+        self, store, read_tool, monkeypatch
+    ):
+        """An unexpected store exception surfaces as internal_error, not a raw traceback."""
+
+        def _boom(entry_id):
+            raise RuntimeError("index corrupted")
+
+        monkeypatch.setattr(store, "get_entry", _boom)
+
+        with assert_raises_error(error_type="internal_error") as ctx:
+            await read_tool(entry_id="whatever")
+        assert "index corrupted" in ctx["envelope"]["error_message"]
+
+    @pytest.mark.asyncio
     async def test_oversize_text_preview(self, store, read_tool):
         """Non-JSON oversized files expose a text head/tail preview."""
         entry = _save_entry(store)

--- a/tests/mcp_server/workspace/test_archiver_downsample.py
+++ b/tests/mcp_server/workspace/test_archiver_downsample.py
@@ -339,7 +339,19 @@ class TestArchiverDownsampleChannelFilter:
 
 
 class TestArchiverDownsampleErrors:
-    """Error cases: wrong category, missing entry, etc."""
+    """Error cases: wrong category, missing entry, unreadable data file, etc."""
+
+    @pytest.fixture
+    def entry(self, art_store):
+        return art_store.save_data(
+            tool="archiver_read",
+            data=_make_timeseries_data(5, 1),
+            title="Doomed entry",
+            description="Doomed entry",
+            summary={},
+            access_details={},
+            category="archiver_data",
+        )
 
     @pytest.fixture
     def non_archiver_entry(self, art_store):
@@ -368,6 +380,35 @@ class TestArchiverDownsampleErrors:
             await fn(entry_id="deadbeef0000")
         result = _exc_ctx["envelope"]
         assert "not found" in result["error_message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_file_path_is_internal_error(self, art_store, entry, monkeypatch):
+        """A file path the store cannot resolve reports internal_error, not a crash."""
+        monkeypatch.setattr(art_store, "get_file_path", lambda entry_id: None)
+
+        fn = _get_archiver_downsample()
+        with assert_raises_error(error_type="internal_error") as _exc_ctx:
+            await fn(entry_id=entry.id)
+        assert "not found on disk" in _exc_ctx["envelope"]["error_message"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "break_file",
+        [
+            # Invalid JSON on disk (JSONDecodeError) and a file deleted behind
+            # the store's back (OSError) take the same internal_error path.
+            pytest.param(lambda p: p.write_text("{not json"), id="corrupt_json"),
+            pytest.param(lambda p: p.unlink(), id="externally_deleted"),
+        ],
+    )
+    async def test_unreadable_data_file_is_internal_error(self, art_store, entry, break_file):
+        """An index entry can be fine while the data file itself is not."""
+        break_file(art_store.get_file_path(entry.id))
+
+        fn = _get_archiver_downsample()
+        with assert_raises_error(error_type="internal_error") as _exc_ctx:
+            await fn(entry_id=entry.id)
+        assert "Could not read data file" in _exc_ctx["envelope"]["error_message"]
 
 
 class TestArchiverDownsampleEmptyData:

--- a/tests/mcp_server/workspace/test_viz_common.py
+++ b/tests/mcp_server/workspace/test_viz_common.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pandas as pd
 import pytest
@@ -318,3 +319,75 @@ class TestBuildDataReaderCSV:
         assert isinstance(data, pd.DataFrame)
         assert list(data.columns) == ["a", "b"]
         assert len(data) == 2
+
+
+class TestCollectAndRegisterArtifacts:
+    """Artifact-store registration shared by all three visualization tools."""
+
+    @pytest.fixture
+    def art_store(self, tmp_path: Path):
+        from osprey.stores.artifact_store import initialize_artifact_store
+
+        return initialize_artifact_store(workspace_root=tmp_path)
+
+    @staticmethod
+    def _exec_result(*paths: Path):
+        """Fake SandboxExecutionResult carrying one artifact dict per path."""
+        return SimpleNamespace(
+            artifacts=[
+                {
+                    "path": p,
+                    "title": p.stem,
+                    "description": f"plot {p.stem}",
+                    "artifact_type": "plot_png",
+                    "mime_type": "image/png",
+                }
+                for p in paths
+            ]
+        )
+
+    def test_unreadable_artifact_skipped_and_data_source_recorded(self, art_store, tmp_path: Path):
+        """One artifact failing to save must not lose the ones after it, and
+        data_source alone still lands in viz metadata (empty code/stdout add no keys).
+        """
+        from osprey.mcp_server.workspace.tools._viz_common import collect_and_register_artifacts
+
+        ghost = tmp_path / "ghost.png"  # never written -> read_bytes raises
+        real = tmp_path / "real.png"
+        real.write_bytes(b"\x89PNG fake")
+
+        ids = collect_and_register_artifacts(
+            self._exec_result(ghost, real),
+            title="t",
+            description="d",
+            tool_source="create_static_plot",
+            data_source="abcdefabcdef",
+        )
+
+        assert len(ids) == 1
+        entry = art_store.get_entry(ids[0])
+        assert entry.filename.endswith("real.png")
+        assert entry.metadata == {"data_source": "abcdefabcdef"}
+        # No category given: the entry is neither categorized nor agent-tagged.
+        assert entry.category == ""
+        assert entry.source_agent == ""
+
+
+class TestBuildVizResponse:
+    """The response dict assembled after artifact registration."""
+
+    def test_gallery_url_failure_is_swallowed(self, monkeypatch):
+        """An unresolvable gallery URL never fails the tool — the key is just omitted."""
+        import osprey.mcp_server.http as http_mod
+        from osprey.mcp_server.workspace.tools._viz_common import build_viz_response
+
+        def _boom():
+            raise RuntimeError("no web config")
+
+        monkeypatch.setattr(http_mod, "gallery_url", _boom)
+
+        response = build_viz_response(["abc123def456"], title="t")
+
+        assert response["status"] == "success"
+        assert response["artifact_id"] == "abc123def456"
+        assert "gallery_url" not in response

--- a/tests/utils/test_timeseries.py
+++ b/tests/utils/test_timeseries.py
@@ -12,8 +12,11 @@ triangle-area math runs on a zero-filled working copy.
 
 from __future__ import annotations
 
+import pytest
+
 from osprey.utils.timeseries import (
     _lttb_select_indices,
+    downsample_channel_map,
     extract_channel_series,
     is_numeric_channel,
     lttb_downsample_channel,
@@ -92,6 +95,13 @@ class TestLttbSelectIndices:
         assert len(selected) == 20
         assert selected[0] == 0
         assert selected[-1] == 199
+
+    def test_empty_values_is_total_and_still_returns_max_points_indices(self):
+        """Degenerate empty channel (unreachable via the public reducer): the
+        lookahead-bucket clamp keeps the selector total instead of raising."""
+        selected = _lttb_select_indices([], 4)
+        assert len(selected) == 4
+        assert selected[0] == 0
 
 
 class TestExtractChannelSeries:
@@ -362,3 +372,58 @@ class TestLttbDownsampleChannel:
         assert out_ts[0] == "t0"
         assert out_ts[-1] == "t29"
         assert out_vals[-1] == 29.0
+
+
+class TestDownsampleChannelMap:
+    """One record per selected channel: the shared shape the artifacts web API
+    and the ``archiver_downsample`` MCP tool rename into their own wire
+    vocabularies.
+    """
+
+    @staticmethod
+    def _series() -> dict[str, dict]:
+        return {
+            "PV:A": {
+                "timestamps": [f"t{i}" for i in range(100)],
+                "values": [float(i) for i in range(100)],
+            },
+            "PV:B": {"timestamps": ["t0", "t1"], "values": ["CW", "STANDBY"]},
+        }
+
+    @pytest.mark.parametrize(
+        ("channels", "expected"),
+        [
+            pytest.param(None, ["PV:A", "PV:B"], id="none-keeps-series-order"),
+            pytest.param(["PV:B", "PV:A"], ["PV:B", "PV:A"], id="subset-in-requested-order"),
+            pytest.param(["PV:A", "PV:X"], ["PV:A"], id="names-not-in-series-dropped"),
+        ],
+    )
+    def test_channel_selection_and_order(self, channels, expected):
+        records = downsample_channel_map(self._series(), max_points=10, channels=channels)
+        assert [r["channel"] for r in records] == expected
+
+    def test_records_report_what_downsampling_cost_each_channel(self):
+        numeric, enum = downsample_channel_map(self._series(), max_points=10)
+        # Numeric channel: LTTB-reduced, cost reported.
+        assert numeric["numeric"] is True
+        assert (numeric["original_points"], numeric["returned_points"]) == (100, 10)
+        assert len(numeric["timestamps"]) == len(numeric["values"]) == 10
+        # First/last survival flows through from the per-channel reducer.
+        assert (numeric["timestamps"][0], numeric["timestamps"][-1]) == ("t0", "t99")
+        # Non-numeric channel: flagged, returned whole when it fits.
+        assert enum["numeric"] is False
+        assert (enum["original_points"], enum["returned_points"]) == (2, 2)
+        assert enum["values"] == ["CW", "STANDBY"]
+
+    def test_channel_missing_timestamps_and_values_keys_yields_an_empty_record(self):
+        records = downsample_channel_map({"PV:E": {}}, max_points=10)
+        assert records == [
+            {
+                "channel": "PV:E",
+                "timestamps": [],
+                "values": [],
+                "original_points": 0,
+                "returned_points": 0,
+                "numeric": True,
+            }
+        ]


### PR DESCRIPTION
## Why

The archiver stack that landed in #526 (and the mock-archiver simulation-file derivation from #524) shipped with uneven coverage: the error-handling arms in the MongoDB connector (85%), the `data_list`/`data_delete` MCP tools (72%, no test file at all), and a swath of artifacts app endpoints (87%) were untested.

## What this does

- Raises every archiver-stack module to **100% line + branch coverage**: all four connectors, `_timerange`, `utils/timeseries`, the four MCP tools (`archiver_read`, `archiver_downsample`, `_viz_common`, `data_context_tools`), and the archiver-freshness probe. `interfaces/artifacts/app.py` reaches 99.8% — 0 missing lines; the one remaining branch arc is unreachable for JSON-sourced data (would require an object whose `__hash__` is inconsistent between calls) and is documented rather than gamed.
- Two new test files: `test_data_context_list_delete.py` (the two tools had no tests) and `test_app_endpoints.py` (focus/pin state, SSE broadcaster, offline Plotly injection, lifecycle).
- Error contracts are pinned, not just exercised: each exception-mapping arm asserts the mapped type, a distinguishing message fragment, and the chained cause.
- Deletes one line of provably dead code: `lttb`'s `if c_end > n` guard in `utils/timeseries.py` — the `min(c_end, n)` clamp two lines earlier makes it unreachable.

Repetitive families are parametrized (connect/get_data error arms, 404 variants, preview shapes), so the whole thing lands in ~1,100 added lines. Suite runtime is unchanged (~104s locally for the touched areas; the added tests are millisecond-scale units).
