### PR TITLE
ci: skip secret-dependent lanes on Dependabot pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,18 @@ on:
         required: false
         type: boolean
         default: false
+      revalidate_secret_lanes:
+        description: >-
+          Run the API-key-dependent lanes (agentic flows, dispatch stacks,
+          Nextcloud/Google Chat bridges) against this ref. Dependabot's own
+          runs are treated as fork runs and receive only the Dependabot
+          secret store, so ALS_APG_API_KEY is empty and those lanes skip on
+          its pull requests. After reading the dependency diff, a maintainer
+          revalidates the branch with:
+          gh workflow run ci.yml --ref <branch> -f revalidate_secret_lanes=true
+        required: false
+        type: boolean
+        default: false
   schedule:
     # Nightly at 07:00 UTC (midnight Pacific) for the always-on jobs
     # (test, lint, docs, ...; no `if:`). Every e2e/benchmark lane is
@@ -592,7 +604,13 @@ jobs:
     # Only run on PRs from same repo (ALS_APG_API_KEY unavailable on forks).
     # Gating (no continue-on-error): a red Tier 3 flow blocks the merge like
     # every other e2e lane — the house rule is full green, no advisory tiers.
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    # Secret-dependent lane: skips on Dependabot PRs, which get no Actions
+    # secrets. Revalidate with the `revalidate_secret_lanes` dispatch input.
+    if: >-
+      (github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name == github.repository
+        && github.actor != 'dependabot[bot]')
+      || (github.event_name == 'workflow_dispatch' && inputs.revalidate_secret_lanes)
     strategy:
       fail-fast: false
       matrix:
@@ -671,7 +689,13 @@ jobs:
     # Only run on PRs (not pushes) to control API costs, and only for non-fork PRs (secrets unavailable on forks).
     # Also runs on manual workflow_dispatch to enable scoped reruns via the e2e_filter input —
     # unless that dispatch asked for the benchmark lanes instead (run_benchmarks).
-    if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'workflow_dispatch' && !inputs.run_benchmarks)
+    # Secret-dependent lane: skips on Dependabot PRs, which get no Actions
+    # secrets. Revalidate with the `revalidate_secret_lanes` dispatch input.
+    if: >-
+      (github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name == github.repository
+        && github.actor != 'dependabot[bot]')
+      || (github.event_name == 'workflow_dispatch' && !inputs.run_benchmarks)
     # The lane's healthy runtime is ~20-25min (real-LLM SDK/CLI pipelines —
     # every full-stack docker deploy now lives in its own dedicated job, and
     # the channel-finder benchmarks moved to the nightly schedule); a run past
@@ -946,7 +970,13 @@ jobs:
     # carries the multi-user topology + write-posture proofs (T1-T4 in
     # tests/e2e/test_dispatch_deploy.py). Persona image builds add
     # cold-cache minutes; the two builds share most layers.
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    # Secret-dependent lane: skips on Dependabot PRs, which get no Actions
+    # secrets. Revalidate with the `revalidate_secret_lanes` dispatch input.
+    if: >-
+      (github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name == github.repository
+        && github.actor != 'dependabot[bot]')
+      || (github.event_name == 'workflow_dispatch' && inputs.revalidate_secret_lanes)
 
     steps:
     - name: Checkout repository
@@ -1016,7 +1046,13 @@ jobs:
     # dispatcher/worker image build + deploy was the lane's single biggest
     # time sink (~11min); it follows the same extraction pattern (and job
     # shape) as dispatch-deploy-e2e.
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    # Secret-dependent lane: skips on Dependabot PRs, which get no Actions
+    # secrets. Revalidate with the `revalidate_secret_lanes` dispatch input.
+    if: >-
+      (github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name == github.repository
+        && github.actor != 'dependabot[bot]')
+      || (github.event_name == 'workflow_dispatch' && inputs.revalidate_secret_lanes)
     # Build + deploy + one real agent turn healthily fits well under 20min
     # (~11min when it ran in-lane, including the web-terminal image builds
     # its fixture has since dropped); past the cap it's wedged, not slow.
