### PR TITLE
feat(ci): keep evidence from red and killed lanes

### DIFF
--- a/.github/actions/capture-ci-diagnostics/action.yml
+++ b/.github/actions/capture-ci-diagnostics/action.yml
@@ -1,0 +1,98 @@
+name: Capture CI diagnostics
+description: >-
+  Snapshot container logs, container state, and runner health into an uploaded
+  artifact. Intended to run on failure, BEFORE any teardown step — the deploy
+  lanes' cleanup blocks delete the very containers that hold the explanation.
+
+inputs:
+  name:
+    description: >-
+      Artifact name suffix. Must be unique across the jobs in one workflow run,
+      or the uploads collide and only one survives.
+    required: true
+  engine:
+    description: Container engine to interrogate — `docker` or `podman`.
+    required: false
+    default: docker
+
+runs:
+  using: composite
+  steps:
+    - name: Snapshot containers and runner state
+      shell: bash
+      # Every container operation here is READ-ONLY: ps, inspect, logs, stats.
+      # No rm, no down, no volume rm, and above all no prune or -a/--all sweep —
+      # this action runs on shared self-hosted runners too, where a prune would
+      # destroy another job's state. Same guardrail the e2e cleanup blocks and
+      # the tests' own teardown follow.
+      #
+      # `|| true` on every probe: this step runs when something has already gone
+      # wrong, so a missing engine or a dead daemon must not mask the original
+      # failure with a diagnostics failure.
+      env:
+        ENGINE: ${{ inputs.engine }}
+      run: |
+        set -u
+        DIAG="ci-diag"
+        mkdir -p "$DIAG/containers"
+
+        # ---- runner health -------------------------------------------------
+        # Answers the "was this an infra stall?" question with evidence rather
+        # than inference: a full disk or an exhausted runner shows up here.
+        {
+          echo "== date =="; date -u
+          echo; echo "== uptime / load =="; uptime
+          echo; echo "== disk =="; df -h
+          echo; echo "== memory =="
+          if command -v free >/dev/null 2>&1; then free -m; else vm_stat; fi
+          echo; echo "== top processes by RSS =="
+          ps -eo pid,ppid,rss,etime,comm --sort=-rss 2>/dev/null | head -25 \
+            || ps axo pid,ppid,rss,etime,comm | head -25
+        } > "$DIAG/runner-state.txt" 2>&1 || true
+
+        if ! command -v "$ENGINE" >/dev/null 2>&1; then
+          echo "$ENGINE not installed on this runner; container capture skipped" \
+            > "$DIAG/containers/SKIPPED.txt"
+          exit 0
+        fi
+
+        # ---- container inventory -------------------------------------------
+        "$ENGINE" ps -a > "$DIAG/containers/ps.txt" 2>&1 || true
+        "$ENGINE" images > "$DIAG/containers/images.txt" 2>&1 || true
+        "$ENGINE" volume ls > "$DIAG/containers/volumes.txt" 2>&1 || true
+        "$ENGINE" network ls > "$DIAG/containers/networks.txt" 2>&1 || true
+
+        # ---- per-container logs and state ----------------------------------
+        # `.State.OOMKilled` and `.State.ExitCode` are the payload: they turn
+        # "the lane just died" into a named cause. Health-check output is
+        # included because a stack that never became healthy fails its test
+        # long before it logs anything interesting.
+        for cid in $("$ENGINE" ps -aq 2>/dev/null); do
+          raw=$("$ENGINE" inspect --format '{{.Name}}' "$cid" 2>/dev/null || echo "$cid")
+          safe=$(printf '%s' "${raw#/}" | tr -c 'A-Za-z0-9._-' '_')
+          [ -n "$safe" ] || safe="$cid"
+
+          "$ENGINE" logs --timestamps "$cid" \
+            > "$DIAG/containers/${safe}.log" 2>&1 || true
+
+          "$ENGINE" inspect \
+            --format '{{.Name}} image={{.Config.Image}} status={{.State.Status}} exit={{.State.ExitCode}} oomkilled={{.State.OOMKilled}} error={{.State.Error}} started={{.State.StartedAt}} finished={{.State.FinishedAt}}' \
+            "$cid" >> "$DIAG/containers/state.txt" 2>&1 || true
+
+          health=$("$ENGINE" inspect --format '{{json .State.Health}}' "$cid" 2>/dev/null || true)
+          if [ -n "$health" ] && [ "$health" != "null" ]; then
+            printf '%s\n' "$health" > "$DIAG/containers/${safe}.health.json"
+          fi
+        done
+
+        echo "--- captured into $DIAG ---"
+        ls -R "$DIAG" || true
+
+    - name: Upload diagnostics artifact
+      uses: actions/upload-artifact@v7
+      if: always()
+      with:
+        name: ci-diag-${{ inputs.name }}
+        path: ci-diag/
+        retention-days: 14
+        if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,9 +116,16 @@ jobs:
       # timeout is a hard cancel: the runner stops the job outright, and the
       # collection steps below never get a dependable chance to run, so a
       # wedged lane is recorded as `cancelled` with nothing to read. Failing
-      # the STEP instead costs the same wall clock and leaves ~8 minutes for
-      # the summary and upload steps to do their work.
-      timeout-minutes: 22
+      # the STEP instead costs the same wall clock and leaves the summary and
+      # upload steps room to run.
+      #
+      # The margin is sized to what collection actually costs, which is two
+      # seconds — measured, both steps together. It is NOT slack for the test
+      # run: the ubuntu cells legitimately reach ~22min (they carry the whole
+      # suite; macOS finishes in ~12), so a margin generous enough to feel safe
+      # reds a healthy lane, which is exactly what a 22-minute cap did here.
+      # Two minutes is sixty times what the collection needs.
+      timeout-minutes: 28
       env:
         # Switches on tests/ci_diagnostics.py: a continuously flushed event log
         # and stack-dump file per xdist worker, written here and uploaded below.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,9 +180,11 @@ jobs:
         # (armed by OSPREY_CI_DIAG_DIR above) writes the same stacks to a file
         # per worker that is uploaded as an artifact, and repeats the dump, so
         # a genuinely stuck stack is distinguishable from a merely slow one.
-        # The two cannot coexist: dump_traceback_later is process-global and
-        # pytest's plugin re-arms it around every test, so setting the ini
-        # option here would silently replace the file-backed timer.
+        # Setting the ini option here would also be actively unsafe: pytest
+        # implements it with faulthandler.dump_traceback_later, whose watchdog
+        # walks frames without the GIL and segfaults workers that are inside a
+        # YAML or Jinja parser. That crashed this lane on three consecutive
+        # runs; tests/ci_diagnostics.py samples from a Python thread instead.
         #
         # Still dump-only, never kill: the container-starting files can sit in
         # a cold image pull for minutes and must not be shot for it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,18 @@ jobs:
       run: uv sync --extra dev --extra virtual-accelerator
 
     - name: Run unit tests
+      # timeout-minutes is deliberately below the job's 30-minute cap. A JOB
+      # timeout is a hard cancel: the runner stops the job outright, and the
+      # collection steps below never get a dependable chance to run, so a
+      # wedged lane is recorded as `cancelled` with nothing to read. Failing
+      # the STEP instead costs the same wall clock and leaves ~8 minutes for
+      # the summary and upload steps to do their work.
+      timeout-minutes: 22
+      env:
+        # Switches on tests/ci_diagnostics.py: a continuously flushed event log
+        # and stack-dump file per xdist worker, written here and uploaded below.
+        # Unset everywhere else, so local runs are unaffected.
+        OSPREY_CI_DIAG_DIR: ci-diag
       # Coverage is measured only on the cell that uploads to Codecov below —
       # the other three cells were paying ~25% runtime (measured) for a report
       # nobody reads.
@@ -145,11 +157,19 @@ jobs:
         else
           COV_ARGS=""
         fi
-        # faulthandler_timeout: any single test stuck past 5 minutes dumps
-        # every thread's stack to stderr without killing the run — a wedged
-        # worker leaves a diagnosis in the log instead of a silent 99% stall.
-        # Dump-only, so the container-starting files (cold image pulls can
-        # legitimately run long) are never killed by it.
+        # No `-o faulthandler_timeout` here, deliberately. pytest's built-in
+        # version does reach the job log under `-n` (xdist relays worker
+        # stderr), but it dumps once per test and lands only in the log — which
+        # is precisely what a cancelled job truncates. tests/ci_diagnostics.py
+        # (armed by OSPREY_CI_DIAG_DIR above) writes the same stacks to a file
+        # per worker that is uploaded as an artifact, and repeats the dump, so
+        # a genuinely stuck stack is distinguishable from a merely slow one.
+        # The two cannot coexist: dump_traceback_later is process-global and
+        # pytest's plugin re-arms it around every test, so setting the ini
+        # option here would silently replace the file-backed timer.
+        #
+        # Still dump-only, never kill: the container-starting files can sit in
+        # a cold image pull for minutes and must not be shot for it.
         #
         # The two live Channel Access modules are excluded here and run in the
         # isolated step below: libca is process-global and not thread-safe, and
@@ -159,7 +179,32 @@ jobs:
         # minutes later in an unrelated test and EPICS' signal handling turns
         # it into a silent wedge rather than a death. A live CA client/server
         # pair is only safe in a process of its own.
-        uv run pytest tests/ --ignore=tests/e2e --ignore=tests/va/test_record_factory.py --ignore=tests/va/test_apply_fault.py -v --tb=short -n 4 --dist loadgroup $COV_ARGS -o faulthandler_timeout=300
+        uv run pytest tests/ --ignore=tests/e2e --ignore=tests/va/test_record_factory.py --ignore=tests/va/test_apply_fault.py -v --tb=short -n 4 --dist loadgroup $COV_ARGS
+
+    # The two steps below are the reason the step above has its own timeout.
+    # They run on success too: on a green lane the summary is one line, and on
+    # a killed lane it is the only place the answer exists.
+    - name: Summarise lane diagnostics
+      if: always()
+      # Names the test each worker was inside when the lane stopped. All four
+      # workers stalling at once means the runner went away; one worker stalling
+      # means the test it names deadlocked. That distinction decides whether a
+      # rerun is legitimate, and it is not recoverable from the job log.
+      #
+      # `python3`, not `uv run`: the script is stdlib-only and standalone by
+      # design, so it still reports when the failure being diagnosed is the
+      # dependency install itself. `|| true` because a broken diagnostic must
+      # never turn a green lane red, nor mask the real failure on a red one.
+      run: python3 scripts/ci/diag_summary.py ci-diag >> "$GITHUB_STEP_SUMMARY" || true
+
+    - name: Upload lane diagnostics
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: ci-diag-unit-${{ matrix.python-version }}-${{ matrix.os }}
+        path: ci-diag/
+        retention-days: 14
+        if-no-files-found: warn
 
     - name: Run live Channel Access suites in isolation
       # One pytest process per module via the live-CA gate — the same venue
@@ -699,6 +744,15 @@ jobs:
         PRESET_K="${PRESET//-/_}"
         uv run pytest tests/e2e/test_preset_agentic.py -v --tb=short -k "$PRESET_K"
 
