### PR TITLE
fix(deploy): read the render's config in host-side verbs

### DIFF
--- a/src/osprey/cli/sim.py
+++ b/src/osprey/cli/sim.py
@@ -72,9 +72,20 @@ def _resolve_deployment(repo: Path | None) -> tuple[Path, dict]:
     these commands cannot work in: ``config.yml`` is what names the simulation
     model, the state directory, and the ARIEL logbook.
 
+    The render is also anchored as this process's config for the rest of the
+    command. These verbs run wholly on the host, so nothing injects
+    ``CONFIG_FILE`` the way compose does for a container, and the working
+    directory is a repo root that holds no ``config.yml`` — every unqualified
+    lookup a scenario apply makes would otherwise answer from defaults. The
+    facility timezone is the one that bites: it decides what wall-clock a
+    seeded logbook entry lands on, and the fallback is a plausible-looking UTC
+    rather than an error. Unwound with the click context, so the anchor cannot
+    outlive the verb (see :func:`~osprey.utils.config.config_anchored_at`).
+
     Raises:
         RepoNotFoundError: When no ``profile.yml`` encloses the search start.
     """
+    from osprey.utils.config import config_anchored_at
     from osprey.utils.workspace import BUILD_DIR_NAME, rendered_config_path
 
     repo_root = find_repo_root(repo)
@@ -83,6 +94,7 @@ def _resolve_deployment(repo: Path | None) -> tuple[Path, dict]:
         click.echo(f"Error: no build found at {repo_root / BUILD_DIR_NAME}.", err=True)
         click.echo("Run 'osprey build' first — the scenarios live in the render.", err=True)
         raise SystemExit(1)
+    click.get_current_context().with_resource(config_anchored_at(config_path))
     return repo_root, load_config(str(config_path))
 
 
@@ -255,10 +267,13 @@ def apply_command(
     )
     from osprey.simulation.engine import resolve_active_scenarios
 
-    now = _parse_now(now_iso) if now_iso else None
     seed_logbook = not (no_seed or no_seed_logbook)
     seed_archive = not (no_seed or no_seed_archiver)
     repo_root, config = _resolve_deployment(repo)
+    # After the deployment resolves, never before: a naive --now is stamped with
+    # the facility timezone, and that zone is only knowable once this repo's
+    # render is the config being read.
+    now = _parse_now(now_iso) if now_iso else None
     ariel_config = config.get("ariel")
 
     # Validate pure, write last: every check that can reject the requested set

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -56,7 +56,7 @@ from osprey.deployment.web_terminals.provision import (
     preflight_web_terminals,
 )
 from osprey.deployment.wheel_build import _staged_dev_artifact_paths
-from osprey.utils.config import load_project_config
+from osprey.utils.config import config_anchored_at, load_project_config
 from osprey.utils.dotenv import (
     compose_unsafe_vars,
     parse_dotenv_file,
@@ -2062,23 +2062,28 @@ def deploy_up(
     # no error anywhere. Never blocks (see warn_if_project_stale).
     warn_if_project_stale(project_dir)
 
-    _start_stack(
-        config,
-        compose_files,
-        repo_root,
-        detached=detached,
-        dev_mode=dev_mode,
-        expose_network=expose_network,
-        # ANCHORED, deliberately: the provisioners this reaches mint REAL
-        # SECRETS, and `_start_stack`'s default leaves them writing a
-        # cwd-relative `.env`. The repo root is resolved four lines up and every
-        # compose invocation below reads `<repo>/.env` with --env-file, so an
-        # unanchored mint writes tokens the stack never reads — a deploy that
-        # comes up with its fail-closed tokens unset, which looks secure and
-        # says nothing.
-        env_path=repo_root / COMPOSE_ENV_FILENAME,
-        keep_archiver_base=keep_archiver_base,
-    )
+    # Anchored on the config this verb was HANDED, not on a derived
+    # `<repo>/build/config.yml`: a legacy flat project's own directory is its
+    # render, so deriving the path would name a file that does not exist there.
+    # Same contract as the as-built path — see `_start_as_built`.
+    with config_anchored_at(config_path):
+        _start_stack(
+            config,
+            compose_files,
+            repo_root,
+            detached=detached,
+            dev_mode=dev_mode,
+            expose_network=expose_network,
+            # ANCHORED, deliberately: the provisioners this reaches mint REAL
+            # SECRETS, and `_start_stack`'s default leaves them writing a
+            # cwd-relative `.env`. The repo root is resolved four lines up and
+            # every compose invocation below reads `<repo>/.env` with
+            # --env-file, so an unanchored mint writes tokens the stack never
+            # reads — a deploy that comes up with its fail-closed tokens unset,
+            # which looks secure and says nothing.
+            env_path=repo_root / COMPOSE_ENV_FILENAME,
+            keep_archiver_base=keep_archiver_base,
+        )
 
 
 def _start_stack(
@@ -2667,23 +2672,33 @@ def _start_as_built(
     makes it repo-specific rather than generic is the two arguments it pins on
     :func:`_start_stack`: the repo's single ``.env``, and the build directory as
     the image build context.
+
+    The whole start runs with this repo's render anchored as the process config.
+    A start is not only a sequence of ``compose`` invocations — it synthesizes
+    and seeds an archive in THIS process, and that work reads the config through
+    unqualified lookups. Compose hands every container ``CONFIG_FILE``; without
+    the anchor the host is the one participant in that contract left resolving
+    against a working directory that holds no ``config.yml`` at all, and its
+    lookups degrade to defaults without failing. See
+    :func:`~osprey.utils.config.config_anchored_at`.
     """
