### PR TITLE
fix(web): harden UI against frozen-panel states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -314,6 +314,22 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- Web terminal panels no longer freeze permanently — rendering but ignoring
+  every click — when a drag from the panel rail loses its end event (for
+  example the dragged entry was removed mid-drag by the agent or another
+  client). Drag cleanup now has document-level failsafes.
+- The web terminal's panel event stream reconnects after a proxy or backend
+  hiccup and re-syncs rail membership on every reconnect, so a browser that
+  missed events while disconnected converges instead of silently drifting.
+  Event-handling errors are now logged instead of swallowed.
+- Workspace gallery: the "Draft created" confirmation no longer sticks as a
+  permanent full-panel overlay after a successful logbook submit.
+- Workspace gallery: deleting the artifact being viewed fullscreen (locally
+  or agent-side) exits fullscreen instead of stranding a pane with no
+  controls.
+- The web terminal welcome screen wires its dismiss controls before any
+  fallible boot step, and a terminal-library load failure degrades the
+  terminal card instead of aborting the whole page boot.
 - Lattice dashboard summary stats (energy, tunes, chromaticity) no longer
   freeze at load time — they recompute with the fast figures after a magnet
   change. Also removed dead panel chrome the audit surfaced: ARIEL's unwired

--- a/src/osprey/interfaces/artifacts/static/js/logbook.js
+++ b/src/osprey/interfaces/artifacts/static/js/logbook.js
@@ -360,7 +360,15 @@ function showModal() {
 }
 
 function hideModal() {
-  if (modal) modal.style.display = "none";
+  // Dismiss on DOM state, never the `modal` cache: the submit success path
+  // nulls the cache (so the next open rebuilds a fresh composer) before
+  // scheduling the auto-dismiss, and the close/backdrop handlers must keep
+  // working in that window. The cached overlay is only concealed (it is
+  // reused); an uncached one is an orphan and is removed outright.
+  document.querySelectorAll(".logbook-overlay").forEach(function (el) {
+    if (el === modal) /** @type {HTMLElement} */ (el).style.display = "none";
+    else el.remove();
+  });
   resetModal();
 }
 
@@ -516,4 +524,4 @@ function injectLogbookButtons() {
   }
 }
 
-export { injectLogbookButtons, makeBtn, updateHeaderTitle, getSteeringValues, getContextValues };
+export { injectLogbookButtons, makeBtn, updateHeaderTitle, getSteeringValues, getContextValues, hideModal };

