### PR TITLE
ci(deps): hold dependency updates for a seven-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,17 @@ updates:
     labels:
       - "dependencies"
       - "python"
+    # Supply-chain quarantine: never propose a release that is less than a week
+    # old. A hijacked package or a malicious maintainer release is usually
+    # caught and yanked within days, so waiting costs nothing and removes the
+    # window in which we would be the ones to find it.
+    #
+    # Note this covers version updates only — Dependabot *security* updates
+    # bypass cooldown by design, which is what we want for a CVE fix.
+    cooldown:
+      default-days: 7
+      include:
+        - "*"
     # Group minor and patch updates together
     groups:
       development-dependencies:
@@ -42,3 +53,9 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    # Same one-week quarantine as the Python block. Actions run with repository
+    # credentials, so a freshly published tag is if anything a sharper risk.
+    cooldown:
+      default-days: 7
+      include:
+        - "*"


### PR DESCRIPTION
Dependabot now waits until a release is at least seven days old before proposing it, for both the Python (`pip`) and GitHub Actions ecosystems.

The rationale is supply-chain quarantine: a hijacked package or a malicious maintainer release is usually spotted and yanked within days. Waiting a week costs nothing on a project that already updates on a weekly schedule, and it removes the window in which this repository would be among the first to pull a bad release in.

`default-days` is the key that does the work here — the `semver-*-days` variants only apply in ecosystems with true SemVer semantics, which Python (PEP 440) is not.

Two things this deliberately does not change:

- **Security updates are exempt.** Dependabot bypasses cooldown for them by design, which is the behaviour wanted for a CVE fix.
- **Resolve-time version selection is untouched.** Dependabot PRs raise a floor in `pyproject.toml`; the versions actually installed are chosen by `uv` at sync time, which no date window currently bounds in CI. Closing that is a separate decision.