### PR TITLE
fix(deploy): self-heal Docker Desktop host ports, cut deploy noise, add profile try

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Compatibility is documented in release notes, not encoded in the version string.
   command a deploy runs. Normal runs no longer echo those commands, so a
   deploy reads as a report — ending in the endpoint summary — rather than a
   transcript.
+- `osprey profile try` runs the whole lifecycle as one command: settle the
+  profile (materialized on the first run, reused — with `--set`/`-O` written
+  into it — on every later one), build the project (re-rendered in place on a
+  rerun), and `deploy up`, ending in the endpoint summary. One command with
+  each phase printed in sequence, instead of three commands chained across
+  three directories. `--dev` and `-d` pass through to the deploy.
 - Profiles carry artifacts into a build through **convention directories** —
   `rules/`, `skills/`, `agents/`, `commands/`, `output-styles/`, `hooks/`,
   `web-terminal-context/`, `mcp_servers/`, `services/`, and `project/` for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Added
 
+- `osprey -v` (`--verbose`) shows debug output, including every container
+  command a deploy runs. Normal runs no longer echo those commands, so a
+  deploy reads as a report — ending in the endpoint summary — rather than a
+  transcript.
 - Profiles carry artifacts into a build through **convention directories** —
   `rules/`, `skills/`, `agents/`, `commands/`, `output-styles/`, `hooks/`,
   `web-terminal-context/`, `mcp_servers/`, `services/`, and `project/` for
@@ -266,6 +270,22 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- On Docker Desktop (macOS/Windows), `osprey deploy up` now repairs a web
+  stack that is fully healthy yet unreachable from the browser. Docker
+  Desktop forwards a host-network port only if it watched the container open
+  it, so a container that restarted while Docker Desktop itself was starting
+  stays invisible from the host — and re-running `deploy up` could never fix
+  it, because nothing in the container's definition changed. The post-deploy
+  reachability probe now restarts the web stack once and re-checks before
+  pointing at the host-networking setting.
+- A deploy is quieter about things that were never wrong: no more
+  orphan-container warnings for its own sibling stack (two compose
+  invocations share one project by design), no more garbled progress
+  rendering on long service names (docker runs use `--progress plain`), and
+  no more platform-mismatch warning for the virtual accelerator on Apple
+  Silicon — that image is amd64 by design (its Channel Access server has no
+  arm64 wheels), and the compose service now declares it via
+  `platform: linux/amd64`, overridable with `OSPREY_VA_PLATFORM`.
 - Importing the control-system connectors no longer drags in pandas. The
   connector factory imported the archiver base eagerly for a type annotation,
   so anything that wanted only `osprey.connectors.control_system` had to

--- a/src/osprey/cli/main.py
+++ b/src/osprey/cli/main.py
@@ -123,8 +123,14 @@ class LazyGroup(click.Group):
 
 @click.group(cls=LazyGroup, invoke_without_command=True)
 @click.version_option(version=__version__, prog_name="osprey")
+@click.option(
+    "-v",
+    "--verbose",
+    is_flag=True,
+    help="Show debug output, including every container command run.",
+)
 @click.pass_context
-def cli(ctx):
+def cli(ctx, verbose):
     """Osprey Framework CLI - Capability-Based Agentic Framework.
 
     A unified command-line interface for creating, deploying, and interacting
@@ -140,12 +146,15 @@ def cli(ctx):
                                       Create new project from a bundled preset
       osprey config                   Manage configuration (show, export, set)
       osprey deploy up                Start services
+      osprey -v deploy up             Same, with every command echoed
       osprey claude regen             Regenerate Claude Code artifacts
       osprey web                      Launch web terminal
       osprey theme-lab                Build and preview themes in the browser
       osprey health                   Check system health
       osprey channel-finder           Interactive channel search
     """
+    import logging
+
     from osprey.utils.config import load_project_dotenv
     from osprey.utils.logger import configure_logging
 
@@ -160,7 +169,12 @@ def cli(ctx):
     # Likewise a process entry point for logging: nothing else configures it,
     # and importing the framework deliberately does not. Records go to stderr,
     # so `--json` subcommand output on stdout stays machine-readable.
-    configure_logging()
+    #
+    # `-v` is the escape hatch for everything demoted to DEBUG so that a normal
+    # run reads as a report rather than a transcript — most visibly the
+    # container commands the deploy path shells out to, which are what someone
+    # needs when reproducing a deploy step by hand.
+    configure_logging(logging.DEBUG if verbose else logging.INFO)
 
     initialize_theme_from_config()
 

--- a/src/osprey/cli/profile_cmd.py
+++ b/src/osprey/cli/profile_cmd.py
@@ -14,6 +14,7 @@ Usage:
     osprey profile presets
     osprey profile validate my-facility/profile/
     osprey profile new my-facility --preset control-assistant