--- a/src/osprey/interfaces/artifacts/static/js/preview.js
+++ b/src/osprey/interfaces/artifacts/static/js/preview.js
@@ -105,6 +105,16 @@ export function createPreviewRenderer(callbacks) {
     if (!previewEmpty || !previewContent) return;
 
     if (!getSelectedArtifact()) {
+      // Never render the empty placeholder while fullscreen: fullscreen-mode
+      // hides the header, sidebar and splitter (gallery.css), so a cleared
+      // selection — Delete from the fullscreen header, or an agent-side
+      // artifact_deleted SSE — would strand a chrome-less pane with no exit
+      // affordance. exitFullscreen re-enters renderPreview with the flag
+      // already cleared, so this cannot recurse.
+      if (isFullscreen) {
+        exitFullscreen();
+        return;
+      }
       previewEmpty.classList.remove("hidden");
       previewContent.classList.add("hidden");
       return;

--- a/src/osprey/interfaces/web_terminal/static/js/api.js
+++ b/src/osprey/interfaces/web_terminal/static/js/api.js
@@ -16,6 +16,7 @@
  * @typedef {object} EventSourceHandlers
  * @property {(data: any) => void} [onMessage]
  * @property {() => void} [onError]
+ * @property {() => void} [onOpen]
  */
 
 /** @type {ConnState} */
@@ -214,13 +215,28 @@ export function createWebSocket(url, { onOpen, onMessage, onClose, onError } = {
 
 /**
  * Create an EventSource with reconnection.
+ *
+ * The browser's built-in retry covers only network-level failures on a
+ * still-live source; a non-2xx response or wrong content type (a proxy 502
+ * while the backend restarts, an auth redirect) parks the EventSource in
+ * CLOSED permanently, where the spec forbids any further retry. This wrapper
+ * takes over from there with the same exponential backoff createWebSocket
+ * uses, so the panel event channel survives backend restarts.
+ *
+ * `onOpen` fires on EVERY open — first connect, browser auto-retry, and this
+ * wrapper's own reconnects. SSE has no replay (no event ids are sent), so
+ * anything published while disconnected is gone; the hook is the caller's
+ * seam for re-fetching authoritative state instead.
  * @param {string} url
  * @param {EventSourceHandlers} [handlers]
  */
-export function createEventSource(url, { onMessage, onError } = {}) {
+export function createEventSource(url, { onMessage, onError, onOpen } = {}) {
   /** @type {EventSource|null} */
   let es = null;
   let stopped = false;
+  let attempt = 0;
+  /** @type {ReturnType<typeof setTimeout>|null} */
+  let reconnectTimer = null;
 
   function connect() {
     if (stopped || sessionExpired) return;
@@ -230,8 +246,10 @@ export function createEventSource(url, { onMessage, onError } = {}) {
     es = new EventSource(withPrefix(url));
 
     es.onopen = () => {
+      attempt = 0;
       sseState = 'connected';
       notifyStateChange();
+      if (onOpen) onOpen();
     };
 
     es.onmessage = (e) => {
@@ -249,15 +267,32 @@ export function createEventSource(url, { onMessage, onError } = {}) {
       sseState = 'disconnected';
       notifyStateChange();
       if (onError) onError();
-      // EventSource auto-reconnects, but update state
+      // readyState 2 is CLOSED (spec constant): the browser has given up on
+      // this source for good, so reconnection is ours from here. While
+      // CONNECTING/OPEN the built-in retry is still running — never race it.
+      if (es && es.readyState === 2) scheduleReconnect();
       reloadIfSessionExpired(() => {
         if (es) es.close();
       });
     };
   }
 
+  function scheduleReconnect() {
+    if (stopped || sessionExpired || reconnectTimer != null) return;
+    const delay = Math.min(1000 * Math.pow(2, attempt), 30000);
+    attempt++;
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      connect();
+    }, delay);
+  }
+
   function stop() {
     stopped = true;
+    if (reconnectTimer != null) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
     if (es) es.close();
     sseState = 'disconnected';
     notifyStateChange();

--- a/src/osprey/interfaces/web_terminal/static/js/app.js
+++ b/src/osprey/interfaces/web_terminal/static/js/app.js
@@ -20,7 +20,20 @@ import { followThemeFamily, getRailPosition, setRailPosition } from './rail-posi
 
 document.addEventListener('DOMContentLoaded', () => {
   initTheme({ role: 'hub' });
-  initTerminal('terminal-container');
+  // Welcome modal FIRST: #welcome-overlay ships in the DOM from first paint
+  // (opaque, full-viewport, z-index 10000) and only this init wires its
+  // dismiss controls. Any earlier throw would leave the page permanently
+  // covered with no way out — so the overlay must be dismissable before any
+  // fallible init runs. Self-contained: needs only the DOM and /health.
+  void initWelcomeModal();
+  // Guarded: xterm.js loads from a CDN by default (local only in
+  // OSPREY_OFFLINE), so a network blip must degrade the terminal card, not
+  // kill the whole boot.
+  try {
+    initTerminal('terminal-container');
+  } catch (err) {
+    console.error('Failed to init terminal:', err);
+  }
   // Simple-mode operator chat. Guarded so a chat init failure can't break the
   // rest of the boot (the expert terminal is already up at this point).
   try {
@@ -57,9 +70,6 @@ document.addEventListener('DOMContentLoaded', () => {
   initHookDebug();
   // Listen for paste requests from embedded iframes (gallery, ARIEL)
   initIframePasteBridge();
-
-  // Welcome modal (once per server session)
-  initWelcomeModal();
 });
 
 /* ---- New Session Button ---- */

--- a/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
@@ -117,6 +117,12 @@ let activeTabId = null;
 /** @type {Record<string, PanelState>} */
 const panelState = {};
 
+/** A panel's cold state — shared by the init loop and runtime addPanel().
+ *  @returns {PanelState} */
+function freshPanelState() {
+  return { url: null, healthy: false, iframe: null, pollTimer: null, polling: false, configLoaded: false };
+}
+
 // Rail MEMBERSHIP — the server-owned visible set, seeded from /api/panels at
 // init. An id in here has a rail entry; toggling one is paired with
 // addEntry()/removeEntry() on the rail.
@@ -260,14 +266,7 @@ export async function initPanelManager(panelId) {
 
   // Initialize state for each (now-filtered) panel
   for (const panel of PANELS) {
-    panelState[panel.id] = {
-      url: null,
-      healthy: false,
-      iframe: null,
-      pollTimer: null,
-      polling: false,
-      configLoaded: false,
-    };
+    panelState[panel.id] = freshPanelState();
   }
 
   // Seed visiblePanels from server config ('visible' field added by Task 1.1).
@@ -396,6 +395,13 @@ export async function initPanelManager(panelId) {
   // adds a transient glow on the rail entry — never a persistent badge, the
   // action itself already happened. Untagged frames behave exactly as before.
   createEventSource('/api/files/events', { // prefixed via createEventSource (api.js)
+    // SSE has no replay: anything broadcast while this client was
+    // disconnected (or dropped by the server's bounded per-client queue) is
+    // gone for good, and every panel command's DOM effect IS its SSE echo —
+    // without a resync a client that missed one frame never converges again.
+    // The hook fires on every open, including the first; the extra boot-time
+    // fetch is a no-op delta.
+    onOpen: () => { void resyncPanelState(); },
     onMessage: (raw) => {
       try {
         const data = /** @type {PanelSSEEvent} */ (raw);
@@ -421,51 +427,7 @@ export async function initPanelManager(panelId) {
           }
 
         } else if (data.type === 'panel_visibility' && data.panel) {
-          const { panel, visible } = data;
-          // Update the membership set and add/remove the matching rail entry.
-          // The agent glow runs after the add so a just-added entry can flash.
-          if (visible) {
-            ensureRailMembership(panel);
-          } else {
-            visiblePanels.delete(panel);
-            removeEntry(railEl, panel);
-          }
-          if (data.source === 'agent') flashAgentGlow(panel);
-
-          // Simple-UX reveal: showing a panel while the workspace is chat-only
-          // suppressed brings up the workspace ON that panel — this is the
-          // "agent produced an artifact, show_panel('artifacts')" onboarding
-          // path the panels-context SessionStart hook instructs. {auto: true}
-          // keeps the health guard: an unhealthy panel leaves the slot for a
-          // later settle (suppression is already cleared).
-          if (visible && workspaceSuppressed) {
-            workspaceSuppressed = false;
-            if (!activeTabId) activateTab(panel, { auto: true });
-          }
-
-          if (!visible) {
-            // EVERY hide drops the panel's dock tile (one panel per tile — a
-            // closed panel's placeholder would be a ghost tile), active or
-            // not. The echo guard covers dockview auto-activating a neighbor
-            // on removal: that programmatic change is a server-applied echo
-            // and must not POST focus back (the fallback below owns focus).
-            withEchoSuppressed(() => hidePanel(panel));
-          }
-
-          // CC-1: if we just hid the currently active panel, switch away from it
-          if (!visible && panel === activeTabId) {
-            // Find the first panel that is visible, healthy, and not the one being hidden
-            const fallback = PANELS.find(
-              p => p.id !== panel && visiblePanels.has(p.id) && panelState[p.id]?.healthy
-            );
-            if (fallback) {
-              activateTab(fallback.id);
-            } else {
-              // No usable panel remains — strand-proof: clear active state and show empty pane
-              activeTabId = null;
-              renderEmptyState('No panels visible');
-            }
-          }
+          applyPanelVisibility(data.panel, data.visible, data.source);
 
         } else if (data.type === 'panel_arrange' && Array.isArray(data.tiles)) {
           // A whole-workspace arrangement (agent arrange_workspace, or a human
@@ -493,9 +455,86 @@ export async function initPanelManager(panelId) {
           if (t.kind !== 'panel' || !t.panel || !setEntryAttention(railEl, t.panel, true)) onAgentActivity(data);
         }
 
-      } catch { /* ignore malformed events */ }
+      } catch (err) {
+        // A throw mid-dispatch can leave rail membership, the dock layout and
+        // the overlay's managed set describing different workspaces — never
+        // swallow it without evidence.
+        console.error('panel-manager: SSE frame dispatch failed', err, raw);
+      }
     },
   });
+}
+
+/**
+ * Apply a server-visible membership change — the single body behind the
+ * panel_visibility SSE branch and the reconnect resync, so a resynced client
+ * ends up exactly where a connected one would be.
+ *
+ * Order matters and is pinned by the test suite: membership + rail entry
+ * first (the agent glow runs after the add so a just-added entry can flash);
+ * then the simple-UX chat-only reveal (showing a panel while the workspace is
+ * suppressed brings the workspace up ON that panel — {auto: true} keeps the
+ * health guard); then, on a hide, the dock tile drop (one panel per tile — a
+ * closed panel's placeholder would be a ghost tile) under the echo guard
+ * (dockview auto-activating a neighbor on removal is a server-applied echo
+ * and must not POST focus back), and finally the active-panel fallback so a
+ * hidden active panel never strands a blank pane.
+ * @param {string} panel
+ * @param {boolean} visible
+ * @param {'agent'} [source]
+ */
+function applyPanelVisibility(panel, visible, source) {
+  if (visible) {
+    ensureRailMembership(panel);
+  } else {
+    visiblePanels.delete(panel);
+    removeEntry(railEl, panel);
+  }
+  if (source === 'agent') flashAgentGlow(panel);
+
+  if (visible && workspaceSuppressed) {
+    workspaceSuppressed = false;
+    if (!activeTabId) activateTab(panel, { auto: true });
+  }
+
+  if (!visible) {
+    withEchoSuppressed(() => hidePanel(panel));
+    if (panel === activeTabId) {
+      const fallback = PANELS.find(
+        p => p.id !== panel && visiblePanels.has(p.id) && panelState[p.id]?.healthy
+      );
+      if (fallback) {
+        activateTab(fallback.id);
+      } else {
+        activeTabId = null;
+        renderEmptyState('No panels visible');
+      }
+    }
+  }
+}
+
+/**
+ * Re-converge rail membership with the server after the SSE stream (re)opens.
+ * The authoritative visible set is re-fetched and applied as a delta through
+ * applyPanelVisibility — the same path the panel_visibility frames use.
+ * Scope: membership of panels known to this page. A runtime panel whose
+ * panel_register frame was missed entirely stays unknown until reload.
+ */
+async function resyncPanelState() {
+  let config = null;
+  try {
+    config = await fetchJSON('/api/panels');
+  } catch {
+    return; // offline — the next reconnect retries
+  }
+  if (!config || !Array.isArray(config.visible)) return;
+  const serverVisible = new Set(config.visible);
+  for (const id of serverVisible) {
+    if (!visiblePanels.has(id) && panelState[id]) applyPanelVisibility(id, true);
+  }
+  for (const id of [...visiblePanels]) {
+    if (!serverVisible.has(id)) applyPanelVisibility(id, false);
+  }
 }
 
 // ---- Rail Rendering ----
@@ -684,14 +723,7 @@ function addPanel(spec) {
   // Keep the adapter's known-service set current (never orphan a runtime panel).
   setKnownServicePanels(PANELS.map((p) => p.id));
 
-  panelState[spec.id] = {
-    url: null,
-    healthy: false,
-    iframe: null,
-    pollTimer: null,
-    polling: false,
-    configLoaded: false,
-  };
+  panelState[spec.id] = freshPanelState();
 
   // Append exactly one entry. addEntry is non-destructive — never a full
   // re-render — so every live entry keeps its active/disabled/LED state, and it

--- a/src/osprey/interfaces/web_terminal/static/js/panel-rail.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-rail.js
@@ -248,7 +248,16 @@ export function addEntry(railEl, panel, options = {}) {
  * @param {string} panelId
  */
 export function removeEntry(railEl, panelId) {
-  getEntry(railEl, panelId)?.remove();
+  const entry = getEntry(railEl, panelId);
+  if (!entry) return;
+  // A detached drag source can never fire dragend (HTML5 delivers it to the
+  // source element only), so a mid-drag removal would strand the caller's
+  // drag-end cleanup — the iframe pointer shields raised in onDragStart.
+  // End the gesture through the entry's own dragend listener before detaching.
+  if (entry.classList.contains('dragging')) {
+    entry.dispatchEvent(new Event('dragend'));
+  }
+  entry.remove();
 }
 
 // ---- Mutators ----

--- a/src/osprey/interfaces/web_terminal/static/js/rail-drag.js
+++ b/src/osprey/interfaces/web_terminal/static/js/rail-drag.js
@@ -117,6 +117,33 @@ function wire() {
   setTimeout(wire, 150);
 }
 
+// The gesture's natural terminators, mirroring dock-workspace.js's
+// onDragGesture. HTML5 delivers dragend only to the drag's SOURCE element —
+// a rail entry removed mid-drag (SSE hide_panel, arrange prune, another
+// client) can never fire it, and native drags suppress mouseup/pointerup
+// until the pointer is released. Relying on the entry's own dragend alone
+// therefore left the shields up FOREVER on a lost gesture: every panel
+// iframe stayed pointer-events:none — rendering, but inert. These document
+// listeners are the failsafe: capture-phase, self-disarming, armed per drag.
+const DRAG_TERMINATORS = ['dragend', 'drop', 'mouseup', 'pointerup'];
+
+/** The armed failsafe's listener, or null while no drag is in flight.
+ *  @type {(() => void) | null} */
+let failsafeLower = null;
+
+function armFailsafe() {
+  if (failsafeLower) return;
+  const lower = () => railDragEnd();
+  failsafeLower = lower;
+  for (const type of DRAG_TERMINATORS) document.addEventListener(type, lower, true);
+}
+
+function disarmFailsafe() {
+  if (!failsafeLower) return;
+  for (const type of DRAG_TERMINATORS) document.removeEventListener(type, failsafeLower, true);
+  failsafeLower = null;
+}
+
 /**
  * Begin a rail drag: stamp the payload and raise the iframe shields. Returns
  * false — cancelling the drag (panel-rail preventDefaults) — in simple mode
@@ -135,11 +162,14 @@ export function railDragStart(id, dataTransfer) {
     dataTransfer.effectAllowed = 'move';
   }
   shield(true);
+  armFailsafe();
   return true;
 }
 
-/** End a rail drag (drop, cancel, or escape): lower the iframe shields. */
+/** End a rail drag (drop, cancel, escape, or failsafe): lower the iframe
+ *  shields and disarm the document-level terminators. Idempotent. */
 export function railDragEnd() {
+  disarmFailsafe();
   shield(false);
 }
 

--- a/tests/interfaces/artifacts/logbook.test.mjs
+++ b/tests/interfaces/artifacts/logbook.test.mjs
@@ -28,6 +28,7 @@ import {
   updateHeaderTitle,
   getSteeringValues,
   getContextValues,
+  hideModal,
 } from '../../../src/osprey/interfaces/artifacts/static/js/logbook.js';
 import { qs, byId } from '../_support/dom.mjs';
 
@@ -231,5 +232,43 @@ describe('getContextValues', () => {
   test('no scope radio checked defaults to "this" (artifact_ids null) and session defaults true when the checkbox is absent', () => {
     document.body.innerHTML = '<div id="logbook-artifact-picker-list"></div>';
     expect(getContextValues()).toEqual({ include_session_log: true, artifact_ids: null });
+  });
+});
+
+// =========================================================================
+// hideModal — dismissal must work on DOM state, never the module cache
+// =========================================================================
+//
+// The submit success path nulls the module's `modal` cache (forcing the next
+// open to rebuild a fresh composer) BEFORE scheduling the 3-second
+// auto-dismiss. A cache-guarded hideModal therefore dismissed nothing: the
+// full-panel fixed overlay stayed up forever and the next open stacked a
+// second one. These tests pin the DOM-based contract.
+
+describe('hideModal', () => {
+  test('removes an overlay the module cache no longer references', () => {
+    const orphan = document.createElement('div');
+    orphan.className = 'logbook-overlay';
+    document.body.appendChild(orphan);
+
+    hideModal();
+
+    expect(document.querySelector('.logbook-overlay')).toBeNull();
+  });
+
+  test('dismisses every stacked overlay, not just the first', () => {
+    for (let i = 0; i < 2; i++) {
+      const el = document.createElement('div');
+      el.className = 'logbook-overlay';
+      document.body.appendChild(el);
+    }
+
+    hideModal();
+
+    expect(document.querySelectorAll('.logbook-overlay')).toHaveLength(0);
+  });
+
+  test('is safe to call with no overlay present', () => {
+    expect(() => hideModal()).not.toThrow();
   });
 });

--- a/tests/interfaces/artifacts/preview.test.mjs
+++ b/tests/interfaces/artifacts/preview.test.mjs
@@ -387,6 +387,26 @@ describe('fullscreen mode', () => {
     expect(callbacks.onFullscreenExit).not.toHaveBeenCalled();
   });
 
+  test('clearing the selection while fullscreen exits fullscreen (no stranded chrome-less pane)', () => {
+    // fullscreen-mode hides the header, sidebar and splitter (gallery.css),
+    // so every exit affordance lives inside the preview content. If the
+    // selection clears while fullscreen — Delete from the fullscreen header,
+    // or an agent-side artifact_deleted SSE — the empty placeholder renders
+    // with the body class still set: no sidebar, no header, no Back button.
+    const callbacks = makeCallbacks();
+    const renderer = createPreviewRenderer(callbacks);
+    renderer.enterFullscreen(makeArtifact());
+    expect(renderer.isFullscreen()).toBe(true);
+
+    setSelectedArtifact(null);
+    renderer.renderPreview();
+
+    expect(renderer.isFullscreen()).toBe(false);
+    expect(document.body.classList.contains('fullscreen-mode')).toBe(false);
+    expect(callbacks.onFullscreenExit).toHaveBeenCalledTimes(1);
+    expect(byId('preview-empty').classList.contains('hidden')).toBe(false);
+  });
+
   test('noteNewArtifactArrival/updateNewArtifactBadge track and display the "N new" count', () => {
     const renderer = createPreviewRenderer(makeCallbacks());
     renderer.enterFullscreen(makeArtifact());

--- a/tests/interfaces/web_terminal/api.test.mjs
+++ b/tests/interfaces/web_terminal/api.test.mjs
@@ -555,3 +555,100 @@ describe('connection state: initial shape and listener registration', () => {
     }
   });
 });
+
+describe('createEventSource: reconnection and resync hook', () => {
+  /**
+   * EventSource stub with the pieces the reconnect logic reads: a settable
+   * per-instance readyState (spec constants: 0 CONNECTING, 1 OPEN, 2 CLOSED)
+   * and recorded instances.
+   * @returns {any[]}
+   */
+  function stubEventSourceRich() {
+    /** @type {any[]} */
+    const instances = [];
+    vi.stubGlobal(
+      'EventSource',
+      class {
+        /** @param {string} url */
+        constructor(url) {
+          this.url = url;
+          this.readyState = 0;
+          this.closed = false;
+          instances.push(this);
+        }
+        close() {
+          this.closed = true;
+          this.readyState = 2;
+        }
+      }
+    );
+    return instances;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('location', { protocol: 'http:', host: 'localhost:5000', reload: vi.fn() });
+    // Health probe answers 200 so the reload-on-401 path stays quiet here.
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, status: 200 })));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('a CLOSED stream is reconnected with backoff (the browser will not retry it)', () => {
+    // Per spec the browser auto-retries only network-level failures; a non-2xx
+    // or wrong content-type (proxy 502 during a backend restart) parks the
+    // EventSource in CLOSED permanently. Without our own reconnect the panel
+    // SSE channel dies for the rest of the page's life.
+    const instances = stubEventSourceRich();
+    api.createEventSource('/events');
+    expect(instances).toHaveLength(1);
+
+    instances[0].readyState = 2; // CLOSED
+    instances[0].onerror();
+
+    vi.advanceTimersByTime(1000);
+    expect(instances).toHaveLength(2);
+  });
+
+  test('a CONNECTING stream is left to the browser\'s own retry (no duplicate connection)', () => {
+    const instances = stubEventSourceRich();
+    api.createEventSource('/events');
+
+    instances[0].readyState = 0; // CONNECTING: built-in retry is running
+    instances[0].onerror();
+
+    vi.advanceTimersByTime(60000);
+    expect(instances).toHaveLength(1);
+  });
+
+  test('onOpen fires on every open — the caller\'s state-resync hook', () => {
+    const instances = stubEventSourceRich();
+    const onOpen = vi.fn();
+    api.createEventSource('/events', { onOpen });
+
+    instances[0].onopen();
+    expect(onOpen).toHaveBeenCalledTimes(1);
+
+    // Lost stream, our reconnect, second open: the hook must fire again so
+    // the caller can re-fetch state it missed while disconnected.
+    instances[0].readyState = 2;
+    instances[0].onerror();
+    vi.advanceTimersByTime(1000);
+    instances[1].onopen();
+    expect(onOpen).toHaveBeenCalledTimes(2);
+  });
+
+  test('stop() cancels a pending reconnect', () => {
+    const instances = stubEventSourceRich();
+    const source = api.createEventSource('/events');
+
+    instances[0].readyState = 2;
+    instances[0].onerror();
+    source.stop();
+
+    vi.advanceTimersByTime(60000);
+    expect(instances).toHaveLength(1);
+  });
+});

--- a/tests/interfaces/web_terminal/panel-manager.test.mjs
+++ b/tests/interfaces/web_terminal/panel-manager.test.mjs
@@ -1373,3 +1373,96 @@ describe('panel_arrange — the declarative whole-workspace rebuild', () => {
     expect(posts(calls)).toEqual([]);
   });
 });
+
+describe('SSE reconnect resync — membership re-converges from /api/panels', () => {
+  /**
+   * Boot against a MUTABLE server state and an EventSource stub whose
+   * `open()` drives the onopen handler — the reconnect seam. SSE has no
+   * replay, so a frame published while a client was disconnected is simply
+   * gone; on every open panel-manager must re-fetch /api/panels and apply
+   * the authoritative visible set as a delta.
+   */
+  async function bootResync() {
+    window.__OSPREY_PREFIX__ = '';
+    renderContainer();
+    const server = { visible: ['artifacts', 'ariel'] };
+    vi.stubGlobal('fetch', vi.fn(async (/** @type {string} */ url) => {
+      if (url === '/api/panels') {
+        return jsonOk({
+          enabled: ['artifacts', 'ariel'],
+          custom: [],
+          default: null,
+          visible: [...server.visible],
+          active: null,
+          labels: {},
+        });
+      }
+      if (url === '/api/artifact-server') {
+        return jsonOk({ url: '/panel/artifacts', available: true });
+      }
+      if (url === '/api/ariel-server') {
+        return jsonOk({ url: '/panel/ariel', available: true });
+      }
+      return jsonOk({ status: 'ok' });
+    }));
+
+    /** @type {{ onopen?: (() => void) | null }[]} */
+    const sources = [];
+    class FakeEventSource {
+      constructor() {
+        /** @type {(() => void) | null} */
+        this.onopen = null;
+        sources.push(this);
+      }
+      close() {}
+    }
+    vi.stubGlobal('EventSource', FakeEventSource);
+
+    const mod = await freshImport();
+    await mod.initPanelManager('panel-manager');
+    return { mod, server, open: () => { for (const s of sources) s.onopen?.(); } };
+  }
+
+  /** @param {string} id */
+  const entry = (id) => document.querySelector(`.panel-rail-button[data-panel-id="${id}"]`);
+
+  test('a hide missed while disconnected is applied on reconnect', async () => {
+    const { mod, server, open } = await bootResync();
+    expect(entry('ariel')).not.toBeNull();
+
+    // The agent hid ariel while this client's SSE stream was down: the
+    // panel_visibility frame never arrived. The stream then reconnects.
+    server.visible = ['artifacts'];
+    open();
+
+    await vi.waitFor(() => expect(entry('ariel')).toBeNull());
+    expect(mod.getHiddenPanels().map((p) => p.id)).toContain('ariel');
+  });
+
+  test('a show missed while disconnected is applied on reconnect', async () => {
+    const { server, open } = await bootResync();
+    server.visible = ['artifacts'];
+    open();
+    await vi.waitFor(() => expect(entry('ariel')).toBeNull());
+
+    server.visible = ['artifacts', 'ariel'];
+    open();
+
+    await vi.waitFor(() => expect(entry('ariel')).not.toBeNull());
+  });
+
+  test('an in-sync reconnect changes nothing', async () => {
+    const { open } = await bootResync();
+    const before = [...document.querySelectorAll('.panel-rail-button')].map(
+      (b) => b.getAttribute('data-panel-id'),
+    );
+
+    open();
+    await new Promise((r) => setTimeout(r, 0));
+
+    const after = [...document.querySelectorAll('.panel-rail-button')].map(
+      (b) => b.getAttribute('data-panel-id'),
+    );
+    expect(after).toEqual(before);
+  });
+});

--- a/tests/interfaces/web_terminal/panel-rail.test.mjs
+++ b/tests/interfaces/web_terminal/panel-rail.test.mjs
@@ -271,6 +271,40 @@ describe('drag from the rail (onDragStart / onDragEnd)', () => {
     expect(ev.defaultPrevented).toBe(true);
   });
 
+  test('removing a mid-drag entry ends its drag gesture (removeEntry heals the shields)', () => {
+    // A detached drag source can never fire dragend (HTML5 delivers it to the
+    // source element only), so the caller's onDragEnd — which lowers the
+    // iframe pointer shields — would never run and every panel would stay
+    // frozen. removeEntry must end the gesture itself before detaching.
+    /** @type {string[]} */
+    const ended = [];
+    createRail(rail, PANELS, {
+      onDragStart: () => true,
+      onDragEnd: (id) => ended.push(id),
+    });
+    const entry = /** @type {HTMLElement} */ (getEntry(rail, 'ariel'));
+    entry.dispatchEvent(dragEvent('dragstart'));
+    expect(entry.classList.contains('dragging')).toBe(true);
+
+    removeEntry(rail, 'ariel');
+
+    expect(getEntry(rail, 'ariel')).toBeNull();
+    expect(ended).toEqual(['ariel']);
+  });
+
+  test('removeEntry of an idle entry does not fire onDragEnd', () => {
+    /** @type {string[]} */
+    const ended = [];
+    createRail(rail, PANELS, {
+      onDragStart: () => true,
+      onDragEnd: (id) => ended.push(id),
+    });
+
+    removeEntry(rail, 'ariel');
+
+    expect(ended).toEqual([]);
+  });
+
   test('dragend clears the dragging state and calls onDragEnd', () => {
     /** @type {string[]} */
     const ended = [];

--- a/tests/interfaces/web_terminal/rail-drag.test.mjs
+++ b/tests/interfaces/web_terminal/rail-drag.test.mjs
@@ -226,6 +226,54 @@ describe('railDragStart / railDragEnd — payload + shields', () => {
     expect(setIframePointerShield).toHaveBeenLastCalledWith(false);
   });
 
+  test('a document-level terminator lowers the shields when the source\'s dragend is lost', async () => {
+    // HTML5 delivers dragend only to the drag's SOURCE element; a rail entry
+    // removed mid-drag (SSE hide_panel / arrange prune) can never fire it, and
+    // during a native drag mouseup/pointerup are suppressed. Without a
+    // document-level fallback the shields stay up forever and every panel
+    // iframe is left pointer-events:none — the "frozen workspace" bug.
+    const api = makeApi();
+    const { mod, container } = await wire(api);
+    mod.railDragStart('ariel', fakeDT());
+    expect(container.classList.contains('dock-dragging')).toBe(true);
+
+    // The source button was removed; the user's next gesture reaches document.
+    document.dispatchEvent(new Event('mouseup'));
+
+    expect(container.classList.contains('dock-dragging')).toBe(false);
+    expect(setIframePointerShield).toHaveBeenLastCalledWith(false);
+  });
+
+  test('terminator listeners disarm after firing — a later gesture cannot re-lower mid-drag', async () => {
+    const api = makeApi();
+    const { mod, container } = await wire(api);
+
+    // First drag ends via the failsafe.
+    mod.railDragStart('ariel', fakeDT());
+    document.dispatchEvent(new Event('mouseup'));
+    expect(container.classList.contains('dock-dragging')).toBe(false);
+
+    // Second drag: the stale listeners must be gone, so the shield stays up
+    // until this drag's own terminator.
+    mod.railDragStart('okf', fakeDT());
+    expect(container.classList.contains('dock-dragging')).toBe(true);
+    document.dispatchEvent(new Event('dragend'));
+    expect(container.classList.contains('dock-dragging')).toBe(false);
+  });
+
+  test('railDragEnd also disarms the failsafe (normal completion path)', async () => {
+    const api = makeApi();
+    const { mod, container } = await wire(api);
+    mod.railDragStart('ariel', fakeDT());
+    mod.railDragEnd();
+    expect(container.classList.contains('dock-dragging')).toBe(false);
+    setIframePointerShield.mockClear();
+
+    // No armed listener may fire later and fight a dockview-owned gesture.
+    document.dispatchEvent(new Event('mouseup'));
+    expect(setIframePointerShield).not.toHaveBeenCalled();
+  });
+
   test('cancels in simple mode (locked layout)', async () => {
     const api = makeApi();
     const { mod, container } = await wire(api);


### PR DESCRIPTION
Five defects could leave part of the web UI rendering but inert, recoverable
only by reloading the page. Each is fixed with a regression test.

**Rail drag could freeze the whole workspace.** Dragging a panel-rail entry
raises a pointer shield over every panel iframe so the drag events aren't
swallowed. If the matching `dragend` was lost — the pointer leaving the window
mid-drag, or the dragged entry being removed while the gesture was live — the
shield stayed up and every panel kept `pointer-events: none` forever. Rail
drags now arm document-level drag terminators (mirroring what the
dockview-drag path already did), and removing a mid-drag entry ends its gesture
before detaching.

**The panel SSE channel never reconnected.** Once the stream reached a
permanently `CLOSED` state it stopped retrying, so a client silently stopped
receiving panel updates. `createEventSource` now reconnects with backoff and
exposes an `onOpen` hook; the panel manager re-fetches `/api/panels` on every
connect and re-converges rail membership through the same path SSE frames use,
so a client that missed frames catches up rather than drifting. The catch-all
in the SSE dispatcher now logs instead of swallowing errors.

**The gallery's logbook success overlay could not be dismissed.** Dismissal
operated on a modal cache that submit had already nulled, leaving a permanent
full-panel overlay. It now operates on the DOM.

**Gallery fullscreen stranded on an empty selection.** Clearing the selection
(delete key, or an agent-side `artifact_deleted`) left a chrome-less dead pane;
it now exits fullscreen.

**A failed boot blacked out the page.** The welcome overlay wires its dismiss
controls before any fallible init step, and a terminal init failure (e.g. the
xterm CDN not loading) degrades the terminal card instead of aborting the whole
boot.