### PR TITLE
fix(connectors): keep pandas out of the lean control-system import chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,10 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- Importing the control-system connectors no longer drags in pandas. The
+  connector factory imported the archiver base eagerly for a type annotation,
+  so anything that wanted only `osprey.connectors.control_system` had to
+  install the archiver's dataframe stack to import it at all.
 - A secret containing `$` no longer reaches a container truncated. Compose
   substitutes `$` sequences inside env-file values, so `secret$abc` arrived as
   `secret` and `P@$$w0rd` as `P@$w0rd` — while the file on disk still read

--- a/src/osprey/connectors/factory.py
+++ b/src/osprey/connectors/factory.py
@@ -7,16 +7,22 @@ system for unified component management and lazy loading.
 
 """
 
+from __future__ import annotations
+
 import importlib
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from osprey.connectors import types
-from osprey.connectors.archiver.base import ArchiverConnector
 from osprey.connectors.control_system.base import ControlSystemConnector
 from osprey.utils.logger import get_logger
+
+if TYPE_CHECKING:
+    # Import only for annotations: pulling in the archiver base eagerly would
+    # make pandas a hard dependency of the lean control-system import chain.
+    from osprey.connectors.archiver.base import ArchiverConnector
 
 logger = get_logger("connector_factory")
 

--- a/tests/connectors/test_import_isolation.py
+++ b/tests/connectors/test_import_isolation.py
@@ -1,0 +1,37 @@
+"""Import isolation for the lean control-system connector chain.
+
+External consumers (e.g. the ALS tuning_scripts backend) import only the
+control-system connectors and their support modules. That chain must not
+eagerly load the archiver stack (pandas) or any LLM/agent machinery.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SRC = str(Path(__file__).resolve().parents[2] / "src")
+
+# Sentinels for the two dependency trees that must stay out of the lean chain:
+# the archiver's dataframe stack and the LLM/agent platform.
+FORBIDDEN = ("pandas", "litellm", "openai", "anthropic", "fastapi", "playwright")
+
+
+def test_control_system_chain_imports_without_heavy_deps():
+    code = (
+        "import osprey.connectors.control_system.epics_connector;"
+        "import osprey.connectors.control_system.limits_validator;"
+        "import osprey.errors, osprey.utils.config, osprey.utils.logger;"
+        "import osprey.simulation, sys;"
+        f"bad = sorted({{m.split('.')[0] for m in sys.modules}} & set({FORBIDDEN!r}));"
+        "assert not bad, f'lean connector chain eagerly imported: {bad}';"
+        "print('CLEAN')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env=dict(os.environ, PYTHONPATH=SRC),
+    )
+    assert result.returncode == 0, result.stderr
+    assert "CLEAN" in result.stdout


### PR DESCRIPTION
Importing `osprey.connectors.control_system.*` fails without pandas: `connectors/__init__.py` eagerly imports `factory.py`, which imports `archiver.base` → pandas. That import is only used in annotations, so it moves under `if TYPE_CHECKING:` (with `from __future__ import annotations`). Archiver behavior is unchanged — pandas loads when archiver code is used, not when the control-system chain is imported.

New `tests/connectors/test_import_isolation.py` imports the lean chain in a subprocess and asserts pandas and the LLM stack stay unloaded; it fails on `main` with `['pandas']`.