### PR TITLE
feat(archiver): give the virtual accelerator a real archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -823,6 +823,7 @@ jobs:
             --ignore=tests/e2e/test_tiled_roundtrip.py \
             --ignore=tests/e2e/test_va_substrate_equivalence.py \
             --ignore=tests/e2e/test_orm_roundtrip.py \
+            --ignore=tests/e2e/test_archiver_world_e2e.py \
             --ignore=tests/e2e/test_bluesky_catalog_e2e.py \
             --ignore=tests/e2e/test_bluesky_sandbox_escape_e2e.py \
             --ignore=tests/e2e/test_bluesky_panels_deploy.py \
@@ -1299,6 +1300,60 @@ jobs:
     - name: Run ORM roundtrip E2E
       run: |
         uv run pytest tests/e2e/test_orm_roundtrip.py -v --tb=short
+
+  archiver-world-e2e:
+    name: Archiver World E2E (VA + mongodb store + recorder, full Docker stack)
+    runs-on: ubuntu-latest
+    # Same-repo-PR gating, same reason as orm-roundtrip-e2e: this job needs no
+    # secrets — every assertion in the file is mechanical (seed duration, store
+    # size, a setpoint round-trip, a noise-band step, document counts), and the
+    # archiver read goes through the connector directly rather than an agent
+    # turn — but the same-repo restriction is house policy for any extra
+    # Docker-build-and-deploy job, not just secret-gated ones. A secret
+    # appearing here would mean the lane's scope silently grew; that is guarded
+    # by test_archiver_world_job_has_no_llm_secret.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    # Builds the native PyAT/serving-stack VA image from source (same cost as
+    # orm-roundtrip-e2e) and then seeds a DEFAULT-knob archive: 30-day
+    # retention at two tiers across the full channel manifest. The seed itself
+    # carries a 3-minute budget asserted inside the test; this cap is for the
+    # cold image cache around it.
+    timeout-minutes: 45
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    # No ghcr login step, unlike the orm lane it is otherwise modelled on: the
+    # trimmed stack pulls nothing from ghcr. The VA image builds locally from
+    # python:3.11-slim, mongodb is mongo:7 from Docker Hub, and the recorder
+    # reuses the VA image — openobserve is not deployed here at all.
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+
+    - name: Set up Python
+      run: uv python install 3.11
+
+    - name: Set up Docker Compose
+      uses: docker/setup-compose-action@v2
+
+    - name: Install osprey
+      # archiver-mongodb: the staged bring-up preflights pymongo before any
+      # image build, so without the extra this lane aborts in seconds with an
+      # install hint rather than running.
+      run: uv sync --extra dev --extra archiver-mongodb
+
+    - name: Run archiver world E2E
+      # -s so the measured budgets this lane owns (seed duration, store size,
+      # write->read latency) reach the log on a GREEN run. Pytest captures
+      # stdout on passing tests, and a budget lane that only shows its numbers
+      # when it fails cannot be read for the trend that precedes a failure.
+      run: |
+        uv run pytest tests/e2e/test_archiver_world_e2e.py -v -s --tb=short
 
   tiled-roundtrip-e2e:
     name: Tiled Roundtrip E2E (bluesky bridge + Tiled persistence, full Docker stack)
@@ -2032,7 +2087,7 @@ jobs:
 
   all-checks-passed:
     name: All CI Checks Passed
-    needs: [test, dependency-floor, lint, docs, package, static-checks, config-key-guard, visual-theming, frontend-js, build-boot-smoke, e2e-tests, deploy-e2e, dispatch-deploy-e2e, dispatch-overlay-e2e, bluesky-deploy-e2e, bluesky-panels-deploy-e2e, va-substrate-equivalence-e2e, orm-roundtrip-e2e, tiled-roundtrip-e2e, bluesky-catalog-e2e, bluesky-sandbox-escape-e2e, nextcloud-talk-bridge-e2e, gchat-bridge-e2e, dockerfile-e2e, execution-environment-parity-e2e, agentic-per-preset, deploy-writeback-e2e, multi-user-deploy-lifecycle-e2e, multi-user-deploy-lifecycle-e2e-podman]
+    needs: [test, dependency-floor, lint, docs, package, static-checks, config-key-guard, visual-theming, frontend-js, build-boot-smoke, e2e-tests, deploy-e2e, dispatch-deploy-e2e, dispatch-overlay-e2e, bluesky-deploy-e2e, bluesky-panels-deploy-e2e, va-substrate-equivalence-e2e, orm-roundtrip-e2e, archiver-world-e2e, tiled-roundtrip-e2e, bluesky-catalog-e2e, bluesky-sandbox-escape-e2e, nextcloud-talk-bridge-e2e, gchat-bridge-e2e, dockerfile-e2e, execution-environment-parity-e2e, agentic-per-preset, deploy-writeback-e2e, multi-user-deploy-lifecycle-e2e, multi-user-deploy-lifecycle-e2e-podman]
     runs-on: ubuntu-latest
     if: always()
 
@@ -2123,6 +2178,7 @@ jobs:
         check_pr_lane "Bluesky panels deploy E2E"    "${{ needs.bluesky-panels-deploy-e2e.result }}"
         check_pr_lane "VA substrate equivalence E2E" "${{ needs.va-substrate-equivalence-e2e.result }}"
         check_pr_lane "ORM roundtrip E2E"            "${{ needs.orm-roundtrip-e2e.result }}"
+        check_pr_lane "Archiver world E2E"           "${{ needs.archiver-world-e2e.result }}"
         check_pr_lane "Tiled roundtrip E2E"          "${{ needs.tiled-roundtrip-e2e.result }}"
         check_pr_lane "Bluesky catalog E2E"          "${{ needs.bluesky-catalog-e2e.result }}"
         check_pr_lane "Bluesky sandbox escape E2E"   "${{ needs.bluesky-sandbox-escape-e2e.result }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Added
 
+- A virtual accelerator can now be deployed with a real archive behind it: a
+  MongoDB store plus an archiver-recorder service that records the machine's
+  channels as they move. Scenario history is seeded into the store when the
+  stack comes up, so questions about what a channel did earlier are answered
+  from recorded samples rather than synthesized at read time.
+- Simulation scenarios are generated against absolute timestamps, so a
+  scenario's history lands at the wall-clock times it describes instead of
+  being anchored to when it was run.
 - The OSPREY agent can see what is actually on screen. `list_panels` now
   reports the open service tiles in left-to-right order plus how long ago that
   arrangement last changed, and tells "nothing open" apart from "no browser
@@ -120,6 +128,12 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Changed
 
+- Pairing a virtual accelerator with the mock archiver is refused — at build,
+  at deploy, and at MCP server startup — because the VA moves channels for
+  modelled reasons while the mock archiver invents history at read time, and
+  the pair reports a past that never happened. The mock archiver remains the
+  default for mock control systems; a project that pairs the two must move to
+  the MongoDB archiver or to a mock control system.
 - Asking the agent to open a panel no longer replaces what you were looking at.
   `switch_panel` opens the tile *beside* your current one — focusing it instead
   if it is already open — so no tile you had open is evicted. The Simple web

--- a/docs/source/getting-started/control-assistant.rst
+++ b/docs/source/getting-started/control-assistant.rst
@@ -39,8 +39,8 @@ control-room operator skills.
    It covers project layout, the ``controls`` MCP server, and the safety model
    in detail — everything below builds directly on it.
 
-Step 1: Build the Project
---------------------------
+Step 1: Build the Project and Bring It Up
+------------------------------------------
 
 Create a project from the ``control-assistant`` preset:
 
@@ -52,16 +52,49 @@ Create a project from the ``control-assistant`` preset:
 As in Hello World, this writes ``my-control-assistant-profile/`` beside the
 project and builds from it; provider keys go in that directory's ``.env``.
 
-Like ``hello-world``, this project starts in **mock** mode, so every example
-below is safe to run with no hardware attached; hardware writes are still gated
-behind the human-approval prompt. Unlike
-``hello-world``, the preset ships a **channel database**, a **seeded electronic
-logbook**, and a **mock archiver**, plus a set of sub-agents and operator skills.
+No hardware is involved, so every example below is safe to run; hardware writes
+are still gated behind the human-approval prompt. Unlike ``hello-world``, the
+preset ships a **channel database**, a **seeded electronic logbook**, and an
+**archive of its own** — a real store this project deploys, seeds and records
+into — plus a set of sub-agents and operator skills.
 
 .. note::
 
    First run may take 1--2 minutes to create a virtual environment and install
    dependencies. Subsequent builds are near-instant.
+
+Then bring the stack up (this needs Docker or Podman):
+
+.. code-block:: bash
+
+   osprey deploy up
+
+This starts the containers the preset declares: the Virtual Accelerator
+soft-IOC the agent reads and writes, and the **archive** — a MongoDB store and a
+recorder service — that holds what those channels did.
+
+**The first deploy seeds the archive**, and it is the step that takes the
+longest. It writes about a month of history for every channel the machine
+serves, printing a progress line every 15 seconds or so while it works:
+
+.. code-block:: text
+
+   Seeding 2,908 channels over 30 days (48h at 10s, then 60s). This takes minutes on a first deploy.
+     seeding archive: 8,960 documents written (15s elapsed)
+     ...
+   seeded 57,600 documents x 2,908 channels (2026-07-12 09:14 to 2026-08-11 09:14 UTC) in 96.3s
+
+Each of those documents holds one instant across every channel, which is why
+the count is in the tens of thousands rather than the millions. Expect a minute
+or two on a first deploy — it is writing, not hanging. Later deploys check what
+is already stored against the settings now in force and skip the seed when it
+already matches.
+
+.. note::
+
+   The store is compressed (zstd) and bounded by its retention window: at the
+   shipped settings it stays under 2 GiB on disk, and samples expire rather than
+   accumulating forever. Tuning that is Step 7.
 
 Step 2: What's Different from Hello World
 ------------------------------------------
@@ -81,9 +114,10 @@ same safety hooks, then adds production capabilities. The most visible additions
    * - **Logbook search** (sub-agents)
      - ``logbook-search`` and ``logbook-deep-research`` query a seeded operations
        logbook for past events.
-   * - **Archiver + visualization**
-     - A mock archiver serves historical data; the ``data-visualizer`` sub-agent
-       turns it into interactive and publication-quality plots.
+   * - **Archive + visualization**
+     - A store this project deploys serves historical data — seeded on the first
+       deploy, then recorded from the running machine; the ``data-visualizer``
+       sub-agent turns it into interactive and publication-quality plots.
    * - **Operator skills**
      - ``/diagnose``, ``/session-report``, ``setup-mode``, ``demo-gallery``, and
        ``demo-ui`` support common control-room workflows.
@@ -193,9 +227,8 @@ search and stitches the entries into a single narrative.
 Step 5: Pull Historical Data and Plot It
 -----------------------------------------
 
-The bundle also configures a **mock archiver** that serves synthetic historical
-data, so you can exercise the trend-and-plot workflow without a real archive
-appliance. Ask for a trend:
+The archive Step 1 seeded is what answers history questions here — the agent
+reads stored samples, not numbers made up when you ask. Ask for a trend:
 
 .. code-block:: text
 
@@ -207,13 +240,21 @@ the result. The visualizer produces a self-contained figure artifact:
 
 .. code-block:: text
 
-   Read 1440 samples for SR:DIAG:DCCT:01:CURRENT:RB (last 24h).
+   Read 8640 samples for SR:DIAG:DCCT:01:CURRENT:RB (last 24h).
    Created interactive plot: beam_current_24h.html (artifact)
 
 The ``data-visualizer`` can produce interactive Plotly figures, publication-quality
-matplotlib images, dashboards, and LaTeX reports. In development everything runs
-against the mock archiver; in production the same query hits your real archiver
+matplotlib images, dashboards, and LaTeX reports. Here the query hits the store
+this project deploys; in production the same query hits your facility's archiver
 (see Step 7).
+
+Two things follow from the history being *stored* rather than made up on
+demand. The last 24 hours come back at one sample every 10 seconds, because that
+is the cadence the archive holds recent history at — so a 24-hour trend is
+around 8,600 points, not a smooth line drawn to fit your window. And a question
+reaching back further than the archive does gets **no points** rather than a
+plausible-looking answer: ask for last year and the honest reply is that the
+archive starts about a month ago.
 
 Step 6: Run Operator Skills
 ----------------------------
@@ -274,6 +315,26 @@ effect for every later build — you can also just edit that file instead.
 
 See :doc:`../how-to/use-channel-finder` for a comparison of the strategies.
 
+**Tune how much history the archive keeps.** Two settings decide the store's
+size and reach: ``retention_days`` (how far back it goes — 30 by default) and
+``hot_span_hours`` (how much of that is kept at the dense 10-second cadence —
+48 by default; everything older is kept at 60 seconds). Both live in the
+**profile**, in its ``va_archiver:`` block, which is the one place the archive is
+described:
+
+.. code-block:: yaml
+
+   # my-control-assistant-profile/profile.yml
+   va_archiver:
+     retention_days: 7        # a week is plenty for a demo, and seeds faster
+     hot_span_hours: 24
+
+Rebuild and deploy after editing. The deploy notices the stored history no
+longer matches what the profile asks for, says what changed, and reseeds it
+(pass ``--keep-archiver-base`` to leave the old data alone instead). Do **not**
+copy these keys into the project's ``config.yml`` — the build writes that file
+from the block, and a second copy is free to disagree with the first.
+
 **Switch to real hardware.** As in Hello World, moving to production is a
 configuration change, not a code change. Point the connectors at your facility in
 ``config.yml``:
@@ -281,10 +342,14 @@ configuration change, not a code change. Point the connectors at your facility i
 .. code-block:: yaml
 
    control_system:
-     type: epics            # was: mock
+     type: epics            # was: virtual_accelerator
 
    archiver:
-     type: epics_archiver   # was: mock_archiver
+     type: epics_archiver   # was: mongodb_archiver
+
+The archive this tutorial deploys is a *simulated* machine's history, which is
+not what you want against hardware — so the archiver moves to your facility's
+appliance at the same time as the control system.
 
 Because these are build-time inputs, regenerate the agent's artifacts and relaunch:
 

--- a/docs/source/how-to/bluesky/queue.rst
+++ b/docs/source/how-to/bluesky/queue.rst
@@ -227,6 +227,12 @@ quirks worth knowing:
 
       osprey config set-control-system virtual_accelerator
 
+   That switch needs a real archive behind it. A project built from the
+   ``control-assistant`` preset has one and the command just works; a project
+   still reading the mock archiver is refused, and told to point
+   ``archiver.type`` at a store its deployment writes first — see
+   :doc:`../use-virtual-accelerator`.
+
 .. seealso::
 
    :doc:`run-first-scan`

--- a/docs/source/how-to/build-profiles.rst
+++ b/docs/source/how-to/build-profiles.rst
@@ -625,6 +625,12 @@ Profile YAML reference
      - mapping
      - ``{}``
      - Container services for ``osprey deploy`` (see :ref:`profile-services`).
+   * - ``va_archiver``
+     - mapping
+     - absent
+     - Declares a stored archive for a simulated machine: a MongoDB store and a
+       recorder the deploy stands up, seeds and records into
+       (see :ref:`profile-va-archiver`).
    * - ``lifecycle``
      - mapping
      - ``{}``
@@ -846,6 +852,136 @@ copied into the project's ``services/`` tree, and the service is registered in
 A service directory placed in the profile's ``services/`` convention directory is
 carried across the same way and marked as yours — that is what
 ``osprey scaffold claim services/<name>`` produces.
+
+.. _profile-va-archiver:
+
+The ``va_archiver`` block
+=========================
+
+A deployment that serves simulated channels still needs somewhere to keep what
+those channels did. Declaring ``va_archiver:`` is what gives it one: the build
+adds a MongoDB store and a recorder to the service stack, ``osprey deploy up``
+seeds the store with history and then records the running machine into it, and
+the ``mongodb_archiver`` connector reads it back.
+
+.. code-block:: yaml
+
+   va_archiver:
+     host: localhost
+     retention_days: 30
+     hot_span_hours: 48
+     hot_cadence_sec: 10
+     tail_cadence_sec: 60
+     freshness_channel: SR:DIAG:DCCT:01:CURRENT:RB
+
+Every key is optional and the defaults describe a working archive; the block's
+presence is the decision, not its contents.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 12 58
+
+   * - Key
+     - Default
+     - Meaning
+   * - ``retention_days``
+     - ``30``
+     - How far back the archive reaches — both what a fresh deployment holds
+       and what a running one keeps.
+   * - ``hot_span_hours``
+     - ``48``
+     - How much of the recent end is kept at the dense cadence. May not exceed
+       ``retention_days``.
+   * - ``hot_cadence_sec``
+     - ``10``
+     - Seconds between samples inside the hot span.
+   * - ``tail_cadence_sec``
+     - ``60``
+     - Seconds between samples outside it. Must be a whole multiple of
+       ``hot_cadence_sec`` — the sparse tier is a subset of the dense grid, so a
+       cadence that does not divide would put the two on timestamps that never
+       coincide.
+   * - ``recorder_cadence_sec``
+     - ``10``
+     - How often the recorder samples the live machine.
+   * - ``recorder_tail_cadence_sec``
+     - ``60``
+     - How often one of those samples is additionally kept for the full
+       retention span, so recorded history survives as the dense copy ages out.
+       Same whole-multiple rule.
+   * - ``recorder_poll_sec``
+     - ``30``
+     - How often the recorder re-reads the deployment's config to decide whether
+       to record at all. It records only for a ``virtual_accelerator`` control
+       system, and this is what lets that flip take effect without a restart.
+   * - ``freshness_channel``
+     - unset
+     - Canary channel for a derived ``archiver_freshness`` health check. Unset
+       derives no check (see :doc:`configure-health-checks`).
+   * - ``host``
+     - ``localhost``
+     - Where the store is. **Required** when ``deploy_services`` is false: an
+       attached project deploys no store of its own, so it has to name the host
+       whose archive it reads.
+   * - ``port_host``
+     - ``27017``
+     - Host port the store publishes on — or, for an attached project, the port
+       the other host published.
+   * - ``database`` / ``collection``
+     - ``osprey_archiver`` / ``pv_history``
+     - Where the samples live inside the store.
+   * - ``compression``
+     - ``zstd``
+     - Block compressor for the collection: ``zstd``, ``snappy``, ``zlib`` or
+       ``none``.
+   * - ``username`` / ``auth_database``
+     - ``osprey`` / ``admin``
+     - The database user the deployment creates and the agent connects as, and
+       the database it authenticates against.
+   * - ``password_env``
+     - ``MONGO_ROOT_PASSWORD``
+     - **Name** of the variable holding that password. The value is minted into
+       the deployment's ``.env``; it is never a profile field.
+   * - ``timeout_sec``
+     - ``5``
+     - How long the connector waits to reach the store.
+
+One fact, one home
+------------------
+
+The block is where the archive is described, and the build writes the rest from
+it. Do **not** also spell these in ``config:`` — a profile that does is refused,
+by name, rather than silently having one copy win:
+
+- the connector's eight connection keys —
+  ``archiver.mongodb_archiver.host``, ``.port``, ``.name``, ``.collection``,
+  ``.auth``, ``.username``, ``.password_env``, ``.timeout`` — all derived from
+  the keys above;
+- the shape knobs, written to ``va_archiver.*`` in the rendered ``config.yml``
+  for the seeder and the recorder to read;
+- ``health.categories.archiver``, when ``freshness_channel`` is set.
+
+Two homes for one fact are free to disagree, and the disagreement is the
+dangerous case: a stale ``collection`` or ``host`` in ``config:`` points the
+agent at an archive nothing is writing, which reads as empty rather than as
+broken.
+
+What the block does *not* do is select the archiver. Declaring where an archive
+lives and choosing it as the deployment's archiver are separate decisions, so
+the block never flips ``archiver.type`` out from under you — set
+``config: {archiver.type: mongodb_archiver}`` yourself, or the project deploys a
+store and then reads something else beside it.
+
+.. warning::
+
+   ``osprey build`` **refuses** a profile that pairs a ``virtual_accelerator``
+   control system with the mock archiver, or with no ``archiver.type`` at all
+   (which resolves to the mock): a simulated machine whose history is
+   synthesized at read time reports a past that never happened, and nothing can
+   catch it. The error names the fix — declare this block and select
+   ``mongodb_archiver``, point the archiver at a store you run yourself, or set
+   the control system to ``mock`` for an honestly storeless project. See
+   :doc:`use-virtual-accelerator`.
 
 
 Lifecycle commands

--- a/docs/source/how-to/configure-health-checks.rst
+++ b/docs/source/how-to/configure-health-checks.rst
@@ -118,7 +118,8 @@ suite runs the checks and grades each result ``ok`` / ``warning`` / ``error`` /
        ``warning``, as is an empty query window. An unreachable archiver, or an
        ``archiver_freshness`` check declared with no ``archiver:`` configured,
        is an ``error``. A reachable archiver UI does not prove data is flowing
-       — this probe checks the data.
+       — this probe checks the data. A project that deploys its own archive can
+       have this check **derived** rather than declared (below).
 
 .. note::
 
@@ -162,6 +163,53 @@ tile on the web dashboard, graded against the bands you choose:
 Reads go through the suite's control-system connector — the same connector,
 selected by ``control_system.type``, the agent itself uses — so a green canary
 also proves the connector configuration end to end.
+
+Recipe: archive freshness, without declaring a check
+-----------------------------------------------------
+
+A project that deploys its own archive — one whose build profile carries a
+``va_archiver:`` block (see :doc:`build-profiles`) — can have the freshness
+check written for it. Name one canary channel and nothing else:
+
+.. code-block:: yaml
+
+   # in the build profile, not config.yml
+   va_archiver:
+     freshness_channel: SR:DIAG:DCCT:01:CURRENT:RB
+
+The build turns that into a complete ``archiver`` category holding one
+``archiver_freshness`` check on that channel — the same thing you would write by
+hand, plus a ``max_age_s`` you do not have to choose.
+
+**Where the threshold comes from.** It is **three times the recorder's own
+sample cadence**, with a floor of 60 seconds. The recorder is what writes this
+archive, so how long a healthy archive can go without a sample is a fact about
+*it*, not a preference: three intervals tolerates two missed ticks before the
+check says anything, which is where "the recorder is behind" stops being
+ordinary scheduling jitter, and the floor keeps a fast recorder from alarming
+sooner than a container can restart. Slow the recorder down and the threshold
+follows — there is no second number to remember to re-tune.
+
+Which channel is representative is the one thing only you know, so there is no
+default: a profile that names none derives no check rather than having the
+framework guess. The ``control-assistant`` preset names the stored-beam DCCT
+current, for the reason a control room would pick it — it is the first thing to
+stop moving when the machine does.
+
+.. note::
+
+   On a deployment whose control system is ``mock``, the recorder idles by
+   design (it records a virtual accelerator, nothing else), so the newest sample
+   is whatever the deploy seeded and the check reports the archive as **stale**.
+   That is a ``warning``, never an ``error``, and it is an honest answer rather
+   than a misconfiguration: the store is reachable, it is simply not being
+   written. Flip the control system back and it goes green within a poll.
+
+Declare the check yourself *or* name a ``freshness_channel`` — not both. A
+profile that sets ``freshness_channel`` and also declares
+``health.categories.archiver`` in its ``config:`` block is refused at build time,
+because the two would be one fact in two homes, merged in whichever order the
+keys happened to be read.
 
 Built-in service categories
 ---------------------------

--- a/docs/source/how-to/use-virtual-accelerator.rst
+++ b/docs/source/how-to/use-virtual-accelerator.rst
@@ -15,7 +15,8 @@ behind the storage-ring lattice channels, so correctors move and BPMs respond.
    - Pointing a project at the soft-IOC the stack already deploys
    - Switching back to the mock, and why scans go browse-only there
    - How ``osprey sim apply`` scenarios behave in Virtual Accelerator mode
-   - Write limits, and the archiver live-vs-history divergence
+   - Write limits
+   - The stored archive the stack deploys, and the one pairing it refuses
 
    **Prerequisites:** Docker (or Podman) installed; the Control Assistant
    tutorial project (see :doc:`/getting-started/control-assistant`).
@@ -63,6 +64,11 @@ to switch on.
    osprey deploy up   # brings up the soft-IOC with the rest of the stack
    osprey web         # the agent talks to real Channel Access
 
+``osprey deploy up`` brings up more than the soft-IOC. Because the preset also
+declares a ``va_archiver:`` block, the deploy stands up the machine's **archive**
+next to it — a MongoDB store and a recorder service — and seeds it before the
+rest of the stack starts. See `The archive`_ below.
+
 The very first ``osprey deploy up`` that includes the Virtual Accelerator
 builds its container image from source (compiling PyAT and the soft-IOC), so
 expect it to take several minutes — it is building, not hanging. Later deploys
@@ -85,6 +91,16 @@ point it at the soft-IOC explicitly:
    change up immediately; anything already running in a container does not,
    until you re-deploy. No image rebuild is involved either way.
 
+**The archive has to come first.** On a project built from the
+``control-assistant`` preset the switch just works: the preset declares where the
+archive lives, so the project already reads a real store. On a project with no
+archive of its own — one still reading the mock archiver, which makes its history
+up as it is asked for it — ``set-control-system virtual_accelerator``
+**refuses**, and says what to do instead: point ``archiver.type`` at a store this
+deployment writes (``mongodb_archiver`` for the store the preset deploys), or
+stay on ``mock`` for an honestly storeless project. `The honesty rule`_ below
+explains why.
+
 Switching back to the mock
 ==========================
 
@@ -106,6 +122,16 @@ browse-only deployment with the exact command that flips it back. Everything
 that is not a scan — channel reads and writes, the archiver, the Channel
 Finder — works as before. The ``epics`` block keeps its production values
 throughout.
+
+The archive follows the flip on its own. The recorder records **only** a virtual
+accelerator, so on ``mock`` it stops writing and idles; it re-reads the project's
+``config.yml`` every 30 seconds, so the change takes effect within one poll and
+no restart or rebuild is involved. Nothing is deleted — the history already in
+the store stays readable, it simply stops growing, and it ages out under the
+retention window as usual. ``osprey health`` will report the archive as **stale**
+(a warning, not an error) once the newest sample is older than the freshness
+threshold, which is the honest answer to "is this archive still being written".
+Flipping back to ``virtual_accelerator`` restarts recording within a poll too.
 
 Connecting to the IOC
 =====================
@@ -181,19 +207,127 @@ connector.
    from ``channel_limits.json`` is not blocked. Range enforcement covers listed
    channels; it is not a closed allowlist here.
 
-Archiver: live values vs. history
-==================================
+The archive
+===========
 
-The mock archiver synthesizes channel *history* from ``machine.json``. That
-history is independent of the Virtual Accelerator's live physics:
+A simulated machine still needs somewhere to keep what its channels did, and the
+stack deploys one. ``osprey deploy up`` brings up two more containers beside the
+soft-IOC:
 
-- In **mock** mode, a channel's live value and its archived history are both
-  synthesized from ``machine.json`` — they agree by construction.
-- In **virtual_accelerator** mode, live storage-ring readbacks come from the PyAT
-  lattice (a corrector write recomputes the orbit), while the archiver's history
-  is still the synthetic ``machine.json`` series.
+- **the store** — a MongoDB service (``archiver-mongodb`` on the deployment's
+  network, published on host port 27017 by default), holding one collection of
+  timestamped samples;
+- **the recorder** — a small service that reads the running machine on a fixed
+  cadence and writes what answered into that collection.
 
-So in Virtual Accelerator mode a lattice channel's **live value and its archived
-history can diverge in meaning**: the live value reflects real simulated physics,
-the history does not. This is expected — a VA-backed archiver is a separate,
-future addition.
+The project's archiver connector (``archiver.type: mongodb_archiver``) reads
+history back out of the same collection, so what the agent plots is what the
+deployment recorded.
+
+What history is there
+---------------------
+
+Two halves of one timeline, and the deploy makes both true before you ask
+anything of them.
+
+**The seeded past.** The first deploy writes a base series for every channel the
+machine serves, covering the whole retention window — at the shipped defaults,
+**30 days back**, of which the most recent **48 hours** are sampled every
+10 seconds and the rest every 60. The values are generated, but they are
+generated the way the live machine generates its own: each channel's history is
+built around the same baseline the soft-IOC boots it at, with excursions scaled
+to that channel's own noise. Nothing invents an event nobody would find in the
+live machine.
+
+Writing it takes a minute or two on a first deploy, and the deploy says so as it
+goes ("seeding archive: N documents written", every 15 seconds or so), then
+reports the span and the document count when it finishes. Later deploys check
+the archive against the knobs now in force and skip the seed when it already
+covers them.
+
+**The recorded present.** From then on the recorder samples the machine every
+10 seconds and stores what answered. A setpoint you write is readable out of the
+archive within about half a minute. A channel that did not answer contributes
+nothing — a gap in the archive is the honest record of a channel that was not
+answering, never a value carried forward.
+
+The join between the two is meant to be invisible: seeded samples and recorded
+samples land on the same timestamps and around the same baselines, so where the
+seed ends and recording begins there is noise, not a step an operator would
+rightly chase.
+
+Retention is enforced by the store itself: dense samples expire after the hot
+span, the coarse ones after the retention window, so a long-running deployment
+stays bounded rather than growing forever. The collection is zstd-compressed;
+the project's end-to-end test budgets the seeded store at under 2 GiB on disk at
+these defaults.
+
+.. note::
+
+   Every number above is a knob in the build profile's ``va_archiver:`` block —
+   ``retention_days``, ``hot_span_hours``, the cadences — not a constant in the
+   code. Changing one is a profile edit and a rebuild; the next
+   ``osprey deploy up`` notices the archive no longer describes what the profile
+   asks for and reseeds it. See :doc:`build-profiles`.
+
+What the archive will not claim
+-------------------------------
+
+Ask for a window older than the archive reaches and you get **no points** —
+not a plausible-looking series stretched to fill the request. ``get_metadata``
+likewise reports the oldest and newest samples the collection really holds,
+rather than the window the profile declared. The archive never claims more than
+it has.
+
+The honesty rule
+================
+
+There is one configuration this stack refuses: a ``virtual_accelerator`` control
+system paired with the **mock archiver** — or with no archiver set at all, which
+resolves to the same thing.
+
+The reason is what the two do differently. The Virtual Accelerator serves
+channels that move for modelled reasons: you step a corrector, the orbit
+responds. The mock archiver does not store anything; it synthesizes a
+plausible-looking history at read time, for questions nobody recorded the answer
+to. Put them together and the agent reports a past that never happened, next to a
+present that did — with nothing connecting the two, so the fiction can never be
+caught by disagreeing with the machine it claims to describe.
+
+The pairing is refused at every point it can be created:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 66
+
+   * - Where
+     - What happens
+   * - ``osprey build``
+     - The build refuses the profile, and names the profile keys to change: add
+       a ``va_archiver:`` block (which is what makes the store exist) and set
+       ``config: {archiver.type: mongodb_archiver}``.
+   * - ``osprey deploy up`` / ``restart``
+     - The deploy aborts before starting anything, and names the ``config.yml``
+       edit: set ``type:`` under ``archiver:`` to a connector reading a store
+       this stack writes, or set ``type:`` under ``control_system:`` back to
+       ``mock``.
+   * - MCP server startup
+     - The server refuses to start on such a ``config.yml``, so a file
+       hand-edited after the build cannot quietly bring the pairing back.
+   * - ``osprey config set-control-system virtual_accelerator``
+     - Refused *before* the write, because this command can create the pairing:
+       it would switch the project onto the simulated machine while its archiver
+       stays the one that invents history.
+
+Two pairings that look similar are perfectly legal, because nothing lies in
+either: **mock control system + mock archiver** is the honestly storeless
+deployment (nothing is claimed to be real), and **EPICS + mock archiver** is a
+real machine that simply has no archive attached yet.
+
+.. warning::
+
+   ``config.yml`` is read as **nested sections**. A top-level dotted line like
+   ``archiver.type: mongodb_archiver`` added at the top of the file configures
+   nothing at all — the archiver is whatever the ``archiver:`` section says.
+   The refusal messages call this out when they find such a line, rather than
+   reporting the key as merely unset.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,11 +253,28 @@ screen-capture-linux = [
     "python-xlib>=0.33",
 ]
 
-# Virtual Accelerator: the serving stack, both transports. Everything else the
-# VA needs (PyAT, the manifest/lattice layer) is a core dependency, so these two
-# entries are the whole extra; `osprey-framework[virtual-accelerator]` keeps
-# resolving for every existing reference to it (CI `uv sync --extra`, both VA
-# images).
+# Virtual Accelerator: the serving stack, both transports, plus what the
+# archiver recorder needs to run on the SAME image. Everything else the VA needs
+# (PyAT, the manifest/lattice layer) is a core dependency;
+# `osprey-framework[virtual-accelerator]` keeps resolving for every existing
+# reference to it (CI `uv sync --extra`, both VA images).
+#
+# The last two entries are the recorder's, not the IOC's. The recorder
+# (osprey.services.archiver_recorder) ships as a compose-template-only service
+# that runs this image with a different command -- deliberately, so it adds no
+# image build to any deploy or to the seven VA-stack CI lanes -- which makes its
+# two dependencies part of what this extra has to deliver:
+#
+#   * aioca is its Channel Access CLIENT. The serving stack below is a CA
+#     *server* and ships no client, and while `ophyd-async[ca]` (a core
+#     dependency) does pull aioca in today, that is a transitive fact about
+#     another package's extra, not a declaration -- and the recorder imports
+#     aioca directly. Declared here so it stays installed if ophyd-async ever
+#     changes backends.
+#   * pymongo arrives through the `archiver-mongodb` extra rather than a second
+#     `pymongo>=4.0` line, so the floor keeps exactly one definition and cannot
+#     drift between the connector's extra and this one. Same self-referencing
+#     form the `all` extra uses.
 #
 # lume-pva-apg is the serving package `serving/runner.py` subclasses. Its `ca`
 # and `pva` extras are what put the two transports on the wire -- pcaspy for
@@ -316,6 +333,13 @@ screen-capture-linux = [
 virtual-accelerator = [
     "pcaspy>=0.8.1; sys_platform == 'linux' and platform_machine == 'x86_64'",
     "lume-pva-apg[ca,pva]==0.1.2; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    # Recorder-side (see the note above); deliberately UNMARKED, unlike the two
+    # serving entries. That marker is not a house style to copy — it exists
+    # because pcaspy publishes no usable wheel off linux/x86_64. These two do,
+    # everywhere, so marking them would only make the recorder's dependencies
+    # silently absent on a developer's machine.
+    "aioca>=1.7",
+    "osprey-framework[archiver-mongodb]",
 ]
 
 # All optional dependencies for complete installation

--- a/scripts/benchmark/matrix_e2e_config.json
+++ b/scripts/benchmark/matrix_e2e_config.json
@@ -55,6 +55,10 @@
       "reason": "Exercises the dispatch pipeline (webhook -> dispatcher -> worker -> SDK round-trip -> persistence), not model capability — the agent task is hello-world level (one-sentence reply, summarize a payload, save a stub report), so any responding model passes and it measures nothing about the model-under-test. Compounding this, its build fixture is pinned to als-apg/haiku and ignores OSPREY_E2E_FORCE_MODEL; under CBORG cells the als-apg key is shimmed to CBORG, so the worker agent hits the real als-apg endpoint with a wrong credential and hangs to the 300s worker timeout — a fixed ~3-test infra penalty per cell."
     },
     {
+      "path": "tests/e2e/test_archiver_world_e2e.py",
+      "reason": "Full-stack Docker deploy (VA + mongodb store + recorder) asserting seed duration, store size, a setpoint round-trip and document counts; no LLM call anywhere, so it measures nothing about the model-under-test. Also needs Docker, which the bench box lacks."
+    },
+    {
       "path": "tests/e2e/test_bluesky_catalog_e2e.py",
       "reason": "Real-container bluesky-bridge deploy driven via raw HTTP (plan catalog discovery + launch/read); no LLM call anywhere."
     },

--- a/scripts/config_key_manifest.yml
+++ b/scripts/config_key_manifest.yml
@@ -191,10 +191,26 @@ keys:
 
   # ── Archiver ────────────────────────────────────────────────────────
   archiver: {evidence: 'get_config_value\("archiver", \{\}\)'}
-  archiver.type: {evidence: 'mock_archiver'}
+  # Evidenced by the factory's own diagnostic for an unset type, not by the name
+  # of whichever connector happens to be the default. The literal 'mock_archiver'
+  # used to serve here and stopped describing the key the moment the
+  # control-assistant default became mongodb_archiver — a matcher that tracks a
+  # default is a matcher that goes quiet on the change it should have caught.
+  archiver.type: {evidence: 'archiver\.type is not set'}
   archiver.epics_archiver: {evidence: 'epics_archiver'}
   archiver.epics_archiver.url: {covered-by: archiver.epics_archiver}
   archiver.epics_archiver.timeout: {covered-by: archiver.epics_archiver}
+  # The stored archive's connection block, rendered by the control_assistant
+  # template and written from the profile's `va_archiver:` block at build time.
+  archiver.mongodb_archiver: {evidence: 'mongodb_archiver'}
+  archiver.mongodb_archiver.host: {covered-by: archiver.mongodb_archiver}
+  archiver.mongodb_archiver.port: {covered-by: archiver.mongodb_archiver}
+  archiver.mongodb_archiver.name: {covered-by: archiver.mongodb_archiver}
+  archiver.mongodb_archiver.collection: {covered-by: archiver.mongodb_archiver}
+  archiver.mongodb_archiver.auth: {covered-by: archiver.mongodb_archiver}
+  archiver.mongodb_archiver.username: {covered-by: archiver.mongodb_archiver}
+  archiver.mongodb_archiver.password_env: {covered-by: archiver.mongodb_archiver}
+  archiver.mongodb_archiver.timeout: {covered-by: archiver.mongodb_archiver}
 
   # ── Execution ───────────────────────────────────────────────────────
   execution: {evidence: 'execution = config\.get\("execution"\) if isinstance\(config, dict\) else None'}
@@ -587,7 +603,12 @@ orphan_sites:
       why: the deleted top-level config block in the templates — a genuine, fireable site
   api.providers.ollama.host:
     - root: src/osprey/templates
-      regex: '^\s+host:\s*localhost'
+      # Anchored on the base_url line that preceded it, not on `host: localhost`
+      # alone. Bare, it claimed every indented `host: localhost` in every
+      # template — so the first unrelated block to use that ordinary default
+      # (the archiver's stored-connection block) read as the deleted ollama key
+      # coming back. An orphan regex has to name the site it is proving gone.
+      regex: '\$\{OLLAMA_HOST[^\n]*\n\s+host:\s*localhost'
       why: the deleted ollama host/port pair (replaced by a single base_url)
   api.providers.ollama.port:
     - root: src/osprey/templates

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -53,6 +53,7 @@ from .build_injectors import (
     _inject_nextcloud_bridge,
     _inject_profile_services,
     _inject_va,
+    _inject_va_archiver,
     _locate_pkg_services,
 )
 from .build_lifecycle import (
@@ -95,6 +96,7 @@ __all__ = [
     "_inject_nextcloud_bridge",
     "_inject_profile_services",
     "_inject_va",
+    "_inject_va_archiver",
     "_locate_pkg_services",
     "_persist_artifact_server",
     "_persist_mcp_servers",
@@ -375,6 +377,7 @@ def build(
         ProfileWriteBackGuard,
         preset_profile_dir,
     )
+    from .build_profile_archiver import va_archiver_config_overrides
     from .build_profile_deploy import deploy_config_overrides
     from .profile_cmd import _resolve_profile_file
     from .project_utils import _clear_claude_code_project_state
@@ -740,17 +743,26 @@ def build(
         if profile_env_example.is_file():
             shutil.copy2(profile_env_example, project_path / ".env.example")
 
-        # 8. Apply config overrides, plus what the deploy block contributes.
-        #    Appended last and written in one pass, so the derived leaf lands
-        #    inside whatever `modules.web_terminals` subtree the profile's own
-        #    entries wrote rather than being replaced by it.
-        derived = deploy_config_overrides(build_profile.deploy, build_profile.config)
+        # 8. Apply config overrides, plus what the deploy and va_archiver blocks
+        #    contribute. Appended last and written in one pass, so the derived
+        #    leaf lands inside whatever `modules.web_terminals` subtree the
+        #    profile's own entries wrote rather than being replaced by it.
+        #    Derived keys the profile also spells are rejected at validation, so
+        #    winning here can never silently overwrite a facility's own value.
+        derived_by_block = {
+            "deploy": deploy_config_overrides(build_profile.deploy, build_profile.config),
+            "va_archiver": va_archiver_config_overrides(build_profile.va_archiver),
+        }
+        derived = {
+            key: value for block in derived_by_block.values() for key, value in block.items()
+        }
         config_overrides = {**build_profile.config, **derived}
         if config_overrides:
             _apply_config_overrides(project_path, config_overrides)
             logger.info("  ✓ Applied %d config override(s)", len(config_overrides))
-            for key, value in derived.items():
-                logger.info("      %s: %s (from the profile's deploy block)", key, value)
+            for block, entries in derived_by_block.items():
+                for key, value in entries.items():
+                    logger.info("      %s: %s (from the profile's %s block)", key, value, block)
 
         # 9-10d. Service scaffolding + injection. Skipped wholesale for an
         # attached project (deploy_services: false): its service sections were
@@ -810,6 +822,17 @@ def build(
             # 10d. Inject the Virtual Accelerator soft-IOC service
             if build_profile.virtual_accelerator is not None:
                 _inject_va(build_profile.virtual_accelerator, project_path)
+
+            # 10e. Inject the archiver store + recorder. Must follow step 10d:
+            # the recorder's compose template gates its image source, its
+            # startup ordering and its Channel Access addressing on
+            # `virtual_accelerator` being in `deployed_services`, which is
+            # exactly what _inject_va writes there. The connection block and
+            # the archive's knobs are not written here — they reached the
+            # rendered config through step 8, which an attached project also
+            # runs (see va_archiver_config_overrides).
+            if build_profile.va_archiver is not None:
+                _inject_va_archiver(build_profile.va_archiver, project_path)
         else:
             logger.info(
                 "deploy_services: false — attached project; no services scaffolded "

--- a/src/osprey/cli/build_injectors.py
+++ b/src/osprey/cli/build_injectors.py
@@ -6,7 +6,8 @@ registers it in ``deployed_services``), and prints a post-build hint. The
 injectors pair 1:1 with the service dataclasses in
 :mod:`osprey.cli.build_profile_schema` (``DispatchConfig``, ``BlueskyConfig``,
 ``BlueskyPanelsConfig``, ``VAConfig``, ``NextcloudBridgeProfileConfig``,
-``GChatBridgeProfileConfig``).
+``GChatBridgeProfileConfig``) plus ``VAArchiverConfig``, whose block lives in
+:mod:`osprey.cli.build_profile_archiver`.
 ``_copy_service_templates`` / ``_inject_profile_services`` handle the framework
 and facility-declared service templates.
 """
@@ -31,6 +32,7 @@ if TYPE_CHECKING:
         NextcloudBridgeProfileConfig,
         VAConfig,
     )
+    from osprey.cli.build_profile_archiver import VAArchiverConfig
 
 logger = get_logger("build")
 
@@ -972,4 +974,125 @@ def _inject_gchat_bridge(gchat_bridge: GChatBridgeProfileConfig, project_path: P
         "    Images:     `osprey deploy up` builds the gchat-bridge image locally "
         "(first run is slow). Use `--dev` to bake in your local osprey checkout; "
         "set OSPREY_GCHAT_BRIDGE_IMAGE to use a published image."
+    )
+
+
+def _inject_va_archiver(va_archiver: VAArchiverConfig, project_path: Path) -> None:
+    """Wire the stored archiver — store plus recorder — into a built project.
+
+    1. Copy the bundled ``mongodb`` and ``archiver_recorder`` compose templates
+       into ``<project>/services/``.
+    2. Write ``services.{mongodb,archiver_recorder}`` config + register both in
+       ``deployed_services``.
+    3. Print a post-build hint (deploy-time seed, minted password, what the
+       recorder waits for).
+
+    A two-service injector like :func:`_inject_dispatch`, and paired for the
+    same reason: a store nothing writes to and a recorder with nowhere to write
+    are each half a feature. They are deployed together and the recorder's
+    compose template health-gates on the store.
+
+    Must run *after* :func:`_inject_va`, which is what puts
+    ``virtual_accelerator`` into ``deployed_services`` — the recorder template
+    reads that membership to decide whether it can reuse the VA's image and
+    address the IOC in-network, or must be told both from the environment.
+
+    The connection block the agent reads (``archiver.mongodb_archiver.*``) and
+    the archive's shape knobs (``va_archiver.*``) are deliberately NOT written
+    here: they come from :func:`~osprey.cli.build_profile_archiver.va_archiver_config_overrides`
+    on the ordinary config-override path, which an attached project reaches and
+    this injector does not.
+
+    Args:
+        va_archiver: Validated archiver configuration from the build profile.
+        project_path: Root of the built project.
+    """
+    from ruamel.yaml import YAML
+
+    # 1. Copy the bundled compose templates (located the same way as service
+    #    templates). The recorder ships no Dockerfile — it runs the VA's image
+    #    with a different command — so there is nothing to build here either.
+    pkg_services = _locate_pkg_services()
+
+    dest_services_root = project_path / "services"
+    dest_services_root.mkdir(exist_ok=True)
+    owned = _user_owned_services(project_path)
+
+    for name in ("mongodb", "archiver_recorder"):
+        src_dir = pkg_services / name
+        if not src_dir.is_dir():
+            logger.warning("No package template for archiver service %r at %s", name, src_dir)
+            continue
+        _refresh_service_dir(src_dir, dest_services_root / name, name, owned)
+
+    # 1a. The recorder bind-mounts the simulation data dir read-only to read the
+    # channel manifest. An app bundle that ships no such tree would leave the
+    # mount source missing, and the container runtime materializes a missing
+    # source itself, root-owned — which then locks the host out of a directory
+    # inside its own project. Same guard, same reason, as the VA injector's.
+    (project_path / "data" / "simulation").mkdir(parents=True, exist_ok=True)
+
+    # 2. Write config.yml entries + register in deployed_services.
+    config_path = project_path / "config.yml"
+    if not config_path.exists():
+        logger.warning("config.yml not found — skipping archiver config registration")
+        return
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    with open(config_path) as fh:
+        config = yaml.load(fh)
+
+    # Only the keys the compose templates read: how the store publishes itself,
+    # who it creates, and how it compresses. They restate profile knobs the
+    # agent-side connection block also carries — one profile value rendered into
+    # the two places that read it, which is derivation rather than a second home
+    # for the fact. No ``image`` key on either service: the store falls to the
+    # template's pinned upstream tag, and the recorder to the VA's image.
+    config.setdefault("services", {})
+    anchored_put(
+        config["services"],
+        "mongodb",
+        {
+            "path": "./services/mongodb",
+            "port_host": va_archiver.port_host,
+            "username": va_archiver.username,
+            "compression": va_archiver.compression,
+        },
+    )
+    anchored_put(
+        config["services"],
+        "archiver_recorder",
+        {"path": "./services/archiver_recorder"},
+    )
+    deployed = config.get("deployed_services", []) or []
+    for name in ("mongodb", "archiver_recorder"):
+        if name not in [str(s) for s in deployed]:
+            anchored_append(deployed, name)
+    config["deployed_services"] = deployed
+
+    with open(config_path, "w") as fh:
+        yaml.dump(config, fh)
+
+    # 3. Post-build hint.
+    logger.info(
+        "  ✓ Injected archiver store + recorder (port %d, %d-day retention)",
+        va_archiver.port_host,
+        va_archiver.retention_days,
+    )
+    logger.info(
+        "    History:    `osprey deploy up` seeds the base series before the "
+        "stack starts (minutes on a first deploy, skipped when the knobs have "
+        "not changed). Until then the archive is empty and archiver reads "
+        "honestly return nothing."
+    )
+    logger.info(
+        "    Password:   `osprey deploy up` mints %s into .env; the store, the "
+        "recorder and the agent all authenticate with that one value.",
+        va_archiver.password_env,
+    )
+    logger.info(
+        "    Recording:  the recorder writes only while control_system.type is "
+        "'virtual_accelerator' — on any other control system it idles. It "
+        "re-reads that setting on an interval, so the flip needs no restart."
     )

--- a/src/osprey/cli/build_profile_archiver.py
+++ b/src/osprey/cli/build_profile_archiver.py
@@ -1,0 +1,711 @@
+"""The ``va_archiver:`` block — the store a simulated facility's history lives in.
+
+A deployment that serves simulated channels still needs somewhere to keep what
+those channels did. This block declares that store: a MongoDB collection the
+build seeds with a deterministic base series, a recorder samples the running
+machine into, and the ``mongodb_archiver`` connector reads back. Declaring the
+block is what makes the history *stored* rather than synthesized at read time.
+
+Every number the store's shape depends on is a key here, because the facility
+that owns the deployment owns those numbers: how far back history reaches, how
+densely, how often the recorder writes, how the collection is compressed. None
+of them are constants in the seeder or the recorder — they travel profile →
+rendered ``config.yml`` → the services that read it, and changing one is a
+profile edit and a rebuild, never a code change.
+
+The block also knows the connector's connection keys, and emits them: a
+facility that has said where its archive lives should not have to say it again
+in ``config:`` under a second spelling that can disagree. Those keys are
+therefore *rejected by name* in ``config:`` while this block is present, the
+same way the ``deploy:`` block refuses a duplicated ``image_source``.
+
+Shapes, parsing, rules and the config it contributes are all here rather than
+split across the loader modules — the block is closed and small, and the build
+step that injects the two archiver services wants exactly one import.
+
+The build-time half of the honesty rule lives here too
+(:func:`va_mock_archiver_errors`): declining to declare a store is a legal
+choice for most deployments, but not for one serving a simulated machine, and
+the profile is the earliest place that pairing can be caught.
+"""
+
+from __future__ import annotations
+
+import difflib
+from dataclasses import dataclass, fields
+from typing import Any
+
+from osprey.connectors.honesty import VA_MOCK_ARCHIVER_WHY, pairing_in_profile
+from osprey.connectors.types import MONGODB_ARCHIVER, VIRTUAL_ACCELERATOR
+from osprey.errors import BuildProfileError
+
+from .build_profile_schema import _ENV_VAR_RE
+
+#: Block compressors ``mongod`` accepts for a WiredTiger collection. The value
+#: reaches the container as a command flag and the collection inherits it at
+#: implicit creation, so a name outside this set fails at container start —
+#: hours after the profile that named it was written.
+COMPRESSORS: tuple[str, ...] = ("zstd", "snappy", "zlib", "none")
+
+#: Where the agent reaches a store this project deploys itself. The service
+#: publishes its port on the deployment's bind address, and the agent runs on
+#: the host, so loopback is the connection for every self-contained project.
+#: An *attached* project overrides it with :attr:`VAArchiverConfig.host`.
+DEFAULT_ARCHIVER_HOST = "localhost"
+
+#: Rendered-config subtree the ``mongodb_archiver`` connector reads. Sibling to
+#: ``archiver.type`` rather than nested under it — the archiver factory looks up
+#: ``archiver.<type>`` for the selected type's settings.
+CONNECTION_CONFIG_PREFIX = "archiver.mongodb_archiver"
+
+#: Rendered-config block the seeder and the recorder read the archive's shape
+#: from. Named after the profile block so the two are recognizably the same
+#: knobs: the profile is where a facility sets them, this is where the services
+#: read them, and nothing in between holds a second copy.
+KNOBS_CONFIG_PREFIX = "va_archiver"
+
+#: Health category the derived freshness check lands in. Deliberately not one of
+#: the core category names (:data:`osprey.health.config.CORE_CATEGORY_NAMES`),
+#: which reject a ``checks:`` list outright.
+FRESHNESS_CATEGORY = "archiver"
+
+#: Check and probe name. Both are the probe's own defaults, stated rather than
+#: relied on so the rendered config reads as a complete declaration.
+FRESHNESS_CHECK_NAME = "archiver_freshness"
+
+#: Where the derived check lands in the rendered config.
+FRESHNESS_CONFIG_KEY = f"health.categories.{FRESHNESS_CATEGORY}.checks"
+
+#: How many recorder intervals may pass before the archive is called stale.
+#:
+#: The writer is the recorder, and its hot cadence is what governs: every sample
+#: it takes is written, and ``recorder_tail_cadence_sec`` only decides which of
+#: those *survive* ageing out of the hot span (see the recorder's store module —
+#: a sample landing on the tail grid gets the longer expiry, it is not a
+#: separate, slower write). So the newest sample is always one hot interval old
+#: at worst, never one tail interval.
+#:
+#: At worst in steady state, that is — which is why the threshold is a multiple
+#: rather than the cadence itself. A threshold equal to the cadence would sit
+#: exactly on the sample age and flap on ordinary scheduling jitter: a container
+#: under load, a CA read that takes most of its interval, a single missed tick.
+#: Three intervals tolerates two consecutive misses before saying anything,
+#: which is the point where "the recorder is behind" stops being noise.
+FRESHNESS_SAFETY_MULTIPLE = 3
+
+#: Floor for that threshold, in seconds. A facility recording every second would
+#: otherwise derive a 3 s threshold, which any container restart trips; nothing
+#: is learned from an alarm that fires faster than the deployment can recover.
+FRESHNESS_FLOOR_SEC = 60
+
+#: The knobs that describe the archive itself rather than the container serving
+#: it. The container-shaping ones (port, user, compressor) are rendered into
+#: ``services.mongodb`` by the injector, where the compose template reads them.
+_KNOB_CONFIG_KEYS: tuple[str, ...] = (
+    "retention_days",
+    "hot_span_hours",
+    "hot_cadence_sec",
+    "tail_cadence_sec",
+    "recorder_cadence_sec",
+    "recorder_tail_cadence_sec",
+    "recorder_poll_sec",
+)
+
+#: Mongo database names may not contain these, and a name that does is refused
+#: at connect time with a pymongo error nobody reads as "fix your profile".
+_ILLEGAL_DB_CHARS = set('/\\. "$*<>:|?')
+
+#: Keys the block recognizes, derived from the dataclass rather than listed by
+#: hand so the check cannot drift from what the parser honors.
+_KNOWN_VA_ARCHIVER_KEYS: frozenset[str] = frozenset()  # populated below
+
+
+@dataclass
+class VAArchiverConfig:
+    """The parsed ``va_archiver:`` block — one store, one timeline.
+
+    The defaults describe the store a control-assistant deployment wants
+    without being told: two days of dense history behind a month of coarse
+    history, sampled every ten seconds, compressed. They are chosen to fit the
+    documented storage budget at the shipped channel count; raising
+    :attr:`retention_days` raises the disk footprint roughly in proportion.
+    """
+
+    retention_days: int = 30
+    """How far back the archive reaches, in days. The coarse tail is seeded over
+    this span and every recorder-written tail sample expires this long after it
+    was taken, so the number is both "how much history a fresh deployment has"
+    and "how much a running one keeps"."""
+
+    hot_span_hours: int = 48
+    """How much of the most recent history is kept at the dense cadence. Sized
+    to cover an operator's plausible lookback ("what happened on the last
+    shift") without paying dense storage for a month."""
+
+    hot_cadence_sec: int = 10
+    """Seconds between samples inside the hot span."""
+
+    tail_cadence_sec: int = 60
+    """Seconds between samples outside it. Must be a whole multiple of
+    :attr:`hot_cadence_sec`: the tail grid is the sparse subset of the hot grid,
+    and a cadence that does not divide it would put the two tiers on timestamps
+    that never coincide."""
+
+    recorder_cadence_sec: int = 10
+    """How often the recorder samples the live machine. Its samples carry the
+    hot-span expiry, so this is the cadence recent recorded history has."""
+
+    recorder_tail_cadence_sec: int = 60
+    """How often one of those samples is additionally kept for the full
+    retention span. Recorded reality survives at the tail cadence as the dense
+    copy ages out, which is what keeps steady-state storage bounded while
+    leaving no hole where the seeded history ended."""
+
+    recorder_poll_sec: int = 30
+    """How often the recorder re-reads the deployment's config to decide whether
+    it should be recording at all. It records only for a simulated control
+    system, and that setting is a documented post-build flip — polling is what
+    lets the flip take effect without restarting the service."""
+
+    port_host: int = 27017
+    """Host port the store publishes on. Only meaningful for a project that
+    deploys its own store; an attached project is reaching someone else's
+    published port, which is the same key seen from the other side."""
+
+    database: str = "osprey_archiver"
+    """Database holding the collection."""
+
+    collection: str = "pv_history"
+    """Collection the samples are written to and read from."""
+
+    compression: str = "zstd"
+    """WiredTiger block compressor for that collection (see :data:`COMPRESSORS`).
+    Time-series documents compress well, and the choice is the difference
+    between a base seed that fits the storage budget and one that does not."""
+
+    username: str = "osprey"
+    """Database user the deployment creates and the agent connects as."""
+
+    auth_database: str = "admin"
+    """Database that user authenticates against — ``admin`` for the root user a
+    deployed store mints. Rendered as the connector's ``auth`` key."""
+
+    password_env: str = "MONGO_ROOT_PASSWORD"
+    """Name of the variable holding that user's password. The value is minted
+    into the deployment's ``.env`` and read at connect time; it is never a
+    profile field, and naming a different variable here does not create one."""
+
+    timeout_sec: int = 5
+    """Seconds the connector waits to reach the store. Deliberately short: the
+    common failure is a project that was built but never deployed, and the
+    honest answer there is a fast, explanatory error rather than a minute of
+    silence on the first archiver call."""
+
+    freshness_channel: str | None = None
+    """Canary channel the ``archiver_freshness`` health check reads, if any.
+
+    Naming one is what turns the archive from something the deployment *has*
+    into something it is *checked on*: the check queries this channel's newest
+    sample and grades its age, which is the difference between "the store is
+    reachable" and "the store is still being written". Which channel is
+    representative is a fact only the facility knows — a stored-beam current, a
+    vacuum gauge, whatever stops moving first when the machine does — so there
+    is no default, and a profile that names none derives no check rather than
+    having the framework guess one.
+    """
+
+    host: str | None = None
+    """Where the store actually is, when it is not this project's own.
+
+    ``None`` — the default — means this project deploys the store and the agent
+    reaches it on loopback. An *attached* project (``deploy_services: false``)
+    deploys nothing, so it must say which host's store it is reading; that is
+    the one configuration where this key is required rather than optional.
+    """
+
+
+_KNOWN_VA_ARCHIVER_KEYS = frozenset(f.name for f in fields(VAArchiverConfig))
+
+# Integer keys and the floor each one has to clear. All of them are counts of
+# something real (seconds, hours, days, a port), so zero and negative are
+# meaningless rather than merely unusual.
+_POSITIVE_INT_KEYS: tuple[str, ...] = (
+    "retention_days",
+    "hot_span_hours",
+    "hot_cadence_sec",
+    "tail_cadence_sec",
+    "recorder_cadence_sec",
+    "recorder_tail_cadence_sec",
+    "recorder_poll_sec",
+    "timeout_sec",
+)
+
+_STRING_KEYS: tuple[str, ...] = (
+    "database",
+    "collection",
+    "compression",
+    "username",
+    "auth_database",
+    "password_env",
+)
+
+
+def parse_va_archiver_block(raw: dict[str, Any]) -> VAArchiverConfig | None:
+    """Parse a profile's ``va_archiver:`` block into its typed shape.
+
+    Structural problems are reported together rather than one per run: the
+    block is a dozen numbers being transcribed at once, and learning about them
+    one rebuild at a time is the slowest way to fill in a table.
+
+    Args:
+        raw: The resolved raw profile dict.
+
+    Returns:
+        The parsed config, or ``None`` when the profile declares no
+        ``va_archiver:`` block — a stored archive is opt-in, and a deployment
+        without one reads whatever archiver its ``config:`` selects.
+
+    Raises:
+        BuildProfileError: If the block is not a mapping, names a key the block
+            does not define, or gives one the wrong type. Range and consistency
+            rules are :func:`va_archiver_errors`', so they can be reported
+            alongside the rest of the profile's.
+    """
+    block = raw.get("va_archiver")
+    if block is None:
+        return None
+    if not isinstance(block, dict):
+        raise BuildProfileError(
+            f"Profile 'va_archiver' must be a mapping (got {type(block).__name__})"
+        )
+
+    problems: list[str] = []
+    _reject_unknown_keys(block, problems)
+
+    values: dict[str, Any] = {}
+    for key in (*_POSITIVE_INT_KEYS, "port_host"):
+        if key in block:
+            values[key] = _parse_int(block[key], key, problems)
+    for key in _STRING_KEYS:
+        if key in block:
+            values[key] = _parse_str(block[key], key, problems)
+    for optional in ("host", "freshness_channel"):
+        if block.get(optional) is not None:
+            values[optional] = _parse_str(block[optional], optional, problems)
+
+    if problems:
+        raise BuildProfileError(
+            "Profile 'va_archiver' block is invalid:\n  - " + "\n  - ".join(problems)
+        )
+
+    return VAArchiverConfig(**values)
+
+
+def va_archiver_errors(
+    va_archiver: VAArchiverConfig | None,
+    config: Any,
+    deploy_services: bool,
+) -> list[str]:
+    """Check the block's ranges and its agreement with the rest of the profile.
+
+    Split from parsing so these land in ``BuildProfile.validate()``'s single
+    report — a facility fixing a profile should meet every problem it has at
+    once — and because two of the rules are not the block's to see alone: where
+    the store lives depends on whether this project deploys one, and a
+    duplicated connection key is a fact about ``config:``.
+
+    Args:
+        va_archiver: The parsed block, or ``None`` when the profile has none.
+        config: The profile's ``config:`` block.
+        deploy_services: Whether this project deploys its own service stack.
+
+    Returns:
+        The problems found, empty when the block is absent or clean.
+    """
+    if va_archiver is None:
+        return []
+
+    errors: list[str] = []
+    cfg = va_archiver
+
+    for key in _POSITIVE_INT_KEYS:
+        value = getattr(cfg, key)
+        if value < 1:
+            errors.append(f"va_archiver.{key} must be >= 1 (got {value})")
+
+    if not (1 <= cfg.port_host <= 65535):
+        errors.append(f"va_archiver.port_host must be in 1..65535 (got {cfg.port_host})")
+
+    # The hot tier is the recent end of the same timeline the tail covers, so a
+    # hot span reaching past retention would describe dense history older than
+    # the oldest history there is.
+    if cfg.hot_span_hours > cfg.retention_days * 24:
+        errors.append(
+            f"va_archiver.hot_span_hours ({cfg.hot_span_hours}) exceeds retention_days "
+            f"({cfg.retention_days} days = {cfg.retention_days * 24} hours) — the dense "
+            f"tier is the recent part of the retained window, not a longer one"
+        )
+
+    # Same grid, two densities: the seeder writes the tail as the sparse subset
+    # of the hot cadence, and the recorder promotes every Nth of its samples the
+    # same way. A cadence that does not divide leaves the tiers on timestamps
+    # that never line up, which shows up as a seam rather than as an error.
+    for dense, sparse in (
+        ("hot_cadence_sec", "tail_cadence_sec"),
+        ("recorder_cadence_sec", "recorder_tail_cadence_sec"),
+    ):
+        fine, coarse = getattr(cfg, dense), getattr(cfg, sparse)
+        if fine < 1 or coarse < 1:
+            continue  # already reported above
+        if coarse < fine:
+            errors.append(
+                f"va_archiver.{sparse} ({coarse}) must be >= {dense} ({fine}) — "
+                f"the sparse tier cannot sample faster than the dense one"
+            )
+        elif coarse % fine:
+            errors.append(
+                f"va_archiver.{sparse} ({coarse}) must be a whole multiple of "
+                f"{dense} ({fine}), so both tiers land on the same timestamps"
+            )
+
+    if cfg.compression not in COMPRESSORS:
+        errors.append(
+            f"va_archiver.compression must be one of "
+            f"{', '.join(repr(name) for name in COMPRESSORS)} (got {cfg.compression!r})"
+        )
+
+    for key in ("database", "collection", "username", "auth_database"):
+        if not getattr(cfg, key).strip():
+            errors.append(f"va_archiver.{key} must be a non-empty string")
+    illegal = sorted(_ILLEGAL_DB_CHARS & set(cfg.database))
+    if illegal:
+        errors.append(
+            f"va_archiver.database {cfg.database!r} contains character(s) MongoDB "
+            f"forbids in a database name: {' '.join(illegal)}"
+        )
+
+    if not _ENV_VAR_RE.match(cfg.password_env):
+        errors.append(
+            f"va_archiver.password_env must be an environment variable NAME "
+            f"(uppercase letters, digits, underscores), got {cfg.password_env!r}. The "
+            f"password itself belongs in the deployment's .env, never in the profile."
+        )
+
+    if cfg.host is not None and not cfg.host.strip():
+        errors.append("va_archiver.host must be a non-empty string when present")
+
+    # An attached project scaffolds no services, so nothing here deploys the
+    # store. Without a host it would silently connect to loopback and find
+    # nothing listening — a deploy-time mystery for a build-time omission.
+    if not deploy_services and cfg.host is None:
+        errors.append(
+            "va_archiver.host is required when deploy_services is false — an "
+            "attached project deploys no store of its own, so it has to name the "
+            "host whose archive it reads (with port_host set to that host's "
+            "published port)."
+        )
+
+    if cfg.freshness_channel is not None and not cfg.freshness_channel.strip():
+        errors.append(
+            "va_archiver.freshness_channel must be a non-empty channel name when present "
+            "(omit the key entirely to derive no freshness check)"
+        )
+
+    errors.extend(_duplicate_derived_key_errors(config))
+    errors.extend(_duplicate_freshness_check_errors(config, cfg))
+    return errors
+
+
+def va_mock_archiver_errors(config: Any) -> list[str]:
+    """Refuse a profile that gives a simulated machine an invented past.
+
+    The build is the earliest of the honesty rule's three sites and the only one
+    that can name the *profile* keys to change, which is why the message here
+    talks about ``va_archiver:`` and ``config:`` rather than about ``config.yml``.
+
+    Reads the profile's resolved ``config:`` block — after presets, ``extends``
+    parents and CLI layers have merged and the ``connector:`` shorthand has
+    folded in — so what is checked is the pairing the rendered project will
+    actually carry, not the one any single layer happened to author. Both the
+    dotted and the nested spelling are read, and a disagreement between them
+    fails closed; see :func:`~osprey.connectors.honesty.pairing_in_profile`.
+
+    Args:
+        config: The profile's ``config:`` block.
+
+    Returns:
+        The single problem as a one-element list, or empty when the profile
+        pairs honestly. Shaped for :meth:`BuildProfile.validate`'s accumulated
+        report — a facility fixing a profile meets all of its problems at once.
+    """
+    pairing = pairing_in_profile(config)
+    if not pairing.is_invented_history:
+        return []
+    return [
+        f"config sets control_system.type to {VIRTUAL_ACCELERATOR!r} while "
+        f"archiver.type is {pairing.archiver_phrase} — {VA_MOCK_ARCHIVER_WHY} "
+        f"Give the deployment a real archive instead: add a `va_archiver:` block "
+        f"(the build then deploys a store and a recorder beside the virtual "
+        f"accelerator, seeds the history, and derives the connector's keys) and set "
+        f"`config: {{archiver.type: {MONGODB_ARCHIVER}}}`. If the archive lives in a "
+        f"store you run yourself, set archiver.type to that connector and give it "
+        f"its connection keys — anything but the mock is accepted here."
+    ]
+
+
+def va_archiver_config_overrides(va_archiver: VAArchiverConfig | None) -> dict[str, Any]:
+    """The ``config:`` entries the block contributes to the rendered project.
+
+    Two groups, both derived from the one block so the profile never states the
+    archive twice:
+
+    - the connector's eight connection keys, because the block already says
+      where the archive is and the connector needs that fact under its own
+      spelling. It is why a ``config:`` block spelling them anyway is refused
+      rather than quietly overwritten;
+    - the archive's shape — retention, tier spans, cadences — which the seeder
+      and the recorder read at run time. They live in the rendered config rather
+      than as constants in those services precisely so that changing one is a
+      profile edit and a rebuild.
+
+    Applied on the ordinary config-override path rather than by the archiver's
+    build-step injector, because an *attached* project scaffolds no services and
+    so never reaches that injector — yet it is exactly the project that most
+    needs to be told where its archive is.
+
+    The archiver *type* is deliberately not among them. Declaring where an
+    archive lives is not the same decision as selecting it as the deployment's
+    archiver, and a block that flipped the connector out from under a facility's
+    ``archiver.type`` would be making that decision for them.
+
+    Args:
+        va_archiver: The parsed block, or ``None``.
+
+    Returns:
+        Dotted config keys to apply after the profile's own, empty when the
+        profile declares no block.
+    """
+    if va_archiver is None:
+        return {}
+    cfg = va_archiver
+    overrides: dict[str, Any] = {
+        **freshness_check_override(cfg),
+        f"{CONNECTION_CONFIG_PREFIX}.host": cfg.host or DEFAULT_ARCHIVER_HOST,
+        f"{CONNECTION_CONFIG_PREFIX}.port": cfg.port_host,
+        f"{CONNECTION_CONFIG_PREFIX}.name": cfg.database,
+        f"{CONNECTION_CONFIG_PREFIX}.collection": cfg.collection,
+        f"{CONNECTION_CONFIG_PREFIX}.auth": cfg.auth_database,
+        f"{CONNECTION_CONFIG_PREFIX}.username": cfg.username,
+        f"{CONNECTION_CONFIG_PREFIX}.password_env": cfg.password_env,
+        f"{CONNECTION_CONFIG_PREFIX}.timeout": cfg.timeout_sec,
+    }
+    overrides.update(
+        {f"{KNOBS_CONFIG_PREFIX}.{knob}": getattr(cfg, knob) for knob in _KNOB_CONFIG_KEYS}
+    )
+    return overrides
+
+
+def freshness_max_age_s(va_archiver: VAArchiverConfig) -> int:
+    """The staleness threshold this archive's own writer implies.
+
+    Derived rather than configured, because the number that matters is not a
+    preference — it is a fact about the recorder this same block configures. A
+    facility that halves ``recorder_cadence_sec`` has halved how long a healthy
+    archive can go without a sample, and the check should follow that edit
+    without anyone remembering to re-tune a second number.
+
+    See :data:`FRESHNESS_SAFETY_MULTIPLE` for why it is a multiple of the hot
+    cadence and not the cadence itself, and why the hot cadence rather than the
+    tail one is the writer that governs.
+    """
+    return max(
+        FRESHNESS_SAFETY_MULTIPLE * va_archiver.recorder_cadence_sec,
+        FRESHNESS_FLOOR_SEC,
+    )
+
+
+def freshness_check_override(va_archiver: VAArchiverConfig | None) -> dict[str, Any]:
+    """The ``health:`` entry the block contributes, when it names a canary.
+
+    Scoped to the block's presence on purpose, and that scope is what makes it
+    right on both sides of the control-system flip. A deployment carrying the
+    block has a store and a recorder, so there is something to be fresh about:
+    on a virtual accelerator the recorder is writing and the check reports
+    ``ok``; on a mock control system the recorder idles by design, the newest
+    sample is the seeded tail, and the check reports staleness — as a
+    ``warning``, because that is the only severity the probe gives staleness.
+    Both are honest answers to "is this archive still being written". A
+    storeless project has no block, derives no check, and claims nothing.
+
+    Returns:
+        The single dotted config key, or empty when there is no block or it
+        names no canary channel.
+    """
+    if va_archiver is None or not va_archiver.freshness_channel:
+        return {}
+    return {
+        FRESHNESS_CONFIG_KEY: [
+            {
+                "name": FRESHNESS_CHECK_NAME,
+                "type": FRESHNESS_CHECK_NAME,
+                "channel": va_archiver.freshness_channel,
+                "max_age_s": freshness_max_age_s(va_archiver),
+            }
+        ]
+    }
+
+
+def config_derived_key_spellings(config: Any) -> list[str]:
+    """How a ``config:`` block spells the keys this block derives, if it does.
+
+    Several spellings reach the same rendered leaves and all are legal YAML: the
+    dotted key, a mapping under the dotted prefix, and — for the connector's
+    keys — a fully nested ``archiver:`` subtree. A duplicate hiding in any of
+    them would defeat the point of looking, so all are checked.
+
+    Returns:
+        The offending ``config:`` keys as written, in a stable order; empty when
+        the block spells none of them.
+    """
+    if not isinstance(config, dict):
+        return []
+
+    found: list[str] = []
+    for prefix in (CONNECTION_CONFIG_PREFIX, KNOBS_CONFIG_PREFIX):
+        found.extend(key for key in config if isinstance(key, str) and key.startswith(f"{prefix}."))
+        subtree = config.get(prefix)
+        if isinstance(subtree, dict):
+            found.extend(f"{prefix}: {leaf}" for leaf in subtree)
+
+    archiver = config.get("archiver")
+    if isinstance(archiver, dict):
+        nested = archiver.get("mongodb_archiver")
+        if isinstance(nested, dict):
+            found.extend(f"archiver: mongodb_archiver: {leaf}" for leaf in nested)
+
+    return sorted(found)
+
+
+def _duplicate_derived_key_errors(config: Any) -> list[str]:
+    """Refuse a profile that states the archive's coordinates in both homes.
+
+    The build derives these keys from this block, so a ``config:`` entry saying
+    the same thing is not an override — it is a second home for one fact, free
+    to disagree with the first. Disagreement is the dangerous case: a stale
+    ``host`` or ``collection`` there points the agent at an archive nothing is
+    writing, and it reads as empty rather than as broken.
+    """
+    spellings = config_derived_key_spellings(config)
+    if not spellings:
+        return []
+    return [
+        f"'{spelling}' is set in the profile's `config:` block while a "
+        f"`va_archiver:` block is present — one fact, two homes, free to "
+        f"disagree. The va_archiver block is the home: the build writes both "
+        f"`{CONNECTION_CONFIG_PREFIX}.*` and `{KNOBS_CONFIG_PREFIX}.*` from it. "
+        f"Delete the `config:` entry and set the matching va_archiver key instead."
+        for spelling in spellings
+    ]
+
+
+def _expand_dotted(config: Any) -> dict[str, Any]:
+    """The nested tree a ``config:`` block addresses, dotted keys folded in.
+
+    Built the way the renderer builds it — every dotted key is a path to a leaf,
+    and a nested mapping addresses the same leaves — so a lookup here answers
+    "does this config reach that key", whichever of the legal spellings was
+    used. Order-independent by construction: it records only *whether* a path is
+    addressed, never which spelling would win, because which one wins is
+    decided at render time by key order and is exactly what must not be relied
+    on.
+    """
+    tree: dict[str, Any] = {}
+    if not isinstance(config, dict):
+        return tree
+    for key, value in config.items():
+        if not isinstance(key, str):
+            continue
+        node = tree
+        parts = key.split(".")
+        for part in parts[:-1]:
+            child = node.get(part)
+            if not isinstance(child, dict):
+                child = {}
+                node[part] = child
+            node = child
+        leaf = parts[-1]
+        if isinstance(value, dict):
+            existing = node.get(leaf)
+            merged = existing if isinstance(existing, dict) else {}
+            node[leaf] = {**merged, **_expand_dotted(value)}
+        else:
+            node.setdefault(leaf, value)
+    return tree
+
+
+def _addresses_freshness_category(config: Any) -> bool:
+    """Whether a ``config:`` block reaches the health category the block derives."""
+    node: Any = _expand_dotted(config)
+    for part in ("health", "categories", FRESHNESS_CATEGORY):
+        if not isinstance(node, dict) or part not in node:
+            return False
+        node = node[part]
+    return True
+
+
+def _duplicate_freshness_check_errors(config: Any, cfg: VAArchiverConfig) -> list[str]:
+    """Refuse a profile that declares the freshness check the block derives.
+
+    Same rule as the connection keys above, for the same reason: the build
+    writes this category from ``freshness_channel`` and the recorder's cadence,
+    so a ``config:`` block writing it too is a second home for one fact. This
+    one is worse than most if left alone — the two would be merged by whichever
+    key the renderer happens to reach last, so the deployment's staleness
+    threshold would depend on the order two unrelated lines were typed in.
+
+    Refused rather than merged or silently overridden: a facility that wants a
+    different threshold has a knob for the number it is really changing
+    (``recorder_cadence_sec``), and one that wants a different *check* should
+    say so by dropping ``freshness_channel`` and declaring the category itself.
+    """
+    if not cfg.freshness_channel or not _addresses_freshness_category(config):
+        return []
+    return [
+        f"the profile's `config:` block declares `health.categories."
+        f"{FRESHNESS_CATEGORY}` while `va_archiver.freshness_channel` is set — the "
+        f"build derives that category from the block (the canary channel, and a "
+        f"staleness threshold from `recorder_cadence_sec`), so the two would be one "
+        f"fact in two homes, merged in whichever order the keys happen to be read. "
+        f"Drop the `config:` entry to keep the derived check, or drop "
+        f"`va_archiver.freshness_channel` to own the category yourself."
+    ]
+
+
+def _reject_unknown_keys(block: dict[str, Any], problems: list[str]) -> None:
+    """Reject anything the block does not define, naming the closest spelling."""
+    unknown = sorted(set(block) - _KNOWN_VA_ARCHIVER_KEYS)
+    if not unknown:
+        return
+    known = sorted(_KNOWN_VA_ARCHIVER_KEYS)
+    for key in unknown:
+        close = difflib.get_close_matches(str(key), known, n=1)
+        suggestion = f" (did you mean '{close[0]}'?)" if close else ""
+        problems.append(
+            f"unknown key '{key}'{suggestion} — valid va_archiver keys are: {', '.join(known)}."
+        )
+
+
+def _parse_int(value: Any, key: str, problems: list[str]) -> int:
+    """Read one integer knob, refusing the bool YAML would otherwise let pass."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        problems.append(f"'{key}' must be an integer (got {value!r}).")
+        return 1
+    return value
+
+
+def _parse_str(value: Any, key: str, problems: list[str]) -> str:
+    """Read one string knob."""
+    if not isinstance(value, str):
+        problems.append(f"'{key}' must be a string (got {type(value).__name__}).")
+        return ""
+    return value

--- a/src/osprey/cli/build_profile_emit.py
+++ b/src/osprey/cli/build_profile_emit.py
@@ -104,9 +104,10 @@ _COMMENTED_TEMPLATE_KEYS: frozenset[str] = frozenset(
         "deploy",  # CI/registry/host coordinates, filled in per facility
         "mcp_servers",  # facility tool servers
         "artifact_server",  # gallery categories + host/port
-        "dispatch",  # the six optional feature blocks
+        "dispatch",  # the seven optional feature blocks
         "bluesky",
         "virtual_accelerator",
+        "va_archiver",
         "bluesky_panels",
         "nextcloud_bridge",
         "gchat_bridge",
@@ -314,6 +315,44 @@ _COMMENTED_TEMPLATES: dict[str, str] = {
 # virtual_accelerator:
 #   port: 5064
 """,
+    "va_archiver": """
+# --- Stored archive ----------------------------------------------------------
+# Where a simulated deployment keeps its history: a MongoDB store the build
+# seeds with a deterministic base series, a recorder samples the running
+# machine into, and the mongodb_archiver connector reads back. Declaring it
+# makes history stored data rather than values synthesized at read time.
+#
+# Every knob below travels into the rendered config.yml, so retention and
+# cadence are profile edits rather than code changes. The connector's own
+# connection keys are DERIVED from this block — do not also write
+# archiver.mongodb_archiver.* under `config:`, which would be the same fact
+# twice. Selecting the archiver stays a separate decision: set
+# `archiver.type: mongodb_archiver` in `config:` to read from this store.
+#
+# The password is never written here: `osprey deploy up` mints it into the
+# deployment's .env under the name password_env gives.
+#
+# An attached project (deploy_services: false) deploys no store of its own and
+# must set `host` to the machine whose archive it reads.
+#
+# va_archiver:
+#   retention_days: 30          # how far back history reaches
+#   hot_span_hours: 48          # recent window kept at the dense cadence
+#   hot_cadence_sec: 10         # seconds between samples inside it
+#   tail_cadence_sec: 60        # ...and outside it (a multiple of the above)
+#   recorder_cadence_sec: 10    # how often the live machine is sampled
+#   recorder_tail_cadence_sec: 60
+#   recorder_poll_sec: 30       # how often the recorder re-reads config.yml
+#   port_host: 27017
+#   database: osprey_archiver
+#   collection: pv_history
+#   compression: zstd           # zstd | snappy | zlib | none
+#   username: osprey
+#   auth_database: admin
+#   password_env: MONGO_ROOT_PASSWORD
+#   timeout_sec: 5
+#   host: archive.example.org   # only for an attached project
+""",
     "bluesky_panels": """
 # --- Bluesky web panels ------------------------------------------------------
 # Scan-monitoring panels for the web terminal (requires the bluesky block).
@@ -382,6 +421,7 @@ _COMMENTED_TEMPLATE_ORDER: tuple[str, ...] = (
     "dispatch",
     "bluesky",
     "virtual_accelerator",
+    "va_archiver",
     "bluesky_panels",
     "nextcloud_bridge",
     "gchat_bridge",

--- a/src/osprey/cli/build_profile_load.py
+++ b/src/osprey/cli/build_profile_load.py
@@ -21,6 +21,7 @@ from typing import Any
 from osprey.connectors.types import CLI_CONTROL_SYSTEM_TYPES
 from osprey.errors import BuildProfileError
 
+from .build_profile_archiver import parse_va_archiver_block
 from .build_profile_deploy import parse_deploy_block
 from .build_profile_document import _normalize_profile_aliases, _read_profile_document
 from .build_profile_merge import resolve_profile_document
@@ -126,7 +127,7 @@ def load_profile_document(path: Path) -> LoadedProfile:
 # needs, and a dynamic stamp would let the emitting release satisfy its own
 # gate while silently ignoring the keys it just wrote. Pinned by test — bump it
 # only when a release adds profile keys older releases cannot honor.
-_PROFILE_SCHEMA_MIN_OSPREY = "2026.8.0"
+_PROFILE_SCHEMA_MIN_OSPREY = "2026.9.0"
 
 
 # Top-level keys recognized by BuildProfile. Anything else is almost certainly
@@ -181,6 +182,7 @@ _KNOWN_PROFILE_KEYS = frozenset(
         "bluesky_panels",
         "nextcloud_bridge",
         "gchat_bridge",
+        "va_archiver",
         "provenance",
     }
 )
@@ -602,5 +604,6 @@ def _parse_profile(raw: dict[str, Any]) -> BuildProfile:
         bluesky_panels=bluesky_panels,
         nextcloud_bridge=nextcloud_bridge,
         gchat_bridge=gchat_bridge,
+        va_archiver=parse_va_archiver_block(raw),
         provenance=provenance,
     )

--- a/src/osprey/cli/build_profile_model.py
+++ b/src/osprey/cli/build_profile_model.py
@@ -1,6 +1,6 @@
 """The ``BuildProfile`` dataclass — the parsed shape of a profile and its validator.
 
-Holds the 34 profile fields, the paradigm-aware tier default, and the
+Holds the 37 profile fields, the paradigm-aware tier default, and the
 consistency checks a profile must pass before a build touches disk. Kept
 separate from the YAML loader so the shape and its rules can be imported (and
 constructed in tests) without pulling in preset resolution or ``extends``
@@ -25,6 +25,11 @@ from osprey.build.build_tiers import (
 from osprey.errors import BuildProfileError
 from osprey.profiles.web_panels import BUILTIN_PANELS
 
+from .build_profile_archiver import (
+    VAArchiverConfig,
+    va_archiver_errors,
+    va_mock_archiver_errors,
+)
 from .build_profile_deploy import DeployConfig
 from .build_profile_presets import _triggers_dir
 from .build_profile_schema import (
@@ -156,6 +161,16 @@ class BuildProfile:
     bluesky_panels: BlueskyPanelsConfig | None = None
     nextcloud_bridge: NextcloudBridgeProfileConfig | None = None
     gchat_bridge: GChatBridgeProfileConfig | None = None
+    va_archiver: VAArchiverConfig | None = None
+    """The stored archive a simulated deployment keeps its history in
+    (``va_archiver:``).
+
+    ``None`` for a profile that declares none — history then comes from
+    whatever archiver ``config:`` selects, including the synthesizing mock. When
+    present, the block carries every knob the store's shape depends on and the
+    build derives the connector's connection keys from it (see
+    :mod:`osprey.cli.build_profile_archiver`).
+    """
     provenance: ProfileProvenance | None = None
     """What ``osprey profile new`` materialized this profile from (``provenance:``).
 
@@ -683,6 +698,17 @@ class BuildProfile:
             sp = self.bluesky_panels
             if not (1 <= sp.port <= 65535):
                 errors.append(f"bluesky_panels.port must be in 1..65535 (got {sp.port})")
+
+        # Validate the archiver store's knobs, and its agreement with the rest
+        # of the profile — see va_archiver_errors for why the rules live beside
+        # the block but are reported from here.
+        errors.extend(va_archiver_errors(self.va_archiver, self.config, bool(self.deploy_services)))
+
+        # The honesty rule's build-time site: a simulated machine may not be
+        # paired with an archiver that invents its history. Checked against the
+        # resolved `config:` rather than the block, because a profile can reach
+        # the pairing by declaring no block at all — which is the common way in.
+        errors.extend(va_mock_archiver_errors(self.config))
 
         # Validate the chat bridges — same checks per channel, see _validate_chat_bridge.
         if self.nextcloud_bridge is not None:

--- a/src/osprey/cli/config_cmd.py
+++ b/src/osprey/cli/config_cmd.py
@@ -302,6 +302,72 @@ def export(output: str, format: str):
         raise click.Abort() from None
 
 
+def _refuse_invented_history(config_path: Path, control_type: str) -> None:
+    """Refuse a switch that would leave a simulated machine a mock past.
+
+    This command changes one key, so the config it would produce is this file
+    with ``control_system.type`` replaced — and that projection is what gets
+    judged, by the same function the deploy and the MCP server judge a rendered
+    config with. Asking the question before the write rather than after is the
+    whole point: the pairing they refuse is one this command can *create*, by
+    switching a project onto a simulated machine while its archiver stays the
+    one that invents history.
+
+    Only the virtual accelerator is affected. Switching to EPICS or mock is
+    never this problem — a mock machine with a mock archive claims nothing, and
+    a real machine with no archive attached yet is a real facility's real state.
+
+    Refuses rather than prompting for an archiver: this command is
+    non-interactive and runs in scripts, where a prompt has nobody to answer it.
+    The interactive menu is where an archiver gets chosen, and the message says
+    so.
+
+    Args:
+        config_path: The project's ``config.yml``.
+        control_type: The type about to be written, already lower-cased.
+
+    Raises:
+        click.Abort: If the resulting config would pair a virtual accelerator
+            with an archiver that synthesizes its history — an unset
+            ``archiver.type`` included.
+    """
+    from osprey.connectors.honesty import VA_MOCK_ARCHIVER_WHY, pairing_in_rendered_config
+    from osprey.connectors.types import MOCK, MONGODB_ARCHIVER, VIRTUAL_ACCELERATOR
+    from osprey.utils.config_writer import config_read
+
+    if control_type != VIRTUAL_ACCELERATOR:
+        return
+
+    projected = config_read(config_path)
+    control_system = projected.get("control_system")
+    if not isinstance(control_system, dict):
+        control_system = {}
+        projected["control_system"] = control_system
+    control_system["type"] = control_type
+
+    pairing = pairing_in_rendered_config(projected)
+    if not pairing.is_invented_history:
+        return
+
+    console.print(
+        f"❌ Refusing the switch: it would pair control_system.type "
+        f"{VIRTUAL_ACCELERATOR!r} with archiver.type {pairing.archiver_phrase}",
+        style=Styles.ERROR,
+    )
+    console.print(f"\n   {VA_MOCK_ARCHIVER_WHY}", style=Styles.DIM)
+    console.print(
+        f"\n💡 Give the project a real archive first, then switch: under this file's "
+        f"`archiver:` section set `type:` to a connector reading a store this "
+        f"deployment writes — {MONGODB_ARCHIVER!r} for the store a project built "
+        f"from the control-assistant preset deploys, with its connection keys under "
+        f"`archiver: {MONGODB_ARCHIVER}:`. The interactive menu (run `osprey`, then "
+        f"config → set-control-system) writes those keys along with the selection. "
+        f"To keep an honestly storeless project, stay on {MOCK!r}.",
+        style=Styles.DIM,
+    )
+    raise click.Abort()
+
+
 @config.command(name="set-control-system")
 @click.argument(
     "system_type",
@@ -321,6 +387,10 @@ def set_control_system(system_type: str, project: str):
 
     Note: Pattern detection is control-system-agnostic (same for all types).
     This setting only affects which connector is loaded at runtime.
+
+    Note: Switching to virtual_accelerator is refused while the project still
+    reads the mock archiver, which invents history rather than storing it. Point
+    archiver.type at a real store first.
 
     Requires: Must be run from a project directory containing config.yml
 
@@ -363,6 +433,8 @@ def set_control_system(system_type: str, project: str):
             )
             raise click.Abort() from None
 
+        _refuse_invented_history(config_path, system_type.lower())
+
         new_content, preview = set_control_system_type(config_path, system_type.lower())
         # Use UTF-8 encoding explicitly to support Unicode characters on Windows
         config_path.write_text(new_content, encoding="utf-8")
@@ -371,6 +443,11 @@ def set_control_system(system_type: str, project: str):
         console.print(f"   Configuration: {config_path}", style=Styles.DIM)
         _regen_claude_artifacts(config_path.parent)
 
+    except click.Abort:
+        # The aborts above have already said what went wrong and how to fix it;
+        # letting them fall into the handler below would append a second,
+        # emptier error line to a message that was complete.
+        raise
     except Exception as e:
         console.print(f"❌ Failed to update control system: {e}", style=Styles.ERROR)
         raise click.Abort() from None

--- a/src/osprey/cli/deploy_cmd.py
+++ b/src/osprey/cli/deploy_cmd.py
@@ -66,6 +66,11 @@ _expose_option = click.option(
     is_flag=True,
     help="Expose services to all network interfaces (0.0.0.0). WARNING: This exposes services to the network! Only use with proper authentication configured.",
 )
+_keep_archiver_base_option = click.option(
+    "--keep-archiver-base",
+    is_flag=True,
+    help="Keep the existing archiver history even when the profile's retention/cadence knobs no longer match it. Without this, changed knobs rebuild the base series and discard recorded samples.",
+)
 _archive_option = click.option(
     "--archive",
     is_flag=True,
@@ -254,10 +259,24 @@ def deploy() -> None:
 @_detached_option
 @_dev_option
 @_expose_option
-def up(project: str | None, config: str, detached: bool, dev: bool, expose: bool) -> None:
+@_keep_archiver_base_option
+def up(
+    project: str | None,
+    config: str,
+    detached: bool,
+    dev: bool,
+    expose: bool,
+    keep_archiver_base: bool,
+) -> None:
     """Start all configured services."""
     with _deploy_session(project, config) as config_path:
-        deploy_up(config_path, detached=detached, dev_mode=dev, expose_network=expose)
+        deploy_up(
+            config_path,
+            detached=detached,
+            dev_mode=dev,
+            expose_network=expose,
+            keep_archiver_base=keep_archiver_base,
+        )
 
 
 @deploy.command()

--- a/src/osprey/cli/project_actions.py
+++ b/src/osprey/cli/project_actions.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 from importlib.util import find_spec
 from pathlib import Path
+from typing import Any
 
 from osprey.cli.styles import (
     Messages,
@@ -17,6 +18,7 @@ from osprey.cli.styles import (
     get_questionary_style,
 )
 from osprey.connectors import types
+from osprey.connectors.honesty import VA_MOCK_ARCHIVER_WHY
 
 try:
     import questionary
@@ -41,23 +43,70 @@ def mongodb_archiver_available() -> bool:
     return find_spec("pymongo") is not None
 
 
-def build_archiver_choices() -> list:
-    """Build the wizard's archiver choices, gating MongoDB on its extra.
+def build_archiver_choices(control_type: str | None = None) -> list:
+    """Build the wizard's archiver choices for *control_type*.
 
     MongoDB stays visible when the extra is missing but is disabled and
     annotated with the install command, so the wizard cannot write an
     ``archiver.type`` the installed environment can't construct.
+
+    The mock archiver is offered for every control system except the virtual
+    accelerator. That one pairing is refused by the build, by the deploy and by
+    the MCP server alike (see :mod:`osprey.connectors.honesty`), so listing it
+    here would only be a trap: an option that writes a config nothing will run.
+    EPICS keeps it — a facility mid-migration legitimately reads a real machine
+    with no archive attached yet.
     """
     mongodb_available = mongodb_archiver_available()
-    return [
+    choices = [
         Choice("EPICS Archiver Appliance", value=types.EPICS_ARCHIVER),
         Choice(
             "MongoDB",
             value=types.MONGODB_ARCHIVER,
             disabled=None if mongodb_available else MONGODB_UNAVAILABLE_HINT,
         ),
-        Choice("Mock archiver (keep)", value=types.MOCK_ARCHIVER),
     ]
+    if control_type != types.VIRTUAL_ACCELERATOR:
+        choices.append(Choice("Mock archiver (keep)", value=types.MOCK_ARCHIVER))
+    return choices
+
+
+def _is_invented_history(archiver_type: str | None) -> bool:
+    """Whether *archiver_type* selects the archiver that synthesizes its answers.
+
+    Resolved through the connector factory's own resolver rather than compared
+    by name, so a blank or unset selection counts as the mock here exactly as it
+    does at the three sites that refuse it.
+    """
+    return types.resolve_archiver_type({"type": archiver_type}) == types.MOCK_ARCHIVER
+
+
+def mongodb_archiver_settings() -> dict[str, Any]:
+    """The connection keys a MongoDB archiver selection has to write with it.
+
+    Selecting the archiver *type* alone leaves a config the connector refuses
+    to build — host, database, collection, credentials and timeout are all
+    required and none of them default. The values come from the same block the
+    build derives them from (``va_archiver:``), so a store the wizard points at
+    and a store the build deploys are described identically rather than by two
+    hand-maintained copies free to disagree.
+
+    Returns:
+        Dotted ``archiver.mongodb_archiver.*`` keys, ready for
+        :func:`~osprey.utils.config_writer.set_control_system_type`.
+    """
+    from osprey.cli.build_profile_archiver import (
+        CONNECTION_CONFIG_PREFIX,
+        VAArchiverConfig,
+        va_archiver_config_overrides,
+    )
+
+    overrides = va_archiver_config_overrides(VAArchiverConfig())
+    return {
+        key: value
+        for key, value in overrides.items()
+        if key.startswith(f"{CONNECTION_CONFIG_PREFIX}.")
+    }
 
 
 def handle_project_selection(project_path: Path):
@@ -549,9 +598,30 @@ def handle_set_control_system(project_path: Path | None = None) -> None:
             console.print(f"[dim]MongoDB archiver unavailable — {MONGODB_UNAVAILABLE_HINT}[/dim]\n")
         archiver_type = questionary.select(
             "Which archiver?",
-            choices=build_archiver_choices(),
+            choices=build_archiver_choices(control_type),
             style=custom_style,
         ).ask()
+        if archiver_type is None:
+            # Backing out of the archiver prompt leaves the control system
+            # alone too: writing half the pair is how a project acquires a
+            # combination nobody chose.
+            console.print(f"\n{Messages.warning('No archiver selected — nothing changed')}")
+            input("\nPress ENTER to continue...")
+            return
+        if control_type == types.VIRTUAL_ACCELERATOR and _is_invented_history(archiver_type):
+            # The choice list does not offer this pairing; this refuses it for
+            # the paths that do not go through the list, so the wizard cannot
+            # author what the build, the deploy and the MCP server all refuse.
+            console.print(
+                f"\n{Messages.error('Refusing to write a simulated machine a mock past')}"
+            )
+            console.print(f"\n[dim]{VA_MOCK_ARCHIVER_WHY}[/dim]")
+            console.print(
+                "\n[dim]Select the MongoDB archiver — 'osprey deploy up' stands the store "
+                "up beside the accelerator — or keep the current control system.[/dim]"
+            )
+            input("\nPress ENTER to continue...")
+            return
     elif control_type == types.DOOCS:
         # The DOOCS archiver reads DOOCS local histories, so it is the only
         # archiver that pairs with a DOOCS control system. Offering the
@@ -561,8 +631,15 @@ def handle_set_control_system(project_path: Path | None = None) -> None:
     else:
         archiver_type = types.MOCK_ARCHIVER
 
-    # Update configuration
-    new_content, preview = set_control_system_type(config_path, control_type, archiver_type)
+    # Update configuration. Selecting MongoDB writes the connection block with
+    # it: the connector requires every one of those keys, so a config carrying
+    # only the type is one the archiver refuses to build.
+    archiver_settings = (
+        mongodb_archiver_settings() if archiver_type == types.MONGODB_ARCHIVER else None
+    )
+    new_content, preview = set_control_system_type(
+        config_path, control_type, archiver_type, archiver_settings=archiver_settings
+    )
 
     # Show preview
     console.print("\n" + preview)

--- a/src/osprey/cli/sim.py
+++ b/src/osprey/cli/sim.py
@@ -103,6 +103,29 @@ def _echo_physics_notice(config: dict, rendered: dict[str, str]) -> None:
     click.echo("  the old environment.")
 
 
+def _confirm_archive_rewrite(store: dict) -> None:
+    """Warn before overwriting stored history, and let the user back out.
+
+    The archive is *stored data*, and the rewrite is not additive: windows a
+    previous scenario marked go back to base, and on a virtual-accelerator
+    deployment the affected windows may hold samples a recorder took from the
+    running machine. That is the documented behaviour — one timeline, and the
+    active scenario owns its event windows — but it is not something to do to
+    someone's data without saying so first.
+
+    The caller passes the store the preflight already resolved, and skips this
+    entirely when the project has none: there is nothing to lose and nothing to
+    decide, and a prompt about a store that does not exist trains people to hit
+    enter.
+    """
+    click.echo(
+        f"This will REWRITE the scenario's event windows in the stored archive "
+        f"({store['host']}:{store['port']}/{store['database']}.{store['collection']}), "
+        f"restoring any windows a previous scenario touched."
+    )
+    click.confirm("Continue?", abort=True)
+
+
 # ---------------------------------------------------------------------------
 # Group
 # ---------------------------------------------------------------------------
@@ -148,8 +171,10 @@ def status_command() -> None:
 
 @sim_group.command("apply")
 @click.argument("names", nargs=-1, required=True)
-@click.option("--no-seed", is_flag=True, help="Change telemetry only; do not touch the logbook DB.")
-@click.option("--yes", "-y", is_flag=True, help="Skip the purge confirmation prompt.")
+@click.option("--no-seed", is_flag=True, help="Change telemetry only; touch no stored data.")
+@click.option("--no-seed-logbook", is_flag=True, help="Leave the logbook database untouched.")
+@click.option("--no-seed-archiver", is_flag=True, help="Leave the stored archive untouched.")
+@click.option("--yes", "-y", is_flag=True, help="Skip the confirmation prompts.")
 @click.option(
     "--now",
     "now_iso",
@@ -163,23 +188,37 @@ def status_command() -> None:
         "Falls back to the OSPREY_SIM_NOW environment variable."
     ),
 )
-def apply_command(names: tuple[str, ...], no_seed: bool, yes: bool, now_iso: str | None) -> None:
-    """Compose and activate scenarios NAMES, seeding their logbook (unless --no-seed).
+def apply_command(
+    names: tuple[str, ...],
+    no_seed: bool,
+    no_seed_logbook: bool,
+    no_seed_archiver: bool,
+    yes: bool,
+    now_iso: str | None,
+) -> None:
+    """Activate scenarios NAMES and seed their stored data.
 
     Active scenarios must touch disjoint channel sets. Seeding purges and
-    reseeds the ARIEL logbook so the narrative matches the active telemetry.
-    A scenario's ``physics`` block is rendered into the project ``.env`` for the
+    reseeds the ARIEL logbook, and rewrites the affected windows of the stored
+    archive, so the narrative and the history both match the active telemetry.
+    Use --no-seed-logbook or --no-seed-archiver to leave one of them alone, or
+    --no-seed for both.
+
+    A scenario's physics block is rendered into the project .env for the
     virtual accelerator to pick up at its next container boot.
     """
     from osprey.simulation.apply import (
         apply_scenarios,
         compute_scenario_physics_env,
+        preflight_archive_rewrite,
         resolve_simulation_file,
         write_scenario_physics_env,
     )
     from osprey.simulation.engine import resolve_active_scenarios
 
     now = _parse_now(now_iso) if now_iso else None
+    seed_logbook = not (no_seed or no_seed_logbook)
+    seed_archive = not (no_seed or no_seed_archiver)
     project_dir = Path.cwd()
     config = load_config(str(project_dir / "config.yml"))
     ariel_config = config.get("ariel")
@@ -192,6 +231,7 @@ def apply_command(names: tuple[str, ...], no_seed: bool, yes: bool, now_iso: str
     # "not simulation-backed" error for it, which the handler turns into exit 1.
     machine_path, *_ = resolve_simulation_file(config, project_dir)
     physics: dict[str, str] | None = None
+    store: dict | None = None
     if machine_path is not None:
         from osprey.simulation.engine import SimulationEngine, resolve_state_dir
 
@@ -210,7 +250,19 @@ def apply_command(names: tuple[str, ...], no_seed: bool, yes: bool, now_iso: str
             click.echo(f"Error: {exc}", err=True)
             raise SystemExit(1) from None
 
-    if not no_seed and not yes and ariel_config:
+        # The archive rewrite's own refusals belong here too, not inside it: a
+        # store whose password the project's .env does not carry, or an event
+        # positioned by window fraction, would otherwise be discovered after
+        # the scenario is live and the logbook reseeded -- leaving telemetry
+        # and narrative saying one thing and the untouched history another.
+        if seed_archive:
+            try:
+                store = preflight_archive_rewrite(project_dir, config, machine_path, list(names))
+            except (ValueError, RuntimeError) as exc:
+                click.echo(f"Error: {exc}", err=True)
+                raise SystemExit(1) from None
+
+    if seed_logbook and not yes and ariel_config:
         from osprey.services.ariel_search.cli_operations import get_purge_info
 
         try:
@@ -225,6 +277,9 @@ def apply_command(names: tuple[str, ...], no_seed: bool, yes: bool, now_iso: str
             )
             click.confirm("Continue?", abort=True)
 
+    if seed_archive and not yes and store is not None:
+        _confirm_archive_rewrite(store)
+
     # Past the last abort point: write the physics vars, then say so immediately.
     # Emitting the notice here rather than after apply_scenarios means a failed
     # logbook seed can never swallow it.
@@ -232,8 +287,17 @@ def apply_command(names: tuple[str, ...], no_seed: bool, yes: bool, now_iso: str
         _echo_physics_notice(config, physics)
 
     try:
-        result = apply_scenarios(project_dir, list(names), seed_logbook=not no_seed, now=now)
+        result = apply_scenarios(
+            project_dir,
+            list(names),
+            seed_logbook=seed_logbook,
+            seed_archive=seed_archive,
+            now=now,
+        )
     except ValueError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        raise SystemExit(1) from None
+    except RuntimeError as exc:
         click.echo(f"Error: {exc}", err=True)
         raise SystemExit(1) from None
     except Exception as exc:
@@ -245,9 +309,16 @@ def apply_command(names: tuple[str, ...], no_seed: bool, yes: bool, now_iso: str
         raise
 
     click.echo("✓ Active scenarios: " + ", ".join(result.active))
-    if no_seed:
-        click.echo("  (telemetry only — logbook unchanged)")
+    if not seed_logbook:
+        click.echo("  (logbook unchanged)")
     elif result.logbook_seeded:
         click.echo(f"✓ Seeded {result.logbook_seeded} logbook entries (purged and reseeded).")
     elif ariel_config is None:
         click.echo("  (no ARIEL config — logbook not seeded)")
+
+    if not seed_archive:
+        click.echo("  (stored archive unchanged)")
+    elif result.archiver is not None and not result.archiver.skipped:
+        click.echo(f"✓ Archive rewritten: {result.archiver.describe()}")
+    elif result.archiver is not None:
+        click.echo(f"  ({result.archiver.skipped})")

--- a/src/osprey/connectors/archiver/mock_archiver_connector.py
+++ b/src/osprey/connectors/archiver/mock_archiver_connector.py
@@ -6,12 +6,10 @@ Ideal for R&D and development without archiver access.
 
 """
 
-import zlib
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import numpy as np
 import pandas as pd
 
 from osprey.connectors.archiver._timerange import (
@@ -20,8 +18,9 @@ from osprey.connectors.archiver._timerange import (
     utc_window,
 )
 from osprey.connectors.archiver.base import ArchiverConnector, ArchiverMetadata
-from osprey.connectors.pv_taxonomy import classify_pv
 from osprey.simulation import engine_serves
+from osprey.simulation.procedural import generate_series
+from osprey.simulation.series import epoch_seconds_array
 from osprey.utils.config import get_facility_timezone
 from osprey.utils.logger import get_logger
 
@@ -106,7 +105,9 @@ class MockArchiverConnector(ArchiverConnector):
 
     Features:
     - Accepts any PV names
-    - Generates realistic time series with trends and noise
+    - Generates realistic time series with texture and noise
+    - Values are a pure function of (channel, absolute timestamp), so two
+      overlapping windows agree on every timestamp they share
     - Configurable sampling rate and noise level
     - Returns pandas DataFrames matching real archiver format
 
@@ -139,9 +140,11 @@ class MockArchiverConnector(ArchiverConnector):
                 - simulation_file: Optional path to a machine.json driving the
                   data-driven simulation engine (relative paths resolve against
                   the project root). Engine-known channels are synthesized from
-                  the machine model; without it, every channel uses the generic
-                  PV-type procedural synthesizer. Unset, it is derived from the
-                  control system's own ``simulation_file`` so live reads and
+                  the machine model; without it, every channel goes through the
+                  shared procedural generator
+                  (:mod:`osprey.simulation.procedural`), whose baselines are the
+                  ones the Virtual Accelerator serves. Unset, it is derived from
+                  the control system's own ``simulation_file`` so live reads and
                   archived history come from one machine model.
         """
         # A zero or negative rate would divide by zero later; reject it at
@@ -215,15 +218,24 @@ class MockArchiverConnector(ArchiverConnector):
         index = pd.date_range(start=start_date, end=end_date, periods=num_points)
 
         # Generate data for each PV. Channels known to the simulation engine
-        # are synthesized from the machine model; everything else uses the
-        # generic procedural generation.
+        # are synthesized from the machine model; everything else goes through
+        # the shared procedural generator, evaluated at this grid's absolute
+        # timestamps — the same values a store seeded from it holds.
+        t_abs = epoch_seconds_array(index)
+        if t_abs is None:  # pragma: no cover - the index above is always datetimes
+            # Refusing beats the alternative the engine can afford: it falls
+            # back to sample-index counters, which is deterministic per window
+            # but not per timestamp — and history that disagrees with a store
+            # seeded from the same generator is the failure this path replaced.
+            raise ValueError(f"Cannot derive epoch seconds for the {start_date} to {end_date} grid")
+
         resolved = resolve_processing(processing, precision_ms)
         series = {}
         for pv in pv_list:
             if engine_serves(self._sim_engine, pv):
                 values = self._sim_engine.synthesize_series(pv, index)
             else:
-                values = self._generate_time_series(pv, num_points)
+                values = generate_series(pv, t_abs, noise_level=self._noise_level)
             series[pv] = pd.Series(values, index=index, name=pv)
 
         data = aggregate_long_frame(series, resolved)
@@ -252,87 +264,3 @@ class MockArchiverConnector(ArchiverConnector):
     async def check_availability(self, pv_names: list[str]) -> dict[str, bool]:
         """All PVs are available in mock archiver."""
         return dict.fromkeys(pv_names, True)
-
-    def _generate_time_series(
-        self,
-        pv_name: str,
-        num_points: int,
-    ) -> np.ndarray:
-        """
-        Generate generic synthetic time series with trends and noise.
-
-        Used for PVs that are not known to the data-driven simulation engine
-        (e.g. projects without a machine file). Creates realistic-looking data
-        with:
-        - Sinusoidal variations
-        - Linear trends
-        - Random noise
-        - PV-type-specific characteristics (current/voltage/power/pressure/
-          temperature/lifetime/default)
-        - BPMs use random offsets with slow oscillations
-
-        Scenario-specific physics (vacuum bursts, RF thermal excursions, etc.)
-        is supplied by the simulation engine, not this generic generator.
-        """
-        t = np.linspace(0, 1, num_points)
-        pv_lower = pv_name.lower()
-        # crc32, not hash(): str hashing is salted per process, which would
-        # break cross-process reproducibility.
-        rng = np.random.default_rng(seed=zlib.crc32(pv_name.encode()))
-
-        # BPM channels — reproducible random offsets with slow oscillations
-        if "position" in pv_lower or "pos" in pv_lower or "bpm" in pv_lower:
-            base = 0.0
-            offset_range = 0.1  # ±100 µm equilibrium position
-            perturbation_amp = 0.01  # ±10 µm oscillation
-            trend = np.ones(num_points) * base
-
-            offset = rng.uniform(-offset_range, offset_range)
-            phase = rng.uniform(0, 2 * np.pi)
-            frequency = rng.uniform(0.01, 0.5)
-
-            wave = perturbation_amp * np.sin(2 * np.pi * t * frequency + phase)
-
-            noise_amplitude = perturbation_amp * self._noise_level
-            noise = rng.normal(0, noise_amplitude, num_points)
-
-            return trend + offset + wave + noise
-
-        # Shape a trend + wave per PV kind. Classification (name -> kind/base)
-        # is shared with the control-system mock via classify_pv; the synthesis
-        # shapes below are archiver-specific.
-        kind = classify_pv(pv_name)
-        base = kind.base_value
-        if kind.name == "beam_current":
-            # Ten sawtooth refill cycles across the window: current decays 5%
-            # over each cycle, then jumps back to base.
-            period = num_points // 10
-            trend = base * (1 - 0.05 * (np.arange(num_points) % period) / period)
-            wave = 5 * np.sin(2 * np.pi * t * 5)
-        elif kind.name == "current":
-            trend = base + 10 * t
-            wave = 10 * np.sin(2 * np.pi * t * 3)
-        elif kind.name == "voltage":
-            trend = np.ones(num_points) * base
-            wave = 50 * np.sin(2 * np.pi * t * 2)
-        elif kind.name == "power":
-            trend = base + 5 * t
-            wave = 5 * np.sin(2 * np.pi * t * 4)
-        elif kind.name == "pressure":
-            trend = base * (1 + 0.1 * t)
-            wave = base * 0.05 * np.sin(2 * np.pi * t * 10)
-        elif kind.name == "temperature":
-            trend = base + 2 * t
-            wave = 0.5 * np.sin(2 * np.pi * t * 8)
-        elif kind.name == "lifetime":
-            trend = base - 2 * t
-            wave = 1 * np.sin(2 * np.pi * t * 3)
-        else:
-            trend = base + 20 * t
-            wave = 10 * np.sin(2 * np.pi * t * 2)
-
-        noise_amplitude = abs(base) * self._noise_level
-        # Draw from the seeded per-PV rng, not the unseeded global np.random.
-        noise = rng.normal(0, noise_amplitude, num_points)
-
-        return trend + wave + noise

--- a/src/osprey/connectors/archiver/mongodb_archiver_connector.py
+++ b/src/osprey/connectors/archiver/mongodb_archiver_connector.py
@@ -22,6 +22,70 @@ from osprey.utils.logger import get_logger
 
 logger = get_logger("mongodb_archiver_connector")
 
+# Appended to every connect()-time failure. On an OSPREY-deployed stack the store
+# is a container the project brings up itself, and "built but never deployed" is
+# by far the most common way to reach these errors — the password is minted into
+# the project's .env by `deploy up`, so before that first run there is nothing to
+# authenticate with and nothing listening. Phrased as a likely remedy rather than
+# the only one, since a facility MongoDB may be administered elsewhere.
+DEPLOY_HINT = "If this project deploys its own MongoDB, run 'osprey deploy up' to start it."
+
+# Names the optional dependency the way it is actually installed, so the message
+# works whether or not the reader knows pymongo is what backs this connector.
+PYMONGO_INSTALL_HINT = (
+    "pymongo is required for the MongoDB archiver. "
+    "Install it with: pip install 'osprey-framework[archiver-mongodb]'"
+)
+
+#: Environment overrides for the two connection keys whose configured value is
+#: only correct when read from the host.
+#:
+#: The contract, stated here because this is the module that opens the socket:
+#: **the config block carries the host-side truth** — where the agent, running on
+#: the host, reaches the store, which for a project deploying its own store is
+#: loopback at the published ``port_host``. Inside the compose network that
+#: address names the reading container's own loopback and reaches nothing, so a
+#: containerized consumer is given the store's network alias and container port
+#: through this pair, and **the environment wins**.
+#:
+#: That is the ordinary environment-override contract, not a container special
+#: case: set in a host shell these win there too, exactly as
+#: ``OSPREY_OTEL_OPENOBSERVE_HOST`` does. Compose templates are simply the
+#: caller that has a reason to set them.
+#:
+#: Read by two consumers — this connector and the archiver-recorder service —
+#: through :func:`address_overrides`, so both agree on what an empty value means
+#: and on how the port is typed.
+HOST_OVERRIDE_ENV = "OSPREY_ARCHIVER_MONGODB_HOST"
+PORT_OVERRIDE_ENV = "OSPREY_ARCHIVER_MONGODB_PORT"
+
+
+def address_overrides() -> tuple[str | None, int | None]:
+    """The in-network store address this process was given, if it was given one.
+
+    Returns:
+        ``(host, port)``, either of which is ``None`` when the corresponding
+        variable is unset — or set to whitespace, which is treated as unset
+        rather than as an address of nothing. A caller applies whichever half it
+        got over its own configured value, and keeps its own rules about what to
+        do when neither source supplies one.
+
+    Raises:
+        ValueError: If the port override is set to something that is not an
+            integer. Silently falling back to the configured host-side port
+            would send a container to an address nothing serves, and the reason
+            would be a typo nobody is looking at.
+    """
+    host = os.environ.get(HOST_OVERRIDE_ENV, "").strip() or None
+
+    raw_port = os.environ.get(PORT_OVERRIDE_ENV, "").strip()
+    if not raw_port:
+        return host, None
+    try:
+        return host, int(raw_port)
+    except ValueError as exc:
+        raise ValueError(f"{PORT_OVERRIDE_ENV} must be an integer port (got {raw_port!r})") from exc
+
 
 class MongoDBArchiverConnector(ArchiverConnector):
     """
@@ -50,6 +114,13 @@ class MongoDBArchiverConnector(ArchiverConnector):
         >>> )
     """
 
+    # pymongo exception classes, bound by connect(). Declared here so every
+    # method can reference them on a connector that never completed a connect()
+    # — including the stub connectors tests wire up by hand.
+    _MongoClient = None
+    _ConnectionFailure = None
+    _ConfigurationError = None
+
     def __init__(self):
         self._connected = False
         self._client = None
@@ -73,8 +144,13 @@ class MongoDBArchiverConnector(ArchiverConnector):
 
         Raises:
             ImportError: If pymongo is not installed
-            ValueError: If required config values are missing
-            ConnectionError: If connection cannot be established
+            ValueError: If required config *keys* are missing — an authoring
+                error in config.yml, not a runtime condition
+            ConnectionError: If the store cannot be reached or authenticated
+                against, including when ``password_env`` names a variable that
+                is not set. These are the states a not-yet-deployed project is
+                in, so they carry the deploy hint and reach the agent as a
+                ``connection_error`` rather than an internal error.
         """
         try:
             from pymongo import MongoClient
@@ -88,12 +164,16 @@ class MongoDBArchiverConnector(ArchiverConnector):
             self._ConnectionFailure = ConnectionFailure
             self._ConfigurationError = ConfigurationError
         except ImportError as e:
-            raise ImportError(
-                "pymongo is required for MongoDB archiver. Install with: pip install pymongo"
-            ) from e
+            raise ImportError(PYMONGO_INSTALL_HINT) from e
 
-        # Validate required config
-        host = config.get("host")
+        # Where the store is. The configured value is the host-side truth; a
+        # containerized consumer is handed the in-network address through the
+        # environment and that wins (see HOST_OVERRIDE_ENV). Resolved before the
+        # required-ness check so an environment-only address is a legitimate
+        # one, and the error below still fires when neither source names a host.
+        override_host, override_port = address_overrides()
+
+        host = override_host or config.get("host")
         if not host:
             raise ValueError("host is required for MongoDB archiver")
 
@@ -105,7 +185,7 @@ class MongoDBArchiverConnector(ArchiverConnector):
         if not collection_name:
             raise ValueError("collection is required for MongoDB archiver")
 
-        port = config.get("port", 27017)
+        port = override_port if override_port is not None else config.get("port", 27017)
         self._timeout = config.get("timeout", 60)
 
         # Validate required authentication config
@@ -121,12 +201,16 @@ class MongoDBArchiverConnector(ArchiverConnector):
         if not auth_db:
             raise ValueError("auth (authentication database) is required for MongoDB archiver")
 
-        # Get password from environment variable
+        # Get password from environment variable. An unset variable is a
+        # deployment state, not a config error: `deploy up` mints the password
+        # into the project's .env, so this is what a built-but-never-deployed
+        # project hits. ConnectionError so the agent gets an actionable
+        # connection_error envelope instead of an opaque internal error.
         password = os.getenv(password_env)
         if not password:
-            raise ValueError(
-                f"Environment variable '{password_env}' not set. "
-                "Password is required for MongoDB authentication."
+            raise ConnectionError(
+                f"Environment variable '{password_env}' is not set, so the MongoDB "
+                f"archiver has no password to authenticate with. {DEPLOY_HINT}"
             )
 
         try:
@@ -157,16 +241,16 @@ class MongoDBArchiverConnector(ArchiverConnector):
         except self._ConnectionFailure as e:
             raise ConnectionError(
                 f"Cannot connect to MongoDB at {host}:{port}. "
-                "Please check connectivity and authentication."
+                f"Please check connectivity and authentication. {DEPLOY_HINT}"
             ) from e
         except self._ConfigurationError as e:
             raise ConnectionError(f"MongoDB configuration error: {e}") from e
         except (TimeoutError, OSError) as e:
-            raise ConnectionError(f"MongoDB connection failed: {e}") from e
+            raise ConnectionError(f"MongoDB connection failed: {e}. {DEPLOY_HINT}") from e
         except Exception as e:
             # Last resort - log and re-raise as ConnectionError
             logger.error(f"Unexpected error connecting to MongoDB: {e}", exc_info=True)
-            raise ConnectionError(f"MongoDB connection failed: {e}") from e
+            raise ConnectionError(f"MongoDB connection failed: {e}. {DEPLOY_HINT}") from e
 
     async def disconnect(self) -> None:
         """Cleanup MongoDB connection."""
@@ -184,6 +268,19 @@ class MongoDBArchiverConnector(ArchiverConnector):
         self._collection = None
         self._connected = False
         logger.debug("MongoDB Archiver connector disconnected")
+
+    def _connection_error_types(self) -> tuple[type[BaseException], ...]:
+        """pymongo's connection-class exceptions, as an ``except``-ready tuple.
+
+        ``ConnectionFailure`` is the root of pymongo's network-and-server
+        family — ``AutoReconnect``, ``NetworkTimeout`` and
+        ``ServerSelectionTimeoutError`` all derive from it — so catching it
+        covers every way a live connection can go away mid-session. Returns an
+        empty tuple when ``connect()`` never ran and the classes were never
+        bound; an empty tuple in an ``except`` clause simply never matches,
+        which is the correct behaviour there.
+        """
+        return (self._ConnectionFailure,) if self._ConnectionFailure is not None else ()
 
     def _require_connected(self) -> None:
         """Raise ``RuntimeError`` unless a live collection is available.
@@ -222,7 +319,9 @@ class MongoDBArchiverConnector(ArchiverConnector):
         Raises:
             RuntimeError: If archiver not connected
             TimeoutError: If operation times out
-            ConnectionError: If MongoDB cannot be reached
+            ConnectionError: If MongoDB cannot be reached, or the connection is
+                lost mid-query — the caller is expected to drop this connector
+                and reconnect
             TypeError: If start_date or end_date are not datetime objects
             ValueError: If pv_list is empty, data retrieval fails, or a
                 non-raw processing mode is requested for a channel that
@@ -301,6 +400,13 @@ class MongoDBArchiverConnector(ArchiverConnector):
             raise TimeoutError(f"MongoDB query timed out after {timeout}s") from e
         except ConnectionError as e:
             raise ConnectionError(f"Network connectivity issue with MongoDB: {e}") from e
+        except self._connection_error_types() as e:
+            # A pymongo connection-class failure means the store went away
+            # mid-session. Surfacing it as ConnectionError (rather than the
+            # ValueError the generic branch below would produce) is what makes
+            # connector_error_handler invalidate the cached connector, so the
+            # next tool call reconnects instead of reusing a dead client.
+            raise ConnectionError(f"Lost connection to MongoDB: {e}") from e
         except (ValueError, TypeError) as e:
             raise ValueError(f"Error retrieving data from MongoDB: {e}") from e
         except Exception as e:
@@ -312,36 +418,48 @@ class MongoDBArchiverConnector(ArchiverConnector):
         """
         Get archiving metadata for a PV.
 
-        Note: Basic implementation that checks if PV exists in collection.
-        Could be enhanced with actual metadata queries.
+        ``archival_start`` and ``archival_end`` are the timestamps of the
+        oldest and newest documents actually holding this PV, read from the
+        store — not a declared or assumed coverage window. An agent that asks
+        how far back the history goes gets the real answer, so a query outside
+        the stored range reads as "not archived that far back" rather than as
+        missing data inside a range it was told existed.
 
         Args:
             pv_name: Name of the process variable
 
         Returns:
-            ArchiverMetadata with basic archiving information
+            ArchiverMetadata; ``is_archived`` is False and both bounds are None
+            when the PV has no stored samples or the store cannot be queried.
 
         Raises:
             RuntimeError: If archiver not connected
         """
         self._require_connected()
 
-        def check_pv():
-            """Check if PV exists in any document."""
-            # Query for any document that has this PV field
+        def stored_extent():
+            """Timestamps of the oldest and newest documents carrying this PV."""
+            # Sorting on 'date' rides the mandatory {date: 1} index, so this is
+            # two index-ordered lookups rather than a collection scan.
             query = {pv_name: {"$exists": True}}
-            count = self._collection.count_documents(query, limit=1)
-            return count > 0
+            projection = {"date": 1}
+            oldest = self._collection.find_one(query, projection, sort=[("date", 1)])
+            if oldest is None:
+                return None, None
+            newest = self._collection.find_one(query, projection, sort=[("date", -1)])
+            return oldest.get("date"), (newest or {}).get("date")
 
         try:
-            is_archived = await asyncio.to_thread(check_pv)
+            first, last = await asyncio.to_thread(stored_extent)
         except Exception as e:
             logger.warning(f"Error checking PV metadata: {e}")
-            is_archived = False
+            first = last = None
 
         return ArchiverMetadata(
             pv_name=pv_name,
-            is_archived=is_archived,
+            is_archived=first is not None,
+            archival_start=first,
+            archival_end=last,
             description=f"MongoDB Archived PV: {pv_name}",
         )
 

--- a/src/osprey/connectors/factory.py
+++ b/src/osprey/connectors/factory.py
@@ -117,16 +117,17 @@ class ConnectorFactory:
                 logger.warning(f"Could not load config: {e}, using defaults")
                 config = {}
 
-        connector_type = config.get("type")
-        if not connector_type:
-            # Fail closed: an under-specified config must never bring up a live
-            # control system. A blank value is treated as absent for the same
-            # reason.
+        # Fail closed: an under-specified config must never bring up a live
+        # control system. A blank value is treated as absent for the same
+        # reason. The fallback lives in types.resolve_control_system_type so
+        # that anything deciding what this call WILL build — the honesty rule's
+        # three refusals above all — resolves it identically.
+        connector_type = types.resolve_control_system_type(config)
+        if not config.get("type"):
             logger.warning(
                 f"control_system.type is not set; defaulting to '{types.MOCK}'. "
                 f"Set control_system.type explicitly to select a connector."
             )
-            connector_type = types.MOCK
 
         connector_class = cls._control_system_connectors.get(connector_type)
 
@@ -204,16 +205,17 @@ class ConnectorFactory:
                 logger.warning(f"Could not load config: {e}, using defaults")
                 config = {}
 
-        connector_type = config.get("type")
-        if not connector_type:
-            # Fail closed: a config with no `archiver:` section is under-specified,
-            # not a declaration that a facility archiver exists. A blank value is
-            # treated as absent for the same reason.
+        # Fail closed: a config with no `archiver:` section is under-specified,
+        # not a declaration that a facility archiver exists. A blank value is
+        # treated as absent for the same reason. The fallback lives in
+        # types.resolve_archiver_type because the honesty rule's refusals have
+        # to answer "what will this build?" with exactly this answer.
+        connector_type = types.resolve_archiver_type(config)
+        if not config.get("type"):
             logger.warning(
                 f"archiver.type is not set; defaulting to '{types.MOCK_ARCHIVER}'. "
                 f"Set archiver.type explicitly to select a connector."
             )
-            connector_type = types.MOCK_ARCHIVER
 
         connector_class = cls._archiver_connectors.get(connector_type)
 
@@ -338,7 +340,12 @@ def isolated_connector_registries(*, clear: bool = False) -> Iterator[ConnectorR
 
 
 _BUILTIN_CONTROL_SYSTEMS = (types.MOCK, types.EPICS, types.VIRTUAL_ACCELERATOR, types.DOOCS)
-_BUILTIN_ARCHIVERS = (types.MOCK_ARCHIVER, types.EPICS_ARCHIVER, types.DOOCS_ARCHIVER)
+_BUILTIN_ARCHIVERS = (
+    types.MOCK_ARCHIVER,
+    types.EPICS_ARCHIVER,
+    types.MONGODB_ARCHIVER,
+    types.DOOCS_ARCHIVER,
+)
 
 
 def register_builtin_connectors() -> None:
@@ -359,17 +366,20 @@ def register_builtin_connectors() -> None:
         name for name in _BUILTIN_ARCHIVERS if name not in ConnectorFactory._archiver_connectors
     ]
     if not missing_control_systems and not missing_archivers:
-        # The optional MongoDB archiver is only probed alongside the required
-        # built-ins, so a missing pymongo isn't re-imported on every call.
         return
 
-    # The DOOCS connectors import doocs4py inside connect(), not at module
-    # scope, so they register unconditionally like any other built-in. A
-    # machine with no DOOCS environment only finds out when it tries to
-    # connect — which is the point at which it would have failed anyway.
+    # The DOOCS and MongoDB connectors import their optional drivers (doocs4py,
+    # pymongo) inside connect(), not at module scope, so they register
+    # unconditionally like any other built-in. A machine without the driver
+    # only finds out when it tries to connect — which is the point at which it
+    # would have failed anyway. Registering MongoDB conditionally instead used
+    # to leave it out of _BUILTIN_ARCHIVERS, which broke convergence: a registry
+    # holding the other built-ins satisfied the early return above and never
+    # healed the missing mongodb_archiver entry.
     from osprey.connectors.archiver.doocs_archiver_connector import DOOCSArchiverConnector
     from osprey.connectors.archiver.epics_archiver_connector import EPICSArchiverConnector
     from osprey.connectors.archiver.mock_archiver_connector import MockArchiverConnector
+    from osprey.connectors.archiver.mongodb_archiver_connector import MongoDBArchiverConnector
     from osprey.connectors.control_system.doocs_connector import DOOCSConnector
     from osprey.connectors.control_system.epics_connector import EPICSConnector
     from osprey.connectors.control_system.mock_connector import MockConnector
@@ -384,17 +394,9 @@ def register_builtin_connectors() -> None:
     archivers: list[tuple[str, type[ArchiverConnector]]] = [
         (types.MOCK_ARCHIVER, MockArchiverConnector),
         (types.EPICS_ARCHIVER, EPICSArchiverConnector),
+        (types.MONGODB_ARCHIVER, MongoDBArchiverConnector),
         (types.DOOCS_ARCHIVER, DOOCSArchiverConnector),
     ]
-
-    try:
-        from osprey.connectors.archiver.mongodb_archiver_connector import (
-            MongoDBArchiverConnector,
-        )
-
-        archivers.append((types.MONGODB_ARCHIVER, MongoDBArchiverConnector))
-    except ImportError:
-        pass
 
     for name, connector_class in control_systems:
         if name not in ConnectorFactory._control_system_connectors:

--- a/src/osprey/connectors/honesty.py
+++ b/src/osprey/connectors/honesty.py
@@ -1,0 +1,235 @@
+"""The one connector pairing a deployment may not have: invented history.
+
+A virtual accelerator serves channels that move for modelled reasons — a
+corrector is stepped, the orbit responds, and the numbers a tool reads back are
+answers to what the deployment actually did. The mock archiver answers a history
+query the other way round: it synthesizes a plausible-looking series at read
+time, for questions nobody recorded the answer to. Configured together they
+produce an agent whose past is fiction and whose present is not, with nothing
+connecting the two — so the fiction can never be caught by disagreeing with the
+machine it claims to describe.
+
+Refused at three independent moments, because a deployment can acquire the
+pairing at any of them: ``osprey build`` writes the config, ``osprey deploy``
+stands the services up, and the MCP server reads whatever ``config.yml`` it is
+pointed at — including one hand-edited long after the build. Each site raises in
+its own vocabulary and names its own fix. What they share, and what lives here,
+is the question they ask and the reason they ask it.
+
+**The question is asked twice, because the two kinds of config are read by
+different readers, and a guard must resolve a key exactly as the reader it
+guards resolves it — otherwise the divergence *is* the bypass.**
+
+- A build profile's ``config:`` block reaches the rendered project through the
+  emitter, which honors the dotted spelling (``archiver.type:``, the canonical
+  one) *and* a nested mapping — both land on the same rendered leaf. Both are
+  therefore live, and :func:`pairing_in_profile` fails closed when they
+  disagree: whichever one wins, the profile has stated the archive twice and is
+  free to be wrong once.
+- A rendered ``config.yml`` is read by :class:`~osprey.utils.config.ConfigBuilder`
+  and by ``MCPServerConfig``, and both walk *nested sections only* — a top-level
+  ``archiver.type:`` line there sets nothing at all. So
+  :func:`pairing_in_rendered_config` resolves nested-only. A flat line is not
+  evidence of an archiver; it is an inert line, and one this module names in its
+  message rather than silently reading as "unset", because someone who typed it
+  deserves to be told why it did nothing.
+
+Both readers fall back to the mock when their key is absent or blank (see the
+factory's ``… is not set; defaulting to …`` warnings), so *unset counts as mock*
+at every site. That is the fallback the rule is really about: the common way
+into the pairing is not naming the mock, it is naming nothing.
+
+Deliberately *not* a refusal of every mock archiver: a mock control system paired
+with the mock archiver is the honest storeless deployment, and it is the app
+template's default. Nothing is claimed to be real there, so nothing lies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .types import (
+    MOCK_ARCHIVER,
+    VIRTUAL_ACCELERATOR,
+    resolve_archiver_type,
+    resolve_control_system_type,
+)
+
+#: Why the pairing is refused, in one sentence pair the three sites share so the
+#: explanation cannot drift between them. Each site supplies its own fix.
+VA_MOCK_ARCHIVER_WHY = (
+    "a virtual accelerator serves a machine whose channels move for modelled "
+    "reasons, while the mock archiver synthesizes history at read time. Paired, "
+    "the agent reports a past that never happened and nothing can catch it — the "
+    "one failure a simulated facility exists to make visible rather than to have."
+)
+
+_CONTROL_SYSTEM_TYPE = "control_system.type"
+_ARCHIVER_TYPE = "archiver.type"
+
+
+class _Absent:
+    """Sentinel for "this spelling does not set the key", distinct from a key
+    set to ``None`` — which YAML produces for a bare ``archiver.type:`` and which
+    the factory resolves to the mock."""
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return "<absent>"
+
+
+_ABSENT = _Absent()
+
+
+@dataclass(frozen=True)
+class ArchiverPairing:
+    """What a config says about its archive, judged the way its reader reads it."""
+
+    is_invented_history: bool
+    """Whether this config gives a simulated machine an archiver that invents
+    its past — the thing all three sites refuse."""
+
+    archiver_phrase: str
+    """How to name the config's archiver back to whoever wrote it, ready to drop
+    into a message after "archiver.type is …". Says *unset* when unset, and says
+    so about an inert flat line rather than pretending the key was never
+    written."""
+
+
+def pairing_in_profile(config: Any) -> ArchiverPairing:
+    """Judge a build profile's ``config:`` block.
+
+    Both spellings are live here — the emitter honors the dotted key and a
+    nested mapping alike — so both are read, and a disagreement between them
+    fails closed. Refusing an ambiguous profile is the same stance
+    ``va_archiver_errors`` already takes on a duplicated connection key: one
+    fact with two homes is free to disagree, and the build should not be the
+    thing that picks a winner.
+
+    Args:
+        config: The profile's resolved ``config:`` block.
+
+    Returns:
+        The verdict and the phrase naming its archiver.
+    """
+    control_system = _spellings(config, _CONTROL_SYSTEM_TYPE, nested_only=False)
+    archiver = _spellings(config, _ARCHIVER_TYPE, nested_only=False)
+
+    # Each candidate is resolved through the factory's own resolver, as the
+    # one-key section that spelling would render into. When two spellings both
+    # exist, either may be the one that lands, so either being the mock is
+    # enough to refuse.
+    is_va = any(
+        resolve_control_system_type({"type": value}) == VIRTUAL_ACCELERATOR
+        for value in control_system
+    )
+    is_mock = not archiver or any(
+        resolve_archiver_type({"type": value}) == MOCK_ARCHIVER for value in archiver
+    )
+
+    return ArchiverPairing(
+        is_invented_history=is_va and is_mock,
+        archiver_phrase=_profile_phrase(archiver),
+    )
+
+
+def pairing_in_rendered_config(config: Any) -> ArchiverPairing:
+    """Judge a rendered ``config.yml`` — the deploy config and the MCP server's.
+
+    Nested sections only, because that is all either reader honors: a top-level
+    ``archiver.type:`` line in this file is read by nothing, so treating it as a
+    statement about the archiver would excuse the very config it fails to
+    configure.
+
+    Args:
+        config: The raw config mapping, as loaded from ``config.yml``.
+
+    Returns:
+        The verdict and the phrase naming its archiver — which calls out an
+        inert flat line when one is what misled the writer.
+    """
+    # The sections handed to the resolvers are the very objects the MCP server
+    # hands the factory (``MCPServerConfig.control_system`` / ``.archiver`` are
+    # ``raw.get(section)``), resolved by the factory's own functions. There is no
+    # second opinion to diverge from: this *is* what the deployment will build.
+    sections = config if isinstance(config, dict) else {}
+    control_system_type = resolve_control_system_type(sections.get("control_system"))
+    archiver_type = resolve_archiver_type(sections.get("archiver"))
+
+    return ArchiverPairing(
+        is_invented_history=(
+            control_system_type == VIRTUAL_ACCELERATOR and archiver_type == MOCK_ARCHIVER
+        ),
+        archiver_phrase=_rendered_phrase(
+            _spellings(config, _ARCHIVER_TYPE, nested_only=True),
+            _flat_value(config, _ARCHIVER_TYPE),
+        ),
+    )
+
+
+def _spellings(config: Any, dotted: str, *, nested_only: bool) -> list[Any]:
+    """The values this config sets for *dotted*, in every spelling that is live.
+
+    Returned exactly as written, never normalized: the resolvers in
+    :mod:`osprey.connectors.types` are what turn a value into a decision, and
+    tidying one on the way in (stripping whitespace, say) would decide something
+    about it that the factory does not — a padded type name is a lookup failure
+    there, and must stay one here.
+    """
+    if not isinstance(config, dict):
+        return []
+    values = [_nested_value(config, dotted)]
+    if not nested_only:
+        values.append(_flat_value(config, dotted))
+    return [value for value in values if value is not _ABSENT]
+
+
+def _flat_value(config: Any, dotted: str) -> Any:
+    """The value of the whole dotted key written as one top-level key."""
+    if not isinstance(config, dict) or dotted not in config:
+        return _ABSENT
+    return config[dotted]
+
+
+def _nested_value(config: Any, dotted: str) -> Any:
+    """The value of *dotted* walked as nested sections."""
+    section, _, leaf = dotted.partition(".")
+    subtree = config.get(section) if isinstance(config, dict) else None
+    if not isinstance(subtree, dict) or leaf not in subtree:
+        return _ABSENT
+    return subtree[leaf]
+
+
+def _stated(values: list[Any]) -> list[str]:
+    """The values that actually say something, as text for a message."""
+    return sorted({str(value) for value in values if value})
+
+
+def _profile_phrase(archiver: list[Any]) -> str:
+    if not archiver:
+        return f"unset (which the connector factory resolves to {MOCK_ARCHIVER!r})"
+    stated = _stated(archiver)
+    if len(stated) > 1:
+        return (
+            f"spelled twice and differently ({' and '.join(repr(v) for v in stated)}) — "
+            f"both spellings reach the same rendered key, and which one lands "
+            f"depends on which comes last in this profile, so one of them is wrong"
+        )
+    if not stated:
+        return f"blank (which the connector factory resolves to {MOCK_ARCHIVER!r})"
+    return repr(stated[0])
+
+
+def _rendered_phrase(archiver: list[Any], flat: Any) -> str:
+    stated = _stated(archiver)
+    if stated:
+        return repr(stated[0])
+    unset = f"unset (which the connector factory resolves to {MOCK_ARCHIVER!r})"
+    if flat is _ABSENT:
+        return unset
+    return (
+        f"{unset}. This file does carry a top-level '{_ARCHIVER_TYPE}: "
+        f"{flat}' line, but config.yml is read as nested sections, so "
+        f"that line configures nothing — the archiver is whatever the "
+        f"'archiver:' section says, and there is none"
+    )

--- a/src/osprey/connectors/types.py
+++ b/src/osprey/connectors/types.py
@@ -1,9 +1,18 @@
-"""Connector type constants.
+"""Connector type constants, and the fallbacks a factory applies to them.
 
 Single source of truth for built-in connector type name strings.
 Custom connectors use dotted module paths (e.g., 'mypackage.TangoConnector')
 and don't need constants here.
+
+The two resolvers at the bottom are here rather than in
+:mod:`osprey.connectors.factory` so that a guard deciding what a deployment
+*will build* can share them with the factory that builds it. A guard which
+re-implements "what does this config select" is a guard that can disagree with
+the answer, and the disagreement is a bypass rather than a discrepancy — see
+:mod:`osprey.connectors.honesty`.
 """
+
+from typing import Any
 
 # -- Control system connector types (have implementations) --
 MOCK = "mock"
@@ -20,3 +29,32 @@ DOOCS_ARCHIVER = "doocs_archiver"
 # -- CLI choice lists (only types with implementations) --
 CLI_CONTROL_SYSTEM_TYPES = [MOCK, EPICS, VIRTUAL_ACCELERATOR, DOOCS]
 CLI_ARCHIVER_TYPES = [MOCK_ARCHIVER, EPICS_ARCHIVER, MONGODB_ARCHIVER, DOOCS_ARCHIVER]
+
+
+def _resolve_type(section: Any, fallback: str) -> str:
+    """The connector type a factory builds from a config section.
+
+    A section that is missing, is not a mapping, or carries no usable ``type``
+    resolves to *fallback* — the factory's documented fail-closed default, which
+    it announces with a ``… is not set; defaulting to …`` warning. Empty and
+    ``None`` count as absent (YAML gives ``None`` for a bare ``type:``); any
+    other value is returned as written, so a typo reaches the factory's
+    "Unknown … type" error rather than being quietly rounded to something.
+    """
+    value = section.get("type") if isinstance(section, dict) else None
+    return str(value) if value else fallback
+
+
+def resolve_archiver_type(section: Any) -> str:
+    """The archiver an ``archiver:`` config section actually selects.
+
+    Absent means the mock: a config that says nothing about its archiver is a
+    config that gets the synthesizing one, which is the fact the honesty rule is
+    really about.
+    """
+    return _resolve_type(section, MOCK_ARCHIVER)
+
+
+def resolve_control_system_type(section: Any) -> str:
+    """The control system a ``control_system:`` config section actually selects."""
+    return _resolve_type(section, MOCK)

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -7,6 +7,8 @@ Docker or Podman compose.
 import os
 import subprocess
 import tempfile
+import time
+from datetime import UTC, datetime
 from pathlib import Path
 
 from osprey.deployment.compose_generator import (
@@ -96,12 +98,27 @@ logger = get_logger("deployment.lifecycle")
 # volume — a pre-existing volume keeps its original password (same
 # stale-volume caveat as openobserve; recreate the volume to adopt the minted
 # value).
+#
+# mongodb is the archiver store, and follows the same shape one step further:
+# its compose template carries an insecure ``${MONGO_ROOT_PASSWORD:-osprey}``
+# default, and the minted value has to reach THREE readers, not two — the
+# container (MONGO_INITDB_ROOT_PASSWORD), the archiver_recorder service writing
+# samples in-network, and the agent's own connector, whose config block names
+# the variable rather than carrying a value
+# (``archiver.mongodb_archiver.password_env: MONGO_ROOT_PASSWORD``). All three
+# resolve the same ``.env`` entry, which is what keeps one store openable by
+# the process that writes it and the process that reads it. The seeder and
+# ``osprey sim apply`` read it from the project ``.env`` explicitly rather than
+# from an ambient environment.
+# NOTE: mongod, like postgres, reads its root credentials only when
+# initializing a fresh data volume — the same stale-volume caveat applies.
 _SERVICE_TOKEN_VARS: dict[str, tuple[str, ...]] = {
     "event_dispatcher": ("EVENT_DISPATCHER_TOKEN", "DISPATCH_WORKER_TOKEN"),
     "dispatch_worker": ("EVENT_DISPATCHER_TOKEN", "DISPATCH_WORKER_TOKEN"),
     "bluesky": ("BLUESKY_LAUNCH_TOKEN", "BLUESKY_TILED_API_KEY"),
     "openobserve": ("ZO_ROOT_USER_PASSWORD",),
     "postgresql": ("ARIEL_DB_PASSWORD",),
+    "mongodb": ("MONGO_ROOT_PASSWORD",),
 }
 
 # Vars checked against their _VAR_VALIDATORS constraint when present, but
@@ -196,6 +213,7 @@ _SERVICE_STATE_VOLUMES: dict[str, tuple[str, ...]] = {
     "bluesky": ("bluesky_tiled_catalog",),
     "openobserve": ("openobserve_data",),
     "postgresql": ("ariel_postgres_data",),
+    "mongodb": ("archiver_mongodb_data",),
 }
 
 
@@ -604,7 +622,8 @@ def _preflight_token_continuity(config: dict, env_path: Path | None = None) -> N
 
     Several of the secrets ``_ensure_service_tokens`` mints are adopted *once*,
     by a docker volume, at the moment the service first initializes: openobserve's
-    root password, the ARIEL database password. The container reads the var only
+    root password, the ARIEL database password, the archiver store's Mongo root
+    password. The container reads the var only
     on a fresh volume — afterwards the volume is the authority, and a deploy that
     supplies a different value simply fails to authenticate against data it can
     no longer open.
@@ -719,6 +738,49 @@ def _matching_volumes(existing: set[str], project_name: str, bare_name: str) -> 
     return sorted(name for name in existing if name == prefix or name.startswith(f"{prefix}_"))
 
 
+def _refuse_invented_history(config: dict) -> None:
+    """Abort a deploy that would stand up a machine with a fabricated past.
+
+    The honesty rule's deploy-time site. ``osprey build`` refuses to write the
+    pairing and the MCP server refuses to start on it, but neither covers the
+    deploy of a project whose ``config.yml`` was edited after the build — and a
+    deploy is where the pairing becomes a running stack other people trust.
+
+    Keyed on ``control_system.type`` alone, exactly as the other two sites are,
+    rather than on ``deployed_services`` like ``_ensure_bluesky_substrate_env``
+    below: that function is auto-configuring a service and so only cares whether
+    the service is here, while this one is asking what the deployment claims
+    about itself. An attached project deploying no VA container of its own still
+    points its agent at one.
+
+    Both keys are resolved through nested sections only, the way ``ConfigBuilder``
+    reads a rendered ``config.yml`` — see
+    :func:`~osprey.connectors.honesty.pairing_in_rendered_config`.
+
+    :param config: Raw deploy config (the rendered project's ``config.yml``).
+    :raises RuntimeError: if the config pairs a virtual accelerator with the
+        mock archiver, an unset ``archiver.type`` included.
+    """
+    from osprey.connectors.honesty import VA_MOCK_ARCHIVER_WHY, pairing_in_rendered_config
+    from osprey.connectors.types import VIRTUAL_ACCELERATOR
+
+    pairing = pairing_in_rendered_config(config)
+    if not pairing.is_invented_history:
+        return
+
+    raise RuntimeError(
+        f"This deployment's control_system.type is {VIRTUAL_ACCELERATOR!r} and its "
+        f"archiver.type is {pairing.archiver_phrase} — {VA_MOCK_ARCHIVER_WHY}\n"
+        f"Fix config.yml before deploying: under its `archiver:` section set `type:` "
+        f"to a connector reading a store this stack writes, or set the `type:` under "
+        f"`control_system:` to 'mock' for an honestly storeless deployment. To have "
+        f"the stack deploy its own store, rebuild from a profile carrying a "
+        f"`va_archiver:` block — the control-assistant preset ships one, and "
+        f"`osprey deploy up` then brings up the store and its recorder beside the "
+        f"virtual accelerator."
+    )
+
+
 def _ensure_bluesky_substrate_env(config: dict, env_path: Path | None = None) -> None:
     """Auto-configure the bluesky bridge's EPICS-substrate scan devices for a
     VA-backed Bluesky stack, making ``osprey deploy up`` turn-key.
@@ -783,7 +845,9 @@ def _ensure_bluesky_substrate_env(config: dict, env_path: Path | None = None) ->
             "be listed and composed but never executed. Skipping "
             "BLUESKY_EPICS_SUBSTRATE auto-configuration (scan devices need an "
             "EPICS-like connector to speak Channel Access to). Flip it with "
-            "`osprey config set-control-system virtual_accelerator`."
+            "`osprey config set-control-system virtual_accelerator`, which first "
+            "needs this project's archiver pointed at a real store -- on a "
+            "mock-archiver project that command refuses and names the fix."
         )
         return
 
@@ -1660,7 +1724,475 @@ def _preflight_host_ports(config, compose_files):
     )
 
 
-def deploy_up(config_path, detached=False, dev_mode=False, expose_network=False):
+# ---------------------------------------------------------------------------
+# Staged archiver bring-up
+# ---------------------------------------------------------------------------
+
+# The archiver's two compose service keys. The store's key and its
+# deployed_services name are the same word; the recorder's are NOT — config and
+# deployed_services call it ``archiver_recorder`` (the directory under
+# ``services/``), while its compose service key is hyphenated. Getting that
+# wrong turns the quiesce below into a "no such service" error, so both spellings
+# are named here rather than being spelled inline at each use.
+_ARCHIVER_STORE_SERVICE = "mongodb"
+_ARCHIVER_RECORDER_SERVICE = "archiver-recorder"
+_ARCHIVER_RECORDER_DEPLOY_NAME = "archiver_recorder"
+
+# The install target every archiver error names. pymongo is an optional extra,
+# and a deploy that hits the seeder without it must say what to install rather
+# than surfacing a bare ImportError.
+_ARCHIVER_EXTRA = "osprey-framework[archiver-mongodb]"
+
+# How long the staged store gets to start answering before the deploy gives up.
+# Generous because the very first start of a fresh volume creates the admin user
+# and preallocates WiredTiger's journal before mongod accepts a connection —
+# which is exactly what the compose healthcheck's own ``start_period`` covers.
+_ARCHIVER_HEALTH_TIMEOUT_S = 180.0
+_ARCHIVER_HEALTH_POLL_S = 2.0
+
+# MongoDB's AuthenticationFailed error code.
+_MONGO_AUTHENTICATION_FAILED = 18
+
+# How long an authentication refusal is read as "the store is still creating its
+# root user" rather than "this password is wrong".
+#
+# Three numbers have to stay in this order, and the ordering IS the design:
+#
+#   15 s   the mongodb compose template's healthcheck ``start_period`` — mongod's
+#          own declared allowance for initializing a fresh volume
+#   45 s   this grace window
+#  180 s   _ARCHIVER_HEALTH_TIMEOUT_S, the full reachability budget
+#
+# Below the start_period, a fresh volume's normal initialization would be called
+# a wrong password and abort the first deploy of every new project. Above the
+# reachability budget, the grace would never expire and a genuinely stale volume
+# would burn the whole budget for a diagnosis available in seconds. Move the
+# healthcheck's start_period and this has to move with it.
+_ARCHIVER_AUTH_GRACE_S = 45.0
+
+# Minimum gap between seed progress lines. A base seed writes thousands of
+# chunks; reporting each one would bury the deploy log, and reporting none would
+# leave a multi-minute step looking like a hang.
+_ARCHIVER_PROGRESS_INTERVAL_S = 15.0
+
+
+def _archiver_store_deployed(config: dict) -> bool:
+    """True when this deploy runs the archiver store itself.
+
+    Membership in ``deployed_services`` is the gate for every archiver step
+    below: a project that reads a store someone *else* runs (an attached
+    facility project, which sets ``va_archiver.host``) must never have its
+    history seeded or reseeded by a local deploy.
+    """
+    return _ARCHIVER_STORE_SERVICE in (config.get("deployed_services") or [])
+
+
+def _preflight_archiver_pymongo(config: dict) -> None:
+    """Abort a store-deploying run that cannot talk to the store it deploys.
+
+    pymongo is an optional extra, and without it the seeder cannot run — but the
+    only place that becomes visible is minutes later, after the project image has
+    been built and the store container is already up. Checking here, beside the
+    token mint, turns that into an immediate error naming the install.
+
+    :param config: Raw deploy config.
+    :raises RuntimeError: if the store is deployed and pymongo is absent.
+    """
+    if not _archiver_store_deployed(config):
+        return
+    try:
+        import pymongo  # noqa: F401
+    except ImportError as exc:
+        raise RuntimeError(
+            "This project deploys the archiver store (services.mongodb), and seeding "
+            "its history needs pymongo, which is not installed.\n"
+            f"Install it with: pip install '{_ARCHIVER_EXTRA}'"
+        ) from exc
+
+
+def _archiver_seed_inputs(config: dict, project_dir: Path):
+    """The channel set, engine and boot values one base seed is built from.
+
+    Every import here is function-local. The seeder pulls in numpy and the
+    simulation package, and hoisting either into this module's import path would
+    put a scientific-stack import on every ``osprey deploy`` invocation, archiver
+    or not.
+
+    The channel set is the build-generated manifest the Virtual Accelerator and
+    the recorder both read, resolved exactly as they resolve it
+    (``VA_CHANNELS_FILE``, relative names against ``data/simulation/``), so the
+    seeded history covers precisely the channels the live half serves. It is read
+    from the project's own ``.env`` first, because that is where the build wrote
+    it; the ambient value is the fallback for a deploy whose environment carries
+    it instead.
+
+    :returns: ``(channels, engine, boot_values)``. ``engine`` is ``None`` and
+        ``boot_values`` empty for a project with no machine model — every channel
+        is then procedural, which is a valid configuration, not a fault.
+    """
+    from osprey.services.virtual_accelerator.manifest.build import build_manifest
+    from osprey.services.virtual_accelerator.manifest.loaders import (
+        load_machine_json_channels,
+        load_manifest_file,
+    )
+    from osprey.simulation.apply import resolve_simulation_file
+    from osprey.simulation.engine import SimulationEngine, resolve_state_dir
+
+    env = parse_dotenv_file(project_dir / ".env") if (project_dir / ".env").is_file() else {}
+    named = (env.get("VA_CHANNELS_FILE") or os.environ.get("VA_CHANNELS_FILE") or "").strip()
+    if named:
+        manifest_path = Path(named)
+        if not manifest_path.is_absolute():
+            manifest_path = project_dir / "data" / "simulation" / manifest_path
+        channels = load_manifest_file(manifest_path)
+    else:
+        channels = build_manifest()["channels"]
+
+    machine_path, _, _, _ = resolve_simulation_file(config, project_dir)
+    if machine_path is None or not machine_path.is_file():
+        return channels, None, {}
+
+    engine = SimulationEngine.from_file(
+        machine_path, state_dir=resolve_state_dir(config, project_dir)
+    )
+    # The same map the Virtual Accelerator boots its records from: machine.json's
+    # static channel values, skipping the handful of derived channels that carry
+    # an expression instead. Anchoring the procedural generator on it is what
+    # makes a seeded sample and a recorded one describe the same machine.
+    boot_values = {
+        address: entry["value"]
+        for address, entry in load_machine_json_channels(machine_path).items()
+        if "value" in entry
+    }
+    return channels, engine, boot_values
+
+
+def _reapply_active_scenarios(config: dict, project_dir: Path, engine) -> None:
+    """Re-apply the active scenario set onto a freshly rebuilt base.
+
+    A reseed rewrites the whole base series, which erases the event windows the
+    active scenarios had written into it. Without this the deployment would come
+    back up claiming a fault is active while its history showed a clean machine —
+    precisely the divergence the stored archiver exists to remove.
+
+    The logbook is deliberately left alone: a knob change rebuilds the archive,
+    not the narrative, and purging ARIEL's entries here would destroy history
+    this deploy was never asked to touch.
+
+    A failure here is not recoverable by retrying the deploy, and the error says
+    so. By this point the seeder has written the manifest, so the next
+    ``deploy up`` reads MATCH, skips the reseed, and skips this step with it —
+    leaving a clean base under a faulted machine permanently. The manifest is
+    deliberately NOT deleted to force a retry: that would throw away a
+    multi-minute seed to redo work that succeeded. The one step that failed is
+    the one the operator is told to re-run.
+
+    :raises RuntimeError: if the re-apply fails, naming the command that fixes it.
+    """
+    from osprey.simulation.apply import apply_scenarios, persisted_scenario_anchor
+    from osprey.simulation.engine import DEFAULT_SCENARIO
+
+    if engine is None:
+        logger.info("No machine model in this project; no scenarios to re-apply after the reseed")
+        return
+
+    names = engine.active_scenarios()
+    # The anchor the running world is already on: re-anchoring here would slide
+    # the live VA's events, the logbook and the archive's windows to a T0 nobody
+    # asked for, as a side effect of a deploy meant to rebuild only the store.
+    anchor = persisted_scenario_anchor(config, project_dir)
+    try:
+        result = apply_scenarios(project_dir, names, seed_logbook=False, now=anchor)
+    except Exception as exc:
+        # `nominal` is implicit, so the recovery command names the faults — which
+        # is what the operator activated and what `sim apply` expects back.
+        faults = [name for name in names if name != DEFAULT_SCENARIO] or [DEFAULT_SCENARIO]
+        raise RuntimeError(
+            "The base series was rebuilt but the active scenarios could not be "
+            "re-applied, so the archive currently shows a clean machine while the "
+            f"simulation runs {list(names)!r}.\n"
+            f"Re-run `osprey sim apply {' '.join(faults)}` from {project_dir} to put the "
+            f"event windows back. Cause: {exc}"
+        ) from exc
+    logger.key_info(f"Re-applied scenarios {list(result.active)!r} onto the rebuilt archive")
+
+
+def _wait_for_archiver_store(
+    collection, deadline: float, store_hint: str = "the archiver store"
+) -> None:
+    """Block until the staged store answers, or fail with what it was asked.
+
+    The compose healthcheck already gates the recorder on the same condition;
+    this is the host side of it, and it probes with the credentials the seeder is
+    about to use — so an authentication failure surfaces here, with the variable
+    named, rather than as an unexplained seeding error.
+
+    :param collection: The archive collection, for its client.
+    :param deadline: :func:`time.monotonic` instant to give up at.
+    :param store_hint: How to name this store in an error — who is connecting
+        where, which is what tells an operator whose credentials were refused.
+    :raises RuntimeError: if the store rejects these credentials, or is still
+        unreachable at ``deadline``.
+    """
+    from pymongo.errors import OperationFailure, PyMongoError
+
+    client = collection.database.client
+    auth_deadline = time.monotonic() + _ARCHIVER_AUTH_GRACE_S
+    last: Exception | None = None
+    while True:
+        try:
+            client.admin.command("ping")
+            return
+        except OperationFailure as exc:
+            # "Authentication failed" means two opposite things depending on
+            # WHEN it arrives, and the difference decides whether a first deploy
+            # works at all.
+            #
+            # On a FRESH volume, mongod accepts connections before it has created
+            # the root user from MONGO_INITDB_ROOT_USERNAME/PASSWORD. A probe
+            # landing in that window is refused — and the store is perfectly
+            # healthy a second later. Treating that as terminal aborts the very
+            # first deploy of every new project, intermittently, depending on
+            # which side of the race the probe lands. (It is the same window the
+            # compose healthcheck covers with its own ``start_period``.)
+            #
+            # Once the store has had time to initialize, the SAME error means the
+            # stale-volume shape instead: mongod reads its root credentials only
+            # when initializing a fresh volume, so a rotated MONGO_ROOT_PASSWORD
+            # leaves a running store that will refuse this password forever. That
+            # is worth failing fast on rather than burning the full budget.
+            #
+            # So the grace window is what separates them: retry while the store
+            # could still be initializing, then treat a refusal as final.
+            if exc.code != _MONGO_AUTHENTICATION_FAILED:
+                raise
+            if time.monotonic() < auth_deadline:
+                last = exc
+                time.sleep(_ARCHIVER_HEALTH_POLL_S)
+                continue
+            raise RuntimeError(
+                f"The archiver store rejected the credentials in {store_hint}: {exc}\n"
+                "mongod reads its root credentials only when initializing a FRESH data "
+                "volume, so a store whose volume predates the current MONGO_ROOT_PASSWORD "
+                "keeps the password it was created with. Either restore the original "
+                "value, or remove the `archiver_mongodb_data` volume to re-initialize the "
+                "store — which discards the seeded and recorded history with it."
+            ) from exc
+        except PyMongoError as exc:
+            last = exc
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    f"The archiver store did not become reachable within "
+                    f"{_ARCHIVER_HEALTH_TIMEOUT_S:.0f}s: {exc}\n"
+                    f"Check `{_ARCHIVER_STORE_SERVICE}` in `osprey deploy status` and its "
+                    "container logs. A store on a pre-existing volume keeps the credentials "
+                    "it was initialized with, so a rotated MONGO_ROOT_PASSWORD needs the "
+                    "volume recreated (which discards the archive)."
+                ) from last
+            time.sleep(_ARCHIVER_HEALTH_POLL_S)
+
+
+def _seed_progress_reporter():
+    """A :func:`~osprey.simulation.archiver_seed.seed_base` progress callback.
+
+    Rate-limited rather than per-chunk: the point is to prove a multi-minute step
+    is moving, not to narrate every insert.
+    """
+    last = [time.monotonic()]
+
+    def report(seed_report) -> None:
+        now = time.monotonic()
+        if now - last[0] < _ARCHIVER_PROGRESS_INTERVAL_S:
+            return
+        last[0] = now
+        logger.info(
+            f"  seeding archive: {seed_report.documents:,} documents written "
+            f"({seed_report.elapsed_s:.0f}s elapsed)"
+        )
+
+    return report
+
+
+def _archiver_store_connection(config: dict, project_dir: Path) -> dict | None:
+    """Connection parameters for the store this deploy is bringing up.
+
+    Delegates to :func:`~osprey.simulation.apply.archiver_store_config` so the
+    deploy-time seeder and ``osprey sim apply`` open one store the same way, then
+    fills in the one difference between the two callers. ``sim apply`` reads the
+    password from the project ``.env`` and never from the ambient environment,
+    because it is routinely run from somewhere else and must not pick up a
+    foreign deployment's credential. ``deploy up`` is the process that hands
+    compose its environment: when the password is exported rather than written to
+    ``.env``, the exported value is what the store container is created with, so
+    it is also what the seeder must authenticate with.
+
+    :returns: The parameters, or ``None`` when the project declares no connection
+        block for the store it deploys — nothing can be seeded, and saying so is
+        better than guessing a host.
+    """
+    from osprey.simulation.apply import archiver_store_config
+
+    store = archiver_store_config(config, project_dir)
+    if store is None:
+        return None
+    if not store["password"]:
+        store["password"] = os.environ.get(store["password_env"], "")
+    return store
+
+
+def _stage_archiver_store(config, compose_files, env, project_dir, *, keep_base=False) -> None:
+    """Start the archiver store on its own and seed its base history.
+
+    Staged ahead of the full bring-up for one reason: the recorder writes into a
+    collection the seeder creates, with the indexes and the compressor the seeder
+    chooses. Starting both at once would race the collection into existence with
+    whatever options the first writer happened to imply.
+
+    What happens depends on what the store's seed manifest says about the knobs
+    now in force:
+
+    * **match** — the store already holds the archive this profile describes.
+      Nothing is written, and the deploy continues immediately.
+    * **absent** — no manifest: a first deploy, or a volume that ``clean``/
+      ``rebuild`` wiped. Seed it.
+    * **mismatch** — the knobs moved, so the store's coverage no longer describes
+      what the profile asks for. Report what changed, then rebuild — unless
+      ``keep_base`` says to leave it alone.
+
+    Both rebuild paths quiesce the recorder first. It is one operation — stop the
+    writer, drop the collection, rebuild it, re-apply the active scenarios — and
+    splitting it by state would leave the mismatch path stopping a writer the
+    absent path lets run into a collection being dropped underneath it. Stopping
+    a service that was never started is a no-op, and neither deploy branch needs
+    anything undone afterwards: the full ``up`` that follows starts it again.
+
+    :param config: Raw deploy config.
+    :param compose_files: Rendered compose file paths for this deploy.
+    :param env: The environment the deploy hands compose.
+    :param project_dir: Root of the built project (holds ``.env`` and ``data/``).
+    :param keep_base: Leave a mismatched base in place instead of rebuilding it.
+    :raises RuntimeError: if the store cannot be reached or authenticated.
+    """
+    from osprey.simulation.apply import archiver_collection
+    from osprey.simulation.archiver_seed import (
+        SeedKnobs,
+        SeedState,
+        compare_fingerprint,
+        seed_base,
+        seed_fingerprint,
+    )
+
+    store = _archiver_store_connection(config, project_dir)
+    if store is None:
+        logger.warning(
+            "This project deploys the archiver store but declares no "
+            "`archiver.mongodb_archiver` connection block, so its history cannot be "
+            "seeded. The store still starts; archiver reads will find it empty."
+        )
+        return
+    if not store["password"]:
+        raise RuntimeError(
+            f"The archiver store's password variable {store['password_env']} is set "
+            f"neither in {project_dir / '.env'} nor in this environment, so the seeder "
+            "cannot authenticate against the store it is about to start."
+        )
+
+    knobs = SeedKnobs.from_config(config)
+    services = config.get("services") or {}
+    compression = str((services.get(_ARCHIVER_STORE_SERVICE) or {}).get("compression") or "zstd")
+
+    run_env = runtime_env(config, env)
+    base_cmd = get_runtime_command(config)
+    for compose_file in compose_files:
+        base_cmd.extend(("-f", compose_file))
+    base_cmd.extend(_env_file_args())
+
+    up_cmd = base_cmd + ["up", "-d", _ARCHIVER_STORE_SERVICE]
+    logger.info(f"Running command:\n    {' '.join(up_cmd)}")
+    subprocess.run(up_cmd, env=run_env, check=True)
+
+    # Assembled while the store boots, and before the health budget starts: this
+    # reads a manifest and a machine model off disk, and charging that time
+    # against the store's start-up allowance would make a slow disk look like an
+    # unreachable server.
+    channels, engine, boot_values = _archiver_seed_inputs(config, project_dir)
+    fingerprint = seed_fingerprint(
+        knobs, (str(channel["address"]) for channel in channels), compression=compression
+    )
+
+    store_hint = f"{store['username']}@{store['host']}:{store['port']}"
+    with archiver_collection(store) as collection:
+        _wait_for_archiver_store(
+            collection, time.monotonic() + _ARCHIVER_HEALTH_TIMEOUT_S, store_hint
+        )
+        comparison = compare_fingerprint(collection, fingerprint)
+
+        if comparison.state is SeedState.MATCH:
+            logger.key_info("Archive already covers the configured window; skipping the base seed")
+            return
+
+        if comparison.state is SeedState.MISMATCH:
+            logger.key_info("The archive's knobs changed since it was seeded:")
+            logger.key_info(comparison.describe())
+            if keep_base:
+                logger.warning(
+                    "Keeping the existing base (--keep-archiver-base). The stored history "
+                    "still describes the OLD knobs, so archiver reads will not match what "
+                    "this profile declares."
+                )
+                return
+            logger.key_info(
+                "Rebuilding the base series. Recorded history is discarded with it — the "
+                "recorder's samples share the collection being dropped. Pass "
+                "--keep-archiver-base to skip this."
+            )
+
+        if _ARCHIVER_RECORDER_DEPLOY_NAME in (config.get("deployed_services") or []):
+            stop_cmd = base_cmd + ["stop", _ARCHIVER_RECORDER_SERVICE]
+            logger.info(f"Running command:\n    {' '.join(stop_cmd)}")
+            quiesce = subprocess.run(stop_cmd, env=run_env)
+            # Not fatal — the rebuild is still the right thing to do — but a
+            # recorder that would not stop is writing into the collection about
+            # to be dropped, so the breach of the quiesce invariant has to be
+            # visible rather than swallowed by a return code nobody reads.
+            if quiesce.returncode != 0:
+                logger.warning(
+                    f"Could not stop `{_ARCHIVER_RECORDER_SERVICE}` (exit "
+                    f"{quiesce.returncode}). If it is still running it may write "
+                    "samples into the collection being rebuilt; check "
+                    "`osprey deploy status` if the reseeded archive looks wrong."
+                )
+
+        collection.drop()
+        logger.key_info(
+            f"Seeding {len(channels):,} channels over {knobs.retention_days} days "
+            f"({knobs.hot_span_hours}h at {knobs.hot_cadence_sec}s, then "
+            f"{knobs.tail_cadence_sec}s). This takes minutes on a first deploy."
+        )
+        report = seed_base(
+            collection,
+            channels,
+            knobs,
+            t0=datetime.now(UTC),
+            engine=engine,
+            boot_values=boot_values,
+            compression=compression,
+            progress=_seed_progress_reporter(),
+        )
+        logger.key_info(report.describe())
+
+    # Outside the store connection: re-applying opens its own, and holding this
+    # one across it would keep an idle client alive for the whole rewrite.
+    _reapply_active_scenarios(config, project_dir, engine)
+
+
+def deploy_up(
+    config_path,
+    detached=False,
+    dev_mode=False,
+    expose_network=False,
+    keep_archiver_base=False,
+):
     """Start services using container runtime (Docker or Podman).
 
     When ``modules.web_terminals.enabled`` is set, the web-terminal stack is
@@ -1686,14 +2218,22 @@ def deploy_up(config_path, detached=False, dev_mode=False, expose_network=False)
     :type dev_mode: bool
     :param expose_network: Expose services to all network interfaces (0.0.0.0)
     :type expose_network: bool
+    :param keep_archiver_base: Leave a mismatched archiver base in place instead
+        of rebuilding it (see :func:`_stage_archiver_store`)
+    :type keep_archiver_base: bool
     """
     config, compose_files = prepare_compose_files(config_path, dev_mode, expose_network)
+    project_dir = Path(config_path).resolve().parent
+
+    # Before every other check, and before any branch below has touched the
+    # host: a deployment whose archive is fabricated does not get to start.
+    _refuse_invented_history(config)
 
     # Advisory staleness check BEFORE anything deploys: a project rendered by
     # an older framework/preset self-describes an out-of-date service set in
     # config.yml, so the deploy below would "succeed" at the wrong goal with
     # no error anywhere. Never blocks (see warn_if_project_stale).
-    warn_if_project_stale(Path(config_path).resolve().parent)
+    warn_if_project_stale(project_dir)
 
     web_terminals_enabled = _web_terminals_enabled(config)
 
@@ -1737,6 +2277,12 @@ def deploy_up(config_path, detached=False, dev_mode=False, expose_network=False)
     # the appended tokens, and a tokens-only .env carries no provider secret to
     # mount in the first place.
     _ensure_service_tokens(config, expose_network)
+
+    # Fail fast on the optional dependency the staged archiver bring-up below
+    # cannot proceed without. Here, beside the mint that provisions the store's
+    # own credential, rather than at the seeder: a missing extra must abort in
+    # seconds, before the minutes-long image build, not after it.
+    _preflight_archiver_pymongo(config)
 
     # Advisory, after the write-back above has had its chance to put this
     # deploy's secrets in the profile: a service whose volume predates the
@@ -1784,6 +2330,13 @@ def deploy_up(config_path, detached=False, dev_mode=False, expose_network=False)
     # unless the worker is deployed on the local project image. Run before
     # `compose up` (which, non-detached, os.execvpe-replaces this process).
     _build_project_image(config, dev_mode, env)
+
+    # Stage the archiver store and seed its history BEFORE the branch split, so
+    # both deploy paths inherit it and the recorder — started by whichever `up`
+    # follows — finds a collection that already exists with the right indexes.
+    # No-op unless this project deploys the store itself.
+    if _archiver_store_deployed(config):
+        _stage_archiver_store(config, compose_files, env, project_dir, keep_base=keep_archiver_base)
 
     if web_terminals_enabled:
         deploy_up_web_terminals(config, compose_files, dev_mode, env, _env_file_args())
@@ -1919,6 +2472,11 @@ def deploy_restart(config_path, detached=False, expose_network=False):
     :type expose_network: bool
     """
     config, compose_files = prepare_compose_files(config_path, expose_network=expose_network)
+
+    # config.yml is bind-mounted, so a restart is how an edit takes effect —
+    # including an edit into the pairing deploy_up refuses. Same guard, same
+    # reason. (`rebuild_deployment` reaches it through deploy_up.)
+    _refuse_invented_history(config)
 
     # Verify container runtime is actually running
     is_running, error_msg = verify_runtime_is_running(config)

--- a/src/osprey/deployment/host_ports.py
+++ b/src/osprey/deployment/host_ports.py
@@ -38,6 +38,7 @@ logger = get_logger("deployment.host_ports")
 # catalog sidecar, whose host port lives under the bluesky service's config.
 _SERVICE_REMEDY_KEYS = {
     "postgresql": "services.postgresql.port_host",
+    "mongodb": "services.mongodb.port_host",
     "openobserve": "services.openobserve.port",
     "event-dispatcher": "services.event_dispatcher.port",
     "bluesky-bridge": "services.bluesky.port",

--- a/src/osprey/deployment/service_tokens.py
+++ b/src/osprey/deployment/service_tokens.py
@@ -90,6 +90,15 @@ _VAR_GENERATORS: dict[str, Callable[[], str]] = {
     # alphanumeric by construction and matches the Tiled recipe: same 256
     # bits of entropy, zero escaping concerns in .env, YAML, or the URI.
     "ARIEL_DB_PASSWORD": lambda: secrets.token_hex(32),
+    # The archiver Mongo root password follows the ARIEL_DB_PASSWORD rationale.
+    # The connector passes it to ``MongoClient`` as a keyword argument, where
+    # escaping would not matter — but it is not the only consumer: the recorder
+    # and the scenario seeder connect to the same store, the compose
+    # healthcheck reaches it through ``mongosh``, and any of those may spell the
+    # connection as a ``mongodb://user:pass@host`` URI. Hex is alphanumeric by
+    # construction, so every spelling is safe unescaped, with the same 256 bits
+    # of entropy as the default recipe.
+    "MONGO_ROOT_PASSWORD": lambda: secrets.token_hex(32),
 }
 
 
@@ -134,6 +143,21 @@ def _validate_ariel_dsn(value: str) -> bool:
     except UnicodeDecodeError:
         return False
     return True
+
+
+def _validate_uri_safe_password(value: str) -> bool:
+    """True if ``value`` can sit unescaped in a URI's password slot.
+
+    The password half of :func:`_validate_ariel_dsn`, applied to a bare secret
+    rather than to an assembled URI: a value carrying a URI-reserved character
+    (``@ : / ? #``) or whitespace reshapes any connection string it is
+    substituted into, silently and without a parse error. Shared by every
+    minted password that some consumer may spell as a URI, so the character
+    class is stated once — two copies of a rule this subtle drift apart.
+    """
+    if not value:
+        return False
+    return not any(c in value for c in "@:/?#") and not any(c.isspace() for c in value)
 
 
 def _validate_openobserve_password(value: str) -> bool:
@@ -188,9 +212,11 @@ _VAR_VALIDATORS: dict[str, Callable[[str], bool]] = {
     # operator-supplied value containing a URI-reserved character would
     # silently reshape the DSN (see _validate_ariel_dsn) — reject it at the
     # deploy boundary instead.
-    "ARIEL_DB_PASSWORD": lambda v: (
-        bool(v) and not any(c in v for c in "@:/?#") and not any(c.isspace() for c in v)
-    ),
+    "ARIEL_DB_PASSWORD": _validate_uri_safe_password,
+    # Same character rule, different consumer: the archiver Mongo password is
+    # read by the recorder, the seeder, and the agent's connector, at least one
+    # of which may assemble a mongodb:// URI around it.
+    "MONGO_ROOT_PASSWORD": _validate_uri_safe_password,
 }
 
 # Human-readable constraint text shown in the RuntimeError _ensure_service_tokens
@@ -212,6 +238,11 @@ _VAR_VALIDATOR_DESCRIPTIONS: dict[str, str] = {
     "ARIEL_DB_PASSWORD": (
         "must be non-empty with no whitespace and no URI-reserved character "
         "(@ : / ? #) — the value is substituted into the ariel DSN's password slot"
+    ),
+    "MONGO_ROOT_PASSWORD": (
+        "must be non-empty with no whitespace and no URI-reserved character "
+        "(@ : / ? #) — the archiver store's clients may spell the connection "
+        "as a mongodb:// URI carrying this value unescaped"
     ),
 }
 
@@ -240,12 +271,12 @@ def _validate_var(var: str, value: str) -> bool:
     Per-*format* constraints stay opt-in and fail-open, as ``_VAR_VALIDATORS``
     documents: a var absent from that dict still passes. Only the ``$`` rule is
     unconditional, because it is a property of how compose loads the file rather
-    than of what any one service accepts. The three registered validators that
-    reason about character safety — ``_validate_ariel_dsn`` and the
-    ``ARIEL_DB_PASSWORD`` lambda, which reject the URI-reserved ``@:/?#``, and
+    than of what any one service accepts. The registered validators that
+    reason about character safety — ``_validate_ariel_dsn`` and
+    ``_validate_uri_safe_password``, which reject the URI-reserved ``@:/?#``, and
     ``_validate_openobserve_password``, whose "at least one special character"
     requirement a ``$`` actively *satisfied* — all admitted ``$`` on their own.
-    Layering it here fixes those three and every var added later in one place.
+    Layering it here fixes all of them and every var added later in one place.
     """
     if "$" in value:
         return False

--- a/src/osprey/mcp_server/control_system/server_context.py
+++ b/src/osprey/mcp_server/control_system/server_context.py
@@ -23,6 +23,7 @@ from typing import Any
 
 from osprey.connectors.archiver.base import ArchiverConnector
 from osprey.connectors.control_system.base import ControlSystemConnector
+from osprey.errors import ConfigurationError
 
 logger = logging.getLogger("osprey.mcp_server.control_system.server_context")
 
@@ -114,7 +115,9 @@ class ControlSystemContext:
             connector_type="archiver",
         )
 
-        # 4. Validate config (warnings, not fatal)
+        # 4. Validate config: warnings for the misconfigurations a tool can
+        #    still work around, and one hard refusal for the pairing no tool can
+        #    (see _validate).
         self._validate()
 
         self._initialized = True
@@ -210,7 +213,25 @@ class ControlSystemContext:
         register_builtin_connectors()
 
     def _validate(self) -> None:
-        """Emit warnings for common misconfigurations."""
+        """Warn about common misconfigurations, and refuse the one that lies.
+
+        Warnings for the rest: an unknown connector type still produces a server
+        whose other tools work, and a missing section is often a project mid-edit.
+
+        The exception is a virtual accelerator paired with the mock archiver.
+        Every tool in this server would answer, and the archiver's answers would
+        be invented — so the failure is not visible in any single call, only in
+        the agent's account of a machine it is also reading live. This is the
+        honesty rule's runtime site: it catches a ``config.yml`` hand-edited into
+        the pairing long after the build refused to write it.
+
+        Raises:
+            ConfigurationError: If ``config.yml`` pairs a virtual accelerator
+                with the mock archiver (an unset ``archiver.type`` included —
+                the factory resolves it to the mock).
+        """
+        self._refuse_invented_history()
+
         from osprey.connectors.factory import ConnectorFactory
 
         cs = self.config.control_system
@@ -230,6 +251,36 @@ class ControlSystemContext:
             known_arch = set(ConnectorFactory.list_archivers())
             if arch_type and arch_type not in known_arch and "." not in arch_type:
                 logger.warning("Unknown archiver.type: %s (registered: %s)", arch_type, known_arch)
+
+    def _refuse_invented_history(self) -> None:
+        """Abort startup on a virtual accelerator with a synthesizing archiver.
+
+        Judged by :func:`~osprey.connectors.honesty.pairing_in_rendered_config`,
+        which resolves both keys through *nested sections only* — exactly as
+        :attr:`MCPServerConfig.control_system` and :attr:`MCPServerConfig.archiver`
+        do a few lines above, and exactly as the factory then reads what they
+        hand it. A guard that resolved a config differently from the reader it
+        guards would not be a guard; the divergence would be the way through.
+        """
+        from osprey.connectors.honesty import VA_MOCK_ARCHIVER_WHY, pairing_in_rendered_config
+        from osprey.connectors.types import MOCK, MONGODB_ARCHIVER, VIRTUAL_ACCELERATOR
+
+        pairing = pairing_in_rendered_config(self.config.raw)
+        if not pairing.is_invented_history:
+            return
+
+        raise ConfigurationError(
+            f"Refusing to start: {self.config.config_path} pairs control_system.type "
+            f"{VIRTUAL_ACCELERATOR!r} with archiver.type "
+            f"{pairing.archiver_phrase} — {VA_MOCK_ARCHIVER_WHY} "
+            f"Under this file's `archiver:` section, set `type:` to a connector that "
+            f"reads a store this deployment actually writes (a project built from the "
+            f"control-assistant preset deploys one, and its type reads "
+            f"{MONGODB_ARCHIVER!r}); or, if this deployment is meant to be a "
+            f"simulation nothing is real in, set the `type:` under `control_system:` "
+            f"to {MOCK!r} — a mock machine with a mock archive claims nothing it "
+            f"cannot back up."
+        )
 
     async def shutdown(self) -> None:
         """Disconnect all connectors. Called on server shutdown."""

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -27,6 +27,14 @@ model: haiku   # tier (haiku/sonnet/opus), or a model ID the provider serves
 # Channel-finder pipeline. Override via --set channel_finder_mode=in_context|middle_layer.
 channel_finder_mode: hierarchical
 
+# Extra packages the built project's environment needs. pymongo is what the
+# archiver connector, the deploy-time seeder and the recorder all read the store
+# through; the tutorial declares a `va_archiver:` block below, so without it the
+# staged bring-up aborts at its pymongo preflight before any image is built.
+# Matches the pin the `archiver-mongodb` extra carries in pyproject.toml.
+dependencies:
+  - pymongo>=4.0
+
 # ── Artifact selection ───────────────────────────────────────────────────────
 # Each list entry is a short name resolved from the osprey artifact library.
 # Remove entries you do not need; add facility-specific artifacts via overlay.
@@ -111,6 +119,52 @@ virtual_accelerator:
 bluesky_panels:
   port: 8095
 
+# ── Stored archive (MongoDB) ─────────────────────────────────────────────────
+# Declaring this block is what gives the tutorial a REAL archive: `osprey deploy
+# up` stands up a MongoDB store and an archiver-recorder beside the VA, seeds the
+# store with history on the first deploy, and records the machine from then on.
+# Without it the agent's history is synthesized at read time — plausible numbers
+# for questions nobody recorded the answer to.
+#
+# The block is the single home for the archive's coordinates: the build derives
+# the connector's eight `archiver.mongodb_archiver.*` keys AND the shape knobs
+# below from it, and REFUSES a profile that also spells them in `config:` (one
+# fact, two homes, free to disagree). Selecting the archiver is a separate
+# decision and lives in `config:` as `archiver.type` — see the note there.
+#
+# Every key is optional; these are the shipped defaults, stated so the tutorial
+# documents the shape it deploys rather than hiding it in a dataclass.
+va_archiver:
+  # Where the agent reaches the store. Stated rather than left to the deploy to
+  # infer, because a profile resolved WITHOUT a service stack — a persona delta,
+  # an attached project, any of the resolution paths that carry no
+  # deploy_services — is required to name the host whose archive it reads, and
+  # would otherwise fail to resolve at all. `localhost` is the host side of the
+  # published `port_host`, which is where this project's own store answers;
+  # point it at the real host when attaching to someone else's.
+  host: localhost
+  retention_days: 30       # how far back the archive reaches
+  hot_span_hours: 48       # how much of it is kept at the dense cadence
+  hot_cadence_sec: 10      # seconds between samples inside the hot span
+  tail_cadence_sec: 60     # and outside it (must be a whole multiple of the above)
+  # How often the recorder samples the running machine. Stated because the
+  # freshness threshold below is derived from it: leaving it to the dataclass
+  # default would hide the one number that decides when this deployment calls
+  # its own archive stale.
+  recorder_cadence_sec: 10
+  # The channel `osprey health` reads to tell a REACHABLE archive from one still
+  # being WRITTEN — a wedged recorder leaves the store answering queries while
+  # history quietly stops, and only the age of the newest sample separates the
+  # two. Naming it here derives the whole `archiver_freshness` check, threshold
+  # included: that follows `recorder_cadence_sec` above, so slowing the recorder
+  # cannot leave a stale threshold behind.
+  #
+  # The stored-beam DCCT current is this simulated facility's canary, for the
+  # reason a real control room would pick it: it is the first thing to stop
+  # moving when the machine does. Point it at your own equivalent when you take
+  # this preset to hardware; drop the key and no check is derived.
+  freshness_channel: SR:DIAG:DCCT:01:CURRENT:RB
+
 # ── Config overrides ─────────────────────────────────────────────────────────
 # These key.path entries are written into config.yml after the template renders.
 # Uncomment and set values appropriate for your facility.
@@ -124,6 +178,17 @@ config:
   # scans are browse-only (a settle-verified run never COMPLETEs on mock) —
   # flip back with `osprey config set-control-system mock`.
   control_system.type: virtual_accelerator
+  # Selects the archive declared by the `va_archiver:` block above as the
+  # deployment's archiver. This is a SEPARATE decision from declaring where the
+  # archive lives, and deliberately so: the block never flips `archiver.type`
+  # out from under a facility that set it. A project that declared the block but
+  # left this alone would deploy a store and then read the mock beside it.
+  #
+  # Dotted, like every key here. A nested `archiver:` mapping would prefix
+  # -collapse; and spelling any `archiver.mongodb_archiver.*` key here is
+  # refused outright while the block is present, because the build already
+  # derives those from it.
+  archiver.type: mongodb_archiver
   # The Bluesky MCP server is off-by-default in the framework registry
   # (default_enabled=False); opt in here so the tutorial's agent can author
   # and launch scan plans out of the box.

--- a/src/osprey/services/archiver_recorder/__init__.py
+++ b/src/osprey/services/archiver_recorder/__init__.py
@@ -1,0 +1,53 @@
+"""The archiver recorder: the live half of a deployment's stored history.
+
+A deployed OSPREY project's archive has two authors. The base seeder writes a
+deterministic synthesized history once per deploy, so the archive reaches back
+before the machine was switched on. This service writes what happened *after*
+that: it reads the running control system over Channel Access on a fixed
+cadence and stores each reading in the same collection, on the same timeline,
+in the same ``{date, <PV>: value}`` documents. There is one store and one
+timeline — a reader cannot tell seeded history from recorded history except by
+the one thing that should distinguish them, which is when it happened.
+
+It records **only** while ``control_system.type`` is ``virtual_accelerator``,
+and re-reads that setting from the mounted config on an interval rather than
+latching it at startup, so the documented post-build flip takes effect without
+restarting the service. On any other control system it idles: a real machine's
+readings do not belong in an archive whose earlier half is synthesized, and a
+mock control system has nothing worth recording.
+
+Storage stays bounded without ever losing the recorded record, via the two
+expiry tiers :func:`~osprey.services.archiver_recorder.store.expiry_for`
+assigns. Every sample is kept for the hot span; the samples that land on the
+tail grid are kept for the full retention window. Recorded reality therefore
+thins out as it ages instead of vanishing, and it thins to exactly the cadence
+the seeded tail already uses, so there is no visible seam at the point where
+the dense copy expires.
+
+The service ships as a compose template only — it runs the virtual
+accelerator's image with a different command, so it adds no image build to any
+deploy. Its knobs come from the profile's ``va_archiver:`` block through the
+rendered ``config.yml``; nothing here carries a cadence or retention constant.
+"""
+
+from .config import (
+    RecorderConfigError,
+    RecorderSettings,
+    load_settings,
+    read_control_system_type,
+    resolve_channel_addresses,
+)
+from .recorder import RECORDING_CONTROL_SYSTEM, Recorder
+from .store import ArchiveWriter, expiry_for
+
+__all__ = [
+    "RECORDING_CONTROL_SYSTEM",
+    "ArchiveWriter",
+    "Recorder",
+    "RecorderConfigError",
+    "RecorderSettings",
+    "expiry_for",
+    "load_settings",
+    "read_control_system_type",
+    "resolve_channel_addresses",
+]

--- a/src/osprey/services/archiver_recorder/__main__.py
+++ b/src/osprey/services/archiver_recorder/__main__.py
@@ -1,0 +1,94 @@
+"""Container entry point: ``python -m osprey.services.archiver_recorder``.
+
+Startup is deliberately fail-fast. Everything the recorder cannot invent — the
+config, the store, the credential, the channel list — is resolved here, before
+the loop begins, so a misconfigured deployment says so in ``docker logs``
+within seconds instead of running as a service that quietly writes nothing.
+
+What is NOT fatal here is the control system being something other than the one
+recorded: that is the ordinary state of a mock deployment, and the service is
+supposed to sit there idling until someone flips it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+import sys
+from pathlib import Path
+
+from osprey.utils.logger import configure_logging
+
+from .config import RecorderConfigError, load_settings, resolve_channel_addresses
+from .recorder import Recorder
+from .store import ArchiveWriter
+
+logger = logging.getLogger(__name__)
+
+#: Same convention as the dispatch worker and the bluesky bridge: the working
+#: directory inside the image is not the project, so the config is named
+#: explicitly and mounted.
+DEFAULT_CONFIG_FILE = "/app/project/config.yml"
+
+
+async def _run(recorder: Recorder) -> None:
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        # `docker stop` sends SIGTERM; without this the process dies where it
+        # stands, mid-write. Asking the loop to stop instead lets the current
+        # sample finish and the client close cleanly.
+        loop.add_signal_handler(sig, recorder.stop)
+    await recorder.run_forever()
+
+
+def main() -> int:
+    configure_logging()
+
+    config_path = Path(os.environ.get("CONFIG_FILE", DEFAULT_CONFIG_FILE))
+    try:
+        settings = load_settings(config_path)
+        addresses = resolve_channel_addresses()
+    except RecorderConfigError as exc:
+        logger.error("FATAL: %s", exc)
+        return 1
+
+    password = os.environ.get(settings.password_env, "")
+    if not password:
+        logger.error(
+            "FATAL: %s is unset, so there is no credential for the archive store. "
+            "`osprey deploy up` mints it into the project .env; deploy through it "
+            "rather than running compose directly.",
+            settings.password_env,
+        )
+        return 1
+
+    writer = ArchiveWriter(settings, password)
+    try:
+        writer.connect()
+    except ConnectionError as exc:
+        logger.error("FATAL: %s", exc)
+        return 1
+
+    recorder = Recorder(
+        settings=settings,
+        addresses=addresses,
+        writer=writer,
+        config_path=config_path,
+    )
+    logger.info(
+        "Archiver recorder started: %d channels available, enablement re-read from %s every %ds.",
+        len(addresses),
+        config_path,
+        settings.poll_sec,
+    )
+    try:
+        asyncio.run(_run(recorder))
+    finally:
+        writer.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/osprey/services/archiver_recorder/config.py
+++ b/src/osprey/services/archiver_recorder/config.py
@@ -1,0 +1,268 @@
+"""What the recorder reads out of a deployment's rendered ``config.yml``.
+
+Two blocks, both written by the profile's ``va_archiver:`` block (see
+``osprey/cli/build_profile_archiver.py``) and neither duplicated here:
+
+* ``archiver.mongodb_archiver.*`` — where the store is and how to authenticate,
+  the same keys ``MongoDBArchiverConnector`` reads, so the writer and the reader
+  cannot end up pointed at different collections.
+* ``va_archiver.*`` — the cadences and retention spans that decide the shape of
+  what gets written.
+
+Nothing in this package carries a default for either. A missing key is an
+error naming the key, not a silent fallback: a recorder that invented its own
+cadence would write an archive whose density disagreed with the seeded half of
+the very same collection, and nothing downstream would notice.
+
+One value here does not come from the file: the store's address. The rendered
+connection block is written for the HOST side — the agent runs there and reaches
+the store on loopback at its published port — which inside the compose network
+names this container's own loopback. The compose template hands the container
+the store's network alias and container port instead, and those win.
+
+That override is NOT defined here. It is read through
+``MongoDBArchiverConnector``'s :func:`~osprey.connectors.archiver.mongodb_archiver_connector.address_overrides`,
+where the contract is stated, so this service and the agent's connector cannot
+drift apart on the variable names, on what an empty value means, or on how the
+port is typed. Two readers of one convention have to agree on its edges.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from osprey.connectors.archiver.mongodb_archiver_connector import address_overrides
+
+#: Where the compose template mounts the project's ``data/simulation`` tree,
+#: matching the virtual accelerator's own mount so a relative
+#: ``VA_CHANNELS_FILE`` resolves to the same file on both sides.
+DEFAULT_DATA_DIR = "/data/simulation"
+
+#: Rendered-config subtree holding the connection keys (mirrors
+#: ``build_profile_archiver.CONNECTION_CONFIG_PREFIX``).
+_CONNECTION_PREFIX = ("archiver", "mongodb_archiver")
+
+#: Rendered-config subtree holding the archive-shape knobs (mirrors
+#: ``build_profile_archiver.KNOBS_CONFIG_PREFIX``).
+_KNOBS_PREFIX = ("va_archiver",)
+
+
+class RecorderConfigError(RuntimeError):
+    """The deployment's config cannot back a recorder.
+
+    Raised only from startup paths. Once the recorder is running, a config that
+    goes unreadable is a torn read to be waited out, not a reason to stop
+    recording — see :func:`read_control_system_type`.
+    """
+
+
+@dataclass(frozen=True)
+class RecorderSettings:
+    """Everything the recorder needs, resolved once at startup.
+
+    Deliberately not re-read on the poll interval: a cadence or retention
+    change alters the shape of the archive, so it goes through the seeder's
+    fingerprint check and a redeploy, which restarts this service anyway. The
+    one setting that IS re-read is ``control_system.type``, which changes only
+    who is being recorded, not what the record looks like.
+    """
+
+    host: str
+    port: int
+    database: str
+    collection: str
+    auth_database: str
+    username: str
+    password_env: str
+    timeout_sec: int
+    cadence_sec: int
+    tail_cadence_sec: int
+    poll_sec: int
+    hot_span_hours: int
+    retention_days: int
+
+
+def load_settings(config_path: Path) -> RecorderSettings:
+    """Resolve :class:`RecorderSettings` from a rendered ``config.yml``.
+
+    Raises:
+        RecorderConfigError: if the file is unreadable, is not a mapping, or is
+            missing a key the recorder has no honest default for. The message
+            names the key and the block it belongs to, because the fix is
+            always a profile edit and a rebuild.
+    """
+    config = _load_mapping(config_path)
+    connection = _subtree(config, _CONNECTION_PREFIX, config_path)
+    knobs = _subtree(config, _KNOBS_PREFIX, config_path)
+
+    # The in-network address override, read through the connector's own helper
+    # so this service and the agent's connector cannot come to differ on what an
+    # empty value means or on how the port is typed — one convention, one reader.
+    override_host, override_port = address_overrides()
+
+    host = override_host or _require(connection, "host", _CONNECTION_PREFIX, config_path)
+    port = (
+        override_port
+        if override_port is not None
+        else _as_int(
+            _require(connection, "port", _CONNECTION_PREFIX, config_path),
+            "port",
+            _CONNECTION_PREFIX,
+            config_path,
+        )
+    )
+
+    return RecorderSettings(
+        host=str(host),
+        port=port,
+        database=str(_require(connection, "name", _CONNECTION_PREFIX, config_path)),
+        collection=str(_require(connection, "collection", _CONNECTION_PREFIX, config_path)),
+        auth_database=str(_require(connection, "auth", _CONNECTION_PREFIX, config_path)),
+        username=str(_require(connection, "username", _CONNECTION_PREFIX, config_path)),
+        password_env=str(_require(connection, "password_env", _CONNECTION_PREFIX, config_path)),
+        timeout_sec=_int_key(connection, "timeout", _CONNECTION_PREFIX, config_path),
+        cadence_sec=_int_key(knobs, "recorder_cadence_sec", _KNOBS_PREFIX, config_path),
+        tail_cadence_sec=_int_key(knobs, "recorder_tail_cadence_sec", _KNOBS_PREFIX, config_path),
+        poll_sec=_int_key(knobs, "recorder_poll_sec", _KNOBS_PREFIX, config_path),
+        hot_span_hours=_int_key(knobs, "hot_span_hours", _KNOBS_PREFIX, config_path),
+        retention_days=_int_key(knobs, "retention_days", _KNOBS_PREFIX, config_path),
+    )
+
+
+def read_control_system_type(config_path: Path) -> str:
+    """Read ``control_system.type`` from the mounted config, right now.
+
+    This is the enablement question, asked again on every poll rather than
+    answered once at startup, because flipping ``control_system.type`` is a
+    documented post-build step and it must not need a redeploy to take effect.
+
+    Raises:
+        RecorderConfigError: if the file cannot be read or parsed *at this
+            moment*. Callers keep their last known answer instead of acting on
+            it: config writes are truncate-in-place, not atomic, so a poll that
+            lands mid-write sees a torn file — and treating that as "the
+            control system changed" would stop and restart recording on a file
+            write that changed nothing.
+    """
+    config = _load_mapping(config_path)
+    control_system = config.get("control_system")
+    if not isinstance(control_system, dict):
+        raise RecorderConfigError(
+            f"{config_path} has no `control_system:` block; cannot tell what is being recorded"
+        )
+    return str(control_system.get("type", "")).strip()
+
+
+def resolve_channel_addresses(data_dir: Path | None = None) -> list[str]:
+    """The addresses to record, in the order the channel source lists them.
+
+    The source is the build-generated channel MANIFEST, named by
+    ``VA_CHANNELS_FILE`` exactly as the virtual accelerator reads it, so the
+    recorder covers precisely the channels the IOC serves. Unset or empty means
+    the image's built-in manifest, again matching the IOC.
+
+    It must never be ``channel_limits.json``. That file is a *write-safety
+    projection* of the same manifest rather than a second copy of it: it holds
+    one entry per address, read-only ones included, alongside top-level metadata
+    keys (``_comment``, ``_version``, ``_description``, ``defaults``). Its key
+    set is therefore not a channel list, and recording from it would ask the
+    IOC for names that are not channels at all. The manifest is the one source
+    the IOC and this service share; reading anything else makes a second source
+    that is free to drift from what is actually being served.
+
+    Raises:
+        RecorderConfigError: if the named manifest cannot be loaded. A recorder
+            that fell back to the built-in channel set here would record
+            another facility's namespace into this facility's archive.
+    """
+    root = Path(data_dir) if data_dir is not None else Path(DEFAULT_DATA_DIR)
+    raw = os.environ.get("VA_CHANNELS_FILE", "").strip()
+
+    # Imported here rather than at module scope: the manifest package pulls in
+    # the channel-database parsers, which a config-only caller has no use for.
+    from osprey.services.virtual_accelerator.manifest import build_manifest
+    from osprey.services.virtual_accelerator.manifest.loaders import (
+        ManifestFileError,
+        load_manifest_file,
+    )
+
+    if not raw:
+        channels = build_manifest()["channels"]
+    else:
+        path = Path(raw)
+        if not path.is_absolute():
+            path = root / path
+        try:
+            channels = load_manifest_file(path)
+        except (ManifestFileError, json.JSONDecodeError, OSError) as exc:
+            raise RecorderConfigError(
+                f"cannot record: the channel manifest named by VA_CHANNELS_FILE ({path}) "
+                f"could not be loaded: {exc}"
+            ) from exc
+
+    return [str(channel["address"]) for channel in channels]
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _load_mapping(config_path: Path) -> dict[str, Any]:
+    try:
+        raw = yaml.safe_load(Path(config_path).read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise RecorderConfigError(f"cannot read {config_path}: {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise RecorderConfigError(f"{config_path} is not valid YAML: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise RecorderConfigError(f"{config_path} does not contain a YAML mapping")
+    return raw
+
+
+def _subtree(config: dict[str, Any], prefix: tuple[str, ...], config_path: Path) -> dict[str, Any]:
+    node: Any = config
+    for key in prefix:
+        node = node.get(key) if isinstance(node, dict) else None
+        if node is None:
+            raise RecorderConfigError(
+                f"{config_path} has no `{'.'.join(prefix)}:` block. The recorder reads its "
+                f"store and its cadences from the profile's `va_archiver:` block; a project "
+                f"without one has no archive to record into."
+            )
+    if not isinstance(node, dict):
+        raise RecorderConfigError(f"{config_path}: `{'.'.join(prefix)}` is not a mapping")
+    return node
+
+
+def _require(block: dict[str, Any], key: str, prefix: tuple[str, ...], config_path: Path) -> Any:
+    value = block.get(key)
+    if value is None or (isinstance(value, str) and not value.strip()):
+        raise RecorderConfigError(
+            f"{config_path}: `{'.'.join((*prefix, key))}` is missing or empty"
+        )
+    return value
+
+
+def _int_key(block: dict[str, Any], key: str, prefix: tuple[str, ...], config_path: Path) -> int:
+    return _as_int(_require(block, key, prefix, config_path), key, prefix, config_path)
+
+
+def _as_int(value: Any, key: str, prefix: tuple[str, ...], config_path: Path) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise RecorderConfigError(
+            f"{config_path}: `{'.'.join((*prefix, key))}` must be an integer, got {value!r}"
+        ) from exc
+    if parsed <= 0:
+        raise RecorderConfigError(
+            f"{config_path}: `{'.'.join((*prefix, key))}` must be positive, got {parsed}"
+        )
+    return parsed

--- a/src/osprey/services/archiver_recorder/recorder.py
+++ b/src/osprey/services/archiver_recorder/recorder.py
@@ -1,0 +1,241 @@
+"""The recording loop: sample the machine on a grid, store what answered.
+
+Three behaviours here are load-bearing and each has a quiet failure mode it is
+written to avoid:
+
+* **Sampling lands on an absolute grid.** Timestamps are floored to a multiple
+  of the sample cadence since the epoch, not spaced from whenever the process
+  started. That is what puts recorded documents on the same instants the seeder
+  used, which is in turn what lets the scenario seeder rewrite an event window
+  across the seam without leaving two interleaved grids behind.
+* **A channel that did not answer contributes nothing.** No last-known value is
+  carried forward and no placeholder is written. A gap in the archive is the
+  honest record of a channel that was not answering, and it is the only record
+  that lets anyone later tell a quiet channel from an absent one.
+* **Enablement is polled, and a torn read changes nothing.** Config writes are
+  truncate-in-place rather than atomic, so a poll can land mid-write and see a
+  half file. Treating that as an answer would stop and restart recording on a
+  write that changed nothing at all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+
+from .config import RecorderConfigError, RecorderSettings, read_control_system_type
+from .store import ArchiveWriter
+
+logger = logging.getLogger(__name__)
+
+#: The one control system whose readings belong in this archive. A simulated
+#: machine's history is synthesized for the past and recorded for the present,
+#: and the two halves are the same kind of thing. A real machine's readings are
+#: not: splicing them onto a synthesized past would produce exactly the
+#: two-world archive this service exists to prevent.
+RECORDING_CONTROL_SYSTEM = "virtual_accelerator"
+
+#: Reads a set of addresses and returns the ones that answered.
+ChannelReader = Callable[[Sequence[str]], Awaitable[Mapping[str, float]]]
+
+
+class Recorder:
+    """Samples the control system into the archive for as long as it runs."""
+
+    def __init__(
+        self,
+        *,
+        settings: RecorderSettings,
+        addresses: Sequence[str],
+        writer: ArchiveWriter,
+        config_path: Path,
+        reader: ChannelReader | None = None,
+        recording: bool = False,
+    ) -> None:
+        self._settings = settings
+        self._addresses = list(addresses)
+        self._writer = writer
+        self._config_path = Path(config_path)
+        self._reader = reader if reader is not None else channel_access_reader(settings)
+        self._recording = recording
+        self._announced = False
+        self._last_slot: int | None = None
+        self._last_poll: float | None = None
+        self._non_numeric: set[str] = set()
+        self._stop = asyncio.Event()
+
+    @property
+    def recording(self) -> bool:
+        """Whether the last enablement answer said to record."""
+        return self._recording
+
+    def refresh_enablement(self, now: datetime) -> bool:
+        """Re-read ``control_system.type`` if the poll interval has elapsed.
+
+        Returns the enablement state in force after this call — unchanged when
+        the interval has not elapsed yet, and unchanged when the read failed.
+        State transitions log one line each; steady state logs nothing, so a
+        recorder idling for a week does not fill the logs saying so.
+        """
+        stamp = now.timestamp()
+        if self._last_poll is not None and stamp - self._last_poll < self._settings.poll_sec:
+            return self._recording
+        self._last_poll = stamp
+
+        try:
+            control_system = read_control_system_type(self._config_path)
+        except RecorderConfigError as exc:
+            # Keep the last known answer. See the module docstring: this is
+            # very likely a config write in progress, and the next poll will
+            # read the finished file.
+            logger.debug("enablement poll could not read the config, keeping last state: %s", exc)
+            return self._recording
+
+        should_record = control_system == RECORDING_CONTROL_SYSTEM
+        if should_record != self._recording or not self._announced:
+            if should_record:
+                logger.info(
+                    "Recording %d channels every %ds into %s.%s (control_system.type=%s).",
+                    len(self._addresses),
+                    self._settings.cadence_sec,
+                    self._settings.database,
+                    self._settings.collection,
+                    control_system,
+                )
+            else:
+                logger.info(
+                    "Idle, writing nothing: control_system.type=%s, and only %s is recorded. "
+                    "Flipping it in %s takes effect within %ds — no restart needed.",
+                    control_system or "<unset>",
+                    RECORDING_CONTROL_SYSTEM,
+                    self._config_path,
+                    self._settings.poll_sec,
+                )
+            self._recording = should_record
+            self._announced = True
+        return self._recording
+
+    def slot_for(self, now: datetime) -> int:
+        """The absolute grid instant, in whole seconds, that ``now`` falls in."""
+        cadence = self._settings.cadence_sec
+        return int(now.timestamp()) // cadence * cadence
+
+    async def tick(self, now: datetime) -> bool:
+        """Run one iteration: poll enablement, and record the current slot.
+
+        Returns True if a document was written. A slot already recorded is
+        skipped rather than written twice, so a restart mid-interval cannot
+        double-write the instant the previous run just covered.
+        """
+        if not self.refresh_enablement(now):
+            return False
+
+        slot = self.slot_for(now)
+        if slot == self._last_slot:
+            return False
+
+        values = await self._read_channels()
+        if not values:
+            logger.warning(
+                "No channel answered at %s; writing nothing for this sample. "
+                "A gap here is the honest record of an unreachable control system.",
+                datetime.fromtimestamp(slot, tz=UTC).isoformat(),
+            )
+            self._last_slot = slot
+            return False
+
+        timestamp = datetime.fromtimestamp(slot, tz=UTC)
+        try:
+            await asyncio.to_thread(self._writer.write_sample, timestamp, values)
+        except Exception as exc:  # noqa: BLE001 — see below
+            # Never let one failed write end the loop. The store may be
+            # restarting, and the next tick is seconds away; a crash here would
+            # instead take the Channel Access channel cache down with it and
+            # reconnect every channel from scratch.
+            logger.warning("Failed to store the sample at %s: %s", timestamp.isoformat(), exc)
+            self._last_slot = slot
+            return False
+
+        self._last_slot = slot
+        logger.debug("Stored %d channel values at %s", len(values), timestamp.isoformat())
+        return True
+
+    async def run_forever(self) -> None:
+        """Tick on the sample grid until :meth:`stop` is called.
+
+        Sleeps to the next grid boundary rather than a fixed interval, so
+        samples stay on the absolute grid however long a tick took.
+        """
+        while not self._stop.is_set():
+            await self.tick(datetime.now(tz=UTC))
+            delay = self._seconds_to_next_slot(datetime.now(tz=UTC))
+            try:
+                await asyncio.wait_for(self._stop.wait(), timeout=delay)
+            except TimeoutError:
+                continue
+
+    def stop(self) -> None:
+        """Ask :meth:`run_forever` to return at the next opportunity."""
+        self._stop.set()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _seconds_to_next_slot(self, now: datetime) -> float:
+        cadence = self._settings.cadence_sec
+        elapsed = now.timestamp() % cadence
+        return cadence - elapsed
+
+    async def _read_channels(self) -> dict[str, float]:
+        raw = await self._reader(self._addresses)
+        values: dict[str, float] = {}
+        for address, value in raw.items():
+            try:
+                values[address] = float(value)
+            except (TypeError, ValueError):
+                # The archive schema is one number per channel per instant.
+                # A channel that is not a number (a string status, a waveform)
+                # has no place in it — said once per address, because saying it
+                # every cadence would bury everything else.
+                if address not in self._non_numeric:
+                    self._non_numeric.add(address)
+                    logger.warning(
+                        "Channel %s returned a non-numeric value (%r); it will not be recorded.",
+                        address,
+                        value,
+                    )
+        return values
+
+
+def channel_access_reader(settings: RecorderSettings) -> ChannelReader:
+    """The production reader: one long-lived Channel Access client.
+
+    ``aioca`` caches its channels across calls, so the connection cost is paid
+    once and every later sample reuses it — and its reconnection is what makes
+    this service survive an IOC restart without any logic here: the channels go
+    disconnected, those reads fail (contributing nothing), and they resume
+    answering once the IOC is back.
+
+    Failed reads come back as falsy ``CANothing`` sentinels rather than
+    exceptions, which is why ``throw=False`` is safe: one unreachable channel
+    must not cost the whole sample.
+    """
+
+    async def read(addresses: Sequence[str]) -> Mapping[str, float]:
+        from aioca import caget
+
+        # Bounded by the sample cadence: a read still outstanding when the next
+        # sample is due has already missed its slot, and waiting longer would
+        # only push every later sample off the grid.
+        results = await caget(list(addresses), timeout=settings.cadence_sec, throw=False)
+        return {
+            address: value
+            for address, value in zip(addresses, results, strict=True)
+            if getattr(value, "ok", True)
+        }
+
+    return read

--- a/src/osprey/services/archiver_recorder/store.py
+++ b/src/osprey/services/archiver_recorder/store.py
@@ -1,0 +1,142 @@
+"""Writing samples into the archive collection.
+
+The document shape is not this module's invention: it is the one
+``MongoDBArchiverConnector`` reads — one document per timestamp, ``date`` plus
+a field per PV, and a PV absent from a document simply contributes no sample
+for that channel. Writing anything else here would produce an archive the
+product cannot read.
+
+The one field the reader never sees is ``expireAt``, the per-document TTL
+stamp. Retention is expressed per document rather than per collection because
+the archive holds three kinds of history with three different lifetimes: dense
+recent samples, coarse older ones, and scenario event windows that must not
+expire at all. A collection-wide TTL could only express one of those. The TTL
+index itself (``expireAfterSeconds=0`` on ``expireAt``) is created by the base
+seeder during the staged bring-up, before this service starts — and a document
+with no ``expireAt`` never expires under it, which is exactly how the seeder
+protects an event window.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from datetime import datetime, timedelta
+from typing import Any
+
+from .config import RecorderSettings
+
+logger = logging.getLogger(__name__)
+
+
+def expiry_for(timestamp: datetime, settings: RecorderSettings) -> datetime:
+    """When the sample taken at ``timestamp`` should expire.
+
+    Two tiers, decided by the timestamp alone. A sample that lands on the tail
+    grid — an exact multiple of ``recorder_tail_cadence_sec`` since the epoch —
+    is kept for the full retention span; every other sample is kept for the hot
+    span only.
+
+    That single rule is what keeps steady-state storage bounded without ever
+    losing the recorded record. As the dense copy of a stretch of history ages
+    past the hot span, what survives is one sample per tail interval — the same
+    density the seeder already used for history of that age, so the archive
+    thins out uniformly instead of ending abruptly at the point where recording
+    began.
+
+    Because the grid is absolute (multiples since the epoch, not since this
+    process started), a restart lands on the same instants the previous run
+    did, and on the same instants the seeder used.
+    """
+    on_tail_grid = int(timestamp.timestamp()) % settings.tail_cadence_sec == 0
+    span = (
+        timedelta(days=settings.retention_days)
+        if on_tail_grid
+        else timedelta(hours=settings.hot_span_hours)
+    )
+    return timestamp + span
+
+
+class ArchiveWriter:
+    """A live connection to the archive collection, held open for the process.
+
+    Deliberately synchronous: pymongo's own client is, the recorder writes once
+    per cadence rather than continuously, and the caller runs the write off the
+    event loop.
+    """
+
+    def __init__(self, settings: RecorderSettings, password: str) -> None:
+        self._settings = settings
+        self._password = password
+        # Untyped because pymongo is imported inside connect(): the module has
+        # to stay importable wherever the optional extra is absent.
+        self._client: Any = None
+        self._collection: Any = None
+
+    def connect(self) -> None:
+        """Open the connection and prove the server answers.
+
+        Raises:
+            ConnectionError: if the store cannot be reached or authenticated.
+                Fatal at startup — a recorder that cannot write is not degraded,
+                it is pointless, and failing loudly is what puts the cause in
+                ``docker logs`` instead of leaving a silently empty archive.
+        """
+        from pymongo import MongoClient
+        from pymongo.errors import PyMongoError
+
+        settings = self._settings
+        try:
+            client: MongoClient = MongoClient(
+                host=settings.host,
+                port=settings.port,
+                username=settings.username,
+                password=self._password,
+                authSource=settings.auth_database,
+                serverSelectionTimeoutMS=settings.timeout_sec * 1000,
+            )
+            client.admin.command("ping")
+        except PyMongoError as exc:
+            raise ConnectionError(
+                f"cannot reach the archive store at {settings.host}:{settings.port} "
+                f"as {settings.username!r}: {exc}"
+            ) from exc
+
+        self._client = client
+        self._collection = client[settings.database][settings.collection]
+        logger.info(
+            "Archive store connected: %s:%s/%s.%s",
+            settings.host,
+            settings.port,
+            settings.database,
+            settings.collection,
+        )
+
+    def write_sample(self, timestamp: datetime, values: Mapping[str, float]) -> None:
+        """Store one instant's readings as one document.
+
+        Merges rather than replaces, and stamps the expiry only when it creates
+        the document. Both matter for coexistence with the seeded half of the
+        collection: merging leaves any value already stored at this instant for
+        a channel this recorder does not read, and stamping on insert only
+        means a document whose expiry the scenario seeder deliberately removed
+        (an event window, protected from retention) never gets one put back.
+        """
+        if self._collection is None:
+            raise RuntimeError("ArchiveWriter.connect() has not been called")
+        if not values:
+            return
+        self._collection.update_one(
+            {"date": timestamp},
+            {
+                "$set": dict(values),
+                "$setOnInsert": {"expireAt": expiry_for(timestamp, self._settings)},
+            },
+            upsert=True,
+        )
+
+    def close(self) -> None:
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+            self._collection = None

--- a/src/osprey/services/build_artifacts/catalog.py
+++ b/src/osprey/services/build_artifacts/catalog.py
@@ -342,6 +342,22 @@ def _get_default_artifacts() -> list[BuildArtifact]:
             is_directory=True,
         ),
         BuildArtifact(
+            canonical_name="services/archiver_recorder",
+            template_path="archiver_recorder",
+            output_path="services/archiver_recorder",
+            description="Archiver recorder compose template (runs on the VA image)",
+            template_root="services",
+            is_directory=True,
+        ),
+        BuildArtifact(
+            canonical_name="services/mongodb",
+            template_path="mongodb",
+            output_path="services/mongodb",
+            description="MongoDB compose template (archiver store)",
+            template_root="services",
+            is_directory=True,
+        ),
+        BuildArtifact(
             canonical_name="services/openobserve",
             template_path="openobserve",
             output_path="services/openobserve",

--- a/src/osprey/simulation/apply.py
+++ b/src/osprey/simulation/apply.py
@@ -16,15 +16,19 @@ from __future__ import annotations
 
 import asyncio
 import json
+import math
 import os
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from osprey.connectors.types import MOCK
 from osprey.simulation.engine import (
+    ACTIVE_SCENARIO_FILENAME,
+    ACTIVE_SCENARIOS_FILENAME,
     SimulationEngine,
     resolve_active_scenarios,
     resolve_state_dir,
@@ -35,9 +39,11 @@ from osprey.utils.logger import get_logger
 from osprey.utils.relative_time import resolve_relative_timestamp
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Coroutine, Sequence
+    from collections.abc import Callable, Coroutine, Iterator, Mapping, Sequence
+    from zoneinfo import ZoneInfo
 
     from osprey.services.ariel_search.models import EnhancedLogbookEntry
+    from osprey.simulation.archiver_seed import SeedKnobs
     from osprey.simulation.machine import BpmErrorSpec, Scenario, ScenarioLogEntry
 
 logger = get_logger("simulation_apply")
@@ -128,6 +134,65 @@ class ApplyResult:
     active: tuple[str, ...]
     logbook_seeded: int
     purged: bool
+    archiver: ArchiverSeedResult | None = None
+    """What the archive rewrite did, or ``None`` when it was skipped."""
+
+
+@dataclass
+class ArchiverSeedResult:
+    """What one archive rewrite changed.
+
+    ``skipped`` names why nothing happened when nothing did — a project with no
+    stored archive, an unreachable store, or an explicit opt-out. It is a
+    reported outcome rather than a silent one: "the scenario is active but its
+    history is not" is precisely the divergence this feature exists to remove,
+    so it must never be something a caller has to infer from zero counts.
+    """
+
+    channels: tuple[str, ...] = ()
+    restored: int = 0
+    """Documents put back under retention, outside every live event window.
+
+    A window a previous set touched, or the calm stretch between two of this
+    set's own bumps: recomputed to what the active set says they hold, and
+    re-stamped with their tier's ordinary lifetime so they age again."""
+
+    updated: int = 0
+    """Documents inside a live event window this set actually changed.
+
+    Counted per document that was written, not per document visited: a re-apply
+    of the set already in force changes nothing and reports zero, which is the
+    honest answer to "how many archived samples did this rewrite?"
+    """
+
+    inserted: int = 0
+    """Dense samples added between coarse ones inside an event window."""
+
+    removed: int = 0
+    """Previously inserted dense samples deleted during the restore."""
+
+    uncovered: int = 0
+    """Dense samples an event window called for that the store cannot carry.
+
+    A window may reach across a stretch the archive has no samples in at all —
+    a recorder outage, or history that expired. Filling it would be inventing
+    coverage that never existed, so those grid points are left out and counted
+    here instead of silently disappearing.
+    """
+
+    skipped: str | None = None
+
+    def describe(self) -> str:
+        """A one-line summary for the CLI."""
+        if self.skipped:
+            return f"archive not rewritten: {self.skipped}"
+        line = (
+            f"rewrote {self.updated:,} archived samples across {len(self.channels)} channel(s) "
+            f"(+{self.inserted:,} dense, restored {self.restored:,}, removed {self.removed:,})"
+        )
+        if self.uncovered:
+            line += f"; left {self.uncovered:,} uncovered instant(s) empty"
+        return line
 
 
 def apply_scenarios(
@@ -135,6 +200,7 @@ def apply_scenarios(
     names: Sequence[str],
     *,
     seed_logbook: bool = True,
+    seed_archive: bool = True,
     now: datetime | None = None,
 ) -> ApplyResult:
     """Compose and activate scenarios for a built project; optionally seed its logbook.
@@ -147,6 +213,10 @@ def apply_scenarios(
         seed_logbook: When True (and the project has an ``ariel`` config),
             purge and reseed the ARIEL logbook from the active scenarios'
             entries so the narrative matches the telemetry.
+        seed_archive: When True (and the project has a stored archive), rewrite
+            the event windows of that archive so its history matches the
+            telemetry too. A project whose history is synthesized at read time
+            has nothing to rewrite and is unaffected either way.
         now: Apply-time anchor T0 (injectable for tests). Defaults to the
             current time in the facility timezone, so seeded logbook entries
             resolve their time-of-day on the same clock as the telemetry.
@@ -191,7 +261,982 @@ def apply_scenarios(
         else:
             logger.info("No 'ariel' config in project; skipped logbook seeding")
 
-    return ApplyResult(active=active, logbook_seeded=seeded, purged=purged)
+    # After activation, never before: the rewrite synthesizes from the composed
+    # event scripts the engine now holds (see :func:`seed_archiver`).
+    archiver = None
+    if seed_archive:
+        archiver = seed_archiver(project_dir, config, engine, machine_path, list(names), t0)
+
+    return ApplyResult(active=active, logbook_seeded=seeded, purged=purged, archiver=archiver)
+
+
+# ---------------------------------------------------------------------------
+# The archive rewrite
+# ---------------------------------------------------------------------------
+
+#: Rendered-config subtree holding the store's connection keys.
+ARCHIVER_CONFIG_PREFIX = "mongodb_archiver"
+
+#: The TTL field, restated as a plain name so this module can build queries and
+#: updates without importing the seeder at module scope (it pulls in numpy, and
+#: this module is reachable from config-loading paths that must stay lean).
+EXPIRE_FIELD_NAME = "expireAt"
+
+#: Marks a document this rewrite inserted to densify a coarse stretch. Sample
+#: documents are read with an explicit projection (``date`` plus the requested
+#: channels), so an extra field is invisible to every archiver query — and it is
+#: the only way a later restore can tell an inserted sample from a seeded one it
+#: must keep.
+DENSIFIED_FIELD = "osprey_densified"
+
+#: Documents per round trip. An event window on a month-deep archive is tens of
+#: thousands of documents, and one unbounded request carrying all of them would
+#: cross the server's 16 MB command limit long before it became merely slow.
+_WRITE_CHUNK = 1000
+
+#: How many sigmas either side of a spike count as "inside" its window. A
+#: Gaussian is never exactly zero, so the window has to be cut somewhere; four
+#: sigmas leaves under 0.01% of the bump outside it, which is far below the
+#: channel's own noise and therefore invisible in the restored history.
+_SPIKE_WINDOW_SIGMAS = 4.0
+
+
+def archiver_store_config(config: dict, project_dir: Path) -> dict | None:
+    """Connection parameters for the project's stored archive, if it has one.
+
+    The password is read from ``<project_dir>/.env`` **by name**, never from the
+    ambient environment and never from a ``.env`` in the current directory. A
+    scenario apply is routinely run from somewhere else — a test's temporary
+    directory, a benchmark harness, another project — and picking up whatever
+    ``MONGO_ROOT_PASSWORD`` happened to be exported would either fail
+    confusingly or, far worse, rewrite a different deployment's archive.
+
+    Args:
+        config: The project's loaded ``config.yml``.
+        project_dir: Root of the built project; supplies the ``.env``.
+
+    Returns:
+        The parameters, or ``None`` when the project declares no MongoDB
+        archive — a project whose history is synthesized at read time has
+        nothing to rewrite, which is a normal configuration, not a fault.
+    """
+    archiver = config.get("archiver") or {}
+    store = archiver.get(ARCHIVER_CONFIG_PREFIX)
+    if not isinstance(store, dict) or not store.get("host"):
+        return None
+
+    from osprey.utils.dotenv import parse_dotenv_file
+
+    env_path = Path(project_dir) / ".env"
+    env = parse_dotenv_file(env_path) if env_path.is_file() else {}
+    password_env = str(store.get("password_env") or "MONGO_ROOT_PASSWORD")
+
+    return {
+        "host": store["host"],
+        "port": int(store.get("port", 27017)),
+        "database": str(store.get("name") or "osprey_archiver"),
+        "collection": str(store.get("collection") or "pv_history"),
+        "auth_database": str(store.get("auth") or "admin"),
+        "username": str(store.get("username") or "osprey"),
+        "password": env.get(password_env),
+        "password_env": password_env,
+        "timeout_s": int(store.get("timeout", 5)),
+    }
+
+
+def persisted_scenario_anchor(config: dict, project_dir: Path) -> datetime | None:
+    """The apply-time anchor T0 the project's scenario state already records.
+
+    A deployment that has to *re-apply* its active set — a reseed after a knob
+    change, say — must anchor that re-apply where the running world already is.
+    Calling :func:`apply_scenarios` with ``now=None`` would mint a fresh anchor
+    instead, silently sliding the whole timeline: the live VA's ``at_offset``
+    events, the seeded logbook and the archive's event windows would all move to
+    a T0 nobody asked for, as a side effect of a deploy that was supposed to
+    rebuild the store and change nothing else.
+
+    Args:
+        config: The project's loaded ``config.yml``.
+        project_dir: Root of the built project.
+
+    Returns:
+        The anchor as a timezone-aware datetime, or ``None`` when no set has
+        been activated yet or the state file records no ``anchor=`` line — in
+        which case there is no established timeline to preserve and a fresh
+        anchor is the right answer.
+    """
+    state_dir = resolve_state_dir(config, project_dir)
+    for name in (ACTIVE_SCENARIOS_FILENAME, ACTIVE_SCENARIO_FILENAME):
+        path = state_dir / name
+        if not path.is_file():
+            continue
+        # The engine's own parser, not a second one: the anchor line's format
+        # (and its naive-value timezone rule) is the engine's to define, and a
+        # copy here would be free to drift from the file the engine actually
+        # reads. Private only because nothing outside the engine needed it
+        # before.
+        _names, anchor_epoch = SimulationEngine._parse_state(  # noqa: SLF001
+            path.read_text(encoding="utf-8")
+        )
+        if anchor_epoch is not None:
+            return datetime.fromtimestamp(anchor_epoch, UTC)
+        return None
+    return None
+
+
+def _require_pymongo() -> None:
+    """Fail with the fix rather than with an ImportError nobody can act on."""
+    try:
+        import pymongo  # noqa: F401
+    except ImportError as exc:
+        raise RuntimeError(
+            "Rewriting the archive needs pymongo, which is not installed. "
+            "Install it with: pip install 'osprey-framework[archiver-mongodb]'"
+        ) from exc
+
+
+@contextmanager
+def archiver_collection(store: dict):
+    """Open the archive collection named by :func:`archiver_store_config`."""
+    _require_pymongo()
+    from pymongo import MongoClient
+
+    client: Any = MongoClient(
+        host=store["host"],
+        port=store["port"],
+        username=store["username"],
+        password=store["password"],
+        authSource=store["auth_database"],
+        serverSelectionTimeoutMS=store["timeout_s"] * 1000,
+    )
+    try:
+        yield client[store["database"]][store["collection"]]
+    finally:
+        client.close()
+
+
+def active_archiver_events(machine_path: Path, names: Sequence[str]) -> dict[str, list[dict]]:
+    """The composed archiver event scripts of an active set, by channel.
+
+    Read straight from the machine model rather than from a live engine: this
+    is the same route :func:`compute_scenario_physics_env` takes, and it keeps
+    the rewrite decidable before anything is activated — so the CLI can tell a
+    user what is about to change while an abort still leaves the project
+    untouched.
+    """
+    with open(machine_path) as handle:
+        model = parse_machine(json.load(handle), machine_path)
+
+    resolved = resolve_active_scenarios(names)
+    unknown = [name for name in resolved if name not in model.scenarios]
+    if unknown:
+        raise ValueError(f"Unknown scenario(s) {unknown!r}; available: {sorted(model.scenarios)}")
+
+    events: dict[str, list[dict]] = {}
+    for name in resolved:
+        for pv, script in model.scenarios[name].archiver.items():
+            events.setdefault(pv, []).extend(script)
+    return events
+
+
+def _refuse_window_fraction(event: Mapping[str, Any]) -> None:
+    """Refuse an event positioned by window fraction, by name."""
+    if "at" in event:
+        raise ValueError(
+            f"Archiver event {event!r} is positioned by window fraction ('at'), which "
+            f"has no place in stored history — a fraction names a position in the "
+            f"reader's window, not an instant. Use 'at_offset' (seconds relative to "
+            f"the activation anchor) instead."
+        )
+
+
+def _require_events(events: Sequence[dict]) -> None:
+    """Refuse an empty script rather than answer with an inverted window."""
+    if not events:
+        raise ValueError(
+            "An empty archiver event script names no window: a channel with nothing "
+            "to write has no stretch of history to recompute, protect or record. "
+            "Skip the channel instead of asking for its window."
+        )
+
+
+def event_window(
+    events: Sequence[dict], anchor: float, horizon_start: float
+) -> tuple[float, float]:
+    """The absolute span one channel's events can affect, in epoch seconds.
+
+    This is the span whose *values* have to be recomputed — every instant whose
+    sample the script can change. A step or a ramp changes every sample from its
+    position onward, so its span runs to the end of the archive; a daily
+    ``at_time`` event recurs on every date the archive covers, so its span is
+    the whole archive. Both are measured against ``anchor`` — the apply-time T0
+    written into the scenario state file, not this process's wall clock (a
+    deploy's post-reseed re-apply passes the anchor the running world is already
+    on; see :func:`seed_archiver`).
+
+    It is deliberately *not* the span to densify or to protect from retention.
+    A daily event's span is a month long but its evidence is a handful of
+    minutes a day; treating the two as one would de-expire an entire deployment
+    and insert dense samples across every quiet hour between the bumps. Ask
+    :func:`event_subwindows` for those.
+
+    Args:
+        events: One channel's event script; must be non-empty.
+        anchor: T0 in epoch seconds.
+        horizon_start: Oldest instant the archive covers; clamps a span whose
+            event is anchored further back than the archive reaches.
+
+    Returns:
+        ``(start, end)`` in epoch seconds. ``end`` is ``anchor`` for anything
+        persistent.
+
+    Raises:
+        ValueError: If the script is empty, or an event is positioned by window
+            *fraction*. A fraction names a place in whatever window a reader
+            happens to ask for, which is not a place in stored history at all —
+            there is no honest timestamp to write it at.
+    """
+    _require_events(events)
+    start = anchor
+    end = horizon_start
+    for event in events:
+        _refuse_window_fraction(event)
+        if "at_time" in event:
+            # A daily time-of-day recurs on every date the archive covers, so
+            # the span its values reach over is the archive.
+            return horizon_start, anchor
+        at = anchor + float(event["at_offset"])
+        if event["shape"] == "spike":
+            width = float(event["width"]) * _SPIKE_WINDOW_SIGMAS
+            start, end = min(start, at - width), max(end, at + width)
+        else:
+            start, end = min(start, at), anchor
+    return max(start, horizon_start), min(end, anchor)
+
+
+def event_subwindows(
+    events: Sequence[dict],
+    anchor: float,
+    horizon_start: float,
+    *,
+    tz: ZoneInfo | None = None,
+) -> list[tuple[float, float]]:
+    """The stretches one channel's events are actually *evidence* over.
+
+    One entry per occurrence rather than one per script: a spike contributes its
+    own bump, a daily spike contributes one bump per date the archive covers,
+    and a step or a ramp — which genuinely does change every later sample —
+    contributes the stretch from its position to the anchor. Overlapping
+    stretches are merged, so the result is disjoint and ascending.
+
+    These are the stretches the rewrite densifies and lifts retention from, and
+    keeping them separate from :func:`event_window`'s single span is what stops
+    a three-spike script from protecting the calm day between its bumps and a
+    daily event from protecting the whole deployment.
+
+    Args:
+        events: One channel's event script; must be non-empty.
+        anchor: T0 in epoch seconds.
+        horizon_start: Oldest instant the archive covers. Occurrences are
+            clamped to ``[horizon_start, anchor]``, and one that falls entirely
+            outside it contributes nothing.
+        tz: Timezone daily ``at_time`` occurrences are placed in. Defaults to
+            the facility zone, matching where the engine places them.
+
+    Returns:
+        Disjoint ``(start, end)`` pairs, ascending. Empty when every occurrence
+        falls outside the archive.
+
+    Raises:
+        ValueError: As :func:`event_window`.
+    """
+    _require_events(events)
+    windows: list[tuple[float, float]] = []
+    for event in events:
+        _refuse_window_fraction(event)
+        for at in _event_instants(event, anchor, horizon_start, tz):
+            if event["shape"] == "spike":
+                half = float(event["width"]) * _SPIKE_WINDOW_SIGMAS
+                windows.append((at - half, at + half))
+            else:
+                windows.append((at, anchor))
+    clamped = [
+        (max(start, horizon_start), min(end, anchor))
+        for start, end in windows
+        if end >= horizon_start and start <= anchor
+    ]
+    return _merge_intervals(clamped)
+
+
+def _event_instants(
+    event: Mapping[str, Any], anchor: float, horizon_start: float, tz: ZoneInfo | None
+) -> list[float]:
+    """Every instant one event fires at, inside ``[horizon_start, anchor]``."""
+    if "at_time" in event:
+        from osprey.simulation.series import daily_occurrences
+
+        if tz is None:
+            tz = get_facility_timezone()
+        return daily_occurrences(str(event["at_time"]), _np_array([horizon_start, anchor]), tz)
+    return [anchor + float(event["at_offset"])]
+
+
+def _merge_intervals(windows: Sequence[tuple[float, float]]) -> list[tuple[float, float]]:
+    """Overlapping or touching spans collapsed into disjoint ascending ones."""
+    merged: list[tuple[float, float]] = []
+    for start, end in sorted(windows):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def _inside(windows: Sequence[tuple[float, float]] | None, moment: float) -> bool:
+    """Whether an instant falls in any of these spans."""
+    return any(start <= moment <= end for start, end in windows or ())
+
+
+def seed_archiver(
+    project_dir: Path,
+    config: dict,
+    engine: SimulationEngine,
+    machine_path: Path,
+    names: Sequence[str],
+    anchor: datetime,
+) -> ArchiverSeedResult:
+    """Rewrite the stored archive so it tells the newly active set's story.
+
+    Call this *after* the set has been activated: the engine's composed event
+    scripts are what the rewrite synthesizes from, and one recompute under the
+    new set is both the restore and the apply.
+
+    That collapse is the design, and it is worth being explicit about. A
+    previous set's events left their marks on some windows, and the naive
+    reading of "restore, then apply" is two passes. But every value in this
+    archive is a pure function of ``(channel, timestamp)`` *under the active
+    set* — so recomputing the union of the old touched windows and the new
+    event windows, once, under the set now in force, lands every document on
+    its correct final value in one pass. A channel the new set does not touch
+    recomputes to its bare base, which is exactly what restoring it means. Two
+    passes would do the same arithmetic twice and leave a window in an
+    intermediate state in between.
+
+    What is genuinely two-sided is *expiry*, because it does not follow from the
+    values, and it is decided one document at a time: a document whose own
+    timestamp falls inside a live event window has its expiry removed, so
+    retention can never prune the evidence a scenario is about to be diagnosed
+    from, and every other document in the recomputed span — including the whole
+    stretch that only the previous set touched — gets its tier's stamp back.
+    Dense samples this rewrite inserted are likewise deleted and re-inserted
+    rather than recomputed — they exist only where an event needs resolution the
+    coarse grid cannot give.
+
+    The order of the writes is a durability contract rather than an efficiency
+    one. The touched-window ledger goes down *first*, naming the union of the
+    old and the new windows, and is narrowed to the new ones only once the
+    rewrite has returned: a process that dies part way through has already
+    written event values into windows the narrowed ledger would not mention, and
+    a window no ledger names is one no later apply ever comes back for.
+
+    Args:
+        project_dir: Root of the built project; supplies ``.env`` and the store.
+        config: The project's loaded ``config.yml``.
+        engine: The engine, already activated on the new set.
+        machine_path: The machine model, for reading the composed event scripts.
+        names: The requested scenario names.
+        anchor: The apply-time anchor T0 — the *same* instant that was written
+            into the scenario state file. It has to be: the engine resolves
+            ``at_offset`` against the state file, so a window computed against
+            any other clock would describe a stretch of history the engine is
+            not writing its events into. One clock for the telemetry, the
+            narrative and the archive is the whole invariant.
+
+    Returns:
+        What changed, or a result carrying ``skipped`` when the project has no
+        stored archive to rewrite.
+
+    Raises:
+        RuntimeError: If pymongo is missing, or the store is configured but its
+            password is not in the project's ``.env``.
+        ValueError: If an active scenario positions an archiver event by window
+            fraction, which stored history cannot represent.
+    """
+    from osprey.simulation.archiver_seed import MANIFEST_ID, SeedKnobs
+
+    store = archiver_store_config(config, project_dir)
+    if store is None:
+        return ArchiverSeedResult(skipped="project declares no MongoDB archive")
+    if not store["password"]:
+        raise RuntimeError(_missing_password_message(project_dir, store))
+
+    _require_pymongo()
+    knobs = SeedKnobs.from_config(config)
+    # An empty script is not a window: it names a channel the scenario mentions
+    # and then leaves alone, and asking for its span would invert one.
+    events = {
+        pv: script for pv, script in active_archiver_events(machine_path, names).items() if script
+    }
+    tz = get_facility_timezone()
+
+    with archiver_collection(store) as collection:
+        manifest = collection.find_one({"_id": MANIFEST_ID})
+        if manifest is None:
+            return ArchiverSeedResult(
+                skipped="the archive has not been seeded yet — run 'osprey deploy up'"
+            )
+
+        anchor_s = anchor.timestamp()
+        horizon_start = _archive_start(collection, manifest, anchor_s, knobs)
+        previous = _ledger_windows(manifest)
+        current = {
+            pv: event_window(script, anchor_s, horizon_start) for pv, script in events.items()
+        }
+        live = {
+            pv: event_subwindows(script, anchor_s, horizon_start, tz=tz)
+            for pv, script in events.items()
+        }
+        spans = _union_spans(previous, current)
+
+        result = ArchiverSeedResult(channels=tuple(sorted(current)))
+
+        # The ledger goes down first, and it names the *union* — every window
+        # this run is about to disturb, not the ones it means to leave marked.
+        # A process that dies mid-rewrite has already written event values into
+        # windows the new ledger would not mention, and a window no ledger names
+        # is a window no later apply ever comes back for: the marks would be
+        # permanent and unsignalled. A superset costs the next apply one extra
+        # recompute over a stretch that is already at its base value.
+        #
+        # Written whenever there is anything at all to disturb, including when
+        # the union happens to equal the new windows — which is exactly the case
+        # on a store no scenario has touched yet. Skipping it there because "the
+        # ledger would say the same thing at the end anyway" would leave the
+        # *first* eventful apply on every fresh deployment writing marks under
+        # an empty ledger, which is the one crash nothing could recover from.
+        #
+        # Any guard here must be phrased against what is already *on disk*,
+        # never against what this run intends to leave behind; the unconditional
+        # form is the one that cannot be got wrong, and it costs one small
+        # manifest write per eventful apply.
+        if spans:
+            _write_ledger(collection, spans, anchor_s)
+
+        # Dense inserts are keyed to the windows that needed them; a window that
+        # is no longer an event window must not keep resolution nothing asked
+        # for, so they go before anything is recomputed.
+        regions = _merge_intervals(list(spans.values()))
+        result.removed = _drop_densified(collection, regions)
+
+        result.updated, result.restored = _rewrite_documents(collection, engine, knobs, spans, live)
+        result.inserted, result.uncovered = _densify(collection, engine, live, knobs)
+
+        _write_ledger(collection, current, anchor_s)
+
+    if result.uncovered:
+        logger.warning(
+            f"{result.uncovered} dense sample(s) an event window called for were left out: "
+            f"the archive has no coverage there to densify."
+        )
+    logger.info(result.describe())
+    return result
+
+
+def _missing_password_message(project_dir: Path, store: dict) -> str:
+    """Why an archive rewrite cannot proceed without the project's own password."""
+    return (
+        f"The archive is configured but {store['password_env']} is not in "
+        f"{project_dir / '.env'}, so its history cannot be rewritten and would "
+        f"contradict the scenario now active. Run 'osprey deploy up' to mint it."
+    )
+
+
+def preflight_archive_rewrite(
+    project_dir: Path,
+    config: dict,
+    machine_path: Path,
+    names: Sequence[str],
+) -> dict | None:
+    """Decide the archive rewrite *before* anything has been activated.
+
+    :func:`active_archiver_events` is readable straight from the machine model,
+    with no engine and no store, precisely so this is possible — and this is the
+    caller that uses it. Every refusal :func:`seed_archiver` can raise before it
+    touches a document (an event positioned by window fraction, a store whose
+    password the project's ``.env`` does not carry) is raised here instead,
+    while the scenario is still inactive and the logbook still intact.
+
+    Reaching those refusals from inside the rewrite would leave the world half
+    applied: telemetry live, narrative reseeded, history untouched and
+    contradicting both — which is the exact divergence this feature removes.
+
+    Args:
+        project_dir: Root of the built project.
+        config: The project's loaded ``config.yml``.
+        machine_path: The machine model.
+        names: The requested scenario names.
+
+    Returns:
+        The store parameters, or ``None`` when the project declares no stored
+        archive and there is nothing to rewrite.
+
+    Raises:
+        ValueError: If a scenario name is unknown, or an active scenario
+            positions an archiver event by window fraction.
+        RuntimeError: If the store is configured but its password is not in the
+            project's ``.env``.
+    """
+    for script in active_archiver_events(machine_path, names).values():
+        for event in script:
+            _refuse_window_fraction(event)
+
+    store = archiver_store_config(config, project_dir)
+    if store is not None and not store["password"]:
+        raise RuntimeError(_missing_password_message(project_dir, store))
+    return store
+
+
+def _archive_start(collection, manifest: dict, anchor_s: float, knobs: SeedKnobs) -> float:
+    """The oldest instant this archive actually covers.
+
+    Read from the store rather than computed from the anchor: retention has been
+    pruning the far end since the day it was seeded, and a horizon derived from
+    arithmetic would claim coverage that expired days ago. Falls back to the
+    manifest's seed instant less the retention span when the store is somehow
+    empty of dated samples, which is the coverage a fresh seed would have.
+
+    Windows are clamped to this so an event anchored further back than the
+    archive reaches writes into the history that exists instead of describing
+    history that does not.
+    """
+    from osprey.simulation.archiver_seed import oldest_sample
+
+    oldest = oldest_sample(collection)
+    if oldest is not None:
+        return float(oldest.timestamp())
+    seeded_at = manifest.get("seeded_at")
+    if isinstance(seeded_at, datetime):
+        aware = seeded_at if seeded_at.tzinfo is not None else seeded_at.replace(tzinfo=UTC)
+        return float(aware.timestamp()) - knobs.retention_s
+    return anchor_s - knobs.retention_s
+
+
+def _ledger_windows(manifest: dict) -> dict[str, tuple[float, float]]:
+    """The windows a previous apply reported touching, by channel."""
+    windows: dict[str, tuple[float, float]] = {}
+    for entry in manifest.get("touched_windows") or []:
+        try:
+            start, end = float(entry["start"]), float(entry["end"])
+            for pv in entry["channels"]:
+                windows[str(pv)] = (start, end)
+        except (KeyError, TypeError, ValueError):
+            logger.warning(f"Ignoring an unreadable touched-window ledger entry: {entry!r}")
+    return windows
+
+
+def _ledger_entries(windows: dict[str, tuple[float, float]]) -> list[dict]:
+    """The ledger to store, grouping channels that share a window."""
+    grouped: dict[tuple[float, float], list[str]] = {}
+    for pv, span in windows.items():
+        grouped.setdefault(span, []).append(pv)
+    return [
+        {"start": start, "end": end, "channels": sorted(channels)}
+        for (start, end), channels in sorted(grouped.items())
+    ]
+
+
+def _write_ledger(collection, windows: dict[str, tuple[float, float]], anchor_s: float) -> None:
+    """Record the windows a later apply has to recompute over."""
+    from osprey.simulation.archiver_seed import MANIFEST_ID
+
+    collection.update_one(
+        {"_id": MANIFEST_ID},
+        {"$set": {"touched_windows": _ledger_entries(windows), "touched_anchor": anchor_s}},
+    )
+
+
+def _union_spans(
+    previous: dict[str, tuple[float, float]],
+    current: dict[str, tuple[float, float]],
+) -> dict[str, tuple[float, float]]:
+    """The span each channel needs recomputing over, old and new together.
+
+    A channel in both maps needs the union of its two spans: the old marks have
+    to be recomputed away and the new ones written, and one span covering both
+    does each document exactly once.
+    """
+    spans: dict[str, tuple[float, float]] = {}
+    for pv in set(previous) | set(current):
+        old, new = previous.get(pv), current.get(pv)
+        if old and new:
+            spans[pv] = (min(old[0], new[0]), max(old[1], new[1]))
+        else:
+            spans[pv] = old or new  # type: ignore[assignment]
+    return spans
+
+
+def _region_documents(collection, channels: Sequence[str], start: float, end: float) -> list[dict]:
+    """Existing documents in a span, projected to ``date`` and these channels."""
+    projection = {"date": 1, EXPIRE_FIELD_NAME: 1, **dict.fromkeys(channels, 1)}
+    cursor = collection.find(
+        {
+            "date": {
+                "$gte": datetime.fromtimestamp(start, UTC),
+                "$lte": datetime.fromtimestamp(end, UTC),
+            }
+        },
+        projection,
+    ).sort("date", 1)
+    return list(cursor)
+
+
+def _stamps(documents: Sequence[dict]) -> list[datetime]:
+    """The instants a set of documents was sampled at, UTC-aware."""
+    return [
+        doc["date"] if doc["date"].tzinfo is not None else doc["date"].replace(tzinfo=UTC)
+        for doc in documents
+    ]
+
+
+def _match_stored_type(existing, value):
+    """Coerce a recomputed value to the type the stored one already had.
+
+    The store is its own schema authority here. The base seed wrote each channel
+    in the type the machine serves it as — a flag as a boolean, an enumeration
+    as an integer — and a rewrite that put a float on a flag channel would leave
+    that channel's history changing type partway through, which reads as a
+    different instrument rather than a different value.
+    """
+    if isinstance(existing, bool):
+        return bool(value)
+    if isinstance(existing, int):
+        return int(value)
+    if isinstance(existing, str):
+        return str(value)
+    return float(value)
+
+
+def _rewrite_documents(
+    collection,
+    engine: SimulationEngine,
+    knobs: SeedKnobs,
+    spans: dict[str, tuple[float, float]],
+    live: dict[str, list[tuple[float, float]]],
+) -> tuple[int, int]:
+    """Recompute every document the old and the new set between them reach.
+
+    One pass over the union of the spans, and every document visited exactly
+    once. Values come from the engine at each document's *own* timestamp, so the
+    rewrite lands on exactly what a query for that instant would synthesize —
+    the same property the base seed relies on, applied to a narrower window.
+
+    Expiry is decided **per document**, from whether that document's own
+    timestamp falls inside a live event window of a channel it actually carries.
+    Inside one, the expiry is removed outright: retention must never prune the
+    stretch of history a scenario exists to be diagnosed from. Outside one, the
+    document goes back under its tier's ordinary lifetime, so a window a
+    previous set protected starts ageing again the moment it stops being
+    evidence. Deciding this once per *region* instead — the union of the old and
+    the new window is a region, and it is live at one end and dead at the other
+    — would leave the whole old window unexpiring for good: the new ledger does
+    not name it, so no later apply would ever come back for it.
+
+    Returns:
+        ``(updated, restored)`` — documents this pass actually wrote, split by
+        whether they now carry the new set's story or were put back under
+        retention. A document whose values and expiry are already correct is not
+        rewritten and not counted, so re-applying the set in force reports zero.
+    """
+    from osprey.simulation.archiver_seed import tier_expiry
+
+    if not spans:
+        return 0, 0
+    channels = sorted(spans)
+    start = min(span[0] for span in spans.values())
+    end = max(span[1] for span in spans.values())
+    documents = _region_documents(collection, channels, start, end)
+    if not documents:
+        return 0, 0
+
+    stamps = _stamps(documents)
+    epochs = [stamp.timestamp() for stamp in stamps]
+    values = _recomputed_values(engine, spans, channels, stamps, epochs)
+    expiry = tier_expiry(knobs, _np_array(epochs))
+
+    from pymongo import UpdateOne
+
+    operations = []
+    updated = restored = 0
+    for index, document in enumerate(documents):
+        protected = False
+        changed: dict[str, Any] = {}
+        for pv in channels:
+            column = values.get(pv)
+            if column is None or index not in column or pv not in document:
+                continue
+            value = _match_stored_type(document[pv], column[index])
+            if document[pv] != value:
+                changed[pv] = value
+            # Per channel *and* per timestamp — do not simplify to a test against
+            # the merged live windows of every channel. The two are behaviourally
+            # identical on this schema, because a base-seeded document carries
+            # every channel and so is "inside" the merged windows exactly when it
+            # is inside its own channel's; no test here can tell them apart. What
+            # makes them different is the sparse documents: a dense insert
+            # carries only the channels live at its instant, and a channel-blind
+            # test would protect it on a neighbour's evidence rather than its own.
+            protected = protected or _inside(live.get(pv), epochs[index])
+        update = _expiry_update(document, protected, float(expiry[index]))
+        if changed:
+            update.setdefault("$set", {}).update(changed)
+        if not update:
+            continue
+        operations.append(UpdateOne({"_id": document["_id"]}, update))
+        if protected:
+            updated += 1
+        else:
+            restored += 1
+
+    for batch in _chunked(operations, _WRITE_CHUNK):
+        collection.bulk_write(batch, ordered=False)
+    return updated, restored
+
+
+def _recomputed_values(
+    engine: SimulationEngine,
+    spans: dict[str, tuple[float, float]],
+    channels: Sequence[str],
+    stamps: Sequence[datetime],
+    epochs: Sequence[float],
+) -> dict[str, dict[int, float]]:
+    """Each channel's recomputed values, by document index, over its own span.
+
+    Synthesized over the channel's own span rather than over the union of every
+    channel's: a daily event's occurrences are placed inside the window it is
+    asked for, so widening that window to accommodate an unrelated channel would
+    make one channel's history depend on which other channels the active set
+    happens to touch.
+    """
+    values: dict[str, dict[int, float]] = {}
+    for pv in channels:
+        low, high = spans[pv]
+        indices = [index for index, epoch in enumerate(epochs) if low <= epoch <= high]
+        if not indices:
+            continue
+        series = engine.synthesize_series(pv, [stamps[index] for index in indices])
+        values[pv] = dict(zip(indices, series, strict=True))
+    return values
+
+
+def _expiry_update(document: Mapping[str, Any], protected: bool, expiry_s: float) -> dict:
+    """The expiry half of one document's update, empty when it is already right."""
+    held = document.get(EXPIRE_FIELD_NAME)
+    if protected:
+        return {"$unset": {EXPIRE_FIELD_NAME: ""}} if held is not None else {}
+    wanted = datetime.fromtimestamp(expiry_s, UTC)
+    if isinstance(held, datetime):
+        aware = held if held.tzinfo is not None else held.replace(tzinfo=UTC)
+        # The store keeps datetimes to the millisecond, so an exact compare
+        # would report a change on every re-apply of an unchanged window.
+        if abs((aware - wanted).total_seconds()) < 0.001:
+            return {}
+    return {"$set": {EXPIRE_FIELD_NAME: wanted}}
+
+
+def _densify(
+    collection,
+    engine: SimulationEngine,
+    live: dict[str, list[tuple[float, float]]],
+    knobs: SeedKnobs,
+) -> tuple[int, int]:
+    """Add dense samples between the coarse ones inside the live event windows.
+
+    Most of the archive is a month deep at a coarse cadence, and a spike whose
+    width is comparable to that cadence would be represented by one or two
+    points — a shape no operator could read and no correlation could find. The
+    inserts carry *only* the channels live at each instant: the schema allows a
+    sparse document, so a dense sample of the channels an event touches costs a
+    fraction of a full one, and every other channel keeps the coarse history it
+    genuinely has rather than being given invented resolution.
+
+    Densification runs once over the merged live windows, not once per channel,
+    so an instant two channels share gets one document carrying both. Filling
+    per channel would let whichever ran first claim the timestamp and leave the
+    other with a hole — and the order it ran in would be a set-iteration
+    accident, so the archive would come out differently run to run.
+
+    Each insert is marked (:data:`DENSIFIED_FIELD`) and left unexpiring, so a
+    later rewrite can tell them from seeded samples and take them away again
+    when the window stops being an event window.
+
+    Returns:
+        ``(inserted, uncovered)`` — samples written, and grid points left empty
+        because the store has no coverage there to densify.
+    """
+    if not live:
+        return 0, 0
+    intervals = _merge_intervals([window for windows in live.values() for window in windows])
+    if not intervals:
+        return 0, 0
+
+    types = _stored_types(collection, sorted(live))
+    inserted = uncovered = 0
+    for start, end in intervals:
+        added, missed = _densify_interval(collection, engine, live, knobs, types, start, end)
+        inserted += added
+        uncovered += missed
+    return inserted, uncovered
+
+
+def _densify_interval(
+    collection,
+    engine: SimulationEngine,
+    live: dict[str, list[tuple[float, float]]],
+    knobs: SeedKnobs,
+    types: Mapping[str, Any],
+    start: float,
+    end: float,
+) -> tuple[int, int]:
+    """Fill one live window's coarse stretches, and only its coarse stretches.
+
+    A grid point is filled only when it lies strictly between two stored samples
+    no further apart than the coarse cadence — that is what "between the coarse
+    ones" means, and it is the difference between adding resolution to history
+    the store has and manufacturing history it does not. A recorder outage, a
+    stretch that expired, or a window reaching past the newest sample all leave
+    gaps wider than the coarse cadence, and inventing a month of samples across
+    one of them would be the same defect this feature exists to remove, told in
+    the opposite direction.
+    """
+    reach = float(knobs.tail_cadence_sec)
+    grid = [
+        moment
+        for moment in _aligned_epochs(start, end, knobs.hot_cadence_sec)
+        if moment % knobs.tail_cadence_sec != 0
+    ]
+    if not grid:
+        return 0, 0
+
+    # One coarse cadence of margin either side, so a grid point at the very edge
+    # of the window can still see the stored sample that brackets it.
+    neighbours = sorted(
+        stamp.timestamp()
+        for stamp in _stamps(_region_documents(collection, [], start - reach, end + reach))
+    )
+    held = set(neighbours)
+
+    wanted: dict[float, tuple[str, ...]] = {}
+    uncovered = 0
+    for moment in grid:
+        if moment in held:
+            continue
+        channels = tuple(pv for pv in sorted(live) if _inside(live[pv], moment))
+        if not channels:
+            continue
+        if not _bracketed(neighbours, moment, reach):
+            uncovered += 1
+            continue
+        wanted[moment] = channels
+
+    if not wanted:
+        return 0, uncovered
+
+    documents = _dense_documents(engine, types, wanted)
+    for batch in _chunked(documents, _WRITE_CHUNK):
+        collection.insert_many(batch, ordered=False)
+    return len(documents), uncovered
+
+
+def _bracketed(neighbours: Sequence[float], moment: float, reach: float) -> bool:
+    """Whether two stored samples no more than ``reach`` apart straddle ``moment``."""
+    import bisect
+
+    index = bisect.bisect_left(neighbours, moment)
+    if index == 0 or index >= len(neighbours):
+        return False
+    return neighbours[index] - neighbours[index - 1] <= reach
+
+
+def _dense_documents(
+    engine: SimulationEngine,
+    types: Mapping[str, Any],
+    wanted: Mapping[float, tuple[str, ...]],
+) -> list[dict]:
+    """The documents to insert: one per instant, carrying the channels live at it."""
+    moments = sorted(wanted)
+    stamps = [datetime.fromtimestamp(moment, UTC) for moment in moments]
+    columns: dict[str, dict[int, float]] = {}
+    for pv in sorted({pv for channels in wanted.values() for pv in channels}):
+        indices = [index for index, moment in enumerate(moments) if pv in wanted[moment]]
+        series = engine.synthesize_series(pv, [stamps[index] for index in indices])
+        columns[pv] = dict(zip(indices, series, strict=True))
+
+    documents = []
+    for index, moment in enumerate(moments):
+        document: dict = {"date": stamps[index], DENSIFIED_FIELD: True}
+        for pv in wanted[moment]:
+            # Same coercion the updates use: a flag channel seeded as a boolean
+            # must not acquire a float beside it half way through its history.
+            document[pv] = _match_stored_type(types.get(pv), columns[pv][index])
+        documents.append(document)
+    return documents
+
+
+def _stored_types(collection, channels: Sequence[str]) -> dict[str, Any]:
+    """One stored value per channel, as the type authority for inserts.
+
+    The store is its own schema authority (see :func:`_match_stored_type`), and
+    an insert has no document of its own to read that from — so it reads one
+    from the channel's existing history instead.
+    """
+    samples: dict[str, Any] = {}
+    for pv in channels:
+        document = collection.find_one({pv: {"$exists": True}}, {pv: 1})
+        if document is not None:
+            samples[pv] = document.get(pv)
+    return samples
+
+
+def _chunked(items: Sequence[Any], size: int) -> Iterator[list]:
+    """Split a batch of writes into round trips the server will accept."""
+    for start in range(0, len(items), size):
+        yield list(items[start : start + size])
+
+
+def _aligned_epochs(start: float, end: float, cadence: int) -> list[float]:
+    """Whole multiples of ``cadence`` since the epoch inside ``[start, end]``.
+
+    The same alignment the base seed's grid uses, so an inserted sample lands on
+    a timestamp the seeded grid would have used had the window been dense —
+    never half a cadence away from one, which would leave two samples where the
+    archive should hold one.
+    """
+    first = math.ceil(start / cadence) * cadence
+    return [float(moment) for moment in range(int(first), int(end) + 1, cadence)]
+
+
+def _np_array(values):
+    """Local numpy import: this module is reachable from config-loading paths."""
+    import numpy as np
+
+    return np.asarray(values, dtype=float)
+
+
+def _drop_densified(collection, windows: Sequence[tuple[float, float]]) -> int:
+    """Delete the dense samples a previous rewrite inserted in these windows."""
+    removed = 0
+    for start, end in windows:
+        outcome = collection.delete_many(
+            {
+                DENSIFIED_FIELD: True,
+                "date": {
+                    "$gte": datetime.fromtimestamp(start, UTC),
+                    "$lte": datetime.fromtimestamp(end, UTC),
+                },
+            }
+        )
+        removed += outcome.deleted_count
+    return removed
 
 
 # BpmErrorSpec field -> VA_BPM_ERRORS sub-field(s) it fans out to, at the

--- a/src/osprey/simulation/archiver_seed.py
+++ b/src/osprey/simulation/archiver_seed.py
@@ -1,0 +1,787 @@
+"""Materializing a deployment's archive: the base seed and its fingerprint.
+
+A deployment that serves simulated channels needs history for them, and the
+honest way to have history is to *store* it. This module computes that stored
+history and writes it: one document per timestamp carrying every channel, over
+a two-tier grid reaching back the configured retention, in the schema
+``MongoDBArchiverConnector`` already reads.
+
+The values are not this module's invention. Every channel is synthesized by the
+same code that answers a live archiver query — ``SimulationEngine`` for the
+channels a machine model describes, :mod:`osprey.simulation.procedural` for the
+rest — evaluated at each document's own absolute timestamp. That is the whole
+reason those generators are pure functions of ``(channel, epoch seconds)``: a
+document written here at time T holds exactly what a query for T would compute,
+so seeded history and synthesized history are one world rather than two
+plausible ones.
+
+Three pieces of the design are worth stating outright:
+
+* **Two tiers, one grid.** The coarse tier spans the full retention window; the
+  dense tier adds samples *between* its points over the recent span. They are
+  built from one epoch-aligned grid and the dense tier skips timestamps the
+  coarse tier already owns, so no timestamp is written twice — the schema is one
+  document per timestamp and a duplicate would be a second, competing sample.
+
+* **Retention is per document, not per collection.** Each document carries an
+  ``expireAt`` that a TTL index acts on, stamped by the tier that produced it.
+  A coarse sample lives for the retention span, a dense one until it ages out
+  of the dense span, and a document with no stamp at all never expires — which
+  is what lets a later scenario rewrite protect the windows it touches by
+  simply removing the field.
+
+* **Reseeding is a decision, not a default.** A seed manifest records the knobs
+  the store was built with, and :func:`compare_fingerprint` reports match,
+  mismatch or absence. The seed instant is stored but deliberately excluded from
+  the comparison — it differs on every deploy, and including it would make every
+  deploy a reseed.
+
+This module never imports ``pymongo``: the functions that talk to a store take
+a collection handle their caller opened. That keeps an optional dependency
+optional, and leaves the grid, the fingerprint and the synthesis — the parts
+worth reasoning about — pure and testable with no store at all.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from osprey.simulation.engine import SimulationEngine, engine_serves
+from osprey.simulation.procedural import (
+    DEFAULT_NOISE_LEVEL,
+    baseline_value,
+    generate_series,
+)
+from osprey.simulation.series import epoch_seconds_array
+from osprey.utils.logger import get_logger
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from pymongo.collection import Collection
+
+logger = get_logger("archiver_seed")
+
+__all__ = [
+    "MANIFEST_ID",
+    "SEED_SCHEMA_VERSION",
+    "FingerprintComparison",
+    "SeedKnobs",
+    "SeedReport",
+    "SeedState",
+    "compare_fingerprint",
+    "oldest_sample",
+    "prepare_collection",
+    "seed_base",
+    "seed_fingerprint",
+    "seed_grid",
+    "synthesize_documents",
+    "tier_expiry",
+    "write_manifest",
+]
+
+#: ``_id`` of the seed-manifest document. A fixed id makes writing it an upsert
+#: and reading it a primary-key lookup, and makes a second manifest impossible.
+MANIFEST_ID = "osprey:seed_manifest"
+
+#: Bumped when the meaning of a stored document changes in a way that makes an
+#: existing store wrong rather than merely differently configured. It is part of
+#: the fingerprint, so a bump reseeds every deployment on upgrade.
+SEED_SCHEMA_VERSION = 1
+
+#: Field naming the instant a document's sample was taken. The connector queries
+#: and sorts on it; the manifest document deliberately has none, which is what
+#: keeps it out of every archiver read without needing a filter.
+DATE_FIELD = "date"
+
+#: Field the TTL index acts on. A document without it never expires.
+EXPIRE_FIELD = "expireAt"
+
+#: Manifest record types, restated rather than imported: this module belongs to
+#: the simulation package and the names live in the Virtual Accelerator service
+#: package, which a host-side seeder must not need installed. They are a wire
+#: vocabulary — the strings appear verbatim in every generated
+#: ``channel_manifest.json`` — so restating them costs no coupling.
+RECORD_TYPE_ANALOG = "ai"
+RECORD_TYPE_BINARY = "bi"
+RECORD_TYPE_MBB = "mbbi"
+_TEXT_RECORD_TYPES = ("stringin", "longstringin")
+
+#: Timestamps synthesized in one pass. Sized so the value matrix of a full
+#: channel set stays in the tens of megabytes: the whole point of chunking is
+#: that a month of history for three thousand channels does not fit in memory
+#: at once.
+DEFAULT_CHUNK_SIZE = 2000
+
+#: Concurrent insert workers. The synthesis runs on the calling thread and the
+#: inserts overlap it, which is the parallelism that matters here — the round
+#: trip to the store, not the arithmetic.
+DEFAULT_WORKERS = 4
+
+
+class SeedState(Enum):
+    """What a store's manifest says about the seed it holds."""
+
+    ABSENT = "absent"
+    """No manifest document: the store has never been seeded (or was wiped)."""
+
+    MATCH = "match"
+    """The store was built with the knobs now in force. Nothing to do."""
+
+    MISMATCH = "mismatch"
+    """The store was built with different knobs, so its coverage no longer
+    describes what the profile asks for. The store has to be rebuilt."""
+
+
+@dataclass(frozen=True)
+class FingerprintComparison:
+    """The outcome of comparing a store's manifest against current knobs."""
+
+    state: SeedState
+    differences: tuple[tuple[str, Any, Any], ...] = ()
+    """``(key, stored, expected)`` for each field that moved. Empty unless the
+    state is :attr:`SeedState.MISMATCH`. Carried so the deploy step can *report*
+    what changed rather than announcing an unexplained reseed."""
+
+    seeded_at: datetime | None = None
+    """The instant the stored seed was anchored at, when there is one. Metadata:
+    it is never compared (see the module docstring)."""
+
+    def describe(self) -> str:
+        """One line per changed knob, for a deploy-time report."""
+        return "\n".join(
+            f"  {key}: {stored!r} -> {expected!r}" for key, stored, expected in self.differences
+        )
+
+
+@dataclass(frozen=True)
+class SeedKnobs:
+    """The shape of the archive, as the profile's ``va_archiver:`` block sets it.
+
+    Defaults mirror :class:`~osprey.cli.build_profile_archiver.VAArchiverConfig`
+    so a caller holding no config still gets the shipped archive rather than an
+    arbitrary one. The block validates ranges and the cadence-divisibility rule
+    at build time; :meth:`validate` repeats the ones this module's arithmetic
+    depends on, because a store can also be seeded from a hand-written config
+    that never went through a profile.
+    """
+
+    retention_days: int = 30
+    hot_span_hours: int = 48
+    hot_cadence_sec: int = 10
+    tail_cadence_sec: int = 60
+
+    @classmethod
+    def from_config(cls, config: Mapping[str, Any]) -> SeedKnobs:
+        """Read the knobs out of a rendered project config.
+
+        Args:
+            config: The loaded ``config.yml`` as a mapping. Its ``va_archiver``
+                subtree supplies the knobs; any absent one keeps its default,
+                so a config predating a knob still seeds.
+
+        Returns:
+            The parsed knobs.
+
+        Raises:
+            ValueError: If a knob is present but not a positive integer, or the
+                set is internally inconsistent (see :meth:`validate`).
+        """
+        block = config.get("va_archiver") or {}
+        if not isinstance(block, Mapping):
+            raise ValueError(f"config 'va_archiver' must be a mapping (got {type(block).__name__})")
+
+        values: dict[str, int] = {}
+        for name in ("retention_days", "hot_span_hours", "hot_cadence_sec", "tail_cadence_sec"):
+            if name in block:
+                raw = block[name]
+                if isinstance(raw, bool) or not isinstance(raw, int):
+                    raise ValueError(f"va_archiver.{name} must be an integer (got {raw!r})")
+                values[name] = raw
+
+        knobs = cls(**values)
+        knobs.validate()
+        return knobs
+
+    def validate(self) -> None:
+        """Refuse knobs this module's grid arithmetic cannot honor.
+
+        Raises:
+            ValueError: If any knob is below one, the dense span reaches past
+                retention, or the coarse cadence is not a whole multiple of the
+                dense one — that last is what makes the coarse grid a subset of
+                the dense one rather than a second grid interleaved with it.
+        """
+        for name in ("retention_days", "hot_span_hours", "hot_cadence_sec", "tail_cadence_sec"):
+            value = getattr(self, name)
+            if value < 1:
+                raise ValueError(f"va_archiver.{name} must be >= 1 (got {value})")
+        if self.hot_span_hours > self.retention_days * 24:
+            raise ValueError(
+                f"va_archiver.hot_span_hours ({self.hot_span_hours}) exceeds "
+                f"retention_days ({self.retention_days} days)"
+            )
+        if self.tail_cadence_sec % self.hot_cadence_sec:
+            raise ValueError(
+                f"va_archiver.tail_cadence_sec ({self.tail_cadence_sec}) must be a whole "
+                f"multiple of hot_cadence_sec ({self.hot_cadence_sec})"
+            )
+
+    @property
+    def retention_s(self) -> int:
+        """Retention span in seconds."""
+        return self.retention_days * 86400
+
+    @property
+    def hot_span_s(self) -> int:
+        """Dense-tier span in seconds."""
+        return self.hot_span_hours * 3600
+
+
+@dataclass
+class SeedReport:
+    """What one seeding run wrote."""
+
+    documents: int = 0
+    channels: int = 0
+    start: datetime | None = None
+    end: datetime | None = None
+    elapsed_s: float = 0.0
+    chunks: int = 0
+
+    def describe(self) -> str:
+        """A one-line summary for a deploy-time progress report."""
+        span = (
+            f"{self.start:%Y-%m-%d %H:%M} to {self.end:%Y-%m-%d %H:%M} UTC"
+            if self.start and self.end
+            else "empty window"
+        )
+        return (
+            f"seeded {self.documents:,} documents x {self.channels:,} channels "
+            f"({span}) in {self.elapsed_s:.1f}s"
+        )
+
+
+# ---------------------------------------------------------------------------
+# The grid
+# ---------------------------------------------------------------------------
+
+
+def seed_grid(knobs: SeedKnobs, t0: datetime) -> tuple[np.ndarray, np.ndarray]:
+    """The timestamps to seed and the instant each one expires.
+
+    The grid is epoch-aligned rather than anchored on ``t0``: both tiers land on
+    whole multiples of their cadence since the epoch, which is the only way the
+    coarse tier can be a subset of the dense one no matter what second ``t0``
+    happens to fall on. The dense tier contributes only the timestamps the
+    coarse tier does not already cover, so every timestamp appears exactly once.
+
+    Expiry is stamped by the tier that produced a timestamp: a coarse sample
+    lives out the retention span, a dense one lives until it ages out of the
+    dense span. Both are measured from the sample's own time, so the oldest
+    seeded documents are already at the end of their life when they are written
+    — which is what makes a seeded archive age like a recorded one instead of
+    surviving intact and then vanishing all at once.
+
+    Args:
+        knobs: The archive's shape.
+        t0: The instant the window ends — the seed anchor. Naive values are read
+            as UTC, matching the store's own convention.
+
+    Returns:
+        ``(epoch_seconds, expire_epoch_seconds)``, both float64, ascending by
+        time. Empty only if the window is degenerate.
+    """
+    knobs.validate()
+    end = _epoch_seconds(t0)
+
+    tail_start = end - knobs.retention_s
+    hot_start = end - knobs.hot_span_s
+
+    tail = _aligned_range(tail_start, end, knobs.tail_cadence_sec)
+    hot = _aligned_range(hot_start, end, knobs.hot_cadence_sec)
+    # The coarse cadence is a whole multiple of the dense one, so a dense point
+    # belongs to the coarse tier exactly when it is a multiple of the coarse
+    # cadence. Testing that is cheaper and exact, where a set difference over
+    # floats would be a float-equality comparison.
+    hot_only = hot[np.mod(hot, knobs.tail_cadence_sec) != 0]
+
+    times = np.concatenate([tail, hot_only])
+    order = np.argsort(times, kind="stable")
+    times = times[order]
+    return times, tier_expiry(knobs, times)
+
+
+def tier_expiry(knobs: SeedKnobs, epoch_s: np.ndarray) -> np.ndarray:
+    """When each of these samples expires, by the tier its timestamp belongs to.
+
+    A timestamp on the coarse cadence belongs to the coarse tier and lives out
+    the retention span; anything else is a dense-tier sample and lives until it
+    ages out of the dense span. Membership is read off the timestamp rather than
+    tracked alongside it, which is what lets a *later* writer — a scenario
+    rewrite restoring a window it once protected — re-stamp a document correctly
+    without knowing how it was originally produced.
+    """
+    dense = np.mod(epoch_s, knobs.tail_cadence_sec) != 0
+    lifetime = np.where(dense, float(knobs.hot_span_s), float(knobs.retention_s))
+    return np.asarray(epoch_s + lifetime)
+
+
+def _aligned_range(start_s: float, end_s: float, cadence_s: int) -> np.ndarray:
+    """Epoch-aligned timestamps in ``[start_s, end_s]`` at ``cadence_s``."""
+    first = np.ceil(start_s / cadence_s) * cadence_s
+    last = np.floor(end_s / cadence_s) * cadence_s
+    if last < first:
+        return np.empty(0, dtype=np.float64)
+    count = int(round((last - first) / cadence_s)) + 1
+    return np.asarray(first + np.arange(count, dtype=np.float64) * cadence_s)
+
+
+def _epoch_seconds(moment: datetime) -> float:
+    """Epoch seconds for one datetime, reading a naive value as UTC."""
+    aware = moment if moment.tzinfo is not None else moment.replace(tzinfo=UTC)
+    return aware.timestamp()
+
+
+def _as_utc_datetimes(epoch_s: np.ndarray) -> list[datetime]:
+    """Epoch seconds back to the timezone-aware datetimes the store stores.
+
+    pymongo reads a naive datetime as UTC, so writing aware ones costs nothing
+    and removes the question entirely.
+    """
+    return [datetime.fromtimestamp(float(value), UTC) for value in epoch_s]
+
+
+# ---------------------------------------------------------------------------
+# Synthesis
+# ---------------------------------------------------------------------------
+
+
+def synthesize_documents(
+    channels: Sequence[Mapping[str, Any]],
+    epoch_s: np.ndarray,
+    *,
+    engine: SimulationEngine | None = None,
+    boot_values: Mapping[str, float] | None = None,
+    noise_level: float = DEFAULT_NOISE_LEVEL,
+) -> list[dict[str, Any]]:
+    """One document per timestamp, carrying every channel's value at it.
+
+    This is the single definition of "what the archive holds at time T", and it
+    is deliberately exported: the base seed writes it, a scenario rewrite
+    restores to it, and an equivalence test compares a live query against it.
+    A second implementation of this arithmetic anywhere would be a second
+    opinion about the machine's past.
+
+    Channel values come from three places, matching what the deployment's live
+    half serves:
+
+    * a channel the machine model describes goes through the engine, events and
+      all;
+    * an analog channel it does not goes through the procedural generator,
+      anchored on the value the Virtual Accelerator boots it at;
+    * a channel served as a flag, an enumeration or text carries a *constant* —
+      the live machine holds those still, and noise on a status flag would be
+      history no operator could read as anything but a fault.
+
+    Args:
+        channels: Manifest channel entries. Each needs ``address``; ``record_type``
+            selects the constant path when present (absent is read as analog).
+        epoch_s: Absolute epoch seconds, one per document.
+        engine: The machine model's engine, or ``None`` when the project has
+            none and every channel is procedural.
+        boot_values: ``{address: value}`` from the machine model, threaded into
+            :func:`~osprey.simulation.procedural.baseline_value` so procedural
+            channels anchor where the VA boots them.
+        noise_level: Relative noise for the procedural channels.
+
+    Returns:
+        A list of ``{date: datetime, <address>: value}`` documents, ascending in
+        time. No ``expireAt`` — stamping is the caller's, because the tier a
+        timestamp belongs to is a property of the grid, not of the values.
+    """
+    stamps = _as_utc_datetimes(epoch_s)
+    documents: list[dict[str, Any]] = [{DATE_FIELD: stamp} for stamp in stamps]
+    if not documents:
+        return documents
+
+    # Synthesize at the epoch seconds a *reader* of these documents derives from
+    # their stored dates, not at the ones the grid was built from. Datetimes
+    # carry microseconds, so a grid time with finer resolution than that would
+    # otherwise be stored as one instant and valued as another — a discrepancy
+    # no test of the shipped whole-second cadences would ever surface, and one
+    # that would break bit-equality for any caller that seeds a finer grid.
+    reader_epoch_s = epoch_seconds_array(stamps)
+    assert reader_epoch_s is not None  # noqa: S101 - datetimes always convert
+
+    for channel in channels:
+        address = str(channel["address"])
+        values = _channel_values(
+            channel,
+            address,
+            stamps,
+            reader_epoch_s,
+            engine=engine,
+            boot_values=boot_values,
+            noise_level=noise_level,
+        )
+        for document, value in zip(documents, values, strict=True):
+            document[address] = value
+
+    return documents
+
+
+def _channel_values(
+    channel: Mapping[str, Any],
+    address: str,
+    stamps: list[datetime],
+    epoch_s: np.ndarray,
+    *,
+    engine: SimulationEngine | None,
+    boot_values: Mapping[str, float] | None,
+    noise_level: float,
+) -> Sequence[Any]:
+    """One channel's values across the chunk, by the rules above."""
+    record_type = str(channel.get("record_type", RECORD_TYPE_ANALOG))
+
+    if engine_serves(engine, address) and engine is not None:
+        # Even a flag goes through synthesis when the model describes it: a
+        # scenario is entitled to step STATUS:FAULT true partway through the
+        # window, and a constant would erase exactly the event worth archiving.
+        return [_coerce(record_type, value) for value in engine.synthesize_series(address, stamps)]
+
+    if record_type == RECORD_TYPE_ANALOG:
+        return [
+            float(value)
+            for value in generate_series(
+                address,
+                epoch_s,
+                noise_level=noise_level,
+                baseline=baseline_value(address, boot_values),
+            )
+        ]
+
+    # A discrete or textual channel with no model entry: nothing moves it. The
+    # manifest forbids declaring these record types noisy, and the VA serves
+    # them as a bare coerced baseline on every poll tick — so one value covers
+    # the window, and computing a noisy series to round it away would be both
+    # slower and a claim about motion that never happens.
+    return [_coerce(record_type, baseline_value(address, boot_values))] * len(stamps)
+
+
+def _coerce(record_type: str, value: Any) -> Any:
+    """One value in the type the channel is served as.
+
+    Mirrors the serving layer's own coercion table. The machine model stores
+    every channel as a number, even the ones served as flags, and a raw float
+    on a flag channel would be archived as a value no client could ever have
+    read back.
+    """
+    if record_type == RECORD_TYPE_BINARY:
+        return bool(value)
+    if record_type == RECORD_TYPE_MBB:
+        return int(value)
+    if record_type in _TEXT_RECORD_TYPES:
+        return str(value)
+    return float(value)
+
+
+# ---------------------------------------------------------------------------
+# The manifest
+# ---------------------------------------------------------------------------
+
+
+def seed_fingerprint(
+    knobs: SeedKnobs,
+    channel_addresses: Iterable[str],
+    *,
+    compression: str,
+) -> dict[str, Any]:
+    """The knobs a store's coverage depends on, as a comparable dict.
+
+    Everything here changes what the store *contains*: the window's depth and
+    density, which channels are in it, how it is compressed on disk, and the
+    document schema itself. Nothing here is an instant or a count — those move
+    on every deploy and would make the comparison a coin flip.
+
+    Args:
+        knobs: The archive's shape.
+        channel_addresses: The seeded channel set. Order does not matter; the
+            hash is taken over the sorted, deduplicated names.
+        compression: The collection's block compressor.
+
+    Returns:
+        The fingerprint, JSON-serializable and safe to store verbatim.
+    """
+    names = sorted(set(channel_addresses))
+    digest = hashlib.sha256("\n".join(names).encode("utf-8")).hexdigest()
+    return {
+        "schema_version": SEED_SCHEMA_VERSION,
+        "retention_days": knobs.retention_days,
+        "hot_span_hours": knobs.hot_span_hours,
+        "hot_cadence_sec": knobs.hot_cadence_sec,
+        "tail_cadence_sec": knobs.tail_cadence_sec,
+        "compression": compression,
+        "channel_count": len(names),
+        "channel_set_sha256": digest,
+    }
+
+
+def write_manifest(
+    collection: Collection,
+    fingerprint: Mapping[str, Any],
+    *,
+    seeded_at: datetime,
+    report: SeedReport | None = None,
+) -> None:
+    """Record what this store was built with, replacing any previous manifest.
+
+    The manifest lives in the sample collection under a fixed ``_id`` and
+    carries no ``date`` field, so no archiver query can ever match it — the
+    connector's window filter requires one. Keeping it here rather than in a
+    sidecar collection is what makes "the store" one thing to create, wipe and
+    reason about.
+
+    The touched-window ledger starts empty. It belongs to the scenario rewrite,
+    which needs to know which windows it has to restore before applying a new
+    set; a fresh base has none, and a reseed clears it precisely because the
+    windows it named no longer exist.
+    """
+    document = {
+        "_id": MANIFEST_ID,
+        "fingerprint": dict(fingerprint),
+        "seeded_at": seeded_at,
+        "touched_windows": [],
+    }
+    if report is not None:
+        document["coverage"] = {
+            "documents": report.documents,
+            "channels": report.channels,
+            "start": report.start,
+            "end": report.end,
+        }
+    collection.replace_one({"_id": MANIFEST_ID}, document, upsert=True)
+
+
+def compare_fingerprint(
+    collection: Collection, fingerprint: Mapping[str, Any]
+) -> FingerprintComparison:
+    """Whether the store in front of us was built with the knobs now in force.
+
+    Args:
+        collection: The sample collection.
+        fingerprint: What :func:`seed_fingerprint` says the knobs are now.
+
+    Returns:
+        The comparison. ``MISMATCH`` carries every field that moved, including
+        ones the stored manifest lacks entirely (reported as ``None``), so a
+        store seeded by an older version reseeds with a readable reason rather
+        than silently.
+    """
+    stored = collection.find_one({"_id": MANIFEST_ID})
+    if stored is None:
+        return FingerprintComparison(SeedState.ABSENT)
+
+    seeded_at = stored.get("seeded_at")
+    held = stored.get("fingerprint") or {}
+    differences = tuple(
+        (key, held.get(key), expected)
+        for key, expected in sorted(fingerprint.items())
+        if held.get(key) != expected
+    )
+    if differences:
+        return FingerprintComparison(SeedState.MISMATCH, differences, seeded_at)
+    return FingerprintComparison(SeedState.MATCH, (), seeded_at)
+
+
+# ---------------------------------------------------------------------------
+# Writing
+# ---------------------------------------------------------------------------
+
+
+def prepare_collection(collection: Collection) -> None:
+    """Create the two indexes the store cannot work without.
+
+    ``{date: 1}`` is not an optimization: every archiver read sorts on ``date``,
+    and an unindexed sort is capped at 32 MB of documents in memory — a limit a
+    real window crosses long before a real deployment notices it in testing.
+
+    The TTL index is declared with ``expireAfterSeconds=0`` so each document's
+    own ``expireAt`` *is* its deadline, which is what gives the two tiers
+    different lifetimes from one index. Documents without the field — the
+    manifest, and any window a scenario rewrite has protected — are ignored by
+    it entirely.
+
+    Both are idempotent: re-creating an identical index is a no-op, so this is
+    safe on every deploy rather than only on the first.
+    """
+    collection.create_index(DATE_FIELD)
+    collection.create_index(EXPIRE_FIELD, expireAfterSeconds=0)
+
+
+def seed_base(
+    collection: Collection,
+    channels: Sequence[Mapping[str, Any]],
+    knobs: SeedKnobs,
+    *,
+    t0: datetime,
+    engine: SimulationEngine | None = None,
+    boot_values: Mapping[str, float] | None = None,
+    noise_level: float = DEFAULT_NOISE_LEVEL,
+    compression: str = "zstd",
+    workers: int = DEFAULT_WORKERS,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    progress: Callable[[SeedReport], None] | None = None,
+) -> SeedReport:
+    """Build the store: indexes, the whole base series, then the manifest.
+
+    The order is the contract. Indexes come first so the documents land into an
+    indexed collection instead of being indexed afterwards; the manifest comes
+    *last*, so a run that dies halfway leaves a store with no manifest — which
+    the next deploy reads as ``ABSENT`` and rebuilds. A manifest written first
+    would make a half-seeded store indistinguishable from a complete one.
+
+    Synthesis runs on the calling thread and inserts overlap it on a small pool.
+    That split is deliberate: the arithmetic is numpy and the engine is not
+    contractually thread-safe, while the round trip to the store is the part
+    worth overlapping. Submission blocks once the pool is saturated, so memory
+    stays bounded at a few chunks rather than the whole window.
+
+    Args:
+        collection: The sample collection. Existing samples are not removed —
+            a caller reseeding is expected to drop first, and one that is
+            extending a store deliberately is not second-guessed here.
+        channels: Manifest channel entries to seed.
+        knobs: The archive's shape.
+        t0: The seed anchor; the window ends here.
+        engine: The machine model's engine, or ``None``.
+        boot_values: Machine-model values, for procedural baseline anchoring.
+        noise_level: Relative noise for the procedural channels.
+        compression: The collection's block compressor, recorded in the
+            manifest because changing it changes the store's size on disk.
+        workers: Concurrent insert workers.
+        chunk_size: Timestamps synthesized and inserted per batch.
+        progress: Called after each chunk with the running report, for a
+            deploy-time progress line.
+
+    Returns:
+        The completed report.
+
+    Raises:
+        ValueError: If ``chunk_size`` or ``workers`` is below one, or the knobs
+            are inconsistent.
+    """
+    if chunk_size < 1:
+        raise ValueError(f"chunk_size must be >= 1 (got {chunk_size})")
+    if workers < 1:
+        raise ValueError(f"workers must be >= 1 (got {workers})")
+
+    times, expiry = seed_grid(knobs, t0)
+    addresses = [str(channel["address"]) for channel in channels]
+    started = time.monotonic()
+
+    report = SeedReport(channels=len(addresses))
+    if len(times):
+        report.start = datetime.fromtimestamp(float(times[0]), UTC)
+        report.end = datetime.fromtimestamp(float(times[-1]), UTC)
+
+    prepare_collection(collection)
+
+    with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="archiver-seed") as pool:
+        pending: set[Future[None]] = set()
+        for chunk_times, chunk_expiry in _chunks(times, expiry, chunk_size):
+            documents = synthesize_documents(
+                channels,
+                chunk_times,
+                engine=engine,
+                boot_values=boot_values,
+                noise_level=noise_level,
+            )
+            for document, expire_at in zip(documents, _as_utc_datetimes(chunk_expiry), strict=True):
+                document[EXPIRE_FIELD] = expire_at
+
+            pending = _submit_bounded(pool, pending, collection, documents, workers)
+
+            report.documents += len(documents)
+            report.chunks += 1
+            report.elapsed_s = time.monotonic() - started
+            if progress is not None:
+                progress(report)
+
+        for future in pending:
+            future.result()
+
+    report.elapsed_s = time.monotonic() - started
+    write_manifest(
+        collection,
+        seed_fingerprint(knobs, addresses, compression=compression),
+        seeded_at=t0,
+        report=report,
+    )
+    logger.info(report.describe())
+    return report
+
+
+def _submit_bounded(
+    pool: ThreadPoolExecutor,
+    pending: set[Future[None]],
+    collection: Collection,
+    documents: list[dict[str, Any]],
+    limit: int,
+) -> set[Future[None]]:
+    """Queue one insert, first draining until fewer than ``limit`` are in flight.
+
+    Draining is what bounds memory: an unbounded submit would let synthesis run
+    ahead of the store and hold the entire window's documents at once. Results
+    are collected as part of draining so an insert failure surfaces here rather
+    than being swallowed by a future nobody reads.
+    """
+    while len(pending) >= limit:
+        done = {future for future in pending if future.done()}
+        if not done:
+            next(iter(pending)).result()
+            continue
+        for future in done:
+            future.result()
+        pending -= done
+
+    pending.add(pool.submit(_insert_chunk, collection, documents))
+    return pending
+
+
+def _insert_chunk(collection: Collection, documents: list[dict[str, Any]]) -> None:
+    """Insert one batch, unordered so the server may parallelize it internally."""
+    if documents:
+        collection.insert_many(documents, ordered=False)
+
+
+def _chunks(
+    times: np.ndarray, expiry: np.ndarray, size: int
+) -> Iterator[tuple[np.ndarray, np.ndarray]]:
+    """Split the grid into contiguous batches of at most ``size`` timestamps."""
+    for start in range(0, len(times), size):
+        stop = start + size
+        yield times[start:stop], expiry[start:stop]
+
+
+def oldest_sample(collection: Collection) -> datetime | None:
+    """The instant of the oldest stored sample, or ``None`` for an empty store.
+
+    This is what honest archiver metadata reports as the start of coverage. The
+    filter on ``date`` skips the manifest, which has none — and skipping it is
+    the reason the manifest was given no ``date`` in the first place.
+    """
+    document = collection.find_one({DATE_FIELD: {"$exists": True}}, sort=[(DATE_FIELD, 1)])
+    if document is None:
+        return None
+    stamp = document.get(DATE_FIELD)
+    if not isinstance(stamp, datetime):
+        return None
+    return stamp if stamp.tzinfo is not None else stamp.replace(tzinfo=UTC)

--- a/src/osprey/simulation/procedural.py
+++ b/src/osprey/simulation/procedural.py
@@ -1,0 +1,385 @@
+"""Absolute-time procedural synthesis for channels the machine model omits.
+
+The data-driven :class:`~osprey.simulation.engine.SimulationEngine` serves only
+the channels a project's ``machine.json`` declares. Everything else in the
+served namespace — 1,872 of the control-assistant preset's 2,908 channels — has
+no model, and the Virtual Accelerator falls back to the shared PV taxonomy for
+it: ``EngineSource`` serves ``classify_pv(address).base_value`` plus a keyed
+noise draw at :meth:`~osprey.connectors.pv_taxonomy.PVKind.noise_sigma`. This
+module is the archiver-side half of that same fallback — the *history* of a
+channel whose live value the VA synthesizes from the taxonomy.
+
+Three properties are contracts, not preferences:
+
+* **Values are a pure function of (channel, absolute epoch seconds).** No
+  window, sample count or stream position enters the computation, so two
+  archiver queries that share a timestamp return the same value at it, and a
+  document written into a store now equals what a query synthesizes for that
+  timestamp later. The window-relative generator this replaces could not
+  satisfy either: its ``np.linspace(0, 1, n)`` axis made every value a function
+  of the query's shape, so materializing it produced history that contradicted
+  the next read.
+
+* **Baselines come from one source, shared with the VA.** A channel's baseline
+  is the value the VA boots it at: the ``machine.json`` seed for the ``:SP`` and
+  ``:RB`` channels that carry one (the pyat-coupled and sp-echo partitions), and
+  ``classify_pv(...).base_value`` for the rest (the static-noisy partition).
+  :func:`baseline_value` is that rule, in one place. This is what makes the
+  splice between seeded history and recorded reality seamless: when a recorder
+  starts sampling the live machine at T0, the last synthesized sample and the
+  first recorded one differ by noise, not by a step an operator would rightly
+  read as an event.
+
+* **The excursion is scaled to the channel's declared noise.** Every shape term
+  below is expressed in multiples of the channel's own sigma rather than in
+  engineering units. A channel the VA serves as a stationary ``base ± 1%`` must
+  not have a history that swings 5% and then flatlines the moment recording
+  starts — that seam *is* a fabricated anomaly, and a diagnosing agent would be
+  right to chase it. :func:`deviation_bound` states the resulting envelope so
+  seam assertions can quote it rather than hard-code a number. A
+  ``noise_level`` of ``0.0`` is an explicit request for determinism and yields
+  the bare baseline, exactly as the VA serves it.
+
+Callers must convert timestamps with
+:func:`osprey.simulation.series.epoch_seconds_array`, the same helper
+:meth:`SimulationEngine.synthesize_series` uses. Deriving epoch seconds some
+other way (integer-nanosecond division, say) agrees only to within a float ULP,
+and the texture terms are continuous functions of that input — so a second
+conversion route would silently cost bit-equality between two writers of the
+same store.
+"""
+
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+import numpy as np
+
+from osprey.connectors.pv_taxonomy import classify_pv
+from osprey.simulation.series import keyed_normals, pv_key_bytes, wander
+
+__all__ = [
+    "DEFAULT_NOISE_LEVEL",
+    "KIND_SHAPES",
+    "KindShape",
+    "baseline_value",
+    "deviation_bound",
+    "generate_series",
+]
+
+_MINUTE = 60.0
+_HOUR = 3600.0
+
+DEFAULT_NOISE_LEVEL = 0.01
+"""Relative noise fraction assumed when a caller names none.
+
+Matches the Virtual Accelerator's ``EngineSource.DEFAULT_NOISE_LEVEL``, which
+is what the live half of a deployed world serves these channels with. The value
+is duplicated rather than imported: ``osprey.simulation`` must stay loadable
+without the VA service package. A writer that has the deployed noise level in
+hand should pass it explicitly.
+"""
+
+# Independent draw streams for this module's three stochastic terms. Subkeyed
+# off the channel key so a channel that is *also* engine-served (a project can
+# move a channel into machine.json) draws different numbers here than the
+# engine's own ":noise"/texture streams, instead of correlating with them.
+_DRIFT_SUBKEY = b":procedural:drift"
+_CYCLE_SUBKEY = b":procedural:cycle"
+_NOISE_SUBKEY = b":procedural:noise"
+
+_TWO_PI = 2.0 * np.pi
+
+# Counters are epoch milliseconds, the convention `_apply_signal_model` pins for
+# every keyed draw in the simulation package.
+_MS_PER_S = 1000.0
+
+_SEAM_NOISE_SIGMAS = 5.0
+"""Noise headroom :func:`deviation_bound` adds on top of the shape envelope.
+
+A seam comparison holds two *independent* draws — the last synthesized sample
+and the first recorded one — so the bound has to cover both tails, not one.
+Five sigma leaves the assertion meaningful (it is a small fraction of the
+excursions the previous generator produced) while making a false failure a
+once-in-millions event rather than a flake to be chased.
+"""
+
+_SINE = "sine"
+_SAWTOOTH = "sawtooth"
+
+# Address suffixes of the channels no value source drives: a setpoint moves
+# only when a client writes it, and its readback only echoes that write. The
+# subfield is the last colon-separated segment of a manifest address, which is
+# how the manifest itself is keyed.
+_UNDRIVEN_SUBFIELDS = (":SP", ":RB")
+
+# What ``serving.pvdb`` boots an analog record at with no seed of its own.
+_RECORD_TYPE_DEFAULT = 0.0
+
+
+@dataclass(frozen=True)
+class KindShape:
+    """One PV kind's texture, in multiples of that channel's noise sigma.
+
+    The two terms play different roles and are both needed. ``drift`` is a
+    :func:`~osprey.simulation.series.wander` stack — quasi-random, band-limited,
+    individualized per channel by its key — which is what stops a whole family
+    of channels from moving in lockstep. ``cycle`` is a single deterministic
+    period carrying the kind's *recognizable* signature: the sawtooth of beam
+    current decaying between refills, the ripple of a vacuum gauge, the daily
+    breathing of a temperature.
+
+    Attributes:
+        drift_sigmas: Wander envelope, in sigmas.
+        drift_period_s: Slowest wander period, in seconds.
+        cycle_sigmas: Periodic-term amplitude, in sigmas.
+        cycle_period_s: Period of that term, in seconds.
+        cycle_shape: ``"sine"``, or ``"sawtooth"`` for a sudden rise followed by
+            a linear decay across the period (a refill cycle).
+    """
+
+    drift_sigmas: float
+    drift_period_s: float
+    cycle_sigmas: float
+    cycle_period_s: float
+    cycle_shape: str = _SINE
+
+    @property
+    def shape_sigmas(self) -> float:
+        """Largest deviation the two shape terms can reach together, in sigmas."""
+        return self.drift_sigmas + self.cycle_sigmas
+
+
+# Per-kind shapes, keyed by PVKind.name. The character of each kind is the one
+# the window-relative generator established -- beam current sawtooths between
+# refills, pressure ripples fast, temperature breathes daily, voltage is steady
+# with a slow swing -- re-expressed on an absolute time axis and rescaled into
+# the channel's declared noise envelope (see the module docstring). Periods are
+# deliberately not harmonics of each other, so two kinds sampled over the same
+# window do not appear to move together.
+KIND_SHAPES: Mapping[str, KindShape] = MappingProxyType(
+    {
+        "beam_current": KindShape(
+            drift_sigmas=0.8,
+            drift_period_s=18 * _HOUR,
+            cycle_sigmas=1.5,
+            cycle_period_s=4 * _HOUR,
+            cycle_shape=_SAWTOOTH,
+        ),
+        "current": KindShape(
+            drift_sigmas=1.5,
+            drift_period_s=12 * _HOUR,
+            cycle_sigmas=1.0,
+            cycle_period_s=90 * _MINUTE,
+        ),
+        "voltage": KindShape(
+            drift_sigmas=0.5, drift_period_s=24 * _HOUR, cycle_sigmas=1.0, cycle_period_s=3 * _HOUR
+        ),
+        "power": KindShape(
+            drift_sigmas=1.0,
+            drift_period_s=9 * _HOUR,
+            cycle_sigmas=1.0,
+            cycle_period_s=45 * _MINUTE,
+        ),
+        "pressure": KindShape(
+            drift_sigmas=1.5,
+            drift_period_s=6 * _HOUR,
+            cycle_sigmas=1.0,
+            cycle_period_s=20 * _MINUTE,
+        ),
+        "temperature": KindShape(
+            drift_sigmas=1.5,
+            drift_period_s=24 * _HOUR,
+            cycle_sigmas=0.75,
+            cycle_period_s=35 * _MINUTE,
+        ),
+        "lifetime": KindShape(
+            drift_sigmas=1.5,
+            drift_period_s=8 * _HOUR,
+            cycle_sigmas=1.0,
+            cycle_period_s=100 * _MINUTE,
+        ),
+        "position": KindShape(
+            drift_sigmas=1.5,
+            drift_period_s=5 * _HOUR,
+            cycle_sigmas=0.75,
+            cycle_period_s=25 * _MINUTE,
+        ),
+        "energy": KindShape(
+            drift_sigmas=0.5, drift_period_s=24 * _HOUR, cycle_sigmas=0.5, cycle_period_s=2 * _HOUR
+        ),
+        "default": KindShape(
+            drift_sigmas=1.0, drift_period_s=12 * _HOUR, cycle_sigmas=1.0, cycle_period_s=2 * _HOUR
+        ),
+    }
+)
+
+
+def _shape_for(kind_name: str) -> KindShape:
+    """The shape table entry for a kind, falling back to the generic one.
+
+    ``classify_pv`` is the only producer of these names and every one it can
+    return has an entry, so the fallback is reached only if a kind is added
+    there without one here — in which case a generic texture is a better
+    outcome than a ``KeyError`` on an archiver read.
+    """
+    return KIND_SHAPES.get(kind_name, KIND_SHAPES["default"])
+
+
+def _keyed_fraction(pv_key: bytes) -> float:
+    """A stable per-channel value in ``[0, 1)``, used as a cycle phase.
+
+    Derived from the key by the same digest-then-truncate construction the draw
+    primitives use, so it is reproducible across processes (unlike anything
+    built on ``hash()``) and independent of the normal draws keyed off the same
+    channel.
+    """
+    word = int.from_bytes(hashlib.sha256(pv_key).digest()[:8], "big")
+    return word / 2.0**64
+
+
+def _cycle_term(pv_key: bytes, times: "np.ndarray", shape: KindShape) -> "np.ndarray":
+    """The kind's periodic signature at ``times``, in sigmas (bounded by 1)."""
+    phase = _keyed_fraction(pv_key + _CYCLE_SUBKEY)
+    turns = times / shape.cycle_period_s + phase
+    if shape.cycle_shape == _SAWTOOTH:
+        # +1 at the refill, decaying linearly to -1 just before the next one.
+        return 1.0 - 2.0 * np.mod(turns, 1.0)
+    return np.sin(_TWO_PI * turns)
+
+
+def baseline_value(pv_name: str, boot_values: Mapping[str, float] | None = None) -> float:
+    """The value the Virtual Accelerator settles ``pv_name`` at.
+
+    This is the single anchoring rule the archiver's synthetic history and the
+    VA's live values share, and it mirrors the VA's own three sources:
+
+    * a channel the machine model describes is served from the model — by the
+      engine on the static-noisy partition, and as the boot seed
+      ``serving.pvdb`` gives a ``:SP``/``:RB`` record on the other two;
+    * a ``:SP``/``:RB`` channel the model does *not* describe boots at its
+      record type's default and stays there, because nothing drives a setpoint
+      but a client write. The taxonomy's guess for its name is the wrong answer:
+      an ion-pump ``VOLTAGE:SP`` no scenario seeds reads 0 V on the live
+      machine, and history claiming 5 kV would be pure invention;
+    * everything else is static-noisy telemetry with no model entry, which
+      ``EngineSource`` serves from the PV taxonomy.
+
+    A caller holding the machine model (the base seeder does) passes it as
+    ``boot_values`` and gets the anchored baseline for all three fidelity
+    partitions. A caller without one — a bare mock connector on a project with
+    no machine file — cannot tell the second case from the third and gets the
+    taxonomy baseline throughout, which is all the information available.
+
+    Args:
+        pv_name: Channel name.
+        boot_values: Optional ``{address: value}`` map, conventionally
+            ``machine.json``'s stored channel values. Entries that are not real
+            numbers (a string-valued channel, say) are ignored rather than
+            coerced — this generator is numeric.
+
+    Returns:
+        The baseline in the channel's engineering units.
+    """
+    if boot_values is None:
+        return classify_pv(pv_name).base_value
+    seed = boot_values.get(pv_name)
+    if isinstance(seed, (int, float)) and not isinstance(seed, bool):
+        return float(seed)
+    if pv_name.endswith(_UNDRIVEN_SUBFIELDS):
+        return _RECORD_TYPE_DEFAULT
+    return classify_pv(pv_name).base_value
+
+
+def generate_series(
+    pv_name: str,
+    t_abs_s: "np.ndarray | float",
+    *,
+    noise_level: float = DEFAULT_NOISE_LEVEL,
+    baseline: float | None = None,
+) -> "np.ndarray":
+    """Synthesize ``pv_name``'s value at absolute epoch seconds ``t_abs_s``.
+
+    Scalars and arrays follow one code path, so a live read at wall-clock *now*
+    and an archiver sample at that same instant agree bit-for-bit.
+
+    Args:
+        pv_name: Channel name; keys every stochastic term and picks the kind.
+        t_abs_s: Absolute epoch seconds — any shape, or a scalar. Pass values
+            produced by :func:`osprey.simulation.series.epoch_seconds_array`
+            (see the module docstring on why the conversion route is pinned).
+        noise_level: Relative noise fraction, floored per kind by
+            :meth:`~osprey.connectors.pv_taxonomy.PVKind.noise_sigma` so a
+            legitimately-zero baseline is not dead flat. ``0.0`` disables every
+            stochastic and shape term and returns the bare baseline.
+        baseline: Baseline override, normally from :func:`baseline_value`.
+            ``None`` resolves the taxonomy baseline for the channel.
+
+    Returns:
+        A float64 array of values with the shape of ``t_abs_s`` (0-d for a
+        scalar input).
+    """
+    times = np.asarray(t_abs_s, dtype=np.float64)
+    kind = classify_pv(pv_name)
+    base = kind.base_value if baseline is None else float(baseline)
+    sigma = kind.noise_sigma(base, noise_level)
+    if sigma <= 0.0:
+        # An explicit request for determinism: the VA serves the bare boot
+        # value at noise_level 0, and so must its history.
+        return np.full(times.shape, base, dtype=np.float64)
+
+    shape = _shape_for(kind.name)
+    pv_key = pv_key_bytes(pv_name)
+    # Flatten before drawing and restore the caller's shape after. The draw
+    # primitives wrap uint64 arithmetic silently on arrays but warn on numpy
+    # scalars, so a 0-d input would produce the right value with a spurious
+    # overflow warning attached -- and the scalar path is the live-read path.
+    flat = times.reshape(-1)
+    values = np.full(flat.shape, base, dtype=np.float64)
+    values = values + wander(
+        pv_key + _DRIFT_SUBKEY, flat, shape.drift_sigmas * sigma, shape.drift_period_s
+    )
+    values = values + shape.cycle_sigmas * sigma * _cycle_term(pv_key, flat, shape)
+    values = values + sigma * keyed_normals(pv_key + _NOISE_SUBKEY, flat * _MS_PER_S)
+    return np.asarray(values.reshape(times.shape))
+
+
+def deviation_bound(
+    pv_name: str,
+    *,
+    noise_level: float = DEFAULT_NOISE_LEVEL,
+    baseline: float | None = None,
+    noise_sigmas: float = _SEAM_NOISE_SIGMAS,
+) -> float:
+    """How far from its baseline this generator can plausibly take a channel.
+
+    The intended reader is a seam assertion: seeded history ends at T0 and
+    recorded reality begins there, and the step between them must be
+    attributable to noise rather than to an event. Quoting this function keeps
+    that threshold derived from the same shape table the values come from, so
+    retuning a kind cannot silently invalidate the assertion.
+
+    The bound is structural, not statistical, for the shape terms —
+    :func:`~osprey.simulation.series.wander`'s weights are positive and sum to
+    one, and the cycle term is a bounded sinusoid or sawtooth — and covers
+    ``noise_sigmas`` of the unbounded Gaussian term on top.
+
+    Args:
+        pv_name: Channel name.
+        noise_level: The relative noise the series was (or will be) generated
+            with. Must match, or the bound describes a different series.
+        baseline: Baseline override, as for :func:`generate_series`.
+        noise_sigmas: Gaussian headroom; the default covers the two independent
+            draws either side of a seam.
+
+    Returns:
+        The bound in the channel's engineering units; ``0.0`` when
+        ``noise_level`` disables synthesis entirely.
+    """
+    kind = classify_pv(pv_name)
+    base = kind.base_value if baseline is None else float(baseline)
+    sigma = kind.noise_sigma(base, noise_level)
+    if sigma <= 0.0:
+        return 0.0
+    return (_shape_for(kind.name).shape_sigmas + noise_sigmas) * sigma

--- a/src/osprey/templates/apps/control_assistant/README.md.j2
+++ b/src/osprey/templates/apps/control_assistant/README.md.j2
@@ -44,9 +44,16 @@ This application demonstrates production-validated patterns for building AI assi
   Channel Access with live storage-ring physics (corrector setpoints move BPM
   readbacks). **Requires the VA service** — add `virtual_accelerator` to
   `deployed_services` in `config.yml`, run `osprey deploy up`, then
-  `osprey config set-control-system virtual_accelerator`. See the
-  "Use the Virtual Accelerator" how-to guide for scenarios, limits, and the
-  archiver live-vs-history note.
+  `osprey config set-control-system virtual_accelerator`.
+
+  That last command **also requires a real archive**, and is refused while the
+  project still reads the `mock_archiver`: a simulated machine whose history is
+  synthesized at read time reports a past that never happened. Point
+  `archiver.type` at a store this deployment writes first — the way to get one
+  is a `va_archiver:` block in the build profile, which makes `osprey deploy up`
+  stand up a store and a recorder beside the VA and seed the history. See the
+  "Use the Virtual Accelerator" how-to guide for the archive, scenarios and
+  limits.
 - **`epics`** — production EPICS via the facility gateway.
 
 ---

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -421,10 +421,19 @@ archiver:
   # Options:
   #   - mock_archiver: Development mode (generates synthetic data)
   #   - epics_archiver: EPICS Archiver Appliance
-  #   - mongodb_archiver: MongoDB time-series collection. Needs the
-  #     archiver-mongodb extra AND a mongodb_archiver block (see below) —
-  #     the connector has no defaults for the required keys.
-  type: mock_archiver  # <-- Change to 'epics_archiver' for production
+  #   - mongodb_archiver: MongoDB time-series collection. Reads a store this
+  #     project deploys, seeds and records into — real recorded history, which
+  #     is what the control-assistant PRESET selects, because it also declares
+  #     the `va_archiver:` block that deploys the store.
+  #
+  # The default here stays mock_archiver, and deliberately: a project built from
+  # this template WITHOUT a `va_archiver:` block deploys no store, so naming a
+  # store-backed connector would leave it pointing at something that does not
+  # exist and failing at connect. A mock is the honest answer for a project with
+  # no archive — it synthesizes, and says so. The flip to a real archive travels
+  # with the block that makes the archive exist, which is the preset's job and
+  # arrives as an `archiver.type` override at build time.
+  type: mock_archiver  # <-- 'epics_archiver' for production
 
   # Mock archiver (development mode) — synthesizes history from the same
   # simulation machine model as the control-system connector above, so live
@@ -447,20 +456,27 @@ archiver:
     url: https://archiver.als.lbl.gov:8443
     timeout: 60              # Timeout for archiver requests in seconds
 
-  # MongoDB archiver — install the extra first:
+  # MongoDB archiver — needs the archiver-mongodb extra:
   #   pip install 'osprey-framework[archiver-mongodb]'
-  # Every key below except port and timeout is required; the connector raises
-  # on the first one missing. The password itself is never stored here — it is
-  # read at connect time from the environment variable named by password_env.
-  # mongodb_archiver:
-  #   host: mongodb.example.org
-  #   port: 27017             # Optional, defaults to 27017
-  #   name: my-archiver-database
-  #   collection: my-archiver-collection
-  #   auth: database-auth     # Authentication database
-  #   username: my-username
-  #   password_env: MONGODB_READONLY_PASSWORD
-  #   timeout: 60             # Optional, defaults to 60 seconds
+  # Every key here except port and timeout is required; the connector raises on
+  # the first one missing. The password itself is never stored here — it is read
+  # at connect time from the environment variable named by password_env, which
+  # `osprey deploy up` mints into the project's .env.
+  #
+  # A project whose build profile declares a `va_archiver:` block has these
+  # written from it at build time, so they describe the store this project
+  # deploys. Edit them to point at a store someone else runs; edit the profile
+  # block instead if this project deploys its own, or the next build overwrites
+  # what you wrote here.
+  mongodb_archiver:
+    host: localhost
+    port: 27017             # Optional, defaults to 27017
+    name: osprey_archiver
+    collection: pv_history
+    auth: admin             # Authentication database
+    username: osprey
+    password_env: MONGO_ROOT_PASSWORD
+    timeout: 5              # Optional, defaults to 60 seconds
 
 # ============================================================
 # SCAN PLANS (BLUESKY BRIDGE)
@@ -492,11 +508,34 @@ archiver:
 #   plan_dirs:
 #     - /app/project/extra_plans
 
-# Migration from tutorial to production:
-# 1. Change control_system.type from 'mock' to 'epics'
-# 2. Change archiver.type from 'mock_archiver' to 'epics_archiver'
+# Migration from tutorial to production. Every key named below is a field INSIDE
+# its section — edit `type:` under `control_system:`, not a new top-level
+# `control_system.type:` line. This file is read as nested sections, so a dotted
+# line added at the top level configures nothing and is silently ignored.
+# 1. Change `type:` under `control_system:` to 'epics' and fill in the epics
+#    block above
+# 2. Change `type:` under `archiver:` to 'epics_archiver' and point
+#    epics_archiver.url at your Archiver Appliance. If you came from the
+#    control-assistant preset, that field reads 'mongodb_archiver': the preset
+#    both DEPLOYS a store and selects it, so that history is real — but it is a
+#    simulated machine's history, which is not what you want against hardware.
 # 3. Test with: osprey health
 # Your code doesn't need to change!
+#
+# One thing not to do: hand-flipping the archiver to a store-backed connector
+# without deploying a store. Nothing would be writing the archive you just named,
+# so it reads as empty rather than as broken — it fails at connect, which is at
+# least an error you can act on.
+#
+# The opposite pairing is refused outright, in all three places it can appear: a
+# 'virtual_accelerator' control system whose archiver is 'mock_archiver' — or
+# unset, which the connector factory resolves to the mock — is rejected by
+# `osprey build`, by `osprey deploy up`, and by the MCP server at startup. A
+# simulated machine whose history is synthesized at read time reports a past that
+# never happened, and nothing can catch it. Each refusal names the way out:
+# declare a `va_archiver:` block and select 'mongodb_archiver' (what this project
+# does), point the archiver at a store you run yourself, or set the control
+# system to 'mock' for an honestly storeless deployment.
 
 # ============================================================
 # CHANNEL FINDER CONFIGURATION

--- a/src/osprey/templates/apps/control_assistant/data/simulation/scenarios/rf-thermal/scenario.json
+++ b/src/osprey/templates/apps/control_assistant/data/simulation/scenarios/rf-thermal/scenario.json
@@ -1,26 +1,36 @@
 {
   "description": "Recurring cavity-1 thermal excursions: body temperature rises, reflected power spikes, and forward power trips from thermal detuning. Cavity 2 shows one minor excursion for contrast.",
+  "_comment": [
+    "Event positions are anchor-relative (`at_offset`), not window fractions.",
+    "`at_offset` is seconds relative to the scenario-activation anchor T0 (negative = past),",
+    "and for anchored spikes `width` is a Gaussian sigma in SECONDS (not a window fraction).",
+    "The three cavity-01 excursions sit at T0-38h / T0-21h / T0-7h -- inside the operator",
+    "lookback band (-40h..-2h), which is also inside the archiver's dense 48h hot tier, so",
+    "every spike is sampled at the 10 s hot cadence. sigma = 7200 s (2 h) is >= 2x both the",
+    "10 s hot and 60 s tail seed cadences, so the excursions stay resolvable at either.",
+    "Cavity-02's single minor excursion shares the middle anchor (T0-21h) for contrast."
+  ],
   "archiver": [
     {
       "channel": "SR:RF:CAVITY:01:TEMPERATURE:RB",
       "events": [
         {
           "shape": "spike",
-          "at": 0.2,
+          "at_offset": -136800,
           "amplitude": 7.0,
-          "width": 0.024
+          "width": 7200
         },
         {
           "shape": "spike",
-          "at": 0.55,
+          "at_offset": -75600,
           "amplitude": 4.9,
-          "width": 0.024
+          "width": 7200
         },
         {
           "shape": "spike",
-          "at": 0.85,
+          "at_offset": -25200,
           "amplitude": 8.4,
-          "width": 0.024
+          "width": 7200
         }
       ]
     },
@@ -29,21 +39,21 @@
       "events": [
         {
           "shape": "spike",
-          "at": 0.2,
+          "at_offset": -136800,
           "amplitude": 80.0,
-          "width": 0.024
+          "width": 7200
         },
         {
           "shape": "spike",
-          "at": 0.55,
+          "at_offset": -75600,
           "amplitude": 56.0,
-          "width": 0.024
+          "width": 7200
         },
         {
           "shape": "spike",
-          "at": 0.85,
+          "at_offset": -25200,
           "amplitude": 96.0,
-          "width": 0.024
+          "width": 7200
         }
       ]
     },
@@ -52,21 +62,21 @@
       "events": [
         {
           "shape": "spike",
-          "at": 0.2,
+          "at_offset": -136800,
           "amplitude": -440.0,
-          "width": 0.024
+          "width": 7200
         },
         {
           "shape": "spike",
-          "at": 0.55,
+          "at_offset": -75600,
           "amplitude": -308.0,
-          "width": 0.024
+          "width": 7200
         },
         {
           "shape": "spike",
-          "at": 0.85,
+          "at_offset": -25200,
           "amplitude": -528.0,
-          "width": 0.024
+          "width": 7200
         }
       ]
     },
@@ -75,21 +85,21 @@
       "events": [
         {
           "shape": "spike",
-          "at": 0.2,
+          "at_offset": -136800,
           "amplitude": -2.4,
-          "width": 0.024
+          "width": 7200
         },
         {
           "shape": "spike",
-          "at": 0.55,
+          "at_offset": -75600,
           "amplitude": -1.68,
-          "width": 0.024
+          "width": 7200
         },
         {
           "shape": "spike",
-          "at": 0.85,
+          "at_offset": -25200,
           "amplitude": -2.88,
-          "width": 0.024
+          "width": 7200
         }
       ]
     },
@@ -98,21 +108,21 @@
       "events": [
         {
           "shape": "spike",
-          "at": 0.2,
+          "at_offset": -136800,
           "amplitude": -0.001,
-          "width": 0.024
+          "width": 7200
         },
         {
           "shape": "spike",
-          "at": 0.55,
+          "at_offset": -75600,
           "amplitude": -0.0007,
-          "width": 0.024
+          "width": 7200
         },
         {
           "shape": "spike",
-          "at": 0.85,
+          "at_offset": -25200,
           "amplitude": -0.0012,
-          "width": 0.024
+          "width": 7200
         }
       ]
     },
@@ -121,21 +131,21 @@
       "events": [
         {
           "shape": "spike",
-          "at": 0.2,
+          "at_offset": -136800,
           "amplitude": 0.05,
-          "width": 0.024
+          "width": 7200
         },
         {
           "shape": "spike",
-          "at": 0.55,
+          "at_offset": -75600,
           "amplitude": 0.035,
-          "width": 0.024
+          "width": 7200
         },
         {
           "shape": "spike",
-          "at": 0.85,
+          "at_offset": -25200,
           "amplitude": 0.06,
-          "width": 0.024
+          "width": 7200
         }
       ]
     },
@@ -144,21 +154,21 @@
       "events": [
         {
           "shape": "spike",
-          "at": 0.2,
+          "at_offset": -136800,
           "amplitude": -390.0,
-          "width": 0.024
+          "width": 7200
         },
         {
           "shape": "spike",
-          "at": 0.55,
+          "at_offset": -75600,
           "amplitude": -273.0,
-          "width": 0.024
+          "width": 7200
         },
         {
           "shape": "spike",
-          "at": 0.85,
+          "at_offset": -25200,
           "amplitude": -468.0,
-          "width": 0.024
+          "width": 7200
         }
       ]
     },
@@ -167,9 +177,9 @@
       "events": [
         {
           "shape": "spike",
-          "at": 0.55,
+          "at_offset": -75600,
           "amplitude": 1.75,
-          "width": 0.024
+          "width": 7200
         }
       ]
     },
@@ -178,9 +188,9 @@
       "events": [
         {
           "shape": "spike",
-          "at": 0.55,
+          "at_offset": -75600,
           "amplitude": 20.0,
-          "width": 0.024
+          "width": 7200
         }
       ]
     },
@@ -189,9 +199,9 @@
       "events": [
         {
           "shape": "spike",
-          "at": 0.55,
+          "at_offset": -75600,
           "amplitude": -110.0,
-          "width": 0.024
+          "width": 7200
         }
       ]
     }

--- a/src/osprey/templates/claude_code/claude/skills/sim-scenarios/SKILL.md
+++ b/src/osprey/templates/claude_code/claude/skills/sim-scenarios/SKILL.md
@@ -2,29 +2,35 @@
 name: sim-scenarios
 description: >
   List, inspect, and switch the simulated machine scenarios that drive the
-  mock control system and mock archiver. Use when the user asks which
-  scenarios are available, which scenario(s) are active, or wants to switch the
-  simulated machine into a different state (e.g. a fault demo or back to
-  nominal), including composing several faults at once.
+  simulated control system and its archived history. Use when the user asks
+  which scenarios are available, which scenario(s) are active, or wants to
+  switch the simulated machine into a different state (e.g. a fault demo or back
+  to nominal), including composing several faults at once.
 summary: List, compose, and apply simulated machine scenarios
 ---
 
 # Simulation Scenarios
 
-The mock control system and mock archiver are driven by a data-driven
-simulation engine. Scenarios are **self-contained bundles** under
-`data/simulation/scenarios/<name>/`: each owns its telemetry overlay
-(`scenario.json` — channel overrides and archiver event scripts) and,
-optionally, its logbook narrative (`logbook.json`). Several scenarios can be
-**active at once** as long as they touch disjoint channel sets.
+The simulated machine is driven by a data-driven simulation engine. Scenarios
+are **self-contained bundles** under `data/simulation/scenarios/<name>/`: each
+owns its telemetry overlay (`scenario.json` — channel overrides and archiver
+event scripts) and, optionally, its logbook narrative (`logbook.json`). Several
+scenarios can be **active at once** as long as they touch disjoint channel sets.
+
+Where the history lives depends on the project. With the **mock archiver**,
+history is synthesized at read time from the active overlays. With a **stored
+archive** (`archiver.type: mongodb_archiver`, backed by the store the deployment
+runs), history is real documents in a collection — so activating a scenario has
+to *rewrite* them.
 
 ## Locate the simulation
 
 Read the project `config.yml` and find the simulation file path:
 
 - `control_system.connector.<type>.simulation_file`, where `<type>` is
-  `control_system.type` (usually `mock`). The mock archiver derives the same
-  path from this key, so it is normally declared here only.
+  `control_system.type` (`mock` or `virtual_accelerator`). A non-mock type falls
+  back to the `mock` connector's key when it has none of its own, and the mock
+  archiver derives the same path from it — so it is normally declared once.
 
 The path is relative to the project root (typically
 `data/simulation/machine.json`); scenario bundles live in the sibling
@@ -65,29 +71,80 @@ osprey sim apply nominal              # back to clean baseline
   attach archiver events to the same channel). `apply` refuses a colliding set
   with a clear error — pick scenarios that don't fight over a channel.
 - `apply` **purges and reseeds** the logbook DB so the narrative matches the
-  active telemetry. Pass `--no-seed` to change only the telemetry state, or
-  `--yes` to skip the purge confirmation.
+  active telemetry. Pass `--no-seed-logbook` to leave it alone.
+- On a project with a **stored archive**, `apply` also **rewrites that
+  archive's event windows** (below). Pass `--no-seed-archiver` to leave it
+  alone, `--no-seed` for neither, or `--yes` to skip the confirmations.
 - The switch is effective on the next channel read — no restart needed.
 
 **Important:** applying scenarios resets the simulated machine — any setpoint
 changes written during the session are cleared. Warn the user before switching
 if writes were made this session.
 
+### What the archive rewrite does
+
+Only for a project with a stored archive; one that synthesizes history at read
+time has nothing to rewrite and is unaffected.
+
+- **Restore, then apply.** Windows a *previous* scenario marked go back to their
+  baseline, and the new set's event windows are written — in one pass, because
+  every archived value is a function of the channel and the timestamp under the
+  set now in force. Re-applying the set already active changes nothing and
+  reports zero.
+- **Confirm before it runs.** The rewrite touches stored data and is not
+  additive, so `apply` prints the store it is about to rewrite and asks. On a
+  virtual-accelerator deployment the affected windows may hold samples a
+  recorder took from the running machine — one timeline, and the active scenario
+  owns its event windows. `--yes` skips the prompt.
+- **It finishes before the command returns**, and reports what it changed
+  (`Archive rewritten: rewrote N archived samples across M channel(s)`), so the
+  next history read already sees it. The recorder keeps appending live samples
+  alongside: a value written to the machine now is readable out of the archive
+  within about 30 seconds.
+- **Nothing is invented to fill a gap.** Where an event window reaches across a
+  stretch the archive has no coverage for, those instants are left empty and
+  counted, not fabricated.
+- **The archive must be seeded first.** On a store `osprey deploy up` has never
+  seeded, the rewrite is skipped and says so — run `osprey deploy up`.
+
 ## Bundle authoring
 
 ### Archiver event format (`scenario.json`)
 
-A scenario's `archiver` entries attach events to a channel's synthesized
-history. Each event has a `shape` (`step`, `ramp`, or `spike`) and exactly one
-positioning style:
+A scenario's `archiver` entries attach events to a channel's history. Each event
+has a `shape` (`step`, `ramp`, or `spike`) and exactly one positioning style.
+**A shipped or seedable bundle must use `at_offset` or `at_time`** — those are
+the two that name an absolute instant, and only an absolute instant can be
+written into a stored archive.
 
-- `at` — fraction (0..1) of whatever time window is requested; ramps use
-  `until`. Spike `width` is a window fraction.
-- `at_offset` — seconds relative to the apply-time anchor (negative = past);
-  ramps use `until_offset`. Spike `width` is in seconds.
+- `at_offset` — **seconds relative to the apply-time anchor T0** (negative =
+  past); ramps use `until_offset`. Spike `width` is a Gaussian sigma in seconds.
+  The style to reach for: an offset becomes an absolute instant the moment the
+  anchor is known.
 - `at_time` — daily wall-clock recurrence (`"HH:MM:SS"`, local time): the event
   fires at that time of day on every calendar date inside the requested window.
-  `step` and `spike` only (no ramps). Spike `width` is in seconds.
+  `step` and `spike` only (no ramps). Spike `width` is in seconds. Also
+  seedable — each occurrence is a real instant — as long as the archive covers
+  at least a day, so there is an occurrence inside it.
+- `at` — fraction (0..1) of whatever time window is requested; ramps use
+  `until`. Spike `width` is a window fraction. **Read-time only**: a fraction
+  names a position in the reader's window, not an instant, so there is no honest
+  timestamp to write it at. On a project with a stored archive `apply` rejects
+  it by name and tells you to use `at_offset`; a contract test keeps the shipped
+  bundles free of it.
+
+The anchor T0 is the same instant for the telemetry, the logbook and the
+archive: the apply-time anchor written into the scenario state file. The
+archive's coverage — seeded at deploy, then carried forward by the recorder —
+reaches back the retention window from there, which is what makes the useful
+property hold: **an event within retention of T0 lands inside history the
+archive actually holds.** At the shipped 30-day retention, an `at_offset` no
+further back than about a month has samples to be written into; anything older
+reaches past where the archive begins (retention keeps pruning the far end, so
+that boundary tracks the present), and anything positive reaches into a future
+nothing has recorded yet. Keep events inside the dense window (48 hours by
+default) when the shape needs resolution — a spike whose sigma is smaller than
+the 60-second coarse cadence is not resolvable out there.
 
 A numeric channel may declare optional `min`/`max` physical bounds; live reads
 and synthesized history are clamped into that range on the way out (e.g.
@@ -124,3 +181,5 @@ Do NOT:
 - Compose scenarios that touch the same channel — `apply` will reject them
 - Restart services after a switch — the engine re-reads the state file
   automatically
+- Position a new scenario's archiver events with `at` — author `at_offset` (or
+  `at_time`), so the event has a real instant a stored archive can hold

--- a/src/osprey/templates/services/archiver_recorder/docker-compose.yml.j2
+++ b/src/osprey/templates/services/archiver_recorder/docker-compose.yml.j2
@@ -1,0 +1,183 @@
+# The archiver-recorder service samples the live control system over Channel
+# Access and writes what it reads into the archiver store (see
+# src/osprey/services/archiver_recorder/). It is what makes deployed history
+# REAL: the base seeder materializes synthesized history once per deploy, and
+# from then on this service records the machine as it actually behaves, into
+# the same collection, on the same timeline.
+#
+# It records only while `control_system.type` is `virtual_accelerator` —
+# read from the mounted CONFIG_FILE below and re-read on an interval, not
+# latched at boot, so the documented post-build flip takes effect without a
+# restart. On any other control system it idles with a one-line log and writes
+# nothing; recording a real machine's readings into a simulated archive would
+# be exactly the kind of two-world dishonesty this feature exists to remove.
+#
+# There is deliberately NO Dockerfile here and no `build:` block: this service
+# runs the VIRTUAL ACCELERATOR's image with a different command, so it adds no
+# image build to any deploy or CI lane, and the two services can never disagree
+# about their Channel Access stack. The `virtual_accelerator` service owns that
+# tag — two services building one tag race each other (the bluesky queueserver
+# carries the same note).
+{#- One condition, read three times below (image source, startup ordering, and
+    Channel Access addressing), so the co-deployed and external cases cannot
+    drift apart in this file. #}
+{% set va_co_deployed = 'virtual_accelerator' in deployed_services %}
+
+services:
+  archiver-recorder:
+{% if va_co_deployed %}
+    image: ${OSPREY_VA_IMAGE:-{{ (services.virtual_accelerator | default({})).image | default(osprey_labels.project_name ~ '-va:local') }}}
+{% else %}
+    # No co-deployed Virtual Accelerator means nothing in this deploy BUILDS
+    # the VA image, so the local tag would not exist and compose would fail
+    # trying to pull it ("pull access denied for <project>-va") without ever
+    # naming the real problem. `:?` says it instead. An external-IOC deploy
+    # that wants a recorder supplies a published image here — the same
+    # variable a project would set to use a prebuilt VA image anyway.
+    image: ${OSPREY_VA_IMAGE:?set OSPREY_VA_IMAGE to a published osprey VA image when the virtual_accelerator service is not co-deployed}
+{% endif %}
+    # container_name is a HOST-GLOBAL docker identifier: namespace it per-project
+    # so two OSPREY projects can deploy a recorder on one host without colliding
+    # on one name. Nothing reaches this service in-network (it only makes
+    # outbound CA reads and Mongo writes), so the rename needs no network alias.
+    container_name: {{ osprey_labels.project_name }}-archiver-recorder
+    # Replaces the VA image's CMD outright (the image declares no ENTRYPOINT).
+    # `-u` for the same reason the VA uses it: unbuffered output, so the
+    # idling/recording state lines reach `docker logs` when they happen rather
+    # than a block later.
+    command: ["python", "-u", "-m", "osprey.services.archiver_recorder"]
+    labels:
+      osprey.project.name: "{{ osprey_labels.project_name }}"
+      osprey.project.root: "{{ osprey_labels.project_root }}"
+      osprey.deployed.at: "{{ osprey_labels.deployed_at }}"
+    restart: unless-stopped
+    # No `ports:` and no `healthcheck:` — deliberately. This service opens no
+    # listening socket, so it has nothing to publish and nothing an HTTP or TCP
+    # probe could ask. Its liveness question ("is history still arriving?") is
+    # answered where it belongs, by the `archiver_freshness` health probe
+    # reading the store itself.
+    depends_on:
+      # Always: the recorder's first write would otherwise race the store's
+      # startup, and on a fresh volume mongod's admin-user creation makes that
+      # window seconds long. Health-gated rather than start-gated because
+      # "container started" is not "answering commands".
+      mongodb:
+        condition: service_healthy
+{% if va_co_deployed %}
+      # Only when the VA is co-deployed: the recorder's CA client connects at
+      # startup, so it must not open before iocInit is answering. A recorder
+      # deployed against an EXTERNAL IOC must NOT get this — compose errors on
+      # depends_on naming an undefined service.
+      virtual-accelerator:
+        condition: service_healthy
+{% endif %}
+    # Deliberately NO bulk .env passthrough (the gchat/nextcloud bridge
+    # convention): this service talks to exactly two things, an IOC and the
+    # archiver store, and never calls an LLM. Everything it reads arrives by
+    # explicit interpolation below, resolved from the project .env because
+    # `deploy up` runs compose with `--env-file .env`.
+    environment:
+      # The recorder reads control_system.type (its own enablement), the
+      # va_archiver cadence/retention knobs and the archiver connection block
+      # from config.yml at runtime. CWD is the image WORKDIR (/app), not the
+      # project dir, so without CONFIG_FILE this falls back to /app/config.yml
+      # and every lookup errors "No config.yml found" — the same CONFIG_FILE
+      # convention the dispatch worker and bluesky bridge follow.
+      CONFIG_FILE: /app/project/config.yml
+      # In-network overrides for the archiver connection, following the
+      # OSPREY_OTEL_OPENOBSERVE_HOST precedent. The connection block in
+      # config.yml is written for the HOST side — `localhost` and the
+      # host-published `port_host` — which is unreachable from inside the
+      # compose network and would point at this container's own loopback. The
+      # recorder reads these two as overrides over the config values.
+      # `archiver-mongodb` is the store's network alias (pinned there
+      # precisely so this name survives the per-project container_name), and
+      # 27017 is its CONTAINER port, never the host publish.
+      OSPREY_ARCHIVER_MONGODB_HOST: archiver-mongodb
+      OSPREY_ARCHIVER_MONGODB_PORT: "27017"
+      # The store's minted root password, read through the same variable the
+      # agent connector's `password_env` names, so container, recorder, seeder
+      # and agent all authenticate with one value. `osprey deploy up` mints it
+      # into the project .env when unset. The literal fallback matches the
+      # mongodb template's own MONGO_INITDB_ROOT_PASSWORD default line for
+      # line: an unset password must mean the SAME thing on both sides, or a
+      # bare `docker compose up` brings up a store the recorder cannot
+      # authenticate against.
+      MONGO_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD:-osprey}
+      # The channel list to record. Passthrough of the same build-derived
+      # variable the VA reads, resolved against the same /data/simulation
+      # mount, so the recorder covers exactly the channels the IOC serves. It
+      # must be the channel MANIFEST — channel_limits.json is a write-safety
+      # PROJECTION of that manifest (one entry per address, read-only ones
+      # included, plus top-level metadata keys), so its key set is not a
+      # channel list and reading it as one would ask the IOC for names that
+      # are not channels. Unset/empty means the image's built-in manifest,
+      # exactly as for the VA.
+      VA_CHANNELS_FILE: "${VA_CHANNELS_FILE:-}"
+{% if va_co_deployed %}
+      # Reach the co-deployed Virtual Accelerator over Channel Access.
+      # Name-server TCP transport is the one host<->container CA config proven
+      # to work — UDP broadcast discovery doesn't cross the VM boundary. Port
+      # matches services.virtual_accelerator.port so an operator override stays
+      # consistent between the two services.
+      EPICS_CA_NAME_SERVERS: "virtual-accelerator:{{ (services.virtual_accelerator | default({})).port | default(5064) }}"
+      EPICS_CA_AUTO_ADDR_LIST: "NO"
+{% else %}
+      # External IOC: the address has to come from the deploy environment, and
+      # is REQUIRED (`:?`) rather than a bare reference. Compose resolves an
+      # unset bare ${VAR} to the empty string, so the recorder would come up
+      # with no route to any IOC and fail every read with a CA timeout — for
+      # minutes, quietly, looking exactly like a slow machine. `:?` turns that
+      # into a startup abort naming the missing variable. Set it (host:port),
+      # or co-deploy the virtual_accelerator service and this branch renders
+      # the address itself.
+      EPICS_CA_NAME_SERVERS: ${EPICS_CA_NAME_SERVERS:?set EPICS_CA_NAME_SERVERS to <host>:<port> of the IOC to record, or co-deploy the virtual_accelerator service}
+      # Defaulted rather than pinned, unlike the co-deployed branch: an
+      # external IOC may sit on a network where broadcast discovery genuinely
+      # works, and that is the operator's call. NO is the default because it
+      # is what pairs with the name-server transport above.
+      EPICS_CA_AUTO_ADDR_LIST: "${EPICS_CA_AUTO_ADDR_LIST:-NO}"
+{% endif %}
+      TZ: {{ system.timezone }}
+    volumes:
+      # Bind-mount sources are relative to the compose project directory
+      # (build/services/), not this file's own subdir — so `../..` is the
+      # project root and `../../data/simulation` the build-owned data tree.
+      #
+      # The PROJECT DIRECTORY, read-only, and a deliberate exception to the
+      # convention every other service follows. The bluesky bridge and the
+      # dispatch worker mount the flattened config.yml the compose generator
+      # stages into their own build dir; this service must not. That staged
+      # copy is written once per `deploy up`, so an enablement poll re-reading
+      # it could only ever re-read a build artifact, and the flip an operator
+      # makes in the project's own config.yml would never arrive. CONFIG_FILE
+      # above names /app/project/config.yml, which is now the LIVE file — which
+      # is what makes this service's own log line ("Flipping it in
+      # /app/project/config.yml takes effect within 30s") true verbatim.
+      #
+      # A DIRECTORY rather than the single file, and this is the load-bearing
+      # part: a single-file bind resolves to an inode when the container
+      # starts. Editors that save by writing a temp file and renaming it over
+      # the original — vim and VS Code both do — leave a NEW inode behind, and
+      # the container goes on reading the old one silently, forever. The flip
+      # would then work for truncate-in-place writers and fail for exactly the
+      # hand edit this feature documents: a green test over a broken operator
+      # flow. Mounting the directory re-resolves the path on every read, so any
+      # editor's save is seen.
+      #
+      # Read-only, so the project's .env is also visible to this container.
+      # Accepted: it is first-party and already receives the store credential
+      # by env. The in-network connection values still come from the
+      # OSPREY_ARCHIVER_MONGODB_* overrides above — the config's own connection
+      # block stays host-side and is not what this service connects with.
+      - ../..:/app/project:ro
+      # The simulation data dir, read-only, mounted at the SAME container path
+      # the VA uses so a relative VA_CHANNELS_FILE resolves identically on both
+      # sides. The recorder only reads the channel manifest from here; it never
+      # writes into the build-owned data tree.
+      - ../../data/simulation:/data/simulation:ro
+    networks:
+      - osprey-network
+
+networks:
+  osprey-network:

--- a/src/osprey/templates/services/dispatch_worker/docker-compose.yml.j2
+++ b/src/osprey/templates/services/dispatch_worker/docker-compose.yml.j2
@@ -72,6 +72,28 @@ services:
       # the container runtime — is what makes emit work under docker AND podman.
       # Inert unless claude_code.telemetry is enabled with backend: openobserve.
       OSPREY_OTEL_OPENOBSERVE_HOST: openobserve
+{#- In-network address of the archiver store, for the same reason and by the
+    same convention as OSPREY_OTEL_OPENOBSERVE_HOST above. The worker answers
+    questions about what the machine did, so its agent reaches for
+    `archiver_read` like any other -- but the connection block in config.yml is
+    written for the HOST side (`localhost` and the published `port_host`), which
+    from inside this container names its own loopback.
+
+    Gated on `deployed_services` membership, like the openobserve link above and
+    for a sharper reason than symmetry: these two are a LITERAL address, not a
+    fallback. A project whose archiver is a store someone else runs -- a
+    facility MongoDB, an Archiver Appliance -- has a config block that is
+    already correct from anywhere, and sending this worker to `archiver-mongodb`
+    would point it at a name that resolves to nothing. Set only when THIS
+    project deploys the store, which is the only case where the configured
+    host-side address is the wrong one from in here. #}
+{% if 'mongodb' in (deployed_services | default([])) %}
+      # `archiver-mongodb` is the store's network alias, pinned in the mongodb
+      # template precisely so this name survives the per-project container_name;
+      # 27017 is its CONTAINER port, never the host publish.
+      OSPREY_ARCHIVER_MONGODB_HOST: archiver-mongodb
+      OSPREY_ARCHIVER_MONGODB_PORT: "27017"
+{% endif %}
     # Bind-mount source is relative to the compose project directory
     # (build/services/), not this service's subdir — hence the dispatch_worker/ prefix.
     volumes:

--- a/src/osprey/templates/services/mongodb/docker-compose.yml.j2
+++ b/src/osprey/templates/services/mongodb/docker-compose.yml.j2
@@ -1,0 +1,117 @@
+# The mongodb service owns the archiver store: one collection of
+# `{date: ISODate, <PV>: value}` documents, written by the base seeder (host
+# CLI, over the published port below), by `osprey sim apply` when a scenario
+# rewrites event windows, and by the archiver_recorder service (in-network)
+# when a Virtual Accelerator is being recorded. `MongoDBArchiverConnector`
+# reads it. There is one store and one timeline — seeded history and recorded
+# history are the same documents in the same collection.
+#
+# Neither the database nor the collection is created here: the seeder creates
+# them, together with the `{date: 1}` index the connector's sort needs and the
+# TTL index that expires per-document `expireAt` stamps. That ordering is
+# deliberate — `osprey deploy up` stages this service first, seeds, and only
+# then starts the recorder, so nothing races the collection into existence
+# with the wrong options.
+
+services:
+  mongodb:
+    # Public upstream image, overridable like every other service image
+    # (env → config → default): set OSPREY_MONGODB_IMAGE, or
+    # services.mongodb.image in config.yml, to point at a mirror or a pinned
+    # digest (e.g. for air-gapped registries).
+    image: ${OSPREY_MONGODB_IMAGE:-{{ (services.mongodb | default({})).image | default('mongo:7', true) }}}
+    # container_name is a HOST-GLOBAL docker identifier: a bare
+    # `archiver-mongodb` collides when two OSPREY projects deploy the archiver
+    # store on one host, forcing them to serialize. Namespace it per-project so
+    # concurrent deploys don't fight over one name. The name in-network
+    # consumers resolve (`archiver-mongodb`) is pinned separately as a network
+    # alias below, so the rename doesn't reach them.
+    container_name: {{ osprey_labels.project_name }}-archiver-mongodb
+    labels:
+      osprey.project.name: "{{ osprey_labels.project_name }}"
+      osprey.project.root: "{{ osprey_labels.project_root }}"
+      osprey.deployed.at: "{{ osprey_labels.deployed_at }}"
+    restart: unless-stopped
+    # Block compression for every collection this server creates. It is set on
+    # the SERVER, not per-collection, precisely because the seeder creates the
+    # archiver collection implicitly on its first insert: an implicitly created
+    # collection inherits the server-wide compressor, so there is no window in
+    # which documents land uncompressed while some later call tries to set
+    # collection options. `zstd` roughly halves the store against the default
+    # `snappy` at this schema's redundancy (one small document per timestamp,
+    # highly repetitive keys); `services.mongodb.compression` moves it for a
+    # facility that would rather trade disk for CPU. Whatever it is set to
+    # becomes part of the seed-manifest fingerprint, so changing it triggers a
+    # reported reseed rather than a store that is half one codec and half the
+    # other.
+    #
+    # The official image's entrypoint prepends `mongod` to any command starting
+    # with `-`, and appends `--bind_ip_all` when no bind is given, so this
+    # short form keeps both behaviors.
+    command: ["--wiredTigerCollectionBlockCompressor", "{{ (services.mongodb | default({})).compression | default('zstd', true) }}"]
+    ports:
+      # Published for the HOST side of the archiver: the agent's connector, the
+      # base seeder inside `osprey deploy up`, and `osprey sim apply`'s event
+      # rewrite all reach the store this way (bind_address defaults to
+      # loopback, so it is not exposed off-box). In-network consumers use the
+      # `archiver-mongodb` alias below instead and never this port mapping.
+      - "{{ deployment.bind_address | default('127.0.0.1') }}:{{ (services.mongodb | default({})).port_host | default(27017, true) }}:27017"
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: {{ (services.mongodb | default({})).username | default('osprey', true) }}
+      # Sourced from the project .env: `osprey deploy up` mints a strong
+      # MONGO_ROOT_PASSWORD when unset, and the agent-side connector block
+      # (`archiver.mongodb_archiver.password_env: MONGO_ROOT_PASSWORD`), the
+      # seeder and the recorder all read that SAME variable, so container and
+      # readers authenticate with one value. Mirrors postgres's
+      # ARIEL_DB_PASSWORD convention, including the absence of a `password:`
+      # key in the `services.mongodb` config block — one set there would be
+      # read by nothing and would silently lose to the minted variable. The
+      # `osprey` fallback applies only before the first deploy or on a bare
+      # `docker compose up`.
+      #
+      # NOTE: mongod reads MONGO_INITDB_ROOT_USERNAME/PASSWORD only when
+      # initializing a FRESH data volume; a pre-existing volume keeps its
+      # original credentials until recreated. Rotating the minted password
+      # therefore requires removing the volume below — which also discards the
+      # seeded and recorded history, so `deploy up` warns before it comes to
+      # that rather than leaving the store silently unauthenticatable.
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD:-osprey}
+      TZ: {{ system.timezone }}
+    volumes:
+      # The store itself. Named (not a bind mount) so it is namespaced per
+      # compose project and survives `deploy down`: a base seed costs minutes,
+      # and re-seeding on every restart would make the archiver's history
+      # younger than the machine it claims to describe.
+      - archiver_mongodb_data:/data/db
+    networks:
+      # The container_name above is per-project, so pin the name in-network
+      # consumers actually address as an alias. The recorder resolves
+      # `archiver-mongodb` (it cannot use the host-published port from inside
+      # the network), and the dispatch worker overrides the agent's archiver
+      # host with the same name. Naming the ROLE rather than the compose
+      # service key keeps both consumers correct if the service key ever moves.
+      osprey-network:
+        aliases:
+          - archiver-mongodb
+    healthcheck:
+      # `ping` is one of the few commands mongod answers before
+      # authentication, so this probe needs no credentials — which is what
+      # keeps the healthcheck from becoming a second place the minted password
+      # has to be spelled. It proves the server is accepting connections and
+      # answering commands, which is exactly the condition the seeder and the
+      # recorder wait on.
+      test: ["CMD-SHELL", "mongosh --quiet --eval 'db.adminCommand(\"ping\")'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      # Grace period before failed probes count: a FRESH volume makes mongod
+      # create the admin user and preallocate WiredTiger's journal before it
+      # answers, which the default (immediate) probing would otherwise count as
+      # failures against the retry budget.
+      start_period: 15s
+
+volumes:
+  archiver_mongodb_data:
+
+networks:
+  osprey-network:

--- a/src/osprey/templates/services/virtual_accelerator/Dockerfile
+++ b/src/osprey/templates/services/virtual_accelerator/Dockerfile
@@ -13,8 +13,11 @@
 #     plus any local dependency delta staged as osprey-local-requirements.txt
 #     on dev builds. Its build cache is shared across projects and only
 #     rebuilds when the staged manifest changes. The extra is what carries the
-#     serving stack (`lume-pva-apg[ca,pva]`, PyAT) — deliberately, so this
-#     file cannot pin a serving dependency that pyproject.toml disagrees with.
+#     serving stack (`lume-pva-apg[ca,pva]`, PyAT) and the archiver recorder's
+#     client-side deps (a CA client, pymongo) — deliberately, so this file
+#     cannot pin a dependency that pyproject.toml disagrees with. The recorder
+#     runs THIS image with a different command (compose template only, no
+#     Dockerfile of its own), which is why its deps ride along here.
 #   * wheel layer — when `osprey deploy up --dev` stages a locally-built wheel
 #     into the build context, this later layer overlays it (so unreleased code
 #     is included). The first wheel install carries the `[virtual-accelerator]`

--- a/src/osprey/utils/config_writer.py
+++ b/src/osprey/utils/config_writer.py
@@ -593,6 +593,7 @@ def set_control_system_type(
     control_type: str,
     archiver_type: str | None = None,
     create_backup: bool = True,
+    archiver_settings: dict[str, Any] | None = None,
 ) -> tuple[str, str]:
     """Update control system and optionally archiver type in config.yml.
 
@@ -603,6 +604,12 @@ def set_control_system_type(
         control_type: 'mock', 'epics', or 'virtual_accelerator'
         archiver_type: Optional archiver type ('mock_archiver', 'epics_archiver')
         create_backup: If True, creates a .bak file before modifying
+        archiver_settings: Optional dotted keys the selected archiver needs to
+            be constructible at all — ``archiver.mongodb_archiver.host`` and
+            its siblings. Written the same way every other key here is: split
+            into nested sections, because a rendered config.yml is read as
+            nested sections and a top-level dotted line in it configures
+            nothing.
 
     Returns:
         Tuple of (updated_content, preview) where updated_content is the new file content
@@ -611,6 +618,9 @@ def set_control_system_type(
 
     if archiver_type:
         updates["archiver.type"] = archiver_type
+
+    if archiver_settings:
+        updates.update(archiver_settings)
 
     update_yaml_file(config_path, updates, create_backup=create_backup)
 
@@ -623,6 +633,9 @@ def set_control_system_type(
 
     if archiver_type:
         preview_lines.append(f"archiver.type: {archiver_type}")
+
+    for key, value in (archiver_settings or {}).items():
+        preview_lines.append(f"{key}: {value}")
 
     preview_lines.append("\n[dim]Updated config.yml[/dim]")
 

--- a/src/osprey/utils/dotenv.py
+++ b/src/osprey/utils/dotenv.py
@@ -160,6 +160,7 @@ RUNTIME_WRITER_KEYS = frozenset(
         "BLUESKY_TILED_API_KEY",
         "ZO_ROOT_USER_PASSWORD",
         "ARIEL_DB_PASSWORD",
+        "MONGO_ROOT_PASSWORD",
     }
 )
 

--- a/tests/cli/test_build_cmd.py
+++ b/tests/cli/test_build_cmd.py
@@ -2629,3 +2629,282 @@ def test_profile_pointing_into_the_osprey_package_is_refused(tmp_path: Path, cap
     reported = caplog.text + (str(result.exception) if result.exception else "")
     assert "inside the installed osprey package" in reported
     assert not (preset_yml.parent / "web-terminal-context").exists()
+
+
+# ---------------------------------------------------------------------------
+# The archiver store + recorder (_inject_va_archiver, step 10e)
+# ---------------------------------------------------------------------------
+
+
+class TestInjectVAArchiver:
+    """The two archiver services, and the config the profile block derives.
+
+    The injector's job is the pair of services; the connection block and the
+    archive's knobs are NOT its job — they are config overrides, so an attached
+    project (which reaches no injector) gets them too. Both halves are asserted
+    here because together they are what makes a built project's archive real.
+    """
+
+    def _write_config(self, project_path: Path, **overrides: object) -> None:
+        """The smallest config.yml the injector needs, plus any overrides."""
+        from ruamel.yaml import YAML
+
+        config: dict = {"deployed_services": [], "services": {}}
+        config.update(overrides)
+        yaml_rt = YAML()
+        with open(project_path / "config.yml", "w") as fh:
+            yaml_rt.dump(config, fh)
+
+    def _project(self, tmp_path: Path, **overrides: object) -> Path:
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        self._write_config(project_path, **overrides)
+        return project_path
+
+    def _inject(self, project_path: Path, **knobs: object):
+        from osprey.cli.build_cmd import _inject_va_archiver
+        from osprey.cli.build_profile_archiver import VAArchiverConfig
+
+        _inject_va_archiver(VAArchiverConfig(**knobs), project_path)  # type: ignore[arg-type]
+
+    def _read_config(self, project_path: Path) -> dict:
+        return yaml.safe_load((project_path / "config.yml").read_text()) or {}
+
+    def test_both_service_templates_land_in_the_project(self, tmp_path: Path) -> None:
+        """A store nothing writes to and a recorder with nowhere to write are
+        each half a feature, so both are copied or neither is."""
+        project_path = self._project(tmp_path)
+
+        self._inject(project_path)
+
+        for name in ("mongodb", "archiver_recorder"):
+            assert (project_path / "services" / name / "docker-compose.yml.j2").is_file()
+
+    def test_both_services_are_deployed(self, tmp_path: Path) -> None:
+        project_path = self._project(tmp_path)
+
+        self._inject(project_path)
+
+        assert self._read_config(project_path)["deployed_services"] == [
+            "mongodb",
+            "archiver_recorder",
+        ]
+
+    def test_the_store_block_carries_what_its_compose_template_reads(self, tmp_path: Path) -> None:
+        """port_host, username and compression are read by the template with a
+        `| default`, so a wrong value here renders a working-but-wrong store."""
+        project_path = self._project(tmp_path)
+
+        self._inject(project_path, port_host=27100, username="facility", compression="snappy")
+
+        mongodb = self._read_config(project_path)["services"]["mongodb"]
+        assert mongodb["path"] == "./services/mongodb"
+        assert mongodb["port_host"] == 27100
+        assert mongodb["username"] == "facility"
+        assert mongodb["compression"] == "snappy"
+        # No password key, following the postgres convention: one minted .env
+        # variable is what the container and every reader authenticate with, so
+        # a key here would be read by nothing and lose to it silently.
+        assert "password" not in mongodb
+
+    def test_the_store_defaults_match_what_its_template_assumes(self, tmp_path: Path) -> None:
+        """The compose template supplies its own `| default` for each of these.
+        Writing a different value here would render a store the connection block
+        cannot authenticate against — with no error until deploy time."""
+        project_path = self._project(tmp_path)
+
+        self._inject(project_path)
+
+        mongodb = self._read_config(project_path)["services"]["mongodb"]
+        assert mongodb["port_host"] == 27017
+        assert mongodb["username"] == "osprey"
+        assert mongodb["compression"] == "zstd"
+
+    def test_the_recorder_block_carries_its_template_path(self, tmp_path: Path) -> None:
+        """The compose generator resolves each deployed service's template dir
+        from `path`, and the recorder needs nothing else — everything it reads
+        arrives from the mounted config.yml at run time."""
+        project_path = self._project(tmp_path)
+
+        self._inject(project_path)
+
+        assert self._read_config(project_path)["services"]["archiver_recorder"] == {
+            "path": "./services/archiver_recorder"
+        }
+
+    def test_no_image_is_pinned_for_either_service(self, tmp_path: Path) -> None:
+        """The store falls to the template's pinned upstream tag and the
+        recorder to the VA's image; writing either here would defeat the
+        env/config/default override chain."""
+        project_path = self._project(tmp_path)
+
+        self._inject(project_path)
+
+        services = self._read_config(project_path)["services"]
+        assert "image" not in services["mongodb"]
+        assert "image" not in services["archiver_recorder"]
+
+    def test_injecting_twice_does_not_deploy_a_service_twice(self, tmp_path: Path) -> None:
+        """A rebuild over an existing project re-runs the injector."""
+        project_path = self._project(tmp_path)
+
+        self._inject(project_path)
+        self._inject(project_path)
+
+        assert self._read_config(project_path)["deployed_services"] == [
+            "mongodb",
+            "archiver_recorder",
+        ]
+
+    def test_a_claimed_service_template_is_left_untouched(self, tmp_path: Path) -> None:
+        """`osprey scaffold claim services/mongodb` means the facility owns that
+        copy — refreshing it would discard their edits on every rebuild."""
+        project_path = self._project(tmp_path, scaffold={"user_owned": ["services/mongodb"]})
+        claimed = project_path / "services" / "mongodb"
+        claimed.mkdir(parents=True)
+        (claimed / "docker-compose.yml.j2").write_text("# hand-edited", encoding="utf-8")
+
+        self._inject(project_path)
+
+        assert (claimed / "docker-compose.yml.j2").read_text() == "# hand-edited"
+        # The unclaimed half of the pair still refreshes.
+        assert (project_path / "services" / "archiver_recorder").is_dir()
+
+    def test_an_existing_va_service_block_survives_injection(self, tmp_path: Path) -> None:
+        """Step 10e runs after the VA's own injector, and the recorder template
+        gates on `virtual_accelerator` being in deployed_services."""
+        project_path = self._project(
+            tmp_path,
+            deployed_services=["virtual_accelerator"],
+            services={"virtual_accelerator": {"path": "./services/virtual_accelerator"}},
+        )
+
+        self._inject(project_path)
+
+        config = self._read_config(project_path)
+        assert config["deployed_services"] == [
+            "virtual_accelerator",
+            "mongodb",
+            "archiver_recorder",
+        ]
+        assert "virtual_accelerator" in config["services"]
+
+    def test_the_injector_writes_no_connection_block(self, tmp_path: Path) -> None:
+        """It belongs to the config-override path, which an attached project
+        also runs — writing it here too would be a second home for it."""
+        project_path = self._project(tmp_path)
+
+        self._inject(project_path)
+
+        assert "archiver" not in self._read_config(project_path)
+
+
+class TestVAArchiverConfigDerivation:
+    """The `va_archiver:` block's keys reach a built project's config.yml."""
+
+    def _build(self, tmp_path: Path, project_name: str, **profile_keys: object) -> Path:
+        """Build the hello-world preset with *profile_keys* layered on top."""
+        from click.testing import CliRunner
+
+        from osprey.cli.build_cmd import build
+
+        argv = [
+            project_name,
+            "--preset",
+            "hello-world",
+            "--skip-deps",
+            "--skip-lifecycle",
+            "--output-dir",
+            str(tmp_path),
+        ]
+        if profile_keys:
+            override = tmp_path / f"{project_name}-override.yml"
+            override.write_text(yaml.safe_dump(profile_keys, sort_keys=False), encoding="utf-8")
+            argv[1:1] = ["-O", str(override)]
+
+        result = CliRunner().invoke(build, argv)
+        assert result.exit_code == 0, result.output
+        return tmp_path / project_name
+
+    def _config(self, project_path: Path) -> dict:
+        return yaml.safe_load((project_path / "config.yml").read_text()) or {}
+
+    def test_the_connector_can_connect_to_what_the_build_wrote(self, tmp_path: Path) -> None:
+        """The connector raises on the first missing key, so a partial block
+        would build cleanly and die at the first archiver call."""
+        project = self._build(tmp_path, "archived", va_archiver={"port_host": 27100})
+
+        mongo = self._config(project)["archiver"]["mongodb_archiver"]
+        # The agent runs on the host, so it reaches the store on the published
+        # port. Container-side consumers use the `archiver-mongodb` network
+        # alias instead and never this block.
+        assert mongo["host"] == "localhost"
+        assert mongo["port"] == 27100
+        assert mongo["name"] and mongo["collection"]
+        # The store mints its root user, and a root user's credentials live in
+        # `admin` — authenticating against the data database would fail.
+        assert mongo["auth"] == "admin"
+        assert mongo["username"] == "osprey"
+        assert mongo["password_env"] == "MONGO_ROOT_PASSWORD"
+        # Short by design: the common failure is a project built but never
+        # deployed, and a fast explanatory error beats a minute of silence.
+        assert mongo["timeout"] == 5
+
+    def test_the_password_is_never_written_into_the_project(self, tmp_path: Path) -> None:
+        """It reaches the store, the recorder and the agent as one minted .env
+        variable. A literal anywhere in config.yml would be both a secret on
+        disk and a second value free to disagree with the minted one."""
+        project = self._build(tmp_path, "archived", va_archiver={})
+
+        config = self._config(project)
+        assert "password" not in config["services"]["mongodb"]
+        assert "password" not in config["archiver"]["mongodb_archiver"]
+
+    def test_the_archive_knobs_reach_the_services_that_read_them(self, tmp_path: Path) -> None:
+        """FR7: retention and cadence are profile edits, not code changes, so
+        they must be in the config the seeder and recorder read."""
+        project = self._build(
+            tmp_path, "archived", va_archiver={"retention_days": 2, "hot_span_hours": 2}
+        )
+
+        knobs = self._config(project)["va_archiver"]
+        assert knobs["retention_days"] == 2
+        assert knobs["hot_span_hours"] == 2
+        assert knobs["hot_cadence_sec"] == 10
+        assert knobs["tail_cadence_sec"] == 60
+        assert knobs["recorder_cadence_sec"] == 10
+        assert knobs["recorder_poll_sec"] == 30
+
+    def test_the_services_are_injected_by_the_build(self, tmp_path: Path) -> None:
+        project = self._build(tmp_path, "archived", va_archiver={})
+
+        config = self._config(project)
+        assert {"mongodb", "archiver_recorder"} <= set(config["deployed_services"])
+        assert (project / "services" / "mongodb" / "docker-compose.yml.j2").is_file()
+        assert (project / "services" / "archiver_recorder" / "docker-compose.yml.j2").is_file()
+
+    def test_a_profile_without_the_block_gets_neither(self, tmp_path: Path) -> None:
+        """Opt-in: nothing about an unarchived project changes."""
+        project = self._build(tmp_path, "plain")
+
+        config = self._config(project)
+        assert "va_archiver" not in config
+        assert "mongodb" not in config["deployed_services"]
+        assert not (project / "services" / "mongodb").exists()
+
+    def test_an_attached_project_is_told_where_the_archive_is(self, tmp_path: Path) -> None:
+        """It scaffolds no services and so reaches no injector — the connection
+        block is exactly what it still needs, and the host it names is the one
+        running the shared store."""
+        project = self._build(
+            tmp_path,
+            "attached",
+            deploy_services=False,
+            va_archiver={"host": "archive.example.org", "port_host": 27100},
+        )
+
+        config = self._config(project)
+        assert config["archiver"]["mongodb_archiver"]["host"] == "archive.example.org"
+        assert config["archiver"]["mongodb_archiver"]["port"] == 27100
+        assert config["deployed_services"] == []
+        assert not (project / "services" / "mongodb").exists()

--- a/tests/cli/test_config_cmd.py
+++ b/tests/cli/test_config_cmd.py
@@ -190,6 +190,96 @@ class TestConfigSetControlSystemCommand:
         assert "invalid" in result.output.lower() or "choice" in result.output.lower()
 
 
+STORELESS_PROJECT = "control_system:\n  type: mock\n\narchiver:\n  type: mock_archiver\n"
+ARCHIVED_PROJECT = (
+    "control_system:\n  type: mock\n\narchiver:\n  type: mongodb_archiver\n"
+    "  mongodb_archiver:\n    host: localhost\n"
+)
+NO_ARCHIVER_SECTION = "control_system:\n  type: mock\n"
+
+
+class TestSetControlSystemRefusesAMockPast:
+    """The command may not switch a project onto a machine whose past is fiction.
+
+    Switching to the virtual accelerator changes one key, and the archiver keeps
+    whatever it was — so this command can *create* the pairing the build, the
+    deploy and the MCP server all refuse. It asks the same question they do,
+    before the write rather than after, and refuses rather than prompting: it is
+    non-interactive and runs in scripts.
+    """
+
+    def _run(self, cli_runner, tmp_path, contents, system_type):
+        config_file = tmp_path / "config.yml"
+        config_file.write_text(contents)
+
+        with patch("osprey.cli.project_utils.resolve_config_path") as mock_resolve:
+            mock_resolve.return_value = str(config_file)
+            result = cli_runner.invoke(set_control_system, [system_type])
+
+        return result, config_file.read_text()
+
+    def test_va_onto_a_mock_archiver_is_refused(self, cli_runner, tmp_path):
+        result, after = self._run(cli_runner, tmp_path, STORELESS_PROJECT, "virtual_accelerator")
+
+        assert result.exit_code != 0
+        assert after == STORELESS_PROJECT, "a refused switch must not write anything"
+
+    def test_va_with_no_archiver_section_is_refused(self, cli_runner, tmp_path):
+        """Unset counts as mock — the common way into the pairing is naming nothing."""
+        result, after = self._run(cli_runner, tmp_path, NO_ARCHIVER_SECTION, "virtual_accelerator")
+
+        assert result.exit_code != 0
+        assert after == NO_ARCHIVER_SECTION
+
+    def test_refusal_names_a_fix(self, cli_runner, tmp_path):
+        """A refusal that does not say what to do instead is just an obstacle."""
+        result, _ = self._run(cli_runner, tmp_path, STORELESS_PROJECT, "virtual_accelerator")
+
+        # Rich wraps the console output, so match on fragments that survive a
+        # line break falling anywhere inside the message.
+        output = " ".join(result.output.split())
+        assert "mongodb_archiver" in output
+        assert "archiver:" in output
+        assert "set-control-system" in output, "the menu that writes the keys is the fix"
+        assert "reports a past that never happened" in output, "the shared reason"
+
+    def test_refusal_is_not_followed_by_a_generic_error(self, cli_runner, tmp_path):
+        """The message is complete; nothing appends a second, emptier line."""
+        result, _ = self._run(cli_runner, tmp_path, STORELESS_PROJECT, "virtual_accelerator")
+
+        assert "Failed to update control system" not in result.output
+
+    def test_va_onto_a_real_archive_goes_through(self, cli_runner, tmp_path):
+        result, after = self._run(cli_runner, tmp_path, ARCHIVED_PROJECT, "virtual_accelerator")
+
+        assert result.exit_code == 0
+        assert "type: virtual_accelerator" in after
+        assert "type: mongodb_archiver" in after
+
+    def test_epics_onto_a_mock_archiver_goes_through(self, cli_runner, tmp_path):
+        """Only the simulated machine is affected. A real machine with no archive
+        attached yet is a real facility mid-migration, and it stays legal."""
+        result, after = self._run(cli_runner, tmp_path, STORELESS_PROJECT, "epics")
+
+        assert result.exit_code == 0
+        assert "type: epics" in after
+        assert "type: mock_archiver" in after
+
+    def test_mock_onto_a_mock_archiver_goes_through(self, cli_runner, tmp_path):
+        """A mock machine with a mock archive claims nothing it cannot back up."""
+        result, after = self._run(cli_runner, tmp_path, STORELESS_PROJECT, "mock")
+
+        assert result.exit_code == 0
+        assert "type: mock_archiver" in after
+
+    def test_case_insensitive_spelling_is_refused_too(self, cli_runner, tmp_path):
+        """Click accepts the type case-insensitively; the guard sees the same value."""
+        result, after = self._run(cli_runner, tmp_path, STORELESS_PROJECT, "VIRTUAL_ACCELERATOR")
+
+        assert result.exit_code != 0
+        assert after == STORELESS_PROJECT
+
+
 class TestConfigSetEpicsGatewayCommand:
     """Test config set-epics-gateway subcommand."""
 

--- a/tests/cli/test_connector_shorthand.py
+++ b/tests/cli/test_connector_shorthand.py
@@ -141,11 +141,20 @@ def test_merge_without_shorthand_is_unchanged() -> None:
 
 
 def test_shorthand_in_an_extends_parent_is_folded(tmp_path: Path) -> None:
-    """A parent's shorthand reaches the child — extends resolution is not an escape."""
+    """A parent's shorthand reaches the child — extends resolution is not an escape.
+
+    The child supplies the archiver because a virtual accelerator may not read
+    the mock one; that the two halves of the pairing can arrive from different
+    layers and still be judged together is the point of checking the *merged*
+    config rather than any single layer's.
+    """
     parent = tmp_path / "parent.yml"
     parent.write_text("name: Parent\nconnector: virtual_accelerator\n", encoding="utf-8")
     child = tmp_path / "child.yml"
-    child.write_text("name: Child\nextends: parent.yml\n", encoding="utf-8")
+    child.write_text(
+        "name: Child\nextends: parent.yml\nconfig:\n  archiver.type: mongodb_archiver\n",
+        encoding="utf-8",
+    )
 
     profile = load_profile(child)
 
@@ -245,9 +254,16 @@ def test_reported_keys_keep_shorthand_order() -> None:
 
 
 def test_preset_resolution_applies_the_shorthand() -> None:
-    """``--set connector=`` retints a bundled preset's control system."""
+    """``--set connector=`` retints a bundled preset's control system.
+
+    Retinting a storeless preset to a virtual accelerator means declaring where
+    that machine's history lives, hence the second pair: the mock archiver is
+    refused for a simulated machine, and hello-world ships with no archive.
+    """
     profile, _profile_dir = resolve_build_profile(
-        None, "hello-world", set_pairs=("connector=virtual_accelerator",)
+        None,
+        "hello-world",
+        set_pairs=("connector=virtual_accelerator", "config.archiver.type=mongodb_archiver"),
     )
 
     assert profile.config[CONNECTOR_CONFIG_KEY] == "virtual_accelerator"

--- a/tests/cli/test_deploy_cmd.py
+++ b/tests/cli/test_deploy_cmd.py
@@ -21,7 +21,17 @@ from osprey.cli.deploy_cmd import deploy
 #: options it acts on and no others, so that a misapplied flag (``up
 #: --dry-run``) is a parse error instead of a silent no-op.
 VERB_OPTIONS = {
-    "up": {"--project", "-p", "--config", "-c", "--detached", "-d", "--dev", "--expose"},
+    "up": {
+        "--project",
+        "-p",
+        "--config",
+        "-c",
+        "--detached",
+        "-d",
+        "--dev",
+        "--expose",
+        "--keep-archiver-base",
+    },
     "down": {"--project", "-p", "--config", "-c", "--dev"},
     "restart": {"--project", "-p", "--config", "-c", "--detached", "-d", "--expose"},
     "status": {"--project", "-p", "--config", "-c"},
@@ -677,7 +687,12 @@ class TestDeployLegacySpellings:
         assert Path.cwd() == project_dir.resolve()
         (config_path,), kwargs = mock_deploy_up.call_args
         assert Path(config_path) == project_dir.resolve() / "config.yml"
-        assert kwargs == {"detached": True, "dev_mode": False, "expose_network": False}
+        assert kwargs == {
+            "detached": True,
+            "dev_mode": False,
+            "expose_network": False,
+            "keep_archiver_base": False,
+        }
 
     def test_relative_project_resolves_against_the_callers_directory(
         self, cli_runner, tmp_path, monkeypatch
@@ -718,7 +733,12 @@ class TestDeployLegacySpellings:
         assert result.exit_code == 0
         (config_path,), kwargs = mock_deploy_up.call_args
         assert Path(config_path) == custom_config
-        assert kwargs == {"detached": False, "dev_mode": True, "expose_network": True}
+        assert kwargs == {
+            "detached": False,
+            "dev_mode": True,
+            "expose_network": True,
+            "keep_archiver_base": False,
+        }
 
     @pytest.mark.parametrize(
         ("argv", "target", "expected_kwargs"),

--- a/tests/cli/test_preset_hash_pin.py
+++ b/tests/cli/test_preset_hash_pin.py
@@ -52,12 +52,36 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # agent's turns. All four rosters list it, so every digest moved — a rebuilt
     # project gains a hook file and a UserPromptSubmit wiring entry, which is
     # exactly what the staleness advisory should report.
-    "control-assistant": "sha256:577f397a604c904e0f742546321bfe5ee39d9e1ec16eb60c5ff68f1fbe7cc6ae",
+    #
+    # Re-pinned again when control-assistant gained a stored archive: a
+    # `va_archiver:` block, `archiver.type: mongodb_archiver` in `config:`, and
+    # pymongo in `dependencies`. The block derives eight
+    # `archiver.mongodb_archiver.*` keys into the resolved config, so this is a
+    # key change rather than a comment change and the digest is expected to
+    # move. Both extends children inherit it, so all three moved.
+    # Re-pinned again when control-assistant named its freshness canary:
+    # `va_archiver.freshness_channel`. The block derives a
+    # `health.categories.archiver.checks` entry from it — the check itself plus
+    # a staleness threshold computed from `recorder_cadence_sec` — so this is a
+    # key change, not a comment change, and the digest is expected to move. A
+    # rebuilt project gains a health check it did not have, which is exactly
+    # what the staleness advisory should announce. Both extends children inherit
+    # it, so all three moved.
+    # ...and again when the block stated `recorder_cadence_sec: 10` explicitly
+    # instead of riding the dataclass default. Behavior-neutral — the resolved
+    # value is unchanged — but the resolved CONTENT now carries the key, so the
+    # digest moves. Stated rather than defaulted because the freshness threshold
+    # is derived from it, and the preset's own convention is to document the
+    # shape it deploys rather than hide it in a dataclass.
+    # The archive and the workspace-delta hook landed either side of the same
+    # rebase, so the digests below carry both at once: re-pinning against
+    # either change alone would leave the other unaccounted for.
+    "control-assistant": "sha256:5ef868a0c4e912bffbbceb1387b8f95f0a19a4dbfb475915bdeb3467c0ed8162",
     "control-assistant-readonly": (
-        "sha256:eaf69900f7783e6b77bceaa52cf69d6e609dc74969715dacf8a639a77cbbe1db"
+        "sha256:7c30309acfa2cc519813eaf3c830b1a3b6829abf5602f11308d3308db8fb5a7f"
     ),
     "control-assistant-readwrite": (
-        "sha256:a04ca9401c9e3dcf2e1bb233b7764183fc00d682473311cc12cbdbc6ce495ed2"
+        "sha256:2721cb96194dc0da4030f05aaea0926fd7febad61a0cd51e5f3c2652d4271679"
     ),
     "hello-world": "sha256:ac9c00d70922c3c88d561f7ffa29af3ccb1650d5a8bfaa13b884563199ce371a",
 }

--- a/tests/cli/test_profile_unknown_keys.py
+++ b/tests/cli/test_profile_unknown_keys.py
@@ -150,7 +150,7 @@ def test_schema_min_osprey_is_pinned() -> None:
     Stamping the running ``__version__`` instead would let the emitting release
     satisfy its own gate while ignoring the keys it just wrote.
     """
-    assert _PROFILE_SCHEMA_MIN_OSPREY == "2026.8.0"
+    assert _PROFILE_SCHEMA_MIN_OSPREY == "2026.9.0"
 
 
 def test_running_osprey_satisfies_the_schema_floor() -> None:

--- a/tests/cli/test_profile_va_archiver_block.py
+++ b/tests/cli/test_profile_va_archiver_block.py
@@ -1,0 +1,770 @@
+"""The ``va_archiver:`` block — the store's knobs, and what they must agree with.
+
+The block declares where a simulated deployment keeps its history and every
+number that store's shape depends on. Two properties are what make it worth a
+schema rather than a free-form mapping: the numbers describe one grid, so pairs
+that cannot coexist (a dense tier longer than retention, a tail cadence that
+does not land on the dense one's timestamps) are refused; and the connector's
+connection keys are DERIVED from it, so spelling them again under ``config:``
+is refused too — one fact with two homes is free to disagree, and a stale
+duplicate reads as an empty archive rather than as a broken one.
+
+The honesty rule's build-time site is here too: declining to declare a store is
+a legal choice for most deployments, but a profile that pairs a virtual
+accelerator with the mock archiver is refused outright.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from osprey.cli.build_profile_archiver import (
+    COMPRESSORS,
+    CONNECTION_CONFIG_PREFIX,
+    DEFAULT_ARCHIVER_HOST,
+    FRESHNESS_CATEGORY,
+    FRESHNESS_CHECK_NAME,
+    FRESHNESS_CONFIG_KEY,
+    FRESHNESS_FLOOR_SEC,
+    FRESHNESS_SAFETY_MULTIPLE,
+    KNOBS_CONFIG_PREFIX,
+    VAArchiverConfig,
+    parse_va_archiver_block,
+    va_archiver_config_overrides,
+    va_archiver_errors,
+    va_mock_archiver_errors,
+)
+from osprey.cli.build_profile_load import _KNOWN_PROFILE_KEYS, load_profile
+from osprey.cli.profile_cmd import profile
+from osprey.errors import BuildProfileError
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _write_profile(tmp_path: Path, va_archiver: Any, **profile_keys: Any) -> Path:
+    body: dict[str, Any] = {"name": "Facility", "data_bundle": "hello_world"}
+    body.update(profile_keys)
+    if va_archiver is not None:
+        body["va_archiver"] = va_archiver
+    path = tmp_path / "profile.yml"
+    path.write_text(yaml.safe_dump(body, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _parse_refusal(block: Any) -> str:
+    """The accumulated report for a block the parser cannot type."""
+    with pytest.raises(BuildProfileError) as excinfo:
+        parse_va_archiver_block({"name": "Facility", "va_archiver": block})
+    return str(excinfo.value)
+
+
+def _errors(config: Any = None, deploy_services: bool = True, **knobs: Any) -> list[str]:
+    """Semantic errors for a block built from *knobs*."""
+    return va_archiver_errors(VAArchiverConfig(**knobs), config or {}, deploy_services)
+
+
+# ---------------------------------------------------------------------------
+# The key is part of the schema, and the block is optional
+# ---------------------------------------------------------------------------
+
+
+def test_va_archiver_is_a_known_profile_key() -> None:
+    assert "va_archiver" in _KNOWN_PROFILE_KEYS
+
+
+def test_a_profile_without_the_block_parses_to_none(tmp_path: Path) -> None:
+    """A stored archive is opt-in: without the block the deployment reads
+    whatever archiver its config selects."""
+    assert load_profile(_write_profile(tmp_path, None)).va_archiver is None
+
+
+def test_an_empty_block_takes_every_default(tmp_path: Path) -> None:
+    """Declaring the block with no keys is how a facility says "the shipped
+    store, as shipped" — it must not need to restate the defaults to get them."""
+    loaded = load_profile(_write_profile(tmp_path, {}))
+
+    assert loaded.va_archiver == VAArchiverConfig()
+
+
+def test_declared_knobs_reach_the_parsed_block(tmp_path: Path) -> None:
+    loaded = load_profile(
+        _write_profile(
+            tmp_path,
+            {"retention_days": 365, "hot_cadence_sec": 5, "tail_cadence_sec": 30},
+        )
+    )
+
+    assert loaded.va_archiver is not None
+    assert loaded.va_archiver.retention_days == 365
+    assert loaded.va_archiver.hot_cadence_sec == 5
+    assert loaded.va_archiver.tail_cadence_sec == 30
+
+
+# ---------------------------------------------------------------------------
+# Structure: the block is closed, and its knobs are typed
+# ---------------------------------------------------------------------------
+
+
+def test_a_non_mapping_block_is_refused() -> None:
+    assert "must be a mapping" in _parse_refusal(["retention_days"])
+
+
+def test_an_unknown_key_is_refused_with_the_closest_spelling() -> None:
+    """Silently ignoring it would ship a store the facility did not ask for."""
+    message = _parse_refusal({"retention_day": 7})
+
+    assert "unknown key 'retention_day'" in message
+    assert "did you mean 'retention_days'" in message
+
+
+def test_a_mistyped_knob_is_refused() -> None:
+    assert "'retention_days' must be an integer" in _parse_refusal({"retention_days": "30"})
+    assert "'database' must be a string" in _parse_refusal({"database": 7})
+
+
+def test_a_boolean_is_not_an_integer_knob() -> None:
+    """YAML's `retention_days: yes` is a bool, and Python would take it as 1 —
+    a month of history quietly becoming a day."""
+    assert "'retention_days' must be an integer" in _parse_refusal({"retention_days": True})
+
+
+def test_every_structural_problem_is_reported_at_once() -> None:
+    """The block is a table being transcribed; one problem per rebuild is the
+    slowest possible way to fill it in."""
+    message = _parse_refusal({"retention_days": "30", "database": 7, "nonsense": 1})
+
+    assert message.count("\n  - ") == 3
+
+
+# ---------------------------------------------------------------------------
+# Ranges and the grid the numbers describe
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "knob",
+    [
+        "retention_days",
+        "hot_span_hours",
+        "hot_cadence_sec",
+        "tail_cadence_sec",
+        "recorder_cadence_sec",
+        "recorder_tail_cadence_sec",
+        "recorder_poll_sec",
+        "timeout_sec",
+    ],
+)
+def test_counts_must_be_positive(knob: str) -> None:
+    assert any(f"va_archiver.{knob} must be >= 1" in error for error in _errors(**{knob: 0}))
+
+
+def test_port_must_be_a_port() -> None:
+    assert any("port_host must be in 1..65535" in error for error in _errors(port_host=70000))
+
+
+def test_a_dense_tier_longer_than_retention_is_refused() -> None:
+    """It would describe dense history older than the oldest history there is."""
+    errors = _errors(retention_days=1, hot_span_hours=48)
+
+    assert any("exceeds retention_days" in error for error in errors)
+
+
+def test_the_tail_cadence_must_land_on_the_dense_grid() -> None:
+    """The tail is the sparse subset of the hot grid. A cadence that does not
+    divide it puts the tiers on timestamps that never coincide — which surfaces
+    as a seam in the data, not as an error."""
+    errors = _errors(hot_cadence_sec=10, tail_cadence_sec=45)
+
+    assert any("must be a whole multiple of" in error for error in errors)
+
+
+def test_the_tail_cannot_sample_faster_than_the_dense_tier() -> None:
+    errors = _errors(hot_cadence_sec=60, tail_cadence_sec=10)
+
+    assert any("cannot sample faster than the dense one" in error for error in errors)
+
+
+def test_the_recorder_cadences_answer_the_same_rule() -> None:
+    errors = _errors(recorder_cadence_sec=10, recorder_tail_cadence_sec=45)
+
+    assert any("recorder_tail_cadence_sec" in error for error in errors)
+
+
+def test_matching_cadences_are_fine() -> None:
+    """One tier at both cadences is a legitimate (if dense) configuration."""
+    assert _errors(hot_cadence_sec=10, tail_cadence_sec=10) == []
+
+
+def test_an_unknown_compressor_is_refused() -> None:
+    """mongod would refuse it at container start, hours after the profile that
+    named it was written."""
+    errors = _errors(compression="brotli")
+
+    assert any("compression must be one of" in error for error in errors)
+
+
+@pytest.mark.parametrize("compressor", COMPRESSORS)
+def test_every_supported_compressor_validates(compressor: str) -> None:
+    assert _errors(compression=compressor) == []
+
+
+def test_a_database_name_mongodb_forbids_is_refused() -> None:
+    errors = _errors(database="my/archive")
+
+    assert any("forbids in a database name" in error for error in errors)
+
+
+def test_an_empty_name_is_refused() -> None:
+    assert any("collection must be a non-empty" in error for error in _errors(collection="  "))
+
+
+def test_password_env_must_name_a_variable_not_hold_one() -> None:
+    errors = _errors(password_env="hunter2")
+
+    assert any("must be an environment variable NAME" in error for error in errors)
+    assert any("never in the profile" in error for error in errors)
+
+
+def test_the_defaults_validate() -> None:
+    """The shipped store must be a legal store."""
+    assert _errors() == []
+
+
+# ---------------------------------------------------------------------------
+# Agreement with the rest of the profile
+# ---------------------------------------------------------------------------
+
+
+def test_an_attached_project_must_name_the_host_it_reads() -> None:
+    """It deploys no store of its own, so loopback points at nothing — a
+    deploy-time mystery for a build-time omission."""
+    errors = _errors(deploy_services=False)
+
+    assert any("va_archiver.host is required when deploy_services is false" in e for e in errors)
+
+
+def test_an_attached_project_with_a_host_validates() -> None:
+    assert _errors(deploy_services=False, host="archive.example.org") == []
+
+
+def test_a_self_deploying_project_needs_no_host() -> None:
+    assert _errors(deploy_services=True) == []
+
+
+def test_a_blank_host_is_refused() -> None:
+    assert any("host must be a non-empty string" in error for error in _errors(host="  "))
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param({f"{CONNECTION_CONFIG_PREFIX}.host": "elsewhere"}, id="dotted-leaf"),
+        pytest.param({CONNECTION_CONFIG_PREFIX: {"host": "elsewhere"}}, id="prefix-subtree"),
+        pytest.param(
+            {"archiver": {"mongodb_archiver": {"host": "elsewhere"}}}, id="nested-subtree"
+        ),
+    ],
+)
+def test_a_connection_key_spelled_in_config_is_refused(config: dict[str, Any]) -> None:
+    """All three spellings reach the same rendered leaf, so all three are a
+    second home for a fact this block already owns."""
+    errors = _errors(config=config)
+
+    assert any("one fact, two homes" in error for error in errors)
+    assert any("The va_archiver block is the home" in error for error in errors)
+
+
+def test_config_may_still_select_the_archiver_type() -> None:
+    """Declaring where the archive lives and selecting it as the deployment's
+    archiver are separate decisions — only the first belongs to this block."""
+    assert _errors(config={"archiver.type": "mongodb_archiver"}) == []
+
+
+def test_a_profile_without_the_block_is_free_to_write_connection_keys(tmp_path: Path) -> None:
+    """The rejection exists because the block derives those keys. With no block
+    there is nothing to collide with, and a hand-configured MongoDB archiver
+    stays a supported configuration."""
+    path = _write_profile(
+        tmp_path, None, config={f"{CONNECTION_CONFIG_PREFIX}.host": "archive.example.org"}
+    )
+
+    assert load_profile(path).va_archiver is None
+
+
+# ---------------------------------------------------------------------------
+# What the block contributes to the rendered config
+# ---------------------------------------------------------------------------
+
+
+def test_no_block_contributes_nothing() -> None:
+    assert va_archiver_config_overrides(None) == {}
+
+
+def test_the_connector_gets_every_key_it_requires() -> None:
+    """The connector raises on the first missing one, so a partial block would
+    build cleanly and die at the first archiver call."""
+    overrides = va_archiver_config_overrides(VAArchiverConfig())
+
+    assert {
+        f"{CONNECTION_CONFIG_PREFIX}.{leaf}"
+        for leaf in (
+            "host",
+            "port",
+            "name",
+            "collection",
+            "auth",
+            "username",
+            "password_env",
+            "timeout",
+        )
+    } <= set(overrides)
+
+
+def test_every_archive_knob_reaches_the_services_that_read_it() -> None:
+    """FR7: retention and cadence are profile edits rather than code changes,
+    which only holds if every one of them is in the rendered config."""
+    overrides = va_archiver_config_overrides(VAArchiverConfig(retention_days=2))
+
+    assert overrides[f"{KNOBS_CONFIG_PREFIX}.retention_days"] == 2
+    for knob in (
+        "hot_span_hours",
+        "hot_cadence_sec",
+        "tail_cadence_sec",
+        "recorder_cadence_sec",
+        "recorder_tail_cadence_sec",
+        "recorder_poll_sec",
+    ):
+        assert f"{KNOBS_CONFIG_PREFIX}.{knob}" in overrides
+
+
+def test_the_derived_keys_are_exactly_the_two_groups() -> None:
+    """Nothing else is derived: a key here that no service reads would be a
+    config entry the facility can neither find nor change."""
+    overrides = va_archiver_config_overrides(VAArchiverConfig())
+
+    assert all(
+        key.startswith((f"{CONNECTION_CONFIG_PREFIX}.", f"{KNOBS_CONFIG_PREFIX}."))
+        for key in overrides
+    )
+
+
+def test_the_derived_keys_carry_the_blocks_values() -> None:
+    overrides = va_archiver_config_overrides(
+        VAArchiverConfig(port_host=27100, database="facility", collection="history", timeout_sec=9)
+    )
+
+    assert overrides[f"{CONNECTION_CONFIG_PREFIX}.port"] == 27100
+    assert overrides[f"{CONNECTION_CONFIG_PREFIX}.name"] == "facility"
+    assert overrides[f"{CONNECTION_CONFIG_PREFIX}.collection"] == "history"
+    assert overrides[f"{CONNECTION_CONFIG_PREFIX}.timeout"] == 9
+
+
+def test_a_self_deployed_store_is_reached_on_loopback() -> None:
+    """The service publishes its port on the deployment's bind address and the
+    agent runs on the host."""
+    overrides = va_archiver_config_overrides(VAArchiverConfig())
+
+    assert overrides[f"{CONNECTION_CONFIG_PREFIX}.host"] == DEFAULT_ARCHIVER_HOST
+
+
+def test_an_attached_project_is_reached_where_it_says() -> None:
+    overrides = va_archiver_config_overrides(VAArchiverConfig(host="archive.example.org"))
+
+    assert overrides[f"{CONNECTION_CONFIG_PREFIX}.host"] == "archive.example.org"
+
+
+def test_the_password_is_named_never_written() -> None:
+    overrides = va_archiver_config_overrides(VAArchiverConfig())
+
+    assert overrides[f"{CONNECTION_CONFIG_PREFIX}.password_env"] == "MONGO_ROOT_PASSWORD"
+
+
+def test_the_archiver_type_is_not_derived() -> None:
+    """Flipping the connector out from under a facility's `archiver.type` would
+    be making a decision the block was not given."""
+    assert "archiver.type" not in va_archiver_config_overrides(VAArchiverConfig())
+
+
+# ---------------------------------------------------------------------------
+# `osprey profile validate` is where a facility meets all of this
+# ---------------------------------------------------------------------------
+
+
+def test_validate_accepts_a_profile_carrying_the_block(runner: CliRunner, tmp_path: Path) -> None:
+    path = _write_profile(tmp_path, {"retention_days": 7, "hot_span_hours": 6})
+    result = runner.invoke(profile, ["validate", str(path)])
+
+    assert result.exit_code == 0, result.output
+
+
+def test_validate_exits_nonzero_and_names_the_problem(runner: CliRunner, tmp_path: Path) -> None:
+    path = _write_profile(tmp_path, {"retention_days": 1, "hot_span_hours": 48})
+    result = runner.invoke(profile, ["validate", str(path)])
+
+    assert result.exit_code != 0
+    assert "hot_span_hours" in result.output
+
+
+def test_validate_reports_the_blocks_problems_alongside_the_profiles(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Reported from BuildProfile.validate() rather than raised at parse time,
+    so a facility meets every problem its profile has in one pass."""
+    path = _write_profile(
+        tmp_path, {"compression": "brotli"}, tier=2, default_panel="does-not-exist"
+    )
+    result = runner.invoke(profile, ["validate", str(path)])
+
+    assert result.exit_code != 0
+    assert "compression" in result.output
+    assert "tier" in result.output
+
+
+# ---------------------------------------------------------------------------
+# The honesty rule at build time: a simulated machine may not invent its past
+# ---------------------------------------------------------------------------
+
+_VA = "virtual_accelerator"
+
+
+def _pairing_errors(config: dict[str, Any]) -> list[str]:
+    return va_mock_archiver_errors(config)
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param({"control_system.type": _VA, "archiver.type": "mock_archiver"}, id="flat"),
+        pytest.param(
+            {"control_system": {"type": _VA}, "archiver": {"type": "mock_archiver"}}, id="nested"
+        ),
+    ],
+)
+def test_a_virtual_accelerator_reading_the_mock_is_refused(config: dict[str, Any]) -> None:
+    """Both spellings are legal YAML and both reach the same rendered config, so
+    a refusal that saw one of them would be one a profile could be written
+    around."""
+    assert len(_pairing_errors(config)) == 1
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param({"control_system.type": _VA}, id="flat"),
+        pytest.param({"control_system": {"type": _VA}}, id="nested"),
+    ],
+)
+def test_saying_nothing_about_the_archiver_is_saying_mock(config: dict[str, Any]) -> None:
+    """The connector factory falls back to the mock, so a profile that names no
+    archiver has named one."""
+    errors = _pairing_errors(config)
+    assert len(errors) == 1
+    assert "unset" in errors[0]
+    assert "mock_archiver" in errors[0]
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param({"control_system.type": _VA, "archiver.type": "mongodb_archiver"}, id="store"),
+        pytest.param(
+            {"control_system.type": _VA, "archiver.type": "epics_archiver"}, id="facility"
+        ),
+        pytest.param({"control_system.type": "mock", "archiver.type": "mock_archiver"}, id="mock"),
+        pytest.param(
+            {"control_system.type": "epics", "archiver.type": "mock_archiver"}, id="epics"
+        ),
+        pytest.param({}, id="says-nothing"),
+    ],
+)
+def test_every_other_pairing_is_left_alone(config: dict[str, Any]) -> None:
+    """The rule is about a simulation inventing its own past — not about which
+    store a facility runs, and not a general ban on the mock archiver."""
+    assert _pairing_errors(config) == []
+
+
+def test_the_refusal_names_both_ways_out() -> None:
+    """This feature's standard: a refusal teaches rather than only blocks."""
+    message = _pairing_errors({"control_system.type": _VA, "archiver.type": "mock_archiver"})[0]
+
+    assert "va_archiver" in message
+    assert "mongodb_archiver" in message
+    assert "run yourself" in message
+
+
+def test_the_pairing_is_reported_with_the_profiles_other_problems(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Accumulated into validate()'s one report, like every other profile rule."""
+    path = _write_profile(tmp_path, None, config={"control_system.type": _VA}, tier=2)
+    result = runner.invoke(profile, ["validate", str(path)])
+
+    assert result.exit_code != 0
+    assert "archiver" in result.output
+    assert "tier" in result.output
+
+
+def test_declaring_the_block_alone_does_not_lift_the_refusal(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """The block says where an archive lives; `archiver.type` says which archiver
+    the deployment reads. A profile that declares the store and then leaves the
+    connector on the mock deploys a store nothing reads."""
+    path = _write_profile(tmp_path, {"retention_days": 2}, config={"control_system.type": _VA})
+    result = runner.invoke(profile, ["validate", str(path)])
+
+    assert result.exit_code != 0
+    assert "va_archiver" in result.output
+
+
+def test_a_profile_that_pairs_honestly_validates(runner: CliRunner, tmp_path: Path) -> None:
+    path = _write_profile(
+        tmp_path,
+        {"retention_days": 2, "hot_span_hours": 2},
+        config={"control_system.type": _VA, "archiver.type": "mongodb_archiver"},
+    )
+    result = runner.invoke(profile, ["validate", str(path)])
+
+    assert result.exit_code == 0, result.output
+
+
+# ---------------------------------------------------------------------------
+# What the REAL renderer does with two spellings, and why that means fail-closed
+# ---------------------------------------------------------------------------
+
+
+def _render_overrides(tmp_path: Path, overrides: dict[str, Any]) -> dict[str, Any]:
+    """Apply *overrides* through the build's own config-override machinery.
+
+    Not a hand-built dict standing in for the renderer: this is
+    ``_apply_config_overrides``, the function ``osprey build`` itself calls with
+    ``{**profile.config, **derived}``, writing into a config.yml shaped like a
+    rendered project's.
+    """
+    from osprey.cli.build_cmd import _apply_config_overrides
+
+    project = tmp_path / "project"
+    project.mkdir(parents=True, exist_ok=True)
+    (project / "config.yml").write_text(
+        "control_system:\n  type: mock\narchiver:\n  type: mock_archiver\n", encoding="utf-8"
+    )
+    _apply_config_overrides(project, overrides)
+    return yaml.safe_load((project / "config.yml").read_text(encoding="utf-8"))
+
+
+def test_both_spellings_reach_the_same_rendered_leaf(tmp_path: Path) -> None:
+    """The premise the build-time rule rests on: a profile's dotted key and a
+    nested mapping under `config:` are two ways of writing one rendered field."""
+    dotted = _render_overrides(tmp_path / "a", {"archiver.type": "mongodb_archiver"})
+    nested = _render_overrides(tmp_path / "b", {"archiver": {"type": "mongodb_archiver"}})
+
+    assert dotted["archiver"]["type"] == "mongodb_archiver"
+    assert nested["archiver"]["type"] == "mongodb_archiver"
+
+
+def test_which_spelling_wins_depends_on_the_order_they_were_written_in(tmp_path: Path) -> None:
+    """And the reason a profile spelling it BOTH ways is refused rather than
+    resolved: the winner is whichever key comes later in the profile's `config:`
+    block. Nothing in the profile says which that is, so the build has no
+    honest way to pick — hence fail-closed."""
+    dotted_last = _render_overrides(
+        tmp_path / "c",
+        {"archiver": {"type": "mock_archiver"}, "archiver.type": "mongodb_archiver"},
+    )
+    nested_last = _render_overrides(
+        tmp_path / "d",
+        {"archiver.type": "mongodb_archiver", "archiver": {"type": "mock_archiver"}},
+    )
+
+    assert dotted_last["archiver"]["type"] == "mongodb_archiver"
+    assert nested_last["archiver"]["type"] == "mock_archiver"
+
+
+def test_a_profile_spelling_the_archiver_both_ways_is_refused(tmp_path: Path) -> None:
+    """Half of the orderings above render a virtual accelerator onto the mock.
+    The build refuses the shape rather than gambling on key order."""
+    errors = _pairing_errors(
+        {
+            "control_system.type": _VA,
+            "archiver.type": "mongodb_archiver",
+            "archiver": {"type": "mock_archiver"},
+        }
+    )
+
+    assert len(errors) == 1
+    assert "twice" in errors[0]
+
+
+# ---------------------------------------------------------------------------
+# The derived freshness check: one canary channel in, one health category out
+# ---------------------------------------------------------------------------
+
+
+def _checks(**knobs: Any) -> list[dict[str, Any]]:
+    """The derived check list for a block built from *knobs*."""
+    return va_archiver_config_overrides(VAArchiverConfig(**knobs)).get(FRESHNESS_CONFIG_KEY, [])
+
+
+def test_a_block_naming_no_canary_derives_no_check() -> None:
+    """Which channel is representative is a fact only the facility has. Without
+    it the build derives nothing rather than guessing a channel that may not
+    exist in this machine model."""
+    assert _checks() == []
+    assert FRESHNESS_CONFIG_KEY not in va_archiver_config_overrides(VAArchiverConfig())
+
+
+def test_naming_a_canary_derives_the_whole_check() -> None:
+    (check,) = _checks(freshness_channel="SR:DIAG:DCCT:01:CURRENT:RB")
+
+    assert check["name"] == FRESHNESS_CHECK_NAME
+    assert check["type"] == FRESHNESS_CHECK_NAME
+    assert check["channel"] == "SR:DIAG:DCCT:01:CURRENT:RB"
+
+
+def test_the_threshold_follows_the_recorder_not_a_second_number() -> None:
+    """A facility that slows its recorder has changed how long a healthy archive
+    can go without a sample; the check follows that edit on its own."""
+    (slow,) = _checks(freshness_channel="X", recorder_cadence_sec=60)
+    (slower,) = _checks(freshness_channel="X", recorder_cadence_sec=120)
+
+    assert slow["max_age_s"] == 3 * 60
+    assert slower["max_age_s"] == 3 * 120
+
+
+def test_the_threshold_is_a_multiple_so_it_does_not_flap() -> None:
+    """Equal to the cadence it would sit exactly on the sample age and alarm on
+    ordinary jitter."""
+    (check,) = _checks(freshness_channel="X", recorder_cadence_sec=100)
+
+    assert check["max_age_s"] == FRESHNESS_SAFETY_MULTIPLE * 100
+    assert check["max_age_s"] > 100
+
+
+def test_a_fast_recorder_still_gets_a_survivable_floor() -> None:
+    """3 s would be tripped by any container restart; nothing is learned from an
+    alarm that fires faster than the deployment can recover."""
+    (check,) = _checks(freshness_channel="X", recorder_cadence_sec=1)
+
+    assert check["max_age_s"] == FRESHNESS_FLOOR_SEC
+
+
+def test_the_tail_cadence_does_not_move_the_threshold() -> None:
+    """Every recorder sample is written at the hot cadence; the tail grid only
+    decides which of them survive ageing. So the newest sample is never a tail
+    interval old, and the tail knob has no business in this threshold."""
+    (dense,) = _checks(freshness_channel="X", recorder_tail_cadence_sec=60)
+    (sparse,) = _checks(freshness_channel="X", recorder_tail_cadence_sec=3600)
+
+    assert dense["max_age_s"] == sparse["max_age_s"]
+
+
+def test_the_derived_check_is_what_the_health_framework_parses() -> None:
+    """The end the derivation exists for: a config the health config loader
+    accepts, carrying the probe's own parameter names."""
+    from osprey.health.config import parse_health_config
+
+    checks = _checks(freshness_channel="SR:DIAG:DCCT:01:CURRENT:RB", recorder_cadence_sec=30)
+    parsed = parse_health_config({"categories": {FRESHNESS_CATEGORY: {"checks": checks}}})
+
+    (spec,) = parsed.categories[FRESHNESS_CATEGORY].checks
+    assert spec.type == FRESHNESS_CHECK_NAME
+    assert spec.params["channel"] == "SR:DIAG:DCCT:01:CURRENT:RB"
+    assert spec.params["max_age_s"] == 90
+
+
+def test_the_derived_category_is_not_a_core_one() -> None:
+    """A core category name rejects a `checks:` list outright, so deriving into
+    one would render a config that fails to load."""
+    from osprey.health.config import CORE_CATEGORY_NAMES
+
+    assert FRESHNESS_CATEGORY not in CORE_CATEGORY_NAMES
+
+
+def test_a_blank_canary_is_refused_rather_than_ignored() -> None:
+    errors = _errors(freshness_channel="   ")
+
+    assert any("freshness_channel" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param({f"{FRESHNESS_CONFIG_KEY}": [{"name": "mine"}]}, id="dotted-leaf"),
+        pytest.param({"health.categories.archiver": {"checks": []}}, id="dotted-category"),
+        pytest.param({"health": {"categories": {"archiver": {"checks": []}}}}, id="nested"),
+        pytest.param({"health.categories": {"archiver": {"checks": []}}}, id="mixed"),
+    ],
+)
+def test_declaring_the_category_yourself_while_the_block_derives_it_is_refused(
+    config: dict[str, Any],
+) -> None:
+    """One fact, two homes — and this one would be merged in whichever order the
+    keys happen to be read, so the staleness threshold would depend on the order
+    two unrelated lines were typed in."""
+    errors = _errors(config=config, freshness_channel="X")
+
+    assert any("health.categories.archiver" in error for error in errors), errors
+
+
+def test_the_category_is_yours_again_once_the_block_names_no_canary() -> None:
+    """Dropping `freshness_channel` is how a facility takes the category back."""
+    config = {"health": {"categories": {"archiver": {"checks": []}}}}
+
+    assert _errors(config=config) == []
+
+
+def test_an_unrelated_health_category_is_left_alone() -> None:
+    """The refusal is scoped to the one category the block derives."""
+    config = {"health": {"categories": {"beamline": {"checks": []}}}}
+
+    assert _errors(config=config, freshness_channel="X") == []
+
+
+# ---------------------------------------------------------------------------
+# The shipped preset's canary has to be a channel the shipped machine serves
+# ---------------------------------------------------------------------------
+
+
+def test_the_control_assistant_preset_names_a_canary() -> None:
+    """The tutorial deployment gets the freshness check, not just the machinery
+    to derive one. A preset that shipped the store and opted out of checking it
+    would under-deliver the feature it exists to demonstrate."""
+    from osprey.cli.build_profile import resolve_build_profile
+
+    profile, _ = resolve_build_profile(None, "control-assistant")
+
+    assert profile.va_archiver is not None
+    assert profile.va_archiver.freshness_channel
+
+
+def test_the_presets_canary_is_a_channel_the_virtual_accelerator_serves() -> None:
+    """Same standard the L0 e2e holds its own canary to, applied where the
+    choice is actually made.
+
+    A canary the IOC does not serve is never recorded, so the check would report
+    "no samples" forever — a permanently yellow health row that says nothing
+    about the archive. Asserted against the manifest builder the VA and the
+    recorder both read, so a machine-model change that drops this channel fails
+    here rather than in a deployed operator's face.
+    """
+    from osprey.cli.build_profile import resolve_build_profile
+    from osprey.services.virtual_accelerator.manifest.build import build_manifest
+
+    profile, _ = resolve_build_profile(None, "control-assistant")
+    assert profile.va_archiver is not None
+    canary = profile.va_archiver.freshness_channel
+
+    served = {channel["address"] for channel in build_manifest()["channels"]}
+    assert canary in served, (
+        f"the control-assistant preset's freshness_channel {canary!r} is not served by the "
+        f"shipped machine model, so the derived check could never see a sample. Pick a "
+        f"channel the manifest carries."
+    )

--- a/tests/cli/test_sim_cmd.py
+++ b/tests/cli/test_sim_cmd.py
@@ -16,7 +16,9 @@ from click.testing import CliRunner
 
 from osprey.cli.sim import sim_group
 
-_FAKE_RESULT = SimpleNamespace(active=["nominal"], logbook_seeded=0)
+# ``archiver`` is None here for the same reason ``load_config`` returns {}: this
+# project declares no stored archive, so the rewrite has nothing to report.
+_FAKE_RESULT = SimpleNamespace(active=["nominal"], logbook_seeded=0, archiver=None)
 
 
 def _invoke(args, env=None):
@@ -77,3 +79,40 @@ def test_apply_help_shows_now():
     assert result.exit_code == 0
     assert "--now" in result.output
     assert "OSPREY_SIM_NOW" in result.output
+
+
+class TestPerStoreOptOuts:
+    """Each store can be left alone on its own, and ``--no-seed`` covers both.
+
+    Applying a scenario writes to two places — the logbook database and the
+    stored archive — and there are real reasons to skip either one: no database
+    running, or an archive somebody is mid-way through inspecting. The flags are
+    only useful if they actually reach ``apply_scenarios``, which is what these
+    pin.
+    """
+
+    def test_by_default_both_stores_are_seeded(self):
+        _, apply_mock = _invoke(["apply", "nominal", "--yes"])
+        assert apply_mock.call_args.kwargs["seed_logbook"] is True
+        assert apply_mock.call_args.kwargs["seed_archive"] is True
+
+    def test_no_seed_logbook_leaves_the_archive_alone_too(self):
+        _, apply_mock = _invoke(["apply", "nominal", "--yes", "--no-seed-logbook"])
+        assert apply_mock.call_args.kwargs["seed_logbook"] is False
+        assert apply_mock.call_args.kwargs["seed_archive"] is True
+
+    def test_no_seed_archiver_leaves_the_logbook_alone(self):
+        _, apply_mock = _invoke(["apply", "nominal", "--yes", "--no-seed-archiver"])
+        assert apply_mock.call_args.kwargs["seed_logbook"] is True
+        assert apply_mock.call_args.kwargs["seed_archive"] is False
+
+    def test_no_seed_still_means_neither(self):
+        """The pre-existing flag kept its meaning: telemetry only."""
+        _, apply_mock = _invoke(["apply", "nominal", "--yes", "--no-seed"])
+        assert apply_mock.call_args.kwargs["seed_logbook"] is False
+        assert apply_mock.call_args.kwargs["seed_archive"] is False
+
+    def test_the_flags_are_documented(self):
+        result = CliRunner().invoke(sim_group, ["apply", "--help"])
+        assert "--no-seed-logbook" in result.output
+        assert "--no-seed-archiver" in result.output

--- a/tests/cli/test_sim_physics_env.py
+++ b/tests/cli/test_sim_physics_env.py
@@ -295,7 +295,11 @@ class TestPromptAbort:
         project = _make_project(tmp_path, ariel=True)
 
         with self._stub_purge_info(), patch("osprey.simulation.apply.apply_scenarios") as mock:
-            mock.return_value = SimpleNamespace(active=["nominal", "corr-fault"], logbook_seeded=3)
+            # ``archiver=None``: this project declares no stored archive, so the
+            # rewrite has nothing to do and raises no second prompt.
+            mock.return_value = SimpleNamespace(
+                active=["nominal", "corr-fault"], logbook_seeded=3, archiver=None
+            )
             result = _apply(project, monkeypatch, "corr-fault", input="y\n")
 
         assert result.exit_code == 0, result.output

--- a/tests/cli/test_va_type_surface.py
+++ b/tests/cli/test_va_type_surface.py
@@ -5,17 +5,45 @@ Covers the config-selectable third type across the two CLI entry points:
   CLI_CONTROL_SYSTEM_TYPES from connectors/types.py, landed in Task 1.3).
 - The interactive control-system menu in cli/project_actions.py, which
   previously hardcoded Mock/EPICS only.
+
+The menu is also where the archiver is chosen, so it is where the honesty rule
+has to be reachable as a *choice* rather than only as a later refusal: a wizard
+that can author a virtual accelerator with a mock past is a wizard that walks
+its user into an error the build, the deploy and the MCP server all raise.
 """
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 from click.testing import CliRunner
 
+from osprey.cli.build_profile_archiver import (
+    CONNECTION_CONFIG_PREFIX,
+    VAArchiverConfig,
+    va_archiver_config_overrides,
+)
 from osprey.cli.config_cmd import set_control_system
-from osprey.cli.project_actions import handle_set_control_system
+from osprey.cli.project_actions import (
+    build_archiver_choices,
+    handle_set_control_system,
+    mongodb_archiver_settings,
+)
 from osprey.connectors import types
+from osprey.connectors.archiver.mongodb_archiver_connector import MongoDBArchiverConnector
 from osprey.utils.config_writer import get_control_system_type, set_control_system_type
+
+#: A project already reading a real archive, so switching it onto the virtual
+#: accelerator is a legal switch rather than the refused pairing.
+ARCHIVED_PROJECT = (
+    "control_system:\n  type: mock\n\narchiver:\n  type: mongodb_archiver\n"
+    "  mongodb_archiver:\n    host: localhost\n"
+)
+
+#: The same project with the archiver that synthesizes its history — the one
+#: the virtual accelerator may not be paired with.
+STORELESS_PROJECT = "control_system:\n  type: mock\n\narchiver:\n  type: mock_archiver\n"
 
 
 @pytest.fixture
@@ -32,9 +60,14 @@ class TestSetControlSystemCliAcceptsVirtualAccelerator:
         assert "virtual_accelerator" in system_type_param.type.choices
 
     def test_set_control_system_accepts_virtual_accelerator(self, cli_runner, tmp_path):
-        """CLI invocation with 'virtual_accelerator' is not rejected by click."""
+        """CLI invocation with 'virtual_accelerator' is not rejected by click.
+
+        The project already reads a real archive — switching one that does not
+        is refused, which ``tests/cli/test_config_cmd.py`` covers alongside the
+        command's other contracts.
+        """
         config_file = tmp_path / "config.yml"
-        config_file.write_text("control_system:\n  type: mock\n")
+        config_file.write_text(ARCHIVED_PROJECT)
 
         with patch("osprey.cli.project_utils.resolve_config_path") as mock_resolve:
             with patch("osprey.utils.config_writer.set_control_system_type") as mock_update:
@@ -61,7 +94,7 @@ class TestSetControlSystemCliAcceptsVirtualAccelerator:
     ):
         """End-to-end (no mocking of the writer): config.yml ends up correct."""
         config_file = tmp_path / "config.yml"
-        config_file.write_text("control_system:\n  type: mock\n")
+        config_file.write_text(ARCHIVED_PROJECT)
 
         with patch("osprey.cli.project_utils.resolve_config_path") as mock_resolve:
             mock_resolve.return_value = str(config_file)
@@ -138,7 +171,7 @@ class TestInteractiveMenuOffersVirtualAccelerator:
         select_mock = MagicMock()
         select_mock.return_value.ask.side_effect = [
             types.VIRTUAL_ACCELERATOR,
-            types.MOCK_ARCHIVER,
+            types.MONGODB_ARCHIVER,
         ]
         confirm_mock = MagicMock()
         confirm_mock.return_value.ask.return_value = True
@@ -151,3 +184,142 @@ class TestInteractiveMenuOffersVirtualAccelerator:
         captured = capsys.readouterr()
         assert "Configure EPICS gateway" in captured.out
         assert "You're now in Mock mode" not in captured.out
+
+
+def _run_wizard(config_file, answers):
+    """Drive the control-system menu with *answers*, one per select() prompt."""
+    select_mock = MagicMock()
+    select_mock.return_value.ask.side_effect = answers
+    confirm_mock = MagicMock()
+    confirm_mock.return_value.ask.return_value = True
+
+    with patch("osprey.cli.project_actions.questionary.select", select_mock):
+        with patch("osprey.cli.project_actions.questionary.confirm", confirm_mock):
+            with patch("osprey.cli.project_actions.input", return_value=""):
+                handle_set_control_system(project_path=config_file.parent)
+
+    return select_mock
+
+
+class TestVirtualAcceleratorNeverOffersAMockPast:
+    """The wizard cannot author the pairing the honesty rule refuses."""
+
+    def test_va_choice_list_omits_the_mock_archiver(self):
+        """A choice the build would refuse is a trap, not an option."""
+        values = [c.value for c in build_archiver_choices(types.VIRTUAL_ACCELERATOR)]
+
+        assert types.MOCK_ARCHIVER not in values
+        assert types.MONGODB_ARCHIVER in values
+
+    def test_epics_choice_list_keeps_the_mock_archiver(self):
+        """EPICS with no archive attached yet is a real facility's real state."""
+        values = [c.value for c in build_archiver_choices(types.EPICS)]
+
+        assert types.MOCK_ARCHIVER in values
+
+    def test_va_menu_asks_from_the_va_choice_list(self, tmp_path):
+        """The VA branch passes its own type down, so the list it shows is gated."""
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("control_system:\n  type: mock\n")
+
+        select_mock = _run_wizard(config_file, [types.VIRTUAL_ACCELERATOR, types.MONGODB_ARCHIVER])
+
+        archiver_choices = select_mock.call_args_list[1].kwargs["choices"]
+        assert types.MOCK_ARCHIVER not in [c.value for c in archiver_choices]
+
+    def test_va_with_a_forced_mock_selection_writes_nothing(self, tmp_path, capsys):
+        """Refused past the choice list too, for any path that skips the list."""
+        config_file = tmp_path / "config.yml"
+        original = "control_system:\n  type: mock\n\narchiver:\n  type: mock_archiver\n"
+        config_file.write_text(original)
+
+        _run_wizard(config_file, [types.VIRTUAL_ACCELERATOR, types.MOCK_ARCHIVER])
+
+        assert config_file.read_text() == original
+        captured = capsys.readouterr()
+        assert "mock past" in captured.out
+
+    def test_va_with_a_cancelled_archiver_prompt_writes_nothing(self, tmp_path):
+        """Backing out must not leave the control system switched and the past mock."""
+        config_file = tmp_path / "config.yml"
+        original = "control_system:\n  type: mock\n\narchiver:\n  type: mock_archiver\n"
+        config_file.write_text(original)
+
+        _run_wizard(config_file, [types.VIRTUAL_ACCELERATOR, None])
+
+        assert config_file.read_text() == original
+
+
+class TestMongoDBSelectionWritesAConstructibleConfig:
+    """Selecting MongoDB has to write the store's coordinates, not just its name."""
+
+    @pytest.fixture
+    def written_config(self, tmp_path):
+        config_file = tmp_path / "config.yml"
+        config_file.write_text(
+            "control_system:\n  type: mock\n\narchiver:\n  type: mock_archiver\n"
+        )
+
+        _run_wizard(config_file, [types.VIRTUAL_ACCELERATOR, types.MONGODB_ARCHIVER])
+
+        return yaml.safe_load(config_file.read_text())
+
+    def test_selection_lands_as_nested_sections(self, written_config):
+        """A rendered config.yml is read as nested sections; a flat dotted line
+        at the top level configures nothing at all."""
+        assert [key for key in written_config if "." in key] == []
+        assert written_config["control_system"]["type"] == types.VIRTUAL_ACCELERATOR
+        assert written_config["archiver"]["type"] == types.MONGODB_ARCHIVER
+
+    def test_connection_keys_match_the_build_derivation(self, written_config):
+        """The wizard and the build describe the same store, from one source."""
+        derived = {
+            key.removeprefix(f"{CONNECTION_CONFIG_PREFIX}."): value
+            for key, value in va_archiver_config_overrides(VAArchiverConfig()).items()
+            if key.startswith(f"{CONNECTION_CONFIG_PREFIX}.")
+        }
+
+        assert written_config["archiver"]["mongodb_archiver"] == derived
+        assert derived["host"] == "localhost"
+
+    def test_connector_accepts_the_written_settings(self, written_config, monkeypatch):
+        """The connector validates the config the wizard wrote, unedited.
+
+        Every key MongoDB refuses to default has to be present, and the only
+        thing left between this config and a live store is the password `deploy
+        up` mints — which is a deployment state, not an authoring error, and is
+        the one failure this connector reports as a connection problem.
+        """
+        settings = written_config["archiver"]["mongodb_archiver"]
+        monkeypatch.delenv(settings["password_env"], raising=False)
+
+        connector = MongoDBArchiverConnector()
+        with pytest.raises(ConnectionError) as exc:
+            asyncio.run(connector.connect(settings))
+
+        assert settings["password_env"] in str(exc.value)
+
+    def test_type_alone_would_not_construct(self, monkeypatch):
+        """Contrast: this is what selecting the type without the block writes."""
+        monkeypatch.delenv("MONGO_ROOT_PASSWORD", raising=False)
+
+        connector = MongoDBArchiverConnector()
+        with pytest.raises(ValueError):
+            asyncio.run(connector.connect({}))
+
+    def test_settings_helper_covers_every_connection_key(self):
+        """Nothing the connector requires may be left for the user to add."""
+        settings = mongodb_archiver_settings()
+
+        leaves = {key.removeprefix(f"{CONNECTION_CONFIG_PREFIX}.") for key in settings}
+        assert leaves == {
+            "host",
+            "port",
+            "name",
+            "collection",
+            "auth",
+            "username",
+            "password_env",
+            "timeout",
+        }
+        assert all(key.startswith(f"{CONNECTION_CONFIG_PREFIX}.") for key in settings)

--- a/tests/cli/test_wizard_mongodb_gating.py
+++ b/tests/cli/test_wizard_mongodb_gating.py
@@ -87,9 +87,22 @@ def test_template_documents_mongodb_option():
 
 
 def test_template_shows_required_mongodb_keys():
-    """A commented block covers every key the connector refuses to default."""
+    """A LIVE block covers every key the connector refuses to default.
+
+    Live rather than commented. The template's own default stays
+    ``mock_archiver`` — a project that deploys no store should read a mock that
+    admits it is one — but the control-assistant PRESET selects
+    ``mongodb_archiver`` and deploys the store to back it, and the build writes
+    these keys from its ``va_archiver:`` block. A commented example could not
+    receive them: the override sets leaves in an existing mapping, so the block
+    has to exist for the preset's values to land in it rather than beside it.
+    """
     template = CONTROL_ASSISTANT_CONFIG.read_text(encoding="utf-8")
 
-    assert "# mongodb_archiver:" in template
+    assert "\n  mongodb_archiver:\n" in template, "the mongodb block must be live, not commented"
+    block = template.split("\n  mongodb_archiver:\n", 1)[1]
+    # Stop at the next key at the same depth, so a later `host:` elsewhere in the
+    # template cannot stand in for one this block is missing.
+    body = block.split("\n\n", 1)[0]
     for key in ("host", "name", "collection", "auth", "username", "password_env"):
-        assert f"#   {key}:" in template, f"required key {key!r} missing from example block"
+        assert f"    {key}:" in body, f"required key {key!r} missing from the mongodb block"

--- a/tests/connectors/test_archiver_world_contracts.py
+++ b/tests/connectors/test_archiver_world_contracts.py
@@ -1,0 +1,1160 @@
+"""Four contracts that decide whether a deployment has one archive or two.
+
+A project that serves simulated channels has a live half and a stored half, and
+the whole point of seeding the store from the same generators the live half uses
+is that the two are one world. That claim is easy to state and easy to lose: a
+second epoch conversion, a grid anchored on the seed instant, a scenario rewrite
+that forgets a stretch of history — each of them leaves a store that is merely
+*plausible* next to what a query would compute. These tests are the acceptance
+surface for the claim, checked end to end against a real MongoDB through the
+same connectors a deployed agent uses.
+
+* **Equivalence.** A value read out of the store equals, bit for bit, the value
+  the mock archiver synthesizes for the same instant — on engine-served channels
+  and on procedural ones, and across the hot/tail boundary where the seed grid
+  changes density. Once a scenario is applied, no sample inside its event window
+  still reads clean: a gap there would be a stretch of calm history sitting
+  inside a fault the agent is being asked to diagnose.
+
+* **Retention.** History ages like history. A forced pass of mongod's own TTL
+  sweeper takes the aged samples of *both* tiers and leaves the event windows a
+  scenario protected standing, because the evidence a fault is diagnosed from
+  must never be the thing retention prunes first. The block compressor the
+  manifest claims is the one the server actually used.
+
+* **Knob change.** Moving ``retention_days`` in the rendered ``config.yml`` —
+  one YAML value, no code — makes the stored fingerprint mismatch, and the
+  reseed that follows really does reach further back.
+
+* **Scenario-switch honesty.** Applying an eventful scenario and then an
+  eventless one leaves the store bit-identical to its base, read back through
+  ``MongoDBArchiverConnector``. The module-level counterpart of this contract is
+  ``tests/simulation/test_archiver_scenario_seed.py::
+  test_switching_back_leaves_no_trace_of_the_previous_scenario``, which pins the
+  same property on the collection directly; this one is the connector's view of
+  it, so a divergence that only the read path could introduce has somewhere to
+  show up.
+
+Everything here needs Docker and skips cleanly without it. There is no LLM in
+this file and no network beyond the container.
+
+The container is this module's own rather than the shared session fixture in
+``conftest.py``, for two reasons that are part of what is under test. The block
+compressor is a *server start flag* (``--wiredTigerCollectionBlockCompressor``,
+exactly as the ``mongodb`` compose template renders it), so a default server
+could only confirm mongod's default. And mongod's TTL monitor is switched off at
+startup here and turned on for the one test that wants a sweep — every other
+anchor in this file is deliberately in the past, and a live sweeper would delete
+those stores out from under their assertions.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+import yaml
+
+from osprey.simulation.apply import (
+    DENSIFIED_FIELD,
+    apply_scenarios,
+    event_subwindows,
+    event_window,
+)
+from osprey.simulation.archiver_seed import (
+    DATE_FIELD,
+    EXPIRE_FIELD,
+    MANIFEST_ID,
+    SeedKnobs,
+    SeedState,
+    compare_fingerprint,
+    oldest_sample,
+    seed_base,
+    seed_fingerprint,
+    synthesize_documents,
+    tier_expiry,
+)
+from osprey.simulation.procedural import DEFAULT_NOISE_LEVEL
+from osprey.simulation.series import epoch_seconds_array
+from tests._container_support import is_docker_available, start_or_skip, stop_quietly
+
+# ---------------------------------------------------------------------------
+# The world under test
+# ---------------------------------------------------------------------------
+
+#: Fixed anchor for every test but the retention one, whose sweep has to be
+#: measured against the server's real clock. A failure here reproduces tomorrow,
+#: and the odd second is load-bearing: the seed grid is epoch-aligned, so an
+#: anchor that happened to fall on a cadence would hide a grid phased on T0.
+T0 = datetime(2026, 3, 14, 9, 26, 53, tzinfo=UTC)
+
+#: A day of coarse history with an hour of dense, so a container test seeds in
+#: about a second. The tier arithmetic does not know how big the numbers are.
+KNOBS = SeedKnobs(retention_days=1, hot_span_hours=1, hot_cadence_sec=10, tail_cadence_sec=60)
+
+#: The block compressor the profile's ``va_archiver`` block defaults to, which
+#: the build renders into ``services.mongodb.compression``.
+COMPRESSION = "zstd"
+
+#: One noise level for both halves of the world. A deployment renders a single
+#: value into the live connector and the seeder alike; stating it once here is
+#: what makes the equivalence assertion about the *generators* rather than about
+#: two differently-tuned copies of them.
+NOISE = DEFAULT_NOISE_LEVEL
+
+# Channels the machine model describes: both halves synthesize these through the
+# engine.
+CAVITY_TEMP = "SR:RF:CAVITY:01:TEMPERATURE:RB"
+CAVITY_POWER = "SR:RF:CAVITY:01:POWER:REV"
+CAVITY_VALID = "SR:RF:CAVITY:01:STATUS:VALID"
+
+# Channels it does not: both halves fall back to the procedural generator on the
+# taxonomy baseline. Neither ends in ``:SP``/``:RB``, so the seeder's
+# boot-value lookup and the mock's baseline-free call resolve to the same
+# number — which is the condition under which the two are comparable at all.
+BPM_X = "SR:DIAG:BPM:12:POSITION:X"
+VAC_PRESSURE = "SR:VAC:IP07:PRESSURE"
+READY = "SR:STATUS:READY"
+
+ENGINE_ANALOG = (CAVITY_TEMP, CAVITY_POWER)
+PROCEDURAL_ANALOG = (BPM_X, VAC_PRESSURE)
+ANALOG = ENGINE_ANALOG + PROCEDURAL_ANALOG
+DISCRETE = (CAVITY_VALID, READY)
+
+#: The build-generated channel manifest, in the shape the seeder reads.
+CHANNELS: list[dict[str, Any]] = [
+    {"address": CAVITY_TEMP, "record_type": "ai"},
+    {"address": CAVITY_POWER, "record_type": "ai"},
+    {"address": CAVITY_VALID, "record_type": "bi"},
+    {"address": BPM_X, "record_type": "ai"},
+    {"address": VAC_PRESSURE, "record_type": "ai"},
+    {"address": READY, "record_type": "bi"},
+]
+ADDRESSES = [str(channel["address"]) for channel in CHANNELS]
+
+# The excursions, positioned to make three geometries testable at once. The
+# temperature spike sits on the hot/tail boundary, so its window has a coarse
+# half and a dense half — where a rewrite that handled one grid and not the
+# other would leave clean samples behind. The power spike is offset from it, so
+# the two windows OVERLAP without being the same window: a rewrite that decided
+# anything per region rather than per channel would smear one channel's event
+# across the other's history. The later scenario's spike is far enough after
+# both to leave an untouched stretch between them.
+SPIKE_WIDTH_S = 120.0
+SPIKE_OFFSET_S = -KNOBS.hot_span_s
+POWER_OFFSET_S = SPIKE_OFFSET_S + 300
+TRIP_OFFSET_S = SPIKE_OFFSET_S + 2400
+
+
+def _machine() -> dict:
+    """A machine model whose channels are the engine-served half of the world."""
+    return {
+        "name": "Archiver world rig",
+        "description": "Three modelled channels; everything else is procedural",
+        "channels": {
+            CAVITY_TEMP: {
+                "value": 23.0,
+                "units": "degC",
+                "noise": 0.01,
+                "description": "Cavity 1 body temperature",
+            },
+            CAVITY_POWER: {
+                "value": 12.0,
+                "units": "kW",
+                "noise": 0.02,
+                "description": "Cavity 1 reflected power",
+            },
+            CAVITY_VALID: {
+                "value": 1.0,
+                "units": "",
+                "noise": 0.0,
+                "description": "Cavity 1 interlock valid",
+            },
+        },
+    }
+
+
+def _rf_thermal() -> dict:
+    """A cavity thermal excursion, in the shape the shipped bundle uses.
+
+    Anchor-relative (``at_offset``) spikes on the cavity's temperature and
+    reflected power, sized for a container test rather than for a 30-day
+    archive. The shipped ``rf-thermal`` bundle's own composition is pinned by
+    ``tests/simulation/test_control_assistant_scenarios.py``; what matters here
+    is the mechanism it exercises, not its amplitudes.
+    """
+    return {
+        "description": "A cavity-1 thermal excursion.",
+        "archiver": [
+            {
+                "channel": CAVITY_TEMP,
+                "events": [
+                    {
+                        "shape": "spike",
+                        "at_offset": SPIKE_OFFSET_S,
+                        "amplitude": 7.0,
+                        "width": SPIKE_WIDTH_S,
+                    }
+                ],
+            },
+            {
+                "channel": CAVITY_POWER,
+                "events": [
+                    {
+                        "shape": "spike",
+                        "at_offset": POWER_OFFSET_S,
+                        "amplitude": 80.0,
+                        "width": SPIKE_WIDTH_S,
+                    }
+                ],
+            },
+        ],
+    }
+
+
+def _cavity_trip() -> dict:
+    """A second, later excursion — a scenario to switch *to*, not back from.
+
+    Switching between two eventful scenarios is the case a switch back to
+    ``nominal`` cannot reach: the two sets' windows are disjoint, so the stretch
+    between them belongs to neither and has to end up under ordinary retention
+    again. It touches the same channel as ``rf-thermal`` on purpose, so the two
+    windows land in one channel's span rather than in two independent ones.
+    """
+    return {
+        "description": "A later cavity trip.",
+        "archiver": [
+            {
+                "channel": CAVITY_TEMP,
+                "events": [
+                    {
+                        "shape": "spike",
+                        "at_offset": TRIP_OFFSET_S,
+                        "amplitude": 5.0,
+                        "width": SPIKE_WIDTH_S,
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def _script(scenario: dict, channel: str) -> list[dict]:
+    """One channel's event script out of a scenario bundle."""
+    for entry in scenario["archiver"]:
+        if entry["channel"] == channel:
+            return entry["events"]
+    raise AssertionError(f"{channel} is not in this scenario")
+
+
+def _within(windows, moment: float) -> bool:
+    """Whether an instant falls inside any of these spans."""
+    return any(start <= moment <= end for start, end in windows)
+
+
+# ---------------------------------------------------------------------------
+# Container and project fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def mongo():
+    """A MongoDB started the way the deployment's compose template starts it.
+
+    The compressor flag is the template's, verbatim. ``ttlMonitorEnabled=false``
+    is this module's own: see the module docstring for why the sweeper has to be
+    off by default and on only where a test asks for it. The one-second sleep is
+    what makes that sweep quick when it is enabled — the shipped default is 60s,
+    which is a timer, not a contract.
+    """
+    if not is_docker_available():
+        pytest.skip("Docker not available — needed to seed and read a real store.")
+    try:
+        from testcontainers.mongodb import MongoDbContainer
+    except ImportError:
+        pytest.skip("testcontainers[mongodb] not installed")
+
+    username, password = "worlduser", "worldpass123"
+    command = [
+        "--wiredTigerCollectionBlockCompressor",
+        COMPRESSION,
+        "--setParameter",
+        "ttlMonitorEnabled=false",
+        "--setParameter",
+        "ttlMonitorSleepSecs=1",
+    ]
+    container = start_or_skip(
+        lambda: MongoDbContainer("mongo:7", username=username, password=password).with_command(
+            command
+        ),
+        label="mongodb-world-contracts",
+    )
+    try:
+        yield {
+            "host": container.get_container_host_ip(),
+            "port": int(container.get_exposed_port(27017)),
+            "username": username,
+            "password": password,
+            "auth_db": "admin",
+            "database": "archiver_world_db",
+            "collection": "pv_history",
+        }
+    finally:
+        stop_quietly(container)
+
+
+@pytest.fixture(scope="module")
+def mongo_client(mongo):
+    """One client for the module, used for setup and for admin commands."""
+    from pymongo import MongoClient
+
+    client: Any = MongoClient(
+        host=mongo["host"],
+        port=mongo["port"],
+        username=mongo["username"],
+        password=mongo["password"],
+        authSource=mongo["auth_db"],
+    )
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+class World:
+    """A built project wired to a real store, and the two ways to read it back.
+
+    The process never chdirs into the project: every path the code under test
+    resolves has to come from the project root or from ``CONFIG_FILE``, not from
+    where the caller happens to be.
+    """
+
+    def __init__(self, root: Path, collection, store: dict, password_env: str):
+        self.root = root
+        self.collection = collection
+        self._store = store
+        self._password_env = password_env
+
+    # -- the project on disk -------------------------------------------------
+
+    @property
+    def machine_path(self) -> Path:
+        return self.root / "data" / "simulation" / "machine.json"
+
+    def config(self) -> dict:
+        """The rendered config, read off disk every time.
+
+        Deliberately not through ``load_config``: the knob-change contract turns
+        on re-reading a file that a human just edited, and a cached loader would
+        make the test pass for the wrong reason.
+        """
+        return yaml.safe_load((self.root / "config.yml").read_text())
+
+    def knobs(self) -> SeedKnobs:
+        return SeedKnobs.from_config(self.config())
+
+    def fingerprint(self) -> dict:
+        return seed_fingerprint(self.knobs(), ADDRESSES, compression=COMPRESSION)
+
+    def set_retention_days(self, days: int) -> None:
+        """Edit one value in the rendered config — the whole of a knob change."""
+        config = self.config()
+        config["va_archiver"]["retention_days"] = days
+        (self.root / "config.yml").write_text(yaml.safe_dump(config))
+
+    # -- the engines ---------------------------------------------------------
+
+    def _engine(self, state_dir: Path):
+        from osprey.simulation.engine import SimulationEngine
+
+        return SimulationEngine.from_file(self.machine_path, state_dir=state_dir)
+
+    def seed_engine(self):
+        """The engine a deploy seeds with: the project's own scenario state."""
+        from osprey.simulation.engine import resolve_state_dir
+
+        return self._engine(resolve_state_dir(self.config(), self.root))
+
+    def boot_values(self) -> dict[str, float]:
+        """The map the Virtual Accelerator boots its records from.
+
+        Read through the loader ``osprey deploy up`` uses, so the seeded
+        procedural baselines are anchored by the same rule the live half applies
+        rather than by this test's reading of the machine file.
+        """
+        from osprey.services.virtual_accelerator.manifest.loaders import (
+            load_machine_json_channels,
+        )
+
+        return {
+            address: entry["value"]
+            for address, entry in load_machine_json_channels(self.machine_path).items()
+            if "value" in entry
+        }
+
+    # -- writing the store ---------------------------------------------------
+
+    def seed(self, t0: datetime, knobs: SeedKnobs | None = None):
+        """Build the base archive, exactly as the deploy step builds it."""
+        return seed_base(
+            self.collection,
+            CHANNELS,
+            knobs or self.knobs(),
+            t0=t0,
+            engine=self.seed_engine(),
+            boot_values=self.boot_values(),
+            noise_level=NOISE,
+            compression=COMPRESSION,
+            chunk_size=512,
+        )
+
+    def reseed(self, t0: datetime):
+        """Drop and rebuild — what a fingerprint mismatch provokes."""
+        self.collection.drop()
+        return self.seed(t0)
+
+    def apply(self, names: list[str], *, at: datetime = T0):
+        """Activate a scenario set; the project has no ARIEL, so no logbook."""
+        return apply_scenarios(self.root, names, seed_logbook=False, now=at)
+
+    # -- reading it back -----------------------------------------------------
+
+    async def stored(self, channels, start: datetime, end: datetime) -> pd.DataFrame:
+        """Read the store through the connector a deployed agent uses."""
+        from osprey.connectors.archiver.mongodb_archiver_connector import (
+            MongoDBArchiverConnector,
+        )
+
+        connector = MongoDBArchiverConnector()
+        await connector.connect(
+            {
+                "host": self._store["host"],
+                "port": self._store["port"],
+                "name": self._store["database"],
+                "collection": self._store["collection"],
+                "auth": self._store["auth_db"],
+                "username": self._store["username"],
+                "password_env": self._password_env,
+                "timeout": 20,
+            }
+        )
+        try:
+            # precision_ms=0 is full resolution: every stored sample at its own
+            # timestamp, with no binning between the store and the assertion.
+            return await connector.get_data(
+                pv_list=list(channels), start_date=start, end_date=end, precision_ms=0
+            )
+        finally:
+            await connector.disconnect()
+
+    async def mocked(
+        self, channels, start: datetime, end: datetime, precision_ms: int
+    ) -> pd.DataFrame:
+        """Synthesize the same window through the mock archiver.
+
+        The connector is handed no ``simulation_file``: deriving it from the
+        control-system config is the shipped behaviour, and a test that named
+        the file explicitly would not be reading the same machine model the
+        store was seeded from for the same reason a deployment does.
+        """
+        from osprey.connectors.archiver.mock_archiver_connector import MockArchiverConnector
+
+        connector = MockArchiverConnector()
+        await connector.connect({"noise_level": NOISE, "sample_rate_hz": 1.0})
+        try:
+            return await connector.get_data(
+                pv_list=list(channels),
+                start_date=start,
+                end_date=end,
+                precision_ms=precision_ms,
+            )
+        finally:
+            await connector.disconnect()
+
+    def base_values(self, channels, stamps: list[datetime]) -> dict[str, list]:
+        """What the archive holds at these instants with no scenario active.
+
+        Computed through :func:`synthesize_documents`, the single definition of
+        an archived value at time T, on an engine that has never had a scenario
+        activated — so "clean" here means what the base seed wrote, not what
+        this test thinks it wrote.
+        """
+        nominal_state = self.root / "_nominal_state"
+        nominal_state.mkdir(exist_ok=True)
+        epochs = epoch_seconds_array(stamps)
+        assert epochs is not None
+        documents = synthesize_documents(
+            CHANNELS,
+            epochs,
+            engine=self._engine(nominal_state),
+            boot_values=self.boot_values(),
+            noise_level=NOISE,
+        )
+        return {pv: [document[pv] for document in documents] for pv in channels}
+
+
+@pytest.fixture
+def world(tmp_path, mongo, mongo_client, monkeypatch):
+    """A freshly built project on an empty collection.
+
+    Function-scoped on purpose: the scenario state file lives in the project,
+    so a shared project would let one test's active set decide what the next
+    test's mock archiver synthesizes.
+    """
+    root = tmp_path / "world"
+    scenarios = root / "data" / "simulation" / "scenarios"
+    scenarios.mkdir(parents=True)
+    (root / "data" / "simulation" / "machine.json").write_text(json.dumps(_machine()))
+    for name, bundle in (("rf-thermal", _rf_thermal()), ("cavity-trip", _cavity_trip())):
+        (scenarios / name).mkdir()
+        (scenarios / name / "scenario.json").write_text(json.dumps(bundle))
+
+    password_env = "ARCHIVER_WORLD_MONGO_PASSWORD"
+    config = {
+        "project_name": "archiver-world-contracts",
+        "project_root": str(root),
+        "control_system": {
+            "type": "mock",
+            "connector": {"mock": {"simulation_file": "data/simulation/machine.json"}},
+        },
+        "archiver": {
+            "type": "mongodb_archiver",
+            "mongodb_archiver": {
+                "host": mongo["host"],
+                "port": mongo["port"],
+                "name": mongo["database"],
+                "collection": mongo["collection"],
+                "auth": mongo["auth_db"],
+                "username": mongo["username"],
+                "password_env": password_env,
+                "timeout": 20,
+            },
+        },
+        "services": {"mongodb": {"compression": COMPRESSION}},
+        "va_archiver": {
+            "retention_days": KNOBS.retention_days,
+            "hot_span_hours": KNOBS.hot_span_hours,
+            "hot_cadence_sec": KNOBS.hot_cadence_sec,
+            "tail_cadence_sec": KNOBS.tail_cadence_sec,
+        },
+    }
+    (root / "config.yml").write_text(yaml.safe_dump(config))
+    (root / ".env").write_text(f"{password_env}={mongo['password']}\n")
+
+    # The mock archiver resolves its machine model, and its scenario state, out
+    # of the ambient project config; the MongoDB connector reads its password
+    # from the environment by name. Both are set the way a deployment sets them.
+    monkeypatch.setenv("CONFIG_FILE", str(root / "config.yml"))
+    monkeypatch.setenv(password_env, mongo["password"])
+
+    collection = mongo_client[mongo["database"]][mongo["collection"]]
+    collection.drop()
+    try:
+        yield World(root, collection, mongo, password_env)
+    finally:
+        collection.drop()
+
+
+@pytest.fixture
+def ttl_sweeper(mongo_client):
+    """Turn mongod's own TTL monitor on for one test, and off again after.
+
+    Yields a callable that starts the sweeper. This is a real pass of the
+    server's sweeper rather than a delete emulating its predicate: the predicate
+    is not the interesting part — whether the documents a scenario protected
+    survive one is.
+    """
+
+    def start() -> None:
+        mongo_client.admin.command("setParameter", 1, ttlMonitorEnabled=True)
+
+    try:
+        yield start
+    finally:
+        mongo_client.admin.command("setParameter", 1, ttlMonitorEnabled=False)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _aligned(moment: datetime, cadence_s: int) -> datetime:
+    """The seeded timestamp at or before ``moment``."""
+    epoch = moment.timestamp() // cadence_s * cadence_s
+    return datetime.fromtimestamp(epoch, UTC)
+
+
+def _probe(start: datetime, cadence_s: int, intervals: int) -> tuple[datetime, datetime, int]:
+    """A mock query whose own grid lands on seeded timestamps.
+
+    ``MockArchiverConnector`` takes ``int(duration / precision)`` points and
+    spreads them evenly from the window's start to its end, so asking for
+    exactly ``intervals + 1`` points across ``intervals`` cadences puts every
+    one of them on a timestamp the seed grid already holds. The comparison
+    asserts the returned stamps really are that grid, so a change to the mock's
+    arithmetic fails loudly here instead of quietly comparing nothing.
+
+    Returns ``(start, end, precision_ms)``.
+    """
+    duration = intervals * cadence_s
+    precision_ms, remainder = divmod(1000 * duration, intervals + 1)
+    assert remainder == 0, "choose an (intervals, cadence) pair with a whole-ms precision"
+    assert intervals + 1 >= 10, "the mock floors a window at ten points"
+    return start, start + timedelta(seconds=duration), precision_ms
+
+
+def _documents_between(collection, start_s: float, end_s: float) -> list[dict]:
+    """Stored samples in a span, ascending, read off the collection directly.
+
+    Expiry is not something an archiver query returns — it is not history, it is
+    how long history lives — so the retention assertions read the documents
+    rather than the connector's frame.
+    """
+    return list(
+        collection.find(
+            {
+                DATE_FIELD: {
+                    "$gte": datetime.fromtimestamp(start_s, UTC),
+                    "$lte": datetime.fromtimestamp(end_s, UTC),
+                }
+            }
+        ).sort(DATE_FIELD, 1)
+    )
+
+
+def _series(frame: pd.DataFrame, channel: str) -> pd.Series:
+    """One channel's samples out of a canonical long frame, indexed by time."""
+    rows = frame[frame["channel"] == channel]
+    return pd.Series(rows["value"].to_numpy(), index=pd.DatetimeIndex(rows["timestamp"]))
+
+
+async def _assert_bit_equal(world: World, channels, start, end, precision_ms) -> int:
+    """Every timestamp the mock reports must be in the store, holding its value.
+
+    Returns the number of samples compared, so a caller can refuse a vacuous
+    pass.
+    """
+    stored = await world.stored(channels, start, end)
+    mocked = await world.mocked(channels, start, end, precision_ms)
+
+    compared = 0
+    for channel in channels:
+        stored_series = _series(stored, channel)
+        mocked_series = _series(mocked, channel)
+        assert not mocked_series.empty, f"the mock synthesized nothing for {channel}"
+
+        missing = mocked_series.index.difference(stored_series.index)
+        assert missing.empty, (
+            f"{channel}: the probe grid left the seeded grid at {list(missing)[:3]} — "
+            "the two halves are being compared at instants only one of them has"
+        )
+        np.testing.assert_array_equal(
+            stored_series.loc[mocked_series.index].to_numpy(dtype=float),
+            mocked_series.to_numpy(dtype=float),
+            err_msg=f"{channel}: stored history and synthesized history disagree",
+        )
+        compared += len(mocked_series)
+    return compared
+
+
+# ---------------------------------------------------------------------------
+# 1. Equivalence: the store holds what a query would compute
+# ---------------------------------------------------------------------------
+
+
+class TestSeederMockEquivalence:
+    """Analog channels only — see :class:`TestServedTypes` for the rest."""
+
+    @pytest.mark.asyncio
+    async def test_the_dense_tier_equals_what_the_mock_synthesizes(self, world):
+        """Inside the hot span, where the store holds a sample every cadence."""
+        world.seed(T0)
+        start = _aligned(T0 - timedelta(minutes=30), KNOBS.hot_cadence_sec)
+
+        compared = await _assert_bit_equal(world, ANALOG, *_probe(start, KNOBS.hot_cadence_sec, 9))
+
+        assert compared == len(ANALOG) * 10
+
+    @pytest.mark.asyncio
+    async def test_the_coarse_tier_equals_what_the_mock_synthesizes(self, world):
+        """Outside the hot span the grid is sparser, and nothing else changes.
+
+        The values are a function of the timestamp alone; a generator that had
+        picked up the sample *rate* anywhere would agree in one tier and not the
+        other.
+        """
+        world.seed(T0)
+        start = _aligned(T0 - timedelta(hours=6), KNOBS.tail_cadence_sec)
+
+        compared = await _assert_bit_equal(world, ANALOG, *_probe(start, KNOBS.tail_cadence_sec, 9))
+
+        assert compared == len(ANALOG) * 10
+
+    @pytest.mark.asyncio
+    async def test_a_window_straddling_the_hot_boundary_equals_it_throughout(self, world):
+        """The seam between the two tiers, checked on the cadence they share.
+
+        The coarse cadence is a whole multiple of the dense one, so coarse
+        timestamps exist on both sides of the boundary and one probe grid spans
+        it. What must not happen is the values changing character where the
+        density does.
+        """
+        world.seed(T0)
+        boundary = T0 - timedelta(seconds=KNOBS.hot_span_s)
+        start = _aligned(boundary - timedelta(seconds=270), KNOBS.tail_cadence_sec)
+        window = _probe(start, KNOBS.tail_cadence_sec, 9)
+
+        compared = await _assert_bit_equal(world, ANALOG, *window)
+
+        assert compared == len(ANALOG) * 10
+        # And the window really did straddle it: the seeded store is denser on
+        # the recent side, which is the whole reason this window is interesting.
+        stored = await world.stored([CAVITY_TEMP], window[0], window[1])
+        stamps = _series(stored, CAVITY_TEMP).index
+        older = stamps[stamps < boundary]
+        newer = stamps[stamps >= boundary]
+        assert len(newer) > len(older) > 0, "the probe did not cross the hot/tail boundary"
+
+    @pytest.mark.asyncio
+    async def test_no_clean_sample_survives_inside_an_applied_event_window(self, world):
+        """A gap here is a stretch of calm history inside an active fault.
+
+        The excursion is positioned on the hot/tail boundary, so its window has
+        a coarse half and a dense half; a rewrite that handled one grid and not
+        the other would leave clean samples in the other one and nothing else in
+        this file would notice.
+        """
+        world.seed(T0)
+        result = world.apply(["rf-thermal"])
+        assert result.archiver.skipped is None
+
+        horizon = oldest_sample(world.collection).timestamp()
+        start_s, end_s = event_window(_script(_rf_thermal(), CAVITY_TEMP), T0.timestamp(), horizon)
+        start = datetime.fromtimestamp(start_s, UTC)
+        end = datetime.fromtimestamp(end_s, UTC)
+        boundary = T0 - timedelta(seconds=KNOBS.hot_span_s)
+        assert start < boundary < end, "the excursion's window must cross the tier boundary"
+
+        stored = await world.stored([CAVITY_TEMP], start, end)
+        series = _series(stored, CAVITY_TEMP)
+        assert len(series) > 0
+
+        stamps = [stamp.to_pydatetime() for stamp in series.index]
+        # Densification steps the same epoch-aligned grid the base seed uses and
+        # skips coarse multiples, so an insert can never land on a timestamp the
+        # base seed already wrote. One sample per instant is the schema.
+        assert len(set(stamps)) == len(stamps), "a dense insert duplicated a base-seed sample"
+
+        clean = world.base_values([CAVITY_TEMP], stamps)[CAVITY_TEMP]
+        untouched = [
+            stamp
+            for stamp, stored_value, clean_value in zip(
+                stamps, series.to_numpy(), clean, strict=True
+            )
+            if stored_value == clean_value
+        ]
+        assert not untouched, (
+            f"{len(untouched)} of {len(stamps)} samples inside the event window still read "
+            f"clean, first at {untouched[0]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_history_outside_the_event_window_is_untouched(self, world):
+        """The other half of the same contract: an event reaches its window and
+        no further, so the store still equals the mock everywhere else."""
+        world.seed(T0)
+        world.apply(["rf-thermal"])
+        start = _aligned(T0 - timedelta(hours=12), KNOBS.tail_cadence_sec)
+
+        compared = await _assert_bit_equal(world, ANALOG, *_probe(start, KNOBS.tail_cadence_sec, 9))
+
+        assert compared == len(ANALOG) * 10
+
+
+class TestServedTypes:
+    """Discrete channels, which are outside the equivalence contract above.
+
+    A ``bi`` record is served — and therefore stored — as a boolean, and the
+    manifest is what says so. The mock archiver has no manifest: it synthesizes
+    from a channel name and a clock, so it cannot know a record type and returns
+    a number for these. That is an accepted divergence, not a defect to assert
+    around, so what gets pinned is the store's side of it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_discrete_channels_are_stored_as_the_type_they_are_served_as(self, world):
+        world.seed(T0)
+
+        document = world.collection.find_one({DATE_FIELD: {"$exists": True}})
+
+        for channel in DISCRETE:
+            assert isinstance(document[channel], bool), (
+                f"{channel} is served as a flag; a float here is a value no client "
+                f"could ever have read back"
+            )
+
+    @pytest.mark.asyncio
+    async def test_the_mock_cannot_know_a_record_type_and_says_so_in_numbers(self, world):
+        """Documents the divergence rather than papering over it."""
+        world.seed(T0)
+        start = _aligned(T0 - timedelta(minutes=30), KNOBS.hot_cadence_sec)
+        window_start, window_end, precision_ms = _probe(start, KNOBS.hot_cadence_sec, 9)
+
+        frame = await world.mocked([READY], window_start, window_end, precision_ms)
+
+        values = _series(frame, READY)
+        assert not values.empty
+        assert not any(isinstance(value, bool) for value in values)
+
+
+# ---------------------------------------------------------------------------
+# 2. Retention: history ages, evidence does not
+# ---------------------------------------------------------------------------
+
+
+def _tier(stamp: datetime, knobs: SeedKnobs) -> str:
+    """Which tier a stored timestamp belongs to, read off the timestamp."""
+    return "coarse" if int(stamp.timestamp()) % knobs.tail_cadence_sec == 0 else "dense"
+
+
+class TestRetention:
+    """A forced pass of mongod's own sweeper, and what it is allowed to take."""
+
+    #: How far the anchor is backdated. Every sample older than
+    #: ``anchor - lifetime`` is then already past its expiry when it is written,
+    #: which is what gives the sweep something to do in both tiers.
+    AGE_S = 1800
+
+    def _anchor(self) -> datetime:
+        return datetime.now(UTC).replace(microsecond=0) - timedelta(seconds=self.AGE_S)
+
+    @pytest.mark.asyncio
+    async def test_a_ttl_pass_takes_the_aged_tiers_and_leaves_the_evidence(
+        self, world, ttl_sweeper
+    ):
+        anchor = self._anchor()
+        world.seed(anchor)
+        # The excursion is anchored deep in the coarse stretch that is already
+        # past its expiry, so the protection it writes is the only thing
+        # standing between those documents and the sweeper.
+        expired_offset = -(KNOBS.retention_s - self.AGE_S // 2)
+        world.root.joinpath("data/simulation/scenarios/rf-thermal/scenario.json").write_text(
+            json.dumps(_aged_rf_thermal(expired_offset))
+        )
+        result = world.apply(["rf-thermal"], at=anchor)
+        assert result.archiver.skipped is None
+        assert result.archiver.updated > 0
+
+        collection = world.collection
+        protected = list(
+            collection.find({EXPIRE_FIELD: {"$exists": False}, DATE_FIELD: {"$exists": True}})
+        )
+        assert protected, "the scenario protected nothing — there is no contract to test"
+
+        cutoff = datetime.now(UTC)
+        doomed = list(collection.find({EXPIRE_FIELD: {"$lte": cutoff}}, {DATE_FIELD: 1}))
+        assert doomed, "nothing was due — the anchor is not old enough to age anything"
+        tiers = {_tier(doc[DATE_FIELD].replace(tzinfo=UTC), KNOBS) for doc in doomed}
+        assert tiers == {"dense", "coarse"}, f"only {tiers} aged; both tiers must"
+
+        ttl_sweeper()
+        _await_sweep(collection, [doc["_id"] for doc in doomed])
+
+        surviving = {doc["_id"] for doc in collection.find({}, {"_id": 1})}
+        assert {doc["_id"] for doc in protected} <= surviving, (
+            "retention pruned the stretch of history the active scenario exists to be "
+            "diagnosed from"
+        )
+        assert MANIFEST_ID in surviving, "the manifest carries no expiry and must survive"
+
+    def test_the_manifest_records_the_compressor_the_server_actually_used(self, world, mongo):
+        """The fingerprint's ``compression`` is a claim about the store on disk.
+
+        It is what a knob change compares against, so a value that merely
+        travelled through the config without reaching WiredTiger would make
+        every reseed decision about the wrong thing.
+        """
+        world.seed(T0)
+
+        stats = world.collection.database.command("collStats", mongo["collection"])
+        creation = stats["wiredTiger"]["creationString"]
+        recorded = world.collection.find_one({"_id": MANIFEST_ID})["fingerprint"]["compression"]
+
+        assert f"block_compressor={COMPRESSION}" in creation
+        assert recorded == COMPRESSION
+
+
+def _aged_rf_thermal(at_offset: float) -> dict:
+    """The excursion, repositioned into a stretch that has already expired."""
+    scenario = _rf_thermal()
+    for entry in scenario["archiver"]:
+        for event in entry["events"]:
+            event["at_offset"] = at_offset
+    return scenario
+
+
+def _await_sweep(collection, ids, timeout_s: float = 90.0) -> None:
+    """Block until mongod has removed every one of these documents."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        remaining = collection.count_documents({"_id": {"$in": ids}})
+        if remaining == 0:
+            return
+        time.sleep(0.5)
+    pytest.fail(
+        f"the TTL monitor left {remaining} of {len(ids)} expired documents after {timeout_s}s"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. A knob change is a config edit, and it reaches the store
+# ---------------------------------------------------------------------------
+
+
+class TestKnobChange:
+    def test_moving_retention_in_the_config_mismatches_and_reseeds_deeper(self, world):
+        """One YAML value moves; nothing else in the project does.
+
+        The fingerprint is what makes a reseed a reported decision rather than a
+        silent rebuild, and coverage is what makes the decision worth taking —
+        so both halves are checked, not just the comparison.
+        """
+        world.seed(T0)
+        assert compare_fingerprint(world.collection, world.fingerprint()).state is SeedState.MATCH
+        shallow_start = oldest_sample(world.collection)
+
+        world.set_retention_days(KNOBS.retention_days + 2)
+
+        comparison = compare_fingerprint(world.collection, world.fingerprint())
+        assert comparison.state is SeedState.MISMATCH
+        assert ("retention_days", KNOBS.retention_days, KNOBS.retention_days + 2) in (
+            comparison.differences
+        )
+        assert "retention_days" in comparison.describe()
+
+        world.reseed(T0)
+
+        assert compare_fingerprint(world.collection, world.fingerprint()).state is SeedState.MATCH
+        deep_start = oldest_sample(world.collection)
+        assert deep_start < shallow_start
+        assert (shallow_start - deep_start) > timedelta(days=2) - timedelta(minutes=1)
+
+    def test_an_unchanged_config_does_not_provoke_a_reseed(self, world):
+        """The other side of the same knob: a redeploy that changed nothing must
+        not rebuild a month of history to arrive back where it started."""
+        world.seed(T0)
+
+        assert compare_fingerprint(world.collection, world.fingerprint()).state is SeedState.MATCH
+
+
+# ---------------------------------------------------------------------------
+# 4. Scenario-switch honesty, seen from the connector
+# ---------------------------------------------------------------------------
+
+
+class TestScenarioSwitchHonesty:
+    """Apply an eventful set, then an eventless one; the world must be the base.
+
+    ``tests/simulation/test_archiver_scenario_seed.py::
+    test_switching_back_leaves_no_trace_of_the_previous_scenario`` pins this on
+    the collection itself, document by document. This is the same contract seen
+    through ``MongoDBArchiverConnector``, which is where a leftover dense insert
+    or a re-typed value would actually reach an agent.
+    """
+
+    @pytest.mark.asyncio
+    async def test_switching_back_leaves_the_archive_bit_identical(self, world):
+        world.seed(T0)
+        horizon = oldest_sample(world.collection) - timedelta(seconds=1)
+        end = T0 + timedelta(seconds=1)
+
+        base = await world.stored(ADDRESSES, horizon, end)
+        assert not base.empty
+
+        world.apply(["rf-thermal"])
+        during = await world.stored(ADDRESSES, horizon, end)
+        assert not during.equals(base), "the scenario never reached the archive"
+
+        world.apply(["nominal"])
+        after = await world.stored(ADDRESSES, horizon, end)
+
+        pd.testing.assert_frame_equal(after, base)
+        assert world.collection.count_documents({DENSIFIED_FIELD: True}) == 0
+
+    @pytest.mark.asyncio
+    async def test_switching_between_two_scenarios_puts_the_gap_back_under_retention(self, world):
+        """The case a switch back to ``nominal`` cannot reach.
+
+        Two eventful sets in a row leave three stretches: the old window, the
+        new one, and the calm between them. Only the middle one is subtle. A
+        rewrite that decided expiry over the *span* it recomputed — the union of
+        the old window and the new one — would strip the stamp from that middle
+        stretch and never put it back, because the ledger it writes names only
+        the new window and no later apply would come back for it. The result is
+        a wedge of history that outlives its retention forever, which is the
+        same dishonesty as history that vanishes early, told backwards.
+
+        So the assertion is made per document against the live windows of the
+        set now in force: inside one, no stamp; outside every one, the stamp its
+        tier says it should have.
+        """
+        world.seed(T0)
+        collection = world.collection
+        anchor_s = T0.timestamp()
+        horizon = oldest_sample(collection).timestamp()
+
+        old_window = event_window(_script(_rf_thermal(), CAVITY_TEMP), anchor_s, horizon)
+        new_window = event_window(_script(_cavity_trip(), CAVITY_TEMP), anchor_s, horizon)
+        assert old_window[1] < new_window[0], "the two windows must leave a gap between them"
+        span = (old_window[0], new_window[1])
+        gap = (old_window[1], new_window[0])
+        before = _documents_between(collection, *gap)
+        assert before, "there is no history between the windows to put back under retention"
+
+        world.apply(["rf-thermal"])
+        world.apply(["cavity-trip"])
+
+        live = {
+            pv: event_subwindows(_script(_cavity_trip(), pv), anchor_s, horizon)
+            for pv in (CAVITY_TEMP,)
+        }
+        stranded, mis_stamped = [], []
+        for document in _documents_between(collection, *span):
+            stamp = document[DATE_FIELD].replace(tzinfo=UTC)
+            epoch = stamp.timestamp()
+            held = document.get(EXPIRE_FIELD)
+            if _within(live[CAVITY_TEMP], epoch):
+                assert held is None, f"the live window lost its protection at {stamp}"
+                continue
+            if held is None:
+                stranded.append(stamp)
+                continue
+            wanted = float(tier_expiry(KNOBS, np.asarray([epoch]))[0])
+            if abs(held.replace(tzinfo=UTC).timestamp() - wanted) > 0.001:
+                mis_stamped.append(stamp)
+
+        assert not stranded, (
+            f"{len(stranded)} document(s) between the two scenarios' windows are still "
+            f"unexpiring and no ledger names them again, first at {stranded[0]}"
+        )
+        assert not mis_stamped, (
+            f"{len(mis_stamped)} document(s) came back under an expiry that is not their "
+            f"tier's, first at {mis_stamped[0]}"
+        )
+
+        # And the stretch is intact, not merely correctly stamped: same
+        # timestamps as the base seed wrote, with no dense inserts left behind
+        # from the set that is no longer active.
+        after = _documents_between(collection, *gap)
+        assert [d[DATE_FIELD] for d in after] == [d[DATE_FIELD] for d in before]
+        assert not any(d.get(DENSIFIED_FIELD) for d in after)
+
+    @pytest.mark.asyncio
+    async def test_the_old_scenarios_window_reads_clean_again(self, world):
+        """Switching to another fault has to erase the first one, not stack it."""
+        world.seed(T0)
+        anchor_s = T0.timestamp()
+        horizon = oldest_sample(world.collection).timestamp()
+        old_window = event_window(_script(_rf_thermal(), CAVITY_TEMP), anchor_s, horizon)
+        start = datetime.fromtimestamp(old_window[0], UTC)
+        end = datetime.fromtimestamp(old_window[1], UTC)
+
+        world.apply(["rf-thermal"])
+        world.apply(["cavity-trip"])
+
+        series = _series(await world.stored([CAVITY_TEMP], start, end), CAVITY_TEMP)
+        stamps = [stamp.to_pydatetime() for stamp in series.index]
+        clean = world.base_values([CAVITY_TEMP], stamps)[CAVITY_TEMP]
+
+        np.testing.assert_array_equal(
+            series.to_numpy(dtype=float),
+            np.asarray(clean, dtype=float),
+            err_msg="the previous scenario's excursion is still in the archive",
+        )
+
+
+class TestOverlappingWindows:
+    """Two channels whose event windows overlap without being the same window.
+
+    Everything the rewrite does — which values it recomputes, which documents it
+    protects, which instants it densifies — has to be decided per channel and
+    per instant. Two channels sharing a region is where a decision made once for
+    the whole region shows up: one channel's excursion smeared across the
+    other's history, or a stretch protected because some *other* channel had an
+    event there.
+    """
+
+    @pytest.mark.asyncio
+    async def test_each_channel_is_rewritten_over_its_own_window_only(self, world):
+        world.seed(T0)
+        anchor_s = T0.timestamp()
+        horizon = oldest_sample(world.collection).timestamp()
+        temp = event_subwindows(_script(_rf_thermal(), CAVITY_TEMP), anchor_s, horizon)
+        power = event_subwindows(_script(_rf_thermal(), CAVITY_POWER), anchor_s, horizon)
+        assert len(temp) == len(power) == 1
+        assert temp[0][0] < power[0][0] < temp[0][1] < power[0][1], (
+            "the two windows must overlap without being the same window"
+        )
+
+        world.apply(["rf-thermal"])
+
+        start = datetime.fromtimestamp(temp[0][0], UTC)
+        end = datetime.fromtimestamp(power[0][1], UTC)
+        stored = await world.stored([CAVITY_TEMP, CAVITY_POWER], start, end)
+
+        seen = {"temp-only": 0, "power-only": 0, "both": 0}
+        for label, channel, windows, other in (
+            ("temp-only", CAVITY_TEMP, temp, power),
+            ("power-only", CAVITY_POWER, power, temp),
+        ):
+            series = _series(stored, channel)
+            stamps = [stamp.to_pydatetime() for stamp in series.index]
+            assert stamps, f"{channel} has no samples across the two windows"
+            clean = world.base_values([channel], stamps)[channel]
+            for stamp, value, base in zip(stamps, series.to_numpy(), clean, strict=True):
+                epoch = stamp.timestamp()
+                if not _within(windows, epoch):
+                    assert value == base, (
+                        f"{channel} was rewritten at {stamp}, which is outside its own window "
+                        f"and inside the other channel's"
+                    )
+                    continue
+                assert value != base, f"{channel} was not rewritten at {stamp}"
+                seen["both" if _within(other, epoch) else label] += 1
+
+        assert seen["both"] > 0, "the windows never actually overlapped in stored history"
+        assert seen["temp-only"] > 0 and seen["power-only"] > 0, (
+            "no document fell in exactly one window, so nothing distinguished the two"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_dense_insert_carries_only_the_channels_live_at_its_instant(self, world):
+        """Sparse documents are legal, so an insert outside a channel's window
+        must simply omit it rather than give it invented resolution."""
+        world.seed(T0)
+        anchor_s = T0.timestamp()
+        horizon = oldest_sample(world.collection).timestamp()
+        power = event_subwindows(_script(_rf_thermal(), CAVITY_POWER), anchor_s, horizon)
+
+        world.apply(["rf-thermal"])
+
+        inserts = list(world.collection.find({DENSIFIED_FIELD: True}))
+        assert inserts, "the coarse half of the window was never densified"
+        outside_power = [
+            document
+            for document in inserts
+            if not _within(power, document[DATE_FIELD].replace(tzinfo=UTC).timestamp())
+        ]
+        assert outside_power, "every insert fell inside both windows — nothing was distinguished"
+        for document in outside_power:
+            assert CAVITY_TEMP in document
+            assert CAVITY_POWER not in document, (
+                "an insert outside the power channel's window still carried it"
+            )

--- a/tests/connectors/test_connector_factory.py
+++ b/tests/connectors/test_connector_factory.py
@@ -1,5 +1,7 @@
 """Tests for connector factory."""
 
+from unittest.mock import patch
+
 import pytest
 
 from osprey.connectors.archiver.base import ArchiverConnector
@@ -178,3 +180,82 @@ class TestConnectorFactory:
 
             # This demonstrates how easy it is to switch connector types
             # Just change the config!
+
+
+class TestBuiltinArchiverRegistration:
+    """``register_builtin_connectors()`` heals a partially-populated registry.
+
+    The function short-circuits when every name in ``_BUILTIN_ARCHIVERS`` is
+    already registered. ``mongodb_archiver`` used to be appended outside that
+    tuple, so a registry holding the other archivers satisfied the early return
+    and the MongoDB entry was never added — leaving a project configured for
+    ``mongodb_archiver`` unable to build its connector at all. These pin the
+    tuple as the complete list.
+    """
+
+    def test_mongodb_archiver_is_registered_from_a_partial_registry(self):
+        """A registry holding the other archivers still gains mongodb_archiver."""
+        from osprey.connectors import types
+        from osprey.connectors.archiver.doocs_archiver_connector import DOOCSArchiverConnector
+        from osprey.connectors.archiver.epics_archiver_connector import EPICSArchiverConnector
+        from osprey.connectors.control_system.doocs_connector import DOOCSConnector
+        from osprey.connectors.control_system.epics_connector import EPICSConnector
+        from osprey.connectors.control_system.va_connector import VirtualAcceleratorConnector
+        from osprey.connectors.factory import register_builtin_connectors
+
+        # The exact state that used to short-circuit: every built-in present
+        # except the MongoDB archiver. The autouse fixture already registered
+        # the two mock names.
+        ConnectorFactory.register_control_system(types.EPICS, EPICSConnector)
+        ConnectorFactory.register_control_system(
+            types.VIRTUAL_ACCELERATOR, VirtualAcceleratorConnector
+        )
+        ConnectorFactory.register_control_system(types.DOOCS, DOOCSConnector)
+        ConnectorFactory.register_archiver(types.EPICS_ARCHIVER, EPICSArchiverConnector)
+        ConnectorFactory.register_archiver(types.DOOCS_ARCHIVER, DOOCSArchiverConnector)
+        assert types.MONGODB_ARCHIVER not in ConnectorFactory._archiver_connectors
+
+        register_builtin_connectors()
+
+        assert types.MONGODB_ARCHIVER in ConnectorFactory._archiver_connectors
+
+    def test_registration_does_not_require_pymongo(self):
+        """The MongoDB connector registers with pymongo absent from the process.
+
+        It defers the pymongo import to ``connect()``, so registration must not
+        depend on the driver being installed — the same rationale that lets the
+        DOOCS connectors register without doocs4py.
+        """
+        import builtins
+
+        from osprey.connectors import types
+        from osprey.connectors.factory import register_builtin_connectors
+
+        real_import = builtins.__import__
+
+        def no_pymongo(name, *args, **kwargs):
+            if name == "pymongo" or name.startswith("pymongo."):
+                raise ImportError("No module named 'pymongo'")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=no_pymongo):
+            register_builtin_connectors()
+
+        assert types.MONGODB_ARCHIVER in ConnectorFactory._archiver_connectors
+
+    def test_factory_builtins_and_framework_registry_agree_on_archivers(self):
+        """The factory's built-in archiver names match the framework registry's.
+
+        Two independent lists name the shipped archivers; a name in one and not
+        the other means a connector the registry advertises but the factory
+        cannot construct, or the reverse.
+        """
+        from osprey.connectors.factory import _BUILTIN_ARCHIVERS
+        from osprey.registry.builtins import FrameworkRegistryProvider
+
+        registry_archivers = {
+            reg.name
+            for reg in FrameworkRegistryProvider().get_registry_config().connectors
+            if reg.connector_type == "archiver"
+        }
+        assert set(_BUILTIN_ARCHIVERS) == registry_archivers

--- a/tests/connectors/test_honesty_rule.py
+++ b/tests/connectors/test_honesty_rule.py
@@ -1,0 +1,191 @@
+"""The question all three refusal sites ask — asked the way each site's reader reads.
+
+There are two kinds of config, read by different readers, and the guard has to
+resolve a key exactly as the reader it guards resolves it. A build profile's
+``config:`` block reaches the rendered project through the emitter, which honors
+the dotted spelling and a nested mapping alike, so both are live there. A
+rendered ``config.yml`` is read by ``ConfigBuilder`` and ``MCPServerConfig``,
+which walk nested sections only — a top-level ``archiver.type:`` line in that
+file configures nothing.
+
+Getting that backwards is not a cosmetic difference: it is a running VA+mock
+stack. The bypass tests below are the regression, and each one states the live
+value the readers would have resolved.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from osprey.connectors.honesty import (
+    VA_MOCK_ARCHIVER_WHY,
+    pairing_in_profile,
+    pairing_in_rendered_config,
+)
+from osprey.connectors.types import MOCK_ARCHIVER
+
+VA = "virtual_accelerator"
+
+
+def _flat(control_system: str | None = None, archiver: Any = ...) -> dict[str, Any]:
+    """The dotted spelling — canonical in a build profile's ``config:`` block."""
+    config: dict[str, Any] = {}
+    if control_system is not None:
+        config["control_system.type"] = control_system
+    if archiver is not ...:
+        config["archiver.type"] = archiver
+    return config
+
+
+def _nested(control_system: str | None = None, archiver: Any = ...) -> dict[str, Any]:
+    """The nested spelling — the only live one in a rendered ``config.yml``."""
+    config: dict[str, Any] = {}
+    if control_system is not None:
+        config["control_system"] = {"type": control_system, "writes_enabled": False}
+    if archiver is not ...:
+        config["archiver"] = {"type": archiver}
+    return config
+
+
+# ---------------------------------------------------------------------------
+# A build profile's config: block — both spellings are live
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("spell", [_flat, _nested], ids=["flat", "nested"])
+def test_a_profile_pairing_a_va_with_the_mock_is_caught_in_either_spelling(spell: Any) -> None:
+    assert pairing_in_profile(spell(VA, MOCK_ARCHIVER)).is_invented_history
+
+
+@pytest.mark.parametrize("spell", [_flat, _nested], ids=["flat", "nested"])
+def test_a_profile_that_names_no_archiver_has_named_the_mock(spell: Any) -> None:
+    """The emitter writes no archiver.type, and the factory then falls back."""
+    verdict = pairing_in_profile(spell(VA))
+
+    assert verdict.is_invented_history
+    assert "unset" in verdict.archiver_phrase
+
+
+@pytest.mark.parametrize("spell", [_flat, _nested], ids=["flat", "nested"])
+def test_a_profile_with_a_store_is_honest_in_either_spelling(spell: Any) -> None:
+    assert not pairing_in_profile(spell(VA, "mongodb_archiver")).is_invented_history
+
+
+def test_a_profile_that_spells_the_archiver_twice_and_differently_fails_closed() -> None:
+    """Both spellings reach the same rendered leaf, so the profile has stated
+    the archive twice and is free to be wrong once. The build is not the thing
+    that should pick a winner — the same stance va_archiver_errors takes on a
+    duplicated connection key."""
+    verdict = pairing_in_profile(
+        {"control_system.type": VA, "archiver.type": "mongodb_archiver"}
+        | {"archiver": {"type": MOCK_ARCHIVER}}
+    )
+
+    assert verdict.is_invented_history
+    assert "twice" in verdict.archiver_phrase
+
+
+def test_a_blank_archiver_type_in_a_profile_is_the_mock() -> None:
+    """YAML's bare `archiver.type:` is None, and the factory falls back for it
+    exactly as for an absent key."""
+    assert pairing_in_profile(
+        {"control_system.type": VA, "archiver.type": None}
+    ).is_invented_history
+
+
+# ---------------------------------------------------------------------------
+# A rendered config.yml — nested sections only, and the bypasses that proves
+# ---------------------------------------------------------------------------
+
+
+def test_a_rendered_va_with_the_nested_mock_is_caught() -> None:
+    assert pairing_in_rendered_config(_nested(VA, MOCK_ARCHIVER)).is_invented_history
+
+
+def test_a_rendered_va_with_no_archiver_section_is_caught() -> None:
+    assert pairing_in_rendered_config(_nested(VA)).is_invented_history
+
+
+def test_a_rendered_va_with_a_nested_store_is_honest() -> None:
+    assert not pairing_in_rendered_config(_nested(VA, "mongodb_archiver")).is_invented_history
+
+
+def test_a_flat_archiver_line_cannot_excuse_a_nested_mock() -> None:
+    """BYPASS REGRESSION. ConfigBuilder and MCPServerConfig walk nested sections
+    only, so the flat line configures nothing while the nested mock is what the
+    factory builds. Reading the flat key as the archiver would wave through a
+    running VA+mock stack."""
+    config = _nested(VA, MOCK_ARCHIVER) | {"archiver.type": "mongodb_archiver"}
+
+    assert pairing_in_rendered_config(config).is_invented_history
+
+
+def test_a_flat_only_archiver_line_is_not_an_archiver() -> None:
+    """BYPASS REGRESSION. With no `archiver:` section the factory finds no type
+    and falls back to the mock, however real the top-level line looks."""
+    config = _nested(VA) | {"archiver.type": "mongodb_archiver"}
+    verdict = pairing_in_rendered_config(config)
+
+    assert verdict.is_invented_history
+    assert "configures nothing" in verdict.archiver_phrase
+    assert "mongodb_archiver" in verdict.archiver_phrase
+
+
+def test_a_flat_control_system_line_cannot_excuse_a_nested_virtual_accelerator() -> None:
+    """BYPASS REGRESSION, the same hole on the other key: the live control system
+    is the nested one, so a flat 'mock' line does not make this deployment a
+    simulation that claims nothing."""
+    config = _nested(VA, MOCK_ARCHIVER) | {"control_system.type": "mock"}
+
+    assert pairing_in_rendered_config(config).is_invented_history
+
+
+def test_a_flat_only_control_system_is_not_a_virtual_accelerator() -> None:
+    """The mirror of the rule, and not a bypass: with no `control_system:`
+    section the factory falls back to the mock, so this deployment is a mock
+    machine with a mock archive — the honest storeless pairing, whatever the
+    inert line says."""
+    assert not pairing_in_rendered_config(_flat(VA, MOCK_ARCHIVER)).is_invented_history
+
+
+# ---------------------------------------------------------------------------
+# Negative space, shared by both readings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("judge", [pairing_in_profile, pairing_in_rendered_config])
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param(_nested("mock", MOCK_ARCHIVER), id="mock-with-mock"),
+        pytest.param(_nested("epics", MOCK_ARCHIVER), id="epics-with-mock"),
+        pytest.param(_nested("epics", "epics_archiver"), id="hardware"),
+        pytest.param({}, id="says-nothing"),
+    ],
+)
+def test_every_other_pairing_is_left_alone(judge: Any, config: dict[str, Any]) -> None:
+    """The rule is about a simulation inventing its own past — not about which
+    store a facility runs, and not a general ban on the mock archiver."""
+    assert not judge(config).is_invented_history
+
+
+@pytest.mark.parametrize("judge", [pairing_in_profile, pairing_in_rendered_config])
+def test_a_config_that_is_not_a_mapping_reads_as_unset(judge: Any) -> None:
+    """A malformed config has its own error elsewhere; this is not the place to
+    compete for it."""
+    assert not judge(None).is_invented_history
+    assert not judge(["control_system.type: virtual_accelerator"]).is_invented_history
+
+
+def test_a_set_type_is_named_as_written() -> None:
+    assert pairing_in_profile({"archiver.type": MOCK_ARCHIVER}).archiver_phrase == repr(
+        MOCK_ARCHIVER
+    )
+
+
+def test_the_shared_explanation_says_what_is_wrong() -> None:
+    """All three sites quote this; it has to carry the reason on its own."""
+    assert "virtual accelerator" in VA_MOCK_ARCHIVER_WHY
+    assert "mock archiver" in VA_MOCK_ARCHIVER_WHY

--- a/tests/connectors/test_mock_archiver_simfile_fallback.py
+++ b/tests/connectors/test_mock_archiver_simfile_fallback.py
@@ -16,6 +16,19 @@ legitimate — but the divergence is logged at WARNING.
 
 Both directions are covered here, plus the template that no longer ships the
 third copy of the path.
+
+A note on the virtual-accelerator cases below, which would otherwise read as
+contradicting the honesty rule: pairing a ``virtual_accelerator`` control system
+with the mock archiver is now refused at build, at deploy and at MCP startup
+(see :mod:`osprey.connectors.honesty`), so no deployment can reach that
+configuration. These tests still exercise it, and legitimately — they construct
+the connector directly, below the level where any of those three refusals live,
+to pin the *resolution* rule: given a mock archiver and a VA-typed control
+system, the simulation file resolves through the VA's own config key rather than
+the mock's. That resolution has to stay correct because the type-aware lookup is
+shared with the ``sim`` CLI and with projects whose control system is a VA while
+some *other* archiver is selected. What is forbidden is deploying the pairing,
+not computing what it would resolve to.
 """
 
 from __future__ import annotations

--- a/tests/connectors/test_mock_connector.py
+++ b/tests/connectors/test_mock_connector.py
@@ -407,8 +407,14 @@ class TestMockArchiverProcessing:
 
 
 class TestMockArchiverProceduralKinds:
-    """Every PV-kind branch of the procedural generator shapes a plausible series:
-    finite, varying, with a mean near the kind's base value — no exact values."""
+    """Every PV-kind branch of the procedural generator reaches the frame.
+
+    The generator's own contract (absolute-time determinism, VA-anchored
+    baselines, per-kind shapes) is covered in
+    ``tests/simulation/test_procedural_generator.py``; what this pins is the
+    connector's half — that a channel the simulation engine does not serve is
+    routed through it and lands in the long frame as a plausible series.
+    """
 
     @pytest.mark.parametrize(
         ("pv_name", "base_value"),
@@ -420,16 +426,25 @@ class TestMockArchiverProceduralKinds:
             ("SOME:RANDOM:PV", 100.0),
         ],
     )
-    def test_each_kind_generates_a_plausible_series(self, pv_name, base_value):
+    @pytest.mark.asyncio
+    async def test_each_kind_generates_a_plausible_series(self, pv_name, base_value):
         connector = MockArchiverConnector()
-        connector._noise_level = 0.01
+        await connector.connect({"noise_level": 0.01})
 
-        values = connector._generate_time_series(pv_name, 200)
+        df = await connector.get_data(
+            pv_list=[pv_name],
+            start_date=datetime(2024, 1, 1, 0, 0, 0),
+            end_date=datetime(2024, 1, 1, 3, 20, 0),
+            precision_ms=60_000,
+        )
+        values = df.loc[df["channel"] == pv_name, "value"].to_numpy()
 
         assert len(values) == 200
         assert np.all(np.isfinite(values))
         assert values.std() > 0, "the series must vary, not sit at the base value"
         assert values.mean() == pytest.approx(base_value, rel=0.5)
+
+        await connector.disconnect()
 
 
 class TestMockArchiverReproducibility:

--- a/tests/connectors/test_mongodb_archiver_connector.py
+++ b/tests/connectors/test_mongodb_archiver_connector.py
@@ -8,7 +8,12 @@ import pandas as pd
 import pytest
 
 from osprey.connectors.archiver.base import ArchiverMetadata
-from osprey.connectors.archiver.mongodb_archiver_connector import MongoDBArchiverConnector
+from osprey.connectors.archiver.mongodb_archiver_connector import (
+    HOST_OVERRIDE_ENV,
+    PORT_OVERRIDE_ENV,
+    MongoDBArchiverConnector,
+    address_overrides,
+)
 from osprey.connectors.factory import ConnectorFactory
 
 # xdist_group("docker"): the session ``mongodb_container`` fixture starts a real
@@ -129,15 +134,24 @@ class TestConnectDisconnectLifecycle:
             await connector.connect(config)
 
     @pytest.mark.asyncio
-    async def test_connect_missing_password_env_var_raises_value_error(self, mongodb_config):
-        """Test that connect raises ValueError when password env var is not set."""
+    async def test_connect_unset_password_env_var_raises_connection_error(self, mongodb_config):
+        """An unset password variable is a deployment state, not a config error.
+
+        ``deploy up`` mints the password into the project's ``.env``, so this is
+        exactly what a built-but-never-deployed project hits on its first
+        archiver call. It must raise ConnectionError — that is what reaches the
+        agent as an actionable ``connection_error`` envelope naming the fix,
+        rather than as an opaque internal error.
+        """
         config = mongodb_config.copy()
         config["password_env"] = "NONEXISTENT_ENV_VAR"
 
         connector = MongoDBArchiverConnector()
 
-        with pytest.raises(ValueError, match="Environment variable.*not set"):
+        with pytest.raises(ConnectionError, match="NONEXISTENT_ENV_VAR.*is not set") as exc_info:
             await connector.connect(config)
+
+        assert "osprey deploy up" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_disconnect_clears_state(self, mongodb_config):
@@ -185,8 +199,10 @@ class TestImportErrorHandling:
             with pytest.raises(ImportError) as exc_info:
                 await connector.connect(mongodb_config)
 
+            # Naming the extra, not the bare package: that is how a user of
+            # this framework actually installs the dependency.
             assert "pymongo is required" in str(exc_info.value)
-            assert "pip install pymongo" in str(exc_info.value)
+            assert "osprey-framework[archiver-mongodb]" in str(exc_info.value)
 
 
 @pytest.mark.integration
@@ -382,7 +398,13 @@ class TestMetadataMethods:
 
     @pytest.mark.asyncio
     async def test_get_metadata_returns_archiver_metadata(self, mongodb_config, mongodb_test_data):
-        """Test that get_metadata returns ArchiverMetadata dataclass."""
+        """get_metadata reports the coverage the collection actually holds.
+
+        The fixture seeds hourly documents from ``start_date`` up to (not
+        including) ``end_date``, so the newest stored sample is one hour before
+        ``end_date``. Asserting that exact boundary is what proves the bounds
+        are read from the store rather than echoed from the request.
+        """
         connector = MongoDBArchiverConnector()
         await connector.connect(mongodb_config)
 
@@ -393,6 +415,8 @@ class TestMetadataMethods:
         assert metadata.pv_name == pv_name
         assert metadata.is_archived is True  # Should be True since we have test data
         assert pv_name in metadata.description
+        assert metadata.archival_start == mongodb_test_data["start_date"]
+        assert metadata.archival_end == mongodb_test_data["end_date"] - timedelta(hours=1)
 
         await connector.disconnect()
 
@@ -407,6 +431,9 @@ class TestMetadataMethods:
         assert isinstance(metadata, ArchiverMetadata)
         assert metadata.pv_name == "NONEXISTENT:PV"
         assert metadata.is_archived is False  # Should be False for nonexistent PV
+        # No stored samples means no coverage window — not an invented one.
+        assert metadata.archival_start is None
+        assert metadata.archival_end is None
 
         await connector.disconnect()
 
@@ -928,12 +955,273 @@ class TestErrorHandlingWithoutDocker:
     @pytest.mark.asyncio
     async def test_availability_query_errors_degrade_to_not_archived(self):
         """get_metadata()/check_availability() report not-archived instead of raising."""
-        connector = self._erroring_connector(count_documents=RuntimeError("cursor lost"))
+        connector = self._erroring_connector(
+            find_one=RuntimeError("cursor lost"),
+            count_documents=RuntimeError("cursor lost"),
+        )
 
         metadata = await connector.get_metadata("BEAM:CURRENT")
         assert isinstance(metadata, ArchiverMetadata)
         assert metadata.pv_name == "BEAM:CURRENT"
         assert metadata.is_archived is False
+        # An unreadable store reports no coverage rather than inventing one.
+        assert metadata.archival_start is None
+        assert metadata.archival_end is None
 
         availability = await connector.check_availability(["BEAM:CURRENT", "BEAM:LIFETIME"])
         assert availability == {"BEAM:CURRENT": False, "BEAM:LIFETIME": False}
+
+    @pytest.mark.asyncio
+    async def test_get_data_pymongo_connection_loss_maps_to_connection_error(self):
+        """A pymongo connection-class failure mid-query must surface as ConnectionError.
+
+        The MCP tool wrapper invalidates the cached connector on ConnectionError
+        and on nothing else, so mapping this to the generic ValueError would
+        leave a dead client cached and every later archiver call failing until
+        the server restarted.
+        """
+        pymongo_errors = pytest.importorskip("pymongo.errors")
+        # ServerSelectionTimeoutError -> AutoReconnect -> ConnectionFailure: the
+        # deepest subclass, so this proves the whole family is covered.
+        lost = pymongo_errors.ServerSelectionTimeoutError("no replica set members available")
+
+        connector = self._erroring_connector(find=lost)
+        connector._ConnectionFailure = pymongo_errors.ConnectionFailure
+
+        with pytest.raises(ConnectionError, match="Lost connection to MongoDB") as exc_info:
+            await connector.get_data(
+                pv_list=["BEAM:CURRENT"],
+                start_date=datetime(2024, 1, 1, tzinfo=UTC),
+                end_date=datetime(2024, 1, 2, tzinfo=UTC),
+            )
+
+        assert exc_info.value.__cause__ is lost
+
+    @pytest.mark.asyncio
+    async def test_get_data_maps_to_value_error_when_pymongo_types_unbound(self):
+        """A connector that never ran connect() still maps unknown failures sanely.
+
+        ``_connection_error_types()`` returns an empty tuple then, and an empty
+        tuple in an ``except`` clause must simply not match rather than blow up.
+        """
+        connector = self._erroring_connector(find=RuntimeError("cursor lost"))
+        assert connector._ConnectionFailure is None
+
+        with pytest.raises(ValueError, match="Error retrieving data from MongoDB"):
+            await connector.get_data(
+                pv_list=["BEAM:CURRENT"],
+                start_date=datetime(2024, 1, 1, tzinfo=UTC),
+                end_date=datetime(2024, 1, 2, tzinfo=UTC),
+            )
+
+    @pytest.mark.asyncio
+    async def test_lost_connection_reaches_the_tool_wrapper_as_an_invalidation(self):
+        """The mapping is only useful if it makes the MCP layer drop the connector.
+
+        This is the half a per-connector unit test cannot see: ``get_data``
+        raising ConnectionError and ``connector_error_handler`` invalidating on
+        ConnectionError are two separate pieces, and the recovery behaviour is
+        the claim that spans them. Wiring the real connector's failure into the
+        real handler is what pins it.
+        """
+        from unittest.mock import AsyncMock
+
+        from fastmcp.exceptions import ToolError
+
+        from osprey.mcp_server.control_system.error_handling import connector_error_handler
+
+        pymongo_errors = pytest.importorskip("pymongo.errors")
+        connector = self._erroring_connector(find=pymongo_errors.AutoReconnect("primary stepped"))
+        connector._ConnectionFailure = pymongo_errors.ConnectionFailure
+
+        registry = MagicMock()
+        registry.invalidate_connector = AsyncMock()
+
+        with patch(
+            "osprey.mcp_server.control_system.server_context.get_server_context",
+            return_value=registry,
+        ):
+            with pytest.raises(ToolError):
+                async with connector_error_handler("archiver_read", connector_name="archiver"):
+                    await connector.get_data(
+                        pv_list=["BEAM:CURRENT"],
+                        start_date=datetime(2024, 1, 1, tzinfo=UTC),
+                        end_date=datetime(2024, 1, 2, tzinfo=UTC),
+                    )
+
+        registry.invalidate_connector.assert_awaited_once_with("archiver")
+
+
+class TestHonestMetadataWithoutDocker:
+    """``get_metadata`` reports the coverage the store actually holds."""
+
+    @staticmethod
+    def _connector_with_extent(oldest, newest):
+        """A connected connector whose find_one returns the given boundary docs."""
+        connector = MongoDBArchiverConnector()
+        connector._connected = True
+        connector._collection = MagicMock()
+        calls = []
+
+        def _find_one(query, projection, sort):
+            calls.append(sort)
+            if oldest is None:
+                return None
+            return oldest if sort == [("date", 1)] else newest
+
+        connector._collection.find_one = _find_one
+        return connector, calls
+
+    @pytest.mark.asyncio
+    async def test_reports_the_oldest_and_newest_stored_sample(self):
+        """archival_start/end come from the store, not from a declared window."""
+        first = datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
+        last = datetime(2025, 7, 1, 12, 0, tzinfo=UTC)
+        connector, calls = self._connector_with_extent({"date": first}, {"date": last})
+
+        metadata = await connector.get_metadata("BEAM:CURRENT")
+
+        assert metadata.is_archived is True
+        assert metadata.archival_start == first
+        assert metadata.archival_end == last
+        # Ascending then descending: the two ends of the {date: 1} index.
+        assert calls == [[("date", 1)], [("date", -1)]]
+
+    @pytest.mark.asyncio
+    async def test_unstored_pv_reports_no_coverage(self):
+        """A PV with no documents is not archived and claims no coverage window.
+
+        The mock archiver's habit of reporting archival_start=2000 for anything
+        asked of it is precisely the fiction this replaces.
+        """
+        connector, calls = self._connector_with_extent(None, None)
+
+        metadata = await connector.get_metadata("NOT:STORED")
+
+        assert metadata.is_archived is False
+        assert metadata.archival_start is None
+        assert metadata.archival_end is None
+        # No second lookup once the first comes back empty.
+        assert calls == [[("date", 1)]]
+
+
+class TestInNetworkAddressOverride:
+    """The config block is the host-side truth; the environment is the
+    per-container translation, and it wins.
+
+    Both halves matter. A container handed the host-side address dials its own
+    loopback and reaches nothing; a host process handed a compose alias dials a
+    name that does not resolve. One config, two vantage points, and the
+    environment is what says which one this process is at.
+    """
+
+    @staticmethod
+    def _config(**overrides):
+        config = {
+            "host": "localhost",
+            "port": 27017,
+            "name": "testdb",
+            "collection": "testcoll",
+            "auth": "admin",
+            "username": "user",
+            "password_env": "MONGODB_MOCK_PASSWORD",
+        }
+        config.update(overrides)
+        return config
+
+    def test_no_environment_means_no_override(self, monkeypatch):
+        monkeypatch.delenv(HOST_OVERRIDE_ENV, raising=False)
+        monkeypatch.delenv(PORT_OVERRIDE_ENV, raising=False)
+
+        assert address_overrides() == (None, None)
+
+    def test_the_environment_is_read_as_host_and_typed_port(self, monkeypatch):
+        monkeypatch.setenv(HOST_OVERRIDE_ENV, "archiver-mongodb")
+        monkeypatch.setenv(PORT_OVERRIDE_ENV, "27017")
+
+        assert address_overrides() == ("archiver-mongodb", 27017)
+
+    def test_whitespace_is_unset_not_an_address_of_nothing(self, monkeypatch):
+        """A compose file that renders an empty value must not point the reader
+        at the empty string — it must leave the configured value alone."""
+        monkeypatch.setenv(HOST_OVERRIDE_ENV, "   ")
+        monkeypatch.setenv(PORT_OVERRIDE_ENV, "  ")
+
+        assert address_overrides() == (None, None)
+
+    def test_the_halves_are_independent(self, monkeypatch):
+        monkeypatch.setenv(HOST_OVERRIDE_ENV, "archiver-mongodb")
+        monkeypatch.delenv(PORT_OVERRIDE_ENV, raising=False)
+
+        assert address_overrides() == ("archiver-mongodb", None)
+
+    def test_a_port_that_is_not_a_port_is_refused_not_ignored(self, monkeypatch):
+        """Falling back to the host-side port would send a container to an
+        address nothing serves, for a reason nobody is looking at."""
+        monkeypatch.setenv(PORT_OVERRIDE_ENV, "27017a")
+
+        with pytest.raises(ValueError, match=PORT_OVERRIDE_ENV):
+            address_overrides()
+
+    @pytest.mark.asyncio
+    async def test_the_connector_dials_the_override_over_its_config(self, monkeypatch):
+        """The end this exists for: the worker's `archiver_read` reaches the
+        store by its network alias while config.yml still says localhost."""
+        monkeypatch.setenv("MONGODB_MOCK_PASSWORD", "secret")
+        monkeypatch.setenv(HOST_OVERRIDE_ENV, "archiver-mongodb")
+        monkeypatch.setenv(PORT_OVERRIDE_ENV, "27017")
+
+        connector = MongoDBArchiverConnector()
+        with patch("pymongo.MongoClient") as mock_client_cls:
+            await connector.connect(self._config(host="localhost", port=27117))
+
+        kwargs = mock_client_cls.call_args.kwargs
+        assert kwargs["host"] == "archiver-mongodb"
+        assert kwargs["port"] == 27017
+
+    @pytest.mark.asyncio
+    async def test_the_connector_keeps_its_config_when_no_override_is_set(self, monkeypatch):
+        """The host-side path, which is every agent running outside a container."""
+        monkeypatch.setenv("MONGODB_MOCK_PASSWORD", "secret")
+        monkeypatch.delenv(HOST_OVERRIDE_ENV, raising=False)
+        monkeypatch.delenv(PORT_OVERRIDE_ENV, raising=False)
+
+        connector = MongoDBArchiverConnector()
+        with patch("pymongo.MongoClient") as mock_client_cls:
+            await connector.connect(self._config(host="facility-mongo.example.org", port=27117))
+
+        kwargs = mock_client_cls.call_args.kwargs
+        assert kwargs["host"] == "facility-mongo.example.org"
+        assert kwargs["port"] == 27117
+
+    @pytest.mark.asyncio
+    async def test_an_environment_only_address_is_a_legitimate_one(self, monkeypatch):
+        """The required-ness check is about having an address, not about where
+        it came from."""
+        monkeypatch.setenv("MONGODB_MOCK_PASSWORD", "secret")
+        monkeypatch.setenv(HOST_OVERRIDE_ENV, "archiver-mongodb")
+        config = self._config()
+        del config["host"]
+
+        connector = MongoDBArchiverConnector()
+        with patch("pymongo.MongoClient") as mock_client_cls:
+            await connector.connect(config)
+
+        assert mock_client_cls.call_args.kwargs["host"] == "archiver-mongodb"
+
+    @pytest.mark.asyncio
+    async def test_no_address_from_either_source_is_still_refused(self, monkeypatch):
+        monkeypatch.setenv("MONGODB_MOCK_PASSWORD", "secret")
+        monkeypatch.delenv(HOST_OVERRIDE_ENV, raising=False)
+        config = self._config()
+        del config["host"]
+
+        with pytest.raises(ValueError, match="host is required"):
+            await MongoDBArchiverConnector().connect(config)
+
+    def test_the_recorder_reads_this_same_contract(self):
+        """Two consumers, one reader — so they cannot come to disagree about
+        what an empty value means or how the port is typed."""
+        from osprey.services.archiver_recorder import config as recorder_config
+
+        assert recorder_config.address_overrides is address_overrides

--- a/tests/deployment/goldens/exemplar-profile/profile.yml
+++ b/tests/deployment/goldens/exemplar-profile/profile.yml
@@ -117,6 +117,25 @@ virtual_accelerator:
   # connector that talks to it.
   port: 5064
 
+# ── Stored archive for the simulated machine ─────────────────────────────────
+# A facility that deploys the VA must also say where that machine's history
+# lives: pairing a simulated machine with the synthesizing mock archiver is
+# refused at build, at deploy, and at MCP startup. This block is the answer —
+# it renders a MongoDB store and an archiver-recorder beside the soft-IOC,
+# seeds the store on first deploy, and derives the connector's connection keys.
+# Selecting it as the deployment's archiver is a separate line, under `config:`.
+va_archiver:
+  host: localhost      # where the agent reaches the store this project deploys
+  retention_days: 30   # how far back the archive reaches
+  hot_span_hours: 48   # how much of it is kept at the dense cadence
+  # The channel `osprey health` reads to decide whether the archive is still
+  # being written, as opposed to merely reachable. The stored-beam current is
+  # this facility's canary: it is the first thing to stop moving when the
+  # machine does. Naming it here is what derives the `archiver_freshness`
+  # check — including its staleness threshold, which follows the recorder's
+  # cadence rather than being a second number to keep in step.
+  freshness_channel: SR:DIAG:DCCT:01:CURRENT:RB
+
 # ── Facility-owned compose services ──────────────────────────────────────────
 # One entry per directory under `services/`. `template:` is profile-relative
 # (or `osprey.<name>` for a packaged one); everything under `config:` is
@@ -138,6 +157,11 @@ config:
   # live machine would. Use "epics" once the connector points at real hardware,
   # or "mock" for a browse-only stack that touches nothing.
   control_system.type: virtual_accelerator
+  # Selects the archive the `va_archiver:` block above declares. A separate
+  # decision from declaring where the archive lives — the block never flips this
+  # key out from under a facility that set it — and a required one here: a
+  # virtual accelerator left on the mock archiver is refused.
+  archiver.type: mongodb_archiver
   # The system-health MCP server is off-by-default in the framework registry
   # (default_enabled=False); opt in so operators can run read-only stack checks.
   claude_code.servers.health.enabled: true
@@ -148,8 +172,13 @@ config:
   # Exactly the three services this facility runs. Set explicitly because the
   # packaged control_assistant skeleton also declares `postgresql` — declared
   # is not deployed, and this list is what `osprey deploy up` reads.
-  # `virtual_accelerator` and `facility-mcp` are appended by their injectors
-  # above; naming openobserve here is what keeps postgresql out.
+  #
+  # Only `openobserve` is named here. Four more are appended by the injectors
+  # their blocks above trigger — `facility-mcp` and `virtual_accelerator`, plus
+  # `mongodb` and `archiver_recorder` from the `va_archiver:` block — so this
+  # facility deploys five services in total. Naming openobserve here is what
+  # keeps postgresql out: it is declared by the packaged skeleton but nothing
+  # this facility runs needs it.
   deployed_services:
     - openobserve
   # Container-name prefix for the web stack: names are `<prefix>-nginx` /

--- a/tests/deployment/test_bluesky_token_mint.py
+++ b/tests/deployment/test_bluesky_token_mint.py
@@ -243,12 +243,13 @@ def test_ensure_service_tokens_writes_an_alphanumeric_tiled_key_every_time(
 def test_var_generators_registry_is_pinned():
     """Pin the blast radius: only vars with a downstream alphabet/policy
     constraint override the default token recipe (Tiled's alphanumeric
-    --api-key, OpenObserve's four-class root password, the ARIEL Postgres
-    password's URI-safe alphabet)."""
+    --api-key, OpenObserve's four-class root password, and the URI-safe
+    alphabet the ARIEL Postgres and archiver Mongo passwords share)."""
     assert set(container_lifecycle._VAR_GENERATORS) == {
         "BLUESKY_TILED_API_KEY",
         "ZO_ROOT_USER_PASSWORD",
         "ARIEL_DB_PASSWORD",
+        "MONGO_ROOT_PASSWORD",
     }
     declared = {
         var for token_vars in container_lifecycle._SERVICE_TOKEN_VARS.values() for var in token_vars
@@ -472,6 +473,7 @@ def test_validator_registry_keyset_is_pinned():
         "ARIEL_DSN",
         "ZO_ROOT_USER_PASSWORD",
         "ARIEL_DB_PASSWORD",
+        "MONGO_ROOT_PASSWORD",
     }
 
     declared = {

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -60,6 +60,8 @@ VA_TEST_FILE = "tests/e2e/test_va_substrate_equivalence.py"
 LIFECYCLE_TEST_FILE = "tests/e2e/test_deploy_lifecycle.py"
 ORM_JOB = "orm-roundtrip-e2e"
 ORM_TEST_FILE = "tests/e2e/test_orm_roundtrip.py"
+ARCHIVER_JOB = "archiver-world-e2e"
+ARCHIVER_TEST_FILE = "tests/e2e/test_archiver_world_e2e.py"
 OVERLAY_JOB = "dispatch-overlay-e2e"
 OVERLAY_TEST_FILE = "tests/e2e/test_dispatch_overlay_visibility.py"
 CATALOG_JOB = "bluesky-catalog-e2e"
@@ -827,6 +829,110 @@ def test_orm_roundtrip_job_has_no_llm_secret__mutation_adds_secret() -> None:
     )
     with pytest.raises(AssertionError):
         assert not _job_declares_secret(mutated, ORM_JOB, SECRET_TOKEN)
+
+
+# ---------------------------------------------------------------------------
+# (g) the archiver-world lane: its own job, secret-free, and gated on both halves
+# ---------------------------------------------------------------------------
+
+
+def test_archiver_world_job_exists(workflow: dict[str, Any]) -> None:
+    assert ARCHIVER_JOB in _jobs(workflow)
+
+
+def test_archiver_world_job_exists__mutation_drops_job() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    del mutated["jobs"][ARCHIVER_JOB]
+    with pytest.raises(AssertionError):
+        assert ARCHIVER_JOB in _jobs(mutated)
+
+
+def test_archiver_world_job_has_no_llm_secret(workflow: dict[str, Any]) -> None:
+    """Every assertion in that file is mechanical — seed duration, store size, a
+    setpoint round-trip, a noise-band step, document counts — and the archiver
+    read goes through the connector rather than an agent turn. A secret
+    appearing in this job would mean the lane's scope silently grew."""
+    assert not _job_declares_secret(workflow, ARCHIVER_JOB, SECRET_TOKEN)
+
+
+def test_archiver_world_job_has_no_llm_secret__mutation_adds_secret() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    mutated["jobs"][ARCHIVER_JOB]["steps"].append(
+        {"name": "inject", "env": {"ALS_APG_API_KEY": "${{ secrets.ALS_APG_API_KEY }}"}}
+    )
+    with pytest.raises(AssertionError):
+        assert not _job_declares_secret(mutated, ARCHIVER_JOB, SECRET_TOKEN)
+
+
+def test_archiver_world_job_installs_the_pymongo_extra(workflow: dict[str, Any]) -> None:
+    """The staged bring-up preflights pymongo before any image build, so without
+    the extra this lane aborts in seconds with an install hint instead of running
+    — a green-looking job that tested nothing."""
+    installed = json.dumps(_jobs(workflow)[ARCHIVER_JOB])
+    assert "archiver-mongodb" in installed, (
+        f"the '{ARCHIVER_JOB}' lane must `uv sync` the archiver-mongodb extra"
+    )
+
+
+def test_archiver_world_job_installs_the_pymongo_extra__mutation_drops_extra() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    mutated["jobs"][ARCHIVER_JOB] = json.loads(
+        json.dumps(mutated["jobs"][ARCHIVER_JOB]).replace(" --extra archiver-mongodb", "")
+    )
+    with pytest.raises(AssertionError):
+        test_archiver_world_job_installs_the_pymongo_extra(mutated)
+
+
+def test_archiver_world_job_runs_pytest_unbuffered(workflow: dict[str, Any]) -> None:
+    """``-s`` is what puts this lane's measured budgets in the log on a GREEN run.
+
+    Pytest captures stdout and replays it only for failures, so without this the
+    seed duration, store size and write->read latency appear exactly when nobody
+    can act on them any more. The budgets are the lane's product — a run that
+    hides them still passes, and the trend that precedes a breach is invisible.
+    """
+    steps = json.dumps(_jobs(workflow)[ARCHIVER_JOB]["steps"])
+    assert ARCHIVER_TEST_FILE in steps
+    assert " -s " in steps or steps.rstrip().endswith(" -s"), (
+        f"the '{ARCHIVER_JOB}' lane must run pytest with -s so the MEASURED "
+        "budget lines reach the log on a passing run"
+    )
+
+
+def test_archiver_world_job_runs_pytest_unbuffered__mutation_drops_the_flag() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    mutated["jobs"][ARCHIVER_JOB] = json.loads(
+        json.dumps(mutated["jobs"][ARCHIVER_JOB]).replace(" -v -s ", " -v ")
+    )
+    with pytest.raises(AssertionError):
+        test_archiver_world_job_runs_pytest_unbuffered(mutated)
+
+
+def test_all_checks_passed_needs_archiver_world(workflow: dict[str, Any]) -> None:
+    """Both halves of the gate, for the reason spelled out on the gchat pair:
+    ``needs:`` makes the roll-up wait, ``check_pr_lane`` makes it care."""
+    assert ARCHIVER_JOB in _jobs(workflow)[GATE_JOB]["needs"]
+    assert f"needs.{ARCHIVER_JOB}.result" in _gate_run_text(workflow)
+
+
+def test_all_checks_passed_needs_archiver_world__mutation_drops_needs_entry() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    _jobs(mutated)[GATE_JOB]["needs"].remove(ARCHIVER_JOB)
+    with pytest.raises(AssertionError):
+        test_all_checks_passed_needs_archiver_world(mutated)
+
+
+def test_all_checks_passed_needs_archiver_world__mutation_drops_check_pr_lane_line() -> None:
+    """The dangerous half: the job is still waited on, but nothing reads its
+    result — the lane could go red forever inside a green check."""
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, GATE_JOB, "Check all jobs status")
+    kept = [line for line in step["run"].splitlines(keepends=True) if ARCHIVER_JOB not in line]
+    assert len(kept) == len(step["run"].splitlines()) - 1, "expected exactly one line dropped"
+    step["run"] = "".join(kept)
+    assert ARCHIVER_JOB in _jobs(mutated)[GATE_JOB]["needs"]  # the needs entry survives
+    with pytest.raises(AssertionError):
+        test_all_checks_passed_needs_archiver_world(mutated)
 
 
 def test_dispatch_overlay_job_exists(workflow: dict[str, Any]) -> None:

--- a/tests/deployment/test_compose_generator.py
+++ b/tests/deployment/test_compose_generator.py
@@ -11,10 +11,12 @@ deployed_services. Two failure modes have to stay fixed:
 
 from __future__ import annotations
 
+import os
 import re
 import sys
 from pathlib import Path
 from typing import Any
+from unittest import mock
 
 import pytest
 import yaml
@@ -123,7 +125,12 @@ _WORKER_PROJECT_NAME = "hwt-fixture"
 _ENV_FILE_LINE = "- ../../.env"
 
 
-def _render_worker_template(*, env_present: bool, project_name: str = _WORKER_PROJECT_NAME) -> str:
+def _render_worker_template(
+    *,
+    env_present: bool,
+    project_name: str = _WORKER_PROJECT_NAME,
+    deployed_services: list[str] | None = None,
+) -> str:
     """Render the worker compose through the real generator injection.
 
     Feeds a minimal config through ``_inject_project_metadata`` (the production
@@ -145,6 +152,7 @@ def _render_worker_template(*, env_present: bool, project_name: str = _WORKER_PR
             "project_root": f"/r/{project_name}",
             "services": {"dispatch_worker": {}},
             "system": {"timezone": "UTC"},
+            "deployed_services": list(deployed_services or []),
         }
     )
     # ``_inject_project_metadata`` sets osprey_env_present from the deploy CWD;
@@ -1415,6 +1423,335 @@ def test_postgres_password_reads_minted_env_var() -> None:
 
 
 # ---------------------------------------------------------------------------
+# mongodb: the archiver store
+#
+# Same shape as postgres — a pulled upstream image holding a persistent store —
+# and the same three host-global hazards: a bare container_name collides across
+# projects, in-network consumers (the recorder, the dispatch worker's archiver
+# host override) need a name that survives that namespacing, and the credential
+# has exactly one home (the minted MONGO_ROOT_PASSWORD in the project .env).
+# The one thing postgres has no analogue for is the compression knob: block
+# compression is set on the SERVER because the seeder creates the collection
+# implicitly, so the knob has to reach mongod's own argv.
+# ---------------------------------------------------------------------------
+def _render_mongodb_template(project_name: str = "proj-a", **mongodb_config: object) -> str:
+    from importlib import resources
+
+    from jinja2 import Template
+
+    tpl = resources.files("osprey").joinpath("templates/services/mongodb/docker-compose.yml.j2")
+    template = Template(tpl.read_text(encoding="utf-8"))
+    return template.render(
+        services={"mongodb": mongodb_config},
+        deployment={},
+        system={"timezone": "UTC"},
+        osprey_labels={
+            "project_name": project_name,
+            "project_root": f"/r/{project_name}",
+            "deployed_at": "now",
+        },
+        osprey_version="",
+    )
+
+
+def _mongodb_service(project_name: str = "proj-a", **mongodb_config: object) -> dict:
+    return yaml.safe_load(_render_mongodb_template(project_name, **mongodb_config))["services"][
+        "mongodb"
+    ]
+
+
+def test_mongodb_container_name_is_project_namespaced() -> None:
+    """Two projects render distinct, project-scoped mongo container names.
+
+    `container_name` is host-global, so a bare `archiver-mongodb` would make two
+    OSPREY projects deploying the archiver on one host collide and serialize.
+    """
+    name_a = _mongodb_service("proj-a")["container_name"]
+    name_b = _mongodb_service("proj-b")["container_name"]
+
+    assert name_a == "proj-a-archiver-mongodb", name_a
+    assert name_b == "proj-b-archiver-mongodb", name_b
+
+
+def test_mongodb_publishes_a_stable_in_network_alias() -> None:
+    """`archiver-mongodb` stays resolvable in-network after the namespacing.
+
+    The recorder writes to this host from inside the compose network (the
+    host-published port is not reachable there), and the dispatch worker points
+    the agent's archiver at the same name. Both break with "could not resolve
+    host" if the alias goes away.
+    """
+    svc = _mongodb_service()
+    aliases = svc["networks"]["osprey-network"]["aliases"]
+    assert "archiver-mongodb" in aliases, aliases
+
+
+def test_mongodb_image_follows_env_config_default_chain() -> None:
+    """env → config → pinned default, like every other pulled service image.
+
+    A hard pin would force air-gapped/mirrored registries to fork the template.
+    """
+    assert _mongodb_service()["image"] == "${OSPREY_MONGODB_IMAGE:-mongo:7}"
+    assert (
+        _mongodb_service(image="registry.local/mongo:custom")["image"]
+        == "${OSPREY_MONGODB_IMAGE:-registry.local/mongo:custom}"
+    )
+
+
+def test_mongodb_root_password_reads_minted_env_var() -> None:
+    """The root password sources MONGO_ROOT_PASSWORD from .env (minted by
+    `deploy up`), the same single-source convention as postgres's
+    ARIEL_DB_PASSWORD — one value for the container, the seeder, the recorder
+    and the agent connector's `password_env`."""
+    env = _mongodb_service()["environment"]
+    assert env["MONGO_INITDB_ROOT_PASSWORD"] == "${MONGO_ROOT_PASSWORD:-osprey}"
+    assert env["MONGO_INITDB_ROOT_USERNAME"] == "osprey"
+
+
+def test_mongodb_block_compression_is_a_knob_on_mongod_argv() -> None:
+    """Compression reaches mongod's own arguments, defaulting to zstd.
+
+    Setting it server-side is what makes the seeder's implicitly created
+    collection inherit it; a per-collection option would leave a window in
+    which documents land under the default codec.
+    """
+    assert _mongodb_service()["command"] == ["--wiredTigerCollectionBlockCompressor", "zstd"]
+    assert _mongodb_service(compression="snappy")["command"] == [
+        "--wiredTigerCollectionBlockCompressor",
+        "snappy",
+    ]
+
+
+def test_mongodb_port_publish_follows_bind_address_and_port_host() -> None:
+    """The host publish honors `services.mongodb.port_host` and the deploy-wide
+    bind address, defaulting to loopback:27017 — the address the host-side
+    seeder and the agent connector both use."""
+    assert _mongodb_service()["ports"] == ["127.0.0.1:27017:27017"]
+    assert _mongodb_service(port_host=27117)["ports"] == ["127.0.0.1:27117:27017"]
+
+
+def test_mongodb_healthcheck_pings_without_credentials() -> None:
+    """The probe is an unauthenticated `ping`, so the minted password has
+    exactly one spelling in this file. `deploy up` gates the base seed on this
+    healthcheck, so it has to answer on a fresh volume too."""
+    healthcheck = _mongodb_service()["healthcheck"]
+    assert healthcheck["test"] == [
+        "CMD-SHELL",
+        "mongosh --quiet --eval 'db.adminCommand(\"ping\")'",
+    ]
+    assert healthcheck["start_period"] == "15s", (
+        "a fresh volume creates the admin user and preallocates the journal "
+        "before mongod answers; without a grace period those attempts burn the "
+        "retry budget"
+    )
+
+
+def test_mongodb_store_is_a_named_volume() -> None:
+    """Seeded + recorded history persists across `deploy down`: a base seed
+    costs minutes, and a store that resets on restart would be younger than the
+    machine it claims to describe."""
+    rendered = yaml.safe_load(_render_mongodb_template())
+    assert rendered["services"]["mongodb"]["volumes"] == ["archiver_mongodb_data:/data/db"]
+    assert "archiver_mongodb_data" in rendered["volumes"], (
+        "the store volume must be declared (named), never an anonymous mount"
+    )
+
+
+# ---------------------------------------------------------------------------
+# archiver_recorder: the live-sampling half of the archiver
+#
+# A compose-template-only service — it runs the VIRTUAL ACCELERATOR's image
+# with a different command, so it adds no image build to any deploy or CI lane.
+# Three properties carry the design and each has a way of failing quietly:
+#
+# * it must not start before the store answers (a fresh mongo volume makes that
+#   window seconds long),
+# * everything cross-service is gated on ``deployed_services`` membership —
+#   compose errors outright on a ``depends_on`` naming an undefined service,
+#   and the CA/image settings the co-deployed branch derives have to be
+#   supplied by the operator otherwise, or the recorder comes up routed
+#   nowhere and times out looking like a slow machine, and
+# * its Mongo address must be the in-network one: config.yml carries the HOST
+#   view (localhost + the published port_host), which inside the network is
+#   this container's own loopback.
+# ---------------------------------------------------------------------------
+_RECORDER_TEMPLATE = "archiver_recorder/docker-compose.yml.j2"
+
+
+def _render_recorder_template(*, va_co_deployed: bool, project_name: str = "proj-a") -> str:
+    deployed = ["mongodb", "archiver_recorder"]
+    if va_co_deployed:
+        deployed.append("virtual_accelerator")
+    return _render_service_template(_RECORDER_TEMPLATE, project_name, deployed_services=deployed)
+
+
+def _recorder_service(*, va_co_deployed: bool, project_name: str = "proj-a") -> dict:
+    rendered = _render_recorder_template(va_co_deployed=va_co_deployed, project_name=project_name)
+    return yaml.safe_load(rendered)["services"]["archiver-recorder"]
+
+
+@pytest.mark.parametrize("va_co_deployed", [True, False])
+def test_recorder_declares_no_build_context(va_co_deployed: bool) -> None:
+    """The recorder never builds an image.
+
+    It runs the VA's image with a different command, which is what keeps it out
+    of the seven VA-stack CI lanes' build cost — and what stops two services
+    racing to tag one image, the same rule the bluesky queueserver follows.
+    """
+    assert "build" not in _recorder_service(va_co_deployed=va_co_deployed)
+
+
+def test_recorder_reuses_the_va_image_when_co_deployed() -> None:
+    """Co-deployed: the recorder renders byte-identically to the VA's own image
+    reference, so the two can never run different Channel Access stacks."""
+    recorder = _recorder_service(va_co_deployed=True)["image"]
+    va = yaml.safe_load(
+        _render_service_template("virtual_accelerator/docker-compose.yml.j2", "proj-a")
+    )["services"]["virtual-accelerator"]["image"]
+    assert recorder == va == "${OSPREY_VA_IMAGE:-proj-a-va:local}"
+
+
+def test_recorder_requires_an_explicit_image_without_a_co_deployed_va() -> None:
+    """Without the VA, nothing in the deploy builds that tag.
+
+    Compose would fail pulling ``<project>-va:local`` with "pull access denied"
+    and never name the real problem, so the reference is required (``:?``)
+    instead of defaulted.
+    """
+    image = _recorder_service(va_co_deployed=False)["image"]
+    assert image.startswith("${OSPREY_VA_IMAGE:?"), image
+
+
+def test_recorder_command_runs_the_recorder_module() -> None:
+    """The command replaces the VA image's CMD outright (no ENTRYPOINT), so the
+    same image serves the IOC in one container and the recorder in another."""
+    assert _recorder_service(va_co_deployed=True)["command"] == [
+        "python",
+        "-u",
+        "-m",
+        "osprey.services.archiver_recorder",
+    ]
+
+
+@pytest.mark.parametrize("va_co_deployed", [True, False])
+def test_recorder_always_waits_for_a_healthy_store(va_co_deployed: bool) -> None:
+    """The store dependency is unconditional and health-gated.
+
+    "Container started" is not "answering commands": on a fresh volume mongod
+    creates the admin user and preallocates its journal first, and a recorder
+    writing into that window fails its first inserts.
+    """
+    depends = _recorder_service(va_co_deployed=va_co_deployed)["depends_on"]
+    assert depends["mongodb"] == {"condition": "service_healthy"}
+
+
+def test_recorder_wires_va_ordering_and_ca_env_only_when_va_co_deployed() -> None:
+    """Co-deployed: wait on the IOC's health and derive its CA address.
+
+    The address is derived from ``services.virtual_accelerator.port`` (not
+    hardcoded) so an operator moving the VA's port moves both services at once,
+    and ``depends_on`` must be absent when the VA is external — compose errors
+    on a dependency naming an undefined service.
+    """
+    svc = _recorder_service(va_co_deployed=True)
+    assert svc["depends_on"]["virtual-accelerator"] == {"condition": "service_healthy"}
+    assert svc["environment"]["EPICS_CA_NAME_SERVERS"] == "virtual-accelerator:5064"
+    assert svc["environment"]["EPICS_CA_AUTO_ADDR_LIST"] == "NO"
+
+    external = _recorder_service(va_co_deployed=False)
+    assert "virtual-accelerator" not in external["depends_on"]
+
+
+def test_recorder_requires_a_ca_address_when_the_va_is_external() -> None:
+    """An unset bare ``${VAR}`` resolves to "", which would leave the recorder
+    routed nowhere: every read times out, for minutes, looking exactly like a
+    slow machine. ``:?`` makes it a startup abort naming the variable."""
+    env = _recorder_service(va_co_deployed=False)["environment"]
+    assert env["EPICS_CA_NAME_SERVERS"].startswith("${EPICS_CA_NAME_SERVERS:?"), env[
+        "EPICS_CA_NAME_SERVERS"
+    ]
+    assert env["EPICS_CA_AUTO_ADDR_LIST"] == "${EPICS_CA_AUTO_ADDR_LIST:-NO}"
+
+
+def test_recorder_addresses_the_store_in_network_not_on_the_host() -> None:
+    """The archiver host/port overrides point at the store's network alias and
+    its CONTAINER port.
+
+    config.yml carries the HOST view (localhost + the published ``port_host``);
+    used verbatim in-network that is this container's own loopback. The alias
+    (not the compose service key, and never the container_name) is what stays
+    resolvable after the per-project container_name namespacing.
+    """
+    env = _recorder_service(va_co_deployed=True)["environment"]
+    assert env["OSPREY_ARCHIVER_MONGODB_HOST"] == "archiver-mongodb"
+    assert env["OSPREY_ARCHIVER_MONGODB_PORT"] == "27017"
+
+
+def test_recorder_and_store_agree_on_the_mongo_password_fallback() -> None:
+    """Both halves must read the same variable AND fall back to the same value.
+
+    They are two spellings of one credential: if the store defaults the root
+    password and the recorder defaults something else, a deploy that never
+    minted the secret comes up with a store the recorder cannot authenticate
+    against — and the only symptom is an archive that stops growing.
+    """
+    recorder = _recorder_service(va_co_deployed=True)["environment"]["MONGO_ROOT_PASSWORD"]
+    store = _mongodb_service()["environment"]["MONGO_INITDB_ROOT_PASSWORD"]
+    assert recorder == store == "${MONGO_ROOT_PASSWORD:-osprey}"
+
+
+def test_recorder_reads_the_channel_manifest_the_va_serves() -> None:
+    """The channel list is the same build-derived variable the VA reads,
+    resolved against the same mount path.
+
+    It must be the manifest. ``channel_limits.json`` is a *write-safety
+    projection* of that manifest, not a second copy of it: it carries one entry
+    per address (read-only ones included — the DCCT current sits there as
+    ``{"writable": false}``), plus top-level metadata keys ``_comment``,
+    ``_version``, ``_description`` and ``defaults``. So its key set is not a
+    channel list, and reading it as one would hand the recorder four names no
+    IOC serves. The manifest is the single channel source the IOC and the
+    recorder have to share; anything else is a second source free to drift.
+    """
+    svc = _recorder_service(va_co_deployed=True)
+    assert svc["environment"]["VA_CHANNELS_FILE"] == "${VA_CHANNELS_FILE:-}"
+    assert "../../data/simulation:/data/simulation:ro" in svc["volumes"]
+    assert not any("channel_limits" in mount for mount in svc["volumes"]), svc["volumes"]
+
+
+def test_recorder_reads_config_yml_from_a_read_only_mount() -> None:
+    """CONFIG_FILE points at a mounted file, not baked env: the enablement poll
+    re-reads it, which is what lets the documented ``control_system.type`` flip
+    take effect without a restart. CWD is the image WORKDIR, so without
+    CONFIG_FILE every lookup errors "No config.yml found".
+
+    The mount is the PROJECT DIRECTORY, deliberately unlike the bluesky
+    bridge's staged copy: a copy is rewritten only by ``deploy up``, so the poll
+    would re-read a build artifact and the flip would silently need a redeploy.
+    It is a directory rather than the single file because a single-file bind
+    pins an inode at container start, and editors that save by rename leave a
+    new one behind — see the template's mount comment.
+    """
+    svc = _recorder_service(va_co_deployed=True)
+    assert svc["environment"]["CONFIG_FILE"] == "/app/project/config.yml"
+    assert "../..:/app/project:ro" in svc["volumes"]
+    assert not any("archiver_recorder/config.yml" in mount for mount in svc["volumes"]), svc[
+        "volumes"
+    ]
+
+
+def test_recorder_publishes_no_ports_declares_no_healthcheck_and_reads_no_bulk_env() -> None:
+    """It opens no listening socket (nothing to publish, nothing to probe) and
+    calls no LLM (so no bulk ``.env`` passthrough — everything it reads is
+    interpolated explicitly). "Is history still arriving?" is answered by the
+    ``archiver_freshness`` probe against the store, not by a container probe."""
+    svc = _recorder_service(va_co_deployed=True)
+    assert "ports" not in svc
+    assert "healthcheck" not in svc
+    assert "env_file" not in svc
+
+
+# ---------------------------------------------------------------------------
 # sibling system-1 services: per-project container_name (concurrent-deploy safety)
 #
 # Every deployed system-1 service shares postgres's problem: `container_name` is
@@ -1475,6 +1812,9 @@ _SIBLING_SERVICES = [
     ("event_dispatcher/docker-compose.yml.j2", "event-dispatcher", "event-dispatcher", {}),
     ("dispatch_worker/docker-compose.yml.j2", "dispatch-worker-1", "dispatch-worker-1", {}),
     ("bluesky/docker-compose.yml.j2", "bluesky-bridge", "bluesky-bridge", {}),
+    # Reached by nobody in-network (outbound CA reads and Mongo writes only),
+    # so it needs no alias either.
+    ("archiver_recorder/docker-compose.yml.j2", "archiver-recorder", "archiver-recorder", {}),
     (
         "bluesky/docker-compose.yml.j2",
         "tiled",
@@ -3892,3 +4232,61 @@ def test_gchat_bridge_image_installs_the_gchat_extra_on_both_install_lines() -> 
     # a layer depending on order, so neither spelling may survive.
     assert '"osprey-framework==$OSPREY_VERSION"' not in dockerfile
     assert '"osprey-framework"' not in dockerfile
+
+
+# ---------------------------------------------------------------------------
+# The worker reaches the archive it can actually reach
+# ---------------------------------------------------------------------------
+
+_ARCHIVER_HOST_ENV = "OSPREY_ARCHIVER_MONGODB_HOST"
+_ARCHIVER_PORT_ENV = "OSPREY_ARCHIVER_MONGODB_PORT"
+
+
+def test_worker_is_pointed_at_the_store_this_project_deploys() -> None:
+    """The worker's agent reads history like any other, but config.yml's
+    connection block is written for the HOST side. Inside the network that names
+    this container's own loopback, so the deploy hands it the store's alias.
+
+    The alias, never the container name: `container_name` carries the project
+    prefix, and the alias is pinned in the mongodb template precisely so this
+    reference survives being deployed under any project name.
+    """
+    rendered = _render_worker_template(
+        env_present=True, deployed_services=["dispatch_worker", "mongodb"]
+    )
+
+    assert f"{_ARCHIVER_HOST_ENV}: archiver-mongodb" in rendered
+    assert f'{_ARCHIVER_PORT_ENV}: "27017"' in rendered
+    assert f"{_ARCHIVER_HOST_ENV}: {_WORKER_PROJECT_NAME}-archiver-mongodb" not in rendered
+
+
+def test_worker_is_not_pointed_at_a_store_this_project_does_not_deploy() -> None:
+    """These two are a LITERAL address, not a fallback — so a project reading a
+    facility's own MongoDB must not get them. Its configured block is already
+    correct from anywhere, and `archiver-mongodb` would resolve to nothing.
+    """
+    rendered = _render_worker_template(env_present=True, deployed_services=["dispatch_worker"])
+
+    assert _ARCHIVER_HOST_ENV not in rendered
+    assert _ARCHIVER_PORT_ENV not in rendered
+
+
+def test_the_worker_address_is_the_one_the_connector_would_dial() -> None:
+    """The integration-level half, asserted at the address-computation level so
+    it needs no Mongo and no Docker: feed the connector's own override reader
+    exactly what this compose file exports, and it yields the alias and the
+    container port — which is what `archiver_read` inside the worker connects
+    to. The Docker-level proof of the same claim rides the archiver-world e2e.
+    """
+    from osprey.connectors.archiver.mongodb_archiver_connector import address_overrides
+
+    rendered = _render_worker_template(
+        env_present=True, deployed_services=["dispatch_worker", "mongodb"]
+    )
+    exported = dict(
+        re.findall(r"^\s+(OSPREY_ARCHIVER_MONGODB_\w+):\s*\"?([^\"\n]+)\"?$", rendered, re.M)
+    )
+    assert set(exported) == {_ARCHIVER_HOST_ENV, _ARCHIVER_PORT_ENV}, exported
+
+    with mock.patch.dict(os.environ, exported, clear=False):
+        assert address_overrides() == ("archiver-mongodb", 27017)

--- a/tests/deployment/test_container_lifecycle.py
+++ b/tests/deployment/test_container_lifecycle.py
@@ -8,7 +8,11 @@ without a container runtime.
 
 from __future__ import annotations
 
+import json
+import logging
 import subprocess
+import time
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -1911,3 +1915,660 @@ class TestResolvePipSpec:
 
         with pytest.raises(UnreleasedVersionPinError):
             container_lifecycle._resolve_pip_spec(dev_mode=False)
+
+
+# ---------------------------------------------------------------------------
+# Staged archiver bring-up
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdmin:
+    """``client.admin``, answering ``ping`` only after ``fail_times`` refusals."""
+
+    def __init__(self, fail_times: int = 0):
+        self.fail_times = fail_times
+        self.pings = 0
+
+    def command(self, name):
+        self.pings += 1
+        if self.fail_times > 0:
+            self.fail_times -= 1
+            from pymongo.errors import ServerSelectionTimeoutError
+
+            raise ServerSelectionTimeoutError("store not up yet")
+        return {"ok": 1}
+
+
+class _FakeCollection:
+    """Just enough of a pymongo collection for the staged bring-up's own calls."""
+
+    def __init__(self, fail_pings: int = 0):
+        self.admin = _FakeAdmin(fail_pings)
+        self.dropped = False
+        # collection.database.client.admin is the path the health poll walks.
+        self.database = type("_Db", (), {"client": type("_Client", (), {"admin": self.admin})()})()
+
+    def drop(self):
+        self.dropped = True
+
+
+ARCHIVER_CONFIG = {
+    "deployed_services": ["mongodb", "archiver_recorder", "virtual_accelerator"],
+    "services": {"mongodb": {"compression": "zstd", "port_host": 27017}},
+    "va_archiver": {
+        "retention_days": 1,
+        "hot_span_hours": 1,
+        "hot_cadence_sec": 10,
+        "tail_cadence_sec": 60,
+    },
+    "archiver": {
+        "mongodb_archiver": {
+            "host": "localhost",
+            "port": 27017,
+            "name": "osprey_archiver",
+            "collection": "pv_history",
+            "auth": "admin",
+            "username": "osprey",
+            "password_env": "MONGO_ROOT_PASSWORD",
+            "timeout": 5,
+        }
+    },
+}
+
+
+@pytest.fixture
+def staged_archiver(monkeypatch, tmp_path):
+    """Drive ``deploy_up`` for an archiver project with every store call faked.
+
+    Records the compose argv in order (so the *sequence* of staged store, quiesce
+    and full bring-up is assertable) plus what the seeder was asked to do.
+    """
+    from osprey.simulation import apply as apply_mod
+    from osprey.simulation import archiver_seed
+
+    state: dict = {
+        "cmds": [],
+        "collection": _FakeCollection(),
+        "seeded": [],
+        "reapplied": [],
+        "fingerprint_state": archiver_seed.SeedState.ABSENT,
+        "differences": (),
+        "returncode": 0,
+    }
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text("MONGO_ROOT_PASSWORD=s3cret\n")
+
+    monkeypatch.setattr(
+        container_lifecycle,
+        "prepare_compose_files",
+        lambda *a, **k: (dict(ARCHIVER_CONFIG), ["docker-compose.yml"]),
+    )
+    monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+    monkeypatch.setattr(container_lifecycle, "_ensure_service_tokens", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "_preflight_token_continuity", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "_build_project_image", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "log_endpoint_summary", lambda *a, **k: None)
+
+    def _fake_run(cmd, env=None, check=False):
+        state["cmds"].append(list(cmd))
+        # A real CompletedProcess, because the quiesce checks its returncode.
+        return subprocess.CompletedProcess(list(cmd), state["returncode"])
+
+    monkeypatch.setattr(container_lifecycle.subprocess, "run", _fake_run)
+
+    # The seed inputs are a manifest read plus a machine-model load; both are
+    # exercised by their own module's tests, and neither belongs in an argv test.
+    monkeypatch.setattr(
+        container_lifecycle,
+        "_archiver_seed_inputs",
+        lambda config, project_dir: ([{"address": "SR:BPM1:X"}], None, {}),
+    )
+    monkeypatch.setattr(
+        container_lifecycle,
+        "_reapply_active_scenarios",
+        lambda config, project_dir, engine: state["reapplied"].append(project_dir),
+    )
+
+    @contextmanager
+    def _fake_collection(store):
+        state["store"] = store
+        yield state["collection"]
+
+    monkeypatch.setattr(apply_mod, "archiver_collection", _fake_collection)
+    monkeypatch.setattr(
+        archiver_seed,
+        "compare_fingerprint",
+        lambda collection, fingerprint: archiver_seed.FingerprintComparison(
+            state["fingerprint_state"], state["differences"]
+        ),
+    )
+
+    def _fake_seed_base(collection, channels, knobs, **kwargs):
+        state["seeded"].append({"channels": list(channels), "knobs": knobs, "kwargs": kwargs})
+        # The staged step reports on what it wrote, so hand back a real report.
+        return archiver_seed.SeedReport(documents=10, channels=len(channels))
+
+    monkeypatch.setattr(archiver_seed, "seed_base", _fake_seed_base)
+    return state
+
+
+def _verbs(cmds):
+    """The compose verb (plus service argument) of each recorded invocation.
+
+    Strips the runtime command and the leading option pairs — ``-f``,
+    ``--env-file`` and ``--progress`` — which are the same on every invocation
+    and only obscure the ordering under test.
+    """
+    verbs = []
+    for cmd in cmds:
+        rest = list(cmd)
+        while rest and rest[0] in ("docker", "compose", "podman"):
+            rest.pop(0)
+        while rest and rest[0] in ("-f", "--env-file", "--progress"):
+            del rest[:2]
+        verbs.append(" ".join(rest))
+    return verbs
+
+
+def test_staged_store_comes_up_before_the_full_bring_up(staged_archiver, tmp_path):
+    """The store is started alone first: the recorder must never race the seeder
+    into creating the collection with the wrong indexes."""
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    verbs = _verbs(staged_archiver["cmds"])
+    staged = verbs.index("up -d mongodb")
+    full = verbs.index("up --remove-orphans -d")
+    assert staged < full
+
+
+def test_reseed_quiesces_the_recorder_before_dropping_the_collection(staged_archiver, tmp_path):
+    """The recorder writes into the collection being dropped, so it is stopped
+    first. The following `up` restores it — nothing here has to undo the stop."""
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    verbs = _verbs(staged_archiver["cmds"])
+    assert verbs.index("stop archiver-recorder") < verbs.index("up --remove-orphans -d")
+    assert staged_archiver["collection"].dropped
+    assert len(staged_archiver["seeded"]) == 1
+
+
+def test_absent_fingerprint_seeds_after_a_volume_wipe(staged_archiver, tmp_path):
+    """`clean`/`rebuild` remove the volume, leaving no manifest — the same path a
+    first deploy takes, which is what makes a wiped store re-seed."""
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    assert len(staged_archiver["seeded"]) == 1
+    assert staged_archiver["reapplied"] == [tmp_path]
+
+
+def test_matching_fingerprint_skips_the_seed(staged_archiver, tmp_path):
+    """Unchanged knobs mean the stored archive already describes this profile:
+    nothing is dropped, written, or re-applied, and the recorder keeps running."""
+    from osprey.simulation.archiver_seed import SeedState
+
+    staged_archiver["fingerprint_state"] = SeedState.MATCH
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    verbs = _verbs(staged_archiver["cmds"])
+    assert "up -d mongodb" in verbs
+    assert "stop archiver-recorder" not in verbs
+    assert staged_archiver["seeded"] == []
+    assert staged_archiver["reapplied"] == []
+    assert not staged_archiver["collection"].dropped
+
+
+def test_mismatched_fingerprint_rebuilds_and_reapplies(staged_archiver, tmp_path):
+    """Changed knobs make the stored coverage wrong, so the base is rebuilt and
+    the active scenario set re-applied onto it — otherwise the deployment would
+    claim a fault whose history it had just erased."""
+    from osprey.simulation.archiver_seed import SeedState
+
+    staged_archiver["fingerprint_state"] = SeedState.MISMATCH
+    staged_archiver["differences"] = (("retention_days", 30, 1),)
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    assert staged_archiver["collection"].dropped
+    assert len(staged_archiver["seeded"]) == 1
+    assert staged_archiver["reapplied"] == [tmp_path]
+
+
+@pytest.mark.parametrize("state", ["ABSENT", "MISMATCH"])
+def test_drop_and_rebuild_always_implies_a_quiesced_recorder(staged_archiver, tmp_path, state):
+    """The invariant, stated once for every path that reaches it: a rebuild of
+    the base implies a quiesced recorder.
+
+    Not "mismatch quiesces and absent does not" — that conditional would leave
+    the absent path letting a writer run into a collection being dropped
+    underneath it. Stopping a service that was never started is a no-op, so the
+    unconditional rule is both simpler and strictly safer.
+    """
+    from osprey.simulation.archiver_seed import SeedState
+
+    staged_archiver["fingerprint_state"] = getattr(SeedState, state)
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    verbs = _verbs(staged_archiver["cmds"])
+    assert "stop archiver-recorder" in verbs
+    assert staged_archiver["collection"].dropped
+
+
+@pytest.mark.parametrize(
+    ("state", "expect_seed"),
+    [("MISMATCH", False), ("ABSENT", True)],
+)
+def test_keep_archiver_base_suppresses_only_the_mismatch_rebuild(
+    staged_archiver, tmp_path, state, expect_seed
+):
+    """The flag keeps an EXISTING base; it does not mean "never seed".
+
+    On a mismatch it preserves recorded history at the cost of honesty about the
+    new knobs. On an absent manifest — a first deploy, or a wiped volume — there
+    is no base to keep, so the seed must still happen; otherwise the flag would
+    silently leave the deployment with no history at all. This is also why
+    `rebuild` needs no flag of its own: it always lands on the absent path.
+    """
+    from osprey.simulation.archiver_seed import SeedState
+
+    staged_archiver["fingerprint_state"] = getattr(SeedState, state)
+    staged_archiver["differences"] = (("retention_days", 30, 1),)
+    container_lifecycle.deploy_up(
+        str(tmp_path / "config.yml"), detached=True, keep_archiver_base=True
+    )
+
+    assert bool(staged_archiver["seeded"]) is expect_seed
+    assert staged_archiver["collection"].dropped is expect_seed
+    assert ("stop archiver-recorder" in _verbs(staged_archiver["cmds"])) is expect_seed
+
+
+def test_seeder_authenticates_with_the_project_dotenv_password(staged_archiver, tmp_path):
+    """Read from the project's own `.env` by name — never from whatever the
+    ambient environment happens to export for another deployment's store."""
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    assert staged_archiver["store"]["password"] == "s3cret"
+
+
+def test_deploy_without_the_store_service_stages_nothing(captured_argv, monkeypatch, tmp_path):
+    """A project that reads a store someone else runs must never have its history
+    seeded by a local deploy."""
+    staged: list = []
+    monkeypatch.setattr(
+        container_lifecycle, "_stage_archiver_store", lambda *a, **k: staged.append(a)
+    )
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    assert staged == []
+
+
+def test_pymongo_preflight_aborts_before_any_container_work(monkeypatch, tmp_path):
+    """Naming the extra in seconds beats an ImportError after a minutes-long
+    image build, so the check sits beside the token mint, not at the seeder."""
+    import sys
+
+    ran: list = []
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        container_lifecycle,
+        "prepare_compose_files",
+        lambda *a, **k: (dict(ARCHIVER_CONFIG), ["docker-compose.yml"]),
+    )
+    monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
+    monkeypatch.setattr(container_lifecycle, "_ensure_service_tokens", lambda *a, **k: None)
+    monkeypatch.setattr(
+        container_lifecycle, "_build_project_image", lambda *a, **k: ran.append("build")
+    )
+    monkeypatch.setattr(
+        container_lifecycle.subprocess, "run", lambda *a, **k: ran.append("compose")
+    )
+    # A None entry in sys.modules is what an absent optional extra looks like to
+    # `import pymongo` — the import machinery raises ImportError without touching
+    # the installed package.
+    monkeypatch.setitem(sys.modules, "pymongo", None)
+
+    with pytest.raises(RuntimeError, match=r"osprey-framework\[archiver-mongodb\]"):
+        container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+    assert ran == []
+
+
+def test_pymongo_preflight_is_silent_without_the_store_service():
+    """No archiver in the deploy, no dependency to demand."""
+    container_lifecycle._preflight_archiver_pymongo({"deployed_services": ["event_dispatcher"]})
+
+
+def test_health_poll_returns_once_the_store_answers(monkeypatch):
+    """A store on a fresh volume creates its admin user before it accepts
+    connections, so early refusals are expected rather than fatal."""
+    monkeypatch.setattr(container_lifecycle.time, "sleep", lambda seconds: None)
+    collection = _FakeCollection(fail_pings=3)
+
+    container_lifecycle._wait_for_archiver_store(
+        collection, time.monotonic() + container_lifecycle._ARCHIVER_HEALTH_TIMEOUT_S
+    )
+    assert collection.admin.pings == 4
+
+
+def test_health_poll_is_bounded(monkeypatch):
+    """An unreachable store fails the deploy with the store named, rather than
+    leaving `deploy up` polling forever."""
+    monkeypatch.setattr(container_lifecycle.time, "sleep", lambda seconds: None)
+    collection = _FakeCollection(fail_pings=10_000)
+
+    with pytest.raises(RuntimeError, match="did not become reachable"):
+        container_lifecycle._wait_for_archiver_store(collection, time.monotonic() - 1)
+
+
+def test_missing_store_password_aborts_with_the_variable_named(
+    staged_archiver, monkeypatch, tmp_path
+):
+    """Without the credential the store is created with, the seeder cannot open
+    the store it is staging — and the fix is a named variable."""
+    (tmp_path / ".env").write_text("")
+    monkeypatch.delenv("MONGO_ROOT_PASSWORD", raising=False)
+
+    with pytest.raises(RuntimeError, match="MONGO_ROOT_PASSWORD"):
+        container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+
+def test_reapply_anchors_on_the_persisted_t0_not_a_fresh_one(monkeypatch, tmp_path):
+    """The re-apply must land on the anchor the running world is already on.
+
+    Minting a fresh T0 would slide the live VA's events, the seeded logbook and
+    the archive's event windows to an instant nobody asked for, as a side effect
+    of a deploy that was only supposed to rebuild the store. Reading the anchor
+    is `osprey.simulation.apply.persisted_scenario_anchor`'s job (and is tested
+    there); what this pins is that the deploy passes what it read straight
+    through to `apply_scenarios` as `now`.
+    """
+    from datetime import UTC, datetime
+
+    from osprey.simulation import apply as apply_mod
+
+    anchor = datetime(2026, 8, 1, 12, 0, tzinfo=UTC)
+    forwarded: dict = {}
+
+    def _record(project_dir, names, **kwargs):
+        forwarded.update(names=names, **kwargs)
+        return apply_mod.ApplyResult(active=tuple(names), logbook_seeded=0, purged=False)
+
+    monkeypatch.setattr(apply_mod, "persisted_scenario_anchor", lambda config, project_dir: anchor)
+    monkeypatch.setattr(apply_mod, "apply_scenarios", _record)
+    engine = type("_Engine", (), {"active_scenarios": lambda self: ("nominal", "rf-thermal")})()
+
+    container_lifecycle._reapply_active_scenarios({}, tmp_path, engine)
+
+    assert forwarded["now"] == anchor
+    # The logbook is a knob change's business only if the narrative changed, and
+    # it did not — purging ARIEL here would destroy history nobody asked to touch.
+    assert forwarded["seed_logbook"] is False
+
+
+def _manifest_channel(address: str) -> dict:
+    """One manifest entry carrying the full per-channel schema the loader demands."""
+    return {
+        "address": address,
+        "ring": "SR",
+        "system": "diagnostics",
+        "family": "BPM",
+        "device": "1",
+        "field": "X",
+        "subfield": "",
+        "partition": "static-noisy",
+        "record_type": "ai",
+        "noise": 0.01,
+    }
+
+
+def test_seed_inputs_read_the_manifest_the_project_env_names(tmp_path):
+    """The seeded channel set is the manifest the VA and the recorder read, found
+    the way they find it — so seeded history covers exactly what the live half
+    serves rather than another facility's namespace."""
+    simulation_dir = tmp_path / "data" / "simulation"
+    simulation_dir.mkdir(parents=True)
+    (simulation_dir / "channel_manifest.json").write_text(
+        json.dumps({"channels": [_manifest_channel("SR:BPM1:X")]})
+    )
+    (tmp_path / ".env").write_text("VA_CHANNELS_FILE=channel_manifest.json\n")
+
+    channels, engine, boot_values = container_lifecycle._archiver_seed_inputs({}, tmp_path)
+
+    assert [c["address"] for c in channels] == ["SR:BPM1:X"]
+    # No machine model in this project: every channel is procedural, which is a
+    # valid configuration rather than a fault.
+    assert engine is None
+    assert boot_values == {}
+
+
+def test_reapply_without_a_machine_model_is_a_no_op(tmp_path):
+    """A store-only project has no scenarios to restore onto the rebuilt base."""
+    container_lifecycle._reapply_active_scenarios({}, tmp_path, None)
+
+
+def test_exported_password_is_used_when_the_dotenv_has_none(staged_archiver, monkeypatch, tmp_path):
+    """`deploy up` is the process that hands compose its environment.
+
+    When the password is exported rather than written to `.env`, the exported
+    value is what the store container is created with — so it is also what the
+    seeder must authenticate with. (`sim apply` deliberately does NOT do this: it
+    runs from anywhere and must not pick up a foreign deployment's credential.)
+    """
+    (tmp_path / ".env").write_text("")
+    monkeypatch.setenv("MONGO_ROOT_PASSWORD", "exported-not-written")
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    assert staged_archiver["store"]["password"] == "exported-not-written"
+
+
+def test_store_without_a_connection_block_seeds_nothing(
+    staged_archiver, monkeypatch, tmp_path, caplog
+):
+    """A project deploying the store but declaring no connection block cannot be
+    seeded. It says so and leaves the store to the normal bring-up rather than
+    guessing a host — an empty archive read honestly beats a wrong one."""
+    config = {key: value for key, value in ARCHIVER_CONFIG.items() if key != "archiver"}
+    monkeypatch.setattr(
+        container_lifecycle,
+        "prepare_compose_files",
+        lambda *a, **k: (config, ["docker-compose.yml"]),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    assert "archiver.mongodb_archiver" in caplog.text
+    verbs = _verbs(staged_archiver["cmds"])
+    assert "up -d mongodb" not in verbs
+    assert staged_archiver["seeded"] == []
+    assert not staged_archiver["collection"].dropped
+
+
+def test_authentication_is_retried_while_a_fresh_volume_initializes(monkeypatch):
+    """A FRESH volume refuses authentication before it has created its root user.
+
+    mongod accepts connections before it applies MONGO_INITDB_ROOT_PASSWORD, so a
+    probe landing in that window is refused by a store that is about to be
+    perfectly healthy. Treating that as terminal aborts the FIRST deploy of every
+    new project — intermittently, depending on which side of the race the probe
+    lands, which is the worst way for it to fail.
+    """
+    from pymongo.errors import OperationFailure
+
+    monkeypatch.setattr(container_lifecycle.time, "sleep", lambda seconds: None)
+    collection = _FakeCollection()
+    refusals = [3]
+
+    def _initializing(name):
+        collection.admin.pings += 1
+        if refusals[0] > 0:
+            refusals[0] -= 1
+            raise OperationFailure("Authentication failed.", code=18)
+        return {"ok": 1}
+
+    collection.admin.command = _initializing
+
+    container_lifecycle._wait_for_archiver_store(
+        collection,
+        time.monotonic() + container_lifecycle._ARCHIVER_HEALTH_TIMEOUT_S,
+        "osprey@localhost:27017",
+    )
+    assert collection.admin.pings == 4
+
+
+def test_authentication_failure_past_the_grace_window_fails_with_the_cause(monkeypatch):
+    """After the store has had time to initialize, the SAME error means the
+    stale-volume shape instead: a rotated password against a volume that keeps
+    the credentials it was created with. That will never succeed, so it fails
+    with the cause named rather than consuming the full reachability budget."""
+    from pymongo.errors import OperationFailure
+
+    monkeypatch.setattr(container_lifecycle.time, "sleep", lambda seconds: None)
+    # Collapse the grace window so the refusal is read as final immediately.
+    monkeypatch.setattr(container_lifecycle, "_ARCHIVER_AUTH_GRACE_S", 0.0)
+    collection = _FakeCollection()
+
+    def _refuse(name):
+        collection.admin.pings += 1
+        raise OperationFailure("Authentication failed.", code=18)
+
+    collection.admin.command = _refuse
+
+    with pytest.raises(RuntimeError, match="rejected the credentials"):
+        container_lifecycle._wait_for_archiver_store(
+            collection,
+            time.monotonic() + container_lifecycle._ARCHIVER_HEALTH_TIMEOUT_S,
+            "osprey@localhost:27017",
+        )
+    # Terminal on the first refusal once the grace window has passed — it will
+    # not start working, and the full budget would only delay the diagnosis.
+    assert collection.admin.pings == 1
+
+
+def test_a_non_auth_operation_failure_is_not_swallowed(monkeypatch):
+    """Only AuthenticationFailed gets the grace/stale-volume treatment; any other
+    server-side command failure propagates as itself rather than being retimed
+    into a credentials message that would misdirect the reader."""
+    from pymongo.errors import OperationFailure
+
+    monkeypatch.setattr(container_lifecycle.time, "sleep", lambda seconds: None)
+    collection = _FakeCollection()
+
+    def _fail(name):
+        raise OperationFailure("not authorized on admin", code=13)
+
+    collection.admin.command = _fail
+
+    with pytest.raises(OperationFailure, match="not authorized"):
+        container_lifecycle._wait_for_archiver_store(
+            collection, time.monotonic() + 5, "osprey@localhost:27017"
+        )
+
+
+def test_a_failed_reapply_names_the_command_that_fixes_it(monkeypatch, tmp_path):
+    """The manifest is already written by this point, so the next deploy reads
+    MATCH and skips both the reseed and this step — leaving a clean base under a
+    faulted machine forever. The error has to hand over the one command that
+    repairs it, because retrying the deploy will not."""
+    from osprey.simulation import apply as apply_mod
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("store went away")
+
+    monkeypatch.setattr(apply_mod, "apply_scenarios", _boom)
+    engine = type("_Engine", (), {"active_scenarios": lambda self: ("nominal", "rf-thermal")})()
+
+    with pytest.raises(RuntimeError, match=r"osprey sim apply rf-thermal") as caught:
+        container_lifecycle._reapply_active_scenarios({}, tmp_path, engine)
+
+    assert "shows a clean machine" in str(caught.value)
+    # The cause is chained rather than replaced — the original failure is what a
+    # maintainer needs, the recovery is what the operator needs.
+    assert isinstance(caught.value.__cause__, RuntimeError)
+
+
+def test_a_recorder_that_will_not_stop_is_reported(staged_archiver, tmp_path, caplog):
+    """A recorder still running writes into the collection being dropped. The
+    rebuild is still right, but the breach of the quiesce invariant must be
+    visible rather than swallowed by a return code nobody reads."""
+    staged_archiver["returncode"] = 1
+
+    with caplog.at_level(logging.WARNING):
+        container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    assert "archiver-recorder" in caplog.text
+    # Reported, not fatal: the seed still ran.
+    assert len(staged_archiver["seeded"]) == 1
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [("snappy", "snappy"), (None, "zstd")],
+)
+def test_compression_comes_from_the_service_block_not_the_knobs(
+    staged_archiver, monkeypatch, tmp_path, configured, expected
+):
+    """The block compressor is a property of the SERVER, not of the archive's
+    shape, so it lives at `services.mongodb.compression` and deliberately not in
+    SeedKnobs. The seeder is handed it from that path, and it reaches the
+    fingerprint from there — which is what makes changing the compressor a
+    reported reseed rather than a store that is half one codec and half another.
+    """
+    config = dict(ARCHIVER_CONFIG)
+    config["services"] = {"mongodb": {"port_host": 27017}}
+    if configured is not None:
+        config["services"]["mongodb"]["compression"] = configured
+    monkeypatch.setattr(
+        container_lifecycle,
+        "prepare_compose_files",
+        lambda *a, **k: (config, ["docker-compose.yml"]),
+    )
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    assert staged_archiver["seeded"][0]["kwargs"]["compression"] == expected
+
+
+def test_the_auth_grace_sits_between_the_healthcheck_and_the_reachability_budget():
+    """The 15/45/180 ordering documented at ``_ARCHIVER_AUTH_GRACE_S`` IS the design.
+
+    Each constant is pinned somewhere already, but only in isolation: nothing
+    compared them, so moving the template's ``start_period`` — the one the
+    comment says "this has to move with it" — inverted the relationship
+    silently. Below the start_period, a fresh volume's normal root-user
+    creation is reported as a wrong password and the first deploy of every new
+    project aborts. Above the reachability budget, the grace never expires and
+    a genuinely stale volume burns the full budget for a diagnosis that was
+    available in seconds.
+    """
+    import re
+
+    import osprey
+
+    template = (
+        Path(osprey.__file__).parent
+        / "templates"
+        / "services"
+        / "mongodb"
+        / "docker-compose.yml.j2"
+    ).read_text(encoding="utf-8")
+
+    match = re.search(r"start_period:\s*(\d+)s", template)
+    assert match, "no healthcheck start_period found in the mongodb template"
+    start_period_s = float(match.group(1))
+
+    assert start_period_s < container_lifecycle._ARCHIVER_AUTH_GRACE_S, (
+        f"the auth grace ({container_lifecycle._ARCHIVER_AUTH_GRACE_S}s) must outlast the "
+        f"store's own healthcheck start_period ({start_period_s}s), or a fresh volume's "
+        "root-user creation is reported as a wrong password"
+    )
+    assert (
+        container_lifecycle._ARCHIVER_AUTH_GRACE_S < container_lifecycle._ARCHIVER_HEALTH_TIMEOUT_S
+    ), (
+        f"the auth grace ({container_lifecycle._ARCHIVER_AUTH_GRACE_S}s) must expire inside the "
+        f"reachability budget ({container_lifecycle._ARCHIVER_HEALTH_TIMEOUT_S}s), or a stale "
+        "volume burns the whole budget before saying so"
+    )

--- a/tests/deployment/test_invented_history_refusal.py
+++ b/tests/deployment/test_invented_history_refusal.py
@@ -1,0 +1,163 @@
+"""Deploy-time refusal of a stack whose archive would be fabricated.
+
+``osprey build`` refuses to write the pairing and the MCP server refuses to
+start on it, but a deploy reads the project's ``config.yml`` as it stands now —
+including one edited after the build. It is also the moment the pairing stops
+being a file and becomes a running stack other people trust, which is why
+``_refuse_invented_history`` runs before any branch of ``deploy_up`` has touched
+the host, and again on the restart path (``config.yml`` is bind-mounted, so a
+restart is how an edit takes effect).
+
+The rule itself — which spelling is live in which kind of config, and why an
+unset ``archiver.type`` counts as the mock — is proven in
+``tests/connectors/test_honesty_rule.py``. Asserted here: that this surface asks
+it, that it raises rather than warns, and that what it says is actionable by
+whoever ran the deploy.
+"""
+
+import pytest
+
+from osprey.deployment.container_lifecycle import _refuse_invented_history
+
+VA_MOCK_NESTED = {
+    "control_system": {"type": "virtual_accelerator", "writes_enabled": True},
+    "archiver": {"type": "mock_archiver"},
+    "deployed_services": ["virtual_accelerator", "bluesky"],
+}
+VA_ARCHIVER_UNSET = {"control_system": {"type": "virtual_accelerator"}}
+
+# Top-level dotted lines a rendered config.yml's readers never honour — see the
+# bypass regressions in tests/connectors/test_honesty_rule.py. Each of these
+# deploys a VA whose live archiver is the mock, behind a line that looks like it
+# said otherwise.
+INERT_FLAT_ARCHIVER = VA_MOCK_NESTED | {"archiver.type": "mongodb_archiver"}
+INERT_FLAT_ARCHIVER_ONLY = VA_ARCHIVER_UNSET | {"archiver.type": "mongodb_archiver"}
+INERT_FLAT_CONTROL_SYSTEM = VA_MOCK_NESTED | {"control_system.type": "mock"}
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param(VA_MOCK_NESTED, id="nested-mock"),
+        pytest.param(VA_ARCHIVER_UNSET, id="archiver-unset"),
+        pytest.param(INERT_FLAT_ARCHIVER, id="inert-flat-archiver-over-mock"),
+        pytest.param(INERT_FLAT_ARCHIVER_ONLY, id="inert-flat-archiver-only"),
+        pytest.param(INERT_FLAT_CONTROL_SYSTEM, id="inert-flat-control-system"),
+    ],
+)
+def test_a_deploy_that_would_fabricate_its_past_is_refused(config):
+    with pytest.raises(RuntimeError) as excinfo:
+        _refuse_invented_history(config)
+
+    assert "virtual_accelerator" in str(excinfo.value)
+
+
+def test_the_refusal_names_the_file_to_fix_and_the_ways_out():
+    """The reader is at a terminal that just declined to deploy; the message has
+    to be the whole diagnosis."""
+    with pytest.raises(RuntimeError) as excinfo:
+        _refuse_invented_history(VA_MOCK_NESTED)
+    message = str(excinfo.value)
+
+    assert "config.yml" in message
+    assert "va_archiver" in message
+    assert "'mock'" in message
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param(
+            {
+                "control_system": {"type": "virtual_accelerator"},
+                "archiver": {"type": "mongodb_archiver"},
+                "deployed_services": ["virtual_accelerator", "mongodb", "archiver-recorder"],
+            },
+            id="va-with-its-store",
+        ),
+        pytest.param(
+            {"control_system": {"type": "mock"}, "archiver": {"type": "mock_archiver"}},
+            id="honestly-storeless",
+        ),
+        pytest.param(
+            {"control_system": {"type": "epics"}, "archiver": {"type": "epics_archiver"}},
+            id="hardware",
+        ),
+        pytest.param(
+            {"control_system.type": "virtual_accelerator", "archiver": {"type": "mock_archiver"}},
+            id="inert-flat-control-system-only",
+        ),
+        pytest.param({}, id="says-nothing"),
+    ],
+)
+def test_every_other_deploy_proceeds_untouched(config):
+    """The last case is the mirror of the rule rather than a hole: with no
+    `control_system:` section the connector factory falls back to the mock, so
+    that deployment is a mock machine with a mock archive — honest, whatever the
+    inert top-level line was aiming at."""
+    assert _refuse_invented_history(config) is None
+
+
+def test_an_attached_project_deploying_no_va_container_is_still_refused():
+    """Keyed on what the deployment claims about itself, not on
+    ``deployed_services``: a project that deploys no VA of its own still points
+    its agent at one."""
+    with pytest.raises(RuntimeError):
+        _refuse_invented_history(
+            {
+                "control_system": {"type": "virtual_accelerator"},
+                "archiver": {"type": "mock_archiver"},
+                "deployed_services": [],
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# Wired into the paths that start containers, before either touches the host
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def lying_project(monkeypatch, tmp_path):
+    """A project whose config.yml pairs a VA with the mock, and a runtime that
+    records any attempt to reach it."""
+    from osprey.deployment import container_lifecycle
+
+    reached: list[list[str]] = []
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        container_lifecycle,
+        "prepare_compose_files",
+        lambda *a, **k: (dict(VA_MOCK_NESTED), ["docker-compose.yml"]),
+    )
+    monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+    monkeypatch.setattr(
+        container_lifecycle.subprocess,
+        "run",
+        lambda cmd, env=None, check=False: reached.append(cmd),
+    )
+    return container_lifecycle, reached, tmp_path
+
+
+def test_deploy_up_aborts_before_the_host_is_touched(lying_project):
+    container_lifecycle, reached, tmp_path = lying_project
+
+    with pytest.raises(RuntimeError, match="virtual_accelerator"):
+        container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    assert reached == []
+
+
+def test_deploy_restart_aborts_too(lying_project):
+    """config.yml is bind-mounted, so a restart is how an edit into the pairing
+    would take effect."""
+    container_lifecycle, reached, tmp_path = lying_project
+
+    with pytest.raises(RuntimeError, match="virtual_accelerator"):
+        container_lifecycle.deploy_restart(str(tmp_path / "config.yml"))
+
+    assert reached == []

--- a/tests/deployment/test_mongo_password_mint.py
+++ b/tests/deployment/test_mongo_password_mint.py
@@ -1,0 +1,188 @@
+"""Unit tests for the archiver Mongo root password in the token-mint map.
+
+Mirrors ``test_postgres_password_mint.py``'s coverage for the ``mongodb``
+deployed-service entry in ``_SERVICE_TOKEN_VARS`` (container_lifecycle.py):
+``osprey deploy up`` mints a strong ``MONGO_ROOT_PASSWORD`` into the project
+``.env``, which the mongodb compose template reads as
+MONGO_INITDB_ROOT_PASSWORD and the agent's archiver connector block names
+(``archiver.mongodb_archiver.password_env``) rather than carrying a value.
+
+What makes this store different from the ARIEL one is the *number* of readers
+the single value has to satisfy: the container that initializes the volume, the
+archiver_recorder writing samples in-network, and the connector reading them
+back. The registry entries are what make those three the same value, so the
+tests assert the invariant end to end — a mint that reaches the ``.env``, and a
+``.env`` value that every registry agrees on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from osprey.deployment import container_lifecycle
+from osprey.deployment.host_ports import _remedy_for_service
+from osprey.deployment.service_tokens import _generate_token, _validate_var
+
+
+@pytest.fixture
+def captured_argv(monkeypatch, tmp_path):
+    """Patch deploy_up's collaborators for a project with only 'mongodb' deployed."""
+    captured: dict = {}
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        container_lifecycle,
+        "prepare_compose_files",
+        lambda *a, **k: ({"deployed_services": ["mongodb"]}, ["docker-compose.yml"]),
+    )
+    monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+
+    def _fake_run(cmd, env=None, check=False):
+        captured["cmd"] = cmd
+
+    monkeypatch.setattr(container_lifecycle.subprocess, "run", _fake_run)
+    return captured
+
+
+@pytest.fixture
+def _clean_token_env(monkeypatch):
+    monkeypatch.delenv("MONGO_ROOT_PASSWORD", raising=False)
+
+
+def _parse_env(tmp_path):
+    from osprey.utils.dotenv import parse_dotenv_file
+
+    path = tmp_path / ".env"
+    return parse_dotenv_file(path) if path.is_file() else {}
+
+
+def test_mongodb_deploy_mints_mongo_root_password(captured_argv, _clean_token_env, tmp_path):
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True, dev_mode=False)
+
+    env = _parse_env(tmp_path)
+    assert env.get("MONGO_ROOT_PASSWORD")
+    # token_hex(32) → 64 hex chars, 256 bits of entropy.
+    assert len(env["MONGO_ROOT_PASSWORD"]) == 64
+    # A mongodb-only deploy must not mint unrelated service tokens.
+    assert "ARIEL_DB_PASSWORD" not in env
+    assert "ZO_ROOT_USER_PASSWORD" not in env
+
+
+def test_mongo_root_password_generator_is_uri_safe_every_time():
+    """Every mint must survive being substituted into a mongodb:// URI.
+
+    The connector passes the password to ``MongoClient`` as a keyword argument,
+    but the recorder, the seeder, and any operator reaching the store by hand
+    may spell the same credential as a URI, where an unescaped reserved
+    character silently reshapes the authority component instead of erroring.
+    The hex alphabet is what makes all of those spellings equivalent.
+    """
+    for _ in range(50):
+        value = _generate_token("MONGO_ROOT_PASSWORD")
+        assert value.isalnum()
+        assert _validate_var("MONGO_ROOT_PASSWORD", value)
+
+
+def test_mongodb_mint_is_idempotent(captured_argv, _clean_token_env, tmp_path):
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+    first = _parse_env(tmp_path)
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+    second = _parse_env(tmp_path)
+
+    assert first["MONGO_ROOT_PASSWORD"] == second["MONGO_ROOT_PASSWORD"]
+    assert (tmp_path / ".env").read_text().count("MONGO_ROOT_PASSWORD=") == 1
+
+
+def test_existing_mongo_root_password_is_preserved(captured_argv, _clean_token_env, tmp_path):
+    """The volume that adopted the value outlives any later mint."""
+    (tmp_path / ".env").write_text("MONGO_ROOT_PASSWORD=preexistingvalue\n", encoding="utf-8")
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+    assert _parse_env(tmp_path)["MONGO_ROOT_PASSWORD"] == "preexistingvalue"
+
+
+@pytest.mark.parametrize("bad", ["p@ssword", "pass word", "a/b", "user:pw", "q?x", "frag#ment"])
+def test_operator_password_with_reserved_char_is_rejected(
+    captured_argv, _clean_token_env, tmp_path, bad
+):
+    """Refuse at the deploy boundary rather than let a URI reader mis-parse it."""
+    (tmp_path / ".env").write_text(f"MONGO_ROOT_PASSWORD={bad}\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="MONGO_ROOT_PASSWORD"):
+        container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+
+def test_rejection_never_echoes_the_password(captured_argv, _clean_token_env, tmp_path):
+    (tmp_path / ".env").write_text("MONGO_ROOT_PASSWORD=p@ssword\n", encoding="utf-8")
+    with pytest.raises(RuntimeError) as excinfo:
+        container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+    assert "p@ssword" not in str(excinfo.value)
+
+
+class TestRegistryAgreement:
+    """The registries that make one minted value reach all three readers."""
+
+    def test_the_token_var_matches_what_the_compose_template_reads(self):
+        """The template's ``${MONGO_ROOT_PASSWORD:-...}`` and the mint map are one contract."""
+        from osprey.deployment.container_lifecycle import _SERVICE_TOKEN_VARS
+
+        template = _mongodb_template_text()
+        (var,) = _SERVICE_TOKEN_VARS["mongodb"]
+        assert f"${{{var}:-" in template
+
+    def test_the_state_volume_matches_what_the_compose_template_declares(self):
+        """A wrong bare name makes the continuity preflight silently never fire.
+
+        It reports on volume *existence*, so a name no template declares simply
+        never matches and the check degrades to a no-op — passing tests, no
+        warning, and an operator who learns about the stranded secret when a
+        rebuilt project cannot open the store.
+        """
+        from osprey.deployment.container_lifecycle import _SERVICE_STATE_VOLUMES
+
+        declared = _declared_top_level_volumes(_mongodb_template_text())
+        assert declared, "no top-level volumes: block found in the mongodb template"
+        assert set(_SERVICE_STATE_VOLUMES["mongodb"]) <= declared
+
+    def test_the_port_remedy_names_the_knob_the_profile_block_emits(self):
+        """The generic fallback would be ``services.mongodb.port``, which is wrong."""
+        assert _remedy_for_service("mongodb") == "services.mongodb.port_host"
+
+
+def _mongodb_template_text() -> str:
+    """The mongodb compose template as written, jinja expressions intact."""
+    from pathlib import Path
+
+    import osprey
+
+    path = (
+        Path(osprey.__file__).parent
+        / "templates"
+        / "services"
+        / "mongodb"
+        / "docker-compose.yml.j2"
+    )
+    return path.read_text(encoding="utf-8")
+
+
+def _declared_top_level_volumes(template: str) -> set[str]:
+    """Bare volume names from the template's top-level ``volumes:`` mapping.
+
+    Scanned textually rather than with ``yaml.safe_load``: the service body
+    carries jinja expressions (``${VAR:-{{ … }}}``) that are not valid YAML, so
+    parsing the file whole would fail for reasons unrelated to what is asserted.
+    The top-level block is a plain list of keys, which reads unambiguously from
+    indentation alone.
+    """
+    names: set[str] = set()
+    in_block = False
+    for line in template.splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        if not line[:1].isspace():
+            in_block = line.rstrip() == "volumes:"
+            continue
+        if in_block:
+            names.add(line.strip().rstrip(":"))
+    return names

--- a/tests/e2e/_orm_stack.py
+++ b/tests/e2e/_orm_stack.py
@@ -119,6 +119,23 @@ DEFAULT_CORRECTOR_COUNT = 4
 DEFAULT_BPM_COUNT = 4
 
 
+# The archive every VA lane deploys, shrunk to what a lane actually reads.
+#
+# The control-assistant preset declares a `va_archiver:` block sized for a
+# tutorial deployment -- a month of history behind two dense days -- and
+# `deploy up` writes every sample of it into the store before the stack answers.
+# No lane here reads that history; they need the store to exist, the recorder to
+# be recording, and the two-tier boundary to be somewhere a contract can find it.
+# Two days of retention behind a two-hour dense head is about a sixteenth of the
+# samples: seconds of seeding instead of a minute, and a store sized to match.
+#
+# One snippet shared by all four VA lanes (`override_yaml` below, plus the three
+# that write their own override) rather than four hand-copied blocks that drift.
+# Deep-merged onto the preset's block, so `host:` and both cadences keep the
+# values the preset ships -- only the two span knobs move.
+VA_ARCHIVER_CI_KNOBS = "va_archiver:\n  retention_days: 2\n  hot_span_hours: 2\n"
+
+
 def override_yaml() -> str:
     """FR11's ``--override`` YAML content: VA control system + the scan MCP
     server.
@@ -139,6 +156,12 @@ def override_yaml() -> str:
     nested ``modules:`` mapping would wholesale-replace the subtree (see the
     preset's own comment above its ``modules.web_terminals`` block).
 
+    ``VA_ARCHIVER_CI_KNOBS`` shrinks the archive the preset's ``va_archiver:``
+    block declares to a CI-sized one -- see the constant for why. It trails
+    ``dispatch: null`` so it stays outside the ``config:`` block (both are
+    top-level profile keys, and ``test_bluesky_panels_deploy`` splices its port
+    moves in ahead of that line).
+
     Written as flat dotted-string keys under ``config:`` (matching the
     preset's own convention), not a `--set config.control_system.type=...`
     CLI override -- `--set` builds a NESTED dict for every dotted segment,
@@ -150,7 +173,7 @@ def override_yaml() -> str:
         "  control_system.type: virtual_accelerator\n"
         "  claude_code.servers.bluesky.enabled: true\n"
         "  modules.web_terminals.enabled: false\n"
-        "dispatch: null\n"
+        "dispatch: null\n" + VA_ARCHIVER_CI_KNOBS
     )
 
 

--- a/tests/e2e/sdk_helpers.py
+++ b/tests/e2e/sdk_helpers.py
@@ -193,6 +193,7 @@ def init_project(
     channel_finder_mode: str | None = None,
     tier: int | None = None,
     connector: str = "mock",
+    archiver: str = "mock_archiver",
 ) -> Path:
     """Create a project via ``osprey build --preset <template>``, return project_dir.
 
@@ -202,6 +203,16 @@ def init_project(
     runs projects without their containers, so the preset's production default
     would turn every channel read/write into a connection timeout. Tests that
     deploy a real stack build through their own fixtures, not this helper.
+
+    ``archiver`` is pinned for the same reason and is the archive half of that
+    same fact: the preset selects ``mongodb_archiver`` and declares the
+    ``va_archiver:`` block that deploys the store it reads, so a containerless
+    build would leave every ``archiver_read`` failing at connect for want of a
+    store — and, before that, for want of the password ``osprey deploy up``
+    mints. Pinning both halves to the mock is not a way around the pairing rule
+    in :mod:`osprey.connectors.honesty` but the case it explicitly allows: a
+    mock control system with the mock archiver claims nothing is real, so
+    nothing lies. Tests that want recorded history deploy a store of their own.
 
     Tier selection follows a per-mode default: tier 1 is in_context-only, while
     ``hierarchical``/``middle_layer`` require tier 3. When ``tier`` is left
@@ -257,6 +268,18 @@ def init_project(
         "--set",
         f"connector={connector}",
     ]
+    # An override FILE, not ``--set config.archiver.type=``: the preset spells
+    # the key in its literal dotted form, and a ``--set`` nested path would
+    # merge a second, competing ``archiver`` mapping alongside it whose winner
+    # is decided by key order — which the build refuses outright rather than
+    # render. A ``-O`` layer replaces the dotted key in the spelling the
+    # profile already uses.
+    archiver_override = tmp_path / "_archiver-pin.yml"
+    archiver_override.write_text(
+        f"config:\n  archiver.type: {archiver}\n",
+        encoding="utf-8",
+    )
+    args.extend(["-O", str(archiver_override)])
     if effective_tier is not None:
         args.extend(["--tier", str(effective_tier)])
     if channel_finder_mode is not None:

--- a/tests/e2e/test_archiver_world_e2e.py
+++ b/tests/e2e/test_archiver_world_e2e.py
@@ -1,0 +1,1074 @@
+"""The honest archiver world, proved end to end against a deployed stack.
+
+Every other test of this feature checks one half of it. This one deploys the
+whole thing — store, seeder, recorder, virtual accelerator — and asks the
+questions an operator would: is the history there, is it affordable, does what I
+just did to the machine show up in it, and does it admit what it does not know.
+
+Eight claims, in the order a deployment makes them true:
+
+* **The seed is affordable.** A first ``deploy up`` seeds the base series inside
+  a measured budget and says so while it works. This lane keeps DEFAULT
+  ``va_archiver`` knobs precisely so the numbers mean something: the CI lanes
+  that shrink retention to run fast cannot own a budget nobody would deploy.
+* **The store is affordable.** The seeded archive fits the declared disk budget,
+  and the block compressor the manifest claims is the one mongod actually used.
+* **The live half reaches the stored half.** A setpoint written now appears in
+  an archiver read within the recorder's budget — the whole point of running a
+  recorder rather than only a seeder.
+* **The archive admits its edges.** A window before coverage begins returns no
+  points, and ``get_metadata`` reports the oldest sample it really holds rather
+  than a declared window.
+* **The seam is invisible.** Where seeded history ends and recorded reality
+  begins, the step in every fidelity partition is attributable to noise — the
+  threshold quoted from :func:`~osprey.simulation.procedural.deviation_bound`
+  per channel, never a constant embedded here.
+* **A scenario apply stays bounded.** Activating an eventful scenario rewrites
+  event windows, not the archive; the document count is asked to stay inside a
+  ratio, which is the budget the disk assertion above rests on.
+* **The recorder records a machine, not whatever is plugged in.** Flipping
+  ``control_system.type`` to ``mock`` on the mounted config stops recording, and
+  flipping back resumes it — with no redeploy and no restart. How many polls
+  that takes is deliberately not asserted: the test waits for the recorder's own
+  announcement, because a poll landing mid-write keeps its previous answer and
+  the service never promised a bound. The claim is that the flip takes effect at
+  all, and it matters because synthesized mock values written into a store the
+  agent reads as machine history is the same lie this whole feature exists to
+  refuse, arriving through a different door.
+* **An operator can see all of it.** ``osprey health`` reports the archive fresh
+  through a check nobody declared by hand: naming a canary channel in the
+  ``va_archiver:`` block derived the category, the probe and a staleness
+  threshold from the recorder's own cadence. Reachable and being-written are
+  different claims, and this is the surface that tells them apart.
+
+Gating: needs Docker. The VA image is pinned ``linux/amd64`` (see its
+Dockerfile's architecture note), so on Apple Silicon it builds and runs under
+emulation — slow on a cold cache. There is no LLM anywhere in this file and no
+network beyond the containers: every assertion is mechanical, which is why the
+CI lane carries no provider secret.
+
+Container safety: every docker invocation names an exact container, image or
+volume — never a wildcard, never ``system prune``, never ``down --volumes``
+(which would reach every volume in the project). Teardown goes through
+``osprey deploy down``, matching every other e2e in this directory, plus the
+removal of the store's one named volume — see ``_discard_store_volume`` for why
+a fresh store is a precondition of these assertions rather than housekeeping.
+
+TTL note: this file deploys the REAL compose stack, where mongod runs with the
+template's own flags and its TTL monitor is live. That is deliberate — retention
+behaving like retention is part of what is under test — and it is why the
+document-count assertion below is a one-sided ratio rather than an equality: the
+sweeper may legitimately retire aged tail samples between two counts. Auxiliary
+fixture containers elsewhere (see
+``tests/connectors/test_archiver_world_contracts.py``) switch the monitor off
+for the opposite reason; do not copy that setting into this file.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import shutil
+import subprocess
+import time
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from osprey.simulation.procedural import DEFAULT_NOISE_LEVEL, deviation_bound
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.slow,
+    # dockerbuild: full VA image build + a real multi-service deploy -- runs in
+    # the dedicated archiver-world-e2e CI job, never the shared e2e-tests lane
+    # (the marker->--ignore pairing is enforced by
+    # tests/deployment/test_ci_workflow_wiring.py).
+    pytest.mark.dockerbuild,
+    pytest.mark.skipif(shutil.which("docker") is None, reason="docker not available"),
+]
+
+PROJECT_NAME = "archiver-world"
+
+# Ports chosen away from the ones a host demo stack habitually holds
+# (5064 EPICS CA, 5080, 5432 postgres): a collision there reads as a deploy
+# failure and costs an afternoon before anyone suspects the host.
+VA_CA_PORT = 5164
+MONGO_PORT_HOST = 27117
+
+BUILD_TIMEOUT_SEC = 600
+DEPLOY_UP_TIMEOUT_SEC = 2400
+
+# The measured budgets this lane owns. Both are stated against DEFAULT
+# va_archiver knobs (30-day retention, 48 h hot span) -- see the module
+# docstring for why the fast lanes cannot own them.
+SEED_BUDGET_SEC = 180.0
+DISK_BUDGET_BYTES = 2 * 1024**3
+
+# From a setpoint write to that value being readable out of the archive. Covers
+# the recorder's own cadence plus one poll, not an arbitrary "should be quick".
+RECORDER_BUDGET_SEC = 30.0
+RECORDER_POLL_SEC = 2.0
+
+#: Budget for one `osprey health --category archiver` run. Generous next to the
+#: probe's own 10 s archiver query: the console script pays a cold interpreter
+#: and a full config load first, and this is a timeout, not a measurement.
+HEALTH_TIMEOUT_SEC = 120.0
+
+#: Canary channel the derived ``archiver_freshness`` check reads. Named here
+#: rather than picked from the deployed manifest the way the write test picks
+#: its setpoint, because it has to travel into the build's `--override` before
+#: any project exists to read a manifest from. The test asserts it really is a
+#: channel this machine model serves, so a model that drops it fails loudly
+#: instead of reporting a mystery "no samples in the window".
+FRESHNESS_CANARY = "SR:DIAG:DCCT:01:CURRENT:RB"
+
+# How far the document count may grow when an eventful scenario is applied.
+# One-sided on purpose: densification inserts a bounded number of samples inside
+# each event window, while a live TTL sweeper may retire aged tail samples in
+# the same interval, so a small net SHRINK is correct behavior. The failure this
+# guards is the whole-archive densification class, which multiplies the count
+# several-fold -- orders of magnitude outside this bound either way.
+APPLY_GROWTH_RATIO = 1.25
+
+# Share of a scenario's intended dense samples that may fall outside coverage.
+# See the assertion in the scenario-apply test for why this is not zero: a real
+# outage sits nowhere near 5%, while the archive's leading edge routinely does.
+UNCOVERED_FRACTION = 0.05
+
+# Channels are sampled per fidelity partition straight from the manifest's own
+# `partition` field, so the test needs no classification logic of its own and
+# cannot drift from how the manifest classifies.
+PARTITIONS = ("pyat-coupled", "sp-echo", "static-noisy")
+SEAM_SAMPLES_PER_PARTITION = 3
+
+# How far before the seed anchor the seam window starts. Only needs to be wide
+# enough to hold a few seeded samples at the hot cadence; the window's other end
+# is the newest sample, so the recorded side needs no allowance.
+SEAM_LEAD_TIME = timedelta(minutes=5)
+
+# `seeded 1,234 documents x 2,908 channels (... ) in 12.3s` -- the seeder's own
+# report line. Parsed rather than timing `deploy up` as a whole, which would
+# fold in a multi-minute image build and measure the wrong thing entirely.
+#
+# Matched against NORMALIZED output, never the raw capture. The deploy logs
+# through a rich console, which hard-wraps each message to the console width and
+# pads the continuation with the log gutter's spaces -- so this line arrives
+# split across two or three physical lines with ANSI colour codes through it.
+# A line-oriented regex silently finds nothing and reads as "the seed never ran".
+_SEED_REPORT_RE = re.compile(r"seeded ([\d,]+) documents x ([\d,]+) channels .* in ([\d.]+)s")
+_SEED_PROGRESS_RE = re.compile(r"seeding archive: [\d,]+ documents written")
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
+
+# The recorder announces each enablement transition with exactly one line, and
+# says nothing in steady state. Those two lines are the only direct evidence of
+# WHEN it noticed a config flip -- see `_await_recorder_transition` for why a
+# test about idling must wait for the announcement rather than assume a latency.
+#
+# Matched against NORMALIZED log output (see `_recorder_logs`), and kept to the
+# opening phrase of each message: rich wraps the rest across physical lines, and
+# a pattern reaching past the wrap would depend on the console width the
+# container happened to render at.
+_RECORDER_IDLE_RE = re.compile(r"Idle, writing nothing")
+_RECORDER_RECORDING_RE = re.compile(r"Recording \d+ channels every \d+s")
+
+
+def _normalize(text: str) -> str:
+    """Strip ANSI and fold every run of whitespace, so wrapped log lines rejoin."""
+    return re.sub(r"\s+", " ", _ANSI_RE.sub("", text))
+
+
+def _override_yaml() -> str:
+    """The ``--override`` content that opts this project into the stored archive.
+
+    Three decisions, each load-bearing:
+
+    ``va_archiver:`` declares the store — which injects the mongodb and
+    archiver_recorder services and renders the connector's connection keys.
+    Declaring it carries NO knob overrides on purpose: this lane owns the
+    measured budgets, and shrinking retention here would make them meaningless.
+    ``freshness_channel`` is not such a knob — it changes no size and no cadence,
+    it only names the canary the derived ``archiver_freshness`` health check
+    reads, and without it that check is never derived and cannot be proven here.
+
+    ``archiver.type`` must be set SEPARATELY. Declaring where an archive lives is
+    not the same decision as selecting it as the deployment's archiver, so
+    ``va_archiver_config_overrides`` deliberately leaves the type alone — a
+    project that only declared the block would deploy the store and then read the
+    mock, and every assertion here would pass against synthesized data while the
+    real store sat empty beside it.
+
+    ``deployed_services: []`` plus the nulled blocks trims the stack to exactly
+    the archiver world. Config overrides are applied BEFORE the build's service
+    injectors run, so emptying the list and letting the VA and archiver
+    injectors append leaves precisely ``[virtual_accelerator, mongodb,
+    archiver_recorder]`` — verified in the built config, not assumed.
+
+    That trim is not only about speed. The preset's full stack publishes
+    postgres, openobserve, the bluesky bridge, Tiled and the panels on fixed
+    host ports, and a developer box running any OSPREY demo stack already holds
+    them: the deploy then aborts on a port preflight that has nothing to do with
+    archiving. Deploying only what is under test makes this lane runnable
+    beside a live demo, and cuts several image builds out of a 45-minute cap.
+    """
+    return (
+        "config:\n"
+        "  control_system.type: virtual_accelerator\n"
+        "  archiver.type: mongodb_archiver\n"
+        "  modules.web_terminals.enabled: false\n"
+        "  deployed_services: []\n"
+        "va_archiver:\n"
+        f"  port_host: {MONGO_PORT_HOST}\n"
+        f"  freshness_channel: {FRESHNESS_CANARY}\n"
+        "bluesky: null\n"
+        "bluesky_panels: null\n"
+        "dispatch: null\n"
+    )
+
+
+def _build_project(output_dir: Path) -> Path:
+    """``osprey build`` the opt-in project, out of process.
+
+    Out of process (not ``CliRunner``) because the deploy that follows needs a
+    project on disk built by the same console script an operator would run.
+    """
+    from tests.e2e import _orm_stack
+
+    override_path = output_dir / "archiver-override.yml"
+    override_path.write_text(_override_yaml(), encoding="utf-8")
+    osprey_bin = _orm_stack.find_osprey_console_script()
+
+    result = subprocess.run(
+        [
+            str(osprey_bin),
+            "build",
+            PROJECT_NAME,
+            "--preset",
+            "control-assistant",
+            "--override",
+            str(override_path),
+            "--set",
+            f"virtual_accelerator.port={VA_CA_PORT}",
+            "--skip-deps",
+            "--skip-lifecycle",
+            "--output-dir",
+            str(output_dir),
+            "--force",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=BUILD_TIMEOUT_SEC,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"osprey build failed (rc={result.returncode}):\n"
+            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+        )
+    return output_dir / PROJECT_NAME
+
+
+class DeployedArchiverWorld:
+    """The deployed project, plus what the seed reported on its way up."""
+
+    def __init__(self, project_dir: Path, deploy_output: str):
+        self.project_dir = project_dir
+        self.deploy_output = deploy_output
+        self.config = _load_config(project_dir)
+
+    @property
+    def store(self) -> dict[str, Any]:
+        """Connection parameters, resolved exactly as the deploy resolves them."""
+        from osprey.simulation.apply import archiver_store_config
+
+        store = archiver_store_config(self.config, self.project_dir)
+        assert store is not None, "deployed project declares no mongodb_archiver block"
+        return store
+
+
+def _load_config(project_dir: Path) -> dict[str, Any]:
+    from osprey.utils.config import load_project_config
+
+    return load_project_config(str(project_dir / "config.yml"), wrap_errors=True)
+
+
+@pytest.fixture(scope="module")
+def archiver_world(tmp_path_factory: pytest.TempPathFactory) -> Iterator[DeployedArchiverWorld]:
+    """Build and deploy the opt-in project once for every assertion below."""
+    from osprey.deployment.compose_generator import resolve_project_name
+    from tests.e2e import _orm_stack
+    from tests.e2e._deploy_diagnostics import dead_container_logs
+
+    project = resolve_project_name({"project_name": PROJECT_NAME})
+    # The store's named volume, spelled EXACTLY — never a wildcard, never a
+    # prune, never `down --volumes` (which would reach every volume in the
+    # project). Derived from the compose project name so it cannot drift.
+    store_volume = f"{project}_archiver_mongodb_data"
+
+    def _dead_containers() -> str:
+        """Logs from every container of THIS deployment that is not running."""
+        return dead_container_logs(project)
+
+    def _discard_store_volume() -> None:
+        """Remove the store's volume so this run starts from a genuinely fresh one.
+
+        Not housekeeping — a correctness precondition. Every run mints a NEW
+        MONGO_ROOT_PASSWORD into its own temporary project, but the named volume
+        is per-compose-project and survives `deploy down`. A volume left by a
+        previous run therefore keeps the credentials it was initialized with, and
+        the next deploy is refused by its own store: exactly the stale-volume
+        case the deploy reports, arriving here as a self-inflicted one.
+
+        It also protects what this file measures. These tests assert a FIRST
+        deploy — a seed that runs, reports and is timed. Against a surviving
+        volume the fingerprint would MATCH, the seed would be skipped entirely,
+        and the budget assertions would have nothing to measure.
+        """
+        subprocess.run(["docker", "volume", "rm", "-f", store_volume], capture_output=True)
+
+    base = tmp_path_factory.mktemp("archiver_world_build")
+    project_dir = _build_project(base)
+
+    # The trim `_override_yaml` describes, checked in the BUILT config before
+    # anything is deployed rather than taken on trust. The essential members are
+    # pinned indirectly — a missing mongodb or recorder reds several tests below
+    # — but an EXTRA service is what this catches, and an extra service is the
+    # failure that costs an afternoon: it lands on a fixed host port a developer
+    # box is already holding and the deploy aborts on a preflight that has
+    # nothing to do with archiving.
+    built_services = sorted(_load_config(project_dir).get("deployed_services") or [])
+    assert built_services == ["archiver_recorder", "mongodb", "virtual_accelerator"], (
+        f"the built project deploys {built_services}, not the archiver world this lane "
+        "trims to; config overrides run BEFORE the service injectors, so an emptied "
+        "deployed_services plus the VA and archiver injectors must leave exactly these three"
+    )
+
+    osprey_bin = _orm_stack.find_osprey_console_script()
+
+    # Force a fresh --dev image so the deployed recorder runs CURRENT source.
+    # Exact-named image only. E2E_REUSE_IMAGES=1 skips it for fast local
+    # iteration on the test itself; never set it in CI.
+    if not os.environ.get("E2E_REUSE_IMAGES"):
+        subprocess.run(
+            ["docker", "rmi", "-f", _orm_stack.va_image(PROJECT_NAME)],
+            capture_output=True,
+            text=True,
+        )
+
+    # Before the deploy, not only after: a run that died without reaching its
+    # teardown (a killed session, a crashed fixture) leaves the volume behind,
+    # and the next run must not inherit it.
+    _discard_store_volume()
+
+    try:
+        up = subprocess.run(
+            [str(osprey_bin), "deploy", "up", "-d", "--dev"],
+            cwd=str(project_dir),
+            capture_output=True,
+            text=True,
+            timeout=DEPLOY_UP_TIMEOUT_SEC,
+            env={**os.environ, "CLAUDECODE": ""},
+        )
+        if up.returncode != 0:
+            pytest.fail(
+                f"osprey deploy up -d --dev failed (rc={up.returncode}):\n"
+                f"--- stdout ---\n{up.stdout}\n--- stderr ---\n{up.stderr}\n"
+                f"--- containers that are not running ---\n{_dead_containers()}"
+            )
+        yield DeployedArchiverWorld(project_dir, up.stdout + up.stderr)
+    finally:
+        down = subprocess.run(
+            [str(osprey_bin), "deploy", "down"],
+            cwd=str(project_dir),
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        _discard_store_volume()
+        if down.returncode != 0:
+            print(  # noqa: T201 - surface teardown issues in CI logs
+                f"osprey deploy down rc={down.returncode}\n{down.stdout}\n{down.stderr}"
+            )
+
+
+@pytest.fixture(autouse=True)
+def store_credential_in_env(archiver_world, monkeypatch):
+    """Export the store's password under the NAME the connector reads.
+
+    The connector takes the name of the variable holding the password, never the
+    password itself — the same indirection the rendered config uses, so a secret
+    never has to be spelled in a config file. Exporting it is what makes the
+    reads below the agent's real path rather than a special case.
+
+    Through ``monkeypatch`` rather than a bare ``os.environ`` write, and that is
+    not tidiness. A bare write outlives this module for the rest of the pytest
+    session, and ``_archiver_store_connection`` falls back to the ambient
+    environment whenever a project's ``.env`` carries no password — so a later
+    e2e bringing up its own store could authenticate against it with THIS
+    deployment's credential, and would report whatever that produced as its own
+    result.
+    """
+    store = archiver_world.store
+    monkeypatch.setenv(store["password_env"], store["password"])
+
+
+# ---------------------------------------------------------------------------
+# Store access helpers
+# ---------------------------------------------------------------------------
+
+
+def _collection(world: DeployedArchiverWorld):
+    from osprey.simulation.apply import archiver_collection
+
+    return archiver_collection(world.store)
+
+
+def _connector(world: DeployedArchiverWorld):
+    """A connected ``MongoDBArchiverConnector``, the agent's own read path.
+
+    Read through the connector rather than pymongo wherever the assertion is
+    about what a READER sees: the store holding a value and the connector
+    surfacing it are different claims, and only the second one is what an
+    operator experiences.
+    """
+    from osprey.connectors.archiver.mongodb_archiver_connector import MongoDBArchiverConnector
+
+    store = world.store
+    connector = MongoDBArchiverConnector()
+    asyncio.run(
+        connector.connect(
+            {
+                "host": store["host"],
+                "port": store["port"],
+                "name": store["database"],
+                "collection": store["collection"],
+                "auth": store["auth_database"],
+                "username": store["username"],
+                "password_env": store["password_env"],
+            }
+        )
+    )
+    return connector
+
+
+def _recorder_container() -> str:
+    """The recorder's container, spelled exactly and derived from the project name."""
+    from osprey.deployment.compose_generator import resolve_project_name
+
+    return f"{resolve_project_name({'project_name': PROJECT_NAME})}-archiver-recorder"
+
+
+def _recorder_logs(tail: str | None = None) -> str:
+    """The recorder's own log, by exact container name, NORMALIZED.
+
+    Normalized for the same reason the seed report above is: the service logs
+    through a rich console, which both hard-wraps each message and injects
+    colour codes INSIDE the text it highlights — ``control_system.type=`` leaves
+    the container with escape sequences sitting between the ``.`` and the
+    ``type``. A regex run over the raw capture therefore matches nothing, and
+    reads as "the recorder never said that", which is the most misleading answer
+    available here.
+    """
+    command = ["docker", "logs"]
+    if tail is not None:
+        command += ["--tail", tail]
+    logs = subprocess.run([*command, _recorder_container()], capture_output=True, text=True)
+    return _normalize(logs.stdout + logs.stderr)
+
+
+def _recorder_transitions(pattern: re.Pattern[str]) -> int:
+    """How many times the recorder has announced this state so far."""
+    return len(pattern.findall(_recorder_logs()))
+
+
+def _await_recorder_transition(
+    pattern: re.Pattern[str], baseline: int, timeout_sec: float, what: str
+) -> float:
+    """Block until the recorder announces ``what`` again, and report how long it took.
+
+    Waiting for the recorder's OWN announcement, rather than sleeping a fixed
+    multiple of the poll interval, is what makes the assertion that follows about
+    the behaviour under test instead of about propagation speed. The service
+    deliberately does not bound that speed at one poll: a poll landing mid-write
+    reads a torn config and keeps its previous answer until the next one (see
+    ``read_control_system_type``), so "two polls" is an assumption the product
+    never made, and a test resting on it fails on an unlucky interleaving while
+    reporting a recorder fault that did not happen.
+
+    A flip that never arrives still fails, and says which of the two it was.
+    """
+    started = time.monotonic()
+    deadline = started + timeout_sec
+    while True:
+        if _recorder_transitions(pattern) > baseline:
+            return time.monotonic() - started
+        assert time.monotonic() < deadline, (
+            f"the recorder never announced {what} within {timeout_sec:.0f}s of the "
+            f"control_system.type flip. It re-reads the mounted config on an interval, so "
+            f"this is the flip not reaching the container at all -- not a slow recorder.\n"
+            f"--- {_recorder_container()} logs ---\n{_recorder_logs(tail='40')}"
+        )
+        time.sleep(RECORDER_POLL_SEC)
+
+
+def _as_utc(moment: datetime) -> datetime:
+    """Pin the zone on a datetime pymongo may have handed back naive.
+
+    Read as UTC, which is what the store holds. Naive and aware values do not
+    compare, so a value that crosses into arithmetic with ``datetime.now(UTC)``
+    has to be pinned once, deliberately, rather than depending on which layer
+    happened to attach a zone.
+    """
+    return moment.replace(tzinfo=UTC) if moment.tzinfo is None else moment
+
+
+def _seed_anchor(world: DeployedArchiverWorld) -> datetime:
+    """The instant seeded history ends and recorded reality begins.
+
+    Read from the seed manifest the seeder writes into the store, so the seam
+    test can put its window ACROSS the seam rather than wherever the clock
+    happens to be when it runs.
+    """
+    from osprey.simulation.archiver_seed import MANIFEST_ID
+
+    with _collection(world) as collection:
+        manifest = collection.find_one({"_id": MANIFEST_ID})
+    assert manifest is not None, "the store holds no seed manifest, so there is no seam to locate"
+    anchor = manifest.get("seeded_at")
+    assert anchor is not None, "the seed manifest carries no seeded_at anchor"
+    return _as_utc(anchor)
+
+
+def _manifest_channels(world: DeployedArchiverWorld) -> list[dict[str, Any]]:
+    path = world.project_dir / "data" / "simulation" / "channel_manifest.json"
+    return json.loads(path.read_text(encoding="utf-8"))["channels"]
+
+
+def _sample_per_partition(world: DeployedArchiverWorld) -> dict[str, list[dict[str, Any]]]:
+    """A few channels from each fidelity partition, taken in manifest order.
+
+    Deterministic rather than random: a seam failure has to be reproducible from
+    the test name alone, and a random sample turns "this partition is broken"
+    into "this run was unlucky".
+    """
+    by_partition: dict[str, list[dict[str, Any]]] = {name: [] for name in PARTITIONS}
+    for channel in _manifest_channels(world):
+        bucket = by_partition.get(str(channel.get("partition")))
+        if bucket is not None and len(bucket) < SEAM_SAMPLES_PER_PARTITION:
+            bucket.append(channel)
+    return by_partition
+
+
+# ---------------------------------------------------------------------------
+# The seed: affordable in time, affordable on disk
+# ---------------------------------------------------------------------------
+
+
+def test_base_seed_completes_within_budget_and_reports_progress(archiver_world):
+    """A first deploy seeds inside the measured budget, and says so while it works.
+
+    The duration is the seeder's OWN reported elapsed time, not the wall time of
+    ``deploy up``: that call also builds an image, and folding a cold image cache
+    into an archive budget would measure the runner, not the feature.
+
+    Progress is asserted too, and is not cosmetic. A silent multi-minute step is
+    indistinguishable from a hang to the operator watching it, and the first
+    thing they do about a hang is kill it -- which leaves a half-seeded store.
+    """
+    output = _normalize(archiver_world.deploy_output)
+    report = _SEED_REPORT_RE.search(output)
+    assert report, (
+        "no seed report in `deploy up` output -- the staged bring-up did not seed.\n"
+        # The whole capture, not a tail slice: the seed happens EARLY in the
+        # deploy and the compose build that follows is far longer, so a tail
+        # would cut away exactly the evidence this assertion is about.
+        f"--- normalized output ---\n{output}"
+    )
+
+    documents = int(report.group(1).replace(",", ""))
+    channels = int(report.group(2).replace(",", ""))
+    elapsed_s = float(report.group(3))
+
+    assert documents > 0, "seed reported zero documents"
+    assert channels > 0, "seed reported zero channels"
+    assert elapsed_s <= SEED_BUDGET_SEC, (
+        f"base seed took {elapsed_s:.1f}s at default knobs, over the "
+        f"{SEED_BUDGET_SEC:.0f}s budget this lane owns "
+        f"({documents:,} documents x {channels:,} channels)"
+    )
+    assert _SEED_PROGRESS_RE.search(output), (
+        "seed emitted no progress lines; a silent multi-minute step reads as a hang"
+    )
+    print(  # noqa: T201
+        f"\nMEASURED base seed: {elapsed_s:.1f}s of the {SEED_BUDGET_SEC:.0f}s budget "
+        f"({documents:,} documents x {channels:,} channels)"
+    )
+
+
+def test_seeded_archive_fits_the_disk_budget_with_the_declared_compressor(archiver_world):
+    """Size and codec together, because the budget only holds if the codec did.
+
+    A store that fits because it is half-empty and a store that fits because zstd
+    did its job look identical on the size assertion alone. Reading the
+    compressor mongod actually used is what separates them -- and it is a SERVER
+    start flag, so getting it wrong is a compose-template regression no unit test
+    of the seeder could catch.
+    """
+    with _collection(archiver_world) as collection:
+        stats = collection.database.command("collStats", collection.name)
+        documents = collection.count_documents({})
+
+    on_disk = int(stats.get("storageSize", 0)) + int(stats.get("totalIndexSize", 0))
+    assert documents > 0, "store is empty -- nothing was seeded"
+    assert on_disk <= DISK_BUDGET_BYTES, (
+        f"stored archive is {on_disk / 1024**3:.2f} GiB at default knobs, over the "
+        f"{DISK_BUDGET_BYTES / 1024**3:.0f} GiB budget this lane owns"
+    )
+
+    block_compressor = (
+        stats.get("wiredTiger", {}).get("creationString", "")
+        if isinstance(stats.get("wiredTiger"), dict)
+        else ""
+    )
+    assert "block_compressor=zstd" in block_compressor, (
+        "the collection was not created with the compressor the compose template "
+        f"declares; wiredTiger creationString reports: {block_compressor[:200]!r}"
+    )
+    print(  # noqa: T201
+        f"\nMEASURED store size: {on_disk / 1024**3:.2f} GiB of the "
+        f"{DISK_BUDGET_BYTES / 1024**3:.0f} GiB budget "
+        f"({documents:,} documents, block_compressor=zstd)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The live half reaching the stored half
+# ---------------------------------------------------------------------------
+
+
+def test_written_setpoint_appears_in_the_archive_within_the_recorder_budget(
+    archiver_world, monkeypatch
+):
+    """Write to the machine, then read it back out of history.
+
+    This is the claim the recorder exists for, and nothing short of a deployed
+    stack can make it: the value has to cross the control system into the VA, be
+    sampled by the recorder over channel access, land in the store, and come back
+    through the connector the agent reads with.
+    """
+    from osprey.connectors.factory import ConnectorFactory, register_builtin_connectors
+    from osprey.utils import config as config_module
+
+    # Writes are fail-closed, and the guard does NOT consult the config handed to
+    # the connector: `_writes_enabled` re-reads `control_system.writes_enabled`
+    # from the GLOBAL config every time (see
+    # osprey.connectors.control_system.base), which resolves from CONFIG_FILE or
+    # the working directory. Pytest runs from the repo root, which has no
+    # config.yml, so without this the guard fails closed and the write is
+    # refused — and the test then blames the recorder for a value that was never
+    # written. Arming it means pointing the guard at the DEPLOYED project, whose
+    # config.yml already declares the posture; the singletons are reset so the
+    # new CONFIG_FILE is the one that gets loaded. `monkeypatch` restores all
+    # three, and the autouse fixture in conftest clears them again after.
+    monkeypatch.setenv("CONFIG_FILE", str(archiver_world.project_dir / "config.yml"))
+    monkeypatch.setattr(config_module, "_default_config", None)
+    monkeypatch.setattr(config_module, "_default_configurable", None)
+
+    limits = json.loads(
+        (archiver_world.project_dir / "data" / "channel_limits.json").read_text(encoding="utf-8")
+    )
+    setpoint = next(name for name in sorted(limits) if name.endswith(":SP"))
+
+    async def _write_a_new_setpoint() -> tuple[float, datetime, Any]:
+        register_builtin_connectors()  # idempotent; must run before create
+        control_system = await ConnectorFactory.create_control_system_connector(
+            archiver_world.config["control_system"]
+        )
+        current = await control_system.read_channel(setpoint)
+        target = float(current.value) + 0.05
+        written_at = datetime.now(UTC)
+        result = await control_system.write_channel(setpoint, target)
+        return target, written_at, result
+
+    target, written_at, write_result = asyncio.run(_write_a_new_setpoint())
+    assert getattr(write_result, "success", True), (
+        f"the write to {setpoint} was refused, so nothing downstream could archive it: "
+        f"{getattr(write_result, 'error', write_result)}"
+    )
+
+    connector = _connector(archiver_world)
+    started = time.monotonic()
+    deadline = started + RECORDER_BUDGET_SEC
+    seen: list[float] = []
+    while True:
+        frame = asyncio.run(
+            connector.get_data([setpoint], written_at - timedelta(seconds=5), datetime.now(UTC))
+        )
+        seen = [float(v) for v in frame["value"]] if len(frame) else []
+        if any(abs(value - target) < 1e-6 for value in seen):
+            print(  # noqa: T201
+                f"\nMEASURED write->read: {time.monotonic() - started:.1f}s of the "
+                f"{RECORDER_BUDGET_SEC:.0f}s budget ({setpoint} = {target})"
+            )
+            return
+        assert time.monotonic() < deadline, (
+            f"{setpoint} was set to {target} but no archived sample carried it within "
+            f"{RECORDER_BUDGET_SEC:.0f}s; the archive held {seen[-5:]}"
+        )
+        time.sleep(RECORDER_POLL_SEC)
+
+
+def test_a_window_before_coverage_is_reported_as_empty_not_invented(archiver_world):
+    """The honesty claim, stated twice: no points, and a truthful start.
+
+    An archiver that answers a pre-archival question with synthesized values is
+    the exact failure this whole feature exists to remove -- the agent cannot
+    tell invented history from recorded history, and neither can the operator
+    reading its conclusion.
+    """
+    connector = _connector(archiver_world)
+    channel = str(_manifest_channels(archiver_world)[0]["address"])
+
+    metadata = asyncio.run(connector.get_metadata(channel))
+    assert metadata.archival_start is not None, "get_metadata reported no archival_start"
+
+    # pymongo hands back naive datetimes read as UTC; the arithmetic below mixes
+    # them with aware ones, so pin the zone rather than letting it depend on
+    # which layer happened to attach it.
+    archival_start = metadata.archival_start
+    if archival_start.tzinfo is None:
+        archival_start = archival_start.replace(tzinfo=UTC)
+
+    before = archival_start - timedelta(days=2)
+    frame = asyncio.run(connector.get_data([channel], before, archival_start - timedelta(hours=1)))
+    assert len(frame) == 0, (
+        f"a window entirely before coverage began returned {len(frame)} points for "
+        f"{channel}; the archive must report what it does not have, not fill it in"
+    )
+
+    with _collection(archiver_world) as collection:
+        from osprey.simulation.archiver_seed import oldest_sample
+
+        actual_oldest = oldest_sample(collection)
+    assert actual_oldest is not None
+    # Reported coverage is the oldest sample really held, not a declared window.
+    assert abs((archival_start - actual_oldest).total_seconds()) < 1.0
+
+
+# ---------------------------------------------------------------------------
+# The seam
+# ---------------------------------------------------------------------------
+
+
+def test_seam_between_seeded_and_recorded_history_is_within_the_noise_band(archiver_world):
+    """Across all three fidelity partitions, the seam is attributable to noise.
+
+    Seeded history ends at the seed anchor and recorded reality begins there. If
+    the two halves were generated from different baselines -- a different epoch
+    convention, a different boot value, a retuned generator -- the step at that
+    instant is a discontinuity no operator could read as anything but an event
+    that never happened.
+
+    The threshold is quoted per channel from ``deviation_bound`` and its own
+    default headroom, never a constant written here: a band embedded in this file
+    would keep passing after a generator retune it no longer describes.
+    """
+    # The bound is only meaningful if both halves were generated with the same
+    # noise level. The two constants are duplicated deliberately (osprey.simulation
+    # must stay importable without the VA service package), so nothing structural
+    # stops them drifting -- and a drift would widen this tolerance silently
+    # instead of failing. Retuning either side must red THIS lane.
+    from osprey.services.virtual_accelerator.ioc.engine_source import (
+        DEFAULT_NOISE_LEVEL as VA_NOISE_LEVEL,
+    )
+
+    assert DEFAULT_NOISE_LEVEL == VA_NOISE_LEVEL, (
+        "the simulation and VA noise levels have drifted "
+        f"({DEFAULT_NOISE_LEVEL} vs {VA_NOISE_LEVEL}); the seam bound below describes "
+        "the seeded half only, so it would pass against a mismatched recorded half"
+    )
+
+    connector = _connector(archiver_world)
+    sampled = _sample_per_partition(archiver_world)
+    # The window is anchored on the SEAM, not on the clock. Ending it at
+    # `archival_end` and reaching back a fixed span looked equivalent and is
+    # not: everything before the anchor is seeded and everything after it is
+    # recorded, so once more than that span separates the seed from this test --
+    # a cold image cache is enough, and CI has a 45-minute allowance -- the
+    # window holds recorded samples only. The step assertion then passes without
+    # a seam anywhere near it, which is the vacuous green this lane exists to
+    # refuse.
+    anchor = _seed_anchor(archiver_world)
+    for partition in PARTITIONS:
+        channels = sampled[partition]
+        assert channels, f"no channels found in the {partition!r} partition"
+        for channel in channels:
+            address = str(channel["address"])
+            metadata = asyncio.run(connector.get_metadata(address))
+            if metadata.archival_end is None:
+                pytest.fail(f"{address} ({partition}) holds no samples at all")
+
+            archival_end = _as_utc(metadata.archival_end)
+            assert archival_end >= anchor, (
+                f"{address} ({partition}) holds nothing at or after the seed anchor, so "
+                "this window covers seeded history only and crosses no seam"
+            )
+            frame = asyncio.run(
+                connector.get_data([address], anchor - SEAM_LEAD_TIME, archival_end)
+            )
+            values = [float(v) for v in frame["value"]] if len(frame) else []
+            if len(values) < 2:
+                continue  # a channel with one sample in the window has no seam to cross
+
+            step = max(abs(b - a) for a, b in zip(values, values[1:], strict=False))
+            bound = deviation_bound(address)
+            assert step <= 2 * bound, (
+                f"{address} ({partition}) steps by {step:.6g} across the seed/record "
+                f"seam, beyond the {2 * bound:.6g} the generator's own noise band allows"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Scenario apply, and the recorder's enablement
+# ---------------------------------------------------------------------------
+
+
+def test_applying_a_scenario_rewrites_windows_not_the_whole_archive(archiver_world):
+    """Bounded growth, and full coverage — the two halves of "windows, not archive".
+
+    Growth is one-sided: densification adds a bounded number of samples inside
+    each event window, while the live TTL sweeper may retire aged tail samples in
+    the same interval, so a small net shrink is correct. The failure guarded here
+    multiplies the count several-fold, which is nowhere near either edge.
+
+    ``uncovered`` is the free half of the assertion: it counts grid points the
+    rewrite wanted but the store does not hold. On a healthy fresh deploy that is
+    zero, and anything else means the archive has holes where the scenario
+    expected history -- the recorder-outage class, which no count ratio would
+    catch on its own.
+    """
+    from osprey.simulation.apply import apply_scenarios
+
+    with _collection(archiver_world) as collection:
+        before = collection.count_documents({})
+
+    result = apply_scenarios(archiver_world.project_dir, ["vacuum-burst"], seed_logbook=False)
+
+    with _collection(archiver_world) as collection:
+        after = collection.count_documents({})
+
+    assert result.archiver is not None, "apply reported no archive rewrite at all"
+    assert result.archiver.skipped is None, (
+        f"the archive rewrite was skipped: {result.archiver.skipped}"
+    )
+    # `uncovered` counts grid points the rewrite wanted but the store does not
+    # hold. It is deliberately NOT asserted to be zero, and tightening it back to
+    # zero would reintroduce a flake that only shows up on the wrong clock:
+    #
+    # `vacuum-burst` fires at a fixed time of day, so its window recurs once per
+    # retained day. The archive ends at the seed anchor — the moment `deploy up`
+    # ran — so whenever the most recent occurrence falls AFTER that anchor, part
+    # of its window lies past the end of coverage and cannot be densified. The
+    # seeder refusing to manufacture coverage there is the honest behavior this
+    # whole feature exists for. `== 0` would therefore be green only when the
+    # lane happens to run after that time of day, and CI runs at arbitrary hours.
+    #
+    # So the bound is "at most one occurrence's worth may be missing", derived
+    # from this run's own numbers and the retention knob rather than a constant:
+    # a daily event over N retained days contributes roughly (total / N) samples
+    # per occurrence. That tolerates exactly the boundary-straddling occurrence
+    # above, while a recorder outage or a hole mid-archive leaves many
+    # occurrences uncovered and trips it by a wide margin.
+    intended = result.archiver.inserted + result.archiver.uncovered
+    allowed = UNCOVERED_FRACTION * intended
+    assert result.archiver.uncovered <= allowed, (
+        f"{result.archiver.uncovered} of {intended} grid points the scenario needed are "
+        f"missing from the store — past the {allowed:.0f} a single boundary-straddling "
+        "occurrence can account for. That is a coverage hole, not the archive's leading edge."
+    )
+    assert after <= before * APPLY_GROWTH_RATIO, (
+        f"applying one scenario grew the archive from {before:,} to {after:,} documents "
+        f"({after / before:.2f}x), past the {APPLY_GROWTH_RATIO}x a windowed rewrite "
+        "should ever need -- this is the whole-archive densification signature"
+    )
+    print(  # noqa: T201
+        f"\nMEASURED apply growth: {before:,} -> {after:,} documents "
+        f"({after / before:.3f}x of the {APPLY_GROWTH_RATIO}x bound); "
+        f"{result.archiver.uncovered} of {intended:,} grid points uncovered "
+        f"(bound {allowed:.0f})"
+    )
+
+
+def test_health_reports_the_archive_fresh_while_the_recorder_writes(archiver_world):
+    """``osprey health`` is where an operator asks whether history is still real.
+
+    Everything above proves the archive from the inside — the collection, the
+    connector, the recorder's own logs. This proves the one surface an operator
+    actually looks at, through the console script they would type, against the
+    check nobody declared by hand: the ``va_archiver:`` block named a canary
+    channel, and the build derived the category, the probe type and a staleness
+    threshold from the recorder's cadence.
+
+    A reachable store and a written store are different claims, and this is the
+    check that tells them apart — so it earns its place on a deployed stack in a
+    way no mocked connector could.
+    """
+    from tests.e2e import _orm_stack
+
+    limits = json.loads(
+        (archiver_world.project_dir / "data" / "channel_limits.json").read_text(encoding="utf-8")
+    )
+    assert FRESHNESS_CANARY in limits, (
+        f"{FRESHNESS_CANARY} is not a channel this machine model serves, so the derived "
+        f"freshness check would report 'no samples' for a reason that has nothing to do "
+        f"with the recorder. Pick a canary from the model and update FRESHNESS_CANARY."
+    )
+
+    store = archiver_world.store
+    env = {
+        **os.environ,
+        "CONFIG_FILE": str(archiver_world.project_dir / "config.yml"),
+        store["password_env"]: store["password"],
+    }
+    result = subprocess.run(
+        [
+            str(_orm_stack.find_osprey_console_script()),
+            "health",
+            "--category",
+            "archiver",
+            "--json",
+        ],
+        cwd=str(archiver_world.project_dir),
+        capture_output=True,
+        text=True,
+        timeout=HEALTH_TIMEOUT_SEC,
+        env=env,
+    )
+    assert result.stdout.strip(), (
+        f"`osprey health --category archiver --json` printed nothing "
+        f"(rc={result.returncode}):\n--- stderr ---\n{result.stderr}"
+    )
+    report = json.loads(result.stdout)
+
+    rows = [
+        row
+        for row in _health_rows(report)
+        if row.get("name") == "archiver_freshness" or row.get("category") == "archiver_freshness"
+    ]
+    assert rows, (
+        "the derived archiver_freshness check did not run. The build should have written "
+        "health.categories.archiver.checks from the va_archiver block's freshness_channel:\n"
+        f"{json.dumps(report, indent=2)[:2000]}"
+    )
+    (row,) = rows
+    assert row.get("status") == "ok", (
+        f"the archive is deployed and the recorder is running, so the newest sample for "
+        f"{FRESHNESS_CANARY} should be inside the derived threshold. Got "
+        f"{row.get('status')!r}: {row.get('message')!r}"
+    )
+
+
+def _health_rows(report: Any) -> list[dict[str, Any]]:
+    """Every check row in a ``--json`` health report, whatever it nests them under.
+
+    Written tolerantly on purpose: this lane is about the archive, and pinning
+    the report's exact envelope here would make an unrelated reshaping of the
+    health JSON fail as an archiver regression.
+    """
+    if isinstance(report, list):
+        rows = report
+    else:
+        rows = report.get("checks") or report.get("results") or []
+        if not rows:
+            for category in (report.get("categories") or {}).values():
+                if isinstance(category, dict):
+                    rows.extend(category.get("checks") or [])
+                elif isinstance(category, list):
+                    rows.extend(category)
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def test_recorder_idles_on_mock_control_system_and_resumes_after_the_flip(archiver_world):
+    """The recorder records a virtual accelerator, and nothing else.
+
+    Recording whatever the control system happens to be would put synthesized
+    mock values into a store the agent reads as machine history. The enablement
+    is re-read on an interval rather than at startup precisely so this flip needs
+    no redeploy -- which is what this test exercises, by flipping the mounted
+    config and waiting rather than restarting anything.
+    """
+    from ruamel.yaml import YAML
+
+    config_path = archiver_world.project_dir / "config.yml"
+    yaml = YAML()
+    yaml.preserve_quotes = True
+
+    def _set_control_system(kind: str) -> None:
+        with open(config_path) as handle:
+            config = yaml.load(handle)
+        config["control_system"]["type"] = kind
+        with open(config_path, "w") as handle:
+            yaml.dump(config, handle)
+
+    poll_sec = int((archiver_world.config.get("va_archiver") or {}).get("recorder_poll_sec", 30))
+    # The window each claim is measured over, once the recorder has SAID which
+    # state it is in. Several sample cadences wide, so a single write the
+    # recorder should not have made still shows up.
+    settle = poll_sec * 2 + 10
+    # How long the announcement itself may take. Not `poll_sec`: propagation is
+    # bounded by several polls, not one -- see `_await_recorder_transition`.
+    announce_timeout = poll_sec * 4 + 30
+
+    idle_baseline = _recorder_transitions(_RECORDER_IDLE_RE)
+    recording_baseline = _recorder_transitions(_RECORDER_RECORDING_RE)
+
+    _set_control_system("mock")
+    try:
+        noticed = _await_recorder_transition(
+            _RECORDER_IDLE_RE, idle_baseline, announce_timeout, "idle"
+        )
+        # Counted by SAMPLE INSTANT, not as a change in the collection total.
+        # The store's TTL monitor is live here, so the total moves on its own:
+        # a difference of two totals mixes the recorder's writes with the
+        # sweeper's deletions, and the sweeper is the larger term. That cuts
+        # both ways -- a recorder wrongly writing during idle is masked whenever
+        # the sweep is bigger, and a recorder correctly resuming is masked the
+        # same way, which is exactly what made the resume half flaky. Every
+        # instant after `watch_from` is one nothing else could have written, so
+        # this asks the precise question: did the recorder write, at all?
+        watch_from = datetime.now(UTC)
+        time.sleep(settle)
+        with _collection(archiver_world) as collection:
+            while_idle = collection.count_documents({"date": {"$gt": watch_from}})
+        assert while_idle == 0, (
+            f"{while_idle} samples were archived in the {settle:.0f}s after the recorder "
+            "announced it was idling on control_system.type='mock'; it must idle rather "
+            "than archive synthesized mock values"
+        )
+        idle_report = (
+            f"idle announced {noticed:.0f}s after the config flip; "
+            f"{while_idle} samples archived in the {settle:.0f}s that followed"
+        )
+    finally:
+        _set_control_system("virtual_accelerator")
+
+    resumed = _await_recorder_transition(
+        _RECORDER_RECORDING_RE, recording_baseline, announce_timeout, "recording"
+    )
+    watch_from = datetime.now(UTC)
+    time.sleep(settle)
+    with _collection(archiver_world) as collection:
+        after_resume = collection.count_documents({"date": {"$gt": watch_from}})
+    assert after_resume > 0, (
+        "the recorder announced it was recording again after control_system.type returned "
+        f"to 'virtual_accelerator', but archived no sample in the {settle:.0f}s that followed"
+    )
+    print(  # noqa: T201
+        f"\nMEASURED recorder flip: {idle_report}; recording announced {resumed:.0f}s "
+        f"after the flip back, {after_resume} samples archived in the {settle:.0f}s after that"
+    )

--- a/tests/e2e/test_bluesky_queue_e2e.py
+++ b/tests/e2e/test_bluesky_queue_e2e.py
@@ -517,7 +517,7 @@ def _wait_for_manager_state(wanted: tuple[str, ...], timeout: float) -> str:
 
 
 def _override_yaml() -> str:
-    """Host-hygiene overrides ONLY -- never ``control_system.type``.
+    """Host hygiene and CI sizing ONLY -- never ``control_system.type``.
 
     ``dispatch: null`` drops the event-dispatcher stack (Node + Claude CLI
     image) and ``modules.web_terminals.enabled: false`` drops the per-persona
@@ -526,6 +526,16 @@ def _override_yaml() -> str:
     move ariel-postgres and OpenObserve -- services the preset deploys
     unconditionally, with no profile knob -- off 5432/5080, which a locally
     running tutorial deploy routinely holds.
+
+    ``_orm_stack.VA_ARCHIVER_CI_KNOBS`` shrinks the archive the preset's
+    ``va_archiver:`` block declares (see the constant). It is a sizing override,
+    not a behavioral one: the store and its recorder still deploy, still record,
+    and still hold both tiers -- there is just far less seeded history to write
+    first, none of which this proof reads. Nothing here touches what the stack
+    IS, which is the property the docstring above is about: this module inherits
+    ``control_system.type`` from the preset on purpose, so that a preset that
+    stopped defaulting to the virtual accelerator would fail these stages rather
+    than be papered over here.
 
     Written as flat dotted-string keys under ``config:`` (the preset's own
     convention): a ``--set`` would build a NESTED dict for every dotted segment
@@ -536,7 +546,7 @@ def _override_yaml() -> str:
         "config:\n"
         f"  services.postgresql.port_host: {POSTGRES_PORT}\n"
         f"  services.openobserve.port: {OPENOBSERVE_PORT}\n"
-        "  modules.web_terminals.enabled: false\n"
+        "  modules.web_terminals.enabled: false\n" + _orm_stack.VA_ARCHIVER_CI_KNOBS
     )
 
 

--- a/tests/e2e/test_claude_code_build_integration.py
+++ b/tests/e2e/test_claude_code_build_integration.py
@@ -95,7 +95,10 @@ def init_project(
     for rationale. The connector is pinned to ``mock`` for the same reason
     that helper pins it: this harness runs projects without their containers,
     and the preset's ``virtual_accelerator`` default needs the deployed VA to
-    answer Channel Access.
+    answer Channel Access. The archiver is pinned for that same reason and by
+    the same means — the preset reads a MongoDB store this harness never
+    deploys — and the override file, rather than ``--set``, is what the
+    preset's dotted ``archiver.type`` spelling requires.
     """
     runner = CliRunner()
     args = [
@@ -113,6 +116,9 @@ def init_project(
         "--set",
         "connector=mock",
     ]
+    archiver_override = tmp_path / "_archiver-pin.yml"
+    archiver_override.write_text("config:\n  archiver.type: mock_archiver\n", encoding="utf-8")
+    args.extend(["-O", str(archiver_override)])
     result = runner.invoke(build, args)
     assert result.exit_code == 0, f"osprey build failed: {result.output}"
     project_dir = tmp_path / name

--- a/tests/e2e/test_rf_cavity_correlation_scenario.py
+++ b/tests/e2e/test_rf_cavity_correlation_scenario.py
@@ -20,9 +20,15 @@ carries these as *relative* timestamps (``when: {days_ago, time}``); applying
 the scenario resolves them against one apply-time anchor (newest entry lands
 two days before today) and seeds them into ARIEL. The telemetry ground truth
 lives in the same bundle (``data/simulation/scenarios/rf-thermal/``): the three
-CAVITY01 thermal excursions are declared at normalized window fractions (0.20,
-0.55, 0.85), so they appear at those relative positions in any window the agent
-chooses and the test stays date-agnostic. The test activates the scenario after
+CAVITY01 thermal excursions are anchored to that same apply-time T0 via
+``at_offset`` — T0-38h, T0-21h and T0-7h, each a 2h-sigma spike. They therefore
+sit at fixed wall-clock times rather than at a fixed proportion of whatever
+window the agent asks for, which is what makes them storable in a real archiver;
+because the anchor is set when the scenario is applied, the test stays
+date-agnostic all the same. Two consequences for the agent's search: the most
+recent excursion falls a few hours back, so the prompt's "this morning" points
+at real data, and a lookback shorter than about two days will not show all three
+excursions. The test activates the scenario after
 building the project via ``activate_scenarios(project, "rf-thermal")``, which
 also purges + reseeds the logbook so narrative and telemetry share one clock;
 the mock connectors then route RF cavity / klystron / DCCT reads through the
@@ -137,9 +143,10 @@ async def test_rf_cavity01_correlation_flow(tmp_path: Path) -> None:
         tier=3,
     )
     # Switch the mock connectors' data substrate to the ``rf-thermal`` scenario
-    # bundle — the CAVITY01 thermal excursions at window fractions 0.20/0.55/0.85 —
-    # and seed its DEMO-026/027/028 incident arc into ARIEL (purge + reseed) so
-    # logbook and telemetry share one apply-time clock.
+    # bundle — the CAVITY01 thermal excursions anchored at T0-38h/-21h/-7h — and
+    # seed its DEMO-026/027/028 incident arc into ARIEL (purge + reseed) so
+    # logbook and telemetry share one apply-time clock. T0 is set here, so the
+    # newest excursion is a few hours old by the time the agent looks.
     activate_scenarios(project, "rf-thermal")
     cf_server = _channel_finder_server_name(project)
     if cf_server is None:
@@ -216,9 +223,11 @@ async def test_rf_cavity01_correlation_flow(tmp_path: Path) -> None:
 
     # --- Diagnostic conclusion -------------------------------------------------
     # The logbook unambiguously names CAVITY01 (DEMO-026/027/028) and the
-    # archiver data unambiguously shows three thermal excursions on CAVITY01
-    # with CAVITY02 stable for contrast. The agent must commit to CAVITY01 and
-    # connect the thermal excursions to the beam dumps.
+    # archiver data unambiguously shows thermal excursions on CAVITY01 with
+    # CAVITY02 stable for contrast — one of them within hours of the reported
+    # dump, so even a short lookback lands on the evidence, and all three appear
+    # once the agent widens to a couple of days. The agent must commit to
+    # CAVITY01 and connect the thermal excursions to the beam dumps.
     eval = await judge.evaluate(
         _to_workflow_result(query, result),
         expectations=(

--- a/tests/e2e/test_va_substrate_equivalence.py
+++ b/tests/e2e/test_va_substrate_equivalence.py
@@ -70,7 +70,7 @@ from typing import Any
 import pytest
 
 from osprey.deployment.compose_generator import resolve_project_name
-from tests.e2e import _queue_drive
+from tests.e2e import _orm_stack, _queue_drive
 from tests.e2e._deploy_diagnostics import dead_container_logs
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -304,12 +304,16 @@ def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Deploye
     # auto-render both persona projects, build two web images, and start
     # nginx/web containers -- none of which this substrate-equivalence proof
     # exercises (that topology is covered by test_control_assistant_demo.py).
+    # `_orm_stack.VA_ARCHIVER_CI_KNOBS` shrinks the archive the preset declares
+    # to a CI-sized one -- this proof deploys the store (the preset's
+    # `va_archiver:` block is what makes the VA's history real) but reads none
+    # of its history, and seeding a tutorial-sized month costs every run.
     override_path = base / "override.yml"
     override_path.write_text(
         "config:\n"
         "  control_system.type: virtual_accelerator\n"
         "  modules.web_terminals.enabled: false\n"
-        "dispatch: null\n",
+        "dispatch: null\n" + _orm_stack.VA_ARCHIVER_CI_KNOBS,
         encoding="utf-8",
     )
 

--- a/tests/integration/test_data_checksum_stability.py
+++ b/tests/integration/test_data_checksum_stability.py
@@ -104,7 +104,15 @@ class TestRuntimeWriters:
     ) -> None:
         from osprey.simulation.apply import apply_scenarios
 
-        apply_scenarios(built_project, ["vacuum-burst"], seed_logbook=False)
+        # Both side-seedings are off for the same reason: each one reaches a
+        # service this test does not run and is not about. `seed_logbook` wants
+        # ARIEL's Postgres; `seed_archive` wants the MongoDB store the
+        # control-assistant preset now declares, and refuses outright without
+        # the password `osprey deploy up` mints -- correctly, since a rewrite it
+        # cannot perform would leave the archive contradicting the scenario.
+        # What is under test here is where the ACTIVATION writes: the state file
+        # belongs in `_agent_data/`, never in the build-owned `data/` tree.
+        apply_scenarios(built_project, ["vacuum-burst"], seed_logbook=False, seed_archive=False)
 
         state_file = built_project / "_agent_data" / "simulation" / "active_scenarios"
         assert "vacuum-burst" in state_file.read_text(encoding="utf-8")
@@ -194,7 +202,10 @@ class TestTheInstrumentHasTeeth:
         (project / "config.yml").write_text(yaml.safe_dump(config), encoding="utf-8")
         before = _data_checksums(project)
 
-        apply_scenarios(project, ["vacuum-burst"], seed_logbook=False)
+        # Same two opt-outs as the positive case above, for the same reason —
+        # this negative control is about where the state file lands, not about
+        # ARIEL or the archive.
+        apply_scenarios(project, ["vacuum-burst"], seed_logbook=False, seed_archive=False)
 
         assert (project / "data" / "simulation" / "active_scenarios").exists()
         assert _data_checksums(project) != before

--- a/tests/mcp_server/test_control_system_context.py
+++ b/tests/mcp_server/test_control_system_context.py
@@ -1,7 +1,8 @@
 """Tests for the MCP Server Registry.
 
 Covers: initialization, singleton access, connector caching, invalidation,
-config validation warnings, shutdown, channel_finder_config, and dot-path access.
+config validation warnings, the one config the server refuses to start on,
+shutdown, channel_finder_config, and dot-path access.
 """
 
 import logging
@@ -10,6 +11,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 import yaml
 
+from osprey.errors import ConfigurationError
 from osprey.mcp_server.control_system.server_context import (
     ControlSystemContext,
     get_server_context,
@@ -402,3 +404,129 @@ async def test_unknown_connector_raises(tmp_path, monkeypatch):
 
     with pytest.raises(ValueError, match="Unknown connector"):
         await registry._get_connector("nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# The honesty rule at runtime: the server refuses to serve invented history
+# ---------------------------------------------------------------------------
+
+_VA_MOCK_NESTED = {
+    "control_system": {"type": "virtual_accelerator", "writes_enabled": False},
+    "archiver": {"type": "mock_archiver"},
+}
+_VA_UNSET_ARCHIVER = {"control_system": {"type": "virtual_accelerator"}}
+
+# A hand-edited config.yml can carry a top-level dotted line that LOOKS like it
+# sets the key. MCPServerConfig reads nested sections only (raw.get("archiver")),
+# and the factory then sees no type and falls back to the mock -- so each of
+# these runs a VA against invented history while appearing configured.
+_FLAT_ARCHIVER_OVER_NESTED_MOCK = _VA_MOCK_NESTED | {"archiver.type": "mongodb_archiver"}
+_FLAT_ARCHIVER_ONLY = _VA_UNSET_ARCHIVER | {"archiver.type": "mongodb_archiver"}
+_FLAT_CONTROL_SYSTEM_OVER_NESTED_VA = _VA_MOCK_NESTED | {"control_system.type": "mock"}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param(_VA_MOCK_NESTED, id="nested-mock"),
+        pytest.param(_VA_UNSET_ARCHIVER, id="archiver-unset"),
+        pytest.param(_FLAT_ARCHIVER_OVER_NESTED_MOCK, id="inert-flat-archiver-over-mock"),
+        pytest.param(_FLAT_ARCHIVER_ONLY, id="inert-flat-archiver-only"),
+        pytest.param(_FLAT_CONTROL_SYSTEM_OVER_NESTED_VA, id="inert-flat-control-system"),
+    ],
+)
+def test_a_virtual_accelerator_with_invented_history_refuses_to_start(
+    tmp_path, monkeypatch, config
+):
+    """Every tool in this server would answer, and the archiver's answers would
+    be invented -- a failure no single call can show. So the server does not
+    start: whether the mock is named or fallen back to, and whether or not an
+    inert top-level dotted line makes the file look configured.
+    """
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, config)
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        initialize_server_context()
+
+    assert "virtual_accelerator" in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_the_refusal_explains_an_inert_flat_line_rather_than_calling_it_unset(
+    tmp_path, monkeypatch
+):
+    """Someone who typed `archiver.type: mongodb_archiver` at the top level is
+    owed better than "unset" -- the reason it did nothing IS the fix."""
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, _FLAT_ARCHIVER_ONLY)
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        initialize_server_context()
+    message = str(excinfo.value)
+
+    assert "configures nothing" in message
+    assert "nested sections" in message
+
+
+@pytest.mark.unit
+def test_a_flat_only_control_system_is_a_mock_deployment_not_a_refusal(tmp_path, monkeypatch):
+    """The mirror of the rule. With no `control_system:` section the factory
+    falls back to the mock, so this is a mock machine with a mock archive --
+    honest, however little the inert line achieved."""
+    monkeypatch.chdir(tmp_path)
+    _write_config(
+        tmp_path,
+        {"control_system.type": "virtual_accelerator", "archiver": {"type": "mock_archiver"}},
+    )
+
+    registry = initialize_server_context()
+
+    assert registry.config.control_system == {}
+
+
+@pytest.mark.unit
+def test_the_refusal_names_the_config_and_both_ways_out(tmp_path, monkeypatch):
+    """A refusal at MCP startup reaches someone reading a launcher's stderr, who
+    needs the file to open and the edit to make."""
+    monkeypatch.chdir(tmp_path)
+    config_file = _write_config(tmp_path, _VA_MOCK_NESTED)
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        initialize_server_context()
+    message = str(excinfo.value)
+
+    assert str(config_file) in message
+    assert "mongodb_archiver" in message
+    assert "'mock'" in message
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param(
+            {
+                "control_system": {"type": "virtual_accelerator"},
+                "archiver": {"type": "mongodb_archiver"},
+            },
+            id="va-with-store",
+        ),
+        pytest.param(
+            {"control_system": {"type": "mock"}, "archiver": {"type": "mock_archiver"}},
+            id="mock-with-mock",
+        ),
+        pytest.param(
+            {"control_system": {"type": "epics"}, "archiver": {"type": "mock_archiver"}},
+            id="epics-with-mock",
+        ),
+    ],
+)
+def test_every_honest_pairing_still_starts(tmp_path, monkeypatch, config):
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, config)
+
+    registry = initialize_server_context()
+
+    assert registry.config.raw == config

--- a/tests/services/test_archiver_recorder.py
+++ b/tests/services/test_archiver_recorder.py
@@ -1,0 +1,610 @@
+"""Contracts for the archiver recorder.
+
+The recorder writes into a collection whose other half is written by the base
+seeder and read by ``MongoDBArchiverConnector``. Almost everything worth
+pinning here is about staying compatible with those two neighbours rather than
+about the recorder in isolation:
+
+* the sample grid is absolute, so recorded and seeded documents share instants;
+* the document shape is the one the connector reads, and a channel that did not
+  answer is absent rather than filled in;
+* the expiry stamp is per-document and two-tiered, and a document the recorder
+  did not create never gets its expiry rewritten (that is how the scenario
+  seeder protects an event window from retention);
+* enablement is polled and a torn config read changes nothing.
+
+The Channel Access side is a plain async callable, so every test here drives it
+directly. The write shape is additionally checked against a real MongoDB via
+the existing session-scoped testcontainers fixture, because "the document the
+connector can read" is not a claim a fake can settle.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+import yaml
+
+from osprey.services.archiver_recorder import (
+    ArchiveWriter,
+    Recorder,
+    RecorderConfigError,
+    RecorderSettings,
+    expiry_for,
+    load_settings,
+    read_control_system_type,
+    resolve_channel_addresses,
+)
+
+# The session-scoped MongoDB container, reused rather than re-declared: one
+# container for the whole test session, skipping cleanly without Docker.
+from tests.connectors.conftest import mongodb_container  # noqa: F401
+
+
+def _settings(**overrides) -> RecorderSettings:
+    base = {
+        "host": "archiver-mongodb",
+        "port": 27017,
+        "database": "osprey_archiver",
+        "collection": "pv_history",
+        "auth_database": "admin",
+        "username": "osprey",
+        "password_env": "MONGO_ROOT_PASSWORD",
+        "timeout_sec": 5,
+        "cadence_sec": 10,
+        "tail_cadence_sec": 60,
+        "poll_sec": 30,
+        "hot_span_hours": 48,
+        "retention_days": 30,
+    }
+    base.update(overrides)
+    return RecorderSettings(**base)
+
+
+def _write_config(path: Path, control_system_type: str = "virtual_accelerator", **extra) -> Path:
+    config = {
+        "control_system": {"type": control_system_type},
+        "archiver": {
+            "mongodb_archiver": {
+                "host": "localhost",
+                "port": 27017,
+                "name": "osprey_archiver",
+                "collection": "pv_history",
+                "auth": "admin",
+                "username": "osprey",
+                "password_env": "MONGO_ROOT_PASSWORD",
+                "timeout": 5,
+            }
+        },
+        "va_archiver": {
+            "retention_days": 30,
+            "hot_span_hours": 48,
+            "hot_cadence_sec": 10,
+            "tail_cadence_sec": 60,
+            "recorder_cadence_sec": 10,
+            "recorder_tail_cadence_sec": 60,
+            "recorder_poll_sec": 30,
+        },
+    }
+    config.update(extra)
+    path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    return path
+
+
+class _FakeWriter:
+    """Records what would have been stored, without a database."""
+
+    def __init__(self) -> None:
+        self.samples: list[tuple[datetime, dict[str, float]]] = []
+        self.fail_with: Exception | None = None
+
+    def write_sample(self, timestamp: datetime, values: dict[str, float]) -> None:
+        if self.fail_with is not None:
+            raise self.fail_with
+        self.samples.append((timestamp, dict(values)))
+
+
+def _reader(values):
+    async def read(addresses):
+        return {a: v for a, v in values.items() if a in set(addresses)}
+
+    return read
+
+
+# ---------------------------------------------------------------------------
+# Settings: no defaults, and the in-network override wins
+# ---------------------------------------------------------------------------
+
+
+def test_settings_come_from_the_rendered_config(tmp_path: Path) -> None:
+    """Every knob is read from config.yml — the same block the profile emits
+    and the seeder reads, so the two halves of the collection cannot end up
+    with different cadences or retention spans."""
+    settings = load_settings(_write_config(tmp_path / "config.yml"))
+
+    assert (settings.cadence_sec, settings.tail_cadence_sec, settings.poll_sec) == (10, 60, 30)
+    assert (settings.hot_span_hours, settings.retention_days) == (48, 30)
+    assert (settings.database, settings.collection) == ("osprey_archiver", "pv_history")
+    assert settings.password_env == "MONGO_ROOT_PASSWORD"
+
+
+def test_in_network_host_and_port_override_the_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The rendered connection block is the HOST view (loopback + the published
+    port). Inside the compose network that names this container's own loopback,
+    so the compose template's alias/container-port pair has to win."""
+    monkeypatch.setenv("OSPREY_ARCHIVER_MONGODB_HOST", "archiver-mongodb")
+    monkeypatch.setenv("OSPREY_ARCHIVER_MONGODB_PORT", "27017")
+
+    settings = load_settings(_write_config(tmp_path / "config.yml"))
+
+    assert (settings.host, settings.port) == ("archiver-mongodb", 27017)
+
+
+@pytest.mark.parametrize(
+    ("block", "key"),
+    [("va_archiver", "recorder_cadence_sec"), ("archiver", "mongodb_archiver")],
+)
+def test_a_missing_knob_is_an_error_naming_it(tmp_path: Path, block: str, key: str) -> None:
+    """No silent defaults. A recorder that invented a cadence would write an
+    archive whose density disagreed with the seeded half of the same
+    collection, and nothing downstream would notice."""
+    path = _write_config(tmp_path / "config.yml")
+    config = yaml.safe_load(path.read_text())
+    del config[block][key]
+    path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    with pytest.raises(RecorderConfigError, match=key):
+        load_settings(path)
+
+
+# ---------------------------------------------------------------------------
+# Channel source: the manifest, never the limits DB
+# ---------------------------------------------------------------------------
+
+
+def test_channel_source_is_the_manifest_named_by_va_channels_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Resolved exactly as the IOC resolves it — a relative name against the
+    shared data mount — so the recorder covers the channels actually served."""
+    manifest = {
+        "channels": [
+            {
+                "address": "SR:BPM01:X",
+                "ring": "SR",
+                "system": "diagnostics",
+                "family": "BPM",
+                "device": "BPM01",
+                "field": "X",
+                "subfield": "",
+                "record_type": "ai",
+                "noise": True,
+                "partition": "static_noisy",
+            }
+        ]
+    }
+    (tmp_path / "channel_manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    monkeypatch.setenv("VA_CHANNELS_FILE", "channel_manifest.json")
+
+    assert resolve_channel_addresses(tmp_path) == ["SR:BPM01:X"]
+
+
+def test_an_unloadable_manifest_is_fatal_not_a_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Falling back to the built-in channel set would record another facility's
+    namespace into this facility's archive — worse than not recording."""
+    monkeypatch.setenv("VA_CHANNELS_FILE", "missing.json")
+
+    with pytest.raises(RecorderConfigError, match="VA_CHANNELS_FILE"):
+        resolve_channel_addresses(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Retention: two tiers, decided by the timestamp alone
+# ---------------------------------------------------------------------------
+
+
+def test_tail_grid_samples_are_kept_for_the_full_retention_span() -> None:
+    """A sample on the tail grid is the one that survives the hot span, so
+    recorded history thins to the seeded tail's density instead of ending."""
+    settings = _settings()
+    on_grid = datetime(2026, 8, 10, 12, 0, 0, tzinfo=UTC)
+    off_grid = datetime(2026, 8, 10, 12, 0, 10, tzinfo=UTC)
+
+    assert expiry_for(on_grid, settings) == on_grid + timedelta(days=30)
+    assert expiry_for(off_grid, settings) == off_grid + timedelta(hours=48)
+
+
+def test_expiry_tiers_follow_the_configured_spans() -> None:
+    """Both spans are knobs: changing retention_days in the profile changes
+    what the recorder stamps, with no code edit."""
+    settings = _settings(retention_days=2, hot_span_hours=2)
+    on_grid = datetime(2026, 8, 10, 12, 0, 0, tzinfo=UTC)
+
+    assert expiry_for(on_grid, settings) == on_grid + timedelta(days=2)
+
+
+# ---------------------------------------------------------------------------
+# The loop
+# ---------------------------------------------------------------------------
+
+
+async def test_samples_land_on_the_absolute_grid(tmp_path: Path) -> None:
+    """Timestamps are floored to a multiple of the cadence since the epoch —
+    not spaced from process start — so recorded documents share instants with
+    seeded ones and a restart lands on the same grid."""
+    writer = _FakeWriter()
+    recorder = Recorder(
+        settings=_settings(),
+        addresses=["SR:BPM01:X"],
+        writer=writer,
+        config_path=_write_config(tmp_path / "config.yml"),
+        reader=_reader({"SR:BPM01:X": 1.5}),
+    )
+
+    await recorder.tick(datetime(2026, 8, 10, 12, 0, 7, 400000, tzinfo=UTC))
+
+    timestamp, values = writer.samples[0]
+    assert timestamp == datetime(2026, 8, 10, 12, 0, 0, tzinfo=UTC)
+    assert values == {"SR:BPM01:X": 1.5}
+
+
+async def test_a_slot_is_recorded_once(tmp_path: Path) -> None:
+    """Two ticks inside one cadence interval write one document: a restart
+    mid-interval must not double-write the instant just covered."""
+    writer = _FakeWriter()
+    recorder = Recorder(
+        settings=_settings(),
+        addresses=["SR:BPM01:X"],
+        writer=writer,
+        config_path=_write_config(tmp_path / "config.yml"),
+        reader=_reader({"SR:BPM01:X": 1.5}),
+    )
+
+    assert await recorder.tick(datetime(2026, 8, 10, 12, 0, 1, tzinfo=UTC)) is True
+    assert await recorder.tick(datetime(2026, 8, 10, 12, 0, 9, tzinfo=UTC)) is False
+    assert await recorder.tick(datetime(2026, 8, 10, 12, 0, 10, tzinfo=UTC)) is True
+    assert len(writer.samples) == 2
+
+
+async def test_a_channel_that_did_not_answer_is_absent_not_filled_in(tmp_path: Path) -> None:
+    """No carried-forward value and no placeholder. The connector treats an
+    absent field as no sample, which is the only record that lets a reader tell
+    a quiet channel from an unreachable one."""
+    writer = _FakeWriter()
+    recorder = Recorder(
+        settings=_settings(),
+        addresses=["SR:BPM01:X", "SR:BPM02:X"],
+        writer=writer,
+        config_path=_write_config(tmp_path / "config.yml"),
+        reader=_reader({"SR:BPM01:X": 1.5}),
+    )
+
+    await recorder.tick(datetime(2026, 8, 10, 12, 0, 0, tzinfo=UTC))
+
+    assert writer.samples[0][1] == {"SR:BPM01:X": 1.5}
+
+
+async def test_nothing_is_written_when_no_channel_answers(tmp_path: Path) -> None:
+    """An unreachable control system leaves a gap, and the gap is the honest
+    record of it."""
+    writer = _FakeWriter()
+    recorder = Recorder(
+        settings=_settings(),
+        addresses=["SR:BPM01:X"],
+        writer=writer,
+        config_path=_write_config(tmp_path / "config.yml"),
+        reader=_reader({}),
+    )
+
+    assert await recorder.tick(datetime(2026, 8, 10, 12, 0, 0, tzinfo=UTC)) is False
+    assert writer.samples == []
+
+
+async def test_a_failed_write_does_not_end_the_loop(tmp_path: Path) -> None:
+    """The store may be restarting and the next tick is seconds away. Crashing
+    would take the Channel Access channel cache with it and reconnect every
+    channel from scratch."""
+    writer = _FakeWriter()
+    writer.fail_with = RuntimeError("store is restarting")
+    recorder = Recorder(
+        settings=_settings(),
+        addresses=["SR:BPM01:X"],
+        writer=writer,
+        config_path=_write_config(tmp_path / "config.yml"),
+        reader=_reader({"SR:BPM01:X": 1.5}),
+    )
+
+    assert await recorder.tick(datetime(2026, 8, 10, 12, 0, 0, tzinfo=UTC)) is False
+
+    writer.fail_with = None
+    assert await recorder.tick(datetime(2026, 8, 10, 12, 0, 10, tzinfo=UTC)) is True
+
+
+async def test_the_channel_access_reader_drops_channels_that_did_not_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """aioca reports a failed read as a falsy ``CANothing`` in the results list
+    rather than raising, which is what makes ``throw=False`` safe: one
+    unreachable channel must not cost the whole sample. Dropping those here is
+    what turns "did not answer" into an absent field downstream."""
+    import aioca
+
+    from osprey.services.archiver_recorder.recorder import channel_access_reader
+
+    async def fake_caget(pvs, **kwargs):
+        return [1.5, aioca.CANothing(pvs[1], -1)]
+
+    monkeypatch.setattr(aioca, "caget", fake_caget)
+
+    values = await channel_access_reader(_settings())(["SR:BPM01:X", "SR:BPM02:X"])
+
+    assert values == {"SR:BPM01:X": 1.5}
+
+
+async def test_non_numeric_channels_are_skipped_and_warned_about_once(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The schema is one number per channel per instant. Saying so every
+    cadence would bury everything else in the log."""
+    writer = _FakeWriter()
+    recorder = Recorder(
+        settings=_settings(),
+        addresses=["SR:BPM01:X", "SR:STATE:MODE"],
+        writer=writer,
+        config_path=_write_config(tmp_path / "config.yml"),
+        reader=_reader({"SR:BPM01:X": 1.5, "SR:STATE:MODE": "USER"}),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        await recorder.tick(datetime(2026, 8, 10, 12, 0, 0, tzinfo=UTC))
+        await recorder.tick(datetime(2026, 8, 10, 12, 0, 10, tzinfo=UTC))
+
+    assert writer.samples[0][1] == {"SR:BPM01:X": 1.5}
+    assert caplog.text.count("SR:STATE:MODE") == 1
+
+
+# ---------------------------------------------------------------------------
+# Enablement
+# ---------------------------------------------------------------------------
+
+
+async def test_only_a_virtual_accelerator_is_recorded(tmp_path: Path) -> None:
+    """A real machine's readings spliced onto a synthesized past is exactly the
+    two-world archive this service exists to prevent."""
+    writer = _FakeWriter()
+    recorder = Recorder(
+        settings=_settings(),
+        addresses=["SR:BPM01:X"],
+        writer=writer,
+        config_path=_write_config(tmp_path / "config.yml", control_system_type="mock"),
+        reader=_reader({"SR:BPM01:X": 1.5}),
+    )
+
+    assert await recorder.tick(datetime(2026, 8, 10, 12, 0, 0, tzinfo=UTC)) is False
+    assert writer.samples == []
+
+
+async def test_the_control_system_flip_takes_effect_without_a_restart(tmp_path: Path) -> None:
+    """The documented post-build flip is a config edit, and the poll is what
+    makes it enough."""
+    config_path = _write_config(tmp_path / "config.yml", control_system_type="mock")
+    writer = _FakeWriter()
+    recorder = Recorder(
+        settings=_settings(poll_sec=30),
+        addresses=["SR:BPM01:X"],
+        writer=writer,
+        config_path=config_path,
+        reader=_reader({"SR:BPM01:X": 1.5}),
+    )
+
+    assert await recorder.tick(datetime(2026, 8, 10, 12, 0, 0, tzinfo=UTC)) is False
+    _write_config(config_path, control_system_type="virtual_accelerator")
+
+    # Still inside the poll interval: the flip is not visible yet.
+    assert await recorder.tick(datetime(2026, 8, 10, 12, 0, 10, tzinfo=UTC)) is False
+    # Past it: recording resumes with no restart.
+    assert await recorder.tick(datetime(2026, 8, 10, 12, 0, 40, tzinfo=UTC)) is True
+
+
+async def test_a_torn_config_read_keeps_the_last_known_state(tmp_path: Path) -> None:
+    """Config writes are truncate-in-place, not atomic. Reading a half-written
+    file as "the control system changed" would stop and restart recording on a
+    write that changed nothing."""
+    config_path = _write_config(tmp_path / "config.yml")
+    writer = _FakeWriter()
+    recorder = Recorder(
+        settings=_settings(poll_sec=30),
+        addresses=["SR:BPM01:X"],
+        writer=writer,
+        config_path=config_path,
+        reader=_reader({"SR:BPM01:X": 1.5}),
+    )
+    assert await recorder.tick(datetime(2026, 8, 10, 12, 0, 0, tzinfo=UTC)) is True
+
+    config_path.write_text("control_system:\n  type: virtual_ac", encoding="utf-8")
+    config_path.write_text("{unterminated", encoding="utf-8")
+
+    assert recorder.refresh_enablement(datetime(2026, 8, 10, 12, 0, 40, tzinfo=UTC)) is True
+
+
+async def test_idling_logs_once_not_every_poll(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A recorder idling for a week must not fill the logs saying so."""
+    recorder = Recorder(
+        settings=_settings(poll_sec=1),
+        addresses=["SR:BPM01:X"],
+        writer=_FakeWriter(),
+        config_path=_write_config(tmp_path / "config.yml", control_system_type="mock"),
+        reader=_reader({"SR:BPM01:X": 1.5}),
+    )
+
+    with caplog.at_level(logging.INFO):
+        for second in range(0, 40, 10):
+            await recorder.tick(datetime(2026, 8, 10, 12, 0, second, tzinfo=UTC))
+
+    assert caplog.text.count("Idle, writing nothing") == 1
+
+
+# ---------------------------------------------------------------------------
+# The write shape, against a real MongoDB
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def archive_collection(mongodb_container):  # noqa: F811
+    """A clean collection plus the settings pointing at it."""
+    from pymongo import MongoClient
+
+    client = MongoClient(
+        host=mongodb_container["host"],
+        port=mongodb_container["port"],
+        username=mongodb_container["username"],
+        password=mongodb_container["password"],
+        authSource=mongodb_container["auth_db"],
+    )
+    collection = client[mongodb_container["db_name"]]["recorder_shape"]
+    collection.delete_many({})
+    settings = _settings(
+        host=mongodb_container["host"],
+        port=mongodb_container["port"],
+        database=mongodb_container["db_name"],
+        collection="recorder_shape",
+        username=mongodb_container["username"],
+        auth_database=mongodb_container["auth_db"],
+    )
+    try:
+        yield settings, collection, mongodb_container["password"]
+    finally:
+        collection.delete_many({})
+        client.close()
+
+
+def test_stored_documents_carry_the_shape_the_connector_reads(archive_collection) -> None:
+    """One document per timestamp, ``date`` plus a field per PV — the shape
+    ``MongoDBArchiverConnector`` queries and projects."""
+    settings, collection, password = archive_collection
+    writer = ArchiveWriter(settings, password)
+    writer.connect()
+    timestamp = datetime(2026, 8, 10, 12, 0, 10, tzinfo=UTC)
+    try:
+        writer.write_sample(timestamp, {"SR:BPM01:X": 1.5, "SR:BPM02:X": -0.25})
+    finally:
+        writer.close()
+
+    doc = collection.find_one({"date": timestamp})
+    assert doc is not None
+    assert doc["SR:BPM01:X"] == 1.5
+    assert doc["SR:BPM02:X"] == -0.25
+    assert doc["expireAt"].replace(tzinfo=UTC) == timestamp + timedelta(hours=48)
+
+
+def test_writing_an_instant_twice_merges_and_never_restamps_expiry(archive_collection) -> None:
+    """The two guards that let the recorder coexist with the seeded half of the
+    collection: a second write leaves values it did not read alone, and it does
+    not put an expiry back on a document whose expiry the scenario seeder
+    deliberately removed to protect an event window from retention."""
+    settings, collection, password = archive_collection
+    timestamp = datetime(2026, 8, 10, 12, 0, 0, tzinfo=UTC)
+    collection.insert_one({"date": timestamp, "SR:SEEDED:VALUE": 42.0})
+
+    writer = ArchiveWriter(settings, password)
+    writer.connect()
+    try:
+        writer.write_sample(timestamp, {"SR:BPM01:X": 1.5})
+    finally:
+        writer.close()
+
+    doc = collection.find_one({"date": timestamp})
+    assert doc["SR:SEEDED:VALUE"] == 42.0, "a value the recorder does not read must survive"
+    assert doc["SR:BPM01:X"] == 1.5
+    assert "expireAt" not in doc, (
+        "re-stamping expiry on a document the recorder did not create would make a "
+        "scenario-protected event window expirable"
+    )
+
+
+def test_a_missing_credential_is_a_connection_error(archive_collection) -> None:
+    """A recorder that cannot write is not degraded, it is pointless — so the
+    cause lands in the log at startup rather than as a silently empty archive."""
+    settings, _collection, _password = archive_collection
+
+    with pytest.raises(ConnectionError, match="archive store"):
+        ArchiveWriter(settings, "not-the-password").connect()
+
+
+def test_control_system_type_reads_the_file_each_time(tmp_path: Path) -> None:
+    """The enablement question is answered from disk, not from a cached parse:
+    the whole point is that an edit is visible without a restart."""
+    config_path = _write_config(tmp_path / "config.yml", control_system_type="mock")
+    assert read_control_system_type(config_path) == "mock"
+
+    _write_config(config_path, control_system_type="virtual_accelerator")
+    assert read_control_system_type(config_path) == "virtual_accelerator"
+
+
+def _recorder_template_text() -> str:
+    """The recorder compose template as written, jinja expressions intact."""
+    import osprey
+
+    path = (
+        Path(osprey.__file__).parent
+        / "templates"
+        / "services"
+        / "archiver_recorder"
+        / "docker-compose.yml.j2"
+    )
+    return path.read_text(encoding="utf-8")
+
+
+def test_the_template_mounts_the_live_project_not_a_staged_config_copy() -> None:
+    """The enablement poll is only honest if it re-reads the operator's own file.
+
+    Every other service mounts the flattened config.yml the compose generator
+    stages into its build dir, and returning this one to that convention is the
+    obvious tidy-up for someone who has not read why it deviates. It would also
+    be silent: the poll would keep running against a file rewritten once per
+    `deploy up`, so a flip would need a redeploy while the service went on
+    logging that it does not — the exact dishonesty this feature removes.
+    """
+    template = _recorder_template_text()
+
+    assert "- ../..:/app/project:ro" in template, (
+        "the recorder must mount the live project directory; a staged copy is "
+        "rewritten only by `deploy up`, so the enablement poll would re-read a "
+        "build artifact and the documented no-redeploy flip would never arrive"
+    )
+    assert "./archiver_recorder/config.yml:/app/project/config.yml" not in template, (
+        "the staged-copy mount is back; see the mount comment for why this "
+        "service deviates from the convention the bluesky bridge follows"
+    )
+    assert "CONFIG_FILE: /app/project/config.yml" in template, (
+        "CONFIG_FILE must keep naming the path the project directory mount now "
+        "makes live, or the service reads nothing"
+    )
+
+
+def test_the_template_mounts_a_directory_so_editor_saves_are_seen() -> None:
+    """A single-file bind would pass a truncate-in-place test and fail a real edit.
+
+    Docker resolves a single-file bind to an inode at container start. vim and
+    VS Code save by writing a temp file and renaming it over the original,
+    which leaves a new inode, and the container then reads the old one forever
+    without saying so. The directory mount re-resolves on every read, so the
+    reason it is a directory has to survive in the file.
+    """
+    template = _recorder_template_text()
+
+    assert "inode" in template, (
+        "the mount comment must keep the inode rationale: without it the "
+        "directory mount reads as an oversight and gets narrowed to the one "
+        "file, which silently breaks the flip for editors that save by rename"
+    )

--- a/tests/simulation/test_archiver_scenario_seed.py
+++ b/tests/simulation/test_archiver_scenario_seed.py
@@ -1,0 +1,1195 @@
+"""Rewriting stored history when the active scenario changes.
+
+A stored archive is the deployment's memory, and activating a scenario has to
+change what that memory says — otherwise the agent reads a month of calm
+history while the live machine shows a fault, which is exactly the two-world
+split this feature exists to close. Rewriting stored data is also the most
+destructive thing ``osprey sim apply`` does, so the contracts are sharp:
+
+* **Switching away leaves nothing behind.** Apply a scenario with events, then
+  apply an eventless one, and the store has to equal the base everywhere — same
+  values, same expiry stamps, no leftover dense inserts. A stale event window
+  surviving a scenario switch would be a fault the agent can find and the
+  operator did not cause, and it is the failure this file's headline test
+  exists to catch.
+
+* **Only the event windows move.** Channels no scenario touches, and stretches
+  of time outside an event's reach, are not rewritten at all.
+
+* **The credentials come from the project, never from the ambient shell.** An
+  apply is routinely run from a temporary directory or another project, and
+  picking up a stray ``MONGO_ROOT_PASSWORD`` would at best fail confusingly and
+  at worst rewrite a different deployment's archive.
+
+Container-backed tests skip cleanly without Docker; the window arithmetic and
+the config resolution carry their own weight without one.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+import yaml
+
+from osprey.simulation.apply import (
+    DENSIFIED_FIELD,
+    active_archiver_events,
+    apply_scenarios,
+    archiver_store_config,
+    event_subwindows,
+    event_window,
+    persisted_scenario_anchor,
+    preflight_archive_rewrite,
+)
+from osprey.simulation.archiver_seed import (
+    DATE_FIELD,
+    EXPIRE_FIELD,
+    MANIFEST_ID,
+    SeedKnobs,
+    seed_base,
+)
+from tests._container_support import is_docker_available, start_or_skip, stop_quietly
+
+PRESSURE = "SR:VAC:IP07:PRESSURE"
+TEMPERATURE = "SR:RF:CAV01:TEMP:BODY"
+FAULT = "SR:VAC:IP07:STATUS:FAULT"
+
+T0 = datetime(2026, 3, 14, 9, 26, 53, tzinfo=UTC)
+
+# Two hours of coarse history with ten minutes of dense, so a container test
+# seeds in well under a second. The event sits inside the coarse stretch on
+# purpose: densification is only interesting where the grid is coarse.
+KNOBS = SeedKnobs(retention_days=1, hot_span_hours=1, hot_cadence_sec=10, tail_cadence_sec=60)
+
+SPIKE_OFFSET_S = -7200  # two hours before the anchor: coarse-grid territory
+LATE_OFFSET_S = -5400  # ninety minutes back: still coarse, and clear of the first
+SPIKE_WIDTH_S = 120.0
+# Four sigmas either side, matching the rewrite's own cut (see ``event_window``).
+SPIKE_REACH_S = 4 * SPIKE_WIDTH_S
+
+CHANNELS = [
+    {"address": PRESSURE, "record_type": "ai"},
+    {"address": TEMPERATURE, "record_type": "ai"},
+    {"address": FAULT, "record_type": "bi"},
+]
+
+
+def _spike(offset: float, amplitude: float = 5e-9) -> dict:
+    return {
+        "shape": "spike",
+        "at_offset": offset,
+        "amplitude": amplitude,
+        "width": SPIKE_WIDTH_S,
+    }
+
+
+def _machine() -> dict:
+    """A three-channel model with one eventful scenario per shape worth testing."""
+    return {
+        "name": "Rewrite rig",
+        "description": "Three channels and a scenario per event shape",
+        "channels": {
+            PRESSURE: {
+                "value": 1e-9,
+                "units": "Torr",
+                "noise": 0.0,
+                "description": "Ion pump pressure",
+            },
+            TEMPERATURE: {
+                "value": 25.0,
+                "units": "degC",
+                "noise": 0.0,
+                "description": "Cavity body temperature",
+            },
+            FAULT: {
+                "value": 0,
+                "units": "",
+                "noise": 0.0,
+                "description": "Ion pump fault flag",
+            },
+        },
+        "scenarios": {
+            "nominal": {"description": "All systems nominal."},
+            "burst": {
+                "description": "A vacuum burst two hours ago.",
+                "archiver": [{"channel": PRESSURE, "events": [_spike(SPIKE_OFFSET_S)]}],
+            },
+            "late-burst": {
+                "description": "The same channel, disturbed at a different hour.",
+                "archiver": [{"channel": PRESSURE, "events": [_spike(LATE_OFFSET_S)]}],
+            },
+            "twin-burst": {
+                "description": "Two channels whose windows overlap but do not coincide.",
+                "archiver": [
+                    {
+                        "channel": PRESSURE,
+                        "events": [_spike(SPIKE_OFFSET_S), _spike(LATE_OFFSET_S)],
+                    },
+                    {"channel": TEMPERATURE, "events": [_spike(LATE_OFFSET_S, amplitude=3.0)]},
+                ],
+            },
+            "flagged": {
+                "description": "A flag channel raised for a while.",
+                "archiver": [{"channel": FAULT, "events": [_spike(SPIKE_OFFSET_S, amplitude=1.0)]}],
+            },
+            "nightly": {
+                "description": "A disturbance that recurs at the same time every day.",
+                "archiver": [
+                    {
+                        "channel": PRESSURE,
+                        "events": [
+                            {
+                                "shape": "spike",
+                                "at_time": "03:00:00",
+                                "amplitude": 5e-9,
+                                "width": SPIKE_WIDTH_S,
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+    }
+
+
+@pytest.fixture(scope="module")
+def mongo_store():
+    """A MongoDB container for this module."""
+    if not is_docker_available():
+        pytest.skip("Docker not available — needed to rewrite a real store.")
+    try:
+        from testcontainers.mongodb import MongoDbContainer
+    except ImportError:
+        pytest.skip("testcontainers[mongodb] not installed")
+
+    username, password = "rewriteuser", "rewritepass123"
+    container = start_or_skip(
+        lambda: MongoDbContainer("mongo:7", username=username, password=password),
+        label="mongodb-rewrite",
+    )
+    try:
+        yield {
+            "host": container.get_container_host_ip(),
+            "port": int(container.get_exposed_port(27017)),
+            "username": username,
+            "password": password,
+            "database": "rewrite_db",
+            "collection": "pv_history",
+        }
+    finally:
+        stop_quietly(container)
+
+
+def _write_project(root: Path, store: dict | None, *, password: str | None) -> Path:
+    """Lay out a built project on disk: model, config, and its ``.env``."""
+    (root / "data" / "simulation").mkdir(parents=True, exist_ok=True)
+    (root / "data" / "simulation" / "machine.json").write_text(json.dumps(_machine()))
+
+    config: dict = {
+        "project_name": "rewrite-project",
+        "project_root": str(root),
+        "control_system": {
+            "type": "mock",
+            "connector": {"mock": {"simulation_file": "data/simulation/machine.json"}},
+        },
+        "va_archiver": {
+            "retention_days": KNOBS.retention_days,
+            "hot_span_hours": KNOBS.hot_span_hours,
+            "hot_cadence_sec": KNOBS.hot_cadence_sec,
+            "tail_cadence_sec": KNOBS.tail_cadence_sec,
+        },
+    }
+    if store is not None:
+        config["archiver"] = {
+            "type": "mongodb_archiver",
+            "mongodb_archiver": {
+                "host": store["host"],
+                "port": store["port"],
+                "name": store["database"],
+                "collection": store["collection"],
+                "auth": "admin",
+                "username": store["username"],
+                "password_env": "MONGO_ROOT_PASSWORD",
+                "timeout": 10,
+            },
+        }
+    (root / "config.yml").write_text(yaml.safe_dump(config))
+    if password is not None:
+        (root / ".env").write_text(f"MONGO_ROOT_PASSWORD={password}\n")
+    return root
+
+
+def _engine(root: Path):
+    """The project's engine, resolved exactly as the product resolves it."""
+    from osprey.simulation.engine import SimulationEngine, resolve_state_dir
+
+    config = yaml.safe_load((root / "config.yml").read_text())
+    return SimulationEngine.from_file(
+        root / "data" / "simulation" / "machine.json",
+        state_dir=resolve_state_dir(config, root),
+    )
+
+
+@pytest.fixture
+def project(tmp_path, mongo_store):
+    """A built project wired to a freshly seeded archive.
+
+    The process never chdirs into it: every path the code under test resolves
+    has to come from ``project_dir``, not from where the caller happens to be.
+    """
+    from pymongo import MongoClient
+
+    root = _write_project(tmp_path / "proj", mongo_store, password=mongo_store["password"])
+
+    client = MongoClient(
+        host=mongo_store["host"],
+        port=mongo_store["port"],
+        username=mongo_store["username"],
+        password=mongo_store["password"],
+        authSource="admin",
+    )
+    collection = client[mongo_store["database"]][mongo_store["collection"]]
+    collection.drop()
+    # Seeded through the same engine the rewrite will use. This is what a
+    # deployment does, and it is load-bearing rather than incidental: a base
+    # seeded procedurally for a channel the machine model describes would
+    # disagree with every later recompute, and the disagreement would look
+    # exactly like a scenario that failed to restore.
+    seed_base(collection, CHANNELS, KNOBS, t0=T0, chunk_size=256, engine=_engine(root))
+    try:
+        yield root, collection
+    finally:
+        collection.drop()
+        client.close()
+
+
+def _snapshot(collection) -> dict:
+    """Every stored sample, keyed by timestamp, for exact before/after compares."""
+    return {
+        doc[DATE_FIELD]: {key: value for key, value in doc.items() if key not in ("_id",)}
+        for doc in collection.find({DATE_FIELD: {"$exists": True}})
+    }
+
+
+def _apply(root: Path, names: list[str], *, at: datetime = T0):
+    """Activate a set with the logbook left alone (no ARIEL in this project)."""
+    return apply_scenarios(root, names, seed_logbook=False, now=at)
+
+
+def _window(offset: float, *, shrink: float = 0.0) -> tuple[datetime, datetime]:
+    """The absolute bounds of one spike's window, optionally pulled in a little.
+
+    Shrinking is for assertions about the *interior* of a window: the grid is
+    epoch-aligned and the window edges are not, so the outermost grid point of a
+    window is a boundary case that says nothing about the property under test.
+    """
+    centre = T0 + timedelta(seconds=offset)
+    reach = timedelta(seconds=SPIKE_REACH_S - shrink)
+    return centre - reach, centre + reach
+
+
+def _stamps_of(collection, channel: str, low: datetime, high: datetime) -> list[float]:
+    """Ascending epoch seconds of every stored sample carrying ``channel``."""
+    return sorted(
+        document[DATE_FIELD].replace(tzinfo=UTC).timestamp()
+        for document in collection.find(
+            {DATE_FIELD: {"$gte": low, "$lte": high}, channel: {"$exists": True}}
+        )
+    )
+
+
+def _gaps(collection, channel: str, low: datetime, high: datetime) -> list[float]:
+    """The intervals between consecutive samples of one channel over a stretch."""
+    stamps = _stamps_of(collection, channel, low, high)
+    return [later - earlier for earlier, later in zip(stamps, stamps[1:], strict=False)]
+
+
+# ---------------------------------------------------------------------------
+# Where the credentials come from
+# ---------------------------------------------------------------------------
+
+
+class TestStoreResolution:
+    def test_a_project_without_a_mongodb_archive_has_nothing_to_rewrite(self, tmp_path):
+        root = _write_project(tmp_path / "plain", None, password=None)
+
+        assert (
+            archiver_store_config(yaml.safe_load((root / "config.yml").read_text()), root) is None
+        )
+
+    def test_the_password_comes_from_the_project_env_not_the_ambient_one(
+        self, tmp_path, monkeypatch
+    ):
+        """The foreign-cwd case, which is the normal one for a test or a harness.
+
+        A stray ``MONGO_ROOT_PASSWORD`` in the environment belongs to whatever
+        deployment exported it. Reaching for it here would, in the bad case,
+        authenticate against someone else's archive and rewrite it.
+        """
+        root = _write_project(
+            tmp_path / "proj",
+            {
+                "host": "127.0.0.1",
+                "port": 27017,
+                "database": "db",
+                "collection": "c",
+                "username": "u",
+            },
+            password="the-project-password",
+        )
+        monkeypatch.setenv("MONGO_ROOT_PASSWORD", "some-other-deployments-password")
+        monkeypatch.chdir(tmp_path)
+
+        store = archiver_store_config(yaml.safe_load((root / "config.yml").read_text()), root)
+
+        assert store["password"] == "the-project-password"
+
+    def test_a_missing_password_is_reported_rather_than_guessed(self, tmp_path):
+        root = _write_project(
+            tmp_path / "proj",
+            {
+                "host": "127.0.0.1",
+                "port": 27017,
+                "database": "db",
+                "collection": "c",
+                "username": "u",
+            },
+            password=None,
+        )
+
+        store = archiver_store_config(yaml.safe_load((root / "config.yml").read_text()), root)
+        assert store is not None
+        assert store["password"] is None
+
+
+# ---------------------------------------------------------------------------
+# Which stretch of history an event reaches
+# ---------------------------------------------------------------------------
+
+
+class TestEventWindow:
+    ANCHOR = T0.timestamp()
+    HORIZON = T0.timestamp() - 86400
+
+    def test_a_spike_is_local_to_its_own_bump(self):
+        start, end = event_window(
+            [{"shape": "spike", "at_offset": -3600, "amplitude": 1.0, "width": 60.0}],
+            self.ANCHOR,
+            self.HORIZON,
+        )
+
+        assert self.ANCHOR - end > 3000, "the window must not run to the anchor"
+        assert end - start == pytest.approx(2 * 4.0 * 60.0)
+
+    def test_a_step_reaches_the_end_of_the_archive(self):
+        """It changes every sample after it, so its window has to as well."""
+        start, end = event_window(
+            [{"shape": "step", "at_offset": -3600, "to": 5.0}], self.ANCHOR, self.HORIZON
+        )
+
+        assert start == pytest.approx(self.ANCHOR - 3600)
+        assert end == pytest.approx(self.ANCHOR)
+
+    def test_a_daily_event_reaches_the_whole_archive(self):
+        """It recurs on every date the archive covers."""
+        assert event_window(
+            [{"shape": "step", "at_time": "03:00:00", "to": 5.0}], self.ANCHOR, self.HORIZON
+        ) == (self.HORIZON, self.ANCHOR)
+
+    def test_an_event_older_than_the_archive_is_clamped_to_it(self):
+        start, _ = event_window(
+            [{"shape": "step", "at_offset": -86400 * 10, "to": 5.0}], self.ANCHOR, self.HORIZON
+        )
+
+        assert start == self.HORIZON
+
+    def test_a_window_fraction_event_is_refused_by_name(self):
+        """A fraction names a position in the reader's window, not an instant —
+        there is no timestamp to store it at, and silently placing it somewhere
+        plausible would be inventing history."""
+        with pytest.raises(ValueError, match="at_offset"):
+            event_window([{"shape": "step", "at": 0.5, "to": 5.0}], self.ANCHOR, self.HORIZON)
+
+    def test_several_events_span_from_the_earliest_to_the_latest(self):
+        start, end = event_window(
+            [
+                {"shape": "spike", "at_offset": -7200, "amplitude": 1.0, "width": 60.0},
+                {"shape": "spike", "at_offset": -3600, "amplitude": 1.0, "width": 60.0},
+            ],
+            self.ANCHOR,
+            self.HORIZON,
+        )
+
+        assert start < self.ANCHOR - 7200 < self.ANCHOR - 3600 < end
+
+
+class TestEventSubwindows:
+    """Which stretches an event is *evidence* over, as opposed to reaches.
+
+    The two are not the same thing, and conflating them is expensive in both
+    directions: a daily event's values reach across the whole archive, but its
+    evidence is a few minutes a day, and protecting the reach would leave an
+    entire deployment unexpiring while densifying it would insert a month of
+    samples nobody asked for.
+    """
+
+    ANCHOR = T0.timestamp()
+    HORIZON = T0.timestamp() - 86400 * 3
+
+    def test_a_daily_event_contributes_one_bump_per_date_it_covers(self):
+        windows = event_subwindows(
+            [{"shape": "spike", "at_time": "03:00:00", "amplitude": 1.0, "width": 60.0}],
+            self.ANCHOR,
+            self.HORIZON,
+            tz=ZoneInfo("UTC"),
+        )
+
+        assert len(windows) == 3, "three dates covered, three bumps"
+        assert all(end - start == pytest.approx(2 * 4.0 * 60.0) for start, end in windows)
+        assert sum(end - start for start, end in windows) < (self.ANCHOR - self.HORIZON) / 100
+
+    def test_separate_spikes_stay_separate_bumps(self):
+        """A three-spike script must not protect the calm hours between them."""
+        windows = event_subwindows(
+            [
+                {"shape": "spike", "at_offset": -7200, "amplitude": 1.0, "width": 60.0},
+                {"shape": "spike", "at_offset": -3600, "amplitude": 1.0, "width": 60.0},
+            ],
+            self.ANCHOR,
+            self.HORIZON,
+        )
+
+        assert len(windows) == 2
+        assert windows[0][1] < windows[1][0], "the quiet stretch between them is not covered"
+
+    def test_overlapping_bumps_are_merged(self):
+        """Disjoint output is what lets the rewrite fill each instant once."""
+        windows = event_subwindows(
+            [
+                {"shape": "spike", "at_offset": -3700, "amplitude": 1.0, "width": 60.0},
+                {"shape": "spike", "at_offset": -3600, "amplitude": 1.0, "width": 60.0},
+            ],
+            self.ANCHOR,
+            self.HORIZON,
+        )
+
+        assert len(windows) == 1
+
+    def test_a_persistent_event_is_evidence_to_the_end_of_the_archive(self):
+        """A step really does change every later sample, so it protects them."""
+        assert event_subwindows(
+            [{"shape": "step", "at_offset": -3600, "to": 5.0}], self.ANCHOR, self.HORIZON
+        ) == [(self.ANCHOR - 3600, self.ANCHOR)]
+
+    def test_an_occurrence_older_than_the_archive_contributes_nothing(self):
+        assert (
+            event_subwindows(
+                [{"shape": "spike", "at_offset": -86400 * 30, "amplitude": 1.0, "width": 60.0}],
+                self.ANCHOR,
+                self.HORIZON,
+            )
+            == []
+        )
+
+    def test_a_window_fraction_event_is_refused_here_too(self):
+        with pytest.raises(ValueError, match="at_offset"):
+            event_subwindows([{"shape": "step", "at": 0.5, "to": 5.0}], self.ANCHOR, self.HORIZON)
+
+    @pytest.mark.parametrize("resolve", [event_window, event_subwindows])
+    def test_an_empty_script_names_no_window(self, resolve):
+        """Answering with an inverted span would put a start > end pair in the
+        ledger, and every later apply would recompute an empty stretch forever."""
+        with pytest.raises(ValueError, match="empty"):
+            resolve([], self.ANCHOR, self.HORIZON)
+
+
+class TestPersistedAnchor:
+    """A re-apply has to land on the timeline the world already has.
+
+    A deploy-time reseed re-applies the active set so the rebuilt store carries
+    its events. If that re-apply minted a fresh anchor, the running VA's
+    ``at_offset`` events, the seeded logbook and the archive's event windows
+    would all slide to a new T0 — a timeline change as a side effect of an
+    operation whose whole point was to leave the world alone.
+    """
+
+    def test_the_anchor_written_by_an_apply_is_readable_afterwards(self, tmp_path):
+        root = _write_project(tmp_path / "proj", None, password=None)
+        config = yaml.safe_load((root / "config.yml").read_text())
+
+        assert persisted_scenario_anchor(config, root) is None, "nothing activated yet"
+
+        _apply(root, ["burst"], at=T0)
+
+        anchor = persisted_scenario_anchor(config, root)
+        assert anchor is not None
+        assert anchor == T0
+
+    def test_a_project_that_never_activated_anything_has_no_anchor(self, tmp_path):
+        """``None`` means "no established timeline", which is a caller's cue to
+        mint one — not an error to paper over with wall-clock now."""
+        root = _write_project(tmp_path / "proj", None, password=None)
+
+        assert (
+            persisted_scenario_anchor(yaml.safe_load((root / "config.yml").read_text()), root)
+            is None
+        )
+
+    def test_the_anchor_survives_a_second_apply_at_a_different_instant(self, tmp_path):
+        """Re-applying moves it, deliberately — this reads what is *current*,
+        so a caller that wants the old timeline has to read it before applying."""
+        root = _write_project(tmp_path / "proj", None, password=None)
+        config = yaml.safe_load((root / "config.yml").read_text())
+        later = T0 + timedelta(hours=3)
+
+        _apply(root, ["burst"], at=T0)
+        _apply(root, ["nominal"], at=later)
+
+        assert persisted_scenario_anchor(config, root) == later
+
+
+class TestComposedEvents:
+    def test_the_active_set_s_scripts_are_composed(self, tmp_path):
+        root = _write_project(tmp_path / "proj", None, password=None)
+        machine = root / "data" / "simulation" / "machine.json"
+
+        assert active_archiver_events(machine, ["nominal"]) == {}
+        assert list(active_archiver_events(machine, ["burst"])) == [PRESSURE]
+
+    def test_an_unknown_scenario_is_refused(self, tmp_path):
+        root = _write_project(tmp_path / "proj", None, password=None)
+
+        with pytest.raises(ValueError, match="Unknown scenario"):
+            active_archiver_events(root / "data" / "simulation" / "machine.json", ["nope"])
+
+
+# ---------------------------------------------------------------------------
+# The rewrite itself
+# ---------------------------------------------------------------------------
+
+
+class TestRewrite:
+    def test_applying_an_eventless_set_to_a_fresh_archive_changes_nothing(self, project):
+        """ "Restore then nothing" has to be genuinely nothing: the benchmark
+        matrix and the doc-screenshot capture both apply ``nominal`` routinely,
+        and neither should pay for, or risk, a rewrite."""
+        root, collection = project
+        before = _snapshot(collection)
+
+        result = _apply(root, ["nominal"])
+
+        assert result.archiver.skipped is None
+        assert result.archiver.updated == 0
+        assert result.archiver.inserted == 0
+        assert _snapshot(collection) == before
+
+    def test_an_event_rewrites_its_own_window_and_leaves_the_rest_alone(self, project):
+        root, collection = project
+        before = _snapshot(collection)
+
+        result = _apply(root, ["burst"])
+
+        assert PRESSURE in result.archiver.channels
+        assert result.archiver.updated > 0
+
+        after = _snapshot(collection)
+        changed = [
+            stamp
+            for stamp, doc in after.items()
+            if stamp in before and doc.get(PRESSURE) != before[stamp].get(PRESSURE)
+        ]
+        assert changed, "the event did not reach the archive"
+
+        window = timedelta(seconds=4 * SPIKE_WIDTH_S + 60)
+        centre = T0 + timedelta(seconds=SPIKE_OFFSET_S)
+        assert all(abs(stamp.replace(tzinfo=UTC) - centre) <= window for stamp in changed)
+
+    def test_the_untouched_channel_keeps_every_sample(self, project):
+        """A scenario declares the channels it affects; the archive must not
+        quietly re-noise the ones it does not."""
+        root, collection = project
+        before = _snapshot(collection)
+
+        _apply(root, ["burst"])
+
+        after = _snapshot(collection)
+        assert all(after[stamp][TEMPERATURE] == doc[TEMPERATURE] for stamp, doc in before.items())
+
+    def test_the_event_window_is_protected_from_retention(self, project):
+        """Retention must never prune the evidence a scenario exists to be
+        diagnosed from, so the touched documents lose their expiry outright."""
+        root, collection = project
+
+        _apply(root, ["burst"])
+
+        centre = T0 + timedelta(seconds=SPIKE_OFFSET_S)
+        in_window = collection.count_documents(
+            {
+                DATE_FIELD: {
+                    "$gte": centre - timedelta(seconds=SPIKE_WIDTH_S),
+                    "$lte": centre + timedelta(seconds=SPIKE_WIDTH_S),
+                },
+                EXPIRE_FIELD: {"$exists": True},
+            }
+        )
+        assert in_window == 0
+
+    def test_the_coarse_stretch_is_densified_for_the_event_channel_only(self, project):
+        """A spike sampled once a minute is a shape nobody can read. The dense
+        inserts carry only the channels the event touches — the others keep the
+        coarse history they genuinely have."""
+        root, collection = project
+
+        result = _apply(root, ["burst"])
+
+        assert result.archiver.inserted > 0
+        inserted = list(collection.find({DENSIFIED_FIELD: True}))
+        assert len(inserted) == result.archiver.inserted
+        for document in inserted:
+            assert PRESSURE in document
+            assert TEMPERATURE not in document
+            assert EXPIRE_FIELD not in document
+
+    def test_dense_inserts_land_on_the_shared_epoch_grid(self, project):
+        """The insert phase must share the recorder's clock, not just the seeder's.
+
+        The recorder floors every sample to an integer multiple of its cadence
+        since the Unix epoch. If densification placed samples at offsets from
+        the apply anchor instead, an event window would end up holding two
+        interleaved timelines — the recorder's and this one's — half a cadence
+        apart, which reads as a doubled sampling rate rather than as a denser
+        one, and no equivalence assertion could tell the two grids apart.
+        """
+        root, collection = project
+
+        _apply(root, ["burst"])
+
+        inserted = list(collection.find({DENSIFIED_FIELD: True}))
+        assert inserted
+        for document in inserted:
+            epoch = document[DATE_FIELD].replace(tzinfo=UTC).timestamp()
+            assert epoch % KNOBS.hot_cadence_sec == 0, "insert is off the dense grid"
+            # Strictly between coarse samples: a dense insert on a coarse
+            # timestamp would duplicate a sample the base seed already wrote.
+            assert epoch % KNOBS.tail_cadence_sec != 0
+
+    def test_the_anchor_second_does_not_leak_into_the_grid(self, project):
+        """Applying at a non-cadence instant must not shift the inserts.
+
+        T0 here has a second of 53, so an implementation that offset its grid
+        from the anchor would put every insert 3 seconds off the shared clock —
+        and would still pass every other test in this file.
+        """
+        root, collection = project
+        assert T0.second % KNOBS.hot_cadence_sec != 0, "the anchor must be off-grid"
+
+        _apply(root, ["burst"], at=T0)
+
+        stamps = [
+            document[DATE_FIELD].replace(tzinfo=UTC).timestamp()
+            for document in collection.find({DENSIFIED_FIELD: True})
+        ]
+        assert stamps
+        assert all(stamp % KNOBS.hot_cadence_sec == 0 for stamp in stamps)
+
+    def test_switching_back_leaves_no_trace_of_the_previous_scenario(self, project):
+        """The headline contract.
+
+        Apply an eventful set, then an eventless one, and the store has to be
+        the base again — values, expiry stamps and document count alike. A
+        surviving event window would be a fault the agent can find and the
+        operator never caused, which is worse than having no history at all.
+        """
+        root, collection = project
+        base = _snapshot(collection)
+
+        _apply(root, ["burst"])
+        assert _snapshot(collection) != base, "the rewrite did nothing to undo"
+
+        result = _apply(root, ["nominal"])
+
+        assert result.archiver.restored > 0
+        assert result.archiver.removed > 0
+        assert collection.count_documents({DENSIFIED_FIELD: True}) == 0
+        assert _snapshot(collection) == base
+
+    def test_the_ledger_records_what_was_touched_and_clears_again(self, project):
+        """The restore can only find the old windows if the apply wrote them
+        down; an empty ledger after an eventless set is what keeps the next
+        apply from re-restoring stretches nobody has touched."""
+        root, collection = project
+
+        _apply(root, ["burst"])
+        ledger = collection.find_one({"_id": MANIFEST_ID})["touched_windows"]
+        assert [entry["channels"] for entry in ledger] == [[PRESSURE]]
+
+        _apply(root, ["nominal"])
+        assert collection.find_one({"_id": MANIFEST_ID})["touched_windows"] == []
+
+    def test_re_applying_the_same_set_is_idempotent(self, project):
+        """A second apply must land on the same store, not stack a second
+        rewrite on top of the first.
+
+        Applied to the two-channel set on purpose: with one channel there is
+        only one region to get right, and every way two regions can interfere —
+        one claiming a shared timestamp, one undoing the other's expiry — is
+        invisible.
+        """
+        root, collection = project
+
+        _apply(root, ["twin-burst"])
+        once = _snapshot(collection)
+        result = _apply(root, ["twin-burst"])
+
+        assert _snapshot(collection) == once
+        assert result.archiver.updated == 0, "a re-apply that changed nothing must not claim it"
+
+
+class TestOverlappingWindows:
+    """Two channels whose event windows overlap without coinciding.
+
+    This is the shape the shipped bundles actually have — a scenario perturbs a
+    handful of channels, and their events do not all sit at the same instant —
+    and it is the one where a rewrite that works region by region comes apart:
+    whichever region reaches a shared timestamp first inserts the document, the
+    second finds it already there and inserts nothing, and the channels it was
+    carrying are simply missing from that stretch. Which region goes first is a
+    set-iteration accident, so the archive comes out differently run to run.
+    """
+
+    def test_the_shared_window_is_dense_for_both_channels(self, project):
+        root, collection = project
+
+        _apply(root, ["twin-burst"])
+
+        low, high = _window(LATE_OFFSET_S, shrink=KNOBS.hot_cadence_sec)
+        for channel in (PRESSURE, TEMPERATURE):
+            gaps = _gaps(collection, channel, low, high)
+            assert gaps, f"{channel} has no samples in the shared window at all"
+            assert max(gaps) <= KNOBS.hot_cadence_sec, f"{channel} has a hole in its own window"
+
+    def test_each_channel_is_dense_only_inside_its_own_windows(self, project):
+        """The other half of the same contract: a channel with no event in a
+        stretch keeps the coarse history it genuinely has, rather than being
+        handed resolution because a neighbour needed it."""
+        root, collection = project
+
+        _apply(root, ["twin-burst"])
+
+        low, high = _window(SPIKE_OFFSET_S, shrink=KNOBS.hot_cadence_sec)
+        assert max(_gaps(collection, PRESSURE, low, high)) <= KNOBS.hot_cadence_sec
+        assert min(_gaps(collection, TEMPERATURE, low, high)) == KNOBS.tail_cadence_sec
+
+    def test_a_shared_instant_is_one_document_carrying_both_channels(self, project):
+        """Not two competing samples of the same instant, and not one sample
+        that quietly dropped a channel."""
+        root, collection = project
+
+        _apply(root, ["twin-burst"])
+
+        low, high = _window(LATE_OFFSET_S, shrink=KNOBS.hot_cadence_sec)
+        inserted = list(
+            collection.find({DATE_FIELD: {"$gte": low, "$lte": high}, DENSIFIED_FIELD: True})
+        )
+        assert inserted
+        assert all(PRESSURE in document and TEMPERATURE in document for document in inserted)
+        stamps = [document[DATE_FIELD] for document in inserted]
+        assert len(set(stamps)) == len(stamps), "an instant was written twice"
+
+    def test_a_stretch_the_store_does_not_cover_is_not_manufactured(self, project):
+        """Densification adds resolution to history that exists; it does not
+        invent history that does not.
+
+        A recorder outage, an expired stretch, or a window reaching past the
+        newest sample all look the same from here: samples are absent. Filling
+        them would be exactly the fabrication this feature exists to remove,
+        told backwards — so the rewrite leaves them empty and says how many.
+        """
+        root, collection = project
+        low, high = _window(LATE_OFFSET_S, shrink=SPIKE_REACH_S / 2)
+        collection.delete_many({DATE_FIELD: {"$gte": low, "$lte": high}})
+
+        result = _apply(root, ["twin-burst"])
+
+        assert collection.count_documents({DATE_FIELD: {"$gte": low, "$lte": high}}) == 0
+        assert result.archiver.uncovered > 0, "the empty stretch was not reported"
+        assert "uncovered" in result.archiver.describe()
+
+
+class TestScenarioSwitch:
+    """Switching from one eventful scenario to another, not back to nominal.
+
+    Switching back to ``nominal`` is the easy direction — every window the old
+    set touched is a window the new set does not, so a restore that recomputes
+    the union lands right by accident. Switching to a *different* eventful set
+    is where the two halves come apart: the union of the old and the new window
+    is live at one end and dead at the other, and the ledger the apply leaves
+    behind names only the new one. Anything the old window keeps here, it keeps
+    forever.
+    """
+
+    def _unexpiring_between_the_windows(self, collection) -> tuple[int, int]:
+        """``(total, unexpiring)`` samples in the stretch neither window covers."""
+        between = {
+            DATE_FIELD: {"$gte": _window(SPIKE_OFFSET_S)[1], "$lte": _window(LATE_OFFSET_S)[0]}
+        }
+        return (
+            collection.count_documents(between),
+            collection.count_documents({**between, EXPIRE_FIELD: {"$exists": False}}),
+        )
+
+    def test_the_stretch_between_the_two_windows_ages_again(self, project):
+        root, collection = project
+        _apply(root, ["burst"])
+
+        _apply(root, ["late-burst"])
+
+        total, unexpiring = self._unexpiring_between_the_windows(collection)
+        assert total > 0, "the two windows do not straddle a stretch to check"
+        assert unexpiring == 0, f"{unexpiring}/{total} samples were left unexpiring"
+
+    def test_a_leak_here_would_be_unrecoverable(self, project):
+        """Why this defect is the critical one rather than merely wrong.
+
+        The ledger a switch leaves behind names only the *new* window. Anything
+        the stretch between the two windows keeps, no later apply ever looks at
+        again — not even applying ``nominal``, which is the operator's one
+        obvious way to put the world back. So the check is not just that the
+        stretch ages again, but that a full restore afterwards agrees: a fix
+        that merely deferred the repair to the next apply would satisfy the
+        first assertion and still leave history that outlives its retention
+        forever.
+        """
+        root, collection = project
+
+        _apply(root, ["burst"])
+        _apply(root, ["late-burst"])
+        _apply(root, ["nominal"])
+
+        total, unexpiring = self._unexpiring_between_the_windows(collection)
+        assert total > 0
+        assert unexpiring == 0, f"{unexpiring}/{total} samples survived a restore to nominal"
+
+    def test_one_span_carries_both_outcomes_at_once(self, project):
+        """Expiry is decided per document, and a single pass proves it.
+
+        The recomputed span is the union of the old and the new window: it is
+        live at one end and dead at the other, *in the same pass*. One boolean
+        over that span cannot produce both answers — whichever way it points,
+        either the new window keeps an expiry retention will prune or the old
+        one loses the expiry it must get back. Asserting the two halves
+        together is what a per-region fix cannot satisfy.
+        """
+        root, collection = project
+        _apply(root, ["burst"])
+
+        _apply(root, ["late-burst"])
+
+        live_low, live_high = _window(LATE_OFFSET_S, shrink=KNOBS.hot_cadence_sec)
+        live = {DATE_FIELD: {"$gte": live_low, "$lte": live_high}}
+        protected = collection.count_documents({**live, EXPIRE_FIELD: {"$exists": False}})
+        assert protected > 0, "the new window is not protected from retention"
+        assert collection.count_documents({**live, EXPIRE_FIELD: {"$exists": True}}) == 0
+
+        _, unexpiring = self._unexpiring_between_the_windows(collection)
+        assert unexpiring == 0, "the same pass left the old stretch unexpiring"
+
+    def test_the_old_window_goes_back_to_base(self, project):
+        root, collection = project
+        base = _snapshot(collection)
+
+        _apply(root, ["burst"])
+        _apply(root, ["late-burst"])
+
+        low, high = _window(SPIKE_OFFSET_S)
+        for stamp, document in _snapshot(collection).items():
+            if low <= stamp.replace(tzinfo=UTC) <= high and stamp in base:
+                assert document == base[stamp], f"the previous scenario survived at {stamp}"
+
+    def test_the_ledger_converges_on_the_new_window(self, project):
+        root, collection = project
+
+        _apply(root, ["burst"])
+        _apply(root, ["late-burst"])
+
+        ledger = collection.find_one({"_id": MANIFEST_ID})["touched_windows"]
+        assert [entry["channels"] for entry in ledger] == [[PRESSURE]]
+        low, high = _window(LATE_OFFSET_S)
+        assert ledger[0]["start"] == pytest.approx(low.timestamp())
+        assert ledger[0]["end"] == pytest.approx(high.timestamp())
+
+    def test_a_switch_reports_the_documents_it_restored_separately(self, project):
+        """The count the CLI prints as "rewrote N samples" is the new set's
+        story, not the union it had to recompute to get there."""
+        root, collection = project
+        _apply(root, ["burst"])
+
+        result = _apply(root, ["late-burst"])
+
+        low, high = _window(LATE_OFFSET_S)
+        live = collection.count_documents({DATE_FIELD: {"$gte": low, "$lte": high}})
+        assert 0 < result.archiver.updated <= live
+        assert result.archiver.restored > 0, "the old window stayed out of retention"
+
+    def test_the_ledger_names_the_union_before_the_rewrite_starts(self, project, monkeypatch):
+        """Crash safety.
+
+        The rewrite writes event values into the union of the old and the new
+        window. A process that dies part way through has already marked
+        documents in the stretch only the old window covered — and if the ledger
+        still named just that old window, or already named just the new one,
+        nothing would ever come back for them. So the union goes down first and
+        is narrowed only after the rewrite returns.
+        """
+        from osprey.simulation import apply as apply_module
+
+        root, collection = project
+        _apply(root, ["burst"])
+
+        def _die(*args, **kwargs):
+            raise RuntimeError("killed mid-rewrite")
+
+        monkeypatch.setattr(apply_module, "_rewrite_documents", _die)
+        with pytest.raises(RuntimeError, match="killed mid-rewrite"):
+            _apply(root, ["late-burst"])
+
+        ledger = collection.find_one({"_id": MANIFEST_ID})["touched_windows"]
+        assert [entry["channels"] for entry in ledger] == [[PRESSURE]]
+        assert ledger[0]["start"] == pytest.approx(_window(SPIKE_OFFSET_S)[0].timestamp())
+        assert ledger[0]["end"] == pytest.approx(_window(LATE_OFFSET_S)[1].timestamp())
+
+
+class TestCrashRecovery:
+    """Dying part way through a rewrite must leave a recoverable store.
+
+    The rewrite marks documents across the union of the old and the new windows
+    and inserts dense samples inside the new ones. Every one of those marks is
+    findable again only through the touched-window ledger, so the ledger is
+    written *before* the first document moves and narrowed only after the last
+    one has. The two tests here kill the process at each of the two write
+    phases; in both cases applying ``nominal`` afterwards — the operator's one
+    obvious way to put the world back — has to reach the base exactly.
+    """
+
+    @staticmethod
+    def _crash_after(real):
+        """Run the real step, then die — a crash that has already written.
+
+        Dying *before* the step is the easy case: nothing moved, so any ledger
+        recovers it. The case that needs the ordering is a process that got its
+        writes in and then lost the narrowing write, which is what these
+        wrappers reproduce.
+        """
+
+        def _wrapped(*args, **kwargs):
+            real(*args, **kwargs)
+            raise RuntimeError("killed mid-rewrite")
+
+        return _wrapped
+
+    def test_a_crash_after_recomputing_leaves_the_marks_findable(self, project, monkeypatch):
+        """The switch case: values written across the union, ledger lost.
+
+        The recompute reaches the whole union of the old and the new window. If
+        the ledger still named only the *old* one, the new window would keep
+        this apply's event values and its lifted expiry with nothing recording
+        that it had been touched — and the restore below would put back only
+        half the store.
+        """
+        from osprey.simulation import apply as apply_module
+
+        root, collection = project
+        base = _snapshot(collection)
+        _apply(root, ["burst"])
+
+        monkeypatch.setattr(
+            apply_module, "_rewrite_documents", self._crash_after(apply_module._rewrite_documents)
+        )
+        with pytest.raises(RuntimeError, match="killed mid-rewrite"):
+            _apply(root, ["late-burst"])
+        monkeypatch.undo()
+
+        _apply(root, ["nominal"])
+        assert collection.count_documents({DENSIFIED_FIELD: True}) == 0
+        assert _snapshot(collection) == base
+
+    def test_a_crash_while_densifying_on_a_fresh_store_is_recoverable(self, project, monkeypatch):
+        """The first eventful apply on a deployment nobody has run a scenario on.
+
+        This is the case a ledger written only when it "differs from the final
+        one" would miss: with no previous windows the union *equals* the new
+        windows, so an implementation that treats that as nothing to record
+        writes marks and dense samples under an empty ledger. Nothing would ever
+        come back for them — not even a restore to nominal, which is what makes
+        it unrecoverable rather than merely untidy.
+        """
+        from osprey.simulation import apply as apply_module
+
+        root, collection = project
+        base = _snapshot(collection)
+        real_densify = apply_module._densify
+
+        def _die_having_already_inserted(*args, **kwargs):
+            real_densify(*args, **kwargs)
+            raise RuntimeError("killed mid-rewrite")
+
+        monkeypatch.setattr(apply_module, "_densify", _die_having_already_inserted)
+        with pytest.raises(RuntimeError, match="killed mid-rewrite"):
+            _apply(root, ["burst"])
+        monkeypatch.undo()
+
+        assert collection.count_documents({DENSIFIED_FIELD: True}) > 0, "nothing was inserted"
+        ledger = collection.find_one({"_id": MANIFEST_ID})["touched_windows"]
+        assert [entry["channels"] for entry in ledger] == [[PRESSURE]], (
+            "the crashed apply left its marks under an empty ledger"
+        )
+
+        _apply(root, ["nominal"])
+        assert collection.count_documents({DENSIFIED_FIELD: True}) == 0
+        assert _snapshot(collection) == base
+
+
+class TestRecurringEvents:
+    """A daily event is evidence for minutes a day, not for the whole archive."""
+
+    def test_it_protects_its_own_bumps_and_nothing_else(self, project):
+        root, collection = project
+
+        _apply(root, ["nightly"])
+
+        total = collection.count_documents({DATE_FIELD: {"$exists": True}})
+        unexpiring = collection.count_documents(
+            {DATE_FIELD: {"$exists": True}, EXPIRE_FIELD: {"$exists": False}}
+        )
+        assert 0 < unexpiring < total / 4, "a daily event de-expired the deployment"
+
+    def test_it_densifies_its_own_bumps_and_nothing_else(self, project):
+        root, collection = project
+        base = collection.count_documents({DATE_FIELD: {"$exists": True}})
+
+        result = _apply(root, ["nightly"])
+
+        # One bump a day at four sigmas either side, filled at the dense
+        # cadence: a small, countable number. Densifying the whole span its
+        # values reach over would multiply the store several times instead.
+        assert 0 < result.archiver.inserted < base / 4
+
+
+class TestStoredTypes:
+    def test_dense_inserts_carry_the_type_the_channel_is_stored_as(self, project):
+        """A flag channel's history must not change type part way through.
+
+        The updates already coerce to the stored type; an insert has no document
+        of its own to read that from, and writing the engine's raw float would
+        leave a boolean channel holding ``0.7`` beside its ``True`` — which reads
+        as a different instrument rather than a different value.
+        """
+        root, collection = project
+
+        _apply(root, ["flagged"])
+
+        inserted = [
+            document for document in collection.find({DENSIFIED_FIELD: True}) if FAULT in document
+        ]
+        assert inserted, "the flag channel's window was not densified"
+        assert all(isinstance(document[FAULT], bool) for document in inserted)
+
+    def test_the_archive_is_not_rewritten_when_the_caller_opts_out(self, project):
+        root, collection = project
+        before = _snapshot(collection)
+
+        result = apply_scenarios(root, ["burst"], seed_logbook=False, seed_archive=False, now=T0)
+
+        assert result.archiver is None
+        assert _snapshot(collection) == before
+
+
+class TestRefusals:
+    def test_an_unseeded_store_is_reported_not_silently_skipped(self, project):
+        """ "The scenario is active but its history is not" must never be
+        something a caller has to infer from a zero count."""
+        root, collection = project
+        collection.delete_one({"_id": MANIFEST_ID})
+
+        result = _apply(root, ["burst"])
+
+        assert "not been seeded" in result.archiver.skipped
+
+    def test_a_project_with_no_store_says_so(self, tmp_path):
+        root = _write_project(tmp_path / "plain", None, password=None)
+
+        result = _apply(root, ["burst"])
+
+        assert result.archiver.skipped == "project declares no MongoDB archive"
+
+    def test_a_configured_store_with_no_password_refuses_loudly(self, tmp_path, mongo_store):
+        """Failing here is the point: the scenario is now active, and history
+        that silently contradicts it is the exact defect being removed."""
+        root = _write_project(tmp_path / "proj", mongo_store, password=None)
+
+        with pytest.raises(RuntimeError, match="MONGO_ROOT_PASSWORD"):
+            _apply(root, ["burst"])
+
+
+class TestPreflight:
+    """Deciding the rewrite before the scenario is activated.
+
+    Every refusal below is one a caller can act on: fix the ``.env``, fix the
+    bundle, and run the command again. Discovering them from inside the rewrite
+    would leave the world half applied — telemetry live, narrative reseeded,
+    history untouched and contradicting both — which is the divergence the
+    feature exists to close, arrived at by a different route.
+    """
+
+    def _machine_path(self, root: Path) -> Path:
+        return root / "data" / "simulation" / "machine.json"
+
+    def _config(self, root: Path) -> dict:
+        return yaml.safe_load((root / "config.yml").read_text())
+
+    def test_a_missing_password_is_refused_with_nothing_activated(self, tmp_path, mongo_store):
+        root = _write_project(tmp_path / "proj", mongo_store, password=None)
+
+        with pytest.raises(RuntimeError, match="MONGO_ROOT_PASSWORD"):
+            preflight_archive_rewrite(root, self._config(root), self._machine_path(root), ["burst"])
+
+        assert persisted_scenario_anchor(self._config(root), root) is None
+
+    def test_a_window_fraction_event_is_refused_before_anything_is_written(self, tmp_path):
+        root = _write_project(tmp_path / "plain", None, password=None)
+        machine = json.loads(self._machine_path(root).read_text())
+        machine["scenarios"]["burst"]["archiver"][0]["events"] = [
+            {"shape": "step", "at": 0.5, "to": 5.0}
+        ]
+        self._machine_path(root).write_text(json.dumps(machine))
+
+        with pytest.raises(ValueError, match="at_offset"):
+            preflight_archive_rewrite(root, self._config(root), self._machine_path(root), ["burst"])
+
+    def test_an_unknown_scenario_is_refused(self, tmp_path):
+        root = _write_project(tmp_path / "plain", None, password=None)
+
+        with pytest.raises(ValueError, match="Unknown scenario"):
+            preflight_archive_rewrite(root, self._config(root), self._machine_path(root), ["nope"])
+
+    def test_a_project_with_no_store_has_nothing_to_decide(self, tmp_path):
+        root = _write_project(tmp_path / "plain", None, password=None)
+
+        assert (
+            preflight_archive_rewrite(root, self._config(root), self._machine_path(root), ["burst"])
+            is None
+        )
+
+    def test_a_healthy_project_returns_the_store_it_would_rewrite(self, tmp_path, mongo_store):
+        root = _write_project(tmp_path / "proj", mongo_store, password=mongo_store["password"])
+
+        store = preflight_archive_rewrite(
+            root, self._config(root), self._machine_path(root), ["burst"]
+        )
+
+        assert store is not None
+        assert store["database"] == mongo_store["database"]

--- a/tests/simulation/test_archiver_seed.py
+++ b/tests/simulation/test_archiver_seed.py
@@ -1,0 +1,679 @@
+"""The base seed: what it writes, what it promises, and what a reader gets back.
+
+Three questions decide whether a deployment's archive is honest, and this file
+answers each against something other than the seeder's own opinion:
+
+* **Does the store hold what a query would compute?** The roundtrip tests seed a
+  real MongoDB and read it back through ``MongoDBArchiverConnector`` — the same
+  connector a deployed agent uses — and compare against the generators directly.
+  A seeder that agreed only with itself would pass a mock and fail a deployment.
+
+* **Does history age like history?** The two tiers carry different lifetimes,
+  stamped per document from the sample's own time. The expiry tests check the
+  stamps rather than waiting on MongoDB's TTL sweeper, which runs on its own
+  minute-scale schedule; the sweeper's own behaviour is the retention contract
+  test's subject, not this file's.
+
+* **Is a reseed a decision?** The fingerprint tests pin what does and does not
+  provoke one. The seed instant is the interesting case: it moves on every
+  deploy, so counting it would make every deploy rebuild the store, and
+  *forgetting* to exclude it is a mistake nothing else would catch.
+
+Container-backed tests skip cleanly without Docker. The grid, synthesis and
+fingerprint tests need no container and carry the contract on their own.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import numpy as np
+import pytest
+
+from osprey.simulation.archiver_seed import (
+    DATE_FIELD,
+    EXPIRE_FIELD,
+    MANIFEST_ID,
+    FingerprintComparison,
+    SeedKnobs,
+    SeedState,
+    compare_fingerprint,
+    oldest_sample,
+    prepare_collection,
+    seed_base,
+    seed_fingerprint,
+    seed_grid,
+    synthesize_documents,
+    write_manifest,
+)
+from osprey.simulation.procedural import baseline_value, generate_series
+from osprey.simulation.series import epoch_seconds_array
+from tests._container_support import is_docker_available, start_or_skip, stop_quietly
+
+# A fixed anchor: every expectation below is a function of it, and a failure
+# should be reproducible tomorrow.
+T0 = datetime(2026, 3, 14, 9, 26, 53, tzinfo=UTC)
+
+# A small archive — an hour of coarse history with ten minutes of dense — so a
+# container test seeds in under a second. The tier *arithmetic* is what is under
+# test, and it does not know how big the numbers are.
+SMALL = SeedKnobs(retention_days=1, hot_span_hours=1, hot_cadence_sec=10, tail_cadence_sec=60)
+
+CHANNELS = [
+    {"address": "SR:VAC:IP07:PRESSURE", "record_type": "ai"},
+    {"address": "SR:RF:CAV01:TEMP:BODY", "record_type": "ai"},
+    {"address": "SR:DIAG:BPM:12:POSITION:X", "record_type": "ai"},
+    {"address": "SR:STATUS:VALID", "record_type": "bi"},
+]
+ADDRESSES = [channel["address"] for channel in CHANNELS]
+
+
+# ---------------------------------------------------------------------------
+# Container fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def mongo_store():
+    """A MongoDB container for this module, yielding connection parameters."""
+    if not is_docker_available():
+        pytest.skip("Docker not available — needed to seed a real store.")
+    try:
+        from testcontainers.mongodb import MongoDbContainer
+    except ImportError:
+        pytest.skip("testcontainers[mongodb] not installed")
+
+    username, password = "seeduser", "seedpass123"
+    container = start_or_skip(
+        lambda: MongoDbContainer("mongo:7", username=username, password=password),
+        label="mongodb-seed",
+    )
+    try:
+        yield {
+            "host": container.get_container_host_ip(),
+            "port": int(container.get_exposed_port(27017)),
+            "username": username,
+            "password": password,
+            "auth_db": "admin",
+            "database": "seed_test_db",
+            "collection": "pv_history",
+        }
+    finally:
+        stop_quietly(container)
+
+
+@pytest.fixture
+def collection(mongo_store):
+    """An empty collection, dropped again afterwards.
+
+    Dropped rather than emptied: the indexes are part of what the seeder
+    creates, so a test that inherited them would not be testing a fresh store.
+    """
+    from pymongo import MongoClient
+
+    client = MongoClient(
+        host=mongo_store["host"],
+        port=mongo_store["port"],
+        username=mongo_store["username"],
+        password=mongo_store["password"],
+        authSource=mongo_store["auth_db"],
+    )
+    handle = client[mongo_store["database"]][mongo_store["collection"]]
+    handle.drop()
+    try:
+        yield handle
+    finally:
+        handle.drop()
+        client.close()
+
+
+@pytest.fixture
+def read_back(mongo_store, monkeypatch):
+    """Read a window through the connector a deployed agent would use.
+
+    The connector takes its password from the environment by name, as it does
+    in a deployment; ``monkeypatch`` is what keeps that variable from outliving
+    the test.
+    """
+    password_env = "SEED_TEST_MONGO_PASSWORD"
+    monkeypatch.setenv(password_env, mongo_store["password"])
+
+    async def query(pv_names, start, end):
+        from osprey.connectors.archiver.mongodb_archiver_connector import (
+            MongoDBArchiverConnector,
+        )
+
+        connector = MongoDBArchiverConnector()
+        await connector.connect(
+            {
+                "host": mongo_store["host"],
+                "port": mongo_store["port"],
+                "name": mongo_store["database"],
+                "collection": mongo_store["collection"],
+                "auth": mongo_store["auth_db"],
+                "username": mongo_store["username"],
+                "password_env": password_env,
+                "timeout": 10,
+            }
+        )
+        try:
+            return await connector.get_data(
+                pv_list=list(pv_names), start_date=start, end_date=end, precision_ms=0
+            )
+        finally:
+            await connector.disconnect()
+
+    return query
+
+
+# ---------------------------------------------------------------------------
+# The grid
+# ---------------------------------------------------------------------------
+
+
+class TestSeedGrid:
+    """One grid, two densities, no timestamp written twice."""
+
+    def test_the_window_reaches_back_the_full_retention(self):
+        times, _ = seed_grid(SeedKnobs(), T0)
+
+        start = datetime.fromtimestamp(float(times[0]), UTC)
+        end = datetime.fromtimestamp(float(times[-1]), UTC)
+        assert T0 - end < timedelta(minutes=1)
+        assert timedelta(days=29, hours=23) < T0 - start <= timedelta(days=30)
+
+    def test_no_timestamp_appears_twice(self):
+        """The schema is one document per timestamp; a duplicate would be a
+        second, competing sample for the same instant."""
+        times, _ = seed_grid(SeedKnobs(), T0)
+
+        assert len(np.unique(times)) == len(times)
+
+    def test_the_coarse_tier_is_a_subset_of_the_dense_grid(self):
+        """Both tiers land on multiples of their cadence since the epoch.
+
+        Anchoring on ``t0`` instead would put the tiers on interleaved
+        timestamps whenever the seed instant was not itself a whole cadence —
+        which is every deploy but a lucky one.
+        """
+        knobs = SeedKnobs()
+        times, _ = seed_grid(knobs, T0)
+
+        assert np.all(np.mod(times, knobs.hot_cadence_sec) == 0)
+        assert T0.second != 0, "the anchor must not accidentally be cadence-aligned"
+
+    def test_the_tiers_have_the_declared_cadences(self):
+        knobs = SeedKnobs()
+        times, _ = seed_grid(knobs, T0)
+        gaps = set(np.diff(times).tolist())
+
+        assert gaps == {float(knobs.hot_cadence_sec), float(knobs.tail_cadence_sec)}
+
+    def test_each_tier_carries_its_own_lifetime(self):
+        """Measured from the sample's own time, so a seeded archive ages like a
+        recorded one instead of surviving intact and then vanishing at once."""
+        knobs = SeedKnobs()
+        times, expiry = seed_grid(knobs, T0)
+        dense = np.mod(times, knobs.tail_cadence_sec) != 0
+
+        assert np.all(expiry[dense] - times[dense] == knobs.hot_span_s)
+        assert np.all(expiry[~dense] - times[~dense] == knobs.retention_s)
+
+    def test_the_oldest_dense_samples_are_already_at_the_end_of_their_life(self):
+        """A dense sample from the start of the dense span expires about at t0.
+
+        This is the property that keeps steady state bounded: the seed does not
+        hand a fresh deployment 48 hours of dense history that then lives 48
+        hours longer than it should. "About" is one coarse cadence — the oldest
+        *dense-only* timestamp is the first cadence-aligned point inside the
+        span that the coarse tier does not already own.
+        """
+        knobs = SeedKnobs()
+        times, expiry = seed_grid(knobs, T0)
+        dense = np.mod(times, knobs.tail_cadence_sec) != 0
+
+        assert expiry[dense].min() <= _epoch(T0) + knobs.tail_cadence_sec
+
+    def test_a_shallow_archive_still_produces_a_grid(self):
+        """The CI lanes run with retention cut to hours, not a month."""
+        times, _ = seed_grid(SMALL, T0)
+
+        assert len(times) > 0
+        assert len(np.unique(times)) == len(times)
+
+
+class TestSeedKnobs:
+    """Knobs the grid arithmetic cannot honour are refused, not approximated."""
+
+    def test_defaults_match_the_shipped_profile_block(self):
+        """The two default sets are written out separately — in the profile
+        block and here — so a deployment seeded without a config gets the
+        archive the profile describes rather than a second opinion about it."""
+        from osprey.cli.build_profile_archiver import VAArchiverConfig
+
+        block = VAArchiverConfig()
+        knobs = SeedKnobs()
+
+        assert knobs.retention_days == block.retention_days
+        assert knobs.hot_span_hours == block.hot_span_hours
+        assert knobs.hot_cadence_sec == block.hot_cadence_sec
+        assert knobs.tail_cadence_sec == block.tail_cadence_sec
+
+    def test_from_config_reads_the_va_archiver_subtree(self):
+        knobs = SeedKnobs.from_config(
+            {"va_archiver": {"retention_days": 2, "hot_span_hours": 6, "port_host": 27017}}
+        )
+
+        assert knobs.retention_days == 2
+        assert knobs.hot_span_hours == 6
+        # Knobs this module does not use are simply not its business.
+        assert knobs.hot_cadence_sec == SeedKnobs().hot_cadence_sec
+
+    def test_a_config_without_the_block_seeds_the_default_archive(self):
+        assert SeedKnobs.from_config({}) == SeedKnobs()
+
+    @pytest.mark.parametrize(
+        "block",
+        [
+            {"retention_days": 0},
+            {"hot_cadence_sec": -1},
+            {"retention_days": 1, "hot_span_hours": 25},
+            {"hot_cadence_sec": 7, "tail_cadence_sec": 60},
+            {"retention_days": "30"},
+            {"retention_days": True},
+        ],
+    )
+    def test_inconsistent_knobs_are_refused(self, block):
+        with pytest.raises(ValueError):
+            SeedKnobs.from_config({"va_archiver": block})
+
+    def test_a_non_dividing_cadence_names_both_knobs(self):
+        """The fix needs both numbers; naming one leaves the reader guessing."""
+        with pytest.raises(ValueError, match="tail_cadence_sec.*hot_cadence_sec"):
+            SeedKnobs(hot_cadence_sec=7, tail_cadence_sec=60).validate()
+
+
+# ---------------------------------------------------------------------------
+# Synthesis
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesizeDocuments:
+    """What a document holds, and why it is that and not something plausible."""
+
+    def test_a_document_carries_every_channel_at_its_own_timestamp(self):
+        times, _ = seed_grid(SMALL, T0)
+        documents = synthesize_documents(CHANNELS, times[:5])
+
+        assert len(documents) == 5
+        for document, epoch in zip(documents, times[:5], strict=True):
+            assert document[DATE_FIELD] == datetime.fromtimestamp(float(epoch), UTC)
+            assert set(document) == {DATE_FIELD, *ADDRESSES}
+
+    def test_analog_values_equal_the_generator_at_the_same_instant(self):
+        """The point of the whole design: a stored document and a live query
+        are one computation, not two that usually agree."""
+        pv = "SR:VAC:IP07:PRESSURE"
+        times, _ = seed_grid(SMALL, T0)
+        documents = synthesize_documents(CHANNELS, times[:32])
+
+        expected = generate_series(pv, times[:32], baseline=baseline_value(pv))
+        assert [document[pv] for document in documents] == expected.tolist()
+
+    def test_values_are_computed_at_the_timestamp_actually_stored(self):
+        """A datetime carries microseconds, so a sub-microsecond grid time would
+        be stored as one instant and valued at another. Seeding a grid finer
+        than a microsecond is the only way to catch that, and a seeder for a
+        higher-rate facility would do exactly that."""
+        pv = "SR:VAC:IP07:PRESSURE"
+        epoch = np.array([1_800_000_000.0 + 1e-9 * i for i in range(4)])
+
+        documents = synthesize_documents(CHANNELS, epoch)
+
+        stored = epoch_seconds_array([document[DATE_FIELD] for document in documents])
+        expected = generate_series(pv, stored, baseline=baseline_value(pv))
+        assert [document[pv] for document in documents] == expected.tolist()
+
+    def test_a_flag_channel_is_stored_as_a_flag(self):
+        """The VA serves these as booleans. A float on a status channel is a
+        value no client could ever have read back — and once archived, it is
+        indistinguishable from one that was."""
+        times, _ = seed_grid(SMALL, T0)
+        documents = synthesize_documents(CHANNELS, times[:8])
+
+        values = {document["SR:STATUS:VALID"] for document in documents}
+        assert values == {True}
+        assert all(isinstance(document["SR:STATUS:VALID"], bool) for document in documents)
+
+    def test_a_modelless_flag_does_not_move(self):
+        """Nothing drives it — the manifest forbids declaring these noisy, and
+        the VA serves a bare coerced baseline on every tick."""
+        channels = [{"address": "SR:STATUS:READY", "record_type": "bi"}]
+        times, _ = seed_grid(SMALL, T0)
+
+        documents = synthesize_documents(channels, times)
+
+        assert len({document["SR:STATUS:READY"] for document in documents}) == 1
+
+    def test_boot_values_anchor_the_procedural_baseline(self):
+        """The seeder holds the machine model; without threading it through, a
+        setpoint would be archived at the taxonomy's guess for its name."""
+        pv = "SR:MAG:HCM:01:CURRENT:SP"
+        channels = [{"address": pv, "record_type": "ai"}]
+        times, _ = seed_grid(SMALL, T0)
+
+        anchored = synthesize_documents(channels, times[:16], boot_values={pv: 0.25})
+        unanchored = synthesize_documents(channels, times[:16])
+
+        assert np.mean([d[pv] for d in anchored]) == pytest.approx(0.25, abs=0.05)
+        assert np.mean([d[pv] for d in unanchored]) == pytest.approx(150.0, rel=0.1)
+
+    def test_an_empty_window_produces_no_documents(self):
+        assert synthesize_documents(CHANNELS, np.empty(0)) == []
+
+
+# ---------------------------------------------------------------------------
+# The manifest
+# ---------------------------------------------------------------------------
+
+
+class TestFingerprint:
+    """What provokes a reseed, and what must not."""
+
+    def _fingerprint(self, knobs=SMALL, addresses=ADDRESSES, compression="zstd"):
+        return seed_fingerprint(knobs, addresses, compression=compression)
+
+    def test_the_channel_set_is_hashed_order_independently(self):
+        """The manifest and the config can list channels in any order; only
+        membership changes what the store contains."""
+        forwards = self._fingerprint(addresses=ADDRESSES)
+        backwards = self._fingerprint(addresses=list(reversed(ADDRESSES)))
+
+        assert forwards == backwards
+
+    def test_adding_a_channel_changes_the_fingerprint(self):
+        assert self._fingerprint() != self._fingerprint(addresses=[*ADDRESSES, "SR:NEW:CHANNEL"])
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("retention_days", 2),
+            ("hot_span_hours", 2),
+            ("hot_cadence_sec", 5),
+            ("tail_cadence_sec", 120),
+        ],
+    )
+    def test_every_knob_that_changes_coverage_changes_the_fingerprint(self, field, value):
+        changed = SeedKnobs(**{**SMALL.__dict__, field: value})
+
+        assert self._fingerprint(knobs=changed) != self._fingerprint()
+
+    def test_compression_is_part_of_it(self):
+        """It does not change which samples are stored, but it changes the size
+        of the store on disk — which is the budget the knob exists to hold."""
+        assert self._fingerprint(compression="snappy") != self._fingerprint()
+
+
+class TestFingerprintComparison:
+    """Match, mismatch, absent — and the trap in between."""
+
+    def test_an_unseeded_store_reports_absent(self, collection):
+        assert compare_fingerprint(collection, self._current()).state is SeedState.ABSENT
+
+    def test_a_store_seeded_with_the_same_knobs_matches(self, collection):
+        write_manifest(collection, self._current(), seeded_at=T0)
+
+        comparison = compare_fingerprint(collection, self._current())
+
+        assert comparison.state is SeedState.MATCH
+        assert comparison.differences == ()
+
+    def test_a_later_deploy_of_an_unchanged_profile_still_matches(self, collection):
+        """The trap: the seed instant moves on every deploy. Counting it would
+        make every deploy rebuild the store, and the mistake would look like
+        working code — a reseed is not an error, just hours of wasted CI."""
+        write_manifest(collection, self._current(), seeded_at=T0)
+
+        comparison = compare_fingerprint(collection, self._current())
+
+        assert comparison.state is SeedState.MATCH
+        assert comparison.seeded_at is not None
+
+    def test_a_changed_knob_reports_what_moved(self, collection):
+        write_manifest(collection, self._current(), seeded_at=T0)
+
+        comparison = compare_fingerprint(
+            collection, seed_fingerprint(SeedKnobs(retention_days=7), ADDRESSES, compression="zstd")
+        )
+
+        assert comparison.state is SeedState.MISMATCH
+        moved = {key for key, _, _ in comparison.differences}
+        assert "retention_days" in moved
+        assert "7" in comparison.describe()
+
+    def test_a_manifest_from_an_older_version_mismatches_readably(self, collection):
+        """A field the stored manifest never had reads as ``None`` rather than
+        being skipped — skipping would let an older store pass as current."""
+        collection.replace_one(
+            {"_id": MANIFEST_ID},
+            {"_id": MANIFEST_ID, "fingerprint": {"retention_days": SMALL.retention_days}},
+            upsert=True,
+        )
+
+        comparison = compare_fingerprint(collection, self._current())
+
+        assert comparison.state is SeedState.MISMATCH
+        assert any(stored is None for _, stored, _ in comparison.differences)
+
+    def test_the_manifest_starts_with_an_empty_ledger(self, collection):
+        """The scenario rewrite owns it; a fresh base has touched nothing."""
+        write_manifest(collection, self._current(), seeded_at=T0)
+
+        assert collection.find_one({"_id": MANIFEST_ID})["touched_windows"] == []
+
+    @staticmethod
+    def _current():
+        return seed_fingerprint(SMALL, ADDRESSES, compression="zstd")
+
+
+# ---------------------------------------------------------------------------
+# Writing to a real store
+# ---------------------------------------------------------------------------
+
+
+class TestSeedBase:
+    """The whole run against MongoDB, read back through the real connector."""
+
+    def test_it_writes_one_document_per_grid_timestamp(self, collection):
+        times, _ = seed_grid(SMALL, T0)
+
+        report = seed_base(collection, CHANNELS, SMALL, t0=T0, chunk_size=64)
+
+        assert report.documents == len(times)
+        assert collection.count_documents({DATE_FIELD: {"$exists": True}}) == len(times)
+        assert report.channels == len(CHANNELS)
+
+    def test_the_indexes_the_store_cannot_work_without_exist(self, collection):
+        """An unindexed sort on ``date`` is capped at 32 MB of documents in
+        memory, which a real window crosses long before a test does."""
+        seed_base(collection, CHANNELS, SMALL, t0=T0, chunk_size=64)
+
+        indexes = collection.index_information()
+        keyed = {tuple(spec["key"][0]) for spec in indexes.values()}
+        assert (DATE_FIELD, 1) in keyed
+        ttl = [spec for spec in indexes.values() if "expireAfterSeconds" in spec]
+        assert len(ttl) == 1
+        assert ttl[0]["expireAfterSeconds"] == 0
+        assert tuple(ttl[0]["key"][0]) == (EXPIRE_FIELD, 1)
+
+    def test_documents_carry_their_tier_s_expiry(self, collection):
+        """Checked on the stamps, not by waiting: MongoDB's TTL sweeper runs on
+        its own minute-scale schedule, so a test that waited for it would be
+        testing the sweeper's timer."""
+        seed_base(collection, CHANNELS, SMALL, t0=T0, chunk_size=64)
+
+        for document in collection.find({DATE_FIELD: {"$exists": True}}):
+            stored = document[DATE_FIELD].replace(tzinfo=UTC)
+            lifetime = (document[EXPIRE_FIELD].replace(tzinfo=UTC) - stored).total_seconds()
+            dense = int(stored.timestamp()) % SMALL.tail_cadence_sec != 0
+            assert lifetime == (SMALL.hot_span_s if dense else SMALL.retention_s)
+
+    def test_the_manifest_is_written_and_is_invisible_to_an_archiver_read(self, collection):
+        """It lives in the sample collection, which is only safe because it has
+        no ``date``: the connector's window filter requires one, so no query can
+        ever return it as a sample."""
+        seed_base(collection, CHANNELS, SMALL, t0=T0, chunk_size=64)
+
+        manifest = collection.find_one({"_id": MANIFEST_ID})
+        assert manifest is not None
+        assert DATE_FIELD not in manifest
+        assert (
+            compare_fingerprint(
+                collection, seed_fingerprint(SMALL, ADDRESSES, compression="zstd")
+            ).state
+            is SeedState.MATCH
+        )
+
+    def test_a_half_written_store_reads_as_absent(self, collection):
+        """The manifest is written last on purpose. A run that dies partway
+        leaves no manifest, so the next deploy rebuilds instead of trusting a
+        store that is missing most of its history."""
+        times, _ = seed_grid(SMALL, T0)
+        prepare_collection(collection)
+        collection.insert_many(synthesize_documents(CHANNELS, times[:10]))
+
+        comparison = compare_fingerprint(
+            collection, seed_fingerprint(SMALL, ADDRESSES, compression="zstd")
+        )
+
+        assert comparison.state is SeedState.ABSENT
+
+    def test_progress_is_reported_per_chunk(self, collection):
+        """A three-minute step with no output reads as a hang."""
+        seen: list[int] = []
+
+        report = seed_base(
+            collection,
+            CHANNELS,
+            SMALL,
+            t0=T0,
+            chunk_size=64,
+            progress=lambda r: seen.append(r.documents),
+        )
+
+        assert len(seen) == report.chunks > 1
+        assert seen == sorted(seen)
+        assert seen[-1] == report.documents
+
+    def test_the_oldest_sample_is_the_start_of_the_window(self, collection):
+        """What honest metadata reports as the start of coverage — no more
+        'archived since the year 2000'."""
+        times, _ = seed_grid(SMALL, T0)
+        seed_base(collection, CHANNELS, SMALL, t0=T0, chunk_size=64)
+
+        assert oldest_sample(collection) == datetime.fromtimestamp(float(times[0]), UTC)
+
+    def test_an_empty_store_has_no_oldest_sample(self, collection):
+        prepare_collection(collection)
+
+        assert oldest_sample(collection) is None
+
+    @pytest.mark.parametrize("workers", [1, 4])
+    def test_the_worker_count_does_not_change_what_is_stored(self, collection, workers):
+        """Inserts are unordered and overlap the synthesis; concurrency is a
+        throughput decision and must not be a correctness one."""
+        seed_base(collection, CHANNELS, SMALL, t0=T0, chunk_size=32, workers=workers)
+
+        times, _ = seed_grid(SMALL, T0)
+        assert collection.count_documents({DATE_FIELD: {"$exists": True}}) == len(times)
+        pv = "SR:VAC:IP07:PRESSURE"
+        document = collection.find_one({DATE_FIELD: {"$exists": True}}, sort=[(DATE_FIELD, 1)])
+        assert (
+            document[pv]
+            == generate_series(pv, np.asarray([float(times[0])]), baseline=baseline_value(pv))[0]
+        )
+
+
+class TestConnectorRoundtrip:
+    """Read the seeded store back the way a deployed agent does."""
+
+    @pytest.mark.asyncio
+    async def test_a_query_returns_the_values_the_generator_computes(self, collection, read_back):
+        """The end-to-end claim: history in the store equals history a query
+        would have synthesized, through the real connector and its real schema."""
+        seed_base(collection, CHANNELS, SMALL, t0=T0, chunk_size=64)
+        pv = "SR:VAC:IP07:PRESSURE"
+        window_end = T0.replace(second=0, microsecond=0)
+        window_start = window_end - timedelta(minutes=5)
+
+        frame = await read_back([pv], window_start, window_end)
+
+        rows = frame[frame["channel"] == pv]
+        assert len(rows) > 0
+        stamps = epoch_seconds_array(list(rows["timestamp"]))
+        expected = generate_series(pv, stamps, baseline=baseline_value(pv))
+        assert np.allclose(rows["value"].to_numpy(), expected, rtol=0, atol=0)
+
+    @pytest.mark.asyncio
+    async def test_a_window_before_the_archive_starts_returns_nothing(self, collection, read_back):
+        """Honest emptiness. The mock archiver's ten-point floor is exactly the
+        fabrication a stored archive exists to replace."""
+        seed_base(collection, CHANNELS, SMALL, t0=T0, chunk_size=64)
+        ancient = T0 - timedelta(days=400)
+
+        frame = await read_back(["SR:VAC:IP07:PRESSURE"], ancient, ancient + timedelta(hours=1))
+
+        assert len(frame) == 0
+
+    @pytest.mark.asyncio
+    async def test_a_channel_outside_the_seeded_set_returns_nothing(self, collection, read_back):
+        """Sparse documents are legal in this schema, so an unseeded channel
+        contributes no samples rather than an error or a plausible series."""
+        seed_base(collection, CHANNELS, SMALL, t0=T0, chunk_size=64)
+
+        frame = await read_back(["SR:NOT:SEEDED"], T0 - timedelta(minutes=10), T0)
+
+        assert len(frame) == 0
+
+
+def _epoch(moment: datetime) -> float:
+    return moment.timestamp()
+
+
+def test_the_module_never_imports_pymongo():
+    """An optional dependency has to stay optional.
+
+    The seeder is imported by deployment code that runs on hosts where the
+    ``archiver-mongodb`` extra was never selected — the fingerprint check has to
+    be able to say "no store here" without one.
+    """
+    import subprocess
+    import sys
+
+    result = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-c",
+            "import sys, osprey.simulation.archiver_seed as m;"
+            "assert 'pymongo' not in sys.modules, sorted(sys.modules);"
+            "print('CLEAN')",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "CLEAN" in result.stdout
+
+
+def test_the_manifest_document_is_json_serializable_apart_from_its_dates():
+    """The fingerprint is stored verbatim and compared field by field, so every
+    value in it has to be a plain scalar rather than something BSON encodes by
+    its own rules."""
+    fingerprint = seed_fingerprint(SMALL, ADDRESSES, compression="zstd")
+
+    assert json.loads(json.dumps(fingerprint)) == fingerprint
+
+
+def test_a_comparison_describes_nothing_when_nothing_moved():
+    assert FingerprintComparison(SeedState.MATCH).describe() == ""

--- a/tests/simulation/test_control_assistant_scenarios.py
+++ b/tests/simulation/test_control_assistant_scenarios.py
@@ -15,25 +15,36 @@ Signatures pinned (target value -> asserted threshold, with margin):
   sector, leading the runner-up by ~0.7 (assert separation > 0.3 — robust to
   the noise tail, unlike an absolute |r| bound); SR07 spike ~4x baseline;
   DCCT dips ~5 mA.
-- ``rf-thermal``: CAVITY01 temperature excursions near window fractions
-  0.20/0.55/0.85 (peaks 32-36 degC, assert > 31 over base 27); CAVITY02
-  stays quiet (~28.5 degC, assert < 29.5, far below the CAVITY01
-  excursions); CAVITY01 reflected power tracks temperature (r ~= 0.96,
-  assert > 0.8); derived
+- ``rf-thermal``: CAVITY01 temperature excursions at the anchored offsets
+  T0-38h/-21h/-7h (peaks 32-36 degC, assert > 31 over base 27), with the
+  stretch older than T0-48h flat; CAVITY02 stays quiet (~28.5 degC, assert
+  < 29.5, far below the CAVITY01 excursions); CAVITY01 reflected power tracks
+  temperature (r ~= 0.97, assert > 0.8); derived
   POWER:NET tracks FWD-REV (r ~= 0.998, assert > 0.95); FREQUENCY:RB detunes
   downward during the excursions.
 """
 
+import json
 from datetime import UTC, datetime, timedelta
 
 import numpy as np
 import pytest
+
+from osprey.cli.build_profile_archiver import VAArchiverConfig
+from tests.simulation.conftest import TEMPLATE_SIM
 
 # The shipped control_assistant engine is built by the shared ``engine_factory``
 # fixture in conftest.py (copies machine.json + the scenarios/ bundle tree).
 GAUGE = "SR:VAC:GAUGE:SR{:02d}:PRESSURE:RB"
 DCCT = "SR:DIAG:DCCT:01:CURRENT:RB"
 RF_SERIES_N = 2016  # 7-day window at 5-minute resolution
+
+# rf-thermal's three CAVITY01 excursions, in hours before the scenario-activation
+# anchor T0, and their Gaussian sigma. Mirrors ``rf-thermal/scenario.json``; the
+# tests below read the bundle back rather than trusting these, so a bundle edit
+# that forgets this file fails loudly instead of silently drifting.
+RF_EXCURSION_OFFSETS_H = (-38.0, -21.0, -7.0)
+RF_EXCURSION_SIGMA_S = 7200.0
 
 
 def _window(center: datetime, minutes: int = 10, step_s: int = 1) -> list[datetime]:
@@ -116,25 +127,71 @@ class TestVacuumBurstContract:
 
 
 class TestRfThermalContract:
-    """CAVITY01 thermal excursions drive reflected power, forward trips, detuning."""
+    """CAVITY01 thermal excursions drive reflected power, forward trips, detuning.
+
+    The bundle positions its events with ``at_offset`` — seconds before the
+    scenario-activation anchor T0 — so an excursion sits at a fixed wall-clock
+    time rather than at a fixed fraction of whatever window is queried. The
+    ``engine_factory`` fixture writes ``active_scenarios`` as it builds the
+    engine and the bundle carries no explicit ``anchor=`` line, so T0 is that
+    file's mtime: within a second of ``datetime.now()`` here. The
+    excursion-position windows below are hours wide, which absorbs that.
+    """
 
     CAV = "SR:RF:CAVITY:{:02d}:{}"
 
     def _series(self, engine, dev, suffix, n=RF_SERIES_N):
+        """A 7-day window ending now, at 5-minute resolution."""
         end = datetime.now()
         ts = [end - timedelta(days=7) + timedelta(minutes=5 * i) for i in range(n)]
         return np.array(engine.synthesize_series(self.CAV.format(dev, suffix), ts))
 
-    def test_cavity01_excursions_at_documented_positions(self, engine_factory):
-        """CAVITY01 temperature peaks > 31 degC (over base 27) near t=0.20/0.55/0.85."""
+    def _hours_before_now(self, n=RF_SERIES_N):
+        """Signed hours-from-now for each sample of ``_series``'s window."""
+        return np.linspace(-7 * 24.0, 0.0, n, endpoint=False)
+
+    def test_cavity01_excursions_at_anchored_offsets(self, engine_factory):
+        """CAVITY01 temperature peaks > 31 degC (over base 27) at T0-38h/-21h/-7h."""
         engine = engine_factory("rf-thermal")
         temp = self._series(engine, 1, "TEMPERATURE:RB")
-        t = np.linspace(0, 1, len(temp))
-        for pos in (0.20, 0.55, 0.85):
-            window = temp[(t > pos - 0.03) & (t < pos + 0.03)]
+        hours = self._hours_before_now(len(temp))
+        for offset_h in RF_EXCURSION_OFFSETS_H:
+            # +/- 3h brackets the 2h-sigma spike without reaching its neighbours,
+            # which sit 15-17h away.
+            window = temp[(hours > offset_h - 3.0) & (hours < offset_h + 3.0)]
             assert window.max() > 31.0, (
-                f"no CAVITY01 excursion near t={pos} (max {window.max():.2f})"
+                f"no CAVITY01 excursion at T0{offset_h:+.0f}h (max {window.max():.2f})"
             )
+
+    def test_cavity01_is_flat_before_the_excursion_band(self, engine_factory):
+        """Older than T0-48h, CAVITY01 temperature is quiet baseline + noise.
+
+        Under the previous window-fraction positioning no part of any window was
+        event-free — the excursions rescaled to whatever span was queried. Anchored
+        offsets confine them to the last 40 hours, so this stretch is genuinely
+        undisturbed, and asserting that is what stops an accidental slide back to
+        fraction semantics from passing silently.
+        """
+        engine = engine_factory("rf-thermal")
+        temp = self._series(engine, 1, "TEMPERATURE:RB")
+        hours = self._hours_before_now(len(temp))
+        quiet = temp[hours < -48.0]
+        assert quiet.max() < 29.0, (
+            f"CAVITY01 temp peak {quiet.max():.2f} older than T0-48h, contract < 29.0 "
+            f"(base 27 + noise); an excursion has leaked outside the anchored band"
+        )
+
+    def test_bundle_offsets_match_the_pinned_contract(self, engine_factory):
+        """The shipped bundle carries exactly the offsets/width this file asserts."""
+        bundle = json.loads((TEMPLATE_SIM / "scenarios/rf-thermal/scenario.json").read_text())
+        cav01_temp = next(
+            entry
+            for entry in bundle["archiver"]
+            if entry["channel"] == self.CAV.format(1, "TEMPERATURE:RB")
+        )
+        offsets_h = tuple(ev["at_offset"] / 3600.0 for ev in cav01_temp["events"])
+        assert offsets_h == RF_EXCURSION_OFFSETS_H
+        assert {ev["width"] for ev in cav01_temp["events"]} == {RF_EXCURSION_SIGMA_S}
 
     def test_cavity02_stays_quiet(self, engine_factory):
         """CAVITY02 temperature stays < 29.5 degC — far below CAVITY01's 32-36 degC excursions."""
@@ -188,4 +245,94 @@ class TestRfThermalContract:
         freq = self._series(engine, 1, "FREQUENCY:RB")
         assert freq.min() < 499.654 - 0.0005, (
             f"CAVITY01 freq min {freq.min():.6f}, contract < 499.6535"
+        )
+
+
+class TestEventsFitTheSeedWindow:
+    """Every shipped scenario event is placeable inside the archiver's seed window.
+
+    The archiver is seeded once at deploy time over ``[T0 - horizon, T0]`` and
+    scenario activation later rewrites only the windows its events touch. An
+    event outside that span has nowhere to be written, so it would silently go
+    missing from stored history while still showing up in the mock's on-the-fly
+    synthesis — exactly the divergence this whole feature exists to remove.
+    These are data contracts on the shipped bundles, so they hold for any deploy
+    rather than for one engine instance.
+
+    **Anchoring assumption.** Two separate clocks are involved: the deploy-time
+    seed anchor and the ``osprey sim apply`` anchor. This property holds only
+    because they are one and the same — the seeder records its T0 in the
+    seed-manifest document and scenario activation resolves ``at_offset``
+    against that persisted anchor, not against its own wall clock. If those two
+    ever drift apart, an event within ``horizon`` of the apply anchor can still
+    land outside the seeded span, and this test no longer proves what it claims.
+    """
+
+    # Seed span: bound to the shipped ``va_archiver.retention_days`` default
+    # rather than restated, so lowering that default in the profile block makes
+    # this test fail instead of quietly passing against a window the seeder no
+    # longer covers.
+    SEED_HORIZON_S = VAArchiverConfig().retention_days * 24 * 3600.0
+    # Fraction of a Gaussian sigma an anchored spike may extend past T0. Spikes
+    # are symmetric, so an event centred too close to T0 has half its shape in
+    # the unseedable future; 3 sigma covers essentially all of it.
+    SIGMA_MARGIN = 3.0
+
+    def _bundles(self):
+        """(name, parsed scenario.json) for every shipped control_assistant bundle."""
+        roots = sorted(p for p in (TEMPLATE_SIM / "scenarios").iterdir() if p.is_dir())
+        assert roots, "no scenario bundles found — the template layout moved"
+        return [(p.name, json.loads((p / "scenario.json").read_text())) for p in roots]
+
+    def _events(self):
+        """(bundle, channel, event) for every archiver event in every bundle."""
+        return [
+            (name, entry["channel"], event)
+            for name, spec in self._bundles()
+            for entry in spec.get("archiver", [])
+            for event in entry["events"]
+        ]
+
+    def test_shipped_bundles_carry_no_window_fraction_events(self):
+        """No shipped event uses ``at`` — fraction positions are unseedable.
+
+        A fraction-positioned event lands at a fixed *proportion* of whichever
+        window is queried, which has no absolute time and so cannot be written
+        into a store. Only ``at_offset`` (anchored) and ``at_time`` (daily
+        recurrence) resolve to real timestamps.
+        """
+        fraction_events = [
+            f"{name}/{pv}: at={event['at']}" for name, pv, event in self._events() if "at" in event
+        ]
+        assert not fraction_events, (
+            "shipped scenario events must be anchored ('at_offset') or daily "
+            f"('at_time'), not window fractions: {fraction_events}"
+        )
+
+    def test_anchored_events_land_inside_the_seed_window(self):
+        """Every ``at_offset`` event sits inside ``[T0 - horizon, T0]``."""
+        for name, pv, event in self._events():
+            if "at_offset" not in event:
+                continue
+            at = float(event["at_offset"])
+            assert -self.SEED_HORIZON_S <= at <= 0.0, (
+                f"{name}/{pv}: at_offset={at:.0f}s falls outside the seed window "
+                f"[T0-{self.SEED_HORIZON_S:.0f}s, T0]"
+            )
+            # A ramp's far end and a spike's tail must fit too, not just its start.
+            end = at + self.SIGMA_MARGIN * float(event["width"]) if "width" in event else at
+            if "until_offset" in event:
+                end = float(event["until_offset"])
+            assert end <= 0.0, (
+                f"{name}/{pv}: event extends to T0{end:+.0f}s, past the end of the "
+                f"seed window (nothing after T0 is seeded)"
+            )
+
+    def test_daily_events_recur_inside_the_seed_window(self):
+        """``at_time`` events recur daily, so a horizon of >= 1 day always contains one."""
+        daily = [e for e in self._events() if "at_time" in e[2]]
+        assert daily, "expected at least one daily event (vacuum-burst); coverage went vacuous"
+        assert self.SEED_HORIZON_S >= 24 * 3600.0, (
+            "seed horizon is under a day — daily events are no longer guaranteed a "
+            "seeded occurrence"
         )

--- a/tests/simulation/test_procedural_generator.py
+++ b/tests/simulation/test_procedural_generator.py
@@ -1,0 +1,511 @@
+"""The procedural generator's contract: absolute time, VA baselines, bounded.
+
+``osprey.simulation.procedural`` synthesizes history for the channels a
+project's ``machine.json`` does not describe — 1,872 of the control-assistant
+preset's 2,908 — and its output is written into a real store as well as
+returned from live archiver queries. That makes three things load-bearing, and
+this file locks each of them:
+
+* **Window independence.** Values are a pure function of ``(channel, epoch
+  seconds)``. Two overlapping queries must agree on every timestamp they share,
+  and a document seeded at time T must equal what a later query synthesizes for
+  T — otherwise materializing the series produces history that contradicts the
+  next read. The predecessor generator was a function of the query's *shape*
+  (an ``np.linspace(0, 1, n)`` axis) and satisfied neither.
+
+* **Baseline anchoring.** The baseline is whatever the Virtual Accelerator
+  boots the channel at, drawn from the same two sources the VA itself uses.
+  The per-partition test below reads the shipped channel manifest and machine
+  model and checks the generator against the VA's own serving layer, so a
+  divergence between the two worlds fails here rather than as a phantom step in
+  a deployed archive.
+
+* **A bounded, noise-scaled envelope.** Seeded history and recorded reality
+  meet at a seam; the step across it has to be attributable to noise, not read
+  as an event. ``deviation_bound`` states the envelope and the shape terms are
+  structurally inside it.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from osprey.connectors.pv_taxonomy import classify_pv
+from osprey.services.virtual_accelerator.manifest.loaders import load_machine_json_channels
+from osprey.services.virtual_accelerator.serving.pvdb import build_serving_pvdb
+from osprey.simulation.procedural import (
+    DEFAULT_NOISE_LEVEL,
+    KIND_SHAPES,
+    baseline_value,
+    deviation_bound,
+    generate_series,
+)
+from osprey.simulation.series import epoch_seconds_array
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = REPO_ROOT / "src/osprey/services/virtual_accelerator/manifest/channel_manifest.json"
+MACHINE = REPO_ROOT / "src/osprey/templates/apps/control_assistant/data/simulation/machine.json"
+
+# A fixed instant, so a failure is reproducible rather than time-of-day
+# dependent. Any epoch works: the generator has no preferred origin.
+T0 = datetime(2026, 3, 14, 9, 26, 53, tzinfo=UTC)
+
+# One PV per kind the taxonomy can return, named the way a real facility names
+# them so `classify_pv` reaches the intended branch.
+KIND_EXAMPLES = {
+    "beam_current": "SR:DCCT:BEAM:CURRENT",
+    "current": "SR:MAG:QF01:CURRENT",
+    "voltage": "SR:RF:CAV01:VOLTAGE",
+    "power": "SR:RF:CAV01:POWER:FWD",
+    "pressure": "SR:VAC:IP07:PRESSURE",
+    "temperature": "SR:RF:CAV01:TEMP:BODY",
+    "lifetime": "SR:BEAM:LIFETIME",
+    "position": "SR:DIAG:BPM:12:POSITION:X",
+    "energy": "SR:BEAM:ENERGY",
+    "default": "SR:SOME:UNCLASSIFIED:CHANNEL",
+}
+
+
+def _sigma(pv: str, noise_level: float = DEFAULT_NOISE_LEVEL) -> float:
+    """The channel's noise sigma, the unit every shape amplitude is quoted in.
+
+    Read back out of the public bound rather than recomputed: passing zero
+    Gaussian headroom leaves exactly the shape envelope, so a test tolerance
+    tracks the shape table instead of restating it.
+    """
+    return deviation_bound(pv, noise_level=noise_level, noise_sigmas=0.0) / (
+        KIND_SHAPES[classify_pv(pv).name].shape_sigmas
+    )
+
+
+def _phase_profile(pv: str, bins: int = 24, cycles: int = 240) -> np.ndarray:
+    """The kind's periodic term, recovered by folding many cycles onto one.
+
+    Every sample carries an independent noise draw roughly as large as the
+    whole shape envelope — deliberately, since the live machine serves these
+    channels as stationary noise and history that visibly exceeded it would be
+    a fabricated dynamic. So the shape is not visible sample to sample and a
+    test that looked for it there would be testing the noise. Averaging samples
+    that share a phase suppresses the noise as ``1/sqrt(n)`` while the periodic
+    term survives intact, and spanning many cycles (here ~40 days, far longer
+    than any declared drift period) averages the drift stack away with it.
+
+    The result is rotated so its maximum sits first. Each channel's cycle
+    starts at a phase drawn from its own key — that is what stops a family of
+    channels from peaking in unison — so the phase *origin* is per-channel and
+    carries no shape information; only the profile's course away from its peak
+    does.
+
+    Returns:
+        ``bins`` mean values, ordered by phase from the peak onwards, with the
+        overall mean removed so the result is centred on zero.
+    """
+    period = KIND_SHAPES[classify_pv(pv).name].cycle_period_s
+    samples_per_cycle = bins * 10
+    grid = _grid(T0, count=cycles * samples_per_cycle, step_s=period / samples_per_cycle)
+
+    values = generate_series(pv, grid)
+    phase_bin = np.floor(np.mod(grid / period, 1.0) * bins).astype(int)
+    profile = np.array([values[phase_bin == b].mean() for b in range(bins)])
+    profile -= profile.mean()
+    return np.roll(profile, -int(np.argmax(profile)))
+
+
+def _grid(start: datetime, count: int, step_s: float) -> np.ndarray:
+    """Epoch seconds for ``count`` samples every ``step_s`` from ``start``.
+
+    Built through ``epoch_seconds_array`` from real datetimes, which is the
+    conversion every production caller is required to use — computing the
+    seconds arithmetically here would test a route the writers do not take.
+    """
+    stamps = [start + timedelta(seconds=step_s * i) for i in range(count)]
+    values = epoch_seconds_array(stamps)
+    assert values is not None
+    return values
+
+
+class TestWindowIndependence:
+    """The property the whole seeded-store design rests on."""
+
+    def test_overlapping_windows_agree_pointwise(self):
+        """Two queries of different span and cadence, sharing timestamps.
+
+        The windows deliberately differ in *both* origin and sample count: a
+        generator that keyed on the sample index would pass a same-shape
+        comparison and fail this one.
+        """
+        pv = "SR:VAC:IP07:PRESSURE"
+        shared_start = T0 + timedelta(hours=2)
+
+        wide = _grid(T0, count=181, step_s=120.0)
+        narrow = _grid(shared_start, count=31, step_s=120.0)
+
+        wide_values = generate_series(pv, wide)
+        narrow_values = generate_series(pv, narrow)
+
+        overlap = np.intersect1d(wide, narrow)
+        assert len(overlap) == 31, "the two grids were meant to share their tail"
+
+        wide_at_overlap = wide_values[np.searchsorted(wide, overlap)]
+        narrow_at_overlap = narrow_values[np.searchsorted(narrow, overlap)]
+        assert np.array_equal(wide_at_overlap, narrow_at_overlap)
+
+    def test_a_single_sample_equals_its_value_in_a_batch(self):
+        """A recorder reads one timestamp; a seeder writes a whole grid.
+
+        The two must not disagree, so batching may not change a value — which
+        also means the scalar (live-read) path and the array path are one
+        computation.
+        """
+        pv = "SR:MAG:QF01:CURRENT"
+        grid = _grid(T0, count=97, step_s=45.0)
+        batch = generate_series(pv, grid)
+
+        for index in (0, 13, 96):
+            assert generate_series(pv, float(grid[index])) == batch[index]
+
+    def test_reordering_the_grid_permutes_the_values(self):
+        """No stream position: a shuffled query returns shuffled values."""
+        pv = "CRYO:LN2:TEMP"
+        grid = _grid(T0, count=64, step_s=30.0)
+        order = np.arange(64)[::-1]
+
+        assert np.array_equal(generate_series(pv, grid[order]), generate_series(pv, grid)[order])
+
+    def test_distinct_channels_do_not_collide(self):
+        """Reproducible must not mean identical across channels."""
+        grid = _grid(T0, count=32, step_s=60.0)
+        first = generate_series("SR:VAC:IP07:PRESSURE", grid)
+        second = generate_series("SR:VAC:IP08:PRESSURE", grid)
+
+        assert not np.array_equal(first, second)
+
+
+class TestCrossProcessDeterminism:
+    """A seeder in one process and a query in another must agree exactly."""
+
+    def test_values_repeat_in_fresh_interpreters(self):
+        """Fresh interpreters with different hash seeds.
+
+        ``hash()`` is salted per process, so only a subprocess can catch a key
+        derived from it — the failure mode this construction exists to avoid.
+        """
+        script = textwrap.dedent("""
+            import json
+            from datetime import UTC, datetime, timedelta
+            from osprey.simulation.procedural import generate_series
+            from osprey.simulation.series import epoch_seconds_array
+
+            start = datetime(2026, 3, 14, 9, 26, 53, tzinfo=UTC)
+            stamps = [start + timedelta(seconds=17 * i) for i in range(24)]
+            grid = epoch_seconds_array(stamps)
+            print(json.dumps(generate_series("SR:VAC:IP07:PRESSURE", grid).tolist()))
+        """)
+
+        runs = []
+        for seed in ("0", "1", "12345"):
+            env = {**os.environ, "PYTHONHASHSEED": seed}
+            result = subprocess.run(  # noqa: S603
+                [sys.executable, "-c", script],
+                capture_output=True,
+                text=True,
+                env=env,
+                check=True,
+            )
+            runs.append(json.loads(result.stdout.strip().splitlines()[-1]))
+
+        assert runs[0] == runs[1] == runs[2]
+        assert len(runs[0]) == 24
+        # The in-process value is the same computation, so it must match too:
+        # cross-process agreement among three subprocesses would be vacuous if
+        # the host process disagreed with all of them.
+        grid = _grid(T0, count=24, step_s=17.0)
+        assert generate_series("SR:VAC:IP07:PRESSURE", grid).tolist() == runs[0]
+
+
+class TestBaselineAnchoring:
+    """Baselines come from the same two sources the VA boots channels from.
+
+    The manifest's three fidelity partitions are covered together because they
+    differ precisely in where their boot value comes from: pyat-coupled and
+    sp-echo channels are ``:SP``/``:RB`` addresses seeded from the machine
+    model, while static-noisy channels have no model entry and are served from
+    the PV taxonomy. A generator that anchored only one of them would seam
+    cleanly on that partition and plant a step on the others.
+    """
+
+    @staticmethod
+    def _manifest_channels() -> list[dict]:
+        return json.loads(MANIFEST.read_text())["channels"]
+
+    @staticmethod
+    def _boot_values() -> dict[str, float]:
+        """The map the VA entrypoint derives for ``build_serving_pvdb``."""
+        return {
+            address: entry["value"]
+            for address, entry in load_machine_json_channels(MACHINE).items()
+            if "value" in entry
+        }
+
+    @staticmethod
+    def _va_value(channel: dict, boot_values: dict, served: dict) -> float:
+        """What the VA settles this channel at, by its own three rules.
+
+        Written as the VA's rules rather than as the generator's, so agreement
+        is evidence and not a tautology. ``served`` is the record database the
+        VA builds at boot; it is the authority for the undriven channels, whose
+        boot value is also their steady value. The static-noisy partition is
+        *not* read from it: those records are overwritten by ``EngineSource``
+        within one poll tick, so their boot spec is a value nobody observes.
+        """
+        address = channel["address"]
+        if address in boot_values:
+            return float(boot_values[address])
+        if channel["subfield"] in ("SP", "RB"):
+            return float(served[address]["value"])
+        return classify_pv(address).base_value
+
+    @pytest.mark.parametrize("partition", ["pyat-coupled", "sp-echo", "static-noisy"])
+    def test_baseline_equals_the_value_the_va_settles_the_channel_at(self, partition):
+        """Every analog channel of the partition, not a sample of them.
+
+        The manifest is the deployed channel universe and it is cheap to sweep
+        whole; a sampled version of this test would pass while leaving a
+        fabricated baseline on any channel it skipped.
+        """
+        channels = [c for c in self._manifest_channels() if c["partition"] == partition]
+        assert channels, f"no {partition} channels in the shipped manifest"
+
+        boot_values = self._boot_values()
+        served = build_serving_pvdb(self._manifest_channels(), boot_values=boot_values).pvdb
+
+        analog = [c for c in channels if c["record_type"] == "ai"]
+        assert analog, f"no analog {partition} channels in the shipped manifest"
+
+        for channel in analog:
+            address = channel["address"]
+            assert baseline_value(address, boot_values) == pytest.approx(
+                self._va_value(channel, boot_values, served)
+            ), f"{address} ({partition}) starts somewhere the VA does not"
+
+    def test_an_unseeded_setpoint_is_not_given_a_taxonomy_guess(self):
+        """The rule the sweep above would let through if it were sampled.
+
+        A dozen sp-echo setpoints have no machine-model seed. Nothing drives a
+        setpoint but a client write, so the live channel reads 0 forever —
+        history at the taxonomy's 5 kV guess for a name containing "VOLTAGE"
+        would be invention, and exactly the kind an agent would diagnose from.
+        """
+        address = "SR:VAC:ION-PUMP:01:VOLTAGE:SP"
+        boot_values = self._boot_values()
+        assert address not in boot_values
+        assert classify_pv(address).base_value == 5000.0
+
+        assert baseline_value(address, boot_values) == 0.0
+        assert np.array_equal(
+            generate_series(address, _grid(T0, count=16, step_s=60.0), baseline=0.0),
+            np.zeros(16),
+        )
+
+    def test_a_seeded_setpoint_overrides_the_taxonomy_guess(self):
+        """The override has to actually bite, or the test above proves nothing.
+
+        A magnet ``:SP`` classifies as the ``current`` kind (base 150 A) while
+        the machine model seeds it at its real value; the seeded one wins.
+        """
+        boot_values = self._boot_values()
+        address = "SR:MAG:HCM:01:CURRENT:SP"
+        assert address in boot_values, "the shipped machine model no longer seeds this"
+        assert boot_values[address] != classify_pv(address).base_value
+
+        assert baseline_value(address, boot_values) == pytest.approx(boot_values[address])
+        assert baseline_value(address) == classify_pv(address).base_value
+
+    def test_an_unseeded_channel_falls_back_to_the_taxonomy(self):
+        """What the VA's own ``EngineSource`` serves for a modelless channel."""
+        pv = "BR:DIAG:BPM:01:POSITION:X"
+        assert baseline_value(pv, {}) == classify_pv(pv).base_value
+        assert baseline_value(pv, None) == classify_pv(pv).base_value
+
+    def test_a_non_numeric_seed_is_ignored_rather_than_coerced(self):
+        """String-valued channels exist in machine models; this one is numeric."""
+        pv = "SR:MAG:QF01:CURRENT"
+        assert baseline_value(pv, {pv: "not a number"}) == classify_pv(pv).base_value
+
+    def test_the_series_is_centred_on_the_anchored_baseline(self):
+        """Anchoring the baseline is pointless if the series drifts off it.
+
+        The tolerance is the shape envelope (``noise_sigmas=0``) plus the
+        standard error of the mean, which is far tighter than the seam bound —
+        a series that sat a whole sigma off its anchor would pass that and fail
+        this.
+        """
+        pv = "SR:MAG:HCM:01:CURRENT:SP"
+        anchored = 0.734
+        count = 2048
+        grid = _grid(T0, count=count, step_s=30.0)
+
+        values = generate_series(pv, grid, baseline=anchored)
+
+        tolerance = deviation_bound(pv, baseline=anchored, noise_sigmas=4.0 / np.sqrt(count))
+        assert values.mean() == pytest.approx(anchored, abs=tolerance)
+
+
+class TestSeamEnvelope:
+    """The excursion stays inside the band a seam assertion is allowed to quote."""
+
+    @pytest.mark.parametrize("pv", sorted(KIND_EXAMPLES.values()))
+    def test_every_sample_is_inside_the_declared_bound(self, pv):
+        """Over a span far longer than any shape period, so no term is missed."""
+        grid = _grid(T0, count=4096, step_s=120.0)  # ~5.7 days
+
+        values = generate_series(pv, grid)
+        base = baseline_value(pv)
+
+        assert np.all(np.isfinite(values))
+        assert np.max(np.abs(values - base)) <= deviation_bound(pv)
+
+    def test_the_bound_scales_with_the_declared_noise(self):
+        """The envelope is a multiple of the channel's sigma, not a constant."""
+        pv = "SR:RF:CAV01:TEMP:BODY"
+        assert deviation_bound(pv, noise_level=0.02) == pytest.approx(
+            2.0 * deviation_bound(pv, noise_level=0.01)
+        )
+
+    def test_zero_noise_level_yields_the_bare_baseline(self):
+        """A noise level of zero is an explicit request for determinism.
+
+        The VA serves the bare boot value there, so its history must be the
+        same flat line — a textured history under a channel the live machine
+        holds perfectly still is exactly the fabricated motion this generator
+        exists to stop producing.
+        """
+        pv = "SR:RF:CAV01:VOLTAGE"
+        grid = _grid(T0, count=128, step_s=60.0)
+
+        values = generate_series(pv, grid, noise_level=0.0)
+
+        assert np.array_equal(values, np.full(128, baseline_value(pv)))
+        assert deviation_bound(pv, noise_level=0.0) == 0.0
+
+    def test_a_zero_baseline_channel_still_moves(self):
+        """A BPM's baseline is 0.0, which kills a purely relative sigma.
+
+        The kind's absolute noise floor is what keeps it alive; without it the
+        channel reads dead flat however noisy it is declared to be.
+        """
+        pv = "SR:DIAG:BPM:12:POSITION:X"
+        assert baseline_value(pv) == 0.0
+
+        values = generate_series(pv, _grid(T0, count=256, step_s=10.0))
+
+        assert values.std() > 0.0
+        assert np.max(np.abs(values)) <= deviation_bound(pv)
+
+
+class TestKindShapes:
+    """Each kind keeps a recognizable, individual signature."""
+
+    def test_every_taxonomy_kind_has_a_shape(self):
+        """A kind added to the taxonomy without one here would fall back
+        silently to the generic texture; the example map is the checklist."""
+        for kind_name, pv in KIND_EXAMPLES.items():
+            assert classify_pv(pv).name == kind_name, f"{pv} no longer classifies as {kind_name}"
+            assert kind_name in KIND_SHAPES
+
+    @pytest.mark.parametrize(("kind_name", "pv"), sorted(KIND_EXAMPLES.items()))
+    def test_each_kind_varies_around_its_baseline(self, kind_name, pv):
+        """Finite, moving, and centred — the sanity floor for every branch.
+
+        The sigma the series moves by is the kind's declared one, not a scale
+        this generator invented: a kind whose shape amplitudes were mistyped in
+        engineering units instead of sigmas would sail past a "varies" check
+        and fail the standard-deviation bound here.
+        """
+        count = 1024
+        grid = _grid(T0, count=count, step_s=60.0)
+        base = baseline_value(pv)
+        sigma = _sigma(pv)
+
+        values = generate_series(pv, grid)
+
+        assert np.all(np.isfinite(values))
+        # At least the noise term's own sigma, and no more than a small
+        # multiple of it once the bounded shape terms are added on top.
+        assert sigma <= values.std() <= 3.0 * sigma
+        assert values.mean() == pytest.approx(
+            base, abs=deviation_bound(pv, noise_sigmas=4.0 / np.sqrt(count))
+        )
+
+    def test_beam_current_sawtooths_between_refills(self):
+        """The kind's signature: a slow decay broken by a sudden recovery.
+
+        The profile is recovered by folding many cycles onto one phase axis
+        (see :func:`_phase_profile`). A refill cycle is a *ramp* on that axis:
+        it descends from the refill all the way to the trough immediately
+        before the next one, which is what tells it apart from any other
+        periodic wiggle of the same amplitude.
+        """
+        pv = KIND_EXAMPLES["beam_current"]
+        profile = _phase_profile(pv)
+        sigma = _sigma(pv)
+
+        # The channel's phase offset is keyed, so the refill lands inside a bin
+        # rather than on a boundary: the last bin of the peak-aligned profile
+        # is the one straddling the jump and averages both sides of it. The
+        # decay is the other bins.
+        decay, straddling = profile[:-1], profile[-1]
+
+        assert np.all(np.diff(decay) < 0), "the cycle is not a monotone decay"
+        # The declared span is 2 x cycle_sigmas = 3 sigma, less the bin widths
+        # the fold averages across; the drift stack leaves a small residual.
+        assert decay[0] - decay[-1] > 2.0 * sigma
+        assert decay[-1] < straddling < decay[0], "the jump is not inside that bin"
+
+    def test_voltage_swings_smoothly_rather_than_sawtoothing(self):
+        """The contrasting shape, on the same phase axis.
+
+        A sine-shaped kind returns to where it started after one period, so its
+        folded profile has no jump: the two ends nearly meet, and the extremes
+        sit about half a period apart. Sawtooth and sine are the only two
+        shapes the table can declare, so this pins the other branch — without
+        it, a table that declared every kind a sawtooth would still pass.
+        """
+        pv = KIND_EXAMPLES["voltage"]
+        profile = _phase_profile(pv)
+        sigma = _sigma(pv)
+        bins = len(profile)
+
+        assert abs(profile[0] - profile[-1]) < 0.5 * sigma
+        separation = abs(int(np.argmax(profile)) - int(np.argmin(profile)))
+        assert abs(separation - bins // 2) <= 2, "extremes are not half a period apart"
+
+    def test_the_default_kind_catches_unclassified_channels(self):
+        """Most of the served namespace is status and reference channels."""
+        pv = KIND_EXAMPLES["default"]
+        assert classify_pv(pv).name == "default"
+
+        values = generate_series(pv, _grid(T0, count=64, step_s=60.0))
+
+        assert np.all(np.isfinite(values))
+        assert values.std() > 0.0
+
+
+def test_default_noise_level_matches_what_the_va_serves():
+    """The two halves of a deployed world must assume the same noise.
+
+    The constant is duplicated rather than imported (``osprey.simulation`` must
+    load without the VA service package), so nothing but this assertion keeps
+    the two from drifting apart — and a drift would show up as a seam step
+    between seeded history and recorded reality.
+    """
+    from osprey.services.virtual_accelerator.ioc.engine_source import DEFAULT_NOISE_LEVEL as VA
+
+    assert DEFAULT_NOISE_LEVEL == VA

--- a/tests/simulation/test_scenario_composition.py
+++ b/tests/simulation/test_scenario_composition.py
@@ -30,6 +30,13 @@ def _yesterday_1432_window(minutes: int = 10) -> list[datetime]:
 
 
 def _seven_day_window() -> list[datetime]:
+    """A 7-day window ending now.
+
+    rf-thermal's excursions are anchored (``at_offset``, hours before the
+    scenario-activation anchor T0), not window fractions, so this window must
+    *end at now* for them to appear in it: the fixture writes ``active_scenarios``
+    as it builds the engine, which puts T0 within a second of now.
+    """
     now = datetime.now()
     step = timedelta(days=7) / RF_SERIES_N
     return [now - timedelta(days=7) + step * i for i in range(RF_SERIES_N)]

--- a/tests/utils/test_config_updater_control_system.py
+++ b/tests/utils/test_config_updater_control_system.py
@@ -3,11 +3,23 @@
 from textwrap import dedent
 
 import pytest
+import yaml
 
 from osprey.utils.config_writer import (
     get_control_system_type,
     set_control_system_type,
 )
+
+MONGODB_SETTINGS = {
+    "archiver.mongodb_archiver.host": "localhost",
+    "archiver.mongodb_archiver.port": 27017,
+    "archiver.mongodb_archiver.name": "osprey_archiver",
+    "archiver.mongodb_archiver.collection": "pv_history",
+    "archiver.mongodb_archiver.auth": "admin",
+    "archiver.mongodb_archiver.username": "osprey",
+    "archiver.mongodb_archiver.password_env": "MONGO_ROOT_PASSWORD",
+    "archiver.mongodb_archiver.timeout": 5,
+}
 
 
 @pytest.fixture
@@ -104,3 +116,90 @@ def test_set_control_system_only(tmp_path, sample_config_content):
     config_path.write_text(new_content)
     assert get_control_system_type(config_path) == "epics"
     assert get_control_system_type(config_path, key="archiver.type") == "mock_archiver"
+
+
+def test_archiver_settings_land_as_nested_sections(tmp_path, sample_config_content):
+    """An archiver that needs settings gets them written under its own section.
+
+    Nested, not as top-level dotted lines: config.yml is read as nested
+    sections, so a flat `archiver.mongodb_archiver.host:` key would configure
+    nothing while looking like it configured something.
+    """
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(sample_config_content)
+
+    new_content, _ = set_control_system_type(
+        config_path,
+        "virtual_accelerator",
+        "mongodb_archiver",
+        archiver_settings=MONGODB_SETTINGS,
+    )
+
+    data = yaml.safe_load(new_content)
+    assert [key for key in data if "." in key] == []
+    assert data["archiver"]["type"] == "mongodb_archiver"
+    assert data["archiver"]["mongodb_archiver"] == {
+        "host": "localhost",
+        "port": 27017,
+        "name": "osprey_archiver",
+        "collection": "pv_history",
+        "auth": "admin",
+        "username": "osprey",
+        "password_env": "MONGO_ROOT_PASSWORD",
+        "timeout": 5,
+    }
+
+
+def test_archiver_settings_appear_in_the_preview(tmp_path, sample_config_content):
+    """What is about to be written is what the confirmation prompt shows."""
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(sample_config_content)
+
+    _, preview = set_control_system_type(
+        config_path,
+        "virtual_accelerator",
+        "mongodb_archiver",
+        archiver_settings=MONGODB_SETTINGS,
+    )
+
+    assert "archiver.mongodb_archiver.host: localhost" in preview
+    assert "archiver.mongodb_archiver.password_env: MONGO_ROOT_PASSWORD" in preview
+
+
+def test_archiver_settings_preserve_surrounding_comments(tmp_path):
+    """The connection block is added without flattening the file around it."""
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(
+        dedent(
+            """
+            # Control system
+            control_system:
+              type: mock
+              writes_enabled: false  # safety
+
+            archiver:
+              type: mock_archiver
+            """
+        )
+    )
+
+    new_content, _ = set_control_system_type(
+        config_path,
+        "virtual_accelerator",
+        "mongodb_archiver",
+        archiver_settings=MONGODB_SETTINGS,
+    )
+
+    assert "# Control system" in new_content
+    assert "# safety" in new_content
+
+
+def test_no_archiver_settings_leaves_the_section_alone(tmp_path, sample_config_content):
+    """Omitting the settings writes only the types, as it always has."""
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(sample_config_content)
+
+    new_content, _ = set_control_system_type(config_path, "epics", "epics_archiver")
+
+    data = yaml.safe_load(new_content)
+    assert set(data["archiver"]) == {"type"}

--- a/tests/utils/test_dotenv_derivation.py
+++ b/tests/utils/test_dotenv_derivation.py
@@ -401,3 +401,39 @@ class TestKeyClassEnumerations:
 
         minted = {var for vars_ in _SERVICE_TOKEN_VARS.values() for var in vars_}
         assert minted <= RUNTIME_WRITER_KEYS
+
+    def test_runtime_writer_keys_hold_nothing_beyond_the_three_writers(self):
+        """The drift guard in the other direction: no key without an owner.
+
+        The subset checks above catch a writer whose key was never enumerated
+        here. They cannot catch the reverse — a name added to the duplicated
+        enumeration that no writer actually produces, which quietly promotes an
+        ordinary rendered key into one an existing project value always wins
+        over. The three groups the enumeration's own comments claim are the
+        whole of it, so assert exactly that.
+        """
+        from osprey.deployment.container_lifecycle import _SERVICE_TOKEN_VARS
+        from osprey.services.bluesky_bridge.substrate_devices import (
+            DETECTORS_ENV,
+            MOTORS_ENV,
+            SUBSTRATE_ENV,
+        )
+        from osprey.simulation.apply import _PHYSICS_ENV_VARS
+
+        owned = (
+            set(_PHYSICS_ENV_VARS)
+            | {SUBSTRATE_ENV, MOTORS_ENV, DETECTORS_ENV}
+            | {var for vars_ in _SERVICE_TOKEN_VARS.values() for var in vars_}
+        )
+        assert RUNTIME_WRITER_KEYS == owned
+
+    def test_the_minted_archiver_password_is_runtime_written(self):
+        """MONGO_ROOT_PASSWORD is pinned by the volume that adopted it.
+
+        Named explicitly rather than left to the set check above because what
+        the archiver's Mongo volume holds is not reproducible at all: a rebuild
+        that re-derived this key from the profile would mint a value the
+        existing volume rejects, and recovering means discarding every seeded
+        and recorded sample in it.
+        """
+        assert "MONGO_ROOT_PASSWORD" in RUNTIME_WRITER_KEYS

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-03T21:34:47.889425Z"
+exclude-newer = "2026-08-04T08:52:16.026376Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -4487,13 +4487,16 @@ sheets = [
     { name = "gspread" },
 ]
 virtual-accelerator = [
+    { name = "aioca" },
     { name = "lume-pva-apg", extra = ["ca", "pva"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "pcaspy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pymongo" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "accelerator-toolbox", extras = ["plot"], specifier = ">=0.7.1" },
+    { name = "aioca", marker = "extra == 'virtual-accelerator'", specifier = ">=1.7" },
     { name = "aiofiles", specifier = ">=25.1.0" },
     { name = "aiohttp", specifier = ">=3.10" },
     { name = "aiohttp-socks", specifier = ">=0.8.0" },
@@ -4574,6 +4577,7 @@ requires-dist = [
     { name = "pyepics" },
     { name = "pymongo", marker = "extra == 'all'", specifier = ">=4.17.0" },
     { name = "pymongo", marker = "extra == 'archiver-mongodb'", specifier = ">=4.17.0" },
+    { name = "pymongo", marker = "extra == 'virtual-accelerator'", specifier = ">=4.17.0" },
     { name = "pysocks", marker = "extra == 'all'", specifier = ">=1.7" },
     { name = "pysocks", marker = "extra == 'gchat'", specifier = ">=1.7" },
     { name = "pytest", marker = "extra == 'all'" },


### PR DESCRIPTION
A simulated machine may now keep a *real* archive, and is refused the option of
faking one.

Until now a virtual accelerator deployment had no honest way to answer a
question about the past. The mock archiver synthesizes a plausible series at
read time, so paired with a VA it produced an agent whose present is modelled
and whose past is fiction, with nothing connecting the two — the invented half
could never be caught by disagreeing with the machine it claimed to describe.

This branch gives that deployment a store, and closes the dishonest pairing:

- **A store and a recorder.** A MongoDB service holds samples; an
  `archiver-recorder` service reads the machine's channels on an absolute grid
  and writes what answered. A channel that did not answer contributes nothing —
  a gap is the honest record of a channel that was not answering, and the only
  record that distinguishes a quiet channel from an absent one. The recorder
  runs on the virtual accelerator image so it shares the serving stack rather
  than carrying a second copy of it.

- **Seeded history from the same functions that serve the present.** Scenario
  channels are now procedural series evaluated against wall-clock timestamps, so
  a value is a function of the time it describes rather than of when the run
  happened. The seeder writes a scenario's past into the store using exactly
  those generators, over a two-tier grid with per-document TTL retention. A
  document written for time T holds what a query for T would compute — seeded
  history and live history are one world, not two plausible ones.

- **Freshness derived, not asserted.** The MongoDB archiver reports what the
  store actually holds.

- **The pairing refused three times, from one rule.** `osprey build` writes the
  config, `osprey deploy` stands the services up, and the MCP server reads
  whatever `config.yml` it is pointed at — including one hand-edited long after
  the build. Each site raises in its own vocabulary and names its own fix; the
  judgement of what a config says about its archive lives in one place, so a
  config cannot read as honest at one site and invented at another. Unset counts
  as mock, because the common way into the pairing is not naming the mock, it is
  naming nothing.

A mock control system with the mock archiver is untouched: nothing is claimed to
be real there, so nothing lies. It remains the app template's default.

Profiles, the build wizard, and the CLI carry the archiver selection through the
same surface, and the archiver's settings are written as nested config sections —
a dotted key in a rendered `config.yml` configures nothing.

An end-to-end lane brings up the full stack and settles the claims only a running
deployment can: that seeded history is what the agent reads back, that freshness
reflects what the store holds, and that a machine with no recorded past says so
instead of producing one.

## How it hangs together

```text
  BUILD PROFILE  ──  archiver: mongodb | mock  ·  control_system: virtual_accelerator
        │
        │                    ┌──────────────────────────────────┐
        └───────────────────▶│  connectors/honesty.py           │
                             │  one question, asked three times │
                             │  VA + mock archiver ⇒ REFUSE     │
                             └──┬───────────┬───────────────┬───┘
                   osprey build │   osprey  │           MCP server
                                │   deploy  │             startup
                                ▼           ▼               ▼
                          config.yml   containers up   server_context
                                            │
  ══ DEPLOYED STACK ═════════════════════════╪═════════════════════════════
                                             ▼
     ┌────────────────────────┐   reads    ┌──────────────────────┐
     │  virtual accelerator   │◀───────────│  archiver-recorder   │
     │  CA / PVA channels     │  on an     │  writes what answered│
     └────────────────────────┘  absolute  └──────────┬───────────┘
                                   grid               │ present
                                                      ▼
     ┌────────────────────────┐   past     ┌──────────────────────┐
     │  scenario seeder       │───────────▶│   MongoDB store      │
     │  simulation/procedural │  two-tier  │   one doc per instant│
     │  + SimulationEngine    │  grid, TTL │   TTL retention      │
     └────────────────────────┘            └──────────┬───────────┘
              same pure functions                     │
              f(channel, epoch_seconds)               │ reads
                                                      ▼
     ┌────────────────────────┐            ┌──────────────────────┐
     │  OSPREY agent          │───────────▶│ MongoDBArchiver      │
     │  "what happened at T?" │  history   │ freshness = what is  │
     │                        │◀───────────│ stored, or "no past" │
     └────────────────────────┘            └──────────────────────┘
```
