### PR TITLE
fix(deploy): refuse secrets compose would corrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,18 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- A secret containing `$` no longer reaches a container truncated. Compose
+  substitutes `$` sequences inside env-file values, so `secret$abc` arrived as
+  `secret` and `P@$$w0rd` as `P@$w0rd` — while the file on disk still read
+  correctly, leaving a login that refused for no visible reason. `osprey
+  deploy` now refuses such a stack and names the offending variables (never
+  their values). All three files a deploy reads secrets from are checked —
+  `.env`, `.env.production` and `.env.auth` — including ones OSPREY did not
+  write itself, so a CI-built `.env.production` and a hand-added OIDC client
+  secret are covered. `deploy passwd` checks before storing a new password.
+- The OIDC section of the multi-user guide named `.env` as the file to put
+  client credentials in. It is `.env.auth` — credentials placed as documented
+  never reached the login service.
 - The settings drawer's `CLAUDE.md` section now has a help tooltip. Its help
   text was filed under a category name no gallery ever displays, so the button
   silently never rendered — on the one artifact that matters most.

--- a/docs/source/how-to/multi-user.rst
+++ b/docs/source/how-to/multi-user.rst
@@ -429,10 +429,30 @@ cannot open this user's terminal:
            oidc_subject: "b7d9a340-..."
 
 The ``*_env`` keys hold environment-variable **names**, not credentials: put the
-client id and secret in the project's ``.env`` under those names. The names
+client id and secret in the project's ``.env.auth`` under those names — that is
+the only file the authentication service reads credentials from. The names
 shown are the ones OSPREY reads when you omit the keys, and ``claim`` falls back
 to ``sub`` in the authentication service itself. ``oidc_subject`` is not a
 secret — it is the identifier your provider already publishes for that person.
+
+.. warning::
+
+   **No secret may contain a dollar sign** — not in ``.env.auth``, and not in
+   the ``.env`` and ``.env.production`` that carry your provider API key and
+   facility passwords. Whichever way the container stack reads these files, it
+   substitutes ``$`` sequences inside the *values* on the way through —
+   ``secret$abc`` arrives as ``secret``, and ``P@$$w0rd`` arrives as
+   ``P@$w0rd``. The file on disk still reads correctly, so the only symptom is
+   a login or a token exchange that refuses for no visible reason.
+
+   This bites hardest with a client secret your identity provider generated for
+   you, since you did not choose those characters. If yours contains a ``$``,
+   issue a new one rather than trying to escape it — escaping is not portable
+   between container runtimes, so there is no spelling that works everywhere.
+
+   ``osprey deploy`` refuses to start a stack whose secrets would be corrupted
+   this way and names the offending variables, so you find out before the
+   deployment is running rather than after someone cannot log in.
 
 Three more keys are optional. ``auth.port`` is the port the authentication
 service listens on (default ``9070``); ``auth.session_lifetime`` is how long a

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -15,6 +15,7 @@ from osprey.deployment.compose_generator import (
     resolve_project_name,
 )
 from osprey.deployment.deploy_summary import log_endpoint_summary