+    osprey profile try my-facility --preset control-assistant --dev -d
 """
 
 from __future__ import annotations
@@ -296,6 +297,130 @@ def new(
     click.echo(f"  3. Edit {profile_rel}/profile.yml and the files under {profile_rel}/data/")
     click.echo(
         f"  4. Build a project from it: osprey build <PROJECT_NAME> {profile_rel}/profile.yml"
+    )
+
+
+@profile.command(name="try")
+@click.argument("project_name")
+@click.argument(
+    "profile_path",
+    required=False,
+    default=None,
+    type=click.Path(exists=False, dir_okay=False),
+)
+@click.option(
+    "--preset",
+    default=None,
+    metavar="NAME",
+    help="Bundled preset to try (see `osprey profile presets`). Materializes "
+    "<PROJECT_NAME>-profile/ the first time; reused as-is afterwards.",
+)
+@click.option(
+    "--override",
+    "-O",
+    "overrides",
+    multiple=True,
+    type=click.Path(exists=False, dir_okay=False, path_type=Path),
+    help="Layer a YAML file on top of the profile before building (repeatable).",
+)
+@click.option(
+    "--set",
+    "set_pairs",
+    multiple=True,
+    metavar="KEY.PATH=VALUE",
+    help="Inline scalar/list override written into the profile before the "
+    "build reads it (repeatable). RHS parsed as YAML.",
+)
+@click.option(
+    "--output-dir",
+    "-o",
+    type=click.Path(),
+    default=".",
+    help="Directory the profile and project land in (default: current directory).",
+)
+@click.option(
+    "--detached",
+    "-d",
+    is_flag=True,
+    help="Run the deployed services in detached mode.",
+)
+@click.option(
+    "--dev",
+    is_flag=True,
+    help="Development mode: bake the local osprey checkout into the containers "
+    "instead of installing from PyPI.",
+)
+@click.pass_context
+def try_(
+    ctx: click.Context,
+    project_name: str,
+    profile_path: str | None,
+    preset: str | None,
+    overrides: tuple[Path, ...],
+    set_pairs: tuple[str, ...],
+    output_dir: str,
+    detached: bool,
+    dev: bool,
+) -> None:
+    """Materialize, build, and deploy in one command.
+
+    Chains the whole lifecycle — profile, build, deploy up — so trying a
+    preset (or a profile edit) is a single command instead of three runs
+    from three directories. Each phase prints in sequence, ending in the
+    deploy's endpoint summary.
+
+    The profile is settled exactly as `osprey build --preset` settles it:
+    the first run materializes <PROJECT_NAME>-profile/ in the output
+    directory, every later run reuses that directory as it stands, and
+    --set / -O are written into it first. The project is re-rendered in
+    place on a rerun (.env, _agent_data/ and .git are preserved) — rerunning
+    is the point, so no --force is needed.
+
+    PROJECT_NAME: project directory to create or re-render.
+
+    PROFILE_PATH: optional path to an existing profile.yml (mutually
+    exclusive with --preset).
+
+    Examples:
+
+    \b
+      $ osprey profile try my-assistant --preset control-assistant \\
+            --set provider=als-apg --set model=haiku --dev -d
+      $ osprey profile try my-assistant my-profile/profile.yml -d
+    """
+    # Imported at call time, not module top: the deploy chain is heavy and
+    # `osprey --help` must stay off it (the lazy-import budget test in
+    # tests/cli/test_main.py pins this).
+    from . import build_cmd, deploy_cmd
+
+    # Phase separators are one line each on purpose: build and deploy narrate
+    # themselves, and the value added here is only the seam between them.
+    click.echo(f"━━ 1/2 build: {project_name} ━━")
+    # force=True is the re-render-in-place behaviour documented above; it
+    # never touches the profile, which is reused (and --set/-O written into
+    # it) by the build itself.
+    ctx.invoke(
+        build_cmd.build,
+        project_name=project_name,
+        profile=profile_path,
+        preset=preset,
+        overrides=overrides,
+        set_pairs=set_pairs,
+        output_dir=output_dir,
+        force=True,
+    )
+
+    project_dir = Path(output_dir).resolve() / project_name
+    click.echo(f"\n━━ 2/2 deploy up: {project_dir.name} ━━")
+    # `deploy up`, the subcommand — not the `deploy` group, which takes no
+    # arguments of its own and would run nothing.
+    ctx.invoke(
+        deploy_cmd.up,
+        project=str(project_dir),
+        config="config.yml",
+        detached=detached,
+        dev=dev,
+        expose=False,
     )
 
 

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -26,6 +26,7 @@ from osprey.deployment.runtime_helper import (
     get_runtime_command,
     runtime_env,
     verify_runtime_is_running,
+    with_plain_progress,
 )
 from osprey.deployment.service_tokens import (
     _VAR_GENERATORS,  # noqa: F401  (re-exported for tests)
@@ -1556,7 +1557,7 @@ def _build_project_image(config: dict, dev_mode: bool, env: dict) -> None:
     try:
         cmd = _project_image_build_cmd(config, runtime, project_root, dev_mode and wheel_staged)
         logger.key_info("Building dispatch worker project image %s:", project_image)
-        logger.info("Running command:\n    %s", " ".join(cmd))
+        logger.debug("Running command:\n    %s", " ".join(cmd))
         subprocess.run(cmd, env=env, check=True)
     finally:
         # Remove BOTH staged artifacts (wheel + requirements manifest) so
@@ -1795,7 +1796,7 @@ def deploy_up(config_path, detached=False, dev_mode=False, expose_network=False)
     # "services" project whose up/down cross-adopts sibling stacks.
     run_env = runtime_env(config, env)
 
-    base_cmd = get_runtime_command(config)
+    base_cmd = with_plain_progress(get_runtime_command(config))
     for compose_file in compose_files:
         base_cmd.extend(("-f", compose_file))
     base_cmd.extend(_env_file_args())
@@ -1810,7 +1811,7 @@ def deploy_up(config_path, detached=False, dev_mode=False, expose_network=False)
     # zero-churn. Volumes are never touched — destroying state stays the job
     # of clean/rebuild. Best-effort: if it fails, `up` surfaces the real error.
     rm_cmd = base_cmd + ["rm", "-f"]
-    logger.info(f"Running command:\n    {' '.join(rm_cmd)}")
+    logger.debug(f"Running command:\n    {' '.join(rm_cmd)}")
     subprocess.run(rm_cmd, env=run_env)
 
     if dev_mode:
@@ -1823,7 +1824,7 @@ def deploy_up(config_path, detached=False, dev_mode=False, expose_network=False)
         # plain `up` so compose's implicit build-on-up still covers a build-only
         # service that has no published upstream tag to pull.
         build_cmd = base_cmd + ["build"]
-        logger.info(f"Running command:\n    {' '.join(build_cmd)}")
+        logger.debug(f"Running command:\n    {' '.join(build_cmd)}")
         subprocess.run(build_cmd, env=run_env, check=True)
 
     # --remove-orphans reconciles away containers whose service left the
@@ -1838,7 +1839,7 @@ def deploy_up(config_path, detached=False, dev_mode=False, expose_network=False)
     if detached:
         cmd.append("-d")
 
-    logger.info(f"Running command:\n    {' '.join(cmd)}")
+    logger.debug(f"Running command:\n    {' '.join(cmd)}")
     if detached:
         subprocess.run(cmd, env=run_env, check=True)
         log_endpoint_summary(config, compose_files)
@@ -1889,7 +1890,7 @@ def deploy_down(config_path, dev_mode=False):
         for f in compose_files:
             logger.info(f"  - {f}")
 
-    cmd = get_runtime_command(config)
+    cmd = with_plain_progress(get_runtime_command(config))
     for compose_file in compose_files:
         cmd.extend(("-f", compose_file))
 
@@ -1900,7 +1901,7 @@ def deploy_down(config_path, dev_mode=False):
 
     cmd.append("down")
 
-    logger.info(f"Running command:\n    {' '.join(cmd)}")
+    logger.debug(f"Running command:\n    {' '.join(cmd)}")
     # execvpe (not execvp) so the COMPOSE_PROJECT_NAME pin reaches compose:
     # `down` must target the same project `up` created, or it either misses this
     # deploy's containers or (unpinned) tears down the shared "services" project.
@@ -1938,12 +1939,12 @@ def deploy_restart(config_path, detached=False, expose_network=False):
     # so generating them would change nothing until the next `deploy up`.
     _ensure_bluesky_control_plane_keys(config)
 
-    cmd = get_runtime_command(config)
+    cmd = with_plain_progress(get_runtime_command(config))
     for compose_file in compose_files:
         cmd.extend(("-f", compose_file))
     cmd.extend(["--env-file", ".env", "restart"])
 
-    logger.info(f"Running command:\n    {' '.join(cmd)}")
+    logger.debug(f"Running command:\n    {' '.join(cmd)}")
     subprocess.run(cmd, env=runtime_env(config, os.environ.copy()))
 
     # If detached mode requested, detach after restart

--- a/src/osprey/deployment/runtime_helper.py
+++ b/src/osprey/deployment/runtime_helper.py
@@ -133,6 +133,20 @@ def runtime_env(config: dict | None, base_env: dict[str, str] | None = None) -> 
     command should build its env through this function rather than passing
     ``os.environ`` (or a copy of it) directly.
 
+    Also sets ``COMPOSE_IGNORE_ORPHANS``. That one is structural, not
+    cosmetic: a web-terminal deploy runs TWO compose invocations against the
+    single project this function pins — the backend services under
+    ``build/services/*.yml`` and the web stack under
+    ``docker-compose.web.yml`` — so each one necessarily sees the other's
+    containers as orphans of the shared project, and says so at length, twice
+    per deploy. The warning's own suggested remedy (``--remove-orphans``) is
+    the one thing that must never be run here: it would delete the other
+    stack, which is exactly why both call sites in
+    :mod:`~osprey.deployment.web_terminals.provision` forbid the flag. A
+    warning whose only advertised fix is destructive, in a situation the
+    design guarantees, is pure noise — so it is turned off at the source
+    rather than left for every operator to learn to ignore.
+
     Args:
         config: Configuration dictionary used to resolve the project name.
             Falsy values (``None``, ``{}``) resolve the same as an empty dict,
@@ -141,13 +155,60 @@ def runtime_env(config: dict | None, base_env: dict[str, str] | None = None) -> 
             ``os.environ``. Never mutated — a fresh copy is always returned.
 
     Returns:
-        A new environment dict with ``COMPOSE_PROJECT_NAME`` set.
+        A new environment dict with ``COMPOSE_PROJECT_NAME`` and
+        ``COMPOSE_IGNORE_ORPHANS`` set.
     """
     from osprey.deployment.compose_generator import resolve_project_name
 
     env = dict(base_env if base_env is not None else os.environ)
     env["COMPOSE_PROJECT_NAME"] = resolve_project_name(config or {})
+    env["COMPOSE_IGNORE_ORPHANS"] = "1"
     return env
