### PR TITLE
docs: describe the system as it is, not as a change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Changed
 
+- Generated deployment repos, bundled skills, agent instructions and the
+  documentation now describe the system as it is, rather than as a set of
+  differences from an earlier arrangement. Guidance for moving an existing
+  deployment onto the profile format is unchanged.
+
 - The control-assistant preset's two-user roster now ships alice as the
   write-capable operator and bob as the read-only viewer. The tiers differ
   visibly, not just in enforcement: the write-armed terminal keeps the full

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 [![License: BSD 3-Clause](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](LICENSE.txt)
 [![DOI](https://img.shields.io/badge/DOI-10.1063%2F5.0306302-blue)](https://doi.org/10.1063/5.0306302)
 
-**An agentic interface and safety harness for safety-critical control systems.**
+**An agentic interface to scientific control systems.**
 
 Osprey addresses control-specific challenges: semantic addressing across large channel
-namespaces, protocol-agnostic integration with control stacks, intelligent logbook search
+namespaces, protocol-agnostic integration with control stacks, logbook search
 across facility electronic logbooks, and mandatory human oversight for every hardware write.
 
 Built for particle accelerators, fusion experiments, beamlines, and large scientific facilities.

--- a/docs/source/how-to/add-connector.rst
+++ b/docs/source/how-to/add-connector.rst
@@ -360,11 +360,10 @@ to ``float64``, since there is no data to infer a dtype from).
 channel contributes only its own real samples -- never forward-filled, never
 reindexed onto a regular grid, never padded with a row for a bin or timestamp
 nothing was actually recorded at. A channel with no data in the requested range
-simply contributes no rows; it does not appear as an all-NaN column the way the old
-wide, shared-index format required. Every connector correctness bug this contract
-replaced traced back to violating this rule, so hold to it strictly: if a custom
-connector finds itself building a shared ``DatetimeIndex`` and reindexing per-channel
-series onto it, that is the bug.
+simply contributes no rows; it never appears as an all-NaN column. Connector
+correctness bugs trace back to violating this rule, so hold to it strictly: if a
+custom connector finds itself building a shared ``DatetimeIndex`` and reindexing
+per-channel series onto it, that is the bug.
 
 **Per-channel aggregation.** ``get_data`` takes a trailing ``processing: str =
 "raw"`` keyword -- one of ``raw``, ``mean``, ``min``, ``max``, ``median``, ``std``,
@@ -374,7 +373,7 @@ channels and never onto a shared grid:
 - ``raw`` decimates each ``precision_ms`` bin down to its **last real sample**,
   keeping that sample's own true timestamp -- never a timestamp invented at the
   bin's edge to hold it. This matches the EPICS Archiver Appliance's long-standing
-  ``lastSample_N`` semantics, and every in-tree backend now applies it the same way.
+  ``lastSample_N`` semantics, and every in-tree backend applies it the same way.
 - Every other mode aggregates the real samples that landed in each ``precision_ms``
   bin. A bin with no samples is dropped, not emitted as ``NaN`` -- so a sparse
   channel returns *fewer* rows than it has samples, never more, and no bin-width

--- a/docs/source/how-to/build-profiles.rst
+++ b/docs/source/how-to/build-profiles.rst
@@ -526,11 +526,11 @@ The write-back is **append-only**. A key already in the profile keeps its value 
 it is pinned by the docker volume that was initialized with it — and a value that
 disagrees is reported by name (never by value) for you to resolve by hand.
 
-If the profile cannot be reached — it has moved, or the project was built before
-this mechanism existed — the deploy still works. The secrets stay in the project
-``.env``, a warning names the path that failed, and the project records that its
-``.env`` is the only copy. A later ``osprey build`` repeats that warning
-before touching the directory.
+If the profile cannot be reached — it has moved or been deleted, or the project
+names none — the deploy still works. The secrets stay in the project ``.env``, a
+warning names the path that failed, and the project records that its ``.env`` is
+the only copy. A later ``osprey build`` repeats that warning before touching the
+directory.
 
 
 Profile YAML reference
@@ -1278,7 +1278,7 @@ one exists.
 error: a directory in the profile that nothing copies. Usually a typo of a
 convention directory name.
 
-**"Unknown profile key(s): 'overlay'"** — profiles no longer have an overlay
+**"Unknown profile key(s): 'overlay'"** — a profile has no ``overlay``
 section. Move the files into the convention directory that matches what they
 are (see the table above), or into ``project/`` for anything without one.
 

--- a/docs/source/how-to/deploy-project.rst
+++ b/docs/source/how-to/deploy-project.rst
@@ -325,11 +325,10 @@ own value disagrees says so by variable name (never by value) and keeps using
 its own, leaving you to reconcile the two.
 
 If the profile cannot be reached — it has moved or been deleted, or the project
-was built before this mechanism existed — the deploy still succeeds. The secrets
-stay in the project ``.env``, a warning names the path that failed, and the
-project records that its ``.env`` is the only copy; a later
-``osprey build`` repeats that warning before it touches the directory.
-Back that file up.
+names none — the deploy still succeeds. The secrets stay in the project
+``.env``, a warning names the path that failed, and the project records that its
+``.env`` is the only copy; a later ``osprey build`` repeats that warning before
+it touches the directory. Back that file up.
 
 Keep both ``.env`` files out of version control (the profile's ``.gitignore``
 does this for you).

--- a/docs/source/how-to/monitor-agent.rst
+++ b/docs/source/how-to/monitor-agent.rst
@@ -110,7 +110,7 @@ stays on the deploy host.
 1. Check the service is enabled
 -------------------------------
 
-New projects ship with the ``openobserve`` service already declared in
+Projects ship with the ``openobserve`` service already declared in
 ``config.yml`` **and** listed under ``deployed_services`` — it deploys by
 default. If your project removed it, restore it:
 

--- a/docs/source/how-to/multi-user.rst
+++ b/docs/source/how-to/multi-user.rst
@@ -13,7 +13,7 @@ host, brought up with a single ``osprey up``.
    :color: primary
    :icon: book
 
-   - Why the single-user ``osprey web`` workflow is unchanged, and when each
+   - How it sits beside the single-user ``osprey web`` workflow, and when each
      mode is the right tool
    - The three ideas behind the multi-user stack: one container per user,
      personas as capability tiers, and one nginx front door
@@ -28,28 +28,27 @@ host, brought up with a single ``osprey up``.
    want Docker (or Podman) and your model-provider credentials — the
    ``control-assistant`` preset ships the whole block pre-wired.
 
-Single-user is still the front door
-===================================
+Single-user is the front door
+=============================
 
-Nothing about multi-user changes the everyday workflow. From any project
-directory,
+The everyday workflow stands on its own. From any project directory,
 
 .. code-block:: bash
 
    osprey web
 
-still launches the single-user Web Terminal as one local process — no
-containers, no proxy, ready in seconds at ``http://127.0.0.1:8087``. It remains
-the fastest way to try OSPREY and the right tool whenever one person sits in
-front of one machine; :doc:`web-terminal/operate` covers it.
+launches the single-user Web Terminal as one local process — no containers, no
+proxy, ready in seconds at ``http://127.0.0.1:8087``. It is the fastest way to
+try OSPREY and the right tool whenever one person sits in front of one machine;
+:doc:`web-terminal/operate` covers it.
 
 The multi-user stack is strictly opt-in. It lives in a
 ``modules.web_terminals`` block in the deployment's built ``config.yml``, read
 only by the lifecycle verbs (and validated by
 ``osprey scaffold web-terminals lint``).
 ``osprey web`` never looks at it — so a project that carries the block (the
-``control-assistant`` preset ships one) still runs single-user exactly as
-before. Reach for the multi-user stack when several people need their own
+``control-assistant`` preset ships one) runs single-user exactly like one that
+does not. Reach for the multi-user stack when several people need their own
 terminal on a shared machine, and stay with ``osprey web`` for everything else.
 
 How it works

--- a/docs/source/how-to/use-python-executor.rst
+++ b/docs/source/how-to/use-python-executor.rst
@@ -83,7 +83,7 @@ Where Code Runs
 ===============
 
 Agent-authored Python runs as a subprocess on the same host as the Osprey
-agent. This is the only execution backend, so there is nothing to choose
+agent. It is the only execution backend, so there is nothing to choose
 between:
 
 .. code-block:: yaml
@@ -92,11 +92,11 @@ between:
    execution:
      execution_method: subprocess
 
-``subprocess`` is the default and the key can be left out entirely. Two older
-values still load, so existing projects keep working: ``local`` is the former
-name for this same backend and is accepted silently, and ``container`` is
-treated as ``subprocess`` and logs a one-time warning naming the config file it
-came from. Any other value is a configuration error.
+``subprocess`` is the default and the key can be left out entirely. Two other
+spellings load: ``local`` is an alias for this same backend and is accepted
+silently, and ``container`` is treated as ``subprocess`` and logs a one-time
+warning naming the config file it came from. Any other value is a
+configuration error.
 
 The ``ExecutionWrapper`` wraps user code with safety monkeypatches (e.g.
 ``epics.caput()`` validation against the limits database), writes the wrapped

--- a/docs/source/how-to/use-virtual-accelerator.rst
+++ b/docs/source/how-to/use-virtual-accelerator.rst
@@ -74,8 +74,8 @@ builds its container image from source (compiling PyAT and the soft-IOC), so
 expect it to take several minutes — it is building, not hanging. Later deploys
 reuse the image.
 
-If your deployment came from an older preset (or a profile that sets it),
-point it at the soft-IOC explicitly:
+If your deployment came from a preset or profile that selects a different
+connector, point it at the soft-IOC explicitly:
 
 .. code-block:: bash
 

--- a/docs/source/how-to/web-terminal/panels.rst
+++ b/docs/source/how-to/web-terminal/panels.rst
@@ -21,12 +21,11 @@ Where the panel rail lives
 --------------------------
 
 Open panels line up in the **panel rail**, which sits along the left edge by
-default. If your team prefers the panel buttons along the top — where the
-tabs lived before the redesign — set ``web.rail_position: top`` in
-``config.yml``, or switch from the panel ``+`` menu (or the command palette)
-at any time. The choice is remembered per browser, and each user's own pick
-wins over the configured default. (For the full pre-redesign appearance, pair
-this with the retro theme — see :doc:`theming`.)
+default. If your team prefers the panel buttons along the top, set
+``web.rail_position: top`` in ``config.yml``, or switch from the panel ``+``
+menu (or the command palette) at any time. The choice is remembered per
+browser, and each user's own pick wins over the configured default. (Pair it
+with the retro theme for a navy-and-teal terminal — see :doc:`theming`.)
 
 Panels backed by a URL
 ----------------------

--- a/docs/source/how-to/web-terminal/theming.rst
+++ b/docs/source/how-to/web-terminal/theming.rst
@@ -29,8 +29,8 @@ Themes come in **families**. OSPREY ships four:
 - **desy** — the DESY corporate palette, in light and dark.
 - **high-contrast** — a stronger-contrast family for accessibility, also in
   light and dark.
-- **retro** — the navy-and-teal look of the pre-redesign web terminal,
-  kept for teams who prefer the familiar appearance.
+- **retro** — a navy-and-teal family, in light and dark, for teams who
+  prefer that look.
 
 In the terminal, click the sliders button at the top right to open the
 display menu — it holds the light/dark switch, the Expert/Simple view toggle,
@@ -99,17 +99,17 @@ The landing page that lists everyone's terminals uses the deployment-wide
 ``web.theme``. It is shown before anyone has said who they are, so there is no
 personal setting to apply yet.
 
-Restoring the pre-redesign look
--------------------------------
+A navy-and-teal terminal
+------------------------
 
-Deployments upgrading from the pre-redesign web terminal can bring back the
-familiar appearance with two settings in ``config.yml``:
+Two settings in ``config.yml`` give the terminal a navy-and-teal look with its
+panel buttons along the top:
 
 .. code-block:: yaml
 
    web:
-     theme: retro            # the original navy/teal palette
-     rail_position: top      # panel buttons along the top, like the old tabs
+     theme: retro            # the navy/teal palette
+     rail_position: top      # panel buttons along the top
 
 Each user can still override both from the interface: the theme from the
 theme switcher in the header, and the rail position from the panel "+" menu.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,11 +1,11 @@
 Osprey Framework Documentation
 ================================
 
-**An agentic interface and safety harness for safety-critical control systems.**
+**An agentic interface to scientific control systems.**
 
 The **Osprey Framework** is an agentic interface and harness for scientific facilities managing complex technical infrastructure — particle accelerators, fusion experiments, beamlines, and large telescopes. It wraps a coding agent in an operator-facing safety policy, a hook-based approval chain, and an MCP-server multiplexer, so the agent layer, the underlying LLM, and the compute backend are each replaceable without changing what the operator sees. The current reference implementation is a browser-based operator workstation; other surfaces (control-room consoles, chat clients, headless services) are possible.
 
-Osprey addresses control-specific challenges: semantic addressing across large channel namespaces, :doc:`protocol-agnostic integration with control stacks <how-to/add-connector>` (EPICS and Mock ship in-tree; LabVIEW, Tango, and other stacks are supported via custom connectors), :doc:`intelligent logbook search <how-to/ariel/index>` across facility electronic logbooks, and mandatory human oversight for safety-critical operations.
+Osprey addresses control-specific challenges: semantic addressing across large channel namespaces, :doc:`protocol-agnostic integration with control stacks <how-to/add-connector>` (EPICS and Mock ship in-tree; LabVIEW, Tango, and other stacks are supported via custom connectors), :doc:`logbook search <how-to/ariel/index>` across facility electronic logbooks, and mandatory human oversight for safety-critical operations.
 
 .. figure:: _static/resources/architecture.png
    :alt: Osprey system architecture — from operator to facility, with the safety gate and approval workflow in-line.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "osprey-framework"
 dynamic = ["version"]
-description = "An agentic interface and safety harness for safety-critical control systems"
+description = "An agentic interface to scientific control systems"
 readme = "README.md"
 requires-python = ">=3.11"
 license = {text = "BSD-3-Clause"}

--- a/src/osprey/agent_runner/project_paths.py
+++ b/src/osprey/agent_runner/project_paths.py
@@ -14,8 +14,8 @@ from pathlib import Path
 
 # Claude Code derives the per-project transcript/memory directory name by
 # replacing every non-alphanumeric character of the absolute cwd with '-'.
-# Replacing only '/' (the old rule) is wrong for any path containing '_' or
-# other special characters — Claude writes to one dir and we look in another,
+# Every special character counts, not just '/': a path containing '_' that
+# normalizes only its slashes names a different directory than Claude writes to,
 # producing silent false-negative reads of transcripts, memory, and sessions.
 _CLAUDE_PROJECT_DIR_NORMALIZE = re.compile(r"[^A-Za-z0-9-]")
 

--- a/src/osprey/agent_runner/verdict.py
+++ b/src/osprey/agent_runner/verdict.py
@@ -6,10 +6,10 @@ Translates the structured ``SDKWorkflowResult`` into one of two exit codes:
   completed without error, and no budget or turn-limit was exceeded.
 * ``EXIT_VERDICT_FAIL`` (1) — any of those conditions is not met.
 
-The third constant, ``EXIT_USAGE`` (2), is reserved for the CLI layer
-(Task 2.1) to report infrastructure or usage errors that prevented the run
-from starting at all.  It lives here so callers can import all three
-constants from a single module.
+The third constant, ``EXIT_USAGE`` (2), is reserved for the CLI layer to
+report infrastructure or usage errors that prevented the run from starting at
+all.  It lives here so callers can import all three constants from a single
+module.
 """
 
 from __future__ import annotations

--- a/src/osprey/agent_runner/write_tools.py
+++ b/src/osprey/agent_runner/write_tools.py
@@ -258,8 +258,8 @@ def _custom_server_side_effect_tools(project_dir: Path) -> list[str]:
     ``.mcp.json`` from a previous build can still launch the server
     (``enableAllProjectMcpServers: true``), so an unresolvable spec must block
     the whole server rather than contribute nothing. A spec with NONE of
-    extends/command/url (legacy form ``phoebus2: {enabled: true}``) fails
-    closed the same way.
+    extends/command/url (e.g. ``phoebus2: {enabled: true}``) fails closed the
+    same way.
 
     Returns an empty list when ``config.yml`` is absent or unreadable.
     """
@@ -294,8 +294,8 @@ def _custom_server_side_effect_tools(project_dir: Path) -> list[str]:
                 out.extend(_extra_side_effect_tools_for(name, spec["extends"]))
             continue
         if not spec.get("command") and not spec.get("url"):
-            # NONE of extends/command/url (legacy form 'phoebus2: {enabled:
-            # true}'): resolve_servers skips such a spec, so it never renders
+            # NONE of extends/command/url (e.g. 'phoebus2: {enabled: true}'):
+            # resolve_servers skips such a spec, so it never renders
             # into .mcp.json — but a stale .mcp.json from a previous build can
             # still launch a server by this name. Fail closed exactly like the
             # unresolvable-extends path above: block the whole server.

--- a/src/osprey/bluesky_tool_names.py
+++ b/src/osprey/bluesky_tool_names.py
@@ -1,16 +1,15 @@
 """Single source of truth for Bluesky MCP tool names.
 
 The Bluesky safety wiring — kill-switch hook matchers, destructive-marker
-checks, and the registry permission allow/ask lists — historically string-
-matched tool names inline, with no shared vocabulary. Every rename was then a
-latent gate-detachment hazard: a tool could be renamed in its module while a
-matcher in ``registry/mcp.py`` still pointed at the old name, silently
-detaching a safety hook.
+checks, and the registry permission allow/ask lists — must never string-match
+tool names inline. Inline literals make every rename a latent gate-detachment
+hazard: a tool renamed in its module while a matcher in ``registry/mcp.py``
+still names the previous string silently detaches a safety hook.
 
-This leaf module holds every Bluesky tool name as registered today, so the
-registry gate wiring and the destructive-marker classifier can import symbols
-instead of repeating string literals. It imports nothing from ``osprey`` and is
-safe to import from ``mcp_server``, ``registry``, and ``agent_runner`` code.
+This leaf module holds every Bluesky tool name as registered, so the registry
+gate wiring and the destructive-marker classifier can import symbols instead of
+repeating string literals. It imports nothing from ``osprey`` and is safe to
+import from ``mcp_server``, ``registry``, and ``agent_runner`` code.
 
 Names here reflect the *current* registered surface. Renames are made here
 first (changing a single constant), then the consumers follow — keeping every

--- a/src/osprey/build/claude_code_resolver.py
+++ b/src/osprey/build/claude_code_resolver.py
@@ -271,9 +271,9 @@ def _load_dotenv(project_dir: Path) -> dict[str, str]:
     ``{}`` when the file is absent or ``python-dotenv`` is not importable. Pure:
     it never touches ``os.environ``, expands no ``${VAR}`` refs, and applies no
     secret or precedence logic — callers own the overlay, expansion, and auth
-    handling. Deduplicates the identical load formerly inlined in
-    :func:`inject_provider_env`, ``provider_env_for_project``, and
-    :func:`load_provider_spec`.
+    handling. The single load shared by :func:`inject_provider_env`,
+    ``provider_env_for_project``, and :func:`load_provider_spec`, so all three
+    see the same file the same way.
     """
     env_file = Path(project_dir) / ".env"
     if not env_file.is_file():
@@ -290,8 +290,8 @@ def _env_lookup(project_dir: Path) -> dict[str, str]:
 
     Never mutates global ``os.environ``. Shared by :func:`load_provider_spec`
     and ``osprey.agent_runner.primitives.provider_env_for_project`` — both need
-    this same merged view for ``${VAR}``/secret lookups, previously built via
-    an identical inline dict-merge in each.
+    this same merged view for ``${VAR}``/secret lookups, and must agree on the
+    precedence.
     """
     return {**os.environ, **_load_dotenv(project_dir)}
 
@@ -622,7 +622,7 @@ class ClaudeCodeModelResolver:
         Model ID resolution order (highest to lowest priority):
         1. ``claude_code.models`` per-tier overrides in config.yml
         2. ``api.providers[name].models`` — the provider's own model IDs
-        3. Built-in ``models`` in CLAUDE_CODE_PROVIDERS (backward compat)
+        3. Built-in ``models`` in CLAUDE_CODE_PROVIDERS (fallback)
 
         This means providers own their model naming: set models under
         ``api.providers`` and the framework picks them up automatically.
@@ -721,7 +721,7 @@ class ClaudeCodeModelResolver:
         # ── Build tier → model mapping ───────────────────────────
         # Priority: built-in fallback < api.providers models < claude_code.models
 
-        # Start with built-in fallbacks (backward compat for old configs)
+        # Start with built-in fallbacks (configs that map no models of their own)
         tier_to_model = dict(provider_def.get("models", {}))
 
         # Override with models defined in api.providers[name].models
@@ -738,9 +738,9 @@ class ClaudeCodeModelResolver:
                 tier_to_model[tier] = model_id
 
         # Every tier must resolve to a model ID the *configured* provider
-        # actually serves. Missing tiers used to be filled with Anthropic's own
-        # direct IDs, so a proxy that ships no map launched the agent asking it
-        # for "claude-opus-4-6" — a 404 if the proxy is strict, and silently the
+        # actually serves. Never fill a missing tier with Anthropic's own direct
+        # IDs: a proxy that ships no map would launch the agent asking it for
+        # "claude-opus-4-6" — a 404 if the proxy is strict, and silently the
         # wrong model if it is not. Refuse instead, before the env block or the
         # default tier are built from the map.
         missing = [tier for tier in TIER_MODEL_ENV_VARS if tier not in tier_to_model]

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -168,9 +168,7 @@ _STATE_DIRS: tuple[str, ...] = STATE_ZONE_DIRS
 
 #: Where the outgoing render's Claude Code artifacts are snapshotted before the
 #: swap replaces them — the durable zone, so the snapshot survives the wipe it
-#: exists to protect against. The shape is inherited from the retired ``osprey
-#: claude regen``, which wrote ``_agent_data/backup/claude-code-<stamp>/``;
-#: here it is re-anchored on ``var/``.
+#: exists to protect against.
 _BACKUP_RELDIR = f"{STATE_DIR_NAME}/agent_data/backup"
 
 #: The rendered files a Claude Code regeneration owns, relative to the render
@@ -327,11 +325,10 @@ def _prune_runtime_state_from_stage(zones: _RenderZones, *, renders: Sequence[Pa
     Nothing durable may live there, and ``rm -rf build/`` losing nothing is the
     property the whole zone layout rests on.
 
-    No renderer writes agent data into its own render any more — each of the
-    three that did was repointed at the repo's own ``var/agent_data`` or dropped
-    outright — so on a correct build this finds nothing and removes nothing.
-    It is kept as the invariant's enforcement point rather than retired with its
-    producers, because the failure it prevents is silent in both directions: a
+    No renderer writes agent data into its own render, so on a correct build
+    this finds nothing and removes nothing. It is kept as the invariant's
+    enforcement point rather than dropped as dead code, because the failure it
+    prevents is silent in both directions: a
     renderer that starts writing state under the tree it is rendering neither
     fails nor logs, and the state it wrote is deleted at the next build with
     nothing to say it existed. Stating the rule once, in the one place that owns
@@ -366,11 +363,10 @@ def _prune_runtime_state_from_stage(zones: _RenderZones, *, renders: Sequence[Pa
 def _backup_outgoing_claude_artifacts(zones: _RenderZones) -> Path | None:
     """Snapshot the outgoing render's Claude Code artifacts that are about to change.
 
-    The retired ``osprey claude regen`` copied these into ``_agent_data/backup/``
-    before overwriting them, so an operator who had edited a rendered hook or
-    agent could get it back. ``build/`` is disposable and no longer a place to edit
-    anything — ``osprey scaffold claim`` is how a file becomes source — but the
-    same courtesy costs nothing and the same accident is still possible.
+    ``build/`` is disposable and not a place to edit anything — ``osprey
+    scaffold claim`` is how a file becomes source — but an operator can still
+    edit a rendered hook or agent by mistake, and a snapshot that lets them get
+    it back costs nothing.
 
     Only files that actually differ are copied, so a rebuild that changes
     nothing leaves no backup directory. Best-effort throughout: this protects
@@ -416,13 +412,11 @@ def _stamp_repo_manifest(
 ) -> None:
     """Add the drift check's per-key commentary to a render's manifest.
 
-    It used to also rewrite ``reproducible_command``, because the generator that
-    produced it assembled a project-name-and-path invocation describing a shape
-    this repo does not have. The generator is gone and
+    ``reproducible_command`` is deliberately not rewritten here.
     :data:`~osprey.cli.templates.manifest.REPO_REPRODUCIBLE_COMMAND` is written
     directly, so the manifest arrives here already correct — generating a wrong
-    answer and patching it afterwards left every manifest written by any other
-    path carrying the wrong one.
+    answer and patching it afterwards would leave every manifest written by any
+    other path carrying the wrong one.
 
     The drift fingerprint's per-key digests are added to the DEPLOYMENT's
     manifest only. The fingerprint itself — ``creation.preset_hash``, a
@@ -475,10 +469,9 @@ def _render_compose_files(
 ) -> dict[str, Any] | None:
     """Render the deployment's compose files into the staged tree.
 
-    This is what ``osprey build`` used to be, folded into the render that
-    produces everything else: compose files are derived from the same
-    ``config.yml``, so having them appear one verb later meant ``build/`` was
-    never a complete description of the deployment.
+    Compose files are rendered in the same pass as everything else, because they
+    are derived from the same ``config.yml``: emitting them a verb later would
+    leave ``build/`` an incomplete description of the deployment.
 
     The generator resolves its inputs relative to the working directory, which
     is what makes it stageable at all: run from the staged render, every service
@@ -1104,8 +1097,7 @@ def _write_image_context_dockerignore(image_root: Path) -> list[str]:
     This is the SECOND guard on the repo's secrets, not the first:
     :func:`_strip_secrets` has already removed every ``.env`` from the tree. Two
     independent guards is the right number for a facility's provider keys — but
-    only if the one that runs at build time actually matches, which before this
-    it did not.
+    only if the one that runs at build time actually matches.
 
     :returns: The patterns written, in file order, for
         :func:`_prune_ignored_entries` to apply to the tree itself.
@@ -1543,8 +1535,8 @@ def _build_repo(
 
     What it renders is the whole OUTPUT zone in one pass — the project (config,
     Claude Code artifacts, data tree, service templates, injected services), the
-    compose files that deploy it, which used to require a second verb, and one
-    project per persona delta (:func:`_render_persona_projects`). It lands in
+    compose files that deploy it, and one project per persona delta
+    (:func:`_render_persona_projects`). It lands in
     ``build/.tmp`` and replaces ``build/`` only once every step below has
     succeeded; see :func:`_swap_in_render`.
 
@@ -1571,7 +1563,7 @@ def _build_repo(
 
     repo_root = find_repo_root(repo)
     profile_path = repo_root / PROFILE_FILENAME
-    # The repo IS the deployment and its directory name IS the deployment's
+    # The repo is the deployment and its directory name is the deployment's
     # name: it is what the compose project, the container labels and the local
     # image tags are derived from. There is no name to pass and none to store.
     name = repo_root.name

--- a/src/osprey/cli/build_injectors.py
+++ b/src/osprey/cli/build_injectors.py
@@ -494,14 +494,13 @@ def _inject_bluesky(bluesky: BlueskyConfig, project_path: Path) -> None:
     }
     if bluesky.plan_dir:
         # Only written when configured — its absence is what keeps a
-        # bridge-only deploy (no facility plan directory) rendering exactly
-        # as before: the compose template's {% if %} guard reads this same
-        # key, so an unset plan_dir means no mount and no BLUESKY_PLAN_DIRS
-        # env var at all (Task 1.4).
+        # bridge-only deploy (no facility plan directory) free of the mount:
+        # the compose template's {% if %} guard reads this same key, so an
+        # unset plan_dir means no mount and no BLUESKY_PLAN_DIRS env var at all.
         svc_config["plan_dir"] = bluesky.plan_dir
     if bluesky.excluded_plans:
         # Only written when non-empty — its absence keeps a deploy with no
-        # exclusions rendering exactly as before: the compose template's
+        # exclusions free of the variable: the compose template's
         # {% if %} guard reads this same key, so an empty list means no
         # BLUESKY_EXCLUDED_PLANS env var at all. The os.pathsep join is done
         # Python-side because the Jinja render context has no `os` module.
@@ -583,11 +582,11 @@ def _inject_va(va: VAConfig, project_path: Path) -> None:
     with open(config_path) as fh:
         config = yaml.load(fh)
 
-    # No scenario-state directory is created here. This used to pre-create the
-    # compose bind source so the container runtime could not materialize it
-    # root-owned — but it created it under the RENDER root, and the render root
-    # is `build/`, which the next build wipes. The path compose actually binds
-    # is anchored on the repo's own `var/agent_data`, and
+    # No scenario-state directory is created here. Pre-creating the compose bind
+    # source — so the container runtime cannot materialize it root-owned — only
+    # helps where it survives, and anything created under the RENDER root is
+    # wiped by the next build. The path compose actually binds is anchored on
+    # the repo's own `var/agent_data`, and
     # `compose_generator._ensure_agent_data_structure` pre-creates it there,
     # which is the copy that survives long enough to be a mount source.
 

--- a/src/osprey/cli/build_persistence.py
+++ b/src/osprey/cli/build_persistence.py
@@ -5,16 +5,12 @@ injector: config overrides, convention-tree application + its
 scaffold-ownership registration, and persisting profile MCP servers / custom
 categories into ``config.yml``.
 
-Nothing here preserves anything across a build any more, and nothing here makes
-a git repository. Both belonged to the layout where a rendered project WAS the
-durable thing an operator kept: a ``--force`` rebuild had to step around the
-``.env``, agent data and ``.git`` living inside it, and the render had to `git
-init` so Claude Code could find a project boundary. Under the three-zone repo
-the render is ``build/`` — output, wiped and re-made whole by every build — and
-the durable state it used to step around sits outside it, in the repo's own
-``.env``, ``var/`` and ``.git``. A pre-clear that preserves is therefore
-meaningless (there is nothing in the render to keep) and a nested repository is
-actively wrong (the repo IS the git boundary).
+Nothing here preserves anything across a build, and nothing here makes a git
+repository. The render is ``build/`` — output, wiped and re-made whole by every
+build — and the durable state sits outside it, in the repo's own ``.env``,
+``var/`` and ``.git``. A pre-clear that preserves is therefore meaningless
+(there is nothing in the render to keep) and a nested repository is actively
+wrong (the repo is the git boundary).
 """
 
 from __future__ import annotations

--- a/src/osprey/cli/build_profile_document.py
+++ b/src/osprey/cli/build_profile_document.py
@@ -56,7 +56,7 @@ def _normalize_profile_aliases(raw: dict[str, Any], source: str) -> dict[str, An
             raise BuildProfileError(
                 f"{source} sets both {yaml_key!r} ({value!r}) and its alias "
                 f"{field!r} ({raw[field]!r}) to different values. "
-                f"Keep one spelling — {yaml_key!r} is the current one."
+                f"Keep one spelling — {yaml_key!r} is the profile-YAML spelling."
             )
         raw[field] = value
     return raw

--- a/src/osprey/cli/build_profile_emit.py
+++ b/src/osprey/cli/build_profile_emit.py
@@ -936,7 +936,7 @@ def emit_persona_delta_yaml(
     header = (
         f"# {profile_name} — persona profile, a delta over {host_ref}\n"
         f"#\n"
-        f"# Sitting in personas/ beside {host_filename} IS the inheritance: the build merges\n"
+        f"# Sitting in personas/ beside {host_filename} is the inheritance: the build merges\n"
         f"# this file over that profile — including any edit you make there — so the keys\n"
         f"# below are this persona's only differences and there is no `extends:` to\n"
         f"# write. See the resolved whole with:\n"
@@ -961,7 +961,7 @@ def emit_persona_delta_yaml(
 # persona siblings share the mental model and repeating the picture three times
 # per repo would just be noise.
 _ZONE_MAP = """\
-# This repository IS the deployment. One directory, four zones:
+# The repository is the deployment. One directory, four zones:
 #
 #   SOURCE   tracked, yours to edit — profile.yml, data/, personas/,
 #            triggers.yml, web-terminal-context/, scripts/, the CI files

--- a/src/osprey/cli/build_profile_merge.py
+++ b/src/osprey/cli/build_profile_merge.py
@@ -565,9 +565,9 @@ def resolve_profile_document(
 
     The one place that decides what a profile file *means*. A file under
     ``personas/`` beside a ``profile.yml`` carries only a delta: living there
-    IS its inheritance, so it is resolved against that root rather than on its
+    is its inheritance, so it is resolved against that root rather than on its
     own, and everything it names anchors at the root. Every other file resolves
-    standalone through its ``extends`` chain, as before.
+    standalone through its ``extends`` chain.
 
     Both the loader and the content hash go through here, which is what keeps a
     persona's built project and its staleness hash describing the same merge.

--- a/src/osprey/cli/channel_finder_cmd.py
+++ b/src/osprey/cli/channel_finder_cmd.py
@@ -84,7 +84,8 @@ def _profile_data_root(project_dir):
 
     Returns:
         The profile's data tree, or ``None`` when the project names no profile
-        (preset-built, legacy or absent manifest), the profile file is gone, it
+        (preset-built, or a manifest that is absent or names none), the profile
+        file is gone, it
         cannot be read, or the resolved profile declares no ``data:`` tree at
         all — every one of which is a normal state the caller falls back from
         rather than an error to raise. Never a guessed ``<root>/data``: a

--- a/src/osprey/cli/chat_cmd.py
+++ b/src/osprey/cli/chat_cmd.py
@@ -40,7 +40,7 @@ def _overlay_repo_env(repo_root: Path) -> None:
     """Load the repo's ``.env`` into ``os.environ``, overriding what is there.
 
     The SECRETS zone is at the repo root while the render is under ``build/``,
-    so the ``.env`` and the ``config.yml`` this verb needs no longer live in one
+    so the ``.env`` and the ``config.yml`` this verb needs do not live in one
     directory. This overlay is what closes that gap *before* the provider spec
     is resolved: a custom provider's ``base_url: ${ARGO_PROD_URL}`` is expanded
     at spec-resolution time, and the value it expands from is a ``.env`` key.

--- a/src/osprey/cli/deploy_cmd.py
+++ b/src/osprey/cli/deploy_cmd.py
@@ -211,7 +211,7 @@ def ensure_repo_env(repo_root: Path, config: dict[str, Any]) -> None:
     every ``${VAR}`` in every rendered compose file substitutes to empty and the
     stack comes up authenticating with nothing — services that fail closed
     refuse, services that do not come up wide open. Compose says nothing about
-    it, which is why this is a refusal rather than the warning it used to be.
+    it, which is why this is a refusal rather than a warning.
 
     On an interactive terminal the operator is offered ``osprey init``'s
     shell-harvest instead: the auth variable this deployment's own provider

--- a/src/osprey/cli/deploy_scaffold.py
+++ b/src/osprey/cli/deploy_scaffold.py
@@ -5,8 +5,8 @@ profile implies around it. Two of those surrounding files are generated from
 the profile rather than written by hand: the CI pipeline at the repo root, and
 the post-deploy health check at ``scripts/verify.sh``. This module turns a
 profile into both files and puts them where they belong — both paths
-repo-relative, because the repo IS the deployment and there is no project
-sibling to key them off.
+repo-relative, because the repo is the deployment: there is no project sibling
+to key them off.
 
 ``osprey scaffold ci`` re-emits them; ``osprey init`` emits them the first
 time. One engine, called twice, so a repo created today and a repo
@@ -66,7 +66,7 @@ CI_OUTPUT_NAMES: dict[str, str] = {"gitlab": ".gitlab-ci.yml"}
 
 #: Where the health check is emitted, as path segments relative to the repo
 #: root. It lands in the source zone, beside the profile that renders it, and
-#: nothing copies it anywhere else: the repo IS the deployment, so the path the
+#: nothing copies it anywhere else: the repo is the deployment, so the path the
 #: pipeline invokes and the path the file sits at are the same path.
 #:
 #: Split from the emitted files' own spelling of it rather than written out

--- a/src/osprey/cli/health_cmd.py
+++ b/src/osprey/cli/health_cmd.py
@@ -103,9 +103,8 @@ def _resolve_anchors(project_path: Path) -> tuple[Path, Path, Path]:
     the rendered ``config.yml`` lives in the ``build/`` zone while the ``.env``
     and every ``project_root``-relative path (registry file, agent data, disk
     sample) belong to the repo root beside ``profile.yml``. Resolving one
-    directory for both is how ``osprey health`` used to give a half-right answer
-    from either stance — no config from the repo root, no credentials from the
-    render.
+    directory for both gives a half-right answer from either stance — no config
+    from the repo root, no credentials from the render.
 
     So the config is looked up the way :func:`osprey.utils.workspace.resolve_config_path`
     looks it up (render first, then the flat spelling a container project

--- a/src/osprey/cli/init_cmd.py
+++ b/src/osprey/cli/init_cmd.py
@@ -1,7 +1,7 @@
 """``osprey init`` — create the deployment repo.
 
-This is the ONE way an OSPREY deployment comes into existence. It writes a git
-repository that IS the deployment: one directory, four zones.
+This is the one way an OSPREY deployment comes into existence. It writes a git
+repository that is the deployment: one directory, four zones.
 
     als-assistant/
     │  ═ SOURCE — tracked, user-edited ═══════════════
@@ -87,7 +87,7 @@ def _repo_gitignore() -> str:
     deliberate exception, being a name pattern rather than a path.
     """
     return f"""\
-# This repo IS the deployment: the source zone is tracked, and the three
+# This repo is the deployment: the source zone is tracked, and the three
 # generated or secret zones below never are. A fresh deployment has a clean
 # `git status` from birth.
 
@@ -136,7 +136,7 @@ def _repo_readme(name: str) -> str:
 This repository is an OSPREY deployment. Everything the assistant is made of
 lives here, and the directory name is the deployment's name.
 
-## The three zones
+## The four zones
 
 | Zone | Path | Tracked? | Survives? |
 | --- | --- | --- | --- |
@@ -560,9 +560,9 @@ def _replacing_source_zone(target: Path, *, active: bool) -> Iterator[None]:
 
     Delete-first could not offer that at any ordering. There is no point in the
     sequence where every way the materialization can fail is already behind it,
-    which is why a mistyped preset used to cost a facility its edited
-    ``profile.yml``: the clearing ran first because it had to run somewhere, and
-    everything that validates the operator's input ran after it.
+    so a mistyped preset would cost a facility its edited ``profile.yml``: the
+    clearing has to run somewhere, and everything that validates the operator's
+    input runs after it.
 
     Only the entries in :data:`~.profile_cmd.MATERIALIZED_SOURCE_ENTRIES` move.
     Everything else in the repo — :data:`PRESERVED_BY_FORCE` — this command
@@ -908,7 +908,7 @@ def init(
 ) -> None:
     """Create a deployment repo from a preset.
 
-    DIRECTORY is the repository the deployment lives in, and its name IS the
+    DIRECTORY is the repository the deployment lives in, and its name is the
     deployment's name. Omit it to initialize the current directory in place,
     which is how a repository cloned empty from a forge is filled in.
 

--- a/src/osprey/cli/main.py
+++ b/src/osprey/cli/main.py
@@ -101,8 +101,6 @@ class LazyGroup(click.Group):
         elif cmd_name in ("up", "down", "restart", "status", "logs"):
             # Every lifecycle verb in deploy_cmd is defined as `<name>_verb`,
             # so it is resolved by that name rather than by the bare one. The
-            # suffix is what kept them apart from the legacy `deploy` group's
-            # same-named subcommands while both existed; it stays because the
             # module has no bare `up`/`down`/`restart`/`status`/`logs` to fall
             # back to, and the generic getattr below would raise AttributeError.
             cmd_func = getattr(mod, f"{cmd_name}_verb")
@@ -210,11 +208,9 @@ def cli(ctx, verbose):
     initialize_theme_from_config()
 
     if ctx.invoked_subcommand is None:
-        # The bare command lists what there is to run. It used to launch an
-        # interactive menu, which existed because the legacy verbs took
-        # arguments nobody could remember (`--project`, `--config`, `--preset`);
-        # the surface it wrapped is gone and every verb it offered is now
-        # zero-argument, so the help IS the menu.
+        # The bare command lists what there is to run. Every verb is
+        # zero-argument, so the help is the menu — an interactive wrapper would
+        # be a surface with nothing to wrap.
         click.echo(ctx.get_help())
 
 

--- a/src/osprey/cli/profile_root.py
+++ b/src/osprey/cli/profile_root.py
@@ -82,7 +82,8 @@ class ProjectProfileProblem(Enum):
     it is there but does not anchor.
     """
 
-    #: The manifest names no profile — a legacy manifest, or not a built project.
+    #: The manifest names no profile — a manifest without that field, or not a
+    #: built project.
     NO_PROFILE_RECORDED = "no_profile_recorded"
 
     #: The manifest names a profile file that is not there any more.

--- a/src/osprey/cli/project_utils.py
+++ b/src/osprey/cli/project_utils.py
@@ -5,10 +5,10 @@ Not the deployment-repo discovery rule — that is
 left here serves the handful of commands that resolve their own inputs and
 carry a ``--project`` flag instead (``channel-finder``, ``health``).
 
-:func:`_clear_claude_code_project_state` lost its last caller with the legacy
-command surface and is kept only because removing it would also remove this
-module's re-export of ``encode_claude_project_path``, which a test still
-imports from here. Both belong to the post-deletion sweep, not to this module.
+:func:`_clear_claude_code_project_state` has no caller. It is kept only because
+removing it would also remove this module's re-export of
+``encode_claude_project_path``, which a test still imports from here. Both
+belong to a dead-code sweep, not to this module.
 """
 
 from pathlib import Path
@@ -62,13 +62,12 @@ def resolve_project_path(project_arg: str | None = None) -> Path:
     Two answers, in priority order: what ``--project`` named, or where the
     command was typed.
 
-    An environment variable naming a project directory used to sit between the
-    two. It is gone, and deliberately not replaced: a variable that silently
-    redirects a command to another directory means the same command line acts on
-    different deployments depending on a shell the operator cannot see in the
-    invocation. Discovery is now one rule
+    No environment variable sits between the two, and none belongs there: a
+    variable that silently redirects a command to another directory means the
+    same command line acts on different deployments depending on a shell the
+    operator cannot see in the invocation. Discovery is one rule
     (:func:`osprey.cli.repo_resolver.find_repo_root`), with ``--repo`` as its
-    only override; the commands still calling this function are the ones that
+    only override; the commands calling this function are the ones that
     resolve their own inputs and take ``--project`` instead.
 
     Args:

--- a/src/osprey/cli/query_cmd.py
+++ b/src/osprey/cli/query_cmd.py
@@ -56,7 +56,7 @@ def _overlay_repo_env(repo_root: Path) -> None:
     """Load the repo's ``.env`` into ``os.environ``, overriding what is there.
 
     The SECRETS zone is at the repo root while the render is under ``build/``,
-    so the ``.env`` and the ``config.yml`` this verb needs no longer live in one
+    so the ``.env`` and the ``config.yml`` this verb needs do not live in one
     directory — and the runner's own overlay
     (``osprey.build.claude_code_resolver._env_lookup``) looks beside the config
     it was handed. Without this the provider secret would simply not be found

--- a/src/osprey/cli/scaffold_cmd.py
+++ b/src/osprey/cli/scaffold_cmd.py
@@ -1228,7 +1228,7 @@ def _reject_retired_config_option(config_path: str | None) -> None:
         return
     message = (
         "--config is no longer supported: there is no facility-config.yml. "
-        "The modules.web_terminals stanza now lives in the repo's built "
+        "The modules.web_terminals stanza lives in the repo's built "
         "config.yml, emitted from the profile's `config:` block — run this verb "
         "with --repo DIR, or from inside the repo. Its deployment artifacts "
         "come from `osprey scaffold ci`, driven by the profile's `deploy:` "

--- a/src/osprey/cli/set_cmd.py
+++ b/src/osprey/cli/set_cmd.py
@@ -15,8 +15,8 @@ refusal of an ``extends:`` write that materialization makes. A second writer
 with its own spelling rules would mean ``osprey set connector=epics`` and
 ``osprey init --set connector=epics`` landing differently in the same file.
 
-Two shorthands from the retired ``osprey config set-*`` commands survive here
-as key spellings: ``connector=`` (folded into ``config.control_system.type`` by
+Two shorthands are accepted as key spellings:
+``connector=`` (folded into ``config.control_system.type`` by
 the shared layering step) and ``epics_gateway=`` (expanded below into the
 facility's gateway addresses). Both write the literal dotted keys a reader
 would otherwise type by hand, so nothing lands in the profile that only this

--- a/src/osprey/cli/skills_cmd.py
+++ b/src/osprey/cli/skills_cmd.py
@@ -11,8 +11,7 @@ directory instead, scoping it to one repo.
 ``osprey-build-interview`` is the one skill covering a deployment's own
 lifetime: what the repo's ``profile.yml`` should say, its ``deploy:`` block
 included, and the build it feeds. There is deliberately no operate-time
-counterpart — the lifecycle verbs the old one was written against no longer
-exist, and a runbook is worth shipping only once it describes the verbs a
+counterpart: a runbook is worth shipping only once it describes the verbs a
 reader actually has.
 """
 
@@ -57,7 +56,7 @@ def install(name: str, target: Path | None) -> None:
     """Install a bundled skill into <target>/<name>/.
 
     \b
-    Currently supported skills:
+    Bundled skills:
       osprey-build-interview  Author OSPREY build profiles (global)
       osprey-contribute       Walk a contributor through the GitHub Flow journey
       osprey-pre-commit       Run quick / ci / premerge check scripts at the right gate

--- a/src/osprey/cli/templates/claude_code.py
+++ b/src/osprey/cli/templates/claude_code.py
@@ -1262,7 +1262,7 @@ def regenerate_claude_code(
     )
 
     # Resolve allowed_outputs from .osprey-manifest.json artifact list.
-    # Fall back to loading the template's manifest.yml for legacy projects.
+    # Fall back to loading the template's manifest.yml for a project without one.
     template_name = ctx.get("template_name", "control_assistant")
     osprey_manifest_path = project_dir / manifest_mod.MANIFEST_FILENAME
     regen_manifest: dict | None = None
@@ -1361,11 +1361,9 @@ def regenerate_claude_code(
             summary = compute_regen_summary(ctx)
             return {"changed": changed, "unchanged": unchanged, **summary}
 
-    # No backup is taken here. This used to snapshot the artifacts it is about
-    # to overwrite into `<project>/_agent_data/backup/claude-code-<stamp>/` —
-    # inside the very tree it regenerates, under the retired agent-data
-    # spelling, so the next build discarded the snapshot along with the rest of
-    # `build/`. The surviving snapshot is
+    # No backup is taken here. A snapshot written inside the tree this
+    # regenerates would be discarded, along with the rest of `build/`, by the
+    # next build. The snapshot that counts is
     # `osprey.cli.build_cmd._backup_outgoing_claude_artifacts`, which writes the
     # same artifacts to the repo's own `var/agent_data/backup/` before the
     # atomic swap: the durable zone, which is the only place a snapshot taken to

--- a/src/osprey/cli/templates/manager.py
+++ b/src/osprey/cli/templates/manager.py
@@ -165,12 +165,11 @@ class TemplateManager:
                 exists without ``force=True``.
 
         Note:
-            ``default_provider`` is no longer defaulted here — callers must
-            inject it via ``context``. ``osprey build`` enforces this at the
-            CLI boundary (``click.UsageError``); internal callers that omit
-            it produce an empty ``provider:`` in the rendered ``config.yml``,
-            which the config loader rejects at project runtime. See
-            plan-remove-implicit-synchronous-narwhal.
+            ``default_provider`` is not defaulted here — callers must inject
+            it via ``context``. ``osprey build`` enforces this at the CLI
+            boundary (``click.UsageError``); internal callers that omit it
+            produce an empty ``provider:`` in the rendered ``config.yml``,
+            which the config loader rejects at project runtime.
         """
         # 1. Validate data bundle exists
         bundle_dir = self.template_root / "apps" / data_bundle
@@ -201,8 +200,8 @@ class TemplateManager:
 
         current_python = sys.executable
 
-        # Fall back to preset profile artifacts when the caller didn't pass any
-        # (legacy code path). An explicit empty dict from `osprey build` means the
+        # Fall back to preset profile artifacts when the caller didn't pass any.
+        # An explicit empty dict from `osprey build` means the
         # profile deliberately selects nothing, and must not be overridden.
         if artifacts is None:
             tmpl_manifest = manifest.load_template_manifest(self.template_root, data_bundle)

--- a/src/osprey/cli/templates/manifest.py
+++ b/src/osprey/cli/templates/manifest.py
@@ -43,12 +43,11 @@ _MANIFEST_CATEGORY_PREFIX = {
 #: for the case where neither a project manifest nor a template manifest names a
 #: selection.
 #:
-#: DERIVED from the artifact catalog, not hand-listed. It used to be a literal
-#: list, and it had silently fallen three artifacts behind the catalog it was
-#: mirroring — which matters because an artifact missing here is an artifact
-#: whose drift is never detected. `resolve_manifest_outputs` above reads the
-#: same `output_path` from the same catalog, so the fallback and the selected
-#: path now cannot disagree about what an artifact is called.
+#: DERIVED from the artifact catalog, never hand-listed: a literal list falls
+#: silently behind the catalog it mirrors, and an artifact missing here is an
+#: artifact whose drift is never detected. `resolve_manifest_outputs` above
+#: reads the same `output_path` from the same catalog, so the fallback and the
+#: selected path cannot disagree about what an artifact is called.
 REGEN_TRACKED_FILES = sorted(
     {"CLAUDE.md", ".mcp.json", ".claude/settings.json", ".claude/statusline.py"}
     | {artifact.output_path for artifact in BuildArtifactCatalog.default().all_artifacts()}
@@ -342,7 +341,7 @@ def extract_build_args(
 
     Captures both the user-facing options (provider/model/etc.) and the
     invocation source (preset vs. positional profile path), as a record of what
-    this build resolved. Nothing renders a command line from it any more — the
+    this build resolved. Nothing renders a command line from it — the
     manifest's ``reproducible_command`` is the constant
     :data:`REPO_REPRODUCIBLE_COMMAND`, because the repo is the invocation.
 
@@ -395,16 +394,12 @@ def extract_build_args(
 
 
 #: What a manifest's ``reproducible_command`` says. A constant, because the
-#: command is one: the repo IS the invocation, so there is no project name to
+#: command is one: the repo is the invocation, so there is no project name to
 #: pass, no profile path to name and no output directory to choose.
 #:
-#: This replaced a generator that assembled the string from ``build_args`` —
-#: ``osprey build NAME --preset PRESET`` or ``osprey build NAME PROFILE_PATH``.
-#: Both forms are gone with the legacy command surface, so every string it could
-#: produce named an invocation that no longer parses. The one caller that
-#: mattered already overwrote its output with this constant afterwards, which
-#: made the generator invisible rather than harmless: a manifest written by any
-#: other path still carried the retired spelling.
+#: Written directly rather than assembled by a generator: a generator's output
+#: would have to be overwritten by this constant afterwards, and a manifest
+#: written by any path that skipped the overwrite would carry the wrong string.
 REPO_REPRODUCIBLE_COMMAND = "osprey build"
 
 
@@ -423,9 +418,9 @@ def calculate_file_checksums(project_dir: Path) -> dict[str, str]:
 
     Excluded:
     - ``.env`` (secrets, never rendered deterministically)
-    - ``_agent_data/`` — the runtime-state directory the retired flat layout put
-      INSIDE the project. Nothing creates it now, so the entry is vestigial; it
-      is kept because the cost of an exclusion that never matches is nothing,
+    - ``_agent_data/`` — a runtime-state directory inside the project. Nothing
+      creates it, so on a current deployment the entry never matches; it is
+      kept because the cost of an exclusion that never matches is nothing,
       while dropping it would silently start checksumming a directory left
       behind by an older release and report the result as project drift.
     - ``__pycache__/`` and ``.pyc`` files

--- a/src/osprey/cli/templates/scaffolding.py
+++ b/src/osprey/cli/templates/scaffolding.py
@@ -102,16 +102,15 @@ def create_project_structure(
 ):
     """Create base project files (config, README, Dockerfile, etc.).
 
-    No ``.env`` is written. The render used to derive one from the owning
-    profile, because a rendered project was a place a stack actually ran from.
-    It is not: the render is ``build/``, and the deployment's one secret store
-    is the ``.env`` at the repo root — the only file compose is pointed at
+    No ``.env`` is written. The render is ``build/``, and the deployment's one
+    secret store is the ``.env`` at the repo root — the only file compose is
+    pointed at
     (``--project-directory <repo>`` + ``--env-file <repo>/.env``), the file
     ``osprey up`` mints service tokens into, and the file a ``rm -rf build/`` is
     documented not to touch. A second copy inside the render would be a second
     thing to keep in step, and one that a build could silently rewrite.
 
-    ``.env.example`` is still rendered here: it carries no values, documents
+    ``.env.example`` is rendered here: it carries no values, documents
     what the repo's ``.env`` may hold, and is safe to commit.
 
     Args:

--- a/src/osprey/cli/web_cmd.py
+++ b/src/osprey/cli/web_cmd.py
@@ -12,9 +12,9 @@ every repo-scoped verb uses: walk up to the nearest ``profile.yml``. ``stop``
 runs the *same* walk as the start, so the two can never disagree about which
 server is being stopped.
 
-``OSPREY_CONFIG`` survives here only as the publication this process makes for
-its own children (PTY shells, their MCP servers, the ``--reload`` worker). It
-is no longer read as a way of *finding* the deployment: an ambient export from
+``OSPREY_CONFIG`` is written here only as the publication this process makes
+for its own children (PTY shells, their MCP servers, the ``--reload`` worker).
+It is never read as a way of *finding* the deployment: an ambient export from
 whichever project the operator last worked in must not decide what this
 command serves.
 """

--- a/src/osprey/connectors/control_system/base.py
+++ b/src/osprey/connectors/control_system/base.py
@@ -111,8 +111,8 @@ def _writes_disabled_result(channel_address: str, value: Any) -> ChannelWriteRes
 def _warn_once_if_fail_on_mismatch_set(verification: Any) -> None:
     """Warn once per process if this project still declares ``fail_on_mismatch: true``.
 
-    The key was deleted because nothing ever read it: a failed verification has
-    never stopped a write on the default path. A project that still carries it at
+    Nothing reads the key: a failed verification does not stop a write on the
+    default path. A project that still carries it at
     ``true`` is running on a belief about its own safety posture that was never
     true, so it gets told once — at the first write, where the belief matters —
     which path actually enforces verification.

--- a/src/osprey/connectors/control_system/mock_connector.py
+++ b/src/osprey/connectors/control_system/mock_connector.py
@@ -73,7 +73,7 @@ class MockConnector(ControlSystemConnector):
                 - noise_level: Relative noise level 0-1 (default: 0.01)
                 - simulation_file: Optional path to a machine.json driving the
                   data-driven simulation engine (relative paths resolve against
-                  the project root). Without it, legacy behavior is unchanged.
+                  the project root). Without it, every PV is served procedurally.
         """
         self._response_delay = config.get("response_delay_ms", 10) / 1000.0
         self._noise_level = config.get("noise_level", 0.01)
@@ -117,7 +117,7 @@ class MockConnector(ControlSystemConnector):
         # Simulate network delay
         await asyncio.sleep(self._response_delay)
 
-        # Simulation engine serves its channels; unknown PVs fall back to legacy
+        # Simulation engine serves its channels; unknown PVs fall back to procedural
         if engine_serves(self._sim_engine, channel_address):
             reading = self._sim_engine.read(channel_address)
             now = datetime.now(get_facility_timezone())
@@ -210,7 +210,7 @@ class MockConnector(ControlSystemConnector):
 
         if engine_serves(self._sim_engine, channel_address):
             # Engine channels: :SP -> :RB mirroring is handled by expr readbacks
-            # in the machine file, so no legacy string-replace mirroring here.
+            # in the machine file, so no string-replace mirroring is needed here.
             self._sim_engine.write(channel_address, value)
         else:
             # Update state

--- a/src/osprey/connectors/control_system/va_connector.py
+++ b/src/osprey/connectors/control_system/va_connector.py
@@ -25,8 +25,8 @@ def resolve_va_gateway_port() -> Any:
     service publishes and sets ``EPICS_CA_SERVER_PORT`` from — so a project
     that moves the deployed soft-IOC's port moves the connector with it.
     Falls back to :data:`DEFAULT_VA_PORT` when the key is unset, and when the
-    config cannot be read at all (no project context, unreadable file): the
-    connector then behaves exactly as it did when the port was hardcoded.
+    config cannot be read at all (no project context, unreadable file), so the
+    connector still resolves a port without one.
 
     Returns:
         The port to default-fill unset gateway ports with.

--- a/src/osprey/connectors/pv_taxonomy.py
+++ b/src/osprey/connectors/pv_taxonomy.py
@@ -5,13 +5,12 @@ guess plausible defaults for PV names that the data-driven simulation engine
 does *not* serve. They classify a PV by substring conventions in its name and
 map it to a physical base value and engineering units.
 
-Historically each connector hard-coded its own copy of this keyword ladder,
-which had already drifted (e.g. the archiver lacked an ``energy`` branch and the
-control connector did not recognise ``dcct`` as a beam-current monitor). This
-module is the single source of truth: :func:`classify_pv` returns a
-:class:`PVKind`, and each connector layers its own behaviour on top — the
-archiver shapes a time series per :attr:`PVKind.name`, the control connector
-seeds an initial value and reports units.
+Neither connector may hold its own copy of this keyword ladder: two copies drift
+apart branch by branch, and the same PV name then classifies one way for live
+reads and another for archived ones. This module is the single source of truth:
+:func:`classify_pv` returns a :class:`PVKind`, and each connector layers its own
+behaviour on top — the archiver shapes a time series per :attr:`PVKind.name`,
+the control connector seeds an initial value and reports units.
 
 The kind also carries :attr:`PVKind.noise_scale`, the absolute floor under the
 otherwise purely relative sigma, so a kind whose base value is legitimately

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -261,11 +261,10 @@ def _ensure_service_tokens(
     A mint lands once and stays there. Nothing is copied anywhere afterwards:
     the file written here IS the deployment's one secret store, sitting at the
     repo root beside the ``profile.yml`` that describes the stack, and it is the
-    same file compose is pointed at (``--env-file <repo>/.env``). This used to
-    write the effective values on to a second ``.env`` owned by the profile,
-    because a rendered project and its profile were different directories and a
-    rebuild elsewhere would otherwise mint secrets the running containers reject.
-    One directory, one file, no second copy to keep in step.
+    same file compose is pointed at (``--env-file <repo>/.env``). A second copy
+    owned by the profile must never be written: two stores drift, and a rebuild
+    reading the wrong one mints secrets the running containers reject. One
+    directory, one file, no second copy to keep in step.
 
     Independently of the above, every var in ``_VALIDATE_ONLY_VARS``
     (e.g. ``ARIEL_DSN``) is checked against its ``_VAR_VALIDATORS`` constraint
@@ -401,7 +400,7 @@ def _ensure_service_tokens(
     # Validate-only vars (ARIEL_DSN): checked when present in the same
     # effective-value sense as required_vars above, but never minted when
     # absent and never required to unblock a deploy — see _VALIDATE_ONLY_VARS'
-    # docstring for why no _SERVICE_TOKEN_VARS entry can express this today.
+    # docstring for why no _SERVICE_TOKEN_VARS entry can express this.
     for name in _VALIDATE_ONLY_VARS:
         effective = _effective_value(name, post)
         if not effective:
@@ -612,7 +611,7 @@ def _ensure_bluesky_document_plane_certs(config: dict, env_path: Path | None = N
     Generation is **unconditional** for any deploy carrying the ``bluesky``
     service, and deliberately NOT gated on the connector being EPICS-like the
     way substrate derivation is. A mock deploy never opens the RE worker
-    environment, so empty certificate directories would cost it nothing today
+    environment, so empty certificate directories would cost such a deploy nothing
     — but they are not free: the moment an operator flips the connector to
     ``virtual_accelerator`` and restarts without a full redeploy, the bridge
     finds no secret certificate and refuses to bind the plane at all (see
@@ -1269,13 +1268,10 @@ def _build_project_image(
     staged_artifacts: list[Path] = []
     wheel_staged = False
     if dev_mode:
-        # No build-context bloat guard here, deliberately. One used to warn when
-        # a context's `build/` was not excluded from it, back when `build/` was
-        # bulk the image had no use for. In this context `build/` IS the
-        # deployment being shipped, so that advice — add `build/` to
-        # `.dockerignore` — would produce an image with no config, no .mcp.json
-        # and no Claude Code artifacts. The guard has been removed rather than
-        # left uncalled, so nothing can call it back into service.
+        # No build-context bloat guard here, deliberately. `build/` IS the
+        # deployment being shipped in this context, so the usual advice — exclude
+        # `build/` via `.dockerignore` — would produce an image with no config,
+        # no .mcp.json and no Claude Code artifacts.
         before = _staged_dev_artifact_paths(project_root)
         wheel_staged = bool(_copy_local_framework_for_override(project_root))
         staged_artifacts = sorted(_staged_dev_artifact_paths(project_root) - before)
@@ -2354,9 +2350,9 @@ def as_built_compose_files(config: dict, repo_root: Path | str) -> list[str]:
     The repo root is handed to the lookup as its explicit ``base`` because
     ``find_existing_compose_files`` resolves ``build_dir`` and each service's
     template directory relatively: every repo-scoped verb must be correct from
-    any directory inside the repo, not only from its root. (This used to move
-    the working directory instead, which answered the same question by
-    borrowing global process state to do it.)
+    any directory inside the repo, not only from its root. Never answer that by
+    moving the working directory instead: that borrows global process state for
+    one lookup, and re-anchors every relative path the caller still holds.
 
     The paths come back RELATIVE to the repo root, which is what
     :func:`~osprey.deployment.compose_generator.compose_base_cmd` resolves for
@@ -2789,8 +2785,8 @@ def down_deployment(repo_root: Path | str) -> None:
 
     The three-zone stop path, and the mirror of :func:`up_as_built`: it acts on
     what a build left in ``build/`` and renders nothing. Where the legacy
-    :func:`deploy_down` re-rendered the compose files when it could not find
-    them, this refuses to render at stop time — the compose files that declared
+    :func:`deploy_down` re-renders the compose files when it cannot find them,
+    this refuses to render at stop time — the compose files that declared
     the running containers are a fact about the past, and re-deriving them from
     a since-edited profile can only produce a ``down`` aimed at a stack that was
     never started. :func:`_down_by_label` covers that case instead.
@@ -2994,8 +2990,8 @@ def deploy_restart(config_path, detached=False, expose_network=False):
     # Same reason the token mint above runs on this path: the bluesky compose
     # template expands the manager's private key with a `:?` guard, so an unset
     # value aborts the whole `compose restart` rather than degrading. A project
-    # whose .env predates this feature has no key, and restarting it must not
-    # be the thing that breaks it. The document-plane certificates are NOT
+    # whose .env carries no key must not be broken by a restart. The
+    # document-plane certificates are NOT
     # provisioned here -- they are bind-mount sources, and `compose restart`
     # reuses each container's existing config rather than re-resolving mounts,
     # so generating them would change nothing until the next `osprey up`.

--- a/src/osprey/deployment/reset.py
+++ b/src/osprey/deployment/reset.py
@@ -173,12 +173,12 @@ PATH_EVIDENCE_LABELS: tuple[str, ...] = (
     "osprey.project.root",
 )
 
-#: Header comments of the ``.env`` blocks a deploy writes, matched at their
-#: HISTORICAL spelling — including ``osprey deploy up``, a verb name that is on
-#: its way out. The text is what identifies the block in ``.env`` files already
-#: on disk, so it is a data format, not a message: renaming it in the writer
-#: without adding the new spelling here would orphan every block written under
-#: the old one, leaving stale tokens in place while reset reported them stripped.
+#: Header comments of the ``.env`` blocks a deploy writes, carried at EVERY
+#: spelling that can be sitting in a ``.env`` on disk. The text is what
+#: identifies the block, so it is a data format, not a message: renaming it in
+#: the writer without adding the new spelling here orphans every block written
+#: under the other one, leaving stale tokens in place while reset reports them
+#: stripped. Entries are only ever added, never rewritten.
 #:
 #: ``tests/deployment/test_reset_scoping.py`` reads the writer's call sites out
 #: of :mod:`osprey.deployment.container_lifecycle` and fails when a block is

--- a/src/osprey/deployment/runtime_helper.py
+++ b/src/osprey/deployment/runtime_helper.py
@@ -205,14 +205,14 @@ def with_plain_progress(cmd: list[str]) -> list[str]:
     Docker only, deliberately. ``--progress`` is a docker compose v2 flag;
     ``podman compose`` delegates to whichever provider the host has, and a
     provider that rejects an unknown flag would turn a cosmetic improvement
-    into a failed deploy. Podman hosts keep today's behaviour, and lose
+    into a failed deploy. Podman hosts keep compose's own default, and lose
     little: ``auto`` already resolves to ``plain`` whenever stdout is not a
     terminal, which covers CI and systemd — the places a production deploy's
     output is actually captured.
 
     ``--progress`` is a global flag, valid ahead of every compose subcommand,
     so callers append their ``-f``/``--env-file`` arguments and the subcommand
-    afterwards exactly as before.
+    afterwards unchanged.
 
     Args:
         cmd: A compose argv base, e.g. ``["docker", "compose"]``, as returned

--- a/src/osprey/deployment/staleness.py
+++ b/src/osprey/deployment/staleness.py
@@ -200,9 +200,8 @@ def warn_if_project_stale(project_dir: Path) -> None:
         remedy = manifest.get("reproducible_command")
         if remedy:
             # Printed verbatim. It is the manifest's own account of how this
-            # render is reproduced, and no suffix is appended to it: `--force`
-            # went with the legacy build surface, and a repo render is
-            # unconditional anyway.
+            # render is reproduced, and no suffix is appended to it: a repo
+            # render is unconditional, so there is no force flag to add.
             message += f" Re-render it with:\n    {remedy}\nthen re-run osprey up."
         logger.warning(message)
     except Exception as exc:  # advisory must never break a deploy

--- a/src/osprey/deployment/status_display.py
+++ b/src/osprey/deployment/status_display.py
@@ -16,8 +16,8 @@ Which containers belong to *this* deployment is decided by the
 ``com.osprey.repo-id`` label the render bakes in, so two checkouts of the same
 repo on one host are told apart rather than merged. The label has an honest
 limit that the display states rather than hides: it is applied when a container
-is CREATED, so a stack started before this labelling existed carries none, and
-this module can only match it by project name.
+is CREATED, so a stack whose containers were created by an OSPREY that did not
+stamp it carries none, and this module can only match it by project name.
 
 :func:`show_status` is the legacy project-scoped display behind
 ``osprey status``. It shares the query and table helpers below with the
@@ -92,10 +92,9 @@ def _format_state(state, styles):
 def _extract_web_terminal_user_names(users_raw):
     """Extract bare usernames from ``modules.web_terminals.users``.
 
-    Entries may be legacy bare strings (``"alice"``) or explicit object form
-    (``{"name": "alice", "index": 0}``); both are handled defensively here
-    rather than importing a shared normalizer, since that normalizer lives in
-    a module edited in parallel by another task.
+    Entries may be bare strings (``"alice"``) or explicit object form
+    (``{"name": "alice", "index": 0}``); both are handled defensively here so
+    this read-only display never fails on a malformed roster.
 
     :param users_raw: Raw value of ``modules.web_terminals.users``
     :type users_raw: object
@@ -126,8 +125,8 @@ def _container_label(container, key):
     Two shapes, because two runtimes: podman emits ``Labels`` as an object,
     docker as a comma-joined ``k=v`` string. ``None`` when the label is absent,
     and that absence is a real answer here rather than a parse failure — a
-    container without :data:`REPO_ID_LABEL` is one created before OSPREY
-    stamped it.
+    container created by an OSPREY that did not stamp :data:`REPO_ID_LABEL`
+    carries none.
 
     :param container: One decoded ``ps`` record
     :param key: Label key to read
@@ -526,9 +525,8 @@ def _partition_by_checkout(containers, identity, project_name):
       answered differently would describe a different set of containers than
       the verb acting on them.
     * ``unlabelled`` — the project name matches but there is no repo-id label at
-      all. Created before this labelling existed, so they are shown as part of
-      the deployment and flagged, because the label-driven paths cannot find
-      them.
+      all — created by an OSPREY that did not stamp it. Shown as part of the
+      deployment and flagged, because the label-driven paths cannot find them.
     * ``foreign`` — the project name matches and the repo-id does not. Another
       checkout of the same deployment, running on this host.
     * ``others`` — some other OSPREY project entirely.
@@ -758,10 +756,9 @@ def _artifact_drift(repo_root, build_dir, config):
 def _print_agent_section(repo_root, build_dir, config, console, styles, *, show_agents):
     """Print how the agent in this deployment is configured, and whether it is in sync.
 
-    Absorbed from the retired ``osprey claude status``: the provider, the
-    environment block its settings carry, whether the credential those need can
-    actually be found, the tier-to-model mapping, and whether the rendered agent
-    artifacts still match the config they came from.
+    Reports the provider, the environment block its settings carry, whether the
+    credential those need can actually be found, the tier-to-model mapping, and
+    whether the rendered agent artifacts still match the config they came from.
 
     The per-agent model assignments are behind *show_agents* rather than
     printed always: there are a dozen of them, and a status report whose longest

--- a/src/osprey/deployment/web_terminals/lint.py
+++ b/src/osprey/deployment/web_terminals/lint.py
@@ -240,8 +240,8 @@ def _check_duplicate_users(users: list[Any]) -> list[Finding]:
 
     Users may be bare strings or object-form ``{"name": ..., "index": ...}`` dicts
     (dicts aren't hashable, so identity is compared on the resolved name, not the
-    raw entry — this only changes how object-form entries are compared, bare
-    strings behave exactly as before).
+    raw entry, so a bare string and an object entry naming the same user
+    collide, and an all-strings roster compares unchanged).
     """
     seen: set[Any] = set()
     duplicates: set[Any] = set()
@@ -790,9 +790,8 @@ def _check_registry_url_coherence(
     Only evaluated once a persona catalog is actually configured. A config
     with no ``personas:`` block at all resolves every user through
     :func:`~osprey.deployment.web_terminals.personas.resolve_personas`'s
-    zero-migration path exactly as it did before catalogs/mode-coherence
-    existed — this check does not retroactively demand a ``registry.url`` from
-    deployments that never opted into the persona system.
+    zero-migration path — this check never demands a ``registry.url`` from a
+    deployment that has not opted into the persona system.
     """
     if not _persona_catalog(web_terminals):
         return []
@@ -1087,8 +1086,8 @@ def _check_registry_mode_build_profile(
     """Registry mode only: every referenced non-default persona must set
     ``build_profile`` — the committed profile YAML that feeds its one
     ``.gitlab-ci.yml`` build job. The default persona is exempt: its image
-    stays the un-suffixed ``web-terminal:latest``, built by the pre-existing
-    core CI job, not a per-persona one."""
+    stays the un-suffixed ``web-terminal:latest``, built by the core CI job,
+    not a per-persona one."""
     if effective_image_source(web_terminals) != "registry":
         return []
     catalog = _persona_catalog(web_terminals)

--- a/src/osprey/deployment/web_terminals/persona_images.py
+++ b/src/osprey/deployment/web_terminals/persona_images.py
@@ -177,10 +177,9 @@ def _referenced_personas(config: dict, resolved_users: list[dict]) -> list[dict[
     rather than raised — well-formedness is lint's job; this function only
     decides what to build from what already resolved. A referenced persona
     whose catalog entry is missing/empty ``project_path`` is also skipped,
-    but is logged as a warning (not silent): lint (Task 2.4) is the well-
-    formedness gate for a config that never runs it, so a local deploy that
-    bypasses lint would otherwise fail opaquely at ``compose up`` on an
-    unbuilt tag with no clue why.
+    but is logged as a warning (not silent): lint is the well-formedness gate,
+    so a local deploy that bypasses lint would otherwise fail opaquely at
+    ``compose up`` on an unbuilt tag with no clue why.
 
     :param config: Raw deploy config (read for ``modules.web_terminals.personas``).
     :param resolved_users: :func:`osprey.deployment.web_terminals.personas.resolve_personas`'s
@@ -543,11 +542,11 @@ def verify_persona_renders(
     start writes none: this runs BEFORE the image builds so a gap is a refusal
     with a remedy rather than an opaque failure inside a container build.
 
-    A start used to render the missing ones itself. It no longer does, and the
-    absence is the point. ``build/`` is a complete account of what a deploy will
-    run, so a persona project appearing at start time made that account false
-    exactly when it mattered: the operator whose delta had changed got a fresh
-    persona standing beside a deployment rendered from the old profile. The
+    A start must never render the missing ones itself, and the absence is the
+    point. ``build/`` is a complete account of what a deploy will run, so a
+    persona project appearing at start time makes that account false exactly
+    when it matters: the operator whose delta changed would get a fresh persona
+    standing beside a deployment rendered from the earlier profile. The
     drift gate already refuses that start — the persona deltas are folded into
     the build fingerprint — so the honest reading of a missing render is "this
     build is stale or partial", and the honest remedy is the one that replaces

--- a/src/osprey/deployment/web_terminals/personas.py
+++ b/src/osprey/deployment/web_terminals/personas.py
@@ -20,7 +20,7 @@ from typing import Any
 # Matches ${VAR} and $VAR env references inside modules.web_terminals.image_tag.
 _ENV_REF_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)")
 
-# Task 2.5: the only wired value for `modules.web_terminals.mcp.topology`. Every
+# The only wired value for `modules.web_terminals.mcp.topology`. Every
 # other value (including the recognized-but-rejected `shared_http`) is
 # fail-closed at render time — see render.py's `_check_mcp_topology()`. Lives
 # in this neutral module so lint.py and render.py can both import it without
@@ -60,7 +60,7 @@ def normalize_users(users_raw: Any) -> list[dict[str, Any]]:
 
     Legacy bare strings (``"alice"``) normalize to ``{"name": "alice", "index":
     <raw list position>}``, matching the fallback ``render.py`` already uses so
-    ports stay identical to what a pre-existing all-strings roster produces today.
+    ports stay identical to what an all-strings roster produces.
     Already-explicit object entries (``{"name": ..., "index": ...}``) pass through
     with their explicit index preserved, regardless of list position. This makes
     the function idempotent: normalizing an already-normalized list is a no-op,
@@ -350,10 +350,10 @@ def resolve_personas(
     ``modules.web_terminals.image_tag`` (``<tag>`` below, default ``latest``);
     local ``:local`` images are unaffected by that field:
 
-    * **No persona in effect** (``persona`` is ``None``): today's exact values —
+    * **No persona in effect** (``persona`` is ``None``): the facility defaults —
       ``image`` is ``<registry_url>/web-terminal:<tag>`` (unsuffixed, the same
-      string the compose template built directly before this function existed
-      whenever ``<tag>`` is its ``latest`` default),
+      string the compose template names directly whenever ``<tag>`` is its
+      ``latest`` default),
       ``project`` and ``container_project_dir`` are ``<facility_prefix>-assistant``
       / ``/app/<facility_prefix>-assistant``. This is the zero-migration path: a
       config with no ``personas`` catalog at all resolves every entry here.
@@ -467,15 +467,14 @@ def resolve_personas(
     def _zero_migration_entry(
         name: str, index: int, persona: str | None, source: dict[str, Any]
     ) -> dict[str, Any]:
-        """The zero-migration resolution: today's exact pre-persona values, with
+        """The zero-migration resolution: the pre-persona values, with
         ``persona`` carried through for logging (``None`` when no persona is in
         effect, or the unresolvable reference on the lenient degrade path) and the
         optional per-user fields passed through unchanged. ``extra_mounts`` is
         empty here — the zero-migration path has no catalog entry to read
         persona-level host mounts from. ``seed_base`` is ``True`` — the shared
-        base-context prepend has always been mandatory for a
-        no-persona/zero-migration entry, and opting out is only expressible
-        through a catalog entry."""
+        base-context prepend is mandatory for a no-persona/zero-migration entry,
+        and opting out is only expressible through a catalog entry."""
         return _with_optional_fields(
             {
                 "name": name,
@@ -530,7 +529,7 @@ def resolve_personas(
 
         # seed_base: whether this persona's users get the shared base context
         # prepended ahead of their own extra context at seed time. Defaults to
-        # True (the historical, always-prepend behavior); a non-bool value is a
+        # True (always prepend); a non-bool value is a
         # config typo that lint reports separately, so coerce it back to the
         # safe default here rather than propagating garbage.
         seed_base = catalog_entry.get("seed_base")

--- a/src/osprey/deployment/web_terminals/ports.py
+++ b/src/osprey/deployment/web_terminals/ports.py
@@ -26,9 +26,9 @@ FAMILY_BASE_FIELDS = {
 
 # Registry-declared default base port per companion family ("web" has none: the
 # terminal's own base port is facility-chosen, required in config). These are
-# what keep a facility config written before a companion server existed
-# deploying unchanged — the new family allocates from its registry default
-# unless the config overrides `<family>_base_port`.
+# what keep a facility config that names no companion base port deploying
+# unchanged — the family allocates from its registry default unless the config
+# overrides `<family>_base_port`.
 DEFAULT_BASE_PORTS = {
     _family_name(key): defn.multi_user_base_port
     for key, defn in FRAMEWORK_WEB_SERVERS.items()
@@ -54,8 +54,8 @@ def base_ports_from_config(web_terminals: dict[str, Any]) -> dict[str, int]:
 
     A companion family whose base-port field is missing (or not an int) falls
     back to its registry default (:data:`DEFAULT_BASE_PORTS`) — the
-    zero-migration path for configs written before that companion server
-    existed. ``web`` has no default: a missing/malformed ``web_base_port`` is
+    zero-migration path for configs that name no port for that companion
+    server. ``web`` has no default: a missing/malformed ``web_base_port`` is
     dropped, so :func:`allocate_ports` reports it as a clear missing-family
     ``ValueError`` instead of a ``TypeError``.
 

--- a/src/osprey/deployment/web_terminals/postup_hooks.py
+++ b/src/osprey/deployment/web_terminals/postup_hooks.py
@@ -105,14 +105,13 @@ def run_verify_script(project_root: str, run_env: dict[str, str]) -> None:
     ships that file as ``<project_root>/scripts/verify.sh`` (the profile's
     ``project/`` mirror copies it verbatim): a health-check script
     parameterized per-facility with a probe for each enabled module.
-    Historically it was operator-run-by-hand only; this makes ``osprey up``
-    run it automatically as the last step of the post-up hook, once
-    ``compose up -d`` has already succeeded and containers are running, so an
-    operator gets an immediate health signal without a separate manual step.
+    ``osprey up`` runs it automatically as the last step of the post-up hook,
+    once ``compose up -d`` has already succeeded and containers are running, so
+    an operator gets an immediate health signal without a separate manual step.
 
     Silently skipped (no log line at all) when ``<project_root>/scripts/
     verify.sh`` doesn't exist — a profile that carries no such script must
-    deploy exactly as before.
+    deploy without any mention of one.
 
     The script's own convention (see its header) is to ALWAYS exit 0 —
     verification is advisory, never deploy-blocking — but this runs it via

--- a/src/osprey/deployment/web_terminals/provision.py
+++ b/src/osprey/deployment/web_terminals/provision.py
@@ -241,7 +241,7 @@ def _report_unshown_mints(credentials: AuthCredentialsResult) -> None:
     credential path prefers over minting.
 
     No-op when nothing was minted, and never reached on a terminal, where the
-    passwords were shown once as before.
+    passwords are shown once as they are generated.
     """
     if not credentials.minted or _stdout_is_a_terminal():
         return
@@ -749,11 +749,10 @@ def deploy_up_web_terminals(
     parameter so this function stays the single place that decides the
     mode-dependent step order:
 
-    - **registry** (default, today's path): :func:`ensure_env_production`
+    - **registry** (the default): :func:`ensure_env_production`
       only exists-checks in this mode (raises if ``.env.production`` is
       missing — a registry deploy expects CI to have produced it already),
-      then the web stack runs ``pull`` before ``up -d``, exactly as before
-      this task.
+      then the web stack runs ``pull`` before ``up -d``.
     - **local**: :func:`ensure_env_production` generates ``.env.production``
       from ``.env`` when absent. Then :func:`build_persona_images` builds
       every referenced persona's ``<project>-<persona>:local`` image —
@@ -770,9 +769,9 @@ def deploy_up_web_terminals(
       upstream tag.
 
     WHY TWO INVOCATIONS, NOT ONE ``-f a -f b -f build/docker-compose.web.yml``:
-    no longer about path resolution. Compose resolves every *relative* path in
+    not path resolution. Compose resolves every *relative* path in
     every merged ``-f`` file (bind-mount sources, ``build:`` contexts,
-    ``env_file:``) against ONE directory, and both invocations below now pin
+    ``env_file:``) against ONE directory, and both invocations below pin
     that directory to the same repo root
     (:func:`~osprey.deployment.compose_generator.compose_base_cmd`), with every
     template spelled against it. Two files, one base — which is what makes the
@@ -1009,7 +1008,7 @@ def _reconcile_web_stack_recreates(
     service whose image or container can't be inspected (missing image,
     container not yet created) is skipped, never aborting the deploy.
 
-    A stale ``.env.auth`` is NOT this function's problem anymore: the render
+    A stale ``.env.auth`` is NOT this function's problem: the render
     step digests the file into the auth sidecar's service definition (the
     ``osprey.auth.env.digest`` label), and a definition change is the recreate
     trigger every compose implementation honours — verified on Docker Compose

--- a/src/osprey/deployment/web_terminals/render.py
+++ b/src/osprey/deployment/web_terminals/render.py
@@ -50,10 +50,9 @@ _COMPOSE_OUTPUT = "docker-compose.web.yml"
 _NGINX_OUTPUT = "nginx/nginx.conf"
 _LANDING_OUTPUT = "nginx/landing.html"
 
-# Per-container constant (Task 1.1): every per-user app's service families
-# (web + every registry companion family) bind this host, never a routable
-# interface —
-# nginx's reverse proxy (Task 1.2) becomes the only off-host path. Not
+# Per-container constant: every per-user app's service families (web + every
+# registry companion family) bind this host, never a routable interface —
+# nginx's reverse proxy is the only off-host path. Not
 # config-driven: unlike the per-family ports, there is no config knob
 # for this, since a facility that wants a per-user port reachable directly
 # off-host would defeat the single-origin chokepoint this module exists to
@@ -62,7 +61,7 @@ _LOOPBACK_BIND_HOST = "127.0.0.1"
 
 # Default nginx image when `modules.web_terminals.nginx_image` is unset. Kept
 # byte-identical to docker-compose.web.yml.j2's own `| default(...)` fallback so
-# an absent config value renders exactly as before this seam existed.
+# an absent config value renders the same image from either side.
 _DEFAULT_NGINX_IMAGE = "nginx:1.27-alpine"
 
 #: The authentication methods this deployment can actually serve: ``none`` (no
@@ -550,9 +549,9 @@ def _user_card(resolved_user: dict[str, Any]) -> dict[str, Any]:
 def _build_groups(
     landing_cfg: dict[str, Any], resolved_users: list[dict[str, Any]]
 ) -> list[dict[str, Any]]:
-    """Transform config ``landing.groups`` (Task 1.2 shape) into template ``groups``
-    (Task 1.6 shape): plain dicts with a ``label`` and an ``items`` key, since
-    landing.html.j2 uses bracket subscript (``group["items"]``) throughout.
+    """Transform config ``landing.groups`` into the template's ``groups`` shape:
+    plain dicts with a ``label`` and an ``items`` key, since landing.html.j2
+    uses bracket subscript (``group["items"]``) throughout.
 
     ``{type: "users"}`` auto-populates one card per configured user, using the
     relative ``/u/<user>/`` path that nginx.conf.j2 (bind-nginx-reverse-proxy)
@@ -561,13 +560,12 @@ def _build_groups(
     resolves to a persona (:func:`resolve_personas` returns a non-``None``
     ``persona``), that card also carries an optional ``sublabel`` holding the
     persona name, shown as a secondary badge on the card; users with no persona
-    in effect (every pre-persona bare-string roster) omit the key entirely, so
-    landing.html.j2's ``{% if item["sublabel"] %}`` guard renders them exactly as
-    before. ``{type: "links", label, links}`` passes ``links`` straight through as
+    in effect (every bare-string roster) omit the key entirely, so
+    landing.html.j2's ``{% if item["sublabel"] %}`` guard renders them without
+    one. ``{type: "links", label, links}`` passes ``links`` straight through as
     ``items`` (link cards never carry a ``sublabel``). Unrecognized/malformed
-    group entries are dropped rather than raising: the lint (Task 1.5) is the
-    authoritative gate on schema well-formedness, this is just the render-time
-    adapter.
+    group entries are dropped rather than raising: lint is the authoritative
+    gate on schema well-formedness, this is just the render-time adapter.
 
     Args:
         landing_cfg: The already-dict-coerced ``modules.web_terminals.landing``
@@ -778,7 +776,7 @@ def _check_roster_charset(services: list[dict[str, Any]], auth_method: str) -> N
 
     Scoped to authentication being on, deliberately: with ``auth.method: none``
     the username is a routing label, not an identity, and raising here would
-    break renders that work today. Lint still reports it in that case.
+    break an otherwise valid render. Lint still reports it in that case.
 
     Args:
         services: The resolved per-user service entries (each with a ``user``).
@@ -852,15 +850,14 @@ def _check_roster_env_var_collisions(services: list[dict[str, Any]], auth_method
 
 def _check_mcp_topology(web_terminals: dict[str, Any]) -> None:
     """Fail closed on any ``modules.web_terminals.mcp.topology`` value other than
-    the one wired topology, ``per_container_stdio`` (Task 2.5).
+    the one wired topology, ``per_container_stdio``.
 
     Only two of the framework's eight MCP servers (``channel-finder`` and
-    ``facility-knowledge``) were found to be safely shareable across a shared
-    HTTP tier without per-user-state corruption — not enough to justify
-    building and securing a whole shared tier this phase. ``shared_http`` is
-    therefore a *recognized but rejected* schema value: it lints as an ERROR
-    (Task 2.4) and raises here at render time. See
-    ``references/modules/web-terminals.md`` for the full deferral rationale.
+    ``facility-knowledge``) are safely shareable across a shared HTTP tier
+    without per-user-state corruption — not enough to justify building and
+    securing a whole shared tier. ``shared_http`` is therefore a *recognized
+    but rejected* schema value: it lints as an ERROR and raises here at render
+    time. See ``references/modules/web-terminals.md`` for the rationale.
 
     This check is scoped to the shared **framework**-MCP tier only. It has
     nothing to do with, and never rejects, a facility's own

--- a/src/osprey/deployment/web_terminals/seeding.py
+++ b/src/osprey/deployment/web_terminals/seeding.py
@@ -316,7 +316,7 @@ def _seed_one_user(
     ``seed_base`` (default ``True``) controls whether ``base_content`` is
     prepended ahead of the user's ``extra.md``. When ``False``, the user's
     ``CLAUDE.md`` payload is its ``extra.md`` alone — the per-persona base
-    opt-out. With ``seed_base=True`` the payload is byte-for-byte the historical
+    opt-out. With ``seed_base=True`` the payload is the byte-for-byte
     ``base_content + extra_content`` concatenation.
 
     Returns:

--- a/src/osprey/health/core/providers.py
+++ b/src/osprey/health/core/providers.py
@@ -6,13 +6,11 @@ once per provider. All items run **concurrently** inside the single category
 callable (``asyncio.gather``); each canary bridges its synchronous
 ``check_health`` onto a daemon thread with a per-item bound of
 :data:`_PER_ITEM_TIMEOUT_S` seconds, so the category's wall-clock stays ≈ 5s
-regardless of how many providers are configured — within the epic-locked poll
-bound.
+regardless of how many providers are configured — within the health poll bound.
 
 Results are advisory only: a reachable provider is ``ok``, and every failure
 mode (bad key, unknown provider, unreachable endpoint, timeout) is ``warning``.
-The category never emits ``error``. Zero configured providers yields no rows,
-matching the pre-framework behavior.
+The category never emits ``error``. Zero configured providers yields no rows.
 """
 
 from __future__ import annotations

--- a/src/osprey/health/core/web_panels.py
+++ b/src/osprey/health/core/web_panels.py
@@ -3,12 +3,12 @@
 Reports whether each web panel the operator has enabled is actually reachable —
 one row per panel, all probed concurrently.
 
-This is the single home for panel liveness. The web terminal's rail used to
-carry a per-entry LED fed by a browser-side poll, which put a status board in a
-navigation surface and reported nothing at all when the terminal wasn't open.
-The rail now renders only the coarse enabled/disabled state; the detailed
-readout lives here, where it sits beside the other core categories, is reachable
-from ``osprey health`` and the MCP surface, and works with no browser involved.
+This is the single home for panel liveness. The web terminal's rail renders only
+the coarse enabled/disabled state — a browser-side poll would put a status board
+in a navigation surface and report nothing at all while the terminal is closed.
+The detailed readout lives here, where it sits beside the other core categories,
+is reachable from ``osprey health`` and the MCP surface, and works with no
+browser involved.
 
 Panels come from two places and are probed accordingly:
 
@@ -52,10 +52,9 @@ _PROBE_TIMEOUT_S = 5.0
 _DEFAULT_BIND = "127.0.0.1"
 
 #: Panel id (as it appears under ``web.panels``) → registry key in
-#: :data:`FRAMEWORK_WEB_SERVERS`. The two namespaces differ for the panels whose
-#: registry entry predates the panel id (``artifacts``/``artifact``,
-#: ``lattice``/``lattice_dashboard``), so the mapping is explicit rather than
-#: derived by string munging.
+#: :data:`FRAMEWORK_WEB_SERVERS`. The two namespaces differ for some panels
+#: (``artifacts``/``artifact``, ``lattice``/``lattice_dashboard``), so the
+#: mapping is explicit rather than derived by string munging.
 _PANEL_TO_REGISTRY_KEY: dict[str, str] = {
     "artifacts": "artifact",
     "ariel": "ariel",

--- a/src/osprey/health/records.py
+++ b/src/osprey/health/records.py
@@ -1,15 +1,15 @@
 """Config loading and category-record assembly for a health run.
 
-This module holds the surface-agnostic core the ``osprey health`` CLI used to
-carry inline: the single ``config.yml`` load (:func:`load_config`) and the
-assembly of the merged category records — built-in "core" categories,
-declarative YAML categories, and facility plugins (:func:`build_records`, with
-its :func:`core_record` / :func:`skip_record` helpers).
+This module holds the surface-agnostic core of a health run: the single
+``config.yml`` load (:func:`load_config`) and the assembly of the merged
+category records — built-in "core" categories, declarative YAML categories, and
+facility plugins (:func:`build_records`, with its :func:`core_record` /
+:func:`skip_record` helpers).
 
-Extracting these off the CLI lets non-CLI surfaces (e.g. the web health view)
-reuse the exact same record-assembly and config-degradation behavior instead of
-reimplementing it. The CLI (:mod:`osprey.cli.health_cmd`) re-imports these names
-and wires them together unchanged.
+Keeping these off the CLI lets non-CLI surfaces (e.g. the web health view) reuse
+the exact same record-assembly and config-degradation behavior instead of
+reimplementing it. The CLI (:mod:`osprey.cli.health_cmd`) imports these names
+and wires them together.
 
 Design contracts honored here:
 

--- a/src/osprey/infrastructure/proxy/app.py
+++ b/src/osprey/infrastructure/proxy/app.py
@@ -42,10 +42,10 @@ def create_proxy_app(
         upstream_base_url: OpenAI-compatible endpoint (e.g. https://aiapi-prod.stanford.edu/v1).
         upstream_api_key: API key for the upstream provider.
     """
-    # One pooled client for the app's lifetime. Creating a fresh AsyncClient per
-    # request (the old behaviour) opened and tore down an upstream TCP connection
-    # every call; at matrix volume that exhausted the host's ephemeral port pool
-    # via tens of thousands of TIME_WAIT sockets (issue #259 outage, 2026-06-18).
+    # One pooled client for the app's lifetime. A fresh AsyncClient per request
+    # opens and tears down an upstream TCP connection every call; at matrix
+    # volume that exhausts the host's ephemeral port pool via tens of thousands
+    # of TIME_WAIT sockets.
     # Construction is safe without a running loop — httpx connects lazily.
     upstream_client = httpx.AsyncClient(
         timeout=300.0,

--- a/src/osprey/infrastructure/server_launcher.py
+++ b/src/osprey/infrastructure/server_launcher.py
@@ -182,9 +182,9 @@ class ServerLauncher:
 
         Ownership is decided by whether a live TCP listener holds the port,
         not by a bare ``/health`` 200. A ``/health`` 200 from a stale or
-        foreign responder is a false positive: it previously made the manager
+        foreign responder is a false positive: acting on it makes the manager
         skip the launch and leave the panel unbacked (proxy 502) after a
-        restart (issue #327). Instead:
+        restart. Instead:
 
         * port free            -> launch and own it;
         * port held then freed -> a shutting-down predecessor; waited out,

--- a/src/osprey/interfaces/artifacts/app.py
+++ b/src/osprey/interfaces/artifacts/app.py
@@ -710,12 +710,12 @@ def create_app(workspace_root: Path | None = None) -> FastAPI:
 
         filepath = Path(data_file)
         if not filepath.is_absolute():
-            # data_file may be (a) a repo-root-relative path like
-            # "var/agent_data/artifacts/foo.json" (current ArtifactStore
-            # format), (b) a bare filename (legacy entries written before the
-            # format change), or (c) some other workspace-relative path. Try
-            # each candidate; the legacy DataContext path used absolute strings
-            # which are handled by the is_absolute() branch above.
+            # A store on disk holds every shape any OSPREY release ever wrote,
+            # so data_file may be (a) a repo-root-relative path like
+            # "var/agent_data/artifacts/foo.json" (the ArtifactStore format),
+            # (b) a bare filename, or (c) some other workspace-relative path.
+            # Try each candidate; the absolute strings a DataContext-era entry
+            # carries are handled by the is_absolute() branch above.
             candidates = [
                 store.repo_root / filepath,
                 store._workspace.parent / filepath,

--- a/src/osprey/interfaces/artifacts/logbook.py
+++ b/src/osprey/interfaces/artifacts/logbook.py
@@ -114,7 +114,7 @@ async def gather_context(
             entry = artifact_store.get_entry(aid)
             if entry is not None:
                 artifacts_meta.append(entry.to_dict())
-        # Set artifact_meta to first for backward compat (artifact_ids in response)
+        # Single-artifact callers read artifact_meta; give them the first
         if artifacts_meta:
             artifact_meta = artifacts_meta[0]
     elif artifact_id is not None:
@@ -157,7 +157,7 @@ JSON_FORMAT_INSTRUCTIONS = (
     '- "tags": a list of 2-5 relevant tags (lowercase, no spaces)'
 )
 
-# Legacy fixed prompt (backward compatibility when no steering fields provided)
+# Fixed prompt, used when no steering fields are provided
 SYSTEM_PROMPT = (
     "You are a logbook entry composer for a particle accelerator control room. "
     "Write concise, technical logbook entries suitable for operator shift logs.\n\n"
@@ -414,8 +414,8 @@ async def compose_entry(
     :func:`_resolve_composition_model` from ``logbook.composition`` (or the
     project's ``claude_code.provider``) and ``api.providers`` tier mappings.
 
-    If *system_prompt* is provided it is used directly; otherwise the
-    legacy ``SYSTEM_PROMPT`` is used for backward compatibility.
+    If *system_prompt* is provided it is used directly; otherwise the fixed
+    ``SYSTEM_PROMPT`` is used.
 
     If *model* is a tier name (haiku/sonnet/opus) the corresponding model_id
     is looked up from the provider's models mapping.
@@ -511,7 +511,7 @@ async def compose(req: ComposeRequest, request: Request):
         include_session_log=req.include_session_log,
     )
 
-    # Resolve system prompt: custom_prompt > steering fields > legacy default
+    # Resolve system prompt: custom_prompt > steering fields > fixed default
     system_prompt: str | None = None
     if req.custom_prompt:
         system_prompt = req.custom_prompt

--- a/src/osprey/interfaces/bluesky_panels/draft_relay.py
+++ b/src/osprey/interfaces/bluesky_panels/draft_relay.py
@@ -1,7 +1,7 @@
 """Sidecar passthrough relay for the Bluesky bridge's plan-draft endpoints.
 
-Task 3.1 (sidecar-draft-relay) of the agent-plan-draft plan. This module only
-defines ``router``; ``osprey.interfaces.bluesky_panels.app`` mounts it alongside
+This module only defines
+``router``; ``osprey.interfaces.bluesky_panels.app`` mounts it alongside
 ``read_proxy``/``launch``/``health``, so every route here reads the shared
 ``httpx.AsyncClient`` and resolved bridge base URL from ``request.app.state``
 at request time (set in the app's lifespan) -- exactly the ``read_proxy``

--- a/src/osprey/interfaces/channel_finder/pending_review_api.py
+++ b/src/osprey/interfaces/channel_finder/pending_review_api.py
@@ -72,16 +72,16 @@ def _resolve_artifact(item: dict, project_cwd: str) -> dict | None:
     Returns ``{"id": ..., "title": ..., "filename": ...}`` or ``None``.
 
     The index is located the way the STORE derives it — the deployment's
-    agent-data root plus the store's own ``artifacts`` subdirectory — not by
-    joining a literal onto the app's working directory. The literal named the
-    retired ``_agent_data``, so this read never found the file the store had
-    written, and every failure here is swallowed by the ``except`` below: the
-    pending-review UI simply showed no artifact for any item, with nothing in
-    the log to say why. ``project_cwd`` no longer takes part in that
-    resolution; it stays on the signature because the route hands it in and its
-    meaning for the app is not this function's to redefine.
+    agent-data root plus the store's own ``artifacts`` subdirectory — never by
+    joining a literal onto the app's working directory. A literal that names a
+    different root reads a file the store never wrote, and every failure here is
+    swallowed by the ``except`` below: the pending-review UI would show no
+    artifact for any item, with nothing in the log to say why. ``project_cwd``
+    takes no part in that resolution; it stays on the signature because the
+    route hands it in and its meaning for the app is not this function's to
+    redefine.
     """
-    del project_cwd  # no longer part of the artifact location; see above
+    del project_cwd  # takes no part in the artifact location; see above
     try:
         artifacts_path = _artifacts_dir() / "artifacts.json"
         if not artifacts_path.is_file():

--- a/src/osprey/interfaces/design_system/generator/emit_css.py
+++ b/src/osprey/interfaces/design_system/generator/emit_css.py
@@ -72,7 +72,7 @@ def _default_theme_stem(tree: TokenTree) -> str:
     independent of filename/manifest order, so adding a theme family whose
     files sort before the canonical one can never hijack the product
     default. When no theme is flagged, fall back to the first dark theme
-    in manifest order (the historical behavior).
+    in manifest order.
 
     Args:
         tree: The loaded token tree.

--- a/src/osprey/interfaces/design_system/generator/emit_js.py
+++ b/src/osprey/interfaces/design_system/generator/emit_js.py
@@ -237,8 +237,7 @@ def _default_family(tree: TokenTree, defaults: dict[str, dict[str, str]]) -> str
     manifest order, so a family whose files sort before the canonical one
     can never silently become the product default. When no theme is
     flagged, fall back to the first family declared in the manifest
-    (insertion order, itself manifest/filename order -- the historical
-    behavior).
+    (insertion order, itself manifest/filename order).
 
     Shared by :func:`render_tokens_js` (which exports it as
     ``DEFAULT_FAMILY`` for ``theme-manager.js`` to read) and
@@ -349,7 +348,7 @@ def render_theme_boot_js(tree: TokenTree) -> str:
     server-rendered ``<html data-theme>`` attribute, each validated
     against the baked-in id list (the query/storage rungs also accept the
     special ``'auto'`` value); the first candidate that validates wins,
-    and anything left over (missing or unknown/legacy) falls all the way
+    and anything left over (missing or unrecognized) falls all the way
     through to ``'auto'``. ``'auto'`` resolves via
     ``matchMedia('(prefers-color-scheme: dark)')`` against ``DEFAULTS``.
     ``data-theme`` is set synchronously as the script's last statement, so
@@ -358,7 +357,7 @@ def render_theme_boot_js(tree: TokenTree) -> str:
     before it.
 
     Server-attribute contract (for whoever renders ``<html>`` server-side,
-    e.g. Task 1.10's web_terminal server): the boot script reads
+    e.g. the web_terminal server): the boot script reads
     ``document.documentElement.getAttribute("data-theme")`` — i.e. the
     ``data-theme`` attribute on the ``<html>`` element. It is treated as a
     candidate only when it is a non-null string present in the baked
@@ -382,8 +381,7 @@ def render_theme_boot_js(tree: TokenTree) -> str:
     otherwise ``DEFAULT_FAMILY`` — the first family declared in the
     manifest (manifest/filename order — never re-sorted) — is the
     deterministic fallback, reached only when no server attribute is
-    present/valid (e.g. before Task 1.10 wires up server rendering, or if
-    it's ever omitted).
+    present/valid (a host that does no server rendering, or omits it).
 
     Args:
         tree: A token tree that has already passed
@@ -473,7 +471,7 @@ def render_theme_boot_js(tree: TokenTree) -> str:
 
   // The server-rendered rung (finding I4): whatever data-theme already
   // sits on <html> when this script runs, e.g. stamped by the web server
-  // from config (Task 1.10). Read once so both the resolution candidate
+  // from config. Read once so both the resolution candidate
   // below and the no-clobber check at the end use the exact same value.
   function readServerTheme() {{
     try {{

--- a/src/osprey/interfaces/design_system/generator/inherits.py
+++ b/src/osprey/interfaces/design_system/generator/inherits.py
@@ -10,9 +10,9 @@ interface to duplicate an identical group.
 Both the validator (which fail-closed-checks the map) and the CSS emitter
 (which must emit the borrowed group into the opted-out theme's block) have to
 agree on where that map lives and what it means. Reading it in exactly one
-place is what stops them from drifting — the drift that previously left every
-high-contrast block emitting *no* interface tokens because the emitter never
-consulted ``inherits`` at all.
+place is what stops them from drifting: an emitter that does not consult
+``inherits`` emits *no* interface tokens into any high-contrast block, and the
+validator passes it anyway.
 """
 
 from __future__ import annotations

--- a/src/osprey/interfaces/design_system/generator/naming.py
+++ b/src/osprey/interfaces/design_system/generator/naming.py
@@ -6,12 +6,12 @@ need the same two naming rules — the semantic/extension mapping
 (:func:`promoted_css_name`, driven by :data:`PROMOTED_PRIMITIVE_GROUPS`).
 Keeping them in this leaf module means the validator's collision checks and
 the emitter's output physically cannot disagree about an emitted name, and
-the validator no longer depends on the emitter (previously it imported the
-emitter's private promoted-groups tuple and re-derived the promoted name
-inline — exactly the drift class ``inherits.py`` was created to kill).
+the validator does not depend on the emitter. Neither side may reach into the
+other's promoted-groups tuple and re-derive a promoted name inline — that is
+exactly the drift class ``inherits.py`` exists to kill.
 
 Dot-path to CSS custom property name is *not* a uniform kebab-join — see
-:func:`css_variable_name` for the exact rules (a handful of legacy names
+:func:`css_variable_name` for the exact rules (a handful of names
 are preserved verbatim, ``tint.*``/``terminal.ansi.*`` are reshaped, and
 ``code.*`` is excluded entirely since it selects a highlight.js asset name
 consumed elsewhere, not a CSS value).
@@ -27,7 +27,7 @@ __all__ = ["PROMOTED_PRIMITIVE_GROUPS", "css_variable_name", "promoted_css_name"
 _EXCLUDED_GROUPS = frozenset({"code"})
 
 #: Dot-path -> CSS custom property name overrides that don't follow the
-#: naive kebab-join rule. Most preserve today's widely-used legacy names;
+#: naive kebab-join rule. Most preserve a widely-used name verbatim;
 #: the ``accent``/``accent-secondary``/``status`` entries also keep the two
 #: accent roles and the status colors on a single ``--color-*`` prefix, so
 #: the emitted names read as one semantic family rather than as whatever

--- a/src/osprey/interfaces/design_system/static/js/theme-boot.js
+++ b/src/osprey/interfaces/design_system/static/js/theme-boot.js
@@ -93,7 +93,7 @@
 
   // The server-rendered rung (finding I4): whatever data-theme already
   // sits on <html> when this script runs, e.g. stamped by the web server
-  // from config (Task 1.10). Read once so both the resolution candidate
+  // from config. Read once so both the resolution candidate
   // below and the no-clobber check at the end use the exact same value.
   function readServerTheme() {
     try {

--- a/src/osprey/interfaces/health/engine.py
+++ b/src/osprey/interfaces/health/engine.py
@@ -70,9 +70,9 @@ class HealthCheckEngine:
     """Owns the cached report and the single-flight refresh that produces it.
 
     Args:
-        loader: The synchronous config-load phase (task 2.1). Called on a daemon
+        loader: The synchronous config-load phase. Called on a daemon
             thread via :func:`offload.run_sync` each refresh.
-        lifecycle: The connector-runtime owner (task 2.2). Its
+        lifecycle: The connector-runtime owner. Its
             :meth:`~HealthRuntimeLifecycle.reconcile` is called each cycle and
             its in-flight-task provider is wired to this engine so teardown can
             cancel a running refresh.

--- a/src/osprey/interfaces/lattice_dashboard/app.py
+++ b/src/osprey/interfaces/lattice_dashboard/app.py
@@ -213,10 +213,9 @@ def create_app(workspace_root: Path | None = None) -> FastAPI:
         workspace_root: Agent-data root (e.g. ``<repo>/var/agent_data``). The
             lattice state lives under ``<workspace>/lattice/``. Omit it to
             resolve the deployment's configured root, which is what the
-            framework launch path passes explicitly. The default used to be a
-            cwd-relative directory, so a direct caller standing anywhere but the
-            repo root got a fresh empty state rather than the running
-            deployment's.
+            framework launch path passes explicitly. Never default it to a
+            cwd-relative directory: a caller standing anywhere but the repo root
+            would get a fresh empty state rather than the running deployment's.
     """
     ws_root = Path(workspace_root) if workspace_root else resolve_shared_data_root()
     state_dir = ws_root / "lattice"

--- a/src/osprey/interfaces/okf_panel/app.py
+++ b/src/osprey/interfaces/okf_panel/app.py
@@ -199,9 +199,9 @@ def create_app(bundle_path=None) -> FastAPI:
 
     # Shared CORS + middleware + static mounts (/design-system, /static/fonts,
     # /static) applied last so they wrap the fully-assembled app and never
-    # shadow the API routes above. Drops the old allow_credentials=True (the
-    # shared helper deliberately omits it) and adds the design-system mounts the
-    # theme trio in index.html needs.
+    # shadow the API routes above. Carries no allow_credentials=True (the shared
+    # helper deliberately omits it) and adds the design-system mounts the theme
+    # trio in index.html needs.
     configure_interface_app(app, static_dir=STATIC_DIR)
 
     return app

--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -348,18 +348,16 @@ def resolve_ui_mode(configured: str) -> str:
     return DEFAULT_UI_MODE
 
 
-#: The two supported rail positions. ``left`` is the redesign's icon-rail
-#: column; ``top`` renders the same rail as a horizontal strip under the
-#: header — the arrangement operators know from the pre-redesign tab bar.
+#: The two supported rail positions. ``left`` is the icon-rail column;
+#: ``top`` renders the same rail as a horizontal strip under the header.
 RAIL_POSITIONS = ("left", "top")
 DEFAULT_RAIL_POSITION = "left"
 
 #: Per-theme-family rail defaults, applied only when ``web.rail_position``
-#: is absent from config. The ``retro`` family restores the pre-redesign
-#: look, and the horizontal tab strip under the header is part of that look
-#: — picking Retro without also moving the rail would hand back the old
-#: colors inside the new layout. Any family not listed here defaults to
-#: :data:`DEFAULT_RAIL_POSITION`.
+#: is absent from config. The ``retro`` family carries a horizontal tab strip
+#: under the header as part of its look — picking Retro without also moving
+#: the rail would give its colors a layout they were never drawn for. Any
+#: family not listed here defaults to :data:`DEFAULT_RAIL_POSITION`.
 #:
 #: This map is the single source of truth for the coupling: ``GET
 #: /api/panels`` echoes it to the browser so ``rail-position.js`` can follow
@@ -670,7 +668,7 @@ def _create_lifespan(
         max_bg = int(config.get("max_background_sessions", 5))
         app.state.pty_registry = PtyRegistry(max_background=max_bg)
 
-        # ── Simple-mode chat pool bounds (Task 1.7) ──
+        # ── Simple-mode chat pool bounds ──
         # Three knobs bound the operator-chat pool; each fails open to its
         # default so a missing/broken config never blocks startup. Read from
         # the top-level `web` section (same section as web.theme/web.ui_mode).
@@ -717,7 +715,7 @@ def _create_lifespan(
             or str(_load_web_ui_config(config_path).get("app_name") or "").strip()
         )
         # Per-user deployment identity for multi-user compose stacks. No
-        # config key exists for either of these today, so the config-side
+        # config key exists for either of these, so the config-side
         # fallback is always empty and ``OSPREY_TERMINAL_USER`` /
         # ``OSPREY_TERMINAL_LANDING_URL`` are the sole source. Empty ⇒ no
         # user badge / logout control is rendered.
@@ -763,10 +761,10 @@ def _create_lifespan(
                 break
         app.state.config_path = resolved_config_path
 
-        # ── Web theme (SSR no-FOUC attribute, Task 1.10) ──
+        # ── Web theme (SSR no-FOUC attribute) ──
         # Resolved once at startup and server-rendered onto <html data-theme>
-        # so the generated theme-boot.js first-paints with no flash (Task
-        # 1.8). Fails open on any load error — a missing/broken theme
+        # so the generated theme-boot.js first-paints with no
+        # flash. Fails open on any load error — a missing/broken theme
         # registry must never block server startup.
         try:
             from osprey.utils.config import get_config_value
@@ -807,9 +805,9 @@ def _create_lifespan(
             app.state.web_theme_mode = None
             app.state.web_theme_family = None
 
-        # ── Web UI mode (SSR no-flash attribute, Task 5.1) ──
+        # ── Web UI mode (SSR no-flash attribute) ──
         # Resolved once at startup and server-rendered onto <html data-ui-mode>
-        # so the pre-paint mode-boot script (Task 5.2) first-paints in the right
+        # so the pre-paint mode-boot script first-paints in the right
         # mode. GET /api/panels also carries ui_mode, but first paint must never
         # depend on that API field — this server-rendered attribute is the
         # authoritative first-paint rung. Read via load_osprey_config (the same
@@ -941,11 +939,10 @@ def _create_lifespan(
                     )
 
         # The watcher's default follows the deployment's CONFIGURED agent-data
-        # root, anchored on the repo. The literal it replaced — `./_agent_data`
-        # — was wrong twice over: it named a directory the three-zone layout
-        # retired (state lives under `var/`), and it anchored on the working
-        # directory, so a terminal started from anywhere but the repo root
-        # watched a path that did not exist and reported no sessions at all.
+        # root, anchored on the repo. Never a cwd-relative literal: state lives
+        # under `var/`, and a path anchored on the working directory means a
+        # terminal started from anywhere but the repo root watches a directory
+        # that does not exist and reports no sessions at all.
         #
         # Deliberately NOT resolve_agent_data_root(): that applies
         # OSPREY_SESSION_ID isolation, and this watcher's whole job is to see
@@ -983,9 +980,8 @@ def _create_lifespan(
         app.state.visible_panels = panel_runtime.visible_panels
 
         # Config-defined panel presets ("Layouts"): named sets of panel ids a
-        # human applies in one click. Immutable config-derived state — the only
-        # new server state this feature adds. Empty (the default) → the "+" menu
-        # renders exactly as before.
+        # human applies in one click. Immutable config-derived state. Empty
+        # (the default) → the "+" menu renders no presets section.
         app.state.panel_presets = _load_panel_presets(enabled_panels, custom_panels)
 
         if panel_runtime.allow_runtime_panels and not panel_runtime.runtime_panel_allowlist:
@@ -1038,7 +1034,7 @@ def _create_lifespan(
             trust_env=False,
         )
 
-        # ── Idle chat-session reaper (Task 1.7) ──
+        # ── Idle chat-session reaper ──
         # Periodically evicts idle chat sessions (per the registry's idle
         # predicate, which also collects zombie-busy sessions) so an abandoned
         # Simple-mode tab does not pin a pool slot indefinitely. Fail-open at

--- a/src/osprey/interfaces/web_terminal/routes/panels.py
+++ b/src/osprey/interfaces/web_terminal/routes/panels.py
@@ -209,7 +209,7 @@ async def get_panels(request: Request):
     ``rail_position`` mirrors the server-rendered ``<html data-rail-position>``
     the same way, and travels with two companions: ``family_rail_defaults``
     (``app.FAMILY_RAIL_DEFAULTS``, the theme-family -> rail-position coupling
-    that makes the retro family restore the pre-redesign top tab strip) and
+    that gives the retro family a top tab strip) and
     ``rail_position_configured`` (whether ``web.rail_position`` was set
     explicitly, which outranks that coupling). ``rail-position.js`` reads both
     so a live theme-family switch can move the rail without the browser
@@ -604,7 +604,7 @@ async def arrange_panels(body: PanelArrangeRequest, request: Request):
     an entry of ``web.presets`` (``app.state.panel_presets``); its members are
     resolved here so the human "Layouts" click and an agent preset call are one
     server operation. A preset additionally sets ``prune_rail`` on the
-    broadcast, preserving today's membership-exclusive preset semantics
+    broadcast, giving presets membership-exclusive semantics
     (non-members leave the launcher rail); a ``tiles`` request never removes
     rail membership, it only adds any listed non-member.
 
@@ -731,8 +731,8 @@ async def report_panel_layout(body: PanelLayoutRequest, request: Request):
     **unknown** (``open_tiles = None``) while still stamping the timestamp and
     the flag — ``GET /api/panels`` then reports ``open_tiles: null`` with a
     numeric age, meaning "a client is watching but cannot report tile order".
-    The request wire format is unchanged; the mapping happens here. ``dock:
-    true`` records the list verbatim, exactly as before.
+    The mapping happens here, not on the wire. ``dock: true`` records the list
+    verbatim.
 
     Content dedupe: a report whose *recorded* occupancy and ``dock`` flag both
     equal the stored state is a no-op — the stored timestamp is deliberately

--- a/src/osprey/interfaces/web_terminal/routes/proxy.py
+++ b/src/osprey/interfaces/web_terminal/routes/proxy.py
@@ -192,7 +192,7 @@ async def proxy_panel_design_system(panel_id: str, asset_path: str, request: Req
     broadcasts resolves to the wrong colors inside that one frame.
 
     Intercepting here makes the shared design system single-sourced from the
-    hub for every embedded panel, so theme consistency no longer depends on
+    hub for every embedded panel, so theme consistency does not depend on
     each sidecar's build being in step. Sidecars still serve their own
     ``/design-system`` on their standalone URLs; only the embedded path is
     redirected to the hub's copy.

--- a/src/osprey/interfaces/web_terminal/scaffold_gallery_service.py
+++ b/src/osprey/interfaces/web_terminal/scaffold_gallery_service.py
@@ -153,9 +153,9 @@ class ScaffoldGalleryService:
         # a body, but a record is more than a body: left in place it flows into
         # the union below and the gallery tells the operator they own the
         # write-safety layer's config, shows them the framework's text as
-        # theirs, and fails their save. A record can predate the guard that
-        # would refuse it today — the store outlives the image — so the read
-        # side has to be as skeptical as the write side.
+        # theirs, and fails their save. The store outlives the image, so it can
+        # hold a record the write guard would refuse — the read side has to be
+        # as skeptical as the write side.
         self._records = {
             name: record
             for name, record in raw.items()
@@ -673,9 +673,9 @@ class ScaffoldGalleryService:
         convention and each convention already decides the shape of one entry:
         a rule is a markdown file, a hook is a script known by its filename, a
         skill is a directory. Assembling ``.claude/<category>/<name>.md`` by
-        hand — what this used to do — got two of the three wrong: it dropped a
-        hook's ``.py`` from the name ownership records, and it wrote a skill as
-        a flat file that Claude Code does not load at all.
+        hand gets two of the three wrong: it drops a hook's ``.py`` from the
+        name ownership records, and it writes a skill as a flat file that
+        Claude Code does not load at all.
         """
         allowed = {"agents", "rules", "hooks", "skills", "commands", "output-styles"}
         if category not in allowed:

--- a/src/osprey/mcp_server/bluesky/tools/draft.py
+++ b/src/osprey/mcp_server/bluesky/tools/draft.py
@@ -49,10 +49,10 @@ logger = logging.getLogger("osprey.mcp_server.bluesky.tools.draft")
 _CLIENT_ID = "mcp-agent"
 
 # Canonical id the build registers the panel under (web.panels.bluesky) and the
-# sidecar path segments it is served at, in preference order. ``plan`` is the
-# pre-merge mount of what is now the panel's Plans tab; the sidecar still serves
-# the same bundle there, so a deployment whose config.yml predates the merge is
-# still found — but only after the current spelling has been looked for.
+# sidecar path segments it is served at, in preference order. ``plan`` is a
+# second mount of the panel's Plans tab serving the same bundle, so a config.yml
+# naming it is still found — but only after the canonical spelling has been
+# looked for.
 _DEFAULT_PLANS_PANEL_ID = "bluesky"
 _PLANS_PANEL_PATH_SEGMENTS = ("bluesky", "plan")
 

--- a/src/osprey/mcp_server/bluesky/tools/queue.py
+++ b/src/osprey/mcp_server/bluesky/tools/queue.py
@@ -1,9 +1,9 @@
 """MCP tools: the agent's side of the bridge's plan queue.
 
-The queue replaces the old launch-a-single-draft path. Execution is now two
-steps, deliberately: ``queue_add`` puts the pinned draft into the queue (which
-starts nothing), and ``queue_start`` begins draining it (which starts a real
-plan). Splitting them is what lets a human review a composed queue before
+Execution is two steps, deliberately: ``queue_add`` puts the pinned draft into
+the queue (which starts nothing), and ``queue_start`` begins draining it (which
+starts a real plan). Splitting them is what lets a human review a composed queue
+before
 anything moves, and it is why the arming gate sits on *start* rather than on
 composition.
 
@@ -237,8 +237,8 @@ def _refuse_unarmed(tool: str) -> NoReturn:
     the agent's environment holds no launch token BY DESIGN — the token lives
     with the operator's queue panel, and only a human arms from there. So the
     suggestion sends the agent to the human, never to config surgery
-    (``queue_start`` itself no longer comes here at all — tokenless, it files
-    a start request for the panel instead).
+    (``queue_start`` itself never comes here — tokenless, it files a start
+    request for the panel instead).
     """
     return make_error(
         "launch_token_required",
@@ -421,7 +421,7 @@ async def queue_add(draft_revision: int) -> str:
 
     A revision is consumable exactly once. Queuing the same plan twice — a
     repeat scan, a retry — needs a draft edit (set_draft) to mint a new
-    revision first; re-adding the old one is refused, by design, so a
+    revision first; re-adding the spent one is refused, by design, so a
     duplicated call cannot silently double-queue a scan.
 
     Args:

--- a/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
+++ b/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
@@ -154,8 +154,8 @@ def _inject_provider_env_once() -> None:
     # The render's config (``<repo>/build/config.yml``), taken from the
     # environment the compose service sets rather than re-derived from the repo
     # root: a flat ``<repo>/config.yml`` names no file in a three-zone
-    # deployment, so this read used to miss and the worker started with no
-    # provider auth at all — silently, on the warning branch below.
+    # deployment, so a read derived that way misses and the worker starts with
+    # no provider auth at all — silently, on the warning branch below.
     config_path = deployed_config_path()
     repo_root = deployed_repo_root()
     if not config_path.is_file():
@@ -890,7 +890,7 @@ async def health() -> dict[str, Any]:
             counts[s] += 1
     # Process-lifetime failure counters — monotonic and independent of the
     # evictable _runs map above (see counters module docstring). The _runs-derived
-    # error_runs field is retained unchanged for compatibility.
+    # error_runs field below is a separate, evictable count.
     lifetime = counters.get_counts()
     return {
         "status": "ok",

--- a/src/osprey/mcp_server/dispatch_worker/tool_policy.py
+++ b/src/osprey/mcp_server/dispatch_worker/tool_policy.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover - exercised only without the SDK
 logger = logging.getLogger("osprey.mcp_server.dispatch_worker.tool_policy")
 
 # Permission-free harness tools the CLI lets an agent use without any allow
-# rule today; a strict deny-only hook would otherwise starve them (TodoWrite
+# rule; a strict deny-only hook would otherwise starve them (TodoWrite
 # progress tracking, WaitForMcpServers for MCP cold-start races). Deliberately
 # NOT included: Read/Glob/Grep — main-thread file access would expose e.g.
 # config.yml provider settings. Denylist entries still beat this set.
@@ -184,7 +184,7 @@ def make_backstop(
     subagent context to the union of all declared surfaces —
     ``ToolPermissionContext`` carries no ``agent_type``, so per-agent
     precision is the hook's job; the union merely never widens the main
-    thread (which today's flat allowlist would).
+    thread (which a single flat allowlist would).
     """
     trigger_set = frozenset(trigger_tools)
     denied_tuple = tuple(denied_tools)

--- a/src/osprey/mcp_server/phoebus/models.py
+++ b/src/osprey/mcp_server/phoebus/models.py
@@ -2,12 +2,9 @@
 
 Pydantic models for configuring Data Browser plots, traces, and annotations.
 
-Migrated from the retired ``phoebus_launch`` server
-(``als-profiles/mcp_servers/phoebus/models.py``) as part of reincarnating its
-``.plt``-generation capability inside the native ``phoebus_open_databrowser``
-tool (see ``.claude/plans/phoebus-als-integration/ADDENDUM-databrowser-reincarnation.md``,
-Task 0.5). Facility-neutral: nothing here names a specific facility, archiver,
-or host — that binding is supplied by the caller (see ``plt_generator``).
+These back the ``.plt`` generation behind ``phoebus_open_databrowser``.
+Facility-neutral: nothing here names a specific facility, archiver, or host —
+that binding is supplied by the caller (see ``plt_generator``).
 """
 
 from __future__ import annotations

--- a/src/osprey/mcp_server/phoebus/plt_generator.py
+++ b/src/osprey/mcp_server/phoebus/plt_generator.py
@@ -2,22 +2,19 @@
 
 Generates Data Browser XML (``.plt``) files from ``PlotConfig`` objects.
 
-Migrated from the retired ``phoebus_launch`` server
-(``als-profiles/mcp_servers/phoebus/plt_generator.py``) as the reincarnated
-capability inside ``phoebus_open_databrowser`` — see
-``.claude/plans/phoebus-als-integration/ADDENDUM-databrowser-reincarnation.md``,
-Task 0.5. The ``.plt`` XML serializer and archiver ``<archive>`` binding are
-kept verbatim; two things were dropped on migration:
+The generator supplies the ``.plt`` XML serializer and the archiver
+``<archive>`` binding behind ``phoebus_open_databrowser``. Two things it
+deliberately does not do:
 
-* ``create_launch_uri`` (the ``myapp://`` custom-scheme launcher) — nothing in
-  the live-open flow consumes it; the bridge ``POST /open`` opens the
-  generated ``.plt`` directly.
-* The hardcoded ALS archiver default. ``archiver_url`` now defaults to
-  ``None`` (no facility baked into framework code); the caller resolves it
-  from config/env (``phoebus.archiver_url`` — each facility profile supplies
-  its own archiver appliance URL). When no archiver URL is supplied, PVs are
-  emitted without an ``<archive>`` binding (live-only data, no historical
-  backfill) rather than silently pointing at a facility that may not exist.
+* No ``myapp://`` custom-scheme launch URI — nothing in the live-open flow
+  consumes one; the bridge ``POST /open`` opens the generated ``.plt``
+  directly.
+* No archiver default. ``archiver_url`` defaults to ``None`` (no facility
+  baked into framework code); the caller resolves it from config/env
+  (``phoebus.archiver_url`` — each facility profile supplies its own archiver
+  appliance URL). When no archiver URL is supplied, PVs are emitted without an
+  ``<archive>`` binding (live-only data, no historical backfill) rather than
+  silently pointing at a facility that may not exist.
 """
 
 from __future__ import annotations

--- a/src/osprey/mcp_server/phoebus/tools/bridge_tools.py
+++ b/src/osprey/mcp_server/phoebus/tools/bridge_tools.py
@@ -145,9 +145,9 @@ def _snapshot_dir() -> Path:
     Runtime output, so it belongs under the deployment's agent-data root — read
     from ``agent_data.base_dir`` rather than spelled here — and a configured
     ``phoebus.snapshot_dir`` is anchored on the repo root the same way every
-    other configured path is. Both halves matter: the default used to name the
-    retired ``./_agent_data``, and either value used to resolve against the
-    working directory, which for an MCP server is whatever launched it.
+    other configured path is. Both halves matter: neither the default nor the
+    configured value may resolve against the working directory, which for an
+    MCP server is whatever launched it.
     """
     config = load_osprey_config()
     configured = (config.get("phoebus", {}) or {}).get("snapshot_dir")

--- a/src/osprey/mcp_server/phoebus/tools/databrowser_tools.py
+++ b/src/osprey/mcp_server/phoebus/tools/databrowser_tools.py
@@ -1,14 +1,11 @@
 """MCP tool: bring up a live Phoebus Data Browser for a PV list + time range.
 
-Reincarnates the ``.plt``-generation capability of the retired
-``phoebus_launch`` server (``als-profiles/mcp_servers/phoebus/``) as a
-first-class action of the native Phoebus agent — see
-``.claude/plans/phoebus-als-integration/ADDENDUM-databrowser-reincarnation.md``,
-Task 0.5. Two things changed on migration:
+``.plt`` generation is a first-class action of the Phoebus agent. Two design
+choices shape this tool:
 
-* The embedded LLM styling call is gone. The calling agent is already an LLM
-  — it supplies styling as structured tool arguments (``styling=``) instead
-  of a natural-language ``query`` that used to be sent to a second model.
+* No embedded LLM styling call. The calling agent is already an LLM — it
+  supplies styling as structured tool arguments (``styling=``) rather than a
+  natural-language ``query`` that a second model would have to interpret.
 * Live-open instead of a ``myapp://`` hand-off. This tool writes a styled
   ``.plt`` into the workspace (reusing ``plt_generator``) and POSTs its
   *content* to the agent bridge's ``POST /open`` — the same bridge-client
@@ -22,7 +19,7 @@ generated XML is read back and POSTed as ``{"content": <xml>, "extension":
 "plt"}`` — the bridge writes its own temp file and opens that. The local
 ``.plt`` written by ``plt_generator`` is kept only as a shareable artifact
 (``plt_file`` in the result, a path in *this* tool's own container) for the
-operator to inspect or download; the open no longer depends on it.
+operator to inspect or download; the open does not depend on it.
 
 Facility-neutral archiver binding: the archiver-appliance URL bound into the
 generated ``.plt`` is never hardcoded here — it is resolved from
@@ -71,8 +68,7 @@ logger = logging.getLogger("osprey.mcp_server.tools.phoebus_databrowser")
 
 _EnumT = TypeVar("_EnumT", bound=Enum)
 
-# Default color palette for multiple PVs — parity with the retired server's
-# DEFAULT_COLORS rotation (phoebus_launch.py).
+# Default color palette for multiple PVs, rotated trace by trace.
 _DEFAULT_COLORS: list[tuple[int, int, int]] = [
     (0, 100, 200),  # Blue
     (200, 0, 0),  # Red
@@ -111,9 +107,9 @@ def _plot_dir() -> Path:
     Runtime output, so it belongs under the deployment's agent-data root — read
     from ``agent_data.base_dir`` rather than spelled here — and a configured
     ``phoebus.plot_dir`` is anchored on the repo root the same way every other
-    configured path is. Both halves matter: the default used to name the retired
-    ``./_agent_data``, and either value used to resolve against the working
-    directory, which for an MCP server is whatever launched it.
+    configured path is. Both halves matter: neither the default nor the
+    configured value may resolve against the working directory, which for an
+    MCP server is whatever launched it.
     """
     config = load_osprey_config()
     configured = (config.get("phoebus", {}) or {}).get("plot_dir")
@@ -168,9 +164,9 @@ def _build_plot_config(
     end_time: str,
     styling: dict | None,
 ) -> PlotConfig:
-    """Translate tool arguments into a ``PlotConfig``, applying the retired
-    server's defaults (color rotation, appearance) wherever ``styling``
-    leaves a value unspecified.
+    """Translate tool arguments into a ``PlotConfig``, applying this module's
+    defaults (color rotation, appearance) wherever ``styling`` leaves a value
+    unspecified.
 
     Raises ``ValueError`` (naming the offending ``styling`` field) on any
     malformed sub-field — enum coercion, color tuples, or
@@ -295,7 +291,7 @@ async def phoebus_open_databrowser(
             "scroll": bool, "update_period": float, "axis_name": str,
             "auto_scale": bool, "axis_min": float, "axis_max": float,
             "log_scale": bool, "annotations": [...]}``. Any key omitted uses
-            the retired server's original default.
+            this module's default.
 
     Returns:
         JSON ``{"status": "success", "handle": "handle:d-N", "plt_file":

--- a/src/osprey/mcp_server/python_executor/executor.py
+++ b/src/osprey/mcp_server/python_executor/executor.py
@@ -27,11 +27,10 @@ from osprey.utils.config import EXECUTION_METHOD_SUBPROCESS
 
 logger = logging.getLogger("osprey.mcp_server.python_executor.executor")
 
-# scrub_sensitive_env (and its deny-list constants) used to be defined here.
-# The implementation now lives in osprey.mcp_server.sandbox_env (imported
-# above) so this module and the workspace sandbox
-# (osprey.mcp_server.workspace.execution.sandbox_executor) share one deny-list
-# instead of two that could drift.
+# scrub_sensitive_env and its deny-list constants live in
+# osprey.mcp_server.sandbox_env (imported above), never here: this module and
+# the workspace sandbox (osprey.mcp_server.workspace.execution.sandbox_executor)
+# must share one deny-list rather than two that can drift.
 
 
 @dataclass

--- a/src/osprey/mcp_server/python_executor/tools/_execution_gates.py
+++ b/src/osprey/mcp_server/python_executor/tools/_execution_gates.py
@@ -4,10 +4,10 @@ Both tools take an ``execution_mode`` string and guard control-system writes
 with two independent checks: a per-call readonly gate (pattern detection) and a
 deployment-level kill switch (``control_system.writes_enabled`` in the project
 config). Each gate only recognises one canonical spelling, so any *other*
-string used to fall through both — not "readonly", so write patterns were not
-blocked; not "readwrite", so the kill switch never fired. Rejecting unknown
-modes here closes that hole for every caller at once, and gives the kill
-switch a single implementation instead of one copy per tool.
+string falls through both — not "readonly", so write patterns are not blocked;
+not "readwrite", so the kill switch never fires. Rejecting unknown modes here
+closes that hole for every caller at once, and gives the kill switch a single
+implementation instead of one copy per tool.
 """
 
 from __future__ import annotations

--- a/src/osprey/mcp_server/python_executor/tools/_package_inventory.py
+++ b/src/osprey/mcp_server/python_executor/tools/_package_inventory.py
@@ -1,10 +1,10 @@
 """Live package inventory for the Python-executor tool descriptions.
 
-The ``execute`` tool description used to name a fixed set of packages
-(``numpy``, ``pandas``, ``scipy``, ``at``, ``matplotlib``, ``plotly``) whatever
-the deployment had actually installed, so the agent reasoned about an import
-set that did not exist — a package present on the host but missing inside the
-deployed container was described as available either way.
+The ``execute`` tool description must never name a fixed set of packages
+(``numpy``, ``pandas``, ``scipy``, ``at``, ``matplotlib``, ``plotly``): a fixed
+list makes the agent reason about an import set that may not exist — a package
+present on the host but missing inside the deployed container would be
+described as available either way.
 
 This module enumerates the environment that
 :func:`~osprey.mcp_server.python_executor.executor.resolve_agent_interpreter`

--- a/src/osprey/mcp_server/python_executor/tools/_response_builder.py
+++ b/src/osprey/mcp_server/python_executor/tools/_response_builder.py
@@ -32,7 +32,7 @@ async def build_execution_response(
     reported errors, raises ``ToolError`` carrying the OSPREY error envelope
     so fastmcp produces a wire-form ``CallToolResult(isError=True)`` (returning
     a CallToolResult with ``isError`` set is silently dropped by fastmcp's
-    ``convert_result`` — see the migration in commit cdba442d).
+    ``convert_result``).
 
     Args:
         code: Original source code (for notebook/metadata — not augmented).
@@ -134,7 +134,7 @@ async def build_execution_response(
         logger.debug("Notebook artifact creation failed (non-fatal)", exc_info=True)
 
     if not save_output:
-        # Return inline (legacy-compatible path for callers that opt out)
+        # Return inline (the path for callers that opt out of saving)
         result = {
             "description": description,
             "execution_mode": execution_mode,

--- a/src/osprey/mcp_server/workspace/execution/sandbox_executor.py
+++ b/src/osprey/mcp_server/workspace/execution/sandbox_executor.py
@@ -252,10 +252,10 @@ def _create_sandbox_wrapper(
     """
     exec_folder_str = str(execution_folder)
     workspace_str = str(workspace_root)
-    # Required, with no parent-of-workspace-root fallback: that fallback was the
-    # retired rule (it resolves to `<repo>/var` under the three-zone layout), and
-    # a default here would let a caller that forgot to resolve the root get the
-    # wrong answer silently rather than a TypeError.
+    # Required, with no parent-of-workspace-root fallback: that rule resolves to
+    # `<repo>/var` under the three-zone layout, and a default here would let a
+    # caller that forgot to resolve the root get the wrong answer silently
+    # rather than a TypeError.
     project_root_str = str(project_root)
 
     return f'''\

--- a/src/osprey/mcp_server/workspace/tools/_sandbox_packages.py
+++ b/src/osprey/mcp_server/workspace/tools/_sandbox_packages.py
@@ -1,8 +1,7 @@
 """Live package inventory for the visualization tool descriptions.
 
-The visualization tools used to name a fixed package set in their descriptions
-whatever the deployment had actually installed, so the agent planned imports
-against a set that need not exist.
+A visualization tool description must never name a fixed package set: the agent
+would plan imports against a set the deployment need not have installed.
 
 This module renders that line from the environment the *visualization sandbox*
 actually uses, which is deliberately not the one

--- a/src/osprey/mcp_server/workspace/tools/screen_capture.py
+++ b/src/osprey/mcp_server/workspace/tools/screen_capture.py
@@ -36,9 +36,9 @@ def _get_output_dir() -> Path:
     Runtime output, so it belongs under the deployment's agent-data root — read
     from ``agent_data.base_dir`` rather than spelled here — and a configured
     ``screen_capture.output_dir`` is anchored on the repo root the same way
-    every other configured path is. Both halves matter: the default used to name
-    the retired ``./_agent_data``, and either value used to resolve against the
-    working directory, which for an MCP server is whatever launched it.
+    every other configured path is. Both halves matter: neither the default nor
+    the configured value may resolve against the working directory, which for an
+    MCP server is whatever launched it.
     """
     config = load_osprey_config()
     configured = (config.get("screen_capture", {}) or {}).get("output_dir")

--- a/src/osprey/mcp_server/workspace/tools/session_log.py
+++ b/src/osprey/mcp_server/workspace/tools/session_log.py
@@ -188,9 +188,9 @@ async def session_log(
     # and `.mcp.json` it discovers there. That is what `deployed_render_dir`
     # answers, and the gallery resolves the same thing the same way.
     #
-    # Emphatically NOT derived from the agent-data root: this used to walk up
-    # from it, which is off by a zone (the render is not the repo root) AND
-    # unstable, because `resolve_workspace_root` is the session-ISOLATED alias —
+    # Emphatically NOT derived from the agent-data root: walking up from it is
+    # off by a zone (the render is not the repo root) AND unstable, because
+    # `resolve_workspace_root` is the session-ISOLATED alias —
     # with OSPREY_SESSION_ID set the root becomes
     # `<repo>/var/agent_data/sessions/<id>`, so any walk-up moves with it. A
     # wrong directory here is silent: find_transcript_dir returns None and the

--- a/src/osprey/mcp_server/workspace/transcript_reader.py
+++ b/src/osprey/mcp_server/workspace/transcript_reader.py
@@ -1,8 +1,8 @@
 """Read Claude Code native transcripts to extract OSPREY tool-call and agent events.
 
-Replaces the former PostToolUse/SubagentStart audit hooks. Claude Code already
-logs every tool call to ``~/.claude/projects/<encoded>/`` as JSONL -- this
-module reads those transcripts on demand.
+No audit hook is needed for this: Claude Code already logs every tool call to
+``~/.claude/projects/<encoded>/`` as JSONL, and this module reads those
+transcripts on demand.
 """
 
 import json

--- a/src/osprey/models/providers/als_apg.py
+++ b/src/osprey/models/providers/als_apg.py
@@ -49,7 +49,6 @@ class ALSAPGProviderAdapter(LiteLLMDelegatingProvider):
     is_openai_compatible = True
     # Note: intentionally leaves supports_native_structured_output at the None default
     # so structured-output support is auto-detected via litellm.supports_response_schema()
-    # on the resolved openai/<model> id — als-apg was never in the old native-json_schema
-    # whitelist, so this preserves its prior behavior.
+    # on the resolved openai/<model> id, which is what the proxy actually serves.
 
     # execute_completion / check_health inherited from LiteLLMDelegatingProvider.

--- a/src/osprey/models/providers/litellm_adapter.py
+++ b/src/osprey/models/providers/litellm_adapter.py
@@ -111,7 +111,7 @@ def get_litellm_model_name(
 
     # Last-resort fallback for providers the registry can't resolve (unregistered
     # names that have no provider class). Registered providers are routed above via
-    # their declared attributes, so these maps no longer drive normal routing.
+    # their declared attributes, so these maps never drive normal routing.
     _fallback_prefixes = {
         "anthropic": "anthropic",
         "google": "gemini",

--- a/src/osprey/models/providers/litellm_delegating.py
+++ b/src/osprey/models/providers/litellm_delegating.py
@@ -10,8 +10,8 @@ attributes; the two delegating methods live here, once.
 **Patch-target preservation.** Each provider's test suite patches
 ``osprey.models.providers.<name>.execute_litellm_completion`` (and
 ``check_litellm_health``) -- the helper name bound in that concrete provider's
-own module. To keep those patches effective now that the method bodies live
-here, the helpers are looked up from the concrete subclass's module namespace
+own module. The method bodies live here, so to keep those patches effective
+the helpers are looked up from the concrete subclass's module namespace
 at call time (via ``sys.modules[type(self).__module__]``) rather than captured
 in this module's globals. Every subclass module therefore still imports the two
 helpers at module level, which is what the patch targets rebind. If a subclass

--- a/src/osprey/profiles/presets/control-assistant-readonly.yml
+++ b/src/osprey/profiles/presets/control-assistant-readonly.yml
@@ -24,7 +24,7 @@ deploy_services: false
 # ── Config overrides ─────────────────────────────────────────────────────────
 # Dotted keys ONLY — see the base profile's block.
 config:
-  # The single axis this persona hard-pins: this key IS the tier boundary, so
+  # The single axis this persona hard-pins: this key is the tier boundary, so
   # it must not drift if the base's default ever changes — it is what makes
   # the read-only terminal read-only.
   control_system.writes_enabled: false

--- a/src/osprey/profiles/presets/control-assistant-readwrite.yml
+++ b/src/osprey/profiles/presets/control-assistant-readwrite.yml
@@ -29,7 +29,7 @@ web_panels:
 # ── Config overrides ─────────────────────────────────────────────────────────
 # Dotted keys ONLY — see the base profile's block.
 config:
-  # The single axis this persona hard-pins: this key IS the tier boundary, so
+  # The single axis this persona hard-pins: this key is the tier boundary, so
   # it must not drift silently if the base's default ever changes.
   control_system.writes_enabled: true
   # Full split-pane terminal + workspace layout for the write-armed operator.

--- a/src/osprey/registry/builtins.py
+++ b/src/osprey/registry/builtins.py
@@ -51,7 +51,7 @@ class FrameworkRegistryProvider(RegistryConfigProvider):
                     requires=[],
                 ),
             ],
-            # Framework AI model providers — built-in table now lives in
+            # Framework AI model providers — the built-in table lives in
             # osprey.models.provider_registry (single source of truth).
             # RegistryManager._initialize_providers() delegates to it.
             providers=[],

--- a/src/osprey/registry/export.py
+++ b/src/osprey/registry/export.py
@@ -27,7 +27,7 @@ def export_registry_to_json(
     """Export registry metadata for external tools and plan editors.
 
     :param config: Current registry configuration.
-    :param registries: Live registries dict (unused today but reserved).
+    :param registries: Live registries dict (reserved; not read here).
     :param output_dir: Directory for saving JSON files; *None* = return only.
     :return: Complete registry metadata dict.
     """

--- a/src/osprey/registry/manager.py
+++ b/src/osprey/registry/manager.py
@@ -26,9 +26,9 @@ class RegistryManager:
     """Centralized registry for all Osprey Agentic Framework components.
 
     This class provides the single point of access for capabilities, context classes,
-    services, providers, and connectors throughout the framework. It replaces the
-    fragmented registry system with a unified approach that eliminates circular imports
-    through lazy loading and provides dependency-ordered initialization.
+    services, providers, and connectors throughout the framework. One unified
+    registry eliminates circular imports through lazy loading and provides
+    dependency-ordered initialization.
 
     The registry system follows a strict initialization order to handle dependencies:
     1. Context classes (required by capabilities)

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -594,8 +594,8 @@ def resolve_servers(claude_code_config: dict, ctx: dict) -> list[dict]:
             # Custom server
             if not spec.get("command") and not spec.get("url"):
                 # Never emit a broken {"command": ""} entry into .mcp.json —
-                # e.g. a legacy 'phoebus2: {enabled: true}' spec left over from
-                # when phoebus2 was a framework server.
+                # e.g. a 'phoebus2: {enabled: true}' spec naming a server no
+                # framework entry defines.
                 logger.warning(
                     "Server %r has none of 'extends'/'command'/'url' — skipping "
                     "(a second framework-server instance is declared via "

--- a/src/osprey/registry/web.py
+++ b/src/osprey/registry/web.py
@@ -40,7 +40,7 @@ class WebServerDefinition:
         port_family: Multi-user port-family name for this server (drives the
             ``modules.web_terminals.<family>_base_port`` config field). ``None``
             means the family name is the server's registry key. Only set when a
-            server predates this field under a different conventional name
+            server's family is conventionally named something else
             (``lattice_dashboard`` → ``lattice``).
         multi_user_base_port: Default first per-user port for this server's
             family in multi-user deployments (user *i* gets ``base + i``; see

--- a/src/osprey/services/ariel_search/database/migrations.py
+++ b/src/osprey/services/ariel_search/database/migrations.py
@@ -29,7 +29,7 @@ logger = get_logger("ariel")
 
 
 # ---------------------------------------------------------------------------
-# Base class & utilities (formerly migration.py)
+# Base class & utilities
 # ---------------------------------------------------------------------------
 
 
@@ -162,7 +162,7 @@ def model_to_table_name(model_name: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Migration runner (formerly migrate.py)
+# Migration runner
 # ---------------------------------------------------------------------------
 
 # Format: (name, module_path, class_name, requires_module)

--- a/src/osprey/services/bluesky_bridge/app.py
+++ b/src/osprey/services/bluesky_bridge/app.py
@@ -64,8 +64,8 @@ _TILED_URI_ENV = "BLUESKY_TILED_URI"
 _TILED_API_KEY_ENV = "BLUESKY_TILED_API_KEY"
 
 # The refusal code every retired direct-execute route answers with. One code
-# for all of them: the answer is always "this capability moved to the queue",
-# and the per-route sentence in `detail` says which route took it over.
+# for all of them: the answer is always "this capability belongs to the queue",
+# and the per-route sentence in `detail` says which route owns it.
 _USE_THE_QUEUE = "use_the_queue"
 
 
@@ -76,7 +76,7 @@ def _use_the_queue(detail: str) -> HTTPException:
     (``queue.py``), so a caller branches on ``detail.code`` uniformly rather
     than special-casing these four routes. 410 Gone, not 404: the route is
     still here and still answering — what is gone is the in-process execution
-    it used to perform.
+    behind it.
     """
     return HTTPException(status_code=410, detail={"code": _USE_THE_QUEUE, "detail": detail})
 
@@ -155,12 +155,10 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
       fail-OPEN refuses startup (raises) only if writes are enabled, limits
       checking is enabled, and the limits database can't be read — every other
       combination, including writes disabled entirely, starts normally. It runs
-      unconditionally here. It used to sit inside the retired EPICS-substrate
-      runner branch, which meant a deployment that never set
-      `BLUESKY_EPICS_SUBSTRATE` was never checked at all; the posture it guards
-      against is a property of the project config, not of how the bridge
-      happens to be wired, so gating it on a wiring flag was always the wrong
-      shape.
+      unconditionally here, never behind a wiring flag such as
+      `BLUESKY_EPICS_SUBSTRATE`: the posture it guards against is a property of
+      the project config, not of how the bridge happens to be wired, and a
+      gated guard leaves whole classes of deployment unchecked.
     - The document plane: the 0MQ proxy the queueserver's Publisher connects
       to, and the dispatcher that turns that stream into live rows.
       Unconfigured is a no-op; see `document_plane.start_from_env`.
@@ -300,12 +298,11 @@ async def _manager_view() -> tuple[Any, list[Any], list[Any]]:
 
 @app.post("/runs")
 def create_run() -> dict:
-    """Retired: the bridge no longer mints launch intents of its own.
+    """Retired: the bridge mints no launch intent of its own.
 
-    A run id used to be minted here and launched in a second call. Both halves
-    now belong to `POST /queue/items`, which mints the id AND enqueues in one
-    armed, race-checked step — there is no intermediate state left for this
-    route to create.
+    Minting a run id here and launching it in a second call would leave an
+    intermediate state nothing owns. Both halves belong to `POST /queue/items`,
+    which mints the id AND enqueues in one armed, race-checked step.
     """
     raise _use_the_queue(
         "The bridge no longer records launch intents separately from execution. "
@@ -366,9 +363,8 @@ def launch_run(run_id: str) -> dict:
     """Retired: launching a pre-minted run in-process is gone.
 
     Execution is the queueserver worker's, and the only way into it is the
-    queue. The two-step mint-then-launch flow this route completed collapsed
-    into `POST /queue/items` (enqueue) plus the token-gated `POST /queue/start`
-    (arm and drain).
+    queue: `POST /queue/items` (enqueue) plus the token-gated `POST
+    /queue/start` (arm and drain).
     """
     raise _use_the_queue(
         "Plans now execute in the queue server, not in the bridge. Enqueue the "
@@ -380,10 +376,10 @@ def launch_run(run_id: str) -> dict:
 def launch_draft_run() -> dict:
     """Retired: launching the shared draft directly is gone.
 
-    `POST /queue/items` is the replacement and keeps everything this route
-    guaranteed — the pinned `draft_revision` and the reservation that stops two
-    callers racing the same revision onto hardware — while putting the plan in a
-    durable, serialized queue instead of a thread in this process. The launch
+    `POST /queue/items` carries every guarantee a direct launch would — the
+    pinned `draft_revision` and the reservation that stops two callers racing
+    the same revision onto hardware — while putting the plan in a durable,
+    serialized queue instead of a thread in this process. The launch
     token still gates every enqueue that can actually start something: one onto
     a draining queue, or onto a queue armed to autostart.
     """
@@ -396,11 +392,11 @@ def launch_draft_run() -> dict:
 
 @app.post("/runs/{run_id}/stop")
 def stop_run(run_id: str) -> dict:
-    """Retired: stopping is a queue operation now.
+    """Retired: stopping is a queue operation.
 
-    This route could only ever stop a plan running inside the bridge process,
-    and none do. There are two replacements, and which one a caller wants
-    depends on what they need stopped: `POST /queue/stop` halts the queue AFTER
+    This route can only stop a plan running inside the bridge process, and none
+    do. Which of the two queue operations a caller wants depends on what they
+    need stopped: `POST /queue/stop` halts the queue AFTER
     the running item finishes, and `POST /queue/abort` aborts the item already
     in motion. Neither is token-gated, on the same principle — halting is
     always allowed.

--- a/src/osprey/services/bluesky_bridge/contribution.py
+++ b/src/osprey/services/bluesky_bridge/contribution.py
@@ -4,15 +4,14 @@ This module is thin glue, not a contribution engine: it never opens a pull/merge
 request, never commits, and never touches ``plan_loader.py``'s directory
 layers or trust order. All it does is (1) refuse to hand off a session plan
 whose *current* on-disk content lacks a passing validation record — the same
-check the load gate (task 2.4) and launch gate (task 2.5) perform — and (2)
+check the load gate and the launch gate perform — and (2)
 copy that plan's exact bytes into a checkout of the repo that owns the target
 ``preset``/``facility`` plan directory, so the file is ready to ``git add``.
 
 **The contribution workflow this glue supports:**
 
-1. Author + validate a session plan (``write_plan`` /
-   ``validate_plan`` — task 2.3), then run it a few times via
-   ``launch_run`` until it looks worth keeping.
+1. Author + validate a session plan (``write_plan`` / ``validate_plan``),
+   then run it a few times via ``launch_run`` until it looks worth keeping.
 2. Call :func:`prepare_contribution` with the plan's ``name`` and a filesystem
    path to a checkout of the repo that owns the target catalog directory —
    one of the directories already listed in ``bluesky.plan_dirs`` (config.yml,

--- a/src/osprey/services/bluesky_bridge/devices/__init__.py
+++ b/src/osprey/services/bluesky_bridge/devices/__init__.py
@@ -7,10 +7,9 @@ imported from the bridge lifecycle core (``app.py``, ``runs.py``,
 so it can be built and unit-tested without loading the device stack. This ``__init__.py`` itself imports nothing from either
 submodule, so ``from osprey.services.bluesky_bridge import devices`` alone
 stays cheap; callers import ``devices.mock`` or ``devices.connector``
-explicitly. There is no raw Channel Access device factory in this package —
-every device that talks to a real IOC is mediated by the OSPREY connector
-(``devices/connector.py``); the earlier direct-CA ``devices/epics.py`` layer
-has been removed.
+explicitly. There is no raw Channel Access device factory in this package, and
+none may be added: every device that talks to a real IOC is mediated by the
+OSPREY connector (``devices/connector.py``).
 """
 
 from __future__ import annotations

--- a/src/osprey/services/bluesky_bridge/document_plane.py
+++ b/src/osprey/services/bluesky_bridge/document_plane.py
@@ -1,6 +1,6 @@
 """The bridge's half of the document plane: a 0MQ proxy feeding the live-row buffer.
 
-Plans no longer run inside this process. The RunEngine lives in the
+No plan runs inside this process. The RunEngine lives in the
 ``queueserver`` container (``qserver_startup.py``), which subscribes a
 ``bluesky.callbacks.zmq`` ``Publisher`` to it; this module runs the other end —
 the ``Proxy`` that Publisher connects to, plus a ``RemoteDispatcher`` that

--- a/src/osprey/services/bluesky_bridge/models.py
+++ b/src/osprey/services/bluesky_bridge/models.py
@@ -4,10 +4,10 @@ Pure Pydantic models — no execution or connector state — so they are
 import-clean of the bluesky stack and safe to import from anywhere the bridge
 needs the wire shapes.
 
-The retired direct-execute routes (``POST /runs``, ``POST /draft/run``) had
-bodies here too; they answer a fixed refusal now and parse nothing, so those
-models are gone. The queue surface defines its own request bodies in
-``queue.py``, next to the routes that read them.
+The retired direct-execute routes (``POST /runs``, ``POST /draft/run``) parse
+nothing — they answer a fixed refusal — so no model here serves them. The queue
+surface defines its own request bodies in ``queue.py``, next to the routes that
+read them.
 """
 
 from __future__ import annotations

--- a/src/osprey/services/bluesky_bridge/plan_loader.py
+++ b/src/osprey/services/bluesky_bridge/plan_loader.py
@@ -10,9 +10,9 @@ Two kinds of plan source, both scanned into the same fail-closed registry:
   own device map at launch.
 - **The legacy single-module contract** — a single ``.py`` file exposing
   ``PLANS: dict[str, PlanSpec]`` and ``get_devices()``, resolved from
-  ``BLUESKY_PLAN_MODULE`` (env) or ``bluesky.plan_module`` (config.yml). This
-  predates the layered model and is folded in as a one-entry ``facility``-tier
-  layer — it is the only source of injected devices.
+  ``BLUESKY_PLAN_MODULE`` (env) or ``bluesky.plan_module`` (config.yml). It is
+  folded in as a one-entry ``facility``-tier layer — and is the only source of
+  injected devices.
 
 Layer sources and their provenance-tier mapping:
 
@@ -24,7 +24,7 @@ Layer sources and their provenance-tier mapping:
    operator trust than a per-instance runtime override.
 3. ``facility`` — directories listed in ``BLUESKY_PLAN_DIRS`` (env,
    ``os.pathsep``-separated), set per bridge instance at launch. This mirrors
-   the legacy contract's existing precedent that an env override outranks
+   the legacy contract's own precedent that an env override outranks
    config (``BLUESKY_PLAN_MODULE`` wins over ``bluesky.plan_module``). The
    legacy single-module contract itself is also pinned to ``facility`` —
    it is scanned *first*, so a lower-trust directory layer (``shipped`` or
@@ -94,8 +94,8 @@ _PLAN_DIRS_ENV = "BLUESKY_PLAN_DIRS"
 # bridge instance. Unioned with config.yml's ``bluesky.excluded_plans``.
 _EXCLUDED_PLANS_ENV = "BLUESKY_EXCLUDED_PLANS"
 
-# The in-image core plan directory shipped with this package (task 1.5
-# populates it; scanned even if absent/empty).
+# The in-image core plan directory shipped with this package (scanned even if
+# absent/empty).
 _SHIPPED_PLANS_DIR = Path(__file__).parent / "plans_core"
 
 _TRUST_ORDER: dict[Provenance, int] = {
@@ -510,7 +510,7 @@ def _load_startup_layers(module_path: str | None) -> _StartupLayers:
 # repeat callers that compare by identity (or just want a stable reference)
 # see one. A signature/mtime-based skip was deliberately rejected: a file's
 # mtime doesn't change when a *validation record* is added after the fact
-# (task 2.3's validate route only touches `validation_record.py`, never the
+# (the validate route only touches `validation_record.py`, never the
 # file), so caching on file staleness alone would keep serving a stale
 # rejection after a plan actually became valid — exactly the live-authoring
 # case this layer exists for. Re-gating on every call is the correctness
@@ -532,7 +532,7 @@ def get_facility_plans() -> FacilityPlans:
     (`shipped`/`preset`/`facility`/`session`) into one trust-resolved plan
     set. The startup layers are loaded once and cached (see
     `_load_startup_layers`) — but the `session` layer is a live authoring
-    surface (task 2.3's `POST /plans/session` writes into it between
+    surface (`POST /plans/session` writes into it between
     requests, and its validation status can change without the file itself
     changing), so it is fully re-scanned and re-gated (see `_load_plan_file`)
     on *every* call, merged fresh over the cached startup registry. A newly

--- a/src/osprey/services/bluesky_bridge/plan_types.py
+++ b/src/osprey/services/bluesky_bridge/plan_types.py
@@ -4,7 +4,7 @@ Kept free of bluesky/ophyd/tiled imports (pydantic is a core bridge dependency,
 pulled in transitively via FastAPI, so it's fine here) so both sides of the
 injection seam stay on the right side of the import-clean boundary:
 
-- ``plan_loader.py`` (task 2.4) loads a facility module exposing
+- ``plan_loader.py`` loads a facility module exposing
   ``PLANS: dict[str, PlanSpec]`` from a config-pointed path *without* itself
   importing bluesky — only the loaded module needs it.
 - the shipped plan files under ``plans_core/`` (e.g. ``orm.py``, ``grid_scan.py``)

--- a/src/osprey/services/bluesky_bridge/plans.py
+++ b/src/osprey/services/bluesky_bridge/plans.py
@@ -1,15 +1,13 @@
-"""Retained as an import-stable shim after the single-registry migration.
+"""Import-stable shim; holds no plan definitions.
 
-The v1 hardcoded plan set (`count`/`scan`/`grid_scan`/`orm`) that used to live
-here as a module-level dict has been deleted: `plan_loader.get_facility_plans()`
-is now the sole plan registry, sourced by scanning `plans_core/` (and any
-preset/facility/session directory layer) for `PLAN_METADATA`/`build_plan`
-files — see `plan_loader.py`. `grid_scan` and `orm` now live as shipped-tier
-files under `plans_core/`; `count`/`scan` were dropped rather than ported.
+No plan may be hardcoded here as a module-level dict:
+`plan_loader.get_facility_plans()` is the sole plan registry, sourced by
+scanning `plans_core/` (and any preset/facility/session directory layer) for
+`PLAN_METADATA`/`build_plan` files — see `plan_loader.py`. The shipped tier
+(`grid_scan`, `orm`) lives as files under `plans_core/`.
 
-This module has no remaining content of its own; it stays importable because
-some callers still `import ...plans` before checking whether it still
-carries the (now absent) hardcoded plan dict.
+This module has no content of its own; it stays importable for callers that
+`import ...plans` before reading the registry.
 """
 
 from __future__ import annotations

--- a/src/osprey/services/bluesky_bridge/queue.py
+++ b/src/osprey/services/bluesky_bridge/queue.py
@@ -370,10 +370,10 @@ def _refuse_manager_not_idle(running_item: dict[str, Any]) -> NoReturn:
     The reason it EXISTS, though, is `_refuse_interrupted_item`'s residual
     race. That gate reads one snapshot and asks whether any item in it carries
     a ``result`` from an earlier interruption. A RUNNING item never does — it
-    has not finished — so a snapshot holding one used to pass the check, and if
-    the plan then aborted or failed in the gap before ``backend.start()``,
-    upstream would requeue the result-bearing copy to the FRONT and the start
-    would drain exactly the item the gate exists to stop.
+    has not finished — so a snapshot holding one passes that check, and if the
+    plan then aborts or fails in the gap before ``backend.start()``, upstream
+    requeues the result-bearing copy to the FRONT and the start drains exactly
+    the item the gate exists to stop.
 
     Refusing every snapshot that holds a running item closes that structurally
     rather than by narrowing the window: after this check, no snapshot that

--- a/src/osprey/services/bluesky_bridge/session_dir.py
+++ b/src/osprey/services/bluesky_bridge/session_dir.py
@@ -5,9 +5,9 @@ writes, rather than merely discovers — every directory layer
 ``plan_loader.py`` otherwise scans (``shipped``/``preset``/``facility``) is
 operator-supplied and read-only from the bridge's point of view. This module
 is the single place that resolves *where* an authored plan file lives, so
-both the write path (task 2.3's ``POST /plans/session``) and the discovery
-path (task 2.4's session-tier directory layer) agree on the same directory
-without either hardcoding it.
+both the write path (``POST /plans/session``) and the discovery path
+(``plan_loader.py``'s session-tier directory layer) agree on the same
+directory without either hardcoding it.
 
 Ephemeral by design, like the run registry (``runs.py``) and the validation
 record store (``validation_record.py``): the default directory has no deploy
@@ -45,9 +45,9 @@ def resolve_session_plan_dir() -> Path:
     2. The in-image default (see :data:`_DEFAULT_SESSION_PLAN_DIR`).
 
     Always ``mkdir(parents=True, exist_ok=True)``s the resolved directory
-    before returning it, so every caller (this task's write/validate routes,
-    task 2.4's session-tier directory layer) can rely on the directory
-    existing without each re-implementing the same check.
+    before returning it, so every caller (the write/validate routes, the
+    session-tier directory layer) can rely on the directory existing without
+    each re-implementing the same check.
     """
     raw = os.environ.get(_SESSION_PLAN_DIR_ENV)
     directory = Path(raw) if raw else _DEFAULT_SESSION_PLAN_DIR

--- a/src/osprey/services/bluesky_bridge/substrate_devices.py
+++ b/src/osprey/services/bluesky_bridge/substrate_devices.py
@@ -43,10 +43,9 @@ the connector's per-put reference monitor and the bridge's arming + limits
 facade, which are the boundary.
 
 Deploy caveat: ``container_lifecycle._ensure_bluesky_substrate_env`` never
-overwrites an already-set value, so a project deployed before this naming
-change keeps whatever ``BLUESKY_EPICS_MOTORS``/``_DETECTORS`` its ``.env``
-already holds until those lines are removed. Fresh deploys get the
-address names automatically.
+overwrites an already-set value, so a project keeps whatever
+``BLUESKY_EPICS_MOTORS``/``_DETECTORS`` its ``.env`` already holds until those
+lines are removed. Fresh deploys get the address names automatically.
 
 Two consumers share this module (DRY, one derivation):
 

--- a/src/osprey/services/channel_finder/benchmarks/backends/in_context_backend.py
+++ b/src/osprey/services/channel_finder/benchmarks/backends/in_context_backend.py
@@ -42,7 +42,7 @@ class InContextBackend(Backend):
 
     The backend identifier is ``"direct"`` rather than ``"in_context"`` —
     that's the *paradigm* this backend can host, not the harness shape.
-    Calling it ``"in_context"`` historically conflated the paradigm axis
+    Calling it ``"in_context"`` would conflate the paradigm axis
     (``in_context`` / ``hierarchical`` / ``middle_layer``) with the harness
     axis (``sdk`` / ``react`` / ``direct``) on the dashboard.
     """

--- a/src/osprey/services/channel_finder/benchmarks/generator.py
+++ b/src/osprey/services/channel_finder/benchmarks/generator.py
@@ -571,7 +571,7 @@ def format_middle_layer(channels: list[dict], tier_spec: TierSpec) -> dict:
 # Paradigms published per tier. Tier 1 ships the flat ``in_context`` view only;
 # tier 3 ships all three cross-paradigm views. Query validation checks each
 # tier's targeted PVs against exactly the paradigms declared here, and callers
-# iterating "all tiers" iterate these keys (tier 2 is retired).
+# iterating "all tiers" iterate these keys — there is no tier 2.
 TIER_PARADIGMS: dict[int, tuple[str, ...]] = {
     1: ("in_context",),
     3: ("in_context", "hierarchical", "middle_layer"),

--- a/src/osprey/services/channel_finder/benchmarks/sdk.py
+++ b/src/osprey/services/channel_finder/benchmarks/sdk.py
@@ -7,11 +7,9 @@ Extracted from ``tests/e2e/sdk_helpers.py`` so that production code
 re-exported from :mod:`osprey.agent_runner` — that module is the single source
 of truth for these primitives.
 
-Nothing here builds a project. An ``init_project`` used to sit alongside these
-helpers, shelling out to the retired positional ``osprey build`` form; its only
-consumer moved to ``tests.e2e.sdk_helpers.init_project``, which drives the
-current ``osprey init`` + ``osprey build`` surface. Benchmarks are handed a
-built repo and read it.
+Nothing here builds a project — benchmarks are handed a built repo and read it.
+Project setup belongs to ``tests.e2e.sdk_helpers.init_project``, which drives
+the ``osprey init`` + ``osprey build`` surface.
 """
 
 from __future__ import annotations

--- a/src/osprey/services/channel_finder/tools/generate_from_spec.py
+++ b/src/osprey/services/channel_finder/tools/generate_from_spec.py
@@ -36,7 +36,7 @@ byte-for-byte untouched.
 For an address in the target grown inventory that already exists in the
 loaded database, the existing entry is kept verbatim (hand-authored prose is
 preserved). Only genuinely new addresses -- a new family (QFA/SHF/SHD) or a
-device index beyond the old count -- are templated from the schema. Once a
+device index beyond the loaded count -- are templated from the schema. Once a
 family has been grown to its target count, every target address already
 exists, so re-running is idempotent (identical bytes).
 

--- a/src/osprey/services/virtual_accelerator/entrypoint.py
+++ b/src/osprey/services/virtual_accelerator/entrypoint.py
@@ -35,17 +35,18 @@ local testing without an actual bind mount.
 ``VA_STATE_DIR`` names the directory holding the ``active_scenarios`` file the
 IOC polls for scenario switches. It is a *separate* mount because the host
 writes it at run time (``osprey sim apply``) while ``data/`` is build-owned and
-checksummed. Unset, it falls back to the data dir — the historical layout, for
-a hand-run container whose state file still sits next to ``machine.json``.
+checksummed. Unset, it falls back to the data dir — the single-directory layout,
+for a hand-run container whose state file sits next to ``machine.json``.
 
-Facility-neutral source configuration (all optional; defaults reproduce the
-historical behaviour exactly):
+Facility-neutral source configuration. Every variable below is optional, and
+unset they serve the built-in tutorial machine byte-for-byte — a deployment
+that sets none of them is unaffected by all of them:
 
 ``VA_CHANNELS_FILE``
     Path to a ``{"channels": [...]}`` manifest JSON (see
     ``manifest.loaders.load_manifest_file``). Relative paths resolve against
     the data dir. Unset/empty -> the built-in generated manifest
-    (``build_manifest()``), as before. With a file source, drive limits come
+    (``build_manifest()``). With a file source, drive limits come
     from ``<data dir>/channel_limits.json`` when present (none otherwise)
     and boot values from the mounted ``machine.json`` -- never from the
     bundled tutorial data.
@@ -260,8 +261,8 @@ def _load_drive_limits(path: Path | None = None) -> dict[str, tuple[float, float
     writable ``:SP`` address with numeric bounds. ``ioc/records.py`` stays
     file-blind (see its ``build_records`` docstring) -- this is the file
     read its ``drive_limits`` argument replaces. ``path`` selects which
-    limits file to parse; ``None`` (the default) keeps the historical
-    bundled-template read."""
+    limits file to parse; ``None`` (the default) reads the bundled
+    template."""
     raw = json.loads((path or _channel_limits_path()).read_text())
     defaults = raw.get("defaults", {})
     limits: dict[str, tuple[float, float]] = {}
@@ -287,7 +288,7 @@ def _load_boot_values(machine_path: Path | None = None) -> dict[str, float]:
     carry no static value and are skipped -- harmless here since none of
     them are ``:SP``/``:RB`` addresses, the only subfields this map is ever
     consulted for. ``machine_path`` selects which machine.json to read;
-    ``None`` (the default) keeps the historical bundled-template read."""
+    ``None`` (the default) reads the bundled template."""
     return {
         address: entry["value"]
         for address, entry in load_machine_json_channels(machine_path).items()
@@ -323,10 +324,9 @@ def _install_shutdown_signals() -> None:
 def _start_engine_source(engine_source: EngineSource, interval: float) -> threading.Thread:
     """Run the telemetry poll loop on a daemon thread of its own.
 
-    The loop used to be scheduled onto the IOC's asyncio dispatcher, which
-    the serving layer has no equivalent of: the runner owns the calling
-    thread (``run()`` blocks on it) and runs its Channel Access server on
-    one of its own. So the poll loop gets one too.
+    There is no shared dispatcher to schedule it on: the runner owns the
+    calling thread (``run()`` blocks on it) and runs its Channel Access server
+    on one of its own. So the poll loop gets one too.
 
     Daemon deliberately. It holds nothing worth draining -- each tick reads
     the scenario files afresh and pushes values it recomputes -- and the
@@ -477,8 +477,7 @@ def main() -> None:
     # each sp-echo readback into it every tick so machine-file expression
     # channels can respond to accepted setpoints (see EngineSource's
     # setpoint_echo_records docstring). With a lattice, physics coupling
-    # flows through PhysicsBridge and the engine stays a pure scenario
-    # source -- exactly the historical behaviour.
+    # flows through PhysicsBridge and the engine stays a pure scenario source.
     setpoint_echoes: dict[str, Any] | None = None
     if lattice_mode == LATTICE_NONE:
         setpoint_echoes = {

--- a/src/osprey/services/virtual_accelerator/ioc/engine_source.py
+++ b/src/osprey/services/virtual_accelerator/ioc/engine_source.py
@@ -22,7 +22,7 @@ Scenario-switch detection deliberately does its own (mtime, content-hash)
 comparison of ``active_scenarios`` in addition to the engine's own internal
 mtime-only tracking: the data directory is bind-mounted (not a single file)
 specifically so an atomic-rename swap survives the mount, but the replacement
-file's mtime can still collide with the old one at the host filesystem's
+file's mtime can still collide with the replaced one at the host filesystem's
 mtime granularity. The content hash is strictly more sensitive than mtime
 alone and catches that edge case.
 """
@@ -68,7 +68,7 @@ class EngineSource:
         state_dir: Directory holding the ``active_scenarios`` file, read fresh
             on every poll tick -- never through a cached file handle, so a
             directory-level atomic-rename swap is always observed. Defaults to
-            ``data_dir`` (the historical layout). The VA entrypoint points it
+            ``data_dir`` (the single-directory layout). The VA entrypoint points it
             at the separately mounted ``_agent_data/simulation/`` the host
             writes, and passes the SAME directory to the engine, so the two
             never disagree about which scenarios are active.

--- a/src/osprey/services/virtual_accelerator/lattice/response.py
+++ b/src/osprey/services/virtual_accelerator/lattice/response.py
@@ -9,8 +9,8 @@ the closed orbit with the guarded :func:`~.solve.solve_orbit` helper, and
 returns every BPM's (x, y) reading in meters, keyed by its flat FamName (e.g.
 "BPM01"). Sharing both the ring source (`build_ring`) and the strength-map
 code path with the bridge is deliberate: it is what lets the ORM crosscheck
-(task 4.3) prove this oracle and the live IOC agree because they run the same
-model, not two independently-written ones.
+prove this oracle and the live IOC agree because they run the same model, not
+two independently-written ones.
 
 ``solve_orbit`` guards against the unstable-lattice failure mode described in
 `solve.py`'s docstring (non-finite/unstable closed orbit surfaces as

--- a/src/osprey/services/virtual_accelerator/manifest/loaders.py
+++ b/src/osprey/services/virtual_accelerator/manifest/loaders.py
@@ -79,8 +79,8 @@ def load_machine_json_channels(
     """Return the scenario-seed machine.json channels keyed by address.
 
     ``path`` selects which machine.json to read: ``None`` (the default)
-    keeps the historical behaviour of reading the bundled control-assistant
-    template's copy; a file-backed facility passes its own mounted
+    reads the bundled control-assistant template's copy; a file-backed
+    facility passes its own mounted
     machine.json instead (see ``entrypoint.py``). ``paths`` supplies the
     fallback for callers that anchor on a data tree rather than a single
     file (the build-time generator).

--- a/src/osprey/services/virtual_accelerator/manifest/paths.py
+++ b/src/osprey/services/virtual_accelerator/manifest/paths.py
@@ -113,8 +113,8 @@ class ManifestPaths:
         return [path for path in self.required_sources if not path.is_file()]
 
 
-# The bundled control-assistant tree: the historical (and container-runtime)
-# source, and the default for every loader in this package.
+# The bundled control-assistant tree: the container-runtime source, and the
+# default for every loader in this package.
 PACKAGE_PATHS = ManifestPaths(data_root=_CONTROL_ASSISTANT_DATA, tier=DEFAULT_TIER)
 
 MANIFEST_OUTPUT = Path(__file__).resolve().parent / "channel_manifest.json"

--- a/src/osprey/services/virtual_accelerator/model/catalog.py
+++ b/src/osprey/services/virtual_accelerator/model/catalog.py
@@ -15,9 +15,9 @@ not model state, so it is not a model variable.
 ``default_validation_config='none'``, so ``LUMEModel.set()`` neither
 rejects nor clamps an out-of-band value -- and nothing in lume clamps
 anywhere. A standalone consumer of this catalog must not read
-``value_range`` as a guarantee. Real enforcement lives exactly where it
-lives today: DRVL/DRVH clamping on the EPICS record before the write hook
-runs, ``channel_limits.json`` at the control-assistant layer, and the
+``value_range`` as a guarantee. Real enforcement lives in three places:
+DRVL/DRVH clamping on the EPICS record before the write hook runs,
+``channel_limits.json`` at the control-assistant layer, and the
 fail-closed orbit solve that rolls the ring back when a setpoint destroys
 the closed orbit.
 

--- a/src/osprey/services/virtual_accelerator/model/pyat.py
+++ b/src/osprey/services/virtual_accelerator/model/pyat.py
@@ -19,7 +19,7 @@ The ring, the strength map and the variables are built as one set, in that
 order: the map bakes its strength baseline from the very lattice the
 simulator goes on to mutate, so a variable's conversion is always relative
 to the ring it writes into. Building the map from a second ``build_ring()``
-would give a baseline that merely *happens* to match today.
+would give a baseline that merely *happens* to match.
 
 Declared defaults are recorded as the retained input values at construction
 but are not written to the lattice, so the ring boots in exactly the state

--- a/src/osprey/services/virtual_accelerator/serving/runner.py
+++ b/src/osprey/services/virtual_accelerator/serving/runner.py
@@ -46,9 +46,8 @@ is reached through the model wrapper, so it too runs there.
 served that the facility's channel manifest does not describe.
 
 The model's variables are served on **both** transports -- co-hosted on CA,
-natively on PVA -- and keeping those two views of one address in step is
-what the suppressed output pass used to do. It is done here instead, by the
-write path rather than by a model read: every setpoint PV's put handler is
+natively on PVA -- and keeping those two views of one address in step is the
+write path's job, not a model read's: every setpoint PV's put handler is
 replaced with one that routes into the same write path the CA driver uses,
 and every value that path publishes is committed on both views. So a write
 arriving on either transport moves both, and a refused write moves neither.

--- a/src/osprey/services/virtual_accelerator/serving/write_path.py
+++ b/src/osprey/services/virtual_accelerator/serving/write_path.py
@@ -233,8 +233,7 @@ class SetpointRoutedModel(LUMEModel):
         The unrouted remainder is applied in one call, preserving the run
         loop's one-``set``-per-cycle shape. An empty batch is passed through
         rather than dropped: the run loop's startup cycle carries no values
-        at all, and the wrapped model treats that as "re-solve and refresh",
-        which is what it did before this wrapper existed.
+        at all, and the wrapped model treats that as "re-solve and refresh".
         """
         routed = {name: values[name] for name in values if name in self._routed}
         direct = {name: values[name] for name in values if name not in self._routed}

--- a/src/osprey/simulation/channel_schema.py
+++ b/src/osprey/simulation/channel_schema.py
@@ -1,9 +1,9 @@
-"""Declarative per-family channel schema for the ``one-facility`` epic.
+"""Declarative per-family channel schema for the simulated facility.
 
 Declares, for each device family in :data:`osprey.simulation.facility_spec.
 ALS_U_AR`, the tier-3 channel structure (FIELD/SUBFIELD levels of the
 ``RING:SYSTEM:FAMILY:DEVICE:FIELD:SUBFIELD`` address) and the human-facing
-display metadata a downstream tier-DB generator (a later task) needs to emit
+display metadata a downstream tier-DB generator needs to emit
 the three shipped tier-3 channel database formats --
 ``hierarchical.json``, ``in_context.json``, ``middle_layer.json`` (under
 ``src/osprey/templates/apps/control_assistant/data/channel_databases/tiers/

--- a/src/osprey/simulation/engine.py
+++ b/src/osprey/simulation/engine.py
@@ -661,7 +661,7 @@ class SimulationEngine:
                     try:
                         parsed = datetime.fromisoformat(value.strip())
                         # Anchors written by apply.py are UTC-aware; attach the
-                        # facility zone to a naive (hand-edited/legacy) anchor so
+                        # facility zone to a naive (hand-edited) anchor so
                         # ``.timestamp()`` does not silently fall back to box-local.
                         if parsed.tzinfo is None:
                             parsed = parsed.replace(tzinfo=get_facility_timezone())

--- a/src/osprey/simulation/facility_spec.py
+++ b/src/osprey/simulation/facility_spec.py
@@ -1,5 +1,5 @@
 """Declarative facility specification — the single source of truth for the
-``one-facility`` epic's device families, counts, naming scheme, and machine
+simulated facility's device families, counts, naming scheme, and machine
 constants.
 
 Stdlib-only (``dataclasses`` + ``typing``), zero third-party dependencies,
@@ -8,8 +8,7 @@ following the import discipline of
 no control-system imports) and the catalog-lookup shape of
 :mod:`osprey.services.build_artifacts.catalog`.
 
-This module inverts the retired ``manifest -> inventory -> lattice`` direction:
-the spec is the authority on families / counts / names, and the hand-ported
+The spec is the authority on families / counts / names, and the hand-ported
 ring (:func:`osprey.simulation.lattice.ring.build_ring`) is its *first
 consumer*. A drift-guard test binds the ring's actual per-family element counts
 and assigned naming to this declaration
@@ -129,5 +128,5 @@ ALS_U_AR = FacilitySpec(
 
 
 def als_u_ar() -> FacilitySpec:
-    """Return the ALS-U Accumulator Ring facility spec (the epic default)."""
+    """Return the ALS-U Accumulator Ring facility spec (the default)."""
     return ALS_U_AR

--- a/src/osprey/simulation/procedural.py
+++ b/src/osprey/simulation/procedural.py
@@ -15,10 +15,9 @@ Three properties are contracts, not preferences:
   window, sample count or stream position enters the computation, so two
   archiver queries that share a timestamp return the same value at it, and a
   document written into a store now equals what a query synthesizes for that
-  timestamp later. The window-relative generator this replaces could not
-  satisfy either: its ``np.linspace(0, 1, n)`` axis made every value a function
-  of the query's shape, so materializing it produced history that contradicted
-  the next read.
+  timestamp later. A window-relative generator cannot satisfy either: an
+  ``np.linspace(0, 1, n)`` axis makes every value a function of the query's
+  shape, so materializing it produces history that contradicts the next read.
 
 * **Baselines come from one source, shared with the VA.** A channel's baseline
   is the value the VA boots it at: the ``machine.json`` seed for the ``:SP`` and

--- a/src/osprey/stores/artifact_store.py
+++ b/src/osprey/stores/artifact_store.py
@@ -127,8 +127,8 @@ class ArtifactEntry:
         """Compact response returned to Claude after artifact creation.
 
         When ``summary`` / ``access_details`` are populated (data artifacts),
-        the response includes them so Claude sees the same compact info that
-        DataContext.to_tool_response() used to provide.
+        the response includes them so Claude sees the shape of the data without
+        a second read.
         """
         resp: dict[str, Any] = {
             "status": "success",

--- a/src/osprey/templates/apps/ariel_standalone/README.md.j2
+++ b/src/osprey/templates/apps/ariel_standalone/README.md.j2
@@ -25,7 +25,7 @@ osprey web                # Open the web terminal — ARIEL panel + agent chat
 ## What's Off by Default
 
 - **Semantic processor enhancement** (`ariel.enhancement_modules.semantic_processor.enabled: false`)
-  — requires an LLM endpoint; re-enable by editing the corresponding line in
+  — requires an LLM endpoint; turn it on by editing the corresponding line in
   `config.yml` once your provider is configured.
 
 ## First-Use Checklist

--- a/src/osprey/templates/apps/ariel_standalone/config.yml.j2
+++ b/src/osprey/templates/apps/ariel_standalone/config.yml.j2
@@ -12,9 +12,9 @@ project_name: "{{ project_name }}"
 # Facility identity — one block, two keys:
 #   name   — display name woven into the agent prompts (CLAUDE.md, subagents)
 #            and the web-terminal landing page. Keep it in sync with
-#            .claude/rules/facility.md. The older top-level `facility_name`
-#            is still honored as a fallback, but this is the canonical
-#            spelling and wins over it.
+#            .claude/rules/facility.md. A top-level `facility_name` is
+#            honored as a fallback, but this is the canonical spelling and
+#            wins over it.
 #   prefix — short abbreviation the deployed web stack uses for container
 #            names (`<prefix>-nginx`, `<prefix>-web-<user>`); must be a
 #            non-empty valid Docker name start ([a-zA-Z0-9]). Only the

--- a/src/osprey/templates/apps/channel_finder_standalone/config.yml.j2
+++ b/src/osprey/templates/apps/channel_finder_standalone/config.yml.j2
@@ -13,9 +13,9 @@ project_name: "{{ project_name }}"
 # Facility identity — one block, two keys:
 #   name   — display name woven into the agent prompts (CLAUDE.md, subagents)
 #            and the web-terminal landing page. Keep it in sync with
-#            .claude/rules/facility.md. The older top-level `facility_name`
-#            is still honored as a fallback, but this is the canonical
-#            spelling and wins over it.
+#            .claude/rules/facility.md. A top-level `facility_name` is
+#            honored as a fallback, but this is the canonical spelling and
+#            wins over it.
 #   prefix — short abbreviation the deployed web stack uses for container
 #            names (`<prefix>-nginx`, `<prefix>-web-<user>`); must be a
 #            non-empty valid Docker name start ([a-zA-Z0-9]). Only the

--- a/src/osprey/templates/apps/control_assistant/README.md.j2
+++ b/src/osprey/templates/apps/control_assistant/README.md.j2
@@ -1,6 +1,6 @@
 # {{ app_display_name }}
 
-A production-grade control system assistant demonstrating enterprise patterns for scientific facility automation.
+A control system assistant for scientific facilities, built on pluggable control-system and archiver connectors.
 
 **Based on:** ALS Accelerator Assistant deployment (arXiv:2509.17255)
 **Framework:** Osprey {{ framework_version }}
@@ -10,14 +10,14 @@ A production-grade control system assistant demonstrating enterprise patterns fo
 
 ## 🎯 Overview
 
-This application demonstrates production-validated patterns for building AI assistants for accelerator control systems. It includes:
+This application shows how to build an AI assistant for an accelerator control system. It includes:
 
 - **Natural Language Channel Finding** - Find control system channels using natural language
 - **Live Value Retrieval** - Read current channel values using pluggable connectors
 - **Historical Data Analysis** - Retrieve and analyze time-series data from archiver
-- **Comprehensive Benchmarking** - Evaluate channel finder performance
-- **Development Mode** - Works instantly with mock connectors (no hardware required)
-- **Production Ready** - Switch to real EPICS/LabVIEW/Tango systems by changing config
+- **Benchmarking** - Evaluate channel finder performance
+- **Development Mode** - Works with mock connectors (no hardware required)
+- **Real Hardware** - Switch to EPICS or DOOCS systems by changing config; other stacks connect through custom connectors
 
 {% if channel_finder_mode == 'in_context' %}
 **Channel Finder Mode:** In-Context (Semantic Search)
@@ -202,7 +202,7 @@ Try these example queries to explore the assistant's capabilities:
 
 ## 🏗️ Architecture
 
-This template follows the proven **production architecture** from the ALS Assistant with pluggable connectors:
+This template follows the **layered architecture** of the ALS Assistant, with pluggable connectors:
 
 ```
 ┌─────────────────────────────────────────────────────────┐
@@ -227,7 +227,7 @@ This template follows the proven **production architecture** from the ALS Assist
                           │                      │
 ┌──────────────────────────────┐    ┌─────────────────────┐
 │  Service Layer               │    │ Osprey Connectors   │
-│  src/{{ package_name }}/services/ │  │ (Issue #18)      │
+│  src/{{ package_name }}/services/ │  │ (pluggable)      │
 │  - channel_finder/           │    │ - Mock connectors   │
 └──────────────────────────────┘    │ - EPICS connectors  │
                                     │ - Custom connectors │
@@ -239,7 +239,7 @@ This template follows the proven **production architecture** from the ALS Assist
 ✅ **No Code Duplication** - Service logic lives in one place
 ✅ **Flexible Deployment** - Use in Osprey OR as standalone MCP server
 ✅ **Clean Testing** - Test services independently of framework
-✅ **Production-Validated** - Based on actual ALS deployment
+✅ **Based on a Real Deployment** - Structure taken from the ALS Assistant
 ✅ **Pluggable Connectors** - Switch from tutorial to production by changing config
 ✅ **Extensible** - Add custom connectors for any control system
 
@@ -247,7 +247,7 @@ This template follows the proven **production architecture** from the ALS Assist
 
 ## 🧪 Benchmarking
 
-The template includes a comprehensive benchmarking system to evaluate channel finder performance.
+The template includes a benchmarking system to evaluate channel finder performance.
 
 ### Run Benchmarks
 
@@ -273,10 +273,10 @@ Results are saved to `data/benchmarks/results/` with detailed metrics:
 
 ### Adding Custom Benchmarks
 
-The default benchmark uses the tier-resolved unified query set at
-`data/benchmarks/queries.json` (one source of truth, all paradigms read the
-same file). To run a custom query set, write a new file alongside it and
-point `channel_finder.benchmark.dataset_path` at it:
+The default benchmark uses the tier-resolved query set at
+`data/benchmarks/queries.json` (one file, read by every paradigm). To run a
+custom query set, write a new file alongside it and point
+`channel_finder.benchmark.dataset_path` at it:
 
 ```json
 [
@@ -356,13 +356,13 @@ models:
 
 ## 🔄 Adapting for Your Facility
 
-This template uses **pluggable connectors** that make migration from development to production incredibly simple - just change the configuration!
+This template uses **pluggable connectors**, so moving from development to production is a configuration change rather than a code change.
 
 ### Connector Architecture
 
-The template uses the **Osprey Connector Abstraction** (Issue #18) which provides:
+The template uses the **Osprey Connector Abstraction**, which provides:
 - **Development Mode**: Mock connectors work with any channel names (no hardware required)
-- **Production Mode**: Real connectors (EPICS, LabVIEW, Tango, etc.) with same API
+- **Production Mode**: Real connectors (EPICS, DOOCS) with the same API; LabVIEW, Tango and other stacks are supported via custom connectors
 - **Zero Code Changes**: Switch modes by editing `config.yml`
 
 ### Migration to Production
@@ -559,7 +559,7 @@ channel_finder:
 
 ## 📊 Production Patterns
 
-This template demonstrates enterprise patterns from the ALS deployment:
+This template carries two structural patterns from the ALS deployment:
 
 ### Error Handling
 - Custom error classes per capability
@@ -619,7 +619,6 @@ osprey build && osprey up -d
 - **Osprey Documentation**: https://als-apg.github.io/osprey/
 - **ALS Assistant Paper**: arXiv:2509.17255
 - **Channel Finder**: Embedded in `services/channel_finder/`
-- **Template Design Doc**: `CONTROL_ASSISTANT_TEMPLATE.md`
 
 ---
 

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -3,7 +3,7 @@
 # ============================================================
 # Accelerator Control System Assistant
 # Based on ALS Assistant deployment (arXiv:2509.17255)
-# Claude Code project — streamlined configuration.
+# Claude Code project configuration.
 # ============================================================
 
 # Project identity
@@ -11,8 +11,9 @@ project_name: "{{ project_name }}"
 
 # Facility identity — one block, two keys:
 #   name   — display name woven into the agent prompts (CLAUDE.md, subagents)
-#            and the web-terminal landing page. Falls back to the older
-#            top-level `facility_name`, then to the project name.
+#            and the web-terminal landing page. Preferred spelling, and it
+#            wins over a top-level `facility_name`, which is honored as a
+#            fallback; with neither set, the project name is used.
 #   prefix — short abbreviation the deployed web stack uses for container
 #            names (`<prefix>-nginx`, `<prefix>-web-<user>`); must be a
 #            non-empty valid Docker name start ([a-zA-Z0-9]).
@@ -252,12 +253,11 @@ hooks:
 
 # ============================================================
 # CONTROL SYSTEM & ARCHIVER CONFIGURATION
-# Issue #18 - Control System Abstraction
 # ============================================================
-# Unified configuration for control systems and archivers.
+# Configuration for control systems and archivers.
 # Supports mock mode (development) and production mode (EPICS, etc.)
 #
-# Development Mode: Works instantly with any channel names (no hardware required)
+# Development Mode: Works with any channel names (no hardware required)
 # Production Mode: Connects to real control system and archiver
 # Switch modes by changing 'type' field
 
@@ -270,7 +270,7 @@ control_system:
   #     Channel Access. Requires the VA service running first — add
   #     virtual_accelerator to deployed_services and run `osprey up`
   #     (see the "Use the Virtual Accelerator" how-to in the OSPREY docs).
-  #   - epics: Production EPICS control system (ALS values below — untouched)
+  #   - epics: Production EPICS control system (ALS values below)
   type: mock  # <-- Change to 'virtual_accelerator' or 'epics' for other modes
 
   # Write Access Control - Master safety switch for hardware control
@@ -399,7 +399,7 @@ control_system:
           # port: 5074
           use_name_server: true
 
-    # EPICS connector (production mode) — untouched ALS production values.
+    # EPICS connector (production mode) — ALS production values.
     epics:
       timeout: 5.0
       gateways:
@@ -859,8 +859,8 @@ agent_data:
 # ============================================================
 # Every panel tab in `osprey web` is served by its own small web server, and
 # each one takes host/port/auto_launch from its own config section. These six
-# are the complete set — five of them have never appeared in a template
-# (artifact_server is the only one that ever shipped), so this is the map:
+# are the complete set — artifact_server is the only one this file writes a
+# stanza for, and the other five run at their defaults, so this is the map:
 #
 #   tab        keys live under        default port   port env var
 #   WORKSPACE  artifact_server        8086           OSPREY_ARTIFACT_SERVER_PORT
@@ -1019,8 +1019,8 @@ claude_code:
 # WEB TERMINAL
 # ============================================================
 # The terminal process itself (`osprey web`) — a different section from `web:`
-# below, which configures the panel tabs it renders. Both are read; neither has
-# ever shipped in a template, so every key here is at its default.
+# below, which configures the panel tabs it renders. Both are read; no
+# `web_terminal:` block is written out here, so every key is at its default.
 # web_terminal:
 #   host: "127.0.0.1"    # Bind address. A deployment that DECLARES
 #                        # OSPREY_TERMINAL_BIND_HOST — the multi-user compose

--- a/src/osprey/templates/apps/control_assistant/data/channel_databases/examples/README.md
+++ b/src/osprey/templates/apps/control_assistant/data/channel_databases/examples/README.md
@@ -291,7 +291,7 @@ Multiple instance levels in a row (like SECTOR then DEVICE) create **combinatori
 ### Variable Subtrees
 Tree branches can define different child structures - not all paths through the hierarchy need to be identical.
 
-### Optional Levels (NEW!)
+### Optional Levels
 Hierarchy levels marked `"optional": true` can be skipped in some paths:
 - **Automatic leaf detection**: Nodes without children are automatically detected as leaves (no `_is_leaf` needed)
 - **Explicit leaf markers**: `"_is_leaf": true` ONLY needed for nodes that have children but are also complete channels

--- a/src/osprey/templates/apps/hello_world/config.yml.j2
+++ b/src/osprey/templates/apps/hello_world/config.yml.j2
@@ -10,8 +10,9 @@ project_name: "{{ project_name }}"
 
 # Facility identity — one block, two keys:
 #   name   — display name woven into the agent prompts (CLAUDE.md, subagents)
-#            and the web-terminal landing page. Falls back to the older
-#            top-level `facility_name`, then to the project name.
+#            and the web-terminal landing page. Preferred spelling, and it
+#            wins over a top-level `facility_name`, which is honored as a
+#            fallback; with neither set, the project name is used.
 #   prefix — short abbreviation the deployed web stack uses for container
 #            names (`<prefix>-nginx`, `<prefix>-web-<user>`); must be a
 #            non-empty valid Docker name start ([a-zA-Z0-9]).
@@ -117,7 +118,7 @@ api:
 # ============================================================
 # CONTROL SYSTEM CONFIGURATION
 # ============================================================
-# Mock mode: works instantly with any channel names (no hardware required)
+# Mock mode: works with any channel names (no hardware required)
 # Production mode: change type to 'epics' and configure the connector
 #
 # Migration to production:

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_config_drift.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_config_drift.py
@@ -29,7 +29,7 @@ SessionStart ──► stat config.yml & .claude/settings.json
 ``control_system.writes_enabled`` kill-switch, which bakes
 ``mcp__controls__channel_write`` into ``settings.json``'s ``permissions.deny``)
 only take effect once the artifacts are re-rendered by ``osprey build``. The web
-and CLI entry points now auto-regenerate, but a hand-edited config.yml launched
+and CLI entry points auto-regenerate, but a hand-edited config.yml launched
 via raw ``claude`` would otherwise run stale settings with no signal. This hook
 is that signal.
 

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_hook_log.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_hook_log.py
@@ -161,7 +161,7 @@ def get_repo_root(hook_input=None):
        verb finds a repo. Reached only when the config named no root and does
        not exist, where the framework has nothing left to consult either.
     4. The project directory itself. A legacy flat layout has no zones to
-       separate, so anchoring on it is both the old behaviour and the right one.
+       separate, so anchoring on it is the right answer.
 
     Returns:
         The repo root as a string, matching :func:`get_project_dir`'s type.

--- a/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
+++ b/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
@@ -1,7 +1,7 @@
 {#
   docker-compose.web.yml.j2 — multi-user web-terminal stack overlay.
 
-  Rendered by render_web_terminals() (Task 1.4, src/osprey/deployment/web_terminals/
+  Rendered by render_web_terminals() (src/osprey/deployment/web_terminals/
   render.py) with a Jinja2 Environment that has autoescape=False — this emits YAML,
   not HTML, and autoescape would corrupt env values containing "&", "<", etc. Added
   to `runtime.compose_files` alongside the base docker-compose.yml.
@@ -52,7 +52,7 @@
           "extra_mounts": [str, ...],   # resolved by resolve_personas() from the persona's
                                         #   `extra_mounts` -> extra per-user `volumes:` lines
                                         #   (compose volume strings, e.g. "/opt/data:/app/data:ro").
-                                        #   Empty list (the zero-migration default) emits none.
+                                        #   Empty list (the default) emits none.
           "display_name": str | None,   # optional window/tab title -> OSPREY_WEB_APP_NAME;
                                         #   None (the default) emits NO env line — see below
           "web": int,        # web_base_port + index -> OSPREY_WEB_PORT / OSPREY_TERMINAL_WEB_PORT
@@ -60,18 +60,17 @@
             {"name": str,    #   derived by render.py from the registry's port_env_var
              "port": int},   #   + `<family>_base_port + index` (ports.PANEL_ENV_VARS)
             ...              #   — the template only iterates; hand-listing env vars
-          ],                 #   here is what once let a panel miss multi-user wiring
+          ],                 #   here is what would let a panel miss multi-user wiring
         }
       (allocate_ports() also merges each companion family's port under its
       family name — e.g. "artifact": int — for callers/tests; this template
       reads only "web" and "panel_env".)
-      A no-personas config (the zero-migration path) resolves every entry's
-      `image` to the same `<registry_url>/web-terminal:latest` this template
-      used to build directly, and every entry's `container_project_dir` to
-      `/app/<facility_prefix>-assistant` — byte-identical output to before
-      personas existed (see resolve_personas()'s docstring). render.py MUST
-      NOT include an entry whose "user" is "nginx" (reserved
-      service name; enforced by the lint (Task 1.5) against the roster).
+      A no-personas config resolves every entry's `image` to
+      `<registry_url>/web-terminal:latest` and every entry's
+      `container_project_dir` to `/app/<facility_prefix>-assistant` (see
+      resolve_personas()'s docstring). render.py MUST NOT include an entry
+      whose "user" is "nginx" (reserved service name; enforced by the lint
+      against the roster).
       This template ALSO refuses to render such a `services` list (see the
       loop below) — belt-and-suspenders, because a `services:` mapping with
       two `nginx:` keys wouldn't fail loudly on its own: PyYAML silently
@@ -85,9 +84,8 @@
       The fully-qualified origin browsers use to reach nginx, e.g.
       "http://als-deploy.lbl.gov:9080" (scheme + deploy host + nginx_port, no
       trailing slash). Passed to every per-user service as
-      OSPREY_TERMINAL_LANDING_URL so the in-app logout control has a target
-      (see the Task 3.3/4.1 contract in shared_context.md). This can't be
-      computed the way nginx.conf.j2 computes its redirect targets (from
+      OSPREY_TERMINAL_LANDING_URL so the in-app logout control has a target.
+      This can't be computed the way nginx.conf.j2 computes its targets (from
       request-time `$host`) — env vars are baked in at container start — so
       render.py must resolve it once, typically from `deploy.host` + this
       same `nginx_port`.
@@ -110,8 +108,8 @@
 
     auth_method: str, required ("none" | "password" | "oidc")
       "none" (the default posture) renders NO `auth:` service at all — the
-      whole block below is suppressed, byte for byte, so every deployment that
-      has not opted into authentication keeps the compose overlay it has today.
+      whole block below is suppressed, byte for byte, so a deployment that has
+      not opted into authentication carries no login surface.
     auth_port: int, required
       Host port the sidecar's uvicorn binds — on `bind_host` only, exactly like
       the per-user apps. nginx (same host netns) is the only thing that reaches
@@ -155,7 +153,7 @@
       does) — this only decides the `Secure` attribute on the cookies it issues,
       which is why no cert/key is mounted into this service.
 
-    bind_host: str, required (Task 1.1)
+    bind_host: str, required
       Loopback address (always "127.0.0.1") baked into every per-user
       service's OSPREY_TERMINAL_BIND_HOST — and into the auth sidecar's own
       uvicorn bind. Not sourced from config at all — see render.py's
@@ -205,15 +203,12 @@
   NOT the host's routable interface: every per-user app binds `bind_host`
   ("127.0.0.1", via OSPREY_TERMINAL_BIND_HOST) only, so a per-user port is
   unreachable from off-host even though it shares the host network
-  namespace. nginx (bind-nginx-reverse-proxy) is therefore the only intended
-  off-host path to a per-user app — it reverse-proxies to these loopback
-  upstreams rather than the redirect-to-distinct-origin scheme this template
-  used prior to Task 1.1. nginx itself still runs on host networking (so
-  `nginx_port` sits in the same reachability class the per-user ports used
-  to) and binds every interface, unrestricted — it is the one service
-  required to be reachable off-host, and it can always reach the per-user
-  loopback upstreams because loopback is visible to every process sharing
-  the same host netns.
+  namespace. nginx is therefore the only intended off-host path to a per-user
+  app — it reverse-proxies to these loopback upstreams. nginx itself runs on
+  host networking and binds every interface, unrestricted — it is the one
+  service required to be reachable off-host, and it can always reach the
+  per-user loopback upstreams because loopback is visible to every process
+  sharing the same host netns.
 
   MOUNT PATHS: every relative path in this file — the nginx mounts and both
   `env_file:` entries — resolves against ONE directory, the pinned compose
@@ -269,7 +264,7 @@ services:
       retries: 5
       start_period: 10s
 {#- The auth sidecar. Whitespace control on this `if` (and its `endif`) is what
-   keeps the `auth.method: none` render byte-identical to the pre-auth overlay:
+   keeps the `auth.method: none` render free of a stray blank line:
    with the block suppressed, the `{%- if %}` swallows the newline it would
    otherwise leave behind and the `endif` line's own newline restores the one
    that ended `start_period: 10s`. Service key "auth" cannot collide with a
@@ -372,7 +367,7 @@ services:
   {# HARD FAIL: a user literally named "nginx" would silently clobber the
      nginx service key above (PyYAML keeps the last of two duplicate mapping
      keys, so the whole nginx service — and the landing page — would just
-     vanish with no render error). The lint (Task 1.5) already rejects this
+     vanish with no render error). The lint already rejects this
      against the roster; this is a second, independent guard that fires
      even if render.py is ever called without going through the lint first. #}
   {{ 1 / 0 }}

--- a/src/osprey/templates/modules/web_terminals/landing.html.j2
+++ b/src/osprey/templates/modules/web_terminals/landing.html.j2
@@ -1,7 +1,7 @@
 {#
   landing.html.j2 — grouped landing page for the multi-user web-terminal stack.
 
-  Rendered by render_web_terminals() (Task 1.4) and served as a plain static file by
+  Rendered by render_web_terminals() and served as a plain static file by
   nginx — there is no app route behind this page, so it must stay self-contained
   (inline CSS, no external assets, no build step).
 

--- a/src/osprey/templates/modules/web_terminals/nginx.conf.j2
+++ b/src/osprey/templates/modules/web_terminals/nginx.conf.j2
@@ -11,7 +11,7 @@
   ----------------------------------------------------------------------------
 
     nginx_port: int, required
-    bind_host: str, required (Task 1.1's _LOOPBACK_BIND_HOST, "127.0.0.1")
+    bind_host: str, required (render.py's _LOOPBACK_BIND_HOST, "127.0.0.1")
       The loopback address every per-user app's `web` family binds (see
       docker-compose.web.yml.j2's OSPREY_TERMINAL_BIND_HOST). This is the
       `proxy_pass` upstream host below — nginx is the only process on the
@@ -38,8 +38,7 @@
       every proxied `/u/<user>/` location, the per-user internal target
       location each of them subrequests, and the public `/auth/` surface the
       sidecar serves the login flow from. When "none", nothing auth-related is
-      emitted and this template renders exactly what it rendered before
-      authentication existed.
+      emitted and the plain proxy config below is the whole render.
     auth_port: int, required when auth_method != "none" (defaults to 9070)
       The loopback port the auth sidecar listens on. Reached at bind_host, the
       same way every per-user app is: the sidecar shares the host network
@@ -69,26 +68,23 @@
   a syntactically-standalone fragment.
 
   ----------------------------------------------------------------------------
-  WHY A REAL REVERSE PROXY, NOT A REDIRECT
+  WHY A REAL REVERSE PROXY
 
   Every per-user app binds its `web` port on `bind_host` (127.0.0.1) only —
-  bind-per-user-apps-loopback moved it off the routable interface, so nginx
-  is now the only off-host path and can safely make the outbound connection
-  itself. Each configured user therefore gets a genuine `proxy_pass` upstream
-  under a shared single origin at `/u/<user>/`, instead of the earlier
-  redirect-to-distinct-origin scheme (nginx never made an outbound connection
-  then; it only told the browser a different host:port to go to next). The
-  `map` below and the `proxy_set_header` lines are what make that proxied
-  connection transparent to WebSocket traffic (`/ws/terminal`, the panel
-  WebSocket) — without them the Upgrade handshake never reaches the upstream
-  and every terminal connection would fail.
+  off the routable interface — so nginx is the only off-host path and is the
+  one process that makes the outbound connection to them. Each configured
+  user therefore gets a genuine `proxy_pass` upstream under a shared single
+  origin at `/u/<user>/`. The `map` below and the `proxy_set_header` lines
+  are what make that proxied connection transparent to WebSocket traffic
+  (`/ws/terminal`, the panel WebSocket) — without them the Upgrade handshake
+  never reaches the upstream and every terminal connection would fail.
 
   `location /u/<user>/ { proxy_pass http://<bind_host>:<web>/; }` — the
   trailing slash on BOTH the location and the proxy_pass target strips the
   `/u/<user>` prefix before the request reaches the upstream app, so the app
   itself never sees the prefix in its request path (it only needs to know its
   own prefix for constructing prefixed links/asset URLs, an app-side concern
-  handled by the Task 2.1 prefix contract, not by anything here).
+  handled by the app's own prefix contract, not by anything here).
 
   A no-trailing-slash `/u/<user>` request would otherwise fall through to
   `location /` (the landing page) instead of the user's app — the companion
@@ -96,12 +92,11 @@
   without the trailing slash still routes in.
 
   `proxy_buffering off` + a raised `proxy_read_timeout`: every request under
-  `/u/<user>/` now genuinely flows through nginx (Phase 1's redirect never put
-  nginx in the data path at all), which means nginx's DEFAULT buffering and
-  60s read timeout now apply to the app's Server-Sent-Events streams too
-  (`/api/files/events`, chat SSE) — not just the WebSocket traffic the Upgrade
-  headers above cover. Buffering ON would batch/delay SSE `data:` lines behind
-  nginx's proxy buffer instead of flushing them as the app emits them, and the
+  `/u/<user>/` genuinely flows through nginx, which means nginx's DEFAULT
+  buffering and 60s read timeout apply to the app's Server-Sent-Events streams
+  too (`/api/files/events`, chat SSE) — not just the WebSocket traffic the
+  Upgrade headers above cover. Buffering ON would batch/delay SSE `data:` lines
+  behind nginx's proxy buffer instead of flushing them as the app emits, and the
   60s default read timeout would tear down a heartbeat-less idle SSE stream
   every minute. Both directives are scoped to this proxied location only —
   WebSocket traffic bypasses proxy buffering entirely once the Upgrade
@@ -118,9 +113,9 @@
   AUTH/TLS, OFF BY DEFAULT
 
   A deployment that sets neither `web_terminals.auth` nor `web_terminals.tls`
-  renders exactly what this template rendered before either existed: plain
-  http, no `auth_request`, every `/u/<user>/` open to anyone who can reach the
-  port. Both features are opt-in, and each is gated independently:
+  renders plain http: no `auth_request`, every `/u/<user>/` open to anyone who
+  can reach the port. Both features are opt-in, and each is gated
+  independently:
 
   - `tls_enabled` (default False) emits nothing. When true, the plain port
     becomes a redirect-only server and a second `listen 443 ssl` server —
@@ -268,9 +263,9 @@ server {
   {{ 1 / 0 }}
 {% endif %}
     # Reverse proxy to {{ svc.user }}'s loopback upstream (the per-user app's
-    # `web` family, bound by bind-per-user-apps-loopback). Trailing slashes on
-    # both the location and proxy_pass target strip /u/{{ svc.user }} before
-    # the request reaches the upstream.
+    # `web` family, bound to loopback only). Trailing slashes on both the
+    # location and proxy_pass target strip /u/{{ svc.user }} before the
+    # request reaches the upstream.
     location /u/{{ svc.user }}/ {
 {% if auth_method != "none" %}
         # Authentication is on (web_terminals.auth.method is "{{ auth_method }}"):

--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -1,7 +1,7 @@
 # ============================================================
 # {{ project_name }} Configuration
 # ============================================================
-# Claude Code project — streamlined configuration.
+# Claude Code project configuration.
 # ============================================================
 
 # Project identity
@@ -9,8 +9,9 @@ project_name: "{{ project_name }}"
 
 # Facility identity — one block, two keys:
 #   name   — display name woven into the agent prompts (CLAUDE.md, subagents)
-#            and the web-terminal landing page. Falls back to the older
-#            top-level `facility_name`, then to the project name.
+#            and the web-terminal landing page. Preferred spelling, and it
+#            wins over a top-level `facility_name`, which is honored as a
+#            fallback; with neither set, the project name is used.
 #   prefix — short abbreviation the deployed web stack uses for container
 #            names (`<prefix>-nginx`, `<prefix>-web-<user>`); must be a
 #            non-empty valid Docker name start ([a-zA-Z0-9]).
@@ -276,7 +277,7 @@ archiver:
 # Agents are auto-managed based on config and are not listed here.
 
 claude_code:
-  # ── CLI Version Pin (issue #218) ──────────────────────────
+  # ── CLI Version Pin ───────────────────────────────────────
   # Pin the Claude Code CLI version to insulate this project from upstream
   # breaking releases. When set, `osprey chat` and `osprey web` launch
   # via `npx -y @anthropic-ai/claude-code@<version>` instead of bare `claude`.
@@ -370,7 +371,7 @@ claude_code:
 # ============================================================
 # Two sections, both read, easy to confuse: `web_terminal:` is the terminal
 # PROCESS (bind address, shell, watcher), `web:` is the browser UI it renders
-# (theme, panel tabs). `web_terminal:` has never shipped in a template, so
+# (theme, panel tabs). No `web_terminal:` block is written out here, so
 # every key below is at its default.
 # web_terminal:
 #   host: "127.0.0.1"    # Bind address. A deployment that DECLARES

--- a/src/osprey/templates/project/dockerignore
+++ b/src/osprey/templates/project/dockerignore
@@ -10,11 +10,10 @@
 # pattern matches nothing. Edit the list here; the spelling for that depth is
 # derived, never maintained twice.
 #
-# There is deliberately NO `build/` entry. It used to exclude the render zone,
-# back when a project directory held its own build output and the image
-# regenerated that output for itself. The render IS the deployment now, and the
-# project image's context is a deployment repo, so excluding `build/` would ship
-# an image with no config, no .mcp.json and no Claude Code artifacts at all.
+# There is deliberately NO `build/` entry. The project image's context is a
+# deployment repo whose render — the deployment itself — lives under `build/`,
+# so excluding it would ship an image with no config, no .mcp.json and no
+# Claude Code artifacts at all.
 
 # Secrets — must never enter the image (pass at runtime: --env-file .env).
 # Every variant is excluded, the deploy-generated .env.production included;

--- a/src/osprey/templates/skills/osprey-build-interview/SKILL.md
+++ b/src/osprey/templates/skills/osprey-build-interview/SKILL.md
@@ -86,7 +86,7 @@ Gather the evidence first, before you ask a single migration question:
 - **What version is installed here** — `osprey --version`. Everything below is relative
   to it, and it is the only version whose behaviour you can check.
 - **What a current setup looks like** — materialize a profile into a scratch directory
-  from a bundled preset (the canonical modern one, unless something they said points
+  from a bundled preset (the canonical one, unless something they said points
   elsewhere) and read what it writes. That is the shape their setup is moving towards,
   defined by the installation in front of you rather than by memory. Delete it
   afterwards; it exists to be read, and the real one gets materialized later.
@@ -96,11 +96,11 @@ Gather the evidence first, before you ask a single migration question:
 
 Now derive your own questions by comparing the two. For each thing they have, the
 question is which of three things it is: a fact that belongs in the new profile, an
-artifact that carries across as a file the profile owns, or something the framework now
+artifact that carries across as a file the profile owns, or something the framework
 does natively and that should retire. Ask one at a time, in plain language, and say what
 each answer costs them — a thing that retires is work they no longer maintain, which is
 usually welcome news once it is put that way. Where you cannot tell whether the
-framework covers something now, check the installation instead of guessing; the map
+framework covers something, check the installation instead of guessing; the map
 lists the commands that answer that.
 
 Two cases are common enough to name, though neither gets a procedure here:
@@ -226,7 +226,7 @@ person* rather than guessing. Categories worth checking:
 Pick the starting preset first. `osprey profile presets` reports what this
 installation ships; open the ones that sound close — the map says where they live — and
 take the one whose privilege level and connection mode match what the interview
-established. The `control-assistant` family is the canonical modern example and a
+established. The `control-assistant` family is the canonical example and a
 sensible default when nothing else stands out.
 
 Then lay out the facility repo:
@@ -325,8 +325,8 @@ here depends on asking a live installation what exists, so without the CLI you c
 this honestly. Tell them exactly what to run — `pip install osprey-framework`, or
 whatever their facility's install instructions say — and then stop cleanly. Do not fall
 back to answering from memory and do not fabricate preset, config, or service names to
-keep the conversation moving; answering from recall is how the previous version of this
-skill went stale.
+keep the conversation moving; answering from recall is exactly how this skill goes
+stale.
 
 **They describe an existing setup you cannot open.** It is on another machine, or behind
 a login, or they only half remember it. Say so plainly and work from what you *can* see:

--- a/src/osprey/templates/skills/osprey-build-interview/references/osprey-map.md
+++ b/src/osprey/templates/skills/osprey-build-interview/references/osprey-map.md
@@ -29,7 +29,7 @@ osprey init <dir> --preset <name>
 re-materialize an existing repo's source zone unless `--force` is given. `-O <file>`
 and `--set KEY=VALUE` bake overrides into the written profile.
 
-`<dir>` becomes a git repo — the repo *is* the deployment — holding four zones:
+`<dir>` becomes a git repo that is the deployment, holding four zones:
 
 | Path | What it is |
 | --- | --- |
@@ -62,7 +62,7 @@ Build from the edited profile: `osprey build`
 | What | Where |
 | --- | --- |
 | Bundled presets (what `extends:` resolves to) | `src/osprey/profiles/presets/` |
-| Canonical modern example | the `control-assistant` family in that directory |
+| Canonical example | the `control-assistant` family in that directory |
 | The `deploy:` block's shape and rules | `src/osprey/cli/build_profile_deploy.py` |
 | Selectable model providers | `_BUILTIN_PROVIDERS` in `src/osprey/models/provider_registry.py` |
 | App templates rendered into a project | `src/osprey/templates/apps/` |

--- a/src/osprey/templates/skills/osprey-release/SKILL.md
+++ b/src/osprey/templates/skills/osprey-release/SKILL.md
@@ -71,8 +71,8 @@ when the tag is not on the commit being built, or when the checkout is shallow
 Open `CHANGELOG.md`, read the `## [Unreleased]` section, and answer three
 questions before doing anything else:
 
-1. **What is this release about?** Pick a short theme (e.g., "GitHub Flow
-   migration & branch-protection enforcement"). It goes into the release
+1. **What is this release about?** Pick a short theme (e.g., "scan-plan
+   authoring & branch-protection enforcement"). It goes into the release
    title, the README "Latest Release" line, and the GitHub Release body.
 2. **What is the version number?** Apply the CalVer rules above. Patch bump
    for fixes, month bump for feature batches, year bump only at January.
@@ -169,12 +169,13 @@ git push origin vYYYY.M.P
 The tag must point at the merge commit on `main`. The `release.yml` workflow
 triggers on `v*.*.*` and:
 
-1. Verifies the tag matches `__version__` in `src/osprey/__init__.py`.
-2. Builds the wheel and sdist.
+1. Builds the wheel and sdist.
+2. Verifies the built version matches the tag. A checkout without full history
+   builds `0.1.devN` instead of the tagged version; this gate catches that.
 3. Publishes to PyPI via trusted publishing (OIDC; no token needed).
 4. Creates a GitHub Release using the CHANGELOG section as the body.
 
-If step 1 fails, the publish aborts before any PyPI write — safe.
+If step 2 fails, the publish aborts before any PyPI write — safe.
 
 ## Step 5: Verify
 
@@ -216,7 +217,7 @@ This is a fallback. The default path is the automated workflow.
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
-| `release.yml` "Verify version matches tag" fails | `__version__` in `__init__.py` doesn't match the pushed tag | Tag the wrong commit, or the version-bump PR didn't actually update `__init__.py`. Delete the tag locally and on origin, fix, retag |
+| `release.yml` "Verify built version matches tag" fails | The wheel built from the tagged commit carries a different version | The tag points at the wrong commit, or the checkout lacked the history `hatch-vcs` needs. Delete the tag locally and on origin, fix, retag |
 | PyPI rejects the upload as a duplicate | This version was already published | CalVer means version numbers are unique; you cannot republish. Bump the patch counter and try again |
 | `gh pr merge --rebase` fails with "not mergeable" | Stale checks because `main` moved | `git rebase origin/main` on the release branch, force-push with lease, wait for CI to re-run |
 | GitHub Release body is empty or wrong | CHANGELOG section heading didn't match the regex `release.yml` uses | Make sure the CHANGELOG heading is exactly `## [YYYY.M.P] - YYYY-MM-DD` |

--- a/src/osprey/utils/config.py
+++ b/src/osprey/utils/config.py
@@ -140,8 +140,8 @@ def resolve_env_vars(data: Any, *, environ: "Mapping[str, str] | None" = None) -
 
 
 # OSPREY runs agent Python code in exactly one backend: a subprocess on the host.
-# ``local`` is the historical name for that same backend; ``container`` named a
-# Jupyter kernel gateway OSPREY never shipped.
+# ``local`` is an accepted alias for that same backend; ``container`` names a
+# Jupyter kernel gateway OSPREY does not ship.
 EXECUTION_METHOD_SUBPROCESS = "subprocess"
 
 # Module-level latch so the ``container`` deprecation is logged once per process
@@ -228,9 +228,9 @@ def resolve_execution_method(
     while the config file stops claiming a backend OSPREY does not ship:
 
     - ``subprocess`` — the honest name; returned as-is.
-    - ``local`` — historical name for the same subprocess backend; mapped silently.
-    - ``container`` — named a Jupyter kernel gateway that was never shipped, so it
-      failed outright at execution time. Mapped to ``subprocess`` with a one-time
+    - ``local`` — an alias for the same subprocess backend; mapped silently.
+    - ``container`` — names a Jupyter kernel gateway OSPREY does not ship, so it
+      fails outright at execution time. Mapped to ``subprocess`` with a one-time
       deprecation warning, because that value's behavior genuinely changes.
     - unset (missing, ``None``, or blank) — defaults to ``subprocess``.
 

--- a/src/osprey/utils/logger.py
+++ b/src/osprey/utils/logger.py
@@ -267,7 +267,7 @@ def get_logger(
         # Custom logger
         logger = get_logger(name="test_logger", color="blue")
     """
-    del level  # no longer configures anything; see configure_logging()
+    del level  # configures nothing here; see configure_logging()
 
     if name is not None:
         base_logger = logging.getLogger(name)
@@ -283,10 +283,10 @@ def get_logger(
 
     base_logger = logging.getLogger(component_name)
 
-    # No config lookup here, deliberately. This used to resolve
-    # ``logging.logging_colors.<component>``, but nothing ever consumed the
-    # result — ComponentLogger.color is write-only and _log() delegates
-    # straight to the stdlib logger. Building a Config to answer it dragged
+    # No config lookup here, deliberately. Resolving
+    # ``logging.logging_colors.<component>`` would buy nothing —
+    # ComponentLogger.color is write-only and _log() delegates
+    # straight to the stdlib logger — while dragging
     # the whole config machinery — and its ``.env`` load — into all ~70
     # module-level ``logger = get_logger(...)`` sites, making a bare
     # ``import osprey.<anything>`` rewrite os.environ. See the module

--- a/src/osprey/utils/workspace.py
+++ b/src/osprey/utils/workspace.py
@@ -1,8 +1,8 @@
 """Cross-layer workspace and config resolution utilities.
 
-These functions were originally in ``mcp_server.common`` but are used across
-``interfaces/``, ``cli/``, ``services/``, and ``mcp_server/`` layers.
-Living in ``utils/`` eliminates layering violations.
+These functions are used across the ``interfaces/``, ``cli/``, ``services/``,
+and ``mcp_server/`` layers, so they live in ``utils/`` — below all of them —
+rather than inside any one layer.
 """
 
 import logging
@@ -73,8 +73,8 @@ def dotted_config_str(config: Mapping[str, Any] | None, key: str) -> str | None:
 
     The single reader for the path-shaped config keys, so the checks that
     *reject* a value and the resolvers that *use* it cannot disagree about what
-    the config says. They previously differed on ``dict`` versus ``Mapping``,
-    which is only invisible while every config arrives straight from the YAML
+    the config says — including on ``dict`` versus ``Mapping``, a difference
+    that stays invisible only while every config arrives straight from the YAML
     loader.
 
     Args:
@@ -252,8 +252,8 @@ def repo_root_for_config(config_path: Path | str) -> Path:
     render and holds ``config.yml`` at its root. One helper for both, so the
     "is this the build zone?" question is asked in exactly one place.
 
-    Known non-goal: a legacy FLAT project whose own directory is literally
-    named ``build`` is read as a render, and its parent is returned. Accepted
+    Known non-goal: a FLAT project whose own directory is literally named
+    ``build`` is read as a render, and its parent is returned. Accepted
     — every runtime path derives the root through this helper, so a regen or a
     status check agreeing with the runtime beats a special case that would make
     the two disagree.

--- a/tests/cli/_lifecycle_build.py
+++ b/tests/cli/_lifecycle_build.py
@@ -1,6 +1,6 @@
 """Stub a ``build/`` inside a deployment repo, for CLI tests that need one.
 
-Every repo-scoped verb now reads the *render* — ``<repo>/build/config.yml`` —
+Every repo-scoped verb reads the *render* — ``<repo>/build/config.yml`` —
 rather than a directory it was handed, so a CLI test that used to write one
 ``config.yml`` into ``tmp_path`` now needs a repo with a render in it. The
 ``lifecycle_repo`` fixture supplies the repo (source zone, state zone, an

--- a/tests/cli/test_answer_provenance_render.py
+++ b/tests/cli/test_answer_provenance_render.py
@@ -126,9 +126,9 @@ class TestControlOperatorOutputStyle:
         assert "confidence" in style.lower()
 
     def test_no_contradictory_leftover(self, control_output_style: str) -> None:
-        # CF-1/FR6: the old absolute prohibition ("fill gaps with textbook
-        # physics") was *rewritten into* the ordered posture, not left beside a
-        # rule that tells the agent how to use general knowledge with a flag.
+        # CF-1/FR6: an absolute prohibition ("fill gaps with textbook physics")
+        # must not sit beside the ordered posture's rule for using general
+        # knowledge with a flag — the two contradict each other.
         assert "textbook physics" not in control_output_style
 
     def test_epistemic_block_is_facility_agnostic(self, control_output_style: str) -> None:

--- a/tests/cli/test_base_url_override.py
+++ b/tests/cli/test_base_url_override.py
@@ -79,7 +79,7 @@ class TestV1StripSurvivesTheOverride:
         assert spec.env_block["ANTHROPIC_BASE_URL"] == FACILITY_GATEWAY
 
     def test_shipped_template_urls_are_unchanged_by_the_override(self):
-        """cborg/als-apg templates ship the built-in URL + /v1 — same result as before."""
+        """cborg/als-apg templates ship the built-in URL + /v1 — the override is a no-op."""
         for provider, shipped, expected in (
             ("cborg", "https://api.cborg.lbl.gov/v1", "https://api.cborg.lbl.gov"),
             (

--- a/tests/cli/test_bluesky_profile_keys.py
+++ b/tests/cli/test_bluesky_profile_keys.py
@@ -1,10 +1,10 @@
 """Tests for the strict key check inside a profile's ``bluesky:`` block.
 
-Every field of the block used to be read with ``.get()``, so an unknown key —
-a typo like ``tiled_enabld:``, or a knob a release removed — was silently
-dropped and the build shipped without whatever the facility asked for. The
-block is now closed the same way the top level is: unknown keys hard-error,
-naming every offender and its closest known spelling.
+Reading every field of the block with ``.get()`` would silently drop an unknown
+key — a typo like ``tiled_enabld:``, or a knob a release removed — and the build
+would ship without whatever the facility asked for. The block is closed the same
+way the top level is: unknown keys hard-error, naming every offender and its
+closest known spelling.
 
 The valid set is *derived* from :class:`BlueskyConfig`'s dataclass fields, the
 same declaration ``_parse_profile`` reads the block into, so the check cannot
@@ -163,11 +163,11 @@ def test_error_style_matches_the_top_level_check() -> None:
 
 
 def test_stale_demo_runner_key_fails_loudly() -> None:
-    """Regression pin for the removed knob's migration story.
+    """Regression pin for a retired knob.
 
-    ``bluesky.demo_runner`` selected a runner that no longer exists. An old
-    profile still carrying it must stop the build rather than be quietly
-    ignored — the removal has to announce itself.
+    ``bluesky.demo_runner`` names a runner OSPREY does not have. A profile
+    carrying it must stop the build rather than be quietly ignored — an
+    unhonored key has to announce itself.
     """
     with pytest.raises(BuildProfileError) as excinfo:
         _parse_profile({"name": "x", "bluesky": {"demo_runner": "mock"}})

--- a/tests/cli/test_bluesky_service_registration.py
+++ b/tests/cli/test_bluesky_service_registration.py
@@ -150,17 +150,15 @@ def _render_copied_compose(project_path: Path, config: dict) -> dict:
 
 
 def test_the_retired_demo_runner_knob_reaches_nothing(tmp_path: Path) -> None:
-    """The bridge no longer runs plans — the queueserver worker does — so the
-    in-process demo runner and the `bluesky.demo_runner` knob that armed it are
-    both gone.
+    """The bridge does not run plans — the queueserver worker does — so there
+    is no in-process demo runner and no `bluesky.demo_runner` knob to arm one.
 
-    This is a standing guard, not a regression test for a bug: the knob rendered
-    `BLUESKY_DEMO_RUNNER` into compose and printed a console line promising a
-    demo, so re-introducing either half would ship a config key that lies about
-    what the deployment does. A stale `demo_runner:` left in an old profile is
-    ignored by the loader (the `bluesky` block ignores every unknown key, which
-    predates this removal), which is why the guard is on the OUTPUT rather than
-    on the parse.
+    This is a standing guard, not a regression test for a bug: such a knob would
+    render `BLUESKY_DEMO_RUNNER` into compose and print a console line promising
+    a demo, so introducing either half would ship a config key that lies about
+    what the deployment does. A stale `demo_runner:` left in a profile is
+    ignored by the loader (the `bluesky` block ignores every unknown key), which
+    is why the guard is on the OUTPUT rather than on the parse.
     """
     project_path = tmp_path / "project"
     project_path.mkdir()

--- a/tests/cli/test_build_cmd.py
+++ b/tests/cli/test_build_cmd.py
@@ -1613,7 +1613,7 @@ class TestProfileExtends:
         assert profile.provider == "cborg"  # inherited from grandparent
 
     def test_no_extends_unchanged(self, minimal_profile_yaml: Path):
-        """Profiles without extends work exactly as before."""
+        """A profile without extends loads its own values verbatim."""
         profile = load_profile(minimal_profile_yaml)
         assert profile.name == "Test Profile"
         assert profile.model == "haiku"
@@ -2298,13 +2298,13 @@ class TestCopyServiceTemplates:
 
         # Deployed service still bundles (regression guard).
         assert (project_path / "services" / "postgresql" / "docker-compose.yml.j2").exists()
-        # Declared-but-not-deployed add-on is bundled too (the new behavior).
+        # Declared-but-not-deployed add-on is bundled too.
         assert (project_path / "services" / "openobserve" / "docker-compose.yml.j2").exists()
         assert count == 2
 
     def test_declared_only_service_bundles_without_deployed_services(self, tmp_path: Path) -> None:
         """With an empty deployed_services, a declared service with a package
-        template is still bundled — the copy path no longer early-returns when
+        template is still bundled — the copy path must not early-return when
         deployed_services is empty."""
         from osprey.cli.build_cmd import _copy_service_templates
 

--- a/tests/cli/test_build_context_guard.py
+++ b/tests/cli/test_build_context_guard.py
@@ -4,8 +4,8 @@ Every build installs the framework's ``docker/web-terminal-context/base.md``.
 The profile's ``web-terminal-context/`` convention directory copies one whole
 directory per user *below* that path, so the baseline survives by construction —
 these tests pin that, and pin the error a profile gets when it puts a loose file
-where a per-user directory belongs (the shape that, under the old free-form
-mapping, could replace the context root wholesale).
+where a per-user directory belongs (the shape that could otherwise replace the
+context root wholesale).
 """
 
 from __future__ import annotations
@@ -55,9 +55,9 @@ def test_per_user_context_keeps_baseline_and_seeds_user(tmp_path: Path) -> None:
 def test_loose_file_in_context_dir_is_rejected(tmp_path: Path) -> None:
     """The context convention holds per-user directories, never loose files.
 
-    This is the structural replacement for the old whole-directory guard: a
-    profile can no longer address the context root at all, and the one shape
-    that tries is rejected before anything is copied.
+    This is a structural guard rather than a whole-directory one: a profile
+    cannot address the context root at all, and the one shape that tries is
+    rejected before anything is copied.
     """
     project_path = _built_project(tmp_path, "context-loose-file")
     profile_dir = _profile_with_user_dir(tmp_path, "alice")

--- a/tests/cli/test_build_preset.py
+++ b/tests/cli/test_build_preset.py
@@ -218,7 +218,7 @@ def test_preset_name_normalization(runner: CliRunner, tmp_path: Path) -> None:
     cfg_b = _config_yaml(_project(out_b, "smoke"))
     # Same preset → same default_model in rendered config.
     # NB: the rendered key lives at claude_code.default_model, NOT top-level
-    # (this test was previously vacuously passing on a top-level lookup).
+    # (a top-level lookup would make this assertion vacuous).
     assert cfg_a["claude_code"]["default_model"] == cfg_b["claude_code"]["default_model"]
 
 
@@ -334,7 +334,7 @@ def test_multiple_override_files_apply_in_order(runner: CliRunner, tmp_path: Pat
 
 
 def test_override_missing_file_aborts(runner: CliRunner, tmp_path: Path) -> None:
-    """A missing -O file is refused where -O now lives: `osprey init`, which
+    """A missing -O file is refused where -O lives: `osprey init`, which
     validates and bakes override layers into the profile it materializes.
     `osprey build` carries no -O of its own — it only ever re-renders a
     profile.yml that already exists — so there is nothing left for it to
@@ -574,7 +574,7 @@ def test_extends_cycle_detected(
 def test_each_bundled_preset_builds_clean(preset: str, runner: CliRunner, tmp_path: Path) -> None:
     """Every bundled preset must materialize and build to a project with a
     valid config and manifest, and the profile it materialized into must still
-    say which preset it came from — the manifest itself no longer can, since a
+    say which preset it came from — the manifest itself cannot, since a
     zero-argument build only ever sees a plain profile.yml and does not know
     whether (or from which preset) it was materialized.
 

--- a/tests/cli/test_build_profile.py
+++ b/tests/cli/test_build_profile.py
@@ -262,16 +262,16 @@ class TestControlAssistantTurnkeyScanPanels:
     def test_control_assistant_ships_no_deprecated_results_panel(
         self, turnkey_scan_config: dict
     ) -> None:
-        """The shipped preset is the new-build path, so it carries only the new
-        id. The deprecated ``results`` entry is an accommodation for projects
-        built before the rename (kept working by the sidecar's alias mount);
-        re-emitting it here would put the old tab back on every rebuild."""
+        """A fresh build carries only the canonical id. The deprecated
+        ``results`` entry is an accommodation for projects built against the
+        earlier spelling (kept working by the sidecar's alias mount); emitting
+        it here would put that tab back on every rebuild."""
         assert "results" not in turnkey_scan_config["web"]["panels"]
 
     def test_control_assistant_ships_no_deprecated_plan_panel(
         self, turnkey_scan_config: dict
     ) -> None:
-        """Same rule for the PLAN panel, now the Plans tab of BLUESKY. Emitting
+        """Same rule for the PLAN panel, which is the Plans tab of BLUESKY. Emitting
         both ids would put two rail entries in front of the same panel."""
         assert "plan" not in turnkey_scan_config["web"]["panels"]
 

--- a/tests/cli/test_build_profile_emit.py
+++ b/tests/cli/test_build_profile_emit.py
@@ -59,7 +59,7 @@ def test_delta_content_is_the_preset_layer_minus_extends(preset: str) -> None:
 
 @pytest.mark.parametrize("preset", PERSONA_PRESETS)
 def test_delta_carries_no_extends(preset: str) -> None:
-    """Position is the inheritance now — a written ``extends:`` inside
+    """Position IS the inheritance — a written ``extends:`` inside
     ``personas/`` is rejected at build time, so emitting one would be a bug."""
     text = emit_persona_delta_yaml(
         preset_name=preset,
@@ -91,7 +91,7 @@ def test_delta_keeps_the_preset_comments() -> None:
     )
 
     unwrapped = _unwrapped_comments(text)
-    assert "this key IS the tier boundary" in unwrapped
+    assert "this key is the tier boundary" in unwrapped
     assert "Pared-down operator layout" in unwrapped
 
 

--- a/tests/cli/test_build_zero_arg.py
+++ b/tests/cli/test_build_zero_arg.py
@@ -85,7 +85,7 @@ class TestRendersTheOutputZone:
         assert manifest_path.parent == lifecycle_repo / "build"
 
     def test_compose_files_are_rendered_by_the_same_build(self, runner, lifecycle_repo):
-        """Absorbed from the old second verb: build/ describes the whole deployment."""
+        """One build does it all: build/ describes the whole deployment."""
         _build(runner, lifecycle_repo)
 
         rendered = list((lifecycle_repo / "build").rglob("docker-compose*.yml"))

--- a/tests/cli/test_channel_finder_cmd.py
+++ b/tests/cli/test_channel_finder_cmd.py
@@ -223,10 +223,9 @@ class TestBuildDatabaseOutputAnchoring:
         printed = _squashed(result.output)
         assert "stale" in printed
         # The command that clears the staleness is a bare `osprey build`.
-        # It used to be `build --force`; the flag is retired, so a message
-        # naming it would hand the operator a command line that no longer
-        # parses. Both halves asserted, because the fragment is exactly
-        # what went stale here.
+        # There is no `--force` flag, so a message naming one would hand
+        # the operator a command line that does not parse. Both halves
+        # asserted, because the fragment is exactly what went stale here.
         assert "ospreybuild" in printed
         assert "--force" not in printed
 
@@ -450,10 +449,9 @@ class TestBuildDatabaseOutputAnchoring:
         printed = _squashed(result.output)
         assert "stale" in printed
         # The command that clears the staleness is a bare `osprey build`.
-        # It used to be `build --force`; the flag is retired, so a message
-        # naming it would hand the operator a command line that no longer
-        # parses. Both halves asserted, because the fragment is exactly
-        # what went stale here.
+        # There is no `--force` flag, so a message naming one would hand
+        # the operator a command line that does not parse. Both halves
+        # asserted, because the fragment is exactly what went stale here.
         assert "ospreybuild" in printed
         assert "--force" not in printed
 

--- a/tests/cli/test_claude_code_integration.py
+++ b/tests/cli/test_claude_code_integration.py
@@ -818,7 +818,7 @@ class TestUserOwnedSkipBehavior:
         assert (project_dir / ".mcp.json").read_text() == custom_content
 
     def test_no_user_owned_behaves_as_before(self, tmp_path):
-        """Project without prompts section behaves exactly as before."""
+        """A project without a prompts section renders unaffected."""
         manager = TemplateManager()
         project_dir = manager.create_project(
             project_name="test-no-owned",

--- a/tests/cli/test_claude_code_resolver.py
+++ b/tests/cli/test_claude_code_resolver.py
@@ -163,7 +163,7 @@ class TestUnsupportedProvider:
 class TestCustomProxyProvider:
     """Custom Anthropic-compatible proxy via api.providers.
 
-    With the redesign, custom proxies own their model IDs via
+    Custom proxies own their model IDs via
     api.providers[name].models.  A proxy that specifies none is refused —
     the framework never substitutes another provider's model IDs.
     """

--- a/tests/cli/test_config_records_environment.py
+++ b/tests/cli/test_config_records_environment.py
@@ -6,14 +6,14 @@ exactly as the build profile declared it — so a build can be reproduced from t
 config alone.
 
 What it deliberately does **not** record is the interpreter that runs agent
-Python. That path used to be baked in as ``execution.python_env_path`` at build
-time, which made every generated config a snapshot of one machine's filesystem:
-move the project, mount it into a container, or rebuild the venv elsewhere and
-the recorded path pointed at nothing. The interpreter is now resolved at run
-time (the project's own ``.venv`` when it has one, else the interpreter running
-OSPREY), so no absolute interpreter path is written to config.yml at all. These
-tests assert that absence directly — it is what lets the heal-and-strip
-workarounds that existed to repair such stale paths be deleted.
+Python. Baking that path in as ``execution.python_env_path`` at build time would
+make every generated config a snapshot of one machine's filesystem: move the
+project, mount it into a container, or rebuild the venv elsewhere and the
+recorded path points at nothing. The interpreter is resolved at run time (the
+project's own ``.venv`` when it has one, else the interpreter running OSPREY),
+so no absolute interpreter path is written to config.yml at all. These tests
+assert that absence directly — it is what keeps heal-and-strip workarounds for
+stale paths out of the loader.
 
 Configs already deployed with the retired key must keep loading: it is ignored
 with a debug log, never an error.
@@ -246,7 +246,7 @@ class TestDeclaredEnvironmentIsRecordedVerbatim:
 
 
 class TestRetiredPythonEnvPathIsIgnored:
-    """Projects deployed with the old key must keep loading, unchanged."""
+    """Projects deployed with the retired key must keep loading, unchanged."""
 
     @staticmethod
     def _legacy_config(tmp_path: Path) -> Path:

--- a/tests/cli/test_deploy_image_source_propagation.py
+++ b/tests/cli/test_deploy_image_source_propagation.py
@@ -51,7 +51,7 @@ WEB_TERMINALS: dict[str, Any] = {
 # The same stack, deployable in LOCAL mode. `image_source: local` builds each
 # persona's image, so it requires a catalog and a default to build them from —
 # `resolve_personas` raises without one at deploy time, and since the build's
-# lint now reads the deploy-propagated config (`deploy_aware_config_errors`) it
+# lint reads the deploy-propagated config (`deploy_aware_config_errors`) it
 # refuses the same profile earlier. Every end-to-end case below names a local
 # deploy block, so they all build from this one.
 WEB_TERMINALS_LOCAL: dict[str, Any] = {

--- a/tests/cli/test_dockerfile_template.py
+++ b/tests/cli/test_dockerfile_template.py
@@ -373,9 +373,7 @@ class TestDockerignore:
     def test_the_render_itself_is_not_excluded(self, hello_project):
         """``build/`` must NOT be ignored — it is the deployment being shipped.
 
-        This entry used to exist, back when a project directory held its own
-        build output and the image regenerated that output for itself. The
-        render IS the deployment now, and the project image's context is a
+        The render IS the deployment, and the project image's context is a
         deployment repo, so an image built with ``build/`` ignored would carry
         no config.yml, no .mcp.json and no Claude Code artifacts — and would
         fail only at runtime, as an agent with nothing configured.

--- a/tests/cli/test_facility_name_resolution.py
+++ b/tests/cli/test_facility_name_resolution.py
@@ -108,7 +108,7 @@ def _channel_finder_prompt(project_dir: Path) -> str:
 
 @pytest.fixture(scope="module")
 def channel_finder_project(tmp_path_factory) -> Path:
-    """A channel-finder build — the path where the config value used to be shadowed."""
+    """A channel-finder build — the path most at risk of shadowing the config value."""
     out_dir = tmp_path_factory.mktemp("cf_facility")
     return TemplateManager().create_project(
         project_name="cf-facility",

--- a/tests/cli/test_health_cmd.py
+++ b/tests/cli/test_health_cmd.py
@@ -1,6 +1,6 @@
 """Contract tests for the ``osprey health`` CLI command.
 
-The command was rebuilt as a thin Click wrapper over the ``osprey.health``
+The command is a thin Click wrapper over the ``osprey.health``
 framework (see ``.claude/plans/configurable-health-system-p1-core-cli/PROPOSAL.md``
 §CLI rebuild). This module pins the *CLI-level contracts* — the observable
 behaviors a caller (human, ``--json`` consumer, or CI) depends on — rather than
@@ -33,20 +33,19 @@ Contracts pinned here
   within the suite deadline with the correct code (the daemon-thread / ``os._exit``
   guarantee). This *must* be a real subprocess — in-process it would kill pytest.
 
-Deliberately dropped from the old 749-line suite
-------------------------------------------------
-The previous file tested a since-deleted ``HealthChecker`` class and its
-``HealthCheckResult`` value object. Those were implementation-detail unit tests of
-a class that no longer exists; the *behaviors* they approximated are now pinned
-either by the contract tests above or by the ``osprey.health.*`` module tests that
-own each check. Consciously dropped assertions, and why:
+Deliberately out of scope here
+------------------------------
+There is no ``HealthChecker`` class and no ``HealthCheckResult`` value object to
+unit-test. The behaviors such tests would approximate are pinned either by the
+contract tests above or by the ``osprey.health.*`` module tests that own each
+check. What this module deliberately does not assert, and why:
 
-* ``HealthCheckResult`` construction/repr/status — deleted type; replaced by
-  ``osprey.health.models.CheckResult`` (owned by the models tests).
+* ``HealthCheckResult`` construction/repr/status — no such type; the value object
+  is ``osprey.health.models.CheckResult`` (owned by the models tests).
 * ``HealthChecker`` init/options/``add_result``/``results``/``config`` state —
-  deleted class; the CLI no longer holds mutable checker state.
+  no such class; the CLI holds no mutable checker state.
 * ``check_configuration`` missing/valid/empty/invalid-YAML unit calls — the
-  configuration *rows* are now pinned here via ``--json`` (``config_file_exists``,
+  configuration *rows* are pinned here via ``--json`` (``config_file_exists``,
   ``yaml_valid``, ``health_config``); row-message internals belong to
   ``core/configuration`` tests.
 * ``check_file_system`` / ``check_python_environment`` per-row unit calls
@@ -63,14 +62,14 @@ own each check. Consciously dropped assertions, and why:
 * ``check_claude_cli_version`` pinned-match/mismatch/npx-missing/unpinned subprocess
   mocking — owned by ``core/claude_cli`` tests; here we pin only the CLI-visible
   unpinned-skip and ``--full`` gating contracts.
-* ``display_results`` all-passing/warnings/errors/verbose calls — rendering is now
-  ``osprey.health.render`` (owned by the render tests); the CLI wires it and we
+* ``display_results`` all-passing/warnings/errors/verbose calls — rendering belongs
+  to ``osprey.health.render`` (owned by the render tests); the CLI wires it and we
   assert the stdout/stderr split, not the glyph layout.
 * ``check_openobserve`` healthz/retention unit calls — owned by
   ``core/openobserve`` tests.
-* The old exit-code tests patched ``HealthChecker`` to inject results; the mapping
-  is now a property of ``CheckReport`` and is pinned here by injecting a report at
-  the ``_run_suite`` boundary.
+* Exit-code mapping is a property of ``CheckReport``, so it is pinned here by
+  injecting a report at the ``_run_suite`` boundary rather than by patching any
+  checker object.
 """
 
 from __future__ import annotations

--- a/tests/cli/test_init_verb.py
+++ b/tests/cli/test_init_verb.py
@@ -148,16 +148,15 @@ def test_every_source_path_the_exemplar_names_is_emitted(exemplar_repo: Path) ->
 # TR-4 / SC-8
 # ---------------------------------------------------------------------------
 #
-# Both tests below are the whole requirement, asserted in full. They were held
-# open as strict xfails while the prose in `profile.yml`, `personas/*.yml`,
-# `.env.example` and `triggers.yml` still described the retired command surface
-# — none of it init's own, all of it coming from the bundled preset's comments,
-# the header `build_profile_emit` renders, the project env template and the
-# bundled trigger file. That rewrite has landed, so both now assert.
+# Both tests below are the whole requirement, asserted in full. The prose they
+# police — `profile.yml`, `personas/*.yml`, `.env.example` and `triggers.yml` —
+# is none of it init's own: it comes from the bundled preset's comments, the
+# header `build_profile_emit` renders, the project env template and the bundled
+# trigger file, so any of those can reintroduce a retired verb.
 
-#: Strings naming a command the redesign retires. Any of them in an artifact a
-#: fresh deployment ships is an instruction to its operator to run something
-#: that no longer exists.
+#: Strings naming a retired command. Any of them in an artifact a fresh
+#: deployment ships is an instruction to its operator to run something
+#: that does not exist.
 RETIRED_VERB_STRINGS = (
     "osprey deploy ",
     "osprey profile ",
@@ -816,11 +815,10 @@ def test_the_chain_refuses_a_flag_the_target_verb_does_not_declare() -> None:
 def test_the_chain_finds_both_verbs_on_the_group() -> None:
     """``--up`` chains ``build`` then ``up`` through the CLI group, by name.
 
-    The lookup is the whole mechanism, so the lookup is what is asserted. It
-    used to be checked indirectly, through a run whose failure mode was "the
-    verb does not exist yet" — now that both verbs are registered, that run's
-    outcome depends on a full render succeeding, which is the acceptance walk's
-    question rather than a unit test's.
+    The lookup is the whole mechanism, so the lookup is what is asserted.
+    Checking it indirectly through a run would make the outcome depend on a
+    full render succeeding, which is the acceptance walk's question rather
+    than a unit test's.
     """
     import click as _click
 

--- a/tests/cli/test_killswitch_bluesky_deny.py
+++ b/tests/cli/test_killswitch_bluesky_deny.py
@@ -1,13 +1,13 @@
 """Tests for the generalized kill-switch deny/remove_ask extension covering scan.
 
-``build_claude_code_context``'s writes-off kill-switch block (previously
-hardcoded to ``controls``/``python`` by name) now walks ``FRAMEWORK_SERVERS``
-for any hooks_pre rule gated by ``_WRITES_CHECK``, so a new write server (e.g.
+``build_claude_code_context``'s writes-off kill-switch block walks
+``FRAMEWORK_SERVERS`` for any hooks_pre rule gated by ``_WRITES_CHECK`` rather
+than naming ``controls``/``python`` by hand, so an added write server (e.g.
 the bluesky queue's arming tools) is covered automatically with no per-server
 code change. These tests pin: every ``bsky.ARMING_TOOLS`` entry is hard-denied
 when writes are off, the approval-only tools (``queue_stop``, ``stop_run``) are
-NEVER denied or removed-from-ask (the kill switch must not block halting), the
-existing controls/python behavior is preserved, and an extends clone gets the
+NEVER denied or removed-from-ask (the kill switch must not block halting),
+controls/python stay covered, and an extends clone gets the
 rewritten-prefix matcher.
 
 Tool names resolve from ``osprey.bluesky_tool_names`` so a rename carries

--- a/tests/cli/test_killswitch_bluesky_driftguard.py
+++ b/tests/cli/test_killswitch_bluesky_driftguard.py
@@ -160,7 +160,7 @@ def test_bluesky_stop_run_never_denied_regardless_of_writes_enabled(tmp_path):
     """stop_run carries approval only (no _WRITES_CHECK) -- the kill switch
     must never block stopping a scan, in either direction.
 
-    This is now load-bearing rather than merely tidy: stop_run is the only
+    This is load-bearing rather than merely tidy: stop_run is the only
     surface that ABORTS a plan already moving hardware (POST /queue/abort).
     Denying it under writes-off would take the emergency halt away at exactly
     the moment writes were disabled because something was wrong.

--- a/tests/cli/test_lifecycle_invariants.py
+++ b/tests/cli/test_lifecycle_invariants.py
@@ -224,8 +224,6 @@ _PROJECT_FLAG_ALLOWLIST = {
     # History, deliberately: the module's opening paragraph names the four rules
     # it replaced, and --project was one of them.
     "src/osprey/cli/repo_resolver.py": "narrates the retired rule it replaced",
-    # Same, in the CLI group's own docstring about what the redesign removed.
-    "src/osprey/cli/main.py": "narrates the retired flags",
     # A docstring contrasting this helper's contract with a `--project` verb's.
     "src/osprey/utils/config.py": "contrast with the exempt commands' contract",
 }
@@ -360,10 +358,10 @@ def test_the_runtime_injection_sites_still_read_the_config_env_vars(relative: st
 #: its profile in ``<name>-profile/`` and its build in ``build/<name>/``.
 _RETIRED_SPELLINGS = {
     "the deleted `deploy` group": re.compile(r"\bosprey deploy [a-z]"),
-    # The group name ALONE, with no verb after it. `osprey deploy` used to be a
-    # thing an operator typed, so prose that says "``osprey deploy`` chdirs
-    # first" reads as a live command and the verb-pair patterns above cannot see
-    # it — one such docstring survived the whole flip for exactly that reason.
+    # The group name ALONE, with no verb after it. `osprey deploy` reads as a
+    # thing an operator types, so prose that says "``osprey deploy`` chdirs
+    # first" looks like a live command while the verb-pair patterns above
+    # cannot see it — the exact gap a docstring can slip through.
     # `(?![- \w])` keeps it off the verb-pair form, which is already reported by
     # the entry above and would otherwise be counted twice.
     "the deleted `deploy` group (no verb)": re.compile(r"\bosprey deploy(?![-\s\w])"),
@@ -481,32 +479,17 @@ _RETIRED_SPELLING_ALLOWLIST: dict[tuple[str, str], str] = {
             '_SECRET_HEADER = "# Auto-generated web-terminal auth signing secrets (osprey deploy)"',
         )
     },
-    # The note explaining why the three above may not be touched. It has to
-    # quote the spelling it is protecting.
-    (
-        "src/osprey/deployment/reset.py",
-        "#: HISTORICAL spelling — including ``osprey deploy up``, a verb name that is on",
-    ): "documents why the banner headers keep the retired spelling",
     # Deliberate history: the sentence exists to contrast today's read-only
     # `osprey up` with what the retired verb did, so naming it is the point.
     (
         "src/osprey/deployment/container_lifecycle.py",
         "the legacy ``deploy up``. The locations come from the rendered config's own",
     ): "narrates the retired verb it replaced",
-    # Three more history sentences. Each names a dead verb in order to explain
-    # where a surviving behaviour came from, and each says so in the same
-    # breath — "retired", "Absorbed from the retired", "absorbed from". They are
-    # listed individually rather than matched by a keyword, because a rule that
-    # excused any line containing the word "retired" would be an escape hatch
-    # rather than an exemption.
-    (
-        "src/osprey/cli/build_cmd.py",
-        "The retired ``osprey claude regen`` copied these into ``_agent_data/backup/``",
-    ): "explains why the backup courtesy survives its verb",
-    (
-        "src/osprey/deployment/status_display.py",
-        "Absorbed from the retired ``osprey claude status``: the provider, the",
-    ): "names what this section was absorbed from",
+    # A history sentence, kept deliberately: it names a dead verb in order to
+    # explain where a surviving behaviour came from, and says so in the same
+    # breath. Listed individually rather than matched by a keyword, because a
+    # rule that excused any line containing the word "retired" would be an
+    # escape hatch rather than an exemption.
     (
         "src/osprey/cli/set_cmd.py",
         "#: CLI-only shorthand absorbed from ``osprey config set-epics-gateway",

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -155,10 +155,9 @@ class TestCliGroup:
     def test_cli_without_command_prints_help(self, runner):
         """Bare `osprey` lists what there is to run.
 
-        It used to launch an interactive menu, which existed because the legacy
-        verbs took arguments nobody could remember. Every surviving verb is
-        zero-argument, so the help IS the menu — and printing it must exit
-        cleanly rather than read as a usage error.
+        Every verb is zero-argument, so the help IS the menu rather than an
+        interactive launcher — and printing it must exit cleanly rather than
+        read as a usage error.
         """
         result = runner.invoke(cli, [])
 

--- a/tests/cli/test_manifest_build_args.py
+++ b/tests/cli/test_manifest_build_args.py
@@ -33,11 +33,11 @@ def test_resolved_selection_values_are_recorded():
 
 
 def test_explicit_overrides_field_is_retired():
-    """The marker is gone even when a caller still stamps the old context key.
+    """No marker is emitted even when a caller stamps the context key.
 
-    Nothing produces ``explicit_set_keys`` any more — an override is written
-    into the profile now, not carried beside the project — so a stray one must
-    not resurrect a field readers would act on.
+    Nothing produces ``explicit_set_keys`` — an override is written into the
+    profile, not carried beside the project — so a stray one must not
+    resurrect a field readers would act on.
     """
     args = _args(
         {

--- a/tests/cli/test_operating_bluesky_scans_skill_install.py
+++ b/tests/cli/test_operating_bluesky_scans_skill_install.py
@@ -15,15 +15,15 @@ The content assertions pin the draft-first run surface: the skill choreographs
 Two assertions here are safety pins rather than documentation checks, and
 both fail in the direction that matters:
 
-* ``test_no_stale_tool_names`` now includes ``launch_run``. That tool and its
-  route are gone; prose naming it would send the agent at a dead surface.
+* ``test_no_stale_tool_names`` includes ``launch_run``. Neither that tool nor
+  its route exists; prose naming it would send the agent at a dead surface.
 * ``TestOperatingBlueskyScansStopHonesty`` pins that the skill tells the truth
   about halting — that a plain ``queue_stop`` halts the queue only after the
   running item finishes, that ``stop_run`` aborts the plan already in motion,
   what that abort costs, and that a failed abort is never reported as a halt.
-  Its last test is the inverse pin: the pre-abort wording ("no OSPREY surface
-  does", "out-of-band") must not survive next to the tool that now works,
-  because that combination tells an agent not to reach for a working halt.
+  Its last test is the inverse pin: wording that denies any abort ("no OSPREY
+  surface does", "out-of-band") must not sit next to the tool that performs
+  one, because that combination tells an agent not to reach for a working halt.
 """
 
 import re
@@ -209,7 +209,7 @@ class TestOperatingBlueskyScansSkillStructure:
 class TestOperatingBlueskyScansStopHonesty:
     """Safety pins: the skill must describe each halt as exactly what it is.
 
-    There are now two, and they are not interchangeable. ``queue_stop`` halts
+    There are two, and they are not interchangeable. ``queue_stop`` halts
     the queue only AFTER the running item finishes; ``stop_run`` aborts the
     plan already moving hardware, via ``POST /queue/abort``. Prose that blurs
     them is read by whoever is deciding whether a queue-halt is enough, at the
@@ -229,7 +229,7 @@ class TestOperatingBlueskyScansStopHonesty:
         return path.read_text(encoding="utf-8")
 
     def test_stop_is_after_the_running_item(self, skill_text):
-        """``queue_stop``'s limit must still be stated, now that a tool exists
+        """``queue_stop``'s limit must be stated, because a tool exists
         which does not share it -- otherwise the two read as synonyms."""
         prose = _prose(skill_text)
         assert "queue_stop" in prose

--- a/tests/cli/test_panel_registration.py
+++ b/tests/cli/test_panel_registration.py
@@ -92,7 +92,7 @@ def test_injector_does_not_register_results_on_a_fresh_build(project_path: Path)
 
 
 def test_injector_does_not_register_plan_on_a_fresh_build(project_path: Path) -> None:
-    """Same rule for the PLAN panel, now the Plans tab of BLUESKY: registering
+    """Same rule for the PLAN panel, which is the Plans tab of BLUESKY: registering
     ``plan`` here would put two rail entries in front of the same panel, on
     every new project and on every rebuild."""
     _write_config(project_path)
@@ -174,7 +174,7 @@ def test_profile_listing_bluesky_validates_without_warning(tmp_path: Path) -> No
 def test_profile_listing_plan_warns_naming_the_merge_and_the_window(
     tmp_path: Path,
 ) -> None:
-    """Same contract for the PLAN panel, now the Plans tab of BLUESKY: the
+    """Same contract for the PLAN panel, which is the Plans tab of BLUESKY: the
     warning has to say what the id became and how long it keeps working."""
     profile = BuildProfile(
         name="legacy",

--- a/tests/cli/test_preset_hash_pin.py
+++ b/tests/cli/test_preset_hash_pin.py
@@ -25,88 +25,15 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     "channel-finder-standalone": (
         "sha256:9faa42d633aae7917429c3ec327c004672e68fa7617832d5ae245780fcb2a20f"
     ),
-    # The web-terminal presets were re-pinned when the shipped roster went
-    # from a bare-string first user to fully explicit name/index/persona
-    # entries — a resolved-content change (deploy-visible as staleness), made
-    # knowingly per the module docstring. The resolved *behavior* is identical.
-    #
-    # Re-pinned again when control-assistant's control_system.type default
-    # flipped from "mock" to "virtual_accelerator" (mock is now the documented
-    # fallback via `osprey set connector=mock`) — both extends
-    # children inherit the new default, so all three digests moved.
-    #
-    # Re-pinned again when the RESULTS panel became BLUESKY: the preset's
-    # web_panels entry and its web.panels.<id>.{label,url,path} overrides all
-    # moved from `results` to `bluesky`. Unlike the two re-pins above this one
-    # is NOT behavior-neutral — a rebuilt project gets a differently-named tab
-    # — so the staleness advisory firing on already-deployed projects is the
-    # correct signal, not noise. Both extends children inherit it, so all three
-    # digests moved again.
-    #
-    # Re-pinned again when control-assistant gained the test-ioc-safety rule
-    # selection (renders only for EPICS-family control systems). Both extends
-    # children inherit it, so all three digests moved.
-    #
-    # Re-pinned again when every preset that ships panels-context also gained
-    # the workspace-delta hook, which reports web workspace changes between the
-    # agent's turns. All four rosters list it, so every digest moved — a rebuilt
-    # project gains a hook file and a UserPromptSubmit wiring entry, which is
-    # exactly what the staleness advisory should report.
-    #
-    # Re-pinned again when control-assistant gained a stored archive: a
-    # `va_archiver:` block, `archiver.type: mongodb_archiver` in `config:`, and
-    # pymongo in `dependencies`. The block derives eight
-    # `archiver.mongodb_archiver.*` keys into the resolved config, so this is a
-    # key change rather than a comment change and the digest is expected to
-    # move. Both extends children inherit it, so all three moved.
-    # Re-pinned again when control-assistant named its freshness canary:
-    # `va_archiver.freshness_channel`. The block derives a
-    # `health.categories.archiver.checks` entry from it — the check itself plus
-    # a staleness threshold computed from `recorder_cadence_sec` — so this is a
-    # key change, not a comment change, and the digest is expected to move. A
-    # rebuilt project gains a health check it did not have, which is exactly
-    # what the staleness advisory should announce. Both extends children inherit
-    # it, so all three moved.
-    # ...and again when the block stated `recorder_cadence_sec: 10` explicitly
-    # instead of riding the dataclass default. Behavior-neutral — the resolved
-    # value is unchanged — but the resolved CONTENT now carries the key, so the
-    # digest moves. Stated rather than defaulted because the freshness threshold
-    # is derived from it, and the preset's own convention is to document the
-    # shape it deploys rather than hide it in a dataclass.
-    # The archive and the workspace-delta hook landed either side of the same
-    # rebase, so the digests below carry both at once: re-pinning against
-    # either change alone would leave the other unaccounted for.
-    # ...and again when the PLAN panel was folded into BLUESKY as its Plans
-    # tab: the preset's `plan` web_panels entry and its `web.panels.plan.*`
-    # overrides are gone. Like the RESULTS rename above, this is NOT
-    # behavior-neutral — a rebuilt project loses a tab and gains it back inside
-    # another — so staleness firing on already-deployed projects is the correct
-    # signal. The archive work and the panel merge landed either side of this
-    # merge, so as above the digests carry both at once. Both extends children
-    # inherit it, so all three moved.
-    #
-    # Re-pinned again for the lifecycle redesign. Comment rewrites cannot move
-    # this hash (`_hash_resolved_profile` hashes resolved canonical JSON and
-    # says so); the content change is the two persona `project_path` values,
-    # which moved from the retired sibling layout
-    # (`../control-assistant-<persona>`) into the render zone
-    # (`build/control-assistant-<persona>`). The digests below carry that AND
-    # every archive/panel change above at once — the redesign and the archiver
-    # work landed either side of one merge. Both extends children inherit it,
-    # so all three moved.
-    # Re-pinned again when the persona tiers were redesigned and setup-mode
-    # left the operator skills roster (it can patch config.yml/.mcp.json —
-    # admin work — and stays in the artifact catalog for admin profiles to opt
-    # into). The roster now maps alice→readwrite and bob→readonly (each with a
-    # `display_name` tab title), the base pins `web.theme: light`, both
-    # personas pin `web.ui_mode` (expert/simple), and the EVENTS/BLUESKY panel
-    # declarations — `config:` overrides AND `web_panels` entries — moved from
-    # the base into the readwrite persona so the readonly build is genuinely
-    # panel-free. NOT behavior-neutral: a rebuilt project loses a skill
-    # directory, a rebuilt readonly project loses two tabs and gains the
-    # simple surface, and the roster swaps which port is write-armed. The
-    # lifecycle redesign and this tier redesign landed either side of the same
-    # merge, so the digests below carry both at once.
+    # A digest here is the resolved content of the preset AND of every preset
+    # that extends it, so a change in a base moves all three control-assistant
+    # entries together. Comment rewrites cannot move a digest
+    # (`_hash_resolved_profile` hashes resolved canonical JSON and says so);
+    # only a key or value change can. Some such changes are behavior-neutral
+    # and some are not — a rebuilt project can gain or lose a tab, a hook, a
+    # health check or a skill directory — and in either case the deploy-side
+    # staleness advisory firing on already-deployed projects is the correct
+    # signal, not noise.
     "control-assistant": "sha256:6926cb0ac876d78035618a7fd2102b3bd7c32e409a4e89a1949ab84bc25ce172",
     "control-assistant-readonly": (
         "sha256:d4f91684bc48b28f51997a32c997d08cb56a108b4acdd9a0a09863472660415a"

--- a/tests/cli/test_profile_conventions.py
+++ b/tests/cli/test_profile_conventions.py
@@ -7,7 +7,7 @@ source validation, and the unknown-root-entry typo warning.
 The ``zone``-named group at the end pins the three-zone repo layout: the repo
 root is the profile root, so the layout's own directories must be recognized
 rather than warned about, and the warning's remedy must not send an operator
-looking for a nested ``profile/`` directory that no longer exists.
+looking for a nested ``profile/`` directory that does not exist.
 """
 
 from __future__ import annotations
@@ -654,8 +654,8 @@ def test_zone_layout_still_flags_a_genuinely_stray_entry(zone_repo: Path):
 
 
 def test_zone_remedy_does_not_instruct_nesting(zone_repo: Path, caplog: pytest.LogCaptureFixture):
-    """The inverse of the design: the old text told operators to move the
-    profile into a nested profile/ directory. Source lives at the repo root."""
+    """The remedy must not tell operators to nest the profile in a
+    profile/ directory. Source lives at the repo root."""
     (zone_repo / "ioc").mkdir()
     with caplog.at_level(logging.WARNING):
         warn_unknown_root_entries(zone_repo)
@@ -669,7 +669,7 @@ def test_zone_remedy_names_the_channel_to_move_an_entry_into(
     zone_repo: Path, caplog: pytest.LogCaptureFixture
 ):
     """An operator with material that *should* reach the deployment needs the
-    way in, now that nesting it away is not an answer."""
+    way in, since nesting it away is not an answer."""
     (zone_repo / "ioc").mkdir()
     with caplog.at_level(logging.WARNING):
         warn_unknown_root_entries(zone_repo)

--- a/tests/cli/test_profile_unknown_keys.py
+++ b/tests/cli/test_profile_unknown_keys.py
@@ -1,7 +1,7 @@
 """Tests for the unknown-key hard error and the profile-schema version floor.
 
 An unrecognized top-level key used to warn and be ignored, which shipped
-deployments quietly missing whatever the profile asked for. It is now rejected,
+deployments quietly missing whatever the profile asked for. It is rejected,
 naming every offender at once.
 """
 

--- a/tests/cli/test_profile_validate_deploy_block.py
+++ b/tests/cli/test_profile_validate_deploy_block.py
@@ -144,8 +144,8 @@ def test_gitlab_is_the_only_platform_with_a_template_today() -> None:
 
 
 def test_the_legacy_ci_mapping_shape_is_rejected() -> None:
-    """`ci:` used to be a mapping of pipeline coordinates. It is now the
-    platform name: everything else comes from the CI environment at run time."""
+    """`ci:` names the platform, not a mapping of pipeline coordinates:
+    everything else comes from the CI environment at run time."""
     message = _refusal(_deploy(ci={"provider": "gitlab", "project_id": 951}))
 
     assert "names the platform as a string" in message
@@ -153,8 +153,8 @@ def test_the_legacy_ci_mapping_shape_is_rejected() -> None:
 
 
 def test_the_removed_gitlab_block_is_rejected_by_name() -> None:
-    """The rule the old facility-config normalizer carried, ported here: a
-    `gitlab:` block names the platform through `ci:` instead."""
+    """A `gitlab:` block is not a deploy key: the platform is named
+    through `ci:` instead."""
     message = _refusal(_deploy(gitlab={"host": "git.example.org", "project_id": 951}))
 
     assert "'gitlab' is not a deploy key" in message

--- a/tests/cli/test_provider_isolation.py
+++ b/tests/cli/test_provider_isolation.py
@@ -350,7 +350,7 @@ class TestManagedListsAgree:
         )
 
 
-# ── inject_provider_env .env branch (previously blind) ───────────
+# ── inject_provider_env .env branch ──────────────────────────────
 
 
 class TestInjectDotenvPassthrough:

--- a/tests/cli/test_provider_models_required.py
+++ b/tests/cli/test_provider_models_required.py
@@ -1,15 +1,15 @@
 """A provider that maps no models is refused, not filled with Anthropic's IDs.
 
-``resolve()`` used to ``setdefault`` every unmapped tier to the built-in
-Anthropic direct model IDs so the env block could always be built. The cost was
-a silent lie: selecting a provider that ships no ``models`` map launched the
-agent asking *that* provider for ``claude-opus-4-6`` — a 404 from a strict
-proxy, and a silently different model from a permissive one.
+``setdefault``-ing every unmapped tier to the built-in Anthropic direct model
+IDs, so the env block can always be built, costs a silent lie: selecting a
+provider that ships no ``models`` map would launch the agent asking *that*
+provider for ``claude-opus-4-6`` — a 404 from a strict proxy, and a silently
+different model from a permissive one.
 
-The map is now required. This module pins both halves of that contract: the
+The map is required. This module pins both halves of that contract: the
 refusal is actionable (it names ``api.providers.<name>.models``, the tiers, and
 the shape to write), and every provider stanza the shipped templates offer
-carries a real map, so the new error can never fire on a config OSPREY itself
+carries a real map, so the refusal can never fire on a config OSPREY itself
 generated.
 """
 
@@ -146,7 +146,7 @@ class TestMapLessProviderIsRefused:
 
 
 class TestShippedTemplatesCarryRealMaps:
-    """No shipped provider stanza can trip the new error."""
+    """No shipped provider stanza can trip the refusal."""
 
     @pytest.mark.parametrize("relative_path", SHIPPED_TEMPLATES)
     def test_every_provider_maps_all_tiers(self, relative_path):

--- a/tests/cli/test_regen_bundle_safety.py
+++ b/tests/cli/test_regen_bundle_safety.py
@@ -3,8 +3,7 @@
 The unit under test is ``TemplateManager.regenerate_claude_code``, the
 re-render step ``osprey build`` runs (``build_cmd.py``); it is addressed
 directly here rather than through the verb, so the guard survives the verb
-being renamed. It used to be reachable as its own command, and "regen" below
-is the name of that step, not of a CLI verb.
+being renamed. "regen" below is the name of that step, not of a CLI verb.
 
 The facility knowledge bundle lives at a path declared by
 ``facility_knowledge.bundle_path`` in config.yml (resolved relative to the

--- a/tests/cli/test_scaffold_ci.py
+++ b/tests/cli/test_scaffold_ci.py
@@ -704,7 +704,7 @@ def test_list_reads_the_build_zone_of_the_repo_it_is_standing_in(
 def test_a_claim_moves_the_artifact_from_the_build_zone_into_the_source_zone(
     runner: CliRunner, built_repo: Path
 ) -> None:
-    """The move this verb exists for, in the layout it now runs in.
+    """The move this verb exists for, in the layout it runs in.
 
     The build zone is disposable — the next build replaces it wholesale — so an
     artifact an operator wants to keep has to leave it. It lands beside the

--- a/tests/cli/test_service_template_ownership.py
+++ b/tests/cli/test_service_template_ownership.py
@@ -346,14 +346,14 @@ class TestScaffoldCliDirectoryArtifacts:
         assert "scaffold" not in config
 
     def test_claim_of_a_catalog_only_service_refuses(self, tmp_path: Path):
-        """Claim no longer materializes a packaged template — it moves what exists.
+        """Claim moves what exists; it does not materialize a packaged template.
 
         ``services/openobserve`` is a real catalog artifact with a packaged
-        template, so the old claim would have copied it into the project and
-        marked it owned. That affordance was removed on purpose: under the
-        profile model an artifact the project does not have is authored in the
-        profile, and a claim that invented one would put a second copy of the
-        framework's template somewhere nothing reconciles.
+        template, so a claim that materialized it would copy it into the
+        project and mark it owned. That affordance is deliberately absent:
+        under the profile model an artifact the project does not have is
+        authored in the profile, and a claim that invented one would put a
+        second copy of the framework's template somewhere nothing reconciles.
         """
         from osprey.cli.scaffold_cmd import claim
 

--- a/tests/cli/test_set_verb.py
+++ b/tests/cli/test_set_verb.py
@@ -197,11 +197,11 @@ def test_build_config_is_never_touched(runner, lifecycle_repo):
     assert rendered.read_text(encoding="utf-8") == "control_system:\n  type: mock\n"
 
 
-# --- absorbed shorthands ----------------------------------------------------
+# --- shorthand keys ---------------------------------------------------------
 
 
 def test_connector_shorthand_writes_the_control_system_key(runner, lifecycle_repo):
-    """Absorbs `config set-control-system` — into the PROFILE, not the render."""
+    """`connector=` writes the control-system key into the PROFILE, not the render."""
     result = _invoke(runner, lifecycle_repo, "connector=virtual_accelerator")
 
     assert result.exit_code == 0, result.output
@@ -221,7 +221,7 @@ def test_unknown_connector_is_refused_and_writes_nothing(runner, lifecycle_repo)
 
 
 def test_epics_gateway_shorthand_writes_the_facility_addresses(runner, lifecycle_repo):
-    """Absorbs `config set-epics-gateway --facility als`."""
+    """`epics_gateway=als` expands to the facility's gateway addresses."""
     result = _invoke(runner, lifecycle_repo, "epics_gateway=als")
 
     assert result.exit_code == 0, result.output
@@ -406,13 +406,12 @@ def test_registered_on_the_top_level_cli():
         assert "set" in cli.list_commands(ctx)
 
 
-# --- the honesty rule, at the verbs that own it now --------------------------
+# --- the honesty rule, at the verbs that own it ------------------------------
 #
-# `osprey config set-control-system` used to refuse a virtual accelerator
-# paired with the mock archiver at WRITE time. The write verb is now
-# `osprey set`, which is deliberately unguarded — profile.yml is a document,
-# and the build is where a profile's claims are judged — so the truth table
-# moved with the refusal: set the pairing, and the next `osprey build`
+# The write verb is `osprey set`, which is deliberately unguarded — profile.yml
+# is a document, and the build is where a profile's claims are judged — so a
+# virtual accelerator paired with the mock archiver is refused at BUILD time,
+# not at write time: set the pairing, and the next `osprey build`
 # refuses it. The pure predicate is pinned in
 # tests/connectors/test_honesty_rule.py; what this class pins is the two-verb
 # OPERATOR path — an `osprey set` that walks into the pairing is caught by the

--- a/tests/cli/test_sim_cmd.py
+++ b/tests/cli/test_sim_cmd.py
@@ -30,7 +30,7 @@ def deployment(lifecycle_repo: Path) -> Path:
 
     ``sim`` resolves its deployment before it parses anything, so the anchor
     passthrough under test is only reachable from inside a real repo — a bare
-    directory with a ``config.yml`` in it is no longer a deployment.
+    directory with a ``config.yml`` in it is not a deployment.
     """
     stub_build(lifecycle_repo)
     return lifecycle_repo

--- a/tests/cli/test_skills_cmd.py
+++ b/tests/cli/test_skills_cmd.py
@@ -103,12 +103,12 @@ def test_install_design_philosophy_skill(fake_home: Path) -> None:
 
 
 def test_no_bundled_skill_survives_the_retired_deploy_surface() -> None:
-    """The operate-time runbook was retired with the verbs it described.
+    """No bundled skill may be an operate-time runbook of retired verbs.
 
     Asserted as an absence rather than left out, because the failure it guards
-    is a re-add: a skill shipped again from a branch written against
+    is a re-add: a skill shipped from a branch written against
     ``osprey deploy`` would install cleanly and instruct its reader to run
-    commands the CLI no longer has.
+    commands the CLI does not have.
     """
     from importlib.resources import files
 

--- a/tests/cli/test_source_zone_materialization.py
+++ b/tests/cli/test_source_zone_materialization.py
@@ -311,7 +311,7 @@ def test_only_keys_of_referenced_providers_are_seeded(
     runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, no_provider_keys: None
 ) -> None:
     """The keys of the providers this profile names, and nothing else — the
-    profile is now where a facility's secrets live, so what lands there must be
+    profile is where a facility's secrets live, so what lands there must be
     predictable, and importing a whole shell keyring is more than it needs."""
     from osprey.utils.dotenv import parse_dotenv_file
 

--- a/tests/cli/test_telemetry_grpc_failloud.py
+++ b/tests/cli/test_telemetry_grpc_failloud.py
@@ -95,7 +95,7 @@ def test_openobserve_backend_grpc_with_explicit_endpoint_still_works():
 
 
 def test_derived_openobserve_endpoint_unaffected_for_http():
-    """The shipped default configuration keeps resolving exactly as before."""
+    """The shipped default configuration resolves the http/protobuf endpoint."""
     env = _build_telemetry_env(_openobserve_cfg(protocol="http/protobuf"), in_container=False)
     assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:5080/api/als"
     assert env["OTEL_EXPORTER_OTLP_PROTOCOL"] == "http/protobuf"

--- a/tests/cli/test_templates.py
+++ b/tests/cli/test_templates.py
@@ -436,9 +436,9 @@ def test_get_framework_version_unknown_on_import_failure(monkeypatch):
 
 
 def test_registry_style_parameter_is_gone():
-    """C1 regression guard: removing the 'standalone' branch must remove the
-    parameter from every entry point that no longer needs it. Catches anyone
-    re-adding it without a real CLI flag."""
+    """C1 regression guard: no entry point may carry the 'standalone' branch's
+    registry-style parameter. Catches anyone re-adding it without a real CLI
+    flag."""
     import inspect
 
     from osprey.cli.templates.manager import TemplateManager
@@ -497,7 +497,7 @@ class TestBuiltinPanelRegistryDrift:
     @pytest.mark.parametrize("template_path", PANEL_TEMPLATES)
     def test_fallback_literal_excludes_okf_when_registry_absent(self, template_path):
         """Safety-net fallback: without ``builtin_panels`` in context the template
-        reverts to the old literal, which excludes ``okf``. Proves the fix is the
+        falls back to its inline literal, which excludes ``okf``. Proves the fix is the
         registry injection — okf is enabled only because the registry supplies it,
         not by accident of an expanded literal."""
         import yaml
@@ -507,12 +507,12 @@ class TestBuiltinPanelRegistryDrift:
         rendered = template.render(selected_web_panels=["okf", "channel-finder"])
         panels = yaml.safe_load(rendered)["web"]["panels"]
 
-        assert "okf" not in panels  # old literal omits okf
+        assert "okf" not in panels  # fallback literal omits okf
         assert panels.get("channel-finder", {}).get("enabled") is True
 
     def test_create_project_enables_okf_builtin_panel(self, tmp_path):
         """End-to-end: ``manager.py`` injects ``sorted(BUILTIN_PANELS)`` → template
-        enables ``okf``. Fails against the old hardcoded literal (which omitted
+        enables ``okf``. Fails against the hardcoded fallback literal (which omits
         okf) and passes with the registry-derived context. This removes the need
         for the ``web.panels.okf.enabled: true`` override BELLA/ALS carried."""
         import yaml

--- a/tests/cli/test_users_group.py
+++ b/tests/cli/test_users_group.py
@@ -1,14 +1,13 @@
 """Tests for the ``osprey users`` web-terminal roster group.
 
-The group is a relocation, not a redesign: the same engines in
-``osprey.deployment.web_terminals`` do the work, called with the same
-signatures. What changed is how the config reaches them — the verbs no longer
-take ``--project``/``--config``, they walk up to the enclosing deployment repo
-and act through its rendered ``build/config.yml``.
+The group is a thin CLI over ``osprey.deployment.web_terminals``: those engines
+do the work, called with their own signatures. The verbs take no
+``--project``/``--config`` — they walk up to the enclosing deployment repo and
+act through its rendered ``build/config.yml``.
 
 So these tests pin two things. First the seam: which file each verb hands the
 engine, what the engine is handed alongside it, and which directory it runs in.
-Second the gates the relocation must not have loosened — the typed
+Second the gates the CLI must not loosen — the typed
 confirmations guarding volume destruction are exercised through the CLI against
 the real lifecycle engine, with the container runtime mocked (no container or
 volume is ever created or removed here).
@@ -202,7 +201,7 @@ def _roster(repo_root: Path) -> list:
 
 
 class TestCommandSurface:
-    """What the group offers, and what it deliberately no longer accepts."""
+    """What the group offers, and what it deliberately does not accept."""
 
     def test_group_help_lists_every_verb(self, cli_runner):
         result = cli_runner.invoke(users, ["--help"])
@@ -228,7 +227,7 @@ class TestCommandSurface:
     @pytest.mark.parametrize("verb", sorted(VERB_OPTIONS))
     @pytest.mark.parametrize("retired", ["--project", "-p", "--config", "-c"])
     def test_retired_location_flags_are_rejected(self, cli_runner, tmp_path, verb, retired):
-        """Discovery is the repo walk; the old location flags are gone."""
+        """Discovery is the repo walk; there are no location flags."""
         argv = [verb, retired, str(tmp_path)]
         if verb in ("remove", "passwd"):
             argv.insert(1, "alice")
@@ -459,9 +458,9 @@ class TestPasswd:
 
 
 class TestTypedGates:
-    """The confirmations guarding destruction survive the relocation verbatim.
+    """The confirmations guarding destruction are pinned verbatim.
 
-    These run the real ``lifecycle`` engine through the new CLI with the
+    These run the real ``lifecycle`` engine through the CLI with the
     container runtime mocked, so what is pinned is the gate an operator
     actually meets: the exact word it demands, and that anything else is a
     true no-op.

--- a/tests/cli/test_web_bind.py
+++ b/tests/cli/test_web_bind.py
@@ -2,8 +2,8 @@
 
 Per the multi-user compose (`docker-compose.web.yml.j2`), every per-user
 container declares `OSPREY_TERMINAL_BIND_HOST=127.0.0.1` so nginx is the
-ONLY off-host path (criterion C3). Nothing previously read that env var, and
-a legacy image CMD passing `--host 0.0.0.0` would silently punch through the
+ONLY off-host path (criterion C3). Without a reader for that env var, a stale
+image CMD passing `--host 0.0.0.0` would silently punch through the
 reverse-proxy chokepoint. `resolve_bind_host()` makes the declared env
 authoritative over both `--host` and config, while leaving single-user
 `osprey web` (no declared env) free to honor `--host 0.0.0.0` verbatim.
@@ -63,8 +63,8 @@ def _inside_a_deployment(lifecycle_repo, monkeypatch):
 
     The env var is deliberately NOT how this is arranged: `OSPREY_CONFIG` is a
     publication `web` makes for its children, not a way of telling it where to
-    look, and a test that set it would be pinning a contract that no longer
-    exists.
+    look, and a test that set it would be pinning a contract that does not
+    exist.
     """
     stub_build(lifecycle_repo, config="web: {}\n")
     monkeypatch.chdir(lifecycle_repo)
@@ -177,7 +177,7 @@ class TestWebCommandHonorsDeclaredBindEnv:
 
     def test_single_user_no_env_keeps_0000(self, runner, monkeypatch):
         """Without the declared env (single-user `osprey web`), --host 0.0.0.0
-        must still work exactly as before."""
+        must still be honored verbatim."""
         monkeypatch.delenv(DECLARED_BIND_ENV, raising=False)
         captured = {}
 
@@ -326,7 +326,7 @@ class TestWebCommandHonorsDeclaredWebPortEnv:
 
     def test_single_user_no_env_keeps_explicit_port(self, runner, monkeypatch):
         """Without the declared env (single-user `osprey web`), --port must
-        still work exactly as before."""
+        still be honored verbatim."""
         monkeypatch.delenv(DECLARED_WEB_PORT_ENV, raising=False)
         captured = {}
 

--- a/tests/cli/test_web_cmd.py
+++ b/tests/cli/test_web_cmd.py
@@ -304,7 +304,7 @@ class TestDeploymentResolution:
         runner,
         deployment,
     ):
-        """Both, because they are now different directories.
+        """Both, because they are different directories.
 
         An operator reading only "build/…" could not tell which deployment they
         are in; reading only the repo could not tell whether the render is the
@@ -1061,9 +1061,9 @@ class TestDetachSkipsPreflightInChild:
 # from the resolved repo: web_cmd's pre-lifespan `.env` load and the lifespan's
 # `app.state.config_path` (which gates provider env injection).
 #
-# The split makes this sharper than it was: the `.env` is at the repo root and
-# the config is in the render, so a launch that gets only one of them right is
-# now a visible failure rather than a coincidence.
+# The split makes this sharp: the `.env` is at the repo root and the config is
+# in the render, so a launch that gets only one of them right is a visible
+# failure rather than a coincidence.
 
 
 @pytest.fixture

--- a/tests/connectors/test_connector_factory.py
+++ b/tests/connectors/test_connector_factory.py
@@ -186,9 +186,9 @@ class TestBuiltinArchiverRegistration:
     """``register_builtin_connectors()`` heals a partially-populated registry.
 
     The function short-circuits when every name in ``_BUILTIN_ARCHIVERS`` is
-    already registered. ``mongodb_archiver`` used to be appended outside that
-    tuple, so a registry holding the other archivers satisfied the early return
-    and the MongoDB entry was never added — leaving a project configured for
+    already registered. An archiver appended outside that tuple is invisible to
+    the check: a registry holding the other archivers satisfies the early return
+    and the missing entry is never added — leaving a project configured for
     ``mongodb_archiver`` unable to build its connector at all. These pin the
     tuple as the complete list.
     """

--- a/tests/connectors/test_doocs_archiver_connector.py
+++ b/tests/connectors/test_doocs_archiver_connector.py
@@ -280,7 +280,7 @@ class TestReadHistory:
 
         Regression: the removed ``max_points`` branch zero-order-held real
         samples onto an ``np.linspace`` grid of manufactured timestamps;
-        asking for it is now a TypeError.
+        asking for it is a TypeError.
         """
         chunk = _make_raw_chunk(n=100)
         mock_d4py = MagicMock()
@@ -861,8 +861,8 @@ class TestProcessingGenuineAggregation:
         """A 10 Hz and a 0.1 Hz channel queried together must each be aggregated
         over only their own samples.
 
-        Regression: the old shared grid floored the bin width at the sparsest
-        channel's cadence and forward-filled the dense channel onto it.
+        Regression: a shared grid would floor the bin width at the sparsest
+        channel's cadence and forward-fill the dense channel onto it.
         """
         fast_chunk = self._dense_chunk(n_bins=10, samples_per_bin=10)  # 10 Hz, 10 s
         slow_chunk = [(_START_TS + 5.0, 0, 0, 500.0)]  # 0.1 Hz: one real sample

--- a/tests/connectors/test_mock_archiver_simfile_fallback.py
+++ b/tests/connectors/test_mock_archiver_simfile_fallback.py
@@ -7,19 +7,19 @@ scenario change had to be made twice, and a project that updated only one of
 them got archived history that contradicted live reads with nothing said about
 it.
 
-So ``archiver.mock_archiver.simulation_file`` is now optional: unset, it is
+So ``archiver.mock_archiver.simulation_file`` is optional: unset, it is
 resolved from the control-system side through the same
 :func:`osprey.simulation.apply.resolve_simulation_file` the ``sim`` CLI uses
 (type-aware, so a virtual-accelerator project resolves its own key). An explicit
 archiver-side value still wins — pointing the archiver at a different model is
 legitimate — but the divergence is logged at WARNING.
 
-Both directions are covered here, plus the template that no longer ships the
-third copy of the path.
+Both directions are covered here, plus the template, which ships no third copy
+of the path.
 
 A note on the virtual-accelerator cases below, which would otherwise read as
 contradicting the honesty rule: pairing a ``virtual_accelerator`` control system
-with the mock archiver is now refused at build, at deploy and at MCP startup
+with the mock archiver is refused at build, at deploy and at MCP startup
 (see :mod:`osprey.connectors.honesty`), so no deployment can reach that
 configuration. These tests still exercise it, and legitimately — they construct
 the connector directly, below the level where any of those three refusals live,
@@ -283,7 +283,7 @@ class TestExplicitArchiverValueWins:
 
     @pytest.mark.asyncio
     async def test_matching_values_do_not_warn(self, project, caplog):
-        """A project that still declares the old duplicate is honoured silently."""
+        """A project that declares the duplicate, matching, is honoured silently."""
         project(
             control_system={
                 "type": "mock",
@@ -306,7 +306,7 @@ class TestExplicitArchiverValueWins:
 
 
 class TestTemplateDropsTheDuplicate:
-    def test_archiver_block_no_longer_declares_a_simulation_file(self):
+    def test_archiver_block_declares_no_simulation_file(self):
         archiver_section = TEMPLATE.read_text().split("\narchiver:\n", 1)[1]
 
         live_keys = [

--- a/tests/connectors/test_mongodb_archiver_connector.py
+++ b/tests/connectors/test_mongodb_archiver_connector.py
@@ -602,7 +602,7 @@ class TestQueryShapeWithoutDocker:
             {"BEAM:CURRENT": {"$exists": True}},
             {"BEAM:LIFETIME": {"$exists": True}},
         ]
-        # The old shape ANDed a top-level key per PV; it must be gone.
+        # ANDing a top-level key per PV is wrong; none may appear.
         assert "BEAM:CURRENT" not in captured["query"]
 
     @pytest.mark.asyncio

--- a/tests/connectors/test_va_gateway_port_fill.py
+++ b/tests/connectors/test_va_gateway_port_fill.py
@@ -1,17 +1,17 @@
 """The VA connector's gateway port is derived from the VA service it talks to.
 
-``control_system.connector.virtual_accelerator.gateways.*.port`` used to be
-rendered as a hardcoded ``5064`` while the deployed soft-IOC's port came from
-``services.virtual_accelerator.port`` — the same fact in two places, with no
-validation between them.  The preset documented the trap instead of fixing it
-("MUST stay 5064 ... changing this here would desync the connector from the
-deployed container").
+Rendering ``control_system.connector.virtual_accelerator.gateways.*.port`` as a
+hardcoded ``5064`` while the deployed soft-IOC's port comes from
+``services.virtual_accelerator.port`` would state the same fact in two places,
+with no validation between them — and documenting the trap ("MUST stay 5064 ...
+changing this here would desync the connector from the deployed container") is
+not a fix.
 
-The template no longer writes the port out: with it unset the connector
-default-fills from ``services.virtual_accelerator.port`` at config-load time,
-so moving the deployed VA's port moves the connector with it.  An explicit
-gateway ``port`` still wins verbatim — that is how a project reaches a VA it
-does not deploy — which is also what keeps legacy rendered configs working.
+The template leaves the port out: with it unset the connector default-fills
+from ``services.virtual_accelerator.port`` at config-load time, so moving the
+deployed VA's port moves the connector with it.  An explicit gateway ``port``
+still wins verbatim — that is how a project reaches a VA it does not deploy,
+and what keeps a legacy rendered config that carries the key working.
 """
 
 from __future__ import annotations
@@ -118,8 +118,8 @@ def test_template_keeps_a_commented_port_override_example() -> None:
 
 
 @pytest.mark.unit
-def test_preset_no_longer_warns_the_port_must_not_change() -> None:
-    """The warning documented a hardcode that no longer exists."""
+def test_preset_does_not_warn_the_port_must_not_change() -> None:
+    """The preset must not warn about a hardcode it does not have."""
     preset_path = Path(osprey.__file__).parent / PRESET_PATH
     text = preset_path.read_text(encoding="utf-8")
     preset = yaml.safe_load(text)
@@ -179,7 +179,7 @@ def test_defaults_to_5064_when_the_service_port_is_unset(deployed_va_port) -> No
 
 @pytest.mark.unit
 def test_unreadable_config_falls_back_to_5064(monkeypatch) -> None:
-    """Outside a project context the connector behaves as it did when hardcoded."""
+    """Outside a project context the connector falls back to the default port."""
     from osprey.utils import config as config_module
 
     def exploding_get_config_value(path: str, default: Any = None, config_path: str = None):

--- a/tests/connectors/test_writes_enabled.py
+++ b/tests/connectors/test_writes_enabled.py
@@ -229,8 +229,8 @@ class TestMockWritesDisabledViaBaseClass:
             result = await connector.write_channel("TEST:PV", 1.0)
         assert result.success is True
 
-    def test_mock_no_longer_has_enable_writes_attr(self):
-        """MockConnector should no longer have _enable_writes after cleanup."""
+    def test_mock_has_no_enable_writes_attr(self):
+        """MockConnector must not carry an _enable_writes attribute."""
         from osprey.connectors.control_system.mock_connector import MockConnector
 
         connector = MockConnector()

--- a/tests/deployment/goldens/exemplar-profile/personas/readonly.yml
+++ b/tests/deployment/goldens/exemplar-profile/personas/readonly.yml
@@ -1,6 +1,6 @@
 # Profile (readonly) — persona profile, a delta over ../profile.yml
 #
-# Sitting in personas/ beside profile.yml IS the inheritance: the
+# Sitting in personas/ beside profile.yml is the inheritance: the
 # build merges this file over that profile — including any edit you
 # make there — so the keys below are this persona's only differences
 # and there is no `extends:` to write. See the resolved whole with:

--- a/tests/deployment/goldens/exemplar-profile/personas/readwrite.yml
+++ b/tests/deployment/goldens/exemplar-profile/personas/readwrite.yml
@@ -1,6 +1,6 @@
 # Profile (readwrite) — persona profile, a delta over ../profile.yml
 #
-# Sitting in personas/ beside profile.yml IS the inheritance: the
+# Sitting in personas/ beside profile.yml is the inheritance: the
 # build merges this file over that profile — including any edit you
 # make there — so the keys below are this persona's only differences
 # and there is no `extends:` to write. See the resolved whole with:

--- a/tests/deployment/goldens/exemplar-profile/profile.yml
+++ b/tests/deployment/goldens/exemplar-profile/profile.yml
@@ -1,6 +1,6 @@
 # Demo Facility — OSPREY deployment repo
 #
-# This repository IS the deployment. One directory, four zones:
+# The repository is the deployment. One directory, four zones:
 #
 #   SOURCE   tracked, yours to edit — profile.yml, data/, personas/,
 #            triggers.yml, web-terminal-context/, scripts/, the CI files

--- a/tests/deployment/test_build_deploy_templates.py
+++ b/tests/deployment/test_build_deploy_templates.py
@@ -1,16 +1,16 @@
 """Multi-user persona parity, held across the deploy split.
 
 A facility with a persona catalog needs one web-terminal image per persona.
-That used to be a pipeline concern: the CI template carried a per-persona
-`osprey build` render and a per-persona `build-web-terminal-<persona>` job, and
-the guards on it were string assertions against the shipped template text.
+Building them in the pipeline would put a per-persona `osprey build` render and
+a per-persona `build-web-terminal-<persona>` job in the CI template, guarded
+only by string assertions against the shipped template text.
 
-The pipeline no longer builds web-terminal images at all — the deploy host
-does, from the persona catalog, when `osprey up` runs. This module holds
-both halves of that relocation to the exemplar profile, which declares two
-personas: the rendered pipeline must build no web-terminal image, and every
-referenced persona must still come out as its own host-side build unit. Losing
-either half loses multi-user support without any test going red.
+The pipeline builds no web-terminal images at all — the deploy host does, from
+the persona catalog, when `osprey up` runs. This module holds both halves of
+that split against the exemplar profile, which declares two personas: the
+rendered pipeline must build no web-terminal image, and every referenced
+persona must still come out as its own host-side build unit. Losing either
+half loses multi-user support without any test going red.
 
 The builder's own behavior (build args, dev wheels, the render check) is covered in
 ``tests/deployment/web_terminals/test_persona_images.py``; what is tested here

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -951,8 +951,8 @@ def _gating_e2e_jobs(wf: dict[str, Any]) -> list[str]:
 
 
 def test_all_checks_passed_needs_promoted_and_new_lanes(workflow: dict[str, Any]) -> None:
-    """The two extracted lanes AND the two previously-advisory bluesky lanes
-    must all gate the merge. Deliberately `all`, not `any` — the same
+    """The two extracted lanes AND the two bluesky lanes must all gate the
+    merge. Deliberately `all`, not `any` — the same
     silent-partial-fix guard shape as ``_needs_contains_both_new_jobs``."""
     assert _gating_e2e_jobs(workflow) == [ORM_JOB, OVERLAY_JOB, CATALOG_JOB, SANDBOX_JOB]
 
@@ -1912,7 +1912,7 @@ def test_all_checks_passed_needs_scan_agentic(workflow: dict[str, Any]) -> None:
     Same drop-together/re-land-together discipline as the queue lane: if
     ``scan-agentic-e2e`` cannot go green in the PR, the job, its gate entry AND
     this guard pair leave as a unit and come back as a unit. Splitting them
-    either wedges the merge gate on a job that no longer exists or leaves the
+    either wedges the merge gate on a job that does not exist or leaves the
     lane running unwatched."""
     assert SCAN_AGENTIC_JOB in _jobs(workflow)[GATE_JOB]["needs"]
     assert f"needs.{SCAN_AGENTIC_JOB}.result" in _gate_run_text(workflow)

--- a/tests/deployment/test_compose_generator.py
+++ b/tests/deployment/test_compose_generator.py
@@ -116,7 +116,7 @@ def test_copy_service_templates_root_always_present_with_valid_pkg_services(
 # ``compose up`` outright.
 # ---------------------------------------------------------------------------
 
-# The worker container now runs the full PROJECT image, whose layout bakes the
+# The worker container runs the full PROJECT image, whose layout bakes the
 # project at /app/<project> (Dockerfile ``COPY . /app/{{ project_name }}/``). The
 # compose paths must track that same <project> name — resolved by the generator's
 # ``_inject_project_metadata`` into ``osprey_labels.project_name`` (and the
@@ -366,7 +366,7 @@ def test_worker_template_declares_openobserve_host() -> None:
 # ---------------------------------------------------------------------------
 # Task 1.3: the worker container layout must match the PROJECT image
 #
-# The worker now runs ``<project>:local`` (the project image built by
+# The worker runs ``<project>:local`` (the project image built by
 # ``osprey up``), which bakes the project at ``/app/<project>``
 # (Dockerfile ``COPY . /app/{{ project_name }}/``, ``WORKDIR /app/<project>``,
 # ``chown -R osprey:osprey /app/<project>``). Every worker path — OSPREY_PROJECT_DIR,
@@ -1118,11 +1118,11 @@ def test_missing_python_env_path_falls_back_to_sys_executable() -> None:
 
 
 def test_host_python_env_path_cannot_bake_host_interpreter_into_mcp_command() -> None:
-    """Companion to the above: the M2 failure mode is now unreachable by design.
+    """Companion to the above: the M2 failure mode is unreachable by design.
 
-    A host-looking ``python_env_path`` that survived staging used to be baked
-    into every MCP server's ``command``. The generator no longer reads the key,
-    so even a config that still carries it — exactly what an already-deployed
+    Baking a host-looking ``python_env_path`` that survived staging into every
+    MCP server's ``command`` is the failure mode. The generator does not read
+    the key, so even a config that carries it — exactly what an already-deployed
     project looks like — yields the container's own interpreter. This is what
     lets ``setup_build_dir`` stage the config untouched: nothing stands between
     the host path and a broken container because nothing consumes the path.
@@ -2090,7 +2090,7 @@ def test_resolve_project_name_project_root_trailing_separator_normalized() -> No
 # (osprey-dispatch:local, osprey-va:local, ...). Service `:local` tags are
 # HOST-GLOBAL docker identifiers, so two OSPREY projects building the same
 # service on one host raced to tag ONE image — a sibling clean/rebuild could
-# delete or replace it mid-deploy. The defaults are now project-prefixed
+# delete or replace it mid-deploy. The defaults are project-prefixed
 # (`<project>-dispatch:local`, ...); the `${OSPREY_*_IMAGE:-...}` env override
 # wrappers are unchanged. The build args additionally carry
 # OSPREY_PROJECT_NAME (always) and OSPREY_DEV=1 (iff `osprey up --dev`,
@@ -2482,7 +2482,7 @@ def test_failed_wheel_staging_aborts_the_deploy(
     Rendering *without* OSPREY_DEV would keep the pinned install (fail-closed on
     the build arg) but still deploy successfully — containers up on released
     osprey under a flag that promises local code. The build-arg gate stays; the
-    deploy no longer reaches it.
+    deploy does not reach it.
     """
     from osprey.deployment import compose_generator
     from osprey.deployment.errors import DevModeUnavailableError

--- a/tests/deployment/test_container_lifecycle.py
+++ b/tests/deployment/test_container_lifecycle.py
@@ -53,7 +53,7 @@ def _addresses(cmd: list[str], compose_filename: str) -> bool:
     """True when this argv's ``-f`` list names *compose_filename*.
 
     The pinned invocation contract spells every ``-f`` as a repo-anchored
-    absolute path, so the old ``filename in cmd`` membership no longer holds.
+    absolute path, so a plain ``filename in cmd`` membership does not hold.
     Matched on the trailing path segment, which keeps ``docker-compose.yml``
     from matching ``docker-compose.web.yml``.
     """

--- a/tests/deployment/test_deploy_scaffold_goldens.py
+++ b/tests/deployment/test_deploy_scaffold_goldens.py
@@ -6,24 +6,21 @@ declares a service with a Dockerfile, and therefore exercises the images stage
 and the registry credential that the exemplar's ``image_source: local`` never
 reaches.
 
-The byte specification moved. It used to live beside this file as
-``goldens/gitlab-ci.yml`` and ``goldens/verify.sh``, hand-built for the retired
-``profile/`` layout; it is now the three-zone exemplar in
-``tests/fixtures/lifecycle_repo.py``, and ``tests/cli/test_emitted_artifacts_clean.py``
-holds the templates to it byte for byte. Keeping two hand-built reference
-deployments meant keeping two specifications, which is one more than a
-specification can be.
+The byte specification lives elsewhere: the three-zone exemplar in
+``tests/fixtures/lifecycle_repo.py``, which
+``tests/cli/test_emitted_artifacts_clean.py`` holds the templates to byte for
+byte. A second, hand-built reference deployment beside this file would mean
+keeping two specifications, which is one more than a specification can be.
 
 So what is asserted here is behaviour rather than bytes: the branches a
 registry turns on, and the security properties that hold whatever the profile
-says. The security half is the surviving part of the old ``.gitlab-ci.yml``
-template tests. The legacy pipeline assembled ``.env.production`` itself, from a
-heredoc of masked CI variables, and those tests policed which tokens the heredoc
-was allowed to name. This pipeline assembles nothing: the deploy host runs
+says. A pipeline that assembled ``.env.production`` itself, from a heredoc of
+masked CI variables, would need tests policing which tokens the heredoc may
+name. This pipeline assembles nothing: the deploy host runs
 ``osprey users env-production`` against its own ``.env``, and the single
 allowlist in ``osprey.deployment.web_terminals.env_production`` decides what
-lands in that file. What carries over is the absence half — no secret may reach
-a file, or the deploy host's command line, from here.
+lands in that file. What this module pins is the absence half — no secret may
+reach a file, or the deploy host's command line, from here.
 """
 
 from __future__ import annotations
@@ -147,13 +144,13 @@ def test_installed_version_is_the_only_value_that_moves_with_a_release(
 
 
 def test_the_byte_specification_lives_with_the_exemplar() -> None:
-    """The hand-built goldens are gone, and must not come back here.
+    """No hand-built goldens live here, and none may come back.
 
-    They were written for the retired ``profile/`` layout, and a repo carrying
-    both them and the three-zone exemplar would carry two specifications free to
+    They belong to the retired ``profile/`` layout, and a repo carrying both
+    them and the three-zone exemplar would carry two specifications free to
     disagree. The bytes are pinned in ``tests/cli/test_emitted_artifacts_clean.py``
-    against ``tests/fixtures/lifecycle_repo.py``; this asserts the old pair did
-    not quietly reappear beside a suite that no longer reads it.
+    against ``tests/fixtures/lifecycle_repo.py``; this asserts the pair has not
+    quietly reappeared beside a suite that does not read it.
     """
     assert not (GOLDENS / "gitlab-ci.yml").exists()
     assert not (GOLDENS / "verify.sh").exists()

--- a/tests/deployment/test_persona_render_e2e.py
+++ b/tests/deployment/test_persona_render_e2e.py
@@ -174,7 +174,7 @@ def test_no_render_carries_the_repos_secrets_into_the_output_zone(built_repo):
     docs promise is disposable, so the rule that keeps the facility's keys at
     the repo root has to hold one level deeper too.
 
-    The render now writes no ``.env`` at all, so the check is for the file's
+    The render writes no ``.env`` at all, so the check is for the file's
     absence rather than for the secret's absence from it — a stronger statement,
     and the one that actually holds: a render that emitted an ``.env`` without
     this key would still be a second secret store for `osprey up` to mint into.

--- a/tests/deployment/test_postgres_password_mint.py
+++ b/tests/deployment/test_postgres_password_mint.py
@@ -75,7 +75,7 @@ def test_ariel_db_password_mints_under_writes_enabled_and_subprocess_execution(
     ``execution`` section, so on its own it never exercises this combination —
     the one a since-deleted deploy-time guard used to withhold tokens under
     (``writes_enabled: true`` plus the ``local`` spelling of the subprocess
-    backend). Minting is now unconditional for every var a deployed service
+    backend). Minting is unconditional for every var a deployed service
     declares, and this password in particular is not an arming credential at
     all: it is the Postgres superuser secret the ARIEL store initializes with,
     and withholding it leaves the store on the shared ``ariel``/``ariel``

--- a/tests/deployment/test_project_staleness.py
+++ b/tests/deployment/test_project_staleness.py
@@ -117,9 +117,9 @@ def test_preset_content_drift_is_reported_when_no_profile_is_recorded(
 ):
     """Same installed version, changed preset — the --dev checkout incident.
 
-    The preset branch is the fallback now: it applies to a manifest carrying no
-    profile path at all (one written before profile-always builds, or one whose
-    profile path could not be recorded). A current build records the profile it
+    The preset branch is the fallback: it applies to a manifest carrying no
+    profile path at all (one written before builds always recorded a profile,
+    or one whose profile path could not be recorded). A build records the profile it
     rendered from and is judged by that instead — see
     :func:`test_an_edited_profile_reports_the_render_stale`.
     """

--- a/tests/deployment/test_service_token_unconditional_mint.py
+++ b/tests/deployment/test_service_token_unconditional_mint.py
@@ -94,7 +94,7 @@ def _config(**overrides) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# The posture no longer changes what is minted.
+# The posture does not change what is minted.
 # ---------------------------------------------------------------------------
 
 
@@ -197,15 +197,14 @@ def test_minted_key_set_is_identical_across_every_posture(_clean_token_env, tmp_
     )
 
 
-def test_mint_logs_no_withholding_warning_under_the_formerly_guarded_posture(
+def test_mint_logs_no_withholding_warning_under_any_posture(
     captured_argv, _clean_token_env, monkeypatch, tmp_path, caplog
 ):
-    """The guard's operator-facing half is gone too.
+    """The operator-facing half must be silent too.
 
-    It warned, per var, that a token had been withheld. A deploy that mints
-    everything must not still be telling operators something was held back —
-    that text is what sent them looking for a safety property that was never
-    there.
+    A per-var warning that a token had been withheld would tell operators
+    something was held back when a deploy mints everything — text that sends
+    them looking for a safety property that is not there.
     """
     config = _config(
         control_system={"writes_enabled": True},
@@ -252,7 +251,7 @@ def test_dispatch_tokens_mint_alongside_bluesky_under_writes_enabled_local(
 def test_a_new_services_token_mints_without_being_triaged_first(
     captured_argv, _clean_token_env, monkeypatch, tmp_path
 ):
-    """Declaring a var is now sufficient — there is no allowlist to be added to.
+    """Declaring a var is sufficient — there is no allowlist to be added to.
 
     Under the old fail-closed allowlist an untriaged var was withheld by
     omission, so a service added without an accompanying allowlist edit

--- a/tests/deployment/test_template_cli_weld.py
+++ b/tests/deployment/test_template_cli_weld.py
@@ -39,7 +39,7 @@ stdout breaks any assertion on error text.
 Concrete values
 ---------------
 
-The pipeline's invocations carry no arguments at all now: the repo IS the
+The pipeline's invocations carry no arguments at all: the repo IS the
 deployment, so every verb walks up to the profile from wherever it runs. The
 harness still expands any ``$NAME`` against the pipeline's own ``variables:``
 block — so the substitution is the pipeline's and not the test's opinion of it —

--- a/tests/deployment/web_terminals/golden/nginx.conf
+++ b/tests/deployment/web_terminals/golden/nginx.conf
@@ -22,9 +22,9 @@ server {
 
 
     # Reverse proxy to alice's loopback upstream (the per-user app's
-    # `web` family, bound by bind-per-user-apps-loopback). Trailing slashes on
-    # both the location and proxy_pass target strip /u/alice before
-    # the request reaches the upstream.
+    # `web` family, bound to loopback only). Trailing slashes on both the
+    # location and proxy_pass target strip /u/alice before the
+    # request reaches the upstream.
     location /u/alice/ {
 
         proxy_pass http://127.0.0.1:9091/;
@@ -46,9 +46,9 @@ server {
 
 
     # Reverse proxy to bob's loopback upstream (the per-user app's
-    # `web` family, bound by bind-per-user-apps-loopback). Trailing slashes on
-    # both the location and proxy_pass target strip /u/bob before
-    # the request reaches the upstream.
+    # `web` family, bound to loopback only). Trailing slashes on both the
+    # location and proxy_pass target strip /u/bob before the
+    # request reaches the upstream.
     location /u/bob/ {
 
         proxy_pass http://127.0.0.1:9092/;

--- a/tests/deployment/web_terminals/test_lifecycle.py
+++ b/tests/deployment/web_terminals/test_lifecycle.py
@@ -342,7 +342,7 @@ def test_decommission_purge_typed_username_confirms(tmp_path, monkeypatch, fake_
     assert len(volume_rm_calls) == 2
 
 
-def test_decommission_purge_generic_yes_no_longer_confirms(tmp_path, monkeypatch, fake_runtime):
+def test_decommission_purge_generic_yes_does_not_confirm(tmp_path, monkeypatch, fake_runtime):
     """A literal "yes" is deliberately NOT accepted — only the exact username is.
     Muscle-memory "yes" on an irreversible two-volume destroy defeats the point
     of a typed confirmation."""
@@ -1284,12 +1284,11 @@ def test_passwd_emits_no_runtime_argv_of_its_own(
 def _capture_recreate_argv(monkeypatch) -> list[list[str]]:
     """Record the argv the REAL recreate primitive emits.
 
-    The fragment used to be resolved at this call site and handed to the
-    primitive, so it could be asserted on the delegated call's arguments. It is
-    now resolved inside the primitive's own argv builder (one definition shared
-    with `up`/`down`), so the honest assertion is on the argv that reaches the
-    runtime — a stricter check than the old one, and one that cannot pass while
-    the fragment is dropped on the floor.
+    The fragment is resolved inside the primitive's own argv builder (one
+    definition shared with `up`/`down`), not at this call site, so the honest
+    assertion is on the argv that reaches the runtime rather than on a
+    delegated call's arguments — a stricter check, and one that cannot pass
+    while the fragment is dropped on the floor.
 
     CAUTION for anyone extending a test that uses this: `lifecycle`, `provision`
     and `postup_hooks` all do a plain `import subprocess`, so they share ONE

--- a/tests/deployment/web_terminals/test_persona_images.py
+++ b/tests/deployment/web_terminals/test_persona_images.py
@@ -885,20 +885,20 @@ def test_a_delta_with_no_profile_beside_it_is_rejected(tmp_path, calls):
 
 
 # ---------------------------------------------------------------------------
-# Deletion assertions. Two things this module used to do are gone, and both
-# would be silent regressions rather than failures if they came back.
+# Absence assertions. Two things this module must never do, both of which would
+# be silent regressions rather than failures if they appeared.
 #
-# It used to shell out to `osprey build` for any persona whose project was
-# absent, which is what made a start able to write into `build/`. And before
-# that it read the parent's `.osprey-manifest.json` `build_args`, took the keys
-# passed as `--set` at parent build time, and appended the same pairs to every
-# persona render, so one parent override retinted the whole stack.
+# It must not shell out to `osprey build` for a persona whose project is
+# absent, which is what would make a start able to write into `build/`. And it
+# must not read the parent's `.osprey-manifest.json` `build_args`, take the keys
+# passed as `--set` at parent build time, and append the same pairs to every
+# persona render, retinting the whole stack from one parent override.
 #
-# Neither can come back by accident: `osprey build` renders every persona from
+# Neither can appear by accident: `osprey build` renders every persona from
 # the profile, an explicit override is written INTO the profile, and a delta
 # merges over that same profile -- so replaying a build invocation would apply
 # the change twice, and a stale manifest entry would apply a value the profile
-# no longer holds.
+# does not hold.
 # ---------------------------------------------------------------------------
 
 
@@ -907,9 +907,9 @@ def test_parent_set_override_forwarding_helper_is_gone():
 
 
 def test_the_start_time_render_is_gone():
-    """Both halves: the entry point that rendered, and the manifest indirection
-    that existed only to find the profile it rendered from. Under three zones
-    the repo root IS the profile root, so the lookup had become a tautology with
+    """Both halves: an entry point that renders, and a manifest indirection
+    whose only job would be finding the profile it rendered from. Under three
+    zones the repo root IS the profile root, so that lookup is a tautology with
     failure modes of its own."""
     assert not hasattr(persona_images, "auto_render_missing_personas")
     assert not hasattr(persona_images, "_parent_profile_root")

--- a/tests/deployment/web_terminals/test_render.py
+++ b/tests/deployment/web_terminals/test_render.py
@@ -290,8 +290,8 @@ def test_nginx_fragment_has_websocket_upgrade_machinery() -> None:
 
 
 def test_nginx_fragment_proxy_disables_buffering_and_raises_read_timeout_for_sse() -> None:
-    """Now that every request under `/u/<user>/` genuinely flows through nginx
-    (unlike Phase-1's redirect, which never put nginx in the data path), nginx's
+    """Every request under `/u/<user>/` flows through nginx as a proxy, not a
+    redirect, so nginx is genuinely in the data path and its
     DEFAULT proxy buffering and 60s read timeout would apply to the app's
     heartbeat-less Server-Sent-Events streams (`/api/files/events`, chat SSE) too
     — batching/delaying `data:` lines behind nginx's buffer and tearing down an
@@ -550,9 +550,9 @@ def test_landing_url_is_the_external_origin_verbatim_under_tls() -> None:
 
 
 def test_landing_url_baked_into_containers_follows_tls_into_https() -> None:
-    """Regression: OSPREY_TERMINAL_LANDING_URL used to be hardcoded to
-    `http://<fqdn>:<nginx_port>` regardless of TLS, so a TLS deployment shipped every
-    container a "back to landing" link on the plain origin — which under the TLS
+    """Regression: hardcoding OSPREY_TERMINAL_LANDING_URL to
+    `http://<fqdn>:<nginx_port>` regardless of TLS ships every container in a TLS
+    deployment a "back to landing" link on the plain origin — which under the TLS
     posture only ever redirects, and would never carry a Secure session cookie."""
     # Arrange
     config = _tls_config()
@@ -1557,7 +1557,7 @@ def test_render_succeeds_with_auth_default_none_and_tls_default_off() -> None:
     # Act
     artifacts = render_web_terminals(config)
 
-    # Assert — round-trips exactly as before (defaults are inert; no seam rendering here)
+    # Assert — round-trips unchanged (defaults are inert; no seam rendering here)
     assert set(artifacts.keys()) == {
         "docker-compose.web.yml",
         "nginx/nginx.conf",

--- a/tests/e2e/_orm_stack.py
+++ b/tests/e2e/_orm_stack.py
@@ -61,8 +61,7 @@ if TYPE_CHECKING:
 # Control Assistant preset deliberately leaves
 # `control_system.connector.virtual_accelerator.gateways.*.port` UNSET, so the
 # connector follows `services.virtual_accelerator.port` and moving the deployed
-# soft-IOC's port is a one-place edit that carries the connector with it. (This
-# note previously said the opposite, from when the preset hardcoded 5064.)
+# soft-IOC's port is a one-place edit that carries the connector with it.
 # Callers that must coexist with another VA deploy on the same host -- 5064 is
 # the tutorial's default and routinely held -- should pass an explicit
 # `va_port=` rather than assume this default is free.
@@ -268,38 +267,37 @@ def init_args(
     extra_config: dict[str, Any] | None = None,
 ) -> list[str]:
     """``osprey init`` CLI args (sans the leading ``init`` token) for FR11's
-        turn-key scan-stack deployment.
+    turn-key scan-stack deployment.
 
-        The stack is materialized in two steps now, because the surface has two:
-        ``osprey init`` writes the deployment repo's source zone from the preset
-        plus these overrides, and a later ``osprey build`` renders ``build/`` from
-        it. This function covers the first step only; both builders below run the
-        second. ``--no-git`` because every caller works in a throwaway directory
-        and none of them reads the history.
+    The stack is materialized in two steps, because the surface has two:
+    ``osprey init`` writes the deployment repo's source zone from the preset
+    plus these overrides, and a later ``osprey build`` renders ``build/`` from
+    it. This function covers the first step only; both builders below run the
+    second. ``--no-git`` because every caller works in a throwaway directory
+    and none of them reads the history.
 
-        Works both as ``CliRunner().invoke(init, init_args(...))`` (in-process, no
-        Docker -- see ``build_via_cli_runner``) and as
-        ``[osprey_bin, "init", *init_args(...)]`` (subprocess, for a real
-        ``osprey up`` afterward -- see ``build_project_subprocess``).
+    Works both as ``CliRunner().invoke(init, init_args(...))`` (in-process, no
+    Docker -- see ``build_via_cli_runner``) and as
+    ``[osprey_bin, "init", *init_args(...)]`` (subprocess, for a real
+    ``osprey up`` afterward -- see ``build_project_subprocess``).
 
-        ``provider``/``model``, when given, append ``--set provider=<provider>``
-        and/or ``--set model=<model>`` overrides -- e.g. an agentic-discovery
-        caller that must pin an explicit provider rather than let the
-        control-assistant preset's own default apply silently (this project's
-        "no default provider" convention). Left ``None`` by default: nothing is
-        appended and the preset's own provider/model apply unchanged, so the
-        default deploy shape is byte-identical to before these params existed.
+    ``provider``/``model``, when given, append ``--set provider=<provider>``
+    and/or ``--set model=<model>`` overrides -- e.g. an agentic-discovery
+    caller that must pin an explicit provider rather than let the
+    control-assistant preset's own default apply silently (this project's
+    "no default provider" convention). Left ``None`` by default: nothing is
+    appended and the preset's own provider/model apply unchanged, so the
+    default deploy shape is unaffected by these params.
 
-        ``extra_config``, when given, is deep-merged into ``override_yaml()`` and
-        the result REWRITES ``override_path`` -- the way to reach config keys that
-        have no ``--set`` hook here (postgres/openobserve/tiled/panels host ports).
-        Writing rather than appending another CLI flag keeps a single ``--override``
-        file, which is what ``osprey build`` wants. That rewrite OVERWRITES whatever
-        the caller previously wrote to ``override_path``, so a caller that hand-rolls
-        its own override text (as the bluesky-panels e2e does) must pass its
-        additions here rather than pre-writing them. Empty or ``None`` is a no-op:
-        ``override_path`` is left exactly as the caller wrote it, byte for byte.
-    >>>>>>> origin/main
+    ``extra_config``, when given, is deep-merged into ``override_yaml()`` and
+    the result REWRITES ``override_path`` -- the way to reach config keys that
+    have no ``--set`` hook here (postgres/openobserve/tiled/panels host ports).
+    Writing rather than appending another CLI flag keeps a single ``--override``
+    file, which is what ``osprey build`` wants. That rewrite OVERWRITES whatever
+    the caller previously wrote to ``override_path``, so a caller that hand-rolls
+    its own override text (as the bluesky-panels e2e does) must pass its
+    additions here rather than pre-writing them. Empty or ``None`` is a no-op:
+    ``override_path`` is left exactly as the caller wrote it, byte for byte.
     """
     if extra_config:
         override_path.write_text(merged_override_yaml(extra_config), encoding="utf-8")

--- a/tests/e2e/claude_code/test_agent_delegation.py
+++ b/tests/e2e/claude_code/test_agent_delegation.py
@@ -9,7 +9,7 @@ Covers the in-core sub-agents shipped by the ``control_assistant`` preset:
 - logbook-deep-research (ARIEL/PostgreSQL, opus model)
 - data-visualizer (workspace plotting/LaTeX tools, no facility backend)
 
-Facility-specific sub-agents (literature/wiki/matlab/graph) are no longer
+Facility-specific sub-agents (literature/wiki/matlab/graph) are not
 covered here — a facility ships them in its own build profile, and coverage
 for them belongs alongside that profile.
 
@@ -53,7 +53,7 @@ def _is_ariel_db_available() -> bool:
     Delegates to :func:`ariel_db_skip_reason`, which honors the
     ``OSPREY_ARIEL_DB_URI`` override. The matrix runner provisions a
     per-cell database and exports that override, so concurrent cells never
-    share one logbook DB — a scenario test in another cell can no longer drop
+    share one logbook DB — a scenario test in another cell cannot drop
     this cell's ``text_embeddings_*`` tables mid-test. Hardcoding
     ``dbname="ariel"`` here would check the wrong (shared) database.
     """

--- a/tests/e2e/test_bluesky_panels_deploy.py
+++ b/tests/e2e/test_bluesky_panels_deploy.py
@@ -691,7 +691,7 @@ def test_sidecar_runs_surface_is_read_only(deployed_stack: DeployedStack) -> Non
     """Nothing under ``/runs`` is POSTable on the sidecar -- every write is a queue write.
 
     ``/runs`` used to carry the sidecar's one write (``POST /runs/launch``).
-    That route is gone: execution is now the queue's, so the whole ``/runs``
+    That route does not exist: execution is the queue's, so the whole ``/runs``
     surface is the read-proxy's and nothing else. Proving the ABSENCE of every
     verb here — rather than "the launch route is the only one" — is a stronger
     invariant AND a simpler one to keep true.

--- a/tests/e2e/test_bluesky_sandbox_escape_e2e.py
+++ b/tests/e2e/test_bluesky_sandbox_escape_e2e.py
@@ -605,10 +605,10 @@ def test_sandbox_escape_is_caught_and_no_write_reaches_the_ioc(
     # /queue/items` takes the plan from the shared draft at a pinned revision,
     # never from its own body, and the draft resolves a plan name against the
     # SAME trust-resolved catalog gate (b) just proved this plan is absent
-    # from. So the escape plan is refused one step earlier than it used to be —
-    # it is not composable, let alone queueable.
+    # from. So the escape plan is refused at composition — it is not
+    # composable, let alone queueable.
     #
-    # This is a stronger statement than the 409 it replaces, and it is the
+    # This is a stronger statement than a 409 at enqueue, and it is the
     # honest one for THIS plan: `session_plan_unvalidated` at enqueue is
     # reachable only for a plan that WAS validated and then had its bytes
     # change underneath the pin, which is a different scenario and is covered

--- a/tests/e2e/test_dispatch_deploy.py
+++ b/tests/e2e/test_dispatch_deploy.py
@@ -282,7 +282,7 @@ def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
     )
 
     # Force a fresh image build so the deployed services run CURRENT source. The
-    # dispatcher runs <project>-dispatch:local; the worker now runs the unified
+    # dispatcher runs <project>-dispatch:local; the worker runs the unified
     # project image <project>:local (built by `up --dev` from the repo root).
     # Both tags are project-prefixed, derived via resolve_project_name exactly as
     # the compose templates / project build do.

--- a/tests/e2e/test_openobserve_telemetry.py
+++ b/tests/e2e/test_openobserve_telemetry.py
@@ -254,7 +254,7 @@ def deployed_openobserve(tmp_path_factory: pytest.TempPathFactory) -> Iterator[P
     _write_credentials(repo)
 
     # Guarantee a clean store: the data volume is host-global (see OO_DATA_VOLUME),
-    # so a volume left by another deployment's openobserve — common now that
+    # so a volume left by another deployment's openobserve — common because
     # telemetry is on by default — would pin foreign credentials and 401 this test.
     # Remove it before deploy so OpenObserve initializes with THIS test's credentials.
     _remove_oo_data_volume()

--- a/tests/e2e/test_scan_stack_agentic.py
+++ b/tests/e2e/test_scan_stack_agentic.py
@@ -342,7 +342,7 @@ def find_satisfying_chain(
     The binding degrades rather than breaks: when the add's result carries no
     usable run id (:func:`_launched_run_id` returns ``None`` — an unparseable
     body, or a response shape that moved), any successful read anchors the
-    chain, exactly as before. A bridge change can cost this floor the extra
+    chain instead. A bridge change can cost this floor the extra
     discrimination; it can never turn a correct run red.
 
     Greedy first-match on the two tail anchors is exhaustive, not a shortcut:

--- a/tests/e2e/test_sdk_helpers.py
+++ b/tests/e2e/test_sdk_helpers.py
@@ -33,7 +33,7 @@ def test_override_rewrites_uri_when_env_set(tmp_path, monkeypatch):
 
     text = config_path.read_text(encoding="utf-8")
     assert _PER_CELL_URI in text
-    # The bare default must no longer stand alone as the configured uri.
+    # The bare default must not stand alone as the configured uri.
     assert f"uri: {_DEFAULT_ARIEL_DB_URI}\n" not in text
 
 

--- a/tests/e2e/test_tiled_roundtrip.py
+++ b/tests/e2e/test_tiled_roundtrip.py
@@ -493,7 +493,7 @@ def test_tiled_roundtrip(deployed_stack: DeployedStack) -> None:
     assert status == 200, f"PATCH /draft failed: {status} {patched}"
 
     # --- 3. enqueue at the pinned revision, then arm the queue -------------
-    # The two halves of what used to be one direct launch: `POST /queue/items`
+    # The two halves of a launch: `POST /queue/items`
     # takes plan_name/plan_args from the server-side draft snapshot AT this
     # revision (never from the request body) and mints the OSPREY run id;
     # `POST /queue/start` is the token-gated arming action that drains it.

--- a/tests/e2e/test_vacuum_burst_scenario.py
+++ b/tests/e2e/test_vacuum_burst_scenario.py
@@ -21,7 +21,7 @@ shape, no "if any" hedging. The agent must do the discovery work:
      (ground truth: Pearson r ≈ -0.88 against DCCT; max|r| for the
      other 11 sectors ≤ 0.077).
 
-The ground truth now lives in the preset's simulation overlay,
+The ground truth lives in the preset's simulation overlay,
 ``data/simulation/machine.json`` (the ``vacuum-burst`` scenario): the SR07
 pressure spike + coincident DCCT dip are declared as an ``at_time`` event
 anchored daily at 14:32:08. The test activates that scenario after building

--- a/tests/e2e/web_terminals/test_prefix_routing.py
+++ b/tests/e2e/web_terminals/test_prefix_routing.py
@@ -198,8 +198,8 @@ class TestStaticAssetUnderPrefix:
     on their bare path even when a prefix is configured -- that bare path is
     the ONLY form the app ever actually receives in the real deployment (nginx
     strips the prefix before proxying; see this module's docstring). This is
-    the exact regression a forced ``FastAPI(root_path=...)`` previously
-    introduced (fixed; pinned at the unit level in
+    the exact regression a forced ``FastAPI(root_path=...)`` introduces
+    (also pinned at the unit level in
     ``test_prefix_injection.py::test_static_mount_served_on_bare_path_when_prefix_set``).
     """
 

--- a/tests/e2e/web_terminals/test_scaffold_render_roundtrip.py
+++ b/tests/e2e/web_terminals/test_scaffold_render_roundtrip.py
@@ -13,11 +13,9 @@ subprocess for a true operator-path check. That verb reads the stanza from a
 deployment repo's BUILT config, so the sample is written where a build would
 have put it.
 
-(A second part — a round-trip against als-profiles' hand-rolled
-``docker-compose.host.yml`` topology — was removed when als-profiles migrated
-to rendering its web stack from the profile: the external reference topology
-this generator was validated against no longer exists, because the generator
-replaced it.)
+(There is no second part checking a round-trip against an external hand-rolled
+``docker-compose.host.yml`` topology: als-profiles renders its web stack from
+the profile, so no such external reference topology exists to check against.)
 """
 
 from __future__ import annotations
@@ -177,8 +175,8 @@ def test_scaffold_render_consistency_across_all_generated_artifacts() -> None:
         assert f">{user}<" in landing_html
         assert f'href="/u/{user}/"' in landing_html
 
-        # Fixed per-service env var (Phase-1 contract, replaces the old
-        # `${prefix|upper}_TERMINAL_USER` convention for every facility).
+        # Fixed per-service env var (Phase-1 contract) — one name for every
+        # facility, not a `${prefix|upper}_TERMINAL_USER` convention.
         assert env["OSPREY_TERMINAL_USER"] == user
 
     assert len(seen_ports) == len(users) * len(_PORT_FAMILIES)

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -78,7 +78,7 @@ from pathlib import Path
 import pytest
 
 #: Directory name of the exemplar deployment. One repo is one deployment and the
-#: directory name IS the deployment name, so this is also the compose project
+#: directory name is the deployment name, so this is also the compose project
 #: name a test should expect.
 EXEMPLAR_DIRNAME = "als-exemplar"
 
@@ -110,7 +110,7 @@ EXECUTABLE_FILES: frozenset[str] = frozenset({"scripts/verify.sh"})
 PROFILE_YML = """\
 # Als Exemplar — OSPREY deployment repo
 #
-# This repository IS the deployment. One directory, four zones:
+# The repository is the deployment. One directory, four zones:
 #
 #   SOURCE   tracked, yours to edit — profile.yml, data/, personas/,
 #            triggers.yml, web-terminal-context/, scripts/, the CI files
@@ -618,7 +618,7 @@ WEB_TERMINALS_IMAGE_SOURCE_LINE = (
 PERSONA_READONLY_YML = """\
 # Als Exemplar (readonly) — persona profile, a delta over ../profile.yml
 #
-# Sitting in personas/ beside profile.yml IS the inheritance: the build merges
+# Sitting in personas/ beside profile.yml is the inheritance: the build merges
 # this file over that profile — including any edit you make there — so the keys
 # below are this persona's only differences and there is no `extends:` to
 # write. See the resolved whole with:
@@ -640,7 +640,7 @@ deploy_services: false
 # ── Config overrides ─────────────────────────────────────────────────────────
 # Dotted keys ONLY — see the base profile's block.
 config:
-  # The single axis this persona hard-pins: this key IS the tier boundary, so
+  # The single axis this persona hard-pins: this key is the tier boundary, so
   # it must not drift if the base's default ever changes — it is what makes
   # the read-only terminal read-only.
   control_system.writes_enabled: false
@@ -661,7 +661,7 @@ config:
 PERSONA_READWRITE_YML = """\
 # Als Exemplar (readwrite) — persona profile, a delta over ../profile.yml
 #
-# Sitting in personas/ beside profile.yml IS the inheritance: the build merges
+# Sitting in personas/ beside profile.yml is the inheritance: the build merges
 # this file over that profile — including any edit you make there — so the keys
 # below are this persona's only differences and there is no `extends:` to
 # write. See the resolved whole with:
@@ -688,7 +688,7 @@ web_panels:
 # ── Config overrides ─────────────────────────────────────────────────────────
 # Dotted keys ONLY — see the base profile's block.
 config:
-  # The single axis this persona hard-pins: this key IS the tier boundary, so
+  # The single axis this persona hard-pins: this key is the tier boundary, so
   # it must not drift silently if the base's default ever changes.
   control_system.writes_enabled: true
   # Full split-pane terminal + workspace layout for the write-armed operator.
@@ -822,7 +822,7 @@ triggers:
 # ─────────────────────────────────────────────────────────────────────────────
 
 GITIGNORE = """\
-# This repo IS the deployment: the source zone is tracked, and the three
+# This repo is the deployment: the source zone is tracked, and the three
 # generated or secret zones below never are. A fresh deployment has a clean
 # `git status` from birth.
 
@@ -919,7 +919,7 @@ README_MD = """\
 This repository is an OSPREY deployment. Everything the assistant is made of
 lives here, and the directory name is the deployment's name.
 
-## The three zones
+## The four zones
 
 | Zone | Path | Tracked? | Survives? |
 | --- | --- | --- | --- |

--- a/tests/health/test_configuration_warnings.py
+++ b/tests/health/test_configuration_warnings.py
@@ -87,7 +87,7 @@ class TestTimezoneRemediation:
         assert "config.yml" in row.details
 
     def test_advice_drops_the_unclearable_env_var_suggestion(self):
-        """``TZ`` in ``.env`` no longer feeds the literal the templates pin."""
+        """``TZ`` in ``.env`` does not feed the literal the templates pin."""
         row = _rows({"system": {"timezone": "UTC"}})["timezone"]
         assert "TZ in .env" not in row.details
         assert ".env" not in row.details

--- a/tests/hooks/test_approval_helpers.py
+++ b/tests/hooks/test_approval_helpers.py
@@ -820,10 +820,9 @@ def test_stop_describers_state_the_limit_and_name_the_tool_that_has_none(approva
     enough, at the moment delay costs most.
 
     It must state the real limit — a plain `queue_stop` does NOT touch the item
-    already in motion — and, now that one exists, name the tool that does. The
-    earlier version of this test pinned the opposite ("no tool here can"),
-    which was true of the retired 410 route and became dangerous the moment a
-    real abort was wired up.
+    already in motion — and name the tool that does. Pinning the opposite ("no
+    tool here can") would be dangerous: a real abort exists, and a prompt that
+    denies it costs the operator the fastest way to stop the machine.
     """
     fake_bridge({"/queue": {"status": {"manager_state": "idle"}, "running_item": None}})
 

--- a/tests/integration/test_profile_roundtrip.py
+++ b/tests/integration/test_profile_roundtrip.py
@@ -18,11 +18,9 @@ it:
 2. **Nothing unregenerable accumulates** (:class:`TestNoUnregenerableFacilityState`)
    — the render carries no secrets surface at all, the mirror refuses a
    build-owned path, and deleting ``build/`` outright loses nothing the source
-   zone owns. This slot previously held the env-derivation classes, which pinned
-   how a rebuild merged the profile's ``.env`` into a copy inside the render.
-   The render carries no ``.env`` now, so the merge and every rule in it are
-   gone; what is left of that contract is asserted directly, as the *absence* of
-   a secrets surface.
+   zone owns. The render carries no ``.env`` at all, so there is no merge of the
+   profile's ``.env`` into a copy inside the render and no rules governing one;
+   that contract is asserted directly, as the *absence* of a secrets surface.
 3. **The persona stack** — a ``personas/<name>.yml`` delta anchored at its root,
    its exclusions (list artifact, convention artifact, and a convention artifact
    shadowing a framework render, which the exclusion restores), its inherited

--- a/tests/interfaces/artifacts/test_logbook.py
+++ b/tests/interfaces/artifacts/test_logbook.py
@@ -257,8 +257,8 @@ class TestLogbookSubmit:
         """Without ARIEL_WEB_URL, the submit URL must be a web-terminal-relative
         proxy path — not an absolute container-internal address.
 
-        Regression: the default used to be ``http://127.0.0.1:8085`` which is
-        unreachable from the user's browser. The panel embeds via /panel/ariel
+        Regression: a default of ``http://127.0.0.1:8085`` is unreachable
+        from the user's browser. The panel embeds via /panel/ariel
         and resolves the URL with ``new URL(url, origin)``, so it must be
         origin-relative to load through the proxy.
         """

--- a/tests/interfaces/artifacts/test_logbook_no_agent_attribution.py
+++ b/tests/interfaces/artifacts/test_logbook_no_agent_attribution.py
@@ -1,14 +1,14 @@
 """The gallery's send-to-logbook is a human gesture, not agent activity.
 
-Composing a logbook entry is something an operator *clicks*. It used to be
-announced with :func:`notify_panel_focus`, which is an agent-source,
-all-clients broadcast: every connected browser painted agent styling and had
-its workspace yanked to ARIEL because one person hit Submit. These tests pin
-the replacement — navigation is sender-local over the same-origin panel-iframe
-postMessage protocol — from both ends:
+Composing a logbook entry is something an operator *clicks*. Announcing it
+with :func:`notify_panel_focus` — an agent-source, all-clients broadcast —
+would paint agent styling in every connected browser and yank each workspace
+to ARIEL because one person hit Submit. These tests pin the honest shape —
+navigation is sender-local over the same-origin panel-iframe postMessage
+protocol — from both ends:
 
   - server: submitting performs no web-terminal broadcast at all, and the
-    module no longer reaches for the agent-source notifier;
+    module never reaches for the agent-source notifier;
   - contract: the gallery posts ``osprey:navigate`` to its host only when it
     is actually embedded, and the host listener accepts it under the existing
     same-origin guard with no agent attribution anywhere in the payload.

--- a/tests/interfaces/bluesky_panels/test_queue_relay.py
+++ b/tests/interfaces/bluesky_panels/test_queue_relay.py
@@ -961,9 +961,9 @@ def test_the_queue_relay_shadows_no_pre_existing_sidecar_route() -> None:
     ``/plans``, ``/runs*`` and ``/draft*``. A queue path that collided with one
     of those would silently take it over.
 
-    ``/runs/launch`` used to be on this list; it was removed with the launch
-    relay itself, since every bridge primitive it called is now an
-    unconditional 410."""
+    ``/runs/launch`` is deliberately not on this list: there is no launch
+    relay, and every bridge primitive it would call answers an unconditional
+    410."""
     from osprey.interfaces.bluesky_panels.app import app as composed_app
 
     paths = composed_app.openapi()["paths"]

--- a/tests/interfaces/channel_finder/test_server_launcher.py
+++ b/tests/interfaces/channel_finder/test_server_launcher.py
@@ -131,8 +131,8 @@ class TestEnsureRunningOwnership:
         """A /health 200 with no real listener must NOT suppress the launch.
 
         This is the core bug: `_is_running()` returning True (stale/foreign
-        responder) previously short-circuited the launch even though nothing
-        was actually bound to the port.
+        responder) must not short-circuit the launch when nothing is actually
+        bound to the port.
         """
         launcher = _make_launcher("127.0.0.1", _free_port())
 

--- a/tests/interfaces/design_system/test_behavioral.py
+++ b/tests/interfaces/design_system/test_behavioral.py
@@ -350,7 +350,7 @@ def test_auto_follows_os_preference_until_explicit_choice(tmp_path, chromium_bro
             "document.documentElement.getAttribute('data-theme') === 'light'", timeout=5_000
         )
 
-        # Make an explicit choice; theme-manager no longer treats the
+        # Make an explicit choice; theme-manager must not treat the
         # preference as 'auto', so a subsequent OS flip must be ignored.
         _dismiss_welcome_modal(page)
         _flip_hub_theme(page)

--- a/tests/interfaces/design_system/test_freshness.py
+++ b/tests/interfaces/design_system/test_freshness.py
@@ -9,8 +9,7 @@ regenerating these three files, this test (and the equivalent
 ``build --check`` invocation) fails.
 
 This module also carries the two other things Task 1.7 is responsible
-for finalizing, now that the real build has actually run against the
-real token tree:
+for finalizing, both checked against the real token tree:
 
 - the CSS custom property names ``base.css`` (hand-written, a
   different task's file) hard-depends on existing;

--- a/tests/interfaces/design_system/test_hygiene.py
+++ b/tests/interfaces/design_system/test_hygiene.py
@@ -9,11 +9,9 @@ three independent kinds of drift:
 
 (a) Hardcoded color literals (hex, ``rgb()``/``rgba()``, ``hsl()``/
     ``hsla()``) that should have been expressed as ``var(--token)``
-    references instead. This used to be a ratchet against
-    ``hygiene_baseline.json`` while the fleet migration (PLAN Phase 2/3)
-    was in progress; Task 4.2 (hygiene-zero-flip) deleted that baseline and
-    flipped this to a strict zero-tolerance check now that every interface
-    has migrated. From this commit on, every in-scope file must have zero
+    references instead. This is a strict zero-tolerance check (Task 4.2,
+    hygiene-zero-flip): there is no ``hygiene_baseline.json`` ratchet to
+    grade against, and every in-scope file must have zero
     non-allowlisted literals — a genuinely justified, permanent survivor
     (a print stylesheet that must stay light-on-white, a fixed categorical
     color with no fleet-wide semantic equivalent, etc.) goes on the

--- a/tests/interfaces/design_system/test_splitter_surfaces.py
+++ b/tests/interfaces/design_system/test_splitter_surfaces.py
@@ -14,31 +14,31 @@ stacked ("column") layout must be selected before the y handle is live.
 
 Why this host:
 
-- It is the only remaining splitter host with no live browser coverage of its
-  own. ``test_gallery_interactions.py`` drives the gallery hard but never
-  touches either handle, and ``test_osprey_drawer.py`` covers only the
-  drawer's x-axis ``anchor: 'end'`` geometry and its 320px/90vw clamp.
-- It is therefore the only place left where a y-axis drag — a different
-  delta sign and a different clamp path than the x-axis — is exercised live.
+- It is the only splitter host with no live browser coverage of its own.
+  ``test_gallery_interactions.py`` drives the gallery hard but never touches
+  either handle, and ``test_osprey_drawer.py`` covers only the drawer's x-axis
+  ``anchor: 'end'`` geometry and its 320px/90vw clamp.
+- It is therefore the only place where a y-axis drag — a different delta sign
+  and a different clamp path than the x-axis — is exercised live.
 
-This suite previously drove the event dashboard, which carried three splitters
-across two axes. That panel was rebuilt around discrete views and has no
-resizable pane left, so the coverage moved here rather than being dropped.
+The event dashboard is not a host: it is built from discrete views and has no
+resizable pane, so this coverage lives on the gallery instead.
 
-Two assertions from the dashboard era are deliberately NOT ported:
+Two assertions a multi-splitter dashboard host would support are deliberately
+absent:
 
-- **Preset / ``storageKey: null`` / ``onCommit`` interplay.** The dashboard was
-  the only host that kept one layout record with a preset system and fed the
-  splitters through ``onCommit``. No host does that now, so there is nothing
-  left to assert; the gallery's handles persist themselves under their own
-  storage keys, which ``splitter.test.mjs`` already covers.
+- **Preset / ``storageKey: null`` / ``onCommit`` interplay.** No host keeps one
+  layout record with a preset system and feeds the splitters through
+  ``onCommit``, so there is nothing to assert; the gallery's handles persist
+  themselves under their own storage keys, which ``splitter.test.mjs`` already
+  covers.
 - **The computed ``transition-duration`` half of the drag-suppression check.**
   ``base.css`` suppresses transitions via ``[data-splitter-dragging]``, but the
   assertion is only meaningful on a pane that declares a transition on the
-  dragged dimension. The dashboard's ``.timeline-zone`` did; ``.browse-sidebar``
-  does not, so asserting ``0s`` here would pass no matter what the rule did.
-  The attribute half — applied for the drag, dropped on release — IS ported,
-  because that is the mechanism itself and it is non-vacuous on any host.
+  dragged dimension. ``.browse-sidebar`` does not, so asserting ``0s`` here
+  would pass no matter what the rule did. The attribute half — applied for the
+  drag, dropped on release — IS asserted, because that is the mechanism itself
+  and it is non-vacuous on any host.
 
 Placement rationale: ``design_system`` already owns the pattern of
 browser-proving a design-system module against a live consumer app (see

--- a/tests/interfaces/test_channel_finder_facility_name.py
+++ b/tests/interfaces/test_channel_finder_facility_name.py
@@ -108,7 +108,7 @@ def test_config_derived_name_is_not_the_registry_reported_name():
 
 
 # ---------------------------------------------------------------------------
-# The formerly canonical-only readers (task 3.5)
+# The canonical-name readers (task 3.5)
 # ---------------------------------------------------------------------------
 
 # (module, initializer, resetter) for the three pipeline server contexts. They

--- a/tests/interfaces/test_lattice_state.py
+++ b/tests/interfaces/test_lattice_state.py
@@ -53,7 +53,7 @@ class TestInitializeRefpts:
     """Verify that initialize() passes explicit refpts to get_optics."""
 
     def test_empty_beta_no_crash(self, state):
-        """Previously crashed with ValueError on np.max of empty array."""
+        """An empty beta array must not raise ValueError from np.max."""
         ring = _make_mock_ring()
         ld_empty = _make_lindata(0)
         rd = SimpleNamespace(tune=np.array([0.3, 0.2]), chromaticity=np.array([1.0, 1.5]))

--- a/tests/interfaces/test_shared_splitter_contract.py
+++ b/tests/interfaces/test_shared_splitter_contract.py
@@ -2,15 +2,14 @@
 
 The OKF knowledge panel, the artifact gallery's browse view, the PLAN panel,
 the LATTICE control sidebar, and the settings drawer all put a draggable
-divider between two panes. Those were once four hand-copied implementations,
-and they drifted — the grip pill was a child element in one and a ``::after``
-in another, the hover treatment disagreed, and two of them never grew keyboard
-or ARIA support at all — because nothing failed when a copy stopped matching.
-This is that missing failure.
+divider between two panes. Hand-copying that implementation per host lets the
+copies drift — a grip pill as a child element in one and a ``::after`` in
+another, disagreeing hover treatments, keyboard and ARIA support in only some
+— because nothing fails when a copy stops matching. This is that missing
+failure.
 
-The event dashboard was a sixth host until its layout zones were replaced by
-discrete views; it has no resizable pane left to divide, so it is no longer
-listed here.
+The event dashboard is not a host: it is built from discrete views and has no
+resizable pane to divide, so it is not listed here.
 
 The contract is static and deliberately shallow: each host's markup must carry
 the shared ``.osprey-splitter`` class on a proper ARIA separator, each host's

--- a/tests/interfaces/web_terminal/test_contract_params.py
+++ b/tests/interfaces/web_terminal/test_contract_params.py
@@ -548,7 +548,7 @@ def test_channel_finder_embedded_non_occlusion(tmp_path, monkeypatch, chromium_b
     ``.app-header`` hides -- and because that header is ``position: fixed``
     with a compensating 48px top padding on ``.app-main``, the padding must
     go with it or the panel opens on an empty 48px band. The pipeline
-    switcher survives the header's removal because it no longer lives there:
+    switcher survives the header's removal because it does not live there:
     it sits in the body's bottom corpus strip, which must stay rendered
     inside the viewport for the panel to remain switchable when embedded.
     """

--- a/tests/interfaces/web_terminal/test_panels_browser.py
+++ b/tests/interfaces/web_terminal/test_panels_browser.py
@@ -1,6 +1,6 @@
 """Browser smoke tests: the docked (dockview) workspace and its server bridge.
 
-The service panels no longer live in a fixed left/right split — they are docked
+The service panels do not live in a fixed left/right split — they are docked
 in a dockview grid (``dock-workspace.js``) whose panel content follows an overlay
 iframe layer (``dock-iframe.js``), with a state bridge (``dock-sync.js``) that
 turns human dock gestures into the same server POSTs the agent's MCP calls make.

--- a/tests/interfaces/web_terminal/test_panels_collab_browser.py
+++ b/tests/interfaces/web_terminal/test_panels_collab_browser.py
@@ -732,9 +732,9 @@ def _apply_preset_by_click(page: Page) -> None:
 def test_preset_click_and_agent_preset_call_are_the_same_operation(tmp_path, chromium_browser):
     """A "Layouts" click and ``arrange_workspace(preset=…)`` produce one workspace.
 
-    Presets used to be applied by the browser, panel by panel; the agent had no
-    way to ask for one. Both paths now resolve the same preset server-side and
-    broadcast the same arrangement, so the claim to prove is equality of the
+    Both paths resolve the same preset server-side and broadcast the same
+    arrangement, rather than the browser applying it panel by panel, so the
+    claim to prove is equality of the
     RESULT, not of the code path: same tiles in the same order, the same focus,
     and the same pruned rail — a preset is exclusive, so the panel it omits
     leaves the launcher rail in both paths.

--- a/tests/interfaces/web_terminal/test_panels_source_tag.py
+++ b/tests/interfaces/web_terminal/test_panels_source_tag.py
@@ -3,7 +3,7 @@
 Task 1.4 (source-agent-tagging): the three panel routes accept an optional
 ``source: "agent"`` field and pass it through into their SSE broadcast
 frames; browser-originated POSTs (which never send ``source``) broadcast
-exactly as before — the key is *omitted*, not null.  The MCP-side
+without it — the key is *omitted*, not null.  The MCP-side
 ``notify_panel_*`` helpers stamp ``source: "agent"`` on their POST payloads.
 """
 

--- a/tests/interfaces/web_terminal/test_proxy_design_system.py
+++ b/tests/interfaces/web_terminal/test_proxy_design_system.py
@@ -100,7 +100,7 @@ class TestDesignSystemIntercept:
         assert ds.text != "from-sidecar"
         assert forwarded == []
 
-        # A non-design-system path still goes to the sidecar as before.
+        # A non-design-system path still goes to the sidecar.
         other = client.get("/panel/my-dash/static/panel.css")
         assert other.text == "from-sidecar"
         assert len(forwarded) == 1

--- a/tests/interfaces/web_terminal/test_scaffold_routes.py
+++ b/tests/interfaces/web_terminal/test_scaffold_routes.py
@@ -196,7 +196,7 @@ class TestClaimAndOverride:
 class TestConflictHandlers:
     """The two shared refusals reach the browser as 409s from every write route.
 
-    The routes no longer name either exception, so what is pinned here is the
+    The routes name neither exception, so what is pinned here is the
     app-level translation — including that the operator-facing message survives
     into ``detail`` rather than being stripped by a bare 500.
     """

--- a/tests/interfaces/web_terminal/test_system_health_wiring.py
+++ b/tests/interfaces/web_terminal/test_system_health_wiring.py
@@ -185,8 +185,8 @@ def test_panel_catalog_registers_system_health_tab_with_explicit_health_endpoint
     An omitted/null ``healthEndpoint`` SKIPS polling and pins the panel healthy,
     which would leave the SYSTEM rail entry permanently enabled even with its
     sidecar down — so the descriptor MUST carry ``healthEndpoint: '/health'``.
-    (The rail no longer draws a per-entry LED; the poll now feeds only the
-    coarse ``.disabled`` state, and the detailed readout is the ``web_panels``
+    (The rail draws no per-entry LED; the poll feeds only the coarse
+    ``.disabled`` state, and the detailed readout is the ``web_panels``
     health category. The explicit endpoint matters either way.)
 
     Reads ``panel-catalog.js``, which owns the shipped ``PANELS`` array —

--- a/tests/interfaces/web_terminal/test_terminal_user.py
+++ b/tests/interfaces/web_terminal/test_terminal_user.py
@@ -163,7 +163,7 @@ class TestSessionFooter:
         # initLogoutButton() and the command palette both find it by id.
         assert 'id="logout-btn"' in body
         assert 'data-landing-url="https://facility.example/portal"' in body
-        # And it is no longer a header chip of its own.
+        # And it is not a header chip of its own.
         assert 'id="identity-menu"' not in body
 
     def test_footer_is_identity_free_for_a_single_user_deployment(self, client):

--- a/tests/mcp_server/ariel/test_draft.py
+++ b/tests/mcp_server/ariel/test_draft.py
@@ -138,14 +138,13 @@ async def test_api_get_nonexistent_returns_404(draft_app):
 def test_read_draft_resolves_dir_without_dict_injection(tmp_path, monkeypatch):
     """Regression: production has no `DRAFTS_DIR` in module.__dict__.
 
-    Earlier code relied on a module-level `__getattr__` to lazily resolve
-    `DRAFTS_DIR`, but PEP-562 `__getattr__` does NOT intercept bare-name
-    global references inside the module — only external attribute access.
-    Tests previously hid this by writing to `module.__dict__` via
-    `monkeypatch.setattr(drafts_mod, "DRAFTS_DIR", ...)`, which made the
-    bare-name lookup succeed *only under test*. This test patches the
-    underlying resolver instead, exercising the exact code path production
-    runs through.
+    A module-level PEP-562 `__getattr__` does NOT intercept bare-name global
+    references inside the module — only external attribute access — so it
+    cannot lazily resolve `DRAFTS_DIR` for the module's own code. Writing to
+    `module.__dict__` via `monkeypatch.setattr(drafts_mod, "DRAFTS_DIR", ...)`
+    hides that by making the bare-name lookup succeed *only under test*. This
+    test patches the underlying resolver instead, exercising the exact code
+    path production runs through.
     """
     import osprey.utils.workspace as ws_mod
 

--- a/tests/mcp_server/ariel/test_entry.py
+++ b/tests/mcp_server/ariel/test_entry.py
@@ -338,8 +338,8 @@ async def test_entry_create_draft_url_is_browser_resolvable(tmp_path, monkeypatc
     """Without ARIEL_WEB_URL, the draft URL must be a web-terminal-relative
     proxy path — not an absolute container-internal address.
 
-    Regression: the default used to be ``http://127.0.0.1:8085`` which is
-    unreachable from the user's browser (nothing listens on 8085 in the
+    Regression: a default of ``http://127.0.0.1:8085`` is unreachable from
+    the user's browser (nothing listens on 8085 in the
     deployed container, and 127.0.0.1 points at the user's own machine). The
     web terminal embeds the ARIEL panel via the relative proxy path
     ``/panel/ariel`` and resolves draft URLs with ``new URL(url, origin)``, so

--- a/tests/mcp_server/data_visualizer/test_create_interactive_plot.py
+++ b/tests/mcp_server/data_visualizer/test_create_interactive_plot.py
@@ -264,7 +264,7 @@ class TestResolveDataSource:
             resolve_data_source("deadbeef0123")
 
     def test_numeric_string_treated_as_file_path(self):
-        """Numeric strings are no longer context entry IDs; treated as file paths."""
+        """Numeric strings are not context entry IDs; treated as file paths."""
         # Numeric strings don't match the 12-char hex pattern, so they
         # fall through to the "assume file path" branch and are returned as-is.
         result = resolve_data_source("42")

--- a/tests/mcp_server/test_artifact_store.py
+++ b/tests/mcp_server/test_artifact_store.py
@@ -207,10 +207,10 @@ class TestArtifactStore:
     def test_save_data_sets_agent_usable_data_file(self, tmp_path, monkeypatch):
         """data_file must be a path the agent can open() from project CWD.
 
-        Regression guard: previously this was a bare filename
-        (``{id}_{tool}.json``) which caused FileNotFoundError when the agent
-        passed it to ``open()`` directly. The contract is now a path relative
-        to the project root (one level above the workspace dir).
+        Regression guard: a bare filename (``{id}_{tool}.json``) raises
+        FileNotFoundError when the agent passes it to ``open()`` directly.
+        The contract is a path relative to the project root (one level above
+        the workspace dir).
         """
         from osprey.stores.artifact_store import ArtifactStore
 

--- a/tests/mcp_server/test_backend_emit_sites.py
+++ b/tests/mcp_server/test_backend_emit_sites.py
@@ -988,7 +988,7 @@ async def test_execute_uncanonical_write_mode_rejected_no_emit(tool_name, tmp_pa
     """A non-canonical mode spelling is refused at the boundary — emit nothing.
 
     "READWRITE" used to clear both write gates as an unvalidated free string
-    and run the script; it is now rejected before any gate, so nothing runs
+    and run the script; it is rejected before any gate, so nothing runs
     and nothing reports.
     """
     monkeypatch.chdir(tmp_path)

--- a/tests/mcp_server/test_phoebus_databrowser.py
+++ b/tests/mcp_server/test_phoebus_databrowser.py
@@ -8,8 +8,8 @@ per Task 0.5, live behavior depends on the app-aware ``/open`` routing
 Gap-1 (content over path): the tool POSTs the generated ``.plt`` *content*
 to the bridge (not the local path), since the tool and the bridge may run in
 separate containers with no shared filesystem. ``plt_file`` in the result is
-still a locally-written copy — a shareable artifact — but is no longer what
-the bridge opens.
+a locally-written copy — a shareable artifact — but not what the bridge
+opens.
 """
 
 from pathlib import Path

--- a/tests/mcp_server/test_python_execute_tool.py
+++ b/tests/mcp_server/test_python_execute_tool.py
@@ -1107,19 +1107,19 @@ async def test_subprocess_outputs_still_written_to_execution_folder(tmp_path):
 # ============================================================================
 # Tool description — live package inventory
 #
-# The description used to name a fixed set of packages (numpy, pandas, scipy,
-# at, matplotlib, plotly) whatever the deployment had installed.  It is now
+# The description must not name a fixed set of packages (numpy, pandas, scipy,
+# at, matplotlib, plotly) regardless of what the deployment installed.  It is
 # generated from the environment that actually runs agent code, and degrades to
 # a sentence that names nothing rather than to a stale list.
 # ============================================================================
 
 
-#: Names the old hardcoded description asserted were available.
+#: Package names the description must never claim are available.
 _FORMERLY_HARDCODED = ("numpy", "pandas", "scipy", "at", "matplotlib", "plotly")
 
 
 def assert_names_no_packages(text: str) -> None:
-    """Assert ``text`` mentions none of the formerly hardcoded package names."""
+    """Assert ``text`` names no package as guaranteed-available."""
     for name in _FORMERLY_HARDCODED:
         assert not re.search(rf"\b{re.escape(name)}\b", text), (
             f"description must not name packages, found {name!r}"

--- a/tests/mcp_server/test_read_run_data_bounded.py
+++ b/tests/mcp_server/test_read_run_data_bounded.py
@@ -233,6 +233,6 @@ async def test_unknown_run_404_does_not_claim_the_data_is_gone():
     assert "unknown run" in envelope["error_message"]
     hints = " ".join(envelope["suggestions"]).lower()
     assert "in-memory" not in hints, (
-        "the run registry is no longer in-memory; this hint would misdescribe "
+        "the run registry is not in-memory; this hint would misdescribe "
         "durable queue history to the agent"
     )

--- a/tests/mcp_server/test_session_metadata.py
+++ b/tests/mcp_server/test_session_metadata.py
@@ -11,8 +11,8 @@ def fake_project(tmp_path, monkeypatch):
     """Set up a fake project directory with workspace and transcript."""
     (tmp_path / "var" / "agent_data").mkdir(parents=True)
 
-    # The metadata gatherer resolves the repo root directly — it no longer
-    # infers it from the agent-data root's position — so that is the seam.
+    # The metadata gatherer resolves the repo root directly, rather than
+    # inferring it from the agent-data root's position, so that is the seam.
     monkeypatch.setattr(
         "osprey.utils.workspace.resolve_project_root",
         lambda config=None: tmp_path,

--- a/tests/mcp_server/test_setup_patch_classification.py
+++ b/tests/mcp_server/test_setup_patch_classification.py
@@ -4,14 +4,14 @@
 (fresh subprocess per call, genuinely re-reads config), the connector (reads the
 value through a process-cached config), and the rendered ``permissions.deny``
 list in ``settings.json`` (re-rendered only by ``osprey build``). Calling the key
-"hot" told the operator a patch alone would un-gate writes, when in fact writes
+"hot" would tell the operator a patch alone un-gates writes, when in fact writes
 stay blocked until a rebuild and restart.
 
 The assertions below pin what each note has to *tell the operator* — the layers
 that stay stale and the verb that clears them — rather than the sentence the
-product happens to phrase it in. That is deliberate: these tests previously
-pinned ``osprey claude regen``, and went red when the verb was retired even
-though the contract they exist to protect had not changed.
+product happens to phrase it in. That is deliberate: pinning a literal verb
+makes these tests go red when the verb is renamed, even though the contract
+they exist to protect has not changed.
 """
 
 from pathlib import Path
@@ -87,8 +87,8 @@ def test_mcp_json_patches_are_cold():
     assert note.startswith("cold")
 
 
-def test_skill_table_no_longer_calls_writes_enabled_hot():
-    """The rendered setup-mode skill tabulated the key as Hot."""
+def test_skill_table_calls_writes_enabled_cold():
+    """The rendered setup-mode skill must tabulate the key as Cold."""
     text = SKILL_TEMPLATE.read_text(encoding="utf-8")
     rows = [ln for ln in text.splitlines() if ln.startswith(f"| `{WRITES_ENABLED}` |")]
     assert len(rows) == 1, f"expected one hot/cold table row, got {rows}"
@@ -97,7 +97,7 @@ def test_skill_table_no_longer_calls_writes_enabled_hot():
 
 
 def test_skill_writes_blocked_remedy_requires_rebuild_and_restart():
-    """The 'Writes Blocked' fix used to prescribe a patch and call it hot."""
+    """The 'Writes Blocked' fix must not prescribe a patch and call it hot."""
     text = SKILL_TEMPLATE.read_text(encoding="utf-8")
     fix_lines = [
         ln for ln in text.splitlines() if ln.startswith("**Fix**:") and WRITES_ENABLED in ln

--- a/tests/mcp_server/test_stop_run.py
+++ b/tests/mcp_server/test_stop_run.py
@@ -200,14 +200,14 @@ async def test_stop_run_falls_back_when_the_bridge_sends_no_structured_detail():
     assert "boom" in ctx["envelope"]["error_message"]
 
 
-def test_stop_run_docstring_matches_the_capability_it_now_has():
+def test_stop_run_docstring_matches_its_actual_capability():
     """Inverse drift, in the direction that costs the most.
 
-    This tool was documented as NOT FUNCTIONAL while its route was a retired
-    410. Leaving any of that wording next to a working abort tells an agent not
-    to reach for the only tool that stops a moving scan — worse than silence,
-    at the moment delay is most expensive. Positive halves pinned too, so a
-    docstring that is merely emptied of the old words fails as well.
+    Wording that documents this tool as NOT FUNCTIONAL, as it would be behind a
+    410 route, tells an agent not to reach for the only tool that stops a moving
+    scan — worse than silence, at the moment delay is most expensive. Positive
+    halves pinned too, so a docstring merely emptied of those words fails as
+    well.
     """
     doc = (stop.stop_run.__doc__ or "") + (stop.__doc__ or "")
     lowered = doc.lower()

--- a/tests/mcp_server/test_workspace_env_scrub.py
+++ b/tests/mcp_server/test_workspace_env_scrub.py
@@ -4,10 +4,10 @@ Mirrors ``test_executor_env_scrub.py`` for the sibling sandbox in
 ``osprey.mcp_server.workspace.execution.sandbox_executor`` (used by the
 data-visualizer tools: ``create_static_plot``, ``create_interactive_plot``,
 ``create_dashboard``). This sandbox has its own local subprocess-spawn seam
-(``execute_sandbox_code``'s ``asyncio.create_subprocess_exec`` call) that
-previously had no ``env=`` kwarg at all and therefore inherited the full
-parent environment — the same write-arming-token leak found and fixed in the
-python-executor sandbox (task 2.11).
+(``execute_sandbox_code``'s ``asyncio.create_subprocess_exec`` call) which,
+without an ``env=`` kwarg, would inherit the full parent environment — the
+same write-arming-token leak the python-executor sandbox guards against
+(task 2.11).
 """
 
 import textwrap

--- a/tests/mcp_server/workspace/test_archiver_downsample.py
+++ b/tests/mcp_server/workspace/test_archiver_downsample.py
@@ -4,7 +4,7 @@ Validates LTTB downsampling of archiver_data artifact entries, channel
 filtering, error handling for wrong entry categories, and empty data edge
 cases.
 
-Each channel now carries its own timestamps (independent sample cadences,
+Each channel carries its own timestamps (independent sample cadences,
 not aligned to a shared axis), so ``datasets`` entries are
 ``{"channel", "timestamps", "values", "original_points", "downsampled_points"}``
 rather than a shared-``labels`` Chart.js config.

--- a/tests/mcp_server/workspace/test_focus_tools.py
+++ b/tests/mcp_server/workspace/test_focus_tools.py
@@ -1,9 +1,8 @@
 """Tests for artifact_focus / artifact_pin honest gallery reporting.
 
-These tools previously fired a fire-and-forget POST at the gallery and
-returned ``"status": "success"`` unconditionally — a focus that never
-happened (gallery down, or gallery serving a different store) was still
-reported as done. The contract under test:
+A fire-and-forget POST at the gallery that returns ``"status": "success"``
+unconditionally reports a focus that never happened (gallery down, or gallery
+serving a different store) as done. The contract under test:
 
   - artifact_focus: the entire effect is gallery-side, so a failed or
     rejected POST is a tool error (gallery_unreachable / gallery_error).

--- a/tests/mcp_server/workspace/test_panel_tools.py
+++ b/tests/mcp_server/workspace/test_panel_tools.py
@@ -27,7 +27,7 @@ _MODULE = "osprey.mcp_server.workspace.tools.panel_tools"
 def _mock_web_terminal_url():
     """Pin the base URL used by the shared http.fetch_panels helper.
 
-    The panel tools no longer resolve the URL themselves — they delegate the
+    The panel tools do not resolve the URL themselves — they delegate the
     ``GET /api/panels`` read to ``osprey.mcp_server.http.fetch_panels``, so the
     patch has to land there for tests that stub ``urllib.request.urlopen``.
     """

--- a/tests/models/test_litellm_adapter_chat_request.py
+++ b/tests/models/test_litellm_adapter_chat_request.py
@@ -368,7 +368,7 @@ class TestHandleStructuredOutputWithChatRequest:
 
     @patch("osprey.models.providers.litellm_adapter.litellm")
     def test_no_chat_request_preserves_existing_behavior(self, mock_litellm):
-        """When chat_request is None, both native and prompt-based paths work as before."""
+        """When chat_request is None, both native and prompt-based paths still work."""
         from osprey.models.providers.litellm_adapter import _handle_structured_output
 
         mock_litellm.supports_response_schema.return_value = True

--- a/tests/registry/test_mcp.py
+++ b/tests/registry/test_mcp.py
@@ -941,7 +941,7 @@ class TestTemplateRendering:
         `osprey.deployment.web_terminals.render`, a module that never reads
         `claude_code.servers` and is never invoked by this project-level `.mcp.json`
         pipeline. A project's own custom `url`-transport server must keep rendering
-        its `{type: "http", url: ...}` entry exactly as before, both on its own
+        its `{type: "http", url: ...}` entry verbatim, both on its own
         (this assertion) and with a sibling facility config that carries the
         default (or omitted) web-terminals topology present in the same overall
         config (the `render_web_terminals()` call below, which must not raise and

--- a/tests/registry/test_provider_registration.py
+++ b/tests/registry/test_provider_registration.py
@@ -3,11 +3,11 @@
 This test module validates the provider registration feature that allows
 applications to register custom AI model providers through the registry system.
 
-Architecture note: Built-in providers (anthropic, openai, etc.) now live in
+Architecture note: Built-in providers (anthropic, openai, etc.) live in
 ``osprey.models.provider_registry`` as the single source of truth.
-``RegistryManager._initialize_providers()`` delegates to it. Tests that
-previously checked ``manager.config.providers`` for built-in entries now check
-``get_provider_registry()`` instead.
+``RegistryManager._initialize_providers()`` delegates to it, so built-in
+entries are checked against ``get_provider_registry()``, not against
+``manager.config.providers``.
 
 Tests cover:
 - Registering custom providers in application registries

--- a/tests/services/ariel_search/test_demo_data.py
+++ b/tests/services/ariel_search/test_demo_data.py
@@ -5,7 +5,7 @@ with GenericJSONAdapter for tutorial use. The demo uses *relative* timestamps
 (``when: {days_ago, time}``) resolved at ingest time, so seeded entries always
 land at a recent, deterministic position without mutating the source file.
 
-(The ``control_assistant`` preset no longer ships a standalone demo logbook —
+(The ``control_assistant`` preset ships no standalone demo logbook —
 its logbook narrative lives in self-contained simulation scenario bundles,
 seeded via ``osprey sim apply``; see tests/simulation/test_scenario_bundles.py.)
 """

--- a/tests/services/ariel_search/test_dsn_derivation.py
+++ b/tests/services/ariel_search/test_dsn_derivation.py
@@ -1,11 +1,11 @@
 """The ARIEL DSN is derived from the Postgres the project actually runs.
 
-``ariel.database.uri`` used to be rendered into every project as a hardcoded
-``postgresql://ariel:…@localhost:5432/ariel`` — a second, silent copy of facts
-already declared under ``services.postgresql``.  Moving the database port there
-left the DSN pointing at the old one, and nothing said so.
+Rendering ``ariel.database.uri`` into every project as a hardcoded
+``postgresql://ariel:…@localhost:5432/ariel`` would be a second, silent copy of
+facts already declared under ``services.postgresql``.  Moving the database port
+there would leave the DSN pointing at the stale one, with nothing to say so.
 
-The templates no longer render the key at all: with ``uri`` unset the DSN is
+The templates do not render the key at all: with ``uri`` unset the DSN is
 derived from ``services.postgresql`` at load time, so a port move is a one-place
 edit.  An explicit ``uri`` still wins verbatim — that is how a project points at
 a database it does not run — and a legacy ``connection_string`` keeps working,

--- a/tests/services/ariel_search/test_semantic_processor_provider.py
+++ b/tests/services/ariel_search/test_semantic_processor_provider.py
@@ -60,7 +60,7 @@ class TestModuleProviderDrivesBothUses:
 
         assert module._model_config["provider"] == "cborg"
 
-    def test_nested_model_provider_is_no_longer_required(self, provider_models) -> None:
+    def test_nested_model_provider_is_optional(self, provider_models) -> None:
         """Omitting the retired ``model.provider`` still yields a usable model config."""
         module = SemanticProcessorModule()
         module.configure(_config(model={"model_id": "anthropic/claude-haiku", "max_tokens": 256}))

--- a/tests/services/bluesky_bridge/test_builtin_plans.py
+++ b/tests/services/bluesky_bridge/test_builtin_plans.py
@@ -1,8 +1,8 @@
 """Bluesky-marked coverage for the shipped `orm`/`grid_scan` plans'
 parameter schemas and the `orm` plan's abort-safe restore behavior.
 
-`plans.py`'s hand-built plan set is gone (the single-registry migration —
-see `plan_loader.get_facility_plans`); `orm`/`grid_scan` are now
+There is no hand-built plan set: a single registry owns them (see
+`plan_loader.get_facility_plans`), and `orm`/`grid_scan` are
 plain `plans_core/` files, discovered through the layered directory loader.
 Their end-to-end registration + RunEngine round trip (through the real
 loader, against mock devices) is `test_exemplar_plans.py`'s job — this file

--- a/tests/services/channel_finder/benchmarks/test_runner.py
+++ b/tests/services/channel_finder/benchmarks/test_runner.py
@@ -84,7 +84,7 @@ def _make_project_dir(
 ) -> Path:
     """Create a fake project directory with config.yml and benchmark queries.
 
-    The runner no longer reads ``claude_code.provider`` (the model is passed
+    The runner does not read ``claude_code.provider`` (the model is passed
     in directly), so the config only needs the channel_finder section.
     """
     project_dir = tmp_path / "project"

--- a/tests/services/test_bundle_path_resolution.py
+++ b/tests/services/test_bundle_path_resolution.py
@@ -110,11 +110,12 @@ def test_shipped_relative_path_agrees_across_all_three_sites(project, monkeypatc
     assert Path.cwd() not in bundle_dir.parents, "fixture must place the CWD outside the project"
 
 
-def test_cli_no_longer_resolves_relative_to_the_cwd(project, monkeypatch):
-    """Regression: the CLI was the CWD-relative outlier.
+def test_cli_does_not_resolve_relative_to_the_cwd(project, monkeypatch):
+    """Regression: the CLI must not be a CWD-relative outlier.
 
     A bundle sitting at ``<cwd>/data/facility_knowledge`` must NOT win over the
-    one the config points at — that decoy is exactly what the CLI used to open.
+    one the config points at — that decoy is exactly what a CWD-relative
+    resolver opens.
     """
     _project_dir, bundle_dir = project
 

--- a/tests/services/test_draft_roundtrip.py
+++ b/tests/services/test_draft_roundtrip.py
@@ -8,11 +8,11 @@ real ``osprey.services.bluesky_bridge.app`` bridge via ``httpx.ASGITransport``
 frame it broadcasts is observed on the bridge itself. That cross-service hop is
 this module's whole subject.
 
-The "launch" third of the original chain has moved: plans execute in the queue
-server now, so ``POST /draft/run`` no longer launches anything and answers the
-machine-readable ``use_the_queue`` refusal instead. This module asserts exactly
-that -- a caller who follows the PATCH with the old launch call learns where
-the capability went. It deliberately stops there. The draft-revision-to-enqueue
+Launching is not part of that chain: plans execute in the queue server, so
+``POST /draft/run`` launches nothing and answers the machine-readable
+``use_the_queue`` refusal instead. This module asserts exactly that -- a caller
+who follows the PATCH with a launch call learns where the capability lives. It
+deliberately stops there. The draft-revision-to-enqueue
 path (reservation, arming, what reaches the manager) is
 ``tests/integration/test_bluesky_queue_contract.py``'s subject, against a
 stateful mock queue server; duplicating it here would mean two places to update

--- a/tests/simulation/test_scenario_bundles.py
+++ b/tests/simulation/test_scenario_bundles.py
@@ -36,7 +36,7 @@ class TestRelativeTimestamps:
         by_id = {e.entry_id: e for e in engine.scenario_logbook("rf-thermal")}
         assert by_id["DEMO-026"].when == RelativeTimestamp(days_ago=4, time=dtime(3, 20, 0))
         assert by_id["DEMO-027"].when == RelativeTimestamp(days_ago=3, time=dtime(10, 0, 0))
-        # Newest incident entry lands at now-2d, matching the old rebase landing.
+        # Newest incident entry lands at now-2d.
         assert by_id["DEMO-028"].when == RelativeTimestamp(days_ago=2, time=dtime(14, 0, 0))
 
     def test_all_relative_timestamps_are_well_formed(self, engine_factory):

--- a/tests/simulation/test_type_aware_lookup.py
+++ b/tests/simulation/test_type_aware_lookup.py
@@ -82,7 +82,7 @@ def _stage_project(tmp_path: Path, control_system: dict) -> Path:
 def _stage_repo(tmp_path: Path, control_system: dict, *, with_model: bool = True) -> Path:
     """Stage a deployment repo the ``sim`` CLI can discover.
 
-    The CLI no longer takes a project directory: it walks up to the nearest
+    The CLI takes no project directory: it walks up to the nearest
     ``profile.yml`` and reads the render under ``build/``. So the same
     ``control_system`` block has to be placed the way a real deployment holds it
     — the rendered config in ``build/``, the simulation model in the source zone

--- a/tests/templates/test_channel_limits_va.py
+++ b/tests/templates/test_channel_limits_va.py
@@ -312,9 +312,8 @@ class TestQuadLimitsArePhysicallyStable:
             assert len(family_sp_addresses[family]) == ALS_U_AR.family(family).count, family
 
     def test_recalibrated_address_count_is_108(self, family_sp_addresses):
-        # Replaces the old toy-ring "48 (QF+QD)" count: the repointed bridge
-        # covers four families, all derived from the facility spec --
-        # 24 QF + 24 QD + 24 QFA + 36 DIPOLE = 108.
+        # The bridge covers four families, all derived from the facility
+        # spec -- 24 QF + 24 QD + 24 QFA + 36 DIPOLE = 108.
         expected = sum(ALS_U_AR.family(family).count for family in QUAD_DIPOLE_FAMILIES)
         assert expected == 108
         total = sum(len(addresses) for addresses in family_sp_addresses.values())

--- a/tests/templates/test_gateway_presets.py
+++ b/tests/templates/test_gateway_presets.py
@@ -2,7 +2,7 @@
 host<->container CA configuration proven by the PyAT Virtual Accelerator
 probe (task 1.1's empirical finding): CA name-server mode over TCP, not
 broadcast discovery, which does not reliably cross the macOS<->container VM
-boundary. This is the shape `osprey config set-epics-gateway` hands out for
+boundary. This is the shape `osprey set epics_gateway=` hands out for
 the "Local Simulation" choice, so it must not mislead users into a broadcast
 configuration.
 """

--- a/tests/unit/dispatch/test_server_routes.py
+++ b/tests/unit/dispatch/test_server_routes.py
@@ -232,7 +232,7 @@ def test_dashboard_state_shape(app):
 
 
 # ---------------------------------------------------------------------------
-# Dashboard READ endpoints are now bearer-gated (they surface agent output).
+# Dashboard READ endpoints are bearer-gated (they surface agent output).
 # ---------------------------------------------------------------------------
 
 _GATED_READ_ROUTES = [

--- a/tests/unit/dispatch/test_trigger_config.py
+++ b/tests/unit/dispatch/test_trigger_config.py
@@ -309,7 +309,7 @@ def test_surface_and_surface_prompt_are_parsed_when_present(tmp_path):
 
 # ---------------------------------------------------------------------------
 # Test 11: `action.surface` / `action.surface_prompt` are optional and default
-#          to None; an otherwise-identical trigger parses the same as before
+#          to None; an otherwise-identical trigger parses identically
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/dispatch_worker/test_dispatch_api.py
+++ b/tests/unit/dispatch_worker/test_dispatch_api.py
@@ -334,9 +334,9 @@ def test_dashboard_runs_session_id_is_none_when_unrecorded(client, monkeypatch):
 # Startup lifecycle: provider-env injection, no artifact regeneration
 # ---------------------------------------------------------------------------
 #
-# The project image now bakes .claude/ and data/ at build time (COPY . +
-# osprey claude regen), so the worker no longer regenerates those artifacts
-# at runtime. Provider auth/model env injection still has to happen at
+# The project image bakes .claude/ and data/ at build time (the render `osprey
+# build` produces is COPYed in), so the worker does not regenerate those
+# artifacts at runtime. Provider auth/model env injection still has to happen at
 # process startup, since it depends on the mounted config.yml/environment.
 
 

--- a/tests/utils/test_agent_data_root.py
+++ b/tests/utils/test_agent_data_root.py
@@ -16,7 +16,7 @@ runtime resolver and the compose-time mkdir that has to pre-create the mount
 point — the interaction that makes ``registry_exports_dir`` land in
 ``registry_exports/`` instead of a directory named after its own config key.
 
-Anchoring is now unified on ``project_root`` — the deployment repo root, not the
+Anchoring is unified on ``project_root`` — the deployment repo root, not the
 directory holding ``config.yml``, which since the repo/render split is one level
 down in ``build/``.  Callers holding a config anchor on it directly; the ones
 with none in hand go through :func:`resolve_agent_data_root`, which loads the
@@ -84,7 +84,7 @@ class TestAgentDataBaseDir:
             {"agent_data": {}},
             {"agent_data": None},
             {"agent_data": {"base_dir": None}},
-            # The retired key names the same directory but no longer supplies it.
+            # The retired key names the same directory but does not supply it.
             {"file_paths": {"agent_data_dir": "_legacy_data"}},
         ],
         ids=["none", "empty", "empty-section", "null-section", "null-value", "retired-key-only"],
@@ -118,10 +118,10 @@ class TestGetAgentDir:
         monkeypatch.setenv("CONFIG_FILE", str(cfg))
         assert Path(get_agent_dir("api_calls_dir")) == project / "scratch-data" / "api_calls"
 
-    def test_retired_file_paths_key_no_longer_moves_the_root(
+    def test_retired_file_paths_key_does_not_move_the_root(
         self, project: Path, monkeypatch
     ) -> None:
-        """A legacy config keeps loading; its retired key just stops steering."""
+        """A legacy config keeps loading; its retired key does not steer."""
         cfg = _write_config(
             project,
             f"project_root: {project}\n"

--- a/tests/utils/test_config_access.py
+++ b/tests/utils/test_config_access.py
@@ -157,7 +157,7 @@ class TestGetAgentDir:
         """``applications:`` is retired — only the top-level ``file_paths`` wins.
 
         Projects that still carry a legacy ``applications:`` block keep loading,
-        but its nested ``file_paths`` no longer scope directory resolution.
+        but its nested ``file_paths`` does not scope directory resolution.
         """
         cfg = _write_config(
             tmp_path,

--- a/tests/utils/test_configure_logging.py
+++ b/tests/utils/test_configure_logging.py
@@ -234,9 +234,9 @@ class TestAcceptedStdoutLimitation:
 
     This is the deliberate trade, not an oversight: the same
     add-only-if-absent rule is what stops Osprey from evicting handlers it does
-    not own — ``caplog``'s among them — which is the leak this whole redesign
-    exists to fix. Nothing in the codebase installs a stdout ``RichHandler``
-    anymore (``redirect_logging_to_stderr()`` is gone), so the case is
+    not own — ``caplog``'s among them — which is the leak this guard exists to
+    prevent. Nothing in the codebase installs a stdout ``RichHandler``
+    (there is no ``redirect_logging_to_stderr()``), so the case is
     hypothetical here. It is pinned rather than described so that changing the
     guard's semantics in EITHER direction fails loudly instead of quietly
     altering where log bytes land.

--- a/tests/utils/test_import_env_hygiene.py
+++ b/tests/utils/test_import_env_hygiene.py
@@ -261,8 +261,8 @@ def test_litellm_mode_is_pinned_but_respects_an_explicit_setting():
 def test_cli_entry_point_loads_dotenv(tmp_path):
     """`osprey <command>` must still see `.env` from its first line.
 
-    Nothing else populates the environment for a CLI process now that import
-    doesn't, so a subcommand reading ``os.environ`` directly — before anything
+    Nothing else populates the environment for a CLI process, since import must
+    not, so a subcommand reading ``os.environ`` directly — before anything
     builds a config — depends on this. The invocation runs inside the probe's
     subprocess because the CLI writes straight to ``os.environ``, which would
     otherwise outlive the test.

--- a/tests/utils/test_legacy_config_tolerance.py
+++ b/tests/utils/test_legacy_config_tolerance.py
@@ -1,7 +1,7 @@
 """Legacy-tolerance coverage for the config loader.
 
-Projects rendered before the config-honesty cleanup carry configuration keys
-that no longer have a reader.  Deleting a key from the templates and from the
+Projects rendered against an earlier template carry configuration keys that
+have no reader.  Deleting a key from the templates and from the
 code that consumed it must never break those projects: their on-disk
 ``config.yml`` still declares the key, and ``load_osprey_config`` has to keep
 accepting it silently — no exception, no ``WARNING``, no deprecation chatter.
@@ -34,8 +34,8 @@ from osprey.utils.workspace import load_osprey_config
 
 FIXTURE = Path(__file__).parent / "fixtures" / "legacy_config_all_deleted_keys.yml"
 
-# Every dotted path the fixture carries deliberately because the cleanup
-# retires it.  Grouped by the ledger section that dispositions it.  Deleting an
+# Every dotted path the fixture carries deliberately, because it is retired.
+# Grouped by the ledger section that dispositions it.  Deleting an
 # entry from this list — or from the fixture — silently drops the backwards
 # compatibility coverage for that key, so both halves are asserted against each
 # other by ``test_fixture_still_carries_every_retired_key``.

--- a/tests/va/test_bindings_parity.py
+++ b/tests/va/test_bindings_parity.py
@@ -1,15 +1,15 @@
 """The bound catalog addresses the ring it was baked against.
 
-The model is now served from the bound catalog alone. The field-for-field
-parity check against ``build_variable_catalog`` retired with the migration
-it certified: with no second derivation left to compare against, comparing
-the bound catalog to a plain one rebuilt beside it only asserted that one
-function calls another. What survives are the properties that hold on their
-own terms -- the catalog's shape, and the baselines below.
+The model is served from the bound catalog alone. There is no field-for-field
+parity check against ``build_variable_catalog``: with no second derivation to
+compare against, comparing the bound catalog to a plain one rebuilt beside it
+would only assert that one function calls another. What this module pins are
+the properties that hold on their own terms -- the catalog's shape, and the
+baselines below.
 
 **Baked baselines (standing).** Every setpoint's element must be the one
 ``StrengthMap`` snapshotted its baked strength from, bit-for-bit. This is
-the check that outlives the migration: the ring, the map and these
+the standing check: the ring, the map and these
 variables are one set, and a change that rebuilt the ring after baking --
 or reordered construction so the map baked a lattice the variables do not
 write -- would leave every conversion scaled by a stale baseline while

--- a/tests/va/test_build_time_manifest.py
+++ b/tests/va/test_build_time_manifest.py
@@ -115,7 +115,7 @@ class TestNonProfileBehaviorUnchanged:
     The channel set itself is pinned by ``tests/va/test_manifest.py``'s
     measured ``EXPECTED_TOTAL`` / ``EXPECTED_RING_COUNTS`` against the
     no-argument ``build_manifest()`` — the call every runtime caller makes.
-    What this class adds is that the refactor did not move that default: see
+    What this class adds is that the default itself is the package tree: see
     ``TestManifestPaths.test_default_argument_is_the_package_tree``.
     """
 

--- a/tests/va/test_facility_seam.py
+++ b/tests/va/test_facility_seam.py
@@ -11,14 +11,14 @@ has to be named separately because its ``__init__`` is PEP 562 lazy -- an
 accidental import costs almost nothing and would not announce itself by
 dragging anything heavy in.
 
-``lume`` and ``h5py`` are **deliberately not blocked**, and that is a change
-of position rather than a relaxation. The serving layer is built around a
+``lume`` and ``h5py`` are **deliberately not blocked**, and that is a considered
+position rather than a relaxation. The serving layer is built around a
 :class:`~lume.model.LUMEModel`: the runner derives its PVA namespace and the
 shape of its run loop from one, and the no-lattice boot serves the empty
 :class:`~osprey.services.virtual_accelerator.serving.model_stub.NullModel`
 rather than no model at all. ``lume`` is therefore a dependency of the
 *serving* layer, not of the physics behind it, and blocking it would have
-this gate assert something the design no longer claims. What the seam
+this gate assert something the design does not claim. What the seam
 protects is what this boot path is allowed to *depend on* -- not what its
 dependencies cost.
 

--- a/tests/va/test_orm_crosscheck.py
+++ b/tests/va/test_orm_crosscheck.py
@@ -142,7 +142,7 @@ def _model_matrix(correctors: list[str], bpms: list[str], currents: list[float])
     Evaluates `orbit_response` at the SAME `currents` sweep and fits the SAME
     degree-1 `numpy.polyfit` that `build_response_matrix` fits over the
     measured rows -- estimator identity, not just data-source independence.
-    This matters because the estimators are no longer interchangeable: the
+    This matters because the estimators are not interchangeable: the
     real AR lattice's sextupoles (see `calibration.py`'s `AMPS_PER_RADIAN_KICK`
     comment) make the closed-orbit response mildly nonlinear in kick angle,
     so a two-point finite-difference slope and a 5-point polyfit slope over

--- a/tests/va/test_physics_bridge.py
+++ b/tests/va/test_physics_bridge.py
@@ -15,9 +15,8 @@ toy lattice: nominal currents are the per-device values baked into
 -- see `_nominal_current` below), device counts/families come from
 `osprey.simulation.facility_spec.ALS_U_AR`, and every "away from nominal"
 setpoint used here was probed against the real optics (see each test's
-comment) rather than carried over from the old toy-ring numbers, since the
-real ring's stability/NaN boundaries sit much closer to nominal than the
-toy ring's did.
+comment) rather than taken from a toy-ring model, since the real ring's
+stability/NaN boundaries sit much closer to nominal than a toy ring's.
 """
 
 from __future__ import annotations
@@ -159,8 +158,8 @@ class TestSetpointWriteMovesBpm:
         # multiplier probed below 1.3x (trace_x jumps to 2.65, unstable);
         # 1.1x is used here to leave comfortable margin below that boundary
         # while still perturbing the gradient enough to move the response
-        # (real ring: 1.5x nominal -- the old toy-ring test's multiplier --
-        # is already well past the instability boundary, so it is not reused).
+        # (real ring: 1.5x nominal -- a typical toy-ring multiplier --
+        # is already well past the instability boundary, so it is not used).
         bridge.on_setpoint("SR:MAG:HCM:01:CURRENT:SP", 10.0)
         response_at_nominal_qf = bridge.bpm_positions()["SR:DIAG:BPM:01:POSITION:X"]
 
@@ -175,7 +174,7 @@ class TestSetpointWriteMovesBpm:
         # (I/I_nom - 1) * BendingAngle / Length) is far more sensitive than
         # the toy ring's -- 1.1x nominal already produces a non-finite
         # one-turn matrix (find_m44 NaN), so 1.05x (still stable, orbit shift
-        # ~13 mm) is used here instead of the old toy-ring 1.2x multiplier.
+        # ~13 mm) is used here instead of a toy-ring 1.2x multiplier.
         bridge.on_setpoint("SR:MAG:HCM:01:CURRENT:SP", 10.0)
         response_at_nominal_dipole = bridge.bpm_positions()["SR:DIAG:BPM:01:POSITION:X"]
 
@@ -409,7 +408,7 @@ class TestElementMisalignment:
         # stability boundary, so this is a real, not contrived, boot fault.
         #
         # Spec-derived device counts (24 QF + 24 QD on the real ALS-U AR
-        # ring, from facility_spec.ALS_U_AR), not the old toy ring's
+        # ring, from facility_spec.ALS_U_AR), not a toy ring's
         # `range(1, 17)` (16 + 16) -- measured: roll=0.6 across all 24+24
         # devices does still destabilize the real ring's one-turn map.
         qf_count = ALS_U_AR.family("QF").count

--- a/tests/va/test_serving_pvdb.py
+++ b/tests/va/test_serving_pvdb.py
@@ -754,7 +754,7 @@ class TestPhysicsReadbacksReachPva:
     record shim after every solve. Nothing between the solve and the wire is
     aware of a transport, which is the point: the bridge is unchanged and the
     reading reaches both views because the shim it already pushes through
-    now carries both.
+    carries both.
     """
 
     BPM_X = "SR:DIAG:BPM:01:POSITION:X"


### PR DESCRIPTION
Shipped text was written mid-redesign, so it explained the system as a diff against arrangements no reader has seen: emitted profile headers, template comments, CLI help, user docs, and test docstrings said what moved, what no longer exists, and what is new. A reader without that history cannot parse it, and it dates every file it touches.

This rewrites all shipped prose as a plain statement of present behavior. Comments that encoded a hazard as a war story now state the invariant and the cost of violating it. Deliberately kept: tombstone errors for removed flags, guidance for moving an existing deployment onto the profile format, on-disk compatibility notes, and external-system facts — history a reader genuinely needs.

The sweep also surfaced and fixed adjacent defects in shipped text: internal issue/task/branch references leaking into generated files, unearned maturity claims, a README claim of LabVIEW and Tango connectors that do not exist, a dead cross-reference, a committed merge-conflict marker, a zone table titled three when it lists four, and a release skill describing a version literal the tree does not have. The project tagline is now: an agentic interface to scientific control systems.