@@ -1405,7 +1441,13 @@ jobs:
     runs-on: ubuntu-latest
     # Only run on PRs from same repo (same house policy as every other
     # Docker-stack lane: secrets are unavailable on forks).
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    # Secret-dependent lane: skips on Dependabot PRs, which get no Actions
+    # secrets. Revalidate with the `revalidate_secret_lanes` dispatch input.
+    if: >-
+      (github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name == github.repository
+        && github.actor != 'dependabot[bot]')
+      || (github.event_name == 'workflow_dispatch' && inputs.revalidate_secret_lanes)
     # A job-level `permissions:` block REPLACES the default token scopes rather
     # than extending them, so `contents: read` is restated alongside the
     # `packages: read` this lane actually needs: the Nextcloud Talk fixture is a
@@ -1503,7 +1545,13 @@ jobs:
     runs-on: ubuntu-latest
     # Only run on PRs from same repo (same house policy as every other
     # container-stack lane: secrets are unavailable on forks).
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    # Secret-dependent lane: skips on Dependabot PRs, which get no Actions
+    # secrets. Revalidate with the `revalidate_secret_lanes` dispatch input.
+    if: >-
+      (github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name == github.repository
+        && github.actor != 'dependabot[bot]')
+      || (github.event_name == 'workflow_dispatch' && inputs.revalidate_secret_lanes)
     # A job-level `permissions:` block REPLACES the default token scopes rather
     # than extending them, so the one scope this lane needs is stated in full.
     # Unlike nextcloud-talk-bridge-e2e there is no `packages: read` here: the
@@ -2001,6 +2049,18 @@ jobs:
       #     (failure, cancelled) fails it. Corollary: on fork PRs the secret
       #     -gated lanes don't run at all — the gate can't vouch for them
       #     there, same as before.
+      #
+      # Dependabot PRs are a third case that looks like the second: the lanes
+      # skip legitimately (no secrets are issued to them), so the gate passes —
+      # but it says so explicitly in the run summary rather than letting a
+      # green check imply coverage it does not have.
+      #
+      # `github.actor` and `github.head_ref` are routed through `env:` and used
+      # only as quoted shell variables — never interpolated into `run:`, where a
+      # crafted branch name would be a script-injection vector.
+      env:
+        ACTOR: ${{ github.actor }}
+        HEAD_BRANCH: ${{ github.head_ref }}
       run: |
         if [[ "${{ needs.test.result }}" != "success" ]]; then
           echo "❌ Tests failed"
@@ -2073,3 +2133,34 @@ jobs:
         check_pr_lane "Multi-user lifecycle E2E (docker)" "${{ needs.multi-user-deploy-lifecycle-e2e.result }}"
         check_pr_lane "Multi-user lifecycle E2E (podman)" "${{ needs.multi-user-deploy-lifecycle-e2e-podman.result }}"
         echo "✅ All CI checks passed!"