+    # On failure only: container logs, exit codes, `OOMKilled`, and runner
+    # disk/memory state, uploaded as the `ci-diag-<lane>` artifact.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: agentic-per-preset-${{ matrix.preset }}
+        engine: docker
+
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
@@ -778,6 +832,10 @@ jobs:
         echo "$bundled" >> "$GITHUB_PATH"
 
     - name: Run E2E tests
+      # Step cap under the job cap so a hang fails THIS step, leaving the
+      # capture step below room to run. A job-level timeout is a hard cancel
+      # that takes the container logs with it.
+      timeout-minutes: 35
       # E2E_FILTER comes from workflow_dispatch `inputs.e2e_filter` and is
       # empty on push/PR/schedule triggers, so the full-suite command runs
       # by default. The filter is a debug-only convenience for scoped CI
@@ -867,6 +925,15 @@ jobs:
             --ignore=tests/e2e/web_terminals/test_auth_perimeter.py \
             --ignore=tests/e2e/claude_code/test_channel_finder_mcp_benchmarks.py
         fi
+    # On failure only: container logs, exit codes, `OOMKilled`, and runner
+    # disk/memory state, uploaded as the `ci-diag-<lane>` artifact.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: e2e-tests
+        engine: docker
+
 
   channel-finder-benchmarks:
     name: Channel-Finder MCP Benchmarks (on demand)
@@ -1006,6 +1073,16 @@ jobs:
         # TemplateNotFound.
         uv run osprey up -d --dev
 
+    # Runs BEFORE the teardown below: the cleanup step deletes the very
+    # containers whose logs explain the failure. Read-only capture; the
+    # artifact is `ci-diag-<lane>` on the run's summary page.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: deploy-e2e
+        engine: docker
+
     - name: osprey down
       if: always()
       run: |
@@ -1092,6 +1169,15 @@ jobs:
         DISPATCH_WORKER_TOKEN: dev-token
       run: |
         uv run pytest tests/e2e/test_dispatch_deploy.py -v --tb=short
+    # On failure only: container logs, exit codes, `OOMKilled`, and runner
+    # disk/memory state, uploaded as the `ci-diag-<lane>` artifact.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: dispatch-deploy-e2e
+        engine: docker
+
 
   dispatch-overlay-e2e:
     name: Dispatch Overlay E2E (overlay skill/data/trigger visibility, full Docker stack)
@@ -1166,12 +1252,25 @@ jobs:
         echo "✅ ALS-APG endpoint reachable (HTTP 200)"
 
     - name: Run dispatch overlay visibility E2E
+      # Step cap under the job cap so a hang fails THIS step, leaving the
+      # capture step below room to run. A job-level timeout is a hard cancel
+      # that takes the container logs with it.
+      timeout-minutes: 25
       env:
         ALS_APG_API_KEY: ${{ secrets.ALS_APG_API_KEY }}
         EVENT_DISPATCHER_TOKEN: dev-token
         DISPATCH_WORKER_TOKEN: dev-token
       run: |
         uv run pytest tests/e2e/test_dispatch_overlay_visibility.py -v --tb=short
+    # On failure only: container logs, exit codes, `OOMKilled`, and runner
+    # disk/memory state, uploaded as the `ci-diag-<lane>` artifact.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: dispatch-overlay-e2e
+        engine: docker
+
 
   bluesky-deploy-e2e:
     name: Bluesky Deploy E2E (bluesky bridge, full Docker stack)
@@ -1212,6 +1311,15 @@ jobs:
     - name: Run bluesky deploy E2E
       run: |
         uv run pytest tests/e2e/test_bluesky_deploy.py -v --tb=short
+    # On failure only: container logs, exit codes, `OOMKilled`, and runner
+    # disk/memory state, uploaded as the `ci-diag-<lane>` artifact.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: bluesky-deploy-e2e
+        engine: docker
+
 
   bluesky-panels-deploy-e2e:
     name: Bluesky Panels Deploy E2E (VA + bluesky bridge + bluesky-panels sidecar, full Docker stack)
@@ -1255,8 +1363,21 @@ jobs:
       run: uv sync --extra dev
 
     - name: Run bluesky panels deploy E2E
+      # Step cap under the job cap so a hang fails THIS step, leaving the
+      # capture step below room to run. A job-level timeout is a hard cancel
+      # that takes the container logs with it.
+      timeout-minutes: 40
       run: |
         uv run pytest tests/e2e/test_bluesky_panels_deploy.py -v --tb=short
+    # On failure only: container logs, exit codes, `OOMKilled`, and runner
+    # disk/memory state, uploaded as the `ci-diag-<lane>` artifact.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: bluesky-panels-deploy-e2e
+        engine: docker
+
 
   va-substrate-equivalence-e2e:
     name: VA Substrate Equivalence E2E (virtual accelerator + bluesky bridge, full Docker stack)
@@ -1305,8 +1426,21 @@ jobs:
       run: uv sync --extra dev
 
     - name: Run VA substrate equivalence E2E
+      # Step cap under the job cap so a hang fails THIS step, leaving the
+      # capture step below room to run. A job-level timeout is a hard cancel
+      # that takes the container logs with it.
+      timeout-minutes: 40
       run: |
         uv run pytest tests/e2e/test_va_substrate_equivalence.py -v --tb=short
+    # On failure only: container logs, exit codes, `OOMKilled`, and runner
+    # disk/memory state, uploaded as the `ci-diag-<lane>` artifact.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: va-substrate-equivalence-e2e
+        engine: docker
+
 
   orm-roundtrip-e2e:
     name: ORM + Grid Scan Roundtrip E2E (VA + bluesky bridge + Tiled, full Docker stack)
@@ -1374,6 +1508,15 @@ jobs:
     - name: Run grid scan roundtrip E2E
       run: |
         uv run pytest tests/e2e/test_grid_scan_roundtrip.py -v --tb=short
+    # On failure only: container logs, exit codes, `OOMKilled`, and runner
+    # disk/memory state, uploaded as the `ci-diag-<lane>` artifact.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: orm-roundtrip-e2e
+        engine: docker
+
 
   bluesky-queue-e2e:
     name: Bluesky Queue E2E (queueserver + Redis + Tiled + VA, full Docker stack)
@@ -1418,8 +1561,21 @@ jobs:
       run: uv sync --extra dev
 
     - name: Run Bluesky queue E2E
+      # Step cap under the job cap so a hang fails THIS step, leaving the
+      # capture step below room to run. A job-level timeout is a hard cancel
+      # that takes the container logs with it.
+      timeout-minutes: 70
       run: |
         uv run pytest tests/e2e/test_bluesky_queue_e2e.py -v --tb=short
+    # On failure only: container logs, exit codes, `OOMKilled`, and runner
+    # disk/memory state, uploaded as the `ci-diag-<lane>` artifact.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: bluesky-queue-e2e
+        engine: docker
+
 
   scan-agentic-e2e:
     name: Scan Stack Agentic E2E (agent-driven ORM + grid scans on the deployed queue stack)
@@ -1518,6 +1674,10 @@ jobs:
         echo "$bundled" >> "$GITHUB_PATH"
 
     - name: Run scan stack agentic E2E
+      # Step cap under the job cap so a hang fails THIS step, leaving the
+      # capture step below room to run. A job-level timeout is a hard cancel
+      # that takes the container logs with it.
+      timeout-minutes: 70
       env:
         ALS_APG_API_KEY: ${{ secrets.ALS_APG_API_KEY }}
       run: |
@@ -1563,6 +1723,15 @@ jobs:
             sys.exit(1)
         print("✅ every scan-stack agentic test ran; none skipped")
         PY
+    # On failure only: container logs, exit codes, `OOMKilled`, and runner
+    # disk/memory state, uploaded as the `ci-diag-<lane>` artifact.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: scan-agentic-e2e
+        engine: docker
+
 
   archiver-world-e2e:
     name: Archiver World E2E (VA + mongodb store + recorder, full Docker stack)
@@ -1611,12 +1780,25 @@ jobs:
       run: uv sync --extra dev --extra archiver-mongodb
 
     - name: Run archiver world E2E
+      # Step cap under the job cap so a hang fails THIS step, leaving the
+      # capture step below room to run. A job-level timeout is a hard cancel
+      # that takes the container logs with it.
+      timeout-minutes: 40
       # -s so the measured budgets this lane owns (seed duration, store size,
       # write->read latency) reach the log on a GREEN run. Pytest captures
       # stdout on passing tests, and a budget lane that only shows its numbers
       # when it fails cannot be read for the trend that precedes a failure.
       run: |
         uv run pytest tests/e2e/test_archiver_world_e2e.py -v -s --tb=short
+    # On failure only: container logs, exit codes, `OOMKilled`, and runner
+    # disk/memory state, uploaded as the `ci-diag-<lane>` artifact.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: archiver-world-e2e
+        engine: docker
+
 
   tiled-roundtrip-e2e:
     name: Tiled Roundtrip E2E (bluesky bridge + Tiled persistence, full Docker stack)
@@ -1659,8 +1841,21 @@ jobs:
       run: uv sync --extra dev
 
     - name: Run Tiled roundtrip E2E
+      # Step cap under the job cap so a hang fails THIS step, leaving the
+      # capture step below room to run. A job-level timeout is a hard cancel
+      # that takes the container logs with it.
+      timeout-minutes: 15
       run: |
         uv run pytest tests/e2e/test_tiled_roundtrip.py -v --tb=short
+    # On failure only: container logs, exit codes, `OOMKilled`, and runner
+    # disk/memory state, uploaded as the `ci-diag-<lane>` artifact.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: tiled-roundtrip-e2e
+        engine: docker
+
 
   bluesky-catalog-e2e:
     name: Bluesky Catalog E2E (layered plan catalog, full Docker stack)
@@ -1706,6 +1901,15 @@ jobs:
     - name: Run bluesky catalog E2E
       run: |
         uv run pytest tests/e2e/test_bluesky_catalog_e2e.py -v --tb=short
+    # On failure only: container logs, exit codes, `OOMKilled`, and runner
+    # disk/memory state, uploaded as the `ci-diag-<lane>` artifact.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: bluesky-catalog-e2e
+        engine: docker
+
 
   bluesky-sandbox-escape-e2e:
     name: Bluesky Sandbox Escape E2E (session-plan authoring gates, full Docker stack)
@@ -1752,8 +1956,21 @@ jobs:
       run: uv sync --extra dev
 
     - name: Run bluesky sandbox escape E2E
+      # Step cap under the job cap so a hang fails THIS step, leaving the
+      # capture step below room to run. A job-level timeout is a hard cancel
+      # that takes the container logs with it.
+      timeout-minutes: 40
       run: |
         uv run pytest tests/e2e/test_bluesky_sandbox_escape_e2e.py -v --tb=short
+    # On failure only: container logs, exit codes, `OOMKilled`, and runner
+    # disk/memory state, uploaded as the `ci-diag-<lane>` artifact.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: bluesky-sandbox-escape-e2e
+        engine: docker
+
 
   nextcloud-talk-bridge-e2e:
     name: Nextcloud Talk Bridge E2E (real Talk server + dispatch stack)