+
+
+def with_plain_progress(cmd: list[str]) -> list[str]:
+    """Add ``--progress plain`` to a docker compose argv so it cannot garble.
+
+    Takes an already-resolved compose argv rather than resolving one itself,
+    deliberately: every call site reaches its runtime through the
+    ``get_runtime_command`` name bound in *its own* module, which is the seam
+    the deploy tests monkeypatch. A helper that called ``get_runtime_command``
+    internally would resolve this module's binding instead, walk straight past
+    that patch, and run live runtime detection inside unit tests.
+
+    Compose's default (``auto``) selects a TTY renderer on an interactive
+    terminal, which repaints each frame by moving the cursor up N lines and
+    rewriting them — without erasing to end of line. Long project and service names
+    (``my-control-assistant-bluesky-queueserver`` and friends) wrap on a
+    normal-width terminal, the renderer's N is then wrong by the number of
+    wrapped lines, and successive frames overprint each other into
+    unreadable fragments. ``plain`` is append-only, so it has no frame
+    arithmetic to get wrong.
+
+    Docker only, deliberately. ``--progress`` is a docker compose v2 flag;
+    ``podman compose`` delegates to whichever provider the host has, and a
+    provider that rejects an unknown flag would turn a cosmetic improvement
+    into a failed deploy. Podman hosts keep today's behaviour, and lose
+    little: ``auto`` already resolves to ``plain`` whenever stdout is not a
+    terminal, which covers CI and systemd — the places a production deploy's
+    output is actually captured.
+
+    ``--progress`` is a global flag, valid ahead of every compose subcommand,
+    so callers append their ``-f``/``--env-file`` arguments and the subcommand
+    afterwards exactly as before.
+
+    Args:
+        cmd: A compose argv base, e.g. ``["docker", "compose"]``, as returned
+            by :func:`get_runtime_command`. Extended in place and returned, so
+            ``with_plain_progress(get_runtime_command(config))`` reads as one
+            expression at the call site.
+
+    Returns:
+        The same list, with the flag appended when the runtime is docker.
+    """
+    if cmd and cmd[0] == "docker":
+        cmd.extend(("--progress", "plain"))
+    return cmd
 
 
 def verify_runtime_is_running(config: Mapping[str, Any] | None = None) -> tuple[bool, str]:

--- a/src/osprey/deployment/runtime_helper.py
+++ b/src/osprey/deployment/runtime_helper.py
@@ -120,7 +120,12 @@ def reset_runtime_cache() -> None:
     _runtime_cmd_cache.clear()
 
 
-def runtime_env(config: dict | None, base_env: dict[str, str] | None = None) -> dict[str, str]:
+def runtime_env(
+    config: dict | None,
+    base_env: dict[str, str] | None = None,
+    *,
+    ignore_orphans: bool = False,
+) -> dict[str, str]:
     """Build the environment for a runtime (docker/podman compose) invocation.
 
     Pins ``COMPOSE_PROJECT_NAME`` to :func:`compose_generator.resolve_project_name`
@@ -133,19 +138,27 @@ def runtime_env(config: dict | None, base_env: dict[str, str] | None = None) -> 
     command should build its env through this function rather than passing
     ``os.environ`` (or a copy of it) directly.
 
-    Also sets ``COMPOSE_IGNORE_ORPHANS``. That one is structural, not
+    ``ignore_orphans=True`` additionally sets ``COMPOSE_IGNORE_ORPHANS``, and
+    is for the web-terminal call sites only. There it is structural, not
     cosmetic: a web-terminal deploy runs TWO compose invocations against the
     single project this function pins — the backend services under
     ``build/services/*.yml`` and the web stack under
     ``docker-compose.web.yml`` — so each one necessarily sees the other's
     containers as orphans of the shared project, and says so at length, twice
     per deploy. The warning's own suggested remedy (``--remove-orphans``) is
-    the one thing that must never be run here: it would delete the other
+    the one thing that must never be run there: it would delete the other
     stack, which is exactly why both call sites in
     :mod:`~osprey.deployment.web_terminals.provision` forbid the flag. A
     warning whose only advertised fix is destructive, in a situation the
     design guarantees, is pure noise — so it is turned off at the source
     rather than left for every operator to learn to ignore.
+
+    It must stay opt-in because the single-stack paths are the mirror image:
+    plain ``deploy up`` reconciles with ``up --remove-orphans`` and ``clean``
+    tears down with ``down --remove-orphans``, and docker compose hard-errors
+    on the combination ("cannot combine COMPOSE_IGNORE_ORPHANS and
+    --remove-orphans") rather than letting one win. A default-on env var
+    would turn every one of those deploys into that error.
 
     Args:
         config: Configuration dictionary used to resolve the project name.
@@ -153,16 +166,20 @@ def runtime_env(config: dict | None, base_env: dict[str, str] | None = None) -> 
             i.e. the ``"unnamed-project"`` fallback.
         base_env: Environment to layer the pin onto. Defaults to
             ``os.environ``. Never mutated — a fresh copy is always returned.
+        ignore_orphans: Set ``COMPOSE_IGNORE_ORPHANS=1`` for a compose
+            invocation that shares its project with another one by design.
+            Never combine with a ``--remove-orphans`` argv.
 
     Returns:
-        A new environment dict with ``COMPOSE_PROJECT_NAME`` and
-        ``COMPOSE_IGNORE_ORPHANS`` set.
+        A new environment dict with ``COMPOSE_PROJECT_NAME`` set (and
+        ``COMPOSE_IGNORE_ORPHANS`` when requested).
     """
     from osprey.deployment.compose_generator import resolve_project_name
 
     env = dict(base_env if base_env is not None else os.environ)
     env["COMPOSE_PROJECT_NAME"] = resolve_project_name(config or {})
-    env["COMPOSE_IGNORE_ORPHANS"] = "1"
+    if ignore_orphans:
+        env["COMPOSE_IGNORE_ORPHANS"] = "1"
     return env
 
 