+
+        # A green gate on a Dependabot PR is green-with-a-gap, and the gap is
+        # invisible unless it is named. Dependabot runs get no Actions secrets,
+        # so every API-key lane skipped above rather than ran. Say so where a
+        # reviewer will actually see it — the run summary, not buried in a log.
+        # `-n "$GITHUB_STEP_SUMMARY"` is not defensive noise: `run:` executes
+        # under `bash -e`, so an unset summary path would make `>> ""` fail and
+        # take the whole gate down with it. This block is advisory — it must
+        # never be able to turn a passing gate red.
+        if [ "$ACTOR" = "dependabot[bot]" ] && [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+          {
+            echo "### ⚠️ Secret-dependent lanes did not run"
+            echo
+            echo "Dependabot pull requests are treated as fork runs and receive only the"
+            echo "Dependabot secret store, so \`ALS_APG_API_KEY\` is unavailable and these"
+            echo "lanes skipped rather than executed:"
+            echo
+            echo "- Tier 3 — Agentic flow (both presets)"
+            echo "- E2E Tests"
+            echo "- Dispatch Deploy E2E / Dispatch Overlay E2E"
+            echo "- Nextcloud Talk Bridge E2E / Google Chat Bridge E2E"
+            echo
+            echo "**This gate cannot vouch for them.** After reviewing the dependency diff,"
+            echo "revalidate the branch as a maintainer (that run does get the secrets):"
+            echo
+            echo '```'
+            echo "gh workflow run ci.yml --ref $HEAD_BRANCH -f revalidate_secret_lanes=true"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "⚠️  Secret-dependent lanes skipped (Dependabot run) — see run summary."
+        fi

--- a/docs/source/contributing/index.rst
+++ b/docs/source/contributing/index.rst
@@ -138,6 +138,40 @@ enforces:
 If a required check turns out to be wrong, fix it forward — there is no
 escape hatch.
 
+Dependency Update Pull Requests
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Dependabot opens pull requests for dependency bumps, subject to a **seven-day
+cooldown**: a release is not proposed until it has been public for a week, so
+that a hijacked or malicious version has time to be found and yanked before it
+reaches this repository. Security updates are exempt, by design — a fix for a
+known vulnerability should not wait.
+
+These pull requests run with a deliberate gap in coverage. GitHub treats a
+Dependabot-triggered run as if it came from a fork: it receives only the
+Dependabot secret store, never the repository's Actions secrets. The lanes that
+need a live model endpoint therefore **skip** rather than run — the agentic
+flows, the E2E suite, the dispatch stacks, and the two chat bridges. The run
+summary of the ``All CI Checks Passed`` job names them explicitly, so a green
+check on a dependency PR is never mistaken for full coverage.
+
+To close that gap before merging, review the diff and then revalidate the branch
+yourself. Because *you* trigger it, that run gets the normal secrets:
+
+.. code-block:: bash
+
+   gh workflow run ci.yml --ref <dependabot-branch> -f revalidate_secret_lanes=true
+
+Find the branch name with ``gh pr view <number> --json headRefName``. Watch the
+resulting run to completion before merging.
+
+The reason this is a manual step rather than an automatic one is worth stating:
+mirroring the model API key into the Dependabot secret store would make these
+lanes pass unattended, but it would also hand a live credential to a
+newly-published third-party package at install time — the precise supply-chain
+exposure the cooldown exists to reduce. The human read of the diff is the point,
+not an inconvenience around it.
+
 Osprey Agent Workflow Skill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Dependency-bump pull requests currently fail seven checks every time, regardless of the dependency. This makes them report honestly instead, and adds a way to actually validate them.

## Why they fail

GitHub treats a Dependabot-triggered run as a fork run — it receives **only** the Dependabot secret store, never the repository's Actions secrets. So `ALS_APG_API_KEY` arrives empty, and the six lanes carrying this preflight guard hard-exit before doing any work:

```
if [ -z "${ALS_APG_API_KEY:-}" ]; then
  echo "❌ ALS_APG_API_KEY secret is not set on this runner"
  exit 1
fi
```

The `if:` those jobs already had tests `head.repo.full_name == github.repository` — a **fork** guard. Dependabot's branches live inside the repository, so they pass it, start, and then die on the empty key. The guard was written for a threat model Dependabot technically sits outside of but effectively sits inside.

Verified from the logs of a real dependency PR: all seven failing checks print that exact line after an env dump showing `ALS_APG_API_KEY:` empty. None fails during install, image build, or the test body — so nothing of value is being suppressed. `deploy-e2e` and `dockerfile-e2e` reference the same secret but carry no preflight guard, which is why they pass; they are deliberately left alone.

## What changes

- The six guarded lanes (`agentic-per-preset`, `e2e-tests`, `dispatch-deploy-e2e`, `dispatch-overlay-e2e`, `nextcloud-talk-bridge-e2e`, `gchat-bridge-e2e`) gain `&& github.actor != 'dependabot[bot]'` and **skip** on Dependabot PRs. The aggregate gate already treats a skipped conditional lane as legitimate, so no gate surgery was needed.
- The gate writes the skipped lanes into `$GITHUB_STEP_SUMMARY`, so a green check on a dependency PR is never mistaken for full coverage.
- A new `revalidate_secret_lanes` dispatch input runs those lanes against a branch on demand. A maintainer-triggered run *does* get the normal secrets:

```
gh workflow run ci.yml --ref <dependabot-branch> -f revalidate_secret_lanes=true
```

## The deliberate non-change

GitHub's documented fix is to mirror the key into the Dependabot secret store so the lanes pass unattended. That is not done here: it hands a live credential to a newly-published third-party package at install time — precisely the exposure the seven-day release cooldown exists to reduce. Requiring a human to read the diff before spending the key is the safeguard, not an oversight.

## Notes

- None of the six is a required status check, so this cannot block a merge either way.
- `actionlint` 1.7.7 passes clean on the modified workflow.
- No `CHANGELOG.md` entry: this changes CI policy, with no user-observable effect on the framework.