@@ -1854,10 +2071,23 @@ jobs:
         echo "✅ ALS-APG endpoint reachable (HTTP 200)"
 
     - name: Run Nextcloud Talk bridge E2E
+      # Step cap under the job cap so a hang fails THIS step, leaving the
+      # capture step below room to run. A job-level timeout is a hard cancel
+      # that takes the container logs with it.
+      timeout-minutes: 40
       env:
         ALS_APG_API_KEY: ${{ secrets.ALS_APG_API_KEY }}
       run: |
         uv run pytest tests/e2e/test_nextcloud_talk_bridge_e2e.py -v --tb=short
+    # On failure only: container logs, exit codes, `OOMKilled`, and runner
+    # disk/memory state, uploaded as the `ci-diag-<lane>` artifact.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: nextcloud-talk-bridge-e2e
+        engine: docker
+
 
   gchat-bridge-e2e:
     name: Google Chat Bridge E2E (Pub/Sub emulator + dispatch stack)
@@ -2011,6 +2241,15 @@ jobs:
             sys.exit(1)
         print("✅ every Google Chat test ran; none skipped")
         PY
+    # On failure only: container logs, exit codes, `OOMKilled`, and runner
+    # disk/memory state, uploaded as the `ci-diag-<lane>` artifact.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: gchat-bridge-e2e
+        engine: docker
+
 
   dockerfile-e2e:
     name: Dockerfile E2E (generated container image)
@@ -2046,6 +2285,15 @@ jobs:
         # secret is ever absent, so this stays advisory and self-gating.
         ALS_APG_API_KEY: ${{ secrets.ALS_APG_API_KEY }}
       run: uv run pytest tests/e2e/test_dockerfile_e2e.py -v --tb=short
+    # On failure only: container logs, exit codes, `OOMKilled`, and runner
+    # disk/memory state, uploaded as the `ci-diag-<lane>` artifact.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: dockerfile-e2e
+        engine: docker
+
 
   execution-environment-parity-e2e:
     name: Execution Environment Parity E2E (host venv vs generated image)
@@ -2083,8 +2331,21 @@ jobs:
       run: uv sync --extra dev
 
     - name: Run execution environment parity E2E
+      # Step cap under the job cap so a hang fails THIS step, leaving the
+      # capture step below room to run. A job-level timeout is a hard cancel
+      # that takes the container logs with it.
+      timeout-minutes: 35
       run: |
         uv run pytest tests/e2e/test_execution_environment_parity.py -v --tb=short
+    # On failure only: container logs, exit codes, `OOMKilled`, and runner
+    # disk/memory state, uploaded as the `ci-diag-<lane>` artifact.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: execution-environment-parity-e2e
+        engine: docker
+
 
   deploy-writeback-e2e:
     name: Deploy Write-Back E2E (profile-owned secrets across a rebuild)
@@ -2130,8 +2391,22 @@ jobs:
       run: uv sync --extra dev
 
     - name: Run deploy write-back E2E
+      # Step cap under the job cap so a hang fails THIS step, leaving the
+      # capture step below room to run. A job-level timeout is a hard cancel
+      # that takes the container logs with it.
+      timeout-minutes: 15
       run: |
         uv run pytest tests/e2e/test_deploy_writeback_e2e.py -v --tb=short
+
+    # Runs BEFORE the teardown below: the cleanup step deletes the very
+    # containers whose logs explain the failure. Read-only capture; the
+    # artifact is `ci-diag-<lane>` on the run's summary page.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: deploy-writeback-e2e
+        engine: docker
 
     # Belt-and-suspenders on top of each test's own try/finally teardown: every
     # resource named here is exact (never a prune/-a/wildcard), matching
@@ -2186,6 +2461,16 @@ jobs:
     - name: Run multi-user deploy lifecycle E2E
       run: |
         uv run pytest tests/e2e/test_deploy_lifecycle.py -v --tb=short
+
+    # Runs BEFORE the teardown below: the cleanup step deletes the very
+    # containers whose logs explain the failure. Read-only capture; the
+    # artifact is `ci-diag-<lane>` on the run's summary page.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: multi-user-deploy-lifecycle-e2e
+        engine: docker
 
     # Belt-and-suspenders on top of the test's own try/finally teardown: every
     # resource named here is exact (never a prune/-a/wildcard), matching
@@ -2246,6 +2531,16 @@ jobs:
     - name: Run auth perimeter E2E
       run: |
         uv run pytest tests/e2e/web_terminals/test_auth_perimeter.py -v --tb=short
+
+    # Runs BEFORE the teardown below: the cleanup step deletes the very
+    # containers whose logs explain the failure. Read-only capture; the
+    # artifact is `ci-diag-<lane>` on the run's summary page.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: auth-perimeter-e2e
+        engine: docker
 
     # Belt-and-suspenders on top of the test's own try/finally teardown. Every
     # resource named here is exact — never a prune, an -a/--all sweep, or a
@@ -2332,6 +2627,16 @@ jobs:
         for _ in $(seq 1 30); do if [ -S "$SOCK" ]; then break; fi; sleep 1; done
         export DOCKER_HOST="unix://$SOCK"
         uv run pytest tests/e2e/test_deploy_lifecycle.py -v --tb=short
+
+    # Runs BEFORE the teardown below: the cleanup step deletes the very
+    # containers whose logs explain the failure. Read-only capture; the
+    # artifact is `ci-diag-<lane>` on the run's summary page.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: multi-user-deploy-lifecycle-e2e-podman
+        engine: podman
 
     # Belt-and-suspenders on top of the test's own try/finally teardown: every
     # resource named here is exact (never a prune/-a/wildcard), matching

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,19 @@ jobs:
   test:
     name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    # The slowest cell (macOS) finishes in ~11 min; without a bound, a single
-    # wedged xdist worker holds the lane at 99% for the 6-hour default.
-    timeout-minutes: 30
+    # Without a bound, a single wedged xdist worker holds the lane at 99% for
+    # the 6-hour default.
+    #
+    # 45 rather than 30, and the cells are no longer close to it. A healthy run
+    # is ~11 min (ubuntu 3.12) to ~22 min (ubuntu 3.11, which also measures
+    # coverage); macOS finishes in ~9-14. What forces the headroom is a known
+    # intermittent tail worth ~12 minutes: a worker wedges mid-test and its
+    # share has to be redistributed to a replacement, or the session hangs
+    # after the last test on non-daemon threads that outlive it. Both are
+    # visible in this lane's uploaded diagnostics, and neither is bounded by
+    # anything the suite controls, so a cap tight enough to catch them also
+    # reds the runs where they merely cost time.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -112,20 +122,19 @@ jobs:
       run: uv sync --extra dev --extra virtual-accelerator
 
     - name: Run unit tests
-      # timeout-minutes is deliberately below the job's 30-minute cap. A JOB
-      # timeout is a hard cancel: the runner stops the job outright, and the
-      # collection steps below never get a dependable chance to run, so a
-      # wedged lane is recorded as `cancelled` with nothing to read. Failing
-      # the STEP instead costs the same wall clock and leaves the summary and
-      # upload steps room to run.
+      # timeout-minutes is deliberately below the job's cap. A JOB timeout is a
+      # hard cancel: the runner stops the job outright, and the collection steps
+      # below never get a dependable chance to run, so a wedged lane is recorded
+      # as `cancelled` with nothing to read. Failing the STEP instead costs the
+      # same wall clock and leaves the summary and upload steps room to run.
       #
-      # The margin is sized to what collection actually costs, which is two
-      # seconds — measured, both steps together. It is NOT slack for the test
-      # run: the ubuntu cells legitimately reach ~22min (they carry the whole
-      # suite; macOS finishes in ~12), so a margin generous enough to feel safe
-      # reds a healthy lane, which is exactly what a 22-minute cap did here.
-      # Two minutes is sixty times what the collection needs.
-      timeout-minutes: 28
+      # The 5-minute margin is not sized to the collection steps, which take two
+      # seconds between them — it is there so this cap sits clear of the ~12
+      # minute intermittent tail described on the job cap above. A cap set just
+      # above the healthy runtime kills the runs that hit that tail and would
+      # have passed anyway; the value is deliberately loose for that reason, and
+      # tightening it is how this lane starts flaking.
+      timeout-minutes: 40
       env:
         # Switches on tests/ci_diagnostics.py: a continuously flushed event log
         # and stack-dump file per xdist worker, written here and uploaded below.

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,11 @@ coverage.xml
 coverage.json
 *.cover
 .hypothesis/
+
+# CI diagnostics drop (per-worker event logs, stack dumps, container logs).
+# Written by tests/ci_diagnostics.py and .github/actions/capture-ci-diagnostics
+# whenever OSPREY_CI_DIAG_DIR is set; uploaded as an artifact, never committed.
+/ci-diag/
 .pytest_cache/
 
 # Jupyter Notebook

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Added
 
+- A red CI lane now leaves evidence behind. Every Docker lane captures its
+  container logs, exit codes and `OOMKilled` flags — plus runner disk and
+  memory state — before teardown removes the containers, and uploads them as a
+  `ci-diag-<lane>` artifact. The unit-test lane records, per parallel worker
+  and flushed as it goes, which test was in flight, along with stack dumps for
+  anything stuck past five minutes. A lane that is killed rather than failing
+  (job timeout, runner stall) now names the test each worker stopped on in the
+  run summary, instead of ending as a silent `cancelled`. Lanes that declare a
+  time budget now cap their test step below it, so a hang fails that step and
+  the capture still runs, rather than the whole job being cancelled mid-teardown.
+
 - A tokenless `queue_start` now files a **start request** the operator confirms
   in the BLUESKY queue panel, instead of dead-ending in a refusal. Deployed
   web terminals never hold the scan launch token by design; the agent stages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,9 @@ Compatibility is documented in release notes, not encoded in the version string.
   container logs, exit codes and `OOMKilled` flags — plus runner disk and
   memory state — before teardown removes the containers, and uploads them as a
   `ci-diag-<lane>` artifact. The unit-test lane records, per parallel worker
-  and flushed as it goes, which test was in flight, along with stack dumps for
-  anything stuck past five minutes. A lane that is killed rather than failing
+  and flushed as it goes, which test was in flight, alongside a stack snapshot
+  of every thread taken every five minutes — including after the last test, so
+  a hang during shutdown is visible too. A lane that is killed rather than failing
   (job timeout, runner stall) now names the test each worker stopped on in the
   run summary, instead of ending as a silent `cancelled`. Lanes that declare a
   time budget now cap their test step below it, so a hang fails that step and