-    _start_stack(
-        config,
-        compose_files,
-        repo_root,
-        detached=detached,
-        dev_mode=dev_mode,
-        expose_network=exposed,
-        # Explicit, never the cwd-relative default: the token mint writes real
-        # secrets, and every compose invocation on this path reads
-        # `<repo>/.env` with --env-file. A mint that landed anywhere else would
-        # leave the stack starting with its fail-closed tokens unset — secure
-        # looking, and silent.
-        env_path=repo_root / COMPOSE_ENV_FILENAME,
-        build_context=container_image_context(repo_root, resolve_project_name(config)),
-        keep_archiver_base=keep_archiver_base,
-    )
+    with config_anchored_at(as_built_config_path(repo_root)):
+        _start_stack(
+            config,
+            compose_files,
+            repo_root,
+            detached=detached,
+            dev_mode=dev_mode,
+            expose_network=exposed,
+            # Explicit, never the cwd-relative default: the token mint writes
+            # real secrets, and every compose invocation on this path reads
+            # `<repo>/.env` with --env-file. A mint that landed anywhere else
+            # would leave the stack starting with its fail-closed tokens unset —
+            # secure looking, and silent.
+            env_path=repo_root / COMPOSE_ENV_FILENAME,
+            build_context=container_image_context(repo_root, resolve_project_name(config)),
+            keep_archiver_base=keep_archiver_base,
+        )
 
 
 def _repo_label_filter(repo_root: Path) -> str:

--- a/src/osprey/utils/config.py
+++ b/src/osprey/utils/config.py
@@ -22,6 +22,7 @@ import copy
 import logging
 import os
 import re
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, overload
 
@@ -38,7 +39,7 @@ from osprey.utils.workspace import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterator, Mapping
     from datetime import datetime
     from zoneinfo import ZoneInfo
 
