### PR TITLE
feat(bluesky): plan-rendered run figures

### DIFF
--- a/docs/source/how-to/bluesky/queue.rst
+++ b/docs/source/how-to/bluesky/queue.rst
@@ -55,6 +55,8 @@ One queue, three ways to drive it
       - ``queue_stop`` / ``stop_run`` — the two halts. Never switched off.
       - ``queue_list`` / ``queue_status`` / ``list_runs`` / ``get_run_data``
         — read what is queued, running, and measured.
+      - ``get_run_figure`` — read the same figure the BLUESKY panel is
+        drawing, so you and the agent are discussing one picture.
 
       A bundled skill (``operating-bluesky-scans``) teaches the agent this
       flow, so you rarely need to name a tool yourself.
@@ -72,7 +74,8 @@ One queue, three ways to drive it
          POST /queue/stop           stop after the running item
          POST /queue/abort          abort the running plan — never gated
          GET  /queue                what is queued and running
-         GET  /runs                 recent runs; /runs/<id>/data for the numbers
+         GET  /runs                 recent runs; /runs/<id>/data for the numbers,
+                                    /runs/<id>/figure for the plotted view
 
       Every refusal comes back with a ``detail`` object of the form
       ``{"code": ..., "detail": ...}`` — a stable code for software to

--- a/docs/source/how-to/bluesky/run-first-scan.rst
+++ b/docs/source/how-to/bluesky/run-first-scan.rst
@@ -78,9 +78,30 @@ Step 5: Watch the results
 =========================
 
 Stay on the **BLUESKY** tab. The lower half follows the selected run: a table
-gains one row per grid position, and a live chart traces each monitor's
-readings. A 5 × 5 grid settles fast on the Virtual Accelerator — all 25
-points should land within a few seconds.
+gains one row per grid position, and beside it the run's **figure** fills in —
+one plot per panel, with real axis labels and units. A 5 × 5 grid settles fast
+on the Virtual Accelerator — all 25 points should land within a few seconds.
+
+What you are watching is ``grid_scan``'s own view of the scan. A two-axis grid
+draws one **heatmap per monitor** — the fast axis across, the slow axis up, one
+cell per grid position — and a cell the scan has not reached yet is left empty
+rather than filled with a zero. Sweep a single axis instead and the same plan
+draws lines: one panel per monitor, against that axis. The ``orm`` plan brings
+its own view too: a trace per corrector while the sweep runs, then the fitted
+response matrix and per-device scores.
+
+A short note above the plots says where the data came from and whether it is
+still arriving — *live data · still filling in* while the scan runs. A run you
+come back to later, read from durable storage, shows *stored data* instead.
+
+A plan does not have to bring a view. For one that does not, the panel draws
+the **default view** instead: every numeric column the run recorded, plotted
+against the scan's own axis, with the note line adding a few words about why
+you are seeing it. None of that is an error — the default view is real data,
+and for many measurements it is exactly the right picture.
+
+Ask the agent *"how does that scan look?"* and it reads the same figure you
+have on screen, so you are both describing one picture rather than two.
 
 If you need to stop
 ===================
@@ -130,7 +151,7 @@ token, no switch can disable them:
       someone stopped earlier (remove it first — see :doc:`queue`), or the
       queue server is still starting up (wait a moment and try again).
 
-   **The chart shows "N points so far" instead of a percentage.**
+   **Progress reads "N points so far" instead of a percentage.**
       That is honesty, not a glitch: not every plan can predict its total
       point count, so the panel counts what has arrived rather than invent a
       percentage.

--- a/docs/source/how-to/bluesky/write-plans.rst
+++ b/docs/source/how-to/bluesky/write-plans.rst
@@ -77,6 +77,10 @@ Two ways to add a plan
    - **The plan function** — builds the actual Bluesky plan from the
      parameters and the resolved devices.
 
+   Plus an optional fourth: **the view** — a ``render`` function that turns
+   the run's rows into the plan's own plots. See *Give a plan its own view*
+   below.
+
    The agent's ``writing-bluesky-plans`` skill carries the full, current
    template — the fastest way to see one is to ask the agent to write a
    minimal plan and read the result.
@@ -109,6 +113,65 @@ Two ways to add a plan
    is why a session plan that outlived a restart asks to be validated once
    more. Facility-tier plans carry no fingerprint bookkeeping — their trust
    comes from being installed by you.
+
+Give a plan its own view
+========================
+
+Every run gets a figure in the BLUESKY panel, and by default it is drawn for
+you: every numeric column the run recorded, plotted against the scan's own
+axis. That **default view** is honest and, for a straightforward measurement,
+enough.
+
+A plan that measures something the raw columns cannot show can bring its own
+view instead — a small ``render`` function that receives the run's rows and its
+parameters and returns the plots the plan itself designs. The shipped ``orm``
+plan does exactly that: a trace per corrector while the sweep runs, then the
+fitted response matrix and per-device scores once there is enough data.
+
+The vocabulary is small on purpose. A figure is a list of **panels**; each
+panel has a title, axis labels and units, any notes worth printing beside it,
+and exactly one **mark**:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 82
+
+   * - Mark
+     - What it draws
+   * - **Lines**
+     - Named series of x/y points — a sweep, a trend, one line per monitor. A
+       reading the run never took stays a gap in the line, never a zero.
+   * - **Bars**
+     - One value per named category — a score or a total per device.
+   * - **Heatmap**
+     - A labelled 2-D grid — for example BPMs against correctors, each cell a
+       fitted slope.
+
+Three rules keep a view honest, and the framework enforces all three:
+
+- **Drawing never disturbs a scan.** A view is computed from data already
+  recorded, after the fact. If it fails, the run and its numbers are untouched
+  and the panel simply shows the default view with a note saying why.
+- **Views name no facility.** Labels come from the plan's parameters and the
+  columns the run recorded, so the same plan draws correct device names at any
+  facility that installs it.
+- **Only installed plans draw their own view.** A plan's ``render`` runs inside
+  the bridge every time a panel refreshes, so it is honored for plans shipped
+  with OSPREY, with a preset, or installed by your facility — not for session
+  plans the agent writes mid-conversation. A session plan queues, runs and
+  records data exactly as any other; its runs just show the default view. A
+  view is one more reason for a plan that earns its keep to graduate into your
+  facility's library.
+
+.. note::
+
+   **Views apply going forward.** A figure is computed by the plan code that
+   owns the plan's name *now*, so adding a ``render`` — or fixing one — shows
+   up on the next run with nothing to migrate. The exception is old data: a run
+   recorded before OSPREY kept track of which plan produced it has nothing to
+   tie it back to plan code, so it keeps showing the default view whatever you
+   add later. Its numbers are all still there; only the plan's own view is out
+   of reach.
 
 .. seealso::
 

--- a/docs/source/how-to/web-terminal/panels.rst
+++ b/docs/source/how-to/web-terminal/panels.rst
@@ -67,7 +67,7 @@ reorder/remove controls, plus the runs that have finished. Picking any run
 opens it under Results. :doc:`/how-to/bluesky/queue` covers what those controls
 do.
 
-**Results** shows the selected run's record, table and live chart.
+**Results** shows the selected run's record, table and live figure.
 
 .. note::
 

--- a/src/osprey/bluesky_tool_names.py
+++ b/src/osprey/bluesky_tool_names.py
@@ -27,6 +27,7 @@ LIST_PLANS = "list_plans"
 LIST_DEVICES = "list_devices"
 LIST_RUNS = "list_runs"
 GET_RUN_DATA = "get_run_data"
+GET_RUN_FIGURE = "get_run_figure"
 
 # --- Draft tools ----------------------------------------------------------
 # Edit the shared plan draft only; touch no hardware (registry
@@ -70,6 +71,7 @@ READ_TOOLS: tuple[str, ...] = (
     LIST_DEVICES,
     LIST_RUNS,
     GET_RUN_DATA,
+    GET_RUN_FIGURE,
 )
 DRAFT_TOOLS: tuple[str, ...] = (
     GET_DRAFT,

--- a/src/osprey/interfaces/bluesky_panels/panels/bluesky/figure-renderer.js
+++ b/src/osprey/interfaces/bluesky_panels/panels/bluesky/figure-renderer.js
@@ -1,0 +1,984 @@
+// @ts-check
+/**
+ * BLUESKY panel — the figure renderer.
+ *
+ * Draws a bridge `Figure` (see `services/bluesky_bridge/figure.py`) as themed
+ * inline SVG. The module is split in two halves:
+ *
+ *  - **Layout** — pure functions (`plotBox`, `linearScale`, `axisTicks`,
+ *    `splitSegments`, `heatmapCells`, `barGeometry`, …). No DOM, no theme, no
+ *    globals; given plain figure objects they return numbers and strings, and
+ *    they are what the unit tests exercise directly.
+ *  - **Drawing** — `renderFigure(elements, figure)`, which turns that geometry
+ *    into nodes. Every node is built with `createElement`/`createElementNS` and
+ *    every string lands via `textContent` or `setAttribute`; nothing in this
+ *    file assigns `innerHTML`.
+ *
+ * Colors are read from the theme-manager computed-style bridges *inside*
+ * `renderFigure`, never at module or closure scope, so a caller that re-renders
+ * from `subscribe()` gets the new theme's colors. Nothing here caches a
+ * resolved token value.
+ *
+ * Honesty rules the drawing obeys, because the figure spec is built around
+ * them:
+ *  - A `null` y is a **gap** — a sample the run took without a reading. The
+ *    line breaks there; it is never interpolated across and never quietly
+ *    dropped (the panel annotates how many gaps it drew).
+ *  - A decimated mark annotates how many of its source points are shown, so a
+ *    thinned trace never passes for the full record.
+ *  - Labels, units and annotations are rendered from the figure's own fields.
+ *    This file invents no axis text.
+ */
+
+import { chartSeries, chartTheme } from '/design-system/js/theme-manager.js';
+
+/** @typedef {{x: number, y: number|null}} FigurePoint */
+/** @typedef {{label: string, points: FigurePoint[], decimated: boolean, source_points: number}} FigureSeries */
+/** @typedef {{kind: 'lines', series: FigureSeries[], decimated: boolean, source_points: number}} LinesMark */
+/** @typedef {{kind: 'heatmap', x_labels: string[], y_labels: string[], values: Array<Array<number|null>>, value_label: string, value_units: string|null, decimated: boolean, source_points: number}} HeatmapMark */
+/** @typedef {{kind: 'bars', label: string, categories: string[], values: Array<number|null>, decimated: boolean, source_points: number}} BarsMark */
+/** @typedef {LinesMark|HeatmapMark|BarsMark} FigureMark */
+/** @typedef {{title: string, x_label: string, y_label: string, x_units: string|null, y_units: string|null, annotations: string[], mark: FigureMark}} FigurePanel */
+/** @typedef {{panels: FigurePanel[], partial: boolean, source: 'live'|'tiled', reason: string|null}} Figure */
+
+/** @typedef {{left: number, top: number, width: number, height: number, right: number, bottom: number}} PlotBox */
+/** @typedef {(value: number) => number} Scale */
+/** @typedef {{pos: number, label: string}} AxisTick */
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+export const FIGURE_WIDTH = 640;
+export const FIGURE_HEIGHT = 240;
+
+/** Room for the y tick labels on the left and the x tick labels + title below. */
+export const FIGURE_MARGIN = Object.freeze({ top: 14, right: 18, bottom: 44, left: 60 });
+
+/** Most category labels drawn on one axis before `labelStride` starts thinning. */
+const MAX_AXIS_LABELS = 12;
+
+// ---------------------------------------------------------------------------
+// Layout — pure, DOM-free
+// ---------------------------------------------------------------------------
+
+/**
+ * The inner plot rectangle, in the figure's own viewBox units.
+ *
+ * @param {number} [width]
+ * @param {number} [height]
+ * @param {{top: number, right: number, bottom: number, left: number}} [margin]
+ * @returns {PlotBox}
+ */
+export function plotBox(width = FIGURE_WIDTH, height = FIGURE_HEIGHT, margin = FIGURE_MARGIN) {
+  const innerWidth = Math.max(1, width - margin.left - margin.right);
+  const innerHeight = Math.max(1, height - margin.top - margin.bottom);
+  return {
+    left: margin.left,
+    top: margin.top,
+    width: innerWidth,
+    height: innerHeight,
+    right: margin.left + innerWidth,
+    bottom: margin.top + innerHeight,
+  };
+}
+
+/**
+ * A linear domain -> range mapping.
+ *
+ * A degenerate domain (a flat series, a single sample) maps everything to the
+ * middle of the range rather than to an edge or a NaN — a constant reading is
+ * drawn as a level line through the middle of the plot, which is what it is.
+ *
+ * @param {number} domainMin
+ * @param {number} domainMax
+ * @param {number} rangeMin
+ * @param {number} rangeMax
+ * @returns {Scale}
+ */
+export function linearScale(domainMin, domainMax, rangeMin, rangeMax) {
+  const span = domainMax - domainMin;
+  if (!Number.isFinite(span) || span === 0) {
+    const middle = (rangeMin + rangeMax) / 2;
+    return () => middle;
+  }
+  return (value) => rangeMin + ((value - domainMin) / span) * (rangeMax - rangeMin);
+}
+
+/**
+ * Widen a domain so the extreme samples are not drawn on the frame.
+ *
+ * A flat domain is widened symmetrically — by 5% of the value, or by 0.5 when
+ * the value is zero and there is no scale to take a fraction of.
+ *
+ * @param {number} min
+ * @param {number} max
+ * @param {number} [fraction]
+ * @returns {[number, number]}
+ */
+export function padRange(min, max, fraction = 0.05) {
+  if (min === max) {
+    const pad = Math.abs(min) * fraction || 0.5;
+    return [min - pad, max + pad];
+  }
+  const pad = (max - min) * fraction;
+  return [min - pad, max + pad];
+}
+
+/**
+ * The drawable extent of a lines mark's series, or `null` when there is
+ * nothing to plot.
+ *
+ * Gap points count toward the **x** extent and not the y extent: the run
+ * sampled that x, it just has no reading there, so the axis still covers it.
+ * `null` comes back when no series holds a single finite y — an all-gap panel
+ * has no y domain to invent, and the caller says so in words instead.
+ *
+ * @param {FigureSeries[]} series
+ * @returns {{xMin: number, xMax: number, yMin: number, yMax: number}|null}
+ */
+export function seriesExtent(series) {
+  let xMin = Infinity;
+  let xMax = -Infinity;
+  let yMin = Infinity;
+  let yMax = -Infinity;
+  for (const line of series) {
+    for (const point of line.points) {
+      if (!Number.isFinite(point.x)) continue;
+      if (point.x < xMin) xMin = point.x;
+      if (point.x > xMax) xMax = point.x;
+      const y = point.y;
+      if (y === null || y === undefined || !Number.isFinite(y)) continue;
+      if (y < yMin) yMin = y;
+      if (y > yMax) yMax = y;
+    }
+  }
+  if (yMin === Infinity || xMin === Infinity) return null;
+  return { xMin, xMax, yMin, yMax };
+}
+
+/**
+ * Split a series' points into gap-free runs.
+ *
+ * Every `null` (or non-finite) y ends the run in progress; the next reading
+ * starts a new one. Drawing one polyline per run is what makes a dropout a
+ * visible break instead of a straight line across data the run never took.
+ *
+ * @param {FigurePoint[]} points
+ * @returns {FigurePoint[][]}
+ */
+export function splitSegments(points) {
+  /** @type {FigurePoint[][]} */
+  const segments = [];
+  /** @type {FigurePoint[]} */
+  let current = [];
+  for (const point of points) {
+    const y = point.y;
+    if (y === null || y === undefined || !Number.isFinite(y) || !Number.isFinite(point.x)) {
+      if (current.length > 0) segments.push(current);
+      current = [];
+      continue;
+    }
+    current.push(point);
+  }
+  if (current.length > 0) segments.push(current);
+  return segments;
+}
+
+/**
+ * How many samples in a lines mark have no reading.
+ *
+ * @param {FigureSeries[]} series
+ * @returns {number}
+ */
+export function gapCount(series) {
+  let gaps = 0;
+  for (const line of series) {
+    for (const point of line.points) {
+      const y = point.y;
+      if (y === null || y === undefined || !Number.isFinite(y)) gaps += 1;
+    }
+  }
+  return gaps;
+}
+
+/**
+ * An SVG `points` attribute for one gap-free run.
+ *
+ * @param {FigurePoint[]} segment
+ * @param {Scale} scaleX
+ * @param {Scale} scaleY
+ * @returns {string}
+ */
+export function polylinePoints(segment, scaleX, scaleY) {
+  return segment
+    .map((point) => `${scaleX(point.x).toFixed(1)},${scaleY(Number(point.y)).toFixed(1)}`)
+    .join(' ');
+}
+
+/**
+ * A tick value formatted for an axis label. Wide-magnitude values go to
+ * exponential rather than to a run of zeros or a long decimal tail.
+ *
+ * @param {number|null} value
+ * @returns {string}
+ */
+export function formatTickValue(value) {
+  if (value === null || value === undefined || !Number.isFinite(value)) return '—';
+  if (value === 0) return '0';
+  const magnitude = Math.abs(value);
+  if (magnitude >= 1e5 || magnitude < 1e-3) return value.toExponential(1);
+  return String(Number(value.toPrecision(4)));
+}
+
+/**
+ * Evenly spaced ticks across a numeric domain, positioned in range units.
+ *
+ * @param {number} domainMin
+ * @param {number} domainMax
+ * @param {Scale} scale Maps a domain value to its coordinate.
+ * @param {number} [count]
+ * @returns {AxisTick[]}
+ */
+export function axisTicks(domainMin, domainMax, scale, count = 5) {
+  const steps = Math.max(1, count - 1);
+  if (domainMin === domainMax) {
+    return [{ pos: scale(domainMin), label: formatTickValue(domainMin) }];
+  }
+  /** @type {AxisTick[]} */
+  const ticks = [];
+  for (let index = 0; index <= steps; index++) {
+    const value = domainMin + ((domainMax - domainMin) * index) / steps;
+    ticks.push({ pos: scale(value), label: formatTickValue(value) });
+  }
+  return ticks;
+}
+
+/**
+ * Draw every n-th category label so a long axis stays readable. Always at
+ * least 1, so a caller can index with it unconditionally.
+ *
+ * @param {number} count
+ * @param {number} [max]
+ * @returns {number}
+ */
+export function labelStride(count, max = MAX_AXIS_LABELS) {
+  if (count <= max) return 1;
+  return Math.ceil(count / max);
+}
+
+/**
+ * Category tick positions at the center of each slot.
+ *
+ * @param {string[]} labels
+ * @param {number} start Coordinate of the first slot's leading edge.
+ * @param {number} extent Total length covered by all slots.
+ * @returns {AxisTick[]}
+ */
+export function categoryTicks(labels, start, extent) {
+  const count = labels.length;
+  if (count === 0) return [];
+  const slot = extent / count;
+  const stride = labelStride(count);
+  /** @type {AxisTick[]} */
+  const ticks = [];
+  for (let index = 0; index < count; index += stride) {
+    ticks.push({ pos: start + slot * (index + 0.5), label: labels[index] });
+  }
+  return ticks;
+}
+
+/**
+ * The grid shape of a heatmap. `values` is row-major (`values[j][i]` is
+ * `y_labels[j]` x `x_labels[i]`), and the labels are the authority on the
+ * shape — but a mark that ships values without labels still gets drawn.
+ *
+ * @param {HeatmapMark} mark
+ * @returns {{rows: number, cols: number}}
+ */
+export function heatmapShape(mark) {
+  const rows = Math.max(mark.y_labels.length, mark.values.length);
+  let cols = mark.x_labels.length;
+  for (const row of mark.values) cols = Math.max(cols, row.length);
+  return { rows, cols };
+}
+
+/**
+ * The value extent of a heatmap, ignoring cells with no reading. `null` when
+ * no cell holds one.
+ *
+ * @param {Array<Array<number|null>>} values
+ * @returns {{min: number, max: number}|null}
+ */
+export function heatmapExtent(values) {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const row of values) {
+    for (const value of row) {
+      if (value === null || value === undefined || !Number.isFinite(value)) continue;
+      if (value < min) min = value;
+      if (value > max) max = value;
+    }
+  }
+  if (min === Infinity) return null;
+  return { min, max };
+}
+
+/**
+ * One rectangle per heatmap cell, row 0 at the top so the drawn grid reads in
+ * the same order as `values` and `y_labels`. Cells with no reading are
+ * returned with `value: null` — the caller leaves them unpainted rather than
+ * coloring them as if a measurement existed.
+ *
+ * @param {HeatmapMark} mark
+ * @param {PlotBox} box
+ * @returns {Array<{x: number, y: number, width: number, height: number, value: number|null, row: number, col: number}>}
+ */
+export function heatmapCells(mark, box) {
+  const { rows, cols } = heatmapShape(mark);
+  if (rows === 0 || cols === 0) return [];
+  const cellWidth = box.width / cols;
+  const cellHeight = box.height / rows;
+  /** @type {Array<{x: number, y: number, width: number, height: number, value: number|null, row: number, col: number}>} */
+  const cells = [];
+  for (let row = 0; row < rows; row++) {
+    const values = mark.values[row] || [];
+    for (let col = 0; col < cols; col++) {
+      const raw = values[col];
+      const value = raw === null || raw === undefined || !Number.isFinite(raw) ? null : raw;
+      cells.push({
+        x: box.left + col * cellWidth,
+        y: box.top + row * cellHeight,
+        width: cellWidth,
+        height: cellHeight,
+        value,
+        row,
+        col,
+      });
+    }
+  }
+  return cells;
+}
+
+/**
+ * The y domain of a bars mark. Zero is always inside it, because a bar is read
+ * against a baseline — clipping the domain to the values would make a set of
+ * large, nearly equal values look like it starts from nothing.
+ *
+ * @param {Array<number|null>} values
+ * @returns {{min: number, max: number}}
+ */
+export function barDomain(values) {
+  let min = 0;
+  let max = 0;
+  for (const value of values) {
+    if (value === null || value === undefined || !Number.isFinite(value)) continue;
+    if (value < min) min = value;
+    if (value > max) max = value;
+  }
+  if (min === 0 && max === 0) return { min: 0, max: 1 };
+  return { min, max };
+}
+
+/**
+ * One rectangle per bar, measured from the zero baseline. A category with no
+ * value is returned with `value: null` and no height — the slot is kept (its
+ * label still belongs on the axis) but nothing is drawn in it.
+ *
+ * @param {BarsMark} mark
+ * @param {PlotBox} box
+ * @returns {Array<{x: number, y: number, width: number, height: number, value: number|null, category: string, index: number}>}
+ */
+export function barGeometry(mark, box) {
+  const count = Math.max(mark.values.length, mark.categories.length);
+  if (count === 0) return [];
+  const domain = barDomain(mark.values);
+  const scaleY = linearScale(domain.min, domain.max, box.bottom, box.top);
+  const baseline = scaleY(0);
+  const slot = box.width / count;
+  const width = slot * 0.7;
+  /** @type {Array<{x: number, y: number, width: number, height: number, value: number|null, category: string, index: number}>} */
+  const bars = [];
+  for (let index = 0; index < count; index++) {
+    const raw = mark.values[index];
+    const value = raw === null || raw === undefined || !Number.isFinite(raw) ? null : raw;
+    const x = box.left + slot * index + (slot - width) / 2;
+    const category = mark.categories[index] ?? '';
+    if (value === null) {
+      bars.push({ x, y: baseline, width, height: 0, value: null, category, index });
+      continue;
+    }
+    const top = scaleY(value);
+    bars.push({
+      x,
+      y: Math.min(top, baseline),
+      width,
+      height: Math.abs(baseline - top),
+      value,
+      category,
+      index,
+    });
+  }
+  return bars;
+}
+
+/**
+ * How many points a mark actually draws — the numerator of its decimation
+ * annotation.
+ *
+ * @param {FigureMark} mark
+ * @returns {number}
+ */
+export function shownPointCount(mark) {
+  if (mark.kind === 'lines') {
+    return mark.series.reduce((total, line) => total + line.points.length, 0);
+  }
+  if (mark.kind === 'bars') return mark.values.length;
+  const { rows, cols } = heatmapShape(mark);
+  return rows * cols;
+}
+
+/**
+ * Annotations a thinned mark owes the reader.
+ *
+ * The aggregate line always comes first. A multi-series lines mark also names
+ * each thinned series, since one busy detector can be decimated while its
+ * neighbours are shown whole; a single-series mark would only repeat its own
+ * numbers, so it does not.
+ *
+ * @param {FigureMark} mark
+ * @returns {string[]}
+ */
+export function decimationAnnotations(mark) {
+  /** @type {string[]} */
+  const notes = [];
+  if (mark.decimated) {
+    notes.push(`showing ${shownPointCount(mark)} of ${mark.source_points} points`);
+  }
+  if (mark.kind === 'lines' && mark.series.length > 1) {
+    for (const line of mark.series) {
+      if (!line.decimated) continue;
+      notes.push(`${line.label}: showing ${line.points.length} of ${line.source_points} points`);
+    }
+  }
+  return notes;
+}
+
+/**
+ * Annotations for the samples a mark could not draw. Only lines marks carry
+ * per-sample gaps; a heatmap's missing cells are visible as holes in the grid.
+ *
+ * @param {FigureMark} mark
+ * @returns {string[]}
+ */
+export function gapAnnotations(mark) {
+  if (mark.kind !== 'lines') return [];
+  const gaps = gapCount(mark.series);
+  if (gaps === 0) return [];
+  return [`${gaps} sample${gaps === 1 ? '' : 's'} had no reading (drawn as gaps)`];
+}
+
+/**
+ * Every line of text under a panel: the plan's own annotations first, then
+ * what the rendering itself has to disclose.
+ *
+ * @param {FigurePanel} panel
+ * @returns {string[]}
+ */
+export function panelAnnotations(panel) {
+  return [
+    ...panel.annotations,
+    ...decimationAnnotations(panel.mark),
+    ...gapAnnotations(panel.mark),
+  ];
+}
+
+/**
+ * An axis title from a label and its units, either of which may be absent.
+ *
+ * @param {string} label
+ * @param {string|null} units
+ * @returns {string}
+ */
+export function axisTitle(label, units) {
+  if (!label) return units || '';
+  return units ? `${label} (${units})` : label;
+}
+
+/**
+ * The figure-level note: where the data came from, whether it is still
+ * arriving, and why it is the figure it is. Reason codes are the bridge's
+ * (deliberately open) vocabulary, so they are spaced out rather than mapped —
+ * an unforeseen reason still reads as words.
+ *
+ * @param {Figure} figure
+ * @returns {string}
+ */
+export function figureNoteText(figure) {
+  const parts = [figure.source === 'tiled' ? 'stored data' : 'live data'];
+  if (figure.partial) parts.push('still filling in');
+  if (figure.reason) parts.push(figure.reason.replace(/_/g, ' '));
+  return parts.join(' · ');
+}
+
+/**
+ * Pick a categorical color, wrapping around a palette of any length.
+ *
+ * @param {string[]} palette
+ * @param {number} index
+ * @param {string} fallback
+ * @returns {string}
+ */
+export function seriesColor(palette, index, fallback) {
+  if (palette.length === 0) return fallback;
+  return palette[index % palette.length] || fallback;
+}
+
+// ---------------------------------------------------------------------------
+// Drawing
+// ---------------------------------------------------------------------------
+
+/** @typedef {{text: string, grid: string, plotBg: string, palette: string[]}} RenderColors */
+/** @typedef {{label: string, color: string}} LegendEntry */
+/** @typedef {{plotted: boolean, legend: LegendEntry[]}} MarkResult */
+
+/**
+ * @param {string} name
+ * @param {Record<string, string|number>} attributes
+ * @returns {SVGElement}
+ */
+function svgNode(name, attributes) {
+  const node = document.createElementNS(SVG_NS, name);
+  for (const [key, value] of Object.entries(attributes)) node.setAttribute(key, String(value));
+  return node;
+}
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @param {string} text
+ * @param {Record<string, string|number>} attributes
+ * @returns {SVGElement}
+ */
+function svgText(x, y, text, attributes) {
+  const node = svgNode('text', { x, y, ...attributes });
+  node.textContent = text;
+  return node;
+}
+
+/**
+ * Horizontal gridlines with their y-axis labels, and the x-axis labels below
+ * the plot. Vertical gridlines are deliberately absent — a category axis has
+ * no continuum to rule, and the horizontal rules are what a reader traces a
+ * value along.
+ *
+ * @param {SVGElement} svg
+ * @param {PlotBox} box
+ * @param {{x: AxisTick[], y: AxisTick[], grid?: boolean}} ticks
+ * @param {RenderColors} colors
+ */
+function drawAxes(svg, box, ticks, colors) {
+  const drawGrid = ticks.grid !== false;
+  for (const tick of ticks.y) {
+    if (drawGrid) {
+      svg.appendChild(
+        svgNode('line', {
+          x1: box.left,
+          x2: box.right,
+          y1: tick.pos.toFixed(1),
+          y2: tick.pos.toFixed(1),
+          stroke: colors.grid,
+          'stroke-width': 1,
+          opacity: 0.5,
+        })
+      );
+    }
+    svg.appendChild(
+      svgText(box.left - 8, tick.pos + 4, tick.label, {
+        class: 'figure-tick',
+        'text-anchor': 'end',
+        fill: colors.text,
+        'font-size': 10,
+      })
+    );
+  }
+  for (const tick of ticks.x) {
+    svg.appendChild(
+      svgText(tick.pos, box.bottom + 16, tick.label, {
+        class: 'figure-tick',
+        'text-anchor': 'middle',
+        fill: colors.text,
+        'font-size': 10,
+      })
+    );
+  }
+  svg.appendChild(
+    svgNode('line', {
+      x1: box.left,
+      x2: box.right,
+      y1: box.bottom,
+      y2: box.bottom,
+      stroke: colors.grid,
+      'stroke-width': 1,
+    })
+  );
+  svg.appendChild(
+    svgNode('line', {
+      x1: box.left,
+      x2: box.left,
+      y1: box.top,
+      y2: box.bottom,
+      stroke: colors.grid,
+      'stroke-width': 1,
+    })
+  );
+}
+
+/**
+ * @param {SVGElement} svg
+ * @param {PlotBox} box
+ * @param {string} xTitle
+ * @param {string} yTitle
+ * @param {RenderColors} colors
+ */
+function drawAxisTitles(svg, box, xTitle, yTitle, colors) {
+  if (xTitle) {
+    svg.appendChild(
+      svgText(box.left + box.width / 2, FIGURE_HEIGHT - 8, xTitle, {
+        class: 'figure-axis-title',
+        'text-anchor': 'middle',
+        fill: colors.text,
+        'font-size': 11,
+      })
+    );
+  }
+  if (yTitle) {
+    const x = 12;
+    const y = box.top + box.height / 2;
+    svg.appendChild(
+      svgText(x, y, yTitle, {
+        class: 'figure-axis-title',
+        'text-anchor': 'middle',
+        fill: colors.text,
+        'font-size': 11,
+        transform: `rotate(-90 ${x} ${y})`,
+      })
+    );
+  }
+}
+
+/**
+ * @param {SVGElement} svg
+ * @param {LinesMark} mark
+ * @param {FigurePanel} panel
+ * @param {PlotBox} box
+ * @param {RenderColors} colors
+ * @returns {MarkResult}
+ */
+function drawLines(svg, mark, panel, box, colors) {
+  const extent = seriesExtent(mark.series);
+  if (extent === null) return { plotted: false, legend: [] };
+
+  const [xMin, xMax] = padRange(extent.xMin, extent.xMax, 0);
+  const [yMin, yMax] = padRange(extent.yMin, extent.yMax);
+  const scaleX = linearScale(xMin, xMax, box.left, box.right);
+  const scaleY = linearScale(yMin, yMax, box.bottom, box.top);
+
+  drawAxes(svg, box, { x: axisTicks(xMin, xMax, scaleX), y: axisTicks(yMin, yMax, scaleY) }, colors);
+  drawAxisTitles(
+    svg,
+    box,
+    axisTitle(panel.x_label, panel.x_units),
+    axisTitle(panel.y_label, panel.y_units),
+    colors
+  );
+
+  /** @type {LegendEntry[]} */
+  const legend = [];
+  mark.series.forEach((line, index) => {
+    const color = seriesColor(colors.palette, index, colors.text);
+    for (const segment of splitSegments(line.points)) {
+      if (segment.length === 1) {
+        svg.appendChild(
+          svgNode('circle', {
+            class: 'figure-point',
+            cx: scaleX(segment[0].x).toFixed(1),
+            cy: scaleY(Number(segment[0].y)).toFixed(1),
+            r: 2,
+            fill: color,
+          })
+        );
+        continue;
+      }
+      svg.appendChild(
+        svgNode('polyline', {
+          class: 'figure-line',
+          points: polylinePoints(segment, scaleX, scaleY),
+          fill: 'none',
+          stroke: color,
+          'stroke-width': 2,
+          'stroke-linejoin': 'round',
+          'stroke-linecap': 'round',
+        })
+      );
+    }
+    legend.push({ label: line.label, color });
+  });
+  return { plotted: true, legend };
+}
+
+/**
+ * A heatmap is painted in one series color at varying opacity rather than by
+ * interpolating between two token colors: the tokens are arbitrary CSS color
+ * strings, and a ramp built by parsing them would break on the first theme
+ * that ships a color space this file does not know how to take apart.
+ *
+ * @param {SVGElement} svg
+ * @param {HeatmapMark} mark
+ * @param {FigurePanel} panel
+ * @param {PlotBox} box
+ * @param {RenderColors} colors
+ * @returns {MarkResult}
+ */
+function drawHeatmap(svg, mark, panel, box, colors) {
+  const extent = heatmapExtent(mark.values);
+  if (extent === null) return { plotted: false, legend: [] };
+
+  const color = seriesColor(colors.palette, 0, colors.text);
+  const toOpacity = linearScale(extent.min, extent.max, 0.12, 1);
+  for (const cell of heatmapCells(mark, box)) {
+    if (cell.value === null) continue;
+    const rect = svgNode('rect', {
+      class: 'figure-cell',
+      x: cell.x.toFixed(1),
+      y: cell.y.toFixed(1),
+      width: Math.max(0, cell.width).toFixed(1),
+      height: Math.max(0, cell.height).toFixed(1),
+      fill: color,
+      'fill-opacity': toOpacity(cell.value).toFixed(3),
+    });
+    const hover = svgNode('title', {});
+    hover.textContent = formatTickValue(cell.value);
+    rect.appendChild(hover);
+    svg.appendChild(rect);
+  }
+
+  const { rows, cols } = heatmapShape(mark);
+  drawAxes(
+    svg,
+    box,
+    {
+      x: categoryTicks(mark.x_labels.slice(0, cols), box.left, box.width),
+      y: categoryTicks(mark.y_labels.slice(0, rows), box.top, box.height),
+      grid: false,
+    },
+    colors
+  );
+  drawAxisTitles(
+    svg,
+    box,
+    axisTitle(panel.x_label, panel.x_units),
+    axisTitle(panel.y_label, panel.y_units),
+    colors
+  );
+
+  const valueTitle = axisTitle(mark.value_label, mark.value_units);
+  const legend = valueTitle ? [{ label: valueTitle, color }] : [];
+  return { plotted: true, legend };
+}
+
+/**
+ * @param {SVGElement} svg
+ * @param {BarsMark} mark
+ * @param {FigurePanel} panel
+ * @param {PlotBox} box
+ * @param {RenderColors} colors
+ * @returns {MarkResult}
+ */
+function drawBars(svg, mark, panel, box, colors) {
+  const bars = barGeometry(mark, box);
+  if (bars.length === 0) return { plotted: false, legend: [] };
+
+  const domain = barDomain(mark.values);
+  const scaleY = linearScale(domain.min, domain.max, box.bottom, box.top);
+  drawAxes(
+    svg,
+    box,
+    {
+      x: categoryTicks(bars.map((bar) => bar.category), box.left, box.width),
+      y: axisTicks(domain.min, domain.max, scaleY),
+    },
+    colors
+  );
+  drawAxisTitles(
+    svg,
+    box,
+    axisTitle(panel.x_label, panel.x_units),
+    axisTitle(panel.y_label, panel.y_units),
+    colors
+  );
+
+  for (const bar of bars) {
+    if (bar.value === null) continue;
+    const color = seriesColor(colors.palette, bar.index, colors.text);
+    const rect = svgNode('rect', {
+      class: 'figure-bar',
+      x: bar.x.toFixed(1),
+      y: bar.y.toFixed(1),
+      width: bar.width.toFixed(1),
+      height: bar.height.toFixed(1),
+      fill: color,
+    });
+    const hover = svgNode('title', {});
+    hover.textContent = formatTickValue(bar.value);
+    rect.appendChild(hover);
+    svg.appendChild(rect);
+  }
+
+  const legend = mark.label ? [{ label: mark.label, color: seriesColor(colors.palette, 0, colors.text) }] : [];
+  return { plotted: true, legend };
+}
+
+/**
+ * @param {LegendEntry[]} entries
+ * @returns {HTMLElement}
+ */
+function legendList(entries) {
+  const list = document.createElement('ul');
+  list.className = 'figure-legend';
+  for (const entry of entries) {
+    const item = document.createElement('li');
+    const swatch = document.createElement('span');
+    swatch.className = 'swatch';
+    swatch.style.backgroundColor = entry.color;
+    const label = document.createElement('span');
+    label.textContent = entry.label;
+    item.append(swatch, label);
+    list.appendChild(item);
+  }
+  return list;
+}
+
+/**
+ * @param {string[]} notes
+ * @returns {HTMLElement}
+ */
+function annotationList(notes) {
+  const list = document.createElement('ul');
+  list.className = 'figure-annotations';
+  for (const note of notes) {
+    const item = document.createElement('li');
+    item.textContent = note;
+    list.appendChild(item);
+  }
+  return list;
+}
+
+/**
+ * @param {FigurePanel} panel
+ * @param {RenderColors} colors
+ * @returns {HTMLElement}
+ */
+function renderPanel(panel, colors) {
+  const section = document.createElement('section');
+  section.className = 'figure-panel';
+  section.dataset.mark = panel.mark.kind;
+
+  if (panel.title) {
+    const heading = document.createElement('h4');
+    heading.className = 'figure-panel-title';
+    heading.textContent = panel.title;
+    section.appendChild(heading);
+  }
+
+  const box = plotBox();
+  const svg = svgNode('svg', {
+    class: 'figure-plot',
+    viewBox: `0 0 ${FIGURE_WIDTH} ${FIGURE_HEIGHT}`,
+    preserveAspectRatio: 'xMidYMid meet',
+    role: 'img',
+    'aria-label': panel.title || panel.mark.kind,
+  });
+  svg.appendChild(
+    svgNode('rect', {
+      class: 'figure-bg',
+      x: 0,
+      y: 0,
+      width: FIGURE_WIDTH,
+      height: FIGURE_HEIGHT,
+      fill: colors.plotBg,
+    })
+  );
+
+  const mark = panel.mark;
+  let result;
+  if (mark.kind === 'lines') result = drawLines(svg, mark, panel, box, colors);
+  else if (mark.kind === 'heatmap') result = drawHeatmap(svg, mark, panel, box, colors);
+  else result = drawBars(svg, mark, panel, box, colors);
+
+  if (result.plotted) {
+    section.appendChild(svg);
+    if (result.legend.length > 0) section.appendChild(legendList(result.legend));
+  } else {
+    const empty = document.createElement('p');
+    empty.className = 'figure-empty';
+    empty.textContent = 'No plottable values in this panel yet.';
+    section.appendChild(empty);
+  }
+
+  // Annotations are appended whether or not anything was drawn: a panel with
+  // no readings still owes the reader its decimation and gap notes.
+  const notes = panelAnnotations(panel);
+  if (notes.length > 0) section.appendChild(annotationList(notes));
+  return section;
+}
+
+/** @typedef {{panels: HTMLElement, note?: HTMLElement|null}} FigureElements */
+
+/**
+ * Draw `figure` into the caller's containers.
+ *
+ * `elements.panels` is emptied and refilled with one `<section
+ * class="figure-panel">` per panel. `elements.note`, when given, receives the
+ * figure-level note (source, partial, reason) and is un-hidden; without it the
+ * note is written as the first child of `elements.panels` instead, so the
+ * provenance line is never silently dropped.
+ *
+ * Theme colors are read here, once per render, so a caller re-rendering from a
+ * theme change gets the new palette.
+ *
+ * @param {FigureElements} elements
+ * @param {Figure} figure
+ */
+export function renderFigure(elements, figure) {
+  const theme = chartTheme();
+  /** @type {RenderColors} */
+  const colors = {
+    text: theme.font.color || 'currentColor',
+    grid: theme.xaxis.gridcolor || theme.yaxis.gridcolor || 'currentColor',
+    plotBg: theme.plot_bgcolor || 'transparent',
+    palette: chartSeries(),
+  };
+
+  const root = elements.panels;
+  root.replaceChildren();
+
+  const noteText = figureNoteText(figure);
+  if (elements.note) {
+    elements.note.textContent = noteText;
+    elements.note.hidden = false;
+  } else {
+    const note = document.createElement('p');
+    note.className = 'figure-note';
+    note.textContent = noteText;
+    root.appendChild(note);
+  }
+
+  if (figure.panels.length === 0) {
+    const empty = document.createElement('p');
+    empty.className = 'figure-empty';
+    empty.textContent = 'No figure for this run.';
+    root.appendChild(empty);
+    return;
+  }
+
+  for (const panel of figure.panels) root.appendChild(renderPanel(panel, colors));
+}

--- a/src/osprey/interfaces/bluesky_panels/panels/bluesky/index.html
+++ b/src/osprey/interfaces/bluesky_panels/panels/bluesky/index.html
@@ -311,15 +311,9 @@
         </div>
       </div>
 
-      <div id="chart-card" hidden>
-        <p class="chart-caption">
-          Each numeric column, min&ndash;max normalized and plotted against row
-          order.
-        </p>
-        <div class="chart-scroll">
-          <svg id="results-chart" viewBox="0 0 640 220" preserveAspectRatio="none" role="img" aria-label="Scan data trace"></svg>
-        </div>
-        <ul id="chart-legend" class="chart-legend"></ul>
+      <div id="figure-card" hidden>
+        <p id="figure-note" class="figure-note" hidden></p>
+        <div id="figure-panels"></div>
       </div>
     </section>
   </div>

--- a/src/osprey/interfaces/bluesky_panels/panels/bluesky/panel.css
+++ b/src/osprey/interfaces/bluesky_panels/panels/bluesky/panel.css
@@ -7,8 +7,8 @@
  * single dot), a dominant detail pane, mono identifiers/values, hairline
  * separators, and a live mono "readout" next to the launch action. The queue
  * reads as a dense ordered list; the running item gets the one piece of chrome
- * that moves (its progress bar); the results view is the same table + trace
- * pair the panel has always shown.
+ * that moves (its progress bar); the results view pairs the raw table with the
+ * run's figure.
  *
  * Layout, outside in: the panel chrome, then the view switcher, then the
  * persistent status strip (queue state + the two halts — on screen for every
@@ -142,7 +142,7 @@ html:not([data-ui-mode="simple"]) body.embedded .panel-tabs { display: none; }
   flex-direction: column;
 }
 /* Queue and Results are scrolling documents held to a reading measure. The
-   width is what keeps `#results-table`/`#results-chart` (both `min-width:
+   width is what keeps `#results-table` and the figure plots (both `min-width:
    480px`) full-width rather than squeezed into a column. */
 .view-scroll {
   display: block;
@@ -1323,7 +1323,7 @@ button.queue-label:focus-visible {
   color: var(--text-muted);
 }
 
-/* ---- Results: meta, empty state, table, chart ---- */
+/* ---- Results: meta, empty state, table, figure ---- */
 
 .run-meta {
   margin: 0 0 10px;
@@ -1399,47 +1399,125 @@ button.queue-label:focus-visible {
   background: var(--neutral-tint-08);
 }
 
-.chart-caption {
-  margin: 12px 0 10px;
+/* ---- Results figure ----
+ *
+ * `figure-renderer.js` owns everything inside `#figure-panels`: one
+ * `<section class="figure-panel" data-mark="lines|heatmap|bars">` per panel,
+ * each holding a title, an inline `<svg class="figure-plot">` (or a
+ * `.figure-empty` line in its place), a legend and its annotations.
+ *
+ * The renderer sets every color as an SVG presentation attribute read from the
+ * live theme, and re-reads the theme on each render. So nothing here paints:
+ * these rules are layout and typography only, and both themes come out right
+ * because the colors never came from this file in the first place. */
+
+#figure-card {
+  margin-top: 14px;
+}
+
+/* The figure-level provenance line ("live data · still filling in"). Mono and
+   quiet, the same readout treatment as `.table-note` — deliberately unlike
+   `#run-note` above it, which is prose about the run RECORD in the display
+   font. The two can be on screen at once saying unrelated things, and the
+   typography is what keeps them from reading as one paragraph. */
+.figure-note {
+  margin: 0 0 10px;
+  font-family: var(--font-mono);
   font-size: 11px;
   color: var(--text-muted);
 }
 
-.chart-scroll {
+#figure-panels {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* Each panel scrolls its OWN plot: a wide heatmap must not drag the line plot
+   sideways with it, and the page body must never scroll horizontally — the
+   `overflow-x` is what stops a plot at its 480px floor from reaching the body.
+   Title, legend and annotations ride inside that scroll box; they wrap to the
+   visible width, so on a narrow host only the plot is actually pushed out. */
+.figure-panel {
   overflow-x: auto;
+  padding: 10px 12px 12px;
   border: 1px solid var(--border-default);
   border-radius: 6px;
   background: var(--chart-plot-bg);
 }
 
-#results-chart {
+.figure-panel-title {
+  margin: 0 0 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+/* Below ~480px of usable width the plot stops shrinking and the panel scrolls
+   instead — the same floor `#results-table` holds, and for the same reason:
+   axis labels squeezed past it are decoration, not a reading. The viewBox
+   carries the aspect ratio, so `height: auto` sizes the box. */
+.figure-plot {
   display: block;
   width: 100%;
   min-width: 480px;
-  height: 220px;
+  height: auto;
 }
 
-.chart-legend {
+/* Axis text: family only. Sizes and fills arrive as presentation attributes
+   from the renderer's theme read, and are left alone. */
+.figure-tick {
+  font-family: var(--font-mono);
+}
+.figure-axis-title {
+  font-family: var(--font-display);
+}
+
+.figure-legend {
   list-style: none;
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
-  margin: 12px 0 0;
+  margin: 10px 0 0;
   padding: 0;
   font-family: var(--font-mono);
   font-size: 11px;
   color: var(--text-secondary);
 }
-.chart-legend li {
+.figure-legend li {
   display: inline-flex;
   align-items: center;
   gap: 6px;
 }
-.chart-legend .swatch {
+.figure-legend .swatch {
   display: inline-block;
   width: 10px;
   height: 10px;
   border-radius: 2px;
+}
+
+/* What the plot could not show: decimation and gap counts. Quiet, but never
+   hidden — they are the plot's honesty, not its footnotes. */
+.figure-annotations {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.figure-annotations li + li {
+  margin-top: 2px;
+}
+
+/* Stands in for the plot when a panel has nothing plottable yet. Styled as an
+   ordinary quiet line, NOT as an error: a run still filling in, and a default
+   view that declined to render, are both normal states. */
+.figure-empty {
+  margin: 0;
+  padding: 20px 0;
+  text-align: center;
+  font-size: 12px;
+  color: var(--text-muted);
 }
 
 /* =========================================================================
@@ -1472,8 +1550,8 @@ button.queue-label:focus-visible {
  * and strips the expert scaffolding: the Source (raw code) tab, the
  * shared-draft binding chrome, the trust/provenance internals (sidebar status
  * dots, provenance folder headers, the detail status line), the connector-
- * arming footnote, the raw data table, the mono run-meta line, the per-item
- * parameter summaries, and the plot's technical caption. Validation still
+ * arming footnote, the raw data table, the mono run-meta line, and the
+ * per-item parameter summaries. Validation still
  * surfaces in plain language: the unvalidated-note, the launch-outcome banner,
  * the draft-rejected banner and the root error all stay visible, and the live
  * parameter readout is kept as friendly guidance. Add-to-queue is promoted to
@@ -1502,11 +1580,12 @@ html[data-ui-mode="simple"] .detail-foot .footnote {
   display: none;
 }
 
-/* Drop the queue/results internals. */
+/* Drop the queue/results internals. The figure is NOT among them: its titles,
+   axes and annotations are the plain-language answer to "what did the run do",
+   which is exactly what Simple keeps. */
 html[data-ui-mode="simple"] #run-meta,
 html[data-ui-mode="simple"] #table-card,
-html[data-ui-mode="simple"] .queue-params,
-html[data-ui-mode="simple"] .chart-caption {
+html[data-ui-mode="simple"] .queue-params {
   display: none;
 }
 

--- a/src/osprey/interfaces/bluesky_panels/panels/bluesky/panel.js
+++ b/src/osprey/interfaces/bluesky_panels/panels/bluesky/panel.js
@@ -118,11 +118,9 @@ const resultsView = createResultsView({
     tableNote: byId('table-note'),
     tableHeadRow: /** @type {HTMLTableRowElement} */ (byId('table-head-row')),
     tableBody: /** @type {HTMLTableSectionElement} */ (byId('table-body')),
-    chartCard: byId('chart-card'),
-    chartSvg: /** @type {SVGSVGElement} */ (
-      /** @type {unknown} */ (document.getElementById('results-chart'))
-    ),
-    chartLegend: byId('chart-legend'),
+    figureCard: byId('figure-card'),
+    figurePanels: byId('figure-panels'),
+    figureNote: byId('figure-note'),
   },
   onPollingChange(polling) {
     if (polling === resultsPolling) return;

--- a/src/osprey/interfaces/bluesky_panels/panels/bluesky/results-view.js
+++ b/src/osprey/interfaces/bluesky_panels/panels/bluesky/results-view.js
@@ -2,29 +2,38 @@
 /**
  * BLUESKY panel — the Results view.
  *
- * Follows ONE run: polls `GET /runs/{id}` for its record and
- * `GET /runs/{id}/data` for a bounded rows/columns window, both through the
- * sidecar's read proxy, and renders a table plus an inline SVG trace. Read
- * only — nothing in this file issues a write verb.
+ * Follows ONE run through three reads per tick, all on the sidecar's read
+ * proxy: `GET /runs/{id}` for its record, `GET /runs/{id}/data` for a bounded
+ * rows/columns window, and `GET /runs/{id}/figure` for the plan's own view of
+ * itself. The first two feed the raw table; the third is handed to
+ * `figure-renderer.js` to draw. Read only — nothing in this file issues a
+ * write verb.
  *
- * Cadence: ~1 s while the run is non-terminal or its data still reports
- * `partial: true`; polling stops once the run is terminal and its data is
- * settled, so a finished run costs nothing.
+ * Cadence: ~1 s while the run is non-terminal or either the data or the figure
+ * still reports `partial: true`; polling stops once the run is terminal and
+ * both halves are settled, so a finished run costs nothing.
  *
  * Two shapes of "gone" are distinguished, because they mean opposite things:
  * `GET /runs/{id}` 404s once the manager has rotated the run out of its
- * history, while `GET /runs/{id}/data` keeps serving it from Tiled long
+ * history, while `/data` and `/figure` keep serving it from Tiled long
  * afterwards. A record 404 therefore does NOT clear the results — the data is
  * shown with a note, because the durable record is the one an operator came
  * for.
  *
- * Colors come from the theme-manager computed-style bridges, re-read inside a
- * `subscribe()` callback so the chart re-themes live rather than caching a
- * resolved token value.
+ * A figure that carries a `reason` is a DEFAULT view, not an error: the bridge
+ * could not run the plan's own `render()` and fell back to plotting the raw
+ * columns. It is drawn like any other, and the renderer's note line says why.
+ * A transient figure fetch failure keeps the last good figure on screen rather
+ * than blanking it, exactly as the table does with its last good rows.
+ *
+ * Colors live in the renderer, which re-reads the theme bridges on every call;
+ * this file re-renders the retained figure from a `subscribe()` callback so a
+ * settled run re-themes without waiting for a poll tick that will never come.
  */
 
-import { chartSeries, chartTheme, subscribe } from '/design-system/js/theme-manager.js';
+import { subscribe } from '/design-system/js/theme-manager.js';
 
+import { renderFigure } from './figure-renderer.js';
 import { describeProgress } from './queue-client.js';
 
 /** @typedef {{
@@ -46,16 +55,15 @@ import { describeProgress } from './queue-client.js';
  *   partial?: boolean,
  * }} RunData */
 
+/** The bridge's figure wire shape, owned by the renderer that draws it. */
+/** @typedef {import('./figure-renderer.js').Figure} Figure */
+
 /** @typedef {{ok: true, data: RunRecord} | {ok: false, notFound: boolean, message: string}} RecordFetch */
 /** @typedef {{ok: true, data: RunData} | {ok: false, notFound: boolean, notStarted: boolean, message: string}} DataFetch */
+/** @typedef {{ok: true, data: Figure} | {ok: false, notFound: boolean, message: string}} FigureFetch */
 
 const POLL_INTERVAL_MS = 1000;
 const TERMINAL_STATUSES = ['completed', 'stopped', 'error'];
-
-const CHART_WIDTH = 640;
-const CHART_HEIGHT = 220;
-const CHART_PADDING = 24;
-const SVG_NS = 'http://www.w3.org/2000/svg';
 
 /**
  * Badge tone for a run status. `pending`/`running` read as in-flight, a clean
@@ -106,30 +114,13 @@ export function formatCell(value) {
 }
 
 /**
- * Columns whose value is a finite number in every row of this window — the
- * only columns plotted. Non-numeric columns still appear in the table.
- *
- * @param {RunData} data
- * @returns {number[]}
- */
-export function numericColumnIndices(data) {
-  if (data.rows.length === 0) return [];
-  const indices = [];
-  for (let col = 0; col < data.columns.length; col++) {
-    const allNumeric = data.rows.every(
-      (row) => typeof row[col] === 'number' && Number.isFinite(row[col])
-    );
-    if (allNumeric) indices.push(col);
-  }
-  return indices;
-}
-
-/**
  * Whether following `run` should keep polling.
  *
  * Partial data outranks a terminal status: the run's stop document can land
  * before the last events are recorded, and stopping the poll there would
- * freeze the table one row short of the truth.
+ * freeze the table one row short of the truth. `partial` is the OR of what the
+ * two data-bearing reads report — either one still filling in is reason enough
+ * to look again.
  *
  * @param {string} status
  * @param {boolean} partial
@@ -148,10 +139,14 @@ export function shouldKeepPolling(status, partial) {
  *   tableNote: HTMLElement,
  *   tableHeadRow: HTMLTableRowElement,
  *   tableBody: HTMLTableSectionElement,
- *   chartCard: HTMLElement,
- *   chartSvg: SVGSVGElement,
- *   chartLegend: HTMLElement,
- * }} ResultsElements */
+ *   figureCard: HTMLElement,
+ *   figurePanels: HTMLElement,
+ *   figureNote: HTMLElement,
+ * }} ResultsElements `figurePanels` is handed straight to the renderer, which
+ *   empties and refills it; nothing else in this file writes to it.
+ *   `figureNote` takes the renderer's provenance line (source, partial,
+ *   reason) — it is a separate element from `note`, which carries this view's
+ *   own message about the run RECORD. */
 
 /**
  * @param {{
@@ -166,8 +161,14 @@ export function shouldKeepPolling(status, partial) {
  * @returns {{follow: (runId: string|null) => void, currentRunId: () => string|null, destroy: () => void}}
  */
 export function createResultsView({ api, elements, onPollingChange }) {
-  /** @type {{runId: string|null, timer: ReturnType<typeof setTimeout>|null, lastData: RunData|null}} */
-  const state = { runId: null, timer: null, lastData: null };
+  /** @type {{
+   *   runId: string|null,
+   *   timer: ReturnType<typeof setTimeout>|null,
+   *   lastFigure: Figure|null,
+   * }} `lastFigure` is the last figure that had something to draw. It is what a
+   *   theme change re-renders from, and what a transient figure fetch failure
+   *   leaves on screen. */
+  const state = { runId: null, timer: null, lastFigure: null };
 
   /**
    * Announce a change in whether the view is polling. Derived from the timer
@@ -213,7 +214,22 @@ export function createResultsView({ api, elements, onPollingChange }) {
     show(elements.note);
   }
 
+  // All three reads below check the SHAPE of a 200 before reporting success,
+  // and treat an unrecognizable body as a transient failure.
+  //
+  // This is not defensive habit, it is what keeps the panel alive: the three
+  // reads share one tick, so anything that throws between the `await` and
+  // `scheduleNextPoll` abandons the tick without rescheduling it. Because
+  // `state.timer` is never rewritten, the view then stops polling for good AND
+  // leaves the Results tab's activity marker stuck on, with nothing on screen
+  // to say so. And an unparseable 200 is not hypothetical: the read proxy's
+  // `safe_json` relays a null body on a 200, so any of these can arrive as
+  // 200 + `null`.
+
   /**
+   * The run's record. `status` is the field the whole tick turns on, so a body
+   * without one is not a record.
+   *
    * @param {string} runId
    * @returns {Promise<RecordFetch>}
    */
@@ -224,13 +240,21 @@ export function createResultsView({ api, elements, onPollingChange }) {
       if (!response.ok) {
         return { ok: false, notFound: false, message: `record HTTP ${response.status}` };
       }
-      return { ok: true, data: /** @type {RunRecord} */ (await response.json()) };
+      const body = await response.json();
+      if (!body || typeof body.status !== 'string') {
+        return { ok: false, notFound: false, message: 'record response was not a run record' };
+      }
+      return { ok: true, data: /** @type {RunRecord} */ (body) };
     } catch {
       return { ok: false, notFound: false, message: 'network error' };
     }
   }
 
   /**
+   * A bounded window of the run's rows. `columns` and `rows` are both checked
+   * because `renderTable` walks both, so a body carrying one without the other
+   * would throw downstream.
+   *
    * @param {string} runId
    * @returns {Promise<DataFetch>}
    */
@@ -246,9 +270,50 @@ export function createResultsView({ api, elements, onPollingChange }) {
       if (!response.ok) {
         return { ok: false, notFound: false, notStarted: false, message: `data HTTP ${response.status}` };
       }
-      return { ok: true, data: /** @type {RunData} */ (await response.json()) };
+      const body = await response.json();
+      if (!body || !Array.isArray(body.columns) || !Array.isArray(body.rows)) {
+        return {
+          ok: false,
+          notFound: false,
+          notStarted: false,
+          message: 'data response was not a data window',
+        };
+      }
+      return { ok: true, data: /** @type {RunData} */ (body) };
     } catch {
       return { ok: false, notFound: false, notStarted: false, message: 'network error' };
+    }
+  }
+
+  /**
+   * The plan's own view of the run.
+   *
+   * There is no "not started" shape here: the bridge answers 200 for any run
+   * either its live buffer or Tiled knows, and 404 — byte-identical to
+   * `/data`'s — only for a run neither source has heard of. A 502 (the sidecar
+   * cannot reach the bridge at all) lands in the transient bucket alongside a
+   * network error, which is what keeps the last good figure on screen.
+   *
+   * A 200 carrying something that is not a figure is treated the same way, per
+   * the shape rule above.
+   *
+   * @param {string} runId
+   * @returns {Promise<FigureFetch>}
+   */
+  async function fetchFigure(runId) {
+    try {
+      const response = await fetch(api(`/runs/${encodeURIComponent(runId)}/figure`));
+      if (response.status === 404) return { ok: false, notFound: true, message: 'run not found' };
+      if (!response.ok) {
+        return { ok: false, notFound: false, message: `figure HTTP ${response.status}` };
+      }
+      const body = await response.json();
+      if (!body || !Array.isArray(body.panels)) {
+        return { ok: false, notFound: false, message: 'figure response was not a figure' };
+      }
+      return { ok: true, data: /** @type {Figure} */ (body) };
+    } catch {
+      return { ok: false, notFound: false, message: 'network error' };
     }
   }
 
@@ -280,7 +345,11 @@ export function createResultsView({ api, elements, onPollingChange }) {
     const runId = state.runId;
     if (!runId) return;
 
-    const [recordFetch, dataFetch] = await Promise.all([fetchRecord(runId), fetchData(runId)]);
+    const [recordFetch, dataFetch, figureFetch] = await Promise.all([
+      fetchRecord(runId),
+      fetchData(runId),
+      fetchFigure(runId),
+    ]);
     // The selection changed while these were in flight — drop the stale
     // response; the newer follow() already issued its own poll.
     if (state.runId !== runId) return;
@@ -303,38 +372,72 @@ export function createResultsView({ api, elements, onPollingChange }) {
       setNote(`Could not load the run record: ${recordFetch.message}`);
     }
 
-    let partial = false;
+    let dataPartial = false;
+    // Neither half of the run exists — the one case where there is nothing
+    // left to wait for. Decided here, acted on below, so the figure still gets
+    // its turn to clear itself before the poll shuts down.
+    let nothingLeft = false;
     if (dataFetch.ok) {
-      partial = dataFetch.data.partial === true;
+      dataPartial = dataFetch.data.partial === true;
       renderTable(dataFetch.data);
-      renderChart(dataFetch.data);
-      state.lastData = dataFetch.data;
       setEmptyState(dataFetch.data.columns.length === 0 ? 'No data columns yet.' : null);
     } else if (dataFetch.notStarted) {
       hide(elements.tableCard);
-      hide(elements.chartCard);
       setEmptyState('This run has not started — no data yet.');
     } else if (dataFetch.notFound && !recordFetch.ok) {
       hide(elements.tableCard);
-      hide(elements.chartCard);
       setEmptyState('No record and no data for this run.', true);
-      stopPolling();
-      return;
+      nothingLeft = true;
     } else if (dataFetch.notFound) {
       hide(elements.tableCard);
-      hide(elements.chartCard);
       setEmptyState('No data recorded for this run yet.');
     } else {
-      // Transient data error: keep the last good table/chart on screen rather
-      // than clearing it out from under the operator.
+      // Transient data error: keep the last good table on screen rather than
+      // clearing it out from under the operator.
       setEmptyState(null);
     }
 
+    let figurePartial = false;
+    if (figureFetch.ok) {
+      figurePartial = figureFetch.data.partial === true;
+      if (figureFetch.data.panels.length > 0) {
+        // Retained only once it has actually been drawn — a figure the
+        // renderer choked on is not a figure worth re-rendering on every
+        // theme change for the rest of the session.
+        if (drawFigure(figureFetch.data)) state.lastFigure = figureFetch.data;
+      } else if (state.lastFigure === null) {
+        // Nothing to draw and nothing drawn before. An empty figure means the
+        // run has no plottable columns yet, or the bridge could not read the
+        // store this tick (`source_unavailable`) — in both cases the empty
+        // state above is already telling the operator where things stand, so
+        // an empty card would only add noise.
+        hide(elements.figureCard);
+      }
+      // An empty figure NEVER replaces a good one: a Tiled read that failed
+      // this tick says nothing about the figure it served last tick.
+    } else if (figureFetch.notFound) {
+      state.lastFigure = null;
+      hide(elements.figureCard);
+    }
+    // Any other figure failure is transient (a 502 while the bridge restarts,
+    // a dropped connection): leave the retained figure exactly where it is.
+
+    if (nothingLeft) {
+      // Neither source has this run any more, so anything still on screen is a
+      // plot of a run that no longer exists. Clearing it is what keeps the
+      // "No record and no data" banner from sitting over a drawn figure and
+      // contradicting it.
+      state.lastFigure = null;
+      hide(elements.figureCard);
+      stopPolling();
+      return;
+    }
+
     // `shouldKeepPolling` is the whole decision. In particular a run the
-    // manager has rotated away (record 404) whose data still reports
+    // manager has rotated away (record 404) whose data or figure still reports
     // `partial: true` keeps polling — the durable store is still filling in,
     // and the record's absence says nothing about that.
-    if (shouldKeepPolling(status, partial)) scheduleNextPoll(POLL_INTERVAL_MS);
+    if (shouldKeepPolling(status, dataPartial || figurePartial)) scheduleNextPoll(POLL_INTERVAL_MS);
   }
 
   /** @param {RunRecord} run */
@@ -389,93 +492,42 @@ export function createResultsView({ api, elements, onPollingChange }) {
     else show(elements.tableCard);
   }
 
-  /** @param {RunData} data */
-  function renderChart(data) {
-    const columnIndices = numericColumnIndices(data);
-    if (columnIndices.length === 0) {
-      hide(elements.chartCard);
-      return;
-    }
-    show(elements.chartCard);
-    drawChart(data, columnIndices);
-  }
-
   /**
-   * @param {RunData} data
-   * @param {number[]} columnIndices
+   * Hand a figure to the renderer and reveal the card.
+   *
+   * The renderer owns everything below `figurePanels` — it empties and refills
+   * that element, writes the provenance line into `figureNote`, and re-reads
+   * the theme on every call. This function exists so the poll path and the
+   * theme path draw through exactly the same door.
+   *
+   * A throwing renderer is contained here for the same reason a bad body is
+   * contained in `fetchFigure`: this runs inside the shared poll tick, so an
+   * escaping error would abandon the tick before it could reschedule itself,
+   * freezing the record and table reads too and leaving the tab's activity
+   * marker stuck on. A 200 whose `panels` array is well-formed but whose
+   * contents are not is the case that gets here.
+   *
+   * @param {Figure} figure
+   * @returns {boolean} Whether the figure actually reached the screen.
    */
-  function drawChart(data, columnIndices) {
-    const theme = chartTheme();
-    const seriesColors = chartSeries();
-    const svg = elements.chartSvg;
-
-    svg.replaceChildren();
-    elements.chartLegend.replaceChildren();
-
-    const background = document.createElementNS(SVG_NS, 'rect');
-    background.setAttribute('x', '0');
-    background.setAttribute('y', '0');
-    background.setAttribute('width', String(CHART_WIDTH));
-    background.setAttribute('height', String(CHART_HEIGHT));
-    background.setAttribute('fill', theme.plot_bgcolor || 'transparent');
-    svg.appendChild(background);
-
-    const gridColor = theme.xaxis.gridcolor || theme.yaxis.gridcolor;
-    for (let i = 0; i <= 4; i++) {
-      const y = CHART_PADDING + (i / 4) * (CHART_HEIGHT - 2 * CHART_PADDING);
-      const line = document.createElementNS(SVG_NS, 'line');
-      line.setAttribute('x1', String(CHART_PADDING));
-      line.setAttribute('x2', String(CHART_WIDTH - CHART_PADDING));
-      line.setAttribute('y1', String(y));
-      line.setAttribute('y2', String(y));
-      line.setAttribute('stroke', gridColor || 'currentColor');
-      line.setAttribute('stroke-width', '1');
-      line.setAttribute('opacity', '0.5');
-      svg.appendChild(line);
+  function drawFigure(figure) {
+    try {
+      renderFigure({ panels: elements.figurePanels, note: elements.figureNote }, figure);
+    } catch (error) {
+      console.error('osprey bluesky results: the figure renderer threw', error);
+      return false;
     }
-
-    const xDenominator = Math.max(1, data.rows.length - 1);
-
-    columnIndices.forEach((col, seriesIndex) => {
-      const values = data.rows.map((row) => /** @type {number} */ (row[col]));
-      const min = Math.min(...values);
-      const max = Math.max(...values);
-      const span = max - min;
-
-      const points = values.map((value, rowIndex) => {
-        const x = CHART_PADDING + (rowIndex / xDenominator) * (CHART_WIDTH - 2 * CHART_PADDING);
-        const normalized = span === 0 ? 0.5 : (value - min) / span;
-        const y = CHART_PADDING + (1 - normalized) * (CHART_HEIGHT - 2 * CHART_PADDING);
-        return `${x.toFixed(1)},${y.toFixed(1)}`;
-      });
-
-      const color =
-        seriesColors[seriesIndex % (seriesColors.length || 1)] || theme.font.color || 'currentColor';
-
-      const polyline = document.createElementNS(SVG_NS, 'polyline');
-      polyline.setAttribute('points', points.join(' '));
-      polyline.setAttribute('fill', 'none');
-      polyline.setAttribute('stroke', color);
-      polyline.setAttribute('stroke-width', '2');
-      polyline.setAttribute('stroke-linejoin', 'round');
-      polyline.setAttribute('stroke-linecap', 'round');
-      svg.appendChild(polyline);
-
-      const legendItem = document.createElement('li');
-      const swatch = document.createElement('span');
-      swatch.className = 'swatch';
-      swatch.style.backgroundColor = color;
-      const label = document.createElement('span');
-      label.textContent = data.columns[col];
-      legendItem.append(swatch, label);
-      elements.chartLegend.appendChild(legendItem);
-    });
+    show(elements.figureCard);
+    return true;
   }
 
-  // Any token-derived chart color must be re-read from getComputedStyle on
-  // every theme change, not cached.
+  // A theme change must re-draw from the retained figure, because a settled
+  // run has stopped polling: without this, flipping to light mode would leave
+  // a finished scan drawn in the dark palette until the operator picked
+  // another run. The renderer re-reads the color tokens itself, so there is
+  // nothing to invalidate here beyond calling it again.
   const unsubscribe = subscribe(() => {
-    if (state.lastData) renderChart(state.lastData);
+    if (state.lastFigure) drawFigure(state.lastFigure);
   });
 
   return {
@@ -483,9 +535,9 @@ export function createResultsView({ api, elements, onPollingChange }) {
     follow(runId) {
       stopPolling();
       state.runId = runId;
-      state.lastData = null;
+      state.lastFigure = null;
       hide(elements.tableCard);
-      hide(elements.chartCard);
+      hide(elements.figureCard);
       hide(elements.statusBadge);
       hide(elements.meta);
       setNote(null);

--- a/src/osprey/interfaces/bluesky_panels/read_proxy.py
+++ b/src/osprey/interfaces/bluesky_panels/read_proxy.py
@@ -17,6 +17,7 @@ bridge-owned field. This mirrors the read side of the bridge contract at
 - ``GET /runs`` (``limit`` query param)
 - ``GET /runs/{run_id}``
 - ``GET /runs/{run_id}/data`` (``max_rows``/``offset``/``tail`` query params)
+- ``GET /runs/{run_id}/figure`` (no query params)
 
 Every path mirrors the bridge's own except the first: the sidecar serves its
 OWN ``GET /health`` (its container healthcheck, in
@@ -117,3 +118,16 @@ async def get_run(request: Request, run_id: str) -> JSONResponse:
 @router.get("/runs/{run_id}/data")
 async def get_run_data(request: Request, run_id: str) -> JSONResponse:
     return await _forward_get(request, f"/runs/{quote(run_id, safe='')}/data")
+
+
+@router.get("/runs/{run_id}/figure")
+async def get_run_figure(request: Request, run_id: str) -> JSONResponse:
+    """Relay the bridge's rendered figure for a run, body untouched.
+
+    The bridge answers 200 for any run it knows about -- a figure it could not
+    draw from the plan's own ``render`` still comes back as a figure carrying a
+    ``reason``, so a ``reason`` is a default view here, not an error. Only a run
+    neither the live buffer nor Tiled knows about 404s, with the same body
+    ``/data`` uses for an unknown run.
+    """
+    return await _forward_get(request, f"/runs/{quote(run_id, safe='')}/figure")

--- a/src/osprey/interfaces/web_terminal/static/js/chat-render.js
+++ b/src/osprey/interfaces/web_terminal/static/js/chat-render.js
@@ -229,6 +229,7 @@ export const TOOL_PHRASES = Object.freeze({
   clear_draft: 'clearing the scan draft',
   get_run: 'reading a scan run',
   get_run_data: 'reading scan data',
+  get_run_figure: 'reading a scan figure',
 
   // Phoebus displays.
   phoebus_open_panel: 'opening a Phoebus display',

--- a/src/osprey/mcp_server/bluesky/tools/read_tools.py
+++ b/src/osprey/mcp_server/bluesky/tools/read_tools.py
@@ -1,7 +1,7 @@
 """MCP tools: read/allow-listed Bluesky bridge operations.
 
 Each tool is a thin HTTP client of one endpoint of the facility-side Bluesky
-bridge. All five are safe to call without operator approval
+bridge. All six are safe to call without operator approval
 (``permissions_allow``) — none of them can start motion; ``queue_start`` is
 the sole path by which execution begins.
 
@@ -13,6 +13,7 @@ list_plans             GET  /plans
 list_devices               GET  /devices
 list_runs                   GET  /runs
 get_run_data               GET  /runs/{id}/data
+get_run_figure             GET  /runs/{id}/figure
 ==========================  =================================================
 
 The HTTP primitive (``_http_get_json``) and the
@@ -22,11 +23,19 @@ boundary and every tool renders identical error shapes. A
 connection-level failure there already raises the standard
 ``bluesky_bridge_unreachable`` error envelope, so the tools below only need to
 translate non-2xx bridge responses (404/409/etc.) into ``make_error`` calls.
+
+``get_run_figure`` is the one tool that does not relay its body verbatim: the
+route serves the panel's figure, whose heatmaps are unbounded by design (a
+facility-scale response matrix is a quarter of a megabyte of cells), so this
+module projects it into a fixed point budget first. That projection lives in
+the "Figure projection" section at the bottom of this file.
 """
 
 import json
+from collections.abc import Sequence
 
 import anyio
+from pydantic import ValidationError
 
 from osprey.mcp_server.bluesky.server import mcp
 from osprey.mcp_server.bluesky.server_context import (
@@ -35,6 +44,17 @@ from osprey.mcp_server.bluesky.server_context import (
     bridge_error_message,
 )
 from osprey.mcp_server.errors import make_error
+from osprey.services.bluesky_bridge.figure import (
+    DEFAULT_MAX_POINTS,
+    BarsMark,
+    Figure,
+    HeatmapMark,
+    LinesMark,
+    Panel,
+    Point,
+    Series,
+    decimate,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -215,3 +235,490 @@ async def get_run_data(
     if status != 200:
         return make_error("bluesky_bridge_error", bridge_error_message(body, status))
     return json.dumps(body)
+
+
+# ---------------------------------------------------------------------------
+# Tool 7: get run figure (point-bounded)
+# ---------------------------------------------------------------------------
+@mcp.tool()
+async def get_run_figure(run_id: str) -> str:
+    """Read a run's figure — the plan's own view of what it measured.
+
+    Point-bounded by design: this never returns an unbounded figure. The
+    budget is 2000 points for the WHOLE figure (not per series), so a 200k-row
+    run and a 20-row run come back the same size. Panels share that budget:
+    series split what is left of it evenly, a series needing less than its
+    share hands the difference back to the others, and each one is re-strided
+    keeping both endpoints, so the x range is never shortened. A stretch of
+    the series that contained a gap is represented BY that gap, so missing
+    data is never smoothed into a reading — but how many dropouts there were,
+    and how wide they ran, does not survive the stride. Grids larger than 40x40 come back as a summary
+    instead of cells (see ``"heatmap_summary"`` below). Backed by
+    ``GET /runs/{id}/figure``, which serves a live run as it goes and a
+    finished one from durable storage.
+
+    Args:
+        run_id: Run id returned by queue_add or list_runs.
+
+    Returns:
+        JSON ``{"partial", "source", "reason", "panels", "point_budget",
+        "points_returned"}``.
+
+        ``partial: true`` means the run was still producing rows when this was
+        drawn: read it again for more rather than describing the figure as
+        final. ``source`` is ``"live"`` (the bridge's in-process row buffer) or
+        ``"tiled"`` (durable storage) — which store answered, not how good the
+        data is. ``points_returned`` is what this projection actually spent of
+        ``point_budget``.
+
+        ``reason`` is null when the plan drew this figure itself. Any other
+        value means the bridge drew its DEFAULT VIEW instead — every numeric
+        column the run recorded, against the scan's own x axis. A default view
+        is real data honestly plotted, NOT an error and not an empty result:
+        narrate it as "the default view" and give the reason in plain terms.
+
+        - ``"no_render"``: this plan declares no view of its own, so the
+          default view IS its view. Never report this as a failure.
+        - ``"render_failed"``: the plan's own view raised and the default view
+          stands in. The data is fine; the plan's drawing code is not.
+        - ``"render_not_supported_for_session_plans"``: the plan came from the
+          session/unreviewed layer, whose drawing code is never run.
+        - ``"params_mismatch"``: the run's recorded parameters did not fit the
+          plan's schema, so its view could not be built.
+        - ``"plan_identity_unavailable"``: the run could not be tied back to a
+          known plan at all.
+        - ``"source_unavailable"``: reading the rows failed. ``panels`` is
+          empty — that means "could not read", never "the run recorded
+          nothing". Try again, and get_run_data as the second opinion.
+        - Anything else: still a default view. Report the reason verbatim
+          rather than guessing at it.
+
+        Each panel carries ``title``, ``x_label``/``y_label`` (plus optional
+        ``x_units``/``y_units``), ``annotations`` — sentences naming what the
+        panel does NOT show, always worth relaying — and one ``mark``:
+
+        - ``"lines"``: ``series``, each ``{label, points: [{x, y}, ...],
+          decimated, source_points}``. A ``y`` of null is a gap the run never
+          measured, never a zero. ``decimated: true`` means points were
+          dropped: say "N of ``source_points`` points shown", never "the run
+          took N points". Read the nulls as "there were gaps here", never as
+          how many readings were missed — on a thinned series one null can
+          stand for a whole run of dropouts, and it is placed where the
+          dropout was, not scaled to how long it lasted.
+        - ``"bars"``: ``categories`` and positionally aligned ``values``
+          (null = a missing bar), with the same ``decimated``/
+          ``source_points`` truth.
+        - ``"heatmap"``: ``x_labels``/``y_labels`` and row-major ``values``,
+          where ``values[j][i]`` is the cell at ``y_labels[j]`` /
+          ``x_labels[i]``. Only grids of 40x40 or smaller arrive this way.
+        - ``"heatmap_summary"``: this tool's stand-in for a grid too big to
+          return as cells. Carries ``rows``/``columns``/``cells``/
+          ``empty_cells``; ``x_labels``/``y_labels`` as ``{count, first,
+          last}`` objects — the axis vocabulary and its ends, NOT the label
+          lists a ``"heatmap"`` mark carries; the ``min`` and ``max``
+          cell, and ``largest_magnitude`` — up to five cells with the biggest
+          absolute value, each ``{value, x_label, y_label}``. Those are the
+          strongest readings, NOT an outlier test: do not call them anomalies,
+          and never state a cell value that is not in the summary, because the
+          other cells were not returned. Ask for get_run_data if a specific
+          cell matters.
+
+    Refusals:
+        - unknown_run: neither the bridge's live buffer nor durable storage
+          knows this run id. A run get_run no longer lists can still have a
+          figure, so a 404 from get_run is never a reason to skip this.
+    """
+    status, body = await anyio.to_thread.run_sync(_http_get_json, f"/runs/{run_id}/figure")
+    if status == 404:
+        return make_error("unknown_run", bridge_error_message(body, status), UNKNOWN_RUN_HINTS)
+    if status != 200:
+        return make_error("bluesky_bridge_error", bridge_error_message(body, status))
+    try:
+        # ValidationError subclasses ValueError, as does decimate()'s rejection
+        # of a mark claiming to have grown under decimation. Either way the
+        # bridge sent a figure this projection cannot bound, and relaying it
+        # unprojected is the one thing this tool promises never to do.
+        projected = _project_figure(Figure.model_validate(body))
+    except ValueError as exc:
+        return make_error(
+            "bluesky_bridge_error",
+            f"The bridge returned a figure in a shape this tool cannot read: "
+            f"{_unreadable_figure_reason(exc)}",
+            [
+                "The bridge may be running a different OSPREY version than this agent.",
+                "get_run_data still serves this run's rows as a table.",
+            ],
+        )
+    return json.dumps(projected)
+
+
+# ---------------------------------------------------------------------------
+# Figure projection
+#
+# The panel and the agent read the same figure, but not at the same cost. The
+# route bounds each line series to 2000 points and leaves heatmaps whole —
+# right for a canvas, where a 100x70 response matrix is 7000 colored cells and
+# 248 KB of JSON the browser streams once. Reading that into an agent's
+# context buys almost nothing: it cannot see the picture, and the numbers it
+# would need are a handful of extremes, not seven thousand cells.
+#
+# So the projection spends ONE budget across the whole figure:
+#
+#   1. Heatmaps claim their cells first, in panel order. A grid bigger than
+#      40x40 in either direction is summarized instead (dimensions, extremes,
+#      largest cells) and costs nothing; a grid that fits the limit but not
+#      the budget left at its turn is summarized for that reason instead. A
+#      heatmap is never partly returned — a grid with holes strided into it
+#      reads as missing measurements rather than as omitted cells.
+#   2. Whatever is left is divided evenly among the strideable units: every
+#      line series, plus each bars mark (its values ride through `decimate` as
+#      index-valued points, the route's own technique). A unit needing less
+#      than its share keeps everything and returns the difference to the pool.
+#   3. Units are re-strided through `figure.decimate` with their prior truth
+#      passed back in, so an already-thinned series stays honest about the
+#      count it started from rather than reporting this pass alone.
+#
+# Thinning is reported by each mark's ``decimated``/``source_points`` flags;
+# structural loss — a summarized grid, an omitted series — is reported as a
+# panel annotation, in sentences, because nothing in the shape would otherwise
+# say it happened.
+# ---------------------------------------------------------------------------
+
+FIGURE_POINT_BUDGET = DEFAULT_MAX_POINTS
+"""Points the projection spends across the whole figure, all panels together."""
+
+HEATMAP_MAX_DIM = 40
+"""Largest grid returned as cells. Beyond this, in either direction, a
+heatmap is summarized: 40x40 is already 1600 cells, most of the budget."""
+
+HEATMAP_TOP_CELLS = 5
+"""How many largest-magnitude cells a heatmap summary names."""
+
+_MAX_REASON_CHARS = 400
+"""How much of an unrecognized figure's complaint the refusal quotes."""
+
+
+def _unreadable_figure_reason(exc: ValueError) -> str:
+    """Say why a figure could not be read, in a bounded number of characters.
+
+    The refusal message is the last place a bound could leak: pydantic reports
+    a validation failure once per offending node, so ONE extra field on
+    `Point` in a 12x2000-point figure is 24000 errors and megabytes of text —
+    handed to the agent as an error, which is the payload this tool exists to
+    prevent. Only the count and the first few locations tell an operator
+    anything anyway. A plain `ValueError` (`decimate` rejecting a mark that
+    claims to have grown) is one short sentence and passes through whole.
+    """
+    if isinstance(exc, ValidationError):
+        reported = exc.errors()
+        first = "; ".join(
+            f"{'.'.join(str(part) for part in item['loc'])}: {item['msg']}" for item in reported[:3]
+        )
+        counted = f"{len(reported)} validation error{'' if len(reported) == 1 else 's'}"
+        text = f"{counted}; first: {first}"
+    else:
+        text = str(exc)
+    if len(text) <= _MAX_REASON_CHARS:
+        return text
+    return f"{text[:_MAX_REASON_CHARS]}... (truncated)"
+
+
+def _heatmap_dims(mark: HeatmapMark) -> tuple[int, int, int]:
+    """Return ``(rows, columns, cells)`` for a possibly ragged grid.
+
+    ``columns`` is the widest row (the dimension check errs toward
+    summarizing), while ``cells`` counts what is actually there (the budget
+    charge errs toward spending less).
+    """
+    rows = len(mark.values)
+    columns = max((len(row) for row in mark.values), default=0)
+    cells = sum(len(row) for row in mark.values)
+    return rows, columns, cells
+
+
+def _label_at(labels: Sequence[str], index: int) -> str | None:
+    """The label for ``index``, or ``None`` when the axis has none.
+
+    Labels and values are separate lists on the wire, so a grid can carry more
+    cells than names. An unnamed cell says so rather than borrowing a
+    neighbour's name.
+    """
+    return labels[index] if 0 <= index < len(labels) else None
+
+
+def _axis_summary(labels: Sequence[str]) -> dict:
+    """The vocabulary of one heatmap axis: how many names, and its ends."""
+    return {
+        "count": len(labels),
+        "first": labels[0] if labels else None,
+        "last": labels[-1] if labels else None,
+    }
+
+
+def _summarize_heatmap(mark: HeatmapMark, note: str) -> tuple[dict, str]:
+    """Project a heatmap to a fixed-size summary, with the annotation for it.
+
+    The summary answers what an agent can actually use from a grid it cannot
+    see: how big it is, how much of it was never measured, where the extremes
+    sit, and which cells read largest. It is explicitly lossy, so it carries
+    ``decimated: true`` and the cell count it came from, like every other
+    mark in the spec.
+    """
+    rows, columns, cells = _heatmap_dims(mark)
+    measured = [
+        (value, j, i)
+        for j, row in enumerate(mark.values)
+        for i, value in enumerate(row)
+        if value is not None
+    ]
+
+    def _cell(entry: tuple[float, int, int]) -> dict:
+        value, j, i = entry
+        return {
+            "value": value,
+            "x_label": _label_at(mark.x_labels, i),
+            "y_label": _label_at(mark.y_labels, j),
+        }
+
+    largest = sorted(measured, key=lambda entry: (-abs(entry[0]), entry[1], entry[2]))
+    summary = {
+        "kind": "heatmap_summary",
+        "rows": rows,
+        "columns": columns,
+        "cells": cells,
+        "empty_cells": cells - len(measured),
+        "value_label": mark.value_label,
+        "value_units": mark.value_units,
+        "x_labels": _axis_summary(mark.x_labels),
+        "y_labels": _axis_summary(mark.y_labels),
+        "min": _cell(min(measured, key=lambda entry: (entry[0], entry[1], entry[2])))
+        if measured
+        else None,
+        "max": _cell(max(measured, key=lambda entry: (entry[0], -entry[1], -entry[2])))
+        if measured
+        else None,
+        "largest_magnitude": [_cell(entry) for entry in largest[:HEATMAP_TOP_CELLS]],
+        "decimated": True,
+        "source_points": mark.source_points,
+    }
+    return summary, note
+
+
+def _allocate(needs: Sequence[int], budget: int) -> list[int]:
+    """Split ``budget`` across units of the given sizes, evenly and by need.
+
+    Every unit gets the same share, except that a unit needing less than its
+    share takes only what it needs and the remainder is re-divided among the
+    rest — the whole budget reaches the series that can use it instead of
+    being reserved for a five-point series that will never spend it.
+
+    When the budget is smaller than the number of units, an even split would
+    give everyone nothing. Those units instead get one point each in figure
+    order for as far as the budget reaches, and the units past that get zero:
+    omitted, and annotated where they were.
+    """
+    grants = [0] * len(needs)
+    pool = budget
+    order = sorted(range(len(needs)), key=lambda index: (needs[index], index))
+    starved: list[int] = []
+    for position, index in enumerate(order):
+        share = pool // (len(order) - position)
+        if share < 1:
+            starved = order[position:]
+            break
+        grants[index] = min(needs[index], share)
+        pool -= grants[index]
+    # A unit with nothing to show must not spend one of the last points: it
+    # would cost a series that has data its only place in the figure.
+    for index in [index for index in sorted(starved) if needs[index] > 0][:pool]:
+        grants[index] = 1
+    return grants
+
+
+def _restride_series(series: Series, budget: int) -> Series:
+    """Re-stride one series to ``budget`` points, keeping its prior truth.
+
+    The route may already have thinned this series; ``source_points`` and
+    ``decimated`` are passed back in so the result reports what the run
+    actually took, not what this pass was handed.
+    """
+    return Series(
+        label=series.label,
+        **decimate(
+            series.points,
+            budget,
+            source_points=series.source_points,
+            decimated=series.decimated,
+        )._asdict(),
+    )
+
+
+def _restride_bars(mark: BarsMark, budget: int) -> BarsMark:
+    """Re-stride a bars mark to ``budget`` bars, keeping category alignment.
+
+    Values ride through `decimate` as index-valued points (the route's own
+    technique), and the surviving indices select the category/value pairs, so
+    the endpoints and any missing bar survive the same way they do on a line.
+    """
+    indexed = [Point(x=float(index), y=value) for index, value in enumerate(mark.values)]
+    thinned = decimate(indexed, budget, source_points=mark.source_points, decimated=mark.decimated)
+    kept = [int(point.x) for point in thinned.points]
+    return BarsMark(
+        label=mark.label,
+        categories=[_label_at(mark.categories, index) or "" for index in kept],
+        values=[mark.values[index] for index in kept],
+        decimated=thinned.decimated,
+        source_points=thinned.source_points,
+    )
+
+
+def _project_figure(figure: Figure) -> dict:
+    """Project ``figure`` into the whole-figure point budget. See section note."""
+    budget = FIGURE_POINT_BUDGET
+    # Panel-order pass 1: heatmaps take their cells or become summaries, and
+    # every other panel records what it would like to spend.
+    marks: list[dict | None] = []
+    notes: list[list[str]] = []
+    # One entry per strideable unit, in panel order — the order pass 2 walks
+    # them again to spend its grant.
+    needs: list[int] = []
+    for panel in figure.panels:
+        mark = panel.mark
+        panel_notes: list[str] = []
+        if isinstance(mark, HeatmapMark):
+            rows, columns, cells = _heatmap_dims(mark)
+            if rows > HEATMAP_MAX_DIM or columns > HEATMAP_MAX_DIM:
+                summary, note = _summarize_heatmap(
+                    mark,
+                    f"This grid is {rows}x{columns}, larger than the {HEATMAP_MAX_DIM}x"
+                    f"{HEATMAP_MAX_DIM} this tool returns cell by cell, so only its size, "
+                    "extremes and largest cells are shown here.",
+                )
+            elif cells > budget:
+                summary, note = _summarize_heatmap(
+                    mark,
+                    f"This grid's {cells} cells do not fit what is left of the figure's "
+                    "point budget, so only its size, extremes and largest cells are "
+                    "shown here.",
+                )
+            else:
+                budget -= cells
+                marks.append(mark.model_dump())
+                notes.append(panel_notes)
+                continue
+            marks.append(summary)
+            notes.append([note])
+            continue
+        marks.append(None)
+        notes.append(panel_notes)
+        if isinstance(mark, LinesMark):
+            needs.extend(len(series.points) for series in mark.series)
+        elif isinstance(mark, BarsMark):
+            needs.append(len(mark.values))
+
+    # Pass 2: divide what the heatmaps left over, then re-stride.
+    grants = _allocate(needs, budget)
+    granted = iter(grants)
+    for panel_index, panel in enumerate(figure.panels):
+        if marks[panel_index] is not None:
+            continue
+        mark = panel.mark
+        if isinstance(mark, LinesMark):
+            kept: list[Series] = []
+            omitted = 0
+            for series in mark.series:
+                budget_for_series = next(granted)
+                if budget_for_series < 1 and series.points:
+                    omitted += 1
+                    continue
+                # A series with no points costs nothing and is kept: a run that
+                # has not produced rows yet has an empty series, and dropping
+                # it would read as "this detector was left out".
+                kept.append(_restride_series(series, max(budget_for_series, 1)))
+            if omitted:
+                notes[panel_index].append(
+                    f"{omitted} of {len(mark.series)} series are not shown: the figure's "
+                    "point budget did not reach them."
+                )
+            # Floored at the incoming mark's own aggregates: a projection may
+            # RAISE the loss a figure reports, never lower it. A plan is free
+            # to set mark-level truth its series do not individually carry
+            # (rows it dropped before building them), and recomputing from the
+            # series alone would quietly erase that.
+            marks[panel_index] = LinesMark(
+                series=kept,
+                decimated=mark.decimated
+                or bool(omitted)
+                or any(series.decimated for series in kept),
+                source_points=max(
+                    mark.source_points,
+                    sum(series.source_points for series in mark.series),
+                ),
+            ).model_dump()
+        elif isinstance(mark, BarsMark):
+            budget_for_bars = next(granted)
+            if budget_for_bars < 1 and mark.values:
+                notes[panel_index].append(
+                    f"None of this panel's {len(mark.values)} bars are shown: the "
+                    "figure's point budget did not reach them."
+                )
+                marks[panel_index] = BarsMark(
+                    label=mark.label,
+                    decimated=True,
+                    source_points=mark.source_points,
+                ).model_dump()
+            else:
+                marks[panel_index] = _restride_bars(mark, max(budget_for_bars, 1)).model_dump()
+        else:
+            # Unreachable today: `Mark` is a closed union, so a kind with no
+            # rule here would have failed validation before reaching this.
+            # It exists so that relaxing validation can never open a hole in
+            # the bound — an unbudgetable mark is withheld, never relayed,
+            # because its size is by definition unknown.
+            marks[panel_index] = {"kind": mark.kind, "omitted": True}
+            notes[panel_index].append(
+                "This panel's contents are not shown: it carries a kind of mark this tool "
+                "has no way to bound, and returning it whole could exceed the figure's "
+                "point budget."
+            )
+
+    return {
+        "partial": figure.partial,
+        "source": figure.source,
+        "reason": figure.reason,
+        "panels": [
+            _panel_dict(panel, mark, note)
+            for panel, mark, note in zip(figure.panels, marks, notes, strict=True)
+        ],
+        "point_budget": FIGURE_POINT_BUDGET,
+        "points_returned": sum(_points_in(mark) for mark in marks if mark is not None),
+    }
+
+
+def _panel_dict(panel: Panel, mark: dict | None, extra_notes: list[str]) -> dict:
+    """One projected panel: the plan's own framing, plus what was left out."""
+    return {
+        "title": panel.title,
+        "x_label": panel.x_label,
+        "y_label": panel.y_label,
+        "x_units": panel.x_units,
+        "y_units": panel.y_units,
+        "annotations": [*panel.annotations, *extra_notes],
+        "mark": mark,
+    }
+
+
+def _points_in(mark: dict) -> int:
+    """How many values a projected mark actually returned.
+
+    A summarized heatmap counts zero: its handful of named cells are a
+    description of the grid, not the grid.
+    """
+    kind = mark.get("kind")
+    if kind == "lines":
+        return sum(len(series.get("points", [])) for series in mark.get("series", []))
+    if kind == "bars":
+        return len(mark.get("values", []))
+    if kind == "heatmap":
+        return sum(len(row) for row in mark.get("values", []))
+    return 0

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -321,6 +321,7 @@ FRAMEWORK_SERVERS: dict[str, ServerDefinition] = {
             bsky.LIST_DEVICES,
             bsky.LIST_RUNS,
             bsky.GET_RUN_DATA,
+            bsky.GET_RUN_FIGURE,
             # Draft tools never touch hardware — editing the shared
             # plan draft only stages what a future queue_add or in-panel
             # Add-to-queue click might queue, so like the read tools above they need no approval

--- a/src/osprey/services/bluesky_bridge/app.py
+++ b/src/osprey/services/bluesky_bridge/app.py
@@ -27,18 +27,37 @@ import logging
 import os
 import re
 from contextlib import asynccontextmanager, suppress
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 from fastapi import FastAPI, HTTPException, Query
+from pydantic import ValidationError
 
-from . import document_plane, draft, live_rows, queue, runs
+from . import document_plane, draft, figure_cache, live_rows, queue, runs
+from .figure import (
+    DEFAULT_MAX_POINTS,
+    REASON_NO_RENDER,
+    REASON_PARAMS_MISMATCH,
+    REASON_PLAN_IDENTITY_UNAVAILABLE,
+    REASON_RENDER_FAILED,
+    REASON_RENDER_NOT_SUPPORTED_FOR_SESSION_PLANS,
+    REASON_SOURCE_UNAVAILABLE,
+    BarsMark,
+    Figure,
+    LinesMark,
+    Point,
+    RowWindow,
+    Series,
+    decimate,
+    default_figure,
+    rows_from_columnar,
+)
 from .models import (
     PlanSessionWriteRequest,
     PlanValidateRequest,
 )
 from .plan_types import Provenance
 from .plan_validation import hash_plan_body, validate_plan
-from .queue_backend import QueueBackendError
+from .queue_backend import PLAN_META_KEY, QueueBackendError
 from .session_dir import resolve_session_plan_dir
 from .session_upload import get_session_uploader, upload_after_validation
 from .validation import _assert_limits_readable_if_writable
@@ -772,6 +791,67 @@ def _window(
     }
 
 
+def _tiled_client() -> Any | None:
+    """A client for the configured Tiled catalog, or ``None`` when unconfigured.
+
+    ``BLUESKY_TILED_API_KEY`` is read with ``.get``, never a bare subscript: a
+    token-less catalog is a working configuration (`from_uri` accepts
+    ``api_key=None``), not a ``KeyError`` on the first read that needs it.
+
+    `tiled` is imported here, never at module level, so `app.py` stays
+    import-clean of it (`_BRIDGE_ONLY_MODULES`) even when Tiled *is* configured
+    for this deploy.
+    """
+    uri = os.environ.get(_TILED_URI_ENV)
+    if not uri:
+        logger.info(
+            "tiled read: %s is unset; Tiled is not configured for this deploy", _TILED_URI_ENV
+        )
+        return None
+
+    from tiled.client import from_uri
+
+    return from_uri(uri, api_key=os.environ.get(_TILED_API_KEY_ENV))
+
+
+def _newest_run_node(client: Any, run_id: str) -> Any | None:
+    """The catalog node for *run_id* — the newest ``start.time`` when several match.
+
+    A re-run of an interrupted item records a second start document under the
+    same OSPREY run id, so the search can legitimately return several nodes;
+    ``matches[0]`` would leave the choice to whatever order the server answers
+    in. The newest start is the run the id currently means — the same "latest
+    occupant wins" rule the live buffer applies by overwriting on start.
+
+    The start doc `TiledWriter.start` records lives under ``metadata["start"]``
+    on the run container — a bare ``Key("osprey_run_id")`` matches nothing.
+    """
+    from tiled.queries import Key
+
+    matches = list(client.search(Key("start.osprey_run_id") == run_id).values())
+    if not matches:
+        return None
+
+    def _start_time(node: Any) -> float:
+        time = dict(node.metadata).get("start", {}).get("time")
+        return time if isinstance(time, int | float) else float("-inf")
+
+    return max(matches, key=_start_time)
+
+
+def _data_columns(table: Any) -> list[str]:
+    """The stored table's data columns, projected onto the live buffer's set.
+
+    Tiled's stored rows carry ``seq_num``, ``time``, and per-signal ``ts_*``
+    timestamp columns the live buffer never had (see `LiveRowRecorder`). Both
+    Tiled readers — `_from_tiled` for the data route, `_figure_source_from_tiled`
+    for the figure route — project them away HERE, so "a run replayed from
+    Tiled has the identical column set it had live" is one rule in one place
+    rather than two filters that happen to agree.
+    """
+    return [c for c in table.columns if c != "seq_num" and c != "time" and not c.startswith("ts_")]
+
+
 def _from_tiled(
     run_id: str, max_rows: int, offset: int | None, tail: bool
 ) -> dict[str, Any] | None:
@@ -791,23 +871,12 @@ def _from_tiled(
     `tiled` is imported here, never at module level, so `app.py` stays import-clean of it
     (`_BRIDGE_ONLY_MODULES`) even when Tiled *is* configured for this deploy.
     """
-    uri = os.environ.get(_TILED_URI_ENV)
-    if not uri:
-        logger.info(
-            "_from_tiled: %s is unset; Tiled is not configured for this deploy", _TILED_URI_ENV
-        )
+    client = _tiled_client()
+    if client is None:
         return None
-
-    from tiled.client import from_uri
-    from tiled.queries import Key
-
-    client = from_uri(uri, api_key=os.environ[_TILED_API_KEY_ENV])
-    # The start doc `TiledWriter.start` records lives under `metadata["start"]`
-    # on the run container — a bare `Key("osprey_run_id")` matches nothing.
-    matches = list(client.search(Key("start.osprey_run_id") == run_id).values())
-    if not matches:
+    run_node = _newest_run_node(client, run_id)
+    if run_node is None:
         return None
-    run_node = matches[0]
 
     run_uid = dict(run_node.metadata).get("start", {}).get("uid")
 
@@ -829,12 +898,7 @@ def _from_tiled(
         # `.base` container.
         internal_table = run_node["primary"].base["internal"]
         table = internal_table.read()
-        # Tiled's stored rows carry `seq_num`, `time`, and per-signal `ts_*`
-        # timestamp columns the live buffer never had (see `LiveRowRecorder`)
-        # — project those away so both sources return the identical column set.
-        columns = [
-            c for c in table.columns if c != "seq_num" and c != "time" and not c.startswith("ts_")
-        ]
+        columns = _data_columns(table)
         rows = table[columns].values.tolist()
         total_seen = len(table)
 
@@ -899,3 +963,339 @@ def get_run_data(
         return tiled_result
 
     raise HTTPException(status_code=404, detail=f"unknown run {run_id!r}")
+
+
+# ---------------------------------------------------------------------------
+# Run figures
+# ---------------------------------------------------------------------------
+
+
+class _CachedFigure(NamedTuple):
+    """What the settled-figure cache stores: the served figure plus check data.
+
+    `figure_cache` stores values opaquely, so the route wraps what it needs
+    beside the figure: ``total_seen`` lets the live branch re-validate a hit
+    against the buffer snapshot it already holds (a recycled run id whose
+    eviction has not landed yet shows up as a row-count mismatch — a free
+    check, costing no extra source read), and ``run_uid`` is carried on Tiled
+    entries for logging only.
+    """
+
+    figure: Figure
+    total_seen: int
+    run_uid: str | None
+
+
+def _figure_source_from_tiled(run_id: str) -> dict[str, Any] | None:
+    """Read a run's FULL stored table from Tiled for the figure route.
+
+    Unlike `_from_tiled`, which windows rows for `get_run_data`, this returns
+    every stored row: a figure is computed over the whole run (a windowed ORM
+    fit is silently wrong), sorted by ``seq_num`` so rows are in emission order
+    however the catalog returns them, then projected onto the live-buffer
+    column set exactly as the data path is.
+
+    The figure route also needs the run's story, not just its rows: the plan
+    stamp the enqueue path recorded onto the start document, and whether the
+    run has settled — decided by the stop document's presence, the same signal
+    ``partial`` means everywhere, never the run record.
+
+    Returns ``None`` when Tiled is unconfigured or no run matches; the caller
+    turns either into `get_run_data`'s exact 404.
+    """
+    client = _tiled_client()
+    if client is None:
+        return None
+    run_node = _newest_run_node(client, run_id)
+    if run_node is None:
+        return None
+
+    metadata = dict(run_node.metadata)
+    start = metadata.get("start") or {}
+
+    if "primary" not in run_node:
+        # Start doc landed but no Event ever arrived — a real, empty run. See
+        # `_from_tiled` for why this is a membership check on `"primary"` and
+        # never a broad `try`/`except KeyError` around the traversal.
+        columns: list[str] = []
+        rows: list[Any] = []
+        total_seen = 0
+    else:
+        table = run_node["primary"].base["internal"].read()
+        if "seq_num" in table.columns:
+            table = table.sort_values("seq_num", kind="stable")
+        columns = _data_columns(table)
+        rows = table[columns].values.tolist()
+        total_seen = len(table)
+
+    return {
+        "columns": columns,
+        "rows": rows,
+        "total_seen": total_seen,
+        "partial": metadata.get("stop") is None,
+        "plan": start.get(PLAN_META_KEY),
+        "run_uid": start.get("uid"),
+    }
+
+
+def _decimate_figure(figure: Figure) -> Figure:
+    """Bound every lines/bars series to `DEFAULT_MAX_POINTS`, truthfully flagged.
+
+    Mutates *figure* in place and returns it. Only marks that actually exceed
+    the budget are touched — an already-bounded mark keeps whatever
+    ``decimated``/``source_points`` truth its author set, and a touched mark's
+    aggregates are recomputed from its per-series truth. `BarsMark` carries no
+    `Point` list, so its values ride through `decimate` as index-valued points
+    and the kept indices select the surviving category/value pairs — same
+    stride, same endpoint rule, and a ``None`` value survives as a gap.
+    """
+    for panel in figure.panels:
+        mark = panel.mark
+        if isinstance(mark, LinesMark):
+            if not any(len(series.points) > DEFAULT_MAX_POINTS for series in mark.series):
+                continue
+            mark.series = [
+                series
+                if len(series.points) <= DEFAULT_MAX_POINTS
+                else Series(
+                    label=series.label,
+                    **decimate(
+                        series.points,
+                        source_points=series.source_points,
+                        decimated=series.decimated,
+                    )._asdict(),
+                )
+                for series in mark.series
+            ]
+            mark.decimated = any(series.decimated for series in mark.series)
+            mark.source_points = sum(series.source_points for series in mark.series)
+        elif isinstance(mark, BarsMark) and len(mark.values) > DEFAULT_MAX_POINTS:
+            indexed = [Point(x=float(i), y=value) for i, value in enumerate(mark.values)]
+            thinned = decimate(indexed, source_points=mark.source_points, decimated=mark.decimated)
+            kept = [int(point.x) for point in thinned.points]
+            mark.categories = [mark.categories[i] for i in kept]
+            mark.values = [mark.values[i] for i in kept]
+            mark.decimated = thinned.decimated
+            mark.source_points = thinned.source_points
+    return figure
+
+
+def _stamp_name(plan_stamp: Any) -> str | None:
+    """The stamp's plan name, or ``None`` unless it is an actual string.
+
+    The stamp is opaque data off a document: a malformed one (non-dict, or a
+    name that is a list/number) must degrade to `plan_identity_unavailable`
+    like any other unusable identity — never reach a catalog lookup or a cache
+    key, where a non-str, possibly unhashable name would raise.
+    """
+    if not isinstance(plan_stamp, dict):
+        return None
+    name = plan_stamp.get("name")
+    return name if isinstance(name, str) else None
+
+
+def _compose_figure(
+    *,
+    columns: list[str],
+    rows: list[Any],
+    total_seen: int,
+    plan_stamp: Any,
+    partial: bool,
+    source: Literal["live", "tiled"],
+) -> tuple[Figure, bool]:
+    """One source snapshot in, one servable figure out — total, never raises.
+
+    Returns ``(figure, cacheable)``. ``cacheable`` is False only when the
+    figure describes a *transient* failure of this process rather than a truth
+    about the run — today, a plan catalog that raised — so the route must not
+    stick it to a settled run; every other outcome, genuine no-owner lookups
+    included, caches normally.
+
+    Every fallback is the default figure carrying its machine-readable
+    ``reason``; ``partial`` and ``source`` are stamped from the SOURCE's truth
+    on every path, plan-rendered figures included — a `render` sees rows, not
+    their provenance, so both of its own values are placeholders by convention
+    (see `plans_core/orm.py`).
+
+    The reason ladder, in the order it is walked:
+
+    - ``plan_identity_unavailable`` — no plan stamp on the source, a stamp
+      with no name (a run enqueued before stamping existed, or driven directly
+      at the worker), or a malformed stamp whose name is not a string. The
+      stamp is the ONLY identity source; the run record is never consulted.
+    - ``no_render`` — the stamped name has no current owner in the plan
+      catalog (removed or renamed since the run), its spec carries no
+      ``render``, or the catalog itself failed to load (logged; the one
+      non-cacheable case). Figures are always computed by the plan code
+      *currently* owning the name.
+    - ``render_not_supported_for_session_plans`` — the name resolves to a
+      session/unreviewed spec. Decided on provenance, not on ``render is
+      None``, so the authoring agent learns *why* rather than seeing a plain
+      ``no_render``.
+    - ``params_mismatch`` — the stamped kwargs no longer validate against the
+      plan's current schema (schema drift since the run), or the source
+      snapshot itself is structurally broken (`rows_from_columnar` refuses a
+      window claiming more rows than its run, or ragged rows — same treatment:
+      the stored shape no longer matches what the code expects).
+    - ``render_failed`` — the plan's `render` raised, returned a non-`Figure`,
+      or produced marks whose decimation truth is inconsistent.
+    """
+    try:
+        window = rows_from_columnar(columns, rows, total_seen)
+    except ValueError:
+        logger.warning("figure: malformed row snapshot; serving the default figure", exc_info=True)
+        window = RowWindow(
+            rows=[], columns=list(columns), rows_complete=False, total_seen=max(total_seen, 0)
+        )
+        figure = _decimate_figure(
+            default_figure(window, reason=REASON_PARAMS_MISMATCH, partial=partial, source=source)
+        )
+        return figure, True
+
+    def _default(reason: str) -> Figure:
+        return _decimate_figure(
+            default_figure(window, reason=reason, partial=partial, source=source)
+        )
+
+    plan_name = _stamp_name(plan_stamp)
+    if plan_name is None:
+        return _default(REASON_PLAN_IDENTITY_UNAVAILABLE), True
+
+    try:
+        from .plan_loader import get_facility_plans
+
+        spec = get_facility_plans().plans.get(plan_name)
+    except Exception:
+        # A failing catalog is this process's transient trouble, not a truth
+        # about the run — hence cacheable=False, so it never sticks to a
+        # settled run the way a genuine no-owner lookup legitimately would.
+        logger.warning(
+            "figure: plan catalog unavailable; serving the default figure", exc_info=True
+        )
+        return _default(REASON_NO_RENDER), False
+    if spec is None:
+        return _default(REASON_NO_RENDER), True
+    if spec.provenance in ("session", "unreviewed"):
+        return _default(REASON_RENDER_NOT_SUPPORTED_FOR_SESSION_PLANS), True
+    if spec.render is None:
+        return _default(REASON_NO_RENDER), True
+
+    kwargs = plan_stamp.get("kwargs")
+    try:
+        params = spec.schema.model_validate({} if kwargs is None else kwargs)
+    except ValidationError:
+        return _default(REASON_PARAMS_MISMATCH), True
+
+    try:
+        rendered = spec.render(window.rows, params)
+        if not isinstance(rendered, Figure):
+            raise TypeError(f"render returned {type(rendered).__name__}, not a Figure")
+        figure = _decimate_figure(
+            rendered.model_copy(update={"partial": partial, "source": source})
+        )
+        return figure, True
+    except Exception:
+        logger.warning(
+            "figure: plan %r render failed; serving the default figure",
+            plan_name,
+            exc_info=True,
+        )
+        return _default(REASON_RENDER_FAILED), True
+
+
+@app.get("/runs/{run_id}/figure")
+def get_run_figure(run_id: str) -> dict:
+    """A run's figure: its plan's own view of the rows, or the default view.
+
+    Total over known runs — every run a DATA source knows has a figure, and
+    every degradation is a 200 default figure with a machine-readable
+    ``reason`` (this route is polled at 1 Hz; a flaky catalog must never
+    become a 500). ``partial`` and ``source`` are always present. 404 only
+    when neither the live buffer nor Tiled knows the run — byte-for-byte
+    `get_run_data`'s 404; the run RECORD is never consulted anywhere here (it
+    would need an awaited manager RPC from this sync def, could raise on a
+    never-non-200 route, and would make /figure and /data disagree about a
+    pending run).
+
+    Settledness comes from the SOURCE only — the live buffer's ``partial``
+    flag, or the stop document's presence in Tiled — never from the run
+    record, whose terminal status can precede the last rows and survives a
+    re-run of an interrupted item under the same run id. Settled figures are
+    cached (`figure_cache`) so a second GET on a settled Tiled run issues zero
+    Tiled calls; recycled run ids are handled by the document plane's
+    invalidate-on-write eviction plus the generation compare-and-set on store.
+    Live runs recompute per tick — ~50 ms end-to-end at facility scale, of
+    which the vectorized fit is ~15 ms.
+
+    A plain sync ``def`` (threadpool, like `get_run_data`) — no awaits, no
+    single-flight; losers of a cache race simply recompute.
+    """
+    # Generation before the source snapshot: if an eviction (a new start doc
+    # for this id) lands between the two reads, the CAS put below must lose.
+    # Read the other way around, a snapshot of the OLD rows could be stored
+    # under the NEW generation — a poisoned settled entry.
+    generation = figure_cache.snapshot_generation(run_id)
+
+    buf = live_rows.get(run_id)
+    if buf is not None:
+        plan_stamp = buf["plan"]
+        partial = bool(buf["partial"])
+        key = figure_cache.make_key(run_id, _stamp_name(plan_stamp), "live")
+        if not partial:
+            cached = figure_cache.get(key)
+            if isinstance(cached, _CachedFigure) and cached.total_seen == buf["total_seen"]:
+                return cached.figure.model_dump()
+        figure, cacheable = _compose_figure(
+            columns=buf["columns"],
+            rows=buf["rows"],
+            total_seen=buf["total_seen"],
+            plan_stamp=plan_stamp,
+            partial=partial,
+            source="live",
+        )
+        if not partial and cacheable:
+            figure_cache.put(key, _CachedFigure(figure, buf["total_seen"], None), generation)
+        return figure.model_dump()
+
+    cached = figure_cache.get_for_source(run_id, "tiled")
+    if isinstance(cached, _CachedFigure):
+        logger.debug(
+            "figure: settled Tiled cache hit for run %r (run_uid=%s)", run_id, cached.run_uid
+        )
+        return cached.figure.model_dump()
+
+    try:
+        snapshot = _figure_source_from_tiled(run_id)
+    except Exception:
+        # `partial=True` because settledness is unknowable without the source:
+        # the panel keeps its last good figure and keeps polling, which is the
+        # behavior that recovers when the catalog does.
+        logger.warning(
+            "figure: Tiled read failed for run %r; serving the default figure",
+            run_id,
+            exc_info=True,
+        )
+        window = RowWindow(rows=[], columns=[], rows_complete=False, total_seen=0)
+        return default_figure(
+            window, reason=REASON_SOURCE_UNAVAILABLE, partial=True, source="tiled"
+        ).model_dump()
+
+    if snapshot is None:
+        raise HTTPException(status_code=404, detail=f"unknown run {run_id!r}")
+
+    plan_stamp = snapshot["plan"]
+    figure, cacheable = _compose_figure(
+        columns=snapshot["columns"],
+        rows=snapshot["rows"],
+        total_seen=snapshot["total_seen"],
+        plan_stamp=plan_stamp,
+        partial=snapshot["partial"],
+        source="tiled",
+    )
+    if not snapshot["partial"] and cacheable:
+        figure_cache.put(
+            figure_cache.make_key(run_id, _stamp_name(plan_stamp), "tiled"),
+            _CachedFigure(figure, snapshot["total_seen"], snapshot["run_uid"]),
+            generation,
+        )
+    return figure.model_dump()

--- a/src/osprey/services/bluesky_bridge/document_plane.py
+++ b/src/osprey/services/bluesky_bridge/document_plane.py
@@ -27,7 +27,13 @@ threads OSPREY's own run id through queueserver item metadata
 run's start document, and :class:`RunDocumentRouter` reads it back out there.
 A start document without it (someone drove the worker directly) falls back to
 the run uid, so such a run is still recorded — just under the only identity it
-has.
+has. The same metadata path carries the plan stamp
+(``queue_backend.PLAN_META_KEY``), read out here and handed to the recorder so
+a run's rows stay self-describing for a reader holding only its id. Because a
+run id can be reused — re-running an interrupted item keeps it — a start
+document also invalidates any settled figure cached under that id
+(``figure_cache.evict``), which is what lets the figure route trust its cache
+without re-reading the source to check.
 
 **Progress is computed here, not in the worker.** ``rows_seen`` comes from the
 live buffer's true event count; ``expected_points`` comes from the plan
@@ -52,9 +58,9 @@ from pathlib import Path
 from threading import Lock
 from typing import Any
 
-from . import live_rows
+from . import figure_cache, live_rows
 from .live_rows import LiveRowRecorder
-from .queue_backend import RUN_ID_META_KEY
+from .queue_backend import PLAN_META_KEY, RUN_ID_META_KEY
 
 logger = logging.getLogger("osprey.services.bluesky_bridge.document_plane")
 
@@ -331,7 +337,12 @@ class RunDocumentRouter:
             if isinstance(declared, int) and not isinstance(declared, bool) and declared > 0:
                 record_expected_points(key, declared)
 
-        recorder = LiveRowRecorder(key=key)
+        # Which plan produced the run travels with its rows: a reader holding
+        # only a run id cannot otherwise tell what the columns mean. Read here,
+        # beside the run id and for the same reason — the stamp is a document
+        # detail, and keeping the extraction in this plane leaves `live_rows`
+        # testable with synthetic documents.
+        recorder = LiveRowRecorder(key=key, plan=doc.get(PLAN_META_KEY))
         with self._lock:
             self._recorders[run_uid] = recorder
             self._recorders.move_to_end(run_uid)
@@ -339,6 +350,16 @@ class RunDocumentRouter:
                 evicted, _ = self._recorders.popitem(last=False)
                 self._forget_descriptors(evicted)
         recorder("start", doc)
+        # The rows under `key` are now this run's, so any settled figure cached
+        # for that id was built from the previous occupant's rows — an operator
+        # re-running an interrupted item reuses the OSPREY run id. Evicting here
+        # is what keeps the figure route from validating its cache at read time,
+        # which would cost the very Tiled search the cache exists to avoid. It
+        # runs AFTER `recorder("start", ...)` returns, so `live_rows`' lock is
+        # released before the cache's is taken (the two are never nested, in
+        # either order) and so the buffer is already the new run's by the time
+        # the generation bump admits figures computed from it.
+        figure_cache.evict(key)
 
     def _on_descriptor(self, doc: dict[str, Any]) -> None:
         descriptor_uid = doc.get("uid")

--- a/src/osprey/services/bluesky_bridge/figure.py
+++ b/src/osprey/services/bluesky_bridge/figure.py
@@ -1,0 +1,561 @@
+"""The figure spec: one drawing vocabulary shared by the panel and the agent.
+
+A plan's ``render(rows, params)`` returns a `Figure`: a list of `Panel`s, each
+carrying exactly one mark (`LinesMark`, `HeatmapMark`, or `BarsMark`) alongside
+its title, axis labels/units, and annotations. The bridge serves that object as
+JSON from `GET /runs/{run_id}/figure`; the panel's ``figure-renderer.js`` draws
+it and the MCP ``get_run_figure`` tool projects it for the agent. Both consumers
+dispatch on ``mark.kind`` and read snake_case field names straight out of
+`model_dump()`, so this module is the contract between them: neither can be
+type-checked against it, and a renamed field breaks them silently.
+
+Every figure is honest about what it shows. `Figure.partial` says whether the
+run was still producing rows, `Figure.source` says which store those rows came
+from, and `Figure.reason` -- one of the ``REASON_*`` constants -- says why a
+default figure stands in for a plan's own view. Every mark reports
+``decimated``/``source_points`` so a thinned series is never mistaken for the
+whole dataset.
+
+Non-finite floats (``NaN``, ``inf``) in nullable value fields are normalized to
+``None`` during validation. They are nothing a renderer can draw, and
+``json.dumps`` writes them as bare ``NaN``/``Infinity`` -- not valid JSON, and a
+``JSON.parse`` failure in the browser rather than a visible gap in the plot. The
+same value on a required axis coordinate is a `ValidationError` instead: a point
+with no x has no place on an axis at all.
+
+Kept pydantic-only (no bluesky/ophyd/tiled imports), like `plan_metadata.py`, so
+plan modules and the bridge process can both import it without dragging the
+RunEngine stack into either one.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from typing import Annotated, Any, Literal, NamedTuple
+
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
+
+# --- Reason vocabulary -------------------------------------------------------
+#
+# Set on `Figure.reason` when the served figure is the bridge's default view
+# rather than the one the plan asked for. Stable strings: the panel and the
+# agent narrate from them, so they are part of the wire contract.
+
+REASON_NO_RENDER = "no_render"
+"""The plan declares no ``render()`` -- the default figure *is* its view."""
+
+REASON_RENDER_FAILED = "render_failed"
+"""The plan's ``render()`` raised; the default figure stands in for it."""
+
+REASON_RENDER_NOT_SUPPORTED_FOR_SESSION_PLANS = "render_not_supported_for_session_plans"
+"""The plan came from the session/unreviewed layer, whose ``render()`` is never run."""
+
+REASON_PARAMS_MISMATCH = "params_mismatch"
+"""The stamped parameters did not validate against the plan's PARAMS schema."""
+
+REASON_PLAN_IDENTITY_UNAVAILABLE = "plan_identity_unavailable"
+"""The run could not be tied back to a known plan, so no ``render()`` applies."""
+
+REASON_SOURCE_UNAVAILABLE = "source_unavailable"
+"""Reading the rows failed; the figure is empty but the response is still a 200."""
+
+FIGURE_REASONS: frozenset[str] = frozenset(
+    {
+        REASON_NO_RENDER,
+        REASON_RENDER_FAILED,
+        REASON_RENDER_NOT_SUPPORTED_FOR_SESSION_PLANS,
+        REASON_PARAMS_MISMATCH,
+        REASON_PLAN_IDENTITY_UNAVAILABLE,
+        REASON_SOURCE_UNAVAILABLE,
+    }
+)
+"""Every reason the bridge may set. `Figure.reason` is left unvalidated against
+this set so an unforeseen reason still serves a figure rather than a 500; use it
+in tests and in narration lookups."""
+
+
+# --- Numeric normalization ---------------------------------------------------
+
+
+def _finite_or_none(value: Any) -> Any:
+    """Coerce ``value`` to a plain ``float``, mapping non-finite results to ``None``.
+
+    Numpy scalars and ints become Python floats so `model_dump()` yields
+    JSON-native types; ``NaN``/``inf`` become ``None`` (a gap the renderer can
+    draw); anything that isn't number-like is passed through untouched for
+    pydantic to report as a type error.
+    """
+    if value is None or isinstance(value, bool):
+        return value
+    try:
+        as_float = float(value)
+    except (TypeError, ValueError):
+        return value
+    return as_float if math.isfinite(as_float) else None
+
+
+def _require_finite(value: Any) -> Any:
+    """Coerce ``value`` to a plain ``float``, rejecting non-finite results.
+
+    Used for axis coordinates, where a ``NaN`` is not a gap but a point with no
+    position: better a `ValidationError` the render contract turns into the
+    default figure than an unplottable coordinate on the wire.
+    """
+    if value is None or isinstance(value, bool):
+        return value
+    try:
+        as_float = float(value)
+    except (TypeError, ValueError):
+        return value
+    if not math.isfinite(as_float):
+        raise ValueError("must be a finite number, got NaN or infinity")
+    return as_float
+
+
+NullableFloat = Annotated[float | None, BeforeValidator(_finite_or_none)]
+"""A measured value, or ``None`` for a gap. Non-finite input becomes ``None``."""
+
+FiniteFloat = Annotated[float, BeforeValidator(_require_finite)]
+"""An axis coordinate. Non-finite input is a validation error."""
+
+
+class _FigureNode(BaseModel):
+    """Shared config for every node in the figure tree.
+
+    ``extra="forbid"`` because a misspelled field is a mark the renderer draws
+    wrong (or not at all) rather than an error anyone sees: caught here, it is a
+    `ValidationError` inside the plan's ``render()`` and the run still gets its
+    default figure.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+
+# --- Marks -------------------------------------------------------------------
+
+
+class Point(_FigureNode):
+    """One sample in a line series."""
+
+    x: FiniteFloat
+    y: NullableFloat = None
+    """The measured value, or ``None`` for a gap the renderer draws as a break
+    in the line rather than a jump through zero."""
+
+
+class Series(_FigureNode):
+    """One named line within a `LinesMark`."""
+
+    label: str
+    points: list[Point] = Field(default_factory=list)
+    decimated: bool = False
+    """Whether ``points`` was thinned from a larger set."""
+
+    source_points: int
+    """How many points this series was built from, before any decimation.
+    Equals ``len(points)`` when ``decimated`` is false."""
+
+
+class LinesMark(_FigureNode):
+    """A set of x/y series drawn as lines."""
+
+    kind: Literal["lines"] = "lines"
+    series: list[Series] = Field(default_factory=list)
+    decimated: bool = False
+    """True when *any* series was thinned; per-series truth is on `Series`."""
+
+    source_points: int
+    """Total points across every series before decimation."""
+
+
+class HeatmapMark(_FigureNode):
+    """A labelled 2-D grid of values, drawn as colored cells."""
+
+    kind: Literal["heatmap"] = "heatmap"
+    x_labels: list[str] = Field(default_factory=list)
+    y_labels: list[str] = Field(default_factory=list)
+    values: list[list[NullableFloat]] = Field(default_factory=list)
+    """Row-major: ``values[j][i]`` is the cell at ``y_labels[j]`` /
+    ``x_labels[i]``. A ``None`` cell is one that was never measured and is drawn
+    as empty, not as zero."""
+
+    value_label: str = ""
+    """What the cell values *are* -- the heatmap's third axis (e.g. ``"slope"``)."""
+
+    value_units: str | None = None
+    decimated: bool = False
+    source_points: int
+    """Number of cells the heatmap was built from, before any summarization."""
+
+
+class BarsMark(_FigureNode):
+    """One value per named category, drawn as bars."""
+
+    kind: Literal["bars"] = "bars"
+    label: str = ""
+    categories: list[str] = Field(default_factory=list)
+    values: list[NullableFloat] = Field(default_factory=list)
+    """Positionally aligned with ``categories``; ``None`` is a missing bar."""
+
+    decimated: bool = False
+    source_points: int
+    """Number of categories before any decimation."""
+
+
+Mark = Annotated[LinesMark | HeatmapMark | BarsMark, Field(discriminator="kind")]
+"""The mark kinds a panel may carry, tagged by ``kind`` so a dumped figure
+round-trips back through `Figure.model_validate` as the same mark type."""
+
+
+# --- Panels and figures ------------------------------------------------------
+
+
+class Panel(_FigureNode):
+    """One plot: a mark plus everything needed to read it."""
+
+    title: str
+    x_label: str = ""
+    y_label: str = ""
+    x_units: str | None = None
+    y_units: str | None = None
+    annotations: list[str] = Field(default_factory=list)
+    """Short operator-facing notes about what the panel does *not* show -- a
+    decimation cap, dropped rows, series omitted past a limit. Rendered as text
+    beside the plot, so they must read as sentences, not as codes."""
+
+    mark: Mark
+    """Exactly one mark. A panel showing two things is two panels."""
+
+
+class Figure(_FigureNode):
+    """A complete plan view: the payload of `GET /runs/{run_id}/figure`.
+
+    JSON-serializable via `model_dump()`, which is how both the panel and the
+    MCP projection consume it.
+    """
+
+    panels: list[Panel] = Field(default_factory=list)
+    partial: bool
+    """True while the run may still produce rows -- the panel keeps polling."""
+
+    source: Literal["live", "tiled"]
+    """Which store the rows came from: the in-process live buffer, or Tiled."""
+
+    reason: str | None = None
+    """Why this is the default figure instead of the plan's own view. ``None``
+    means the plan rendered it; otherwise one of `FIGURE_REASONS`."""
+
+
+# --- Decimation --------------------------------------------------------------
+
+DEFAULT_MAX_POINTS = 2000
+"""Points per series the panel-facing route serves. The MCP projection spends
+the same number across the *whole* figure instead."""
+
+
+class DecimatedPoints(NamedTuple):
+    """What `decimate` kept, and the truth about what it dropped.
+
+    The field names are `Series`'s, so a caller can splat the result::
+
+        Series(label="bpm3", **decimate(points)._asdict())
+    """
+
+    points: list[Point]
+    decimated: bool
+    source_points: int
+
+
+def decimate(
+    points: Sequence[Point],
+    max_points: int = DEFAULT_MAX_POINTS,
+    *,
+    source_points: int | None = None,
+    decimated: bool = False,
+) -> DecimatedPoints:
+    """Thin ``points`` to at most ``max_points``, keeping both endpoints.
+
+    A run with 200k rows is not 200k pixels wide, and neither the browser nor
+    the agent's context can afford the difference. This picks an evenly spaced
+    subset instead: the first and last points verbatim, so the series still
+    spans the x range it actually covered, and one representative from each of
+    the ``max_points - 2`` equal windows in between.
+
+    **Gaps survive.** A window whose points include a ``y is None`` gap is
+    represented *by that gap* rather than by a measured value, so missing data
+    is never smoothed over by the stride -- the drawn line breaks wherever the
+    source had nothing to draw. This over-reports gap width (one dropout in a
+    window of ten renders as a window-wide break) and never under-reports it,
+    which is the direction that keeps the picture honest: the figure may say
+    "no data here" where the data was merely sparse, but it never claims a
+    reading the run did not take. The first gap in the window wins; the two
+    endpoints are always the source's own endpoints, gap or not.
+
+    **Stride is positional, not by x value.** Points are taken every ``n /
+    max_points`` samples in sequence order, which is even in x for the
+    acquisition-ordered series this module builds. A series whose x samples
+    bunch up keeps that bunching -- decimation preserves the shape of the
+    sampling, it does not resample onto a uniform axis.
+
+    **Re-decimation composes** only if the caller passes the prior truth in.
+    ``source_points`` always means the count *before any* decimation, so the
+    MCP projection re-striding an already-thinned series to a smaller budget
+    must hand back what it was told::
+
+        thinner = decimate(
+            series.points,
+            budget,
+            source_points=series.source_points,
+            decimated=series.decimated,
+        )
+
+    Without those two arguments the input is taken to be the raw, untouched
+    data, and the returned ``source_points`` would shrink to the already-thinned
+    count -- a figure claiming it drew everything it had.
+
+    Args:
+        points: The series' points, in the order they were acquired.
+        max_points: Most points to keep. Must be at least 1. Budgets of 1 and 2
+            are degenerate but legal (the MCP projection can allocate them when
+            a figure carries more series than points): 1 keeps the first point,
+            2 keeps both endpoints, and neither leaves room for the gap rule.
+        source_points: How many points the input was itself built from, when it
+            has already been decimated. Defaults to ``len(points)``.
+        decimated: Whether the input has already been thinned. The returned flag
+            is this ``or`` whatever this call does.
+
+    Returns:
+        A `DecimatedPoints` with the kept points -- a new list, never the input
+        object -- and the composed ``decimated`` / ``source_points`` truth.
+
+    Raises:
+        ValueError: If ``max_points`` is below 1, or ``source_points`` is
+            smaller than the number of points given (which would report a
+            series as larger after decimation than before it).
+    """
+    if max_points < 1:
+        raise ValueError(f"max_points must be at least 1, got {max_points}")
+
+    count = len(points)
+    original = count if source_points is None else source_points
+    if original < count:
+        raise ValueError(
+            f"source_points ({original}) is smaller than the {count} points given; "
+            "it counts the points before decimation, not after"
+        )
+
+    if count <= max_points:
+        return DecimatedPoints(list(points), decimated, original)
+
+    kept = [points[0]]
+    windows = max_points - 2  # <= 0 for the degenerate budgets, skipping the loop
+    span = count - 2  # every interior window holds at least one point
+    for i in range(windows):
+        start = 1 + (i * span) // windows
+        stop = 1 + ((i + 1) * span) // windows
+        gap = next((j for j in range(start, stop) if points[j].y is None), None)
+        kept.append(points[gap if gap is not None else start + (stop - start) // 2])
+    if max_points >= 2:
+        kept.append(points[-1])
+
+    return DecimatedPoints(kept, True, original)
+
+
+# --- Row windows -------------------------------------------------------------
+
+
+class RowWindow(NamedTuple):
+    """The rows a figure is being built from, and how much of the run they are.
+
+    ``rows_complete`` is the load-bearing field: it says whether these rows are
+    the run's *whole* dataset or a window onto it. A renderer that indexes rows
+    positionally -- the orm render deriving which corrector a row belongs to
+    from its position in the sweep -- is only sound over a complete set, and
+    must fall back to something position-free when this is ``False``.
+    """
+
+    rows: list[dict[str, Any]]
+    columns: list[str]
+    rows_complete: bool
+    total_seen: int
+
+
+def rows_from_columnar(
+    columns: Sequence[str],
+    rows: Sequence[Sequence[Any]],
+    total_seen: int,
+) -> RowWindow:
+    """Turn the bridge's columnar row payload into per-row dicts.
+
+    Both row sources -- the in-process live buffer and Tiled -- reach a plan's
+    ``render()`` through here, so this is where their two spellings of "no
+    reading" are reconciled: the live buffer stores a missing value as ``None``
+    (an Event doc simply had no key for that column), while a Tiled table, being
+    a numeric array, has no ``None`` to store and surfaces the same absence as a
+    float ``NaN``. Downstream everything -- the plan renders, the default
+    figure, the live-vs-Tiled parity the panel depends on -- sees ``None`` and
+    only ``None``, so a run replayed from Tiled draws the same figure it drew
+    live. Infinities are left alone: an ``inf`` is a value the run produced, not
+    a reading it failed to take, and the figure models null it at the drawing
+    edge anyway.
+
+    **Emission order is the caller's to establish.** Rows are mapped in the
+    order given and never sorted -- the live buffer appends in Event order, and
+    a Tiled caller must read its table sorted by ``seq_num`` -- because sorting
+    here would need a key column this payload deliberately projects away.
+
+    Args:
+        columns: The column names, in the order each row's values are stored.
+        rows: The window's rows, each a sequence of values positionally
+            matching ``columns``.
+        total_seen: How many rows the run has produced in total, which is more
+            than ``len(rows)`` when the window is paginated or the buffer hit
+            its retention cap.
+
+    Returns:
+        A `RowWindow` whose ``rows_complete`` is exact: ``True`` only when the
+        rows given are every row the run produced.
+
+    Raises:
+        ValueError: If a row's width does not match ``columns`` (a corrupt
+            buffer, not a figure), or if ``total_seen`` is smaller than the
+            number of rows given (a window larger than the run it windows).
+    """
+    if total_seen < len(rows):
+        raise ValueError(
+            f"total_seen ({total_seen}) is smaller than the {len(rows)} rows given; "
+            "it counts every row the run produced, not just this window's"
+        )
+
+    mapped = [
+        {
+            name: (None if isinstance(value, float) and math.isnan(value) else value)
+            for name, value in zip(columns, values, strict=True)
+        }
+        for values in rows
+    ]
+
+    return RowWindow(mapped, list(columns), len(mapped) == total_seen, total_seen)
+
+
+# --- Default figure ----------------------------------------------------------
+
+MAX_DEFAULT_SERIES = 12
+"""How many columns the default figure draws. Past this the panels stop being
+readable and the payload stops being cheap; the raw table below the plot still
+lists every column, and the figure says how many it left out."""
+
+
+def _numeric_value(value: Any) -> float | None:
+    """Return ``value`` as a finite ``float``, or ``None`` if it is not one.
+
+    ``None`` here means "nothing to draw at this row": a missing reading, a
+    string, a boolean flag, a ``NaN`` that survived the adapter, or an ``inf``
+    -- which is a value the run produced but not one an axis has a place for.
+    Anything number-like (including numpy scalars and ints) converts.
+    """
+    if value is None or isinstance(value, bool | str | bytes):
+        return None
+    try:
+        as_float = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return as_float if math.isfinite(as_float) else None
+
+
+def default_figure(
+    window: RowWindow,
+    *,
+    reason: str | None,
+    partial: bool,
+    source: Literal["live", "tiled"],
+) -> Figure:
+    """Build the bridge's stand-in view: every numeric column against row index.
+
+    This is what a run gets when no plan ``render()`` produced a figure for it
+    -- the plan declares none, its render raised, its parameters did not
+    validate, its identity was lost. It answers the one question a plan-agnostic
+    view can: what did each recorded number do over the course of the run.
+
+    **A column is drawn when at least one row holds a finite number for it**, and
+    it is drawn over *every* row: a column that reads values through row 49 and
+    ``None`` afterwards is one series with a gap, never a series that quietly
+    ends and never a dropped column. The alternative -- deciding numericness
+    from the rows currently in hand -- makes the figure's shape depend on when
+    the panel polled, so a column would appear and disappear between ticks. Rows
+    that hold a string, a boolean, or a non-finite float are gaps for the same
+    reason: the renderer breaks the line rather than inventing a position.
+
+    x is the row's index in ``window.rows``, not a time or a setpoint. The
+    default figure has no way to know which column is the independent one, so it
+    plots against the only ordering it can trust -- the order the run emitted.
+
+    Series past `MAX_DEFAULT_SERIES` are dropped in column order and the count
+    of what was dropped is annotated on the first panel, so the figure never
+    implies it is showing every column. A window that is only part of its run
+    (``rows_complete`` false) is annotated the same way.
+
+    **Never raises.** Every fallback path in the figure route ends here,
+    including the one that got here *because* something else raised, so an empty
+    window, a run with no columns, or a table of nothing but strings all produce
+    a valid `Figure` with no panels rather than a second failure.
+
+    Args:
+        window: The rows to draw, their column order, and how much of the run
+            they are.
+        reason: Why the default figure is standing in -- one of the ``REASON_*``
+            constants, or ``None`` if some caller genuinely means "no reason".
+            Required rather than defaulted: a default figure that does not say
+            why it is the default is the thing this vocabulary exists to prevent.
+        partial: Whether the run may still produce rows. The caller owns this:
+            it knows whether the stop document has arrived, and this function
+            only sees a window.
+        source: Which store the rows came from. On a source-read failure, pass
+            the store that was being read -- the empty figure still says where
+            it was looking.
+
+    Returns:
+        A `Figure` of one single-series lines `Panel` per drawn column, in
+        column order, each series decimated to `DEFAULT_MAX_POINTS`.
+    """
+    drawn = [
+        name
+        for name in window.columns
+        if any(_numeric_value(row.get(name)) is not None for row in window.rows)
+    ]
+    omitted = len(drawn) - MAX_DEFAULT_SERIES
+
+    annotations: list[str] = []
+    if omitted > 0:
+        annotations.append(
+            f"{omitted} more numeric column{'s' if omitted > 1 else ''} not shown; "
+            "the table below lists every column."
+        )
+    if not window.rows_complete:
+        annotations.append(
+            f"Showing {len(window.rows)} of {window.total_seen} rows the run produced."
+        )
+
+    panels: list[Panel] = []
+    for name in drawn[:MAX_DEFAULT_SERIES]:
+        points = [
+            Point(x=float(index), y=_numeric_value(row.get(name)))
+            for index, row in enumerate(window.rows)
+        ]
+        kept = decimate(points)
+        panels.append(
+            Panel(
+                title=name,
+                x_label="Row",
+                y_label=name,
+                annotations=annotations if not panels else [],
+                mark=LinesMark(
+                    series=[Series(label=name, **kept._asdict())],
+                    decimated=kept.decimated,
+                    source_points=kept.source_points,
+                ),
+            )
+        )
+
+    return Figure(panels=panels, partial=partial, source=source, reason=reason)

--- a/src/osprey/services/bluesky_bridge/figure_cache.py
+++ b/src/osprey/services/bluesky_bridge/figure_cache.py
@@ -1,0 +1,201 @@
+"""Bounded cache of SETTLED run figures, invalidated on write.
+
+``GET /runs/{id}/figure`` is polled: the panel asks again every tick while a run
+is in flight, and keeps asking for a moment after it finishes. Rendering a
+finished run's figure means reading its whole table back — from Tiled, over the
+network — and computing the same picture from the same rows every time. This
+module holds those finished pictures so a second GET on a settled run issues
+zero source reads.
+
+Only settled figures belong here. A run still producing rows has a different
+figure a second later, so the route caches nothing for it; settledness is
+decided by the SOURCE (live buffer no longer partial, or a stop document in
+Tiled), never by the run record, whose terminal status can precede the last
+rows and survives a re-run of an interrupted item under the same OSPREY run id.
+
+**Recycled run ids are handled by invalidate-on-write.** Validating a cached
+figure at read time would cost the Tiled search the cache exists to avoid, so
+instead the *write* side invalidates: when a start document arrives for a run id
+that already has entries (the operator re-ran an interrupted item), the document
+plane calls :func:`evict`, which drops that id's entries for every source and
+bumps a per-run generation counter. Stores are compare-and-set on that counter —
+:func:`snapshot_generation` is read when the rows are snapshotted and handed
+back to :func:`put`, which checks it inside the same lock acquisition as the
+write. A figure computation already in flight across an eviction therefore
+discards its now-stale result instead of re-poisoning a settled key; the loser
+simply recomputes on the next poll.
+
+**Lock discipline.** This is a two-thread structure: the route's threadpool
+threads write and read, the document plane's dispatcher thread evicts. Every
+get/put/evict is guarded by one module-level lock, mirroring ``live_rows._lock``.
+The two locks are never nested, in either order: the document plane's eviction
+runs after its ``live_rows`` write has released that lock, and the route never
+holds this lock across ``live_rows.get()`` or any Tiled call. Nothing here calls
+out to anything, so there is no lock ordering to get wrong — keep it that way.
+
+Values are opaque: whatever the route stores is what a later get returns, by
+reference and unvalidated. This module never inspects a figure, which keeps it
+free of pydantic and of bluesky alike (like ``figure.py``), so it can be
+unit-tested with plain sentinels.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from threading import Lock
+from typing import Any
+
+# Settled figures retained at once, oldest-*used* evicted first: a settled run
+# being polled stays hot, and one nobody has asked about since falls out. Sized
+# like `live_rows._MAX_RUNS` — the runs whose rows are still retained are
+# roughly the runs whose figures are worth keeping.
+_MAX_ENTRIES = 50
+
+# Generation counters retained at once. Larger than the entry cap because a
+# counter (one small int) is cheap and must outlive its run's cached entries:
+# dropping one would reset that run id's generation to zero, which is exactly
+# the value an in-flight computation may be holding. Dropping a counter
+# therefore drops that run's entries too, so a cached entry always has a
+# counter to be compared against (see `_forget_oldest_generation`). One
+# residual window is accepted rather than designed away: a put still in
+# flight while 500+ distinct runs churn through the cache could find its
+# run's counter dropped and re-created at the very value it snapshotted, and
+# land a stale figure — practically unreachable at a 1 Hz poll against a
+# 50-entry cache.
+_MAX_GENERATIONS = 500
+
+FigureKey = tuple[str, str | None, str]
+"""``(run_id, plan_name, source)``. The plan name is part of the key because a
+run id resolved to a different plan is a different picture, and ``None`` (plan
+unknown) is a key in its own right rather than a wildcard. ``source`` is
+``"live"`` or ``"tiled"``; both variants of a run id are dropped together."""
+
+_lock = Lock()
+_entries: OrderedDict[FigureKey, Any] = OrderedDict()
+_generations: OrderedDict[str, int] = OrderedDict()
+
+
+def make_key(run_id: str, plan_name: str | None, source: str) -> FigureKey:
+    """The cache key for *run_id*'s figure of *plan_name* read from *source*.
+
+    A constructor rather than a bare tuple literal at each call site: the run id
+    must be the first element for :func:`evict` to find it, and three strings in
+    a row are easy to transpose.
+    """
+    return (run_id, plan_name, source)
+
+
+def snapshot_generation(run_id: str) -> int:
+    """*run_id*'s current generation, to be handed back to :func:`put`.
+
+    Read this when the rows are snapshotted, not when the figure is finished:
+    the value's whole job is to say which occupant of the run id those rows came
+    from, so a later :func:`evict` can reject the store.
+    """
+    with _lock:
+        return _generations.get(run_id, 0)
+
+
+def get(key: FigureKey) -> Any | None:
+    """The cached figure for *key*, or ``None`` if there is none.
+
+    Returned by reference — this module stores what it was given and never
+    copies it, so a caller must treat the result as immutable. A hit refreshes
+    the entry's position, so a figure that keeps being asked for is not the one
+    evicted to make room.
+    """
+    with _lock:
+        if key not in _entries:
+            return None
+        _entries.move_to_end(key)
+        return _entries[key]
+
+
+def get_for_source(run_id: str, source: str) -> Any | None:
+    """The cached figure for *run_id* read from *source*, whatever its plan name.
+
+    The rotated branch of the figure route needs this: a run whose live buffer
+    is gone has its plan name recorded only in the Tiled start document, so a
+    lookup that required the full key would cost the very Tiled read the cache
+    exists to avoid. A run-scoped read is unambiguous because at most one plan
+    name can occupy a ``(run_id, source)`` pair at a time — every start
+    document for the id evicts ALL of its names and bumps the generation
+    (:func:`evict`), and a bridge restart clears the whole in-process cache —
+    so this never has to choose between candidates. Stores still use the exact
+    key (:func:`put`, generation-checked); this is a read-side accessor only,
+    and like :func:`get` it refreshes the entry's LRU position, returns by
+    reference, and never creates anything.
+    """
+    with _lock:
+        for key in _entries:
+            if key[0] == run_id and key[2] == source:
+                _entries.move_to_end(key)
+                return _entries[key]
+        return None
+
+
+def put(key: FigureKey, figure: Any, generation: int) -> bool:
+    """Store *figure* under *key*, unless *key*'s run was evicted meanwhile.
+
+    Args:
+        key: What was rendered — see :data:`FigureKey`.
+        figure: The settled figure, stored as-is and never inspected.
+        generation: What :func:`snapshot_generation` returned for the run id at
+            the time its rows were read.
+
+    Returns:
+        True if the figure was stored; False if the run id's generation moved on
+        while the figure was being computed, in which case *figure* describes
+        rows that are no longer what that run id means and is dropped. The
+        caller has already served it to this requester — the next poll
+        recomputes, which is the point.
+    """
+    run_id = key[0]
+    with _lock:
+        if _generations.get(run_id, 0) != generation:
+            return False
+        # Keep a counter alive for every run that has an entry, so an entry can
+        # never outlive the generation it would be compared against.
+        _generations.setdefault(run_id, generation)
+        _generations.move_to_end(run_id)
+        _entries[key] = figure
+        _entries.move_to_end(key)
+        while len(_entries) > _MAX_ENTRIES:
+            _entries.popitem(last=False)
+        while len(_generations) > _MAX_GENERATIONS:
+            _forget_oldest_generation()
+        return True
+
+
+def evict(run_id: str) -> None:
+    """Drop every cached figure for *run_id* and invalidate stores in flight.
+
+    Called when a start document lands for a run id that may already be cached:
+    the rows behind that id are about to be replaced, so both the entries built
+    from the old rows and any computation still running over them are void. The
+    generation bump is what voids the latter — see :func:`put`.
+
+    Must not be called while holding ``live_rows._lock`` (the document plane
+    calls it after its recorder write returns).
+    """
+    with _lock:
+        for key in [key for key in _entries if key[0] == run_id]:
+            del _entries[key]
+        _generations[run_id] = _generations.get(run_id, 0) + 1
+        _generations.move_to_end(run_id)
+        while len(_generations) > _MAX_GENERATIONS:
+            _forget_oldest_generation()
+
+
+def _forget_oldest_generation() -> None:
+    """Drop the least recently touched counter, and its run's entries (caller holds the lock)."""
+    run_id, _ = _generations.popitem(last=False)
+    for key in [key for key in _entries if key[0] == run_id]:
+        del _entries[key]
+
+
+def _clear() -> None:
+    """Drop every entry and counter (test isolation only)."""
+    with _lock:
+        _entries.clear()
+        _generations.clear()

--- a/src/osprey/services/bluesky_bridge/live_rows.py
+++ b/src/osprey/services/bluesky_bridge/live_rows.py
@@ -16,7 +16,8 @@ Document handling (bluesky's plain-dict document protocol):
 
 - ``start``: begins a new buffer for ``doc["uid"]`` — or for the recorder's
   explicit ``key``, when the caller keys buffers by something other than the
-  RunEngine's own uid (see :class:`LiveRowRecorder`) — marked partial.
+  RunEngine's own uid (see :class:`LiveRowRecorder`) — marked partial, and
+  stamped with the recorder's opaque ``plan`` value if it was given one.
 - ``event``: each event's ``doc["data"]`` becomes one row; columns are
   discovered incrementally in first-seen order across events. A key seen for
   the first time extends the column list and backfills every already-stored
@@ -66,12 +67,19 @@ _MAX_RUNS = 50
 _MAX_ROWS_PER_RUN = 10_000
 
 _lock = Lock()
-# run_uid -> {"columns": [...], "rows": [[...], ...], "partial": bool, "total_seen": int}
+# run_uid -> {"columns": [...], "rows": [[...], ...], "partial": bool,
+#             "total_seen": int, "plan": Any | None}
 _buffers: OrderedDict[str, dict[str, Any]] = OrderedDict()
 
 
 def get(run_uid: str) -> dict[str, Any] | None:
-    """A snapshot of the live buffer for *run_uid* (or None if unknown)."""
+    """A snapshot of the live buffer for *run_uid* (or None if unknown).
+
+    ``columns`` and ``rows`` are copies, so a caller cannot reach back into the
+    buffer through them. ``plan`` is whatever the recorder was handed and is
+    returned by reference — this module never inspects or mutates it, and
+    neither may a caller.
+    """
     with _lock:
         buf = _buffers.get(run_uid)
         if buf is None:
@@ -81,6 +89,7 @@ def get(run_uid: str) -> dict[str, Any] | None:
             "rows": [list(row) for row in buf["rows"]],
             "partial": buf["partial"],
             "total_seen": buf["total_seen"],
+            "plan": buf["plan"],
         }
 
 
@@ -105,10 +114,19 @@ class LiveRowRecorder:
             chose and cannot map back to the item an operator enqueued. Left
             ``None``, the run uid IS the identity the read path looks up —
             which is the honest key for a run that carries no OSPREY id.
+        plan: Which plan produced this run, carried alongside its rows so a
+            reader that has only a run id can tell what the columns mean. The
+            value is opaque here: this module stores it and hands it back in
+            :func:`get`, and never interprets, validates, or copies it. The
+            document plane extracts it from the start document (mirroring
+            ``key``), which keeps this module testable with synthetic
+            documents. ``None`` for a run whose start document carried no plan
+            stamp — an honest "not known", never a placeholder.
     """
 
-    def __init__(self, key: str | None = None) -> None:
+    def __init__(self, key: str | None = None, plan: Any | None = None) -> None:
         self._key = key
+        self._plan = plan
         self._uid: str | None = None
 
     def __call__(self, name: str, doc: dict[str, Any]) -> None:
@@ -129,7 +147,13 @@ class LiveRowRecorder:
             return
         self._uid = uid
         with _lock:
-            _buffers[uid] = {"columns": [], "rows": [], "partial": True, "total_seen": 0}
+            _buffers[uid] = {
+                "columns": [],
+                "rows": [],
+                "partial": True,
+                "total_seen": 0,
+                "plan": self._plan,
+            }
             _buffers.move_to_end(uid)
             while len(_buffers) > _MAX_RUNS:
                 _buffers.popitem(last=False)

--- a/src/osprey/services/bluesky_bridge/orm_analysis.py
+++ b/src/osprey/services/bluesky_bridge/orm_analysis.py
@@ -7,9 +7,13 @@ live-buffer or Tiled-specific shape, so this module has no dependency on
 loading the bluesky stack (a core dependency, but heavier than this pure-numpy
 analysis needs).
 
-Three pieces:
+Four pieces:
 
 - `build_response_matrix`: per-(BPM, corrector) slope fit from swept rows.
+- `sliced_response_matrix`: the same fit, sliced by acquisition index and
+  vectorized — the entry point a plan's `render()` uses on every live tick,
+  where `build_response_matrix`'s per-pair `polyfit` over per-row dict scans
+  is orders of magnitude too slow.
 - `localize_kick`: `lstsq` fault localization against a measured orbit.
 - `column_anomaly`/`row_anomaly`: model-free structural fault detectors that
   use only the matrix's own peer/neighbour structure — no independent model
@@ -38,6 +42,7 @@ key first, then by `f"{name}-"` prefix.
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
@@ -154,6 +159,226 @@ def build_response_matrix(
             matrix[i, j] = slope
 
     return matrix
+
+
+@dataclass(frozen=True)
+class SlicedResponseFit:
+    """What `sliced_response_matrix` recovers from one ORM run's rows.
+
+    Two groups of fields, because a plan's `render()` needs both: the raw
+    per-corrector sweep it can always draw as traces, and the fitted matrix
+    it can only draw once a sweep has actually finished.
+
+    Attributes:
+        correctors: The requested corrector names, in the order given —
+            `complete`, `currents` and `readings` are all aligned to this.
+        detectors: The requested detector names, in the order given — the
+            row axis of `matrix` and the column axis of every `readings`
+            block.
+        complete: One flag per requested corrector: `True` when that
+            corrector's slice was fitted into a `matrix` column. `False`
+            for a slice that is short (the sweep is still in flight, or the
+            row buffer ran out), that is missing a corrector current, or
+            whose currents never move (nothing to fit a slope against).
+        matrix: `[n_detectors, n_complete]` response slopes. Only complete
+            correctors get a column — an in-flight sweep has no slope yet,
+            and a zero column would read as a dead corrector. Use
+            `fitted_correctors` for its column labels; both are ordered as
+            `correctors` is.
+        fitted_correctors: The names of the correctors that produced a
+            `matrix` column, in column order. A subsequence of `correctors`.
+        currents: Per requested corrector, that corrector's own recorded
+            currents over its slice, `[k]` with `k <= num` — the x-axis of a
+            sweep trace. Present for incomplete correctors too.
+        readings: Per requested corrector, the detector block over its
+            slice, `[k, n_detectors]` — the y-axes of a sweep trace, one
+            column per detector. Present for incomplete correctors too.
+            A detector that did not report reads back as `nan` here (in
+            `matrix` it lands on `0.0`; see `sliced_response_matrix`).
+    """
+
+    correctors: tuple[str, ...]
+    detectors: tuple[str, ...]
+    complete: tuple[bool, ...]
+    matrix: np.ndarray
+    fitted_correctors: tuple[str, ...]
+    currents: tuple[np.ndarray, ...]
+    readings: tuple[np.ndarray, ...]
+
+
+def _resolve_key(row: Mapping[str, Any], device_name: str) -> str | None:
+    """The event-data *key* carrying *device_name* in *row*, or ``None``.
+
+    `_match_value`'s matching rules (exact key, then `f"{name}-"` prefix)
+    resolved to the key instead of the value, so a whole run's rows can be
+    read through one fixed key list rather than re-matching every row.
+    """
+    if device_name in row:
+        return device_name
+    prefix = f"{device_name}-"
+    for key in row:
+        if key.startswith(prefix):
+            return key
+    return None
+
+
+def sliced_response_matrix(
+    rows: Sequence[Mapping[str, Any]],
+    correctors: Sequence[str],
+    detectors: Sequence[str],
+    num: int,
+) -> SlicedResponseFit:
+    """Fit the response matrix by slicing *rows* into one sweep per corrector.
+
+    Same physics as `build_response_matrix`, different — and much stronger —
+    assumption about the input, which buys both correctness on inputs that
+    function cannot take and a fit fast enough to run on every live tick.
+
+    The `orm` plan sweeps its correctors strictly one at a time, `num`
+    points each, in the order they were requested (see `plans_core/orm.py`'s
+    `build_plan`), so corrector `j`'s samples are exactly
+    `rows[j * num : (j + 1) * num]` — no need to infer which rows belong to
+    which corrector from the data. Each corrector's slope is then fitted
+    against its OWN currents over its OWN slice only, which drops
+    `build_response_matrix`'s zero-mean-sweep requirement entirely: idle
+    correctors' rows are never in the slice to begin with, so a
+    `monodirectional` sweep over `[0, span_a]` (which that function rejects
+    with `DegenerateFitError`, its polyfit having no way to tell an
+    asymmetric sweep from a biased idle reading) fits correctly here.
+
+    The caller owes that slicing invariant: *rows* must be the run's events
+    in emission order, un-truncated at the front and with nothing dropped in
+    the middle. A truncated-from-the-front buffer silently misattributes
+    every sample, so a caller reading a capped live buffer must check its
+    completeness before calling (there is nothing in the rows themselves to
+    detect it from). Trailing truncation IS safe and expected — that is just
+    a run still in progress, and it shows up as trailing `complete=False`.
+
+    Speed comes from doing the two costly things once instead of per pair:
+    device names are resolved to event keys once for the whole run (rather
+    than `_match_value`-scanning every row for every device), and each
+    corrector's slopes are computed for the whole detector block at once
+    with the closed-form least-squares slope
+
+        slope = (dx @ (Y - Y_mean)) / (dx @ dx),    dx = x - x_mean
+
+    which is what a degree-1 `numpy.polyfit` solves, without building a
+    Vandermonde system per (detector, corrector) pair.
+
+    A slice that is short (the run is still going, or ended early), that is
+    missing its corrector's current, or whose currents never move produces
+    no matrix column and is flagged `complete=False`; its raw samples are
+    still returned for tracing. Inside a complete slice, a detector that
+    failed to report leaves its slope at `0.0` rather than `nan`, matching
+    `build_response_matrix` and keeping the matrix usable by
+    `column_anomaly`/`row_anomaly`; the `nan` survives in `readings` where a
+    trace can show the gap.
+
+    Args:
+        rows: The run's event `data` dicts in emission order.
+        correctors: Corrector device names, in the order the plan swept them.
+        detectors: Detector device names; the matrix's row axis.
+        num: Points per corrector sweep — the plan's `num` parameter.
+
+    Raises:
+        ValueError: *num* is below 2 (no slope is defined over fewer than
+            two points, and a non-positive *num* makes the slicing itself
+            meaningless).
+    """
+    if num < 2:
+        raise ValueError(f"num must be at least 2 to fit a slope per corrector, got {num}")
+
+    correctors = tuple(correctors)
+    detectors = tuple(detectors)
+    n_corr = len(correctors)
+    n_det = len(detectors)
+
+    # Only the rows the slicing can attribute to a corrector: a run carrying
+    # more than the sweep accounts for has extra rows at the END (nothing
+    # else preserves the invariant above), so they belong to no slice.
+    n_rows = min(len(rows), n_corr * num)
+    if n_corr == 0 or n_rows == 0:
+        empty = np.zeros((n_det, 0))
+        return SlicedResponseFit(
+            correctors=correctors,
+            detectors=detectors,
+            complete=(False,) * n_corr,
+            matrix=empty,
+            fitted_correctors=(),
+            currents=tuple(np.zeros(0) for _ in correctors),
+            readings=tuple(np.zeros((0, n_det)) for _ in correctors),
+        )
+
+    # Resolve every device to its event key once. The first row normally
+    # settles all of them (a bluesky stream's rows share one key set); the
+    # loop only runs on to cover a caller's hand-built ragged rows.
+    keys: list[str | None] = [None] * (n_corr + n_det)
+    unresolved = set(range(n_corr + n_det))
+    names = correctors + detectors
+    for row in rows[:n_rows]:
+        for position in tuple(unresolved):
+            key = _resolve_key(row, names[position])
+            if key is not None:
+                keys[position] = key
+                unresolved.discard(position)
+        if not unresolved:
+            break
+
+    # One pass over the rows through that fixed key list. A device that
+    # resolved to no key reads as `nan` everywhere, which is exactly how a
+    # missing device should behave downstream.
+    nan = float("nan")
+    table = np.array(
+        [[nan if key is None else row.get(key, nan) for key in keys] for row in rows[:n_rows]],
+        dtype=float,
+    )
+    currents_table = table[:, :n_corr]
+    readings_table = table[:, n_corr:]
+
+    complete: list[bool] = []
+    slice_currents: list[np.ndarray] = []
+    slice_readings: list[np.ndarray] = []
+    columns: list[np.ndarray] = []
+    fitted: list[str] = []
+
+    for j, corrector in enumerate(correctors):
+        start = j * num
+        stop = min(start + num, n_rows)
+        x = currents_table[start:stop, j]
+        block = readings_table[start:stop, :]
+        slice_currents.append(x)
+        slice_readings.append(block)
+
+        if x.shape[0] < num or not np.all(np.isfinite(x)):
+            complete.append(False)
+            continue
+
+        dx = x - x.mean()
+        denominator = float(dx @ dx)
+        if denominator <= 0.0:
+            # The corrector never moved over its own sweep: no slope exists,
+            # and dividing by zero would fill the column with inf/nan.
+            complete.append(False)
+            continue
+
+        slopes = (dx @ (block - block.mean(axis=0))) / denominator
+        # A detector that dropped out mid-slice poisons only its own entry.
+        slopes = np.where(np.isfinite(slopes), slopes, 0.0)
+        complete.append(True)
+        columns.append(slopes)
+        fitted.append(corrector)
+
+    matrix = np.column_stack(columns) if columns else np.zeros((n_det, 0))
+
+    return SlicedResponseFit(
+        correctors=correctors,
+        detectors=detectors,
+        complete=tuple(complete),
+        matrix=matrix,
+        fitted_correctors=tuple(fitted),
+        currents=tuple(slice_currents),
+        readings=tuple(slice_readings),
+    )
 
 
 def localize_kick(

--- a/src/osprey/services/bluesky_bridge/plan_loader.py
+++ b/src/osprey/services/bluesky_bridge/plan_loader.py
@@ -5,7 +5,7 @@ Two kinds of plan source, both scanned into the same fail-closed registry:
 
 - **Directory layers** — ordered ``(directory, provenance)`` pairs, each
   scanned for ``.py`` files exposing ``PLAN_METADATA``/``build_plan``
-  (optionally ``PARAMS``). Device-agnostic: these files never define
+  (optionally ``PARAMS`` and ``render``). Device-agnostic: these files never define
   ``get_devices()``; their plans resolve device names against the bridge's
   own device map at launch.
 - **The legacy single-module contract** — a single ``.py`` file exposing
@@ -68,13 +68,14 @@ import importlib.util
 import logging
 import os
 import sys
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel
 
+from .figure import REASON_RENDER_NOT_SUPPORTED_FOR_SESSION_PLANS, Figure
 from .plan_metadata import parse_plan_metadata
 from .plan_types import PlanSpec, Provenance
 from .plan_validation import hash_plan_body
@@ -336,6 +337,76 @@ def _register_plan(
         registry[name] = (provenance, source, spec)
 
 
+def _resolve_render(
+    module: Any,
+    path: Path,
+    provenance: Provenance,
+) -> Callable[[list[dict[str, Any]], Any], Figure] | None:
+    """Resolve a plan file's optional module-level ``render(rows, params)``.
+
+    Never raises, and never causes a quarantine: a plan whose ``render`` is
+    unusable is still a perfectly good plan to *launch*, and refusing to
+    register it would take the scan away over a drawing concern. The worst
+    outcome here is ``None``, which the figure route serves as the default
+    figure with a reason attached.
+
+    The rule, by tier:
+
+    - ``session``/``unreviewed`` — never resolved, even when the file defines
+      one. ``render()`` runs in the bridge API process on every poll tick of
+      every watching client, so an agent-authored one is an unbounded-work
+      denial-of-service seam that the validation gate (which checks the file
+      is a *plan*, not that its drawing code terminates) does not close. A
+      file that declares one warns at load time, quoting the route's
+      ``render_not_supported_for_session_plans`` reason so the author sees the
+      same words the panel will show them. A file that declares none is
+      silent — there is nothing to warn about.
+    - ``shipped``/``preset``/``facility`` — a callable module-level ``render``
+      is stored on the spec. A *missing* one is silent and ordinary (most
+      plans have no view of their own). A present-but-non-callable one warns:
+      it reads as an author mistake — a stray constant, or a name shadowed by
+      an import — not as a deliberate opt-out.
+
+    ``getattr`` itself is guarded because a module can define ``__getattr__``
+    (PEP 562) and raise from it; that must not become a quarantine either.
+    """
+    try:
+        render = getattr(module, "render", None)
+    except Exception as exc:  # PEP 562 module __getattr__ may raise
+        logger.warning(
+            "plan_loader: could not read render from %s (%s): %s — loading without a figure",
+            path,
+            provenance,
+            exc,
+        )
+        return None
+
+    if provenance in ("session", "unreviewed"):
+        if render is not None:
+            logger.warning(
+                "plan_loader: ignoring render() in %s-tier plan file %s (%s) — a "
+                "plan's render() runs in the bridge process on every poll tick, so "
+                "it is only honored for operator-supplied plans; this run will show "
+                "the default figure",
+                provenance,
+                path,
+                REASON_RENDER_NOT_SUPPORTED_FOR_SESSION_PLANS,
+            )
+        return None
+
+    if render is None:
+        return None
+    if not callable(render):
+        logger.warning(
+            "plan_loader: ignoring non-callable render in %s (%s): %r — loading without a figure",
+            path,
+            provenance,
+            render,
+        )
+        return None
+    return render  # type: ignore[no-any-return]
+
+
 def _load_plan_file(
     path: Path,
     provenance: Provenance,
@@ -369,6 +440,11 @@ def _load_plan_file(
     provenance (not on "no metadata"/"no record" alone) matters: built-ins and
     the shipped exemplars carry no validation record either, and a broader
     gate would wrongly quarantine them too.
+
+    An optional module-level ``render`` is resolved onto the spec by
+    `_resolve_render`, which is total: no ``render`` attribute, an unusable
+    one, or an untrusted tier all yield ``render=None``, and the plan itself
+    still registers.
     """
     try:
         if provenance in ("session", "unreviewed"):
@@ -404,6 +480,7 @@ def _load_plan_file(
             description=meta.description,
             metadata=meta,
             provenance=provenance,
+            render=_resolve_render(module, path, provenance),
         )
     except (Exception, SystemExit) as exc:
         logger.warning("plan_loader: quarantining %s (%s): %s", path, provenance, exc)

--- a/src/osprey/services/bluesky_bridge/plan_types.py
+++ b/src/osprey/services/bluesky_bridge/plan_types.py
@@ -17,6 +17,10 @@ Any``, where ``devices`` is whatever ``get_devices()`` returned and ``params``
 is a validated instance of ``schema``. Neither this module nor callers need to
 know if the callable returns a real bluesky plan generator or, in a test
 double, something else entirely.
+
+A plan's optional ``render`` callable is the opposite — fully typed, because
+it is the seam the figure route serves to the panel and the agent. ``figure.py``
+is pydantic-only, so importing `Figure` here costs the loader nothing.
 """
 
 from __future__ import annotations
@@ -27,6 +31,7 @@ from typing import Any, Generic, Literal, TypeVar
 
 from pydantic import BaseModel
 
+from .figure import Figure
 from .plan_metadata import PlanMetadata
 
 SchemaT = TypeVar("SchemaT", bound=BaseModel)
@@ -47,6 +52,15 @@ class PlanSpec(Generic[SchemaT]):
     callable can be typed against its own pydantic model (e.g. ``CountParams``)
     rather than the common ``BaseModel`` supertype — callers that don't care
     about a specific plan's schema can still hold these as ``PlanSpec[Any]``.
+
+    ``render`` is the plan's own view of a run: ``(rows, params) -> Figure``,
+    where ``rows`` are the run's data rows as plain dicts and ``params`` is a
+    validated ``schema`` instance — the *same* ``SchemaT``, so a plan whose
+    ``render`` takes anything other than its own PARAMS is a type error rather
+    than a runtime surprise at the first poll tick. ``None`` (the default)
+    means the plan has no view of its own and the bridge's default figure
+    stands in for it. The loader only ever populates this for operator-supplied
+    tiers; see ``plan_loader._resolve_render``.
     """
 
     name: str
@@ -55,6 +69,7 @@ class PlanSpec(Generic[SchemaT]):
     description: str = ""
     metadata: PlanMetadata | None = None
     provenance: Provenance = "shipped"
+    render: Callable[[list[dict[str, Any]], SchemaT], Figure] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize for `GET /plans`: name, description, schema, metadata, provenance."""

--- a/src/osprey/services/bluesky_bridge/plan_validation.py
+++ b/src/osprey/services/bluesky_bridge/plan_validation.py
@@ -75,6 +75,28 @@ _ALLOWED_BLUESKY_SUBMODULES: frozenset[str] = frozenset(
     {"bluesky.plan_stubs", "bluesky.plans", "bluesky.preprocessors"}
 )
 
+# `osprey` is narrowed the same way, and for a narrower reason: a plan file may
+# declare a `render(rows, params)` returning a `Figure` (see `plan_types.py`),
+# and there is no way to build one without importing the module that defines it.
+# `plans_core/*.py` files are exec'd by `plan_loader` via
+# `spec_from_file_location` with no package, so a relative `from ..figure
+# import` would fail at load — the absolute path below is the only spelling
+# that works, which is what puts it in front of this allowlist at all.
+#
+# Both entries are inert by construction: `figure` is pydantic-only (models,
+# `decimate`, the row adapter) and `orm_analysis` is numpy-only, neither
+# performs I/O, spawns anything, or touches a control system. Nothing else
+# under `osprey` belongs here. In particular the connector, config, queue, and
+# executor packages are the capabilities this validator exists to keep out of
+# an agent-authored plan body, and admitting bare `osprey` would hand a plan
+# every one of them.
+_ALLOWED_OSPREY_SUBMODULES: frozenset[str] = frozenset(
+    {
+        "osprey.services.bluesky_bridge.figure",
+        "osprey.services.bluesky_bridge.orm_analysis",
+    }
+)
+
 # Everything else a plan body may import, checked top-level only (a plan body
 # doing numerical/stdlib bookkeeping around its bluesky calls has no reason to
 # reach past these). `pydantic` is a deliberate addition beyond the plain
@@ -118,11 +140,13 @@ _DENIED_LOGGING_SUBMODULES: frozenset[str] = frozenset({"logging.config", "loggi
 
 # Passed to `validate_sandbox_code`'s own (coarser, top-level-only) import
 # check so it never disagrees with `_check_import_allowlist` below: `bluesky`
-# is allowed at the top level here, then narrowed to the three submodules
-# above by the finer-grained walk. Every other name in this set is identical
-# to `_ALLOWED_TOP_LEVEL_MODULES`, so the two checks agree everywhere except
-# the bluesky narrowing `validate_sandbox_code` cannot itself express.
-_VALIDATOR_TOP_LEVEL_MODULES: frozenset[str] = _ALLOWED_TOP_LEVEL_MODULES | {"bluesky"}
+# and `osprey` are allowed at the top level here, then narrowed to the exact
+# submodules above by the finer-grained walk. Every other name in this set is
+# identical to `_ALLOWED_TOP_LEVEL_MODULES`, so the two checks agree everywhere
+# except those two narrowings, which `validate_sandbox_code` cannot itself
+# express. Widening THIS set alone would admit any `osprey` submodule at all —
+# it is only ever safe paired with the submodule gate in `_is_allowed_import`.
+_VALIDATOR_TOP_LEVEL_MODULES: frozenset[str] = _ALLOWED_TOP_LEVEL_MODULES | {"bluesky", "osprey"}
 
 
 def _is_allowed_import(dotted_name: str) -> bool:
@@ -130,6 +154,8 @@ def _is_allowed_import(dotted_name: str) -> bool:
     top = dotted_name.split(".")[0]
     if top == "bluesky":
         return dotted_name in _ALLOWED_BLUESKY_SUBMODULES
+    if top == "osprey":
+        return dotted_name in _ALLOWED_OSPREY_SUBMODULES
     if top == "logging":
         return dotted_name not in _DENIED_LOGGING_SUBMODULES
     return top in _ALLOWED_TOP_LEVEL_MODULES

--- a/src/osprey/services/bluesky_bridge/plans_core/grid_scan.py
+++ b/src/osprey/services/bluesky_bridge/plans_core/grid_scan.py
@@ -8,14 +8,33 @@ at every grid point, wrapping ``bluesky.plans.grid_scan``.
 Device-agnostic: ``setpoints``/``detectors`` are resolved by string name
 against whatever ``devices`` dict the bridge passes in; nothing here names a
 facility PV or a fixed device set.
+
+`render` at the bottom is this plan's own view of its rows, served by
+``GET /runs/{run_id}/figure``: lines for a 1-D sweep, a heatmap for a 2-D
+grid, one line per outer-axis combination above that.
 """
 
 from __future__ import annotations
 
+import logging
+import math
+from collections.abc import Callable
 from typing import Any
 
 from bluesky import plans as bp
 from pydantic import BaseModel, Field, model_validator
+
+from osprey.services.bluesky_bridge.figure import (
+    Figure,
+    HeatmapMark,
+    LinesMark,
+    Panel,
+    Point,
+    Series,
+    decimate,
+)
+
+logger = logging.getLogger("osprey.services.bluesky_bridge.plans_core.grid_scan")
 
 PLAN_METADATA = {
     "name": "grid_scan",
@@ -80,3 +99,378 @@ def build_plan(devices: dict[str, Any], params: PARAMS) -> Any:
     for axis in params.axes:
         args.extend([devices[axis.setpoint], axis.start, axis.stop, axis.num_points])
     return bp.grid_scan(detectors, *args, snake_axes=params.snake_axes)
+
+
+# --- Rendering ---------------------------------------------------------------
+#
+# What a grid scan *is* decides how it should be drawn, and the plan knows that
+# where the bridge does not: a 1-D sweep is a line, a 2-D grid is an image, and
+# anything deeper is a family of lines along the fast axis. Everything below is
+# total -- `render` never raises, because a figure that cannot be drawn should
+# cost the operator the panel's default view, never the run.
+
+_MAX_SERIES = 12
+"""Most lines drawn on one panel for a 3-or-more-axis scan. A 5x5x5 grid has 25
+outer-axis combinations and no reader can tell 25 lines apart; the excess is
+reported in an annotation rather than drawn."""
+
+_GRID_REL_TOL = 1e-6
+_GRID_ABS_TOL = 1e-8
+"""How far a recorded axis value may sit from a grid point and still be counted
+as that point, as a fraction of the axis span and as an absolute floor.
+
+Rows carry axis *readbacks*, not the commanded setpoints: the bridge's
+``ConnectorSettable`` waits for a device to settle within its deadband (1e-9)
+and the value recorded is whatever the device then reported. Keying heatmap
+cells on those floats directly would give a 10x10 scan up to 100 distinct
+"columns" that each hold one point, so cell indices are derived from the grid
+geometry instead and the readback only has to land near its own grid point."""
+
+
+def _resolve_column(rows: list[dict[str, Any]], device_name: str) -> str | None:
+    """The event-data column holding *device_name*'s readings, if there is one.
+
+    Same name-fuzzy rule the ORM analysis uses (`orm_analysis._match_value`):
+    ophyd-async keys a hinted signal as either the bare device name or
+    ``f"{device}-{signal}"`` depending on how many readable children the device
+    exposes, so match the exact key first and the ``"<device>-"`` prefix second.
+    Only the first row is inspected -- every row of a window carries every
+    column (the shared row adapter's contract).
+    """
+    if not rows:
+        return None
+    keys = rows[0]
+    if device_name in keys:
+        return device_name
+    prefix = f"{device_name}-"
+    for key in keys:
+        if key.startswith(prefix):
+            return key
+    return None
+
+
+def _numeric(value: Any) -> float | None:
+    """*value* as a plain finite float, or ``None`` if it is not one.
+
+    ``None`` covers every un-drawable reading with one answer: a missing key, a
+    Tiled ``NaN``, an ``inf``, a string an odd device wrote. On a y value that
+    is a gap in the line; on an x value the row has no position and is dropped.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        as_float = float(value)
+    except (TypeError, ValueError):
+        return None
+    return as_float if math.isfinite(as_float) else None
+
+
+def _axis_step(axis: GridAxis) -> float:
+    """The spacing between two adjacent points on *axis*.
+
+    ``num_points >= 2`` is enforced by `GridAxis`, so this never divides by
+    zero. It can legitimately *be* zero, for the degenerate ``start == stop``
+    axis, which `_grid_index` handles separately.
+    """
+    return (axis.stop - axis.start) / (axis.num_points - 1)
+
+
+def _grid_index(axis: GridAxis, value: float) -> int | None:
+    """Which point of *axis* the readback *value* belongs to, or ``None``.
+
+    Nearest grid point by ``round((value - start) / step)``, clamped into range
+    so a readback that overshot the last point still lands on it, then accepted
+    only if it really is within `_GRID_REL_TOL` / `_GRID_ABS_TOL` of that
+    point's commanded position. A value between two grid points -- a device
+    caught mid-move, a scan whose axis was disturbed -- is ``None``: better a
+    dropped row the panel counts than a reading filed under a position it was
+    never taken at.
+    """
+    step = _axis_step(axis)
+    tolerance = max(_GRID_REL_TOL * abs(axis.stop - axis.start), _GRID_ABS_TOL)
+    if step == 0.0:
+        index = 0
+    else:
+        try:
+            index = round((value - axis.start) / step)
+        except (OverflowError, ValueError):  # pragma: no cover - denormal step
+            return None
+        index = min(max(index, 0), axis.num_points - 1)
+    if abs(value - (axis.start + index * step)) > tolerance:
+        return None
+    return index
+
+
+def _format_number(value: float) -> str:
+    """A short, human-readable spelling of an axis position for a label."""
+    return f"{value:g}"
+
+
+def _dropped_note(dropped: int, total: int) -> str:
+    return (
+        f"{dropped} of {total} rows are not shown: their axis readings did not land "
+        "on a grid point."
+    )
+
+
+def _thinned_note() -> str:
+    return "Lines are thinned to a fixed number of points for display."
+
+
+def _lines_mark(series: list[Series]) -> LinesMark:
+    """A `LinesMark` carrying *series*, with the aggregate truth filled in.
+
+    Nothing cross-validates mark-level ``decimated``/``source_points`` against
+    the series', so summing them here is the one place it happens.
+    """
+    return LinesMark(
+        series=series,
+        decimated=any(entry.decimated for entry in series),
+        source_points=sum(entry.source_points for entry in series),
+    )
+
+
+def _one_axis_panels(rows: list[dict[str, Any]], params: PARAMS) -> list[Panel]:
+    """One detector-versus-setpoint line panel per detector.
+
+    ``snake_axes`` is a no-op with a single axis (there is no outer axis to
+    snake against), so the sweep is one monotone pass and the panel is one line.
+    Points are drawn against the axis *readback*, not its commanded position:
+    with only one dimension there is no cell to key, so the honest x is the
+    value the device actually reported.
+    """
+    axis = params.axes[0]
+    axis_column = _resolve_column(rows, axis.setpoint)
+    if axis_column is None:
+        return []
+
+    panels: list[Panel] = []
+    for detector in params.detectors:
+        detector_column = _resolve_column(rows, detector)
+        if detector_column is None:
+            continue
+
+        points: list[Point] = []
+        dropped = 0
+        for row in rows:
+            x = _numeric(row.get(axis_column))
+            if x is None:
+                dropped += 1
+                continue
+            points.append(Point(x=x, y=_numeric(row.get(detector_column))))
+        points.sort(key=lambda point: point.x)
+
+        kept = decimate(points)
+        annotations: list[str] = []
+        if dropped:
+            annotations.append(_dropped_note(dropped, len(rows)))
+        if kept.decimated:
+            annotations.append(_thinned_note())
+
+        panels.append(
+            Panel(
+                title=f"{detector} vs {axis.setpoint}",
+                x_label=axis.setpoint,
+                y_label=detector,
+                annotations=annotations,
+                mark=_lines_mark([Series(label=detector, **kept._asdict())]),
+            )
+        )
+    return panels
+
+
+def _two_axis_panels(rows: list[dict[str, Any]], params: PARAMS) -> list[Panel]:
+    """One heatmap panel per detector over the two-axis grid.
+
+    The inner (fast) axis runs along x and the outer (slow) axis along y, the
+    orientation bluesky's own ``LiveGrid`` uses, so a snaked scan fills the
+    image row by row. Cells are keyed by grid *index* (see `_grid_index`), which
+    is what makes a snaked run and a monodirectional one produce the same
+    image: traversal order never reaches the cell key. A cell measured twice
+    keeps the later row, and a cell never measured stays ``None`` -- drawn
+    empty, not as a zero the run never read.
+    """
+    outer, inner = params.axes[0], params.axes[1]
+    outer_column = _resolve_column(rows, outer.setpoint)
+    inner_column = _resolve_column(rows, inner.setpoint)
+    if outer_column is None or inner_column is None:
+        return []
+
+    outer_step, inner_step = _axis_step(outer), _axis_step(inner)
+    y_labels = [_format_number(outer.start + j * outer_step) for j in range(outer.num_points)]
+    x_labels = [_format_number(inner.start + i * inner_step) for i in range(inner.num_points)]
+
+    panels: list[Panel] = []
+    for detector in params.detectors:
+        detector_column = _resolve_column(rows, detector)
+        if detector_column is None:
+            continue
+
+        cells: dict[tuple[int, int], float | None] = {}
+        dropped = 0
+        for row in rows:
+            outer_value = _numeric(row.get(outer_column))
+            inner_value = _numeric(row.get(inner_column))
+            j = None if outer_value is None else _grid_index(outer, outer_value)
+            i = None if inner_value is None else _grid_index(inner, inner_value)
+            if j is None or i is None:
+                dropped += 1
+                continue
+            cells[(j, i)] = _numeric(row.get(detector_column))
+
+        values: list[list[float | None]] = [
+            [cells.get((j, i)) for i in range(inner.num_points)] for j in range(outer.num_points)
+        ]
+        annotations = [_dropped_note(dropped, len(rows))] if dropped else []
+
+        panels.append(
+            Panel(
+                title=f"{detector} over the {outer.setpoint} × {inner.setpoint} grid",
+                x_label=inner.setpoint,
+                y_label=outer.setpoint,
+                annotations=annotations,
+                mark=HeatmapMark(
+                    x_labels=x_labels,
+                    y_labels=y_labels,
+                    values=values,
+                    value_label=detector,
+                    source_points=len(cells),
+                ),
+            )
+        )
+    return panels
+
+
+def _combination_label(axes: list[GridAxis], indices: tuple[int, ...]) -> str:
+    """``"m1=0.5, m2=2"`` -- an outer-axis combination named by grid position.
+
+    The commanded positions, not the readbacks: two rows in the same series
+    have slightly different readbacks and only one label between them.
+    """
+    return ", ".join(
+        f"{axis.setpoint}={_format_number(axis.start + index * _axis_step(axis))}"
+        for axis, index in zip(axes, indices, strict=True)
+    )
+
+
+def _multi_axis_panels(rows: list[dict[str, Any]], params: PARAMS) -> list[Panel]:
+    """One panel per detector: lines along the innermost axis.
+
+    A 3-D grid has no honest single picture, so this draws the scan the way it
+    was run -- one line per pass along the fast axis -- and names each line by
+    where the outer axes were parked for it. Lines are ordered by outer grid
+    index (never by arrival), so the legend reads the same for a partial run as
+    for the finished one, and capped at `_MAX_SERIES` with the excess counted
+    in an annotation rather than quietly missing.
+    """
+    inner = params.axes[-1]
+    outer_axes = params.axes[:-1]
+    inner_column = _resolve_column(rows, inner.setpoint)
+    resolved = [_resolve_column(rows, axis.setpoint) for axis in outer_axes]
+    if inner_column is None or any(column is None for column in resolved):
+        return []
+    outer_columns = [column for column in resolved if column is not None]
+
+    panels: list[Panel] = []
+    for detector in params.detectors:
+        detector_column = _resolve_column(rows, detector)
+        if detector_column is None:
+            continue
+
+        groups: dict[tuple[int, ...], list[Point]] = {}
+        dropped = 0
+        for row in rows:
+            x = _numeric(row.get(inner_column))
+            indices: list[int] = []
+            for axis, column in zip(outer_axes, outer_columns, strict=True):
+                value = _numeric(row.get(column))
+                index = None if value is None else _grid_index(axis, value)
+                if index is None:
+                    break
+                indices.append(index)
+            if x is None or len(indices) != len(outer_axes):
+                dropped += 1
+                continue
+            groups.setdefault(tuple(indices), []).append(
+                Point(x=x, y=_numeric(row.get(detector_column)))
+            )
+
+        ordered = sorted(groups.items())
+        series: list[Series] = []
+        for combination, points in ordered[:_MAX_SERIES]:
+            points.sort(key=lambda point: point.x)
+            kept = decimate(points)
+            series.append(
+                Series(label=_combination_label(outer_axes, combination), **kept._asdict())
+            )
+
+        annotations = []
+        if dropped:
+            annotations.append(_dropped_note(dropped, len(rows)))
+        if len(ordered) > _MAX_SERIES:
+            annotations.append(
+                f"Showing {_MAX_SERIES} of {len(ordered)} combinations of the outer axes; "
+                "the rest are not drawn."
+            )
+        if any(entry.decimated for entry in series):
+            annotations.append(_thinned_note())
+
+        panels.append(
+            Panel(
+                title=f"{detector} vs {inner.setpoint}",
+                x_label=inner.setpoint,
+                y_label=detector,
+                annotations=annotations,
+                mark=_lines_mark(series),
+            )
+        )
+    return panels
+
+
+def render(rows: list[dict[str, Any]], params: PARAMS) -> Figure:
+    """Draw a grid scan's rows: lines for 1-D, a heatmap for 2-D, lines above.
+
+    Args:
+        rows: The run's rows so far, one dict per grid point, keyed by event
+            column (the shared row adapter's output). May be a partial run, or
+            empty.
+        params: The parameters the run was launched with, which is where the
+            grid geometry -- and therefore every cell index and axis label --
+            comes from.
+
+    Returns:
+        A `Figure` with one panel per detector, or no panels at all when the
+        rows carry nothing this plan can place on a grid. ``partial`` and
+        ``source`` are placeholders: the figure route knows which store the
+        rows came from and whether the run is still producing them, and stamps
+        both onto the returned figure. ``partial=True`` is the safe standing
+        value -- a panel that keeps polling a settled run costs a request,
+        while one that stops polling a live run shows a half-finished scan and
+        calls it the whole thing.
+
+    Never raises. A malformed row, a device that never reported, a column the
+    scan did not record: each costs at most the panel it belonged to, and an
+    unforeseen failure costs the panels but still returns a figure, because the
+    alternative is an operator watching a running scan see an error where the
+    picture should be.
+    """
+    panels: list[Panel] = []
+    try:
+        if len(params.axes) == 1:
+            panels = _one_axis_panels(rows, params)
+        elif len(params.axes) == 2:
+            panels = _two_axis_panels(rows, params)
+        else:
+            panels = _multi_axis_panels(rows, params)
+    except Exception:
+        logger.warning("grid_scan render failed; serving an empty figure", exc_info=True)
+        panels = []
+    return Figure(panels=panels, partial=True, source="live")
+
+
+_RENDER_CONFORMANCE: Callable[[list[dict[str, Any]], PARAMS], Figure] = render
+"""Binds `render` to the signature `PlanSpec.render` declares, so a drifting
+annotation is a type error here rather than a surprise in the figure route.
+`PlanSpec` is generic over its params model but the loader holds
+``PlanSpec[Any]``, which makes a module-level ``render`` invisible to mypy
+unless the module says what it should be -- this is the module saying it."""

--- a/src/osprey/services/bluesky_bridge/plans_core/orm.py
+++ b/src/osprey/services/bluesky_bridge/plans_core/orm.py
@@ -13,11 +13,34 @@ facility PV or a fixed device set.
 from __future__ import annotations
 
 import logging
+import math
+from collections.abc import Callable
 from typing import Any, Literal
 
 from bluesky import plan_stubs as bps
 from bluesky import preprocessors as bpp
 from pydantic import BaseModel, Field, model_validator
+
+# Absolute imports, not relative: the plan loader execs this file by path under
+# a synthetic `sys.modules` name with no parent package (see
+# `plan_loader._load_plan_module_from_path`), so a relative import raises at
+# load time and quarantines the plan.
+from osprey.services.bluesky_bridge.figure import (
+    BarsMark,
+    Figure,
+    HeatmapMark,
+    LinesMark,
+    Panel,
+    Point,
+    Series,
+    decimate,
+)
+from osprey.services.bluesky_bridge.orm_analysis import (
+    SlicedResponseFit,
+    column_anomaly,
+    row_anomaly,
+    sliced_response_matrix,
+)
 
 logger = logging.getLogger("osprey.services.bluesky_bridge.plans_core.orm")
 
@@ -141,3 +164,273 @@ def build_plan(devices: dict[str, Any], params: PARAMS) -> Any:
                     )
 
     return _sweep()
+
+
+# --- Live view ---------------------------------------------------------------
+#
+# `render()` runs in the bridge API process on every poll tick of every client
+# watching an `orm` run, over the run's FULL stored row set. Everything below
+# is sized for that: one vectorized fit (`sliced_response_matrix`), no per-row
+# Python scan, and hard caps on how much of a facility-scale run reaches the
+# wire.
+
+_LIVE_BUFFER_ROW_CAP = 10_000
+"""Mirror of the bridge live buffer's per-run row cap.
+
+`render()` is handed rows with no word on where they came from or whether they
+are all of them, so it recognizes a capped buffer arithmetically: the buffer
+stores exactly this many rows and then stops (`live_rows._MAX_ROWS_PER_RUN`),
+so a row set of exactly this length for a sweep that should have produced more
+is a run whose stored rows are a strict subset of what it measured. This module
+cannot import that private constant -- a facility-authored plan could not
+either, and the loader execs plan files outside the package -- so the value is
+duplicated here and pinned equal by `test_orm_render.py`, which fails on drift
+rather than letting a stale copy silently mis-shape a figure.
+"""
+
+_MAX_TRACE_PANELS = 8
+"""Most corrector sweeps drawn as trace panels. A 70-corrector run is 70 panels
+of 100 lines each -- neither the browser nor the agent's context can take it."""
+
+_MAX_TRACE_SERIES = 12
+"""Most BPM traces per sweep panel. The first N in the requested order, not the
+N largest: series identity has to stay stable from tick to tick, and a
+"largest" selection would swap lines in and out as the sweep fills in."""
+
+
+def _sweep_series(fit: SlicedResponseFit, index: int) -> tuple[list[Series], bool, int, int]:
+    """Corrector *index*'s BPM traces: series, decimated, points, samples drawn.
+
+    A sample whose corrector current is non-finite is dropped -- there is no
+    place on the x axis for a point with no x (and `Point.x` rejects it) --
+    while a non-finite BPM reading is kept and becomes a drawn gap. The last
+    element is how many samples survived that, which is what tells a caller
+    whether this corrector reported a current at all.
+    """
+    currents = fit.currents[index]
+    readings = fit.readings[index]
+    kept = [k for k, current in enumerate(currents) if math.isfinite(float(current))]
+
+    series: list[Series] = []
+    decimated = False
+    source_points = 0
+    for i, detector in enumerate(fit.detectors[:_MAX_TRACE_SERIES]):
+        points = [Point(x=float(currents[k]), y=float(readings[k, i])) for k in kept]
+        thinned = decimate(points)
+        series.append(Series(label=detector, **thinned._asdict()))
+        decimated = decimated or thinned.decimated
+        source_points += thinned.source_points
+    return series, decimated, source_points, len(kept)
+
+
+def _trace_panels(fit: SlicedResponseFit, num: int, lead_annotations: list[str]) -> list[Panel]:
+    """One panel per traced corrector: BPM readings against that corrector's current.
+
+    A corrector that has recorded no current yet -- the sweep has not reached
+    it, or the run's rows never carried that device -- gets no panel at all; an
+    empty plot says less than no plot. Past `_MAX_TRACE_PANELS` the *most
+    recently swept* correctors are kept, not the first: the plan sweeps in
+    order, so the tail is where a live run's in-flight sweep is, and a settled
+    run's tail is as arbitrary a choice as its head.
+    """
+    traced = [j for j in range(len(fit.correctors)) if fit.currents[j].size]
+    hidden = max(0, len(traced) - _MAX_TRACE_PANELS)
+    if hidden:
+        traced = traced[-_MAX_TRACE_PANELS:]
+    shown_detectors = min(len(fit.detectors), _MAX_TRACE_SERIES)
+
+    panels: list[Panel] = []
+    for j in traced:
+        series, decimated, source_points, samples = _sweep_series(fit, j)
+        if not samples:
+            continue
+
+        annotations: list[str] = []
+        if not panels:
+            annotations.extend(lead_annotations)
+            if hidden:
+                annotations.append(
+                    f"Showing the {len(traced)} most recently swept of "
+                    f"{len(fit.correctors)} correctors."
+                )
+        if shown_detectors < len(fit.detectors):
+            annotations.append(f"Showing the first {shown_detectors} of {len(fit.detectors)} BPMs.")
+        if not fit.complete[j]:
+            recorded = int(fit.currents[j].shape[0])
+            if recorded < num:
+                annotations.append(
+                    f"This sweep is still in flight: {recorded} of {num} points "
+                    "recorded, so no response is fitted for it yet."
+                )
+            else:
+                annotations.append(
+                    "This corrector's recorded currents never moved, so no "
+                    "response could be fitted for it."
+                )
+        panels.append(
+            Panel(
+                title=f"{fit.correctors[j]} sweep",
+                x_label="Corrector current",
+                x_units="A",
+                y_label="BPM reading",
+                annotations=annotations,
+                mark=LinesMark(series=series, decimated=decimated, source_points=source_points),
+            )
+        )
+    return panels
+
+
+def _fit_panels(fit: SlicedResponseFit) -> list[Panel]:
+    """The response matrix and its two model-free anomaly views.
+
+    Only completed sweeps have columns, so the heatmap's x axis is
+    `fitted_correctors` (a subsequence of the requested correctors) and says so
+    when the two differ -- an in-flight corrector must not read as a dead one.
+    """
+    incomplete = len(fit.correctors) - len(fit.fitted_correctors)
+    matrix_note = (
+        [
+            f"{len(fit.fitted_correctors)} of {len(fit.correctors)} corrector sweeps "
+            "have completed; only those have a column here."
+        ]
+        if incomplete
+        else []
+    )
+
+    return [
+        Panel(
+            title="Response matrix",
+            x_label="Corrector",
+            y_label="BPM",
+            annotations=matrix_note,
+            mark=HeatmapMark(
+                x_labels=list(fit.fitted_correctors),
+                y_labels=list(fit.detectors),
+                values=[[float(cell) for cell in row] for row in fit.matrix],
+                value_label="Response slope",
+                value_units="BPM units / A",
+                source_points=int(fit.matrix.size),
+            ),
+        ),
+        Panel(
+            title="Corrector anomaly score",
+            x_label="Corrector",
+            y_label="Anomaly score",
+            annotations=[
+                "Each corrector's column scored against the median of its peers "
+                "-- higher is more unlike the rest of the machine."
+            ],
+            mark=BarsMark(
+                label="Corrector anomaly",
+                categories=list(fit.fitted_correctors),
+                values=[float(score) for score in column_anomaly(fit.matrix)],
+                source_points=len(fit.fitted_correctors),
+            ),
+        ),
+        Panel(
+            title="BPM anomaly score",
+            x_label="BPM",
+            y_label="Anomaly score",
+            annotations=[
+                "Each BPM's row scored against the median of its peers -- "
+                "higher is more unlike the rest of the machine."
+            ],
+            mark=BarsMark(
+                label="BPM anomaly",
+                categories=list(fit.detectors),
+                values=[float(score) for score in row_anomaly(fit.matrix)],
+                source_points=len(fit.detectors),
+            ),
+        ),
+    ]
+
+
+def _build(rows: list[dict[str, Any]], params: PARAMS, *, with_fit: bool) -> Figure:
+    """Assemble the figure. Raises freely -- `render` is what must not."""
+    expected_rows = len(params.correctors) * params.num
+    capped = len(rows) == _LIVE_BUFFER_ROW_CAP and expected_rows > _LIVE_BUFFER_ROW_CAP
+
+    fit = sliced_response_matrix(rows, params.correctors, params.detectors, params.num)
+
+    lead_annotations: list[str] = []
+    if capped:
+        lead_annotations.append(
+            f"This run produced more rows than the bridge stores per run "
+            f"({_LIVE_BUFFER_ROW_CAP:,} of about {expected_rows:,} expected), so the "
+            "response matrix and anomaly scores are not shown -- they would be "
+            "computed over whichever correctors happened to fit under the cap, and "
+            "an anomaly score compares each corrector against its peers."
+        )
+
+    panels = _trace_panels(fit, params.num, lead_annotations)
+    if with_fit and not capped and fit.fitted_correctors:
+        panels.extend(_fit_panels(fit))
+
+    # Placeholders: the figure route stamps the truth onto both on every path.
+    # A render sees rows, never their provenance, so `partial=True` is the
+    # honest direction for a forgotten overwrite -- extra polling, never a
+    # false "settled".
+    return Figure(panels=panels, partial=True, source="live")
+
+
+def render(rows: list[dict[str, Any]], params: PARAMS) -> Figure:
+    """The `orm` plan's own view of a run: sweep traces, then the fitted matrix.
+
+    Panel order is stable, so a live figure grows rather than rearranging:
+
+    1. One **sweep trace** panel per corrector that has recorded a point --
+       every BPM reading against that corrector's own current. These always
+       appear, for a `monodirectional` sweep as readily as a `bidirectional`
+       one and for a run three points in as readily as a finished one.
+    2. Once at least one corrector's sweep has completed, the **response
+       matrix** heatmap (BPMs against correctors, labelled with the real device
+       names), then the **corrector** and **BPM anomaly score** bars from
+       `orm_analysis`'s peer-structure detectors.
+
+    Rows are attributed to correctors by acquisition index -- corrector ``j``'s
+    samples are ``rows[j * num : (j + 1) * num]``, which is what this plan's
+    `build_plan` emits -- so the caller owes emission order with nothing dropped
+    from the front. The one incompleteness this function can see for itself is
+    a **capped row set**: exactly `_LIVE_BUFFER_ROW_CAP` rows for a sweep whose
+    parameters call for more. There the traces still stand (each is a claim
+    about individual rows) but the matrix and anomaly panels are suppressed,
+    because a peer-comparison score computed over whichever correctors fit
+    under the cap is a statement about the cap, not about the machine. An
+    annotation on the first panel says so.
+
+    **Never raises.** A figure is a view, not a result: any internal failure
+    degrades to the traces alone, and a failure in those to a figure with no
+    panels, so the route always has something to serve.
+
+    **`partial` and `source` are placeholders the route overwrites.** This
+    function sees rows, not their provenance, so it returns ``partial=True,
+    source="live"`` unconditionally and the figure route stamps the truth onto
+    both on every path. ``True`` is the honest direction for the placeholder: a
+    forgotten overwrite costs a client extra polling, never a false "settled".
+
+    Args:
+        rows: The run's event `data` dicts in emission order -- the run's whole
+            stored set, never a window of it.
+        params: The parameters the run was launched with.
+
+    Returns:
+        A `Figure` whose panels are as complete as the rows allow.
+    """
+    try:
+        return _build(rows, params, with_fit=True)
+    except Exception:
+        logger.warning("orm render failed; falling back to sweep traces only", exc_info=True)
+    try:
+        return _build(rows, params, with_fit=False)
+    except Exception:
+        logger.warning("orm render failed entirely; serving an empty figure", exc_info=True)
+        return Figure(panels=[], partial=True, source="live")
+
+
+_RENDER_CONFORMANCE: Callable[[list[dict[str, Any]], PARAMS], Figure] = render
+"""Static proof that `render` matches `PlanSpec.render`'s signature.
+
+The loader holds `PlanSpec[Any]`, so a module-level `render` is not type-checked
+by merely existing (see `plan_loader._resolve_render`); this binding is what
+makes mypy check it here, where the mistake would be made.
+"""

--- a/src/osprey/services/bluesky_bridge/queue.py
+++ b/src/osprey/services/bluesky_bridge/queue.py
@@ -86,6 +86,7 @@ from pydantic import BaseModel, Field
 
 from . import document_plane, draft, runs
 from .queue_backend import (
+    PLAN_META_KEY,
     REASON_MANAGER_NOT_CONFIGURED,
     REASON_MANAGER_UNREACHABLE,
     AbortPauseTimeoutError,
@@ -647,6 +648,30 @@ def _with_progress(running_item: Any) -> Any:
     return {**running_item, "progress": progress}
 
 
+def _public_item(item: Any) -> Any:
+    """One queue item as the bridge relays it: the plan-identity stamp removed.
+
+    The enqueue path stamps the plan's own name and kwargs into the item's
+    metadata (`queue_backend.PLAN_META_KEY`) so that a run's figure can be
+    rendered as the plan it was, from the run's start document alone. On a
+    queue READ that stamp is pure duplication — the item already carries its
+    ``name`` and ``kwargs`` at top level — and the queue is the one surface
+    panels both poll and stream continuously, so it is dropped here rather
+    than doubling every item's params on every frame.
+
+    Only that key goes. ``RUN_ID_META_KEY`` stays, because it is what joins a
+    queue row to its run (`itemRunId()` in `queue-client.js` reads it), and
+    any other metadata is somebody else's — an item enqueued out of band
+    passes through untouched.
+    """
+    if not isinstance(item, dict):
+        return item
+    meta = item.get("meta")
+    if not isinstance(meta, dict) or PLAN_META_KEY not in meta:
+        return item
+    return {**item, "meta": {key: value for key, value in meta.items() if key != PLAN_META_KEY}}
+
+
 async def _frame_from(summary: dict[str, Any], frame_type: str) -> dict[str, Any]:
     """A full snapshot frame: summary plus the current items, freshly fetched."""
     items: list[Any] = []
@@ -654,8 +679,8 @@ async def _frame_from(summary: dict[str, Any], frame_type: str) -> dict[str, Any
     if summary.get("available"):
         try:
             queue_state = await _get_backend().items()
-            items = list(queue_state.get("items") or [])
-            running_item = _with_progress(queue_state.get("running_item"))
+            items = [_public_item(item) for item in (queue_state.get("items") or [])]
+            running_item = _public_item(_with_progress(queue_state.get("running_item")))
         except QueueBackendError as exc:  # pragma: no cover - narrow race
             logger.debug("queue item fetch failed after a good status read: %s", exc)
     return {"type": frame_type, "status": summary, "items": items, "running_item": running_item}
@@ -802,7 +827,12 @@ class StartRequestBody(BaseModel):
 
 @router.get("/queue")
 async def get_queue() -> dict[str, Any]:
-    """The queue as the manager holds it: pending items, running item, status summary."""
+    """The queue as the manager holds it: pending items, running item, status summary.
+
+    Items are relayed through `_public_item`, which drops the enqueue path's
+    plan-identity stamp — it duplicates the item's own name and kwargs, and
+    the run id panels join on rides through untouched.
+    """
     backend = _get_backend()
     try:
         status = await backend.status()
@@ -811,8 +841,8 @@ async def get_queue() -> dict[str, Any]:
         raise _http_error(exc) from exc
     return {
         "status": _status_summary(status),
-        "items": list(queue_state.get("items") or []),
-        "running_item": _with_progress(queue_state.get("running_item")),
+        "items": [_public_item(item) for item in (queue_state.get("items") or [])],
+        "running_item": _public_item(_with_progress(queue_state.get("running_item"))),
     }
 
 

--- a/src/osprey/services/bluesky_bridge/queue_backend.py
+++ b/src/osprey/services/bluesky_bridge/queue_backend.py
@@ -68,6 +68,12 @@ QSERVER_PUBLIC_KEY_ENV = "QSERVER_ZMQ_PUBLIC_KEY"
 # are matched back to the run the operator enqueued.
 RUN_ID_META_KEY = "osprey_run_id"
 
+# The item-metadata key carrying the plan's own identity — its name and the
+# kwargs it was enqueued with — along the same path. Start documents are the
+# only place a completed run's plan identity survives into Tiled, so this stamp
+# is what lets results be rendered as the plan the operator actually asked for.
+PLAN_META_KEY = "osprey_plan"
+
 # Manager states in which a plan is under way (or about to be). Enqueuing during
 # one of these is an armed operation — the item joins a queue that is already
 # draining toward hardware — so the route layer gates it behind the launch
@@ -405,6 +411,10 @@ class QueueBackend:
     ) -> dict[str, Any]:
         """Append (or insert) one item into the queue.
 
+        When a run id is given, the item also carries the plan's identity — its
+        name and kwargs — under :data:`PLAN_META_KEY`, so a finished run can be
+        rendered as the plan it was without consulting the queue.
+
         Args:
             item: A queueserver item — a plain dict, or a ``BItem``/``BPlan``.
             run_id: OSPREY's run id for this item. Threaded through the item's
@@ -423,6 +433,10 @@ class QueueBackend:
         if run_id is not None:
             meta = dict(payload.get("meta") or {})
             meta[RUN_ID_META_KEY] = run_id
+            meta[PLAN_META_KEY] = {
+                "name": payload.get("name"),
+                "kwargs": dict(payload.get("kwargs") or {}),
+            }
             payload["meta"] = meta
 
         kwargs: dict[str, Any] = {"item": payload}

--- a/src/osprey/templates/claude_code/claude/skills/operating-bluesky-scans/SKILL.md
+++ b/src/osprey/templates/claude_code/claude/skills/operating-bluesky-scans/SKILL.md
@@ -122,7 +122,8 @@ This queues exactly the draft the human can see in their plan panel at that
 revision — never anything you pass here — and then stops. It is the agent
 analog of the plan panel's *Add to queue* button. On success it returns
 `{run_id, revision, item}`: `run_id` is OSPREY's id for the eventual run (use
-it with `get_run` / `get_run_data`), and `item.item_uid` is the queue handle.
+it with `get_run` / `get_run_data` / `get_run_figure`), and `item.item_uid` is
+the queue handle.
 
 **A revision is consumable exactly once.** Queuing the same plan again — a
 repeat scan, a retry — needs a `set_draft` edit to mint a new revision first;
@@ -301,6 +302,17 @@ A running queue is live hardware — never fire-and-forget. Watch it:
   run's rows; `partial: true` means the run is still producing data. Never
   returns an unbounded table. A run rotated out of the manager's history still
   has its data, so a 404 from `get_run` is never a reason to skip reading here.
+- **`get_run_figure(run_id)`** — the run's figure: the plan's own view of what
+  it measured, as data rather than pixels. It comes back as panels, each with a
+  title, axis labels and units, `annotations` worth relaying, and exactly one
+  mark — `lines`, `bars`, `heatmap`, or a `heatmap_summary` standing in for a
+  grid too large to send as cells. The whole figure is point-bounded, so a
+  200k-row run and a 20-row run cost the same to read; **the tool's own
+  docstring states the bounds and the mark vocabulary in full** — read them
+  there rather than assuming numbers. This is the same figure the human's
+  BLUESKY panel is drawing, which is what lets you and them discuss one
+  picture. A run that has rotated out of the manager's history still has a
+  figure, so a 404 from `get_run` is never a reason to skip it.
 - **`list_runs()`** — recent runs, newest first, same record shape as
   `get_run`. It covers what OSPREY enqueued; an item queued by some other
   route has no OSPREY run id and is absent from it, so `queue_list` is the
@@ -312,6 +324,46 @@ far" — never as 0%.
 
 Results land in the queue panel as the run produces them, so the human watches
 alongside the agent.
+
+### Narrating a figure
+
+**A `reason` is a default view, never an error.** `reason: null` means the plan
+drew the figure itself. Any other value means the bridge drew its **default
+view** instead — every numeric column the run recorded, against the scan's own
+x axis. That is real data, honestly plotted, so say "the default view, because
+<the reason in plain words>" and never "the figure failed". `no_render` in
+particular means the plan declares no view of its own, so the default view **is**
+that plan's view — there is nothing wrong to report. The vocabulary is open:
+a reason you do not recognize is still a default view, so relay it verbatim
+rather than guessing at it.
+
+The rest of the reading rules:
+
+- **`source_unavailable` is the one reason that comes with empty panels**, and
+  it means "the rows could not be read", never "the run recorded nothing".
+  Offer `get_run_data` as the second opinion.
+- **`partial: true` means the run was still producing rows** when the figure
+  was drawn — read it again rather than calling it final.
+- **`source` says which store answered** — `live` (the bridge's own buffer) or
+  `tiled` (durable storage) — not how good the data is.
+- **A decimated series was thinned, not cut short.** Say "N of `source_points`
+  points shown"; never report the returned count as how many points the run
+  took.
+- **A `null` value is a gap, never a zero — and never a count.** On a thinned
+  series one null can stand for a whole stretch of missing readings, and it
+  sits where the gap was rather than spanning how long it lasted. Read nulls as
+  "there were gaps here" and never say how many readings were missed.
+- **`heatmap_summary` is lossy and says so.** Its `x_labels`/`y_labels` are
+  `{count, first, last}` objects — the axis vocabulary and its ends, not the
+  label lists a `heatmap` mark carries — and `largest_magnitude` holds the
+  cells with the biggest absolute value: the strongest readings, **not** an
+  outlier test. **Do not call them anomalies** — the `orm` plan draws its own
+  anomaly-score panels, scored against peer devices, and blurring the two
+  misreports the machine. Never state a cell value the summary does not
+  contain; if one specific cell matters, read it with `get_run_data`.
+- **Relay a panel's `annotations`.** They name what the panel does *not* show —
+  a cap, dropped rows, series left out — and are the honest half of the
+  picture.
 
 ---
 
@@ -389,7 +441,13 @@ know why it was requested.
 - **Never** call `queue_start` without reading `queue_list` first — start
   drains the whole queue, including items you did not add.
 - **Never** treat a started queue as fire-and-forget — it drives real
-  hardware; watch it with `queue_list`/`get_run`/`get_run_data`.
+  hardware; watch it with `queue_list`/`get_run`/`get_run_data`/`get_run_figure`.
+- **Never** report a figure's `reason` as a failure — it says the bridge drew
+  the default view, which is real data, and `no_render` means that view is the
+  plan's own.
+- **Never** call a `heatmap_summary`'s `largest_magnitude` cells anomalies —
+  they are the strongest readings, and the `orm` plan ships real anomaly-score
+  panels that would be contradicted by saying otherwise.
 - **Never** let "stop" cover both halts — `queue_stop` halts the queue after
   the running item, `stop_run` aborts the item already in motion. Name which
   one you mean.

--- a/src/osprey/templates/claude_code/claude/skills/writing-bluesky-plans/SKILL.md
+++ b/src/osprey/templates/claude_code/claude/skills/writing-bluesky-plans/SKILL.md
@@ -22,7 +22,8 @@ run directly.
 
 ## The plan-file format
 
-A plan file is a single Python module exposing exactly three things:
+A plan file is a single Python module exposing three required things (plus one
+optional fourth, `render` — see *The plan's own view* below):
 
 1. **`PLAN_METADATA`** — a plain dict with five required keys, all required
    (a plan missing one is rejected at load time, not defaulted):
@@ -106,6 +107,13 @@ any of which can reject it outright before the next ever runs:
      `itertools`, `functools`, `pydantic`, `typing`, and `logging`
      (except `logging.config` and `logging.handlers`, which are denied —
      they resolve callables by string, an import-by-string bypass).
+   - Exactly two OSPREY modules, both spelled in full and imported
+     absolutely: `osprey.services.bluesky_bridge.figure` (the figure
+     vocabulary an optional `render()` returns) and
+     `osprey.services.bluesky_bridge.orm_analysis` (the numeric helpers
+     behind the `orm` plan's own view). Both are inert — models and numeric
+     code, no I/O and no control system. Bare `import osprey` and every other
+     `osprey.*` module are rejected.
    - Everything else (`epics`, `os`, `subprocess`, `ctypes`, `importlib`,
      `socket`, ...) is rejected.
 2. **CA/connector pattern scan** — rejects any body matching `caput(`,
@@ -128,6 +136,70 @@ step, status update, or stop request can be serviced until it returns.
 cooperatively, so the run stays responsive. `time` is on the import
 allowlist for ordinary bookkeeping (computing a delay, timestamping) — it is
 never a substitute for `bps.sleep` inside a plan's own control flow.
+
+---
+
+## The plan's own view: `render(rows, params)`
+
+A plan file may expose one optional extra: a module-level
+
+```python
+def render(rows: list[dict[str, Any]], params: PARAMS) -> Figure:
+```
+
+`rows` are the run's event `data` dicts in emission order, `params` are the
+parameters the run was launched with, and the return value is a `Figure` from
+`osprey.services.bluesky_bridge.figure` — a list of `Panel`s, each carrying a
+title, axis labels and units, `annotations` (short sentences saying what the
+panel does *not* show), and exactly **one** mark: `LinesMark` (named x/y
+series), `BarsMark` (one value per named category), or `HeatmapMark` (a
+labelled 2-D grid). A panel showing two things is two panels. The bridge serves
+that figure from `GET /runs/{id}/figure`, the operator's BLUESKY panel draws
+it, and `get_run_figure` reads it — one view, three places.
+
+Import the figure vocabulary **absolutely**, never relatively: plan files are
+loaded by path with no parent package, so `from ..figure import ...` fails at
+load time and takes the plan out of the catalog with it.
+
+```python
+from osprey.services.bluesky_bridge.figure import Figure, LinesMark, Panel, Point, Series
+```
+
+**A plan with no `render` is complete and ordinary.** Watchers then see the
+bridge's **default view** — every numeric column the run recorded, plotted
+against the scan's own x axis — carrying the reason `no_render`. That is a real
+view of real data, not a missing one, so `render()` is worth writing only when
+the plan can say something the columns cannot say for themselves.
+
+Four rules govern one:
+
+- **`render()` must never raise.** A figure is a view, not a result. If it
+  raises — or returns anything other than a `Figure` — the run's data is
+  untouched and the bridge quietly serves the default view with the reason
+  `render_failed`, but the plan's own view is gone for everyone watching until
+  the code is fixed. Write it to degrade instead: guard the parts that can
+  fail, drop a panel rather than the figure, and return the panels that still
+  stand.
+- **Stay facility-neutral.** Label panels from `params` and the row keys — the
+  device names the run actually used — exactly as `build_plan` resolves its
+  devices by string name. Never hard-code a facility's device names, PV
+  strings, or a fixed device count in the drawing code.
+- **`partial` and `source` are placeholders.** `render()` sees rows, not where
+  they came from, so set them to anything (the exemplar returns
+  `partial=True, source="live"`) and let the route stamp the truth onto both.
+- **A session-tier `render()` is never run.** It would run in the bridge's own
+  process on every poll of every watching client, so it is honored only for
+  plans from the reviewed, installed tiers — shipped, preset and facility. A
+  session-tier file that declares one still loads, queues, runs and records
+  data exactly as it would otherwise; only the drawing is skipped, and
+  watchers see the default view with the reason
+  `render_not_supported_for_session_plans`. Nothing about the execution
+  surface changes. So write `render()` when authoring for a facility library;
+  while a plan is session-tier, the default view is what everyone sees.
+
+`plans_core/orm.py`'s `render` is the worked pattern — sweep traces first, then
+the fitted matrix and its anomaly-score bars, with each stage guarded so a
+failure downgrades the figure instead of losing it.
 
 ---
 
@@ -172,7 +244,9 @@ never a substitute for `bps.sleep` inside a plan's own control flow.
    `detail.code` starts with `session_plan_` (`session_plan_unvalidated`,
    `session_plan_not_in_namespace`) means exactly one thing: re-validate the
    plan and try again. Use `get_run(run_id)` / `get_run_data(run_id, ...)` to
-   watch it. The `operating-bluesky-scans` skill covers this run flow in full
+   watch it, and `get_run_figure(run_id)` for the figure — the better watch for
+   a plan that ships a `render()`, and still a real view of the data for one
+   that does not. The `operating-bluesky-scans` skill covers this run flow in full
    — staging the complete configuration, the two-step add/start, refusal
    handling, and stopping.
 5. **Contribute to the permanent catalog** — a session plan stays
@@ -193,7 +267,10 @@ never a substitute for `bps.sleep` inside a plan's own control flow.
   only scan patterns this framework ships.
 - **Never** hard-code a facility device name inside `build_plan` — resolve
   every device by string name through the injected `devices` dict, exactly
-  like both exemplars.
+  like both exemplars. The same holds for `render()`: label its panels from
+  `params` and the row keys, never from a name written into the file.
+- **Never** let `render()` raise — guard what can fail and drop a panel
+  instead, or every watcher gets the default view in place of the plan's own.
 - **Never** treat a passing dry run as proof the plan is safe against real
   hardware — it proves the plan *runs*, not that its device motion is
   physically sound. Human approval at queue start is the real backstop.

--- a/tests/cli/test_operating_bluesky_scans_skill_install.py
+++ b/tests/cli/test_operating_bluesky_scans_skill_install.py
@@ -128,7 +128,7 @@ class TestOperatingBlueskyScansSkillStructure:
         assert "two steps" in lowered
 
     def test_documents_watch_tools(self, skill_text):
-        for tool in ("get_run", "get_run_data", "list_runs", "list_plans"):
+        for tool in ("get_run", "get_run_data", "get_run_figure", "list_runs", "list_plans"):
             assert tool in skill_text, f"Missing run tool: {tool}"
 
     # --- the choreography ---
@@ -286,6 +286,79 @@ class TestOperatingBlueskyScansStopHonesty:
                 f"the skill still carries pre-abort wording {retired!r} -- it now "
                 f"contradicts stop_run"
             )
+
+
+class TestOperatingBlueskyScansFigureNarration:
+    """Safety pins: how the skill tells an agent to read a run's figure.
+
+    A figure is the one read whose payload can be misread into a claim about
+    the machine. Each pin below guards a specific misreading that the
+    ``get_run_figure`` docstring already refuses to make, so the skill and the
+    tool cannot drift into telling an operator different stories:
+
+    * a ``reason`` is the bridge's default view, which is real data -- prose
+      that lets it read as a failure turns "this plan draws no view of its own"
+      into "the scan went wrong";
+    * a decimated series is thinned, not short, and a ``null`` is a gap rather
+      than a zero or a count of missed readings;
+    * a ``heatmap_summary``'s largest cells are the strongest readings, NOT an
+      outlier test -- the ``orm`` plan ships real anomaly-score panels, and
+      calling the summary's cells anomalies contradicts them.
+    """
+
+    @pytest.fixture()
+    def skill_text(self):
+        path = TEMPLATE_ROOT / "claude" / "skills" / "operating-bluesky-scans" / "SKILL.md"
+        return path.read_text(encoding="utf-8")
+
+    def test_documents_the_figure_read(self, skill_text):
+        """The mark vocabulary an agent dispatches on has to be named."""
+        assert "get_run_figure" in skill_text
+        for kind in ("lines", "bars", "heatmap", "heatmap_summary"):
+            assert kind in skill_text, f"Missing figure mark kind: {kind}"
+
+    def test_points_at_the_tool_for_the_bounds(self, skill_text):
+        """The projection's numbers live in the tool's docstring, which is the
+        agent-facing statement of them. Restating them here is how the two
+        drift into disagreeing about the budget."""
+        prose = _prose(skill_text)
+        assert "docstring states the bounds and the mark vocabulary in full" in prose
+        assert "2000" not in skill_text, "the point budget belongs to the tool, not to prose"
+
+    def test_a_reason_is_a_default_view_not_an_error(self, skill_text):
+        prose = _prose(skill_text)
+        assert "a reason is a default view, never an error" in prose
+        assert "no_render" in prose
+        assert "there is nothing wrong to report" in prose
+
+    def test_empty_panels_mean_unreadable_not_empty(self, skill_text):
+        """``source_unavailable`` is the only reason with no panels, and the
+        difference between "could not read" and "recorded nothing" is the
+        difference between a retry and a wrong conclusion about the run."""
+        prose = _prose(skill_text)
+        assert "source_unavailable" in prose
+        assert 'never "the run recorded nothing"' in prose
+
+    def test_partial_means_read_again(self, skill_text):
+        prose = _prose(skill_text)
+        assert "read it again rather than calling it final" in prose
+
+    def test_decimation_is_narrated_as_thinning(self, skill_text):
+        prose = _prose(skill_text)
+        assert "n of source_points points shown" in prose
+        assert "never report the returned count as how many points the run took" in prose
+
+    def test_nulls_are_gaps_never_zeros_or_counts(self, skill_text):
+        prose = _prose(skill_text)
+        assert "a null value is a gap, never a zero" in prose
+        assert "never say how many readings were missed" in prose
+
+    def test_heatmap_summary_cells_are_not_anomalies(self, skill_text):
+        """The pin that protects the ``orm`` plan's real anomaly panels."""
+        prose = _prose(skill_text)
+        assert "largest_magnitude" in prose
+        assert "do not call them anomalies" in prose
+        assert "never state a cell value the summary does not contain" in prose
 
 
 class TestOperatingBlueskyScansInstall:

--- a/tests/cli/test_writing_bluesky_plans_skill_install.py
+++ b/tests/cli/test_writing_bluesky_plans_skill_install.py
@@ -182,6 +182,53 @@ class TestWritingBlueskyPlansSkillStructure:
         assert "contribute" in skill_text.lower()
         assert "promote" not in skill_text.lower()
 
+    # --- the plan's own view ---
+
+    def test_documents_the_render_contract(self, skill_text):
+        """``render`` is optional, but the three things an author gets wrong
+        about it are not: its signature, that it must never raise, and that its
+        labels come from the run rather than from a facility."""
+        assert "render(rows, params)" in skill_text
+        prose = _prose(skill_text)
+        assert "render() must never raise" in prose
+        assert "render_failed" in skill_text
+        assert "stay facility-neutral" in prose
+
+    def test_documents_the_figure_vocabulary(self, skill_text):
+        """One panel carries exactly one mark; an author has to know which
+        three exist before choosing between them."""
+        for name in ("Figure", "Panel", "LinesMark", "BarsMark", "HeatmapMark"):
+            assert name in skill_text, f"Missing figure model: {name}"
+
+    def test_documents_the_osprey_modules_a_plan_may_import(self, skill_text):
+        """Keyed to the validator's own constant, and bidirectional.
+
+        Set equality rather than a membership loop: a loop catches a WIDENED
+        allowlist (a new module the prose never mentions) but not a narrowed
+        one, which would leave the skill telling authors to import something
+        the validator now rejects -- stale prose staying green. The dotted
+        ``osprey.*`` strings in this skill are exactly the allow-listed modules
+        (``_osprey_connector`` in the pattern-scan section has no dot and does
+        not match), so equality holds today and fails on drift in either
+        direction. It also pins the "Exactly two" claim in the prose without
+        asserting on that wording.
+        """
+        named = set(re.findall(r"osprey\.[\w.]*\w", skill_text))
+        assert named == set(plan_validation._ALLOWED_OSPREY_SUBMODULES)
+
+    def test_documents_the_session_tier_render_exclusion(self, skill_text):
+        """A session plan's ``render`` is never run -- and the reason an author
+        needs is that nothing about running the plan changes, only the drawing,
+        so this never reads as a plan that half-works."""
+        assert "render_not_supported_for_session_plans" in skill_text
+        prose = _prose(skill_text)
+        assert "nothing about the execution surface changes" in prose
+
+    def test_documents_the_figure_watch_tool(self, skill_text):
+        """A plan that ships a view is exactly the case where the figure read
+        beats the row read."""
+        assert "get_run_figure" in skill_text
+
     # --- explicit out-of-scope guidance ---
 
     def test_explicitly_rules_out_bba_and_tune_scan(self, skill_text):

--- a/tests/e2e/_orm_stack.py
+++ b/tests/e2e/_orm_stack.py
@@ -504,6 +504,153 @@ def wait_for_health(url: str, timeout: float) -> None:
     raise AssertionError(f"timed out after {timeout:.0f}s waiting for {url} (last: {last_err})")
 
 
+#: The bridge's compose SERVICE name -- the key under ``services:`` in
+#: ``services/bluesky/docker-compose.yml.j2``, and what a compose subcommand
+#: takes. Distinct from the CONTAINER name the same template pins with
+#: ``container_name:`` (``<project>-bluesky-bridge``, see
+#: :func:`bridge_container`), which is what ``docker inspect``/``docker logs``
+#: take.
+BRIDGE_SERVICE = "bluesky-bridge"
+
+#: Budget for the ``compose restart`` call itself. A restart stops and starts
+#: one already-built container -- no image build, no dependency resolution --
+#: so this is headroom over a healthy stop/start, not a build allowance.
+RESTART_TIMEOUT_SEC = 120
+
+#: Budget for the bridge to answer ``/health`` again after a restart. Far
+#: shorter than a cold deploy's health wait: the image exists and the container
+#: exists, so this covers one process start plus its manager reconnect.
+RESTART_HEALTH_TIMEOUT_SEC = 180.0
+
+
+def bridge_container(project_name: str) -> str:
+    """``<project>-bluesky-bridge`` for ``project_name`` -- the CONTAINER name
+    the bridge compose template pins with ``container_name:``.
+
+    Derived from :func:`project_prefix` rather than hardcoded, for the same
+    reason the image helpers are: the name is project-scoped, and a host-global
+    literal would be wrong for every other deployed project.
+    """
+    return f"{project_prefix(project_name)}-{BRIDGE_SERVICE}"
+
+
+def _container_started_at(container: str) -> str:
+    """``.State.StartedAt`` of ``container``, as docker reports it.
+
+    Compared across a restart to prove the process was actually replaced -- the
+    whole point of :func:`restart_bridge`, and the one thing a zero exit code
+    from compose does not establish on its own.
+    """
+    result = subprocess.run(
+        ["docker", "inspect", "-f", "{{.State.StartedAt}}", container],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"could not inspect {container} (rc={result.returncode}): "
+            f"{(result.stderr or result.stdout).strip()}"
+        )
+    return result.stdout.strip()
+
+
+def restart_bridge(
+    project_name: str,
+    *,
+    bridge_url: str,
+    health_timeout: float = RESTART_HEALTH_TIMEOUT_SEC,
+) -> None:
+    """Restart ONLY the bluesky-bridge container of a deployed stack, then wait
+    for it to answer ``/health`` again.
+
+    Why an e2e needs this: the bridge holds a run's rows in an in-process ring
+    buffer (``live_rows``), and nothing an HTTP client can call empties it --
+    ``live_rows._clear()`` is in-process, and eviction needs 50 further runs.
+    Restarting the process is the only way a test can drop that buffer and so
+    force the read paths (``/runs/{id}/data``, ``/runs/{id}/figure``) onto their
+    Tiled branch. Everything else keeps running: the queueserver, its Redis, the
+    Tiled catalog and the Virtual Accelerator are untouched, so the completed
+    run's documents are still in the catalog and the scan stack is still
+    deployed.
+
+    Restarting the bridge cannot lose documents, because the bridge is not what
+    writes them: the ``TiledWriter`` subscription lives in the QUEUESERVER
+    WORKER (``qserver_startup``), on the other side of this restart. What dies
+    with the bridge process is its READ-side live buffer, which is exactly the
+    state a test wants gone.
+
+    WHAT THIS PROVES, AND WHAT IT DOES NOT. The health wait proves the bridge
+    process is UP and serving. It says nothing about TiledWriter having flushed
+    the run to the catalog -- that is a separate, asynchronous fact. A caller
+    that needs the Tiled branch to actually answer must poll for it (a bounded
+    poll on the route it cares about until ``source == "tiled"``), never infer
+    it from this function returning. That poll belongs to the caller, whose
+    route knows what "answered from Tiled" looks like -- see
+    ``test_orm_roundtrip.py``, which waits on ``/runs/{id}/figure`` reporting
+    both ``source == "tiled"`` and ``partial == false``.
+
+    Nor does it restore enqueue readiness: the RE worker environment is opened
+    by the bridge off its readiness path, so a caller that goes on to enqueue
+    after a restart must re-wait via ``_queue_drive.wait_for_worker_environment``.
+
+    Container safety: the compose invocation is pinned to THIS deployment's
+    project (``-p <project>``, resolved exactly as the deploy pins
+    ``COMPOSE_PROJECT_NAME``) and names one exact service, so it can never reach
+    another session's containers. No ``-f`` is passed: compose resolves the
+    project from the running containers' own labels, which is what makes this a
+    one-service operation on a live stack rather than a re-read of a render.
+
+    :param project_name: The name the stack was built/deployed under (the raw
+        name, as passed to ``build_project_subprocess``) -- the compose project
+        and container names are derived from it here.
+    :param bridge_url: The bridge's base URL, e.g. ``http://localhost:18102``.
+        ``/health`` is appended to it.
+    :param health_timeout: Seconds to wait for ``/health`` after the restart.
+    :raises AssertionError: if the restart fails, if the container was not
+        actually replaced, or if ``/health`` does not come back.
+    """
+    container = bridge_container(project_name)
+    started_before = _container_started_at(container)
+
+    # --no-deps is what makes "only the bridge" structural rather than
+    # incidental: compose's default service selection follows depends_on edges
+    # whose `restart: true` flag is set, and the bluesky-panels template
+    # declares `depends_on: bluesky-bridge` in this same project. No template
+    # sets that flag today, so the selection happens to be one service -- an
+    # accident this flag stops depending on.
+    restart = subprocess.run(
+        [
+            "docker",
+            "compose",
+            "-p",
+            project_prefix(project_name),
+            "restart",
+            "--no-deps",
+            BRIDGE_SERVICE,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=RESTART_TIMEOUT_SEC,
+    )
+    if restart.returncode != 0:
+        raise AssertionError(
+            f"compose restart {BRIDGE_SERVICE} failed (rc={restart.returncode}):\n"
+            f"--- stdout ---\n{restart.stdout}\n--- stderr ---\n{restart.stderr}"
+        )
+
+    started_after = _container_started_at(container)
+    if started_after == started_before:
+        raise AssertionError(
+            f"compose reported success but {container} was not restarted "
+            f"(StartedAt still {started_before}) -- the in-process live buffer "
+            "is therefore still populated and any Tiled-branch assertion after "
+            "this would be vacuous"
+        )
+
+    wait_for_health(f"{bridge_url}/health", health_timeout)
+
+
 def select_correctors(
     limits: dict[str, Any], count: int | None = DEFAULT_CORRECTOR_COUNT
 ) -> dict[str, tuple[str, str]]:

--- a/tests/e2e/test_bluesky_write_refused_e2e.py
+++ b/tests/e2e/test_bluesky_write_refused_e2e.py
@@ -140,6 +140,7 @@ def test_bluesky_write_tools_structurally_disallowed(tmp_path: Path) -> None:
     # Reads stay structurally available.
     assert "mcp__bluesky__get_run" not in disallowed
     assert "mcp__bluesky__get_run_data" not in disallowed
+    assert "mcp__bluesky__get_run_figure" not in disallowed
 
 
 def test_query_refuses_queue_arming_tools(tmp_path: Path) -> None:

--- a/tests/e2e/test_grid_scan_roundtrip.py
+++ b/tests/e2e/test_grid_scan_roundtrip.py
@@ -58,6 +58,7 @@ from typing import Any
 
 import pytest
 
+from osprey.services.bluesky_bridge.figure import rows_from_columnar
 from tests.e2e import _orm_stack, _queue_drive
 from tests.e2e._deploy_diagnostics import queue_stack_logs
 
@@ -273,7 +274,7 @@ def test_grid_scan_roundtrip_produces_a_well_formed_grid(
     corrector_col = _find_column(columns, corrector_name)
     bpm_col = _find_column(columns, bpm_name)
 
-    rows = [dict(zip(columns, values, strict=True)) for values in data["rows"]]
+    rows = rows_from_columnar(columns, data["rows"], data["row_count"]).rows
     assert len(rows) == NUM_POINTS
 
     corrector_values = [row[corrector_col] for row in rows]

--- a/tests/e2e/test_orm_roundtrip.py
+++ b/tests/e2e/test_orm_roundtrip.py
@@ -6,7 +6,7 @@ Deploys the turn-key scan-stack config (task 4.3, ``tests/e2e/_orm_stack.py``
 discovery e2e in 5.3/5.4), drives the real ``orm`` plan over the bridge's
 queue API (``PATCH /draft`` -> ``POST /queue/items`` -> armed
 ``POST /queue/start`` -> poll -> ``GET /runs/{id}/data``, spelled once in
-``tests/e2e/_queue_drive.py``), and proves two things end to end:
+``tests/e2e/_queue_drive.py``), and proves four things end to end:
 
   (a) the measured response matrix -- built via the SAME
       ``orm_analysis.build_response_matrix`` an MCP-side analysis step would
@@ -21,6 +21,16 @@ queue API (``PATCH /draft`` -> ``POST /queue/items`` -> armed
       regression this deploy config's ``echo-pyat-coupled-sp-to-rb`` fix
       addresses) blocks exactly there, so a fixture-level timeout on this
       assertion IS the regression signature, not an incidentally slow test.
+  (c) ``GET /runs/{id}/figure`` serves the ``orm`` plan's OWN view of that run
+      -- sweep traces while it is still filling in, then the fitted response
+      matrix and the two anomaly-score panels once it settles -- computed over
+      the run's FULL row set. This run is sized past ``get_run_data``'s
+      100-row window on purpose (see ``NUM_POINTS``), so a figure route that
+      quietly reused that window would draw short sweeps here and fail.
+  (d) that same figure survives the run leaving the bridge's memory: after the
+      bridge container is restarted (``_orm_stack.restart_bridge``) the live
+      row buffer is gone, the route can only answer from the Tiled catalog,
+      and the figure it draws from there matches the one it drew live.
 
 No physics fault is seeded on this stack (no ``VA_BPM_ERRORS``/
 ``VA_CORR_GAIN`` in the written ``.env`` -- see ``_orm_stack.write_scan_env``),
@@ -37,7 +47,8 @@ device the ``orm`` plan and the model oracle both operate on).
 
 Container safety: every docker invocation below names an exact
 container/image -- never a wildcard, never ``system prune``/``--volumes``.
-Teardown goes through ``osprey down``, matching every other e2e in
+The one restart names a single compose service inside this deployment's own
+project. Teardown goes through ``osprey down``, matching every other e2e in
 this directory.
 
 Gating: needs Docker; the VA image builds natively for the host arch, so on
@@ -51,10 +62,12 @@ is warm.
 
 from __future__ import annotations
 
+import math
 import os
 import shutil
 import subprocess
-from collections.abc import Iterator
+import time
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -62,6 +75,7 @@ import numpy as np
 import pytest
 
 from osprey.deployment.compose_generator import resolve_project_name
+from osprey.services.bluesky_bridge.figure import rows_from_columnar
 from osprey.services.bluesky_bridge.orm_analysis import build_response_matrix
 from tests.e2e import _orm_stack, _queue_drive
 from tests.e2e._deploy_diagnostics import dead_container_logs, queue_stack_logs
@@ -93,17 +107,62 @@ def _dead_container_logs() -> str:
 BUILD_TIMEOUT_SEC = _orm_stack.BUILD_TIMEOUT_SEC
 DEPLOY_UP_TIMEOUT_SEC = 1200  # first-time native VA source build is slow (minutes)
 HEALTH_TIMEOUT_SEC = 300.0
-# 4 correctors x 5 points x an 8-device (4 corrector + 4 BPM) bundle read per
-# point -- generous headroom over a healthy run's expected
-# few-tens-of-seconds so this stays a meaningful "did it hang" gate rather
-# than a flaky timing assertion.
-SCAN_TIMEOUT_SEC = 240.0
 
 # Within the corrector channel_limits band (+-12A) and the response model's
 # documented linear regime (ORMParams' own docstring); NUM_POINTS >= 3 per
 # the schema's `ge=3`.
 SPAN_A = 5.0
-NUM_POINTS = 5
+
+#: 6 correctors x 21 points = 126 rows, sized deliberately past the 100-row
+#: default window of ``GET /runs/{id}/data``. The figure route computes over a
+#: run's WHOLE row set -- a windowed ORM fit is silently wrong -- and this is
+#: the run shape that can tell the two apart: read through the data window, the
+#: last correctors' sweeps would come out short or missing entirely. Both stay
+#: well under the 8-panel/12-series caps `plans_core/orm.py`'s render applies,
+#: so every corrector gets its own trace panel and every BPM its own line.
+CORRECTOR_COUNT = 6
+NUM_POINTS = 21
+
+# 6 correctors x 21 points x a 10-device (6 corrector + 4 BPM) bundle read per
+# point. A healthy point costs a second or two, so a healthy run here is a few
+# minutes; this is roughly fivefold headroom over that, which keeps it a
+# meaningful "did it hang" gate (a hung settle-wait never returns at all)
+# rather than a flaky timing assertion.
+SCAN_TIMEOUT_SEC = 900.0
+
+#: Interval for the in-flight figure poll. Shorter than the settled polls
+#: because it is hunting for a window that closes: it has to land inside the
+#: run rather than merely wait for a state that persists.
+MIDFLIGHT_POLL_SEC = 0.5
+FIGURE_POLL_SEC = 1.0
+
+#: How long to wait for the run's FIRST recorded point. Much shorter than the
+#: whole scan on purpose: this wait is over as soon as one corrector has been
+#: set and one bundle read, so a budget sized to the whole run would just be
+#: the corrector-hang timeout spent under a less informative message.
+MIDFLIGHT_TIMEOUT_SEC = 300.0
+
+#: How long the live figure may take to report itself settled AFTER the run
+#: record reads "completed". These are two different facts: the record is the
+#: queue item's status, while ``partial`` comes from the run's stop document
+#: reaching the bridge's document plane, which the route reads instead of the
+#: record on purpose (see ``app.get_run_figure``).
+SETTLED_FIGURE_TIMEOUT_SEC = 60.0
+
+#: How long the restarted bridge may take to answer from Tiled. The health
+#: wait inside ``restart_bridge`` proves only that the bridge process is back
+#: up; whether the queueserver's ``TiledWriter`` has flushed this run to the
+#: catalog is a separate, asynchronous fact, and this poll is what establishes
+#: it (see that function's "WHAT THIS PROVES, AND WHAT IT DOES NOT").
+TILED_FIGURE_TIMEOUT_SEC = 60.0
+
+#: Tolerance for live-vs-Tiled figure parity. Both figures are drawn by the
+#: same `render` over the same measurements, so the only thing between them is
+#: the storage round trip -- float64 through a Tiled table on one side, float64
+#: through JSON on the other, neither of which loses a bit. This is insurance
+#: against a dtype narrowing somewhere in that path, not a real error budget.
+PARITY_RTOL = 1e-9
+PARITY_ATOL = 1e-12
 
 # No VA_BPM_ERRORS/VA_CORR_GAIN are seeded on this stack (see module
 # docstring) -- every device carries PhysicsBridge's identity error
@@ -146,7 +205,7 @@ def deployed_orm_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Dep
     # control_system.limits_checking.database_path resolves against the rendered
     # config's directory, so build/data is the file the containers actually read.
     limits = _orm_stack.channel_limits(repo / "build")
-    correctors = _orm_stack.select_correctors(limits)
+    correctors = _orm_stack.select_correctors(limits, CORRECTOR_COUNT)
     bpms = _orm_stack.select_bpms(limits)
     # Writes the repo root's `.env` — the deployment's whole secret store, and
     # the file `osprey up` refuses to start without.
@@ -245,6 +304,167 @@ def _model_response_matrix(
 
 
 # ---------------------------------------------------------------------------
+# Reading figures off the deployed bridge
+# ---------------------------------------------------------------------------
+
+
+def _figure(run_id: str) -> tuple[int, Any]:
+    """One ``GET /runs/{id}/figure``, returning ``(status, body)``.
+
+    A shorter per-request timeout than `_queue_drive.request`'s 20 s default:
+    this is called from 1 Hz polls with their own deadlines, and one hung
+    request must not eat a whole poll budget by itself.
+    """
+    return _queue_drive.request(BRIDGE_URL, f"/runs/{run_id}/figure", "GET", timeout=10.0)
+
+
+def _figure_summary(figure: dict[str, Any]) -> str:
+    """A one-line digest of a figure response, for a failure message.
+
+    Never the whole body: a settled figure is mostly heatmap numbers, and what
+    a timed-out poll needs to report is which flags and which panels it kept
+    seeing instead of the ones it wanted.
+    """
+    titles = [panel.get("title") for panel in figure.get("panels") or []]
+    return (
+        f"source={figure.get('source')!r} partial={figure.get('partial')!r} "
+        f"reason={figure.get('reason')!r} panels={titles}"
+    )
+
+
+def _poll_figure(
+    run_id: str,
+    *,
+    until: Callable[[dict[str, Any]], bool],
+    what: str,
+    timeout: float,
+    poll: float = FIGURE_POLL_SEC,
+    give_up: Callable[[dict[str, Any]], str | None] | None = None,
+) -> dict[str, Any]:
+    """Poll ``GET /runs/{id}/figure`` until *until* accepts a response body.
+
+    Non-200 answers are retried rather than raised: a run whose first document
+    has not landed yet is in neither the live buffer nor the Tiled catalog, and
+    the route's honest answer for that is a 404.
+
+    *give_up* names the conditions under which waiting can no longer succeed --
+    the run settling before any in-flight figure was seen, or the live buffer
+    outliving a restart. Returning a message from it fails right there, with
+    that message, rather than spending the rest of the deadline on a wait whose
+    outcome is already decided.
+
+    Every failure path raises ``AssertionError``, never ``pytest.fail``: this
+    test's ``flaky`` marker reruns on ``AssertionError`` only, so a ``Failed``
+    raised in here would quietly opt the whole test out of its one retry.
+    """
+    deadline = time.monotonic() + timeout
+    last = "(no answer yet)"
+    while time.monotonic() < deadline:
+        status, body = _figure(run_id)
+        if status == 200 and isinstance(body, dict):
+            if give_up is not None:
+                abandon = give_up(body)
+                if abandon is not None:
+                    raise AssertionError(abandon)
+            if until(body):
+                return body
+            last = _figure_summary(body)
+        else:
+            last = f"HTTP {status}: {body}"
+        time.sleep(poll)
+    raise AssertionError(
+        f"timed out after {timeout:.0f}s waiting for {what} on "
+        f"GET /runs/{run_id}/figure (last seen: {last})"
+    )
+
+
+def _panel(figure: dict[str, Any], title: str) -> dict[str, Any]:
+    """The one panel titled *title*, or an AssertionError naming what was there."""
+    panels: list[dict[str, Any]] = figure["panels"]
+    matches = [panel for panel in panels if panel["title"] == title]
+    assert len(matches) == 1, (
+        f"expected exactly one {title!r} panel, found {len(matches)} in "
+        f"{[panel['title'] for panel in figure['panels']]}"
+    )
+    return matches[0]
+
+
+def _sweep_panels(figure: dict[str, Any]) -> list[dict[str, Any]]:
+    """The corrector-sweep trace panels -- every panel drawn as lines."""
+    return [panel for panel in figure["panels"] if panel["mark"]["kind"] == "lines"]
+
+
+def _is_number(value: Any) -> bool:
+    """True for a JSON number. Deliberately false for ``bool``, which is an
+    ``int`` in Python but a flag on the wire -- ``decimated: true`` must be
+    compared exactly, never within a tolerance."""
+    return isinstance(value, int | float) and not isinstance(value, bool)
+
+
+def _assert_json_close(live: Any, tiled: Any, *, path: str) -> None:
+    """Assert two figure bodies are structurally identical, numbers to a tolerance.
+
+    Walked generically rather than field by field so that the parity claim
+    covers the WHOLE wire contract -- including any field a later change adds
+    to a mark -- and so a mismatch reports the exact path (e.g.
+    ``figure.panels[6].mark.values[3][1]``) instead of a diff of two large
+    dumps.
+    """
+    if isinstance(live, dict) and isinstance(tiled, dict):
+        assert live.keys() == tiled.keys(), (
+            f"{path}: the live and Tiled figures carry different fields "
+            f"(live only: {sorted(live.keys() - tiled.keys())}, "
+            f"Tiled only: {sorted(tiled.keys() - live.keys())})"
+        )
+        for key in live:
+            _assert_json_close(live[key], tiled[key], path=f"{path}.{key}")
+        return
+    if isinstance(live, list) and isinstance(tiled, list):
+        assert len(live) == len(tiled), (
+            f"{path}: the live figure has {len(live)} entries here, the Tiled figure {len(tiled)}"
+        )
+        for index, (one, other) in enumerate(zip(live, tiled, strict=True)):
+            _assert_json_close(one, other, path=f"{path}[{index}]")
+        return
+    if _is_number(live) or _is_number(tiled):
+        # A drawn gap (null) on one side and a number on the other is a real
+        # parity failure, and lands here rather than in the exact branch below.
+        assert _is_number(live) and _is_number(tiled), (
+            f"{path}: live={live!r} and Tiled={tiled!r} are not both numbers"
+        )
+        # Two NaNs are not a parity failure but a wire-contract one, and
+        # `isclose` would report them as an unequal pair. The figure models
+        # null every non-finite value at the drawing edge, so a NaN reaching a
+        # client means that nulling was skipped -- on BOTH paths at once, which
+        # a parity message would send someone hunting the wrong difference.
+        both_nan = math.isnan(float(live)) and math.isnan(float(tiled))
+        assert not both_nan, (
+            f"both figures carry NaN at {path} -- no NaN should reach the wire; "
+            "the figure models null non-finite values instead"
+        )
+        assert math.isclose(float(live), float(tiled), rel_tol=PARITY_RTOL, abs_tol=PARITY_ATOL), (
+            f"{path}: live={live!r} vs Tiled={tiled!r} "
+            f"(rel_tol={PARITY_RTOL}, abs_tol={PARITY_ATOL})"
+        )
+        return
+    assert live == tiled, f"{path}: live={live!r} vs Tiled={tiled!r}"
+
+
+def _assert_figures_agree(live: dict[str, Any], from_tiled: dict[str, Any]) -> None:
+    """The two figures are the same figure, drawn from two stores.
+
+    ``source`` is the one field that must differ -- it names which store
+    answered -- so it is checked for its expected value and then set aside;
+    everything else, panels and annotations and numbers alike, has to agree.
+    """
+    live_body = dict(live)
+    tiled_body = dict(from_tiled)
+    assert live_body.pop("source") == "live"
+    assert tiled_body.pop("source") == "tiled"
+    _assert_json_close(live_body, tiled_body, path="figure")
+
+
+# ---------------------------------------------------------------------------
 # The round trip
 # ---------------------------------------------------------------------------
 
@@ -266,15 +486,82 @@ def test_orm_roundtrip_matches_model_with_no_corrector_hang(
         "span_a": SPAN_A,
         "num": NUM_POINTS,
     }
+    expected_rows = len(correctors) * NUM_POINTS
+
+    # The module fixture waits for the RE worker environment once, which covers
+    # the first pass. This test restarts the bridge at the end, though, and the
+    # bridge opens that environment off its readiness path -- so on a `flaky`
+    # rerun the enqueue below IS an enqueue after a restart, which would
+    # otherwise be refused 409 "not in the list of allowed plans" against a
+    # still-empty worker namespace. Re-waiting costs one request when the
+    # environment is already open.
+    _queue_drive.wait_for_worker_environment(BRIDGE_URL)
 
     token = _orm_stack.minted_launch_token(deployed_orm_stack.repo)
-    run_id, status_body = _queue_drive.run_scan(
-        BRIDGE_URL,
-        "orm",
-        plan_args,
-        token=token,
-        client_id="orm-roundtrip-e2e",
-        timeout=SCAN_TIMEOUT_SEC,
+    run_id = _queue_drive.stage_and_enqueue(
+        BRIDGE_URL, "orm", plan_args, client_id="orm-roundtrip-e2e"
+    )
+    _queue_drive.start_queue(BRIDGE_URL, token)
+
+    # --- (c) the figure while the run is still filling in ------------------
+    # One in-flight reading, taken at whatever moment the poll below first
+    # finds a sweep drawn. Everything about that moment is a claim the panel
+    # depends on: a figure exists before the run ends, it is the PLAN's figure
+    # (`reason` is null -- a reason means the route fell back to the generic
+    # view), it is served from the live buffer, and it says so by reporting
+    # itself unsettled.
+    try:
+        midflight = _poll_figure(
+            run_id,
+            until=lambda figure: bool(figure["partial"]) and bool(_sweep_panels(figure)),
+            what="an in-flight figure carrying at least one corrector sweep",
+            timeout=MIDFLIGHT_TIMEOUT_SEC,
+            poll=MIDFLIGHT_POLL_SEC,
+            give_up=lambda figure: (
+                None
+                if figure["partial"]
+                else (
+                    f"the {expected_rows}-row run settled before any in-flight figure was "
+                    f"observed (polled every {MIDFLIGHT_POLL_SEC}s) -- there is nothing wrong "
+                    "with the route here, but this assertion is no longer testing what it "
+                    "claims to; the run needs to be longer or the poll faster"
+                )
+            ),
+        )
+    except AssertionError as exc:
+        # A run that never records a first row cannot produce an in-flight
+        # figure either, so this wait is the first place the FR10 settle-wait
+        # hang shows up -- earlier than the completion assertion below, and
+        # with a message that would otherwise blame the figure route for it.
+        # The run record is what tells the two apart, so it is attached here.
+        record_status, record = _queue_drive.run_record(BRIDGE_URL, run_id)
+        raise AssertionError(
+            f"{exc}\n--- GET /runs/{run_id} (HTTP {record_status}) ---\n{record}\n"
+            "If that record shows a run that never got going, this is the corrector "
+            "settle-wait hang the completion assertion below names, not a figure-route "
+            "failure."
+        ) from exc
+    assert midflight["source"] == "live", (
+        f"an in-flight run must be served from the live row buffer: {_figure_summary(midflight)}"
+    )
+    assert midflight["partial"] is True, (
+        f"an in-flight run must report itself unsettled: {_figure_summary(midflight)}"
+    )
+    assert midflight["reason"] is None, (
+        "the in-flight figure fell back to the default view instead of the orm plan's own "
+        f"render: {_figure_summary(midflight)}"
+    )
+    sweep_titles = [f"{name} sweep" for name in correctors]
+    drawn = [panel["title"] for panel in _sweep_panels(midflight)]
+    assert set(drawn) <= set(sweep_titles), (
+        f"in-flight sweep panels {drawn} are not all correctors this run swept ({sweep_titles})"
+    )
+    assert all(
+        series["points"] for panel in _sweep_panels(midflight) for series in panel["mark"]["series"]
+    ), f"an in-flight sweep panel was drawn with no points on it: {_figure_summary(midflight)}"
+
+    status_body = _queue_drive.wait_for_terminal_status(
+        BRIDGE_URL, run_id, timeout=SCAN_TIMEOUT_SEC
     )
 
     # (b) no corrector-step hang: the poll above ran to a terminal status
@@ -288,16 +575,107 @@ def test_orm_roundtrip_matches_model_with_no_corrector_hang(
         "exactly here, at the bridge's ConnectorSettable.set() settle-wait"
     )
 
-    status, data = _get(f"/runs/{run_id}/data")
-    assert status == 200, f"GET /runs/{run_id}/data failed: {status} {data}"
-    expected_rows = len(correctors) * NUM_POINTS
-    assert data["row_count"] == expected_rows, (
-        f"expected {expected_rows} rows (one per (corrector, current) point), "
-        f"got {data['row_count']}: {data}"
+    # --- (c) the figure once the run has settled ---------------------------
+    # A short wait rather than an immediate read: the run RECORD reaching
+    # "completed" is the queue item's status, while `partial` comes from the
+    # stop document reaching the bridge's document plane. The route reads the
+    # source and never the record, deliberately, so the two facts can land in
+    # either order.
+    settled = _poll_figure(
+        run_id,
+        until=lambda figure: figure["partial"] is False,
+        what='the live figure to settle ("partial": false)',
+        timeout=SETTLED_FIGURE_TIMEOUT_SEC,
+    )
+    assert settled["source"] == "live", (
+        f"the completed run should still be served from the live buffer: {_figure_summary(settled)}"
+    )
+    assert settled["reason"] is None, (
+        "the settled figure fell back to the default view instead of the orm plan's own "
+        f"render: {_figure_summary(settled)}"
     )
 
+    # Panel order is part of the wire contract the JS renderer and the MCP
+    # projection both read: every swept corrector's traces, in sweep order,
+    # then the fit.
+    assert [panel["title"] for panel in settled["panels"]] == [
+        *sweep_titles,
+        "Response matrix",
+        "Corrector anomaly score",
+        "BPM anomaly score",
+    ], f"unexpected panels on the settled figure: {_figure_summary(settled)}"
+
+    # THE point of the oversized run: a full sweep on every panel. Read through
+    # get_run_data's 100-row window instead of the whole row set, the later
+    # correctors' sweeps would be short here or missing altogether.
+    for panel in _sweep_panels(settled):
+        assert [series["label"] for series in panel["mark"]["series"]] == list(bpms), (
+            f"{panel['title']}: one line per requested BPM was expected, got "
+            f"{[series['label'] for series in panel['mark']['series']]}"
+        )
+        for series in panel["mark"]["series"]:
+            assert len(series["points"]) == NUM_POINTS, (
+                f"{panel['title']} / {series['label']}: {len(series['points'])} points, "
+                f"expected {NUM_POINTS} -- on a {expected_rows}-row run this is the figure "
+                "having been computed over a window of the rows rather than all of them, or "
+                "a point whose corrector current was never recorded (a sample with no x is "
+                "dropped from the trace)"
+            )
+
+    heatmap = _panel(settled, "Response matrix")["mark"]
+    assert heatmap["kind"] == "heatmap", heatmap["kind"]
+    assert heatmap["x_labels"] == list(correctors), (
+        f"the heatmap's corrector axis is {heatmap['x_labels']}, expected every swept "
+        f"corrector {list(correctors)} -- a missing column is a sweep the fit did not "
+        "consider complete"
+    )
+    assert heatmap["y_labels"] == list(bpms), heatmap["y_labels"]
+    assert len(heatmap["values"]) == len(bpms), (
+        f"the heatmap has {len(heatmap['values'])} rows for {len(bpms)} BPMs"
+    )
+    assert all(len(row) == len(correctors) for row in heatmap["values"]), (
+        f"the heatmap is ragged: row widths {[len(row) for row in heatmap['values']]}"
+    )
+
+    corrector_bars = _panel(settled, "Corrector anomaly score")["mark"]
+    assert corrector_bars["kind"] == "bars", corrector_bars["kind"]
+    assert corrector_bars["categories"] == list(correctors), corrector_bars["categories"]
+    assert all(value is not None and math.isfinite(value) for value in corrector_bars["values"]), (
+        f"the corrector anomaly scores are not all real numbers: {corrector_bars['values']}"
+    )
+
+    bpm_bars = _panel(settled, "BPM anomaly score")["mark"]
+    assert bpm_bars["kind"] == "bars", bpm_bars["kind"]
+    assert bpm_bars["categories"] == list(bpms), bpm_bars["categories"]
+    assert all(value is not None and math.isfinite(value) for value in bpm_bars["values"]), (
+        f"the BPM anomaly scores are not all real numbers: {bpm_bars['values']}"
+    )
+
+    # --- the recorded rows -------------------------------------------------
+    # The default data window really is a window of this run, which is the
+    # premise the sweep-length assertion above rests on.
+    status, windowed = _get(f"/runs/{run_id}/data")
+    assert status == 200, f"GET /runs/{run_id}/data failed: {status} {windowed}"
+    assert windowed["row_count"] == expected_rows, (
+        f"expected {expected_rows} rows (one per (corrector, current) point), "
+        f"got {windowed['row_count']}: {windowed}"
+    )
+    assert windowed["truncated"] is True, (
+        f"a {expected_rows}-row run should overflow this route's default window, but it "
+        f"reported no truncation: {windowed['row_count']} rows, "
+        f"{len(windowed['rows'])} returned"
+    )
+    assert len(windowed["rows"]) < windowed["row_count"], (
+        f"the default window returned all {len(windowed['rows'])} rows of this run, so it "
+        "no longer separates a windowed read from a whole-run one"
+    )
+
+    status, data = _get(f"/runs/{run_id}/data?max_rows={expected_rows}")
+    assert status == 200, f"GET /runs/{run_id}/data failed: {status} {data}"
+    assert data["truncated"] is False, f"asked for every row and still got a window: {data}"
+
     columns = data["columns"]
-    rows = [dict(zip(columns, values, strict=True)) for values in data["rows"]]
+    rows = rows_from_columnar(columns, data["rows"], data["row_count"]).rows
     measured = build_response_matrix(rows, correctors=list(correctors), detectors=list(bpms))
 
     # (a) matches the model oracle: the same symmetric-sweep currents the
@@ -314,3 +692,45 @@ def test_orm_roundtrip_matches_model_with_no_corrector_hang(
         f"measured=\n{measured}\nmodel=\n{model}\n"
         f"max abs diff={float(np.max(np.abs(measured - model))):.3e}"
     )
+
+    # The served heatmap carries that same physics. It comes from the figure
+    # route's own fit (`sliced_response_matrix`, which slices each corrector's
+    # sweep) rather than from `build_response_matrix` above, so agreement with
+    # the model here is a second, independent path to the same slopes -- and
+    # the statement that what an operator SEES is the measurement, not merely
+    # a correctly shaped picture.
+    drawn_matrix = np.array(heatmap["values"], dtype=float)
+    assert np.allclose(drawn_matrix, model, rtol=MATCH_RTOL, atol=MATCH_ATOL), (
+        "the response matrix the figure route DREW does not match the model oracle within "
+        f"tolerance (rtol={MATCH_RTOL}, atol={MATCH_ATOL}):\n"
+        f"drawn=\n{drawn_matrix}\nmodel=\n{model}\n"
+        f"max abs diff={float(np.max(np.abs(drawn_matrix - model))):.3e}"
+    )
+
+    # --- (d) the same figure, after the run leaves the bridge's memory -----
+    # Restarting the bridge drops its in-process row buffer and nothing else:
+    # the queueserver owns the TiledWriter subscription, so this cannot lose
+    # documents, and the catalog, Redis and the VA all keep running. The poll
+    # below is the real readiness probe, since it waits for a SETTLED figure
+    # rather than for any 200.
+    _orm_stack.restart_bridge(PROJECT_NAME, bridge_url=BRIDGE_URL)
+
+    from_tiled = _poll_figure(
+        run_id,
+        until=lambda figure: figure["source"] == "tiled" and figure["partial"] is False,
+        what='the settled Tiled figure ("source": "tiled", "partial": false)',
+        timeout=TILED_FIGURE_TIMEOUT_SEC,
+        give_up=lambda figure: (
+            "the restarted bridge is still serving this run from its live buffer, so it "
+            "kept the state the restart was supposed to drop -- every Tiled assertion "
+            f"below would be vacuous: {_figure_summary(figure)}"
+            if figure["source"] == "live"
+            else None
+        ),
+    )
+    assert from_tiled["reason"] is None, (
+        "the figure read back from Tiled fell back to the default view instead of the orm "
+        f"plan's own render -- the plan identity stamped on the start document is what "
+        f"carries the run's plan across the restart: {_figure_summary(from_tiled)}"
+    )
+    _assert_figures_agree(settled, from_tiled)

--- a/tests/integration/test_bluesky_queue_contract.py
+++ b/tests/integration/test_bluesky_queue_contract.py
@@ -502,11 +502,17 @@ def test_enqueue_puts_the_pinned_draft_in_the_managers_queue(
     assert "capability" not in body
 
     # The manager holds exactly the plan the DRAFT named, with OSPREY's run id
-    # in the item metadata — the key start documents and Tiled results join on.
+    # in the item metadata — the key start documents and Tiled results join on —
+    # beside the plan-identity stamp a finished run is rendered from. Both keys
+    # ride the item into the start document; the queue's own read surfaces relay
+    # only the run id (`queue._public_item`).
     (item,) = manager.items
     assert item["name"] == "grid_scan"
     assert item["kwargs"] == _grid_scan_args()
-    assert item["meta"] == {qb.RUN_ID_META_KEY: body["run_id"]}
+    assert item["meta"] == {
+        qb.RUN_ID_META_KEY: body["run_id"],
+        qb.PLAN_META_KEY: {"name": "grid_scan", "kwargs": _grid_scan_args()},
+    }
 
 
 def test_a_draft_revision_can_be_enqueued_only_once(

--- a/tests/interfaces/bluesky_panels/bluesky-panel.test.mjs
+++ b/tests/interfaces/bluesky_panels/bluesky-panel.test.mjs
@@ -59,10 +59,12 @@ import {
   badgeToneForStatus,
   createResultsView,
   formatCell,
-  numericColumnIndices,
   runMetaParts,
   shouldKeepPolling,
 } from '../../../src/osprey/interfaces/bluesky_panels/panels/bluesky/results-view.js';
+// The absolute specifier the panel itself imports, so the `setTheme()` this
+// file calls drives the very same subscriber set `createResultsView` joins.
+import { setTheme } from '/design-system/js/theme-manager.js';
 
 /** A manager summary in the shape `_status_summary` publishes. */
 function summary(overrides = {}) {
@@ -473,6 +475,13 @@ describe('itemRunId', () => {
     expect(itemRunId(item({ meta: undefined }))).toBeNull();
     expect(itemRunId(null)).toBeNull();
   });
+
+  test('the bridge strips the plan stamp, and the run id still resolves', () => {
+    // What the bridge actually puts on the wire: the enqueue path stamps both
+    // `osprey_run_id` and `osprey_plan` into the item's metadata, and the
+    // queue relays drop the latter. The join key survives that strip.
+    expect(itemRunId(item({ meta: { osprey_run_id: 'run-1' } }))).toBe('run-1');
+  });
 });
 
 describe('itemParamSummary', () => {
@@ -792,20 +801,6 @@ describe('results helpers', () => {
     expect(formatCell('ok')).toBe('ok');
   });
 
-  test('only fully numeric columns are plotted', () => {
-    const data = {
-      columns: ['time', 'signal', 'label'],
-      rows: [
-        [1, 2.5, 'a'],
-        [2, 3.5, 'b'],
-      ],
-      row_count: 2,
-      truncated: false,
-    };
-    expect(numericColumnIndices(data)).toEqual([0, 1]);
-    expect(numericColumnIndices({ ...data, rows: [] })).toEqual([]);
-  });
-
   test('partial data outranks a terminal status when deciding to keep polling', () => {
     expect(shouldKeepPolling('running', false)).toBe(true);
     expect(shouldKeepPolling('completed', false)).toBe(false);
@@ -830,8 +825,8 @@ describe('createResultsView', () => {
       <div id="table-card" hidden><p id="table-note"></p>
         <table><thead><tr id="table-head-row"></tr></thead><tbody id="table-body"></tbody></table>
       </div>
-      <div id="chart-card" hidden>
-        <svg id="results-chart"></svg><ul id="chart-legend"></ul>
+      <div id="figure-card" hidden>
+        <p id="figure-note" hidden></p><div id="figure-panels"></div>
       </div>`;
     /** @param {string} id */
     const byId = (id) => /** @type {any} */ (document.getElementById(id));
@@ -844,13 +839,19 @@ describe('createResultsView', () => {
       tableNote: byId('table-note'),
       tableHeadRow: byId('table-head-row'),
       tableBody: byId('table-body'),
-      chartCard: byId('chart-card'),
-      chartSvg: byId('results-chart'),
-      chartLegend: byId('chart-legend'),
+      figureCard: byId('figure-card'),
+      figurePanels: byId('figure-panels'),
+      figureNote: byId('figure-note'),
     };
   }
 
-  /** @param {Record<string, {status: number, body: any}>} routes */
+  /**
+   * `routes` is read on every call rather than captured, so a test can swap a
+   * route between poll ticks — which is the only way to drive "this tick
+   * failed, the last one did not".
+   *
+   * @param {Record<string, {status: number, body: any}>} routes
+   */
   function stubFetch(routes) {
     return vi.fn(async (/** @type {string} */ url) => {
       const route = routes[url];
@@ -874,6 +875,45 @@ describe('createResultsView', () => {
     truncated: false,
   };
 
+  /**
+   * What `GET /runs/{id}/figure` serves: a bare `Figure`, no wrapper. Typed
+   * against the renderer's own wire typedef so a fixture that drifts from the
+   * bridge's shape fails typecheck rather than quietly testing a fiction.
+   *
+   * @type {import('../../../src/osprey/interfaces/bluesky_panels/panels/bluesky/figure-renderer.js').Figure}
+   */
+  const FIGURE = {
+    panels: [
+      {
+        title: 'signal',
+        x_label: 'time',
+        y_label: 'signal',
+        x_units: 's',
+        y_units: 'counts',
+        annotations: [],
+        mark: {
+          kind: 'lines',
+          series: [
+            {
+              label: 'signal',
+              points: [
+                { x: 1, y: 10 },
+                { x: 2, y: 20 },
+              ],
+              decimated: false,
+              source_points: 2,
+            },
+          ],
+          decimated: false,
+          source_points: 2,
+        },
+      },
+    ],
+    partial: false,
+    source: 'live',
+    reason: null,
+  };
+
   /** @type {ReturnType<typeof createResultsView>|undefined} */
   let view;
 
@@ -893,12 +933,13 @@ describe('createResultsView', () => {
     expect(view.currentRunId()).toBeNull();
   });
 
-  test('a completed run renders its record, table, and trace', async () => {
+  test('a completed run renders its record, its raw table, and its figure', async () => {
     vi.stubGlobal(
       'fetch',
       stubFetch({
         '/runs/r1': { status: 200, body: { id: 'r1', status: 'completed', plan_name: 'orm' } },
         '/runs/r1/data': { status: 200, body: DATA },
+        '/runs/r1/figure': { status: 200, body: FIGURE },
       })
     );
     const elements = mountElements();
@@ -910,7 +951,90 @@ describe('createResultsView', () => {
     expect(elements.meta.textContent).toContain('orm');
     expect(elements.tableBody.querySelectorAll('tr')).toHaveLength(2);
     expect(elements.tableNote.textContent).toBe('2 rows');
-    expect(elements.chartCard.hidden).toBe(false);
+
+    // The figure is drawn by the renderer, into the container this view hands
+    // it — one section per panel, plus the provenance line.
+    expect(elements.figureCard.hidden).toBe(false);
+    expect(elements.figurePanels.querySelectorAll('.figure-panel')).toHaveLength(1);
+    expect(elements.figureNote.hidden).toBe(false);
+    expect(elements.figureNote.textContent).toContain('live data');
+  });
+
+  test('a default figure carries its reason and is drawn like any other', async () => {
+    // A `reason` means the bridge could not run the plan's own render() and
+    // plotted the raw columns instead. That is a fallback VIEW, not an error
+    // state: nothing about it may be styled or hidden as a failure.
+    vi.stubGlobal(
+      'fetch',
+      stubFetch({
+        '/runs/r1': { status: 200, body: { id: 'r1', status: 'completed' } },
+        '/runs/r1/data': { status: 200, body: DATA },
+        '/runs/r1/figure': { status: 200, body: { ...FIGURE, reason: 'no_render' } },
+      })
+    );
+    const elements = mountElements();
+    view = createResultsView({ api: (p) => p, elements });
+    view.follow('r1');
+    await vi.waitFor(() => expect(elements.figureCard.hidden).toBe(false));
+
+    expect(elements.figurePanels.querySelectorAll('.figure-panel')).toHaveLength(1);
+    // The renderer humanizes the wire vocabulary — `no_render` reads as
+    // "no render" — but it never drops the reason.
+    expect(elements.figureNote.textContent).toContain('no render');
+    expect(elements.emptyState.classList.contains('error')).toBe(false);
+  });
+
+  test('a settled run re-draws its figure on a theme change, with no poll tick', async () => {
+    // The reason `lastFigure` is retained at all: a settled run has STOPPED
+    // polling, so nothing else will ever redraw it. Without this, flipping to
+    // light mode would leave a finished scan in the dark palette until the
+    // operator picked another run.
+    const fetchMock = stubFetch({
+      '/runs/r1': { status: 200, body: { id: 'r1', status: 'completed' } },
+      '/runs/r1/data': { status: 200, body: DATA },
+      '/runs/r1/figure': { status: 200, body: FIGURE },
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const elements = mountElements();
+    view = createResultsView({ api: (p) => p, elements });
+    view.follow('r1');
+    await vi.waitFor(() => expect(elements.figureCard.hidden).toBe(false));
+
+    const drawn = elements.figurePanels.querySelector('.figure-panel');
+    const callsBefore = fetchMock.mock.calls.length;
+
+    setTheme('light');
+
+    // The renderer replaces the container's children wholesale, so a new node
+    // in place of the old one IS the re-render — and no request was made to
+    // get it.
+    const redrawn = elements.figurePanels.querySelector('.figure-panel');
+    expect(redrawn).not.toBeNull();
+    expect(redrawn).not.toBe(drawn);
+    expect(fetchMock.mock.calls.length).toBe(callsBefore);
+  });
+
+  test('the theme subscription is released on destroy', async () => {
+    vi.stubGlobal(
+      'fetch',
+      stubFetch({
+        '/runs/r1': { status: 200, body: { id: 'r1', status: 'completed' } },
+        '/runs/r1/data': { status: 200, body: DATA },
+        '/runs/r1/figure': { status: 200, body: FIGURE },
+      })
+    );
+    const elements = mountElements();
+    view = createResultsView({ api: (p) => p, elements });
+    view.follow('r1');
+    await vi.waitFor(() => expect(elements.figureCard.hidden).toBe(false));
+
+    view.destroy();
+    view = undefined;
+    const drawn = elements.figurePanels.querySelector('.figure-panel');
+    setTheme('dark');
+    // A destroyed view still holding a live subscription would keep drawing
+    // into a container the panel has moved on from.
+    expect(elements.figurePanels.querySelector('.figure-panel')).toBe(drawn);
   });
 
   test('a run the manager has rotated away still shows its stored data', async () => {
@@ -921,6 +1045,7 @@ describe('createResultsView', () => {
       stubFetch({
         '/runs/old': { status: 404, body: { detail: "unknown run 'old'" } },
         '/runs/old/data': { status: 200, body: DATA },
+        '/runs/old/figure': { status: 200, body: { ...FIGURE, source: 'tiled' } },
       })
     );
     const elements = mountElements();
@@ -928,6 +1053,7 @@ describe('createResultsView', () => {
     view.follow('old');
     await vi.waitFor(() => expect(elements.tableCard.hidden).toBe(false));
 
+    expect(elements.figureCard.hidden).toBe(false);
     expect(elements.note.hidden).toBe(false);
     expect(elements.note.textContent).toContain('no longer in the queue');
     expect(elements.statusBadge.hidden).toBe(true);
@@ -941,6 +1067,7 @@ describe('createResultsView', () => {
       stubFetch({
         '/runs/r2': { status: 200, body: { id: 'r2', status: 'running' } },
         '/runs/r2/data': { status: 404, body: { detail: "unknown run 'r2'" } },
+        '/runs/r2/figure': { status: 404, body: { detail: "unknown run 'r2'" } },
       })
     );
     const elements = mountElements();
@@ -949,6 +1076,256 @@ describe('createResultsView', () => {
     await vi.waitFor(() => expect(elements.emptyState.textContent).toContain('No data recorded'));
     expect(elements.emptyState.classList.contains('error')).toBe(false);
     expect(elements.statusBadge.textContent).toBe('running');
+    // A figure 404 is the same "neither source knows this run" as a data 404;
+    // there is nothing to draw, so the card stays away.
+    expect(elements.figureCard.hidden).toBe(true);
+  });
+
+  test('a transient figure failure leaves the last good figure on screen', async () => {
+    // Mirrors what the table already does with its last good rows. A 502 is
+    // the bridge restarting mid-scan — the figure it served a second ago is
+    // still the best thing the operator can be shown.
+    vi.useFakeTimers();
+    /** @type {Record<string, {status: number, body: any}>} */
+    const routes = {
+      '/runs/r1': { status: 200, body: { id: 'r1', status: 'running' } },
+      '/runs/r1/data': { status: 200, body: { ...DATA, partial: true } },
+      '/runs/r1/figure': { status: 200, body: { ...FIGURE, partial: true } },
+    };
+    vi.stubGlobal('fetch', stubFetch(routes));
+    const elements = mountElements();
+    view = createResultsView({ api: (p) => p, elements });
+    view.follow('r1');
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(elements.figurePanels.querySelectorAll('.figure-panel')).toHaveLength(1);
+
+    routes['/runs/r1/figure'] = { status: 502, body: { detail: 'bluesky bridge unreachable' } };
+    await vi.advanceTimersByTimeAsync(1100);
+
+    expect(elements.figureCard.hidden).toBe(false);
+    expect(elements.figurePanels.querySelectorAll('.figure-panel')).toHaveLength(1);
+  });
+
+  test('an empty figure never replaces a good one', async () => {
+    // `source_unavailable` is served as a 200 with no panels: the store could
+    // not be read THIS tick, which says nothing about the figure drawn last
+    // tick. Blanking here would flicker a settled scan away and back.
+    vi.useFakeTimers();
+    /** @type {Record<string, {status: number, body: any}>} */
+    const routes = {
+      '/runs/r1': { status: 200, body: { id: 'r1', status: 'running' } },
+      '/runs/r1/data': { status: 200, body: { ...DATA, partial: true } },
+      '/runs/r1/figure': { status: 200, body: { ...FIGURE, partial: true } },
+    };
+    vi.stubGlobal('fetch', stubFetch(routes));
+    const elements = mountElements();
+    view = createResultsView({ api: (p) => p, elements });
+    view.follow('r1');
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(elements.figurePanels.querySelectorAll('.figure-panel')).toHaveLength(1);
+
+    routes['/runs/r1/figure'] = {
+      status: 200,
+      body: { panels: [], partial: true, source: 'tiled', reason: 'source_unavailable' },
+    };
+    await vi.advanceTimersByTimeAsync(1100);
+
+    expect(elements.figureCard.hidden).toBe(false);
+    expect(elements.figurePanels.querySelectorAll('.figure-panel')).toHaveLength(1);
+  });
+
+  test('a 200 that is not a figure is transient, and never kills the poll tick', async () => {
+    // What a misconfigured proxy answering for the bridge looks like. The
+    // figure read shares its tick with the record and table reads, so a body
+    // this view cannot parse must not throw: that would take the whole tick
+    // down and freeze the panel with no visible reason.
+    vi.useFakeTimers();
+    /** @type {Record<string, {status: number, body: any}>} */
+    const routes = {
+      '/runs/r1': { status: 200, body: { id: 'r1', status: 'running' } },
+      '/runs/r1/data': { status: 200, body: { ...DATA, partial: true } },
+      '/runs/r1/figure': { status: 200, body: { ...FIGURE, partial: true } },
+    };
+    const fetchMock = stubFetch(routes);
+    vi.stubGlobal('fetch', fetchMock);
+    const elements = mountElements();
+    view = createResultsView({ api: (p) => p, elements });
+    view.follow('r1');
+
+    await vi.advanceTimersByTimeAsync(0);
+    routes['/runs/r1/figure'] = { status: 200, body: [] };
+    await vi.advanceTimersByTimeAsync(1100);
+
+    // A tick beyond the bad one, because the bad tick's own requests go out
+    // before its body is read — counting them would prove nothing.
+    const afterBadPoll = fetchMock.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(afterBadPoll);
+
+    // Table still updating, last good figure still drawn.
+    expect(elements.tableCard.hidden).toBe(false);
+    expect(elements.figurePanels.querySelectorAll('.figure-panel')).toHaveLength(1);
+  });
+
+  test('a null record body mid-poll keeps the tick alive and holds the table', async () => {
+    // The read proxy's `safe_json` relays a null body on a 200, so every read
+    // in this tick can arrive as 200 + null. Unchecked, `body.status` would
+    // throw and abandon the tick — no reschedule, and the activity marker
+    // stuck on with nothing on screen to explain it.
+    vi.useFakeTimers();
+    /** @type {Record<string, {status: number, body: any}>} */
+    const routes = {
+      '/runs/r1': { status: 200, body: { id: 'r1', status: 'running' } },
+      '/runs/r1/data': { status: 200, body: { ...DATA, partial: true } },
+      '/runs/r1/figure': { status: 200, body: { ...FIGURE, partial: true } },
+    };
+    const fetchMock = stubFetch(routes);
+    vi.stubGlobal('fetch', fetchMock);
+    const elements = mountElements();
+    view = createResultsView({ api: (p) => p, elements });
+    view.follow('r1');
+
+    await vi.advanceTimersByTimeAsync(0);
+    routes['/runs/r1'] = { status: 200, body: null };
+    await vi.advanceTimersByTimeAsync(1100);
+
+    // The tick that SAW the null body has to have rescheduled itself. Counting
+    // requests right after it would prove nothing — its own three requests go
+    // out before the body is ever read, so that count rises even when the tick
+    // then dies. Only a further tick proves it survived.
+    const afterBadPoll = fetchMock.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(afterBadPoll);
+
+    expect(elements.note.textContent).toContain('Could not load the run record');
+    // And the halves that DID answer are still on screen.
+    expect(elements.tableCard.hidden).toBe(false);
+    expect(elements.tableBody.querySelectorAll('tr')).toHaveLength(2);
+    expect(elements.figurePanels.querySelectorAll('.figure-panel')).toHaveLength(1);
+  });
+
+  test('a null data body mid-poll keeps the tick alive and holds the last rows', async () => {
+    // Same hazard on the table's read: `renderTable` walks `columns` and
+    // `rows`, so a body with neither is transient, and transient means the
+    // last good window stays where the operator can still read it.
+    vi.useFakeTimers();
+    /** @type {Record<string, {status: number, body: any}>} */
+    const routes = {
+      '/runs/r1': { status: 200, body: { id: 'r1', status: 'running' } },
+      '/runs/r1/data': { status: 200, body: { ...DATA, partial: true } },
+      '/runs/r1/figure': { status: 200, body: { ...FIGURE, partial: true } },
+    };
+    const fetchMock = stubFetch(routes);
+    vi.stubGlobal('fetch', fetchMock);
+    const elements = mountElements();
+    view = createResultsView({ api: (p) => p, elements });
+    view.follow('r1');
+
+    await vi.advanceTimersByTimeAsync(0);
+    routes['/runs/r1/data'] = { status: 200, body: null };
+    await vi.advanceTimersByTimeAsync(1100);
+
+    // Same reasoning as the record case: only a tick AFTER the bad one proves
+    // the bad one rescheduled rather than died.
+    const afterBadPoll = fetchMock.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(afterBadPoll);
+
+    expect(elements.tableCard.hidden).toBe(false);
+    expect(elements.tableBody.querySelectorAll('tr')).toHaveLength(2);
+    expect(elements.statusBadge.textContent).toBe('running');
+    // Not an error state: a read that failed this tick is not a claim that
+    // the run went wrong.
+    expect(elements.emptyState.hidden).toBe(true);
+  });
+
+  test('a run that exists in neither source clears the figure and goes quiet', async () => {
+    // The one genuinely terminal case. The banner must not sit over a plot of
+    // a run that no longer exists, so whatever was drawn is cleared first —
+    // and with nothing left to wait for, the poll stops.
+    vi.useFakeTimers();
+    const fetchMock = stubFetch({
+      '/runs/gone': { status: 404, body: { detail: "unknown run 'gone'" } },
+      '/runs/gone/data': { status: 404, body: { detail: "unknown run 'gone'" } },
+      '/runs/gone/figure': { status: 404, body: { detail: "unknown run 'gone'" } },
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const elements = mountElements();
+    view = createResultsView({ api: (p) => p, elements });
+    view.follow('gone');
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(elements.emptyState.textContent).toContain('No record and no data');
+    expect(elements.emptyState.classList.contains('error')).toBe(true);
+    expect(elements.figureCard.hidden).toBe(true);
+
+    const afterFirstPoll = fetchMock.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(fetchMock.mock.calls.length).toBe(afterFirstPoll);
+  });
+
+  test('a renderer that throws does not take the poll tick down with it', async () => {
+    // A body whose `panels` array is well-formed but whose contents are not
+    // gets past the wire check and reaches the renderer. Containing the throw
+    // here is what keeps the record and table reads — which share this tick —
+    // alive, and the tab's activity marker honest.
+    vi.useFakeTimers();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    /** @type {Record<string, {status: number, body: any}>} */
+    const routes = {
+      '/runs/r1': { status: 200, body: { id: 'r1', status: 'running' } },
+      '/runs/r1/data': { status: 200, body: { ...DATA, partial: true } },
+      '/runs/r1/figure': { status: 200, body: { ...FIGURE, panels: [{ nonsense: true }] } },
+    };
+    const fetchMock = stubFetch(routes);
+    vi.stubGlobal('fetch', fetchMock);
+    const elements = mountElements();
+    view = createResultsView({ api: (p) => p, elements });
+    view.follow('r1');
+
+    await vi.advanceTimersByTimeAsync(0);
+    const afterBadPoll = fetchMock.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(1100);
+
+    // The first tick already hit the throwing panel, so a further tick is what
+    // proves the throw was contained rather than fatal.
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(afterBadPoll);
+    expect(elements.tableCard.hidden).toBe(false);
+    // Named specifically, because the theme bridges also log to console.error
+    // in this environment (no stylesheet, so the sentinel token reads empty) —
+    // a bare "was called" assertion here would pass without a throw at all.
+    expect(consoleError).toHaveBeenCalledWith(
+      'osprey bluesky results: the figure renderer threw',
+      expect.any(Error)
+    );
+    // And the draw genuinely failed: the card was never revealed.
+    expect(elements.figureCard.hidden).toBe(true);
+    consoleError.mockRestore();
+  });
+
+  test('a run whose figure is still partial keeps polling after its data settles', async () => {
+    // The Tiled-served case the bridge documents: a run with no stop document
+    // reports `partial: true` on the figure even once its record reads
+    // terminal and its data window looks settled. Either half still filling in
+    // has to keep the poll alive.
+    vi.useFakeTimers();
+    const fetchMock = stubFetch({
+      '/runs/r1': { status: 200, body: { id: 'r1', status: 'completed' } },
+      '/runs/r1/data': { status: 200, body: DATA },
+      '/runs/r1/figure': { status: 200, body: { ...FIGURE, partial: true, source: 'tiled' } },
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    view = createResultsView({ api: (p) => p, elements: mountElements() });
+    view.follow('r1');
+
+    await vi.advanceTimersByTimeAsync(0);
+    const afterFirstPoll = fetchMock.mock.calls.length;
+    expect(afterFirstPoll).toBe(3);
+
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(afterFirstPoll);
   });
 
   test('a rotated-away run whose data is still partial keeps polling', async () => {
@@ -959,6 +1336,8 @@ describe('createResultsView', () => {
     const fetchMock = stubFetch({
       '/runs/old': { status: 404, body: { detail: "unknown run 'old'" } },
       '/runs/old/data': { status: 200, body: { ...DATA, partial: true } },
+      // Settled, so the data half alone is what keeps this alive.
+      '/runs/old/figure': { status: 200, body: { ...FIGURE, source: 'tiled' } },
     });
     vi.stubGlobal('fetch', fetchMock);
     view = createResultsView({ api: (p) => p, elements: mountElements() });
@@ -966,19 +1345,21 @@ describe('createResultsView', () => {
 
     await vi.advanceTimersByTimeAsync(0);
     const afterFirstPoll = fetchMock.mock.calls.length;
-    expect(afterFirstPoll).toBe(2);
+    expect(afterFirstPoll).toBe(3);
 
     await vi.advanceTimersByTimeAsync(1100);
     expect(fetchMock.mock.calls.length).toBeGreaterThan(afterFirstPoll);
   });
 
   test('a settled rotated-away run stops polling', async () => {
-    // The negative control for the test above: without `partial`, a 404 record
-    // is the end of the story and the panel must go quiet.
+    // The negative control for both tests above: with neither half reporting
+    // `partial`, a 404 record is the end of the story and the panel must go
+    // quiet.
     vi.useFakeTimers();
     const fetchMock = stubFetch({
       '/runs/old': { status: 404, body: { detail: "unknown run 'old'" } },
       '/runs/old/data': { status: 200, body: DATA },
+      '/runs/old/figure': { status: 200, body: { ...FIGURE, source: 'tiled' } },
     });
     vi.stubGlobal('fetch', fetchMock);
     view = createResultsView({ api: (p) => p, elements: mountElements() });
@@ -1091,12 +1472,16 @@ describe('bundle wiring', () => {
   // repo root.
   const BUNDLE = `${cwd()}/src/osprey/interfaces/bluesky_panels/panels/bluesky/`;
 
-  test('every element id the shell and queue view look up exists in index.html', () => {
+  test('every element id the shell, queue view and figure renderer look up exists in index.html', () => {
     // The bundle has no build step and is served as authored, so a renamed id
     // fails only at runtime, in the operator's browser, as a silently dead
     // control. This is the drift-net for that. (plans-view.js gets the same
     // guard in draft-client.test.mjs.)
-    const source = [`${BUNDLE}panel.js`, `${BUNDLE}queue-view.js`]
+    //
+    // figure-renderer.js contributes nothing today — it is handed its
+    // containers and looks nothing up — and is scanned precisely so that stays
+    // true: the first `byId` added there has to name a real element.
+    const source = [`${BUNDLE}panel.js`, `${BUNDLE}queue-view.js`, `${BUNDLE}figure-renderer.js`]
       .map((path) => readFileSync(path, 'utf-8'))
       .join('\n');
     const html = readFileSync(`${BUNDLE}index.html`, 'utf-8');

--- a/tests/interfaces/bluesky_panels/figure-renderer.test.mjs
+++ b/tests/interfaces/bluesky_panels/figure-renderer.test.mjs
@@ -1,0 +1,920 @@
+/**
+ * Unit tests for the BLUESKY panel's figure renderer
+ * (bluesky_panels/panels/bluesky/figure-renderer.js).
+ *
+ * happy-dom environment (configured globally in vitest.config.js):
+ *   npx vitest run tests/interfaces/bluesky_panels/figure-renderer.test.mjs
+ *
+ * Two layers:
+ *  - The layout half against plain figure objects in the shape
+ *    `services/bluesky_bridge/figure.py` dumps — scales, ticks, the gap split,
+ *    heatmap/bar geometry, and the annotation text. No DOM involved.
+ *  - `renderFigure` against a real element bag, driving the *real*
+ *    theme-manager bridges through a `:root` custom-property fixture. Flipping
+ *    that fixture between renders is how the "colors are re-read, never
+ *    cached" rule is actually checked rather than asserted.
+ */
+
+import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  FIGURE_HEIGHT,
+  FIGURE_MARGIN,
+  FIGURE_WIDTH,
+  axisTicks,
+  axisTitle,
+  barDomain,
+  barGeometry,
+  categoryTicks,
+  decimationAnnotations,
+  figureNoteText,
+  formatTickValue,
+  gapAnnotations,
+  gapCount,
+  heatmapCells,
+  heatmapExtent,
+  heatmapShape,
+  labelStride,
+  linearScale,
+  padRange,
+  panelAnnotations,
+  plotBox,
+  polylinePoints,
+  renderFigure,
+  seriesColor,
+  seriesExtent,
+  shownPointCount,
+  splitSegments,
+} from '../../../src/osprey/interfaces/bluesky_panels/panels/bluesky/figure-renderer.js';
+
+/** @typedef {import('../../../src/osprey/interfaces/bluesky_panels/panels/bluesky/figure-renderer.js').FigurePoint} FigurePoint */
+/** @typedef {import('../../../src/osprey/interfaces/bluesky_panels/panels/bluesky/figure-renderer.js').FigureSeries} FigureSeries */
+/** @typedef {import('../../../src/osprey/interfaces/bluesky_panels/panels/bluesky/figure-renderer.js').LinesMark} LinesMark */
+/** @typedef {import('../../../src/osprey/interfaces/bluesky_panels/panels/bluesky/figure-renderer.js').HeatmapMark} HeatmapMark */
+/** @typedef {import('../../../src/osprey/interfaces/bluesky_panels/panels/bluesky/figure-renderer.js').BarsMark} BarsMark */
+/** @typedef {import('../../../src/osprey/interfaces/bluesky_panels/panels/bluesky/figure-renderer.js').FigureMark} FigureMark */
+/** @typedef {import('../../../src/osprey/interfaces/bluesky_panels/panels/bluesky/figure-renderer.js').FigurePanel} FigurePanel */
+/** @typedef {import('../../../src/osprey/interfaces/bluesky_panels/panels/bluesky/figure-renderer.js').Figure} Figure */
+
+// ---------------------------------------------------------------------------
+// Wire-shaped builders — every field the bridge dumps, so a test object is
+// exactly what the renderer sees at runtime.
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {Array<[number, number|null]>} pairs
+ * @returns {FigurePoint[]}
+ */
+const points = (pairs) => pairs.map(([x, y]) => ({ x, y }));
+
+/**
+ * @param {string} label
+ * @param {Array<[number, number|null]>} pairs
+ * @param {{decimated?: boolean, source_points?: number}} [extra]
+ * @returns {FigureSeries}
+ */
+function series(label, pairs, extra = {}) {
+  const pts = points(pairs);
+  return {
+    label,
+    points: pts,
+    decimated: extra.decimated ?? false,
+    source_points: extra.source_points ?? pts.length,
+  };
+}
+
+/**
+ * @param {FigureSeries[]} lines
+ * @param {{decimated?: boolean, source_points?: number}} [extra]
+ * @returns {LinesMark}
+ */
+function linesMark(lines, extra = {}) {
+  const total = lines.reduce((sum, line) => sum + line.points.length, 0);
+  return {
+    kind: 'lines',
+    series: lines,
+    decimated: extra.decimated ?? false,
+    source_points: extra.source_points ?? total,
+  };
+}
+
+/**
+ * @param {string[]} xLabels
+ * @param {string[]} yLabels
+ * @param {Array<Array<number|null>>} values
+ * @param {{value_label?: string, value_units?: string|null, decimated?: boolean, source_points?: number}} [extra]
+ * @returns {HeatmapMark}
+ */
+function heatmapMark(xLabels, yLabels, values, extra = {}) {
+  const cells = values.reduce((sum, row) => sum + row.length, 0);
+  return {
+    kind: 'heatmap',
+    x_labels: xLabels,
+    y_labels: yLabels,
+    values,
+    value_label: extra.value_label ?? 'response',
+    value_units: extra.value_units ?? null,
+    decimated: extra.decimated ?? false,
+    source_points: extra.source_points ?? cells,
+  };
+}
+
+/**
+ * @param {string[]} categories
+ * @param {Array<number|null>} values
+ * @param {{label?: string, decimated?: boolean, source_points?: number}} [extra]
+ * @returns {BarsMark}
+ */
+function barsMark(categories, values, extra = {}) {
+  return {
+    kind: 'bars',
+    label: extra.label ?? 'residual',
+    categories,
+    values,
+    decimated: extra.decimated ?? false,
+    source_points: extra.source_points ?? values.length,
+  };
+}
+
+/**
+ * @param {FigureMark} mark
+ * @param {{title?: string, x_label?: string, y_label?: string, x_units?: string|null, y_units?: string|null, annotations?: string[]}} [extra]
+ * @returns {FigurePanel}
+ */
+function panel(mark, extra = {}) {
+  return {
+    title: extra.title ?? 'Panel',
+    x_label: extra.x_label ?? 'corrector',
+    y_label: extra.y_label ?? 'orbit',
+    x_units: extra.x_units ?? null,
+    y_units: extra.y_units ?? null,
+    annotations: extra.annotations ?? [],
+    mark,
+  };
+}
+
+/**
+ * @param {FigurePanel[]} panels
+ * @param {{partial?: boolean, source?: 'live'|'tiled', reason?: string|null}} [extra]
+ * @returns {Figure}
+ */
+function figure(panels, extra = {}) {
+  return {
+    panels,
+    partial: extra.partial ?? false,
+    source: extra.source ?? 'tiled',
+    reason: extra.reason ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Layout — pure functions, no DOM
+// ---------------------------------------------------------------------------
+
+describe('plot geometry', () => {
+  test('the plot box is the viewBox minus the margins', () => {
+    const box = plotBox();
+    expect(box.left).toBe(FIGURE_MARGIN.left);
+    expect(box.top).toBe(FIGURE_MARGIN.top);
+    expect(box.width).toBe(FIGURE_WIDTH - FIGURE_MARGIN.left - FIGURE_MARGIN.right);
+    expect(box.height).toBe(FIGURE_HEIGHT - FIGURE_MARGIN.top - FIGURE_MARGIN.bottom);
+    expect(box.right).toBe(box.left + box.width);
+    expect(box.bottom).toBe(box.top + box.height);
+  });
+
+  test('margins wider than the canvas still leave a positive box', () => {
+    const box = plotBox(40, 40);
+    expect(box.width).toBeGreaterThan(0);
+    expect(box.height).toBeGreaterThan(0);
+  });
+});
+
+describe('linearScale', () => {
+  test('maps the domain onto the range, inverted or not', () => {
+    const scale = linearScale(0, 10, 100, 200);
+    expect(scale(0)).toBe(100);
+    expect(scale(10)).toBe(200);
+    expect(scale(5)).toBe(150);
+    const inverted = linearScale(0, 10, 200, 100);
+    expect(inverted(0)).toBe(200);
+    expect(inverted(10)).toBe(100);
+  });
+
+  test('a flat domain lands in the middle of the range, never on an edge or NaN', () => {
+    const scale = linearScale(7, 7, 0, 100);
+    expect(scale(7)).toBe(50);
+    expect(scale(999)).toBe(50);
+  });
+});
+
+describe('padRange', () => {
+  test('widens a real span by the fraction', () => {
+    expect(padRange(0, 10)).toEqual([-0.5, 10.5]);
+  });
+
+  test('widens a flat domain symmetrically', () => {
+    const [low, high] = padRange(4, 4);
+    expect(low).toBeLessThan(4);
+    expect(high).toBeGreaterThan(4);
+    expect(4 - low).toBeCloseTo(high - 4);
+  });
+
+  test('a flat zero domain gets an absolute pad rather than nothing', () => {
+    expect(padRange(0, 0)).toEqual([-0.5, 0.5]);
+  });
+});
+
+describe('seriesExtent', () => {
+  test('spans every series', () => {
+    const extent = seriesExtent([
+      series('a', [
+        [0, 1],
+        [5, 3],
+      ]),
+      series('b', [
+        [2, -4],
+        [9, 0],
+      ]),
+    ]);
+    expect(extent).toEqual({ xMin: 0, xMax: 9, yMin: -4, yMax: 3 });
+  });
+
+  test('a gap contributes its x but not a y — the run sampled there', () => {
+    const extent = seriesExtent([
+      series('a', [
+        [0, 1],
+        [50, null],
+      ]),
+    ]);
+    expect(extent).toEqual({ xMin: 0, xMax: 50, yMin: 1, yMax: 1 });
+  });
+
+  test('no finite y anywhere means there is nothing to plot', () => {
+    expect(
+      seriesExtent([
+        series('a', [
+          [0, null],
+          [1, null],
+        ]),
+      ])
+    ).toBeNull();
+    expect(seriesExtent([])).toBeNull();
+    expect(seriesExtent([series('a', [])])).toBeNull();
+  });
+});
+
+describe('splitSegments', () => {
+  test('a gap breaks the run instead of being interpolated across', () => {
+    const segments = splitSegments(
+      points([
+        [0, 1],
+        [1, 2],
+        [2, null],
+        [3, 4],
+        [4, 5],
+      ])
+    );
+    expect(segments).toHaveLength(2);
+    expect(segments[0].map((p) => p.x)).toEqual([0, 1]);
+    expect(segments[1].map((p) => p.x)).toEqual([3, 4]);
+    // The gap's own x appears in neither run: nothing is drawn at an x where
+    // the run recorded no reading.
+    expect(segments.flat().map((p) => p.x)).not.toContain(2);
+  });
+
+  test('leading, trailing and consecutive gaps produce no empty runs', () => {
+    const segments = splitSegments(
+      points([
+        [0, null],
+        [1, null],
+        [2, 1],
+        [3, null],
+        [4, null],
+      ])
+    );
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toHaveLength(1);
+  });
+
+  test('an all-gap series has no runs at all', () => {
+    expect(
+      splitSegments(
+        points([
+          [0, null],
+          [1, null],
+        ])
+      )
+    ).toEqual([]);
+  });
+
+  test('gapCount counts the samples with no reading', () => {
+    expect(
+      gapCount([
+        series('a', [
+          [0, 1],
+          [1, null],
+        ]),
+        series('b', [
+          [0, null],
+          [1, null],
+        ]),
+      ])
+    ).toBe(3);
+  });
+
+  test('polylinePoints emits scaled "x,y" pairs', () => {
+    const identity = linearScale(0, 10, 0, 10);
+    expect(polylinePoints(points([[0, 1], [10, 9]]), identity, identity)).toBe('0.0,1.0 10.0,9.0');
+  });
+});
+
+describe('tick formatting and placement', () => {
+  test('formats readable values and falls back to exponential at the extremes', () => {
+    expect(formatTickValue(0)).toBe('0');
+    expect(formatTickValue(1.23456)).toBe('1.235');
+    expect(formatTickValue(-42)).toBe('-42');
+    expect(formatTickValue(1.5e6)).toBe('1.5e+6');
+    expect(formatTickValue(2e-5)).toBe('2.0e-5');
+    expect(formatTickValue(null)).toBe('—');
+    expect(formatTickValue(NaN)).toBe('—');
+  });
+
+  test('axisTicks spans the domain at the requested count', () => {
+    const scale = linearScale(0, 100, 0, 500);
+    const ticks = axisTicks(0, 100, scale, 5);
+    expect(ticks).toHaveLength(5);
+    expect(ticks[0]).toEqual({ pos: 0, label: '0' });
+    expect(ticks[4]).toEqual({ pos: 500, label: '100' });
+  });
+
+  test('a flat domain gets a single tick', () => {
+    const ticks = axisTicks(3, 3, linearScale(3, 3, 0, 10));
+    expect(ticks).toEqual([{ pos: 5, label: '3' }]);
+  });
+
+  test('labelStride thins only once the axis is crowded', () => {
+    expect(labelStride(5)).toBe(1);
+    expect(labelStride(12)).toBe(1);
+    expect(labelStride(24)).toBe(2);
+    expect(labelStride(100)).toBe(9);
+  });
+
+  test('categoryTicks centers each label in its slot', () => {
+    const ticks = categoryTicks(['a', 'b', 'c', 'd'], 0, 400);
+    expect(ticks.map((tick) => tick.label)).toEqual(['a', 'b', 'c', 'd']);
+    expect(ticks.map((tick) => tick.pos)).toEqual([50, 150, 250, 350]);
+    expect(categoryTicks([], 0, 100)).toEqual([]);
+  });
+
+  test('a crowded category axis is thinned by the stride', () => {
+    const labels = Array.from({ length: 30 }, (_, index) => `c${index}`);
+    const ticks = categoryTicks(labels, 0, 300);
+    expect(ticks.length).toBeLessThanOrEqual(12);
+    expect(ticks[0].label).toBe('c0');
+    expect(ticks[1].label).toBe('c3');
+  });
+});
+
+describe('heatmap geometry', () => {
+  const mark = heatmapMark(
+    ['x0', 'x1', 'x2'],
+    ['y0', 'y1'],
+    [
+      [1, 2, 3],
+      [4, null, 6],
+    ]
+  );
+
+  test('shape comes from the labels', () => {
+    expect(heatmapShape(mark)).toEqual({ rows: 2, cols: 3 });
+  });
+
+  test('shape falls back to the values when labels are absent', () => {
+    expect(heatmapShape(heatmapMark([], [], [[1, 2], [3, 4], [5, 6]]))).toEqual({
+      rows: 3,
+      cols: 2,
+    });
+  });
+
+  test('the extent ignores cells with no reading', () => {
+    expect(heatmapExtent(mark.values)).toEqual({ min: 1, max: 6 });
+    expect(heatmapExtent([[null, null]])).toBeNull();
+    expect(heatmapExtent([])).toBeNull();
+  });
+
+  test('values are row-major: values[j][i] is y_labels[j] x x_labels[i]', () => {
+    const box = plotBox();
+    const cells = heatmapCells(mark, box);
+    expect(cells).toHaveLength(6);
+    const cell = cells.find((candidate) => candidate.row === 1 && candidate.col === 2);
+    expect(cell?.value).toBe(6);
+    // Row 1 sits below row 0: rows read top-down in the same order as y_labels.
+    const rowZero = cells.find((candidate) => candidate.row === 0 && candidate.col === 2);
+    expect(cell && rowZero && cell.y > rowZero.y).toBe(true);
+    // Column 2 sits right of column 0.
+    const colZero = cells.find((candidate) => candidate.row === 1 && candidate.col === 0);
+    expect(cell && colZero && cell.x > colZero.x).toBe(true);
+  });
+
+  test('the grid fills the plot box exactly', () => {
+    const box = plotBox();
+    const cells = heatmapCells(mark, box);
+    expect(cells[0].x).toBe(box.left);
+    expect(cells[0].y).toBe(box.top);
+    const last = cells[cells.length - 1];
+    expect(last.x + last.width).toBeCloseTo(box.right);
+    expect(last.y + last.height).toBeCloseTo(box.bottom);
+  });
+
+  test('a cell with no reading keeps its slot and carries a null value', () => {
+    const missing = heatmapCells(mark, plotBox()).find(
+      (cell) => cell.row === 1 && cell.col === 1
+    );
+    expect(missing?.value).toBeNull();
+  });
+
+  test('an empty heatmap has no cells', () => {
+    expect(heatmapCells(heatmapMark([], [], []), plotBox())).toEqual([]);
+  });
+});
+
+describe('bar geometry', () => {
+  test('the domain always contains zero, so bars are read against a baseline', () => {
+    expect(barDomain([10, 12, 11])).toEqual({ min: 0, max: 12 });
+    expect(barDomain([-3, -1])).toEqual({ min: -3, max: 0 });
+    expect(barDomain([])).toEqual({ min: 0, max: 1 });
+    expect(barDomain([null, null])).toEqual({ min: 0, max: 1 });
+  });
+
+  test('bars grow from the baseline in both directions', () => {
+    const box = plotBox();
+    const bars = barGeometry(barsMark(['up', 'down'], [4, -4]), box);
+    const scaleY = linearScale(-4, 4, box.bottom, box.top);
+    const baseline = scaleY(0);
+    expect(bars[0].y).toBeCloseTo(scaleY(4));
+    expect(bars[0].y + bars[0].height).toBeCloseTo(baseline);
+    expect(bars[1].y).toBeCloseTo(baseline);
+    expect(bars[1].y + bars[1].height).toBeCloseTo(scaleY(-4));
+  });
+
+  test('a category with no value keeps its slot and draws nothing', () => {
+    const bars = barGeometry(barsMark(['a', 'b', 'c'], [1, null, 3]), plotBox());
+    expect(bars).toHaveLength(3);
+    expect(bars[1].value).toBeNull();
+    expect(bars[1].height).toBe(0);
+    expect(bars[1].category).toBe('b');
+  });
+
+  test('bars stay inside the plot box and do not overlap', () => {
+    const box = plotBox();
+    const bars = barGeometry(barsMark(['a', 'b', 'c'], [1, 2, 3]), box);
+    expect(bars[0].x).toBeGreaterThanOrEqual(box.left);
+    expect(bars[2].x + bars[2].width).toBeLessThanOrEqual(box.right);
+    expect(bars[0].x + bars[0].width).toBeLessThan(bars[1].x);
+  });
+
+  test('an empty bars mark has no geometry', () => {
+    expect(barGeometry(barsMark([], []), plotBox())).toEqual([]);
+  });
+});
+
+describe('annotations', () => {
+  test('shownPointCount counts what each mark kind actually draws', () => {
+    expect(shownPointCount(linesMark([series('a', [[0, 1]]), series('b', [[0, 1], [1, 2]])]))).toBe(
+      3
+    );
+    expect(shownPointCount(barsMark(['a', 'b'], [1, 2]))).toBe(2);
+    expect(shownPointCount(heatmapMark(['x0', 'x1'], ['y0'], [[1, 2]]))).toBe(2);
+  });
+
+  test('an undecimated mark says nothing', () => {
+    expect(decimationAnnotations(linesMark([series('a', [[0, 1]])]))).toEqual([]);
+  });
+
+  test('a thinned mark names how many of its source points are shown', () => {
+    const mark = linesMark([series('bpm3', [[0, 1], [1, 2]], { decimated: true, source_points: 500 })], {
+      decimated: true,
+      source_points: 500,
+    });
+    expect(decimationAnnotations(mark)).toEqual(['showing 2 of 500 points']);
+  });
+
+  test('a multi-series mark also names each thinned series', () => {
+    const thinned = series('bpm3', [[0, 1], [1, 2]], { decimated: true, source_points: 400 });
+    const whole = series('bpm4', [[0, 1]]);
+    const mark = linesMark([thinned, whole], { decimated: true, source_points: 401 });
+    expect(decimationAnnotations(mark)).toEqual([
+      'showing 3 of 401 points',
+      'bpm3: showing 2 of 400 points',
+    ]);
+  });
+
+  test('a heatmap and a bars mark report their own totals', () => {
+    expect(
+      decimationAnnotations(
+        heatmapMark(['x0', 'x1'], ['y0'], [[1, 2]], { decimated: true, source_points: 90 })
+      )
+    ).toEqual(['showing 2 of 90 points']);
+    expect(
+      decimationAnnotations(barsMark(['a'], [1], { decimated: true, source_points: 12 }))
+    ).toEqual(['showing 1 of 12 points']);
+  });
+
+  test('gaps are disclosed in words, not only as a break in the line', () => {
+    expect(gapAnnotations(linesMark([series('a', [[0, 1], [1, null]])]))).toEqual([
+      '1 sample had no reading (drawn as gaps)',
+    ]);
+    expect(
+      gapAnnotations(linesMark([series('a', [[0, null], [1, null]])]))
+    ).toEqual(['2 samples had no reading (drawn as gaps)']);
+    expect(gapAnnotations(linesMark([series('a', [[0, 1]])]))).toEqual([]);
+    expect(gapAnnotations(barsMark(['a'], [null]))).toEqual([]);
+  });
+
+  test("the panel's own annotations come first, then what the drawing discloses", () => {
+    const mark = linesMark([series('a', [[0, 1], [1, null]], { decimated: true, source_points: 9 })], {
+      decimated: true,
+      source_points: 9,
+    });
+    expect(panelAnnotations(panel(mark, { annotations: ['fit failed on 2 correctors'] }))).toEqual([
+      'fit failed on 2 correctors',
+      'showing 2 of 9 points',
+      '1 sample had no reading (drawn as gaps)',
+    ]);
+  });
+});
+
+describe('text helpers', () => {
+  test('axisTitle joins a label with its units and tolerates either missing', () => {
+    expect(axisTitle('orbit', 'mm')).toBe('orbit (mm)');
+    expect(axisTitle('orbit', null)).toBe('orbit');
+    expect(axisTitle('', 'mm')).toBe('mm');
+    expect(axisTitle('', null)).toBe('');
+  });
+
+  test('the figure note reports source, partiality and reason', () => {
+    expect(figureNoteText(figure([]))).toBe('stored data');
+    expect(figureNoteText(figure([], { source: 'live', partial: true }))).toBe(
+      'live data · still filling in'
+    );
+    expect(figureNoteText(figure([], { reason: 'render_failed' }))).toBe(
+      'stored data · render failed'
+    );
+    // The bridge deliberately leaves the reason vocabulary open, so an
+    // unforeseen code still has to read as words.
+    expect(figureNoteText(figure([], { reason: 'some_new_reason' }))).toBe(
+      'stored data · some new reason'
+    );
+  });
+
+  test('seriesColor wraps the palette and falls back when it is empty', () => {
+    expect(seriesColor(['a', 'b'], 0, 'fb')).toBe('a');
+    expect(seriesColor(['a', 'b'], 3, 'fb')).toBe('b');
+    expect(seriesColor([], 0, 'fb')).toBe('fb');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Drawing — against the real theme bridges
+// ---------------------------------------------------------------------------
+
+const LIGHT = {
+  '--bg-primary': '#ffffff',
+  '--chart-paper-bg': '#ffffff',
+  '--chart-plot-bg': '#fafafa',
+  '--chart-grid': '#dddddd',
+  '--chart-axis-text': '#222222',
+  '--chart-series-1': '#1f77b4',
+  '--chart-series-2': '#ff7f0e',
+};
+
+const DARK = {
+  '--bg-primary': '#101014',
+  '--chart-paper-bg': '#101014',
+  '--chart-plot-bg': '#18181c',
+  '--chart-grid': '#3a3a42',
+  '--chart-axis-text': '#e6e6ea',
+  '--chart-series-1': '#7fc7ff',
+  '--chart-series-2': '#ffb570',
+};
+
+const THEME_STYLE_ID = 'figure-renderer-theme-fixture';
+
+/**
+ * Drive the real theme-manager computed-style bridges by defining the
+ * `--chart-*` custom properties the way a theme stylesheet does. Swapping the
+ * rule is a theme flip as far as `chartTheme()`/`chartSeries()` can tell.
+ *
+ * @param {Record<string, string>} tokens
+ */
+function applyTheme(tokens) {
+  const existing = document.getElementById(THEME_STYLE_ID);
+  const style = existing ?? document.createElement('style');
+  style.id = THEME_STYLE_ID;
+  style.textContent = `:root { ${Object.entries(tokens)
+    .map(([name, value]) => `${name}: ${value};`)
+    .join(' ')} }`;
+  if (!existing) document.head.appendChild(style);
+}
+
+function mount() {
+  document.body.replaceChildren();
+  const panels = document.createElement('div');
+  const note = document.createElement('p');
+  note.hidden = true;
+  document.body.append(note, panels);
+  return { panels, note };
+}
+
+/**
+ * @param {Element} root
+ * @param {string} selector
+ * @returns {string[]}
+ */
+const textsOf = (root, selector) =>
+  Array.from(root.querySelectorAll(selector)).map((node) => node.textContent ?? '');
+
+describe('renderFigure', () => {
+  beforeEach(() => {
+    applyTheme(LIGHT);
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+    document.getElementById(THEME_STYLE_ID)?.remove();
+    vi.restoreAllMocks();
+  });
+
+  test('a lines panel draws one polyline per series in the theme palette', () => {
+    const elements = mount();
+    renderFigure(
+      elements,
+      figure([
+        panel(
+          linesMark([
+            series('bpm3', [[0, 1], [1, 2], [2, 3]]),
+            series('bpm4', [[0, 3], [1, 2], [2, 1]]),
+          ]),
+          { title: 'Orbit response', x_label: 'corrector', x_units: 'A', y_label: 'orbit', y_units: 'mm' }
+        ),
+      ])
+    );
+
+    const section = elements.panels.querySelector('section.figure-panel');
+    expect(section?.getAttribute('data-mark')).toBe('lines');
+    expect(section?.querySelector('.figure-panel-title')?.textContent).toBe('Orbit response');
+
+    const lines = elements.panels.querySelectorAll('polyline.figure-line');
+    expect(lines).toHaveLength(2);
+    expect(lines[0].getAttribute('stroke')).toBe(LIGHT['--chart-series-1']);
+    expect(lines[1].getAttribute('stroke')).toBe(LIGHT['--chart-series-2']);
+    expect(elements.panels.querySelector('.figure-bg')?.getAttribute('fill')).toBe(
+      LIGHT['--chart-plot-bg']
+    );
+
+    // Axis text comes from the figure's own label/units fields.
+    expect(textsOf(elements.panels, 'text.figure-axis-title')).toEqual([
+      'corrector (A)',
+      'orbit (mm)',
+    ]);
+    expect(textsOf(elements.panels, 'ul.figure-legend li')).toEqual(['bpm3', 'bpm4']);
+  });
+
+  test('the same lines panel re-renders in the dark palette after a theme flip', () => {
+    const elements = mount();
+    const fig = figure([panel(linesMark([series('bpm3', [[0, 1], [1, 2]])]))]);
+
+    renderFigure(elements, fig);
+    expect(elements.panels.querySelector('polyline.figure-line')?.getAttribute('stroke')).toBe(
+      LIGHT['--chart-series-1']
+    );
+
+    applyTheme(DARK);
+    renderFigure(elements, fig);
+
+    const line = elements.panels.querySelector('polyline.figure-line');
+    expect(line?.getAttribute('stroke')).toBe(DARK['--chart-series-1']);
+    expect(line?.getAttribute('stroke')).not.toBe(LIGHT['--chart-series-1']);
+    expect(elements.panels.querySelector('.figure-bg')?.getAttribute('fill')).toBe(
+      DARK['--chart-plot-bg']
+    );
+    expect(elements.panels.querySelector('text.figure-tick')?.getAttribute('fill')).toBe(
+      DARK['--chart-axis-text']
+    );
+    // One render replaces the previous one rather than stacking on it.
+    expect(elements.panels.querySelectorAll('polyline.figure-line')).toHaveLength(1);
+  });
+
+  test('a heatmap paints one rect per reading and labels both axes, in either theme', () => {
+    for (const [name, tokens] of /** @type {Array<[string, Record<string, string>]>} */ ([
+      ['light', LIGHT],
+      ['dark', DARK],
+    ])) {
+      applyTheme(tokens);
+      const elements = mount();
+      renderFigure(
+        elements,
+        figure([
+          panel(
+            heatmapMark(
+              ['ch1', 'ch2', 'ch3'],
+              ['bpm1', 'bpm2'],
+              [
+                [1, 2, 3],
+                [4, null, 6],
+              ],
+              { value_label: 'response', value_units: 'mm/A' }
+            ),
+            { title: 'Response matrix', x_label: 'corrector', y_label: 'monitor' }
+          ),
+        ])
+      );
+
+      const cells = elements.panels.querySelectorAll('rect.figure-cell');
+      expect(cells, name).toHaveLength(5); // six slots, one with no reading
+      expect(cells[0].getAttribute('fill'), name).toBe(tokens['--chart-series-1']);
+
+      // Opacity carries the value: the smallest reading is the faintest.
+      const opacities = Array.from(cells).map((cell) =>
+        Number(cell.getAttribute('fill-opacity'))
+      );
+      expect(opacities[0], name).toBeLessThan(opacities[opacities.length - 1]);
+
+      // Both label lists are rendered, and only from the mark's own labels.
+      const ticks = textsOf(elements.panels, 'text.figure-tick');
+      expect(ticks, name).toEqual(expect.arrayContaining(['ch1', 'ch2', 'ch3', 'bpm1', 'bpm2']));
+      expect(textsOf(elements.panels, 'ul.figure-legend li'), name).toEqual([
+        'response (mm/A)',
+      ]);
+      expect(
+        elements.panels.querySelector('section.figure-panel')?.getAttribute('data-mark'),
+        name
+      ).toBe('heatmap');
+    }
+  });
+
+  test('heatmap cells carry their value as hover text', () => {
+    const elements = mount();
+    renderFigure(elements, figure([panel(heatmapMark(['x0'], ['y0'], [[2.5]]))]));
+    expect(elements.panels.querySelector('rect.figure-cell title')?.textContent).toBe('2.5');
+  });
+
+  test('bars draw one rect per value and label the categories, in either theme', () => {
+    for (const [name, tokens] of /** @type {Array<[string, Record<string, string>]>} */ ([
+      ['light', LIGHT],
+      ['dark', DARK],
+    ])) {
+      applyTheme(tokens);
+      const elements = mount();
+      renderFigure(
+        elements,
+        figure([
+          panel(barsMark(['ch1', 'ch2', 'ch3'], [1.5, null, -0.5], { label: 'residual' }), {
+            title: 'Fit residual',
+            y_label: 'residual',
+            y_units: 'mm',
+          }),
+        ])
+      );
+
+      const bars = elements.panels.querySelectorAll('rect.figure-bar');
+      expect(bars, name).toHaveLength(2); // the category with no value draws nothing
+      expect(bars[0].getAttribute('fill'), name).toBe(tokens['--chart-series-1']);
+      const ticks = textsOf(elements.panels, 'text.figure-tick');
+      expect(ticks, name).toEqual(expect.arrayContaining(['ch1', 'ch2', 'ch3']));
+      expect(textsOf(elements.panels, 'ul.figure-legend li'), name).toEqual(['residual']);
+    }
+  });
+
+  test('a gapped series is drawn as separate runs and says so', () => {
+    const elements = mount();
+    renderFigure(
+      elements,
+      figure([
+        panel(
+          linesMark([
+            series('bpm3', [
+              [0, 1],
+              [1, 2],
+              [2, null],
+              [3, 4],
+            ]),
+          ])
+        ),
+      ])
+    );
+
+    const lines = elements.panels.querySelectorAll('polyline.figure-line');
+    expect(lines).toHaveLength(1);
+    expect(lines[0].getAttribute('points')?.split(' ')).toHaveLength(2);
+    // The reading after the gap is a lone point, so it is drawn as a dot
+    // rather than vanishing.
+    expect(elements.panels.querySelectorAll('circle.figure-point')).toHaveLength(1);
+    expect(textsOf(elements.panels, 'ul.figure-annotations li')).toEqual([
+      '1 sample had no reading (drawn as gaps)',
+    ]);
+  });
+
+  test("a decimated panel renders both the figure's annotations and the decimation note", () => {
+    const elements = mount();
+    renderFigure(
+      elements,
+      figure([
+        panel(
+          linesMark([series('bpm3', [[0, 1], [1, 2]], { decimated: true, source_points: 20000 })], {
+            decimated: true,
+            source_points: 20000,
+          }),
+          { annotations: ['fit converged in 3 iterations'] }
+        ),
+      ])
+    );
+    expect(textsOf(elements.panels, 'ul.figure-annotations li')).toEqual([
+      'fit converged in 3 iterations',
+      'showing 2 of 20000 points',
+    ]);
+  });
+
+  test('a panel with no plottable values says so and still carries its annotations', () => {
+    const elements = mount();
+    renderFigure(
+      elements,
+      figure([
+        panel(linesMark([series('bpm3', [[0, null], [1, null]])]), {
+          annotations: ['detector offline'],
+        }),
+      ])
+    );
+    expect(elements.panels.querySelector('svg.figure-plot')).toBeNull();
+    expect(elements.panels.querySelector('.figure-empty')?.textContent).toBe(
+      'No plottable values in this panel yet.'
+    );
+    expect(textsOf(elements.panels, 'ul.figure-annotations li')).toEqual([
+      'detector offline',
+      '2 samples had no reading (drawn as gaps)',
+    ]);
+  });
+
+  test('the figure note goes to the caller’s note element', () => {
+    const elements = mount();
+    renderFigure(elements, figure([], { source: 'live', partial: true }));
+    expect(elements.note.textContent).toBe('live data · still filling in');
+    expect(elements.note.hidden).toBe(false);
+    expect(elements.panels.querySelector('.figure-empty')?.textContent).toBe(
+      'No figure for this run.'
+    );
+  });
+
+  test('without a note element the note is written into the panel container instead', () => {
+    const elements = mount();
+    renderFigure({ panels: elements.panels }, figure([], { reason: 'no_render' }));
+    expect(elements.panels.querySelector('.figure-note')?.textContent).toBe(
+      'stored data · no render'
+    );
+  });
+
+  test('multiple panels each get their own section, in figure order', () => {
+    const elements = mount();
+    renderFigure(
+      elements,
+      figure([
+        panel(linesMark([series('a', [[0, 1], [1, 2]])]), { title: 'first' }),
+        panel(barsMark(['x'], [1]), { title: 'second' }),
+      ])
+    );
+    expect(textsOf(elements.panels, 'section.figure-panel .figure-panel-title')).toEqual([
+      'first',
+      'second',
+    ]);
+    expect(
+      Array.from(elements.panels.querySelectorAll('section.figure-panel')).map((section) =>
+        section.getAttribute('data-mark')
+      )
+    ).toEqual(['lines', 'bars']);
+  });
+
+  test('figure text is set as text, never parsed as markup', () => {
+    const elements = mount();
+    const hostile = '<img src=x onerror="alert(1)">';
+    renderFigure(
+      elements,
+      figure([
+        panel(linesMark([series(hostile, [[0, 1], [1, 2]])]), {
+          title: hostile,
+          annotations: [hostile],
+        }),
+      ])
+    );
+    expect(elements.panels.querySelector('img')).toBeNull();
+    expect(elements.panels.querySelector('.figure-panel-title')?.textContent).toBe(hostile);
+    expect(textsOf(elements.panels, 'ul.figure-legend li')).toEqual([hostile]);
+    expect(textsOf(elements.panels, 'ul.figure-annotations li')).toEqual([hostile]);
+  });
+
+  test('rendering reads real theme tokens — the bridge never logs an untrusted read', () => {
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const elements = mount();
+    renderFigure(elements, figure([panel(linesMark([series('a', [[0, 1], [1, 2]])]))]));
+    expect(errors).not.toHaveBeenCalled();
+  });
+});

--- a/tests/interfaces/bluesky_panels/test_read_proxy.py
+++ b/tests/interfaces/bluesky_panels/test_read_proxy.py
@@ -37,7 +37,7 @@ def _json_response(status_code: int, body: object) -> httpx.Response:
 
 
 # ---------------------------------------------------------------------------
-# Round-trip passthrough for each of the 6 GET endpoints
+# Round-trip passthrough for each GET endpoint
 # ---------------------------------------------------------------------------
 
 
@@ -151,6 +151,97 @@ def test_get_run_data_round_trips() -> None:
     assert body["truncated"] is False
 
 
+def test_get_run_figure_round_trips() -> None:
+    """The figure body is the bridge's `Figure.model_dump()` and nothing else --
+    the proxy relays every field, panels and marks included, untouched."""
+    figure = {
+        "panels": [
+            {
+                "title": "COR1 vs BPM1",
+                "x_label": "COR1",
+                "y_label": "BPM1",
+                "x_units": "A",
+                "y_units": "mm",
+                "annotations": ["slope = 1.2 mm/A"],
+                "mark": {
+                    "kind": "lines",
+                    "series": [
+                        {
+                            "label": "BPM1",
+                            "points": [[0.0, 1.0], [1.0, 2.2]],
+                            "decimated": False,
+                            "source_points": 2,
+                        }
+                    ],
+                },
+            }
+        ],
+        "partial": False,
+        "source": "tiled",
+        "reason": None,
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/runs/abc123/figure"
+        return _json_response(200, figure)
+
+    app = _build_app(handler)
+    with TestClient(app) as client:
+        response = client.get("/runs/abc123/figure")
+
+    assert response.status_code == 200
+    assert response.json() == figure
+
+
+def test_get_run_figure_relays_reason_and_partial_unreshaped() -> None:
+    """A figure the plan's own `render` could not draw still comes back 200 with
+    a `reason` and empty panels -- the proxy must not turn that into an error or
+    invent panels for it."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return _json_response(
+            200,
+            {
+                "panels": [],
+                "partial": True,
+                "source": "tiled",
+                "reason": "source_unavailable",
+            },
+        )
+
+    app = _build_app(handler)
+    with TestClient(app) as client:
+        response = client.get("/runs/abc123/figure")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "panels": [],
+        "partial": True,
+        "source": "tiled",
+        "reason": "source_unavailable",
+    }
+
+
+def test_get_run_figure_quotes_run_id() -> None:
+    """Run ids reach the bridge escaped into a single path segment, exactly as
+    they do for `/data`. `#` is the sharp case: unquoted it would truncate the
+    outgoing URL to `/runs/a` and swallow the route entirely."""
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return _json_response(
+            200, {"panels": [], "partial": False, "source": "live", "reason": None}
+        )
+
+    app = _build_app(handler)
+    with TestClient(app) as client:
+        response = client.get("/runs/a%23b/figure")
+
+    assert response.status_code == 200
+    assert seen[0].url.raw_path == b"/runs/a%23b/figure"
+
+
 # ---------------------------------------------------------------------------
 # Error passthrough (verbatim body + status, never recomputed)
 # ---------------------------------------------------------------------------
@@ -178,6 +269,22 @@ def test_run_data_409_passes_through_verbatim() -> None:
 
     assert response.status_code == 409
     assert response.json() == {"detail": "run 'abc123' has not started; no data yet"}
+
+
+def test_run_figure_404_passes_through_verbatim() -> None:
+    """The unknown-run 404 body must survive the relay unchanged: the MCP tool
+    maps it to `unknown_run` by the same string `/data`'s 404 carries."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/runs/nope/figure"
+        return _json_response(404, {"detail": "unknown run 'nope'"})
+
+    app = _build_app(handler)
+    with TestClient(app) as client:
+        response = client.get("/runs/nope/figure")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "unknown run 'nope'"}
 
 
 def test_plan_source_404_passes_through_verbatim() -> None:
@@ -240,7 +347,14 @@ def test_get_run_data_forwards_max_rows_offset_tail_params() -> None:
 
 @pytest.mark.parametrize(
     "path",
-    ["/plans", "/plans/grid_scan/source", "/runs", "/runs/abc123", "/runs/abc123/data"],
+    [
+        "/plans",
+        "/plans/grid_scan/source",
+        "/runs",
+        "/runs/abc123",
+        "/runs/abc123/data",
+        "/runs/abc123/figure",
+    ],
 )
 def test_bridge_unreachable_returns_502(path: str) -> None:
     def handler(request: httpx.Request) -> httpx.Response:

--- a/tests/mcp_server/test_bluesky_client_tools.py
+++ b/tests/mcp_server/test_bluesky_client_tools.py
@@ -17,7 +17,19 @@ from fastmcp.exceptions import ToolError
 
 from osprey.mcp_server.bluesky.server import mcp
 from osprey.mcp_server.bluesky.tools import read_tools
+from osprey.mcp_server.bluesky.tools.read_tools import FIGURE_POINT_BUDGET
 from osprey.mcp_server.errors import make_error
+from osprey.services.bluesky_bridge.figure import (
+    FIGURE_REASONS,
+    REASON_SOURCE_UNAVAILABLE,
+    BarsMark,
+    Figure,
+    HeatmapMark,
+    LinesMark,
+    Panel,
+    Point,
+    Series,
+)
 from tests.mcp_server.conftest import assert_raises_error, extract_response_dict, get_tool_fn
 
 pytestmark = pytest.mark.unit
@@ -283,6 +295,631 @@ async def test_get_run_data_unreachable(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# get_run_figure — GET /runs/{id}/figure (point-bounded projection)
+#
+# The tool is the one read that does NOT relay its body: the route serves
+# heatmaps whole (a canvas can afford 7000 cells; an agent's context cannot),
+# so these pin the projection's promise — one 2000-point budget for the whole
+# figure, grids over 40x40 summarized, and every count still honest about what
+# the run actually took.
+# ---------------------------------------------------------------------------
+
+
+def _serve(monkeypatch, body, status=200):
+    """Point the tool's HTTP primitive at ``body``; return the captured path."""
+    captured = {}
+
+    def fake_get(path, **kwargs):
+        captured["path"] = path
+        return status, body
+
+    monkeypatch.setattr(f"{_MOD}._http_get_json", fake_get)
+    return captured
+
+
+def _lines_panel(title="Sweep", *, series):
+    return Panel(title=title, mark=LinesMark(**_lines_mark_kwargs(series)))
+
+
+def _lines_mark_kwargs(series):
+    return {
+        "series": series,
+        "decimated": any(s.decimated for s in series),
+        "source_points": sum(s.source_points for s in series),
+    }
+
+
+def _series(label, n, *, source_points=None, decimated=False, gap_at=None):
+    points = [Point(x=float(i), y=None if i == gap_at else float(i)) for i in range(n)]
+    return Series(
+        label=label,
+        points=points,
+        decimated=decimated,
+        source_points=n if source_points is None else source_points,
+    )
+
+
+def _heatmap_panel(rows, columns, *, title="Grid", values=None):
+    grid = values or [[float(j * columns + i) for i in range(columns)] for j in range(rows)]
+    return Panel(
+        title=title,
+        mark=HeatmapMark(
+            x_labels=[f"C{i}" for i in range(columns)],
+            y_labels=[f"B{j}" for j in range(rows)],
+            values=grid,
+            value_label="Response slope",
+            value_units="mm/A",
+            source_points=rows * columns,
+        ),
+    )
+
+
+def _figure(*panels, partial=False, source="live", reason=None):
+    return Figure(panels=list(panels), partial=partial, source=source, reason=reason).model_dump()
+
+
+def _total_points(projected):
+    """Every value the projection actually returned, across all panels."""
+    total = 0
+    for panel in projected["panels"]:
+        mark = panel["mark"]
+        if mark["kind"] == "lines":
+            total += sum(len(s["points"]) for s in mark["series"])
+        elif mark["kind"] == "bars":
+            total += len(mark["values"])
+        elif mark["kind"] == "heatmap":
+            total += sum(len(row) for row in mark["values"])
+    return total
+
+
+async def test_get_run_figure_request_response_mapping(monkeypatch):
+    """A figure already under budget is relayed shape-for-shape, panels intact."""
+    body = _figure(
+        _lines_panel(series=[_series("det1", 3, gap_at=1)]),
+        partial=True,
+        source="live",
+        reason=None,
+    )
+    captured = _serve(monkeypatch, body)
+
+    projected = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))
+
+    assert captured["path"] == "/runs/run-1/figure"
+    assert (projected["partial"], projected["source"], projected["reason"]) == (True, "live", None)
+    assert projected["panels"][0]["mark"]["series"][0]["points"] == [
+        {"x": 0.0, "y": 0.0},
+        {"x": 1.0, "y": None},  # a gap stays a gap, never a zero
+        {"x": 2.0, "y": 2.0},
+    ]
+    assert projected["point_budget"] == FIGURE_POINT_BUDGET
+    assert projected["points_returned"] == 3
+
+
+async def test_get_run_figure_unknown_run(monkeypatch):
+    """404 maps to unknown_run exactly as get_run_data does."""
+    _serve(monkeypatch, {"detail": "unknown run 'nope'"}, status=404)
+    with assert_raises_error(error_type="unknown_run"):
+        await _fn("get_run_figure")(run_id="nope")
+
+
+async def test_get_run_figure_bridge_error(monkeypatch):
+    _serve(monkeypatch, {"detail": "boom"}, status=503)
+    with assert_raises_error(error_type="bluesky_bridge_error"):
+        await _fn("get_run_figure")(run_id="run-1")
+
+
+async def test_get_run_figure_unreachable(monkeypatch):
+    monkeypatch.setattr(f"{_MOD}._http_get_json", _unreachable)
+    with assert_raises_error(error_type="bluesky_bridge_unreachable"):
+        await _fn("get_run_figure")(run_id="run-1")
+
+
+async def test_get_run_figure_relays_partial_source_and_any_reason(monkeypatch):
+    """A reason is a default view, not an error — including one this build has
+    never heard of. The route deliberately leaves ``reason`` unvalidated so an
+    unforeseen value still serves a figure; the tool must not narrow that."""
+    body = _figure(
+        _lines_panel(series=[_series("det1", 2)]),
+        partial=True,
+        source="tiled",
+        reason="a_reason_from_a_newer_bridge",
+    )
+    _serve(monkeypatch, body)
+
+    projected = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))
+
+    assert projected["reason"] == "a_reason_from_a_newer_bridge"
+    assert projected["partial"] is True
+    assert projected["source"] == "tiled"
+
+
+async def test_get_run_figure_source_unavailable_is_a_200_with_no_panels(monkeypatch):
+    """An unreadable source is an empty figure with a reason, never a refusal."""
+    _serve(monkeypatch, _figure(reason=REASON_SOURCE_UNAVAILABLE))
+
+    projected = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))
+
+    assert projected["panels"] == []
+    assert projected["reason"] == REASON_SOURCE_UNAVAILABLE
+    assert projected["points_returned"] == 0
+
+
+# --- the budget ------------------------------------------------------------
+
+
+async def test_budget_is_spent_across_the_whole_figure_not_per_series(monkeypatch):
+    """Six 2000-point series in two panels come back as 2000 points TOTAL.
+
+    The route's bound is per series; this tool's is per figure, which is the
+    whole reason it exists — six panel-legal series are six times the context.
+    """
+    _serve(
+        monkeypatch,
+        _figure(
+            _lines_panel(title="A", series=[_series(f"a{i}", 2000) for i in range(3)]),
+            _lines_panel(title="B", series=[_series(f"b{i}", 2000) for i in range(3)]),
+        ),
+    )
+
+    projected = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))
+
+    kept = [len(s["points"]) for panel in projected["panels"] for s in panel["mark"]["series"]]
+    assert sum(kept) == FIGURE_POINT_BUDGET
+    assert projected["points_returned"] == FIGURE_POINT_BUDGET
+    # Evenly split, to within the one point integer division leaves over.
+    assert max(kept) - min(kept) <= 1
+
+
+async def test_a_series_needing_less_than_its_share_hands_the_rest_back(monkeypatch):
+    """Max-min fairness: a 5-point series does not reserve 1000 points.
+
+    An even split alone would leave 995 points unspent while the long series
+    is thinned to half of what the figure could have shown.
+    """
+    _serve(
+        monkeypatch,
+        _figure(_lines_panel(series=[_series("short", 5), _series("long", 50_000)])),
+    )
+
+    projected = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))
+
+    short, long = projected["panels"][0]["mark"]["series"]
+    assert len(short["points"]) == 5
+    assert len(long["points"]) == FIGURE_POINT_BUDGET - 5
+    assert short["decimated"] is False
+    assert long["decimated"] is True
+
+
+async def test_restriding_composes_with_the_routes_own_decimation(monkeypatch):
+    """An already-thinned series still reports what the RUN took, not what the
+    route handed us. Dropping decimate's prior-truth arguments would make this
+    series claim 2000 source points — a figure saying it drew everything."""
+    _serve(
+        monkeypatch,
+        _figure(
+            _lines_panel(
+                series=[_series("det1", 2000, source_points=200_000, decimated=True)],
+            )
+        ),
+    )
+
+    projected = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))
+
+    series = projected["panels"][0]["mark"]["series"][0]
+    assert series["source_points"] == 200_000
+    assert series["decimated"] is True
+    assert projected["panels"][0]["mark"]["source_points"] == 200_000
+
+
+async def test_mark_level_truth_is_a_floor_the_projection_never_lowers(monkeypatch):
+    """A projection may RAISE the loss a figure reports, never lower it.
+
+    A plan can set mark-level truth its series do not individually carry —
+    rows it dropped before building them — and recomputing the aggregates
+    from the series alone would quietly erase that, turning a partial view
+    into one that claims to have drawn everything.
+    """
+    body = _figure(_lines_panel(series=[_series("det1", 10)]))
+    body["panels"][0]["mark"]["decimated"] = True
+    body["panels"][0]["mark"]["source_points"] = 999_999
+
+    _serve(monkeypatch, body)
+
+    mark = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))["panels"][0]["mark"]
+
+    assert mark["decimated"] is True
+    assert mark["source_points"] == 999_999
+    # The series' own truth is untouched — only the mark aggregates are floored.
+    assert mark["series"][0]["source_points"] == 10
+
+
+async def test_the_last_points_go_to_series_that_have_data(monkeypatch):
+    """An empty series must not spend one of the scarce single points.
+
+    Under starvation every unit is fighting for one point each; letting a
+    series with nothing to show take one would cost a series that has data
+    its only place in the figure.
+    """
+    empty = [_series(f"empty{i}", 0) for i in range(100)]
+    measured = [_series(f"det{i}", 3) for i in range(400)]
+    _serve(
+        monkeypatch,
+        _figure(
+            _heatmap_panel(40, 40),  # 1600 cells, leaving exactly 400 points
+            _lines_panel(series=[*empty, *measured]),
+        ),
+    )
+
+    projected = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))
+
+    lines_panel = projected["panels"][1]
+    kept = {series["label"]: len(series["points"]) for series in lines_panel["mark"]["series"]}
+    assert len(kept) == 500, "no series was dropped — the empty ones cost nothing"
+    assert all(kept[f"det{i}"] == 1 for i in range(400)), "a measured series was starved"
+    assert lines_panel["annotations"] == []
+    assert _total_points(projected) == FIGURE_POINT_BUDGET
+
+
+async def test_endpoints_and_gaps_survive_the_restride(monkeypatch):
+    """The x range is never shortened and a dropout is never smoothed over."""
+    _serve(
+        monkeypatch,
+        _figure(_lines_panel(series=[_series("det1", 10_000, gap_at=4_321)])),
+    )
+
+    projected = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))
+
+    points = projected["panels"][0]["mark"]["series"][0]["points"]
+    assert (points[0]["x"], points[-1]["x"]) == (0.0, 9_999.0)
+    assert any(point["y"] is None for point in points)
+
+
+async def test_series_past_the_budget_are_omitted_and_said_so(monkeypatch):
+    """More series than points: the ones that fit are kept, the rest are named.
+
+    Nothing in the mark shape could report a series that simply is not there,
+    so the loss is a panel annotation — a sentence, per the spec's rule for
+    what annotations are.
+    """
+    _serve(
+        monkeypatch,
+        _figure(
+            _heatmap_panel(40, 40),  # 1600 cells, leaving 400 points
+            _lines_panel(series=[_series(f"s{i}", 3) for i in range(500)]),
+        ),
+    )
+
+    projected = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))
+
+    lines_panel = projected["panels"][1]
+    assert len(lines_panel["mark"]["series"]) == 400
+    assert lines_panel["mark"]["decimated"] is True
+    assert "100 of 500 series are not shown" in lines_panel["annotations"][0]
+    assert _total_points(projected) <= FIGURE_POINT_BUDGET
+
+
+# --- heatmaps: the projection's real payload problem -----------------------
+
+
+async def test_a_facility_scale_heatmap_is_summarized_and_costs_nothing(monkeypatch):
+    """A 70x100 response matrix is 7000 cells the agent cannot read anyway.
+
+    Summarizing it is what actually bounds this projection (the route serves
+    heatmaps whole, in spec), and because the summary is fixed-size it spends
+    none of the budget: the line series still get all 2000 points.
+    """
+    grid = [[float(j - i) for i in range(100)] for j in range(70)]
+    grid[3][7] = -999.0  # the extreme cell, by magnitude and by minimum
+    _serve(
+        monkeypatch,
+        _figure(
+            _heatmap_panel(70, 100, title="Response matrix", values=grid),
+            _lines_panel(series=[_series("det1", 50_000)]),
+        ),
+    )
+
+    projected = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))
+
+    grid_panel, lines_panel = projected["panels"]
+    summary = grid_panel["mark"]
+    assert summary["kind"] == "heatmap_summary"
+    assert (summary["rows"], summary["columns"], summary["cells"]) == (70, 100, 7000)
+    assert summary["empty_cells"] == 0
+    assert (summary["value_label"], summary["value_units"]) == ("Response slope", "mm/A")
+    assert summary["x_labels"] == {"count": 100, "first": "C0", "last": "C99"}
+    assert summary["min"] == {"value": -999.0, "x_label": "C7", "y_label": "B3"}
+    assert summary["largest_magnitude"][0] == summary["min"]
+    assert len(summary["largest_magnitude"]) == 5
+    # Lossy, and says so in the same vocabulary every other mark uses.
+    assert (summary["decimated"], summary["source_points"]) == (True, 7000)
+    assert "larger than the 40x40" in grid_panel["annotations"][0]
+    # Costs nothing: the series keep the entire budget.
+    assert len(lines_panel["mark"]["series"][0]["points"]) == FIGURE_POINT_BUDGET
+
+
+async def test_heatmap_summary_reports_cells_never_measured(monkeypatch):
+    """A cell the run never took is counted, not folded in as a zero."""
+    grid = [[None if i == 0 else float(i) for i in range(50)] for _ in range(50)]
+    _serve(monkeypatch, _figure(_heatmap_panel(50, 50, values=grid)))
+
+    summary = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))["panels"][0][
+        "mark"
+    ]
+
+    assert summary["cells"] == 2500
+    assert summary["empty_cells"] == 50
+    assert summary["min"]["value"] == 1.0  # the Nones are absent, not minimal
+
+
+async def test_a_grid_at_the_limit_passes_through_as_cells_and_is_charged(monkeypatch):
+    """40x40 is returned cell by cell, and its 1600 cells come OUT of the budget.
+
+    Passing a small grid through whole and then spending the budget again on
+    series would put 3600 points in front of the agent under a 2000 promise.
+    """
+    _serve(
+        monkeypatch,
+        _figure(
+            _heatmap_panel(40, 40),
+            _lines_panel(series=[_series("det1", 50_000)]),
+        ),
+    )
+
+    projected = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))
+
+    assert projected["panels"][0]["mark"]["kind"] == "heatmap"
+    assert projected["panels"][0]["annotations"] == []
+    assert len(projected["panels"][1]["mark"]["series"][0]["points"]) == 400
+    assert projected["points_returned"] == FIGURE_POINT_BUDGET
+    assert _total_points(projected) == FIGURE_POINT_BUDGET
+
+
+async def test_one_row_over_the_limit_summarizes(monkeypatch):
+    """The limit is on either dimension: 41x40 is a summary, 40x40 is cells."""
+    _serve(monkeypatch, _figure(_heatmap_panel(41, 40)))
+
+    projected = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))
+
+    assert projected["panels"][0]["mark"]["kind"] == "heatmap_summary"
+
+
+async def test_a_small_grid_that_does_not_fit_is_summarized_for_that_reason(monkeypatch):
+    """Two 40x40 grids are 3200 cells. The second is summarized because the
+    budget ran out, and the annotation says budget rather than size — the
+    agent should not read it as an oversized grid."""
+    _serve(monkeypatch, _figure(_heatmap_panel(40, 40), _heatmap_panel(40, 40, title="Second")))
+
+    projected = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))
+
+    first, second = projected["panels"]
+    assert first["mark"]["kind"] == "heatmap"
+    assert second["mark"]["kind"] == "heatmap_summary"
+    assert "do not fit what is left of the figure's point budget" in second["annotations"][0]
+    assert _total_points(projected) == 1600
+
+
+async def test_a_grid_that_measured_nothing_summarizes_to_no_extremes(monkeypatch):
+    """A grid of nothing has no minimum, no maximum and no largest cell.
+
+    Reporting 0.0 for any of them would put a reading in front of the
+    operator that the run never took.
+    """
+    _serve(
+        monkeypatch,
+        _figure(_heatmap_panel(50, 50, values=[[None] * 50 for _ in range(50)])),
+    )
+
+    summary = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))["panels"][0][
+        "mark"
+    ]
+
+    assert (summary["min"], summary["max"]) == (None, None)
+    assert summary["largest_magnitude"] == []
+    assert (summary["cells"], summary["empty_cells"]) == (2500, 2500)
+
+
+async def test_a_ragged_grid_is_measured_by_what_is_actually_there(monkeypatch):
+    """Rows of differing length, and more cells than labels, are wire-legal.
+
+    ``columns`` takes the widest row (the size check errs toward summarizing)
+    while ``cells`` counts what the grid actually holds. A cell past the end
+    of the label list has no name, and says so rather than borrowing one.
+    """
+    values = [[1.0, 2.0, 90.0], [3.0], *([[4.0, 5.0]] * 39)]
+    panel = _heatmap_panel(41, 3, values=values)
+    panel.mark.x_labels = ["C0", "C1"]  # one column short of the widest row
+    _serve(monkeypatch, _figure(panel))
+
+    summary = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))["panels"][0][
+        "mark"
+    ]
+
+    assert (summary["rows"], summary["columns"]) == (41, 3)
+    assert summary["cells"] == 3 + 1 + 39 * 2
+    assert summary["max"] == {"value": 90.0, "x_label": None, "y_label": "B0"}
+    assert summary["x_labels"] == {"count": 2, "first": "C0", "last": "C1"}
+
+
+async def test_a_tall_thin_grid_is_over_the_limit(monkeypatch):
+    """41x1 is 41 cells and would fit the budget easily — the limit is on the
+    dimension, not the total, because a 41-row grid is already past what an
+    agent reads cell by cell."""
+    _serve(monkeypatch, _figure(_heatmap_panel(41, 1)))
+
+    mark = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))["panels"][0]["mark"]
+
+    assert mark["kind"] == "heatmap_summary"
+    assert (mark["rows"], mark["columns"]) == (41, 1)
+
+
+async def test_a_grid_is_never_returned_half_measured(monkeypatch):
+    """Striding cells out of a grid would read as missing measurements, so a
+    heatmap is all cells or a summary — never a grid with holes in it."""
+    _serve(monkeypatch, _figure(_heatmap_panel(30, 30)))
+
+    mark = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))["panels"][0]["mark"]
+
+    assert [len(row) for row in mark["values"]] == [30] * 30
+
+
+# --- bars ------------------------------------------------------------------
+
+
+async def test_bars_are_restrided_with_their_categories(monkeypatch):
+    """Bars ride through the same stride as lines, and the surviving values
+    stay aligned with the categories they belong to."""
+    values = [float(i) for i in range(5_000)]
+    _serve(
+        monkeypatch,
+        _figure(
+            Panel(
+                title="Corrector anomaly",
+                mark=BarsMark(
+                    label="anomaly",
+                    categories=[f"C{i}" for i in range(5_000)],
+                    values=values,
+                    source_points=5_000,
+                ),
+            )
+        ),
+    )
+
+    projected = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))
+
+    mark = projected["panels"][0]["mark"]
+    assert len(mark["values"]) == FIGURE_POINT_BUDGET
+    assert mark["decimated"] is True
+    assert mark["source_points"] == 5_000
+    assert mark["categories"][0] == "C0" and mark["categories"][-1] == "C4999"
+    assert all(
+        category == f"C{int(value)}"
+        for category, value in zip(mark["categories"], mark["values"], strict=True)
+    )
+
+
+async def test_bars_share_the_budget_with_series(monkeypatch):
+    """A bars mark is one more claimant on the same budget, not a free panel."""
+    _serve(
+        monkeypatch,
+        _figure(
+            Panel(
+                title="Anomaly",
+                mark=BarsMark(
+                    categories=[f"C{i}" for i in range(100)],
+                    values=[float(i) for i in range(100)],
+                    source_points=100,
+                ),
+            ),
+            _lines_panel(series=[_series("det1", 50_000)]),
+        ),
+    )
+
+    projected = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))
+
+    assert len(projected["panels"][0]["mark"]["values"]) == 100
+    assert len(projected["panels"][1]["mark"]["series"][0]["points"]) == 1_900
+    assert projected["points_returned"] == FIGURE_POINT_BUDGET
+
+
+# --- totality --------------------------------------------------------------
+
+
+async def test_a_figure_this_tool_cannot_read_is_an_error_not_a_relay(monkeypatch):
+    """The one thing this tool promises never to do is hand over an unbounded
+    figure, so an unreadable body refuses rather than falling back to the raw
+    payload — and says where to look instead."""
+    _serve(monkeypatch, {"panels": [{"title": "t", "mark": {"kind": "spirograph"}}]})
+
+    with assert_raises_error(error_type="bluesky_bridge_error"):
+        await _fn("get_run_figure")(run_id="run-1")
+
+
+async def test_the_refusal_message_is_bounded_like_the_figure_is(monkeypatch):
+    """The error path is the last place the bound could leak.
+
+    Pydantic reports a validation failure once per offending node, so a single
+    extra field on Point across 12x2000 points is tens of thousands of errors
+    and megabytes of message — handed to the agent as an error, which is
+    exactly the payload this tool exists to keep out of its context. Only the
+    count and the first few locations tell an operator anything.
+    """
+    body = _figure(
+        _lines_panel(series=[_series(f"det{i}", 2_000) for i in range(12)]),
+    )
+    for series in body["panels"][0]["mark"]["series"]:
+        for point in series["points"]:
+            point["z"] = 1.0
+
+    _serve(monkeypatch, body)
+
+    with pytest.raises(ToolError) as exc_info:
+        await _fn("get_run_figure")(run_id="run-1")
+    envelope = json.loads(str(exc_info.value))
+    assert len(envelope["error_message"]) < 600, "the refusal itself blew the context budget"
+    assert "24000 validation errors" in envelope["error_message"]
+
+
+async def test_a_mark_lying_about_its_decimation_refuses_rather_than_raising(monkeypatch):
+    """A series claiming fewer source points than it carries is a bug in the
+    figure, not something to repair silently: decimate rejects it, and the tool
+    turns that into the standard envelope instead of an unhandled error."""
+    body = _figure(_lines_panel(series=[_series("det1", 10)]))
+    body["panels"][0]["mark"]["series"][0]["source_points"] = 3
+
+    _serve(monkeypatch, body)
+
+    with pytest.raises(ToolError) as exc_info:
+        await _fn("get_run_figure")(run_id="run-1")
+    envelope = json.loads(str(exc_info.value))
+    assert envelope["error_type"] == "bluesky_bridge_error"
+    assert "get_run_data" in " ".join(envelope["suggestions"])
+
+
+async def test_a_figure_with_nothing_in_it_yet_keeps_its_empty_marks(monkeypatch):
+    """A run that has not produced rows yet has empty series, not missing ones.
+
+    Nothing to draw costs nothing, so an empty mark is never reported as one
+    the budget could not reach — an operator reading "not shown" would go
+    looking for a detector that is in fact simply not there yet.
+    """
+    _serve(
+        monkeypatch,
+        _figure(
+            _lines_panel(series=[_series("det1", 0)]),
+            Panel(title="Anomaly", mark=BarsMark(source_points=0)),
+            partial=True,
+        ),
+    )
+
+    projected = extract_response_dict(await _fn("get_run_figure")(run_id="run-1"))
+
+    lines_panel, bars_panel = projected["panels"]
+    assert lines_panel["mark"]["series"][0]["points"] == []
+    assert lines_panel["annotations"] == []
+    assert bars_panel["mark"]["values"] == []
+    assert bars_panel["annotations"] == []
+    assert projected["points_returned"] == 0
+
+
+# --- the docstring is the contract -----------------------------------------
+
+
+def test_docstring_narrates_every_reason_the_bridge_can_send():
+    """The docstring is the only description of a reason the agent ever sees.
+
+    A reason added to the bridge without a line here reaches the operator as a
+    bare code, or worse as "the plan failed" — the default view is real data,
+    and narrating it as an error is the failure mode this pins against.
+    """
+    doc = read_tools.get_run_figure.__doc__
+    for reason in FIGURE_REASONS:
+        assert f'"{reason}"' in doc, f"{reason} is not narrated in get_run_figure's docstring"
+    assert "Point-bounded by design: this never returns an unbounded figure." in doc
+    assert "DEFAULT VIEW" in doc
+    assert "heatmap_summary" in doc
+
+
+# ---------------------------------------------------------------------------
 # get_tool_fn unwrapping sanity check
 # ---------------------------------------------------------------------------
 
@@ -295,6 +932,7 @@ async def test_all_client_tools_are_registered_fastmcp_function_tools():
         "list_devices",
         "list_runs",
         "get_run_data",
+        "get_run_figure",
     ):
         tool = await mcp.get_tool(name)
         assert tool.fn is getattr(read_tools, name), f"{name} was not registered via @mcp.tool()"

--- a/tests/registry/test_bluesky_server_definition.py
+++ b/tests/registry/test_bluesky_server_definition.py
@@ -75,6 +75,7 @@ _EXPECTED_ALLOW = [
     "list_devices",
     "list_runs",
     "get_run_data",
+    "get_run_figure",
     "get_draft",
     "set_draft",
     "clear_draft",
@@ -89,7 +90,7 @@ def test_bluesky_permissions_allow():
 
 
 def test_bluesky_surface_has_no_bypass_of_the_panel_visible_draft():
-    """The agent-facing surface is exactly 16 tools and exposes no launch bypass.
+    """The agent-facing surface is exactly 17 tools and exposes no launch bypass.
 
     ``create_run_intent`` (the old intent-composing read tool) and
     ``launch_run`` (the old direct launch) are both gone: every agent execution
@@ -100,7 +101,7 @@ def test_bluesky_surface_has_no_bypass_of_the_panel_visible_draft():
     surface = [*bluesky["permissions_allow"], *bluesky["permissions_ask"]]
     assert "create_run_intent" not in surface
     assert "launch_run" not in surface
-    assert len(surface) == 16
+    assert len(surface) == 17
 
 
 def test_bluesky_permissions_ask():

--- a/tests/services/bluesky_bridge/test_decimation.py
+++ b/tests/services/bluesky_bridge/test_decimation.py
@@ -1,0 +1,295 @@
+"""Coverage for `decimate`.
+
+Three callers share this function -- the default figure builder, the
+panel-facing figure route, and the MCP projection that re-strides an already
+thinned figure onto a smaller budget -- and each of them publishes its result
+as `Series.decimated` / `Series.source_points`, which an operator and an agent
+both read as fact. So these tests pin the honesty properties, not just the
+count: the endpoints survive, the x order survives, gaps survive, and
+``source_points`` keeps meaning "before *any* decimation" across a second pass.
+
+Pure pydantic -- no bluesky import, so this runs in the fast import-clean lane.
+"""
+
+from __future__ import annotations
+
+from itertools import pairwise
+
+import pytest
+
+from osprey.services.bluesky_bridge.figure import (
+    DEFAULT_MAX_POINTS,
+    LinesMark,
+    Point,
+    Series,
+    decimate,
+)
+
+
+def _ramp(count: int, *, gaps: set[int] | None = None) -> list[Point]:
+    """``count`` points along x = index, with ``y=None`` at the ``gaps`` indices."""
+    gaps = gaps or set()
+    return [Point(x=float(i), y=None if i in gaps else float(i) * 2.0) for i in range(count)]
+
+
+def _xs(points: list[Point]) -> list[float]:
+    return [p.x for p in points]
+
+
+# --- Under budget: nothing is touched, nothing is claimed --------------------
+
+
+@pytest.mark.parametrize("count", [0, 1, 2, 7, 10])
+def test_at_or_under_budget_keeps_every_point(count: int) -> None:
+    points = _ramp(count)
+
+    result = decimate(points, 10)
+
+    assert result.points == points
+    assert result.decimated is False
+    assert result.source_points == count
+
+
+def test_under_budget_returns_a_new_list() -> None:
+    points = _ramp(5)
+
+    result = decimate(points, 10)
+
+    assert result.points is not points
+    result.points.append(Point(x=99.0, y=99.0))
+    assert len(points) == 5
+
+
+def test_default_budget_is_two_thousand() -> None:
+    assert DEFAULT_MAX_POINTS == 2000
+    assert decimate(_ramp(2000)).decimated is False
+    assert len(decimate(_ramp(2001)).points) == 2000
+
+
+def test_input_is_never_mutated() -> None:
+    points = _ramp(50, gaps={13})
+    before = [(p.x, p.y) for p in points]
+
+    decimate(points, 7)
+
+    assert [(p.x, p.y) for p in points] == before
+
+
+# --- Over budget: the stride ------------------------------------------------
+
+
+@pytest.mark.parametrize(("count", "budget"), [(11, 10), (100, 10), (2001, 2000), (99999, 2000)])
+def test_over_budget_spends_exactly_the_budget(count: int, budget: int) -> None:
+    result = decimate(_ramp(count), budget)
+
+    assert len(result.points) == budget
+    assert result.decimated is True
+    assert result.source_points == count
+
+
+@pytest.mark.parametrize(("count", "budget"), [(11, 10), (100, 10), (12345, 2000), (99999, 3)])
+def test_endpoints_and_x_order_survive(count: int, budget: int) -> None:
+    points = _ramp(count)
+
+    kept = decimate(points, budget).points
+
+    assert kept[0] == points[0]
+    assert kept[-1] == points[-1]
+    assert _xs(kept) == sorted(_xs(kept)), "stride must not reorder the series"
+    assert len(set(_xs(kept))) == len(kept), "no point is emitted twice"
+
+
+def test_stride_is_evenly_spaced() -> None:
+    # 10 points onto 5: both endpoints plus one from each of three equal
+    # interior windows -- the same selection an even stride would make.
+    kept = decimate(_ramp(10), 5).points
+
+    assert _xs(kept) == [0.0, 2.0, 4.0, 7.0, 9.0]
+
+
+def test_stride_spacing_stays_regular_on_a_large_series() -> None:
+    kept = decimate(_ramp(100_000), 1000).points
+
+    steps = [b - a for a, b in pairwise(_xs(kept))]
+    # 100 samples per window; only the endpoint-adjacent windows differ, and
+    # then by less than one window.
+    assert max(steps) - min(steps) < 100
+
+
+# --- Gaps are data, not noise ------------------------------------------------
+
+
+def test_a_lone_gap_survives_a_heavy_stride() -> None:
+    # An even stride over 1000 points onto 10 would sample none of index 500.
+    result = decimate(_ramp(1000, gaps={500}), 10)
+
+    gaps = [p for p in result.points if p.y is None]
+    assert len(gaps) == 1
+    assert gaps[0].x == 500.0
+
+
+def test_every_window_holding_a_gap_reports_one() -> None:
+    # 10 points onto 5 -> interior windows [1,3), [3,6), [6,9). Gaps in the
+    # first and last of those; the middle window has none.
+    kept = decimate(_ramp(10, gaps={2, 8}), 5).points
+
+    assert [(p.x, p.y) for p in kept] == [
+        (0.0, 0.0),
+        (2.0, None),  # window [1,3): the gap, not the midpoint
+        (4.0, 8.0),  # window [3,6): no gap, so the midpoint
+        (8.0, None),  # window [6,9): the gap, not the midpoint 7
+        (9.0, 18.0),
+    ]
+
+
+def test_the_first_gap_in_a_window_wins() -> None:
+    kept = decimate(_ramp(10, gaps={1, 2}), 5).points
+
+    assert kept[1].x == 1.0
+    assert kept[1].y is None
+
+
+def test_an_all_gap_series_decimates_to_gaps() -> None:
+    result = decimate(_ramp(500, gaps=set(range(500))), 20)
+
+    assert len(result.points) == 20
+    assert all(p.y is None for p in result.points)
+    assert result.source_points == 500
+
+
+def test_endpoints_win_over_the_gap_rule_but_are_still_truthful() -> None:
+    # A gap at index 1 sits in the first interior window, so it is kept there;
+    # index 0 stays index 0 because the series' x range is not negotiable.
+    kept = decimate(_ramp(10, gaps={0, 1, 9}), 5).points
+
+    assert (kept[0].x, kept[0].y) == (0.0, None), "an endpoint that IS a gap stays a gap"
+    assert (kept[1].x, kept[1].y) == (1.0, None)
+    assert (kept[-1].x, kept[-1].y) == (9.0, None)
+
+
+def test_a_gap_never_displaces_a_measured_window() -> None:
+    kept = decimate(_ramp(100, gaps={5}), 10).points
+
+    assert [p for p in kept if p.y is None] == [Point(x=5.0, y=None)]
+    assert sum(1 for p in kept if p.y is not None) == 9
+
+
+# --- Re-decimation composes -------------------------------------------------
+
+
+def test_second_pass_carries_the_original_count_forward() -> None:
+    first = decimate(_ramp(50_000), 2000)
+    assert first.source_points == 50_000
+
+    second = decimate(
+        first.points,
+        200,
+        source_points=first.source_points,
+        decimated=first.decimated,
+    )
+
+    assert len(second.points) == 200
+    assert second.decimated is True
+    assert second.source_points == 50_000, "source_points means before ANY decimation"
+    assert second.points[0] == first.points[0]
+    assert second.points[-1] == first.points[-1]
+
+
+def test_a_second_pass_under_budget_still_reports_the_first() -> None:
+    first = decimate(_ramp(5000), 100)
+
+    second = decimate(
+        first.points,
+        500,
+        source_points=first.source_points,
+        decimated=first.decimated,
+    )
+
+    assert second.points == first.points
+    assert second.decimated is True, "the series is still a thinned one"
+    assert second.source_points == 5000
+
+
+def test_forgetting_the_prior_truth_reports_only_this_pass() -> None:
+    # The trap the composing callers must avoid: without the two keyword
+    # arguments, an already-thinned input looks like raw data.
+    first = decimate(_ramp(50_000), 2000)
+
+    naive = decimate(first.points, 200)
+
+    assert naive.source_points == 2000
+    assert naive.decimated is True
+
+
+def test_source_points_smaller_than_the_input_is_a_bug_not_a_figure() -> None:
+    with pytest.raises(ValueError, match="before decimation"):
+        decimate(_ramp(100), 10, source_points=50)
+
+
+def test_source_points_may_exceed_the_input_without_a_second_stride() -> None:
+    result = decimate(_ramp(10), 100, source_points=999, decimated=True)
+
+    assert result.source_points == 999
+    assert result.decimated is True
+
+
+# --- Degenerate budgets ------------------------------------------------------
+
+
+def test_budget_of_two_keeps_only_the_endpoints() -> None:
+    result = decimate(_ramp(100), 2)
+
+    assert _xs(result.points) == [0.0, 99.0]
+    assert result.source_points == 100
+
+
+def test_budget_of_one_keeps_the_first_point() -> None:
+    result = decimate(_ramp(100), 1)
+
+    assert _xs(result.points) == [0.0]
+    assert result.decimated is True
+
+
+@pytest.mark.parametrize("budget", [0, -1])
+def test_a_budget_below_one_is_rejected(budget: int) -> None:
+    with pytest.raises(ValueError, match="at least 1"):
+        decimate(_ramp(10), budget)
+
+
+def test_empty_input_needs_no_budget_argument() -> None:
+    result = decimate([])
+
+    assert result.points == []
+    assert result.decimated is False
+    assert result.source_points == 0
+
+
+# --- Feeding the models ------------------------------------------------------
+
+
+def test_the_result_splats_into_a_series() -> None:
+    result = decimate(_ramp(9000, gaps={4500}), 2000)
+
+    series = Series(label="bpm3", **result._asdict())
+
+    assert series.decimated is True
+    assert series.source_points == 9000
+    assert len(series.points) == 2000
+    assert any(p.y is None for p in series.points)
+
+
+def test_mark_level_truth_aggregates_the_per_series_truth() -> None:
+    thinned = decimate(_ramp(5000), 2000)
+    untouched = decimate(_ramp(10))
+
+    mark = LinesMark(
+        series=[
+            Series(label="thinned", **thinned._asdict()),
+            Series(label="untouched", **untouched._asdict()),
+        ],
+        decimated=thinned.decimated or untouched.decimated,
+        source_points=thinned.source_points + untouched.source_points,
+    )
+
+    assert mark.decimated is True
+    assert mark.source_points == 5010

--- a/tests/services/bluesky_bridge/test_default_figure.py
+++ b/tests/services/bluesky_bridge/test_default_figure.py
@@ -1,0 +1,465 @@
+"""Coverage for `default_figure`.
+
+The default figure is what a run gets when no plan render produced one -- and
+several of the paths that land here landed here *because* something already
+failed, so these tests pin two things above the drawing itself: the figure never
+misrepresents what it is showing (a column that stops reading is a gap, not a
+dropped column; a capped or windowed figure says so), and no input makes it
+raise.
+
+Pure pydantic -- no bluesky import, so this runs in the fast import-clean lane.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from osprey.services.bluesky_bridge.figure import (
+    DEFAULT_MAX_POINTS,
+    MAX_DEFAULT_SERIES,
+    REASON_NO_RENDER,
+    REASON_SOURCE_UNAVAILABLE,
+    Figure,
+    LinesMark,
+    RowWindow,
+    default_figure,
+    rows_from_columnar,
+)
+
+
+def _window(columns, rows, total_seen=None):
+    """A `RowWindow` from columnar values, complete unless told otherwise."""
+    return rows_from_columnar(columns, rows, len(rows) if total_seen is None else total_seen)
+
+
+def _series(figure: Figure, index: int):
+    mark = figure.panels[index].mark
+    assert isinstance(mark, LinesMark)
+    return mark.series[0]
+
+
+def _ys(figure: Figure, index: int) -> list[float | None]:
+    return [point.y for point in _series(figure, index).points]
+
+
+# --- Which columns become series ---------------------------------------------
+
+
+def test_one_panel_per_numeric_column_in_column_order():
+    figure = default_figure(
+        _window(["bpm1", "bpm2"], [[1.0, 4.0], [2.0, 5.0]]),
+        reason=REASON_NO_RENDER,
+        partial=False,
+        source="live",
+    )
+
+    assert [panel.title for panel in figure.panels] == ["bpm1", "bpm2"]
+    assert [_series(figure, i).label for i in (0, 1)] == ["bpm1", "bpm2"]
+
+
+def test_each_panel_carries_exactly_one_series():
+    figure = default_figure(
+        _window(["bpm1", "bpm2"], [[1.0, 4.0]]),
+        reason=REASON_NO_RENDER,
+        partial=False,
+        source="live",
+    )
+
+    for panel in figure.panels:
+        assert isinstance(panel.mark, LinesMark)
+        assert len(panel.mark.series) == 1
+
+
+def test_x_is_the_row_index():
+    figure = default_figure(
+        _window(["bpm1"], [[1.0], [2.0], [3.0]]),
+        reason=REASON_NO_RENDER,
+        partial=False,
+        source="live",
+    )
+
+    assert [point.x for point in _series(figure, 0).points] == [0.0, 1.0, 2.0]
+
+
+def test_a_column_numeric_in_one_row_only_is_still_drawn():
+    figure = default_figure(
+        _window(["mostly_missing"], [[None], [None], [7.0], [None]]),
+        reason=REASON_NO_RENDER,
+        partial=False,
+        source="live",
+    )
+
+    assert [panel.title for panel in figure.panels] == ["mostly_missing"]
+    assert _ys(figure, 0) == [None, None, 7.0, None]
+
+
+def test_a_column_that_stops_reading_is_a_gapped_series_not_a_dropped_column():
+    # The pinned case: numeric through row 49, nothing afterwards. A predicate
+    # that asked "is this column numeric in the rows I have?" of the tail window
+    # would drop it; the column must survive as one series with a long gap.
+    values = [[float(i), 0.0] for i in range(50)] + [[None, 0.0] for _ in range(50)]
+    figure = default_figure(
+        _window(["stops_early", "steady"], values),
+        reason=REASON_NO_RENDER,
+        partial=False,
+        source="live",
+    )
+
+    assert [panel.title for panel in figure.panels] == ["stops_early", "steady"]
+    ys = _ys(figure, 0)
+    assert len(ys) == 100
+    assert ys[:50] == [float(i) for i in range(50)]
+    assert ys[50:] == [None] * 50
+
+
+def test_a_column_that_starts_reading_late_is_drawn_from_row_zero():
+    figure = default_figure(
+        _window(["starts_late"], [[None], [None], [3.0]]),
+        reason=REASON_NO_RENDER,
+        partial=False,
+        source="live",
+    )
+
+    assert _ys(figure, 0) == [None, None, 3.0]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, "reading", b"reading", True, False, math.inf, -math.inf],
+    ids=["none", "str", "bytes", "true", "false", "inf", "neg-inf"],
+)
+def test_non_numeric_entries_are_gaps_not_values(value):
+    figure = default_figure(
+        _window(["mixed"], [[1.0], [value], [3.0]]),
+        reason=REASON_NO_RENDER,
+        partial=False,
+        source="live",
+    )
+
+    assert _ys(figure, 0) == [1.0, None, 3.0]
+
+
+@pytest.mark.parametrize(
+    "values",
+    [["a", "b"], [True, False], [None, None], [math.inf, -math.inf]],
+    ids=["strings", "bools", "nones", "infinities"],
+)
+def test_a_column_never_finite_numeric_is_not_drawn(values):
+    figure = default_figure(
+        _window(["never_numeric"], [[value] for value in values]),
+        reason=REASON_NO_RENDER,
+        partial=False,
+        source="live",
+    )
+
+    assert figure.panels == []
+
+
+def test_nan_from_a_tiled_table_draws_the_same_figure_as_none_from_the_live_buffer():
+    live = default_figure(
+        _window(["bpm1"], [[1.0], [None], [3.0]]),
+        reason=REASON_NO_RENDER,
+        partial=False,
+        source="live",
+    )
+    tiled = default_figure(
+        _window(["bpm1"], [[1.0], [float("nan")], [3.0]]),
+        reason=REASON_NO_RENDER,
+        partial=False,
+        source="tiled",
+    )
+
+    assert _ys(live, 0) == _ys(tiled, 0) == [1.0, None, 3.0]
+
+
+def test_integers_and_integer_strings_are_told_apart():
+    figure = default_figure(
+        _window(["count", "label"], [[3, "12"], [4, "13"]]),
+        reason=REASON_NO_RENDER,
+        partial=False,
+        source="live",
+    )
+
+    assert [panel.title for panel in figure.panels] == ["count"]
+    assert _ys(figure, 0) == [3.0, 4.0]
+
+
+def test_a_row_missing_a_column_key_is_a_gap():
+    window = RowWindow([{"bpm1": 1.0}, {}, {"bpm1": 3.0}], ["bpm1"], True, 3)
+
+    figure = default_figure(window, reason=REASON_NO_RENDER, partial=False, source="live")
+
+    assert _ys(figure, 0) == [1.0, None, 3.0]
+
+
+def test_keys_outside_the_declared_columns_are_not_drawn():
+    window = RowWindow([{"bpm1": 1.0, "undeclared": 2.0}], ["bpm1"], True, 1)
+
+    figure = default_figure(window, reason=REASON_NO_RENDER, partial=False, source="live")
+
+    assert [panel.title for panel in figure.panels] == ["bpm1"]
+
+
+# --- The series cap ----------------------------------------------------------
+
+
+def test_forty_numeric_columns_give_twelve_panels_and_an_annotation_naming_the_rest():
+    columns = [f"bpm{i}" for i in range(40)]
+    figure = default_figure(
+        _window(columns, [[float(i) for i in range(40)]]),
+        reason=REASON_NO_RENDER,
+        partial=False,
+        source="live",
+    )
+
+    assert len(figure.panels) == MAX_DEFAULT_SERIES == 12
+    assert [panel.title for panel in figure.panels] == columns[:12]
+    assert any("28" in note for note in figure.panels[0].annotations)
+
+
+def test_the_cap_annotation_lands_on_the_first_panel_only():
+    columns = [f"bpm{i}" for i in range(40)]
+    figure = default_figure(
+        _window(columns, [[float(i) for i in range(40)]]),
+        reason=REASON_NO_RENDER,
+        partial=False,
+        source="live",
+    )
+
+    assert len(figure.panels[0].annotations) == 1
+    assert all(panel.annotations == [] for panel in figure.panels[1:])
+
+
+def test_the_cap_counts_drawable_columns_not_declared_ones():
+    # 40 declared columns, half of them never numeric: 20 drawable, 8 omitted.
+    columns = [f"col{i}" for i in range(40)]
+    row = [float(i) if i % 2 else "text" for i in range(40)]
+    figure = default_figure(
+        _window(columns, [row]),
+        reason=REASON_NO_RENDER,
+        partial=False,
+        source="live",
+    )
+
+    assert len(figure.panels) == 12
+    assert any("8 more" in note for note in figure.panels[0].annotations)
+
+
+def test_exactly_twelve_columns_are_not_annotated():
+    columns = [f"bpm{i}" for i in range(12)]
+    figure = default_figure(
+        _window(columns, [[float(i) for i in range(12)]]),
+        reason=REASON_NO_RENDER,
+        partial=False,
+        source="live",
+    )
+
+    assert len(figure.panels) == 12
+    assert figure.panels[0].annotations == []
+
+
+def test_a_single_omitted_column_reads_as_singular():
+    columns = [f"bpm{i}" for i in range(13)]
+    figure = default_figure(
+        _window(columns, [[float(i) for i in range(13)]]),
+        reason=REASON_NO_RENDER,
+        partial=False,
+        source="live",
+    )
+
+    assert figure.panels[0].annotations == [
+        "1 more numeric column not shown; the table below lists every column."
+    ]
+
+
+# --- Incomplete windows ------------------------------------------------------
+
+
+def test_a_windowed_run_says_how_many_rows_it_is_showing():
+    figure = default_figure(
+        _window(["bpm1"], [[1.0], [2.0]], total_seen=500),
+        reason=REASON_NO_RENDER,
+        partial=True,
+        source="live",
+    )
+
+    assert figure.panels[0].annotations == ["Showing 2 of 500 rows the run produced."]
+
+
+def test_a_complete_window_is_not_annotated():
+    figure = default_figure(
+        _window(["bpm1"], [[1.0], [2.0]]),
+        reason=REASON_NO_RENDER,
+        partial=False,
+        source="live",
+    )
+
+    assert figure.panels[0].annotations == []
+
+
+def test_a_capped_and_windowed_figure_reports_both():
+    columns = [f"bpm{i}" for i in range(40)]
+    figure = default_figure(
+        _window(columns, [[float(i) for i in range(40)]], total_seen=9),
+        reason=REASON_NO_RENDER,
+        partial=True,
+        source="tiled",
+    )
+
+    assert len(figure.panels[0].annotations) == 2
+
+
+# --- Decimation --------------------------------------------------------------
+
+
+def test_a_long_series_is_decimated_and_says_so():
+    rows = [[float(i)] for i in range(DEFAULT_MAX_POINTS * 3)]
+    figure = default_figure(
+        _window(["bpm1"], rows),
+        reason=REASON_NO_RENDER,
+        partial=False,
+        source="tiled",
+    )
+
+    series = _series(figure, 0)
+    mark = figure.panels[0].mark
+    assert len(series.points) == DEFAULT_MAX_POINTS
+    assert series.decimated is True
+    assert series.source_points == DEFAULT_MAX_POINTS * 3
+    assert mark.decimated is True
+    assert mark.source_points == DEFAULT_MAX_POINTS * 3
+
+
+def test_decimation_keeps_the_first_and_last_rows():
+    rows = [[float(i)] for i in range(DEFAULT_MAX_POINTS * 3)]
+    figure = default_figure(
+        _window(["bpm1"], rows),
+        reason=REASON_NO_RENDER,
+        partial=False,
+        source="tiled",
+    )
+
+    points = _series(figure, 0).points
+    assert points[0].x == 0.0
+    assert points[-1].x == float(DEFAULT_MAX_POINTS * 3 - 1)
+
+
+def test_a_gap_survives_decimation():
+    rows = [[float(i)] for i in range(DEFAULT_MAX_POINTS * 3)]
+    rows[7] = [None]
+    figure = default_figure(
+        _window(["bpm1"], rows),
+        reason=REASON_NO_RENDER,
+        partial=False,
+        source="tiled",
+    )
+
+    assert any(point.y is None for point in _series(figure, 0).points)
+
+
+def test_an_undecimated_series_reports_its_own_length():
+    figure = default_figure(
+        _window(["bpm1"], [[1.0], [2.0], [3.0]]),
+        reason=REASON_NO_RENDER,
+        partial=False,
+        source="live",
+    )
+
+    series = _series(figure, 0)
+    mark = figure.panels[0].mark
+    assert series.decimated is False
+    assert series.source_points == 3
+    assert mark.decimated is False
+    assert mark.source_points == 3
+
+
+# --- The figure envelope -----------------------------------------------------
+
+
+def test_partial_source_and_reason_are_the_callers_to_state():
+    figure = default_figure(
+        _window(["bpm1"], [[1.0]]),
+        reason=REASON_SOURCE_UNAVAILABLE,
+        partial=True,
+        source="tiled",
+    )
+
+    assert figure.partial is True
+    assert figure.source == "tiled"
+    assert figure.reason == REASON_SOURCE_UNAVAILABLE
+
+
+def test_reason_may_be_none():
+    figure = default_figure(
+        _window(["bpm1"], [[1.0]]),
+        reason=None,
+        partial=False,
+        source="live",
+    )
+
+    assert figure.reason is None
+
+
+def test_the_figure_round_trips_through_its_own_wire_form():
+    columns = [f"bpm{i}" for i in range(40)]
+    figure = default_figure(
+        _window(columns, [[float(i) for i in range(40)], [None] * 40]),
+        reason=REASON_NO_RENDER,
+        partial=True,
+        source="live",
+    )
+
+    assert Figure.model_validate(figure.model_dump()) == figure
+
+
+# --- Never raises ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("columns", "rows"),
+    [
+        ([], []),
+        ([], [[]]),
+        (["bpm1"], []),
+        (["bpm1"], [[None]]),
+        (["bpm1", "bpm2"], [["a", "b"], ["c", "d"]]),
+    ],
+    ids=["nothing", "empty-rows", "no-rows", "all-none", "all-strings"],
+)
+def test_degenerate_windows_give_an_empty_figure_rather_than_raising(columns, rows):
+    figure = default_figure(
+        _window(columns, rows),
+        reason=REASON_SOURCE_UNAVAILABLE,
+        partial=False,
+        source="tiled",
+    )
+
+    assert figure.panels == []
+    assert figure.reason == REASON_SOURCE_UNAVAILABLE
+
+
+def test_an_unhelpful_value_type_is_a_gap_not_an_exception():
+    class Opaque:
+        pass
+
+    window = RowWindow([{"bpm1": 1.0}, {"bpm1": Opaque()}], ["bpm1"], True, 2)
+
+    figure = default_figure(window, reason=REASON_NO_RENDER, partial=False, source="live")
+
+    assert _ys(figure, 0) == [1.0, None]
+
+
+def test_an_empty_window_over_a_nonempty_run_still_draws_nothing_and_says_so():
+    figure = default_figure(
+        RowWindow([], ["bpm1"], False, 400),
+        reason=REASON_SOURCE_UNAVAILABLE,
+        partial=True,
+        source="tiled",
+    )
+
+    # No panel exists to carry the annotation -- an empty figure shows nothing
+    # to qualify -- but the envelope still reports partial/source/reason.
+    assert figure.panels == []
+    assert figure.partial is True

--- a/tests/services/bluesky_bridge/test_figure_cache.py
+++ b/tests/services/bluesky_bridge/test_figure_cache.py
@@ -1,0 +1,463 @@
+"""Unit tests for the settled-figure cache (`figure_cache.py`).
+
+Figures are opaque to the cache, so these tests store plain sentinels rather
+than real `Figure` objects — anything the cache did to a value would show up as
+a failure here. The threaded sections drive the two-thread shape the module is
+built for: route threads snapshotting a generation, computing, and storing,
+against document-plane threads evicting the same run id.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from osprey.services.bluesky_bridge import document_plane, figure_cache, live_rows
+from osprey.services.bluesky_bridge.document_plane import RunDocumentRouter
+from osprey.services.bluesky_bridge.queue_backend import PLAN_META_KEY, RUN_ID_META_KEY
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cache():
+    """Every test gets an empty module-level cache."""
+    figure_cache._clear()
+    live_rows._clear()
+    yield
+    figure_cache._clear()
+    live_rows._clear()
+
+
+def _key(run_id: str = "run-1", plan: str | None = "orm", source: str = "tiled"):
+    return figure_cache.make_key(run_id, plan, source)
+
+
+# =========================================================================
+# Keys and basic storage
+# =========================================================================
+
+
+def test_make_key_orders_run_id_first() -> None:
+    assert figure_cache.make_key("run-1", "orm", "tiled") == ("run-1", "orm", "tiled")
+
+
+def test_unknown_key_misses() -> None:
+    assert figure_cache.get(_key()) is None
+
+
+def test_a_stored_figure_comes_back_by_identity() -> None:
+    figure = object()
+    assert figure_cache.put(_key(), figure, generation=0) is True
+
+    assert figure_cache.get(_key()) is figure
+
+
+def test_a_stored_none_is_indistinguishable_from_a_miss() -> None:
+    # Documented consequence of `get` returning `None` for a miss: the route
+    # never stores `None`, and this pins that the cache does not pretend
+    # otherwise.
+    figure_cache.put(_key(), None, generation=0)
+
+    assert figure_cache.get(_key()) is None
+
+
+def test_the_three_key_fields_are_all_significant() -> None:
+    live, tiled = object(), object()
+    figure_cache.put(_key(source="live"), live, generation=0)
+    figure_cache.put(_key(source="tiled"), tiled, generation=0)
+
+    assert figure_cache.get(_key(source="live")) is live
+    assert figure_cache.get(_key(source="tiled")) is tiled
+    assert figure_cache.get(_key(plan="grid_scan")) is None
+    assert figure_cache.get(_key(run_id="run-2")) is None
+
+
+def test_an_unknown_plan_name_is_its_own_key_not_a_wildcard() -> None:
+    unknown = object()
+    figure_cache.put(_key(plan=None), unknown, generation=0)
+
+    assert figure_cache.get(_key(plan=None)) is unknown
+    assert figure_cache.get(_key(plan="orm")) is None
+
+
+def test_a_second_put_replaces_the_entry() -> None:
+    first, second = object(), object()
+    figure_cache.put(_key(), first, generation=0)
+    figure_cache.put(_key(), second, generation=0)
+
+    assert figure_cache.get(_key()) is second
+
+
+# =========================================================================
+# Run-scoped reads (get_for_source — the rotated branch's lookup, which has
+# no plan name until it pays for the Tiled read the cache exists to avoid)
+# =========================================================================
+
+
+def test_get_for_source_finds_an_exact_key_put_without_the_plan_name() -> None:
+    figure = object()
+    figure_cache.put(_key(plan="orm", source="tiled"), figure, generation=0)
+
+    assert figure_cache.get_for_source("run-1", "tiled") is figure
+
+
+def test_get_for_source_discriminates_source_and_run_id() -> None:
+    live, tiled = object(), object()
+    figure_cache.put(_key(source="live"), live, generation=0)
+    figure_cache.put(_key(source="tiled"), tiled, generation=0)
+
+    assert figure_cache.get_for_source("run-1", "live") is live
+    assert figure_cache.get_for_source("run-1", "tiled") is tiled
+    assert figure_cache.get_for_source("run-2", "tiled") is None
+
+
+def test_get_for_source_misses_after_evict() -> None:
+    figure_cache.put(_key(source="tiled"), object(), generation=0)
+    figure_cache.evict("run-1")
+
+    assert figure_cache.get_for_source("run-1", "tiled") is None
+
+
+def test_get_for_source_refreshes_the_lru_position_like_get() -> None:
+    kept = object()
+    figure_cache.put(_key(run_id="hot", source="tiled"), kept, generation=0)
+    for i in range(figure_cache._MAX_ENTRIES - 1):
+        figure_cache.put(_key(run_id=f"filler-{i}"), object(), generation=0)
+
+    # A run-scoped read must keep its entry hot, exactly as `get` does...
+    assert figure_cache.get_for_source("hot", "tiled") is kept
+    figure_cache.put(_key(run_id="one-more"), object(), generation=0)
+
+    # ...so the overflow evicts the oldest filler, not the just-read entry.
+    assert figure_cache.get_for_source("hot", "tiled") is kept
+    assert figure_cache.get(_key(run_id="filler-0")) is None
+
+
+# =========================================================================
+# Bounding
+# =========================================================================
+
+
+def test_the_cache_is_bounded_and_drops_the_least_recently_used() -> None:
+    for index in range(figure_cache._MAX_ENTRIES):
+        figure_cache.put(_key(run_id=f"run-{index}"), index, generation=0)
+    # Touch the oldest so it is no longer the eviction candidate.
+    assert figure_cache.get(_key(run_id="run-0")) == 0
+
+    figure_cache.put(_key(run_id="overflow"), "new", generation=0)
+
+    assert len(figure_cache._entries) == figure_cache._MAX_ENTRIES
+    assert figure_cache.get(_key(run_id="run-0")) == 0
+    assert figure_cache.get(_key(run_id="run-1")) is None
+    assert figure_cache.get(_key(run_id="overflow")) == "new"
+
+
+def test_generations_are_bounded_and_take_their_runs_entries_with_them() -> None:
+    # A counter that outlives its entries is harmless; an entry that outlives
+    # its counter would be compared against a generation reset to zero — which
+    # is exactly the value a stalled computation may be holding.
+    figure_cache.put(_key(run_id="oldest"), "figure", generation=0)
+    for index in range(figure_cache._MAX_GENERATIONS):
+        figure_cache.evict(f"run-{index}")
+
+    assert "oldest" not in figure_cache._generations
+    assert figure_cache.get(_key(run_id="oldest")) is None
+    assert len(figure_cache._generations) == figure_cache._MAX_GENERATIONS
+
+
+def test_every_cached_entry_keeps_a_generation_counter() -> None:
+    figure_cache.put(_key(), "figure", generation=0)
+
+    assert figure_cache._generations["run-1"] == 0
+
+
+# =========================================================================
+# Eviction and the generation counter
+# =========================================================================
+
+
+def test_evict_drops_every_source_variant_of_the_run() -> None:
+    figure_cache.put(_key(source="live"), "live", generation=0)
+    figure_cache.put(_key(source="tiled"), "tiled", generation=0)
+    figure_cache.put(_key(plan="grid_scan", source="tiled"), "other-plan", generation=0)
+
+    figure_cache.evict("run-1")
+
+    assert figure_cache.get(_key(source="live")) is None
+    assert figure_cache.get(_key(source="tiled")) is None
+    assert figure_cache.get(_key(plan="grid_scan", source="tiled")) is None
+
+
+def test_evict_leaves_other_runs_alone() -> None:
+    figure_cache.put(_key(run_id="run-1"), "one", generation=0)
+    figure_cache.put(_key(run_id="run-2"), "two", generation=0)
+
+    figure_cache.evict("run-1")
+
+    assert figure_cache.get(_key(run_id="run-2")) == "two"
+    assert figure_cache.snapshot_generation("run-2") == 0
+
+
+def test_evict_bumps_the_generation_even_with_nothing_cached() -> None:
+    # The bump is for computations in flight, which leave no trace in the map.
+    assert figure_cache.snapshot_generation("run-1") == 0
+
+    figure_cache.evict("run-1")
+
+    assert figure_cache.snapshot_generation("run-1") == 1
+
+
+def test_generations_accumulate_across_evictions() -> None:
+    for expected in range(1, 4):
+        figure_cache.evict("run-1")
+        assert figure_cache.snapshot_generation("run-1") == expected
+
+
+# =========================================================================
+# Compare-and-set stores
+# =========================================================================
+
+
+def test_a_store_at_the_current_generation_lands() -> None:
+    figure_cache.evict("run-1")
+    generation = figure_cache.snapshot_generation("run-1")
+
+    assert figure_cache.put(_key(), "figure", generation) is True
+    assert figure_cache.get(_key()) == "figure"
+
+
+def test_a_store_from_before_an_eviction_is_dropped() -> None:
+    generation = figure_cache.snapshot_generation("run-1")
+    figure_cache.evict("run-1")
+
+    assert figure_cache.put(_key(), "stale", generation) is False
+    assert figure_cache.get(_key()) is None
+
+
+def test_a_stale_store_does_not_overwrite_a_fresh_entry() -> None:
+    stale_generation = figure_cache.snapshot_generation("run-1")
+    figure_cache.evict("run-1")
+    figure_cache.put(_key(), "fresh", figure_cache.snapshot_generation("run-1"))
+
+    assert figure_cache.put(_key(), "stale", stale_generation) is False
+    assert figure_cache.get(_key()) == "fresh"
+
+
+def test_a_store_from_the_future_is_dropped_too() -> None:
+    # Not reachable through the route, but the check is an equality on purpose:
+    # a generation the cache never issued is not evidence of freshness.
+    assert figure_cache.put(_key(), "figure", generation=7) is False
+    assert figure_cache.get(_key()) is None
+
+
+# =========================================================================
+# Threaded: evictions against reads and stores
+# =========================================================================
+
+
+def test_a_stalled_computation_interleaved_with_an_eviction_does_not_land() -> None:
+    """The stalled-render race, driven for real rather than by call ordering."""
+    snapshotted = threading.Event()
+    evicted = threading.Event()
+    stored: list[bool] = []
+
+    def compute_and_store() -> None:
+        generation = figure_cache.snapshot_generation("run-1")
+        snapshotted.set()
+        assert evicted.wait(timeout=5.0)
+        stored.append(figure_cache.put(_key(), "stale", generation))
+
+    worker = threading.Thread(target=compute_and_store)
+    worker.start()
+    assert snapshotted.wait(timeout=5.0)
+    figure_cache.evict("run-1")
+    evicted.set()
+    worker.join(timeout=5.0)
+
+    assert not worker.is_alive()
+    assert stored == [False]
+    assert figure_cache.get(_key()) is None
+
+
+def test_concurrent_evictions_and_reads_neither_deadlock_nor_lose_an_eviction() -> None:
+    """Route threads storing against document-plane threads evicting.
+
+    The invariant asserted is the one the cache exists to keep: whatever is
+    cached at the end was stored at the generation still current for that run.
+    An entry stamped with an older generation would be a lost eviction — a
+    figure built from rows that run id no longer means.
+    """
+    run_ids = [f"run-{index}" for index in range(4)]
+    stop = threading.Event()
+    failures: list[str] = []
+    barrier = threading.Barrier(6)
+
+    def reader(run_id: str) -> None:
+        barrier.wait(timeout=5.0)
+        try:
+            while not stop.is_set():
+                generation = figure_cache.snapshot_generation(run_id)
+                key = figure_cache.make_key(run_id, "orm", "tiled")
+                figure_cache.get(key)
+                # Stand in for the source read + render the route does here.
+                time.sleep(0.0005)
+                figure_cache.put(key, generation, generation)
+        except Exception as exc:  # pragma: no cover - a failure path
+            failures.append(f"reader {run_id}: {exc!r}")
+
+    def evictor() -> None:
+        barrier.wait(timeout=5.0)
+        try:
+            while not stop.is_set():
+                for run_id in run_ids:
+                    figure_cache.evict(run_id)
+                time.sleep(0.0005)
+        except Exception as exc:  # pragma: no cover - a failure path
+            failures.append(f"evictor: {exc!r}")
+
+    threads = [threading.Thread(target=reader, args=(run_id,)) for run_id in run_ids]
+    threads += [threading.Thread(target=evictor) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    time.sleep(0.5)
+    stop.set()
+    for thread in threads:
+        thread.join(timeout=10.0)
+
+    assert not [thread for thread in threads if thread.is_alive()], "threads did not finish"
+    assert failures == []
+    assert figure_cache._lock.acquire(timeout=1.0), "cache lock was left held"
+    figure_cache._lock.release()
+    for run_id in run_ids:
+        assert figure_cache.snapshot_generation(run_id) > 0, "the evictors never ran"
+        cached = figure_cache.get(figure_cache.make_key(run_id, "orm", "tiled"))
+        if cached is not None:
+            assert cached == figure_cache.snapshot_generation(run_id)
+
+
+# =========================================================================
+# Document-plane wiring
+# =========================================================================
+
+
+def _start_doc(run_uid: str, run_id: str | None = "run-1") -> dict:
+    doc: dict = {"uid": run_uid, "num_points": 3}
+    if run_id is not None:
+        doc[RUN_ID_META_KEY] = run_id
+        doc[PLAN_META_KEY] = {"name": "orm", "kwargs": {}}
+    return doc
+
+
+def test_a_start_document_evicts_the_run_ids_cached_figures() -> None:
+    figure_cache.put(_key(source="live"), "live", generation=0)
+    figure_cache.put(_key(source="tiled"), "tiled", generation=0)
+
+    RunDocumentRouter()("start", _start_doc("uid-1"))
+
+    assert figure_cache.get(_key(source="live")) is None
+    assert figure_cache.get(_key(source="tiled")) is None
+    assert figure_cache.snapshot_generation("run-1") == 1
+
+
+def test_a_start_document_without_a_run_id_evicts_under_the_run_uid() -> None:
+    # Same fallback identity the recorder keys its buffer by.
+    figure_cache.put(_key(run_id="uid-1"), "figure", generation=0)
+
+    RunDocumentRouter()("start", _start_doc("uid-1", run_id=None))
+
+    assert figure_cache.get(_key(run_id="uid-1")) is None
+    assert figure_cache.snapshot_generation("uid-1") == 1
+
+
+def test_a_start_document_leaves_other_run_ids_cached() -> None:
+    figure_cache.put(_key(run_id="run-2"), "untouched", generation=0)
+
+    RunDocumentRouter()("start", _start_doc("uid-1"))
+
+    assert figure_cache.get(_key(run_id="run-2")) == "untouched"
+
+
+def test_the_rows_are_already_the_new_runs_when_the_generation_is_bumped() -> None:
+    """Ordering: eviction runs after the recorder write, not before it.
+
+    A figure computation that snapshots the post-bump generation must be reading
+    the NEW run's rows — otherwise it could cache the previous occupant's rows
+    under a generation that looks current.
+    """
+    router = RunDocumentRouter()
+    router("start", _start_doc("uid-1"))
+    router("descriptor", {"uid": "desc-1", "run_start": "uid-1"})
+    router("event", {"descriptor": "desc-1", "data": {"x": 1.0}})
+    router("stop", {"run_start": "uid-1"})
+    assert live_rows.get("run-1")["total_seen"] == 1
+
+    observed: list[int] = []
+
+    class _WatchingRecorder:
+        """Records the generation as of the moment the buffer is reset."""
+
+        def __init__(self, key=None, plan=None):
+            self._inner = live_rows.LiveRowRecorder(key=key, plan=plan)
+
+        def __call__(self, name: str, doc: dict) -> None:
+            self._inner(name, doc)
+            if name == "start":
+                observed.append(figure_cache.snapshot_generation("run-1"))
+                observed.append(live_rows.get("run-1")["total_seen"])
+
+    before = figure_cache.snapshot_generation("run-1")
+    original = document_plane.LiveRowRecorder
+    document_plane.LiveRowRecorder = _WatchingRecorder  # type: ignore[misc]
+    try:
+        router("start", _start_doc("uid-2"))
+    finally:
+        document_plane.LiveRowRecorder = original  # type: ignore[misc]
+
+    # Buffer already reset while the generation was still the old one, so the
+    # bump strictly follows the row reset.
+    assert observed == [before, 0]
+    assert figure_cache.snapshot_generation("run-1") == before + 1
+
+
+def test_the_eviction_hook_never_holds_both_locks() -> None:
+    """`live_rows`' lock is free while the cache's is held, and vice versa.
+
+    The two locks are never nested in either order, so there is no ordering for
+    a future caller to violate. Asserted from inside each critical section.
+    """
+    held: list[bool] = []
+
+    original_evict = figure_cache.evict
+
+    def watching_evict(run_id: str) -> None:
+        with figure_cache._lock:
+            held.append(live_rows._lock.acquire(blocking=False))
+            if held[-1]:
+                live_rows._lock.release()
+        original_evict(run_id)
+
+    figure_cache.evict = watching_evict  # type: ignore[assignment]
+    document_plane.figure_cache.evict = watching_evict  # type: ignore[assignment]
+    try:
+        RunDocumentRouter()("start", _start_doc("uid-1"))
+    finally:
+        figure_cache.evict = original_evict  # type: ignore[assignment]
+        document_plane.figure_cache.evict = original_evict  # type: ignore[assignment]
+
+    assert held == [True], "live_rows' lock was still held when the cache's was taken"
+
+
+# =========================================================================
+# Module hygiene
+# =========================================================================
+
+
+def test_the_cache_module_imports_neither_bluesky_nor_pydantic() -> None:
+    # It is imported by the bridge process and, transitively, by anything that
+    # imports the document plane; it needs neither stack to hold opaque values.
+    source = Path(figure_cache.__file__).read_text()
+    assert "import bluesky" not in source
+    assert "import pydantic" not in source
+    assert "from pydantic" not in source

--- a/tests/services/bluesky_bridge/test_figure_models.py
+++ b/tests/services/bluesky_bridge/test_figure_models.py
@@ -1,0 +1,319 @@
+"""Coverage for the figure spec models.
+
+The figure JSON is read by two consumers that cannot be type-checked against
+this module -- the panel's ``figure-renderer.js`` and the MCP ``get_run_figure``
+projection -- so these tests pin the things a rename or a stray default would
+break silently: the snake_case field names, the ``kind`` discriminator, the
+`model_dump()` round trip, and the guarantee that what comes out of a figure is
+valid JSON.
+
+Pure pydantic -- no bluesky import, so this runs in the fast import-clean lane.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+from osprey.services.bluesky_bridge.figure import (
+    FIGURE_REASONS,
+    REASON_NO_RENDER,
+    REASON_PARAMS_MISMATCH,
+    REASON_PLAN_IDENTITY_UNAVAILABLE,
+    REASON_RENDER_FAILED,
+    REASON_RENDER_NOT_SUPPORTED_FOR_SESSION_PLANS,
+    REASON_SOURCE_UNAVAILABLE,
+    BarsMark,
+    Figure,
+    HeatmapMark,
+    LinesMark,
+    Panel,
+    Point,
+    Series,
+)
+
+# The bridge's import boundary (`app._BRIDGE_ONLY_MODULES`), restated here so
+# this test file stays importable without pulling in `app.py`.
+_BRIDGE_ONLY_MODULES = ("bluesky", "ophyd", "ophyd_async", "tiled")
+
+
+def _lines_panel() -> Panel:
+    return Panel(
+        title="BPM 3 vs corrector 1",
+        x_label="corrector setpoint",
+        x_units="A",
+        y_label="orbit",
+        y_units="mm",
+        annotations=["decimated from 5000 points"],
+        mark=LinesMark(
+            series=[
+                Series(
+                    label="bpm3",
+                    points=[Point(x=0.0, y=1.5), Point(x=1.0, y=None), Point(x=2.0, y=-0.5)],
+                    decimated=True,
+                    source_points=5000,
+                )
+            ],
+            decimated=True,
+            source_points=5000,
+        ),
+    )
+
+
+def _heatmap_panel() -> Panel:
+    return Panel(
+        title="response matrix",
+        x_label="corrector",
+        y_label="BPM",
+        mark=HeatmapMark(
+            x_labels=["HCM1", "HCM2"],
+            y_labels=["BPM1", "BPM2", "BPM3"],
+            values=[[1.0, 2.0], [3.0, None], [5.0, 6.0]],
+            value_label="slope",
+            value_units="mm/A",
+            source_points=6,
+        ),
+    )
+
+
+def _bars_panel() -> Panel:
+    return Panel(
+        title="column anomaly",
+        mark=BarsMark(
+            label="anomaly",
+            categories=["HCM1", "HCM2"],
+            values=[0.1, None],
+            source_points=2,
+        ),
+    )
+
+
+def _full_figure() -> Figure:
+    return Figure(
+        panels=[_lines_panel(), _heatmap_panel(), _bars_panel()],
+        partial=False,
+        source="tiled",
+    )
+
+
+# --- Shape and round trip ----------------------------------------------------
+
+
+def test_full_figure_round_trips_through_model_dump() -> None:
+    figure = _full_figure()
+    assert Figure.model_validate(figure.model_dump()) == figure
+
+
+def test_dumped_figure_is_json_serializable() -> None:
+    # `json.dumps` is what Starlette does to the route's return value; the
+    # browser's JSON.parse rejects the NaN/Infinity literals Python would emit.
+    payload = json.dumps(_full_figure().model_dump(), allow_nan=False)
+    assert '"kind": "lines"' in payload
+
+
+def test_dumped_field_names_are_the_wire_contract() -> None:
+    dumped = _full_figure().model_dump()
+    assert set(dumped) == {"panels", "partial", "source", "reason"}
+    assert set(dumped["panels"][0]) == {
+        "title",
+        "x_label",
+        "y_label",
+        "x_units",
+        "y_units",
+        "annotations",
+        "mark",
+    }
+    assert set(dumped["panels"][0]["mark"]["series"][0]) == {
+        "label",
+        "points",
+        "decimated",
+        "source_points",
+    }
+    assert set(dumped["panels"][1]["mark"]) == {
+        "kind",
+        "x_labels",
+        "y_labels",
+        "values",
+        "value_label",
+        "value_units",
+        "decimated",
+        "source_points",
+    }
+    assert set(dumped["panels"][2]["mark"]) == {
+        "kind",
+        "label",
+        "categories",
+        "values",
+        "decimated",
+        "source_points",
+    }
+
+
+@pytest.mark.parametrize(
+    ("panel_factory", "expected_kind", "expected_type"),
+    [
+        (_lines_panel, "lines", LinesMark),
+        (_heatmap_panel, "heatmap", HeatmapMark),
+        (_bars_panel, "bars", BarsMark),
+    ],
+)
+def test_mark_kind_discriminates_on_revalidation(
+    panel_factory: object, expected_kind: str, expected_type: type
+) -> None:
+    panel = panel_factory()  # type: ignore[operator]
+    dumped = panel.model_dump()
+    assert dumped["mark"]["kind"] == expected_kind
+    assert isinstance(Panel.model_validate(dumped).mark, expected_type)
+
+
+def test_unknown_mark_kind_is_rejected() -> None:
+    dumped = _lines_panel().model_dump()
+    dumped["mark"]["kind"] = "table"
+    with pytest.raises(ValidationError):
+        Panel.model_validate(dumped)
+
+
+def test_extra_fields_are_forbidden() -> None:
+    dumped = _lines_panel().model_dump()
+    dumped["y_labl"] = "typo"
+    with pytest.raises(ValidationError):
+        Panel.model_validate(dumped)
+
+
+# --- Honesty fields ----------------------------------------------------------
+
+
+def test_partial_and_source_are_required() -> None:
+    with pytest.raises(ValidationError):
+        Figure.model_validate({"panels": []})
+    with pytest.raises(ValidationError):
+        Figure.model_validate({"panels": [], "partial": True})
+
+
+def test_source_is_restricted_to_the_two_stores() -> None:
+    assert Figure(panels=[], partial=True, source="live").source == "live"
+    with pytest.raises(ValidationError):
+        Figure.model_validate({"panels": [], "partial": True, "source": "cache"})
+
+
+def test_reason_defaults_to_none_and_survives_a_round_trip() -> None:
+    figure = Figure(panels=[], partial=False, source="live")
+    assert figure.reason is None
+
+    defaulted = Figure(panels=[], partial=False, source="live", reason=REASON_NO_RENDER)
+    assert Figure.model_validate(defaulted.model_dump()).reason == REASON_NO_RENDER
+
+
+def test_reason_vocabulary_is_complete_and_stable() -> None:
+    assert FIGURE_REASONS == {
+        "no_render",
+        "render_failed",
+        "render_not_supported_for_session_plans",
+        "params_mismatch",
+        "plan_identity_unavailable",
+        "source_unavailable",
+    }
+    assert {
+        REASON_NO_RENDER,
+        REASON_RENDER_FAILED,
+        REASON_RENDER_NOT_SUPPORTED_FOR_SESSION_PLANS,
+        REASON_PARAMS_MISMATCH,
+        REASON_PLAN_IDENTITY_UNAVAILABLE,
+        REASON_SOURCE_UNAVAILABLE,
+    } == FIGURE_REASONS
+
+
+def test_every_mark_carries_decimation_provenance() -> None:
+    lines = LinesMark(source_points=10)
+    heatmap = HeatmapMark(source_points=10)
+    bars = BarsMark(source_points=10)
+    for mark in (lines, heatmap, bars):
+        assert mark.decimated is False
+        assert mark.source_points == 10
+
+    with pytest.raises(ValidationError):
+        LinesMark()  # type: ignore[call-arg]  # source_points has no default: no silent zero
+
+
+# --- Numeric normalization ---------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_y_becomes_a_gap(bad: float) -> None:
+    assert Point(x=1.0, y=bad).y is None
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+def test_non_finite_heatmap_and_bar_values_become_gaps(bad: float) -> None:
+    heatmap = HeatmapMark(values=[[bad, 1.0]], source_points=2)
+    assert heatmap.values == [[None, 1.0]]
+    bars = BarsMark(categories=["a"], values=[bad], source_points=1)
+    assert bars.values == [None]
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_x_is_a_validation_error(bad: float) -> None:
+    with pytest.raises(ValidationError, match="finite"):
+        Point(x=bad)
+
+
+def test_numpy_scalars_are_coerced_to_plain_floats() -> None:
+    point = Point(x=np.float32(1.5), y=np.float64(2.5))
+    assert type(point.x) is float
+    assert type(point.y) is float
+    assert (point.x, point.y) == (1.5, 2.5)
+
+
+def test_numpy_nan_is_a_gap_not_a_nan() -> None:
+    # Renders compute with numpy; np.nan reaching the wire would be invalid JSON.
+    point = Point(x=1.0, y=np.float64("nan"))
+    assert point.y is None
+    heatmap = HeatmapMark(values=[[np.float32("nan")]], source_points=1)
+    assert heatmap.values == [[None]]
+
+
+def test_ints_are_accepted_as_coordinates() -> None:
+    point = Point(x=3, y=4)
+    assert (point.x, point.y) == (3.0, 4.0)
+
+
+def test_non_numeric_values_still_fail_validation() -> None:
+    with pytest.raises(ValidationError):
+        Point(x="over there")  # type: ignore[arg-type]
+    with pytest.raises(ValidationError):
+        Point(x=1.0, y=object())  # type: ignore[arg-type]
+
+
+def test_nan_string_is_normalized_rather_than_parsed_into_a_nan() -> None:
+    assert Point(x=1.0, y="nan").y is None  # type: ignore[arg-type]
+    assert math.isclose(Point(x=1.0, y="2.5").y or 0.0, 2.5)  # type: ignore[arg-type]
+
+
+# --- Import discipline -------------------------------------------------------
+
+
+def test_importing_figure_does_not_import_the_runengine_stack() -> None:
+    # Must run in a fresh interpreter: other tests in this suite legitimately
+    # import bluesky, so an in-process `sys.modules` check would depend on test
+    # order rather than on what `figure.py` imports.
+    failures: dict[str, str] = {}
+    for module in _BRIDGE_ONLY_MODULES:
+        code = (
+            "import osprey.services.bluesky_bridge.figure, sys; "
+            f"assert {module!r} not in sys.modules"
+        )
+        result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+        if result.returncode != 0:
+            failures[module] = result.stderr
+
+    assert not failures, "\n".join(
+        f"importing osprey.services.bluesky_bridge.figure leaked a top-level "
+        f"import of {module!r}:\n{stderr}"
+        for module, stderr in failures.items()
+    )

--- a/tests/services/bluesky_bridge/test_figure_route.py
+++ b/tests/services/bluesky_bridge/test_figure_route.py
@@ -960,14 +960,23 @@ def test_live_run_resolves_its_plan_with_no_manager_and_no_tiled(
     assert "Response matrix" in titles
 
 
-def test_orm_figure_at_facility_scale_stays_under_200ms_median(
+def test_orm_figure_at_facility_scale_stays_off_the_row_scan_path(
     client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
     """The plan's perf gate: 70 correctors x 100 BPMs x 1470 rows through the
     WHOLE route — buffer read, adapter, real `orm.render`, decimation, dump,
-    HTTP — at 200 ms median-of-5. The run is left partial, so every GET
-    recomputes (the live-tick cost this bounds); median, never max, per the
-    CI-timing house rule."""
+    HTTP. The run is left partial, so every GET recomputes (the live-tick cost
+    this bounds); median, never max, per the CI-timing house rule.
+
+    The bound is a REGRESSION GUARD, not a fine-grained perf assertion. What
+    it exists to catch is a return to the pre-vectorized row-scan fit, which
+    measured 5-77 s at this scale; the vectorized path measures ~15 ms on an
+    unloaded machine. The threshold sits far above that measurement on
+    purpose: this suite runs under xdist on shared CI runners, where the same
+    work has been observed at 405 ms purely from contention. A threshold tight
+    enough to police the ~15 ms figure would fail on runner load rather than
+    on a real slowdown — it would report the weather, not the code. Two
+    seconds still leaves the row-scan path no room to come back unnoticed."""
     pytest.importorskip("bluesky")
     monkeypatch.setenv("BLUESKY_SESSION_PLAN_DIR", str(tmp_path))
 
@@ -985,4 +994,4 @@ def test_orm_figure_at_facility_scale_stays_under_200ms_median(
         timings.append(time.perf_counter() - started)
 
     assert body["reason"] is None
-    assert statistics.median(timings) < 0.200
+    assert statistics.median(timings) < 2.0

--- a/tests/services/bluesky_bridge/test_figure_route.py
+++ b/tests/services/bluesky_bridge/test_figure_route.py
@@ -1,0 +1,988 @@
+"""Tests for `GET /runs/{run_id}/figure` — the figure route.
+
+The route is TOTAL over known runs: every run either the live buffer or Tiled
+knows gets a 200 figure, every degradation is the default figure with its
+machine-readable ``reason``, and only a run neither source knows 404s —
+byte-for-byte `get_run_data`'s 404, pinned here by comparing the two routes'
+raw response bodies. ``partial`` and ``source`` are asserted present on every
+single response this file receives (see `_get_figure`).
+
+Sources are faked at the same seams the sibling files use: the live buffer is
+fed real documents through `LiveRowRecorder` / `RunDocumentRouter`, and Tiled
+through a fake `tiled.client.from_uri` modeled on `test_tiled_read_source.py`'s
+(flattened-column composite, table under ``.base["internal"]``), extended with
+plan stamps, stop-document presence, multi-node search results, and call
+counters — the counters are what make "a settled Tiled hit issues zero Tiled
+calls" an assertion rather than a hope.
+
+Plan resolution is faked by monkeypatching `plan_loader.get_facility_plans`
+for the reason-path tests (so each tier/failure is constructed exactly), and
+exercised against the REAL catalog for the shipped-`orm` resolution test and
+the perf gate — those two are the ones that prove the route needs no manager,
+no Tiled, and no test-injected catalog to serve a live run's figure.
+"""
+
+from __future__ import annotations
+
+import statistics
+import time
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import BaseModel, Field
+
+from osprey.services.bluesky_bridge import figure_cache, live_rows
+from osprey.services.bluesky_bridge.app import app
+from osprey.services.bluesky_bridge.document_plane import RunDocumentRouter
+from osprey.services.bluesky_bridge.figure import (
+    DEFAULT_MAX_POINTS,
+    REASON_NO_RENDER,
+    REASON_PARAMS_MISMATCH,
+    REASON_PLAN_IDENTITY_UNAVAILABLE,
+    REASON_RENDER_FAILED,
+    REASON_RENDER_NOT_SUPPORTED_FOR_SESSION_PLANS,
+    REASON_SOURCE_UNAVAILABLE,
+    Figure,
+    LinesMark,
+    Panel,
+    Point,
+    Series,
+)
+from osprey.services.bluesky_bridge.figure import (
+    BarsMark as FigBarsMark,
+)
+from osprey.services.bluesky_bridge.live_rows import LiveRowRecorder
+from osprey.services.bluesky_bridge.plan_loader import FacilityPlans
+from osprey.services.bluesky_bridge.plan_types import PlanSpec
+from osprey.services.bluesky_bridge.queue_backend import PLAN_META_KEY, RUN_ID_META_KEY
+
+_TILED_URI_ENV = "BLUESKY_TILED_URI"
+_TILED_API_KEY_ENV = "BLUESKY_TILED_API_KEY"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(monkeypatch: pytest.MonkeyPatch):
+    """Fresh buffers, fresh cache, no ambient Tiled config.
+
+    Clearing the Tiled env means a test that forgets to fake the client fails
+    loudly on the wrong branch instead of passing against whatever the ambient
+    environment happens to hold (`test_dual_source_read.py`'s precedent).
+    """
+    live_rows._clear()
+    figure_cache._clear()
+    monkeypatch.delenv(_TILED_URI_ENV, raising=False)
+    monkeypatch.delenv(_TILED_API_KEY_ENV, raising=False)
+    yield
+    live_rows._clear()
+    figure_cache._clear()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _get_figure(client: TestClient, run_id: str) -> dict:
+    """GET the figure, asserting the envelope invariants every response owes.
+
+    ``partial`` and ``source`` are ALWAYS present — that is the route's
+    contract, so it is asserted on every single fetch this file performs
+    rather than in one dedicated test.
+    """
+    response = client.get(f"/runs/{run_id}/figure")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert "partial" in body
+    assert body["source"] in ("live", "tiled")
+    return body
+
+
+# =========================================================================
+# Catalog fakes
+# =========================================================================
+
+
+class _EchoParams(BaseModel):
+    """Permissive schema for fake plans whose kwargs don't matter."""
+
+    model_config = {"extra": "allow"}
+
+
+class _StrictParams(BaseModel):
+    """Schema with a required field, for the schema-drift path."""
+
+    required_gain: float = Field(...)
+
+
+def _spec(
+    name: str = "demo",
+    *,
+    provenance: str = "shipped",
+    render: Any = None,
+    schema: type[BaseModel] = _EchoParams,
+) -> PlanSpec[Any]:
+    return PlanSpec(
+        name=name,
+        plan=lambda devices, params: None,
+        schema=schema,
+        provenance=provenance,  # type: ignore[arg-type]
+        render=render,
+    )
+
+
+def _install_catalog(monkeypatch: pytest.MonkeyPatch, *specs: PlanSpec[Any]) -> None:
+    plans = FacilityPlans(plans={spec.name: spec for spec in specs})
+    monkeypatch.setattr(
+        "osprey.services.bluesky_bridge.plan_loader.get_facility_plans", lambda: plans
+    )
+
+
+def _echo_render(rows: list[dict[str, Any]], params: Any) -> Figure:
+    """A deterministic render built row-by-row from what it was handed.
+
+    One series per detector-ish column, y taken verbatim (None survives as a
+    gap) — so any live/Tiled difference the adapter failed to normalize (NaN
+    vs None, row order) would change the output and fail the parity test.
+    ``partial``/``source`` are the team's placeholder convention: the route
+    must overwrite both.
+    """
+    columns = sorted({key for row in rows for key in row})
+    panels = [
+        Panel(
+            title=column,
+            mark=LinesMark(
+                series=[
+                    Series(
+                        label=column,
+                        points=[Point(x=float(i), y=row.get(column)) for i, row in enumerate(rows)],
+                        source_points=len(rows),
+                    )
+                ],
+                source_points=len(rows),
+            ),
+        )
+        for column in columns
+    ]
+    return Figure(panels=panels, partial=True, source="live")
+
+
+# =========================================================================
+# Live-buffer seeding
+# =========================================================================
+
+
+def _feed_live(
+    run_id: str,
+    rows: list[dict[str, Any]],
+    *,
+    plan: Any = None,
+    stop: bool = False,
+) -> None:
+    """Push start/event[/stop] documents into the live buffer, stamped."""
+    recorder = LiveRowRecorder(key=run_id, plan=plan)
+    recorder("start", {"uid": f"engine-{run_id}"})
+    for row in rows:
+        recorder("event", {"data": row})
+    if stop:
+        recorder("stop", {})
+
+
+# =========================================================================
+# Tiled fakes (modeled on test_tiled_read_source.py, plus what the figure
+# route needs: stamps, stop presence, start.time, multi-match, call counters)
+# =========================================================================
+
+
+class _FakeInternalTable:
+    def __init__(self, df: pd.DataFrame) -> None:
+        self._df = df
+
+    def read(self) -> pd.DataFrame:
+        return self._df
+
+
+class _FakeBaseContainer:
+    def __init__(self, tables: dict) -> None:
+        self._tables = tables
+
+    def __getitem__(self, key: str):
+        return self._tables[key]
+
+
+class _FakeCompositeClient:
+    """The run's `"primary"` child: keys are flattened column names, the table
+    hangs off `.base` — same fidelity rationale as `test_tiled_read_source.py`."""
+
+    def __init__(self, columns: list[str], base: _FakeBaseContainer) -> None:
+        self._columns = list(columns)
+        self.base = base
+
+    def __getitem__(self, key: str):
+        if key in self._columns:
+            return object()
+        raise KeyError(f"Key '{key}' not found.")
+
+
+class _FakeRunNode:
+    def __init__(self, metadata: dict, streams: dict | None = None) -> None:
+        self.metadata = metadata
+        self._streams = streams or {}
+
+    def __getitem__(self, key: str):
+        return self._streams[key]
+
+    def __contains__(self, key: str) -> bool:
+        try:
+            self[key]
+        except KeyError:
+            return False
+        return True
+
+
+class _FakeSearchResult:
+    def __init__(self, nodes: list[_FakeRunNode]) -> None:
+        self._nodes = nodes
+
+    def values(self) -> list[_FakeRunNode]:
+        return self._nodes
+
+
+class _FakeTiledClient:
+    """Counts every search; a settled cache hit must leave the count alone."""
+
+    def __init__(self, nodes_by_run_id: dict[str, list[_FakeRunNode]]) -> None:
+        self._nodes_by_run_id = nodes_by_run_id
+        self.search_queries: list[object] = []
+
+    def search(self, query) -> _FakeSearchResult:
+        self.search_queries.append(query)
+        return _FakeSearchResult(list(self._nodes_by_run_id.get(query.value, [])))
+
+
+def _install_fake_tiled(
+    monkeypatch: pytest.MonkeyPatch,
+    client: _FakeTiledClient,
+    *,
+    api_key: str | None = "test-api-key",
+) -> list[tuple]:
+    """Configure the env and patch `from_uri`; returns the from_uri call log."""
+    pytest.importorskip("tiled")
+    monkeypatch.setenv(_TILED_URI_ENV, "http://tiled:8000")
+    if api_key is not None:
+        monkeypatch.setenv(_TILED_API_KEY_ENV, api_key)
+
+    calls: list[tuple] = []
+
+    def fake_from_uri(uri, **kwargs):
+        calls.append((uri, kwargs))
+        return client
+
+    monkeypatch.setattr("tiled.client.from_uri", fake_from_uri)
+    return calls
+
+
+def _tiled_run_node(
+    run_uid: str,
+    run_id: str,
+    rows: list[dict],
+    *,
+    plan: Any = None,
+    stopped: bool = True,
+    start_time: float = 1000.0,
+    row_order: list[int] | None = None,
+) -> _FakeRunNode:
+    """A run container shaped like TiledWriter's output.
+
+    ``row_order`` stores the table's rows in that physical order while
+    ``seq_num`` still records emission order — the route must sort, so a
+    shuffled table and an ordered one produce the same figure.
+    """
+    start: dict[str, Any] = {"uid": run_uid, "osprey_run_id": run_id, "time": start_time}
+    if plan is not None:
+        start[PLAN_META_KEY] = plan
+    metadata: dict[str, Any] = {"start": start}
+    if stopped:
+        metadata["stop"] = {"exit_status": "success"}
+
+    table_rows = []
+    for i, row in enumerate(rows):
+        table_row = {"seq_num": i + 1, "time": 1000.0 + i, **row}
+        table_row.update({f"ts_{k}": 1000.0 + i for k in row})
+        table_rows.append(table_row)
+    if row_order is not None:
+        table_rows = [table_rows[i] for i in row_order]
+    if not table_rows:
+        return _FakeRunNode(metadata=metadata, streams={})
+    df = pd.DataFrame(table_rows)
+    primary = _FakeCompositeClient(
+        columns=list(df.columns),
+        base=_FakeBaseContainer({"internal": _FakeInternalTable(df)}),
+    )
+    return _FakeRunNode(metadata=metadata, streams={"primary": primary})
+
+
+# =========================================================================
+# 404 parity with get_run_data
+# =========================================================================
+
+
+def test_unknown_run_404_matches_get_run_data_byte_for_byte(client: TestClient) -> None:
+    """No live buffer AND no Tiled match: the figure route's 404 is
+    `get_run_data`'s, byte for byte — the MCP tool maps both identically."""
+    figure_response = client.get("/runs/no-such-run/figure")
+    data_response = client.get("/runs/no-such-run/data")
+
+    assert figure_response.status_code == 404
+    assert data_response.status_code == 404
+    assert figure_response.content == data_response.content
+
+
+def test_unknown_run_with_tiled_configured_is_still_the_same_404(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_fake_tiled(monkeypatch, _FakeTiledClient({}))
+
+    figure_response = client.get("/runs/no-such-run/figure")
+    data_response = client.get("/runs/no-such-run/data")
+
+    assert figure_response.status_code == 404
+    assert figure_response.content == data_response.content
+
+
+# =========================================================================
+# Reason paths (live branch, catalog faked per test)
+# =========================================================================
+
+
+def test_missing_stamp_is_plan_identity_unavailable(client: TestClient) -> None:
+    _feed_live("run-1", [{"m": 1.0, "d": 10.0}], plan=None)
+
+    body = _get_figure(client, "run-1")
+
+    assert body["reason"] == REASON_PLAN_IDENTITY_UNAVAILABLE
+    assert body["source"] == "live"
+    assert body["partial"] is True
+    # The default figure still draws the numeric columns.
+    assert [panel["title"] for panel in body["panels"]] == ["m", "d"]
+
+
+def test_stamp_with_null_name_is_plan_identity_unavailable(client: TestClient) -> None:
+    _feed_live("run-1", [{"m": 1.0}], plan={"name": None, "kwargs": {}})
+
+    assert _get_figure(client, "run-1")["reason"] == REASON_PLAN_IDENTITY_UNAVAILABLE
+
+
+@pytest.mark.parametrize("bad_name", [["orm"], 42, {"nested": "orm"}, 1.5])
+def test_non_string_stamp_name_is_plan_identity_unavailable(
+    client: TestClient, bad_name: Any
+) -> None:
+    """A malformed stamp whose name is not a string must degrade like any
+    other unusable identity — never reach a catalog lookup or a cache key,
+    where an unhashable name would 500 a route that promises 200s."""
+    _feed_live("run-1", [{"m": 1.0}], plan={"name": bad_name, "kwargs": {}}, stop=True)
+
+    body = _get_figure(client, "run-1")
+
+    assert body["reason"] == REASON_PLAN_IDENTITY_UNAVAILABLE
+
+
+def test_a_raising_catalog_is_no_render_and_never_cached(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failing plan catalog is this process's transient trouble, not a truth
+    about the run: it serves the default figure with `no_render` but must NOT
+    stick to a settled run — once the catalog recovers, the next poll serves
+    the real figure."""
+    _feed_live("run-1", [{"m": 1.0, "d": 2.0}], plan={"name": "echo", "kwargs": {}}, stop=True)
+
+    def broken_catalog() -> FacilityPlans:
+        raise OSError("session plan dir is read-only")
+
+    monkeypatch.setattr(
+        "osprey.services.bluesky_bridge.plan_loader.get_facility_plans", broken_catalog
+    )
+    degraded = _get_figure(client, "run-1")
+    assert degraded["reason"] == REASON_NO_RENDER
+
+    _install_catalog(monkeypatch, _spec("echo", render=_echo_render))
+    recovered = _get_figure(client, "run-1")
+
+    assert recovered["reason"] is None
+    assert [panel["title"] for panel in recovered["panels"]] == ["d", "m"]
+
+
+def test_stamp_name_with_no_current_owner_is_no_render(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A plan removed or renamed since the run: identity is known, but no plan
+    code currently owns a view of it."""
+    _install_catalog(monkeypatch)  # empty catalog
+    _feed_live("run-1", [{"m": 1.0}], plan={"name": "gone", "kwargs": {}})
+
+    assert _get_figure(client, "run-1")["reason"] == REASON_NO_RENDER
+
+
+def test_spec_without_render_is_no_render(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_catalog(monkeypatch, _spec("plain", render=None))
+    _feed_live("run-1", [{"m": 1.0}], plan={"name": "plain", "kwargs": {}})
+
+    assert _get_figure(client, "run-1")["reason"] == REASON_NO_RENDER
+
+
+@pytest.mark.parametrize("provenance", ["session", "unreviewed"])
+def test_session_tier_spec_is_the_session_reason_not_no_render(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, provenance: str
+) -> None:
+    """Session-tier specs always carry `render=None` (the loader strips it),
+    so the tier must be decided on provenance — the authoring agent learns
+    WHY there is no custom view, not just that there isn't one."""
+    _install_catalog(monkeypatch, _spec("mine", provenance=provenance, render=None))
+    _feed_live("run-1", [{"m": 1.0}], plan={"name": "mine", "kwargs": {}})
+
+    assert _get_figure(client, "run-1")["reason"] == REASON_RENDER_NOT_SUPPORTED_FOR_SESSION_PLANS
+
+
+def test_schema_drift_is_params_mismatch(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_catalog(monkeypatch, _spec("strict", render=_echo_render, schema=_StrictParams))
+    _feed_live("run-1", [{"m": 1.0}], plan={"name": "strict", "kwargs": {"old_field": 2.0}})
+
+    assert _get_figure(client, "run-1")["reason"] == REASON_PARAMS_MISMATCH
+
+
+def test_raising_render_is_render_failed(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def exploding(rows: list[dict[str, Any]], params: Any) -> Figure:
+        raise RuntimeError("boom")
+
+    _install_catalog(monkeypatch, _spec("bad", render=exploding))
+    _feed_live("run-1", [{"m": 1.0}], plan={"name": "bad", "kwargs": {}})
+
+    assert _get_figure(client, "run-1")["reason"] == REASON_RENDER_FAILED
+
+
+def test_render_returning_a_non_figure_is_render_failed(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_catalog(monkeypatch, _spec("liar", render=lambda rows, params: {"not": "a figure"}))
+    _feed_live("run-1", [{"m": 1.0}], plan={"name": "liar", "kwargs": {}})
+
+    assert _get_figure(client, "run-1")["reason"] == REASON_RENDER_FAILED
+
+
+def test_malformed_source_snapshot_is_params_mismatch(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`rows_from_columnar` refuses a window claiming more rows than its run
+    (`total_seen < len(rows)`); the route degrades exactly like a schema
+    mismatch — the stored shape no longer matches what the code expects."""
+    monkeypatch.setattr(
+        live_rows,
+        "get",
+        lambda run_id: {
+            "columns": ["m"],
+            "rows": [[1.0], [2.0]],
+            "partial": True,
+            "total_seen": 1,  # fewer than the rows physically present: impossible
+            "plan": None,
+        },
+    )
+
+    body = _get_figure(client, "run-1")
+
+    assert body["reason"] == REASON_PARAMS_MISMATCH
+    assert body["panels"] == []
+
+
+def test_plan_render_serves_reason_none_and_the_sources_truth(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Happy path: the plan's own figure, with `partial`/`source` overwritten
+    from the source — the render's own values are placeholders by convention
+    (it deliberately claims partial=True/source="live" here; the buffer is
+    settled, so the route must flip `partial`)."""
+    _install_catalog(monkeypatch, _spec("echo", render=_echo_render))
+    _feed_live(
+        "run-1",
+        [{"m": 1.0, "d": 10.0}, {"m": 2.0, "d": 20.0}],
+        plan={"name": "echo", "kwargs": {}},
+        stop=True,
+    )
+
+    body = _get_figure(client, "run-1")
+
+    assert body["reason"] is None
+    assert body["partial"] is False  # the source's truth, not the render's placeholder
+    assert body["source"] == "live"
+    assert [panel["title"] for panel in body["panels"]] == ["d", "m"]
+
+
+# =========================================================================
+# Live settled caching
+# =========================================================================
+
+
+def _counting_render(calls: list[list[dict[str, Any]]]):
+    def render(rows: list[dict[str, Any]], params: Any) -> Figure:
+        calls.append(rows)
+        return _echo_render(rows, params)
+
+    return render
+
+
+def test_settled_live_run_renders_once_then_serves_the_cache(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[list[dict[str, Any]]] = []
+    _install_catalog(monkeypatch, _spec("echo", render=_counting_render(calls)))
+    _feed_live("run-1", [{"m": 1.0}], plan={"name": "echo", "kwargs": {}}, stop=True)
+
+    first = _get_figure(client, "run-1")
+    second = _get_figure(client, "run-1")
+
+    assert len(calls) == 1
+    assert first == second
+
+
+def test_partial_live_run_recomputes_every_tick(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[list[dict[str, Any]]] = []
+    _install_catalog(monkeypatch, _spec("echo", render=_counting_render(calls)))
+    _feed_live("run-1", [{"m": 1.0}], plan={"name": "echo", "kwargs": {}}, stop=False)
+
+    _get_figure(client, "run-1")
+    _get_figure(client, "run-1")
+
+    assert len(calls) == 2  # nothing cached while the run may still grow
+
+
+def test_settled_hit_revalidates_total_seen_against_the_buffer(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A recycled run id whose eviction has not landed yet shows up as a
+    row-count mismatch between the cached entry and the buffer in hand — the
+    live branch's free staleness check."""
+    calls: list[list[dict[str, Any]]] = []
+    _install_catalog(monkeypatch, _spec("echo", render=_counting_render(calls)))
+
+    def snapshot(total_seen: int, value: float) -> dict[str, Any]:
+        return {
+            "columns": ["m"],
+            "rows": [[value]] * total_seen,
+            "partial": False,
+            "total_seen": total_seen,
+            "plan": {"name": "echo", "kwargs": {}},
+        }
+
+    monkeypatch.setattr(live_rows, "get", lambda run_id: snapshot(2, 1.0))
+    _get_figure(client, "run-1")
+    monkeypatch.setattr(live_rows, "get", lambda run_id: snapshot(3, 9.0))
+    body = _get_figure(client, "run-1")
+
+    assert len(calls) == 2
+    assert calls[1] == [{"m": 9.0}] * 3
+    assert body["panels"][0]["mark"]["series"][0]["points"][0]["y"] == 9.0
+
+
+def test_a_new_start_doc_for_a_cached_run_id_recomputes_from_the_new_rows(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Invalidate-on-write: the document plane's eviction hook (not any
+    read-side validation) is what makes a re-run under the same OSPREY run id
+    serve the re-run's figure."""
+    calls: list[list[dict[str, Any]]] = []
+    _install_catalog(monkeypatch, _spec("echo", render=_counting_render(calls)))
+
+    def drive(engine_uid: str, value: float) -> None:
+        router = RunDocumentRouter()
+        router(
+            "start",
+            {
+                "uid": engine_uid,
+                RUN_ID_META_KEY: "run-1",
+                PLAN_META_KEY: {"name": "echo", "kwargs": {}},
+            },
+        )
+        router("descriptor", {"uid": f"desc-{engine_uid}", "run_start": engine_uid})
+        router("event", {"descriptor": f"desc-{engine_uid}", "data": {"m": value}})
+        router("stop", {"run_start": engine_uid})
+
+    drive("engine-1", 1.0)
+    first = _get_figure(client, "run-1")
+    assert first["panels"][0]["mark"]["series"][0]["points"][0]["y"] == 1.0
+
+    drive("engine-2", 42.0)
+    second = _get_figure(client, "run-1")
+
+    assert second["panels"][0]["mark"]["series"][0]["points"][0]["y"] == 42.0
+    assert len(calls) == 2
+
+
+# =========================================================================
+# Tiled branch
+# =========================================================================
+
+
+def test_tiled_settled_run_serves_the_plan_figure(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_catalog(monkeypatch, _spec("echo", render=_echo_render))
+    node = _tiled_run_node(
+        "uid-1", "run-1", [{"m": 1.0, "d": 10.0}], plan={"name": "echo", "kwargs": {}}
+    )
+    _install_fake_tiled(monkeypatch, _FakeTiledClient({"run-1": [node]}))
+
+    body = _get_figure(client, "run-1")
+
+    assert body["reason"] is None
+    assert body["source"] == "tiled"
+    assert body["partial"] is False  # stop document present
+
+
+def test_tiled_stop_doc_absent_is_partial_and_never_cached(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_catalog(monkeypatch, _spec("echo", render=_echo_render))
+    node = _tiled_run_node(
+        "uid-1", "run-1", [{"m": 1.0}], plan={"name": "echo", "kwargs": {}}, stopped=False
+    )
+    tiled = _FakeTiledClient({"run-1": [node]})
+    _install_fake_tiled(monkeypatch, tiled)
+
+    first = _get_figure(client, "run-1")
+    second = _get_figure(client, "run-1")
+
+    assert first["partial"] is True
+    assert second["partial"] is True
+    assert len(tiled.search_queries) == 2  # in-flight figures are recomputed, not cached
+
+
+def test_a_settled_tiled_hit_issues_zero_tiled_calls(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The cache's whole point: the second GET on a settled Tiled run touches
+    neither `from_uri` nor `search` — asserted with call counters, not timing."""
+    _install_catalog(monkeypatch, _spec("echo", render=_echo_render))
+    node = _tiled_run_node(
+        "uid-1", "run-1", [{"m": 1.0, "d": 2.0}], plan={"name": "echo", "kwargs": {}}
+    )
+    tiled = _FakeTiledClient({"run-1": [node]})
+    from_uri_calls = _install_fake_tiled(monkeypatch, tiled)
+
+    first = _get_figure(client, "run-1")
+    searches_after_first = len(tiled.search_queries)
+    clients_after_first = len(from_uri_calls)
+
+    second = _get_figure(client, "run-1")
+
+    assert first == second
+    assert len(tiled.search_queries) == searches_after_first
+    assert len(from_uri_calls) == clients_after_first
+
+
+def test_tiled_configured_without_api_key_passes_none(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A token-less catalog is a working configuration: `from_uri` gets
+    `api_key=None`, never a `KeyError` from a bare env subscript."""
+    node = _tiled_run_node("uid-1", "run-1", [{"m": 1.0}])
+    from_uri_calls = _install_fake_tiled(
+        monkeypatch, _FakeTiledClient({"run-1": [node]}), api_key=None
+    )
+
+    body = _get_figure(client, "run-1")
+
+    assert from_uri_calls == [("http://tiled:8000", {"api_key": None})]
+    assert body["source"] == "tiled"
+
+
+def test_tiled_read_failure_is_source_unavailable_not_a_500(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("tiled")
+    monkeypatch.setenv(_TILED_URI_ENV, "http://tiled:8000")
+
+    def broken_from_uri(uri, **kwargs):
+        raise ConnectionError("catalog unreachable")
+
+    monkeypatch.setattr("tiled.client.from_uri", broken_from_uri)
+
+    body = _get_figure(client, "run-1")
+
+    assert body["reason"] == REASON_SOURCE_UNAVAILABLE
+    assert body["source"] == "tiled"  # the store the route WAS reading
+    assert body["partial"] is True  # settledness unknowable: keep polling
+    assert body["panels"] == []
+
+
+def test_multiple_matches_resolve_to_the_newest_start_time(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A re-run of an interrupted item leaves two catalog nodes under one
+    OSPREY run id; the figure must come from the newest start, not from
+    whatever order the server answered in."""
+    _install_catalog(monkeypatch, _spec("echo", render=_echo_render))
+    stale = _tiled_run_node(
+        "uid-old", "run-1", [{"m": 1.0}], plan={"name": "echo", "kwargs": {}}, start_time=1000.0
+    )
+    fresh = _tiled_run_node(
+        "uid-new", "run-1", [{"m": 77.0}], plan={"name": "echo", "kwargs": {}}, start_time=2000.0
+    )
+    # Stale one listed FIRST: `matches[0]` would pick it.
+    _install_fake_tiled(monkeypatch, _FakeTiledClient({"run-1": [stale, fresh]}))
+
+    body = _get_figure(client, "run-1")
+
+    assert body["panels"][0]["mark"]["series"][0]["points"][0]["y"] == 77.0
+
+
+def test_live_and_tiled_produce_the_same_figure_through_the_shared_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Parity: Tiled hands back NaN for a missing reading and may return rows
+    out of order; the live buffer stores None in emission order. Same run,
+    same figure — differing only in the `source` stamp."""
+    _install_catalog(monkeypatch, _spec("echo", render=_echo_render))
+    stamp = {"name": "echo", "kwargs": {}}
+    logical_rows: list[dict[str, Any]] = [
+        {"m": 1.0, "d": 10.0},
+        {"m": 2.0, "d": None},
+        {"m": 3.0, "d": 30.0},
+    ]
+
+    client = TestClient(app)
+    _feed_live("run-live", logical_rows, plan=stamp, stop=True)
+    live_body = _get_figure(client, "run-live")
+
+    live_rows._clear()
+    figure_cache._clear()
+    tiled_rows = [
+        {key: (np.nan if value is None else value) for key, value in row.items()}
+        for row in logical_rows
+    ]
+    node = _tiled_run_node("uid-1", "run-tiled", tiled_rows, plan=stamp, row_order=[2, 0, 1])
+    _install_fake_tiled(monkeypatch, _FakeTiledClient({"run-tiled": [node]}))
+    tiled_body = _get_figure(client, "run-tiled")
+
+    assert live_body.pop("source") == "live"
+    assert tiled_body.pop("source") == "tiled"
+    assert live_body == tiled_body
+
+
+def test_tiled_start_doc_without_a_stamp_is_plan_identity_unavailable(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    node = _tiled_run_node("uid-1", "run-1", [{"m": 1.0}], plan=None)
+    _install_fake_tiled(monkeypatch, _FakeTiledClient({"run-1": [node]}))
+
+    assert _get_figure(client, "run-1")["reason"] == REASON_PLAN_IDENTITY_UNAVAILABLE
+
+
+# =========================================================================
+# Decimation at the serving edge
+# =========================================================================
+
+
+def _long_lines_figure(n: int) -> Figure:
+    return Figure(
+        panels=[
+            Panel(
+                title="long",
+                mark=LinesMark(
+                    series=[
+                        Series(
+                            label="s",
+                            points=[Point(x=float(i), y=float(i)) for i in range(n)],
+                            source_points=n,
+                        )
+                    ],
+                    source_points=n,
+                ),
+            )
+        ],
+        partial=True,
+        source="live",
+    )
+
+
+def test_plan_lines_series_are_decimated_to_the_budget(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    n = 5000
+    _install_catalog(monkeypatch, _spec("long", render=lambda rows, params: _long_lines_figure(n)))
+    _feed_live("run-1", [{"m": 1.0}], plan={"name": "long", "kwargs": {}})
+
+    series = _get_figure(client, "run-1")["panels"][0]["mark"]["series"][0]
+
+    assert len(series["points"]) == DEFAULT_MAX_POINTS
+    assert series["decimated"] is True
+    assert series["source_points"] == n
+    # Endpoints survive decimation.
+    assert series["points"][0]["x"] == 0.0
+    assert series["points"][-1]["x"] == float(n - 1)
+
+
+def test_plan_bars_are_decimated_with_categories_kept_aligned(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    n = 3000
+
+    def bars_render(rows: list[dict[str, Any]], params: Any) -> Figure:
+        return Figure(
+            panels=[
+                Panel(
+                    title="bars",
+                    mark=FigBarsMark(
+                        categories=[f"c{i}" for i in range(n)],
+                        values=[float(i) for i in range(n)],
+                        source_points=n,
+                    ),
+                )
+            ],
+            partial=True,
+            source="live",
+        )
+
+    _install_catalog(monkeypatch, _spec("bars", render=bars_render))
+    _feed_live("run-1", [{"m": 1.0}], plan={"name": "bars", "kwargs": {}})
+
+    mark = _get_figure(client, "run-1")["panels"][0]["mark"]
+
+    assert len(mark["values"]) == DEFAULT_MAX_POINTS
+    assert len(mark["categories"]) == DEFAULT_MAX_POINTS
+    assert mark["decimated"] is True
+    assert mark["source_points"] == n
+    # Category/value pairs survive selection together.
+    for category, value in zip(mark["categories"], mark["values"], strict=True):
+        assert category == f"c{int(value)}"
+
+
+def test_default_figure_series_are_decimated_too(client: TestClient) -> None:
+    """The budget is the route's, not the plan's: a stampless 2500-row run's
+    default figure is bounded exactly like a plan-rendered one."""
+    n = 2500
+    _feed_live("run-1", [{"m": float(i)} for i in range(n)], plan=None)
+
+    series = _get_figure(client, "run-1")["panels"][0]["mark"]["series"][0]
+
+    assert len(series["points"]) == DEFAULT_MAX_POINTS
+    assert series["decimated"] is True
+    assert series["source_points"] == n
+
+
+def test_inconsistent_plan_decimation_truth_is_render_failed(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A series claiming fewer source points than it holds would make
+    `decimate` report a series as larger after decimation than before — plan
+    garbage, degraded like any other render failure."""
+
+    def lying_render(rows: list[dict[str, Any]], params: Any) -> Figure:
+        figure = _long_lines_figure(2001)
+        figure.panels[0].mark.series[0].source_points = 5  # type: ignore[union-attr]
+        return figure
+
+    _install_catalog(monkeypatch, _spec("liar", render=lying_render))
+    _feed_live("run-1", [{"m": 1.0}], plan={"name": "liar", "kwargs": {}})
+
+    assert _get_figure(client, "run-1")["reason"] == REASON_RENDER_FAILED
+
+
+# =========================================================================
+# Real catalog: shipped-plan resolution and the perf gate
+# =========================================================================
+
+
+def _orm_rows(correctors: list[str], detectors: list[str], num: int) -> list[dict[str, float]]:
+    """Rows a real `orm` run emits: corrector-major, every row carrying every
+    corrector's current (idle 0.0) and every detector's reading."""
+    rng = np.random.default_rng(11)
+    truth = rng.normal(size=(len(detectors), len(correctors)))
+    span = 2.0
+    step = (2 * span) / (num - 1)
+    currents = [-span + i * step for i in range(num)]
+    rows: list[dict[str, float]] = []
+    for j, corrector in enumerate(correctors):
+        for current in currents:
+            row = dict.fromkeys(correctors, 0.0)
+            row[corrector] = current
+            orbit = truth[:, j] * current
+            for i, detector in enumerate(detectors):
+                row[detector] = float(orbit[i])
+            rows.append(row)
+    return rows
+
+
+def _orm_stamp(correctors: list[str], detectors: list[str], num: int) -> dict[str, Any]:
+    return {
+        "name": "orm",
+        "kwargs": {
+            "correctors": correctors,
+            "detectors": detectors,
+            "span_a": 2.0,
+            "num": num,
+        },
+    }
+
+
+def test_live_run_resolves_its_plan_with_no_manager_and_no_tiled(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """The whole live path needs nothing but this process: the in-process
+    stamp resolves against the REAL shipped catalog — no manager RPC, no
+    Tiled config, no test-injected catalog."""
+    pytest.importorskip("bluesky")
+    monkeypatch.setenv("BLUESKY_SESSION_PLAN_DIR", str(tmp_path))
+
+    correctors, detectors, num = ["CH0", "CH1"], ["BPM0", "BPM1"], 3
+    _feed_live(
+        "run-orm",
+        _orm_rows(correctors, detectors, num),
+        plan=_orm_stamp(correctors, detectors, num),
+        stop=False,
+    )
+
+    body = _get_figure(client, "run-orm")
+
+    assert body["reason"] is None
+    assert body["source"] == "live"
+    assert body["partial"] is True
+    titles = [panel["title"] for panel in body["panels"]]
+    assert "CH0 sweep" in titles
+    assert "Response matrix" in titles
+
+
+def test_orm_figure_at_facility_scale_stays_under_200ms_median(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """The plan's perf gate: 70 correctors x 100 BPMs x 1470 rows through the
+    WHOLE route — buffer read, adapter, real `orm.render`, decimation, dump,
+    HTTP — at 200 ms median-of-5. The run is left partial, so every GET
+    recomputes (the live-tick cost this bounds); median, never max, per the
+    CI-timing house rule."""
+    pytest.importorskip("bluesky")
+    monkeypatch.setenv("BLUESKY_SESSION_PLAN_DIR", str(tmp_path))
+
+    correctors = [f"CH{j}" for j in range(70)]
+    detectors = [f"BPM{i}" for i in range(100)]
+    num = 21
+    rows = _orm_rows(correctors, detectors, num)
+    assert len(rows) == 1470
+    _feed_live("run-perf", rows, plan=_orm_stamp(correctors, detectors, num), stop=False)
+
+    timings = []
+    for _ in range(5):
+        started = time.perf_counter()
+        body = _get_figure(client, "run-perf")
+        timings.append(time.perf_counter() - started)
+
+    assert body["reason"] is None
+    assert statistics.median(timings) < 0.200

--- a/tests/services/bluesky_bridge/test_grid_render.py
+++ b/tests/services/bluesky_bridge/test_grid_render.py
@@ -1,0 +1,554 @@
+"""Coverage for ``plans_core/grid_scan.py``'s ``render()``.
+
+Three shapes, one per grid dimensionality: lines for a 1-D sweep, a heatmap for
+a 2-D grid, one line per outer-axis combination above that. The load-bearing
+property throughout is that **cell and series keys come from the grid geometry,
+not from the recorded floats**. Rows carry axis READBACKS -- the bridge's
+`ConnectorSettable` records what the device reported after settling, not the
+value it was commanded to -- so the fixtures here perturb every axis reading by
++/-1e-9 before handing it to `render`. Without that perturbation a
+float-equality-keyed implementation passes every test in this file while
+producing ``num_points**2`` one-point cells against a real stack; with it, the
+same implementation fails immediately.
+
+Runs in the normal unit lane -- the bluesky stack is a core dependency -- with
+the same `importorskip` guard as its siblings so a slimmed install skips rather
+than errors.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+pytest.importorskip("bluesky")
+
+from osprey.services.bluesky_bridge.figure import (  # noqa: E402
+    DEFAULT_MAX_POINTS,
+    Figure,
+    HeatmapMark,
+    LinesMark,
+)
+from osprey.services.bluesky_bridge.plans_core import grid_scan  # noqa: E402
+from osprey.services.bluesky_bridge.plans_core.grid_scan import (  # noqa: E402
+    PARAMS,
+    GridAxis,
+    render,
+)
+
+# =========================================================================
+# Fixture builders: a grid scan's rows, as the bridge would have recorded them
+# =========================================================================
+
+
+def _axis(setpoint: str, start: float, stop: float, num_points: int) -> GridAxis:
+    return GridAxis(setpoint=setpoint, start=start, stop=stop, num_points=num_points)
+
+
+def _nominal(axis: GridAxis, index: int) -> float:
+    """The position axis *index* was commanded to."""
+    return axis.start + index * (axis.stop - axis.start) / (axis.num_points - 1)
+
+
+def _traverse(axes: list[GridAxis], snake: bool, flip: bool = False) -> Iterator[tuple[int, ...]]:
+    """Grid indices in emission order, outermost axis slowest.
+
+    With ``snake`` every axis but the outermost reverses direction each time
+    the axis outside it steps -- the boustrophedon path ``bp.grid_scan`` drives
+    with ``snake_axes=True``.
+    """
+    if not axes:
+        yield ()
+        return
+    head, rest = axes[0], axes[1:]
+    order = range(head.num_points - 1, -1, -1) if flip else range(head.num_points)
+    for step, index in enumerate(order):
+        for tail in _traverse(rest, snake, flip=snake and step % 2 == 1):
+            yield (index, *tail)
+
+
+def _detector_value(indices: tuple[int, ...]) -> float:
+    """A value unique to one grid point, so a mis-keyed cell is unmistakable."""
+    return sum(index * 100**position for position, index in enumerate(reversed(indices))) + 0.5
+
+
+def _rows(
+    axes: list[GridAxis],
+    detectors: dict[str, str],
+    *,
+    snake: bool = False,
+    jitter: float = 1e-9,
+    axis_columns: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """The rows a run over *axes* would have produced.
+
+    Axis columns hold the commanded position plus an alternating ``+/-jitter``:
+    a real readback is never bit-identical to its setpoint, and a cell keyed on
+    the float itself would fan out into one cell per row.
+
+    Args:
+        axes: The grid, outermost first.
+        detectors: Detector device name -> the event column it is recorded in
+            (ophyd-async names a hinted child ``"<device>-<signal>"``).
+        snake: Whether the inner axes reverse direction each outer step.
+        jitter: How far each readback sits from its commanded position.
+        axis_columns: Setpoint device name -> event column, for the axes whose
+            column is not the bare device name. Defaults to bare names.
+    """
+    axis_columns = axis_columns or {}
+    rows: list[dict[str, Any]] = []
+    for sign, indices in enumerate(_traverse(axes, snake)):
+        row: dict[str, Any] = {}
+        for axis, index in zip(axes, indices, strict=True):
+            offset = jitter if sign % 2 == 0 else -jitter
+            row[axis_columns.get(axis.setpoint, axis.setpoint)] = _nominal(axis, index) + offset
+        for column in detectors.values():
+            row[column] = _detector_value(indices)
+        rows.append(row)
+    return rows
+
+
+def _sole_panel(figure: Figure):
+    assert len(figure.panels) == 1, f"expected one panel, got {[p.title for p in figure.panels]}"
+    return figure.panels[0]
+
+
+# =========================================================================
+# One axis: detector-vs-setpoint lines
+# =========================================================================
+
+
+def test_one_axis_draws_one_line_panel_per_detector_against_the_readback() -> None:
+    axes = [_axis("motor1", 0.0, 4.0, 5)]
+    params = PARAMS(detectors=["det1", "det2"], axes=axes)
+    rows = _rows(axes, {"det1": "det1", "det2": "det2"})
+
+    figure = render(rows, params)
+
+    assert [panel.title for panel in figure.panels] == ["det1 vs motor1", "det2 vs motor1"]
+    panel = figure.panels[0]
+    assert (panel.x_label, panel.y_label) == ("motor1", "det1")
+    mark = panel.mark
+    assert isinstance(mark, LinesMark)
+    assert len(mark.series) == 1
+
+    # x is the readback the run recorded, jitter and all -- with one dimension
+    # there is no cell to key, so nothing is rounded to the commanded position.
+    points = mark.series[0].points
+    assert [point.x for point in points] == [row["motor1"] for row in rows]
+    assert [point.y for point in points] == [row["det1"] for row in rows]
+    assert mark.source_points == len(rows)
+    assert mark.decimated is False
+    assert panel.annotations == []
+
+
+def test_one_axis_orders_points_by_x_whatever_order_the_rows_arrived_in() -> None:
+    axes = [_axis("motor1", 0.0, 4.0, 5)]
+    params = PARAMS(detectors=["det1"], axes=axes)
+    rows = list(reversed(_rows(axes, {"det1": "det1"})))
+
+    mark = _sole_panel(render(rows, params)).mark
+
+    assert isinstance(mark, LinesMark)
+    xs = [point.x for point in mark.series[0].points]
+    assert xs == sorted(xs)
+
+
+def test_one_axis_keeps_a_missing_detector_reading_as_a_gap_not_a_zero() -> None:
+    axes = [_axis("motor1", 0.0, 2.0, 3)]
+    params = PARAMS(detectors=["det1"], axes=axes)
+    rows = _rows(axes, {"det1": "det1"})
+    rows[1]["det1"] = None
+    rows[2]["det1"] = float("nan")  # how Tiled spells the same absence
+
+    mark = _sole_panel(render(rows, params)).mark
+
+    assert isinstance(mark, LinesMark)
+    assert [point.y for point in mark.series[0].points] == [0.5, None, None]
+
+
+def test_one_axis_drops_rows_with_no_usable_axis_reading_and_counts_them() -> None:
+    axes = [_axis("motor1", 0.0, 4.0, 5)]
+    params = PARAMS(detectors=["det1"], axes=axes)
+    rows = _rows(axes, {"det1": "det1"})
+    rows[1]["motor1"] = None
+    rows[3]["motor1"] = float("nan")
+
+    panel = _sole_panel(render(rows, params))
+    mark = panel.mark
+
+    assert isinstance(mark, LinesMark)
+    assert len(mark.series[0].points) == 3
+    assert panel.annotations == [
+        "2 of 5 rows are not shown: their axis readings did not land on a grid point."
+    ]
+
+
+def test_one_axis_thins_a_long_sweep_and_says_so() -> None:
+    total = DEFAULT_MAX_POINTS * 2
+    axes = [_axis("motor1", 0.0, 1.0, total)]
+    params = PARAMS(detectors=["det1"], axes=axes)
+    rows = _rows(axes, {"det1": "det1"})
+
+    panel = _sole_panel(render(rows, params))
+    mark = panel.mark
+
+    assert isinstance(mark, LinesMark)
+    series = mark.series[0]
+    assert len(series.points) == DEFAULT_MAX_POINTS
+    assert series.decimated is True
+    assert series.source_points == total
+    assert mark.decimated is True
+    assert mark.source_points == total
+    assert "thinned" in " ".join(panel.annotations).lower()
+
+
+def test_snake_axes_is_a_no_op_for_a_single_axis() -> None:
+    axes = [_axis("motor1", 0.0, 4.0, 5)]
+    rows = _rows(axes, {"det1": "det1"})
+
+    straight = render(rows, PARAMS(detectors=["det1"], axes=axes, snake_axes=False))
+    snaked = render(rows, PARAMS(detectors=["det1"], axes=axes, snake_axes=True))
+
+    assert straight.model_dump() == snaked.model_dump()
+
+
+# =========================================================================
+# Two axes: a heatmap keyed by grid geometry
+# =========================================================================
+
+
+@pytest.mark.parametrize("snake", [False, True])
+def test_two_axis_heatmap_cells_match_their_source_rows(snake: bool) -> None:
+    axes = [_axis("motor1", 0.0, 2.0, 3), _axis("motor2", -1.0, 1.0, 5)]
+    params = PARAMS(detectors=["det1"], axes=axes, snake_axes=snake)
+    rows = _rows(axes, {"det1": "det1-value"}, snake=snake)
+
+    panel = _sole_panel(render(rows, params))
+    mark = panel.mark
+    assert isinstance(mark, HeatmapMark)
+
+    # Every (i, j, value) triple is the one its source row carried: the outer
+    # axis indexes rows of `values`, the inner axis indexes columns, and
+    # traversal order never reaches the key.
+    for (j, i), value in zip(
+        _traverse(axes, snake), [row["det1-value"] for row in rows], strict=True
+    ):
+        assert mark.values[j][i] == value, f"cell (j={j}, i={i}) holds the wrong row's reading"
+
+    assert len(mark.values) == 3
+    assert all(len(row) == 5 for row in mark.values)
+    assert mark.source_points == 15
+    assert panel.annotations == []
+
+
+def test_two_axis_heatmap_is_the_same_picture_snaked_or_not() -> None:
+    axes = [_axis("motor1", 0.0, 2.0, 3), _axis("motor2", -1.0, 1.0, 5)]
+
+    straight = render(
+        _rows(axes, {"det1": "det1"}, snake=False),
+        PARAMS(detectors=["det1"], axes=axes, snake_axes=False),
+    )
+    snaked = render(
+        _rows(axes, {"det1": "det1"}, snake=True),
+        PARAMS(detectors=["det1"], axes=axes, snake_axes=True),
+    )
+
+    assert straight.model_dump() == snaked.model_dump()
+
+
+def test_two_axis_heatmap_labels_the_commanded_grid_positions() -> None:
+    axes = [_axis("motor1", 0.0, 2.0, 3), _axis("motor2", -1.0, 1.0, 5)]
+    params = PARAMS(detectors=["det1"], axes=axes)
+
+    panel = _sole_panel(render(_rows(axes, {"det1": "det1"}), params))
+    mark = panel.mark
+
+    assert isinstance(mark, HeatmapMark)
+    assert mark.y_labels == ["0", "1", "2"]
+    assert mark.x_labels == ["-1", "-0.5", "0", "0.5", "1"]
+    assert (panel.x_label, panel.y_label) == ("motor2", "motor1")
+    assert mark.value_label == "det1"
+    assert panel.title == "det1 over the motor1 × motor2 grid"
+
+
+def test_two_axis_heatmap_does_not_fan_out_when_readbacks_miss_their_setpoints() -> None:
+    """The regression this whole file exists for.
+
+    A 3x5 grid whose readbacks are all perturbed must still produce 15 cells in
+    a 3x5 image. Keying on the recorded float instead would produce 15 distinct
+    "columns" -- one row of the image per reading.
+    """
+    axes = [_axis("motor1", 0.0, 2.0, 3), _axis("motor2", -1.0, 1.0, 5)]
+    params = PARAMS(detectors=["det1"], axes=axes, snake_axes=True)
+    rows = _rows(axes, {"det1": "det1"}, snake=True, jitter=5e-9)
+
+    mark = _sole_panel(render(rows, params)).mark
+
+    assert isinstance(mark, HeatmapMark)
+    assert mark.source_points == 15
+    assert all(cell is not None for row in mark.values for cell in row)
+
+
+def test_two_axis_unmeasured_cells_stay_empty_on_a_partial_run() -> None:
+    axes = [_axis("motor1", 0.0, 2.0, 3), _axis("motor2", 0.0, 1.0, 3)]
+    params = PARAMS(detectors=["det1"], axes=axes)
+    rows = _rows(axes, {"det1": "det1"})[:4]  # the run is still on its second pass
+
+    mark = _sole_panel(render(rows, params)).mark
+
+    assert isinstance(mark, HeatmapMark)
+    assert mark.source_points == 4
+    assert mark.values[0] == [0.5, 1.5, 2.5]
+    assert mark.values[1] == [100.5, None, None]
+    assert mark.values[2] == [None, None, None]
+
+
+def test_two_axis_drops_a_row_caught_between_grid_points_and_counts_it() -> None:
+    axes = [_axis("motor1", 0.0, 2.0, 3), _axis("motor2", 0.0, 2.0, 3)]
+    params = PARAMS(detectors=["det1"], axes=axes)
+    rows = _rows(axes, {"det1": "det1"})
+    rows[4]["motor2"] = 0.5  # a device caught mid-move, halfway between points
+
+    panel = _sole_panel(render(rows, params))
+    mark = panel.mark
+
+    assert isinstance(mark, HeatmapMark)
+    assert mark.source_points == 8
+    assert mark.values[1][1] is None
+    assert panel.annotations == [
+        "1 of 9 rows are not shown: their axis readings did not land on a grid point."
+    ]
+
+
+def test_two_axis_keeps_the_axis_span_tolerance_proportional() -> None:
+    """A wide axis tolerates a proportionally wider readback error."""
+    axes = [_axis("motor1", 0.0, 1.0, 2), _axis("motor2", 0.0, 1e6, 3)]
+    params = PARAMS(detectors=["det1"], axes=axes)
+    rows = _rows(axes, {"det1": "det1"}, jitter=0.0)
+    rows[0]["motor2"] = 0.4  # 4e-7 of the span: noise on a metre-scale stage
+
+    mark = _sole_panel(render(rows, params)).mark
+
+    assert isinstance(mark, HeatmapMark)
+    assert mark.values[0][0] == 0.5
+
+
+def test_two_axis_records_the_later_row_when_a_cell_is_measured_twice() -> None:
+    axes = [_axis("motor1", 0.0, 1.0, 2), _axis("motor2", 0.0, 1.0, 2)]
+    params = PARAMS(detectors=["det1"], axes=axes)
+    rows = _rows(axes, {"det1": "det1"})
+    revisit = dict(rows[0])
+    revisit["det1"] = 42.0
+    rows.append(revisit)
+
+    mark = _sole_panel(render(rows, params)).mark
+
+    assert isinstance(mark, HeatmapMark)
+    assert mark.values[0][0] == 42.0
+    assert mark.source_points == 4
+
+
+def test_two_axis_draws_one_heatmap_per_detector() -> None:
+    axes = [_axis("motor1", 0.0, 1.0, 2), _axis("motor2", 0.0, 1.0, 2)]
+    params = PARAMS(detectors=["det1", "det2"], axes=axes)
+    rows = _rows(axes, {"det1": "det1", "det2": "det2-value"})
+
+    figure = render(rows, params)
+
+    assert [panel.mark.value_label for panel in figure.panels] == ["det1", "det2"]  # type: ignore[union-attr]
+
+
+# =========================================================================
+# Three or more axes: lines along the innermost axis
+# =========================================================================
+
+
+def test_three_axes_draw_one_line_per_outer_combination() -> None:
+    axes = [
+        _axis("motor1", 0.0, 1.0, 2),
+        _axis("motor2", 0.0, 2.0, 3),
+        _axis("motor3", 0.0, 3.0, 4),
+    ]
+    params = PARAMS(detectors=["det1"], axes=axes, snake_axes=True)
+    rows = _rows(axes, {"det1": "det1"}, snake=True)
+
+    panel = _sole_panel(render(rows, params))
+    mark = panel.mark
+    assert isinstance(mark, LinesMark)
+
+    assert len(mark.series) == 6  # 2 x 3 outer combinations
+    assert [series.label for series in mark.series] == [
+        "motor1=0, motor2=0",
+        "motor1=0, motor2=1",
+        "motor1=0, motor2=2",
+        "motor1=1, motor2=0",
+        "motor1=1, motor2=1",
+        "motor1=1, motor2=2",
+    ]
+    assert (panel.x_label, panel.y_label) == ("motor3", "det1")
+    assert panel.title == "det1 vs motor3"
+
+    # Each line holds its own pass along the fast axis, left to right, and
+    # every y is the reading its own grid point produced.
+    for series in mark.series:
+        assert len(series.points) == 4
+        xs = [point.x for point in series.points]
+        assert xs == sorted(xs)
+    assert [point.y for point in mark.series[0].points] == [0.5, 1.5, 2.5, 3.5]
+    assert [point.y for point in mark.series[5].points] == [10200.5, 10201.5, 10202.5, 10203.5]
+    assert mark.source_points == 24
+    assert panel.annotations == []
+
+
+def test_three_axes_cap_the_lines_and_count_what_is_not_drawn() -> None:
+    axes = [
+        _axis("motor1", 0.0, 3.0, 4),
+        _axis("motor2", 0.0, 4.0, 5),
+        _axis("motor3", 0.0, 1.0, 2),
+    ]
+    params = PARAMS(detectors=["det1"], axes=axes)
+    rows = _rows(axes, {"det1": "det1"})
+
+    panel = _sole_panel(render(rows, params))
+    mark = panel.mark
+
+    assert isinstance(mark, LinesMark)
+    assert len(mark.series) == grid_scan._MAX_SERIES == 12
+    assert mark.series[0].label == "motor1=0, motor2=0"
+    assert panel.annotations == [
+        "Showing 12 of 20 combinations of the outer axes; the rest are not drawn."
+    ]
+    # The aggregate counts what the mark actually carries, not the whole run.
+    assert mark.source_points == 24
+
+
+def test_four_axes_still_group_by_every_outer_axis() -> None:
+    axes = [
+        _axis("motor1", 0.0, 1.0, 2),
+        _axis("motor2", 0.0, 1.0, 2),
+        _axis("motor3", 0.0, 1.0, 2),
+        _axis("motor4", 0.0, 1.0, 2),
+    ]
+    params = PARAMS(detectors=["det1"], axes=axes, snake_axes=True)
+    rows = _rows(axes, {"det1": "det1"}, snake=True)
+
+    mark = _sole_panel(render(rows, params)).mark
+
+    assert isinstance(mark, LinesMark)
+    assert len(mark.series) == 8
+    assert mark.series[0].label == "motor1=0, motor2=0, motor3=0"
+
+
+def test_three_axes_drop_rows_whose_outer_readbacks_are_off_grid() -> None:
+    axes = [
+        _axis("motor1", 0.0, 1.0, 2),
+        _axis("motor2", 0.0, 1.0, 2),
+        _axis("motor3", 0.0, 1.0, 2),
+    ]
+    params = PARAMS(detectors=["det1"], axes=axes)
+    rows = _rows(axes, {"det1": "det1"})
+    rows[0]["motor2"] = 0.5
+    rows[1]["motor3"] = None
+
+    panel = _sole_panel(render(rows, params))
+    mark = panel.mark
+
+    assert isinstance(mark, LinesMark)
+    assert mark.source_points == 6
+    assert panel.annotations == [
+        "2 of 8 rows are not shown: their axis readings did not land on a grid point."
+    ]
+
+
+# =========================================================================
+# Column resolution, degradation, and the render contract
+# =========================================================================
+
+
+def test_columns_resolve_through_the_ophyd_async_child_suffix() -> None:
+    axes = [_axis("motor1", 0.0, 1.0, 2)]
+    params = PARAMS(detectors=["det1"], axes=axes)
+    rows = _rows(
+        axes,
+        {"det1": "det1-value"},
+        axis_columns={"motor1": "motor1-readback"},
+    )
+
+    mark = _sole_panel(render(rows, params)).mark
+
+    assert isinstance(mark, LinesMark)
+    assert [point.y for point in mark.series[0].points] == [0.5, 1.5]
+
+
+def test_a_detector_that_never_reported_costs_only_its_own_panel() -> None:
+    axes = [_axis("motor1", 0.0, 1.0, 2)]
+    params = PARAMS(detectors=["det1", "det_offline"], axes=axes)
+    rows = _rows(axes, {"det1": "det1"})
+
+    figure = render(rows, params)
+
+    assert [panel.title for panel in figure.panels] == ["det1 vs motor1"]
+
+
+def test_an_axis_column_that_is_absent_leaves_the_figure_empty() -> None:
+    axes = [_axis("motor1", 0.0, 1.0, 2), _axis("motor2", 0.0, 1.0, 2)]
+    params = PARAMS(detectors=["det1"], axes=axes)
+
+    figure = render([{"det1": 1.0}, {"det1": 2.0}], params)
+
+    assert figure.panels == []
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [
+        pytest.param([], id="no rows yet"),
+        pytest.param([{}], id="a row with nothing in it"),
+        pytest.param([{"motor1": "not a number", "det1": object()}], id="unreadable values"),
+        pytest.param([{"motor1": True, "det1": [1, 2]}], id="wrong types entirely"),
+    ],
+)
+def test_render_never_raises_on_malformed_rows(rows: list[dict[str, Any]]) -> None:
+    for axes in (
+        [_axis("motor1", 0.0, 1.0, 2)],
+        [_axis("motor1", 0.0, 1.0, 2), _axis("motor2", 0.0, 1.0, 2)],
+        [_axis("motor1", 0.0, 1.0, 2), _axis("motor2", 0.0, 1.0, 2), _axis("motor3", 0.0, 1.0, 2)],
+    ):
+        figure = render(rows, PARAMS(detectors=["det1"], axes=axes))
+        assert isinstance(figure, Figure)
+
+
+def test_an_unforeseen_failure_costs_the_panels_not_the_response(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    def _boom(*_args: Any, **_kwargs: Any) -> list[Any]:
+        raise RuntimeError("something no fixture anticipated")
+
+    monkeypatch.setattr(grid_scan, "_one_axis_panels", _boom)
+    axes = [_axis("motor1", 0.0, 1.0, 2)]
+
+    with caplog.at_level(logging.WARNING):
+        figure = render(_rows(axes, {"det1": "det1"}), PARAMS(detectors=["det1"], axes=axes))
+
+    assert figure.panels == []
+    assert figure.partial is True
+    assert "grid_scan render failed" in caplog.text
+
+
+def test_the_figure_round_trips_through_its_own_wire_form() -> None:
+    axes = [_axis("motor1", 0.0, 2.0, 3), _axis("motor2", 0.0, 2.0, 3)]
+    params = PARAMS(detectors=["det1"], axes=axes)
+
+    figure = render(_rows(axes, {"det1": "det1"}), params)
+    revalidated = Figure.model_validate(figure.model_dump())
+
+    assert revalidated.model_dump() == figure.model_dump()
+    assert isinstance(revalidated.panels[0].mark, HeatmapMark)
+
+
+def test_render_is_bound_to_the_signature_planspec_declares() -> None:
+    assert grid_scan._RENDER_CONFORMANCE is render

--- a/tests/services/bluesky_bridge/test_live_rows_plan.py
+++ b/tests/services/bluesky_bridge/test_live_rows_plan.py
@@ -1,0 +1,159 @@
+"""The plan stamp riding along with a run's live rows.
+
+A reader that holds only a run id cannot tell what the run's columns mean, so
+the recorder carries the plan that produced them next to the rows themselves.
+Two properties are load-bearing and tested here:
+
+- **`live_rows` never interprets the stamp.** It is stored as handed over and
+  returned as stored — no validation, no defaulting, no shape assumptions. A
+  later reader (the figure route) is what knows how to read it; teaching this
+  module the shape would put a second, drifting copy of that knowledge here.
+- **The extraction lives in the document plane**, beside the run-id read and
+  for the same reason: the stamp is a start-document detail. That is what
+  keeps `live_rows` testable with synthetic plain dicts, so the first half of
+  this file drives the recorder directly with no document plane at all.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from osprey.services.bluesky_bridge import live_rows
+from osprey.services.bluesky_bridge.document_plane import RunDocumentRouter
+from osprey.services.bluesky_bridge.live_rows import LiveRowRecorder
+from osprey.services.bluesky_bridge.queue_backend import PLAN_META_KEY
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _isolated_buffers():
+    live_rows._clear()
+    yield
+    live_rows._clear()
+
+
+def _start_doc(uid: str = "run-1", **extra: Any) -> dict[str, Any]:
+    return {"uid": uid, "time": 1.0, "scan_id": 1, **extra}
+
+
+def _event_doc(data: dict[str, Any]) -> dict[str, Any]:
+    return {"data": data}
+
+
+def _stop_doc(uid: str = "run-1") -> dict[str, Any]:
+    return {"run_start": uid}
+
+
+_STAMP = {"name": "grid_scan", "kwargs": {"num_points": 5}}
+
+
+# =========================================================================
+# The recorder: an opaque value in, the same value out
+# =========================================================================
+
+
+def test_snapshot_carries_the_plan_the_recorder_was_given() -> None:
+    recorder = LiveRowRecorder(plan=_STAMP)
+    recorder("start", _start_doc())
+
+    assert live_rows.get("run-1")["plan"] == _STAMP
+
+
+def test_plan_is_none_when_the_recorder_was_given_none() -> None:
+    """A missing plan is a real answer, not a missing key the reader must guess at."""
+    recorder = LiveRowRecorder()
+    recorder("start", _start_doc())
+
+    snapshot = live_rows.get("run-1")
+    assert "plan" in snapshot
+    assert snapshot["plan"] is None
+
+
+def test_plan_survives_events_and_the_stop_document() -> None:
+    """It is a property of the run, not of the moment the buffer was opened."""
+    recorder = LiveRowRecorder(plan=_STAMP)
+    recorder("start", _start_doc())
+    recorder("event", _event_doc({"x": 1.0}))
+    recorder("stop", _stop_doc())
+
+    snapshot = live_rows.get("run-1")
+    assert snapshot["plan"] == _STAMP
+    assert snapshot["partial"] is False
+    assert snapshot["rows"] == [[1.0]]
+
+
+def test_the_plan_value_is_never_interpreted() -> None:
+    """A stamp of an unexpected shape is stored verbatim, not rejected or coerced.
+
+    The recorder has no opinion about what a plan looks like — validating here
+    would duplicate the reader's knowledge of the shape and start drifting from
+    it the moment the stamp changes.
+    """
+    recorder = LiveRowRecorder(plan="not-a-mapping")
+    recorder("start", _start_doc())
+
+    assert live_rows.get("run-1")["plan"] == "not-a-mapping"
+
+
+def test_each_run_keeps_its_own_plan() -> None:
+    LiveRowRecorder(plan=_STAMP)("start", _start_doc("run-1"))
+    LiveRowRecorder(plan={"name": "orm", "kwargs": {}})("start", _start_doc("run-2"))
+
+    assert live_rows.get("run-1")["plan"] == _STAMP
+    assert live_rows.get("run-2")["plan"] == {"name": "orm", "kwargs": {}}
+
+
+def test_a_restarted_buffer_takes_the_new_recorders_plan() -> None:
+    """A second start under the same key opens a fresh buffer, stamp included."""
+    LiveRowRecorder(plan=_STAMP)("start", _start_doc("run-1"))
+    LiveRowRecorder(plan={"name": "orm", "kwargs": {}})("start", _start_doc("run-1"))
+
+    assert live_rows.get("run-1")["plan"] == {"name": "orm", "kwargs": {}}
+
+
+def test_plan_is_recorded_under_the_explicit_key() -> None:
+    """The stamp follows the buffer key, not the run uid it was recorded from."""
+    recorder = LiveRowRecorder(key="osprey-run-7", plan=_STAMP)
+    recorder("start", _start_doc("engine-uid"))
+
+    assert live_rows.get("engine-uid") is None
+    assert live_rows.get("osprey-run-7")["plan"] == _STAMP
+
+
+# =========================================================================
+# The document plane: where the stamp is read out of the start document
+# =========================================================================
+
+
+def test_router_records_the_plan_stamped_on_the_start_document() -> None:
+    router = RunDocumentRouter()
+    router(
+        "start",
+        _start_doc("engine-uid", osprey_run_id="osprey-run-1", **{PLAN_META_KEY: _STAMP}),
+    )
+
+    assert live_rows.get("osprey-run-1")["plan"] == _STAMP
+
+
+def test_router_records_no_plan_when_the_start_document_carries_no_stamp() -> None:
+    """Out-of-band runs (the worker driven directly) still record — without a plan."""
+    router = RunDocumentRouter()
+    router("start", _start_doc("engine-uid"))
+
+    snapshot = live_rows.get("engine-uid")
+    assert snapshot is not None
+    assert snapshot["plan"] is None
+
+
+def test_router_keeps_the_stamps_of_interleaved_runs_apart() -> None:
+    """One stream carries every run the worker executes; the stamps must not cross."""
+    router = RunDocumentRouter()
+    orm = {"name": "orm", "kwargs": {"correctors": ["c1"]}}
+    router("start", _start_doc("uid-a", osprey_run_id="run-a", **{PLAN_META_KEY: _STAMP}))
+    router("start", _start_doc("uid-b", osprey_run_id="run-b", **{PLAN_META_KEY: orm}))
+
+    assert live_rows.get("run-a")["plan"] == _STAMP
+    assert live_rows.get("run-b")["plan"] == orm

--- a/tests/services/bluesky_bridge/test_orm_render.py
+++ b/tests/services/bluesky_bridge/test_orm_render.py
@@ -1,0 +1,515 @@
+"""Unit tests for `plans_core/orm.py`'s `render()`.
+
+What is actually load-bearing about an `orm` figure, and gets pinned here:
+
+- it draws sweeps `build_response_matrix` cannot fit at all -- a
+  `monodirectional` run renders a full matrix where the legacy path raises;
+- it is honest mid-run: completed sweeps are fitted, the in-flight one is
+  traced and says so, and correctors the sweep has not reached are absent
+  rather than drawn as dead;
+- it never raises, whatever it is handed, because a figure is a view and the
+  run's own result does not depend on it;
+- a row set the run outgrew (the live buffer's per-run cap) keeps its traces
+  but loses the peer-comparison panels, which over an arbitrary subset of the
+  machine would describe the cap rather than the machine.
+
+Rows are hand-built to the shape `build_plan` emits -- one row per (corrector,
+current) point, corrector-major, every row carrying every corrector's current.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from osprey.services.bluesky_bridge import live_rows, plan_loader
+from osprey.services.bluesky_bridge.figure import BarsMark, Figure, HeatmapMark, LinesMark
+from osprey.services.bluesky_bridge.orm_analysis import (
+    DegenerateFitError,
+    build_response_matrix,
+)
+from osprey.services.bluesky_bridge.plans_core import orm
+
+# =========================================================================
+# Fixtures: rows in the shape the real plan emits
+# =========================================================================
+
+
+def _currents(span_a: float, num: int, *, sweep: str) -> list[float]:
+    """The currents `build_plan` sweeps, by the same arithmetic."""
+    if sweep == "monodirectional":
+        step = span_a / (num - 1)
+        return [i * step for i in range(num)]
+    step = (2 * span_a) / (num - 1)
+    return [-span_a + i * step for i in range(num)]
+
+
+def _rows(
+    correctors: list[str],
+    detectors: list[str],
+    truth: np.ndarray,
+    currents: list[float],
+    *,
+    stop_after: int | None = None,
+) -> list[dict[str, float]]:
+    """Rows an `orm` run emits for a machine whose response is *truth*.
+
+    Corrector-major emission order, every row carrying EVERY corrector's
+    current (idle ones read back 0.0) alongside every detector -- the document
+    shape `build_plan` produces.
+    """
+    rows: list[dict[str, float]] = []
+    for j, corrector in enumerate(correctors):
+        for current in currents:
+            row = dict.fromkeys(correctors, 0.0)
+            row[corrector] = current
+            for i, detector in enumerate(detectors):
+                row[detector] = float(truth[i, j] * current)
+            rows.append(row)
+            if stop_after is not None and len(rows) >= stop_after:
+                return rows
+    return rows
+
+
+def _truth(n_det: int, n_corr: int, seed: int = 7) -> np.ndarray:
+    """A deterministic, non-degenerate `[n_det, n_corr]` response matrix."""
+    return np.random.default_rng(seed).normal(size=(n_det, n_corr))
+
+
+def _params(**overrides) -> orm.PARAMS:
+    defaults = {
+        "correctors": ["hcm1", "hcm2"],
+        "detectors": ["bpm1", "bpm2", "bpm3"],
+        "span_a": 1.0,
+        "num": 7,
+    }
+    return orm.PARAMS(**{**defaults, **overrides})
+
+
+def _panel(figure: Figure, title: str):
+    return next(panel for panel in figure.panels if panel.title == title)
+
+
+# =========================================================================
+# The sweeps the legacy fit cannot take
+# =========================================================================
+
+
+def test_monodirectional_run_renders_a_full_response_matrix() -> None:
+    """A one-sided sweep fits here and raises on the legacy row-scan path.
+
+    That contrast is the whole reason `render` fits by acquisition index:
+    `build_response_matrix` needs every corrector's samples to be symmetric
+    about 0, which a `monodirectional` sweep is not.
+    """
+    correctors, detectors = ["hcm1", "hcm2"], ["bpm1", "bpm2", "bpm3"]
+    truth = _truth(len(detectors), len(correctors))
+    params = _params(correctors=correctors, detectors=detectors, num=7, sweep="monodirectional")
+    rows = _rows(correctors, detectors, truth, _currents(1.0, 7, sweep="monodirectional"))
+
+    with pytest.raises(DegenerateFitError):
+        build_response_matrix(rows, correctors, detectors)
+
+    figure = orm.render(rows, params)
+
+    heatmap = _panel(figure, "Response matrix").mark
+    assert isinstance(heatmap, HeatmapMark)
+    assert heatmap.x_labels == correctors
+    assert heatmap.y_labels == detectors
+    assert np.allclose(np.array(heatmap.values), truth, atol=1e-9)
+
+
+def test_bidirectional_run_renders_the_same_matrix() -> None:
+    """The default sweep is not a special case -- same panels, same slopes."""
+    correctors, detectors = ["hcm1", "hcm2"], ["bpm1", "bpm2", "bpm3"]
+    truth = _truth(len(detectors), len(correctors))
+    params = _params(correctors=correctors, detectors=detectors, num=7)
+    rows = _rows(correctors, detectors, truth, _currents(1.0, 7, sweep="bidirectional"))
+
+    heatmap = _panel(orm.render(rows, params), "Response matrix").mark
+    assert isinstance(heatmap, HeatmapMark)
+    assert np.allclose(np.array(heatmap.values), truth, atol=1e-9)
+
+
+# =========================================================================
+# Panel structure -- the contract the panel renderer and the agent consume
+# =========================================================================
+
+
+def test_panel_order_is_traces_then_matrix_then_anomaly_bars() -> None:
+    """Stable order, so a live figure grows instead of rearranging."""
+    correctors, detectors = ["hcm1", "hcm2"], ["bpm1", "bpm2", "bpm3"]
+    truth = _truth(len(detectors), len(correctors))
+    rows = _rows(correctors, detectors, truth, _currents(1.0, 7, sweep="bidirectional"))
+
+    figure = orm.render(rows, _params(correctors=correctors, detectors=detectors))
+
+    assert [panel.title for panel in figure.panels] == [
+        "hcm1 sweep",
+        "hcm2 sweep",
+        "Response matrix",
+        "Corrector anomaly score",
+        "BPM anomaly score",
+    ]
+    traces = figure.panels[0].mark
+    assert isinstance(traces, LinesMark)
+    assert [series.label for series in traces.series] == detectors
+    assert traces.source_points == len(detectors) * 7
+    assert traces.decimated is False
+
+    correctors_bar = _panel(figure, "Corrector anomaly score").mark
+    bpm_bar = _panel(figure, "BPM anomaly score").mark
+    assert isinstance(correctors_bar, BarsMark)
+    assert isinstance(bpm_bar, BarsMark)
+    assert correctors_bar.categories == correctors
+    assert bpm_bar.categories == detectors
+
+
+def test_trace_points_are_the_recorded_current_and_reading() -> None:
+    """A trace point is a claim about one row, not a smoothed curve."""
+    correctors, detectors = ["hcm1", "hcm2"], ["bpm1", "bpm2", "bpm3"]
+    truth = _truth(len(detectors), len(correctors))
+    currents = _currents(1.0, 7, sweep="bidirectional")
+    rows = _rows(correctors, detectors, truth, currents)
+
+    figure = orm.render(rows, _params(correctors=correctors, detectors=detectors))
+    traces = figure.panels[1].mark
+    assert isinstance(traces, LinesMark)
+
+    series = traces.series[0]
+    assert [point.x for point in series.points] == pytest.approx(currents)
+    assert [point.y for point in series.points] == pytest.approx(
+        [truth[0, 1] * current for current in currents]
+    )
+
+
+def test_figure_round_trips_through_model_validate() -> None:
+    """What the route dumps to JSON validates back to the same marks."""
+    correctors, detectors = ["hcm1", "hcm2"], ["bpm1", "bpm2"]
+    rows = _rows(
+        correctors,
+        detectors,
+        _truth(len(detectors), len(correctors)),
+        _currents(1.0, 7, sweep="bidirectional"),
+    )
+
+    figure = orm.render(rows, _params(correctors=correctors, detectors=detectors))
+    assert Figure.model_validate(figure.model_dump()) == figure
+
+
+def test_partial_and_source_are_placeholders_the_route_overwrites() -> None:
+    """The team-wide render convention: always `partial=True, source="live"`.
+
+    A render sees rows, never their provenance, so neither field can be its
+    answer to give -- the figure route stamps the truth onto both on every
+    path. `True` is the honest direction for the placeholder: a forgotten
+    overwrite costs a client extra polling, never a false "settled". Pinned
+    across a finished run, a mid-flight one, and a degraded one so nobody
+    later "improves" this into a data-derived value the route discards.
+    """
+    correctors, detectors = ["hcm1", "hcm2"], ["bpm1", "bpm2"]
+    truth = _truth(len(detectors), len(correctors))
+    currents = _currents(1.0, 7, sweep="bidirectional")
+    params = _params(correctors=correctors, detectors=detectors)
+
+    finished = _rows(correctors, detectors, truth, currents)
+    mid_flight = _rows(correctors, detectors, truth, currents, stop_after=9)
+    degraded = [{"motor": 1.0}]
+
+    for rows in (finished, mid_flight, degraded, []):
+        figure = orm.render(rows, params)
+        assert figure.partial is True
+        assert figure.source == "live"
+
+
+# =========================================================================
+# Mid-run honesty
+# =========================================================================
+
+
+def test_mid_sweep_fits_completed_correctors_and_traces_the_in_flight_one() -> None:
+    """Three sweeps done, one in flight, one not started."""
+    correctors = ["hcm1", "hcm2", "hcm3", "hcm4", "hcm5"]
+    detectors = ["bpm1", "bpm2", "bpm3"]
+    truth = _truth(len(detectors), len(correctors))
+    num = 7
+    rows = _rows(
+        correctors,
+        detectors,
+        truth,
+        _currents(1.0, num, sweep="bidirectional"),
+        stop_after=3 * num + 4,  # three complete sweeps, then four points of the fourth
+    )
+
+    figure = orm.render(rows, _params(correctors=correctors, detectors=detectors, num=num))
+
+    titles = [panel.title for panel in figure.panels]
+    assert titles[:4] == ["hcm1 sweep", "hcm2 sweep", "hcm3 sweep", "hcm4 sweep"]
+    assert "hcm5 sweep" not in titles  # not started: no panel, not an empty one
+
+    heatmap = _panel(figure, "Response matrix").mark
+    assert isinstance(heatmap, HeatmapMark)
+    assert heatmap.x_labels == ["hcm1", "hcm2", "hcm3"]
+    assert np.allclose(np.array(heatmap.values), truth[:, :3], atol=1e-9)
+
+    in_flight = _panel(figure, "hcm4 sweep")
+    traces = in_flight.mark
+    assert isinstance(traces, LinesMark)
+    assert len(traces.series[0].points) == 4
+    assert any("still in flight" in note for note in in_flight.annotations)
+    assert any("4 of 7 points" in note for note in in_flight.annotations)
+
+    matrix_notes = _panel(figure, "Response matrix").annotations
+    assert any("3 of 5 corrector sweeps" in note for note in matrix_notes)
+
+
+def test_full_input_fits_every_corrector_and_a_windowed_input_does_not() -> None:
+    """The property the route's full-row-set contract exists to protect.
+
+    A 300-row run (5 correctors x 60 points): given all of it, every corrector
+    -- including the three whose sweeps begin past row 100 -- gets a non-zero
+    fitted slope. Given only the first 100 rows, they are simply absent; the
+    figure never invents a column for a corrector it did not see finish.
+    """
+    correctors = [f"hcm{j}" for j in range(1, 6)]
+    detectors = ["bpm1", "bpm2", "bpm3"]
+    num = 60
+    truth = _truth(len(detectors), len(correctors))
+    rows = _rows(correctors, detectors, truth, _currents(1.0, num, sweep="bidirectional"))
+    assert len(rows) == 300
+
+    params = _params(correctors=correctors, detectors=detectors, num=num)
+
+    full = _panel(orm.render(rows, params), "Response matrix").mark
+    assert isinstance(full, HeatmapMark)
+    assert full.x_labels == correctors
+    values = np.array(full.values)
+    assert values.shape == (len(detectors), len(correctors))
+    for j, corrector in enumerate(correctors):
+        assert np.all(np.abs(values[:, j]) > 0.0), f"{corrector} fitted a zero column"
+    assert np.allclose(values, truth, atol=1e-9)
+
+    windowed = _panel(orm.render(rows[:100], params), "Response matrix").mark
+    assert isinstance(windowed, HeatmapMark)
+    assert windowed.x_labels == ["hcm1"]  # hcm2 is 40/60 in; hcm3-5 have no rows at all
+
+
+def test_a_bpm_that_missed_a_reading_draws_a_gap_not_a_zero() -> None:
+    """A missing reading is `None` on the wire -- a break in the line."""
+    correctors, detectors = ["hcm1"], ["bpm1", "bpm2"]
+    truth = _truth(len(detectors), len(correctors))
+    rows = _rows(correctors, detectors, truth, _currents(1.0, 7, sweep="bidirectional"))
+    rows[3]["bpm1"] = None  # type: ignore[assignment]
+
+    figure = orm.render(rows, _params(correctors=correctors, detectors=detectors))
+    traces = figure.panels[0].mark
+    assert isinstance(traces, LinesMark)
+    assert traces.series[0].points[3].y is None
+    assert traces.series[1].points[3].y is not None
+
+
+# =========================================================================
+# Caps: what a facility-scale run is allowed to put on the wire
+# =========================================================================
+
+
+def test_the_row_cap_mirror_matches_the_live_buffer() -> None:
+    """`orm.py` duplicates the buffer's cap; drift is a wrong figure."""
+    assert orm._LIVE_BUFFER_ROW_CAP == live_rows._MAX_ROWS_PER_RUN
+
+
+def test_a_capped_row_set_keeps_its_traces_and_drops_the_peer_panels() -> None:
+    """Exactly the cap's worth of rows for a sweep that wanted more.
+
+    The traces still stand -- each point is a claim about one stored row -- but
+    a peer-comparison score over whichever correctors fit under the cap would
+    describe the cap, not the machine, so those panels go and an annotation
+    says why.
+    """
+    correctors, detectors = ["hcm1", "hcm2"], ["bpm1", "bpm2", "bpm3"]
+    num = 6000  # 12,000 rows expected, 10,000 stored
+    truth = _truth(len(detectors), len(correctors))
+    rows = _rows(
+        correctors,
+        detectors,
+        truth,
+        _currents(1.0, num, sweep="bidirectional"),
+        stop_after=orm._LIVE_BUFFER_ROW_CAP,
+    )
+    assert len(rows) == orm._LIVE_BUFFER_ROW_CAP
+
+    figure = orm.render(rows, _params(correctors=correctors, detectors=detectors, num=num))
+
+    assert [panel.title for panel in figure.panels] == ["hcm1 sweep", "hcm2 sweep"]
+    lead = figure.panels[0].annotations
+    assert any("more rows than the bridge stores" in note for note in lead)
+    assert any("10,000" in note for note in lead)
+
+    traces = figure.panels[0].mark
+    assert isinstance(traces, LinesMark)
+    assert traces.decimated is True
+    assert len(traces.series[0].points) == 2000
+    assert traces.series[0].source_points == num
+
+
+def test_an_uncapped_run_longer_than_the_cap_still_fits() -> None:
+    """A settled Tiled read is not a capped buffer just because it is big.
+
+    The cap is recognized by an exact row count against the parameters' own
+    expected total, so a complete row set that merely exceeds the cap keeps
+    every panel.
+    """
+    correctors, detectors = ["hcm1", "hcm2"], ["bpm1", "bpm2"]
+    num = 6000
+    truth = _truth(len(detectors), len(correctors))
+    rows = _rows(correctors, detectors, truth, _currents(1.0, num, sweep="bidirectional"))
+    assert len(rows) == 12_000
+
+    figure = orm.render(rows, _params(correctors=correctors, detectors=detectors, num=num))
+
+    assert "Response matrix" in [panel.title for panel in figure.panels]
+
+
+def test_panels_and_series_are_capped_with_annotations_naming_the_excess() -> None:
+    """A 20-corrector, 30-BPM run is not 20 panels of 30 lines."""
+    correctors = [f"hcm{j}" for j in range(1, 21)]
+    detectors = [f"bpm{i}" for i in range(1, 31)]
+    num = 5
+    truth = _truth(len(detectors), len(correctors))
+    rows = _rows(correctors, detectors, truth, _currents(1.0, num, sweep="bidirectional"))
+
+    figure = orm.render(rows, _params(correctors=correctors, detectors=detectors, num=num))
+
+    trace_titles = [panel.title for panel in figure.panels if panel.title.endswith(" sweep")]
+    assert len(trace_titles) == orm._MAX_TRACE_PANELS
+    assert trace_titles[-1] == "hcm20 sweep"  # the tail, where a live sweep is
+
+    first = figure.panels[0]
+    assert any("8 most recently swept of 20 correctors" in n for n in first.annotations)
+    assert any("first 12 of 30 BPMs" in n for n in first.annotations)
+
+    traces = first.mark
+    assert isinstance(traces, LinesMark)
+    assert len(traces.series) == orm._MAX_TRACE_SERIES
+
+    # The fit itself is never capped: every corrector and BPM keeps its cell.
+    heatmap = _panel(figure, "Response matrix").mark
+    assert isinstance(heatmap, HeatmapMark)
+    assert len(heatmap.x_labels) == 20
+    assert len(heatmap.y_labels) == 30
+
+
+# =========================================================================
+# Totality: a figure is a view, and its failure is never the run's
+# =========================================================================
+
+
+def test_no_rows_render_an_empty_figure() -> None:
+    figure = orm.render([], _params())
+    assert figure.panels == []
+
+
+def test_non_numeric_rows_do_not_raise() -> None:
+    """Rows the fit cannot even build an array from degrade to no panels."""
+    rows = [{"hcm1": "not a number", "bpm1": "nor this"} for _ in range(7)]
+    figure = orm.render(rows, _params())
+    assert figure.panels == []
+
+
+def test_rows_from_a_different_plan_do_not_raise() -> None:
+    """None of the named devices appear: nothing to draw, still a figure."""
+    rows = [{"motor": float(i), "det": float(i) ** 2} for i in range(20)]
+    figure = orm.render(rows, _params())
+    assert figure.panels == []
+
+
+def test_a_stuck_corrector_is_traced_and_named_not_fitted() -> None:
+    """Currents that never move have no slope -- say so, do not invent one."""
+    correctors, detectors = ["hcm1", "hcm2"], ["bpm1", "bpm2"]
+    truth = _truth(len(detectors), len(correctors))
+    rows = _rows(correctors, detectors, truth, _currents(1.0, 7, sweep="bidirectional"))
+    for row in rows[7:]:  # hcm2's slice: the corrector never moves
+        row["hcm2"] = 0.0
+
+    figure = orm.render(rows, _params(correctors=correctors, detectors=detectors))
+
+    stuck = _panel(figure, "hcm2 sweep")
+    assert any("never moved" in note for note in stuck.annotations)
+    heatmap = _panel(figure, "Response matrix").mark
+    assert isinstance(heatmap, HeatmapMark)
+    assert heatmap.x_labels == ["hcm1"]
+
+
+def test_a_failing_fit_panel_degrades_to_the_traces(monkeypatch) -> None:
+    """The second stage of the fallback, exercised rather than assumed."""
+
+    def _boom(matrix):
+        raise RuntimeError("anomaly scoring blew up")
+
+    monkeypatch.setattr(orm, "column_anomaly", _boom)
+
+    correctors, detectors = ["hcm1", "hcm2"], ["bpm1", "bpm2"]
+    rows = _rows(
+        correctors,
+        detectors,
+        _truth(len(detectors), len(correctors)),
+        _currents(1.0, 7, sweep="bidirectional"),
+    )
+
+    figure = orm.render(rows, _params(correctors=correctors, detectors=detectors))
+
+    assert [panel.title for panel in figure.panels] == ["hcm1 sweep", "hcm2 sweep"]
+    traces = figure.panels[0].mark
+    assert isinstance(traces, LinesMark)
+    assert len(traces.series) == 2
+
+
+def test_every_trace_x_is_finite() -> None:
+    """`Point.x` rejects a non-finite coordinate; render must not offer one."""
+    correctors, detectors = ["hcm1"], ["bpm1"]
+    truth = _truth(len(detectors), len(correctors))
+    rows = _rows(correctors, detectors, truth, _currents(1.0, 7, sweep="bidirectional"))
+    rows[2]["hcm1"] = float("nan")
+
+    figure = orm.render(rows, _params(correctors=correctors, detectors=detectors))
+    traces = figure.panels[0].mark
+    assert isinstance(traces, LinesMark)
+    assert len(traces.series[0].points) == 6
+    assert all(math.isfinite(point.x) for point in traces.series[0].points)
+
+
+# =========================================================================
+# The loader picks it up
+# =========================================================================
+
+
+def test_the_shipped_orm_spec_carries_this_render() -> None:
+    plan_loader.reset_facility_plans()
+    try:
+        spec = plan_loader.get_facility_plans().plans["orm"]
+        assert spec.render is not None
+        assert spec.render.__name__ == "render"
+
+        # The loader execs the file under a synthetic module name, so identity
+        # with `orm.render` does not hold -- behaviour is what matters.
+        correctors, detectors = ["hcm1", "hcm2"], ["bpm1", "bpm2"]
+        rows = _rows(
+            correctors,
+            detectors,
+            _truth(len(detectors), len(correctors)),
+            _currents(1.0, 7, sweep="bidirectional"),
+        )
+        params = spec.schema.model_validate(
+            {
+                "correctors": correctors,
+                "detectors": detectors,
+                "span_a": 1.0,
+                "num": 7,
+            }
+        )
+        figure = spec.render(rows, params)
+        assert "Response matrix" in [panel.title for panel in figure.panels]
+    finally:
+        plan_loader.reset_facility_plans()

--- a/tests/services/bluesky_bridge/test_plan_validation.py
+++ b/tests/services/bluesky_bridge/test_plan_validation.py
@@ -219,6 +219,16 @@ class TestStaticAllowlistCheck:
             "from logging import config",  # same submodule, "from X import Y" form
             "from logging import handlers",
             "from logging.config import dictConfig",
+            "import osprey",  # bare osprey, no submodule
+            "import osprey as o",
+            "from osprey.connectors import epics",  # the control-system surface itself
+            "from osprey.services.bluesky_bridge.queue_backend import QueueBackend",
+            "import osprey.services.bluesky_bridge.queue_backend",
+            "from osprey.services.python_executor import runner",
+            # The parent package of an allowed leaf is NOT itself allowed: this
+            # form binds the whole package, from which `figure` is one attribute
+            # among all its siblings.
+            "from osprey.services.bluesky_bridge import figure",
         ],
     )
     def test_rejects_disallowed_imports(self, code):
@@ -247,6 +257,10 @@ class TestStaticAllowlistCheck:
             "import typing",
             "import logging",
             "from logging import getLogger",
+            # The two inert modules a plan's `render()` needs to exist at all.
+            "from osprey.services.bluesky_bridge.figure import Figure, Panel",
+            "import osprey.services.bluesky_bridge.figure",
+            "from osprey.services.bluesky_bridge.orm_analysis import build_response_matrix",
         ],
     )
     def test_accepts_allowed_imports(self, code):
@@ -269,6 +283,46 @@ class TestStaticAllowlistCheck:
     def test_submodule_granularity_plan_stubs_accept_some_other_reject(self):
         assert _static_allowlist_check("from bluesky import plan_stubs") == []
         assert _static_allowlist_check("from bluesky import some_other") != []
+
+    def test_osprey_is_two_leaf_modules_and_nothing_else(self):
+        """`osprey` is narrowed exactly as `bluesky` is: the top level is denied
+        and two fully-dotted leaves are allowed.
+
+        A plan file may declare a `render()`, and a `Figure` cannot be built
+        without importing the module that defines it -- but that is the whole
+        of the widening. `figure` is pydantic-only and `orm_analysis` is
+        numpy-only; the connector, config, queue, and executor packages next
+        door are precisely what this allowlist exists to keep out of an
+        agent-authored plan body, and admitting bare `osprey` would hand a plan
+        every one of them.
+        """
+        assert _static_allowlist_check("import osprey") != []
+        assert _static_allowlist_check("from osprey import connectors") != []
+        assert _static_allowlist_check("from osprey.services import bluesky_bridge") != []
+        assert _static_allowlist_check("from osprey.services.bluesky_bridge import app") != []
+        assert (
+            _static_allowlist_check("from osprey.services.bluesky_bridge.figure import Figure")
+            == []
+        )
+        assert (
+            _static_allowlist_check(
+                "from osprey.services.bluesky_bridge.orm_analysis import build_response_matrix"
+            )
+            == []
+        )
+
+    def test_the_validator_top_level_set_never_admits_osprey_on_its_own(self):
+        """`_VALIDATOR_TOP_LEVEL_MODULES` carries `osprey` so
+        `validate_sandbox_code`'s coarser top-level check agrees with the walk
+        above -- but it is only ever safe paired with the submodule gate, and a
+        future edit that drops the gate while keeping the set would admit every
+        `osprey` submodule silently. Pin both halves together.
+        """
+        assert "osprey" in plan_validation._VALIDATOR_TOP_LEVEL_MODULES
+        assert "osprey" not in plan_validation._ALLOWED_TOP_LEVEL_MODULES
+        assert not plan_validation._is_allowed_import("osprey")
+        assert not plan_validation._is_allowed_import("osprey.connectors")
+        assert plan_validation._is_allowed_import("osprey.services.bluesky_bridge.figure")
 
     def test_dunder_import_variant_rejected(self):
         violations = _static_allowlist_check("x = __import__('epics')")

--- a/tests/services/bluesky_bridge/test_planspec_render.py
+++ b/tests/services/bluesky_bridge/test_planspec_render.py
@@ -1,0 +1,430 @@
+"""Coverage for `PlanSpec.render`: the optional, typed
+``render(rows, params) -> Figure`` a plan may declare, and the loader rule that
+decides whether it is honored.
+
+Two halves, because the field has two contracts:
+
+- **Runtime** — `plan_loader._resolve_render`'s resolution rule. It is total:
+  every failure mode (no ``render``, a non-callable one, an attribute access
+  that raises, an untrusted tier) yields ``render=None`` and the plan still
+  registers. A drawing concern must never cost an operator a launchable plan.
+- **Static** — the field is typed against the plan's *own* ``SchemaT``, so a
+  ``render()`` that takes ``dict[str, Any]`` instead of its PARAMS is a mypy
+  error rather than a surprise at the first poll tick. Nothing at runtime can
+  observe that, so it is pinned by running mypy over a fixture snippet.
+
+The snippet check carries its own vacuity guard (see
+`test_the_snippet_check_actually_resolves_planspec`): mypy has
+``ignore_missing_imports = true``, so a snippet that cannot resolve ``osprey``
+silently degrades `PlanSpec` to ``Any`` and every type assertion below it
+passes for the wrong reason. The positive control asserts the revealed type is
+the real parameterized class, not ``Any``.
+
+All plan files here are pure pydantic/stdlib — no bluesky import — so this
+suite runs in the bluesky-less lane alongside `test_plan_loader_layered.py`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel
+
+import osprey
+from osprey.services.bluesky_bridge import plan_loader
+from osprey.services.bluesky_bridge.figure import (
+    REASON_RENDER_NOT_SUPPORTED_FOR_SESSION_PLANS,
+    Figure,
+)
+from osprey.services.bluesky_bridge.plan_types import PlanSpec, Provenance
+from osprey.services.bluesky_bridge.plan_validation import hash_plan_body
+from osprey.services.bluesky_bridge.validation_record import validation_records
+
+_LOGGER_NAME = "osprey.services.bluesky_bridge.plan_loader"
+
+# `osprey.__file__` is the running interpreter's answer, so these stay correct
+# inside a worktree (where a repo-relative path would point at the main checkout).
+_SRC_ROOT = Path(osprey.__file__).parents[1]
+_REPO_ROOT = _SRC_ROOT.parent
+
+# The trusted tiers, the ones whose `render()` the bridge is willing to run.
+_TRUSTED_TIERS: tuple[Provenance, ...] = ("shipped", "preset", "facility")
+
+
+@pytest.fixture(autouse=True)
+def _isolated_plan_loader(monkeypatch: pytest.MonkeyPatch):
+    """Clean loader caches and no leftover layer env vars, per test."""
+    monkeypatch.delenv("BLUESKY_PLAN_DIRS", raising=False)
+    monkeypatch.delenv("BLUESKY_PLAN_MODULE", raising=False)
+    plan_loader.reset_facility_plans()
+    yield
+    plan_loader.reset_facility_plans()
+
+
+@pytest.fixture
+def _isolated_validation_records():
+    """Swap in an empty record store so a session-tier fixture can be validated
+    without leaking its hash into whatever the rest of the suite recorded."""
+    with validation_records.lock:
+        saved = set(validation_records._passing_hashes)
+        validation_records._passing_hashes.clear()
+    yield validation_records
+    with validation_records.lock:
+        validation_records._passing_hashes.clear()
+        validation_records._passing_hashes.update(saved)
+
+
+# ==========================================================================
+# Plan-file fixtures
+# ==========================================================================
+
+
+def _plan_source(name: str, *, tail: str = "") -> str:
+    """A minimal, well-formed directory-layer plan file, plus optional ``tail``."""
+    return (
+        "from osprey.services.bluesky_bridge.figure import Figure\n\n\n"
+        "PLAN_METADATA = {\n"
+        f'    "name": {name!r},\n'
+        '    "description": "A render-contract test plan.",\n'
+        '    "category": "accelerator",\n'
+        '    "required_devices": [],\n'
+        '    "writes": False,\n'
+        "}\n\n\n"
+        "def build_plan(devices, params):\n"
+        f'    return {{"plan": {name!r}}}\n'
+        f"{tail}"
+    )
+
+
+_GOOD_RENDER = '\n\ndef render(rows, params):\n    return Figure(partial=False, source="live")\n'
+
+_NON_CALLABLE_RENDER = "\n\nrender = 42\n"
+
+_RAISING_RENDER = (
+    "\n\n"
+    "def __getattr__(name):\n"
+    '    if name == "render":\n'
+    '        raise RuntimeError("render attribute exploded")\n'
+    "    raise AttributeError(name)\n"
+)
+
+
+def _write_plan(directory: Path, name: str, *, tail: str = "") -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{name}.py"
+    path.write_text(_plan_source(name, tail=tail))
+    return path
+
+
+def _load_one(path: Path, provenance: Provenance) -> dict[str, tuple[Provenance, str, PlanSpec]]:
+    registry: dict[str, tuple[Provenance, str, PlanSpec]] = {}
+    plan_loader._load_plan_file(path, provenance, registry)
+    return registry
+
+
+def _spec(registry: dict[str, tuple[Provenance, str, PlanSpec]], name: str) -> PlanSpec:
+    assert name in registry, f"{name!r} was not registered: {sorted(registry)}"
+    return registry[name][2]
+
+
+# ==========================================================================
+# The field itself
+# ==========================================================================
+
+
+class _DemoParams(BaseModel):
+    amplitude: float = 1.0
+
+
+def test_render_defaults_to_none() -> None:
+    """A plan that says nothing about drawing gets no render — not a stub."""
+    spec = PlanSpec(name="demo", plan=lambda devices, params: None, schema=_DemoParams)
+    assert spec.render is None
+
+
+def test_to_dict_does_not_serialize_render() -> None:
+    """`GET /plans` is unchanged by this field. Callables do not serialize, and a
+    plan's *view* is served by the figure route, not by the catalog."""
+    spec = PlanSpec(
+        name="demo",
+        plan=lambda devices, params: None,
+        schema=_DemoParams,
+        render=lambda rows, params: Figure(partial=False, source="live"),
+    )
+    assert set(spec.to_dict()) == {
+        "name",
+        "description",
+        "schema",
+        "metadata",
+        "provenance",
+    }
+
+
+# ==========================================================================
+# Loader resolution — trusted tiers
+# ==========================================================================
+
+
+@pytest.mark.parametrize("provenance", _TRUSTED_TIERS)
+def test_trusted_tier_render_is_resolved_onto_the_spec(
+    tmp_path: Path, provenance: Provenance
+) -> None:
+    """Every operator-supplied tier gets its `render()`, not just the shipped one."""
+    path = _write_plan(tmp_path, "drawable", tail=_GOOD_RENDER)
+
+    spec = _spec(_load_one(path, provenance), "drawable")
+
+    assert spec.render is not None
+    figure = spec.render([], _DemoParams())
+    assert isinstance(figure, Figure)
+    assert figure.source == "live"
+
+
+def test_plan_without_render_loads_silently(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Most plans have no view of their own. That is ordinary, not a defect —
+    warning about it would train operators to ignore the log."""
+    path = _write_plan(tmp_path, "plain")
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        spec = _spec(_load_one(path, "shipped"), "plain")
+
+    assert spec.render is None
+    assert "render" not in caplog.text
+
+
+def test_non_callable_render_warns_and_still_registers_the_plan(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A stray ``render = 42`` reads as an author mistake, so it warns — but the
+    plan stays launchable. Quarantining it would take a working plan away over
+    a drawing concern."""
+    path = _write_plan(tmp_path, "botched", tail=_NON_CALLABLE_RENDER)
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        registry = _load_one(path, "shipped")
+
+    spec = _spec(registry, "botched")
+    assert spec.render is None
+    assert "non-callable render" in caplog.text
+    assert "quarantining" not in caplog.text
+
+
+def test_render_attribute_that_raises_warns_and_still_registers_the_plan(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A module ``__getattr__`` (PEP 562) can raise from the attribute lookup
+    itself. That is still not a reason to lose the plan."""
+    path = _write_plan(tmp_path, "explosive", tail=_RAISING_RENDER)
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        registry = _load_one(path, "shipped")
+
+    spec = _spec(registry, "explosive")
+    assert spec.render is None
+    assert "could not read render" in caplog.text
+    assert "render attribute exploded" in caplog.text
+    assert "quarantining" not in caplog.text
+
+
+# ==========================================================================
+# Loader resolution — untrusted tiers
+# ==========================================================================
+
+
+def test_session_tier_render_is_ignored_and_names_the_route_reason(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    _isolated_validation_records,
+) -> None:
+    """A session plan's `render()` runs nowhere. `render()` executes in the bridge
+    API process on every poll tick, so an agent-authored one is an unbounded-work
+    seam the validation gate does not close.
+
+    The warning quotes the route's own reason constant so a plan author reads the
+    same words the panel will show them, instead of two vocabularies for one rule.
+    """
+    path = _write_plan(tmp_path, "session_drawable", tail=_GOOD_RENDER)
+    validation_records.record(hash_plan_body(path.read_text()))
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        registry = _load_one(path, "session")
+
+    spec = _spec(registry, "session_drawable")
+    assert spec.render is None
+    assert REASON_RENDER_NOT_SUPPORTED_FOR_SESSION_PLANS in caplog.text
+
+
+def test_unreviewed_tier_render_is_ignored_too(
+    tmp_path: Path, _isolated_validation_records
+) -> None:
+    """The gate is on the tier, not on the one tier name that exists today."""
+    path = _write_plan(tmp_path, "unreviewed_drawable", tail=_GOOD_RENDER)
+    validation_records.record(hash_plan_body(path.read_text()))
+
+    spec = _spec(_load_one(path, "unreviewed"), "unreviewed_drawable")
+
+    assert spec.render is None
+
+
+def test_session_tier_plan_without_render_does_not_warn(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    _isolated_validation_records,
+) -> None:
+    """Nothing was ignored, so there is nothing to tell the author about."""
+    path = _write_plan(tmp_path, "session_plain")
+    validation_records.record(hash_plan_body(path.read_text()))
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        spec = _spec(_load_one(path, "session"), "session_plain")
+
+    assert spec.render is None
+    assert REASON_RENDER_NOT_SUPPORTED_FOR_SESSION_PLANS not in caplog.text
+
+
+# ==========================================================================
+# The legacy single-module contract
+# ==========================================================================
+
+
+def test_legacy_module_render_survives_provenance_normalization(tmp_path: Path) -> None:
+    """`load_facility_plans` rewrites provenance with `dataclasses.replace`, which
+    would drop `render` if the field were ever handled specially there."""
+    module = tmp_path / "facility_plans.py"
+    module.write_text(
+        "from pydantic import BaseModel\n\n"
+        "from osprey.services.bluesky_bridge.figure import Figure\n"
+        "from osprey.services.bluesky_bridge.plan_types import PlanSpec\n\n\n"
+        "class Params(BaseModel):\n"
+        "    amplitude: float = 1.0\n\n\n"
+        "def render(rows, params):\n"
+        '    return Figure(partial=True, source="tiled")\n\n\n'
+        "PLANS = {\n"
+        '    "legacy": PlanSpec(\n'
+        '        name="legacy",\n'
+        "        plan=lambda devices, params: None,\n"
+        "        schema=Params,\n"
+        '        provenance="shipped",\n'
+        "        render=render,\n"
+        "    )\n"
+        "}\n\n\n"
+        "def get_devices():\n"
+        "    return {}\n"
+    )
+
+    loaded = plan_loader.load_facility_plans(module_path=str(module))
+
+    spec = loaded.plans["legacy"]
+    assert spec.provenance == "facility"
+    assert spec.render is not None
+    assert spec.render([], spec.schema()).source == "tiled"
+
+
+# ==========================================================================
+# The static contract
+# ==========================================================================
+
+_SNIPPET_PREAMBLE = (
+    "from __future__ import annotations\n\n"
+    "from typing import Any\n\n"
+    "from pydantic import BaseModel\n\n"
+    "from osprey.services.bluesky_bridge.figure import Figure\n"
+    "from osprey.services.bluesky_bridge.plan_types import PlanSpec\n\n\n"
+    "class DemoParams(BaseModel):\n"
+    "    amplitude: float = 1.0\n\n\n"
+    "def build_plan(devices: dict[str, Any], params: DemoParams) -> Any:\n"
+    "    return None\n\n\n"
+)
+
+_WELL_TYPED_SNIPPET = (
+    _SNIPPET_PREAMBLE + "def render(rows: list[dict[str, Any]], params: DemoParams) -> Figure:\n"
+    '    return Figure(partial=False, source="live")\n\n\n'
+    "SPEC = PlanSpec(name='demo', plan=build_plan, schema=DemoParams, render=render)\n"
+    "reveal_type(SPEC)  # noqa: F821\n"
+)
+
+_MIS_TYPED_SNIPPET = (
+    _SNIPPET_PREAMBLE
+    + "def render(rows: list[dict[str, Any]], params: dict[str, Any]) -> Figure:\n"
+    '    return Figure(partial=False, source="live")\n\n\n'
+    "SPEC = PlanSpec(name='demo', plan=build_plan, schema=DemoParams, render=render)\n"
+)
+
+
+@pytest.fixture(scope="module")
+def mypy_output(tmp_path_factory: pytest.TempPathFactory) -> str:
+    """Both snippets checked in one mypy pass — the process start dominates the cost.
+
+    ``MYPYPATH`` is set explicitly: the snippets live outside the source tree, and
+    with ``ignore_missing_imports = true`` an unresolved ``osprey`` would make
+    `PlanSpec` ``Any`` and every assertion here vacuous.
+    """
+    snippet_dir = tmp_path_factory.mktemp("render_typing")
+    (snippet_dir / "well_typed.py").write_text(_WELL_TYPED_SNIPPET)
+    (snippet_dir / "mis_typed.py").write_text(_MIS_TYPED_SNIPPET)
+
+    env = dict(os.environ)
+    env["MYPYPATH"] = str(_SRC_ROOT)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "mypy",
+            "--config-file",
+            str(_REPO_ROOT / "pyproject.toml"),
+            "--no-incremental",
+            str(snippet_dir),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(_REPO_ROOT),
+        env=env,
+    )
+    assert "No module named mypy" not in result.stderr, (
+        "mypy is not installed in this environment, so the static half of this "
+        f"contract cannot be checked at all:\n{result.stderr}"
+    )
+    return result.stdout + result.stderr
+
+
+def test_the_snippet_check_actually_resolves_planspec(mypy_output: str) -> None:
+    """The vacuity guard, and the reason this test exists at all.
+
+    Without `MYPYPATH`, mypy resolves nothing and reports ``Revealed type is
+    "Any"`` — under which the mis-typed snippet below type-checks clean and the
+    whole static contract silently stops being enforced.
+    """
+    assert "PlanSpec[well_typed.DemoParams]" in mypy_output, (
+        "mypy did not resolve PlanSpec to the real parameterized class — every "
+        f"static assertion in this module would be vacuous:\n{mypy_output}"
+    )
+
+
+def test_a_render_typed_against_its_own_params_type_checks(mypy_output: str) -> None:
+    """The positive control: the contract is satisfiable, not merely strict."""
+    offending = [
+        line for line in mypy_output.splitlines() if "well_typed.py" in line and "error:" in line
+    ]
+    assert not offending, "\n".join(offending)
+
+
+def test_a_render_taking_dict_instead_of_its_params_fails_mypy(mypy_output: str) -> None:
+    """The point of typing the field: `render()` is handed a validated PARAMS
+    instance, and a plan that annotates it ``dict[str, Any]`` would fail at the
+    first poll tick of a live run. mypy is where that gets caught."""
+    offending = [
+        line
+        for line in mypy_output.splitlines()
+        if "mis_typed.py" in line and "error:" in line and 'Argument "render"' in line
+    ]
+    assert offending, (
+        "a render() annotated dict[str, Any] instead of its PARAMS type-checked "
+        f"clean — the field's SchemaT parameterization is not biting:\n{mypy_output}"
+    )

--- a/tests/services/bluesky_bridge/test_queue_backend.py
+++ b/tests/services/bluesky_bridge/test_queue_backend.py
@@ -181,7 +181,22 @@ async def test_add_item_threads_the_run_id_through_item_metadata() -> None:
     await QueueBackend(manager).add_item({"item_type": "plan", "name": "count"}, run_id="run-7")
 
     (kwargs,) = manager.kwargs_for("item_add")
-    assert kwargs["item"]["meta"] == {qb.RUN_ID_META_KEY: "run-7"}
+    assert kwargs["item"]["meta"] == {
+        qb.RUN_ID_META_KEY: "run-7",
+        qb.PLAN_META_KEY: {"name": "count", "kwargs": {}},
+    }
+
+
+async def test_add_item_stamps_the_plan_kwargs_as_enqueued() -> None:
+    manager = FakeManager()
+    item = {"item_type": "plan", "name": "grid_scan", "kwargs": {"num": 5, "detectors": ["det"]}}
+    await QueueBackend(manager).add_item(item, run_id="run-7")
+
+    (kwargs,) = manager.kwargs_for("item_add")
+    assert kwargs["item"]["meta"][qb.PLAN_META_KEY] == {
+        "name": "grid_scan",
+        "kwargs": {"num": 5, "detectors": ["det"]},
+    }
 
 
 async def test_add_item_preserves_existing_metadata() -> None:
@@ -190,7 +205,11 @@ async def test_add_item_preserves_existing_metadata() -> None:
     await QueueBackend(manager).add_item(item, run_id="run-7")
 
     (kwargs,) = manager.kwargs_for("item_add")
-    assert kwargs["item"]["meta"] == {"operator": "ada", qb.RUN_ID_META_KEY: "run-7"}
+    assert kwargs["item"]["meta"] == {
+        "operator": "ada",
+        qb.RUN_ID_META_KEY: "run-7",
+        qb.PLAN_META_KEY: {"name": "count", "kwargs": {}},
+    }
     # The caller's own dict is never mutated.
     assert item["meta"] == {"operator": "ada"}
 
@@ -202,7 +221,10 @@ async def test_add_item_accepts_a_bplan() -> None:
     (kwargs,) = manager.kwargs_for("item_add")
     assert kwargs["item"]["name"] == "count"
     assert kwargs["item"]["kwargs"] == {"num": 3}
-    assert kwargs["item"]["meta"][qb.RUN_ID_META_KEY] == "run-9"
+    assert kwargs["item"]["meta"] == {
+        qb.RUN_ID_META_KEY: "run-9",
+        qb.PLAN_META_KEY: {"name": "count", "kwargs": {"num": 3}},
+    }
 
 
 async def test_add_item_without_a_run_id_adds_no_metadata() -> None:

--- a/tests/services/bluesky_bridge/test_queue_meta_strip.py
+++ b/tests/services/bluesky_bridge/test_queue_meta_strip.py
@@ -1,0 +1,297 @@
+"""The plan-identity stamp never reaches a queue client (`queue._public_item`).
+
+The enqueue path stamps the plan's name and kwargs into the item's metadata
+(`queue_backend.PLAN_META_KEY`) so a run's figure can be rendered from its
+start document alone. On a queue READ that stamp duplicates the item's own
+top-level ``name``/``kwargs``, on the one surface panels both poll and stream
+continuously — so both relays drop it.
+
+What these tests pin is the ASYMMETRY, in both directions at once: the item
+the manager holds carries BOTH keys (the stamp has to reach the RunEngine, or
+the whole feature is dead), while every item on the wire carries only
+``osprey_run_id`` (drop that one and `itemRunId()` can no longer join a queue
+row to its run). Both relays are checked against a real response: `GET /queue`
+over `TestClient`, and the SSE stream over an actual `TestClient.stream`
+capture of the hello frame plus a driven change frame.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from osprey.services.bluesky_bridge import app as app_module
+from osprey.services.bluesky_bridge import document_plane, draft, plan_loader, queue
+from osprey.services.bluesky_bridge import queue_backend as qb
+from osprey.services.bluesky_bridge.app import app
+from osprey.services.bluesky_bridge.queue_backend import QueueBackend
+
+_SESSION_PLAN_DIR_ENV = "BLUESKY_SESSION_PLAN_DIR"
+_PLAN_DIRS_ENV = "BLUESKY_PLAN_DIRS"
+_PLAN_MODULE_ENV = "BLUESKY_PLAN_MODULE"
+_TOKEN_ENV = "BLUESKY_LAUNCH_TOKEN"
+
+_GRID_SCAN_ARGS: dict[str, Any] = {
+    "detectors": ["BPM1"],
+    "axes": [{"setpoint": "COR1", "start": 0.0, "stop": 1.0, "num_points": 3}],
+}
+_RUN_ID = "run-abc"
+
+# The stamp `queue_backend.add_item` puts on an item enqueued with a run id.
+_STAMP = {"name": "grid_scan", "kwargs": _GRID_SCAN_ARGS}
+
+
+class FakeManager:
+    """A scripted ``REManagerAPI`` stand-in (same contract as `test_queue_routes.py`'s)."""
+
+    def __init__(self, **responses: Any) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.responses = responses
+
+    def __getattr__(self, method: str) -> Any:
+        async def call(**kwargs: Any) -> Any:
+            self.calls.append((method, kwargs))
+            response = self.responses.get(method, {"success": True, "msg": ""})
+            if isinstance(response, Exception):
+                raise response
+            return response
+
+        return call
+
+    async def close(self) -> None:  # pragma: no cover - lifespan only
+        pass
+
+
+def status_doc(**overrides: Any) -> dict[str, Any]:
+    """A manager status document: idle, environment open, nothing running."""
+    doc = {
+        "success": True,
+        "manager_state": "idle",
+        "worker_environment_exists": True,
+        "items_in_queue": 1,
+        "items_in_history": 0,
+        "running_item_uid": None,
+        "plan_queue_uid": "q-1",
+        "plan_history_uid": "h-1",
+        "queue_stop_pending": False,
+        "queue_autostart_enabled": False,
+    }
+    doc.update(overrides)
+    return doc
+
+
+def stamped_item(uid: str = "u1", **overrides: Any) -> dict[str, Any]:
+    """A queue item exactly as the manager holds it after a stamped enqueue."""
+    item = {
+        "item_uid": uid,
+        "item_type": "plan",
+        "name": "grid_scan",
+        "kwargs": dict(_GRID_SCAN_ARGS),
+        "meta": {qb.RUN_ID_META_KEY: _RUN_ID, qb.PLAN_META_KEY: dict(_STAMP)},
+    }
+    item.update(overrides)
+    return item
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(_PLAN_DIRS_ENV, raising=False)
+    monkeypatch.delenv(_PLAN_MODULE_ENV, raising=False)
+    monkeypatch.delenv(_TOKEN_ENV, raising=False)
+    monkeypatch.setenv(_SESSION_PLAN_DIR_ENV, str(tmp_path / "plans_session"))
+    plan_loader.reset_facility_plans()
+    draft._clear()
+    queue._clear()
+    document_plane._clear()
+    app_module.set_queue_backend(None)
+    yield
+    plan_loader.reset_facility_plans()
+    draft._clear()
+    queue._clear()
+    document_plane._clear()
+    app_module.set_queue_backend(None)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _install(manager: Any) -> QueueBackend:
+    backend = QueueBackend(manager)
+    app_module.set_queue_backend(backend)
+    return backend
+
+
+def _parse_frame(raw: str) -> dict[str, Any]:
+    assert raw.startswith("data: ")
+    return json.loads(raw[len("data: ") :])
+
+
+# ---------------------------------------------------------------------------
+# The helper itself
+# ---------------------------------------------------------------------------
+
+
+def test_public_item_drops_the_plan_stamp_and_keeps_the_run_id() -> None:
+    public = queue._public_item(stamped_item())
+
+    assert public["meta"] == {qb.RUN_ID_META_KEY: _RUN_ID}
+    # Everything else is the item verbatim — the strip touches metadata only.
+    assert public["name"] == "grid_scan"
+    assert public["kwargs"] == _GRID_SCAN_ARGS
+
+
+def test_public_item_leaves_metadata_it_did_not_write_alone() -> None:
+    """An item enqueued out of band (a `qserver` CLI, another client) carries
+    whatever metadata its author chose; none of it is ours to remove."""
+    foreign = {"item_uid": "u9", "name": "count", "meta": {"scan_id": 7, "owner": "beamline"}}
+
+    assert queue._public_item(foreign) is foreign
+    assert queue._public_item({"item_uid": "u9"}) == {"item_uid": "u9"}
+    assert queue._public_item(None) is None
+
+
+def test_public_item_does_not_mutate_the_item_it_was_given() -> None:
+    """The strip is a projection for the wire; the caller's item — and the
+    manager's own response dict it came out of — must be untouched."""
+    item = stamped_item()
+
+    queue._public_item(item)
+
+    assert item["meta"] == {qb.RUN_ID_META_KEY: _RUN_ID, qb.PLAN_META_KEY: _STAMP}
+
+
+# ---------------------------------------------------------------------------
+# Relay 1: GET /queue
+# ---------------------------------------------------------------------------
+
+
+def test_get_queue_relays_items_without_the_plan_stamp(client: TestClient) -> None:
+    manager = FakeManager(
+        status=status_doc(),
+        queue_get={
+            "success": True,
+            "items": [stamped_item("u1")],
+            "running_item": stamped_item("u2"),
+        },
+    )
+    _install(manager)
+
+    body = client.get("/queue").json()
+
+    # The manager's own item is the control: it carries BOTH keys, because the
+    # stamp has to reach the RunEngine for a figure to be renderable at all.
+    (held,) = manager.responses["queue_get"]["items"]
+    assert held["meta"] == {qb.RUN_ID_META_KEY: _RUN_ID, qb.PLAN_META_KEY: _STAMP}
+
+    (relayed,) = body["items"]
+    assert relayed["meta"] == {qb.RUN_ID_META_KEY: _RUN_ID}
+    assert relayed["kwargs"] == _GRID_SCAN_ARGS
+    assert body["running_item"]["meta"] == {qb.RUN_ID_META_KEY: _RUN_ID}
+
+
+def test_the_running_items_progress_survives_the_strip(client: TestClient) -> None:
+    """`_with_progress` and `_public_item` compose on the running item — one
+    adds a key, the other removes one, and neither undoes the other."""
+    _install(
+        FakeManager(
+            status=status_doc(running_item_uid="u2"),
+            queue_get={"success": True, "items": [], "running_item": stamped_item("u2")},
+        )
+    )
+    document_plane.record_run_params(_RUN_ID, _GRID_SCAN_ARGS)
+
+    running = client.get("/queue").json()["running_item"]
+
+    assert running["meta"] == {qb.RUN_ID_META_KEY: _RUN_ID}
+    assert running["progress"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Relay 2: GET /queue/events — the SSE stream
+# ---------------------------------------------------------------------------
+
+
+def test_a_streamed_hello_frame_carries_no_plan_stamp(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The frame is read off a real SSE response over HTTP, not off `_frame_from`.
+
+    The stream is ended right after the hello frame by pushing the module's own
+    ``_DISCONNECT`` sentinel (the slow-consumer path) into the new subscriber:
+    Starlette's `TestClient` buffers a response to completion before returning
+    it, so a genuinely endless stream would simply hang. Everything up to that
+    point is production code — the route, `_frame_from`, `_format_sse`, and the
+    ASGI transport.
+    """
+    _install(
+        FakeManager(
+            status=status_doc(),
+            queue_get={
+                "success": True,
+                "items": [stamped_item("u1")],
+                "running_item": stamped_item("u2"),
+            },
+        )
+    )
+
+    subscribe = queue._subscribe
+
+    async def _subscribe_then_end() -> tuple[asyncio.Queue[Any], dict[str, Any]]:
+        subscriber, hello = await subscribe()
+        subscriber.put_nowait(queue._DISCONNECT)
+        return subscriber, hello
+
+    monkeypatch.setattr(queue, "_subscribe", _subscribe_then_end)
+
+    with client.stream("GET", "/queue/events") as resp:
+        assert resp.status_code == 200
+        hello = _parse_frame(next(line for line in resp.iter_lines() if line.startswith("data: ")))
+
+    assert hello["type"] == "hello"
+    (streamed,) = hello["items"]
+    assert streamed["meta"] == {qb.RUN_ID_META_KEY: _RUN_ID}
+    assert streamed["name"] == "grid_scan"
+    assert hello["running_item"]["meta"] == {qb.RUN_ID_META_KEY: _RUN_ID}
+
+
+async def test_a_streamed_change_frame_carries_no_plan_stamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The hello frame is not a special case: every later change frame is
+    built by the same `_frame_from`, so the strip has to hold there too."""
+    monkeypatch.setattr(queue, "_POLL_INTERVAL_S", 0.01)
+    manager = FakeManager(
+        status=status_doc(items_in_queue=0),
+        queue_get={"success": True, "items": [], "running_item": {}},
+    )
+    _install(manager)
+
+    resp = await queue.queue_events()
+    gen = resp.body_iterator
+    try:
+        assert _parse_frame(await gen.__anext__())["type"] == "hello"
+
+        # An enqueue lands out of band: the poller notices and pushes a full
+        # snapshot, which is the second place a stamp could escape.
+        manager.responses["status"] = status_doc(plan_queue_uid="q-2")
+        manager.responses["queue_get"] = {
+            "success": True,
+            "items": [stamped_item("u1")],
+            "running_item": {},
+        }
+
+        frame = _parse_frame(await asyncio.wait_for(gen.__anext__(), timeout=2))
+    finally:
+        await gen.aclose()
+
+    assert frame["type"] == "queue"
+    (streamed,) = frame["items"]
+    assert streamed["meta"] == {qb.RUN_ID_META_KEY: _RUN_ID}
+    assert qb.PLAN_META_KEY not in json.dumps(frame)

--- a/tests/services/bluesky_bridge/test_queue_routes.py
+++ b/tests/services/bluesky_bridge/test_queue_routes.py
@@ -238,8 +238,12 @@ def test_enqueue_on_an_idle_queue_is_ungated_and_threads_the_run_id(
     assert add_kwargs["item"]["item_type"] == "plan"
     assert add_kwargs["item"]["name"] == "grid_scan"
     assert add_kwargs["item"]["kwargs"] == _GRID_SCAN_ARGS
-    # The OSPREY run id rides the item metadata into start docs.
-    assert add_kwargs["item"]["meta"] == {qb.RUN_ID_META_KEY: body["run_id"]}
+    # The OSPREY run id and the plan's identity ride the item metadata into
+    # start docs.
+    assert add_kwargs["item"]["meta"] == {
+        qb.RUN_ID_META_KEY: body["run_id"],
+        qb.PLAN_META_KEY: {"name": "grid_scan", "kwargs": _GRID_SCAN_ARGS},
+    }
 
     # Arming checks bypass the client's status cache: the capability probe is
     # a plain read, but the pre-check and the unarmed post-add re-check MUST

--- a/tests/services/bluesky_bridge/test_row_adapter.py
+++ b/tests/services/bluesky_bridge/test_row_adapter.py
@@ -1,0 +1,166 @@
+"""Coverage for `rows_from_columnar` / `RowWindow`.
+
+Every figure -- a plan's own `render()`, the default figure, the panel-facing
+route, and the MCP projection -- is built from rows that came through here, and
+they arrive from two stores that spell "no reading" differently: the live buffer
+stores ``None``, a Tiled table stores float ``NaN``. So these tests pin the two
+properties downstream depends on rather than the mechanics of the conversion:
+the same run replayed from Tiled produces the same rows it produced live, and
+``rows_complete`` is exact -- the orm render only trusts row *position* when it
+is ``True``.
+
+Pure pydantic -- no bluesky import, so this runs in the fast import-clean lane.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from osprey.services.bluesky_bridge.figure import RowWindow, rows_from_columnar
+
+_COLUMNS = ["corrector_1", "bpm3"]
+
+
+# --- The conversion ----------------------------------------------------------
+
+
+def test_columns_and_values_are_zipped_positionally():
+    window = rows_from_columnar(_COLUMNS, [[1.0, -0.5], [2.0, 0.25]], 2)
+
+    assert window.rows == [
+        {"corrector_1": 1.0, "bpm3": -0.5},
+        {"corrector_1": 2.0, "bpm3": 0.25},
+    ]
+
+
+def test_returns_a_row_window_carrying_the_columns():
+    window = rows_from_columnar(_COLUMNS, [[1.0, -0.5]], 1)
+
+    assert isinstance(window, RowWindow)
+    assert window.columns == _COLUMNS
+    assert window.total_seen == 1
+
+
+def test_columns_are_copied_not_aliased():
+    columns = list(_COLUMNS)
+    window = rows_from_columnar(columns, [[1.0, -0.5]], 1)
+
+    columns.append("added_later")
+
+    assert window.columns == _COLUMNS
+
+
+def test_no_rows_gives_an_empty_window():
+    window = rows_from_columnar(_COLUMNS, [], 0)
+
+    assert window.rows == []
+    assert window.columns == _COLUMNS
+    assert window.rows_complete is True
+
+
+def test_a_run_with_no_columns_yet_maps_to_empty_dicts():
+    """A start doc landed but no Event did: real rows, no keys (Tiled's shape)."""
+    window = rows_from_columnar([], [], 0)
+
+    assert window.rows == []
+    assert window.columns == []
+
+
+def test_non_float_values_pass_through_untouched():
+    window = rows_from_columnar(
+        ["seq", "label", "flag", "missing"],
+        [[3, "cycle-a", True, None]],
+        1,
+    )
+
+    assert window.rows == [{"seq": 3, "label": "cycle-a", "flag": True, "missing": None}]
+
+
+# --- NaN is the other store's None -------------------------------------------
+
+
+def test_nan_becomes_none():
+    window = rows_from_columnar(_COLUMNS, [[1.0, float("nan")]], 1)
+
+    assert window.rows == [{"corrector_1": 1.0, "bpm3": None}]
+
+
+def test_tiled_nan_rows_equal_live_none_rows():
+    """The parity the panel depends on: replaying a run from Tiled produces the
+    same rows the live buffer produced, so it draws the same figure."""
+    live = rows_from_columnar(_COLUMNS, [[1.0, None], [2.0, 0.25]], 2)
+    tiled = rows_from_columnar(_COLUMNS, [[1.0, float("nan")], [2.0, 0.25]], 2)
+
+    assert tiled.rows == live.rows
+
+
+def test_infinities_are_left_alone():
+    """An ``inf`` is a value the run produced, not a reading it failed to take
+    -- the figure models null it at the drawing edge, this adapter does not."""
+    window = rows_from_columnar(_COLUMNS, [[float("inf"), float("-inf")]], 1)
+
+    assert window.rows[0]["corrector_1"] == math.inf
+    assert window.rows[0]["bpm3"] == -math.inf
+
+
+def test_a_nan_string_is_not_a_nan():
+    window = rows_from_columnar(["note"], [["nan"]], 1)
+
+    assert window.rows == [{"note": "nan"}]
+
+
+# --- Emission order is the caller's, and is preserved ------------------------
+
+
+def test_emission_order_is_preserved_and_never_sorted():
+    """Rows are mapped in the order given -- the adapter has no ``seq_num`` to
+    sort on, so a Tiled caller must read its table already sorted."""
+    out_of_order = [[2.0, 0.2], [0.0, 0.0], [1.0, 0.1]]
+
+    window = rows_from_columnar(_COLUMNS, out_of_order, 3)
+
+    assert [row["corrector_1"] for row in window.rows] == [2.0, 0.0, 1.0]
+
+
+# --- rows_complete is exact, not a heuristic ---------------------------------
+
+
+def test_rows_complete_when_the_window_holds_every_row():
+    window = rows_from_columnar(_COLUMNS, [[1.0, 0.1], [2.0, 0.2]], 2)
+
+    assert window.rows_complete is True
+
+
+def test_rows_incomplete_when_the_run_produced_more_than_the_window_holds():
+    """A paginated window, or a buffer that hit its retention cap: index
+    arithmetic over these rows is unsound, so the orm render falls back."""
+    window = rows_from_columnar(_COLUMNS, [[1.0, 0.1], [2.0, 0.2]], 5000)
+
+    assert window.rows_complete is False
+    assert window.total_seen == 5000
+
+
+def test_an_empty_window_over_a_run_that_produced_rows_is_incomplete():
+    window = rows_from_columnar(_COLUMNS, [], 7)
+
+    assert window.rows_complete is False
+
+
+# --- Structural bugs are loud ------------------------------------------------
+
+
+def test_a_window_larger_than_its_run_raises():
+    with pytest.raises(ValueError, match="smaller than the 2 rows given"):
+        rows_from_columnar(_COLUMNS, [[1.0, 0.1], [2.0, 0.2]], 1)
+
+
+def test_a_short_row_raises():
+    with pytest.raises(ValueError):
+        rows_from_columnar(_COLUMNS, [[1.0]], 1)
+
+
+def test_a_long_row_raises():
+    with pytest.raises(ValueError):
+        rows_from_columnar(_COLUMNS, [[1.0, 0.1, 99.0]], 1)

--- a/tests/services/bluesky_bridge/test_sliced_response_matrix.py
+++ b/tests/services/bluesky_bridge/test_sliced_response_matrix.py
@@ -1,0 +1,303 @@
+"""Unit tests for `orm_analysis.sliced_response_matrix`.
+
+The vectorized, index-sliced ORM fit a plan's `render()` runs on every live
+tick. Three things are actually load-bearing and get pinned here:
+
+- it agrees with `numpy.polyfit` to 1e-12, so switching a fit onto it is not
+  a change in answer, only in cost;
+- it fits inputs `build_response_matrix` cannot take at all — a
+  `monodirectional` sweep, and a run still in flight — because it slices by
+  acquisition index instead of inferring corrector membership from the data;
+- it is fast enough for the tick it runs on (a facility-scale shape here,
+  well under the route's own budget).
+
+Pure numpy, like the module under test: no bluesky, no bridge, no fixtures
+beyond hand-built event rows.
+"""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pytest
+
+from osprey.services.bluesky_bridge.orm_analysis import (
+    DegenerateFitError,
+    build_response_matrix,
+    sliced_response_matrix,
+)
+
+
+def _sweep_currents(span_a: float, num: int, *, monodirectional: bool = False) -> list[float]:
+    """The currents `plans_core/orm.py`'s `build_plan` sweeps, same arithmetic."""
+    if monodirectional:
+        step = span_a / (num - 1)
+        return [i * step for i in range(num)]
+    step = (2 * span_a) / (num - 1)
+    return [-span_a + i * step for i in range(num)]
+
+
+def _emit_rows(
+    correctors: list[str],
+    detectors: list[str],
+    truth: np.ndarray,
+    currents: list[float],
+    *,
+    offsets: np.ndarray | None = None,
+    stop_after: int | None = None,
+) -> list[dict[str, float]]:
+    """Rows an `orm` run emits for a machine whose response is *truth*.
+
+    Mirrors the real plan's document shape: one row per (corrector, current)
+    point, in corrector-major emission order, every row carrying EVERY
+    corrector's current (idle ones read back 0.0) alongside every detector.
+    *offsets* gives each detector a nonzero intercept so a fit that ignored
+    the intercept would visibly fail.
+    """
+    if offsets is None:
+        offsets = np.zeros(len(detectors))
+    rows: list[dict[str, float]] = []
+    for j, corrector in enumerate(correctors):
+        for current in currents:
+            row = dict.fromkeys(correctors, 0.0)
+            row[corrector] = current
+            orbit = offsets + truth[:, j] * current
+            for i, detector in enumerate(detectors):
+                row[detector] = float(orbit[i])
+            rows.append(row)
+            if stop_after is not None and len(rows) >= stop_after:
+                return rows
+    return rows
+
+
+def _truth_matrix(n_det: int, n_corr: int, seed: int = 7) -> np.ndarray:
+    """A deterministic, non-degenerate `[n_det, n_corr]` response matrix."""
+    return np.random.default_rng(seed).normal(size=(n_det, n_corr))
+
+
+def test_matches_polyfit_within_1e_12_on_a_bidirectional_sweep():
+    """The closed-form slope IS polyfit's answer, to 1e-12 relative."""
+    correctors = ["CH1", "CH2", "CH3"]
+    detectors = ["BPM1", "BPM2", "BPM3", "BPM4"]
+    truth = _truth_matrix(len(detectors), len(correctors))
+    currents = _sweep_currents(2.0, 7)
+    rows = _emit_rows(
+        correctors, detectors, truth, currents, offsets=np.array([1.0, -2.0, 0.5, 3.0])
+    )
+
+    fit = sliced_response_matrix(rows, correctors, detectors, num=7)
+
+    assert fit.complete == (True, True, True)
+    assert fit.fitted_correctors == tuple(correctors)
+    assert fit.matrix.shape == (4, 3)
+
+    # Independently polyfit each (detector, corrector) pair over that
+    # corrector's own slice -- the reference the vectorized path replaces.
+    for j in range(len(correctors)):
+        block = rows[j * 7 : (j + 1) * 7]
+        x = [row[correctors[j]] for row in block]
+        for i, detector in enumerate(detectors):
+            y = [row[detector] for row in block]
+            expected, _intercept = np.polyfit(x, y, deg=1)
+            assert fit.matrix[i, j] == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+    # ...and that reference is itself the machine we simulated.
+    np.testing.assert_allclose(fit.matrix, truth, rtol=1e-9)
+
+
+def test_fits_a_monodirectional_sweep_that_the_legacy_path_rejects():
+    """Index slicing drops the zero-mean-sweep requirement entirely."""
+    correctors = ["CH1", "CH2"]
+    detectors = ["BPM1", "BPM2", "BPM3"]
+    truth = _truth_matrix(len(detectors), len(correctors))
+    currents = _sweep_currents(1.5, 5, monodirectional=True)
+    rows = _emit_rows(correctors, detectors, truth, currents)
+
+    fit = sliced_response_matrix(rows, correctors, detectors, num=5)
+
+    assert fit.complete == (True, True)
+    np.testing.assert_allclose(fit.matrix, truth, rtol=1e-9)
+
+    # The per-pair polyfit path cannot take this input at all: a one-sided
+    # sweep leaves the idle-corrector rows with real leverage on the fit.
+    with pytest.raises(DegenerateFitError, match="not symmetric about 0"):
+        build_response_matrix(rows, correctors, detectors)
+
+
+def test_partial_run_fits_finished_correctors_and_traces_the_one_in_flight():
+    """A sweep still in progress costs its own column, not the matrix."""
+    correctors = ["CH1", "CH2", "CH3"]
+    detectors = ["BPM1", "BPM2"]
+    truth = _truth_matrix(len(detectors), len(correctors))
+    currents = _sweep_currents(2.0, 6)
+    # Two correctors done (12 rows), the third three points into its sweep.
+    rows = _emit_rows(correctors, detectors, truth, currents, stop_after=15)
+
+    fit = sliced_response_matrix(rows, correctors, detectors, num=6)
+
+    assert fit.complete == (True, True, False)
+    assert fit.fitted_correctors == ("CH1", "CH2")
+    assert fit.matrix.shape == (2, 2)
+    np.testing.assert_allclose(fit.matrix, truth[:, :2], rtol=1e-9)
+
+    # The in-flight corrector still yields its raw samples for a trace.
+    assert fit.currents[2].shape == (3,)
+    assert fit.readings[2].shape == (3, 2)
+    np.testing.assert_allclose(fit.currents[2], currents[:3])
+    # ...and the finished ones carry their full sweeps.
+    assert fit.currents[0].shape == (6,)
+    assert fit.readings[0].shape == (6, 2)
+    np.testing.assert_allclose(fit.currents[0], currents)
+
+
+def test_no_rows_yet_is_all_incomplete_and_an_empty_matrix():
+    """The first tick of a run, before any event arrives, is not an error."""
+    fit = sliced_response_matrix([], ["CH1", "CH2"], ["BPM1"], num=5)
+
+    assert fit.complete == (False, False)
+    assert fit.fitted_correctors == ()
+    assert fit.matrix.shape == (1, 0)
+    assert all(current.shape == (0,) for current in fit.currents)
+    assert all(reading.shape == (0, 1) for reading in fit.readings)
+
+
+def test_resolves_prefixed_signal_keys_once_per_run():
+    """`name-signal` document keys match, same rules as `_match_value`."""
+    correctors = ["CH1", "CH2"]
+    detectors = ["BPM1", "BPM2"]
+    truth = _truth_matrix(len(detectors), len(correctors))
+    currents = _sweep_currents(1.0, 4)
+    plain = _emit_rows(correctors, detectors, truth, currents)
+    # StandardReadable's multi-child spelling, plus unrelated keys that must
+    # not be mistaken for a device (no `name-` prefix match).
+    rows = [
+        {f"{name}-readback": value for name, value in row.items()} | {"seq_num": 1, "CH": 0.0}
+        for row in plain
+    ]
+
+    fit = sliced_response_matrix(rows, correctors, detectors, num=4)
+
+    assert fit.complete == (True, True)
+    np.testing.assert_allclose(fit.matrix, truth, rtol=1e-9)
+
+
+def test_a_detector_that_never_reported_lands_on_zero_not_nan():
+    """One dead BPM costs its own row, and never poisons the matrix."""
+    correctors = ["CH1", "CH2"]
+    detectors = ["BPM1", "BPM_DEAD", "BPM2"]
+    truth = _truth_matrix(len(detectors), len(correctors))
+    currents = _sweep_currents(2.0, 5)
+    rows = _emit_rows(correctors, detectors, truth, currents)
+    for row in rows:
+        del row["BPM_DEAD"]
+
+    fit = sliced_response_matrix(rows, correctors, detectors, num=5)
+
+    assert fit.complete == (True, True)
+    assert np.all(np.isfinite(fit.matrix))
+    np.testing.assert_allclose(fit.matrix[1, :], [0.0, 0.0])
+    np.testing.assert_allclose(fit.matrix[[0, 2], :], truth[[0, 2], :], rtol=1e-9)
+    # The gap survives where a trace can show it.
+    assert np.all(np.isnan(fit.readings[0][:, 1]))
+
+
+def test_a_detector_dropping_out_mid_slice_costs_only_that_entry():
+    """A single missing sample is a `nan` slope; it is clamped to `0.0`."""
+    correctors = ["CH1"]
+    detectors = ["BPM1", "BPM2"]
+    truth = _truth_matrix(len(detectors), len(correctors))
+    currents = _sweep_currents(2.0, 5)
+    rows = _emit_rows(correctors, detectors, truth, currents)
+    del rows[2]["BPM2"]
+
+    fit = sliced_response_matrix(rows, correctors, detectors, num=5)
+
+    assert fit.complete == (True,)
+    assert fit.matrix[0, 0] == pytest.approx(truth[0, 0], rel=1e-9)
+    assert fit.matrix[1, 0] == 0.0
+
+
+def test_a_corrector_that_never_moved_yields_no_column():
+    """A stuck corrector has no slope; it must not divide by zero."""
+    correctors = ["CH1", "CH_STUCK"]
+    detectors = ["BPM1", "BPM2"]
+    truth = _truth_matrix(len(detectors), len(correctors))
+    currents = _sweep_currents(2.0, 5)
+    rows = _emit_rows(correctors, detectors, truth, currents)
+    for row in rows[5:]:
+        row["CH_STUCK"] = 0.0
+
+    fit = sliced_response_matrix(rows, correctors, detectors, num=5)
+
+    assert fit.complete == (True, False)
+    assert fit.fitted_correctors == ("CH1",)
+    assert fit.matrix.shape == (2, 1)
+    assert np.all(np.isfinite(fit.matrix))
+
+
+def test_a_corrector_missing_its_own_current_yields_no_column():
+    """Without the driven current there is no x-axis to fit against."""
+    correctors = ["CH1", "CH2"]
+    detectors = ["BPM1"]
+    truth = _truth_matrix(len(detectors), len(correctors))
+    currents = _sweep_currents(2.0, 5)
+    rows = _emit_rows(correctors, detectors, truth, currents)
+    del rows[7]["CH2"]
+
+    fit = sliced_response_matrix(rows, correctors, detectors, num=5)
+
+    assert fit.complete == (True, False)
+    assert fit.fitted_correctors == ("CH1",)
+
+
+def test_trailing_rows_beyond_the_sweep_are_not_attributed_to_a_corrector():
+    """Extra rows belong to no slice and must not shift the ones that do."""
+    correctors = ["CH1", "CH2"]
+    detectors = ["BPM1", "BPM2"]
+    truth = _truth_matrix(len(detectors), len(correctors))
+    currents = _sweep_currents(2.0, 4)
+    rows = _emit_rows(correctors, detectors, truth, currents)
+    rows = rows + [dict(rows[-1]) for _ in range(3)]
+
+    fit = sliced_response_matrix(rows, correctors, detectors, num=4)
+
+    assert fit.complete == (True, True)
+    np.testing.assert_allclose(fit.matrix, truth, rtol=1e-9)
+    assert all(current.shape == (4,) for current in fit.currents)
+
+
+def test_num_below_two_is_rejected():
+    """One point per corrector defines no slope, and no slicing either."""
+    with pytest.raises(ValueError, match="at least 2"):
+        sliced_response_matrix([], ["CH1"], ["BPM1"], num=1)
+
+
+def test_facility_scale_fit_is_fast():
+    """Perf sanity at 70 correctors x 100 BPMs x 1470 rows.
+
+    The formal gate (median-of-5 under 200 ms) lives with the figure route,
+    which measures the whole tick; this only pins that the fit itself is
+    vectorized -- the per-pair polyfit path it replaces takes seconds on
+    this shape, so the threshold discriminates by orders of magnitude and
+    does not need CI-machine tuning.
+    """
+    correctors = [f"CH{j}" for j in range(70)]
+    detectors = [f"BPM{i}" for i in range(100)]
+    num = 21
+    truth = _truth_matrix(len(detectors), len(correctors))
+    currents = _sweep_currents(2.0, num)
+    rows = _emit_rows(correctors, detectors, truth, currents)
+    assert len(rows) == 1470
+
+    timings = []
+    for _ in range(5):
+        started = time.perf_counter()
+        fit = sliced_response_matrix(rows, correctors, detectors, num=num)
+        timings.append(time.perf_counter() - started)
+
+    assert fit.matrix.shape == (100, 70)
+    np.testing.assert_allclose(fit.matrix, truth, rtol=1e-9)
+
+    median = sorted(timings)[len(timings) // 2]
+    assert median < 0.2, f"fit took {median * 1e3:.1f} ms at 70x100x1470 (timings: {timings})"

--- a/tests/services/bluesky_bridge/test_sliced_response_matrix.py
+++ b/tests/services/bluesky_bridge/test_sliced_response_matrix.py
@@ -276,11 +276,11 @@ def test_num_below_two_is_rejected():
 def test_facility_scale_fit_is_fast():
     """Perf sanity at 70 correctors x 100 BPMs x 1470 rows.
 
-    The formal gate (median-of-5 under 200 ms) lives with the figure route,
-    which measures the whole tick; this only pins that the fit itself is
-    vectorized -- the per-pair polyfit path it replaces takes seconds on
-    this shape, so the threshold discriminates by orders of magnitude and
-    does not need CI-machine tuning.
+    The formal gate (median-of-5) lives with the figure route, which measures
+    the whole tick; this only pins that the fit itself is vectorized -- the
+    per-pair polyfit path it replaces takes seconds on this shape, so the
+    threshold discriminates by orders of magnitude and does not need
+    CI-machine tuning.
     """
     correctors = [f"CH{j}" for j in range(70)]
     detectors = [f"BPM{i}" for i in range(100)]


### PR DESCRIPTION
Scan results were only visible as raw traces. The panel drew every numeric
column of a run, so a plan's meaning — a fitted response matrix, a grid map —
was not recoverable from what it showed, and the ORM fit that could recover it
walked rows in Python for 5-77 s at facility scale. Runs also lost their
producing plan once history rotated, so a stored run could not be redrawn the
way its plan intended. The agent had no way to see the figure at all.

A plan file may now export `render(rows, params)`, returning a validated figure
spec typed against the plan's own parameters. `GET /runs/{id}/figure` serves
that figure to both readers, so the operator's panel and the OSPREY agent
describe one picture rather than two.

Design points a reviewer may want to push back on:

- **Drawing never breaks a scan.** A render that raises, a session-tier plan, a
  params mismatch, an unreadable source — each falls back to the default view
  (every numeric column against row index) with a stated reason. A reason is a
  default view, not an error, and the docs and the tool docstring say so.
- **The route executes plan Python on an ungated read.** It runs sync in the
  threadpool like the data route, and settled runs short-circuit to a cache
  before any source read.
- **Plan files may import exactly two OSPREY modules** — the figure spec models
  and the numpy analysis helpers. The execution surface is unchanged (session
  plans never run `render()`), but this allowlist widening is the
  security-relevant line of the diff.
- **Figures are point-bounded twice, at different limits.** The route bounds per
  series; the MCP tool bounds the whole figure and summarizes large heatmaps,
  because a raw figure body costs up to ~250 KB of agent context.
- **The ORM fit is now closed-form and vectorized** (~15 ms at 70 correctors ×
  100 BPMs × 1470 rows), replacing a per-pair polyfit over per-row dict scans.

Frozen surfaces — tool lists, skill prose, the reason vocabulary — are pinned by
tests so the docs and the code cannot drift apart silently.

## How it hangs together

```text
PRODUCE — the plan defines the picture

  plans_core/orm.py ────────┐
  plans_core/grid_scan.py ──┤  render(rows, params)
                            ▼
     figure.py        Figure › Panel › Mark (lines | bars | heatmap)
     orm_analysis.py  closed-form response-matrix fit
            ▲
            ├── plan_validation.py  import allowlist (exactly these two)
            └── plan_loader.py      shipped / preset / facility tiers only

SERVE — one route, one figure

                     GET /runs/{id}/figure        (app.py)
                               │
   live_rows.py ──────────────►│  render() when the plan has one
   Tiled (durable) ───────────►│  else default view + reason  (never raises)
   figure_cache.py ───────────►│  settled runs, generation-checked
   document_plane / queue ────►│  plan stamp survives history rotation
                               │  series decimated, loss reported
                               ▼
CONSUME — the same figure, two readers

           ┌───────────────────┴───────────────────┐
           ▼                                       ▼
   read_proxy.py                            read_tools.py
   results-view.js                          get_run_figure  (MCP)
   figure-renderer.js                       whole-figure point bound,
   theme-aware  → operator's panel          heatmap summaries → agent
```