--- a/scripts/ci/diag_summary.py
+++ b/scripts/ci/diag_summary.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Turn a CI diagnostics directory into a one-screen answer.
+
+``tests/ci_diagnostics.py`` writes an event log per xdist worker while the suite
+runs. When a lane is killed rather than failing — a step timeout, a runner OOM,
+a wedged worker — those logs hold the one fact the job log cannot show: which
+test each worker was inside at the moment everything stopped.
+
+This reads them and says so, in the run's step summary, so nobody has to
+download the artifact to learn whether a freeze was one stuck test or the whole
+runner going away.
+
+Deliberately standalone — no imports from ``tests/`` — so the reader cannot be
+broken by the writer, and so it still runs in a job that never installed the
+project. Usage::
+
+    python scripts/ci/diag_summary.py [ci-diag-dir]
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def _events(path: Path) -> list[dict]:
+    """Parse one JSONL log, skipping records a signal cut in half.
+
+    A killed process is routinely interrupted mid-``write``, so a malformed
+    final line is the normal case, not corruption. Dropping the report over it
+    would discard the diagnosis this file exists to carry.
+    """
+    records = []
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return records
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return records
+
+
+def stalled_tests(directory: Path | str) -> dict[str, str]:
+    """Map worker -> the test it started and never finished.
+
+    Workers that finished everything they started are absent, so an empty result
+    means no test was in flight — the process died between tests, or exited
+    cleanly and something else failed the job.
+    """
+    directory = Path(directory)
+    if not directory.is_dir():
+        return {}
+
+    stalled: dict[str, str] = {}
+    for path in sorted(directory.glob("events-*.jsonl")):
+        worker = path.stem.removeprefix("events-")
+        in_flight: str | None = None
+        for record in _events(path):
+            event = record.get("event")
+            if event == "start":
+                in_flight = record.get("nodeid")
+            elif event in ("finish", "session_end"):
+                in_flight = None
+        if in_flight:
+            stalled[worker] = in_flight
+    return stalled
+
+
+def _counts(directory: Path) -> dict[str, int]:
+    return {
+        path.stem.removeprefix("events-"): sum(
+            1 for record in _events(path) if record.get("event") == "finish"
+        )
+        for path in sorted(directory.glob("events-*.jsonl"))
+    }
+
+
+def render_report(directory: Path | str) -> str:
+    """Markdown for ``$GITHUB_STEP_SUMMARY``."""
+    directory = Path(directory)
+    stalled = stalled_tests(directory)
+    completed = _counts(directory)
+
+    lines = ["### Test lane diagnostics", ""]
+
+    if not completed:
+        lines.append("No diagnostics were recorded (the lane never started the suite).")
+        return "\n".join(lines) + "\n"
+
+    if stalled:
+        # Every worker stopping at once points at the runner rather than at any
+        # one test; a single stalled worker points at the test it names.
+        scope = "all workers" if len(stalled) == len(completed) else "some workers"
+        lines += [
+            f"**In flight when the lane stopped ({scope}):**",
+            "",
+            "| Worker | Test | Completed before it |",
+            "| --- | --- | --- |",
+        ]
+        lines += [
+            f"| `{worker}` | `{nodeid}` | {completed.get(worker, 0)} |"
+            for worker, nodeid in sorted(stalled.items())
+        ]
+        if len(stalled) == len(completed) and len(stalled) > 1:
+            lines += [
+                "",
+                "Every worker stopped with a test in flight — consistent with the "
+                "runner stalling or being killed, not with one deadlocked test. "
+                "Check `runner-state.txt` and the container `OOMKilled` flags.",
+            ]
+    else:
+        lines.append("No stalled tests: every started test also finished.")
+
+    stacks = sorted(directory.glob("stacks-*.txt"))
+    if stacks:
+        lines += ["", f"**Stack dumps captured:** {', '.join(p.name for p in stacks)}"]
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str]) -> int:
+    directory = Path(argv[1]) if len(argv) > 1 else Path("ci-diag")
+    sys.stdout.write(render_report(directory))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/ci_diagnostics.py
+++ b/tests/ci_diagnostics.py
@@ -14,9 +14,14 @@ complete at every instant rather than at exit:
     ``scripts/ci/diag_summary.py``.
 
 ``stacks-<worker>.txt``
-    Every thread's stack, dumped on a repeating timer once a single test has run
-    longer than the stack timeout, plus a traceback if the interpreter crashes
-    outright.
+    Every thread's stack, sampled on a repeating timer for the whole session,
+    plus a traceback if the interpreter crashes outright. The timer is armed
+    once at session start rather than around each test, so this is a periodic
+    snapshot, not a per-test stuck detector: a healthy long run leaves a handful
+    of dumps, and a wedged one leaves the same frames over and over, which is
+    what "stuck" looks like. Sampling the whole session is deliberate — it keeps
+    dumping after the LAST test has finished, which is where a shutdown hang
+    lives, and a per-test timer would be cancelled by then and show nothing.
 
 Both are gated on ``OSPREY_CI_DIAG_DIR``: unset (every local run) means this
 module installs nothing at all.
@@ -57,13 +62,13 @@ from typing import Any
 #: to. The CI job uploads that directory as an artifact.
 ENV_DIR = "OSPREY_CI_DIAG_DIR"
 
-#: Seconds a single test may run before its stacks are dumped. ``0`` disables
-#: stack dumping while leaving the event log on.
+#: Seconds between whole-process stack snapshots. ``0`` disables stack dumping
+#: while leaving the event log on.
 ENV_STACK_TIMEOUT = "OSPREY_CI_DIAG_STACK_TIMEOUT"
 
-#: Comfortably above the slowest legitimate test — the container-starting files
-#: can sit in a cold image pull for minutes. Dump-only: nothing is ever killed
-#: on this timer, so a slow-but-honest test costs one wasted stack dump.
+#: The sampling interval, not a deadline: nothing is ever killed on this timer.
+#: Five minutes keeps a healthy half-hour lane down to a handful of dumps while
+#: still landing several inside any hang worth investigating.
 DEFAULT_STACK_TIMEOUT = 300.0
 
 

--- a/tests/ci_diagnostics.py
+++ b/tests/ci_diagnostics.py
@@ -1,0 +1,172 @@
+"""Survivable per-worker diagnostics for CI test runs.
+
+A test lane that *fails* explains itself: pytest prints the assertion and the
+traceback. A lane that is *killed* explains nothing — the job hits its
+``timeout-minutes``, the runner sends a signal, and whatever pytest was about to
+say dies in a buffer. That is the case this module covers.
+
+Two records are written per process, both continuously flushed so they are
+complete at every instant rather than at exit:
+
+``events-<worker>.jsonl``
+    One line per test start and finish. A ``start`` with no matching ``finish``
+    is the test that was in flight when the process died — see
+    ``scripts/ci/diag_summary.py``.
+
+``stacks-<worker>.txt``
+    Every thread's stack, dumped on a repeating timer once a single test has run
+    longer than the stack timeout, plus a traceback if the interpreter crashes
+    outright.
+
+Both are gated on ``OSPREY_CI_DIAG_DIR``: unset (every local run) means this
+module installs nothing at all.
+
+Why a file rather than stderr
+-----------------------------
+pytest's built-in ``faulthandler_timeout`` does reach the job log even under
+``-n`` — xdist relays worker stderr to the controller, verified against
+pytest-xdist 3.8.0. What it cannot do is survive the case this module exists
+for. Its dump lands only in the job log, which is exactly what a cancelled job
+truncates; it fires once per test, so a stack that is genuinely stuck looks the
+same as one that was merely slow; and it says nothing at all about which test
+each worker was inside. Writing to a file fixes the first (the artifact is
+uploaded whatever happens to the log), ``repeat=True`` fixes the second
+(identical frames dumped again and again is what "stuck" looks like), and the
+event log fixes the third.
+
+Because ``faulthandler.dump_traceback_later`` is process-global and pytest's
+plugin re-arms it around every test, the two cannot coexist: the unit lane
+passes no ``faulthandler_timeout`` so that the timer installed here survives.
+
+One diagnostic aside worth keeping: if the ini option *is* set and no dump
+appears despite a long stall, that is itself evidence. It means the timer
+thread never ran, which points at the runner being frozen rather than at a
+deadlocked test.
+"""
+
+from __future__ import annotations
+
+import faulthandler
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+#: Enables the whole module, and names the directory both records are written
+#: to. The CI job uploads that directory as an artifact.
+ENV_DIR = "OSPREY_CI_DIAG_DIR"
+
+#: Seconds a single test may run before its stacks are dumped. ``0`` disables
+#: stack dumping while leaving the event log on.
+ENV_STACK_TIMEOUT = "OSPREY_CI_DIAG_STACK_TIMEOUT"
+
+#: Comfortably above the slowest legitimate test — the container-starting files
+#: can sit in a cold image pull for minutes. Dump-only: nothing is ever killed
+#: on this timer, so a slow-but-honest test costs one wasted stack dump.
+DEFAULT_STACK_TIMEOUT = 300.0
+
+
+def worker_id() -> str:
+    """This process's xdist worker name, or ``main`` when running unparallelised.
+
+    Every artifact is keyed on it. With ``-n 4`` a freeze produces four separate
+    files, which is what makes "all workers stopped at the same instant"
+    (a runner-level stall) distinguishable from "one worker wedged" (a real
+    deadlock in a test).
+    """
+    return os.environ.get("PYTEST_XDIST_WORKER", "main")
+
+
+class DiagnosticsRecorder:
+    """Writes the event log and arms the stack dumper for one process."""
+
+    def __init__(
+        self,
+        directory: Path | str,
+        worker: str,
+        stack_timeout: float | None = DEFAULT_STACK_TIMEOUT,
+    ) -> None:
+        self.directory = Path(directory)
+        self.worker = worker
+        self.stack_timeout = stack_timeout
+        self._events: Any = None
+        self._stacks: Any = None
+        self._stopped = False
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def start(self) -> None:
+        self.directory.mkdir(parents=True, exist_ok=True)
+
+        # buffering=1 is line buffering: every record reaches the OS the moment
+        # its newline is written, with no dependence on a clean shutdown.
+        self._events = (self.directory / f"events-{self.worker}.jsonl").open(
+            "a", buffering=1, encoding="utf-8"
+        )
+
+        if self.stack_timeout:
+            self._stacks = (self.directory / f"stacks-{self.worker}.txt").open(
+                "a", buffering=1, encoding="utf-8"
+            )
+            # enable() covers a hard interpreter crash (a segfault inside a C
+            # extension leaves no Python-level trace otherwise);
+            # dump_traceback_later covers the wedge.
+            faulthandler.enable(file=self._stacks, all_threads=True)
+            faulthandler.dump_traceback_later(
+                self.stack_timeout, repeat=True, file=self._stacks, exit=False
+            )
+
+        self.record("session_start", stack_timeout=self.stack_timeout)
+
+    def stop(self) -> None:
+        if self._stopped:
+            return
+        self.record("session_end")
+        self._stopped = True
+
+        if self._stacks is not None:
+            faulthandler.cancel_dump_traceback_later()
+            self._stacks.close()
+            self._stacks = None
+
+        if self._events is not None:
+            self._events.close()
+            self._events = None
+
+    # -- writing -----------------------------------------------------------
+
+    def record(self, event: str, **fields: Any) -> None:
+        """Append one event. Never raises — diagnostics must not break a run."""
+        if self._events is None:
+            return
+        payload = {
+            "event": event,
+            "worker": self.worker,
+            "pid": os.getpid(),
+            "t": time.time(),
+            **fields,
+        }
+        try:
+            self._events.write(json.dumps(payload, default=str) + "\n")
+            self._events.flush()
+        except (OSError, ValueError):  # closed handle, full disk
+            pass
+
+
+def recorder_from_env() -> DiagnosticsRecorder | None:
+    """Build a recorder from the environment, or ``None`` when CI diag is off."""
+    directory = os.environ.get(ENV_DIR)
+    if not directory:
+        return None
+
+    raw = os.environ.get(ENV_STACK_TIMEOUT)
+    if raw is None:
+        stack_timeout: float | None = DEFAULT_STACK_TIMEOUT
+    else:
+        try:
+            stack_timeout = float(raw) or None
+        except ValueError:
+            stack_timeout = DEFAULT_STACK_TIMEOUT
+
+    return DiagnosticsRecorder(directory, worker=worker_id(), stack_timeout=stack_timeout)

