### PR TITLE
feat(cli): report lifecycle progress as phases, spool container output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ Compatibility is documented in release notes, not encoded in the version string.
   magnifier and remaining controls fold into a ⋯ menu instead of vanishing.
   The six-dot drag grip is gone — the bar itself remains the drag handle.
 
+- Lifecycle commands now report what they are doing instead of scrolling their
+  transcript past. `osprey init`, `build`, `up`, `restart` and `down` print one
+  line per phase as they work; `init`, `build`, `down` and a detached
+  `up -d`/`restart -d` finish with a summary card saying where the deployment
+  stands and what to run next (an attached start ends inside the live log
+  stream, so it gets none), and `osprey reset` ends with a one-line summary.
+  The container build and compose output they used to stream is spooled to
+  `var/logs/` — and a step that fails replays its own spool in full before the
+  error, so the reason is still on the screen. `osprey -v` streams everything
+  to the terminal as before.
+
 - The control-assistant preset's two-user roster now ships alice as the
   write-capable operator and bob as the read-only viewer. The tiers differ
   visibly, not just in enforcement: the write-armed terminal keeps the full

--- a/docs/source/getting-started/control-assistant.rst
+++ b/docs/source/getting-started/control-assistant.rst
@@ -77,12 +77,14 @@ recorder service — that holds what those channels did.
 
 **The first deploy seeds the archive**, and it is the step that takes the
 longest. It writes about a month of history for every channel the machine
-serves, printing a progress line every 15 seconds or so while it works:
+serves, printing a progress line every 15 seconds or so while it works. The
+duration on each line is how long that slice of the seeding took:
 
 .. code-block:: text
 
    Seeding 2,908 channels over 30 days (48h at 10s, then 60s). This takes minutes on a first deploy.
-     seeding archive: 8,960 documents written (15s elapsed)
+     · seeding archive: 8,960 documents written across 2,908 channels (17.4s)
+     · seeding archive: 17,920 documents written across 2,908 channels (15.0s)
      ...
    seeded 57,600 documents x 2,908 channels (2026-07-12 09:14 to 2026-08-11 09:14 UTC) in 96.3s
 

--- a/docs/source/how-to/use-virtual-accelerator.rst
+++ b/docs/source/how-to/use-virtual-accelerator.rst
@@ -240,10 +240,10 @@ to that channel's own noise. Nothing invents an event nobody would find in the
 live machine.
 
 Writing it takes a minute or two on a first deploy, and the deploy says so as it
-goes ("seeding archive: N documents written", every 15 seconds or so), then
-reports the span and the document count when it finishes. Later deploys check
-the archive against the knobs now in force and skip the seed when it already
-covers them.
+goes ("seeding archive: N documents written across N channels", every 15 seconds
+or so), then reports the span and the document count when it finishes. Later
+deploys check the archive against the knobs now in force and skip the seed when
+it already covers them.
 
 **The recorded present.** From then on the recorder samples the machine every
 10 seconds and stores what answered. A setpoint you write is readable out of the

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -640,6 +640,7 @@ def _render_project(
     deployment: bool,
     progress: Any,
     extra_known: Sequence[str] = (),
+    injected_out: list[str] | None = None,
 ) -> Path:
     """Render one resolved profile into ``<output_dir>/<project_name>``.
 
@@ -684,6 +685,12 @@ def _render_project(
         extra_known: Repo-root entry names to exempt from the unknown-entry
             warning on top of the profile's own, so a persona render does not
             repeat a warning the deployment's render already made.
+        injected_out: A list to record this render's injected service names in,
+            for a caller that reports them. Passed rather than returned because
+            a build renders six times and every pass injects the same set: the
+            caller names the ONE pass whose set it reports (``deployment`` does
+            not identify it — the deployment's container copy renders with it
+            set too).
 
     Returns:
         The rendered project directory.
@@ -764,7 +771,9 @@ def _render_project(
             for key, value in entries.items():
                 progress("      %s: %s (from the profile's %s block)", key, value, block)
 
-    _inject_services(build_profile, repo_root, render_dir)
+    injected = _inject_services(build_profile, repo_root, render_dir)
+    if injected_out is not None:
+        injected_out.extend(injected)
 
     applied = _apply_conventions(
         repo_root,
@@ -963,7 +972,7 @@ def _render_persona_projects(shared: _SharedRenderInputs, zones: _RenderZones) -
     rendered: list[Path] = []
     for delta in deltas:
         project_name = f"{shared.repo_root.name}-{delta.stem}"
-        logger.info("  Rendering persona %r → %s/", delta.stem, project_name)
+        logger.debug("  Rendering persona %r → %s/", delta.stem, project_name)
         rendered.append(
             _render_project(
                 shared,
@@ -1558,8 +1567,16 @@ def _build_repo(
             included. ``build/`` is left as it was found.
         click.UsageError: When no deployment repo encloses the search path.
     """
+    from osprey.deployment.errors import CapturedProcessError
+
     from .build_profile import resolve_build_document
     from .build_profile_deploy import deploy_aware_config_errors
+    from .phase_reporter import current_reporter
+
+    # Whatever the verb at the top of this run installed — this build's own
+    # reporter under `osprey build`, and the one `init --up` or `up --build`
+    # already had open when they chained here.
+    reporter = current_reporter()
 
     repo_root = find_repo_root(repo)
     profile_path = repo_root / PROFILE_FILENAME