+from osprey.deployment.errors import ComposeInterpolationError
 from osprey.deployment.facility_config import normalize_facility_config
 from osprey.deployment.host_ports import (
     find_port_conflicts,
@@ -48,6 +49,7 @@ from osprey.utils.config import ConfigBuilder
 from osprey.utils.dotenv import (
     append_profile_env,
     atomic_write,
+    compose_unsafe_vars,
     derive_project_env,
     parse_dotenv_file,
 )
@@ -370,6 +372,37 @@ def _ensure_service_tokens(
     if env_path is None:
         env_path = Path(".env")
 
+    # Scan the WHOLE file, ahead of everything else, because compose mangles a
+    # `$` on BOTH routes out of this file and every deploy uses both:
+    #
+    #   * `--env-file .env` (see _env_file_args) makes it the substitution
+    #     source for the compose DOCUMENT, so every `environment: - X=${X}`
+    #     entry — how most services here receive their secrets — resolves
+    #     through it;
+    #   * the dispatch worker additionally gets the file entire, via
+    #     `env_file: ../../.env` in its compose template.
+    #
+    # Measured on compose v2.34: `h0rse$battery` substitutes to `h0rse`, and
+    # `secret$HOME` to the deploy host's home path with NO warning at all.
+    # So the check cannot be per-var — _validate_var below only ever sees the
+    # deployed services' _SERVICE_TOKEN_VARS plus _VALIDATE_ONLY_VARS, while
+    # the provider API key, the olog password and the wiki-search token all
+    # travel in this file and are in neither set.
+    #
+    # Before the mint, deliberately. Scanning after would leave freshly minted
+    # tokens appended to .env while the raise skips _sync_secrets_to_profile,
+    # so the next `osprey build` re-derives .env from the profile, drops them,
+    # and mints a second set. Nothing is lost by checking early: every minted
+    # value is `$`-free by construction (see the alphabets in service_tokens),
+    # which the generator self-rejection test pins.
+    #
+    # The file — not the effective value — is what matters: compose reads it
+    # off disk, so a process-env override never reaches a container this way.
+    if env_path.is_file():
+        offenders = compose_unsafe_vars(parse_dotenv_file(env_path))
+        if offenders:
+            raise ComposeInterpolationError(offenders, env_path)
+
     if required_vars:
         existing = parse_dotenv_file(env_path) if env_path.is_file() else {}
 
@@ -409,7 +442,7 @@ def _ensure_service_tokens(
                 f"empty token. Set {name} in .env to a strong secret."
             )
         if effective and not _validate_var(name, effective):
-            _raise_invalid_var(name)
+            _raise_invalid_var(name, effective)
 
     # Validate-only vars (ARIEL_DSN): checked when present in the same
     # effective-value sense as required_vars above, but never minted when
@@ -420,7 +453,7 @@ def _ensure_service_tokens(
         if not effective:
             continue  # absent — never fabricated, never minted
         if not _validate_var(name, effective):
-            _raise_invalid_var(name)
+            _raise_invalid_var(name, effective)
 
     # Persist the *effective* secrets — not just the ones minted a moment ago —
     # into the profile that owns them, so a rebuild reproduces this stack

--- a/src/osprey/deployment/errors.py
+++ b/src/osprey/deployment/errors.py
@@ -6,9 +6,47 @@ errors live in :mod:`osprey.errors`.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from pathlib import Path
+
 
 class DeploymentError(Exception):
     """Base class for deployment failures."""
+
+
+class ComposeInterpolationError(DeploymentError):
+    """A secret bound for a compose ``env_file:`` contains ``$``.
+
+    Compose interpolates env_file *values*, so such a secret reaches the
+    container truncated (or, when the text after ``$`` names a variable set on
+    the deploy host, with the host's value spliced in) while the file on disk
+    reads correctly. Nothing downstream can tell the difference between a
+    truncated secret and a wrong one, so the symptom is an authentication
+    failure pointing nowhere near the cause.
+
+    That invisibility is why this refuses the deploy rather than warning. A
+    warning would scroll past and leave a stack running with a credential no
+    service accepts; the honest outcome is to stop before compose is invoked,
+    while the operator still has the context to fix it.
+
+    Carries the offending variable *names* only. The values are secrets and are
+    never rendered — the same discipline as
+    ``service_tokens._raise_invalid_var``.
+    """
+
+    def __init__(self, variables: Sequence[str], path: str | Path) -> None:
+        self.variables = list(variables)
+        self.path = str(path)
+        named = ", ".join(self.variables)
+        super().__init__(
+            f"{named} in {self.path} contain(s) '$'. Docker Compose interpolates "
+            f"env_file values, so the container would receive a truncated secret "
+            f"while {self.path} still reads correctly. Refusing to deploy. "
+            f"(Values not shown.) Re-issue or rotate the listed secret(s) to a "
+            f"'$'-free value — '$' cannot be escaped portably here, because '$$' "
+            f"means a literal '$' to Docker Compose but two characters to a "
+            f"runtime that does not interpolate."
+        )
 
 
 class DevModeUnavailableError(DeploymentError):

--- a/src/osprey/deployment/service_tokens.py
+++ b/src/osprey/deployment/service_tokens.py
@@ -162,13 +162,18 @@ def _validate_openobserve_password(value: str) -> bool:
 # at the deploy boundary (see ``_ensure_service_tokens``), regardless of
 # whether that value was freshly minted, carried over from an existing
 # ``.env``, supplied by the operator, or overridden in the process
-# environment. A var absent from this map has no registered constraint and
-# ``_validate_var`` returns True for it — deliberately fail-open. Opting a var
-# *into* a format constraint is additive hardening (it turns a downstream
+# environment. A var absent from this map has no registered *format* constraint
+# and ``_validate_var`` returns True for it — deliberately fail-open. Opting a
+# var *into* a format constraint is additive hardening (it turns a downstream
 # crash-loop into a clear deploy-time error), not a prerequisite the deploy
 # must clear, so withholding it by default must not block an otherwise-working
 # deploy. Adding an entry here is opt-in per var, exactly like
 # ``_VAR_GENERATORS``.
+#
+# The one rule this fail-open posture does NOT cover is ``$``, which
+# ``_validate_var`` applies to every var ahead of this map: a ``$`` is
+# corrupted by how compose loads the file, not by what any one service
+# accepts, so it cannot be a per-var opt-in. See ``_validate_var``.
 _VAR_VALIDATORS: dict[str, Callable[[str], bool]] = {
     # Tiled rejects a non-alphanumeric --api-key at startup (see
     # _VAR_GENERATORS above); reject it here too so an *operator-supplied*
@@ -224,21 +229,49 @@ def _effective_value(var: str, dotenv: dict[str, str]) -> str:
 
 
 def _validate_var(var: str, value: str) -> bool:
-    """Check ``value`` against ``var``'s registered constraint, if any.
+    """Check ``value`` against the universal ``$`` rule, then ``var``'s own.
 
-    Returns True (pass) for any var with no registered validator in
-    ``_VAR_VALIDATORS`` — see that dict's docstring for the fail-open
-    rationale.
+    Two layers, and the order matters. Every var here ends up in the project
+    ``.env``, which the dispatch worker receives *in its entirety* via
+    ``env_file: ../../.env`` — so a ``$`` in any of them is truncated on the way
+    into the container regardless of which var it is. That check is therefore
+    universal and runs first, ahead of the per-var lookup.
+
+    Per-*format* constraints stay opt-in and fail-open, as ``_VAR_VALIDATORS``
+    documents: a var absent from that dict still passes. Only the ``$`` rule is
+    unconditional, because it is a property of how compose loads the file rather
+    than of what any one service accepts. The three registered validators that
+    reason about character safety — ``_validate_ariel_dsn`` and the
+    ``ARIEL_DB_PASSWORD`` lambda, which reject the URI-reserved ``@:/?#``, and
+    ``_validate_openobserve_password``, whose "at least one special character"
+    requirement a ``$`` actively *satisfied* — all admitted ``$`` on their own.
+    Layering it here fixes those three and every var added later in one place.
     """
+    if "$" in value:
+        return False
     validator = _VAR_VALIDATORS.get(var)
     if validator is None:
         return True
     return validator(value)
 
 
-def _raise_invalid_var(var: str) -> None:
-    """Raise the standard "invalid var" RuntimeError, never the value."""
-    constraint = _VAR_VALIDATOR_DESCRIPTIONS.get(
-        var, "does not satisfy its registered format constraint"
-    )
+def _raise_invalid_var(var: str, value: str = "") -> None:
+    """Raise the standard "invalid var" RuntimeError, never the value.
+
+    ``value`` is inspected only to pick the right explanation — a ``$`` failure
+    and a format failure are different problems with different fixes, and the
+    generic "does not satisfy its registered format constraint" text sends an
+    operator hunting through a validator that is not the one that rejected them.
+    It is never rendered into the message.
+    """
+    if "$" in value:
+        constraint = (
+            "must not contain '$' — compose interpolates env_file values, so the "
+            "container would receive a truncated secret while .env still reads "
+            "correctly ('$' cannot be escaped portably here)"
+        )
+    else:
+        constraint = _VAR_VALIDATOR_DESCRIPTIONS.get(
+            var, "does not satisfy its registered format constraint"
+        )
     raise RuntimeError(f"{var} is invalid: {constraint}. Refusing to deploy. (Value not shown.)")

--- a/src/osprey/deployment/web_terminals/auth_credentials.py
+++ b/src/osprey/deployment/web_terminals/auth_credentials.py
@@ -39,6 +39,7 @@ from pathlib import Path
 # The service-token recipes are imported rather than restated so the signing
 # secrets below are minted and validated exactly like every other deploy-time
 # secret, and pick up any constraint registered for them later.
+from osprey.deployment.errors import ComposeInterpolationError
 from osprey.deployment.service_tokens import (
     _generate_token,
     _raise_invalid_var,
@@ -55,7 +56,7 @@ from osprey.deployment.web_terminals.personas import (
     env_var_suffix_collisions,
 )
 from osprey.services.auth_sidecar.passwords import hash_password
-from osprey.utils.dotenv import dotenv_line_var, parse_dotenv_file
+from osprey.utils.dotenv import compose_unsafe_vars, dotenv_line_var, parse_dotenv_file
 from osprey.utils.logger import get_logger
 
 logger = get_logger("deployment.lifecycle")
@@ -206,6 +207,43 @@ def _normalize_mode(env_auth_path: Path) -> None:
             env_auth_path,
             exc,
         )
+
+
+def raise_if_env_auth_would_be_interpolated(project_root: str | Path) -> None:
+    """Refuse to act on a ``.env.auth`` holding a ``$``-bearing value.
+
+    Scans the file *as it exists on disk*, which is the whole point. Everything
+    this module writes is ``$``-free by construction — base64url hashes joined
+    by :data:`~osprey.services.auth_sidecar.passwords.FIELD_SEP`,
+    ``token_urlsafe`` signing secrets — and a unit test already pins that. The
+    value this catches is the one OSPREY never writes: the OIDC client secret,
+    which the compose template references by *name* only and the operator
+    appends by hand, minted by an IdP whose alphabet routinely includes
+    punctuation. There is no write boundary to hook, and the generator-side test
+    cannot see it because that test calls the generators. Reading the finished
+    file is the only place both the minted and the hand-added lines are visible
+    at once.
+
+    Note the sidecar's own startup check tests the client secret for
+    *emptiness*. A fully-eaten secret trips it; a partially truncated one is
+    non-empty, clears startup, and fails later against the IdP with an opaque
+    token-endpoint rejection. This scan is what closes that gap.
+
+    CALL THIS BEFORE MUTATING ``.env.auth``, never between a mutation and the
+    sidecar recreate that puts it into force. ``decommission``/``prune`` remove
+    a departed user's hash and then recreate; a refusal wedged in between would
+    leave the file saying the user is gone while the running sidecar still
+    accepts their password — the exact divergence those verbs exist to prevent,
+    traded for an unrelated secret. Refusing *before* any mutation costs
+    nothing, and a corrupt value left in place is still caught by the next
+    ``osprey deploy up``.
+    """
+    env_auth = Path(project_root) / AUTH_ENV_FILENAME
+    if not env_auth.is_file():
+        return
+    offenders = compose_unsafe_vars(parse_dotenv_file(env_auth))
+    if offenders:
+        raise ComposeInterpolationError(offenders, env_auth)
 
 
 def ensure_auth_credentials(
@@ -462,7 +500,7 @@ def ensure_auth_session_secrets(project_root: str | Path) -> AuthSecretsResult:
             continue
         effective = post.get(var, "")
         if effective and not _validate_var(var, effective):
-            _raise_invalid_var(var)
+            _raise_invalid_var(var, effective)
 
     return AuthSecretsResult(
         env_auth_path=env_auth_path,

--- a/src/osprey/deployment/web_terminals/env_production.py
+++ b/src/osprey/deployment/web_terminals/env_production.py
@@ -11,8 +11,9 @@ from pathlib import Path
 
 import yaml
 
+from osprey.deployment.errors import ComposeInterpolationError
 from osprey.deployment.web_terminals.personas import effective_image_source
-from osprey.utils.dotenv import parse_dotenv_file
+from osprey.utils.dotenv import compose_unsafe_vars, parse_dotenv_file
 from osprey.utils.logger import get_logger
 
 logger = get_logger("deployment.lifecycle")
@@ -283,6 +284,17 @@ def ensure_env_production(config: dict, project_root: str | Path) -> Path:
     env_production_path = root / ".env.production"
     if env_production_path.is_file():
         _warn_if_env_production_lacks_credentials(config, root, env_production_path)
+        # Scan the file we are about to hand to every web terminal, not just
+        # one this run generated. Registry mode -- the DEFAULT -- never reaches
+        # the generator below at all: CI assembles .env.production from masked
+        # variables and ships it beside the image. An operator-authored file
+        # takes the same path, since an existing one is never regenerated. Both
+        # carry values OSPREY never saw, which is exactly the case the
+        # generate-path check cannot cover (same reasoning as
+        # provision._raise_if_auth_env_would_be_interpolated).
+        offenders = compose_unsafe_vars(parse_dotenv_file(env_production_path))
+        if offenders:
+            raise ComposeInterpolationError(offenders, env_production_path)
         return env_production_path
 
     web_terminals = (config.get("modules") or {}).get("web_terminals") or {}
@@ -369,6 +381,17 @@ def ensure_env_production(config: dict, project_root: str | Path) -> Path:
         )
 
     subset = _build_env_production_subset(config, dotenv, {**required_cc_vars, **extra_cc_vars})
+
+    # Every value above is a verbatim copy out of the operator's .env (or, for
+    # ARIEL_DSN, straight out of facility config), and this file is handed to
+    # every per-user web terminal as `env_file: .env.production`. A `$` in any
+    # of them is interpolated away en route to the container. Checked before the
+    # open() below, not after: a refused deploy must not leave a half-written
+    # secrets file that a later run would mistake for one the operator authored
+    # (an existing .env.production is never regenerated).
+    offenders = compose_unsafe_vars(subset)
+    if offenders:
+        raise ComposeInterpolationError(offenders, env_production_path)
 
     lines = "".join(f"{key}={value}\n" for key, value in subset.items())
     # Create with mode 0600 from the FIRST byte on disk, not write-then-chmod:

--- a/src/osprey/deployment/web_terminals/lifecycle.py
+++ b/src/osprey/deployment/web_terminals/lifecycle.py
@@ -77,6 +77,7 @@ from osprey.deployment.web_terminals.auth_credentials import (
     AUTH_ENV_FILENAME,
     PW_PLAINTEXT_VAR_PREFIX,
     purge_auth_credentials,
+    raise_if_env_auth_would_be_interpolated,
     set_auth_password,
 )
 from osprey.deployment.web_terminals.naming import web_container_name, web_container_prefix
@@ -826,6 +827,14 @@ def rotate_user_password(config_path: str | Path, user: str, password: str) -> N
     # against CWD (see the module's CWD CONTRACT), and the two must agree or a
     # caller off the project root would store the hash in one place and
     # recreate against another.
+    # BEFORE the write, not after: a rotation that stores the new hash and is
+    # then refused would leave the operator holding a password the sidecar has
+    # not been given. An operator who has just pasted an IdP client secret into
+    # `.env.auth` and reaches for `passwd` is the likeliest way a `$`-bearing
+    # value meets a deploy verb, so this is where catching it is worth the
+    # check — the removal verbs deliberately do not, see the function docstring.
+    raise_if_env_auth_would_be_interpolated(Path.cwd())
+
     set_auth_password(user, password, Path.cwd())
 
     # The shared primitive, imported rather than re-implemented: provision.py

--- a/src/osprey/deployment/web_terminals/provision.py
+++ b/src/osprey/deployment/web_terminals/provision.py
@@ -40,6 +40,7 @@ from osprey.deployment.web_terminals.auth_credentials import (
     AuthSecretsResult,
     ensure_auth_credentials,
     ensure_auth_session_secrets,
+    raise_if_env_auth_would_be_interpolated,
 )
 from osprey.deployment.web_terminals.env_production import ensure_env_production
 from osprey.deployment.web_terminals.persona_images import (
@@ -213,6 +214,13 @@ def _provision_auth_secrets(web_terminals: dict, project_root: str) -> bool:
         credentials = ensure_auth_credentials(usernames, project_root)
     session_secrets = ensure_auth_session_secrets(project_root)
     _raise_if_auth_provisioning_incomplete(auth_method, credentials, session_secrets)
+    # After the mint rather than before it, uniquely on this path: on a fresh
+    # root .env.auth does not exist until ensure_auth_session_secrets creates
+    # it, so there would be nothing to scan. Safe here because the mint is
+    # idempotent and appends only `$`-free values — a refusal leaves the file
+    # exactly as a re-run would rebuild it, unlike the credential-removing
+    # verbs (see the function's own docstring for why they scan up front).
+    raise_if_env_auth_would_be_interpolated(project_root)
     return bool(credentials and credentials.changed) or session_secrets.changed
 
 
@@ -574,6 +582,14 @@ def force_recreate_auth_sidecar(
             AUTH_ENV_FILENAME,
         )
         return
+    # Deliberately NOT scanned here, though this is the one line every path
+    # that re-bakes .env.auth passes through. A recreate is always the step
+    # that puts an ALREADY-APPLIED file change into force, so refusing at this
+    # point would leave the file and the running sidecar disagreeing — for
+    # `decommission`/`prune`, the file would say a departed user is gone while
+    # the sidecar still accepts their password, which is the precise divergence
+    # those verbs exist to close. The scan runs ahead of each mutation instead;
+    # see auth_credentials.raise_if_env_auth_would_be_interpolated.
     _force_recreate_services(
         web_stack_compose_cmd(config, env_file_args),
         runtime_env(config, env if env is not None else dict(os.environ)),

--- a/src/osprey/utils/dotenv.py
+++ b/src/osprey/utils/dotenv.py
@@ -54,6 +54,36 @@ def parse_dotenv_text(text: str) -> dict[str, str]:
     return env
 
 
+def compose_unsafe_vars(values: Mapping[str, str]) -> list[str]:
+    """Names of vars whose value a compose ``env_file:`` would not deliver intact.
+
+    Compose interpolates the *values* it reads from an ``env_file:``, not just
+    the compose document. A ``$`` followed by an identifier character is
+    replaced with the named variable's value — the empty string when that name
+    is unset — so the container receives a truncated secret while the file on
+    disk stays byte-perfect. Two forms carry no warning whatsoever: ``$$``
+    collapses to a single ``$``, and a ``$`` followed by a name that *is* set on
+    the deploy host splices the host's value into the secret.
+
+    The test is "contains ``$``", not "contains an interpolating ``$``".
+    ``trailing$`` and ``$1`` survive Docker Compose, but podman-compose is the
+    documented default for facility deploys and is not guaranteed to agree, and
+    escaping cannot bridge the two: writing ``$$`` yields ``$`` under a runtime
+    that interpolates and a literal ``$$`` under one that does not, so no single
+    file is correct for both. Refusing ``$`` outright is the only
+    runtime-independent rule — and the one the codebase already designs to
+    (``auth_sidecar.passwords.FIELD_SEP``, the minted alphabets in
+    :mod:`osprey.deployment.service_tokens`).
+
+    Returns variable *names*, sorted — deliberately never the values, so that no
+    caller can accidentally render a secret into an error message or a log line.
+
+    :param values: Parsed ``KEY=VALUE`` pairs bound for a compose ``env_file:``.
+    :return: Sorted names of the offending variables; empty when all are safe.
+    """
+    return sorted(name for name, value in values.items() if "$" in value)
+
+
 def dotenv_line_var(line: str) -> str | None:
     """The variable a raw ``.env`` line assigns, or ``None`` for a non-assignment.
 

--- a/tests/deployment/test_compose_env_interpolation.py
+++ b/tests/deployment/test_compose_env_interpolation.py
@@ -1,0 +1,389 @@
+"""Secrets bound for a compose ``env_file:`` must not contain ``$``.
+
+Compose interpolates the *values* it reads from an ``env_file:``, not just the
+compose document. A ``$`` followed by an identifier character is replaced with
+the named variable's value — the empty string when that name is unset — so a
+``$``-bearing secret arrives inside the container truncated. Two variants carry
+no warning at all: ``$$`` collapses to a single ``$``, and a ``$`` followed by a
+name that *is* set on the deploy host splices the host's value in.
+
+The same substitution happens on the OTHER route out of a ``.env``: every
+deploy runs compose with ``--env-file .env``, which makes it the variable source
+for the compose *document*, so an ``environment: - X=${X}`` entry — how most
+services here receive their secrets — resolves through it too. Measured on
+compose v2.34, ``h0rse$battery`` becomes ``h0rse`` and ``secret$HOME`` becomes
+the deploy host's home path, the latter with no warning.
+
+The failure is invisible from the host. The file on disk is byte-perfect, every
+test that reads the file passes, and only the service that consumes the secret
+refuses. These tests pin the guard at each boundary where a value OSPREY did not
+mint can reach a container:
+
+* ``.env.auth``   — the auth sidecar (includes the operator-appended OIDC secret)
+* ``.env.production`` — every per-user web terminal
+* ``.env``        — the compose document on every deploy, plus the dispatch
+  worker, which receives the file wholesale
+
+The rule is "no ``$`` at all", not "no interpolating ``$``". A trailing ``$``
+survives Docker Compose today, but podman-compose is the documented default for
+facility deploys and its interpolation is not guaranteed to agree; the codebase
+already designs to a ``$``-free invariant (``passwords.FIELD_SEP``, the minted
+alphabets in ``service_tokens``). A rejected-but-harmless secret costs a
+rotation. A missed one is a silent outage.
+
+Offending values are reported by variable *name* only — never echoed — matching
+``_raise_invalid_var``'s existing discipline.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from osprey.deployment import container_lifecycle, service_tokens
+from osprey.deployment.errors import ComposeInterpolationError
+from osprey.deployment.web_terminals import auth_credentials, env_production, provision
+from osprey.utils.dotenv import compose_unsafe_vars
+
+# ---------------------------------------------------------------------------
+# The detection helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "secret$abc",  # interpolated -> truncated (warned)
+        "secret${abc}",  # braced form -> truncated (warned)
+        "secret$_x",  # underscore is an identifier char
+        "P@$$w0rd",  # $$ collapses to $ -- SILENT
+        "secret$HOME",  # host value spliced in -- SILENT
+        "trailing$",  # survives docker compose, not guaranteed elsewhere
+        "digit$1abc",  # ditto
+    ],
+)
+def test_compose_unsafe_vars_flags_every_dollar_form(value: str) -> None:
+    assert compose_unsafe_vars({"SECRET": value}) == ["SECRET"]
+
+
+def test_compose_unsafe_vars_passes_clean_values() -> None:
+    clean = {
+        "ANTHROPIC_API_KEY": "sk-ant-api03-AbC_def-123XyZ",  # base64url
+        "ARIEL_DB_PASSWORD": "deadbeefdeadbeef",  # token_hex alphabet
+        "OSPREY_AUTH_SESSION_SECRET": "xY-_09azAZ",  # token_urlsafe
+        "TZ": "America/Los_Angeles",
+    }
+    assert compose_unsafe_vars(clean) == []
+
+
+def test_compose_unsafe_vars_returns_names_never_values() -> None:
+    """The helper's return type is the leak guard: it cannot carry a secret."""
+    offenders = compose_unsafe_vars({"B_KEY": "b$ad", "A_KEY": "a$ad", "OK": "fine"})
+    assert offenders == ["A_KEY", "B_KEY"]  # sorted names, no values
+
+
+# ---------------------------------------------------------------------------
+# service_tokens validators -- the three that reason about character safety
+# and admitted `$` anyway
+# ---------------------------------------------------------------------------
+
+
+def test_ariel_dsn_with_dollar_in_password_is_rejected() -> None:
+    """``_validate_ariel_dsn`` rejects ``@:/?#`` but ``$`` is a URI sub-delim.
+
+    ``postgresql://ariel:se$cret@db/ariel`` parses cleanly and reaches the
+    container as ``postgresql://ariel:se@db/ariel``.
+    """
+    assert not service_tokens._validate_var("ARIEL_DSN", "postgresql://ariel:se$cret@db:5432/ariel")
+
+
+def test_ariel_db_password_with_dollar_is_rejected() -> None:
+    assert not service_tokens._validate_var("ARIEL_DB_PASSWORD", "se$cret")
+
+
+def test_openobserve_password_dollar_does_not_satisfy_the_special_class() -> None:
+    """The policy check *requires* a non-alphanumeric character.
+
+    ``$`` satisfies ``any(not c.isalnum())``, so it was not merely tolerated --
+    it was an accepted way to pass. ``Passw0rd$x`` cleared validation and the
+    container received ``Passw0rd``.
+    """
+    assert not service_tokens._validate_var("ZO_ROOT_USER_PASSWORD", "Passw0rd$x")
+
+
+def test_dollar_guard_applies_to_vars_with_no_registered_validator() -> None:
+    """``_validate_var`` is fail-open per-format, but never for ``$``."""
+    assert not service_tokens._validate_var("EVENT_DISPATCHER_TOKEN", "tok$en")
+
+
+@pytest.mark.parametrize(
+    "var",
+    [
+        # The three with custom alphabets...
+        "ZO_ROOT_USER_PASSWORD",
+        "ARIEL_DB_PASSWORD",
+        "BLUESKY_TILED_API_KEY",
+        # ...and the three that fall back to _default_token.
+        "EVENT_DISPATCHER_TOKEN",
+        "DISPATCH_WORKER_TOKEN",
+        "BLUESKY_LAUNCH_TOKEN",
+    ],
+)
+def test_minted_secrets_still_satisfy_their_own_validators(var: str) -> None:
+    """Regression: the guard must not reject what OSPREY itself mints.
+
+    Also the premise the ``.env`` scan's placement rests on — it runs *before*
+    the mint, which is only sound because minted values are ``$``-free.
+    """
+    minted = service_tokens._generate_token(var)
+    assert "$" not in minted, f"{var} generator emits a value its own guard rejects"
+    assert service_tokens._validate_var(var, minted)
+
+
+# ---------------------------------------------------------------------------
+# The project .env -- handed to the dispatch worker WHOLESALE, so the check
+# has to cover the file, not just the vars that carry a registered validator
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_service_tokens_refuses_a_dollar_outside_the_validated_vars(tmp_path) -> None:
+    """The hole a per-var check cannot close.
+
+    ``_validate_var`` only ever runs over the deployed services'
+    ``_SERVICE_TOKEN_VARS`` plus ``_VALIDATE_ONLY_VARS``. ``OLOG_PASSWORD`` is
+    in neither, yet ``env_file: ../../.env`` hands the dispatch worker the whole
+    file — so the scan has to be over the file.
+    """
+    env_path = tmp_path / ".env"
+    env_path.write_text("OLOG_PASSWORD=h0rse$battery\n", encoding="utf-8")
+
+    with pytest.raises(ComposeInterpolationError) as excinfo:
+        container_lifecycle._ensure_service_tokens({}, False, env_path)
+
+    assert "OLOG_PASSWORD" in str(excinfo.value)
+    assert "battery" not in str(excinfo.value)
+
+
+def test_ensure_service_tokens_refuses_before_minting_anything(tmp_path) -> None:
+    """A refused deploy must not leave freshly minted tokens behind.
+
+    The raise skips ``_sync_secrets_to_profile``, so tokens appended before it
+    would be dropped by the next ``osprey build`` re-deriving ``.env`` from the
+    profile — and a second set minted. Checking ahead of the mint avoids it.
+    """
+    env_path = tmp_path / ".env"
+    env_path.write_text("OLOG_PASSWORD=h0rse$battery\n", encoding="utf-8")
+    config = {"deployed_services": ["event_dispatcher"]}
+
+    with pytest.raises(ComposeInterpolationError):
+        container_lifecycle._ensure_service_tokens(config, False, env_path)
+
+    assert env_path.read_text(encoding="utf-8") == "OLOG_PASSWORD=h0rse$battery\n", (
+        "nothing may be appended to .env before the scan refuses"
+    )
+
+
+def test_ensure_service_tokens_passes_a_clean_env(tmp_path) -> None:
+    """Regression: the ordinary path is undisturbed."""
+    env_path = tmp_path / ".env"
+    env_path.write_text("OLOG_PASSWORD=cleanpassword\n", encoding="utf-8")
+
+    container_lifecycle._ensure_service_tokens({}, False, env_path)
+
+    assert "cleanpassword" in env_path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# .env.production -- every value is copied verbatim from the operator's .env
+# ---------------------------------------------------------------------------
+
+
+_CONFIG = {
+    "facility": {"name": "T", "prefix": "t", "timezone": "UTC"},
+    "llm": {"provider": "cborg", "api_key_env_var": "CBORG_API_KEY"},
+    "modules": {
+        "web_terminals": {"enabled": True, "image_source": "local"},
+        "olog": {
+            "enabled": True,
+            "username_env_var": "OLOG_USERNAME",
+            "password_env_var": "OLOG_PASSWORD",
+        },
+    },
+}
+
+
+def _write_env(tmp_path, values: dict) -> None:
+    (tmp_path / ".env").write_text(
+        "".join(f"{k}={v}\n" for k, v in values.items()), encoding="utf-8"
+    )
+
+
+def test_env_production_refuses_a_dollar_bearing_secret(tmp_path) -> None:
+    """An OLOG password with a ``$`` must abort the deploy, not ship truncated."""
+    _write_env(
+        tmp_path,
+        {
+            "CBORG_API_KEY": "sk-clean-key",
+            "OLOG_USERNAME": "logbot",
+            "OLOG_PASSWORD": "h0rse$battery",
+        },
+    )
+
+    with pytest.raises(ComposeInterpolationError) as excinfo:
+        env_production.ensure_env_production(_CONFIG, tmp_path)
+
+    message = str(excinfo.value)
+    assert "OLOG_PASSWORD" in message, "the offending variable must be named"
+    assert "h0rse" not in message, "the secret value must never be echoed"
+    assert not (tmp_path / ".env.production").exists(), (
+        "a refused deploy must not leave a half-written secrets file behind"
+    )
+
+
+def test_env_production_writes_clean_secrets_unchanged(tmp_path) -> None:
+    """Regression: the guard must not disturb the ordinary path."""
+    _write_env(
+        tmp_path,
+        {
+            "CBORG_API_KEY": "sk-clean-key",
+            "OLOG_USERNAME": "logbot",
+            "OLOG_PASSWORD": "cleanpassword",
+        },
+    )
+
+    path = env_production.ensure_env_production(_CONFIG, tmp_path)
+
+    assert "OLOG_PASSWORD=cleanpassword" in path.read_text(encoding="utf-8")
+
+
+def test_env_production_scans_a_file_it_did_not_generate(tmp_path) -> None:
+    """Registry mode -- the DEFAULT -- never generates this file.
+
+    CI assembles it from masked variables and ships it beside the image; an
+    operator-authored file takes the same path, since an existing one is never
+    regenerated. Both hold values OSPREY never saw, so the generate-path check
+    alone would leave the default deploy unguarded.
+    """
+    (tmp_path / ".env.production").write_text("OLOG_PASSWORD=h0rse$battery\n", encoding="utf-8")
+
+    with pytest.raises(ComposeInterpolationError) as excinfo:
+        env_production.ensure_env_production(_CONFIG, tmp_path)
+
+    assert "OLOG_PASSWORD" in str(excinfo.value)
+    assert "battery" not in str(excinfo.value)
+
+
+def test_env_production_returns_an_existing_clean_file_untouched(tmp_path) -> None:
+    """Regression: an existing clean file is still returned, never regenerated."""
+    existing = tmp_path / ".env.production"
+    existing.write_text("OLOG_PASSWORD=cleanpassword\n", encoding="utf-8")
+
+    path = env_production.ensure_env_production(_CONFIG, tmp_path)
+
+    assert path.read_text(encoding="utf-8") == "OLOG_PASSWORD=cleanpassword\n"
+
+
+def test_env_production_refuses_a_dollar_in_the_ariel_dsn(tmp_path) -> None:
+    """``ARIEL_DSN`` comes from facility config, not ``.env`` -- same guard."""
+    config = {
+        **_CONFIG,
+        "modules": {
+            **_CONFIG["modules"],
+            "ariel": {"enabled": True, "dsn": "postgresql://ariel:se$cret@db:5432/ariel"},
+        },
+    }
+    _write_env(tmp_path, {"CBORG_API_KEY": "sk-clean-key"})
+
+    with pytest.raises(ComposeInterpolationError) as excinfo:
+        env_production.ensure_env_production(config, tmp_path)
+
+    assert "ARIEL_DSN" in str(excinfo.value)
+    assert "se$cret" not in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# .env.auth -- the OIDC client secret, which no OSPREY code writes
+# ---------------------------------------------------------------------------
+
+
+def test_env_auth_scan_catches_an_operator_appended_oidc_secret(tmp_path) -> None:
+    """The one value in ``.env.auth`` a human chooses, and no writer can guard.
+
+    The compose template emits only the variable *name*; the operator appends
+    the IdP-minted value by hand. The generator-side regression test cannot see
+    it, so the deploy path must scan the file as it exists on disk.
+    """
+    (tmp_path / ".env.auth").write_text(
+        "OSPREY_AUTH_OIDC_CLIENT_SECRET=idp$ecret-value\n", encoding="utf-8"
+    )
+    web_terminals = {
+        "enabled": True,
+        "auth": {"method": "password"},
+        "users": [{"name": "alice"}],
+    }
+
+    with pytest.raises(ComposeInterpolationError) as excinfo:
+        provision._provision_auth_secrets(web_terminals, str(tmp_path))
+
+    message = str(excinfo.value)
+    assert "OSPREY_AUTH_OIDC_CLIENT_SECRET" in message
+    assert "ecret-value" not in message
+
+
+def test_sidecar_recreate_itself_is_never_blocked_by_the_scan(tmp_path, monkeypatch) -> None:
+    """The recreate must stay unconditional, and this is why.
+
+    A recreate is always the step that puts an ALREADY-APPLIED change to
+    ``.env.auth`` into force. ``decommission``/``prune`` remove a departed
+    user's hash and then recreate; refusing in between would leave the file
+    saying the user is gone while the running sidecar still accepts their
+    password — the exact divergence those verbs exist to close, traded for an
+    unrelated secret. So the scan goes ahead of each mutation, never here.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "docker-compose.web.yml").write_text("services: {}\n", encoding="utf-8")
+    (tmp_path / ".env.auth").write_text(
+        "OSPREY_AUTH_OIDC_CLIENT_SECRET=idp$ecret\n", encoding="utf-8"
+    )
+    called: list[object] = []
+    monkeypatch.setattr(provision, "_force_recreate_services", lambda *a, **k: called.append(a))
+    monkeypatch.setattr(provision, "web_stack_compose_cmd", lambda *a, **k: ["compose"])
+    monkeypatch.setattr(provision, "runtime_env", lambda *a, **k: {})
+
+    provision.force_recreate_auth_sidecar({})
+
+    assert called, "a credential removal must still be put into force"
+
+
+def test_password_rotation_is_refused_before_it_writes(tmp_path, monkeypatch) -> None:
+    """The one removal-free verb, so refusing up front costs nothing.
+
+    An operator who has just pasted an IdP client secret into ``.env.auth`` and
+    reaches for ``passwd`` is the likeliest way a ``$``-bearing value meets a
+    deploy verb. Refusing before ``set_auth_password`` writes means the operator
+    is never left holding a password the sidecar was not given.
+    """
+    (tmp_path / ".env.auth").write_text(
+        "OSPREY_AUTH_OIDC_CLIENT_SECRET=idp$ecret\n", encoding="utf-8"
+    )
+    before = (tmp_path / ".env.auth").read_text(encoding="utf-8")
+
+    with pytest.raises(ComposeInterpolationError):
+        auth_credentials.raise_if_env_auth_would_be_interpolated(tmp_path)
+
+    assert (tmp_path / ".env.auth").read_text(encoding="utf-8") == before
+
+
+def test_env_auth_scan_passes_a_clean_file(tmp_path) -> None:
+    """Regression: a clean operator-supplied secret must deploy normally."""
+    (tmp_path / ".env.auth").write_text(
+        "OSPREY_AUTH_OIDC_CLIENT_SECRET=cleanidpsecret\n", encoding="utf-8"
+    )
+    web_terminals = {
+        "enabled": True,
+        "auth": {"method": "password"},
+        "users": [{"name": "alice"}],
+    }
+
+    provision._provision_auth_secrets(web_terminals, str(tmp_path))
+
+    assert "cleanidpsecret" in (tmp_path / ".env.auth").read_text(encoding="utf-8")


### PR DESCRIPTION
## What

A secret containing `$` reaches a container corrupted. Compose substitutes `$` sequences inside the *values* it loads from a `.env`, so `secret$abc` arrives as `secret` and `P@$$w0rd` arrives as `P@$w0rd` — while the file on disk still reads correctly. `osprey deploy` now refuses such a stack and names the offending variables.

## Why it is hard to see

The corruption happens between the file and the process. The file is byte-perfect, every test that reads it passes, and the only symptom is a login or token exchange that refuses for no visible reason.

Two forms carry **no warning at all**. `$$` collapses to a single `$`, and `$NAME` where `NAME` is set on the deploy host splices the host's value into the secret. Compose warns only when the interpolated name is unset.

Measured against Docker Compose v2.34, reading the value back out of a running container:

| In the env file | In the container | Warned |
| --- | --- | --- |
| `corr3ct-h0rse$battery` | `corr3ct-h0rse` | yes |
| `P@$$w0rd` | `P@$w0rd` | **no** |
| `secret$HOME` | `secret/Users/<user>` | **no** |
| `abc$1def`, `Summer2026$` | unchanged | n/a |

This affects **both** routes a secret takes. `env_file:` values are substituted, and so are values pulled through `--env-file .env`, which every deploy passes and which backs the `environment: - X=${X}` pattern most services here use. The exposure is therefore wider than the `env_file:` services alone.

## What was exposed

OSPREY-generated values were already safe by construction — base64url hashes joined by `passwords.FIELD_SEP`, `token_urlsafe` signing secrets, alphanumeric minted passwords — and a unit test pinned that for `.env.auth`. Everything a human or a third party chooses was not:

- **OIDC client secret** in `.env.auth`. No OSPREY code writes it: the compose template references the variable by name and the operator appends the IdP-minted value by hand. Nothing could guard it at a write boundary, and the generator-side test cannot see it. The sidecar's startup check tests only for *emptiness*, so a partially truncated secret clears startup and fails later against the IdP.
- **`.env.production`** — every value is a verbatim copy out of the operator's `.env`, including the OLOG facility password, and `ARIEL_DSN`, which carries a Postgres password inline.
- **Project `.env`** — the compose document's variable source on every deploy, and handed to the dispatch worker entire.

Three validators sat on this path and admitted `$` anyway. `_validate_ariel_dsn` and the `ARIEL_DB_PASSWORD` check reject the URI-reserved `@:/?#`; `$` is a sub-delimiter and passed. `_validate_openobserve_password` *requires* a non-alphanumeric character, so `$` was an accepted way to satisfy the policy.

## The change

- `utils.dotenv.compose_unsafe_vars` — the shared check. Returns variable *names*, sorted, never values, so no caller can render a secret into a message.
- `deployment.errors.ComposeInterpolationError` — refuses the deploy, names the variables, explains the fix.
- `service_tokens._validate_var` — applies the `$` rule universally, ahead of the opt-in per-var validators. Per-format constraints stay fail-open as documented.
- `container_lifecycle._ensure_service_tokens` — scans the whole `.env`, before minting. Whole-file because the per-var validators only ever see the deployed services' token vars, while the provider key and the olog password travel in the same file. Before the mint so a refusal leaves no freshly minted tokens that the next build would drop and re-mint.
- `env_production.ensure_env_production` — scans on both paths: the one it generates, and the existing file it returns untouched. The latter matters most, because registry mode is the default and never generates the file at all — CI builds it from masked variables.
- `auth_credentials.raise_if_env_auth_would_be_interpolated` — scans `.env.auth` on disk, the only place the minted and hand-added lines are visible together.

### Two judgement calls worth reviewing

**Reject every `$`, not just the interpolating forms.** `trailing$` and `$1` survive Docker Compose today, so a narrower rule would have fewer false positives. But podman-compose is the documented default for facility deploys and is not guaranteed to agree, and escaping cannot bridge the two: `$$` means a literal `$` to Docker Compose and two characters to a runtime that does not interpolate, so no single file is correct for both. Refusing `$` outright is the only runtime-independent rule, and the one the codebase already designs to. A rejected-but-harmless secret costs a rotation; a missed one is a silent outage.

**The sidecar recreate is deliberately never blocked.** A recreate is always the step that puts an already-applied change to `.env.auth` into force. Refusing there would let `decommission`/`prune` remove a departed user's hash from the file while the running sidecar kept accepting their password — the precise divergence those verbs exist to close, traded for an unrelated secret. The scan runs ahead of each mutation instead. `deploy passwd` checks before it writes; the removal verbs do not check at all, and the next `deploy up` catches anything they leave.

## Docs correction included

The OIDC section of the multi-user guide told operators to put client credentials in the project's `.env`. The sidecar reads credentials solely from `.env.auth`, and the compose template gives it no other env file — so credentials placed as documented would never reach the service. Corrected here because the new warning sits in the same paragraph and would otherwise contradict it.

## Verification

- `tests/deployment/test_compose_env_interpolation.py` pins the guard at all three boundaries, both directions, and asserts no error message echoes a secret. It also pins that the recreate stays unblocked, so the ordering decision above cannot be undone silently.
- A regression test asserts all six of OSPREY's own generators still satisfy the stricter rule — the premise the pre-mint scan placement rests on.
- Confirmed end to end against a real container that every value the guard accepts survives Compose byte-for-byte, with no warnings.

## Not addressed

- **podman-compose is untested** — it is not installed on the development host. Its interpolation may differ, which would change the exposure at facilities. Worth confirming on a deploy host.
- **Registry-mode `.env.production` at build time** is assembled by the facility's CI from masked variables. This change checks the file when a deploy reads it, but the CI job that writes it has no check of its own.