--- a/tests/ci_diagnostics.py
+++ b/tests/ci_diagnostics.py
@@ -14,14 +14,14 @@ complete at every instant rather than at exit:
     ``scripts/ci/diag_summary.py``.
 
 ``stacks-<worker>.txt``
-    Every thread's stack, sampled on a repeating timer for the whole session,
-    plus a traceback if the interpreter crashes outright. The timer is armed
-    once at session start rather than around each test, so this is a periodic
-    snapshot, not a per-test stuck detector: a healthy long run leaves a handful
-    of dumps, and a wedged one leaves the same frames over and over, which is
-    what "stuck" looks like. Sampling the whole session is deliberate — it keeps
-    dumping after the LAST test has finished, which is where a shutdown hang
-    lives, and a per-test timer would be cancelled by then and show nothing.
+    Every thread's stack, sampled at a fixed interval for the whole session,
+    plus a traceback if the interpreter crashes outright. Sampling runs for the
+    whole session rather than around each test, so this is a periodic snapshot,
+    not a per-test stuck detector: a healthy long run leaves a handful of dumps,
+    and a wedged one leaves the same frames over and over, which is what "stuck"
+    looks like. Covering the whole session is deliberate — it keeps dumping
+    after the LAST test has finished, which is where a shutdown hang lives, and
+    a per-test timer would be cancelled by then and show nothing.
 
 Both are gated on ``OSPREY_CI_DIAG_DIR``: unset (every local run) means this
 module installs nothing at all.
@@ -35,18 +35,42 @@ for. Its dump lands only in the job log, which is exactly what a cancelled job
 truncates; it fires once per test, so a stack that is genuinely stuck looks the
 same as one that was merely slow; and it says nothing at all about which test
 each worker was inside. Writing to a file fixes the first (the artifact is
-uploaded whatever happens to the log), ``repeat=True`` fixes the second
+uploaded whatever happens to the log), repeated sampling fixes the second
 (identical frames dumped again and again is what "stuck" looks like), and the
 event log fixes the third.
 
-Because ``faulthandler.dump_traceback_later`` is process-global and pytest's
-plugin re-arms it around every test, the two cannot coexist: the unit lane
-passes no ``faulthandler_timeout`` so that the timer installed here survives.
+Why the sampler is a Python thread, and not ``dump_traceback_later``
+--------------------------------------------------------------------
+``faulthandler.dump_traceback_later`` is the obvious way to write this, and it
+is not safe here. Its watchdog lives in C and walks every thread's frames
+*without holding the GIL* — that is the whole point of it, since it has to work
+when the GIL is deadlocked. The cost is that it reads frames the interpreter is
+still mutating. Under this suite that is not a theoretical race: the config and
+template tests spend much of their time inside PyYAML, ruamel and Jinja2, whose
+recursive-descent parsers build and tear down frames continuously, and a sample
+landing there walks a half-freed frame and takes the process down with it. The
+worker dies with no traceback and no protocol shutdown, xdist reports ``node
+down: Not properly terminated``, and the lane then fails in one of two ways
+that look nothing like each other: xdist's loadscope scheduler raises
+``KeyError`` on the replacement worker, or the controller parks forever in
+``dsession.loop_once`` waiting for an event the dead worker will never send.
+Both were observed, on consecutive runs, caused by this module.
 