@@ -1569,7 +1586,7 @@ def _build_repo(
     name = repo_root.name
     zones = _render_zones(repo_root)
 
-    logger.info("Building %s", repo_root)
+    logger.debug("Building %s", repo_root)
 
     # The durable zone first: a fresh clone carries no git-ignored directory,
     # and the render below records paths into it.
@@ -1627,10 +1644,15 @@ def _build_repo(
         # beside it, is copied into the staged tree — the record and the
         # environment it describes must ship together.
         if not skip_deps:
-            project_deps = _create_project_venv(zones.build_dir, build_profile)
-            recorded = zones.build_dir / "pyproject.toml"
-            if recorded.is_file():
-                shutil.copy2(recorded, zones.stage / "pyproject.toml")
+            # Reported on its own, not folded into the render below: it is the
+            # longest thing a first build does by a wide margin, and a build
+            # that looks stuck for two minutes is the moment an operator most
+            # needs to be told what it is waiting on.
+            with reporter.phase("Preparing the project environment"):
+                project_deps = _create_project_venv(zones.build_dir, build_profile)
+                recorded = zones.build_dir / "pyproject.toml"
+                if recorded.is_file():
+                    shutil.copy2(recorded, zones.stage / "pyproject.toml")
         else:
             project_deps = list(build_profile.dependencies or [])
 
@@ -1644,33 +1666,54 @@ def _build_repo(
             va_manifests={},
         )
 
-        _render_project(
-            shared,
-            resolved,
-            profile_path=profile_path,
-            project_name=name,
-            output_dir=zones.stage.parent,
-            deployment=True,
-            progress=logger.info,
-        )
-
-        config = _render_compose_files(zones, runtime_root, dev_mode=dev)
-
-        persona_renders = _render_persona_projects(shared, zones)
-
-        # The copies the images are built from — the deployment's and one per
-        # persona — each rendered against the path its container sees itself at
-        # rather than the host's. Skipped under an explicit --runtime-root: that
-        # build is ALREADY aimed at a runtime elsewhere, and rendering a second
-        # relocation inside it would be guessing which of the two the operator
-        # meant.
-        image_renders = (
-            []
-            if runtime_root
-            else _render_container_projects(
-                shared, resolved, zones, profile_path=profile_path, project_name=name
+        # One reported phase over every render pass this build makes — the
+        # deployment, the compose files, one per persona delta, one per image
+        # copy. They are six passes over the same profile producing one build/,
+        # and reported one by one they read as six builds. Each pass gets a step
+        # line naming what it produced instead.
+        with reporter.phase("Rendering the configuration") as phase:
+            # Only this pass records what it injected: all six inject the same
+            # set, and the operator wants the components named once.
+            injected: list[str] = []
+            _render_project(
+                shared,
+                resolved,
+                profile_path=profile_path,
+                project_name=name,
+                output_dir=zones.stage.parent,
+                deployment=True,
+                # The step lines below are the default view of this pass now, so
+                # its own line-by-line narration joins the other five passes at
+                # DEBUG, where `--verbose` still has all of it.
+                progress=logger.debug,
+                injected_out=injected,
             )
-        )
+            phase.step("project files, agent artifacts and services")
+            if injected:
+                phase.step(f"services injected: {', '.join(injected)}")
+
+            config = _render_compose_files(zones, runtime_root, dev_mode=dev)
+            phase.step("compose files")
+
+            persona_renders = _render_persona_projects(shared, zones)
+            if persona_renders:
+                phase.step(f"{len(persona_renders)} persona render(s)")
+
+            # The copies the images are built from — the deployment's and one per
+            # persona — each rendered against the path its container sees itself at
+            # rather than the host's. Skipped under an explicit --runtime-root: that
+            # build is ALREADY aimed at a runtime elsewhere, and rendering a second
+            # relocation inside it would be guessing which of the two the operator
+            # meant.
+            image_renders = (
+                []
+                if runtime_root
+                else _render_container_projects(
+                    shared, resolved, zones, profile_path=profile_path, project_name=name
+                )
+            )
+            if image_renders:
+                phase.step(f"{len(image_renders)} image build context(s)")
 
         # Both remaining phases run against the staged tree, before the swap:
         # a profile whose own validation fails must not be able to replace a
@@ -1724,6 +1767,13 @@ def _build_repo(
     except ValueError as e:
         logger.error("✗ Error: %s", e)
         raise click.Abort() from e
+    except CapturedProcessError as e:
+        # A child that exited non-zero is a build failure, not an unexpected
+        # one. Its output has already been replayed by the phase this ran
+        # under, so the message names the spool rather than repeating it — and
+        # carries no ✗ of its own, because that phase's failure line has one.
+        logger.error("Build failed: %s", e)
+        raise click.Abort() from e
     except Exception as e:
         logger.error("✗ Unexpected error: %s", e)
         import traceback
@@ -1738,7 +1788,7 @@ def _build_repo(
             shutil.rmtree(zones.stage_root, ignore_errors=True)
 
     if backup_dir is not None:
-        logger.info("  ✓ Previous Claude Code artifacts saved to %s", backup_dir)
+        logger.debug("  ✓ Previous Claude Code artifacts saved to %s", backup_dir)
     logger.info("✓ Rendered %s", zones.build_dir)
     _warn_if_deployment_running(config, name)
 
@@ -1775,7 +1825,7 @@ def _check_osprey_version_requirement(build_profile: Any) -> None:
             build_profile.requires_osprey_version,
         )
         raise click.Abort()
-    logger.info("  ✓ OSPREY %s satisfies %s", current, build_profile.requires_osprey_version)
+    logger.debug("  ✓ OSPREY %s satisfies %s", current, build_profile.requires_osprey_version)
 
 
 def _collect_profile_artifacts(
@@ -1888,7 +1938,7 @@ def _repo_render_context(
     return context
 
 
-def _inject_services(build_profile: Any, profile_dir: Path, project_path: Path) -> None:
+def _inject_services(build_profile: Any, profile_dir: Path, project_path: Path) -> list[str]:
     """Scaffold the service tree and inject every service the profile declares.
 
     Skipped wholesale for an attached project (``deploy_services: false``): its
@@ -1902,33 +1952,50 @@ def _inject_services(build_profile: Any, profile_dir: Path, project_path: Path) 
     already being in ``deployed_services``, which is what the dispatch injector
     writes there; the bluesky-panels sidecar read-proxies the bluesky bridge and
     follows it for the same reason.
+
+    Returns:
+        The name of each component injected, in injection order — what the
+        build reports as one step line. Empty when nothing was injected.
     """
     if not build_profile.deploy_services:
-        logger.info(
+        logger.debug(
             "deploy_services: false — attached project; no services scaffolded "
             "(connects to a shared OSPREY services stack)"
         )
-        return
+        return []
+
+    injected: list[str] = []
 
     svc_count = _copy_service_templates(project_path)
     if svc_count:
-        logger.info("  ✓ Copied %d service template(s)", svc_count)
+        logger.debug("  ✓ Copied %d service template(s)", svc_count)
 
     if build_profile.services:
         psvc_count = _inject_profile_services(profile_dir, project_path, build_profile.services)
-        logger.info("  ✓ Injected %d profile service(s)", psvc_count)
+        logger.debug("  ✓ Injected %d profile service(s)", psvc_count)
+        if psvc_count:
+            # Counted rather than named: an unresolvable template is warned
+            # about and skipped, so the profile's own keys can name more
+            # services than were injected.
+            injected.append(f"{psvc_count} profile service(s)")
     if build_profile.dispatch is not None:
         _inject_dispatch(build_profile.dispatch, profile_dir, project_path)
+        injected.append("event dispatch")
     if build_profile.nextcloud_bridge is not None:
         _inject_nextcloud_bridge(build_profile.nextcloud_bridge, project_path)
+        injected.append("Nextcloud Talk bridge")
     if build_profile.gchat_bridge is not None:
         _inject_gchat_bridge(build_profile.gchat_bridge, project_path)
+        injected.append("Google Chat bridge")
     if build_profile.bluesky is not None:
         _inject_bluesky(build_profile.bluesky, project_path)
+        injected.append("bluesky bridge")
     if build_profile.bluesky_panels is not None:
         _inject_bluesky_panels(build_profile.bluesky_panels, project_path)
+        injected.append("bluesky panels")
     if build_profile.virtual_accelerator is not None:
         _inject_va(build_profile.virtual_accelerator, project_path)
+        injected.append("virtual accelerator")
     # Must follow the VA injector: the recorder's compose template gates its
     # image source, startup ordering and Channel Access addressing on
     # `virtual_accelerator` being in `deployed_services`, which is exactly what
@@ -1938,6 +2005,9 @@ def _inject_services(build_profile: Any, profile_dir: Path, project_path: Path) 
     # va_archiver_config_overrides).
     if build_profile.va_archiver is not None:
         _inject_va_archiver(build_profile.va_archiver, project_path)
+        injected.append("archiver store")
+
+    return injected
 
 
 @click.command()
@@ -2002,11 +2072,27 @@ def build(
       # Dev build: images run this checkout, not the published release
       $ osprey build --dev
     """
-    _build_repo(
-        repo,
-        stream=stream,
-        skip_lifecycle=skip_lifecycle,
-        skip_deps=skip_deps,
-        runtime_root=runtime_root,
-        dev=dev,
-    )
+    from .main import lifecycle_reporter
+    from .summary_card import owns_summary_card, print_summary_card
+
+    # Both decided here rather than in `_build_repo`, because a chained build —
+    # `init --up`, `up --build` — reaches that function with the chaining verb's
+    # reporter already installed, and this is the entry that has to leave it
+    # alone. `lifecycle_reporter` makes that decision for the reporter and
+    # `owns_summary_card` the same one for the card, which the chaining verb
+    # prints at the end of the whole run instead.
+    owns_card = owns_summary_card()
+    with lifecycle_reporter():
+        _build_repo(
+            repo,
+            stream=stream,
+            skip_lifecycle=skip_lifecycle,
+            skip_deps=skip_deps,
+            runtime_root=runtime_root,
+            dev=dev,
+        )
+        if owns_card:
+            # Resolved again rather than returned: `_build_repo` derives the
+            # same root from the same argument, and a build that got here
+            # resolved it successfully.
+            print_summary_card(find_repo_root(repo), "built")

--- a/src/osprey/cli/build_environment.py
+++ b/src/osprey/cli/build_environment.py
@@ -159,11 +159,11 @@ def report_provider_credentials(
     if selected is None:
         # Keyless provider, or a name outside the registry (custom adapter).
         if provider in PROVIDER_API_KEYS:
-            logger.info("  ✓ Provider: %s — no API key required", provider)
+            logger.debug("  ✓ Provider: %s — no API key required", provider)
         else:
-            logger.info("  ✓ Provider: %s — no known API key env var; skipping check", provider)
+            logger.debug("  ✓ Provider: %s — no known API key env var; skipping check", provider)
     elif selected.found:
-        logger.info("  ✓ Provider: %s — %s found (%s)", provider, selected.var, selected.source)
+        logger.debug("  ✓ Provider: %s — %s found (%s)", provider, selected.var, selected.source)
     else:
         logger.warning("  ✗ Provider: %s — %s NOT SET", provider, selected.var)
         logger.warning("      The build will complete, but the agent cannot reach the model.")
@@ -185,9 +185,9 @@ def report_provider_credentials(
     found_others = [s.var for s in others if s.found]
     missing_others = [s.var for s in others if not s.found]
     if found_others:
-        logger.info("      Other keys detected: %s", ", ".join(found_others))
+        logger.debug("      Other keys detected: %s", ", ".join(found_others))
     if missing_others:
-        logger.info("      Not set:             %s", ", ".join(missing_others))
+        logger.debug("      Not set:             %s", ", ".join(missing_others))
 
     return statuses
 
@@ -712,7 +712,7 @@ def freeze_base_environment(python_path: Path, inherit_exclude: list[str]) -> li
         raise BuildProfileError(_freeze_offender_message(python_path, unreproducible, conflicts))
 
     pinned = [f"{name}=={version}" for _, (name, version, _) in sorted(survivors.items())]
-    logger.info(
+    logger.debug(
         "  ✓ Froze %d packages from base venv %s (%.2fs)",
         len(pinned),
         python_path,
@@ -776,7 +776,7 @@ def _create_project_venv(project_path: Path, profile: Any) -> list[str]:
     # --- Create venv ---
     logger.info("  Creating project virtual environment...")
     if base_python is not None:
-        logger.info("  Base interpreter: %s", base_python)
+        logger.debug("  Base interpreter: %s", base_python)
     if uv_path:
         result = subprocess.run(
             [uv_path, "venv", str(venv_path), "--python", base_python_arg, "--quiet"],

--- a/src/osprey/cli/build_injectors.py
+++ b/src/osprey/cli/build_injectors.py
@@ -82,7 +82,7 @@ def _refresh_service_dir(src_dir: Path, dest_dir: Path, name: str, owned: set[st
     user-owned and the project copy was left untouched.
     """
     if name in owned:
-        logger.info("  ⏭  services/%s is user-owned — left untouched (scaffold claim)", name)
+        logger.debug("  ⏭  services/%s is user-owned — left untouched (scaffold claim)", name)
         return False
     if dest_dir.exists():
         shutil.rmtree(dest_dir)
@@ -413,23 +413,23 @@ def _inject_dispatch(dispatch: DispatchConfig, profile_dir: Path, project_path: 
         yaml.dump(config, fh)
 
     # 4. Post-build hint.
-    logger.info(
+    logger.debug(
         "  ✓ Injected event dispatch (%d worker(s), port %d)",
         dispatch.worker_count,
         dispatch.dispatcher_port,
     )
-    logger.info("    Dashboard:  http://localhost:%d/dashboard", dispatch.dispatcher_port)
-    logger.info(
+    logger.debug("    Dashboard:  http://localhost:%d/dashboard", dispatch.dispatcher_port)
+    logger.debug(
         "    Token:      `osprey up` writes EVENT_DISPATCHER_TOKEN to .env; "
         "load it with: export $(grep -E '^EVENT_DISPATCHER_TOKEN=' .env | xargs)"
     )
-    logger.info(
+    logger.debug(
         "    Try it:     curl -X POST http://localhost:%d/webhook/hello-dispatch "
         '-H "Authorization: Bearer $EVENT_DISPATCHER_TOKEN" '
         "-H 'Content-Type: application/json' -d '{}'",
         dispatch.dispatcher_port,
     )
-    logger.info(
+    logger.debug(
         "    Images:     `osprey up` builds the dispatch image and the "
         "worker's project image locally (first run is slow). Use `--dev` to bake "
         "in your local osprey checkout; set OSPREY_DISPATCH_IMAGE/OSPREY_WORKER_IMAGE "
@@ -515,22 +515,22 @@ def _inject_bluesky(bluesky: BlueskyConfig, project_path: Path) -> None:
         yaml.dump(config, fh)
 
     # 3. Post-build hint.
-    logger.info("  ✓ Injected Bluesky scan bridge (port %d)", bluesky.port)
-    logger.info(
+    logger.debug("  ✓ Injected Bluesky scan bridge (port %d)", bluesky.port)
+    logger.debug(
         "    Token:      `osprey up` writes BLUESKY_LAUNCH_TOKEN to .env; "
         "a host-run agent's queue tools read it automatically. Deployed web "
         "terminals never receive it — their agents file a start request the "
         "operator confirms in the BLUESKY queue panel."
     )
-    logger.info(
+    logger.debug(
         "    Images:     `osprey up` builds the bluesky-bridge image locally "
         "(first run is slow). Use `--dev` to bake in your local osprey checkout; "
         "set OSPREY_BLUESKY_BRIDGE_IMAGE to use a published image."
     )
     if bluesky.tiled_enabled:
-        logger.info("    Tiled:      enabled on port %d", bluesky.tiled_port)
+        logger.debug("    Tiled:      enabled on port %d", bluesky.tiled_port)
     if bluesky.plan_dir:
-        logger.info(
+        logger.debug(
             "    Plan dir:   %s mounted read-only into the bridge; its plans "
             "load as the 'facility' trust tier (BLUESKY_PLAN_DIRS)",
             bluesky.plan_dir,
@@ -611,12 +611,12 @@ def _inject_va(va: VAConfig, project_path: Path) -> None:
         yaml.dump(config, fh)
 
     # 3. Post-build hint.
-    logger.info("  ✓ Injected Virtual Accelerator soft-IOC (CA port %d)", va.port)
-    logger.info(
+    logger.debug("  ✓ Injected Virtual Accelerator soft-IOC (CA port %d)", va.port)
+    logger.debug(
         "    Data:       requires <project>/data/simulation/machine.json "
         "(the simulation preset provisions this; without it the IOC SystemExits)."
     )
-    logger.info(
+    logger.debug(
         "    Images:     `osprey up` builds the virtual-accelerator image "
         "locally for your native architecture (first run is slow — the native deps "
         "are compiled from source, so no prebuilt aarch64 wheels are "
@@ -784,12 +784,12 @@ def _inject_bluesky_panels(bluesky_panels: BlueskyPanelsConfig, project_path: Pa
         yaml.dump(config, fh)
 
     # 4. Post-build hint.
-    logger.info("  ✓ Injected bluesky-panels sidecar (port %d)", bluesky_panels.port)
-    logger.info(
+    logger.debug("  ✓ Injected bluesky-panels sidecar (port %d)", bluesky_panels.port)
+    logger.debug(
         "    Panels:     BLUESKY (Plans | Queue | Results) — reached through the "
         "web-terminal proxy at /panel/bluesky."
     )
-    logger.info(
+    logger.debug(
         "    Images:     `osprey up` builds the bluesky-panels image locally "
         "(first run is slow). Use `--dev` to bake in your local osprey checkout; "
         "set OSPREY_BLUESKY_PANELS_IMAGE to use a published image."
@@ -876,20 +876,20 @@ def _inject_nextcloud_bridge(
         yaml.dump(config, fh)
 
     # 3. Post-build hint.
-    logger.info("  ✓ Injected Nextcloud Talk bridge (trigger %r)", nextcloud_bridge.trigger)
-    logger.info(
+    logger.debug("  ✓ Injected Nextcloud Talk bridge (trigger %r)", nextcloud_bridge.trigger)
+    logger.debug(
         "    Credentials: set NEXTCLOUD_BASE_URL, NEXTCLOUD_BOT_ACCOUNT, "
         "NEXTCLOUD_APP_PASSWORD and NEXTCLOUD_ROOMS in the project .env before "
         "`osprey up`. These are user-supplied — unlike the dispatch "
         "tokens, deploy does not mint them, and the bridge aborts at boot "
         "naming whichever is missing."
     )
-    logger.info(
+    logger.debug(
         "    Rooms:       NEXTCLOUD_ROOMS is a comma-separated list of Talk room "
         "tokens. Room membership is the access gate: whoever can post in a "
         "listed room can reach the agent."
     )
-    logger.info(
+    logger.debug(
         "    Images:     `osprey up` builds the nextcloud-bridge image locally "
         "(first run is slow). Use `--dev` to bake in your local osprey checkout; "
         "set OSPREY_NEXTCLOUD_BRIDGE_IMAGE to use a published image."
@@ -970,8 +970,8 @@ def _inject_gchat_bridge(gchat_bridge: GChatBridgeProfileConfig, project_path: P
         yaml.dump(config, fh)
 
     # 3. Post-build hint.
-    logger.info("  ✓ Injected Google Chat bridge (trigger %r)", gchat_bridge.trigger)
-    logger.info(
+    logger.debug("  ✓ Injected Google Chat bridge (trigger %r)", gchat_bridge.trigger)
+    logger.debug(
         "    Credentials: set GCHAT_SA_KEY (host path to the service-account JSON "
         "key, mounted read-only at the same path in the container), "
         "GCHAT_SUBSCRIPTION and GCHAT_APP_ID in the project .env before "
@@ -979,14 +979,14 @@ def _inject_gchat_bridge(gchat_bridge: GChatBridgeProfileConfig, project_path: P
         "tokens, deploy does not mint them, and the bridge aborts at boot "
         "naming whichever is missing."
     )
-    logger.info(
+    logger.debug(
         "    Subscription: deploy exactly ONE bridge per Pub/Sub subscription. "
         "Pub/Sub load-balances a subscription across its consumers, so a second "
         "deployment on the same name does not duplicate events — it silently "
         "splits them, and each half answers only what it received. Give every "
         "deployment its own subscription on the topic."
     )
-    logger.info(
+    logger.debug(
         "    Images:     `osprey up` builds the gchat-bridge image locally "
         "(first run is slow). Use `--dev` to bake in your local osprey checkout; "
         "set OSPREY_GCHAT_BRIDGE_IMAGE to use a published image."
@@ -1091,23 +1091,23 @@ def _inject_va_archiver(va_archiver: VAArchiverConfig, project_path: Path) -> No
         yaml.dump(config, fh)
 
     # 3. Post-build hint.
-    logger.info(
+    logger.debug(
         "  ✓ Injected archiver store + recorder (port %d, %d-day retention)",
         va_archiver.port_host,
         va_archiver.retention_days,
     )
-    logger.info(
+    logger.debug(
         "    History:    `osprey up` seeds the base series before the "
         "stack starts (minutes on a first deploy, skipped when the knobs have "
         "not changed). Until then the archive is empty and archiver reads "
         "honestly return nothing."
     )
-    logger.info(
+    logger.debug(
         "    Password:   `osprey up` mints %s into .env; the store, the "
         "recorder and the agent all authenticate with that one value.",
         va_archiver.password_env,
     )
-    logger.info(
+    logger.debug(
         "    Recording:  the recorder writes only while control_system.type is "
         "'virtual_accelerator' — on any other control system it idles. It "
         "re-reads that setting on an interval, so the flip needs no restart."

--- a/src/osprey/cli/deploy_cmd.py
+++ b/src/osprey/cli/deploy_cmd.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Any, NoReturn
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import click
 
@@ -23,6 +23,9 @@ from osprey.utils.config import load_project_config
 from osprey.utils.logger import get_logger
 
 from .repo_resolver import repo_option
+
+if TYPE_CHECKING:
+    from .phase_reporter import PhaseReporter
 
 logger = get_logger("deploy")
 
@@ -278,6 +281,38 @@ def ensure_repo_env(repo_root: Path, config: dict[str, Any]) -> None:
     )
 
 
+def _preflight(repo_root: Path, reporter: PhaseReporter, *, nothing_done: str) -> None:
+    """Check the two things a start verb needs before it starts anything.
+
+    Reported as one phase because it is one question to the operator — can this
+    deployment start at all? — answered by two facts: a ``build/`` to start, and
+    the secret store every compose invocation is pointed at. Both refusals name
+    the same remedies they always did; the phase only adds a ✗ line naming the
+    step that stopped.
+
+    Args:
+        repo_root: The deployment repo.
+        reporter: The reporter this verb installed.
+        nothing_done: The sentence the ``build/`` refusal ends with, spelled for
+            the verb the operator typed (``up`` starts nothing, ``restart`` also
+            stops nothing).
+
+    Raises:
+        click.Abort: When there is no build, or no ``.env`` and none was seeded.
+    """
+    from osprey.deployment.container_lifecycle import as_built_config_path
+
+    with reporter.phase("Preflight") as phase:
+        config_path = as_built_config_path(repo_root)
+        if not config_path.is_file():
+            _abort(
+                f"No build found at {config_path.parent}. Run `osprey build` to render it. "
+                f"{nothing_done}"
+            )
+        ensure_repo_env(repo_root, load_project_config(str(config_path), wrap_errors=True))
+        phase.done("build/ and .env are in place")
+
+
 @click.command("up")
 @repo_option
 @click.option("--detached", "-d", is_flag=True, help="Run services in the background.")
@@ -354,53 +389,69 @@ def up_verb(
       # Test local osprey changes in the containers (dev render + start)
       $ osprey up --build --dev
     """
+    from osprey.cli.main import lifecycle_reporter
     from osprey.cli.repo_resolver import find_repo_root
-    from osprey.deployment.container_lifecycle import (
-        NoBuildError,
-        as_built_config_path,
-        up_as_built,
-    )
+    from osprey.cli.summary_card import owns_summary_card, print_summary_card
+    from osprey.deployment.container_lifecycle import NoBuildError, up_as_built
 
     repo_root = find_repo_root(repo)
-    gate_start_from_build(
-        ctx, repo_root, chain_build=chain_build, as_built=as_built, verb="up", dev=dev
-    )
-
-    config_path = as_built_config_path(repo_root)
-    if not config_path.is_file():
-        _abort(
-            f"No build found at {config_path.parent}. Run `osprey build` to render it. "
-            "Nothing was started."
+    # Asked before the reporter is installed, so a start chained from `init --up`
+    # leaves the card to the verb that owns the run (see `owns_summary_card`).
+    owns_card = owns_summary_card()
+    with lifecycle_reporter() as reporter:
+        # The gate opens no phase of its own: with --build it chains a whole
+        # `osprey build`, which reports its own phases into this same reporter,
+        # and a phase held open around them would close after them and time the
+        # build as part of the start.
+        gate_start_from_build(
+            ctx, repo_root, chain_build=chain_build, as_built=as_built, verb="up", dev=dev
         )
-    ensure_repo_env(repo_root, load_project_config(str(config_path), wrap_errors=True))
 
-    # Into the repo for the duration: the compose-file lookup and the runtime's
-    # own relative-path handling both resolve against the working directory, and
-    # a start verb has to be correct from any directory inside the repo. Restored
-    # on the detached path; the attached one os.execvpe-replaces this process.
-    previous = Path.cwd()
-    os.chdir(repo_root)
-    try:
-        up_as_built(
-            repo_root, detached=detached, dev_mode=dev, keep_archiver_base=keep_archiver_base
-        )
-    except NoBuildError as e:
-        _abort(f"{e} Nothing was started.")
-    except DevModeUnavailableError as e:
-        console.print(f"\n✗ --dev cannot be honored: {e.reason}\n", style=Styles.ERROR)
-        for line in e.remedy.splitlines():
-            console.print(f"  {line}" if line else "")
-        console.print("\n  Nothing was deployed.\n", style=Styles.WARNING)
-        raise click.Abort() from None
-    except KeyboardInterrupt:
-        console.print("\n!  Operation cancelled by user", style=Styles.WARNING)
-        raise click.Abort() from None
-    except (click.Abort, click.ClickException):
-        raise
-    except Exception as e:
-        _abort(f"Deployment failed: {e}")
-    finally:
-        os.chdir(previous)
+        _preflight(repo_root, reporter, nothing_done="Nothing was started.")
+
+        # Into the repo for the duration: the compose-file lookup and the runtime's
+        # own relative-path handling both resolve against the working directory, and
+        # a start verb has to be correct from any directory inside the repo. Restored
+        # on the detached path; the attached one os.execvpe-replaces this process.
+        previous = Path.cwd()
+        os.chdir(repo_root)
+        try:
+            # Attached starts never close this phase: `up_as_built` hands the
+            # terminal to compose with os.execvpe and this process is gone. That
+            # is the documented shape — phases up to the exec point, then the
+            # live log stream, and no summary card.
+            with reporter.phase(f"Starting {repo_root.name}"):
+                up_as_built(
+                    repo_root,
+                    detached=detached,
+                    dev_mode=dev,
+                    keep_archiver_base=keep_archiver_base,
+                )
+        except NoBuildError as e:
+            _abort(f"{e} Nothing was started.")
+        except DevModeUnavailableError as e:
+            # No ✗ of its own: this is raised from inside the start phase, whose
+            # failure line has already marked the run. Two markers for one
+            # refusal read as two things having gone wrong.
+            console.print(f"\n--dev cannot be honored: {e.reason}\n", style=Styles.ERROR)
+            for line in e.remedy.splitlines():
+                console.print(f"  {line}" if line else "")
+            console.print("\n  Nothing was deployed.\n", style=Styles.WARNING)
+            raise click.Abort() from None
+        except KeyboardInterrupt:
+            console.print("\n!  Operation cancelled by user", style=Styles.WARNING)
+            raise click.Abort() from None
+        except (click.Abort, click.ClickException):
+            raise
+        except Exception as e:
+            _abort(f"Deployment failed: {e}")
+        finally:
+            os.chdir(previous)
+
+        # Reached only on a detached start that succeeded: every refusal above
+        # aborts, and an attached one never comes back from `up_as_built`.
+        if owns_card and detached:
+            print_summary_card(repo_root, "running")
 
 
 @click.command("down")
@@ -439,7 +490,9 @@ def down_verb(repo: Path | None) -> None:
       # Stop a deployment you are not standing in
       $ osprey down --repo ~/deployments/my-agent
     """
+    from osprey.cli.main import lifecycle_reporter
     from osprey.cli.repo_resolver import find_repo_root
+    from osprey.cli.summary_card import print_summary_card
     from osprey.deployment.container_lifecycle import down_deployment
 
     repo_root = find_repo_root(repo)
@@ -452,7 +505,13 @@ def down_verb(repo: Path | None) -> None:
     previous = Path.cwd()
     os.chdir(repo_root)
     try:
-        down_deployment(repo_root)
+        with lifecycle_reporter() as reporter:
+            # The card is the verb's, not the library's: `down_deployment` is
+            # also what `restart` and `reset` stop with, and a "stopped" card
+            # printed from inside it would land in the middle of both.
+            with reporter.phase(f"Stopping {repo_root.name}"):
+                down_deployment(repo_root)
+            print_summary_card(repo_root, "stopped")
     except KeyboardInterrupt:
         console.print("\n!  Operation cancelled by user", style=Styles.WARNING)
         raise click.Abort() from None
@@ -544,49 +603,57 @@ def restart_verb(
       # Restart the existing render anyway
       $ osprey restart --as-built -d
     """
+    from osprey.cli.main import lifecycle_reporter
     from osprey.cli.repo_resolver import find_repo_root
-    from osprey.deployment.container_lifecycle import (
-        NoBuildError,
-        as_built_config_path,
-        restart_deployment,
-    )
+    from osprey.cli.summary_card import owns_summary_card, print_summary_card
+    from osprey.deployment.container_lifecycle import NoBuildError, restart_deployment
 
     repo_root = find_repo_root(repo)
-    gate_start_from_build(
-        ctx, repo_root, chain_build=chain_build, as_built=as_built, verb="restart", dev=dev
-    )
-
-    config_path = as_built_config_path(repo_root)
-    if not config_path.is_file():
-        _abort(
-            f"No build found at {config_path.parent}. Run `osprey build` to render it. "
-            "Nothing was stopped."
+    owns_card = owns_summary_card()
+    with lifecycle_reporter() as reporter:
+        gate_start_from_build(
+            ctx, repo_root, chain_build=chain_build, as_built=as_built, verb="restart", dev=dev
         )
-    ensure_repo_env(repo_root, load_project_config(str(config_path), wrap_errors=True))
 
-    previous = Path.cwd()
-    os.chdir(repo_root)
-    try:
-        restart_deployment(
-            repo_root, detached=detached, dev_mode=dev, keep_archiver_base=keep_archiver_base
-        )
-    except NoBuildError as e:
-        _abort(f"{e} Nothing was stopped.")
-    except DevModeUnavailableError as e:
-        console.print(f"\n✗ --dev cannot be honored: {e.reason}\n", style=Styles.ERROR)
-        for line in e.remedy.splitlines():
-            console.print(f"  {line}" if line else "")
-        console.print("\n  Nothing was stopped.\n", style=Styles.WARNING)
-        raise click.Abort() from None
-    except KeyboardInterrupt:
-        console.print("\n!  Operation cancelled by user", style=Styles.WARNING)
-        raise click.Abort() from None
-    except (click.Abort, click.ClickException):
-        raise
-    except Exception as e:
-        _abort(f"Restart failed: {e}")
-    finally:
-        os.chdir(previous)
+        _preflight(repo_root, reporter, nothing_done="Nothing was stopped.")
+
+        previous = Path.cwd()
+        os.chdir(repo_root)
+        try:
+            # One phase for the stop and the start together, because that is what
+            # the verb is: `restart_deployment` recreates the containers, and a
+            # stop reported as finished while the start is still to come would
+            # invite reading the ✓ as "it is down now".
+            with reporter.phase(f"Restarting {repo_root.name}"):
+                restart_deployment(
+                    repo_root,
+                    detached=detached,
+                    dev_mode=dev,
+                    keep_archiver_base=keep_archiver_base,
+                )
+        except NoBuildError as e:
+            _abort(f"{e} Nothing was stopped.")
+        except DevModeUnavailableError as e:
+            # Same dedupe as `up`: the restart phase's ✗ is the run's marker.
+            console.print(f"\n--dev cannot be honored: {e.reason}\n", style=Styles.ERROR)
+            for line in e.remedy.splitlines():
+                console.print(f"  {line}" if line else "")
+            console.print("\n  Nothing was stopped.\n", style=Styles.WARNING)
+            raise click.Abort() from None
+        except KeyboardInterrupt:
+            console.print("\n!  Operation cancelled by user", style=Styles.WARNING)
+            raise click.Abort() from None
+        except (click.Abort, click.ClickException):
+            raise
+        except Exception as e:
+            _abort(f"Restart failed: {e}")
+        finally:
+            os.chdir(previous)
+
+        # Detached only, for the same reason `up` has it: an attached restart
+        # ends inside compose's log stream, which the card cannot follow.
+        if owns_card and detached:
+            print_summary_card(repo_root, "running")
 
 
 @click.command("status")

--- a/src/osprey/cli/init_cmd.py
+++ b/src/osprey/cli/init_cmd.py
@@ -942,7 +942,9 @@ def init(
             "-d/--dev only mean something with --up, which is what starts the deployment."
         )
 
+    from .main import lifecycle_reporter
     from .profile_cmd import _directory_derived_name, _materialize_profile_directory
+    from .summary_card import print_summary_card
 
     target = _resolve_target(directory)
     _refuse_enclosing_repo(target)
@@ -952,47 +954,70 @@ def init(
     _reinstate_held_source_zone(target)
     created = _prepare_repo_root(target, force=force)
 
-    # Everything that can reject this run happens inside the block — the preset
-    # resolves in there — so the zone being replaced is held aside for it rather
-    # than removed ahead of it.
-    try:
-        with _replacing_source_zone(target, active=force):
-            materialized = _materialize_profile_directory(
-                target,
-                preset,
-                overrides,
-                set_pairs,
-                profile_name=_directory_derived_name(target.name),
-            )
-    except BuildProfileError as e:
-        # Reaching here means a packaging problem, not a user mistake — the
-        # helper raises UsageError for everything the caller could have got
-        # wrong. Abort (exit 1) keeps that distinct from usage errors (exit 2).
-        _discard_created_root(target, created=created)
-        logger.error("✗ %s", e)
-        raise click.Abort() from e
-    except BaseException:
-        _discard_created_root(target, created=created)
-        raise
+    # The reporter is installed around the `--up` chain as well as around the
+    # creation itself: `_chain_up` invokes `build` and `up`, each of which finds
+    # this one already installed and reports into it, so `init --up` reads as
+    # one run of phases rather than three commands' worth.
+    with lifecycle_reporter() as reporter:
+        # The phase opens only once the refusals above are past, so a run that
+        # is turned away prints its reason and nothing else.
+        with reporter.phase(f"Creating {target.name}") as phase:
+            # Everything that can reject this run happens inside the block — the
+            # preset resolves in there — so the zone being replaced is held aside
+            # for it rather than removed ahead of it.
+            try:
+                with _replacing_source_zone(target, active=force):
+                    materialized = _materialize_profile_directory(
+                        target,
+                        preset,
+                        overrides,
+                        set_pairs,
+                        profile_name=_directory_derived_name(target.name),
+                    )
+            except BuildProfileError as e:
+                # Reaching here means a packaging problem, not a user mistake —
+                # the helper raises UsageError for everything the caller could
+                # have got wrong. Abort (exit 1) keeps that distinct from usage
+                # errors (exit 2).
+                _discard_created_root(target, created=created)
+                logger.error("✗ %s", e)
+                raise click.Abort() from e
+            except BaseException:
+                _discard_created_root(target, created=created)
+                raise
+            phase.step(f"source zone from preset {preset}")
 
-    name = materialized.profile_name
-    # Driven off the table rather than three calls written out: the set of
-    # files this command authors and the set the --force promise names are
-    # then the same object, not two lists that agree today.
-    for filename, build_text in WRITE_ONCE_FILES.items():
-        _write_if_absent(target / filename, build_text(name))
-    for relative in _STATE_DIRS:
-        (target / relative).mkdir(parents=True, exist_ok=True)
+            name = materialized.profile_name
+            # Driven off the table rather than three calls written out: the set of
+            # files this command authors and the set the --force promise names are
+            # then the same object, not two lists that agree today.
+            for filename, build_text in WRITE_ONCE_FILES.items():
+                _write_if_absent(target / filename, build_text(name))
+            for relative in _STATE_DIRS:
+                (target / relative).mkdir(parents=True, exist_ok=True)
 
-    # Emitted through the same engine `osprey scaffold ci` re-runs, so a repo
-    # created today and one re-scaffolded a year from now carry the same files.
-    deploy_files = _emit_ci(target, declared=materialized.deploy_declared)
-    git_note = _bootstrap_git(target, no_git=no_git)
+            # Emitted through the same engine `osprey scaffold ci` re-runs, so a
+            # repo created today and one re-scaffolded a year from now carry the
+            # same files.
+            deploy_files = _emit_ci(target, declared=materialized.deploy_declared)
+            phase.step("repo scaffolding")
 
-    _report(target, materialized, deploy_files, git_note)
+            # No step of its own: whatever git did or did not do, `_report`
+            # below says so in a sentence, and saying it twice in two shapes is
+            # exactly the duplication this feature is removing.
+            git_note = _bootstrap_git(target, no_git=no_git)
 
-    if start:
-        _chain_up(ctx, target, detached=detached, dev=dev)
+        _report(target, materialized, deploy_files, git_note)
+
+        if start:
+            _chain_up(ctx, target, detached=detached, dev=dev)
+
+        # The chain's single card, printed by the verb that owns the run: the
+        # `build` and `up` inside `_chain_up` find this reporter installed and
+        # leave it to here, so `init --up -d` ends with one card describing the
+        # deployment that is now running rather than three. An ATTACHED
+        # `init --up` never arrives — compose replaced this process.
+        print_summary_card(target, "running" if start else "created")
 
 
 def _write_if_absent(path: Path, text: str) -> bool:
@@ -1093,11 +1118,13 @@ def _report(
     for line in _ci_report(deploy_files, target):
         click.echo(line)
 
+    # What to READ and EDIT, only. The commands that follow are on the summary
+    # card this verb ends with, which is also the one place they are correct
+    # for both shapes of the verb: `init --up` has already run them.
     click.echo("\nNext steps:")
     click.echo(f"  1. cd {target.name}")
     click.echo("  2. Read README.md — it explains the four zones")
     click.echo("  3. Edit profile.yml and the files under data/")
-    click.echo("  4. osprey build && osprey up -d")
 
 
 def _zone_tree(repo_name: str, has_ci: bool) -> list[str]:

--- a/src/osprey/cli/main.py
+++ b/src/osprey/cli/main.py
@@ -5,8 +5,14 @@ commands under the `osprey` command namespace.
 """
 
 import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
 
 import click
+
+if TYPE_CHECKING:
+    from .phase_reporter import PhaseReporter
 
 # Ensure UTF-8 on Windows for Unicode CLI output
 if sys.platform == "win32":
@@ -212,6 +218,48 @@ def cli(ctx, verbose):
         # zero-argument, so the help is the menu — an interactive wrapper would
         # be a surface with nothing to wrap.
         click.echo(ctx.get_help())
+
+
+@contextmanager
+def lifecycle_reporter() -> Iterator["PhaseReporter"]:
+    """Install the phase reporter for the duration of one lifecycle verb.
+
+    Every lifecycle verb (``init``, ``build``, ``up``, ``restart``, ``down``,
+    ``reset``) opens this at entry. The verb that opens it OUTERMOST owns the
+    reporter: a verb that finds one already installed reuses it and installs
+    nothing, so ``init --up`` — which chains ``build`` and ``up`` through
+    ``ctx.invoke`` — reports as one continuous run rather than three, and does
+    it through the module-level handle instead of threading a reporter through
+    every signature.
+
+    "Already installed" is judged as "not the quiet default": the default is a
+    :class:`~osprey.cli.phase_reporter.NullReporter` with ``verbose`` False, and
+    that is the one shape no verb ever installs. Under the global ``--verbose``
+    the installed reporter is ``NullReporter(verbose=True)`` — verbose there is
+    not decoration, it is what :func:`~osprey.cli.phase_reporter.is_verbose`
+    reports to the capture helper, which streams its subprocesses instead of
+    spooling them.
+
+    The flag is read off the root context rather than taken as an argument,
+    because the verbs reach here three different ways — a plain invocation, a
+    ``ctx.invoke`` chain, and a direct call in a test — and only the context
+    knows about all three. ``build`` declares no ``pass_context`` at all.
+    """
+    from .phase_reporter import NullReporter, PhaseReporter, current_reporter, install_reporter
+
+    active = current_reporter()
+    if not (isinstance(active, NullReporter) and not active.verbose):
+        yield active
+        return
+
+    ctx = click.get_current_context(silent=True)
+    verbose = bool(ctx.find_root().params.get("verbose")) if ctx is not None else False
+    reporter: PhaseReporter = NullReporter(verbose=True) if verbose else PhaseReporter()
+    previous = install_reporter(reporter)
+    try:
+        yield reporter
+    finally:
+        install_reporter(previous)
 
 
 def main():

--- a/src/osprey/cli/phase_reporter.py
+++ b/src/osprey/cli/phase_reporter.py
@@ -1,0 +1,224 @@
+"""Plain-line phase reporting for the OSPREY lifecycle verbs.
+
+Lifecycle verbs (``init``, ``build``, ``up``, ``restart``, ``down``, ``reset``)
+report progress as a short sequence of phases rendered as plain sequential
+lines on stdout: ``→ title`` when a phase starts, ``  ✓ title (elapsed)`` when
+it ends, ``  · name`` for sub-steps. No Rich Live, no spinners, no in-place
+repainting -- TTY and non-TTY share one code path and only color differs.
+
+The active reporter is a module-level singleton (the same pattern as
+``styles.console``): verbs call :func:`install_reporter` at entry, helpers deep
+in the call stack reach it through :func:`current_reporter`. The default is a
+quiet :class:`NullReporter`, so helper calls are safe before any verb installs.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+from types import TracebackType
+
+from .styles import Styles, console
+
+
+def format_elapsed(seconds: float) -> str:
+    """Format an elapsed duration for a phase line."""
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes, secs = divmod(int(seconds), 60)
+    return f"{minutes}m{secs:02d}s"
+
+
+class Phase:
+    """One reported phase. Usable as a context manager or driven directly."""
+
+    def __init__(self, reporter: PhaseReporter, title: str) -> None:
+        self.title = title
+        self.spool: Path | None = None
+        self._reporter = reporter
+        self._start = time.monotonic()
+        self._lap = self._start
+        self._closed = False
+
+    @property
+    def elapsed(self) -> float:
+        """Seconds since the phase started."""
+        return time.monotonic() - self._start
+
+    def set_spool(self, path: Path | None) -> None:
+        """Record the spool file the phase is currently writing to."""
+        self.spool = path
+
+    def step(self, name: str) -> None:
+        """Print a sub-line under this phase.
+
+        The duration shown is the lap since the previous step (or since the
+        phase started), so a step reported after a unit of work names that
+        unit's own cost. Laps under 50ms print without a duration.
+        """
+        now = time.monotonic()
+        lap, self._lap = now - self._lap, now
+        suffix = f" ({format_elapsed(lap)})" if lap >= 0.05 else ""
+        self._reporter.emit(f"  · {name}{suffix}")
+
+    def done(self, note: str = "") -> None:
+        """Print the success line for this phase."""
+        if self._closed:
+            return
+        self._closed = True
+        suffix = f" — {note}" if note else ""
+        self._reporter.emit(
+            f"  ✓ {self.title} ({format_elapsed(self.elapsed)}){suffix}", style=Styles.SUCCESS
+        )
+
+    def fail(self, replay: Path | None = None) -> None:
+        """Print the failure line, replaying ``replay``'s content in full."""
+        if self._closed:
+            return
+        self._closed = True
+        self._reporter.emit(
+            f"  ✗ {self.title} ({format_elapsed(self.elapsed)})", style=Styles.ERROR
+        )
+        self._reporter.replay(replay)
+
+    def interrupted(self) -> None:
+        """Print one line naming the partial spool instead of replaying it."""
+        if self._closed:
+            return
+        self._closed = True
+        spool = f" — partial output: {self.spool}" if self.spool else ""
+        self._reporter.emit(
+            f"  ⚠ {self.title} interrupted ({format_elapsed(self.elapsed)}){spool}",
+            style=Styles.WARNING,
+        )
+
+    def __enter__(self) -> Phase:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Always close the phase, whatever left the block.
+
+        A clean ``SystemExit`` closes the phase as a success, not a failure. A
+        verb whose last act is to exit on a child's status (``down`` propagates
+        ``compose``'s exit code verbatim) leaves the block by raising
+        ``SystemExit(0)``, and treating that like any other exception would
+        print ``✗`` and replay the whole spool for a run that did exactly what
+        it was asked to. A non-zero (or non-numeric) code is a real failure and
+        still takes the failure path.
+        """
+        self._reporter.clear_phase(self)
+        if exc_type is None or (isinstance(exc, SystemExit) and not exc.code):
+            self.done()
+        elif issubclass(exc_type, KeyboardInterrupt):
+            self.interrupted()
+        else:
+            self.fail(self.spool)
+
+
+class PhaseReporter:
+    """Prints phase lines to stdout through the themed console."""
+
+    verbose = False
+
+    def __init__(self, *, color: bool | None = None) -> None:
+        # The console is force_terminal on win32, so ask stdout directly.
+        self.color = sys.stdout.isatty() if color is None else color
+        self._phase: Phase | None = None
+
+    def emit(self, text: str, style: str | None = None) -> None:
+        """Print one plain line -- styled only when stdout is a terminal."""
+        console.print(
+            text,
+            style=style if self.color else None,
+            markup=False,
+            highlight=False,
+            soft_wrap=True,
+        )
+
+    def phase(self, title: str) -> Phase:
+        """Start a phase, printing its opening line."""
+        self.emit(f"→ {title}", style=Styles.BOLD)
+        self._phase = Phase(self, title)
+        return self._phase
+
+    @property
+    def current_phase(self) -> Phase | None:
+        """The most recently started phase, if one is still open."""
+        return self._phase
+
+    def clear_phase(self, phase: Phase) -> None:
+        """Drop ``phase`` as the current one (no-op if it is not)."""
+        if self._phase is phase:
+            self._phase = None
+
+    def note_spool(self, path: Path | None) -> None:
+        """Record a spool path on the open phase, for interrupt reporting."""
+        if self._phase is not None:
+            self._phase.set_spool(path)
+
+    def replay(self, path: Path | None) -> None:
+        """Dump a spool file's content to stdout in full."""
+        if path is None:
+            return
+        self.emit(f"--- {path} ---")
+        try:
+            self.emit(Path(path).read_text(errors="replace").rstrip("\n"))
+        except OSError as exc:
+            self.emit(f"(could not read spool: {exc})")
+        self.emit("--- end ---")
+
+
+class NullReporter(PhaseReporter):
+    """No-op reporter installed under the global ``--verbose`` flag."""
+
+    def __init__(self, *, verbose: bool = False) -> None:
+        super().__init__(color=False)
+        self.verbose = verbose
+
+    def emit(self, text: str, style: str | None = None) -> None:
+        """Swallow the line -- verbose mode streams the real output instead."""
+
+    def replay(self, path: Path | None) -> None:
+        """Nothing to replay: the output already went to the terminal."""
+
+
+_reporter: PhaseReporter = NullReporter()
+
+
+def current_reporter() -> PhaseReporter:
+    """Return the installed reporter (a quiet :class:`NullReporter` default)."""
+    return _reporter
+
+
+def install_reporter(reporter: PhaseReporter) -> PhaseReporter:
+    """Install ``reporter`` as the active one and return the previous one."""
+    global _reporter
+    previous, _reporter = _reporter, reporter
+    return previous
+
+
+def is_verbose() -> bool:
+    """True when the verbs installed the reporter for global ``--verbose``."""
+    return _reporter.verbose
+
+
+def report_step(name: str) -> None:
+    """Report ``name`` as a sub-step of the open phase, if there is one.
+
+    The one helper every deploy site uses to hang a ``  · name`` line off the
+    verb's phase. Those sites run both under a lifecycle verb (which installs a
+    reporter and opens a phase) and from tests or library callers that never do,
+    so the line is conditional on there being a phase to hang it under.
+
+    Call it AFTER the work it names: :meth:`Phase.step` prints the lap since the
+    previous step, so a step reported afterwards carries that unit's own cost.
+    """
+    phase = current_reporter().current_phase
+    if phase is not None:
+        phase.step(name)

--- a/src/osprey/cli/reset_cmd.py
+++ b/src/osprey/cli/reset_cmd.py
@@ -99,44 +99,53 @@ def reset(repo: Path | None, dry_run: bool, assume_yes: bool, purge_audit: bool)
         reset_deployment,
     )
 
+    from .main import lifecycle_reporter
+
     repo_root = find_repo_root(repo)
 
-    try:
-        outcome = reset_deployment(
-            repo_root,
-            dry_run=dry_run,
-            assume_yes=assume_yes,
-            purge_audit=purge_audit,
-            emit=click.echo,
-        )
-    except ForeignCheckoutError as e:
-        # Shown verbatim rather than summarized: the message is already the whole
-        # explanation, and it is carefully scoped to what the labels actually
-        # prove. Rewording it here would be how a claim it does not make gets
-        # reintroduced.
-        raise click.ClickException(str(e)) from None
-    except KeyboardInterrupt:
-        # An interrupt AT THE PROMPT is handled inside reset_deployment, which
-        # can prove nothing ran and says so. Reaching here means the interrupt
-        # landed after the confirmation, mid-teardown — so this must not claim
-        # the deployment is untouched, because it very likely is not.
-        #
-        # It exits with the PARTIAL code rather than 1 for the same reason the
-        # partial-failure ending does: what a script needs from `$?` is the
-        # state on disk, and this path leaves exactly the state a stuck removal
-        # leaves. Reporting 1 here would tell a caller "nothing was touched"
-        # about a half-wiped deployment.
-        click.echo(
-            "Reset interrupted while it was removing things. It does not roll back, so "
-            "this deployment is in a partly-reset state. Re-run `osprey reset` to finish; "
-            "it re-reads what is actually there.",
-            err=True,
-        )
-        raise click.exceptions.Exit(PARTIAL_RESET_EXIT_CODE) from None
-    except RuntimeError as e:
-        # ClickException is deliberately NOT re-raised above this: it does not
-        # inherit from RuntimeError, so it already passes through untouched.
-        raise click.ClickException(str(e)) from None
+    # Installed, but not reported through: reset says what it is doing on its
+    # own `emit` callback, which is the plan an operator reads before confirming
+    # and the record of what actually went. The reporter is here for what reset
+    # reaches — the shared teardown helpers, which capture their subprocesses
+    # and need a reporter to report a failure to, and which must stream instead
+    # of spooling when `--verbose` was asked for.
+    with lifecycle_reporter():
+        try:
+            outcome = reset_deployment(
+                repo_root,
+                dry_run=dry_run,
+                assume_yes=assume_yes,
+                purge_audit=purge_audit,
+                emit=click.echo,
+            )
+        except ForeignCheckoutError as e:
+            # Shown verbatim rather than summarized: the message is already the
+            # whole explanation, and it is carefully scoped to what the labels
+            # actually prove. Rewording it here would be how a claim it does not
+            # make gets reintroduced.
+            raise click.ClickException(str(e)) from None
+        except KeyboardInterrupt:
+            # An interrupt AT THE PROMPT is handled inside reset_deployment, which
+            # can prove nothing ran and says so. Reaching here means the interrupt
+            # landed after the confirmation, mid-teardown — so this must not claim
+            # the deployment is untouched, because it very likely is not.
+            #
+            # It exits with the PARTIAL code rather than 1 for the same reason the
+            # partial-failure ending does: what a script needs from `$?` is the
+            # state on disk, and this path leaves exactly the state a stuck removal
+            # leaves. Reporting 1 here would tell a caller "nothing was touched"
+            # about a half-wiped deployment.
+            click.echo(
+                "Reset interrupted while it was removing things. It does not roll back, so "
+                "this deployment is in a partly-reset state. Re-run `osprey reset` to finish; "
+                "it re-reads what is actually there.",
+                err=True,
+            )
+            raise click.exceptions.Exit(PARTIAL_RESET_EXIT_CODE) from None
+        except RuntimeError as e:
+            # ClickException is deliberately NOT re-raised above this: it does not
+            # inherit from RuntimeError, so it already passes through untouched.
+            raise click.ClickException(str(e)) from None
 
     # The exit status is this verb's contract in machine-readable form: 0 says
     # the deployment is now what the plan described. Both non-zero endings have

--- a/src/osprey/cli/styles.py
+++ b/src/osprey/cli/styles.py
@@ -259,7 +259,7 @@ def _build_rich_theme(theme: ColorTheme) -> Theme:
     )
 
 
-def _build_questionary_style(theme: ColorTheme) -> QuestionaryStyle | None:
+def _build_questionary_style(theme: ColorTheme) -> "QuestionaryStyle | None":
     """Build a Questionary style from a ColorTheme.
 
     Args:
@@ -301,7 +301,7 @@ else:
     console = Console(theme=osprey_theme)
 
 
-def get_questionary_style() -> QuestionaryStyle | None:
+def get_questionary_style() -> "QuestionaryStyle | None":
     """Get the Questionary style for interactive prompts.
 
     Returns the current active theme's questionary style.

--- a/src/osprey/cli/summary_card.py
+++ b/src/osprey/cli/summary_card.py
@@ -1,0 +1,93 @@
+"""The closing summary card for the OSPREY lifecycle verbs.
+
+``init``, ``build``, ``up -d``, ``restart -d`` and ``down`` all end the same
+way: one short card saying which deployment this was, what state it is in now,
+where it answers, where the command output went, and which command comes next.
+One renderer for all five, so the five cannot describe the same deployment in
+five shapes.
+
+It prints through the installed phase reporter, after the last phase has
+closed, so it shares that module's plain-line path -- color only on a terminal,
+and nothing at all under the global ``--verbose``, where the real output was
+streamed instead of spooled. Attached (non-``-d``) starts print no card at all:
+``compose up`` replaces this process and the terminal belongs to the log stream.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from osprey.deployment.subprocess_capture import SPOOL_DIR
+from osprey.utils.logger import get_logger
+
+from .phase_reporter import NullReporter, current_reporter
+from .styles import Styles
+
+logger = get_logger("cli.summary_card")
+
+#: What to do next, per state. Only ``running`` is reachable-anywhere, so it is
+#: the only state whose card carries endpoints.
+_NEXT_STEPS = {
+    "created": "osprey build · osprey up -d",
+    "built": "osprey up -d · osprey status",
+    "running": "osprey status · osprey logs · osprey down",
+    "stopped": "osprey up -d · osprey status",
+}
+
+
+def owns_summary_card() -> bool:
+    """True when the calling verb is the outermost one, so the card is its own.
+
+    Asked BEFORE :func:`~osprey.cli.main.lifecycle_reporter`, and by the same
+    rule that decides who owns the reporter: the verb that still finds the quiet
+    default installed is the one about to install a reporter. A chained verb
+    (``init --up`` invokes ``build`` and ``up``) finds the outer verb's reporter
+    and leaves the card to it, so a chain prints one card at its end rather than
+    one per verb.
+    """
+    active = current_reporter()
+    return isinstance(active, NullReporter) and not active.verbose
+
+
+def format_summary_card(repo_root: Path | str, state: str) -> list[str]:
+    """Render the card for ``repo_root`` in ``state`` as plain lines.
+
+    :param repo_root: The deployment repo -- its directory name IS the
+        deployment's name, the same one the compose project carries
+    :param state: One of ``created``, ``built``, ``running``, ``stopped``
+    """
+    from osprey.deployment.deploy_summary import as_built_endpoint_entries
+
+    root = Path(repo_root)
+    rows = []
+    if state == "running":
+        # URLs only: a card is the "what now" surface, and the addresses someone
+        # can act on are the ones they can open. The full list, bare addresses
+        # and the not-configured facts included, is `osprey status`.
+        rows += [(s, a) for s, a in as_built_endpoint_entries(root) if a.startswith("http://")]
+    rows.append(("command output", str(root / SPOOL_DIR)))
+    rows.append(("next", _NEXT_STEPS.get(state, "osprey status")))
+
+    width = max(len(label) for label, _ in rows)
+    return [f"{root.name} — {state}"] + [
+        f"  {label.ljust(width)}   {value}" for label, value in rows
+    ]
+
+
+def print_summary_card(repo_root: Path | str, state: str) -> None:
+    """Print the card through the installed reporter; advisory, never raises.
+
+    A verb that has done its work has succeeded, and a card that cannot be
+    rendered -- an unreadable render, a compose file that moved -- must not turn
+    that into a failure.
+    """
+    try:
+        lines = format_summary_card(repo_root, state)
+    except Exception as exc:
+        logger.debug("Summary card skipped: %s", exc)
+        return
+    reporter = current_reporter()
+    reporter.emit("")
+    reporter.emit(lines[0], style=Styles.BOLD)
+    for line in lines[1:]:
+        reporter.emit(line)

--- a/src/osprey/cli/templates/claude_code.py
+++ b/src/osprey/cli/templates/claude_code.py
@@ -1136,7 +1136,7 @@ def create_claude_code_integration(
             if hook.is_file() and hook.suffix == ".py":
                 hook.chmod(hook.stat().st_mode | 0o755)
 
-    console.print(f"  [success]✓[/success] Created {files_created} Claude Code integration file(s)")
+    logger.debug("Created %s Claude Code integration file(s)", files_created)
 
 
 def check_user_owned_drift(

--- a/src/osprey/cli/templates/manager.py
+++ b/src/osprey/cli/templates/manager.py
@@ -1,5 +1,6 @@
 """TemplateManager facade: thin orchestrator delegating to submodules."""
 
+import logging
 import os
 import shutil
 from pathlib import Path
@@ -13,7 +14,6 @@ from osprey.build.build_tiers import (
     default_tier_for_mode,
     tier_mode_conflict,
 )
-from osprey.cli.styles import console
 from osprey.cli.templates import claude_code, manifest, scaffolding
 from osprey.cli.templates._rendering import render_template as _render_template
 from osprey.errors import BuildProfileError
@@ -21,6 +21,8 @@ from osprey.profiles.web_panels import BUILTIN_PANELS
 from osprey.utils.config import resolve_env_vars
 from osprey.utils.facility import resolve_facility_name
 from osprey.utils.workspace import repo_root_for_config
+
+logger = logging.getLogger("osprey.cli.templates")
 
 
 class TemplateManager:
@@ -342,9 +344,7 @@ class TemplateManager:
         if machine_data_src.exists():
             machine_data_dst = project_dir / "machine_data"
             shutil.copytree(machine_data_src, machine_data_dst, dirs_exist_ok=True)
-            console.print(
-                f"  [success]✓[/success] Copied machine data to [path]{machine_data_dst}[/path]"
-            )
+            logger.debug("Copied machine data to %s", machine_data_dst)
 
         # 6a'. Install the web-terminal persona baseline. base.md is
         # framework-layer, not bundle-layer: seeding requires it for ANY
@@ -353,9 +353,7 @@ class TemplateManager:
         context_src = self.template_root / "claude_code" / "web-terminal-context"
         context_dst = project_dir / "docker" / "web-terminal-context"
         shutil.copytree(context_src, context_dst, dirs_exist_ok=True)
-        console.print(
-            f"  [success]✓[/success] Installed web-terminal context to [path]{context_dst}[/path]"
-        )
+        logger.debug("Installed web-terminal context to %s", context_dst)
 
         # 6b. Flatten the preset's tier-routed channel DBs into the canonical
         # data/channel_databases/<paradigm>.json locations. Must run before the

--- a/src/osprey/cli/templates/scaffolding.py
+++ b/src/osprey/cli/templates/scaffolding.py
@@ -12,7 +12,6 @@ import logging
 import shutil
 from pathlib import Path
 
-from osprey.cli.styles import console
 from osprey.cli.templates._rendering import render_template
 
 logger = logging.getLogger("osprey.cli.templates")
@@ -301,10 +300,7 @@ def copy_template_data(
         dst_data = project_dir / "data"
         # dirs_exist_ok is defensive — no build path reaches here with data/ present.
         shutil.copytree(data_root, dst_data, dirs_exist_ok=True)
-        console.print(
-            f"  [success]✓[/success] Copied profile data files from "
-            f"[path]{data_root}[/path] to [path]{dst_data}[/path]"
-        )
+        logger.debug("Copied profile data files from %s to %s", data_root, dst_data)
         return
 
     app_template_dir = template_root / "apps" / data_bundle
@@ -317,9 +313,7 @@ def copy_template_data(
             _copy_data_tree(template_data_dir, dst_data, template_root, jinja_env, ctx)
         else:
             shutil.copytree(template_data_dir, dst_data, dirs_exist_ok=True)
-        console.print(
-            f"  [success]✓[/success] Copied template data files to [path]{dst_data}[/path]"
-        )
+        logger.debug("Copied template data files to %s", dst_data)
         return
 
     # Fallback: scan for data/ directories inside template subdirectories
@@ -344,9 +338,7 @@ def copy_template_data(
                         elif item.is_file():
                             dst_item.parent.mkdir(parents=True, exist_ok=True)
                             shutil.copy2(item, dst_item)
-            console.print(
-                f"  [success]✓[/success] Copied template data files to [path]{dst_data}[/path]"
-            )
+            logger.debug("Copied template data files to %s", dst_data)
             return
 
 
@@ -443,10 +435,11 @@ def materialize_tier_artifacts(project_dir: Path, tier: int, channel_finder_mode
     if queries_src_root.exists():
         shutil.rmtree(queries_src_root)
 
-    console.print(
-        f"  [success]✓[/success] Materialized tier{tier} artifacts "
-        f"(channel DB + queries) for {sorted(paradigms)!r} to "
-        f"[path]{project_dir / 'data'}[/path]"
+    logger.debug(
+        "Materialized tier%s artifacts (channel DB + queries) for %r to %s",
+        tier,
+        sorted(paradigms),
+        project_dir / "data",
     )
 
 
@@ -474,7 +467,4 @@ def prune_csv_build_artifacts(project_dir: Path, channel_finder_mode: str) -> No
         return
 
     shutil.rmtree(raw_dir)
-    console.print(
-        f"  [success]✓[/success] Removed [path]{raw_dir}[/path] "
-        f"(no CSV build path for {channel_finder_mode!r} paradigm)"
-    )
+    logger.debug("Removed %s (no CSV build path for %r paradigm)", raw_dir, channel_finder_mode)

--- a/src/osprey/deployment/compose_generator.py
+++ b/src/osprey/deployment/compose_generator.py
@@ -16,13 +16,14 @@ because its wrong answer is an empty list rather than an error.
 import os
 import re
 import shutil
-import subprocess
 from pathlib import Path, PurePosixPath
 
 import yaml
 from jinja2 import Environment, FileSystemLoader
 
+from osprey.cli.phase_reporter import report_step
 from osprey.deployment.runtime_helper import get_runtime_command, runtime_env
+from osprey.deployment.subprocess_capture import run_captured
 
 # The dev-wheel build, per-process cache, and staging-copy helpers live in
 # wheel_build; the copy helper is invoked here by _stage_dev_wheel_for_context,
@@ -593,7 +594,9 @@ def _stage_dev_wheel_for_context(out_dir, dev_mode):
     :rtype: bool
     """
     if not dev_mode:
-        logger.info("Production mode: Containers will install osprey from PyPI")
+        # DEBUG, not INFO — fires once per service build context on every
+        # production build, restating a flag the operator already passed.
+        logger.debug("Production mode: Containers will install osprey from PyPI")
         return False
     if not os.path.isfile(os.path.join(out_dir, "Dockerfile")):
         # Routine and correct: pure-image services (postgresql, openobserve)
@@ -1181,14 +1184,23 @@ def clean_deployment(compose_files, config=None):
     cmd_down.extend(["down", "--volumes", "--remove-orphans"])
 
     logger.info(f"Running: {' '.join(cmd_down)}")
-    subprocess.run(cmd_down, env=run_env)
+    report_step("Removing containers and volumes")
+    # No check: a clean over a deployment that was never up exits non-zero, and
+    # that has always been tolerated here. Capturing must not turn it into a
+    # failure — only move the output off the terminal.
+    run_captured(
+        cmd_down, env=run_env, spool_name="compose-clean-down", repo_root=repo_root, check=False
+    )
 
     # Remove images built by the compose files
     cmd_rmi = compose_base_cmd(get_runtime_command(config), compose_files, repo_root, env_file_args)
     cmd_rmi.extend(["down", "--rmi", "all"])
 
     logger.info(f"Running: {' '.join(cmd_rmi)}")
-    subprocess.run(cmd_rmi, env=run_env)
+    report_step("Removing images")
+    run_captured(
+        cmd_rmi, env=run_env, spool_name="compose-clean-rmi", repo_root=repo_root, check=False
+    )
 
     logger.success("Cleanup completed")
 

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -7,6 +7,7 @@ Docker or Podman compose.
 import os
 import re
 import subprocess
+import sys
 import tempfile
 import time
 from collections.abc import Mapping
@@ -15,6 +16,7 @@ from pathlib import Path
 
 import yaml
 
+from osprey.cli.phase_reporter import report_step as _report_step
 from osprey.deployment.compose_generator import (
     COMPOSE_ENV_FILENAME,
     REPO_ID_LABEL,
@@ -50,6 +52,7 @@ from osprey.deployment.service_tokens import (
     _validate_var,
 )
 from osprey.deployment.staleness import BUILD_DIRNAME, warn_if_project_stale
+from osprey.deployment.subprocess_capture import run_captured
 from osprey.deployment.web_terminals.provision import (
     deploy_down_web_terminals,
     deploy_up_web_terminals,
@@ -1284,9 +1287,15 @@ def _build_project_image(
 
     try:
         cmd = _project_image_build_cmd(config, runtime, project_root, dev_mode and wheel_staged)
-        logger.key_info("Building dispatch worker project image %s:", project_image)
+        logger.debug("Building dispatch worker project image %s:", project_image)
         logger.debug("Running command:\n    %s", " ".join(cmd))
-        subprocess.run(cmd, env=env, check=True)
+        run_captured(
+            cmd,
+            env=env,
+            spool_name="build-project-image",
+            repo_root=resolve_repo_root(config),
+        )
+        _report_step(f"project image {project_image}")
     finally:
         # Remove BOTH staged artifacts (wheel + requirements manifest) so
         # neither can poison a later non-dev build in this context.
@@ -1819,8 +1828,13 @@ def _wait_for_archiver_store(
 def _seed_progress_reporter():
     """A :func:`~osprey.simulation.archiver_seed.seed_base` progress callback.
 
-    Rate-limited rather than per-chunk: the point is to prove a multi-minute step
-    is moving, not to narrate every insert.
+    Each firing becomes a step line under the verb's open phase, so a first
+    deploy's multi-minute seed reports as it goes instead of stalling silently.
+    Rate-limited rather than per-chunk: the callback fires once per chunk, which
+    on a large archive is many times a second, and the point is to prove the step
+    is moving — not to narrate every insert. The channel count and the seeded
+    span are fixed for the run and already announced before seeding starts, so
+    the line carries the one quantity that grows.
     """
     last = [time.monotonic()]
 
@@ -1829,9 +1843,9 @@ def _seed_progress_reporter():
         if now - last[0] < _ARCHIVER_PROGRESS_INTERVAL_S:
             return
         last[0] = now
-        logger.info(
-            f"  seeding archive: {seed_report.documents:,} documents written "
-            f"({seed_report.elapsed_s:.0f}s elapsed)"
+        _report_step(
+            f"seeding archive: {seed_report.documents:,} documents written "
+            f"across {seed_report.channels:,} channels"
         )
 
     return report
@@ -1937,8 +1951,9 @@ def _stage_archiver_store(config, compose_files, env, project_dir, *, keep_base=
     )
 
     up_cmd = base_cmd + ["up", "-d", _ARCHIVER_STORE_SERVICE]
-    logger.info(f"Running command:\n    {' '.join(up_cmd)}")
-    subprocess.run(up_cmd, env=run_env, check=True)
+    logger.debug(f"Running command:\n    {' '.join(up_cmd)}")
+    run_captured(up_cmd, env=run_env, spool_name="archiver-store-up", repo_root=project_dir)
+    _report_step("archiver store started")
 
     # Assembled while the store boots, and before the health budget starts: this
     # reads a manifest and a machine model off disk, and charging that time
@@ -1978,8 +1993,15 @@ def _stage_archiver_store(config, compose_files, env, project_dir, *, keep_base=
 
         if _ARCHIVER_RECORDER_DEPLOY_NAME in (config.get("deployed_services") or []):
             stop_cmd = base_cmd + ["stop", _ARCHIVER_RECORDER_SERVICE]
-            logger.info(f"Running command:\n    {' '.join(stop_cmd)}")
-            quiesce = subprocess.run(stop_cmd, env=run_env)
+            logger.debug(f"Running command:\n    {' '.join(stop_cmd)}")
+            quiesce = run_captured(
+                stop_cmd,
+                env=run_env,
+                spool_name="archiver-recorder-stop",
+                repo_root=project_dir,
+                check=False,
+            )
+            _report_step("archiver recorder quiesced")
             # Not fatal — the rebuild is still the right thing to do — but a
             # recorder that would not stop is writing into the collection about
             # to be dropped, so the breach of the quiesce invariant has to be
@@ -2282,7 +2304,8 @@ def _start_stack(
     # of clean/rebuild. Best-effort: if it fails, `up` surfaces the real error.
     rm_cmd = base_cmd + ["rm", "-f"]
     logger.debug(f"Running command:\n    {' '.join(rm_cmd)}")
-    subprocess.run(rm_cmd, env=run_env)
+    run_captured(rm_cmd, env=run_env, spool_name="compose-rm", repo_root=repo_root, check=False)
+    _report_step("cleared stopped containers")
 
     if dev_mode:
         # `osprey up --dev` re-bakes the local osprey checkout into a fresh
@@ -2295,7 +2318,8 @@ def _start_stack(
         # service that has no published upstream tag to pull.
         build_cmd = base_cmd + ["build"]
         logger.debug(f"Running command:\n    {' '.join(build_cmd)}")
-        subprocess.run(build_cmd, env=run_env, check=True)
+        run_captured(build_cmd, env=run_env, spool_name="compose-build", repo_root=repo_root)
+        _report_step("service images built")
 
     # --remove-orphans reconciles away containers whose service left the
     # config since the last deploy (including a formerly-enabled web-terminal
@@ -2311,7 +2335,8 @@ def _start_stack(
 
     logger.debug(f"Running command:\n    {' '.join(cmd)}")
     if detached:
-        subprocess.run(cmd, env=run_env, check=True)
+        run_captured(cmd, env=run_env, spool_name="compose-up", repo_root=repo_root)
+        _report_step("containers started")
         log_endpoint_summary(config, compose_files)
     else:
         # execvpe replaces this process, so the summary must print first —
@@ -2794,6 +2819,11 @@ def _down_by_label(config: dict | None, repo_root: Path) -> None:
                 f"{(result.stderr or '').strip()}"
             )
 
+    # The recovery path reports what it did for the same reason the compose path
+    # does: without it, a `down` that fell back to labels closes its phase with a
+    # bare ✓ and never says that anything was found, let alone how much.
+    _report_step(f"removed {len(container_ids)} labelled container(s)")
+
 
 def down_deployment(repo_root: Path | str) -> None:
     """Stop a deployment repo's stack, keeping every volume.
@@ -2852,12 +2882,26 @@ def down_deployment(repo_root: Path | str) -> None:
     cmd.append("down")
 
     logger.debug(f"Running command:\n    {' '.join(cmd)}")
-    result = subprocess.run(cmd, env=runtime_env(config, os.environ.copy()), check=False)
+    # Captured, not streamed: the phase line this runs under is only readable if
+    # compose's own output goes to the spool instead of the same terminal. The
+    # pinned COMPOSE_PROJECT_NAME reaches compose through `env=` — unpinned,
+    # `down` targets the shared "services" project rather than this deploy's.
+    result = run_captured(
+        cmd,
+        env=runtime_env(config, os.environ.copy()),
+        spool_name="compose-down",
+        repo_root=repo_root,
+        check=False,
+    )
     if getattr(result, "returncode", 0):
+        # check=False and raise here, rather than letting run_captured raise:
+        # a failed `down` has a specific consequence to state. The reporter
+        # already holds the spool path, so the failure line replays it.
         raise RuntimeError(
             f"`compose down` failed (exit {result.returncode}) — this deployment's "
-            "containers may still be running. The output above is the runtime's own."
+            "containers may still be running."
         )
+    _report_step("containers stopped")
 
 
 def restart_deployment(
@@ -2923,11 +2967,12 @@ def deploy_down(config_path, dev_mode=False):
     torn down first via its own compose invocation
     (:func:`osprey.deployment.web_terminals.provision.deploy_down_web_terminals`):
     the two stacks are separate invocations of one pinned base, and the
-    services ``down`` execvpe-replaces this process, so the web ``down`` must
-    happen before it.
+    services ``down`` ends this process, so the web ``down`` must happen
+    before it.
 
     :param config_path: Path to the configuration file
     :type config_path: str
+    :raises SystemExit: Always — with the ``compose down`` child's own exit code.
     """
     config = load_project_config(config_path, wrap_errors=True)
     repo_root = resolve_repo_root(config, config_path)
@@ -2962,10 +3007,24 @@ def deploy_down(config_path, dev_mode=False):
     cmd.append("down")
 
     logger.debug(f"Running command:\n    {' '.join(cmd)}")
-    # execvpe (not execvp) so the COMPOSE_PROJECT_NAME pin reaches compose:
-    # `down` must target the same project `up` created, or it either misses this
-    # deploy's containers or (unpinned) tears down the shared "services" project.
-    os.execvpe(cmd[0], cmd, runtime_env(config, os.environ.copy()))
+    # The COMPOSE_PROJECT_NAME pin must reach compose: `down` must target the
+    # same project `up` created, or it either misses this deploy's containers
+    # or (unpinned) tears down the shared "services" project. That pin is why
+    # this used to `execvpe` rather than `execvp`; the captured run carries the
+    # same environment through `env=`.
+    run_env = runtime_env(config, os.environ.copy())
+    # check=False, then exit on the child's own code: `down` is the last thing
+    # this process does, and propagating the code verbatim keeps the exit
+    # status callers see identical to the exec'd child's.
+    proc = run_captured(
+        cmd, env=run_env, spool_name="compose-down", repo_root=repo_root, check=False
+    )
+    if proc.returncode == 0:
+        _report_step("containers stopped")
+    # A signal-killed child reports a NEGATIVE returncode, which sys.exit would
+    # mask to its low byte (-15 -> 241). Shells spell "killed by signal N" as
+    # 128+N, and 128+N is exactly what the exec'd child's own status used to be.
+    sys.exit(proc.returncode if proc.returncode >= 0 else 128 - proc.returncode)
 
 
 def deploy_restart(config_path, detached=False, expose_network=False):

--- a/src/osprey/deployment/deploy_summary.py
+++ b/src/osprey/deployment/deploy_summary.py
@@ -10,6 +10,8 @@ listens on the landing port" from a silent absence into a stated fact.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from osprey.deployment.compose_generator import resolve_project_name
 from osprey.deployment.host_ports import _WILDCARD_HOSTS, parse_host_port_bindings
 from osprey.utils.logger import get_logger
@@ -28,20 +30,20 @@ _HTTP_SERVICES = {
 }
 
 
-def format_endpoint_summary(config: dict, compose_files: list[str]) -> str:
-    """Render where a deployment's services are reachable, as its render declares it.
+def endpoint_entries(config: dict, compose_files: list[str]) -> list[tuple[str, str]]:
+    """Where a deployment's services are reachable, as ``(service, address)`` pairs.
 
-    The single derivation of "what answers where", so the summary a deploy
-    prints when it finishes and the one a report prints later cannot describe
-    the same deployment differently. It says where a service *would* answer —
-    the published ports are read out of the rendered compose files, not probed.
+    The single derivation of "what answers where": the text summary below lays
+    these out, and the closing summary card takes the URLs off the same list, so
+    no reader of a deployment can describe it differently from another. It says
+    where a service *would* answer — the published ports are read out of the
+    rendered compose files, not probed.
 
     :param config: Loaded configuration dictionary
     :param compose_files: Rendered compose file paths, spelled absolutely or
         resolvable from the working directory — they are opened here
-    :return: Multi-line summary text
     """
-    lines = [f"Service endpoints ({resolve_project_name(config)}):"]
+    entries: list[tuple[str, str]] = []
 
     try:
         bindings = parse_host_port_bindings(compose_files)
@@ -52,15 +54,57 @@ def format_endpoint_summary(config: dict, compose_files: list[str]) -> str:
         address = f"{host}:{binding.host_port}"
         if binding.service in _HTTP_SERVICES:
             address = f"http://{address}"
-        lines.append(f"  {binding.service:<20} {address}")
+        entries.append((binding.service, address))
 
     web_terminals = (config.get("modules") or {}).get("web_terminals") or {}
     nginx_port = web_terminals.get("nginx_port")
     if web_terminals.get("enabled") and isinstance(nginx_port, int):
-        lines.append(f"  {'web terminal':<20} http://127.0.0.1:{nginx_port}  (landing page)")
+        entries.append(("web terminal", f"http://127.0.0.1:{nginx_port}  (landing page)"))
     else:
-        lines.append(f"  {'web terminal':<20} (not configured in this project)")
+        entries.append(("web terminal", "(not configured in this project)"))
 
+    return entries
+
+
+def as_built_endpoint_entries(repo_root: Path | str) -> list[tuple[str, str]]:
+    """The endpoint entries of the deployment ``repo_root`` has BUILT.
+
+    The same two facts every other reader of a deployment starts from — the
+    rendered ``build/config.yml`` and the compose files it names — so a caller
+    holding nothing but the repo (the summary card at the end of a verb) reaches
+    the same answer as one that was handed the config. A repo with nothing
+    rendered has no endpoints to declare and answers with an empty list.
+
+    Compose paths come back relative to the repo root and are anchored on it
+    here, because :func:`endpoint_entries` opens them itself.
+    """
+    from osprey.deployment.container_lifecycle import as_built_compose_files, as_built_config_path
+    from osprey.utils.config import load_project_config
+
+    root = Path(repo_root)
+    config_path = as_built_config_path(root)
+    if not config_path.is_file():
+        return []
+    config = load_project_config(str(config_path), wrap_errors=True)
+    files = [
+        str(path if path.is_absolute() else root / path)
+        for path in (Path(name) for name in as_built_compose_files(config, root))
+    ]
+    return endpoint_entries(config, files)
+
+
+def format_endpoint_summary(config: dict, compose_files: list[str]) -> str:
+    """Render :func:`endpoint_entries` as the text block a deploy or report prints.
+
+    :param config: Loaded configuration dictionary
+    :param compose_files: Rendered compose file paths, spelled absolutely or
+        resolvable from the working directory — they are opened here
+    :return: Multi-line summary text
+    """
+    lines = [f"Service endpoints ({resolve_project_name(config)}):"]
+    lines += [
+        f"  {service:<20} {address}" for service, address in endpoint_entries(config, compose_files)
+    ]
     return "\n".join(lines)
 
 

--- a/src/osprey/deployment/errors.py
+++ b/src/osprey/deployment/errors.py
@@ -14,6 +14,27 @@ class DeploymentError(Exception):
     """Base class for deployment failures."""
 
 
+class CapturedProcessError(DeploymentError):
+    """A captured child process exited non-zero.
+
+    Carries the ``spool_path`` holding that process's full output so the verb's
+    handler can replay it beneath the failed phase line. In verbose mode there
+    is no spool — the output already went to the terminal — and ``spool_path``
+    is ``None``.
+
+    This replaces :class:`subprocess.CalledProcessError` for runs made through
+    :func:`osprey.deployment.subprocess_capture.run_captured`, so callers have
+    one exception type to catch whichever mode they ran in.
+    """
+
+    def __init__(self, cmd: Sequence[str], returncode: int, spool_path: Path | None = None) -> None:
+        self.cmd = list(cmd)
+        self.returncode = returncode
+        self.spool_path = spool_path
+        where = f" (output: {spool_path})" if spool_path is not None else ""
+        super().__init__(f"Command '{' '.join(self.cmd)}' exited {returncode}{where}")
+
+
 class ComposeInterpolationError(DeploymentError):
     """A secret bound for a compose ``env_file:`` contains ``$``.
 

--- a/src/osprey/deployment/subprocess_capture.py
+++ b/src/osprey/deployment/subprocess_capture.py
@@ -1,0 +1,173 @@
+"""Capture a child process's output to a spool file instead of the terminal.
+
+The lifecycle verbs report progress as a handful of phase lines (see
+:mod:`osprey.cli.phase_reporter`). That reporting is only readable if the
+subprocesses underneath it — image builds, compose invocations — stop writing
+their own thousands of lines to the same terminal. :func:`run_captured` is the
+one seam that makes that true: the child's stdout and stderr go to
+``<repo>/var/logs/<spool_name>-<timestamp>.log`` as a single merged stream, and
+the file is named on the failure path so nothing is lost.
+
+Under the global ``--verbose`` flag the helper is a pass-through: the child
+inherits this process's stdio and streams straight to the terminal, with no
+redirection kwargs at all. Verbosity is read from the reporter's module-level
+singleton rather than threaded through every caller, so the two surfaces cannot
+disagree about which mode a run is in.
+
+The default reporter is a quiet ``NullReporter(verbose=False)``, so calls made
+before a verb installs a reporter still capture. That is deliberate: capturing
+is the safe default, and the spool path is reported on failure either way.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from osprey.cli.phase_reporter import current_reporter, is_verbose
+from osprey.deployment.errors import CapturedProcessError
+from osprey.utils.logger import get_logger
+
+logger = get_logger("deployment.capture")
+
+#: Spool directory, relative to the deployment repo root.
+SPOOL_DIR = Path("var") / "logs"
+
+#: How many spool files survive a prune. Older ones are removed at entry, so a
+#: long-lived deployment repo keeps the recent runs without growing unbounded.
+SPOOL_RETENTION = 20
+
+
+class CapturedProcess(subprocess.CompletedProcess[bytes]):
+    """A finished captured run, naming the file its output went to.
+
+    A plain :class:`subprocess.CompletedProcess` plus ``spool_path``: the spool
+    this run's output was written to, or ``None`` in verbose mode where it went
+    straight to the terminal. Declaring it as a type rather than setting the
+    attribute dynamically is what lets a caller read ``result.spool_path``
+    without a type checker rejecting it.
+
+    ``stdout``/``stderr`` stay ``None`` for a captured run — that output is in
+    the spool file, not in memory — but the constructor accepts them so this
+    remains substitutable for its base class.
+    """
+
+    def __init__(
+        self,
+        args: Sequence[str] | str,
+        returncode: int,
+        stdout: bytes | None = None,
+        stderr: bytes | None = None,
+        *,
+        spool_path: Path | None = None,
+    ) -> None:
+        super().__init__(args, returncode, stdout, stderr)
+        self.spool_path = spool_path
+
+
+def _prune_spools(spool_dir: Path, keep: int = SPOOL_RETENTION) -> None:
+    """Delete all but the newest ``keep`` spool files, best-effort.
+
+    Retention is a housekeeping nicety; a directory that cannot be read or an
+    entry that cannot be removed must never take down the deploy that was about
+    to run, so every failure here is a debug line and nothing more.
+    """
+    try:
+        existing = sorted(spool_dir.glob("*.log"), key=lambda p: p.stat().st_mtime)
+    except OSError as exc:  # pragma: no cover - depends on filesystem state
+        logger.debug("Could not list spool directory %s: %s", spool_dir, exc)
+        return
+    for stale in existing[: max(0, len(existing) - keep)]:
+        try:
+            stale.unlink()
+        except OSError as exc:  # pragma: no cover - depends on filesystem state
+            logger.debug("Could not prune spool %s: %s", stale, exc)
+
+
+def _spool_path(spool_dir: Path, spool_name: str) -> Path:
+    """Return an unused spool path for ``spool_name`` in ``spool_dir``.
+
+    The timestamp sorts lexicographically, which is what makes the directory
+    listing readable. Two runs can still land in the same second — a compose
+    ``rm`` followed immediately by a build — so the name takes a numeric suffix
+    until it is free rather than overwriting the earlier run's output.
+    """
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    candidate = spool_dir / f"{spool_name}-{stamp}.log"
+    suffix = 1
+    while candidate.exists():
+        suffix += 1
+        candidate = spool_dir / f"{spool_name}-{stamp}-{suffix}.log"
+    return candidate
+
+
+def run_captured(
+    cmd: Sequence[str],
+    *,
+    env: Mapping[str, str] | None = None,
+    cwd: Path | str | None = None,
+    spool_name: str,
+    repo_root: Path | str | None = None,
+    check: bool = True,
+) -> CapturedProcess:
+    """Run ``cmd``, spooling its merged output to ``<repo>/var/logs/``.
+
+    :param cmd: The argv to run. Passed through unchanged in both modes.
+    :param env: Environment for the child, as for :func:`subprocess.run`.
+    :param cwd: Working directory for the child, as for :func:`subprocess.run`.
+        Unrelated to ``repo_root``: a scaffolded script is run from the project
+        root so its own relative paths resolve, while its output still spools
+        under the deployment repo. Forwarded in both modes, so a run behaves
+        the same way under ``--verbose``.
+    :param spool_name: Descriptive stem for the spool file (``"build-worker"``).
+    :param repo_root: Deployment repo the ``var/logs/`` directory hangs off.
+        Callers already hold this (``resolve_repo_root(config)``); ``None``
+        means the current directory, the same default the compose ``--env-file``
+        helpers use. No repo discovery happens here.
+    :param check: Raise :class:`CapturedProcessError` on a non-zero exit.
+    :returns: A :class:`CapturedProcess`, whose ``spool_path`` is the file this
+        run's output went to, or ``None`` in verbose mode.
+        ``stdout``/``stderr`` are ``None`` — the output is in that file (or on
+        the terminal). A ``check=False`` caller that wants to point at the
+        output reads it from there; the reporter's copy only covers runs made
+        while a phase is open.
+    :raises CapturedProcessError: ``check`` is set and the child exited
+        non-zero. The exception carries the spool path.
+
+    Under ``--verbose`` the child inherits this process's stdio: same argv, no
+    redirection at all, so long-running builds stream live.
+    """
+    if is_verbose():
+        # Spool-less in both senses: no file was written, and the result says so
+        # explicitly, so a caller can read ``spool_path`` unconditionally.
+        completed = subprocess.run(cmd, env=env, cwd=cwd)
+        if check and completed.returncode != 0:
+            raise CapturedProcessError(cmd, completed.returncode)
+        return CapturedProcess(cmd, completed.returncode)
+
+    spool_dir = Path(repo_root or Path.cwd()) / SPOOL_DIR
+    spool_dir.mkdir(parents=True, exist_ok=True)
+    _prune_spools(spool_dir)
+    spool_path = _spool_path(spool_dir, spool_name)
+
+    logger.debug("Capturing %s output to %s", spool_name, spool_path)
+    with open(spool_path, "wb") as spool:
+        # The reporter keeps the path for the whole phase, not just this call:
+        # an interrupt during the child needs to name the partial output.
+        current_reporter().note_spool(spool_path)
+        # stderr into the same handle, not a second file — a build's errors are
+        # only legible interleaved with the step they interrupted.
+        completed = subprocess.run(cmd, env=env, cwd=cwd, stdout=spool, stderr=subprocess.STDOUT)
+
+    if check and completed.returncode != 0:
+        raise CapturedProcessError(cmd, completed.returncode, spool_path)
+
+    # The spool goes on the result, not only on the reporter: an advisory caller
+    # that does not raise still has to be able to name the file its output went
+    # to, and it may be running with no phase open at all.
+    return CapturedProcess(cmd, completed.returncode, spool_path=spool_path)
+
+
+__all__ = ["SPOOL_DIR", "SPOOL_RETENTION", "CapturedProcess", "run_captured"]

--- a/src/osprey/deployment/web_terminals/lifecycle.py
+++ b/src/osprey/deployment/web_terminals/lifecycle.py
@@ -84,6 +84,7 @@ from osprey.deployment.compose_generator import (
     resolve_repo_root,
     resolve_user_volume_names,
 )
+from osprey.deployment.errors import CapturedProcessError
 from osprey.deployment.runtime_helper import (
     get_runtime_command,
     runtime_env,
@@ -693,7 +694,7 @@ def _reconcile_auth_after_user_removal(
             runtime_env(config, ignore_orphans=True),
         )
 
-    recreate_error: OSError | subprocess.CalledProcessError | None = None
+    recreate_error: OSError | subprocess.CalledProcessError | CapturedProcessError | None = None
     # The recreate runs on a PARTIAL purge (see above) but not on one that
     # removed nothing: with no change to `.env.auth` there is nothing to put
     # into force — a recreate would re-read the file with the surviving hash
@@ -701,7 +702,9 @@ def _reconcile_auth_after_user_removal(
     try:
         if purged or (rerendered and purge_error is None):
             force_recreate_auth_sidecar(config, repo_root=repo_root)
-    except (OSError, subprocess.CalledProcessError) as exc:
+    # The recreate spools its compose output, so it raises CapturedProcessError;
+    # CalledProcessError stays in the tuple for any path that still raises it.
+    except (OSError, subprocess.CalledProcessError, CapturedProcessError) as exc:
         recreate_error = exc
 
     # A surviving credential outranks an unreconciled sidecar: one is an open
@@ -904,7 +907,9 @@ def rotate_user_password(config_path: str | Path, user: str, password: str) -> N
 
     try:
         force_recreate_auth_sidecar(config, repo_root=repo_root)
-    except subprocess.CalledProcessError as exc:
+    except (subprocess.CalledProcessError, CapturedProcessError) as exc:
+        # The recreate spools its compose output (CapturedProcessError);
+        # CalledProcessError stays for any path that still raises it.
         # The hash is ALREADY stored, so this is not "the rotation failed" — it
         # is the mirror image of the write-failure case above. Left to
         # propagate, the CLI's generic handler prints "Deployment failed" over a

--- a/src/osprey/deployment/web_terminals/persona_images.py
+++ b/src/osprey/deployment/web_terminals/persona_images.py
@@ -12,16 +12,18 @@ registry-mode deploys never enter this module.
 
 import os
 import posixpath
-import subprocess
 from pathlib import Path
 from typing import cast
 
 from osprey.build.claude_code_resolver import load_provider_spec
+from osprey.cli.phase_reporter import report_step as _report_step
 from osprey.deployment.compose_generator import (
     _copy_local_framework_for_override,
     resolve_project_name,
+    resolve_repo_root,
 )
 from osprey.deployment.runtime_helper import get_runtime_command
+from osprey.deployment.subprocess_capture import run_captured
 from osprey.deployment.web_terminals.personas import effective_image_source
 from osprey.deployment.wheel_build import _staged_dev_artifact_paths
 from osprey.utils.config import ConfigBuilder
@@ -686,6 +688,8 @@ def build_persona_images(
 
     runtime = get_runtime_command(config)[0]
     project_label = resolve_project_name(config)
+    # The deployment repo whose var/logs/ takes each build's spooled output.
+    repo_root = resolve_repo_root(config)
 
     for unit in referenced:
         persona_name = unit["persona"]
@@ -724,7 +728,16 @@ def build_persona_images(
             )
             logger.key_info("Building persona image %s-%s:local:", project, persona_name)
             logger.debug("Running command:\n    %s", " ".join(cmd))
-            subprocess.run(cmd, env=env, check=True)
+            run_captured(
+                cmd,
+                env=env,
+                spool_name=f"build-persona-{project}-{persona_name}",
+                repo_root=repo_root,
+            )
+            # One line per image, after its own build: the slowest step of a
+            # local-mode deploy, and the only progress an operator gets while
+            # a handful of multi-minute builds run one after another.
+            _report_step(f"persona image {project}-{persona_name}:local")
         finally:
             # Remove BOTH staged artifacts (wheel + requirements manifest) so
             # neither can poison a later non-dev build in this context.

--- a/src/osprey/deployment/web_terminals/postup_hooks.py
+++ b/src/osprey/deployment/web_terminals/postup_hooks.py
@@ -16,7 +16,10 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+from osprey.cli.phase_reporter import report_step as _report_step
+from osprey.deployment.compose_generator import resolve_repo_root
 from osprey.deployment.runtime_helper import get_runtime_command
+from osprey.deployment.subprocess_capture import run_captured
 from osprey.utils.logger import get_logger
 
 logger = get_logger("deployment.lifecycle")
@@ -119,11 +122,11 @@ def run_verify_script(project_root: str, run_env: dict[str, str]) -> None:
     exit code it reports either way, so a site-customized copy that doesn't
     honor that convention still can never fail ``osprey up``: this
     step runs after compose already reported success, so a nonzero exit is a
-    signal to look closer, not evidence the deploy failed. Output streams
-    straight to the operator's terminal (stdout/stderr are inherited, not
-    captured) exactly like every other compose subprocess call in this
-    module, so the health report appears live rather than being buffered and
-    dumped at the end.
+    signal to look closer, not evidence the deploy failed. The script's output
+    is spooled rather than streamed, exactly like every other child on this
+    path: the deploy reports it as one sub-step, and a non-zero exit names the
+    spool file holding the whole health report. Under ``--verbose`` it streams
+    to the terminal instead, like every other captured run.
 
     :param project_root: The project root whose ``scripts/verify.sh`` (if
         any) to run; also the script's working directory, so its own
@@ -140,19 +143,37 @@ def run_verify_script(project_root: str, run_env: dict[str, str]) -> None:
 
     logger.key_info("Running post-up smoke check: %s", verify_path)
     try:
-        result = subprocess.run(["bash", str(verify_path)], cwd=project_root, env=run_env)
+        # check=False: the exit code is advisory (see above), so a site-
+        # customized script that exits non-zero must not raise from here.
+        # cwd is the project root and repo_root is where the output spools —
+        # the same directory here, but they answer different questions.
+        result = run_captured(
+            ["bash", str(verify_path)],
+            env=run_env,
+            cwd=project_root,
+            spool_name="verify-script",
+            repo_root=project_root,
+            check=False,
+        )
     except OSError as exc:
-        logger.warning("Could not run %s: %s", verify_path, exc)
+        # Covers both halves of the call: the script itself failing to launch,
+        # and the spool file it would have been captured into failing to open.
+        logger.warning("Could not run %s or capture its output: %s", verify_path, exc)
         return
 
+    _report_step(f"smoke check {verify_path.name} — exit {result.returncode}")
     if result.returncode == 0:
         logger.key_info("%s completed (exit 0)", verify_path)
     else:
+        # Read off the result, not the reporter: this hook has callers that run
+        # it with no phase open, and they need the path just as much.
+        # None only under --verbose, where the output already streamed past.
+        spool = result.spool_path
         logger.warning(
-            "%s exited %s -- advisory only, this does NOT fail the deploy. "
-            "Review the output above.",
+            "%s exited %s -- advisory only, this does NOT fail the deploy. %s",
             verify_path,
             result.returncode,
+            f"Its output: {spool}" if spool else "Review the output above.",
         )
 
 
@@ -266,13 +287,21 @@ def warn_if_web_stack_unreachable(
             " ".join(restart_cmd),
         )
         try:
-            # Output is inherited, not captured, like every other compose call
-            # on this path: a restart of the whole web tier is visible work and
-            # the operator should watch it happen.
-            subprocess.run(restart_cmd, env=run_env)
+            # Spooled, not inherited: the restart's compose chatter would bury
+            # the warning above, which is the part the operator has to act on.
+            # check=False keeps this advisory — a failed restart falls through
+            # to the settings hint below, exactly as before.
+            run_captured(
+                restart_cmd,
+                env=run_env,
+                spool_name="compose-web-restart",
+                repo_root=resolve_repo_root(config),
+                check=False,
+            )
         except OSError as exc:
             logger.warning("Could not restart the web stack: %s", exc)
         else:
+            _report_step("bounced the web stack for host-port re-registration")
             if _host_port_answers(url, attempts, delay):
                 logger.key_info("%s is reachable now.", url)
                 return

--- a/src/osprey/deployment/web_terminals/provision.py
+++ b/src/osprey/deployment/web_terminals/provision.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 import yaml
 
+from osprey.cli.phase_reporter import report_step as _report_step
 from osprey.deployment.compose_generator import (
     _stage_dev_wheel_for_context,
     compose_base_cmd,
@@ -35,6 +36,7 @@ from osprey.deployment.runtime_helper import (
     runtime_env,
     with_plain_progress,
 )
+from osprey.deployment.subprocess_capture import run_captured
 from osprey.deployment.web_terminals.artifacts import (
     web_compose_file,
     write_web_terminal_artifacts,
@@ -507,7 +509,8 @@ def build_auth_sidecar_image(config: dict, dev_mode: bool, env: dict[str, str]) 
         )
         return
 
-    context_dir = _materialize_auth_build_context(resolve_repo_root(config), dev_mode)
+    repo_root = resolve_repo_root(config)
+    context_dir = _materialize_auth_build_context(repo_root, dev_mode)
 
     from osprey import __version__ as osprey_version
 
@@ -535,7 +538,8 @@ def build_auth_sidecar_image(config: dict, dev_mode: bool, env: dict[str, str]) 
 
     logger.key_info("Building auth sidecar image %s:", tag)
     logger.debug("Running command:\n    %s", " ".join(cmd))
-    subprocess.run(cmd, env=env, check=True)
+    run_captured(cmd, env=env, spool_name="build-auth-sidecar", repo_root=repo_root)
+    _report_step(f"auth sidecar image {tag}")
 
 
 def web_stack_compose_cmd(
@@ -701,11 +705,16 @@ def force_recreate_auth_sidecar(
         web_stack_compose_cmd(config, env_file_args, repo_root=root),
         runtime_env(config, env if env is not None else dict(os.environ), ignore_orphans=True),
         [AUTH_SERVICE_NAME],
+        repo_root=root,
     )
 
 
 def _force_recreate_services(
-    web_cmd: list[str], run_env: dict[str, str], services: list[str]
+    web_cmd: list[str],
+    run_env: dict[str, str],
+    services: list[str],
+    *,
+    repo_root: Path | str | None = None,
 ) -> None:
     """Run one service-scoped ``up -d --force-recreate`` for ``services``.
 
@@ -713,10 +722,14 @@ def _force_recreate_services(
     ``up -d --force-recreate`` would bounce every live terminal in the stack,
     which is exactly what both callers (the post-``up`` reconcile and
     :func:`force_recreate_auth_sidecar`) exist to avoid.
+
+    :param repo_root: The deployment repo whose ``var/logs/`` holds this
+        recreate's spooled output. Both callers already resolved it.
     """
     cmd = web_cmd + ["up", "-d", "--force-recreate", *services]
     logger.debug(f"Running command:\n    {' '.join(cmd)}")
-    subprocess.run(cmd, env=run_env, check=True)
+    run_captured(cmd, env=run_env, spool_name="compose-force-recreate", repo_root=repo_root)
+    _report_step(f"recreated {', '.join(services)}")
 
 
 def deploy_up_web_terminals(
@@ -914,7 +927,14 @@ def deploy_up_web_terminals(
         # OTHER stack's containers as "orphans" of the shared project.
         services_rm = services_base + ["rm", "-f"]
         logger.debug(f"Running command:\n    {' '.join(services_rm)}")
-        subprocess.run(services_rm, env=run_env)
+        run_captured(
+            services_rm,
+            env=run_env,
+            spool_name="compose-services-rm",
+            repo_root=repo_root,
+            check=False,
+        )
+        _report_step("cleared stale service containers")
         if dev_mode:
             # Mirrors the plain non-web path's dev-mode build (see deploy_up):
             # without a rebuild, a co-deployed service's cached image tag keeps
@@ -923,13 +943,19 @@ def deploy_up_web_terminals(
             # image-store race.
             services_build = services_base + ["build"]
             logger.debug(f"Running command:\n    {' '.join(services_build)}")
-            subprocess.run(services_build, env=run_env, check=True)
+            run_captured(
+                services_build, env=run_env, spool_name="build-services", repo_root=repo_root
+            )
+            _report_step("built service images")
         services_cmd = services_base + ["up"]
         if dev_mode:
             services_cmd.append("--no-build")
         services_cmd.append("-d")
         logger.debug(f"Running command:\n    {' '.join(services_cmd)}")
-        subprocess.run(services_cmd, env=run_env, check=True)
+        run_captured(
+            services_cmd, env=run_env, spool_name="compose-services-up", repo_root=repo_root
+        )
+        _report_step("backend services started")
 
     # ---- web-terminal stack (same pinned project directory: the repo root) --
     web_cmd = web_stack_compose_cmd(config, env_file_args, repo_root=repo_root)
@@ -938,7 +964,8 @@ def deploy_up_web_terminals(
     # no-`--remove-orphans` constraint — see that comment).
     web_rm = web_cmd + ["rm", "-f"]
     logger.debug(f"Running command:\n    {' '.join(web_rm)}")
-    subprocess.run(web_rm, env=run_env)
+    run_captured(web_rm, env=run_env, spool_name="compose-web-rm", repo_root=repo_root, check=False)
+    _report_step("cleared stale web-terminal containers")
 
     if not local_mode:
         # Registry mode only: local-only tags have no upstream to pull from,
@@ -947,17 +974,19 @@ def deploy_up_web_terminals(
         # to add; never run `pull` unconditionally here again.
         pull_cmd = web_cmd + ["pull"]
         logger.debug(f"Running command:\n    {' '.join(pull_cmd)}")
-        subprocess.run(pull_cmd, env=run_env, check=True)
+        run_captured(pull_cmd, env=run_env, spool_name="compose-web-pull", repo_root=repo_root)
+        _report_step("pulled web-terminal images")
 
     up_cmd = web_cmd + ["up", "-d"]
     logger.debug(f"Running command:\n    {' '.join(up_cmd)}")
-    subprocess.run(up_cmd, env=run_env, check=True)
+    run_captured(up_cmd, env=run_env, spool_name="compose-web-up", repo_root=repo_root)
+    _report_step("web-terminal stack started")
 
     # Post-`up` recreate for podman's same-tag image drift. A changed
     # `.env.auth` needs nothing here: the render above stamped its content
     # digest into the sidecar's service definition, so the `up -d` itself
     # already recreated the sidecar on any content change.
-    _reconcile_web_stack_recreates(config, web_cmd, run_env)
+    _reconcile_web_stack_recreates(config, web_cmd, run_env, repo_root=repo_root)
 
     # Hot-reload nginx: `up -d` never restarts a running nginx whose
     # bind-mounted nginx.conf/landing.html CONTENT changed — the container
@@ -992,6 +1021,8 @@ def _reconcile_web_stack_recreates(
     config: dict,
     web_cmd: list[str],
     run_env: dict[str, str],
+    *,
+    repo_root: Path | str | None = None,
 ) -> None:
     """Issue the one post-``up`` force-recreate this deploy needs: image drift.
 
@@ -1024,7 +1055,11 @@ def _reconcile_web_stack_recreates(
         against the same compose project as the preceding ``up``.
     :param run_env: The ``COMPOSE_PROJECT_NAME``-pinned environment shared by
         every web-stack invocation.
+    :param repo_root: The deployment repo — the rendered compose file this
+        reads and the spooled output of any recreate it issues both hang off
+        it. Defaults to the one resolved from ``config``.
     """
+    root = Path(repo_root) if repo_root is not None else None
     changed: list[str] = []
 
     runtime = get_runtime_command(config)[0]
@@ -1034,7 +1069,10 @@ def _reconcile_web_stack_recreates(
         # services exist and what image / container name each carries -- reading
         # it here keeps this reconcile free of any per-service name
         # reconstruction and covers nginx and every per-user terminal uniformly.
-        compose_file = web_compose_file(resolve_repo_root(config))
+        # Resolved lazily, inside the branch that needs it: the docker path
+        # touches neither the compose file nor a recreate.
+        root = root if root is not None else resolve_repo_root(config)
+        compose_file = web_compose_file(root)
         try:
             compose_doc = yaml.safe_load(compose_file.read_text(encoding="utf-8"))
         except (OSError, yaml.YAMLError) as exc:
@@ -1061,7 +1099,7 @@ def _reconcile_web_stack_recreates(
     if not changed:
         return
 
-    _force_recreate_services(web_cmd, run_env, changed)
+    _force_recreate_services(web_cmd, run_env, changed, repo_root=root)
 
 
 def deploy_down_web_terminals(

--- a/src/osprey/simulation/archiver_seed.py
+++ b/src/osprey/simulation/archiver_seed.py
@@ -725,7 +725,7 @@ def seed_base(
         seeded_at=t0,
         report=report,
     )
-    logger.info(report.describe())
+    logger.debug(report.describe())
     return report
 
 

--- a/src/osprey/utils/config_writer.py
+++ b/src/osprey/utils/config_writer.py
@@ -310,7 +310,7 @@ def config_remove_from_list(
                 del parent_node[parent_key]
 
     _save(config_path, data)
-    logger.info("config_remove_from_list: %s -= %s in %s", ".".join(key_path), value, config_path)
+    logger.debug("config_remove_from_list: %s -= %s in %s", ".".join(key_path), value, config_path)
     return True
 
 
@@ -346,7 +346,7 @@ def config_replace_list(
 
     node[key_path[-1]] = new_list
     _save(config_path, data)
-    logger.info(
+    logger.debug(
         "config_replace_list: %s = <%d item(s)> in %s",
         ".".join(key_path),
         len(new_list),
@@ -373,7 +373,7 @@ def config_update_fields(
         _set_dotted_anchored(data, data, dotted_key, value, create_only=True)
 
     _save(config_path, data)
-    logger.info("config_update_fields: updated %d field(s) in %s", len(updates), config_path)
+    logger.debug("config_update_fields: updated %d field(s) in %s", len(updates), config_path)
 
 
 def _set_dotted_anchored(

--- a/tests/cli/test_build_output_quiet.py
+++ b/tests/cli/test_build_output_quiet.py
@@ -1,0 +1,438 @@
+"""What a build says at INFO, and what it now only says at DEBUG.
+
+``osprey build`` renders the project six times — the deployment, one project per
+persona, and a container copy of each. Every render used to re-emit its full
+report at INFO, so an operator read the same injector block, the same provider
+report and the same config-writer field dumps six times over for one build.
+
+The demotion is the whole mechanism: no new log level, no change to
+:func:`~osprey.utils.logger.configure_logging`. INFO stays the default filter,
+and the per-render detail moves below it. These tests pin both halves — the
+noise is gone from INFO, and it is still *there* at DEBUG, because a build that
+cannot be debugged is not quieter, only less honest.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import logging
+import os
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from osprey.cli.build_cmd import build as build_command
+from osprey.cli.phase_reporter import PhaseReporter, install_reporter
+
+
+class _Capture(logging.Handler):
+    """Every record the build emits, kept whole so level and text stay paired."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+        #: The repo the captured run built, for assertions about paths it named.
+        self.repo: Path | None = None
+        #: The phase-reporter lines the same run printed — the default view the
+        #: demoted records used to be part of.
+        self.lines: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def messages(self, *, at_least: int) -> list[str]:
+        """The formatted messages of every record at ``at_least`` or above."""
+        return [r.getMessage() for r in self.records if r.levelno >= at_least]
+
+
+class _RecordingReporter(PhaseReporter):
+    """A real reporter that keeps its lines instead of printing them.
+
+    Read off the reporter rather than out of ``result.output`` because reporter
+    output goes through the Rich console singleton, which wraps to whatever
+    terminal width a CliRunner presents.
+    """
+
+    def __init__(self, sink: list[str]) -> None:
+        super().__init__(color=False)
+        self._sink = sink
+
+    def emit(self, text: str, style: str | None = None) -> None:
+        self._sink.append(text)
+
+
+@pytest.fixture(scope="module")
+def build_records(tmp_path_factory: pytest.TempPathFactory) -> _Capture:
+    """One real build of the exemplar, with every record it emitted.
+
+    Module-scoped because the build is the expensive part and every assertion
+    below reads the same run: what the six renders said is one fact, and
+    re-running the build per assertion would only make it slower to check.
+
+    ``--skip-deps``/``--skip-lifecycle`` drop the venv install and the profile's
+    shell phases — neither emits the per-render reports under test, and both
+    cost minutes.
+    """
+    from tests.fixtures.lifecycle_repo import EXEMPLAR_DIRNAME, build_exemplar_repo
+
+    repo = build_exemplar_repo(tmp_path_factory.mktemp("quiet") / EXEMPLAR_DIRNAME, seed_env=True)
+
+    capture = _Capture()
+    capture.repo = repo.resolve()
+    root = logging.getLogger()
+    previous_level = root.level
+    root.addHandler(capture)
+    root.setLevel(logging.DEBUG)
+    previous_cwd = Path.cwd()
+    os.chdir(repo)
+    # Pre-installed, so the verb reports into it — the same path a chained verb
+    # puts `build` on — and its lines are captured beside the log records.
+    previous_reporter = install_reporter(_RecordingReporter(capture.lines))
+    try:
+        result = CliRunner().invoke(build_command, ["--skip-deps", "--skip-lifecycle"])
+    finally:
+        install_reporter(previous_reporter)
+        os.chdir(previous_cwd)
+        root.removeHandler(capture)
+        root.setLevel(previous_level)
+
+    assert result.exit_code == 0, result.output
+    return capture
+
+
+#: Text that a build must no longer say at INFO, paired with what it is.
+#:
+#: Each fires once per render — six times for one build — except the provider
+#: report, which the deployment's own render and its container copy each emit.
+DEMOTED_NEEDLES = {
+    "Injected": "the injector block's post-build hints",
+    "service template(s)": "the service-template copy count",
+    "Provider:": "the provider-credential report",
+    "config_update_fields": "the config writer's field dump",
+    "Rendering persona": "the per-persona render announcement",
+    "satisfies": "the OSPREY-version check confirming it passed",
+}
+
+
+class TestLoggerDemotions:
+    """The build/deploy path's noisy call sites, now at DEBUG."""
+
+    @pytest.mark.parametrize("needle", sorted(DEMOTED_NEEDLES), ids=sorted(DEMOTED_NEEDLES))
+    def test_logger_says_nothing_of_the_kind_at_info(
+        self, build_records: _Capture, needle: str
+    ) -> None:
+        """INFO carries none of the per-render detail."""
+        offenders = [m for m in build_records.messages(at_least=logging.INFO) if needle in m]
+        assert not offenders, (
+            f"{DEMOTED_NEEDLES[needle]} is still at INFO ({len(offenders)} record(s)): {offenders}"
+        )
+
+    @pytest.mark.parametrize("needle", sorted(DEMOTED_NEEDLES), ids=sorted(DEMOTED_NEEDLES))
+    def test_logger_still_says_it_at_debug(self, build_records: _Capture, needle: str) -> None:
+        """Demoted, not deleted — ``--debug`` still shows every line."""
+        assert any(needle in m for m in build_records.messages(at_least=logging.DEBUG)), (
+            f"{DEMOTED_NEEDLES[needle]} vanished entirely; demotion must keep it at DEBUG"
+        )
+
+    def test_logger_keeps_the_builds_one_success_line_at_info(
+        self, build_records: _Capture
+    ) -> None:
+        """The sweep is a demotion, not a blanket silencing.
+
+        A build that says nothing at all on success would pass every assertion
+        above while being strictly worse than the noise it replaced.
+        """
+        assert any(
+            m.startswith("✓ Rendered") for m in build_records.messages(at_least=logging.INFO)
+        ), f"no success line survived: {build_records.messages(at_least=logging.INFO)}"
+
+    def test_logger_spells_the_build_path_out_only_in_that_success_line(
+        self, build_records: _Capture
+    ) -> None:
+        """One absolute path in the whole default view, and it is the useful one.
+
+        Every demoted line above named the tree it had just written to, so a
+        build spelled its own output path out once per render and each one wrapped
+        across a normal terminal. Where the build landed is worth saying — once,
+        at the end. Asserted as equality rather than as a count so a *different*
+        line reacquiring a path cannot pass by replacing this one.
+        """
+        assert build_records.repo is not None
+        carrying = [
+            m for m in build_records.messages(at_least=logging.INFO) if str(build_records.repo) in m
+        ]
+        assert carrying == [f"✓ Rendered {build_records.repo / 'build'}"]
+
+    def test_reporter_names_the_injected_services_once(self, build_records: _Capture) -> None:
+        """The injector highlights survive the demotion, as one step line.
+
+        Demoting the per-service hint blocks to DEBUG must not take the fact
+        that services were injected down with them. The render phase names the
+        components once — not once per service, and not once per render.
+        """
+        steps = [line for line in build_records.lines if "services injected:" in line]
+        assert len(steps) == 1, f"expected one injector step line, got {len(steps)}: {steps}"
+        # The exemplar declares dispatch, bluesky, bluesky panels, a virtual
+        # accelerator and an archiver; two of them pin the line's shape.
+        assert steps[0].startswith("  · services injected: "), steps[0]
+        # Read as names rather than as substrings: the names are accumulated per
+        # render into one list, so a second render feeding that list would repeat
+        # every component *within* this single line and still pass the count
+        # above. Asserting membership in the parsed list also proves the parse.
+        listed = steps[0].split("services injected: ", 1)[1]
+        names = [name.strip() for name in re.sub(r"\s*\([^()]*\)$", "", listed).split(",")]
+        assert "event dispatch" in names and "archiver store" in names, names
+        assert len(names) == len(set(names)), f"components repeated within the line: {names}"
+
+    def test_logger_repeats_no_render_line_across_the_six_renders(
+        self, build_records: _Capture
+    ) -> None:
+        """Not one duplicate at INFO from the renderer itself.
+
+        Scoped to the ``build`` logger — the renderer's own voice, which is what
+        the six renders share. Compose generation logs under its own name and
+        repeats a line per service build context; that one is the compose
+        generator's to quiet, and scoping here keeps this test reporting on the
+        render loop rather than failing for a neighbour.
+        """
+        info = [
+            r.getMessage()
+            for r in build_records.records
+            if r.levelno >= logging.INFO and r.name == "build"
+        ]
+        duplicates = {m for m in info if info.count(m) > 1}
+        assert not duplicates, f"INFO still repeats across renders: {sorted(duplicates)}"
+
+
+class TestLoggerConfigWriterQuiet:
+    """``config.yml`` edits report at DEBUG, path echo and all."""
+
+    def _config(self, tmp_path: Path) -> Path:
+        path = tmp_path / "config.yml"
+        path.write_text("modules:\n  web_terminals:\n    users:\n      - alice\n", encoding="utf-8")
+        return path
+
+    def test_logger_field_update_dump_is_debug(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from osprey.utils.config_writer import config_update_fields
+
+        path = self._config(tmp_path)
+        with caplog.at_level(logging.DEBUG):
+            config_update_fields(path, {"modules.web_terminals.nginx_port": 8080})
+
+        assert "config_update_fields" in caplog.text
+        assert not [r for r in caplog.records if r.levelno >= logging.INFO]
+
+    def test_logger_list_edits_are_debug(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from osprey.utils.config_writer import config_remove_from_list, config_replace_list
+
+        path = self._config(tmp_path)
+        key = ["modules", "web_terminals", "users"]
+        with caplog.at_level(logging.DEBUG):
+            config_remove_from_list(path, key, "alice")
+            config_replace_list(path, key, ["bob"])
+
+        assert "config_remove_from_list" in caplog.text
+        assert "config_replace_list" in caplog.text
+        assert not [r for r in caplog.records if r.levelno >= logging.INFO]
+
+
+class _StubCollection:
+    """The three calls :func:`seed_base` makes on a store, and nothing else."""
+
+    def __init__(self) -> None:
+        self.documents: list[dict[str, Any]] = []
+
+    def create_index(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def insert_many(self, documents: list[dict[str, Any]], **kwargs: Any) -> None:
+        self.documents.extend(documents)
+
+    def replace_one(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+class TestLoggerArchiverSeedQuiet:
+    """The seeder's own report line, off the deploy's INFO stream."""
+
+    def test_logger_seed_report_is_debug(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A deploy seeds the archive; the seeder no longer narrates it at INFO.
+
+        Seeded with no channels, so the run is the report line and the manifest
+        write — the arithmetic is covered by the archiver seed suite, and what
+        is under test here is only the level the summary goes out at.
+        """
+        from osprey.simulation.archiver_seed import SeedKnobs, seed_base
+
+        knobs = SeedKnobs(
+            retention_days=1, hot_span_hours=1, hot_cadence_sec=600, tail_cadence_sec=3600
+        )
+        with caplog.at_level(logging.DEBUG):
+            report = seed_base(
+                _StubCollection(),  # type: ignore[arg-type]
+                [],
+                knobs,
+                t0=datetime(2026, 3, 14, 9, 26, 53, tzinfo=UTC),
+            )
+
+        assert report.describe() in caplog.text
+        assert not [r for r in caplog.records if r.levelno >= logging.INFO]
+
+
+# ---------------------------------------------------------------------------
+# stdout: the ``console.print`` chatter no log level can reach
+# ---------------------------------------------------------------------------
+
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
+
+
+def plain(text: str) -> str:
+    """``text`` with ANSI styling gone and every whitespace run collapsed.
+
+    Rich wraps to the console width, so a phrase that *is* on stdout can still
+    be missing from a naive ``in`` check — split across a newline mid-sentence.
+    An absence assertion against unnormalized Rich output is therefore prone to
+    passing for the wrong reason; collapsing first makes it mean what it says.
+    """
+    return " ".join(_ANSI.sub("", text).split())
+
+
+#: Console lines a render must no longer put on stdout, paired with what they are.
+#:
+#: All of them fire once per render — six times for one build — and each spells
+#: out an absolute path, so the shortest still wraps to several lines in a normal
+#: terminal.
+#:
+#: One demoted line is missing here: ``Copied machine data to <path>``, which
+#: only runs for a bundle that ships ``machine_data/``. No bundled app does, so
+#: a render cannot reach it and an assertion would pass vacuously. It is covered
+#: by the same demotion in the same function as the web-terminal line below.
+STDOUT_NEEDLES = {
+    "Created": "Claude Code integration file(s)",
+    "data files": "Copied template data files to",
+    "tier artifacts": "Materialized tier",
+    "web-terminal context": "Installed web-terminal context to",
+}
+
+
+@pytest.fixture(scope="module")
+def rendered_project(tmp_path_factory: pytest.TempPathFactory) -> tuple[str, _Capture]:
+    """One real render, with everything it wrote to stdout and to the log.
+
+    A render rather than a full build: these call sites live in the template
+    layer, and :meth:`TemplateManager.create_project` is the shortest path that
+    exercises all of them for real. Module-scoped for the same reason as
+    :func:`build_records` — one render answers every assertion below.
+
+    ``redirect_stdout`` rather than ``capsys`` because the fixture outlives a
+    single test; the ``console`` singleton resolves ``sys.stdout`` per write, so
+    the redirect catches it.
+    """
+    from osprey.cli.templates.manager import TemplateManager
+
+    capture = _Capture()
+    root = logging.getLogger()
+    previous_level = root.level
+    root.addHandler(capture)
+    root.setLevel(logging.DEBUG)
+    stdout = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(stdout):
+            TemplateManager().create_project(
+                project_name="quiet-render",
+                output_dir=tmp_path_factory.mktemp("render"),
+                data_bundle="control_assistant",
+                context={"channel_finder_mode": "hierarchical"},
+            )
+    finally:
+        root.removeHandler(capture)
+        root.setLevel(previous_level)
+
+    return plain(stdout.getvalue()), capture
+
+
+class TestStdoutDemotions:
+    """Per-render ``console.print`` chatter, moved off stdout onto DEBUG."""
+
+    @pytest.mark.parametrize("case", sorted(STDOUT_NEEDLES), ids=sorted(STDOUT_NEEDLES))
+    def test_stdout_render_says_nothing_of_the_kind(
+        self, rendered_project: tuple[str, _Capture], case: str
+    ) -> None:
+        """Nothing on stdout, and the line still on DEBUG.
+
+        The DEBUG half is what keeps this honest: it proves the call site ran at
+        all, so the empty stdout is a demotion rather than a code path that
+        never fired in this render.
+        """
+        out, records = rendered_project
+        needle = STDOUT_NEEDLES[case]
+
+        assert any(needle in m for m in records.messages(at_least=logging.DEBUG)), (
+            f"{needle!r} never fired in this render — the stdout check below would be vacuous"
+        )
+        assert needle not in out, f"{needle!r} is still on stdout: {out}"
+
+
+class TestStdoutDataCopyQuiet:
+    """The two data-copy branches no build exercises together."""
+
+    def _tree(self, root: Path) -> Path:
+        root.mkdir(parents=True, exist_ok=True)
+        (root / "channels.json").write_text("{}", encoding="utf-8")
+        return root
+
+    def test_stdout_profile_data_copy_is_quiet(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The profile branch — the one a facility build takes.
+
+        Not reachable from :func:`rendered_project`: a profile's ``data:`` tree
+        fully replaces the bundle's, so the two branches are alternatives and
+        only the bundle one runs in a bundle render.
+        """
+        from osprey.cli.templates.scaffolding import copy_template_data
+
+        data_root = self._tree(tmp_path / "profile" / "data")
+        project = tmp_path / "project"
+        project.mkdir()
+
+        capsys.readouterr()
+        with caplog.at_level(logging.DEBUG, logger="osprey.cli.templates"):
+            copy_template_data(
+                tmp_path / "templates",
+                project,
+                package_name="quiet_project",
+                data_bundle="control_assistant",
+                ctx={},
+                data_root=data_root,
+            )
+
+        assert (project / "data" / "channels.json").exists()
+        assert "Copied profile data files" in caplog.text
+        assert "Copied profile data" not in plain(capsys.readouterr().out)
+
+    def test_stdout_csv_prune_is_quiet(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Pruning ``data/raw/`` reports the removal at DEBUG, not on stdout."""
+        from osprey.cli.templates.scaffolding import prune_csv_build_artifacts
+
+        raw = self._tree(tmp_path / "project" / "data" / "raw")
+
+        capsys.readouterr()
+        with caplog.at_level(logging.DEBUG, logger="osprey.cli.templates"):
+            prune_csv_build_artifacts(tmp_path / "project", "hierarchical")
+
+        assert not raw.exists()
+        assert "no CSV build path" in caplog.text
+        assert "no CSV build path" not in plain(capsys.readouterr().out)

--- a/tests/cli/test_build_provider_credentials.py
+++ b/tests/cli/test_build_provider_credentials.py
@@ -171,7 +171,7 @@ class TestReportProviderCredentials:
     def test_found_selected_provider_is_reported_with_source(self, project, profile_dir, caplog):
         (project / ".env").write_text("CBORG_API_KEY=secret\n", encoding="utf-8")
 
-        with caplog.at_level(logging.INFO):
+        with caplog.at_level(logging.DEBUG):
             report_provider_credentials(project, "cborg", profile_dir=profile_dir)
 
         text = caplog.text
@@ -200,7 +200,7 @@ class TestReportProviderCredentials:
         (project / ".env").write_text("CBORG_API_KEY=secret\n", encoding="utf-8")
         monkeypatch.setenv("ALS_APG_API_KEY", "als-key")
 
-        with caplog.at_level(logging.INFO):
+        with caplog.at_level(logging.DEBUG):
             report_provider_credentials(project, "cborg", profile_dir=profile_dir)
 
         assert "ALS_APG_API_KEY" in caplog.text
@@ -208,7 +208,7 @@ class TestReportProviderCredentials:
     def test_unset_keys_are_still_listed(self, project, profile_dir, caplog):
         (project / ".env").write_text("CBORG_API_KEY=secret\n", encoding="utf-8")
 
-        with caplog.at_level(logging.INFO):
+        with caplog.at_level(logging.DEBUG):
             report_provider_credentials(project, "cborg", profile_dir=profile_dir)
 
         assert "OPENAI_API_KEY" in caplog.text
@@ -246,7 +246,7 @@ class TestReportProviderCredentials:
         assert _status_for(statuses, "anthropic").found is False
 
     def test_keyless_selected_provider_reports_no_key_required(self, project, profile_dir, caplog):
-        with caplog.at_level(logging.INFO):
+        with caplog.at_level(logging.DEBUG):
             report_provider_credentials(project, "ollama", profile_dir=profile_dir)
 
         assert "ollama" in caplog.text
@@ -254,7 +254,7 @@ class TestReportProviderCredentials:
         assert not warnings, "a keyless provider must not warn about a missing key"
 
     def test_unknown_provider_does_not_crash_the_build(self, project, profile_dir, caplog):
-        with caplog.at_level(logging.INFO):
+        with caplog.at_level(logging.DEBUG):
             report_provider_credentials(project, "not-a-real-provider", profile_dir=profile_dir)
 
         assert "not-a-real-provider" in caplog.text

--- a/tests/cli/test_claude_code_integration.py
+++ b/tests/cli/test_claude_code_integration.py
@@ -323,13 +323,18 @@ class TestClaudeCodeGitignore:
 class TestClaudeCodeCLI:
     """Test CLI Claude Code generation."""
 
-    def test_build_logs_claude_code_creation(self, tmp_path):
-        """osprey build logs that it created Claude Code integration files."""
+    def test_build_logs_claude_code_creation(self, tmp_path, caplog):
+        """osprey build logs that it created Claude Code integration files.
+
+        The line is DEBUG detail now — `build`'s terminal output is a handful of
+        phase lines — so the record is read off the log, not off stdout.
+        """
         runner = CliRunner()
-        _, result = _init_and_build(runner, tmp_path / "cc-project")
+        with caplog.at_level("DEBUG", logger="osprey.cli.templates"):
+            _, result = _init_and_build(runner, tmp_path / "cc-project")
 
         assert result.exit_code == 0, result.output
-        assert "Claude Code integration file" in result.output
+        assert "Claude Code integration file" in caplog.text
 
     def test_build_always_creates_claude_code_files(self, tmp_path):
         """osprey build always generates Claude Code integration files."""

--- a/tests/cli/test_failure_replay.py
+++ b/tests/cli/test_failure_replay.py
@@ -1,0 +1,341 @@
+"""What the lifecycle verbs print when a captured child fails or is interrupted.
+
+Capturing a subprocess to a spool file is only honest if the failure path gives
+that output back. Two shapes are asserted here, both with a real child process
+writing a real spool:
+
+* a child that exits non-zero — its spool is replayed **in full**, beneath the
+  phase's own ✗ line and **before** the verb's error message, exactly once;
+* a run interrupted by SIGINT — the partial spool is **named in one line** and
+  never replayed, because an interrupt is not a diagnosis and the operator did
+  not ask to read a half-written log.
+
+Neither of those is wired at the verb's ``except`` blocks: the replay comes from
+``Phase.__exit__``, which fails the open phase with whatever spool the capture
+helper last recorded on it. That is what makes it work for the paths whose
+failure is not a ``CapturedProcessError`` at all. The verb handlers' part is the
+negative one — not replaying a second time, and not printing a second failure
+marker over the phase's.
+
+Output is read with ``capfd`` and the verbs are driven through ``cli.main``
+rather than ``CliRunner``: the question is what reached the terminal's file
+descriptors while a real child was writing to a file beside them, and a runner
+that swaps ``sys.stdout`` for a buffer cannot answer it.
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+from pathlib import Path
+
+import click
+import pytest
+
+from osprey.cli.main import cli
+
+#: Written by the child into its spool. Deliberately absent from the argv that
+#: produces it — the error message quotes the command, and a marker that also
+#: appeared there would make "the spool was printed once" unaskable.
+POISON = "the-child-said-this"
+
+
+def run_verb(*args: str) -> int:
+    """Run one verb in this process and return the exit status a shell would see.
+
+    ``standalone_mode=False`` keeps Click from swallowing the abort into
+    ``sys.exit``, so the status is decided here instead of by an exception that
+    would take the test session with it.
+    """
+    try:
+        cli.main(args=list(args), prog_name="osprey", standalone_mode=False)
+    except click.Abort:
+        return 1
+    except SystemExit as exit_:  # `down` propagates the runtime's own status
+        return int(exit_.code or 0)
+    return 0
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A directory standing in for a built deployment repo."""
+    (tmp_path / "build").mkdir()
+    (tmp_path / "build" / "config.yml").write_text("{}\n")
+    (tmp_path / "poison.txt").write_text(f"{POISON}\n")
+    return tmp_path
+
+
+@pytest.fixture
+def wide(monkeypatch):
+    """Take Rich's 80-column default out of the assertions.
+
+    The reporter soft-wraps, but the refusal paths print through the plain
+    console, and a wrapped ✗ line would be a test about terminal width.
+    """
+    monkeypatch.setenv("COLUMNS", "200")
+
+
+@pytest.fixture
+def stubs(monkeypatch, repo: Path):
+    """Stub everything `up`/`down` reach outside the CLI layer."""
+    from osprey.cli import deploy_cmd, repo_resolver
+    from osprey.deployment import container_lifecycle
+
+    monkeypatch.setattr(repo_resolver, "find_repo_root", lambda start=None: repo)
+    monkeypatch.setattr(deploy_cmd, "gate_start_from_build", lambda *a, **k: None)
+    monkeypatch.setattr(deploy_cmd, "ensure_repo_env", lambda *a, **k: None)
+    monkeypatch.setattr(deploy_cmd, "load_project_config", lambda *a, **k: {})
+    monkeypatch.setattr(
+        container_lifecycle, "as_built_config_path", lambda root: repo / "build" / "config.yml"
+    )
+
+
+@pytest.fixture
+def errors_on_stdout():
+    """Tee ERROR records onto stdout, so their order against the replay is visible.
+
+    The reporter prints to stdout and ``_abort`` logs to stderr. Two streams
+    carry no order relative to one another, and "the spool came first" is
+    exactly what has to be asserted — so the record is echoed a second time onto
+    the stream the replay uses. Production behaviour is untouched: this adds a
+    handler for the duration of the test and removes it again.
+    """
+
+    class Tee(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            print(f"LOGGED {record.getMessage()}", flush=True)
+
+    handler = Tee(level=logging.ERROR)
+    verb_logger = logging.getLogger("deploy")
+    verb_logger.addHandler(handler)
+    try:
+        yield
+    finally:
+        verb_logger.removeHandler(handler)
+
+
+def poisoned(*args, **kwargs) -> None:
+    """Stand-in for the verb's real work: one captured child that exits 3."""
+    from osprey.deployment.subprocess_capture import run_captured
+
+    repo_root = Path(args[0])
+    run_captured(
+        ["sh", "-c", "cat poison.txt; exit 3"],
+        cwd=repo_root,
+        spool_name="probe",
+        repo_root=repo_root,
+    )
+
+
+def spools(repo: Path) -> list[Path]:
+    """The spool files this run left in the repo."""
+    return sorted((repo / "var" / "logs").glob("probe-*.log"))
+
+
+# ---------------------------------------------------------------------------
+# A captured child that exits non-zero
+# ---------------------------------------------------------------------------
+
+
+def test_a_failed_captured_step_replays_its_spool_before_the_error(
+    monkeypatch, capfd, wide, stubs, errors_on_stdout, repo
+):
+    """The order is the whole point.
+
+    An error message that arrives before the output it is about leaves the
+    operator scrolling back for the reason, which is the state the capture was
+    supposed to remove.
+    """
+    from osprey.deployment import container_lifecycle
+
+    monkeypatch.setattr(container_lifecycle, "down_deployment", poisoned)
+
+    status = run_verb("down")
+
+    assert status != 0
+    out = capfd.readouterr().out
+    assert POISON in out, out
+    assert out.index("✗ Stopping") < out.index(POISON)
+    assert out.index(POISON) < out.index("LOGGED Could not stop this deployment")
+
+
+def test_the_error_message_names_the_spool_it_replayed(monkeypatch, caplog, wide, stubs, repo):
+    """The replay is for now; the path is for the operator who comes back later.
+
+    Read off the record rather than off stderr: the log console is a Rich one,
+    which wraps a long path across lines and colours the pieces, so an
+    assertion on what it printed would be an assertion about terminal width.
+    """
+    from osprey.deployment import container_lifecycle
+
+    monkeypatch.setattr(container_lifecycle, "down_deployment", poisoned)
+
+    with caplog.at_level(logging.ERROR):
+        status = run_verb("down")
+
+    assert status != 0
+    spool = spools(repo)[0]
+    assert str(spool) in caplog.text
+
+
+def test_a_failed_captured_step_replays_its_spool_only_once(
+    monkeypatch, capfd, wide, stubs, errors_on_stdout, repo
+):
+    """The phase teardown replays. A handler that replayed too would print the
+    whole log twice, which for a compose build is thousands of duplicated
+    lines — and would read as two separate failures."""
+    from osprey.deployment import container_lifecycle
+
+    monkeypatch.setattr(container_lifecycle, "down_deployment", poisoned)
+
+    status = run_verb("down")
+
+    assert status != 0
+    assert capfd.readouterr().out.count(POISON) == 1
+
+
+def test_a_start_that_fails_on_a_captured_child_replays_it_too(
+    monkeypatch, capfd, wide, stubs, errors_on_stdout, repo
+):
+    """Same property on the other verb, whose phase is opened separately."""
+    from osprey.deployment import container_lifecycle
+
+    monkeypatch.setattr(container_lifecycle, "up_as_built", poisoned)
+
+    status = run_verb("up", "-d")
+
+    assert status != 0
+    out = capfd.readouterr().out
+    assert out.count(POISON) == 1
+    assert out.index("✗ Starting") < out.index(POISON)
+    assert out.index(POISON) < out.index("LOGGED Deployment failed")
+
+
+# ---------------------------------------------------------------------------
+# A captured child interrupted with SIGINT
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def alarm_sigint():
+    """Deliver a real SIGINT to this process shortly after the child starts.
+
+    An alarm rather than a helper thread: ``SIGALRM`` reaches the main thread,
+    which is the one parked in the child's ``waitpid``, so the interrupt lands
+    inside the capture instead of after it. What the handler then raises is the
+    genuine signal — the ``KeyboardInterrupt`` comes from Python's own SIGINT
+    handling, not from the test.
+    """
+
+    def fire(_signum, _frame):
+        signal.raise_signal(signal.SIGINT)
+
+    previous = signal.signal(signal.SIGALRM, fire)
+    try:
+        yield lambda seconds=0.4: signal.setitimer(signal.ITIMER_REAL, seconds)
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous)
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGALRM"), reason="POSIX signal delivery")
+def test_an_interrupted_capture_names_its_partial_spool_and_does_not_replay_it(
+    monkeypatch, capfd, wide, stubs, alarm_sigint, repo
+):
+    """Ctrl-C is a decision, not a diagnosis.
+
+    The operator who stops a deploy has not asked to read the log of the half
+    of it that ran; they have asked for it to stop. So the spool is named in one
+    line and left on disk, and replaying it here would bury the one thing worth
+    saying under the output of a run nobody is waiting on any more.
+    """
+    from osprey.deployment import container_lifecycle
+    from osprey.deployment.subprocess_capture import run_captured
+
+    def interrupted(*args, **kwargs) -> None:
+        repo_root = Path(args[0])
+        alarm_sigint()
+        run_captured(
+            ["sh", "-c", "cat poison.txt; sleep 30"],
+            cwd=repo_root,
+            spool_name="probe",
+            repo_root=repo_root,
+        )
+
+    monkeypatch.setattr(container_lifecycle, "down_deployment", interrupted)
+
+    status = run_verb("down")
+
+    assert status != 0
+    out = capfd.readouterr().out
+
+    # The child got far enough to write, and what it wrote survived the kill.
+    spool = spools(repo)[0]
+    assert POISON in spool.read_text()
+
+    # One line, naming that file, from the phase's own teardown.
+    named = [line for line in out.splitlines() if "partial output:" in line]
+    assert len(named) == 1, out
+    assert named[0].lstrip().startswith("⚠ Stopping")
+    assert str(spool) in named[0]
+
+    # And no replay: the content stayed in the file it was written to.
+    assert POISON not in out
+    assert f"--- {spool} ---" not in out
+
+
+# ---------------------------------------------------------------------------
+# One failure marker per failure
+# ---------------------------------------------------------------------------
+
+
+def test_a_dev_refusal_prints_one_failure_marker(monkeypatch, capfd, wide, stubs, repo):
+    """The ✗ belongs to the phase that stopped, and there is one of those.
+
+    The handler's job is the reason and the remedy; a second ✗ in front of them
+    reads as a second thing having gone wrong.
+    """
+    from osprey.deployment import container_lifecycle
+    from osprey.deployment.errors import DevModeUnavailableError
+
+    def refuse(*args, **kwargs):
+        raise DevModeUnavailableError("this render carries no wheel", "osprey build --dev")
+
+    monkeypatch.setattr(container_lifecycle, "up_as_built", refuse)
+
+    status = run_verb("up", "-d", "--dev")
+
+    assert status != 0
+    out = capfd.readouterr().out
+    assert out.count("✗") == 1, out
+    assert "--dev cannot be honored: this render carries no wheel" in out
+    assert "osprey build --dev" in out
+
+
+def test_a_captured_build_failure_is_not_reported_as_unexpected(monkeypatch, caplog, tmp_path):
+    """A child that exited non-zero is a build failure with a log to read.
+
+    The catch-all it used to land in called it "Unexpected error" and put a ✗ in
+    front of it — a second marker over the phase's own, under a heading that
+    tells the operator nothing about what to do next.
+    """
+    from osprey.cli import build_cmd, build_profile
+    from osprey.deployment.errors import CapturedProcessError
+
+    spool = tmp_path / "var" / "logs" / "compose-config-20260101-000000.log"
+
+    def boom(*args, **kwargs):
+        raise CapturedProcessError(["docker", "compose", "config"], 1, spool)
+
+    monkeypatch.setattr(build_cmd, "find_repo_root", lambda repo=None: tmp_path)
+    monkeypatch.setattr(build_profile, "resolve_build_document", boom)
+
+    with caplog.at_level(logging.ERROR), pytest.raises(click.Abort):
+        build_cmd._build_repo(
+            tmp_path, stream=False, skip_lifecycle=True, skip_deps=True, runtime_root=None
+        )
+
+    assert "Build failed:" in caplog.text
+    assert str(spool) in caplog.text
+    assert "Unexpected error" not in caplog.text
+    assert "✗" not in caplog.text

--- a/tests/cli/test_freeze_base_environment.py
+++ b/tests/cli/test_freeze_base_environment.py
@@ -153,7 +153,9 @@ def test_freeze_logs_duration(
     python, _ = base_venv
     write_dist(clean_site_packages, "lmfit", "1.3.2")
 
-    with caplog.at_level("INFO", logger="build"):
+    # DEBUG: the freeze duration is build-internal detail, below the phase lines
+    # the verb now prints.
+    with caplog.at_level("DEBUG", logger="build"):
         freeze_base_environment(python, [])
 
     assert any("Froze 1 packages" in r.message and "s)" in r.message for r in caplog.records)

--- a/tests/cli/test_lifecycle_phases.py
+++ b/tests/cli/test_lifecycle_phases.py
@@ -1,0 +1,634 @@
+"""The lifecycle verbs' wiring to the phase reporter.
+
+What is asserted here is the wiring, not the rendering: which reporter each verb
+installs, that a chained verb reports into the outer verb's reporter instead of
+installing a second one, and the phase titles each verb opens in order. The line
+shapes themselves belong to ``test_phase_reporter.py``.
+
+Phase lines are read off a recording reporter rather than out of ``result.output``
+on purpose. Reporter output goes through the Rich console singleton, which wraps
+to the terminal width a CliRunner happens to present, so an assertion on captured
+stdout is an assertion about wrapping.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from osprey.cli.main import cli
+from osprey.cli.phase_reporter import (
+    PhaseReporter,
+    current_reporter,
+    install_reporter,
+    is_verbose,
+)
+
+
+class RecordingReporter(PhaseReporter):
+    """A real reporter that keeps its lines instead of printing them."""
+
+    def __init__(self) -> None:
+        super().__init__(color=False)
+        self.lines: list[str] = []
+
+    def emit(self, text: str, style: str | None = None) -> None:
+        self.lines.append(text)
+
+
+def titles(reporter: RecordingReporter) -> list[str]:
+    """The phase-opening lines, in the order the verb opened them."""
+    return [line for line in reporter.lines if line.startswith("→ ")]
+
+
+def closed(reporter: RecordingReporter) -> list[str]:
+    """The phase-closing lines (✓/✗/⚠), stripped of their indent, in order."""
+    return [line.strip() for line in reporter.lines if line.lstrip()[:1] in {"✓", "✗", "⚠"}]
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def recorder():
+    """Pre-install a recording reporter, as an outer verb would have.
+
+    Verbs invoked with this in place find a reporter already installed and
+    report into it — the same path ``init --up`` puts ``build`` and ``up`` on.
+    """
+    recording = RecordingReporter()
+    previous = install_reporter(recording)
+    try:
+        yield recording
+    finally:
+        install_reporter(previous)
+
+
+@pytest.fixture
+def restore_reporter():
+    """Put the module handle back, for tests that let a verb install its own."""
+    previous = current_reporter()
+    try:
+        yield
+    finally:
+        install_reporter(previous)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A directory standing in for a built deployment repo."""
+    (tmp_path / "build").mkdir()
+    (tmp_path / "build" / "config.yml").write_text("{}\n")
+    return tmp_path
+
+
+@pytest.fixture
+def seen() -> list:
+    """Where the stubs record what reporter was installed when they ran."""
+    return []
+
+
+@pytest.fixture
+def deploy_stubs(monkeypatch, repo: Path, seen: list):
+    """Stub everything `up`/`restart`/`down` reach outside the CLI layer."""
+    from osprey.cli import deploy_cmd, repo_resolver
+    from osprey.deployment import container_lifecycle
+
+    monkeypatch.setattr(
+        repo_resolver, "find_repo_root", lambda start=None: Path(start) if start else repo
+    )
+    monkeypatch.setattr(deploy_cmd, "gate_start_from_build", lambda *a, **k: None)
+    monkeypatch.setattr(deploy_cmd, "ensure_repo_env", lambda *a, **k: None)
+    monkeypatch.setattr(deploy_cmd, "load_project_config", lambda *a, **k: {})
+    monkeypatch.setattr(
+        container_lifecycle, "as_built_config_path", lambda root: repo / "build" / "config.yml"
+    )
+
+    def record(verb: str):
+        def stub(*args, **kwargs):
+            seen.append((verb, type(current_reporter()).__name__, is_verbose()))
+
+        return stub
+
+    monkeypatch.setattr(container_lifecycle, "up_as_built", record("up"))
+    monkeypatch.setattr(container_lifecycle, "restart_deployment", record("restart"))
+    monkeypatch.setattr(container_lifecycle, "down_deployment", record("down"))
+    return seen
+
+
+# ---------------------------------------------------------------------------
+# Which reporter gets installed
+# ---------------------------------------------------------------------------
+
+
+class TestInstalledReporter:
+    """A verb installs one reporter, and `--verbose` decides which."""
+
+    @pytest.mark.parametrize("verb", ["up", "restart", "down"])
+    def test_a_start_or_stop_verb_installs_a_real_reporter(
+        self, runner, deploy_stubs, restore_reporter, verb
+    ):
+        result = runner.invoke(cli, [verb])
+
+        assert result.exit_code == 0, result.output
+        assert deploy_stubs == [(verb, "PhaseReporter", False)]
+
+    @pytest.mark.parametrize("verb", ["up", "restart", "down"])
+    def test_verbose_installs_a_null_reporter_that_says_it_is_verbose(
+        self, runner, deploy_stubs, restore_reporter, verb
+    ):
+        """A bare NullReporter would silence the phases AND leave `is_verbose()`
+        False, which is what the capture helper reads to decide between
+        streaming a subprocess and spooling it. Under `--verbose` the operator
+        asked for the stream, so the flag has to travel with the reporter."""
+        result = runner.invoke(cli, ["--verbose", verb])
+
+        assert result.exit_code == 0, result.output
+        assert deploy_stubs == [(verb, "NullReporter", True)]
+
+    def test_the_default_handle_is_restored_afterwards(
+        self, runner, deploy_stubs, restore_reporter
+    ):
+        """The install is scoped to the verb: a process that goes on to do
+        something else must not keep printing into a finished run's reporter."""
+        before = current_reporter()
+
+        result = runner.invoke(cli, ["down"])
+
+        assert result.exit_code == 0, result.output
+        assert current_reporter() is before
+
+    def test_an_already_installed_reporter_is_not_clobbered(self, runner, deploy_stubs, recorder):
+        """The rule the `init --up` chain rests on: an inner verb reports into
+        the reporter it finds rather than installing a second one."""
+        result = runner.invoke(cli, ["up"])
+
+        assert result.exit_code == 0, result.output
+        assert deploy_stubs == [("up", "RecordingReporter", False)]
+        assert current_reporter() is recorder
+
+
+# ---------------------------------------------------------------------------
+# The phases each verb opens
+# ---------------------------------------------------------------------------
+
+
+class TestDeployVerbPhases:
+    def test_up_reports_a_preflight_and_then_the_start(self, runner, deploy_stubs, recorder, repo):
+        result = runner.invoke(cli, ["up", "-d"])
+
+        assert result.exit_code == 0, result.output
+        assert titles(recorder) == ["→ Preflight", f"→ Starting {repo.name}"]
+        assert closed(recorder)[0].startswith("✓ Preflight")
+        assert closed(recorder)[0].endswith("— build/ and .env are in place")
+        assert closed(recorder)[1].startswith(f"✓ Starting {repo.name}")
+
+    def test_restart_reports_the_stop_and_start_as_one_phase(
+        self, runner, deploy_stubs, recorder, repo
+    ):
+        """`restart` recreates the containers in one call. A ✓ on a separate
+        stop phase would read as "it is down now" while the start is still to
+        come."""
+        result = runner.invoke(cli, ["restart", "-d"])
+
+        assert result.exit_code == 0, result.output
+        assert titles(recorder) == ["→ Preflight", f"→ Restarting {repo.name}"]
+
+    def test_down_reports_one_stopping_phase(self, runner, deploy_stubs, recorder, repo):
+        result = runner.invoke(cli, ["down"])
+
+        assert result.exit_code == 0, result.output
+        assert titles(recorder) == [f"→ Stopping {repo.name}"]
+
+    def test_an_attached_start_renders_its_phases_up_to_the_exec_point(
+        self, runner, deploy_stubs, recorder, monkeypatch, repo
+    ):
+        """Attached (`up` without `-d`) hands the terminal to compose with
+        os.execvpe, so this process is gone before the start phase can close.
+        What is guaranteed is what this asserts: the phases before the exec are
+        rendered, and the start phase is open when the exec happens."""
+        from osprey.deployment import container_lifecycle
+
+        open_phase: list[str | None] = []
+
+        def stub(*args, **kwargs):
+            phase = current_reporter().current_phase
+            open_phase.append(phase.title if phase else None)
+
+        monkeypatch.setattr(container_lifecycle, "up_as_built", stub)
+
+        result = runner.invoke(cli, ["up"])
+
+        assert result.exit_code == 0, result.output
+        assert open_phase == [f"Starting {repo.name}"]
+        assert closed(recorder)[0].startswith("✓ Preflight")
+
+    def test_a_failed_start_closes_its_phase_before_the_error(
+        self, runner, deploy_stubs, recorder, monkeypatch, repo
+    ):
+        """The ✗ line has to come from the phase, not from the handler: the
+        handler's message is about the deployment, the phase line is about which
+        step of the run stopped."""
+        from osprey.deployment import container_lifecycle
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("compose said no")
+
+        monkeypatch.setattr(container_lifecycle, "up_as_built", boom)
+
+        result = runner.invoke(cli, ["up", "-d"])
+
+        assert result.exit_code != 0
+        assert closed(recorder)[-1].startswith(f"✗ Starting {repo.name}")
+
+    def test_preflight_fails_its_phase_when_there_is_no_build(
+        self, runner, deploy_stubs, recorder, monkeypatch, tmp_path
+    ):
+        from osprey.deployment import container_lifecycle
+
+        monkeypatch.setattr(
+            container_lifecycle,
+            "as_built_config_path",
+            lambda root: tmp_path / "gone" / "config.yml",
+        )
+
+        result = runner.invoke(cli, ["up", "-d"])
+
+        assert result.exit_code != 0
+        assert titles(recorder) == ["→ Preflight"]
+        assert closed(recorder) == [closed(recorder)[0]]
+        assert closed(recorder)[0].startswith("✗ Preflight")
+
+
+class TestBuildPhases:
+    """`build` reports the venv and the six render passes.
+
+    Everything under the verb is stubbed: what is asserted is which phases the
+    render opens and in what order, and no real build is run for it.
+    """
+
+    @pytest.fixture
+    def build_stubs(self, monkeypatch, tmp_path: Path, seen):
+        from osprey.cli import build_cmd, build_profile, build_profile_deploy
+
+        class _Lifecycle:
+            pre_build = None
+            post_build = None
+            validate = None
+
+        class _Profile:
+            name = "probe"
+            data_bundle = "control-assistant"
+            provider = "anthropic"
+            requires_osprey_version = None
+            dependencies: list[str] = []
+            lifecycle = _Lifecycle()
+            config: dict = {}
+            deploy = None
+
+            def resolved_tier(self) -> int:
+                return 1
+
+        class _Resolved:
+            profile = _Profile()
+            excluded_artifacts: list[str] = []
+
+        (tmp_path / "profile.yml").write_text("name: probe\n")
+        monkeypatch.setattr(build_cmd, "find_repo_root", lambda repo=None: tmp_path)
+        monkeypatch.setattr(build_profile, "resolve_build_document", lambda *a, **k: _Resolved())
+        monkeypatch.setattr(build_profile_deploy, "deploy_aware_config_errors", lambda *a: [])
+        monkeypatch.setattr(build_cmd, "TemplateManager", lambda *a, **k: object())
+        monkeypatch.setattr(build_cmd, "_create_project_venv", lambda *a, **k: [])
+
+        def _render(*a, injected_out=None, **k):
+            """Stand in for a render, recording one injected service."""
+            if injected_out is not None:
+                injected_out.append("event dispatch")
+
+        monkeypatch.setattr(build_cmd, "_render_project", _render)
+        monkeypatch.setattr(build_cmd, "_render_compose_files", lambda *a, **k: {})
+        monkeypatch.setattr(
+            build_cmd, "_render_persona_projects", lambda *a, **k: [tmp_path / "readonly"]
+        )
+        monkeypatch.setattr(
+            build_cmd, "_render_container_projects", lambda *a, **k: [tmp_path / "image"]
+        )
+        monkeypatch.setattr(build_cmd, "_backup_outgoing_claude_artifacts", lambda *a, **k: None)
+        monkeypatch.setattr(build_cmd, "_prune_runtime_state_from_stage", lambda *a, **k: None)
+        monkeypatch.setattr(build_cmd, "_swap_in_render", lambda *a, **k: None)
+        monkeypatch.setattr(build_cmd, "_wire_build_derived_env", lambda *a, **k: None)
+        monkeypatch.setattr(build_cmd, "_warn_if_deployment_running", lambda *a, **k: None)
+        return seen
+
+    def test_build_reports_the_venv_and_the_render(self, runner, build_stubs, recorder):
+        """Six render passes, one phase. Reported one by one they would read as
+        six builds of six different things."""
+        result = runner.invoke(cli, ["build"])
+
+        assert result.exit_code == 0, result.output
+        assert titles(recorder) == [
+            "→ Preparing the project environment",
+            "→ Rendering the configuration",
+        ]
+        steps = [line.split(" (")[0].strip() for line in recorder.lines if "·" in line]
+        assert steps == [
+            "· project files, agent artifacts and services",
+            # Named once, from the deployment's render — the other five passes
+            # inject the same set and say nothing about it.
+            "· services injected: event dispatch",
+            "· compose files",
+            "· 1 persona render(s)",
+            "· 1 image build context(s)",
+        ]
+
+    def test_skip_deps_opens_no_environment_phase(self, runner, build_stubs, recorder):
+        """--skip-deps is CI's "there is no venv to make". A phase announced for
+        work that was skipped is the kind of small lie this feature removes."""
+        result = runner.invoke(cli, ["build", "--skip-deps"])
+
+        assert result.exit_code == 0, result.output
+        assert titles(recorder) == ["→ Rendering the configuration"]
+
+    @pytest.fixture
+    def installed(self, monkeypatch):
+        """What `build` had installed by the time the render would have run."""
+        from osprey.cli import build_cmd
+
+        recorded: list[tuple[str, bool]] = []
+        monkeypatch.setattr(
+            build_cmd,
+            "_build_repo",
+            lambda *a, **k: recorded.append((type(current_reporter()).__name__, is_verbose())),
+        )
+        return recorded
+
+    def test_build_installs_its_own_reporter(
+        self, runner, build_stubs, restore_reporter, installed
+    ):
+        result = runner.invoke(cli, ["build"])
+
+        assert result.exit_code == 0, result.output
+        assert installed == [("PhaseReporter", False)]
+
+    def test_verbose_silences_the_build_phases(
+        self, runner, build_stubs, restore_reporter, installed
+    ):
+        """The render is the biggest captured-subprocess consumer on the build
+        path, so `is_verbose()` being True here is what makes `--verbose` mean
+        "stream it" rather than just "print no phases"."""
+        result = runner.invoke(cli, ["--verbose", "build"])
+
+        assert result.exit_code == 0, result.output
+        assert installed == [("NullReporter", True)]
+
+
+class TestResetPhases:
+    """`reset` gets a reporter, but keeps reporting on its own `emit` callback."""
+
+    @pytest.fixture
+    def reset_stub(self, monkeypatch, repo: Path, seen):
+        from osprey.cli import reset_cmd
+        from osprey.deployment import reset as reset_mod
+
+        # reset_cmd binds find_repo_root at import, so the name to replace is
+        # the one in reset_cmd, not the one in repo_resolver.
+        monkeypatch.setattr(reset_cmd, "find_repo_root", lambda start=None: repo)
+        monkeypatch.setattr(reset_mod, "reset_deployment", lambda *a, **k: _record(seen))
+        return seen
+
+    def test_reset_installs_a_reporter_and_opens_no_phase(self, runner, reset_stub, recorder):
+        result = runner.invoke(cli, ["reset", "--dry-run", "-y"])
+
+        assert result.exit_code == 0, result.output
+        assert reset_stub == [("reset", "RecordingReporter", False)]
+        assert recorder.lines == []
+
+    def test_verbose_reaches_reset_too(self, runner, reset_stub, restore_reporter):
+        """Reset's teardown reaches the same captured-subprocess helpers the
+        start verbs do, and `--verbose` has to mean the same thing there."""
+        result = runner.invoke(cli, ["--verbose", "reset", "--dry-run", "-y"])
+
+        assert result.exit_code == 0, result.output
+        assert reset_stub == [("reset", "NullReporter", True)]
+
+
+def _record(seen):
+    """Record the installed reporter, then end the reset as a dry run."""
+    from osprey.deployment.reset import ResetOutcome
+
+    seen.append(("reset", type(current_reporter()).__name__, is_verbose()))
+    return ResetOutcome.DRY_RUN
+
+
+# ---------------------------------------------------------------------------
+# init, and the one reporter its --up chain shares
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def init_stubs(monkeypatch, seen):
+    """Stub what `init` reaches outside the CLI layer, and the chained verbs.
+
+    `find_repo_root` is deliberately NOT stubbed: `init` asks it whether the
+    target would nest inside an existing deployment, and the chained verbs ask
+    it where the deployment they were handed is. Both answers have to come from
+    the same directory the run actually creates, so the materialize stub writes
+    the `profile.yml` that makes the target a repo — the one thing the real
+    helper does that the rest of the chain depends on.
+    """
+    from osprey.cli import build_cmd, deploy_cmd, init_cmd, profile_cmd
+    from osprey.deployment import container_lifecycle
+
+    class _Materialized:
+        profile_name = "probe"
+        deploy_declared = False
+
+    def materialize(target, *args, **kwargs):
+        Path(target).mkdir(parents=True, exist_ok=True)
+        (Path(target) / "profile.yml").write_text("name: probe\n")
+        return _Materialized()
+
+    def rendered_config(root: Path) -> Path:
+        path = Path(root) / "build" / "config.yml"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n")
+        return path
+
+    monkeypatch.setattr(profile_cmd, "_materialize_profile_directory", materialize)
+    monkeypatch.setattr(init_cmd, "_emit_ci", lambda target, declared: [])
+    monkeypatch.setattr(init_cmd, "_report", lambda *a, **k: None)
+
+    # The chain: both verbs are looked up on the root group and invoked for
+    # real, so what is stubbed is the work under them, not the wiring.
+    monkeypatch.setattr(build_cmd, "_build_repo", lambda *a, **k: _seen(seen, "build"))
+    monkeypatch.setattr(deploy_cmd, "gate_start_from_build", lambda *a, **k: None)
+    monkeypatch.setattr(deploy_cmd, "ensure_repo_env", lambda *a, **k: None)
+    monkeypatch.setattr(deploy_cmd, "load_project_config", lambda *a, **k: {})
+    monkeypatch.setattr(container_lifecycle, "as_built_config_path", rendered_config)
+    monkeypatch.setattr(container_lifecycle, "up_as_built", lambda *a, **k: _seen(seen, "up"))
+    return seen
+
+
+def _seen(seen, verb: str) -> None:
+    seen.append((verb, type(current_reporter()).__name__, id(current_reporter())))
+
+
+class TestInitPhases:
+    def test_init_reports_one_creation_phase(self, runner, init_stubs, recorder, tmp_path):
+        target = tmp_path / "probe"
+
+        result = runner.invoke(
+            cli, ["init", str(target), "--preset", "control-assistant", "--no-git"]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert titles(recorder) == ["→ Creating probe"]
+        assert "  · source zone from preset control-assistant" in [
+            line.split(" (")[0] for line in recorder.lines
+        ]
+        assert closed(recorder)[-1].startswith("✓ Creating probe")
+
+    def test_a_refused_init_opens_no_phase(self, runner, init_stubs, recorder, tmp_path):
+        """A run that is turned away prints its reason and nothing else — a
+        `→ Creating x` above it would announce work that never started."""
+        result = runner.invoke(cli, ["init", str(tmp_path / "probe")])
+
+        assert result.exit_code != 0
+        assert recorder.lines == []
+
+    def test_the_up_chain_reports_into_one_reporter(self, runner, init_stubs, recorder, tmp_path):
+        """`init --up` is three commands and one run. The chained verbs find
+        this reporter through the module handle — nothing is threaded through
+        their signatures — so the operator reads one sequence of phases."""
+        target = tmp_path / "probe"
+
+        result = runner.invoke(
+            cli,
+            ["init", str(target), "--preset", "control-assistant", "--no-git", "--up", "-d"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert [verb for verb, _, _ in init_stubs] == ["build", "up"]
+        assert {name for _, name, _ in init_stubs} == {"RecordingReporter"}
+        assert len({handle for _, _, handle in init_stubs}) == 1
+        assert titles(recorder) == ["→ Creating probe", "→ Preflight", "→ Starting probe"]
+
+    def test_the_chain_shares_the_reporter_init_installed(
+        self, runner, init_stubs, restore_reporter, tmp_path
+    ):
+        """Same property with nothing pre-installed: the reporter the chained
+        verbs report into is the one `init` installed, not one of their own."""
+        target = tmp_path / "probe"
+
+        result = runner.invoke(
+            cli,
+            ["init", str(target), "--preset", "control-assistant", "--no-git", "--up", "-d"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert {name for _, name, _ in init_stubs} == {"PhaseReporter"}
+        assert len({handle for _, _, handle in init_stubs}) == 1
+
+
+# ---------------------------------------------------------------------------
+# What `--verbose` puts back
+# ---------------------------------------------------------------------------
+
+
+class _RecordSink(logging.Handler):
+    """Every record that survived the level filter, as its formatted message."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.messages: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.messages.append(record.getMessage())
+
+
+@pytest.fixture
+def debug_probe(monkeypatch, deploy_stubs, restore_reporter):
+    """One DEBUG record emitted from inside a running verb, and what survived.
+
+    The demoted call sites all still log — at DEBUG, which
+    ``test_build_output_quiet.py`` pins. What decides whether an operator ever
+    SEES them again is the level `--verbose` hands ``configure_logging``, and
+    that is a different link in the chain from the reporter the verb installs.
+    Emitting from inside the verb reads the level the group callback actually
+    applied, rather than the one the flag was supposed to imply.
+    """
+    from osprey.deployment import container_lifecycle
+
+    sink = _RecordSink()
+    root = logging.getLogger()
+    previous_level = root.level
+    root.addHandler(sink)
+
+    monkeypatch.setattr(
+        container_lifecycle,
+        "down_deployment",
+        lambda *a, **k: logging.getLogger("build").debug("a demoted call site speaking"),
+    )
+    try:
+        yield sink
+    finally:
+        root.removeHandler(sink)
+        root.setLevel(previous_level)
+
+
+def test_the_default_view_still_filters_the_demoted_records_out(runner, debug_probe):
+    """Without the flag the demotion is a real one: the record never emits."""
+    result = runner.invoke(cli, ["down"])
+
+    assert result.exit_code == 0, result.output
+    assert debug_probe.messages == []
+
+
+def test_verbose_lets_the_demoted_records_through(runner, debug_probe):
+    """SC4: `--verbose` is the escape hatch for everything SC1 took off INFO."""
+    result = runner.invoke(cli, ["--verbose", "down"])
+
+    assert result.exit_code == 0, result.output
+    assert "a demoted call site speaking" in debug_probe.messages
+
+
+# ---------------------------------------------------------------------------
+# The lazy-import budget
+# ---------------------------------------------------------------------------
+
+
+def test_a_fresh_interpreter_neither_imports_nor_installs_a_reporter():
+    """Two invariants that only a fresh process can be asked about.
+
+    First: `osprey --help` must not pay for the reporter, which is why the
+    verbs import `phase_reporter` inside their command bodies — a top-level
+    import anywhere on the CLI entry path would put it back on the budget.
+
+    Second: the module default is a NullReporter that does NOT claim
+    verbosity. That is the one shape no verb ever installs, which is what makes
+    "somebody already installed one" decidable at all.
+
+    In-process both questions are unanswerable: this test module has imported
+    the reporter, and every test above installs one.
+    """
+    probe = (
+        "import sys; import osprey.cli.main;"
+        "print('osprey.cli.phase_reporter' in sys.modules);"
+        "from osprey.cli.phase_reporter import NullReporter, current_reporter;"
+        "d = current_reporter();"
+        "print(isinstance(d, NullReporter), d.verbose)"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, timeout=180
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.split() == ["False", "True", "False"]

--- a/tests/cli/test_phase_reporter.py
+++ b/tests/cli/test_phase_reporter.py
@@ -1,0 +1,305 @@
+"""Tests for the lifecycle phase reporter (plain-line progress output)."""
+
+import io
+from types import SimpleNamespace
+
+import pytest
+from rich.console import Console
+
+from osprey.cli import phase_reporter
+from osprey.cli.phase_reporter import (
+    NullReporter,
+    PhaseReporter,
+    current_reporter,
+    format_elapsed,
+    install_reporter,
+    is_verbose,
+)
+from osprey.cli.styles import osprey_theme
+
+
+@pytest.fixture
+def sink(monkeypatch):
+    """Capture reporter output through a forced-terminal console.
+
+    force_terminal mirrors the win32 console in ``styles``: it proves the
+    no-ANSI guarantee comes from the reporter, not from Rich noticing a pipe.
+    """
+    buffer = io.StringIO()
+    monkeypatch.setattr(
+        phase_reporter,
+        "console",
+        Console(file=buffer, theme=osprey_theme, force_terminal=True, width=200),
+    )
+    return buffer
+
+
+@pytest.fixture
+def fake_clock(monkeypatch):
+    """Drive the reporter's elapsed arithmetic from a scripted monotonic clock.
+
+    Patches the module's own ``time`` reference, not ``time.monotonic``
+    itself, so nothing else in the process sees the fake clock.
+    """
+
+    def install(*ticks):
+        stream = iter(ticks)
+        monkeypatch.setattr(phase_reporter, "time", SimpleNamespace(monotonic=lambda: next(stream)))
+
+    return install
+
+
+@pytest.fixture(autouse=True)
+def restore_installed_reporter():
+    """Leave the module singleton exactly as the test found it."""
+    original = current_reporter()
+    yield
+    install_reporter(original)
+
+
+def test_format_elapsed_seconds_and_minutes():
+    assert format_elapsed(0.0) == "0.0s"
+    assert format_elapsed(3.44) == "3.4s"
+    assert format_elapsed(59.9) == "59.9s"
+    assert format_elapsed(60) == "1m00s"
+    assert format_elapsed(127.6) == "2m07s"
+
+
+def test_phase_lifecycle_lines(sink):
+    reporter = PhaseReporter(color=False)
+    with reporter.phase("Rendering configuration") as phase:
+        phase.step("compose")
+        phase.done("6 files")
+
+    lines = [line for line in sink.getvalue().splitlines() if line.strip()]
+    assert lines[0] == "→ Rendering configuration"
+    assert lines[1].startswith("  · compose")
+    assert lines[2].startswith("  ✓ Rendering configuration (")
+    assert lines[2].endswith("— 6 files")
+
+
+def test_done_reports_elapsed_from_monotonic(sink, fake_clock):
+    fake_clock(100.0, 190.5)
+
+    reporter = PhaseReporter(color=False)
+    reporter.phase("Building images").done()
+
+    assert "✓ Building images (1m30s)" in sink.getvalue()
+
+
+def test_step_reports_lap_and_suppresses_instant_laps(sink, fake_clock):
+    # phase start, first step, second step
+    fake_clock(0.0, 0.01, 12.0)
+
+    reporter = PhaseReporter(color=False)
+    phase = reporter.phase("Building images")
+    phase.step("web-terminal")
+    phase.step("project")
+
+    lines = [line for line in sink.getvalue().splitlines() if line.strip()]
+    assert lines[1] == "  · web-terminal"
+    assert lines[2] == "  · project (12.0s)"
+
+
+def test_non_tty_output_has_no_ansi_escapes(sink):
+    reporter = PhaseReporter(color=False)
+    with reporter.phase("Starting stack") as phase:
+        phase.step("compose up")
+
+    output = sink.getvalue()
+    assert "\x1b[" not in output
+    assert "→ Starting stack" in output
+    assert "  · compose up" in output
+
+
+def test_color_defaults_to_stdout_isatty(monkeypatch):
+    monkeypatch.setattr(phase_reporter.sys, "stdout", io.StringIO())
+    assert PhaseReporter().color is False
+
+
+def test_tty_output_is_styled(sink):
+    PhaseReporter(color=True).phase("Starting stack").done()
+    assert "\x1b[" in sink.getvalue()
+
+
+def test_teardown_runs_on_exception_and_replays_spool(sink, tmp_path):
+    spool = tmp_path / "build-images.log"
+    spool.write_text("step 1/3\nERROR: no such image\n")
+
+    reporter = PhaseReporter(color=False)
+    with pytest.raises(RuntimeError):
+        with reporter.phase("Building images") as phase:
+            phase.set_spool(spool)
+            raise RuntimeError("compose failed")
+
+    output = sink.getvalue()
+    assert "✗ Building images (" in output
+    assert "ERROR: no such image" in output
+    assert str(spool) in output
+
+
+def test_fail_dumps_replay_content_in_full(sink, tmp_path):
+    spool = tmp_path / "up.log"
+    spool.write_text("line one\nline two\nline three\n")
+
+    reporter = PhaseReporter(color=False)
+    reporter.phase("Starting stack").fail(spool)
+
+    output = sink.getvalue()
+    for line in ("line one", "line two", "line three"):
+        assert line in output
+
+
+def test_fail_without_replay_prints_only_the_failure_line(sink):
+    reporter = PhaseReporter(color=False)
+    reporter.phase("Provider check").fail(None)
+
+    lines = [line for line in sink.getvalue().splitlines() if line.strip()]
+    assert len(lines) == 2
+    assert lines[0] == "→ Provider check"
+    assert lines[1].startswith("  ✗ Provider check (")
+
+
+def test_fail_reports_unreadable_spool_without_raising(sink, tmp_path):
+    reporter = PhaseReporter(color=False)
+    reporter.phase("Starting stack").fail(tmp_path / "missing.log")
+
+    assert "could not read spool" in sink.getvalue()
+
+
+def test_explicit_fail_is_not_repeated_by_teardown(sink, tmp_path):
+    spool = tmp_path / "build.log"
+    spool.write_text("boom\n")
+
+    reporter = PhaseReporter(color=False)
+    with pytest.raises(RuntimeError):
+        with reporter.phase("Building images") as phase:
+            phase.fail(spool)
+            raise RuntimeError("propagated")
+
+    assert sink.getvalue().count("boom") == 1
+    assert sink.getvalue().count("✗ Building images") == 1
+
+
+@pytest.mark.parametrize("code", [0, None])
+def test_a_clean_systemexit_closes_the_phase_as_a_success(sink, tmp_path, code):
+    """``down`` ends by exiting on compose's status; exit 0 is not a failure.
+
+    Without this the successful path prints ``✗`` and replays the entire spool
+    it just captured — the exact noise the phase lines exist to remove.
+    """
+    spool = tmp_path / "down.log"
+    spool.write_text("compose chatter\n")
+
+    reporter = PhaseReporter(color=False)
+    with pytest.raises(SystemExit):
+        with reporter.phase("Stopping myrepo"):
+            reporter.note_spool(spool)
+            raise SystemExit(code)
+
+    assert "✓ Stopping myrepo" in sink.getvalue()
+    assert "✗" not in sink.getvalue()
+    assert "compose chatter" not in sink.getvalue()
+
+
+@pytest.mark.parametrize("code", [1, "boom"])
+def test_a_nonzero_systemexit_still_fails_the_phase(sink, tmp_path, code):
+    """Only a clean exit is a success; a failing one keeps the replay."""
+    spool = tmp_path / "down.log"
+    spool.write_text("compose chatter\n")
+
+    reporter = PhaseReporter(color=False)
+    with pytest.raises(SystemExit):
+        with reporter.phase("Stopping myrepo"):
+            reporter.note_spool(spool)
+            raise SystemExit(code)
+
+    assert "✗ Stopping myrepo" in sink.getvalue()
+    assert "compose chatter" in sink.getvalue()
+
+
+def test_interrupt_names_partial_spool_without_replaying(sink, tmp_path):
+    spool = tmp_path / "up.log"
+    spool.write_text("half a log\n")
+
+    reporter = PhaseReporter(color=False)
+    with pytest.raises(KeyboardInterrupt):
+        with reporter.phase("Starting stack"):
+            reporter.note_spool(spool)
+            raise KeyboardInterrupt
+
+    lines = [line for line in sink.getvalue().splitlines() if line.strip()]
+    assert len(lines) == 2
+    assert lines[1].startswith("  ⚠ Starting stack interrupted (")
+    assert str(spool) in lines[1]
+    assert "half a log" not in sink.getvalue()
+
+
+def test_interrupt_without_spool_prints_one_line(sink):
+    reporter = PhaseReporter(color=False)
+    with pytest.raises(KeyboardInterrupt):
+        with reporter.phase("Project environment"):
+            raise KeyboardInterrupt
+
+    lines = [line for line in sink.getvalue().splitlines() if line.strip()]
+    assert len(lines) == 2
+    assert lines[1] == lines[1].rstrip()
+    assert "partial output" not in lines[1]
+
+
+def test_current_phase_tracks_the_open_phase(sink):
+    reporter = PhaseReporter(color=False)
+    assert reporter.current_phase is None
+    with reporter.phase("Repo created") as phase:
+        assert reporter.current_phase is phase
+    assert reporter.current_phase is None
+
+
+def test_note_spool_without_an_open_phase_is_harmless(sink, tmp_path):
+    reporter = PhaseReporter(color=False)
+    reporter.note_spool(tmp_path / "orphan.log")
+    assert sink.getvalue() == ""
+
+
+def test_null_reporter_emits_nothing(sink, tmp_path):
+    spool = tmp_path / "verbose.log"
+    spool.write_text("streamed live already\n")
+
+    reporter = NullReporter()
+    with reporter.phase("Building images") as phase:
+        phase.step("web-terminal")
+        phase.set_spool(spool)
+        phase.fail(spool)
+
+    assert sink.getvalue() == ""
+
+
+def test_null_reporter_swallows_interrupt_teardown(sink):
+    reporter = NullReporter(verbose=True)
+    with pytest.raises(KeyboardInterrupt):
+        with reporter.phase("Starting stack"):
+            raise KeyboardInterrupt
+
+    assert sink.getvalue() == ""
+
+
+def test_install_and_current_reporter_round_trip():
+    reporter = PhaseReporter(color=False)
+    previous = install_reporter(reporter)
+
+    assert current_reporter() is reporter
+    assert install_reporter(previous) is reporter
+    assert current_reporter() is previous
+
+
+def test_default_reporter_is_quiet_and_not_verbose():
+    assert isinstance(current_reporter(), NullReporter)
+    assert is_verbose() is False
+
+
+def test_is_verbose_follows_the_installed_reporter():
+    install_reporter(NullReporter(verbose=True))
+    assert is_verbose() is True
+
+    install_reporter(PhaseReporter(color=False))
+    assert is_verbose() is False

--- a/tests/cli/test_summary_card.py
+++ b/tests/cli/test_summary_card.py
@@ -1,0 +1,430 @@
+"""The closing summary card, and which verbs print one.
+
+Three things are asserted here and kept apart on purpose: what the card SAYS
+(rendered from a repo and a state), that it says it through the phase reporter,
+and WHICH verb prints one — a detached start, never an attached one, and exactly
+one for a whole ``init --up`` chain rather than one per verb in it.
+
+Card lines are read off a recording reporter or off the renderer directly,
+never out of ``result.output``: reporter output goes through the Rich console
+singleton, which wraps to whatever width a CliRunner presents, so an assertion
+on captured stdout is an assertion about wrapping — and the card carries a
+filesystem path, which is exactly what wrapping breaks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from osprey.cli import summary_card
+from osprey.cli.main import cli
+from osprey.cli.phase_reporter import (
+    NullReporter,
+    PhaseReporter,
+    current_reporter,
+    install_reporter,
+)
+from osprey.cli.summary_card import format_summary_card, owns_summary_card, print_summary_card
+
+
+class RecordingReporter(PhaseReporter):
+    """A real reporter that keeps its lines instead of printing them."""
+
+    def __init__(self) -> None:
+        super().__init__(color=False)
+        self.lines: list[str] = []
+
+    def emit(self, text: str, style: str | None = None) -> None:
+        self.lines.append(text)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def recorder():
+    """Install a recording reporter for the duration of one test."""
+    recording = RecordingReporter()
+    previous = install_reporter(recording)
+    try:
+        yield recording
+    finally:
+        install_reporter(previous)
+
+
+@pytest.fixture
+def restore_reporter():
+    """Put the module handle back, for tests that let a verb install its own."""
+    previous = current_reporter()
+    try:
+        yield
+    finally:
+        install_reporter(previous)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A deployment repo whose build declares one web-terminal endpoint."""
+    build = tmp_path / "build"
+    build.mkdir()
+    (build / "config.yml").write_text(
+        "project_name: demo\n"
+        "deployed_services: []\n"
+        "modules:\n"
+        "  web_terminals:\n"
+        "    enabled: true\n"
+        "    nginx_port: 8080\n"
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def cards(monkeypatch) -> list[tuple[Path, str]]:
+    """Record every card a verb asks for, without rendering any.
+
+    The verbs import the function inside their own body, so patching the
+    module attribute catches the call however the verb was reached.
+    """
+    printed: list[tuple[Path, str]] = []
+    monkeypatch.setattr(
+        summary_card, "print_summary_card", lambda root, state: printed.append((Path(root), state))
+    )
+    return printed
+
+
+# ---------------------------------------------------------------------------
+# What the card says
+# ---------------------------------------------------------------------------
+
+
+class TestCardContent:
+    def test_the_card_leads_with_the_deployment_name_and_its_state(self, repo: Path) -> None:
+        """The repo's directory name IS the deployment's name — the same one the
+        compose project and the container labels carry."""
+        assert format_summary_card(repo, "running")[0] == f"{repo.name} — running"
+
+    def test_a_running_card_shows_the_urls_the_render_declares(self, repo: Path) -> None:
+        """Read out of the repo's own build/, so the card cannot name an endpoint
+        that this deployment does not publish."""
+        card = "\n".join(format_summary_card(repo, "running"))
+
+        assert "web terminal" in card
+        assert "http://127.0.0.1:8080" in card
+
+    def test_only_addresses_that_can_be_opened_reach_the_card(
+        self, repo: Path, monkeypatch
+    ) -> None:
+        """A card is the "what now" surface: the addresses on it are the ones
+        somebody can act on. Bare host:port services, and the explicit
+        "not configured" facts, stay on `osprey status`, which lists them all."""
+        from osprey.deployment import deploy_summary
+
+        monkeypatch.setattr(
+            deploy_summary,
+            "as_built_endpoint_entries",
+            lambda root: [
+                ("event-dispatcher", "http://127.0.0.1:8001"),
+                ("postgres", "127.0.0.1:5432"),
+                ("web terminal", "(not configured in this project)"),
+            ],
+        )
+
+        card = "\n".join(format_summary_card(repo, "running"))
+
+        assert "http://127.0.0.1:8001" in card
+        assert "postgres" not in card
+        assert "not configured" not in card
+
+    @pytest.mark.parametrize("state", ["created", "built", "stopped"])
+    def test_a_deployment_that_is_not_running_advertises_no_endpoints(
+        self, repo: Path, state: str
+    ) -> None:
+        """Nothing answers on them, and a URL printed under `down` reads as an
+        invitation to open something that is not there."""
+        assert "http://" not in "\n".join(format_summary_card(repo, state))
+
+    def test_the_card_says_where_the_command_output_went(self, repo: Path) -> None:
+        """The spool directory is the one thing a quiet run cannot be read back
+        from anywhere else."""
+        card = "\n".join(format_summary_card(repo, "running"))
+
+        assert str(repo / "var" / "logs") in card
+
+    @pytest.mark.parametrize(
+        ("state", "expected"),
+        [
+            ("created", "osprey build"),
+            ("built", "osprey up -d"),
+            ("running", "osprey down"),
+            ("stopped", "osprey up -d"),
+        ],
+    )
+    def test_every_state_ends_with_the_command_that_follows_it(
+        self, repo: Path, state: str, expected: str
+    ) -> None:
+        assert expected in format_summary_card(repo, state)[-1]
+
+    def test_the_endpoints_come_from_the_endpoint_summary_module(
+        self, repo: Path, monkeypatch
+    ) -> None:
+        """One derivation of "what answers where", not two. The card asks
+        deploy_summary for this repo's entries rather than reading ports out of
+        the compose files a second way — two readers would eventually disagree
+        about the same deployment."""
+        from osprey.deployment import deploy_summary
+
+        asked: list[Path] = []
+
+        def record(root):
+            asked.append(Path(root))
+            return []
+
+        monkeypatch.setattr(deploy_summary, "as_built_endpoint_entries", record)
+
+        format_summary_card(repo, "running")
+
+        assert asked == [repo]
+
+
+# ---------------------------------------------------------------------------
+# How it is printed
+# ---------------------------------------------------------------------------
+
+
+class TestCardPrinting:
+    def test_the_card_prints_through_the_installed_reporter(
+        self, repo: Path, recorder: RecordingReporter
+    ) -> None:
+        """Same path as the phase lines, so the card is plain, unwrapped, and
+        colored only when stdout is a terminal."""
+        print_summary_card(repo, "running")
+
+        assert recorder.lines[0] == ""
+        assert recorder.lines[1] == f"{repo.name} — running"
+        assert any("http://127.0.0.1:8080" in line for line in recorder.lines)
+
+    def test_a_card_that_cannot_be_rendered_does_not_fail_the_verb(
+        self, repo: Path, recorder: RecordingReporter, monkeypatch
+    ) -> None:
+        """The work succeeded. An unreadable render is not a reason to end a
+        successful deploy with an error."""
+        from osprey.deployment import deploy_summary
+
+        def boom(root):
+            raise RuntimeError("build/ moved under us")
+
+        monkeypatch.setattr(deploy_summary, "as_built_endpoint_entries", boom)
+
+        print_summary_card(repo, "running")
+
+        assert recorder.lines == []
+
+    def test_a_repo_with_nothing_rendered_still_gets_a_card(self, tmp_path: Path) -> None:
+        """`osprey init` prints one before anything has been built."""
+        card = format_summary_card(tmp_path, "created")
+
+        assert card[0] == f"{tmp_path.name} — created"
+
+
+class TestCardOwnership:
+    """Who prints the card is decided by the same rule as who owns the reporter."""
+
+    def test_a_verb_that_finds_the_quiet_default_owns_the_card(self, restore_reporter) -> None:
+        install_reporter(NullReporter())
+
+        assert owns_summary_card() is True
+
+    def test_a_verb_chained_under_another_one_does_not(self, recorder) -> None:
+        assert owns_summary_card() is False
+
+    def test_a_verb_chained_under_a_verbose_run_does_not_either(self, restore_reporter) -> None:
+        """`--verbose` installs a NullReporter that is not the quiet default:
+        the flag travels with it, and the outer verb still owns the run."""
+        install_reporter(NullReporter(verbose=True))
+
+        assert owns_summary_card() is False
+
+
+# ---------------------------------------------------------------------------
+# Which verbs print one
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def deploy_stubs(monkeypatch, repo: Path):
+    """Stub everything `up`/`restart`/`down` reach outside the CLI layer."""
+    from osprey.cli import deploy_cmd, repo_resolver
+    from osprey.deployment import container_lifecycle
+
+    monkeypatch.setattr(
+        repo_resolver, "find_repo_root", lambda start=None: Path(start) if start else repo
+    )
+    monkeypatch.setattr(deploy_cmd, "gate_start_from_build", lambda *a, **k: None)
+    monkeypatch.setattr(deploy_cmd, "ensure_repo_env", lambda *a, **k: None)
+    monkeypatch.setattr(deploy_cmd, "load_project_config", lambda *a, **k: {})
+    monkeypatch.setattr(
+        container_lifecycle, "as_built_config_path", lambda root: repo / "build" / "config.yml"
+    )
+    monkeypatch.setattr(container_lifecycle, "up_as_built", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "restart_deployment", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "down_deployment", lambda *a, **k: None)
+
+
+class TestVerbsThatPrintOne:
+    @pytest.mark.parametrize("verb", ["up", "restart"])
+    def test_a_detached_start_ends_with_a_running_card(
+        self, runner, deploy_stubs, restore_reporter, cards, repo: Path, verb: str
+    ) -> None:
+        result = runner.invoke(cli, [verb, "-d"])
+
+        assert result.exit_code == 0, result.output
+        assert cards == [(repo, "running")]
+
+    @pytest.mark.parametrize("verb", ["up", "restart"])
+    def test_an_attached_start_prints_no_card(
+        self, runner, deploy_stubs, restore_reporter, cards, verb: str
+    ) -> None:
+        """Attached, compose owns the terminal from the exec point on: `up` never
+        comes back to print a card, and a `restart` that ends in the log stream
+        has nothing to append it to."""
+        result = runner.invoke(cli, [verb])
+
+        assert result.exit_code == 0, result.output
+        assert cards == []
+
+    def test_down_ends_with_a_stopped_card(
+        self, runner, deploy_stubs, restore_reporter, cards, repo: Path
+    ) -> None:
+        result = runner.invoke(cli, ["down"])
+
+        assert result.exit_code == 0, result.output
+        assert cards == [(repo, "stopped")]
+
+    def test_a_failed_start_prints_no_card(
+        self, runner, deploy_stubs, restore_reporter, cards, monkeypatch
+    ) -> None:
+        """The card states what is now true. Nothing is running, so nothing on
+        it would be."""
+        from osprey.deployment import container_lifecycle
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("compose said no")
+
+        monkeypatch.setattr(container_lifecycle, "up_as_built", boom)
+
+        result = runner.invoke(cli, ["up", "-d"])
+
+        assert result.exit_code != 0
+        assert cards == []
+
+    def test_a_start_chained_under_another_verb_leaves_the_card_to_it(
+        self, runner, deploy_stubs, recorder, cards
+    ) -> None:
+        """The mechanism `init --up` rests on: a verb that finds a reporter
+        already installed reports into it and prints no card of its own."""
+        result = runner.invoke(cli, ["up", "-d"])
+
+        assert result.exit_code == 0, result.output
+        assert cards == []
+
+
+# ---------------------------------------------------------------------------
+# The chain, and the one verb that gets a line instead
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def chain_stubs(monkeypatch):
+    """Stub the render and the start, leaving the chain itself real."""
+    from osprey.cli import build_cmd, deploy_cmd
+    from osprey.deployment import container_lifecycle
+
+    monkeypatch.setattr(build_cmd, "_build_repo", lambda *a, **k: None)
+    monkeypatch.setattr(deploy_cmd, "gate_start_from_build", lambda *a, **k: None)
+    monkeypatch.setattr(deploy_cmd, "_preflight", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "up_as_built", lambda *a, **k: None)
+
+
+class TestTheInitChain:
+    def test_a_fresh_repo_ends_with_a_created_card(
+        self, runner, restore_reporter, cards, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "demo"
+
+        result = runner.invoke(
+            cli, ["init", str(target), "--preset", "hello-world"], catch_exceptions=False
+        )
+
+        assert result.exit_code == 0, result.output
+        assert cards == [(target, "created")]
+
+    def test_init_up_prints_exactly_one_card_for_the_whole_chain(
+        self, runner, restore_reporter, chain_stubs, cards, tmp_path: Path
+    ) -> None:
+        """`init --up -d` runs three verbs — create, build, start — as one run.
+        Three cards for one run is the duplication this replaces, so the outer
+        verb prints the only one, and it describes the end state."""
+        target = tmp_path / "chained"
+
+        result = runner.invoke(
+            cli,
+            ["init", str(target), "--preset", "hello-world", "--up", "-d"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0, result.output
+        assert cards == [(target, "running")]
+
+    def test_build_on_its_own_ends_with_a_built_card(
+        self, runner, restore_reporter, chain_stubs, cards, repo: Path, monkeypatch
+    ) -> None:
+        from osprey.cli import build_cmd
+
+        monkeypatch.setattr(build_cmd, "find_repo_root", lambda start=None: repo)
+
+        result = runner.invoke(cli, ["build"])
+
+        assert result.exit_code == 0, result.output
+        assert cards == [(repo, "built")]
+
+
+class TestResetGetsALineNotACard:
+    def test_reset_says_it_is_finished_through_its_own_emit_callback(
+        self, recorder: RecordingReporter, monkeypatch, tmp_path: Path
+    ) -> None:
+        """`reset` prints a plan, asks, and destroys; its ending belongs to that
+        transcript, in the same voice and through the same callback, not on a
+        card describing a deployment that no longer exists."""
+        from osprey.deployment import reset as reset_module
+
+        class FakePlan:
+            project = "demo"
+            repo_root = tmp_path
+            removes_anything = True
+
+            def render(self):
+                return ["Reset plan for demo:"]
+
+            def confirmation_summary(self):
+                return "1 container"
+
+        class FakeProbe:
+            failures: list[tuple[str, str]] = []
+
+        monkeypatch.setattr(reset_module, "plan_reset", lambda *a, **k: FakePlan())
+        monkeypatch.setattr(reset_module, "execute_reset", lambda *a, **k: None)
+        monkeypatch.setattr(reset_module, "confirm_destroy", lambda *a, **k: True)
+
+        lines: list[str] = []
+        reset_module.reset_deployment(
+            tmp_path, assume_yes=True, emit=lines.append, probe=FakeProbe()
+        )
+
+        assert lines[-1] == "Reset complete. `osprey build && osprey up -d` starts demo again."
+        assert lines.count("Reset complete. `osprey build && osprey up -d` starts demo again.") == 1
+        assert recorder.lines == []

--- a/tests/deployment/test_bluesky_token_mint.py
+++ b/tests/deployment/test_bluesky_token_mint.py
@@ -10,6 +10,7 @@ launch attempt after a fresh deploy.
 from __future__ import annotations
 
 import secrets
+import subprocess
 
 import pytest
 
@@ -36,8 +37,11 @@ def captured_argv(monkeypatch, tmp_path):
         container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
     )
 
-    def _fake_run(cmd, env=None, check=False):
+    def _fake_run(cmd, env=None, check=False, **kwargs):
         captured["cmd"] = cmd
+        # run_captured hangs its spool path off the result, so the stand-in has
+        # to be an object, and it passes redirection kwargs this ignores.
+        return subprocess.CompletedProcess(list(cmd), 0)
 
     monkeypatch.setattr(container_lifecycle.subprocess, "run", _fake_run)
     return captured
@@ -154,7 +158,11 @@ def test_bluesky_alongside_dispatch_mints_both_independently(
     monkeypatch.setattr(
         container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
     )
-    monkeypatch.setattr(container_lifecycle.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(
+        container_lifecycle.subprocess,
+        "run",
+        lambda cmd, **k: subprocess.CompletedProcess(list(cmd), 0),
+    )
 
     container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
 

--- a/tests/deployment/test_clean_path_capture.py
+++ b/tests/deployment/test_clean_path_capture.py
@@ -1,0 +1,148 @@
+"""The clean/rebuild path spools its compose output instead of the terminal.
+
+``clean_deployment`` runs two compose invocations back to back. Both used to
+inherit this process's stdio, so a rebuild buried the phase lines under compose's
+own progress stream. They now go through :func:`run_captured`, and each announces
+itself as a step on the open phase.
+
+Two properties matter beyond the routing itself and are asserted per site:
+
+* ``check=False`` — a clean over a deployment that was never up exits non-zero,
+  and that has always been tolerated. Capturing must not promote it to a
+  failure.
+* ``repo_root=`` — the spool lands under the deployment repo's ``var/logs/``,
+  not under whatever directory the operator happened to stand in.
+"""
+
+import logging
+
+import pytest
+
+from osprey.cli.phase_reporter import install_reporter
+from osprey.deployment import compose_generator
+
+
+class _RecordingPhase:
+    """A stand-in for :class:`osprey.cli.phase_reporter.Phase` that records steps."""
+
+    def __init__(self):
+        self.steps = []
+
+    def step(self, name):
+        self.steps.append(name)
+
+
+class _RecordingReporter:
+    def __init__(self, phase):
+        self.current_phase = phase
+
+
+@pytest.fixture(autouse=True)
+def stub_runtime(monkeypatch):
+    """Answer the runtime probe from a fixture instead of the host's daemon.
+
+    ``clean_deployment`` builds both compose commands from
+    :func:`get_runtime_command`, which detects a *running* runtime and raises
+    when it finds none. Nothing below asserts on the detection — the argv checks
+    read the subcommand tail — so on a machine with no daemon these tests would
+    fail for the host's state rather than for the routing under test.
+    """
+    monkeypatch.setattr(
+        compose_generator, "get_runtime_command", lambda config=None: ["docker", "compose"]
+    )
+
+
+@pytest.fixture
+def captured_runs(monkeypatch):
+    """Replace ``run_captured`` in compose_generator's namespace, recording calls."""
+    calls = []
+
+    def _fake_run_captured(cmd, **kwargs):
+        calls.append((list(cmd), kwargs))
+        return None
+
+    monkeypatch.setattr(compose_generator, "run_captured", _fake_run_captured)
+    return calls
+
+
+@pytest.fixture
+def phase():
+    """Install a recording phase as the reporter's open phase."""
+    recording = _RecordingPhase()
+    previous = install_reporter(_RecordingReporter(recording))
+    yield recording
+    install_reporter(previous)
+
+
+@pytest.fixture
+def clean_run(captured_runs, phase, tmp_path):
+    """Run ``clean_deployment`` pinned to ``tmp_path`` as the deployment repo."""
+    compose_generator.clean_deployment(
+        ["docker-compose.yml"], {"project_name": "myproj", "project_root": str(tmp_path)}
+    )
+    return captured_runs
+
+
+def test_clean_runs_exactly_two_captured_commands(clean_run):
+    assert len(clean_run) == 2
+
+
+def test_down_site_argv_ends_with_the_down_subcommand(clean_run):
+    cmd, _ = clean_run[0]
+    assert cmd[-3:] == ["down", "--volumes", "--remove-orphans"]
+
+
+def test_rmi_site_argv_ends_with_the_rmi_subcommand(clean_run):
+    cmd, _ = clean_run[1]
+    assert cmd[-3:] == ["down", "--rmi", "all"]
+
+
+def test_each_site_spools_under_its_own_descriptive_name(clean_run):
+    names = [kwargs["spool_name"] for _, kwargs in clean_run]
+    assert names == ["compose-clean-down", "compose-clean-rmi"]
+
+
+def test_each_site_pins_the_spool_to_the_deployment_repo(clean_run, tmp_path):
+    for _, kwargs in clean_run:
+        assert kwargs["repo_root"] == tmp_path.absolute()
+
+
+def test_neither_site_promotes_a_tolerated_non_zero_exit_to_a_failure(clean_run):
+    """Both invocations tolerated non-zero before capture; they still must."""
+    assert [kwargs["check"] for _, kwargs in clean_run] == [False, False]
+
+
+def test_each_site_still_receives_the_pinned_compose_environment(clean_run):
+    for _, kwargs in clean_run:
+        assert kwargs["env"]["COMPOSE_PROJECT_NAME"] == "myproj"
+
+
+def test_each_site_announces_itself_as_a_step_on_the_open_phase(clean_run, phase):
+    assert len(phase.steps) == 2
+    assert phase.steps[0] != phase.steps[1]
+
+
+def test_clean_runs_when_no_phase_is_open(captured_runs, tmp_path):
+    """No open phase is the normal case for a library caller — not an error."""
+    previous = install_reporter(_RecordingReporter(None))
+    try:
+        compose_generator.clean_deployment(["docker-compose.yml"], {"project_root": str(tmp_path)})
+    finally:
+        install_reporter(previous)
+
+    assert len(captured_runs) == 2
+
+
+def test_production_mode_line_is_not_emitted_at_info(tmp_path, caplog):
+    """It fires once per service build context on every production build."""
+    with caplog.at_level(logging.INFO):
+        compose_generator._stage_dev_wheel_for_context(str(tmp_path), dev_mode=False)
+
+    assert "Production mode" not in caplog.text
+
+
+def test_production_mode_line_is_still_available_at_debug(tmp_path, caplog):
+    with caplog.at_level(logging.DEBUG):
+        compose_generator._stage_dev_wheel_for_context(str(tmp_path), dev_mode=False)
+
+    assert "Production mode: Containers will install osprey from PyPI" in caplog.text

--- a/tests/deployment/test_compose_generator.py
+++ b/tests/deployment/test_compose_generator.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -565,7 +566,7 @@ def test_dev_wheel_build_uses_sys_executable(monkeypatch: pytest.MonkeyPatch) ->
         # Return non-zero so the function bails before trying to copy a wheel.
         return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="stop here")
 
-    monkeypatch.setattr(compose_generator.subprocess, "run", _fake_run)
+    monkeypatch.setattr(subprocess, "run", _fake_run)
     # A failed build now aborts the deploy rather than falling back to the
     # released package; the interpreter assertion below is what this test is for.
     with pytest.raises(DevModeUnavailableError):
@@ -2335,8 +2336,6 @@ def spy_wheel_build(monkeypatch: pytest.MonkeyPatch) -> list:
     """
     import subprocess as subprocess_module
 
-    from osprey.deployment import compose_generator
-
     calls: list = []
     real_run = subprocess_module.run
 
@@ -2348,7 +2347,7 @@ def spy_wheel_build(monkeypatch: pytest.MonkeyPatch) -> list:
             return subprocess_module.CompletedProcess(cmd, 0, stdout="", stderr="")
         return real_run(cmd, **kwargs)
 
-    monkeypatch.setattr(compose_generator.subprocess, "run", _fake_run)
+    monkeypatch.setattr(subprocess, "run", _fake_run)
     return calls
 
 
@@ -2506,7 +2505,6 @@ def test_dev_deploy_aborts_on_build_failure_and_stages_nothing(
     the deploy must abort, and no wheel may be left in the build context."""
     import subprocess as subprocess_module
 
-    from osprey.deployment import compose_generator
     from osprey.deployment.errors import DevModeUnavailableError
 
     real_run = subprocess_module.run
@@ -2518,7 +2516,7 @@ def test_dev_deploy_aborts_on_build_failure_and_stages_nothing(
             )
         return real_run(cmd, **kwargs)
 
-    monkeypatch.setattr(compose_generator.subprocess, "run", _failing_build)
+    monkeypatch.setattr(subprocess, "run", _failing_build)
 
     config_path = _write_dispatch_stack_config(tmp_path, deployed=["event_dispatcher"])
     _copy_service_templates(tmp_path)
@@ -2808,7 +2806,6 @@ def test_staging_fails_closed_when_manifest_cannot_be_derived(
     still lacks the local wheel's added deps (half-staged)."""
     import subprocess as subprocess_module
 
-    from osprey.deployment import compose_generator
     from osprey.deployment.compose_generator import _copy_local_framework_for_override
     from osprey.deployment.errors import DevModeUnavailableError
 
@@ -2821,7 +2818,7 @@ def test_staging_fails_closed_when_manifest_cannot_be_derived(
             return subprocess_module.CompletedProcess(cmd, 0, stdout="", stderr="")
         return real_run(cmd, **kwargs)
 
-    monkeypatch.setattr(compose_generator.subprocess, "run", _fake_run)
+    monkeypatch.setattr(subprocess, "run", _fake_run)
 
     ctx = tmp_path / "ctx"
     ctx.mkdir()

--- a/tests/deployment/test_container_lifecycle.py
+++ b/tests/deployment/test_container_lifecycle.py
@@ -41,9 +41,10 @@ def captured_argv(monkeypatch, tmp_path):
         container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
     )
 
-    def _fake_run(cmd, env=None, check=False):
+    def _fake_run(cmd, env=None, check=False, **kwargs):
         captured["cmd"] = cmd
         captured["env"] = env
+        return _FakeCompletedProcess(returncode=0)
 
     monkeypatch.setattr(container_lifecycle.subprocess, "run", _fake_run)
     return captured
@@ -178,7 +179,9 @@ def test_non_dispatch_deploy_generates_no_tokens(monkeypatch, _clean_token_env, 
     monkeypatch.setattr(
         container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
     )
-    monkeypatch.setattr(container_lifecycle.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(
+        container_lifecycle.subprocess, "run", lambda *a, **k: _FakeCompletedProcess()
+    )
 
     container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
 
@@ -1138,36 +1141,28 @@ def _mock_down_config(monkeypatch, project_name, extra=None):
     )
 
 
-def test_deploy_down_pins_compose_project_name(monkeypatch, tmp_path):
-    """deploy_down must target the same project it brought up — pinned, and via
-    execvpe (env-carrying), not the bare-env execvp."""
-    monkeypatch.chdir(tmp_path)
-    _mock_down_config(monkeypatch, "myproj")
-    captured: dict = {}
-    # Guard BOTH exec variants: the fix flips execvp -> execvpe, and an
-    # unpatched real execvp would replace the test process.
-    monkeypatch.setattr(
-        container_lifecycle.os, "execvp", lambda file, args: captured.update(args=args, env=None)
-    )
-    monkeypatch.setattr(
-        container_lifecycle.os,
-        "execvpe",
-        lambda file, args, env: captured.update(file=file, args=args, env=env),
-    )
-    container_lifecycle.deploy_down(str(tmp_path / "config.yml"))
-    assert captured["env"]["COMPOSE_PROJECT_NAME"] == "myproj"
-    assert "down" in captured["args"]
+# deploy_down's own compose invocation — the pin it carries and the web-stack
+# ordering around it — is covered against the captured-run seam in
+# tests/deployment/test_down_conversion.py, which owns the conversion. What is
+# only asserted here is the *negative* branch: a project with the module off
+# must not touch the web stack at all.
 
 
-def _capture_exec_and_web_down(monkeypatch):
-    """Record the services execvpe and any deploy_down_web_terminals call."""
-    captured: dict = {"web_down_order": None, "exec_order": None}
+def _capture_services_down_and_web_down(monkeypatch):
+    """Record the services compose ``down`` and any deploy_down_web_terminals call.
+
+    ``down`` no longer ``execvpe``-replaces the process; it runs through
+    ``run_captured`` and exits on the child's code, so the seam to patch is
+    ``container_lifecycle.run_captured`` and the caller must expect SystemExit.
+    """
+    captured: dict = {"web_down_order": None, "down_order": None}
     order = iter(range(100))
-    monkeypatch.setattr(
-        container_lifecycle.os,
-        "execvpe",
-        lambda file, args, env: captured.update(args=args, env=env, exec_order=next(order)),
-    )
+
+    def _fake_run_captured(cmd, **kwargs):
+        captured.update(args=list(cmd), env=kwargs.get("env"), down_order=next(order))
+        return _FakeCompletedProcess(returncode=0)
+
+    monkeypatch.setattr(container_lifecycle, "run_captured", _fake_run_captured)
     monkeypatch.setattr(
         container_lifecycle,
         "deploy_down_web_terminals",
@@ -1178,36 +1173,15 @@ def _capture_exec_and_web_down(monkeypatch):
     return captured
 
 
-def test_deploy_down_tears_down_web_stack_before_services(monkeypatch, tmp_path):
-    """With modules.web_terminals.enabled, deploy_down must run the web
-    stack's own `compose down` (deploy_up_web_terminals' mirror) BEFORE the
-    services execvpe replaces the process — the services `-f` list can never
-    carry docker-compose.web.yml (root-relative paths), so skipping this
-    leaves the fixed-name web/nginx containers running after every
-    `osprey down`."""
-    monkeypatch.chdir(tmp_path)
-    _mock_down_config(
-        monkeypatch, "myproj", extra={"modules": {"web_terminals": {"enabled": True}}}
-    )
-    captured = _capture_exec_and_web_down(monkeypatch)
-
-    container_lifecycle.deploy_down(str(tmp_path / "config.yml"))
-
-    assert captured["web_down_order"] is not None, "web stack was never torn down"
-    assert captured["web_down_order"] < captured["exec_order"], (
-        "web-stack down must run before the process-replacing services down"
-    )
-    assert captured["web_down_config"]["project_name"] == "myproj"
-
-
 def test_deploy_down_skips_web_stack_when_module_disabled(monkeypatch, tmp_path):
     """No modules.web_terminals.enabled → the plain services-only down, no
     web-stack invocation."""
     monkeypatch.chdir(tmp_path)
     _mock_down_config(monkeypatch, "myproj")
-    captured = _capture_exec_and_web_down(monkeypatch)
+    captured = _capture_services_down_and_web_down(monkeypatch)
 
-    container_lifecycle.deploy_down(str(tmp_path / "config.yml"))
+    with pytest.raises(SystemExit):
+        container_lifecycle.deploy_down(str(tmp_path / "config.yml"))
 
     assert captured["web_down_order"] is None
     assert "down" in captured["args"]
@@ -1257,7 +1231,9 @@ def test_rebuild_deployment_pins_compose_project_name(monkeypatch, tmp_path):
         container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
     )
     # The stale-container `rm -f` preflight lands on subprocess.run; swallow it.
-    monkeypatch.setattr(container_lifecycle.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(
+        container_lifecycle.subprocess, "run", lambda *a, **k: _FakeCompletedProcess()
+    )
     captured: dict = {}
     monkeypatch.setattr(
         container_lifecycle.os,
@@ -1280,7 +1256,9 @@ def test_clean_deployment_pins_compose_project_name(monkeypatch, tmp_path):
     )
     envs: list = []
     monkeypatch.setattr(
-        compose_generator.subprocess, "run", lambda cmd, env=None, **k: envs.append(env)
+        compose_generator,
+        "run_captured",
+        lambda cmd, env=None, **k: envs.append(env) or _FakeCompletedProcess(),
     )
     compose_generator.clean_deployment(["docker-compose.yml"], {"project_name": "myproj"})
     assert envs, "clean_deployment ran no compose commands"
@@ -1317,7 +1295,9 @@ def test_deploy_up_dev_mode_splits_build_from_up(monkeypatch, tmp_path):
     )
     runs: list = []
     monkeypatch.setattr(
-        container_lifecycle.subprocess, "run", lambda cmd, env=None, **k: runs.append(cmd)
+        container_lifecycle.subprocess,
+        "run",
+        lambda cmd, env=None, **k: runs.append(cmd) or _FakeCompletedProcess(),
     )
     container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True, dev_mode=True)
 
@@ -1347,7 +1327,9 @@ def test_rebuild_deployment_dev_mode_splits_build_from_up(monkeypatch, tmp_path)
     )
     runs: list = []
     monkeypatch.setattr(
-        container_lifecycle.subprocess, "run", lambda cmd, env=None, **k: runs.append(cmd)
+        container_lifecycle.subprocess,
+        "run",
+        lambda cmd, env=None, **k: runs.append(cmd) or _FakeCompletedProcess(),
     )
     execd: dict = {}
     monkeypatch.setattr(
@@ -1447,7 +1429,9 @@ def captured_plain_runs(monkeypatch, tmp_path):
         container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
     )
     monkeypatch.setattr(
-        container_lifecycle.subprocess, "run", lambda cmd, env=None, **k: calls.append(list(cmd))
+        container_lifecycle.subprocess,
+        "run",
+        lambda cmd, env=None, **k: calls.append(list(cmd)) or _FakeCompletedProcess(),
     )
     return calls
 
@@ -1610,7 +1594,11 @@ def _project_image_dev_build_cmds(monkeypatch, tmp_path, staging_result):
         lambda project_root: staging_result,
     )
     calls = []
-    monkeypatch.setattr(container_lifecycle.subprocess, "run", lambda cmd, **k: calls.append(cmd))
+    monkeypatch.setattr(
+        container_lifecycle.subprocess,
+        "run",
+        lambda cmd, **k: calls.append(cmd) or _FakeCompletedProcess(),
+    )
     config = {"project_name": "myfacility", "deployed_services": ["dispatch_worker"]}
     container_lifecycle._build_project_image(config, dev_mode=True, env={})
     return calls
@@ -1642,7 +1630,9 @@ def test_build_project_image_dev_cleans_staged_wheel_and_manifest(monkeypatch, t
     monkeypatch.setattr(
         container_lifecycle, "_copy_local_framework_for_override", _fake_wheel_and_manifest_stage
     )
-    monkeypatch.setattr(container_lifecycle.subprocess, "run", lambda cmd, **k: None)
+    monkeypatch.setattr(
+        container_lifecycle.subprocess, "run", lambda cmd, **k: _FakeCompletedProcess()
+    )
     config = {"project_name": "myfacility", "deployed_services": ["dispatch_worker"]}
 
     container_lifecycle._build_project_image(config, dev_mode=True, env={})
@@ -1697,7 +1687,9 @@ def _wiring_calls(monkeypatch, tmp_path):
     monkeypatch.setattr(
         container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
     )
-    monkeypatch.setattr(container_lifecycle.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(
+        container_lifecycle.subprocess, "run", lambda *a, **k: _FakeCompletedProcess()
+    )
     monkeypatch.setattr(
         container_lifecycle,
         "warn_if_project_stale",
@@ -1820,7 +1812,9 @@ def test_deploy_up_no_web_terminals_skips_preflight(monkeypatch, tmp_path):
         "_build_project_image",
         lambda *a, **k: order.append("build_image"),
     )
-    monkeypatch.setattr(container_lifecycle.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(
+        container_lifecycle.subprocess, "run", lambda *a, **k: _FakeCompletedProcess()
+    )
     monkeypatch.setattr(container_lifecycle, "log_endpoint_summary", lambda *a, **k: None)
 
     container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
@@ -1999,10 +1993,14 @@ def staged_archiver(monkeypatch, tmp_path):
     monkeypatch.setattr(container_lifecycle, "_build_project_image", lambda *a, **k: None)
     monkeypatch.setattr(container_lifecycle, "log_endpoint_summary", lambda *a, **k: None)
 
-    def _fake_run(cmd, env=None, check=False):
+    def _fake_run(cmd, env=None, check=False, **kwargs):
         state["cmds"].append(list(cmd))
         # A real CompletedProcess, because the quiesce checks its returncode.
-        return subprocess.CompletedProcess(list(cmd), state["returncode"])
+        # `returncode` models the *quiesce* specifically: every other compose
+        # call runs under check=True, so a blanket non-zero would abort the
+        # deploy before the behaviour under test is reached.
+        rc = state["returncode"] if "stop" in cmd else 0
+        return subprocess.CompletedProcess(list(cmd), rc)
 
     monkeypatch.setattr(container_lifecycle.subprocess, "run", _fake_run)
 

--- a/tests/deployment/test_down_conversion.py
+++ b/tests/deployment/test_down_conversion.py
@@ -1,0 +1,313 @@
+"""``deploy_down`` runs compose through the capture helper, not ``execvpe``.
+
+The legacy ``down`` used to hand itself to ``os.execvpe``, which made its
+output impossible to capture: the compose child inherited the terminal and this
+process was gone. It now runs through :func:`run_captured` and exits on the
+child's own status, so the spool file and the phase reporter both survive the
+call — while the reason ``execvpe`` (and not ``execvp``) was chosen in the first
+place, the ``COMPOSE_PROJECT_NAME`` pin, still has to reach compose.
+
+The attached ``up``/``restart`` paths are deliberately still ``execvpe``: there
+the operator WANTS compose's live output, so those are guarded here against an
+over-broad conversion.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from osprey.deployment import container_lifecycle
+
+
+def _mock_down_config(monkeypatch, project_name="myproj", extra=None):
+    """Wire deploy_down's config load and compose-file discovery to fixtures."""
+    raw_config = {"project_name": project_name, "deployed_services": ["event_dispatcher"]}
+    raw_config.update(extra or {})
+    monkeypatch.setattr(container_lifecycle, "load_project_config", lambda p, **kwargs: raw_config)
+    monkeypatch.setattr(
+        "osprey.deployment.compose_generator.find_existing_compose_files",
+        lambda *a, **k: ["docker-compose.yml"],
+    )
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+
+
+def _forbid_exec(monkeypatch):
+    """Make any ``os.exec*`` from the code under test a loud failure.
+
+    Both variants, and both loudly: an unpatched real ``execvp`` would replace
+    the test process rather than fail it.
+    """
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("the down path must not exec away")
+
+    monkeypatch.setattr(container_lifecycle.os, "execvp", _boom)
+    monkeypatch.setattr(container_lifecycle.os, "execvpe", _boom)
+
+
+def _capture_run(monkeypatch, returncode=0):
+    """Patch run_captured in container_lifecycle's namespace; record its call."""
+    calls: list[dict] = []
+
+    def _fake(cmd, **kwargs):
+        calls.append({"cmd": list(cmd), **kwargs})
+        return subprocess.CompletedProcess(list(cmd), returncode)
+
+    monkeypatch.setattr(container_lifecycle, "run_captured", _fake)
+    return calls
+
+
+def test_down_runs_compose_through_the_capture_helper(monkeypatch, tmp_path):
+    """The compose ``down`` is a captured run, spooled under its own name."""
+    monkeypatch.chdir(tmp_path)
+    _mock_down_config(monkeypatch)
+    _forbid_exec(monkeypatch)
+    calls = _capture_run(monkeypatch)
+
+    with pytest.raises(SystemExit):
+        container_lifecycle.deploy_down(str(tmp_path / "config.yml"))
+
+    assert len(calls) == 1, calls
+    call = calls[0]
+    assert "down" in call["cmd"]
+    assert call["spool_name"] == "compose-down"
+    assert call["repo_root"] is not None
+
+
+def test_down_carries_the_pinned_compose_project_name(monkeypatch, tmp_path):
+    """SC8: the pin ``execvpe`` existed to deliver must reach the captured run.
+
+    Unpinned, ``down`` either misses this deploy's containers or tears down the
+    shared "services" project that every deploy on the host collapses into.
+    """
+    monkeypatch.chdir(tmp_path)
+    _mock_down_config(monkeypatch, "myproj")
+    _forbid_exec(monkeypatch)
+    calls = _capture_run(monkeypatch)
+
+    with pytest.raises(SystemExit):
+        container_lifecycle.deploy_down(str(tmp_path / "config.yml"))
+
+    env = calls[0]["env"]
+    assert env is not None, "the captured run inherited the parent env, losing the pin"
+    assert env["COMPOSE_PROJECT_NAME"] == "myproj"
+    # The rest of the environment still comes through — the pin is an overlay on
+    # os.environ, not a replacement for it (compose reads PATH, DOCKER_HOST, ...).
+    assert "PATH" in env
+
+
+@pytest.mark.parametrize("returncode", [0, 1, 137])
+def test_down_exits_with_the_compose_child_s_own_code(monkeypatch, tmp_path, returncode):
+    """``execvpe`` gave the caller compose's exit status verbatim; so does this.
+
+    ``check=False`` plus an explicit exit is what preserves that: ``check=True``
+    would turn every non-zero compose exit into one uniform failure code.
+    """
+    monkeypatch.chdir(tmp_path)
+    _mock_down_config(monkeypatch)
+    _forbid_exec(monkeypatch)
+    calls = _capture_run(monkeypatch, returncode=returncode)
+
+    with pytest.raises(SystemExit) as excinfo:
+        container_lifecycle.deploy_down(str(tmp_path / "config.yml"))
+
+    assert excinfo.value.code == returncode
+    assert calls[0]["check"] is False, "a raising run would never reach the exit"
+
+
+def test_a_signal_killed_compose_exits_the_way_a_shell_spells_it(monkeypatch, tmp_path):
+    """SIGTERM: -15 from Popen, 143 from the exec'd child a shell would see.
+
+    Passed through raw, sys.exit(-15) masks to 241 — a status no signal maps to.
+    """
+    monkeypatch.chdir(tmp_path)
+    _mock_down_config(monkeypatch)
+    _forbid_exec(monkeypatch)
+    _capture_run(monkeypatch, returncode=-15)
+
+    with pytest.raises(SystemExit) as excinfo:
+        container_lifecycle.deploy_down(str(tmp_path / "config.yml"))
+
+    assert excinfo.value.code == 143
+
+
+def test_a_failed_down_reports_no_step(monkeypatch, tmp_path):
+    """Steps name work that happened: a non-zero ``down`` stopped nothing."""
+    monkeypatch.chdir(tmp_path)
+    _mock_down_config(monkeypatch)
+    _forbid_exec(monkeypatch)
+    _capture_run(monkeypatch, returncode=1)
+    steps: list[str] = []
+    monkeypatch.setattr(container_lifecycle, "_report_step", steps.append)
+
+    with pytest.raises(SystemExit):
+        container_lifecycle.deploy_down(str(tmp_path / "config.yml"))
+
+    assert steps == []
+
+
+def test_a_successful_down_reports_its_step(monkeypatch, tmp_path):
+    """The verb's phase gets one line for the containers it stopped."""
+    monkeypatch.chdir(tmp_path)
+    _mock_down_config(monkeypatch)
+    _forbid_exec(monkeypatch)
+    _capture_run(monkeypatch)
+    steps: list[str] = []
+    monkeypatch.setattr(container_lifecycle, "_report_step", steps.append)
+
+    with pytest.raises(SystemExit):
+        container_lifecycle.deploy_down(str(tmp_path / "config.yml"))
+
+    assert steps == ["containers stopped"]
+
+
+def test_the_web_stack_still_comes_down_before_the_services(monkeypatch, tmp_path):
+    """Ordering survives the conversion.
+
+    The services ``down`` still ends this process (now by exiting rather than by
+    exec), and its ``-f`` list can never carry ``docker-compose.web.yml``, so a
+    web ``down`` that ran afterwards would never run at all.
+    """
+    monkeypatch.chdir(tmp_path)
+    _mock_down_config(monkeypatch, extra={"modules": {"web_terminals": {"enabled": True}}})
+    _forbid_exec(monkeypatch)
+    order: list[str] = []
+
+    monkeypatch.setattr(
+        container_lifecycle,
+        "deploy_down_web_terminals",
+        lambda config, env, env_file_args: order.append("web"),
+    )
+
+    def _fake(cmd, **kwargs):
+        order.append("services")
+        return subprocess.CompletedProcess(list(cmd), 0)
+
+    monkeypatch.setattr(container_lifecycle, "run_captured", _fake)
+
+    with pytest.raises(SystemExit):
+        container_lifecycle.deploy_down(str(tmp_path / "config.yml"))
+
+    assert order == ["web", "services"]
+
+
+# ---------------------------------------------------------------------------
+# down_deployment — the LIVE path (`osprey down` -> down_verb -> here).
+#
+# deploy_down above is the legacy library entry point with no caller left in
+# src/, so converting it alone would have left the verb an operator actually
+# types still streaming compose to the terminal.
+# ---------------------------------------------------------------------------
+
+
+def _mock_live_down(monkeypatch, tmp_path):
+    """Wire down_deployment's as-built reads to fixtures under *tmp_path*."""
+    config_path = tmp_path / "build" / "config.yml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text("project_name: myrepo\n")
+
+    monkeypatch.setattr(container_lifecycle, "as_built_config_path", lambda root: config_path)
+    monkeypatch.setattr(
+        container_lifecycle, "load_project_config", lambda p, **k: {"project_name": "myrepo"}
+    )
+    monkeypatch.setattr(
+        container_lifecycle, "as_built_compose_files", lambda config, root: ["docker-compose.yml"]
+    )
+    monkeypatch.setattr(container_lifecycle, "_web_terminals_enabled", lambda config: False)
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+
+
+def test_the_live_down_captures_compose_under_the_pinned_project(monkeypatch, tmp_path):
+    """The verb's own compose invocation is spooled, not streamed — with the pin."""
+    _mock_live_down(monkeypatch, tmp_path)
+    calls = _capture_run(monkeypatch)
+
+    container_lifecycle.down_deployment(tmp_path)
+
+    assert len(calls) == 1, calls
+    call = calls[0]
+    assert "down" in call["cmd"]
+    assert call["spool_name"] == "compose-down"
+    assert Path(call["repo_root"]) == tmp_path
+    assert call["check"] is False
+    assert call["env"]["COMPOSE_PROJECT_NAME"] == "myrepo"
+
+
+def test_the_live_down_reports_its_step(monkeypatch, tmp_path):
+    """The step hangs off the path the verb actually drives, not the legacy one."""
+    _mock_live_down(monkeypatch, tmp_path)
+    _capture_run(monkeypatch)
+    steps: list[str] = []
+    monkeypatch.setattr(container_lifecycle, "_report_step", steps.append)
+
+    container_lifecycle.down_deployment(tmp_path)
+
+    assert steps == ["containers stopped"]
+
+
+def test_a_failed_live_down_still_says_the_containers_may_be_running(monkeypatch, tmp_path):
+    """The consequence a bare CapturedProcessError would not state.
+
+    The spool is still written and noted on the reporter, so the failure line
+    replays it; this path adds what a non-zero ``down`` MEANS.
+    """
+    _mock_live_down(monkeypatch, tmp_path)
+    _capture_run(monkeypatch, returncode=1)
+    steps: list[str] = []
+    monkeypatch.setattr(container_lifecycle, "_report_step", steps.append)
+
+    with pytest.raises(RuntimeError, match="may still be running"):
+        container_lifecycle.down_deployment(tmp_path)
+
+    assert steps == [], "a failed down stopped nothing to report"
+
+
+def test_attached_up_still_execvpes(monkeypatch, tmp_path):
+    """Non-regression: the conversion is scoped to ``down``.
+
+    A non-detached ``up`` hands the terminal to compose on purpose — the
+    operator asked to watch it — so that call site must still exec.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        container_lifecycle,
+        "prepare_compose_files",
+        lambda *a, **k: ({"deployed_services": ["event_dispatcher"]}, ["docker-compose.yml"]),
+    )
+    monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
+    monkeypatch.setattr(container_lifecycle, "_ensure_service_tokens", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "_build_project_image", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "log_endpoint_summary", lambda *a, **k: None)
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+    monkeypatch.setattr(
+        container_lifecycle,
+        "run_captured",
+        lambda cmd, **k: subprocess.CompletedProcess(list(cmd), 0),
+    )
+    execd: dict = {}
+    monkeypatch.setattr(
+        container_lifecycle.os,
+        "execvpe",
+        lambda file, args, env: execd.update(args=list(args), env=env),
+    )
+    # execvp too: a call that lost its env would otherwise replace the test
+    # process instead of failing the assertion below.
+    monkeypatch.setattr(
+        container_lifecycle.os,
+        "execvp",
+        lambda file, args: pytest.fail("attached up must exec WITH its env"),
+    )
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=False)
+
+    assert "up" in execd["args"], execd
+    assert execd["env"]["COMPOSE_PROJECT_NAME"]

--- a/tests/deployment/test_down_restart_gates.py
+++ b/tests/deployment/test_down_restart_gates.py
@@ -77,7 +77,10 @@ def runtime(monkeypatch):
         lambda *a, **k: record.setdefault("built", True),
     )
 
-    def _fake_run(cmd, env=None, check=False, capture_output=False, text=False):
+    def _fake_run(cmd, env=None, check=False, capture_output=False, text=False, **kwargs):
+        # ``**kwargs`` swallows the redirection keywords ``run_captured`` passes
+        # (``cwd``/``stdout``/``stderr``): a captured child's output goes to a
+        # spool file, and nothing here writes any, so they are ignored.
         argv = list(cmd)
         record["cmds"].append(argv)
         # Matched on presence rather than position: a compose argv carries its

--- a/tests/deployment/test_env_shadow_preflight.py
+++ b/tests/deployment/test_env_shadow_preflight.py
@@ -28,6 +28,7 @@ the one end-to-end test drives ``osprey up`` with the runtime stubbed out.
 from __future__ import annotations
 
 import logging
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -413,7 +414,9 @@ def test_the_start_sequence_runs_the_preflight_before_the_image_build(tmp_path, 
         lambda config, dev, env, ctx=None: order.append("image"),
     )
     monkeypatch.setattr(
-        container_lifecycle.subprocess, "run", lambda cmd, env=None, check=False: None
+        container_lifecycle.subprocess,
+        "run",
+        lambda cmd, **k: subprocess.CompletedProcess(list(cmd), 0),
     )
 
     container_lifecycle._start_stack(
@@ -454,7 +457,7 @@ def test_a_divergent_export_warns_but_still_starts_the_stack(tmp_path, monkeypat
     monkeypatch.setattr(
         container_lifecycle.subprocess,
         "run",
-        lambda cmd, env=None, check=False: ran.append(list(cmd)),
+        lambda cmd, **k: ran.append(list(cmd)) or subprocess.CompletedProcess(list(cmd), 0),
     )
 
     with caplog.at_level(logging.WARNING):

--- a/tests/deployment/test_lifecycle_capture.py
+++ b/tests/deployment/test_lifecycle_capture.py
@@ -1,0 +1,467 @@
+"""The container lifecycle's subprocesses spool their output instead of the terminal.
+
+``osprey up`` used to hand its terminal to whatever it started: an image build's
+thousands of layer lines, compose's per-container churn, the archiver store's
+boot chatter. The phase lines a verb prints are only readable if none of that
+lands beside them, so every child process on this path now runs through
+:func:`osprey.deployment.subprocess_capture.run_captured` — output to
+``<repo>/var/logs/<spool_name>-<timestamp>.log``, and one ``· step`` line
+reported in its place.
+
+What these tests pin, site by site:
+
+* the child runs through ``run_captured``, never a bare ``subprocess.run`` — the
+  regression this feature exists to prevent is a site quietly reverting to
+  inherited stdio, which no output assertion would catch;
+* each site names its own ``spool_name``, so a failed deploy's spool directory
+  says which step produced which file;
+* ``repo_root`` is passed at every site: the helper's fallback is
+  :func:`Path.cwd`, so an omission spools into whatever directory the operator
+  happened to run from rather than the deployment repo;
+* the step line is reported *after* the work, because
+  :meth:`~osprey.cli.phase_reporter.Phase.step` times the lap since the previous
+  step and a line printed first would credit the cost to the next unit;
+* the best-effort sites (``compose rm``, the recorder quiesce) keep
+  ``check=False`` — capturing must not turn a tolerated non-zero exit into a
+  failed deploy.
+
+No container runtime is touched: ``run_captured`` itself is stubbed, and the
+reporter is a real :class:`~osprey.cli.phase_reporter.PhaseReporter` whose
+``emit`` records lines rather than printing them.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from osprey.cli.phase_reporter import PhaseReporter, install_reporter
+from osprey.deployment import container_lifecycle
+from osprey.simulation import archiver_seed as seed_mod
+
+#: The ``(1.2s)`` / ``(2m03s)`` suffix ``Phase.step`` appends to a slow lap.
+_DURATION = re.compile(r" \((?:\d+\.\d+s|\d+m\d{2}s)\)$")
+
+
+class RecordingReporter(PhaseReporter):
+    """A real reporter whose lines land in a list instead of on stdout."""
+
+    def __init__(self) -> None:
+        super().__init__(color=False)
+        self.lines: list[str] = []
+
+    def emit(self, text: str, style: str | None = None) -> None:
+        self.lines.append(text)
+
+    @property
+    def steps(self) -> list[str]:
+        """Just the sub-step names, with the bullet and any duration stripped."""
+        return [
+            _DURATION.sub("", line.strip()[2:]) for line in self.lines if line.startswith("  ·")
+        ]
+
+
+@pytest.fixture
+def reporter():
+    """An installed reporter with one open phase, as a verb would have."""
+    recorder = RecordingReporter()
+    previous = install_reporter(recorder)
+    recorder.phase("test phase")
+    try:
+        yield recorder
+    finally:
+        install_reporter(previous)
+
+
+class CaptureRecorder:
+    """Stand-in for ``run_captured`` that records how each site called it."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def __call__(self, cmd, *, env=None, spool_name, repo_root=None, check=True):
+        self.calls.append(
+            {
+                "cmd": list(cmd),
+                "env": env,
+                "spool_name": spool_name,
+                "repo_root": repo_root,
+                "check": check,
+            }
+        )
+        return subprocess.CompletedProcess(list(cmd), 0)
+
+    @property
+    def spool_names(self) -> list[str]:
+        return [call["spool_name"] for call in self.calls]
+
+    def call(self, spool_name: str) -> dict:
+        """The one call made under ``spool_name`` (fails if it never happened)."""
+        matches = [call for call in self.calls if call["spool_name"] == spool_name]
+        assert len(matches) == 1, f"expected one {spool_name!r} call, got {self.spool_names}"
+        return matches[0]
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    """Route every converted site's child process into a recorder."""
+    recorder = CaptureRecorder()
+    monkeypatch.setattr(container_lifecycle, "run_captured", recorder)
+    return recorder
+
+
+@pytest.fixture
+def no_bare_subprocess(monkeypatch):
+    """Fail any site that still runs a child with inherited stdio.
+
+    The point of the conversion is that nothing on this path writes to the
+    terminal behind the reporter's back. A site that regressed to
+    ``subprocess.run`` would still pass every assertion about the *other* sites,
+    so the absence is pinned directly.
+    """
+
+    def _forbidden(*args, **kwargs):
+        raise AssertionError(f"a lifecycle site ran a bare subprocess: {args!r}")
+
+    monkeypatch.setattr(container_lifecycle.subprocess, "run", _forbidden)
+
+
+# ---------------------------------------------------------------------------
+# The dispatch worker's project image
+# ---------------------------------------------------------------------------
+
+
+def _image_config() -> dict:
+    return {"project_name": "proj", "deployed_services": ["dispatch_worker"]}
+
+
+@pytest.fixture
+def image_build_stubs(monkeypatch, tmp_path):
+    """Everything ``_build_project_image`` reaches for except the build itself."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setattr(container_lifecycle, "resolve_project_name", lambda config: "proj")
+    monkeypatch.setattr(container_lifecycle, "resolve_repo_root", lambda config, *a: repo)
+    monkeypatch.setattr(
+        container_lifecycle, "_worker_image_target", lambda config, env: "proj:local"
+    )
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+    monkeypatch.setattr(
+        container_lifecycle,
+        "_project_image_build_cmd",
+        lambda config, runtime, root, dev: ["docker", "build", "-t", "proj:local", str(root)],
+    )
+    return repo
+
+
+def test_the_project_image_build_spools_its_output(
+    captured, reporter, image_build_stubs, no_bare_subprocess
+):
+    """An image build is the loudest thing on the deploy path — and the slowest.
+
+    Layer-by-layer output is exactly what an operator does not need until
+    something fails, at which point they need all of it. Spooling gives both:
+    one line while it works, the whole log named on the failure path.
+    """
+    container_lifecycle._build_project_image(_image_config(), False, {}, None)
+
+    call = captured.call("build-project-image")
+    assert call["cmd"][:2] == ["docker", "build"]
+    assert call["repo_root"] == image_build_stubs
+    assert call["check"] is True
+    assert reporter.steps == ["project image proj:local"]
+
+
+def test_the_image_step_is_reported_after_the_build(reporter, image_build_stubs, monkeypatch):
+    """The step line names the build's own cost, so it follows the build.
+
+    ``Phase.step`` reports the lap since the previous step. A line emitted
+    before the work would time the *setup* and leave the minutes-long build
+    charged to whatever step came next.
+    """
+
+    def _marking(cmd, *, env=None, spool_name, repo_root=None, check=True):
+        reporter.lines.append("<<ran>>")
+        return subprocess.CompletedProcess(list(cmd), 0)
+
+    monkeypatch.setattr(container_lifecycle, "run_captured", _marking)
+    reporter.lines.clear()
+
+    container_lifecycle._build_project_image(_image_config(), False, {}, None)
+
+    marks = [line for line in reporter.lines if line == "<<ran>>" or line.startswith("  ·")]
+    assert marks[0] == "<<ran>>", "the step line was reported before the build it times"
+    assert marks[1].startswith("  · project image proj:local")
+
+
+def test_the_image_build_is_skipped_without_a_dispatch_worker(captured, reporter):
+    """No worker, no image, no step line claiming one was built."""
+    container_lifecycle._build_project_image(
+        {"project_name": "proj", "deployed_services": ["postgresql"]}, False, {}, None
+    )
+
+    assert captured.calls == []
+    assert reporter.steps == []
+
+
+# ---------------------------------------------------------------------------
+# The staged archiver store, and the recorder it quiesces
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def archiver_stubs(monkeypatch):
+    """Reduce ``_stage_archiver_store`` to its two subprocess calls.
+
+    The seeder's own machinery — the store connection, the fingerprint
+    comparison, the base rewrite — is covered elsewhere. What matters here is
+    that the two compose invocations it makes are captured.
+    """
+    monkeypatch.setattr(
+        container_lifecycle,
+        "_archiver_store_connection",
+        lambda config, project_dir: {
+            "password": "pw",
+            "password_env": "MONGO_PW",
+            "username": "root",
+            "host": "localhost",
+            "port": 27017,
+        },
+    )
+    monkeypatch.setattr(container_lifecycle, "runtime_env", lambda config, env: dict(env))
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+    monkeypatch.setattr(
+        container_lifecycle, "compose_base_cmd", lambda *a, **k: ["docker", "compose"]
+    )
+    monkeypatch.setattr(container_lifecycle, "_env_file_args", lambda root=None: [])
+    monkeypatch.setattr(
+        container_lifecycle, "_archiver_seed_inputs", lambda config, project_dir: ([], None, {})
+    )
+    monkeypatch.setattr(container_lifecycle, "_wait_for_archiver_store", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "_reapply_active_scenarios", lambda *a, **k: None)
+
+    knobs = SimpleNamespace(
+        retention_days=7, hot_span_hours=6, hot_cadence_sec=1, tail_cadence_sec=60
+    )
+    monkeypatch.setattr(
+        seed_mod, "SeedKnobs", SimpleNamespace(from_config=staticmethod(lambda config: knobs))
+    )
+    monkeypatch.setattr(seed_mod, "seed_fingerprint", lambda *a, **k: "fp")
+    monkeypatch.setattr(
+        seed_mod,
+        "compare_fingerprint",
+        lambda collection, fingerprint: SimpleNamespace(state=seed_mod.SeedState.ABSENT),
+    )
+    monkeypatch.setattr(
+        seed_mod, "seed_base", lambda *a, **k: SimpleNamespace(describe=lambda: "seeded")
+    )
+
+    class _Collection:
+        def drop(self) -> None:
+            pass
+
+    class _Connection:
+        def __enter__(self):
+            return _Collection()
+
+        def __exit__(self, *exc):
+            return False
+
+    from osprey.simulation import apply as apply_mod
+
+    monkeypatch.setattr(apply_mod, "archiver_collection", lambda store: _Connection())
+
+
+def _stage(config: dict, project_dir: Path) -> None:
+    container_lifecycle._stage_archiver_store(config, ["compose.yml"], {}, project_dir)
+
+
+def test_the_archiver_store_bring_up_spools_its_output(
+    captured, reporter, archiver_stubs, no_bare_subprocess, tmp_path
+):
+    """The store is started on its own, ahead of the stack, and boots noisily."""
+    _stage({"deployed_services": ["archiver_store"]}, tmp_path)
+
+    call = captured.call("archiver-store-up")
+    assert call["cmd"] == ["docker", "compose", "up", "-d", "mongodb"]
+    assert call["repo_root"] == tmp_path
+    assert "archiver store started" in reporter.steps
+
+
+def test_the_recorder_quiesce_stays_best_effort(
+    captured, reporter, archiver_stubs, no_bare_subprocess, tmp_path
+):
+    """A recorder that will not stop warns; it does not abort the reseed.
+
+    Capturing must not change that. ``check=False`` keeps the non-zero exit a
+    return code the caller inspects rather than a ``CapturedProcessError`` that
+    takes down a deploy the old code carried on through.
+    """
+    _stage(
+        {"deployed_services": ["archiver_store", "archiver_recorder"]},
+        tmp_path,
+    )
+
+    call = captured.call("archiver-recorder-stop")
+    assert call["cmd"] == ["docker", "compose", "stop", "archiver-recorder"]
+    assert call["repo_root"] == tmp_path
+    assert call["check"] is False
+    assert "archiver recorder quiesced" in reporter.steps
+
+
+def test_a_recorder_that_will_not_stop_still_warns(
+    captured, reporter, archiver_stubs, monkeypatch, tmp_path, caplog
+):
+    """The quiesce invariant is still reported when the stop exits non-zero."""
+
+    def _failing(cmd, *, env=None, spool_name, repo_root=None, check=True):
+        code = 1 if spool_name == "archiver-recorder-stop" else 0
+        return subprocess.CompletedProcess(list(cmd), code)
+
+    monkeypatch.setattr(container_lifecycle, "run_captured", _failing)
+
+    with caplog.at_level(logging.WARNING):
+        _stage({"deployed_services": ["archiver_store", "archiver_recorder"]}, tmp_path)
+
+    assert "Could not stop `archiver-recorder`" in caplog.text
+
+
+def test_the_archiver_compose_echoes_are_debug_only(
+    captured, reporter, archiver_stubs, tmp_path, caplog
+):
+    """The argv echoes are for debugging, not for the operator's terminal.
+
+    These two were the last ``INFO``-level ``Running command:`` lines on the
+    deploy path — the reason a quiet ``up`` printed raw compose argv beside its
+    phase lines.
+    """
+    with caplog.at_level(logging.INFO):
+        _stage({"deployed_services": ["archiver_store", "archiver_recorder"]}, tmp_path)
+    assert "Running command" not in caplog.text
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        _stage({"deployed_services": ["archiver_store", "archiver_recorder"]}, tmp_path)
+    assert caplog.text.count("Running command") == 2
+
+
+# ---------------------------------------------------------------------------
+# The stack's own compose invocations
+# ---------------------------------------------------------------------------
+
+
+def _repo(tmp_path: Path) -> Path:
+    """A repo root with the ``.env`` and compose file a start sequence reads."""
+    root = tmp_path / "repo"
+    services = root / "build" / "services"
+    services.mkdir(parents=True)
+    (root / ".env").write_text("", encoding="utf-8")
+    (services / "docker-compose.0.yml").write_text("services: {}\n", encoding="utf-8")
+    return root
+
+
+@pytest.fixture
+def start_stack_stubs(monkeypatch):
+    """The host-touching preflights ``_start_stack`` runs before its compose calls."""
+    monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
+    monkeypatch.setattr(container_lifecycle, "_preflight_host_ports", lambda config, files: None)
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+    monkeypatch.setattr(container_lifecycle, "log_endpoint_summary", lambda config, files: None)
+    monkeypatch.setattr(
+        container_lifecycle, "_build_project_image", lambda config, dev, env, ctx=None: None
+    )
+
+
+def _start(repo: Path, *, dev_mode: bool = False) -> None:
+    container_lifecycle._start_stack(
+        {"project_name": "proj", "deployed_services": ["postgresql"]},
+        ["build/services/docker-compose.0.yml"],
+        repo,
+        detached=True,
+        dev_mode=dev_mode,
+        env_path=repo / ".env",
+    )
+
+
+def test_the_stack_compose_calls_all_spool_their_output(
+    captured, reporter, start_stack_stubs, no_bare_subprocess, tmp_path
+):
+    """``rm``, ``build`` and ``up`` — the three loudest calls in a dev deploy.
+
+    Ordering is part of the contract: the self-heal ``rm`` clears wedged
+    containers before the build, and ``up --no-build`` runs on the images the
+    build just produced.
+    """
+    repo = _repo(tmp_path)
+
+    _start(repo, dev_mode=True)
+
+    assert captured.spool_names == ["compose-rm", "compose-build", "compose-up"]
+    for name in captured.spool_names:
+        assert captured.call(name)["repo_root"] == repo, f"{name} spooled outside the repo"
+    assert reporter.steps == [
+        "cleared stopped containers",
+        "service images built",
+        "containers started",
+    ]
+
+
+def test_the_self_heal_removal_stays_best_effort(
+    captured, reporter, start_stack_stubs, no_bare_subprocess, tmp_path
+):
+    """``compose rm`` is advisory: if it fails, ``up`` surfaces the real error.
+
+    Raising here would turn a self-heal that was always allowed to fail into a
+    deploy-stopping error, which is exactly the behaviour change a capture
+    conversion must not smuggle in.
+    """
+    _start(_repo(tmp_path))
+
+    assert captured.call("compose-rm")["check"] is False
+    assert captured.call("compose-up")["check"] is True
+
+
+def test_a_non_dev_deploy_does_not_build(captured, reporter, start_stack_stubs, tmp_path):
+    """Compose's implicit build-on-up covers it; a separate build step would not."""
+    _start(_repo(tmp_path))
+
+    assert captured.spool_names == ["compose-rm", "compose-up"]
+    assert "service images built" not in reporter.steps
+
+
+def test_the_stack_compose_echoes_are_debug_only(
+    captured, reporter, start_stack_stubs, tmp_path, caplog
+):
+    """No raw compose argv on an operator's terminal."""
+    with caplog.at_level(logging.INFO):
+        _start(_repo(tmp_path), dev_mode=True)
+
+    assert "Running command" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Called outside a verb
+# ---------------------------------------------------------------------------
+
+
+def test_steps_are_silent_without_an_open_phase(captured, start_stack_stubs, tmp_path):
+    """These helpers are also library calls, and tests, and ``up_as_built``.
+
+    Only a lifecycle verb installs a reporter and opens a phase. Every other
+    caller reaches the same code with the default ``NullReporter``, so a step
+    line must be a no-op rather than an attribute error on ``None``.
+    """
+    _start(_repo(tmp_path), dev_mode=True)
+
+    assert captured.spool_names == ["compose-rm", "compose-build", "compose-up"]

--- a/tests/deployment/test_mongo_password_mint.py
+++ b/tests/deployment/test_mongo_password_mint.py
@@ -17,6 +17,8 @@ tests assert the invariant end to end — a mint that reaches the ``.env``, and 
 
 from __future__ import annotations
 
+import subprocess
+
 import pytest
 
 from osprey.deployment import container_lifecycle
@@ -40,8 +42,12 @@ def captured_argv(monkeypatch, tmp_path):
         container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
     )
 
-    def _fake_run(cmd, env=None, check=False):
+    def _fake_run(cmd, env=None, check=False, **kwargs):
         captured["cmd"] = cmd
+        # run_captured re-wraps this result to carry its spool path, so the
+        # stand-in has to be a real completed process, and it passes redirection
+        # kwargs this ignores.
+        return subprocess.CompletedProcess(list(cmd), 0)
 
     monkeypatch.setattr(container_lifecycle.subprocess, "run", _fake_run)
     return captured

--- a/tests/deployment/test_postgres_password_mint.py
+++ b/tests/deployment/test_postgres_password_mint.py
@@ -11,6 +11,8 @@ shared ``ariel``/``ariel`` default on fresh volumes.
 
 from __future__ import annotations
 
+import subprocess
+
 import pytest
 
 from osprey.deployment import container_lifecycle
@@ -33,8 +35,12 @@ def captured_argv(monkeypatch, tmp_path):
         container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
     )
 
-    def _fake_run(cmd, env=None, check=False):
+    def _fake_run(cmd, env=None, check=False, **kwargs):
         captured["cmd"] = cmd
+        # run_captured re-wraps this result to carry its spool path, so the
+        # stand-in has to be a real completed process, and it passes redirection
+        # kwargs this ignores.
+        return subprocess.CompletedProcess(list(cmd), 0)
 
     monkeypatch.setattr(container_lifecycle.subprocess, "run", _fake_run)
     return captured

--- a/tests/deployment/test_seed_progress_reporting.py
+++ b/tests/deployment/test_seed_progress_reporting.py
@@ -1,0 +1,135 @@
+"""The archiver seed's progress callback, reported as phase sub-steps.
+
+Seeding an archive base is the one deploy step that runs for minutes, so its
+progress callback is bridged to the open phase: each firing that survives the
+rate limit becomes a ``· seeding archive: …`` line. These tests drive the
+callback directly with synthetic :class:`SeedReport` values — no store, no
+containers — and assert the three things the bridge owns: what a line says,
+that the rate limit holds, and that a callback outside a verb is inert.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from osprey.cli.phase_reporter import (
+    NullReporter,
+    PhaseReporter,
+    current_reporter,
+    install_reporter,
+)
+from osprey.deployment import container_lifecycle
+from osprey.simulation.archiver_seed import SeedReport
+
+
+class RecordingReporter(PhaseReporter):
+    """A real reporter that keeps its lines instead of printing them."""
+
+    def __init__(self) -> None:
+        super().__init__(color=False)
+        self.lines: list[str] = []
+
+    def emit(self, text: str, style: str | None = None) -> None:
+        self.lines.append(text)
+
+
+@pytest.fixture
+def restore_reporter():
+    """Put the module handle back however a test left it."""
+    previous = current_reporter()
+    try:
+        yield
+    finally:
+        install_reporter(previous)
+
+
+@pytest.fixture
+def phase(restore_reporter):
+    """A recording reporter with a phase open, as a verb would leave it."""
+    recording = RecordingReporter()
+    install_reporter(recording)
+    recording.phase("Seeding archive")
+    return recording
+
+
+def steps(reporter: RecordingReporter) -> list[str]:
+    """The sub-step lines, in order, as names only.
+
+    The indent, the bullet and the lap duration a step line carries when the lap
+    is long enough all belong to the reporter's own rendering tests; what this
+    module asserts is the name the bridge composed.
+    """
+    return [
+        re.sub(r" \([^()]*\)$", "", line.strip()[2:])
+        for line in reporter.lines
+        if line.strip().startswith("·")
+    ]
+
+
+def a_report(documents: int, channels: int = 12) -> SeedReport:
+    """A running report as the seeder hands one to the callback."""
+    return SeedReport(documents=documents, channels=channels, chunks=1, elapsed_s=1.0)
+
+
+def test_progress_reports_documents_and_channels_as_a_step(phase, monkeypatch):
+    monkeypatch.setattr(container_lifecycle, "_ARCHIVER_PROGRESS_INTERVAL_S", 0.0)
+    report = container_lifecycle._seed_progress_reporter()
+
+    report(a_report(1_234_567, channels=1_024))
+
+    assert steps(phase) == ["seeding archive: 1,234,567 documents written across 1,024 channels"]
+
+
+def test_every_firing_past_the_interval_reports_the_running_count(phase, monkeypatch):
+    monkeypatch.setattr(container_lifecycle, "_ARCHIVER_PROGRESS_INTERVAL_S", 0.0)
+    report = container_lifecycle._seed_progress_reporter()
+
+    for documents in (500, 1_000, 1_500):
+        report(a_report(documents))
+
+    assert steps(phase) == [
+        "seeding archive: 500 documents written across 12 channels",
+        "seeding archive: 1,000 documents written across 12 channels",
+        "seeding archive: 1,500 documents written across 12 channels",
+    ]
+
+
+def test_the_rate_limit_swallows_the_burst_of_per_chunk_firings(phase):
+    """The seeder fires once per chunk; at the shipped interval none get through.
+
+    The default interval is the shipped one and the clock is the real one, so a
+    tight burst is entirely inside the first window — which is exactly the flood
+    the limit exists to stop.
+    """
+    report = container_lifecycle._seed_progress_reporter()
+
+    for chunk in range(200):
+        report(a_report(chunk * 500))
+
+    assert steps(phase) == []
+
+
+def test_a_callback_outside_a_verb_reports_nothing(restore_reporter, monkeypatch):
+    """Seeding also runs from ``sim apply`` and from tests, with no phase open."""
+    monkeypatch.setattr(container_lifecycle, "_ARCHIVER_PROGRESS_INTERVAL_S", 0.0)
+    recording = RecordingReporter()
+    install_reporter(recording)
+
+    container_lifecycle._seed_progress_reporter()(a_report(500))
+
+    assert recording.lines == []
+
+
+def test_progress_prints_nothing_under_a_null_reporter(restore_reporter, monkeypatch, capsys):
+    """Under ``--verbose`` the raw seeder output is what the operator watches."""
+    monkeypatch.setattr(container_lifecycle, "_ARCHIVER_PROGRESS_INTERVAL_S", 0.0)
+    null = NullReporter(verbose=True)
+    install_reporter(null)
+    null.phase("Seeding archive")
+    capsys.readouterr()
+
+    container_lifecycle._seed_progress_reporter()(a_report(500))
+
+    assert capsys.readouterr().out == ""

--- a/tests/deployment/test_service_token_unconditional_mint.py
+++ b/tests/deployment/test_service_token_unconditional_mint.py
@@ -28,6 +28,7 @@ sections say — including when they are absent entirely.
 from __future__ import annotations
 
 import logging
+import subprocess
 
 import pytest
 
@@ -51,8 +52,11 @@ def captured_argv(monkeypatch, tmp_path):
         container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
     )
 
-    def _fake_run(cmd, env=None, check=False):
+    def _fake_run(cmd, env=None, check=False, **kwargs):
         captured["cmd"] = cmd
+        # run_captured hangs its spool path off the result, so the stand-in has
+        # to be an object, and it passes redirection kwargs this ignores.
+        return subprocess.CompletedProcess(list(cmd), 0)
 
     monkeypatch.setattr(container_lifecycle.subprocess, "run", _fake_run)
     return captured

--- a/tests/deployment/test_status_sections.py
+++ b/tests/deployment/test_status_sections.py
@@ -525,13 +525,13 @@ def test_status_writes_nothing_into_the_repo(lifecycle_repo, runtime):
 def test_status_never_announces_creating_the_files_it_did_not_create(
     lifecycle_repo, runtime, capsys
 ):
-    """The artifact renderer narrates itself, and the dry run makes it narrate a lie.
+    """The artifact renderer must not narrate itself inside a read-only report.
 
-    Rendering into a temporary directory still runs the writer, which ends with
-    "✓ Created N Claude Code integration file(s)" on stdout. Inside a status
-    report that sentence tells an operator this read-only command just rewrote
-    their repo. This runs the real renderer, not a stub, because the sentence
-    comes from the real one.
+    Rendering into a temporary directory still runs the writer. Any "Created N
+    …" sentence it puts on stdout would tell an operator that this read-only
+    command just rewrote their repo. The renderer now keeps that detail in the
+    log rather than on the terminal, and this test is the guard that it stays
+    there: it runs the real renderer, not a stub.
     """
     render_build(lifecycle_repo)
     capsys.readouterr()

--- a/tests/deployment/test_subprocess_capture.py
+++ b/tests/deployment/test_subprocess_capture.py
@@ -1,0 +1,305 @@
+"""Behavior of the subprocess capture helper.
+
+Two modes are under test: the default, which spools a child's merged output to
+``var/logs/`` and names that file on failure, and ``--verbose``, which must hand
+the child this process's own stdio with no redirection at all.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from osprey.cli.phase_reporter import NullReporter, PhaseReporter, install_reporter
+from osprey.deployment.errors import CapturedProcessError
+from osprey.deployment.subprocess_capture import SPOOL_RETENTION, run_captured
+
+
+@pytest.fixture(autouse=True)
+def quiet_reporter():
+    """Install a fresh quiet reporter and restore the previous one after."""
+    previous = install_reporter(NullReporter(verbose=False))
+    yield
+    install_reporter(previous)
+
+
+@pytest.fixture
+def verbose_reporter():
+    """Put the helper in pass-through mode for the duration of a test."""
+    previous = install_reporter(NullReporter(verbose=True))
+    yield
+    install_reporter(previous)
+
+
+@pytest.fixture
+def recorded_run(monkeypatch):
+    """Replace ``subprocess.run`` with a recorder, returning the call log."""
+    calls: list[tuple[tuple, dict]] = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return subprocess.CompletedProcess(args[0], 0)
+
+    monkeypatch.setattr("osprey.deployment.subprocess_capture.subprocess.run", fake_run)
+    return calls
+
+
+def _echo(*lines: str) -> list[str]:
+    """Argv for a child that writes ``lines`` to stdout, in order."""
+    body = "\n".join(f"print({line!r}, flush=True)" for line in lines)
+    return [sys.executable, "-c", body]
+
+
+def _spools(repo_root: Path) -> list[Path]:
+    return sorted((repo_root / "var" / "logs").glob("*.log"))
+
+
+class TestSpoolFile:
+    """The default mode writes the child's output under ``var/logs/``."""
+
+    def test_creates_spool_under_var_logs(self, tmp_path):
+        run_captured(_echo("hello"), spool_name="build-worker", repo_root=tmp_path)
+
+        spools = _spools(tmp_path)
+        assert len(spools) == 1
+        assert spools[0].name.startswith("build-worker-")
+        assert spools[0].read_text() == "hello\n"
+
+    def test_defaults_repo_root_to_cwd(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        run_captured(_echo("hi"), spool_name="compose-up")
+
+        spools = _spools(tmp_path)
+        assert len(spools) == 1
+        assert spools[0].name.startswith("compose-up-")
+
+    def test_merges_stderr_into_stdout_in_order(self, tmp_path):
+        argv = [
+            sys.executable,
+            "-c",
+            "import sys\n"
+            "print('one', flush=True)\n"
+            "print('two', file=sys.stderr, flush=True)\n"
+            "print('three', flush=True)\n",
+        ]
+
+        run_captured(argv, spool_name="merged", repo_root=tmp_path)
+
+        assert _spools(tmp_path)[0].read_text() == "one\ntwo\nthree\n"
+
+    def test_second_run_in_the_same_second_gets_its_own_file(self, tmp_path):
+        run_captured(_echo("first"), spool_name="twice", repo_root=tmp_path)
+        run_captured(_echo("second"), spool_name="twice", repo_root=tmp_path)
+
+        bodies = {p.read_text() for p in _spools(tmp_path)}
+        assert bodies == {"first\n", "second\n"}
+
+    def test_stdout_is_not_captured_into_the_result(self, tmp_path):
+        completed = run_captured(_echo("hello"), spool_name="build", repo_root=tmp_path)
+
+        assert completed.stdout is None
+        assert completed.stderr is None
+
+
+class TestRetention:
+    """Old spools are pruned at entry, never failing the run."""
+
+    def test_prunes_to_the_newest_twenty(self, tmp_path, recorded_run):
+        logs = tmp_path / "var" / "logs"
+        logs.mkdir(parents=True)
+        for index in range(22):
+            stale = logs / f"old-{index:02d}.log"
+            stale.write_text(str(index))
+            when = 1_700_000_000 + index
+            os.utime(stale, (when, when))
+
+        run_captured(["true"], spool_name="new", repo_root=tmp_path)
+
+        names = sorted(p.name for p in _spools(tmp_path))
+        assert len(names) == SPOOL_RETENTION + 1
+        # The two oldest went; the newest kept ones and the new spool remain.
+        assert "old-00.log" not in names
+        assert "old-01.log" not in names
+        assert "old-21.log" in names
+        assert any(name.startswith("new-") for name in names)
+
+    def test_unreadable_spool_does_not_fail_the_run(self, tmp_path, monkeypatch):
+        def boom(self):
+            raise OSError("nope")
+
+        monkeypatch.setattr(Path, "unlink", boom)
+        logs = tmp_path / "var" / "logs"
+        logs.mkdir(parents=True)
+        for index in range(25):
+            (logs / f"old-{index:02d}.log").write_text("x")
+
+        completed = run_captured(_echo("ok"), spool_name="new", repo_root=tmp_path)
+
+        assert completed.returncode == 0
+
+
+class TestFailure:
+    """A non-zero exit points the caller at the spool holding the output."""
+
+    def test_raises_carrying_spool_path(self, tmp_path):
+        argv = [sys.executable, "-c", "import sys; print('boom'); sys.exit(3)"]
+
+        with pytest.raises(CapturedProcessError) as excinfo:
+            run_captured(argv, spool_name="failing", repo_root=tmp_path)
+
+        error = excinfo.value
+        assert error.returncode == 3
+        assert error.cmd == argv
+        assert error.spool_path == _spools(tmp_path)[0]
+        assert error.spool_path.read_text() == "boom\n"
+        assert str(error.spool_path) in str(error)
+
+    def test_check_false_returns_completed_process(self, tmp_path):
+        argv = [sys.executable, "-c", "raise SystemExit(4)"]
+
+        completed = run_captured(argv, spool_name="tolerated", repo_root=tmp_path, check=False)
+
+        assert isinstance(completed, subprocess.CompletedProcess)
+        assert completed.returncode == 4
+
+
+class TestReporterCoupling:
+    """The open spool is handed to the reporter for interrupt reporting."""
+
+    def test_notes_the_spool_on_the_open_phase(self, tmp_path):
+        reporter = PhaseReporter(color=False)
+        reporter.emit = lambda text, style=None: None  # type: ignore[method-assign]
+        install_reporter(reporter)
+        phase = reporter.phase("Building images")
+
+        run_captured(_echo("x"), spool_name="noted", repo_root=tmp_path)
+
+        assert phase.spool == _spools(tmp_path)[0]
+
+    def test_spool_stays_set_after_the_child_exits(self, tmp_path):
+        reporter = PhaseReporter(color=False)
+        reporter.emit = lambda text, style=None: None  # type: ignore[method-assign]
+        install_reporter(reporter)
+        phase = reporter.phase("Building images")
+
+        run_captured(_echo("x"), spool_name="noted", repo_root=tmp_path)
+        run_captured(_echo("y"), spool_name="noted", repo_root=tmp_path)
+
+        assert phase.spool is not None
+        assert phase.spool.exists()
+
+
+class TestVerbosePassThrough:
+    """SC7: verbose runs the identical argv with inherited stdio."""
+
+    def test_same_argv_and_no_redirection_kwargs(self, tmp_path, recorded_run, verbose_reporter):
+        argv = ["docker", "build", "."]
+
+        run_captured(argv, env={"A": "1"}, spool_name="build", repo_root=tmp_path)
+
+        (args, kwargs) = recorded_run[0]
+        assert args[0] == argv
+        assert "stdout" not in kwargs
+        assert "stderr" not in kwargs
+        assert kwargs["env"] == {"A": "1"}
+
+    def test_writes_no_spool_file(self, tmp_path, recorded_run, verbose_reporter):
+        run_captured(["docker", "build", "."], spool_name="build", repo_root=tmp_path)
+
+        assert not (tmp_path / "var" / "logs").exists()
+
+    def test_default_mode_uses_the_same_argv_plus_redirection(self, tmp_path, recorded_run):
+        argv = ["docker", "build", "."]
+
+        run_captured(argv, env={"A": "1"}, spool_name="build", repo_root=tmp_path)
+
+        (args, kwargs) = recorded_run[0]
+        assert args[0] == argv
+        assert kwargs["stderr"] is subprocess.STDOUT
+        assert Path(kwargs["stdout"].name) == _spools(tmp_path)[0]
+
+    def test_failure_still_raises_captured_error_without_a_spool(
+        self, tmp_path, monkeypatch, verbose_reporter
+    ):
+        monkeypatch.setattr(
+            "osprey.deployment.subprocess_capture.subprocess.run",
+            lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 7),
+        )
+
+        with pytest.raises(CapturedProcessError) as excinfo:
+            run_captured(["docker", "build", "."], spool_name="build", repo_root=tmp_path)
+
+        # One exception type in both modes, so a verb's handler needs one except
+        # clause. There is nothing to replay here — the output already streamed.
+        assert excinfo.value.returncode == 7
+        assert excinfo.value.spool_path is None
+        assert not (tmp_path / "var" / "logs").exists()
+
+
+class TestSpoolPathOnTheResult:
+    """The result names its own spool file, in both modes.
+
+    The reporter's copy only covers runs made while a phase is open, so an
+    advisory caller (``check=False``, no phase) would otherwise have no way to
+    point an operator at output that never reached the terminal.
+    """
+
+    def test_capture_mode_result_carries_the_spool_path(self, tmp_path):
+        completed = run_captured(_echo("hello"), spool_name="build", repo_root=tmp_path)
+
+        assert completed.spool_path == _spools(tmp_path)[0]
+        assert completed.spool_path.read_text() == "hello\n"
+
+    def test_verbose_mode_result_carries_none(self, tmp_path, recorded_run, verbose_reporter):
+        completed = run_captured(["docker", "build", "."], spool_name="build", repo_root=tmp_path)
+
+        # Nothing was spooled — the output already went to the terminal.
+        assert completed.spool_path is None
+
+
+class TestWorkingDirectory:
+    """``cwd`` is the child's directory, independent of the spool's location.
+
+    A scaffolded script (``scripts/verify.sh``) is run from the project root so
+    its own relative paths resolve the way they do when an operator runs it by
+    hand, while its output still spools under the deployment repo. Both modes
+    forward it: a run must not change directory just because ``--verbose`` was
+    passed.
+    """
+
+    def test_default_mode_runs_the_child_in_cwd(self, tmp_path):
+        elsewhere = tmp_path / "project"
+        elsewhere.mkdir()
+        repo = tmp_path / "repo"
+
+        run_captured(
+            [sys.executable, "-c", "import os; print(os.getcwd())"],
+            cwd=elsewhere,
+            spool_name="verify-script",
+            repo_root=repo,
+        )
+
+        spool = _spools(repo)[0]
+        assert Path(spool.read_text().strip()).resolve() == elsewhere.resolve()
+
+    def test_verbose_mode_forwards_cwd(self, tmp_path, recorded_run, verbose_reporter):
+        run_captured(
+            ["bash", "scripts/verify.sh"],
+            cwd=tmp_path,
+            spool_name="verify-script",
+            repo_root=tmp_path,
+        )
+
+        (_args, kwargs) = recorded_run[0]
+        assert kwargs["cwd"] == tmp_path
+
+    def test_omitting_cwd_leaves_the_child_in_this_process_directory(self, tmp_path, recorded_run):
+        run_captured(["docker", "build", "."], spool_name="build", repo_root=tmp_path)
+
+        (_args, kwargs) = recorded_run[0]
+        assert kwargs["cwd"] is None

--- a/tests/deployment/test_up_as_built.py
+++ b/tests/deployment/test_up_as_built.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import json
 import os
 import stat
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -155,9 +156,12 @@ def started(monkeypatch):
     # from the rendered bindings by a different function, which stays live.
     monkeypatch.setattr(container_lifecycle, "_preflight_host_ports", lambda config, files: None)
 
-    def _fake_run(cmd, env=None, check=False):
+    def _fake_run(cmd, env=None, check=False, **kwargs):
         record.setdefault("cmds", []).append(list(cmd))
         record["env"] = dict(env or {})
+        # run_captured hangs its spool path off the result, so a stand-in has to
+        # be an object with a __dict__, not None.
+        return subprocess.CompletedProcess(list(cmd), 0)
 
     monkeypatch.setattr(container_lifecycle.subprocess, "run", _fake_run)
 
@@ -1036,7 +1040,11 @@ def test_the_legacy_deploy_up_still_renders(tmp_path, monkeypatch):
         container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
     )
     monkeypatch.setattr(container_lifecycle, "_preflight_host_ports", lambda config, files: None)
-    monkeypatch.setattr(container_lifecycle.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(
+        container_lifecycle.subprocess,
+        "run",
+        lambda cmd, **k: subprocess.CompletedProcess(list(cmd), 0),
+    )
 
     container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
 

--- a/tests/deployment/test_web_terminals_capture.py
+++ b/tests/deployment/test_web_terminals_capture.py
@@ -1,0 +1,553 @@
+"""The web-terminal deploy path spools its children instead of streaming them.
+
+`deploy_up` returns through `deploy_up_web_terminals` for every
+`modules.web_terminals` deployment, which makes this the path an operator of
+the control-assistant preset actually watches. Every inherited-stdio child on
+it — the persona and auth-sidecar image builds, both compose stacks' `rm`,
+`build`, `pull`, `up` and the post-`up` recreate/restart — now runs through
+`run_captured`, and each reports itself as one phase sub-step instead of
+thousands of BuildKit lines.
+
+The headline assertion is `test_default_view_hides_buildkit_lines_...`: a real
+child emitting BuildKit-shaped output, through the real reporter and the real
+capture helper, must leave no `#N [stage]` line on the terminal while the spool
+file holds all of them.
+
+Every "nothing reached the terminal" assertion here uses `capfd`, never
+`capsys`. An uncaptured child writes to file descriptor 1 directly, which
+Python-level capture cannot see at all — a `capsys` version of these tests
+passes even with the capture seam removed, which is exactly the regression they
+exist to catch.
+"""
+
+import re
+import sys
+
+import pytest
+
+from osprey.cli.phase_reporter import PhaseReporter, install_reporter
+from osprey.deployment.subprocess_capture import SPOOL_DIR, CapturedProcess
+from osprey.deployment.web_terminals import persona_images, postup_hooks, provision
+
+# A BuildKit progress line: `#5 [stage-0 2/7] RUN ...`. The whole point of the
+# capture seam is that this shape never reaches the operator's terminal.
+BUILDKIT_LINE = re.compile(r"#\d+ \[")
+
+BUILDKIT_OUTPUT = [
+    "#1 [internal] load build definition from Dockerfile",
+    "#5 [stage-0 2/7] RUN pip install --no-cache-dir osprey-framework",
+    "#9 exporting to image",
+]
+
+
+class RecordingReporter(PhaseReporter):
+    """A reporter that keeps its lines instead of printing them."""
+
+    def __init__(self) -> None:
+        super().__init__(color=False)
+        self.lines: list[str] = []
+
+    def emit(self, text: str, style: str | None = None) -> None:
+        self.lines.append(text)
+
+    @property
+    def steps(self) -> list[str]:
+        """Just the sub-step lines, stripped of their `  · ` prefix and lap."""
+        return [line[4:].split(" (")[0] for line in self.lines if line.startswith("  · ")]
+
+
+@pytest.fixture
+def reporter():
+    """A recording reporter with one phase open, uninstalled afterwards."""
+    rep = RecordingReporter()
+    previous = install_reporter(rep)
+    rep.phase("Starting the stack")
+    try:
+        yield rep
+    finally:
+        install_reporter(previous)
+
+
+@pytest.fixture
+def terminal_reporter(monkeypatch):
+    """The real reporter, printing to the captured stdout, one phase open."""
+    rep = PhaseReporter(color=False)
+    previous = install_reporter(rep)
+    rep.phase("Starting the stack")
+    try:
+        yield rep
+    finally:
+        install_reporter(previous)
+
+
+class RunRecorder:
+    """Stands in for `run_captured`, recording every call's argv and kwargs.
+
+    Returns the real return type, so a caller that reads `spool_path` off the
+    result (the smoke-check hook does) sees `None` — this stand-in spooled
+    nothing — rather than raising `AttributeError`.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def __call__(self, cmd, *, env=None, cwd=None, spool_name, repo_root=None, check=True):
+        self.calls.append(
+            {
+                "cmd": list(cmd),
+                "env": env,
+                "cwd": cwd,
+                "spool_name": spool_name,
+                "repo_root": repo_root,
+                "check": check,
+            }
+        )
+        return CapturedProcess(list(cmd), 0, spool_path=None)
+
+    def by_spool(self, spool_name: str) -> dict:
+        matches = [call for call in self.calls if call["spool_name"] == spool_name]
+        assert matches, f"no captured run named {spool_name!r} (got {self.spool_names})"
+        assert len(matches) == 1, f"{spool_name!r} ran {len(matches)} times"
+        return matches[0]
+
+    @property
+    def spool_names(self) -> list[str]:
+        return [call["spool_name"] for call in self.calls]
+
+
+def _echo_cmd(lines: list[str]) -> list[str]:
+    """A real child printing `lines` — a stand-in for a BuildKit-noisy build."""
+    body = "\n".join(f"print({line!r})" for line in lines)
+    return [sys.executable, "-c", body]
+
+
+def _spool_files(repo_root):
+    return sorted((repo_root / SPOOL_DIR).glob("*.log"))
+
+
+# --------------------------------------------------------------------------
+# persona_images.build_persona_images — the headline scenario's slow step
+# --------------------------------------------------------------------------
+
+
+def _persona_config() -> dict:
+    return {
+        "project_name": "demo",
+        "modules": {
+            "web_terminals": {
+                "image_source": "local",
+                "default_persona": "ops",
+                "personas": {"ops": {}, "physics": {}},
+            }
+        },
+    }
+
+
+def _stub_persona_builds(monkeypatch, tmp_path, units, build_cmd=None):
+    """Neuter everything around the persona build except the run itself."""
+    monkeypatch.chdir(tmp_path)  # resolve_repo_root -> tmp_path
+    monkeypatch.setattr(persona_images, "get_runtime_command", lambda config: ["docker"])
+    monkeypatch.setattr(persona_images, "_referenced_personas", lambda config, users: units)
+    monkeypatch.setattr(
+        persona_images,
+        "_persona_image_build_cmd",
+        lambda *args: list(build_cmd) if build_cmd else ["docker", "build", "."],
+    )
+
+
+def _unit(project: str, persona: str, tmp_path) -> dict:
+    return {"project": project, "persona": persona, "project_path": str(tmp_path / persona)}
+
+
+def test_persona_build_captures_per_image_with_its_own_spool(monkeypatch, tmp_path, reporter):
+    """Each persona image is its own captured run, named for the image it
+    builds, so a failed build names a spool holding only that build's output."""
+    units = [_unit("demo", "ops", tmp_path), _unit("demo", "physics", tmp_path)]
+    _stub_persona_builds(monkeypatch, tmp_path, units)
+    recorder = RunRecorder()
+    monkeypatch.setattr(persona_images, "run_captured", recorder)
+
+    persona_images.build_persona_images(_persona_config(), [], False, {"HOME": "/x"})
+
+    assert recorder.spool_names == ["build-persona-demo-ops", "build-persona-demo-physics"]
+    for call in recorder.calls:
+        assert call["cmd"] == ["docker", "build", "."]
+        assert call["env"] == {"HOME": "/x"}
+        assert call["repo_root"] == tmp_path
+        assert call["check"] is True
+
+
+def test_persona_build_reports_one_step_per_image(monkeypatch, tmp_path, reporter):
+    """One sub-step per persona image, naming that image: the only progress an
+    operator sees while a run of multi-minute builds goes by."""
+    units = [_unit("demo", "ops", tmp_path), _unit("demo", "physics", tmp_path)]
+    _stub_persona_builds(monkeypatch, tmp_path, units)
+    monkeypatch.setattr(persona_images, "run_captured", RunRecorder())
+
+    persona_images.build_persona_images(_persona_config(), [], False, {})
+
+    assert reporter.steps == ["persona image demo-ops:local", "persona image demo-physics:local"]
+
+
+def test_default_view_hides_buildkit_lines_but_the_spool_keeps_them(
+    monkeypatch, tmp_path, capfd, terminal_reporter
+):
+    """SC2, end to end on the headline path: a real child emitting BuildKit
+    progress, the real reporter, the real capture helper. The operator's
+    terminal shows the step line and nothing of the build; the spool file
+    exists and holds every line."""
+    units = [_unit("demo", "ops", tmp_path)]
+    _stub_persona_builds(monkeypatch, tmp_path, units, build_cmd=_echo_cmd(BUILDKIT_OUTPUT))
+
+    persona_images.build_persona_images(_persona_config(), [], False, None)
+
+    out = capfd.readouterr().out
+    assert not BUILDKIT_LINE.search(out), f"raw build output reached the terminal:\n{out}"
+    for line in BUILDKIT_OUTPUT:
+        assert line not in out
+    assert "· persona image demo-ops:local" in out
+
+    spools = _spool_files(tmp_path)
+    assert len(spools) == 1, f"expected one spool file, got {[p.name for p in spools]}"
+    assert spools[0].name.startswith("build-persona-demo-ops-")
+    spooled = spools[0].read_text()
+    for line in BUILDKIT_OUTPUT:
+        assert line in spooled
+
+
+# --------------------------------------------------------------------------
+# provision.build_auth_sidecar_image
+# --------------------------------------------------------------------------
+
+
+def test_auth_sidecar_build_is_captured_and_reported(monkeypatch, tmp_path, reporter):
+    """The sidecar build is the other local-mode image build; same treatment,
+    and its own spool name so the two never share a file."""
+    monkeypatch.chdir(tmp_path)
+    context = tmp_path / "build" / "auth"
+    context.mkdir(parents=True)
+    monkeypatch.setattr(provision, "get_runtime_command", lambda config: ["docker"])
+    monkeypatch.setattr(
+        provision, "_materialize_auth_build_context", lambda repo_root, dev_mode: context
+    )
+    recorder = RunRecorder()
+    monkeypatch.setattr(provision, "run_captured", recorder)
+
+    config = {
+        "project_name": "demo",
+        "modules": {
+            "web_terminals": {"image_source": "local", "auth": {"method": "password"}},
+        },
+    }
+    provision.build_auth_sidecar_image(config, False, {"HOME": "/x"})
+
+    call = recorder.by_spool("build-auth-sidecar")
+    assert call["cmd"][:2] == ["docker", "build"]
+    assert call["cmd"][-1] == str(context)
+    assert call["env"] == {"HOME": "/x"}
+    assert call["repo_root"] == tmp_path
+    assert call["check"] is True
+    assert reporter.steps == [f"auth sidecar image {provision.auth_sidecar_local_tag(config)}"]
+
+
+# --------------------------------------------------------------------------
+# provision._force_recreate_services — post-up recreate and the auth rotation
+# --------------------------------------------------------------------------
+
+
+def test_force_recreate_is_captured_with_the_callers_repo_root(monkeypatch, tmp_path, reporter):
+    """The recreate is a compose `up` like any other: captured, and anchored to
+    the repo root the caller already resolved rather than the process cwd."""
+    recorder = RunRecorder()
+    monkeypatch.setattr(provision, "run_captured", recorder)
+
+    provision._force_recreate_services(
+        ["docker", "compose", "-f", "web.yml"],
+        {"COMPOSE_PROJECT_NAME": "demo"},
+        ["osprey-auth", "nginx"],
+        repo_root=tmp_path,
+    )
+
+    call = recorder.by_spool("compose-force-recreate")
+    assert call["cmd"] == [
+        "docker",
+        "compose",
+        "-f",
+        "web.yml",
+        "up",
+        "-d",
+        "--force-recreate",
+        "osprey-auth",
+        "nginx",
+    ]
+    assert call["repo_root"] == tmp_path
+    assert call["check"] is True
+    assert reporter.steps == ["recreated osprey-auth, nginx"]
+
+
+def test_image_drift_reconcile_forwards_the_deploys_repo_root(monkeypatch, tmp_path, reporter):
+    """The post-`up` reconcile is handed the root `deploy_up_web_terminals`
+    already resolved, so the recreate spools beside the `up` that preceded it
+    rather than wherever the process happens to be."""
+    (tmp_path / "build").mkdir()
+    (tmp_path / "build" / "docker-compose.web.yml").write_text(
+        "services:\n  nginx:\n    image: nginx:local\n    container_name: demo-nginx\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(provision, "get_runtime_command", lambda config: ["podman"])
+    monkeypatch.setattr(provision, "get_image_id", lambda *a, **kw: "sha256:new")
+    monkeypatch.setattr(provision, "get_container_image_id", lambda *a, **kw: "sha256:old")
+    recorded: dict = {}
+    monkeypatch.setattr(
+        provision,
+        "_force_recreate_services",
+        lambda web_cmd, run_env, services, **kwargs: recorded.update(
+            services=services, repo_root=kwargs.get("repo_root")
+        ),
+    )
+
+    provision._reconcile_web_stack_recreates(
+        {"project_name": "demo"}, ["podman", "compose"], {}, repo_root=tmp_path
+    )
+
+    assert recorded == {"services": ["nginx"], "repo_root": tmp_path}
+
+
+# --------------------------------------------------------------------------
+# provision.deploy_up_web_terminals — both compose stacks
+# --------------------------------------------------------------------------
+
+
+def _stub_web_stack(monkeypatch, tmp_path):
+    """Neuter every collaborator of deploy_up_web_terminals except the runs."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(provision, "get_runtime_command", lambda config=None: ["docker", "compose"])
+    monkeypatch.setattr(provision, "runtime_env", lambda config, env, **kw: dict(env))
+    monkeypatch.setattr(provision, "write_web_terminal_artifacts", lambda config, dest=".": [])
+    monkeypatch.setattr(provision, "ensure_env_production", lambda config, root: None)
+    monkeypatch.setattr(provision, "resolve_personas", lambda *a, **kw: [])
+    monkeypatch.setattr(provision, "verify_persona_renders", lambda *a, **kw: None)
+    monkeypatch.setattr(provision, "build_persona_images", lambda *a, **kw: None)
+    monkeypatch.setattr(provision, "build_auth_sidecar_image", lambda *a, **kw: None)
+    monkeypatch.setattr(provision, "_reconcile_web_stack_recreates", lambda *a, **kw: None)
+    monkeypatch.setattr(provision, "reload_nginx_config", lambda *a, **kw: None)
+    monkeypatch.setattr(provision, "enable_linger", lambda *a, **kw: None)
+    monkeypatch.setattr(provision, "seed_user_containers", lambda *a, **kw: None)
+    monkeypatch.setattr(provision, "run_verify_script", lambda *a, **kw: None)
+    monkeypatch.setattr(provision, "warn_if_web_stack_unreachable", lambda *a, **kw: None)
+    recorder = RunRecorder()
+    monkeypatch.setattr(provision, "run_captured", recorder)
+    return recorder
+
+
+def _web_config(image_source: str = "registry") -> dict:
+    return {
+        "project_name": "demo",
+        "deployed_services": ["ariel"],
+        "modules": {
+            "web_terminals": {"image_source": image_source, "auth": {"method": "none"}},
+        },
+    }
+
+
+def test_dev_mode_up_captures_every_compose_invocation(monkeypatch, tmp_path, reporter):
+    """A dev-mode registry deploy runs both stacks: services rm/build/up, then
+    the web stack's rm/pull/up. Every one is captured, in that order, each
+    under its own spool name and anchored to the repo root."""
+    recorder = _stub_web_stack(monkeypatch, tmp_path)
+
+    provision.deploy_up_web_terminals(_web_config(), ["docker-compose.yml"], True, {}, [])
+
+    assert recorder.spool_names == [
+        "compose-services-rm",
+        "build-services",
+        "compose-services-up",
+        "compose-web-rm",
+        "compose-web-pull",
+        "compose-web-up",
+    ]
+    assert all(call["repo_root"] == tmp_path for call in recorder.calls)
+    assert recorder.by_spool("compose-services-rm")["cmd"][-2:] == ["rm", "-f"]
+    assert recorder.by_spool("build-services")["cmd"][-1] == "build"
+    assert recorder.by_spool("compose-services-up")["cmd"][-3:] == ["up", "--no-build", "-d"]
+    assert recorder.by_spool("compose-web-rm")["cmd"][-2:] == ["rm", "-f"]
+    assert recorder.by_spool("compose-web-pull")["cmd"][-1] == "pull"
+    assert recorder.by_spool("compose-web-up")["cmd"][-2:] == ["up", "-d"]
+
+
+def test_stale_container_preflights_stay_non_fatal(monkeypatch, tmp_path, reporter):
+    """Both `rm -f` preflights no-op on a clean stack and must never abort the
+    deploy on a non-zero exit — check=False, exactly as before the conversion.
+    Every other invocation stays fail-loud."""
+    recorder = _stub_web_stack(monkeypatch, tmp_path)
+
+    provision.deploy_up_web_terminals(_web_config(), ["docker-compose.yml"], False, {}, [])
+
+    checks = {call["spool_name"]: call["check"] for call in recorder.calls}
+    assert checks == {
+        "compose-services-rm": False,
+        "compose-services-up": True,
+        "compose-web-rm": False,
+        "compose-web-pull": True,
+        "compose-web-up": True,
+    }
+
+
+def test_up_reports_a_step_for_each_stack(monkeypatch, tmp_path, reporter):
+    """The default view of a deploy: a handful of sub-steps, no compose output."""
+    _stub_web_stack(monkeypatch, tmp_path)
+
+    provision.deploy_up_web_terminals(_web_config(), ["docker-compose.yml"], False, {}, [])
+
+    assert reporter.steps == [
+        "cleared stale service containers",
+        "backend services started",
+        "cleared stale web-terminal containers",
+        "pulled web-terminal images",
+        "web-terminal stack started",
+    ]
+
+
+def test_local_mode_up_still_never_pulls(monkeypatch, tmp_path, reporter):
+    """The local-only tags have no upstream, so local mode issues no pull —
+    the conversion must not smuggle one back in."""
+    recorder = _stub_web_stack(monkeypatch, tmp_path)
+
+    provision.deploy_up_web_terminals(_web_config("local"), ["docker-compose.yml"], False, {}, [])
+
+    assert "compose-web-pull" not in recorder.spool_names
+
+
+# --------------------------------------------------------------------------
+# postup_hooks — the advisory verify.sh smoke check
+# --------------------------------------------------------------------------
+
+
+def _write_verify_script(project_root, body: str = "echo ok") -> None:
+    scripts = project_root / "scripts"
+    scripts.mkdir(parents=True, exist_ok=True)
+    (scripts / "verify.sh").write_text(f"#!/usr/bin/env bash\n{body}\n", encoding="utf-8")
+
+
+def test_verify_script_is_captured_from_the_project_root(monkeypatch, tmp_path, reporter):
+    """The smoke check spools like every other child, but must still RUN from
+    the project root — its own `./scripts/...` assumptions depend on it, so
+    `cwd` and `repo_root` are passed separately."""
+    _write_verify_script(tmp_path)
+    recorder = RunRecorder()
+    monkeypatch.setattr(postup_hooks, "run_captured", recorder)
+
+    postup_hooks.run_verify_script(str(tmp_path), {"COMPOSE_PROJECT_NAME": "demo"})
+
+    call = recorder.by_spool("verify-script")
+    assert call["cmd"] == ["bash", str(tmp_path / "scripts" / "verify.sh")]
+    assert call["cwd"] == str(tmp_path)
+    assert call["repo_root"] == str(tmp_path)
+    # Advisory: the script's own convention is to always exit 0, and a
+    # site-customized copy that does not must still never fail the deploy.
+    assert call["check"] is False
+    assert reporter.steps == ["smoke check verify.sh — exit 0"]
+
+
+def test_verify_script_output_never_reaches_the_terminal(
+    monkeypatch, tmp_path, capfd, terminal_reporter
+):
+    """Real script, real capture: a chatty health report belongs in the spool,
+    with only the step line on the operator's terminal."""
+    _write_verify_script(tmp_path, body="\n".join(f"echo '{line}'" for line in BUILDKIT_OUTPUT))
+
+    postup_hooks.run_verify_script(str(tmp_path), {})
+
+    out = capfd.readouterr().out
+    assert not BUILDKIT_LINE.search(out)
+    assert "· smoke check verify.sh — exit 0" in out
+    spooled = _spool_files(tmp_path)[0].read_text()
+    for line in BUILDKIT_OUTPUT:
+        assert line in spooled
+
+
+def test_failing_verify_script_names_its_spool_and_does_not_raise(
+    monkeypatch, tmp_path, caplog, terminal_reporter
+):
+    """A non-zero exit stays advisory — and now that nothing streamed, the
+    warning has to name the file holding the report."""
+    _write_verify_script(tmp_path, body="echo 'probe failed'\nexit 3")
+
+    with caplog.at_level("WARNING"):
+        postup_hooks.run_verify_script(str(tmp_path), {})
+
+    spool = _spool_files(tmp_path)[0]
+    assert "exited 3" in caplog.text
+    assert str(spool) in caplog.text
+
+
+def test_failing_verify_script_names_its_spool_with_no_phase_open(monkeypatch, tmp_path, caplog):
+    """The hook has callers outside the lifecycle verbs (no reporter phase, so
+    nothing recorded a spool path for them). The path comes off the completed
+    process, so those callers get it too rather than being pointed at output
+    that is not on their terminal."""
+    _write_verify_script(tmp_path, body="echo 'probe failed'\nexit 3")
+
+    with caplog.at_level("WARNING"):
+        postup_hooks.run_verify_script(str(tmp_path), {})
+
+    assert str(_spool_files(tmp_path)[0]) in caplog.text
+    assert "Review the output above" not in caplog.text
+
+
+def test_missing_verify_script_runs_nothing(monkeypatch, tmp_path, reporter):
+    """A profile that carries no verify.sh deploys exactly as before."""
+    recorder = RunRecorder()
+    monkeypatch.setattr(postup_hooks, "run_captured", recorder)
+
+    postup_hooks.run_verify_script(str(tmp_path), {})
+
+    assert recorder.calls == []
+    assert reporter.steps == []
+
+
+# --------------------------------------------------------------------------
+# postup_hooks — the Docker Desktop host-port self-heal restart
+# --------------------------------------------------------------------------
+
+
+def test_host_port_self_heal_restart_is_captured(monkeypatch, tmp_path, reporter):
+    """The self-heal restart's compose chatter would bury the warning it sits
+    under, so it spools; advisory as before (check=False), and it reports the
+    bounce as a step."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(postup_hooks.sys, "platform", "darwin")
+    monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker"])
+    monkeypatch.setattr(postup_hooks, "_host_port_answers", lambda url, attempts, delay: False)
+    recorder = RunRecorder()
+    monkeypatch.setattr(postup_hooks, "run_captured", recorder)
+
+    postup_hooks.warn_if_web_stack_unreachable(
+        {"modules": {"web_terminals": {"nginx_port": 8080}}},
+        attempts=1,
+        delay=0,
+        web_cmd=["docker", "compose", "-f", "web.yml"],
+        run_env={"COMPOSE_PROJECT_NAME": "demo"},
+    )
+
+    call = recorder.by_spool("compose-web-restart")
+    assert call["cmd"] == ["docker", "compose", "-f", "web.yml", "restart"]
+    assert call["repo_root"] == tmp_path
+    assert call["check"] is False
+    assert reporter.steps == ["bounced the web stack for host-port re-registration"]
+
+
+def test_host_port_probe_that_answers_runs_nothing(monkeypatch, tmp_path, reporter):
+    """A reachable port is the common case: no restart, no spool, no step."""
+    monkeypatch.setattr(postup_hooks, "_host_port_answers", lambda url, attempts, delay: True)
+    recorder = RunRecorder()
+    monkeypatch.setattr(postup_hooks, "run_captured", recorder)
+
+    postup_hooks.warn_if_web_stack_unreachable(
+        {"modules": {"web_terminals": {"nginx_port": 8080}}},
+        web_cmd=["docker", "compose"],
+        run_env={},
+    )
+
+    assert recorder.calls == []
+    assert reporter.steps == []

--- a/tests/deployment/web_terminals/test_lifecycle.py
+++ b/tests/deployment/web_terminals/test_lifecycle.py
@@ -102,7 +102,7 @@ def fake_runtime(monkeypatch):
     """Patch subprocess.run + get_runtime_command; return the list of captured argvs."""
     calls: list[list[str]] = []
 
-    def _fake_run(argv, capture_output=True, text=True, env=None, check=False):
+    def _fake_run(argv, capture_output=True, text=True, env=None, check=False, **kwargs):
         calls.append(list(argv))
         return subprocess.CompletedProcess(argv, returncode=0, stdout="", stderr="")
 
@@ -125,7 +125,7 @@ def fake_runtime_prune(monkeypatch):
     calls: list[list[str]] = []
     listing: dict[str, list[str]] = {"containers": [], "volumes": []}
 
-    def _fake_run(argv, capture_output=True, text=True, env=None, check=False):
+    def _fake_run(argv, capture_output=True, text=True, env=None, check=False, **kwargs):
         calls.append(list(argv))
         if argv[1:3] == ["ps", "-a"]:
             stdout = "\n".join(listing["containers"])
@@ -164,7 +164,7 @@ def fake_runtime_nuke(monkeypatch):
     down_result = {"returncode": 0, "stderr": ""}
     image_labels: dict[str, str | None] = {}
 
-    def _fake_run(argv, capture_output=True, text=True, env=None, check=False):
+    def _fake_run(argv, capture_output=True, text=True, env=None, check=False, **kwargs):
         calls.append(list(argv))
         if argv[1:3] == ["ps", "-a"]:
             return subprocess.CompletedProcess(
@@ -1290,18 +1290,22 @@ def _capture_recreate_argv(monkeypatch) -> list[list[str]]:
     delegated call's arguments — a stricter check, and one that cannot pass
     while the fragment is dropped on the floor.
 
-    CAUTION for anyone extending a test that uses this: `lifecycle`, `provision`
-    and `postup_hooks` all do a plain `import subprocess`, so they share ONE
-    module object. Patching `provision.subprocess.run` here REPLACES the patch
-    `fake_runtime` installed, which means `fake_runtime`'s own list stays EMPTY
-    in these tests. Assert on the list this returns; an assertion against
-    `fake_runtime` here would be vacuously true.
+    CAUTION for anyone extending a test that uses this: the recreate is a
+    captured run, so this patches `provision.run_captured` — the seam the
+    primitive actually calls — while `fake_runtime` patches the shared
+    `subprocess` module. The recreate therefore never reaches `fake_runtime`'s
+    list, which stays EMPTY in these tests. Assert on the list this returns; an
+    assertion against `fake_runtime` here would be vacuously true.
     """
     from osprey.deployment.web_terminals import provision
 
     calls: list[list[str]] = []
     monkeypatch.setattr(provision, "get_runtime_command", lambda config=None: ["docker", "compose"])
-    monkeypatch.setattr(provision.subprocess, "run", lambda cmd, **kwargs: calls.append(list(cmd)))
+    monkeypatch.setattr(
+        provision,
+        "run_captured",
+        lambda cmd, **kwargs: calls.append(list(cmd)) or subprocess.CompletedProcess(list(cmd), 0),
+    )
     return calls
 
 
@@ -1469,6 +1473,38 @@ def test_passwd_reports_a_failed_recreate_as_a_password_that_DID_change(
     assert "osprey up" in message
     # The stored hash really is the new one — the message is not a consolation.
     assert verify_password("alices-new-password", _read_hash(tmp_path, "ALICE"))
+
+
+def test_passwd_reports_a_spooled_recreate_failure_the_same_way(
+    tmp_path, monkeypatch, fake_runtime
+):
+    """The recreate's compose output is spooled, so this is the type it raises.
+
+    ``CalledProcessError`` above is the shape the guard was written for;
+    ``CapturedProcessError`` is the one it now actually meets. Caught, the
+    operator gets the same two facts plus the spool to read. Uncaught, the
+    generic CLI handler prints "Deployment failed" over a changed password.
+    """
+    monkeypatch.chdir(tmp_path)
+    config_path = _write_config(tmp_path, _auth_config(["alice"]))
+
+    from osprey.deployment.errors import CapturedProcessError
+    from osprey.deployment.web_terminals import provision
+
+    spool = tmp_path / "var" / "logs" / "compose-auth-recreate.log"
+
+    def _failed_recreate(*args, **kwargs):
+        raise CapturedProcessError(["docker", "compose", "up"], 1, spool)
+
+    monkeypatch.setattr(provision, "force_recreate_auth_sidecar", _failed_recreate)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        lifecycle.rotate_user_password(str(config_path), "alice", "alices-new-password")
+
+    message = str(exc_info.value)
+    assert "'alice'" in message
+    assert "WAS changed" in message
+    assert str(spool) in message, "the spooled output is unreadable if nothing names it"
 
 
 def test_passwd_never_logs_or_prints_the_password(
@@ -1710,6 +1746,37 @@ def test_decommission_auth_recreate_failure_is_fatal_after_the_volume_policy_run
     assert f"{PW_HASH_VAR_PREFIX}ALICE" not in parse_dotenv_file(tmp_path / AUTH_ENV_FILENAME)
     # ...and the deferred raise let the volume policy finish first.
     assert [cmd for cmd in fake_runtime if cmd[1:3] == ["volume", "rm"]]
+
+
+def test_decommission_reports_a_spooled_recreate_failure_the_same_way(
+    tmp_path, monkeypatch, fake_runtime, auth_reconcile_runtime
+):
+    """The reconcile guard meets the spooled type too, and must still name both.
+
+    Which user was removed, and where the compose output that explains the
+    failure went — an unreconciled sidecar is only actionable with both.
+    """
+    from osprey.deployment.errors import CapturedProcessError
+    from osprey.deployment.web_terminals import provision
+
+    monkeypatch.chdir(tmp_path)
+    _seed_env_auth(tmp_path, ALICE="scrypt.alice")
+    config_path = _write_config(tmp_path, _renderable_auth_config(["alice", "bob"]))
+
+    spool = tmp_path / "var" / "logs" / "compose-auth-recreate.log"
+
+    def _failed_recreate(*args, **kwargs):
+        raise CapturedProcessError(["docker", "compose", "up"], 1, spool)
+
+    monkeypatch.setattr(provision, "force_recreate_auth_sidecar", _failed_recreate)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        lifecycle.decommission_user(str(config_path), "alice", purge=True, assume_yes=True)
+
+    message = str(exc_info.value)
+    assert "'alice'" in message
+    assert "still holds their roster entry and password hash" in message
+    assert str(spool) in message, "the spooled output is unreadable if nothing names it"
 
 
 def test_prune_auth_recreate_failure_is_fatal_too(

--- a/tests/deployment/web_terminals/test_persona_images.py
+++ b/tests/deployment/web_terminals/test_persona_images.py
@@ -8,11 +8,11 @@ refuses a start when `osprey build` has not written a persona's project.
 from __future__ import annotations
 
 import os
-import subprocess
 from pathlib import Path
 
 import pytest
 
+from osprey.deployment.errors import CapturedProcessError
 from osprey.deployment.web_terminals import persona_images
 
 # ---------------------------------------------------------------------------
@@ -59,7 +59,7 @@ def _no_dev_wheel_staging(monkeypatch):
 
 def test_build_persona_images_noop_in_registry_mode(monkeypatch, tmp_path):
     calls = []
-    monkeypatch.setattr(persona_images.subprocess, "run", lambda *a, **k: calls.append(a))
+    monkeypatch.setattr(persona_images, "run_captured", lambda *a, **k: calls.append(a))
     config = {"modules": {"web_terminals": {"image_source": "registry"}}}
 
     persona_images.build_persona_images(config, [{"persona": "ops"}], False, {})
@@ -115,7 +115,7 @@ def test_build_persona_images_builds_each_referenced_persona_once(
 
     monkeypatch.setattr(persona_images, "get_runtime_command", lambda config: ["docker", "compose"])
     calls = []
-    monkeypatch.setattr(persona_images.subprocess, "run", lambda cmd, **k: calls.append(cmd))
+    monkeypatch.setattr(persona_images, "run_captured", lambda cmd, **k: calls.append(cmd))
 
     persona_images.build_persona_images(config, resolved_users, False, {})
 
@@ -161,7 +161,7 @@ def test_build_persona_images_never_builds_zero_migration_entries(
 
     monkeypatch.setattr(persona_images, "get_runtime_command", lambda config: ["docker", "compose"])
     calls = []
-    monkeypatch.setattr(persona_images.subprocess, "run", lambda cmd, **k: calls.append(cmd))
+    monkeypatch.setattr(persona_images, "run_captured", lambda cmd, **k: calls.append(cmd))
 
     persona_images.build_persona_images(config, resolved_users, False, {})
 
@@ -186,7 +186,7 @@ def test_build_persona_images_includes_cli_version_from_persona_config(
 
     monkeypatch.setattr(persona_images, "get_runtime_command", lambda config: ["docker", "compose"])
     calls = []
-    monkeypatch.setattr(persona_images.subprocess, "run", lambda cmd, **k: calls.append(cmd))
+    monkeypatch.setattr(persona_images, "run_captured", lambda cmd, **k: calls.append(cmd))
 
     persona_images.build_persona_images(config, resolved_users, False, {})
 
@@ -215,7 +215,7 @@ def test_build_persona_images_omits_cli_version_when_unset_in_persona_config(
 
     monkeypatch.setattr(persona_images, "get_runtime_command", lambda config: ["docker", "compose"])
     calls = []
-    monkeypatch.setattr(persona_images.subprocess, "run", lambda cmd, **k: calls.append(cmd))
+    monkeypatch.setattr(persona_images, "run_captured", lambda cmd, **k: calls.append(cmd))
 
     persona_images.build_persona_images(config, resolved_users, False, {})
 
@@ -249,7 +249,7 @@ def test_build_persona_images_never_reads_facility_cli_version(
 
     monkeypatch.setattr(persona_images, "get_runtime_command", lambda config: ["docker", "compose"])
     calls = []
-    monkeypatch.setattr(persona_images.subprocess, "run", lambda cmd, **k: calls.append(cmd))
+    monkeypatch.setattr(persona_images, "run_captured", lambda cmd, **k: calls.append(cmd))
 
     persona_images.build_persona_images(config, resolved_users, False, {})
 
@@ -277,7 +277,7 @@ def test_build_persona_images_dev_mode_adds_osprey_dev_build_arg(
 
     monkeypatch.setattr(persona_images, "get_runtime_command", lambda config: ["docker", "compose"])
     calls = []
-    monkeypatch.setattr(persona_images.subprocess, "run", lambda cmd, **k: calls.append(cmd))
+    monkeypatch.setattr(persona_images, "run_captured", lambda cmd, **k: calls.append(cmd))
 
     persona_images.build_persona_images(config, resolved_users, True, {})
 
@@ -308,7 +308,7 @@ def test_build_persona_images_dev_mode_omits_osprey_dev_when_staging_fails(monke
     )
     monkeypatch.setattr(persona_images, "get_runtime_command", lambda config: ["docker", "compose"])
     calls = []
-    monkeypatch.setattr(persona_images.subprocess, "run", lambda cmd, **k: calls.append(cmd))
+    monkeypatch.setattr(persona_images, "run_captured", lambda cmd, **k: calls.append(cmd))
 
     persona_images.build_persona_images(config, resolved_users, True, {})
 
@@ -334,7 +334,7 @@ def test_build_persona_images_non_dev_omits_osprey_dev_build_arg(
 
     monkeypatch.setattr(persona_images, "get_runtime_command", lambda config: ["docker", "compose"])
     calls = []
-    monkeypatch.setattr(persona_images.subprocess, "run", lambda cmd, **k: calls.append(cmd))
+    monkeypatch.setattr(persona_images, "run_captured", lambda cmd, **k: calls.append(cmd))
 
     persona_images.build_persona_images(config, resolved_users, False, {})
 
@@ -363,7 +363,7 @@ def test_build_persona_images_dev_mode_stages_and_cleans_wheel(monkeypatch, tmp_
 
     monkeypatch.setattr(persona_images, "_copy_local_framework_for_override", _fake_stage)
     monkeypatch.setattr(persona_images, "get_runtime_command", lambda config: ["docker", "compose"])
-    monkeypatch.setattr(persona_images.subprocess, "run", lambda cmd, **k: None)
+    monkeypatch.setattr(persona_images, "run_captured", lambda cmd, **k: None)
 
     persona_images.build_persona_images(config, resolved_users, True, {})
 
@@ -400,13 +400,15 @@ def test_build_persona_images_dev_mode_cleans_staged_artifacts_on_build_failure(
         return True
 
     def _failing_build(cmd, **k):
-        raise subprocess.CalledProcessError(1, cmd)
+        # A captured build reports failure as CapturedProcessError, which carries
+        # the spool path holding the output the terminal never saw.
+        raise CapturedProcessError(cmd, 1)
 
     monkeypatch.setattr(persona_images, "_copy_local_framework_for_override", _fake_stage)
     monkeypatch.setattr(persona_images, "get_runtime_command", lambda config: ["docker", "compose"])
-    monkeypatch.setattr(persona_images.subprocess, "run", _failing_build)
+    monkeypatch.setattr(persona_images, "run_captured", _failing_build)
 
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(CapturedProcessError):
         persona_images.build_persona_images(config, resolved_users, True, {})
 
     context = persona_images._persona_image_context(ops_path)
@@ -433,7 +435,7 @@ def test_build_persona_images_no_referenced_personas_runs_no_build(
 
     monkeypatch.setattr(persona_images, "get_runtime_command", lambda config: ["docker", "compose"])
     calls = []
-    monkeypatch.setattr(persona_images.subprocess, "run", lambda cmd, **k: calls.append(cmd))
+    monkeypatch.setattr(persona_images, "run_captured", lambda cmd, **k: calls.append(cmd))
 
     persona_images.build_persona_images(config, [], False, {})
 
@@ -522,7 +524,7 @@ _PERSONA_USERS = [{"name": "alice", "index": 0, "persona": "ops", "project": "op
 def calls(monkeypatch) -> list[list[str]]:
     """Every subprocess this module would run. It must stay empty here."""
     recorded: list[list[str]] = []
-    monkeypatch.setattr(persona_images.subprocess, "run", lambda cmd, **k: recorded.append(cmd))
+    monkeypatch.setattr(persona_images, "run_captured", lambda cmd, **k: recorded.append(cmd))
     return recorded
 
 

--- a/tests/deployment/web_terminals/test_postup_hooks.py
+++ b/tests/deployment/web_terminals/test_postup_hooks.py
@@ -283,9 +283,12 @@ def test_docker_desktop_unreachable_self_heals_via_restart(monkeypatch, caplog):
     monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker", "compose"])
 
     ran: list[list[str]] = []
+    # The self-heal restart is a captured run: patching the helper (rather than
+    # the shared stdlib `subprocess`) keeps the assertion on the argv and stops
+    # the real capture branch spooling a log into the working directory.
     monkeypatch.setattr(
-        postup_hooks.subprocess,
-        "run",
+        postup_hooks,
+        "run_captured",
         lambda cmd, **kw: ran.append(cmd) or _FakeCompletedProcess(0),
     )
 
@@ -311,9 +314,12 @@ def test_docker_desktop_warns_only_after_restart_fails_to_help(monkeypatch, capl
     monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker", "compose"])
 
     ran: list[list[str]] = []
+    # The self-heal restart is a captured run: patching the helper (rather than
+    # the shared stdlib `subprocess`) keeps the assertion on the argv and stops
+    # the real capture branch spooling a log into the working directory.
     monkeypatch.setattr(
-        postup_hooks.subprocess,
-        "run",
+        postup_hooks,
+        "run_captured",
         lambda cmd, **kw: ran.append(cmd) or _FakeCompletedProcess(0),
     )
 
@@ -334,9 +340,12 @@ def test_self_heal_never_fires_on_linux(monkeypatch, caplog):
     monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker", "compose"])
 
     ran: list[list[str]] = []
+    # The self-heal restart is a captured run: patching the helper (rather than
+    # the shared stdlib `subprocess`) keeps the assertion on the argv and stops
+    # the real capture branch spooling a log into the working directory.
     monkeypatch.setattr(
-        postup_hooks.subprocess,
-        "run",
+        postup_hooks,
+        "run_captured",
         lambda cmd, **kw: ran.append(cmd) or _FakeCompletedProcess(0),
     )
 
@@ -356,9 +365,12 @@ def test_self_heal_skipped_when_caller_supplies_no_compose_cmd(monkeypatch, capl
     monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker", "compose"])
 
     ran: list[list[str]] = []
+    # The self-heal restart is a captured run: patching the helper (rather than
+    # the shared stdlib `subprocess`) keeps the assertion on the argv and stops
+    # the real capture branch spooling a log into the working directory.
     monkeypatch.setattr(
-        postup_hooks.subprocess,
-        "run",
+        postup_hooks,
+        "run_captured",
         lambda cmd, **kw: ran.append(cmd) or _FakeCompletedProcess(0),
     )
 


### PR DESCRIPTION
A build printed 326 lines of interleaved internal logging. Nothing in it
told the operator which stage was running, which had finished, or what the
build had produced when it stopped — and when a container command failed,
its output was somewhere in the middle of that scroll.

## What the lifecycle verbs do now

`osprey init`, `build`, `up`, `restart` and `down` report a short sequence
of named phases, one line each, opened as the phase starts and closed with
its elapsed time. `init`, `build`, `down` and a detached `up -d` / `restart -d`
end with a summary card naming the project, its services and where they can
be reached; an attached start ends inside the live log stream, so it gets
none. `osprey reset` ends with a one-line summary. One reporter spans the
whole `init --up` chain, so the sequence reads as a single run rather than
three.

`osprey -v` installs a no-op reporter and restores the raw stream, so the
old behaviour is still there for debugging.

## Where the container output went

Container stdout and stderr used to inherit the terminal. They are now
spooled to a file under `var/logs/` and replayed only when the command
fails — the failure raises an error carrying its own captured output, so
the reason is on screen at the point of failure rather than scrolled past.
Spools are retained, so a past failure can still be read afterwards.

The `down` path converts from `execvpe` to a captured run and keeps its
environment pin. Starts that hand the terminal to the container still exec.

## Reviewing this

Per-render and per-injection logging moves from info to debug (39 sites);
warnings and errors keep their levels. The test suites move with the seams:
they patch the capture point in the namespace that now uses it and read the
demoted lines with caplog at debug. Two tests are retired where the new
capture and replay suites cover their behaviour.

The last commit is separable from the rest. `cli/styles.py` guards its
`questionary` import and falls back to `None`, but two return annotations
named the type unquoted and so were evaluated at import; without the
dependency the module raised `TypeError` rather than degrading. That was
latent until the deployment package began reaching the theme module, and
the composed auth-stack test is what surfaced it.

## Known gaps

The manual acceptance run against a scratch repo has not been done. A
pre-existing bug turned up along the way and is not addressed here: a
second `osprey build` in the same repo fails, because the environment is
created with `uv venv` and no `--clear`.