--- a/src/osprey/deployment/web_terminals/lifecycle.py
+++ b/src/osprey/deployment/web_terminals/lifecycle.py
@@ -198,7 +198,7 @@ def decommission_user(
     write_web_terminal_artifacts(updated_config)
 
     runtime = get_runtime_command(config)[0]
-    env = runtime_env(config)
+    env = runtime_env(config, ignore_orphans=True)
     facility_prefix = as_dict(config.get("facility")).get("prefix") or ""
     remove_container(runtime, web_container_name(facility_prefix, user), env=env)
 
@@ -280,7 +280,7 @@ def prune_users(
     roster_names = {entry["name"] for entry in normalize_users(web_terminals.get("users"))}
 
     runtime = get_runtime_command(config)[0]
-    env = runtime_env(config)
+    env = runtime_env(config, ignore_orphans=True)
     facility_prefix = as_dict(config.get("facility")).get("prefix") or ""
     project = resolve_project_name(config)
 
@@ -426,7 +426,7 @@ def nuke_stack(config_path: str | Path, *, assume_yes: bool = False) -> None:
 
     runtime_cmd = get_runtime_command(config)
     runtime = runtime_cmd[0]
-    env = runtime_env(config)
+    env = runtime_env(config, ignore_orphans=True)
     project = resolve_project_name(config)
     facility_prefix = as_dict(config.get("facility")).get("prefix") or ""
 
@@ -643,7 +643,7 @@ def _reconcile_auth_after_user_removal(
     # nginx serving the removed user's route until the next deploy. Advisory
     # and never raises (it warns).
     if rerendered:
-        reload_nginx_config(web_stack_compose_cmd(config), runtime_env(config))
+        reload_nginx_config(web_stack_compose_cmd(config), runtime_env(config, ignore_orphans=True))
 
     recreate_error: OSError | subprocess.CalledProcessError | None = None
     # The recreate runs on a PARTIAL purge (see above) but not on one that

--- a/src/osprey/deployment/web_terminals/persona_images.py
+++ b/src/osprey/deployment/web_terminals/persona_images.py
@@ -584,7 +584,7 @@ def auto_render_missing_personas(
         ]
         logger.key_info("Auto-rendering persona %r project at %s", persona_name, project_path)
         logger.info("  ↳ from %s", profile_path)
-        logger.info("Running command:\n    %s", " ".join(cmd))
+        logger.debug("Running command:\n    %s", " ".join(cmd))
         subprocess.run(cmd, env=env, check=True)
 
 
@@ -692,7 +692,7 @@ def build_persona_images(
                 dev_mode and wheel_staged,
             )
             logger.key_info("Building persona image %s-%s:local:", project, persona_name)
-            logger.info("Running command:\n    %s", " ".join(cmd))
+            logger.debug("Running command:\n    %s", " ".join(cmd))
             subprocess.run(cmd, env=env, check=True)
         finally:
             # Remove BOTH staged artifacts (wheel + requirements manifest) so

--- a/src/osprey/deployment/web_terminals/postup_hooks.py
+++ b/src/osprey/deployment/web_terminals/postup_hooks.py
@@ -167,7 +167,7 @@ def reload_nginx_config(web_cmd: list[str], run_env: dict[str, str]) -> None:
     warns rather than failing a deploy that did reconcile.
     """
     reload_cmd = web_cmd + ["exec", "-T", "nginx", "nginx", "-s", "reload"]
-    logger.info(f"Running command:\n    {' '.join(reload_cmd)}")
+    logger.debug(f"Running command:\n    {' '.join(reload_cmd)}")
     result = subprocess.run(reload_cmd, env=run_env, capture_output=True, text=True)
     if result.returncode != 0:
         detail = (result.stderr or result.stdout or "").strip()
@@ -177,46 +177,121 @@ def reload_nginx_config(web_cmd: list[str], run_env: dict[str, str]) -> None:
         )
 
 
-def warn_if_web_stack_unreachable(config: dict, attempts: int = 5, delay: float = 2.0) -> None:
+def _host_port_answers(url: str, attempts: int, delay: float) -> bool:
+    """Poll ``url`` from this host; ``True`` as soon as anything answers.
+
+    Any HTTP status counts — a 502 from nginx still proves the host can reach
+    the listening socket, which is the only thing being tested here.
+    """
+    for attempt in range(attempts):
+        try:
+            with urllib.request.urlopen(url, timeout=3):
+                return True
+        except urllib.error.HTTPError:
+            return True  # any HTTP response at all proves host-side reachability
+        except OSError:
+            if attempt + 1 < attempts:
+                time.sleep(delay)
+    return False
+
+
+def warn_if_web_stack_unreachable(
+    config: dict,
+    attempts: int = 5,
+    delay: float = 2.0,
+    *,
+    web_cmd: list[str] | None = None,
+    run_env: dict[str, str] | None = None,
+) -> None:
     """Advisory post-up probe: is nginx actually reachable from THIS host?
 
     The whole web tier runs ``network_mode: host`` with loopback-only
     upstreams (the security baseline). On a Linux host that binds
     ``nginx_port`` on the machine itself — but on Docker Desktop
-    (macOS/Windows) "host" is the hypervisor's Linux VM, and unless Docker
-    Desktop's opt-in host-networking setting is enabled, nothing ever
-    listens on the real host: ``compose up`` succeeds, every healthcheck
-    passes (they probe from *inside* the VM), and the landing page is
-    unreachable in any browser. This probe is the only signal that
-    distinguishes that state from a working deploy.
+    (macOS/Windows) "host" is the hypervisor's Linux VM, and the port reaches
+    the real machine only through Docker Desktop's host-network forwarder:
+    ``compose up`` succeeds, every healthcheck passes (they probe from
+    *inside* the VM), and the landing page is unreachable in any browser.
+    This probe is the only signal that distinguishes that state from a
+    working deploy.
+
+    SELF-HEAL, and why it comes before the settings hint. That forwarder
+    registers a VM-side socket by *watching* for the listen event. A
+    container that came back up under ``restart: unless-stopped`` while
+    Docker Desktop was still starting — after an update, a reboot, or the
+    Apply & Restart that enabling the setting itself performs — opens its
+    socket unobserved and stays invisible to the host indefinitely. Nothing
+    about its compose definition changed, so every subsequent ``up -d``
+    leaves it ``Running``, reconciles nothing, and reports the same failure
+    forever. Bouncing the container re-opens the socket while the forwarder
+    is watching, which fixes it. Because that state is indistinguishable
+    from "the setting is off" without a second experiment, and because the
+    restart is cheap and repairs the far more common cause, this tries the
+    restart first and only blames the setting if the port is *still* dark
+    afterwards. Gated to Docker Desktop: on Linux the port is bound on the
+    machine directly, so an unreachable one means something else entirely
+    and a blind restart would be noise.
 
     Advisory like :func:`run_verify_script`: the containers themselves are
     healthy, so an unreachable host port warns loudly (with the Docker
     Desktop remedy where that's the likely cause) but never fails a deploy
     that did, in fact, reconcile.
+
+    :param web_cmd: The web stack's compose argv (from
+        :func:`provision.web_stack_compose_cmd`), used for the self-heal
+        restart. ``None`` — the lifecycle callers that never had one — keeps
+        the warn-only behaviour.
+    :param run_env: Environment for that restart, the same
+        ``COMPOSE_PROJECT_NAME``-pinned env the caller's other compose calls
+        use.
     """
     web_terminals = (config.get("modules") or {}).get("web_terminals") or {}
     nginx_port = web_terminals.get("nginx_port")
     if not isinstance(nginx_port, int):
         return
     url = f"http://127.0.0.1:{nginx_port}/"
-    for attempt in range(attempts):
+    if _host_port_answers(url, attempts, delay):
+        return
+
+    on_docker_desktop = (
+        sys.platform in ("darwin", "win32") and get_runtime_command(config)[0] == "docker"
+    )
+
+    if on_docker_desktop and web_cmd:
+        restart_cmd = web_cmd + ["restart"]
+        logger.key_info(
+            "%s is not reachable from this host yet. On Docker Desktop this is "
+            "usually a stale host-network port registration; bouncing the web "
+            "stack to re-register it:\n    %s",
+            url,
+            " ".join(restart_cmd),
+        )
         try:
-            with urllib.request.urlopen(url, timeout=3):
+            # Output is inherited, not captured, like every other compose call
+            # on this path: a restart of the whole web tier is visible work and
+            # the operator should watch it happen.
+            subprocess.run(restart_cmd, env=run_env)
+        except OSError as exc:
+            logger.warning("Could not restart the web stack: %s", exc)
+        else:
+            if _host_port_answers(url, attempts, delay):
+                logger.key_info("%s is reachable now.", url)
                 return
-        except urllib.error.HTTPError:
-            return  # any HTTP response at all proves host-side reachability
-        except OSError:
-            if attempt + 1 < attempts:
-                time.sleep(delay)
+
     hint = ""
-    if sys.platform in ("darwin", "win32") and get_runtime_command(config)[0] == "docker":
+    if on_docker_desktop:
         hint = (
             " On Docker Desktop the web stack's network_mode: host binds "
-            "inside the Docker Linux VM, not on this machine, unless host "
-            "networking is enabled: Docker Desktop -> Settings -> Resources "
-            "-> Network -> 'Enable host networking', then Apply & Restart "
-            "and re-run `osprey deploy up`."
+            "inside the Docker Linux VM and reaches this machine only through "
+            "Docker Desktop's host-network forwarder"
+            + (
+                ", and restarting the stack did not re-register it. Check that host "
+                "networking is enabled"
+                if web_cmd
+                else ", which is off unless host networking is enabled"
+            )
+            + ": Docker Desktop -> Settings -> Resources -> Network -> 'Enable "
+            "host networking', then Apply & Restart and re-run `osprey deploy up`."
         )
     logger.warning(
         f"Web-terminal containers are up, but {url} is not reachable from "

--- a/src/osprey/deployment/web_terminals/provision.py
+++ b/src/osprey/deployment/web_terminals/provision.py
@@ -31,6 +31,7 @@ from osprey.deployment.runtime_helper import (
     get_image_id,
     get_runtime_command,
     runtime_env,
+    with_plain_progress,
 )
 from osprey.deployment.web_terminals.artifacts import write_web_terminal_artifacts
 from osprey.deployment.web_terminals.auth_credentials import (
@@ -464,7 +465,7 @@ def build_auth_sidecar_image(config: dict, dev_mode: bool, env: dict[str, str]) 
     cmd.append(str(context_dir))
 
     logger.key_info("Building auth sidecar image %s:", tag)
-    logger.info("Running command:\n    %s", " ".join(cmd))
+    logger.debug("Running command:\n    %s", " ".join(cmd))
     subprocess.run(cmd, env=env, check=True)
 
 
@@ -491,7 +492,7 @@ def web_stack_compose_cmd(config: dict, env_file_args: list[str] | None = None) 
         from osprey.deployment.container_lifecycle import _env_file_args
 
         env_file_args = _env_file_args()
-    cmd = get_runtime_command(config)
+    cmd = with_plain_progress(get_runtime_command(config))
     cmd.extend(("-f", "docker-compose.web.yml"))
     cmd.extend(env_file_args)
     return cmd
@@ -606,7 +607,7 @@ def _force_recreate_services(
     :func:`force_recreate_auth_sidecar`) exist to avoid.
     """
     cmd = web_cmd + ["up", "-d", "--force-recreate", *services]
-    logger.info(f"Running command:\n    {' '.join(cmd)}")
+    logger.debug(f"Running command:\n    {' '.join(cmd)}")
     subprocess.run(cmd, env=run_env, check=True)
 
 
@@ -795,7 +796,7 @@ def deploy_up_web_terminals(
     # Skipped when no real service is deployed -- see docstring for why
     # `up` on the network-only top-level file alone would fail outright.
     if config.get("deployed_services"):
-        services_base = get_runtime_command(config)
+        services_base = with_plain_progress(get_runtime_command(config))
         for compose_file in compose_files:
             services_base.extend(("-f", compose_file))
         services_base.extend(env_file_args)
@@ -809,7 +810,7 @@ def deploy_up_web_terminals(
         # COMPOSE_PROJECT_NAME, so orphan-removal in either would destroy the
         # OTHER stack's containers as "orphans" of the shared project.
         services_rm = services_base + ["rm", "-f"]
-        logger.info(f"Running command:\n    {' '.join(services_rm)}")
+        logger.debug(f"Running command:\n    {' '.join(services_rm)}")
         subprocess.run(services_rm, env=run_env)
         if dev_mode:
             # Mirrors the plain non-web path's dev-mode build (see deploy_up):
@@ -818,13 +819,13 @@ def deploy_up_web_terminals(
             # then `up --no-build`, to dodge the `up --build` containerd
             # image-store race.
             services_build = services_base + ["build"]
-            logger.info(f"Running command:\n    {' '.join(services_build)}")
+            logger.debug(f"Running command:\n    {' '.join(services_build)}")
             subprocess.run(services_build, env=run_env, check=True)
         services_cmd = services_base + ["up"]
         if dev_mode:
             services_cmd.append("--no-build")
         services_cmd.append("-d")
-        logger.info(f"Running command:\n    {' '.join(services_cmd)}")
+        logger.debug(f"Running command:\n    {' '.join(services_cmd)}")
         subprocess.run(services_cmd, env=run_env, check=True)
 
     # ---- web-terminal stack (own compose project directory: project root) --
@@ -833,7 +834,7 @@ def deploy_up_web_terminals(
     # Same stale-container preflight as the services stack above (and same
     # no-`--remove-orphans` constraint — see that comment).
     web_rm = web_cmd + ["rm", "-f"]
-    logger.info(f"Running command:\n    {' '.join(web_rm)}")
+    logger.debug(f"Running command:\n    {' '.join(web_rm)}")
     subprocess.run(web_rm, env=run_env)
 
     if not local_mode:
@@ -842,11 +843,11 @@ def deploy_up_web_terminals(
         # MODE BRANCH section. This is the load-bearing guard the task exists
         # to add; never run `pull` unconditionally here again.
         pull_cmd = web_cmd + ["pull"]
-        logger.info(f"Running command:\n    {' '.join(pull_cmd)}")
+        logger.debug(f"Running command:\n    {' '.join(pull_cmd)}")
         subprocess.run(pull_cmd, env=run_env, check=True)
 
     up_cmd = web_cmd + ["up", "-d"]
-    logger.info(f"Running command:\n    {' '.join(up_cmd)}")
+    logger.debug(f"Running command:\n    {' '.join(up_cmd)}")
     subprocess.run(up_cmd, env=run_env, check=True)
 
     # Post-`up` recreate for podman's same-tag image drift. A changed
@@ -873,12 +874,15 @@ def deploy_up_web_terminals(
     # advisory only and never raises from here. The host-reachability probe
     # runs last and is likewise advisory (see warn_if_web_stack_unreachable:
     # on Docker Desktop a fully-healthy stack can still be unreachable from
-    # the host).
+    # the host). It gets this invocation's `web_cmd`/`run_env` so it can bounce
+    # the stack to re-register a stale Docker Desktop port forward -- the one
+    # failure mode `up -d` structurally cannot fix on its own, because the
+    # containers' definitions are unchanged and compose reconciles nothing.
     # -----------------------------------------------------------------------
     enable_linger(config, run_env)
     seed_user_containers(config, env=run_env)
     run_verify_script(project_root, run_env)
-    warn_if_web_stack_unreachable(config)
+    warn_if_web_stack_unreachable(config, web_cmd=web_cmd, run_env=run_env)
 
 
 def _reconcile_web_stack_recreates(
@@ -996,7 +1000,7 @@ def deploy_down_web_terminals(
         return
     down_cmd = web_stack_compose_cmd(config, env_file_args)
     down_cmd.append("down")
-    logger.info(f"Running command:\n    {' '.join(down_cmd)}")
+    logger.debug(f"Running command:\n    {' '.join(down_cmd)}")
     result = subprocess.run(
         down_cmd, env=runtime_env(config, env), capture_output=True, text=True, check=False
     )

--- a/src/osprey/deployment/web_terminals/provision.py
+++ b/src/osprey/deployment/web_terminals/provision.py
@@ -591,7 +591,7 @@ def force_recreate_auth_sidecar(
     # see auth_credentials.raise_if_env_auth_would_be_interpolated.
     _force_recreate_services(
         web_stack_compose_cmd(config, env_file_args),
-        runtime_env(config, env if env is not None else dict(os.environ)),
+        runtime_env(config, env if env is not None else dict(os.environ), ignore_orphans=True),
         [AUTH_SERVICE_NAME],
     )
 
@@ -790,7 +790,7 @@ def deploy_up_web_terminals(
         # Registry mode has no auto-render; the same before-compose rule holds.
         ensure_env_production(config, project_root)
 
-    run_env = runtime_env(config, env)
+    run_env = runtime_env(config, env, ignore_orphans=True)
 
     # ---- backend services (own compose project directory: build/services/) --
     # Skipped when no real service is deployed -- see docstring for why
@@ -1002,7 +1002,11 @@ def deploy_down_web_terminals(
     down_cmd.append("down")
     logger.debug(f"Running command:\n    {' '.join(down_cmd)}")
     result = subprocess.run(
-        down_cmd, env=runtime_env(config, env), capture_output=True, text=True, check=False
+        down_cmd,
+        env=runtime_env(config, env, ignore_orphans=True),
+        capture_output=True,
+        text=True,
+        check=False,
     )
     if result.returncode != 0:
         logger.warning(

--- a/src/osprey/deployment/web_terminals/seeding.py
+++ b/src/osprey/deployment/web_terminals/seeding.py
@@ -198,7 +198,7 @@ def seed_user_containers(
         targets = roster
 
     runtime = get_runtime_command(config)[0]
-    run_env = env if env is not None else runtime_env(config)
+    run_env = env if env is not None else runtime_env(config, ignore_orphans=True)
     facility_prefix = as_dict(config.get("facility")).get("prefix") or ""
     registry_cfg = as_dict(config.get("registry"))
     # strict=True: an unresolvable persona reference is a misconfiguration, not a

--- a/src/osprey/templates/services/virtual_accelerator/docker-compose.yml.j2
+++ b/src/osprey/templates/services/virtual_accelerator/docker-compose.yml.j2
@@ -6,17 +6,31 @@
 # Use `osprey deploy up --dev` to bake in your local osprey checkout (incl.
 # unreleased code) via a wheel; otherwise the image installs osprey from PyPI.
 #
-# Native architecture: the service resolves to the host's arch (no platform
-# pin). On arm64 hosts the native deps (accelerator-toolbox and the CA server
-# stack's epicscorelibs/pvxslibs) have no manylinux_aarch64 wheels, so they
-# compile from sdist during the image build — a one-time cost of a couple of
-# minutes, no x86 emulation involved.
+# ARCHITECTURE: linux/amd64, and on Apple Silicon that means emulation.
+#
+# The image is amd64-only by construction — Dockerfile pins
+# `FROM --platform=linux/amd64` and hard-fails any other build arch, because
+# pcaspy (the Channel Access server behind the serving stack) publishes no
+# linux/aarch64 wheel at any interpreter. An arm64 image would build cleanly
+# and then have no CA server at all, so the pin is a correctness guard, not a
+# packaging shortcut. Read that Dockerfile's header before touching it.
+#
+# `platform:` below states that out loud rather than leaving it implicit. It
+# is what the build already produces; declaring it means compose stops warning
+# "the requested image's platform (linux/amd64) does not match the detected
+# host platform (linux/arm64/v8)" on every single `deploy up` from an arm64
+# machine — a warning that read as a defect when it was in fact the design.
+# The cost it names is real and unchanged: on Apple Silicon the virtual
+# accelerator runs under QEMU emulation and is correspondingly slower.
+#
+# OSPREY_VA_PLATFORM overrides it, for the one case the pin would otherwise
+# get wrong: a published multi-arch OSPREY_VA_IMAGE that does have a native
+# arm64 variant worth resolving to (`OSPREY_VA_PLATFORM=linux/arm64`).
 
 services:
   virtual-accelerator:
-    # OSPREY_VA_IMAGE now inherits host-arch resolution too: a single-arch amd64
-    # published image on an arm64 host must supply its own `platform` override (VA-8).
     image: ${OSPREY_VA_IMAGE:-{{ services.virtual_accelerator.image | default(osprey_labels.project_name ~ '-va:local') }}}
+    platform: ${OSPREY_VA_PLATFORM:-linux/amd64}
     build:
       # With multiple `-f` compose files, ALL relative paths (build contexts and
       # bind mounts alike) resolve against the FIRST file's dir — the compose

--- a/tests/cli/test_persona_presets.py
+++ b/tests/cli/test_persona_presets.py
@@ -461,7 +461,7 @@ class TestWebTerminalContextShipped:
 
         monkeypatch.setattr(seeding.subprocess, "run", _fake_run)
         monkeypatch.setattr(seeding, "get_runtime_command", lambda config=None: ["docker"])
-        monkeypatch.setattr(seeding, "runtime_env", lambda config, base_env=None: {})
+        monkeypatch.setattr(seeding, "runtime_env", lambda config, base_env=None, **kw: {})
         monkeypatch.chdir(project_dir)
 
         seeding.seed_user_containers(

--- a/tests/cli/test_profile_cmd.py
+++ b/tests/cli/test_profile_cmd.py
@@ -2,7 +2,8 @@
 
 The group holds the verbs that act on a build profile as editable *source*
 (``presets``, ``validate``, ``new``), as opposed to ``osprey build``, which
-consumes a profile and derives a project from it.
+consumes a profile and derives a project from it — plus ``try``, the one-shot
+that chains profile → build → deploy up into a single command.
 """
 
 from __future__ import annotations
@@ -45,10 +46,10 @@ def test_profile_group_is_registered_on_the_cli() -> None:
     assert group.get_command(None, "profile") is profile
 
 
-def test_profile_help_lists_the_three_subcommands(runner: CliRunner) -> None:
+def test_profile_help_lists_the_four_subcommands(runner: CliRunner) -> None:
     result = runner.invoke(profile, ["--help"])
     assert result.exit_code == 0, result.output
-    for name in ("presets", "validate", "new"):
+    for name in ("presets", "validate", "new", "try"):
         assert name in result.output
 
 
@@ -183,6 +184,117 @@ def test_emit_helper_leaves_nothing_behind_on_an_invalid_override(tmp_path: Path
 
 
 # --------------------------------------------------------------------------
+# try — the one-shot: build (which settles the profile), then deploy up.
+#
+# The chained commands are patched out with plain callables: ctx.invoke on a
+# non-Command passes through exactly the kwargs `try` supplies, so these tests
+# pin the contract between `try` and the commands it chains — everything past
+# that seam is build's and deploy's own test coverage.
+# --------------------------------------------------------------------------
+
+
+def test_try_chains_build_then_deploy_up(runner: CliRunner, monkeypatch, tmp_path) -> None:
+    calls: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        "osprey.cli.build_cmd.build", lambda **kw: calls.append(("build", kw)) and None
+    )
+    monkeypatch.setattr(
+        "osprey.cli.deploy_cmd.up", lambda **kw: calls.append(("deploy", kw)) and None
+    )
+
+    result = runner.invoke(
+        profile,
+        [
+            "try",
+            "my-assistant",
+            "--preset",
+            "control-assistant",
+            "--set",
+            "provider=als-apg",
+            "--set",
+            "model=haiku",
+            "--output-dir",
+            str(tmp_path),
+            "--dev",
+            "-d",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert [name for name, _ in calls] == ["build", "deploy"]
+
+    build_kw = calls[0][1]
+    assert build_kw["project_name"] == "my-assistant"
+    assert build_kw["preset"] == "control-assistant"
+    assert build_kw["set_pairs"] == ("provider=als-apg", "model=haiku")
+    # Rerunnability is the point of a one-shot test loop: the re-render is
+    # forced, and (per build --force) the profile itself is never touched.
+    assert build_kw["force"] is True
+
+    # The `up` SUBCOMMAND, not the `deploy` group -- the group takes no
+    # arguments of its own, so invoking it would run nothing at all.
+    deploy_kw = calls[1][1]
+    assert deploy_kw["project"] == str(tmp_path / "my-assistant")
+    assert deploy_kw["detached"] is True
+    assert deploy_kw["dev"] is True
+    assert deploy_kw["expose"] is False
+
+
+def test_try_accepts_a_profile_path_instead_of_a_preset(
+    runner: CliRunner, monkeypatch, tmp_path
+) -> None:
+    """The positional profile passes through; preset stays None (build enforces XOR)."""
+    calls: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        "osprey.cli.build_cmd.build", lambda **kw: calls.append(("build", kw)) and None
+    )
+    monkeypatch.setattr(
+        "osprey.cli.deploy_cmd.up", lambda **kw: calls.append(("deploy", kw)) and None
+    )
+
+    result = runner.invoke(
+        profile,
+        ["try", "my-assistant", "my-profile/profile.yml", "--output-dir", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    build_kw = calls[0][1]
+    assert build_kw["profile"] == "my-profile/profile.yml"
+    assert build_kw["preset"] is None
+
+
+def test_try_prints_a_separator_before_each_phase(runner: CliRunner, monkeypatch, tmp_path) -> None:
+    """The seam between the chained commands is the one thing try narrates."""
+    monkeypatch.setattr("osprey.cli.build_cmd.build", lambda **kw: None)
+    monkeypatch.setattr("osprey.cli.deploy_cmd.up", lambda **kw: None)
+
+    result = runner.invoke(
+        profile, ["try", "my-assistant", "--preset", "hello-world", "-o", str(tmp_path)]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "1/2 build: my-assistant" in result.output
+    assert "2/2 deploy up: my-assistant" in result.output
+
+
+def test_try_skips_deploy_when_the_build_fails(runner: CliRunner, monkeypatch) -> None:
+    """A build that did not complete leaves nothing worth deploying."""
+    import click as _click
+
+    def _failing_build(**kw):
+        raise _click.ClickException("build failed")
+
+    deployed: list[dict] = []
+    monkeypatch.setattr("osprey.cli.build_cmd.build", _failing_build)
+    monkeypatch.setattr("osprey.cli.deploy_cmd.up", lambda **kw: deployed.append(kw))
+
+    result = runner.invoke(profile, ["try", "my-assistant", "--preset", "hello-world"])
+
+    assert result.exit_code != 0
+    assert deployed == []
+
+
+# --------------------------------------------------------------------------
 # Lazy-import budget
 # --------------------------------------------------------------------------
 
@@ -198,7 +310,10 @@ def test_module_import_stays_lazy() -> None:
         "import sys; import osprey.cli.profile_cmd; "
         "heavy = [m for m in ("
         "'osprey.cli.templates.manager', 'osprey.cli.build_profile', "
-        "'osprey.cli.build_profile_emit') if m in sys.modules]; "
+        "'osprey.cli.build_profile_emit', "
+        # `try` chains into build and deploy; both must stay behind its
+        # function-local import or `osprey --help` pays for the whole chain.
+        "'osprey.cli.build_cmd', 'osprey.cli.deploy_cmd') if m in sys.modules]; "
         "print(','.join(heavy))"
     )
     out = subprocess.run(

--- a/tests/deployment/test_runtime_helper.py
+++ b/tests/deployment/test_runtime_helper.py
@@ -41,6 +41,80 @@ def test_runtime_env_pins_default_project_name_for_falsy_config() -> None:
     assert runtime_env({}, base_env={})["COMPOSE_PROJECT_NAME"] == "unnamed-project"
 
 
+# ---------------------------------------------------------------------------
+# COMPOSE_IGNORE_ORPHANS -- structural, not cosmetic.
+#
+# A web-terminal deploy issues TWO compose invocations against ONE
+# COMPOSE_PROJECT_NAME: the backend services (-f build/services/*.yml) and the
+# web stack (-f docker-compose.web.yml). Each therefore sees the other's
+# containers as orphans of the shared project and prints a warning naming every
+# one of them, twice per deploy. The warning is not actionable here: its
+# suggested remedy, `--remove-orphans`, would delete the OTHER stack, which is
+# exactly why provision.py forbids that flag on both paths.
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_env_suppresses_the_shared_project_orphan_warning() -> None:
+    """The two-invocations-one-project design makes orphans expected, not news."""
+    env = runtime_env({"project_name": "proj-a"}, base_env={})
+    assert env["COMPOSE_IGNORE_ORPHANS"] == "1"
+
+
+def test_runtime_env_never_mutates_the_base_env() -> None:
+    """Both pins land on a copy -- the caller's env is untouched."""
+    base: dict[str, str] = {}
+    runtime_env({"project_name": "proj-a"}, base_env=base)
+    assert base == {}
+
+
+# ---------------------------------------------------------------------------
+# with_plain_progress -- `--progress plain` for docker only.
+#
+# Compose's default `auto` progress picks its TTY renderer on an interactive
+# terminal, which redraws frames with cursor-up and no erase-to-end-of-line.
+# Long project/service names wrap, the renderer's line arithmetic goes wrong,
+# and frames paint over each other into unreadable garbage. `plain` is
+# append-only and cannot garble. Docker only: `--progress` is a docker compose
+# v2 flag, and a podman deploy may resolve `podman compose` to a provider that
+# rejects it -- a hard failure in exchange for cosmetics is a bad trade, and
+# non-interactive runs (CI, systemd) already default to plain anyway.
+#
+# It takes a RESOLVED argv rather than a config on purpose: every deploy call
+# site reaches its runtime through the `get_runtime_command` name bound in its
+# own module, and that binding is the seam the deploy tests monkeypatch. A
+# helper that resolved the runtime itself would bypass those patches and run
+# live runtime detection inside unit tests.
+# ---------------------------------------------------------------------------
+
+
+def test_with_plain_progress_forces_plain_progress_on_docker() -> None:
+    assert runtime_helper.with_plain_progress(["docker", "compose"]) == [
+        "docker",
+        "compose",
+        "--progress",
+        "plain",
+    ]
+
+
+def test_with_plain_progress_leaves_podman_untouched() -> None:
+    assert runtime_helper.with_plain_progress(["podman", "compose"]) == ["podman", "compose"]
+
+
+def test_with_plain_progress_tolerates_an_empty_argv() -> None:
+    """Never index [0] blind -- a runtime stub may hand back an empty list."""
+    assert runtime_helper.with_plain_progress([]) == []
+
+
+def test_with_plain_progress_does_not_resolve_a_runtime_itself(monkeypatch) -> None:
+    """The seam guard: it must never call get_runtime_command on its own."""
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("with_plain_progress must not resolve the runtime")
+
+    monkeypatch.setattr(runtime_helper, "get_runtime_command", _boom)
+    assert runtime_helper.with_plain_progress(["docker", "compose"])[:2] == ["docker", "compose"]
+
+
 def test_runtime_env_layers_onto_base_env_without_mutating_it() -> None:
     """The pin is added to a copy; the caller's base_env dict is untouched."""
     base_env = {"PATH": "/usr/bin", "SOME_VAR": "1"}

--- a/tests/deployment/test_runtime_helper.py
+++ b/tests/deployment/test_runtime_helper.py
@@ -42,28 +42,43 @@ def test_runtime_env_pins_default_project_name_for_falsy_config() -> None:
 
 
 # ---------------------------------------------------------------------------
-# COMPOSE_IGNORE_ORPHANS -- structural, not cosmetic.
+# COMPOSE_IGNORE_ORPHANS -- opt-in, and the default matters as much as the
+# opt-in.
 #
 # A web-terminal deploy issues TWO compose invocations against ONE
 # COMPOSE_PROJECT_NAME: the backend services (-f build/services/*.yml) and the
 # web stack (-f docker-compose.web.yml). Each therefore sees the other's
 # containers as orphans of the shared project and prints a warning naming every
-# one of them, twice per deploy. The warning is not actionable here: its
+# one of them, twice per deploy. The warning is not actionable there: its
 # suggested remedy, `--remove-orphans`, would delete the OTHER stack, which is
-# exactly why provision.py forbids that flag on both paths.
+# exactly why provision.py forbids that flag on both paths --
+# ignore_orphans=True silences it at the source.
+#
+# The single-stack paths are the mirror image: plain `deploy up` reconciles
+# with `up --remove-orphans`, `clean` with `down --remove-orphans`, and docker
+# compose HARD-ERRORS on the combination ("cannot combine
+# COMPOSE_IGNORE_ORPHANS and --remove-orphans"). A default-on env var breaks
+# every one of those deploys outright, so the default-off pin below is a
+# regression guard, not a formality.
 # ---------------------------------------------------------------------------
 
 
-def test_runtime_env_suppresses_the_shared_project_orphan_warning() -> None:
-    """The two-invocations-one-project design makes orphans expected, not news."""
+def test_runtime_env_does_not_set_ignore_orphans_by_default() -> None:
+    """Single-stack deploys pass --remove-orphans; the env var would hard-error."""
     env = runtime_env({"project_name": "proj-a"}, base_env={})
+    assert "COMPOSE_IGNORE_ORPHANS" not in env
+
+
+def test_runtime_env_suppresses_the_orphan_warning_on_request() -> None:
+    """The two-invocations-one-project design makes orphans expected, not news."""
+    env = runtime_env({"project_name": "proj-a"}, base_env={}, ignore_orphans=True)
     assert env["COMPOSE_IGNORE_ORPHANS"] == "1"
 
 
 def test_runtime_env_never_mutates_the_base_env() -> None:
     """Both pins land on a copy -- the caller's env is untouched."""
     base: dict[str, str] = {}
-    runtime_env({"project_name": "proj-a"}, base_env=base)
+    runtime_env({"project_name": "proj-a"}, base_env=base, ignore_orphans=True)
     assert base == {}
 
 

--- a/tests/deployment/web_terminals/test_lifecycle.py
+++ b/tests/deployment/web_terminals/test_lifecycle.py
@@ -1299,9 +1299,13 @@ def test_passwd_carries_the_env_file_fragment_into_the_recreate(
 
     lifecycle.rotate_user_password(str(config_path), "alice", "alices-new-password")
 
-    assert argv[0][:6] == [
+    assert argv[0][:8] == [
         "docker",
         "compose",
+        # Global flags precede the -f list; docker only (see
+        # runtime_helper.with_plain_progress).
+        "--progress",
+        "plain",
         "-f",
         "docker-compose.web.yml",
         "--env-file",

--- a/tests/deployment/web_terminals/test_postup_hooks.py
+++ b/tests/deployment/web_terminals/test_postup_hooks.py
@@ -241,6 +241,134 @@ def test_web_stack_unreachable_on_linux_warns_without_desktop_hint(monkeypatch, 
     assert "Enable host networking" not in caplog.text
 
 
+# ---------------------------------------------------------------------------
+# Docker Desktop stale-forwarder self-heal.
+#
+# Docker Desktop's host-network forwarder registers a VM-side listen socket by
+# WATCHING for the listen event. A container that came back up via
+# `restart: unless-stopped` while Docker Desktop was still starting (an update,
+# a reboot, an Apply & Restart) opens its socket unobserved and stays invisible
+# to the host forever -- and because its compose definition never changed,
+# every later `up -d` leaves it `Running` and reconciles nothing, so the deploy
+# can never fix itself. Bouncing the container re-opens the socket while the
+# forwarder is watching. That is the common case whenever this probe fails on
+# Docker Desktop, so the restart is tried BEFORE blaming the opt-in setting.
+# ---------------------------------------------------------------------------
+
+
+def _refusing_urlopen(succeed_after: int, calls: list[int]):
+    """urlopen stub that refuses the first ``succeed_after`` calls, then answers."""
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def _urlopen(url, timeout):
+        calls.append(1)
+        if len(calls) <= succeed_after:
+            raise OSError("connection refused")
+        return _Resp()
+
+    return _urlopen
+
+
+def test_docker_desktop_unreachable_self_heals_via_restart(monkeypatch, caplog):
+    """A stale forwarder registration is repaired by a restart, with no warning."""
+    probes: list[int] = []
+    monkeypatch.setattr(postup_hooks.urllib.request, "urlopen", _refusing_urlopen(2, probes))
+    monkeypatch.setattr(postup_hooks.sys, "platform", "darwin")
+    monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker", "compose"])
+
+    ran: list[list[str]] = []
+    monkeypatch.setattr(
+        postup_hooks.subprocess,
+        "run",
+        lambda cmd, **kw: ran.append(cmd) or _FakeCompletedProcess(0),
+    )
+
+    with caplog.at_level("WARNING"):
+        postup_hooks.warn_if_web_stack_unreachable(
+            _PROBE_CONFIG,
+            attempts=2,
+            delay=0,
+            web_cmd=["docker", "compose", "-f", "docker-compose.web.yml"],
+            run_env={},
+        )
+
+    assert ran == [["docker", "compose", "-f", "docker-compose.web.yml", "restart"]]
+    assert "not reachable" not in caplog.text
+    assert "Enable host networking" not in caplog.text
+
+
+def test_docker_desktop_warns_only_after_restart_fails_to_help(monkeypatch, caplog):
+    """When the bounce does not help, the setting really is the likely cause."""
+    probes: list[int] = []
+    monkeypatch.setattr(postup_hooks.urllib.request, "urlopen", _refusing_urlopen(999, probes))
+    monkeypatch.setattr(postup_hooks.sys, "platform", "darwin")
+    monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker", "compose"])
+
+    ran: list[list[str]] = []
+    monkeypatch.setattr(
+        postup_hooks.subprocess,
+        "run",
+        lambda cmd, **kw: ran.append(cmd) or _FakeCompletedProcess(0),
+    )
+
+    with caplog.at_level("WARNING"):
+        postup_hooks.warn_if_web_stack_unreachable(
+            _PROBE_CONFIG, attempts=2, delay=0, web_cmd=["docker", "compose"], run_env={}
+        )
+
+    assert ran == [["docker", "compose", "restart"]]
+    assert "not reachable" in caplog.text
+    assert "Enable host networking" in caplog.text
+
+
+def test_self_heal_never_fires_on_linux(monkeypatch, caplog):
+    """Linux host networking is real -- an unreachable port means something else."""
+    monkeypatch.setattr(postup_hooks.urllib.request, "urlopen", _refusing_urlopen(999, []))
+    monkeypatch.setattr(postup_hooks.sys, "platform", "linux")
+    monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker", "compose"])
+
+    ran: list[list[str]] = []
+    monkeypatch.setattr(
+        postup_hooks.subprocess,
+        "run",
+        lambda cmd, **kw: ran.append(cmd) or _FakeCompletedProcess(0),
+    )
+
+    with caplog.at_level("WARNING"):
+        postup_hooks.warn_if_web_stack_unreachable(
+            _PROBE_CONFIG, attempts=2, delay=0, web_cmd=["docker", "compose"], run_env={}
+        )
+
+    assert ran == []
+    assert "not reachable" in caplog.text
+
+
+def test_self_heal_skipped_when_caller_supplies_no_compose_cmd(monkeypatch, caplog):
+    """Lifecycle callers that never had a web_cmd keep the old warn-only behaviour."""
+    monkeypatch.setattr(postup_hooks.urllib.request, "urlopen", _refusing_urlopen(999, []))
+    monkeypatch.setattr(postup_hooks.sys, "platform", "darwin")
+    monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker", "compose"])
+
+    ran: list[list[str]] = []
+    monkeypatch.setattr(
+        postup_hooks.subprocess,
+        "run",
+        lambda cmd, **kw: ran.append(cmd) or _FakeCompletedProcess(0),
+    )
+
+    with caplog.at_level("WARNING"):
+        postup_hooks.warn_if_web_stack_unreachable(_PROBE_CONFIG, attempts=2, delay=0)
+
+    assert ran == []
+    assert "Enable host networking" in caplog.text
+
+
 def test_web_stack_http_error_counts_as_reachable(monkeypatch, caplog):
     def _http_error(url, timeout):
         raise postup_hooks.urllib.error.HTTPError(url, 502, "Bad Gateway", None, None)

--- a/tests/deployment/web_terminals/test_provision.py
+++ b/tests/deployment/web_terminals/test_provision.py
@@ -76,6 +76,10 @@ def test_deploy_down_web_terminals_runs_compose_down_on_web_file(monkeypatch, tm
     assert recorded["cmd"] == [
         "docker",
         "compose",
+        # Global flags precede the -f list; docker only (see
+        # runtime_helper.with_plain_progress).
+        "--progress",
+        "plain",
         "-f",
         "docker-compose.web.yml",
         "--env-file",

--- a/tests/deployment/web_terminals/test_provision.py
+++ b/tests/deployment/web_terminals/test_provision.py
@@ -690,7 +690,7 @@ def _stub_web_stack(monkeypatch, tmp_path):
 
     monkeypatch.setattr(provision.subprocess, "run", _fake_run)
     monkeypatch.setattr(provision, "get_runtime_command", lambda config=None: ["docker", "compose"])
-    monkeypatch.setattr(provision, "runtime_env", lambda config, env: dict(env))
+    monkeypatch.setattr(provision, "runtime_env", lambda config, env, **kw: dict(env))
     monkeypatch.setattr(provision, "write_web_terminal_artifacts", lambda config, dest_dir=".": [])
     monkeypatch.setattr(provision, "ensure_env_production", lambda config, root: None)
     monkeypatch.setattr(provision, "resolve_personas", lambda *a, **kw: [])

--- a/tests/deployment/web_terminals/test_seeding.py
+++ b/tests/deployment/web_terminals/test_seeding.py
@@ -116,7 +116,7 @@ def fake_runtime(monkeypatch):
 
     monkeypatch.setattr(seeding.subprocess, "run", _fake_run)
     monkeypatch.setattr(seeding, "get_runtime_command", lambda config=None: ["docker", "compose"])
-    monkeypatch.setattr(seeding, "runtime_env", lambda config, base_env=None: {"FAKE": "env"})
+    monkeypatch.setattr(seeding, "runtime_env", lambda config, base_env=None, **kw: {"FAKE": "env"})
     return calls, inputs, ready
 
 


### PR DESCRIPTION
## What

Two commits: a deploy reliability/noise fix and a new CLI one-shot.

### Self-heal Docker Desktop host-network ports

On Docker Desktop (macOS/Windows), the host-network forwarder registers a VM-side port only if it *observes* the container open it. A container brought back by `restart: unless-stopped` while Docker Desktop is still starting opens its socket unobserved and stays unreachable from the host indefinitely — and `deploy up` can never repair it, because the compose definition is unchanged and compose reconciles nothing. The post-up reachability probe now restarts the web stack once and re-probes before pointing at the host-networking setting. Gated to darwin/win32 + docker: on Linux host networking is real and a blind restart would be noise.

### Deploy output noise

- `COMPOSE_IGNORE_ORPHANS=1` in `runtime_env()`: a web-terminal deploy runs two compose invocations against one project, so each always flags the other's containers as orphans — and the warning's suggested remedy (`--remove-orphans`) is the one flag both call sites forbid because it would delete the other stack.
- `--progress plain` on docker compose argvs (`with_plain_progress()`): the TTY renderer repaints frames with cursor-up and no erase-to-EOL, so long service names wrap and frames overprint into garbage. Docker-only — podman compose delegates to a provider that may reject the flag.
- "Running command:" echoes demoted to DEBUG, retrievable via a new global `osprey -v/--verbose`.
- The virtual accelerator declares `platform: ${OSPREY_VA_PLATFORM:-linux/amd64}` and its template comment now tells the truth: the image is amd64-only because pcaspy ships no aarch64 wheel, so the per-deploy platform-mismatch warning described the design, not a defect.

### `osprey profile try`

One command for what was three runs from three directories: settle the profile (materialize on first run, reuse + write `--set`/`-O` back afterwards), build the project (re-rendered in place on reruns), `deploy up` ending in the endpoint summary. `--dev`/`-d` pass through. The chained commands stay behind function-local imports, keeping `osprey --help` inside its lazy-import budget — the probe now pins `build_cmd`/`deploy_cmd` too.

## Testing

- Full suite green locally: 18239 passed (`pytest tests/ --ignore=tests/e2e`); `tests/cli/` 2957 passed after the `-v` group-signature change.
- New tests: self-heal matrix (heals / warns-after-failed-heal / never on Linux / warn-only without a compose argv), `with_plain_progress` docker/podman/empty-argv plus a seam guard pinning that it never resolves a runtime itself, `COMPOSE_IGNORE_ORPHANS` pins, and the `profile try` chaining contract (build-then-deploy order, force-implied re-render, profile-path variant, deploy skipped on build failure).