-One diagnostic aside worth keeping: if the ini option *is* set and no dump
-appears despite a long stall, that is itself evidence. It means the timer
-thread never ran, which points at the runner being frozen rather than at a
-deadlocked test.
+Calling ``faulthandler.dump_traceback`` from an ordinary Python thread holds
+the GIL for the walk, so no frame can move underneath it. What that gives up is
+the case the C watchdog exists for: a hard GIL deadlock, or a C extension
+spinning without releasing it, starves this thread and no dump appears. Every
+hang this lane has actually produced — blocked on a queue, a socket, or a
+subprocess — releases the GIL and samples fine. A dump that never comes is
+itself the signature of the case we cannot sample.
+
+``faulthandler.enable`` is kept. It installs a fatal-signal handler that only
+runs once the process is already lost, so it carries none of this risk, and it
+is what turns a segfault in a C extension into something with a stack on it.
+
+The unit lane still passes no ``faulthandler_timeout`` — pytest's built-in is
+implemented with ``dump_traceback_later``, so arming it re-introduces exactly
+the crash described above, on a per-test timer.
 """
 
 from __future__ import annotations
@@ -54,6 +78,7 @@ from __future__ import annotations
 import faulthandler
 import json
 import os
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -70,6 +95,11 @@ ENV_STACK_TIMEOUT = "OSPREY_CI_DIAG_STACK_TIMEOUT"
 #: Five minutes keeps a healthy half-hour lane down to a handful of dumps while
 #: still landing several inside any hang worth investigating.
 DEFAULT_STACK_TIMEOUT = 300.0
+
+#: How long ``stop()`` waits for an in-flight sample to finish before closing
+#: the file under it. A dump of a few dozen threads takes milliseconds; this is
+#: only here so a wedged sampler can never hold up the end of a run.
+SAMPLER_JOIN_TIMEOUT = 5.0
 
 
 def worker_id() -> str:
@@ -98,6 +128,8 @@ class DiagnosticsRecorder:
         self._events: Any = None
         self._stacks: Any = None
         self._stopped = False
+        self._sampler: threading.Thread | None = None
+        self._stop_sampling = threading.Event()
 
     # -- lifecycle ---------------------------------------------------------
 
@@ -114,15 +146,35 @@ class DiagnosticsRecorder:
             self._stacks = (self.directory / f"stacks-{self.worker}.txt").open(
                 "a", buffering=1, encoding="utf-8"
             )
-            # enable() covers a hard interpreter crash (a segfault inside a C
-            # extension leaves no Python-level trace otherwise);
-            # dump_traceback_later covers the wedge.
+            # enable() covers a hard interpreter crash: a segfault inside a C
+            # extension leaves no Python-level trace otherwise. It only fires
+            # on a fatal signal, so it cannot itself destabilise a healthy
+            # process — unlike the C watchdog this sampler replaces. See the
+            # module docstring.
             faulthandler.enable(file=self._stacks, all_threads=True)
-            faulthandler.dump_traceback_later(
-                self.stack_timeout, repeat=True, file=self._stacks, exit=False
+            self._sampler = threading.Thread(
+                target=self._sample_stacks,
+                name="osprey-ci-diag-stacks",
+                daemon=True,
             )
+            self._sampler.start()
 
         self.record("session_start", stack_timeout=self.stack_timeout)
+
+    def _sample_stacks(self) -> None:
+        """Dump every thread's stack on an interval until ``stop()`` is called.
+
+        Runs as an ordinary Python thread so the walk happens under the GIL and
+        cannot read a frame mid-mutation. ``Event.wait`` rather than ``sleep``
+        so a finished run is not held up for a whole interval.
+        """
+        assert self.stack_timeout is not None
+        while not self._stop_sampling.wait(self.stack_timeout):
+            try:
+                faulthandler.dump_traceback(file=self._stacks, all_threads=True)
+            except (OSError, ValueError, AttributeError):
+                # Closed handle or full disk. Diagnostics never break a run.
+                return
 
     def stop(self) -> None:
         if self._stopped:
@@ -131,7 +183,13 @@ class DiagnosticsRecorder:
         self._stopped = True
 
         if self._stacks is not None:
-            faulthandler.cancel_dump_traceback_later()
+            # Wake the sampler and let any in-flight dump finish before the
+            # file goes out from under it.
+            self._stop_sampling.set()
+            if self._sampler is not None:
+                self._sampler.join(SAMPLER_JOIN_TIMEOUT)
+                self._sampler = None
+            faulthandler.disable()
             self._stacks.close()
             self._stacks = None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import pytest
 from rich.logging import RichHandler
 
 from osprey.utils.logger import QUIET_THIRD_PARTY_LOGGERS
+from tests import ci_diagnostics
 
 #: Repo root — the fallback when a test leaves the process in a deleted cwd.
 _REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -387,6 +388,48 @@ def pytest_collection_modifyitems(config, items):
                 cache[marker_name] = available
             if not available:
                 item.add_marker(pytest.mark.skip(reason=reason))
+
+
+# ===================================================================
+# CI diagnostics: what survives a kill
+# ===================================================================
+#
+# A test that FAILS reports itself. A lane that is KILLED — job timeout, runner
+# OOM, a wedged worker held until the step cap — reports nothing at all: the
+# signal lands while pytest's output is still in a buffer. These hooks keep a
+# continuously flushed record on disk instead, so the post-mortem has something
+# to read. See tests/ci_diagnostics.py for the file formats and for why
+# faulthandler must target a file rather than a worker's stderr.
+#
+# Entirely gated on OSPREY_CI_DIAG_DIR, which only the CI lanes set: with the
+# variable unset this installs nothing and costs nothing.
+
+_CI_DIAGNOSTICS: ci_diagnostics.DiagnosticsRecorder | None = None
+
+
+def pytest_configure(config):
+    """Open the per-worker records and arm the stack dumper."""
+    global _CI_DIAGNOSTICS
+    _CI_DIAGNOSTICS = ci_diagnostics.recorder_from_env()
+    if _CI_DIAGNOSTICS is not None:
+        _CI_DIAGNOSTICS.start()
+
+
+def pytest_runtest_logstart(nodeid, location):
+    """Fires before setup — so a test that never returns is still on record."""
+    if _CI_DIAGNOSTICS is not None:
+        _CI_DIAGNOSTICS.record("start", nodeid=nodeid)
+
+
+def pytest_runtest_logfinish(nodeid, location):
+    """Fires after teardown. A `start` left unmatched is the wedged test."""
+    if _CI_DIAGNOSTICS is not None:
+        _CI_DIAGNOSTICS.record("finish", nodeid=nodeid)
+
+
+def pytest_unconfigure(config):
+    if _CI_DIAGNOSTICS is not None:
+        _CI_DIAGNOSTICS.stop()
 
 
 # ===================================================================

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -2112,3 +2112,310 @@ def test_all_checks_passed_needs_archiver_world__mutation_drops_check_pr_lane_li
     assert ARCHIVER_JOB in _jobs(mutated)[GATE_JOB]["needs"]  # the needs entry survives
     with pytest.raises(AssertionError):
         test_all_checks_passed_needs_archiver_world(mutated)
+
+
+# ---------------------------------------------------------------------------
+# CI diagnostics: the evidence a killed lane leaves behind
+# ---------------------------------------------------------------------------
+#
+# A lane that FAILS explains itself in the job log. A lane that is KILLED — job
+# timeout, runner OOM, a wedged xdist worker held to the cap — explains nothing,
+# because the signal lands while pytest's output is still buffered. Everything
+# pinned below exists to make that second case readable, and every piece of it
+# is silently droppable: removing a step, raising a timeout, or restoring an ini
+# option costs no test failure of its own. Hence these pins.
+
+CAPTURE_ACTION = "./.github/actions/capture-ci-diagnostics"
+CAPTURE_STEP = "Capture failure diagnostics"
+WRITEBACK_JOB = "deploy-writeback-e2e"
+PODMAN_LIFECYCLE_JOB = "multi-user-deploy-lifecycle-e2e-podman"
+#: Jobs that name a container engine without running one — the gate lists the
+#: Docker lanes in its human-readable status strings.
+NON_CONTAINER_JOBS = {GATE_JOB}
+
+
+def _container_jobs(wf: dict[str, Any]) -> set[str]:
+    """Jobs that touch a container engine, derived rather than listed.
+
+    Derived on purpose: a hand-maintained list is exactly what a newly added
+    Docker lane forgets to join. Comments cannot pollute the match because
+    ``yaml.safe_load`` has already dropped them.
+    """
+    pattern = re.compile(r"\b(docker|podman)\b")
+    return {
+        name
+        for name, job in _jobs(wf).items()
+        if name not in NON_CONTAINER_JOBS and pattern.search(json.dumps(job))
+    }
+
+
+def _capture_step_index(job: dict[str, Any]) -> int | None:
+    for index, step in enumerate(job.get("steps") or []):
+        if step.get("uses") == CAPTURE_ACTION:
+            return index
+    return None
+
+
+def test_every_container_job_captures_diagnostics(workflow: dict[str, Any]) -> None:
+    """No Docker lane may fail without leaving its container logs behind.
+
+    Before this action existed, the only ``if: always()`` steps on these lanes
+    were teardown blocks — so a red lane deleted the containers holding the
+    explanation and uploaded nothing at all.
+    """
+    missing = sorted(
+        name
+        for name in _container_jobs(workflow)
+        if _capture_step_index(_jobs(workflow)[name]) is None
+    )
+    assert missing == [], (
+        f"these jobs run containers but have no '{CAPTURE_STEP}' step: {missing}. "
+        f"Add `uses: {CAPTURE_ACTION}` with `if: failure()`, positioned before any "
+        f"teardown step — or add the job to NON_CONTAINER_JOBS if it only names an "
+        f"engine in a status string."
+    )
+
+
+def test_every_container_job_captures_diagnostics__mutation_drops_a_lane() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    job = _jobs(mutated)[TILED_JOB]
+    del job["steps"][_capture_step_index(job)]
+    with pytest.raises(AssertionError):
+        test_every_container_job_captures_diagnostics(mutated)
+
+
+def test_capture_runs_before_teardown(workflow: dict[str, Any]) -> None:
+    """Ordering is the whole point: the teardown blocks ``docker rm -f`` the very
+    containers whose logs are the diagnosis. Capture after cleanup captures
+    nothing."""
+    late = []
+    for name in sorted(_container_jobs(workflow)):
+        steps = _jobs(workflow)[name]["steps"]
+        capture = _capture_step_index(_jobs(workflow)[name])
+        teardown = [i for i, step in enumerate(steps) if step.get("if") == "always()"]
+        if capture is not None and teardown and capture > min(teardown):
+            late.append(name)
+    assert late == [], (
+        f"'{CAPTURE_STEP}' runs after an `if: always()` teardown step in {late} — "
+        f"by then the containers it reads have been removed."
+    )
+
+
+def test_capture_runs_before_teardown__mutation_moves_it_after_cleanup() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    steps = _jobs(mutated)[WRITEBACK_JOB]["steps"]
+    steps.append(steps.pop(_capture_step_index(_jobs(mutated)[WRITEBACK_JOB])))
+    with pytest.raises(AssertionError):
+        test_capture_runs_before_teardown(mutated)
+
+
+def test_capture_steps_run_on_failure(workflow: dict[str, Any]) -> None:
+    """``if: failure()`` and not the default: a step with no condition is skipped
+    the moment anything upstream fails, which is the only time it matters."""
+    wrong = {}
+    for name in sorted(_container_jobs(workflow)):
+        index = _capture_step_index(_jobs(workflow)[name])
+        if index is None:
+            continue
+        condition = _jobs(workflow)[name]["steps"][index].get("if")
+        if condition != "failure()":
+            wrong[name] = condition
+    assert wrong == {}, f"capture steps must carry `if: failure()`; got {wrong}"
+
+
+def test_capture_steps_run_on_failure__mutation_drops_the_condition() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    job = _jobs(mutated)[TILED_JOB]
+    del job["steps"][_capture_step_index(job)]["if"]
+    with pytest.raises(AssertionError):
+        test_capture_steps_run_on_failure(mutated)
+
+
+def test_capture_artifact_names_are_unique(workflow: dict[str, Any]) -> None:
+    """Artifact names collide silently within a run — two lanes sharing one name
+    means one lane's evidence overwrites the other's."""
+    names = []
+    for name in sorted(_container_jobs(workflow)):
+        index = _capture_step_index(_jobs(workflow)[name])
+        if index is not None:
+            names.append(_jobs(workflow)[name]["steps"][index]["with"]["name"])
+    duplicates = sorted({n for n in names if names.count(n) > 1})
+    assert duplicates == [], f"duplicate capture artifact names: {duplicates}"
+
+
+def test_capture_artifact_names_are_unique__mutation_collides_two_lanes() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    job = _jobs(mutated)[TILED_JOB]
+    job["steps"][_capture_step_index(job)]["with"]["name"] = VA_JOB
+    with pytest.raises(AssertionError):
+        test_capture_artifact_names_are_unique(mutated)
+
+
+def test_podman_lane_captures_with_podman(workflow: dict[str, Any]) -> None:
+    """The podman lane has no ``docker`` binary; asking for one captures nothing."""
+    job = _jobs(workflow)[PODMAN_LIFECYCLE_JOB]
+    step = job["steps"][_capture_step_index(job)]
+    assert step["with"]["engine"] == "podman"
+
+
+def test_podman_lane_captures_with_podman__mutation_asks_for_docker() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    job = _jobs(mutated)[PODMAN_LIFECYCLE_JOB]
+    job["steps"][_capture_step_index(job)]["with"]["engine"] = "docker"
+    with pytest.raises(AssertionError):
+        test_podman_lane_captures_with_podman(mutated)
+
+
+# ---------------------------------------------------------------------------
+# The unit lane's own survivability
+# ---------------------------------------------------------------------------
+
+
+def test_unit_test_step_timeout_is_below_the_job_cap(workflow: dict[str, Any]) -> None:
+    """A JOB timeout is a hard cancel — the collection steps never dependably
+    run, which is how a frozen lane ends up recorded as ``cancelled`` with
+    nothing to read. A STEP timeout fails cleanly and leaves the rest of the
+    job's time for the summary and upload steps."""
+    job = _jobs(workflow)[UNIT_TEST_JOB]
+    step = _find_named_step(workflow, UNIT_TEST_JOB, "Run unit tests")
+    step_cap = step.get("timeout-minutes")
+    assert step_cap is not None, (
+        "the 'Run unit tests' step needs its own `timeout-minutes`; without one a "
+        "wedged worker is killed by the job cap and takes the evidence with it"
+    )
+    assert step_cap < job["timeout-minutes"], (
+        f"step cap ({step_cap}m) must leave headroom under the job cap "
+        f"({job['timeout-minutes']}m) for the diagnostics steps to run"
+    )
+
+
+def test_unit_test_step_timeout_is_below_the_job_cap__mutation_drops_it() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    del _find_named_step(mutated, UNIT_TEST_JOB, "Run unit tests")["timeout-minutes"]
+    with pytest.raises(AssertionError):
+        test_unit_test_step_timeout_is_below_the_job_cap(mutated)
+
+
+def test_unit_test_step_timeout_is_below_the_job_cap__mutation_raises_it_to_the_cap() -> None:
+    """Equal is as bad as absent: no headroom means no collection phase."""
+    mutated = copy.deepcopy(_load_workflow())
+    job = _jobs(mutated)[UNIT_TEST_JOB]
+    _find_named_step(mutated, UNIT_TEST_JOB, "Run unit tests")["timeout-minutes"] = job[
+        "timeout-minutes"
+    ]
+    with pytest.raises(AssertionError):
+        test_unit_test_step_timeout_is_below_the_job_cap(mutated)
+
+
+def test_unit_lane_arms_the_diagnostics_recorder(workflow: dict[str, Any]) -> None:
+    """``tests/ci_diagnostics.py`` installs nothing unless this variable is set,
+    so without it the lane runs exactly as blind as before."""
+    step = _find_named_step(workflow, UNIT_TEST_JOB, "Run unit tests")
+    assert step.get("env", {}).get("OSPREY_CI_DIAG_DIR"), (
+        "the unit lane must set OSPREY_CI_DIAG_DIR on the pytest step to enable the "
+        "per-worker event log and stack dumps"
+    )
+
+
+def test_unit_lane_arms_the_diagnostics_recorder__mutation_drops_the_env() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    del _find_named_step(mutated, UNIT_TEST_JOB, "Run unit tests")["env"]["OSPREY_CI_DIAG_DIR"]
+    with pytest.raises(AssertionError):
+        test_unit_lane_arms_the_diagnostics_recorder(mutated)
+
+
+def test_unit_lane_uploads_its_diagnostics(workflow: dict[str, Any]) -> None:
+    """``always()``, not ``failure()``: a lane killed by the job cap is recorded
+    as ``cancelled``, and a ``failure()`` step would not run for it."""
+    upload = _find_named_step(workflow, UNIT_TEST_JOB, "Upload lane diagnostics")
+    assert upload["if"] == "always()"
+    assert upload["with"]["path"].rstrip("/") == "ci-diag"
+    summary = _find_named_step(workflow, UNIT_TEST_JOB, "Summarise lane diagnostics")
+    assert summary["if"] == "always()"
+
+
+def test_unit_lane_uploads_its_diagnostics__mutation_narrows_to_failure() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    _find_named_step(mutated, UNIT_TEST_JOB, "Upload lane diagnostics")["if"] = "failure()"
+    with pytest.raises(AssertionError):
+        test_unit_lane_uploads_its_diagnostics(mutated)
+
+
+def test_unit_lane_does_not_set_faulthandler_timeout(workflow: dict[str, Any]) -> None:
+    """The subtle one: two mechanisms competing for one process-global timer.
+
+    ``faulthandler.dump_traceback_later`` can only have one owner, and pytest's
+    plugin re-arms it around every test whenever the ini option is set. Setting
+    it here would therefore silently replace the repeating, file-backed timer
+    armed by ``tests/ci_diagnostics.py`` with a one-shot one that writes only to
+    the job log — the log being exactly what a cancelled job truncates.
+    """
+    line = _unit_test_pytest_line(workflow)
+    assert "faulthandler_timeout" not in line, (
+        "the unit lane must not pass `-o faulthandler_timeout`: pytest's plugin would "
+        "re-arm the process-global faulthandler timer around every test, replacing the "
+        "repeating file-backed dumps armed by tests/ci_diagnostics.py. See that "
+        "module's docstring."
+    )
+
+
+def _sole_heavy_step(job: dict[str, Any]) -> dict[str, Any] | None:
+    """The lane's single pytest-running step, or None if there isn't exactly one.
+
+    Lanes with several heavy steps are excluded on purpose: capping them means
+    splitting one job budget between them, which is a per-lane runtime judgement
+    rather than something derivable, and a wrong split reds a healthy run.
+    """
+    heavy = [s for s in (job.get("steps") or []) if "uv run pytest" in str(s.get("run", ""))]
+    return heavy[0] if len(heavy) == 1 else None
+
+
+def test_capped_container_lanes_cap_their_heavy_step(workflow: dict[str, Any]) -> None:
+    """Same argument as the unit lane, applied to the e2e lanes.
+
+    Without a step cap the hang is killed by the JOB cap, which is a hard cancel
+    — and the capture step never runs, so the containers are torn down by the
+    runner with their logs unread. That is the exact blind spot the capture step
+    exists to close, so a capped lane must not leave it open.
+    """
+    missing = []
+    for name in sorted(_container_jobs(workflow)):
+        job = _jobs(workflow)[name]
+        job_cap = job.get("timeout-minutes")
+        step = _sole_heavy_step(job)
+        if not job_cap or step is None:
+            continue
+        step_cap = step.get("timeout-minutes")
+        if step_cap is None or step_cap >= job_cap:
+            missing.append((name, step.get("name"), step_cap, job_cap))
+    assert missing == [], (
+        "these lanes declare a job cap and have one heavy step, so that step needs its "
+        f"own smaller `timeout-minutes`: {missing}"
+    )
+
+
+def test_capped_container_lanes_cap_their_heavy_step__mutation_drops_a_step_cap() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    del _sole_heavy_step(_jobs(mutated)[TILED_JOB])["timeout-minutes"]
+    with pytest.raises(AssertionError):
+        test_capped_container_lanes_cap_their_heavy_step(mutated)
+
+
+def test_capped_container_lanes_cap_their_heavy_step__mutation_raises_it_to_the_job_cap() -> None:
+    """No headroom is the same as no cap — the capture step still never runs."""
+    mutated = copy.deepcopy(_load_workflow())
+    job = _jobs(mutated)[TILED_JOB]
+    _sole_heavy_step(job)["timeout-minutes"] = job["timeout-minutes"]
+    with pytest.raises(AssertionError):
+        test_capped_container_lanes_cap_their_heavy_step(mutated)
+
+
+def test_unit_lane_does_not_set_faulthandler_timeout__mutation_restores_the_ini_option() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, UNIT_TEST_JOB, "Run unit tests")
+    step["run"] = step["run"].replace(
+        " --dist loadgroup $COV_ARGS",
+        " --dist loadgroup $COV_ARGS -o faulthandler_timeout=300",
+    )
+    with pytest.raises(AssertionError):
+        test_unit_lane_does_not_set_faulthandler_timeout(mutated)

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -2342,20 +2342,26 @@ def test_unit_lane_uploads_its_diagnostics__mutation_narrows_to_failure() -> Non
 
 
 def test_unit_lane_does_not_set_faulthandler_timeout(workflow: dict[str, Any]) -> None:
