### PR TITLE
Tile header bar redesign: full-width seated chrome, one control language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Compatibility is documented in release notes, not encoded in the version string.
   differences from an earlier arrangement. Guidance for moving an existing
   deployment onto the profile format is unchanged.
 
+- Web terminal tile headers were redesigned: the bar now spans its whole tile
+  (close always at the tile's right edge), sits on one seated surface whose
+  hairline turns accent on the active tile, and renders one unified 24px
+  control language with SVG icons. Panel names lead the bar with contributed
+  text as a subtitle; on narrow tiles a contributed search collapses to its
+  magnifier and remaining controls fold into a ⋯ menu instead of vanishing.
+  The six-dot drag grip is gone — the bar itself remains the drag handle.
+
 - The control-assistant preset's two-user roster now ships alice as the
   write-capable operator and bob as the read-only viewer. The tiers differ
   visibly, not just in enforcement: the write-armed terminal keeps the full

--- a/src/osprey/interfaces/design_system/static/js/header-contrib.js
+++ b/src/osprey/interfaces/design_system/static/js/header-contrib.js
@@ -14,7 +14,9 @@
  *
  * Item vocabulary (closed set; the hub ignores unknown kinds):
  *
- * - `{kind:'text', id, text}` — inert label (e.g. a loaded-file name).
+ * - `{kind:'text', id, text}` — inert label (e.g. a loaded-file name). The
+ *   hub renders it as the tile's SUBTITLE, beside the tile name — it is
+ *   identity, not a control — while interactive items right-anchor.
  * - `{kind:'nav', id, items:[{id, label, active}]}` — view switcher; the
  *   action's `value` is the clicked entry's id.
  * - `{kind:'button', id, label, title?, tone?:'default'|'accent', disabled?}`

--- a/src/osprey/interfaces/web_terminal/static/css/dockview-overrides.css
+++ b/src/osprey/interfaces/web_terminal/static/css/dockview-overrides.css
@@ -30,13 +30,17 @@
 .dock-root.dockview-theme-light,
 .dock-root .dv-shell.dockview-theme-dark,
 .dock-root .dv-shell.dockview-theme-light {
-  /* Surfaces */
+  /* Surfaces. The header bar is ONE seated surface: strip and tab share
+   * --bg-panel so there is no seam where the tab ends (--bg-secondary is
+   * only 3/255 from the body in the dark theme — a distinction that read as
+   * dirt, not structure). The active-tile signal is the bar's hairline and
+   * title color (below), not a background split. */
   --dv-group-view-background-color: var(--bg-primary);
-  --dv-tabs-and-actions-container-background-color: var(--bg-secondary);
-  --dv-activegroup-visiblepanel-tab-background-color: var(--bg-primary);
-  --dv-activegroup-hiddenpanel-tab-background-color: var(--bg-secondary);
-  --dv-inactivegroup-visiblepanel-tab-background-color: var(--bg-secondary);
-  --dv-inactivegroup-hiddenpanel-tab-background-color: var(--bg-secondary);
+  --dv-tabs-and-actions-container-background-color: var(--bg-panel);
+  --dv-activegroup-visiblepanel-tab-background-color: var(--bg-panel);
+  --dv-activegroup-hiddenpanel-tab-background-color: var(--bg-panel);
+  --dv-inactivegroup-visiblepanel-tab-background-color: var(--bg-panel);
+  --dv-inactivegroup-hiddenpanel-tab-background-color: var(--bg-panel);
 
   /* Tab text: the active tab reads primary, everything backgrounded is dimmer. */
   --dv-activegroup-visiblepanel-tab-color: var(--text-primary);
@@ -142,13 +146,20 @@
 /* ---- Tile header bar: the single tab IS the host chrome ----
  * One panel per tile is a workspace invariant (both modes), so a tile's "tab"
  * can never have siblings; dock-tab.js renders it as the tile's header bar.
- * EVERY tile carries the same 36px bar with the same grammar — six-dot drag
- * grip on the left, the tile's identity beside it, close on the right — so
- * grabbing, naming and closing a tile is one gesture learned once:
+ * EVERY tile carries the same 36px bar with the same grammar — the tile's
+ * identity on the left, its actions right-anchored — so naming and closing a
+ * tile is one gesture learned once. There is no drag badge: the whole bar is
+ * the drag handle (cursor: grab below).
  *
- *   SERVICE tiles show grip + the panel's name (.tile-tab-title) + close.
- *   The TERMINAL tile shows grip + the adopted .terminal-header (session LED,
+ *   SERVICE tiles show the panel's name (.tile-tab-title) + contributed
+ *     controls + close.
+ *   The TERMINAL tile shows the adopted .terminal-header (session LED,
  *     session id, selector, "+ New") + close.
+ *
+ * SEATED CHROME: the bar is its own surface (--bg-panel, remapped above)
+ * closed by a hairline. The hairline turns accent on the ACTIVE tile — the
+ * tile receiving keystrokes — and inactive tiles dim their name to
+ * secondary, so focus is legible at a glance without a background split.
  *
  * Fixed height, no hover reveal: the bar never changes size, so tile content
  * never reflows on pointer movement.
@@ -163,6 +174,21 @@
  * specificity, deterministically, in either theme. */
 .dock-root .dv-tabs-and-actions-container {
   height: 36px;
+  border-bottom: 1px solid var(--border-default);
+}
+
+/* The active tile's bar closes with the accent hairline. dv-active-group /
+ * dv-inactive-group are stamped by dockview on the group element (verified
+ * against the vendored 7.0.2 bundle); the container is box-sizing:border-box,
+ * so the hairline never changes the bar's outer height. */
+.dock-root .dv-groupview.dv-active-group > .dv-tabs-and-actions-container {
+  border-bottom-color: var(--color-accent);
+}
+
+/* Inactive tiles dim their identity to secondary; the active tile's name
+ * reads primary (set on .tile-tab-title below). */
+.dock-root .dv-groupview.dv-inactive-group .tile-tab-title {
+  color: var(--text-secondary);
 }
 
 /* The lone tab fills the strip; the void container (dockview's empty-space
@@ -184,37 +210,16 @@
   align-items: center;
   justify-content: flex-start;
   gap: 8px;
-  padding: 0 6px 0 10px;
+  padding: 0 6px 0 12px;
   width: 100%;
   height: 100%;
   min-width: 0;
   cursor: grab;
 }
 
-/* The drag grip: an upright 2×3 dot grid on every tile — the one mark that
- * means "grab here to move this tile", muted at rest and accent under the
- * pointer, matching the sash/splitter grip treatment above. */
-.dock-root .tile-tab-grip {
-  flex: 0 0 auto;
-  width: 10px;
-  height: 14px;
-  background-image:
-    radial-gradient(circle, var(--text-muted) 1.5px, transparent 1.6px);
-  background-size: 5px 5px;
-  background-position: 0 0;
-  opacity: 0.6;
-  transition: opacity var(--duration-fast) ease;
-}
-
-.dock-root .dv-tab:hover .tile-tab-grip,
-.dock-root .dv-tab:active .tile-tab-grip {
-  background-image:
-    radial-gradient(circle, var(--color-accent) 1.5px, transparent 1.6px);
-  opacity: 1;
-}
-
-/* Service tile name: display type at rail-label weight, ellipsized so a long
- * runtime-panel label can never push the close control off the bar. */
+/* Service tile name: the bar's identity anchor, ellipsized so a long
+ * runtime-panel label can never push the close control off the bar. Primary
+ * on the active tile; the dv-inactive-group rule above dims it. */
 .dock-root .tile-tab-title {
   flex: 0 1 auto;
   min-width: 0;
@@ -224,7 +229,7 @@
   font-family: var(--font-display);
   font-size: var(--text-sm);
   letter-spacing: 0.05em;
-  color: var(--text-secondary);
+  color: var(--text-primary);
 }
 
 /* ---- Contribution region: the panel-controls slot ----
@@ -472,9 +477,9 @@
  * (disableDnd) and sash resize (api.locked) at runtime, so a service tile's
  * header bar is dead chrome there — it collapses away entirely and the panel
  * gets those pixels back. The terminal's bar stays (`:not(:has(...))` — it
- * carries live session controls, content rather than chrome), but its grip
- * and close are suppressed: moving or closing tiles is not a simple-mode
- * gesture.
+ * carries live session controls, content rather than chrome), but its close
+ * is suppressed: closing tiles is not a simple-mode gesture (drag is already
+ * off via disableDnd).
  * display:none overrides dockview's own visibility toggle on the active tab.
  *
  * A zero-height flex container does not clip its children on its own, and
@@ -486,7 +491,6 @@ html[data-ui-mode="simple"] .dock-root .dv-tabs-and-actions-container:not(:has(.
 }
 
 html[data-ui-mode="simple"] .dv-tab .tile-tab-close,
-html[data-ui-mode="simple"] .dv-tab .tile-tab-grip,
 html[data-ui-mode="simple"] .dv-tab .dv-default-tab-action {
   display: none;
 }

--- a/src/osprey/interfaces/web_terminal/static/css/dockview-overrides.css
+++ b/src/osprey/interfaces/web_terminal/static/css/dockview-overrides.css
@@ -186,8 +186,10 @@
 }
 
 /* Inactive tiles dim their identity to secondary; the active tile's name
- * reads primary (set on .tile-tab-title below). */
-.dock-root .dv-groupview.dv-inactive-group .tile-tab-title {
+ * reads primary (set on .tile-tab-title below). The terminal's session label
+ * is the same identity element (see terminal.css), so it dims the same way. */
+.dock-root .dv-groupview.dv-inactive-group .tile-tab-title,
+.dock-root .dv-groupview.dv-inactive-group .tile-tab .terminal-label {
   color: var(--text-secondary);
 }
 
@@ -217,9 +219,11 @@
   cursor: grab;
 }
 
-/* Service tile name: the bar's identity anchor, ellipsized so a long
- * runtime-panel label can never push the close control off the bar. Primary
- * on the active tile; the dv-inactive-group rule above dims it. */
+/* Service tile name: the bar's identity anchor — display type at medium
+ * weight so it outranks the controls beside it (it was 10px/400, dimmer than
+ * the buttons it labels) — ellipsized so a long runtime-panel label can never
+ * push the close control off the bar. Primary on the active tile; the
+ * dv-inactive-group rule above dims it. */
 .dock-root .tile-tab-title {
   flex: 0 1 auto;
   min-width: 0;
@@ -227,17 +231,22 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   font-family: var(--font-display);
-  font-size: var(--text-sm);
-  letter-spacing: 0.05em;
+  font-size: var(--text-lg);
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.04em;
   color: var(--text-primary);
 }
 
-/* ---- Contribution region: the panel-controls slot ----
+/* ---- Contribution region: subtitle + the panel-controls slot ----
  * Rendered by tile-header-contrib.js from an embedded panel's
- * `osprey-header-contribution`. Sits between the tile name and the close
- * button, separated by a hairline when non-empty. min-width:0 + hidden
- * overflow let text items ellipsize before whole items are priority-hidden
- * (.contrib-hidden). */
+ * `osprey-header-contribution`. Fills the bar between the tile name and the
+ * close button, with no divider fence: inert `text` items are the tile's
+ * SUBTITLE and read left, beside the name (they are identity, not a
+ * control), while every interactive control right-anchors toward the
+ * actions. The split is pure CSS `order` around a flexible ::before spacer,
+ * so the reconcile in tile-header-contrib.js keeps one flat child list.
+ * min-width:0 + hidden overflow let text ellipsize before the overflow
+ * ladder folds whole controls (.contrib-hidden). */
 .dock-root .tile-tab-contrib {
   display: flex;
   align-items: center;
@@ -248,11 +257,23 @@
   overflow: hidden;
 }
 
-.dock-root .tile-tab-contrib.has-items {
-  border-left: 1px solid var(--border-default);
-  padding-left: 10px;
+.dock-root .tile-tab-contrib::before {
+  content: "";
+  flex: 1 1 0;
+  order: 1;
+  min-width: 0;
 }
 
+.dock-root .tile-tab-contrib > * {
+  order: 2;
+}
+
+.dock-root .tile-tab-contrib > .contrib-text {
+  order: 0;
+}
+
+/* Subtitle: the loaded-file-name idiom — quiet mono beside the display-type
+ * name. */
 .dock-root .contrib-text {
   flex: 0 1 auto;
   min-width: 0;
@@ -264,41 +285,56 @@
   color: var(--text-muted);
 }
 
-.dock-root .contrib-nav {
-  display: flex;
-  align-items: center;
-  gap: 2px;
-  flex: 0 0 auto;
-}
-
+/* ---- One control language ----
+ * Every interactive element the bar renders — contributed buttons, nav
+ * segments, the ⋯ menu, the tile's own close — is the same 24px ghost
+ * control: transparent at rest, elevated fill under the pointer, one
+ * radius, one type style. Icons are inline SVG on currentColor
+ * (svg-icons.js), so they take each control's own state color. */
+.dock-root .tile-tab-actions button,
+.dock-root .contrib-btn,
 .dock-root .contrib-nav-link,
-.dock-root .contrib-btn {
+.dock-root .contrib-menu-btn {
   appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+  height: 24px;
+  padding: 0 var(--space-2);
   border: none;
   background: transparent;
   font-family: var(--font-display);
   font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
   line-height: var(--leading-none);
   color: var(--text-secondary);
-  padding: 4px 8px;
   border-radius: var(--radius-sm);
   cursor: pointer;
   white-space: nowrap;
+  flex: 0 0 auto;
 }
 
+.dock-root .tile-tab-actions button:hover,
+.dock-root .contrib-btn:hover:not(:disabled),
 .dock-root .contrib-nav-link:hover,
-.dock-root .contrib-btn:hover:not(:disabled) {
+.dock-root .contrib-menu-btn:hover,
+.dock-root .contrib-menu-btn[aria-expanded='true'] {
   color: var(--text-primary);
   background: var(--bg-elevated);
 }
 
-.dock-root .contrib-nav-link.active {
-  color: var(--text-primary);
-  background: var(--bg-elevated);
+/* Icon-only controls square off. */
+.dock-root .tile-tab-actions button,
+.dock-root .contrib-menu-btn {
+  width: 24px;
+  padding: 0;
 }
 
-.dock-root .contrib-btn {
-  border: 1px solid var(--border-default);
+.dock-root .bar-icon {
+  width: 14px;
+  height: 14px;
+  display: block;
 }
 
 .dock-root .contrib-btn:disabled {
@@ -308,14 +344,44 @@
 
 .dock-root .contrib-btn-accent {
   color: var(--color-accent);
-  border-color: var(--border-accent);
+}
+
+.dock-root .contrib-btn-accent:hover:not(:disabled) {
+  color: var(--color-accent);
+  background: var(--accent-tint-08);
+}
+
+/* Nav renders as a segmented control: one bordered track, the active view a
+ * filled segment — a view switcher should read as one control with N
+ * positions, not N sibling buttons. */
+.dock-root .contrib-nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  height: 24px;
+  padding: 2px;
+  box-sizing: border-box;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  flex: 0 0 auto;
+}
+
+.dock-root .contrib-nav-link {
+  height: 18px;
+  border-radius: var(--radius-xs);
+}
+
+.dock-root .contrib-nav-link.active {
+  color: var(--text-primary);
+  background: var(--bg-elevated);
 }
 
 /* Search pill. Deliberately the same grammar as `.command-palette-trigger`
- * in palette.css — magnifier, muted placeholder, bordered panel field — so a
- * panel's filter and the hub's own search read as one affordance. Sized to
+ * in palette.css — magnifier, muted placeholder, bordered field — so a
+ * panel's filter and the hub's own search read as one affordance. Recessed
+ * to --bg-primary now that the bar itself sits on --bg-panel. Sized to
  * the 36px bar rather than the 28px header, and allowed to shrink to an
- * icon-plus-stub before the priority pass considers hiding it outright. */
+ * icon-plus-stub before the overflow ladder collapses it further. */
 .dock-root .contrib-search {
   display: inline-flex;
   align-items: center;
@@ -324,9 +390,9 @@
   min-width: 92px;
   height: 24px;
   padding: 0 var(--space-2);
-  background: var(--bg-panel);
+  background: var(--bg-primary);
   border: 1px solid var(--border-default);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-sm);
   transition: border-color var(--wt-transition-fast), background var(--wt-transition-fast);
 }
 
@@ -337,10 +403,15 @@
 }
 
 .dock-root .contrib-search-icon {
-  font-size: var(--text-sm);
-  line-height: var(--leading-none);
+  display: inline-flex;
+  align-items: center;
   flex-shrink: 0;
-  opacity: 0.8;
+  color: var(--text-muted);
+}
+
+.dock-root .contrib-search-icon .bar-icon {
+  width: 12px;
+  height: 12px;
 }
 
 .dock-root .contrib-search-input {
@@ -365,26 +436,6 @@
  * key is the panel-agnostic one and the bar has no room for both. */
 .dock-root .contrib-search-input::-webkit-search-cancel-button {
   display: none;
-}
-
-/* ⋯ overflow trigger. Quiet until hovered, like the tile's own actions. */
-.dock-root .contrib-menu-btn {
-  appearance: none;
-  border: none;
-  background: transparent;
-  color: var(--text-muted);
-  font-size: var(--text-lg);
-  line-height: var(--leading-none);
-  padding: 2px 6px;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  flex: 0 0 auto;
-}
-
-.dock-root .contrib-menu-btn:hover,
-.dock-root .contrib-menu-btn[aria-expanded='true'] {
-  color: var(--text-primary);
-  background: var(--bg-elevated);
 }
 
 .dock-root .contrib-hidden {
@@ -449,28 +500,13 @@
   color: var(--color-accent);
 }
 
+/* Actions cluster: right-anchored; its buttons take the unified ghost
+ * language above. */
 .dock-root .tile-tab-actions {
   margin-left: auto;
   display: flex;
   align-items: center;
   gap: 2px;
-}
-
-.dock-root .tile-tab-actions button {
-  appearance: none;
-  border: none;
-  background: transparent;
-  color: var(--text-muted);
-  font-size: var(--text-xl);
-  line-height: var(--leading-none);
-  padding: 4px 6px;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-}
-
-.dock-root .tile-tab-actions button:hover {
-  color: var(--text-primary);
-  background: var(--bg-elevated);
 }
 
 /* Simple mode is a locked layout. dock-workspace.js disables drag/float

--- a/src/osprey/interfaces/web_terminal/static/css/dockview-overrides.css
+++ b/src/osprey/interfaces/web_terminal/static/css/dockview-overrides.css
@@ -166,9 +166,15 @@
 }
 
 /* The lone tab fills the strip; the void container (dockview's empty-space
- * group drag surface) collapses to zero — the bar itself is the handle. */
+ * group drag surface) collapses to zero — the bar itself is the handle.
+ * singleTabMode:'fullwidth' (dock-workspace.js) does the stretching; the
+ * min-width:0 here is what makes the shrink side real — a flex item's
+ * default min-width:auto floors it at content width, which would silently
+ * disable both `flex-shrink` and the whole priority-hide/ellipsis path on
+ * narrow tiles. */
 .dock-root .dv-tab {
   flex: 1 1 auto;
+  min-width: 0;
   max-width: none;
   padding: 0;
 }

--- a/src/osprey/interfaces/web_terminal/static/css/dockview-overrides.css
+++ b/src/osprey/interfaces/web_terminal/static/css/dockview-overrides.css
@@ -564,6 +564,11 @@
 html[data-ui-mode="simple"] .dock-root .dv-tabs-and-actions-container:not(:has(.tile-tab-terminal)) {
   height: 0;
   overflow: hidden;
+  /* The seated bar's closing hairline must go too. `height: 0` zeroes the
+   * CONTENT box; a border is not content, so under border-box the border
+   * still paints and the "collapsed" strip measures 1px — a stray rule over
+   * the panel, and one the simple-mode geometry assertion catches. */
+  border-bottom: none;
 }
 
 html[data-ui-mode="simple"] .dv-tab .tile-tab-close,

--- a/src/osprey/interfaces/web_terminal/static/css/dockview-overrides.css
+++ b/src/osprey/interfaces/web_terminal/static/css/dockview-overrides.css
@@ -225,7 +225,12 @@
  * push the close control off the bar. Primary on the active tile; the
  * dv-inactive-group rule above dims it. */
 .dock-root .tile-tab-title {
-  flex: 0 1 auto;
+  /* Identity holds its ground: the name does not flex-shrink (a narrowing
+   * tile crowds the contrib region instead, which is what engages the
+   * overflow ladder), but a long runtime label caps at 40% of the bar and
+   * ellipsizes so it can never push the close control off the tile. */
+  flex: 0 0 auto;
+  max-width: 40%;
   min-width: 0;
   overflow: hidden;
   white-space: nowrap;
@@ -273,10 +278,11 @@
 }
 
 /* Subtitle: the loaded-file-name idiom — quiet mono beside the display-type
- * name. */
+ * name. Its floor makes the region overflow (and the ladder fold controls)
+ * before the subtitle is squeezed past a stub. */
 .dock-root .contrib-text {
   flex: 0 1 auto;
-  min-width: 0;
+  min-width: 40px;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -438,8 +444,42 @@
   display: none;
 }
 
+/* A control the overflow ladder folded into the bar's ⋯ menu. Folded, not
+ * lost: the menu keeps it reachable (see applyOverflowLadder). */
 .dock-root .contrib-hidden {
   display: none;
+}
+
+/* The bar-owned ⋯ fold target sits at the controls cluster's right edge,
+ * inside the region (order 3 > the controls' order 2). */
+.dock-root .tile-tab-contrib > .contrib-overflow-btn {
+  order: 3;
+}
+
+/* Ladder step 1: the search field down to its magnifier — a 24px ghost
+ * button (click / Enter re-expands it for typing). */
+.dock-root .contrib-search-collapsed {
+  flex: 0 0 auto;
+  width: 24px;
+  min-width: 24px;
+  padding: 0;
+  justify-content: center;
+  background: transparent;
+  border-color: transparent;
+  cursor: pointer;
+}
+
+.dock-root .contrib-search-collapsed:hover {
+  background: var(--bg-elevated);
+  border-color: transparent;
+}
+
+.dock-root .contrib-search-collapsed .contrib-search-input {
+  display: none;
+}
+
+.dock-root .contrib-search-collapsed .contrib-search-icon {
+  color: var(--text-secondary);
 }
 
 /* Menu popover. Body-level and fixed — the contribution region is

--- a/src/osprey/interfaces/web_terminal/static/css/terminal.css
+++ b/src/osprey/interfaces/web_terminal/static/css/terminal.css
@@ -1243,6 +1243,27 @@ html[data-rail-position="top"] .rail-hint {
   border-bottom: none;
 }
 
+/* In the bar, the session label is the tile's IDENTITY and renders exactly
+ * like every service tile's name (.tile-tab-title in dockview-overrides.css)
+ * — the green LED, selector and "+ New" are what keep the terminal
+ * recognizable, not a divergent type treatment. The un-scoped .terminal-label
+ * above stays the fallback-mode look. */
+.tile-tab .terminal-label {
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.04em;
+  color: var(--text-primary);
+}
+
+/* "+ New" joins the bar's 24px control geometry (its chip fill stays). */
+.tile-tab .new-session-btn {
+  display: inline-flex;
+  align-items: center;
+  height: 24px;
+  padding: 0 9px;
+}
+
 .session-led {
   width: 7px;
   height: 7px;

--- a/src/osprey/interfaces/web_terminal/static/js/dock-tab.js
+++ b/src/osprey/interfaces/web_terminal/static/js/dock-tab.js
@@ -26,6 +26,7 @@ import { TERMINAL_RAIL_ID } from './panel-catalog.js';
 import { registerContribHost, unregisterContribHost } from './tile-header-contrib.js';
 import { PLACEHOLDER_PREFIX } from './dock-reconcile.js';
 import { withEchoSuppressed } from './dock-sync.js';
+import { svgIcon } from './svg-icons.js';
 
 /** defaultTabComponent name registered on the dockview instance. */
 export const OSPREY_TAB_COMPONENT = 'osprey-tile-tab';
@@ -159,7 +160,7 @@ class TileTab {
     const close = document.createElement('button');
     close.type = 'button';
     close.className = 'tile-tab-close';
-    close.textContent = '×';
+    close.appendChild(svgIcon('close'));
     close.title = 'Close tile';
     close.setAttribute('aria-label', 'Close tile');
     close.addEventListener('click', (e) => {

--- a/src/osprey/interfaces/web_terminal/static/js/dock-tab.js
+++ b/src/osprey/interfaces/web_terminal/static/js/dock-tab.js
@@ -3,15 +3,16 @@
  *
  * Under the one-panel-per-tile invariant a tile's "tab" can never have
  * siblings, so instead of a tab it renders the tile's HOST HEADER BAR. Every
- * tile gets the same bar grammar — drag grip on the left, the tile's
- * identity in the middle, close on the right — so grabbing, naming and
- * closing a tile is one gesture learned once:
+ * tile gets the same bar grammar — the tile's identity on the left, its
+ * actions right-anchored — so naming and closing a tile is one gesture
+ * learned once. There is no drag badge: the bar itself is the drag handle
+ * (cursor: grab), a convention the workspace teaches by use:
  *
- *   service tiles — grip + a visible `.tile-tab-title` + close. The close is
+ *   service tiles — a visible `.tile-tab-title` + close. The close is
  *     a LOCAL tile close (the panel keeps its rail entry; dock-sync routes
  *     the click to a vacate handler); membership removal stays the rail
  *     entry's "×". Popout remains rail-only.
- *   the terminal tile — grip + the adopted live `.terminal-header` + close.
+ *   the terminal tile — the adopted live `.terminal-header` + close.
  *     The header supplies the identity and more: session LED, session id,
  *     the session selector and "+ New" are frequently-used, stateful
  *     controls with nowhere better to live.
@@ -101,11 +102,6 @@ class TileTab {
     // here gives the tile a stable handle for the browser suite and for any
     // future per-tile styling, independent of a title that may be renamed.
     root.dataset.panelId = id;
-
-    const grip = document.createElement('span');
-    grip.className = 'tile-tab-grip';
-    grip.setAttribute('aria-hidden', 'true');
-    root.appendChild(grip);
 
     /** @type {HTMLElement | null} visible name element (service tiles only) */
     this._titleEl = null;

--- a/src/osprey/interfaces/web_terminal/static/js/dock-workspace.js
+++ b/src/osprey/interfaces/web_terminal/static/js/dock-workspace.js
@@ -197,12 +197,18 @@ export function initDockWorkspace() {
       if (options.name === PANEL_TERMINAL) return adoptSubtree(terminalSource);
       return { element: document.createElement('div'), init() {} };
     },
-    // Every tile's tab renders as the host header bar (grip/title/actions) —
-    // see dock-tab.js. defaultTabComponent routes panels with no explicit
+    // Every tile's tab renders as the host header bar (title/actions) — see
+    // dock-tab.js. defaultTabComponent routes panels with no explicit
     // tabComponent (i.e. all of them, including restored layouts) through
     // createTabComponent.
     createTabComponent: (/** @type {{ id: string }} */ options) => createTileTab(options.id),
     defaultTabComponent: OSPREY_TAB_COMPONENT,
+    // One panel per tile means every tab is a lone tab: stretch it across the
+    // whole strip so the bar spans its tile, the close control anchors at the
+    // tile's right edge, and the void container (dockview's empty-space drag
+    // surface) collapses to zero. Without this the tab is sized to its
+    // content and two thirds of the "bar" is void painted a different color.
+    singleTabMode: 'fullwidth',
   });
 
   // Bind dockview's light/dark base theme (root classes + the api's own theme

--- a/src/osprey/interfaces/web_terminal/static/js/svg-icons.js
+++ b/src/osprey/interfaces/web_terminal/static/js/svg-icons.js
@@ -1,0 +1,65 @@
+// @ts-check
+/* OSPREY Web Terminal — inline SVG icons for the tile header bar
+ *
+ * The bar's icons were typographic glyphs (×, ⋯) and one emoji (🔍). The
+ * emoji renders full-color on macOS/Windows — a loud non-chrome mark in an
+ * otherwise monochrome bar — and glyph metrics drift across the font stack.
+ * These are geometric strokes on currentColor instead, so every icon takes
+ * the button's own text color, including hover and disabled states.
+ *
+ * Built via createElementNS rather than an innerHTML literal so the modules
+ * that consume them (tile-header-items.js, dock-tab.js) keep their "nothing
+ * here interpolates markup" contract intact.
+ */
+
+const NS = 'http://www.w3.org/2000/svg';
+
+/** Stroke path data per icon, on a 16×16 viewBox. */
+const PATHS = {
+  /** × — close. */
+  close: ['M4.5 4.5 L11.5 11.5', 'M11.5 4.5 L4.5 11.5'],
+  /** 🔍 → magnifier. */
+  search: ['M10.1 10.1 L13.5 13.5'],
+  /** ⋯ — overflow menu. */
+  ellipsis: [],
+};
+
+/**
+ * Build one icon. The element is aria-hidden: the OWNING control carries the
+ * accessible name (aria-label/title), never the pictogram.
+ * @param {'close'|'search'|'ellipsis'} name
+ * @returns {SVGSVGElement}
+ */
+export function svgIcon(name) {
+  const svg = document.createElementNS(NS, 'svg');
+  svg.setAttribute('viewBox', '0 0 16 16');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '1.5');
+  svg.setAttribute('stroke-linecap', 'round');
+  svg.setAttribute('aria-hidden', 'true');
+  svg.classList.add('bar-icon', `bar-icon-${name}`);
+  for (const d of PATHS[name]) {
+    const path = document.createElementNS(NS, 'path');
+    path.setAttribute('d', d);
+    svg.appendChild(path);
+  }
+  if (name === 'search') {
+    const lens = document.createElementNS(NS, 'circle');
+    lens.setAttribute('cx', '7');
+    lens.setAttribute('cy', '7');
+    lens.setAttribute('r', '4.25');
+    svg.appendChild(lens);
+  } else if (name === 'ellipsis') {
+    for (const cx of ['3.5', '8', '12.5']) {
+      const dot = document.createElementNS(NS, 'circle');
+      dot.setAttribute('cx', cx);
+      dot.setAttribute('cy', '8');
+      dot.setAttribute('r', '1.4');
+      dot.setAttribute('fill', 'currentColor');
+      dot.setAttribute('stroke', 'none');
+      svg.appendChild(dot);
+    }
+  }
+  return svg;
+}

--- a/src/osprey/interfaces/web_terminal/static/js/tile-header-contrib.js
+++ b/src/osprey/interfaces/web_terminal/static/js/tile-header-contrib.js
@@ -18,10 +18,12 @@
  * claimed in the payload, so one panel cannot inject controls into another
  * tile's bar. All rendering uses textContent (no innerHTML).
  *
- * Narrow tiles: text items ellipsize via CSS first; when the region still
- * overflows, whole items are hidden lowest-priority-first (re-measured on
- * every render and host resize). A panel may also contribute its own `menu`
- * item; the bar itself still has no overflow menu — curated bars are sparse.
+ * Narrow tiles run an overflow LADDER (re-measured on every render and host
+ * resize) in which nothing silently vanishes: text ellipsizes via CSS, then
+ * a search field collapses to its magnifier (click/Enter re-expands it while
+ * focused), then remaining controls fold lowest-priority-first into a
+ * bar-owned ⋯ menu that keeps every folded control reachable. Text
+ * (subtitle) and search never fold — text truncates, search collapses.
  *
  * Rendering is a keyed reconcile, not a rebuild. Items are matched on
  * `kind:id`; a survivor is patched in place and never detached, because a
@@ -30,7 +32,8 @@
  */
 
 import { sendHeaderActionToIframe } from './panel-iframe-sync.js';
-import { createItem, disposeItem, patchItem } from './tile-header-items.js';
+import { createItem, disposeItem, patchItem, toggleOverflowMenu } from './tile-header-items.js';
+import { svgIcon } from './svg-icons.js';
 
 /** Hard caps so a misbehaving panel cannot flood the bar. */
 const MAX_ITEMS = 12;
@@ -187,10 +190,47 @@ function clip(s) {
  */
 export function registerContribHost(panelId, host) {
   hosts.set(panelId, host);
+  // A collapsed search expands (and re-collapses on blur) via delegation on
+  // the host: the wrap elements come and go with every reconcile, while the
+  // host lives as long as its TileTab — one listener each, never stacked.
+  host.addEventListener('click', (e) => {
+    const wrap = e.target instanceof Element ? e.target.closest('.contrib-search-collapsed') : null;
+    if (wrap instanceof HTMLElement) expandSearch(wrap);
+  });
+  host.addEventListener('keydown', (e) => {
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    const wrap = e.target instanceof Element ? e.target.closest('.contrib-search-collapsed') : null;
+    if (wrap instanceof HTMLElement) {
+      e.preventDefault();
+      expandSearch(wrap);
+    }
+  });
+  host.addEventListener('focusout', (e) => {
+    const wrap = e.target instanceof Element ? e.target.closest('.contrib-search') : null;
+    if (wrap instanceof HTMLElement && wrap.dataset.searchPinned) {
+      delete wrap.dataset.searchPinned;
+      applyOverflowLadder(panelId, host);
+    }
+  });
   render(panelId, host);
-  const ro = new ResizeObserver(() => applyPriorityHide(host));
+  const ro = new ResizeObserver(() => applyOverflowLadder(panelId, host));
   ro.observe(host);
   observers.set(panelId, ro);
+}
+
+/**
+ * Re-open a ladder-collapsed search for typing. The pin keeps the ladder from
+ * re-collapsing it underneath the caret (the expansion itself re-triggers
+ * measurement); focusout unpins and re-runs the ladder.
+ * @param {HTMLElement} wrap
+ */
+function expandSearch(wrap) {
+  wrap.dataset.searchPinned = '1';
+  wrap.classList.remove('contrib-search-collapsed');
+  wrap.removeAttribute('role');
+  wrap.removeAttribute('tabindex');
+  wrap.removeAttribute('aria-label');
+  wrap.querySelector('input')?.focus();
 }
 
 /**
@@ -259,7 +299,7 @@ function render(panelId, host) {
     else host.insertBefore(el, ref);
   }
 
-  applyPriorityHide(host);
+  applyOverflowLadder(panelId, host);
 }
 
 /**
@@ -272,18 +312,138 @@ function dispatchAction(panelId, id, value) {
 }
 
 /**
- * Hide lowest-priority items until the region no longer overflows. Reveals
- * everything first so a widened tile gets its items back.
+ * The overflow ladder: reset to the full arrangement (so a widened tile gets
+ * everything back), then give way in identity-preserving order —
+ *
+ *   1. the search field collapses to its magnifier (still clickable; the
+ *      pin set by expandSearch exempts one being typed in), then
+ *   2. remaining CONTROLS fold lowest-priority-first into a bar-owned
+ *      ⋯ menu, so nothing becomes unreachable on a narrow tile.
+ *
+ * Text (subtitle) never folds — it truncates via CSS — and search never
+ * folds past its magnifier. The ⋯ button is appended before the fold loop
+ * measures, so the space it consumes is part of what the loop solves for.
+ * @param {string} panelId
  * @param {HTMLElement} host
  */
-function applyPriorityHide(host) {
+function applyOverflowLadder(panelId, host) {
+  const prev = host.querySelector('.contrib-overflow-btn');
+  if (prev instanceof HTMLElement) {
+    disposeItem(prev); // closes the popover if it is the open one
+    prev.remove();
+  }
   const children = /** @type {HTMLElement[]} */ ([...host.children]);
-  for (const c of children) c.classList.remove('contrib-hidden');
-  const byPriority = [...children].sort(
+  for (const c of children) {
+    c.classList.remove('contrib-hidden');
+    if (c.classList.contains('contrib-search') && !c.dataset.searchPinned) {
+      c.classList.remove('contrib-search-collapsed');
+      c.removeAttribute('role');
+      c.removeAttribute('tabindex');
+      c.removeAttribute('aria-label');
+    }
+  }
+
+  const crowded = () => host.scrollWidth > host.clientWidth + 1;
+  if (!crowded()) return;
+
+  const search = children.find(
+    (c) => c.classList.contains('contrib-search') && !c.dataset.searchPinned
+  );
+  if (search) {
+    search.classList.add('contrib-search-collapsed');
+    // Collapsed, the wrap is itself the "open search" control.
+    search.setAttribute('role', 'button');
+    search.setAttribute('tabindex', '0');
+    search.setAttribute('aria-label', search.querySelector('input')?.placeholder || 'Search');
+    if (!crowded()) return;
+  }
+
+  const foldable = children.filter(
+    (c) =>
+      c.dataset.contribKey &&
+      !c.classList.contains('contrib-search') &&
+      !c.classList.contains('contrib-text')
+  );
+  if (!foldable.length) return;
+
+  const btn = buildOverflowButton(panelId);
+  host.appendChild(btn);
+  const byPriority = [...foldable].sort(
     (a, b) => Number(a.dataset.priority) - Number(b.dataset.priority)
   );
+  /** @type {string[]} */
+  const foldedKeys = [];
   for (const victim of byPriority) {
-    if (host.scrollWidth <= host.clientWidth) break;
+    if (!crowded()) break;
     victim.classList.add('contrib-hidden');
+    if (victim.dataset.contribKey) foldedKeys.push(victim.dataset.contribKey);
   }
+  if (!foldedKeys.length) {
+    btn.remove();
+    return;
+  }
+  btn.dataset.foldedKeys = foldedKeys.join('\n');
+}
+
+/**
+ * The bar-owned ⋯ button holding whatever the fold loop took. Rows are
+ * derived at CLICK time from the panel's current contribution, so a
+ * re-contribution between fold and click can never show stale entries.
+ * @param {string} panelId
+ * @returns {HTMLButtonElement}
+ */
+function buildOverflowButton(panelId) {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'contrib-menu-btn contrib-overflow-btn';
+  btn.appendChild(svgIcon('ellipsis'));
+  btn.title = 'More controls';
+  btn.setAttribute('aria-label', 'More controls');
+  btn.setAttribute('aria-haspopup', 'menu');
+  btn.setAttribute('aria-expanded', 'false');
+  btn.addEventListener('click', () => {
+    const keys = btn.dataset.foldedKeys ? btn.dataset.foldedKeys.split('\n') : [];
+    toggleOverflowMenu(btn, overflowRows(panelId, keys));
+  });
+  return btn;
+}
+
+/**
+ * Flatten the folded controls into menu rows. A folded button is one row; a
+ * folded nav contributes a row per view (active = checked); a folded menu's
+ * entries are inlined. Each row dispatches exactly what the unfolded control
+ * would have.
+ * @param {string} panelId
+ * @param {string[]} keys  contribKeys (`kind:id`) in folded order
+ * @returns {import('./tile-header-items.js').OverflowRow[]}
+ */
+function overflowRows(panelId, keys) {
+  const items = contributions.get(panelId) ?? [];
+  /** @type {import('./tile-header-items.js').OverflowRow[]} */
+  const rows = [];
+  for (const key of keys) {
+    const item = /** @type {any} */ (items.find((it) => `${it.kind}:${it.id}` === key));
+    if (!item) continue;
+    if (item.kind === 'button') {
+      rows.push({
+        label: item.label ?? item.id,
+        disabled: item.disabled === true,
+        pick: () => dispatchAction(panelId, item.id),
+      });
+    } else if (item.kind === 'nav' || item.kind === 'menu') {
+      for (const entry of item.items ?? []) {
+        rows.push({
+          label: entry.label,
+          ...(item.kind === 'nav'
+            ? { checked: entry.active === true }
+            : typeof entry.checked === 'boolean'
+              ? { checked: entry.checked }
+              : {}),
+          disabled: entry.disabled === true,
+          pick: () => dispatchAction(panelId, item.id, entry.id),
+        });
+      }
+    }
+  }
+  return rows;
 }

--- a/src/osprey/interfaces/web_terminal/static/js/tile-header-items.js
+++ b/src/osprey/interfaces/web_terminal/static/js/tile-header-items.js
@@ -19,14 +19,10 @@
  * All text reaches the DOM via textContent. Nothing here interpolates markup.
  */
 
+import { svgIcon } from './svg-icons.js';
+
 /** Debounce before a search item reports its text back to the panel. */
 const SEARCH_DEBOUNCE_MS = 200;
-
-/** ⋯ — the overflow-menu glyph. */
-const MENU_GLYPH = '⋯';
-
-/** 🔍 — the same magnifier the hub's own command-palette trigger uses. */
-const SEARCH_GLYPH = '\u{1F50D}';
 
 /**
  * @typedef {import('/design-system/js/header-contrib.js').HeaderItem} HeaderItem
@@ -158,7 +154,7 @@ function buildSearch(item, dispatch) {
   const icon = document.createElement('span');
   icon.className = 'contrib-search-icon';
   icon.setAttribute('aria-hidden', 'true');
-  icon.textContent = SEARCH_GLYPH;
+  icon.appendChild(svgIcon('search'));
 
   const input = document.createElement('input');
   input.type = 'search';
@@ -204,7 +200,7 @@ function buildMenu(item, dispatch) {
   const btn = document.createElement('button');
   btn.type = 'button';
   btn.className = 'contrib-menu-btn';
-  btn.textContent = MENU_GLYPH;
+  btn.appendChild(svgIcon('ellipsis'));
   btn.setAttribute('aria-haspopup', 'menu');
   btn.setAttribute('aria-expanded', 'false');
   const label = item.label || 'More options';

--- a/src/osprey/interfaces/web_terminal/static/js/tile-header-items.js
+++ b/src/osprey/interfaces/web_terminal/static/js/tile-header-items.js
@@ -4,7 +4,9 @@
  * Creates and patches the DOM for one contributed item. Split out of
  * tile-header-contrib.js, which keeps the message plumbing, the per-panel
  * store and the reconcile pass; this module knows only how a single item of
- * each kind looks and behaves. The item vocabulary itself is documented once,
+ * each kind looks and behaves, plus the shared body-level popover both menu
+ * kinds ride (a contributed ⋯ menu and the overflow ladder's fold target —
+ * see toggleOverflowMenu). The item vocabulary itself is documented once,
  * on the panel side: design_system/static/js/header-contrib.js.
  *
  * Create vs. patch matters more than it looks. A contribution is a whole
@@ -274,21 +276,17 @@ function patchNav(item, nav) {
  * scroll/resize close rather than a reposition loop. */
 
 /**
+ * Open an empty popover anchored to btn and register it as THE open menu
+ * (there is at most one, shared by contributed menus and the bar's own
+ * overflow menu). The caller fills in rows and click handling.
  * @param {HTMLElement} btn
- * @param {Dispatch} dispatch
+ * @returns {HTMLElement} the popover element
  */
-function openMenuFor(btn, dispatch) {
+function openPopover(btn) {
   closeMenu();
   const pop = document.createElement('div');
   pop.className = 'contrib-menu-popover';
   pop.setAttribute('role', 'menu');
-  pop.addEventListener('click', (e) => {
-    const row = e.target instanceof Element ? e.target.closest('.contrib-menu-item') : null;
-    if (!(row instanceof HTMLElement) || !row.dataset.entryId) return;
-    const id = /** @type {HeaderItem} */ (itemState.get(btn))?.id;
-    closeMenu();
-    if (id) dispatch(id, row.dataset.entryId);
-  });
   document.body.appendChild(pop);
 
   const onDocDown = (/** @type {Event} */ e) => {
@@ -316,7 +314,58 @@ function openMenuFor(btn, dispatch) {
     },
   };
   btn.setAttribute('aria-expanded', 'true');
+  return pop;
+}
+
+/**
+ * @param {HTMLElement} btn
+ * @param {Dispatch} dispatch
+ */
+function openMenuFor(btn, dispatch) {
+  const pop = openPopover(btn);
+  pop.addEventListener('click', (e) => {
+    const row = e.target instanceof Element ? e.target.closest('.contrib-menu-item') : null;
+    if (!(row instanceof HTMLElement) || !row.dataset.entryId) return;
+    const id = /** @type {HeaderItem} */ (itemState.get(btn))?.id;
+    closeMenu();
+    if (id) dispatch(id, row.dataset.entryId);
+  });
   renderMenuRows(btn);
+  place(pop, btn);
+}
+
+/**
+ * One row of the bar's overflow menu — a control the overflow ladder folded
+ * out of a narrow bar, carrying its own pick action.
+ * @typedef {object} OverflowRow
+ * @property {string} label
+ * @property {boolean} [checked]
+ * @property {boolean} [disabled]
+ * @property {() => void} pick
+ */
+
+/**
+ * Toggle the bar-owned overflow menu (tile-header-contrib.js's fold target).
+ * One-shot rows: a re-render of the bar rebuilds the fold set, so the open
+ * popover is simply closed by disposeItem/closeMenu rather than re-rendered
+ * the way a contributed menu is.
+ * @param {HTMLElement} btn
+ * @param {OverflowRow[]} rows
+ */
+export function toggleOverflowMenu(btn, rows) {
+  if (openMenu && openMenu.btn === btn) {
+    closeMenu();
+    return;
+  }
+  const pop = openPopover(btn);
+  pop.replaceChildren(...rows.map((row) => {
+    const el = rowElement(row.label, row.checked, row.disabled === true);
+    el.addEventListener('click', () => {
+      closeMenu();
+      row.pick();
+    });
+    return el;
+  }));
   place(pop, btn);
 }
 
@@ -332,30 +381,41 @@ function renderMenuRows(btn) {
   );
   openMenu.pop.replaceChildren(
     ...entries.map((entry) => {
-      const row = document.createElement('button');
-      row.type = 'button';
-      row.className = 'contrib-menu-item';
+      const row = rowElement(entry.label, entry.checked, entry.disabled === true);
       row.dataset.entryId = entry.id;
-      row.disabled = entry.disabled === true;
-      // A checkable entry keeps its checkbox role so the state is announced;
-      // a plain action must not claim one.
-      if (entry.checked === undefined) {
-        row.setAttribute('role', 'menuitem');
-      } else {
-        row.setAttribute('role', 'menuitemcheckbox');
-        row.setAttribute('aria-checked', entry.checked ? 'true' : 'false');
-        row.classList.toggle('checked', entry.checked);
-      }
-      const tick = document.createElement('span');
-      tick.className = 'contrib-menu-tick';
-      tick.setAttribute('aria-hidden', 'true');
-      tick.textContent = entry.checked ? '✓' : '';
-      const text = document.createElement('span');
-      text.textContent = entry.label;
-      row.append(tick, text);
       return row;
     })
   );
+}
+
+/**
+ * Build one popover row: tick gutter + label, with the checkbox role only
+ * when the entry is actually checkable — a plain action must not claim one.
+ * @param {string} label
+ * @param {boolean | undefined} checked
+ * @param {boolean} disabled
+ * @returns {HTMLButtonElement}
+ */
+function rowElement(label, checked, disabled) {
+  const row = document.createElement('button');
+  row.type = 'button';
+  row.className = 'contrib-menu-item';
+  row.disabled = disabled;
+  if (checked === undefined) {
+    row.setAttribute('role', 'menuitem');
+  } else {
+    row.setAttribute('role', 'menuitemcheckbox');
+    row.setAttribute('aria-checked', checked ? 'true' : 'false');
+    row.classList.toggle('checked', checked);
+  }
+  const tick = document.createElement('span');
+  tick.className = 'contrib-menu-tick';
+  tick.setAttribute('aria-hidden', 'true');
+  tick.textContent = checked ? '✓' : '';
+  const text = document.createElement('span');
+  text.textContent = label;
+  row.append(tick, text);
+  return row;
 }
 
 /**

--- a/tests/interfaces/web_terminal/js/tile-header-contrib.test.js
+++ b/tests/interfaces/web_terminal/js/tile-header-contrib.test.js
@@ -307,6 +307,183 @@ describe('action round-trip', () => {
   });
 });
 
+describe('overflow ladder', () => {
+  /**
+   * happy-dom does no layout, so crowding is mocked: clientWidth is fixed and
+   * scrollWidth derives from the currently-VISIBLE children at deterministic
+   * per-kind widths. Folding/collapsing therefore changes the measurement,
+   * which is exactly the feedback loop the ladder runs on.
+   * @param {HTMLElement} host
+   * @param {number} clientWidth
+   */
+  function mockCrowding(host, clientWidth) {
+    Object.defineProperty(host, 'clientWidth', { value: clientWidth, configurable: true });
+    Object.defineProperty(host, 'scrollWidth', {
+      configurable: true,
+      get() {
+        let w = 0;
+        for (const el of host.children) {
+          if (el.classList.contains('contrib-hidden')) continue;
+          else if (el.classList.contains('contrib-search-collapsed')) w += 24;
+          else if (el.classList.contains('contrib-search')) w += 92;
+          else if (el.classList.contains('contrib-overflow-btn')) w += 24;
+          else if (el.classList.contains('contrib-text')) w += 40;
+          else w += 80;
+        }
+        return w;
+      },
+    });
+  }
+
+  test('a crowded bar collapses search to its magnifier before folding anything', () => {
+    const panelId = freshPanelId();
+    const { contentWindow } = addPanelIframe(panelId);
+    const host = document.createElement('div');
+    registerContribHost(panelId, host);
+    mockCrowding(host, 150); // search(92) + button(80) = 172 > 150; collapsed: 104 fits
+
+    deliverContribution(
+      [
+        { kind: 'search', id: 'filter', placeholder: 'Filter…' },
+        { kind: 'button', id: 'refresh', label: 'Refresh' },
+      ],
+      contentWindow
+    );
+
+    const search = host.querySelector('.contrib-search');
+    expect(search?.classList.contains('contrib-search-collapsed')).toBe(true);
+    expect(search?.getAttribute('role')).toBe('button');
+    expect(host.querySelector('.contrib-hidden')).toBeNull();
+    expect(host.querySelector('.contrib-overflow-btn')).toBeNull();
+  });
+
+  test('still-crowded controls fold lowest-priority-first into a bar ⋯ menu that round-trips', () => {
+    const panelId = freshPanelId();
+    const { contentWindow } = addPanelIframe(panelId);
+    const host = document.createElement('div');
+    document.body.appendChild(host); // popover positions off a real element
+    registerContribHost(panelId, host);
+    mockCrowding(host, 120); // nav(80) + button(80) = 160 > 120; fold nav: 80+24 fits
+
+    deliverContribution(
+      [
+        {
+          kind: 'nav',
+          id: 'view',
+          priority: 1,
+          items: [
+            { id: 'browse', label: 'Browse', active: true },
+            { id: 'edit', label: 'Edit' },
+          ],
+        },
+        { kind: 'button', id: 'refresh', label: 'Refresh', priority: 5 },
+      ],
+      contentWindow
+    );
+
+    // The lower-priority nav folded; the button stayed; the ⋯ appeared.
+    expect(host.querySelector('.contrib-nav')?.classList.contains('contrib-hidden')).toBe(true);
+    expect(host.querySelector('.contrib-btn')?.classList.contains('contrib-hidden')).toBe(false);
+    const more = /** @type {HTMLElement} */ (host.querySelector('.contrib-overflow-btn'));
+    expect(more).toBeTruthy();
+
+    // Open it: the folded nav appears as one row per view, active = checked.
+    more.dispatchEvent(new Event('click', { bubbles: true }));
+    const rows = [...document.querySelectorAll('.contrib-menu-item')];
+    expect(rows.map((r) => r.textContent)).toEqual(['✓Browse', 'Edit']);
+    expect(rows[0].getAttribute('aria-checked')).toBe('true');
+
+    // A row dispatches exactly what the unfolded control would have.
+    rows[1].dispatchEvent(new Event('click', { bubbles: true }));
+    expect(contentWindow.postMessage).toHaveBeenCalledWith(
+      { type: 'osprey-header-action', id: 'view', value: 'edit' },
+      window.location.origin
+    );
+    expect(document.querySelector('.contrib-menu-popover')).toBeNull();
+  });
+
+  test('subtitle text never folds — controls give way around it', () => {
+    const panelId = freshPanelId();
+    const { contentWindow } = addPanelIframe(panelId);
+    const host = document.createElement('div');
+    registerContribHost(panelId, host);
+    mockCrowding(host, 60); // text(40) + button(80) = 120 > 60
+
+    deliverContribution(
+      [
+        { kind: 'text', id: 'file', text: 'als_ring_v3.lat' },
+        { kind: 'button', id: 'refresh', label: 'Refresh' },
+      ],
+      contentWindow
+    );
+
+    expect(host.querySelector('.contrib-text')?.classList.contains('contrib-hidden')).toBe(false);
+    expect(host.querySelector('.contrib-btn')?.classList.contains('contrib-hidden')).toBe(true);
+    expect(host.querySelector('.contrib-overflow-btn')).toBeTruthy();
+  });
+
+  test('a widened tile gets everything back', () => {
+    const panelId = freshPanelId();
+    const { contentWindow } = addPanelIframe(panelId);
+    const host = document.createElement('div');
+    registerContribHost(panelId, host);
+    mockCrowding(host, 120);
+
+    const items = [
+      { kind: 'search', id: 'filter' },
+      { kind: 'button', id: 'refresh', label: 'Refresh' },
+      { kind: 'button', id: 'export', label: 'Export' },
+    ];
+    deliverContribution(items, contentWindow);
+    expect(host.querySelectorAll('.contrib-hidden').length).toBeGreaterThan(0);
+
+    mockCrowding(host, 1000);
+    deliverContribution(items, contentWindow);
+
+    expect(host.querySelectorAll('.contrib-hidden').length).toBe(0);
+    expect(host.querySelector('.contrib-overflow-btn')).toBeNull();
+    expect(host.querySelector('.contrib-search-collapsed')).toBeNull();
+  });
+
+  test('a collapsed search expands for typing on click and re-collapses on blur', () => {
+    const panelId = freshPanelId();
+    const { contentWindow } = addPanelIframe(panelId);
+    const host = document.createElement('div');
+    document.body.appendChild(host); // focus needs an attached element
+    registerContribHost(panelId, host);
+    mockCrowding(host, 100); // search alone: 92 fits, but with a button it collapses
+
+    deliverContribution(
+      [
+        { kind: 'search', id: 'filter', placeholder: 'Filter…' },
+        { kind: 'button', id: 'refresh', label: 'Refresh' },
+      ],
+      contentWindow
+    );
+    const wrap = /** @type {HTMLElement} */ (host.querySelector('.contrib-search'));
+    expect(wrap.classList.contains('contrib-search-collapsed')).toBe(true);
+
+    wrap.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    const input = /** @type {HTMLInputElement} */ (wrap.querySelector('input'));
+    expect(wrap.classList.contains('contrib-search-collapsed')).toBe(false);
+    expect(document.activeElement).toBe(input);
+
+    // While pinned open, a ladder re-run must not collapse it under the caret.
+    deliverContribution(
+      [
+        { kind: 'search', id: 'filter', placeholder: 'Filter…' },
+        { kind: 'button', id: 'refresh', label: 'Refresh' },
+      ],
+      contentWindow
+    );
+    expect(wrap.classList.contains('contrib-search-collapsed')).toBe(false);
+
+    input.blur();
+    input.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+    expect(wrap.classList.contains('contrib-search-collapsed')).toBe(true);
+  });
+});
+
 describe('host lifecycle', () => {
   test('a rebuilt tab re-renders from the cache; the stale host is dropped', () => {
     const panelId = freshPanelId();

--- a/tests/interfaces/web_terminal/js/tile-header-items.test.js
+++ b/tests/interfaces/web_terminal/js/tile-header-items.test.js
@@ -104,7 +104,9 @@ describe('search items', () => {
     expect(input).toBeTruthy();
     expect(input.placeholder).toBe('Filter plans…');
     expect(input.value).toBe('orm');
-    expect(host.querySelector('.contrib-search-icon')?.textContent).toBe('\u{1F50D}');
+    // The magnifier is an inline SVG on currentColor — not the old emoji,
+    // which rendered full-color on macOS/Windows.
+    expect(host.querySelector('.contrib-search-icon .bar-icon-search')).toBeTruthy();
   });
 
   test('report their text back to the panel, debounced to the trailing edge', () => {

--- a/tests/interfaces/web_terminal/test_panels_browser.py
+++ b/tests/interfaces/web_terminal/test_panels_browser.py
@@ -252,8 +252,9 @@ def _open_page(browser, base_url: str) -> Page:
 # Dock DOM helpers
 # ---------------------------------------------------------------------------
 #
-# Every tile renders the same header bar (dock-tab.js): drag grip, identity,
-# close. A service tile's identity is its visible .tile-tab-title, mirrored
+# Every tile renders the same header bar (dock-tab.js): identity on the left,
+# actions right-anchored (the bar itself is the drag handle — no grip badge).
+# A service tile's identity is its visible .tile-tab-title, mirrored
 # into the bar's aria-label and kept current through onDidTitleChange — the
 # aria-label is the stable handle these tests address tabs by.
 # The terminal tab is the one exception: it renders no aria-label — it adopts
@@ -804,9 +805,10 @@ def test_service_tile_close_button_is_local_vacate(tmp_path, chromium_browser):
     ) as (base_url, _app):
         page = _open_page(chromium_browser, base_url)
         _focus_service_panel(page, "data-viz", "DATA VIZ")
-        # The unified bar: grip + visible title + close (popout stays rail-only).
+        # The unified bar: visible title + close, no grip badge (popout stays
+        # rail-only).
         tab = _service_tab(page, "DATA VIZ")
-        expect(tab.locator(".tile-tab-grip")).to_have_count(1)
+        expect(tab.locator(".tile-tab-grip")).to_have_count(0)
         expect(tab.locator(".tile-tab-title")).to_have_text("DATA VIZ")
         expect(tab.locator(".tile-tab-close")).to_have_count(1)
         expect(tab.locator(".tile-tab-popout")).to_have_count(0)
@@ -1444,13 +1446,13 @@ def test_corrupt_stored_layout_falls_back_to_default(tmp_path, chromium_browser)
 
 
 def test_simple_mode_locks_layout_and_hides_close_controls(tmp_path, chromium_browser):
-    """Simple mode is a locked layout: no per-tab close/grip, and drag is a no-op.
+    """Simple mode is a locked layout: no per-tab close, and drag is a no-op.
 
-    The dock is api.locked with drag disabled and the per-tab close and drag-grip
-    controls (.tile-tab-close, .tile-tab-grip) hidden by the simple-mode CSS; a
-    service tile's strip collapses to nothing at all there, since a grip with
-    drag disabled is dead chrome. A Playwright drag of a tab leaves the
-    arrangement unchanged.
+    The dock is api.locked with drag disabled and the per-tab close control
+    (.tile-tab-close) hidden by the simple-mode CSS; a service tile's strip
+    collapses to nothing at all there, since a bar that can neither drag nor
+    close is dead chrome. A Playwright drag of a tab leaves the arrangement
+    unchanged.
     """
     workspace = tmp_path / "_agent_data"
     workspace.mkdir()
@@ -1469,12 +1471,11 @@ def test_simple_mode_locks_layout_and_hides_close_controls(tmp_path, chromium_br
         expect(page.locator("html")).to_have_attribute("data-ui-mode", "simple")
         page.wait_for_timeout(1_000)
 
-        # Locked, and no per-tab close or grip control is visible anywhere —
-        # neither on the single service tile the locked simple layout docks
-        # (per applySimpleLayout) nor on the terminal beside it.
+        # Locked, and no per-tab close control is visible anywhere — neither
+        # on the single service tile the locked simple layout docks (per
+        # applySimpleLayout) nor on the terminal beside it.
         assert _dock_locked(page) is True
         expect(page.locator(".dv-tab .tile-tab-close:visible")).to_have_count(0)
-        expect(page.locator(".dv-tab .tile-tab-grip:visible")).to_have_count(0)
         # The service tile's whole strip collapses; the terminal's stays, since
         # its bar is content (session id, "+ New") rather than a drag handle.
         assert _strip_height(page, terminal=False) == 0
@@ -2058,7 +2059,7 @@ def test_tile_bar_fixed_height_no_hover_reflow(tmp_path, chromium_browser):
     """Tile header bars never change height — hover must not reflow content.
 
     Replaces the retired collapse/reveal behavior. Every tile carries the same
-    fixed-height bar (grip + identity + close); hovering one (the old expand
+    fixed-height bar (identity + actions); hovering one (the old expand
     trigger) must leave the height and the content's top edge unmoved.
     """
     workspace = tmp_path / "_agent_data"
@@ -2094,10 +2095,10 @@ def test_tile_bar_fixed_height_no_hover_reflow(tmp_path, chromium_browser):
             == content_top
         ), "tile content shifted on hover"
 
-        # A service tile carries the unified bar: grip + visible title + close
-        # (popout stays a rail-entry affordance).
+        # A service tile carries the unified bar: visible title + close, no
+        # grip badge (popout stays a rail-entry affordance).
         ws = _service_tab(page, "WORKSPACE")
-        expect(ws.locator(".tile-tab-grip")).to_have_count(1)
+        expect(ws.locator(".tile-tab-grip")).to_have_count(0)
         expect(ws.locator(".tile-tab-title")).to_have_text("WORKSPACE")
         expect(ws.locator(".tile-tab-close")).to_have_count(1)
         expect(ws.locator(".tile-tab-popout")).to_have_count(0)

--- a/tests/interfaces/web_terminal/tile-tab.test.mjs
+++ b/tests/interfaces/web_terminal/tile-tab.test.mjs
@@ -1,8 +1,9 @@
 /**
  * Contract tests for the tile-tab renderer (dock-tab.js): the custom dockview
- * tab that IS each tile's header bar. Every tile gets the same bar — drag
- * grip, identity, close. Service tiles carry a visible `.tile-tab-title`;
- * the terminal tile adopts the live .terminal-header instead. Run:
+ * tab that IS each tile's header bar. Every tile gets the same bar — identity
+ * on the left, actions right-anchored; the bar itself is the drag handle.
+ * Service tiles carry a visible `.tile-tab-title`; the terminal tile adopts
+ * the live .terminal-header instead. Run:
  *   npx vitest run tests/interfaces/web_terminal/tile-tab.test.mjs
  */
 import { test, expect, describe, beforeEach, vi } from 'vitest';
@@ -24,17 +25,19 @@ describe('tile-tab renderer', () => {
     vi.restoreAllMocks();
   });
 
-  test('service tab renders grip, visible title, and close', async () => {
+  test('service tab renders visible title and close, no drag badge', async () => {
     const { createTileTab } = await import(MOD);
     const tab = createTileTab('iframe:ariel');
     tab.init({ title: 'ARIEL', params: {}, api: fakeApi() });
 
     expect(tab.element.classList.contains('tile-tab')).toBe(true);
-    expect(tab.element.querySelector('.tile-tab-grip')).toBeTruthy();
     // One header grammar for every tile: name on the bar, close on the bar.
     expect(tab.element.querySelector('.tile-tab-title')?.textContent).toBe('ARIEL');
     expect(tab.element.querySelector('.tile-tab-close')).toBeTruthy();
     expect(tab.element.querySelector('.tile-tab-actions')).toBeTruthy();
+    // Dragging by the bar is a learned convention — no grip badge spends
+    // bar pixels on it.
+    expect(tab.element.querySelector('.tile-tab-grip')).toBeNull();
     // Popout stays a rail-entry affordance — never on the tile.
     expect(tab.element.querySelector('.tile-tab-popout')).toBeNull();
   });
@@ -98,7 +101,7 @@ describe('tile-tab renderer', () => {
     const reachedRoot = vi.fn();
     tab.element.addEventListener('pointerdown', reachedRoot);
 
-    /** @type {HTMLElement} */ (tab.element.querySelector('.tile-tab-grip'))
+    /** @type {HTMLElement} */ (tab.element.querySelector('.tile-tab-title'))
       .dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, cancelable: true }));
     expect(reachedRoot).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Summary

Redesigns the web terminal's tile header bars around one structural repair and three deliberate design decisions.

**Structural** — a tile's lone tab was sized to its content, so most of each "bar" was dockview's void container painted a different color: a two-tone seam, a close control at a different x on every tile (off-viewport on narrow ones), and an overflow path that could never run. `singleTabMode: 'fullwidth'` plus `min-width: 0` on `.dv-tab` makes the bar span its tile, anchors close at the tile's right edge, and makes the responsive path reachable.

**Surface (seated chrome)** — the bar is one surface on `--bg-panel`, closed by a hairline that turns accent on the active tile; inactive tiles dim their name to secondary. The old `--bg-secondary` split sat 3/255 from the body in the dark theme, which is why the focused-tile signal was invisible.

**Control language** — one 24px ghost-button treatment replaces the five that coexisted; glyph/emoji icons (including the full-color magnifier emoji) become inline SVG strokes on currentColor. Tile names step up to display type at medium weight; the terminal's session label takes the same treatment (green LED, selector and "+ New" keep it recognizable). Contributed nav renders as a segmented control; inert `text` items render as the tile's subtitle beside its name. The six-dot grip is gone — the bar itself stays the drag handle.

**Overflow** — narrow tiles run an identity-preserving ladder instead of hiding controls: search collapses to its magnifier (click/Enter re-expands, pinned open while focused), then controls fold lowest-priority-first into a bar-owned ⋯ menu whose rows dispatch exactly what the unfolded controls would. Subtitles truncate but never fold; the tile name holds its width so controls give way before identity.

## Testing

- `vitest` unit suites updated and extended (5 new ladder tests mocking crowding); all web-terminal JS tests pass locally
- `tsc --noEmit`, `eslint` on touched modules, and the design-system hygiene scanner pass
- Playwright browser suite assertions updated for the removed grip; relying on CI for the browser lane