### PR TITLE
feat(web): collaborative panel workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,6 +472,7 @@ jobs:
         uv run pytest tests/interfaces/design_system/test_behavioral.py \
           tests/interfaces/design_system/test_theme_lab.py \
           tests/interfaces/web_terminal/test_panels_browser.py \
+          tests/interfaces/web_terminal/test_panels_collab_browser.py \
           tests/interfaces/web_terminal/test_agent_activity_browser.py \
           tests/interfaces/web_terminal/test_contract_params.py \
           tests/interfaces/web_terminal/test_logout_resume_browser.py \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Added
 
+- The OSPREY agent can see what is actually on screen. `list_panels` now
+  reports the open service tiles in left-to-right order plus how long ago that
+  arrangement last changed, and tells "nothing open" apart from "no browser
+  reporting" — so the agent can work from your view instead of guessing at it.
+  It is also told what changed in the workspace between turns, and told nothing
+  when nothing changed.
+- `arrange_workspace` sets a whole layout in one call: exactly these tiles, in
+  this order, optionally focusing one — or a named layout from the deployment's
+  config, the same arrangement the **Layouts** menu applies. Clicking
+  **Layouts** yourself behaves as it did before.
 - Docked panels now show **one** header bar instead of two. A panel embedded
   in the web terminal contributes its real toolbar controls (view switcher,
   action buttons, live text) into the tile's header bar over a new
@@ -110,6 +120,10 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Changed
 
+- Asking the agent to open a panel no longer replaces what you were looking at.
+  `switch_panel` opens the tile *beside* your current one — focusing it instead
+  if it is already open — so no tile you had open is evicted. The Simple web
+  UI's single workspace slot is unchanged.
 - **The profile is the source of truth for a built project.** Every
   `osprey build` reads a profile directory; there is no build straight out of a
   bundled preset. `--preset NAME` materializes `<PROJECT_NAME>-profile/` beside

--- a/src/osprey/cli/templates/manifest.py
+++ b/src/osprey/cli/templates/manifest.py
@@ -63,6 +63,7 @@ REGEN_TRACKED_FILES = [
     ".claude/hooks/osprey_focus_validate.py",
     ".claude/hooks/osprey_config_drift.py",
     ".claude/hooks/osprey_panels_context.py",
+    ".claude/hooks/osprey_workspace_delta.py",
     ".claude/rules/python-execution.md",
     ".claude/rules/control-system-safety.md",
     ".claude/rules/test-ioc-safety.md",

--- a/src/osprey/interfaces/web_terminal/routes/panels.py
+++ b/src/osprey/interfaces/web_terminal/routes/panels.py
@@ -8,6 +8,7 @@ import ipaddress
 import logging
 import os
 import socket
+import time
 from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
@@ -189,6 +190,9 @@ async def get_panels(request: Request):
             "ui_mode":  str,            # resolved web.ui_mode ("expert" | "simple")
             "project_key": str,         # stable 16-hex per-project key (layout persistence)
             "workspace_has_artifacts": bool,  # any non-hidden file under the agent workspace
+            "open_tiles": [...]|None,   # last-reported service tiles, reading order
+            "open_tiles_age_s": float|None,   # seconds since that report (None = never)
+            "open_tiles_dock": bool|None,     # reporting client had a dock shell (None = never)
         }
 
     ``project_key`` is an opaque, stable per-project identifier (16 hex chars,
@@ -234,6 +238,29 @@ async def get_panels(request: Request):
     first paint is chat-only (empty workspace) or includes the WORKSPACE
     panel; recomputed per request so a reload after the first artifact lands
     sees ``true``.
+
+    ``open_tiles`` is what a browser last reported through
+    ``POST /api/panel-layout``: the service tiles actually on screen, in spatial
+    reading order. It is distinct from ``visible`` — that is launcher-rail
+    membership, this is occupancy. ``open_tiles_age_s`` is the seconds elapsed
+    since the occupancy last *changed* (a deduped repeat report does not reset
+    it) and ``open_tiles_dock`` is whether the reporting client had a dock
+    shell.
+
+    Read together, the three fields carry three distinct states, and a
+    consumer must not collapse them:
+
+    - **Never reported** — all three ``null``. No client has ever checked in;
+      nothing is known about the screen. Not the same as an empty workspace.
+    - **Unknown occupancy** — ``open_tiles: null`` with a numeric
+      ``open_tiles_age_s`` and ``open_tiles_dock: false``. A client is watching
+      but runs without the dock shell, so it cannot report tile order.
+    - **Known occupancy** — ``open_tiles`` is a list (possibly ``[]``, meaning
+      the operator genuinely closed every service tile) with a numeric age and
+      ``open_tiles_dock: true``.
+
+    So ``[]`` always means known-empty and ``null`` always means unknown; the
+    age tells the two flavours of unknown apart.
     """
     enabled = list(getattr(request.app.state, "enabled_panels", set()))
     custom_raw = getattr(request.app.state, "custom_panels", [])
@@ -261,6 +288,14 @@ async def get_panels(request: Request):
     rail_position_configured = getattr(request.app.state, "web_rail_position_configured", False)
     project_key = _project_key(getattr(request.app.state, "project_cwd", None))
     has_artifacts = _workspace_has_artifacts(getattr(request.app.state, "workspace_dir", None))
+    # Tile occupancy as last reported by a browser, with its freshness. The
+    # timestamp is never exposed raw: an age is what a consumer can reason
+    # about without knowing the server's clock. ``None`` survives untouched —
+    # it is the "unknown occupancy" state, distinct from a known-empty list.
+    open_tiles = getattr(request.app.state, "open_tiles", None)
+    open_tiles_ts = getattr(request.app.state, "open_tiles_ts", None)
+    open_tiles_age = None if open_tiles_ts is None else time.time() - open_tiles_ts
+    open_tiles_dock = getattr(request.app.state, "open_tiles_dock", None)
     return {
         "enabled": enabled,
         "custom": custom,
@@ -276,6 +311,9 @@ async def get_panels(request: Request):
         "family_rail_defaults": dict(FAMILY_RAIL_DEFAULTS),
         "project_key": project_key,
         "workspace_has_artifacts": has_artifacts,
+        "open_tiles": open_tiles,
+        "open_tiles_age_s": open_tiles_age,
+        "open_tiles_dock": open_tiles_dock,
     }
 
 
@@ -288,6 +326,14 @@ def _known_panel_ids(request: Request) -> set[str]:
     known: set[str] = set(getattr(request.app.state, "enabled_panels", set()))
     known |= {p["id"] for p in getattr(request.app.state, "custom_panels", [])}
     return known
+
+
+#: Dock id of the native terminal/chat tile (``PANEL_TERMINAL`` in
+#: ``dock-workspace.js``). It carries no server-side panel state and is never a
+#: service tile, so every layout verb refuses it explicitly rather than relying
+#: on it being absent from :func:`_known_panel_ids` — a custom panel squatting
+#: the id must not become a way to move or close the operator's terminal.
+_TERMINAL_PANEL_ID = "terminal"
 
 
 class PanelFocusRequest(BaseModel):
@@ -311,10 +357,57 @@ async def set_panel_focus(body: PanelFocusRequest, request: Request):
     run through ``_prefix_path()`` before broadcast so a root-absolute path
     lands inside the user's own mount; an already-absolute URL is left
     untouched.
+
+    Focusing a panel that is **not** in the launcher rail also adds it there,
+    emitting a ``panel_visibility`` frame *before* the focus frame. An agent's
+    ``switch_panel`` may name a panel the operator has hidden; without the
+    membership update the rail entry would exist only on the client that
+    happened to apply the focus, so ``list_panels`` would keep reporting the
+    panel invisible, a reload would drop both the entry and the agent-opened
+    tile, and a late-connecting client would never see it at all. Ordering is
+    deliberate: clients add the rail entry, then apply focus to it.
+
+    A panel already in the rail — which is the only kind a human can click —
+    changes nothing and emits no visibility frame.
+
+    Args:
+        body: ``panel`` (panel id), optional ``url`` to load, and optional
+            ``source`` attribution.
+        request: Incoming FastAPI request carrying ``app.state``.
+
+    Returns:
+        ``{"status": "ok", "active_panel": <id>}``
+
+    Raises:
+        HTTPException: 422 when ``panel`` is not a known enabled or custom id.
     """
     if body.panel not in _known_panel_ids(request):
         raise HTTPException(status_code=422, detail=f"Unknown panel: {body.panel}")
+
+    # Membership, resolved the same way ``get_panels`` resolves ``visible`` —
+    # an unset list means "the enabled built-ins are the rail", so a panel the
+    # read route calls visible is never treated here as a non-member.
+    stored_visible = getattr(request.app.state, "visible_panels", None)
+    if stored_visible is None:
+        visible_panels = list(getattr(request.app.state, "enabled_panels", set()))
+    else:
+        visible_panels = list(stored_visible)
+    adds_membership = body.panel not in visible_panels
+    if adds_membership:
+        visible_panels.append(body.panel)
+        request.app.state.visible_panels = visible_panels
+
     request.app.state.active_panel = body.panel
+    if adds_membership:
+        visibility_event: dict = {
+            "type": "panel_visibility",
+            "panel": body.panel,
+            "visible": True,
+        }
+        if body.source:
+            visibility_event["source"] = body.source
+        request.app.state.broadcaster.broadcast(visibility_event)
+
     event: dict = {"type": "panel_focus", "panel": body.panel}
     if body.url:
         event["url"] = _prefix_path(body.url)
@@ -358,6 +451,287 @@ async def set_panel_visibility(body: PanelVisibilityRequest, request: Request):
         event["source"] = body.source
     request.app.state.broadcaster.broadcast(event)
     return {"status": "ok", "panel": body.panel, "visible": body.visible}
+
+
+class PanelArrangeRequest(BaseModel):
+    tiles: list[str] | None = None
+    preset: str | None = None
+    focus: str | None = None
+    source: Literal["agent"] | None = None
+
+
+def _resolve_preset_tiles(request: Request, name: str, known: set[str]) -> list[str]:
+    """Resolve a preset name to its member panel ids, fail-safe filtered.
+
+    Mirrors ``computePresetDiff`` in ``panel-presets.js``: members are filtered
+    to the known ids (and the terminal id is dropped) so a typo'd or disabled
+    member in config is skipped rather than breaking the whole layout. Config
+    order is preserved — it is the left-to-right tile order clients apply.
+
+    Args:
+        request: Incoming request carrying ``app.state.panel_presets``.
+        name: The requested preset name.
+        known: Valid panel ids from :func:`_known_panel_ids`.
+
+    Returns:
+        The preset's surviving member ids, in config order.
+
+    Raises:
+        HTTPException: 422 when no preset carries ``name``, or when none of its
+            members survives filtering (applying it would strand an empty
+            workspace).
+    """
+    presets: list[dict] = list(getattr(request.app.state, "panel_presets", []))
+    match = next((p for p in presets if p.get("name") == name), None)
+    if match is None:
+        available = [p.get("name") for p in presets]
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unknown preset: {name!r}. Available presets: {available}",
+        )
+    members = [pid for pid in match.get("panels", []) if pid in known and pid != _TERMINAL_PANEL_ID]
+    if not members:
+        raise HTTPException(
+            status_code=422,
+            detail=(f"Preset {name!r} has no known members. Valid panel ids: {sorted(known)}"),
+        )
+    return members
+
+
+def _resolve_requested_tiles(tiles: list[str], known: set[str]) -> list[str]:
+    """Validate an explicitly requested tile list, preserving its order.
+
+    Explicit tiles are validated strictly — unlike preset members, which are
+    config-authored and filtered fail-safe. An agent that names a panel that
+    does not exist gets told so rather than silently receiving a different
+    workspace than it asked for, matching the focus and visibility routes.
+
+    Args:
+        tiles: Requested panel ids, in the left-to-right order to apply.
+        known: Valid panel ids from :func:`_known_panel_ids`.
+
+    Returns:
+        ``tiles`` with duplicates collapsed (first occurrence wins).
+
+    Raises:
+        HTTPException: 422 when ``tiles`` is empty, names the terminal tile, or
+            names any id outside ``known``.
+    """
+    if not tiles:
+        raise HTTPException(
+            status_code=422,
+            detail="tiles must not be empty — an arrangement must leave at least one tile open",
+        )
+    if _TERMINAL_PANEL_ID in tiles:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"The terminal tile ({_TERMINAL_PANEL_ID!r}) is not a service panel "
+                "and cannot be arranged"
+            ),
+        )
+    unknown = [pid for pid in tiles if pid not in known]
+    if unknown:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unknown panel ids: {unknown}. Valid panel ids: {sorted(known)}",
+        )
+    deduped: list[str] = []
+    for pid in tiles:
+        if pid not in deduped:
+            deduped.append(pid)
+    return deduped
+
+
+@router.post("/api/panel-arrange")
+async def arrange_panels(body: PanelArrangeRequest, request: Request):
+    """Request a whole-workspace tile arrangement and broadcast it via SSE.
+
+    Declarative end state: exactly the resolved tiles are open, left to right,
+    in the order given. Clients apply it as a deterministic rebuild of the
+    service-tile region; the terminal tile is never touched.
+
+    Exactly one of ``tiles`` and ``preset`` must be supplied. ``preset`` names
+    an entry of ``web.presets`` (``app.state.panel_presets``); its members are
+    resolved here so the human "Layouts" click and an agent preset call are one
+    server operation. A preset additionally sets ``prune_rail`` on the
+    broadcast, preserving today's membership-exclusive preset semantics
+    (non-members leave the launcher rail); a ``tiles`` request never removes
+    rail membership, it only adds any listed non-member.
+
+    Focus caveat: the server records the *requested* focus in
+    ``app.state.active_panel`` and passes it through the broadcast unchanged.
+    Panel health is only observable in the browser, so clients apply the
+    healthy-fallback rule (requested panel if healthy, else the first healthy
+    listed tile, else no focus change). A read-back of ``active`` therefore
+    reports what was asked for, which may differ from what a client could
+    actually focus.
+
+    With no ``focus`` given — every human "Layouts" click, and any agent
+    arrangement that does not name one — the first resolved tile is recorded
+    instead. An arrangement always lands focus somewhere, and ``tiles[0]`` is
+    what the client's healthy-fallback rule picks in the common case. Leaving
+    ``active_panel`` untouched would strand it on a panel the arrangement just
+    closed, so a preset click could leave ``active`` naming a panel that the
+    very same ``GET /api/panels`` response omits from ``visible``. The
+    broadcast still carries ``focus`` only when one was requested, leaving the
+    client's fallback rule in charge of what is actually focused on screen.
+
+    Args:
+        body: ``tiles`` (explicit ids, left-to-right) **or** ``preset`` (a
+            configured layout name), an optional ``focus`` target that must be
+            one of the resolved tiles, and an optional ``source`` attribution.
+        request: Incoming FastAPI request carrying ``app.state``.
+
+    Returns:
+        ``{"status": "ok", "tiles": [...], "focus": <id|None>,
+        "preset": <name|None>, "prune_rail": <bool>}``
+
+    Raises:
+        HTTPException: 422 when neither or both of ``tiles``/``preset`` are
+            given, when ``tiles`` is empty, when any requested id is unknown or
+            is the terminal tile, when the preset name is unknown or resolves
+            to no known member, or when ``focus`` is not one of the resolved
+            tiles.
+    """
+    if (body.tiles is None) == (body.preset is None):
+        raise HTTPException(
+            status_code=422,
+            detail="Provide exactly one of 'tiles' or 'preset'",
+        )
+
+    known = _known_panel_ids(request)
+    if body.preset is not None:
+        tiles = _resolve_preset_tiles(request, body.preset, known)
+        prune_rail = True
+    else:
+        tiles = _resolve_requested_tiles(body.tiles or [], known)
+        prune_rail = False
+
+    if body.focus is not None and body.focus not in tiles:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Focus target {body.focus!r} is not among the arranged tiles: {tiles}",
+        )
+
+    # Rail membership. A tiles request is additive (a panel the operator can
+    # still reach from the rail keeps its entry); a preset prunes to its
+    # members, keeping the existing rail order for the ones that survive.
+    visible_panels: list[str] = list(getattr(request.app.state, "visible_panels", []))
+    if prune_rail:
+        visible_panels = [pid for pid in visible_panels if pid in tiles]
+    visible_panels += [pid for pid in tiles if pid not in visible_panels]
+    request.app.state.visible_panels = visible_panels
+
+    # An arrangement always lands focus somewhere, so the recorded active panel
+    # must move with it. Leaving it alone would let ``active`` name a panel the
+    # same response no longer lists as visible — the state consumers read.
+    request.app.state.active_panel = body.focus or tiles[0]
+
+    event: dict = {"type": "panel_arrange", "tiles": tiles}
+    if body.focus is not None:
+        event["focus"] = body.focus
+    if prune_rail:
+        event["prune_rail"] = True
+    if body.source:
+        event["source"] = body.source
+    request.app.state.broadcaster.broadcast(event)
+    return {
+        "status": "ok",
+        "tiles": tiles,
+        "focus": body.focus,
+        "preset": body.preset,
+        "prune_rail": prune_rail,
+    }
+
+
+class PanelLayoutRequest(BaseModel):
+    tiles: list[str]
+    dock: bool
+
+
+@router.post("/api/panel-layout")
+async def report_panel_layout(body: PanelLayoutRequest, request: Request):
+    """Record which service tiles a client currently has on screen.
+
+    This is the reporter's endpoint, not a command: it is how the browser tells
+    the server what the operator's workspace actually looks like, so the agent
+    stops guessing tile occupancy from rail membership. Nothing is broadcast —
+    a human's tile gestures are never pushed to other clients (report-only,
+    last-writer-wins), and reports are agent-facing state only.
+
+    ``tiles`` is the service-tile list in spatial reading order (rows
+    top-then-left); the terminal tile is never part of it. An empty list is a
+    valid report from a dock client — it means the operator closed every
+    service tile.
+
+    ``dock`` is the reporting client's capability flag, and it decides how the
+    report is *recorded*. A client running without the dock shell cannot see
+    tile order, so the ``{"tiles": [], "dock": false}`` it sends is a presence
+    signal, not an observation of an empty workspace. Recording that ``[]``
+    verbatim would let a fallback client clobber a dock client's live list with
+    a confident "nothing is open". So ``dock: false`` stores occupancy as
+    **unknown** (``open_tiles = None``) while still stamping the timestamp and
+    the flag — ``GET /api/panels`` then reports ``open_tiles: null`` with a
+    numeric age, meaning "a client is watching but cannot report tile order".
+    The request wire format is unchanged; the mapping happens here. ``dock:
+    true`` records the list verbatim, exactly as before.
+
+    Content dedupe: a report whose *recorded* occupancy and ``dock`` flag both
+    equal the stored state is a no-op — the stored timestamp is deliberately
+    *not* bumped, so ``open_tiles_age_s`` keeps measuring when the layout last
+    **changed**. This is the server half of the convergence contract: the
+    client also skips posting a report equal to its last acknowledged one, so
+    an applied arrangement settles after at most one extra round-trip instead
+    of looping. Two successive dock-less reports therefore dedupe against each
+    other, since both record the same unknown occupancy.
+
+    Args:
+        body: ``tiles`` (service panel ids in reading order) and ``dock``
+            (whether the reporting client has a dock shell).
+        request: Incoming FastAPI request carrying ``app.state``.
+
+    Returns:
+        ``{"status": "ok", "tiles": [...]|None, "dock": <bool>,
+        "updated": <bool>}`` — ``tiles`` echoes what was *recorded*, so it is
+        ``None`` for a dock-less report, and ``updated`` is ``False`` when the
+        report was deduped.
+
+    Raises:
+        HTTPException: 422 when a reported id is unknown or is the terminal
+            tile.
+    """
+    known = _known_panel_ids(request)
+    if _TERMINAL_PANEL_ID in body.tiles:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"The terminal tile ({_TERMINAL_PANEL_ID!r}) is not a service panel "
+                "and must not be reported"
+            ),
+        )
+    unknown = [pid for pid in body.tiles if pid not in known]
+    if unknown:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unknown panel ids: {unknown}. Valid panel ids: {sorted(known)}",
+        )
+
+    # A dock-less client cannot see tile order, so its report says only "someone
+    # is watching" — the occupancy it carries is recorded as unknown (``None``)
+    # rather than as a confident empty list that consumers would read as
+    # "the operator closed everything".
+    occupancy: list[str] | None = list(body.tiles) if body.dock else None
+
+    stored_tiles = getattr(request.app.state, "open_tiles", None)
+    stored_dock = getattr(request.app.state, "open_tiles_dock", None)
+    if stored_tiles == occupancy and stored_dock == body.dock:
+        return {"status": "ok", "tiles": stored_tiles, "dock": stored_dock, "updated": False}
+
+    request.app.state.open_tiles = occupancy
+    request.app.state.open_tiles_dock = body.dock
+    request.app.state.open_tiles_ts = time.time()
+    return {"status": "ok", "tiles": occupancy, "dock": body.dock, "updated": True}
 
 
 # ---- Runtime panel registration ---- #

--- a/src/osprey/interfaces/web_terminal/static/js/dock-sync.js
+++ b/src/osprey/interfaces/web_terminal/static/js/dock-sync.js
@@ -22,6 +22,9 @@
  *    and closing a tile does not remove the panel from the rail), so the close
  *    is routed to a locally-registered vacate handler instead.
  *
+ * …plus one channel that is neither: the OCCUPANCY REPORT below tells the
+ * server what is on screen without commanding anything.
+ *
  * THE ECHO GUARD (core correctness property)
  * ------------------------------------------
  * dockview's onDidActivePanelChange fires for BOTH a human tab click AND a
@@ -31,6 +34,64 @@
  * raises a depth counter the onDidActivePanelChange handler checks — so the
  * echo of an applied focus is recognised and never re-POSTed. (dockview's
  * Emitter.fire is synchronous, so the suppressed window covers the echo.)
+ *
+ * THE OCCUPANCY REPORT (deliberately NOT echo-guarded)
+ * ----------------------------------------------------
+ * Rail membership says which panels an operator can reach; it does not say what
+ * is actually on screen. So this module also REPORTS the open service tiles in
+ * reading order (POST /api/panel-layout), letting the agent read real occupancy
+ * instead of inferring it. A report is not a command: the server stores it
+ * last-writer-wins and broadcasts nothing.
+ *
+ * Unlike the focus POST, the reporter is NOT gated on the echo guard — it must
+ * not be. dockview emits onDidLayoutChange on a microtask, so the event lands
+ * AFTER the synchronous withEchoSuppressed window has already closed; a guard
+ * check there would read 0, suppress nothing, and merely look correct.
+ * Convergence comes from CONTENT DEDUPE on both ends instead: this module skips
+ * a POST whose tile list matches the last one the server ACKNOWLEDGED, and the
+ * route treats a report equal to stored state as a no-op. A server-applied
+ * arrangement therefore settles after at most one no-op round-trip rather than
+ * looping. The baseline tracks acknowledgements, not attempts, so a report that
+ * never landed is retried on the next layout change instead of being deduped
+ * away forever — and only ONE report is ever in flight, so the ack being waited
+ * on always names the last write the server applied. Overlapping reports could
+ * be applied in one order and acknowledged in the other, leaving no client-side
+ * rule able to tell which one stuck; the overlap is prevented rather than
+ * arbitrated.
+ *
+ * NO SEQUENCE GUARD, DELIBERATELY. The reflex when acks can race is to stamp
+ * each request and ignore any ack that is not the newest — do not add that here.
+ * It reverses the direction this code fails in. A guard makes the client trust
+ * the NEWEST REQUEST's ack as the server's state; if the requests themselves
+ * were reordered, the server holds the older list while the client believes the
+ * newer one was accepted, and dedupe then suppresses every future report —
+ * stranding the server wrong indefinitely. Trusting the LAST ACK TO ARRIVE
+ * instead can only ever cause a redundant report the server deduplicates,
+ * because response order follows the order writes were applied. Suppression is
+ * the one failure that does not self-heal, so the design always errs toward
+ * re-reporting. Serializing reports (above) makes the race unreachable in the
+ * first place; this rule is what keeps it unreachable if that ever changes.
+ *
+ * Each report is serialized at FLUSH time from the live api, once a settle
+ * debounce has expired — so a rebuild that removes and re-adds panels one at a
+ * time (mode flip, reset, fromJSON restore) reports only the arrangement it
+ * settles on, never an intermediate one. Note the debounce RESTARTS on every
+ * event, unlike dock-workspace's schedulePersist (which fires a fixed delay
+ * after the FIRST event of a burst) — settling on the final state is the whole
+ * point here, so the two are deliberately not the same shape.
+ *
+ * THE BOOT WINDOW is the one case a debounce cannot cover. dock-workspace
+ * restores the stored layout only after an /api/panels round trip, so the gap
+ * between the default arrangement and the real one is a network latency, not a
+ * duration this module could budget for. Reporting on any fixed deadline would,
+ * on a slow fetch, publish a confident "empty workspace" that a hook could read
+ * as fact. So no deadline is what starts the first report: dock-workspace
+ * announces the boot layout as final (setLayoutRestoredHook, called on every
+ * exit of initPersistence including the no-project-key one) and that
+ * announcement is what ARMS reporting. The settle debounce still paces the send
+ * once armed — it simply cannot begin before the announcement lands. Layout
+ * churn before that point is ignored outright. The long deadline that remains is
+ * a backstop for the announcement never arriving.
  *
  * WHY CLOSE USES A CLICK, NOT onDidRemovePanel
  * --------------------------------------------
@@ -52,10 +113,16 @@
  *
  * FALLBACK: with no DockviewApi (dock shell absent / failed to init) every entry
  * point no-ops — the pre-dock rail path in panel-manager still POSTs on its own.
+ * The one exception is the single dock:false capability report initDockSync
+ * sends when the shell never arrives; such a client has no tile order to offer,
+ * and reporting that fact is what keeps the server's freshness fields honest.
+ * Polling continues at a slower cadence afterwards so that conclusion can be
+ * retracted — a shell that merely booted slowly still wires and replaces the
+ * record with a real dock:true report.
  */
 
-import { getDockApi } from './dock-workspace.js';
-import { setPanelFocus } from './panel-commands.js';
+import { getDockApi, setLayoutRestoredHook } from './dock-workspace.js';
+import { setPanelFocus, reportPanelLayout } from './panel-commands.js';
 // dock-iframe.js owns the placeholder lifecycle and resolves panels by these ids;
 // dockPanelBesideActive() below pre-creates a placeholder the adapter then adopts
 // by the same id, so both modules share the single source of truth for them.
@@ -68,6 +135,14 @@ let wired = false;
 /** Bounded retry so late DockviewApi arrival still wires (mirrors the adapter). */
 let wireAttempts = 0;
 
+/** Attempts spent at the fast 150ms cadence (~4.5s) before this client concludes
+ *  it has no dock and says so. */
+const FAST_POLL_ATTEMPTS = 30;
+
+/** Last attempt of the slow 1s cadence that follows — about a further minute of
+ *  watching, so an unusually slow shell can still retract that conclusion. */
+const SLOW_POLL_UNTIL_ATTEMPT = 90;
+
 /**
  * The service panel id behind a dockview panel id, or null when the id is not a
  * service placeholder (the native terminal/workspace panels, or a nullish id).
@@ -78,6 +153,195 @@ export function serviceIdOf(panelId) {
   return typeof panelId === 'string' && panelId.startsWith(PLACEHOLDER_PREFIX)
     ? panelId.slice(PLACEHOLDER_PREFIX.length)
     : null;
+}
+
+/**
+ * The service panels currently occupying dock tiles, in the order an operator
+ * reads them off the screen — the single source of truth for "left-to-right
+ * order" behind the server-side occupancy report (`open_tiles`).
+ *
+ * Read from the SERIALIZED grid (`api.toJSON().grid.root`) rather than from the
+ * live panel/group collections: only the serialized tree carries the spatial
+ * arrangement, and its child arrays are already ordered along each branch's own
+ * axis — a horizontal branch left-to-right, a vertical one top-to-bottom (the
+ * same node shape dock-reconcile.js repairs). A depth-first pre-order walk of
+ * those arrays therefore flattens the grid the way it reads: tiles stacked in a
+ * column are reported top-to-bottom before the walk moves on to what sits
+ * beside them. Pixel geometry is deliberately not reconstructed, so a genuinely
+ * 2D arrangement is reported flattened, not raster-scanned.
+ *
+ * The native terminal/workspace tiles have no server-side panel state and are
+ * dropped; `iframe:` placeholders map back to their rail ids via
+ * {@link serviceIdOf}. Reads the api and mutates nothing — neither the dock nor
+ * the payload it hands back.
+ *
+ * @param {any} api  a DockviewApi, or a nullish value in fallback mode
+ * @returns {string[] | null}  service ids in reading order — `[]` when the dock
+ *   holds no service tile — or null when the layout could not be read at all
+ *   (no api, no dock shell, a toJSON that threw). Callers report nothing on
+ *   null rather than asserting an empty workspace.
+ */
+export function serializeOpenTiles(api) {
+  if (!api || typeof api.toJSON !== 'function') return null;
+  let root;
+  try {
+    root = api.toJSON()?.grid?.root;
+  } catch (err) {
+    console.error('dock-sync: layout serialization failed', err);
+    return null;
+  }
+  if (!root || typeof root !== 'object') return null;
+  // An unrecognized ROOT leaves the whole tree unreadable, which is not the same
+  // as a dock holding no service tile: collapsing it to [] would assert an empty
+  // workspace the layout never described. An unrecognized INNER node is skipped
+  // instead — its siblings still describe real tiles.
+  if (root.type !== 'branch' && root.type !== 'leaf') return null;
+  /** @type {string[]} */
+  const tiles = [];
+  collectTiles(root, tiles, new Set());
+  return tiles;
+}
+
+/**
+ * Depth-first pre-order walk collecting service ids off a serialized grid node.
+ * A leaf's `views` is its tab order (one entry per tile under the one-panel-per-
+ * tile invariant, several only for a layout persisted before it); a branch's
+ * `data` is its children in spatial order. `seen` keeps the result a sequence of
+ * distinct ids even if a malformed tree references one panel from two groups.
+ * @param {any} node
+ * @param {string[]} out
+ * @param {Set<string>} seen
+ */
+function collectTiles(node, out, seen) {
+  if (!node || typeof node !== 'object') return;
+  if (node.type === 'leaf') {
+    const views = node.data?.views;
+    if (!Array.isArray(views)) return;
+    for (const view of views) {
+      const id = serviceIdOf(view);
+      if (id && !seen.has(id)) {
+        seen.add(id);
+        out.push(id);
+      }
+    }
+    return;
+  }
+  if (node.type === 'branch' && Array.isArray(node.data)) {
+    for (const child of node.data) collectTiles(child, out, seen);
+  }
+}
+
+/**
+ * How long the dock must sit still before its occupancy is reported. Long
+ * enough that a multi-step rebuild (mode flip, reset, fromJSON restore) settles
+ * inside one window and reports once, short enough that an agent reading
+ * `open_tiles` right after a human gesture sees the new arrangement.
+ */
+const REPORT_SETTLE_MS = 250;
+
+/**
+ * Outer bound on waiting for dock-workspace's boot-layout announcement. The
+ * announcement covers a failed fetch as well as a successful one, so reaching
+ * this deadline means the hook itself never ran — a dock-workspace that never
+ * got to initPersistence, or a fetch that hangs without resolving or rejecting.
+ * Generous, because reporting the wrong layout is worse than reporting late.
+ */
+const BOOT_DEADLINE_MS = 10000;
+
+/** Pending settle timer for the occupancy report, or null when none is armed.
+ *  @type {ReturnType<typeof setTimeout> | null} */
+let reportHandle = null;
+
+/** False until the boot layout is final. Layout churn before that point — the
+ *  default arrangement, the adapter's first placeholder docks — describes a
+ *  workspace the restore is about to replace, so it must not be reported at
+ *  all. Nothing schedules a report while this is false. */
+let bootReportArmed = false;
+
+/** True while a report is in flight. At most one report is outstanding at a
+ *  time, which is what makes "the ack I am waiting for" and "the last write the
+ *  server applied" the same thing — see the module header. */
+let reportInFlight = false;
+
+/** The last tile list the server ACKNOWLEDGED, serialized for comparison; null
+ *  before the first acknowledgement. The client half of the dedupe contract (see
+ *  the module header). Set from the response rather than optimistically at POST
+ *  time: a report that never landed must not be remembered as sent, or the
+ *  layout it described would be deduped away and never reach the server. A
+ *  deduped no-op (`updated: false`) is still an acknowledgement — the server
+ *  demonstrably holds that list — so it updates the baseline too. */
+let lastReported = /** @type {string | null} */ (null);
+
+/** True once the no-dock capability report has been sent, so the give-up branch
+ *  of initDockSync reports at most once however often it is re-entered. */
+let capabilityReported = false;
+
+/**
+ * Arm (or re-arm) the settle window before the next occupancy report. Every
+ * layout change restarts it, so a burst of changes reports once, from the
+ * arrangement the dock ends up in. Silent until the boot layout is final —
+ * before that there is no arrangement worth describing.
+ */
+function scheduleLayoutReport() {
+  if (!bootReportArmed) return;
+  if (reportHandle != null) clearTimeout(reportHandle);
+  reportHandle = setTimeout(flushLayoutReport, REPORT_SETTLE_MS);
+}
+
+/**
+ * Mark the boot layout final and report it. Called from dock-workspace's
+ * layoutRestored hook — the restore itself, not a guess at how long it takes —
+ * and from the boot deadline if that hook never fires. Safe to call repeatedly:
+ * a later call is just another settled layout to report, which is exactly what a
+ * restore that lands after the deadline is.
+ */
+function armBootReport() {
+  bootReportArmed = true;
+  scheduleLayoutReport();
+}
+
+/**
+ * Serialize the CURRENT occupancy and POST it unless it matches the last report.
+ * Reads the live api at flush time (not at event time), so an intermediate
+ * arrangement is never what gets reported. An unreadable layout — the dock shell
+ * torn down mid-window, a toJSON that threw — reports nothing and leaves the
+ * dedupe baseline untouched: silence is honest, an invented empty workspace is
+ * not.
+ *
+ * One report at a time: a flush that lands while another is in flight re-arms
+ * instead of overlapping it. Two concurrent reports could be applied by the
+ * server in either order and acknowledged in either order, and no client-side
+ * rule can tell which write actually stuck — so the overlap is prevented rather
+ * than reasoned about. The cost is bounded (a settle window of extra latency
+ * while a report is outstanding); the benefit is that the baseline always names
+ * a list the server demonstrably holds.
+ */
+function flushLayoutReport() {
+  reportHandle = null;
+  if (reportInFlight) {
+    scheduleLayoutReport();
+    return;
+  }
+  const tiles = serializeOpenTiles(getDockApi());
+  if (!tiles) return;
+  if (JSON.stringify(tiles) === lastReported) return;
+  reportInFlight = true;
+  void reportPanelLayout(tiles, true)
+    .then((ack) => {
+      if (ack) lastReported = JSON.stringify(ack.tiles ?? tiles);
+    })
+    // reportPanelLayout resolves null on failure rather than rejecting, so this
+    // clause should be unreachable — but nothing enforces that across the module
+    // boundary, and a rejection escaping it would strand reportInFlight and kill
+    // reporting for the rest of the session. Settling the flag unconditionally
+    // costs nothing and keeps a broken contract merely lossy: the baseline is
+    // left untouched, so the next layout change re-reports.
+    .catch((err) => {
+      console.error('dock-sync: layout report failed', err);
+    })
+    .finally(() => {
+      reportInFlight = false;
+    });
 }
 
 /**
@@ -231,6 +495,20 @@ export function dockPanelBesideActive(serviceId, title = serviceId) {
  * after panel-manager inits (dock-workspace runs later in boot), so this polls a
  * bounded number of times, mirroring the dock-iframe adapter's late-api pattern.
  * Idempotent: a no-op once wired or once the shell is confirmed absent.
+ *
+ * Wiring does NOT report immediately. The first report waits for dock-workspace
+ * to announce the boot layout as final (setLayoutRestoredHook), because the
+ * stored-layout restore happens after a network round trip: any deadline short
+ * enough to be useful is one a slow fetch can lose, and losing it means
+ * reporting a layout the restore is about to discard. The deadline that remains
+ * is only a backstop for the hook never firing at all.
+ *
+ * When the retry budget runs out this client sends ONE dock:false capability
+ * report — it has no tile order to offer, but the server still learns a client
+ * is watching, which keeps the freshness fields honest rather than silently
+ * stale. That claim stays RETRACTABLE: polling continues at a slower cadence,
+ * so a dock shell that merely booted slowly still wires and overwrites the
+ * record with a real dock:true report.
  */
 export function initDockSync() {
   if (wired) return;
@@ -242,10 +520,24 @@ export function initDockSync() {
   const root = document.getElementById('dock-root');
   if (api && root) {
     api.onDidActivePanelChange(onActivePanelChange);
+    api.onDidLayoutChange(scheduleLayoutReport);
     root.addEventListener('click', onDockClickCapture, true);
     wired = true;
+    setLayoutRestoredHook(armBootReport);
+    setTimeout(armBootReport, BOOT_DEADLINE_MS);
     return;
   }
-  if (wireAttempts++ > 30) return;  // ~4.5s at 150ms — the shell is genuinely absent
+  const attempt = wireAttempts++;
+  if (attempt > FAST_POLL_ATTEMPTS) {  // ~4.5s at 150ms — the shell is late or absent
+    if (!capabilityReported) {
+      capabilityReported = true;
+      reportPanelLayout([], false);
+    }
+    // Keep watching, slowly and finitely: a shell arriving after the fast budget
+    // must be able to correct the dock:false record, but a page that genuinely
+    // has no dock must not poll forever.
+    if (attempt < SLOW_POLL_UNTIL_ATTEMPT) setTimeout(initDockSync, 1000);
+    return;
+  }
   setTimeout(initDockSync, 150);
 }

--- a/src/osprey/interfaces/web_terminal/static/js/dock-workspace.js
+++ b/src/osprey/interfaces/web_terminal/static/js/dock-workspace.js
@@ -82,6 +82,45 @@ export function setServiceRedock(fn) {
 }
 
 /**
+ * Callback dock-sync registers to learn when the BOOT layout is final — i.e.
+ * when initPersistence has finished deciding what this session starts with,
+ * whether that is a restored expert layout, the synthesized simple layout, or
+ * the plain default because no project key came back.
+ *
+ * It exists because the occupancy reporter must not describe a layout the
+ * restore is about to replace, and the restore's timing is a network round trip,
+ * not a delay anyone can budget for. Registration (rather than dock-sync being
+ * imported here) keeps the dependency one-way: dock-sync already imports this
+ * module, and the reverse import would close a cycle.
+ * @type {(() => void) | null}
+ */
+let layoutRestored = null;
+
+/** Whether the boot layout has already been announced. "Settled" is a LATCHED
+ *  state, not a passing event: initPersistence's fetch routinely resolves before
+ *  dock-sync has finished its own retry-poll wiring, so an announcement made to
+ *  nobody must still be delivered to whoever registers next. Without this a fast
+ *  server — the common case locally — silently costs the reporter its first
+ *  report. */
+let layoutRestoredAlready = false;
+
+/**
+ * Register the boot-layout-settled hook. Fires immediately when the boot layout
+ * has already settled, so registration order does not matter.
+ * @param {() => void} fn
+ */
+export function setLayoutRestoredHook(fn) {
+  layoutRestored = fn;
+  if (layoutRestoredAlready) fn();
+}
+
+/** Announce the boot layout as final, latching it for any later subscriber. */
+function announceLayoutRestored() {
+  layoutRestoredAlready = true;
+  layoutRestored?.();
+}
+
+/**
  * Wrap an already-rendered page subtree as a dockview content renderer. dockview
  * MOVES `element` into its content container (a DOM relocation, not a clone), so
  * every reference terminal.js / chat.js / panel-manager.js already hold into the
@@ -503,6 +542,12 @@ function applyStoredLayout(api) {
  * default, then wire settled-change persistence. onDidLayoutChange is subscribed
  * AFTER the stored layout is applied so the restore itself doesn't trigger a
  * redundant write-back.
+ *
+ * Every exit announces the boot layout as final through the layoutRestored hook
+ * — including the no-project-key early return, where the default arrangement IS
+ * the final one. Missing an exit would leave the occupancy reporter waiting on
+ * its fallback deadline, so the announcement is unconditional rather than tied
+ * to a restore having happened.
  * @param {any} api
  */
 async function initPersistence(api) {
@@ -513,7 +558,10 @@ async function initPersistence(api) {
       projectKey = info.project_key;
     }
   } catch { /* offline / endpoint error — no persistence this session */ }
-  if (!projectKey) return;
+  if (!projectKey) {
+    announceLayoutRestored();
+    return;
+  }
   layoutStorageKey = LAYOUT_KEY_PREFIX + projectKey;
 
   // Boot into the mode the server rendered. In simple mode the locked layout is
@@ -526,6 +574,7 @@ async function initPersistence(api) {
   } else {
     applyStoredLayout(api);
   }
+  announceLayoutRestored();
   api.onDidLayoutChange(schedulePersist);
 }
 

--- a/src/osprey/interfaces/web_terminal/static/js/palette-registry.js
+++ b/src/osprey/interfaces/web_terminal/static/js/palette-registry.js
@@ -52,7 +52,7 @@
  *   actions?: Array<{ label: string, detail?: string, run: () => void }>,
  *   showPanel?: (id: string) => void,
  *   focusPanel?: (id: string) => void,
- *   applyPreset?: (panels: string[]) => void,
+ *   applyPreset?: (name: string) => void,
  *   revealSetting?: (dotKey: string) => void,
  * }} PaletteDeps
  */
@@ -189,27 +189,25 @@ function buildPanels(deps) {
 }
 
 /**
- * Build the Layouts group: one item per preset, whose `run` applies the
- * preset's panel set via the injected `applyPreset`.
+ * Build the Layouts group: one item per preset, whose `run` applies that preset
+ * BY NAME via the injected `applyPreset` — the same one-call path the "+"
+ * menu's Layouts section uses, so both surfaces produce the same arrangement.
  *
  * @param {PaletteDeps} deps
  * @returns {Item[]}
  */
 function buildLayouts(deps) {
   const applyPreset = deps.applyPreset;
-  return safeList(deps.getPresets).map((preset) => {
-    const panels = Array.isArray(preset.panels) ? preset.panels : [];
-    return {
-      group: 'Layouts',
-      label: `Layout: ${preset.name}`,
-      searchText: preset.name,
-      run: () => {
-        if (typeof applyPreset === 'function') {
-          applyPreset(panels);
-        }
-      },
-    };
-  });
+  return safeList(deps.getPresets).map((preset) => ({
+    group: 'Layouts',
+    label: `Layout: ${preset.name}`,
+    searchText: preset.name,
+    run: () => {
+      if (typeof applyPreset === 'function') {
+        applyPreset(preset.name);
+      }
+    },
+  }));
 }
 
 /**

--- a/src/osprey/interfaces/web_terminal/static/js/palette.js
+++ b/src/osprey/interfaces/web_terminal/static/js/palette.js
@@ -50,7 +50,7 @@ import { el } from '/design-system/js/dom.js';
  *   getPresets?: () => Array<{ name: string, panels: string[] }>,
  *   showPanel?: (id: string) => void,
  *   focusPanel?: (id: string) => void,
- *   applyPreset?: (panels: string[]) => void,
+ *   applyPreset?: (name: string) => void,
  *   revealSetting?: (dotKey: string) => void,
  *   actions?: Array<{ label: string, detail?: string, run: () => void }>,
  *   fetchConfig?: () => Promise<any>,

--- a/src/osprey/interfaces/web_terminal/static/js/panel-add-menu.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-add-menu.js
@@ -51,7 +51,7 @@ import { getRailPosition, setRailPosition } from './rail-position.js';
  * @property {(id: string) => void} onShowPanel      - reveal + focus a hidden panel
  * @property {(fields: {id: string, label: string, url: string}) => Promise<RegisterResult>} onRegisterUrl
  * @property {() => {name: string, panels: string[]}[]} getPresets - config-defined layouts, in config order
- * @property {(panels: string[]) => void} onApplyPreset - apply a layout (show members, hide the rest)
+ * @property {(name: string) => void} onApplyPreset  - apply a named layout (those panels open, the rest close)
  */
 
 /**
@@ -151,7 +151,7 @@ export function initPanelAddMenu(opts) {
         // textContent — preset.name is config-supplied JSON (never innerHTML).
         item.textContent = preset.name;
         item.addEventListener('click', () => {
-          opts.onApplyPreset(preset.panels);
+          opts.onApplyPreset(preset.name);
           closeMenu();
         });
         layouts.appendChild(item);

--- a/src/osprey/interfaces/web_terminal/static/js/panel-commands.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-commands.js
@@ -38,6 +38,61 @@ export function setPanelFocus(panelId) {
 }
 
 /**
+ * Report which service tiles this client currently has on screen, in spatial
+ * reading order. A REPORT rather than a command: the server records it as the
+ * workspace's `open_tiles` for the agent to read and broadcasts nothing, so one
+ * operator's tile gestures never rearrange another's workspace. An empty list is
+ * a meaningful report — every service tile closed — so a caller that cannot
+ * determine occupancy must skip the call rather than send `[]`.
+ *
+ * Unlike the fire-and-forget commands above this resolves with the server's
+ * acknowledgement, because the caller's dedupe baseline must track what the
+ * server actually holds: a report the server never received must not be
+ * remembered as sent, or the layout it described would be deduped away forever.
+ * Never rejects — a failed or rejected report resolves null, which callers read
+ * as "baseline unchanged, report again next time".
+ * @param {string[]} tiles  service panel ids, left-to-right
+ * @param {boolean} dock    whether this client has a dock shell; a false report
+ *   carries no meaningful tile order, only the fact that a client is watching
+ * @returns {Promise<{status: string, tiles: string[], dock: boolean,
+ *   updated: boolean} | null>}  the acknowledgement — `updated: false` marks a
+ *   server-side deduped no-op, which is still an acknowledgement — or null when
+ *   the report did not land.
+ */
+export async function reportPanelLayout(tiles, dock) {
+  try {
+    const resp = await fetch(withPrefix('/api/panel-layout'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tiles, dock }),
+    });
+    if (!resp.ok) return null;
+    return await resp.json();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Request a whole-workspace tile arrangement: exactly these service tiles open,
+ * left to right. Fire-and-forget like the commands above — the server validates
+ * the request and broadcasts one panel_arrange frame, and this client applies
+ * the arrangement from that echo just like every other client, so a human
+ * "Layouts" click and an agent arrange_workspace call are one operation.
+ *
+ * Pass exactly one of `tiles` and `preset`; a `preset` is resolved to its
+ * members server-side and additionally prunes rail membership to them.
+ * @param {{tiles?: string[], preset?: string, focus?: string}} request
+ */
+export function arrangePanels(request) {
+  fetch(withPrefix('/api/panel-arrange'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+  }).catch(() => {});
+}
+
+/**
  * Register a runtime URL panel. Returns the outcome so the caller (the "+" menu)
  * can surface the server's rejection reason (registration disabled, host not in
  * the allowlist, SSRF-blocked). The panel_register SSE echo adds the tab on

--- a/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
@@ -28,14 +28,14 @@ import {
   initDockIframeAdapter, focusPanel, hidePanel, concealPanel,
   setKnownServicePanels, setServerVisiblePanels,
 } from './dock-iframe.js';
+import {
+  initPanelPlacement, openPanelBeside, dropPanelAt, applyAgentSwitch, applyArrange,
+} from './panel-placement.js';
 import { createPanelIframe } from './panel-iframe-factory.js';
 import {
   PANELS, TERMINAL_RAIL_ID, TERMINAL_RAIL_LABEL, DEFAULT_PANEL_FALLBACK,
 } from './panel-catalog.js';
-import {
-  initDockSync, withEchoSuppressed, setTileCloseHandler,
-  dockPanelBesideActive, dockPanelAt,
-} from './dock-sync.js';
+import { initDockSync, withEchoSuppressed, setTileCloseHandler } from './dock-sync.js';
 import { initRailDrag, railDragStart, railDragEnd } from './rail-drag.js';
 import { startHealthPolling as startPolling } from './panel-health.js';
 import { openTerminalPanel, closeTerminalPanel } from './dock-workspace.js';
@@ -86,13 +86,21 @@ import {
  * @property {string} [path]
  * @property {'agent'} [source]
  *
+ * @typedef {object} PanelArrangeEvent
+ * @property {'panel_arrange'} type
+ * @property {string[]} tiles      - the service tiles to have open, left to right
+ * @property {string} [focus]      - requested focus target, one of `tiles`
+ * @property {boolean} [prune_rail] - preset path: rail membership becomes exactly `tiles`
+ * @property {'agent'} [source]
+ *
  * @typedef {object} AgentActivityEvent
  * @property {'agent_activity'} type
  * @property {string} tool
  * @property {{ kind: 'panel' | 'channel' | 'run' | 'artifact', panel?: string, detail?: string }} target
  * @property {number} [ts]
  *
- * @typedef {PanelFocusEvent | PanelVisibilityEvent | PanelRegisterEvent | AgentActivityEvent} PanelSSEEvent
+ * @typedef {PanelFocusEvent | PanelVisibilityEvent | PanelRegisterEvent | PanelArrangeEvent
+ *   | AgentActivityEvent} PanelSSEEvent
  */
 
 // ---- State ----
@@ -177,16 +185,32 @@ export async function initPanelManager(panelId) {
   // and agent use. Wires lazily once the dockview shell is up; no-ops without it.
   initDockSync();
 
+  // Hand panel-placement (the tile-geometry half of this module: open-beside,
+  // agent switch, arrange rebuild) live access to the state it places panels
+  // through. Every entry is a closure over this module's private state, so the
+  // placement verbs see the same rail/health/membership the SSE handlers do.
+  initPanelPlacement({
+    isKnown: (id) => !!panelState[id],
+    isHealthy: (id) => !!panelState[id]?.healthy,
+    isMember: (id) => visiblePanels.has(id),
+    members: () => [...visiblePanels],
+    label: labelOf,
+    addMember: ensureRailMembership,
+    dropMember: (id) => { visiblePanels.delete(id); removeEntry(railEl, id); },
+    activate: activateTab,
+    reveal: showPanel,
+    getActive: () => activeTabId,
+    clearActive: clearActivePanel,
+    renderEmpty: renderEmptyState,
+    glow: flashAgentGlow,
+    openTerminal: openTerminalPanel,
+  });
+
   // Rail drag-and-drop: a rail entry dropped on a tile edge opens (or moves)
   // that panel as a new tile at the drop position, then reveals it through the
   // same activate/show tail every other open path uses. Wires lazily like
   // initDockSync; no-ops without a dock shell.
-  initRailDrag({
-    onDropPanel: (id, position) => {
-      dockPanelAt(id, labelOf(id), position);
-      revealOpenedPanel(id);
-    },
-  });
+  initRailDrag({ onDropPanel: dropPanelAt });
 
   // Fetch panel config and filter PANELS before rendering
   let panelConfig = null;
@@ -341,14 +365,25 @@ export async function initPanelManager(panelId) {
   // unchanged behavior). createEventSource also drives the module-level
   // sseState in api.js, but nothing currently reads getConnectionState().sse
   // (only .ws is consumed, by app.js's status dot), so that side effect is
-  // harmless. Three event types are handled:
+  // harmless. These event types are handled:
   //
-  //   panel_focus      {type, panel, url?}      — explicit switch_panel MCP call;
-  //                                               always honor (user asked for it).
+  //   panel_focus      {type, panel, url?}      — explicit switch_panel MCP call
+  //                                               or the echo of a human focus
+  //                                               gesture; always honor. An
+  //                                               agent-tagged frame surfaces
+  //                                               the panel without evicting
+  //                                               anything (applyAgentSwitch);
+  //                                               a human echo takes the tile
+  //                                               over as it always has.
   //   panel_visibility {type, panel, visible}   — show/hide a rail entry; if the
   //                                               active panel is hidden, switch to
   //                                               the next visible+healthy panel or
   //                                               empty state.
+  //   panel_arrange    {type, tiles, focus?, prune_rail?}
+  //                                             — a whole-workspace layout
+  //                                               request: exactly these
+  //                                               service tiles, left to right
+  //                                               (see panel-placement.js).
   //   panel_register   {type, id, label, url, healthEndpoint, path}
   //                                             — add a runtime panel; do NOT
   //                                               auto-activate (URL may not be ready).
@@ -366,30 +401,31 @@ export async function initPanelManager(panelId) {
         const data = /** @type {PanelSSEEvent} */ (raw);
 
         if (data.type === 'panel_focus' && data.panel) {
-          // Agent asked the panel to switch — honor unconditionally. An
-          // explicit switch also ends the simple-UX chat-only suppression,
-          // even when activateTab still refuses (unhealthy panel): the intent
-          // to surface the workspace is clear, so the next health settle may
-          // fill the slot.
+          // A switch — agent or human — honor unconditionally. It also ends the
+          // simple-UX chat-only suppression, even when the activation still
+          // refuses (unhealthy panel): the intent to surface the workspace is
+          // clear, so the next health settle may fill the slot.
           workspaceSuppressed = false;
           if (data.url) navigatePanel(data.panel, data.url);
-          activateTab(data.panel);
-          if (data.source === 'agent') flashAgentGlow(data.panel);
+          // An AGENT switch is polite: focus the panel's own tile, or open one
+          // beside the operator's — never take a tile away (applyAgentSwitch).
+          // Every other frame is the echo of a human gesture (rail click, dock
+          // tab focus) whose takeover semantics are the operator's own choice,
+          // so it keeps the plain activation. The glow runs after the switch so
+          // a just-added entry can flash.
+          if (data.source === 'agent') {
+            applyAgentSwitch(data.panel);
+            flashAgentGlow(data.panel);
+          } else {
+            activateTab(data.panel);
+          }
 
         } else if (data.type === 'panel_visibility' && data.panel) {
           const { panel, visible } = data;
-          // Update the membership set and add/remove the matching rail entry
-          // (membership IS the rail — there is no dimmed in-between state). A
-          // re-added entry is rebuilt cold, so re-apply its live health/enabled
-          // state. The agent glow runs after the add so a just-added entry can
-          // flash.
+          // Update the membership set and add/remove the matching rail entry.
+          // The agent glow runs after the add so a just-added entry can flash.
           if (visible) {
-            visiblePanels.add(panel);
-            const spec = PANELS.find((p) => p.id === panel);
-            if (spec) {
-              addEntry(railEl, { id: spec.id, label: spec.label }, railOptions());
-              applyEntryState(panel);
-            }
+            ensureRailMembership(panel);
           } else {
             visiblePanels.delete(panel);
             removeEntry(railEl, panel);
@@ -430,6 +466,16 @@ export async function initPanelManager(panelId) {
               renderEmptyState('No panels visible');
             }
           }
+
+        } else if (data.type === 'panel_arrange' && Array.isArray(data.tiles)) {
+          // A whole-workspace arrangement (agent arrange_workspace, or a human
+          // "Layouts" click — one server operation, one apply path). Precedence
+          // against the visibility channel above: a hide keeps its existing
+          // meaning everywhere, while an arrange only ADDS membership for the
+          // tiles it lists — except on the preset path, where prune_rail
+          // reproduces today's membership-exclusive semantics. See
+          // panel-placement.js's header for the full split.
+          applyArrange(data);
 
         } else if (data.type === 'panel_register' && data.id) {
           // Seed membership before addPanel so the appended entry is a member
@@ -524,32 +570,6 @@ function labelOf(id) {
 }
 
 /**
- * Shared reveal tail for every "open as a new tile" path (rail ⊞, rail drop):
- * a member panel is focused locally + reported (activateTab no-ops while the
- * panel is unhealthy — the placeholder tile still appears and fills on the
- * next health settle); a non-member is revealed through the same
- * visibility-POST path the "+" menu uses.
- * @param {string} panelId
- */
-function revealOpenedPanel(panelId) {
-  if (visiblePanels.has(panelId)) activateTab(panelId, { userInitiated: true });
-  else showPanel(panelId);
-}
-
-/**
- * Open a panel as a NEW tile beside the active group — the rail ⊞ corner's
- * action. An already-open panel is MOVED beside the active tile (dockPanelAt's
- * move semantics), never duplicated. In simple mode the placement no-ops in
- * dock-sync and the reveal tail takes the single tile over like a rail click.
- * @param {string} panelId
- */
-function openPanelBeside(panelId) {
-  if (panelId === TERMINAL_RAIL_ID) { openTerminalPanel(); return; }
-  dockPanelBesideActive(panelId, labelOf(panelId));
-  revealOpenedPanel(panelId);
-}
-
-/**
  * Destructive full render of the rail: the terminal entry first (the session
  * tile is the workspace's anchor), then every MEMBER service panel in PANELS
  * order — non-members have no entry at all. The terminal entry is enabled
@@ -618,6 +638,21 @@ function applyEntryState(panelId) {
   if (!ps) return;
   if (ps.healthy) setEntryEnabled(railEl, panelId, true);
   if (activeTabId === panelId) setActive(railEl, panelId);
+}
+
+/**
+ * Give a panel its rail entry as a MEMBER: record the membership and append the
+ * entry (membership IS the rail — there is no dimmed in-between state). The
+ * entry is built cold, so its live health/active state is re-applied after the
+ * add. Idempotent: addEntry no-ops for an id that already has an entry.
+ * @param {string} panelId
+ */
+function ensureRailMembership(panelId) {
+  visiblePanels.add(panelId);
+  const spec = PANELS.find((p) => p.id === panelId);
+  if (!spec) return;
+  addEntry(railEl, { id: spec.id, label: spec.label }, railOptions());
+  applyEntryState(panelId);
 }
 
 /**
@@ -908,21 +943,14 @@ export function showPanel(panelId) {
 }
 
 /**
- * Apply a config-defined preset ("Layout") exclusively: show its members, hide
- * every visible non-member, focus the first healthy member locally. Feeds
- * panel-manager's live state into the pure applyPreset() orchestrator; each
- * show/hide rides the same setPanelVisibility POST + SSE echo the "+"/"×" use.
- * focus is a purely-local activateTab (no visibility re-POST for the primary).
- * @param {string[]} panels
+ * Apply a config-defined preset ("Layout") by name — the "+" menu's and the
+ * command palette's Layouts action. One arrange request; the panel_arrange echo
+ * opens exactly the preset's tiles and prunes the rail to its members on every
+ * client, so nothing is applied locally ahead of it.
+ * @param {string} name
  */
-export function applyMenuPreset(panels) {
-  applyPreset(panels, {
-    getVisible: () => visiblePanels,
-    getKnown: () => new Set(PANELS.map(p => p.id)),
-    isHealthy: (id) => !!panelState[id]?.healthy,
-    setVisibility: setPanelVisibility,
-    focus: (id) => activateTab(id, { userInitiated: true }),
-  });
+export function applyMenuPreset(name) {
+  applyPreset(name);
 }
 
 // ---- Panel Navigation ----

--- a/src/osprey/interfaces/web_terminal/static/js/panel-placement.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-placement.js
@@ -1,0 +1,315 @@
+// @ts-check
+/* OSPREY Web Terminal — Panel Placement
+ *
+ * WHERE a panel lands in the workspace. panel-manager.js owns the panel state
+ * machine (health, membership, iframes, SSE dispatch); this module owns the
+ * tile geometry those states are applied onto — the open-beside verb behind the
+ * rail's ⊞ corner and drag-and-drop, the polite agent switch, and the
+ * whole-workspace rebuild a `panel_arrange` frame requests.
+ *
+ * It reaches the dock only through the existing seams: dock-sync's placement
+ * verbs (dockPanelAt / dockPanelBesideActive) and echo guard, dock-iframe's
+ * hidePanel and placeholder-id namespace. Everything it needs from
+ * panel-manager's private state arrives as injected effects registered once at
+ * init ({@link initPanelPlacement}), the same seam pattern the iframe adapter
+ * and the tile-close handler use — so this module holds no panel state of its
+ * own and stays unit-testable through panel-manager's own SSE surface.
+ *
+ * TWO MUTATION CHANNELS (precedence)
+ * ----------------------------------
+ * `panel_visibility` and `panel_arrange` can both touch the same panel, so the
+ * split is deliberate: a visibility HIDE keeps its existing meaning everywhere
+ * (rail removal plus tile close, on every client), while an arrange only ever
+ * ADDS membership for the tiles it lists — except on the preset path, where
+ * `prune_rail` reproduces today's membership-exclusive preset semantics and
+ * non-members leave the rail. An arrange therefore never silently un-shows a
+ * panel the operator added, and a preset click keeps behaving as it always has.
+ *
+ * MODE DEGRADATION
+ * ----------------
+ * The tile rebuild runs only with a dock shell in expert mode. Simple mode has
+ * exactly one service tile by construction, and fallback mode (no dock shell)
+ * has none at all: both skip the rebuild and let the focus step take the single
+ * surface over. Rail MEMBERSHIP is applied in every mode — the launcher rail is
+ * not a dock feature, and a preset must prune it wherever it is clicked.
+ */
+
+import {
+  withEchoSuppressed, dockPanelAt, dockPanelBesideActive, serializeOpenTiles,
+} from './dock-sync.js';
+import { hidePanel, PLACEHOLDER_PREFIX } from './dock-iframe.js';
+import { getDockApi } from './dock-workspace.js';
+import { TERMINAL_RAIL_ID } from './panel-catalog.js';
+
+/**
+ * The panel-manager state and actions this module places panels through. Every
+ * entry is a live closure over panel-manager's private state — never a snapshot.
+ * @typedef {object} PlacementDeps
+ * @property {(id: string) => boolean} isKnown - panel-manager tracks this id (it has panel state)
+ * @property {(id: string) => boolean} isHealthy - the panel can currently fill a tile
+ * @property {(id: string) => boolean} isMember - the panel has rail membership
+ * @property {() => string[]} members - every rail member id
+ * @property {(id: string) => string} label - the panel's dock tab title
+ * @property {(id: string) => void} addMember - apply membership + rail entry LOCALLY (no POST)
+ * @property {(id: string) => void} dropMember - remove membership + rail entry LOCALLY (no POST)
+ * @property {(id: string, options?: {userInitiated?: boolean, auto?: boolean}) => void} activate
+ * @property {(id: string) => void} reveal - reveal a NON-member through the visibility POST path
+ * @property {() => string | null} getActive - the locally surfaced panel id
+ * @property {() => void} clearActive - drop the local active accent/stamp
+ * @property {(message: string) => void} renderEmpty - paint the strand-proof empty pane
+ * @property {(id: string) => void} glow - transient agent glow on a rail entry
+ * @property {() => void} openTerminal - reopen the native terminal tile
+ */
+
+/** @type {PlacementDeps | null} */
+let deps = null;
+
+/**
+ * Register the panel-manager effects every verb here applies through. Called
+ * once from initPanelManager, before any placement can happen.
+ * @param {PlacementDeps} placementDeps
+ */
+export function initPanelPlacement(placementDeps) {
+  deps = placementDeps;
+}
+
+/**
+ * The registered effects, or a hard failure. Placement before init is a wiring
+ * bug, not a runtime condition to degrade around — panel-manager registers the
+ * deps in the same init that mounts the rail.
+ * @returns {PlacementDeps}
+ */
+function ctx() {
+  if (!deps) throw new Error('panel-placement: initPanelPlacement() has not run');
+  return deps;
+}
+
+/**
+ * Whether a service panel currently occupies a dock tile — its placeholder
+ * exists in the grid. False in fallback mode, where there are no tiles at all.
+ * Resolved through the adapter's public placeholder-id namespace, the same way
+ * dock-sync's placement verbs address them.
+ * @param {string} panelId
+ * @returns {boolean}
+ */
+export function hasDockedTile(panelId) {
+  return !!getDockApi()?.getPanel(PLACEHOLDER_PREFIX + panelId);
+}
+
+/**
+ * Whether ANY service panel holds a tile right now — read straight off the live
+ * panel list, not off the serialized layout.
+ *
+ * The polarity matters and is not symmetric with the rebuild's. There, a layout
+ * that cannot be read means "drop nothing" — the safe direction. Here, a false
+ * "no tiles" would send an agent switch down the plain-activation path, whose
+ * placement REPLACES the tile the operator is watching: the one outcome this
+ * verb exists to prevent. Reading the panel list directly removes the question,
+ * since it stays answerable while a layout is mid-rebuild or refuses toJSON.
+ * @returns {boolean}
+ */
+function hasAnyServiceTile() {
+  const panels = getDockApi()?.panels;
+  return (Array.isArray(panels) ? panels : []).some(
+    (/** @type {any} */ p) => typeof p?.id === 'string' && p.id.startsWith(PLACEHOLDER_PREFIX),
+  );
+}
+
+/**
+ * Shared reveal tail for every "open as a new tile" path (rail ⊞, rail drop): a
+ * member panel is focused locally + reported (the activation no-ops while the
+ * panel is unhealthy — the placeholder tile still appears and fills on the next
+ * health settle); a non-member is revealed through the same visibility-POST path
+ * the "+" menu uses.
+ * @param {string} panelId
+ */
+function revealOpenedPanel(panelId) {
+  const c = ctx();
+  if (c.isMember(panelId)) c.activate(panelId, { userInitiated: true });
+  else c.reveal(panelId);
+}
+
+/**
+ * Open a panel as a NEW tile beside the active group — the rail ⊞ corner's
+ * action. An already-open panel is MOVED beside the active tile (dockPanelAt's
+ * move semantics), never duplicated. In simple mode the placement no-ops in
+ * dock-sync and the reveal tail takes the single tile over like a rail click.
+ * @param {string} panelId
+ */
+export function openPanelBeside(panelId) {
+  if (panelId === TERMINAL_RAIL_ID) { ctx().openTerminal(); return; }
+  dockPanelBesideActive(panelId, ctx().label(panelId));
+  revealOpenedPanel(panelId);
+}
+
+/**
+ * Open (or move) a panel at an explicit drop position — the rail's
+ * drag-and-drop landing, the precise half of the open-beside verb.
+ * @param {string} panelId
+ * @param {{referenceGroup?: any, direction: string} | null} position
+ */
+export function dropPanelAt(panelId, position) {
+  dockPanelAt(panelId, ctx().label(panelId), position);
+  revealOpenedPanel(panelId);
+}
+
+/**
+ * Apply an agent switch_panel: bring the panel into view without ever taking a
+ * tile away from the operator. A panel that already holds a tile is simply
+ * focused (no move); one without a tile opens as a NEW tile beside the active
+ * group — the same placement the rail's ⊞ corner uses — so whatever the
+ * operator was watching survives. A non-member gains its rail entry first: the
+ * switch implies membership, and the server's own visibility broadcast then
+ * lands on an already-current rail.
+ *
+ * Both mode degradations fall out of the placement verb rather than a branch
+ * here: dockPanelBesideActive no-ops in simple mode (one service tile by
+ * construction) and in fallback mode (no dock shell), leaving exactly the plain
+ * activation takeover both had before.
+ * @param {string} panelId
+ */
+export function applyAgentSwitch(panelId) {
+  const c = ctx();
+  // Unknown id — a panel dropped from the deployment, or the terminal entry,
+  // which has no panel state. The activation would refuse it, so refuse before
+  // touching membership or the grid.
+  if (!c.isKnown(panelId)) return;
+  if (!c.isMember(panelId)) c.addMember(panelId);
+  // Only a panel that can fill a tile gets one: the activation refuses while
+  // unhealthy, and the tile it never claimed would linger empty. An unhealthy
+  // target stays the no-op it has always been (attention badge intact).
+  //
+  // "Beside" also needs something to be beside. With every service tile retired
+  // the active group is the TERMINAL's, so splitting off it would open the
+  // panel to the terminal's right at a default width — losing the first-tile
+  // rule (left of the terminal at the classic split) that the adapter applies
+  // on a plain activation. Nothing is open to evict in that state either, so
+  // the plain activation below is both correctly anchored and still polite.
+  if (c.isHealthy(panelId) && !hasDockedTile(panelId) && hasAnyServiceTile()) {
+    dockPanelBesideActive(panelId, c.label(panelId));
+  }
+  c.activate(panelId);
+}
+
+/**
+ * Whether the service-tile region can be rebuilt: a dock shell must exist, and
+ * the mode must not be the locked single-tile simple layout.
+ * @returns {boolean}
+ */
+function canRebuildTiles() {
+  return !!getDockApi() && document.documentElement.getAttribute('data-ui-mode') !== 'simple';
+}
+
+/**
+ * Rebuild the service-tile region to exactly `tiles`, left to right.
+ *
+ * Deterministic by construction rather than by diffing: every docked service
+ * tile the arrangement does not list is dropped, then each requested tile is
+ * docked in order — the first against the grid's left edge (so services sit
+ * left of the terminal, as they always open), each next one to the RIGHT of the
+ * one before it. dockPanelAt MOVES an already-docked placeholder rather than
+ * duplicating it, so a tile that was already open simply slides into position.
+ * Prior service-tile geometry (sash positions) is deliberately discarded — an
+ * arrangement is a request for a layout, not for the operator's pixel widths.
+ *
+ * The whole rebuild runs inside the echo guard: every add/remove drives
+ * dockview's active-panel change, and each one is a server-applied echo that
+ * must not POST focus back. Surfacing each tile afterwards fills the
+ * placeholders with their overlay iframes — a docked tile whose panel was never
+ * activated has no iframe to show.
+ * @param {string[]} tiles
+ */
+function rebuildTiles(tiles) {
+  const c = ctx();
+  const api = getDockApi();
+  const wanted = new Set(tiles);
+  // A layout the serializer cannot read is not the same as an empty workspace:
+  // drop nothing rather than assert tiles that may still be there.
+  const open = serializeOpenTiles(api) ?? [];
+  withEchoSuppressed(() => {
+    for (const id of open) if (!wanted.has(id)) hidePanel(id);
+    /** @type {string | null} */
+    let prev = null;
+    for (const id of tiles) {
+      // Never OPEN a tile for a panel that cannot fill it — the same rule
+      // applyAgentSwitch applies. The activation below refuses while unhealthy,
+      // so the tile would stay empty for as long as anything else holds focus,
+      // and nothing would come back for it. Membership is applied regardless,
+      // so the panel stays one rail click away. A tile that already exists is
+      // still positioned: it is filled (its iframe outlives a health dip), and
+      // leaving it out of the walk would strand it outside the requested order.
+      if (!c.isHealthy(id) && !hasDockedTile(id)) continue;
+      const group = prev ? api.getPanel(PLACEHOLDER_PREFIX + prev)?.group : null;
+      dockPanelAt(id, c.label(id), group
+        ? { referenceGroup: group, direction: 'right' }
+        : { direction: 'left' });
+      // Advance only for a tile that actually landed: a skipped panel — or a
+      // placement that threw — must not become the anchor the next one splits
+      // against, which is what could push a tile to the terminal's right.
+      if (hasDockedTile(id)) prev = id;
+    }
+  });
+  for (const id of tiles) c.activate(id, { auto: true });
+}
+
+/**
+ * Apply a `panel_arrange` frame: the declarative end state an `arrange_workspace`
+ * call (or a preset click, which is the same server operation) asked for.
+ *
+ * Order matters. Membership first, so a listed non-member already has its rail
+ * entry when its tile appears and a pruned panel's entry is gone before the
+ * region is rebuilt. Then the tile rebuild, where the dock shell allows one.
+ * Focus last, by the shipped preset rule: the requested panel when it is
+ * healthy, else the first healthy listed tile, else no focus change at all —
+ * which falls out on its own, since an activation refuses an unhealthy panel.
+ *
+ * @param {{tiles?: string[], focus?: string, prune_rail?: boolean, source?: string}} frame
+ */
+export function applyArrange({ tiles = [], focus, prune_rail: pruneRail = false, source }) {
+  const c = ctx();
+  // The server validates against the same inventory; filtering again keeps a
+  // stale client (a panel dropped from the deployment) from arranging a ghost.
+  const wanted = tiles.filter((id) => c.isKnown(id));
+  const wantedSet = new Set(wanted);
+
+  // MEMBERSHIP — every mode. A preset prunes to its members (today's exclusive
+  // semantics); a plain tiles request only adds. A pruned panel loses its tile
+  // here too: in simple and fallback mode the rebuild below never runs, and its
+  // surface must not outlive its rail entry.
+  if (pruneRail) {
+    for (const id of c.members()) {
+      if (wantedSet.has(id)) continue;
+      c.dropMember(id);
+      withEchoSuppressed(() => hidePanel(id));
+    }
+  }
+  for (const id of wanted) if (!c.isMember(id)) c.addMember(id);
+
+  if (canRebuildTiles()) rebuildTiles(wanted);
+
+  // FOCUS — healthy-fallback. {auto: true} keeps the health guard and the
+  // membership guard; both are satisfied for a target picked here, so it only
+  // documents that this is an applied policy, not a human's explicit pick.
+  const active = c.getActive();
+  const target = focus && c.isHealthy(focus) ? focus : wanted.find((id) => c.isHealthy(id));
+  if (target) {
+    c.activate(target, { auto: true });
+  } else if (active && !wantedSet.has(active)) {
+    // Nothing listed can be surfaced and the panel that held the view is not in
+    // the arrangement, so the accent is genuinely stale and always clears.
+    //
+    // The empty PANE is a separate question, and the honest one to ask is
+    // OCCUPANCY, not focusability: the rebuild above deliberately keeps an
+    // unhealthy panel's EXISTING tile (it is still filled — the overlay iframe
+    // outlives a health dip), so an arrangement listing only such a panel would
+    // otherwise paint "No panels visible" across a workspace that visibly still
+    // holds one. Occupancy is read from the live panel list, so a layout
+    // mid-rebuild still reports the tiles it holds; fallback mode has no tiles
+    // by construction and does paint, which is the case where a stale surface
+    // would otherwise linger behind the cleared accent.
+    c.clearActive();
+    if (!hasAnyServiceTile()) c.renderEmpty('No panels visible');
+  }
+
+  if (source === 'agent') for (const id of wanted) c.glow(id);
+}

--- a/src/osprey/interfaces/web_terminal/static/js/panel-presets.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-presets.js
@@ -2,18 +2,24 @@
 /* OSPREY Web Terminal — Panel Presets ("Layouts")
  *
  * A preset is a config-defined, named set of panel ids a human applies in one
- * click from the "+" popover's "Layouts" section. Applying a preset is
- * EXCLUSIVE: show exactly the preset's members, hide every currently-visible
- * non-member ("those panels open and the rest close").
+ * click from the "+" popover's "Layouts" section (or from the command palette).
+ * Applying a preset is EXCLUSIVE: exactly the preset's members end up open, and
+ * every non-member leaves the rail ("those panels open and the rest close").
  *
- * This is a thin layer over the existing panel-visibility path — each show/hide
- * is the same setPanelVisibility() POST the "×"/"+" controls already use, so a
- * preset click and an agent show/hide call are indistinguishable downstream.
- * There is no parallel state system: the canonical visible set still lives on
- * the server and is broadcast over the panel_visibility SSE echo.
+ * The click is a one-line request: the preset NAME goes to /api/panel-arrange,
+ * the server resolves its members from `web.presets` and broadcasts a single
+ * panel_arrange frame, and every client — this one included — applies the
+ * arrangement from that echo (panel-placement.js). A human "Layouts" click and
+ * an agent `arrange_workspace(preset=...)` call are therefore literally the same
+ * server operation, with no local orchestration to drift from it.
+ *
+ * {@link computePresetDiff} stays here as the executable statement of those
+ * exclusive semantics — the resolution the route performs mirrors its fail-safe
+ * filtering, and its tests are where that contract is pinned.
  */
 
 import { initPanelAddMenu } from './panel-add-menu.js';
+import { arrangePanels } from './panel-commands.js';
 
 /**
  * @typedef {object} PresetDiff
@@ -26,9 +32,16 @@ import { initPanelAddMenu } from './panel-add-menu.js';
  * Compute the exclusive show/hide diff for applying a preset.
  *
  * Members are first filtered to knownSet (enabled built-ins + custom ids) so a
- * typo'd or disabled id is skipped fail-safe. If no member survives filtering,
- * ``focus`` is null and {@link applyPreset} no-ops — never strand the user on a
- * blank "No panels visible" tabset.
+ * typo'd or disabled id is skipped fail-safe; a preset where no member survives
+ * that filtering reports `focus: null`.
+ *
+ * That last case is ENFORCED server-side, not here: routes/panels.py's
+ * `_resolve_preset_tiles` applies the same filtering and rejects an empty
+ * result with a 422 naming the valid ids, so the arrangement is never
+ * broadcast. Since {@link applyPreset} is fire-and-forget the rejection is
+ * dropped silently, which lands on the intended fail-safe — an inapplicable
+ * preset leaves the workspace exactly as it was, rather than stranding the
+ * operator on a blank one.
  *
  * @param {string[]} members - the preset's member panel ids, in config order
  * @param {Set<string>} visibleSet - currently-visible panel ids
@@ -47,35 +60,18 @@ export function computePresetDiff(members, visibleSet, knownSet) {
 }
 
 /**
- * @typedef {object} ApplyPresetDeps
- * @property {() => Set<string>} getVisible - current visible-panel id set
- * @property {() => Set<string>} getKnown   - all known panel id set
- * @property {(id: string) => boolean} isHealthy - whether a panel can be focused (loaded/reachable)
- * @property {(id: string, visible: boolean) => void} setVisibility - the visibility POST helper
- * @property {(id: string) => void} focus   - focus a panel LOCALLY (no visibility POST)
- */
-
-/**
- * Apply a preset EXCLUSIVELY: show its members, hide every visible non-member.
+ * Apply a config-defined preset by NAME: one arrange request, applied on every
+ * client by the panel_arrange handler.
  *
- * Ordering avoids a transient all-hidden flash: show every member first, then
- * focus LOCALLY (not waiting for the SSE echo), then hide the non-members. The
- * focus target is the preset's primary member when it is healthy, else the first
- * healthy member — focusing an unhealthy panel is a no-op, so an offline primary
- * would otherwise strand focus on the outgoing panel. No-op entirely when no
- * member is known (empty guard).
- *
- * @param {string[]} members
- * @param {ApplyPresetDeps} deps
+ * Nothing is orchestrated locally. The server resolves the preset's members
+ * (filtered fail-safe to known ids, as {@link computePresetDiff} describes),
+ * prunes rail membership to them, and broadcasts the arrangement; the echo then
+ * opens exactly those tiles and focuses the first healthy one — the same focus
+ * rule this module used to apply by hand, now applied once for everyone.
+ * @param {string} name  a `web.presets` entry name
  */
-export function applyPreset(members, { getVisible, getKnown, isHealthy, setVisibility, focus }) {
-  const known = getKnown();
-  const { toShow, toHide, focus: primary } = computePresetDiff(members, getVisible(), known);
-  if (primary === null) return;
-  for (const id of toShow) setVisibility(id, true);
-  const target = isHealthy(primary) ? primary : members.find((id) => known.has(id) && isHealthy(id));
-  if (target) focus(target);
-  for (const id of toHide) setVisibility(id, false);
+export function applyPreset(name) {
+  arrangePanels({ preset: name });
 }
 
 /**
@@ -85,7 +81,7 @@ export function applyPreset(members, { getVisible, getKnown, isHealthy, setVisib
  * @property {(id: string) => void} onShowPanel - reveal + focus a hidden panel
  * @property {(fields: {id: string, label: string, url: string}) => Promise<{ok: boolean, error?: string}>} onRegisterUrl
  * @property {() => {name: string, panels: string[]}[]} getPresets - config-defined layouts, in config order
- * @property {(panels: string[]) => void} onApplyPreset - apply a layout exclusively
+ * @property {(name: string) => void} onApplyPreset - apply a named layout exclusively
  */
 
 /**

--- a/src/osprey/mcp_server/http.py
+++ b/src/osprey/mcp_server/http.py
@@ -126,6 +126,50 @@ def _post_json_with_response(url: str, payload: dict, *, timeout: int = 3) -> tu
         return exc.code, body
 
 
+def fetch_panels(timeout: int = 3) -> dict | None:
+    """Read the Web Terminal's panel inventory from ``GET /api/panels``.
+
+    The read counterpart of the ``notify_*`` helpers, and the one place MCP
+    tools go for live panel state: rail membership (``visible``), the active
+    panel, the configured presets, and the layout-report fields ``open_tiles``,
+    ``open_tiles_age_s`` and ``open_tiles_dock`` that say what is actually on
+    screen and how stale that knowledge is.
+
+    The three layout-report fields carry three distinct states, and a caller
+    must not collapse them: all-``null`` means no client has ever reported;
+    ``open_tiles: null`` with a numeric age and ``open_tiles_dock: false``
+    means a client is watching but runs without the dock shell and cannot
+    report tile order; a list (including ``[]``, a genuinely empty workspace)
+    with ``open_tiles_dock: true`` is a real occupancy report.
+
+    .. warning::
+        This performs a **blocking** HTTP call (bounded by ``timeout``).
+        Async tools MUST call it via ``await anyio.to_thread.run_sync(...)``
+        rather than inline, which would stall the event loop.
+
+    Args:
+        timeout: Socket timeout in seconds.
+
+    Returns:
+        The parsed JSON payload, or ``None`` when the web terminal is
+        unreachable (CLI-only mode) or answered with something other than a
+        JSON object — callers decide how to surface that.  Read individual
+        keys with ``.get()``; servers predating the layout-report feature omit
+        the three fields entirely.
+    """
+    import json as _json
+    import urllib.request
+
+    base = web_terminal_url()
+    try:
+        with urllib.request.urlopen(f"{base}/api/panels", timeout=timeout) as resp:
+            data = _json.loads(resp.read())
+    except Exception as exc:
+        logger.warning("panel fetch failed (web terminal unreachable): %s", exc)
+        return None
+    return data if isinstance(data, dict) else None
+
+
 def notify_panel_visibility(panel: str, visible: bool) -> None:
     """Fire-and-forget POST to show or hide a panel in the Web Terminal.
 
@@ -195,6 +239,69 @@ def notify_panel_register(
         return {"ok": True, "status": 200, "data": body}
     detail = body.get("detail", "") if isinstance(body, dict) else str(body)
     return {"ok": False, "status": status, "detail": detail}
+
+
+def notify_panel_arrange(
+    tiles: list[str] | None = None,
+    preset: str | None = None,
+    focus: str | None = None,
+) -> dict:
+    """Request a workspace tile arrangement and return the server's verdict.
+
+    Like :func:`notify_panel_register`, and unlike the fire-and-forget
+    ``notify_*`` helpers, this captures the real HTTP response: the arrange
+    route validates the tile ids, the preset name and the focus target
+    server-side, so a rejection carries a detail string the calling tool must
+    show the agent rather than swallow.  ``source: "agent"`` is always sent so
+    the UI can flash the agent glow on the affected rail entries.
+
+    Exactly one of ``tiles`` and ``preset`` is expected.  Supplying both or
+    neither is left to the route to reject, so the agent sees one authoritative
+    validation message instead of two divergent ones.
+
+    Args:
+        tiles: Panel ids to leave open, in left-to-right order.
+        preset: Name of a configured layout (``web.presets``) to apply instead
+            of an explicit tile list.
+        focus: Optional panel to focus; the route requires it to be one of the
+            resulting tiles.  Omitted from the body when ``None``.
+
+    Returns:
+        A dict with the following keys:
+
+        * ``ok`` (bool) — ``True`` on HTTP 200, ``False`` otherwise.
+        * ``status`` (int | None) — HTTP status code, or ``None`` when the web
+          terminal was unreachable.
+        * ``data`` (dict) — Parsed response body on success (``ok=True`` only):
+          the applied ``tiles``, ``focus``, ``preset`` and ``prune_rail``.
+        * ``detail`` (str) — Rejection text (``ok=False`` only): the server's
+          ``"detail"``, or ``"Web Terminal is not running."`` when unreachable.
+          Always text — FastAPI's own body-validation 422s carry a list of
+          error dicts, which is stringified here.
+    """
+    base = web_terminal_url()
+    payload: dict = {"source": "agent"}
+    if tiles is not None:
+        payload["tiles"] = tiles
+    if preset is not None:
+        payload["preset"] = preset
+    if focus is not None:
+        payload["focus"] = focus
+
+    try:
+        status, body = _post_json_with_response(f"{base}/api/panel-arrange", payload, timeout=5)
+    except Exception as exc:
+        logger.warning("panel arrange POST failed (web terminal unreachable): %s", exc)
+        return {"ok": False, "status": None, "detail": "Web Terminal is not running."}
+
+    if status == 200:
+        return {"ok": True, "status": 200, "data": body}
+    detail = body.get("detail", "") if isinstance(body, dict) else body
+    return {
+        "ok": False,
+        "status": status,
+        "detail": detail if isinstance(detail, str) else str(detail),
+    }
 
 
 def notify_panel_focus(panel_id: str, url: str | None = None) -> None:

--- a/src/osprey/mcp_server/workspace/tools/panel_tools.py
+++ b/src/osprey/mcp_server/workspace/tools/panel_tools.py
@@ -1,73 +1,80 @@
-"""MCP tools: list_panels, show_panel, hide_panel, register_panel, switch_panel.
+"""MCP tools: list_panels, show_panel, hide_panel, register_panel, switch_panel,
+arrange_workspace.
 
-list_panels returns the panels available in the Web Terminal together with
-their visibility and active state.
-show_panel / hide_panel toggle a panel's visibility flag.
+list_panels returns the panels available in the Web Terminal, their launcher-rail
+membership, and the tiles a browser last reported as being on screen.
+show_panel / hide_panel add and remove a panel's launcher-rail entry.
 register_panel dynamically registers a new panel (requires deployment opt-in).
-switch_panel directs the Web Terminal to activate a specific panel tab.
+switch_panel brings a panel into the user's view; in the dock workspace it never
+evicts an open tile.
+arrange_workspace applies a whole-workspace tile layout in one declarative call.
 """
 
+import functools
 import json
-import logging
 
+import anyio
+
+from osprey.mcp_server.errors import make_error
 from osprey.mcp_server.http import (
+    fetch_panels,
+    notify_panel_arrange,
     notify_panel_focus,
     notify_panel_register,
     notify_panel_visibility,
-    web_terminal_url,
 )
 from osprey.mcp_server.workspace.server import mcp
-
-logger = logging.getLogger("osprey.mcp_server.tools.panel")
-
-
-def _fetch_panels(base: str) -> dict | None:
-    """Fetch and parse ``GET /api/panels`` from the Web Terminal.
-
-    Single source of truth for the panel-inventory fetch shared by
-    :func:`list_panels` and :func:`_fetch_known_panel_ids`.
-
-    Returns:
-        The parsed JSON payload, or ``None`` when the web terminal is
-        unreachable (the caller decides how to surface that).
-    """
-    import urllib.request
-
-    try:
-        with urllib.request.urlopen(f"{base}/api/panels", timeout=3) as resp:
-            return json.loads(resp.read())
-    except Exception as exc:
-        logger.warning("panel fetch: web terminal unreachable: %s", exc)
-        return None
 
 
 @mcp.tool()
 async def list_panels() -> str:
-    """List the panels available in the Web Terminal.
+    """List the panels available in the Web Terminal, and what is on screen.
 
-    Returns the enabled built-in panels (e.g. artifacts, ariel,
-    channel-finder, lattice, okf, events) and any custom panels defined in
-    config.yml, together with their current visibility state and the
-    currently active panel.
+    Two different things, easy to confuse:
 
-    The current panel inventory (ids, labels, visibility, active tab) is
-    provided in your context at session start.  Call this tool to refresh
-    the live state (e.g. after visibility changes) or when the inventory
-    is not present.  Panel IDs vary between deployments and include custom
-    panels defined in config.yml.
+    - ``visible`` — the panel has an entry in the **launcher rail**, so the
+      operator can open it in one click.  It says nothing about whether the
+      panel is on screen right now.
+    - ``open_tiles`` — the service tiles **actually on screen**, in
+      left-to-right reading order.  This is what the operator is looking at.
+
+    Covers the enabled built-in panels (e.g. artifacts, ariel, channel-finder,
+    lattice, okf, events) and any custom panels defined in config.yml.  The
+    inventory is provided in your context at session start; call this tool to
+    refresh the live state, or when you need to know what is on screen before
+    rearranging it.  Panel IDs vary between deployments — do not guess them.
+
+    How far to trust ``open_tiles``: it is whatever a browser last reported,
+    and three cases read differently.
+
+    - A list with ``open_tiles_dock: true`` is a real report — including an
+      empty list, which means the operator closed every service tile.
+    - ``open_tiles: null`` with ``open_tiles_dock: false`` means someone is
+      watching but their client has no dock shell and cannot report tile
+      order: occupancy is unknown, not empty.
+    - ``open_tiles_dock: null`` (with a null age) means no client has ever
+      reported — nobody is watching.
+
+    ``open_tiles_age_s`` counts seconds since the arrangement last *changed*,
+    so a large age means either that the operator has not moved a tile in a
+    while or that their browser is gone; the two are indistinguishable from
+    here.  Treat an old report as a hint, not as fact.
+
+    To honor a request like "set up for machine setup", look up the named
+    layout in ``presets`` and apply it with ``arrange_workspace(preset=...)``
+    — the same operation a human's "Layouts" click performs.
 
     Returns:
-        JSON with ``status``, ``active`` (id of the currently visible panel,
-        or null), ``panels`` list, and ``presets`` (config-defined layouts —
-        each ``{name, panels: [id, ...]}``; empty unless the deployment defines
-        any).  Each panel entry has ``id``, ``label``, and ``visible`` (bool —
-        whether the tab is shown in the tab bar).  To honor a request like "set
-        up for machine setup," look up the named preset and compose the result
-        with ``show_panel``/``hide_panel`` — the same primitive a human's click
-        resolves to.
+        JSON with ``status``, ``active`` (the last focus the server recorded —
+        an operator's tab click, a ``switch_panel``, or the focus an arrange
+        resolved to; it is an intent, so a client that could not honor it may
+        be showing something else), ``panels``, ``open_tiles``,
+        ``open_tiles_age_s``,
+        ``open_tiles_dock``, and ``presets`` (config-defined layouts — each
+        ``{name, panels: [id, ...]}``; empty unless the deployment defines
+        any).  Each panel entry has ``id``, ``label`` and ``visible``.
     """
-    base = web_terminal_url()
-    data = _fetch_panels(base)
+    data = await anyio.to_thread.run_sync(fetch_panels)
     if data is None:
         return json.dumps(
             {
@@ -103,17 +110,20 @@ async def list_panels() -> str:
             "status": "success",
             "active": data.get("active"),
             "panels": panels,
+            "open_tiles": data.get("open_tiles"),
+            "open_tiles_age_s": data.get("open_tiles_age_s"),
+            "open_tiles_dock": data.get("open_tiles_dock"),
             "presets": data.get("presets", []),
         }
     )
 
 
-def _fetch_known_panel_ids(base: str) -> set[str] | None:
+def _fetch_known_panel_ids() -> set[str] | None:
     """Fetch /api/panels and return the set of known panel ids.
 
     Returns None when the web terminal is unreachable.
     """
-    data = _fetch_panels(base)
+    data = fetch_panels()
     if data is None:
         return None
 
@@ -124,15 +134,17 @@ def _fetch_known_panel_ids(base: str) -> set[str] | None:
 
 
 def _set_panel_visibility(panel_id: str, visible: bool) -> str:
-    """Validate ``panel_id`` against the live inventory, then toggle its tab.
+    """Validate ``panel_id`` against the live inventory, then toggle its rail entry.
 
     Shared by :func:`show_panel` and :func:`hide_panel`, which differ only in the
     ``visible`` flag.  Returns the JSON string those tools hand back to the agent:
     a structured error when the web terminal is unreachable or the id is unknown,
     otherwise a success payload echoing the new ``visible`` state.
+
+    Blocking: it makes two HTTP calls, so async callers run it in a worker
+    thread rather than inline.
     """
-    base = web_terminal_url()
-    known = _fetch_known_panel_ids(base)
+    known = _fetch_known_panel_ids()
     if known is None:
         return json.dumps(
             {
@@ -155,12 +167,20 @@ def _set_panel_visibility(panel_id: str, visible: bool) -> str:
 
 @mcp.tool()
 async def show_panel(panel_id: str) -> str:
-    """Make a panel visible in the Web Terminal tab bar.
+    """Add a panel to the Web Terminal's launcher rail.
 
-    Use this when the user asks to show, reveal, or enable a panel tab.
-    In the Simple web UI, showing a panel while the page is chat-only also
-    brings up the workspace column on that panel — use ``show_panel``
-    after producing an artifact so the operator can see it.
+    This changes rail membership only.  In the expert (dock) UX it makes the
+    panel available to launch — it does NOT put the panel on screen.  To
+    surface a panel for the operator use ``switch_panel``; to lay several
+    tiles out at once use ``arrange_workspace``.
+
+    Use this when the user asks to make a panel available, add it back to
+    the rail, or re-enable one they hid earlier.
+
+    The Simple web UI has the same rail, but a single locked workspace slot
+    instead of a multi-tile dock.  There, showing a panel while the page is
+    chat-only also brings up the workspace column, on that panel when the slot
+    is still empty.
 
     Panel IDs are provided in your context at session start; call
     ``list_panels`` to refresh the live state if needed.  Do NOT guess
@@ -170,16 +190,24 @@ async def show_panel(panel_id: str) -> str:
         panel_id: Panel identifier (e.g. 'artifacts', 'ariel', 'lattice').
 
     Returns:
-        JSON with status confirmation and the updated ``visible`` state.
+        JSON with status confirmation and the updated ``visible`` state
+        (rail membership).
     """
-    return _set_panel_visibility(panel_id, True)
+    return await anyio.to_thread.run_sync(_set_panel_visibility, panel_id, True)
 
 
 @mcp.tool()
 async def hide_panel(panel_id: str) -> str:
-    """Hide a panel from the Web Terminal tab bar.
+    """Remove a panel from the launcher rail and from the screen.
 
-    Use this when the user asks to hide, remove, or collapse a panel tab.
+    The subtractive single-panel verb: it removes the panel's rail entry and
+    closes its tile on every connected client.  (``arrange_workspace`` with a
+    preset also prunes rail membership, but for a whole layout at once.)  Use
+    this when the user asks to hide, remove, or get rid of a panel.
+
+    To clear the screen while keeping panels available to launch, use
+    ``arrange_workspace`` with the tiles that should stay open — that leaves
+    rail membership intact.
 
     Panel IDs are provided in your context at session start; call
     ``list_panels`` to refresh the live state if needed.  Do NOT guess
@@ -189,9 +217,10 @@ async def hide_panel(panel_id: str) -> str:
         panel_id: Panel identifier (e.g. 'artifacts', 'ariel', 'lattice').
 
     Returns:
-        JSON with status confirmation and the updated ``visible`` state.
+        JSON with status confirmation and the updated ``visible`` state
+        (rail membership).
     """
-    return _set_panel_visibility(panel_id, False)
+    return await anyio.to_thread.run_sync(_set_panel_visibility, panel_id, False)
 
 
 @mcp.tool()
@@ -205,7 +234,9 @@ async def register_panel(
     """Register a new panel with the Web Terminal dynamically.
 
     Use this to add a custom panel (e.g. a Grafana dashboard or local web
-    service) at runtime without restarting OSPREY.
+    service) at runtime without restarting OSPREY.  The new panel joins the
+    launcher rail; it is not opened on screen — follow with ``switch_panel``
+    once its upstream is ready.
 
     The current panel inventory is available in your context at session start;
     call ``list_panels`` to refresh if needed before registering a new panel.
@@ -216,8 +247,8 @@ async def register_panel(
     the operator can update the configuration.
 
     Args:
-        panel_id: Unique panel identifier (used as the tab key).
-        label: Human-readable panel name shown in the UI tab bar.
+        panel_id: Unique panel identifier (used as the rail-entry key).
+        label: Human-readable panel name shown on the launcher rail.
         url: Upstream URL the Web Terminal will proxy or embed.
         path: Sub-path to open inside *url* on first load (default ``"/"``).
         health_endpoint: Optional URL polled to determine panel health.
@@ -227,7 +258,9 @@ async def register_panel(
         JSON with status and the registered panel URL on success, or a
         structured error describing why registration was rejected.
     """
-    result = notify_panel_register(panel_id, label, url, path, health_endpoint)
+    result = await anyio.to_thread.run_sync(
+        notify_panel_register, panel_id, label, url, path, health_endpoint
+    )
     if result["ok"]:
         return json.dumps(
             {
@@ -258,10 +291,30 @@ async def register_panel(
 
 @mcp.tool()
 async def switch_panel(panel_id: str, url: str | None = None) -> str:
-    """Switch the Web Terminal to show a specific panel tab.
+    """Bring a panel into the user's view.
 
-    Use this when the user asks to open, show, or switch to a panel.
-    Also useful after producing content relevant to a particular panel.
+    This is the "look at this" verb: use it when the user asks to open, show,
+    or go to a panel, and after producing content the operator should see
+    (a new artifact, a drafted plan, a lattice view).
+
+    In the expert (dock) UX the panel is surfaced additively — an open tile is
+    never evicted:
+
+    - the panel's tile is already on screen → it is focused;
+    - the panel is in the launcher rail but has no tile → a tile opens
+      *beside* the one the operator is currently on;
+    - the panel is not in the rail → it is added to the rail, then opened
+      beside.
+
+    In the Simple web UI there is a single workspace slot, so the panel takes
+    it over (and the workspace column appears if the page was chat-only).
+
+    A panel whose backend is unhealthy does not surface: nothing opens and
+    focus is unchanged.
+
+    ``switch_panel`` surfaces one panel.  For an explicit multi-tile end state
+    ("lattice next to artifacts", "set up for injection") use
+    ``arrange_workspace`` instead.
 
     Panel IDs are provided in your context at session start; call
     ``list_panels`` to refresh the live state if needed.  Do NOT guess
@@ -270,10 +323,96 @@ async def switch_panel(panel_id: str, url: str | None = None) -> str:
     Args:
         panel_id: Panel identifier returned by list_panels (e.g.
             'artifacts', 'events', 'ariel', 'lattice', etc.).
-        url: Optional URL to navigate the panel iframe to.
+        url: Optional URL to navigate the panel iframe to before surfacing it.
 
     Returns:
         JSON with status confirmation.
     """
-    notify_panel_focus(panel_id, url=url)
+    await anyio.to_thread.run_sync(functools.partial(notify_panel_focus, panel_id, url=url))
     return json.dumps({"status": "success", "panel": panel_id})
+
+
+@mcp.tool()
+async def arrange_workspace(
+    tiles: list[str] | None = None,
+    focus: str | None = None,
+    preset: str | None = None,
+) -> str:
+    """Lay out the whole workspace: exactly these tiles on screen, in this order.
+
+    Use this when the user describes an arrangement rather than a single panel
+    — "put lattice next to artifacts", "just the orbit tools", "set up for
+    injection".  For surfacing one panel, use ``switch_panel`` instead.
+
+    This is a declarative end state, not a set of steps.  After it is applied:
+
+    - exactly the listed panels have a tile, left to right in the order given;
+    - panels not listed have their tiles closed; with ``tiles`` they **keep**
+      their launcher-rail entry so the operator can reopen them, while a
+      ``preset`` also drops non-members from the rail;
+    - listed panels that were not in the rail are added to it;
+    - the terminal tile is never moved, closed, or reordered.
+
+    Pass either ``tiles`` or ``preset``, never both.  A ``preset`` names a
+    layout from the deployment's config (``list_panels`` reports the available
+    ones); pruning the rail to its members is exactly what an operator gets
+    from clicking that layout in "Layouts".
+
+    Focus is applied with a health fallback in the browser: the requested panel
+    if it is healthy, otherwise the first healthy tile in the list, otherwise
+    focus is left where it is — unless the arrangement closed the focused tile,
+    in which case nothing is focused.  Health is only observable client-side,
+    so the response echoes the focus that was *requested*, which may not be the
+    one the operator ends up on.
+
+    Args:
+        tiles: Panel ids to leave open, in left-to-right order.  Must name at
+            least one panel — an arrangement never empties the workspace.
+        focus: Optional panel to focus; must be one of the resulting tiles.
+        preset: Name of a configured layout to apply instead of ``tiles``.
+
+    Returns:
+        JSON with ``status``, the applied ``tiles`` and requested ``focus``,
+        ``preset`` when one was applied, and ``open_tiles_age_s`` /
+        ``open_tiles_dock``.  Those last two describe the *last layout report*,
+        not the arrangement just requested — usually the state from before this
+        call, since the client reports back on its own schedule.  A null
+        ``open_tiles_dock`` means no client has ever reported, so there may be
+        nobody there to apply this.  The age counts from the last time the
+        arrangement *changed*, so a large value does not by itself mean the
+        browser is gone.  Read the result back with ``list_panels`` if you need
+        to confirm what landed.
+    """
+    result = await anyio.to_thread.run_sync(
+        functools.partial(notify_panel_arrange, tiles=tiles, preset=preset, focus=focus)
+    )
+
+    if not result["ok"]:
+        if result.get("status") is None:
+            return make_error(
+                "web_terminal_unreachable",
+                "Web Terminal is not running — the workspace cannot be arranged.",
+                ["Continue without the workspace, or ask the operator to start it."],
+            )
+        return make_error(
+            "arrange_rejected",
+            f"The arrangement was rejected: {result.get('detail', '')}",
+            [
+                "Call list_panels for the valid panel ids and the configured presets.",
+                "Pass exactly one of 'tiles' or 'preset'.",
+                "A focus target must be one of the arranged tiles.",
+            ],
+        )
+
+    data = result.get("data", {})
+    panels = await anyio.to_thread.run_sync(fetch_panels) or {}
+    response: dict = {
+        "status": "success",
+        "tiles": data.get("tiles", tiles),
+        "focus": data.get("focus", focus),
+        "open_tiles_age_s": panels.get("open_tiles_age_s"),
+        "open_tiles_dock": panels.get("open_tiles_dock"),
+    }
+    if data.get("preset") is not None:
+        response["preset"] = data["preset"]
+    return json.dumps(response)

--- a/src/osprey/profiles/presets/ariel-standalone.yml
+++ b/src/osprey/profiles/presets/ariel-standalone.yml
@@ -33,6 +33,7 @@ hooks:
   - config-drift      # Warn at session start when config.yml drifted from generated artifacts
   - focus-validate    # Strip stale artifact IDs from focus_state.txt on each prompt
   - panels-context    # Inject the web terminal panel inventory into agent context
+  - workspace-delta   # Report web workspace changes since the agent's last turn
 
 rules:
   - error-handling      # Standard error handling and retry guidance

--- a/src/osprey/profiles/presets/channel-finder-standalone.yml
+++ b/src/osprey/profiles/presets/channel-finder-standalone.yml
@@ -41,6 +41,7 @@ hooks:
   - cf-feedback-capture  # Capture channel-finder accuracy feedback for tuning
   - focus-validate    # Strip stale artifact IDs from focus_state.txt on each prompt
   - panels-context    # Inject the web terminal panel inventory into agent context
+  - workspace-delta   # Report web workspace changes since the agent's last turn
 
 rules:
   - error-handling      # Standard error handling and retry guidance

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -44,6 +44,7 @@ hooks:
   - config-drift      # Warn at session start when config.yml drifted from generated artifacts
   - focus-validate    # Strip stale artifact IDs from focus_state.txt on each prompt
   - panels-context    # Inject the web terminal panel inventory into agent context
+  - workspace-delta   # Report web workspace changes since the agent's last turn
 
 rules:
   - safety              # Core safety rules: never write without approval

--- a/src/osprey/profiles/presets/hello-world.yml
+++ b/src/osprey/profiles/presets/hello-world.yml
@@ -25,6 +25,7 @@ hooks:
   - config-drift   # Warn at session start when config.yml drifted from generated artifacts
   - focus-validate # Strip stale artifact IDs from focus_state.txt on each prompt
   - panels-context # Inject the web terminal panel inventory into agent context
+  - workspace-delta # Report web workspace changes since the agent's last turn
 
 rules:
   - safety          # Core safety rules: never write without approval

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -236,6 +236,7 @@ FRAMEWORK_SERVERS: dict[str, ServerDefinition] = {
             "lattice_set_baseline",
             "list_panels",
             "switch_panel",
+            "arrange_workspace",
         ],
         permissions_ask=["setup_patch"],
         hooks_pre=[

--- a/src/osprey/services/build_artifacts/catalog.py
+++ b/src/osprey/services/build_artifacts/catalog.py
@@ -254,6 +254,12 @@ def _get_default_artifacts() -> list[BuildArtifact]:
             output_path=".claude/hooks/osprey_panels_context.py",
             description="SessionStart hook that injects the web surface (simple/expert) and panel inventory into agent context",
         ),
+        BuildArtifact(
+            canonical_name="hooks/workspace-delta",
+            template_path="claude/hooks/osprey_workspace_delta.py",
+            output_path=".claude/hooks/osprey_workspace_delta.py",
+            description="UserPromptSubmit hook that reports web workspace changes since the agent's last turn",
+        ),
         # ── Skills ──────────────────────────────────────────────────
         BuildArtifact(
             canonical_name="skills/session-report",

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_panels_context.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_panels_context.py
@@ -2,8 +2,8 @@
 """
 ---
 name: Panels Context
-description: Injects the web surface (simple/expert) and panel inventory into the agent context at session start
-summary: Agent learns which web UX it serves and what panels exist without a list_panels round-trip
+description: Injects the web surface (simple/expert), panel inventory and open-tile state into the agent context at session start
+summary: Agent learns which web UX it serves, what panels exist and what is on screen without a list_panels round-trip
 event: SessionStart
 ---
 
@@ -13,19 +13,24 @@ event: SessionStart
 SessionStart ──► read OSPREY_WEB_UX (set by the web terminal per surface)
                      │
                      ▼
+                 read stdin JSON ──► session_id (absent/malformed ─► None)
+                     │
+                     ▼
                  GET /api/panels (web terminal)
                      │
-                     ▼
-   build [ux line?] + [inventory?] from env + enabled/custom panels
+                     ├──► build [ux line?] + [inventory?] + [tile line?]
+                     │         │
+                     │         ▼
+                     │    emit additionalContext JSON (any part present) ─► exit 0
+                     │    (no env var AND web terminal down/empty) ─► silent ─► exit 0
                      │
-                     ▼
-   emit additionalContext JSON (any part present) ───► exit 0
-   (no env var AND web terminal down/empty) ─► silent ► exit 0
+                     └──► session_id known? ─► overwrite the workspace snapshot
+                                                (tempdir/osprey-workspace-<id>.json)
 ```
 
 ## Details
 
-Injects two independent pieces of session context as ``additionalContext``:
+Injects three independent pieces of session context as ``additionalContext``:
 
 1. **Web surface** — ``OSPREY_WEB_UX`` (``simple`` | ``expert``) marks which web
    UI surface launched this session (the operator chat sets ``simple``, the PTY
@@ -37,11 +42,52 @@ Injects two independent pieces of session context as ``additionalContext``:
 2. **Panel inventory** — fetched from the web terminal so the agent knows which
    panels exist, their labels, visibility state, and the active tab — without a
    ``list_panels`` tool round-trip.
+3. **Open tiles** — which panels are actually on screen, in spatial reading
+   order, e.g. ``Open tiles: [lattice, artifacts], active artifacts.`` Tiles are
+   reported by the browser, so the line is omitted entirely whenever occupancy
+   is *unknown* rather than empty (see below) — an unobserved workspace is never
+   described as an empty one.
+
+## Workspace snapshot
+
+Besides the context lines, this hook seeds the *workspace snapshot* — the file
+``osprey_workspace_delta.py`` (UserPromptSubmit) diffs against to report what
+moved between turns.  It is JSON at::
+
+    os.path.join(tempfile.gettempdir(), f"osprey-workspace-{session_id}.json")
+
+with exactly three keys::
+
+    {
+      "tiles":   ["lattice", "artifacts"] | null,  # on-screen, reading order;
+                                                   # null = occupancy UNKNOWN
+      "active":  "artifacts" | null,               # active tab id
+      "visible": ["lattice", "artifacts", "scan"]  # launcher-rail membership
+    }
+
+``tiles`` is null whenever the server's answer does not actually describe what
+is on screen — ``open_tiles`` absent, ``open_tiles_age_s`` null (nobody has ever
+reported), or ``open_tiles_dock`` false (the reporting client has no dock, so it
+knows the rail but not the tiles, and its report carries a *numeric* age).
+Unknown and empty are different claims, and only one of them is honest.  Both
+hooks apply this rule identically — see :func:`_occupancy_is_known`.
+
+The seed is **unconditional**: SessionStart re-fires on resume and on ``/clear``
+with the same session id, and a stale snapshot would make the first delta line
+of the resumed session describe changes the agent already knows about.  It is
+written only when a ``session_id`` is available *and* the live state was
+fetched — with no live state there is nothing honest to record, and the delta
+hook reseeds from a missing snapshot on its own.
+
+``session_id`` comes from the hook's stdin JSON and is restricted to
+``[A-Za-z0-9_-]`` before it reaches a path join; anything else is treated as
+absent.  ``osprey_workspace_delta.py`` applies the same rule, so both hooks
+agree on the file name.
 
 stdlib-only — must NOT import osprey, yaml, requests, or any third-party lib.
-Uses only ``json``, ``os``, ``sys``, ``urllib.request``, ``urllib.error``.
-The SessionStart hook runs under ``python3`` (possibly system Python 3.9, not
-the venv interpreter), so this file must be 3.9-safe.
+Uses only ``json``, ``os``, ``sys``, ``tempfile``, ``urllib.request``,
+``urllib.error``.  The SessionStart hook runs under ``python3`` (possibly system
+Python 3.9, not the venv interpreter), so this file must be 3.9-safe.
 
 Fails open on any error — stays silent and exits 0.  A down web terminal is not
 a session-blocking condition.
@@ -50,8 +96,143 @@ a session-blocking condition.
 import json
 import os
 import sys
+import tempfile
 import urllib.error
 import urllib.request
+
+#: Characters a session id may contain before it is joined into a file name.
+_SESSION_ID_CHARS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-")
+
+
+def _read_session_id(stream=None):
+    """Pull ``session_id`` out of the hook's stdin JSON payload.
+
+    Args:
+        stream: Text stream to read the payload from. Defaults to ``sys.stdin``.
+
+    Returns:
+        The session id, or None when stdin is unreadable, is not a JSON object,
+        carries no session id, or carries one with characters that have no
+        business in a file name. The caller then skips all snapshot work and
+        still emits whatever context the environment alone supports.
+    """
+    try:
+        raw = (stream if stream is not None else sys.stdin).read()
+    except Exception:
+        return None
+    if not raw:
+        return None
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    session_id = payload.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        return None
+    if not set(session_id) <= _SESSION_ID_CHARS:
+        return None
+    return session_id
+
+
+def _snapshot_path(session_id):
+    """Return the workspace-snapshot path for ``session_id``.
+
+    Both this hook and ``osprey_workspace_delta.py`` derive the path this way;
+    changing it here without changing it there breaks the delta line.
+    """
+    return os.path.join(tempfile.gettempdir(), f"osprey-workspace-{session_id}.json")
+
+
+def _occupancy_is_known(data):
+    """True when the payload's tile list really describes what is on screen.
+
+    There are three ways occupancy is unknown, and none of them may be reported
+    as an empty workspace:
+
+    * ``open_tiles`` absent or not a list — a web terminal predating the field.
+    * ``open_tiles_age_s`` explicitly null — the field exists, but no client has
+      ever reported a layout.
+    * ``open_tiles_dock`` false — the reporting client has no dock, so it knows
+      the launcher rail but cannot see tiles. This case carries a *numeric* age,
+      so the age check alone would read it as a trustworthy empty workspace.
+
+    A missing or null ``open_tiles_dock`` says nothing either way and is left to
+    the other two checks; only an explicit ``false`` forces unknown.
+    """
+    if not isinstance(data.get("open_tiles"), list):
+        return False
+    if "open_tiles_age_s" in data and data.get("open_tiles_age_s") is None:
+        return False
+    return data.get("open_tiles_dock") is not False
+
+
+def _workspace_state(data):
+    """Reduce a ``/api/panels`` payload to the three snapshot facets.
+
+    Args:
+        data: Decoded ``GET /api/panels`` response.
+
+    Returns:
+        A dict with ``tiles`` (on-screen ids in reading order, or None when
+        occupancy is unknown per :func:`_occupancy_is_known`), ``active``
+        (active tab id or None) and ``visible`` (launcher-rail membership).
+        Every field is defended against a payload of the wrong shape.
+    """
+    tiles = data.get("open_tiles")
+    if _occupancy_is_known(data):
+        tiles = [t for t in tiles if isinstance(t, str)]
+    else:
+        tiles = None
+
+    visible = data.get("visible")
+    visible = [v for v in visible if isinstance(v, str)] if isinstance(visible, list) else []
+
+    active = data.get("active")
+    if not isinstance(active, str):
+        active = None
+
+    return {"tiles": tiles, "active": active, "visible": visible}
+
+
+def _write_snapshot(path, state):
+    """Overwrite the snapshot at ``path`` with ``state``.
+
+    Written to a sibling temp file and renamed so the delta hook can never read
+    a half-written file. Returns True on success, False on any failure — the
+    snapshot is an optimization, never a reason to disturb a session start.
+    """
+    tmp_path = f"{path}.tmp"
+    try:
+        with open(tmp_path, "w") as handle:
+            json.dump(state, handle)
+        os.replace(tmp_path, path)
+        return True
+    except Exception:
+        try:
+            os.remove(tmp_path)
+        except Exception:
+            pass
+        return False
+
+
+def _build_tile_line(state):
+    """Describe what is on screen, or None when no client has reported tiles.
+
+    Silence is the honest answer for an unreported workspace: the browser may
+    not have connected yet, and "no tiles are open" would be a claim the server
+    cannot back up.
+    """
+    tiles = state.get("tiles")
+    if tiles is None:
+        return None
+    active = state.get("active")
+    if not tiles:
+        return "Open tiles: [] (nothing on screen besides the terminal)."
+    listed = ", ".join(tiles)
+    active_part = f"active {active}" if active else "no active tile"
+    return f"Open tiles: [{listed}], {active_part}."
 
 
 def _build_ux_context(ux):
@@ -113,21 +294,31 @@ def _build_inventory(data):
 def main():
     try:
         ux_context = _build_ux_context(os.environ.get("OSPREY_WEB_UX"))
+        session_id = _read_session_id()
 
         port = os.environ.get("OSPREY_WEB_PORT", "8087")
         host = "127.0.0.1"
         base = f"http://{host}:{port}"
 
         inventory = None
+        tile_line = None
         try:
             req = urllib.request.urlopen(f"{base}/api/panels", timeout=2)
-            inventory = _build_inventory(json.loads(req.read()))
+            data = json.loads(req.read())
+            inventory = _build_inventory(data)
+            state = _workspace_state(data)
+            tile_line = _build_tile_line(state)
+            if session_id:
+                # Unconditional: SessionStart re-fires on resume and /clear with
+                # the same id, and the delta hook must start from what is on
+                # screen now, not from what was there before the resume.
+                _write_snapshot(_snapshot_path(session_id), state)
         except Exception:
             # Web terminal down or unreachable — the surface line (env-only)
-            # still applies; only the inventory is dropped.
+            # still applies; only the live-state parts are dropped.
             pass
 
-        parts = [p for p in (ux_context, inventory) if p]
+        parts = [p for p in (ux_context, inventory, tile_line) if p]
         if not parts:
             return 0
 

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_workspace_delta.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_workspace_delta.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""
+---
+name: Workspace Delta
+description: Tells the agent what moved in the web workspace since its last turn
+summary: One terse line when tiles, the active tab or rail membership changed — silence when nothing did
+event: UserPromptSubmit
+---
+
+## Flow
+
+```
+UserPromptSubmit ──► read stdin JSON ──► session_id (absent/malformed ─► exit 0, silent)
+                          │
+                          ▼
+                     GET /api/panels ──► (down/unreachable) ─► exit 0, silent
+                          │
+                          ▼
+                     load snapshot (tempdir/osprey-workspace-<id>.json)
+                          │
+              ┌───────────┴────────────┐
+        missing/corrupt              loaded
+              │                        │
+              ▼                        ▼
+        reseed, emit nothing     diff {tiles, active, visible}
+              │                        │
+              ▼               ┌────────┴────────┐
+           exit 0        unchanged            changed
+                              │                  │
+                              ▼                  ▼
+                        exit 0, silent    emit one additionalContext
+                        (no output)       line, rewrite snapshot ─► exit 0
+```
+
+## Details
+
+The SessionStart sibling (``osprey_panels_context.py``) tells the agent what the
+workspace looked like when the session began.  Between turns a human can close a
+tile, drag one somewhere else, or switch tabs — none of which the agent would
+otherwise see without spending a ``list_panels`` round-trip on every turn.  This
+hook spends nothing when nothing moved.
+
+**Silence is the default.**  The hook writes to stdout only when the workspace
+genuinely differs from the snapshot, and then only one line naming what moved::
+
+    Workspace changed: lattice tile closed; active now artifacts.
+
+Everything else exits 0 with byte-empty stdout: an unchanged workspace, a
+missing or corrupt snapshot (reseeded first, so the *next* turn diffs cleanly),
+a session id it cannot read, and a web terminal that is down.  A down terminal
+is never reported as an empty workspace — an unknown workspace and an empty one
+are different claims, and only one of them is honest here.
+
+The same applies to tiles specifically: the browser reports them, so occupancy
+may be unknown while the rail state is perfectly well known — nobody has ever
+reported (``open_tiles_age_s`` null), or the reporting client has no dock
+(``open_tiles_dock`` false) and can see the rail but not the tiles.  When tiles
+go from known to unknown — the last dock-capable browser closed — the hook says
+nothing about tiles and keeps the last known list in the snapshot, so a
+returning browser reporting the same layout does not read as a change.
+
+## Snapshot contract
+
+Reads and rewrites the file seeded by ``osprey_panels_context.py``::
+
+    os.path.join(tempfile.gettempdir(), f"osprey-workspace-{session_id}.json")
+
+    {
+      "tiles":   ["lattice", "artifacts"] | null,  # on-screen, reading order;
+                                                   # null = occupancy UNKNOWN
+      "active":  "artifacts" | null,               # active tab id
+      "visible": ["lattice", "artifacts", "scan"]  # launcher-rail membership
+    }
+
+The schema is documented in full in the sibling hook, which owns it.  Both hooks
+restrict ``session_id`` to ``[A-Za-z0-9_-]`` before joining it into a path, and
+both derive the file name the same way — change one and the other stops seeing
+the same file.
+
+stdlib-only — must NOT import osprey, yaml, requests, or any third-party lib.
+Uses only ``json``, ``os``, ``sys``, ``tempfile``, ``urllib.request``,
+``urllib.error``.  Runs under ``python3`` (possibly system Python 3.9, not the
+venv interpreter), so this file must be 3.9-safe.
+
+Fails open on any error — stays silent and exits 0.  A user prompt is never
+blocked by workspace bookkeeping.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+
+#: Characters a session id may contain before it is joined into a file name.
+#: Must match ``osprey_panels_context.py`` — the two hooks share the file.
+_SESSION_ID_CHARS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-")
+
+
+def _read_session_id(stream=None):
+    """Pull ``session_id`` out of the hook's stdin JSON payload.
+
+    Args:
+        stream: Text stream to read the payload from. Defaults to ``sys.stdin``.
+
+    Returns:
+        The session id, or None when stdin is unreadable, is not a JSON object,
+        carries no session id, or carries one with characters that have no
+        business in a file name. Without an id there is no snapshot to diff
+        against, so the hook simply stays silent.
+    """
+    try:
+        raw = (stream if stream is not None else sys.stdin).read()
+    except Exception:
+        return None
+    if not raw:
+        return None
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    session_id = payload.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        return None
+    if not set(session_id) <= _SESSION_ID_CHARS:
+        return None
+    return session_id
+
+
+def _snapshot_path(session_id):
+    """Return the workspace-snapshot path for ``session_id``."""
+    return os.path.join(tempfile.gettempdir(), f"osprey-workspace-{session_id}.json")
+
+
+def _load_snapshot(path):
+    """Read the previous workspace state, or None when there is none to trust.
+
+    A missing file (first prompt of a session started outside the web terminal),
+    a half-written one, or one carrying anything other than the three-key object
+    all read as None, which the caller answers by reseeding silently.
+    """
+    try:
+        with open(path) as handle:
+            data = json.load(handle)
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    if not all(key in data for key in ("tiles", "active", "visible")):
+        return None
+    return _normalize_state(data)
+
+
+def _normalize_state(data):
+    """Coerce a snapshot or live payload into the three diffed facets."""
+    tiles = data.get("tiles")
+    tiles = [t for t in tiles if isinstance(t, str)] if isinstance(tiles, list) else None
+
+    visible = data.get("visible")
+    visible = [v for v in visible if isinstance(v, str)] if isinstance(visible, list) else []
+
+    active = data.get("active")
+    if not isinstance(active, str):
+        active = None
+
+    return {"tiles": tiles, "active": active, "visible": visible}
+
+
+def _occupancy_is_known(data):
+    """True when the payload's tile list really describes what is on screen.
+
+    Kept identical to the sibling hook's copy — the two must agree or a session
+    would be told about a "change" that is only a difference in how the two
+    hooks read the same server. Occupancy is unknown when ``open_tiles`` is
+    absent or not a list, when ``open_tiles_age_s`` is explicitly null (nobody
+    has ever reported), or when ``open_tiles_dock`` is false (the reporting
+    client has no dock, so it knows the rail but cannot see tiles — and its
+    report carries a *numeric* age, which the age check alone would trust).
+    """
+    if not isinstance(data.get("open_tiles"), list):
+        return False
+    if "open_tiles_age_s" in data and data.get("open_tiles_age_s") is None:
+        return False
+    return data.get("open_tiles_dock") is not False
+
+
+def _workspace_state(data):
+    """Reduce a ``GET /api/panels`` response to the three snapshot facets.
+
+    ``tiles`` is None whenever occupancy is unknown per
+    :func:`_occupancy_is_known`. Unknown is not the same as empty, and the
+    difference decides whether this hook says anything about tiles at all.
+    """
+    tiles = data.get("open_tiles") if _occupancy_is_known(data) else None
+    return _normalize_state(
+        {"tiles": tiles, "active": data.get("active"), "visible": data.get("visible")}
+    )
+
+
+def _write_snapshot(path, state):
+    """Overwrite the snapshot at ``path`` with ``state``.
+
+    Written to a sibling temp file and renamed, so a hook reading concurrently
+    never sees a half-written file. Returns True on success, False on any
+    failure — a snapshot that cannot be written costs one redundant line next
+    turn, which is not worth disturbing a prompt over.
+    """
+    tmp_path = f"{path}.tmp"
+    try:
+        with open(tmp_path, "w") as handle:
+            json.dump(state, handle)
+        os.replace(tmp_path, path)
+        return True
+    except Exception:
+        try:
+            os.remove(tmp_path)
+        except Exception:
+            pass
+        return False
+
+
+def _merge_state(previous, current):
+    """Build the state to persist, carrying forward facts that went unknown.
+
+    Only ``tiles`` can go from known to unknown (the last browser closed). The
+    last known list is kept so a browser returning with the same layout reads as
+    no change rather than as a reopened workspace.
+    """
+    merged = dict(current)
+    if merged["tiles"] is None:
+        merged["tiles"] = previous.get("tiles")
+    return merged
+
+
+def _describe_tiles(previous, current):
+    """Describe how the on-screen tiles moved, in the order a reader wants them.
+
+    Returns a list of clause strings (possibly empty). Nothing is said when the
+    tile set is unknown on either side: a first report cannot be phrased as a
+    transition, and a workspace that stopped being reported has not changed —
+    it stopped being observed.
+    """
+    before, after = previous.get("tiles"), current.get("tiles")
+    if after is None:
+        return []
+    if before is None:
+        listed = ", ".join(after) if after else "none"
+        return [f"tiles now [{listed}]"]
+
+    before_set, after_set = set(before), set(after)
+    clauses = []
+    opened = [t for t in after if t not in before_set]
+    closed = [t for t in before if t not in after_set]
+    if opened:
+        clauses.append(f"{', '.join(opened)} {_tile_noun(opened)} opened")
+    if closed:
+        clauses.append(f"{', '.join(closed)} {_tile_noun(closed)} closed")
+    if not clauses and before != after:
+        clauses.append(f"tiles rearranged to [{', '.join(after)}]")
+    return clauses
+
+
+def _tile_noun(ids):
+    return "tile" if len(ids) == 1 else "tiles"
+
+
+def _describe_active(previous, current):
+    """Describe an active-tab change, or nothing when it held still."""
+    before, after = previous.get("active"), current.get("active")
+    if before == after:
+        return []
+    if after is None:
+        return ["no tile active now"]
+    return [f"active now {after}"]
+
+
+def _describe_visible(previous, current):
+    """Describe launcher-rail membership changes as a set difference.
+
+    Rail order carries no meaning the agent can act on, so only membership is
+    compared — a reordered rail is not a change worth a line.
+    """
+    before, after = set(previous.get("visible") or []), set(current.get("visible") or [])
+    clauses = []
+    added = sorted(after - before)
+    removed = sorted(before - after)
+    if added:
+        clauses.append(f"{', '.join(added)} added to the launcher rail")
+    if removed:
+        clauses.append(f"{', '.join(removed)} removed from the launcher rail")
+    return clauses
+
+
+def _build_delta_line(previous, current):
+    """Build the one-line change summary, or None when nothing moved."""
+    clauses = (
+        _describe_tiles(previous, current)
+        + _describe_active(previous, current)
+        + _describe_visible(previous, current)
+    )
+    if not clauses:
+        return None
+    return f"Workspace changed: {'; '.join(clauses)}."
+
+
+def _fetch_state():
+    """Fetch live workspace state, or None when the web terminal is unreachable."""
+    port = os.environ.get("OSPREY_WEB_PORT", "8087")
+    try:
+        response = urllib.request.urlopen(f"http://127.0.0.1:{port}/api/panels", timeout=2)
+        return _workspace_state(json.loads(response.read()))
+    except Exception:
+        return None
+
+
+def main():
+    try:
+        session_id = _read_session_id()
+        if not session_id:
+            return 0
+
+        current = _fetch_state()
+        if current is None:
+            # Web terminal down: the workspace is unknown, not unchanged and not
+            # empty. Say nothing and leave the snapshot alone.
+            return 0
+
+        path = _snapshot_path(session_id)
+        previous = _load_snapshot(path)
+        if previous is None:
+            # No trustworthy baseline — seed one so the next turn can diff.
+            _write_snapshot(path, current)
+            return 0
+
+        line = _build_delta_line(previous, current)
+        if line is None:
+            return 0
+
+        _write_snapshot(path, _merge_state(previous, current))
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "UserPromptSubmit",
+                        "additionalContext": line,
+                    }
+                }
+            )
+        )
+        return 0
+    except Exception:
+        # Last-resort fail-open: never block a user prompt.
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/osprey/templates/claude_code/claude/settings.json.j2
+++ b/src/osprey/templates/claude_code/claude/settings.json.j2
@@ -116,6 +116,11 @@
             "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/osprey_focus_validate.py\" 2>/dev/null || true",
             "timeout": 2
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/osprey_workspace_delta.py\" 2>/dev/null || true",
+            "timeout": 3
           }
         ]
       }{% for rule in declared.get('UserPromptSubmit', []) %},{{ declared_entry(rule, current_python_env) }}{% endfor %}

--- a/tests/cli/test_preset_hash_pin.py
+++ b/tests/cli/test_preset_hash_pin.py
@@ -21,9 +21,9 @@ from osprey.cli.build_profile_merge import _hash_resolved_profile
 
 # preset name -> resolved-content hash, pre-rename.
 PINNED_PRESET_HASHES: dict[str, str] = {
-    "ariel-standalone": "sha256:a401c62979ff477c8294954a39c15076f3b6d981826f2ec01ffbe863ae23e9e5",
+    "ariel-standalone": "sha256:a08bde688f81f7604da07822db5def68d6c0d294688f15ec8720ac5df11a8cee",
     "channel-finder-standalone": (
-        "sha256:03c3d35070730762db3d46ef88beabe3b0e0bf98abd5fff72d81a95d2b6fc918"
+        "sha256:9faa42d633aae7917429c3ec327c004672e68fa7617832d5ae245780fcb2a20f"
     ),
     # The web-terminal presets were re-pinned when the shipped roster went
     # from a bare-string first user to fully explicit name/index/persona
@@ -46,14 +46,20 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # Re-pinned again when control-assistant gained the test-ioc-safety rule
     # selection (renders only for EPICS-family control systems). Both extends
     # children inherit it, so all three digests moved.
-    "control-assistant": "sha256:9b354d59dfb523bd6a3591de7155c0d2c91c82710aac2db98127b8f8d0db78b2",
+    #
+    # Re-pinned again when every preset that ships panels-context also gained
+    # the workspace-delta hook, which reports web workspace changes between the
+    # agent's turns. All four rosters list it, so every digest moved — a rebuilt
+    # project gains a hook file and a UserPromptSubmit wiring entry, which is
+    # exactly what the staleness advisory should report.
+    "control-assistant": "sha256:577f397a604c904e0f742546321bfe5ee39d9e1ec16eb60c5ff68f1fbe7cc6ae",
     "control-assistant-readonly": (
-        "sha256:f85d545d3c9f61693dd7a48861b2ae46443c2e6e90447560391db1cc79311ac4"
+        "sha256:eaf69900f7783e6b77bceaa52cf69d6e609dc74969715dacf8a639a77cbbe1db"
     ),
     "control-assistant-readwrite": (
-        "sha256:c4b63c8a00876924117edafc80d3e785ca2e3c01375d8908390b78bef3788110"
+        "sha256:a04ca9401c9e3dcf2e1bb233b7764183fc00d682473311cc12cbdbc6ce495ed2"
     ),
-    "hello-world": "sha256:e1666b0b1a1d1232bc3aa9c32ccf11e3555a217162fda292f4240396ef19ec8a",
+    "hello-world": "sha256:ac9c00d70922c3c88d561f7ffa29af3ccb1650d5a8bfaa13b884563199ce371a",
 }
 
 

--- a/tests/cli/test_profile_to_claude_contract.py
+++ b/tests/cli/test_profile_to_claude_contract.py
@@ -600,6 +600,41 @@ def test_hook_config_with_no_enabled_servers(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Panel-awareness hooks: rendered into the project and wired to their event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "hook_file,event",
+    [
+        ("osprey_panels_context.py", "SessionStart"),
+        ("osprey_workspace_delta.py", "UserPromptSubmit"),
+    ],
+)
+def test_panel_hooks_rendered_and_wired(built_control_assistant_project, hook_file, event):
+    """Both halves of panel awareness must survive a fresh render.
+
+    The template hook directory is catalog-bound: a hook file that is not listed
+    in the build-artifact catalog and the template manifest never reaches a
+    project's ``.claude/hooks/``, and one that is shipped but wired to no event
+    never runs. Neither failure is visible from the template tree alone, which
+    is what this pair of assertions covers.
+    """
+    project = built_control_assistant_project
+
+    assert (project / ".claude" / "hooks" / hook_file).is_file(), (
+        f"{hook_file} was not rendered into the project — check the build-artifact "
+        f"catalog and the template manifest"
+    )
+
+    settings = json.loads((project / ".claude" / "settings.json").read_text())
+    commands = [hook["command"] for rule in settings["hooks"][event] for hook in rule["hooks"]]
+    assert any(hook_file in command for command in commands), (
+        f"{hook_file} is shipped but wired to no {event} entry in settings.json"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Crown-jewel invariant
 # ---------------------------------------------------------------------------
 

--- a/tests/cli/test_templates.py
+++ b/tests/cli/test_templates.py
@@ -661,6 +661,7 @@ class TestTemplateManifest:
             "osprey_memory_guard.py",
             "osprey_notebook_update.py",
             "osprey_panels_context.py",
+            "osprey_workspace_delta.py",
             "osprey_writes_check.py",
         }
         hooks_dir = project_dir / ".claude" / "hooks"

--- a/tests/hooks/test_hook_docstring_frontmatter.py
+++ b/tests/hooks/test_hook_docstring_frontmatter.py
@@ -25,6 +25,7 @@ HOOK_FILES = [
     "osprey_config_drift.py",
     "osprey_focus_validate.py",
     "osprey_panels_context.py",
+    "osprey_workspace_delta.py",
     "osprey_cf_feedback_capture.py",
 ]
 

--- a/tests/hooks/test_osprey_panels_context.py
+++ b/tests/hooks/test_osprey_panels_context.py
@@ -1,15 +1,18 @@
 """Tests for the SessionStart panels-context hook.
 
 ``osprey_panels_context.py`` fetches the web-terminal panel inventory at session
-start and injects it as ``additionalContext``. It is a stdlib-only, fail-open
-hook: any unreachable web terminal or parse error must leave the session
-unblocked (silent, exit 0). These tests cover the inventory-string builder as a
-pure function and the ``main`` envelope/fail-open behavior with a stubbed
-``urlopen`` (no real HTTP).
+start, injects it as ``additionalContext`` alongside a line naming the tiles
+actually on screen, and seeds the workspace snapshot that the UserPromptSubmit
+delta hook diffs against. It is a stdlib-only, fail-open hook: any unreachable
+web terminal or parse error must leave the session unblocked (silent, exit 0).
+These tests cover the string builders and snapshot helpers as pure functions,
+and the ``main`` envelope/fail-open behavior with a stubbed ``urlopen`` (no real
+HTTP).
 """
 
 from __future__ import annotations
 
+import io
 import json
 
 import pytest
@@ -41,6 +44,19 @@ def _stub_urlopen(monkeypatch, *, payload=None, raises=None, bad_body=False):
         return _FakeResponse(payload or {})
 
     monkeypatch.setattr(panels.urllib.request, "urlopen", _fake)
+
+
+def _stub_stdin(monkeypatch, payload):
+    """Hand ``main`` a hook stdin payload (a str is written through verbatim)."""
+    raw = payload if isinstance(payload, str) else json.dumps(payload)
+    monkeypatch.setattr(panels.sys, "stdin", io.StringIO(raw))
+
+
+@pytest.fixture
+def temp_snapshot_dir(tmp_path, monkeypatch):
+    """Redirect ``tempfile.gettempdir()`` so snapshots land in ``tmp_path``."""
+    monkeypatch.setattr(panels.tempfile, "tempdir", str(tmp_path))
+    return tmp_path
 
 
 # ---------------------------------------------------------------------------
@@ -103,6 +119,173 @@ def test_inventory_mentions_control_tools():
 
 
 # ---------------------------------------------------------------------------
+# _read_session_id (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_session_id_read_from_stdin_payload():
+    stream = io.StringIO(json.dumps({"session_id": "abc-123_DEF", "cwd": "/tmp"}))
+    assert panels._read_session_id(stream) == "abc-123_DEF"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["", "{not json", "[]", '"a string"', "{}", '{"session_id": null}', '{"session_id": ""}'],
+    ids=["empty", "invalid", "list", "scalar", "no-key", "null", "blank"],
+)
+def test_session_id_absent_returns_none(raw):
+    """Anything the hook cannot read a session id out of yields None, not a raise."""
+    assert panels._read_session_id(io.StringIO(raw)) is None
+
+
+@pytest.mark.parametrize(
+    "session_id",
+    ["../../etc/passwd", "a/b", "a b", "with.dot", "sess\x00id"],
+    ids=["traversal", "slash", "space", "dot", "nul"],
+)
+def test_session_id_rejects_unsafe_filename_chars(session_id):
+    """The id is joined into a path, so anything outside [A-Za-z0-9_-] is dropped."""
+    stream = io.StringIO(json.dumps({"session_id": session_id}))
+    assert panels._read_session_id(stream) is None
+
+
+def test_session_id_unreadable_stream_returns_none():
+    class _Exploding:
+        def read(self):
+            raise OSError("stdin closed")
+
+    assert panels._read_session_id(_Exploding()) is None
+
+
+# ---------------------------------------------------------------------------
+# _workspace_state / _snapshot_path / _write_snapshot (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_state_extracts_three_facets():
+    data = {
+        "open_tiles": ["lattice", "artifacts"],
+        "open_tiles_age_s": 1.5,
+        "active": "artifacts",
+        "visible": ["lattice", "artifacts", "scan"],
+    }
+    assert panels._workspace_state(data) == {
+        "tiles": ["lattice", "artifacts"],
+        "active": "artifacts",
+        "visible": ["lattice", "artifacts", "scan"],
+    }
+
+
+def test_workspace_state_null_age_means_never_reported():
+    """A tile list nobody has reported is None, not an empty workspace."""
+    data = {"open_tiles": [], "open_tiles_age_s": None, "visible": ["scan"]}
+    assert panels._workspace_state(data)["tiles"] is None
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"open_tiles": None, "open_tiles_age_s": 0.3, "open_tiles_dock": False},
+        {"open_tiles": [], "open_tiles_age_s": 0.3, "open_tiles_dock": False},
+        {"open_tiles": ["scan"], "open_tiles_age_s": 0.3, "open_tiles_dock": False},
+    ],
+    ids=["null-tiles", "legacy-empty-list", "stale-list-from-dockless-client"],
+)
+def test_workspace_state_dock_false_means_occupancy_unknown(payload):
+    """A client without a dock knows the rail but cannot see tiles.
+
+    Its report carries a numeric age, so the age check alone would read it as a
+    trustworthy empty workspace. Both the post-fix shape (null tiles) and the
+    legacy shape (empty list) must land on unknown.
+    """
+    state = panels._workspace_state(dict(payload, visible=["scan"], active="scan"))
+    assert state["tiles"] is None
+    assert state["visible"] == ["scan"]
+
+
+@pytest.mark.parametrize("dock", [True, None], ids=["dock-capable", "capability-unknown"])
+def test_workspace_state_trusts_tiles_unless_dock_is_explicitly_false(dock):
+    data = {
+        "open_tiles": ["scan"],
+        "open_tiles_age_s": 0.3,
+        "open_tiles_dock": dock,
+        "visible": ["scan"],
+    }
+    assert panels._workspace_state(data)["tiles"] == ["scan"]
+
+
+def test_workspace_state_older_terminal_without_tile_fields():
+    """A web terminal that predates open_tiles reports them as never reported."""
+    state = panels._workspace_state({"visible": ["scan"], "active": "scan"})
+    assert state == {"tiles": None, "active": "scan", "visible": ["scan"]}
+
+
+def test_workspace_state_ignores_wrong_types():
+    state = panels._workspace_state({"open_tiles": "nope", "visible": {"a": 1}, "active": 7})
+    assert state == {"tiles": None, "active": None, "visible": []}
+
+
+def test_workspace_state_drops_non_string_ids():
+    data = {"open_tiles": ["scan", 3, None], "open_tiles_age_s": 0.2, "visible": ["scan", {}]}
+    state = panels._workspace_state(data)
+    assert state["tiles"] == ["scan"]
+    assert state["visible"] == ["scan"]
+
+
+def test_snapshot_path_is_session_scoped(temp_snapshot_dir):
+    path = panels._snapshot_path("sess-1")
+    assert path == str(temp_snapshot_dir / "osprey-workspace-sess-1.json")
+
+
+def test_write_snapshot_roundtrips_and_leaves_no_temp_file(temp_snapshot_dir):
+    path = panels._snapshot_path("sess-1")
+    state = {"tiles": ["scan"], "active": "scan", "visible": ["scan"]}
+
+    assert panels._write_snapshot(path, state) is True
+    assert json.loads(open(path).read()) == state
+    assert list(temp_snapshot_dir.iterdir()) == [temp_snapshot_dir / "osprey-workspace-sess-1.json"]
+
+
+def test_write_snapshot_overwrites_previous_content(temp_snapshot_dir):
+    path = panels._snapshot_path("sess-1")
+    panels._write_snapshot(path, {"tiles": ["old"], "active": "old", "visible": ["old"]})
+    panels._write_snapshot(path, {"tiles": ["new"], "active": "new", "visible": ["new"]})
+    assert json.loads(open(path).read())["tiles"] == ["new"]
+
+
+def test_write_snapshot_returns_false_when_unwritable(tmp_path):
+    """An unwritable temp dir is reported, never raised."""
+    assert panels._write_snapshot(str(tmp_path / "missing-dir" / "snap.json"), {}) is False
+
+
+# ---------------------------------------------------------------------------
+# _build_tile_line (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_tile_line_names_tiles_in_order_and_active():
+    line = panels._build_tile_line(
+        {"tiles": ["lattice", "artifacts"], "active": "artifacts", "visible": []}
+    )
+    assert line == "Open tiles: [lattice, artifacts], active artifacts."
+
+
+def test_tile_line_without_active_tile():
+    line = panels._build_tile_line({"tiles": ["lattice"], "active": None, "visible": []})
+    assert line == "Open tiles: [lattice], no active tile."
+
+
+def test_tile_line_reported_empty_workspace():
+    line = panels._build_tile_line({"tiles": [], "active": None, "visible": []})
+    assert "Open tiles: []" in line
+
+
+def test_tile_line_omitted_when_never_reported():
+    """No client has reported — say nothing rather than claim an empty screen."""
+    assert panels._build_tile_line({"tiles": None, "active": "scan", "visible": ["scan"]}) is None
+
+
+# ---------------------------------------------------------------------------
 # main() — envelope + fail-open
 # ---------------------------------------------------------------------------
 
@@ -162,6 +345,129 @@ def test_main_uses_configured_web_port(monkeypatch):
     monkeypatch.setattr(panels.urllib.request, "urlopen", _fake)
     panels.main()
     assert "127.0.0.1:9123/api/panels" in seen["url"]
+
+
+# ---------------------------------------------------------------------------
+# main() — workspace line + snapshot seed
+# ---------------------------------------------------------------------------
+
+_TILED_PAYLOAD = {
+    "enabled": ["lattice", "artifacts"],
+    "labels": {"lattice": "LATTICE", "artifacts": "WORKSPACE"},
+    "visible": ["lattice", "artifacts"],
+    "active": "artifacts",
+    "open_tiles": ["lattice", "artifacts"],
+    "open_tiles_age_s": 0.4,
+}
+
+
+def test_main_appends_tile_state_to_context(monkeypatch, capsys):
+    _stub_urlopen(monkeypatch, payload=_TILED_PAYLOAD)
+    _stub_stdin(monkeypatch, {"session_id": "sess-1"})
+
+    assert panels.main() == 0
+
+    context = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+    assert "WORKSPACE (id=artifacts, shown)" in context
+    assert "Open tiles: [lattice, artifacts], active artifacts." in context
+
+
+def test_main_omits_tile_state_when_never_reported(monkeypatch, capsys):
+    payload = dict(_TILED_PAYLOAD, open_tiles=[], open_tiles_age_s=None)
+    _stub_urlopen(monkeypatch, payload=payload)
+    _stub_stdin(monkeypatch, {"session_id": "sess-1"})
+
+    assert panels.main() == 0
+    assert "Open tiles" not in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "unknown",
+    [
+        {"open_tiles": None, "open_tiles_age_s": 0.3, "open_tiles_dock": False},
+        {"open_tiles": [], "open_tiles_age_s": 0.3, "open_tiles_dock": False},
+    ],
+    ids=["null-tiles", "legacy-empty-list"],
+)
+def test_main_omits_tile_line_for_dockless_client(monkeypatch, capsys, temp_snapshot_dir, unknown):
+    """A dock-less reporter must not turn into a claim about what is on screen."""
+    _stub_urlopen(monkeypatch, payload=dict(_TILED_PAYLOAD, **unknown))
+    _stub_stdin(monkeypatch, {"session_id": "sess-1"})
+
+    assert panels.main() == 0
+
+    out = capsys.readouterr().out
+    assert "Open tiles" not in out
+    # The inventory is still known and still worth injecting.
+    assert "WORKSPACE (id=artifacts, shown)" in out
+    snapshot = json.loads((temp_snapshot_dir / "osprey-workspace-sess-1.json").read_text())
+    assert snapshot["tiles"] is None
+
+
+def test_main_seeds_snapshot_from_stdin_session_id(monkeypatch, capsys, temp_snapshot_dir):
+    _stub_urlopen(monkeypatch, payload=_TILED_PAYLOAD)
+    _stub_stdin(monkeypatch, {"session_id": "sess-1"})
+
+    assert panels.main() == 0
+    capsys.readouterr()
+
+    snapshot = json.loads((temp_snapshot_dir / "osprey-workspace-sess-1.json").read_text())
+    assert snapshot == {
+        "tiles": ["lattice", "artifacts"],
+        "active": "artifacts",
+        "visible": ["lattice", "artifacts"],
+    }
+
+
+def test_main_overwrites_stale_snapshot_on_resume(monkeypatch, capsys, temp_snapshot_dir):
+    """SessionStart re-fires on resume/clear with the same id — always overwrite.
+
+    A snapshot left from before the resume would make the first delta line of
+    the resumed session report changes the agent has already been told about.
+    """
+    stale = temp_snapshot_dir / "osprey-workspace-sess-1.json"
+    stale.write_text(json.dumps({"tiles": ["gone"], "active": "gone", "visible": ["gone"]}))
+
+    _stub_urlopen(monkeypatch, payload=_TILED_PAYLOAD)
+    _stub_stdin(monkeypatch, {"session_id": "sess-1"})
+    assert panels.main() == 0
+    capsys.readouterr()
+
+    assert json.loads(stale.read_text())["tiles"] == ["lattice", "artifacts"]
+
+
+def test_main_without_session_id_still_emits_context(monkeypatch, capsys, temp_snapshot_dir):
+    """No usable stdin: skip the snapshot, keep every context line."""
+    _stub_urlopen(monkeypatch, payload=_TILED_PAYLOAD)
+    _stub_stdin(monkeypatch, "{truncated")
+
+    assert panels.main() == 0
+
+    context = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+    assert "Open tiles: [lattice, artifacts], active artifacts." in context
+    assert list(temp_snapshot_dir.iterdir()) == []
+
+
+def test_main_writes_no_snapshot_when_web_terminal_down(monkeypatch, capsys, temp_snapshot_dir):
+    """No live state means nothing honest to record — the delta hook reseeds."""
+    _stub_urlopen(monkeypatch, raises=ConnectionRefusedError("down"))
+    _stub_stdin(monkeypatch, {"session_id": "sess-1"})
+
+    assert panels.main() == 0
+    capsys.readouterr()
+    assert list(temp_snapshot_dir.iterdir()) == []
+
+
+def test_main_keeps_surface_line_when_web_terminal_down(monkeypatch, capsys):
+    """Reading stdin must not cost the env-derived line when the fetch fails."""
+    monkeypatch.setenv("OSPREY_WEB_UX", "expert")
+    _stub_urlopen(monkeypatch, raises=ConnectionRefusedError("down"))
+    _stub_stdin(monkeypatch, {"session_id": "sess-1"})
+
+    assert panels.main() == 0
+
+    context = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+    assert "EXPERT surface" in context
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hooks/test_osprey_workspace_delta.py
+++ b/tests/hooks/test_osprey_workspace_delta.py
@@ -1,0 +1,438 @@
+"""Tests for the UserPromptSubmit workspace-delta hook.
+
+``osprey_workspace_delta.py`` diffs the live web workspace against the snapshot
+seeded by the SessionStart panels-context hook and injects one line naming what
+moved. Its defining property is silence: an unchanged workspace, an unreadable
+session id, a missing or corrupt snapshot and a down web terminal must each exit
+0 with *byte-empty* stdout, because anything else spends tokens on every turn
+for no information.
+
+These tests cover the diff/describe helpers as pure functions and the ``main``
+envelope with a stubbed ``urlopen`` (no real HTTP) and a redirected temp dir.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+import osprey.templates.claude_code.claude.hooks.osprey_workspace_delta as delta
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._data = json.dumps(payload).encode()
+
+    def read(self):
+        return self._data
+
+
+def _stub_urlopen(monkeypatch, *, payload=None, raises=None, bad_body=False):
+    """Point the hook's urlopen at a fake response, an error, or garbage body."""
+
+    def _fake(url, timeout=None):
+        if raises is not None:
+            raise raises
+        if bad_body:
+
+            class _Bad:
+                def read(self):
+                    return b"not json{{{"
+
+            return _Bad()
+        return _FakeResponse(payload or {})
+
+    monkeypatch.setattr(delta.urllib.request, "urlopen", _fake)
+
+
+def _stub_stdin(monkeypatch, payload):
+    """Hand ``main`` a hook stdin payload (a str is written through verbatim)."""
+    raw = payload if isinstance(payload, str) else json.dumps(payload)
+    monkeypatch.setattr(delta.sys, "stdin", io.StringIO(raw))
+
+
+def _state(tiles=None, active=None, visible=()):
+    return {"tiles": tiles, "active": active, "visible": list(visible)}
+
+
+def _panels_payload(tiles=None, active=None, visible=(), age=0.5):
+    """A ``GET /api/panels`` body; ``tiles=None`` means nobody has reported."""
+    return {
+        "open_tiles": list(tiles) if tiles is not None else [],
+        "open_tiles_age_s": age if tiles is not None else None,
+        "active": active,
+        "visible": list(visible),
+    }
+
+
+@pytest.fixture
+def temp_snapshot_dir(tmp_path, monkeypatch):
+    """Redirect ``tempfile.gettempdir()`` so snapshots land in ``tmp_path``."""
+    monkeypatch.setattr(delta.tempfile, "tempdir", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def snapshot_file(temp_snapshot_dir):
+    """Read/write access to the snapshot ``main`` will use for session ``s1``."""
+
+    class _Snapshot:
+        path = temp_snapshot_dir / "osprey-workspace-s1.json"
+
+        def write(self, state):
+            self.path.write_text(json.dumps(state))
+
+        def read(self):
+            return json.loads(self.path.read_text())
+
+        def exists(self):
+            return self.path.exists()
+
+    return _Snapshot()
+
+
+# ---------------------------------------------------------------------------
+# Session id + snapshot IO (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_session_id_read_from_stdin_payload():
+    stream = io.StringIO(json.dumps({"session_id": "s1", "prompt": "hi"}))
+    assert delta._read_session_id(stream) == "s1"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["", "{not json", "[]", "{}", '{"session_id": null}', '{"session_id": "../escape"}'],
+    ids=["empty", "invalid", "list", "no-key", "null", "traversal"],
+)
+def test_session_id_absent_or_unsafe_returns_none(raw):
+    assert delta._read_session_id(io.StringIO(raw)) is None
+
+
+def test_snapshot_path_matches_sibling_hook(temp_snapshot_dir):
+    """Both hooks must name the same file or the delta line never fires.
+
+    The seeding hook owns the schema; this asserts the two independent copies of
+    the path rule have not drifted apart.
+    """
+    import osprey.templates.claude_code.claude.hooks.osprey_panels_context as panels
+
+    assert delta._snapshot_path("s1") == str(temp_snapshot_dir / "osprey-workspace-s1.json")
+    assert delta._snapshot_path("s1") == panels._snapshot_path("s1")
+
+
+def test_load_snapshot_reads_the_three_facets(snapshot_file):
+    snapshot_file.write({"tiles": ["a"], "active": "a", "visible": ["a", "b"]})
+    assert delta._load_snapshot(str(snapshot_file.path)) == _state(["a"], "a", ["a", "b"])
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["", "{half-writ", "[]", '{"tiles": ["a"]}'],
+    ids=["empty", "torn", "wrong-type", "missing-keys"],
+)
+def test_load_snapshot_rejects_untrustworthy_content(snapshot_file, raw):
+    snapshot_file.path.write_text(raw)
+    assert delta._load_snapshot(str(snapshot_file.path)) is None
+
+
+def test_load_snapshot_missing_file_is_none(temp_snapshot_dir):
+    assert delta._load_snapshot(str(temp_snapshot_dir / "nope.json")) is None
+
+
+def test_write_snapshot_leaves_no_temp_file(temp_snapshot_dir):
+    path = delta._snapshot_path("s1")
+    assert delta._write_snapshot(path, _state(["a"], "a", ["a"])) is True
+    assert [p.name for p in temp_snapshot_dir.iterdir()] == ["osprey-workspace-s1.json"]
+
+
+def test_write_snapshot_returns_false_when_unwritable(tmp_path):
+    assert delta._write_snapshot(str(tmp_path / "no-such-dir" / "s.json"), {}) is False
+
+
+def test_workspace_state_null_age_means_tiles_unknown():
+    state = delta._workspace_state(_panels_payload(tiles=None, active="a", visible=["a"]))
+    assert state == _state(None, "a", ["a"])
+
+
+#: The two payload shapes that mean "a client reported, but it has no dock".
+#: The first is what the server sends after the occupancy fix; the second is the
+#: legacy shape an older server still sends. Both carry a *numeric* age, so an
+#: age-only guard would read either as a trustworthy empty workspace.
+DOCKLESS_PAYLOADS = [
+    {"open_tiles": None, "open_tiles_age_s": 0.3, "open_tiles_dock": False},
+    {"open_tiles": [], "open_tiles_age_s": 0.3, "open_tiles_dock": False},
+]
+DOCKLESS_IDS = ["null-tiles", "legacy-empty-list"]
+
+
+@pytest.mark.parametrize("unknown", DOCKLESS_PAYLOADS, ids=DOCKLESS_IDS)
+def test_workspace_state_dock_false_means_occupancy_unknown(unknown):
+    state = delta._workspace_state(dict(unknown, active="a", visible=["a", "b"]))
+    assert state == _state(None, "a", ["a", "b"])
+
+
+@pytest.mark.parametrize("dock", [True, None], ids=["dock-capable", "capability-unknown"])
+def test_workspace_state_trusts_tiles_unless_dock_is_explicitly_false(dock):
+    data = {"open_tiles": ["a"], "open_tiles_age_s": 0.3, "open_tiles_dock": dock}
+    assert delta._workspace_state(data)["tiles"] == ["a"]
+
+
+@pytest.mark.parametrize("unknown", DOCKLESS_PAYLOADS, ids=DOCKLESS_IDS)
+def test_main_says_nothing_about_tiles_for_dockless_client(
+    monkeypatch, capsys, snapshot_file, unknown
+):
+    """Occupancy going unknown is not a tile change, and must not be recorded as one."""
+    snapshot_file.write(_state(["a", "b"], "a", ["a", "b"]))
+    _stub_urlopen(monkeypatch, payload=dict(unknown, active="a", visible=["a", "b"]))
+    _stub_stdin(monkeypatch, {"session_id": "s1"})
+
+    assert delta.main() == 0
+    assert capsys.readouterr().out == ""
+    assert snapshot_file.read()["tiles"] == ["a", "b"]
+
+
+@pytest.mark.parametrize("unknown", DOCKLESS_PAYLOADS, ids=DOCKLESS_IDS)
+def test_main_dockless_client_still_reports_rail_changes(
+    monkeypatch, capsys, snapshot_file, unknown
+):
+    """A dock-less client knows the rail perfectly well — that half stays honest.
+
+    The tile list it cannot see must survive into the rewritten snapshot, or a
+    returning dock client would read as having reopened everything.
+    """
+    snapshot_file.write(_state(["a", "b"], "a", ["a", "b"]))
+    _stub_urlopen(monkeypatch, payload=dict(unknown, active="a", visible=["a", "b", "c"]))
+    _stub_stdin(monkeypatch, {"session_id": "s1"})
+
+    assert delta.main() == 0
+
+    context = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+    assert context == "Workspace changed: c added to the launcher rail."
+    assert snapshot_file.read()["tiles"] == ["a", "b"]
+
+
+def test_workspace_state_reads_reported_tiles():
+    state = delta._workspace_state(
+        _panels_payload(tiles=["a", "b"], active="b", visible=["a", "b"])
+    )
+    assert state == _state(["a", "b"], "b", ["a", "b"])
+
+
+# ---------------------------------------------------------------------------
+# _build_delta_line (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_no_change_produces_no_line():
+    before = _state(["a", "b"], "b", ["a", "b"])
+    assert delta._build_delta_line(before, dict(before)) is None
+
+
+def test_tile_closed():
+    line = delta._build_delta_line(
+        _state(["lattice", "artifacts"], "artifacts", ["lattice", "artifacts"]),
+        _state(["artifacts"], "artifacts", ["lattice", "artifacts"]),
+    )
+    assert line == "Workspace changed: lattice tile closed."
+
+
+def test_tile_opened():
+    line = delta._build_delta_line(
+        _state(["artifacts"], "artifacts", ["artifacts"]),
+        _state(["artifacts", "scan"], "artifacts", ["artifacts"]),
+    )
+    assert line == "Workspace changed: scan tile opened."
+
+
+def test_several_tiles_closed_share_one_clause():
+    line = delta._build_delta_line(
+        _state(["a", "b", "c"], "a", []),
+        _state(["a"], "a", []),
+    )
+    assert line == "Workspace changed: b, c tiles closed."
+
+
+def test_tiles_rearranged_without_membership_change():
+    line = delta._build_delta_line(
+        _state(["a", "b"], "a", []),
+        _state(["b", "a"], "a", []),
+    )
+    assert line == "Workspace changed: tiles rearranged to [b, a]."
+
+
+def test_active_change():
+    line = delta._build_delta_line(
+        _state(["a", "b"], "a", ["a", "b"]),
+        _state(["a", "b"], "b", ["a", "b"]),
+    )
+    assert line == "Workspace changed: active now b."
+
+
+def test_active_cleared():
+    line = delta._build_delta_line(_state(["a"], "a", ["a"]), _state(["a"], None, ["a"]))
+    assert line == "Workspace changed: no tile active now."
+
+
+def test_visible_added_and_removed():
+    line = delta._build_delta_line(
+        _state(["a"], "a", ["a", "gone"]),
+        _state(["a"], "a", ["a", "new"]),
+    )
+    assert line == (
+        "Workspace changed: new added to the launcher rail; gone removed from the launcher rail."
+    )
+
+
+def test_rail_reorder_is_not_a_change():
+    """Rail order carries nothing the agent can act on."""
+    before = _state(["a"], "a", ["a", "b", "c"])
+    assert delta._build_delta_line(before, _state(["a"], "a", ["c", "a", "b"])) is None
+
+
+def test_combined_delta_names_each_facet_once():
+    line = delta._build_delta_line(
+        _state(["lattice", "artifacts"], "lattice", ["lattice", "artifacts"]),
+        _state(["artifacts"], "artifacts", ["lattice", "artifacts", "scan"]),
+    )
+    assert line == (
+        "Workspace changed: lattice tile closed; active now artifacts; "
+        "scan added to the launcher rail."
+    )
+
+
+def test_first_tile_report_states_rather_than_claims_a_transition():
+    """Unknown -> known is new information, but nothing "opened"."""
+    line = delta._build_delta_line(_state(None, "a", ["a"]), _state(["a", "b"], "a", ["a"]))
+    assert line == "Workspace changed: tiles now [a, b]."
+
+
+def test_tiles_going_unknown_says_nothing_about_tiles():
+    """The last browser closed — the workspace stopped being observed, not changed."""
+    assert delta._build_delta_line(_state(["a", "b"], "a", ["a"]), _state(None, "a", ["a"])) is None
+
+
+def test_merge_state_carries_forward_last_known_tiles():
+    merged = delta._merge_state(_state(["a", "b"], "a", ["a"]), _state(None, "b", ["a"]))
+    assert merged == _state(["a", "b"], "b", ["a"])
+
+
+# ---------------------------------------------------------------------------
+# main() — silence
+# ---------------------------------------------------------------------------
+
+
+def test_main_silent_when_nothing_moved(monkeypatch, capsys, snapshot_file):
+    """The defining property: byte-empty stdout, not an empty JSON envelope."""
+    snapshot_file.write(_state(["a", "b"], "b", ["a", "b"]))
+    _stub_urlopen(monkeypatch, payload=_panels_payload(["a", "b"], "b", ["a", "b"]))
+    _stub_stdin(monkeypatch, {"session_id": "s1"})
+
+    assert delta.main() == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_main_silent_without_session_id(monkeypatch, capsys, temp_snapshot_dir):
+    """No stdin payload: nothing to diff, nothing written."""
+    _stub_urlopen(monkeypatch, payload=_panels_payload(["a"], "a", ["a"]))
+    _stub_stdin(monkeypatch, "")
+
+    assert delta.main() == 0
+    assert capsys.readouterr().out == ""
+    assert list(temp_snapshot_dir.iterdir()) == []
+
+
+def test_main_silent_when_web_terminal_down(monkeypatch, capsys, snapshot_file):
+    """A down terminal leaves the snapshot alone — staleness is never asserted."""
+    snapshot_file.write(_state(["a"], "a", ["a"]))
+    _stub_urlopen(monkeypatch, raises=ConnectionRefusedError("down"))
+    _stub_stdin(monkeypatch, {"session_id": "s1"})
+
+    assert delta.main() == 0
+    assert capsys.readouterr().out == ""
+    assert snapshot_file.read() == _state(["a"], "a", ["a"])
+
+
+def test_main_silent_on_unparseable_response(monkeypatch, capsys, snapshot_file):
+    snapshot_file.write(_state(["a"], "a", ["a"]))
+    _stub_urlopen(monkeypatch, bad_body=True)
+    _stub_stdin(monkeypatch, {"session_id": "s1"})
+
+    assert delta.main() == 0
+    assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------------
+# main() — reseed + emit
+# ---------------------------------------------------------------------------
+
+
+def test_main_reseeds_missing_snapshot_without_emitting(monkeypatch, capsys, snapshot_file):
+    _stub_urlopen(monkeypatch, payload=_panels_payload(["a", "b"], "b", ["a", "b"]))
+    _stub_stdin(monkeypatch, {"session_id": "s1"})
+
+    assert delta.main() == 0
+    assert capsys.readouterr().out == ""
+    assert snapshot_file.read() == _state(["a", "b"], "b", ["a", "b"])
+
+
+def test_main_reseeds_corrupt_snapshot_without_emitting(monkeypatch, capsys, snapshot_file):
+    """A torn file is a missing baseline, not a diff against garbage."""
+    snapshot_file.path.write_text('{"tiles": ["a"], "acti')
+    _stub_urlopen(monkeypatch, payload=_panels_payload(["a", "b"], "b", ["a", "b"]))
+    _stub_stdin(monkeypatch, {"session_id": "s1"})
+
+    assert delta.main() == 0
+    assert capsys.readouterr().out == ""
+    assert snapshot_file.read() == _state(["a", "b"], "b", ["a", "b"])
+
+
+@pytest.mark.parametrize(
+    "live,expected",
+    [
+        (_panels_payload(["a"], "a", ["a", "b"]), "b tile closed"),
+        (_panels_payload(["a", "b"], "b", ["a", "b"]), "active now b"),
+        (_panels_payload(["a", "b"], "a", ["a", "b", "c"]), "c added to the launcher rail"),
+    ],
+    ids=["tiles", "active", "visible"],
+)
+def test_main_emits_one_line_per_delta_type(monkeypatch, capsys, snapshot_file, live, expected):
+    snapshot_file.write(_state(["a", "b"], "a", ["a", "b"]))
+    _stub_urlopen(monkeypatch, payload=live)
+    _stub_stdin(monkeypatch, {"session_id": "s1"})
+
+    assert delta.main() == 0
+
+    hook_out = json.loads(capsys.readouterr().out)["hookSpecificOutput"]
+    assert hook_out["hookEventName"] == "UserPromptSubmit"
+    assert hook_out["additionalContext"] == f"Workspace changed: {expected}."
+
+
+def test_main_rewrites_snapshot_so_a_change_is_reported_once(monkeypatch, capsys, snapshot_file):
+    snapshot_file.write(_state(["a", "b"], "a", ["a", "b"]))
+    _stub_urlopen(monkeypatch, payload=_panels_payload(["a"], "a", ["a", "b"]))
+    _stub_stdin(monkeypatch, {"session_id": "s1"})
+
+    assert delta.main() == 0
+    assert "b tile closed" in capsys.readouterr().out
+    assert snapshot_file.read() == _state(["a"], "a", ["a", "b"])
+
+    _stub_stdin(monkeypatch, {"session_id": "s1"})
+    assert delta.main() == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_main_keeps_last_known_tiles_when_browser_leaves(monkeypatch, capsys, snapshot_file):
+    """Rail change with tiles unreported: the tile list must not be forgotten."""
+    snapshot_file.write(_state(["a", "b"], "a", ["a", "b"]))
+    _stub_urlopen(monkeypatch, payload=_panels_payload(None, "a", ["a", "b", "c"]))
+    _stub_stdin(monkeypatch, {"session_id": "s1"})
+
+    assert delta.main() == 0
+    assert "c added to the launcher rail" in capsys.readouterr().out
+    assert snapshot_file.read()["tiles"] == ["a", "b"]

--- a/tests/interfaces/web_terminal/dock-sync.test.mjs
+++ b/tests/interfaces/web_terminal/dock-sync.test.mjs
@@ -27,24 +27,36 @@
  * tests.
  */
 
-import { test, expect, describe, beforeEach, vi } from 'vitest';
+import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
 
 const SYNC = '../../../src/osprey/interfaces/web_terminal/static/js/dock-sync.js';
 
 // Boundary stubs. Hoisted so the spies exist before dock-sync's static imports
 // resolve; the same spy instances persist across resetModules (they are closed
 // over here), while dock-sync's own state is rebuilt on each fresh import.
-const { getDockApi, setPanelFocus, setPanelVisibility, state } = vi.hoisted(() => ({
-  state: { api: /** @type {any} */ (null) },
-  getDockApi: vi.fn(() => /** @type {any} */ (null)),
-  setPanelFocus: vi.fn(),
-  setPanelVisibility: vi.fn(),
-}));
+const {
+  getDockApi, setPanelFocus, setPanelVisibility, reportPanelLayout, setLayoutRestoredHook, state,
+} = vi.hoisted(
+  () => ({
+    state: { api: /** @type {any} */ (null), restoreHook: /** @type {any} */ (null) },
+    getDockApi: vi.fn(() => /** @type {any} */ (null)),
+    setLayoutRestoredHook: vi.fn(),
+    setPanelFocus: vi.fn(),
+    setPanelVisibility: vi.fn(),
+    // Resolves with the server's acknowledgement; the reporter sets its dedupe
+    // baseline from that, so tests can model a lost report by resolving null.
+    reportPanelLayout: vi.fn(),
+  }),
+);
 // getDockApi reads the mutable holder so a test can swap the live api in place.
 getDockApi.mockImplementation(() => state.api);
 
 vi.mock('../../../src/osprey/interfaces/web_terminal/static/js/dock-workspace.js', () => ({
   getDockApi,
+  // The boot-layout-settled seam. dock-workspace calls the registered hook at
+  // every exit of initPersistence; tests capture it and fire it by hand to model
+  // a restore landing (or deliberately never landing).
+  setLayoutRestoredHook,
   // dock-iframe.js imports these from dock-workspace; the mock must supply
   // them or the transitive import chain resolves them to undefined.
   // (PLACEHOLDER_PREFIX comes from dock-reconcile.js, a pure module that
@@ -56,12 +68,22 @@ vi.mock('../../../src/osprey/interfaces/web_terminal/static/js/dock-workspace.js
 vi.mock('../../../src/osprey/interfaces/web_terminal/static/js/panel-commands.js', () => ({
   setPanelFocus,
   setPanelVisibility,
+  reportPanelLayout,
 }));
 
 beforeEach(() => {
   vi.resetModules();
   vi.clearAllMocks();
   getDockApi.mockImplementation(() => state.api);
+  state.restoreHook = null;
+  setLayoutRestoredHook.mockImplementation((/** @type {any} */ fn) => {
+    state.restoreHook = fn;
+  });
+  // Default: the server acknowledges every report as a genuine update, echoing
+  // the tiles back the way the real route does.
+  reportPanelLayout.mockImplementation((/** @type {string[]} */ tiles, /** @type {boolean} */ dock) =>
+    Promise.resolve({ status: 'ok', tiles, dock, updated: true }),
+  );
   state.api = null;
   document.body.innerHTML = '';
 });
@@ -70,7 +92,13 @@ beforeEach(() => {
  * A hand-built stand-in for dockview's DockviewApi exposing only the surface
  * dock-sync touches. `fireActive()` invokes the onDidActivePanelChange listener
  * dock-sync registered (dockview fires it synchronously for both a human tab
- * click and a programmatic setActive — the ambiguity the echo guard resolves).
+ * click and a programmatic setActive — the ambiguity the echo guard resolves);
+ * `fireLayout()` invokes the onDidLayoutChange listener the occupancy reporter
+ * registered.
+ *
+ * Deliberately has NO toJSON: an api that cannot serialize its grid reports
+ * nothing, which keeps the settle timer wiring arms at boot inert in every test
+ * that is not about the reporter. Reporter tests opt in via {@link withGrid}.
  * @returns {any}
  */
 function makeApi() {
@@ -85,12 +113,22 @@ function makeApi() {
     _activateOnRemove: /** @type {any} */ (null),
     /** @type {null | (() => void)} */
     _activeCb: null,
+    /** @type {null | (() => void)} */
+    _layoutCb: null,
     fireActive() {
       if (api._activeCb) api._activeCb();
+    },
+    /** dockview's settled-layout-change event (panel add/move/close, sash end). */
+    fireLayout() {
+      if (api._layoutCb) api._layoutCb();
     },
   };
   api.onDidActivePanelChange = vi.fn((/** @type {() => void} */ cb) => {
     api._activeCb = cb;
+    return { dispose() {} };
+  });
+  api.onDidLayoutChange = vi.fn((/** @type {() => void} */ cb) => {
+    api._layoutCb = cb;
     return { dispose() {} };
   });
   api.getPanel = vi.fn((/** @type {string} */ id) => api._panels[id] ?? null);
@@ -179,6 +217,696 @@ describe('serviceIdOf — service-placeholder id extraction', () => {
     expect(serviceIdOf(null)).toBeNull();
     expect(serviceIdOf(undefined)).toBeNull();
     expect(serviceIdOf(42)).toBeNull();
+  });
+});
+
+/**
+ * A serialized grid LEAF (one tile) in the shape `api.toJSON()` emits — `views`
+ * is the tile's tab order, one entry under the one-panel-per-tile invariant.
+ * @param {...string} views
+ */
+function leaf(...views) {
+  return {
+    type: 'leaf',
+    data: { views, activeView: views[0], id: `group-${views.join('+') || 'empty'}` },
+    size: 500,
+  };
+}
+
+/**
+ * A serialized grid BRANCH: children in spatial order along the branch's own
+ * axis — left-to-right for a horizontal branch, top-to-bottom for a vertical
+ * one (the root's axis is `grid.orientation`, nested branches alternate).
+ * @param {...any} children
+ */
+function branch(...children) {
+  return { type: 'branch', data: children, size: 1000 };
+}
+
+/**
+ * A serialized dockview layout carrying `root` as its grid tree.
+ * @param {any} root  the grid tree, or undefined for a layout with no grid
+ */
+function gridPayload(root) {
+  return {
+    grid:
+      root === undefined ? undefined : { root, width: 1600, height: 900, orientation: 'HORIZONTAL' },
+    panels: {},
+    activeGroup: 'group-1',
+  };
+}
+
+/**
+ * A minimal api stub exposing only toJSON — serializeOpenTiles takes the api as
+ * an argument, so these tests need no wiring, no DOM, and no dockview.
+ * @param {any} root
+ */
+function apiWithGrid(root) {
+  return { toJSON: () => gridPayload(root) };
+}
+
+/**
+ * Teach a {@link makeApi} stub to serialize `root`, opting that api into the
+ * occupancy reporter. Returns the api for chaining; call again to model the
+ * operator rearranging tiles before firing the next layout change.
+ * @param {any} api
+ * @param {any} root
+ */
+function withGrid(api, root) {
+  api.toJSON = () => gridPayload(root);
+  return api;
+}
+
+describe('serializeOpenTiles — occupancy in spatial reading order', () => {
+  test('returns null with no api at all (fallback mode — never an empty report)', async () => {
+    const { serializeOpenTiles } = await import(SYNC);
+    expect(serializeOpenTiles(null)).toBeNull();
+    expect(serializeOpenTiles(undefined)).toBeNull();
+  });
+
+  test('returns null for an api that cannot serialize (no toJSON)', async () => {
+    const { serializeOpenTiles } = await import(SYNC);
+    expect(serializeOpenTiles({})).toBeNull();
+  });
+
+  test('returns null when toJSON throws — the layout is unknown, not empty', async () => {
+    const { serializeOpenTiles } = await import(SYNC);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const api = {
+      toJSON: () => {
+        throw new Error('dockview mid-rebuild');
+      },
+    };
+
+    expect(serializeOpenTiles(api)).toBeNull();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  test('returns null when the payload carries no grid tree', async () => {
+    const { serializeOpenTiles } = await import(SYNC);
+    expect(serializeOpenTiles(apiWithGrid(undefined))).toBeNull();
+    expect(serializeOpenTiles(apiWithGrid(null))).toBeNull();
+  });
+
+  test('an EMPTY dock reports an empty list (distinct from the unknown null)', async () => {
+    const { serializeOpenTiles } = await import(SYNC);
+    expect(serializeOpenTiles(apiWithGrid(branch()))).toEqual([]);
+  });
+
+  test('a dock holding only the terminal reports no tiles', async () => {
+    const { serializeOpenTiles } = await import(SYNC);
+    expect(serializeOpenTiles(apiWithGrid(branch(leaf('terminal'))))).toEqual([]);
+  });
+
+  test('maps placeholder ids back to service ids and drops the native tiles', async () => {
+    const { serializeOpenTiles } = await import(SYNC);
+    const root = branch(leaf('iframe:ariel'), leaf('terminal'));
+
+    expect(serializeOpenTiles(apiWithGrid(root))).toEqual(['ariel']);
+  });
+
+  test('a horizontal split reports left-to-right, terminal excluded from the order', async () => {
+    const { serializeOpenTiles } = await import(SYNC);
+    const root = branch(leaf('iframe:ariel'), leaf('iframe:bluesky'), leaf('terminal'));
+
+    expect(serializeOpenTiles(apiWithGrid(root))).toEqual(['ariel', 'bluesky']);
+  });
+
+  test('a single group holding several placeholders reports them in tab order', async () => {
+    // The one-panel-per-tile invariant makes this a pre-strict-model layout, but
+    // the serializer must still describe it rather than drop the stack.
+    const { serializeOpenTiles } = await import(SYNC);
+    const root = branch(leaf('iframe:ariel', 'iframe:bluesky', 'iframe:okf'));
+
+    expect(serializeOpenTiles(apiWithGrid(root))).toEqual(['ariel', 'bluesky', 'okf']);
+  });
+
+  test('a NESTED branch (what a rail-drag vertical split produces) flattens in child order', async () => {
+    // Named for what this can actually observe: a serialized branch carries no
+    // orientation, so the axis itself is not visible here — the browser suite
+    // pins that a vertical split reads top-to-bottom.
+    const { serializeOpenTiles } = await import(SYNC);
+    const root = branch(branch(leaf('iframe:ariel'), leaf('iframe:bluesky')));
+
+    expect(serializeOpenTiles(apiWithGrid(root))).toEqual(['ariel', 'bluesky']);
+  });
+
+  test('a 2D arrangement flattens column-first: a stacked pair before its neighbor', async () => {
+    // ariel over bluesky on the left, okf full-height on the right. Flattened,
+    // not raster-scanned — pixel geometry is out of scope for the report.
+    const { serializeOpenTiles } = await import(SYNC);
+    const root = branch(
+      branch(leaf('iframe:ariel'), leaf('iframe:bluesky')),
+      leaf('iframe:okf'),
+      leaf('terminal'),
+    );
+
+    expect(serializeOpenTiles(apiWithGrid(root))).toEqual(['ariel', 'bluesky', 'okf']);
+  });
+
+  test('nests to arbitrary depth', async () => {
+    const { serializeOpenTiles } = await import(SYNC);
+    const root = branch(
+      leaf('iframe:a'),
+      branch(leaf('iframe:b'), branch(leaf('iframe:c'), leaf('terminal'))),
+      leaf('iframe:d'),
+    );
+
+    expect(serializeOpenTiles(apiWithGrid(root))).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  test('a leaf with a bare (non-branch) root is walked too', async () => {
+    // dockview requires a branch root on fromJSON, but toJSON is read here
+    // without that assumption.
+    const { serializeOpenTiles } = await import(SYNC);
+    expect(serializeOpenTiles(apiWithGrid(leaf('iframe:ariel')))).toEqual(['ariel']);
+  });
+
+  test('an UNRECOGNIZED ROOT is unreadable (null), never an affirmative empty workspace', async () => {
+    // The whole tree is unreadable, so there is nothing to assert about
+    // occupancy — distinct from an inner node, whose siblings still describe
+    // real tiles and which is therefore skipped rather than fatal.
+    const { serializeOpenTiles } = await import(SYNC);
+
+    expect(serializeOpenTiles(apiWithGrid({ type: 'mystery', data: [] }))).toBeNull();
+    expect(serializeOpenTiles(apiWithGrid({ data: [] }))).toBeNull();
+    expect(serializeOpenTiles(apiWithGrid({ type: 'leaf', data: { views: [] } }))).toEqual([]);
+  });
+
+  test('malformed nodes are skipped, not thrown on', async () => {
+    const { serializeOpenTiles } = await import(SYNC);
+    const root = branch(
+      null,
+      { type: 'leaf' },
+      { type: 'leaf', data: { views: 'not-an-array' } },
+      { type: 'mystery', data: [leaf('iframe:ignored')] },
+      leaf('iframe:ariel'),
+    );
+
+    expect(serializeOpenTiles(apiWithGrid(root))).toEqual(['ariel']);
+  });
+
+  test('a panel referenced twice by a malformed tree is reported once', async () => {
+    const { serializeOpenTiles } = await import(SYNC);
+    const root = branch(leaf('iframe:ariel'), leaf('iframe:bluesky'), leaf('iframe:ariel'));
+
+    expect(serializeOpenTiles(apiWithGrid(root))).toEqual(['ariel', 'bluesky']);
+  });
+
+  test('does not mutate the serialized layout it reads', async () => {
+    const { serializeOpenTiles } = await import(SYNC);
+    const root = branch(branch(leaf('iframe:ariel'), leaf('terminal')), leaf('iframe:okf'));
+    const before = JSON.stringify(root);
+
+    serializeOpenTiles(apiWithGrid(root));
+
+    expect(JSON.stringify(root)).toBe(before);
+  });
+});
+
+describe('occupancy reporter — settle debounce, content dedupe, capability', () => {
+  const SETTLE = 250;
+
+  /**
+   * Wire dock-sync against an api that serializes `root`, then fire the
+   * boot-layout-settled hook — the normal boot, where dock-workspace finishes
+   * deciding the starting layout. Reporting is inert until that fires, so tests
+   * about steady-state behavior go through here; tests about the boot window
+   * itself withhold it (pass `settled: false`) and fire state.restoreHook
+   * themselves.
+   * @param {any} root
+   * @param {{settled?: boolean}} [opts]
+   */
+  async function wireReporting(root, { settled = true } = {}) {
+    const api = withGrid(makeApi(), root);
+    const { mod } = await wire(api);
+    if (settled) state.restoreHook?.();
+    return { api, mod };
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('a SLOW restore never publishes the pre-restore layout as fact', async () => {
+    // The critical boot case. dock-workspace restores only after an /api/panels
+    // round trip; if reporting ran on a deadline, a fetch slower than that
+    // deadline would publish "no tiles open" as a confident fact, and a hook
+    // reading /api/panels in that window would believe it.
+    const { api } = await wireReporting(branch(leaf('terminal')), { settled: false });
+
+    // Far past any settle window, with the restore still in flight.
+    await vi.advanceTimersByTimeAsync(SETTLE * 20);
+    expect(reportPanelLayout).not.toHaveBeenCalled();
+
+    // The restore finally lands, and only now is there a layout worth reporting.
+    withGrid(api, branch(leaf('iframe:ariel'), leaf('iframe:okf'), leaf('terminal')));
+    state.restoreHook();
+    await vi.advanceTimersByTimeAsync(SETTLE);
+
+    expect(reportPanelLayout).toHaveBeenCalledExactlyOnceWith(['ariel', 'okf'], true);
+    expect(reportPanelLayout).not.toHaveBeenCalledWith([], true);
+  });
+
+  test('layout churn before the restore is ignored, not merely debounced', async () => {
+    const { api } = await wireReporting(branch(leaf('terminal')), { settled: false });
+
+    // The adapter docking its first placeholders, pre-restore.
+    withGrid(api, branch(leaf('iframe:ariel'), leaf('terminal')));
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE * 4);
+    withGrid(api, branch(leaf('terminal')));
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE * 4);
+
+    expect(reportPanelLayout).not.toHaveBeenCalled();
+  });
+
+  test('the boot deadline is a backstop when the restore hook never fires', async () => {
+    // A dock-workspace that never reached initPersistence, or a fetch that
+    // neither resolves nor rejects: reporting must not be disabled forever.
+    const { api } = await wireReporting(branch(leaf('iframe:ariel')), { settled: false });
+
+    await vi.advanceTimersByTimeAsync(SETTLE * 8);
+    expect(reportPanelLayout).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(reportPanelLayout).toHaveBeenCalledExactlyOnceWith(['ariel'], true);
+    expect(api.onDidLayoutChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('a restore arriving after the deadline is an ordinary layout change', async () => {
+    const { api } = await wireReporting(branch(leaf('terminal')), { settled: false });
+    await vi.advanceTimersByTimeAsync(10000 + SETTLE);
+    reportPanelLayout.mockClear();
+
+    withGrid(api, branch(leaf('iframe:ariel'), leaf('terminal')));
+    state.restoreHook();
+    await vi.advanceTimersByTimeAsync(SETTLE);
+
+    expect(reportPanelLayout).toHaveBeenCalledExactlyOnceWith(['ariel'], true);
+  });
+
+  test('reports the settled layout once the window expires', async () => {
+    const { api } = await wireReporting(branch(leaf('iframe:ariel'), leaf('terminal')));
+
+    expect(api.onDidLayoutChange).toHaveBeenCalledTimes(1);
+    expect(reportPanelLayout).not.toHaveBeenCalled(); // still settling
+
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    expect(reportPanelLayout).toHaveBeenCalledExactlyOnceWith(['ariel'], true);
+  });
+
+  test('a burst of layout changes reports ONCE, from the arrangement it settles on', async () => {
+    // The shape of a mode flip / reset / fromJSON restore: panels land one at a
+    // time, and only the final arrangement may reach the server.
+    const { api } = await wireReporting(branch(leaf('terminal')));
+
+    withGrid(api, branch(leaf('iframe:ariel'), leaf('terminal')));
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(100);
+    withGrid(api, branch(leaf('iframe:ariel'), leaf('iframe:bluesky'), leaf('terminal')));
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(100);
+    withGrid(api, branch(leaf('iframe:bluesky'), leaf('iframe:ariel'), leaf('terminal')));
+    api.fireLayout();
+
+    expect(reportPanelLayout).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    expect(reportPanelLayout).toHaveBeenCalledExactlyOnceWith(['bluesky', 'ariel'], true);
+  });
+
+  test('serializes at FLUSH time — an intermediate arrangement is never reported', async () => {
+    const { api } = await wireReporting(branch(leaf('iframe:ariel')));
+
+    // Mid-rebuild the dock is momentarily empty; it settles holding okf.
+    withGrid(api, branch());
+    api.fireLayout();
+    withGrid(api, branch(leaf('iframe:okf')));
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE);
+
+    expect(reportPanelLayout).toHaveBeenCalledExactlyOnceWith(['okf'], true);
+  });
+
+  test('an api.clear()/fromJSON rebuild never records its transient EMPTY window', async () => {
+    // The correctness case behind subscribe-after-apply + settle debounce: a
+    // rebuild legitimately serializes to [] between clear() and fromJSON, and []
+    // is a VALID report ("operator closed everything"), so nothing downstream
+    // could tell that transient from real occupancy. Only the debounce can — the
+    // window must never expire mid-rebuild.
+    const { api } = await wireReporting(branch(leaf('iframe:ariel'), leaf('terminal')));
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    reportPanelLayout.mockClear();
+
+    withGrid(api, branch()); // api.clear()
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE - 50);
+    withGrid(api, branch(leaf('terminal'))); // fromJSON, panel by panel
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE - 50);
+    withGrid(api, branch(leaf('iframe:okf'), leaf('terminal')));
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE);
+
+    expect(reportPanelLayout).toHaveBeenCalledExactlyOnceWith(['okf'], true);
+    expect(reportPanelLayout).not.toHaveBeenCalledWith([], true);
+  });
+
+  test('an unchanged layout is not re-POSTed (client half of the dedupe contract)', async () => {
+    const { api } = await wireReporting(branch(leaf('iframe:ariel')));
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    expect(reportPanelLayout).toHaveBeenCalledTimes(1);
+
+    // A sash drag or a focus change settles the layout without moving a tile.
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE);
+
+    expect(reportPanelLayout).toHaveBeenCalledTimes(1);
+  });
+
+  test('a genuine change after a deduped repeat still reports', async () => {
+    const { api } = await wireReporting(branch(leaf('iframe:ariel')));
+    await vi.advanceTimersByTimeAsync(SETTLE);
+
+    api.fireLayout(); // same list — deduped
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    withGrid(api, branch(leaf('iframe:ariel'), leaf('iframe:okf')));
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE);
+
+    expect(reportPanelLayout).toHaveBeenCalledTimes(2);
+    expect(reportPanelLayout).toHaveBeenLastCalledWith(['ariel', 'okf'], true);
+  });
+
+  test('REORDERING the same panels is a change, not a duplicate', async () => {
+    const { api } = await wireReporting(branch(leaf('iframe:ariel'), leaf('iframe:okf')));
+    await vi.advanceTimersByTimeAsync(SETTLE);
+
+    withGrid(api, branch(leaf('iframe:okf'), leaf('iframe:ariel')));
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE);
+
+    expect(reportPanelLayout).toHaveBeenCalledTimes(2);
+    expect(reportPanelLayout).toHaveBeenLastCalledWith(['okf', 'ariel'], true);
+  });
+
+  test('closing the last service tile reports an empty list (a real report)', async () => {
+    const { api } = await wireReporting(branch(leaf('iframe:ariel'), leaf('terminal')));
+    await vi.advanceTimersByTimeAsync(SETTLE);
+
+    withGrid(api, branch(leaf('terminal')));
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE);
+
+    expect(reportPanelLayout).toHaveBeenLastCalledWith([], true);
+  });
+
+  test('reports during an echo-guarded apply — the guard must NOT gate it', async () => {
+    // dockview defers onDidLayoutChange to a microtask, so it lands after the
+    // synchronous suppress window closes; gating here would suppress nothing
+    // while looking correct. Dedupe is what stops the loop instead.
+    const { api, mod } = await wireReporting(branch(leaf('terminal')));
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    reportPanelLayout.mockClear();
+
+    mod.withEchoSuppressed(() => {
+      withGrid(api, branch(leaf('iframe:ariel'), leaf('terminal')));
+      api.fireLayout();
+    });
+    await vi.advanceTimersByTimeAsync(SETTLE);
+
+    expect(reportPanelLayout).toHaveBeenCalledExactlyOnceWith(['ariel'], true);
+  });
+
+  test('an applied arrangement settles in ONE report, then goes quiet (no loop)', async () => {
+    // The convergence criterion: a server-applied arrange fires layout changes,
+    // which report once; the induced report matches, so nothing follows.
+    const { api } = await wireReporting(branch(leaf('terminal')));
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    reportPanelLayout.mockClear();
+
+    withGrid(api, branch(leaf('iframe:ariel'), leaf('iframe:okf'), leaf('terminal')));
+    api.fireLayout();
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    expect(reportPanelLayout).toHaveBeenCalledTimes(1);
+
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE * 4);
+    expect(reportPanelLayout).toHaveBeenCalledTimes(1);
+  });
+
+  test('an api that cannot serialize reports nothing and leaves the baseline intact', async () => {
+    const api = makeApi(); // no toJSON — occupancy is unknown, not empty
+    await wire(api);
+    state.restoreHook();
+
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    expect(reportPanelLayout).not.toHaveBeenCalled();
+
+    // Once it can serialize, the first real report still goes out.
+    withGrid(api, branch(leaf('iframe:ariel')));
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    expect(reportPanelLayout).toHaveBeenCalledExactlyOnceWith(['ariel'], true);
+  });
+
+  test('a dock torn down inside the settle window reports nothing', async () => {
+    const { api } = await wireReporting(branch(leaf('iframe:ariel')));
+    api.fireLayout();
+    state.api = null; // shell gone before the window expires
+
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    expect(reportPanelLayout).not.toHaveBeenCalled();
+  });
+
+  test('fallback mode sends ONE dock:false capability report and no tile reports', async () => {
+    const mod = await import(SYNC);
+    mod.initDockSync(); // no api, no #dock-root — the shell never arrives
+
+    await vi.advanceTimersByTimeAsync(150 * 33); // exhaust the bounded retry budget
+    expect(reportPanelLayout).toHaveBeenCalledExactlyOnceWith([], false);
+
+    // Re-entering after the budget is spent must not re-report.
+    mod.initDockSync();
+    mod.initDockSync();
+    await vi.advanceTimersByTimeAsync(150 * 10);
+    expect(reportPanelLayout).toHaveBeenCalledTimes(1);
+  });
+
+  test('a dock:false claim is RETRACTED when a slow shell finally arrives', async () => {
+    // The fast budget expiring means "no dock seen yet", not "no dock exists".
+    // A shell that boots slowly must be able to correct the record rather than
+    // leaving the server believing this client is dockless.
+    const mod = await import(SYNC);
+    mod.initDockSync();
+    await vi.advanceTimersByTimeAsync(150 * 33);
+    expect(reportPanelLayout).toHaveBeenCalledExactlyOnceWith([], false);
+
+    // The shell shows up late; the slow poll is still watching.
+    const api = withGrid(makeApi(), branch(leaf('iframe:ariel'), leaf('terminal')));
+    state.api = api;
+    const root = document.createElement('div');
+    root.id = 'dock-root';
+    document.body.appendChild(root);
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(api.onDidActivePanelChange).toHaveBeenCalledTimes(1);
+
+    state.restoreHook();
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    expect(reportPanelLayout).toHaveBeenLastCalledWith(['ariel'], true);
+  });
+
+  test('the slow poll is finite — a page with no dock stops watching', async () => {
+    const mod = await import(SYNC);
+    mod.initDockSync();
+    await vi.advanceTimersByTimeAsync(150 * 33 + 1000 * 70); // past both budgets
+
+    const api = makeApi();
+    state.api = api;
+    const root = document.createElement('div');
+    root.id = 'dock-root';
+    document.body.appendChild(root);
+    await vi.advanceTimersByTimeAsync(1000 * 10);
+
+    expect(api.onDidActivePanelChange).not.toHaveBeenCalled();
+  });
+
+  test('a deduped no-op ack (updated:false) still sets the dedupe baseline', async () => {
+    // The server already held this list, so it is acknowledged even though
+    // nothing changed — the client must treat it as reported, not retry it.
+    reportPanelLayout.mockImplementation((/** @type {string[]} */ tiles, /** @type {boolean} */ dock) =>
+      Promise.resolve({ status: 'ok', tiles, dock, updated: false }),
+    );
+    const { api } = await wireReporting(branch(leaf('iframe:ariel')));
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    expect(reportPanelLayout).toHaveBeenCalledTimes(1);
+
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE * 4);
+    expect(reportPanelLayout).toHaveBeenCalledTimes(1);
+  });
+
+  test('a report that never LANDED is retried, not remembered as sent', async () => {
+    // Optimistically marking a failed POST as reported would dedupe that layout
+    // away forever, leaving the server permanently wrong about occupancy.
+    reportPanelLayout.mockImplementation(() => Promise.resolve(null));
+    const { api } = await wireReporting(branch(leaf('iframe:ariel')));
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    expect(reportPanelLayout).toHaveBeenCalledTimes(1);
+
+    api.fireLayout(); // same layout — but the server never got it
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    expect(reportPanelLayout).toHaveBeenCalledTimes(2);
+    expect(reportPanelLayout).toHaveBeenLastCalledWith(['ariel'], true);
+
+    // Once a report lands, the baseline takes hold and dedupe resumes.
+    reportPanelLayout.mockImplementation((/** @type {string[]} */ tiles, /** @type {boolean} */ dock) =>
+      Promise.resolve({ status: 'ok', tiles, dock, updated: true }),
+    );
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    expect(reportPanelLayout).toHaveBeenCalledTimes(3);
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    expect(reportPanelLayout).toHaveBeenCalledTimes(3);
+  });
+
+  test('a REJECTED report does not strand the in-flight flag and kill reporting', async () => {
+    // reportPanelLayout is documented never to reject, but that contract lives in
+    // another module. Were it ever broken, an unhandled rejection would leave the
+    // serialization flag raised and silently suppress every later report — the one
+    // failure mode the whole design errs away from. Pinned so it stays recoverable.
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    reportPanelLayout.mockImplementation(() => Promise.reject(new Error('contract broken')));
+    const { api } = await wireReporting(branch(leaf('iframe:ariel')));
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    expect(reportPanelLayout).toHaveBeenCalledTimes(1);
+    expect(errSpy).toHaveBeenCalled();
+
+    // The reporter is still alive: the next layout change reports normally.
+    reportPanelLayout.mockImplementation((/** @type {string[]} */ tiles, /** @type {boolean} */ dock) =>
+      Promise.resolve({ status: 'ok', tiles, dock, updated: true }),
+    );
+    withGrid(api, branch(leaf('iframe:ariel'), leaf('iframe:okf')));
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    expect(reportPanelLayout).toHaveBeenCalledTimes(2);
+    expect(reportPanelLayout).toHaveBeenLastCalledWith(['ariel', 'okf'], true);
+    errSpy.mockRestore();
+  });
+
+  test('the baseline follows the ACKNOWLEDGED tiles, not the ones sent', async () => {
+    // A server that normalized the list would otherwise leave the client
+    // re-POSTing forever; the baseline is whatever the server says it holds.
+    reportPanelLayout.mockImplementation((/** @type {string[]} */ _tiles, /** @type {boolean} */ dock) =>
+      Promise.resolve({ status: 'ok', tiles: ['ariel'], dock, updated: true }),
+    );
+    const { api } = await wireReporting(branch(leaf('iframe:ariel')));
+    await vi.advanceTimersByTimeAsync(SETTLE);
+
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE);
+
+    expect(reportPanelLayout).toHaveBeenCalledTimes(1);
+  });
+
+  test('a second report never overlaps one in flight — it waits for the ack', async () => {
+    // Two concurrent reports could be applied by the server in one order and
+    // acknowledged in the other, and no client-side rule could tell which write
+    // stuck. Overlap is therefore prevented rather than arbitrated.
+    /** Resolvers for the reports still in flight; calling one delivers its ack.
+     *  @type {(() => void)[]} */
+    const pending = [];
+    reportPanelLayout.mockImplementation((/** @type {string[]} */ tiles, /** @type {boolean} */ dock) =>
+      new Promise((resolve) => pending.push(() => resolve({
+        status: 'ok', tiles, dock, updated: true,
+      }))),
+    );
+
+    const { api } = await wireReporting(branch(leaf('iframe:ariel')));
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    expect(reportPanelLayout).toHaveBeenCalledTimes(1); // first report, unacked
+
+    // The operator keeps working while that report is still outstanding.
+    withGrid(api, branch(leaf('iframe:ariel'), leaf('iframe:okf')));
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE * 4);
+    expect(reportPanelLayout).toHaveBeenCalledTimes(1); // still only the first
+
+    // Once it acks, the deferred report goes out — with the CURRENT layout.
+    pending[0]();
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    expect(reportPanelLayout).toHaveBeenCalledTimes(2);
+    expect(reportPanelLayout).toHaveBeenLastCalledWith(['ariel', 'okf'], true);
+  });
+
+  test('a late ack cannot rewrite a baseline set by a newer report', async () => {
+    // The out-of-order-acks scenario, made unreachable by serialization: because
+    // the second report is not sent until the first is acknowledged, their acks
+    // cannot race. Pinned so a future change that reintroduces overlap fails here.
+    /** @type {(() => void)[]} */
+    const pending = [];
+    reportPanelLayout.mockImplementation((/** @type {string[]} */ tiles, /** @type {boolean} */ dock) =>
+      new Promise((resolve) => pending.push(() => resolve({
+        status: 'ok', tiles, dock, updated: true,
+      }))),
+    );
+
+    const { api } = await wireReporting(branch(leaf('iframe:ariel')));
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    withGrid(api, branch(leaf('iframe:okf')));
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE * 2);
+
+    expect(pending).toHaveLength(1); // never two in flight, so no ack race exists
+    pending[0]();
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    pending[1]();
+    await vi.advanceTimersByTimeAsync(SETTLE);
+
+    // Baseline ended on the newer list: a repeat of it is deduped away.
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE * 4);
+    expect(reportPanelLayout).toHaveBeenCalledTimes(2);
+    expect(reportPanelLayout).toHaveBeenLastCalledWith(['okf'], true);
+  });
+
+  test('a STALE ack causes a redundant report, never suppression', async () => {
+    // The invariant behind the module header's "no sequence guard" rule. Feed an
+    // ack that names an older list than the one just sent — what a reordered or
+    // superseded response would carry — and the client must end up re-reporting
+    // the real layout. Erring toward a redundant POST is recoverable (the server
+    // dedupes it); erring toward suppression is not, because a suppressed report
+    // leaves the server wrong with nothing scheduled to correct it.
+    reportPanelLayout.mockImplementation((/** @type {string[]} */ _tiles, /** @type {boolean} */ dock) =>
+      Promise.resolve({ status: 'ok', tiles: ['stale-older-list'], dock, updated: true }),
+    );
+    const { api } = await wireReporting(branch(leaf('iframe:ariel')));
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    expect(reportPanelLayout).toHaveBeenCalledExactlyOnceWith(['ariel'], true);
+
+    // Layout unchanged, but the baseline disagrees with it, so it reports again
+    // rather than concluding the server already knows.
+    api.fireLayout();
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    expect(reportPanelLayout).toHaveBeenCalledTimes(2);
+    expect(reportPanelLayout).toHaveBeenLastCalledWith(['ariel'], true);
+  });
+
+  test('a client WITH a dock never sends the dock:false capability report', async () => {
+    await wireReporting(branch(leaf('iframe:ariel')));
+    await vi.advanceTimersByTimeAsync(SETTLE * 4);
+
+    expect(reportPanelLayout).toHaveBeenCalledExactlyOnceWith(['ariel'], true);
   });
 });
 
@@ -657,20 +1385,22 @@ describe('initDockSync — wiring, idempotency, late arrival', () => {
     }
   });
 
-  test('gives up after the bounded retry budget when the shell never appears', async () => {
+  test('gives up once BOTH retry budgets are spent and the shell never appears', async () => {
     vi.useFakeTimers();
     try {
       const mod = await import(SYNC);
       mod.initDockSync();
-      // 31 ticks exhausts the wireAttempts budget without a root/api present.
-      vi.advanceTimersByTime(150 * 33);
+      // The fast budget only concludes "no dock seen yet" — a slow 1s poll keeps
+      // watching for about a minute so a late shell can still wire (see the
+      // reporter suite's retraction test). Both must be spent to stop for good.
+      vi.advanceTimersByTime(150 * 33 + 1000 * 70);
       // Shell finally arrives, but the retry loop has already stopped.
       const api = makeApi();
       state.api = api;
       const root = document.createElement('div');
       root.id = 'dock-root';
       document.body.appendChild(root);
-      vi.advanceTimersByTime(150 * 5);
+      vi.advanceTimersByTime(1000 * 10);
       expect(api.onDidActivePanelChange).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();

--- a/tests/interfaces/web_terminal/palette-registry.test.mjs
+++ b/tests/interfaces/web_terminal/palette-registry.test.mjs
@@ -9,7 +9,7 @@
  *   - config ok flattens a NESTED sections tree into leaf dot-keys, and each
  *     item's run calls the injected revealSetting with its dot-key
  *   - Panels emit Show/Focus items wired to showPanel/focusPanel by id
- *   - Layouts emit items wired to applyPreset with the preset's panels
+ *   - Layouts emit items wired to applyPreset with the preset's NAME
  *   - Actions are wrapped in order with run passed through
  *   - missing optional deps never throw and contribute nothing
  *
@@ -134,19 +134,21 @@ describe('buildRegistry', () => {
     expect(focused).toEqual(['okf']);
   });
 
-  it('LAYOUTS: preset run applies the preset panels array', () => {
-    /** @type {string[][]} */
+  it('LAYOUTS: preset run applies the preset BY NAME', () => {
+    /** @type {string[]} */
     const applied = [];
     const items = buildRegistry({
       getPresets: () => [{ name: 'Focus Mode', panels: ['chat', 'ariel'] }],
-      applyPreset: (panels) => applied.push(panels),
+      applyPreset: (name) => applied.push(name),
     });
 
     const layouts = inGroup(items, 'Layouts');
     expect(layouts).toHaveLength(1);
     expect(layouts[0].label).toContain('Focus Mode');
     layouts[0].run();
-    expect(applied).toEqual([['chat', 'ariel']]);
+    // The name is what the arrange request carries — members are resolved
+    // server-side, so the palette never handles the panel list itself.
+    expect(applied).toEqual(['Focus Mode']);
   });
 
   it('ACTIONS: injected actions preserved in order with run wired through', () => {

--- a/tests/interfaces/web_terminal/panel-add-menu.test.mjs
+++ b/tests/interfaces/web_terminal/panel-add-menu.test.mjs
@@ -123,7 +123,7 @@ describe('initPanelAddMenu — Layouts section', () => {
     expect(headings).not.toContain('Layouts');
   });
 
-  test('clicking a preset calls onApplyPreset with its panels and closes the menu', () => {
+  test('clicking a preset calls onApplyPreset with its NAME and closes the menu', () => {
     const dom = mountMenuDom();
     const onApplyPreset = vi.fn();
     const presets = [{ name: 'Machine setup', panels: ['channel-finder', 'lattice'] }];
@@ -133,7 +133,9 @@ describe('initPanelAddMenu — Layouts section', () => {
     const item = /** @type {HTMLElement} */ (dom.menu.querySelector('.panel-add-item'));
     item.click();
 
-    expect(onApplyPreset).toHaveBeenCalledWith(['channel-finder', 'lattice']);
+    // The name is the whole request — members are resolved server-side, so the
+    // menu never hands a panel list around.
+    expect(onApplyPreset).toHaveBeenCalledWith('Machine setup');
     expect(dom.menu.classList.contains('open')).toBe(false); // menu closed after apply
   });
 });

--- a/tests/interfaces/web_terminal/panel-manager.test.mjs
+++ b/tests/interfaces/web_terminal/panel-manager.test.mjs
@@ -18,6 +18,13 @@
  * Every prefix case is paired with an empty-prefix case asserting
  * byte-identical (unprefixed) behavior, per the prefix contract.
  *
+ * Beyond the prefix contract this file also pins the SSE-driven behavior the
+ * rail and the dock share — agent activity styling, rail membership, the
+ * simple-UX chat-only boot, and (with a hand-built DockviewApi published
+ * through the mocked dock-workspace module) the placement an agent switch_panel
+ * produces: focus the panel's own tile, or open one BESIDE, never evicting the
+ * tile the operator is watching.
+ *
  * Module isolation: panel-manager.js keeps PANELS/panelState/visiblePanels
  * as module-private state mutated in place by initPanelManager(), so each
  * test does vi.resetModules() + a fresh dynamic import (same pattern as
@@ -27,6 +34,37 @@
  */
 
 import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
+
+// dock-workspace.js is stubbed at the module boundary so a test can publish a
+// hand-built DockviewApi (see makeDockApi) and exercise the real placement
+// engine in dock-iframe.js / dock-sync.js. `dockState.api` stays null by
+// default, which is exactly what the real getDockApi returns with no dockview
+// shell — every test that does not opt in keeps running in fallback mode.
+const { getDockApi, openTerminalPanel, closeTerminalPanel, dockState } = vi.hoisted(() => ({
+  dockState: { api: /** @type {any} */ (null) },
+  getDockApi: vi.fn(() => /** @type {any} */ (null)),
+  openTerminalPanel: vi.fn(),
+  closeTerminalPanel: vi.fn(),
+}));
+getDockApi.mockImplementation(() => dockState.api);
+
+vi.mock('../../../src/osprey/interfaces/web_terminal/static/js/dock-workspace.js', () => ({
+  getDockApi,
+  openTerminalPanel,
+  closeTerminalPanel,
+  // Pulled in by dock-iframe.js on the transitive import chain; a mock must
+  // supply them or they resolve to undefined.
+  defaultServiceWidth: () => 600,
+  setServiceRedock: () => {},
+  onDragGesture: () => [],
+}));
+
+/** The adapter's live-follow observer; geometry itself is browser-suite turf. */
+class FakeResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
 
 /** Minimal ok-JSON fetch Response stand-in. @param {any} body */
 function jsonOk(body) {
@@ -80,6 +118,9 @@ async function freshImport() {
 
 beforeEach(() => {
   delete window.__OSPREY_PREFIX__;
+  vi.clearAllMocks();
+  getDockApi.mockImplementation(() => dockState.api);
+  dockState.api = null;
 });
 
 afterEach(() => {
@@ -698,5 +739,637 @@ describe('rail membership (launcher model: entry ⇔ member, never dimmed)', () 
     const term = entry('terminal');
     expect(term).not.toBeNull();
     expect(term?.classList.contains('disabled')).toBe(false);
+  });
+});
+
+/**
+ * A hand-built DockviewApi stand-in modeling the group bookkeeping the placement
+ * engine relies on: an add with `direction: 'within'` joins the reference group
+ * (dockview's stacking — the evicting 'replace' placement), anything else opens
+ * a fresh group. Activation is tracked on both `activePanel` and `activeGroup`
+ * (the anchor dockPanelBesideActive splits against) and fires the active-panel
+ * listeners synchronously, as dockview does — that synchronicity is what makes
+ * the echo guard work.
+ * @returns {any}
+ */
+function makeDockApi() {
+  let groupSeq = 0;
+  /** @type {any} */
+  const api = {
+    activePanel: null,
+    activeGroup: null,
+    groups: /** @type {any[]} */ ([]),
+    panels: /** @type {any[]} */ ([]),
+    _added: /** @type {any[]} */ ([]),
+    _activeCbs: /** @type {(() => void)[]} */ ([]),
+    onDidLayoutChange: vi.fn(() => ({ dispose() {} })),
+    // rail-drag.js wires these two; HTML5 rail drags are not under test here.
+    onUnhandledDragOver: vi.fn(() => ({ dispose() {} })),
+    onDidDrop: vi.fn(() => ({ dispose() {} })),
+    onDidActivePanelChange: vi.fn((/** @type {() => void} */ cb) => {
+      api._activeCbs.push(cb);
+      return { dispose() {} };
+    }),
+    getPanel: (/** @type {string} */ id) =>
+      api.panels.find((/** @type {any} */ p) => p.id === id) ?? null,
+    addPanel: (/** @type {any} */ opts) => {
+      api._added.push(opts);
+      const group = opts.position?.referenceGroup && opts.position.direction === 'within'
+        ? opts.position.referenceGroup
+        : makeGroup();
+      /** @type {any} */
+      const panel = { id: opts.id, title: opts.title, group };
+      panel.api = { setActive: () => activate(panel) };
+      group.panels.push(panel);
+      api.panels.push(panel);
+      activate(panel);
+      return panel;
+    },
+    removePanel: (/** @type {any} */ panel) => {
+      api.panels = api.panels.filter((/** @type {any} */ p) => p !== panel);
+      const group = panel.group;
+      group.panels = group.panels.filter((/** @type {any} */ p) => p !== panel);
+      if (group.panels.length === 0) {
+        api.groups = api.groups.filter((/** @type {any} */ g) => g !== group);
+      } else if (group.activePanel === panel) {
+        group.activePanel = group.panels[0];
+      }
+      if (api.activePanel === panel) {
+        const next = group.panels[0] ?? api.panels[0] ?? null;
+        api.activePanel = next;
+        api.activeGroup = next?.group ?? null;
+        if (next) for (const cb of api._activeCbs) cb();
+      }
+    },
+    /** The dock's own view of its layout — what serializeOpenTiles walks. */
+    toJSON: () => ({
+      grid: {
+        root: {
+          type: 'branch',
+          data: api.groups.map((/** @type {any} */ g) => ({
+            type: 'leaf',
+            data: { views: g.panels.map((/** @type {any} */ p) => p.id) },
+          })),
+        },
+      },
+    }),
+  };
+  /** @param {any} panel */
+  function activate(panel) {
+    panel.group.activePanel = panel;
+    api.activePanel = panel;
+    api.activeGroup = panel.group;
+    for (const cb of api._activeCbs) cb();
+  }
+  function makeGroup() {
+    const element = document.createElement('div');
+    const content = document.createElement('div');
+    content.className = 'dv-content-container';
+    element.appendChild(content);
+    /** @type {any} */
+    const group = { id: `group-${++groupSeq}`, panels: [], activePanel: null, element };
+    api.groups.push(group);
+    return group;
+  }
+  /** Seed the native terminal card in its own group (the first split's anchor). */
+  api._addTerminal = () => {
+    const group = makeGroup();
+    /** @type {any} */
+    const terminal = { id: 'terminal', group };
+    terminal.api = { setActive: () => activate(terminal) };
+    group.panels.push(terminal);
+    api.panels.push(terminal);
+    activate(terminal);
+    return terminal;
+  };
+  return api;
+}
+
+/** Catalog config endpoints for the panels these suites boot (panel-catalog.js).
+ *  @type {Record<string, string>} */
+const CONFIG_ENDPOINT = {
+  artifacts: '/api/artifact-server',
+  ariel: '/api/ariel-server',
+  'channel-finder': '/api/channel-finder-server',
+  lattice: '/api/lattice-server',
+};
+
+/**
+ * The service ids holding a dock tile, in the order the fake api added them —
+ * a set membership check, NOT spatial order. Left-to-right placement is pinned
+ * by the `position` an add carried, which is what dockview actually lays out on.
+ */
+const dockedTiles = (/** @type {any} */ api) =>
+  api.panels
+    .filter((/** @type {any} */ p) => p.id.startsWith('iframe:'))
+    .map((/** @type {any} */ p) => p.id.slice('iframe:'.length));
+
+/**
+ * Boot the manager against a live dock shell. Every listed panel is enabled and
+ * (unless named in `unhealthy`) resolves a url, which is what marks these
+ * endpoint-less panels healthy; `visible` is the server-owned rail membership,
+ * defaulting to all of them. The FIRST listed panel is the catalog default, so
+ * boot docks its tile. Resolves once every panel's config has settled and that
+ * first tile exists, i.e. past every activation the boot itself performs.
+ * @param {{ panels?: string[], visible?: string[], unhealthy?: string[],
+ *           mode?: 'simple'|'expert' }} [opts]
+ */
+async function bootWorkspace({ panels = ['artifacts', 'ariel'], visible, unhealthy = [], mode } = {}) {
+  if (mode) document.documentElement.setAttribute('data-ui-mode', mode);
+  window.__OSPREY_PREFIX__ = '';
+  vi.stubGlobal('ResizeObserver', FakeResizeObserver);
+  // The overlay layer mounts in .main-container — without it the adapter
+  // silently stays in fallback mode and no placeholder is ever created.
+  // (No #dock-root: dock-sync's reverse half — a human dock gesture becoming a
+  // POST — is its own module's contract, and leaving it unwired keeps the POST
+  // assertions in these suites about panel-manager's own reporting.)
+  document.body.innerHTML = `
+    <div class="main-container">
+      <nav id="panel-rail"></nav>
+      <div id="panel-manager"><div id="panel-content"></div></div>
+    </div>
+  `;
+  const members = visible ?? panels;
+  /** @type {{url: string, opts: any}[]} */
+  const calls = [];
+  vi.stubGlobal('fetch', vi.fn(async (/** @type {string} */ url, /** @type {any} */ o) => {
+    calls.push({ url, opts: o });
+    if (url === '/api/panels') {
+      return jsonOk({
+        enabled: panels,
+        custom: [],
+        default: null,
+        visible: members,
+        active: null,
+        labels: {},
+        // Simple mode boots chat-only while the workspace is empty; these
+        // suites are about placement, so start past that onboarding state.
+        workspace_has_artifacts: true,
+      });
+    }
+    const id = panels.find((p) => CONFIG_ENDPOINT[p] === url);
+    if (id) return jsonOk(unhealthy.includes(id) ? {} : { url: `/panel/${id}`, available: true });
+    return jsonOk({ status: 'ok' });
+  }));
+  const { emit } = stubEventSource();
+
+  const api = makeDockApi();
+  api._addTerminal();
+  dockState.api = api;
+
+  const mod = await freshImport();
+  await mod.initPanelManager('panel-manager');
+  // The configEndpoint fetches settle after initPanelManager's own promise: a
+  // healthy panel resolves its url on that settle, an unhealthy one never does
+  // (wait on the fetch itself so both land before the frame under test).
+  for (const id of panels) {
+    if (unhealthy.includes(id)) {
+      await vi.waitFor(() => expect(calls.some((c) => c.url === CONFIG_ENDPOINT[id])).toBe(true));
+    } else {
+      await vi.waitFor(() => expect(mod.getPanelStandaloneUrl(id)).toBe(`/panel/${id}`));
+    }
+  }
+  await vi.waitFor(() => expect(api.getPanel(`iframe:${panels[0]}`)).not.toBeNull());
+  calls.length = 0;
+  return { api, emit, mod, calls };
+}
+
+/** POSTs the client sent — an applied SSE frame must never re-report focus. */
+const posts = (/** @type {{url: string, opts: any}[]} */ calls) =>
+  calls.filter((c) => c.opts?.method === 'POST').map((c) => c.url);
+
+describe("agent switch_panel (panel_focus source:'agent') — focus or open BESIDE, never evict", () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute('data-ui-mode');
+  });
+
+  test('an undocked rail member opens as a NEW tile beside the active one — nothing is evicted', async () => {
+    const { api, emit, calls } = await bootWorkspace();
+    const artifactsTile = api.getPanel('iframe:artifacts');
+    const artifactsGroup = artifactsTile.group;
+
+    emit({ type: 'panel_focus', panel: 'ariel', source: 'agent' });
+
+    // The operator's tile survives, untouched (same panel object, same group).
+    expect(api.getPanel('iframe:artifacts')).toBe(artifactsTile);
+    expect(artifactsTile.group).toBe(artifactsGroup);
+    // ariel arrived as its own tile, split off the active group.
+    const added = api._added.filter((/** @type {any} */ o) => o.id === 'iframe:ariel');
+    expect(added).toHaveLength(1);
+    expect(added[0].position).toMatchObject({ referenceGroup: artifactsGroup, direction: 'right' });
+    expect(api.getPanel('iframe:ariel').group).not.toBe(artifactsGroup);
+    // ...and holds the focus, without echoing it back to the server.
+    expect(document.getElementById('panel-manager')?.dataset.activePanel).toBe('ariel');
+    expect(posts(calls)).toEqual([]);
+  });
+
+  test('a panel that already holds a tile is only focused — no second tile, no move', async () => {
+    const { api, emit, calls } = await bootWorkspace();
+    emit({ type: 'panel_focus', panel: 'ariel', source: 'agent' });
+    const arielTile = api.getPanel('iframe:ariel');
+    const artifactsTile = api.getPanel('iframe:artifacts');
+    const addsBefore = api._added.length;
+
+    emit({ type: 'panel_focus', panel: 'artifacts', source: 'agent' });
+
+    expect(api._added).toHaveLength(addsBefore);
+    expect(api.getPanel('iframe:artifacts')).toBe(artifactsTile);
+    expect(api.getPanel('iframe:ariel')).toBe(arielTile);
+    expect(api.activePanel).toBe(artifactsTile);
+    expect(document.getElementById('panel-manager')?.dataset.activePanel).toBe('artifacts');
+    expect(posts(calls)).toEqual([]);
+  });
+
+  test('a NON-member gains its rail entry first, then opens beside', async () => {
+    const { api, emit, mod, calls } = await bootWorkspace({ visible: ['artifacts'] });
+    expect(document.querySelector('.panel-rail-button[data-panel-id="ariel"]')).toBeNull();
+    const artifactsTile = api.getPanel('iframe:artifacts');
+
+    emit({ type: 'panel_focus', panel: 'ariel', source: 'agent' });
+
+    const entry = document.querySelector('.panel-rail-button[data-panel-id="ariel"]');
+    expect(entry).not.toBeNull();
+    expect(entry?.classList.contains('disabled')).toBe(false);
+    expect(mod.getHiddenPanels().map((p) => p.id)).not.toContain('ariel');
+    expect(api.getPanel('iframe:artifacts')).toBe(artifactsTile);
+    expect(api.getPanel('iframe:ariel')).not.toBeNull();
+    // Membership is APPLIED locally, never reported: this is the optimistic
+    // half of a decision the server makes too, and its visibility echo lands on
+    // the entry already here (see the idempotency case below).
+    expect(posts(calls)).toEqual([]);
+  });
+
+  test('an UNHEALTHY target opens no tile — a tile it could never fill would linger empty', async () => {
+    const { api, emit } = await bootWorkspace({ unhealthy: ['ariel'] });
+    const addsBefore = api._added.length;
+
+    emit({ type: 'panel_focus', panel: 'ariel', source: 'agent' });
+
+    expect(api.getPanel('iframe:ariel')).toBeNull();
+    expect(api._added).toHaveLength(addsBefore);
+    // The activation refuses too, exactly as before — artifacts keeps the focus.
+    expect(document.getElementById('panel-manager')?.dataset.activePanel).toBe('artifacts');
+  });
+
+  test('an unknown panel id touches neither the rail nor the grid', async () => {
+    const { api, emit } = await bootWorkspace();
+    const addsBefore = api._added.length;
+
+    emit({ type: 'panel_focus', panel: 'no-such-panel', source: 'agent' });
+
+    expect(api._added).toHaveLength(addsBefore);
+    expect(api.getPanel('iframe:no-such-panel')).toBeNull();
+    expect(document.querySelector('.panel-rail-button[data-panel-id="no-such-panel"]')).toBeNull();
+  });
+
+  test('a layout that cannot be serialized still opens BESIDE — never a takeover', async () => {
+    const { api, emit } = await bootWorkspace();
+    const artifactsTile = api.getPanel('iframe:artifacts');
+    const artifactsGroup = artifactsTile.group;
+    // Mid-rebuild, or an api that refuses toJSON: occupancy is unreadable from
+    // the serialized layout even though a tile is plainly on screen. Reading it
+    // as "no tiles" would send this switch down the replacing path.
+    api.toJSON = () => {
+      throw new Error('layout mid-rebuild');
+    };
+
+    emit({ type: 'panel_focus', panel: 'ariel', source: 'agent' });
+
+    expect(api.getPanel('iframe:artifacts')).toBe(artifactsTile);
+    expect(artifactsTile.group).toBe(artifactsGroup);
+    expect(api.getPanel('iframe:ariel')).not.toBeNull();
+    expect(api.getPanel('iframe:ariel').group).not.toBe(artifactsGroup);
+  });
+
+  test('with EVERY service tile retired, the switch re-anchors left of the terminal', async () => {
+    const { api, emit } = await bootWorkspace({ visible: ['artifacts'] });
+    // Retire the only service tile the way a hide does, leaving the dock holding
+    // just the terminal — the state where "beside the active group" would mean
+    // "beside the terminal".
+    emit({ type: 'panel_visibility', panel: 'artifacts', visible: false });
+    expect(dockedTiles(api)).toEqual([]);
+    expect(api.activeGroup).toBe(api.getPanel('terminal').group);
+
+    emit({ type: 'panel_focus', panel: 'ariel', source: 'agent' });
+
+    // The first tile rule wins: left of the terminal at the classic width, not
+    // a default-width split off the terminal's own group.
+    const added = api._added.filter((/** @type {any} */ o) => o.id === 'iframe:ariel');
+    expect(added).toHaveLength(1);
+    expect(added[0].position).toMatchObject({ referencePanel: 'terminal', direction: 'left' });
+    expect(added[0].initialWidth).toBeGreaterThan(0);
+    expect(document.getElementById('panel-manager')?.dataset.activePanel).toBe('ariel');
+  });
+
+  test("the switch's membership add is idempotent with the server's own visibility echo", async () => {
+    const { emit } = await bootWorkspace({ visible: ['artifacts'] });
+
+    emit({ type: 'panel_focus', panel: 'ariel', source: 'agent' });
+    const added = document.querySelector('.panel-rail-button[data-panel-id="ariel"]');
+    expect(added).not.toBeNull();
+
+    // The focus route also appends the non-member server-side and broadcasts a
+    // visibility frame; arriving after the optimistic local add, it must leave
+    // the very same entry in place rather than rebuild or duplicate it.
+    emit({ type: 'panel_visibility', panel: 'ariel', visible: true, source: 'agent' });
+
+    const entries = document.querySelectorAll('.panel-rail-button[data-panel-id="ariel"]');
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toBe(added);
+    expect(entries[0].classList.contains('disabled')).toBe(false);
+  });
+
+  test('an untagged (human-origin) focus echo keeps the evicting takeover', async () => {
+    const { api, emit } = await bootWorkspace();
+    const artifactsTile = api.getPanel('iframe:artifacts');
+    const artifactsGroup = artifactsTile.group;
+
+    emit({ type: 'panel_focus', panel: 'ariel' });
+
+    // Rail-click semantics: ariel takes the tile over and artifacts is evicted.
+    expect(api.getPanel('iframe:artifacts')).toBeNull();
+    expect(api.getPanel('iframe:ariel').group).toBe(artifactsGroup);
+  });
+
+  test('simple mode keeps the single-tile takeover (the placement verb no-ops there)', async () => {
+    const { api, emit } = await bootWorkspace({ mode: 'simple' });
+    const artifactsGroup = api.getPanel('iframe:artifacts').group;
+
+    emit({ type: 'panel_focus', panel: 'ariel', source: 'agent' });
+
+    expect(api.getPanel('iframe:artifacts')).toBeNull();
+    expect(api.getPanel('iframe:ariel').group).toBe(artifactsGroup);
+    expect(api.panels.filter((/** @type {any} */ p) => p.id.startsWith('iframe:'))).toHaveLength(1);
+  });
+
+  test('fallback mode (no dock shell) activates exactly as before — no focus re-POST', async () => {
+    window.__OSPREY_PREFIX__ = '';
+    renderContainer();
+    /** @type {{url: string, opts: any}[]} */
+    const calls = [];
+    vi.stubGlobal('fetch', vi.fn(async (/** @type {string} */ url, /** @type {any} */ o) => {
+      calls.push({ url, opts: o });
+      if (url === '/api/panels') {
+        return jsonOk({
+          enabled: ['artifacts', 'ariel'], custom: [], default: null,
+          visible: ['artifacts'], active: null, labels: {},
+        });
+      }
+      if (url === '/api/artifact-server') return jsonOk({ url: '/panel/artifacts', available: true });
+      if (url === '/api/ariel-server') return jsonOk({ url: '/panel/ariel', available: true });
+      return jsonOk({ status: 'ok' });
+    }));
+    const { emit } = stubEventSource();
+
+    const mod = await freshImport();
+    await mod.initPanelManager('panel-manager');
+    await vi.waitFor(() => expect(mod.getPanelStandaloneUrl('ariel')).toBe('/panel/ariel'));
+    calls.length = 0;
+
+    emit({ type: 'panel_focus', panel: 'ariel', source: 'agent' });
+
+    expect(document.getElementById('panel-manager')?.dataset.activePanel).toBe('ariel');
+    expect(document.querySelector('.panel-rail-button[data-panel-id="ariel"]')).not.toBeNull();
+    expect(posts(calls)).toEqual([]);
+  });
+});
+
+describe('panel_arrange — the declarative whole-workspace rebuild', () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute('data-ui-mode');
+  });
+
+  /** @param {string} id */
+  const entry = (id) => document.querySelector(`.panel-rail-button[data-panel-id="${id}"]`);
+  const activeStamp = () => document.getElementById('panel-manager')?.dataset.activePanel ?? null;
+
+  const THREE = ['artifacts', 'ariel', 'channel-finder'];
+
+  test('converges to exactly the requested tiles, left to right', async () => {
+    const { api, emit } = await bootWorkspace({ panels: THREE });
+
+    emit({ type: 'panel_arrange', tiles: ['channel-finder', 'ariel'] });
+
+    expect(dockedTiles(api)).toEqual(['channel-finder', 'ariel']);
+    // The first tile splits against the grid's left edge (services sit left of
+    // the terminal); each next one lands to the RIGHT of the one before it.
+    const adds = api._added.filter((/** @type {any} */ o) => o.id.startsWith('iframe:'));
+    const cf = adds.at(-2);
+    const ariel = adds.at(-1);
+    expect(cf).toMatchObject({ id: 'iframe:channel-finder', position: { direction: 'left' } });
+    expect(ariel.position).toMatchObject({
+      referenceGroup: api.getPanel('iframe:channel-finder').group,
+      direction: 'right',
+    });
+  });
+
+  test('converges from a DIFFERENT start layout to the same end state', async () => {
+    const { api, emit } = await bootWorkspace({ panels: THREE });
+    // Start with all three open in a different order than the arrangement asks
+    // for, so the rebuild has both a tile to drop and tiles to reorder.
+    emit({ type: 'panel_focus', panel: 'ariel', source: 'agent' });
+    emit({ type: 'panel_focus', panel: 'channel-finder', source: 'agent' });
+    expect(dockedTiles(api).sort()).toEqual(['ariel', 'artifacts', 'channel-finder']);
+
+    emit({ type: 'panel_arrange', tiles: ['channel-finder', 'ariel'] });
+
+    expect(dockedTiles(api)).toEqual(['channel-finder', 'ariel']);
+    // Same end state as the clean-start case, positions included: the region is
+    // rebuilt, not diffed, so a differing start layout cannot leave order behind.
+    expect(api._added.at(-1).position).toMatchObject({
+      referenceGroup: api.getPanel('iframe:channel-finder').group,
+      direction: 'right',
+    });
+    // The dropped tile keeps its rail membership — a tile close is not a hide.
+    expect(entry('artifacts')).not.toBeNull();
+  });
+
+  test('the requested focus wins when healthy; the tiles all get their iframes', async () => {
+    const { api, emit } = await bootWorkspace({ panels: THREE });
+
+    emit({ type: 'panel_arrange', tiles: ['channel-finder', 'ariel'], focus: 'ariel' });
+
+    expect(activeStamp()).toBe('ariel');
+    expect(api.getPanel('iframe:ariel').group.activePanel.id).toBe('iframe:ariel');
+    // Every arranged tile is surfaced, not just the focused one: a docked tile
+    // whose panel was never activated would show an empty placeholder.
+    for (const id of ['channel-finder', 'ariel']) {
+      expect(document.querySelector(`iframe[data-panel-id="${id}"]`)).not.toBeNull();
+    }
+  });
+
+  test('an unhealthy focus target falls back to the first healthy listed tile', async () => {
+    const { emit } = await bootWorkspace({ panels: THREE, unhealthy: ['channel-finder'] });
+
+    emit({ type: 'panel_arrange', tiles: ['channel-finder', 'ariel'], focus: 'channel-finder' });
+
+    expect(activeStamp()).toBe('ariel');
+  });
+
+  test('no healthy tile at all leaves focus unchanged rather than stranding it', async () => {
+    const { emit } = await bootWorkspace({ panels: THREE, unhealthy: ['ariel', 'channel-finder'] });
+    expect(activeStamp()).toBe('artifacts');
+
+    emit({ type: 'panel_arrange', tiles: ['channel-finder', 'ariel'], focus: 'channel-finder' });
+
+    // artifacts lost its tile to the rebuild, so the accent it held is dropped;
+    // nothing healthy remains to take it, and no unhealthy panel is surfaced.
+    expect(activeStamp()).toBeNull();
+    expect(document.querySelector('.panel-rail-button.active')).toBeNull();
+    // ...and the pane is painted empty, the same strand-proof ending the
+    // visibility channel gives when its last usable panel goes away — a
+    // cleared accent over a stale surface would be the worse half of both.
+    expect(document.querySelector('.artifacts-empty-state')).not.toBeNull();
+  });
+
+  test('an UNHEALTHY listed panel gets no tile — only its rail entry', async () => {
+    const { api, emit } = await bootWorkspace({ panels: THREE, unhealthy: ['channel-finder'] });
+
+    emit({ type: 'panel_arrange', tiles: ['channel-finder', 'ariel'] });
+
+    // A tile it could never fill would sit empty for as long as anything else
+    // holds focus, and nothing comes back for it.
+    expect(api.getPanel('iframe:channel-finder')).toBeNull();
+    expect(api._added.filter((/** @type {any} */ o) => o.id === 'iframe:channel-finder')).toHaveLength(0);
+    expect(dockedTiles(api)).toEqual(['ariel']);
+    // Membership still applied, so it stays one rail click away.
+    expect(entry('channel-finder')).not.toBeNull();
+  });
+
+  test('a skipped tile never becomes the anchor the next one splits against', async () => {
+    const { api, emit } = await bootWorkspace({ panels: THREE, unhealthy: ['channel-finder'] });
+
+    // The unhealthy panel is listed FIRST, so a naive walk would leave `prev`
+    // pointing at a tile that does not exist and split ariel off the terminal.
+    emit({ type: 'panel_arrange', tiles: ['channel-finder', 'ariel'] });
+
+    const added = api._added.filter((/** @type {any} */ o) => o.id === 'iframe:ariel').at(-1);
+    expect(added.position).toEqual({ direction: 'left' });
+    expect(api.getPanel('iframe:ariel').group).not.toBe(api.getPanel('terminal').group);
+  });
+
+  test('a tile still on screen is never painted over as an empty workspace', async () => {
+    // The one reachable route to "docked but UNHEALTHY": the rail's ⊞ corner
+    // docks a tile regardless of health (its activation then refuses), which is
+    // the state the rebuild deliberately leaves on screen.
+    const { api, emit } = await bootWorkspace({
+      panels: ['artifacts', 'ariel'],
+      unhealthy: ['ariel'],
+    });
+    const beside = /** @type {HTMLElement} */ (
+      document.querySelector('[data-panel-id="ariel"] .panel-rail-beside')
+    );
+    beside.click();
+    expect(dockedTiles(api).sort()).toEqual(['ariel', 'artifacts']);
+    expect(activeStamp()).toBe('artifacts'); // the unhealthy panel took no focus
+
+    // Arrange onto the unhealthy panel alone: nothing listed can be focused, and
+    // the panel that held the view (artifacts) is not listed.
+    emit({ type: 'panel_arrange', tiles: ['ariel'] });
+
+    // Its existing tile survives the rebuild...
+    expect(dockedTiles(api)).toEqual(['ariel']);
+    // ...so the accent clears, but the pane is NOT painted empty over it.
+    expect(activeStamp()).toBeNull();
+    expect(document.querySelector('.artifacts-empty-state')).toBeNull();
+  });
+
+  test('a listed NON-member is added to the rail; a plain tiles request removes nobody', async () => {
+    const { emit, mod } = await bootWorkspace({ panels: THREE, visible: ['artifacts'] });
+    expect(entry('ariel')).toBeNull();
+
+    emit({ type: 'panel_arrange', tiles: ['ariel'] });
+
+    expect(entry('ariel')).not.toBeNull();
+    // Membership is only ADDED: artifacts is not in the arrangement but keeps
+    // its rail entry (the precedence split against panel_visibility).
+    expect(entry('artifacts')).not.toBeNull();
+    expect(mod.getHiddenPanels().map((p) => p.id)).toEqual(['channel-finder']);
+  });
+
+  test('prune_rail (the preset path) makes membership exactly the arranged tiles', async () => {
+    const { api, emit, mod } = await bootWorkspace({ panels: THREE });
+
+    emit({ type: 'panel_arrange', tiles: ['ariel'], prune_rail: true });
+
+    expect(entry('ariel')).not.toBeNull();
+    expect(entry('artifacts')).toBeNull();
+    expect(entry('channel-finder')).toBeNull();
+    expect(mod.getHiddenPanels().map((p) => p.id).sort()).toEqual(['artifacts', 'channel-finder']);
+    expect(dockedTiles(api)).toEqual(['ariel']);
+  });
+
+  test('applying an arrangement reports nothing back to the server', async () => {
+    const { emit, calls } = await bootWorkspace({ panels: THREE });
+
+    emit({ type: 'panel_arrange', tiles: ['channel-finder', 'ariel'], focus: 'ariel', source: 'agent' });
+
+    expect(posts(calls)).toEqual([]);
+  });
+
+  test("source:'agent' glows the arranged entries transiently, without the badge", async () => {
+    const { emit } = await bootWorkspace({ panels: THREE });
+
+    emit({ type: 'panel_arrange', tiles: ['channel-finder', 'ariel'], source: 'agent' });
+
+    expect(entry('ariel')?.classList.contains('agent-flash')).toBe(true);
+    expect(entry('channel-finder')?.classList.contains('agent-flash')).toBe(true);
+    expect(entry('ariel')?.classList.contains('agent-attention')).toBe(false);
+    expect(entry('artifacts')?.classList.contains('agent-flash')).toBe(false);
+  });
+
+  test('unknown ids are dropped rather than arranged as ghost tiles', async () => {
+    const { api, emit } = await bootWorkspace({ panels: THREE });
+
+    emit({ type: 'panel_arrange', tiles: ['ariel', 'no-such-panel'] });
+
+    expect(dockedTiles(api)).toEqual(['ariel']);
+    expect(entry('no-such-panel')).toBeNull();
+  });
+
+  test('simple mode skips the rebuild and takes the single tile over', async () => {
+    const { api, emit } = await bootWorkspace({ panels: THREE, mode: 'simple' });
+    expect(dockedTiles(api)).toEqual(['artifacts']);
+
+    emit({ type: 'panel_arrange', tiles: ['channel-finder', 'ariel'], focus: 'ariel' });
+
+    // One service tile by construction: the focus target takes it over, and no
+    // second tile is opened beside it.
+    expect(dockedTiles(api)).toEqual(['ariel']);
+    expect(activeStamp()).toBe('ariel');
+    // Membership still applies in simple mode — the rail is not a dock feature.
+    expect(entry('channel-finder')).not.toBeNull();
+  });
+
+  test('fallback mode (no dock shell) applies membership and focus only', async () => {
+    window.__OSPREY_PREFIX__ = '';
+    renderContainer();
+    /** @type {{url: string, opts: any}[]} */
+    const calls = [];
+    vi.stubGlobal('fetch', vi.fn(async (/** @type {string} */ url, /** @type {any} */ o) => {
+      calls.push({ url, opts: o });
+      if (url === '/api/panels') {
+        return jsonOk({
+          enabled: ['artifacts', 'ariel'], custom: [], default: null,
+          visible: ['artifacts'], active: null, labels: {},
+        });
+      }
+      if (url === '/api/artifact-server') return jsonOk({ url: '/panel/artifacts', available: true });
+      if (url === '/api/ariel-server') return jsonOk({ url: '/panel/ariel', available: true });
+      return jsonOk({ status: 'ok' });
+    }));
+    const { emit } = stubEventSource();
+
+    const mod = await freshImport();
+    await mod.initPanelManager('panel-manager');
+    await vi.waitFor(() => expect(mod.getPanelStandaloneUrl('ariel')).toBe('/panel/ariel'));
+    calls.length = 0;
+
+    emit({ type: 'panel_arrange', tiles: ['ariel'], focus: 'ariel', prune_rail: true });
+
+    expect(entry('ariel')).not.toBeNull();
+    expect(entry('artifacts')).toBeNull();  // prune_rail holds without a dock
+    expect(activeStamp()).toBe('ariel');
+    expect(posts(calls)).toEqual([]);
   });
 });

--- a/tests/interfaces/web_terminal/panel-presets.test.mjs
+++ b/tests/interfaces/web_terminal/panel-presets.test.mjs
@@ -1,18 +1,26 @@
 /**
- * Unit tests for the pure preset-diff core.
+ * Unit tests for the preset core.
  *
  *   npx vitest run tests/interfaces/web_terminal/panel-presets.test.mjs
  *
  * computePresetDiff resolves a preset into an EXCLUSIVE show/hide diff against
- * the live visible set; applyPreset orchestrates show-before-hide + local focus.
- * The DOM/popover behavior is covered end-to-end by the Playwright suite
- * (test_panels_browser.py); here we pin the pure contract.
+ * the live visible set. It is the executable statement of what "apply a layout"
+ * means — exactly the members open, every non-member closed, unknown ids
+ * dropped fail-safe — and the resolution /api/panel-arrange performs
+ * server-side mirrors it, so these cases stay the reference for both.
+ *
+ * applyPreset itself no longer orchestrates anything locally: it sends the
+ * preset NAME to the arrange endpoint and the panel_arrange SSE echo applies
+ * the result on every client (panel-placement.js), which is what makes a human
+ * "Layouts" click and an agent arrange_workspace(preset=...) call one
+ * operation. What is pinned here is that request; the applied DOM behavior is
+ * covered by panel-manager.test.mjs and the Playwright suite.
  *
  * Imported by RELATIVE path — this module lives under web_terminal, so the
  * /design-system/js/* alias does not apply.
  */
 
-import { test, expect, describe } from 'vitest';
+import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
 
 import {
   computePresetDiff,
@@ -50,67 +58,56 @@ describe('computePresetDiff', () => {
   });
 });
 
-describe('applyPreset', () => {
-  /**
-   * Build a recording harness over applyPreset's injected deps.
-   * @param {string[]} members
-   * @param {{visible: string[], known: string[], healthy?: string[]}} state
-   * @returns {[string, string][]}
-   */
-  function harness(members, { visible, known, healthy }) {
-    // Default: every known panel is healthy (the common all-reachable case).
-    const healthySet = new Set(healthy ?? known);
-    /** @type {[string, string][]} */
-    const calls = [];
-    applyPreset(members, {
-      getVisible: () => new Set(visible),
-      getKnown: () => new Set(known),
-      isHealthy: (id) => healthySet.has(id),
-      setVisibility: (id, v) => calls.push([v ? 'show' : 'hide', id]),
-      focus: (id) => calls.push(['focus', id]),
-    });
-    return calls;
-  }
+describe('applyPreset — one arrange request, no local orchestration', () => {
+  /** @type {{url: string, opts: any}[]} */
+  let calls = [];
 
-  test('shows every member first, then focuses, then hides non-members', () => {
-    const calls = harness(['a', 'b'], { visible: ['c'], known: ['a', 'b', 'c'] });
-    // a,b shown (both missing), focus a, then c hidden — show-before-hide ordering.
-    expect(calls).toEqual([
-      ['show', 'a'],
-      ['show', 'b'],
-      ['focus', 'a'],
-      ['hide', 'c'],
-    ]);
+  beforeEach(() => {
+    delete window.__OSPREY_PREFIX__;
+    calls = [];
+    vi.stubGlobal('fetch', vi.fn(async (/** @type {string} */ url, /** @type {any} */ opts) => {
+      calls.push({ url, opts });
+      return { ok: true, status: 200, json: async () => ({ status: 'ok' }) };
+    }));
   });
 
-  test('focus fires before any hide (no transient all-hidden flash)', () => {
-    const calls = harness(['a'], { visible: ['a', 'b'], known: ['a', 'b'] });
-    // a already visible (no show); focus a happens BEFORE hiding b.
-    expect(calls).toEqual([
-      ['focus', 'a'],
-      ['hide', 'b'],
-    ]);
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
-  test('no-op when the diff yields a null focus (all members unknown)', () => {
-    const calls = harness(['ghost'], { visible: ['a'], known: ['a', 'b'] });
-    expect(calls).toEqual([]);
+  test('POSTs the preset NAME to /api/panel-arrange', () => {
+    applyPreset('Machine setup');
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('/api/panel-arrange');
+    expect(calls[0].opts).toMatchObject({ method: 'POST' });
+    // preset, never a resolved panel list: the server owns resolution, and it is
+    // the preset path that sets prune_rail — a tiles request would silently lose
+    // the exclusive ("and the rest close") half of the semantics.
+    expect(JSON.parse(calls[0].opts.body)).toEqual({ preset: 'Machine setup' });
   });
 
-  test('focuses the first HEALTHY member when the primary is unhealthy', () => {
-    // a is the primary but offline → focus falls through to b (first healthy member).
-    const calls = harness(['a', 'b'], { visible: ['c'], known: ['a', 'b', 'c'], healthy: ['b', 'c'] });
-    expect(calls).toEqual([
-      ['show', 'a'],
-      ['show', 'b'],
-      ['focus', 'b'],
-      ['hide', 'c'],
-    ]);
+  test('sends nothing else — no visibility or focus POST rides along', () => {
+    applyPreset('Logbook review');
+
+    expect(calls.map((c) => c.url)).toEqual(['/api/panel-arrange']);
   });
 
-  test('no focus call when no member is healthy (SSE fallback lands the view)', () => {
-    // both members already visible (no show), neither healthy → no local focus.
-    const calls = harness(['a', 'b'], { visible: ['a', 'b'], known: ['a', 'b'], healthy: [] });
-    expect(calls).toEqual([]);
+  test('the request is prefixed under a multi-user deployment', () => {
+    window.__OSPREY_PREFIX__ = '/u/alice';
+
+    applyPreset('Machine setup');
+
+    expect(calls[0].url).toBe('/u/alice/api/panel-arrange');
+  });
+
+  test('a rejected request is swallowed — a failed layout click never throws', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new Error('offline');
+    }));
+
+    expect(() => applyPreset('Machine setup')).not.toThrow();
+    // Let the rejected promise settle: an unhandled rejection would fail the run.
+    await new Promise((r) => setTimeout(r, 0));
   });
 });

--- a/tests/interfaces/web_terminal/test_app.py
+++ b/tests/interfaces/web_terminal/test_app.py
@@ -213,6 +213,68 @@ class TestPanelFocus:
         broadcaster.unsubscribe(q)
 
 
+class TestPanelsOpenTiles:
+    """``GET /api/panels`` reports tile occupancy and how stale it is.
+
+    ``visible`` is launcher-rail membership; ``open_tiles`` is what a browser
+    last reported as actually on screen. The two freshness companions exist so
+    a consumer can tell "no client has ever reported" from "reported N seconds
+    ago" instead of trusting a possibly-abandoned list.
+
+    The payload carries three distinct states that must never collapse into
+    each other: never reported (all null), unknown occupancy (null list, real
+    age, dock false), and known occupancy (a list, possibly empty).
+    """
+
+    def test_panels_open_tiles_all_null_before_any_report(self, client):
+        """Never reported is all-null — emphatically not a known-empty screen."""
+        body = client.get("/api/panels").json()
+        assert body["open_tiles"] is None
+        assert body["open_tiles_age_s"] is None
+        assert body["open_tiles_dock"] is None
+
+    def test_panels_dock_less_report_is_unknown_occupancy(self, client):
+        """A watching-but-blind client: null tiles, real age, dock false."""
+        client.post("/api/panel-layout", json={"tiles": [], "dock": False})
+        body = client.get("/api/panels").json()
+        assert body["open_tiles"] is None
+        assert body["open_tiles_age_s"] is not None
+        assert body["open_tiles_dock"] is False
+
+    def test_panels_known_empty_is_distinct_from_unknown(self, client):
+        """A dock client reporting [] means the operator closed everything."""
+        client.post("/api/panel-layout", json={"tiles": [], "dock": True})
+        body = client.get("/api/panels").json()
+        assert body["open_tiles"] == []
+        assert body["open_tiles_dock"] is True
+
+    def test_panels_open_tiles_reflect_the_last_report(self, client):
+        client.post("/api/panel-layout", json={"tiles": ["artifacts"], "dock": True})
+        body = client.get("/api/panels").json()
+        assert body["open_tiles"] == ["artifacts"]
+        assert body["open_tiles_dock"] is True
+
+    def test_panels_open_tiles_age_is_seconds_since_the_report(self, client):
+        import time
+
+        client.post("/api/panel-layout", json={"tiles": ["artifacts"], "dock": True})
+        fresh = client.get("/api/panels").json()["open_tiles_age_s"]
+        assert 0 <= fresh < 60
+
+        # Age the stored report; the payload must report it as stale, not fresh.
+        client.app.state.open_tiles_ts = time.time() - 3600
+        aged = client.get("/api/panels").json()["open_tiles_age_s"]
+        assert aged >= 3600
+
+    def test_panels_open_tiles_are_independent_of_rail_membership(self, client):
+        """Closing every tile leaves the rail alone — occupancy is not membership."""
+        before = client.get("/api/panels").json()["visible"]
+        client.post("/api/panel-layout", json={"tiles": [], "dock": True})
+        after = client.get("/api/panels").json()
+        assert after["open_tiles"] == []
+        assert after["visible"] == before
+
+
 class TestStaticServing:
     def test_root_serves_html(self, client):
         resp = client.get("/")

--- a/tests/interfaces/web_terminal/test_panel_arrange_route.py
+++ b/tests/interfaces/web_terminal/test_panel_arrange_route.py
@@ -1,0 +1,326 @@
+"""Tests for ``POST /api/panel-arrange`` (`routes/panels.py`).
+
+The arrange route is the single server operation behind both the agent's
+``arrange_workspace`` verb and the human "Layouts" click. It validates the
+requested end state against the live panel inventory, updates rail membership
+and the recorded focus, and broadcasts exactly one ``panel_arrange`` frame that
+every client applies as a deterministic rebuild of the service-tile region.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from osprey.interfaces.web_terminal.routes.panels import router
+
+
+def _make_client(**state) -> TestClient:
+    """A minimal app exposing the panels router with a stub broadcaster.
+
+    Defaults give three known panels (two built-ins plus a custom one) and an
+    empty rail; individual tests override via keyword arguments.
+    """
+    app = FastAPI()
+    app.include_router(router)
+    app.state.broadcaster = MagicMock()
+    app.state.enabled_panels = {"ariel", "lattice", "artifacts"}
+    app.state.custom_panels = [{"id": "grafana", "label": "GRAFANA", "url": "http://10.0.0.5:3000"}]
+    app.state.visible_panels = []
+    app.state.panel_presets = []
+    for key, value in state.items():
+        setattr(app.state, key, value)
+    return TestClient(app)
+
+
+def _frame(client: TestClient) -> dict:
+    """The single broadcast frame the request produced."""
+    broadcaster = client.app.state.broadcaster
+    broadcaster.broadcast.assert_called_once()
+    return broadcaster.broadcast.call_args[0][0]
+
+
+class TestTilesPath:
+    def test_arranges_requested_tiles_in_order(self):
+        client = _make_client()
+        resp = client.post("/api/panel-arrange", json={"tiles": ["lattice", "ariel"]})
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "status": "ok",
+            "tiles": ["lattice", "ariel"],
+            "focus": None,
+            "preset": None,
+            "prune_rail": False,
+        }
+
+    def test_broadcasts_one_arrange_frame(self):
+        client = _make_client()
+        client.post("/api/panel-arrange", json={"tiles": ["lattice", "ariel"]})
+        assert _frame(client) == {"type": "panel_arrange", "tiles": ["lattice", "ariel"]}
+
+    def test_listed_non_members_are_added_to_the_rail(self):
+        client = _make_client(visible_panels=["artifacts"])
+        client.post("/api/panel-arrange", json={"tiles": ["lattice", "ariel"]})
+        assert client.app.state.visible_panels == ["artifacts", "lattice", "ariel"]
+
+    def test_omitted_panels_keep_rail_membership(self):
+        """A tiles request never removes a rail entry — only presets prune."""
+        client = _make_client(visible_panels=["artifacts", "grafana"])
+        client.post("/api/panel-arrange", json={"tiles": ["ariel"]})
+        assert client.app.state.visible_panels == ["artifacts", "grafana", "ariel"]
+
+    def test_duplicate_ids_collapse_to_first_occurrence(self):
+        client = _make_client()
+        resp = client.post("/api/panel-arrange", json={"tiles": ["ariel", "lattice", "ariel"]})
+        assert resp.json()["tiles"] == ["ariel", "lattice"]
+
+    def test_custom_panel_ids_are_arrangeable(self):
+        client = _make_client()
+        resp = client.post("/api/panel-arrange", json={"tiles": ["grafana"]})
+        assert resp.status_code == 200
+        assert resp.json()["tiles"] == ["grafana"]
+
+    def test_source_agent_is_passed_through(self):
+        client = _make_client()
+        client.post("/api/panel-arrange", json={"tiles": ["ariel"], "source": "agent"})
+        assert _frame(client)["source"] == "agent"
+
+    def test_source_key_omitted_when_not_supplied(self):
+        client = _make_client()
+        client.post("/api/panel-arrange", json={"tiles": ["ariel"]})
+        assert "source" not in _frame(client)
+
+    def test_prune_rail_key_omitted_on_the_tiles_path(self):
+        client = _make_client()
+        client.post("/api/panel-arrange", json={"tiles": ["ariel"]})
+        assert "prune_rail" not in _frame(client)
+
+
+class TestFocus:
+    def test_requested_focus_is_recorded_and_broadcast(self):
+        client = _make_client()
+        resp = client.post(
+            "/api/panel-arrange", json={"tiles": ["lattice", "ariel"], "focus": "ariel"}
+        )
+        assert resp.json()["focus"] == "ariel"
+        assert client.app.state.active_panel == "ariel"
+        assert _frame(client)["focus"] == "ariel"
+
+    def test_first_tile_becomes_active_when_no_focus_requested(self):
+        """An arrangement always lands focus — it never strands the old one."""
+        client = _make_client(active_panel="artifacts")
+        client.post("/api/panel-arrange", json={"tiles": ["lattice", "ariel"]})
+        assert client.app.state.active_panel == "lattice"
+
+    def test_no_focus_request_still_omits_focus_from_the_broadcast(self):
+        """The client's healthy-fallback rule stays in charge of the screen."""
+        client = _make_client(active_panel="artifacts")
+        client.post("/api/panel-arrange", json={"tiles": ["lattice", "ariel"]})
+        assert "focus" not in _frame(client)
+
+    def test_focus_less_response_still_reports_no_requested_focus(self):
+        """The response echoes what was *asked*, not the recorded fallback."""
+        client = _make_client()
+        resp = client.post("/api/panel-arrange", json={"tiles": ["lattice", "ariel"]})
+        assert resp.json()["focus"] is None
+
+    def test_focus_outside_the_arranged_tiles_is_rejected(self):
+        client = _make_client()
+        resp = client.post("/api/panel-arrange", json={"tiles": ["ariel"], "focus": "lattice"})
+        assert resp.status_code == 422
+        assert "lattice" in resp.json()["detail"]
+
+    def test_unknown_focus_id_is_rejected(self):
+        client = _make_client()
+        resp = client.post("/api/panel-arrange", json={"tiles": ["ariel"], "focus": "nope"})
+        assert resp.status_code == 422
+
+
+class TestPresetPath:
+    def test_preset_resolves_members_server_side(self):
+        client = _make_client(panel_presets=[{"name": "Injection", "panels": ["lattice", "ariel"]}])
+        resp = client.post("/api/panel-arrange", json={"preset": "Injection"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["tiles"] == ["lattice", "ariel"]
+        assert body["preset"] == "Injection"
+        assert body["prune_rail"] is True
+
+    def test_preset_broadcast_carries_prune_rail(self):
+        client = _make_client(panel_presets=[{"name": "L1", "panels": ["ariel"]}])
+        client.post("/api/panel-arrange", json={"preset": "L1"})
+        assert _frame(client) == {
+            "type": "panel_arrange",
+            "tiles": ["ariel"],
+            "prune_rail": True,
+        }
+
+    def test_preset_prunes_the_rail_to_its_members(self):
+        client = _make_client(
+            visible_panels=["artifacts", "lattice", "grafana"],
+            panel_presets=[{"name": "L1", "panels": ["lattice", "ariel"]}],
+        )
+        client.post("/api/panel-arrange", json={"preset": "L1"})
+        # Surviving members keep their rail order; new members are appended.
+        assert client.app.state.visible_panels == ["lattice", "ariel"]
+
+    def test_unknown_members_are_filtered_fail_safe(self):
+        """Mirrors ``computePresetDiff``: a typo'd member is skipped, not fatal."""
+        client = _make_client(panel_presets=[{"name": "L1", "panels": ["ariel", "typo"]}])
+        resp = client.post("/api/panel-arrange", json={"preset": "L1"})
+        assert resp.status_code == 200
+        assert resp.json()["tiles"] == ["ariel"]
+
+    def test_terminal_member_is_filtered_out(self):
+        client = _make_client(panel_presets=[{"name": "L1", "panels": ["terminal", "ariel"]}])
+        resp = client.post("/api/panel-arrange", json={"preset": "L1"})
+        assert resp.json()["tiles"] == ["ariel"]
+
+    def test_unknown_preset_lists_available_names(self):
+        client = _make_client(
+            panel_presets=[
+                {"name": "Injection", "panels": ["ariel"]},
+                {"name": "Tuning", "panels": ["lattice"]},
+            ]
+        )
+        resp = client.post("/api/panel-arrange", json={"preset": "Nope"})
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert "Injection" in detail and "Tuning" in detail
+        client.app.state.broadcaster.broadcast.assert_not_called()
+
+    def test_preset_with_no_known_member_is_rejected(self):
+        """Never strand an empty workspace when every member is unknown."""
+        client = _make_client(panel_presets=[{"name": "L1", "panels": ["typo", "gone"]}])
+        resp = client.post("/api/panel-arrange", json={"preset": "L1"})
+        assert resp.status_code == 422
+        assert "ariel" in resp.json()["detail"]  # valid ids are named
+        client.app.state.broadcaster.broadcast.assert_not_called()
+
+    def test_focus_may_target_a_resolved_preset_member(self):
+        client = _make_client(panel_presets=[{"name": "L1", "panels": ["lattice", "ariel"]}])
+        resp = client.post("/api/panel-arrange", json={"preset": "L1", "focus": "ariel"})
+        assert resp.status_code == 200
+        assert client.app.state.active_panel == "ariel"
+
+
+class TestActiveStaysConsistentWithVisible:
+    """``active`` must never name a panel the same payload calls invisible.
+
+    A human "Layouts" click is a focus-less preset arrange, so before the fix
+    a preset could prune the previously-active panel out of the rail while
+    ``active_panel`` still pointed at it — a contradiction that reached
+    ``list_panels`` and both workspace hooks.
+    """
+
+    def test_focus_less_preset_arrange_leaves_active_inside_visible(self):
+        client = _make_client(
+            visible_panels=["artifacts"],
+            active_panel="artifacts",
+            panel_presets=[{"name": "Injection", "panels": ["lattice", "ariel"]}],
+        )
+
+        resp = client.post("/api/panel-arrange", json={"preset": "Injection"})
+        assert resp.status_code == 200
+
+        body = client.get("/api/panels").json()
+        assert body["active"] in body["visible"], (
+            f"active={body['active']!r} is not in visible={body['visible']!r}"
+        )
+        assert body["active"] == "lattice"
+        assert "artifacts" not in body["visible"]
+
+    def test_surviving_rail_member_does_not_steal_the_recorded_focus(self):
+        """Active follows TILE order, not rail order, when the two diverge.
+
+        Pruning keeps a surviving member's rail position, so the rail can lead
+        with a panel that is not the arrangement's first tile. The recorded
+        focus must still be the first tile, matching what a client's
+        healthy-fallback rule picks.
+        """
+        client = _make_client(
+            visible_panels=["artifacts", "ariel"],
+            active_panel="artifacts",
+            panel_presets=[{"name": "Machine setup", "panels": ["lattice", "ariel"]}],
+        )
+
+        client.post("/api/panel-arrange", json={"preset": "Machine setup"})
+
+        body = client.get("/api/panels").json()
+        assert body["visible"] == ["ariel", "lattice"]  # survivor keeps its slot
+        assert body["active"] == "lattice"  # but focus follows the tile order
+        assert body["active"] in body["visible"]
+
+    def test_focus_less_tiles_arrange_leaves_active_inside_visible(self):
+        client = _make_client(visible_panels=["artifacts"], active_panel="artifacts")
+
+        client.post("/api/panel-arrange", json={"tiles": ["grafana", "ariel"]})
+
+        body = client.get("/api/panels").json()
+        assert body["active"] in body["visible"]
+        assert body["active"] == "grafana"
+
+    def test_explicit_focus_still_wins_over_the_first_tile(self):
+        client = _make_client(visible_panels=["artifacts"], active_panel="artifacts")
+
+        client.post("/api/panel-arrange", json={"tiles": ["lattice", "ariel"], "focus": "ariel"})
+
+        body = client.get("/api/panels").json()
+        assert body["active"] == "ariel"
+        assert body["active"] in body["visible"]
+
+
+class TestValidation:
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {},
+            {"focus": "ariel"},
+            {"tiles": ["ariel"], "preset": "L1"},
+        ],
+        ids=["neither", "focus-only", "both"],
+    )
+    def test_exactly_one_of_tiles_or_preset(self, payload):
+        client = _make_client(panel_presets=[{"name": "L1", "panels": ["ariel"]}])
+        resp = client.post("/api/panel-arrange", json=payload)
+        assert resp.status_code == 422
+        client.app.state.broadcaster.broadcast.assert_not_called()
+
+    def test_empty_tiles_is_rejected(self):
+        client = _make_client()
+        resp = client.post("/api/panel-arrange", json={"tiles": []})
+        assert resp.status_code == 422
+        client.app.state.broadcaster.broadcast.assert_not_called()
+
+    def test_unknown_tile_id_lists_valid_ids(self):
+        client = _make_client()
+        resp = client.post("/api/panel-arrange", json={"tiles": ["ariel", "nope"]})
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert "nope" in detail
+        for valid in ("ariel", "lattice", "artifacts", "grafana"):
+            assert valid in detail
+
+    def test_terminal_tile_is_rejected(self):
+        client = _make_client()
+        resp = client.post("/api/panel-arrange", json={"tiles": ["ariel", "terminal"]})
+        assert resp.status_code == 422
+        assert "terminal" in resp.json()["detail"]
+
+    def test_terminal_is_rejected_even_when_a_custom_panel_squats_the_id(self):
+        """The terminal check is explicit, not a side effect of id validation."""
+        client = _make_client(
+            custom_panels=[{"id": "terminal", "label": "T", "url": "http://10.0.0.5:1"}]
+        )
+        resp = client.post("/api/panel-arrange", json={"tiles": ["terminal"]})
+        assert resp.status_code == 422
+
+    def test_rejected_requests_leave_state_untouched(self):
+        client = _make_client(visible_panels=["artifacts"], active_panel="artifacts")
+        client.post("/api/panel-arrange", json={"tiles": ["nope"], "focus": "nope"})
+        assert client.app.state.visible_panels == ["artifacts"]
+        assert client.app.state.active_panel == "artifacts"
+        client.app.state.broadcaster.broadcast.assert_not_called()

--- a/tests/interfaces/web_terminal/test_panel_layout_route.py
+++ b/tests/interfaces/web_terminal/test_panel_layout_route.py
@@ -1,0 +1,252 @@
+"""Tests for ``POST /api/panel-layout`` (`routes/panels.py`).
+
+The layout report is how a browser tells the server which service tiles are
+actually on screen. It is report-only: last-writer-wins, never broadcast to
+other clients, and content-deduped so an applied arrangement converges instead
+of ping-ponging reports (the server half of the convergence contract).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from osprey.interfaces.web_terminal.routes.panels import router
+
+
+def _make_client(**state) -> TestClient:
+    """A minimal app exposing the panels router with a stub broadcaster."""
+    app = FastAPI()
+    app.include_router(router)
+    app.state.broadcaster = MagicMock()
+    app.state.enabled_panels = {"ariel", "lattice", "artifacts"}
+    app.state.custom_panels = [{"id": "grafana", "label": "GRAFANA", "url": "http://10.0.0.5:3000"}]
+    for key, value in state.items():
+        setattr(app.state, key, value)
+    return TestClient(app)
+
+
+def _report(client: TestClient, tiles: list[str], dock: bool = True):
+    return client.post("/api/panel-layout", json={"tiles": tiles, "dock": dock})
+
+
+class TestStore:
+    def test_first_report_is_stored_with_a_timestamp(self):
+        client = _make_client()
+        resp = _report(client, ["lattice", "ariel"])
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "status": "ok",
+            "tiles": ["lattice", "ariel"],
+            "dock": True,
+            "updated": True,
+        }
+        assert client.app.state.open_tiles == ["lattice", "ariel"]
+        assert client.app.state.open_tiles_dock is True
+        assert isinstance(client.app.state.open_tiles_ts, float)
+
+    def test_reported_order_is_preserved(self):
+        """The list is a spatial reading order, not a set — order is the payload."""
+        client = _make_client()
+        _report(client, ["ariel", "grafana", "lattice"])
+        assert client.app.state.open_tiles == ["ariel", "grafana", "lattice"]
+
+    def test_empty_report_is_valid(self):
+        """Every service tile closed is a real state, not an error."""
+        client = _make_client()
+        resp = _report(client, [])
+        assert resp.status_code == 200
+        assert client.app.state.open_tiles == []
+        assert isinstance(client.app.state.open_tiles_ts, float)
+
+    def test_last_writer_wins(self):
+        client = _make_client()
+        _report(client, ["ariel"])
+        _report(client, ["lattice", "grafana"])
+        assert client.app.state.open_tiles == ["lattice", "grafana"]
+
+    def test_stored_list_is_a_copy_of_the_request(self):
+        """Mutating the response list must not reach into app.state."""
+        client = _make_client()
+        resp = _report(client, ["ariel"])
+        resp.json()["tiles"].append("lattice")
+        assert client.app.state.open_tiles == ["ariel"]
+
+    def test_never_broadcasts(self):
+        client = _make_client()
+        _report(client, ["ariel"])
+        _report(client, ["lattice"])
+        _report(client, [])
+        client.app.state.broadcaster.broadcast.assert_not_called()
+
+
+class TestDockLessReportsUnknownOccupancy:
+    """A client without a dock shell reports presence, not an empty screen.
+
+    Its ``{"tiles": [], "dock": false}`` is a capability signal — it cannot see
+    tile order at all. Recording that ``[]`` verbatim would let it clobber a
+    dock client's live list with a confident "nothing is open", so it is stored
+    as unknown occupancy instead.
+    """
+
+    def test_dock_false_records_unknown_not_empty(self):
+        client = _make_client()
+        _report(client, [], dock=False)
+        assert client.app.state.open_tiles is None
+        assert client.app.state.open_tiles_dock is False
+
+    def test_dock_false_still_stamps_a_timestamp(self):
+        """Someone IS watching — that fact is fresh news even without order."""
+        client = _make_client()
+        _report(client, [], dock=False)
+        assert isinstance(client.app.state.open_tiles_ts, float)
+
+    def test_dock_false_response_echoes_the_recorded_unknown(self):
+        client = _make_client()
+        body = _report(client, [], dock=False).json()
+        assert body["tiles"] is None
+        assert body["dock"] is False
+        assert body["updated"] is True
+
+    def test_dock_false_does_not_clobber_a_dock_list_with_a_fake_empty(self):
+        """The regression this exists for: the list is dropped, not falsified."""
+        client = _make_client()
+        _report(client, ["ariel", "lattice"], dock=True)
+
+        _report(client, [], dock=False)
+
+        assert client.app.state.open_tiles is None  # unknown, never []
+
+    def test_dock_true_report_restores_known_occupancy(self):
+        client = _make_client()
+        _report(client, [], dock=False)
+        _report(client, ["ariel"], dock=True)
+        assert client.app.state.open_tiles == ["ariel"]
+        assert client.app.state.open_tiles_dock is True
+
+    def test_dock_false_ignores_any_tiles_it_sends(self):
+        """Occupancy is unknown regardless of payload — the flag decides."""
+        client = _make_client()
+        _report(client, ["ariel"], dock=False)
+        assert client.app.state.open_tiles is None
+
+    def test_dock_true_empty_is_still_known_empty(self):
+        """The dock:true path is untouched: [] keeps meaning known-empty."""
+        client = _make_client()
+        _report(client, [], dock=True)
+        assert client.app.state.open_tiles == []
+
+
+class TestDedupe:
+    def test_identical_report_is_a_no_op(self):
+        client = _make_client()
+        _report(client, ["ariel", "lattice"])
+        first_ts = client.app.state.open_tiles_ts
+
+        resp = _report(client, ["ariel", "lattice"])
+
+        assert resp.status_code == 200
+        assert resp.json()["updated"] is False
+        assert client.app.state.open_tiles_ts == first_ts
+        assert client.app.state.open_tiles == ["ariel", "lattice"]
+
+    def test_reordered_tiles_are_a_different_report(self):
+        client = _make_client()
+        _report(client, ["ariel", "lattice"])
+        first_ts = client.app.state.open_tiles_ts
+
+        resp = _report(client, ["lattice", "ariel"])
+
+        assert resp.json()["updated"] is True
+        assert client.app.state.open_tiles == ["lattice", "ariel"]
+        assert client.app.state.open_tiles_ts >= first_ts
+
+    def test_changed_dock_flag_is_a_different_report(self):
+        client = _make_client()
+        _report(client, ["ariel"], dock=True)
+        first_ts = client.app.state.open_tiles_ts
+
+        resp = _report(client, ["ariel"], dock=False)
+
+        assert resp.json()["updated"] is True
+        assert client.app.state.open_tiles_dock is False
+        assert client.app.state.open_tiles is None
+        assert client.app.state.open_tiles_ts >= first_ts
+
+    def test_successive_dock_less_reports_dedupe(self):
+        """Both record the same unknown occupancy, so the second is a no-op."""
+        client = _make_client()
+        _report(client, [], dock=False)
+        first_ts = client.app.state.open_tiles_ts
+
+        resp = _report(client, [], dock=False)
+
+        assert resp.json()["updated"] is False
+        assert client.app.state.open_tiles_ts == first_ts
+
+    def test_known_empty_and_unknown_are_not_the_same_report(self):
+        """[] from a dock client must not dedupe against a dock-less unknown."""
+        client = _make_client()
+        _report(client, [], dock=False)
+
+        resp = _report(client, [], dock=True)
+
+        assert resp.json()["updated"] is True
+        assert client.app.state.open_tiles == []
+
+    def test_first_empty_report_is_not_deduped_against_the_never_reported_state(self):
+        """``dock`` starts unset, so even an empty first report is real news."""
+        client = _make_client()
+        resp = _report(client, [], dock=True)
+        assert resp.json()["updated"] is True
+        assert client.app.state.open_tiles_ts is not None
+
+    def test_deduped_report_echoes_the_stored_state(self):
+        client = _make_client()
+        _report(client, ["ariel"])
+        body = _report(client, ["ariel"]).json()
+        assert body["tiles"] == ["ariel"]
+        assert body["dock"] is True
+
+
+class TestValidation:
+    def test_unknown_id_is_rejected_and_lists_valid_ids(self):
+        client = _make_client()
+        resp = _report(client, ["ariel", "nope"])
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert "nope" in detail
+        for valid in ("ariel", "lattice", "artifacts", "grafana"):
+            assert valid in detail
+
+    def test_terminal_tile_is_rejected(self):
+        client = _make_client()
+        resp = _report(client, ["terminal", "ariel"])
+        assert resp.status_code == 422
+        assert "terminal" in resp.json()["detail"]
+
+    def test_terminal_is_rejected_even_when_a_custom_panel_squats_the_id(self):
+        client = _make_client(
+            custom_panels=[{"id": "terminal", "label": "T", "url": "http://10.0.0.5:1"}]
+        )
+        assert _report(client, ["terminal"]).status_code == 422
+
+    def test_rejected_report_leaves_stored_state_untouched(self):
+        client = _make_client()
+        _report(client, ["ariel"])
+        stored_ts = client.app.state.open_tiles_ts
+
+        assert _report(client, ["ariel", "nope"]).status_code == 422
+
+        assert client.app.state.open_tiles == ["ariel"]
+        assert client.app.state.open_tiles_ts == stored_ts
+
+    def test_dock_is_required(self):
+        client = _make_client()
+        assert client.post("/api/panel-layout", json={"tiles": []}).status_code == 422
+
+    def test_tiles_is_required(self):
+        client = _make_client()
+        assert client.post("/api/panel-layout", json={"dock": True}).status_code == 422

--- a/tests/interfaces/web_terminal/test_panels_browser.py
+++ b/tests/interfaces/web_terminal/test_panels_browser.py
@@ -361,6 +361,20 @@ def _track_panel_posts(page: Page) -> list[str]:
     return posts
 
 
+def _command_posts(posts: list[str]) -> list[str]:
+    """The COMMAND POSTs among ``posts``, with occupancy reports filtered out.
+
+    ``/api/panel-layout`` is a report, not a command: the dock-sync occupancy
+    reporter POSTs it whenever tile occupancy changes — including on a purely
+    LOCAL tile close, which is the feature working rather than a leak. The
+    invariant these tests guard is what a gesture *commands* (focus/visibility,
+    the calls that move every client's workspace), so reports are filtered out
+    before the assertion. A report is safe here precisely because the server
+    stores it last-writer-wins and broadcasts nothing.
+    """
+    return [p for p in posts if p != "panel-layout"]
+
+
 def _open_second_tile(page: Page, base_url: str, panel_id: str, label: str) -> None:
     """Open ``panel_id`` as a SECOND tile beside the current one via the rail's ⊞.
 
@@ -689,7 +703,7 @@ def test_dock_tab_focus_posts_setfocus_once(tmp_path, chromium_browser):
         # Let any (wrongly-)looping echo settle before counting.
         page.wait_for_timeout(600)
 
-        assert posts == ["panel-focus"], f"expected one focus POST, got {posts}"
+        assert _command_posts(posts) == ["panel-focus"], f"expected one focus POST, got {posts}"
 
         page.close()
 
@@ -727,7 +741,7 @@ def test_dock_tab_close_is_local_vacate_no_posts(tmp_path, chromium_browser):
         expect(rail_entry).to_be_attached(timeout=5_000)
         expect(rail_entry).not_to_have_class(re.compile(r"\bactive\b"), timeout=5_000)
         page.wait_for_timeout(600)
-        assert posts == [], f"a local tile close must not POST, got {posts}"
+        assert _command_posts(posts) == [], f"a local tile close must not command, got {posts}"
 
         page.close()
 
@@ -767,7 +781,7 @@ def test_service_tile_close_button_is_local_vacate(tmp_path, chromium_browser):
         expect(rail_entry).to_be_attached(timeout=5_000)
         expect(rail_entry).not_to_have_class(re.compile(r"\bactive\b"), timeout=5_000)
         page.wait_for_timeout(600)
-        assert posts == [], f"a tile close must not POST, got {posts}"
+        assert _command_posts(posts) == [], f"a tile close must not command, got {posts}"
 
         # One rail click reopens the panel — close is never a removal.
         rail_entry.click()
@@ -933,7 +947,7 @@ def test_server_sse_focus_is_applied_without_posting_back(tmp_path, chromium_bro
         ).to_have_count(1, timeout=5_000)
         # ...with zero POSTs echoed back out (the guard suppressed the setActive).
         page.wait_for_timeout(600)
-        assert posts == [], f"server-driven focus POSTed back: {posts}"
+        assert _command_posts(posts) == [], f"server-driven focus POSTed back: {posts}"
 
         page.close()
 
@@ -1903,7 +1917,7 @@ def test_evicted_panel_entry_click_redocks_it(tmp_path, chromium_browser):
         # pre-existing, benign) — evictions never touch server visibility.
         page.wait_for_timeout(600)
         assert "panel-visibility" not in posts, f"eviction must stay local, got {posts}"
-        assert set(posts) == {"panel-focus"}, f"expected only focus POSTs: {posts}"
+        assert set(_command_posts(posts)) == {"panel-focus"}, f"expected only focus POSTs: {posts}"
 
         page.close()
 

--- a/tests/interfaces/web_terminal/test_panels_collab_browser.py
+++ b/tests/interfaces/web_terminal/test_panels_collab_browser.py
@@ -1,0 +1,1069 @@
+"""Browser tests: the collaborative-panels contract between dock and server.
+
+``test_panels_browser.py`` proves the docked workspace itself (tiles, drags,
+persistence, the echo guard). This suite proves the *two-party* contract layered
+on top of it — the one where the agent finally sees, and can rearrange, what is
+actually on screen:
+
+  * the occupancy REPORT (``POST /api/panel-layout`` → ``GET /api/panels``'s
+    ``open_tiles`` / ``open_tiles_age_s`` / ``open_tiles_dock``),
+  * the polite agent SWITCH (``panel-focus`` with ``source: agent`` opens a tile
+    *beside* the operator's instead of evicting it),
+  * the declarative ARRANGE (``POST /api/panel-arrange``, shared by the agent's
+    ``arrange_workspace`` and the human "Layouts" click).
+
+Every assertion here needs a real dockview grid, a real SSE stream and real
+client-side fetches, so none of it is reachable from the unit suites:
+
+  * ``open_tiles`` is serialized from the live grid tree — a Python test can post
+    any list it likes, but only a browser can prove the list the dock produces.
+  * the "no echo loop" criteria are about POSTs a client does **not** make.
+    They are asserted by intercepting the page's own requests; a mocked fetch
+    proves only that the mock was not called.
+  * the vertical axis of the reading order (a column reported top-to-bottom
+    *before* what sits beside it) has no serialized representation to assert
+    against — a persisted branch carries no orientation, so the ordering can
+    only be pinned by making a real vertical split and reading the result back.
+
+Run:
+    uv run pytest tests/interfaces/web_terminal/test_panels_collab_browser.py -m browser -v
+
+Skips cleanly when the chromium headless binary is not installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from tests.interfaces.conftest import _free_port, _run_app_server
+
+# ---------------------------------------------------------------------------
+# Playwright availability guard
+# ---------------------------------------------------------------------------
+
+try:
+    from playwright.sync_api import Page, expect
+
+    _PLAYWRIGHT_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _PLAYWRIGHT_AVAILABLE = False
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+
+# ---------------------------------------------------------------------------
+# Panels used across the suite
+# ---------------------------------------------------------------------------
+#
+# ``healthEndpoint: None`` marks a custom panel healthy on load with no polling
+# and no backend (panel-manager.js), which is what most tests here want: the
+# subject is tile placement, not health. The one test that needs an UNHEALTHY
+# panel builds it separately, pointing a real healthEndpoint at a dead port.
+
+_DATA_VIZ: dict = {
+    "id": "data-viz",
+    "label": "DATA VIZ",
+    "url": "http://data-viz.internal:8080",
+    "healthEndpoint": None,
+    "path": "/",
+}
+
+_SCOPE: dict = {
+    "id": "scope",
+    "label": "SCOPE",
+    "url": "http://scope.internal:8080",
+    "healthEndpoint": None,
+    "path": "/",
+}
+
+#: rail id → dock tab accessible name, for the tab locator below.
+_LABELS = {"artifacts": "WORKSPACE", "data-viz": "DATA VIZ", "scope": "SCOPE"}
+
+
+def _unhealthy_panel(panel_id: str = "beam-cam") -> dict:
+    """A custom panel that polls a port nothing listens on — permanently unhealthy.
+
+    A ``healthEndpoint`` is what makes a panel poll at all; pointing it at a
+    closed port makes every poll fail, so the panel stays unhealthy for the
+    lifetime of the test instead of racing a backend into readiness.
+    """
+    return {
+        "id": panel_id,
+        "label": panel_id.upper(),
+        "url": f"http://127.0.0.1:{_free_port()}",
+        "healthEndpoint": "/health",
+        "path": "/",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Live-server context manager
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _live_server(
+    workspace_dir,
+    enabled_panels,
+    custom_panels=None,
+    presets=None,
+    project_cwd: str | None = None,
+    panels_delay: float = 0.0,
+):
+    """Launch a real web terminal server on a free port in a background thread.
+
+    Mirrors the launcher in ``test_panels_browser.py`` (companion backends
+    patched out, artifacts reporting the standard fallback URL) with the two
+    knobs this suite needs:
+
+    ``presets`` seeds ``app.state.panel_presets`` — the ``web.presets`` layouts
+    the "+" popover's "Layouts" section renders and ``/api/panel-arrange``
+    resolves by name — before the first page load, so both preset paths see it.
+
+    ``panels_delay`` holds every ``GET /api/panels`` open for that many seconds.
+    That is the boot window the layout reporter must not report inside: the
+    stored-layout restore only happens after this round trip, so a reporter
+    armed on a timer would publish the pre-restore arrangement as fact.
+
+    Yields:
+        (base_url: str, app: FastAPI) — live server address and the app object.
+    """
+    if custom_panels is None:
+        custom_panels = []
+
+    with (
+        patch(
+            "osprey.interfaces.web_terminal.app._load_web_config",
+            return_value={"watch_dir": str(workspace_dir)},
+        ),
+        patch(
+            "osprey.interfaces.web_terminal.app._load_panel_config",
+            return_value=(enabled_panels, custom_panels, None),
+        ),
+        patch(
+            "osprey.interfaces.web_terminal.app._launch_artifact_server",
+            side_effect=lambda a: setattr(a.state, "artifact_server_url", "http://127.0.0.1:8086"),
+        ),
+    ):
+        from osprey.interfaces.web_terminal.app import create_app
+
+        app = create_app(shell_command=["echo", "hello"])
+
+        if panels_delay:
+
+            @app.middleware("http")
+            async def _delay_panels(request, call_next):
+                if request.url.path == "/api/panels" and request.method == "GET":
+                    await asyncio.sleep(panels_delay)
+                return await call_next(request)
+
+        with _run_app_server(app) as base_url:
+            # Set AFTER startup: the lifespan assigns project_cwd and the preset
+            # list from config, so a pre-startup value would be clobbered.
+            if project_cwd is not None:
+                app.state.project_cwd = project_cwd
+            if presets is not None:
+                app.state.panel_presets = presets
+            yield base_url, app
+
+
+# ---------------------------------------------------------------------------
+# Page helpers
+# ---------------------------------------------------------------------------
+
+_DISMISS_RAIL_HINT = (
+    "try { localStorage.setItem('osprey-rail-hint-dismissed-v1', '1') } catch (e) {}"
+)
+
+
+def _new_page(browser) -> Page:
+    """A page with the one-time rail hint pre-dismissed (it would eat clicks)."""
+    page = browser.new_page()
+    page.add_init_script(_DISMISS_RAIL_HINT)
+    return page
+
+
+def _open_page(browser, base_url: str) -> Page:
+    """Open a page and wait for the rail and the dock grid to be up."""
+    page = _new_page(browser)
+    page.goto(base_url, wait_until="domcontentloaded")
+    expect(page.locator('button.panel-rail-button[data-panel-id="artifacts"]')).to_be_attached(
+        timeout=15_000
+    )
+    expect(page.locator(".dv-groupview").first).to_be_visible(timeout=15_000)
+    page.evaluate("document.getElementById('welcome-overlay')?.remove()")
+    return page
+
+
+# ---------------------------------------------------------------------------
+# Dock DOM / module helpers
+# ---------------------------------------------------------------------------
+
+# Every dockview group with its tab labels and pixel rectangle. The terminal
+# tile's tab carries no accessible name (it adopts the live .terminal-header),
+# so it is reported under the synthetic "SESSION" handle, as in the sibling
+# suite.
+_GROUPS_JS = r"""() => [...document.querySelectorAll('.dv-groupview')].map(g => {
+  const tabs = [...g.querySelectorAll('.dv-tab')].map(t =>
+    t.querySelector('.terminal-header')
+      ? 'SESSION'
+      : (t.querySelector('.tile-tab')?.getAttribute('aria-label') ?? ''));
+  const r = g.getBoundingClientRect();
+  return { x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.width),
+           h: Math.round(r.height), tabs };
+})"""
+
+# The client's OWN view of tile occupancy, straight from the serializer the
+# reporter posts. Asserting on this (rather than only on the server read-back)
+# separates "the dock is arranged wrongly" from "the report never landed".
+_OPEN_TILES_JS = r"""async () => {
+  const sync = await import('/static/js/dock-sync.js');
+  const dock = await import('/static/js/dock-workspace.js');
+  return sync.serializeOpenTiles(dock.getDockApi());
+}"""
+
+# Stamp / read a marker on the dockview panel OBJECT behind a service tile.
+# dockPanelAt MOVES an already-docked placeholder by remove+re-add, so a
+# surviving stamp is proof the tile was left strictly alone — a stronger claim
+# than "a tab with that label is still on screen".
+_STAMP_TILES_JS = r"""async (ids) => {
+  const dock = await import('/static/js/dock-workspace.js');
+  const api = dock.getDockApi();
+  const out = {};
+  for (const id of ids) {
+    const panel = api && api.getPanel('iframe:' + id);
+    if (panel) { panel.__collabStamp = 'stamped:' + id; out[id] = true; } else out[id] = false;
+  }
+  return out;
+}"""
+
+_READ_STAMPS_JS = r"""async (ids) => {
+  const dock = await import('/static/js/dock-workspace.js');
+  const api = dock.getDockApi();
+  const out = {};
+  for (const id of ids) {
+    const panel = api && api.getPanel('iframe:' + id);
+    out[id] = panel ? (panel.__collabStamp ?? null) : null;
+  }
+  return out;
+}"""
+
+
+def _dock_groups(page: Page) -> list[dict]:
+    return page.evaluate(_GROUPS_JS)
+
+
+def _client_open_tiles(page: Page) -> list[str] | None:
+    return page.evaluate(_OPEN_TILES_JS)
+
+
+def _wait_for_client_tiles(page: Page, expected: list[str], timeout: float = 10_000) -> None:
+    """Block until the page's own serializer reports exactly ``expected``.
+
+    Auto-waiting on the serializer rather than on a tab locator: the assertion
+    subject is the tile list the reporter would post, and a tab appearing is not
+    the same instant as the grid settling on its final shape.
+    """
+    page.wait_for_function(
+        """async (want) => {
+            const sync = await import('/static/js/dock-sync.js');
+            const dock = await import('/static/js/dock-workspace.js');
+            return JSON.stringify(sync.serializeOpenTiles(dock.getDockApi())) === want;
+        }""",
+        arg=json.dumps(expected),
+        timeout=timeout,
+    )
+
+
+def _service_tab(page: Page, label: str):
+    """The dockview tile strip whose accessible name is exactly ``label``."""
+    strip = page.locator(f'.tile-tab[aria-label="{label}"]')
+    return page.locator(".dv-tab").filter(has=strip)
+
+
+def _rail_ids(page: Page) -> list[str]:
+    """Every rail entry's panel id, in rail order (the terminal anchor leads)."""
+    return page.eval_on_selector_all(".panel-rail-button", "els => els.map(e => e.dataset.panelId)")
+
+
+def _active_rail_id(page: Page) -> str | None:
+    return page.evaluate(
+        "() => document.querySelector('.panel-rail-button.active')?.dataset.panelId ?? null"
+    )
+
+
+def _open_beside(page: Page, panel_id: str) -> None:
+    """Open ``panel_id`` as a NEW tile beside the active one via the rail's ⊞.
+
+    A plain rail click REPLACES the focused tile's panel (one panel per tile),
+    so every test here that needs side-by-side tiles grows the layout through
+    the entry's hover ⊞ corner — the human open-beside verb.
+    """
+    entry = page.locator(f'button.panel-rail-button[data-panel-id="{panel_id}"]')
+    entry.hover()
+    entry.locator(".panel-rail-beside").click()
+    expect(_service_tab(page, _LABELS[panel_id])).to_have_count(1, timeout=5_000)
+
+
+def _close_tile(page: Page, panel_id: str) -> None:
+    """Close a service tile through its header "×" — the human close gesture."""
+    label = _LABELS[panel_id]
+    _service_tab(page, label).locator(".tile-tab-close").click()
+    expect(_service_tab(page, label)).to_have_count(0, timeout=5_000)
+
+
+# ---------------------------------------------------------------------------
+# Request interception
+# ---------------------------------------------------------------------------
+
+
+def _track_panel_posts(page: Page) -> list[tuple[float, str, dict | None]]:
+    """Record ``(monotonic_time, endpoint, parsed_body)`` for every panel POST.
+
+    The no-loop and no-echo criteria of this feature are all statements about
+    requests the client must NOT make, so the request stream is the instrument.
+    Bodies are parsed because a layout report's *content* is the assertion (an
+    ``{"tiles": [], "dock": true}`` during boot is the specific failure).
+    """
+    posts: list[tuple[float, str, dict | None]] = []
+
+    def _record(req):
+        if req.method != "POST" or "/api/panel" not in req.url:
+            return
+        body: dict | None
+        try:
+            body = json.loads(req.post_data or "null")
+        except (ValueError, TypeError):  # pragma: no cover - defensive
+            body = None
+        posts.append((time.monotonic(), req.url.rsplit("/api/", 1)[-1], body))
+
+    page.on("request", _record)
+    return posts
+
+
+def _endpoints(posts: list[tuple[float, str, dict | None]]) -> list[str]:
+    return [endpoint for _, endpoint, _ in posts]
+
+
+def _layout_reports(posts: list[tuple[float, str, dict | None]]) -> list[dict | None]:
+    return [body for _, endpoint, body in posts if endpoint == "panel-layout"]
+
+
+# ---------------------------------------------------------------------------
+# Server read-back helpers
+# ---------------------------------------------------------------------------
+
+
+def _panels_state(base_url: str) -> dict:
+    resp = requests.get(f"{base_url}/api/panels", timeout=10)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _wait_for_open_tiles(base_url: str, expected, timeout: float = 15.0) -> dict:
+    """Poll ``GET /api/panels`` until ``open_tiles`` equals ``expected``.
+
+    Returns the whole payload so the caller can assert the freshness fields off
+    the same read that observed the occupancy.
+    """
+    deadline = time.monotonic() + timeout
+    state: dict = {}
+    while time.monotonic() < deadline:
+        state = _panels_state(base_url)
+        if state["open_tiles"] == expected:
+            return state
+        time.sleep(0.2)
+    raise AssertionError(f"open_tiles never became {expected!r}; last read: {state!r}")
+
+
+def _wait_for_active(base_url: str, expected: str, timeout: float = 10.0) -> None:
+    """Poll ``GET /api/panels`` until the server's recorded ``active`` matches."""
+    deadline = time.monotonic() + timeout
+    state: dict = {}
+    while time.monotonic() < deadline:
+        state = _panels_state(base_url)
+        if state["active"] == expected:
+            return
+        time.sleep(0.2)
+    raise AssertionError(f"active never became {expected!r}; last read: {state!r}")
+
+
+# ===========================================================================
+# (a) The human half: a tile gesture reaches the server
+# ===========================================================================
+
+
+def test_human_tile_close_updates_open_tiles_and_freshness(tmp_path, chromium_browser):
+    """Closing a tile by hand updates ``open_tiles``, with honest freshness fields.
+
+    Tile occupancy used to live entirely in the browser: the operator could close
+    a panel and the agent would keep reading it off the rail as "visible". Here
+    two tiles are opened, the server is checked to see both in reading order, one
+    is closed through its header "×", and the server must converge on the
+    remaining tile — reported by a client that has a dock shell (``dock: true``)
+    and with an age that reflects the close that just happened, not the boot.
+
+    Rail MEMBERSHIP is deliberately asserted unchanged: a close is occupancy, and
+    the two must not be conflated in either direction.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _live_server(
+        workspace,
+        enabled_panels={"artifacts"},
+        custom_panels=[_DATA_VIZ],
+        project_cwd=str(workspace),
+    ) as (base_url, _app):
+        page = _open_page(chromium_browser, base_url)
+        expect(_service_tab(page, "WORKSPACE")).to_have_count(1, timeout=15_000)
+        _open_beside(page, "data-viz")
+
+        # Both tiles reach the server, in the order they read off the screen.
+        before = _wait_for_open_tiles(base_url, ["artifacts", "data-viz"])
+        assert before["open_tiles_dock"] is True, before
+        rail_before = _rail_ids(page)
+
+        # Act — the operator closes the data-viz tile.
+        _close_tile(page, "data-viz")
+
+        # Assert — occupancy converges, freshness describes THIS change.
+        after = _wait_for_open_tiles(base_url, ["artifacts"])
+        assert after["open_tiles_dock"] is True, after
+        assert isinstance(after["open_tiles_age_s"], float), after
+        assert 0.0 <= after["open_tiles_age_s"] < 10.0, (
+            f"age should describe the close that just landed: {after}"
+        )
+
+        # …and membership is untouched: a closed tile is still one rail click away.
+        assert _rail_ids(page) == rail_before, _rail_ids(page)
+        assert set(after["visible"]) == set(before["visible"]), (before, after)
+
+        page.close()
+
+
+# ===========================================================================
+# (b) The polite agent switch
+# ===========================================================================
+
+
+def test_agent_switch_opens_beside_and_posts_nothing_back(tmp_path, chromium_browser):
+    """An agent switch onto an undocked rail member opens BESIDE, silently.
+
+    Two halves, both only observable in a browser:
+
+    * **Non-destructive.** The operator has two tiles open; the agent switches to
+      a third panel that is a rail member but holds no tile. The new tile appears
+      and the two existing tiles survive *as the same dockview panels* — proven
+      with a marker stamped on the panel objects beforehand, so a remove-and-
+      re-add (which would discard the operator's tile) cannot pass as survival.
+    * **No echo.** Applying the switch drives a placeholder add and a
+      programmatic active-panel change, both of which look exactly like human
+      dock gestures to dockview. If either leaked back out as a
+      ``POST /api/panel-focus`` the client would be talking to itself; only the
+      occupancy report is allowed to follow an applied switch.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _live_server(
+        workspace,
+        enabled_panels={"artifacts"},
+        custom_panels=[_DATA_VIZ, _SCOPE],
+        project_cwd=str(workspace),
+    ) as (base_url, _app):
+        page = _open_page(chromium_browser, base_url)
+        expect(_service_tab(page, "WORKSPACE")).to_have_count(1, timeout=15_000)
+        _open_beside(page, "data-viz")
+        # scope is a rail member from config but holds no tile — the exact state
+        # switch_panel's "open beside" branch exists for.
+        assert "scope" in _rail_ids(page)
+        expect(_service_tab(page, "SCOPE")).to_have_count(0)
+
+        stamped = page.evaluate(_STAMP_TILES_JS, ["artifacts", "data-viz"])
+        assert stamped == {"artifacts": True, "data-viz": True}, stamped
+
+        # Drain the open-beside gesture's own POSTs before counting.
+        _wait_for_open_tiles(base_url, ["artifacts", "data-viz"])
+        page.wait_for_timeout(800)
+        posts = _track_panel_posts(page)
+
+        # Act — the agent's switch_panel, as the MCP tool issues it.
+        r = requests.post(
+            f"{base_url}/api/panel-focus",
+            json={"panel": "scope", "source": "agent"},
+            timeout=10,
+        )
+        assert r.status_code == 200, r.text
+
+        # The panel is on screen, in a tile of its own…
+        expect(_service_tab(page, "SCOPE")).to_have_count(1, timeout=10_000)
+        expect(
+            page.locator('button.panel-rail-button[data-panel-id="scope"].active')
+        ).to_have_count(1, timeout=10_000)
+
+        # …and neither prior tile was disturbed: same tabs, same panel objects.
+        survived = page.evaluate(_READ_STAMPS_JS, ["artifacts", "data-viz"])
+        assert survived == {
+            "artifacts": "stamped:artifacts",
+            "data-viz": "stamped:data-viz",
+        }, f"an agent switch replaced an operator's tile: {survived}"
+        expect(_service_tab(page, "WORKSPACE")).to_have_count(1)
+        expect(_service_tab(page, "DATA VIZ")).to_have_count(1)
+
+        # The client reported the new occupancy and said nothing else.
+        _wait_for_open_tiles(base_url, ["artifacts", "data-viz", "scope"])
+        page.wait_for_timeout(800)
+        assert set(_endpoints(posts)) <= {"panel-layout"}, (
+            f"an applied agent switch echoed back out: {_endpoints(posts)}"
+        )
+
+        page.close()
+
+
+# ===========================================================================
+# (c) Arrange convergence, and the absence of a report loop
+# ===========================================================================
+
+
+def test_arrange_converges_from_two_layouts_without_a_report_loop(tmp_path, chromium_browser):
+    """One arrange, two differently-arranged clients, one converged workspace.
+
+    The arrangement is a declarative end state, so the workspace a client starts
+    from must not change where it ends up. Two pages are given deliberately
+    different layouts (one tile vs three in the opposite order), then a single
+    ``POST /api/panel-arrange`` names two tiles and a focus target; both pages
+    must land on exactly those tiles, in that order, focused the same way.
+
+    The second half is the convergence criterion. Applying an arrangement makes
+    the dock emit layout changes, each of which the reporter would post — and
+    every report the server *stored* would be a fact a hook could read. If the
+    dedupe on either end were missing, the two clients would ping-pong reports
+    indefinitely; the contract is at most ONE report per client after the
+    arrangement settles. That is a statement about requests, so it is measured
+    by intercepting them.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _live_server(
+        workspace,
+        enabled_panels={"artifacts"},
+        custom_panels=[_DATA_VIZ, _SCOPE],
+        project_cwd=str(workspace),
+    ) as (base_url, _app):
+        # Client A: the boot layout — artifacts alone.
+        page_a = _open_page(chromium_browser, base_url)
+        expect(_service_tab(page_a, "WORKSPACE")).to_have_count(1, timeout=15_000)
+
+        # Client B: three tiles, deliberately in a different order.
+        page_b = _open_page(chromium_browser, base_url)
+        expect(_service_tab(page_b, "WORKSPACE")).to_have_count(1, timeout=15_000)
+        _open_beside(page_b, "scope")
+        _open_beside(page_b, "data-viz")
+
+        # Opening a tile reports the focus, and a focus IS broadcast — every
+        # client applies it with its own takeover semantics, so B's setup has
+        # meanwhile swapped the panel in A's single tile. A's start layout is
+        # therefore established last, with a plain rail click (which only moves
+        # focus on B, where artifacts already holds a tile of its own). Wait for
+        # B's LAST focus to have landed on A first, or the click races it and
+        # the takeover happens in the wrong order.
+        expect(
+            page_a.locator('button.panel-rail-button[data-panel-id="data-viz"].active')
+        ).to_have_count(1, timeout=10_000)
+        page_a.locator('button.panel-rail-button[data-panel-id="artifacts"]').click()
+        _wait_for_client_tiles(page_a, ["artifacts"])
+        assert _client_open_tiles(page_b) == ["artifacts", "scope", "data-viz"], _client_open_tiles(
+            page_b
+        )
+
+        # Let both clients' own reports drain, then watch what they say next.
+        page_a.wait_for_timeout(1_200)
+        page_b.wait_for_timeout(1_200)
+        posts_a = _track_panel_posts(page_a)
+        posts_b = _track_panel_posts(page_b)
+
+        # Act — one declarative arrangement for everyone.
+        r = requests.post(
+            f"{base_url}/api/panel-arrange",
+            json={"tiles": ["data-viz", "artifacts"], "focus": "artifacts", "source": "agent"},
+            timeout=10,
+        )
+        assert r.status_code == 200, r.text
+
+        # Assert — identical end state on both clients, whatever they started from.
+        for page in (page_a, page_b):
+            _wait_for_client_tiles(page, ["data-viz", "artifacts"])
+            expect(
+                page.locator('button.panel-rail-button[data-panel-id="artifacts"].active')
+            ).to_have_count(1, timeout=10_000)
+            expect(_service_tab(page, "SCOPE")).to_have_count(0, timeout=10_000)
+            # Left-to-right on screen, not merely in the serialization.
+            service = [g for g in _dock_groups(page) if "SESSION" not in g["tabs"]]
+            order = [g["tabs"][0] for g in sorted(service, key=lambda g: g["x"])]
+            assert order == ["DATA VIZ", "WORKSPACE"], order
+
+        # The arrangement reached the server as an observation, not just a command.
+        _wait_for_open_tiles(base_url, ["data-viz", "artifacts"])
+
+        # Now the no-loop criterion: give any ping-pong a generous window to
+        # show itself (a loop would be unbounded, so a few seconds is decisive).
+        page_a.wait_for_timeout(2_500)
+        page_b.wait_for_timeout(2_500)
+        for name, posts in (("A", posts_a), ("B", posts_b)):
+            reports = _layout_reports(posts)
+            assert len(reports) <= 1, f"client {name} looped layout reports: {reports}"
+            assert set(_endpoints(posts)) <= {"panel-layout"}, (
+                f"client {name} echoed an applied arrange back out: {_endpoints(posts)}"
+            )
+
+        page_a.close()
+        page_b.close()
+
+
+# ===========================================================================
+# (d) Health is a client-side fact: focus fallback, and no empty tiles
+# ===========================================================================
+
+
+def test_arrange_with_unhealthy_focus_falls_back_and_docks_no_empty_tile(
+    tmp_path, chromium_browser
+):
+    """An arrangement naming an unhealthy panel focuses elsewhere and opens no ghost.
+
+    Panel health only exists in the browser, so the server records the requested
+    focus verbatim and the client applies the fallback rule: the requested panel
+    if it is healthy, else the first healthy tile listed. Here the requested
+    focus target is a panel whose health endpoint is a dead port, so focus must
+    land on the other listed tile instead.
+
+    The starting focus is deliberately on a panel the arrangement does NOT list.
+    Left on the boot default, focus would already be sitting on ``artifacts``
+    (the default panel auto-activates on its first healthy settle), and the
+    fallback assertion would be confirming a state that was true before the
+    arrangement ran — it would still pass with the healthy-fallback rule deleted.
+    From a start focused on an unlisted panel, losing that rule instead clears
+    the active state altogether, and the assertion fails as it should.
+
+    The second assertion is the one that keeps the workspace honest: a tile is
+    only ever docked for a panel that can fill it. An unhealthy panel's
+    activation refuses, so docking a tile for it would leave a permanently empty
+    rectangle on the operator's screen — worse than not opening it at all. Its
+    rail entry survives either way, so nothing is lost: the panel is one click
+    away the moment it comes back.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+    broken = _unhealthy_panel()
+
+    with _live_server(
+        workspace,
+        enabled_panels={"artifacts"},
+        custom_panels=[_DATA_VIZ, broken],
+        project_cwd=str(workspace),
+    ) as (base_url, _app):
+        page = _open_page(chromium_browser, base_url)
+        expect(_service_tab(page, "WORKSPACE")).to_have_count(1, timeout=15_000)
+        # Let the broken panel's first health polls fail so it is decidedly
+        # unhealthy before the arrangement is applied.
+        page.wait_for_timeout(1_500)
+        assert (
+            page.locator(f'button.panel-rail-button[data-panel-id="{broken["id"]}"]').count() == 1
+        )
+
+        # Move focus onto data-viz, which the arrangement below does not list —
+        # see the docstring: from the boot default the fallback assertion would
+        # be confirmatory.
+        _open_beside(page, "data-viz")
+        _wait_for_client_tiles(page, ["artifacts", "data-viz"])
+        expect(
+            page.locator('button.panel-rail-button[data-panel-id="data-viz"].active')
+        ).to_have_count(1, timeout=10_000)
+
+        # Act — arrange onto the unhealthy panel, asking for it as the focus.
+        r = requests.post(
+            f"{base_url}/api/panel-arrange",
+            json={"tiles": ["artifacts", broken["id"]], "focus": broken["id"], "source": "agent"},
+            timeout=10,
+        )
+        assert r.status_code == 200, r.text
+
+        # Focus falls back to the first healthy listed tile.
+        expect(
+            page.locator('button.panel-rail-button[data-panel-id="artifacts"].active')
+        ).to_have_count(1, timeout=10_000)
+        page.wait_for_timeout(1_000)
+
+        # No ghost tile for the panel that cannot fill one — and its rail entry
+        # is still there, so the arrangement cost the operator nothing.
+        assert _client_open_tiles(page) == ["artifacts"], (
+            f"an unhealthy panel was given an empty tile: {_client_open_tiles(page)}"
+        )
+        assert broken["id"] in _rail_ids(page), _rail_ids(page)
+        expect(_service_tab(page, broken["label"])).to_have_count(0)
+        assert _wait_for_open_tiles(base_url, ["artifacts"])["open_tiles_dock"] is True
+
+        page.close()
+
+
+# ===========================================================================
+# (e) Preset parity: the human click and the agent call are one operation
+# ===========================================================================
+
+_PRESETS = [{"name": "Injection", "panels": ["data-viz", "artifacts"]}]
+
+
+def _workspace_signature(page: Page) -> dict:
+    """What an operator would see: tiles in order, rail membership, focus."""
+    return {
+        "tiles": _client_open_tiles(page),
+        "rail": _rail_ids(page),
+        "active": _active_rail_id(page),
+    }
+
+
+def _apply_preset_by_click(page: Page) -> None:
+    """Apply the "Injection" layout the way a human does — the "+" popover."""
+    page.locator("#panel-add-btn").click()
+    expect(page.locator(".panel-add-menu.open")).to_be_visible(timeout=5_000)
+    page.locator(".panel-add-item", has_text="Injection").click()
+
+
+def test_preset_click_and_agent_preset_call_are_the_same_operation(tmp_path, chromium_browser):
+    """A "Layouts" click and ``arrange_workspace(preset=…)`` produce one workspace.
+
+    Presets used to be applied by the browser, panel by panel; the agent had no
+    way to ask for one. Both paths now resolve the same preset server-side and
+    broadcast the same arrangement, so the claim to prove is equality of the
+    RESULT, not of the code path: same tiles in the same order, the same focus,
+    and the same pruned rail — a preset is exclusive, so the panel it omits
+    leaves the launcher rail in both paths.
+
+    Each path runs against its own freshly-booted server so neither inherits the
+    other's state; the two signatures are then compared directly.
+
+    The signature also carries the server's own ``active``/``visible``, because a
+    preset names no focus target and a focus-less arrangement is exactly where
+    the recorded focus can go stale: leaving ``active_panel`` where it was would
+    have it name a panel the very same ``GET /api/panels`` response no longer
+    lists as ``visible``, which is the pair every consumer of that response reads
+    together. Only a real click can prove the human path lands the same way.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    def _boot(page_action) -> dict:
+        with _live_server(
+            workspace,
+            enabled_panels={"artifacts"},
+            custom_panels=[_DATA_VIZ, _SCOPE],
+            presets=_PRESETS,
+            project_cwd=str(workspace),
+        ) as (base_url, _app):
+            page = _open_page(chromium_browser, base_url)
+            expect(_service_tab(page, "WORKSPACE")).to_have_count(1, timeout=15_000)
+            # scope starts in the rail; the preset omits it, so its removal is
+            # what makes the pruning observable.
+            assert "scope" in _rail_ids(page)
+
+            # Focus scope before applying the preset, so the recorded focus is
+            # on a panel the arrangement is about to close. Starting focused on
+            # a preset MEMBER instead would let a stale active_panel still name
+            # a visible panel, and the active-in-visible check below would pass
+            # for the wrong reason.
+            page.locator('button.panel-rail-button[data-panel-id="scope"]').click()
+            _wait_for_client_tiles(page, ["scope"])
+            _wait_for_active(base_url, "scope")
+
+            page_action(page, base_url)
+
+            _wait_for_client_tiles(page, ["data-viz", "artifacts"])
+            page.wait_for_timeout(800)
+            signature = _workspace_signature(page)
+            server = _wait_for_open_tiles(base_url, ["data-viz", "artifacts"])
+            signature["server_open_tiles"] = server["open_tiles"]
+            signature["server_active"] = server["active"]
+            # Order is not part of the claim — `visible` keeps rail order while
+            # `tiles` carries the preset's config order, and the two need not
+            # agree — so membership is compared as a set.
+            signature["server_visible"] = sorted(server["visible"])
+            page.close()
+            return signature
+
+    human = _boot(lambda page, _base: _apply_preset_by_click(page))
+    agent = _boot(
+        lambda _page, base: requests.post(
+            f"{base}/api/panel-arrange",
+            json={"preset": "Injection", "source": "agent"},
+            timeout=10,
+        ).raise_for_status()
+    )
+
+    assert human == agent, f"preset paths diverged\nhuman: {human}\nagent: {agent}"
+    # And the shared result is the preset's own semantics: its members open in
+    # config order, the rail pruned to them (plus the terminal anchor).
+    assert human["tiles"] == ["data-viz", "artifacts"], human
+    assert "scope" not in human["rail"], human
+    assert set(human["rail"]) == {"terminal", "data-viz", "artifacts"}, human
+    assert human["server_visible"] == ["artifacts", "data-viz"], human
+
+    # The recorded focus moved with the arrangement rather than being stranded
+    # on the panel the preset just closed. Asserted as membership of the SAME
+    # response's visible list, since that is the inconsistency a consumer would
+    # actually hit — not merely that active changed to some particular id.
+    assert human["server_active"] in human["server_visible"], (
+        f"a preset click left the server's active panel outside visible: {human}"
+    )
+
+
+# ===========================================================================
+# (f) The vertical axis of the reading order
+# ===========================================================================
+
+# Drag a rail entry INTO a specific tile's content at a relative position — the
+# rail's own HTML5 drag, dispatched in-page because Playwright's mouse-based
+# drag_to cannot produce HTML5 dnd events. dragstart runs panel-rail's real
+# handler (payload + iframe shields); the repeated dragover with settles between
+# is required because dockview resolves its drop overlay asynchronously and a
+# drop immediately after a single dragover is silently ignored.
+_RAIL_DRAG_INTO_TILE_JS = r"""async ({ panelId, targetPanel, fx, fy }) => {
+    const dock = await import('/static/js/dock-workspace.js');
+    const api = dock.getDockApi();
+    const target = api.getPanel('iframe:' + targetPanel);
+    const content = target.group.element.querySelector('.dv-content-container');
+    const r = content.getBoundingClientRect();
+    const x = r.left + r.width * fx;
+    const y = r.top + r.height * fy;
+    const entry = document.querySelector(
+        `button.panel-rail-button[data-panel-id="${panelId}"]`);
+    const dt = new DataTransfer();
+    entry.dispatchEvent(new DragEvent('dragstart',
+        { bubbles: true, cancelable: true, dataTransfer: dt }));
+    const opts = { bubbles: true, cancelable: true, dataTransfer: dt,
+                   clientX: x, clientY: y };
+    const el = document.elementFromPoint(x, y) ?? content;
+    const settle = () => new Promise((res) => setTimeout(res, 120));
+    el.dispatchEvent(new DragEvent('dragenter', opts));
+    el.dispatchEvent(new DragEvent('dragover', opts));
+    await settle();
+    el.dispatchEvent(new DragEvent('dragover', opts));
+    await settle();
+    el.dispatchEvent(new DragEvent('drop', opts));
+    entry.dispatchEvent(new DragEvent('dragend', { bubbles: true, dataTransfer: dt }));
+}"""
+
+
+def test_vertical_split_reports_column_before_its_neighbour(tmp_path, chromium_browser):
+    """A stacked column is reported top-to-bottom BEFORE the tile beside it.
+
+    The reading order is a depth-first walk of the grid tree, so a genuinely 2D
+    arrangement flattens column-first: with ``scope`` stacked under
+    ``artifacts`` and ``data-viz`` full height to their right, the report is
+    ``[artifacts, scope, data-viz]`` — not the row-major ``[artifacts, data-viz,
+    scope]`` a raster scan of the screen would produce.
+
+    This is the one ordering claim no unit test can pin. A serialized branch
+    carries its children in axis order but records no orientation, so a
+    hand-built fixture cannot state which axis it means; only a real vertical
+    split, made through the rail's own drag-and-drop, produces a tree whose
+    vertical branch is unambiguous. The geometry is asserted first, so a drop
+    that landed against the grid edge instead of inside the tile fails as the
+    wrong *arrangement* rather than silently as the wrong *order*.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _live_server(
+        workspace,
+        enabled_panels={"artifacts"},
+        custom_panels=[_DATA_VIZ, _SCOPE],
+        project_cwd=str(workspace),
+    ) as (base_url, _app):
+        page = _open_page(chromium_browser, base_url)
+        expect(_service_tab(page, "WORKSPACE")).to_have_count(1, timeout=15_000)
+        # Three columns: artifacts | data-viz | terminal.
+        _open_beside(page, "data-viz")
+        assert _client_open_tiles(page) == ["artifacts", "data-viz"], _client_open_tiles(page)
+
+        # Act — drop scope into the LOWER part of the artifacts tile, splitting
+        # that tile vertically rather than the grid.
+        page.evaluate(
+            _RAIL_DRAG_INTO_TILE_JS,
+            {"panelId": "scope", "targetPanel": "artifacts", "fx": 0.5, "fy": 0.85},
+        )
+        expect(_service_tab(page, "SCOPE")).to_have_count(1, timeout=10_000)
+        page.wait_for_timeout(500)
+
+        # Assert the arrangement really is a column beside a full-height tile.
+        groups = {g["tabs"][0]: g for g in _dock_groups(page) if len(g["tabs"]) == 1}
+        artifacts, scope, data_viz = groups["WORKSPACE"], groups["SCOPE"], groups["DATA VIZ"]
+        assert abs(scope["x"] - artifacts["x"]) <= 2, groups
+        assert abs(scope["w"] - artifacts["w"]) <= 2, groups
+        assert scope["y"] > artifacts["y"], groups
+        assert data_viz["x"] > artifacts["x"] + artifacts["w"] - 2, groups
+        assert data_viz["h"] > artifacts["h"] + 2, (
+            f"data-viz should span both rows of the column: {groups}"
+        )
+
+        # Assert the reading order: down the column, then across.
+        assert _client_open_tiles(page) == ["artifacts", "scope", "data-viz"], _client_open_tiles(
+            page
+        )
+        _wait_for_open_tiles(base_url, ["artifacts", "scope", "data-viz"])
+
+        page.close()
+
+
+# ===========================================================================
+# (g) The boot window: never publish a layout the restore is about to replace
+# ===========================================================================
+
+
+def test_slow_restore_reports_nothing_before_the_layout_is_final(tmp_path, chromium_browser):
+    """No occupancy is reported until the stored layout has actually been applied.
+
+    The dock boots into a default arrangement and only restores the operator's
+    stored layout after an ``/api/panels`` round trip. A reporter armed on a
+    timer would, on a slow response, publish that pre-restore arrangement — an
+    empty workspace — and a hook reading ``open_tiles`` would take it as fact.
+    The reporter therefore arms on the restore itself, not on a deadline.
+
+    That gap is a network latency, so the test makes it one: ``/api/panels`` is
+    held open far longer than the reporter's settle window, and every layout
+    POST the page makes is timestamped against the moment that response landed.
+    A report before it is the bug; a report after it is the design.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _live_server(
+        workspace,
+        enabled_panels={"artifacts"},
+        custom_panels=[],
+        project_cwd=str(workspace),
+        panels_delay=2.0,
+    ) as (base_url, _app):
+        page = _new_page(chromium_browser)
+        posts = _track_panel_posts(page)
+        panels_response: list[float] = []
+
+        def _record_response(resp):
+            if resp.request.method == "GET" and resp.url.rsplit("?", 1)[0].endswith("/api/panels"):
+                panels_response.append(time.monotonic())
+
+        page.on("response", _record_response)
+
+        page.goto(base_url, wait_until="domcontentloaded")
+        expect(page.locator(".dv-groupview").first).to_be_visible(timeout=15_000)
+        expect(_service_tab(page, "WORKSPACE")).to_have_count(1, timeout=20_000)
+        # Outlast the settle window plus a generous margin so a late report is
+        # still counted rather than raced past.
+        page.wait_for_timeout(2_000)
+
+        assert panels_response, "the page never fetched /api/panels"
+        restore_seam = min(panels_response)
+        early = [
+            (endpoint, body)
+            for when, endpoint, body in posts
+            if endpoint == "panel-layout" and when < restore_seam
+        ]
+        assert not early, f"occupancy was reported before the layout was restored: {early}"
+
+        # Reporting is armed, not merely silent: the settled layout does land,
+        # and it is the real one rather than the pre-restore empty workspace.
+        reports = _layout_reports(posts)
+        assert reports, "no occupancy report was ever sent after the restore"
+        assert {"tiles": [], "dock": True} not in reports, reports
+        assert reports[-1] == {"tiles": ["artifacts"], "dock": True}, reports
+        assert _panels_state(base_url)["open_tiles"] == ["artifacts"]
+
+        page.close()
+
+
+# ===========================================================================
+# (h) Three-state occupancy: never reported / unknown / known
+# ===========================================================================
+
+
+def test_occupancy_read_back_distinguishes_unknown_from_empty(tmp_path, chromium_browser):
+    """``open_tiles`` tells "nothing is open" apart from "nobody can say".
+
+    Three states share one field, and collapsing any two of them would let a
+    hook assert something nobody observed:
+
+    * **never reported** — no client has checked in; all three fields null.
+    * **known empty** — a dock client reports that the operator closed every
+      service tile: ``[]`` with ``dock: true``.
+    * **unknown** — a client without a dock shell is watching but cannot see
+      tile order. It sends a presence report whose ``tiles`` the server must
+      record as *null*, not as an empty workspace, or a fallback client would
+      overwrite a real list with a confident lie.
+
+    The dock-less client is real, not simulated: the dockview bundle is blocked
+    for that page, so the shell genuinely never arrives and the client reaches
+    its own give-up branch.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _live_server(
+        workspace,
+        enabled_panels={"artifacts"},
+        custom_panels=[],
+        project_cwd=str(workspace),
+    ) as (base_url, _app):
+        # --- never reported: nobody has looked at the screen yet.
+        fresh = _panels_state(base_url)
+        assert fresh["open_tiles"] is None, fresh
+        assert fresh["open_tiles_age_s"] is None, fresh
+        assert fresh["open_tiles_dock"] is None, fresh
+
+        # --- known empty: a dock client closes the last service tile.
+        page = _open_page(chromium_browser, base_url)
+        expect(_service_tab(page, "WORKSPACE")).to_have_count(1, timeout=15_000)
+        _wait_for_open_tiles(base_url, ["artifacts"])
+        _close_tile(page, "artifacts")
+        known_empty = _wait_for_open_tiles(base_url, [])
+        assert known_empty["open_tiles_dock"] is True, known_empty
+        assert isinstance(known_empty["open_tiles_age_s"], float), known_empty
+        page.close()
+
+        # --- unknown: a client with no dock shell at all.
+        dockless = _new_page(chromium_browser)
+        dockless.route("**/dockview-core*", lambda route: route.abort())
+        dockless.goto(base_url, wait_until="domcontentloaded")
+        expect(
+            dockless.locator('button.panel-rail-button[data-panel-id="artifacts"]')
+        ).to_be_attached(timeout=15_000)
+        assert (
+            dockless.evaluate(
+                "async () => { const m = await import('/static/js/dock-workspace.js');"
+                " return m.getDockApi(); }"
+            )
+            is None
+        ), "the dock shell was supposed to be unavailable on this page"
+
+        # The give-up branch waits out its fast poll budget (~4.5s) before it
+        # concludes there is no dock and says so.
+        deadline = time.monotonic() + 25.0
+        state: dict = {}
+        while time.monotonic() < deadline:
+            state = _panels_state(base_url)
+            if state["open_tiles_dock"] is False:
+                break
+            dockless.wait_for_timeout(300)
+        assert state.get("open_tiles_dock") is False, f"no dock-less report arrived: {state}"
+        assert state["open_tiles"] is None, (
+            f"a dock-less client's presence report was recorded as an empty workspace: {state}"
+        )
+        assert isinstance(state["open_tiles_age_s"], float), state
+
+        dockless.close()

--- a/tests/interfaces/web_terminal/test_panels_routes.py
+++ b/tests/interfaces/web_terminal/test_panels_routes.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import re
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -117,6 +118,9 @@ def test_project_key_does_not_disturb_existing_fields(tmp_path):
         "family_rail_defaults",
         "project_key",
         "workspace_has_artifacts",
+        "open_tiles",
+        "open_tiles_age_s",
+        "open_tiles_dock",
     }
 
 
@@ -187,3 +191,115 @@ def test_workspace_flag_recomputed_per_request(tmp_path):
     assert _panels(app)["workspace_has_artifacts"] is False
     (ws / "result.csv").write_text("a,b\n")
     assert _panels(app)["workspace_has_artifacts"] is True
+
+
+# ---- Focus adds rail membership ---- #
+
+
+def _make_focus_app(visible: list[str] | None = None) -> FastAPI:
+    """An app with a stub broadcaster and a known panel inventory.
+
+    ``visible`` is the launcher-rail membership; ``None`` leaves the attribute
+    unset so the route's "no explicit list" fallback is exercised.
+    """
+    app = FastAPI()
+    app.include_router(router)
+    app.state.broadcaster = MagicMock()
+    app.state.enabled_panels = {"ariel", "lattice"}
+    app.state.custom_panels = [{"id": "grafana", "label": "GRAFANA", "url": "http://10.0.0.5:3000"}]
+    if visible is not None:
+        app.state.visible_panels = visible
+    return app
+
+
+def _frames(app: FastAPI) -> list[dict]:
+    """Every broadcast frame the request produced, in order."""
+    return [call.args[0] for call in app.state.broadcaster.broadcast.call_args_list]
+
+
+def test_focus_on_non_member_adds_rail_membership():
+    """An agent switch_panel on a hidden panel must not leave a client-only entry."""
+    app = _make_focus_app(visible=["ariel"])
+    with TestClient(app) as client:
+        resp = client.post("/api/panel-focus", json={"panel": "grafana", "source": "agent"})
+    assert resp.status_code == 200
+    assert app.state.visible_panels == ["ariel", "grafana"]
+
+
+def test_focus_on_non_member_is_consistent_on_read_back():
+    """list_panels must agree with the tool's promise that the panel is visible."""
+    app = _make_focus_app(visible=["ariel"])
+    with TestClient(app) as client:
+        client.post("/api/panel-focus", json={"panel": "grafana", "source": "agent"})
+        body = client.get("/api/panels").json()
+    assert "grafana" in body["visible"]
+    assert body["active"] == "grafana"
+
+
+def test_focus_on_non_member_broadcasts_visibility_before_focus():
+    """Ordering is load-bearing: clients add the rail entry, then focus it."""
+    app = _make_focus_app(visible=["ariel"])
+    with TestClient(app) as client:
+        client.post("/api/panel-focus", json={"panel": "grafana"})
+    frames = _frames(app)
+    assert [f["type"] for f in frames] == ["panel_visibility", "panel_focus"]
+    assert frames[0] == {"type": "panel_visibility", "panel": "grafana", "visible": True}
+
+
+def test_focus_visibility_frame_carries_the_source_tag():
+    """The agent glow must fire on the rail entry the agent just added."""
+    app = _make_focus_app(visible=["ariel"])
+    with TestClient(app) as client:
+        client.post("/api/panel-focus", json={"panel": "grafana", "source": "agent"})
+    assert _frames(app)[0]["source"] == "agent"
+
+
+def test_focus_on_member_emits_only_a_focus_frame():
+    """A human rail click is unchanged — no spurious visibility traffic."""
+    app = _make_focus_app(visible=["ariel", "grafana"])
+    with TestClient(app) as client:
+        client.post("/api/panel-focus", json={"panel": "grafana"})
+    assert _frames(app) == [{"type": "panel_focus", "panel": "grafana"}]
+
+
+def test_focus_on_member_leaves_rail_order_untouched():
+    app = _make_focus_app(visible=["ariel", "grafana"])
+    with TestClient(app) as client:
+        client.post("/api/panel-focus", json={"panel": "ariel"})
+    assert app.state.visible_panels == ["ariel", "grafana"]
+
+
+def test_focus_without_explicit_membership_treats_enabled_as_the_rail():
+    """Mirrors get_panels: an unset list means the enabled built-ins are visible."""
+    app = _make_focus_app(visible=None)
+    with TestClient(app) as client:
+        client.post("/api/panel-focus", json={"panel": "ariel"})
+    assert _frames(app) == [{"type": "panel_focus", "panel": "ariel"}]
+
+
+def test_focus_without_explicit_membership_still_adds_a_custom_non_member():
+    """A custom panel is not in the enabled set, so it is a genuine non-member."""
+    app = _make_focus_app(visible=None)
+    with TestClient(app) as client:
+        client.post("/api/panel-focus", json={"panel": "grafana"})
+    assert [f["type"] for f in _frames(app)] == ["panel_visibility", "panel_focus"]
+    assert "grafana" in app.state.visible_panels
+
+
+def test_focus_on_unknown_panel_changes_nothing():
+    app = _make_focus_app(visible=["ariel"])
+    with TestClient(app) as client:
+        resp = client.post("/api/panel-focus", json={"panel": "nope"})
+    assert resp.status_code == 422
+    assert app.state.visible_panels == ["ariel"]
+    app.state.broadcaster.broadcast.assert_not_called()
+
+
+def test_focus_with_url_keeps_the_url_on_the_focus_frame_only():
+    """The visibility frame is membership-only; the url rides the focus frame."""
+    app = _make_focus_app(visible=["ariel"])
+    with TestClient(app) as client:
+        client.post("/api/panel-focus", json={"panel": "grafana", "url": "/x"})
+    visibility, focus = _frames(app)
+    assert "url" not in visibility
+    assert focus["url"].endswith("/x")

--- a/tests/mcp_server/test_http.py
+++ b/tests/mcp_server/test_http.py
@@ -2,8 +2,10 @@
 
 Covers URL construction (config + env precedence), the fire-and-forget
 ``post_json`` swallowing unreachable targets, the response-returning
-``_post_json_with_response`` distinguishing rejection from unreachability, and
-``notify_panel_register`` mapping HTTP outcomes to its structured dict.
+``_post_json_with_response`` distinguishing rejection from unreachability,
+``fetch_panels`` reading live panel state (including the layout-report
+freshness fields), and ``notify_panel_register`` / ``notify_panel_arrange``
+mapping HTTP outcomes to their structured dicts.
 """
 
 from __future__ import annotations
@@ -220,6 +222,169 @@ def test_notify_panel_register_passes_health_endpoint():
     assert captured["health_endpoint"] == "http://h"
     assert captured["path"] == "/sub"
     assert captured["id"] == "p1"
+
+
+# ---------------------------------------------------------------------------
+# fetch_panels
+# ---------------------------------------------------------------------------
+
+
+def _panels_response(payload: bytes) -> MagicMock:
+    """Build a urlopen context-manager mock returning *payload*."""
+    resp = MagicMock()
+    resp.read.return_value = payload
+    cm = MagicMock()
+    cm.__enter__.return_value = resp
+    return cm
+
+
+@pytest.mark.unit
+def test_fetch_panels_returns_payload_with_freshness_fields():
+    """The layout-report fields reach the caller unchanged."""
+    body = (
+        b'{"enabled": ["artifacts"], "visible": ["artifacts"], "active": null,'
+        b' "open_tiles": ["artifacts", "lattice"], "open_tiles_age_s": 4.5,'
+        b' "open_tiles_dock": true}'
+    )
+    with (
+        patch.object(http, "web_terminal_url", return_value="http://wt"),
+        patch("urllib.request.urlopen", return_value=_panels_response(body)) as urlopen,
+    ):
+        data = http.fetch_panels()
+    assert urlopen.call_args.args[0] == "http://wt/api/panels"
+    assert data is not None
+    assert data["open_tiles"] == ["artifacts", "lattice"]
+    assert data["open_tiles_age_s"] == 4.5
+    assert data["open_tiles_dock"] is True
+
+
+@pytest.mark.unit
+def test_fetch_panels_tolerates_server_without_freshness_fields():
+    """An older server omitting the fields is not an error — keys are absent."""
+    with (
+        patch.object(http, "web_terminal_url", return_value="http://wt"),
+        patch("urllib.request.urlopen", return_value=_panels_response(b'{"enabled": []}')),
+    ):
+        data = http.fetch_panels()
+    assert data == {"enabled": []}
+    assert data.get("open_tiles_age_s") is None
+
+
+@pytest.mark.unit
+def test_fetch_panels_unreachable_returns_none():
+    """An unreachable web terminal yields None rather than raising."""
+    with (
+        patch.object(http, "web_terminal_url", return_value="http://wt"),
+        patch("urllib.request.urlopen", side_effect=OSError("connection refused")),
+        patch.object(http, "logger") as mock_logger,
+    ):
+        assert http.fetch_panels() is None
+    assert mock_logger.warning.called
+
+
+@pytest.mark.unit
+def test_fetch_panels_non_object_payload_returns_none():
+    """A JSON body that is not an object is treated as unusable."""
+    with (
+        patch.object(http, "web_terminal_url", return_value="http://wt"),
+        patch("urllib.request.urlopen", return_value=_panels_response(b"[1, 2]")),
+    ):
+        assert http.fetch_panels() is None
+
+
+# ---------------------------------------------------------------------------
+# notify_panel_arrange
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_notify_panel_arrange_posts_tiles_and_focus():
+    """Tiles, focus and the agent attribution are sent to the arrange route."""
+    captured: dict = {}
+
+    def _fake(url, payload, *, timeout):
+        captured["url"] = url
+        captured["payload"] = payload
+        return 200, {"status": "ok", "tiles": payload["tiles"]}
+
+    with (
+        patch.object(http, "web_terminal_url", return_value="http://wt"),
+        patch.object(http, "_post_json_with_response", side_effect=_fake),
+    ):
+        http.notify_panel_arrange(tiles=["artifacts", "lattice"], focus="lattice")
+
+    assert captured["url"] == "http://wt/api/panel-arrange"
+    assert captured["payload"] == {
+        "source": "agent",
+        "tiles": ["artifacts", "lattice"],
+        "focus": "lattice",
+    }
+
+
+@pytest.mark.unit
+def test_notify_panel_arrange_preset_omits_tiles_and_focus():
+    """A preset call sends only the preset name (plus attribution)."""
+    captured: dict = {}
+
+    def _fake(url, payload, *, timeout):
+        captured.update(payload)
+        return 200, {}
+
+    with (
+        patch.object(http, "web_terminal_url", return_value="http://wt"),
+        patch.object(http, "_post_json_with_response", side_effect=_fake),
+    ):
+        http.notify_panel_arrange(preset="injection")
+
+    assert captured == {"source": "agent", "preset": "injection"}
+
+
+@pytest.mark.unit
+def test_notify_panel_arrange_success_returns_data():
+    applied = {"status": "ok", "tiles": ["artifacts"], "focus": None, "prune_rail": False}
+    with (
+        patch.object(http, "web_terminal_url", return_value="http://wt"),
+        patch.object(http, "_post_json_with_response", return_value=(200, applied)),
+    ):
+        out = http.notify_panel_arrange(tiles=["artifacts"])
+    assert out == {"ok": True, "status": 200, "data": applied}
+
+
+@pytest.mark.unit
+def test_notify_panel_arrange_rejected_surfaces_detail():
+    """A 422 from the route reaches the caller verbatim — never swallowed."""
+    detail = "Unknown panel ids: ['bogus']. Valid panel ids: ['artifacts', 'lattice']"
+    with (
+        patch.object(http, "web_terminal_url", return_value="http://wt"),
+        patch.object(http, "_post_json_with_response", return_value=(422, {"detail": detail})),
+    ):
+        out = http.notify_panel_arrange(tiles=["bogus"])
+    assert out == {"ok": False, "status": 422, "detail": detail}
+
+
+@pytest.mark.unit
+def test_notify_panel_arrange_stringifies_structured_detail():
+    """FastAPI body-validation 422s carry a list; the contract stays textual."""
+    structured = [{"loc": ["body", "tiles"], "msg": "value is not a valid list"}]
+    with (
+        patch.object(http, "web_terminal_url", return_value="http://wt"),
+        patch.object(http, "_post_json_with_response", return_value=(422, {"detail": structured})),
+    ):
+        out = http.notify_panel_arrange(tiles=["artifacts"])
+    assert out["ok"] is False
+    assert isinstance(out["detail"], str)
+    assert "value is not a valid list" in out["detail"]
+
+
+@pytest.mark.unit
+def test_notify_panel_arrange_unreachable():
+    """A down web terminal is reported as such, not raised."""
+    with (
+        patch.object(http, "web_terminal_url", return_value="http://wt"),
+        patch.object(http, "_post_json_with_response", side_effect=OSError("no route")),
+    ):
+        out = http.notify_panel_arrange(tiles=["artifacts"])
+    assert out == {"ok": False, "status": None, "detail": "Web Terminal is not running."}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mcp_server/workspace/test_panel_tools.py
+++ b/tests/mcp_server/workspace/test_panel_tools.py
@@ -1,4 +1,4 @@
-"""Tests for panel_tools MCP tools (list_panels, switch_panel).
+"""Tests for the panel_tools MCP tools.
 
 Covers:
   - list_panels returns enabled built-in panels with correct labels
@@ -7,6 +7,10 @@ Covers:
   - switch_panel calls notify_panel_focus with correct args
   - switch_panel passes optional url through
   - switch_panel works with app-registered (custom) panel IDs
+  - show_panel / hide_panel validate ids before toggling rail membership
+  - register_panel maps the register helper's outcomes to its response
+  - arrange_workspace reports the applied layout plus report freshness, and
+    surfaces the route's validation details verbatim as structured errors
 """
 
 import json
@@ -14,14 +18,20 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tests.mcp_server.conftest import extract_response_dict, get_tool_fn
+from tests.mcp_server.conftest import assert_raises_error, extract_response_dict, get_tool_fn
 
 _MODULE = "osprey.mcp_server.workspace.tools.panel_tools"
 
 
 @pytest.fixture
 def _mock_web_terminal_url():
-    with patch(f"{_MODULE}.web_terminal_url", return_value="http://127.0.0.1:8087"):
+    """Pin the base URL used by the shared http.fetch_panels helper.
+
+    The panel tools no longer resolve the URL themselves — they delegate the
+    ``GET /api/panels`` read to ``osprey.mcp_server.http.fetch_panels``, so the
+    patch has to land there for tests that stub ``urllib.request.urlopen``.
+    """
+    with patch("osprey.mcp_server.http.web_terminal_url", return_value="http://127.0.0.1:8087"):
         yield
 
 
@@ -145,6 +155,108 @@ class TestListPanels:
 
         assert result["status"] == "error"
         assert "not running" in result["message"]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_list_panels_reports_open_tiles_independently_of_rail_membership(
+        self, _mock_web_terminal_url
+    ):
+        """Rail membership and on-screen occupancy are reported as separate facts."""
+        fn = _get_list_panels()
+
+        api_response = json.dumps(
+            {
+                "enabled": ["artifacts", "ariel", "lattice"],
+                "custom": [],
+                "labels": {},
+                # ariel is in the rail but has no tile; lattice has a tile.
+                "visible": ["artifacts", "ariel", "lattice"],
+                "active": "lattice",
+                "open_tiles": ["lattice", "artifacts"],
+                "open_tiles_age_s": 12.0,
+                "open_tiles_dock": True,
+            }
+        ).encode()
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = api_response
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = extract_response_dict(await fn())
+
+        assert result["open_tiles"] == ["lattice", "artifacts"]
+        assert result["open_tiles_age_s"] == 12.0
+        assert result["open_tiles_dock"] is True
+        visible = {p["id"]: p["visible"] for p in result["panels"]}
+        assert visible["ariel"] is True and "ariel" not in result["open_tiles"]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_list_panels_freshness_is_null_when_no_client_has_reported(
+        self, _mock_web_terminal_url
+    ):
+        """Never-reported is all-null — never [], which would claim a known-empty screen."""
+        fn = _get_list_panels()
+
+        api_response = json.dumps(
+            {
+                "enabled": ["artifacts"],
+                "custom": [],
+                "labels": {},
+                "visible": ["artifacts"],
+                "active": None,
+                # The route's never-reported state: all three null.
+                "open_tiles": None,
+                "open_tiles_age_s": None,
+                "open_tiles_dock": None,
+            }
+        ).encode()
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = api_response
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = extract_response_dict(await fn())
+
+        assert result["open_tiles"] is None
+        assert result["open_tiles_age_s"] is None
+        assert result["open_tiles_dock"] is None
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_list_panels_passes_through_unknown_occupancy(self, _mock_web_terminal_url):
+        """A dock-less client reports unknown occupancy (null), never known-empty."""
+        fn = _get_list_panels()
+
+        api_response = json.dumps(
+            {
+                "enabled": ["artifacts"],
+                "custom": [],
+                "labels": {},
+                "visible": ["artifacts"],
+                "active": "artifacts",
+                # Server maps a dock:false report to unknown occupancy.
+                "open_tiles": None,
+                "open_tiles_age_s": 3.0,
+                "open_tiles_dock": False,
+            }
+        ).encode()
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = api_response
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = extract_response_dict(await fn())
+
+        assert result["open_tiles"] is None
+        assert result["open_tiles_dock"] is False
+        assert result["open_tiles_age_s"] == 3.0
 
 
 class TestSwitchPanel:
@@ -416,3 +528,192 @@ class TestRegisterPanel:
         # Assert
         assert result["status"] == "error"
         assert "not running" in result["message"].lower()
+
+
+# ---- arrange_workspace ----
+
+
+def _get_arrange_workspace():
+    from osprey.mcp_server.workspace.tools.panel_tools import arrange_workspace
+
+    return get_tool_fn(arrange_workspace)
+
+
+class TestArrangeWorkspace:
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_arrange_tiles_returns_applied_layout_and_freshness(self):
+        """A tiles arrangement echoes the server's applied layout plus freshness."""
+        # Arrange
+        fn = _get_arrange_workspace()
+        ok_result = {
+            "ok": True,
+            "status": 200,
+            "data": {
+                "status": "ok",
+                "tiles": ["artifacts", "lattice"],
+                "focus": "lattice",
+                "preset": None,
+                "prune_rail": False,
+            },
+        }
+        panels = {"open_tiles": ["artifacts"], "open_tiles_age_s": 2.5, "open_tiles_dock": True}
+
+        # Act
+        with (
+            patch(f"{_MODULE}.notify_panel_arrange", return_value=ok_result) as mock_arrange,
+            patch(f"{_MODULE}.fetch_panels", return_value=panels),
+        ):
+            result = extract_response_dict(
+                await fn(tiles=["artifacts", "lattice"], focus="lattice")
+            )
+
+        # Assert
+        assert result["status"] == "success"
+        assert result["tiles"] == ["artifacts", "lattice"]
+        assert result["focus"] == "lattice"
+        assert result["open_tiles_age_s"] == 2.5
+        assert result["open_tiles_dock"] is True
+        assert "preset" not in result
+        mock_arrange.assert_called_once_with(
+            tiles=["artifacts", "lattice"], preset=None, focus="lattice"
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_arrange_preset_reports_preset_name(self):
+        """A preset call forwards the name and reports it back."""
+        # Arrange
+        fn = _get_arrange_workspace()
+        ok_result = {
+            "ok": True,
+            "status": 200,
+            "data": {
+                "status": "ok",
+                "tiles": ["artifacts", "errors"],
+                "focus": None,
+                "preset": "injection",
+                "prune_rail": True,
+            },
+        }
+
+        # Act
+        with (
+            patch(f"{_MODULE}.notify_panel_arrange", return_value=ok_result) as mock_arrange,
+            patch(f"{_MODULE}.fetch_panels", return_value={}),
+        ):
+            result = extract_response_dict(await fn(preset="injection"))
+
+        # Assert
+        assert result["preset"] == "injection"
+        assert result["tiles"] == ["artifacts", "errors"]
+        assert result["focus"] is None
+        mock_arrange.assert_called_once_with(tiles=None, preset="injection", focus=None)
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_arrange_reports_null_freshness_when_readback_fails(self):
+        """An arrangement that applied is still a success when the freshness read fails."""
+        # Arrange
+        fn = _get_arrange_workspace()
+        ok_result = {"ok": True, "status": 200, "data": {"tiles": ["artifacts"], "focus": None}}
+
+        # Act
+        with (
+            patch(f"{_MODULE}.notify_panel_arrange", return_value=ok_result),
+            patch(f"{_MODULE}.fetch_panels", return_value=None),
+        ):
+            result = extract_response_dict(await fn(tiles=["artifacts"]))
+
+        # Assert
+        assert result["status"] == "success"
+        assert result["open_tiles_age_s"] is None
+        assert result["open_tiles_dock"] is None
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_arrange_reports_nulls_when_no_client_has_reported(self):
+        """Nulls from a live server mean nobody is watching — the agent should see that."""
+        # Arrange
+        fn = _get_arrange_workspace()
+        ok_result = {"ok": True, "status": 200, "data": {"tiles": ["artifacts"], "focus": None}}
+        never_reported = {
+            "enabled": ["artifacts"],
+            "open_tiles": None,
+            "open_tiles_age_s": None,
+            "open_tiles_dock": None,
+        }
+
+        # Act
+        with (
+            patch(f"{_MODULE}.notify_panel_arrange", return_value=ok_result),
+            patch(f"{_MODULE}.fetch_panels", return_value=never_reported),
+        ):
+            result = extract_response_dict(await fn(tiles=["artifacts"]))
+
+        # Assert
+        assert result["status"] == "success"
+        assert result["open_tiles_age_s"] is None
+        assert result["open_tiles_dock"] is None
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_arrange_surfaces_route_detail_verbatim(self):
+        """A 422 from the route reaches the agent word for word."""
+        # Arrange
+        fn = _get_arrange_workspace()
+        detail = "Unknown panel ids: ['bogus']. Valid panel ids: ['artifacts', 'lattice']"
+        rejected = {"ok": False, "status": 422, "detail": detail}
+
+        # Act / Assert
+        with patch(f"{_MODULE}.notify_panel_arrange", return_value=rejected):
+            with assert_raises_error(error_type="arrange_rejected") as ctx:
+                await fn(tiles=["bogus"])
+        assert detail in ctx["envelope"]["error_message"]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_arrange_unknown_preset_detail_lists_available(self):
+        """The route's available-preset list is preserved for the agent."""
+        # Arrange
+        fn = _get_arrange_workspace()
+        detail = "Unknown preset: 'nope'. Available presets: ['injection']"
+        rejected = {"ok": False, "status": 422, "detail": detail}
+
+        # Act / Assert
+        with patch(f"{_MODULE}.notify_panel_arrange", return_value=rejected):
+            with assert_raises_error(error_type="arrange_rejected") as ctx:
+                await fn(preset="nope")
+        assert "Available presets: ['injection']" in ctx["envelope"]["error_message"]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_arrange_web_terminal_unreachable(self):
+        """An unreachable web terminal is its own error type, not a rejection."""
+        # Arrange
+        fn = _get_arrange_workspace()
+        down = {"ok": False, "status": None, "detail": "Web Terminal is not running."}
+
+        # Act / Assert
+        with patch(f"{_MODULE}.notify_panel_arrange", return_value=down):
+            with assert_raises_error(error_type="web_terminal_unreachable") as ctx:
+                await fn(tiles=["artifacts"])
+        assert "not running" in ctx["envelope"]["error_message"].lower()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_arrange_does_not_prevalidate_tiles_xor_preset(self):
+        """The route owns tiles/preset exclusivity — the tool forwards and reports it."""
+        # Arrange
+        fn = _get_arrange_workspace()
+        rejected = {
+            "ok": False,
+            "status": 422,
+            "detail": "Provide exactly one of 'tiles' or 'preset'",
+        }
+
+        # Act / Assert
+        with patch(f"{_MODULE}.notify_panel_arrange", return_value=rejected) as mock_arrange:
+            with assert_raises_error(error_type="arrange_rejected"):
+                await fn(tiles=["artifacts"], preset="injection")
+        mock_arrange.assert_called_once_with(tiles=["artifacts"], preset="injection", focus=None)

--- a/tests/registry/test_mcp.py
+++ b/tests/registry/test_mcp.py
@@ -198,6 +198,27 @@ class TestResolveServers:
                 f"{name} must set CONFIG_FILE={expected!r}, got {srv['env'].get('CONFIG_FILE')!r}"
             )
 
+    def test_workspace_panel_tools_allow_split(self):
+        """Only the workspace-scoped panel verbs are auto-approved.
+
+        The split is not "read-only versus mutating": ``switch_panel`` adds a
+        rail entry when it surfaces a non-member, and ``arrange_workspace``
+        adds membership for a tiles request and prunes it for a preset. It is
+        scope and reversibility — these three act on the workspace the operator
+        is already looking at, and every effect is undoable from the rail or
+        the Layouts menu, so a prompt per call would only break the one-call
+        arrange flow. ``show_panel`` / ``hide_panel`` are the explicit
+        per-panel membership verbs and ``register_panel`` adds a proxied
+        upstream, so all three stay behind a prompt. This pins that split
+        rather than leaving it to the order of a list literal.
+        """
+        ctx = _base_ctx()
+        servers = resolve_servers({}, ctx)
+        workspace = [s for s in servers if s["name"] == "osprey_workspace"][0]
+        allow = set(workspace["permissions_allow"])
+        assert {"list_panels", "switch_panel", "arrange_workspace"} <= allow
+        assert allow.isdisjoint({"show_panel", "hide_panel", "register_panel"})
+
     def test_health_server_entry(self):
         """The health server is an opt-in, read-only server.
 


### PR DESCRIPTION
Closes the gap between the web terminal's multi-tile dock workspace and the agent's single-tab model, in both directions.

**The agent can now see the workspace.** The server tracks `open_tiles` — the service tiles actually on screen, in left-to-right reading order — reported by dock clients with content dedupe and last-writer-wins semantics. `GET /api/panels` and `list_panels` expose the list plus freshness fields that distinguish "nobody has ever reported", "a client is watching but cannot see tiles", and "genuinely empty". Two hooks keep the agent current between turns: a workspace line at session start, and a prompt-time delta line that stays completely silent when nothing changed.

**The agent acts at the right altitude.** `switch_panel` becomes non-destructive in the dock workspace: an open tile is focused, a rail member without a tile opens *beside* the operator's current view, and a non-member is added to the rail first — an operator's open tile is never evicted. A new `arrange_workspace(tiles|preset, focus)` verb expresses a whole layout declaratively, applied on every client as a deterministic rebuild with a healthy-fallback focus rule; the terminal tile is untouchable throughout.

**Human and agent preset paths are unified.** A "Layouts" click and `arrange_workspace(preset=...)` are the same server operation (server-side member resolution, rail pruned to members), so the two paths cannot drift.

Covered by 8 new Playwright browser scenarios (registered in the CI browser lane) plus ~370 unit tests across routes, tools, hooks, and the dock/panel JS modules.

## How it hangs together

```text
                              AGENT (Claude Code session)
┌───────────────────────────────────────┐   ┌──────────────────────────────────────┐
│ panel_tools.py (MCP)                  │   │ list_panels tool                     │
│  switch_panel (focus-or-open-beside)  │   │ SessionStart hook: workspace line    │
│  arrange_workspace(tiles|preset,focus)│   │ UserPromptSubmit delta hook          │
└─────────────┬─────────────────────────┘   │  (tempfile diff; silent if same)     │
              │ notify_* helpers (http.py)  └──────────────────▲───────────────────┘
              │ POST /api/panel-focus                          │ GET /api/panels
              ▼      /api/panel-arrange                        │ open_tiles + age_s
┌──────────────────────────────────────────────────────────────┴─── + dock state ───┐
│ SERVER (web terminal, state in app.state)                                         │
│  /api/panel-focus, /api/panel-arrange: validation, preset resolution, prune_rail, │
│    active_panel bookkeeping → emits ONE SSE event on /api/files/events            │
│  /api/panel-layout: occupancy store, last-writer-wins + content dedupe;           │
│    dock:false report → occupancy=unknown.  READ-SIDE ONLY — NO BROADCAST          │
└──────┬──────────────────────────────▲───────────────────────────▲─────────────────┘
       │ SSE: panel_focus /           │ (a) POST /api/panel-layout│ (b) POST /api/
       │      panel_arrange           │     report-only,          │     panel-arrange
       ▼ fan-out to EVERY client      │     never echoed back     │     (human click)
┌───────────────────────────────────────────────────────────────────────────────────┐
│ BROWSER DOCK CLIENTS (each)                                                       │
│  [ECHO GUARD] panel-placement.js applies SSE: applyAgentSwitch (open-beside,      │
│               never evict) / applyArrange (deterministic rebuild)                 │
│  dockview grid ─▶ serializeOpenTiles() (spatial reading order)                    │
│    ─▶ dock-sync.js reporter: settle-debounced, strictly serial, fires only after  │
│       dock-workspace.js's latched restore-applied announcement ─▶ (a)             │
│  "Layouts" preset click ─▶ panel-presets.js, thin caller of same endpoint ─▶ (b)  │
└───────────────────────────────────────────────────────────────────────────────────┘
  lanes: human gestures report UP │ agent verbs go DOWN via SSE │ reads flow → agent
```