-    """The subtle one: two mechanisms competing for one process-global timer.
+    """The subtle one: the ini option arms a watchdog that kills workers.
 
-    ``faulthandler.dump_traceback_later`` can only have one owner, and pytest's
-    plugin re-arms it around every test whenever the ini option is set. Setting
-    it here would therefore silently replace the repeating, file-backed timer
-    armed by ``tests/ci_diagnostics.py`` with a one-shot one that writes only to
-    the job log — the log being exactly what a cancelled job truncates.
+    pytest implements ``faulthandler_timeout`` with
+    ``faulthandler.dump_traceback_later``, whose watchdog walks every thread's
+    frames without holding the GIL. A sample landing inside one of the parsers
+    this suite lives in — PyYAML, ruamel, Jinja2 — reads a frame that is being
+    freed and takes the worker down with it, which xdist reports only as ``node
+    down: Not properly terminated``. ``tests/ci_diagnostics.py`` samples from an
+    ordinary Python thread for that reason, and setting this option would put
+    the unsafe watchdog back, on a per-test timer.
+
+    Its dumps would also reach only the job log, which is exactly what a
+    cancelled job truncates.
     """
     line = _unit_test_pytest_line(workflow)
     assert "faulthandler_timeout" not in line, (
-        "the unit lane must not pass `-o faulthandler_timeout`: pytest's plugin would "
-        "re-arm the process-global faulthandler timer around every test, replacing the "
-        "repeating file-backed dumps armed by tests/ci_diagnostics.py. See that "
-        "module's docstring."
+        "the unit lane must not pass `-o faulthandler_timeout`: pytest implements it "
+        "with faulthandler.dump_traceback_later, whose GIL-free watchdog segfaults "
+        "workers that are inside a YAML or Jinja parser. See the docstring of "
+        "tests/ci_diagnostics.py."
     )
 
 

--- a/tests/infrastructure/test_ci_diagnostics.py
+++ b/tests/infrastructure/test_ci_diagnostics.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -129,6 +130,59 @@ def test_stack_dump_file_is_opened_when_timeout_set(tmp_path):
         assert (tmp_path / "stacks-gw3.txt").exists()
     finally:
         recorder.stop()
+
+
+def test_sampling_never_arms_the_c_level_watchdog(tmp_path, monkeypatch):
+    """``dump_traceback_later`` must not be used, however tempting it is.
+
+    Its watchdog walks every thread's frames without the GIL, so a sample that
+    lands inside a parser building and discarding frames — which this suite does
+    for minutes at a time, in PyYAML, ruamel and Jinja2 — reads a frame that is
+    being freed and kills the process. That crashed real workers on three
+    consecutive CI runs, which xdist reported as ``node down: Not properly
+    terminated``. The module docstring has the full chain.
+    """
+    import faulthandler
+
+    called: list[object] = []
+    monkeypatch.setattr(faulthandler, "dump_traceback_later", lambda *a, **k: called.append(a))
+
+    recorder = DiagnosticsRecorder(tmp_path, worker="gw0", stack_timeout=0.01)
+    recorder.start()
+    try:
+        time.sleep(0.1)
+    finally:
+        recorder.stop()
+
+    assert called == [], "the GIL-free faulthandler watchdog must never be armed"
+
+
+def test_sampler_writes_dumps_on_its_interval(tmp_path):
+    """The thread must actually produce dumps, not merely exist."""
+    recorder = DiagnosticsRecorder(tmp_path, worker="gw0", stack_timeout=0.01)
+    recorder.start()
+    try:
+        deadline = time.monotonic() + 5.0
+        stacks = tmp_path / "stacks-gw0.txt"
+        while time.monotonic() < deadline and "Thread" not in stacks.read_text():
+            time.sleep(0.02)
+    finally:
+        recorder.stop()
+
+    assert "Thread" in (tmp_path / "stacks-gw0.txt").read_text()
+
+
+def test_stop_shuts_the_sampler_down(tmp_path):
+    """No thread may outlive the recorder and write into a closed file."""
+    recorder = DiagnosticsRecorder(tmp_path, worker="gw0", stack_timeout=0.01)
+    recorder.start()
+    sampler = recorder._sampler
+    assert sampler is not None and sampler.is_alive()
+
+    recorder.stop()
+
+    sampler.join(timeout=5.0)
+    assert not sampler.is_alive()
 
 
 def test_no_stack_file_when_timeout_disabled(tmp_path):

--- a/tests/infrastructure/test_ci_diagnostics.py
+++ b/tests/infrastructure/test_ci_diagnostics.py
@@ -1,0 +1,296 @@
+"""The survivable-diagnostics writer and its reader.
+
+The whole point of this machinery is to leave a usable record behind when the
+process is killed rather than exiting — a wedged xdist worker, a step timeout,
+a runner OOM. So the properties under test are all about what survives:
+every event is on disk *before* the next test starts, and the reader tolerates
+the half-written final line a SIGKILL leaves.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.ci_diagnostics import (
+    ENV_DIR,
+    ENV_STACK_TIMEOUT,
+    DiagnosticsRecorder,
+    recorder_from_env,
+    worker_id,
+)
+
+_SUMMARY = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "diag_summary.py"
+
+
+def _load_summary():
+    """Import the reader by path — it is a standalone script, not a package."""
+    spec = importlib.util.spec_from_file_location("diag_summary", _SUMMARY)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["diag_summary"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ===================================================================
+# Env gating
+# ===================================================================
+
+
+def test_recorder_from_env_is_none_when_unset(monkeypatch, tmp_path):
+    """Local runs must be untouched — no directory, no faulthandler timer."""
+    monkeypatch.delenv(ENV_DIR, raising=False)
+    assert recorder_from_env() is None
+
+
+def test_recorder_from_env_builds_recorder_when_set(monkeypatch, tmp_path):
+    monkeypatch.setenv(ENV_DIR, str(tmp_path / "diag"))
+    recorder = recorder_from_env()
+    assert isinstance(recorder, DiagnosticsRecorder)
+    assert recorder.directory == tmp_path / "diag"
+
+
+def test_worker_id_defaults_to_main(monkeypatch):
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+    assert worker_id() == "main"
+
+
+def test_worker_id_follows_xdist(monkeypatch):
+    """Per-worker filenames are what make a four-worker freeze readable."""
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw2")
+    assert worker_id() == "gw2"
+
+
+# ===================================================================
+# Writing
+# ===================================================================
+
+
+def test_events_are_on_disk_before_stop(tmp_path):
+    """The load-bearing property: a SIGKILL mid-run still leaves the record.
+
+    Nothing may sit in a buffer waiting for a clean shutdown that never comes,
+    so the assertions read the file while the recorder is still open.
+    """
+    recorder = DiagnosticsRecorder(tmp_path, worker="gw0", stack_timeout=None)
+    recorder.start()
+    recorder.record("start", nodeid="tests/test_a.py::test_one")
+
+    events = _read_events(tmp_path / "events-gw0.jsonl")
+    assert [e["event"] for e in events] == ["session_start", "start"]
+    assert events[-1]["nodeid"] == "tests/test_a.py::test_one"
+    recorder.stop()
+
+
+def test_records_carry_worker_pid_and_monotonic_time(tmp_path):
+    recorder = DiagnosticsRecorder(tmp_path, worker="gw1", stack_timeout=None)
+    recorder.start()
+    recorder.record("start", nodeid="tests/test_a.py::test_one")
+    recorder.stop()
+
+    event = _read_events(tmp_path / "events-gw1.jsonl")[-1]
+    assert event["worker"] == "gw1"
+    assert isinstance(event["pid"], int)
+    assert isinstance(event["t"], float)
+
+
+def test_stop_is_idempotent_and_records_session_end(tmp_path):
+    recorder = DiagnosticsRecorder(tmp_path, worker="gw0", stack_timeout=None)
+    recorder.start()
+    recorder.stop()
+    recorder.stop()
+
+    events = _read_events(tmp_path / "events-gw0.jsonl")
+    assert [e["event"] for e in events] == ["session_start", "session_end"]
+
+
+def test_recording_after_stop_is_a_no_op(tmp_path):
+    """pytest_unconfigure can land before a late hook; it must not raise."""
+    recorder = DiagnosticsRecorder(tmp_path, worker="gw0", stack_timeout=None)
+    recorder.start()
+    recorder.stop()
+    recorder.record("start", nodeid="tests/test_a.py::test_late")  # must not raise
+
+
+def test_stack_dump_file_is_opened_when_timeout_set(tmp_path):
+    """faulthandler must target a FILE, not stderr.
+
+    A dump that exists only in the job log is lost the moment the job is
+    cancelled and its log truncated — which is the case this whole module is
+    for. The file is uploaded as an artifact regardless.
+    """
+    recorder = DiagnosticsRecorder(tmp_path, worker="gw3", stack_timeout=600)
+    recorder.start()
+    try:
+        assert (tmp_path / "stacks-gw3.txt").exists()
+    finally:
+        recorder.stop()
+
+
+def test_no_stack_file_when_timeout_disabled(tmp_path):
+    recorder = DiagnosticsRecorder(tmp_path, worker="gw3", stack_timeout=None)
+    recorder.start()
+    recorder.stop()
+    assert not (tmp_path / "stacks-gw3.txt").exists()
+
+
+def test_stack_timeout_read_from_env(monkeypatch, tmp_path):
+    monkeypatch.setenv(ENV_DIR, str(tmp_path))
+    monkeypatch.setenv(ENV_STACK_TIMEOUT, "45")
+    assert recorder_from_env().stack_timeout == 45.0
+
+
+def test_stack_timeout_of_zero_disables_dumping(monkeypatch, tmp_path):
+    monkeypatch.setenv(ENV_DIR, str(tmp_path))
+    monkeypatch.setenv(ENV_STACK_TIMEOUT, "0")
+    assert recorder_from_env().stack_timeout is None
+
+
+def test_directory_is_created(tmp_path):
+    target = tmp_path / "nested" / "diag"
+    recorder = DiagnosticsRecorder(target, worker="gw0", stack_timeout=None)
+    recorder.start()
+    recorder.stop()
+    assert target.is_dir()
+
+
+# ===================================================================
+# Reading
+# ===================================================================
+
+
+def test_summary_names_the_in_flight_test_per_worker(tmp_path):
+    """The question a frozen lane needs answered: what was each worker inside?"""
+    _write_jsonl(
+        tmp_path / "events-gw0.jsonl",
+        [
+            {"event": "start", "nodeid": "tests/test_a.py::done", "worker": "gw0"},
+            {"event": "finish", "nodeid": "tests/test_a.py::done", "worker": "gw0"},
+            {"event": "start", "nodeid": "tests/test_a.py::wedged", "worker": "gw0"},
+        ],
+    )
+    _write_jsonl(
+        tmp_path / "events-gw1.jsonl",
+        [{"event": "start", "nodeid": "tests/test_b.py::also_wedged", "worker": "gw1"}],
+    )
+
+    stalled = _load_summary().stalled_tests(tmp_path)
+    assert stalled == {
+        "gw0": "tests/test_a.py::wedged",
+        "gw1": "tests/test_b.py::also_wedged",
+    }
+
+
+def test_summary_reports_no_stall_when_every_test_finished(tmp_path):
+    _write_jsonl(
+        tmp_path / "events-gw0.jsonl",
+        [
+            {"event": "start", "nodeid": "tests/test_a.py::one", "worker": "gw0"},
+            {"event": "finish", "nodeid": "tests/test_a.py::one", "worker": "gw0"},
+            {"event": "session_end", "worker": "gw0"},
+        ],
+    )
+    assert _load_summary().stalled_tests(tmp_path) == {}
+
+
+def test_summary_tolerates_a_truncated_final_line(tmp_path):
+    """A SIGKILL lands mid-`write`, so the last line is routinely half a record.
+
+    Losing the whole report to one malformed line would defeat the purpose.
+    """
+    path = tmp_path / "events-gw0.jsonl"
+    _write_jsonl(path, [{"event": "start", "nodeid": "tests/test_a.py::wedged", "worker": "gw0"}])
+    with path.open("a") as handle:
+        handle.write('{"event": "fin')  # killed mid-write
+
+    assert _load_summary().stalled_tests(tmp_path) == {"gw0": "tests/test_a.py::wedged"}
+
+
+def test_summary_handles_a_missing_directory(tmp_path):
+    assert _load_summary().stalled_tests(tmp_path / "absent") == {}
+
+
+def test_summary_renders_a_report_naming_the_stalled_test(tmp_path):
+    _write_jsonl(
+        tmp_path / "events-gw0.jsonl",
+        [{"event": "start", "nodeid": "tests/test_a.py::wedged", "worker": "gw0"}],
+    )
+    report = _load_summary().render_report(tmp_path)
+    assert "gw0" in report
+    assert "tests/test_a.py::wedged" in report
+
+
+def test_summary_report_says_so_when_nothing_stalled(tmp_path):
+    _write_jsonl(
+        tmp_path / "events-gw0.jsonl",
+        [
+            {"event": "start", "nodeid": "tests/test_a.py::one", "worker": "gw0"},
+            {"event": "finish", "nodeid": "tests/test_a.py::one", "worker": "gw0"},
+        ],
+    )
+    report = _load_summary().render_report(tmp_path)
+    assert "no stalled" in report.lower()
+
+
+def test_summary_report_distinguishes_an_empty_run(tmp_path):
+    """An empty directory means the suite never started — not "all clear"."""
+    report = _load_summary().render_report(tmp_path)
+    assert "never started" in report.lower()
+
+
+def test_summary_report_flags_an_all_worker_stall(tmp_path):
+    """Every worker stalling at once is the runner-stall signature.
+
+    Worth calling out by name: it is the difference between "one of our tests
+    deadlocks" and "the VM went away", and it decides whether a rerun is
+    legitimate or a papering-over.
+    """
+    for worker in ("gw0", "gw1"):
+        _write_jsonl(
+            tmp_path / f"events-{worker}.jsonl",
+            [{"event": "start", "nodeid": f"tests/test_{worker}.py::t", "worker": worker}],
+        )
+    report = _load_summary().render_report(tmp_path)
+    assert "all workers" in report.lower()
+    assert "runner stalling" in report.lower()
+
+
+# ===================================================================
+# Round trip
+# ===================================================================
+
+
+def test_writer_output_is_readable_by_the_summary(tmp_path):
+    """Writer and reader are separate modules; pin that they still agree."""
+    recorder = DiagnosticsRecorder(tmp_path, worker="gw0", stack_timeout=None)
+    recorder.start()
+    recorder.record("start", nodeid="tests/test_a.py::finished")
+    recorder.record("finish", nodeid="tests/test_a.py::finished")
+    recorder.record("start", nodeid="tests/test_a.py::wedged")
+
+    assert _load_summary().stalled_tests(tmp_path) == {"gw0": "tests/test_a.py::wedged"}
+    recorder.stop()
+
+
+# ===================================================================
+# Helpers
+# ===================================================================
+
+
+def _read_events(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text("".join(json.dumps(r) + "\n" for r in records))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    """Keep the ambient CI diag settings out of these tests."""
+    monkeypatch.delenv(ENV_DIR, raising=False)
+    monkeypatch.delenv(ENV_STACK_TIMEOUT, raising=False)


### PR DESCRIPTION
CI failures were routinely unreadable. On the Docker lanes the only `if: always()` steps were teardown blocks, so a red lane removed the containers holding its logs before anything read them, and uploaded nothing at all. On the unit lane a job-level timeout is a hard cancel, so a frozen run was recorded as `cancelled` with no record of where it stopped.

Container lanes now snapshot logs, exit codes, `OOMKilled` and runner disk/memory into a per-lane artifact, ordered before every teardown block. The unit lane writes a flushed per-worker event log plus repeating stack dumps, and prints which test each worker was inside into the run summary.

Two decisions worth disagreeing with:

- **The unit lane no longer passes `-o faulthandler_timeout`.** It and the file-backed dumps drive one process-global timer, and pytest re-arms the ini option's copy around every test, so keeping both would silently disable the artifact-backed dumps. Worth stating plainly: xdist *does* relay the built-in dump to the job log — that was checked, not assumed. The reason for replacing it is that the log is what a cancelled job truncates, and that it says nothing about which test each worker was inside.

- **Step caps are derived, not chosen.** A lane gets `job cap − 5` only if it declares a budget and has exactly one heavy step, where a step cap can only fire inside a window the job cap had already doomed. Lanes with several heavy steps, or no declared budget, are deliberately untouched: splitting one budget between steps is a per-lane runtime judgement, and a wrong split reds a healthy run. Eleven lanes stay uncapped for that reason.

Behaviour was checked rather than argued: a probe test SIGKILLed its own worker mid-run and the summary correctly named the test it stopped on, and the capture action was run against live containers to confirm the `OOMKilled` and exit-code fields populate. Nineteen new wiring pins each carry a mutation counter-test, and the derivation of "which lanes need capture" reads the workflow rather than a hand-maintained list, so a future Docker lane cannot quietly skip it.

## How it hangs together

```text
  unit lane                                container lanes (23)
  ─────────                                ────────────────────
  pytest -n 4                              pytest / osprey up
    │  conftest hooks, gated on               │
    │  OSPREY_CI_DIAG_DIR                     │  step fails or hits step cap
    ▼                                         ▼
  tests/ci_diagnostics.py                  .github/actions/capture-ci-diagnostics
    ├─ events-<worker>.jsonl                   ├─ docker|podman logs (per container)
    │    flushed every test                    ├─ state: exit code, OOMKilled, health
    └─ stacks-<worker>.txt                     └─ runner disk / memory / load
         repeating dumps                       │
    │                                          │   ordered BEFORE teardown,
    ▼                                          │   which removes the containers
  scripts/ci/diag_summary.py                   │
    "gw2 was inside test_x"                    │
    │                                          │
    ▼                                          ▼
  $GITHUB_STEP_SUMMARY                     artifact: ci-diag-<lane>
```