@@ -835,6 +836,58 @@ def get_config_builder(
     return _get_config(config_path, set_as_default)
 
 
+@contextmanager
+def config_anchored_at(config_path: str | Path) -> "Iterator[None]":
+    """Answer this process's unqualified config lookups from *config_path*.
+
+    Every :func:`get_config_value` and :func:`get_facility_timezone` call that
+    names no config resolves the default singleton, which knows exactly two
+    places to look: ``CONFIG_FILE``, and ``config.yml`` in the working
+    directory. Compose satisfies that contract for every container by injecting
+    ``CONFIG_FILE``. On the host there is nobody to inject it, and a deployment
+    repo keeps its render one zone down in ``build/`` while its verbs stand at
+    the repo root — so a host verb doing in-process work satisfies neither
+    branch, and every lookup it makes degrades to a default. Silently: a
+    degraded answer (UTC, an empty dict) is indistinguishable from a configured
+    one at the call site, which is how a whole archive can be synthesized
+    against the wrong clock without anything failing.
+
+    This is the host's half of that contract, and it is deliberately in-process
+    rather than an exported ``CONFIG_FILE``. The attached start path
+    ``os.execvpe``-replaces itself with the container runtime, and an exported
+    variable would ride into that process's interpolation environment; the
+    anchor has no business outliving the verb that set it.
+
+    Scoped for the same reason — the previous default is restored on exit, so a
+    verb pointed at one deployment with ``--repo`` cannot leave the next lookup
+    in this process answering for it.
+
+    Never raises. A config that will not load leaves the previous default in
+    place and warns: this makes lookups honest, and an anchor that aborted its
+    caller would turn a degraded lookup into a failed deploy.
+
+    Args:
+        config_path: The rendered config this process is acting on — normally
+            ``<repo>/build/config.yml`` (see
+            :func:`osprey.utils.workspace.rendered_config_path`).
+    """
+    global _default_config, _default_configurable
+
+    previous = (_default_config, _default_configurable)
+    try:
+        try:
+            _get_config(str(config_path), set_as_default=True)
+        except Exception as exc:  # noqa: BLE001 - an unusable anchor must not fail the caller
+            logger.warning(
+                f"Could not anchor configuration at {config_path} "
+                f"({type(exc).__name__}: {exc}). Values this process reads without an "
+                "explicit path will fall back to their defaults."
+            )
+        yield
+    finally:
+        _default_config, _default_configurable = previous
+
+
 def load_config(config_path: str | None = None) -> dict[str, Any]:
     """Load raw configuration dictionary from YAML file.
 
@@ -989,6 +1042,7 @@ def get_config_value(path: str, default: Any = None, config_path: str | None = N
 
 
 _tz_drift_warned = False
+_tz_fallback_warned = False
 
 
 def get_facility_timezone() -> "ZoneInfo":
@@ -999,16 +1053,28 @@ def get_facility_timezone() -> "ZoneInfo":
     ``config.yml`` and no ``CONFIG_FILE``) or a misconfigured/typo'd zone name
     degrades to UTC with a logged warning rather than propagating to callers.
 
+    The fallback warns **once per process**, not once per call. Synthesis calls
+    this per channel per chunk — thousands of times to seed one archive — and a
+    failed load is never cached (only a successful one is), so the fallback is
+    re-taken on every one of them. Repeating the multi-line "no config.yml
+    found" remedy that often buries every other line of the deploy and makes a
+    seed that is working normally read as a hung terminal. Once is deliberate
+    rather than none: a process resolving the wrong config still has to be
+    diagnosable from its own log.
+
     Returns:
         ZoneInfo for the configured facility timezone, defaulting to UTC.
     """
+    global _tz_fallback_warned
     from zoneinfo import ZoneInfo
 
     try:
         tz_name = get_config_value("facility_timezone", "UTC")
         zone = ZoneInfo(tz_name)
     except Exception as exc:  # noqa: BLE001 - any failure must degrade to UTC, not raise
-        logger.warning(f"Falling back to UTC facility timezone ({type(exc).__name__}: {exc})")
+        if not _tz_fallback_warned:
+            _tz_fallback_warned = True
+            logger.warning(f"Falling back to UTC facility timezone ({type(exc).__name__}: {exc})")
         return ZoneInfo("UTC")
 
     _warn_on_tz_drift(tz_name)

--- a/src/osprey/utils/workspace.py
+++ b/src/osprey/utils/workspace.py
@@ -236,12 +236,20 @@ def load_osprey_config() -> dict:
 
 
 def reset_config_cache() -> None:
-    """Clear all config caches — used between tests."""
+    """Clear all config caches — used between tests.
+
+    The warn-once latch on the facility-timezone fallback is cleared with them.
+    It is process state in exactly the way a cache is: left set, whichever test
+    happened to run first would consume the single warning and every later test
+    asserting on it would see none — an order-dependent pass that says nothing
+    about the code.
+    """
     from osprey.utils import config as config_module
 
     config_module._default_config = None
     config_module._default_configurable = None
     config_module._config_cache.clear()
+    config_module._tz_fallback_warned = False
 
 
 def repo_root_for_config(config_path: Path | str) -> Path:

--- a/tests/cli/test_sim_cmd.py
+++ b/tests/cli/test_sim_cmd.py
@@ -17,7 +17,7 @@ import pytest
 from click.testing import CliRunner
 
 from osprey.cli.sim import sim_group
-from tests.cli._lifecycle_build import stub_build
+from tests.cli._lifecycle_build import STUB_CONFIG, stub_build
 
 # ``archiver`` is None here for the same reason ``load_config`` returns {}: this
 # project declares no stored archive, so the rewrite has nothing to report.
@@ -62,6 +62,42 @@ def test_apply_now_threads_aware_anchor(deployment):
     assert isinstance(now, datetime)
     assert now.tzinfo is not None, "naive --now must be given the facility timezone"
     assert (now.year, now.month, now.day, now.hour) == (2024, 3, 18, 12)
+
+
+def test_apply_now_is_stamped_with_the_renders_zone_not_utc(lifecycle_repo):
+    """A naive ``--now`` takes the DEPLOYMENT's zone, not whatever resolves.
+
+    ``tzinfo is not None`` cannot catch the failure this guards: an unanchored
+    process falls back to UTC, which is aware, non-``None``, and wrong. Only a
+    repo whose render names a real zone tells the two apart — which is also why
+    the bug survived so long in the deploy path, where the fallback and the
+    configured default happened to agree.
+
+    ``sim`` runs entirely on the host, so nothing injects ``CONFIG_FILE`` for it
+    and its working directory is the repo root, which holds no ``config.yml``.
+    The zone therefore has to come from the render this verb resolved.
+    """
+    stub_build(
+        lifecycle_repo,
+        config=STUB_CONFIG + "system:\n  timezone: America/Los_Angeles\n",
+    )
+
+    with patch("osprey.simulation.apply.apply_scenarios", return_value=_FAKE_RESULT) as apply_mock:
+        result = CliRunner().invoke(
+            sim_group,
+            [
+                "apply",
+                "nominal",
+                "--yes",
+                "--now",
+                "2024-03-18T12:00:00",
+                "--repo",
+                str(lifecycle_repo),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert str(apply_mock.call_args.kwargs["now"].tzinfo) == "America/Los_Angeles"
 
 
 def test_apply_now_from_env(deployment):

--- a/tests/config/test_config_builder.py
+++ b/tests/config/test_config_builder.py
@@ -363,6 +363,35 @@ class TestGetFacilityTimezone:
 
         assert get_facility_timezone() == ZoneInfo("America/Los_Angeles")
 
+    def test_an_unresolvable_config_is_reported_once_not_once_per_call(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """The fallback must say its piece once, then stop.
+
+        This resolver is called once per channel per chunk by the archiver
+        seeder — thousands of times on a first deploy — and a failed load is
+        never cached, so the fallback is re-taken every time. Unguarded, the
+        eight-line "no config.yml found" remedy is re-rendered for each call and
+        a seed that is working normally reads as a hung terminal.
+
+        Once is not zero: a deploy resolving the wrong config still has to be
+        diagnosable from its own log.
+        """
+        import logging
+
+        from osprey.utils.config import get_facility_timezone
+
+        monkeypatch.delenv("CONFIG_FILE", raising=False)
+        monkeypatch.chdir(tmp_path)  # empty dir, no config.yml
+        self._reset_config_singleton()
+
+        with caplog.at_level(logging.WARNING, logger="CONFIG"):
+            for _ in range(5):
+                get_facility_timezone()
+
+        fallback = [r for r in caplog.records if "Falling back to UTC" in r.message]
+        assert len(fallback) == 1, f"expected one fallback warning, got {len(fallback)}"
+
 
 class TestToFacilityIso:
     """``to_facility_iso`` is the single shared timestamp-egress transform for the

--- a/tests/deployment/test_service_token_unconditional_mint.py
+++ b/tests/deployment/test_service_token_unconditional_mint.py
@@ -217,8 +217,15 @@ def test_mint_logs_no_withholding_warning_under_the_formerly_guarded_posture(
         container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
 
     # caplog's handler already calls record.getMessage(), so r.message is the
-    # final rendered string.
-    warnings = " ".join(r.message for r in caplog.records if r.levelno >= logging.WARNING).lower()
+    # final rendered string. Scoped to the logger this test opened, because the
+    # claim is about what the MINT says: an unscoped sweep also reads warnings
+    # that echo a filesystem path, and pytest names ``tmp_path`` after the test
+    # — so this test's own name would match its own assertion.
+    warnings = " ".join(
+        r.message
+        for r in caplog.records
+        if r.levelno >= logging.WARNING and r.name == "deployment.lifecycle"
+    ).lower()
     assert "withheld" not in warnings
     assert "withholding" not in warnings
     assert "bluesky_launch_token" not in warnings

--- a/tests/deployment/test_up_as_built.py
+++ b/tests/deployment/test_up_as_built.py
@@ -267,6 +267,64 @@ def test_a_start_exports_no_repo_identity_variable(lifecycle_repo, started):
     assert "OSPREY_REPO_ID" not in started["env"]
 
 
+# ---------------------------------------------------------------------------
+# The host process resolves the same config the containers are handed
+# ---------------------------------------------------------------------------
+
+
+def test_host_side_work_during_a_start_reads_the_render_not_the_working_directory(
+    lifecycle_repo, started, monkeypatch
+):
+    """A start does real work in-process, and it must read ``build/config.yml``.
+
+    Compose hands every service ``CONFIG_FILE`` naming the render, so a container
+    resolves the facility zone correctly. The host process that stages and seeds
+    the archiver store before that compose runs is the one participant in the
+    same contract that used to be left out: it chdirs to the repo ROOT, where the
+    three-zone layout puts only ``profile.yml``, so the global resolver found no
+    ``config.yml`` at all and every synthesis call degraded to UTC.
+
+    Asserted on the resolved zone rather than on the variable, because UTC is
+    what a facility that configures nothing gets anyway: the bug is only visible
+    as a WRONG ANSWER when the render names a real zone.
+    """
+    from osprey.utils.config import get_facility_timezone
+
+    (lifecycle_repo / ".env").write_text("ANTHROPIC_API_KEY=x\n", encoding="utf-8")
+    render_build(
+        lifecycle_repo, config=_RENDERED_CONFIG + "system:\n  timezone: America/Los_Angeles\n"
+    )
+
+    seen: dict = {}
+
+    def _probe(config, dev_mode, env, build_context=None):
+        seen["tz"] = str(get_facility_timezone())
+
+    monkeypatch.setattr(container_lifecycle, "_build_project_image", _probe)
+
+    result = run_up(lifecycle_repo, "-d")
+
+    assert result.exit_code == 0, result.output
+    assert seen["tz"] == "America/Los_Angeles"
+
+
+def test_a_start_leaves_no_config_anchor_behind_in_the_environment(
+    lifecycle_repo, started, monkeypatch
+):
+    """The anchor is scoped to the start, like the working directory is.
+
+    ``CONFIG_FILE`` is a generic enough name that leaving one deployment's render
+    exported would redirect the next OSPREY process this shell runs — including a
+    verb pointed at a DIFFERENT repo with ``--repo``.
+    """
+    monkeypatch.delenv("CONFIG_FILE", raising=False)
+    (lifecycle_repo / ".env").write_text("ANTHROPIC_API_KEY=x\n", encoding="utf-8")
+    render_build(lifecycle_repo)
+
+    assert run_up(lifecycle_repo, "-d").exit_code == 0
+    assert "CONFIG_FILE" not in os.environ
+
+
 def test_a_missing_build_is_a_refusal_naming_the_build_verb(lifecycle_repo, started, caplog):
     result = run_up(lifecycle_repo, "-d")
 

--- a/tests/e2e/web_terminals/test_skills_overlay_discovery.py
+++ b/tests/e2e/web_terminals/test_skills_overlay_discovery.py
@@ -15,8 +15,16 @@ record, and that record carries a ``skills`` array (and a matching
 ``slash_commands`` array). This init event is emitted at session start, *before*
 the model is contacted — so the signal is deterministic and needs no working
 provider credentials: a bogus ``ANTHROPIC_API_KEY`` still yields a full init
-record before the run ends with a 401. That keeps this test runnable in CI
-without spending tokens or requiring VPN/provider access.
+record. That keeps this test runnable in CI without spending tokens or requiring
+VPN/provider access.
+
+We read that init record off the stream and then KILL the CLI, rather than
+waiting for it to exit. The exit path is not part of the contract under test and
+is not ours to depend on: with an unusable credential the CLI retries the API
+call with backoff (``{"type":"system","subtype":"api_retry"}``) rather than
+terminating promptly, so waiting for exit wedges the test for as long as the
+retry schedule runs while the answer has already been sitting in stdout since
+the first second.
 
 VERDICT (recorded empirically against claude 2.1.210)
 -----------------------------------------------------
@@ -53,7 +61,10 @@ from __future__ import annotations
 
 import json
 import os
+import signal
 import subprocess
+import tempfile
+import threading
 from pathlib import Path
 
 import pytest
@@ -66,6 +77,11 @@ pytestmark = [pytest.mark.e2e, pytest.mark.e2e_smoke]
 # (osprey.utils.claude_launcher._SETTING_SOURCES_ARGS).
 _SETTING_SOURCES_PROJECT = ["--setting-sources", "project"]
 _SETTING_SOURCES_USER_PROJECT = ["--setting-sources", "user,project"]
+
+# The init record is emitted at session start, before the model is contacted, so
+# it lands in about a second. This bound only has to cover CLI startup on a cold,
+# loaded runner — it is a wedged-process backstop, not an expected wait.
+_INIT_RECORD_TIMEOUT_S = 60.0
 
 _SKILLIFY = """---
 name: {name}
@@ -90,8 +106,10 @@ def _clean_env(config_dir: Path) -> dict[str, str]:
     ``CLAUDECODE``/``CLAUDE_CODE_ENTRYPOINT`` are stripped so the CLI does not
     treat this as a nested session. Any inherited Anthropic auth (including a
     proxy base URL) is removed and replaced with a deliberately-bogus key: the
-    init record is emitted before the API is contacted, so the run reaches a fast
-    401 without us needing — or spending — a valid provider credential.
+    init record is emitted before the API is contacted, so we get the signal
+    without needing — or spending — a valid provider credential. What the CLI
+    does with the doomed request afterwards is immaterial; the caller stops
+    reading and kills it once the init record is in hand.
     """
     env = {
         k: v
@@ -111,13 +129,24 @@ def _clean_env(config_dir: Path) -> dict[str, str]:
     return env
 
 
+def _kill_group(proc: subprocess.Popen[str]) -> None:
+    """SIGKILL the CLI's whole process group, tolerating an already-dead child."""
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        proc.kill()
+
+
 def _discovered_skills(*, config_dir: Path, cwd: Path, setting_sources: list[str]) -> list[str]:
     """Return the ``skills`` list from the CLI's stream-json init record.
 
     Invokes ``claude --print --output-format stream-json --verbose`` with the
-    given ``--setting-sources`` and parses the first ``subtype == "init"``
-    record. Raises ``AssertionError`` if no init record is produced (a CLI/format
-    change we want to surface loudly rather than mistake for "nothing
+    given ``--setting-sources`` and returns the first ``subtype == "init"``
+    record's skills, killing the CLI the moment that record is in hand — see the
+    module docstring on why the exit path is deliberately not awaited.
+
+    Raises ``AssertionError`` if the stream ends without an init record (a
+    CLI/format change we want to surface loudly rather than mistake for "nothing
     discovered").
     """
     cmd = [
@@ -131,34 +160,61 @@ def _discovered_skills(*, config_dir: Path, cwd: Path, setting_sources: list[str
         "haiku",
         "probe",
     ]
-    proc = subprocess.run(
+    # stderr goes to a file, not a pipe: we stop reading stdout as soon as the
+    # init record lands, and an unread stderr pipe would let the CLI block
+    # forever on a full buffer instead of dying to the kill below.
+    stderr_file = tempfile.TemporaryFile(mode="w+", encoding="utf-8", errors="replace")
+    proc = subprocess.Popen(  # noqa: S603 - fixed argv, no shell
         cmd,
         cwd=str(cwd),
         env=_clean_env(config_dir),
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=stderr_file,
         text=True,
-        timeout=120,
+        bufsize=1,
+        # Own process group, so the teardown below reaps the CLI's children too.
+        # We kill it mid-run rather than letting it exit, and a bare proc.kill()
+        # would signal only the node parent and orphan anything it spawned.
+        start_new_session=True,
     )
-    for line in proc.stdout.splitlines():
-        line = line.strip()
-        if not line.startswith("{"):
-            continue
-        try:
-            record = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if record.get("type") == "system" and record.get("subtype") == "init":
-            skills = record.get("skills")
-            assert isinstance(skills, list), (
-                "init record present but has no 'skills' list — CLI schema changed?\n"
-                f"init keys: {sorted(record)}"
-            )
-            return skills
+    # readline() blocks, so a deadline between lines cannot bound a CLI that has
+    # gone quiet. Killing the child is what makes stdout reach EOF and the loop
+    # below terminate.
+    watchdog = threading.Timer(_INIT_RECORD_TIMEOUT_S, lambda: _kill_group(proc))
+    watchdog.start()
+    stdout_seen: list[str] = []
+    try:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            stdout_seen.append(line)
+            stripped = line.strip()
+            if not stripped.startswith("{"):
+                continue
+            try:
+                record = json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+            if record.get("type") == "system" and record.get("subtype") == "init":
+                skills = record.get("skills")
+                assert isinstance(skills, list), (
+                    "init record present but has no 'skills' list — CLI schema changed?\n"
+                    f"init keys: {sorted(record)}"
+                )
+                return skills
+    finally:
+        watchdog.cancel()
+        _kill_group(proc)
+        proc.wait(timeout=30)
+        if proc.stdout is not None:
+            proc.stdout.close()
+        stderr_file.seek(0)
+        stderr_text = stderr_file.read()
+        stderr_file.close()
     raise AssertionError(
-        "No stream-json init record produced by the claude CLI. This test "
-        "depends on the init event being emitted before the (bogus-auth) run "
-        "ends.\n--- stdout ---\n"
-        f"{proc.stdout[:2000]}\n--- stderr ---\n{proc.stderr[:2000]}"
+        "No stream-json init record produced by the claude CLI before the stream "
+        f"ended or {_INIT_RECORD_TIMEOUT_S:.0f}s elapsed. This test depends on the "
+        "init event being emitted at session start.\n--- stdout ---\n"
+        f"{''.join(stdout_seen)[:2000]}\n--- stderr ---\n{stderr_text[:2000]}"
     )
 
 


### PR DESCRIPTION
## What

`osprey up`, `osprey restart` and `osprey sim` do real work in the CLI process —
staging and seeding the archiver store, applying scenarios — and that work
resolved its configuration against the working directory. The default config
resolver knows two places to look: `CONFIG_FILE`, and `config.yml` in the
current directory. A deployment repo keeps its render in `build/` and these
verbs stand at the repo root, which holds only `profile.yml`, so neither branch
matched and every lookup that named no config answered from a default.

Containers were never exposed: compose injects `CONFIG_FILE` into each service,
and the compose generator's tests assert it. The host process was the one
participant in that contract nobody had wired up.

## Why it mattered, and why it was invisible

The facility timezone is what this decided in practice, and its fallback is UTC.
For a project that configures no zone the fallback equals the correct answer, so
the archive seeded fine and nothing failed — but any facility that sets a real
`system.timezone` would have had host-seeded history and logbook narrative land
hours away from where the containers place the same events.

What was visible was noise. `get_facility_timezone()` warned on every call, a
failed load is never cached, and synthesis calls it once per channel per chunk —
so a first deploy printed the same eight-line "no config.yml found" remedy
thousands of times, and a seed that was working normally read as a hang.

Both halves were green in CI. The suite runs with no `config.yml` and
`CONFIG_FILE` stripped, so the fallback fires constantly; `pytest` captures the
warnings silently, and every assertion still passed because UTC-by-fallback
equals UTC-by-default. The deploy-verb tests also mock the seeder away, so the
question "what environment does host-side work actually run in" was asked
nowhere.

## The change

- `config_anchored_at()` — a scoped context manager that makes a given rendered
  config answer this process's unqualified lookups, restoring the previous
  default on exit. In-process rather than an exported `CONFIG_FILE`: the
  attached start path `os.execvpe`-replaces itself with the container runtime,
  and an exported variable would ride into that process's interpolation
  environment. It never raises — an unloadable anchor warns and leaves the
  previous default alone, since aborting the caller would turn a degraded lookup
  into a failed deploy.
- Both start paths (`_start_as_built`, and the legacy `deploy_up`) run under it.
  The legacy path anchors on the config it was handed rather than a derived
  `build/config.yml`, because a flat project's own directory is its render.
- `sim` anchors on the render it resolved, unwound with the click context. Its
  `--now` anchor is parsed after the deployment resolves, since a naive
  timestamp is stamped with a zone that is only knowable by then.
- The UTC fallback warns once per process instead of once per call. Once rather
  than none, so a process resolving the wrong config is still diagnosable; the
  latch is cleared with the config caches between tests so it can't make a later
  test order-dependent.

## Tests

Written first, and each was watched failing for the right reason:

- `test_host_side_work_during_a_start_reads_the_render_not_the_working_directory`
  — asserts the resolved zone during a start, not the env var. It failed
  `assert 'UTC' == 'America/Los_Angeles'`, which is the latent correctness bug
  rather than the visible noise.
- `test_apply_now_is_stamped_with_the_renders_zone_not_utc` — the existing
  `--now` test asserted only `tzinfo is not None`, which UTC satisfies. This one
  pins the zone.
- `test_an_unresolvable_config_is_reported_once_not_once_per_call`.
- `test_a_start_leaves_no_config_anchor_behind_in_the_environment` pins the
  scoping.

One existing test needed a fix it had coming: it swept *every* warning for the
string "withholding", and pytest names `tmp_path` after the test — so a warning
that echoes a path made the test match its own name. It now scopes the sweep to
the logger it already declares.

Locally: 5949 passed across `tests/deployment`, `tests/config`,
`tests/simulation` and `tests/cli`; `ruff check`, `ruff format --check` and
`mypy` clean. The rest is left to CI.
